### PR TITLE
fix(QF-20260412-625): AGNOSTIC device type fix in Stitch desktop pass

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -396,7 +396,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     for (const screen of screens) {
       curationPrompts.push({
         text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
-        deviceType: inferDeviceType(screen) === 'MOBILE' ? 'DESKTOP' : (inferDeviceType(screen) || 'DESKTOP'),
+        deviceType: 'DESKTOP', // QF-20260412-625: always DESKTOP in desktop pass (was leaking AGNOSTIC)
         _platform: 'desktop',
         _screenName: screen.name || screen.title || 'Unknown',
       });


### PR DESCRIPTION
## Summary
- Hardcodes DESKTOP device type in the desktop pass loop
- Prevents AGNOSTIC from leaking through inferDeviceType() fallback

## Test plan
- [ ] Verify all desktop screens use DESKTOP device type in next pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)