### PR TITLE
feat(pipeline): add UAT test plan generator from sprint items

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -312,6 +312,7 @@ function extractSprintItems(groups) {
           description: item.description || item.scope || '',
           storyPoints: item.story_points || item.points || 0,
           priority: item.priority || 'medium',
+          acceptanceCriteria: item.success_criteria || item.acceptanceCriteria || item.acceptance_criteria || '',
         });
       }
     }
@@ -579,6 +580,7 @@ export function formatPlanModePrompt(groups, venture, summary) {
       const descText = item.description ? ` — ${item.description}` : '';
       const line = `${i + 1}. ${item.name} (${item.storyPoints} pts)${descText}`;
       lines.push(line);
+      if (item.acceptanceCriteria) lines.push(`   Done when: ${item.acceptanceCriteria}`);
     }
     lines.push('');
   }
@@ -660,6 +662,13 @@ export function formatFeaturePrompts(groups, venture, summary) {
     // Story points and priority
     lines.push(`**Story Points**: ${item.storyPoints} | **Priority**: ${item.priority}`);
     lines.push('');
+
+    // Acceptance criteria (from S19 sprint planning)
+    if (item.acceptanceCriteria) {
+      lines.push('### Acceptance Criteria');
+      lines.push(item.acceptanceCriteria);
+      lines.push('');
+    }
 
     // Build order context
     if (items.length > 1) {

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -262,6 +262,8 @@ export async function formatReplitPrompt(ventureId, options = {}) {
           const points = item.story_points || item.points || '?';
           sections.push(`${i + 1}. **${name}** (${points} pts)`);
           if (desc) sections.push(`   ${desc}`);
+          const ac = item.success_criteria || item.acceptanceCriteria || item.acceptance_criteria || '';
+          if (ac) sections.push(`   **Done when**: ${ac}`);
           sections.push('');
         }
       }

--- a/lib/eva/bridge/uat-test-plan-generator.js
+++ b/lib/eva/bridge/uat-test-plan-generator.js
@@ -1,0 +1,125 @@
+/**
+ * UAT Test Plan Generator
+ * SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-D
+ *
+ * Generates structured UAT test plans from S19 sprint items and S20 repo analysis.
+ * Each sprint item's acceptance criteria are mapped to testable scenarios with
+ * steps, expected results, and pass/fail criteria.
+ *
+ * @module lib/eva/bridge/uat-test-plan-generator
+ */
+
+/**
+ * Generate a UAT test plan from sprint items and repo analysis.
+ *
+ * @param {Array<{name: string, description: string, acceptanceCriteria?: string, architectureLayer?: string, designReference?: object}>} sprintItems
+ * @param {object} [repoAnalysis] - Repo analysis from github-repo-analyzer
+ * @param {Array<{path: string}>} [repoAnalysis.files]
+ * @param {object} [repoAnalysis.structure] - { hasTests, hasSrc, topLevelDirs }
+ * @param {object} [repoAnalysis.dependencies]
+ * @returns {{ testPlan: Array<object>, summary: { totalScenarios: number, itemsCovered: number } }}
+ */
+export function generateUATTestPlan(sprintItems = [], repoAnalysis = {}) {
+  if (!Array.isArray(sprintItems) || sprintItems.length === 0) {
+    return { testPlan: [], summary: { totalScenarios: 0, itemsCovered: 0 } };
+  }
+
+  const routes = extractRoutes(repoAnalysis);
+  const testPlan = sprintItems.map((item, index) => {
+    const scenarios = buildScenarios(item, routes, repoAnalysis.structure);
+    return {
+      sprintItemRef: item.name || `Item ${index + 1}`,
+      sprintItemIndex: index,
+      architectureLayer: item.architectureLayer || 'unknown',
+      scenarios,
+    };
+  });
+
+  const totalScenarios = testPlan.reduce((sum, item) => sum + item.scenarios.length, 0);
+  return {
+    testPlan,
+    summary: { totalScenarios, itemsCovered: testPlan.length },
+  };
+}
+
+function buildScenarios(item, routes, structure) {
+  const scenarios = [];
+  const criteria = item.acceptanceCriteria || item.acceptance_criteria || '';
+
+  if (criteria) {
+    // Split multi-criteria strings (semicolons, newlines, or numbered lists)
+    const parts = criteria.split(/[;\n]|(?:\d+\.\s)/).map(s => s.trim()).filter(Boolean);
+    for (const part of parts) {
+      scenarios.push({
+        title: `Verify: ${part.substring(0, 80)}`,
+        steps: buildSteps(item, part, routes, structure),
+        expectedResult: part,
+        passCriteria: `Criterion met: ${part.substring(0, 120)}`,
+      });
+    }
+  }
+
+  // Always generate at least one scenario from the item description
+  if (scenarios.length === 0) {
+    scenarios.push({
+      title: `Verify ${item.name} works as described`,
+      steps: buildSteps(item, item.description || item.name, routes, structure),
+      expectedResult: item.description || `${item.name} is functional`,
+      passCriteria: `Feature "${item.name}" operates correctly`,
+    });
+  }
+
+  return scenarios;
+}
+
+function buildSteps(item, criterion, routes, structure) {
+  const steps = [];
+  const layer = (item.architectureLayer || '').toLowerCase();
+
+  // Step 1: Navigate to the relevant area
+  if (layer === 'frontend' && routes.length > 0) {
+    const matchedRoute = routes.find(r => criterion.toLowerCase().includes(r.toLowerCase())) || routes[0];
+    steps.push(`Navigate to ${matchedRoute}`);
+  } else if (layer === 'frontend') {
+    steps.push('Open the application in a browser');
+  } else if (layer === 'backend') {
+    steps.push('Send a request to the relevant API endpoint');
+  } else {
+    steps.push('Access the feature under test');
+  }
+
+  // Step 2: Execute the action
+  steps.push(`Perform the action described: ${criterion.substring(0, 150)}`);
+
+  // Step 3: Verify
+  steps.push('Verify the expected outcome matches the acceptance criteria');
+
+  // Step 4: Check for regressions (if tests exist)
+  if (structure?.hasTests) {
+    steps.push('Run existing test suite to confirm no regressions');
+  }
+
+  return steps;
+}
+
+function extractRoutes(repoAnalysis) {
+  if (!repoAnalysis?.files) return [];
+
+  // Detect route-like files (pages/, routes/, app/ directories)
+  return repoAnalysis.files
+    .filter(f => {
+      const path = typeof f === 'string' ? f : f.path || '';
+      return /\/(pages|routes|app)\//.test(path) && /\.(js|ts|jsx|tsx)$/.test(path);
+    })
+    .map(f => {
+      const path = typeof f === 'string' ? f : f.path || '';
+      // Convert file path to route: pages/about.tsx -> /about
+      return '/' + path
+        .replace(/.*\/(pages|routes|app)\//, '')
+        .replace(/\.(js|ts|jsx|tsx)$/, '')
+        .replace(/\/index$/, '')
+        .replace(/\[([^\]]+)\]/g, ':$1');
+    })
+    .filter(r => r !== '/')
+    .slice(0, 20);
+}

--- a/tests/unit/eva/bridge/acceptance-criteria-in-prompts.test.js
+++ b/tests/unit/eva/bridge/acceptance-criteria-in-prompts.test.js
@@ -1,0 +1,77 @@
+/**
+ * Tests for acceptance criteria in Replit prompt surfaces
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-D
+ */
+import { describe, it, expect } from 'vitest';
+import { formatFeaturePrompts, formatPlanModePrompt } from '../../../../lib/eva/bridge/replit-format-strategies.js';
+
+const makeGroups = (items) => [{
+  group_key: 'sprint_plan',
+  group_name: 'Sprint Plan',
+  artifacts: [{
+    content: JSON.stringify({ items }),
+    title: 'Sprint Items',
+    artifact_type: 'sprint_plan',
+    lifecycle_stage: 19,
+  }],
+}];
+
+const venture = { name: 'TestVenture', description: 'Test' };
+const summary = { total_groups: 1, venture_name: 'TestVenture' };
+
+describe('Acceptance criteria in Replit prompts', () => {
+  const itemWithAC = {
+    name: 'User Dashboard',
+    description: 'Build the main dashboard',
+    story_points: 5,
+    priority: 'high',
+    success_criteria: 'Dashboard loads in <2s and shows user stats',
+  };
+
+  const itemWithoutAC = {
+    name: 'Setup CI/CD',
+    description: 'Configure pipeline',
+    story_points: 3,
+    priority: 'medium',
+  };
+
+  describe('formatFeaturePrompts', () => {
+    it('includes acceptance criteria section when present', () => {
+      const groups = makeGroups([itemWithAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].content).toContain('### Acceptance Criteria');
+      expect(prompts[0].content).toContain('Dashboard loads in <2s');
+    });
+
+    it('omits acceptance criteria section when missing', () => {
+      const groups = makeGroups([itemWithoutAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].content).not.toContain('### Acceptance Criteria');
+    });
+
+    it('handles mixed items correctly', () => {
+      const groups = makeGroups([itemWithAC, itemWithoutAC]);
+      const prompts = formatFeaturePrompts(groups, venture, summary);
+      expect(prompts).toHaveLength(2);
+      expect(prompts[0].content).toContain('### Acceptance Criteria');
+      expect(prompts[1].content).not.toContain('### Acceptance Criteria');
+    });
+  });
+
+  describe('formatPlanModePrompt', () => {
+    it('includes acceptance criteria in plan mode prompt', () => {
+      const groups = makeGroups([itemWithAC]);
+      const result = formatPlanModePrompt(groups, venture, summary);
+      expect(result).toContain('Done when:');
+      expect(result).toContain('Dashboard loads in <2s');
+    });
+
+    it('omits criteria line when not present', () => {
+      const groups = makeGroups([itemWithoutAC]);
+      const result = formatPlanModePrompt(groups, venture, summary);
+      expect(result).not.toContain('Done when:');
+    });
+  });
+});

--- a/tests/unit/eva/bridge/uat-test-plan-generator.test.js
+++ b/tests/unit/eva/bridge/uat-test-plan-generator.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { generateUATTestPlan } from '../../../../lib/eva/bridge/uat-test-plan-generator.js';
+
+describe('generateUATTestPlan', () => {
+  it('returns empty plan for empty sprint items', () => {
+    const result = generateUATTestPlan([]);
+    expect(result.testPlan).toEqual([]);
+    expect(result.summary.totalScenarios).toBe(0);
+    expect(result.summary.itemsCovered).toBe(0);
+  });
+
+  it('returns empty plan for undefined input', () => {
+    const result = generateUATTestPlan();
+    expect(result.testPlan).toEqual([]);
+  });
+
+  it('generates scenarios from acceptance criteria', () => {
+    const items = [{
+      name: 'User login',
+      description: 'Implement user login with email and password',
+      acceptanceCriteria: 'User can log in with valid credentials; Error shown for invalid credentials',
+      architectureLayer: 'frontend',
+    }];
+    const result = generateUATTestPlan(items);
+    expect(result.summary.itemsCovered).toBe(1);
+    expect(result.summary.totalScenarios).toBe(2);
+    expect(result.testPlan[0].scenarios[0].title).toContain('Verify:');
+    expect(result.testPlan[0].scenarios[0].expectedResult).toContain('valid credentials');
+    expect(result.testPlan[0].scenarios[1].expectedResult).toContain('invalid credentials');
+  });
+
+  it('generates fallback scenario when no acceptance criteria', () => {
+    const items = [{
+      name: 'Dashboard page',
+      description: 'Build a dashboard showing key metrics',
+    }];
+    const result = generateUATTestPlan(items);
+    expect(result.summary.totalScenarios).toBe(1);
+    expect(result.testPlan[0].scenarios[0].title).toContain('Dashboard page');
+    expect(result.testPlan[0].scenarios[0].expectedResult).toContain('key metrics');
+  });
+
+  it('uses repo analysis routes in frontend steps', () => {
+    const items = [{
+      name: 'About page',
+      description: 'Create about page',
+      acceptanceCriteria: 'About page loads correctly',
+      architectureLayer: 'frontend',
+    }];
+    const repoAnalysis = {
+      files: [
+        { path: 'src/pages/index.tsx' },
+        { path: 'src/pages/about.tsx' },
+        { path: 'src/pages/dashboard.tsx' },
+      ],
+      structure: { hasTests: true, hasSrc: true },
+    };
+    const result = generateUATTestPlan(items, repoAnalysis);
+    const steps = result.testPlan[0].scenarios[0].steps;
+    expect(steps.some(s => s.includes('/about') || s.includes('Navigate'))).toBe(true);
+    expect(steps.some(s => s.includes('test suite'))).toBe(true);
+  });
+
+  it('handles backend architecture layer', () => {
+    const items = [{
+      name: 'API endpoint',
+      description: 'Create REST endpoint',
+      acceptanceCriteria: 'Returns 200 for valid request',
+      architectureLayer: 'backend',
+    }];
+    const result = generateUATTestPlan(items);
+    const steps = result.testPlan[0].scenarios[0].steps;
+    expect(steps[0]).toContain('API endpoint');
+  });
+
+  it('includes sprint item reference and index', () => {
+    const items = [
+      { name: 'Feature A', description: 'First feature' },
+      { name: 'Feature B', description: 'Second feature' },
+    ];
+    const result = generateUATTestPlan(items);
+    expect(result.testPlan[0].sprintItemRef).toBe('Feature A');
+    expect(result.testPlan[0].sprintItemIndex).toBe(0);
+    expect(result.testPlan[1].sprintItemRef).toBe('Feature B');
+    expect(result.testPlan[1].sprintItemIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- New module `lib/eva/bridge/uat-test-plan-generator.js` that generates structured UAT test plans
- Maps sprint item acceptance criteria to testable scenarios with steps, expected results, pass/fail criteria
- Uses repo analysis routes to ground frontend scenarios in actual file paths
- 7 tests covering criteria parsing, fallback generation, route integration, empty inputs

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-D

## Test plan
- [x] 7 new tests pass
- [x] 15 smoke tests pass
- [x] Pure function, no database dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)