### PR TITLE
fix(SD-LEO-FIX-ADD-QUICK-FIXES-001): add quick_fixes to unified inbox

### DIFF
--- a/lib/inbox/unified-inbox-builder.js
+++ b/lib/inbox/unified-inbox-builder.js
@@ -2,7 +2,7 @@
  * Unified Inbox Builder
  * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-D
  *
- * Aggregates feedback, issue_patterns, audit_findings, and SDs
+ * Aggregates feedback, issue_patterns, audit_findings, SDs, and quick_fixes
  * into a single normalized list with lifecycle grouping and
  * smart deduplication.
  */
@@ -56,6 +56,18 @@ function mapIntakeLifecycle(status, feedbackId) {
   if (status === 'archived') return 'COMPLETED';
   if (feedbackId) return 'PENDING_SDS';
   return 'NEW';
+}
+
+function mapQuickFixLifecycle(status) {
+  switch (status) {
+    case 'open': return 'NEW';
+    case 'in_progress': return 'IN_PROGRESS';
+    case 'escalated': return 'PENDING_SDS';
+    case 'completed':
+    case 'cancelled':
+    case 'closed': return 'COMPLETED';
+    default: return 'NEW';
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +167,31 @@ function normalizeSD(row) {
   };
 }
 
+function normalizeQuickFix(row) {
+  return {
+    item_id: `qf-${row.id}`,
+    item_type: 'quick_fix',
+    title: row.title || row.id,
+    lifecycle_status: mapQuickFixLifecycle(row.status),
+    created_at: row.created_at,
+    updated_at: row.updated_at || row.created_at,
+    source_ref: { table: 'quick_fixes', pk: row.id },
+    assigned_sd_id: row.escalated_to_sd_id || null,
+    linked_items: null,
+    priority: row.severity || null,
+    metadata: {
+      status: row.status,
+      severity: row.severity,
+      tier: row.tier,
+      estimated_loc: row.estimated_loc,
+      actual_loc: row.actual_loc,
+      claiming_session_id: row.claiming_session_id,
+      target_application: row.target_application,
+      escalated_to_sd_id: row.escalated_to_sd_id
+    }
+  };
+}
+
 function normalizeIntake(row) {
   return {
     item_id: `intake-${row.id}`,
@@ -233,6 +270,23 @@ async function loadIntake(supabase) {
   const youtubeRows = (youtubeResult.data || []).map(r => ({ ...r, _source_table: 'eva_youtube_intake' }));
 
   return [...todoistRows, ...youtubeRows];
+}
+
+async function loadQuickFixes(supabase) {
+  try {
+    const { data, error } = await supabase
+      .from('quick_fixes')
+      .select('id, title, status, severity, tier, estimated_loc, actual_loc, claiming_session_id, target_application, escalated_to_sd_id, created_at, updated_at');
+    if (error) {
+      if (error.message.includes('Could not find the table') || error.code === 'PGRST204') {
+        return [];
+      }
+      throw error;
+    }
+    return data || [];
+  } catch {
+    return [];
+  }
 }
 
 async function loadSDs(supabase, options = {}) {
@@ -332,7 +386,7 @@ function applyDeduplication(feedbackItems, patternItems, auditItems, sdItems, in
   }
 
   const topLevel = [];
-  const linkedCount = { feedback: 0, pattern: 0, audit: 0, intake: 0 };
+  const linkedCount = { feedback: 0, pattern: 0, audit: 0, intake: 0, quick_fix: 0 };
 
   // Process non-SD items: link to SD or keep as top-level
   for (const item of [...feedbackItems, ...patternItems, ...auditItems, ...intakeItems]) {
@@ -410,12 +464,13 @@ async function buildUnifiedInbox(supabase, options = {}) {
   } = options;
 
   // 1. Load all sources in parallel
-  const [feedbackRows, patternRows, auditRows, sdRows, intakeRows] = await Promise.all([
+  const [feedbackRows, patternRows, auditRows, sdRows, intakeRows, quickFixRows] = await Promise.all([
     loadFeedback(supabase),
     loadPatterns(supabase),
     loadAuditFindings(supabase),
     loadSDs(supabase, { includeCompleted, completedDaysBack, excludeChildSDs }),
-    loadIntake(supabase)
+    loadIntake(supabase),
+    loadQuickFixes(supabase)
   ]);
 
   // 2. Normalize
@@ -424,10 +479,11 @@ async function buildUnifiedInbox(supabase, options = {}) {
   const auditItems = auditRows.map(normalizeAudit);
   const sdItems = sdRows.map(normalizeSD);
   const intakeItems = normalizeAndDedupIntake(intakeRows.map(normalizeIntake));
+  const quickFixItems = quickFixRows.map(normalizeQuickFix);
 
   // 3. Smart deduplication
   const { topLevelItems, linkedCount } = applyDeduplication(
-    feedbackItems, patternItems, auditItems, sdItems, intakeItems
+    feedbackItems, patternItems, auditItems, sdItems, [...intakeItems, ...quickFixItems]
   );
 
   // 4. Group by lifecycle
@@ -439,7 +495,7 @@ async function buildUnifiedInbox(supabase, options = {}) {
   }
 
   const totalTopLevel = Object.values(sections).reduce((sum, arr) => sum + arr.length, 0);
-  const totalLinked = linkedCount.feedback + linkedCount.pattern + linkedCount.audit + linkedCount.intake;
+  const totalLinked = linkedCount.feedback + linkedCount.pattern + linkedCount.audit + linkedCount.intake + (linkedCount.quick_fix || 0);
 
   return {
     sections,
@@ -450,7 +506,8 @@ async function buildUnifiedInbox(supabase, options = {}) {
         patterns: patternItems.length,
         audit: auditItems.length,
         sds: sdItems.length,
-        intake: intakeItems.length
+        intake: intakeItems.length,
+        quick_fixes: quickFixItems.length
       },
       linked: totalLinked,
       by_section: Object.fromEntries(
@@ -477,13 +534,16 @@ export {
   mapAuditLifecycle,
   mapSDLifecycle,
   mapIntakeLifecycle,
+  mapQuickFixLifecycle,
   normalizeFeedback,
   normalizePattern,
   normalizeAudit,
   normalizeSD,
   normalizeIntake,
+  normalizeQuickFix,
   normalizeAndDedupIntake,
   loadIntake,
+  loadQuickFixes,
   applyDeduplication,
   groupByLifecycle,
   sortItems

--- a/tests/unit/inbox/unified-inbox-builder.test.js
+++ b/tests/unit/inbox/unified-inbox-builder.test.js
@@ -10,11 +10,13 @@ import {
   mapAuditLifecycle,
   mapSDLifecycle,
   mapIntakeLifecycle,
+  mapQuickFixLifecycle,
   normalizeFeedback,
   normalizePattern,
   normalizeAudit,
   normalizeSD,
   normalizeIntake,
+  normalizeQuickFix,
   normalizeAndDedupIntake,
   applyDeduplication,
   groupByLifecycle,
@@ -63,6 +65,16 @@ describe('Lifecycle mapping', () => {
     it('maps archived to COMPLETED', () => expect(mapIntakeLifecycle('archived', null)).toBe('COMPLETED'));
     it('maps archived with feedback_id to COMPLETED (archived takes precedence)', () => expect(mapIntakeLifecycle('archived', 'fb-123')).toBe('COMPLETED'));
     it('defaults null status without feedback to NEW', () => expect(mapIntakeLifecycle(null, null)).toBe('NEW'));
+  });
+
+  describe('mapQuickFixLifecycle', () => {
+    it('maps "open" to NEW', () => expect(mapQuickFixLifecycle('open')).toBe('NEW'));
+    it('maps "in_progress" to IN_PROGRESS', () => expect(mapQuickFixLifecycle('in_progress')).toBe('IN_PROGRESS'));
+    it('maps "escalated" to PENDING_SDS', () => expect(mapQuickFixLifecycle('escalated')).toBe('PENDING_SDS'));
+    it('maps "completed" to COMPLETED', () => expect(mapQuickFixLifecycle('completed')).toBe('COMPLETED'));
+    it('maps "cancelled" to COMPLETED', () => expect(mapQuickFixLifecycle('cancelled')).toBe('COMPLETED'));
+    it('maps "closed" to COMPLETED', () => expect(mapQuickFixLifecycle('closed')).toBe('COMPLETED'));
+    it('defaults unknown to NEW', () => expect(mapQuickFixLifecycle('foo')).toBe('NEW'));
   });
 });
 
@@ -224,6 +236,63 @@ describe('Normalizers', () => {
     expect(item.metadata.chairman_intent).toBeNull();
     expect(item.metadata.classification_confidence).toBeNull();
   });
+
+  it('normalizeQuickFix produces correct shape', () => {
+    const row = {
+      id: 'QF-20260407-001',
+      title: 'Fix breadcrumb navigation',
+      status: 'open',
+      severity: 'high',
+      tier: 1,
+      estimated_loc: 12,
+      actual_loc: null,
+      claiming_session_id: 'session_abc',
+      target_application: 'EHG_Engineer',
+      escalated_to_sd_id: null,
+      created_at: '2026-04-07T00:00:00Z',
+      updated_at: '2026-04-07T01:00:00Z'
+    };
+    const item = normalizeQuickFix(row);
+
+    expect(item.item_id).toBe('qf-QF-20260407-001');
+    expect(item.item_type).toBe('quick_fix');
+    expect(item.title).toBe('Fix breadcrumb navigation');
+    expect(item.lifecycle_status).toBe('NEW');
+    expect(item.source_ref).toEqual({ table: 'quick_fixes', pk: 'QF-20260407-001' });
+    expect(item.assigned_sd_id).toBeNull();
+    expect(item.priority).toBe('high');
+    expect(item.metadata.tier).toBe(1);
+    expect(item.metadata.estimated_loc).toBe(12);
+    expect(item.metadata.claiming_session_id).toBe('session_abc');
+    expect(item.metadata.target_application).toBe('EHG_Engineer');
+  });
+
+  it('normalizeQuickFix uses escalated_to_sd_id as assigned_sd_id', () => {
+    const row = {
+      id: 'QF-20260407-002', title: 'Escalated fix', status: 'escalated',
+      severity: 'medium', tier: 2, estimated_loc: 40, actual_loc: null,
+      claiming_session_id: null, target_application: 'EHG',
+      escalated_to_sd_id: 'sd-uuid-123',
+      created_at: '2026-04-07T00:00:00Z', updated_at: null
+    };
+    const item = normalizeQuickFix(row);
+
+    expect(item.assigned_sd_id).toBe('sd-uuid-123');
+    expect(item.lifecycle_status).toBe('PENDING_SDS');
+    expect(item.metadata.escalated_to_sd_id).toBe('sd-uuid-123');
+  });
+
+  it('normalizeQuickFix falls back to id when title is missing', () => {
+    const row = {
+      id: 'QF-20260407-003', title: null, status: 'open',
+      severity: null, tier: null, estimated_loc: null, actual_loc: null,
+      claiming_session_id: null, target_application: null, escalated_to_sd_id: null,
+      created_at: '2026-04-07T00:00:00Z', updated_at: null
+    };
+    const item = normalizeQuickFix(row);
+    expect(item.title).toBe('QF-20260407-003');
+    expect(item.priority).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -382,6 +451,37 @@ describe('Smart deduplication', () => {
 
     const { topLevelItems } = applyDeduplication(fb, [], [], sd);
     expect(topLevelItems).toHaveLength(2); // fb + sd (not linked)
+  });
+
+  it('links escalated quick fix to target SD via assigned_sd_id', () => {
+    const sd = [makeSD('SD-001', 'uuid-001')];
+    const qf = [{
+      item_id: 'qf-QF-001', item_type: 'quick_fix', title: 'Escalated QF',
+      lifecycle_status: 'PENDING_SDS', created_at: '2026-04-07T00:00:00Z',
+      updated_at: '2026-04-07T00:00:00Z', source_ref: { table: 'quick_fixes', pk: 'QF-001' },
+      assigned_sd_id: 'uuid-001', linked_items: null, priority: 'high', metadata: {}
+    }];
+
+    const { topLevelItems, linkedCount } = applyDeduplication([], [], [], sd, qf);
+    expect(topLevelItems).toHaveLength(1); // only the SD
+    expect(topLevelItems[0].item_type).toBe('sd');
+    expect(topLevelItems[0].linked_items).toHaveLength(1);
+    expect(topLevelItems[0].linked_items[0].item_type).toBe('quick_fix');
+    expect(linkedCount.quick_fix).toBe(1);
+  });
+
+  it('keeps non-escalated quick fix as top-level item', () => {
+    const sd = [makeSD('SD-001', 'uuid-001')];
+    const qf = [{
+      item_id: 'qf-QF-002', item_type: 'quick_fix', title: 'Open QF',
+      lifecycle_status: 'NEW', created_at: '2026-04-07T00:00:00Z',
+      updated_at: '2026-04-07T00:00:00Z', source_ref: { table: 'quick_fixes', pk: 'QF-002' },
+      assigned_sd_id: null, linked_items: null, priority: 'medium', metadata: {}
+    }];
+
+    const { topLevelItems } = applyDeduplication([], [], [], sd, qf);
+    expect(topLevelItems).toHaveLength(2); // sd + qf both top-level
+    expect(topLevelItems.some(i => i.item_type === 'quick_fix')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `quick_fixes` as 6th data source in `lib/inbox/unified-inbox-builder.js`
- Closes visibility gap where `/inbox` omitted QF items that were shown in `sd:next`
- Add `mapQuickFixLifecycle()`, `normalizeQuickFix()`, `loadQuickFixes()` following existing patterns
- Escalated QFs with `escalated_to_sd_id` deduplicate against their target SD
- Graceful degradation if `quick_fixes` table doesn't exist (try/catch)

## Test plan
- [x] 61 unit tests pass (49 existing + 12 new QF-specific)
- [x] mapQuickFixLifecycle: 7 status mappings verified
- [x] normalizeQuickFix: shape, escalation, null-title edge cases
- [x] applyDeduplication: escalated QF links to SD, non-escalated stays top-level
- [x] No regressions on existing 5 data sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)