### PR TITLE
feat(SD-AUTOPROCEED-SHIP-ENFORCEMENT-ORCH-001): emit HANDOFF_POST_ACTION=ship on LEAD-FINAL-APPROVAL

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,11 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/auto-learning-capture.cjs",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/post-ship-enforcement.cjs",
+            "timeout": 3
           }
         ]
       },

--- a/scripts/hooks/post-ship-enforcement.cjs
+++ b/scripts/hooks/post-ship-enforcement.cjs
@@ -1,0 +1,69 @@
+/**
+ * PostToolUse Hook: Ship Enforcement Safety Net
+ *
+ * Detects when HANDOFF_POST_ACTION=ship was emitted in Bash tool output
+ * and injects a reminder if /ship has not been invoked.
+ *
+ * SD-AUTOPROCEED-SHIP-ENFORCEMENT-ORCH-001
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const STATE_FILE = path.join(__dirname, '..', '..', '.claude', 'post-action-state.json');
+
+module.exports = async ({ tool, tool_input, tool_output }) => {
+  // Guard: only process Bash tool results
+  if (tool !== 'Bash') return;
+
+  const output = typeof tool_output === 'string' ? tool_output : '';
+
+  // Detect HANDOFF_POST_ACTION=ship in handoff output
+  if (output.includes('HANDOFF_POST_ACTION=ship')) {
+    // Write state file so we can check on next tool call
+    try {
+      fs.writeFileSync(STATE_FILE, JSON.stringify({
+        detected_at: new Date().toISOString(),
+        action: 'ship'
+      }));
+    } catch (e) {
+      // Non-blocking
+    }
+    return;
+  }
+
+  // Check if a pending ship action exists from a previous tool call
+  let pending = null;
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      pending = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+    }
+  } catch (e) {
+    return;
+  }
+
+  if (!pending || pending.action !== 'ship') return;
+
+  // Check if this tool call is /ship invocation (Skill tool with ship)
+  if (tool === 'Bash' && output.includes('/ship')) {
+    // Ship was invoked, clear state
+    try { fs.unlinkSync(STATE_FILE); } catch (e) { /* ignore */ }
+    return;
+  }
+
+  // Check age — only remind within 60 seconds of detection
+  const ageMs = Date.now() - new Date(pending.detected_at).getTime();
+  if (ageMs > 60000) {
+    // Stale, clear it
+    try { fs.unlinkSync(STATE_FILE); } catch (e) { /* ignore */ }
+    return;
+  }
+
+  // Clear state after reminding once
+  try { fs.unlinkSync(STATE_FILE); } catch (e) { /* ignore */ }
+
+  // Inject reminder
+  return {
+    message: '⚠️ HANDOFF_POST_ACTION=ship was emitted but /ship has not been invoked. AUTO-PROCEED requires running /ship to complete this SD. Invoke /ship now.'
+  };
+};

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -7,10 +7,12 @@
  * Part of SD-LEO-REFACTOR-HANDOFF-001
  */
 
+import { execSync } from 'child_process';
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 import { normalizeSDId } from '../../sd-id-normalizer.js';
 import { createTaskHydrator } from '../../../../lib/tasks/index.js';
 import { validateBypassReason } from '../bypass-rubric.js';
+import { resolveAutoProceed } from '../auto-proceed-resolver.js';
 
 /**
  * Check bypass rate limits and log to audit
@@ -269,6 +271,25 @@ export async function displayExecutionResult(result, handoffType, sdId) {
     // Emitted LAST so grep/tail can always find it regardless of output size
     const passDisplayScore = result.normalizedScore ?? result.qualityScore ?? Math.round((result.totalScore / result.maxScore) * 100) ?? 0;
     console.log(`\nHANDOFF_RESULT=PASS SD=${sdId} SCORE=${passDisplayScore} PHASE=${handoffType.toUpperCase()}`);
+
+    // SD-AUTOPROCEED-SHIP-ENFORCEMENT-ORCH-001: Emit post-action directive for LEAD-FINAL-APPROVAL
+    // When auto-proceed is ON and commits exist on branch, emit HANDOFF_POST_ACTION=ship
+    // so Claude treats /ship as a deterministic obligation, not a context-dependent suggestion.
+    if (handoffType.toUpperCase() === 'LEAD-FINAL-APPROVAL') {
+      try {
+        const supabase = createSupabaseServiceClient();
+        const autoProceedResult = await resolveAutoProceed({ supabase, verbose: false });
+        if (autoProceedResult.enabled) {
+          const commitOutput = execSync('git log origin/main..HEAD --oneline 2>/dev/null || true', { encoding: 'utf-8' }).trim();
+          if (commitOutput.length > 0) {
+            console.log(`\nHANDOFF_POST_ACTION=ship`);
+          }
+        }
+      } catch (e) {
+        // Non-blocking: if post-action check fails, handoff still succeeded
+        console.debug(`[post-action] Could not resolve post-action: ${e.message}`);
+      }
+    }
   } else {
     console.log('');
     console.log('❌ HANDOFF FAILED');

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -736,12 +736,12 @@ export class BaseExecutor {
     // single source of truth. Active claims are sessions with sd_id set and status='active'.
     const { data: existingClaims } = await this.supabase
       .from('claude_sessions')
-      .select('session_id, sd_key, claimed_at')
+      .select('session_id, sd_key, claimed_at, heartbeat_at')
       .eq('sd_key', claimId)
       .in('status', ['active', 'idle']);
 
     const activeClaim = (existingClaims || []).find(c => {
-      const ageSeconds = (Date.now() - new Date(c.claimed_at).getTime()) / 1000;
+      const ageSeconds = (Date.now() - new Date(c.heartbeat_at || c.claimed_at).getTime()) / 1000;
       return ageSeconds < 900;
     });
 
@@ -775,7 +775,7 @@ export class BaseExecutor {
     try {
       const { resolveOwnSession } = await import('../../../../lib/resolve-own-session.js');
       const resolved = await resolveOwnSession(this.supabase, {
-        select: 'session_id, sd_id, status, heartbeat_at',
+        select: 'session_id, sd_key, status, heartbeat_at',
         warnOnFallback: false
       });
       if (resolved.data && resolved.source !== 'heartbeat_fallback') {


### PR DESCRIPTION
## Summary
- Emit `HANDOFF_POST_ACTION=ship` from handoff.js when AUTO-PROCEED is ON and LEAD-FINAL-APPROVAL passes with commits on branch — eliminates #1 recurring friction point (5+ reports)
- Fix BaseExecutor.js claim staleness check: use `heartbeat_at` instead of `claimed_at` (RCA: sessions active >15min incorrectly rejected)  
- Fix `sd_id`→`sd_key` column name typo in resolveOwnSession fallback (RCA: silent query failure broke all fallback strategies)
- Add PostToolUse safety net hook (`post-ship-enforcement.cjs`) that detects missed ship directives
- Add `leo_protocol_sections` entry for CLAUDE.md directive parsing instruction

## Test plan
- [ ] Run LEAD-FINAL-APPROVAL with auto-proceed ON + commits → verify `HANDOFF_POST_ACTION=ship` in stdout
- [ ] Run LEAD-FINAL-APPROVAL with auto-proceed OFF → verify no `HANDOFF_POST_ACTION`
- [ ] Run non-final-approval handoff → verify no `HANDOFF_POST_ACTION`
- [ ] Verify handoffs succeed for sessions active >15 minutes (BaseExecutor heartbeat fix)
- [ ] Verify existing handoff tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)