### PR TITLE
feat(SD-DUALPLAT-MOBILE-WEB-ORCH-001-B): S17 mobile QA assertions

### DIFF
--- a/lib/eva/qa/stitch-vision-qa.js
+++ b/lib/eva/qa/stitch-vision-qa.js
@@ -521,5 +521,195 @@ export async function reviewStitchExport(ventureId, manifest) {
   return { ...payload, qa_report_id: id };
 }
 
+// ---------------------------------------------------------------------------
+// Mobile-specific QA assertions (SD-DUALPLAT-MOBILE-WEB-ORCH-001-B)
+// ---------------------------------------------------------------------------
+
+const MOBILE_TOUCH_TARGET_PROMPT = `You are a mobile UX accessibility auditor. Analyze this mobile screen screenshot for touch target compliance.
+
+Identify ALL interactive elements (buttons, links, form inputs, toggles, icons that appear clickable) and estimate their approximate dimensions in pixels.
+
+The WCAG 2.1 minimum touch target size is 44x44 pixels.
+
+Respond with valid JSON only:
+{
+  "elements": [
+    { "name": "description of element", "estimated_width_px": <number>, "estimated_height_px": <number>, "compliant": <boolean> }
+  ],
+  "total_interactive": <number>,
+  "total_compliant": <number>,
+  "score": <0-100>
+}
+
+Score = (total_compliant / total_interactive) * 100. If no interactive elements found, score = 100.
+Do NOT include any text before or after the JSON.`;
+
+const MOBILE_BOTTOM_NAV_PROMPT = `You are a mobile UX pattern reviewer. Analyze this mobile screen screenshot to determine if a bottom navigation bar is present.
+
+A bottom navigation bar is a tab bar or icon row fixed at the bottom of the screen, typically containing 3-5 navigation items for primary app sections (common in mobile apps for thumb-zone ergonomics).
+
+Respond with valid JSON only:
+{
+  "detected": <boolean>,
+  "confidence": <0.0-1.0>,
+  "description": "brief description of what was found at the bottom of the screen"
+}
+
+Do NOT include any text before or after the JSON.`;
+
+const MOBILE_HORIZONTAL_SCROLL_PROMPT = `You are a mobile viewport compliance reviewer. Analyze this mobile screen screenshot to check for horizontal scrolling issues.
+
+Look for:
+- Content that appears to extend beyond the visible viewport width
+- Horizontal scroll indicators or overflow indicators
+- Wide tables, images, or elements that break the mobile layout
+- Any visual clue that the page scrolls horizontally
+
+Respond with valid JSON only:
+{
+  "overflow_detected": <boolean>,
+  "score": <0-100>,
+  "overflow_elements": ["description of element causing overflow"],
+  "findings": ["observation about the layout"]
+}
+
+Score 100 = no overflow detected. Lower scores indicate more overflow issues.
+Do NOT include any text before or after the JSON.`;
+
+/**
+ * Check mobile touch target compliance via vision analysis.
+ * @param {Object} client - Anthropic SDK client
+ * @param {string} screenId - Screen identifier
+ * @param {string} base64Image - PNG screenshot as base64
+ * @returns {Promise<Object>} Touch target analysis result
+ */
+export async function checkTouchTargets(client, screenId, base64Image) {
+  try {
+    const response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 2048,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64Image } },
+          { type: 'text', text: MOBILE_TOUCH_TARGET_PROMPT },
+        ],
+      }],
+    });
+
+    const textBlock = (response.content || []).find(b => b.type === 'text');
+    if (!textBlock?.text) return { score: null, status: 'empty_response', violations: [] };
+
+    const parsed = JSON.parse(textBlock.text.trim());
+    const violations = (parsed.elements || []).filter(e => !e.compliant);
+    return {
+      score: parsed.score ?? 100,
+      total_interactive: parsed.total_interactive ?? 0,
+      total_compliant: parsed.total_compliant ?? 0,
+      violations,
+      usage: response.usage,
+    };
+  } catch (err) {
+    return { score: null, status: 'error', error: err.message, violations: [] };
+  }
+}
+
+/**
+ * Detect bottom navigation bar in mobile screen.
+ * @param {Object} client - Anthropic SDK client
+ * @param {string} screenId - Screen identifier
+ * @param {string} base64Image - PNG screenshot as base64
+ * @returns {Promise<Object>} Bottom nav detection result
+ */
+export async function checkBottomNavigation(client, screenId, base64Image) {
+  try {
+    const response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 512,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64Image } },
+          { type: 'text', text: MOBILE_BOTTOM_NAV_PROMPT },
+        ],
+      }],
+    });
+
+    const textBlock = (response.content || []).find(b => b.type === 'text');
+    if (!textBlock?.text) return { detected: null, status: 'empty_response' };
+
+    const parsed = JSON.parse(textBlock.text.trim());
+    return {
+      detected: parsed.detected ?? null,
+      confidence: parsed.confidence ?? 0,
+      description: parsed.description || '',
+      usage: response.usage,
+    };
+  } catch (err) {
+    return { detected: null, status: 'vision_api_unavailable', error: err.message };
+  }
+}
+
+/**
+ * Check for horizontal scroll issues in mobile screen.
+ * @param {Object} client - Anthropic SDK client
+ * @param {string} screenId - Screen identifier
+ * @param {string} base64Image - PNG screenshot as base64
+ * @returns {Promise<Object>} Horizontal scroll analysis result
+ */
+export async function checkHorizontalScroll(client, screenId, base64Image) {
+  try {
+    const response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1024,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64Image } },
+          { type: 'text', text: MOBILE_HORIZONTAL_SCROLL_PROMPT },
+        ],
+      }],
+    });
+
+    const textBlock = (response.content || []).find(b => b.type === 'text');
+    if (!textBlock?.text) return { score: null, status: 'empty_response', overflow_elements: [] };
+
+    const parsed = JSON.parse(textBlock.text.trim());
+    return {
+      score: parsed.score ?? 100,
+      overflow_detected: parsed.overflow_detected ?? false,
+      overflow_elements: parsed.overflow_elements || [],
+      findings: parsed.findings || [],
+      usage: response.usage,
+    };
+  } catch (err) {
+    return { score: null, status: 'error', error: err.message, overflow_elements: [] };
+  }
+}
+
+/**
+ * Run all mobile-specific assertions on a screen.
+ * @param {Object} client - Anthropic SDK client
+ * @param {string} screenId - Screen identifier
+ * @param {string} base64Image - PNG screenshot as base64
+ * @returns {Promise<Object>} Combined mobile assertions result
+ */
+export async function scoreMobileAssertions(client, screenId, base64Image) {
+  const [touchTargets, bottomNav, horizontalScroll] = await Promise.all([
+    checkTouchTargets(client, screenId, base64Image),
+    checkBottomNavigation(client, screenId, base64Image),
+    checkHorizontalScroll(client, screenId, base64Image),
+  ]);
+
+  return {
+    touch_target_compliance: touchTargets,
+    bottom_nav_detected: bottomNav.detected,
+    bottom_nav_confidence: bottomNav.confidence,
+    bottom_nav_description: bottomNav.description,
+    horizontal_scroll_score: horizontalScroll,
+    platform: 'MOBILE',
+  };
+}
+
 // Exports for testing
 export { aggregateRubrics, estimateCallCostUsd, getRemainingDailyBudget, buildRubricPrompt, RUBRIC_CATEGORIES };

--- a/lib/eva/qa/stitch-wireframe-qa.js
+++ b/lib/eva/qa/stitch-wireframe-qa.js
@@ -26,6 +26,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@supabase/supabase-js';
+import { scoreMobileAssertions } from './stitch-vision-qa.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -319,10 +320,12 @@ async function persistWireframeFidelity(supabase, ventureId, fidelityData) {
  * @param {string} ventureId - Venture UUID
  * @param {Object} [options={}]
  * @param {number} [options.threshold=70] - Fidelity threshold (0-100)
+ * @param {string} [options.platform] - 'MOBILE' or 'DESKTOP' (default: 'DESKTOP')
  * @returns {Promise<Object>} Result with status, per-screen scores, aggregate
  */
 export async function scoreWireframeFidelity(ventureId, options = {}) {
   const threshold = options.threshold ?? DEFAULT_FIDELITY_THRESHOLD;
+  const platform = (options.platform || 'DESKTOP').toUpperCase();
 
   logEvent('info', 'wireframe_qa_started', { venture_id: ventureId, threshold });
 
@@ -411,6 +414,31 @@ export async function scoreWireframeFidelity(ventureId, options = {}) {
       });
     }
 
+    // ── Mobile-specific assertions (SD-DUALPLAT-MOBILE-WEB-ORCH-001-B) ──────
+    let mobileAssertions = null;
+    if (platform === 'MOBILE') {
+      logEvent('info', 'mobile_assertions_started', { venture_id: ventureId, screen_count: exportedScreens.length });
+      const mobileResults = [];
+      for (const screen of exportedScreens) {
+        const screenId = screen.screen_id || screen.title || 'unknown';
+        let base64 = screen.base64;
+        if (!base64 && screen.url) base64 = await downloadPngAsBase64(screen.url);
+        if (!base64 && screen.download_url) base64 = await downloadPngAsBase64(screen.download_url);
+        if (!base64) {
+          mobileResults.push({ screen_id: screenId, status: 'no_image' });
+          continue;
+        }
+        const result = await scoreMobileAssertions(client, screenId, base64);
+        mobileResults.push({ screen_id: screenId, ...result });
+      }
+      mobileAssertions = {
+        screens: mobileResults,
+        screen_count: mobileResults.length,
+        scored_at: new Date().toISOString(),
+      };
+      logEvent('info', 'mobile_assertions_completed', { venture_id: ventureId, screen_count: mobileResults.length });
+    }
+
     const scoredScreens = screenResults.filter(s => s.status === 'pass' || s.status === 'fail');
     const aggregate = scoredScreens.length > 0
       ? {
@@ -428,6 +456,8 @@ export async function scoreWireframeFidelity(ventureId, options = {}) {
       status: 'completed', scored_at: new Date().toISOString(),
       screen_count: screenResults.length, threshold, aggregate,
       screens: screenResults, unpaired_wireframes: unpaired_wireframes.map(w => w.name),
+      platform,
+      ...(mobileAssertions ? { mobile_assertions: mobileAssertions } : {}),
     };
 
     const artifactId = await persistWireframeFidelity(supabase, ventureId, fidelityData);
@@ -438,7 +468,7 @@ export async function scoreWireframeFidelity(ventureId, options = {}) {
       fail_count: aggregate?.fail_count, artifact_id: artifactId,
     });
 
-    return { status: 'completed', screens: screenResults, aggregate, artifact_id: artifactId };
+    return { status: 'completed', screens: screenResults, aggregate, artifact_id: artifactId, platform, mobile_assertions: mobileAssertions };
   } catch (err) {
     logEvent('warn', 'wireframe_qa_fatal', { venture_id: ventureId, error: err.message?.slice(0, 500) });
     return { status: 'error', screens: [], aggregate: null, error: err.message?.slice(0, 500) };

--- a/tests/unit/eva/qa/stitch-mobile-qa.test.js
+++ b/tests/unit/eva/qa/stitch-mobile-qa.test.js
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for mobile QA assertions in stitch-vision-qa.js
+ * SD-DUALPLAT-MOBILE-WEB-ORCH-001-B
+ *
+ * Covers:
+ * - checkTouchTargets: happy path, violations, no elements, API error
+ * - checkBottomNavigation: detected, not detected, API error
+ * - checkHorizontalScroll: no overflow, overflow detected, API error
+ * - scoreMobileAssertions: runs all 3 in parallel
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+const {
+  checkTouchTargets,
+  checkBottomNavigation,
+  checkHorizontalScroll,
+  scoreMobileAssertions,
+} = await import('../../../../lib/eva/qa/stitch-vision-qa.js');
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function makeClient(responseJson) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(responseJson) }],
+        usage: { input_tokens: 1500, output_tokens: 400 },
+      }),
+    },
+  };
+}
+
+function makeErrorClient(errorMsg) {
+  return {
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error(errorMsg)),
+    },
+  };
+}
+
+const FAKE_BASE64 = 'iVBORw0KGgoAAAANSUhEUg==';
+
+// -------------------------------------------------------------------------
+// checkTouchTargets
+// -------------------------------------------------------------------------
+
+describe('checkTouchTargets', () => {
+  it('returns score and violations for non-compliant elements', async () => {
+    const client = makeClient({
+      elements: [
+        { name: 'Submit button', estimated_width_px: 80, estimated_height_px: 48, compliant: true },
+        { name: 'Small icon', estimated_width_px: 24, estimated_height_px: 24, compliant: false },
+      ],
+      total_interactive: 2,
+      total_compliant: 1,
+      score: 50,
+    });
+
+    const result = await checkTouchTargets(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBe(50);
+    expect(result.total_interactive).toBe(2);
+    expect(result.total_compliant).toBe(1);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].name).toBe('Small icon');
+  });
+
+  it('returns score 100 when no interactive elements found', async () => {
+    const client = makeClient({
+      elements: [],
+      total_interactive: 0,
+      total_compliant: 0,
+      score: 100,
+    });
+
+    const result = await checkTouchTargets(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBe(100);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('handles API error gracefully', async () => {
+    const client = makeErrorClient('API timeout');
+    const result = await checkTouchTargets(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBeNull();
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('API timeout');
+  });
+});
+
+// -------------------------------------------------------------------------
+// checkBottomNavigation
+// -------------------------------------------------------------------------
+
+describe('checkBottomNavigation', () => {
+  it('detects bottom navigation bar', async () => {
+    const client = makeClient({
+      detected: true,
+      confidence: 0.95,
+      description: 'Tab bar with Home, Search, Profile icons at bottom',
+    });
+
+    const result = await checkBottomNavigation(client, 'screen-1', FAKE_BASE64);
+    expect(result.detected).toBe(true);
+    expect(result.confidence).toBe(0.95);
+    expect(result.description).toContain('Tab bar');
+  });
+
+  it('reports absence of bottom nav', async () => {
+    const client = makeClient({
+      detected: false,
+      confidence: 0.9,
+      description: 'No navigation bar found at the bottom of the screen',
+    });
+
+    const result = await checkBottomNavigation(client, 'screen-1', FAKE_BASE64);
+    expect(result.detected).toBe(false);
+    expect(result.confidence).toBe(0.9);
+  });
+
+  it('handles API error gracefully', async () => {
+    const client = makeErrorClient('Network error');
+    const result = await checkBottomNavigation(client, 'screen-1', FAKE_BASE64);
+    expect(result.detected).toBeNull();
+    expect(result.status).toBe('vision_api_unavailable');
+  });
+});
+
+// -------------------------------------------------------------------------
+// checkHorizontalScroll
+// -------------------------------------------------------------------------
+
+describe('checkHorizontalScroll', () => {
+  it('returns score 100 when no overflow', async () => {
+    const client = makeClient({
+      overflow_detected: false,
+      score: 100,
+      overflow_elements: [],
+      findings: ['All content fits within viewport width'],
+    });
+
+    const result = await checkHorizontalScroll(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBe(100);
+    expect(result.overflow_detected).toBe(false);
+    expect(result.overflow_elements).toHaveLength(0);
+  });
+
+  it('detects horizontal overflow', async () => {
+    const client = makeClient({
+      overflow_detected: true,
+      score: 40,
+      overflow_elements: ['Wide data table extends beyond viewport'],
+      findings: ['Table element causes horizontal scroll'],
+    });
+
+    const result = await checkHorizontalScroll(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBe(40);
+    expect(result.overflow_detected).toBe(true);
+    expect(result.overflow_elements).toHaveLength(1);
+  });
+
+  it('handles API error gracefully', async () => {
+    const client = makeErrorClient('Rate limited');
+    const result = await checkHorizontalScroll(client, 'screen-1', FAKE_BASE64);
+    expect(result.score).toBeNull();
+    expect(result.status).toBe('error');
+  });
+});
+
+// -------------------------------------------------------------------------
+// scoreMobileAssertions
+// -------------------------------------------------------------------------
+
+describe('scoreMobileAssertions', () => {
+  it('runs all three assertions and returns combined result', async () => {
+    let callCount = 0;
+    const client = {
+      messages: {
+        create: vi.fn().mockImplementation(({ max_tokens }) => {
+          callCount++;
+          let json;
+          if (max_tokens === 2048) {
+            // Touch targets prompt
+            json = { elements: [], total_interactive: 0, total_compliant: 0, score: 100 };
+          } else if (max_tokens === 512) {
+            // Bottom nav prompt
+            json = { detected: true, confidence: 0.9, description: 'Tab bar found' };
+          } else {
+            // Horizontal scroll prompt
+            json = { overflow_detected: false, score: 100, overflow_elements: [], findings: [] };
+          }
+          return Promise.resolve({
+            content: [{ type: 'text', text: JSON.stringify(json) }],
+            usage: { input_tokens: 1500, output_tokens: 400 },
+          });
+        }),
+      },
+    };
+
+    const result = await scoreMobileAssertions(client, 'screen-1', FAKE_BASE64);
+    expect(result.platform).toBe('MOBILE');
+    expect(result.touch_target_compliance.score).toBe(100);
+    expect(result.bottom_nav_detected).toBe(true);
+    expect(result.horizontal_scroll_score.score).toBe(100);
+    expect(client.messages.create).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 3 mobile-specific vision assertions to S17 QA: touch target 44x44px validation, bottom navigation detection, horizontal scroll check
- Platform-aware routing in `scoreWireframeFidelity()` runs mobile assertions only for `MOBILE` ventures
- Results stored with `platform` tag and `mobile_assertions` sub-object in `venture_artifacts`

## Test plan
- [x] 10 new unit tests for mobile assertions (all passing)
- [x] 30 existing QA tests still pass (no regressions)
- [ ] Manual: run S17 QA on venture with `target_platform=MOBILE`
- [ ] Manual: verify desktop QA unchanged with `target_platform=DESKTOP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)