### PR TITLE
fix: write stitch_curation artifact before generation + work_type UPSERT

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -365,22 +365,42 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     ventureId,
   });
 
-  // Step 6: Fire generateScreens for each prompt (fire-and-forget).
-  //
-  // Why: API-created empty Stitch projects are non-interactive in the web UI —
-  // the chairman can't paste prompts until the project has been "activated" by
-  // at least one generate() call. Firing all screens via the API both seeds the
-  // project AND saves the chairman from manual copy-paste.
-  //
-  // Fire-and-forget is required because Stitch's generate_screen_from_text
-  // takes 30-60s and often drops the HTTP response mid-stream. stitch-client's
-  // generateScreens handles this by catching socket errors and returning "fired"
-  // status — the server-side generation proceeds regardless.
-  //
-  // Known Stitch bug: list_screens returns empty until the project is opened
-  // in an authenticated browser. The chairman triggers sync with a one-time
-  // click on the "Open in Stitch to Activate Sync" button in Stage 17 UI.
-  // Reference: https://discuss.ai.google.dev/t/list-screens-returns-empty-after-generate-screen-from-text-until-project-is-opened-in-browser/123348
+  // Step 6: Write stitch_curation artifact IMMEDIATELY with project + prompts.
+  // RCA: The 480s abort guard in stage-execution-worker.js kills the hook before
+  // generateScreens finishes (7 screens * 180s poll = 21 min > 480s timeout).
+  // By writing the artifact first, we guarantee the project_id + prompts are
+  // persisted even if generation times out. The chairman can always trigger
+  // generation manually via the Stitch UI using the saved prompts.
+  const artifactData = {
+    project_id: project.project_id,
+    url: project.url,
+    screen_count: screens.length,
+    brand_tokens: brandTokens,
+    screen_prompts: curationPrompts.map((prompt, i) => ({
+      screen_name: screens[i]?.name || `Screen ${i + 1}`,
+      prompt,
+    })),
+    generation_results: [],
+    status: 'awaiting_curation',
+    provisioned_at: new Date().toISOString(),
+  };
+
+  await writeArtifact(supabase, {
+    ventureId,
+    lifecycleStage: 15,
+    artifactType: 'stitch_curation',
+    title: 'Stitch Curation Prompts',
+    artifactData,
+    source: 'stitch-provisioner',
+  });
+
+  console.info(`[stitch-provisioner] Project created: ${project.project_id} — artifact persisted`);
+
+  // Step 7: Fire generateScreens (best-effort, may timeout).
+  // Google's Stitch MCP drops TCP after ~30-60s. The fire-and-poll pattern in
+  // stitch-client.js handles this: fire once, poll listScreens(), never retry.
+  // If the hook gets killed by the abort guard, the screens will still be
+  // generated server-side — the chairman can see them in the Stitch web UI.
   let generationResults = [];
   try {
     console.info(`[stitch-provisioner] Firing ${curationPrompts.length} generate() call(s)...`);
@@ -392,35 +412,19 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     const fired = generationResults.filter(r => r.status === 'fired').length;
     const returned = generationResults.filter(r => r.status === 'returned').length;
     console.info(`[stitch-provisioner] Generate results: ${returned} returned, ${fired} fired (socket drop)`);
+
+    // Update artifact with generation results
+    await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 15,
+      artifactType: 'stitch_curation',
+      title: 'Stitch Curation Prompts',
+      artifactData: { ...artifactData, generation_results: generationResults },
+      source: 'stitch-provisioner',
+    });
   } catch (err) {
-    // Only genuine errors (not socket drops) reach here — log but continue.
-    console.error(`[stitch-provisioner] generateScreens fatal error: ${err.message}`);
+    console.error(`[stitch-provisioner] generateScreens error (artifact already persisted): ${err.message}`);
   }
-
-  // Step 7+8 (consolidated): Store single artifact with project + curation context
-  // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-C: merged stitch_project into stitch_curation
-  await writeArtifact(supabase, {
-    ventureId,
-    lifecycleStage: 15,
-    artifactType: 'stitch_curation',
-    title: 'Stitch Curation Prompts',
-    artifactData: {
-      project_id: project.project_id,
-      url: project.url,
-      screen_count: screens.length,
-      brand_tokens: brandTokens,
-      screen_prompts: curationPrompts.map((prompt, i) => ({
-        screen_name: screens[i]?.name || `Screen ${i + 1}`,
-        prompt,
-      })),
-      generation_results: generationResults,
-      status: 'awaiting_curation',
-      provisioned_at: new Date().toISOString(),
-    },
-    source: 'stitch-provisioner',
-  });
-
-  console.info(`[stitch-provisioner] Project created: ${project.project_id}`);
   console.info(`[stitch-provisioner] Chairman: open ${project.url} to activate sync and review screens`);
   console.info(`[stitch-provisioner] ${curationPrompts.length} screen prompt(s) saved for reference`);
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1872,6 +1872,7 @@ export class StageExecutionWorker {
           lifecycle_stage: completedStage,
           health_score: healthScore,
           stage_status: 'completed',
+          work_type: 'artifact_only',
           completed_at: now,
           updated_at: now,
         }, { onConflict: 'venture_id,lifecycle_stage' });
@@ -1914,6 +1915,7 @@ export class StageExecutionWorker {
         venture_id: ventureId,
         lifecycle_stage: fromStage,
         stage_status: 'completed',
+        work_type: 'artifact_only',
         health_score: healthScore,
         started_at: now,
         completed_at: now,


### PR DESCRIPTION
## Summary
- Write `stitch_curation` artifact IMMEDIATELY after project creation, BEFORE `generateScreens`
- Add `work_type: 'artifact_only'` to `_advanceStage` and `_writeHealthScore` UPSERTs (NOT NULL constraint)

## Root cause
The S15 Stitch hook fires `generateScreens` (7 screens * 180s poll = 21 min) but the worker's 480s abort guard kills the hook first. The artifact write was AFTER generation, so it never executed. Fix: write first, generate as best-effort.

## Evidence
Compliance Compass AI: 3 Stitch projects created (hook re-fired on worker restart), only 2/7 screens, 0 `stitch_curation` artifact at S15.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Next venture: verify stitch_curation artifact exists at S15 with project_id + prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)