### PR TITLE
feat: claim-queue coherence + stale threshold sync + EXEC-TO-PLAN RPC fix

### DIFF
--- a/database/migrations/20260406_fix_atomic_transition_uuid_cast.sql
+++ b/database/migrations/20260406_fix_atomic_transition_uuid_cast.sql
@@ -1,0 +1,187 @@
+-- Migration: Fix type mismatch in fn_atomic_exec_to_plan_transition
+-- Bug: user_stories.sd_id is varchar(50) but v_sd_uuid is UUID
+-- Fix: Cast v_sd_uuid to text in the WHERE clause
+-- Date: 2026-04-06
+-- Rollback: Re-run the original CREATE OR REPLACE without ::text cast
+
+CREATE OR REPLACE FUNCTION public.fn_atomic_exec_to_plan_transition(
+  p_sd_id text,
+  p_prd_id text,
+  p_session_id text,
+  p_request_id text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_sd_uuid UUID;
+  v_prd_uuid UUID;
+  v_pre_state JSONB;
+  v_post_state JSONB;
+  v_audit_id UUID;
+  v_request_id TEXT;
+  v_sd_row RECORD;
+  v_prd_row RECORD;
+  v_lock_acquired BOOLEAN;
+  v_stories_updated INTEGER;
+BEGIN
+  -- Generate request_id for idempotency if not provided
+  v_request_id := COALESCE(p_request_id, p_sd_id || '-' || p_session_id || '-' || EXTRACT(EPOCH FROM NOW())::TEXT);
+
+  -- Check for duplicate request (idempotency)
+  SELECT id INTO v_audit_id
+  FROM sd_transition_audit
+  WHERE request_id = v_request_id AND status = 'completed';
+
+  IF v_audit_id IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'idempotent_hit', true,
+      'message', 'Transition already completed',
+      'audit_id', v_audit_id
+    );
+  END IF;
+
+  -- Resolve SD UUID from id or sd_key
+  SELECT uuid_id INTO v_sd_uuid
+  FROM strategic_directives_v2
+  WHERE id = p_sd_id OR sd_key = p_sd_id
+  LIMIT 1;
+
+  IF v_sd_uuid IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'SD not found: ' || p_sd_id);
+  END IF;
+
+  -- Resolve PRD UUID if provided
+  IF p_prd_id IS NOT NULL AND p_prd_id != '' THEN
+    SELECT uuid_id INTO v_prd_uuid
+    FROM product_requirements_v2
+    WHERE prd_id = p_prd_id OR uuid_id::TEXT = p_prd_id
+    LIMIT 1;
+  END IF;
+
+  -- Acquire advisory lock (transaction-scoped, auto-releases on commit/rollback)
+  v_lock_acquired := pg_try_advisory_xact_lock(hashtext(p_sd_id));
+
+  IF NOT v_lock_acquired THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Concurrent transition in progress',
+      'code', 'CONCURRENT_LOCK'
+    );
+  END IF;
+
+  -- Capture pre-state
+  SELECT id, status, current_phase, transition_version, progress
+  INTO v_sd_row
+  FROM strategic_directives_v2
+  WHERE uuid_id = v_sd_uuid
+  FOR UPDATE; -- Row-level lock
+
+  v_pre_state := jsonb_build_object(
+    'sd_id', p_sd_id,
+    'sd_status', v_sd_row.status,
+    'sd_phase', v_sd_row.current_phase,
+    'sd_version', v_sd_row.transition_version,
+    'sd_progress', v_sd_row.progress
+  );
+
+  -- Add PRD state if exists
+  IF v_prd_uuid IS NOT NULL THEN
+    SELECT prd_id, status, phase
+    INTO v_prd_row
+    FROM product_requirements_v2
+    WHERE uuid_id = v_prd_uuid
+    FOR UPDATE;
+
+    v_pre_state := v_pre_state || jsonb_build_object(
+      'prd_id', p_prd_id,
+      'prd_status', v_prd_row.status,
+      'prd_phase', v_prd_row.phase
+    );
+  END IF;
+
+  -- Create audit record (in_progress)
+  INSERT INTO sd_transition_audit (sd_id, transition_type, session_id, request_id, pre_state, status)
+  VALUES (v_sd_uuid, 'EXEC_TO_PLAN', p_session_id, v_request_id, v_pre_state, 'in_progress')
+  RETURNING id INTO v_audit_id;
+
+  -- === ATOMIC TRANSITIONS START ===
+
+  -- Step 1: Update user stories to validated/completed
+  -- FIX: Cast v_sd_uuid to text because user_stories.sd_id is varchar(50), not UUID
+  UPDATE user_stories
+  SET
+    status = CASE WHEN status = 'in_progress' THEN 'completed' ELSE status END,
+    implementation_status = 'validated',
+    updated_at = NOW()
+  WHERE sd_id = v_sd_uuid::text
+  AND status IN ('in_progress', 'draft', 'ready');
+
+  GET DIAGNOSTICS v_stories_updated = ROW_COUNT;
+
+  -- Step 2: Update PRD status to verification
+  IF v_prd_uuid IS NOT NULL THEN
+    UPDATE product_requirements_v2
+    SET
+      status = 'verification',
+      phase = 'verification',
+      updated_at = NOW()
+    WHERE uuid_id = v_prd_uuid;
+  END IF;
+
+  -- Step 3: Update SD phase to EXEC_COMPLETE
+  UPDATE strategic_directives_v2
+  SET
+    current_phase = 'EXEC_COMPLETE',
+    status = 'verification',
+    transition_version = COALESCE(transition_version, 1) + 1,
+    updated_at = NOW()
+  WHERE uuid_id = v_sd_uuid;
+
+  -- === ATOMIC TRANSITIONS END ===
+
+  -- Capture post-state
+  v_post_state := jsonb_build_object(
+    'sd_phase', 'EXEC_COMPLETE',
+    'sd_status', 'verification',
+    'prd_status', 'verification',
+    'stories_updated', v_stories_updated
+  );
+
+  -- Update audit record to completed
+  UPDATE sd_transition_audit
+  SET
+    status = 'completed',
+    post_state = v_post_state,
+    completed_at = NOW()
+  WHERE id = v_audit_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'audit_id', v_audit_id,
+    'stories_updated', v_stories_updated,
+    'pre_state', v_pre_state,
+    'post_state', v_post_state
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  -- Log error to audit table
+  IF v_audit_id IS NOT NULL THEN
+    UPDATE sd_transition_audit
+    SET
+      status = 'failed',
+      error_details = jsonb_build_object(
+        'code', SQLSTATE,
+        'message', SQLERRM,
+        'detail', COALESCE(v_pre_state, '{}'::JSONB)
+      ),
+      completed_at = NOW()
+    WHERE id = v_audit_id;
+  END IF;
+
+  -- Re-raise to trigger transaction rollback
+  RAISE;
+END;
+$function$;

--- a/database/migrations/20260406_v_active_sessions_stale_600s.sql
+++ b/database/migrations/20260406_v_active_sessions_stale_600s.sql
@@ -1,0 +1,16 @@
+-- Migration: Update v_active_sessions stale threshold from 300s to 600s
+-- Applied: 2026-04-06 (via database-agent)
+-- SD: SD-CLAIMQUEUE-COHERENCE-WIRE-HEARTBEATAWARE-ORCH-001
+-- Purpose: Sync DB view threshold with stale-threshold.js (300s -> 600s, 10min = 2x heartbeat)
+--
+-- Changes applied to v_active_sessions view:
+--   1. seconds_until_stale: GREATEST(0, 300 -> 600 - EXTRACT(...))
+--   2. computed_status: WHEN EXTRACT(...) > 300 -> 600 THEN 'stale'
+--
+-- NOTE: This migration was applied directly to the database.
+-- The CREATE OR REPLACE VIEW statement is not reproduced here because
+-- pg_get_viewdef is not accessible via Supabase REST API.
+-- To regenerate: pg_dump --schema-only -t v_active_sessions
+
+-- Verification query (should show 600 in stale calculations):
+-- SELECT pg_get_viewdef('v_active_sessions'::regclass, true);

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -216,7 +216,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
             ? `${Math.round(heartbeatAge / 60)}m ago`
             : `${Math.round(heartbeatAge / 3600)}h ago`,
         computed_status: s.status === 'released' ? 'released'
-          : heartbeatAge > 300 ? 'stale' : 'active'
+          : heartbeatAge > STALE_THRESHOLD_SECONDS ? 'stale' : 'active'
       };
     });
   }

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -19,6 +19,7 @@
 import path from 'path';
 import { realpathSync } from 'fs';
 import { resolveOwnSession } from './resolve-own-session.js';
+import { analyzeClaimRelationship } from '../scripts/modules/sd-next/claim-analysis.js';
 
 /**
  * Structured error for claim validity failures. Carries discriminant `reason`
@@ -76,6 +77,8 @@ function explainRemediation(reason) {
       return 'Multiple sessions share this terminal_id. Run `/claim list` to see all active sessions. This usually means two Claude Code instances are running on the same host without unique CLAUDE_SESSION_ID env vars.';
     case 'no_deterministic_identity':
       return 'CLAUDE_SESSION_ID env var is not set and no matching marker file was found. Restart Claude Code so the SessionStart hook can populate .claude/session-identity/. Do NOT fall back to heartbeat guessing.';
+    case 'soft_block':
+      return 'Session is stale but liveness cannot be confirmed. Wait for TTL expiry or release manually.';
     case 'error':
       return 'Identity resolution query failed. Check Supabase connectivity and SUPABASE_URL env var.';
     default:
@@ -141,8 +144,105 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     return { resolved, sd, ownership: 'unclaimed' };
   }
 
-  // Claimed by another active session → HARD STOP
+  // Claimed by another session → classify relationship before deciding
+  // SD-CLAIMQUEUE-COHERENCE-WIRE-HEARTBEATAWARE-ORCH-001-A: heartbeat-aware branching
   if (sd.claiming_session_id !== mySessionId) {
+    // Look up the claiming session's heartbeat and liveness data
+    const { data: claimingSession } = await supabase
+      .from('v_active_sessions')
+      .select('session_id, heartbeat_age_seconds, terminal_id, pid, hostname, status, current_branch')
+      .eq('session_id', sd.claiming_session_id)
+      .maybeSingle();
+
+    const classification = analyzeClaimRelationship({
+      claimingSessionId: sd.claiming_session_id,
+      claimingSession: claimingSession || { heartbeat_age_seconds: 9999 },
+      currentSession: resolved.data
+    });
+
+    if (classification.canAutoRelease) {
+      // stale_dead: Auto-release via atomic conditional UPDATE
+      // Check git activity grace: if recent git, extend grace by one threshold interval
+      let gitGrace = false;
+      if (claimingSession?.current_branch) {
+        try {
+          const { execSync } = await import('child_process');
+          const lastCommitAge = execSync(
+            `git log -1 --format=%cr "${claimingSession.current_branch}" 2>/dev/null || echo "unknown"`,
+            { encoding: 'utf8', timeout: 5000 }
+          ).trim();
+          if (lastCommitAge.includes('second') || lastCommitAge.includes('minute')) {
+            gitGrace = true;
+          }
+        } catch { /* git check failed, proceed without grace */ }
+      }
+
+      if (gitGrace) {
+        throw new ClaimIdentityError({
+          reason: 'soft_block',
+          operation, sdKey,
+          mySessionId,
+          ownerSessionId: sd.claiming_session_id,
+          heartbeatAge: claimingSession?.heartbeat_age_seconds,
+          classification: classification.relationship,
+          remediation: `Session is stale but has recent git activity. Waiting one grace interval before auto-release.\n  Heartbeat: ${Math.round((claimingSession?.heartbeat_age_seconds || 0) / 60)}m ago\n  Classification: ${classification.relationship} (git grace active)`
+        });
+      }
+
+      // Emit structured audit log before release
+      console.log(JSON.stringify({
+        event: 'claim_auto_release',
+        releasing_session: mySessionId,
+        prior_owner_session: sd.claiming_session_id,
+        sd_key: sdKey,
+        reason: classification.relationship,
+        heartbeat_age_seconds: claimingSession?.heartbeat_age_seconds || null,
+        pid_verified: !!classification.pid,
+        timestamp: new Date().toISOString()
+      }));
+
+      // Atomic conditional UPDATE: release + reclaim in one operation
+      const { data: updated, error: releaseErr } = await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: mySessionId })
+        .eq('sd_key', sdKey)
+        .eq('claiming_session_id', sd.claiming_session_id)
+        .select('sd_key')
+        .maybeSingle();
+
+      if (releaseErr || !updated) {
+        throw new ClaimIdentityError({
+          reason: 'foreign_claim',
+          operation, sdKey,
+          mySessionId,
+          ownerSessionId: sd.claiming_session_id,
+          remediation: 'Auto-release failed (another session may have claimed first). Run `/claim list` to check.'
+        });
+      }
+
+      // Also update claude_sessions to reflect the claim transfer
+      await supabase.from('claude_sessions')
+        .update({ sd_id: sdKey })
+        .eq('session_id', mySessionId);
+
+      console.log(`   ✅ Auto-released stale claim from ${sd.claiming_session_id} → ${mySessionId}`);
+      return { resolved, sd: { ...sd, claiming_session_id: mySessionId }, ownership: 'self' };
+    }
+
+    if (classification.relationship === 'stale_alive' || classification.relationship === 'stale_remote') {
+      // Soft block: informative error with context
+      throw new ClaimIdentityError({
+        reason: 'soft_block',
+        operation, sdKey,
+        mySessionId,
+        ownerSessionId: sd.claiming_session_id,
+        heartbeatAge: claimingSession?.heartbeat_age_seconds,
+        classification: classification.relationship,
+        remediation: `Session is stale but cannot confirm it's dead (${classification.relationship}).\n  Heartbeat: ${Math.round((claimingSession?.heartbeat_age_seconds || 0) / 60)}m ago\n  Classification: ${classification.relationship}\n  Suggestion: Wait for TTL expiry or release manually via /claim release.`
+      });
+    }
+
+    // other_active: Hard stop (unchanged behavior)
     throw new ClaimIdentityError({
       reason: 'foreign_claim',
       operation, sdKey,

--- a/lib/claim/stale-threshold.js
+++ b/lib/claim/stale-threshold.js
@@ -15,7 +15,7 @@ const DEFAULT_STALE_THRESHOLD_SECONDS = 600;
 
 /**
  * Get the stale session threshold in seconds.
- * Reads from STALE_SESSION_THRESHOLD_SECONDS env var, falls back to 300s default.
+ * Reads from STALE_SESSION_THRESHOLD_SECONDS env var, falls back to 600s default.
  * @returns {number} Threshold in seconds
  */
 export function getStaleThresholdSeconds() {

--- a/lib/claim/stale-threshold.js
+++ b/lib/claim/stale-threshold.js
@@ -7,10 +7,11 @@
  *          /claim command, sd-next recommendations.
  *
  * Override via STALE_SESSION_THRESHOLD_SECONDS environment variable.
- * Default: 300 seconds (5 minutes) — matches v_active_sessions view.
+ * Default: 600 seconds (10 minutes) — 2x heartbeat interval per board consensus.
+ * Increased from 300s to provide safety margin above context compaction window (2-3 min).
  */
 
-const DEFAULT_STALE_THRESHOLD_SECONDS = 300;
+const DEFAULT_STALE_THRESHOLD_SECONDS = 600;
 
 /**
  * Get the stale session threshold in seconds.

--- a/lib/eva/capacity-assignment-engine.js
+++ b/lib/eva/capacity-assignment-engine.js
@@ -138,7 +138,7 @@ export async function getCapacityOverview(supabase, options = {}) {
         ? (now - new Date(s.heartbeat_at).getTime()) / 1000
         : Infinity;
 
-      if (age > 300) {
+      if (age > 600) { // synced with stale-threshold.js
         stale++;
       } else if (s.status === 'active') {
         active++;

--- a/lib/eva/capacity-assignment-engine.js
+++ b/lib/eva/capacity-assignment-engine.js
@@ -57,7 +57,7 @@ export async function getAssignmentRecommendations(supabase, params, options = {
       const heartbeatAge = s.heartbeat_at
         ? (now - new Date(s.heartbeat_at).getTime()) / 1000
         : Infinity;
-      const isStale = heartbeatAge > 300; // 5 minutes stale threshold
+      const isStale = heartbeatAge > 600; // 10 minutes — synced with stale-threshold.js DEFAULT_STALE_THRESHOLD_SECONDS
       const available = !hasClaim && !isStale;
 
       return {

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -446,7 +446,7 @@ async function main() {
 
   // SD-LEO-INFRA-CLAIM-SYSTEM-IMPROVEMENTS-001 (FR-003): Clean up stale sessions on startup.
   // Fire-and-forget — does not block session initialization.
-  const staleThreshold = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS || '300', 10);
+  const staleThreshold = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS || '600', 10);
   supabase.rpc('cleanup_stale_sessions', { p_stale_threshold_seconds: staleThreshold })
     .then(({ error }) => {
       if (error) {

--- a/scripts/modules/claim-health/triangulate.js
+++ b/scripts/modules/claim-health/triangulate.js
@@ -165,7 +165,7 @@ export async function triangulate(supabase, sdKey = null) {
       const heartbeatAge = sessionClaim.heartbeat_at
         ? (Date.now() - new Date(sessionClaim.heartbeat_at).getTime()) / 1000
         : Infinity;
-      signals.heartbeatStale = heartbeatAge > 300; // 5 minutes
+      signals.heartbeatStale = heartbeatAge > 600; // 10 minutes — synced with stale-threshold.js
     }
 
     const entry = {

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -184,7 +184,7 @@ export async function loadSDHierarchy(supabase) {
   try {
     const { data: sds } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority, target_application')
+      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority, target_application, claiming_session_id')
       .eq('is_active', true)
       .order('created_at')
       .limit(1000);

--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -130,11 +130,24 @@ export async function showFallbackQueue(supabase, options = {}) {
   }
 
   // Show top ready SD per track (including unassigned)
+  // SD-CLAIMQUEUE-COHERENCE-WIRE-HEARTBEATAWARE-ORCH-001-B: Exclude claimed SDs from recommendations
+  let hasRecommendation = false;
   for (const [trackKey, trackSDs] of Object.entries(tracks)) {
-    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on);
+    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on && !s.claiming_session_id);
     if (ready) {
       const trackLabel = trackKey === 'UNASSIGNED' ? 'Unassigned' : `Track ${trackKey}`;
       console.log(`${colors.green}  ${trackLabel}:${colors.reset} ${ready.sd_key || ready.id} - ${ready.title.substring(0, 50)}...`);
+      hasRecommendation = true;
+    }
+  }
+
+  // Show informative message when all SDs are claimed
+  if (!hasRecommendation && !sds.find(s => s.is_working_on)) {
+    const claimedCount = sds.filter(s => s.claiming_session_id).length;
+    if (claimedCount > 0) {
+      console.log(`${colors.dim}  No unclaimed SDs available.`);
+      console.log(`  ${claimedCount} SD(s) claimed by other sessions.`);
+      console.log(`  Tip: Run /claim list for details.${colors.reset}`);
     }
   }
 

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -852,6 +852,21 @@ async function main() {
       console.warn(`   ${colors.yellow}⚠️  Failed to persist worktree_path: ${e?.message || e}${colors.reset}`);
     }
 
+    // SD-CLAIMQUEUE-COHERENCE-WIRE-HEARTBEATAWARE-ORCH-001-C: Propagate session_id
+    // into worktree .env so handoff.js and other commands can resolve identity via dotenv.
+    // Fixes no_deterministic_identity in CLI mode where CLAUDE_ENV_FILE is unavailable.
+    try {
+      const wtEnvPath = path.join(worktreeInfo.cwd, '.env');
+      const fs = await import('fs');
+      const existing = fs.existsSync(wtEnvPath) ? fs.readFileSync(wtEnvPath, 'utf8') : '';
+      if (!existing.includes('CLAUDE_SESSION_ID=')) {
+        fs.appendFileSync(wtEnvPath, `\nCLAUDE_SESSION_ID=${session.session_id}\n`);
+        console.log(`   ${colors.dim}Session ID propagated to worktree .env${colors.reset}`);
+      }
+    } catch (envErr) {
+      console.warn(`   ${colors.yellow}⚠️  Failed to propagate session ID to worktree .env: ${envErr?.message || envErr}${colors.reset}`);
+    }
+
     // QF-20260314-250: Child claim verification gate
     // Warn when orchestrator sd:start resolves to a child's worktree
     const wtBranch = worktreeInfo.worktree.branch || '';


### PR DESCRIPTION
## Summary
Orchestrator SD with 3 children + 3 infrastructure fixes discovered during implementation.

**Total: 11 files changed, ~190 LOC**

## Children (Brainstorm-Planned)

### Child C — Session Identity Propagation (`scripts/sd-start.js`, 15 LOC)
- Appends `CLAUDE_SESSION_ID=session_xxx` to worktree `.env` after creation
- Fixes `no_deterministic_identity` blocking handoffs from CLI-mode worktrees
- RCA: CLAUDE_ENV_FILE absent in CLI + SSE port marker collision

### Child A — Heartbeat-Aware Claim Gate (`lib/claim-validity-gate.js`, 104 LOC)
- Wires `analyzeClaimRelationship()` into Check 2
- `stale_dead`: atomic conditional UPDATE auto-releases + reclaims
- `stale_alive`/`stale_remote`: `soft_block` with heartbeat context
- `other_active`: hard `foreign_claim` (unchanged)
- Git activity grace + structured JSON audit log

### Child B — Queue Display (`scripts/modules/sd-next/`, 15 LOC)
- Adds `claiming_session_id` to `loadSDHierarchy()` query
- Filters claimed SDs from RECOMMENDED in fallback-queue.js

## Infrastructure Fixes (Discovered During Implementation)

### Stale Threshold Sync (300s to 600s)
- `lib/claim/stale-threshold.js`: Default 300 -> 600
- `v_active_sessions` DB view: 300 -> 600 (migration applied)
- `lib/claim-guard.mjs`: Hardcoded 300 -> uses STALE_THRESHOLD_SECONDS
- `lib/eva/capacity-assignment-engine.js`: 2x hardcoded 300 -> 600
- `scripts/hooks/concurrent-session-worktree.cjs`: Default 300 -> 600
- `scripts/modules/claim-health/triangulate.js`: 300 -> 600

### EXEC-TO-PLAN RPC Type Mismatch Fix
- `fn_atomic_exec_to_plan_transition`: `WHERE sd_id = v_sd_uuid` -> `v_sd_uuid::text`
- Pre-existing bug blocking all EXEC-TO-PLAN handoffs (varchar vs uuid comparison)

### specialist_testimony Argument Type
- Added to `debate_arguments.argument_type` CHECK constraint (migration applied separately)

## Test plan
- [ ] sd-start in CLI mode creates worktree with CLAUDE_SESSION_ID in .env
- [ ] Handoff from worktree passes claim-validity-gate
- [ ] Stale+dead session auto-releases on sd-start attempt
- [ ] Active session claim is not stolen
- [ ] Stale remote gets soft_block with context
- [ ] sd:next excludes claimed SDs from RECOMMENDED
- [ ] EXEC-TO-PLAN handoff succeeds (no varchar/uuid error)

SD-CLAIMQUEUE-COHERENCE-WIRE-HEARTBEATAWARE-ORCH-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)