### PR TITLE
fix(QF-20260412-498): normalize brandTokens.personality to string

### DIFF
--- a/lib/eva/bridge/stitch-design-system.js
+++ b/lib/eva/bridge/stitch-design-system.js
@@ -126,8 +126,8 @@ function extractFonts(brandTokens) {
 }
 
 function inferColorMode(brandTokens) {
-  const raw = brandTokens.personality || ''; // QF-20260412-498: guard against object
-  const personality = (typeof raw === 'string' ? raw : String(raw)).toLowerCase();
+  const raw = brandTokens.personality || '';
+  const personality = (typeof raw === 'string' ? raw : '').toLowerCase();
   if (personality.includes('dark') || personality.includes('moody') || personality.includes('night')) {
     return 'dark';
   }
@@ -135,8 +135,8 @@ function inferColorMode(brandTokens) {
 }
 
 function inferRoundness(brandTokens) {
-  const raw = brandTokens.personality || ''; // QF-20260412-498: guard against object
-  const personality = (typeof raw === 'string' ? raw : String(raw)).toLowerCase();
+  const raw = brandTokens.personality || '';
+  const personality = (typeof raw === 'string' ? raw : '').toLowerCase();
   if (personality.includes('sharp') || personality.includes('corporate') || personality.includes('formal')) {
     return 'none';
   }

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -132,7 +132,7 @@ function extractStage11Tokens(stage11Artifacts) {
   if (rawPersonality) {
     tokens.personality = typeof rawPersonality === 'string'
       ? rawPersonality
-      : (rawPersonality.summary || rawPersonality.description || JSON.stringify(rawPersonality));
+      : (rawPersonality.summary || rawPersonality.description || rawPersonality.personality || rawPersonality.tone || JSON.stringify(rawPersonality));
   }
 
   return tokens;
@@ -373,7 +373,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
           ventureId,
           archetype: options.archetype,
           references: refs,
-          personality: brandTokens.personality || 'balanced',
+          personality: typeof brandTokens.personality === 'string' ? brandTokens.personality : 'balanced',
           count: 3,
         });
         designRefSection = generateDesignReferenceSection(primary);


### PR DESCRIPTION
## Summary
- Normalizes personality to string at extraction boundary in extractStage11Tokens
- Adds typeof guards in inferColorMode/inferRoundness (stitch-design-system.js)
- Fixes selectPatterns call to use typeof check with fallback

## Test plan
- [ ] Verify no `.toLowerCase is not a function` errors during S15 provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)