### PR TITLE
fix(SD-INTELLIGENT-REPO-CLEANUP-COMMAND-ORCH-001-A): expand parsePhases for bullet and numbered list formats

### DIFF
--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -105,12 +105,22 @@ function parsePhases(content) {
   let current = null;
 
   for (const line of lines) {
-    const match = line.match(/^#{1,4}\s*(Phase|Implementation Phase|Step)\s+(\d+)[:\s-]*(.*)/i);
+    // Format 1: Heading — ### Phase 1: Title
+    const headingMatch = line.match(/^#{1,4}\s*(Phase|Implementation Phase|Step)\s+(\d+)[:\s-]*(.*)/i);
+    // Format 2: Bullet — - **Phase 1 (MVP, ~3 days)**: Title
+    const bulletMatch = !headingMatch && line.match(/^\s*[-*]\s*\*\*(?:Phase|Step)\s+(\d+)\b[^*]*\*\*[:\s-]*(.*)/i);
+    // Format 3: Numbered — 1. **Phase 1**: Title
+    const numberedMatch = !headingMatch && !bulletMatch && line.match(/^\s*\d+\.\s*\*\*(?:Phase|Step)\s+(\d+)\b[^*]*\*\*[:\s-]*(.*)/i);
+
+    const match = headingMatch || bulletMatch || numberedMatch;
     if (match) {
       if (current) phases.push(current);
+      // headingMatch has phase number in group 2, bullet/numbered in group 1
+      const phaseNum = headingMatch ? parseInt(match[2], 10) : parseInt(match[1], 10);
+      const titleText = headingMatch ? (match[3] || '').trim() : (match[2] || '').trim();
       current = {
-        number: parseInt(match[2], 10),
-        title: match[3].trim() || `Phase ${match[2]}`,
+        number: phaseNum,
+        title: titleText || `Phase ${phaseNum}`,
         description: '',
         content: ''
       };


### PR DESCRIPTION
## Summary
- `parsePhases()` in `create-orchestrator-from-plan.js` only matched heading format (`### Phase N: title`)
- Architecture plans commonly use bullet (`- **Phase N**: ...`) or numbered (`1. **Phase N**: ...`) formats
- This caused orchestrators to be created with **0 children** when the arch plan used non-heading formatting
- Added 2 new regex patterns alongside the existing heading match — all 3 formats now parse correctly

## Test plan
- [x] Heading format: `### Phase 1: MVP` -> parses correctly
- [x] Bullet format: `- **Phase 1 (MVP, ~3 days)**: Core engine` -> parses correctly  
- [x] Numbered format: `1. **Phase 1**: Core engine` -> parses correctly
- [x] Mixed format plan with all 3 styles -> all phases parsed
- [x] Empty/null input -> returns `[]`
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)