### PR TITLE
feat(SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-C): consolidate Stitch artifacts

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -372,10 +372,8 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     console.error(`[stitch-provisioner] generateScreens fatal error: ${err.message}`);
   }
 
-  // Step 7: Store artifact with curation context
-  await storeStitchArtifact(ventureId, project.project_id, project.url, 0);
-
-  // Step 8: Store curation prompts + generation results
+  // Step 7+8 (consolidated): Store single artifact with project + curation context
+  // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-C: merged stitch_project into stitch_curation
   await writeArtifact(supabase, {
     ventureId,
     lifecycleStage: 15,
@@ -384,6 +382,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     artifactData: {
       project_id: project.project_id,
       url: project.url,
+      screen_count: screens.length,
       brand_tokens: brandTokens,
       screen_prompts: curationPrompts.map((prompt, i) => ({
         screen_name: screens[i]?.name || `Screen ${i + 1}`,


### PR DESCRIPTION
## Summary
- Remove redundant `stitch_project` artifact write at S15
- Merge project_id, url, screen_count into single `stitch_curation` artifact
- Reduces from 2 Stitch artifacts to 1 per venture

## Test plan
- [x] Smoke tests pass (15/15)
- [x] stitch_curation artifact contains all fields (project_id, url, screen_count, screen_prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)