### PR TITLE
fix: replace em-dash with ASCII dash in leo-stack.ps1

### DIFF
--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -310,7 +310,7 @@ function Stop-Workers {
     $staleWorkers = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
         Where-Object { $_.CommandLine -match 'stage-zero|stage-execution-worker|start-stage-worker|eva-master-scheduler|subagent-worker' }
     if ($staleWorkers) {
-        Write-Log "WARN" "[WORKERS] $($staleWorkers.Count) stale worker(s) still running — force killing..." "Yellow"
+        Write-Log "WARN" "[WORKERS] $($staleWorkers.Count) stale worker(s) still running - force killing..." "Yellow"
         foreach ($stale in $staleWorkers) {
             try {
                 & taskkill /T /F /PID $stale.ProcessId 2>&1 | Out-Null


### PR DESCRIPTION
## Summary
- Replace Unicode em-dash (U+2014) with ASCII hyphen-minus in PowerShell Write-Log string
- Em-dash caused PowerShell parse error on `/restart`, preventing server startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)