### PR TITLE
fix: add missing NOT NULL columns to complete_orchestrator_sd()

### DIFF
--- a/database/migrations/20260412_fix_complete_orchestrator_sd_not_null_cols.sql
+++ b/database/migrations/20260412_fix_complete_orchestrator_sd_not_null_cols.sql
@@ -1,0 +1,153 @@
+-- Fix: complete_orchestrator_sd() INSERT into sd_phase_handoffs was missing
+-- NOT NULL columns: key_decisions, known_issues, resource_utilization, action_items
+-- This caused orchestrator auto-completion to fail with NOT NULL constraint violations.
+
+CREATE OR REPLACE FUNCTION public.complete_orchestrator_sd(sd_id_param character varying)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  sd RECORD;
+  is_orch BOOLEAN;
+  children_done BOOLEAN;
+  retro_exists BOOLEAN;
+  total_children INT;
+  completed_children INT;
+  children_without_handoffs INT;
+  child_quality_issues JSONB;
+BEGIN
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'SD not found: ' || sd_id_param
+    );
+  END IF;
+  IF sd.status = 'completed' THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'message', 'SD already completed',
+      'sd_id', sd_id_param
+    );
+  END IF;
+  is_orch := is_orchestrator_sd(sd_id_param);
+  IF NOT is_orch THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Not an orchestrator SD (has no children)',
+      'sd_id', sd_id_param
+    );
+  END IF;
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'completed')
+  INTO total_children, completed_children
+  FROM strategic_directives_v2
+  WHERE parent_sd_id = sd_id_param;
+  children_done := (completed_children = total_children);
+  IF NOT children_done THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Not all children completed: %s/%s', completed_children, total_children),
+      'completed_children', completed_children,
+      'total_children', total_children
+    );
+  END IF;
+  SELECT COUNT(*) INTO children_without_handoffs
+  FROM strategic_directives_v2 child
+  WHERE child.parent_sd_id = sd_id_param
+  AND child.status = 'completed'
+  AND NOT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs h
+    WHERE h.sd_id = child.id
+    AND h.status = 'accepted'
+  );
+  IF children_without_handoffs > 0 THEN
+    SELECT jsonb_agg(jsonb_build_object(
+      'sd_key', child.sd_key,
+      'title', child.title,
+      'issue', 'No accepted handoff records found'
+    ))
+    INTO child_quality_issues
+    FROM strategic_directives_v2 child
+    WHERE child.parent_sd_id = sd_id_param
+    AND child.status = 'completed'
+    AND NOT EXISTS (
+      SELECT 1 FROM sd_phase_handoffs h
+      WHERE h.sd_id = child.id
+      AND h.status = 'accepted'
+    );
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('PCVP: %s child(ren) completed without handoff evidence', children_without_handoffs),
+      'children_without_handoffs', children_without_handoffs,
+      'quality_issues', child_quality_issues,
+      'hint', 'Each child SD must have at least one accepted handoff in sd_phase_handoffs'
+    );
+  END IF;
+  SELECT EXISTS (
+    SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+  ) INTO retro_exists;
+  IF NOT retro_exists THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Retrospective required but not found',
+      'hint', 'Create a retrospective before completing'
+    );
+  END IF;
+  INSERT INTO sd_phase_handoffs (
+    sd_id,
+    handoff_type,
+    from_phase,
+    to_phase,
+    status,
+    validation_score,
+    executive_summary,
+    deliverables_manifest,
+    completeness_report,
+    key_decisions,
+    known_issues,
+    resource_utilization,
+    action_items,
+    created_by
+  ) VALUES (
+    sd_id_param,
+    'PLAN-TO-LEAD',
+    'PLAN',
+    'LEAD',
+    'accepted',
+    100,
+    format('Orchestrator auto-completion: All %s child SDs completed with verified handoff evidence.', total_children),
+    format('All %s child SDs completed with passing status and handoff records.', total_children),
+    jsonb_build_object(
+      'children_completed', completed_children,
+      'children_total', total_children,
+      'children_without_handoffs', 0,
+      'quality_verified', true,
+      'auto_completed', true,
+      'completion_date', now()
+    ),
+    '[]'::jsonb,
+    '[]'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    'ORCHESTRATOR_AUTO_COMPLETE'
+  );
+  UPDATE strategic_directives_v2
+  SET
+    status = 'completed',
+    current_phase = 'COMPLETED',
+    is_working_on = false,
+    updated_at = now()
+  WHERE id = sd_id_param;
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('Orchestrator completed: %s/%s children done (quality verified)', completed_children, total_children),
+    'sd_id', sd_id_param,
+    'completed_children', completed_children,
+    'quality_verified', true
+  );
+END;
+$function$;

--- a/database/migrations/20260412_fix_complete_orchestrator_sd_runner.js
+++ b/database/migrations/20260412_fix_complete_orchestrator_sd_runner.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Runner for complete_orchestrator_sd() fix.
+ * The migration runner splits on semicolons which breaks dollar-quoted plpgsql functions.
+ * This script sends the CREATE OR REPLACE as a single query.
+ */
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sqlPath = join(__dirname, '20260412_fix_complete_orchestrator_sd_not_null_cols.sql');
+const sql = readFileSync(sqlPath, 'utf-8');
+
+const client = await createDatabaseClient('engineer', { verify: true });
+try {
+  await client.query(sql);
+  console.log('SUCCESS: complete_orchestrator_sd() function replaced with NOT NULL column fix.');
+} catch (err) {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+} finally {
+  await client.end();
+}


### PR DESCRIPTION
## Summary
- `complete_orchestrator_sd()` function was inserting into `sd_phase_handoffs` without `key_decisions`, `known_issues`, `resource_utilization`, `action_items` (all NOT NULL)
- Added empty JSONB defaults (`'[]'::jsonb` / `'{}'::jsonb`) to prevent constraint violations
- Includes migration SQL + runner script (dollar-quoted plpgsql needs special handling)

Found when SD-FIX-EVA-FRIDAY-DATA-ORCH-001 auto-completion trigger failed.

## Test plan
- [x] Migration already applied to production DB by database-agent
- [x] Trigger re-enabled and verified
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)