### PR TITLE
feat(vision): dynamic threshold adjustment + floor rule + audit logging

### DIFF
--- a/database/migrations/20260413_vision_scoring_audit_log.sql
+++ b/database/migrations/20260413_vision_scoring_audit_log.sql
@@ -1,0 +1,29 @@
+-- Vision Scoring Audit Log
+-- SD: SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A
+-- Purpose: Audit trail for every vision gate evaluation with dynamic threshold context
+
+CREATE TABLE IF NOT EXISTS vision_scoring_audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sd_id TEXT NOT NULL,
+  sd_type TEXT NOT NULL,
+  total_dims INTEGER NOT NULL DEFAULT 0,
+  addressable_count INTEGER NOT NULL DEFAULT 0,
+  base_threshold INTEGER NOT NULL,
+  adjusted_threshold INTEGER NOT NULL,
+  score INTEGER,
+  verdict TEXT NOT NULL,
+  floor_rule_triggered BOOLEAN NOT NULL DEFAULT false,
+  evaluation_context TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for querying by SD
+CREATE INDEX IF NOT EXISTS idx_vision_audit_sd_id ON vision_scoring_audit_log(sd_id);
+
+-- Index for querying by verdict (for Phase 2 analysis)
+CREATE INDEX IF NOT EXISTS idx_vision_audit_verdict ON vision_scoring_audit_log(verdict);
+
+-- Index for time-based queries
+CREATE INDEX IF NOT EXISTS idx_vision_audit_created_at ON vision_scoring_audit_log(created_at);
+
+COMMENT ON TABLE vision_scoring_audit_log IS 'Audit trail for vision scoring gate evaluations with dynamic threshold context. SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -1,9 +1,15 @@
 /**
  * Vision Score Gate for LEAD-TO-PLAN
  * SD: SD-MAN-INFRA-VISION-SCORE-GATE-HARDEN-001
+ * Enhanced: SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A
  *
  * Hard SD-type-aware enforcement gate — blocks handoff when vision score is
  * below the type-specific threshold or when no score exists.
+ *
+ * Dynamic threshold adjustment (SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A):
+ *   adjusted_threshold = base_threshold * (addressable_dims / total_dims)
+ *   Floor rule: min 3 addressable dimensions, score >= 60
+ *   Audit: every gate evaluation logged with full dimensional context
  *
  * Threshold tiers:
  *   feature / governance / security    → must score ≥ 90
@@ -44,6 +50,109 @@ export const SD_TYPE_THRESHOLDS = {
 
 /** Minimum dimension score before a named warning is emitted. */
 export const DIMENSION_WARNING_THRESHOLD = 75;
+
+/** Minimum addressable dimensions for auto-scoring (floor rule). */
+export const MIN_ADDRESSABLE_DIMENSIONS = 3;
+
+/** Minimum average score for addressable dimensions (floor rule). */
+export const FLOOR_MINIMUM_SCORE = 60;
+
+/**
+ * Dimension addressability by SD type.
+ * Maps SD type to a Set of dimension name patterns that the type CAN address.
+ * Dimensions not in this set are considered non-addressable for that SD type.
+ * Pattern matching is case-insensitive substring match.
+ *
+ * null = all dimensions addressable (no adjustment needed).
+ */
+export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
+  feature:        null, // features can address all dimensions
+  governance:     null,
+  security:       ['security', 'compliance', 'risk', 'architecture', 'reliability', 'data'],
+  infrastructure: ['architecture', 'reliability', 'scalability', 'performance', 'security', 'maintainability', 'automation', 'observability'],
+  enhancement:    null,
+  maintenance:    ['reliability', 'maintainability', 'performance', 'security', 'architecture'],
+  protocol:       ['process', 'governance', 'compliance', 'documentation', 'automation', 'quality'],
+  bugfix:         ['reliability', 'quality', 'performance', 'security'],
+  fix:            ['reliability', 'quality', 'performance', 'security'],
+  documentation:  ['documentation', 'knowledge', 'compliance', 'process'],
+  refactor:       ['architecture', 'maintainability', 'performance', 'scalability', 'reliability'],
+  orchestrator:   null,
+};
+
+/**
+ * Count addressable dimensions for an SD type given the total dimension names.
+ * Returns { addressable, total } counts.
+ *
+ * @param {string} sdType
+ * @param {Object|null} dimensionScores - JSONB { dimName: score, ... }
+ * @returns {{ addressable: number, total: number }}
+ */
+export function countAddressableDimensions(sdType, dimensionScores) {
+  if (!dimensionScores || typeof dimensionScores !== 'object') {
+    return { addressable: 0, total: 0 };
+  }
+
+  const dimNames = Object.keys(dimensionScores);
+  const total = dimNames.length;
+
+  const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
+  if (patterns === null || patterns === undefined) {
+    return { addressable: total, total }; // all addressable
+  }
+
+  const addressable = dimNames.filter(name => {
+    const lower = name.toLowerCase();
+    return patterns.some(p => lower.includes(p.toLowerCase()));
+  }).length;
+
+  return { addressable, total };
+}
+
+/**
+ * Calculate dynamic threshold based on addressable dimension ratio.
+ * Formula: adjusted = base * (addressable / total)
+ * Returns base threshold if all dims addressable or no dimension data.
+ *
+ * @param {number} baseThreshold
+ * @param {number} addressable
+ * @param {number} total
+ * @returns {number} Adjusted threshold (rounded to nearest integer)
+ */
+export function calculateDynamicThreshold(baseThreshold, addressable, total) {
+  if (total === 0 || addressable >= total) return baseThreshold;
+  return Math.round(baseThreshold * (addressable / total));
+}
+
+/**
+ * Log a vision gate evaluation to the database (audit trail).
+ * Non-blocking — failures are logged but do not affect the gate result.
+ *
+ * @param {Object} supabase
+ * @param {Object} auditData
+ */
+async function logGateEvaluation(supabase, auditData) {
+  if (!supabase) return;
+  try {
+    await supabase
+      .from('vision_scoring_audit_log')
+      .insert({
+        sd_id: auditData.sdId,
+        sd_type: auditData.sdType,
+        total_dims: auditData.totalDims,
+        addressable_count: auditData.addressableCount,
+        base_threshold: auditData.baseThreshold,
+        adjusted_threshold: auditData.adjustedThreshold,
+        score: auditData.score,
+        verdict: auditData.verdict,
+        floor_rule_triggered: auditData.floorRuleTriggered || false,
+        evaluation_context: auditData.context || null,
+      });
+  } catch (e) {
+    // Non-blocking: audit logging failure must not block the gate
+    console.debug('[VisionScore] Audit log insert suppressed:', e?.message || e);
+  }
+}
 
 const THRESHOLD_LABELS = {
   accept:        { emoji: '✅', label: 'ACCEPT',      desc: 'Strong vision alignment' },
@@ -115,7 +224,7 @@ function getDimensionWarnings(dimensionScores) {
 export async function validateVisionScore(sd, supabase) {
   const sdKey = sd.sd_key || sd.id;
   const sdType = (sd.sd_type || 'unknown').toLowerCase();
-  const threshold = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
+  const baseThreshold = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
 
   // ── Orchestrator-child exemption ──────────────────────────────────────
   // Children of an orchestrator are tactical decompositions of an already
@@ -125,7 +234,7 @@ export async function validateVisionScore(sd, supabase) {
   // The parent orchestrator already passed vision alignment at creation.
   if (sd.metadata?.parent_orchestrator || sd.metadata?.auto_generated) {
     console.log('\n🔍 GATE: Vision Alignment Score (Hard Enforcement)');
-    console.log(`   SD Type: ${sdType} | Required: ${threshold}/100`);
+    console.log(`   SD Type: ${sdType} | Required: ${baseThreshold}/100`);
     console.log('-'.repeat(50));
     console.log(`   ⏭️  Orchestrator child detected (parent: ${sd.metadata.parent_orchestrator || 'auto_generated'})`);
     console.log('   ✅ Orchestrator children exempt — parent already validated vision alignment');
@@ -145,7 +254,7 @@ export async function validateVisionScore(sd, supabase) {
   // Blocking them creates a circular dependency. RCA: PAT-CORR-VISION-GATE-001
   if (sd.vision_origin_score_id || sd.metadata?.source === 'corrective_sd_generator') {
     console.log('\n🔍 GATE: Vision Alignment Score (Hard Enforcement)');
-    console.log(`   SD Type: ${sdType} | Required: ${threshold}/100`);
+    console.log(`   SD Type: ${sdType} | Required: ${baseThreshold}/100`);
     console.log('-'.repeat(50));
     console.log(`   ⏭️  Corrective SD detected (origin_score: ${sd.vision_origin_score_id || 'metadata.source'})`);
     console.log('   ✅ Corrective SDs exempt from GATE_VISION_SCORE — they exist to fix vision gaps');
@@ -184,14 +293,26 @@ export async function validateVisionScore(sd, supabase) {
     }
   }
 
+  // ── Dynamic threshold adjustment ────────────────────────────────────────
+  const { addressable, total } = countAddressableDimensions(sdType, dimensionScores);
+  const threshold = calculateDynamicThreshold(baseThreshold, addressable, total);
+  const thresholdAdjusted = threshold !== baseThreshold;
+
   console.log('\n🔍 GATE: Vision Alignment Score (Hard Enforcement)');
-  console.log(`   SD Type: ${sdType} | Required: ${threshold}/100`);
+  console.log(`   SD Type: ${sdType} | Base Threshold: ${baseThreshold}/100`);
+  if (thresholdAdjusted) {
+    console.log(`   📐 Dynamic Threshold: ${threshold}/100 (${addressable}/${total} addressable dims)`);
+  }
   console.log('-'.repeat(50));
 
   // ── No score present → hard block ───────────────────────────────────────
   if (visionScore === null) {
     console.log('   ❌ No vision alignment score found — handoff BLOCKED');
     console.log(`   💡 Run: node scripts/eva/vision-scorer.js --sd-id ${sdKey || '<SD-KEY>'}`);
+    await logGateEvaluation(supabase, {
+      sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+      baseThreshold, adjustedThreshold: threshold, score: null, verdict: 'blocked_no_score',
+    });
     return {
       passed: false,
       score: 0,
@@ -200,6 +321,59 @@ export async function validateVisionScore(sd, supabase) {
       remediation: `node scripts/eva/vision-scorer.js --sd-id ${sdKey || '<SD-KEY>'}`,
       warnings: [],
     };
+  }
+
+  // ── Floor rule: minimum addressable dimensions ───────────────────────────
+  // Only applies when some dims are non-addressable (addressable < total).
+  // If all dims are addressable, no adjustment needed regardless of count.
+  if (total > 0 && addressable < total && addressable < MIN_ADDRESSABLE_DIMENSIONS) {
+    console.log(`   ⚠️  Floor rule: only ${addressable}/${total} addressable dims (min: ${MIN_ADDRESSABLE_DIMENSIONS})`);
+    console.log('   🔍 Flagged for human review — too few addressable dimensions');
+    await logGateEvaluation(supabase, {
+      sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+      baseThreshold, adjustedThreshold: threshold, score: visionScore,
+      verdict: 'human_review_floor_dims', floorRuleTriggered: true,
+      context: `Only ${addressable} addressable dimensions (minimum ${MIN_ADDRESSABLE_DIMENSIONS} required)`,
+    });
+    return {
+      passed: true,
+      score: 75,
+      maxScore: 100,
+      details: `Floor rule: ${addressable}/${total} addressable dims (min: ${MIN_ADDRESSABLE_DIMENSIONS}). Human review recommended.`,
+      warnings: [`Floor rule triggered: only ${addressable} addressable dims for ${sdType} SD (minimum ${MIN_ADDRESSABLE_DIMENSIONS})`],
+    };
+  }
+
+  // ── Floor rule: minimum average score for addressable dims ────────────────
+  if (total > 0 && addressable > 0 && addressable < total && dimensionScores) {
+    const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
+    if (patterns) {
+      const addressableDimScores = Object.entries(dimensionScores)
+        .filter(([name]) => patterns.some(p => name.toLowerCase().includes(p.toLowerCase())))
+        .map(([, score]) => score)
+        .filter(s => typeof s === 'number');
+
+      if (addressableDimScores.length > 0) {
+        const avgScore = addressableDimScores.reduce((a, b) => a + b, 0) / addressableDimScores.length;
+        if (avgScore < FLOOR_MINIMUM_SCORE) {
+          console.log(`   ❌ Floor rule: addressable dim avg ${Math.round(avgScore)}/100 < ${FLOOR_MINIMUM_SCORE} minimum`);
+          await logGateEvaluation(supabase, {
+            sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+            baseThreshold, adjustedThreshold: threshold, score: visionScore,
+            verdict: 'blocked_floor_score', floorRuleTriggered: true,
+            context: `Addressable dim avg ${Math.round(avgScore)} below floor minimum ${FLOOR_MINIMUM_SCORE}`,
+          });
+          return {
+            passed: false,
+            score: 0,
+            maxScore: 100,
+            details: `Floor rule: addressable dim avg ${Math.round(avgScore)}/100 below minimum ${FLOOR_MINIMUM_SCORE}`,
+            remediation: `Improve addressable dimension scores to avg >= ${FLOOR_MINIMUM_SCORE}`,
+            warnings: [],
+          };
+        }
+      }
+    }
   }
 
   const classification = THRESHOLD_LABELS[thresholdAction] || THRESHOLD_LABELS.escalate;
@@ -214,6 +388,10 @@ export async function validateVisionScore(sd, supabase) {
       console.log(`   📋 Chairman justification: ${override.justification}`);
       const dimWarnings = getDimensionWarnings(dimensionScores);
       dimWarnings.forEach(w => console.log(`   ⚠️  ${w}`));
+      await logGateEvaluation(supabase, {
+        sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+        baseThreshold, adjustedThreshold: threshold, score: visionScore, verdict: 'pass_override',
+      });
       return {
         passed: true,
         score: 100,
@@ -224,13 +402,20 @@ export async function validateVisionScore(sd, supabase) {
     }
 
     console.log(`   ❌ Score ${visionScore}/100 BELOW ${sdType} threshold ${threshold} — handoff BLOCKED`);
+    if (thresholdAdjusted) {
+      console.log(`   ℹ️  (Adjusted from base ${baseThreshold} to ${threshold} for ${addressable}/${total} addressable dims)`);
+    }
     console.log(`   💡 Improve vision alignment: node scripts/eva/vision-scorer.js --sd-id ${sdKey}`);
     console.log('   💡 Or request Chairman override via validation_gate_registry');
+    await logGateEvaluation(supabase, {
+      sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+      baseThreshold, adjustedThreshold: threshold, score: visionScore, verdict: 'blocked_below_threshold',
+    });
     return {
       passed: false,
       score: 0,
       maxScore: 100,
-      details: `Vision score ${visionScore}/100 does not meet ${sdType} threshold ${threshold}/100`,
+      details: `Vision score ${visionScore}/100 does not meet ${sdType} threshold ${threshold}/100${thresholdAdjusted ? ` (adjusted from ${baseThreshold} for ${addressable}/${total} dims)` : ''}`,
       remediation: `Score must reach ${threshold}/100 for ${sdType} SDs. Run: node scripts/eva/vision-scorer.js --sd-id ${sdKey}`,
       warnings: [],
     };
@@ -241,16 +426,21 @@ export async function validateVisionScore(sd, supabase) {
   dimWarnings.forEach(w => console.log(`   ⚠️  ${w}`));
 
   if (dimWarnings.length === 0) {
-    console.log(`   ✅ Score ${visionScore}/100 meets ${sdType} threshold ${threshold}`);
+    console.log(`   ✅ Score ${visionScore}/100 meets ${sdType} threshold ${threshold}${thresholdAdjusted ? ` (adjusted from ${baseThreshold})` : ''}`);
   } else {
     console.log(`   ✅ Score ${visionScore}/100 meets threshold — ${dimWarnings.length} dimension(s) below ${DIMENSION_WARNING_THRESHOLD}`);
   }
+
+  await logGateEvaluation(supabase, {
+    sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+    baseThreshold, adjustedThreshold: threshold, score: visionScore, verdict: 'pass',
+  });
 
   return {
     passed: true,
     score: 100,
     maxScore: 100,
-    details: `Vision score: ${visionScore}/100 (${thresholdAction || 'unknown'}) — meets ${sdType} threshold ${threshold}`,
+    details: `Vision score: ${visionScore}/100 (${thresholdAction || 'unknown'}) — meets ${sdType} threshold ${threshold}${thresholdAdjusted ? ` (adjusted from ${baseThreshold} for ${addressable}/${total} dims)` : ''}`,
     warnings: dimWarnings,
   };
 }

--- a/tests/unit/vision-score-dynamic-threshold.test.js
+++ b/tests/unit/vision-score-dynamic-threshold.test.js
@@ -1,0 +1,345 @@
+/**
+ * Unit Tests: Dynamic Vision Threshold, Floor Rule, and Audit Logging
+ * SD: SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A
+ *
+ * Tests the new dynamic threshold adjustment, floor rule enforcement,
+ * and audit logging features added to the vision score gate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validateVisionScore,
+  SD_TYPE_THRESHOLDS,
+  SD_TYPE_ADDRESSABLE_DIMENSIONS,
+  MIN_ADDRESSABLE_DIMENSIONS,
+  FLOOR_MINIMUM_SCORE,
+  countAddressableDimensions,
+  calculateDynamicThreshold,
+} from '../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSD(sdKey, sdType, visionScore = null, dimensionScores = null) {
+  return {
+    sd_key: sdKey,
+    sd_type: sdType,
+    vision_score: visionScore,
+    vision_score_action: visionScore !== null ? (visionScore >= 93 ? 'accept' : visionScore >= 83 ? 'minor_sd' : 'gap_closure_sd') : null,
+    dimension_scores: dimensionScores,
+  };
+}
+
+/** Build a Supabase stub that captures audit log inserts. */
+function makeAuditCapturingSupabase(auditInserts = []) {
+  return {
+    from: vi.fn().mockImplementation((table) => {
+      if (table === 'vision_scoring_audit_log') {
+        return {
+          insert: vi.fn().mockImplementation((data) => {
+            auditInserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }),
+        };
+      }
+      // Default: return empty results for other tables
+      const obj = {
+        select: () => obj,
+        eq: () => obj,
+        order: () => obj,
+        limit: () => Promise.resolve({ data: [] }),
+      };
+      return obj;
+    }),
+  };
+}
+
+// ─── Tests: countAddressableDimensions ───────────────────────────────────────
+
+describe('countAddressableDimensions', () => {
+  it('returns all dims addressable for feature type (null mapping)', () => {
+    const dims = { strategic_alignment: 90, innovation: 85, reliability: 80, accessibility: 75, ui_ux: 70 };
+    const result = countAddressableDimensions('feature', dims);
+    expect(result.addressable).toBe(5);
+    expect(result.total).toBe(5);
+  });
+
+  it('returns subset for infrastructure type', () => {
+    const dims = {
+      architecture: 90,
+      reliability: 80,
+      scalability: 75,
+      accessibility: 70, // not addressable by infrastructure
+      ui_ux: 60,          // not addressable
+      security: 85,
+    };
+    const result = countAddressableDimensions('infrastructure', dims);
+    expect(result.addressable).toBe(4); // architecture, reliability, scalability, security
+    expect(result.total).toBe(6);
+  });
+
+  it('returns subset for documentation type', () => {
+    const dims = {
+      documentation: 90,
+      knowledge: 85,
+      architecture: 80,
+      ui_ux: 70,
+      scalability: 60,
+    };
+    const result = countAddressableDimensions('documentation', dims);
+    expect(result.addressable).toBe(2); // documentation, knowledge
+    expect(result.total).toBe(5);
+  });
+
+  it('returns 0/0 for null dimension scores', () => {
+    const result = countAddressableDimensions('feature', null);
+    expect(result.addressable).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('handles unknown sd_type with no mapping (all addressable)', () => {
+    const dims = { dim_a: 90, dim_b: 80 };
+    const result = countAddressableDimensions('unknown_type', dims);
+    // undefined mapping => all addressable
+    expect(result.addressable).toBe(2);
+    expect(result.total).toBe(2);
+  });
+});
+
+// ─── Tests: calculateDynamicThreshold ────────────────────────────────────────
+
+describe('calculateDynamicThreshold', () => {
+  it('returns base threshold when all dims addressable', () => {
+    expect(calculateDynamicThreshold(80, 10, 10)).toBe(80);
+  });
+
+  it('scales threshold proportionally', () => {
+    // 80 * (4/10) = 32
+    expect(calculateDynamicThreshold(80, 4, 10)).toBe(32);
+  });
+
+  it('rounds to nearest integer', () => {
+    // 90 * (3/7) = 38.57... → 39
+    expect(calculateDynamicThreshold(90, 3, 7)).toBe(39);
+  });
+
+  it('returns base threshold when total is 0', () => {
+    expect(calculateDynamicThreshold(80, 0, 0)).toBe(80);
+  });
+
+  it('returns base threshold when addressable >= total', () => {
+    expect(calculateDynamicThreshold(80, 12, 10)).toBe(80);
+  });
+});
+
+// ─── Tests: Dynamic threshold in validateVisionScore ────────────────────────
+
+describe('validateVisionScore — dynamic threshold', () => {
+  it('infrastructure SD with 4/8 addressable dims uses adjusted threshold', async () => {
+    const dims = {
+      architecture: 80, reliability: 75, scalability: 70, security: 80,
+      accessibility: 30, ui_ux: 20, innovation: 25, market_fit: 15,
+    };
+    // Base threshold: 80. Addressable: 4/8 → adjusted: 40
+    // Vision score: 45 → passes adjusted threshold 40
+    const sd = makeSD('SD-DYN-001', 'infrastructure', 45, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(true);
+    expect(result.details).toMatch(/adjusted from 80/);
+  });
+
+  it('infrastructure SD fails when below adjusted threshold', async () => {
+    const dims = {
+      architecture: 80, reliability: 75, scalability: 70, security: 80,
+      accessibility: 30, ui_ux: 20, innovation: 25, market_fit: 15,
+    };
+    // Adjusted threshold: 40. Score: 35 → fails
+    const sd = makeSD('SD-DYN-002', 'infrastructure', 35, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(false);
+    expect(result.details).toMatch(/35.*40/);
+  });
+
+  it('feature SD with all dims addressable uses base threshold unchanged', async () => {
+    const dims = { strategic: 92, innovation: 91, reliability: 90, quality: 93 };
+    const sd = makeSD('SD-DYN-003', 'feature', 91, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(true);
+    expect(result.details).not.toMatch(/adjusted from/);
+  });
+
+  it('full-dimension SD uses original base threshold (backward compat)', async () => {
+    const dims = { dim_a: 85, dim_b: 80, dim_c: 75 };
+    // feature type: null mapping → all addressable → no adjustment
+    const sd = makeSD('SD-DYN-004', 'feature', 89, dims);
+    const result = await validateVisionScore(sd, null);
+
+    // 89 < 90 (feature threshold) → should fail
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ─── Tests: Floor rule ──────────────────────────────────────────────────────
+
+describe('validateVisionScore — floor rule', () => {
+  it('flags human review when <3 addressable dims', async () => {
+    const dims = {
+      documentation: 90, knowledge: 85,
+      architecture: 70, scalability: 60, ui_ux: 50,
+      innovation: 40, reliability: 30, security: 20,
+    };
+    // documentation type: only 'documentation' and 'knowledge' match → 2 addressable
+    const sd = makeSD('SD-FLOOR-001', 'documentation', 80, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(75); // reduced score for floor rule
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toMatch(/floor rule/i);
+  });
+
+  it('blocks when addressable dim average < 60', async () => {
+    const dims = {
+      reliability: 50, quality: 55, security: 45, performance: 50,
+      architecture: 80, ui_ux: 90, innovation: 85, documentation: 75,
+    };
+    // bugfix type: reliability, quality, performance, security → 4 addressable
+    // avg of addressable: (50+55+45+50)/4 = 50 → below floor of 60
+    const sd = makeSD('SD-FLOOR-002', 'bugfix', 65, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(false);
+    expect(result.details).toMatch(/floor rule/i);
+    expect(result.details).toMatch(/50.*60/);
+  });
+
+  it('passes when addressable dim average >= 60', async () => {
+    const dims = {
+      reliability: 70, quality: 65, security: 60, performance: 65,
+      architecture: 30, ui_ux: 20, innovation: 15, documentation: 10,
+    };
+    // bugfix type: 4 addressable, avg = (70+65+60+65)/4 = 65 >= 60
+    // Dynamic threshold: 70 * (4/8) = 35. Score: 45 → passes 35
+    const sd = makeSD('SD-FLOOR-003', 'bugfix', 45, dims);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('MIN_ADDRESSABLE_DIMENSIONS is 3', () => {
+    expect(MIN_ADDRESSABLE_DIMENSIONS).toBe(3);
+  });
+
+  it('FLOOR_MINIMUM_SCORE is 60', () => {
+    expect(FLOOR_MINIMUM_SCORE).toBe(60);
+  });
+});
+
+// ─── Tests: Audit logging ───────────────────────────────────────────────────
+
+describe('validateVisionScore — audit logging', () => {
+  it('logs gate evaluation on pass', async () => {
+    const auditInserts = [];
+    const supabase = makeAuditCapturingSupabase(auditInserts);
+    const dims = { architecture: 90, reliability: 85 };
+    const sd = makeSD('SD-AUDIT-001', 'feature', 95, dims);
+
+    await validateVisionScore(sd, supabase);
+
+    expect(auditInserts.length).toBe(1);
+    expect(auditInserts[0].sd_id).toBe('SD-AUDIT-001');
+    expect(auditInserts[0].verdict).toBe('pass');
+    expect(auditInserts[0].score).toBe(95);
+    expect(auditInserts[0].base_threshold).toBe(90);
+  });
+
+  it('logs gate evaluation on blocked (no score)', async () => {
+    const auditInserts = [];
+    const supabase = makeAuditCapturingSupabase(auditInserts);
+    const sd = makeSD('SD-AUDIT-002', 'infrastructure');
+
+    await validateVisionScore(sd, supabase);
+
+    expect(auditInserts.length).toBe(1);
+    expect(auditInserts[0].verdict).toBe('blocked_no_score');
+    expect(auditInserts[0].score).toBeNull();
+  });
+
+  it('logs floor rule triggered flag', async () => {
+    const auditInserts = [];
+    const supabase = makeAuditCapturingSupabase(auditInserts);
+    const dims = {
+      documentation: 90, knowledge: 85,
+      architecture: 70, scalability: 60, ui_ux: 50,
+    };
+    const sd = makeSD('SD-AUDIT-003', 'documentation', 80, dims);
+
+    await validateVisionScore(sd, supabase);
+
+    expect(auditInserts.length).toBe(1);
+    expect(auditInserts[0].floor_rule_triggered).toBe(true);
+    expect(auditInserts[0].verdict).toBe('human_review_floor_dims');
+  });
+
+  it('audit log contains all required fields', async () => {
+    const auditInserts = [];
+    const supabase = makeAuditCapturingSupabase(auditInserts);
+    const dims = { architecture: 90, reliability: 85, scalability: 80, security: 75 };
+    const sd = makeSD('SD-AUDIT-004', 'infrastructure', 85, dims);
+
+    await validateVisionScore(sd, supabase);
+
+    const log = auditInserts[0];
+    expect(log).toHaveProperty('sd_id');
+    expect(log).toHaveProperty('sd_type');
+    expect(log).toHaveProperty('total_dims');
+    expect(log).toHaveProperty('addressable_count');
+    expect(log).toHaveProperty('base_threshold');
+    expect(log).toHaveProperty('adjusted_threshold');
+    expect(log).toHaveProperty('score');
+    expect(log).toHaveProperty('verdict');
+  });
+
+  it('audit log failure does not block gate result', async () => {
+    const supabase = {
+      from: vi.fn().mockImplementation((table) => {
+        if (table === 'vision_scoring_audit_log') {
+          return { insert: vi.fn().mockRejectedValue(new Error('DB write failed')) };
+        }
+        const obj = { select: () => obj, eq: () => obj, order: () => obj, limit: () => Promise.resolve({ data: [] }) };
+        return obj;
+      }),
+    };
+    const sd = makeSD('SD-AUDIT-005', 'feature', 95, { dim_a: 90 });
+    const result = await validateVisionScore(sd, supabase);
+
+    // Gate should still pass despite audit log failure
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ─── Tests: SD_TYPE_ADDRESSABLE_DIMENSIONS config ───────────────────────────
+
+describe('SD_TYPE_ADDRESSABLE_DIMENSIONS', () => {
+  it('feature type has null (all addressable)', () => {
+    expect(SD_TYPE_ADDRESSABLE_DIMENSIONS.feature).toBeNull();
+  });
+
+  it('infrastructure type has specific patterns', () => {
+    const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS.infrastructure;
+    expect(patterns).toContain('architecture');
+    expect(patterns).toContain('reliability');
+    expect(patterns).toContain('security');
+    expect(patterns).not.toContain('ui');
+    expect(patterns).not.toContain('accessibility');
+  });
+
+  it('documentation type has documentation-relevant patterns', () => {
+    const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS.documentation;
+    expect(patterns).toContain('documentation');
+    expect(patterns).toContain('knowledge');
+    expect(patterns).not.toContain('architecture');
+  });
+});

--- a/tests/unit/vision-score-gate.test.js
+++ b/tests/unit/vision-score-gate.test.js
@@ -211,7 +211,10 @@ describe('validateVisionScore — score meets threshold', () => {
 
     // Should use cached 85, not DB 40
     expect(result.passed).toBe(true);
-    expect(supabase.from).not.toHaveBeenCalled(); // never hit DB
+    // Audit logging may call supabase.from('vision_scoring_audit_log'),
+    // but it should NOT call eva_vision_scores (the score lookup table)
+    const calls = supabase.from.mock.calls.map(c => c[0]);
+    expect(calls).not.toContain('eva_vision_scores');
   });
 });
 


### PR DESCRIPTION
## Summary
- **Dynamic threshold**: `adjusted = base * (addressable_dims / total_dims)` — infrastructure SDs no longer fail on UI/accessibility dimensions they can't address
- **Floor rule**: Min 3 addressable dims for auto-scoring (otherwise human review), min avg score 60 for addressable dims
- **Audit logging**: Every gate evaluation logged with SD ID, total dims, addressable count, adjusted threshold, score, verdict

## Files Changed
- `scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js` — Core gate logic with dynamic threshold, floor rule, audit
- `tests/unit/vision-score-dynamic-threshold.test.js` — 27 new tests
- `tests/unit/vision-score-gate.test.js` — 1 test updated for backward compat
- `database/migrations/20260413_vision_scoring_audit_log.sql` — Audit log table

## Test plan
- [x] 27 new unit tests for dynamic threshold, floor rule, and audit logging
- [x] 27 existing vision score gate tests pass (backward compatibility)
- [x] Migration executed successfully on production database

SD: SD-CONTEXTAWARE-VISION-SCORING-DYNAMIC-ORCH-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)