### PR TITLE
fix: correct Stitch design system schema + filter design pages from confirmations

### DIFF
--- a/lib/eva/bridge/stitch-design-system.js
+++ b/lib/eva/bridge/stitch-design-system.js
@@ -5,56 +5,71 @@
  * Maps S11 brand_tokens (colors, fonts, visual style) to Stitch DesignSystem
  * API format and creates a project-level theme that all generated screens inherit.
  *
- * Uses normalized brand_tokens from PR #2950 — colors are strings (hex),
- * fonts are strings (family names).
+ * API schema from @google/stitch-sdk tool-definitions.js:
+ *   designSystem.displayName (required, string)
+ *   designSystem.theme.colorMode (required, enum: LIGHT | DARK)
+ *   designSystem.theme.headlineFont (required, enum: INTER | MANROPE | ...)
+ *   designSystem.theme.bodyFont (required, enum: INTER | MANROPE | ...)
+ *   designSystem.theme.roundness (required, enum: ROUND_FOUR | ROUND_EIGHT | ROUND_TWELVE | ROUND_FULL)
+ *   designSystem.theme.customColor (required, hex string e.g. "#ff0000")
+ *   designSystem.theme.designMd (optional, markdown string)
  */
+
+// Valid font enums from the Stitch SDK
+const VALID_FONTS = [
+  'INTER', 'MANROPE', 'SPACE_GROTESK', 'WORK_SANS', 'PLUS_JAKARTA_SANS',
+  'PUBLIC_SANS', 'SPLINE_SANS', 'EPILOGUE', 'LEXEND', 'BE_VIETNAM_PRO',
+  'NEWSREADER', 'NOTO_SERIF', 'DOMINE', 'LIBRE_CASLON_TEXT', 'EB_GARAMOND',
+  'LITERATA', 'SOURCE_SERIF_FOUR', 'MONTSERRAT', 'SOURCE_SANS_THREE',
+  'NUNITO_SANS', 'ARIMO', 'HANKEN_GROTESK', 'RUBIK', 'GEIST', 'DM_SANS',
+  'IBM_PLEX_SANS', 'SORA'
+];
+
+// Map common font names to SDK enums
+const FONT_NAME_MAP = {
+  'inter': 'INTER', 'manrope': 'MANROPE', 'space grotesk': 'SPACE_GROTESK',
+  'work sans': 'WORK_SANS', 'plus jakarta sans': 'PLUS_JAKARTA_SANS',
+  'public sans': 'PUBLIC_SANS', 'spline sans': 'SPLINE_SANS',
+  'epilogue': 'EPILOGUE', 'lexend': 'LEXEND', 'montserrat': 'MONTSERRAT',
+  'roboto': 'INTER', 'helvetica': 'INTER', 'arial': 'INTER',
+  'dm sans': 'DM_SANS', 'ibm plex sans': 'IBM_PLEX_SANS', 'sora': 'SORA',
+  'rubik': 'RUBIK', 'geist': 'GEIST', 'nunito sans': 'NUNITO_SANS',
+  'noto serif': 'NOTO_SERIF', 'eb garamond': 'EB_GARAMOND',
+};
 
 /**
- * Map brand_tokens extracted at S11 to Stitch DesignSystem format.
- * Never throws — returns sensible defaults for missing fields.
- *
- * @param {Object} brandTokens - Normalized brand tokens from extractStage11Tokens
- * @param {Array<string>} [brandTokens.colors] - Array of hex color strings
- * @param {Array<string>} [brandTokens.fonts] - Array of font family strings
- * @param {string} [brandTokens.personality] - Visual personality (bold, minimal, etc.)
- * @returns {Object} Stitch DesignSystem configuration
+ * Map brand_tokens extracted at S11 to Stitch DesignSystem API format.
+ * Never throws -- returns sensible defaults for missing fields.
  */
-export function mapBrandTokensToDesignSystem(brandTokens) {
+export function mapBrandTokensToDesignSystem(brandTokens, ventureName) {
   if (!brandTokens || typeof brandTokens !== 'object') {
-    return buildDefaultDesignSystem();
+    return buildDefaultDesignSystem(ventureName);
   }
 
-  const colors = extractColors(brandTokens);
-  const fonts = extractFonts(brandTokens);
+  const customColor = extractPrimaryColor(brandTokens);
+  const headlineFont = mapFontToEnum(brandTokens.fonts, 0);
+  const bodyFont = mapFontToEnum(brandTokens.fonts, 1) || headlineFont;
   const colorMode = inferColorMode(brandTokens);
   const roundness = inferRoundness(brandTokens);
 
   return {
+    displayName: ventureName || 'Design System',
     theme: {
       colorMode,
-      fonts: {
-        heading: fonts.heading,
-        body: fonts.body,
-      },
+      headlineFont,
+      bodyFont,
       roundness,
+      customColor,
     },
-    customColors: colors,
   };
 }
 
 /**
- * Create a DesignSystem on a Stitch project and optionally apply it.
- * Fire-and-forget pattern — failure is non-fatal.
- *
- * @param {Object} params
- * @param {Object} params.sdk - Stitch SDK module
- * @param {string} params.apiKey - Stitch API key
- * @param {string} params.projectId - Stitch project ID
- * @param {Object} params.brandTokens - Brand tokens from S11
- * @returns {Promise<{designSystemId: string|null, applied: boolean}>}
+ * Create a DesignSystem on a Stitch project.
+ * Fire-and-forget pattern -- failure is non-fatal.
  */
-export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brandTokens }) {
-  const designSystemConfig = mapBrandTokensToDesignSystem(brandTokens);
+export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brandTokens, ventureName }) {
+  const designSystemConfig = mapBrandTokensToDesignSystem(brandTokens, ventureName);
 
   try {
     const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
@@ -64,8 +79,7 @@ export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brand
     const designSystemId = designSystem?.id || designSystem?.design_system_id || null;
 
     console.info(`[stitch-design-system] DesignSystem created: ${designSystemId}`);
-    console.info(`[stitch-design-system] Theme: colorMode=${designSystemConfig.theme.colorMode}, fonts=${designSystemConfig.theme.fonts.heading}/${designSystemConfig.theme.fonts.body}, roundness=${designSystemConfig.theme.roundness}`);
-    console.info(`[stitch-design-system] Colors: ${designSystemConfig.customColors.map(c => `${c.name}=${c.hex}`).join(', ')}`);
+    console.info(`[stitch-design-system] Theme: colorMode=${designSystemConfig.theme.colorMode}, headline=${designSystemConfig.theme.headlineFont}, body=${designSystemConfig.theme.bodyFont}, roundness=${designSystemConfig.theme.roundness}, color=${designSystemConfig.theme.customColor}`);
 
     try { await client.close(); } catch { /* ignore */ }
 
@@ -74,7 +88,7 @@ export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brand
     const msg = err.message || '';
     const isTransport = /fetch failed|socket|ECONNRESET|other side closed/i.test(msg);
     if (isTransport) {
-      console.info('[stitch-design-system] DesignSystem fired (socket dropped — server processing)');
+      console.info('[stitch-design-system] DesignSystem fired (socket dropped -- server processing)');
       return { designSystemId: 'fired', applied: false, config: designSystemConfig };
     }
     console.warn(`[stitch-design-system] createDesignSystem failed (non-fatal): ${msg}`);
@@ -86,73 +100,69 @@ export async function createAndApplyDesignSystem({ sdk, apiKey, projectId, brand
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function extractColors(brandTokens) {
-  const colors = [];
+function extractPrimaryColor(brandTokens) {
   const rawColors = brandTokens.colors || [];
-
-  if (Array.isArray(rawColors)) {
-    const colorNames = ['primary', 'secondary', 'accent', 'neutral', 'background'];
-    rawColors.forEach((color, i) => {
-      const hex = typeof color === 'string' ? color : (color?.hex || color?.value || null);
-      if (hex && /^#[0-9a-fA-F]{3,8}$/.test(hex)) {
-        colors.push({ name: colorNames[i] || `color_${i}`, hex });
-      }
-    });
+  if (Array.isArray(rawColors) && rawColors.length > 0) {
+    const first = rawColors[0];
+    const hex = typeof first === 'string' ? first : (first?.hex || first?.value || null);
+    if (hex && /^#[0-9a-fA-F]{3,8}$/.test(hex)) return hex;
   }
-
-  // Fallback: if no valid colors extracted, use a neutral default
-  if (colors.length === 0) {
-    colors.push({ name: 'primary', hex: '#3b82f6' });
-  }
-
-  return colors;
+  return '#3b82f6';
 }
 
-function extractFonts(brandTokens) {
-  const rawFonts = brandTokens.fonts || [];
-  let heading = 'Inter';
-  let body = 'Inter';
+function mapFontToEnum(fonts, index) {
+  if (!Array.isArray(fonts) || fonts.length <= index) return 'INTER';
+  const raw = fonts[index];
+  const name = (typeof raw === 'string' ? raw : (raw?.name || raw?.family || '')).toLowerCase().trim();
 
-  if (Array.isArray(rawFonts) && rawFonts.length > 0) {
-    heading = typeof rawFonts[0] === 'string' ? rawFonts[0] : (rawFonts[0]?.name || rawFonts[0]?.family || 'Inter');
-    if (rawFonts.length > 1) {
-      body = typeof rawFonts[1] === 'string' ? rawFonts[1] : (rawFonts[1]?.name || rawFonts[1]?.family || 'Inter');
-    } else {
-      body = heading; // Single font = use for both
-    }
-  }
+  // Direct match in map
+  if (FONT_NAME_MAP[name]) return FONT_NAME_MAP[name];
 
-  return { heading, body };
+  // Try converting to enum format (e.g. "Plus Jakarta Sans" -> "PLUS_JAKARTA_SANS")
+  const enumAttempt = name.replace(/\s+/g, '_').toUpperCase();
+  if (VALID_FONTS.includes(enumAttempt)) return enumAttempt;
+
+  // Fuzzy: check if any valid font starts with the same prefix
+  const prefix = name.split(' ')[0].toUpperCase();
+  const fuzzy = VALID_FONTS.find(f => f.startsWith(prefix));
+  if (fuzzy) return fuzzy;
+
+  return 'INTER';
 }
 
 function inferColorMode(brandTokens) {
   const raw = brandTokens.personality || '';
   const personality = (typeof raw === 'string' ? raw : '').toLowerCase();
   if (personality.includes('dark') || personality.includes('moody') || personality.includes('night')) {
-    return 'dark';
+    return 'DARK';
   }
-  return 'light';
+  return 'LIGHT';
 }
 
 function inferRoundness(brandTokens) {
   const raw = brandTokens.personality || '';
   const personality = (typeof raw === 'string' ? raw : '').toLowerCase();
   if (personality.includes('sharp') || personality.includes('corporate') || personality.includes('formal')) {
-    return 'none';
+    return 'ROUND_FOUR';
   }
   if (personality.includes('playful') || personality.includes('friendly') || personality.includes('soft')) {
-    return 'full';
+    return 'ROUND_FULL';
   }
-  return 'medium';
+  return 'ROUND_EIGHT';
 }
 
-function buildDefaultDesignSystem() {
+function buildDefaultDesignSystem(ventureName) {
   return {
+    displayName: ventureName || 'Design System',
     theme: {
-      colorMode: 'light',
-      fonts: { heading: 'Inter', body: 'Inter' },
-      roundness: 'medium',
+      colorMode: 'LIGHT',
+      headlineFont: 'INTER',
+      bodyFont: 'INTER',
+      roundness: 'ROUND_EIGHT',
+      customColor: '#3b82f6',
     },
-    customColors: [{ name: 'primary', hex: '#3b82f6' }],
   };
 }
+
+// Export for testing
+export { mapFontToEnum, inferColorMode, inferRoundness, extractPrimaryColor, VALID_FONTS, FONT_NAME_MAP };

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -440,7 +440,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
     if (sdk) {
       const apiKey = process.env.GOOGLE_STITCH_API_KEY || process.env.STITCH_API_KEY;
       designSystemResult = await createAndApplyDesignSystem({
-        sdk, apiKey, projectId: project.project_id, brandTokens,
+        sdk, apiKey, projectId: project.project_id, brandTokens, ventureName,
       });
     }
   } catch (err) {
@@ -603,9 +603,32 @@ export async function checkCurationStatus(ventureId) {
     source: 'stitch-provisioner',
   });
 
-  // Record confirmation metrics (append-only — never mutates submission rows)
-  // Each confirmed screen gets a status='confirmed' row in stitch_generation_metrics
-  for (const screen of screens) {
+  // Filter out design system pages from screen list.
+  // Stitch auto-generates design system pages alongside screens. These have
+  // creative names like "Precision Vitality" that don't match any submitted prompt.
+  // We identify actual screens by checking against submitted screen names in metrics.
+  const { data: submittedRows } = await supabase.from('stitch_generation_metrics')
+    .select('screen_name')
+    .eq('venture_id', ventureId)
+    .neq('status', 'confirmed');
+  const submittedNames = new Set((submittedRows || []).map(r => r.screen_name));
+
+  const actualScreens = screens.filter(s => {
+    const name = s.name || '';
+    // Match if any submitted screen name is a substring of this screen's name (or vice versa)
+    for (const submitted of submittedNames) {
+      if (name.includes(submitted) || submitted.includes(name)) return true;
+    }
+    return false;
+  });
+
+  const designSystemPages = screens.length - actualScreens.length;
+  if (designSystemPages > 0) {
+    console.info(`[stitch-provisioner] Filtered ${designSystemPages} design system page(s) from ${screens.length} total`);
+  }
+
+  // Record confirmation metrics (append-only -- never mutates submission rows)
+  for (const screen of actualScreens) {
     try {
       await supabase.from('stitch_generation_metrics').insert({
         venture_id: ventureId,
@@ -621,7 +644,7 @@ export async function checkCurationStatus(ventureId) {
       console.warn(`[stitch-provisioner] confirmation metric insert failed (non-blocking): ${err.message}`);
     }
   }
-  console.info(`[stitch-provisioner] Recorded ${screens.length} confirmation metrics for venture ${ventureId.slice(0, 8)}`);
+  console.info(`[stitch-provisioner] Confirmed ${actualScreens.length} screen(s) for venture ${ventureId.slice(0, 8)} (${designSystemPages} design system pages excluded)`);
 
   return {
     ready: true,


### PR DESCRIPTION
## Summary
- **Fix 1**: Rewrite `mapBrandTokensToDesignSystem()` to match actual Stitch SDK API schema (correct enum values, field names, required `displayName`)
- **Fix 2**: Filter auto-generated design system pages from `listScreens()` results when recording confirmation metrics

## Root Cause
- Design system creation failed with "invalid argument" because every field used wrong types/enums
- 7 auto-generated design system pages inflated screen count from 10 to 17

## Test plan
- [x] 15 smoke tests pass
- [x] 8 stitch-client unit tests pass
- [ ] Run venture through S15 and verify `createDesignSystem` succeeds
- [ ] Verify confirmation count matches actual screens, not total pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)