### PR TITLE
fix(SD-MAN-FIX-FIX-CUSTOMER-PERSONAS-001): replace .upsert() with RPC for expression-based index

### DIFF
--- a/database/migrations/20260406_upsert_customer_persona_rpc.sql
+++ b/database/migrations/20260406_upsert_customer_persona_rpc.sql
@@ -1,0 +1,43 @@
+-- Migration: Create upsert_customer_persona RPC function
+-- SD: SD-MAN-FIX-FIX-CUSTOMER-PERSONAS-001
+-- Purpose: Fix customer_personas upsert failure caused by PostgREST's inability
+--          to resolve expression-based partial unique indexes.
+--          The idx_customer_personas_canonical index uses COALESCE(industry, '')
+--          which .upsert() cannot target via onConflict parameter.
+
+CREATE OR REPLACE FUNCTION public.upsert_customer_persona(
+  p_name text,
+  p_demographics jsonb DEFAULT '{}'::jsonb,
+  p_goals text[] DEFAULT '{}'::text[],
+  p_pain_points text[] DEFAULT '{}'::text[],
+  p_psychographics jsonb DEFAULT '{}'::jsonb,
+  p_industry text DEFAULT '',
+  p_source_venture_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  INSERT INTO customer_personas (name, demographics, goals, pain_points, psychographics, industry, source_venture_id)
+  VALUES (p_name, p_demographics, p_goals, p_pain_points, p_psychographics, p_industry, p_source_venture_id)
+  ON CONFLICT (name, COALESCE(industry, '')) WHERE canonical_id IS NULL
+  DO UPDATE SET
+    demographics = EXCLUDED.demographics,
+    goals = EXCLUDED.goals,
+    pain_points = EXCLUDED.pain_points,
+    psychographics = EXCLUDED.psychographics,
+    source_venture_id = EXCLUDED.source_venture_id
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+-- Grant execute to service_role (used by stage worker)
+GRANT EXECUTE ON FUNCTION public.upsert_customer_persona(text, jsonb, text[], text[], jsonb, text, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.upsert_customer_persona IS 'Upsert a customer persona using the expression-based partial unique index idx_customer_personas_canonical. Required because PostgREST/Supabase JS .upsert() cannot resolve ON CONFLICT with COALESCE expressions.';

--- a/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
@@ -456,24 +456,25 @@ async function writeStage10Artifacts({ supabase, ventureId, customerPersonas, br
   for (let idx = 0; idx < customerPersonas.length; idx++) {
     const persona = customerPersonas[idx];
     try {
-      const { data: personaRow, error: personaErr } = await supabase
-        .from('customer_personas')
-        .upsert({
-          name: persona.name,
-          demographics: persona.demographics,
-          goals: persona.goals,
-          pain_points: persona.painPoints,
-          psychographics: { behaviors: persona.behaviors, motivations: persona.motivations },
-          // Coalesce to empty string to match the partial unique index expression:
-          // CREATE UNIQUE INDEX idx_customer_personas_canonical ON customer_personas (name, COALESCE(industry, '')) WHERE canonical_id IS NULL
-          industry: ventureIndustry || '',
-          source_venture_id: ventureId,
-        }, { onConflict: 'name,industry' })
-        .select('id')
-        .single();
-
+      // Use RPC function to handle expression-based partial unique index
+      // (PostgREST .upsert() cannot resolve ON CONFLICT with COALESCE expressions)
+      const { data: rpcResult, error: personaErr } = await supabase
+        .rpc('upsert_customer_persona', {
+          p_name: persona.name,
+          p_demographics: persona.demographics || {},
+          p_goals: persona.goals || [],
+          p_pain_points: persona.painPoints || [],
+          p_psychographics: { behaviors: persona.behaviors, motivations: persona.motivations },
+          p_industry: ventureIndustry || '',
+          p_source_venture_id: ventureId,
+        });
       if (personaErr) {
         logger.warn('[Stage10] Persona upsert failed', { name: persona.name, error: personaErr.message });
+        continue;
+      }
+      const personaRow = rpcResult ? { id: rpcResult } : null;
+      if (!personaRow) {
+        logger.warn('[Stage10] Persona upsert returned no id', { name: persona.name });
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Created `upsert_customer_persona()` RPC function to handle expression-based partial unique index that PostgREST `.upsert()` cannot resolve
- Updated `stage-10-customer-brand.js` to call `supabase.rpc()` instead of `.upsert()` for persona writes
- Fixes 0 persona rows written since table creation (2026-03-15) — every venture was losing persona data at Stage 10

## Changes
- `database/migrations/20260406_upsert_customer_persona_rpc.sql` — New RPC function with SECURITY DEFINER, correct ON CONFLICT clause
- `lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js` — Replace `.upsert()` with `supabase.rpc()`, add null-result guard

## Test plan
- [x] Smoke tests: 15/15 passing
- [x] Unit tests: 0 new failures
- [x] Migration applied to production database
- [ ] Run Stage 10 on a venture and verify customer_personas rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)