### PR TITLE
feat(pipeline): add UI assessment framework for Replit builds

### DIFF
--- a/lib/eva/bridge/ui-assessment-framework.js
+++ b/lib/eva/bridge/ui-assessment-framework.js
@@ -1,0 +1,123 @@
+/**
+ * UI Assessment Framework
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-C
+ *
+ * Evaluates the UI structure of Replit-built venture apps by analyzing
+ * the repository file listing from github-repo-analyzer. Produces a
+ * weighted quality score (0-100) and human-readable findings for
+ * chairman gate decisions at S21.
+ */
+
+const UI_CATEGORIES = {
+  landingPage: {
+    weight: 25,
+    patterns: [
+      /^src\/(pages|app)\/(index|home|landing)\.(jsx?|tsx?)$/i,
+      /^src\/components\/(Hero|Landing|Home)/i,
+      /^(pages|app)\/(index|home|page)\.(jsx?|tsx?)$/i,
+    ],
+    label: 'Landing Page',
+  },
+  navigation: {
+    weight: 20,
+    patterns: [
+      /^src\/components\/(Nav|Header|Sidebar|Menu|Layout)/i,
+      /^src\/(layout|navigation)\//i,
+      /\/(router|routes|routing)\.(jsx?|tsx?)$/i,
+    ],
+    label: 'Navigation & Routing',
+  },
+  forms: {
+    weight: 20,
+    patterns: [
+      /^src\/components\/(Form|Input|Login|Signup|Auth|Register)/i,
+      /\/(form|input|auth)\.(jsx?|tsx?)$/i,
+      /\/hooks\/use(Form|Auth|Input)/i,
+    ],
+    label: 'Forms & Input',
+  },
+  responsive: {
+    weight: 15,
+    patterns: [
+      /tailwind\.config/i,
+      /globals?\.(css|scss|less)$/i,
+      /\/styles\//i,
+      /postcss\.config/i,
+      /\.css$/i,
+    ],
+    label: 'Responsive Layout & Styles',
+  },
+  assets: {
+    weight: 20,
+    patterns: [
+      /^(public|static)\/(images?|img|icons?|assets)/i,
+      /\.(png|jpg|jpeg|svg|ico|webp)$/i,
+      /favicon/i,
+      /^(public|static)\//i,
+    ],
+    label: 'Static Assets',
+  },
+};
+
+/**
+ * Assess the UI quality of a repository based on its file listing.
+ *
+ * @param {string[]} files - Array of file paths from github-repo-analyzer
+ * @param {object} [structure] - Optional structure summary from github-repo-analyzer
+ * @returns {{score: number, findings: object[], categories: object, summary: string}}
+ */
+export function assessUI(files, structure = {}) {
+  if (!files || files.length === 0) {
+    return {
+      score: 0,
+      findings: [{ category: 'general', status: 'missing', message: 'No files found in repository' }],
+      categories: {},
+      summary: 'Empty repository — no UI assessment possible.',
+    };
+  }
+
+  const categories = {};
+  const findings = [];
+  let totalScore = 0;
+
+  for (const [key, config] of Object.entries(UI_CATEGORIES)) {
+    const matchingFiles = files.filter(f =>
+      config.patterns.some(p => p.test(f))
+    );
+
+    const present = matchingFiles.length > 0;
+    const categoryScore = present ? config.weight : 0;
+    totalScore += categoryScore;
+
+    categories[key] = {
+      label: config.label,
+      present,
+      matchCount: matchingFiles.length,
+      weight: config.weight,
+      score: categoryScore,
+      sampleFiles: matchingFiles.slice(0, 3),
+    };
+
+    findings.push({
+      category: config.label,
+      status: present ? 'present' : 'missing',
+      message: present
+        ? `Found ${matchingFiles.length} file(s) matching ${config.label} patterns`
+        : `No ${config.label} components detected`,
+      files: matchingFiles.slice(0, 3),
+    });
+  }
+
+  const presentCount = Object.values(categories).filter(c => c.present).length;
+  const totalCount = Object.keys(categories).length;
+
+  const summary = `UI Assessment: ${totalScore}/100 — ${presentCount}/${totalCount} categories present. ${
+    totalScore >= 80 ? 'Strong UI structure.' :
+    totalScore >= 50 ? 'Partial UI — some categories missing.' :
+    'Weak UI structure — multiple categories missing.'
+  }`;
+
+  return { score: totalScore, findings, categories, summary };
+}
+
+export default { assessUI };

--- a/tests/unit/eva/ui-assessment-framework.test.js
+++ b/tests/unit/eva/ui-assessment-framework.test.js
@@ -1,0 +1,81 @@
+/**
+ * Tests for ui-assessment-framework.js
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-C
+ */
+import { describe, it, expect } from 'vitest';
+import { assessUI } from '../../../lib/eva/bridge/ui-assessment-framework.js';
+
+describe('ui-assessment-framework', () => {
+  it('returns zero score for empty file list', () => {
+    const result = assessUI([]);
+    expect(result.score).toBe(0);
+    expect(result.findings[0].status).toBe('missing');
+  });
+
+  it('returns zero score for null input', () => {
+    const result = assessUI(null);
+    expect(result.score).toBe(0);
+  });
+
+  it('detects a complete React app', () => {
+    const files = [
+      'src/pages/index.tsx',
+      'src/components/Header.tsx',
+      'src/components/NavBar.tsx',
+      'src/components/LoginForm.tsx',
+      'tailwind.config.js',
+      'src/styles/globals.css',
+      'public/images/logo.png',
+      'public/favicon.ico',
+    ];
+    const result = assessUI(files);
+    expect(result.score).toBe(100);
+    expect(result.categories.landingPage.present).toBe(true);
+    expect(result.categories.navigation.present).toBe(true);
+    expect(result.categories.forms.present).toBe(true);
+    expect(result.categories.responsive.present).toBe(true);
+    expect(result.categories.assets.present).toBe(true);
+  });
+
+  it('detects partial app missing forms', () => {
+    const files = [
+      'src/pages/index.tsx',
+      'src/components/Header.tsx',
+      'tailwind.config.js',
+      'public/logo.svg',
+    ];
+    const result = assessUI(files);
+    expect(result.categories.forms.present).toBe(false);
+    expect(result.score).toBe(80); // 25 + 20 + 0 + 15 + 20
+  });
+
+  it('detects landing page from app/page pattern', () => {
+    const files = ['app/page.tsx'];
+    const result = assessUI(files);
+    expect(result.categories.landingPage.present).toBe(true);
+  });
+
+  it('generates human-readable findings', () => {
+    const files = ['src/pages/index.tsx'];
+    const result = assessUI(files);
+    const landingFinding = result.findings.find(f => f.category === 'Landing Page');
+    expect(landingFinding.status).toBe('present');
+    expect(landingFinding.message).toContain('1 file(s)');
+
+    const navFinding = result.findings.find(f => f.category === 'Navigation & Routing');
+    expect(navFinding.status).toBe('missing');
+  });
+
+  it('provides summary text', () => {
+    const files = ['src/pages/index.tsx', 'src/components/Header.tsx', 'tailwind.config.js', 'public/logo.svg', 'src/components/Form.tsx'];
+    const result = assessUI(files);
+    expect(result.summary).toContain('UI Assessment');
+    expect(result.summary).toContain('/100');
+  });
+
+  it('limits sample files to 3', () => {
+    const files = Array.from({ length: 10 }, (_, i) => `public/images/img${i}.png`);
+    const result = assessUI(files);
+    expect(result.categories.assets.sampleFiles.length).toBeLessThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary
- New `ui-assessment-framework.js` evaluates Replit-built app UI quality from repo file structure
- Checks 5 categories: landing page, navigation, forms, responsive layout, static assets
- Produces weighted score (0-100) and human-readable findings for S21 gate decisions

## Test plan
- [x] 8 unit tests (empty repo, complete app, partial app, findings generation)
- [ ] Integrate with S21 stage template to populate advisory_data

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)