### PR TITLE
fix: S17 blueprint review reads quality_score from column

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
@@ -142,7 +142,7 @@ export async function analyzeStage17({
   // Fetch all current artifacts for stages 1-16
   const { data: artifacts, error } = await supabase
     .from('venture_artifacts')
-    .select('id, lifecycle_stage, artifact_type, is_current, metadata, created_at, artifact_data')
+    .select('id, lifecycle_stage, artifact_type, is_current, metadata, quality_score, created_at, artifact_data')
     .eq('venture_id', ventureId)
     .eq('is_current', true)
     .gte('lifecycle_stage', 1)
@@ -214,7 +214,7 @@ export async function analyzeStage17({
         if (found) {
           phasePresent++;
           totalPresent++;
-          const qScore = found.metadata?.quality_score;
+          const qScore = found.quality_score ?? found.metadata?.quality_score;
           if (typeof qScore === 'number') {
             phaseQualitySum += qScore;
             phaseQualityCount++;
@@ -237,7 +237,7 @@ export async function analyzeStage17({
 
       // Count quality scores from all artifacts (not just required)
       for (const art of stageArtifacts) {
-        const qScore = art.metadata?.quality_score;
+        const qScore = art.quality_score ?? art.metadata?.quality_score;
         if (typeof qScore === 'number' && art.artifact_type !== (requiredType || '')) {
           phaseQualitySum += qScore;
           phaseQualityCount++;


### PR DESCRIPTION
## Summary
- Adds `quality_score` to the SELECT query in stage-17-blueprint-review.js
- Changes read path from `metadata?.quality_score` (always undefined) to `quality_score` column (always 70+)
- Uses `quality_score ?? metadata?.quality_score` for backward compatibility

## Root Cause
`writeArtifact()` stores quality_score in the venture_artifacts column (default 70), but S17 read from `metadata.quality_score` which was never populated. Result: overall_quality_score always 0, S17 gate always FAIL on quality.

## Test plan
- [ ] Run S17 on a venture with artifacts — quality_score should be 70 (not 0)
- [ ] S17 gate recommendation should reflect actual quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)