### PR TITLE
feat(SD-IMPROVE-S15-WIREFRAME-HANDOFF-ORCH-001-A): enhance wireframe prompt for handoff specs

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -32,7 +32,10 @@ You MUST output valid JSON with exactly this structure:
       "persona": "Which persona this screen primarily serves",
       "ascii_layout": ["Line 1 of ASCII wireframe", "Line 2", "...(use +, -, |, [ ], text labels, min 5 lines as separate array elements)"],
       "key_components": ["Component 1", "Component 2"],
-      "interaction_notes": "How the user interacts with this screen"
+      "interaction_notes": "How the user interacts with this screen",
+      "error_state": "What the screen shows when an error occurs (e.g., failed API call, invalid input)",
+      "empty_state": "What the screen shows when there is no data yet (first-time user or no results)",
+      "responsive_notes": "How the layout adapts: mobile (stack vertically), tablet (2-col), desktop (full layout)"
     }
   ],
   "navigation_flows": [
@@ -68,7 +71,10 @@ Rules:
 - key_components should reference actual UI elements (buttons, forms, lists, charts, etc.)
 - Design choices should reflect the brand genome (colors, typography, tone)
 - Technical feasibility should align with the Stage 14 architecture (data entities, API layer)
-- Reference UX patterns from Product Hunt and Awwwards examples when provided`;
+- Reference UX patterns from Product Hunt and Awwwards examples when provided
+- HANDOFF COMPLETENESS: Every screen with user input MUST include error_state (what shows on failure)
+- HANDOFF COMPLETENESS: Data-dependent screens MUST include empty_state (first-time user experience)
+- HANDOFF COMPLETENESS: Every screen MUST include responsive_notes (mobile/tablet/desktop behavior)`;
 
 /**
  * Derive a category from brand genome archetype for service lookups.


### PR DESCRIPTION
## Summary
- Adds `error_state`, `empty_state`, `responsive_notes` to wireframe output schema
- Updates prompt rules to require handoff completeness specs on all screens
- Error states required for input screens, empty states for data-dependent screens

## Root Cause
Visual convergence handoff_completeness scored 45/100 (real Gemini evaluation, not mock). Wireframes lacked error/empty states, responsive behavior annotations, and interaction state documentation. Other domains scored 85-88.

## Test plan
- [ ] Run S15 on new venture — verify output includes error_state, empty_state, responsive_notes
- [ ] Run visual convergence — handoff_completeness should improve to 70+
- [ ] Verify Gemini generates the richer format consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)