### PR TITLE
feat(SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-A): validateLLMResponse utility + stage schemas

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -14,6 +14,8 @@
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+import { validateLLMResponse } from '../../utils/validate-llm-response.js';
+import { S15_WIREFRAME_SCHEMA } from '../../utils/stage-response-schemas.js';
 
 // ── Constants ────────────────────────────────────────────────────────
 const MIN_SCREENS = 5;
@@ -379,6 +381,12 @@ Output ONLY valid JSON.`;
     try {
       parsed = parseJSON(response);
       if (parsed && (Array.isArray(parsed.screens) || parsed.wireframes)) {
+        // SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-A: Validate structure after parse
+        const validation = validateLLMResponse(parsed, S15_WIREFRAME_SCHEMA);
+        if (!validation.valid) {
+          logger.warn(`[Stage15-WF] Schema validation failed (attempt ${attempt}/${LLM_MAX_RETRIES}): ${validation.errors.join('; ')}`);
+          if (attempt < LLM_MAX_RETRIES) continue;
+        }
         break; // Valid response with screens — exit retry loop
       }
       // Parsed but no screens — log and retry

--- a/lib/eva/stage-zero/modeling.js
+++ b/lib/eva/stage-zero/modeling.js
@@ -161,6 +161,14 @@ Return JSON (use actual numbers based on YOUR analysis, not placeholder values):
       if (repaired) {
         logger.warn('   [forecast] JSON repaired (trailing comma or missing brace) — monitor frequency');
       }
+      // SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-A: Validate forecast structure
+      const { validateLLMResponse } = await import('../utils/validate-llm-response.js');
+      const { S0_FORECAST_SCHEMA } = await import('../utils/stage-response-schemas.js');
+      const validation = validateLLMResponse(forecast, S0_FORECAST_SCHEMA);
+      if (!validation.valid) {
+        logger.warn(`   [forecast] Schema validation failed: ${validation.errors.join('; ')}`);
+        return defaultForecastResult(`Schema validation failed: ${validation.errors.join(', ')}`);
+      }
       return {
         component: 'forecast',
         rubric_scores: forecast.rubric_scores || defaultRubricScores(),

--- a/lib/eva/utils/stage-response-schemas.js
+++ b/lib/eva/utils/stage-response-schemas.js
@@ -1,0 +1,43 @@
+/**
+ * Per-stage LLM response schemas for validateLLMResponse.
+ *
+ * Each schema defines required fields, their types, and constraints.
+ * Only required fields are checked — extra fields are always allowed.
+ *
+ * SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-A
+ */
+
+/**
+ * S0 Forecast schema.
+ * Expects revenue_projections, cost_breakdown, and timeline as objects.
+ */
+export const S0_FORECAST_SCHEMA = {
+  revenue_projections: { type: 'object', required: true },
+  cost_breakdown: { type: 'object', required: true },
+  timeline: { type: 'object', required: true },
+};
+
+/**
+ * S5 Financial Model schema.
+ * Expects metrics array and projections object.
+ */
+export const S5_FINANCIAL_SCHEMA = {
+  metrics: { type: 'array', required: true },
+  projections: { type: 'object', required: true },
+};
+
+/**
+ * S15 Wireframe schema.
+ * Expects screens array with min 3 items, each having name and ascii_layout.
+ */
+export const S15_WIREFRAME_SCHEMA = {
+  screens: {
+    type: 'array',
+    required: true,
+    minLength: 3,
+    items: {
+      name: { required: true },
+      ascii_layout: { required: true },
+    },
+  },
+};

--- a/lib/eva/utils/validate-llm-response.js
+++ b/lib/eva/utils/validate-llm-response.js
@@ -1,0 +1,73 @@
+/**
+ * Validate parsed LLM response against a stage-specific schema.
+ *
+ * Called AFTER parseJSON succeeds — validates structure, not syntax.
+ * Pure JS, zero dependencies, deterministic.
+ *
+ * SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-A
+ *
+ * @param {Object} parsed - Parsed JSON from LLM response
+ * @param {Object} schema - Schema definition (see stage-response-schemas.js)
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateLLMResponse(parsed, schema) {
+  const errors = [];
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { valid: false, errors: ['Response is null or not an object'] };
+  }
+
+  if (!schema || typeof schema !== 'object') {
+    return { valid: true, errors: [] };
+  }
+
+  for (const [field, rule] of Object.entries(schema)) {
+    if (!rule.required) continue;
+
+    const value = parsed[field];
+
+    // Check presence
+    if (value === undefined || value === null) {
+      errors.push(`Missing required field: ${field}`);
+      continue;
+    }
+
+    // Check type
+    if (rule.type === 'array' && !Array.isArray(value)) {
+      errors.push(`Field "${field}" must be an array, got ${typeof value}`);
+      continue;
+    }
+    if (rule.type === 'object' && (typeof value !== 'object' || Array.isArray(value))) {
+      errors.push(`Field "${field}" must be an object, got ${Array.isArray(value) ? 'array' : typeof value}`);
+      continue;
+    }
+    if (rule.type === 'string' && typeof value !== 'string') {
+      errors.push(`Field "${field}" must be a string, got ${typeof value}`);
+      continue;
+    }
+    if (rule.type === 'number' && typeof value !== 'number') {
+      errors.push(`Field "${field}" must be a number, got ${typeof value}`);
+      continue;
+    }
+
+    // Check minLength for arrays
+    if (rule.type === 'array' && rule.minLength && value.length < rule.minLength) {
+      errors.push(`Field "${field}" must have at least ${rule.minLength} items, got ${value.length}`);
+    }
+
+    // Check nested fields (items schema for arrays)
+    if (rule.type === 'array' && rule.items && Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const item = value[i];
+        if (!item || typeof item !== 'object') continue;
+        for (const [nestedField, nestedRule] of Object.entries(rule.items)) {
+          if (nestedRule.required && (item[nestedField] === undefined || item[nestedField] === null)) {
+            errors.push(`${field}[${i}] missing required field: ${nestedField}`);
+          }
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/tests/unit/validate-llm-response.test.js
+++ b/tests/unit/validate-llm-response.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { validateLLMResponse } from '../../lib/eva/utils/validate-llm-response.js';
+import {
+  S0_FORECAST_SCHEMA,
+  S5_FINANCIAL_SCHEMA,
+  S15_WIREFRAME_SCHEMA,
+} from '../../lib/eva/utils/stage-response-schemas.js';
+
+describe('validateLLMResponse', () => {
+  it('returns valid for conforming input', () => {
+    const schema = { name: { type: 'string', required: true } };
+    const result = validateLLMResponse({ name: 'test' }, schema);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns invalid for null input', () => {
+    const result = validateLLMResponse(null, { x: { required: true } });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('null');
+  });
+
+  it('returns invalid for undefined input', () => {
+    const result = validateLLMResponse(undefined, { x: { required: true } });
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns valid when schema is null', () => {
+    const result = validateLLMResponse({ anything: true }, null);
+    expect(result.valid).toBe(true);
+  });
+
+  it('catches missing required field', () => {
+    const schema = { name: { type: 'string', required: true } };
+    const result = validateLLMResponse({}, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('name');
+  });
+
+  it('catches wrong type (expected array, got object)', () => {
+    const schema = { items: { type: 'array', required: true } };
+    const result = validateLLMResponse({ items: {} }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('array');
+  });
+
+  it('catches wrong type (expected object, got array)', () => {
+    const schema = { config: { type: 'object', required: true } };
+    const result = validateLLMResponse({ config: [] }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('object');
+  });
+
+  it('catches array minLength violation', () => {
+    const schema = { items: { type: 'array', required: true, minLength: 3 } };
+    const result = validateLLMResponse({ items: [1] }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('3');
+  });
+
+  it('allows extra fields', () => {
+    const schema = { name: { type: 'string', required: true } };
+    const result = validateLLMResponse({ name: 'test', bonus: true, extra: 42 }, schema);
+    expect(result.valid).toBe(true);
+  });
+
+  it('reports all errors, not just first', () => {
+    const schema = {
+      a: { type: 'string', required: true },
+      b: { type: 'number', required: true },
+      c: { type: 'array', required: true },
+    };
+    const result = validateLLMResponse({}, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+  });
+
+  it('validates nested items in arrays', () => {
+    const schema = {
+      screens: {
+        type: 'array',
+        required: true,
+        items: { name: { required: true }, layout: { required: true } },
+      },
+    };
+    const result = validateLLMResponse({
+      screens: [{ name: 'Home' }, { name: 'About', layout: 'grid' }],
+    }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('screens[0]') && e.includes('layout'))).toBe(true);
+  });
+
+  it('skips non-required fields', () => {
+    const schema = { opt: { type: 'string', required: false } };
+    const result = validateLLMResponse({}, schema);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('S15_WIREFRAME_SCHEMA', () => {
+  it('validates a complete wireframe response', () => {
+    const valid = {
+      screens: [
+        { name: 'Home', ascii_layout: '+--header--+' },
+        { name: 'Dashboard', ascii_layout: '+--sidebar--+' },
+        { name: 'Settings', ascii_layout: '+--form--+' },
+      ],
+    };
+    const result = validateLLMResponse(valid, S15_WIREFRAME_SCHEMA);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects response with no screens', () => {
+    const result = validateLLMResponse({ wireframes: {} }, S15_WIREFRAME_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('screens');
+  });
+
+  it('rejects response with too few screens', () => {
+    const result = validateLLMResponse({
+      screens: [{ name: 'Home', ascii_layout: 'x' }],
+    }, S15_WIREFRAME_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('3');
+  });
+
+  it('rejects screen missing ascii_layout', () => {
+    const result = validateLLMResponse({
+      screens: [
+        { name: 'Home' },
+        { name: 'About', ascii_layout: 'x' },
+        { name: 'Contact', ascii_layout: 'x' },
+      ],
+    }, S15_WIREFRAME_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('ascii_layout'))).toBe(true);
+  });
+});
+
+describe('S0_FORECAST_SCHEMA', () => {
+  it('validates a complete forecast', () => {
+    const result = validateLLMResponse({
+      revenue_projections: { y1: 100000 },
+      cost_breakdown: { dev: 50000 },
+      timeline: { launch: 'Q2' },
+    }, S0_FORECAST_SCHEMA);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects forecast missing cost_breakdown', () => {
+    const result = validateLLMResponse({
+      revenue_projections: {},
+      timeline: {},
+    }, S0_FORECAST_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('cost_breakdown');
+  });
+
+  it('rejects forecast with all fields missing', () => {
+    const result = validateLLMResponse({}, S0_FORECAST_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+  });
+});
+
+describe('S5_FINANCIAL_SCHEMA', () => {
+  it('validates a complete financial model', () => {
+    const result = validateLLMResponse({
+      metrics: [{ name: 'ARR' }],
+      projections: { y1: 100 },
+    }, S5_FINANCIAL_SCHEMA);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects model missing metrics', () => {
+    const result = validateLLMResponse({
+      projections: {},
+    }, S5_FINANCIAL_SCHEMA);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('metrics');
+  });
+});


### PR DESCRIPTION
## Summary
- Create `validateLLMResponse(parsed, schema)` utility for structural contract enforcement on LLM responses after `parseJSON` succeeds
- Define per-stage schemas for S0 forecast, S5 financial, and S15 wireframe responses
- Wire into S15 wireframe generator retry loop (validation failure triggers retry) and S0 forecast fallback (returns defaultForecastResult)

## Test plan
- [x] 21 unit tests covering valid/invalid inputs, null handling, type checking, nested validation, all 3 schemas
- [ ] Smoke: run venture through S15 and verify wireframes non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)