### PR TITLE
fix: add /chairman/eva-friday to allowed route patterns

### DIFF
--- a/lib/eva/chairman-dashboard-scope.js
+++ b/lib/eva/chairman-dashboard-scope.js
@@ -35,6 +35,7 @@ const ALLOWED_ROUTE_PATTERNS = [
   /^\/chairman\/health/,           // Health dashboard
   /^\/chairman\/notifications/,    // Notification settings
   /^\/chairman\/stakeholder-response/, // V02: Stakeholder response acknowledgment
+  /^\/chairman\/eva-friday/,          // V03: Friday Management Review dashboard
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add `/chairman/eva-friday` to `ALLOWED_ROUTE_PATTERNS` in `chairman-dashboard-scope.js`
- Closes CISO-identified security control gap where the EVA Friday Management Review route was missing from governance scope

## SD
- `SD-FIX-EVA-FRIDAY-DATA-ORCH-001-A` (Child A of EVA Friday Dashboard orchestrator)
- Vision: `VISION-EVA-FRIDAY-PIPELINE-UI-L2-001`

## Test plan
- [ ] Verify regex matches `/chairman/eva-friday` route
- [ ] Verify no other routes are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)