### PR TITLE
fix: claim-validity-gate wrong_worktree — add isRealWorktree + auto-recovery

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -17,8 +17,72 @@
  */
 
 import path from 'path';
-import { realpathSync } from 'fs';
+import { realpathSync, existsSync, readdirSync } from 'fs';
+import { execSync } from 'child_process';
 import { resolveOwnSession } from './resolve-own-session.js';
+
+// ── Worktree validation helpers (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-074) ────
+
+/** Module-level cache for isRealWorktree results (2s TTL). */
+export const _worktreeCache = new Map();
+const WORKTREE_CACHE_TTL_MS = 2000;
+
+/**
+ * Check if a path is a registered git worktree by querying `git worktree list --porcelain`.
+ * Memoized with 2s TTL to avoid repeated subprocess calls during a single handoff.
+ *
+ * @param {string} worktreePath - Absolute path to check
+ * @returns {boolean} true if path is in git worktree list
+ */
+export function isRealWorktree(worktreePath) {
+  const cached = _worktreeCache.get(worktreePath);
+  if (cached && Date.now() - cached.ts < WORKTREE_CACHE_TTL_MS) return cached.val;
+
+  let result = false;
+  try {
+    const output = execSync('git worktree list --porcelain', {
+      timeout: 2000,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // Porcelain format: "worktree /absolute/path\n" lines
+    const registeredPaths = output
+      .split('\n')
+      .filter(l => l.startsWith('worktree '))
+      .map(l => {
+        try { return realpathSync(l.slice('worktree '.length).trim()); } catch { return null; }
+      })
+      .filter(Boolean);
+
+    let normalizedInput;
+    try { normalizedInput = realpathSync(worktreePath); } catch { normalizedInput = null; }
+    result = normalizedInput != null && registeredPaths.includes(normalizedInput);
+  } catch {
+    // execSync timeout or git error — treat as not a real worktree
+    result = false;
+  }
+
+  _worktreeCache.set(worktreePath, { val: result, ts: Date.now() });
+  return result;
+}
+
+/**
+ * Attempt to recover a stale worktree_path by scanning .worktrees/<SD-KEY>/.
+ * Returns the recovered path or null.
+ */
+function tryRecoverWorktreePath(sdKey) {
+  try {
+    // Find git root
+    const gitRoot = execSync('git rev-parse --show-toplevel', {
+      timeout: 2000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const worktreeDir = path.join(gitRoot, '.worktrees', sdKey);
+    if (existsSync(worktreeDir) && isRealWorktree(worktreeDir)) {
+      return worktreeDir;
+    }
+  } catch { /* recovery failed */ }
+  return null;
+}
 
 /**
  * Structured error for claim validity failures. Carries discriminant `reason`
@@ -156,19 +220,51 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
   // Claim is ours. Enforce that cwd is inside the SD's registered worktree.
   // Exception: sd-start.js with allowMainRepoForAcquisition=true — it creates the worktree.
   if (sd.worktree_path && !allowMainRepoForAcquisition) {
+    let effectiveWorktreePath = sd.worktree_path;
+
+    // Step 3a: Validate stored path is a real git worktree (not phantom/stale)
+    if (!isRealWorktree(effectiveWorktreePath)) {
+      // Attempt auto-recovery: scan .worktrees/<SD-KEY>/
+      const recovered = tryRecoverWorktreePath(sdKey);
+      if (recovered) {
+        // Update DB with recovered path (idempotent — only if different)
+        try {
+          const resolvedRecovered = realpathSync(recovered);
+          if (resolvedRecovered !== sd.worktree_path) {
+            await supabase
+              .from('strategic_directives_v2')
+              .update({ worktree_path: resolvedRecovered })
+              .eq('sd_key', sdKey);
+          }
+          effectiveWorktreePath = resolvedRecovered;
+        } catch {
+          effectiveWorktreePath = recovered;
+        }
+      } else {
+        // Recovery failed — worktree is truly stale/deleted
+        throw new ClaimIdentityError({
+          reason: 'stale_worktree',
+          operation, sdKey,
+          expectedWorktree: sd.worktree_path,
+          actualCwd: process.cwd(),
+          remediation: `Registered worktree at ${sd.worktree_path} is no longer a valid git worktree (removed or corrupted).\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree and update the database.`
+        });
+      }
+    }
+
+    // Step 3b: Verify cwd is inside the (possibly recovered) worktree
     let expectedWt;
     let actualCwd;
     try {
-      expectedWt = realpathSync(sd.worktree_path);
+      expectedWt = realpathSync(effectiveWorktreePath);
       actualCwd = realpathSync(process.cwd());
     } catch (e) {
-      // Path doesn't resolve (worktree deleted?). Fail closed with diagnostic.
       throw new ClaimIdentityError({
         reason: 'wrong_worktree',
         operation, sdKey,
-        expectedWorktree: sd.worktree_path,
+        expectedWorktree: effectiveWorktreePath,
         actualCwd: process.cwd(),
-        remediation: `Worktree path resolution failed: ${e.message}. The worktree may have been deleted. Run: npm run sd:start ${sdKey} to recreate it.`
+        remediation: `Worktree path resolution failed: ${e.message}.\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree.`
       });
     }
 

--- a/tests/unit/claim-validity-gate.test.js
+++ b/tests/unit/claim-validity-gate.test.js
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for claim-validity-gate.js — CHECK 3 worktree isolation enhancements.
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-074
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before importing the module
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Normalize to forward slashes (simulates canonical path on Windows)
+    realpathSync: vi.fn((p) => p.replace(/\\/g, '/')),
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+  };
+});
+vi.mock('../../lib/resolve-own-session.js', () => ({
+  resolveOwnSession: vi.fn(),
+}));
+
+const { execSync } = await import('child_process');
+const { realpathSync, existsSync } = await import('fs');
+const { resolveOwnSession } = await import('../../lib/resolve-own-session.js');
+const { assertValidClaim, isRealWorktree, ClaimIdentityError, _worktreeCache } = await import('../../lib/claim-validity-gate.js');
+
+function mockSupabase(sdData) {
+  const updateEq = vi.fn().mockResolvedValue({ error: null });
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({ data: sdData, error: null }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({ eq: updateEq }),
+    }),
+  };
+}
+
+const WORKTREE_LIST_TEMPLATE = (paths) =>
+  paths.map(p => `worktree ${p}\nHEAD abc123\nbranch refs/heads/main\n`).join('\n');
+
+describe('isRealWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _worktreeCache.clear();
+    realpathSync.mockImplementation((p) => p.replace(/\\/g, '/'));
+  });
+
+  it('returns true for a registered worktree', () => {
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main', '/repo/.worktrees/SD-FOO-001']));
+    expect(isRealWorktree('/repo/.worktrees/SD-FOO-001')).toBe(true);
+  });
+
+  it('returns false for a phantom path not in git registry', () => {
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main']));
+    expect(isRealWorktree('/repo/.worktrees/SD-PHANTOM-001')).toBe(false);
+  });
+
+  it('returns false when execSync times out', () => {
+    execSync.mockImplementation(() => { throw new Error('timed out'); });
+    expect(isRealWorktree('/any/path')).toBe(false);
+  });
+
+  it('returns false when realpathSync fails on input path', () => {
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main']));
+    realpathSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(isRealWorktree('/deleted/path')).toBe(false);
+  });
+
+  it('uses cache on second call within TTL', () => {
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main', '/repo/.worktrees/SD-CACHE']));
+    expect(isRealWorktree('/repo/.worktrees/SD-CACHE')).toBe(true);
+    expect(execSync).toHaveBeenCalledTimes(1);
+    // Second call should hit cache
+    expect(isRealWorktree('/repo/.worktrees/SD-CACHE')).toBe(true);
+    expect(execSync).toHaveBeenCalledTimes(1); // still 1
+  });
+});
+
+describe('assertValidClaim — CHECK 3 enhanced', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _worktreeCache.clear();
+    realpathSync.mockImplementation((p) => p.replace(/\\/g, '/'));
+    resolveOwnSession.mockResolvedValue({
+      data: { session_id: 'sess-123' },
+      source: 'env_var',
+    });
+  });
+
+  it('passes when cwd is inside valid worktree', async () => {
+    const wt = '/repo/.worktrees/SD-PASS-001';
+    vi.spyOn(process, 'cwd').mockReturnValue(wt);
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main', wt]));
+
+    const sb = mockSupabase({
+      sd_key: 'SD-PASS-001',
+      claiming_session_id: 'sess-123',
+      worktree_path: wt,
+      current_phase: 'EXEC',
+    });
+
+    const result = await assertValidClaim(sb, 'SD-PASS-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('self');
+  });
+
+  it('throws stale_worktree when path is phantom and recovery fails', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/repo/main');
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main'])); // stored path NOT in list
+    existsSync.mockReturnValue(false);
+
+    const sb = mockSupabase({
+      sd_key: 'SD-STALE-001',
+      claiming_session_id: 'sess-123',
+      worktree_path: '/repo/.worktrees/SD-STALE-001',
+      current_phase: 'EXEC',
+    });
+
+    try {
+      await assertValidClaim(sb, 'SD-STALE-001', { operation: 'test_op' });
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ClaimIdentityError);
+      expect(e.reason).toBe('stale_worktree');
+      expect(e.remediation).toContain('npm run sd:start SD-STALE-001');
+    }
+  });
+
+  it('auto-recovers when worktree found at .worktrees/<SD-KEY>/', async () => {
+    const recoveredPath = '/repo/.worktrees/SD-REC-001';
+    vi.spyOn(process, 'cwd').mockReturnValue(recoveredPath);
+
+    // isRealWorktree calls: the stored path (OLD) is NOT registered, the recovered path IS
+    const validList = WORKTREE_LIST_TEMPLATE(['/repo/main', recoveredPath]);
+    execSync.mockImplementation((cmd) => {
+      if (cmd.includes('rev-parse')) return '/repo\n';
+      return validList;
+    });
+    existsSync.mockReturnValue(true);
+
+    const sb = mockSupabase({
+      sd_key: 'SD-REC-001',
+      claiming_session_id: 'sess-123',
+      worktree_path: '/repo/.worktrees/SD-REC-001-OLD', // stale path
+      current_phase: 'EXEC',
+    });
+
+    const result = await assertValidClaim(sb, 'SD-REC-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('self');
+    // Verify DB was updated
+    expect(sb.from).toHaveBeenCalled();
+  });
+
+  it('skips CHECK 3 when worktree_path is null', async () => {
+    const sb = mockSupabase({
+      sd_key: 'SD-NULL-001',
+      claiming_session_id: 'sess-123',
+      worktree_path: null,
+      current_phase: 'EXEC',
+    });
+
+    const result = await assertValidClaim(sb, 'SD-NULL-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('self');
+    // execSync should NOT have been called (no worktree check)
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it('throws wrong_worktree with cd command when cwd is outside valid worktree', async () => {
+    const wt = '/repo/.worktrees/SD-DIR-001';
+    vi.spyOn(process, 'cwd').mockReturnValue('/repo/main');
+    execSync.mockReturnValue(WORKTREE_LIST_TEMPLATE(['/repo/main', wt]));
+
+    const sb = mockSupabase({
+      sd_key: 'SD-DIR-001',
+      claiming_session_id: 'sess-123',
+      worktree_path: wt,
+      current_phase: 'EXEC',
+    });
+
+    try {
+      await assertValidClaim(sb, 'SD-DIR-001', { operation: 'test_op' });
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ClaimIdentityError);
+      expect(e.reason).toBe('wrong_worktree');
+      expect(e.remediation).toContain(`cd "${wt}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isRealWorktree()` helper validating paths against `git worktree list --porcelain` with 2s timeout + memoization
- CHECK 3 now detects phantom/stale worktree paths before `realpathSync` comparison
- Auto-recovery scans `.worktrees/<SD-KEY>/` and updates DB when valid worktree found at expected location
- New `stale_worktree` error reason with clear `npm run sd:start` remediation

Fixes 5 patterns (23 occurrences) of `wrong_worktree` gate failures on EXEC-TO-PLAN and LEAD-FINAL-APPROVAL handoffs.

## Test plan
- [x] 10 unit tests covering: valid worktree, phantom path, stale path, auto-recovery, null worktree_path, wrong dir, cache behavior
- [x] All tests pass (vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)