### PR TITLE
fix(SD-FIX-WORKER-STARTUP-LOCK-RECOVERY-001): add startup recovery to reset orphaned processing locks

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -170,7 +170,7 @@ export class StageExecutionWorker {
    * Start the polling loop.
    * Idempotent: calling start() when already running is a no-op.
    */
-  start() {
+  async start() {
     if (this._running) {
       this._logger.warn('[Worker] Already running');
       return;
@@ -179,6 +179,9 @@ export class StageExecutionWorker {
     this._running = true;
     this._startedAt = new Date();
     this._logger.log(`[Worker] Started (poll every ${this._pollIntervalMs}ms, dryRun=${this._dryRun}, id=${this._workerId})`);
+
+    // SD-FIX-WORKER-STARTUP-LOCK-RECOVERY-001: Reset orphaned locks from previous worker instances
+    await this._onStartupRecovery();
 
     // Register heartbeat
     this._upsertHeartbeat('online').catch(err =>
@@ -1636,6 +1639,60 @@ export class StageExecutionWorker {
       }
     } catch (err) {
       this._logger.error(`[Worker] Stale lock sweep error: ${err.message}`);
+    }
+  }
+
+  /**
+   * SD-FIX-WORKER-STARTUP-LOCK-RECOVERY-001: Reset ventures stuck in processing
+   * state from previous worker instances. Called once at startup before the first
+   * poll tick. Only resets ventures whose lock_id does not match this worker.
+   */
+  async _onStartupRecovery() {
+    try {
+      const { data: orphaned, error } = await this._supabase
+        .from('ventures')
+        .select('id, name, orchestrator_lock_id')
+        .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING)
+        .neq('orchestrator_lock_id', this._workerId);
+
+      if (error) {
+        this._logger.warn(`[Worker] Startup recovery query failed: ${error.message}`);
+        return;
+      }
+
+      if (!orphaned || orphaned.length === 0) return;
+
+      for (const venture of orphaned) {
+        this._logger.warn(
+          `[Worker] Startup recovery: resetting ${venture.name || venture.id} ` +
+          `(stale lock_id=${venture.orchestrator_lock_id})`
+        );
+
+        const { error: resetError } = await this._supabase
+          .from('ventures')
+          .update({
+            orchestrator_state: ORCHESTRATOR_STATES.IDLE,
+            orchestrator_lock_id: null,
+            orchestrator_lock_acquired_at: null,
+          })
+          .eq('id', venture.id)
+          .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING);
+
+        if (resetError) {
+          this._logger.error(`[Worker] Startup recovery reset failed for ${venture.id}: ${resetError.message}`);
+        } else {
+          await emit(this._supabase, 'startup_recovery_lock_released', {
+            ventureId: venture.id,
+            ventureName: venture.name,
+            staleLockId: venture.orchestrator_lock_id,
+            releasedBy: this._workerId,
+          }, 'stage-execution-worker').catch(() => {});
+        }
+      }
+
+      this._logger.log(`[Worker] Startup recovery complete: ${orphaned.length} venture(s) reset`);
+    } catch (err) {
+      this._logger.error(`[Worker] Startup recovery error: ${err.message}`);
     }
   }
 

--- a/tests/unit/eva/stage-execution-worker.test.js
+++ b/tests/unit/eva/stage-execution-worker.test.js
@@ -522,4 +522,89 @@ describe('StageExecutionWorker', () => {
       expect(result).toEqual(mockData);
     });
   });
+
+  // ── Startup Recovery (SD-FIX-WORKER-STARTUP-LOCK-RECOVERY-001) ──
+
+  describe('_onStartupRecovery', () => {
+    beforeEach(() => {
+      worker = new StageExecutionWorker({ supabase, logger });
+    });
+
+    it('resets ventures with foreign lock_id on startup', async () => {
+      const orphaned = [
+        { id: 'v1', name: 'Venture A', orchestrator_lock_id: 'old-worker-1' },
+      ];
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        then: vi.fn(),
+      };
+      // First from('ventures') call: select query returns orphaned
+      // Second from('ventures') call: update succeeds
+      let callCount = 0;
+      supabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // SELECT query chain
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                neq: vi.fn().mockResolvedValue({ data: orphaned, error: null }),
+              }),
+            }),
+          };
+        }
+        // UPDATE chain
+        return {
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        };
+      });
+
+      await worker._onStartupRecovery();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Startup recovery: resetting Venture A'),
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Startup recovery complete: 1 venture(s) reset'),
+      );
+    });
+
+    it('does nothing when no orphaned ventures exist', async () => {
+      supabase.from.mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            neq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }));
+
+      await worker._onStartupRecovery();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('continues worker startup on query error', async () => {
+      supabase.from.mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            neq: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } }),
+          }),
+        }),
+      }));
+
+      await worker._onStartupRecovery();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Startup recovery query failed: DB down'),
+      );
+      // Worker should not throw — start() continues
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `_onStartupRecovery()` to `StageExecutionWorker.start()` that immediately resets ventures stuck in processing state from previous worker instances
- Eliminates 5-minute blind window after worker restart by querying for foreign lock_ids and resetting them to idle
- Includes 3 unit tests covering: foreign lock reset, no-orphans case, DB error handling

## Changes
- `lib/eva/stage-execution-worker.js`: Made `start()` async, added `_onStartupRecovery()` method (~55 LOC)
- `tests/unit/eva/stage-execution-worker.test.js`: 3 new tests for startup recovery

## Test plan
- [x] 3 new unit tests pass (startup recovery query, reset, error handling)
- [x] 18/21 existing tests pass (3 pre-existing failures unrelated to this change)
- [ ] Manual verification: restart worker with stuck ventures, verify immediate reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)