### PR TITLE
fix(PAT-AUTO-24215d2a): make legacy L2P verifier SD-type-aware

### DIFF
--- a/scripts/verify-l2p/constants.js
+++ b/scripts/verify-l2p/constants.js
@@ -28,6 +28,21 @@ export const SD_REQUIREMENTS = {
 };
 
 /**
+ * SD-type-aware overrides for validation thresholds.
+ * Bugfix/fix/refactor/docs SDs have lighter requirements than features.
+ * PAT-AUTO-24215d2a: Legacy verifier blocked bugfix SDs at 70% because
+ * minimumObjectives:2 is unreasonable for single-purpose fixes.
+ */
+export const SD_TYPE_OVERRIDES = {
+  bugfix:        { minimumScore: 60, minimumObjectives: 1, minimumMetrics: 1 },
+  fix:           { minimumScore: 60, minimumObjectives: 1, minimumMetrics: 1 },
+  refactor:      { minimumScore: 70, minimumObjectives: 1, minimumMetrics: 2 },
+  documentation: { minimumScore: 60, minimumObjectives: 1, minimumMetrics: 1 },
+  infrastructure:{ minimumScore: 70, minimumObjectives: 1, minimumMetrics: 2 },
+  database:      { minimumScore: 70, minimumObjectives: 1, minimumMetrics: 2 },
+};
+
+/**
  * PRD Readiness Check Configuration
  */
 export const PRD_READINESS_CHECKS = {

--- a/scripts/verify-l2p/index.js
+++ b/scripts/verify-l2p/index.js
@@ -102,9 +102,15 @@ export class LeadToPlanVerifier {
       // 3. Validate Strategic Directive Completeness
       const sdValidation = validateStrategicDirective(sd);
 
-      console.log(`\n📊 SD Completeness Score: ${sdValidation.percentage}%`);
+      // PAT-AUTO-24215d2a: Use SD-type-aware minimum score threshold
+      const sdType = (sd.sd_type || '').toLowerCase();
+      const { SD_TYPE_OVERRIDES } = await import('./constants.js');
+      const typeOverrides = SD_TYPE_OVERRIDES[sdType] || {};
+      const effectiveMinScore = typeOverrides.minimumScore ?? this.sdRequirements.minimumScore;
 
-      if (!sdValidation.valid || sdValidation.percentage < this.sdRequirements.minimumScore) {
+      console.log(`\n📊 SD Completeness Score: ${sdValidation.percentage}% (threshold: ${effectiveMinScore}%, type: ${sdType})`);
+
+      if (!sdValidation.valid || sdValidation.percentage < effectiveMinScore) {
         return rejectHandoff(this.supabase, sdId, 'SD_INCOMPLETE', 'Strategic Directive does not meet completeness standards', {
           sdValidation,
           requiredScore: this.sdRequirements.minimumScore,

--- a/scripts/verify-l2p/sd-validation.js
+++ b/scripts/verify-l2p/sd-validation.js
@@ -8,6 +8,7 @@
 
 import {
   SD_REQUIREMENTS,
+  SD_TYPE_OVERRIDES,
   RISK_KEYWORDS,
   TARGET_APP_PATTERNS,
   SMART_KEYWORDS
@@ -20,6 +21,14 @@ import { autoDetectSdType } from './type-detection.js';
  * @returns {Object} Validation result with score, errors, warnings
  */
 export function validateStrategicDirective(sd) {
+  // Resolve SD-type-aware thresholds (PAT-AUTO-24215d2a fix)
+  const sdType = (sd.sd_type || '').toLowerCase();
+  const typeOverrides = SD_TYPE_OVERRIDES[sdType] || {};
+  const effectiveReqs = {
+    minimumObjectives: typeOverrides.minimumObjectives ?? SD_REQUIREMENTS.minimumObjectives,
+    minimumMetrics: typeOverrides.minimumMetrics ?? SD_REQUIREMENTS.minimumMetrics,
+  };
+
   const validation = {
     valid: true,
     score: 0,
@@ -39,7 +48,7 @@ export function validateStrategicDirective(sd) {
   });
 
   // Validate strategic objectives (20 points)
-  validateStrategicObjectives(sd, validation);
+  validateStrategicObjectives(sd, validation, effectiveReqs);
 
   // Validate success metrics OR success_criteria (20 points)
   validateSuccessMetrics(sd, validation);
@@ -67,7 +76,8 @@ export function validateStrategicDirective(sd) {
 /**
  * Validate strategic objectives field
  */
-function validateStrategicObjectives(sd, validation) {
+function validateStrategicObjectives(sd, validation, effectiveReqs = {}) {
+  const minObjectives = effectiveReqs.minimumObjectives ?? SD_REQUIREMENTS.minimumObjectives;
   if (!sd.strategic_objectives) return;
 
   const objectivesText = sd.strategic_objectives.toString();
@@ -75,7 +85,7 @@ function validateStrategicObjectives(sd, validation) {
   if (typeof sd.strategic_objectives === 'string' && objectivesText.length >= 100) {
     validation.score += 20;
   } else if (Array.isArray(sd.strategic_objectives)) {
-    if (sd.strategic_objectives.length >= SD_REQUIREMENTS.minimumObjectives) {
+    if (sd.strategic_objectives.length >= minObjectives) {
       validation.score += 20;
 
       sd.strategic_objectives.forEach(obj => {
@@ -84,7 +94,7 @@ function validateStrategicObjectives(sd, validation) {
         }
       });
     } else {
-      validation.errors.push(`Insufficient strategic objectives: ${sd.strategic_objectives.length}/${SD_REQUIREMENTS.minimumObjectives}`);
+      validation.errors.push(`Insufficient strategic objectives: ${sd.strategic_objectives.length}/${minObjectives}`);
       validation.valid = false;
     }
   } else if (objectivesText.length < 100) {


### PR DESCRIPTION
## Summary
- Adds `SD_TYPE_OVERRIDES` map to `verify-l2p/constants.js` with per-type thresholds
- Bugfix/fix/docs: `minimumObjectives: 1`, `minimumScore: 60`
- Updates `sd-validation.js` to use effective thresholds based on SD type
- Updates `index.js` to use type-aware minimum score (logs threshold in output)

## Root Cause (PAT-AUTO-24215d2a — 6+ occurrences)
The legacy `verify-l2p/` scorer applied `minimumObjectives: 2` and `minimumScore: 90` to ALL SD types. Bugfix SDs with 1 strategic objective scored exactly 70% (30+0+20+10+10), always failing the 90% threshold. The new gate system (`sd-quality-scoring.js`) correctly passes them at 60%, but both systems run during LEAD-TO-PLAN — the legacy verifier acted as a hidden second blocker.

## Test plan
- [ ] Bugfix SD with 1 strategic objective passes LEAD-TO-PLAN (was: blocked at 70%)
- [ ] Feature SD with 2+ objectives still passes (no regression)
- [ ] Score output now shows threshold and type: `SD Completeness Score: 90% (threshold: 60%, type: bugfix)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)