### PR TITLE
fix: inherit parent worktree path for child SDs

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -446,6 +446,15 @@ async function createChild(parentKey, index = 0, overrides = {}) {
     }
   });
 
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-101: Inherit parent worktree_path
+  // Children share the parent's worktree — prevents wrong_worktree gate failures
+  if (parent.worktree_path) {
+    await supabase
+      .from('strategic_directives_v2')
+      .update({ worktree_path: parent.worktree_path })
+      .eq('sd_key', sdKey);
+  }
+
   // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Assert parent claim before returning child
   // Verifies the creating session holds the parent SD claim
   try {


### PR DESCRIPTION
## Summary
- Fix `createChild()` in `leo-create-sd.js` to copy parent's `worktree_path` to child SDs
- Prevents `wrong_worktree` gate failures during handoffs for child SDs
- Resolves 5 `/learn` patterns (17 total occurrences)

## Root Cause
When `leo-create-sd.js --child` creates a child SD, it never sets `worktree_path`. When `sd-start.js` later runs for the child, it creates a nested worktree path (e.g., `.worktrees/parent/.worktrees/child`), which the claim-validity gate rejects as `wrong_worktree`.

## Fix
After `createSD()` succeeds for a child, copy the parent's `worktree_path` to the child record so both share the same worktree.

## Test plan
- [x] Patterns resolved in `issue_patterns` table
- [ ] Create a child SD and verify `worktree_path` matches parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)