### PR TITLE
fix(SD-LEARN-FIX-079): sanitize Gemini API prompt inputs

### DIFF
--- a/lib/ai/multimodal-client.js
+++ b/lib/ai/multimodal-client.js
@@ -260,7 +260,7 @@ Respond in JSON format:
           {
             contents: [{
               parts: [
-                { text: prompt },
+                { text: typeof prompt === 'string' ? prompt : JSON.stringify(prompt) },
                 {
                   inlineData: {
                     mimeType: 'image/png',

--- a/lib/programmatic/tool-loop.js
+++ b/lib/programmatic/tool-loop.js
@@ -105,6 +105,14 @@ function toGeminiFunctionDeclarations(tools) {
   });
 }
 
+/** Coerce a value to string for Gemini API parts[].text fields (PAT-AUTO-8a251901). */
+function ensureString(value) {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
 async function runGeminiLoop(prompt, tools, options) {
   const {
     maxTokens = DEFAULT_MAX_TOKENS,
@@ -122,12 +130,12 @@ async function runGeminiLoop(prompt, tools, options) {
   const handlerMap = {};
   for (const t of tools) handlerMap[t.definition.name] = t.handler;
 
-  // Build initial contents
+  // Build initial contents — ensureString guards against non-string prompts (PAT-AUTO-8a251901)
   const contents = [];
   if (systemPrompt) {
     // Gemini uses systemInstruction, handled in request body
   }
-  contents.push({ role: 'user', parts: [{ text: prompt }] });
+  contents.push({ role: 'user', parts: [{ text: ensureString(prompt) }] });
 
   let turns = 0;
   let finalText = '';
@@ -141,7 +149,7 @@ async function runGeminiLoop(prompt, tools, options) {
       generationConfig: { maxOutputTokens: maxTokens },
     };
     if (systemPrompt) {
-      requestBody.systemInstruction = { parts: [{ text: systemPrompt }] };
+      requestBody.systemInstruction = { parts: [{ text: ensureString(systemPrompt) }] };
     }
 
     const response = await fetch(

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -43,7 +43,8 @@ function sleep(ms) {
  * @returns {string} Sanitized string with invalid surrogates replaced by U+FFFD
  */
 function sanitizeUnicode(value) {
-  if (typeof value !== 'string') return value;
+  if (value == null) return '';
+  if (typeof value !== 'string') return typeof value === 'object' ? JSON.stringify(value) : String(value);
 
   let result = '';
   for (let i = 0; i < value.length; i++) {


### PR DESCRIPTION
## Summary
- Add `ensureString()` guard to coerce non-string prompts before Gemini API calls
- Fixes PAT-AUTO-8a251901: 5 occurrences of `Invalid value at contents[0].parts[0]`
- Guards added to: `tool-loop.js`, `multimodal-client.js`, `provider-adapters.js`

## Test plan
- [x] 6 existing tool-loop tests pass
- [x] 15 smoke tests pass
- [x] 19 LOC total change

🤖 Generated with [Claude Code](https://claude.com/claude-code)