### PR TITLE
feat(SD-DUALPLAT-MOBILE-WEB-ORCH-001-C): PWA shell templates for mobile delivery

### DIFF
--- a/templates/pwa/manifest-generator.js
+++ b/templates/pwa/manifest-generator.js
@@ -1,0 +1,58 @@
+/**
+ * PWA Manifest Generator
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Generates a W3C Web App Manifest from venture brand tokens.
+ * Brand tokens come from S11 (visual identity) artifacts.
+ *
+ * @module templates/pwa/manifest-generator
+ */
+
+/**
+ * Generate a valid manifest.json from venture brand tokens.
+ *
+ * @param {Object} brandTokens - S11 brand token data
+ * @param {string} brandTokens.venture_name - Venture display name
+ * @param {string} [brandTokens.short_name] - Short name for home screen
+ * @param {Object} [brandTokens.colors] - Color palette
+ * @param {string} [brandTokens.colors.primary] - Primary brand color
+ * @param {string} [brandTokens.colors.background] - Background color
+ * @param {string} [brandTokens.description] - Venture description
+ * @param {Array}  [brandTokens.icons] - Icon definitions [{src, sizes, type}]
+ * @returns {Object} Valid W3C Web App Manifest object
+ */
+export function generateManifest(brandTokens) {
+  const name = brandTokens.venture_name || brandTokens.name || 'Venture App';
+  const shortName = brandTokens.short_name || name.slice(0, 12);
+  const themeColor = brandTokens.colors?.primary || brandTokens.theme_color || '#000000';
+  const backgroundColor = brandTokens.colors?.background || brandTokens.background_color || '#ffffff';
+  const description = brandTokens.description || `${name} - Progressive Web App`;
+
+  // Default icons if none provided
+  const icons = brandTokens.icons || [
+    { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
+    { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' },
+  ];
+
+  return {
+    name,
+    short_name: shortName,
+    description,
+    start_url: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    theme_color: themeColor,
+    background_color: backgroundColor,
+    icons,
+    categories: ['business'],
+  };
+}
+
+/**
+ * Serialize manifest to JSON string.
+ * @param {Object} manifest - Manifest object from generateManifest
+ * @returns {string} JSON string ready to write to manifest.json
+ */
+export function serializeManifest(manifest) {
+  return JSON.stringify(manifest, null, 2);
+}

--- a/templates/pwa/pwa-injector.js
+++ b/templates/pwa/pwa-injector.js
@@ -1,0 +1,102 @@
+/**
+ * PWA Injector
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Injects PWA artifacts (manifest link, service worker registration,
+ * viewport meta tag, install prompt) into HTML output for ventures
+ * with target_platform including mobile.
+ *
+ * @module templates/pwa/pwa-injector
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { generateManifest, serializeManifest } from './manifest-generator.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Generate all PWA artifacts for a venture.
+ *
+ * @param {Object} options
+ * @param {Object} options.brandTokens - S11 brand token data
+ * @param {string} [options.deployHash] - Deployment hash for cache versioning
+ * @param {number} [options.cacheTtlMs] - Cache TTL in ms (default: 24hr)
+ * @returns {{ manifest: string, serviceWorker: string, headTags: string, bodyScript: string }}
+ */
+export function generatePWAArtifacts(options) {
+  const { brandTokens, deployHash = Date.now().toString(36), cacheTtlMs = 86400000 } = options;
+
+  // 1. Generate manifest.json
+  const manifestObj = generateManifest(brandTokens);
+  const manifest = serializeManifest(manifestObj);
+
+  // 2. Generate service worker with version stamp
+  let serviceWorker;
+  try {
+    serviceWorker = readFileSync(resolve(__dirname, 'service-worker.js'), 'utf-8');
+  } catch {
+    // Fallback minimal service worker
+    serviceWorker = 'self.addEventListener(\'fetch\', () => {});';
+  }
+  serviceWorker = serviceWorker
+    .replace(/__CACHE_VERSION__/g, deployHash)
+    .replace(/__CACHE_TTL_MS__/g, String(cacheTtlMs));
+
+  // 3. Head tags to inject
+  const themeColor = manifestObj.theme_color;
+  const headTags = [
+    '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">',
+    `<meta name="theme-color" content="${themeColor}">`,
+    '<meta name="apple-mobile-web-app-capable" content="yes">',
+    '<meta name="apple-mobile-web-app-status-bar-style" content="default">',
+    '<link rel="manifest" href="/manifest.json">',
+  ].join('\n    ');
+
+  // 4. Service worker registration script (inject before </body>)
+  const bodyScript = `<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js')
+        .then(reg => console.log('[PWA] Service worker registered:', reg.scope))
+        .catch(err => console.warn('[PWA] Service worker registration failed:', err));
+    });
+  }
+  </script>`;
+
+  return { manifest, serviceWorker, headTags, bodyScript };
+}
+
+/**
+ * Inject PWA artifacts into an HTML string.
+ *
+ * @param {string} html - Raw HTML content
+ * @param {Object} pwaArtifacts - Output from generatePWAArtifacts
+ * @returns {string} HTML with PWA artifacts injected
+ */
+export function injectPWAIntoHTML(html, pwaArtifacts) {
+  let result = html;
+
+  // Inject head tags before </head>
+  if (result.includes('</head>')) {
+    result = result.replace('</head>', `    ${pwaArtifacts.headTags}\n  </head>`);
+  }
+
+  // Inject SW registration before </body>
+  if (result.includes('</body>')) {
+    result = result.replace('</body>', `  ${pwaArtifacts.bodyScript}\n  </body>`);
+  }
+
+  return result;
+}
+
+/**
+ * Check if a venture should get PWA artifacts.
+ *
+ * @param {string} targetPlatform - Venture's target_platform value
+ * @returns {boolean} True if PWA artifacts should be generated
+ */
+export function shouldInjectPWA(targetPlatform) {
+  return targetPlatform === 'both' || targetPlatform === 'mobile';
+}

--- a/templates/pwa/service-worker.js
+++ b/templates/pwa/service-worker.js
@@ -1,0 +1,87 @@
+/**
+ * PWA Service Worker Template
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Cache-first strategy with configurable TTL and version-stamped cache keys.
+ * This template is injected into venture builds when target_platform includes mobile.
+ *
+ * Configuration is injected at build time via string replacement:
+ *   __CACHE_VERSION__ → deployment hash
+ *   __CACHE_TTL_MS__  → TTL in milliseconds (default: 86400000 = 24hr)
+ */
+
+const CACHE_NAME = 'venture-cache-v__CACHE_VERSION__';
+const CACHE_TTL_MS = __CACHE_TTL_MS__ || 86400000; // 24 hours default
+
+// Assets to precache on install
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+];
+
+// Install: precache core assets
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+// Activate: clean up old cache versions
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith('venture-cache-') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// Fetch: cache-first with TTL
+self.addEventListener('fetch', (event) => {
+  // Only handle GET requests
+  if (event.request.method !== 'GET') return;
+
+  // Skip non-HTTP(S) requests
+  if (!event.request.url.startsWith('http')) return;
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(event.request);
+
+      if (cached) {
+        // Check TTL via custom header
+        const cachedAt = cached.headers.get('x-cached-at');
+        if (cachedAt && Date.now() - parseInt(cachedAt, 10) < CACHE_TTL_MS) {
+          return cached;
+        }
+      }
+
+      // Fetch from network, cache the response
+      try {
+        const response = await fetch(event.request);
+        if (response.ok) {
+          // Clone and add timestamp header for TTL tracking
+          const headers = new Headers(response.headers);
+          headers.set('x-cached-at', String(Date.now()));
+          const timestamped = new Response(await response.clone().blob(), {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          });
+          cache.put(event.request, timestamped);
+        }
+        return response;
+      } catch {
+        // Network failed — serve stale cache if available
+        if (cached) return cached;
+        return new Response('Offline', { status: 503 });
+      }
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- Add `templates/pwa/manifest-generator.js`: W3C manifest from S11 brand tokens
- Add `templates/pwa/service-worker.js`: cache-first with 24hr TTL + version stamps
- Add `templates/pwa/pwa-injector.js`: inject manifest, SW, viewport meta into HTML
- `shouldInjectPWA()` utility for target_platform routing

## Parent Orchestrator
SD-DUALPLATFORM-MOBILEWEB-VENTURE-DESIGN-ORCH-001 — Dual-Platform Mobile+Web Pipeline

## Test plan
- [x] All modules import cleanly
- [x] Manifest generates correct fields from brand tokens
- [x] Service worker template has cache-first + TTL
- [x] HTML injection adds manifest link + SW registration
- [x] shouldInjectPWA() returns true for both/mobile, false for web
- [x] Smoke tests 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)