### PR TITLE
fix(stitch): uniform 15s delay between all screen generation calls

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -517,10 +517,8 @@ export async function generateScreens(projectId, prompts, ventureId) {
   //   2. Close the client immediately (transport is tainted after any error)
   //   3. Mark as "fired" — the server completes generation regardless
   //   4. No polling (listScreens is broken until browser activation)
-  //   5. Progressive delay: start slow (15s), ramp down to 12s as API warms up
-  const INITIAL_DELAY_MS = parseInt(process.env.STITCH_INITIAL_DELAY_MS || '15000', 10);
-  const MIN_DELAY_MS = parseInt(process.env.STITCH_MIN_DELAY_MS || '12000', 10);
-  const WARMUP_SCREENS = 3; // first N screens use initial delay
+  //   5. Uniform delay between all screens (default 15s)
+  const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '15000', 10);
 
   const results = [];
   const apiKey = getApiKey();
@@ -566,11 +564,10 @@ export async function generateScreens(projectId, prompts, ventureId) {
       results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType });
     }
 
-    // Progressive delay: slow start, ramp down after warmup
+    // Uniform delay between screens
     if (i < prompts.length - 1) {
-      const delay = i < WARMUP_SCREENS ? INITIAL_DELAY_MS : MIN_DELAY_MS;
-      console.info(`[stitch-client] Waiting ${delay / 1000}s before next screen (${i < WARMUP_SCREENS ? 'warmup' : 'steady'})`);
-      await new Promise(r => setTimeout(r, delay));
+      console.info(`[stitch-client] Waiting ${SCREEN_DELAY_MS / 1000}s before next screen`);
+      await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
     }
   }
 


### PR DESCRIPTION
## Summary
- Simplified to uniform 15s delay between ALL screen generation calls
- Establishes working baseline before optimizing down
- Configurable via `STITCH_SCREEN_DELAY_MS` env var

## Test plan
- [ ] Run S15 pipeline — verify all screens generate without "Incomplete API response"
- [ ] If successful, can reduce delay incrementally in follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)