### PR TITLE
fix(handoff): self-heal stale worktrees + orchestrator exemption + PRD status fix

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -221,6 +221,7 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
   // Exception: sd-start.js with allowMainRepoForAcquisition=true — it creates the worktree.
   if (sd.worktree_path && !allowMainRepoForAcquisition) {
     let effectiveWorktreePath = sd.worktree_path;
+    let worktreeCleared = false;
 
     // Step 3a: Validate stored path is a real git worktree (not phantom/stale)
     if (!isRealWorktree(effectiveWorktreePath)) {
@@ -241,47 +242,57 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
           effectiveWorktreePath = recovered;
         }
       } else {
-        // Recovery failed — worktree is truly stale/deleted
-        throw new ClaimIdentityError({
-          reason: 'stale_worktree',
-          operation, sdKey,
-          expectedWorktree: sd.worktree_path,
-          actualCwd: process.cwd(),
-          remediation: `Registered worktree at ${sd.worktree_path} is no longer a valid git worktree (removed or corrupted).\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree and update the database.`
-        });
+        // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094: Self-heal stale worktree paths.
+        // Instead of blocking the handoff, clear the stale path from DB and proceed.
+        // The worktree was already cleaned up (auto-cleanup for no-change worktrees),
+        // so requiring it to exist blocks all subsequent handoffs unnecessarily.
+        console.warn(
+          `[claim-validity-gate] Stale worktree cleared for ${sdKey}: ${sd.worktree_path} no longer exists. Proceeding without worktree isolation.`
+        );
+        try {
+          await supabase
+            .from('strategic_directives_v2')
+            .update({ worktree_path: null })
+            .eq('sd_key', sdKey);
+        } catch { /* non-fatal — DB update best-effort */ }
+        worktreeCleared = true;
       }
     }
 
     // Step 3b: Verify cwd is inside the (possibly recovered) worktree
-    let expectedWt;
-    let actualCwd;
-    try {
-      expectedWt = realpathSync(effectiveWorktreePath);
-      actualCwd = realpathSync(process.cwd());
-    } catch (e) {
-      throw new ClaimIdentityError({
-        reason: 'wrong_worktree',
-        operation, sdKey,
-        expectedWorktree: effectiveWorktreePath,
-        actualCwd: process.cwd(),
-        remediation: `Worktree path resolution failed: ${e.message}.\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree.`
-      });
-    }
+    // Skip if worktree was cleared (stale path self-healed above)
+    if (!worktreeCleared) {
+      // Step 3b only when worktree is still valid (not self-healed)
+      let expectedWt;
+      let actualCwd;
+      try {
+        expectedWt = realpathSync(effectiveWorktreePath);
+        actualCwd = realpathSync(process.cwd());
+      } catch (e) {
+        throw new ClaimIdentityError({
+          reason: 'wrong_worktree',
+          operation, sdKey,
+          expectedWorktree: effectiveWorktreePath,
+          actualCwd: process.cwd(),
+          remediation: `Worktree path resolution failed: ${e.message}.\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree.`
+        });
+      }
 
-    // Normalize paths to lowercase on Windows (case-insensitive filesystem) and
-    // ensure consistent separators before comparison to prevent false wrong_worktree errors.
-    const normalize = (p) => process.platform === 'win32' ? p.replace(/\//g, '\\').toLowerCase() : p;
-    const normalExpected = normalize(expectedWt);
-    const normalActual = normalize(actualCwd);
-    const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
-    if (!insideWorktree) {
-      throw new ClaimIdentityError({
-        reason: 'wrong_worktree',
-        operation, sdKey,
-        expectedWorktree: expectedWt,
-        actualCwd,
-        remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your command.`
-      });
+      // Normalize paths to lowercase on Windows (case-insensitive filesystem) and
+      // ensure consistent separators before comparison to prevent false wrong_worktree errors.
+      const normalize = (p) => process.platform === 'win32' ? p.replace(/\//g, '\\').toLowerCase() : p;
+      const normalExpected = normalize(expectedWt);
+      const normalActual = normalize(actualCwd);
+      const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
+      if (!insideWorktree) {
+        throw new ClaimIdentityError({
+          reason: 'wrong_worktree',
+          operation, sdKey,
+          expectedWorktree: expectedWt,
+          actualCwd,
+          remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your command.`
+        });
+      }
     }
   }
 

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -132,13 +132,16 @@ export class BaseExecutor {
       //   (a) resolveOwnSession returns ambiguous/no_deterministic_identity (cross-CC collision),
       //   (b) SD.claiming_session_id does not match our session (foreign claim),
       //   (c) process.cwd() is not inside SD.worktree_path (wrong directory).
-      // No allowMainRepoForAcquisition flag here — handoffs MUST run from inside the worktree,
-      // enforced from LEAD phase onward via BaseExecutor inheritance.
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094: Orchestrator SDs are exempt from worktree
+      // isolation (check c) because they coordinate children and don't produce code directly.
+      // They still must pass identity (a) and ownership (b) checks.
+      const isOrchestrator = sd?.sd_type === 'orchestrator';
       try {
         const { assertValidClaim, ClaimIdentityError } = await import('../../../../lib/claim-validity-gate.js');
         const sdKeyForGate = sd?.sd_key || sdId;
         await assertValidClaim(this.supabase, sdKeyForGate, {
-          operation: `handoff_${this.handoffType}`
+          operation: `handoff_${this.handoffType}`,
+          allowMainRepoForAcquisition: isOrchestrator
         });
       } catch (e) {
         if (e?.name === 'ClaimIdentityError') {

--- a/scripts/modules/handoff/executors/plan-to-lead/plan-verification.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/plan-verification.js
@@ -93,11 +93,14 @@ async function validateStandardSDCompletion(supabase, prd, sd, validation) {
   let prdScore = 0, handoffScore = 0, storiesScore = 0;
 
   // Check PRD status
-  if (prd.status === 'verification' || prd.status === 'completed') {
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094: Accept 'in_progress' alongside 'verification'/'completed'.
+  // PLAN-TO-EXEC state transitions set PRD to 'in_progress', and this status persists through EXEC.
+  // Rejecting it here creates a circular failure where the handoff that set it blocks the next handoff.
+  if (prd.status === 'verification' || prd.status === 'completed' || prd.status === 'in_progress') {
     validation.score += 30;
     prdScore = 30;
   } else {
-    validation.issues.push(`PRD status is '${prd.status}', expected 'verification' or 'completed'`);
+    validation.issues.push(`PRD status is '${prd.status}', expected 'verification', 'completed', or 'in_progress'`);
   }
 
   // Check EXEC→PLAN handoff exists (or skip for lightweight SDs)

--- a/tests/unit/claim-validity-gate.test.js
+++ b/tests/unit/claim-validity-gate.test.js
@@ -121,14 +121,10 @@ describe('assertValidClaim — CHECK 3 enhanced', () => {
       current_phase: 'EXEC',
     });
 
-    try {
-      await assertValidClaim(sb, 'SD-STALE-001', { operation: 'test_op' });
-      expect.unreachable('should have thrown');
-    } catch (e) {
-      expect(e).toBeInstanceOf(ClaimIdentityError);
-      expect(e.reason).toBe('stale_worktree');
-      expect(e.remediation).toContain('npm run sd:start SD-STALE-001');
-    }
+    // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094: Stale worktrees now self-heal
+    // (clear path from DB) instead of throwing. The call should succeed.
+    const result = await assertValidClaim(sb, 'SD-STALE-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('self');
   });
 
   it('auto-recovers when worktree found at .worktrees/<SD-KEY>/', async () => {


### PR DESCRIPTION
## Summary
- **Stale worktree self-heal**: claim-validity-gate clears stale DB worktree paths instead of blocking handoffs (addresses PAT-HF-LEADTOPLAN-55c04a29, PAT-RETRO-PLANTOLEAD-3741735a)
- **Orchestrator worktree exemption**: orchestrator SDs bypass worktree isolation in BaseExecutor since they don't produce code (addresses PAT-RETRO-LEADTOPLAN-9c4f1e5f)
- **PRD status acceptance**: PLAN-TO-LEAD accepts 'in_progress' PRD status, fixing circular failure from PLAN-TO-EXEC state transition (addresses PAT-RETRO-PLANTOLEAD-9c4f1e5f)

## Test plan
- [x] 10 claim-validity-gate tests pass (stale_worktree test updated for self-heal behavior)
- [x] 15 smoke tests pass

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094

🤖 Generated with [Claude Code](https://claude.com/claude-code)