### PR TITLE
feat(SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E): Stitch Design System from brand tokens

### DIFF
--- a/lib/eva/bridge/stitch-design-system.js
+++ b/lib/eva/bridge/stitch-design-system.js
@@ -1,0 +1,156 @@
+/**
+ * Stitch Design System Integration
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E
+ *
+ * Maps S11 brand_tokens (colors, fonts, visual style) to Stitch DesignSystem
+ * API format and creates a project-level theme that all generated screens inherit.
+ *
+ * Uses normalized brand_tokens from PR #2950 — colors are strings (hex),
+ * fonts are strings (family names).
+ */
+
+/**
+ * Map brand_tokens extracted at S11 to Stitch DesignSystem format.
+ * Never throws — returns sensible defaults for missing fields.
+ *
+ * @param {Object} brandTokens - Normalized brand tokens from extractStage11Tokens
+ * @param {Array<string>} [brandTokens.colors] - Array of hex color strings
+ * @param {Array<string>} [brandTokens.fonts] - Array of font family strings
+ * @param {string} [brandTokens.personality] - Visual personality (bold, minimal, etc.)
+ * @returns {Object} Stitch DesignSystem configuration
+ */
+export function mapBrandTokensToDesignSystem(brandTokens) {
+  if (!brandTokens || typeof brandTokens !== 'object') {
+    return buildDefaultDesignSystem();
+  }
+
+  const colors = extractColors(brandTokens);
+  const fonts = extractFonts(brandTokens);
+  const colorMode = inferColorMode(brandTokens);
+  const roundness = inferRoundness(brandTokens);
+
+  return {
+    theme: {
+      colorMode,
+      fonts: {
+        heading: fonts.heading,
+        body: fonts.body,
+      },
+      roundness,
+    },
+    customColors: colors,
+  };
+}
+
+/**
+ * Create a DesignSystem on a Stitch project and optionally apply it.
+ * Fire-and-forget pattern — failure is non-fatal.
+ *
+ * @param {Object} params
+ * @param {Object} params.sdk - Stitch SDK module
+ * @param {string} params.apiKey - Stitch API key
+ * @param {string} params.projectId - Stitch project ID
+ * @param {Object} params.brandTokens - Brand tokens from S11
+ * @returns {Promise<{designSystemId: string|null, applied: boolean}>}
+ */
+export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brandTokens }) {
+  const designSystemConfig = mapBrandTokensToDesignSystem(brandTokens);
+
+  try {
+    const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
+    const project = client.project(projectId);
+
+    const designSystem = await project.createDesignSystem(designSystemConfig);
+    const designSystemId = designSystem?.id || designSystem?.design_system_id || null;
+
+    console.info(`[stitch-design-system] DesignSystem created: ${designSystemId}`);
+    console.info(`[stitch-design-system] Theme: colorMode=${designSystemConfig.theme.colorMode}, fonts=${designSystemConfig.theme.fonts.heading}/${designSystemConfig.theme.fonts.body}, roundness=${designSystemConfig.theme.roundness}`);
+    console.info(`[stitch-design-system] Colors: ${designSystemConfig.customColors.map(c => `${c.name}=${c.hex}`).join(', ')}`);
+
+    try { await client.close(); } catch { /* ignore */ }
+
+    return { designSystemId, applied: false, config: designSystemConfig };
+  } catch (err) {
+    const msg = err.message || '';
+    const isTransport = /fetch failed|socket|ECONNRESET|other side closed/i.test(msg);
+    if (isTransport) {
+      console.info('[stitch-design-system] DesignSystem fired (socket dropped — server processing)');
+      return { designSystemId: 'fired', applied: false, config: designSystemConfig };
+    }
+    console.warn(`[stitch-design-system] createDesignSystem failed (non-fatal): ${msg}`);
+    return { designSystemId: null, applied: false, config: designSystemConfig };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function extractColors(brandTokens) {
+  const colors = [];
+  const rawColors = brandTokens.colors || [];
+
+  if (Array.isArray(rawColors)) {
+    const colorNames = ['primary', 'secondary', 'accent', 'neutral', 'background'];
+    rawColors.forEach((color, i) => {
+      const hex = typeof color === 'string' ? color : (color?.hex || color?.value || null);
+      if (hex && /^#[0-9a-fA-F]{3,8}$/.test(hex)) {
+        colors.push({ name: colorNames[i] || `color_${i}`, hex });
+      }
+    });
+  }
+
+  // Fallback: if no valid colors extracted, use a neutral default
+  if (colors.length === 0) {
+    colors.push({ name: 'primary', hex: '#3b82f6' });
+  }
+
+  return colors;
+}
+
+function extractFonts(brandTokens) {
+  const rawFonts = brandTokens.fonts || [];
+  let heading = 'Inter';
+  let body = 'Inter';
+
+  if (Array.isArray(rawFonts) && rawFonts.length > 0) {
+    heading = typeof rawFonts[0] === 'string' ? rawFonts[0] : (rawFonts[0]?.name || rawFonts[0]?.family || 'Inter');
+    if (rawFonts.length > 1) {
+      body = typeof rawFonts[1] === 'string' ? rawFonts[1] : (rawFonts[1]?.name || rawFonts[1]?.family || 'Inter');
+    } else {
+      body = heading; // Single font = use for both
+    }
+  }
+
+  return { heading, body };
+}
+
+function inferColorMode(brandTokens) {
+  const personality = (brandTokens.personality || '').toLowerCase();
+  if (personality.includes('dark') || personality.includes('moody') || personality.includes('night')) {
+    return 'dark';
+  }
+  return 'light';
+}
+
+function inferRoundness(brandTokens) {
+  const personality = (brandTokens.personality || '').toLowerCase();
+  if (personality.includes('sharp') || personality.includes('corporate') || personality.includes('formal')) {
+    return 'none';
+  }
+  if (personality.includes('playful') || personality.includes('friendly') || personality.includes('soft')) {
+    return 'full';
+  }
+  return 'medium';
+}
+
+function buildDefaultDesignSystem() {
+  return {
+    theme: {
+      colorMode: 'light',
+      fonts: { heading: 'Inter', body: 'Inter' },
+      roundness: 'medium',
+    },
+    customColors: [{ name: 'primary', hex: '#3b82f6' }],
+  };
+}

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -365,6 +365,22 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     ventureId,
   });
 
+  // Step 5.5: Create DesignSystem from brand tokens (SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E)
+  // Must happen BEFORE generateScreens so screens inherit the theme.
+  let designSystemResult = { designSystemId: null };
+  try {
+    const { createAndApplyDesignSystem } = await import('./stitch-design-system.js');
+    const sdk = await import('@google/stitch-sdk').then(m => m.default || m).catch(() => null);
+    if (sdk) {
+      const apiKey = process.env.GOOGLE_STITCH_API_KEY || process.env.STITCH_API_KEY;
+      designSystemResult = await createAndApplyDesignSystem({
+        sdk, apiKey, projectId: project.project_id, brandTokens,
+      });
+    }
+  } catch (err) {
+    console.warn(`[stitch-provisioner] DesignSystem creation failed (non-fatal): ${err.message}`);
+  }
+
   // Step 6: Write stitch_curation artifact IMMEDIATELY with project + prompts.
   // RCA: The 480s abort guard in stage-execution-worker.js kills the hook before
   // generateScreens finishes (7 screens * 180s poll = 21 min > 480s timeout).
@@ -376,6 +392,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     url: project.url,
     screen_count: screens.length,
     brand_tokens: brandTokens,
+    design_system_id: designSystemResult.designSystemId,
     screen_prompts: curationPrompts.map((prompt, i) => ({
       screen_name: screens[i]?.name || `Screen ${i + 1}`,
       prompt,

--- a/tests/unit/stitch-design-system.test.js
+++ b/tests/unit/stitch-design-system.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { mapBrandTokensToDesignSystem } from '../../lib/eva/bridge/stitch-design-system.js';
+
+describe('mapBrandTokensToDesignSystem', () => {
+  describe('color mapping', () => {
+    it('maps hex color strings to customColors', () => {
+      const result = mapBrandTokensToDesignSystem({
+        colors: ['#2563eb', '#10b981', '#f59e0b'],
+      });
+      expect(result.customColors).toHaveLength(3);
+      expect(result.customColors[0]).toEqual({ name: 'primary', hex: '#2563eb' });
+      expect(result.customColors[1]).toEqual({ name: 'secondary', hex: '#10b981' });
+      expect(result.customColors[2]).toEqual({ name: 'accent', hex: '#f59e0b' });
+    });
+
+    it('handles single color', () => {
+      const result = mapBrandTokensToDesignSystem({ colors: ['#ff0000'] });
+      expect(result.customColors).toHaveLength(1);
+      expect(result.customColors[0]).toEqual({ name: 'primary', hex: '#ff0000' });
+    });
+
+    it('filters invalid hex values', () => {
+      const result = mapBrandTokensToDesignSystem({ colors: ['not-a-color', '#abc'] });
+      expect(result.customColors).toHaveLength(1);
+      expect(result.customColors[0].hex).toBe('#abc');
+    });
+
+    it('uses default when no colors provided', () => {
+      const result = mapBrandTokensToDesignSystem({ fonts: ['Inter'] });
+      expect(result.customColors).toHaveLength(1);
+      expect(result.customColors[0].name).toBe('primary');
+    });
+
+    it('handles object-shaped colors (legacy format)', () => {
+      const result = mapBrandTokensToDesignSystem({
+        colors: [{ hex: '#2563eb' }, { value: '#10b981' }],
+      });
+      expect(result.customColors).toHaveLength(2);
+      expect(result.customColors[0].hex).toBe('#2563eb');
+      expect(result.customColors[1].hex).toBe('#10b981');
+    });
+  });
+
+  describe('font mapping', () => {
+    it('maps font strings to heading/body', () => {
+      const result = mapBrandTokensToDesignSystem({
+        fonts: ['Playfair Display', 'Inter'],
+      });
+      expect(result.theme.fonts.heading).toBe('Playfair Display');
+      expect(result.theme.fonts.body).toBe('Inter');
+    });
+
+    it('uses single font for both heading and body', () => {
+      const result = mapBrandTokensToDesignSystem({ fonts: ['Roboto'] });
+      expect(result.theme.fonts.heading).toBe('Roboto');
+      expect(result.theme.fonts.body).toBe('Roboto');
+    });
+
+    it('defaults to Inter when no fonts provided', () => {
+      const result = mapBrandTokensToDesignSystem({ colors: ['#000'] });
+      expect(result.theme.fonts.heading).toBe('Inter');
+      expect(result.theme.fonts.body).toBe('Inter');
+    });
+  });
+
+  describe('color mode inference', () => {
+    it('infers dark mode from personality', () => {
+      const result = mapBrandTokensToDesignSystem({ personality: 'dark and moody' });
+      expect(result.theme.colorMode).toBe('dark');
+    });
+
+    it('defaults to light mode', () => {
+      const result = mapBrandTokensToDesignSystem({ personality: 'professional' });
+      expect(result.theme.colorMode).toBe('light');
+    });
+  });
+
+  describe('roundness inference', () => {
+    it('infers none for corporate personality', () => {
+      const result = mapBrandTokensToDesignSystem({ personality: 'corporate formal' });
+      expect(result.theme.roundness).toBe('none');
+    });
+
+    it('infers full for playful personality', () => {
+      const result = mapBrandTokensToDesignSystem({ personality: 'playful and friendly' });
+      expect(result.theme.roundness).toBe('full');
+    });
+
+    it('defaults to medium', () => {
+      const result = mapBrandTokensToDesignSystem({ personality: 'balanced' });
+      expect(result.theme.roundness).toBe('medium');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles null input', () => {
+      const result = mapBrandTokensToDesignSystem(null);
+      expect(result.theme).toBeDefined();
+      expect(result.customColors).toBeDefined();
+    });
+
+    it('handles undefined input', () => {
+      const result = mapBrandTokensToDesignSystem(undefined);
+      expect(result.theme.colorMode).toBe('light');
+    });
+
+    it('handles empty object', () => {
+      const result = mapBrandTokensToDesignSystem({});
+      expect(result.theme.fonts.heading).toBe('Inter');
+      expect(result.customColors.length).toBeGreaterThan(0);
+    });
+
+    it('returns complete structure with all fields', () => {
+      const result = mapBrandTokensToDesignSystem({
+        colors: ['#2563eb', '#10b981'],
+        fonts: ['Playfair Display', 'Inter'],
+        personality: 'elegant',
+      });
+      expect(result).toHaveProperty('theme.colorMode');
+      expect(result).toHaveProperty('theme.fonts.heading');
+      expect(result).toHaveProperty('theme.fonts.body');
+      expect(result).toHaveProperty('theme.roundness');
+      expect(result).toHaveProperty('customColors');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `stitch-design-system.js` with `mapBrandTokensToDesignSystem()` mapper that converts S11 brand_tokens to Stitch DesignSystem format (customColors, theme.fonts, colorMode, roundness)
- Wire `createAndApplyDesignSystem()` into `stitch-provisioner.js` between project creation and screen generation
- Persist `design_system_id` in stitch_curation artifact for reference
- Graceful fallback: if DesignSystem API fails, continues with prompt-based theming

## Test plan
- [x] 17 unit tests for color/font mapping and edge cases (all pass)
- [x] Smoke tests pass (15/15)
- [ ] Run S15 for a venture with known brand colors and verify design_system_id in artifact
- [ ] Open Stitch project and verify consistent theme across screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)