### PR TITLE
feat(SD-NARRATIVE-ORCH-001-D): branch protection policy-as-code + drift audit

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Branch protection policy-as-code for EHG_Engineer. Applied via scripts/configure-branch-protection.js.",
+  "repository": "rickfelix/EHG_Engineer",
+  "branches": {
+    "main": {
+      "required_pull_request_reviews": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false
+      },
+      "required_status_checks": {
+        "strict": false,
+        "contexts": []
+      },
+      "enforce_admins": false,
+      "required_linear_history": false,
+      "allow_force_pushes": false,
+      "allow_deletions": false,
+      "restrictions": null
+    }
+  },
+  "metadata": {
+    "managed_by": "SD-NARRATIVE-KNOWLEDGE-TO-ENFORCED-ORCH-001-D",
+    "last_updated": "2026-04-10",
+    "notes": "Minimal policy: block force push and branch deletion on main. Review requirements kept at 0 for solo developer workflow."
+  }
+}

--- a/scripts/audit-branch-protection.js
+++ b/scripts/audit-branch-protection.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+/**
+ * Branch protection drift audit — ALERT-ONLY mode.
+ *
+ * Compares live GitHub branch protection settings against the
+ * declarative policy in .github/branch-protection.json and reports
+ * any differences. NEVER auto-remediates.
+ *
+ * Exit codes:
+ *   0 — no drift detected
+ *   1 — drift detected (differences printed)
+ *   2 — error (missing token, API failure)
+ *
+ * SD: SD-NARRATIVE-KNOWLEDGE-TO-ENFORCED-ORCH-001-D
+ * @module scripts/audit-branch-protection
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Octokit } from '@octokit/rest';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const POLICY_PATH = resolve(import.meta.dirname, '..', '.github', 'branch-protection.json');
+
+function loadPolicy() {
+  const raw = readFileSync(POLICY_PATH, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function compareBoolField(name, live, policy) {
+  const liveVal = typeof live === 'object' ? live?.enabled : live;
+  if (liveVal !== policy) {
+    return { field: name, live: liveVal, policy };
+  }
+  return null;
+}
+
+async function auditBranch(octokit, owner, repo, branch, policy) {
+  const diffs = [];
+
+  let live;
+  try {
+    const { data } = await octokit.repos.getBranchProtection({ owner, repo, branch });
+    live = data;
+  } catch (err) {
+    if (err.status === 404) {
+      diffs.push({ field: 'protection', live: 'NONE', policy: 'CONFIGURED' });
+      return diffs;
+    }
+    throw err;
+  }
+
+  // Compare key boolean fields
+  const checks = [
+    compareBoolField('allow_force_pushes', live.allow_force_pushes, policy.allow_force_pushes ?? false),
+    compareBoolField('allow_deletions', live.allow_deletions, policy.allow_deletions ?? false),
+    compareBoolField('enforce_admins', live.enforce_admins, policy.enforce_admins ?? false),
+    compareBoolField('required_linear_history', live.required_linear_history, policy.required_linear_history ?? false),
+  ];
+
+  for (const diff of checks) {
+    if (diff) diffs.push(diff);
+  }
+
+  // Compare review count
+  const liveReviews = live.required_pull_request_reviews?.required_approving_review_count ?? 0;
+  const policyReviews = policy.required_pull_request_reviews?.required_approving_review_count ?? 0;
+  if (liveReviews !== policyReviews) {
+    diffs.push({ field: 'required_approving_review_count', live: liveReviews, policy: policyReviews });
+  }
+
+  return diffs;
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('[audit-branch-protection] GITHUB_TOKEN not set');
+    process.exit(2);
+  }
+
+  const policy = loadPolicy();
+  const [owner, repo] = policy.repository.split('/');
+  const octokit = new Octokit({ auth: token });
+
+  console.log(`[audit-branch-protection] Repository: ${owner}/${repo}`);
+  console.log(`[audit-branch-protection] Mode: ALERT-ONLY (no auto-remediation)`);
+  console.log(`[audit-branch-protection] Time: ${new Date().toISOString()}\n`);
+
+  let totalDrift = 0;
+
+  for (const [branch, branchPolicy] of Object.entries(policy.branches)) {
+    console.log(`[Branch: ${branch}]`);
+
+    try {
+      const diffs = await auditBranch(octokit, owner, repo, branch, branchPolicy);
+
+      if (diffs.length === 0) {
+        console.log('  No drift detected');
+      } else {
+        totalDrift += diffs.length;
+        for (const d of diffs) {
+          console.log(`  DRIFT: ${d.field} — live=${d.live}, policy=${d.policy}`);
+        }
+      }
+    } catch (err) {
+      console.error(`  ERROR: ${err.message}`);
+      totalDrift++;
+    }
+    console.log();
+  }
+
+  if (totalDrift === 0) {
+    console.log('[audit-branch-protection] All branches match policy.');
+    process.exit(0);
+  } else {
+    console.log(`[audit-branch-protection] ${totalDrift} drift(s) detected. Review and remediate manually.`);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(`[audit-branch-protection] Fatal: ${err.message}`);
+  process.exit(2);
+});

--- a/scripts/configure-branch-protection.js
+++ b/scripts/configure-branch-protection.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Apply branch protection settings from .github/branch-protection.json.
+ *
+ * Reads the declarative policy file and applies it to the repository
+ * via GitHub REST API using @octokit/rest.
+ *
+ * Usage:
+ *   node scripts/configure-branch-protection.js              # Apply policy
+ *   node scripts/configure-branch-protection.js --dry-run    # Show what would change
+ *
+ * Requires: GITHUB_TOKEN env var with repo admin scope.
+ *
+ * SD: SD-NARRATIVE-KNOWLEDGE-TO-ENFORCED-ORCH-001-D
+ * @module scripts/configure-branch-protection
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Octokit } from '@octokit/rest';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const POLICY_PATH = resolve(import.meta.dirname, '..', '.github', 'branch-protection.json');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function loadPolicy() {
+  const raw = readFileSync(POLICY_PATH, 'utf-8');
+  return JSON.parse(raw);
+}
+
+async function getCurrentProtection(octokit, owner, repo, branch) {
+  try {
+    const { data } = await octokit.repos.getBranchProtection({ owner, repo, branch });
+    return data;
+  } catch (err) {
+    if (err.status === 404) return null;
+    throw err;
+  }
+}
+
+async function applyProtection(octokit, owner, repo, branch, policy) {
+  const params = {
+    owner,
+    repo,
+    branch,
+    required_pull_request_reviews: policy.required_pull_request_reviews || null,
+    required_status_checks: policy.required_status_checks || null,
+    enforce_admins: policy.enforce_admins ?? false,
+    required_linear_history: policy.required_linear_history ?? false,
+    allow_force_pushes: policy.allow_force_pushes ?? false,
+    allow_deletions: policy.allow_deletions ?? false,
+    restrictions: policy.restrictions || null,
+  };
+
+  await octokit.repos.updateBranchProtection(params);
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('[configure-branch-protection] GITHUB_TOKEN not set');
+    process.exit(1);
+  }
+
+  const policy = loadPolicy();
+  const [owner, repo] = policy.repository.split('/');
+  const octokit = new Octokit({ auth: token });
+
+  console.log(`[configure-branch-protection] Repository: ${owner}/${repo}`);
+  console.log(`[configure-branch-protection] Mode: ${DRY_RUN ? 'DRY RUN' : 'APPLY'}`);
+
+  for (const [branch, branchPolicy] of Object.entries(policy.branches)) {
+    console.log(`\n[Branch: ${branch}]`);
+
+    const current = await getCurrentProtection(octokit, owner, repo, branch);
+
+    if (!current) {
+      console.log('  No protection currently set');
+    } else {
+      console.log(`  Current: force_push=${current.allow_force_pushes?.enabled}, deletions=${current.allow_deletions?.enabled}`);
+    }
+
+    console.log(`  Policy:  force_push=${branchPolicy.allow_force_pushes}, deletions=${branchPolicy.allow_deletions}`);
+
+    if (DRY_RUN) {
+      console.log('  [DRY RUN] Would apply policy — no changes made');
+      continue;
+    }
+
+    try {
+      await applyProtection(octokit, owner, repo, branch, branchPolicy);
+      console.log('  Applied successfully');
+    } catch (err) {
+      console.error(`  Failed: ${err.message}`);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(`[configure-branch-protection] Fatal: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `.github/branch-protection.json`: declarative policy-as-code for main branch
- `scripts/configure-branch-protection.js`: apply policy via GitHub API (supports --dry-run)
- `scripts/audit-branch-protection.js`: daily drift detection (ALERT-ONLY, no auto-remediation)
- CODEOWNERS already existed

## Test plan
- [ ] `node scripts/configure-branch-protection.js --dry-run` shows current vs policy
- [ ] `node scripts/audit-branch-protection.js` detects drift when settings differ
- [ ] JSON policy validates with `JSON.parse()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)