### PR TITLE
fix(SD-MAN-FIX-S15-DESIGN-STUDIO-001): S15 Design Studio + Stitch reliability

### DIFF
--- a/database/migrations/20260411_s15_stage_timeout_override.sql
+++ b/database/migrations/20260411_s15_stage_timeout_override.sql
@@ -1,0 +1,6 @@
+-- SD-MAN-FIX-S15-DESIGN-STUDIO-001: Set per-stage timeout override for S15
+-- S15 Design Studio uniquely runs 4 LLM sub-steps + Stitch screen generation,
+-- requiring 600s vs the 300s global default.
+UPDATE lifecycle_stage_config
+SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"stage_timeout_ms": 600000}'::jsonb
+WHERE stage_number = 15;

--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -18,8 +18,8 @@ dotenv.config();
 // Configuration
 // ---------------------------------------------------------------------------
 
-const RETRY_MAX = 3;
-const RETRY_BASE_DELAY_MS = 1000;
+const RETRY_MAX = 2;
+const RETRY_BASE_DELAY_MS = 15_000;
 const CIRCUIT_BREAKER_THRESHOLD = 5;
 const CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
 const BUDGET_PER_VENTURE = 50;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1399,14 +1399,38 @@ export class StageExecutionWorker {
   }
 
   /**
+   * Get the effective stale-lock threshold for a given stage.
+   * Checks lifecycle_stage_config.metadata.stage_timeout_ms for per-stage overrides.
+   * SD-MAN-FIX-S15-DESIGN-STUDIO-001: Per-stage timeout support
+   *
+   * @param {number} stageNumber - Stage number
+   * @returns {Promise<number>} Threshold in ms
+   */
+  async _getStageTimeoutMs(stageNumber) {
+    try {
+      const { data: cfg } = await this._supabase
+        .from('lifecycle_stage_config')
+        .select('metadata')
+        .eq('stage_number', stageNumber)
+        .single();
+      if (cfg?.metadata?.stage_timeout_ms) {
+        return cfg.metadata.stage_timeout_ms;
+      }
+    } catch { /* use default */ }
+    return this._staleLockThresholdMs;
+  }
+
+  /**
    * Mark running execution records with stale heartbeats as timed_out.
    * Supplements _releaseStaleLocks by detecting crashed workers at the
    * per-stage granularity rather than per-venture lock level.
+   * SD-MAN-FIX-S15-DESIGN-STUDIO-001: Uses per-stage timeout overrides.
    *
    * SD-VW-BACKEND-EXEC-RECORDS-001: FR5 — Stale execution detection
    */
   async _markStaleExecutions() {
     try {
+      // Use default threshold for the initial query to find candidates
       const cutoff = new Date(Date.now() - this._staleLockThresholdMs).toISOString();
 
       const { data: stale, error } = await this._supabase
@@ -1424,10 +1448,15 @@ export class StageExecutionWorker {
 
       for (const exec of stale) {
         const age = Date.now() - new Date(exec.heartbeat_at).getTime();
+
+        // Check per-stage timeout override before marking as stale
+        const stageThreshold = await this._getStageTimeoutMs(exec.lifecycle_stage);
+        if (age < stageThreshold) continue;
+
         this._logger.warn(
           `[Worker] Marking stale execution ${exec.id} as timed_out ` +
           `(venture=${exec.venture_id}, stage=${exec.lifecycle_stage}, ` +
-          `worker=${exec.worker_id}, heartbeat ${Math.round(age / 1000)}s ago)`
+          `worker=${exec.worker_id}, heartbeat ${Math.round(age / 1000)}s ago, threshold ${stageThreshold / 1000}s)`
         );
 
         const { error: updateError } = await this._supabase
@@ -1435,7 +1464,7 @@ export class StageExecutionWorker {
           .update({
             status: 'timed_out',
             completed_at: new Date().toISOString(),
-            error_message: `Stale heartbeat detected (${Math.round(age / 1000)}s since last heartbeat)`,
+            error_message: `Stale heartbeat detected (${Math.round(age / 1000)}s since last heartbeat, threshold ${stageThreshold / 1000}s)`,
           })
           .eq('id', exec.id)
           .eq('status', 'running');
@@ -1925,7 +1954,23 @@ export class StageExecutionWorker {
       .limit(1)
       .maybeSingle();
 
-    const result = await postStage15Hook(ventureId, s15Work);
+    // SD-MAN-FIX-S15-DESIGN-STUDIO-001: 480s abort guard — fires before the 600s lock expiry
+    const STITCH_PROVISION_TIMEOUT_MS = 480_000;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), STITCH_PROVISION_TIMEOUT_MS);
+    let result;
+    try {
+      result = await Promise.race([
+        postStage15Hook(ventureId, s15Work),
+        new Promise((_, reject) => {
+          ac.signal.addEventListener('abort', () =>
+            reject(new Error(`[S15] Stitch provisioner timed out after ${STITCH_PROVISION_TIMEOUT_MS / 1000}s`))
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
 
     // Fallback: when Stitch unavailable, continue with ASCII wireframes
     if (result?.status === 'unavailable' || result?.status === 'no_op') {

--- a/lib/eva/stage-templates/analysis-steps/stage-15-user-story-pack.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-user-story-pack.js
@@ -37,10 +37,13 @@ ${ventureBrief}
 
 Output valid JSON with keys: "epics" (array), "personas" (array), "mvp_story_count" (number), "total_story_points" (number).`;
 
+  if (typeof llm.complete !== 'function') {
+    throw new Error('LLM client missing complete() method — ensure getLLMClient() returns the unified interface');
+  }
+
   try {
-    const response = await llm.generateContent({
-      systemPrompt,
-      userPrompt,
+    const response = await llm.complete(systemPrompt, userPrompt, {
+      timeout: 120000,
       maxOutputTokens: 8192,
       temperature: 0.4,
     });

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -196,6 +196,11 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     logger.log('[Stage15-DesignStudio] Skipping wireframes — Stage 10 brand data not available');
   }
 
+  // SD-MAN-FIX-S15-DESIGN-STUDIO-001: Hard-fail on zero screens when gating enabled
+  if (wireframeGatingEnabled && wireframeResult && wireframeResult.screens?.length === 0) {
+    throw new Error('[Stage15] Hard-fail: 0 wireframe screens generated with EVA_WIREFRAME_GATING_ENABLED=true. Empty wireframes must not propagate to S17.');
+  }
+
   // Sub-step 4: Visual convergence (5 expert LLM passes on wireframes)
   let convergenceResult = null;
   if (wireframeResult?.screens?.length > 0) {

--- a/tests/eva/s15-design-studio-reliability.test.js
+++ b/tests/eva/s15-design-studio-reliability.test.js
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for SD-MAN-FIX-S15-DESIGN-STUDIO-001
+ * S15 Design Studio + Stitch Integration Reliability
+ *
+ * Covers 5 fixes:
+ *   1. LLM interface migration (generateContent → complete)
+ *   2. Stitch retry backoff alignment (1s→15s base, 3→2 retries)
+ *   3. Per-stage timeout override via lifecycle_stage_config
+ *   4. Hard-fail gating on zero wireframe screens
+ *   5. 480s AbortController guard on Stitch provisioner
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function readSource(relPath) {
+  return readFileSync(resolve(relPath), 'utf-8');
+}
+
+// ── Fix 1: LLM Interface Migration ──────────────────────────────────────
+
+describe('Fix 1: stage-15-user-story-pack LLM interface', () => {
+  const source = readSource('lib/eva/stage-templates/analysis-steps/stage-15-user-story-pack.js');
+
+  it('uses llm.complete() instead of llm.generateContent()', () => {
+    expect(source).toContain('llm.complete(systemPrompt, userPrompt,');
+    expect(source).not.toContain('llm.generateContent(');
+  });
+
+  it('has runtime check for missing complete() method', () => {
+    expect(source).toContain("typeof llm.complete !== 'function'");
+    expect(source).toContain('LLM client missing complete() method');
+  });
+
+  it('passes timeout option to llm.complete()', () => {
+    expect(source).toContain('timeout: 120000');
+  });
+});
+
+// ── Fix 2: Stitch Retry Backoff ─────────────────────────────────────────
+
+describe('Fix 2: Stitch retry backoff constants', () => {
+  const source = readSource('lib/eva/bridge/stitch-client.js');
+
+  it('RETRY_BASE_DELAY_MS is 15000 (was 1000)', () => {
+    expect(source).toContain('const RETRY_BASE_DELAY_MS = 15_000;');
+    expect(source).not.toContain('const RETRY_BASE_DELAY_MS = 1000;');
+  });
+
+  it('RETRY_MAX is 2 (was 3)', () => {
+    expect(source).toContain('const RETRY_MAX = 2;');
+    expect(source).not.toContain('const RETRY_MAX = 3;');
+  });
+
+  it('worst-case per-screen: 2 retries × 60s + 15s + 30s = 165s', () => {
+    // Verify the exponential backoff math: base=15000, attempts=[1,2]
+    const base = 15_000;
+    const maxRetries = 2;
+    const delays = [];
+    for (let i = 1; i < maxRetries; i++) {
+      delays.push(base * Math.pow(2, i - 1));
+    }
+    // delay for attempt 1 retry = 15000ms
+    expect(delays[0]).toBe(15_000);
+    // Total delay budget is manageable (< 60s)
+    expect(delays.reduce((a, b) => a + b, 0)).toBeLessThan(60_000);
+  });
+});
+
+// ── Fix 3: Per-Stage Timeout Override ───────────────────────────────────
+
+describe('Fix 3: per-stage timeout override', () => {
+  const source = readSource('lib/eva/stage-execution-worker.js');
+
+  it('has _getStageTimeoutMs method that reads lifecycle_stage_config', () => {
+    expect(source).toContain('async _getStageTimeoutMs(stageNumber)');
+    expect(source).toContain("'lifecycle_stage_config'");
+    expect(source).toContain('stage_timeout_ms');
+  });
+
+  it('_getStageTimeoutMs falls back to _staleLockThresholdMs', () => {
+    expect(source).toContain('return this._staleLockThresholdMs');
+  });
+
+  it('_markStaleExecutions checks per-stage timeout before marking', () => {
+    expect(source).toContain('const stageThreshold = await this._getStageTimeoutMs(exec.lifecycle_stage)');
+    expect(source).toContain('if (age < stageThreshold) continue');
+  });
+
+  it('stale execution error message includes per-stage threshold', () => {
+    expect(source).toContain('threshold ${stageThreshold / 1000}s');
+  });
+});
+
+// ── Fix 4: Hard-Fail Gating on Zero Screens ────────────────────────────
+
+describe('Fix 4: hard-fail on zero wireframe screens', () => {
+  const source = readSource('lib/eva/stage-templates/stage-15.js');
+
+  it('checks screen count === 0 when gating enabled', () => {
+    expect(source).toContain('wireframeResult.screens?.length === 0');
+  });
+
+  it('throws descriptive error on zero screens', () => {
+    expect(source).toContain('Hard-fail: 0 wireframe screens generated');
+  });
+
+  it('only fails when wireframeGatingEnabled is true', () => {
+    expect(source).toContain('wireframeGatingEnabled && wireframeResult');
+  });
+
+  it('check runs before visual convergence (sub-step 4)', () => {
+    const hardFailIndex = source.indexOf('Hard-fail: 0 wireframe screens');
+    const convergenceIndex = source.indexOf('Sub-step 4: Visual convergence');
+    expect(hardFailIndex).toBeLessThan(convergenceIndex);
+  });
+});
+
+// ── Fix 5: Abort Timeout Guard ──────────────────────────────────────────
+
+describe('Fix 5: 480s abort guard on Stitch provisioner', () => {
+  const source = readSource('lib/eva/stage-execution-worker.js');
+
+  it('has 480s timeout constant', () => {
+    expect(source).toContain('STITCH_PROVISION_TIMEOUT_MS = 480_000');
+  });
+
+  it('uses AbortController for timeout', () => {
+    expect(source).toContain('new AbortController()');
+    expect(source).toContain('ac.abort()');
+  });
+
+  it('uses Promise.race for timeout enforcement', () => {
+    expect(source).toContain('Promise.race');
+    expect(source).toContain('postStage15Hook(ventureId, s15Work)');
+  });
+
+  it('cleans up timer in finally block', () => {
+    expect(source).toContain('clearTimeout(timer)');
+  });
+
+  it('abort fires before the 600s lock expiry (120s margin)', () => {
+    const STITCH_PROVISION_TIMEOUT_MS = 480_000;
+    const STAGE_15_LOCK_TIMEOUT_MS = 600_000;
+    expect(STITCH_PROVISION_TIMEOUT_MS).toBeLessThan(STAGE_15_LOCK_TIMEOUT_MS);
+    expect(STAGE_15_LOCK_TIMEOUT_MS - STITCH_PROVISION_TIMEOUT_MS).toBe(120_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix 4 reliability failures in S15 Design Studio causing empty wireframes for all ventures
- LLM interface migration (generateContent → complete) in user-story-pack
- Stitch retry backoff aligned to 30-60s backend latency (15s base, 2 retries)
- Per-stage timeout override (S15 gets 600s via lifecycle_stage_config)
- Hard-fail gating on 0 screens when EVA_WIREFRAME_GATING_ENABLED=true
- 480s AbortController guard on Stitch provisioner (fires before 600s lock)

## Test plan
- [x] 19 regression tests covering all 5 fixes
- [x] Zero regressions across full eva test suite
- [x] Migration applied: S15 stage_timeout_ms = 600000

🤖 Generated with [Claude Code](https://claude.com/claude-code)