### PR TITLE
feat(friday-meeting): eva_friday_meetings + eva_preferences migrations

### DIFF
--- a/database/migrations/20260410_eva_friday_meetings.sql
+++ b/database/migrations/20260410_eva_friday_meetings.sql
@@ -1,0 +1,28 @@
+-- Migration: eva_friday_meetings
+-- Date: 2026-04-10
+-- Purpose: Session state persistence for Friday management review meetings
+-- SD: SD-FRIDAY-MANAGEMENT-REVIEW-MEETING-ORCH-001
+
+CREATE TABLE IF NOT EXISTS eva_friday_meetings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  meeting_date DATE NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('waiting', 'active', 'paused', 'completed', 'abandoned')),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  mood_inference JSONB,
+  agenda JSONB,
+  current_section_index INT DEFAULT 0,
+  meeting_state JSONB,
+  feedback JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eva_friday_meetings_date ON eva_friday_meetings(meeting_date);
+CREATE INDEX IF NOT EXISTS idx_eva_friday_meetings_status ON eva_friday_meetings(status);
+
+ALTER TABLE eva_friday_meetings ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE eva_friday_meetings IS 'Stores session state for EVA Friday management review meetings';
+
+-- Rollback:
+-- DROP TABLE IF EXISTS eva_friday_meetings;

--- a/database/migrations/20260410_eva_preferences.sql
+++ b/database/migrations/20260410_eva_preferences.sql
@@ -1,0 +1,25 @@
+-- Migration: eva_preferences
+-- Purpose: Store accumulated mood/preference patterns from Friday meetings
+-- Date: 2026-04-10
+-- SD: SD-FRIDAY-MANAGEMENT-REVIEW-MEETING-ORCH-001
+
+CREATE TABLE IF NOT EXISTS eva_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  preference_type TEXT NOT NULL CHECK (preference_type IN ('mood_pattern', 'time_preference', 'topic_priority', 'section_skip', 'agenda_override', 'feedback')),
+  pattern_data JSONB NOT NULL,
+  observation_count INT DEFAULT 1,
+  last_observed_at TIMESTAMPTZ DEFAULT now(),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+COMMENT ON TABLE eva_preferences IS 'Accumulated mood/preference patterns from Friday management review meetings';
+COMMENT ON COLUMN eva_preferences.preference_type IS 'Category of preference: mood_pattern, time_preference, topic_priority, section_skip, agenda_override, feedback';
+COMMENT ON COLUMN eva_preferences.pattern_data IS 'JSONB payload containing the preference details - structure varies by preference_type';
+COMMENT ON COLUMN eva_preferences.observation_count IS 'Number of times this pattern has been observed';
+
+CREATE INDEX IF NOT EXISTS idx_eva_preferences_type ON eva_preferences(preference_type);
+
+ALTER TABLE eva_preferences ENABLE ROW LEVEL SECURITY;
+
+-- Rollback:
+-- DROP TABLE IF EXISTS eva_preferences;


### PR DESCRIPTION
## Summary
- `eva_friday_meetings` table: session state persistence for meeting resume (Child B)
- `eva_preferences` table: preference learning with observation counts (Child D)
- Both tables: RLS enabled, indexed, service-role-only access

## Test plan
- [ ] Both migrations already executed and verified
- [ ] Tables exist with correct schemas and constraints
- [ ] RLS enabled on both tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)