### PR TITLE
feat(S19): add /api/stitch/seed-repo endpoint + fix isMainModule

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -854,7 +854,8 @@ ${screen.micro_animations ? `- Add micro-animations (designed for this screen's 
 }
 
 // CLI entry point
-if (isMainModule(import.meta.url)) {
+const _isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (_isMain) {
   const args = process.argv.slice(2);
   const cmd = args[0];
   const ventureId = args[1];

--- a/server/routes/stitch.js
+++ b/server/routes/stitch.js
@@ -163,4 +163,25 @@ router.get('/metrics', asyncHandler(async (_req, res) => {
   res.json({ fleet, degraded_ventures: degraded });
 }));
 
+/**
+ * POST /api/stitch/seed-repo
+ * Seeds a GitHub repo with venture docs for Replit Agent build.
+ * Body: { ventureId, repoUrl }
+ */
+router.post('/seed-repo', asyncHandler(async (req, res) => {
+  const { ventureId, repoUrl } = req.body;
+  if (!ventureId || !repoUrl) {
+    return res.status(400).json({ error: 'ventureId and repoUrl are required' });
+  }
+
+  try {
+    const { seedRepo } = await import('../../lib/eva/bridge/replit-repo-seeder.js');
+    const result = await seedRepo(ventureId, repoUrl);
+    res.json(result);
+  } catch (err) {
+    console.error('[stitch-route] seed-repo failed:', err);
+    res.status(500).json({ error: err.message, code: 'SEED_FAILED' });
+  }
+}));
+
 export default router;


### PR DESCRIPTION
## Summary
- Add `POST /api/stitch/seed-repo` endpoint to push venture docs to GitHub repos for Replit builds
- Fix broken `isMainModule` reference in replit-repo-seeder.js CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)