### PR TITLE
fix(convergence): add final_screens to visual convergence output

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-19-visual-convergence.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-visual-convergence.js
@@ -273,6 +273,7 @@ export async function analyzeStage19VisualConvergence(ventureId, stageData, opti
       threshold: CONVERGENCE_THRESHOLD,
       screen_count: 0,
       refinement_priority: ['Provide Stage 15 wireframe screens before running visual convergence'],
+      final_screens: [],
     };
   }
 
@@ -365,6 +366,7 @@ Output ONLY valid JSON.`;
     threshold: CONVERGENCE_THRESHOLD,
     screen_count: screens.length,
     refinement_priority,
+    final_screens: screens,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `final_screens` field to `stage-19-visual-convergence.js` return value
- Fixes contract mismatch where stitch-provisioner expected `wireframe_convergence.final_screens` but convergence only returned scoring data
- Stitch-provisioner now uses actual wireframe screens instead of falling back to IA sitemap pages

## Changes
- `lib/eva/stage-templates/analysis-steps/stage-19-visual-convergence.js`: Add `final_screens` to both return paths (empty array for no-wireframes case, screens array for main path)

## Test plan
- [x] 25 existing unit tests pass (no regressions)
- [x] `final_screens` is empty array when no wireframes provided
- [x] `final_screens` contains screen objects when wireframes exist
- [x] Existing fields (passes, overall_score, verdict) unchanged

SD: SD-FIX-WIREFRAME-CONVERGENCE-PRODUCING-ORCH-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)