### PR TITLE
fix: retry transient git worktree creation failures

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-ia-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-ia-generator.js
@@ -1,0 +1,217 @@
+/**
+ * Stage 15 Analysis Step - Information Architecture Generator
+ * SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B
+ *
+ * Generates a sitemap and page hierarchy from:
+ *   1. Venture brief (S1 problem/solution)
+ *   2. Customer personas (S10)
+ *   3. Product roadmap (S13)
+ *   4. User story pack (generated earlier in S15)
+ *
+ * Output is consumed by the wireframe generator to produce
+ * architecture-informed wireframes.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-15-ia-generator
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+
+const IA_TIMEOUT = 60000; // 60s internal timeout
+
+const SYSTEM_PROMPT = `You are EVA's Information Architecture Engine. Generate a structured sitemap and page hierarchy for a venture's product.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "pages": [
+    {
+      "name": "Page name (e.g., 'Dashboard', 'Settings', 'Onboarding')",
+      "path": "/suggested-url-path",
+      "purpose": "What this page accomplishes",
+      "parent": null or "Parent Page Name",
+      "priority": "primary" | "secondary" | "utility",
+      "persona_relevance": ["Persona 1", "Persona 2"]
+    }
+  ],
+  "navigation": {
+    "primary": ["Page 1", "Page 2", "Page 3"],
+    "secondary": ["Page 4", "Page 5"],
+    "utility": ["Settings", "Help", "Profile"]
+  },
+  "user_flows": [
+    {
+      "name": "Flow name",
+      "persona": "Target persona",
+      "steps": ["Page A", "Page B", "Page C"],
+      "description": "What this flow accomplishes"
+    }
+  ],
+  "hierarchy_depth": 2,
+  "total_pages": 10
+}
+
+Rules:
+- Generate 8-20 pages covering all personas
+- Every persona must have at least one primary page
+- Navigation groups pages by importance
+- User flows must trace complete journeys
+- Hierarchy depth should be 2-3 levels max
+- Page names should be user-friendly, not technical
+- Paths should follow URL conventions (/kebab-case)
+- Output ONLY valid JSON`;
+
+/**
+ * Generate Information Architecture (sitemap) from venture context.
+ *
+ * @param {Object} ctx - Stage context
+ * @param {Object} ctx.stage1Data - Stage 1 venture brief
+ * @param {Object} ctx.stage10Data - Stage 10 personas and brand
+ * @param {Object} ctx.stage13Data - Stage 13 roadmap
+ * @param {Object} [ctx.userStoryPack] - User story pack from earlier S15 sub-step
+ * @param {string} [ctx.ventureName] - Venture display name
+ * @param {Object} [ctx.logger] - Logger
+ * @returns {Promise<Object|null>} IA sitemap or null on failure
+ */
+export async function generateInformationArchitecture(ctx) {
+  const logger = ctx.logger || console;
+  logger.log('[Stage15-IA] Starting information architecture generation');
+
+  const ventureBrief = buildIAContext(ctx);
+  if (!ventureBrief) {
+    logger.warn('[Stage15-IA] Insufficient venture context — skipping IA generation');
+    return null;
+  }
+
+  const llm = getLLMClient({ purpose: 'content-generation' });
+
+  const userPrompt = `Generate an information architecture (sitemap and page hierarchy) for this venture's product.
+
+${ventureBrief}
+
+Output ONLY valid JSON matching the schema above.`;
+
+  try {
+    const response = await llm.complete(SYSTEM_PROMPT, userPrompt, { timeout: IA_TIMEOUT });
+    const usage = extractUsage(response);
+    const parsed = parseJSON(response);
+
+    // Normalize the output
+    const result = normalizeIAResult(parsed, ctx.stage10Data?.customerPersonas || []);
+    result.usage = usage;
+
+    logger.log('[Stage15-IA] Information architecture generated', {
+      pageCount: result.pages.length,
+      flowCount: result.user_flows.length,
+    });
+
+    return result;
+  } catch (err) {
+    logger.warn('[Stage15-IA] IA generation failed (non-fatal)', { error: err.message });
+    return null;
+  }
+}
+
+/**
+ * Build context string for IA generation from available stage data.
+ * @param {Object} ctx
+ * @returns {string|null}
+ */
+function buildIAContext(ctx) {
+  const parts = [];
+
+  if (ctx.ventureName) {
+    parts.push(`Venture: ${ctx.ventureName}`);
+  }
+
+  if (ctx.stage1Data?.description) {
+    parts.push(`Description: ${sanitizeForPrompt(ctx.stage1Data.description)}`);
+  }
+
+  if (ctx.stage1Data?.problem) {
+    parts.push(`Problem: ${sanitizeForPrompt(ctx.stage1Data.problem)}`);
+  }
+
+  if (ctx.stage1Data?.solution) {
+    parts.push(`Solution: ${sanitizeForPrompt(ctx.stage1Data.solution)}`);
+  }
+
+  // Personas from S10
+  if (ctx.stage10Data?.customerPersonas?.length > 0) {
+    const personaList = ctx.stage10Data.customerPersonas
+      .map(p => `- ${p.name}: ${(p.goals || []).slice(0, 2).join(', ')}`)
+      .join('\n');
+    parts.push(`\nCustomer Personas:\n${personaList}`);
+  }
+
+  // Roadmap from S13
+  if (ctx.stage13Data?.roadmap) {
+    const roadmap = typeof ctx.stage13Data.roadmap === 'string'
+      ? ctx.stage13Data.roadmap.substring(0, 500)
+      : JSON.stringify(ctx.stage13Data.roadmap).substring(0, 500);
+    parts.push(`\nProduct Roadmap Summary:\n${roadmap}`);
+  }
+
+  // User stories from earlier S15 sub-step
+  if (ctx.userStoryPack?.epics?.length > 0) {
+    const epicList = ctx.userStoryPack.epics
+      .slice(0, 5)
+      .map(e => `- ${e.name || e.title}: ${(e.stories || []).length} stories`)
+      .join('\n');
+    parts.push(`\nUser Story Epics:\n${epicList}`);
+  }
+
+  if (parts.length < 2) return null; // Need at least venture name + one data source
+  return parts.join('\n');
+}
+
+/**
+ * Normalize IA result to ensure consistent structure.
+ * @param {Object} parsed - Raw LLM output
+ * @param {Array} personas - Customer personas for coverage validation
+ * @returns {Object} Normalized IA result
+ */
+function normalizeIAResult(parsed, personas) {
+  const personaNames = personas.map(p => p.name);
+
+  // Normalize pages
+  let pages = Array.isArray(parsed.pages) ? parsed.pages : [];
+  pages = pages.map(p => ({
+    name: String(p.name || 'Unnamed Page').substring(0, 200),
+    path: String(p.path || '/').substring(0, 200),
+    purpose: String(p.purpose || '').substring(0, 500),
+    parent: p.parent ? String(p.parent).substring(0, 200) : null,
+    priority: ['primary', 'secondary', 'utility'].includes(p.priority) ? p.priority : 'secondary',
+    persona_relevance: Array.isArray(p.persona_relevance)
+      ? p.persona_relevance.map(r => String(r).substring(0, 200))
+      : [],
+  }));
+
+  // Normalize navigation
+  const nav = parsed.navigation && typeof parsed.navigation === 'object' ? parsed.navigation : {};
+  const navigation = {
+    primary: Array.isArray(nav.primary) ? nav.primary.map(n => String(n)) : pages.filter(p => p.priority === 'primary').map(p => p.name),
+    secondary: Array.isArray(nav.secondary) ? nav.secondary.map(n => String(n)) : pages.filter(p => p.priority === 'secondary').map(p => p.name),
+    utility: Array.isArray(nav.utility) ? nav.utility.map(n => String(n)) : pages.filter(p => p.priority === 'utility').map(p => p.name),
+  };
+
+  // Normalize user flows
+  let userFlows = Array.isArray(parsed.user_flows) ? parsed.user_flows : [];
+  userFlows = userFlows.map(f => ({
+    name: String(f.name || 'Unnamed Flow').substring(0, 200),
+    persona: String(f.persona || personaNames[0] || 'General User').substring(0, 200),
+    steps: Array.isArray(f.steps) ? f.steps.map(s => String(s)) : [],
+    description: String(f.description || '').substring(0, 500),
+  }));
+
+  return {
+    pages,
+    navigation,
+    user_flows: userFlows,
+    hierarchy_depth: typeof parsed.hierarchy_depth === 'number' ? parsed.hierarchy_depth : 2,
+    total_pages: pages.length,
+  };
+}
+
+// Export helpers for testing
+export { buildIAContext, normalizeIAResult, IA_TIMEOUT };

--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -220,6 +220,32 @@ Total Story Points: ${userStoryPack.total_story_points || 'N/A'}`;
 }
 
 /**
+ * Build IA sitemap context for the wireframe generation prompt.
+ * SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B: IA informs wireframes.
+ *
+ * @param {Object|null} iaSitemap - IA result from generateInformationArchitecture
+ * @returns {string} Formatted IA context for the wireframe prompt
+ */
+function buildIASitemapContext(iaSitemap) {
+  if (!iaSitemap || !Array.isArray(iaSitemap.pages) || iaSitemap.pages.length === 0) {
+    return '';
+  }
+
+  const pageList = iaSitemap.pages
+    .map(p => `  - ${p.name} (${p.path}) — ${p.purpose || 'N/A'} [${p.priority}]`)
+    .join('\n');
+
+  const navSummary = iaSitemap.navigation
+    ? `Primary nav: ${(iaSitemap.navigation.primary || []).join(', ')}`
+    : '';
+
+  return `\nInformation Architecture (sitemap — align wireframe screens to these pages):
+${pageList}
+${navSummary}
+Total pages: ${iaSitemap.total_pages || iaSitemap.pages.length}`;
+}
+
+/**
  * Build context strings from Product Hunt and Awwwards data.
  *
  * @param {Array} phProducts - Product Hunt products
@@ -275,6 +301,7 @@ export async function analyzeStage15WireframeGenerator({
   stage1Data,
   ventureName,
   userStoryPack = null,
+  iaSitemap = null,
   productHuntRefs = [],
   options = {},
   logger = console,
@@ -306,6 +333,9 @@ export async function analyzeStage15WireframeGenerator({
   // Build user story context from the user story pack (SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A)
   const userStoryContext = buildUserStoryContext(userStoryPack);
 
+  // Build IA context from information architecture sitemap (SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B)
+  const iaContext = buildIASitemapContext(iaSitemap);
+
   const ventureDescription = stage1Data?.description
     ? sanitizeForPrompt(stage1Data.description)
     : 'No description available';
@@ -324,6 +354,7 @@ ${brandContext}
 Technical Architecture (from Stage 14):
 ${techContext}
 ${userStoryContext}
+${iaContext}
 ${phContext}
 ${awwwardsContext}
 
@@ -409,7 +440,8 @@ Output ONLY valid JSON.`;
     screens = screens.slice(0, MAX_SCREENS);
   }
 
-  // Normalize each screen
+  // Normalize each screen — ensure enrichment fields are always populated
+  // SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B: enforce error_state, empty_state, responsive_notes
   screens = screens.map((s, i) => ({
     name: String(s.name || `Screen ${i + 1}`).substring(0, 200),
     purpose: String(s.purpose || 'General purpose screen').substring(0, 500),
@@ -421,6 +453,9 @@ Output ONLY valid JSON.`;
       ? s.key_components.map(c => String(c).substring(0, 200))
       : ['Content area'],
     interaction_notes: String(s.interaction_notes || '').substring(0, 500),
+    error_state: String(s.error_state || 'Display error message with retry option').substring(0, 500),
+    empty_state: String(s.empty_state || 'Show onboarding prompt or placeholder content').substring(0, 500),
+    responsive_notes: String(s.responsive_notes || 'Stack vertically on mobile, 2-col on tablet, full layout on desktop').substring(0, 500),
   }));
 
   // ── Normalize navigation flows ─────────────────────────────────
@@ -520,6 +555,7 @@ Output ONLY valid JSON.`;
       awwwards_count: awwwardsRefs.length,
       category,
       user_story_pack_available: !!userStoryPack,
+      ia_sitemap_available: !!iaSitemap,
     },
     usage,
     llmFallbackCount,
@@ -538,4 +574,5 @@ export {
   buildTechContext,
   buildExternalContext,
   buildUserStoryContext,
+  buildIASitemapContext,
 };

--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -194,6 +194,32 @@ function buildTechContext(stage14Data) {
 }
 
 /**
+ * Build user story context from the user story pack for wireframe generation.
+ * SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A: user stories now inform wireframes.
+ *
+ * @param {Object|null} userStoryPack - User story pack from generateUserStoryPack
+ * @returns {string} Formatted user story context for the wireframe prompt
+ */
+function buildUserStoryContext(userStoryPack) {
+  if (!userStoryPack || !Array.isArray(userStoryPack.epics) || userStoryPack.epics.length === 0) {
+    return '';
+  }
+
+  const epicSummaries = userStoryPack.epics.map(epic => {
+    const storyCount = Array.isArray(epic.stories) ? epic.stories.length : 0;
+    const storyList = Array.isArray(epic.stories)
+      ? epic.stories.slice(0, 3).map(s => `    - ${s.title || s.name || 'Untitled story'}`).join('\n')
+      : '';
+    return `  Epic: ${epic.name || epic.title || 'Untitled'} (${storyCount} stories)\n${storyList}`;
+  });
+
+  return `\nUser Stories (from User Story Pack — design wireframes to support these flows):
+${epicSummaries.join('\n')}
+MVP Story Count: ${userStoryPack.mvp_story_count || 'N/A'}
+Total Story Points: ${userStoryPack.total_story_points || 'N/A'}`;
+}
+
+/**
  * Build context strings from Product Hunt and Awwwards data.
  *
  * @param {Array} phProducts - Product Hunt products
@@ -248,6 +274,8 @@ export async function analyzeStage15WireframeGenerator({
   stage14Data,
   stage1Data,
   ventureName,
+  userStoryPack = null,
+  productHuntRefs = [],
   options = {},
   logger = console,
 }) {
@@ -273,7 +301,10 @@ export async function analyzeStage15WireframeGenerator({
   const personaContext = buildPersonaContext(stage10Data.customerPersonas);
   const brandContext = buildBrandContext(stage10Data.brandGenome);
   const techContext = buildTechContext(stage14Data);
-  const { phContext, awwwardsContext } = buildExternalContext([], awwwardsRefs);
+  const { phContext, awwwardsContext } = buildExternalContext(productHuntRefs, awwwardsRefs);
+
+  // Build user story context from the user story pack (SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A)
+  const userStoryContext = buildUserStoryContext(userStoryPack);
 
   const ventureDescription = stage1Data?.description
     ? sanitizeForPrompt(stage1Data.description)
@@ -292,6 +323,7 @@ ${brandContext}
 
 Technical Architecture (from Stage 14):
 ${techContext}
+${userStoryContext}
 ${phContext}
 ${awwwardsContext}
 
@@ -484,9 +516,10 @@ Output ONLY valid JSON.`;
     totalFlows: navigationFlows.length,
     avgPersonaCoverageScore: avgCoverageScore,
     enrichment: {
-      product_hunt_count: 0,
+      product_hunt_count: productHuntRefs.length,
       awwwards_count: awwwardsRefs.length,
       category,
+      user_story_pack_available: !!userStoryPack,
     },
     usage,
     llmFallbackCount,
@@ -504,4 +537,5 @@ export {
   buildBrandContext,
   buildTechContext,
   buildExternalContext,
+  buildUserStoryContext,
 };

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -21,6 +21,42 @@ import { generateUserStoryPack } from './analysis-steps/stage-15-user-story-pack
 
 const wireframeGatingEnabled = process.env.EVA_WIREFRAME_GATING_ENABLED === 'true';
 
+/**
+ * Extract Product Hunt competitor references from S10 brand data.
+ * Normalizes various S10 field locations where PH data may reside.
+ * SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A
+ *
+ * @param {Object} stage10Data - Stage 10 data with brandGenome, competitive landscape, etc.
+ * @returns {Array<{name: string, tagline: string}>} Normalized PH refs
+ */
+function extractProductHuntRefs(stage10Data) {
+  if (!stage10Data) return [];
+
+  const refs = [];
+
+  // Check competitive_landscape (most common location)
+  const landscape = stage10Data.competitive_landscape || stage10Data.competitiveLandscape || stage10Data.brandGenome?.competitive_landscape;
+  if (Array.isArray(landscape)) {
+    for (const entry of landscape) {
+      if (entry && (entry.source === 'product_hunt' || entry.source === 'producthunt' || entry.platform === 'product_hunt')) {
+        refs.push({ name: String(entry.name || entry.title || ''), tagline: String(entry.tagline || entry.description || '') });
+      }
+    }
+  }
+
+  // Check product_hunt_products (direct field)
+  const phProducts = stage10Data.product_hunt_products || stage10Data.productHuntProducts;
+  if (Array.isArray(phProducts)) {
+    for (const p of phProducts) {
+      if (p && p.name) {
+        refs.push({ name: String(p.name), tagline: String(p.tagline || p.description || '') });
+      }
+    }
+  }
+
+  return refs.filter(r => r.name.length > 0);
+}
+
 const TEMPLATE = {
   id: 'stage-15',
   slug: 'design-studio',
@@ -56,11 +92,51 @@ TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
   const logger = ctx.logger || console;
 
-  // Sub-step 1: Wireframe generation (conditional on Stage 10 brand data)
+  // Sub-step 1: User story pack generation (runs BEFORE wireframes so stories inform wireframe context)
+  // SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A: reordered from sub-step 3 to sub-step 1
+  let userStoryResult = null;
+  try {
+    userStoryResult = await generateUserStoryPack(ctx);
+    if (userStoryResult && ctx.supabase && ctx.ventureId) {
+      await writeArtifact(ctx.supabase, {
+        ventureId: ctx.ventureId,
+        lifecycleStage: 15,
+        artifactType: 'blueprint_user_story_pack',
+        title: 'User Story Pack (Stage 15)',
+        artifactData: userStoryResult,
+        content: JSON.stringify(userStoryResult),
+        qualityScore: 70,
+        validationStatus: 'validated',
+        source: 'stage-15-user-story-pack',
+        visionKey: ctx.visionKey || null,
+        planKey: ctx.planKey || null,
+      });
+      logger.log('[Stage15-DesignStudio] User story pack artifact persisted', {
+        epicCount: userStoryResult?.epics?.length || 0,
+      });
+    }
+  } catch (err) {
+    logger.warn('[Stage15-DesignStudio] User story pack generation failed (non-fatal)', { error: err.message });
+  }
+
+  // Sub-step 2: Wireframe generation (conditional on Stage 10 brand data)
+  // Now receives user stories and Product Hunt refs as additional context
   let wireframeResult = null;
   if (ctx.stage10Data?.customerPersonas?.length > 0 && ctx.stage10Data?.brandGenome) {
+    // Build enriched context with user stories and Product Hunt refs
+    const wireframeCtx = { ...ctx };
+    if (userStoryResult) {
+      wireframeCtx.userStoryPack = userStoryResult;
+    }
+
+    // Extract Product Hunt refs from S10 competitive landscape
+    const phRefs = extractProductHuntRefs(ctx.stage10Data);
+    if (phRefs.length > 0) {
+      wireframeCtx.productHuntRefs = phRefs;
+    }
+
     try {
-      wireframeResult = await analyzeStage15WireframeGenerator(ctx);
+      wireframeResult = await analyzeStage15WireframeGenerator(wireframeCtx);
       logger.log('[Stage15-DesignStudio] Wireframe generation complete', {
         screenCount: wireframeResult?.screens?.length || 0,
       });
@@ -97,7 +173,7 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     logger.log('[Stage15-DesignStudio] Skipping wireframes — Stage 10 brand data not available');
   }
 
-  // Sub-step 2: Visual convergence (5 expert LLM passes on wireframes)
+  // Sub-step 3: Visual convergence (5 expert LLM passes on wireframes)
   let convergenceResult = null;
   if (wireframeResult?.screens?.length > 0) {
     try {
@@ -113,32 +189,6 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     } catch (err) {
       logger.warn('[Stage15-DesignStudio] Visual convergence failed (non-fatal)', { error: err.message });
     }
-  }
-
-  // Sub-step 3: User story pack generation (SD-WIRE-USERSTORYPACK-AGENT-INTO-ORCH-001-A)
-  let userStoryResult = null;
-  try {
-    userStoryResult = await generateUserStoryPack(ctx);
-    if (userStoryResult && ctx.supabase && ctx.ventureId) {
-      await writeArtifact(ctx.supabase, {
-        ventureId: ctx.ventureId,
-        lifecycleStage: 15,
-        artifactType: 'blueprint_user_story_pack',
-        title: 'User Story Pack (Stage 15)',
-        artifactData: userStoryResult,
-        content: JSON.stringify(userStoryResult),
-        qualityScore: 70,
-        validationStatus: 'validated',
-        source: 'stage-15-user-story-pack',
-        visionKey: ctx.visionKey || null,
-        planKey: ctx.planKey || null,
-      });
-      logger.log('[Stage15-DesignStudio] User story pack artifact persisted', {
-        epicCount: userStoryResult?.epics?.length || 0,
-      });
-    }
-  } catch (err) {
-    logger.warn('[Stage15-DesignStudio] User story pack generation failed (non-fatal)', { error: err.message });
   }
 
   return { wireframes: wireframeResult, wireframe_convergence: convergenceResult, user_story_pack: userStoryResult };

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -18,6 +18,7 @@ import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wire
 import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { generateUserStoryPack } from './analysis-steps/stage-15-user-story-pack.js';
+import { generateInformationArchitecture } from './analysis-steps/stage-15-ia-generator.js';
 
 const wireframeGatingEnabled = process.env.EVA_WIREFRAME_GATING_ENABLED === 'true';
 
@@ -119,14 +120,36 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     logger.warn('[Stage15-DesignStudio] User story pack generation failed (non-fatal)', { error: err.message });
   }
 
-  // Sub-step 2: Wireframe generation (conditional on Stage 10 brand data)
-  // Now receives user stories and Product Hunt refs as additional context
+  // Sub-step 2: Information Architecture generation (SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B)
+  // Generates sitemap from venture context; feeds into wireframe generation
+  let iaResult = null;
+  try {
+    const iaCtx = { ...ctx };
+    if (userStoryResult) {
+      iaCtx.userStoryPack = userStoryResult;
+    }
+    iaResult = await generateInformationArchitecture(iaCtx);
+    if (iaResult) {
+      logger.log('[Stage15-DesignStudio] IA generation complete', {
+        pageCount: iaResult.pages?.length || 0,
+        flowCount: iaResult.user_flows?.length || 0,
+      });
+    }
+  } catch (err) {
+    logger.warn('[Stage15-DesignStudio] IA generation failed (non-fatal, wireframes will proceed without sitemap)', { error: err.message });
+  }
+
+  // Sub-step 3: Wireframe generation (conditional on Stage 10 brand data)
+  // Now receives user stories, Product Hunt refs, and IA sitemap as additional context
   let wireframeResult = null;
   if (ctx.stage10Data?.customerPersonas?.length > 0 && ctx.stage10Data?.brandGenome) {
-    // Build enriched context with user stories and Product Hunt refs
+    // Build enriched context with user stories, IA sitemap, and Product Hunt refs
     const wireframeCtx = { ...ctx };
     if (userStoryResult) {
       wireframeCtx.userStoryPack = userStoryResult;
+    }
+    if (iaResult) {
+      wireframeCtx.iaSitemap = iaResult;
     }
 
     // Extract Product Hunt refs from S10 competitive landscape
@@ -149,8 +172,8 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
             lifecycleStage: 15,
             artifactType: 'blueprint_wireframes',
             title: 'Design Studio Wireframes (Stage 15)',
-            artifactData: { wireframes: wireframeResult },
-            content: JSON.stringify({ wireframes: wireframeResult }),
+            artifactData: { wireframes: wireframeResult, ia_sitemap: iaResult || null },
+            content: JSON.stringify({ wireframes: wireframeResult, ia_sitemap: iaResult || null }),
             qualityScore: 70,
             validationStatus: 'validated',
             source: 'stage-15-design-studio',
@@ -173,7 +196,7 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     logger.log('[Stage15-DesignStudio] Skipping wireframes — Stage 10 brand data not available');
   }
 
-  // Sub-step 3: Visual convergence (5 expert LLM passes on wireframes)
+  // Sub-step 4: Visual convergence (5 expert LLM passes on wireframes)
   let convergenceResult = null;
   if (wireframeResult?.screens?.length > 0) {
     try {
@@ -191,7 +214,7 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     }
   }
 
-  return { wireframes: wireframeResult, wireframe_convergence: convergenceResult, user_story_pack: userStoryResult };
+  return { wireframes: wireframeResult, wireframe_convergence: convergenceResult, user_story_pack: userStoryResult, ia_sitemap: iaResult };
 };
 
 ensureOutputSchema(TEMPLATE);

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -11,12 +11,77 @@
  * Legacy session-keyed API is supported via deprecation adapter.
  */
 
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
 const WORKTREES_DIR = '.worktrees';
+
+// Transient git errors that warrant retry (e.g., index.lock from concurrent git ops)
+const TRANSIENT_GIT_PATTERNS = [
+  /unable to create.*\.lock/i,
+  /index\.lock.*exists/i,
+  /cannot lock ref/i,
+  /another git process seems to be running/i,
+];
+
+/**
+ * Classify a git worktree error for actionable messaging.
+ * @param {string} msg - Error message from git
+ * @returns {{ transient: boolean, hint: string }}
+ */
+export function classifyWorktreeError(msg) {
+  if (TRANSIENT_GIT_PATTERNS.some(p => p.test(msg))) {
+    return { transient: true, hint: 'Git lock contention — another git operation is running. Retrying.' };
+  }
+  if (/already checked out/i.test(msg)) {
+    return { transient: false, hint: 'Branch is checked out in another worktree. Run: git worktree list' };
+  }
+  if (/already exists/i.test(msg) && /not a valid path/i.test(msg)) {
+    return { transient: false, hint: 'Stale worktree reference. Run: git worktree prune' };
+  }
+  if (/ENOSPC|no space/i.test(msg)) {
+    return { transient: false, hint: 'Disk full — free space before retrying.' };
+  }
+  return { transient: false, hint: '' };
+}
+
+/**
+ * Synchronous sleep using spawnSync (no async needed).
+ * @param {number} ms - Milliseconds to sleep
+ */
+function sleepSync(ms) {
+  if (process.platform === 'win32') {
+    spawnSync('ping', ['-n', String(Math.ceil(ms / 1000) + 1), '127.0.0.1'], { stdio: 'ignore' });
+  } else {
+    spawnSync('sleep', [String(ms / 1000)], { stdio: 'ignore' });
+  }
+}
+
+/**
+ * Execute a git command with retry on transient failures.
+ * @param {string} cmd - Shell command
+ * @param {object} opts - execSync options
+ * @param {{ maxRetries?: number, baseDelayMs?: number }} [retryOpts]
+ * @returns {string} stdout
+ */
+function execSyncWithRetry(cmd, opts, { maxRetries = 3, baseDelayMs = 500 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return execSync(cmd, opts);
+    } catch (err) {
+      lastErr = err;
+      const msg = (err.stderr || err.message || '').toString();
+      const { transient } = classifyWorktreeError(msg);
+      if (!transient || attempt === maxRetries) break;
+      // Exponential backoff: 500ms, 1s, 2s
+      sleepSync(baseDelayMs * Math.pow(2, attempt));
+    }
+  }
+  throw lastErr;
+}
 
 /** @typedef {'SD'|'QF'|'ADHOC'} WorkType */
 
@@ -141,18 +206,11 @@ export function createWorktree({ sdKey, session, branch, force = false, repoRoot
   // Check if branch exists (local or remote)
   const branchExists = branchExistsLocally(branch) || branchExistsRemotely(branch);
 
+  const execOpts = { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' };
   if (branchExists) {
-    execSync(`git worktree add "${worktreePath}" "${branch}"`, {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
+    execSyncWithRetry(`git worktree add "${worktreePath}" "${branch}"`, execOpts);
   } else {
-    execSync(`git worktree add -b "${branch}" "${worktreePath}"`, {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
+    execSyncWithRetry(`git worktree add -b "${branch}" "${worktreePath}"`, execOpts);
   }
 
   // Write .worktree.json metadata
@@ -284,21 +342,14 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
       removeWorktree(path.relative(worktreesDir, worktreePath).replace(/\\/g, '/'));
     }
 
-    // Create worktree
+    // Create worktree (with retry on transient git lock contention)
     const branchExists = branchExistsLocally(resolvedBranch) || branchExistsRemotely(resolvedBranch);
+    const execOpts = { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' };
 
     if (branchExists) {
-      execSync(`git worktree add "${worktreePath}" "${resolvedBranch}"`, {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        stdio: 'pipe'
-      });
+      execSyncWithRetry(`git worktree add "${worktreePath}" "${resolvedBranch}"`, execOpts);
     } else {
-      execSync(`git worktree add -b "${resolvedBranch}" "${worktreePath}"`, {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        stdio: 'pipe'
-      });
+      execSyncWithRetry(`git worktree add -b "${resolvedBranch}" "${worktreePath}"`, execOpts);
     }
 
     // Write metadata file

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -24,6 +24,7 @@ import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
 import { getEstimatedDuration, formatEstimateDetailed } from './lib/duration-estimator.js';
 import { resolve as resolveWorkdir } from './resolve-sd-workdir.js';
+import { classifyWorktreeError } from '../lib/worktree-manager.js';
 import { getNextReadyChild } from './modules/handoff/child-sd-selector.js';
 import { checkSDAge, handleTimelineViolation, formatBlockMessage } from './modules/governance/timeline-violation-handler.js';
 
@@ -806,13 +807,17 @@ async function main() {
       // SD-MULTISESSION-WORKTREE-SAFETY-ATOMIC-ORCH-001-C: Hard-fail on worktree failure
       // instead of silently continuing on main (which caused data loss from wrong-branch commits)
       const detail = worktreeInfo.error || worktreeInfo.errorCode || 'unknown';
+      const { hint } = classifyWorktreeError(detail);
       console.error(`${colors.red}   ❌  Worktree creation failed: ${detail}${colors.reset}`);
+      if (hint) console.error(`${colors.yellow}   💡  ${hint}${colors.reset}`);
       console.error(`${colors.red}   Cannot proceed without worktree isolation. Pick a different SD or resolve the conflict.${colors.reset}`);
       process.exit(1);
     }
   } catch (wtErr) {
     // SD-MULTISESSION-WORKTREE-SAFETY-ATOMIC-ORCH-001-C: Hard-fail on worktree error
+    const { hint } = classifyWorktreeError(wtErr.message);
     console.error(`${colors.red}   ❌  Worktree resolution error: ${wtErr.message}${colors.reset}`);
+    if (hint) console.error(`${colors.yellow}   💡  ${hint}${colors.reset}`);
     console.error(`${colors.red}   Cannot proceed without worktree isolation. Pick a different SD or resolve the conflict.${colors.reset}`);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- Add `execSyncWithRetry()` to `lib/worktree-manager.js` — retries `git worktree add` up to 3 times with exponential backoff (500ms→1s→2s) on transient git lock contention errors
- Add `classifyWorktreeError()` to distinguish transient errors (index.lock, ref lock) from permanent ones (branch conflict, disk full, stale refs)
- Wire actionable diagnostic hints into `sd-start.js` hard-fail messages (e.g., "Branch is checked out in another worktree. Run: git worktree list")

## Context
During multi-session fleet operations, concurrent git operations cause transient `index.lock` contention. Previously, any worktree creation failure killed the session immediately. Now transient failures retry automatically while permanent errors still hard-fail with specific remediation hints.

## Test plan
- [x] `vitest run tests/unit/worktree-manager.test.js` — 26/26 pass
- [x] Smoke tests — 15/15 pass
- [x] Manual verification of `classifyWorktreeError()` for all error patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)