### PR TITLE
feat(seeder): filter wireframe screens by target_platform

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -162,7 +162,7 @@ function generateArchitectureDoc(groups) {
   return lines.join('\n');
 }
 
-function generateWireframesDoc(groups) {
+function generateWireframesDoc(groups, { targetPlatform = 'web' } = {}) {
   const lines = ['# Application Wireframes\n'];
   const archGroup = findGroup(groups, 'how_to_build_it');
   if (!archGroup) return '';
@@ -173,10 +173,34 @@ function generateWireframesDoc(groups) {
   if (!wfArt?.content) return '';
 
   const data = parseContent(wfArt.content) || {};
-  const screens = data.wireframes?.screens || data.screens || [];
+  let screens = data.wireframes?.screens || data.screens || [];
   if (screens.length === 0) return '';
 
-  lines.push(`Total screens: ${screens.length}\n`);
+  // Filter screens by platform (SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-B)
+  const MOBILE_KEYWORDS = /\b(mobile|phone|ios|android|app.home|on.the.go)\b/i;
+  const DESKTOP_KEYWORDS = /\b(dashboard|admin|analytics|portal|editor|console|monitor)\b/i;
+
+  if (targetPlatform === 'mobile') {
+    const mobileScreens = screens.filter(s => {
+      const text = `${s.name || ''} ${s.purpose || ''}`;
+      return MOBILE_KEYWORDS.test(text) || !DESKTOP_KEYWORDS.test(text);
+    });
+    screens = mobileScreens.length > 0 ? mobileScreens : screens; // fallback to all if none match
+  } else if (targetPlatform === 'web') {
+    const webScreens = screens.filter(s => {
+      const text = `${s.name || ''} ${s.purpose || ''}`;
+      return DESKTOP_KEYWORDS.test(text) || !MOBILE_KEYWORDS.test(text);
+    });
+    screens = webScreens.length > 0 ? webScreens : screens;
+  }
+  // targetPlatform === 'both': keep all screens, mobile-first ordering
+  if (targetPlatform === 'both') {
+    const mobile = screens.filter(s => MOBILE_KEYWORDS.test(`${s.name || ''} ${s.purpose || ''}`));
+    const other = screens.filter(s => !MOBILE_KEYWORDS.test(`${s.name || ''} ${s.purpose || ''}`));
+    screens = [...mobile, ...other];
+  }
+
+  lines.push(`Platform: ${targetPlatform} | Screens: ${screens.length}\n`);
 
   for (const screen of screens) {
     lines.push(`## ${screen.name || 'Screen'}`);
@@ -348,7 +372,7 @@ npx @sentry/wizard@latest -i nextjs
  */
 // ── Agent-Optimized Document Generators ────────────
 
-function generateSpecDoc(groups, ventureName) {
+function generateSpecDoc(groups, ventureName, { targetPlatform = 'web' } = {}) {
   const lines = [`# ${ventureName || 'Venture'} — Specification\n`];
 
   // Section 1: Problem Statement (from context doc)
@@ -380,7 +404,7 @@ function generateSpecDoc(groups, ventureName) {
 
   // Section 4: Screen Layouts (from wireframes doc)
   lines.push('## Screen Layouts\n');
-  const wireContent = generateWireframesDoc(groups);
+  const wireContent = generateWireframesDoc(groups, { targetPlatform });
   if (wireContent.length > 20) {
     lines.push(wireContent.replace(/^# Application Wireframes\n*/m, ''));
   } else {
@@ -546,10 +570,11 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
 
   const groups = data.groups;
 
-  // Get venture name
+  // Get venture name and platform
   const { data: venture } = await supabase
-    .from('ventures').select('name').eq('id', ventureId).single();
+    .from('ventures').select('name, target_platform').eq('id', ventureId).single();
   const ventureName = venture?.name || 'Venture';
+  const targetPlatform = venture?.target_platform || 'web';
 
   // Determine clone directory
   const match = repoUrl.match(/\/([^/]+?)(?:\.git)?$/);
@@ -601,14 +626,14 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
 
   // Generate and write each document
   const docs = docFormat === 'agent-optimized' ? [
-    { name: 'spec.md', generator: () => generateSpecDoc(groups, ventureName), required: true },
+    { name: 'spec.md', generator: () => generateSpecDoc(groups, ventureName, { targetPlatform }), required: true },
     { name: 'tasks.md', generator: () => generateTasksDoc(groups), required: true },
     { name: 'architecture.md', generator: () => generateArchitectureDoc(groups), required: true },
     { name: 'branding.md', generator: () => generateBrandingDoc(groups), required: true },
   ] : [
     { name: 'branding.md', generator: () => generateBrandingDoc(groups), required: true },
     { name: 'architecture.md', generator: () => generateArchitectureDoc(groups), required: true },
-    { name: 'wireframes.md', generator: () => generateWireframesDoc(groups), required: true },
+    { name: 'wireframes.md', generator: () => generateWireframesDoc(groups, { targetPlatform }), required: true },
     { name: 'context.md', generator: () => generateContextDoc(groups), required: false },
     { name: 'pricing.md', generator: () => generatePricingDoc(groups), required: false },
     { name: 'monitoring.md', generator: () => generateMonitoringDoc(ventureName, sentryConfig), required: false },


### PR DESCRIPTION
## Summary
- Filter WIREFRAMES.md by ventures.target_platform (mobile/web/both)
- Mobile ventures get mobile screens, web gets desktop, both gets all mobile-first
- Fallback to all screens when filter yields empty
- Platform indicator in wireframes header

## Test plan
- [x] All handoffs passed (92%, 88%, 84%, 86%)

SD: SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)