### PR TITLE
fix(stitch): add per-screen watchdog timeout for silent hang recovery

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -581,8 +581,12 @@ export async function generateScreens(projectId, prompts, ventureId) {
       try {
         const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
         const project = client.project(projectId);
+        const SCREEN_TIMEOUT_MS = parseInt(process.env.STITCH_SCREEN_TIMEOUT_MS || '150000', 10);
         try {
-          const screen = await project.generate(promptText, deviceType, modelId);
+          const screen = await Promise.race([
+            project.generate(promptText, deviceType, modelId),
+            new Promise((_, reject) => setTimeout(() => reject(new Error(`[watchdog] Screen "${screenName}" (${deviceType}) timed out after ${SCREEN_TIMEOUT_MS / 1000}s — SSE transport may be hung`)), SCREEN_TIMEOUT_MS)),
+          ]);
           const screenId = screen?.id || screen?.screen_id;
           console.info(`[stitch-client] ${attemptLabel} returned directly: ${screenId}`);
           results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType, attempt });
@@ -590,12 +594,13 @@ export async function generateScreens(projectId, prompts, ventureId) {
           recordMetric({ ventureId, screenName, deviceType, promptText, status: 'success', attemptCount: attempt, durationMs: Date.now() - attemptStart });
         } catch (err) {
           const msg = err.message || '';
-          const isTransport = /fetch failed|socket|ECONNRESET|other side closed|Already connected|AbortError|This operation was aborted/i.test(msg);
+          const isWatchdog = /\[watchdog\]/.test(msg);
+          const isTransport = isWatchdog || /fetch failed|socket|ECONNRESET|other side closed|Already connected|AbortError|This operation was aborted/i.test(msg);
           const isIncompleteResponse = /expected object at projection path|Incomplete API response/i.test(msg);
           if (isTransport || isIncompleteResponse) {
             // RCA: SDK projection path throws non-transport error for transient server timing
             // issue. Incomplete responses mean server is likely still processing — treat as fired.
-            const reason = isTransport ? 'socket dropped' : 'incomplete response — server likely still processing';
+            const reason = isWatchdog ? 'watchdog timeout — SSE transport hung' : isTransport ? 'socket dropped' : 'incomplete response — server likely still processing';
             console.info(`[stitch-client] ${attemptLabel} fired (${reason})`);
             results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt });
             succeeded = true;


### PR DESCRIPTION
## Summary
- Wrap `project.generate()` in `Promise.race` with configurable watchdog (150s default)
- Watchdog fires when SSE transport hangs, allowing generation loop to continue
- Watchdog timeouts classified as transport errors with clear diagnostics
- 8 LOC change in `lib/eva/bridge/stitch-client.js`

SD: SD-MAN-FIX-STITCH-GENERATION-PER-001

## Test plan
- [x] 15 smoke tests pass
- [x] Watchdog timeout configurable via STITCH_SCREEN_TIMEOUT_MS env var
- [x] Existing error handling (transport, quota, SDK) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)