### PR TITLE
feat(SD-DUALPLAT-MOBILE-WEB-ORCH-001-A): dual-platform Stitch generation + target_platform migration

### DIFF
--- a/database/migrations/20260412_dual_platform_target_platform.sql
+++ b/database/migrations/20260412_dual_platform_target_platform.sql
@@ -1,0 +1,31 @@
+-- Migration: Add target_platform to ventures + platform to venture_artifacts
+-- SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-A
+-- Purpose: Enable per-venture platform targeting for dual-platform design generation
+--
+-- target_platform: Controls which Stitch generation passes run
+--   'web'    → DESKTOP only
+--   'mobile' → MOBILE only
+--   'both'   → MOBILE first, then DESKTOP (default)
+--
+-- platform: Tags each generated screen with its target platform
+--   'mobile'  → Generated with deviceType=MOBILE
+--   'desktop' → Generated with deviceType=DESKTOP
+
+-- 1. Add target_platform to ventures (default: 'both')
+ALTER TABLE ventures
+  ADD COLUMN IF NOT EXISTS target_platform TEXT NOT NULL DEFAULT 'both'
+  CHECK (target_platform IN ('web', 'mobile', 'both'));
+
+COMMENT ON COLUMN ventures.target_platform IS 'Platform targeting: web (desktop only), mobile (mobile only), both (mobile-first + desktop)';
+
+-- 2. Add platform to venture_artifacts (nullable — existing rows have no platform tag)
+ALTER TABLE venture_artifacts
+  ADD COLUMN IF NOT EXISTS platform TEXT
+  CHECK (platform IS NULL OR platform IN ('mobile', 'desktop'));
+
+COMMENT ON COLUMN venture_artifacts.platform IS 'Platform tag for generated design screens: mobile or desktop';
+
+-- 3. Index for filtering artifacts by platform
+CREATE INDEX IF NOT EXISTS idx_venture_artifacts_platform
+  ON venture_artifacts (venture_id, platform)
+  WHERE platform IS NOT NULL;

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -312,6 +312,22 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     return { status: 'no_op', reason: governance.reason };
   }
 
+  // Step 1.5: Read target_platform from venture record (SD-DUALPLAT-MOBILE-WEB-ORCH-001-A)
+  let targetPlatform = 'both'; // default
+  try {
+    const { data: venture } = await supabase
+      .from('ventures')
+      .select('target_platform')
+      .eq('id', ventureId)
+      .single();
+    if (venture?.target_platform) {
+      targetPlatform = venture.target_platform;
+    }
+  } catch {
+    // graceful fallback — if ventures table doesn't have the column yet, default to 'both'
+  }
+  console.info(`[stitch-provisioner] target_platform: ${targetPlatform}`);
+
   // Step 2: Extract brand tokens from Stage 11
   const brandTokens = extractStage11Tokens(stage11Artifacts);
 
@@ -352,6 +368,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   }
 
   // Step 4: Build curation prompts with deviceType (SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D)
+  // SD-DUALPLAT-MOBILE-WEB-ORCH-001-A: Dual-platform generation (mobile-first ordering)
   let inferDeviceType;
   try {
     const resolver = await import('./stitch-device-type-resolver.js');
@@ -359,10 +376,33 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   } catch {
     inferDeviceType = () => undefined; // graceful fallback if module unavailable
   }
-  const curationPrompts = screens.map(screen => ({
-    text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
-    deviceType: inferDeviceType(screen),
-  }));
+
+  const curationPrompts = [];
+  const includeMobile = targetPlatform === 'both' || targetPlatform === 'mobile';
+  const includeDesktop = targetPlatform === 'both' || targetPlatform === 'web';
+
+  // Mobile-first: generate MOBILE screens before DESKTOP (research shows better Stitch output)
+  if (includeMobile) {
+    for (const screen of screens) {
+      curationPrompts.push({
+        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
+        deviceType: 'MOBILE',
+        _platform: 'mobile',
+        _screenName: screen.name || screen.title || 'Unknown',
+      });
+    }
+  }
+  if (includeDesktop) {
+    for (const screen of screens) {
+      curationPrompts.push({
+        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
+        deviceType: inferDeviceType(screen) === 'MOBILE' ? 'DESKTOP' : (inferDeviceType(screen) || 'DESKTOP'),
+        _platform: 'desktop',
+        _screenName: screen.name || screen.title || 'Unknown',
+      });
+    }
+  }
+  console.info(`[stitch-provisioner] Dual-platform: ${curationPrompts.length} prompts (${includeMobile ? 'mobile' : ''}${includeMobile && includeDesktop ? '+' : ''}${includeDesktop ? 'desktop' : ''})`);
 
   // Step 5: Create project via stitch-client (API call — works reliably)
   const client = await getStitchClient();
@@ -409,10 +449,12 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     brand_tokens: brandTokens,
     design_system_id: designSystemResult.designSystemId,
     available_tools: availableTools,
-    screen_prompts: curationPrompts.map((p, i) => ({
-      screen_name: screens[i]?.name || `Screen ${i + 1}`,
+    target_platform: targetPlatform,
+    screen_prompts: curationPrompts.map((p) => ({
+      screen_name: p._screenName || 'Unknown',
       prompt: typeof p === 'string' ? p : p.text,
       deviceType: typeof p === 'object' ? p.deviceType : undefined,
+      platform: typeof p === 'object' ? p._platform : undefined,
     })),
     generation_results: [],
     status: 'awaiting_curation',
@@ -459,6 +501,31 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   } catch (err) {
     console.error(`[stitch-provisioner] generateScreens error (artifact already persisted): ${err.message}`);
   }
+
+  // Step 7.5: Tag venture_artifacts with platform metadata (SD-DUALPLAT-MOBILE-WEB-ORCH-001-A)
+  // For each returned/fired screen, update the venture_artifacts.platform column
+  if (generationResults.length > 0) {
+    for (let i = 0; i < generationResults.length; i++) {
+      const result = generationResults[i];
+      const prompt = curationPrompts[i];
+      if (result.screen_id && prompt?._platform) {
+        try {
+          await supabase
+            .from('venture_artifacts')
+            .update({ platform: prompt._platform })
+            .eq('venture_id', ventureId)
+            .eq('artifact_data->>screen_id', result.screen_id);
+        } catch {
+          // non-fatal — platform tagging is best-effort
+        }
+      }
+    }
+    const taggedCount = generationResults.filter((r, i) => r.screen_id && curationPrompts[i]?._platform).length;
+    if (taggedCount > 0) {
+      console.info(`[stitch-provisioner] Tagged ${taggedCount} screen artifact(s) with platform metadata`);
+    }
+  }
+
   console.info(`[stitch-provisioner] Chairman: open ${project.url} to activate sync and review screens`);
   console.info(`[stitch-provisioner] ${curationPrompts.length} screen prompt(s) saved for reference`);
 
@@ -466,6 +533,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     status: 'awaiting_curation',
     project_id: project.project_id,
     url: project.url,
+    target_platform: targetPlatform,
     curation_prompts: curationPrompts,
     generation_results: generationResults,
   };

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -642,6 +642,7 @@ export class HandoffRecorder {
     } catch (error) {
       // SD-LEO-PROTOCOL-V435-001 US-004: Silent error logging with recovery paths
       console.error('⚠️  Could not create handoff artifact:', error.message);
+      console.error('⚠️  ARTIFACT ERROR STACK:', error.stack?.slice(0, 500));
 
       // Log error silently to database for debugging
       await this._logErrorSilently('createArtifact', {
@@ -652,8 +653,11 @@ export class HandoffRecorder {
         stack: safeTruncate(error.stack || '', 500)
       });
 
-      // Return null but don't throw - the handoff execution was still recorded
-      return null;
+      // SD-DUALPLAT-MOBILE-WEB-ORCH-001 RCA: If artifact creation fails,
+      // the handoff reports PASS but sd_phase_handoffs has no accepted record.
+      // This causes sequence validator to block the next handoff.
+      // THROW instead of returning null so the handoff correctly reports failure.
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `target_platform` column to ventures table (web/mobile/both, default: both)
- Add `platform` column to venture_artifacts for screen tagging
- Modify stitch-provisioner.js for mobile-first dual-pass generation
- Fix HandoffRecorder.createArtifact silently swallowing errors (RCA systemic fix)

## Parent Orchestrator
SD-DUALPLATFORM-MOBILEWEB-VENTURE-DESIGN-ORCH-001 — Dual-Platform Mobile+Web Venture Design Pipeline

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] stitch-provisioner.js imports cleanly
- [x] DB migration executed (target_platform + platform columns verified)
- [x] Live Stitch test confirmed MOBILE deviceType generates distinct layouts (project 6196856486975890024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)