### PR TITLE
fix(stitch): RCA fixes for screen generation failures + S15 landing page

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -548,8 +548,9 @@ export async function generateScreens(projectId, prompts, ventureId) {
   //   2. Close the client immediately (transport is tainted after any error)
   //   3. Mark as "fired" — the server completes generation regardless
   //   4. No polling (listScreens is broken until browser activation)
-  //   5. Delay between screens — 5s default (experiments show delay doesn't affect success rate)
-  const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '5000', 10);
+  //   5. Delay between screens — 10s default (increased from 5s: RCA showed 45-90s server-side
+  //      generation means 5s retries hit the same in-progress generation)
+  const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '10000', 10);
 
   const results = [];
   const apiKey = getApiKey();
@@ -589,11 +590,15 @@ export async function generateScreens(projectId, prompts, ventureId) {
           recordMetric({ ventureId, screenName, deviceType, promptText, status: 'success', attemptCount: attempt, durationMs: Date.now() - attemptStart });
         } catch (err) {
           const msg = err.message || '';
-          const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected/i.test(msg);
-          if (isTransport) {
-            console.info(`[stitch-client] ${attemptLabel} fired (socket dropped — server processing)`);
+          const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected|AbortError|This operation was aborted/i.test(msg);
+          const isIncompleteResponse = /expected object at projection path|Incomplete API response/i.test(msg);
+          if (isTransport || isIncompleteResponse) {
+            // RCA: SDK projection path throws non-transport error for transient server timing
+            // issue. Incomplete responses mean server is likely still processing — treat as fired.
+            const reason = isTransport ? 'socket dropped' : 'incomplete response — server likely still processing';
+            console.info(`[stitch-client] ${attemptLabel} fired (${reason})`);
             results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt });
-            succeeded = true; // socket drop = server processing, count as success
+            succeeded = true;
             recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: attempt, durationMs: Date.now() - attemptStart });
           } else if (/resource has been exhausted|check quota/i.test(msg)) {
             // Quota exhaustion is permanent for the day — do not retry

--- a/lib/eva/stage-templates/analysis-steps/stage-15-ia-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-ia-generator.js
@@ -52,6 +52,7 @@ You MUST output valid JSON with exactly this structure:
 }
 
 Rules:
+- REQUIRED: Always include a "Landing Page" (path: "/", priority: "primary") as the public-facing marketing entry point visitors see before signing up
 - Generate 8-20 pages covering all personas
 - Every persona must have at least one primary page
 - Navigation groups pages by importance


### PR DESCRIPTION
## Summary
- **Stitch fire-and-assume pattern**: Add SDK "projection path" errors and AbortErrors to fire-and-assume handling — these are transient server timing issues, not permanent failures (observed 40-50% error rate during LocalVantage AI monitoring)
- **Screen delay increase**: Bump default `STITCH_SCREEN_DELAY_MS` from 5s to 10s — server needs 45-90s per generation, 5s retries hit in-progress work
- **S15 Landing Page**: Add mandatory "Landing Page" (path: `/`) to IA generator rules — wireframes previously only generated authenticated app screens with no public marketing entry point

## Root Cause Analysis
RCA sub-agent identified the SDK's rigid projection path (`raw.outputComponents[1].design.screens[0]`) throws `recoverable: false` errors for what are actually transient server timing conditions. The `stitch-client.js` fire-and-assume pattern didn't recognize these errors, causing them to fall through to the generic retry path with only a 5s delay.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Next venture ideation run should show `fired` status instead of `error` for projection path failures
- [ ] S15 IA output should include a Landing Page entry in the sitemap
- [ ] Stitch generation success+fired rate should improve from ~40% to ~80%+

🤖 Generated with [Claude Code](https://claude.com/claude-code)