### PR TITLE
feat(pipeline): backfill advisory_data on pending-decision shortcut

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -715,8 +715,33 @@ export class StageExecutionWorker {
               continue;
             }
 
+            // SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-A: Backfill advisory_data
+            // when pending-decision shortcut fires. Without this, chairman sees empty brief
+            // if the first poll cycle's _syncStageWork was missed (restart, error, migration).
+            try {
+              const { data: stageWork } = await this._supabase.from('venture_stage_work')
+                .select('advisory_data')
+                .eq('venture_id', ventureId).eq('lifecycle_stage', currentStage)
+                .maybeSingle();
+              if (!stageWork?.advisory_data || Object.keys(stageWork.advisory_data).length === 0) {
+                const { data: existingArt } = await this._supabase.from('venture_artifacts')
+                  .select('artifact_data')
+                  .eq('venture_id', ventureId).eq('lifecycle_stage', currentStage).eq('is_current', true)
+                  .maybeSingle();
+                if (existingArt?.artifact_data) {
+                  await this._syncStageWork(ventureId, currentStage, {
+                    artifacts: [{ payload: existingArt.artifact_data }],
+                    status: 'BLOCKED',
+                  });
+                  this._logger.log(`[Worker] Backfilled advisory_data for S${currentStage} from existing artifact`);
+                }
+              }
+            } catch (backfillErr) {
+              this._logger.warn(`[Worker] advisory_data backfill failed (non-fatal): ${backfillErr.message}`);
+            }
+
             this._logger.log(
-              `[Worker] Stage ${currentStage} has pending decision ${pendingDecision.id} — skipping execution, remaining blocked`
+              `[Worker] Stage ${currentStage} has pending decision ${pendingDecision.id} — remaining blocked`
             );
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             lastResult = {


### PR DESCRIPTION
## Summary
- **Advisory data backfill**: When the stage worker hits a pending chairman decision, it previously broke the loop without syncing `advisory_data` to `venture_stage_work`. If the first poll cycle's sync was missed (worker restart, error, or migrated venture), the chairman dashboard showed a blank brief with no stage output to review.
- **Fix**: Before breaking on pending-decision shortcut, check if `advisory_data` exists in `venture_stage_work`. If missing, backfill from existing `venture_artifacts`. Non-fatal on error — existing behavior preserved.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Stage worker processes a blocking gate with existing artifacts — verify `advisory_data` populated
- [ ] Chairman dashboard shows real data for blocked stages after worker restart

SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)