### PR TITLE
feat: wireframe fidelity scoring engine

### DIFF
--- a/lib/eva/qa/stitch-wireframe-qa.js
+++ b/lib/eva/qa/stitch-wireframe-qa.js
@@ -1,0 +1,446 @@
+/**
+ * Stitch Wireframe Fidelity QA — Compare exported PNGs against ASCII wireframes
+ *
+ * SD: SD-WIREFRAME-FIDELITY-VERIFICATION-VISION-ORCH-001-A
+ *
+ * Reads blueprint_wireframes artifact for source wireframe specs, pairs each
+ * with exported Stitch screen PNGs by name, sends each pair to Claude Sonnet
+ * vision for four-dimension fidelity scoring, and persists results as an
+ * additive wireframe_fidelity field in the stitch_qa_report artifact.
+ *
+ * Scoring dimensions:
+ *   1. component_presence — Are all wireframe-specified UI elements in the PNG?
+ *   2. layout_fidelity — Does spatial arrangement match the wireframe grid?
+ *   3. navigation_accuracy — Do links/buttons match the wireframe nav spec?
+ *   4. purpose_match — Does the rendered screen serve the wireframe's intent?
+ *
+ * Error handling:
+ * - Missing wireframes artifact → returns { status: 'no_wireframes' }
+ * - Missing API key → returns { status: 'vision_api_unavailable' }
+ * - Per-screen errors (expired URL, API failure) → that screen marked as error,
+ *   others scored normally
+ * - The function NEVER throws.
+ *
+ * @module lib/eva/qa/stitch-wireframe-qa
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_FIDELITY_THRESHOLD = 70;
+const FIDELITY_DIMENSIONS = ['component_presence', 'layout_fidelity', 'navigation_accuracy', 'purpose_match'];
+
+// ---------------------------------------------------------------------------
+// Test-injectable client loaders (mirrors stitch-vision-qa.js pattern)
+// ---------------------------------------------------------------------------
+
+let _anthropicClient = null;
+let _anthropicLoader = null;
+
+export function setAnthropicClientLoader(loader) {
+  _anthropicLoader = loader;
+  _anthropicClient = null;
+}
+
+function getAnthropicClient() {
+  if (_anthropicClient) return _anthropicClient;
+  if (_anthropicLoader) {
+    _anthropicClient = _anthropicLoader();
+    return _anthropicClient;
+  }
+  if (!process.env.ANTHROPIC_API_KEY) return null;
+  _anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return _anthropicClient;
+}
+
+let _supabaseClient = null;
+let _supabaseLoader = null;
+
+export function setSupabaseClientLoader(loader) {
+  _supabaseLoader = loader;
+  _supabaseClient = null;
+}
+
+function getSupabaseClient() {
+  if (_supabaseClient) return _supabaseClient;
+  if (_supabaseLoader) {
+    _supabaseClient = _supabaseLoader();
+    return _supabaseClient;
+  }
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required for stitch-wireframe-qa');
+  }
+  _supabaseClient = createClient(url, key);
+  return _supabaseClient;
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function logEvent(level, event, details = {}) {
+  const entry = JSON.stringify({ event, level, timestamp: new Date().toISOString(), ...details });
+  (level === 'warn' ? console.warn : console.info)(`[wireframe-qa] ${entry}`);
+}
+
+// ---------------------------------------------------------------------------
+// Fidelity scoring prompt
+// ---------------------------------------------------------------------------
+
+function buildFidelityPrompt(wireframeSpec) {
+  return `You are a wireframe fidelity QA reviewer. Compare the screenshot against this ASCII wireframe specification and score on four dimensions.
+
+WIREFRAME SPECIFICATION:
+${wireframeSpec}
+
+Score each dimension from 0 to 100:
+
+1. COMPONENT_PRESENCE — What percentage of UI elements specified in the wireframe are visible in the screenshot? List any missing elements.
+2. LAYOUT_FIDELITY — How closely does the spatial arrangement match the wireframe's grid/layout structure? Note any position mismatches.
+3. NAVIGATION_ACCURACY — Do the navigation elements (links, buttons, menus) match what the wireframe specifies? List missing or extra nav items.
+4. PURPOSE_MATCH — Does the rendered screen serve the same purpose described in the wireframe? Note any intent mismatches.
+
+Respond with valid JSON only, matching this exact schema:
+{
+  "component_presence": { "score": <0-100>, "findings": ["specific finding"], "missing_elements": ["element name"] },
+  "layout_fidelity": { "score": <0-100>, "findings": ["specific finding"], "layout_issues": ["issue description"] },
+  "navigation_accuracy": { "score": <0-100>, "findings": ["specific finding"], "missing_nav": ["nav item"] },
+  "purpose_match": { "score": <0-100>, "findings": ["specific finding"] }
+}
+
+Do NOT include any text before or after the JSON. Do NOT use markdown code fences.`;
+}
+
+// ---------------------------------------------------------------------------
+// Screen pairing
+// ---------------------------------------------------------------------------
+
+/**
+ * Pair exported screens with wireframe specs by name matching.
+ * @param {Array} wireframes - Array of { name, content } from blueprint_wireframes
+ * @param {Array} screens - Array of { screen_id, title, base64|url } from export
+ * @returns {{ paired: Array, unpaired_screens: Array, unpaired_wireframes: Array }}
+ */
+export function pairScreensWithWireframes(wireframes, screens) {
+  const paired = [];
+  const matchedWireframeNames = new Set();
+  const matchedScreenIds = new Set();
+
+  for (const screen of screens) {
+    const screenTitle = (screen.title || screen.screen_id || '').toLowerCase().trim();
+    const match = wireframes.find(w => {
+      const wName = (w.name || '').toLowerCase().trim();
+      return wName === screenTitle || wName.includes(screenTitle) || screenTitle.includes(wName);
+    });
+    if (match) {
+      paired.push({ screen, wireframe: match });
+      matchedWireframeNames.add(match.name);
+      matchedScreenIds.add(screen.screen_id);
+    }
+  }
+
+  const unpaired_screens = screens.filter(s => !matchedScreenIds.has(s.screen_id));
+  const unpaired_wireframes = wireframes.filter(w => !matchedWireframeNames.has(w.name));
+
+  return { paired, unpaired_screens, unpaired_wireframes };
+}
+
+// ---------------------------------------------------------------------------
+// Per-screen vision scoring
+// ---------------------------------------------------------------------------
+
+async function scoreScreenFidelity(client, screenId, base64Image, wireframeSpec) {
+  const response = await client.messages.create({
+    model: ANTHROPIC_MODEL,
+    max_tokens: 2048,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: base64Image },
+          },
+          { type: 'text', text: buildFidelityPrompt(wireframeSpec) },
+        ],
+      },
+    ],
+  });
+
+  const textBlock = (response.content || []).find(b => b.type === 'text');
+  if (!textBlock?.text) {
+    throw new Error(`Empty response from vision API for screen ${screenId}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(textBlock.text.trim());
+  } catch (err) {
+    throw new Error(`Vision API returned non-JSON for screen ${screenId}: ${err.message}`);
+  }
+
+  for (const dim of FIDELITY_DIMENSIONS) {
+    if (!parsed[dim] || typeof parsed[dim].score !== 'number') {
+      throw new Error(`Response missing or malformed dimension '${dim}' for screen ${screenId}`);
+    }
+  }
+
+  return { parsed, usage: response.usage };
+}
+
+// ---------------------------------------------------------------------------
+// PNG download helper
+// ---------------------------------------------------------------------------
+
+async function downloadPngAsBase64(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`PNG download failed: ${response.status} ${response.statusText}`);
+  }
+  const buffer = await response.arrayBuffer();
+  return Buffer.from(buffer).toString('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Read wireframes artifact
+// ---------------------------------------------------------------------------
+
+async function getWireframes(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('metadata, content')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'blueprint_wireframes')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const wireframes = data.metadata?.wireframes || data.metadata?.screens || [];
+  if (wireframes.length > 0) return wireframes;
+
+  if (typeof data.content === 'string') {
+    try {
+      const parsed = JSON.parse(data.content);
+      return parsed.wireframes || parsed.screens || [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Read exported screens
+// ---------------------------------------------------------------------------
+
+async function getExportedScreens(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'stitch_design_export')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return [];
+
+  return data.metadata?.screens || data.metadata?.png_files_base64 || [];
+}
+
+// ---------------------------------------------------------------------------
+// Persist wireframe fidelity to stitch_qa_report
+// ---------------------------------------------------------------------------
+
+async function persistWireframeFidelity(supabase, ventureId, fidelityData) {
+  const { data: existing } = await supabase
+    .from('venture_artifacts')
+    .select('id, metadata, version')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'stitch_qa_report')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (existing?.id) {
+    const updatedMetadata = { ...existing.metadata, wireframe_fidelity: fidelityData };
+    const { error } = await supabase
+      .from('venture_artifacts')
+      .update({ metadata: updatedMetadata })
+      .eq('id', existing.id);
+
+    if (error) {
+      logEvent('warn', 'wireframe_fidelity_update_failed', { error: error.message, venture_id: ventureId });
+      return null;
+    }
+    return existing.id;
+  }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('venture_artifacts')
+    .insert({
+      venture_id: ventureId,
+      artifact_type: 'stitch_qa_report',
+      lifecycle_stage: 17,
+      title: 'Stitch Wireframe Fidelity QA Report',
+      content: `Wireframe fidelity QA for ${fidelityData.screen_count || 0} screens`,
+      is_current: true,
+      version: 1,
+      metadata: { schema_version: 1, wireframe_fidelity: fidelityData },
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    logEvent('warn', 'wireframe_fidelity_insert_failed', { error: insertError.message, venture_id: ventureId });
+    return null;
+  }
+  return inserted?.id || null;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Score wireframe fidelity for a venture's exported Stitch screens.
+ * Never throws.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options={}]
+ * @param {number} [options.threshold=70] - Fidelity threshold (0-100)
+ * @returns {Promise<Object>} Result with status, per-screen scores, aggregate
+ */
+export async function scoreWireframeFidelity(ventureId, options = {}) {
+  const threshold = options.threshold ?? DEFAULT_FIDELITY_THRESHOLD;
+
+  logEvent('info', 'wireframe_qa_started', { venture_id: ventureId, threshold });
+
+  try {
+    const supabase = getSupabaseClient();
+
+    const client = getAnthropicClient();
+    if (!client) {
+      logEvent('warn', 'wireframe_qa_no_api_key', { venture_id: ventureId });
+      return { status: 'vision_api_unavailable', screens: [], aggregate: null };
+    }
+
+    const wireframes = await getWireframes(supabase, ventureId);
+    if (!wireframes || wireframes.length === 0) {
+      logEvent('info', 'wireframe_qa_no_wireframes', { venture_id: ventureId });
+      return { status: 'no_wireframes', screens: [], aggregate: null };
+    }
+
+    const exportedScreens = await getExportedScreens(supabase, ventureId);
+    if (exportedScreens.length === 0) {
+      logEvent('info', 'wireframe_qa_no_screens', { venture_id: ventureId });
+      return { status: 'no_screens', screens: [], aggregate: null };
+    }
+
+    const { paired, unpaired_screens, unpaired_wireframes } = pairScreensWithWireframes(wireframes, exportedScreens);
+
+    logEvent('info', 'wireframe_qa_pairing', {
+      venture_id: ventureId,
+      paired: paired.length,
+      unpaired_screens: unpaired_screens.length,
+      unpaired_wireframes: unpaired_wireframes.length,
+    });
+
+    const screenResults = [];
+
+    for (const { screen, wireframe } of paired) {
+      const screenId = screen.screen_id || screen.title || 'unknown';
+      try {
+        let base64 = screen.base64;
+        if (!base64 && screen.url) base64 = await downloadPngAsBase64(screen.url);
+        if (!base64 && screen.download_url) base64 = await downloadPngAsBase64(screen.download_url);
+        if (!base64) {
+          screenResults.push({
+            screen_id: screenId, wireframe_name: wireframe.name,
+            status: 'error', error: 'No base64 data or download URL available',
+            fidelity_score: 0, dimensions: null,
+          });
+          continue;
+        }
+
+        const wireframeSpec = wireframe.content || wireframe.spec || wireframe.ascii || JSON.stringify(wireframe);
+        const { parsed, usage } = await scoreScreenFidelity(client, screenId, base64, wireframeSpec);
+
+        const dimScores = FIDELITY_DIMENSIONS.map(d => parsed[d].score);
+        const fidelityScore = Math.round(dimScores.reduce((a, b) => a + b, 0) / dimScores.length);
+
+        const result = {
+          screen_id: screenId, wireframe_name: wireframe.name,
+          status: fidelityScore >= threshold ? 'pass' : 'fail',
+          fidelity_score: fidelityScore, threshold, dimensions: parsed, usage,
+        };
+
+        if (fidelityScore < threshold) {
+          result.missing_elements = parsed.component_presence?.missing_elements || [];
+          result.layout_issues = parsed.layout_fidelity?.layout_issues || [];
+          result.missing_nav = parsed.navigation_accuracy?.missing_nav || [];
+        }
+
+        screenResults.push(result);
+        logEvent('info', 'wireframe_qa_screen_scored', { venture_id: ventureId, screen_id: screenId, score: fidelityScore, status: result.status });
+      } catch (err) {
+        screenResults.push({
+          screen_id: screenId, wireframe_name: wireframe.name,
+          status: 'error', error: err.message?.slice(0, 500),
+          fidelity_score: 0, dimensions: null,
+        });
+        logEvent('warn', 'wireframe_qa_screen_error', { venture_id: ventureId, screen_id: screenId, error: err.message?.slice(0, 200) });
+      }
+    }
+
+    for (const screen of unpaired_screens) {
+      screenResults.push({
+        screen_id: screen.screen_id || screen.title || 'unknown',
+        wireframe_name: null, status: 'unpaired', fidelity_score: 0,
+        dimensions: null, warning: 'No matching wireframe found for this screen',
+      });
+    }
+
+    const scoredScreens = screenResults.filter(s => s.status === 'pass' || s.status === 'fail');
+    const aggregate = scoredScreens.length > 0
+      ? {
+        average_fidelity: Math.round(scoredScreens.reduce((a, s) => a + s.fidelity_score, 0) / scoredScreens.length),
+        pass_count: scoredScreens.filter(s => s.status === 'pass').length,
+        fail_count: scoredScreens.filter(s => s.status === 'fail').length,
+        error_count: screenResults.filter(s => s.status === 'error').length,
+        unpaired_count: unpaired_screens.length,
+        total_screens: screenResults.length,
+        threshold,
+      }
+      : null;
+
+    const fidelityData = {
+      status: 'completed', scored_at: new Date().toISOString(),
+      screen_count: screenResults.length, threshold, aggregate,
+      screens: screenResults, unpaired_wireframes: unpaired_wireframes.map(w => w.name),
+    };
+
+    const artifactId = await persistWireframeFidelity(supabase, ventureId, fidelityData);
+
+    logEvent('info', 'wireframe_qa_completed', {
+      venture_id: ventureId, screen_count: screenResults.length,
+      average_fidelity: aggregate?.average_fidelity, pass_count: aggregate?.pass_count,
+      fail_count: aggregate?.fail_count, artifact_id: artifactId,
+    });
+
+    return { status: 'completed', screens: screenResults, aggregate, artifact_id: artifactId };
+  } catch (err) {
+    logEvent('warn', 'wireframe_qa_fatal', { venture_id: ventureId, error: err.message?.slice(0, 500) });
+    return { status: 'error', screens: [], aggregate: null, error: err.message?.slice(0, 500) };
+  }
+}

--- a/tests/unit/eva/qa/stitch-wireframe-qa.test.js
+++ b/tests/unit/eva/qa/stitch-wireframe-qa.test.js
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for lib/eva/qa/stitch-wireframe-qa.js
+ * SD-WIREFRAME-FIDELITY-VERIFICATION-VISION-ORCH-001-A
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  scoreWireframeFidelity,
+  setAnthropicClientLoader,
+  setSupabaseClientLoader,
+  pairScreensWithWireframes,
+} = await import('../../../../lib/eva/qa/stitch-wireframe-qa.js');
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function makeVisionResponse(scores = {}) {
+  const defaults = {
+    component_presence: { score: 85, findings: ['All components present'], missing_elements: [] },
+    layout_fidelity: { score: 80, findings: ['Grid aligned'], layout_issues: [] },
+    navigation_accuracy: { score: 90, findings: ['Nav matches spec'], missing_nav: [] },
+    purpose_match: { score: 88, findings: ['Purpose aligned'] },
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ ...defaults, ...scores }) }],
+    usage: { input_tokens: 2000, output_tokens: 600 },
+  };
+}
+
+function makeFailingVisionResponse() {
+  return makeVisionResponse({
+    component_presence: { score: 40, findings: ['Missing sidebar'], missing_elements: ['sidebar', 'footer'] },
+    layout_fidelity: { score: 50, findings: ['Header displaced'], layout_issues: ['header not at top'] },
+    navigation_accuracy: { score: 60, findings: ['Missing nav bar'], missing_nav: ['main nav'] },
+    purpose_match: { score: 55, findings: ['Purpose mismatch'] },
+  });
+}
+
+function makeSupabaseMock({
+  wireframes = [
+    { name: 'Home', content: 'Home wireframe with header, nav, content' },
+    { name: 'Dashboard', content: 'Dashboard with sidebar and charts' },
+    { name: 'Settings', content: 'Settings page with form fields' },
+  ],
+  screens = [
+    { screen_id: 'home-001', title: 'Home', base64: 'base64png1' },
+    { screen_id: 'dash-001', title: 'Dashboard', base64: 'base64png2' },
+    { screen_id: 'settings-001', title: 'Settings', base64: 'base64png3' },
+  ],
+  existingQaReport = null,
+  noWireframes = false,
+  noScreens = false,
+} = {}) {
+  // Track artifact_type from eq calls per chain
+  let currentArtifactType = null;
+
+  const createChain = () => {
+    const chain = {
+      select: vi.fn().mockImplementation(() => chain),
+      eq: vi.fn().mockImplementation((col, val) => {
+        if (col === 'artifact_type') currentArtifactType = val;
+        return chain;
+      }),
+      limit: vi.fn().mockImplementation(() => chain),
+      maybeSingle: vi.fn().mockImplementation(() => {
+        const type = currentArtifactType;
+        currentArtifactType = null;
+        if (type === 'blueprint_wireframes') {
+          if (noWireframes) return Promise.resolve({ data: null, error: null });
+          return Promise.resolve({ data: { metadata: { wireframes }, content: null }, error: null });
+        }
+        if (type === 'stitch_design_export') {
+          if (noScreens) return Promise.resolve({ data: null, error: null });
+          return Promise.resolve({ data: { metadata: { screens } }, error: null });
+        }
+        if (type === 'stitch_qa_report') {
+          if (!existingQaReport) return Promise.resolve({ data: null, error: null });
+          return Promise.resolve({ data: { id: 'existing-qa-id', metadata: existingQaReport, version: 1 }, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+      insert: vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockImplementation(() => ({
+          single: vi.fn().mockResolvedValue({ data: { id: 'new-artifact-id' }, error: null }),
+        })),
+      })),
+      update: vi.fn().mockImplementation(() => ({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      })),
+    };
+    return chain;
+  };
+
+  return { from: vi.fn().mockImplementation(() => createChain()) };
+}
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+describe('pairScreensWithWireframes', () => {
+  it('pairs by exact name match', () => {
+    const wf = [{ name: 'Home' }, { name: 'Dashboard' }];
+    const sc = [{ screen_id: 's1', title: 'Home' }, { screen_id: 's2', title: 'Dashboard' }];
+    const { paired, unpaired_screens, unpaired_wireframes } = pairScreensWithWireframes(wf, sc);
+    expect(paired).toHaveLength(2);
+    expect(unpaired_screens).toHaveLength(0);
+    expect(unpaired_wireframes).toHaveLength(0);
+  });
+
+  it('flags unpaired screens', () => {
+    const wf = [{ name: 'Home' }];
+    const sc = [{ screen_id: 's1', title: 'Home' }, { screen_id: 's2', title: 'Extra' }];
+    const { paired, unpaired_screens } = pairScreensWithWireframes(wf, sc);
+    expect(paired).toHaveLength(1);
+    expect(unpaired_screens).toHaveLength(1);
+    expect(unpaired_screens[0].screen_id).toBe('s2');
+  });
+
+  it('handles case-insensitive matching', () => {
+    const wf = [{ name: 'HOME PAGE' }];
+    const sc = [{ screen_id: 's1', title: 'home page' }];
+    const { paired } = pairScreensWithWireframes(wf, sc);
+    expect(paired).toHaveLength(1);
+  });
+});
+
+describe('scoreWireframeFidelity', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+  afterEach(() => { setAnthropicClientLoader(null); setSupabaseClientLoader(null); });
+
+  it('scores all paired screens with passing fidelity', async () => {
+    const anthropic = { messages: { create: vi.fn().mockResolvedValue(makeVisionResponse()) } };
+    setAnthropicClientLoader(() => anthropic);
+    setSupabaseClientLoader(() => makeSupabaseMock());
+
+    const result = await scoreWireframeFidelity('venture-123');
+
+    expect(result.status).toBe('completed');
+    expect(result.screens).toHaveLength(3);
+    expect(result.screens.every(s => s.status === 'pass')).toBe(true);
+    expect(result.aggregate.pass_count).toBe(3);
+    expect(result.aggregate.fail_count).toBe(0);
+    expect(result.aggregate.average_fidelity).toBeGreaterThanOrEqual(70);
+    expect(anthropic.messages.create).toHaveBeenCalledTimes(3);
+  });
+
+  it('flags below-threshold screens with missing elements', async () => {
+    const anthropic = { messages: { create: vi.fn().mockResolvedValue(makeFailingVisionResponse()) } };
+    setAnthropicClientLoader(() => anthropic);
+    setSupabaseClientLoader(() => makeSupabaseMock({
+      wireframes: [{ name: 'Home', content: 'Home wireframe' }],
+      screens: [{ screen_id: 'home-001', title: 'Home', base64: 'base64png' }],
+    }));
+
+    const result = await scoreWireframeFidelity('venture-123');
+
+    expect(result.status).toBe('completed');
+    expect(result.screens[0].status).toBe('fail');
+    expect(result.screens[0].fidelity_score).toBeLessThan(70);
+    expect(result.screens[0].missing_elements).toContain('sidebar');
+    expect(result.screens[0].layout_issues).toContain('header not at top');
+  });
+
+  it('handles unpaired screens gracefully', async () => {
+    const anthropic = { messages: { create: vi.fn().mockResolvedValue(makeVisionResponse()) } };
+    setAnthropicClientLoader(() => anthropic);
+    setSupabaseClientLoader(() => makeSupabaseMock({
+      wireframes: [{ name: 'Home', content: 'Home wireframe' }],
+      screens: [
+        { screen_id: 'home-001', title: 'Home', base64: 'base64png1' },
+        { screen_id: 'extra-001', title: 'Extra Page', base64: 'base64png2' },
+      ],
+    }));
+
+    const result = await scoreWireframeFidelity('venture-123');
+
+    expect(result.screens).toHaveLength(2);
+    const unpaired = result.screens.find(s => s.screen_id === 'extra-001');
+    expect(unpaired.status).toBe('unpaired');
+    expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns no_wireframes when blueprint artifact is missing', async () => {
+    setAnthropicClientLoader(() => ({ messages: { create: vi.fn() } }));
+    setSupabaseClientLoader(() => makeSupabaseMock({ noWireframes: true }));
+
+    const result = await scoreWireframeFidelity('venture-123');
+    expect(result.status).toBe('no_wireframes');
+    expect(result.screens).toHaveLength(0);
+  });
+
+  it('returns no_screens when export has no screens', async () => {
+    setAnthropicClientLoader(() => ({ messages: { create: vi.fn() } }));
+    setSupabaseClientLoader(() => makeSupabaseMock({ noScreens: true }));
+
+    const result = await scoreWireframeFidelity('venture-123');
+    expect(result.status).toBe('no_screens');
+  });
+
+  it('returns vision_api_unavailable when no API key', async () => {
+    setAnthropicClientLoader(() => null);
+    setSupabaseClientLoader(() => makeSupabaseMock());
+
+    const result = await scoreWireframeFidelity('venture-123');
+    expect(result.status).toBe('vision_api_unavailable');
+  });
+
+  it('isolates per-screen errors without crashing other screens', async () => {
+    const anthropic = {
+      messages: {
+        create: vi.fn()
+          .mockResolvedValueOnce(makeVisionResponse())
+          .mockRejectedValueOnce(new Error('API timeout'))
+          .mockResolvedValueOnce(makeVisionResponse()),
+      },
+    };
+    setAnthropicClientLoader(() => anthropic);
+    setSupabaseClientLoader(() => makeSupabaseMock());
+
+    const result = await scoreWireframeFidelity('venture-123');
+
+    expect(result.status).toBe('completed');
+    const home = result.screens.find(s => s.screen_id === 'home-001');
+    const dash = result.screens.find(s => s.screen_id === 'dash-001');
+    const settings = result.screens.find(s => s.screen_id === 'settings-001');
+
+    expect(home.status).toBe('pass');
+    expect(dash.status).toBe('error');
+    expect(dash.error).toContain('API timeout');
+    expect(settings.status).toBe('pass');
+  });
+
+  it('uses configurable threshold', async () => {
+    const anthropic = { messages: { create: vi.fn().mockResolvedValue(makeVisionResponse()) } };
+    setAnthropicClientLoader(() => anthropic);
+    setSupabaseClientLoader(() => makeSupabaseMock({
+      wireframes: [{ name: 'Home', content: 'Home wireframe' }],
+      screens: [{ screen_id: 'home-001', title: 'Home', base64: 'png' }],
+    }));
+
+    const result = await scoreWireframeFidelity('venture-123', { threshold: 90 });
+    // avg of 85,80,90,88 = 85.75 → rounds to 86, below 90
+    expect(result.screens[0].status).toBe('fail');
+    expect(result.screens[0].threshold).toBe(90);
+  });
+});


### PR DESCRIPTION
## Summary
- New `stitch-wireframe-qa.js` module using Claude Sonnet vision API to compare exported Stitch PNGs against ASCII wireframe specs
- Four-dimension scoring: component presence, layout fidelity, navigation accuracy, screen purpose match
- Persists as additive `wireframe_fidelity` field in `stitch_qa_report` artifact
- Per-screen error isolation, configurable 70% threshold, never throws

## Test plan
- [x] 11 unit tests passing (pairing, scoring, error handling, degradation)
- [ ] Integration test with real venture data
- [ ] Verify artifact persistence in stitch_qa_report

SD: SD-WIREFRAME-FIDELITY-VERIFICATION-VISION-ORCH-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)