### PR TITLE
fix(SD-LEO-INFRA-AUTO-CHAIN-MERGE-001): gate auto-chain on PR merge

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -23,9 +23,11 @@ import { publishVisionEvent, VISION_EVENTS } from '../../../../../lib/eva/event-
  *
  * @param {Object} sd - SD record
  * @param {Object} supabase - Supabase client
+ * @param {Object} [options] - Options
+ * @param {Object} [options.shippingResults] - PR merge/cleanup results from auto-shipping (SD-LEO-INFRA-AUTO-CHAIN-MERGE-001)
  * @returns {Promise<{ orchestratorCompleted: boolean, chainContinue?: boolean, nextOrchestrator?: string }>}
  */
-export async function checkAndCompleteParentSD(sd, supabase) {
+export async function checkAndCompleteParentSD(sd, supabase, { shippingResults } = {}) {
   console.log('\n   Checking parent SD completion...');
 
   // Default return for non-completion cases
@@ -71,7 +73,7 @@ export async function checkAndCompleteParentSD(sd, supabase) {
               parentSD.id,
               parentSD.title,
               siblings.length,
-              { supabase }
+              { supabase, shippingResults }
             );
 
             return {
@@ -98,7 +100,7 @@ export async function checkAndCompleteParentSD(sd, supabase) {
               parentSD.id,
               parentSD.title,
               siblings.length,
-              { supabase }
+              { supabase, shippingResults }
             );
 
             return {
@@ -146,7 +148,7 @@ export async function checkAndCompleteParentSD(sd, supabase) {
             parentSD.id,
             parentSD.title,
             siblings.length,
-            { supabase }
+            { supabase, shippingResults }
           );
 
           return {

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -413,13 +413,6 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       console.log('   ℹ️  AUTO-PROCEED state retained (child SD - continuation possible)');
     }
 
-    // Check if this SD has a parent that should be auto-completed
-    // SD-LEO-ENH-AUTO-PROCEED-001-05: Capture chaining info for orchestrator continuation
-    let orchestratorChainingInfo = { orchestratorCompleted: false };
-    if (sd.parent_sd_id) {
-      orchestratorChainingInfo = await checkAndCompleteParentSD(sd, this.supabase);
-    }
-
     const handoffId = `LEAD-FINAL-${sdId}-${Date.now()}`;
 
     console.log('\n🎉 SD COMPLETION: Final approval granted');
@@ -427,7 +420,10 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     console.log(`   Title: ${sd.title}`);
     console.log(`   Handoff ID: ${handoffId}`);
 
-    // Automated Shipping: PR Merge & Branch Cleanup
+    // SD-LEO-INFRA-AUTO-CHAIN-MERGE-001: Ship BEFORE orchestrator completion.
+    // Previously, auto-chain fired before PR merge, causing next SD to start
+    // while current SD's code was still unshipped. Now shipping runs first so
+    // the merge result can gate the auto-chain decision.
     let shippingResults = { merge: null, cleanup: null };
     try {
       console.log('\n🚢 [AUTO-SHIP] Merge & Cleanup Decisions');
@@ -456,6 +452,14 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       }
     } catch (shippingError) {
       console.warn(`   ⚠️  Auto-shipping error (non-blocking): ${shippingError.message}`);
+    }
+
+    // Check if this SD has a parent that should be auto-completed
+    // SD-LEO-ENH-AUTO-PROCEED-001-05: Capture chaining info for orchestrator continuation
+    // SD-LEO-INFRA-AUTO-CHAIN-MERGE-001: Pass shippingResults so auto-chain can gate on merge
+    let orchestratorChainingInfo = { orchestratorCompleted: false };
+    if (sd.parent_sd_id) {
+      orchestratorChainingInfo = await checkAndCompleteParentSD(sd, this.supabase, { shippingResults });
     }
 
     // SD-LEO-INFRA-INTEGRATE-WORKTREE-CREATION-001: Cleanup worktree on SD completion

--- a/scripts/modules/handoff/orchestrator-completion-hook.js
+++ b/scripts/modules/handoff/orchestrator-completion-hook.js
@@ -762,6 +762,7 @@ async function invokeParentHeal(supabase, orchestratorId, orchestratorTitle, cor
  * @param {number} childCount - Number of completed children
  * @param {object} options - Hook options
  * @param {object} options.supabase - Supabase client (optional)
+ * @param {object} [options.shippingResults] - PR merge/cleanup results (SD-LEO-INFRA-AUTO-CHAIN-MERGE-001)
  * @returns {Promise<{ fired: boolean, autoProceed: boolean, correlationId: string }>}
  */
 export async function executeOrchestratorCompletionHook(
@@ -1045,6 +1046,46 @@ export async function executeOrchestratorCompletionHook(
       completedSdKey = sdData?.sd_key;
     } catch {
       // Non-fatal
+    }
+
+    // SD-LEO-INFRA-AUTO-CHAIN-MERGE-001: PR_MERGE gate — block auto-chain if PR not merged.
+    // shippingResults is threaded from lead-final-approval/index.js through helpers.js.
+    // When shipping did not occur (no shippingResults or no merge attempt), allow auto-chain
+    // to proceed (backward compatible for documentation SDs or manual shipping).
+    const mergeSuccess = options.shippingResults?.merge?.executionResult?.success;
+    const mergeDeferred = options.shippingResults?.merge?.executionResult?.deferred;
+    const mergeEscalated = options.shippingResults?.merge?.shouldEscalate;
+    const shippingAttempted = options.shippingResults?.merge != null;
+
+    if (shippingAttempted && !mergeSuccess) {
+      const prUrl = options.shippingResults?.merge?.executionResult?.pr_url
+        || options.shippingResults?.merge?.pr_url || 'unknown';
+      const reason = mergeDeferred ? 'deferred' : mergeEscalated ? 'escalated to human' : 'failed';
+
+      console.log('\n   ═══════════════════════════════════════════════════════');
+      console.log('   🚫 PR_MERGE GATE: Auto-chain blocked — code not shipped');
+      console.log('   ═══════════════════════════════════════════════════════');
+      console.log(`      PR:     ${prUrl}`);
+      console.log(`      Reason: Merge ${reason}`);
+      console.log(`      Action: Run /ship manually, then re-run LEAD-FINAL-APPROVAL`);
+      console.log('   ═══════════════════════════════════════════════════════');
+
+      hookDetails.prMergeGate = { blocked: true, reason, prUrl };
+      await recordHookEvent(supabase, orchestratorId, correlationId, hookDetails);
+
+      return {
+        fired: true,
+        autoProceed: false,
+        chainContinue: false,
+        correlationId,
+        mergeBlocked: true,
+        mergeReason: reason
+      };
+    }
+
+    if (shippingAttempted && mergeSuccess) {
+      console.log('   ✅ PR_MERGE GATE: Merge confirmed — auto-chain allowed');
+      hookDetails.prMergeGate = { blocked: false };
     }
 
     const chainResult = await executeAutoChain(supabase, {


### PR DESCRIPTION
## Summary
- Reorders lead-final-approval to run PR shipping/merge BEFORE orchestrator completion hook
- Adds PR_MERGE gate in orchestrator-completion-hook.js that blocks auto-chain when merge fails or defers
- Threads shippingResults through helpers.js to the completion hook
- Previously, auto-chain fired before PR merge, allowing next SD to start with unshipped code

## Files Changed
- `scripts/modules/handoff/executors/lead-final-approval/index.js` — reorder shipping before checkAndCompleteParentSD
- `scripts/modules/handoff/executors/lead-final-approval/helpers.js` — accept and thread shippingResults parameter
- `scripts/modules/handoff/orchestrator-completion-hook.js` — PR_MERGE gate before executeAutoChain

## Test plan
- [ ] LEAD-FINAL-APPROVAL on child SD → verify PR merge runs before orchestrator completion
- [ ] Successful merge → auto-chain proceeds normally
- [ ] Failed merge → auto-chain blocked with actionable CLI message
- [ ] Standalone SD (no parent) → completes without interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)