### PR TITLE
feat(testing): add proactive testability guidance to LEO lifecycle

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/architectural-pattern-checklist.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/architectural-pattern-checklist.js
@@ -46,6 +46,16 @@ const PATTERN_CATEGORIES = {
       'structured log', 'correlation id', 'trace id',
       'sentry', 'datadog', 'prometheus', 'grafana'
     ]
+  },
+  testability: {
+    label: 'Testability',
+    keywords: [
+      'testability', 'testable', 'dependency injection', 'injectable',
+      'pure function', 'side effect isolation', 'mock', 'stub',
+      'seam', 'interface boundary', 'test hook', 'test fixture',
+      'separation of concerns', 'single responsibility',
+      'factory', 'adapter pattern', 'inversion of control'
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- Add `testability` keyword category to the architectural pattern checklist gate (PLAN-TO-EXEC), so complex SDs get an advisory nudge if the PRD doesn't address testability
- Database sections updated: EXEC section 210 (Testability-Aware Implementation directive) and PLAN section 337 (system_architecture testability prompt)
- CLAUDE file regeneration will pick up the DB changes on next `docs(schema)` auto-update

## Context
Testing in the LEO lifecycle is ~70-80% reactive (validate after code is written). This threads proactive testability awareness into the two moments that matter: when the PRD is authored (PLAN) and when the code is about to be written (EXEC).

## Test plan
- [x] All 34 existing plan-to-exec gate tests pass
- [x] Smoke tests pass (15/15)
- [ ] Verify testability keywords surface in next complex SD's architectural pattern checklist gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)