### PR TITLE
fix: harden wireframe LLM with parse-aware retry (4-layer defense)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -368,11 +368,31 @@ IMPORTANT:
 
 Output ONLY valid JSON.`;
 
-  // ── Call LLM ───────────────────────────────────────────────────
+  // ── Call LLM (with retry on parse failure) ──────────────────────
   const client = getLLMClient({ purpose: 'content-generation' });
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt, { timeout: 120000 });
-  const usage = extractUsage(response);
-  const parsed = parseJSON(response);
+  let parsed = null;
+  let usage = {};
+  const LLM_MAX_RETRIES = 2;
+  for (let attempt = 1; attempt <= LLM_MAX_RETRIES; attempt++) {
+    const response = await client.complete(SYSTEM_PROMPT, userPrompt, { timeout: 120000 });
+    usage = extractUsage(response);
+    try {
+      parsed = parseJSON(response);
+      if (parsed && (Array.isArray(parsed.screens) || parsed.wireframes)) {
+        break; // Valid response with screens — exit retry loop
+      }
+      // Parsed but no screens — log and retry
+      logger.warn(`[Stage15-WF] LLM returned valid JSON but no screens (attempt ${attempt}/${LLM_MAX_RETRIES})`);
+      if (attempt < LLM_MAX_RETRIES) continue;
+      // Last attempt — use whatever we got
+      parsed = parsed || {};
+    } catch (parseErr) {
+      logger.warn(`[Stage15-WF] LLM JSON parse failed (attempt ${attempt}/${LLM_MAX_RETRIES}): ${parseErr.message.substring(0, 100)}`);
+      if (attempt >= LLM_MAX_RETRIES) {
+        throw new Error(`[Stage15-WF] Wireframe LLM failed after ${LLM_MAX_RETRIES} attempts: ${parseErr.message}`);
+      }
+    }
+  }
 
   let llmFallbackCount = 0;
   const personaNames = stage10Data.customerPersonas.map(p => p.name);


### PR DESCRIPTION
## Summary
Wireframe LLM call now retries on parse failure (2 attempts). Validates response contains screens array before accepting. Combined with stage-level retry, ia_sitemap fallback, and S17 backup, creates 4-layer defense against wireframe generation failures.

## Test plan
- [x] Smoke tests pass
- [ ] Verify wireframes non-null in next pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)