### PR TITLE
fix(worktree): detect orphaned worktrees via git registration check

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -59,7 +59,23 @@ function getRepoRoot(override) {
 function isValidWorktree(wtPath) {
   if (!fs.existsSync(wtPath)) return false;
   try {
+    // Check git recognizes this as a work tree
     execSync('git rev-parse --is-inside-work-tree', { cwd: wtPath, encoding: 'utf8', stdio: 'pipe' });
+
+    // Verify it's a *registered* git worktree, not just a directory inside
+    // the main repo. After branch deletion or git worktree prune, the directory
+    // may still exist but git no longer tracks it, causing module resolution
+    // failures when scripts run from the orphaned directory.
+    const absPath = path.resolve(wtPath).replace(/\\/g, '/');
+    const listed = execSync('git worktree list --porcelain', { encoding: 'utf8', stdio: 'pipe' });
+    const registeredPaths = listed
+      .split('\n')
+      .filter(l => l.startsWith('worktree '))
+      .map(l => l.replace('worktree ', '').trim().replace(/\\/g, '/'));
+    if (!registeredPaths.some(rp => absPath === rp.replace(/\\/g, '/'))) {
+      return false; // Directory exists but is not a registered worktree
+    }
+
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Fix `isValidWorktree()` in `resolve-sd-workdir.js` to verify directories are registered git worktrees
- Previously, orphaned worktree directories (after branch merge + deletion) passed validation because `git rev-parse --is-inside-work-tree` falls back to the main repo
- Now checks `git worktree list --porcelain` to confirm the directory is properly registered
- Prevents module resolution failures when scripts run from orphaned worktree directories

## Root Cause
After a PR is squash-merged and the remote branch deleted, `git worktree prune` removes the worktree registration but the physical directory remains. Scripts running from this orphaned directory can't find modules like `lib/supabase-client.js` because git treats the directory as part of the main repo but the filesystem is incomplete.

## Test plan
- [x] Verified orphaned worktree correctly returns `false` from `isValidWorktree()`
- [x] Verified registered worktrees still return `true`
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)