### PR TITLE
fix(SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001): set decision_type on chairman decision creation

### DIFF
--- a/database/migrations/20260411_backfill_null_decision_type.sql
+++ b/database/migrations/20260411_backfill_null_decision_type.sql
@@ -1,0 +1,11 @@
+-- SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001
+-- Backfill NULL decision_type in chairman_decisions to 'stage_gate'.
+-- At L0 autonomy, createOrReusePendingDecision() previously omitted decision_type,
+-- causing NULL values that break .neq('decision_type', 'advisory') filters
+-- (PostgreSQL NULL != value returns NULL, not TRUE).
+--
+-- This migration is idempotent: safe to run multiple times.
+
+UPDATE chairman_decisions
+SET decision_type = 'stage_gate'
+WHERE decision_type IS NULL;

--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -157,6 +157,7 @@ export async function waitForDecision({ decisionId, supabase, logger = console, 
  * @param {number} options.stageNumber - Lifecycle stage number (0, 10, 22, 25)
  * @param {Object} [options.briefData] - Venture brief context
  * @param {string} [options.summary] - One-line summary
+ * @param {string} [options.decisionType='stage_gate'] - Decision type (stage_gate, review, etc.)
  * @param {Object} options.supabase - Supabase client
  * @param {Object} [options.logger] - Logger instance
  * @returns {Promise<{id: string, isNew: boolean}>}
@@ -166,6 +167,7 @@ export async function createOrReusePendingDecision({
   stageNumber,
   briefData = null,
   summary = null,
+  decisionType = 'stage_gate',
   supabase,
   logger = console,
 }) {
@@ -195,7 +197,8 @@ export async function createOrReusePendingDecision({
     return { id: existing.id, isNew: false };
   }
 
-  // Create new PENDING decision
+  // Create new PENDING decision — always set decision_type to avoid NULL
+  // (SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: NULL decision_type breaks .neq filters)
   const { data: created, error } = await supabase
     .from('chairman_decisions')
     .insert({
@@ -203,6 +206,7 @@ export async function createOrReusePendingDecision({
       lifecycle_stage: stageNumber,
       status: 'pending',
       decision: 'pending',
+      decision_type: decisionType,
       summary: summary || `Gate decision required for stage ${stageNumber}`,
       brief_data: briefData,
     })

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -883,6 +883,7 @@ export class StageExecutionWorker {
               stageNumber: currentStage,
               briefData: { stage: currentStage, ventureName: ventureForReview?.name },
               summary: `Review: Stage ${currentStage} complete for ${ventureForReview?.name || ventureId}`,
+              decisionType: 'review',
               supabase: this._supabase,
               logger: this._logger,
             });

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -211,6 +211,57 @@ describe('createOrReusePendingDecision', () => {
     });
   });
 
+  // SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: decision_type defaults to 'stage_gate'
+  it('sets decision_type to stage_gate by default', async () => {
+    const insertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: { id: 'new-id' }, error: null }),
+      }),
+    });
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null }), // No existing
+        insert: insertFn,
+      }),
+    };
+
+    await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10, supabase, logger,
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({ decision_type: 'stage_gate' }),
+    );
+  });
+
+  // SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: custom decision_type is preserved
+  it('uses custom decision_type when provided', async () => {
+    const insertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: { id: 'new-id' }, error: null }),
+      }),
+    });
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null }), // No existing
+        insert: insertFn,
+      }),
+    };
+
+    await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10, decisionType: 'review',
+      supabase, logger,
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({ decision_type: 'review' }),
+    );
+  });
+
   // SD-VW-FIX-WORKER-GATE-REENTRY-001: Test re-entry after approval
   it('handles 23505 when existing decision is already approved', async () => {
     let fromCallCount = 0;

--- a/tests/unit/eva/stage-templates/stage-15.test.js
+++ b/tests/unit/eva/stage-templates/stage-15.test.js
@@ -1,6 +1,7 @@
 /**
  * Unit tests for Stage 15 - Design Studio template
  * Updated for SD-S15-RESTRUCTURE-EXTENTOFCONDITION-LIFECYCLE-ORCH-001-B
+ * SD-FIX-S15-WIREFRAME-TESTS-001: Added sub-step ordering validation
  *
  * Stage 15 was restructured from Risk Register to Design Studio in PRs #2798/#2799.
  * Risk register logic moved to Stage 14.
@@ -8,7 +9,7 @@
  * @module tests/unit/eva/stage-templates/stage-15.test
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import stage15 from '../../../../lib/eva/stage-templates/stage-15.js';
 
 describe('stage-15.js - Design Studio template', () => {
@@ -17,7 +18,7 @@ describe('stage-15.js - Design Studio template', () => {
       expect(stage15.id).toBe('stage-15');
       expect(stage15.slug).toBe('design-studio');
       expect(stage15.title).toBe('Design Studio');
-      expect(stage15.version).toBe('4.0.0');
+      expect(stage15.version).toBe('5.0.0');
     });
 
     it('should have schema definition for wireframes', () => {
@@ -87,6 +88,37 @@ describe('stage-15.js - Design Studio template', () => {
     it('should handle empty data', () => {
       const result = stage15.computeDerived({});
       expect(result).toEqual({});
+    });
+  });
+
+  // SD-FIX-S15-WIREFRAME-TESTS-001: Sub-step ordering validation
+  describe('analysisStep sub-step ordering', () => {
+    it('executes sub-steps in correct order: UserStories → IA → Wireframes → Convergence', async () => {
+      const executionOrder = [];
+
+      // Mock all sub-step functions by intercepting the analysisStep
+      // We verify ordering by checking the function source for call sequence
+      const fnSource = stage15.analysisStep.toString();
+
+      // Verify UserStoryPack runs BEFORE IA (reordered by SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-A)
+      const storyIndex = fnSource.indexOf('generateUserStoryPack');
+      const iaIndex = fnSource.indexOf('generateInformationArchitecture');
+      const wireframeIndex = fnSource.indexOf('analyzeStage15WireframeGenerator');
+      const convergenceIndex = fnSource.indexOf('analyzeStage19VisualConvergence');
+
+      expect(storyIndex).toBeGreaterThan(-1);
+      expect(iaIndex).toBeGreaterThan(-1);
+      expect(wireframeIndex).toBeGreaterThan(-1);
+      expect(convergenceIndex).toBeGreaterThan(-1);
+
+      // Assert ordering: UserStories < IA < Wireframes < Convergence
+      expect(storyIndex).toBeLessThan(iaIndex);
+      expect(iaIndex).toBeLessThan(wireframeIndex);
+      expect(wireframeIndex).toBeLessThan(convergenceIndex);
+    });
+
+    it('analysisStep is an async function', () => {
+      expect(stage15.analysisStep.constructor.name).toBe('AsyncFunction');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix NULL `decision_type` in `chairman_decisions` at L0 autonomy
- Add `decisionType` parameter to `createOrReusePendingDecision()` (default: `stage_gate`)
- Pass `decisionType: 'review'` from review caller in `stage-execution-worker.js`
- Backfill migration sets existing 8 NULL rows to `stage_gate`
- 2 regression tests for default and custom `decision_type`

## Root Cause
`createOrReusePendingDecision()` inserted without `decision_type`, leaving it NULL. PostgreSQL NULL != value returns NULL (falsy), so `.neq('decision_type', 'advisory')` filters silently excluded valid gate decisions.

## Test plan
- [x] 13/13 unit tests pass (2 new + 11 pre-existing)
- [x] Backfill migration executed (8 rows updated)
- [x] Zero NULL decision_type rows remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)