### PR TITLE
fix: Path C fire-and-forget hooks + rejection to_phase constraint

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1913,7 +1913,10 @@ export class StageExecutionWorker {
     this._logStageTransition(ventureId, fromStage, 'completed', durationMs, result).catch(() => {});
 
     // Side-effect 4: Post-stage hooks (Stitch S15, DocGen S17, SD Bridge S19)
-    await this._runPostStageHooks(ventureId, fromStage);
+    // Fire-and-forget to avoid blocking stage advancement (5-8 min delay on Path C)
+    // Matches Paths A/B fix from SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-C
+    this._runPostStageHooks(ventureId, fromStage).catch(e =>
+      this._logger.warn(`[Worker] Post-hook S${fromStage} failed (fire-and-forget): ${e.message}`));
 
     // Side-effect 5: Record advancement type in advisory_data
     try {

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -257,7 +257,8 @@ export class HandoffRecorder {
       id: executionId,
       template_id: template?.id,
       from_phase: handoffType.split('-')[0],
-      to_phase: handoffType.split('-')[2],
+      // LEAD-FINAL-APPROVAL splits to 'APPROVAL' which violates CHECK constraint (LEAD/PLAN/EXEC only)
+      to_phase: (() => { const p = handoffType.split('-')[2]; return ['LEAD', 'PLAN', 'EXEC'].includes(p) ? p : 'LEAD'; })(),
       sd_id: sdUuid,
       handoff_type: handoffType,
       status: 'rejected',


### PR DESCRIPTION
## Summary
- Make Path C (`_advanceStage`) post-stage hooks fire-and-forget, matching Paths A/B fix from PR #2928. Eliminates 137s S15→S16 delay.
- Fix `HandoffRecorder` rejection path parsing `LEAD-FINAL-APPROVAL` as `to_phase='APPROVAL'` (violates CHECK constraint). Falls back to `'LEAD'`.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] S12 duplicate already resolved by dedup guard (PR #2914) — confirmed single write site

🤖 Generated with [Claude Code](https://claude.com/claude-code)