### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PAT-LEADTOPLAN-002): auto-create session row on env var match

### DIFF
--- a/lib/resolve-own-session.js
+++ b/lib/resolve-own-session.js
@@ -138,6 +138,35 @@ export async function resolveOwnSession(supabase, options = {}) {
     if (data) {
       return { data, source: 'env_var', sessionId: envId };
     }
+
+    // SD-LEARN-FIX-ADDRESS-PAT-LEADTOPLAN-002: Auto-create session row when env var
+    // is set but no matching row exists. The identity IS deterministic (env var set by
+    // SessionStart hook), the DB row just wasn't created yet (race condition during
+    // sd-start → handoff sequence, or cross-worktree subprocess invocation).
+    if (requireDeterministic) {
+      try {
+        const { error: upsertErr } = await supabase
+          .from('claude_sessions')
+          .upsert({
+            session_id: envId,
+            status: 'active',
+            heartbeat_at: new Date().toISOString(),
+            metadata: { auto_created: true, source: 'resolve_own_session_env_var_autocreate' }
+          }, { onConflict: 'session_id' });
+
+        if (!upsertErr) {
+          const { data: created } = await supabase
+            .from('claude_sessions')
+            .select(select)
+            .eq('session_id', envId)
+            .maybeSingle();
+          if (created) {
+            console.info(`[resolve-own-session] Auto-created session row for CLAUDE_SESSION_ID=${envId.slice(0, 8)}...`);
+            return { data: created, source: 'env_var', sessionId: envId };
+          }
+        }
+      } catch { /* auto-create failed, fall through to other strategies */ }
+    }
   }
 
   // Strategy 2: Lookup by session_id using marker file UUID


### PR DESCRIPTION
## Summary
- Fix `no_deterministic_identity` gate failures when CLAUDE_SESSION_ID is set but no DB row exists
- Auto-create `claude_sessions` row in `resolveOwnSession` when env var provides deterministic identity
- Resolves PAT-HF-LEADTOPLAN-e0839b1b (3 occurrences of LEAD-TO-PLAN gate failures)

## Test plan
- [x] Smoke tests passing (15/15)
- [ ] Manual: Run handoff with CLAUDE_SESSION_ID set but no pre-existing session row

🤖 Generated with [Claude Code](https://claude.com/claude-code)