### PR TITLE
fix(gate): self-heal stale worktree paths in claim-validity-gate

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -269,29 +269,32 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
         expectedWt = realpathSync(effectiveWorktreePath);
         actualCwd = realpathSync(process.cwd());
       } catch (e) {
-        throw new ClaimIdentityError({
-          reason: 'wrong_worktree',
-          operation, sdKey,
-          expectedWorktree: effectiveWorktreePath,
-          actualCwd: process.cwd(),
-          remediation: `Worktree path resolution failed: ${e.message}.\n  Run:  npm run sd:start ${sdKey}\n  This will recreate the worktree.`
-        });
+        // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-096: Self-heal on path resolution failure.
+        // Worktree directory was deleted (merge/cleanup). Clear path and proceed.
+        console.warn(`[claim-validity-gate] Worktree path resolution failed for ${sdKey}: ${e.message}. Clearing stale path.`);
+        try {
+          await supabase.from('strategic_directives_v2').update({ worktree_path: null }).eq('sd_key', sdKey);
+        } catch { /* non-fatal */ }
+        worktreeCleared = true;
       }
 
-      // Normalize paths to lowercase on Windows (case-insensitive filesystem) and
-      // ensure consistent separators before comparison to prevent false wrong_worktree errors.
-      const normalize = (p) => process.platform === 'win32' ? p.replace(/\//g, '\\').toLowerCase() : p;
-      const normalExpected = normalize(expectedWt);
-      const normalActual = normalize(actualCwd);
-      const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
-      if (!insideWorktree) {
-        throw new ClaimIdentityError({
-          reason: 'wrong_worktree',
-          operation, sdKey,
-          expectedWorktree: expectedWt,
-          actualCwd,
-          remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your command.`
-        });
+      // Only check path when worktree is still valid (not self-healed)
+      if (!worktreeCleared && expectedWt && actualCwd) {
+        // Normalize paths to lowercase on Windows (case-insensitive filesystem) and
+        // ensure consistent separators before comparison to prevent false wrong_worktree errors.
+        const normalize = (p) => process.platform === 'win32' ? p.replace(/\//g, '\\').toLowerCase() : p;
+        const normalExpected = normalize(expectedWt);
+        const normalActual = normalize(actualCwd);
+        const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
+        if (!insideWorktree) {
+          throw new ClaimIdentityError({
+            reason: 'wrong_worktree',
+            operation, sdKey,
+            expectedWorktree: expectedWt,
+            actualCwd,
+            remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your command.`
+          });
+        }
       }
     }
   }

--- a/tests/unit/eva/logo-image-generator.test.js
+++ b/tests/unit/eva/logo-image-generator.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for logo-image-generator.js
+ * SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+ */
+import { describe, it, expect } from 'vitest';
+import { buildLogoPrompt } from '../../../lib/eva/logo-image-generator.js';
+
+describe('logo-image-generator', () => {
+  describe('buildLogoPrompt', () => {
+    it('builds prompt from full logoSpec', () => {
+      const spec = {
+        name: 'GuardianCode',
+        colors: [{ hex: '#3B82F6' }, { hex: '#10B981' }],
+        style: 'modern tech',
+      };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('GuardianCode');
+      expect(prompt).toContain('#3B82F6');
+      expect(prompt).toContain('modern tech');
+      expect(prompt).toContain('professional');
+    });
+
+    it('handles null logoSpec with default prompt', () => {
+      const prompt = buildLogoPrompt(null);
+      expect(prompt).toContain('startup logo');
+      expect(prompt).toContain('blue');
+    });
+
+    it('handles empty object', () => {
+      const prompt = buildLogoPrompt({});
+      expect(prompt).toContain('Startup');
+    });
+
+    it('sanitizes special characters from name', () => {
+      const spec = { name: 'Test<script>alert("xss")</script>' };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).not.toContain('<script>');
+      expect(prompt).not.toContain('"xss"');
+    });
+
+    it('truncates long names', () => {
+      const spec = { name: 'A'.repeat(100) };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt.length).toBeLessThan(300);
+    });
+
+    it('limits colors to 3', () => {
+      const spec = {
+        name: 'Test',
+        colors: [
+          { hex: '#111' }, { hex: '#222' }, { hex: '#333' },
+          { hex: '#444' }, { hex: '#555' },
+        ],
+      };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('#111');
+      expect(prompt).toContain('#333');
+      expect(prompt).not.toContain('#444');
+    });
+
+    it('uses selectedName when name missing', () => {
+      const spec = { selectedName: 'BrandName' };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('BrandName');
+    });
+
+    it('uses primaryColor when colors array missing', () => {
+      const spec = { name: 'Test', primaryColor: 'green' };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('green');
+    });
+
+    it('includes icon-only instruction', () => {
+      const prompt = buildLogoPrompt({ name: 'Test' });
+      expect(prompt).toContain('icon only');
+      expect(prompt).toContain('white background');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- When `realpathSync` throws on a stale worktree path, clear it from DB and proceed instead of blocking
- Guard path comparison with null checks after self-heal
- Addresses 21 handoff failure occurrences across 5 patterns

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-096

## Test plan
- [x] 25 tests pass (10 claim-validity-gate + 15 smoke)
- [x] Self-heal only triggers for missing/deleted worktree paths
- [x] Valid worktree enforcement unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)