### PR TITLE
feat(SD-CLAIMQUEUE-ORCH-001-B): wire claiming_session_id into sd-next SD query

### DIFF
--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -184,7 +184,7 @@ export async function loadSDHierarchy(supabase) {
   try {
     const { data: sds } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority, target_application')
+      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority, target_application, claiming_session_id')
       .eq('is_active', true)
       .order('created_at')
       .limit(1000);

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -70,8 +70,8 @@ async function displaySDItem(item, indent, childItems, allItems, sessionContext)
   const sdId = item.sd_key || item.sd_id;
   const rankStr = item.sequence_rank ? `[${item.sequence_rank}]`.padEnd(5) : '     ';
 
-  // Check if claimed by another session
-  const claimedBySession = claimedSDs.get(sdId);
+  // Check if claimed by another session (session map OR SD-level claiming_session_id)
+  const claimedBySession = claimedSDs.get(sdId) || item.claiming_session_id || null;
   let isClaimedByOther = claimedBySession &&
     currentSession &&
     claimedBySession !== currentSession.session_id;


### PR DESCRIPTION
## Summary
- Added `claiming_session_id` to the main SD select in `data-loaders.js` so claim status is visible even when the claiming session is stale/dead
- Used SD-level `claiming_session_id` as fallback in `tracks.js` for CLAIMED badge rendering

## Test plan
- [x] Smoke tests: 15/15 passing
- [x] `npm run sd:next` runs correctly with new field
- [x] CLAIMED badges render correctly for claimed SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)