### PR TITLE
fix(QF-20260412-604): distinguish SDK errors from transport fire-and-forget

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -551,14 +551,15 @@ export async function generateScreens(projectId, prompts, ventureId) {
           console.info(`[stitch-client] ${label} fired (socket dropped — server processing)`);
           results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType });
         } else {
+          // QF-20260412-604: SDK errors are permanent failures, not fire-and-forget
           console.error(`[stitch-client] ${label} error: ${msg.slice(0, 120)}`);
-          results.push({ prompt: promptText.slice(0, 60), status: 'fired', error: msg, deviceType });
+          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType });
         }
       }
       try { await client.close(); } catch { /* ignore */ }
     } catch (outerErr) {
       console.error(`[stitch-client] ${label} unexpected: ${outerErr.message}`);
-      results.push({ prompt: promptText.slice(0, 60), status: 'fired', error: outerErr.message, deviceType });
+      results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType });
     }
 
     // Delay between screens to avoid Google throttling


### PR DESCRIPTION
## Summary
- Changes status from 'fired' to 'error' for non-transport SDK exceptions
- Prevents masking permanent generation failures as server-side successes

## Test plan
- [ ] Verify failed screens show status:'error' not status:'fired' in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)