### PR TITLE
fix: add git fetch --prune before PR_MERGE_VERIFICATION gate

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -440,6 +440,15 @@ export function createPRMergeVerificationGate() {
           try {
             const repoPath = repo === 'rickfelix/ehg' ? getRepoPath('EHG') : getRepoPath('EHG_Engineer');
 
+            // SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-B RCA: prune stale remote-tracking refs
+            // before checking branches. Without this, squash-merged branches whose remote was
+            // deleted on GitHub still appear in `git branch -r` and trigger false failures.
+            try {
+              execSync('git fetch --prune origin', { encoding: 'utf8', cwd: repoPath, timeout: 30000 });
+            } catch (_fetchErr) {
+              console.log('   ⚠️  Could not fetch latest remote state — branch check may use stale data');
+            }
+
             const branchList = execSync('git branch -r', { encoding: 'utf8', cwd: repoPath, timeout: 10000 });
 
             for (const pattern of branchPatterns) {


### PR DESCRIPTION
## Summary
- Add `git fetch --prune origin` before `git branch -r` in the PR_MERGE_VERIFICATION gate
- Prevents false failures when squash-merged branches have stale remote-tracking refs

## Root Cause
After `gh pr merge --squash --delete-branch`, the remote branch is deleted on GitHub but the local `refs/remotes/origin/feat/...` ref persists until pruned. The gate saw this stale ref and reported "1 unmerged branch" even though the PR was already merged.

## Test plan
- [x] Verified fix resolves the issue in SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-B session
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)