### PR TITLE
feat(S11): add Imagen 3 logo generation pipeline

### DIFF
--- a/lib/eva/bridge/imagen-logo-renderer.js
+++ b/lib/eva/bridge/imagen-logo-renderer.js
@@ -1,0 +1,179 @@
+/**
+ * Imagen Logo Renderer
+ * SD: SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+ *
+ * Renders logo images from S11 logoSpec using Google Imagen 3 via Gemini API.
+ * Returns a PNG buffer or null on failure (never throws).
+ */
+
+const IMAGEN_MODEL = 'imagen-3.0-generate-002';
+const FALLBACK_MODEL = 'imagen-3.0-generate-001';
+
+/**
+ * Render a logo image from a logoSpec using Google Imagen 3.
+ *
+ * @param {Object} logoSpec - From S11 output: {textTreatment, primaryColor, accentColor, typography, iconConcept, svgPrompt}
+ * @param {Object} [options]
+ * @param {string} [options.ventureName] - Venture name for fallback prompt
+ * @param {number} [options.maxRetries=2] - Max retry attempts
+ * @param {Object} [options.logger=console]
+ * @returns {Promise<{buffer: Buffer, mimeType: string}|null>} PNG image buffer or null
+ */
+export async function renderLogo(logoSpec, { ventureName = 'Venture', maxRetries = 2, logger = console } = {}) {
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    logger.warn('[ImagenLogo] No GEMINI_API_KEY or GOOGLE_AI_API_KEY — skipping logo generation');
+    return null;
+  }
+
+  if (!logoSpec || typeof logoSpec !== 'object') {
+    logger.warn('[ImagenLogo] No logoSpec provided — skipping');
+    return null;
+  }
+
+  const prompts = buildPromptVariants(logoSpec, ventureName);
+
+  for (let attempt = 0; attempt < Math.min(prompts.length, maxRetries + 1); attempt++) {
+    try {
+      const result = await callImagenAPI(apiKey, prompts[attempt], logger);
+      if (result) {
+        logger.log('[ImagenLogo] Logo generated successfully', { attempt, model: IMAGEN_MODEL });
+        return result;
+      }
+    } catch (err) {
+      logger.warn(`[ImagenLogo] Attempt ${attempt + 1} failed: ${err.message}`);
+    }
+  }
+
+  logger.warn('[ImagenLogo] All attempts exhausted — no logo generated');
+  return null;
+}
+
+/**
+ * Build prompt variants from logoSpec (most specific → most generic).
+ */
+function buildPromptVariants(logoSpec, ventureName) {
+  const name = logoSpec.textTreatment || ventureName;
+  const primary = logoSpec.primaryColor || '#2563EB';
+  const accent = logoSpec.accentColor || '#10B981';
+  const font = logoSpec.typography || 'Inter';
+
+  const prompts = [];
+
+  // Attempt 1: Full prompt from svgPrompt
+  if (logoSpec.svgPrompt) {
+    prompts.push(sanitizePrompt(logoSpec.svgPrompt));
+  }
+
+  // Attempt 2: Structured prompt from individual fields
+  prompts.push(sanitizePrompt(
+    `Professional minimalist logo for "${name}". ` +
+    `Colors: ${primary} primary, ${accent} accent. Font: ${font} bold. ` +
+    (logoSpec.iconConcept ? `Icon: ${logoSpec.iconConcept}. ` : '') +
+    'Clean vector style on white background. 512x512 pixels.'
+  ));
+
+  // Attempt 3: Simple text logo (safest for content policy)
+  prompts.push(sanitizePrompt(
+    `Simple text logo reading "${name}" in ${font} bold font, color ${primary}, on white background. Clean minimalist design. 512x512 pixels.`
+  ));
+
+  return prompts;
+}
+
+/**
+ * Sanitize prompt to reduce content policy rejection risk.
+ */
+function sanitizePrompt(prompt) {
+  return String(prompt)
+    .replace(/[<>{}]/g, '')       // Remove angle brackets and braces
+    .replace(/\s+/g, ' ')         // Collapse whitespace
+    .substring(0, 1000)           // Cap length
+    .trim();
+}
+
+/**
+ * Call Google Imagen 3 API to generate an image.
+ */
+async function callImagenAPI(apiKey, prompt, logger) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${IMAGEN_MODEL}:generateImages?key=${apiKey}`;
+
+  const body = {
+    instances: [{ prompt }],
+    parameters: {
+      sampleCount: 1,
+      aspectRatio: '1:1',
+      personGeneration: 'DONT_ALLOW',
+    },
+  };
+
+  logger.log('[ImagenLogo] Calling Imagen API', { promptLength: prompt.length });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60000),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => 'unknown');
+    // Try fallback model on 404 (model not found)
+    if (response.status === 404) {
+      return callImagenFallback(apiKey, prompt, logger);
+    }
+    throw new Error(`Imagen API ${response.status}: ${errText.substring(0, 200)}`);
+  }
+
+  const data = await response.json();
+  const predictions = data.predictions || data.generatedImages || [];
+  if (predictions.length === 0) {
+    logger.warn('[ImagenLogo] Imagen returned no predictions');
+    return null;
+  }
+
+  const imageData = predictions[0].bytesBase64Encoded || predictions[0].image?.bytesBase64Encoded;
+  if (!imageData) {
+    logger.warn('[ImagenLogo] No image data in prediction');
+    return null;
+  }
+
+  return {
+    buffer: Buffer.from(imageData, 'base64'),
+    mimeType: predictions[0].mimeType || 'image/png',
+  };
+}
+
+/**
+ * Fallback to older Imagen model if primary returns 404.
+ */
+async function callImagenFallback(apiKey, prompt, logger) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${FALLBACK_MODEL}:generateImages?key=${apiKey}`;
+  logger.log('[ImagenLogo] Trying fallback model', { model: FALLBACK_MODEL });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      instances: [{ prompt }],
+      parameters: { sampleCount: 1, aspectRatio: '1:1', personGeneration: 'DONT_ALLOW' },
+    }),
+    signal: AbortSignal.timeout(60000),
+  });
+
+  if (!response.ok) return null;
+
+  const data = await response.json();
+  const predictions = data.predictions || data.generatedImages || [];
+  if (predictions.length === 0) return null;
+
+  const imageData = predictions[0].bytesBase64Encoded || predictions[0].image?.bytesBase64Encoded;
+  if (!imageData) return null;
+
+  return {
+    buffer: Buffer.from(imageData, 'base64'),
+    mimeType: predictions[0].mimeType || 'image/png',
+  };
+}
+
+export { buildPromptVariants, sanitizePrompt };

--- a/lib/eva/logo-image-generator.js
+++ b/lib/eva/logo-image-generator.js
@@ -1,0 +1,116 @@
+/**
+ * Logo Image Generator
+ * SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+ *
+ * Post-S11 hook that generates venture logo images using Google Imagen 3
+ * via the Gemini API, uploads to Supabase Storage, and writes the URL
+ * to venture_artifacts via the artifact persistence service.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { writeArtifact } from './artifact-persistence-service.js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const IMAGEN_MODEL = 'imagen-3.0-generate-002';
+const MAX_RETRIES = 2;
+const BUCKET_NAME = 'venture-logos';
+
+/**
+ * Sanitize logo spec into a safe Imagen prompt.
+ * @param {object} logoSpec - Brand identity data from S11
+ * @returns {string} Sanitized prompt
+ */
+export function buildLogoPrompt(logoSpec) {
+  if (!logoSpec || typeof logoSpec !== 'object') {
+    return 'A clean, modern startup logo with blue and white colors';
+  }
+  const name = String(logoSpec.name || logoSpec.selectedName || 'Startup').slice(0, 50).replace(/[^\w\s-]/g, '');
+  const colors = Array.isArray(logoSpec.colors)
+    ? logoSpec.colors.slice(0, 3).map(c => String(c.hex || c).slice(0, 7)).join(', ')
+    : logoSpec.primaryColor || 'blue';
+  const style = String(logoSpec.style || 'modern minimalist').slice(0, 30).replace(/[^\w\s-]/g, '');
+  return `A professional ${style} logo for "${name}". Colors: ${colors}. Clean vector style on white background, suitable for web header. No text overlay, icon only.`;
+}
+
+function buildSimplifiedPrompt(logoSpec) {
+  const name = String(logoSpec?.name || 'Startup').slice(0, 30).replace(/[^\w\s]/g, '');
+  return `A simple, clean geometric logo icon in blue tones on white background for a company called "${name}". Minimal, professional, icon only.`;
+}
+
+async function callImagen(prompt) {
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) { console.warn('[logo-gen] No API key — skipping'); return null; }
+
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${IMAGEN_MODEL}:predict?key=${apiKey}`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instances: [{ prompt }],
+        parameters: { sampleCount: 1, aspectRatio: '1:1', safetyFilterLevel: 'block_few' },
+      }),
+    });
+    if (!response.ok) { console.warn(`[logo-gen] Imagen ${response.status}`); return null; }
+    const data = await response.json();
+    const imageData = data?.predictions?.[0]?.bytesBase64Encoded;
+    return imageData ? Buffer.from(imageData, 'base64') : null;
+  } catch (err) { console.warn(`[logo-gen] ${err.message}`); return null; }
+}
+
+async function uploadToStorage(supabase, ventureId, imageBuffer) {
+  const filePath = `${ventureId}/logo.png`;
+  const { error } = await supabase.storage.from(BUCKET_NAME).upload(filePath, imageBuffer, { contentType: 'image/png', upsert: true });
+  if (error) { console.warn(`[logo-gen] Upload failed: ${error.message}`); return null; }
+  const { data: urlData } = supabase.storage.from(BUCKET_NAME).getPublicUrl(filePath);
+  return urlData?.publicUrl || null;
+}
+
+/**
+ * Generate and store a logo image for a venture.
+ * @param {string} ventureId
+ * @param {object} logoSpec - Brand identity from S11
+ * @param {object} [options]
+ * @returns {Promise<{success: boolean, logoUrl: string|null, error: string|null}>}
+ */
+export async function generateLogoImage(ventureId, logoSpec, options = {}) {
+  const { minStage = 7 } = options;
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  // Viability gate
+  const { data: venture } = await supabase.from('ventures').select('current_lifecycle_stage').eq('id', ventureId).single();
+  if (!venture || venture.current_lifecycle_stage < minStage) {
+    return { success: false, logoUrl: null, error: `Stage ${venture?.current_lifecycle_stage || 0} < ${minStage}` };
+  }
+
+  // Idempotency
+  const { data: existing } = await supabase.from('venture_artifacts')
+    .select('id, content').eq('venture_id', ventureId).eq('artifact_type', 'logo_image').eq('is_current', true).maybeSingle();
+  if (existing?.content?.logo_url) {
+    return { success: true, logoUrl: existing.content.logo_url, error: null };
+  }
+
+  // Generate with retries
+  let imageBuffer = null;
+  let prompt = buildLogoPrompt(logoSpec);
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    imageBuffer = await callImagen(prompt);
+    if (imageBuffer) break;
+    if (attempt < MAX_RETRIES) { prompt = buildSimplifiedPrompt(logoSpec); }
+  }
+  if (!imageBuffer) return { success: false, logoUrl: null, error: 'Generation failed' };
+
+  // Upload
+  const logoUrl = await uploadToStorage(supabase, ventureId, imageBuffer);
+  if (!logoUrl) return { success: false, logoUrl: null, error: 'Upload failed' };
+
+  // Write via persistence service
+  await writeArtifact(supabase, {
+    ventureId, lifecycleStage: 11, artifactType: 'logo_image',
+    content: { logo_url: logoUrl, prompt, generated_at: new Date().toISOString() },
+  });
+
+  return { success: true, logoUrl, error: null };
+}
+
+export default { generateLogoImage, buildLogoPrompt };

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -161,6 +161,7 @@ export class StageExecutionWorker {
      * @type {Map<number, (ventureId: string) => Promise<void>>}
      */
     this._postStageHookRegistry = new Map([
+      [11, (ventureId) => this._postStageHook_S11_LogoGeneration(ventureId)],
       [15, (ventureId) => this._postStageHook_S15_StitchProvision(ventureId)],
       [17, (ventureId) => this._postStageHook_S17_DocGen(ventureId)],
       [19, (ventureId) => this._postStageHook_S19_Bridge(ventureId)],
@@ -2092,6 +2093,125 @@ export class StageExecutionWorker {
    * S17 post-stage hook: Generate EVA vision + architecture plan documents.
    * @param {string} ventureId
    */
+  /**
+   * S11 post-stage hook: Generate logo image from logoSpec via Imagen 3.
+   * SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+   *
+   * Viability gate: only renders for ventures past S7 (strategy formulation).
+   * Idempotent: skips if logo already exists in venture_artifacts.
+   */
+  async _postStageHook_S11_LogoGeneration(ventureId) {
+    const logger = this._logger;
+
+    // Viability gate: check venture has passed S7
+    const { data: stages } = await this._supabase
+      .from('venture_stage_work')
+      .select('lifecycle_stage')
+      .eq('venture_id', ventureId)
+      .gte('lifecycle_stage', 7)
+      .limit(1);
+    if (!stages || stages.length === 0) {
+      logger.log('[S11-Logo] Skipping — venture has not passed S7');
+      return;
+    }
+
+    // Idempotency: check if logo already exists
+    const { data: existing } = await this._supabase
+      .from('venture_artifacts')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'identity_logo_image')
+      .limit(1);
+    if (existing && existing.length > 0) {
+      logger.log('[S11-Logo] Skipping — logo already exists');
+      return;
+    }
+
+    // Load S11 data to get logoSpec
+    const { data: s11Work } = await this._supabase
+      .from('venture_stage_work')
+      .select('stage_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 11)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const logoSpec = s11Work?.stage_data?.logoSpec;
+    if (!logoSpec) {
+      logger.log('[S11-Logo] No logoSpec in S11 data — skipping');
+      return;
+    }
+
+    // Get venture name for fallback prompt
+    const { data: venture } = await this._supabase
+      .from('ventures')
+      .select('name')
+      .eq('id', ventureId)
+      .single();
+
+    // Render logo via Imagen 3
+    const { renderLogo } = await import('./bridge/imagen-logo-renderer.js');
+    const result = await renderLogo(logoSpec, {
+      ventureName: venture?.name || 'Venture',
+      maxRetries: 2,
+      logger,
+    });
+
+    if (!result) {
+      logger.warn('[S11-Logo] Logo generation failed — venture will use text fallback');
+      return;
+    }
+
+    // Upload to Supabase Storage
+    const storagePath = `logos/${ventureId}/logo.png`;
+    const { error: uploadErr } = await this._supabase.storage
+      .from('venture-logos')
+      .upload(storagePath, result.buffer, {
+        contentType: result.mimeType,
+        upsert: true,
+      });
+
+    if (uploadErr) {
+      // Bucket may not exist yet — try to create it
+      if (uploadErr.message?.includes('not found') || uploadErr.statusCode === 404) {
+        logger.log('[S11-Logo] Creating venture-logos bucket');
+        await this._supabase.storage.createBucket('venture-logos', { public: true });
+        const { error: retryErr } = await this._supabase.storage
+          .from('venture-logos')
+          .upload(storagePath, result.buffer, { contentType: result.mimeType, upsert: true });
+        if (retryErr) {
+          logger.warn('[S11-Logo] Upload failed after bucket creation:', retryErr.message);
+          return;
+        }
+      } else {
+        logger.warn('[S11-Logo] Upload failed:', uploadErr.message);
+        return;
+      }
+    }
+
+    // Get public URL
+    const { data: urlData } = this._supabase.storage
+      .from('venture-logos')
+      .getPublicUrl(storagePath);
+
+    const logoUrl = urlData?.publicUrl;
+
+    // Write logo artifact
+    const { writeArtifact } = await import('./artifact-persistence-service.js');
+    await writeArtifact(this._supabase, {
+      ventureId,
+      lifecycleStage: 11,
+      artifactType: 'identity_logo_image',
+      title: 'Logo Image (Imagen 3)',
+      artifactData: { logoUrl, logoSpec, storagePath, generatedAt: new Date().toISOString() },
+      metadata: { source: 'post-stage-11-hook', renderer: 'imagen-3' },
+      source: 'post-stage-11-logo-hook',
+    });
+
+    logger.log('[S11-Logo] Logo generated and stored', { logoUrl, storagePath });
+  }
+
   /**
    * S15 post-stage hook: Provision Stitch design project via stitch-provisioner.
    * SD-LEO-FIX-FIX-STAGE-VENTURE-001: Wire postStage15Hook into pipeline.

--- a/tests/unit/eva/imagen-logo-renderer.test.js
+++ b/tests/unit/eva/imagen-logo-renderer.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for Imagen Logo Renderer
+ * SD: SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildPromptVariants, sanitizePrompt } from '../../../lib/eva/bridge/imagen-logo-renderer.js';
+
+describe('imagen-logo-renderer', () => {
+  describe('buildPromptVariants', () => {
+    it('should return 3 prompts when svgPrompt is provided', () => {
+      const spec = {
+        textTreatment: 'ACME',
+        primaryColor: '#2563EB',
+        accentColor: '#10B981',
+        typography: 'Inter',
+        iconConcept: 'A mountain peak',
+        svgPrompt: 'Create a minimal SVG logo with mountain icon',
+      };
+      const prompts = buildPromptVariants(spec, 'Acme Corp');
+      expect(prompts).toHaveLength(3);
+      expect(prompts[0]).toContain('mountain icon');
+      expect(prompts[1]).toContain('ACME');
+      expect(prompts[2]).toContain('ACME');
+    });
+
+    it('should return 2 prompts when svgPrompt is missing', () => {
+      const spec = { textTreatment: 'TestCo', primaryColor: '#FF0000' };
+      const prompts = buildPromptVariants(spec, 'TestCo');
+      expect(prompts).toHaveLength(2);
+    });
+
+    it('should use ventureName as fallback for textTreatment', () => {
+      const spec = { primaryColor: '#000000' };
+      const prompts = buildPromptVariants(spec, 'FallbackName');
+      expect(prompts[0]).toContain('FallbackName');
+    });
+
+    it('should use default colors when not provided', () => {
+      const spec = {};
+      const prompts = buildPromptVariants(spec, 'Test');
+      expect(prompts[0]).toContain('#2563EB');
+    });
+  });
+
+  describe('sanitizePrompt', () => {
+    it('should remove angle brackets and braces', () => {
+      expect(sanitizePrompt('a <b> {c}')).toBe('a b c');
+    });
+
+    it('should collapse whitespace', () => {
+      expect(sanitizePrompt('a   b\n\nc')).toBe('a b c');
+    });
+
+    it('should cap length at 1000 chars', () => {
+      const long = 'x'.repeat(2000);
+      expect(sanitizePrompt(long).length).toBe(1000);
+    });
+
+    it('should handle non-string input', () => {
+      expect(sanitizePrompt(123)).toBe('123');
+      expect(sanitizePrompt(null)).toBe('null');
+    });
+  });
+});

--- a/tests/unit/eva/logo-image-generator.test.js
+++ b/tests/unit/eva/logo-image-generator.test.js
@@ -1,0 +1,56 @@
+/**
+ * Tests for logo-image-generator.js
+ * SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
+ */
+import { describe, it, expect } from 'vitest';
+import { buildLogoPrompt } from '../../../lib/eva/logo-image-generator.js';
+
+describe('logo-image-generator', () => {
+  describe('buildLogoPrompt', () => {
+    it('builds prompt from full logoSpec', () => {
+      const spec = { name: 'GuardianCode', colors: [{ hex: '#3B82F6' }, { hex: '#10B981' }], style: 'modern tech' };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('GuardianCode');
+      expect(prompt).toContain('#3B82F6');
+      expect(prompt).toContain('modern tech');
+    });
+
+    it('handles null logoSpec with default', () => {
+      expect(buildLogoPrompt(null)).toContain('startup logo');
+    });
+
+    it('handles empty object', () => {
+      expect(buildLogoPrompt({})).toContain('Startup');
+    });
+
+    it('sanitizes special characters', () => {
+      const prompt = buildLogoPrompt({ name: 'Test<script>xss</script>' });
+      expect(prompt).not.toContain('<script>');
+    });
+
+    it('truncates long names', () => {
+      expect(buildLogoPrompt({ name: 'A'.repeat(100) }).length).toBeLessThan(300);
+    });
+
+    it('limits colors to 3', () => {
+      const spec = { name: 'T', colors: [{ hex: '#111' }, { hex: '#222' }, { hex: '#333' }, { hex: '#444' }] };
+      const prompt = buildLogoPrompt(spec);
+      expect(prompt).toContain('#333');
+      expect(prompt).not.toContain('#444');
+    });
+
+    it('uses selectedName fallback', () => {
+      expect(buildLogoPrompt({ selectedName: 'Brand' })).toContain('Brand');
+    });
+
+    it('uses primaryColor fallback', () => {
+      expect(buildLogoPrompt({ name: 'T', primaryColor: 'green' })).toContain('green');
+    });
+
+    it('includes icon-only instruction', () => {
+      const prompt = buildLogoPrompt({ name: 'T' });
+      expect(prompt).toContain('icon only');
+      expect(prompt).toContain('white background');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add post-S11 hook that renders logos via Google Imagen 3 API
- Logo images uploaded to Supabase Storage (venture-logos bucket)
- Viability gate (S7+), idempotency, auto-bucket creation
- Prompt fallback chain: full svgPrompt -> structured -> text-only
- 8 unit tests for prompt building and sanitization

## Test plan
- [x] 8 unit tests (prompt variants, sanitization, edge cases)
- [x] Smoke tests pass (15/15)

SD: SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)