### PR TITLE
fix: Stitch export — wiring, projectId, fresh clients, drop poll

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -476,19 +476,16 @@ export async function generateScreens(projectId, prompts, ventureId) {
   }
 
   // Deep research (2026-04-12): Google's Stitch MCP generation takes 45-90s server-side.
-  // The GFE load balancer drops TCP connections after ~30-60s idle timeout. The SDK's MCP
-  // transport becomes permanently broken after a socket drop. This is a confirmed
-  // infrastructure issue (stitch-sdk#114), not a code bug.
+  // The GFE drops TCP after ~30-60s, but the server ALWAYS completes the generation.
+  // listScreens() returns empty until the project is opened in a browser (confirmed bug).
   //
-  // Pattern: Snapshot → Fire → Close → Poll (fire-and-forget with reconciliation)
-  //   1. Snapshot existing screen IDs before each generation
-  //   2. Fire generate() with a fresh client — expect socket drop
-  //   3. Close the client immediately (transport is tainted)
-  //   4. Poll listScreens() with a fresh client until a new screen appears
-  //   5. Wait 3s between screens to avoid throttling (~3 req/min observed limit)
-  const POLL_INTERVAL_MS = 10_000;     // poll every 10s
-  const POLL_TIMEOUT_MS = 180_000;     // 3 min max wait per screen
-  const INTER_SCREEN_DELAY_MS = 3_000; // 3s between screens
+  // Pattern: Fire → Close → Assume Success
+  //   1. Fire generate() with a fresh client — expect socket drop as normal
+  //   2. Close the client immediately (transport is tainted after any error)
+  //   3. Mark as "fired" — the server completes generation regardless
+  //   4. No polling (listScreens is broken until browser activation)
+  //   5. 3s delay between screens to avoid Google throttling (~3 req/min)
+  const INTER_SCREEN_DELAY_MS = 3_000;
 
   const results = [];
   const apiKey = getApiKey();
@@ -499,77 +496,32 @@ export async function generateScreens(projectId, prompts, ventureId) {
     const label = `[${i + 1}/${prompts.length}]`;
 
     try {
-      // Step 1: Snapshot current screens
-      const snapClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
-      const snapProject = snapClient.project(projectId);
-      let beforeScreens = [];
+      const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
+      const project = client.project(projectId);
       try {
-        beforeScreens = await snapProject.screens();
-      } catch { /* empty project or read failure — proceed */ }
-      const knownIds = new Set((beforeScreens || []).map(s => s.screen_id || s.id).filter(Boolean));
-      try { await snapClient.close(); } catch { /* ignore */ }
-
-      // Step 2: Fire generate — expect socket drop
-      const genClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
-      const genProject = genClient.project(projectId);
-      let directResult = null;
-      try {
-        directResult = await genProject.generate(prompt);
+        const screen = await project.generate(prompt);
+        const screenId = screen?.id || screen?.screen_id;
+        console.info(`[stitch-client] ${label} returned directly: ${screenId}`);
+        results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || prompt.substring(0, 30) });
       } catch (err) {
         const msg = err.message || '';
         const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
-        if (!isTransport) {
-          // Real error (auth, validation, budget) — don't poll
-          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: msg });
-          try { await genClient.close(); } catch { /* ignore */ }
-          continue;
-        }
-        console.info(`[stitch-client] ${label} socket dropped (expected) — polling for completion`);
-      }
-      try { await genClient.close(); } catch { /* always close */ }
-
-      // Step 3: If generate returned directly, we're done
-      if (directResult) {
-        const screenId = directResult.id || directResult.screen_id;
-        console.info(`[stitch-client] ${label} returned directly: ${screenId}`);
-        results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: screenId, name: directResult.name || prompt.substring(0, 30) });
-      } else {
-        // Step 4: Poll for new screen
-        const deadline = Date.now() + POLL_TIMEOUT_MS;
-        let found = null;
-        while (Date.now() < deadline) {
-          await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
-          try {
-            const pollClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
-            const afterScreens = await pollClient.project(projectId).screens();
-            try { await pollClient.close(); } catch { /* ignore */ }
-            const newScreens = (afterScreens || []).filter(s => {
-              const sid = s.screen_id || s.id;
-              return sid && !knownIds.has(sid);
-            });
-            if (newScreens.length > 0) {
-              found = newScreens[0];
-              break;
-            }
-          } catch (pollErr) {
-            console.warn(`[stitch-client] ${label} poll error: ${pollErr.message?.slice(0, 80)}`);
-          }
-        }
-        if (found) {
-          const foundId = found.screen_id || found.id;
-          console.info(`[stitch-client] ${label} found via poll: ${foundId}`);
-          results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: foundId, name: found.name || prompt.substring(0, 30) });
+        if (isTransport) {
+          // Socket drop = normal. Server completes generation regardless.
+          console.info(`[stitch-client] ${label} fired (socket dropped — server processing)`);
+          results.push({ prompt: prompt.slice(0, 60), status: 'fired' });
         } else {
-          console.warn(`[stitch-client] ${label} not found after ${POLL_TIMEOUT_MS / 1000}s polling`);
-          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: 'poll timeout' });
+          console.error(`[stitch-client] ${label} error: ${msg.slice(0, 120)}`);
+          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: msg });
         }
       }
+      try { await client.close(); } catch { /* ignore */ }
     } catch (outerErr) {
-      console.error(`[stitch-client] ${label} unexpected error: ${outerErr.message}`);
+      console.error(`[stitch-client] ${label} unexpected: ${outerErr.message}`);
       results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: outerErr.message });
     }
 
-    // Step 5: Delay between screens to avoid throttling
+    // Delay between screens to avoid Google throttling
     if (i < prompts.length - 1) {
       await new Promise(r => setTimeout(r, INTER_SCREEN_DELAY_MS));
     }
@@ -585,8 +537,11 @@ export async function generateScreens(projectId, prompts, ventureId) {
  * @returns {Promise<string>} HTML download URL
  */
 export async function exportScreenHtml(screenId, projectId) {
-  return instrumentedCall('exportScreenHtml', async () => {
-    const client = await getClient();
+  // Use fresh client — shared getClient() may have broken transport from prior socket drops
+  const apiKey = getApiKey();
+  const sdk = await getSDK();
+  const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey }));
+  try {
     const project = client.project(projectId);
     const screen = await project.getScreen(screenId);
     const result = await screen.getHtml();
@@ -594,7 +549,9 @@ export async function exportScreenHtml(screenId, projectId) {
       throw new StitchValidationError('exportScreenHtml: expected URL string');
     }
     return result;
-  });
+  } finally {
+    try { await client.close(); } catch { /* ignore */ }
+  }
 }
 
 /**
@@ -605,8 +562,10 @@ export async function exportScreenHtml(screenId, projectId) {
  * @returns {Promise<string>} Image download URL
  */
 export async function exportScreenImage(screenId, options = {}) {
-  return instrumentedCall('exportScreenImage', async () => {
-    const client = await getClient();
+  const apiKey = getApiKey();
+  const sdk = await getSDK();
+  const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey }));
+  try {
     const project = client.project(options.projectId);
     const screen = await project.getScreen(screenId);
     const result = await screen.getImage();
@@ -614,7 +573,9 @@ export async function exportScreenImage(screenId, options = {}) {
       throw new StitchValidationError('exportScreenImage: expected URL string');
     }
     return result;
-  });
+  } finally {
+    try { await client.close(); } catch { /* ignore */ }
+  }
 }
 
 /**

--- a/lib/eva/bridge/stitch-exporter.js
+++ b/lib/eva/bridge/stitch-exporter.js
@@ -33,11 +33,13 @@ async function getStitchClient() {
     return _stitchClient;
   }
   try {
-    const mod = await import(/* @vite-ignore */ './stitch-adapter.js');
+    // Use stitch-client.js (not stitch-adapter.js) — exporter needs listScreens,
+    // exportScreenHtml, exportScreenImage which are on the client, not the adapter.
+    const mod = await import(/* @vite-ignore */ './stitch-client.js');
     _stitchClient = mod;
     return _stitchClient;
   } catch (err) {
-    throw new Error(`Cannot load stitch-adapter: ${err.message}`);
+    throw new Error(`Cannot load stitch-client: ${err.message}`);
   }
 }
 
@@ -471,7 +473,7 @@ export async function exportStitchArtifacts(ventureId, projectId, outputDir, opt
 
       // Export HTML
       try {
-        let html = await client.exportScreenHtml(screenId);
+        let html = await client.exportScreenHtml(screenId, projectId);
         html = injectSRIHashes(html);
         htmlEntries.push({ screen_id: screenId, html });
         if (wantsFilesystem) {
@@ -487,7 +489,7 @@ export async function exportStitchArtifacts(ventureId, projectId, outputDir, opt
 
       // Export PNG
       try {
-        const pngBuffer = await client.exportScreenImage(screenId);
+        const pngBuffer = await client.exportScreenImage(screenId, { projectId });
         pngEntries.push({ screen_id: screenId, buffer: pngBuffer });
         if (wantsFilesystem) {
           const pngPath = join(screenshotsDir, `${screenId}.png`);


### PR DESCRIPTION
## Summary
- Fix exporter to import `stitch-client.js` (not `stitch-adapter.js`) for `listScreens`/`exportScreenHtml`/`exportScreenImage`
- Pass `projectId` to `exportScreenHtml` and `exportScreenImage` (was missing, caused undefined property access)
- Fresh SDK client per export call (shared singleton has broken transport)
- Drop useless poll from `generateScreens` — `listScreens` returns empty until browser activation (confirmed Stitch SDK bug). Fire-and-assume-success reduces S15 hook from 21+ min to ~30s

## Test result
1 screen generated → browser activated → export returned: HTML URL + PNG URL + DESIGN.md. Status: persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)