### PR TITLE
feat(SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-B): iterative wireframe quality loop

### DIFF
--- a/lib/eva/bridge/stitch-exporter.js
+++ b/lib/eva/bridge/stitch-exporter.js
@@ -570,6 +570,12 @@ export async function exportStitchArtifacts(ventureId, projectId, outputDir, opt
       import(/* @vite-ignore */ '../qa/stitch-vision-qa.js')
         .then(({ reviewStitchExport }) => reviewStitchExport(ventureId, qaPayload))
         .catch((err) => logWarn('stitch_qa_dispatch_failed', { error: err?.message || String(err) }));
+
+      // SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-A: fire-and-forget wireframe fidelity QA.
+      // Compares exported PNGs against S15 wireframe specs. Never throws.
+      import(/* @vite-ignore */ '../qa/stitch-wireframe-qa.js')
+        .then(({ scoreWireframeFidelity }) => scoreWireframeFidelity(ventureId, projectId, { png_files_base64: qaPayload.png_files_base64 }))
+        .catch((err) => logWarn('wireframe_qa_dispatch_failed', { error: err?.message || String(err) }));
     } catch (err) {
       logWarn('persistence_failed', { venture_id: ventureId, error: err.message });
       manifest.status = 'persistence_failed';

--- a/lib/eva/qa/stitch-wireframe-qa-loop.js
+++ b/lib/eva/qa/stitch-wireframe-qa-loop.js
@@ -1,0 +1,243 @@
+/**
+ * Stitch Wireframe QA Iterative Loop — Re-generate failing screens
+ *
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-B
+ *
+ * Evaluates wireframe fidelity scores from Child A's scoring engine.
+ * Screens below threshold get re-generated with improved prompts
+ * incorporating QA feedback (missing elements, low-scoring dimensions).
+ * Repeats up to MAX_ITERATIONS times per screen.
+ *
+ * Never throws — all errors result in graceful termination of the loop.
+ *
+ * @module lib/eva/qa/stitch-wireframe-qa-loop
+ */
+
+import { scoreWireframeFidelity } from './stitch-wireframe-qa.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_THRESHOLD = 70;
+const MAX_ITERATIONS = 3;
+const MIN_IMPROVEMENT = 5; // Log diminishing returns below this
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function log(level, event, details = {}) {
+  const entry = JSON.stringify({ event, level, timestamp: new Date().toISOString(), ...details });
+  (level === 'warn' ? console.warn : console.info)(`[wireframe-qa-loop] ${entry}`);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt improvement
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an improved generation prompt incorporating QA feedback.
+ *
+ * @param {string} originalPrompt - Original Stitch generation prompt
+ * @param {Object} screenResult - Result from scoreWireframeFidelity for this screen
+ * @returns {string} Improved prompt with QA feedback injected
+ */
+export function buildImprovedPrompt(originalPrompt, screenResult) {
+  const feedbackParts = [];
+
+  // Add missing elements
+  if (screenResult.missing_elements?.length > 0) {
+    feedbackParts.push(
+      `CRITICAL: The following UI elements are MISSING and MUST be included: ${screenResult.missing_elements.join(', ')}.`
+    );
+  }
+
+  // Add low-scoring dimension feedback
+  if (screenResult.dimensions) {
+    const lowDimensions = Object.entries(screenResult.dimensions)
+      .filter(([, score]) => typeof score === 'number' && score < DEFAULT_THRESHOLD)
+      .map(([dim, score]) => {
+        const labels = {
+          component_presence: 'UI components (buttons, forms, navigation)',
+          layout_fidelity: 'spatial layout and zone arrangement',
+          navigation_accuracy: 'navigation links and menu structure',
+          screen_purpose_match: 'core screen purpose and function',
+        };
+        return `${labels[dim] || dim} (scored ${score}%)`;
+      });
+
+    if (lowDimensions.length > 0) {
+      feedbackParts.push(
+        `IMPROVE these areas: ${lowDimensions.join('; ')}.`
+      );
+    }
+  }
+
+  if (feedbackParts.length === 0) {
+    return originalPrompt;
+  }
+
+  return `${originalPrompt}\n\n--- QA FEEDBACK (must address) ---\n${feedbackParts.join('\n')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main iterative loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Run iterative quality loop on screens below threshold.
+ *
+ * @param {string} ventureId
+ * @param {string} projectId
+ * @param {Object} initialResult - Result from scoreWireframeFidelity
+ * @param {Object} [options]
+ * @param {number} [options.threshold] - Fidelity threshold (default 70)
+ * @param {Function} [options.regenerate] - Screen regeneration function (for testing)
+ * @param {Function} [options.reExport] - Screen re-export function (for testing)
+ * @param {Function} [options.reScore] - Re-scoring function (for testing)
+ * @param {Array} [options.wireframes] - Wireframe specs for re-scoring
+ * @returns {Promise<Object>} Updated fidelity result with iteration history
+ */
+export async function runIterativeLoop(ventureId, projectId, initialResult, options = {}) {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+
+  try {
+    if (!initialResult?.screens || initialResult.screens.length === 0) {
+      log('info', 'no_screens_to_iterate', { venture_id: ventureId });
+      return initialResult;
+    }
+
+    const updatedScreens = [];
+    let totalIterationsUsed = 0;
+
+    for (const screen of initialResult.screens) {
+      // Skip screens that already meet threshold or weren't scored
+      if (typeof screen.score !== 'number' || screen.score >= threshold) {
+        updatedScreens.push({ ...screen, iteration_count: 0, iteration_history: [] });
+        continue;
+      }
+
+      log('info', 'iterating_screen', {
+        screen: screen.screen_name,
+        initial_score: screen.score,
+        threshold,
+      });
+
+      let currentScreen = { ...screen };
+      const iterationHistory = [{ iteration: 0, score: screen.score }];
+      let iterationCount = 0;
+
+      for (let i = 0; i < MAX_ITERATIONS; i++) {
+        iterationCount = i + 1;
+
+        // Build improved prompt
+        const originalPrompt = `Generate the "${currentScreen.screen_name}" screen matching the wireframe specification.`;
+        const improvedPrompt = buildImprovedPrompt(originalPrompt, currentScreen);
+
+        // Re-generate screen
+        try {
+          if (options.regenerate) {
+            await options.regenerate(projectId, [improvedPrompt], ventureId);
+          } else {
+            // Dynamic import to avoid circular deps
+            const { generateScreens } = await import('../bridge/stitch-client.js');
+            await generateScreens(projectId, [improvedPrompt], ventureId);
+          }
+        } catch (err) {
+          log('warn', 'regeneration_failed', { screen: currentScreen.screen_name, error: err.message });
+          iterationHistory.push({ iteration: iterationCount, score: null, error: 'regeneration_failed' });
+          break;
+        }
+
+        // Re-export (if function provided) — in production, export happens via stitch-exporter
+        if (options.reExport) {
+          try {
+            await options.reExport(ventureId, projectId, currentScreen.screen_name);
+          } catch (err) {
+            log('warn', 'reexport_failed', { screen: currentScreen.screen_name, error: err.message });
+            iterationHistory.push({ iteration: iterationCount, score: null, error: 'reexport_failed' });
+            break;
+          }
+        }
+
+        // Re-score
+        let newScore;
+        try {
+          if (options.reScore) {
+            newScore = await options.reScore(ventureId, projectId, currentScreen.screen_name);
+          } else {
+            const reResult = await scoreWireframeFidelity(ventureId, projectId, {
+              wireframes: options.wireframes,
+            });
+            const matchingScreen = reResult.screens?.find(s => s.screen_name === currentScreen.screen_name);
+            newScore = matchingScreen || { score: null, status: 'rescore_no_match' };
+          }
+        } catch (err) {
+          log('warn', 'rescore_failed', { screen: currentScreen.screen_name, error: err.message });
+          iterationHistory.push({ iteration: iterationCount, score: null, error: 'rescore_failed' });
+          break;
+        }
+
+        const newScoreValue = newScore?.score ?? null;
+        iterationHistory.push({ iteration: iterationCount, score: newScoreValue });
+
+        // Check improvement
+        if (typeof newScoreValue === 'number' && typeof currentScreen.score === 'number') {
+          const delta = newScoreValue - currentScreen.score;
+          if (delta < MIN_IMPROVEMENT) {
+            log('info', 'diminishing_returns', {
+              screen: currentScreen.screen_name,
+              delta,
+              iteration: iterationCount,
+            });
+          }
+        }
+
+        // Update current screen with new result
+        if (newScore && typeof newScore.score === 'number') {
+          currentScreen = { ...currentScreen, ...newScore };
+        }
+
+        // Check if threshold met
+        if (typeof newScoreValue === 'number' && newScoreValue >= threshold) {
+          log('info', 'threshold_met', {
+            screen: currentScreen.screen_name,
+            score: newScoreValue,
+            iteration: iterationCount,
+          });
+          break;
+        }
+      }
+
+      totalIterationsUsed += iterationCount;
+      updatedScreens.push({
+        ...currentScreen,
+        iteration_count: iterationCount,
+        iteration_history: iterationHistory,
+      });
+    }
+
+    // Update overall score
+    const scoredScreens = updatedScreens.filter(s => typeof s.score === 'number');
+    const overall_score = scoredScreens.length > 0
+      ? Math.round(scoredScreens.reduce((sum, s) => sum + s.score, 0) / scoredScreens.length)
+      : initialResult.overall_score;
+
+    return {
+      ...initialResult,
+      overall_score,
+      screens: updatedScreens,
+      iterations_used: totalIterationsUsed,
+      threshold,
+      loop_status: 'completed',
+    };
+  } catch (err) {
+    log('warn', 'loop_failed', { venture_id: ventureId, error: err.message });
+    return {
+      ...initialResult,
+      loop_status: 'error',
+      loop_error: err.message,
+    };
+  }
+}

--- a/lib/eva/qa/stitch-wireframe-qa.js
+++ b/lib/eva/qa/stitch-wireframe-qa.js
@@ -1,0 +1,431 @@
+/**
+ * Stitch Wireframe Fidelity QA — 4-dimension scoring engine
+ *
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-A
+ *
+ * Compares exported Stitch PNG screenshots against S15 ASCII wireframe
+ * specifications using Claude Sonnet vision API. Scores each screen on
+ * 4 dimensions: component_presence, layout_fidelity, navigation_accuracy,
+ * screen_purpose_match. Persists results as additive wireframe_fidelity
+ * field on the stitch_qa_report artifact.
+ *
+ * Never throws — returns degraded result on any error.
+ *
+ * @module lib/eva/qa/stitch-wireframe-qa
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+const PER_SCREEN_TIMEOUT_MS = 30_000;
+const DIMENSIONS = ['component_presence', 'layout_fidelity', 'navigation_accuracy', 'screen_purpose_match'];
+
+// ---------------------------------------------------------------------------
+// Client loaders (test-injectable)
+// ---------------------------------------------------------------------------
+
+let _anthropicClient = null;
+let _anthropicLoader = null;
+
+export function setAnthropicClientLoader(loader) {
+  _anthropicLoader = loader;
+  _anthropicClient = null;
+}
+
+function getAnthropicClient() {
+  if (_anthropicClient) return _anthropicClient;
+  if (_anthropicLoader) {
+    _anthropicClient = _anthropicLoader();
+    return _anthropicClient;
+  }
+  if (!process.env.ANTHROPIC_API_KEY) return null;
+  _anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return _anthropicClient;
+}
+
+let _supabaseClient = null;
+let _supabaseLoader = null;
+
+export function setSupabaseClientLoader(loader) {
+  _supabaseLoader = loader;
+  _supabaseClient = null;
+}
+
+function getSupabaseClient() {
+  if (_supabaseClient) return _supabaseClient;
+  if (_supabaseLoader) {
+    _supabaseClient = _supabaseLoader();
+    return _supabaseClient;
+  }
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  _supabaseClient = createClient(url, key);
+  return _supabaseClient;
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function log(level, event, details = {}) {
+  const entry = JSON.stringify({ event, level, timestamp: new Date().toISOString(), ...details });
+  (level === 'warn' ? console.warn : console.info)(`[wireframe-qa] ${entry}`);
+}
+
+// ---------------------------------------------------------------------------
+// Screen-to-wireframe pairing
+// ---------------------------------------------------------------------------
+
+export function pairScreensToWireframes(screens, wireframes) {
+  const pairs = [];
+  const usedWireframeIndices = new Set();
+
+  for (let i = 0; i < screens.length; i++) {
+    const screen = screens[i];
+    const screenName = (screen.screen_id || screen.name || `screen_${i}`).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+    // Try exact name match first
+    let matchIdx = wireframes.findIndex((wf, idx) => {
+      if (usedWireframeIndices.has(idx)) return false;
+      const wfName = (wf.name || wf.screen_name || `wireframe_${idx}`).toLowerCase().replace(/[^a-z0-9]/g, '');
+      return screenName === wfName || screenName.includes(wfName) || wfName.includes(screenName);
+    });
+
+    if (matchIdx === -1) {
+      // Index fallback
+      matchIdx = i < wireframes.length ? i : -1;
+      if (matchIdx !== -1 && !usedWireframeIndices.has(matchIdx)) {
+        log('warn', 'wireframe_name_mismatch', {
+          screen: screen.screen_id || screen.name,
+          wireframe: wireframes[matchIdx]?.name,
+          fallback: 'index',
+        });
+      }
+    }
+
+    if (matchIdx !== -1 && !usedWireframeIndices.has(matchIdx)) {
+      usedWireframeIndices.add(matchIdx);
+      pairs.push({
+        screen,
+        wireframe: wireframes[matchIdx],
+        screen_name: screen.screen_id || screen.name || `screen_${i}`,
+        wireframe_name: wireframes[matchIdx].name || wireframes[matchIdx].screen_name || `wireframe_${matchIdx}`,
+      });
+    } else {
+      pairs.push({
+        screen,
+        wireframe: null,
+        screen_name: screen.screen_id || screen.name || `screen_${i}`,
+        wireframe_name: null,
+      });
+      log('warn', 'wireframe_unmatched_screen', { screen: screen.screen_id || screen.name });
+    }
+  }
+
+  const unpaired = wireframes.length - usedWireframeIndices.size;
+  if (unpaired > 0) {
+    log('warn', 'wireframe_unpaired_wireframes', { count: unpaired });
+  }
+
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Vision scoring prompt
+// ---------------------------------------------------------------------------
+
+function buildFidelityPrompt(wireframeSpec) {
+  return `You are a wireframe fidelity QA reviewer. Compare the screenshot against this ASCII wireframe specification:
+
+---WIREFRAME---
+${wireframeSpec}
+---END WIREFRAME---
+
+Score the screenshot on 4 dimensions (0-100 each):
+
+1. COMPONENT_PRESENCE — Are all UI components from the wireframe present? (buttons, forms, navigation bars, headers, footers, input fields, cards, etc.)
+2. LAYOUT_FIDELITY — Does the spatial arrangement match the wireframe zones? (header at top, sidebar left/right, content area proportions, grid structure)
+3. NAVIGATION_ACCURACY — Do links, menus, and navigation elements match the wireframe nav structure? (menu items, link destinations, breadcrumbs, tabs)
+4. SCREEN_PURPOSE_MATCH — Does the screen serve the function described in the wireframe? (dashboard shows data, form collects input, list displays items)
+
+Also list any specific components from the wireframe that are MISSING in the screenshot.
+
+Respond with valid JSON only:
+{
+  "component_presence": <0-100>,
+  "layout_fidelity": <0-100>,
+  "navigation_accuracy": <0-100>,
+  "screen_purpose_match": <0-100>,
+  "missing_elements": ["element1", "element2"],
+  "notes": "brief observation"
+}
+
+Do NOT include text before or after the JSON.`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-screen vision call
+// ---------------------------------------------------------------------------
+
+async function scoreScreen(client, base64Image, wireframeSpec) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PER_SCREEN_TIMEOUT_MS);
+
+  try {
+    const response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 500,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64Image } },
+          { type: 'text', text: buildFidelityPrompt(wireframeSpec) },
+        ],
+      }],
+    });
+
+    clearTimeout(timeout);
+    const text = response.content?.[0]?.text || '';
+    const parsed = JSON.parse(text);
+
+    // Validate dimension scores
+    for (const dim of DIMENSIONS) {
+      if (typeof parsed[dim] !== 'number' || parsed[dim] < 0 || parsed[dim] > 100) {
+        parsed[dim] = 0;
+      }
+    }
+
+    return {
+      status: 'scored',
+      dimensions: {
+        component_presence: parsed.component_presence,
+        layout_fidelity: parsed.layout_fidelity,
+        navigation_accuracy: parsed.navigation_accuracy,
+        screen_purpose_match: parsed.screen_purpose_match,
+      },
+      score: Math.round(DIMENSIONS.reduce((sum, d) => sum + parsed[d], 0) / DIMENSIONS.length),
+      missing_elements: Array.isArray(parsed.missing_elements) ? parsed.missing_elements : [],
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err.name === 'AbortError') {
+      return { status: 'api_timeout', dimensions: null, score: null, missing_elements: [], notes: 'Vision API timed out' };
+    }
+    return { status: 'api_error', dimensions: null, score: null, missing_elements: [], notes: err.message || String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Score wireframe fidelity for a venture's exported screens.
+ *
+ * @param {string} ventureId
+ * @param {string} projectId
+ * @param {Object} [options]
+ * @param {Array} [options.png_files_base64] - Pre-loaded PNGs [{screen_id, base64}]
+ * @param {Array} [options.wireframes] - Pre-loaded wireframe specs [{name, content}]
+ * @returns {Promise<Object>} Fidelity result (never throws)
+ */
+export async function scoreWireframeFidelity(ventureId, projectId, options = {}) {
+  try {
+    const client = getAnthropicClient();
+    if (!client) {
+      log('warn', 'vision_api_unavailable', { venture_id: ventureId });
+      return { status: 'vision_api_unavailable', overall_score: null, screens: [] };
+    }
+
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      log('warn', 'supabase_unavailable', { venture_id: ventureId });
+      return { status: 'supabase_unavailable', overall_score: null, screens: [] };
+    }
+
+    // Load PNG files (from options or from artifact)
+    let pngFiles = options.png_files_base64;
+    if (!pngFiles) {
+      const { data: exportArtifact } = await supabase
+        .from('venture_artifacts')
+        .select('metadata')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'stitch_design_export')
+        .eq('is_current', true)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      pngFiles = exportArtifact?.metadata?.png_files_base64;
+      if (!pngFiles || pngFiles.length === 0) {
+        log('warn', 'no_png_files', { venture_id: ventureId });
+        return { status: 'no_png_files', overall_score: null, screens: [] };
+      }
+    }
+
+    // Load wireframe specs (from options or from artifact)
+    let wireframes = options.wireframes;
+    if (!wireframes) {
+      const { data: wfArtifact } = await supabase
+        .from('venture_artifacts')
+        .select('metadata, content')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'blueprint_wireframes')
+        .eq('is_current', true)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      // Try metadata.wireframes, then metadata.screens, then parse content
+      wireframes = wfArtifact?.metadata?.wireframes
+        || wfArtifact?.metadata?.screens
+        || [];
+
+      if (wireframes.length === 0 && wfArtifact?.content) {
+        // Content may be a string with wireframe specs — treat as single wireframe
+        wireframes = [{ name: 'full_blueprint', content: wfArtifact.content }];
+      }
+
+      if (wireframes.length === 0) {
+        log('warn', 'no_wireframes', { venture_id: ventureId });
+        return { status: 'no_wireframes', overall_score: null, screens: [] };
+      }
+    }
+
+    // Pair screens to wireframes
+    const pairs = pairScreensToWireframes(pngFiles, wireframes);
+
+    // Score each pair sequentially
+    const screenResults = [];
+    for (const pair of pairs) {
+      if (!pair.wireframe) {
+        screenResults.push({
+          screen_name: pair.screen_name,
+          wireframe_name: null,
+          status: 'no_wireframe_match',
+          dimensions: null,
+          score: null,
+          missing_elements: [],
+          notes: 'No wireframe matched for this screen',
+        });
+        continue;
+      }
+
+      const wireframeContent = pair.wireframe.content || pair.wireframe.ascii || JSON.stringify(pair.wireframe);
+      const base64 = pair.screen.base64 || pair.screen.data;
+
+      if (!base64) {
+        screenResults.push({
+          screen_name: pair.screen_name,
+          wireframe_name: pair.wireframe_name,
+          status: 'download_failed',
+          dimensions: null,
+          score: null,
+          missing_elements: [],
+          notes: 'No base64 image data available',
+        });
+        continue;
+      }
+
+      log('info', 'scoring_screen', { screen: pair.screen_name, wireframe: pair.wireframe_name });
+      const result = await scoreScreen(client, base64, wireframeContent);
+
+      screenResults.push({
+        screen_name: pair.screen_name,
+        wireframe_name: pair.wireframe_name,
+        ...result,
+      });
+    }
+
+    // Compute overall score (average of scored screens)
+    const scoredScreens = screenResults.filter(s => typeof s.score === 'number');
+    const overall_score = scoredScreens.length > 0
+      ? Math.round(scoredScreens.reduce((sum, s) => sum + s.score, 0) / scoredScreens.length)
+      : null;
+
+    const fidelityResult = {
+      status: 'completed',
+      overall_score,
+      screens: screenResults,
+      scored_at: new Date().toISOString(),
+      model: ANTHROPIC_MODEL,
+      screen_count: pngFiles.length,
+      wireframe_count: wireframes.length,
+    };
+
+    // Persist wireframe_fidelity in stitch_qa_report
+    await persistFidelityResult(supabase, ventureId, fidelityResult);
+
+    log('info', 'scoring_complete', { venture_id: ventureId, overall_score, screens: screenResults.length });
+    return fidelityResult;
+  } catch (err) {
+    log('warn', 'scoring_failed', { venture_id: ventureId, error: err.message || String(err) });
+    return { status: 'degraded', overall_score: null, screens: [], error: err.message || String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Artifact persistence
+// ---------------------------------------------------------------------------
+
+async function persistFidelityResult(supabase, ventureId, fidelityResult) {
+  try {
+    // Check for existing stitch_qa_report
+    const { data: existing } = await supabase
+      .from('venture_artifacts')
+      .select('id, metadata, version')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'stitch_qa_report')
+      .eq('is_current', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (existing) {
+      // Additive merge: keep existing metadata, add wireframe_fidelity
+      const mergedMetadata = { ...existing.metadata, wireframe_fidelity: fidelityResult };
+      const newVersion = (existing.version || 1) + 1;
+
+      // Flip old version
+      await supabase
+        .from('venture_artifacts')
+        .update({ is_current: false })
+        .eq('id', existing.id);
+
+      // Insert new version
+      await supabase.from('venture_artifacts').insert({
+        venture_id: ventureId,
+        artifact_type: 'stitch_qa_report',
+        lifecycle_stage: 17,
+        is_current: true,
+        version: newVersion,
+        title: `Stitch Design QA Report (v${newVersion})`,
+        content: `Vision QA + Wireframe Fidelity — overall fidelity: ${fidelityResult.overall_score ?? 'N/A'}%`,
+        metadata: mergedMetadata,
+      });
+    } else {
+      // Create new stitch_qa_report with wireframe_fidelity only
+      await supabase.from('venture_artifacts').insert({
+        venture_id: ventureId,
+        artifact_type: 'stitch_qa_report',
+        lifecycle_stage: 17,
+        is_current: true,
+        version: 1,
+        title: 'Stitch Design QA Report (wireframe fidelity)',
+        content: `Wireframe Fidelity QA — overall fidelity: ${fidelityResult.overall_score ?? 'N/A'}%`,
+        metadata: { schema_version: 1, wireframe_fidelity: fidelityResult },
+      });
+    }
+
+    log('info', 'fidelity_persisted', { venture_id: ventureId });
+  } catch (err) {
+    log('warn', 'fidelity_persist_failed', { venture_id: ventureId, error: err.message || String(err) });
+  }
+}

--- a/tests/unit/stitch-wireframe-qa-loop.test.js
+++ b/tests/unit/stitch-wireframe-qa-loop.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildImprovedPrompt, runIterativeLoop } from '../../lib/eva/qa/stitch-wireframe-qa-loop.js';
+
+// ---------------------------------------------------------------------------
+// buildImprovedPrompt tests
+// ---------------------------------------------------------------------------
+
+describe('buildImprovedPrompt', () => {
+  it('includes missing elements in improved prompt', () => {
+    const result = buildImprovedPrompt('Generate Home screen', {
+      missing_elements: ['search bar', 'footer navigation'],
+      dimensions: { component_presence: 80, layout_fidelity: 80, navigation_accuracy: 80, screen_purpose_match: 80 },
+    });
+
+    expect(result).toContain('search bar');
+    expect(result).toContain('footer navigation');
+    expect(result).toContain('CRITICAL');
+    expect(result).toContain('MISSING');
+  });
+
+  it('includes low-scoring dimension feedback', () => {
+    const result = buildImprovedPrompt('Generate Home screen', {
+      missing_elements: [],
+      dimensions: { component_presence: 50, layout_fidelity: 90, navigation_accuracy: 40, screen_purpose_match: 85 },
+    });
+
+    expect(result).toContain('UI components');
+    expect(result).toContain('50%');
+    expect(result).toContain('navigation links');
+    expect(result).toContain('40%');
+    expect(result).not.toContain('spatial layout'); // 90 is above threshold
+  });
+
+  it('returns original prompt when no feedback needed', () => {
+    const result = buildImprovedPrompt('Generate Home screen', {
+      missing_elements: [],
+      dimensions: { component_presence: 80, layout_fidelity: 80, navigation_accuracy: 80, screen_purpose_match: 80 },
+    });
+
+    expect(result).toBe('Generate Home screen');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIterativeLoop tests
+// ---------------------------------------------------------------------------
+
+describe('runIterativeLoop', () => {
+  it('skips screens already above threshold', async () => {
+    const initialResult = {
+      status: 'completed',
+      overall_score: 85,
+      screens: [
+        { screen_name: 'Home', score: 90, dimensions: {}, missing_elements: [] },
+        { screen_name: 'About', score: 80, dimensions: {}, missing_elements: [] },
+      ],
+    };
+
+    const regenerate = vi.fn();
+    const result = await runIterativeLoop('v1', 'p1', initialResult, { regenerate });
+
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(result.screens[0].iteration_count).toBe(0);
+    expect(result.screens[1].iteration_count).toBe(0);
+    expect(result.iterations_used).toBe(0);
+  });
+
+  it('re-generates screen below threshold and exits on threshold met', async () => {
+    const initialResult = {
+      status: 'completed',
+      overall_score: 50,
+      screens: [
+        { screen_name: 'Home', score: 50, dimensions: { component_presence: 40, layout_fidelity: 60, navigation_accuracy: 50, screen_purpose_match: 50 }, missing_elements: ['nav bar'] },
+      ],
+    };
+
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reScore = vi.fn().mockResolvedValue({
+      screen_name: 'Home',
+      score: 80,
+      dimensions: { component_presence: 80, layout_fidelity: 80, navigation_accuracy: 80, screen_purpose_match: 80 },
+      missing_elements: [],
+    });
+
+    const result = await runIterativeLoop('v1', 'p1', initialResult, { regenerate, reScore });
+
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(reScore).toHaveBeenCalledTimes(1);
+    expect(result.screens[0].iteration_count).toBe(1);
+    expect(result.screens[0].score).toBe(80);
+    expect(result.iterations_used).toBe(1);
+  });
+
+  it('caps at 3 iterations even if threshold not met', async () => {
+    const initialResult = {
+      status: 'completed',
+      overall_score: 30,
+      screens: [
+        { screen_name: 'Home', score: 30, dimensions: { component_presence: 30, layout_fidelity: 30, navigation_accuracy: 30, screen_purpose_match: 30 }, missing_elements: ['everything'] },
+      ],
+    };
+
+    let callCount = 0;
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reScore = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve({
+        screen_name: 'Home',
+        score: 30 + (callCount * 10), // 40, 50, 60 — never reaches 70
+        dimensions: { component_presence: 50, layout_fidelity: 50, navigation_accuracy: 50, screen_purpose_match: 50 },
+        missing_elements: ['still missing'],
+      });
+    });
+
+    const result = await runIterativeLoop('v1', 'p1', initialResult, { regenerate, reScore });
+
+    expect(regenerate).toHaveBeenCalledTimes(3);
+    expect(reScore).toHaveBeenCalledTimes(3);
+    expect(result.screens[0].iteration_count).toBe(3);
+    expect(result.screens[0].iteration_history).toHaveLength(4); // initial + 3 iterations
+    expect(result.iterations_used).toBe(3);
+  });
+
+  it('handles regeneration failure gracefully', async () => {
+    const initialResult = {
+      status: 'completed',
+      overall_score: 40,
+      screens: [
+        { screen_name: 'Home', score: 40, dimensions: {}, missing_elements: [] },
+      ],
+    };
+
+    const regenerate = vi.fn().mockRejectedValue(new Error('Stitch socket closed'));
+    const result = await runIterativeLoop('v1', 'p1', initialResult, { regenerate });
+
+    expect(result.screens[0].iteration_count).toBe(1);
+    expect(result.screens[0].iteration_history[1].error).toBe('regeneration_failed');
+    expect(result.loop_status).toBe('completed');
+  });
+
+  it('persists iteration history with per-iteration scores', async () => {
+    const initialResult = {
+      status: 'completed',
+      overall_score: 50,
+      screens: [
+        { screen_name: 'Home', score: 50, dimensions: { component_presence: 50, layout_fidelity: 50, navigation_accuracy: 50, screen_purpose_match: 50 }, missing_elements: ['sidebar'] },
+      ],
+    };
+
+    let callCount = 0;
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reScore = vi.fn().mockImplementation(() => {
+      callCount++;
+      const score = callCount === 1 ? 65 : 75;
+      return Promise.resolve({ screen_name: 'Home', score, dimensions: {}, missing_elements: [] });
+    });
+
+    const result = await runIterativeLoop('v1', 'p1', initialResult, { regenerate, reScore });
+
+    const history = result.screens[0].iteration_history;
+    expect(history).toHaveLength(3); // initial(50) + iter1(65) + iter2(75)
+    expect(history[0]).toEqual({ iteration: 0, score: 50 });
+    expect(history[1]).toEqual({ iteration: 1, score: 65 });
+    expect(history[2]).toEqual({ iteration: 2, score: 75 });
+    expect(result.screens[0].iteration_count).toBe(2);
+  });
+
+  it('returns initial result when no screens to iterate', async () => {
+    const initialResult = { status: 'completed', overall_score: null, screens: [] };
+    const result = await runIterativeLoop('v1', 'p1', initialResult);
+    expect(result).toEqual(initialResult);
+  });
+});

--- a/tests/unit/stitch-wireframe-qa.test.js
+++ b/tests/unit/stitch-wireframe-qa.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  pairScreensToWireframes,
+  scoreWireframeFidelity,
+  setAnthropicClientLoader,
+  setSupabaseClientLoader,
+} from '../../lib/eva/qa/stitch-wireframe-qa.js';
+
+// ---------------------------------------------------------------------------
+// Pairing tests
+// ---------------------------------------------------------------------------
+
+describe('pairScreensToWireframes', () => {
+  it('pairs screens to wireframes by exact name match', () => {
+    const screens = [
+      { screen_id: 'Home', base64: 'abc' },
+      { screen_id: 'About', base64: 'def' },
+    ];
+    const wireframes = [
+      { name: 'About', content: 'about wireframe' },
+      { name: 'Home', content: 'home wireframe' },
+    ];
+
+    const pairs = pairScreensToWireframes(screens, wireframes);
+
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].screen_name).toBe('Home');
+    expect(pairs[0].wireframe_name).toBe('Home');
+    expect(pairs[1].screen_name).toBe('About');
+    expect(pairs[1].wireframe_name).toBe('About');
+  });
+
+  it('falls back to index pairing when names mismatch', () => {
+    const screens = [
+      { screen_id: 'screen_1', base64: 'abc' },
+      { screen_id: 'screen_2', base64: 'def' },
+    ];
+    const wireframes = [
+      { name: 'Home', content: 'home' },
+      { name: 'About', content: 'about' },
+    ];
+
+    const pairs = pairScreensToWireframes(screens, wireframes);
+
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].wireframe_name).toBe('Home');
+    expect(pairs[1].wireframe_name).toBe('About');
+  });
+
+  it('handles more screens than wireframes', () => {
+    const screens = [
+      { screen_id: 'A', base64: 'a' },
+      { screen_id: 'B', base64: 'b' },
+      { screen_id: 'C', base64: 'c' },
+    ];
+    const wireframes = [
+      { name: 'A', content: 'wf-a' },
+      { name: 'B', content: 'wf-b' },
+    ];
+
+    const pairs = pairScreensToWireframes(screens, wireframes);
+
+    expect(pairs).toHaveLength(3);
+    expect(pairs[0].wireframe).not.toBeNull();
+    expect(pairs[1].wireframe).not.toBeNull();
+    expect(pairs[2].wireframe).toBeNull();
+  });
+
+  it('handles more wireframes than screens', () => {
+    const screens = [{ screen_id: 'Home', base64: 'a' }];
+    const wireframes = [
+      { name: 'Home', content: 'wf1' },
+      { name: 'About', content: 'wf2' },
+      { name: 'Contact', content: 'wf3' },
+    ];
+
+    const pairs = pairScreensToWireframes(screens, wireframes);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].wireframe_name).toBe('Home');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreWireframeFidelity tests
+// ---------------------------------------------------------------------------
+
+describe('scoreWireframeFidelity', () => {
+  beforeEach(() => {
+    setAnthropicClientLoader(null);
+    setSupabaseClientLoader(null);
+  });
+
+  it('returns degraded when ANTHROPIC_API_KEY missing', async () => {
+    const origKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    setAnthropicClientLoader(() => null);
+
+    const result = await scoreWireframeFidelity('v1', 'p1');
+
+    expect(result.status).toBe('vision_api_unavailable');
+    expect(result.overall_score).toBeNull();
+    expect(result.screens).toEqual([]);
+
+    if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
+  });
+
+  it('scores 7 screens with mock vision API', async () => {
+    const mockResponse = {
+      content: [{
+        text: JSON.stringify({
+          component_presence: 85,
+          layout_fidelity: 90,
+          navigation_accuracy: 80,
+          screen_purpose_match: 95,
+          missing_elements: ['search bar'],
+          notes: 'Good fidelity overall',
+        }),
+      }],
+    };
+
+    const mockClient = { messages: { create: vi.fn().mockResolvedValue(mockResponse) } };
+    setAnthropicClientLoader(() => mockClient);
+
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: null }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    };
+    setSupabaseClientLoader(() => mockSupabase);
+
+    const screens = Array.from({ length: 7 }, (_, i) => ({
+      screen_id: `screen_${i}`,
+      base64: `base64data${i}`,
+    }));
+    const wireframes = Array.from({ length: 7 }, (_, i) => ({
+      name: `screen_${i}`,
+      content: `wireframe spec for screen ${i}`,
+    }));
+
+    const result = await scoreWireframeFidelity('v1', 'p1', {
+      png_files_base64: screens,
+      wireframes,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.screens).toHaveLength(7);
+    expect(result.overall_score).toBe(88); // avg of 85+90+80+95 = 87.5 rounded
+    expect(result.screens[0].dimensions.component_presence).toBe(85);
+    expect(result.screens[0].missing_elements).toContain('search bar');
+    expect(mockClient.messages.create).toHaveBeenCalledTimes(7);
+  });
+
+  it('handles per-screen download failure gracefully', async () => {
+    const mockResponse = {
+      content: [{ text: JSON.stringify({
+        component_presence: 80, layout_fidelity: 80,
+        navigation_accuracy: 80, screen_purpose_match: 80,
+        missing_elements: [], notes: 'ok',
+      }) }],
+    };
+
+    const mockClient = { messages: { create: vi.fn().mockResolvedValue(mockResponse) } };
+    setAnthropicClientLoader(() => mockClient);
+
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: null }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    };
+    setSupabaseClientLoader(() => mockSupabase);
+
+    const screens = [
+      { screen_id: 'good', base64: 'valid_data' },
+      { screen_id: 'bad', base64: null }, // no image data
+    ];
+    const wireframes = [
+      { name: 'good', content: 'wf1' },
+      { name: 'bad', content: 'wf2' },
+    ];
+
+    const result = await scoreWireframeFidelity('v1', 'p1', {
+      png_files_base64: screens,
+      wireframes,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.screens[0].status).toBe('scored');
+    expect(result.screens[1].status).toBe('download_failed');
+    expect(result.overall_score).toBe(80); // only scored screen counts
+  });
+});


### PR DESCRIPTION
## Summary
- Create `stitch-wireframe-qa-loop.js` — iterative quality loop that re-generates failing Stitch screens
- Injects QA feedback (missing elements, low-scoring dimensions) into improved generation prompts
- Max 3 iterations per screen with early exit on threshold met (default 70%)
- Tracks iteration history with per-iteration scores in wireframe_fidelity report

## Test plan
- [x] 9 unit tests passing (prompt improvement, iteration cap, early exit, failure handling)
- [ ] Manual: Run venture with low-scoring screens, verify re-generation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)