### PR TITLE
fix: add stitch confirmation tracking (submitted vs created)

### DIFF
--- a/database/migrations/20260413_create_stitch_generation_metrics.sql
+++ b/database/migrations/20260413_create_stitch_generation_metrics.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS stitch_generation_metrics (
   device_type TEXT NOT NULL,
   prompt_char_count INTEGER,
   prompt_hash TEXT,
-  status TEXT NOT NULL CHECK (status IN ('success', 'error', 'fired')),
+  status TEXT NOT NULL CHECK (status IN ('success', 'error', 'fired', 'confirmed')),
   attempt_count INTEGER NOT NULL DEFAULT 1,
   duration_ms INTEGER,
   error_category TEXT,

--- a/lib/eva/bridge/stitch-metrics.js
+++ b/lib/eva/bridge/stitch-metrics.js
@@ -34,20 +34,26 @@ export async function getVentureMetrics(ventureId, days = 30) {
 
   if (error || !data || data.length === 0) return null;
 
-  const total = data.length;
-  const successes = data.filter(r => r.status === 'success' || r.status === 'fired').length;
-  const errors = data.filter(r => r.status === 'error').length;
-  const retries = data.filter(r => r.attempt_count > 1).length;
-  const durations = data.filter(r => r.duration_ms > 0).map(r => r.duration_ms);
+  // Separate submission rows from confirmation rows
+  const submissions = data.filter(r => r.status !== 'confirmed');
+  const confirmations = data.filter(r => r.status === 'confirmed');
+
+  const total = submissions.length;
+  const successes = submissions.filter(r => r.status === 'success' || r.status === 'fired').length;
+  const errors = submissions.filter(r => r.status === 'error').length;
+  const retries = submissions.filter(r => r.attempt_count > 1).length;
+  const durations = submissions.filter(r => r.duration_ms > 0).map(r => r.duration_ms);
 
   const errorBreakdown = {};
-  data.filter(r => r.error_category).forEach(r => {
+  submissions.filter(r => r.error_category).forEach(r => {
     errorBreakdown[r.error_category] = (errorBreakdown[r.error_category] || 0) + 1;
   });
 
   return {
     venture_id: ventureId,
     total_screens: total,
+    screens_confirmed: confirmations.length,
+    confirmation_gap: total > 0 ? total - confirmations.length : 0,
     success_rate: total > 0 ? Math.round((successes / total) * 100) : 0,
     retry_rate: total > 0 ? Math.round((retries / total) * 100) : 0,
     error_count: errors,
@@ -128,13 +134,16 @@ export async function getFleetHealth(days = 7) {
     return { total_screens: 0, success_rate: 0, ventures_active: 0, period_days: days };
   }
 
-  const total = data.length;
-  const successes = data.filter(r => r.status === 'success' || r.status === 'fired').length;
-  const ventures = new Set(data.filter(r => r.venture_id).map(r => r.venture_id));
-  const durations = data.filter(r => r.duration_ms > 0).map(r => r.duration_ms);
+  const submissions = data.filter(r => r.status !== 'confirmed');
+  const confirmations = data.filter(r => r.status === 'confirmed');
+  const total = submissions.length;
+  const successes = submissions.filter(r => r.status === 'success' || r.status === 'fired').length;
+  const ventures = new Set(submissions.filter(r => r.venture_id).map(r => r.venture_id));
+  const durations = submissions.filter(r => r.duration_ms > 0).map(r => r.duration_ms);
 
   return {
     total_screens: total,
+    screens_confirmed: confirmations.length,
     success_rate: total > 0 ? Math.round((successes / total) * 100) : 0,
     ventures_active: ventures.size,
     avg_duration_ms: durations.length > 0 ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length) : 0,
@@ -194,7 +203,10 @@ export function renderStitchHealth(data) {
     return lines.join('\n');
   }
 
-  lines.push(`  Fleet: ${data.fleet.success_rate}% success rate | ${data.fleet.total_screens} screens | ${data.fleet.ventures_active} ventures | avg ${data.fleet.avg_duration_ms}ms`);
+  const confirmLabel = data.fleet.screens_confirmed > 0
+    ? ` | ${data.fleet.screens_confirmed}/${data.fleet.total_screens} confirmed`
+    : '';
+  lines.push(`  Fleet: ${data.fleet.success_rate}% success rate | ${data.fleet.total_screens} submitted${confirmLabel} | ${data.fleet.ventures_active} ventures | avg ${data.fleet.avg_duration_ms}ms`);
 
   if (data.degraded_ventures.length > 0) {
     lines.push('');

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -603,6 +603,26 @@ export async function checkCurationStatus(ventureId) {
     source: 'stitch-provisioner',
   });
 
+  // Record confirmation metrics (append-only — never mutates submission rows)
+  // Each confirmed screen gets a status='confirmed' row in stitch_generation_metrics
+  for (const screen of screens) {
+    try {
+      await supabase.from('stitch_generation_metrics').insert({
+        venture_id: ventureId,
+        screen_name: screen.name || 'unknown',
+        device_type: 'CONFIRMED',
+        prompt_char_count: 0,
+        status: 'confirmed',
+        attempt_count: 0,
+        duration_ms: 0,
+        sdk_version: 'listScreens'
+      });
+    } catch (err) {
+      console.warn(`[stitch-provisioner] confirmation metric insert failed (non-blocking): ${err.message}`);
+    }
+  }
+  console.info(`[stitch-provisioner] Recorded ${screens.length} confirmation metrics for venture ${ventureId.slice(0, 8)}`);
+
   return {
     ready: true,
     screen_count: screens.length,


### PR DESCRIPTION
## Summary
- Record `status='confirmed'` rows in `stitch_generation_metrics` when `checkCurationStatus()` at S17 finds screens via `listScreens()`
- Append-only pattern: submission rows are never mutated
- Update metrics queries to separate submissions from confirmations (`screens_confirmed`, `confirmation_gap`)
- Update Friday meeting stitch_health to show "16 submitted | 14/16 confirmed"

## Root Cause
`recordMetric()` only captured submission-side data (fired/success/error). No confirmation tracking existed to verify screens were actually created on Google Stitch server.

## Test plan
- [x] 15 smoke tests pass
- [x] 8 stitch-client unit tests pass
- [ ] Run venture through S17, open in Stitch, verify confirmation rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)