### PR TITLE
feat(security): extract mobile security defaults as shared module

### DIFF
--- a/lib/eva/bridge/mobile-security-defaults.js
+++ b/lib/eva/bridge/mobile-security-defaults.js
@@ -1,0 +1,88 @@
+/**
+ * Mobile Security Defaults — Shared Module
+ * SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-C
+ *
+ * Codifies mobile security patterns as reusable defaults that all
+ * mobile Replit templates must include. Extracted as a shared module
+ * so future platform-specific templates (Option B migration) inherit
+ * these patterns automatically.
+ *
+ * @module lib/eva/bridge/mobile-security-defaults
+ */
+
+/**
+ * Security instructions for mobile (Expo/React Native) builds.
+ * Included in Replit prompts when target_platform is 'mobile' or 'both'.
+ */
+export const MOBILE_SECURITY_INSTRUCTIONS = `### Mobile Security Requirements
+
+**Secure Storage**:
+- Use \`expo-secure-store\` for tokens, API keys, and sensitive user data
+- NEVER store secrets in AsyncStorage — it is unencrypted plaintext on device
+- Supabase auth tokens should use SecureStore adapter:
+  \`\`\`typescript
+  import * as SecureStore from 'expo-secure-store';
+  const supabase = createClient(url, key, {
+    auth: { storage: {
+      getItem: (key) => SecureStore.getItemAsync(key),
+      setItem: (key, value) => SecureStore.setItemAsync(key, value),
+      removeItem: (key) => SecureStore.deleteItemAsync(key),
+    }}
+  });
+  \`\`\`
+
+**Certificate Pinning** (Production):
+- Pin Supabase API certificates to prevent MITM attacks
+- Use \`expo-certificate-transparency\` or custom TLS verification
+- At minimum, verify HTTPS is enforced on all API calls
+
+**Deep Link Security**:
+- Validate all deep link parameters before navigation
+- Never pass authentication tokens via deep link URLs
+- Use Universal Links (iOS) / App Links (Android) over custom URL schemes
+
+**App Transport Security**:
+- All network requests MUST use HTTPS — no HTTP exceptions
+- Configure \`app.json\` with strict transport security settings
+
+**No Embedded Secrets**:
+- API keys, database URLs, and service credentials must come from environment variables
+- React Native JS bundles can be decompiled — assume all bundled code is public
+- Use Supabase Edge Functions for server-side operations requiring elevated access
+
+**OTA Update Security** (Expo Updates):
+- Enable code signing for OTA updates when using \`expo-updates\`
+- Verify update integrity before applying
+- Use release channels to separate staging/production updates`;
+
+/**
+ * Security instructions for web builds.
+ * Used when target_platform is 'web'.
+ */
+export const WEB_SECURITY_INSTRUCTIONS = `### Web Security Requirements
+
+**Key Management**:
+- \`SUPABASE_ANON_KEY\` is safe for client-side code (designed for browser use with RLS)
+- \`SUPABASE_SERVICE_ROLE_KEY\` MUST NEVER appear in client code — it bypasses RLS entirely
+- All third-party API keys belong in Supabase Edge Functions only
+
+**SECURITY DEFINER Functions**:
+- Avoid \`SECURITY DEFINER\` on PostgreSQL functions — they bypass all RLS policies
+- If unavoidable, add explicit \`auth.uid()\` checks inside the function body
+
+**Rate Limiting**:
+- Edge Functions handling sensitive operations must implement rate limiting
+- Use Supabase built-in rate limiting or in-memory counter per user`;
+
+/**
+ * Get the appropriate security instructions for a target platform.
+ *
+ * @param {'mobile'|'web'|'both'} targetPlatform
+ * @returns {string} Security instruction block for Replit prompts
+ */
+export function getSecurityInstructions(targetPlatform) {
+  if (targetPlatform === 'mobile' || targetPlatform === 'both') {
+    return MOBILE_SECURITY_INSTRUCTIONS;
+  }
+  return WEB_SECURITY_INSTRUCTIONS;
+}

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -9,6 +9,7 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { isMainModule } from '../../utils/is-main-module.js';
+import { getSecurityInstructions } from './mobile-security-defaults.js';
 dotenv.config();
 
 const TOKEN_BUDGET_WARN = 50000; // chars (~12.5K tokens)
@@ -67,26 +68,14 @@ function buildReplitInstructions(groups) {
 - Responsive design (mobile-first)
 - Accessibility basics (semantic HTML, ARIA labels)
 
-### Security Requirements
+${getSecurityInstructions(targetPlatform)}
+
+### Database Security (All Platforms)
 **Row Level Security (RLS)**:
 - Enable RLS on EVERY public table: \`ALTER TABLE public.my_table ENABLE ROW LEVEL SECURITY;\`
 - Every policy MUST scope to the authenticated user via \`auth.uid()\`
 - NEVER use \`USING (true)\` — this makes the table readable/writable by everyone
 - Create separate policies for SELECT, INSERT, UPDATE, DELETE as needed
-
-**Key Management**:
-- \`SUPABASE_ANON_KEY\` is safe for client-side code (designed for browser use with RLS)
-- \`SUPABASE_SERVICE_ROLE_KEY\` MUST NEVER appear in client code — it bypasses RLS entirely
-- All third-party API keys (Stripe, AI providers, etc.) belong in Supabase Edge Functions only
-- Use \`Deno.env.get()\` inside Edge Functions to access secrets
-
-**SECURITY DEFINER Functions**:
-- Avoid \`SECURITY DEFINER\` on PostgreSQL functions — they execute as the function owner (superuser), bypassing all RLS policies
-- If unavoidable, add explicit \`auth.uid()\` checks inside the function body
-
-**Rate Limiting**:
-- Edge Functions handling sensitive operations (payments, auth, AI calls) must implement rate limiting
-- Use Supabase's built-in rate limiting or a simple in-memory counter per user
 
 ### Monitoring & Error Tracking
 1. Install Sentry SDK: \`npm install @sentry/node\`

--- a/tests/unit/eva/bridge/mobile-security-defaults.test.js
+++ b/tests/unit/eva/bridge/mobile-security-defaults.test.js
@@ -1,0 +1,37 @@
+/**
+ * Tests for mobile security defaults shared module
+ * SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-C
+ */
+import { describe, it, expect } from 'vitest';
+import { getSecurityInstructions, MOBILE_SECURITY_INSTRUCTIONS, WEB_SECURITY_INSTRUCTIONS } from '../../../../lib/eva/bridge/mobile-security-defaults.js';
+
+describe('Mobile security defaults', () => {
+  it('returns mobile instructions for mobile platform', () => {
+    const result = getSecurityInstructions('mobile');
+    expect(result).toBe(MOBILE_SECURITY_INSTRUCTIONS);
+    expect(result).toContain('expo-secure-store');
+    expect(result).toContain('Certificate Pinning');
+    expect(result).toContain('Deep Link Security');
+  });
+
+  it('returns mobile instructions for both platform', () => {
+    const result = getSecurityInstructions('both');
+    expect(result).toBe(MOBILE_SECURITY_INSTRUCTIONS);
+  });
+
+  it('returns web instructions for web platform', () => {
+    const result = getSecurityInstructions('web');
+    expect(result).toBe(WEB_SECURITY_INSTRUCTIONS);
+    expect(result).toContain('SUPABASE_ANON_KEY');
+    expect(result).not.toContain('expo-secure-store');
+  });
+
+  it('mobile instructions include OTA security', () => {
+    expect(MOBILE_SECURITY_INSTRUCTIONS).toContain('OTA Update Security');
+    expect(MOBILE_SECURITY_INSTRUCTIONS).toContain('code signing');
+  });
+
+  it('mobile instructions warn against AsyncStorage for secrets', () => {
+    expect(MOBILE_SECURITY_INSTRUCTIONS).toContain('NEVER store secrets in AsyncStorage');
+  });
+});


### PR DESCRIPTION
## Summary
- New `mobile-security-defaults.js` module with platform-specific security patterns
- SecureStore, cert pinning, deep link validation, OTA signing for mobile
- Standard web security (key management, RLS, rate limiting) for web
- Wired into replit-prompt-formatter via `getSecurityInstructions()`

## Test plan
- [x] 5/5 unit tests pass
- [x] All handoffs passed (91%, 91%, 84%, 88%)

SD: SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)