### PR TITLE
fix: add missing rejection_reason to recordSystemError()

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E",
-  "expectedBranch": "feat/SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E",
-  "createdAt": "2026-04-12T16:20:33.515Z",
+  "sdKey": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-076",
+  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-076",
+  "createdAt": "2026-04-12T19:15:57.455Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -360,6 +360,9 @@ export class HandoffRecorder {
     const execution = {
       id: executionId,
       sd_id: sdUuid,
+      from_phase: handoffType.split('-')[0],
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-076: Match recordFailure() phase parsing
+      to_phase: (() => { const p = handoffType.split('-')[2]; return ['LEAD', 'PLAN', 'EXEC'].includes(p) ? p : 'LEAD'; })(),
       handoff_type: handoffType,
       status: 'failed',
       executive_summary: `System error during ${handoffType} handoff: ${errorMessage}`,
@@ -369,6 +372,7 @@ export class HandoffRecorder {
       resource_utilization: '',
       action_items: '- [ ] Investigate and fix system error\n- [ ] Retry handoff',
       completeness_report: 'System Error - handoff incomplete',
+      rejection_reason: errorMessage,
       validation_score: 0,
       validation_passed: false,
       validation_details: {
@@ -389,6 +393,15 @@ export class HandoffRecorder {
       } else {
         console.log(`📝 System error recorded: ${executionId}`);
       }
+
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-076: Governance audit trail (match recordFailure pattern)
+      await this._logGovernanceAudit(handoffType, sdUuid, {
+        status: 'failed',
+        score: 0,
+        executionId,
+        reasonCode: 'SYSTEM_ERROR',
+        errorMessage
+      });
     } catch (e) {
       console.error('Could not record system error:', e.message);
     }


### PR DESCRIPTION
## Summary
- Adds `rejection_reason`, `from_phase`, and `to_phase` to `HandoffRecorder.recordSystemError()`, bringing it to parity with `recordFailure()`
- Adds governance audit trail logging for system error handoffs
- Fixes ~40% of handoff failures being stored with null `rejection_reason` in `sd_phase_handoffs`

## Root Cause
`recordFailure()` (line 282) sets `rejection_reason: result.message` but `recordSystemError()` had no equivalent field, leaving it null when handoffs fail via the system error path (uncaught exceptions, claim validity failures).

## Test plan
- [ ] Trigger a system error handoff (e.g., invalid SD key) and verify `rejection_reason` is populated
- [ ] Verify `from_phase`/`to_phase` are correctly parsed from handoff_type
- [ ] Confirm governance audit entry created for system errors
- [ ] Verify existing `recordFailure()` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)