### PR TITLE
fix(PAT-TAXONOMY-COLLISION-001): align archetype taxonomy across pipeline

### DIFF
--- a/database/migrations/20260411_fix_design_ref_archetype_hyphen.sql
+++ b/database/migrations/20260411_fix_design_ref_archetype_hyphen.sql
@@ -1,0 +1,33 @@
+-- Migration: Fix e-commerce archetype to use underscore (canonical format)
+-- SD: SD-DYNAMIC-ARCHETYPEMATCHED-DESIGN-REFERENCE-ORCH-001
+-- RCA: PAT-TAXONOMY-COLLISION-001
+-- Purpose: Align design_reference_library.archetype_category with canonical ARCHETYPES list
+
+-- Fix hyphenated value to underscore (matches stage-01-constants.js)
+UPDATE design_reference_library
+SET archetype_category = 'e_commerce'
+WHERE archetype_category = 'e-commerce';
+
+-- Map 'portfolio' and 'corporate' to nearest canonical archetypes
+-- portfolio → creator_tools (creative/design focus)
+-- corporate → services (enterprise/B2B focus)
+UPDATE design_reference_library
+SET archetype_category = 'creator_tools'
+WHERE archetype_category = 'portfolio';
+
+UPDATE design_reference_library
+SET archetype_category = 'services'
+WHERE archetype_category = 'corporate';
+
+-- Update the CHECK constraint to use canonical values
+ALTER TABLE design_reference_library
+DROP CONSTRAINT IF EXISTS design_reference_library_archetype_category_check;
+
+ALTER TABLE design_reference_library
+ADD CONSTRAINT design_reference_library_archetype_category_check
+CHECK (archetype_category IN ('saas', 'marketplace', 'ai_product', 'e_commerce', 'fintech', 'healthtech', 'edtech', 'media', 'creator_tools', 'services', 'deeptech', 'real_estate'));
+
+-- Rollback:
+-- UPDATE design_reference_library SET archetype_category = 'e-commerce' WHERE archetype_category = 'e_commerce';
+-- UPDATE design_reference_library SET archetype_category = 'portfolio' WHERE archetype_category = 'creator_tools' AND url IN (SELECT url FROM design_reference_library WHERE archetype_category = 'creator_tools');
+-- UPDATE design_reference_library SET archetype_category = 'corporate' WHERE archetype_category = 'services';

--- a/lib/eva/stage-zero/synthesis/archetype-mapping.js
+++ b/lib/eva/stage-zero/synthesis/archetype-mapping.js
@@ -3,20 +3,31 @@
  *
  * The synthesis engine classifies ventures into 7 strategic archetypes,
  * but ventures.archetype has a FK to archetype_benchmarks which uses
- * industry archetypes. This module bridges the two taxonomies.
+ * industry archetypes (canonical list in stage-01-constants.js).
  *
  * RCA: PAT-TAXONOMY-COLLISION-001
+ * Fix: SD-DYNAMIC-ARCHETYPEMATCHED-DESIGN-REFERENCE-ORCH-001 — aligned to
+ * post-migration canonical values (20260324_unify_archetype_taxonomy.sql)
  */
 
+import { ARCHETYPES } from '../../stage-templates/stage-01-constants.js';
+
 const SYNTHESIS_TO_DB_ARCHETYPE = {
-  democratizer: 'saas_b2c',
-  automator: 'saas_b2b',
-  capability_productizer: 'ai_agents',
+  democratizer: 'saas',
+  automator: 'saas',
+  capability_productizer: 'ai_product',
   first_principles_rebuilder: 'marketplace',
-  vertical_specialist: 'saas_b2b',
+  vertical_specialist: 'saas',
   portfolio_connector: 'services',
-  experience_designer: 'content',
+  experience_designer: 'media',
 };
+
+// Startup validation: ensure all mapped values exist in canonical list
+for (const [synth, db] of Object.entries(SYNTHESIS_TO_DB_ARCHETYPE)) {
+  if (!ARCHETYPES.includes(db)) {
+    console.error(`[archetype-mapping] WARNING: "${synth}" maps to "${db}" which is not in ARCHETYPES canonical list`);
+  }
+}
 
 const DEFAULT_DB_ARCHETYPE = 'saas';
 


### PR DESCRIPTION
## Summary
- Fix `archetype-mapping.js` to use post-migration canonical values (saas, ai_product, media) instead of stale pre-migration values (saas_b2b, ai_agents, content)
- Add startup validation ensuring mapped values exist in canonical ARCHETYPES list
- Migrate `design_reference_library.archetype_category`: e-commerce→e_commerce, portfolio→creator_tools, corporate→services
- Update CHECK constraint to enforce canonical values

## Root Cause (5-Whys)
Three independent archetype taxonomies (synthesis engine, DB mapping, design reference library) with no shared constant. The unify-archetype-taxonomy migration updated DB rows but not the code mapping.

## Test plan
- [x] Pattern selector returns matches for venture with archetype "saas" (was returning 0 with "saas_b2b")
- [x] Smoke tests pass
- [x] No rows with stale archetype values in design_reference_library
- [x] Startup validation passes (no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)