### PR TITLE
fix(stitch): progressive delay for screen generation

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -517,8 +517,10 @@ export async function generateScreens(projectId, prompts, ventureId) {
   //   2. Close the client immediately (transport is tainted after any error)
   //   3. Mark as "fired" — the server completes generation regardless
   //   4. No polling (listScreens is broken until browser activation)
-  //   5. 3s delay between screens to avoid Google throttling (~3 req/min)
-  const INTER_SCREEN_DELAY_MS = 3_000;
+  //   5. Progressive delay: start slow (15s), ramp down to 5s as API warms up
+  const INITIAL_DELAY_MS = parseInt(process.env.STITCH_INITIAL_DELAY_MS || '15000', 10);
+  const MIN_DELAY_MS = parseInt(process.env.STITCH_MIN_DELAY_MS || '5000', 10);
+  const WARMUP_SCREENS = 3; // first N screens use initial delay
 
   const results = [];
   const apiKey = getApiKey();
@@ -564,9 +566,11 @@ export async function generateScreens(projectId, prompts, ventureId) {
       results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType });
     }
 
-    // Delay between screens to avoid Google throttling
+    // Progressive delay: slow start, ramp down after warmup
     if (i < prompts.length - 1) {
-      await new Promise(r => setTimeout(r, INTER_SCREEN_DELAY_MS));
+      const delay = i < WARMUP_SCREENS ? INITIAL_DELAY_MS : MIN_DELAY_MS;
+      console.info(`[stitch-client] Waiting ${delay / 1000}s before next screen (${i < WARMUP_SCREENS ? 'warmup' : 'steady'})`);
+      await new Promise(r => setTimeout(r, delay));
     }
   }
 


### PR DESCRIPTION
## Summary
- Changed from fixed 3s delay to progressive warmup pattern
- First 3 screens: 15s delay (warmup), remaining screens: 5s (steady state)
- Addresses "Incomplete API response" errors from rapid-fire Stitch calls
- Configurable via `STITCH_INITIAL_DELAY_MS` and `STITCH_MIN_DELAY_MS`

## Context
During GitLog venture monitoring, screens 2-4 still failed with "Incomplete API response" even after prompt trimming (QF-20260412-929). The issue is API rate sensitivity, not prompt length.

## Test plan
- [ ] Run full S15 pipeline and verify improved screen generation success rate
- [ ] Check logs for warmup vs steady delay messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)