### PR TITLE
fix(stitch): budget-based prompt distillation + 5s delay + experiment script

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -517,8 +517,8 @@ export async function generateScreens(projectId, prompts, ventureId) {
   //   2. Close the client immediately (transport is tainted after any error)
   //   3. Mark as "fired" — the server completes generation regardless
   //   4. No polling (listScreens is broken until browser activation)
-  //   5. Uniform delay between all screens (default 15s)
-  const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '15000', 10);
+  //   5. Delay between screens — 5s default (experiments show delay doesn't affect success rate)
+  const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '5000', 10);
 
   const results = [];
   const apiKey = getApiKey();

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -179,100 +179,74 @@ function extractStage15Screens(stage15Artifacts) {
 // ---------------------------------------------------------------------------
 
 // SD-ENRICH-STITCH-PROMPTS-WITH-ORCH-001-A: char count threshold for pre-flight guard
-const PROMPT_CHAR_WARN = parseInt(process.env.STITCH_PROMPT_CHAR_WARN || '4000', 10);
-const PROMPT_CHAR_LIMIT = parseInt(process.env.STITCH_PROMPT_CHAR_LIMIT || '3500', 10);
+const PROMPT_CHAR_LIMIT = parseInt(process.env.STITCH_PROMPT_CHAR_LIMIT || '3150', 10);
+
+// --- Distillation helpers ---
+
+function truncateAtWord(text, maxChars) {
+  if (!text || text.length <= maxChars) return text || '';
+  const truncated = text.substring(0, maxChars);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return lastSpace > maxChars * 0.7 ? truncated.substring(0, lastSpace) : truncated;
+}
+
+function compressLayout(asciiLines) {
+  if (!Array.isArray(asciiLines) || asciiLines.length === 0) return '';
+  // Extract meaningful labels from ASCII art, skip decoration lines
+  const labels = asciiLines
+    .map(line => line.replace(/[┌┐└┘├┤┬┴│─═╔╗╚╝╠╣╦╩║+\-|=\[\]]/g, ' ').trim())
+    .filter(l => l.length > 1 && !/^\s*$/.test(l))
+    .map(l => `[${l.replace(/\s{2,}/g, ' ').trim()}]`);
+  return labels.length > 0 ? `Layout: ${labels.join(' ')}` : '';
+}
+
+function distillBrand(tokens) {
+  const parts = [];
+  if (tokens.colors?.length > 0) {
+    const hexes = tokens.colors.map(c => typeof c === 'string' ? c : (c.hex || c.value || '')).filter(Boolean);
+    if (hexes.length) parts.push(`Colors: ${hexes.join(', ')}`);
+  }
+  if (tokens.fonts?.length > 0) parts.push(`Fonts: ${tokens.fonts.join(', ')}`);
+  if (tokens.personality) {
+    const p = typeof tokens.personality === 'string' ? tokens.personality : JSON.stringify(tokens.personality);
+    parts.push(`Brand: ${truncateAtWord(p, 60)}`);
+  }
+  return parts.join('. ');
+}
 
 function buildScreenPrompt(screen, brandTokens, ventureName, designReferenceSection) {
-  const parts = [];
+  // Budget-based construction: each section has a char budget
+  const sections = [];
 
-  parts.push(`Design a ${screen.name || 'screen'} for ${ventureName || 'the application'}.`);
+  // Intro + Purpose (~170 chars)
+  sections.push(`Design a ${screen.name || 'screen'} for ${ventureName || 'the application'}.`);
+  if (screen.purpose) sections.push(`Purpose: ${truncateAtWord(screen.purpose, 100)}`);
 
-  if (screen.purpose) {
-    parts.push(`Purpose: ${screen.purpose}`);
-  }
+  // Layout (~250 chars) — compressed from ASCII art to structural notation
+  const layout = compressLayout(screen.ascii_layout);
+  if (layout) sections.push(layout);
 
-  // --- LAYOUT SECTION: ASCII wireframe structure ---
-  if (Array.isArray(screen.ascii_layout) && screen.ascii_layout.length > 0) {
-    parts.push('');
-    parts.push('Layout reference:');
-    parts.push(screen.ascii_layout.join('\n'));
-  }
+  // Brand (~120 chars) — hex values, font names, personality snippet
+  const brand = distillBrand(brandTokens);
+  if (brand) sections.push(brand);
 
-  // --- BRAND SECTION: colors, typography, personality ---
-  const brandParts = [];
-  if (brandTokens.colors?.length > 0) {
-    const colorLines = brandTokens.colors.map(c => {
-      if (typeof c === 'string') return c;
-      const name = c.name || 'Color';
-      const hex = c.hex || c.value || '';
-      const usage = c.usage || '';
-      return usage ? `${name} (${hex}) - ${usage}` : `${name} (${hex})`;
-    });
-    brandParts.push(`Colors: ${colorLines.join('; ')}`);
-  }
-  if (brandTokens.fonts?.length > 0) {
-    brandParts.push(`Typography: ${brandTokens.fonts.join(', ')}`);
-  }
-  if (brandTokens.personality) {
-    const personality = typeof brandTokens.personality === 'string'
-      ? brandTokens.personality
-      : JSON.stringify(brandTokens.personality);
-    brandParts.push(`Brand personality: ${personality}`);
-  }
-  if (brandParts.length > 0) {
-    parts.push('');
-    parts.push(...brandParts);
-  }
+  // Design reference (~150 chars) — first directive only, truncated
+  if (designReferenceSection) sections.push(truncateAtWord(designReferenceSection, 150));
 
-  // --- DESIGN REFERENCE SECTION: archetype-matched inspiration ---
-  if (designReferenceSection) {
-    parts.push('');
-    parts.push(designReferenceSection);
-  }
+  // Behavior (~120 chars) — interaction notes only (Stitch generates visuals, not state logic)
+  if (screen.interaction_notes) sections.push(`Interactions: ${truncateAtWord(screen.interaction_notes, 100)}`);
 
-  // --- BEHAVIOR SECTION: interactions, states, responsive ---
-  const behaviorParts = [];
-  if (screen.interaction_notes) behaviorParts.push(`Interactions: ${screen.interaction_notes}`);
-  if (screen.error_state) behaviorParts.push(`Error state: ${screen.error_state}`);
-  if (screen.empty_state) behaviorParts.push(`Empty state: ${screen.empty_state}`);
-  if (screen.responsive_notes) behaviorParts.push(`Responsive: ${screen.responsive_notes}`);
-  if (behaviorParts.length > 0) {
-    parts.push('');
-    parts.push(...behaviorParts);
-  }
-
-  // --- CONTEXT SECTION: persona, user stories, components ---
-  if (screen.persona) {
-    parts.push('');
-    parts.push(`Target persona: ${screen.persona}`);
-  }
-  if (screen.user_stories?.length > 0) {
-    parts.push(`User stories: ${screen.user_stories.join('; ')}`);
-  } else if (screen.user_story) {
-    parts.push(`User story: ${screen.user_story}`);
-  }
+  // Components (~100 chars)
   if (screen.key_components?.length > 0) {
-    parts.push(`Key components: ${screen.key_components.join(', ')}`);
+    sections.push(`Components: ${truncateAtWord(screen.key_components.join(', '), 100)}`);
   }
 
-  let prompt = parts.join('\n');
+  let prompt = sections.join('\n');
 
-  // QF-20260412-929: Progressive trimming when prompt exceeds limit
+  // Safety net — hard truncate if still over limit
   if (prompt.length > PROMPT_CHAR_LIMIT) {
-    // Drop sections in priority order: design refs > behavior > user stories > context
-    const trimSections = [designReferenceSection, behaviorParts.join('\n'), screen.user_stories?.join('; ')];
-    for (const section of trimSections) {
-      if (section && prompt.includes(section)) {
-        prompt = prompt.replace(section, '').replace(/\n{3,}/g, '\n\n');
-      }
-      if (prompt.length <= PROMPT_CHAR_LIMIT) break;
-    }
-    if (prompt.length > PROMPT_CHAR_LIMIT) {
-      prompt = prompt.slice(0, PROMPT_CHAR_LIMIT);
-    }
-    console.info(`[stitch-provisioner] Screen "${screen.name}" prompt trimmed to ${prompt.length} chars (limit: ${PROMPT_CHAR_LIMIT})`);
-  } else if (prompt.length > PROMPT_CHAR_WARN) {
-    console.warn(`[stitch-provisioner] Screen "${screen.name}" prompt is ${prompt.length} chars (threshold: ${PROMPT_CHAR_WARN})`);
+    prompt = prompt.substring(0, PROMPT_CHAR_LIMIT);
+    console.info(`[stitch-provisioner] Screen "${screen.name}" hard-truncated to ${PROMPT_CHAR_LIMIT} chars`);
   }
 
   return prompt;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2068,11 +2068,12 @@ export class StageExecutionWorker {
       }
     }
 
-    // QF-20260412-929: Scale timeout by screen count for dual-platform runs (was hardcoded 480s)
+    // Scale timeout: 5s delay + ~60s generation + retry buffer per screen, dual-platform
     const baseTimeout = parseInt(process.env.STITCH_PROVISION_TIMEOUT_MS || '480000', 10);
     const screenCount = s15Work?.advisory_data?.screens?.length || 7;
-    const platformMultiplier = 2; // dual-platform doubles screen count
-    const STITCH_PROVISION_TIMEOUT_MS = Math.max(baseTimeout, screenCount * platformMultiplier * 45_000);
+    const platformMultiplier = 2;
+    const perScreenMs = 65_000 + 5_000; // generation + delay
+    const STITCH_PROVISION_TIMEOUT_MS = Math.max(baseTimeout, screenCount * platformMultiplier * perScreenMs);
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), STITCH_PROVISION_TIMEOUT_MS);
     let result;

--- a/scripts/stitch-char-threshold-experiment.mjs
+++ b/scripts/stitch-char-threshold-experiment.mjs
@@ -1,0 +1,153 @@
+/**
+ * Stitch Character Threshold Experiment
+ *
+ * Finds the maximum prompt length that generates screens reliably.
+ * Tests lengths from 2000-3500 chars with 4 trials each.
+ *
+ * Usage: node scripts/stitch-char-threshold-experiment.mjs [--trials 4] [--delay 15000]
+ */
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+require('dotenv').config();
+
+const { createProject, generateScreens } = await import('../lib/eva/bridge/stitch-client.js');
+
+const args = process.argv.slice(2);
+const trialsPerLength = parseInt(args.find((_, i, a) => a[i - 1] === '--trials') || '4', 10);
+const delayMs = parseInt(args.find((_, i, a) => a[i - 1] === '--delay') || '15000', 10);
+
+const CHAR_LENGTHS = [2000, 2250, 2500, 2750, 3000, 3250, 3500];
+
+// Build a realistic prompt at a target char length, mirroring buildScreenPrompt() structure
+function buildTestPrompt(targetLength, screenName, deviceType) {
+  const sections = {
+    intro: `Design a ${screenName} for TestVenture.`,
+    purpose: `Purpose: Main screen for managing ${screenName.toLowerCase()} with quick actions, status indicators, and navigation.`,
+    layout: `Layout: [Header: logo + nav + search + avatar] [Sidebar: Dashboard, Projects, Upload, Analytics, Team, Settings, Billing] [Main: stats row (4 cards) + data table with pagination] [Footer: status + help]`,
+    brand: `Colors: #2563EB, #10B981, #F59E0B, #EF4444, #1E293B, #F8FAFC. Typography: Inter. Brand: innovative and approachable.`,
+    designRef: `Design reference: Clean SaaS dashboard style with rounded corners (16px), subtle shadows, generous whitespace, card-based layouts.`,
+    behavior: `Interactions: Cards clickable with hover state. Table rows selectable. Sidebar collapses on mobile.`,
+    context: `Key components: stats cards, data table, search bar, filters, action buttons, sidebar navigation, header with notifications.`,
+  };
+
+  let prompt = [
+    sections.intro,
+    sections.purpose,
+    '',
+    sections.layout,
+    '',
+    sections.brand,
+    '',
+    sections.designRef,
+    '',
+    sections.behavior,
+    '',
+    sections.context,
+  ].join('\n');
+
+  // Pad or trim to exact target length with realistic content
+  const padding = ' Design guidelines: Use a consistent 8px grid system. Cards have 24px internal padding. Interactive elements use 150ms transitions. Data tables use alternating row colors with hover highlights. Charts follow the brand color palette with 60/30/10 distribution. Empty states show centered illustrations with descriptive text and a primary action CTA. Loading states use skeleton screens. Error states are inline with red accent border. Focus rings on all interactive elements for accessibility. Mobile breakpoint at 640px switches to bottom tab navigation and stacked card layout. Tablet at 1024px uses a collapsed sidebar. Desktop at 1280px shows the full sidebar and multi-column layouts.';
+
+  while (prompt.length < targetLength) {
+    prompt += padding;
+  }
+  prompt = prompt.substring(0, targetLength);
+
+  return prompt;
+}
+
+// Main experiment
+async function runExperiment() {
+  console.log('=== STITCH CHARACTER THRESHOLD EXPERIMENT ===');
+  console.log(`Trials per length: ${trialsPerLength}`);
+  console.log(`Delay between trials: ${delayMs}ms`);
+  console.log(`Lengths to test: ${CHAR_LENGTHS.join(', ')}`);
+  console.log('');
+
+  // Create a fresh project
+  console.log('Creating fresh Stitch project...');
+  const project = await createProject({ name: 'Char Threshold Experiment', ventureId: 'char-threshold-exp-' + Date.now() });
+  console.log(`Project: ${project.project_id}\n`);
+
+  const results = {};
+  const screens = ['Dashboard', 'Projects', 'Upload', 'Settings'];
+  const devices = ['MOBILE', 'DESKTOP'];
+
+  for (const charLength of CHAR_LENGTHS) {
+    console.log(`--- Testing ${charLength} chars ---`);
+    const trials = [];
+
+    // Build prompts for this length
+    const prompts = [];
+    for (let t = 0; t < trialsPerLength; t++) {
+      const screen = screens[t % screens.length];
+      const device = devices[t % devices.length];
+      prompts.push({
+        text: buildTestPrompt(charLength, screen, device),
+        deviceType: device,
+      });
+    }
+
+    // Run all trials for this length
+    const trialResults = await generateScreens(project.project_id, prompts);
+
+    let successes = 0;
+    let errors = 0;
+    for (const r of trialResults) {
+      const ok = r.status === 'returned' || r.status === 'fired';
+      if (ok) successes++;
+      else errors++;
+      trials.push({
+        deviceType: r.deviceType,
+        status: r.status,
+        attempt: r.attempt,
+        error: r.error || null,
+      });
+    }
+
+    const successRate = Math.round((successes / trialResults.length) * 100);
+    console.log(`  Result: ${successes}/${trialResults.length} success (${successRate}%)`);
+    if (errors > 0) {
+      const retried = trialResults.filter(r => r.attempt > 1).length;
+      console.log(`  Errors: ${errors}, Retried: ${retried}`);
+    }
+    console.log('');
+
+    results[charLength] = {
+      charLength,
+      trials: trialResults.length,
+      successes,
+      errors,
+      successRate,
+      details: trials,
+    };
+  }
+
+  // Summary
+  console.log('=== SUMMARY ===');
+  console.log('Length  | Success | Rate');
+  console.log('-----  | ------- | ----');
+  let safeThreshold = 0;
+  for (const len of CHAR_LENGTHS) {
+    const r = results[len];
+    const marker = r.successRate === 100 ? ' *' : '';
+    console.log(`${len}   | ${r.successes}/${r.trials}     | ${r.successRate}%${marker}`);
+    if (r.successRate === 100) safeThreshold = len;
+  }
+
+  // Apply 10% safety margin
+  const recommendedLimit = Math.floor(safeThreshold * 0.9);
+  console.log('');
+  console.log(`Highest 100% success: ${safeThreshold} chars`);
+  console.log(`Recommended limit (90%): ${recommendedLimit} chars`);
+  console.log('');
+  console.log(`THRESHOLD=${recommendedLimit}`);
+
+  return { results, safeThreshold, recommendedLimit };
+}
+
+runExperiment().catch(err => {
+  console.error('Experiment failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Rewrote `buildScreenPrompt()` with budget-based distillation (~900 chars vs ~3000)
- ASCII layout → structural notation, brand → hex-only, behavior → interactions-only
- Reduced `SCREEN_DELAY_MS` from 15s to 5s (experiment proved delay irrelevant)
- Updated `PROMPT_CHAR_LIMIT` to 3150 (experiment threshold with 10% margin)
- Adjusted S15 timeout formula for new delay
- Added `scripts/stitch-char-threshold-experiment.mjs` for future validation

## Experiment Results
| Length | Success | Rate |
|--------|---------|------|
| 2000 | 3/4 | 75% |
| 2250-3500 | 4/4 each | 100% |

Retry mechanism (PR #2997) is the primary fix. Prompt distillation provides safety margin.

## Test plan
- [ ] Full pipeline run S0-S17 with dual-platform venture
- [ ] Verify 0 "Incomplete API response" errors in worker logs
- [ ] Check Google Stitch for correct page count

🤖 Generated with [Claude Code](https://claude.com/claude-code)