### PR TITLE
feat(SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-F): screen.edit() for iterative QA

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -579,6 +579,47 @@ export async function exportScreenImage(screenId, options = {}) {
 }
 
 /**
+ * Edit an existing screen with a targeted prompt.
+ * Uses fire-and-assume-success pattern (same as generate).
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-F
+ *
+ * @param {string} screenId - Screen ID to edit
+ * @param {string} editPrompt - Targeted edit instruction
+ * @param {string} projectId - Project ID
+ * @returns {Promise<{status: string, screen_id?: string, error?: string}>}
+ */
+export async function editScreen(screenId, editPrompt, projectId) {
+  try {
+    const apiKey = getApiKey();
+    const sdk = await getSDK();
+    const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
+    const project = client.project(projectId);
+    try {
+      const screen = await project.getScreen(screenId);
+      const edited = await screen.edit(editPrompt);
+      const editedId = edited?.id || edited?.screen_id || screenId;
+      console.info(`[stitch-client] editScreen: ${editedId} edited successfully`);
+      try { await client.close(); } catch { /* ignore */ }
+      return { status: 'edited', screen_id: editedId };
+    } catch (err) {
+      const msg = err.message || '';
+      const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
+      if (isTransport) {
+        console.info('[stitch-client] editScreen: fired (socket dropped — server processing)');
+        try { await client.close(); } catch { /* ignore */ }
+        return { status: 'fired', screen_id: screenId };
+      }
+      console.warn(`[stitch-client] editScreen error: ${msg.slice(0, 120)}`);
+      try { await client.close(); } catch { /* ignore */ }
+      return { status: 'error', screen_id: screenId, error: msg };
+    }
+  } catch (outerErr) {
+    console.warn(`[stitch-client] editScreen unexpected: ${outerErr.message}`);
+    return { status: 'error', screen_id: screenId, error: outerErr.message };
+  }
+}
+
+/**
  * List all screens in a project.
  * @param {string} projectId - Stitch project ID
  * @returns {Promise<Array<{screen_id: string, name: string}>>}

--- a/lib/eva/qa/stitch-edit-prompt-builder.js
+++ b/lib/eva/qa/stitch-edit-prompt-builder.js
@@ -1,0 +1,58 @@
+/**
+ * Stitch Edit Prompt Builder
+ * SD: SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-F
+ *
+ * Translates wireframe fidelity QA results (missing elements and low-scoring
+ * dimensions) into targeted Stitch screen.edit() prompts.
+ */
+
+const DIMENSION_LABELS = {
+  components: 'component presence (buttons, forms, navigation elements)',
+  layout: 'layout fidelity (spatial arrangement and zones)',
+  navigation: 'navigation accuracy (links, menus, navigation structure)',
+  purpose: 'screen purpose (overall function and user flow)',
+};
+
+/**
+ * Build a targeted edit prompt from QA fidelity results.
+ *
+ * @param {Object} qaResult - Fidelity QA result for a single screen
+ * @param {string[]} [qaResult.missing_elements] - Specific missing UI elements
+ * @param {Object} [qaResult.dimensions] - Per-dimension scores {components, layout, navigation, purpose}
+ * @param {number} [qaResult.score] - Overall fidelity score (0-100)
+ * @param {string} [qaResult.name] - Screen name for context
+ * @returns {string} Edit prompt for screen.edit()
+ */
+export function buildEditPrompt(qaResult) {
+  if (!qaResult || typeof qaResult !== 'object') {
+    return 'Improve the overall design quality and ensure all expected UI elements are present.';
+  }
+
+  const parts = [];
+
+  // Missing elements — most actionable feedback
+  const missing = qaResult.missing_elements || [];
+  if (missing.length > 0) {
+    parts.push(`Add the following missing elements: ${missing.join(', ')}.`);
+  }
+
+  // Low-scoring dimensions — guide structural improvements
+  const dimensions = qaResult.dimensions || {};
+  const lowDimensions = Object.entries(dimensions)
+    .filter(([, score]) => typeof score === 'number' && score < 70)
+    .sort(([, a], [, b]) => a - b); // worst first
+
+  for (const [dim, score] of lowDimensions) {
+    const label = DIMENSION_LABELS[dim] || dim;
+    parts.push(`Improve ${label} (currently ${score}% fidelity).`);
+  }
+
+  // If no specific feedback, provide generic improvement
+  if (parts.length === 0) {
+    return 'Refine the design to better match the wireframe specification. Ensure all components are present and properly laid out.';
+  }
+
+  // Context prefix
+  const screenContext = qaResult.name ? `For the "${qaResult.name}" screen: ` : '';
+  return `${screenContext}${parts.join(' ')}`;
+}

--- a/tests/unit/stitch-edit-prompt-builder.test.js
+++ b/tests/unit/stitch-edit-prompt-builder.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { buildEditPrompt } from '../../lib/eva/qa/stitch-edit-prompt-builder.js';
+
+describe('buildEditPrompt', () => {
+  describe('missing elements', () => {
+    it('includes missing elements in prompt', () => {
+      const result = buildEditPrompt({
+        missing_elements: ['navigation bar', 'search button'],
+      });
+      expect(result).toContain('navigation bar');
+      expect(result).toContain('search button');
+    });
+
+    it('handles single missing element', () => {
+      const result = buildEditPrompt({ missing_elements: ['sidebar'] });
+      expect(result).toContain('sidebar');
+    });
+  });
+
+  describe('low dimensions', () => {
+    it('mentions low layout score', () => {
+      const result = buildEditPrompt({
+        dimensions: { components: 90, layout: 30, navigation: 85, purpose: 90 },
+      });
+      expect(result).toContain('layout');
+      expect(result).toContain('30%');
+    });
+
+    it('mentions multiple low dimensions sorted by score', () => {
+      const result = buildEditPrompt({
+        dimensions: { components: 20, layout: 40, navigation: 85, purpose: 90 },
+      });
+      expect(result).toContain('component');
+      expect(result).toContain('layout');
+      expect(result.indexOf('component')).toBeLessThan(result.indexOf('layout'));
+    });
+
+    it('skips dimensions above 70 and returns generic prompt', () => {
+      const result = buildEditPrompt({
+        dimensions: { components: 90, layout: 80, navigation: 85, purpose: 95 },
+      });
+      // All dimensions are above 70, so no specific dimension feedback — generic prompt
+      expect(result).toContain('Refine');
+      expect(result).not.toContain('currently');
+    });
+  });
+
+  describe('combined feedback', () => {
+    it('includes both missing elements and low dimensions', () => {
+      const result = buildEditPrompt({
+        missing_elements: ['footer'],
+        dimensions: { layout: 45 },
+      });
+      expect(result).toContain('footer');
+      expect(result).toContain('layout');
+    });
+
+    it('includes screen name as context', () => {
+      const result = buildEditPrompt({
+        name: 'Dashboard',
+        missing_elements: ['chart widget'],
+      });
+      expect(result).toContain('Dashboard');
+      expect(result).toContain('chart widget');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns generic prompt for null input', () => {
+      const result = buildEditPrompt(null);
+      expect(result).toContain('Improve');
+    });
+
+    it('returns generic prompt for undefined input', () => {
+      const result = buildEditPrompt(undefined);
+      expect(result.length).toBeGreaterThan(10);
+    });
+
+    it('returns generic prompt for empty object', () => {
+      const result = buildEditPrompt({});
+      expect(result).toContain('Refine');
+    });
+
+    it('returns generic prompt for empty missing_elements and high dimensions', () => {
+      const result = buildEditPrompt({
+        missing_elements: [],
+        dimensions: { components: 90, layout: 85, navigation: 80, purpose: 95 },
+      });
+      expect(result).toContain('Refine');
+    });
+
+    it('handles non-numeric dimension scores gracefully', () => {
+      const result = buildEditPrompt({
+        dimensions: { components: 'high', layout: null },
+      });
+      // Should not crash, should return generic
+      expect(result).toContain('Refine');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `editScreen()` to stitch-client.js using fire-and-assume-success pattern
- Create `stitch-edit-prompt-builder.js` with `buildEditPrompt(qaResult)` that translates missing elements and low-scoring dimensions into targeted edit instructions
- Enables edit-first, regenerate-as-fallback strategy for the iterative QA loop

## Test plan
- [x] 12 unit tests for prompt builder (all pass)
- [x] Smoke tests pass (15/15)
- [ ] Test editScreen on a real Stitch screen and verify edit applied
- [ ] Verify edit prompt includes specific missing elements from QA feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)