### PR TITLE
feat(rubric): add target platform decision rubric with programmatic enforcement

### DIFF
--- a/docs/reference/target-platform-decision-rubric.md
+++ b/docs/reference/target-platform-decision-rubric.md
@@ -1,0 +1,85 @@
+# Target Platform Decision Rubric
+
+## Overview
+
+Every EHG venture must have `target_platform` set before Stage 15 (Design/Wireframes). This field controls which Stitch screens are generated, which Replit template is used, and which security patterns are applied.
+
+## Decision Matrix
+
+| Signal | Mobile | Web | Both |
+|--------|--------|-----|------|
+| **Primary audience** | B2C consumers | B2B enterprise / dashboards | Consumer app + admin panel |
+| **Location services needed** | Yes | No | Mixed |
+| **Camera/push notifications** | Yes | No | Consumer needs push, admin doesn't |
+| **Complex data entry** | No | Yes (forms, tables, spreadsheets) | Consumer simple, admin complex |
+| **SEO discovery important** | No | Yes | Landing page web, app mobile |
+| **Multi-monitor workflow** | No | Yes | No |
+| **Offline capability needed** | Yes | No | Consumer offline, admin online |
+| **App Store presence** | Yes | No | Consumer yes, admin no |
+
+## Quick Decision Flow
+
+```
+Is the primary user a consumer on their phone?
+├── YES → Is SEO important for discovery?
+│   ├── YES → target_platform = 'both' (PWA web + native mobile)
+│   └── NO → target_platform = 'mobile'
+└── NO → Is this a dashboard/admin/analytics tool?
+    ├── YES → target_platform = 'web'
+    └── NO → target_platform = 'both'
+```
+
+## Platform Implications
+
+### target_platform = 'mobile'
+- **Replit template**: Expo (React Native)
+- **Stitch screens**: Mobile viewport designs only
+- **Build output**: iOS + Android via Expo EAS Build
+- **Testing**: Expo Go QR code on physical device
+- **Distribution**: App Store + Google Play
+- **Cost**: $99/yr Apple + $25 Google
+
+### target_platform = 'web'
+- **Replit template**: React + Vite or Next.js
+- **Stitch screens**: Desktop viewport designs only
+- **Build output**: Static site or SSR web app
+- **Testing**: Browser preview in Replit
+- **Distribution**: URL (Replit hosting or custom domain)
+- **Cost**: Replit hosting (included)
+
+### target_platform = 'both'
+- **Replit template**: Expo (handles web + mobile from single codebase)
+- **Stitch screens**: Both viewports, mobile-first ordering
+- **Build output**: Native mobile + Expo web
+- **Testing**: Expo Go for mobile, browser for web
+- **Distribution**: App Stores + URL
+- **Cost**: $99/yr Apple + $25 Google + hosting
+
+## Default Behavior
+
+- **Default**: `target_platform = 'both'` (mobile-first with web support)
+- **Rationale**: Expo handles both platforms from one codebase, maximizing reach
+- **Override**: Set explicitly when venture has clear single-platform focus
+
+## When to Revisit
+
+Re-evaluate target_platform when:
+1. User research reveals unexpected platform preference
+2. Feature requirements change (e.g., adding camera support → consider mobile)
+3. Revenue data shows one platform dominating (>80% of users)
+4. Competitive analysis shows platform gap
+
+## Database Field
+
+```sql
+-- ventures.target_platform
+-- Values: 'mobile', 'web', 'both'
+-- Default: 'both'
+-- Set before Stage 15 (Design/Wireframes)
+ALTER TABLE ventures ADD COLUMN target_platform TEXT DEFAULT 'both';
+```
+
+## Related SDs
+- SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-A: Template selection
+- SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-B: Wireframe filtering
+- SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-C: Security defaults

--- a/lib/eva/bridge/target-platform-rubric.js
+++ b/lib/eva/bridge/target-platform-rubric.js
@@ -1,0 +1,114 @@
+/**
+ * Target Platform Decision Rubric — Programmatic Enforcement
+ * SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-D
+ *
+ * Auto-recommends target_platform based on venture characteristics.
+ * Called before Stage 15 to ensure platform is set correctly.
+ *
+ * @module lib/eva/bridge/target-platform-rubric
+ */
+
+// Signal keywords that indicate platform preference
+const MOBILE_SIGNALS = [
+  'location', 'gps', 'map', 'nearby', 'navigation',
+  'camera', 'photo', 'scan', 'qr', 'barcode',
+  'push notification', 'alert', 'reminder',
+  'on-the-go', 'mobile', 'phone', 'app',
+  'fitness', 'health', 'tracking', 'wearable',
+  'offline', 'sync', 'local-first',
+  'b2c', 'consumer', 'marketplace', 'social',
+];
+
+const WEB_SIGNALS = [
+  'dashboard', 'admin', 'analytics', 'reporting',
+  'spreadsheet', 'table', 'data entry', 'form-heavy',
+  'multi-monitor', 'workspace', 'editor',
+  'seo', 'search engine', 'organic traffic', 'content marketing',
+  'b2b', 'enterprise', 'saas', 'crm', 'erp',
+  'portal', 'backoffice', 'management',
+];
+
+/**
+ * Analyze venture metadata to recommend target_platform.
+ *
+ * @param {object} venture - Venture record with description, metadata, etc.
+ * @param {string} venture.description - Venture description
+ * @param {string} [venture.name] - Venture name
+ * @param {object} [venture.metadata] - Additional venture metadata
+ * @returns {{ recommendation: 'mobile'|'web'|'both', confidence: number, signals: object }}
+ */
+export function recommendPlatform(venture) {
+  const text = [
+    venture.description || '',
+    venture.name || '',
+    venture.metadata?.problem_statement || '',
+    venture.metadata?.target_audience || '',
+    venture.metadata?.value_proposition || '',
+  ].join(' ').toLowerCase();
+
+  let mobileScore = 0;
+  let webScore = 0;
+  const matchedMobile = [];
+  const matchedWeb = [];
+
+  for (const signal of MOBILE_SIGNALS) {
+    if (text.includes(signal)) {
+      mobileScore++;
+      matchedMobile.push(signal);
+    }
+  }
+
+  for (const signal of WEB_SIGNALS) {
+    if (text.includes(signal)) {
+      webScore++;
+      matchedWeb.push(signal);
+    }
+  }
+
+  let recommendation;
+  let confidence;
+
+  if (mobileScore > 0 && webScore > 0) {
+    recommendation = 'both';
+    confidence = 0.7;
+  } else if (mobileScore > webScore) {
+    recommendation = 'mobile';
+    confidence = Math.min(0.95, 0.5 + mobileScore * 0.1);
+  } else if (webScore > mobileScore) {
+    recommendation = 'web';
+    confidence = Math.min(0.95, 0.5 + webScore * 0.1);
+  } else {
+    // No signals — default to both (mobile-first with web support)
+    recommendation = 'both';
+    confidence = 0.5;
+  }
+
+  return {
+    recommendation,
+    confidence,
+    signals: {
+      mobile: { score: mobileScore, matched: matchedMobile },
+      web: { score: webScore, matched: matchedWeb },
+    },
+  };
+}
+
+/**
+ * Validate that a venture has target_platform set.
+ * Called as a pre-Stage-15 gate.
+ *
+ * @param {object} venture - Venture record
+ * @returns {{ valid: boolean, message: string, autoSet?: string }}
+ */
+export function validatePlatformSet(venture) {
+  if (venture.target_platform && ['mobile', 'web', 'both'].includes(venture.target_platform)) {
+    return { valid: true, message: `target_platform is set to '${venture.target_platform}'` };
+  }
+
+  const { recommendation, confidence, signals } = recommendPlatform(venture);
+  return {
+    valid: false,
+    message: `target_platform not set. Auto-recommendation: '${recommendation}' (confidence: ${Math.round(confidence * 100)}%). Mobile signals: ${signals.mobile.matched.join(', ') || 'none'}. Web signals: ${signals.web.matched.join(', ') || 'none'}.`,
+    autoSet: recommendation,
+  };
+}

--- a/tests/unit/eva/bridge/target-platform-rubric.test.js
+++ b/tests/unit/eva/bridge/target-platform-rubric.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for target platform decision rubric
+ * SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-D
+ */
+import { describe, it, expect } from 'vitest';
+import { recommendPlatform, validatePlatformSet } from '../../../../lib/eva/bridge/target-platform-rubric.js';
+
+describe('Target platform rubric', () => {
+  describe('recommendPlatform', () => {
+    it('recommends mobile for location-based consumer app', () => {
+      const result = recommendPlatform({ description: 'A B2C app that helps consumers find nearby parking using GPS location tracking' });
+      expect(result.recommendation).toBe('mobile');
+      expect(result.signals.mobile.score).toBeGreaterThan(0);
+    });
+
+    it('recommends web for B2B dashboard', () => {
+      const result = recommendPlatform({ description: 'An enterprise SaaS dashboard for analytics and reporting with data tables' });
+      expect(result.recommendation).toBe('web');
+      expect(result.signals.web.score).toBeGreaterThan(0);
+    });
+
+    it('recommends both when mixed signals', () => {
+      const result = recommendPlatform({ description: 'A consumer marketplace app with admin dashboard for sellers' });
+      expect(result.recommendation).toBe('both');
+    });
+
+    it('defaults to both with low confidence when no signals', () => {
+      const result = recommendPlatform({ description: 'A simple utility tool' });
+      expect(result.recommendation).toBe('both');
+      expect(result.confidence).toBe(0.5);
+    });
+  });
+
+  describe('validatePlatformSet', () => {
+    it('returns valid when platform is set', () => {
+      const result = validatePlatformSet({ target_platform: 'mobile' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns invalid with recommendation when not set', () => {
+      const result = validatePlatformSet({ description: 'A mobile fitness tracking app with push notifications' });
+      expect(result.valid).toBe(false);
+      expect(result.autoSet).toBe('mobile');
+      expect(result.message).toContain('Auto-recommendation');
+    });
+
+    it('rejects invalid platform values', () => {
+      const result = validatePlatformSet({ target_platform: 'desktop', description: 'Test' });
+      expect(result.valid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Decision rubric documentation: when to choose mobile vs web vs both
- Programmatic `recommendPlatform()` analyzing venture metadata keywords
- `validatePlatformSet()` as pre-Stage-15 gate
- Decision matrix, quick flow chart, platform implications

## Test plan
- [x] 7/7 unit tests pass
- [x] All handoffs passed

SD: SD-MOBILEFIRST-VENTURE-BUILD-STRATEGY-ORCH-001-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)