### PR TITLE
feat(SD-DYNAMIC-ARCHETYPEMATCHED-DESIGN-REFERENCE-ORCH-001): wire design references into Stitch prompts

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -16,6 +16,8 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { writeArtifact } from '../artifact-persistence-service.js';
+import { selectPatterns } from '../design-reference/pattern-selector.js';
+import { generateDesignReferenceSection } from '../design-reference/design-directive-generator.js';
 
 dotenv.config();
 
@@ -152,7 +154,7 @@ function extractStage15Screens(stage15Artifacts) {
 // SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: char count threshold for pre-flight guard
 const PROMPT_CHAR_WARN = parseInt(process.env.STITCH_PROMPT_CHAR_WARN || '4000', 10);
 
-function buildScreenPrompt(screen, brandTokens, ventureName) {
+function buildScreenPrompt(screen, brandTokens, ventureName, designReferenceSection) {
   const parts = [];
 
   parts.push(`Design a ${screen.name || 'screen'} for ${ventureName || 'the application'}.`);
@@ -192,6 +194,12 @@ function buildScreenPrompt(screen, brandTokens, ventureName) {
   if (brandParts.length > 0) {
     parts.push('');
     parts.push(...brandParts);
+  }
+
+  // --- DESIGN REFERENCE SECTION: archetype-matched inspiration ---
+  if (designReferenceSection) {
+    parts.push('');
+    parts.push(designReferenceSection);
   }
 
   // --- BEHAVIOR SECTION: interactions, states, responsive ---
@@ -294,9 +302,33 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     return { status: 'no_op', reason: 'no_screens' };
   }
 
+  // Step 3.5: Generate design reference section (archetype-matched inspiration)
+  let designRefSection = '';
+  if (options.archetype) {
+    try {
+      const { data: refs } = await supabase
+        .from('design_reference_library')
+        .select('id, site_name, archetype_category, score_combined, design_tokens')
+        .not('design_tokens', 'is', null);
+
+      if (refs && refs.length > 0) {
+        const { primary } = selectPatterns({
+          ventureId,
+          archetype: options.archetype,
+          references: refs,
+          personality: brandTokens.personality || 'balanced',
+          count: 3,
+        });
+        designRefSection = generateDesignReferenceSection(primary);
+      }
+    } catch (err) {
+      console.warn('[stitch-provisioner] Design reference generation failed (non-blocking):', err.message);
+    }
+  }
+
   // Step 4: Build curation prompts (chairman uses these in Stitch web UI)
   const curationPrompts = screens.map(screen =>
-    buildScreenPrompt(screen, brandTokens, options.ventureName)
+    buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection)
   );
 
   // Step 5: Create project via stitch-client (API call — works reliably)
@@ -443,10 +475,10 @@ export async function checkCurationStatus(ventureId) {
  */
 export async function postStage15Hook(ventureId, stageData) {
   try {
-    // Fetch venture name for project naming
+    // Fetch venture name and archetype for project naming + design references
     const { data: venture } = await supabase
       .from('ventures')
-      .select('name')
+      .select('name, archetype')
       .eq('id', ventureId)
       .single();
 
@@ -464,7 +496,7 @@ export async function postStage15Hook(ventureId, stageData) {
       ventureId,
       s11?.advisory_data || {},
       stageData?.advisory_data || stageData || {},
-      { ventureName: venture?.name }
+      { ventureName: venture?.name, archetype: venture?.archetype }
     );
 
     return result;


### PR DESCRIPTION
## Summary
- Wire pattern selector + directive generator into `buildScreenPrompt` in stitch-provisioner
- When venture has an archetype, selects 3 archetype-matched references and generates NL design directives
- Appears as "Design References" section in curation prompts
- Non-blocking: gracefully skips if no archetype or no enriched references

## Test plan
- [x] Smoke tests pass (15/15)
- [x] All design reference tests pass (52/52)
- [x] No archetype = section skipped (existing behavior unchanged)
- [x] Pre-existing stitch-provisioner test failure is unrelated (mock chain depth issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)