### PR TITLE
fix(SD-MAN-FIX-FIX-NULL-DECISION-001): fix NULL decision_type and kill gate advisory overlap

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -875,7 +875,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   }
 
   // ── 7d. Advisory checkpoint notifications (non-blocking) ──
-  const ADVISORY_STAGES = [3, 5, 16, 23];
+  const ADVISORY_STAGES = [16, 23];  // SD-MAN-FIX-FIX-NULL-DECISION-001: removed 3,5 (kill gates must not get pre-approved advisory rows)
   if (ADVISORY_STAGES.includes(resolvedStage) && !options.dryRun) {
     try {
       await createAdvisoryNotification({

--- a/lib/eva/gate-failure-recovery.js
+++ b/lib/eva/gate-failure-recovery.js
@@ -205,6 +205,7 @@ export async function routeGateOutcome(ventureId, severity, context, deps) {
         lifecycle_stage: fromStage || toStage || 0,
         decision: 'pending',
         status: 'pending',
+        decision_type: 'gate_failure_escalation',  // SD-MAN-FIX-FIX-NULL-DECISION-001: was missing, caused NULL
         rationale: `Gate failure escalation (${severity}): ${(reasons || []).join('; ')}`,
         dfe_context: {
           source: 'gate_failure_recovery',


### PR DESCRIPTION
## Summary
- Add `decision_type: 'gate_failure_escalation'` to direct INSERT in `gate-failure-recovery.js` — fixes NULL decision_type from DFE escalation path
- Remove kill gate stages 3 and 5 from `ADVISORY_STAGES` in `eva-orchestrator.js` — prevents pre-approved advisory rows on kill gates that confuse monitoring queries

**RCA source:** DomainVerifier API monitoring run (Apr 11). Board of Directors deliberation session `16df560d`.

## Test plan
- [x] 15/15 smoke tests pass
- [ ] Next venture run: S3 should only have `stage_gate` type, not `advisory`
- [ ] DFE escalation creates decisions with non-NULL `decision_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)