### PR TITLE
feat: conditional SD queue governance — deferred filtering + audit trail

### DIFF
--- a/database/migrations/20260412_deferred_sd_audit_trigger.sql
+++ b/database/migrations/20260412_deferred_sd_audit_trigger.sql
@@ -1,0 +1,61 @@
+-- SD-LEO-INFRA-CONDITIONAL-QUEUE-GOVERNANCE-001
+-- Governance metadata audit trail for deferred Strategic Directives
+-- Creates: sd_metadata_audit_log table, BEFORE UPDATE trigger, CHECK constraint
+
+-- 1. Audit log table
+-- NOTE: sd_id is VARCHAR(50) to match strategic_directives_v2.id column type (not UUID)
+CREATE TABLE IF NOT EXISTS sd_metadata_audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sd_id VARCHAR(50) NOT NULL REFERENCES strategic_directives_v2(id),
+  changed_field TEXT NOT NULL,
+  old_value JSONB,
+  new_value JSONB,
+  changed_by TEXT DEFAULT current_user,
+  changed_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sd_metadata_audit_sd_id ON sd_metadata_audit_log(sd_id);
+CREATE INDEX IF NOT EXISTS idx_sd_metadata_audit_changed_at ON sd_metadata_audit_log(changed_at DESC);
+
+COMMENT ON TABLE sd_metadata_audit_log IS 'Immutable audit trail for governance metadata mutations on strategic_directives_v2. Board of Directors requirement (CISO).';
+
+-- 2. BEFORE UPDATE trigger: logs governance key mutations
+CREATE OR REPLACE FUNCTION trg_audit_governance_metadata()
+RETURNS TRIGGER AS $$
+DECLARE
+  gov_keys TEXT[] := ARRAY['do_not_advance_without_trigger', 'chairman_decision_required', 'auto_cancel_after_days', 'trigger_condition', 'is_pareto_deferred'];
+  k TEXT;
+BEGIN
+  IF OLD.metadata IS DISTINCT FROM NEW.metadata THEN
+    FOREACH k IN ARRAY gov_keys LOOP
+      IF (OLD.metadata->k) IS DISTINCT FROM (NEW.metadata->k) THEN
+        INSERT INTO sd_metadata_audit_log (sd_id, changed_field, old_value, new_value)
+        VALUES (NEW.id, k, OLD.metadata->k, NEW.metadata->k);
+      END IF;
+    END LOOP;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sd_governance_metadata_audit ON strategic_directives_v2;
+CREATE TRIGGER trg_sd_governance_metadata_audit
+  BEFORE UPDATE ON strategic_directives_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_audit_governance_metadata();
+
+-- 3. CHECK constraint: do_not_advance_without_trigger requires trigger_condition
+ALTER TABLE strategic_directives_v2
+  DROP CONSTRAINT IF EXISTS chk_deferred_requires_trigger_condition;
+
+ALTER TABLE strategic_directives_v2
+  ADD CONSTRAINT chk_deferred_requires_trigger_condition
+  CHECK (
+    NOT (
+      (metadata->>'do_not_advance_without_trigger')::boolean = true
+      AND metadata->'trigger_condition' IS NULL
+    )
+  );
+
+COMMENT ON CONSTRAINT chk_deferred_requires_trigger_condition ON strategic_directives_v2
+  IS 'Prevents setting do_not_advance_without_trigger=true without specifying a trigger_condition';

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -758,6 +758,9 @@ export class SDNextSelector {
       }
       if (sd.status === 'completed' || sd.status === 'cancelled') continue;
 
+      // Governance: skip deferred SDs from recommendation pipeline (keep in display with badge)
+      const isDeferred = sd.metadata?.do_not_advance_without_trigger === true;
+
       // QA: Check for dependency info in metadata with empty dependencies column
       const depsEmpty = !sd.dependencies || (Array.isArray(sd.dependencies) && sd.dependencies.length === 0);
       if (depsEmpty && sd.metadata) {
@@ -849,6 +852,7 @@ export class SDNextSelector {
         urgency_band: urgencyBand,
         urgency_numeric: urgencyNumeric,
         deps_resolved: depsResolved,
+        is_deferred: isDeferred,
         childDepStatus,
         actual: this.actuals[sd.sd_key] || this.actuals[sd.id]
       });

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -259,6 +259,9 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
       .single();
 
     if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      // SD-LEO-INFRA-CONDITIONAL-QUEUE-GOVERNANCE-001: Skip deferred SDs from recommendations
+      if (sd.metadata?.do_not_advance_without_trigger === true) continue;
+
       // SD-LEO-INFRA-CLAIM-GUARD-001: Skip SDs claimed by OTHER sessions (use claiming_session_id)
       if (sd.claiming_session_id && sd.claiming_session_id !== currentSessionId) {
         // Check if this is same conversation or stale-dead — these are actionable

--- a/scripts/modules/sd-next/status-helpers.js
+++ b/scripts/modules/sd-next/status-helpers.js
@@ -73,6 +73,11 @@ export function getPhaseAwareStatus(item) {
     return `${colors.cyan}PLANNING${colors.reset}`;
   }
 
+  // Governance: deferred SDs with trigger conditions
+  if (item.is_deferred || item.metadata?.do_not_advance_without_trigger === true) {
+    return `${colors.dim}DEFERRED${colors.reset}`;
+  }
+
   // Draft status = needs LEAD review first
   if (status === 'draft') {
     return `${colors.yellow}DRAFT${colors.reset}`;

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -451,6 +451,25 @@ async function main() {
 
   let effectiveId = sd.sd_key || sd.id;
 
+  // 1.1 SD-LEO-INFRA-CONDITIONAL-QUEUE-GOVERNANCE-001: Reject claims on deferred SDs
+  if (sd.metadata?.do_not_advance_without_trigger === true) {
+    console.log(`\n${colors.red}❌ SD is DEFERRED — cannot be claimed${colors.reset}`);
+    console.log('   This SD has a governance gate: do_not_advance_without_trigger=true');
+    if (sd.metadata?.trigger_condition) {
+      const tc = sd.metadata.trigger_condition;
+      console.log(`\n   ${colors.cyan}Trigger condition:${colors.reset}`);
+      console.log(`   Type: ${tc.type || 'unknown'}`);
+      console.log(`   Threshold: ${tc.threshold || 'unknown'}`);
+      if (tc.decision_venue) console.log(`   Decision venue: ${tc.decision_venue}`);
+      if (tc.chairman_decision_required) console.log(`   ${colors.yellow}Chairman decision required${colors.reset}`);
+    }
+    if (sd.metadata?.auto_cancel_after_days) {
+      console.log(`   Auto-cancel: ${sd.metadata.auto_cancel_after_days} days from creation`);
+    }
+    console.log(`\n   ${colors.dim}This SD will be promoted automatically when trigger conditions are met via EVA Friday.${colors.reset}`);
+    process.exit(1);
+  }
+
   // 1.5. Orchestrator detection — route to child instead of claiming parent
   const explicitChild = process.argv.includes('--child') ? process.argv[process.argv.indexOf('--child') + 1] : null;
   if (!explicitChild) {


### PR DESCRIPTION
## Summary
- **SDNextSelector.js**: Add `is_deferred` flag from metadata governance keys, passed to tracks for downstream filtering
- **status-helpers.js**: DEFERRED badge (gray/dim) renders before DRAFT check for governance-flagged SDs
- **recommendations.js**: Exclude deferred SDs (`do_not_advance_without_trigger=true`) from RECOMMENDED ACTIONS categorization
- **sd-start.js**: Reject claims on deferred SDs with explanatory message showing trigger condition details
- **Migration**: `sd_metadata_audit_log` table, Postgres BEFORE UPDATE trigger on governance metadata keys, CHECK constraint (flag requires trigger_condition)

## Context
Board of Directors deliberation (6/6 seats) converged on metadata-first approach with DB-level audit controls. SD-NARRATIVE-ENFORCEMENT-LAYER-001 was being recommended by sd:next despite having `do_not_advance_without_trigger=true` — wasting session capacity.

## Test plan
- [ ] Run `npm run sd:next` — verify SD-NARRATIVE-ENFORCEMENT-LAYER-001 shows DEFERRED badge, not in RECOMMENDED ACTIONS
- [ ] Run `sd-start.js` against deferred SD — verify claim rejected with trigger condition message
- [ ] Update governance metadata key — verify `sd_metadata_audit_log` populated
- [ ] Set `do_not_advance_without_trigger=true` without `trigger_condition` — verify CHECK constraint violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)