### PR TITLE
feat(replit): add acceptance criteria to sprint item prompts

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -312,6 +312,7 @@ function extractSprintItems(groups) {
           description: item.description || item.scope || '',
           storyPoints: item.story_points || item.points || 0,
           priority: item.priority || 'medium',
+          acceptanceCriteria: item.success_criteria || item.acceptanceCriteria || item.acceptance_criteria || '',
         });
       }
     }
@@ -579,6 +580,7 @@ export function formatPlanModePrompt(groups, venture, summary) {
       const descText = item.description ? ` — ${item.description}` : '';
       const line = `${i + 1}. ${item.name} (${item.storyPoints} pts)${descText}`;
       lines.push(line);
+      if (item.acceptanceCriteria) lines.push(`   Done when: ${item.acceptanceCriteria}`);
     }
     lines.push('');
   }
@@ -660,6 +662,13 @@ export function formatFeaturePrompts(groups, venture, summary) {
     // Story points and priority
     lines.push(`**Story Points**: ${item.storyPoints} | **Priority**: ${item.priority}`);
     lines.push('');
+
+    // Acceptance criteria (from S19 sprint planning)
+    if (item.acceptanceCriteria) {
+      lines.push('### Acceptance Criteria');
+      lines.push(item.acceptanceCriteria);
+      lines.push('');
+    }
 
     // Build order context
     if (items.length > 1) {

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -262,6 +262,8 @@ export async function formatReplitPrompt(ventureId, options = {}) {
           const points = item.story_points || item.points || '?';
           sections.push(`${i + 1}. **${name}** (${points} pts)`);
           if (desc) sections.push(`   ${desc}`);
+          const ac = item.success_criteria || item.acceptanceCriteria || item.acceptance_criteria || '';
+          if (ac) sections.push(`   **Done when**: ${ac}`);
           sections.push('');
         }
       }

--- a/tests/unit/eva/bridge/acceptance-criteria-in-prompts.test.js
+++ b/tests/unit/eva/bridge/acceptance-criteria-in-prompts.test.js
@@ -1,0 +1,77 @@
+/**
+ * Tests for acceptance criteria in Replit prompt surfaces
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-D
+ */
+import { describe, it, expect } from 'vitest';
+import { formatFeaturePrompts, formatPlanModePrompt } from '../../../../lib/eva/bridge/replit-format-strategies.js';
+
+const makeGroups = (items) => [{
+  group_key: 'sprint_plan',
+  group_name: 'Sprint Plan',
+  artifacts: [{
+    content: JSON.stringify({ items }),
+    title: 'Sprint Items',
+    artifact_type: 'sprint_plan',
+    lifecycle_stage: 19,
+  }],
+}];
+
+const venture = { name: 'TestVenture', description: 'Test' };
+const summary = { total_groups: 1, venture_name: 'TestVenture' };
+
+describe('Acceptance criteria in Replit prompts', () => {
+  const itemWithAC = {
+    name: 'User Dashboard',
+    description: 'Build the main dashboard',
+    story_points: 5,
+    priority: 'high',
+    success_criteria: 'Dashboard loads in <2s and shows user stats',
+  };
+
+  const itemWithoutAC = {
+    name: 'Setup CI/CD',
+    description: 'Configure pipeline',
+    story_points: 3,
+    priority: 'medium',
+  };
+
+  describe('formatFeaturePrompts', () => {
+    it('includes acceptance criteria section when present', () => {
+      const groups = makeGroups([itemWithAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].content).toContain('### Acceptance Criteria');
+      expect(prompts[0].content).toContain('Dashboard loads in <2s');
+    });
+
+    it('omits acceptance criteria section when missing', () => {
+      const groups = makeGroups([itemWithoutAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].content).not.toContain('### Acceptance Criteria');
+    });
+
+    it('handles mixed items correctly', () => {
+      const groups = makeGroups([itemWithAC, itemWithoutAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(2);
+      expect(prompts[0].content).toContain('### Acceptance Criteria');
+      expect(prompts[1].content).not.toContain('### Acceptance Criteria');
+    });
+  });
+
+  describe('formatPlanModePrompt', () => {
+    it('includes acceptance criteria in plan mode prompt', () => {
+      const groups = makeGroups([itemWithAC]);
+      const result = formatPlanModePrompt(groups, venture, summary);
+      expect(result).toContain('Done when:');
+      expect(result).toContain('Dashboard loads in <2s');
+    });
+
+    it('omits criteria line when not present', () => {
+      const groups = makeGroups([itemWithoutAC]);
+      const result = formatPlanModePrompt(groups, venture, summary);
+      expect(result).not.toContain('Done when:');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Surface acceptance criteria from S19 sprint items in all 3 Replit prompt formats
- `extractSprintItems` now includes `acceptanceCriteria` field
- Main prompt formatter shows "Done when:" per sprint item
- Per-feature prompts include "### Acceptance Criteria" section

## Changes
- `lib/eva/bridge/replit-format-strategies.js` — extractSprintItems + formatFeaturePrompts + formatPlanModePrompt
- `lib/eva/bridge/replit-prompt-formatter.js` — Sprint items section
- `tests/unit/eva/bridge/acceptance-criteria-in-prompts.test.js` — 5 tests

## Test plan
- [x] 5/5 unit tests pass
- [x] All handoffs passed (93%, 90%, 86%, 85%, 96%)

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)