### PR TITLE
fix(QF-20260412-732): guard listTools response for wrapper object

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -80,8 +80,10 @@ export async function discoverTools() {
     const sdk = await getSDK();
     const apiKey = getApiKey();
     const client = new sdk.StitchToolClient({ apiKey, timeout: 30_000 });
-    const tools = await client.listTools();
-    const toolNames = (tools || []).map(t => t.name || t).filter(Boolean);
+    const toolsRaw = await client.listTools();
+    // QF-20260412-732: SDK may return {tools:[...]} wrapper, not bare array
+    const tools = Array.isArray(toolsRaw) ? toolsRaw : (toolsRaw?.tools || []);
+    const toolNames = tools.map(t => t.name || t).filter(Boolean);
     _cachedTools = toolNames;
     console.info(`[stitch-client] Available Stitch tools (${toolNames.length}): ${toolNames.join(', ')}`);
     try { await client.close(); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- Stitch SDK `listTools()` returns `{tools:[...]}` wrapper object, not bare array
- Adds `Array.isArray()` check with `.tools` fallback to prevent `.map()` crash on object

## Test plan
- [x] Smoke tests pass (15/15)
- [x] LOC: +4/-2 (within 50 LOC cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)