### PR TITLE
fix: NULL health_score on early-exit paths + stale lock recovery

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -50,7 +50,7 @@ const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 const DEFAULT_GATE_TIMEOUT_MS = 0; // 0 = wait indefinitely
-const DEFAULT_STALE_LOCK_THRESHOLD_MS = 300_000; // 5 minutes
+const DEFAULT_STALE_LOCK_THRESHOLD_MS = 120_000; // 2 minutes (was 5 min; reduced to speed recovery after worker restart)
 const DEFAULT_STALL_THRESHOLD_MS = 300_000; // 5 minutes
 const DEFAULT_HEALTH_PORT = 3001;
 const DEFAULT_EXEC_HEARTBEAT_MS = 15_000; // heartbeat every 15s during stage processing
@@ -133,6 +133,9 @@ export class StageExecutionWorker {
     /** @type {boolean} */
     this._processing = false;
 
+    /** @type {Promise|null} - Track active processing for graceful shutdown */
+    this._processingPromise = null;
+
     /** @type {S20PauseController} SD-LEO-INFRA-S20-VENTURE-LEO-001 */
     this._s20PauseController = new S20PauseController(this._supabase, this._logger);
 
@@ -200,9 +203,11 @@ export class StageExecutionWorker {
 
   /**
    * Stop the polling loop and abort all active ventures.
-   * Graceful: waits for current processing cycle to finish.
+   * Graceful: aborts active ventures, then waits for their finally blocks
+   * to release processing locks before returning. This prevents orphaned
+   * locks on worker restart (QF: stale orchestrator lock fix).
    */
-  stop() {
+  async stop() {
     if (!this._running) return;
 
     this._running = false;
@@ -211,11 +216,25 @@ export class StageExecutionWorker {
       this._pollTimer = null;
     }
 
-    // Abort all active ventures
+    // Abort all active ventures — triggers loop break at abort signal check
     for (const [ventureId, controller] of this._activeVentures) {
       this._logger.log(`[Worker] Aborting venture ${ventureId}`);
       controller.abort();
     }
+
+    // Wait for the active processing promise to complete its finally block
+    // (which releases the processing lock). Timeout at 3s to avoid hanging.
+    if (this._processingPromise) {
+      try {
+        await Promise.race([
+          this._processingPromise,
+          new Promise(resolve => setTimeout(resolve, 3000)),
+        ]);
+      } catch {
+        // Swallow errors — we just need the finally block to run
+      }
+    }
+
     this._activeVentures.clear();
 
     // SD-LEO-INFRA-S20-VENTURE-LEO-001: Cleanup S20 pause controller
@@ -414,7 +433,9 @@ export class StageExecutionWorker {
       // Process sequentially to respect lock semantics
       for (const venture of ventures) {
         if (!this._running) break;
-        await this._processVenture(venture.id);
+        this._processingPromise = this._processVenture(venture.id);
+        await this._processingPromise;
+        this._processingPromise = null;
       }
     } catch (err) {
       this._logger.error(`[Worker] Tick error: ${err.message}`);
@@ -913,6 +934,7 @@ export class StageExecutionWorker {
           // UI path to unblock. Instead, log the error and continue processing.
           if (reviewInsertOk) {
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on review-blocked exit
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'review' };
             break;
@@ -939,12 +961,14 @@ export class StageExecutionWorker {
               .eq('id', ventureId);
             this._logger.log(`[Worker] Blocked at chairman gate stage ${currentStage} (post-execution)`);
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on chairman-gate-blocked exit
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'chairman' };
             break;
           }
           if (gateResult.killed) {
             this._logger.log(`[Worker] Killed at chairman gate stage ${currentStage}`);
+            await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on killed exit
             releaseState = ORCHESTRATOR_STATES.KILLED_AT_REALITY_GATE;
             lastResult = { ventureId, stageId: currentStage, status: 'killed' };
             break;
@@ -968,6 +992,7 @@ export class StageExecutionWorker {
           if (!canGovernanceOverrideFailed) {
             this._logger.error(`[Worker] Stage ${currentStage} failed for ${ventureId} after retries`);
             this._logStageTransition(ventureId, currentStage, 'failed', stageDurationMs, result).catch(() => {});
+            await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on failed exit
             releaseState = ORCHESTRATOR_STATES.FAILED;
             break;
           }
@@ -1031,6 +1056,7 @@ export class StageExecutionWorker {
           } else {
             this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
             this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
+            await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on governance-blocked exit
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             break;
           }
@@ -1042,12 +1068,14 @@ export class StageExecutionWorker {
         // Check filter decision
         if (result.filterDecision?.action === 'STOP') {
           this._logger.log(`[Worker] Filter STOP at stage ${currentStage}`);
+          await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on filter STOP
           releaseState = ORCHESTRATOR_STATES.BLOCKED;
           break;
         }
 
         if (result.filterDecision?.action === 'REQUIRE_REVIEW' && !this._waitForReview) {
           this._logger.log(`[Worker] Review required at stage ${currentStage}, pausing`);
+          await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on filter REQUIRE_REVIEW
           releaseState = ORCHESTRATOR_STATES.BLOCKED;
           break;
         }
@@ -1106,6 +1134,7 @@ export class StageExecutionWorker {
         // Check for lifecycle completion or determine next stage
         if (currentStage >= MAX_STAGE) {
           this._logger.log(`[Worker] Venture ${ventureId} completed lifecycle at stage ${currentStage}`);
+          await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on lifecycle completion
           await markCompleted(this._supabase, ventureId, { lockId, logger: this._logger });
           this._activeVentures.delete(ventureId);
           return lastResult;
@@ -1138,6 +1167,7 @@ export class StageExecutionWorker {
             const nextStage = currentStage + 1;
             if (nextStage > MAX_STAGE) {
               this._logger.log(`[Worker] Venture ${ventureId} completed lifecycle at stage ${currentStage}`);
+              await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on secondary lifecycle completion
               await markCompleted(this._supabase, ventureId, { lockId, logger: this._logger });
               this._activeVentures.delete(ventureId);
               return lastResult;

--- a/scripts/start-stage-worker.js
+++ b/scripts/start-stage-worker.js
@@ -288,12 +288,12 @@ async function runDirect() {
 
   writePid(process.pid);
 
-  // Graceful shutdown
-  function shutdown(signal) {
+  // Graceful shutdown — await lock release before exit (QF: stale lock fix)
+  async function shutdown(signal) {
     console.log(`\n[stage-worker] Received ${signal}, shutting down...`);
-    worker.stop();
+    await worker.stop();
     removePid();
-    setTimeout(() => process.exit(0), 2000);
+    process.exit(0);
   }
 
   process.on('SIGINT', () => shutdown('SIGINT'));


### PR DESCRIPTION
## Summary
- **QF-1**: Add `_writeHealthScore()` to 9 early-exit break points in `_processVenture()` that occur after stage execution but before normal health score write. Fixes 8/17 stages having NULL health_score in venture monitoring (Compliance Compass AI).
- **QF-2**: Reduce stale lock threshold from 300s to 120s. Make `stop()` async and await active processing completion (3s timeout) so lock release runs before process exit. Prevents orphaned locks on nodemon restart.

## Test plan
- [x] Module loads without syntax errors
- [x] Smoke tests pass (15/15)
- [x] Unit tests pass (21/21)
- [ ] Run venture pipeline S0-S17 and verify all stages have non-NULL health_score
- [ ] Restart worker via file edit and verify lock released within 3s (not 5min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)