### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-076): reduce false handoff gate failures

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -23,9 +23,9 @@ import { resolveOwnSession } from './resolve-own-session.js';
 
 // ── Worktree validation helpers (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-074) ────
 
-/** Module-level cache for isRealWorktree results (2s TTL). */
+/** Module-level cache for isRealWorktree results (10s TTL). */
 export const _worktreeCache = new Map();
-const WORKTREE_CACHE_TTL_MS = 2000;
+const WORKTREE_CACHE_TTL_MS = 10000;
 
 /**
  * Check if a path is a registered git worktree by querying `git worktree list --porcelain`.
@@ -41,7 +41,7 @@ export function isRealWorktree(worktreePath) {
   let result = false;
   try {
     const output = execSync('git worktree list --porcelain', {
-      timeout: 2000,
+      timeout: 5000,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -74,7 +74,7 @@ function tryRecoverWorktreePath(sdKey) {
   try {
     // Find git root
     const gitRoot = execSync('git rev-parse --show-toplevel', {
-      timeout: 2000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     const worktreeDir = path.join(gitRoot, '.worktrees', sdKey);
     if (existsSync(worktreeDir) && isRealWorktree(worktreeDir)) {
@@ -268,7 +268,12 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
       });
     }
 
-    const insideWorktree = actualCwd === expectedWt || actualCwd.startsWith(expectedWt + path.sep);
+    // Normalize paths to lowercase on Windows (case-insensitive filesystem) and
+    // ensure consistent separators before comparison to prevent false wrong_worktree errors.
+    const normalize = (p) => process.platform === 'win32' ? p.replace(/\//g, '\\').toLowerCase() : p;
+    const normalExpected = normalize(expectedWt);
+    const normalActual = normalize(actualCwd);
+    const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
     if (!insideWorktree) {
       throw new ClaimIdentityError({
         reason: 'wrong_worktree',

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
@@ -160,7 +160,7 @@ export async function validateTransitionReadiness(sd, supabase) {
     if (isOrchestratorChild) {
       warnings.push('success_metrics empty for orchestrator child - will be populated during PLAN phase');
       console.log('   ⚠️  success_metrics empty (orchestrator child - warning only)');
-      score -= 15;
+      score -= 5;
     } else {
       issues.push('success_metrics AND success_criteria are both empty - must define at least one measurable success metric');
       console.log('   ❌ success_metrics and success_criteria are both empty or missing');

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -175,11 +175,25 @@ export class PlanToExecVerifier {
         }
 
         if (!stories || stories.length === 0) {
-          console.log('   ❌ No user stories found');
-          return rejectHandoff(this.supabase,sdId, 'NO_USER_STORIES', 'User stories are MANDATORY before EXEC phase.', {
-            userStoriesCount: 0,
-            requiredMinimum: 1
-          });
+          // Fallback: check if PRD content has embedded user_stories before rejecting
+          // Some workflows store stories in the PRD JSON but haven't migrated them to the table
+          const prdForStoryCheck = prds && prds.length > 0 ? (Array.isArray(prds) ? prds[0] : prds) : null;
+          const prdContent = prdForStoryCheck?.content;
+          const embeddedStories = typeof prdContent === 'object' && prdContent?.user_stories;
+          const hasEmbeddedStories = Array.isArray(embeddedStories) && embeddedStories.length > 0;
+
+          if (hasEmbeddedStories) {
+            console.log(`   ⚠️  No user stories in table, but found ${embeddedStories.length} in PRD content (fallback)`);
+            console.log('   💡 Run add-prd-to-database.js to migrate stories to the user_stories table');
+            userStories = embeddedStories;
+          } else {
+            console.log('   ❌ No user stories found');
+            return rejectHandoff(this.supabase,sdId, 'NO_USER_STORIES', 'User stories are MANDATORY before EXEC phase.', {
+              userStoriesCount: 0,
+              requiredMinimum: 1,
+              hint: 'If stories exist in the PRD, run add-prd-to-database.js to sync them to the user_stories table.'
+            });
+          }
         }
 
         userStories = stories;


### PR DESCRIPTION
## Summary
- Reduce orchestrator child success_metrics penalty from -15 to -5 in LEAD-TO-PLAN gate (expected empty at creation)
- Increase worktree cache TTL (2s→10s) and git timeout (2s→5s) to prevent stale_worktree false positives on Windows
- Add PRD content fallback for user_stories check in PLAN-TO-EXEC before rejecting
- Normalize Windows paths (case + separators) in wrong_worktree detection

Addresses 5 recurring handoff failure patterns with 38 total occurrences.

## Test plan
- [x] All claim-validity-gate unit tests pass (6/6)
- [x] No new test failures introduced (same 150 pre-existing failures on main)
- [x] EXEC-TO-PLAN handoff passed at 94%
- [x] PLAN-TO-LEAD handoff passed at 96%
- [x] LEAD-FINAL-APPROVAL passed at 96%

🤖 Generated with [Claude Code](https://claude.com/claude-code)