### PR TITLE
feat(SD-CLAIMQUEUE-ORCH-001-A): wire heartbeat-aware auto-release into claim-validity-gate

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -18,7 +18,9 @@
 
 import path from 'path';
 import { realpathSync } from 'fs';
+import { execSync } from 'child_process';
 import { resolveOwnSession } from './resolve-own-session.js';
+import { analyzeClaimRelationship } from '../scripts/modules/sd-next/claim-analysis.js';
 
 /**
  * Structured error for claim validity failures. Carries discriminant `reason`
@@ -76,6 +78,8 @@ function explainRemediation(reason) {
       return 'Multiple sessions share this terminal_id. Run `/claim list` to see all active sessions. This usually means two Claude Code instances are running on the same host without unique CLAUDE_SESSION_ID env vars.';
     case 'no_deterministic_identity':
       return 'CLAUDE_SESSION_ID env var is not set and no matching marker file was found. Restart Claude Code so the SessionStart hook can populate .claude/session-identity/. Do NOT fall back to heartbeat guessing.';
+    case 'soft_block':
+      return 'Claim is stale but cannot be safely auto-released. The owning process may still be alive on another host or the PID is still running. Wait for TTL expiry or manually release.';
     case 'error':
       return 'Identity resolution query failed. Check Supabase connectivity and SUPABASE_URL env var.';
     default:
@@ -141,14 +145,103 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     return { resolved, sd, ownership: 'unclaimed' };
   }
 
-  // Claimed by another active session → HARD STOP
+  // Claimed by different session — classify relationship before deciding
   if (sd.claiming_session_id !== mySessionId) {
+    const { data: ownerSession } = await supabase
+      .from('v_active_sessions')
+      .select('*')
+      .eq('session_id', sd.claiming_session_id)
+      .maybeSingle();
+
+    const classification = analyzeClaimRelationship({
+      claimingSessionId: sd.claiming_session_id,
+      claimingSession: ownerSession || { heartbeat_age_seconds: 99999 },
+      currentSession: resolved.data,
+    });
+
+    // FR-5: other_active → hard foreign_claim (unchanged)
+    if (classification.relationship === 'other_active') {
+      throw new ClaimIdentityError({
+        reason: 'foreign_claim',
+        operation, sdKey,
+        mySessionId,
+        ownerSessionId: sd.claiming_session_id,
+        remediation: 'Another active Claude Code session owns this claim. Run `/claim list` to see all active claims.'
+      });
+    }
+
+    // FR-4: stale_alive or stale_remote → soft block with enriched context
+    if (classification.relationship === 'stale_alive' || classification.relationship === 'stale_remote') {
+      throw new ClaimIdentityError({
+        reason: 'soft_block',
+        operation, sdKey,
+        mySessionId,
+        ownerSessionId: sd.claiming_session_id,
+        remediation: `Claim is stale (${classification.displayLabel}, heartbeat age ${Math.round(ownerSession?.heartbeat_age_seconds || 0)}s) but cannot safely auto-release (${classification.relationship}). Wait for TTL expiry or manually release.`
+      });
+    }
+
+    // FR-8: git activity grace — check for recent commits from owner
+    if (classification.relationship === 'stale_dead') {
+      try {
+        const recentCommit = execSync('git log --oneline -1 --since="5 minutes ago" 2>/dev/null', { encoding: 'utf8', timeout: 3000 }).trim();
+        if (recentCommit) {
+          throw new ClaimIdentityError({
+            reason: 'soft_block',
+            operation, sdKey,
+            mySessionId,
+            ownerSessionId: sd.claiming_session_id,
+            remediation: `Claim is stale_dead but recent git activity detected ("${recentCommit.slice(0, 60)}"). Grace period active — retry in 5 minutes.`
+          });
+        }
+      } catch (e) {
+        if (e instanceof ClaimIdentityError) throw e;
+        // git check failed — proceed with auto-release
+      }
+    }
+
+    // FR-3: stale_dead + canAutoRelease → atomic conditional UPDATE
+    if (classification.canAutoRelease) {
+      // FR-6: structured audit log
+      const auditEntry = {
+        event: 'claim_auto_release',
+        releasing_session_id: mySessionId,
+        prior_owner_session_id: sd.claiming_session_id,
+        sd_key: sdKey,
+        reason: classification.relationship,
+        timestamp: new Date().toISOString(),
+        pid_verified: classification.pid !== null,
+      };
+      console.log(JSON.stringify(auditEntry));
+
+      const { data: released, error: releaseErr } = await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: mySessionId })
+        .eq('sd_key', sdKey)
+        .eq('claiming_session_id', sd.claiming_session_id)
+        .select('sd_key')
+        .maybeSingle();
+
+      if (releaseErr || !released) {
+        throw new ClaimIdentityError({
+          reason: 'foreign_claim',
+          operation, sdKey,
+          mySessionId,
+          ownerSessionId: sd.claiming_session_id,
+          remediation: releaseErr ? `Auto-release failed: ${releaseErr.message}` : 'Race condition — another session claimed it first.'
+        });
+      }
+
+      return { resolved, sd: { ...sd, claiming_session_id: mySessionId }, ownership: 'self' };
+    }
+
+    // Fallback: unclassified stale → foreign_claim
     throw new ClaimIdentityError({
       reason: 'foreign_claim',
       operation, sdKey,
       mySessionId,
       ownerSessionId: sd.claiming_session_id,
-      remediation: 'Another Claude Code session owns this claim. Run `/claim list` to see all active claims. If the owning session is legitimately done, run `/claim release` from it. If you believe the claim is stale, wait for TTL expiry (15 min) or have the owner release it.'
+      remediation: `Claim relationship: ${classification.relationship}. Cannot auto-release. Run \`/claim list\` to investigate.`
     });
   }
 

--- a/lib/claim/stale-threshold.js
+++ b/lib/claim/stale-threshold.js
@@ -7,10 +7,10 @@
  *          /claim command, sd-next recommendations.
  *
  * Override via STALE_SESSION_THRESHOLD_SECONDS environment variable.
- * Default: 300 seconds (5 minutes) — matches v_active_sessions view.
+ * Default: 600 seconds (10 minutes) — 2x heartbeat interval for claim auto-release safety.
  */
 
-const DEFAULT_STALE_THRESHOLD_SECONDS = 300;
+const DEFAULT_STALE_THRESHOLD_SECONDS = 600;
 
 /**
  * Get the stale session threshold in seconds.


### PR DESCRIPTION
## Summary
- Wire `analyzeClaimRelationship()` from `claim-analysis.js` into `claim-validity-gate.js` Check 2
- Stale claims with dead PIDs (`stale_dead`) are auto-released atomically instead of hard-blocking
- Stale/alive and stale/remote claims get soft_block with enriched context (heartbeat age, classification)
- Active claims remain hard `foreign_claim` (unchanged behavior)
- Raise default stale threshold from 300s to 600s (2x heartbeat interval)
- Add git activity grace period before auto-release

## Test plan
- [x] Module loads successfully (`import('./lib/claim-validity-gate.js')`)
- [x] 15/15 smoke tests pass
- [x] 11/11 claim-guard-session-fixes tests pass
- [x] 11/12 claim-default tests pass (1 pre-existing failure unrelated)
- [ ] Manual: verify stale_dead claim auto-releases on next sd-start

🤖 Generated with [Claude Code](https://claude.com/claude-code)