### PR TITLE
fix(SD-MAN-FIX-FIX-ADVANCE-VENTURE-001): drop redundant 4-param fn_advance_venture_stage overload

### DIFF
--- a/database/migrations/20260406_drop_redundant_advance_venture_overload.sql
+++ b/database/migrations/20260406_drop_redundant_advance_venture_overload.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- SD-MAN-FIX-FIX-ADVANCE-VENTURE-001
+-- Drop redundant 4-param overload of fn_advance_venture_stage
+-- ============================================================================
+-- The 20260406_add_artifact_gate migration created both a 4-param and 5-param
+-- overload. PostgREST cannot disambiguate between them when callers send 4
+-- params because the 5-param version has DEFAULT values on trailing params.
+-- The 5-param version (with p_idempotency_key UUID DEFAULT NULL) is the
+-- canonical one — it has FOR UPDATE lock, idempotency, artifact gate, and
+-- correct column names. The 4-param version is redundant and buggy.
+-- ============================================================================
+
+-- Drop the redundant 4-param overload
+DROP FUNCTION IF EXISTS fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB);
+
+-- Revoke any lingering grants on the 4-param signature (no-op if already gone)
+-- The 5-param version retains its grants from the earlier migration.

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -307,11 +307,8 @@ export async function advanceStage(supabase, opts) {
     p_from_stage: fromStage,
     p_to_stage: toStage,
     p_handoff_data: handoffData,
+    p_idempotency_key: idempotencyKey,
   };
-
-  if (idempotencyKey) {
-    rpcParams.p_idempotency_key = idempotencyKey;
-  }
 
   const { data: result, error } = await supabase.rpc('fn_advance_venture_stage', rpcParams);
 


### PR DESCRIPTION
## Summary
- Drop redundant 4-param `fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB)` overload that caused PostgREST ambiguity with the 5-param version
- Update `artifact-persistence-service.js` to always send `p_idempotency_key` explicitly (null when not provided) to force unambiguous 5-param resolution
- Fixes 100% RPC failure rate on audit trail writes observed during live CronDescriptor venture monitoring

## Test plan
- [x] `tests/integration/artifact-gate.test.js` — 6/6 passing
- [x] `tests/integration/eva/advance-stage-transition.test.js` — 6/6 passing
- [x] Migration applied: only 5-param overload remains in database
- [x] Verified PostgREST can resolve RPC unambiguously

🤖 Generated with [Claude Code](https://claude.com/claude-code)