### PR TITLE
fix(stitch): include in-memory entries in export manifest file counts

### DIFF
--- a/lib/eva/bridge/stitch-exporter.js
+++ b/lib/eva/bridge/stitch-exporter.js
@@ -513,13 +513,19 @@ export async function exportStitchArtifacts(ventureId, projectId, outputDir, opt
     manifestFiles.push({ type: 'design_md', path: 'DESIGN.md', size: Buffer.byteLength(designMd) });
   }
 
+  // Count both filesystem files and in-memory entries for accurate totals
+  const inMemoryFileCount = htmlEntries.length + pngEntries.length + (designMd ? 1 : 0);
+  const inMemorySize = htmlEntries.reduce((sum, h) => sum + Buffer.byteLength(h.html || '', 'utf-8'), 0)
+    + pngEntries.reduce((sum, p) => sum + (p.buffer?.length || 0), 0)
+    + (designMd ? Buffer.byteLength(designMd, 'utf-8') : 0);
+
   const manifest = {
     venture_id: ventureId,
     project_id: projectId,
     screen_count: screens.length,
     exported_at: new Date().toISOString(),
-    total_files: manifestFiles.length,
-    total_size: manifestFiles.reduce((sum, f) => sum + (f.size || 0), 0),
+    total_files: manifestFiles.length || inMemoryFileCount,
+    total_size: manifestFiles.reduce((sum, f) => sum + (f.size || 0), 0) || inMemorySize,
     files: manifestFiles,
     export_errors: exportErrors,
   };


### PR DESCRIPTION
## Summary
- Fix manifest `total_files` and `total_size` showing 0 when persisting to venture_artifacts
- Falls back to counting in-memory htmlEntries + pngEntries + designMd when no filesystem files

🤖 Generated with [Claude Code](https://claude.com/claude-code)