### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080): enhance handoff gate feedback

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -230,6 +230,21 @@ export class HandoffOrchestrator {
         supabase: this.supabase
       });
 
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Show gate scores and thresholds
+      if (result.gateResults && Object.keys(result.gateResults).length > 0) {
+        console.log('');
+        console.log('📊 GATE SCORES (Precheck)');
+        console.log('─'.repeat(60));
+        for (const [gateName, gr] of Object.entries(result.gateResults)) {
+          const pct = gr.maxScore > 0 ? Math.round((gr.score / gr.maxScore) * 100) : 0;
+          const threshold = gr.threshold || 70;
+          const status = gr.passed !== false ? '✅' : '❌';
+          console.log(`   ${status} ${gateName}: ${pct}% (threshold: ${threshold}%)`);
+        }
+        console.log(`   📈 Overall: ${result.normalizedScore || 0}%`);
+        console.log('─'.repeat(60));
+      }
+
       // Add actionable remediation for each failed gate
       if (result.failedGates.length > 0) {
         console.log('');

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
@@ -164,6 +164,11 @@ export async function validateTransitionReadiness(sd, supabase) {
     } else {
       issues.push('success_metrics AND success_criteria are both empty - must define at least one measurable success metric');
       console.log('   ❌ success_metrics and success_criteria are both empty or missing');
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Add format guidance to prevent retry loops
+      console.log('   💡 FIX: Populate one of these fields on the SD:');
+      console.log('      success_metrics: [{ metric: "Name", target: "Goal", actual: "TBD" }]');
+      console.log('      success_criteria: [{ criterion: "What", measure: "How to verify" }]');
+      console.log('      Either field works — success_criteria is used as fallback if success_metrics is empty.');
       score -= 25;
     }
   } else if (Array.isArray(successMetrics)) {

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
@@ -173,8 +173,12 @@ export function createSuccessMetricsGate(supabase) {
           const EVIDENCE_STATUSES = new Set(['completed', 'ready', 'done', 'validated']);
           const completedStories = stories?.filter(s => EVIDENCE_STATUSES.has(s.status))?.length || 0;
 
+          // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Show auto-population status per metric
+          const emptyMetrics = metrics.filter(m => isEmptyOrPending(m.actual));
+          console.log(`   📋 Auto-population check: ${emptyMetrics.length} metric(s) missing actual values`);
           if (acceptedCount > 0 || completedStories > 0) {
-            console.log(`   🔄 Auto-populating missing actuals from evidence (${acceptedCount} handoffs, ${completedStories}/${totalStories} stories)`);
+            console.log(`   🔄 Auto-populating from evidence: ${acceptedCount} handoff(s), ${completedStories}/${totalStories} stories`);
+            console.log(`      Source: ${acceptedCount > 0 ? 'handoff evidence' : ''}${acceptedCount > 0 && completedStories > 0 ? ' + ' : ''}${completedStories > 0 ? 'story completion' : ''}`);
             for (const metric of metrics) {
               if (!isEmptyOrPending(metric.actual)) continue;
               const name = (metric.metric || metric.name || '').toLowerCase();
@@ -199,6 +203,10 @@ export function createSuccessMetricsGate(supabase) {
             await supabase.from('strategic_directives_v2')
               .update({ success_metrics: metrics })
               .eq('id', sdUuid);
+          } else {
+            // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Explain why auto-population skipped
+            console.log(`   ⚠️  No evidence found for auto-population (0 handoffs, 0 completed stories)`);
+            console.log(`      💡 Complete user stories or handoffs to provide evidence for metric actuals`);
           }
         } catch (autoPopErr) {
           console.log(`   ⚠️  Auto-populate failed: ${autoPopErr.message} (continuing with manual values)`);

--- a/scripts/modules/handoff/executors/plan-to-lead/plan-verification.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/plan-verification.js
@@ -89,9 +89,13 @@ async function validateParentSDCompletion(supabase, prd, childSDs, validation) {
  * Validate standard SD completion
  */
 async function validateStandardSDCompletion(supabase, prd, sd, validation) {
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Track component scores for breakdown output
+  let prdScore = 0, handoffScore = 0, storiesScore = 0;
+
   // Check PRD status
   if (prd.status === 'verification' || prd.status === 'completed') {
     validation.score += 30;
+    prdScore = 30;
   } else {
     validation.issues.push(`PRD status is '${prd.status}', expected 'verification' or 'completed'`);
   }
@@ -102,6 +106,7 @@ async function validateStandardSDCompletion(supabase, prd, sd, validation) {
 
   if (isLightweightSDType(sdType)) {
     validation.score += 40;
+    handoffScore = 40;
     validation.warnings.push(`Infrastructure SD: EXEC-TO-PLAN is OPTIONAL (sd_type='${sdType}')`);
   } else {
     const { data: execHandoff } = await supabase
@@ -114,6 +119,7 @@ async function validateStandardSDCompletion(supabase, prd, sd, validation) {
 
     if (execHandoff && execHandoff.length > 0) {
       validation.score += 40;
+      handoffScore = 40;
     } else {
       validation.issues.push('No EXEC→PLAN handoff found');
     }
@@ -131,11 +137,20 @@ async function validateStandardSDCompletion(supabase, prd, sd, validation) {
     );
     if (completedStories.length === userStories.length) {
       validation.score += 30;
+      storiesScore = 30;
     } else {
       validation.warnings.push(`${completedStories.length}/${userStories.length} user stories completed`);
-      validation.score += Math.round(30 * (completedStories.length / userStories.length));
+      storiesScore = Math.round(30 * (completedStories.length / userStories.length));
+      validation.score += storiesScore;
     }
   }
+
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Show component score breakdown
+  console.log('   📊 Plan Verification Breakdown:');
+  console.log(`      PRD status:    ${prdScore}/30 ${prdScore === 30 ? '✅' : '❌'}`);
+  console.log(`      EXEC handoff:  ${handoffScore}/40 ${handoffScore === 40 ? '✅' : isLightweightSDType(sdType) ? '(N/A - infra)' : '❌'}`);
+  console.log(`      User stories:  ${storiesScore}/30 ${storiesScore === 30 ? '✅' : `(${userStories?.length || 0} total)`}`);
+  console.log(`      Total:         ${validation.score}/100 (threshold: 70)`);
 
   validation.complete = validation.score >= 70;
   return validation;


### PR DESCRIPTION
## Summary
- Add gate score/threshold display to precheck output (HandoffOrchestrator.js)
- Add format guidance when success_metrics/success_criteria empty (transition-readiness.js)
- Add auto-population status messaging per metric (success-metrics-gate.js)
- Add plan verification component breakdown (plan-verification.js)
- Resolves 5 recurring patterns (15 total occurrences) causing handoff retry loops

## Test plan
- [ ] Run `node scripts/handoff.js precheck LEAD-TO-PLAN <SD>` — verify gate scores shown
- [ ] Test empty success_metrics shows format guidance
- [ ] Verify existing output format preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)