### PR TITLE
fix(stitch): increase steady-state delay from 5s to 12s

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -517,9 +517,9 @@ export async function generateScreens(projectId, prompts, ventureId) {
   //   2. Close the client immediately (transport is tainted after any error)
   //   3. Mark as "fired" — the server completes generation regardless
   //   4. No polling (listScreens is broken until browser activation)
-  //   5. Progressive delay: start slow (15s), ramp down to 5s as API warms up
+  //   5. Progressive delay: start slow (15s), ramp down to 12s as API warms up
   const INITIAL_DELAY_MS = parseInt(process.env.STITCH_INITIAL_DELAY_MS || '15000', 10);
-  const MIN_DELAY_MS = parseInt(process.env.STITCH_MIN_DELAY_MS || '5000', 10);
+  const MIN_DELAY_MS = parseInt(process.env.STITCH_MIN_DELAY_MS || '12000', 10);
   const WARMUP_SCREENS = 3; // first N screens use initial delay
 
   const results = [];


### PR DESCRIPTION
## Summary
- Warmup screens (15s delay) all succeeded in Testimonial Trust-Engine run
- Screen 4 at 5s steady delay still failed with "Incomplete API response"
- Bumping steady state to 12s to match API rate sensitivity

## Test plan
- [ ] Run another S15 pipeline and compare success rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)