### PR TITLE
fix(stitch): defer project creation from taste gate to S15

### DIFF
--- a/lib/eva/bridge/stitch-adapter.js
+++ b/lib/eva/bridge/stitch-adapter.js
@@ -194,57 +194,14 @@ export async function exportScreens(ventureId, projectId, options = {}) {
 }
 
 /**
- * Provision triggered by taste gate ESCALATE verdict.
- * Fallback: logs warning and returns no-op.
+ * Taste gate ESCALATE verdict handler.
+ * No-op: project creation deferred to S15 provision() where wireframes and
+ * brand tokens are available. The taste gate ESCALATE is a design-quality
+ * signal, not a provisioning trigger.
  */
 export async function tasteGateProvision(ventureId, stage11Artifacts, stage15Artifacts, options = {}) {
-  const enabled = await isStitchEnabled();
-  if (!enabled) {
-    logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'skipped_disabled' });
-    return { status: 'unavailable', reason: 'stitch_disabled' };
-  }
-
-  // QF-20260412-273: Idempotency guard — check for existing project
-  const { data: existingArt } = await supabase
-    .from('venture_artifacts')
-    .select('data')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_curation')
-    .eq('is_current', true)
-    .maybeSingle();
-
-  if (existingArt?.data?.project_id) {
-    logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'already_provisioned' });
-    return { status: 'already_provisioned', project_id: existingArt.data.project_id, url: existingArt.data.url };
-  }
-
-  try {
-    // QF-20260412-273: Idempotency guard — reuse existing project
-    const { data: existing } = await supabase
-      .from('venture_artifacts')
-      .select('artifact_data')
-      .eq('venture_id', ventureId)
-      .in('artifact_type', ['stitch_curation', 'stitch_project'])
-      .not('artifact_data->>project_id', 'is', null)
-      .limit(1)
-      .maybeSingle();
-
-    if (existing?.artifact_data?.project_id) {
-      logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'reused_existing' });
-      return { status: 'success', project_id: existing.artifact_data.project_id };
-    }
-
-    const client = await getClient();
-    const result = await client.createProject({
-      name: options.ventureName || 'Venture',
-      ventureId,
-    });
-    logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'success' });
-    return { status: 'success', ...result };
-  } catch (err) {
-    logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'error', error: err });
-    return { status: 'unavailable', reason: 'taste_gate_provision_failed', error: err.message };
-  }
+  logStitchEvent({ event: 'taste_gate_provision', ventureId, stage: options.stage || null, status: 'deferred_to_s15' });
+  return { status: 'deferred', reason: 'provision_deferred_to_s15' };
 }
 
 /**

--- a/tests/unit/eva/bridge/stitch-adapter.test.js
+++ b/tests/unit/eva/bridge/stitch-adapter.test.js
@@ -122,17 +122,18 @@ describe('stitch-adapter', () => {
   });
 
   describe('tasteGateProvision', () => {
-    it('returns unavailable when stitch is disabled', async () => {
-      setStitchEnabled(false);
-      const result = await tasteGateProvision('v1', {}, {});
-      expect(result.status).toBe('unavailable');
+    it('returns deferred without creating a project (provisioning deferred to S15)', async () => {
+      const result = await tasteGateProvision('v1', {}, {}, { stage: 10 });
+      expect(result.status).toBe('deferred');
+      expect(result.reason).toBe('provision_deferred_to_s15');
+      expect(mockClient.createProject).not.toHaveBeenCalled();
     });
 
-    it('provisions successfully when enabled', async () => {
+    it('returns deferred regardless of stitch enabled state', async () => {
       setStitchEnabled(true);
-      mockClient.createProject.mockResolvedValue({ project_id: 'p2', url: 'http://stitch/p2' });
-      const result = await tasteGateProvision('v1', {}, {}, { ventureName: 'V', stage: 12 });
-      expect(result.status).toBe('success');
+      const result = await tasteGateProvision('v1', {}, {}, { ventureName: 'V', stage: 13 });
+      expect(result.status).toBe('deferred');
+      expect(mockClient.createProject).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- **Remove `createProject()` from `tasteGateProvision()`** — S10/S13 taste gate ESCALATE was creating Stitch projects prematurely before wireframes/brand tokens existed, causing triple project creation per venture
- **`tasteGateProvision()` is now a no-op** that logs `deferred_to_s15` and returns `{ status: 'deferred' }` — project creation only happens at S15 `provision()` where full design context is available
- Updated tests to verify no project creation occurs on taste gate ESCALATE

## Test plan
- [x] `tasteGateProvision` tests pass (returns deferred, no createProject call)
- [x] Smoke tests pass (15/15)
- [ ] Verify ventures no longer get 3x Stitch projects (S10+S13+S15 → just S15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)