### PR TITLE
fix(SD-MAN-FIX-FIX-GOVERNANCE-OVERRIDE-001): prevent governance override from bypassing reality gate kills

### DIFF
--- a/lib/eva/gate-failure-recovery.js
+++ b/lib/eva/gate-failure-recovery.js
@@ -149,8 +149,10 @@ export async function markKilledAtGate(supabase, ventureId, opts = {}) {
   }
 
   try {
+    // FIX: Write to `ventures` (not `eva_ventures`) — worker polls `ventures` table,
+    // so kill marker on `eva_ventures` was invisible to the governance override guard.
     const { error } = await supabase
-      .from('eva_ventures')
+      .from('ventures')
       .update({
         orchestrator_state: 'killed_at_reality_gate',
         orchestrator_lock_id: null,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -862,9 +862,11 @@ export class StageExecutionWorker {
           // auto-approved via _handleChairmanGate (result._gateApproved=true),
           // and (2) stages NOT in BLOCKING that get BLOCKED by EVA's internal
           // gate evaluations (e.g., Stage 16 promotion gate).
-          // Only override gate/decision blocks, NOT contract validation failures (missing upstream data)
+          // Only override gate/decision blocks, NOT contract validation failures or reality gate kills.
+          // Reality gates enforce data integrity and must NEVER be overridable by governance auto-proceed.
           const isContractBlock = result?.errors?.some(e => e.code === 'MISSING_DEPENDENCY' || e.message?.includes('upstream') || e.message?.includes('missing'));
-          const governanceOverride = !isContractBlock && (result._gateApproved || await this._canAutoAdvance(currentStage));
+          const isRealityGateBlock = result?.errors?.some(e => e.code === 'REALITY_GATE_FAILED' || e.message?.includes('reality gate') || e.message?.includes('killed_at_reality_gate'));
+          const governanceOverride = !isContractBlock && !isRealityGateBlock && (result._gateApproved || await this._canAutoAdvance(currentStage));
           if (governanceOverride) {
             this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approves — advancing as advisory`);
             this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});
@@ -909,9 +911,15 @@ export class StageExecutionWorker {
             currentStage = nextOverrideStage;
             continue;
           } else {
-            this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
+            // Distinguish reality gate kills from chairman review blocks (Layer 3 fix)
+            if (isRealityGateBlock) {
+              this._logger.log(`[Worker] Stage ${currentStage} killed by reality gate for ${ventureId} — terminal`);
+              releaseState = ORCHESTRATOR_STATES.KILLED_AT_REALITY_GATE;
+            } else {
+              this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
+              releaseState = ORCHESTRATOR_STATES.BLOCKED;
+            }
             this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
-            releaseState = ORCHESTRATOR_STATES.BLOCKED;
             break;
           }
         }


### PR DESCRIPTION
## Summary
- **Layer 1**: Add `isRealityGateBlock` check to governance override guard — `REALITY_GATE_FAILED` errors can no longer be auto-overridden by `global_auto_proceed`
- **Layer 2**: Fix `markKilledAtGate()` in `gate-failure-recovery.js` to write to `ventures` table instead of `eva_ventures` — the worker polls `ventures`, so the kill marker was previously invisible
- **Layer 3**: Distinguish reality gate kills from chairman review blocks — reality gates now set `KILLED_AT_REALITY_GATE` state instead of generic `BLOCKED`

## Test plan
- [ ] Run venture through stage with reality gate failure — should NOT be overridden by governance
- [ ] Verify `markKilledAtGate` writes to `ventures` table (query after call)
- [ ] Verify worker correctly reports `killed by reality gate — terminal` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)