### PR TITLE
fix(session): resolve PID mismatch + stale row reactivation

### DIFF
--- a/lib/resolve-own-session.js
+++ b/lib/resolve-own-session.js
@@ -114,6 +114,27 @@ export async function resolveOwnSession(supabase, options = {}) {
         .maybeSingle());
     }
 
+    // QF: Reactivate stale rows on deterministic env_var match.
+    // When CLAUDE_SESSION_ID matches session_id exactly, the identity is unambiguous —
+    // the caller IS that session. Transient stale marking (e.g. PID_NOT_FOUND from
+    // a subprocess intermediary PID) should not permanently lock out the real session.
+    if (!data) {
+      const { data: staleRow } = await supabase
+        .from('claude_sessions')
+        .select(select)
+        .eq('session_id', envId)
+        .eq('status', 'stale')
+        .maybeSingle();
+
+      if (staleRow) {
+        await supabase
+          .from('claude_sessions')
+          .update({ status: 'active', heartbeat_at: new Date().toISOString(), stale_reason: null })
+          .eq('session_id', envId);
+        return { data: { ...staleRow, status: 'active' }, source: 'env_var', sessionId: envId };
+      }
+    }
+
     if (data) {
       return { data, source: 'env_var', sessionId: envId };
     }
@@ -161,8 +182,8 @@ export async function resolveOwnSession(supabase, options = {}) {
       // CLAUDE_SESSION_ID env var (Strategy 1) for claim/handoff operations.
       if (requireDeterministic) {
         if (warnOnFallback) {
-          console.warn(`[resolve-own-session] terminal_id match found but demoted (requireDeterministic=true). ` +
-            `Set CLAUDE_SESSION_ID env var for deterministic identity.`);
+          console.warn('[resolve-own-session] terminal_id match found but demoted (requireDeterministic=true). ' +
+            'Set CLAUDE_SESSION_ID env var for deterministic identity.');
         }
         continue; // fall through — will reach no_deterministic_identity
       }
@@ -190,7 +211,7 @@ export async function resolveOwnSession(supabase, options = {}) {
       .sort((a, b) => new Date(b.heartbeat_at).getTime() - new Date(a.heartbeat_at).getTime())[0];
     if (warnOnFallback) {
       console.warn(`[resolve-own-session] WARNING: ${matches.length} rows match terminal_id=${candidate}. ` +
-        `Returning newest heartbeat (legacy behavior). Pass requireDeterministic=true to fail closed.`);
+        'Returning newest heartbeat (legacy behavior). Pass requireDeterministic=true to fail closed.');
     }
     return { data: newest, source: 'terminal_id', sessionId: newest.session_id };
   }

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -48,6 +48,26 @@ function getTTY() {
 }
 
 /**
+ * Read the Claude Code PID from the session-identity marker file.
+ * The SessionStart hook writes pid-{ccPid}.json with the real CC process PID.
+ * This is more reliable than process.ppid, which returns a shell intermediary.
+ */
+function _readCcPidFromMarker() {
+  try {
+    const markerDir = path.resolve(__dirname, '../.claude/session-identity');
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    if (sessionId) {
+      const markerPath = path.join(markerDir, `${sessionId}.json`);
+      if (fs.existsSync(markerPath)) {
+        const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+        if (marker.cc_pid) return Number(marker.cc_pid);
+      }
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+/**
  * SD-LEO-INFRA-ISL-001: Get machine identifier for terminal identity
  * Uses hostname + OS info to create a unique machine ID
  */
@@ -303,7 +323,10 @@ export async function getOrCreateSession() {
   // Create new session
   const sessionId = generateSessionId();
   const tty = getTTY();
-  const pid = process.ppid || process.pid;
+  // QF: Read cc_pid from marker file (the actual Claude Code PID) instead of
+  // process.ppid which is a shell intermediary that dies when the subprocess exits.
+  // This prevents PID_NOT_FOUND stale marking on freshly created sessions.
+  const pid = _readCcPidFromMarker() || process.ppid || process.pid;
   const hostname = os.hostname();
   const codebase = getCodebase();
   const branch = getBranch();


### PR DESCRIPTION
## Summary
- **Fix 1**: `session-manager.mjs` reads `cc_pid` from marker file instead of `process.ppid`, which returns a shell intermediary PID that dies immediately after subprocess exit, causing instant `PID_NOT_FOUND` stale marking on freshly created sessions.
- **Fix 2**: `resolve-own-session.js` Strategy 1 now reactivates stale rows when `CLAUDE_SESSION_ID` env var matches `session_id` exactly (deterministic identity), making the system self-healing against transient stale marking.

## Root Cause
When `npm run sd:next` runs, the process chain is: CC Desktop → node (CC CLI) → bash → npm → node (sd-next.js). `process.ppid` from sd-next.js is the bash/npm intermediary, not the Claude Code process. That PID is ephemeral and dies when the command exits. `cleanupStaleSessions()` then finds it dead and marks the session stale within seconds of creation.

## Test plan
- [x] Verified marker file correctly returns cc_pid=33652 (real CC PID) vs process.ppid returning wrong intermediary
- [x] Verified stale session reactivation works — `sd-start.js` successfully resolved identity after fix (source=env_var)
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)