### PR TITLE
fix: _advanceStage and _writeHealthScore UPDATE→UPSERT (zero stage_work rows)

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1863,11 +1863,18 @@ export class StageExecutionWorker {
         .eq('lifecycle_stage', completedStage)
         .maybeSingle();
       const healthScore = computeHealthScore(stageWork?.advisory_data);
+      // RCA: Use UPSERT — row may not exist if _syncStageWork was skipped (early-exit paths)
+      const now = new Date().toISOString();
       await this._supabase
         .from('venture_stage_work')
-        .update({ health_score: healthScore })
-        .eq('venture_id', ventureId)
-        .eq('lifecycle_stage', completedStage);
+        .upsert({
+          venture_id: ventureId,
+          lifecycle_stage: completedStage,
+          health_score: healthScore,
+          stage_status: 'completed',
+          completed_at: now,
+          updated_at: now,
+        }, { onConflict: 'venture_id,lifecycle_stage' });
       this._logger.log(`[Worker] S${completedStage} health_score: ${healthScore}`);
     } catch (err) {
       this._logger.warn(`[Worker] Health score failed (non-fatal): ${err.message}`);
@@ -1884,13 +1891,10 @@ export class StageExecutionWorker {
       .eq('id', ventureId);
 
     // Side-effect 2: Mark venture_stage_work as completed
-    await this._supabase
-      .from('venture_stage_work')
-      .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
-      .eq('venture_id', ventureId)
-      .eq('lifecycle_stage', fromStage);
-
-    // Side-effect 2.5: Compute and write health score (SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-A)
+    // RCA: _advanceStage is called by 5+ early-exit paths that skip _syncStageWork.
+    // Using UPSERT ensures the row is created even if _syncStageWork was never called.
+    const now = new Date().toISOString();
+    let healthScore = 'green';
     try {
       const { computeHealthScore } = await import('./health-score-computer.js');
       const { data: stageWork } = await this._supabase
@@ -1899,15 +1903,22 @@ export class StageExecutionWorker {
         .eq('venture_id', ventureId)
         .eq('lifecycle_stage', fromStage)
         .maybeSingle();
-      const healthScore = computeHealthScore(stageWork?.advisory_data);
-      await this._supabase
-        .from('venture_stage_work')
-        .update({ health_score: healthScore })
-        .eq('venture_id', ventureId)
-        .eq('lifecycle_stage', fromStage);
+      healthScore = computeHealthScore(stageWork?.advisory_data);
     } catch (err) {
       this._logger.warn(`[Worker] Health score computation failed (non-fatal): ${err.message}`);
     }
+
+    await this._supabase
+      .from('venture_stage_work')
+      .upsert({
+        venture_id: ventureId,
+        lifecycle_stage: fromStage,
+        stage_status: 'completed',
+        health_score: healthScore,
+        started_at: now,
+        completed_at: now,
+        updated_at: now,
+      }, { onConflict: 'venture_id,lifecycle_stage' });
 
     // Side-effect 3: Audit log
     this._logStageTransition(ventureId, fromStage, 'completed', durationMs, result).catch(() => {});


### PR DESCRIPTION
## Summary
- Change `_advanceStage` from UPDATE to UPSERT on `venture_stage_work` (line 1887)
- Change `_writeHealthScore` from UPDATE to UPSERT (line 1866)
- Root cause: 5+ early-exit paths skip `_syncStageWork` (the only INSERT path), so UPDATE silently affects 0 rows

## Evidence
- BriefGenius monitoring: S0-S17 completed with 0 `venture_stage_work` rows
- Cascading: S15 Stitch hook reads `venture_stage_work.advisory_data` → null → 0 screens → no artifact

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Run new venture through S0-S17 and verify `venture_stage_work` rows match completed stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)