### PR TITLE
fix: retry wireframe generation (root cause of null wireframes + silent Stitch failure)

### DIFF
--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -158,39 +158,48 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
       wireframeCtx.productHuntRefs = phRefs;
     }
 
-    try {
-      wireframeResult = await analyzeStage15WireframeGenerator(wireframeCtx);
-      logger.log('[Stage15-DesignStudio] Wireframe generation complete', {
-        screenCount: wireframeResult?.screens?.length || 0,
-      });
+    // Retry wireframe generation once on failure (LLM calls can fail transiently)
+    const MAX_WIREFRAME_RETRIES = 2;
+    for (let attempt = 1; attempt <= MAX_WIREFRAME_RETRIES; attempt++) {
+      try {
+        wireframeResult = await analyzeStage15WireframeGenerator(wireframeCtx);
+        logger.log('[Stage15-DesignStudio] Wireframe generation complete' + (attempt > 1 ? ` (retry ${attempt})` : ''), {
+          screenCount: wireframeResult?.screens?.length || 0,
+        });
 
-      // Persist wireframes as a separate artifact
-      if (wireframeResult && ctx.supabase && ctx.ventureId) {
-        try {
-          await writeArtifact(ctx.supabase, {
-            ventureId: ctx.ventureId,
-            lifecycleStage: 15,
-            artifactType: 'blueprint_wireframes',
-            title: 'Design Studio Wireframes (Stage 15)',
-            artifactData: { wireframes: wireframeResult, ia_sitemap: iaResult || null },
-            content: JSON.stringify({ wireframes: wireframeResult, ia_sitemap: iaResult || null }),
-            qualityScore: 70,
-            validationStatus: 'validated',
-            source: 'stage-15-design-studio',
-            visionKey: ctx.visionKey || null,
-            planKey: ctx.planKey || null,
-          });
-          logger.log('[Stage15-DesignStudio] Wireframe artifact persisted');
-        } catch (persistErr) {
-          logger.warn('[Stage15-DesignStudio] Wireframe artifact persist failed (non-fatal)', { error: persistErr.message });
+        // Persist wireframes as a separate artifact
+        if (wireframeResult && ctx.supabase && ctx.ventureId) {
+          try {
+            await writeArtifact(ctx.supabase, {
+              ventureId: ctx.ventureId,
+              lifecycleStage: 15,
+              artifactType: 'blueprint_wireframes',
+              title: 'Design Studio Wireframes (Stage 15)',
+              artifactData: { wireframes: wireframeResult, ia_sitemap: iaResult || null },
+              content: JSON.stringify({ wireframes: wireframeResult, ia_sitemap: iaResult || null }),
+              qualityScore: 70,
+              validationStatus: 'validated',
+              source: 'stage-15-design-studio',
+              visionKey: ctx.visionKey || null,
+              planKey: ctx.planKey || null,
+            });
+            logger.log('[Stage15-DesignStudio] Wireframe artifact persisted');
+          } catch (persistErr) {
+            logger.warn('[Stage15-DesignStudio] Wireframe artifact persist failed (non-fatal)', { error: persistErr.message });
+          }
+        }
+        break; // Success — exit retry loop
+      } catch (err) {
+        if (wireframeGatingEnabled) {
+          logger.error('[Stage15-DesignStudio] Wireframe generation FAILED (fail-closed, EVA_WIREFRAME_GATING_ENABLED=true)', { error: err.message });
+          throw new Error(`[Stage15] Wireframe generation failed under gating: ${err.message}`);
+        }
+        if (attempt < MAX_WIREFRAME_RETRIES) {
+          logger.warn(`[Stage15-DesignStudio] Wireframe generation failed (attempt ${attempt}/${MAX_WIREFRAME_RETRIES}), retrying...`, { error: err.message });
+        } else {
+          logger.warn(`[Stage15-DesignStudio] Wireframe generation failed after ${MAX_WIREFRAME_RETRIES} attempts (non-fatal)`, { error: err.message });
         }
       }
-    } catch (err) {
-      if (wireframeGatingEnabled) {
-        logger.error('[Stage15-DesignStudio] Wireframe generation FAILED (fail-closed, EVA_WIREFRAME_GATING_ENABLED=true)', { error: err.message });
-        throw new Error(`[Stage15] Wireframe generation failed under gating: ${err.message}`);
-      }
-      logger.warn('[Stage15-DesignStudio] Wireframe generation failed (non-fatal)', { error: err.message });
     }
   } else {
     logger.log('[Stage15-DesignStudio] Skipping wireframes — Stage 10 brand data not available');


### PR DESCRIPTION
## Summary
Root cause: wireframe LLM call fails transiently, catch block swallows error (EVA_WIREFRAME_GATING_ENABLED not set), wireframeResult stays null, cascading to no Stitch screens and no design references.

Fix: retry wireframe generation once before giving up. Most LLM failures are transient (JSON parse, timeout).

## Test plan
- [x] Smoke tests pass
- [ ] Verify wireframes non-null in next pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)