### PR TITLE
feat: add feedback page to Stitch prompts + fix preflight PRD lookup

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -333,7 +333,19 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     return { status: 'no_op', reason: 'no_screens' };
   }
 
-  // Step 3.5: Generate design reference section (archetype-matched inspiration)
+  // Step 3.5: Append feedback page screen (parity with Replit prompt — replit-prompt-formatter.js:82-117)
+  const hasFeedbackScreen = screens.some(s =>
+    (s.name || '').toLowerCase().includes('feedback')
+  );
+  if (!hasFeedbackScreen) {
+    screens.push({
+      name: 'Feedback',
+      purpose: 'User feedback form at /feedback. Fields: feedback_type dropdown (Bug Report, Feature Request, Usability Issue, Other), description textarea (max 500 chars with counter), optional contact_email. Submit via Supabase anon key with rate limiting (50/hr). Show success toast. Add Feedback link in footer or help menu.',
+      key_components: ['feedback_type dropdown', 'description textarea', 'contact_email input', 'submit button', 'success toast'],
+    });
+  }
+
+  // Step 3.6: Generate design reference section (archetype-matched inspiration)
   let designRefSection = '';
   if (options.archetype) {
     try {

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -149,7 +149,7 @@ async function checkPlanToExecPrereqs(supabase, sd, sdId) {
   const { data: prd } = await supabase
     .from('product_requirements_v2')
     .select('id, status, executive_summary')
-    .eq('sd_id', sdId)
+    .eq('sd_id', sd.id)
     .single();
 
   if (!prd) {
@@ -180,7 +180,7 @@ async function checkPlanToExecPrereqs(supabase, sd, sdId) {
   const { data: stories, error: storiesErr } = await supabase
     .from('user_stories')
     .select('story_key')
-    .eq('sd_id', sdId);
+    .eq('sd_id', sd.id);
 
   if (storiesErr || !stories || stories.length === 0) {
     issues.push({

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -56,7 +56,7 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
 
       case 'LEAD_FINAL_APPROVAL':
       case 'LEAD-FINAL-APPROVAL':
-        issues.push(...await checkLeadFinalApprovalPrereqs(supabase, sdId));
+        issues.push(...await checkLeadFinalApprovalPrereqs(supabase, sd, sdId));
         break;
 
       // EXEC-TO-PLAN and PLAN-TO-LEAD have fewer prerequisite issues
@@ -197,14 +197,15 @@ async function checkPlanToExecPrereqs(supabase, sd, sdId) {
  * LEAD-FINAL-APPROVAL: Check prerequisite handoff chain + retrospective
  * Catches: PAT-HF-LEADFINALAPPROVAL (missing prerequisites)
  */
-async function checkLeadFinalApprovalPrereqs(supabase, sdId) {
+async function checkLeadFinalApprovalPrereqs(supabase, sd, sdId) {
   const issues = [];
+  const lookupId = sd?.id || sdId;
 
   // Check PLAN-TO-LEAD handoff exists
   const { data: planToLeadRows } = await supabase
     .from('sd_phase_handoffs')
     .select('id, status')
-    .eq('sd_id', sdId)
+    .eq('sd_id', lookupId)
     .eq('to_phase', 'LEAD')
     .eq('from_phase', 'PLAN')
     .in('status', ['accepted', 'completed'])
@@ -223,7 +224,7 @@ async function checkLeadFinalApprovalPrereqs(supabase, sdId) {
   const { data: retros } = await supabase
     .from('retrospectives')
     .select('id')
-    .eq('sd_id', sdId)
+    .eq('sd_id', lookupId)
     .limit(1);
   const retro = retros?.[0] || null;
 


### PR DESCRIPTION
## Summary
- Add feedback page screen to Stitch prompt output (parity with Replit prompt formatter)
- Fix prerequisite-preflight.js PRD/story lookup bug: used sd_key string instead of UUID for FK queries

## SD
SD-LEO-INFRA-ENFORCE-FEEDBACK-WIDGET-001

## Test plan
- [ ] Verify Stitch prompt includes feedback page section
- [ ] Verify PLAN-TO-EXEC preflight finds PRDs by UUID
- [ ] Verify no changes to replit-prompt-formatter.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)