### PR TITLE
fix: guard CI workflows against missing secrets and deprecated flags

### DIFF
--- a/.github/workflows/backlog-integrity-staging-readonly.yml
+++ b/.github/workflows/backlog-integrity-staging-readonly.yml
@@ -39,10 +39,15 @@ jobs:
           DATABASE_URL: ${{ secrets.SUPABASE_POOLER_URL }}
         run: |
           set -e
-          
+
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::warning::SUPABASE_POOLER_URL secret not configured. Skipping staging integrity checks."
+            exit 0
+          fi
+
           echo "🔍 Running backlog integrity checks against staging..."
           mkdir -p reports
-          
+
           # Execute the staging SQL file
           psql "$DATABASE_URL" -f ops/checks/backlog_integrity_staging.sql
           
@@ -56,6 +61,10 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.SUPABASE_POOLER_URL }}
         run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::warning::SUPABASE_POOLER_URL secret not configured. Skipping."
+            exit 0
+          fi
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f ops/checks/backlog_sequence_staging.sql
           # Move sequencing CSV to reports/
           mv sequence_candidates.csv reports/ 2>/dev/null || true

--- a/.github/workflows/sign-artifacts.yml
+++ b/.github/workflows/sign-artifacts.yml
@@ -163,8 +163,6 @@ jobs:
 
       - name: Sign artifact with Sigstore
         id: sign
-        env:
-          COSIGN_EXPERIMENTAL: 1
         run: |
           echo "🔏 Signing artifact with Sigstore keyless..."
 

--- a/.github/workflows/vh-ideation-staging-readonly.yml
+++ b/.github/workflows/vh-ideation-staging-readonly.yml
@@ -39,7 +39,12 @@ jobs:
       - name: Export ideation reports (read-only)
         env:
           PGPASSWORD: ${{ secrets.PGPASSWORD_STAGING }}
-        run: psql -v ON_ERROR_STOP=1 -f ops/checks/vh_ideation_integrity_staging.sql
+        run: |
+          if [ -z "${{ secrets.PGHOST_STAGING }}" ]; then
+            echo "::warning::PGHOST_STAGING secret not configured. Skipping ideation staging checks."
+            exit 0
+          fi
+          psql -v ON_ERROR_STOP=1 -f ops/checks/vh_ideation_integrity_staging.sql
 
       - name: Summarize counts
         run: |

--- a/.github/workflows/youtube-subscription-digest.yml
+++ b/.github/workflows/youtube-subscription-digest.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - run: npm ci --omit=dev
+      - run: npm ci --omit=dev --ignore-scripts
 
       - name: Run YouTube Subscription Digest
         env:


### PR DESCRIPTION
## Summary
- **youtube-subscription-digest**: Add `--ignore-scripts` to `npm ci --omit=dev` to prevent `husky: not found` error (husky is a devDep)
- **backlog-integrity**: Guard `psql` steps against empty `SUPABASE_POOLER_URL` secret — emit warning instead of crashing
- **vh-ideation**: Guard `psql` step against empty `PGHOST_STAGING` secret
- **sign-artifacts**: Remove deprecated `COSIGN_EXPERIMENTAL=1` env var (not needed in cosign v2+)

## Test plan
- [ ] Verify youtube-subscription-digest workflow runs without husky error
- [ ] Verify backlog-integrity workflow skips gracefully when pooler URL is missing
- [ ] Verify vh-ideation workflow skips gracefully when PG secrets are missing
- [ ] Verify sign-artifacts workflow succeeds without COSIGN_EXPERIMENTAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)