### PR TITLE
fix(pipeline): add chairman decision allowlist and soft-delete spurious decisions

### DIFF
--- a/database/migrations/20260414_chairman_decision_hygiene.sql
+++ b/database/migrations/20260414_chairman_decision_hygiene.sql
@@ -1,0 +1,93 @@
+-- SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B
+-- Chairman decision hygiene: soft-delete, NOT NULL decision_type,
+-- and mark spurious decisions from non-gate/non-review stages.
+--
+-- Gate stages: 3, 5, 10, 13, 17 (BLOCKING gates)
+-- Review stages: 7, 8, 9, 11 (REVIEW_MODE_STAGES)
+-- Promotion gates: 18, 19, 20, 21, 22, 23 (PROMOTION_GATE_STAGES)
+-- Advisory stages: any (but should have decision_type = 'advisory')
+-- Legitimate non-null types: stage_gate, review, promotion_gate, advisory,
+--   gate_failure_escalation, stage_failure_review, budget_override
+--
+-- This migration is idempotent: safe to run multiple times.
+
+-- Step 1: Add deleted_at column for soft-delete (if not exists)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'chairman_decisions'
+      AND column_name = 'deleted_at'
+  ) THEN
+    ALTER TABLE chairman_decisions ADD COLUMN deleted_at TIMESTAMPTZ DEFAULT NULL;
+    CREATE INDEX IF NOT EXISTS idx_chairman_decisions_deleted_at
+      ON chairman_decisions (deleted_at) WHERE deleted_at IS NULL;
+  END IF;
+END $$;
+
+-- Step 2: Backfill any remaining NULL decision_type values
+-- (the 20260411 migration did this but new NULLs appeared)
+UPDATE chairman_decisions
+SET decision_type = 'stage_gate'
+WHERE decision_type IS NULL;
+
+-- Step 3: Soft-delete spurious decisions from non-gate, non-review stages
+-- that have generic 'stage_gate' type but shouldn't exist at all.
+-- Legitimate gate stages: 3, 5, 10, 13, 17, 18, 19, 20, 21, 22, 23
+-- Legitimate review stages: 7, 8, 9, 11
+-- Everything else with 'stage_gate' type is spurious.
+UPDATE chairman_decisions
+SET deleted_at = NOW()
+WHERE decision_type = 'stage_gate'
+  AND lifecycle_stage NOT IN (3, 5, 7, 8, 9, 10, 11, 13, 17, 18, 19, 20, 21, 22, 23)
+  AND deleted_at IS NULL;
+
+-- Step 4: Add NOT NULL constraint on decision_type
+-- (after backfill ensures no NULLs remain)
+DO $$
+BEGIN
+  -- Check if column already has NOT NULL constraint
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'chairman_decisions'
+      AND column_name = 'decision_type'
+      AND is_nullable = 'YES'
+  ) THEN
+    ALTER TABLE chairman_decisions ALTER COLUMN decision_type SET NOT NULL;
+  END IF;
+END $$;
+
+-- Step 5: Update v_chairman_pending_decisions view to exclude soft-deleted
+CREATE OR REPLACE VIEW v_chairman_pending_decisions AS
+SELECT
+  cd.id,
+  cd.venture_id,
+  v.name AS venture_name,
+  cd.lifecycle_stage,
+  lsc.stage_name,
+  cd.health_score,
+  cd.recommendation,
+  cd.decision,
+  cd.status,
+  cd.summary,
+  cd.brief_data,
+  cd.override_reason,
+  cd.risks_acknowledged,
+  cd.quick_fixes_applied,
+  cd.created_at,
+  cd.updated_at,
+  cd.decided_by,
+  cd.rationale,
+  CASE
+    WHEN v.updated_at > cd.created_at THEN true
+    ELSE false
+  END AS is_stale_context,
+  v.updated_at AS venture_updated_at
+FROM chairman_decisions cd
+JOIN ventures v ON v.id = cd.venture_id
+LEFT JOIN lifecycle_stage_config lsc ON lsc.stage_number = cd.lifecycle_stage
+WHERE cd.deleted_at IS NULL  -- SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B: exclude soft-deleted
+ORDER BY
+  cd.created_at DESC;

--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -12,6 +12,14 @@ import { ServiceError } from './shared-services.js';
 const POLLING_INTERVAL_MS = 10_000; // 10 seconds
 const REALTIME_CHANNEL = 'chairman-decisions';
 
+// SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B: Stages allowed to create chairman decisions.
+// Gate stages (CHAIRMAN_GATES.BLOCKING): 3, 5, 10, 13, 17, 18, 19, 20, 23, 24, 25
+// Review-mode stages: 7, 8, 9, 11
+// Any stage not in this set will be silently skipped by createOrReusePendingDecision.
+const DECISION_CREATING_STAGES = new Set([
+  3, 5, 7, 8, 9, 10, 11, 13, 17, 18, 19, 20, 23, 24, 25,
+]);
+
 /**
  * Wait for a specific decision to be resolved (approved or rejected).
  *
@@ -173,6 +181,13 @@ export async function createOrReusePendingDecision({
 }) {
   if (!ventureId || stageNumber === undefined || !supabase) {
     throw new ServiceError('INVALID_ARGS', 'ventureId, stageNumber, and supabase are required', 'ChairmanDecisionWatcher');
+  }
+
+  // SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B: Skip decision creation for non-gate/non-review stages.
+  // This prevents spurious chairman decisions from cluttering the dashboard.
+  if (!DECISION_CREATING_STAGES.has(stageNumber)) {
+    logger.log(`[Decision] Skipping decision creation for non-gate stage ${stageNumber}`);
+    return { id: null, isNew: false, skipped: true };
   }
 
   // Only reuse PENDING decisions — never reuse approved decisions from prior visits.

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -130,6 +130,7 @@ router.patch('/:id/stage', validateUuidParam('id'), asyncHandler(async (req, res
       .eq('venture_id', id)
       .eq('lifecycle_stage', stage)
       .eq('status', 'approved')
+      .is('deleted_at', null) // SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B: exclude soft-deleted
       .in('decision', ['pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release'])
       .limit(1);
 

--- a/tests/unit/eva/chairman-decision-allowlist.test.js
+++ b/tests/unit/eva/chairman-decision-allowlist.test.js
@@ -1,0 +1,87 @@
+/**
+ * Tests for chairman decision stage allowlist
+ * SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B
+ *
+ * Verifies that createOrReusePendingDecision skips non-gate/non-review stages.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/eva/shared-services.js', () => ({
+  ServiceError: class ServiceError extends Error {
+    constructor(code, msg, source) {
+      super(msg);
+      this.code = code;
+      this.source = source;
+    }
+  },
+}));
+
+describe('Chairman decision stage allowlist (SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B)', () => {
+  let createOrReusePendingDecision;
+
+  beforeEach(async () => {
+    const mod = await import('../../../lib/eva/chairman-decision-watcher.js');
+    createOrReusePendingDecision = mod.createOrReusePendingDecision;
+  });
+
+  const mockSupabase = {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { id: 'test-id' }, error: null }),
+        }),
+      }),
+      update: vi.fn().mockReturnThis(),
+      not: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    }),
+  };
+
+  const logger = { log: vi.fn(), warn: vi.fn() };
+
+  // Gate stages should create decisions
+  for (const stage of [3, 5, 10, 13, 17, 18, 19, 20, 23, 24, 25]) {
+    it(`allows decision creation for gate stage ${stage}`, async () => {
+      const result = await createOrReusePendingDecision({
+        ventureId: 'v1',
+        stageNumber: stage,
+        supabase: mockSupabase,
+        logger,
+      });
+      expect(result.skipped).not.toBe(true);
+    });
+  }
+
+  // Review stages should create decisions
+  for (const stage of [7, 8, 9, 11]) {
+    it(`allows decision creation for review stage ${stage}`, async () => {
+      const result = await createOrReusePendingDecision({
+        ventureId: 'v1',
+        stageNumber: stage,
+        supabase: mockSupabase,
+        logger,
+      });
+      expect(result.skipped).not.toBe(true);
+    });
+  }
+
+  // Non-gate/non-review stages should be skipped
+  for (const stage of [0, 1, 2, 4, 6, 12, 14, 15, 16]) {
+    it(`skips decision creation for non-gate stage ${stage}`, async () => {
+      const result = await createOrReusePendingDecision({
+        ventureId: 'v1',
+        stageNumber: stage,
+        supabase: mockSupabase,
+        logger,
+      });
+      expect(result.skipped).toBe(true);
+      expect(result.id).toBeNull();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add `DECISION_CREATING_STAGES` allowlist in `chairman-decision-watcher.js` to prevent non-gate stages from creating decisions
- Migration adds `deleted_at` column, backfills NULL `decision_type`, enforces NOT NULL constraint
- Soft-deletes 7 spurious decisions from non-gate stages (S0, S1, S4, S6, S12, S14, S16)
- Updates `v_chairman_pending_decisions` view to exclude soft-deleted rows

## SD Reference
SD-FIX-STAGE-TIMING-ZEROS-ORCH-001-B (Child B of SD-FIX-STAGE-TIMING-ZEROS-ORCH-001)

## Test plan
- [x] 24 unit tests covering all gate (11), review (4), and non-gate (9) stages
- [ ] Verify chairman dashboard shows no spurious entries
- [ ] Confirm NULL decision_type INSERT is rejected by constraint
- [ ] Verify soft-deleted rows are excluded from dashboard view

🤖 Generated with [Claude Code](https://claude.com/claude-code)