### PR TITLE
fix: wire JSON repair into forecast + chairman decision health_score

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -197,6 +197,20 @@ export async function createOrReusePendingDecision({
     return { id: existing.id, isNew: false };
   }
 
+  // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-A: Populate health_score from latest stage
+  let healthScore = null;
+  try {
+    const { data: latestStage } = await supabase
+      .from('venture_stage_work')
+      .select('health_score')
+      .eq('venture_id', ventureId)
+      .not('health_score', 'is', null)
+      .order('lifecycle_stage', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    healthScore = latestStage?.health_score || null;
+  } catch (_) { /* non-fatal */ }
+
   // Create new PENDING decision — always set decision_type to avoid NULL
   // (SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: NULL decision_type breaks .neq filters)
   const { data: created, error } = await supabase
@@ -209,6 +223,7 @@ export async function createOrReusePendingDecision({
       decision_type: decisionType,
       summary: summary || `Gate decision required for stage ${stageNumber}`,
       brief_data: briefData,
+      health_score: healthScore,
     })
     .select('id')
     .single();

--- a/lib/eva/stage-zero/modeling.js
+++ b/lib/eva/stage-zero/modeling.js
@@ -151,7 +151,16 @@ Return JSON (use actual numbers based on YOUR analysis, not placeholder values):
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {
-      const forecast = JSON.parse(jsonMatch[0]);
+      // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-B: Use repair utility for malformed LLM JSON
+      const { repairLLMJson } = await import('../../utils/repair-llm-json.js');
+      const { parsed: forecast, repaired, error: repairError } = repairLLMJson(jsonMatch[0]);
+      if (!forecast) {
+        logger.warn(`   Warning: Forecast JSON repair failed: ${repairError}`);
+        return defaultForecastResult('JSON repair failed');
+      }
+      if (repaired) {
+        logger.warn('   [forecast] JSON repaired (trailing comma or missing brace) — monitor frequency');
+      }
       return {
         component: 'forecast',
         rubric_scores: forecast.rubric_scores || defaultRubricScores(),


### PR DESCRIPTION
## Summary
Two gaps found during post-implementation review against architecture plan:
1. `repairLLMJson()` was not integrated into `modeling.js` forecast generator (S0 JSON parse failures persisted)
2. `chairman_decisions.health_score` was not populated at decision creation time

## Test plan
- [x] Smoke tests pass (15/15)
- [x] JSON repair tests pass (11/11)
- [x] Health score tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)