### PR TITLE
fix(stitch): parse screen_id from SDK name field in listScreens

### DIFF
--- a/.claude/.protocol-sync
+++ b/.claude/.protocol-sync
@@ -1,1 +1,1 @@
-{"timestamp":"2026-03-31T23:50:16.046Z","pid":62884,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}
+{"timestamp":"2026-04-13T18:04:36.782Z","pid":57072,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}

--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,12 @@
 {
-  "isActive": true,
+  "isActive": false,
   "wasInterrupted": false,
-  "currentSd": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-092",
-  "currentPhase": "EXEC",
-  "currentTask": "Implementing Resolve 5 operational patterns from /learn analysis",
+  "currentSd": null,
+  "currentPhase": null,
+  "currentTask": null,
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-04-04T23:11:07.416Z",
-  "lastUpdatedAt": "2026-04-13T18:59:08.696Z"
+  "clearedAt": "2026-04-13T17:54:31.100Z"
 }

--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -787,12 +787,22 @@ export async function listScreens(projectId) {
     if (!Array.isArray(screens)) {
       throw new StitchValidationError('listScreens: expected array of screens');
     }
-    return screens.map(s => ({
-      screen_id: s.id || s.screen_id,
-      name: s.name,
-      dimensions: s.dimensions || null,
-      created_at: s.created_at || null,
-    }));
+    return screens.map(s => {
+      // SDK returns screen ID in different shapes depending on the method:
+      //   - s.id or s.screen_id (from generate/edit)
+      //   - s.name = "projects/{pid}/screens/{sid}" (from list_screens MCP tool)
+      const nameId = typeof s.name === 'string' && s.name.includes('/screens/')
+        ? s.name.split('/screens/')[1]
+        : undefined;
+      return {
+        screen_id: s.id || s.screen_id || s.screenId || nameId,
+        name: s.name,
+        title: s.title || s.displayName,
+        device_type: s.deviceType,
+        dimensions: s.dimensions || (s.width && s.height ? { width: s.width, height: s.height } : null),
+        created_at: s.created_at || null,
+      };
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Fix `listScreens` to parse screen ID from SDK's `name` resource path (`projects/{pid}/screens/{sid}`)
- Previous code read `s.id || s.screen_id` which was always undefined from the `list_screens` MCP tool
- This caused the exporter to produce 0 files and QA to report "manifest contained zero screens"

## Root Cause
SDK's `list_screens` returns `name: "projects/xxx/screens/yyy"` but not `id` or `screen_id` as separate fields. Our wrapper didn't parse the name path.

## Test plan
- [x] Verified `listScreens('4780046920644727710')` now returns valid screen_ids
- [ ] Re-run Confirm and Export Designs on GuardianCode at S17

🤖 Generated with [Claude Code](https://claude.com/claude-code)