### PR TITLE
fix: normalize brand_tokens to strings at extraction source

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -99,7 +99,13 @@ function extractStage11Tokens(stage11Artifacts) {
     stage11Artifacts?.visual_identity?.colorPalette ||   // mixed-case fallback
     null;
   if (colorSource) {
-    tokens.colors = Array.isArray(colorSource) ? colorSource : [colorSource];
+    // Normalize colors to strings — LLM may produce objects {hex, name, usage, personaAlignment}
+    const rawColors = Array.isArray(colorSource) ? colorSource : [colorSource];
+    tokens.colors = rawColors.map(c => {
+      if (typeof c === 'string') return c;
+      if (c && typeof c === 'object') return String(c.hex || c.value || c.name || JSON.stringify(c));
+      return String(c);
+    });
   }
 
   // Typography — SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: fix path resolution
@@ -109,9 +115,13 @@ function extractStage11Tokens(stage11Artifacts) {
     stage11Artifacts?.visual_identity?.typography ||  // snake_case fallback
     null;
   if (typoSource) {
-    tokens.fonts = Array.isArray(typoSource)
-      ? typoSource.map(t => typeof t === 'string' ? t : t.name || t.family || t)
-      : [typoSource];
+    // Normalize fonts to strings — LLM may produce objects {body, heading, rationale}
+    const rawFonts = Array.isArray(typoSource) ? typoSource : [typoSource];
+    tokens.fonts = rawFonts.map(t => {
+      if (typeof t === 'string') return t;
+      if (t && typeof t === 'object') return String(t.name || t.family || t.heading || t.body || JSON.stringify(t));
+      return String(t);
+    });
   }
 
   // Brand expression / personality


### PR DESCRIPTION
## Summary
- `extractStage11Tokens` now always produces `string[]` for colors and fonts
- Colors: extracts `hex || value || name` from LLM objects, falls back to `JSON.stringify`
- Fonts: extracts `name || family || heading || body` from LLM objects, falls back to `JSON.stringify`
- This is the systemic backend fix; ehg#447 frontend normalization remains as defense-in-depth

## Root cause
LLM produces colors as `{hex, name, usage, personaAlignment}` and fonts as `{body, heading, rationale}`. The extractor passed these through raw, causing React render crash in `BrandTokensSummary`.

## Test plan
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)