### PR TITLE
feat(SD-INTELLIGENT-REPO-CLEANUP-COMMAND-ORCH-001-C): wire cleanup into sd:next and /leo router

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -211,6 +211,17 @@ Skill tool: skill="leo-settings"
 
 The leo-settings skill handles querying current settings, displaying them, and modifying global defaults or session overrides.
 
+### If argument is "cleanup" or "cl" or "tidy":
+
+**DELEGATES TO**: `/leo-cleanup` skill (`.claude/commands/leo-cleanup.md`)
+
+Invoke the `leo-cleanup` skill using the Skill tool:
+```
+Skill tool: skill="leo-cleanup"
+```
+
+The leo-cleanup skill handles scanning, categorization, interactive review, and rule learning.
+
 ### If argument is "restart" or "r":
 Run the LEO stack restart command:
 ```bash
@@ -571,6 +582,7 @@ LEO Commands:
   /leo assist    (a)     - Autonomous inbox processing (issues + enhancements)
   /leo audit     (au)    - Show audit discovery report (patterns, alerts, retros)
   /leo analytics (an)    - Show self-improvement analytics dashboard
+  /leo cleanup   (cl)    - Scan and clean untracked files (pattern rules)
   /leo restart   (r)     - Restart all LEO servers
   /leo inbox     (inb)   - Show feedback inbox (view only)
   /leo next      (n)     - Show SD queue (what to work on)

--- a/lib/root-temp-checker.mjs
+++ b/lib/root-temp-checker.mjs
@@ -76,21 +76,39 @@ export async function checkRootTempFiles() {
 }
 
 /**
- * Display temp file warning if threshold exceeded
+ * Display temp file warning if threshold exceeded.
+ * Uses repo-cleanup scan for richer categorization when available.
  * @param {number} threshold - Number of files to trigger warning (default 10)
  */
 export async function warnIfTempFilesExceedThreshold(threshold = 10) {
-  const { count, files } = await checkRootTempFiles();
+  // Try repo-cleanup scan for categorized output
+  try {
+    const { scan } = await import('../scripts/repo-cleanup.js');
+    const categories = scan();
+    const total = categories.delete.length + categories.gitignore.length +
+                  categories.commit.length + categories.review.length;
 
-  if (count > threshold) {
-    console.log('');
-    console.log(`⚠️  ${count} temp files at repository root`);
-    console.log('   Run: npm run leo:cleanup:root');
-    console.log('');
-    return true;
+    if (total > threshold) {
+      console.log('');
+      console.log(`⚠️  ${total} untracked files detected`);
+      if (categories.delete.length) console.log(`   ${categories.delete.length} to delete, ${categories.commit.length} to commit, ${categories.review.length} to review`);
+      console.log('   Run: /leo cleanup');
+      console.log('');
+      return true;
+    }
+    return false;
+  } catch {
+    // Fallback to basic check if repo-cleanup not available
+    const { count } = await checkRootTempFiles();
+    if (count > threshold) {
+      console.log('');
+      console.log(`⚠️  ${count} temp files at repository root`);
+      console.log('   Run: npm run leo:cleanup:root');
+      console.log('');
+      return true;
+    }
+    return false;
   }
-
-  return false;
 }
 
 // Allow running as CLI


### PR DESCRIPTION
## Summary
- **root-temp-checker.mjs**: Imports `scan()` from repo-cleanup.js for categorized untracked file output. sd:next now shows "N to delete, N to commit, N to review" instead of just "N temp files". Suggests `/leo cleanup` instead of `npm run leo:cleanup:root`. Graceful fallback to basic check.
- **leo.md**: Added `cleanup` / `cl` / `tidy` argument routing to the leo-cleanup skill. Added to help menu.

## Test plan
- [x] `warnIfTempFilesExceedThreshold(0)` imports scan() without errors
- [x] Clean repo correctly returns `warned: false`
- [x] `/leo cleanup` now appears in skill list
- [x] Fallback path (catch block) preserves original behavior if repo-cleanup.js unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)