### PR TITLE
feat(pipeline): add prompt-vs-build analysis engine

### DIFF
--- a/lib/eva/bridge/prompt-build-analyzer.js
+++ b/lib/eva/bridge/prompt-build-analyzer.js
@@ -1,0 +1,190 @@
+/**
+ * Prompt-Build Analyzer
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-D-A
+ *
+ * Compares sprint specification prompts against actual Replit build
+ * output from github-repo-analyzer. Produces a coverage report showing
+ * which sprint items were implemented, partially implemented, or missed.
+ *
+ * This powers the feedback loop that improves prompts for subsequent builds.
+ */
+
+/**
+ * Normalize a string for fuzzy matching — lowercase, remove punctuation,
+ * collapse whitespace.
+ * @param {string} str
+ * @returns {string}
+ */
+function normalize(str) {
+  if (!str) return '';
+  return str.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Extract keywords from a sprint item for matching.
+ * @param {object} item - Sprint item with name/title, description, acceptance_criteria
+ * @returns {string[]} Keywords for matching
+ */
+function extractKeywords(item) {
+  const parts = [
+    item.name || item.title || '',
+    item.description || item.scope || '',
+    ...(Array.isArray(item.acceptance_criteria) ? item.acceptance_criteria : []),
+  ];
+
+  const text = normalize(parts.join(' '));
+  const stopWords = new Set([
+    'the', 'a', 'an', 'and', 'or', 'but', 'to', 'from', 'with', 'of', 'for',
+    'in', 'on', 'at', 'is', 'it', 'be', 'as', 'by', 'this', 'that', 'should',
+    'must', 'can', 'will', 'has', 'have', 'been', 'are', 'was', 'were',
+    'create', 'add', 'implement', 'build', 'make', 'ensure', 'include',
+  ]);
+
+  return text.split(' ').filter(w => w.length > 2 && !stopWords.has(w));
+}
+
+/**
+ * Score how well a sprint item matches the repo file listing.
+ * Returns a match score (0-1) and evidence (matching files).
+ *
+ * @param {object} item - Sprint item
+ * @param {string[]} files - Repo file paths
+ * @param {object} structure - Repo structure from analyzer
+ * @returns {{score: number, evidence: string[], matchType: string}}
+ */
+function scoreItemMatch(item, files, structure) {
+  const keywords = extractKeywords(item);
+  if (keywords.length === 0) {
+    return { score: 0, evidence: [], matchType: 'no_keywords' };
+  }
+
+  const normalizedFiles = files.map(f => ({ path: f, normalized: normalize(f) }));
+  const matchedFiles = [];
+  let keywordHits = 0;
+
+  for (const keyword of keywords) {
+    const matches = normalizedFiles.filter(f => f.normalized.includes(keyword));
+    if (matches.length > 0) {
+      keywordHits++;
+      for (const m of matches) {
+        if (!matchedFiles.includes(m.path)) {
+          matchedFiles.push(m.path);
+        }
+      }
+    }
+  }
+
+  // Also check top-level dirs for broad feature areas
+  const dirs = structure?.topLevelDirs || [];
+  for (const keyword of keywords) {
+    if (dirs.some(d => normalize(d).includes(keyword))) {
+      keywordHits++;
+    }
+  }
+
+  const score = Math.min(1, keywordHits / Math.max(keywords.length, 1));
+  const evidence = matchedFiles.slice(0, 5); // Limit evidence to 5 files
+
+  let matchType;
+  if (score >= 0.6) matchType = 'implemented';
+  else if (score >= 0.3) matchType = 'partial';
+  else if (score > 0) matchType = 'weak';
+  else matchType = 'missing';
+
+  return { score, evidence, matchType };
+}
+
+/**
+ * Analyze how well a Replit build matches its sprint specification.
+ *
+ * @param {object} sprintPlan - Sprint plan data from S19 advisory_data
+ * @param {object} repoAnalysis - Output from github-repo-analyzer.analyzeRepo()
+ * @returns {{
+ *   coveragePercent: number,
+ *   totalItems: number,
+ *   implemented: number,
+ *   partial: number,
+ *   missing: number,
+ *   items: Array<{name: string, status: string, score: number, evidence: string[]}>,
+ *   summary: string
+ * }}
+ */
+export function analyzePromptVsBuild(sprintPlan, repoAnalysis) {
+  const empty = {
+    coveragePercent: 0,
+    totalItems: 0,
+    implemented: 0,
+    partial: 0,
+    missing: 0,
+    items: [],
+    summary: 'No data available for analysis.',
+  };
+
+  if (!sprintPlan || !repoAnalysis) return empty;
+
+  // Extract sprint items from various formats
+  const rawItems = sprintPlan.items
+    || sprintPlan.sprint_items
+    || sprintPlan.tasks
+    || [];
+
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    return { ...empty, summary: 'No sprint items found in plan.' };
+  }
+
+  const { files = [], structure = {} } = repoAnalysis;
+
+  if (files.length === 0) {
+    return {
+      ...empty,
+      totalItems: rawItems.length,
+      missing: rawItems.length,
+      items: rawItems.map(item => ({
+        name: item.name || item.title || 'Unnamed',
+        status: 'missing',
+        score: 0,
+        evidence: [],
+      })),
+      summary: `Empty repository — 0/${rawItems.length} sprint items matched.`,
+    };
+  }
+
+  // Score each sprint item
+  const results = rawItems.map(item => {
+    const { score, evidence, matchType } = scoreItemMatch(item, files, structure);
+    return {
+      name: item.name || item.title || 'Unnamed',
+      status: matchType,
+      score: Math.round(score * 100),
+      evidence,
+      keywords: extractKeywords(item).slice(0, 5),
+    };
+  });
+
+  const implemented = results.filter(r => r.status === 'implemented').length;
+  const partial = results.filter(r => r.status === 'partial' || r.status === 'weak').length;
+  const missing = results.filter(r => r.status === 'missing').length;
+
+  // Weighted coverage: implemented = 100%, partial = 50%, missing = 0%
+  const totalWeight = results.length;
+  const weightedScore = results.reduce((sum, r) => {
+    if (r.status === 'implemented') return sum + 1;
+    if (r.status === 'partial' || r.status === 'weak') return sum + 0.5;
+    return sum;
+  }, 0);
+  const coveragePercent = Math.round((weightedScore / totalWeight) * 100);
+
+  const summary = `Prompt-vs-Build Coverage: ${coveragePercent}% — ${implemented} implemented, ${partial} partial, ${missing} missing out of ${results.length} sprint items.`;
+
+  return {
+    coveragePercent,
+    totalItems: results.length,
+    implemented,
+    partial,
+    missing,
+    items: results,
+    summary,
+  };
+}
+
+export default { analyzePromptVsBuild };

--- a/tests/unit/eva/bridge/prompt-build-analyzer.test.js
+++ b/tests/unit/eva/bridge/prompt-build-analyzer.test.js
@@ -1,0 +1,142 @@
+/**
+ * Tests for prompt-build-analyzer.js
+ * SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-D-A
+ */
+import { describe, it, expect } from 'vitest';
+import { analyzePromptVsBuild } from '../../../../lib/eva/bridge/prompt-build-analyzer.js';
+
+describe('prompt-build-analyzer', () => {
+  const sampleRepo = {
+    files: [
+      'src/pages/index.tsx',
+      'src/components/Header.tsx',
+      'src/components/LoginForm.tsx',
+      'src/components/Dashboard.tsx',
+      'src/components/VentureList.tsx',
+      'src/hooks/useAuth.ts',
+      'src/lib/supabase.ts',
+      'package.json',
+      'tailwind.config.js',
+    ],
+    structure: {
+      totalFiles: 9,
+      topLevelDirs: ['src'],
+      hasSrc: true,
+    },
+  };
+
+  describe('analyzePromptVsBuild', () => {
+    it('returns empty analysis for null inputs', () => {
+      expect(analyzePromptVsBuild(null, null).coveragePercent).toBe(0);
+      expect(analyzePromptVsBuild(null, null).summary).toContain('No data');
+    });
+
+    it('handles missing sprint items', () => {
+      const result = analyzePromptVsBuild({}, sampleRepo);
+      expect(result.summary).toContain('No sprint items');
+    });
+
+    it('detects implemented items via file matching', () => {
+      const sprint = {
+        items: [
+          { name: 'Login form with authentication', description: 'User login form' },
+          { name: 'Dashboard page', description: 'Main dashboard view' },
+        ],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+
+      expect(result.totalItems).toBe(2);
+      expect(result.items[0].status).not.toBe('missing');
+      expect(result.items[0].evidence.length).toBeGreaterThan(0);
+    });
+
+    it('marks items as missing when no repo matches', () => {
+      const sprint = {
+        items: [
+          { name: 'Stripe payment integration', description: 'Process payments via Stripe' },
+          { name: 'Email notification system', description: 'Send email alerts' },
+        ],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+
+      expect(result.items.every(i => i.status === 'missing')).toBe(true);
+      expect(result.coveragePercent).toBe(0);
+    });
+
+    it('calculates weighted coverage correctly', () => {
+      const sprint = {
+        items: [
+          { name: 'Header navigation component', description: 'Top nav bar' },
+          { name: 'Stripe checkout flow', description: 'Payment processing' },
+        ],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+
+      // Header should match, Stripe should not
+      expect(result.coveragePercent).toBeGreaterThan(0);
+      expect(result.coveragePercent).toBeLessThan(100);
+    });
+
+    it('handles empty repo gracefully', () => {
+      const sprint = { items: [{ name: 'Feature A' }] };
+      const emptyRepo = { files: [], structure: {} };
+      const result = analyzePromptVsBuild(sprint, emptyRepo);
+
+      expect(result.missing).toBe(1);
+      expect(result.coveragePercent).toBe(0);
+      expect(result.summary).toContain('Empty repository');
+    });
+
+    it('provides evidence file paths', () => {
+      const sprint = {
+        items: [{ name: 'Supabase client setup', description: 'Configure supabase connection' }],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+
+      const item = result.items[0];
+      if (item.evidence.length > 0) {
+        expect(item.evidence[0]).toContain('supabase');
+      }
+    });
+
+    it('limits evidence to 5 files', () => {
+      const manyFiles = {
+        files: Array.from({ length: 20 }, (_, i) => `src/components/auth/auth${i}.tsx`),
+        structure: { topLevelDirs: ['src'] },
+      };
+      const sprint = { items: [{ name: 'Auth components', description: 'Authentication auth system' }] };
+      const result = analyzePromptVsBuild(sprint, manyFiles);
+
+      expect(result.items[0].evidence.length).toBeLessThanOrEqual(5);
+    });
+
+    it('generates human-readable summary', () => {
+      const sprint = {
+        items: [
+          { name: 'Dashboard page', description: 'Main dashboard' },
+          { name: 'Unknown feature', description: 'Something non-existent' },
+        ],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+
+      expect(result.summary).toContain('Prompt-vs-Build Coverage');
+      expect(result.summary).toContain('%');
+      expect(result.summary).toContain('sprint items');
+    });
+
+    it('supports sprint_items key format', () => {
+      const sprint = {
+        sprint_items: [{ title: 'Landing page', description: 'Home page with hero section' }],
+      };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+      expect(result.totalItems).toBe(1);
+    });
+
+    it('includes keywords in item results', () => {
+      const sprint = { items: [{ name: 'Venture list component' }] };
+      const result = analyzePromptVsBuild(sprint, sampleRepo);
+      expect(result.items[0].keywords).toBeDefined();
+      expect(result.items[0].keywords.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `prompt-build-analyzer.js` compares sprint spec items against actual Replit build output
- Produces coverage report: implemented/partial/missing with per-item file evidence
- Powers the feedback loop for continuous prompt quality improvement

## Test plan
- [x] 11 unit tests (null inputs, file matching, coverage calc, empty repo, evidence limits)

SD: SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-D-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)