### PR TITLE
fix: auto-release stale inactive claims in sd:next queue

### DIFF
--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -24,6 +24,7 @@ import { getStaleThresholdSeconds } from '../../../lib/claim/stale-threshold.js'
  * Relationships:
  *   same_conversation - Post-compaction same conversation (terminal_id match)
  *   other_active      - Different session, heartbeat fresh
+ *   stale_inactive    - Session status is released/stale/idle (safe to auto-release)
  *   stale_dead        - Stale heartbeat + same host + PID dead (safe to auto-release)
  *   stale_alive       - Stale heartbeat + same host + PID alive (risky)
  *   stale_remote      - Stale heartbeat + different host (can't check PID)
@@ -59,6 +60,17 @@ export function analyzeClaimRelationship({ claimingSessionId: _claimingSessionId
         pid: claimPid
       };
     }
+  }
+
+  // Session explicitly released/stale/idle → safe to auto-release regardless of heartbeat
+  const sessionStatus = claimingSession?.status || 'unknown';
+  if (['released', 'stale', 'idle'].includes(sessionStatus)) {
+    return {
+      relationship: 'stale_inactive',
+      canAutoRelease: true,
+      displayLabel: 'STALE (inactive)',
+      pid: claimPid
+    };
   }
 
   // Fresh heartbeat → active different session

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -272,6 +272,8 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
           });
           if (analysis.relationship === 'same_conversation') {
             actionable = true;
+          } else if (analysis.relationship === 'stale_inactive') {
+            actionable = true; // Session explicitly released/stale/idle
           } else if (analysis.relationship === 'stale_dead') {
             // Don't assume orphaned — check if SD itself shows recent work
             // (session may have compacted, restarted, or be mid-execution)

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -191,6 +191,19 @@ async function displaySDItem(item, indent, childItems, allItems, sessionContext)
           console.log(`${colors.yellow}${indent}        └─ Session ${shortId} (${ageMin}m) — PID ${claimAnalysis.pid} is alive, likely busy${colors.reset}`);
           console.log(`${colors.dim}${indent}        └─ Heartbeat stale but process running — risky to release${colors.reset}`);
           break;
+        case 'stale_inactive': {
+          console.log(`${colors.red}${indent}        └─ Session ${shortId} (${ageMin}m) — session ${claimAnalysis.displayLabel}${colors.reset}`);
+          if (supabase) {
+            const released = await autoReleaseStaleDeadClaim(supabase, claimedBySession);
+            if (released) {
+              console.log(`${colors.green}${indent}        └─ Auto-released inactive session claim${colors.reset}`);
+              claimedSDs.delete(sdId);
+            }
+          } else {
+            console.log(`${colors.yellow}${indent}        └─ Release: /claim release ${claimedBySession}${colors.reset}`);
+          }
+          break;
+        }
         case 'stale_remote':
           console.log(`${colors.yellow}${indent}        └─ Session ${shortId} (${ageMin}m) — different host, cannot verify PID${colors.reset}`);
           console.log(`${colors.yellow}${indent}        └─ Release: /claim release ${claimedBySession}${colors.reset}`);


### PR DESCRIPTION
## Summary
- Add `stale_inactive` relationship type to `claim-analysis.js` — detects sessions with status `released`/`stale`/`idle`
- Auto-releases these claims during `npm run sd:next` queue display (tracks.js)
- Marks stale-inactive claimed SDs as actionable in recommendations.js

Prevents `foreign_claim` errors when starting SDs that were claimed by sessions that terminated without releasing. Previously only `stale_dead` (same host + PID dead) claims were auto-released.

## Test plan
- [x] `npm run sd:next` runs without errors
- [x] All 3 modules import cleanly
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)