### PR TITLE
fix(SD-WORKER-GATE-FIX-KILL-ORCH-001-B): spin loop guard for chairman gates

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1577,6 +1577,26 @@ export class StageExecutionWorker {
           .maybeSingle();
 
         if (prevWork?.stage_status === 'completed') {
+          // SD-WORKER-GATE-FIX-KILL-ORCH-001-B: Check for pending chairman decision
+          // before unblocking. If a chairman decision is pending on the current stage,
+          // the block is legitimate and should NOT be reset (prevents spin loop).
+          const { data: pendingDecision } = await this._supabase
+            .from('chairman_decisions')
+            .select('id')
+            .eq('venture_id', venture.id)
+            .eq('lifecycle_stage', venture.current_lifecycle_stage)
+            .eq('status', 'pending')
+            .limit(1)
+            .maybeSingle();
+
+          if (pendingDecision) {
+            this._logger.log(
+              `[Worker] Keeping ${venture.name || venture.id} blocked at Stage ${venture.current_lifecycle_stage}: ` +
+              `pending chairman decision ${pendingDecision.id}`
+            );
+            continue;
+          }
+
           this._logger.log(
             `[Worker] Unblocking ${venture.name || venture.id}: Stage ${prevStage} completed externally, ` +
             `resetting orchestrator_state to idle for Stage ${venture.current_lifecycle_stage}`


### PR DESCRIPTION
## Summary
- Add pending chairman decision check to `_checkResolvedBlocks` in stage-execution-worker.js
- When a chairman decision is pending on the current stage, the block is legitimate and should NOT be reset
- Prevents 30-second acquire/release spin loop at chairman hard gates

## Test plan
- [x] Worker does not spin loop when chairman decision is pending
- [x] Worker still unblocks when no pending decision exists
- [x] 20 lines added, no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)