### PR TITLE
fix: isolate Stitch SDK client per parallel screen generation

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -476,12 +476,15 @@ export async function generateScreens(projectId, prompts, ventureId) {
   }
 
   // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001: Parallel generation with bounded concurrency
-  // Each prompt gets its own fresh client to avoid transport conflicts.
-  // Promise.allSettled ensures one failure doesn't block the rest.
+  // RCA: resetClient()/getClient() share a module-level _stitchInstance variable.
+  // When 7 parallel calls race, they stomp on each other's transport state, causing
+  // "Already connected to a transport" errors on 6/7 screens. Fix: create a fully
+  // independent client per call without touching the shared _stitchInstance.
   const generateOne = async (prompt) => {
-    await resetClient();
-    const client = await getClient();
-    const project = client.project(projectId);
+    const apiKey = getApiKey();
+    const sdk = await getSDK();
+    const isolatedClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey }));
+    const project = isolatedClient.project(projectId);
 
     try {
       const screen = await instrumentedCall('generateScreen', () => project.generate(prompt));


### PR DESCRIPTION
## Summary
- Each parallel screen generation now creates a fully independent `StitchToolClient` instance
- Previously, `resetClient()`/`getClient()` shared a module-level `_stitchInstance` — 7 parallel calls stomped on each other's MCP transport

## Root cause
`Promise.allSettled(prompts.map(generateOne))` fires 7 calls simultaneously. Each called `resetClient()` then `getClient()`, both operating on the shared `_stitchInstance` variable. The SDK's MCP transport enters "already connected" state when a second call tries to use a transport that another parallel call connected first. Result: 6/7 screens fail with transport collision, only ~2 survive.

## Evidence
BriefGenius monitoring: 7 screen_prompts sent, generation_results show 6x "Already connected to a transport" + 1x "fetch failed". Only 2/7 screens appeared in Google Stitch.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Run new venture through S15 and verify all 7 screens appear in Stitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)