### PR TITLE
fix(QF-20260412-273): add idempotency guard to Stitch project creation

### DIFF
--- a/lib/eva/bridge/stitch-adapter.js
+++ b/lib/eva/bridge/stitch-adapter.js
@@ -119,6 +119,21 @@ export async function provision(ventureId, stage11Artifacts, stage15Artifacts, o
   }
 
   try {
+    // QF-20260412-273: Idempotency guard — reuse existing project
+    const { data: existing } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .in('artifact_type', ['stitch_curation', 'stitch_project'])
+      .not('artifact_data->>project_id', 'is', null)
+      .limit(1)
+      .maybeSingle();
+
+    if (existing?.artifact_data?.project_id) {
+      logStitchEvent({ event: 'provision', ventureId, stage: 15, status: 'reused_existing' });
+      return { status: 'success', project_id: existing.artifact_data.project_id };
+    }
+
     const client = await getClient();
     const result = await client.createProject({
       name: options.ventureName || 'Venture',
@@ -176,6 +191,21 @@ export async function tasteGateProvision(ventureId, stage11Artifacts, stage15Art
   }
 
   try {
+    // QF-20260412-273: Idempotency guard — reuse existing project
+    const { data: existing } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .in('artifact_type', ['stitch_curation', 'stitch_project'])
+      .not('artifact_data->>project_id', 'is', null)
+      .limit(1)
+      .maybeSingle();
+
+    if (existing?.artifact_data?.project_id) {
+      logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'reused_existing' });
+      return { status: 'success', project_id: existing.artifact_data.project_id };
+    }
+
     const client = await getClient();
     const result = await client.createProject({
       name: options.ventureName || 'Venture',

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -178,6 +178,7 @@ function extractStage15Screens(stage15Artifacts) {
 
 // SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: char count threshold for pre-flight guard
 const PROMPT_CHAR_WARN = parseInt(process.env.STITCH_PROMPT_CHAR_WARN || '4000', 10);
+const PROMPT_CHAR_LIMIT = parseInt(process.env.STITCH_PROMPT_CHAR_LIMIT || '3500', 10);
 
 function buildScreenPrompt(screen, brandTokens, ventureName, designReferenceSection) {
   const parts = [];
@@ -405,13 +406,29 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   console.info(`[stitch-provisioner] Dual-platform: ${curationPrompts.length} prompts (${includeMobile ? 'mobile' : ''}${includeMobile && includeDesktop ? '+' : ''}${includeDesktop ? 'desktop' : ''})`);
 
   // Step 5: Create project via stitch-client (API call — works reliably)
+  // QF-20260412-273: Idempotency guard — reuse existing project if already created
   const client = await getStitchClient();
   const ventureName = options.ventureName || 'Venture';
 
-  const project = await client.createProject({
-    name: ventureName,
-    ventureId,
-  });
+  const { data: existingArtifact } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', ['stitch_curation', 'stitch_project'])
+    .not('artifact_data->>project_id', 'is', null)
+    .limit(1)
+    .maybeSingle();
+
+  let project;
+  if (existingArtifact?.artifact_data?.project_id) {
+    console.info(`[stitch-provisioner] Reusing existing project ${existingArtifact.artifact_data.project_id} for venture ${ventureId}`);
+    project = { project_id: existingArtifact.artifact_data.project_id };
+  } else {
+    project = await client.createProject({
+      name: ventureName,
+      ventureId,
+    });
+  }
 
   // Step 5.5: Create DesignSystem from brand tokens (SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-E)
   // Must happen BEFORE generateScreens so screens inherit the theme.


### PR DESCRIPTION
## Summary
- Adds idempotency check to all 3 `createProject()` call sites (stitch-provisioner.js, stitch-adapter.js x2)
- Queries `venture_artifacts` for existing `stitch_curation`/`stitch_project` before creating
- Reuses existing `project_id` if found, preventing duplicate Stitch projects per venture

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)