### PR TITLE
fix(SD-MAN-FIX-FIX-WORKER-POLLING-001): prevent polling loop on blocked ventures

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1555,6 +1555,20 @@ export class StageExecutionWorker {
           .maybeSingle();
 
         if (prevWork?.stage_status === 'completed') {
+          // Check for pending chairman decision on current stage — if present, block is legitimate
+          const { data: pendingDecision } = await this._supabase
+            .from('chairman_decisions')
+            .select('id')
+            .eq('venture_id', venture.id)
+            .eq('stage_number', venture.current_lifecycle_stage)
+            .eq('status', 'pending')
+            .maybeSingle();
+
+          if (pendingDecision) {
+            // Block is from pending chairman review — do NOT unblock (avoids polling loop)
+            continue;
+          }
+
           this._logger.log(
             `[Worker] Unblocking ${venture.name || venture.id}: Stage ${prevStage} completed externally, ` +
             `resetting orchestrator_state to idle for Stage ${venture.current_lifecycle_stage}`


### PR DESCRIPTION
## Summary
- Fix `_checkResolvedBlocks()` in stage-execution-worker.js to check for pending chairman decisions before unblocking a venture
- Prevents BLOCKED→IDLE→BLOCKED infinite loop (~6 lock acquisitions/minute) at chairman gate stages
- When a venture is blocked at Stage N with a pending chairman decision, Stage N-1 being completed is expected — the block is legitimate

## Test plan
- [ ] Verify venture blocked at chairman gate stays blocked (no repeated "completed externally" logs)
- [ ] Verify venture blocked by non-chairman cause still unblocks correctly when resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)