### PR TITLE
feat(SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D): Stitch deviceType parameter and tool discovery

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -40,6 +40,7 @@ const supabase = createClient(
 
 let _sdk = null;
 let _sdkLoader = null;
+let _cachedTools = null; // SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D: listTools() cache
 
 /**
  * Set a custom SDK loader (for testing or tool-swapping).
@@ -65,6 +66,30 @@ async function getSDK() {
     return _sdk;
   } catch (err) {
     throw new StitchSDKError(`Failed to load @google/stitch-sdk: ${err.message}`);
+  }
+}
+
+/**
+ * Discover available Stitch MCP tools. Results cached per process lifetime.
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D
+ * @returns {Promise<string[]>} Array of tool names, or empty array on failure
+ */
+export async function discoverTools() {
+  if (_cachedTools) return _cachedTools;
+  try {
+    const sdk = await getSDK();
+    const apiKey = getApiKey();
+    const client = new sdk.StitchToolClient({ apiKey, timeout: 30_000 });
+    const tools = await client.listTools();
+    const toolNames = (tools || []).map(t => t.name || t).filter(Boolean);
+    _cachedTools = toolNames;
+    console.info(`[stitch-client] Available Stitch tools (${toolNames.length}): ${toolNames.join(', ')}`);
+    try { await client.close(); } catch { /* ignore */ }
+    return toolNames;
+  } catch (err) {
+    console.warn(`[stitch-client] listTools() failed (non-fatal): ${err.message}`);
+    _cachedTools = [];
+    return [];
   }
 }
 
@@ -470,6 +495,12 @@ export async function createProject(options) {
  * @param {string} [ventureId] - Venture ID for budget tracking
  * @returns {Promise<Array<{prompt: string, status: 'returned'|'fired', screen_id?: string, name?: string, error?: string}>>}
  */
+/**
+ * Generate screens in a Stitch project.
+ * @param {string} projectId - Stitch project ID
+ * @param {Array<string|{text: string, deviceType?: string}>} prompts - Prompt strings or objects with deviceType
+ * @param {string} [ventureId] - Venture ID for budget tracking
+ */
 export async function generateScreens(projectId, prompts, ventureId) {
   if (ventureId) {
     await consumeBudget(ventureId, prompts.length);
@@ -492,33 +523,42 @@ export async function generateScreens(projectId, prompts, ventureId) {
   const sdk = await getSDK();
 
   for (let i = 0; i < prompts.length; i++) {
-    const prompt = prompts[i];
+    const rawPrompt = prompts[i];
+    // SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D: Support {text, deviceType} prompt objects
+    const promptText = typeof rawPrompt === 'string' ? rawPrompt : rawPrompt.text;
+    const deviceType = typeof rawPrompt === 'object' ? rawPrompt.deviceType : undefined;
     const label = `[${i + 1}/${prompts.length}]`;
+    if (deviceType) {
+      console.info(`[stitch-client] ${label} deviceType: ${deviceType}`);
+    }
 
     try {
       const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
       const project = client.project(projectId);
       try {
-        const screen = await project.generate(prompt);
+        // Pass deviceType as second arg if available (Stitch SDK supports MOBILE/DESKTOP/TABLET/AGNOSTIC)
+        const screen = deviceType
+          ? await project.generate(promptText, deviceType)
+          : await project.generate(promptText);
         const screenId = screen?.id || screen?.screen_id;
         console.info(`[stitch-client] ${label} returned directly: ${screenId}`);
-        results.push({ prompt: prompt.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || prompt.substring(0, 30) });
+        results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType });
       } catch (err) {
         const msg = err.message || '';
         const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
         if (isTransport) {
           // Socket drop = normal. Server completes generation regardless.
           console.info(`[stitch-client] ${label} fired (socket dropped — server processing)`);
-          results.push({ prompt: prompt.slice(0, 60), status: 'fired' });
+          results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType });
         } else {
           console.error(`[stitch-client] ${label} error: ${msg.slice(0, 120)}`);
-          results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: msg });
+          results.push({ prompt: promptText.slice(0, 60), status: 'fired', error: msg, deviceType });
         }
       }
       try { await client.close(); } catch { /* ignore */ }
     } catch (outerErr) {
       console.error(`[stitch-client] ${label} unexpected: ${outerErr.message}`);
-      results.push({ prompt: prompt.slice(0, 60), status: 'fired', error: outerErr.message });
+      results.push({ prompt: promptText.slice(0, 60), status: 'fired', error: outerErr.message, deviceType });
     }
 
     // Delay between screens to avoid Google throttling

--- a/lib/eva/bridge/stitch-device-type-resolver.js
+++ b/lib/eva/bridge/stitch-device-type-resolver.js
@@ -1,0 +1,66 @@
+/**
+ * Stitch Device Type Resolver
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D
+ *
+ * Infers the Stitch deviceType (MOBILE, DESKTOP, TABLET, AGNOSTIC) from
+ * wireframe screen metadata. Used by postStage15Hook to pass deviceType
+ * per screen to generateScreens().
+ */
+
+const DESKTOP_KEYWORDS = [
+  'dashboard', 'admin', 'analytics', 'reporting', 'management',
+  'backoffice', 'back-office', 'cms', 'crm', 'erp', 'portal',
+  'editor', 'workspace', 'console', 'monitor',
+];
+
+const MOBILE_KEYWORDS = [
+  'mobile', 'phone', 'ios', 'android', 'app home', 'app screen',
+  'native app', 'smartphone', 'pocket', 'on-the-go',
+];
+
+const TABLET_KEYWORDS = [
+  'tablet', 'ipad', 'split-view', 'split view',
+];
+
+/**
+ * Infer Stitch deviceType from a wireframe screen spec.
+ * Never throws — returns 'AGNOSTIC' for unknown/malformed input.
+ *
+ * @param {Object|string} screenSpec - Wireframe screen object or name string
+ * @param {string} [screenSpec.name] - Screen name
+ * @param {string} [screenSpec.purpose] - Screen purpose/description
+ * @param {string} [screenSpec.ascii_layout] - ASCII wireframe content
+ * @returns {'MOBILE'|'DESKTOP'|'TABLET'|'AGNOSTIC'}
+ */
+export function inferDeviceType(screenSpec) {
+  try {
+    const text = extractSearchText(screenSpec).toLowerCase();
+    if (!text) return 'AGNOSTIC';
+
+    if (TABLET_KEYWORDS.some(kw => text.includes(kw))) return 'TABLET';
+    if (MOBILE_KEYWORDS.some(kw => text.includes(kw))) return 'MOBILE';
+    if (DESKTOP_KEYWORDS.some(kw => text.includes(kw))) return 'DESKTOP';
+
+    return 'AGNOSTIC';
+  } catch {
+    return 'AGNOSTIC';
+  }
+}
+
+/**
+ * Extract searchable text from various screen spec formats.
+ * @param {Object|string} spec
+ * @returns {string}
+ */
+function extractSearchText(spec) {
+  if (!spec) return '';
+  if (typeof spec === 'string') return spec;
+  const parts = [
+    spec.name,
+    spec.purpose,
+    spec.screen_purpose,
+    spec.title,
+    spec.description,
+  ].filter(Boolean);
+  return parts.join(' ');
+}

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -351,10 +351,18 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     }
   }
 
-  // Step 4: Build curation prompts (chairman uses these in Stitch web UI)
-  const curationPrompts = screens.map(screen =>
-    buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection)
-  );
+  // Step 4: Build curation prompts with deviceType (SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D)
+  let inferDeviceType;
+  try {
+    const resolver = await import('./stitch-device-type-resolver.js');
+    inferDeviceType = resolver.inferDeviceType;
+  } catch {
+    inferDeviceType = () => undefined; // graceful fallback if module unavailable
+  }
+  const curationPrompts = screens.map(screen => ({
+    text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
+    deviceType: inferDeviceType(screen),
+  }));
 
   // Step 5: Create project via stitch-client (API call — works reliably)
   const client = await getStitchClient();
@@ -371,14 +379,23 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   // By writing the artifact first, we guarantee the project_id + prompts are
   // persisted even if generation times out. The chairman can always trigger
   // generation manually via the Stitch UI using the saved prompts.
+  // SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D: Discover available Stitch tools (best-effort)
+  let availableTools = [];
+  try {
+    const { discoverTools } = await import('./stitch-client.js');
+    availableTools = await discoverTools();
+  } catch { /* non-fatal */ }
+
   const artifactData = {
     project_id: project.project_id,
     url: project.url,
     screen_count: screens.length,
     brand_tokens: brandTokens,
-    screen_prompts: curationPrompts.map((prompt, i) => ({
+    available_tools: availableTools,
+    screen_prompts: curationPrompts.map((p, i) => ({
       screen_name: screens[i]?.name || `Screen ${i + 1}`,
-      prompt,
+      prompt: typeof p === 'string' ? p : p.text,
+      deviceType: typeof p === 'object' ? p.deviceType : undefined,
     })),
     generation_results: [],
     status: 'awaiting_curation',

--- a/tests/unit/stitch-device-type-resolver.test.js
+++ b/tests/unit/stitch-device-type-resolver.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { inferDeviceType } from '../../lib/eva/bridge/stitch-device-type-resolver.js';
+
+describe('inferDeviceType', () => {
+  describe('DESKTOP mapping', () => {
+    it('maps "dashboard" to DESKTOP', () => {
+      expect(inferDeviceType({ name: 'Admin Dashboard' })).toBe('DESKTOP');
+    });
+
+    it('maps "analytics" to DESKTOP', () => {
+      expect(inferDeviceType({ purpose: 'Analytics Overview' })).toBe('DESKTOP');
+    });
+
+    it('maps "management" to DESKTOP', () => {
+      expect(inferDeviceType({ name: 'User Management Console' })).toBe('DESKTOP');
+    });
+
+    it('maps "portal" to DESKTOP', () => {
+      expect(inferDeviceType({ name: 'Customer Portal' })).toBe('DESKTOP');
+    });
+  });
+
+  describe('MOBILE mapping', () => {
+    it('maps "mobile" to MOBILE', () => {
+      expect(inferDeviceType({ name: 'Mobile Home Screen' })).toBe('MOBILE');
+    });
+
+    it('maps "app home" to MOBILE', () => {
+      expect(inferDeviceType({ purpose: 'App Home' })).toBe('MOBILE');
+    });
+
+    it('maps "ios" to MOBILE', () => {
+      expect(inferDeviceType({ name: 'iOS Settings' })).toBe('MOBILE');
+    });
+  });
+
+  describe('TABLET mapping', () => {
+    it('maps "tablet" to TABLET', () => {
+      expect(inferDeviceType({ name: 'Tablet View' })).toBe('TABLET');
+    });
+
+    it('maps "ipad" to TABLET', () => {
+      expect(inferDeviceType({ purpose: 'iPad Layout' })).toBe('TABLET');
+    });
+  });
+
+  describe('AGNOSTIC fallback', () => {
+    it('returns AGNOSTIC for unknown purpose', () => {
+      expect(inferDeviceType({ name: 'Settings Page' })).toBe('AGNOSTIC');
+    });
+
+    it('returns AGNOSTIC for null input', () => {
+      expect(inferDeviceType(null)).toBe('AGNOSTIC');
+    });
+
+    it('returns AGNOSTIC for undefined input', () => {
+      expect(inferDeviceType(undefined)).toBe('AGNOSTIC');
+    });
+
+    it('returns AGNOSTIC for empty object', () => {
+      expect(inferDeviceType({})).toBe('AGNOSTIC');
+    });
+
+    it('returns AGNOSTIC for empty string', () => {
+      expect(inferDeviceType('')).toBe('AGNOSTIC');
+    });
+  });
+
+  describe('string input', () => {
+    it('handles plain string with dashboard keyword', () => {
+      expect(inferDeviceType('Dashboard Overview')).toBe('DESKTOP');
+    });
+
+    it('handles plain string with mobile keyword', () => {
+      expect(inferDeviceType('Mobile App Login')).toBe('MOBILE');
+    });
+  });
+
+  describe('priority (tablet > mobile > desktop)', () => {
+    it('tablet wins over mobile', () => {
+      expect(inferDeviceType({ name: 'Mobile Tablet View' })).toBe('TABLET');
+    });
+
+    it('mobile wins over desktop', () => {
+      expect(inferDeviceType({ name: 'Mobile Dashboard' })).toBe('MOBILE');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `inferDeviceType()` resolver that maps wireframe screen purpose keywords to Stitch deviceType (MOBILE/DESKTOP/TABLET/AGNOSTIC)
- Modify `generateScreens()` to accept `{text, deviceType}` prompt objects (backward compatible with plain strings)
- Add `discoverTools()` export that caches `listTools()` results per process lifetime
- Store `available_tools` in stitch_curation artifact metadata for observability

## Test plan
- [x] 18 unit tests for deviceType inference (all pass)
- [x] Smoke tests pass (15/15)
- [ ] Run S15 for a venture and verify deviceType logged per screen
- [ ] Verify listTools() output in console on first Stitch connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)