### PR TITLE
fix: S15 Stitch hook fallback to ia_sitemap + artifact data source

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -135,12 +135,27 @@ function extractStage15Screens(stage15Artifacts) {
   if (Array.isArray(stage15Artifacts?.wireframes?.screens)) {
     return stage15Artifacts.wireframes.screens;
   }
+  // Try wireframe_convergence.final_screens or .screens
+  if (Array.isArray(stage15Artifacts?.wireframe_convergence?.final_screens)) {
+    return stage15Artifacts.wireframe_convergence.final_screens;
+  }
+  if (Array.isArray(stage15Artifacts?.wireframe_convergence?.screens)) {
+    return stage15Artifacts.wireframe_convergence.screens;
+  }
   // Try navigation_flows as screen source
   if (Array.isArray(stage15Artifacts?.navigation_flows)) {
     return stage15Artifacts.navigation_flows.map(flow => ({
       name: flow.name || flow.screen_name,
       purpose: flow.purpose || flow.description,
       key_components: flow.components || [],
+    }));
+  }
+  // Fallback: derive screens from ia_sitemap pages (when wireframes are null)
+  if (Array.isArray(stage15Artifacts?.ia_sitemap?.pages)) {
+    return stage15Artifacts.ia_sitemap.pages.map(page => ({
+      name: page.name || page.path,
+      purpose: page.purpose || page.description || '',
+      key_components: page.components || page.sections || [],
     }));
   }
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1993,7 +1993,10 @@ export class StageExecutionWorker {
     // SD-LEO-FIX-STITCH-INTEGRATION-WIRING-001: Route through provisioner for full business logic + artifact storage
     const { postStage15Hook } = await import('./bridge/stitch-provisioner.js');
     const { logStitchEvent } = await import('./bridge/stitch-adapter.js');
-    const { data: s15Work } = await this._supabase
+    // Read S15 data from venture_stage_work, falling back to venture_artifacts
+    // when advisory_data has null wireframes (wireframe sub-step may have failed)
+    let s15Work = null;
+    const { data: vsw } = await this._supabase
       .from('venture_stage_work')
       .select('advisory_data')
       .eq('venture_id', ventureId)
@@ -2001,6 +2004,23 @@ export class StageExecutionWorker {
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
+
+    if (vsw?.advisory_data && (vsw.advisory_data.wireframes || vsw.advisory_data.screens || vsw.advisory_data.ia_sitemap)) {
+      s15Work = vsw;
+    } else {
+      // Fallback: read from blueprint_wireframes artifact (has ia_sitemap even when wireframes are null)
+      const { data: artifact } = await this._supabase
+        .from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', 15)
+        .eq('artifact_type', 'blueprint_wireframes')
+        .eq('is_current', true)
+        .maybeSingle();
+      if (artifact?.artifact_data) {
+        s15Work = { advisory_data: artifact.artifact_data };
+      }
+    }
 
     // SD-MAN-FIX-S15-DESIGN-STUDIO-001: 480s abort guard — fires before the 600s lock expiry
     const STITCH_PROVISION_TIMEOUT_MS = 480_000;


### PR DESCRIPTION
## Summary
- Add ia_sitemap.pages fallback to extractStage15Screens when wireframes are null
- Read from venture_artifacts when venture_stage_work advisory_data has null wireframes
- Fixes the last remaining issue: S15 Stitch hook not creating stitch_curation artifact

## Test plan
- [x] Smoke tests pass
- [ ] Verify Stitch artifact at S15 in pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)