### PR TITLE
feat(SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-B): JSON repair + directive truncation fix

### DIFF
--- a/lib/eva/design-reference/design-directive-generator.js
+++ b/lib/eva/design-reference/design-directive-generator.js
@@ -38,7 +38,7 @@ export function generateDirective(tokens, siteName) {
 
   for (const [key, label] of Object.entries(DIMENSION_LABELS)) {
     if (tokens[key]) {
-      const value = sanitizeDesignReference(String(tokens[key]), 80);
+      const value = sanitizeDesignReference(String(tokens[key]), 120);
       if (value) {
         parts.push(`${label}: ${value}`);
       }
@@ -50,7 +50,13 @@ export function generateDirective(tokens, siteName) {
   let directive = `Inspired by ${siteName}: ${parts.join('. ')}.`;
 
   if (directive.length > MAX_DIRECTIVE_LENGTH) {
-    directive = directive.substring(0, MAX_DIRECTIVE_LENGTH - 3) + '...';
+    // Truncate at word boundary to prevent mid-word cuts
+    let truncated = directive.substring(0, MAX_DIRECTIVE_LENGTH - 3);
+    const lastSpace = truncated.lastIndexOf(' ');
+    if (lastSpace > MAX_DIRECTIVE_LENGTH * 0.7) {
+      truncated = truncated.substring(0, lastSpace);
+    }
+    directive = truncated + '...';
   }
 
   return directive;

--- a/lib/utils/repair-llm-json.js
+++ b/lib/utils/repair-llm-json.js
@@ -1,0 +1,65 @@
+/**
+ * Repair malformed LLM JSON output.
+ *
+ * Common LLM issues: markdown code fences, trailing commas,
+ * missing closing braces. This utility attempts repair before failing.
+ *
+ * SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-B
+ * @module lib/utils/repair-llm-json
+ */
+
+/**
+ * Attempt to repair and parse malformed JSON from LLM output.
+ *
+ * @param {string} raw - Raw LLM text that should contain JSON
+ * @returns {{ parsed: object|null, repaired: boolean, error: string|null }}
+ */
+export function repairLLMJson(raw) {
+  if (!raw || typeof raw !== 'string') {
+    return { parsed: null, repaired: false, error: 'Input is null or not a string' };
+  }
+
+  let text = raw.trim();
+
+  // Step 1: Strip markdown code fences
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?\s*```\s*$/, '');
+  }
+
+  // Step 2: Try parsing as-is first
+  try {
+    return { parsed: JSON.parse(text), repaired: false, error: null };
+  } catch (_) {
+    // Continue to repair
+  }
+
+  // Step 3: Remove trailing commas before } or ]
+  let repaired = text.replace(/,\s*([\]}])/g, '$1');
+
+  // Step 4: Try parsing after trailing comma fix
+  try {
+    return { parsed: JSON.parse(repaired), repaired: true, error: null };
+  } catch (_) {
+    // Continue to more aggressive repair
+  }
+
+  // Step 5: Try to balance braces/brackets
+  const openBraces = (repaired.match(/{/g) || []).length;
+  const closeBraces = (repaired.match(/}/g) || []).length;
+  const openBrackets = (repaired.match(/\[/g) || []).length;
+  const closeBrackets = (repaired.match(/]/g) || []).length;
+
+  if (openBraces > closeBraces) {
+    repaired += '}'.repeat(openBraces - closeBraces);
+  }
+  if (openBrackets > closeBrackets) {
+    repaired += ']'.repeat(openBrackets - closeBrackets);
+  }
+
+  // Step 6: Final parse attempt
+  try {
+    return { parsed: JSON.parse(repaired), repaired: true, error: null };
+  } catch (err) {
+    return { parsed: null, repaired: false, error: err.message };
+  }
+}

--- a/tests/unit/repair-llm-json.test.js
+++ b/tests/unit/repair-llm-json.test.js
@@ -1,0 +1,82 @@
+/**
+ * Repair LLM JSON — Unit Tests
+ * SD: SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-B
+ */
+
+import { describe, it, expect } from 'vitest';
+import { repairLLMJson } from '../../lib/utils/repair-llm-json.js';
+
+describe('repairLLMJson', () => {
+  it('returns null for null/undefined input', () => {
+    expect(repairLLMJson(null).parsed).toBeNull();
+    expect(repairLLMJson(undefined).parsed).toBeNull();
+    expect(repairLLMJson('').parsed).toBeNull();
+  });
+
+  it('parses valid JSON without repair', () => {
+    const result = repairLLMJson('{"key": "value"}');
+    expect(result.parsed).toEqual({ key: 'value' });
+    expect(result.repaired).toBe(false);
+  });
+
+  it('strips markdown code fences', () => {
+    const input = '```json\n{"revenue": 1000}\n```';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ revenue: 1000 });
+    expect(result.repaired).toBe(false); // Stripping fences then parse succeeds
+  });
+
+  it('strips code fences without json label', () => {
+    const input = '```\n{"data": true}\n```';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ data: true });
+  });
+
+  it('fixes trailing comma in object', () => {
+    const input = '{"a": 1, "b": 2,}';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ a: 1, b: 2 });
+    expect(result.repaired).toBe(true);
+  });
+
+  it('fixes trailing comma in array', () => {
+    const input = '[1, 2, 3,]';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual([1, 2, 3]);
+    expect(result.repaired).toBe(true);
+  });
+
+  it('fixes missing closing brace', () => {
+    const input = '{"revenue": {"year1": 5000}';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ revenue: { year1: 5000 } });
+    expect(result.repaired).toBe(true);
+  });
+
+  it('fixes missing closing bracket', () => {
+    const input = '{"items": [1, 2, 3]';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ items: [1, 2, 3] });
+    expect(result.repaired).toBe(true);
+  });
+
+  it('handles combined issues (fence + trailing comma)', () => {
+    const input = '```json\n{"cost": 500, "timeline": "6mo",}\n```';
+    const result = repairLLMJson(input);
+    expect(result.parsed).toEqual({ cost: 500, timeline: '6mo' });
+    expect(result.repaired).toBe(true);
+  });
+
+  it('returns error for completely unparseable input', () => {
+    const result = repairLLMJson('This is not JSON at all');
+    expect(result.parsed).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+
+  it('handles deeply nested JSON', () => {
+    const input = '{"forecast": {"revenue": {"y1": 1000, "y2": 5000}, "costs": {"y1": 800}}}';
+    const result = repairLLMJson(input);
+    expect(result.parsed.forecast.revenue.y2).toBe(5000);
+    expect(result.repaired).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `repairLLMJson()` utility: strips markdown fences, fixes trailing commas, balances braces
- Fix directive truncation: 80→120 chars with word-boundary awareness (no mid-word cuts)
- 11 unit tests for JSON repair, 18 existing design reference tests still pass

## Test plan
- [x] JSON repair tests (11/11)
- [x] Design reference engine tests (18/18)
- [x] Smoke tests (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)