### PR TITLE
fix(stitch): Flash mode default + quota exhaustion fail-fast

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -554,6 +554,8 @@ export async function generateScreens(projectId, prompts, ventureId) {
   const results = [];
   const apiKey = getApiKey();
   const sdk = await getSDK();
+  const modelId = process.env.STITCH_MODEL_ID || 'GEMINI_3_FLASH';
+  let consecutiveQuotaErrors = 0;
 
   for (let i = 0; i < prompts.length; i++) {
     const rawPrompt = prompts[i];
@@ -579,9 +581,7 @@ export async function generateScreens(projectId, prompts, ventureId) {
         const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
         const project = client.project(projectId);
         try {
-          const screen = deviceType
-            ? await project.generate(promptText, deviceType)
-            : await project.generate(promptText);
+          const screen = await project.generate(promptText, deviceType, modelId);
           const screenId = screen?.id || screen?.screen_id;
           console.info(`[stitch-client] ${attemptLabel} returned directly: ${screenId}`);
           results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType, attempt });
@@ -595,7 +595,15 @@ export async function generateScreens(projectId, prompts, ventureId) {
             results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt });
             succeeded = true; // socket drop = server processing, count as success
             recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: attempt, durationMs: Date.now() - attemptStart });
+          } else if (/resource has been exhausted|check quota/i.test(msg)) {
+            // Quota exhaustion is permanent for the day — do not retry
+            console.error(`[stitch-client] ${attemptLabel} QUOTA EXHAUSTED: ${msg.slice(0, 120)}`);
+            results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
+            recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'quota_exhausted', errorMessage: msg.slice(0, 500) });
+            consecutiveQuotaErrors++;
+            succeeded = true; // break retry loop — retrying won't help
           } else if (attempt < MAX_RETRIES) {
+            consecutiveQuotaErrors = 0;
             console.warn(`[stitch-client] ${attemptLabel} failed: ${msg.slice(0, 120)} — retrying in ${SCREEN_DELAY_MS / 1000}s`);
             recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });
             await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
@@ -613,6 +621,17 @@ export async function generateScreens(projectId, prompts, ventureId) {
           recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'unexpected', errorMessage: outerErr.message?.slice(0, 500) });
         }
       }
+    }
+
+    // Fail-fast: abort remaining screens after 2 consecutive quota errors
+    if (consecutiveQuotaErrors >= 2) {
+      console.error(`[stitch-client] Aborting: ${consecutiveQuotaErrors} consecutive quota errors — daily credits exhausted`);
+      for (let j = i + 1; j < prompts.length; j++) {
+        const skippedPrompt = prompts[j];
+        const skippedText = typeof skippedPrompt === 'string' ? skippedPrompt : skippedPrompt.text;
+        results.push({ prompt: (skippedText || '').slice(0, 60), status: 'skipped_quota', error: 'Daily credits exhausted — skipped', deviceType: typeof skippedPrompt === 'object' ? skippedPrompt.deviceType : undefined });
+      }
+      break;
     }
 
     // Uniform delay between screens


### PR DESCRIPTION
## Summary
- Switch default Stitch model from unspecified (Pro) to `GEMINI_3_FLASH` — lower credit cost per generation
- Detect quota exhaustion as non-transient error — no retries on "Resource has been exhausted"
- Fail-fast: abort remaining screens after 2 consecutive quota errors instead of burning through all 16 prompts

## Context
RCA from GuardianCode venture pipeline run: 32 API calls wasted on exhausted daily quota (400 credits/day, resets midnight UTC). All returned same error in <2s. With this fix: max 2 calls, then skip.

Model overridable via `STITCH_MODEL_ID` env var if Pro is needed.

## Test plan
- [ ] Verify GEMINI_3_FLASH is passed to `project.generate()`
- [ ] Verify quota errors skip retry loop
- [ ] Verify fail-fast triggers after 2 consecutive quota errors
- [ ] Re-test with GuardianCode venture after daily credit reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)