### PR TITLE
fix(stitch): fetch PNG binary from download URL in exportScreenImage

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -710,11 +710,12 @@ export async function exportScreenHtml(screenId, projectId) {
 }
 
 /**
- * Export a screen as PNG image (returns download URL).
+ * Export a screen as PNG image (returns Buffer of PNG data).
+ * The SDK returns a download URL; this function fetches the binary.
  * @param {string} screenId - Screen ID to export
  * @param {Object} [options] - Export options
  * @param {string} options.projectId - Project ID (required)
- * @returns {Promise<string>} Image download URL
+ * @returns {Promise<Buffer>} PNG image binary data
  */
 export async function exportScreenImage(screenId, options = {}) {
   const apiKey = getApiKey();
@@ -723,11 +724,17 @@ export async function exportScreenImage(screenId, options = {}) {
   try {
     const project = client.project(options.projectId);
     const screen = await project.getScreen(screenId);
-    const result = await screen.getImage();
-    if (typeof result !== 'string') {
-      throw new StitchValidationError('exportScreenImage: expected URL string');
+    const url = await screen.getImage();
+    if (typeof url !== 'string') {
+      throw new StitchValidationError('exportScreenImage: expected URL string from SDK');
     }
-    return result;
+    // SDK returns a download URL — fetch the actual binary
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new StitchValidationError(`exportScreenImage: fetch failed (${response.status})`);
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
   } finally {
     try { await client.close(); } catch { /* ignore */ }
   }


### PR DESCRIPTION
## Summary
- `exportScreenImage` now fetches the actual PNG binary from the download URL instead of returning the URL string
- Previous behavior: SDK returns URL → stored as "buffer" → failed PNG magic validation → 0 PNGs exported
- New behavior: SDK returns URL → fetch binary → return Buffer → valid PNG data

## Root Cause
SDK's `getImage()` returns a Google CDN download URL, not binary. The exporter assumed Buffer, validator checked PNG magic bytes on a URL string, and silently dropped every PNG.

## Test plan
- [x] Verified `exportScreenImage` returns Buffer with valid PNG magic bytes (35KB)
- [ ] Re-run Confirm and Export Designs — should produce 15 PNGs + 15 HTMLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)