### PR TITLE
feat(SD-MAN-INFRA-FLEET-NPM-INSTALL-001): fleet npm install mutex

### DIFF
--- a/lib/npm-install-lock.cjs
+++ b/lib/npm-install-lock.cjs
@@ -1,0 +1,141 @@
+/**
+ * NPM Install Mutex — Coordination-based dependency lock
+ *
+ * Prevents node_modules corruption when parallel CC sessions run npm install
+ * simultaneously. Uses the session_coordination table as a distributed lock.
+ *
+ * Usage:
+ *   const { acquireLock, waitForLock, releaseLock } = require('./npm-install-lock');
+ *   const lock = await acquireLock(supabase, sessionId);
+ *   if (lock.held) {
+ *     console.log(`Waiting — session ${lock.holder} is installing...`);
+ *     await waitForLock(supabase, { timeout: 120000 });
+ *   } else if (lock.acquired) {
+ *     try { await runNpmInstall(); }
+ *     finally { await releaseLock(supabase, sessionId); }
+ *   }
+ *
+ * SD: SD-MAN-INFRA-FLEET-NPM-INSTALL-001
+ */
+
+const LOCK_TYPE = 'NODE_MODULES';
+const LOCK_TTL_MS = 120_000; // 2 minutes
+const POLL_INTERVAL_MS = 5_000; // 5 seconds
+
+/**
+ * Find the active NODE_MODULES lock in session_coordination.
+ * @returns {Promise<object|null>} The active lock row, or null.
+ */
+async function findActiveLock(supabase) {
+  const { data: existing } = await supabase
+    .from('session_coordination')
+    .select('id, payload, created_at')
+    .eq('message_type', 'INFO')
+    .is('read_at', null)
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  return (existing || []).find(
+    m => m.payload?.lock_type === LOCK_TYPE && m.payload?.status === 'locked'
+  ) || null;
+}
+
+/**
+ * Try to acquire the NODE_MODULES lock.
+ * @returns {Promise<{acquired: boolean}|{held: boolean, holder: string, age_ms: number}>}
+ */
+async function acquireLock(supabase, sessionId) {
+  const activeLock = await findActiveLock(supabase);
+
+  if (activeLock) {
+    const age = Date.now() - new Date(activeLock.created_at).getTime();
+    if (age < LOCK_TTL_MS) {
+      return { held: true, holder: activeLock.payload.holder_session, age_ms: age };
+    }
+    // Stale lock — auto-expire it
+    await supabase
+      .from('session_coordination')
+      .update({ read_at: new Date().toISOString() })
+      .eq('id', activeLock.id);
+  }
+
+  // Claim the lock
+  const { error } = await supabase.from('session_coordination').insert({
+    message_type: 'INFO',
+    target_session: 'broadcast',
+    subject: 'NODE_MODULES_LOCK',
+    body: `Session ${sessionId.slice(0, 8)} is running npm install`,
+    payload: {
+      lock_type: LOCK_TYPE,
+      status: 'locked',
+      holder_session: sessionId,
+      locked_at: new Date().toISOString()
+    },
+    sender_type: 'system'
+  });
+
+  if (error) {
+    return { acquired: false, error: error.message };
+  }
+  return { acquired: true };
+}
+
+/**
+ * Wait until the NODE_MODULES lock is released or expires.
+ * @param {object} options - { timeout, pollInterval, onPoll }
+ * @returns {Promise<{resolved: boolean, reason: string}>}
+ */
+async function waitForLock(supabase, options = {}) {
+  const timeout = options.timeout || LOCK_TTL_MS;
+  const pollInterval = options.pollInterval || POLL_INTERVAL_MS;
+  const onPoll = options.onPoll || (() => {});
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    const activeLock = await findActiveLock(supabase);
+
+    if (!activeLock) {
+      return { resolved: true, reason: 'lock_released' };
+    }
+
+    const age = Date.now() - new Date(activeLock.created_at).getTime();
+    if (age >= LOCK_TTL_MS) {
+      // Auto-expire stale lock
+      await supabase
+        .from('session_coordination')
+        .update({ read_at: new Date().toISOString() })
+        .eq('id', activeLock.id);
+      return { resolved: true, reason: 'lock_expired' };
+    }
+
+    onPoll({ elapsed: Date.now() - start, lockAge: age, holder: activeLock.payload.holder_session });
+    await new Promise(r => setTimeout(r, pollInterval));
+  }
+
+  return { resolved: false, reason: 'timeout' };
+}
+
+/**
+ * Release the NODE_MODULES lock held by this session.
+ * @returns {Promise<{released: boolean}>}
+ */
+async function releaseLock(supabase, sessionId) {
+  const { data: all } = await supabase
+    .from('session_coordination')
+    .select('id, payload')
+    .eq('message_type', 'INFO')
+    .is('read_at', null);
+
+  for (const m of (all || [])) {
+    if (m.payload?.lock_type === LOCK_TYPE && m.payload?.holder_session === sessionId) {
+      await supabase
+        .from('session_coordination')
+        .update({ read_at: new Date().toISOString() })
+        .eq('id', m.id);
+    }
+  }
+
+  return { released: true };
+}
+
+module.exports = { acquireLock, waitForLock, releaseLock, LOCK_TYPE, LOCK_TTL_MS, POLL_INTERVAL_MS };

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -919,6 +919,59 @@ async function main() {
     }
   }
 
+  // 5.45. SD-MAN-INFRA-FLEET-NPM-INSTALL-001: node_modules health check with coordination lock
+  // If worktree's node_modules is broken, coordinate npm install across fleet
+  if (worktreeInfo?.success && worktreeInfo.cwd) {
+    try {
+      const { acquireLock, waitForLock, releaseLock } = require('../lib/npm-install-lock.cjs');
+      const fs = await import('fs');
+      const path = await import('path');
+
+      // Check if node_modules is functional by testing a critical dependency
+      const testPath = path.join(worktreeInfo.cwd, 'node_modules', '@supabase', 'supabase-js');
+      if (!fs.existsSync(testPath)) {
+        console.log(`\n${colors.yellow}   ⚠️  node_modules missing or broken — coordinating install...${colors.reset}`);
+        const lock = await acquireLock(supabase, session.session_id);
+
+        if (lock.held) {
+          console.log(`   ⏳ Session ${lock.holder.slice(0, 8)} is installing dependencies — waiting...`);
+          const waitResult = await waitForLock(supabase, {
+            timeout: 120000,
+            pollInterval: 5000,
+            onPoll: ({ elapsed }) => {
+              console.log(`   ⏳ Still waiting... (${Math.round(elapsed / 1000)}s)`);
+            }
+          });
+          if (waitResult.resolved) {
+            console.log(`   ${colors.green}✓ Dependencies ready (${waitResult.reason})${colors.reset}`);
+          } else {
+            console.log(`   ${colors.yellow}⚠️  Lock wait timed out — attempting install anyway${colors.reset}`);
+          }
+        } else if (lock.acquired) {
+          console.log('   🔒 Lock acquired — running npm install...');
+          try {
+            // Install in the repo root (worktrees symlink from there)
+            const repoRoot = execSync('git rev-parse --show-toplevel', {
+              encoding: 'utf8', cwd: worktreeInfo.cwd, stdio: 'pipe'
+            }).trim();
+            execSync('npm install --ignore-scripts', {
+              cwd: repoRoot, stdio: 'pipe', timeout: 120000
+            });
+            console.log(`   ${colors.green}✓ npm install complete${colors.reset}`);
+          } catch (npmErr) {
+            console.log(`   ${colors.yellow}⚠️  npm install failed: ${npmErr.message?.split('\n')[0]}${colors.reset}`);
+          } finally {
+            await releaseLock(supabase, session.session_id);
+            console.log('   🔓 Lock released');
+          }
+        }
+      }
+    } catch (lockErr) {
+      // Non-fatal — lock system failure should not block sd-start
+      console.debug(`[sd-start] node_modules lock check error: ${lockErr?.message || lockErr}`);
+    }
+  }
+
   // 5.5. Show duration estimate
   try {
     // Note: legacy_id was deprecated - using sd_key instead

--- a/tests/lib/npm-install-lock.test.js
+++ b/tests/lib/npm-install-lock.test.js
@@ -1,0 +1,147 @@
+/**
+ * Tests for npm-install-lock.js — distributed mutex via session_coordination
+ * SD: SD-MAN-INFRA-FLEET-NPM-INSTALL-001
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+// Mock supabase client
+function createMockSupabase(rows = []) {
+  const store = [...rows];
+  let insertError = null;
+
+  const chainable = {
+    select: () => chainable,
+    eq: () => chainable,
+    is: () => chainable,
+    order: () => chainable,
+    limit: () => ({ data: store.filter(r => !r.read_at), error: null }),
+    insert: (row) => {
+      if (insertError) return { error: insertError };
+      store.push({ id: `mock-${Date.now()}`, ...row, created_at: new Date().toISOString() });
+      return { error: null };
+    },
+    update: () => chainable,
+  };
+
+  const mock = {
+    from: () => chainable,
+    _store: store,
+    _setInsertError: (err) => { insertError = err; },
+  };
+  return mock;
+}
+
+describe('npm-install-lock', () => {
+  let acquireLock, waitForLock, releaseLock;
+
+  beforeEach(() => {
+    vi.resetModules();
+    ({ acquireLock, waitForLock, releaseLock } = require('../../lib/npm-install-lock.cjs'));
+  });
+
+  describe('acquireLock', () => {
+    it('acquires lock when none exists', async () => {
+      const sb = createMockSupabase();
+      const result = await acquireLock(sb, 'session-aaa');
+      expect(result.acquired).toBe(true);
+    });
+
+    it('detects held lock from another session', async () => {
+      const sb = createMockSupabase([{
+        id: 'lock-1',
+        message_type: 'INFO',
+        payload: { lock_type: 'NODE_MODULES', status: 'locked', holder_session: 'session-bbb' },
+        created_at: new Date().toISOString(),
+        read_at: null
+      }]);
+      const result = await acquireLock(sb, 'session-aaa');
+      expect(result.held).toBe(true);
+      expect(result.holder).toBe('session-bbb');
+    });
+
+    it('auto-expires stale lock older than TTL', async () => {
+      const staleTime = new Date(Date.now() - 130_000).toISOString();
+      const sb = createMockSupabase([{
+        id: 'lock-old',
+        message_type: 'INFO',
+        payload: { lock_type: 'NODE_MODULES', status: 'locked', holder_session: 'session-dead' },
+        created_at: staleTime,
+        read_at: null
+      }]);
+      const result = await acquireLock(sb, 'session-aaa');
+      expect(result.acquired).toBe(true);
+    });
+
+    it('returns error on insert failure', async () => {
+      const sb = createMockSupabase();
+      sb._setInsertError({ message: 'DB unavailable' });
+      const result = await acquireLock(sb, 'session-aaa');
+      expect(result.acquired).toBe(false);
+      expect(result.error).toBe('DB unavailable');
+    });
+  });
+
+  describe('waitForLock', () => {
+    it('resolves immediately when no lock exists', async () => {
+      const sb = createMockSupabase();
+      const result = await waitForLock(sb, { timeout: 10000, pollInterval: 100 });
+      expect(result.resolved).toBe(true);
+      expect(result.reason).toBe('lock_released');
+    });
+
+    it('times out when lock persists', async () => {
+      const sb = createMockSupabase([{
+        id: 'lock-persistent',
+        message_type: 'INFO',
+        payload: { lock_type: 'NODE_MODULES', status: 'locked', holder_session: 'session-busy' },
+        created_at: new Date().toISOString(),
+        read_at: null
+      }]);
+      const result = await waitForLock(sb, { timeout: 200, pollInterval: 50 });
+      expect(result.resolved).toBe(false);
+      expect(result.reason).toBe('timeout');
+    });
+
+    it('calls onPoll callback while waiting', async () => {
+      const sb = createMockSupabase([{
+        id: 'lock-1',
+        message_type: 'INFO',
+        payload: { lock_type: 'NODE_MODULES', status: 'locked', holder_session: 'session-x' },
+        created_at: new Date().toISOString(),
+        read_at: null
+      }]);
+      const polls = [];
+      await waitForLock(sb, {
+        timeout: 300,
+        pollInterval: 50,
+        onPoll: (info) => polls.push(info)
+      });
+      expect(polls.length).toBeGreaterThan(0);
+      expect(polls[0]).toHaveProperty('holder', 'session-x');
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('releases lock held by session', async () => {
+      const sb = createMockSupabase([{
+        id: 'lock-mine',
+        message_type: 'INFO',
+        payload: { lock_type: 'NODE_MODULES', status: 'locked', holder_session: 'session-aaa' },
+        created_at: new Date().toISOString(),
+        read_at: null
+      }]);
+      const result = await releaseLock(sb, 'session-aaa');
+      expect(result.released).toBe(true);
+    });
+
+    it('succeeds when no lock exists', async () => {
+      const sb = createMockSupabase();
+      const result = await releaseLock(sb, 'session-aaa');
+      expect(result.released).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds distributed npm install mutex using `session_coordination` table to prevent node_modules corruption in parallel CC fleet sessions
- New `lib/npm-install-lock.cjs` with `acquireLock`/`waitForLock`/`releaseLock` (2-min auto-expiry)
- Integrates pre-flight node_modules health check into `sd-start.js` — sessions wait instead of failing
- 9 unit tests, all passing

## Test plan
- [ ] Run 3+ parallel `sd-start` sessions — verify only 1 runs npm install, others wait
- [ ] Kill installing session mid-install — verify auto-expiry after 2 minutes
- [ ] Verify zero ERR_MODULE_NOT_FOUND errors across fleet
- [ ] Run `npx vitest run tests/lib/npm-install-lock.test.js` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)