### PR TITLE
fix(SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A): enrich Stitch prompts with wireframe data and brand tokens

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -88,22 +88,28 @@ async function checkGovernanceFlags() {
 function extractStage11Tokens(stage11Artifacts) {
   const tokens = {};
 
-  // Color palette
-  if (stage11Artifacts?.colorPalette) {
-    tokens.colors = Array.isArray(stage11Artifacts.colorPalette)
-      ? stage11Artifacts.colorPalette
-      : [stage11Artifacts.colorPalette];
-  } else if (stage11Artifacts?.visual_identity?.color_palette) {
-    tokens.colors = stage11Artifacts.visual_identity.color_palette;
+  // Color palette — SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: fix path resolution
+  // S11 identity_naming_visual stores colors at visualIdentity.colorPalette (camelCase)
+  const colorSource =
+    stage11Artifacts?.visualIdentity?.colorPalette ||  // actual S11 path (camelCase)
+    stage11Artifacts?.colorPalette ||                   // legacy flat path
+    stage11Artifacts?.visual_identity?.color_palette ||  // snake_case fallback
+    stage11Artifacts?.visual_identity?.colorPalette ||   // mixed-case fallback
+    null;
+  if (colorSource) {
+    tokens.colors = Array.isArray(colorSource) ? colorSource : [colorSource];
   }
 
-  // Typography
-  if (stage11Artifacts?.typography) {
-    tokens.fonts = Array.isArray(stage11Artifacts.typography)
-      ? stage11Artifacts.typography.map(t => typeof t === 'string' ? t : t.name || t.family)
-      : [stage11Artifacts.typography];
-  } else if (stage11Artifacts?.visual_identity?.typography) {
-    tokens.fonts = [stage11Artifacts.visual_identity.typography];
+  // Typography — SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: fix path resolution
+  const typoSource =
+    stage11Artifacts?.visualIdentity?.typography ||  // actual S11 path
+    stage11Artifacts?.typography ||                   // legacy flat path
+    stage11Artifacts?.visual_identity?.typography ||  // snake_case fallback
+    null;
+  if (typoSource) {
+    tokens.fonts = Array.isArray(typoSource)
+      ? typoSource.map(t => typeof t === 'string' ? t : t.name || t.family || t)
+      : [typoSource];
   }
 
   // Brand expression / personality
@@ -143,6 +149,9 @@ function extractStage15Screens(stage15Artifacts) {
 // Prompt Construction
 // ---------------------------------------------------------------------------
 
+// SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: char count threshold for pre-flight guard
+const PROMPT_CHAR_WARN = parseInt(process.env.STITCH_PROMPT_CHAR_WARN || '4000', 10);
+
 function buildScreenPrompt(screen, brandTokens, ventureName) {
   const parts = [];
 
@@ -152,26 +161,72 @@ function buildScreenPrompt(screen, brandTokens, ventureName) {
     parts.push(`Purpose: ${screen.purpose}`);
   }
 
-  // Brand tokens
+  // --- LAYOUT SECTION: ASCII wireframe structure ---
+  if (Array.isArray(screen.ascii_layout) && screen.ascii_layout.length > 0) {
+    parts.push('');
+    parts.push('Layout reference:');
+    parts.push(screen.ascii_layout.join('\n'));
+  }
+
+  // --- BRAND SECTION: colors, typography, personality ---
+  const brandParts = [];
   if (brandTokens.colors?.length > 0) {
-    parts.push(`Color palette: ${brandTokens.colors.slice(0, 5).join(', ')}`);
+    const colorLines = brandTokens.colors.map(c => {
+      if (typeof c === 'string') return c;
+      const name = c.name || 'Color';
+      const hex = c.hex || c.value || '';
+      const usage = c.usage || '';
+      return usage ? `${name} (${hex}) - ${usage}` : `${name} (${hex})`;
+    });
+    brandParts.push(`Colors: ${colorLines.join('; ')}`);
   }
   if (brandTokens.fonts?.length > 0) {
-    parts.push(`Typography: ${brandTokens.fonts.join(', ')}`);
+    brandParts.push(`Typography: ${brandTokens.fonts.join(', ')}`);
   }
   if (brandTokens.personality) {
     const personality = typeof brandTokens.personality === 'string'
       ? brandTokens.personality
       : JSON.stringify(brandTokens.personality);
-    parts.push(`Brand personality: ${personality}`);
+    brandParts.push(`Brand personality: ${personality}`);
+  }
+  if (brandParts.length > 0) {
+    parts.push('');
+    parts.push(...brandParts);
   }
 
-  // Screen components
+  // --- BEHAVIOR SECTION: interactions, states, responsive ---
+  const behaviorParts = [];
+  if (screen.interaction_notes) behaviorParts.push(`Interactions: ${screen.interaction_notes}`);
+  if (screen.error_state) behaviorParts.push(`Error state: ${screen.error_state}`);
+  if (screen.empty_state) behaviorParts.push(`Empty state: ${screen.empty_state}`);
+  if (screen.responsive_notes) behaviorParts.push(`Responsive: ${screen.responsive_notes}`);
+  if (behaviorParts.length > 0) {
+    parts.push('');
+    parts.push(...behaviorParts);
+  }
+
+  // --- CONTEXT SECTION: persona, user stories, components ---
+  if (screen.persona) {
+    parts.push('');
+    parts.push(`Target persona: ${screen.persona}`);
+  }
+  if (screen.user_stories?.length > 0) {
+    parts.push(`User stories: ${screen.user_stories.join('; ')}`);
+  } else if (screen.user_story) {
+    parts.push(`User story: ${screen.user_story}`);
+  }
   if (screen.key_components?.length > 0) {
     parts.push(`Key components: ${screen.key_components.join(', ')}`);
   }
 
-  return parts.join('\n');
+  const prompt = parts.join('\n');
+
+  // Pre-flight char count guard (warn-only)
+  if (prompt.length > PROMPT_CHAR_WARN) {
+    console.warn(`[stitch-provisioner] Screen "${screen.name}" prompt is ${prompt.length} chars (threshold: ${PROMPT_CHAR_WARN})`);
+  }
+
+  return prompt;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix `extractStage11Tokens` path/casing bug: S11 stores colors at `visualIdentity.colorPalette` (camelCase) but extractor checked wrong paths — brand colors and typography never reached Google Stitch
- Enrich `buildScreenPrompt` with 4 structured sections: Layout (ASCII wireframes), Brand (formatted colors + typography), Behavior (interaction notes, error/empty states, responsive), Context (persona, user stories)
- Add pre-flight char count guard (configurable via `STITCH_PROMPT_CHAR_WARN`, default 4000) to detect potential silent Stitch prompt truncation

**Traceability:**
- Vision: `VISION-STITCH-PROMPT-ENRICHMENT-L2-001`
- Architecture: `ARCH-STITCH-PROMPT-ENRICHMENT-001`
- Brainstorm: Board deliberation (6/6 seats, 2 rounds) — session `dd169180`
- Parent orchestrator: `SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001`

## Test plan
- [x] 12/13 stitch-provisioner tests pass (1 pre-existing mock failure unrelated to changes)
- [x] 15/15 smoke tests pass
- [ ] Verify Stitch prompts include colors, typography, wireframe layouts in next venture run
- [ ] Verify existing S17 review, dashboard, frontend consumers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)