### PR TITLE
fix(stitch): route QA vision model through LLM router + strip JSON fences

### DIFF
--- a/lib/config/model-config.js
+++ b/lib/config/model-config.js
@@ -42,6 +42,7 @@ const MODEL_DEFAULTS = {
     classification: 'claude-haiku-4-5-20251001',
     generation: 'claude-opus-4-6',
     fast: 'claude-haiku-4-5-20251001',
+    vision: 'claude-haiku-4-5-20251001',
   },
   google: {
     validation: 'gemini-2.5-pro',
@@ -70,6 +71,7 @@ const ENV_VARS = {
     classification: 'CLAUDE_MODEL_CLASSIFICATION',
     generation: 'CLAUDE_MODEL_GENERATION',
     fast: 'CLAUDE_MODEL_FAST',
+    vision: 'CLAUDE_MODEL_VISION',
   },
   google: {
     default: 'GEMINI_MODEL',
@@ -148,9 +150,8 @@ function getOpenAIModel(purpose = 'validation') {
  * const model = getClaudeModel('generation'); // 'claude-opus-4-6' or env override
  */
 function getClaudeModel(purpose = 'validation') {
-  const validClaudePurposes = VALID_PURPOSES.filter(p => p !== 'vision');
-  if (!validClaudePurposes.includes(purpose)) {
-    throw new Error(`Invalid purpose: ${purpose}. Valid Claude purposes: ${validClaudePurposes.join(', ')}`);
+  if (!VALID_PURPOSES.includes(purpose)) {
+    throw new Error(`Invalid purpose: ${purpose}. Valid purposes: ${VALID_PURPOSES.join(', ')}`);
   }
 
   // Check purpose-specific env var first
@@ -218,6 +219,7 @@ function getAllModels() {
       classification: getClaudeModel('classification'),
       generation: getClaudeModel('generation'),
       fast: getClaudeModel('fast'),
+      vision: getClaudeModel('vision'),
     },
     google: {
       validation: getGoogleModel('validation'),

--- a/lib/eva/qa/stitch-vision-qa.js
+++ b/lib/eva/qa/stitch-vision-qa.js
@@ -32,17 +32,18 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@supabase/supabase-js';
+import { getClaudeModel } from '../../config/model-config.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
-const ANTHROPIC_MODEL = 'claude-3-5-haiku-latest';
+const ANTHROPIC_MODEL = getClaudeModel('vision');
 const DEFAULT_DAILY_BUDGET_USD = 0.50;
 const APPROX_TOKENS_PER_IMAGE = 1500;
 const APPROX_OUTPUT_TOKENS_PER_SCREEN = 400;
 const CLAUDE_HAIKU_PRICING = {
-  input_per_million: 0.80,    // claude-3-5-haiku-latest as of 2026-04
+  input_per_million: 0.80,    // claude-haiku-4-5 pricing (via model-config.js vision purpose)
   output_per_million: 4.00,
 };
 
@@ -221,7 +222,11 @@ async function reviewSingleScreen(client, screenId, base64Image) {
 
   let parsed;
   try {
-    parsed = JSON.parse(textBlock.text.trim());
+    // Strip markdown code fences if present (```json ... ```)
+    let raw = textBlock.text.trim();
+    const fenceMatch = raw.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
+    if (fenceMatch) raw = fenceMatch[1].trim();
+    parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(`Vision API returned non-JSON for screen ${screenId}: ${err.message}`);
   }


### PR DESCRIPTION
## Summary
- Route QA vision model through centralized `model-config.js` router instead of hardcoded `claude-3-5-haiku-latest` (404)
- Add `vision` purpose to Claude config: `claude-haiku-4-5-20251001`, overridable via `CLAUDE_MODEL_VISION`
- Strip markdown code fences from Haiku responses before JSON parsing

## Tested
- 15/15 screens reviewed successfully, 0 parse failures, $0.03 cost
- Model resolves correctly via `getClaudeModel('vision')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)