### PR TITLE
feat(pipeline): strengthen design file references in prompt templates

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,12 +1,13 @@
 {
-  "isActive": false,
+  "isActive": true,
   "wasInterrupted": false,
-  "currentSd": null,
-  "currentPhase": null,
-  "currentTask": null,
+  "currentSd": "SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C",
+  "currentPhase": "EXEC",
+  "currentTask": "Implementing Strengthen Design File References in Pipeline Prompt Templates",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-04-13T17:54:31.100Z"
+  "clearedAt": "2026-04-13T17:54:31.100Z",
+  "lastUpdatedAt": "2026-04-14T11:11:40.899Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-092",
-  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-092",
-  "createdAt": "2026-04-13T18:54:28.592Z",
+  "sdKey": "SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C",
+  "expectedBranch": "feat/SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C",
+  "createdAt": "2026-04-14T10:52:09.658Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -765,6 +765,8 @@ export function formatWireframePrompts(groups, venture, summary) {
 
     lines.push('**Instructions:**');
     lines.push('- Refer to replit.md for branding (colors, typography, product name)');
+    lines.push('- Refer to `docs/wireframes.md` for full wireframe specifications and screen flow');
+    lines.push('- If available, refer to `docs/stitch/DESIGN.md` for design tokens and component specs');
     lines.push('- Match the wireframe layout as closely as possible');
     lines.push('- Implement all interactive elements shown in the wireframe');
     lines.push('- Ensure responsive design (mobile-first)');

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -268,6 +268,28 @@ export async function formatReplitPrompt(ventureId, options = {}) {
     }
   }
 
+  // Design References — surface available design artifacts for Replit builders
+  const designGroup = groups.find(g => g.group_key === 'visual_convergence' || g.group_key === 'design_intelligence');
+  const stitchGroup = groups.find(g => g.group_key === 'how_to_build_it');
+  const hasDesignArtifacts = designGroup?.artifacts?.length > 0;
+  const hasStitchExport = stitchGroup?.artifacts?.some(a =>
+    a.artifact_type === 'stitch_design_export' || a.title?.toLowerCase().includes('design')
+  );
+
+  if (hasDesignArtifacts || hasStitchExport) {
+    sections.push('---');
+    sections.push('## Design References');
+    sections.push('');
+    sections.push('Use these design documents to guide your implementation:');
+    if (hasDesignArtifacts) {
+      sections.push('- `docs/wireframes.md` — Wireframe layouts and screen flow');
+    }
+    if (hasStitchExport) {
+      sections.push('- `docs/stitch/DESIGN.md` — Design tokens, colors, typography, and component specs');
+    }
+    sections.push('');
+  }
+
   const prompt = sections.join('\n');
   const charCount = prompt.length;
 

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -37,7 +37,11 @@ You MUST output valid JSON with exactly this structure:
       "estimatedLoc": 150,
       "acceptanceCriteria": "How to verify this item is done",
       "architectureLayer": "frontend|backend|database|infrastructure|integration|security",
-      "milestoneRef": "Which roadmap milestone this supports"
+      "milestoneRef": "Which roadmap milestone this supports",
+      "designReference": {
+        "wireframeName": "Name of the wireframe screen this item implements (from Stage 17 blueprint, or null)",
+        "designLayer": "Which design layer applies: layout|branding|interaction|content"
+      }
     }
   ]
 }
@@ -51,6 +55,7 @@ Rules:
 - Sprint goal should be specific and measurable
 - Items should be ordered by priority (critical first)
 - Each item should be independently deliverable
+- designReference: If wireframe screens are available from the blueprint review (Stage 17), map each sprint item to the most relevant wireframe screen name and design layer. Set wireframeName to null if no wireframe applies.
 - CRITICAL: At least one sprint item MUST have type "feature" that delivers core user-facing value. Infrastructure, refactoring, and bugfix items are important but a sprint with ONLY non-feature items fails to advance the venture toward its product goal.
 - MANDATORY: Include a sprint item for a user-facing landing page or demo page that stakeholders can review. This artifact is required to pass the Stage 20 stakeholder review gate. The item should produce an accessible URL (e.g., /index.html, /demo, or /) that demonstrates the venture's core value proposition.`;
 


### PR DESCRIPTION
## Summary
- Add `designReference` field (wireframeName, designLayer) to S19 sprint item schema so Replit builders know which wireframe each item maps to
- Add Design References section to replit-prompt-formatter.js that surfaces wireframe and stitch design paths when artifacts exist
- Add `docs/wireframes.md` and `docs/stitch/DESIGN.md` references to wireframe build instructions

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C

## Test plan
- [x] 49 existing tests pass (replit-format-strategies, replit-prompt-formatter)
- [x] Changes are additive — no breaking changes to existing prompt generation
- [x] Design References section only appears when design artifacts exist (conditional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)