### PR TITLE
fix(stitch): retry screen generation on Incomplete API response

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -534,34 +534,47 @@ export async function generateScreens(projectId, prompts, ventureId) {
       console.info(`[stitch-client] ${label} deviceType: ${deviceType}`);
     }
 
-    try {
-      const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
-      const project = client.project(projectId);
+    const MAX_RETRIES = parseInt(process.env.STITCH_MAX_RETRIES || '2', 10);
+    let attempt = 0;
+    let succeeded = false;
+
+    while (attempt < MAX_RETRIES && !succeeded) {
+      attempt++;
+      const attemptLabel = attempt > 1 ? `${label} retry ${attempt}/${MAX_RETRIES}` : label;
+
       try {
-        // Pass deviceType as second arg if available (Stitch SDK supports MOBILE/DESKTOP/TABLET/AGNOSTIC)
-        const screen = deviceType
-          ? await project.generate(promptText, deviceType)
-          : await project.generate(promptText);
-        const screenId = screen?.id || screen?.screen_id;
-        console.info(`[stitch-client] ${label} returned directly: ${screenId}`);
-        results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType });
-      } catch (err) {
-        const msg = err.message || '';
-        const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
-        if (isTransport) {
-          // Socket drop = normal. Server completes generation regardless.
-          console.info(`[stitch-client] ${label} fired (socket dropped — server processing)`);
-          results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType });
-        } else {
-          // QF-20260412-604: SDK errors are permanent failures, not fire-and-forget
-          console.error(`[stitch-client] ${label} error: ${msg.slice(0, 120)}`);
-          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType });
+        const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
+        const project = client.project(projectId);
+        try {
+          const screen = deviceType
+            ? await project.generate(promptText, deviceType)
+            : await project.generate(promptText);
+          const screenId = screen?.id || screen?.screen_id;
+          console.info(`[stitch-client] ${attemptLabel} returned directly: ${screenId}`);
+          results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType, attempt });
+          succeeded = true;
+        } catch (err) {
+          const msg = err.message || '';
+          const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
+          if (isTransport) {
+            console.info(`[stitch-client] ${attemptLabel} fired (socket dropped — server processing)`);
+            results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt });
+            succeeded = true; // socket drop = server processing, count as success
+          } else if (attempt < MAX_RETRIES) {
+            console.warn(`[stitch-client] ${attemptLabel} failed: ${msg.slice(0, 120)} — retrying in ${SCREEN_DELAY_MS / 1000}s`);
+            await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
+          } else {
+            console.error(`[stitch-client] ${attemptLabel} failed after ${MAX_RETRIES} attempts: ${msg.slice(0, 120)}`);
+            results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
+          }
+        }
+        try { await client.close(); } catch { /* ignore */ }
+      } catch (outerErr) {
+        if (attempt >= MAX_RETRIES) {
+          console.error(`[stitch-client] ${attemptLabel} unexpected after ${MAX_RETRIES} attempts: ${outerErr.message}`);
+          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType, attempt });
         }
       }
-      try { await client.close(); } catch { /* ignore */ }
-    } catch (outerErr) {
-      console.error(`[stitch-client] ${label} unexpected: ${outerErr.message}`);
-      results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType });
     }
 
     // Uniform delay between screens


### PR DESCRIPTION
## Summary
- Adds retry loop (default 2 attempts) for Stitch screen generation
- Same prompt often succeeds on second attempt — API flakiness, not prompt issue
- Socket drops still count as success (fire-and-forget pattern)
- Configurable via `STITCH_MAX_RETRIES` env var

## Context
Testing showed ~50% failure rate regardless of delay (3s, 5s, 12s, 15s).
Failures are SDK projection path errors, not timing-related.

## Test plan
- [ ] Run S15 pipeline and compare success rate vs previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)