### PR TITLE
fix: Stitch fire-and-poll pattern — reliable screen generation

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -475,37 +475,105 @@ export async function generateScreens(projectId, prompts, ventureId) {
     await consumeBudget(ventureId, prompts.length);
   }
 
-  // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001: Parallel generation with bounded concurrency
-  // RCA: resetClient()/getClient() share a module-level _stitchInstance variable.
-  // When 7 parallel calls race, they stomp on each other's transport state, causing
-  // "Already connected to a transport" errors on 6/7 screens. Fix: create a fully
-  // independent client per call without touching the shared _stitchInstance.
-  const generateOne = async (prompt) => {
-    const apiKey = getApiKey();
-    const sdk = await getSDK();
-    const isolatedClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey }));
-    const project = isolatedClient.project(projectId);
+  // Deep research (2026-04-12): Google's Stitch MCP generation takes 45-90s server-side.
+  // The GFE load balancer drops TCP connections after ~30-60s idle timeout. The SDK's MCP
+  // transport becomes permanently broken after a socket drop. This is a confirmed
+  // infrastructure issue (stitch-sdk#114), not a code bug.
+  //
+  // Pattern: Snapshot → Fire → Close → Poll (fire-and-forget with reconciliation)
+  //   1. Snapshot existing screen IDs before each generation
+  //   2. Fire generate() with a fresh client — expect socket drop
+  //   3. Close the client immediately (transport is tainted)
+  //   4. Poll listScreens() with a fresh client until a new screen appears
+  //   5. Wait 3s between screens to avoid throttling (~3 req/min observed limit)
+  const POLL_INTERVAL_MS = 10_000;     // poll every 10s
+  const POLL_TIMEOUT_MS = 180_000;     // 3 min max wait per screen
+  const INTER_SCREEN_DELAY_MS = 3_000; // 3s between screens
+
+  const results = [];
+  const apiKey = getApiKey();
+  const sdk = await getSDK();
+
+  for (let i = 0; i < prompts.length; i++) {
+    const prompt = prompts[i];
+    const label = `[${i + 1}/${prompts.length}]`;
 
     try {
-      const screen = await instrumentedCall('generateScreen', () => project.generate(prompt));
-      const screenId = screen.id || screen.screen_id;
-      console.info(`[stitch-client] generateScreens: returned ${screenId}`);
-      return { prompt: prompt.slice(0, 60), status: 'returned', screen_id: screenId, name: screen.name || prompt.substring(0, 30) };
-    } catch (err) {
-      const msg = err.message || '';
-      const isTransient = /fetch failed|socket|ECONNRESET|other side closed|Already connected|Incomplete API response|expected object at projection path/i.test(msg);
-      if (isTransient) {
-        console.warn(`[stitch-client] generateScreens: transient (server likely processing): ${msg.slice(0, 120)}`);
-        return { prompt: prompt.slice(0, 60), status: 'fired', error: msg };
-      }
-      throw err;
-    }
-  };
+      // Step 1: Snapshot current screens
+      const snapClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
+      const snapProject = snapClient.project(projectId);
+      let beforeScreens = [];
+      try {
+        beforeScreens = await snapProject.screens();
+      } catch { /* empty project or read failure — proceed */ }
+      const knownIds = new Set((beforeScreens || []).map(s => s.screen_id || s.id).filter(Boolean));
+      try { await snapClient.close(); } catch { /* ignore */ }
 
-  const settled = await Promise.allSettled(prompts.map(p => generateOne(p)));
-  const results = settled.map(r =>
-    r.status === 'fulfilled' ? r.value : { prompt: '?', status: 'fired', error: r.reason?.message || 'unknown' }
-  );
+      // Step 2: Fire generate — expect socket drop
+      const genClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
+      const genProject = genClient.project(projectId);
+      let directResult = null;
+      try {
+        directResult = await genProject.generate(prompt);
+      } catch (err) {
+        const msg = err.message || '';
+        const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
+        if (!isTransport) {
+          // Real error (auth, validation, budget) — don't poll
+          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: msg });
+          try { await genClient.close(); } catch { /* ignore */ }
+          continue;
+        }
+        console.info(`[stitch-client] ${label} socket dropped (expected) — polling for completion`);
+      }
+      try { await genClient.close(); } catch { /* always close */ }
+
+      // Step 3: If generate returned directly, we're done
+      if (directResult) {
+        const screenId = directResult.id || directResult.screen_id;
+        console.info(`[stitch-client] ${label} returned directly: ${screenId}`);
+        results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: screenId, name: directResult.name || prompt.substring(0, 30) });
+      } else {
+        // Step 4: Poll for new screen
+        const deadline = Date.now() + POLL_TIMEOUT_MS;
+        let found = null;
+        while (Date.now() < deadline) {
+          await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+          try {
+            const pollClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
+            const afterScreens = await pollClient.project(projectId).screens();
+            try { await pollClient.close(); } catch { /* ignore */ }
+            const newScreens = (afterScreens || []).filter(s => {
+              const sid = s.screen_id || s.id;
+              return sid && !knownIds.has(sid);
+            });
+            if (newScreens.length > 0) {
+              found = newScreens[0];
+              break;
+            }
+          } catch (pollErr) {
+            console.warn(`[stitch-client] ${label} poll error: ${pollErr.message?.slice(0, 80)}`);
+          }
+        }
+        if (found) {
+          const foundId = found.screen_id || found.id;
+          console.info(`[stitch-client] ${label} found via poll: ${foundId}`);
+          results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: foundId, name: found.name || prompt.substring(0, 30) });
+        } else {
+          console.warn(`[stitch-client] ${label} not found after ${POLL_TIMEOUT_MS / 1000}s polling`);
+          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: 'poll timeout' });
+        }
+      }
+    } catch (outerErr) {
+      console.error(`[stitch-client] ${label} unexpected error: ${outerErr.message}`);
+      results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: outerErr.message });
+    }
+
+    // Step 5: Delay between screens to avoid throttling
+    if (i < prompts.length - 1) {
+      await new Promise(r => setTimeout(r, INTER_SCREEN_DELAY_MS));
+    }
+  }
 
   return results;
 }


### PR DESCRIPTION
## Summary
- Replace parallel/retry `generate()` calls with snapshot → fire → close → poll pattern
- Google's Stitch MCP server processes generate() even after dropping the TCP connection
- Previous retries created duplicates (BriefGenius: 17 screens instead of 7)
- Sequential with 3s inter-screen delay, poll listScreens() for up to 3min per screen
- Fixed screen_id field detection (API returns `screen_id`, not `id`)

## Root cause
Stitch's MCP generate endpoint takes 45-90s but Google's GFE drops TCP after ~30-60s. The SDK transport becomes permanently broken. Every retry fires a new server-side generation. Confirmed by stitch-sdk#114 and community implementations.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Verified: all 7 "failed" generate() calls created screens server-side (17 total)
- [ ] Next venture: verify 7/7 screens appear with no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)