### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-078): prerequisite preflight prevents 0% gate scores

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -22,6 +22,7 @@ import {
   createHandoffMetadata
 } from './auto-proceed-resolver.js';
 import { captureHandoffGate } from '../../../lib/flywheel/capture.js';
+import { runPrerequisitePreflight } from './pre-checks/prerequisite-preflight.js';
 
 export class HandoffOrchestrator {
   constructor(options = {}) {
@@ -124,6 +125,34 @@ export class HandoffOrchestrator {
         );
       }
 
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-078: Quick prerequisite preflight
+      // Catches common 0% gate causes before running expensive full validation
+      const preflight = await runPrerequisitePreflight(this.supabase, normalizedType, sdId);
+      if (!preflight.passed) {
+        console.log('');
+        console.log('🚫 PREREQUISITE PREFLIGHT FAILED');
+        console.log('─'.repeat(50));
+        console.log('   The following prerequisites must be met before running gates:');
+        console.log('');
+        for (const issue of preflight.issues) {
+          console.log(`   ❌ [${issue.code}] ${issue.message}`);
+          console.log(`      💡 ${issue.remediation}`);
+          console.log('');
+        }
+        console.log('─'.repeat(50));
+        console.log('   Fix these issues first, then retry the handoff.');
+        console.log('');
+
+        // Record as failure with clear reason
+        const preflightResult = ResultBuilder.rejected(
+          'PREREQUISITE_PREFLIGHT_FAILED',
+          `Prerequisite preflight failed: ${preflight.issues.map(i => i.code).join(', ')}`
+        );
+        preflightResult.preflightIssues = preflight.issues;
+        await this.recorder.recordFailure(normalizedType, sdId, preflightResult, null);
+        return preflightResult;
+      }
+
       // Execute the handoff with AUTO-PROCEED metadata
       const result = await executor.execute(sdId, enhancedOptions);
 
@@ -205,6 +234,20 @@ export class HandoffOrchestrator {
           passedGates: [],
           failedGates: [{ name: 'SD_EXISTS', issues: ['SD not found'] }]
         };
+      }
+
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-078: Run quick preflight first
+      const preflight = await runPrerequisitePreflight(this.supabase, normalizedType, sdId);
+      if (!preflight.passed) {
+        console.log('');
+        console.log('🚫 PREREQUISITE PREFLIGHT ISSUES (fix these first):');
+        for (const issue of preflight.issues) {
+          console.log(`   ❌ [${issue.code}] ${issue.message}`);
+          console.log(`      💡 ${issue.remediation}`);
+        }
+        console.log('');
+        console.log('   Continuing with full gate check to find additional issues...');
+        console.log('');
       }
 
       // Get executor and gates

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -1,0 +1,239 @@
+/**
+ * Prerequisite Preflight Checks
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-078
+ *
+ * Quick prerequisite validation that runs BEFORE full gate validation.
+ * Catches the most common causes of 0% gate scores:
+ * - Missing SD JSONB fields (LEAD-TO-PLAN)
+ * - Missing PRD or user stories (PLAN-TO-EXEC)
+ * - Missing prerequisite handoffs (LEAD-FINAL-APPROVAL)
+ *
+ * These checks are fast (single DB query each) and provide immediate
+ * actionable feedback, preventing expensive 24-gate validation runs
+ * that would score 0%.
+ */
+
+import { SD_TYPE_THRESHOLDS, DEFAULT_THRESHOLD, JSONB_FIELDS } from '../../sd-quality-scoring.js';
+
+/**
+ * Run prerequisite preflight checks for a given handoff type.
+ * Returns { passed, issues[] } where each issue has { code, message, remediation }.
+ */
+export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
+  const issues = [];
+
+  try {
+    // Load SD record
+    const { data: sd, error: sdError } = await supabase
+      .from('strategic_directives_v2')
+      .select('*')
+      .eq('sd_key', sdId)
+      .single();
+
+    if (sdError || !sd) {
+      return {
+        passed: false,
+        issues: [{
+          code: 'SD_NOT_FOUND',
+          message: `Strategic Directive ${sdId} not found in database`,
+          remediation: `Verify the SD key is correct. Run: node -e "..." to check.`
+        }]
+      };
+    }
+
+    const normalizedType = handoffType.toUpperCase().replace(/-/g, '_');
+
+    switch (normalizedType) {
+      case 'LEAD_TO_PLAN':
+      case 'LEAD-TO-PLAN':
+        issues.push(...checkLeadToPlanPrereqs(sd));
+        break;
+
+      case 'PLAN_TO_EXEC':
+      case 'PLAN-TO-EXEC':
+        issues.push(...await checkPlanToExecPrereqs(supabase, sd, sdId));
+        break;
+
+      case 'LEAD_FINAL_APPROVAL':
+      case 'LEAD-FINAL-APPROVAL':
+        issues.push(...await checkLeadFinalApprovalPrereqs(supabase, sdId));
+        break;
+
+      // EXEC-TO-PLAN and PLAN-TO-LEAD have fewer prerequisite issues
+      default:
+        break;
+    }
+  } catch (err) {
+    // Fail-open: don't block handoff if preflight itself errors
+    console.warn(`   ⚠️  Prerequisite preflight error (non-blocking): ${err.message}`);
+    return { passed: true, issues: [] };
+  }
+
+  return {
+    passed: issues.length === 0,
+    issues
+  };
+}
+
+/**
+ * LEAD-TO-PLAN: Check SD JSONB field completeness
+ * Catches: PAT-HF-LEADTOPLAN (SD does not meet completeness standards)
+ */
+function checkLeadToPlanPrereqs(sd) {
+  const issues = [];
+  const sdType = sd.sd_type || 'default';
+  const threshold = SD_TYPE_THRESHOLDS[sdType] || DEFAULT_THRESHOLD;
+  const requiredCount = threshold.requiredFields;
+
+  // Check JSONB field population
+  const populated = JSONB_FIELDS.filter(field => {
+    const val = sd[field];
+    return val && (Array.isArray(val) ? val.length > 0 : Object.keys(val).length > 0);
+  });
+
+  if (populated.length < requiredCount) {
+    const missing = JSONB_FIELDS.filter(field => {
+      const val = sd[field];
+      return !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0);
+    });
+
+    issues.push({
+      code: 'JSONB_FIELDS_INCOMPLETE',
+      message: `SD has ${populated.length}/${requiredCount} required JSONB fields populated (type: ${sdType})`,
+      remediation: `Populate these fields before LEAD-TO-PLAN: ${missing.join(', ')}. ` +
+        `Expected structure: success_criteria=[{criterion,measure}], key_changes=[{change,type}], risks=[{risk,mitigation}]`
+    });
+  }
+
+  // Check description word count
+  const descWords = (sd.description || '').split(/\s+/).filter(w => w.length > 0).length;
+  const minWords = threshold.minDescriptionWords;
+  if (descWords < minWords) {
+    issues.push({
+      code: 'DESCRIPTION_TOO_SHORT',
+      message: `SD description has ${descWords} words (minimum: ${minWords} for ${sdType})`,
+      remediation: `Expand the description field to at least ${minWords} words.`
+    });
+  }
+
+  // Check smoke_test_steps
+  const smokeSteps = sd.smoke_test_steps;
+  if (!smokeSteps || !Array.isArray(smokeSteps) || smokeSteps.length === 0) {
+    issues.push({
+      code: 'SMOKE_TEST_MISSING',
+      message: 'No smoke_test_steps defined',
+      remediation: 'Add smoke_test_steps: [{instruction: "...", expected_outcome: "..."}]'
+    });
+  } else {
+    const validSteps = smokeSteps.filter(s => s.instruction && s.expected_outcome);
+    if (validSteps.length === 0) {
+      issues.push({
+        code: 'SMOKE_TEST_INVALID',
+        message: 'smoke_test_steps exist but none have both instruction and expected_outcome',
+        remediation: 'Each step needs: {instruction: "...", expected_outcome: "..."}'
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * PLAN-TO-EXEC: Check PRD exists + user stories exist
+ * Catches: PAT-HF-PLANTOEXEC (PRD/stories missing)
+ */
+async function checkPlanToExecPrereqs(supabase, sd, sdId) {
+  const issues = [];
+
+  // Check PRD exists and is approved
+  const { data: prd } = await supabase
+    .from('product_requirements_v2')
+    .select('id, status, executive_summary')
+    .eq('sd_id', sdId)
+    .single();
+
+  if (!prd) {
+    issues.push({
+      code: 'PRD_MISSING',
+      message: 'No PRD record found for this SD',
+      remediation: `Create PRD: node scripts/add-prd-to-database.js ${sdId} "Title"`
+    });
+  } else {
+    if (!['approved', 'ready_for_exec', 'in_progress'].includes(prd.status)) {
+      issues.push({
+        code: 'PRD_NOT_APPROVED',
+        message: `PRD status is '${prd.status}', expected: approved/ready_for_exec/in_progress`,
+        remediation: `Update PRD status: UPDATE product_requirements_v2 SET status='approved' WHERE id='${prd.id}'`
+      });
+    }
+
+    if (!prd.executive_summary || prd.executive_summary.length < 50) {
+      issues.push({
+        code: 'PRD_SUMMARY_SHORT',
+        message: `PRD executive_summary is ${(prd.executive_summary || '').length} chars (minimum: 50)`,
+        remediation: 'Add a substantive executive_summary to the PRD (50+ chars)'
+      });
+    }
+  }
+
+  // Check user stories exist
+  const { data: stories, error: storiesErr } = await supabase
+    .from('user_stories')
+    .select('story_key')
+    .eq('sd_id', sdId);
+
+  if (storiesErr || !stories || stories.length === 0) {
+    issues.push({
+      code: 'USER_STORIES_MISSING',
+      message: 'No user stories found for this SD',
+      remediation: `Create user stories linked to ${sdId}. Each story needs: story_key, title, user_role, user_want, user_benefit, acceptance_criteria, implementation_context`
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * LEAD-FINAL-APPROVAL: Check prerequisite handoff chain + retrospective
+ * Catches: PAT-HF-LEADFINALAPPROVAL (missing prerequisites)
+ */
+async function checkLeadFinalApprovalPrereqs(supabase, sdId) {
+  const issues = [];
+
+  // Check PLAN-TO-LEAD handoff exists
+  const { data: planToLead } = await supabase
+    .from('sd_phase_handoffs')
+    .select('id, status')
+    .eq('sd_id', sdId)
+    .eq('to_phase', 'LEAD')
+    .eq('from_phase', 'PLAN')
+    .in('status', ['accepted', 'completed'])
+    .single();
+
+  if (!planToLead) {
+    issues.push({
+      code: 'PLAN_TO_LEAD_MISSING',
+      message: 'No accepted PLAN-TO-LEAD handoff found',
+      remediation: `Run PLAN-TO-LEAD first: node scripts/handoff.js execute PLAN-TO-LEAD ${sdId}`
+    });
+  }
+
+  // Check retrospective exists
+  const { data: retro } = await supabase
+    .from('retrospectives')
+    .select('id')
+    .eq('sd_id', sdId)
+    .single();
+
+  if (!retro) {
+    issues.push({
+      code: 'RETROSPECTIVE_MISSING',
+      message: 'No retrospective found for this SD',
+      remediation: `Create a retrospective before LEAD-FINAL-APPROVAL. This is generated during the /learn step.`
+    });
+  }
+
+  return issues;
+}
+
+export default { runPrerequisitePreflight };

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -201,14 +201,15 @@ async function checkLeadFinalApprovalPrereqs(supabase, sdId) {
   const issues = [];
 
   // Check PLAN-TO-LEAD handoff exists
-  const { data: planToLead } = await supabase
+  const { data: planToLeadRows } = await supabase
     .from('sd_phase_handoffs')
     .select('id, status')
     .eq('sd_id', sdId)
     .eq('to_phase', 'LEAD')
     .eq('from_phase', 'PLAN')
     .in('status', ['accepted', 'completed'])
-    .single();
+    .limit(1);
+  const planToLead = planToLeadRows?.[0] || null;
 
   if (!planToLead) {
     issues.push({
@@ -219,11 +220,12 @@ async function checkLeadFinalApprovalPrereqs(supabase, sdId) {
   }
 
   // Check retrospective exists
-  const { data: retro } = await supabase
+  const { data: retros } = await supabase
     .from('retrospectives')
     .select('id')
     .eq('sd_id', sdId)
-    .single();
+    .limit(1);
+  const retro = retros?.[0] || null;
 
   if (!retro) {
     issues.push({

--- a/templates/pwa/manifest-generator.js
+++ b/templates/pwa/manifest-generator.js
@@ -1,0 +1,58 @@
+/**
+ * PWA Manifest Generator
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Generates a W3C Web App Manifest from venture brand tokens.
+ * Brand tokens come from S11 (visual identity) artifacts.
+ *
+ * @module templates/pwa/manifest-generator
+ */
+
+/**
+ * Generate a valid manifest.json from venture brand tokens.
+ *
+ * @param {Object} brandTokens - S11 brand token data
+ * @param {string} brandTokens.venture_name - Venture display name
+ * @param {string} [brandTokens.short_name] - Short name for home screen
+ * @param {Object} [brandTokens.colors] - Color palette
+ * @param {string} [brandTokens.colors.primary] - Primary brand color
+ * @param {string} [brandTokens.colors.background] - Background color
+ * @param {string} [brandTokens.description] - Venture description
+ * @param {Array}  [brandTokens.icons] - Icon definitions [{src, sizes, type}]
+ * @returns {Object} Valid W3C Web App Manifest object
+ */
+export function generateManifest(brandTokens) {
+  const name = brandTokens.venture_name || brandTokens.name || 'Venture App';
+  const shortName = brandTokens.short_name || name.slice(0, 12);
+  const themeColor = brandTokens.colors?.primary || brandTokens.theme_color || '#000000';
+  const backgroundColor = brandTokens.colors?.background || brandTokens.background_color || '#ffffff';
+  const description = brandTokens.description || `${name} - Progressive Web App`;
+
+  // Default icons if none provided
+  const icons = brandTokens.icons || [
+    { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
+    { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' },
+  ];
+
+  return {
+    name,
+    short_name: shortName,
+    description,
+    start_url: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    theme_color: themeColor,
+    background_color: backgroundColor,
+    icons,
+    categories: ['business'],
+  };
+}
+
+/**
+ * Serialize manifest to JSON string.
+ * @param {Object} manifest - Manifest object from generateManifest
+ * @returns {string} JSON string ready to write to manifest.json
+ */
+export function serializeManifest(manifest) {
+  return JSON.stringify(manifest, null, 2);
+}

--- a/templates/pwa/pwa-injector.js
+++ b/templates/pwa/pwa-injector.js
@@ -1,0 +1,102 @@
+/**
+ * PWA Injector
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Injects PWA artifacts (manifest link, service worker registration,
+ * viewport meta tag, install prompt) into HTML output for ventures
+ * with target_platform including mobile.
+ *
+ * @module templates/pwa/pwa-injector
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { generateManifest, serializeManifest } from './manifest-generator.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Generate all PWA artifacts for a venture.
+ *
+ * @param {Object} options
+ * @param {Object} options.brandTokens - S11 brand token data
+ * @param {string} [options.deployHash] - Deployment hash for cache versioning
+ * @param {number} [options.cacheTtlMs] - Cache TTL in ms (default: 24hr)
+ * @returns {{ manifest: string, serviceWorker: string, headTags: string, bodyScript: string }}
+ */
+export function generatePWAArtifacts(options) {
+  const { brandTokens, deployHash = Date.now().toString(36), cacheTtlMs = 86400000 } = options;
+
+  // 1. Generate manifest.json
+  const manifestObj = generateManifest(brandTokens);
+  const manifest = serializeManifest(manifestObj);
+
+  // 2. Generate service worker with version stamp
+  let serviceWorker;
+  try {
+    serviceWorker = readFileSync(resolve(__dirname, 'service-worker.js'), 'utf-8');
+  } catch {
+    // Fallback minimal service worker
+    serviceWorker = 'self.addEventListener(\'fetch\', () => {});';
+  }
+  serviceWorker = serviceWorker
+    .replace(/__CACHE_VERSION__/g, deployHash)
+    .replace(/__CACHE_TTL_MS__/g, String(cacheTtlMs));
+
+  // 3. Head tags to inject
+  const themeColor = manifestObj.theme_color;
+  const headTags = [
+    '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">',
+    `<meta name="theme-color" content="${themeColor}">`,
+    '<meta name="apple-mobile-web-app-capable" content="yes">',
+    '<meta name="apple-mobile-web-app-status-bar-style" content="default">',
+    '<link rel="manifest" href="/manifest.json">',
+  ].join('\n    ');
+
+  // 4. Service worker registration script (inject before </body>)
+  const bodyScript = `<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js')
+        .then(reg => console.log('[PWA] Service worker registered:', reg.scope))
+        .catch(err => console.warn('[PWA] Service worker registration failed:', err));
+    });
+  }
+  </script>`;
+
+  return { manifest, serviceWorker, headTags, bodyScript };
+}
+
+/**
+ * Inject PWA artifacts into an HTML string.
+ *
+ * @param {string} html - Raw HTML content
+ * @param {Object} pwaArtifacts - Output from generatePWAArtifacts
+ * @returns {string} HTML with PWA artifacts injected
+ */
+export function injectPWAIntoHTML(html, pwaArtifacts) {
+  let result = html;
+
+  // Inject head tags before </head>
+  if (result.includes('</head>')) {
+    result = result.replace('</head>', `    ${pwaArtifacts.headTags}\n  </head>`);
+  }
+
+  // Inject SW registration before </body>
+  if (result.includes('</body>')) {
+    result = result.replace('</body>', `  ${pwaArtifacts.bodyScript}\n  </body>`);
+  }
+
+  return result;
+}
+
+/**
+ * Check if a venture should get PWA artifacts.
+ *
+ * @param {string} targetPlatform - Venture's target_platform value
+ * @returns {boolean} True if PWA artifacts should be generated
+ */
+export function shouldInjectPWA(targetPlatform) {
+  return targetPlatform === 'both' || targetPlatform === 'mobile';
+}

--- a/templates/pwa/service-worker.js
+++ b/templates/pwa/service-worker.js
@@ -1,0 +1,87 @@
+/**
+ * PWA Service Worker Template
+ * SD: SD-DUALPLAT-MOBILE-WEB-ORCH-001-C
+ *
+ * Cache-first strategy with configurable TTL and version-stamped cache keys.
+ * This template is injected into venture builds when target_platform includes mobile.
+ *
+ * Configuration is injected at build time via string replacement:
+ *   __CACHE_VERSION__ → deployment hash
+ *   __CACHE_TTL_MS__  → TTL in milliseconds (default: 86400000 = 24hr)
+ */
+
+const CACHE_NAME = 'venture-cache-v__CACHE_VERSION__';
+const CACHE_TTL_MS = __CACHE_TTL_MS__ || 86400000; // 24 hours default
+
+// Assets to precache on install
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+];
+
+// Install: precache core assets
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+// Activate: clean up old cache versions
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith('venture-cache-') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// Fetch: cache-first with TTL
+self.addEventListener('fetch', (event) => {
+  // Only handle GET requests
+  if (event.request.method !== 'GET') return;
+
+  // Skip non-HTTP(S) requests
+  if (!event.request.url.startsWith('http')) return;
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(event.request);
+
+      if (cached) {
+        // Check TTL via custom header
+        const cachedAt = cached.headers.get('x-cached-at');
+        if (cachedAt && Date.now() - parseInt(cachedAt, 10) < CACHE_TTL_MS) {
+          return cached;
+        }
+      }
+
+      // Fetch from network, cache the response
+      try {
+        const response = await fetch(event.request);
+        if (response.ok) {
+          // Clone and add timestamp header for TTL tracking
+          const headers = new Headers(response.headers);
+          headers.set('x-cached-at', String(Date.now()));
+          const timestamped = new Response(await response.clone().blob(), {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          });
+          cache.put(event.request, timestamped);
+        }
+        return response;
+      } catch {
+        // Network failed — serve stale cache if available
+        if (cached) return cached;
+        return new Response('Offline', { status: 503 });
+      }
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- Add prerequisite preflight checks to `HandoffOrchestrator` that run before full gate validation
- LEAD-TO-PLAN: validates SD JSONB fields, description length, smoke test steps
- PLAN-TO-EXEC: validates PRD exists/approved, user stories exist
- LEAD-FINAL-APPROVAL: validates PLAN-TO-LEAD handoff + retrospective exist
- Resolves 5 patterns (23 total occurrences) of 0% gate scores from missing prerequisites
- Uses `limit(1)` instead of `single()` for queries with potentially multiple matches

## Test plan
- [x] Module loads correctly (ESM import verified)
- [x] LEAD-TO-PLAN preflight passes for complete SD
- [x] PLAN-TO-EXEC preflight passes for SD with PRD + stories
- [x] LEAD-FINAL-APPROVAL preflight correctly fails when prerequisites missing
- [x] Preflight integrated into both execute and precheck flows
- [x] 5 source patterns marked resolved in issue_patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)