### PR TITLE
feat(S15): add landing page and signup flow to wireframe generation

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -83,7 +83,14 @@ Rules:
 - HANDOFF COMPLETENESS: Every screen with user input MUST include error_state (what shows on failure)
 - HANDOFF COMPLETENESS: Data-dependent screens MUST include empty_state (first-time user experience)
 - HANDOFF COMPLETENESS: Every screen MUST include responsive_notes (mobile/tablet/desktop behavior)
-- MICRO-ANIMATIONS: Every screen MUST include micro_animations with entry_transition, hover_states, loading_animation, and cta_effects. Use specific CSS-like values (durations, easing, transforms) not vague descriptions.`;
+- MICRO-ANIMATIONS: Every screen MUST include micro_animations with entry_transition, hover_states, loading_animation, and cta_effects. Use specific CSS-like values (durations, easing, transforms) not vague descriptions.
+
+MANDATORY SCREENS (must always be included):
+- Landing Page: Public-facing marketing page with hero section (value proposition headline + subtext), key feature highlights (3-4 features with icons), social proof section (testimonials, logos, or stats), and a prominent CTA button. This is the first screen visitors see before signing up.
+- Signup/Registration: Account creation screen with email/password fields (or magic link), social login options (Google, GitHub, etc.), terms of service acceptance, and form validation feedback. Include both the initial empty form state and error states for invalid input.
+
+MANDATORY NAVIGATION FLOW:
+- Include a "User Acquisition" flow: Landing Page → Signup/Registration → Onboarding (or Dashboard). This represents the pre-login journey from first visit to authenticated user.`;
 
 /**
  * Derive a category from brand genome archetype for service lookups.
@@ -369,6 +376,8 @@ ${awwwardsContext}
 
 IMPORTANT:
 - Generate ${MIN_SCREENS}-${MAX_SCREENS} screens covering ALL personas
+- You MUST include a Landing Page screen and a Signup/Registration screen (these are mandatory)
+- You MUST include a "User Acquisition" navigation flow: Landing Page → Signup → Dashboard
 - Each screen must have a detailed ASCII wireframe layout (min 5 lines)
 - Navigation flows must connect screens into coherent user journeys
 - persona_coverage must include EVERY persona listed above
@@ -412,8 +421,9 @@ Output ONLY valid JSON.`;
   let llmFallbackCount = 0;
   const personaNames = stage10Data.customerPersonas.map(p => p.name);
 
-  // ── Normalize screens ──────────────────────────────────────────
   let screens = Array.isArray(parsed.screens) ? parsed.screens : [];
+
+  // ── Normalize screens ──────────────────────────────────────────
   if (screens.length < MIN_SCREENS) {
     llmFallbackCount++;
     // First pass: pad with fallback screens for uncovered personas
@@ -468,6 +478,89 @@ Output ONLY valid JSON.`;
       });
       genericIdx++;
     }
+  }
+
+  // ── Ensure mandatory screens (Landing Page + Signup) ─────────
+  // SD-ADD-LANDING-PAGE-AND-ORCH-001: Added after persona padding to preserve persona coverage
+  const hasLanding = screens.some(s => /landing|home\s*page/i.test(s.name));
+  const hasSignup = screens.some(s => /sign\s*up|register|registration/i.test(s.name));
+  if (!hasLanding) {
+    screens.push({
+      name: 'Landing Page',
+      purpose: 'Public-facing marketing page that converts visitors into signups',
+      persona: personaNames[0] || 'Visitor',
+      ascii_layout: [
+        '+---------------------------------------------+',
+        '|  Logo            [ Login ] [ Sign Up ]      |',
+        '+---------------------------------------------+',
+        '|                                             |',
+        '|       ★ Venture Value Proposition ★         |',
+        '|    Subtitle describing the core benefit     |',
+        '|                                             |',
+        '|          [ Get Started Free → ]             |',
+        '|                                             |',
+        '+---------------------------------------------+',
+        '|  Feature 1  |  Feature 2  |  Feature 3     |',
+        '|  [icon]     |  [icon]     |  [icon]        |',
+        '|  Desc...    |  Desc...    |  Desc...       |',
+        '+---------------------------------------------+',
+        '|  "Testimonial quote..." — Customer Name     |',
+        '+---------------------------------------------+',
+        '|  Footer   [ Privacy ] [ Terms ] [ Contact ] |',
+        '+---------------------------------------------+',
+      ],
+      key_components: ['Navigation bar', 'Hero section', 'CTA button', 'Feature highlights', 'Testimonials', 'Footer'],
+      interaction_notes: 'First screen visitors see. CTA scrolls to signup or navigates to signup page.',
+      error_state: 'Display fallback static content if dynamic testimonials fail to load',
+      empty_state: 'N/A — landing page always has static content',
+      responsive_notes: 'Stack features vertically on mobile, hero section full-width, CTA prominent at top',
+    });
+  }
+  if (!hasSignup) {
+    screens.push({
+      name: 'Signup',
+      purpose: 'Account creation screen for new users converting from landing page',
+      persona: personaNames[0] || 'Visitor',
+      ascii_layout: [
+        '+---------------------------------------------+',
+        '|  Logo                        [ ← Back ]     |',
+        '+---------------------------------------------+',
+        '|                                             |',
+        '|         Create Your Account                 |',
+        '|                                             |',
+        '|  [ Email Address               ]            |',
+        '|  [ Password                    ]            |',
+        '|  [ Confirm Password            ]            |',
+        '|                                             |',
+        '|  [ ✓ ] I agree to Terms of Service          |',
+        '|                                             |',
+        '|          [ Create Account ]                 |',
+        '|                                             |',
+        '|  ─── or sign up with ───                    |',
+        '|  [ Google ]  [ GitHub ]                     |',
+        '|                                             |',
+        '|  Already have an account? [ Log in ]        |',
+        '+---------------------------------------------+',
+      ],
+      key_components: ['Email input', 'Password input', 'Terms checkbox', 'Submit button', 'Social login buttons', 'Login link'],
+      interaction_notes: 'Form validates on submit. Social login opens OAuth flow. Success redirects to onboarding.',
+      error_state: 'Inline field validation (red border + message). Server errors shown as toast above form.',
+      empty_state: 'Clean form with placeholder text in fields',
+      responsive_notes: 'Form centered, max-width 400px. Social buttons stack vertically on mobile.',
+    });
+  }
+
+  // ── Ensure mandatory navigation flow (User Acquisition) ───────
+  let navFlows = Array.isArray(parsed.navigation_flows) ? parsed.navigation_flows : [];
+  const hasAcquisitionFlow = navFlows.some(f => /acquisition|signup|landing.*sign/i.test(f.name || '') || /acquisition|signup|landing.*sign/i.test(f.description || ''));
+  if (!hasAcquisitionFlow) {
+    navFlows.push({
+      name: 'User Acquisition',
+      steps: ['Landing Page', 'Signup', screens.find(s => /dashboard|onboard/i.test(s.name))?.name || 'Dashboard'],
+      persona: personaNames[0] || 'Visitor',
+      description: 'Pre-login journey from first visit through signup to authenticated experience'
+    });
+    parsed.navigation_flows = navFlows;
   }
 
   // Truncate to max

--- a/tests/unit/stage-15-wireframe-generator.test.js
+++ b/tests/unit/stage-15-wireframe-generator.test.js
@@ -867,4 +867,105 @@ describe('Stage 15 Wireframe Generator', () => {
       expect(userPrompt).toContain('PostgreSQL');
     });
   });
+
+  // ─── Mandatory screens: Landing Page + Signup ─────────────────
+  // SD-ADD-LANDING-PAGE-AND-ORCH-001
+
+  describe('mandatory landing page and signup screens', () => {
+    it('adds Landing Page screen when LLM does not generate one', async () => {
+      const stage10Data = createMockStage10Data();
+      const personaNames = stage10Data.customerPersonas.map(p => p.name);
+      // LLM returns screens WITHOUT a landing page
+      const llmResponse = createFullLLMResponse(personaNames);
+      mockComplete.mockResolvedValue({ _parsed: llmResponse });
+
+      const result = await analyzeStage15WireframeGenerator({
+        ventureId: 'v-1',
+        stage10Data,
+        logger: silentLogger,
+      });
+
+      const landingScreen = result.screens.find(s => /landing/i.test(s.name));
+      expect(landingScreen).toBeDefined();
+      expect(landingScreen.name).toBe('Landing Page');
+      expect(landingScreen.key_components).toContain('CTA button');
+    });
+
+    it('adds Signup screen when LLM does not generate one', async () => {
+      const stage10Data = createMockStage10Data();
+      const personaNames = stage10Data.customerPersonas.map(p => p.name);
+      const llmResponse = createFullLLMResponse(personaNames);
+      mockComplete.mockResolvedValue({ _parsed: llmResponse });
+
+      const result = await analyzeStage15WireframeGenerator({
+        ventureId: 'v-1',
+        stage10Data,
+        logger: silentLogger,
+      });
+
+      const signupScreen = result.screens.find(s => /sign\s*up/i.test(s.name));
+      expect(signupScreen).toBeDefined();
+      expect(signupScreen.key_components).toContain('Email input');
+    });
+
+    it('does not duplicate Landing Page when LLM already generates one', async () => {
+      const stage10Data = createMockStage10Data();
+      const personaNames = stage10Data.customerPersonas.map(p => p.name);
+      const llmResponse = createFullLLMResponse(personaNames);
+      // Add a Landing Page to the LLM response
+      llmResponse.screens.push({
+        name: 'Landing Page',
+        purpose: 'Marketing page',
+        persona: personaNames[0],
+        ascii_layout: ['+---+', '|LP |', '+---+', '|   |', '+---+'],
+        key_components: ['Hero section'],
+        interaction_notes: 'First impression',
+      });
+      mockComplete.mockResolvedValue({ _parsed: llmResponse });
+
+      const result = await analyzeStage15WireframeGenerator({
+        ventureId: 'v-1',
+        stage10Data,
+        logger: silentLogger,
+      });
+
+      const landingScreens = result.screens.filter(s => /landing/i.test(s.name));
+      expect(landingScreens.length).toBe(1);
+    });
+
+    it('adds User Acquisition navigation flow when missing', async () => {
+      const stage10Data = createMockStage10Data();
+      const personaNames = stage10Data.customerPersonas.map(p => p.name);
+      const llmResponse = createFullLLMResponse(personaNames);
+      mockComplete.mockResolvedValue({ _parsed: llmResponse });
+
+      const result = await analyzeStage15WireframeGenerator({
+        ventureId: 'v-1',
+        stage10Data,
+        logger: silentLogger,
+      });
+
+      const acquisitionFlow = result.navigation_flows.find(f => /acquisition/i.test(f.name));
+      expect(acquisitionFlow).toBeDefined();
+      expect(acquisitionFlow.steps).toContain('Landing Page');
+      expect(acquisitionFlow.steps).toContain('Signup');
+    });
+
+    it('prompt includes landing page and signup requirements', async () => {
+      const stage10Data = createMockStage10Data();
+      const personaNames = stage10Data.customerPersonas.map(p => p.name);
+      mockComplete.mockResolvedValue({ _parsed: createFullLLMResponse(personaNames) });
+
+      await analyzeStage15WireframeGenerator({
+        ventureId: 'v-1',
+        stage10Data,
+        logger: silentLogger,
+      });
+
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('Landing Page');
+      expect(userPrompt).toContain('Signup');
+      expect(userPrompt).toContain('User Acquisition');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add mandatory landing page and signup flow screens to S15 wireframe generator
- Add User Acquisition navigation flow (Landing → Signup → Dashboard) 
- Fallback screens injected after persona padding to preserve persona coverage

## Test plan
- [x] All 52 unit tests pass (5 new tests for mandatory screens)
- [x] Landing page screen present when LLM omits it
- [x] Signup screen present when LLM omits it
- [x] No duplicates when LLM already generates these screens
- [x] User Acquisition nav flow injected when missing
- [x] Prompt includes landing/signup requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)