### PR TITLE
feat(S19): add app_type selector to sprint spec generation

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -14,14 +14,46 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { resolveTargetApplication } from '../../bridge/sd-router.js';
+import { inferDeviceType } from '../../bridge/stitch-device-type-resolver.js';
 
 // NOTE: These constants intentionally duplicated from stage-19.js
 // to avoid circular dependency — stage-19.js imports analyzeStage19 from this file,
 // and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
+const APP_TYPE_VALUES = ['mobile', 'web', 'desktop', 'tablet', 'agnostic'];
 const ARCHITECTURE_LAYERS = ['frontend', 'backend', 'database', 'infrastructure', 'integration', 'security'];
 const MIN_SPRINT_ITEMS = 1;
+
+/**
+ * Resolve dominant app type from Stage 15 wireframe screen data.
+ * Uses majority vote of inferDeviceType() across screens.
+ * Returns 'agnostic' when no data available.
+ *
+ * @param {Object} [stage15Data] - Stage 15 wireframe data
+ * @returns {string} One of APP_TYPE_VALUES
+ */
+function resolveAppType(stage15Data) {
+  if (!stage15Data) return 'agnostic';
+
+  const screens = stage15Data.screens || stage15Data.wireframes || [];
+  if (!Array.isArray(screens) || screens.length === 0) return 'agnostic';
+
+  const counts = {};
+  for (const screen of screens) {
+    const deviceType = inferDeviceType(screen).toLowerCase();
+    // Map Stitch device types to app_type values
+    const appType = deviceType === 'desktop' ? 'web' : deviceType;
+    counts[appType] = (counts[appType] || 0) + 1;
+  }
+
+  // Return majority vote, excluding 'agnostic' unless it's the only type
+  const sorted = Object.entries(counts)
+    .filter(([type]) => type !== 'agnostic')
+    .sort((a, b) => b[1] - a[1]);
+
+  return sorted.length > 0 ? sorted[0][0] : 'agnostic';
+}
 
 const SYSTEM_PROMPT = `You are EVA's Sprint Planning Engine. Generate a sprint plan with actionable items that bridge to the LEO Protocol SD system.
 
@@ -62,11 +94,12 @@ Rules:
  * @param {Object} [params.stage17Data] - Blueprint review (quality scores, gap analysis)
  * @param {Object} [params.stage13Data] - Product roadmap
  * @param {Object} [params.stage14Data] - Technical architecture
+ * @param {Object} [params.stage15Data] - Wireframe data (screens with device type info)
  * @param {string} [params.ventureName]
  * @param {number} [params.sprintIteration=0] - Current sprint iteration number (0 = first sprint)
  * @returns {Promise<Object>} Sprint plan with SD bridge items
  */
-export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, stage14Data, ventureName, sprintIteration = 0, logger = console }) {
+export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, stage14Data, stage15Data, ventureName, sprintIteration = 0, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage19] Starting sprint planning analysis', { ventureName, sprintIteration });
   if (!stage18Data) {
@@ -137,10 +170,15 @@ export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, st
       ].filter(Boolean).join('\n')}`
     : '';
 
+  const platformContext = appType !== 'agnostic'
+    ? `Platform Target: ${appType} (derived from wireframe analysis — prioritize ${appType}-appropriate UI patterns and frameworks)`
+    : '';
+
   const userPrompt = `Generate a sprint plan for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
 ${sprintIterationContext}
+${platformContext}
 ${ventureContextStr}
 ${buildBriefContext}
 ${readinessContext}
@@ -213,6 +251,12 @@ Output ONLY valid JSON.`;
   // Resolve venture routing from registry (replaces hardcoded 'ehg')
   const routing = resolveTargetApplication(ventureName, { logger });
 
+  // Resolve dominant app type from Stage 15 wireframe data
+  const appType = resolveAppType(stage15Data);
+  if (appType !== 'agnostic') {
+    logger.log('[Stage19] App type resolved from Stage 15 wireframes', { appType });
+  }
+
   // Transform sprint items to match template schema
   const items = sprintItems.map(item => ({
     title: item.title,
@@ -225,6 +269,7 @@ Output ONLY valid JSON.`;
     risks: [],
     target_application: routing.targetApp,
     story_points: typeof item.estimatedLoc === 'number' ? Math.ceil(item.estimatedLoc / 50) : 3,
+    app_type: appType,
     architectureLayer: item.architectureLayer,
     milestoneRef: item.milestoneRef,
   }));
@@ -244,6 +289,7 @@ Output ONLY valid JSON.`;
     dependencies: item.dependencies,
     risks: item.risks,
     target_application: item.target_application,
+    app_type: item.app_type,
   }));
 
   logger.log('[Stage19] Analysis complete', { duration: Date.now() - startTime });
@@ -255,6 +301,7 @@ Output ONLY valid JSON.`;
     total_items,
     total_story_points,
     sd_bridge_payloads,
+    app_type: appType,
     llmFallbackCount,
     hasValueFeature,
     sprintIteration,
@@ -263,4 +310,4 @@ Output ONLY valid JSON.`;
 }
 
 
-export { PRIORITY_VALUES, SD_TYPES, ARCHITECTURE_LAYERS, MIN_SPRINT_ITEMS };
+export { PRIORITY_VALUES, SD_TYPES, APP_TYPE_VALUES, ARCHITECTURE_LAYERS, MIN_SPRINT_ITEMS, resolveAppType };

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -18,6 +18,7 @@ import { analyzeStage19 } from './analysis-steps/stage-19-sprint-planning.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
+const APP_TYPE_VALUES = ['mobile', 'web', 'desktop', 'tablet', 'agnostic'];
 const MIN_SPRINT_ITEMS = 1;
 const MIN_SPRINT_DURATION_DAYS = 1;
 const MAX_SPRINT_DURATION_DAYS = 30;
@@ -50,6 +51,7 @@ const TEMPLATE = {
         risks: { type: 'array' },
         target_application: { type: 'string', required: true },
         story_points: { type: 'number', min: 1 },
+        app_type: { type: 'enum', values: APP_TYPE_VALUES },
         architectureLayer: { type: 'string' },
         milestoneRef: { type: 'string' },
       },
@@ -101,6 +103,9 @@ const TEMPLATE = {
           validateString(item?.success_criteria, `${prefix}.success_criteria`, 1),
           validateString(item?.target_application, `${prefix}.target_application`, 1),
         ];
+        if (item?.app_type != null) {
+          results.push(validateEnum(item.app_type, `${prefix}.app_type`, APP_TYPE_VALUES));
+        }
         if (item?.architectureLayer != null) {
           results.push(validateString(item.architectureLayer, `${prefix}.architectureLayer`, 1));
         }
@@ -127,5 +132,5 @@ TEMPLATE.analysisStep = analyzeStage19;
 
 ensureOutputSchema(TEMPLATE);
 
-export { PRIORITY_VALUES, SD_TYPES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS, MIN_SPRINT_DURATION_DAYS, MAX_SPRINT_DURATION_DAYS };
+export { PRIORITY_VALUES, SD_TYPES, APP_TYPE_VALUES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS, MIN_SPRINT_DURATION_DAYS, MAX_SPRINT_DURATION_DAYS };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/stage-19-app-type.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-app-type.test.js
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for Stage 19 app_type feature
+ * SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-A
+ *
+ * Tests app_type field in schema, resolveAppType from Stage 15 data,
+ * and app_type propagation to sprint items and SD bridge payloads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import stage19, { APP_TYPE_VALUES } from '../../../../lib/eva/stage-templates/stage-19.js';
+
+describe('Stage 19 - app_type feature', () => {
+  describe('APP_TYPE_VALUES constant', () => {
+    it('should export APP_TYPE_VALUES with all expected values', () => {
+      expect(APP_TYPE_VALUES).toEqual(['mobile', 'web', 'desktop', 'tablet', 'agnostic']);
+    });
+  });
+
+  describe('Schema definition', () => {
+    it('should include app_type in item schema', () => {
+      const itemSchema = stage19.schema.items.items;
+      expect(itemSchema.app_type).toBeDefined();
+      expect(itemSchema.app_type.type).toBe('enum');
+      expect(itemSchema.app_type.values).toEqual(APP_TYPE_VALUES);
+    });
+
+    it('should not require app_type (optional field)', () => {
+      const itemSchema = stage19.schema.items.items;
+      expect(itemSchema.app_type.required).toBeUndefined();
+    });
+  });
+
+  describe('Validation', () => {
+    const validData = {
+      sprint_name: 'Sprint 2026-04-14',
+      sprint_duration_days: 14,
+      sprint_goal: 'Complete initial build sprint',
+      items: [{
+        title: 'Build landing page',
+        description: 'Create main landing page',
+        priority: 'high',
+        type: 'feature',
+        scope: 'frontend',
+        success_criteria: 'Page renders correctly',
+        target_application: 'ehg',
+        app_type: 'mobile',
+      }],
+    };
+
+    it('should pass validation with valid app_type', () => {
+      const result = stage19.validate(validData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass validation without app_type (optional)', () => {
+      const data = { ...validData, items: [{ ...validData.items[0] }] };
+      delete data.items[0].app_type;
+      const result = stage19.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail validation with invalid app_type', () => {
+      const data = {
+        ...validData,
+        items: [{ ...validData.items[0], app_type: 'invalid_type' }],
+      };
+      const result = stage19.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('app_type'))).toBe(true);
+    });
+
+    for (const validType of APP_TYPE_VALUES) {
+      it(`should accept app_type="${validType}"`, () => {
+        const data = {
+          ...validData,
+          items: [{ ...validData.items[0], app_type: validType }],
+        };
+        const result = stage19.validate(data, { logger: { warn: () => {} } });
+        expect(result.valid).toBe(true);
+      });
+    }
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-19-resolve-app-type.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-resolve-app-type.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for resolveAppType in Stage 19 Sprint Planning
+ * SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-A
+ *
+ * Tests the majority-vote device type resolution from Stage 15 wireframe data.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveAppType, APP_TYPE_VALUES } from '../../../../lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js';
+
+describe('resolveAppType', () => {
+  it('should return agnostic when no stage15Data', () => {
+    expect(resolveAppType(null)).toBe('agnostic');
+    expect(resolveAppType(undefined)).toBe('agnostic');
+  });
+
+  it('should return agnostic when screens array is empty', () => {
+    expect(resolveAppType({ screens: [] })).toBe('agnostic');
+  });
+
+  it('should return agnostic when no screens property', () => {
+    expect(resolveAppType({})).toBe('agnostic');
+  });
+
+  it('should return mobile for mobile-dominant screens', () => {
+    const stage15Data = {
+      screens: [
+        { name: 'Mobile App Home', purpose: 'Main app screen for phone' },
+        { name: 'Mobile Settings', purpose: 'App settings on phone' },
+        { name: 'Dashboard', purpose: 'Admin dashboard' },
+      ],
+    };
+    expect(resolveAppType(stage15Data)).toBe('mobile');
+  });
+
+  it('should return web for desktop-dominant screens (desktop maps to web)', () => {
+    const stage15Data = {
+      screens: [
+        { name: 'Admin Dashboard', purpose: 'Admin management panel' },
+        { name: 'Analytics Dashboard', purpose: 'Reporting and analytics' },
+        { name: 'Mobile App', purpose: 'Mobile app screen' },
+      ],
+    };
+    expect(resolveAppType(stage15Data)).toBe('web');
+  });
+
+  it('should return tablet for tablet-dominant screens', () => {
+    const stage15Data = {
+      screens: [
+        { name: 'iPad Main View', purpose: 'Tablet primary view' },
+        { name: 'Tablet Split View', purpose: 'Split view for tablet' },
+      ],
+    };
+    expect(resolveAppType(stage15Data)).toBe('tablet');
+  });
+
+  it('should return agnostic when all screens are agnostic', () => {
+    const stage15Data = {
+      screens: [
+        { name: 'Page One', purpose: 'Generic page' },
+        { name: 'Page Two', purpose: 'Another page' },
+      ],
+    };
+    expect(resolveAppType(stage15Data)).toBe('agnostic');
+  });
+
+  it('should handle wireframes key as alternative to screens', () => {
+    const stage15Data = {
+      wireframes: [
+        { name: 'Mobile Login', purpose: 'Phone login screen' },
+      ],
+    };
+    expect(resolveAppType(stage15Data)).toBe('mobile');
+  });
+
+  it('should handle string screen specs', () => {
+    const stage15Data = {
+      screens: ['mobile app home', 'mobile settings'],
+    };
+    expect(resolveAppType(stage15Data)).toBe('mobile');
+  });
+
+  it('should return a valid APP_TYPE_VALUES value', () => {
+    const testCases = [
+      null,
+      {},
+      { screens: [] },
+      { screens: [{ name: 'Mobile App' }] },
+      { screens: [{ name: 'Dashboard' }] },
+    ];
+    for (const data of testCases) {
+      const result = resolveAppType(data);
+      expect(APP_TYPE_VALUES).toContain(result);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `app_type` field (mobile/web/desktop/tablet/agnostic) to Stage 19 sprint spec generation
- Leverage existing Stage 15 device-type inference (`inferDeviceType`) via majority vote across wireframe screens
- Include `app_type` in sprint items, SD bridge payloads, and LLM platform context
- Backward compatible: defaults to `agnostic` when no Stage 15 data available

## Changes
- `lib/eva/stage-templates/stage-19.js`: Schema + validation for `app_type` enum
- `lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js`: `resolveAppType` helper, modified `analyzeStage19` signature, output integration
- 2 new test files (21 tests passing)

## Test plan
- [x] 21 unit tests covering schema validation and resolveAppType
- [x] All enum values validated (mobile, web, desktop, tablet, agnostic)
- [x] Edge cases: null data, empty screens, string specs, wireframes key
- [x] Existing stage-19 tests unchanged (pre-existing failures confirmed on main)

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)