### PR TITLE
fix(fleet): detect CC Desktop markers + remove stale sd_claims refs

### DIFF
--- a/.claude/commands/claim.md
+++ b/.claude/commands/claim.md
@@ -141,13 +141,12 @@ async function releaseClaim() {
     console.log('  Error releasing claim: ' + releaseError.message);
     console.log('');
 
-    // Fallback: try direct update if RPC fails
+    // Fallback: try direct update on claude_sessions if RPC fails
     console.log('  Attempting direct release...');
     const { error: directError } = await supabase
-      .from('sd_claims')
-      .update({ released_at: new Date().toISOString(), release_reason: 'manual' })
-      .eq('session_id', sessionId)
-      .is('released_at', null);
+      .from('claude_sessions')
+      .update({ sd_key: null, released_at: new Date().toISOString(), released_reason: 'manual' })
+      .eq('session_id', sessionId);
 
     if (directError) {
       console.log('  Direct release also failed: ' + directError.message);

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -510,7 +510,7 @@ This step runs automatically via PostToolUse hook - no manual action required.
 1. **Detects merge success**: Hook monitors `gh pr merge` commands
 2. **Checks SD/QF status**: Queries database to determine if this is SD/QF work
    - Checks `v_active_sessions` for active SD claim
-   - Checks `sd_claims` for recently completed SDs
+   - Checks `claude_sessions` for recently released SDs
    - Checks `quick_fixes` for in-progress QFs
    - Checks `is_working_on` flag
    - Greps commit messages for SD-*/QF-* patterns

--- a/docs/reference/schema/engineer/tables/sd_claims.md
+++ b/docs/reference/schema/engineer/tables/sd_claims.md
@@ -6,7 +6,9 @@ author: auto-fixer
 last_updated: 2026-02-28
 tags: [reference, auto-generated]
 ---
-# sd_claims Table
+# sd_claims Table (DROPPED)
+
+> **This table no longer exists.** It was dropped in migration `20260218_consolidate_sd_claims_into_claude_sessions.sql`. Claim state now lives in `claude_sessions` (columns: `sd_key`, `released_at`, `released_reason`). See also `claiming_session_id` and `is_working_on` on `strategic_directives_v2`.
 
 > ⚠️ **DROPPED** — This table was removed on 2026-02-18 by SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001.
 > Claim state now lives exclusively in `claude_sessions.sd_id` + `status='active'`.

--- a/scripts/hooks/auto-learning-capture.cjs
+++ b/scripts/hooks/auto-learning-capture.cjs
@@ -17,7 +17,7 @@
  *
  * Detection Strategy (Database-First, Survives Branch Deletion):
  * 1. Check claude_sessions.sd_id for active SD claim
- * 2. Check sd_claims for recently released SD
+ * 2. Check claude_sessions for recently released SD
  * 3. Check quick_fixes for in-progress QF
  * 4. Check is_working_on flag
  * 5. Grep commit messages for SD-xxx/QF-xxx references
@@ -160,20 +160,20 @@ async function checkSDWorkStatus() {
       return { isSDWork: true, source: 'active_session', sdId: activeSessions.sd_id };
     }
 
-    // Query 2: Check sd_claims for recently released SD (within 10 minutes)
+    // Query 2: Check claude_sessions for recently released SD (within 10 minutes)
     const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
     const { data: recentRelease } = await supabase
-      .from('sd_claims')
-      .select('sd_id')
-      .eq('release_reason', 'completed')
+      .from('claude_sessions')
+      .select('sd_key')
+      .eq('released_reason', 'completed')
       .gte('released_at', tenMinutesAgo)
       .order('released_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
-    if (recentRelease?.sd_id) {
-      log('info', 'sd_work_detected', { source: 'recent_release', sd_id: recentRelease.sd_id });
-      return { isSDWork: true, source: 'recent_release', sdId: recentRelease.sd_id };
+    if (recentRelease?.sd_key) {
+      log('info', 'sd_work_detected', { source: 'recent_release', sd_id: recentRelease.sd_key });
+      return { isSDWork: true, source: 'recent_release', sdId: recentRelease.sd_key };
     }
 
     // Query 3: Check for active Quick Fix

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -83,27 +83,50 @@ function bar(pct, width = 20) {
 }
 
 // --- Layer 1: Terminal Identity Collision Detection ---
-// Reads .claude/session-identity/pid-*.json marker files to detect when multiple
+// Reads .claude/session-identity/ marker files to detect when multiple
 // live Claude Code processes share the same session_id (identity collision).
+// Supports both pid-*.json (CLI sessions) and fallback-*.json (Desktop sessions).
 // Returns: [{ pid, session_id, marker_path, cc_pid, sse_port }]
 function detectIdentityCollisions() {
   const markerDir = path.resolve(__dirname, '../.claude/session-identity');
   if (!fs.existsSync(markerDir)) return { collisions: [], aliveMarkers: [] };
 
   const markers = fs.readdirSync(markerDir)
-    .filter(f => /^pid-\d+\.json$/.test(f))
+    .filter(f => /^pid-\d+\.json$/.test(f) || /^fallback-\d+-\d+\.json$/.test(f))
     .map(f => {
       const filePath = path.resolve(markerDir, f);
-      const pid = Number(f.match(/^pid-(\d+)\.json$/)[1]);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        // pid-*.json: PID is in the filename; fallback-*.json: PID is in the JSON body
+        const pidMatch = f.match(/^pid-(\d+)\.json$/);
+        const pid = pidMatch ? Number(pidMatch[1]) : Number(data.pid);
+        if (!pid || isNaN(pid)) return null;
         return { pid, session_id: data.session_id, claude_session_id: data.claude_session_id || null, cc_pid: data.cc_pid || pid, sse_port: data.sse_port, marker_path: filePath, mtime: fs.statSync(filePath).mtimeMs };
       } catch { return null; }
     })
     .filter(Boolean);
 
-  // Check which PIDs are alive
-  const aliveMarkers = markers.filter(m => isProcessRunning(m.pid));
+  // Check which PIDs are alive.
+  // For CLI markers (pid-*.json), check the specific PID.
+  // For Desktop markers (fallback-*.json), the recorded PID is ephemeral —
+  // the actual CC Desktop process runs as claude.exe with a different PID.
+  // Detect if ANY claude.exe is running; if so, recent fallback markers are alive.
+  let hasClaudeDesktop = false;
+  try {
+    const { execSync } = require('child_process');
+    const out = execSync('tasklist /FI "IMAGENAME eq claude.exe" /NH 2>nul', { encoding: 'utf8', timeout: 5000 });
+    hasClaudeDesktop = out.includes('claude.exe');
+  } catch { /* tasklist unavailable or timed out — fall back to PID check only */ }
+
+  const FALLBACK_MARKER_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour — fallback markers older than this are stale
+  const aliveMarkers = markers.filter(m => {
+    // CLI sessions: direct PID liveness check
+    if (isProcessRunning(m.pid)) return true;
+    // Desktop sessions: if claude.exe is running and marker is recent, consider alive
+    const isFallbackMarker = path.basename(m.marker_path).startsWith('fallback-');
+    if (isFallbackMarker && hasClaudeDesktop && (Date.now() - m.mtime) < FALLBACK_MARKER_MAX_AGE_MS) return true;
+    return false;
+  });
 
   // Group alive markers by session_id
   const bySession = {};
@@ -277,9 +300,9 @@ async function main() {
   // so aliveMarkers are available for PID-based liveness cross-referencing.
   const { collisions, aliveMarkers } = detectIdentityCollisions();
 
-  // Build a set of alive CC PIDs from marker files.
-  // Marker filename = pid-{ccPid}.json, and DB terminal_id = "win-cc-{port}-{ccPid}".
-  // Match by extracting ccPid from terminal_id and checking if that PID's marker is alive.
+  // Build a set of alive CC PIDs from marker files (pid-*.json + fallback-*.json).
+  // DB terminal_id formats: "win-cc-{port}-{ccPid}" (CLI) or "win-{PID}" (Desktop).
+  // Match by extracting the last segment from terminal_id and checking the alive set.
   const aliveCcPids = new Set(aliveMarkers.map(m => String(m.pid)));
 
   // 2. Classify each session
@@ -298,7 +321,8 @@ async function main() {
 
     // Cross-reference with PID marker files: if the CC process is alive on this
     // machine, the session is running even without recent heartbeats.
-    // terminal_id format: "win-cc-{port}-{ccPid}" — extract the ccPid suffix.
+    // terminal_id formats: "win-cc-{port}-{ccPid}" (CLI) or "win-{PID}" (Desktop).
+    // Extract the last segment as the PID to check against alive markers.
     let hasPidAlive = false;
     if (s.terminal_id) {
       const parts = s.terminal_id.split('-');
@@ -306,15 +330,23 @@ async function main() {
       hasPidAlive = aliveCcPids.has(ccPid);
     }
 
+    // Desktop sessions use heuristic liveness (claude.exe running + recent marker).
+    // Cap the protection: if heartbeat is >30 min stale, treat as dead even with
+    // a "live" marker — the specific session has likely exited while claude.exe
+    // continues running for other sessions.
+    const DESKTOP_DEAD_CAP_SECONDS = 1800; // 30 minutes
+    const isDesktopSession = s.terminal_id && /^win-\d+$/.test(s.terminal_id);
+    const exceedsDesktopCap = isDesktopSession && s.heartbeat_age_seconds > DESKTOP_DEAD_CAP_SECONDS;
+
     let status;
     if (!isStale) {
       status = 'ACTIVE';
-    } else if (hasPidAlive) {
+    } else if (hasPidAlive && !exceedsDesktopCap) {
       // PID is alive but heartbeat is stale — session is loading context,
       // compacting, or between tool calls. NOT stale.
       status = 'ALIVE_NO_HEARTBEAT';
-    } else if (isVeryStale) {
-      status = 'DEAD'; // No heartbeat for 15min+ AND no living PID = definitely gone
+    } else if (isVeryStale || exceedsDesktopCap) {
+      status = 'DEAD'; // No heartbeat for 15min+ (CLI) or 30min+ (Desktop) AND no living PID
     } else {
       status = 'STALE_UNKNOWN'; // Between 5-15min, no PID match = might be on another host
     }


### PR DESCRIPTION
## Summary
- **Desktop marker detection**: Stale session sweep now reads `fallback-*.json` marker files (CC Desktop) alongside `pid-*.json` (CLI). Uses `claude.exe` process detection as liveness heuristic with 30-min cap to prevent false releases of live Desktop sessions.
- **sd_claims table cleanup**: Removed 3 active references to the dropped `sd_claims` table — `auto-learning-capture.cjs` query, `claim.md` fallback release, `ship.md` docs. Updated to use `claude_sessions` with correct column names.
- Added deprecation notice to `docs/reference/schema/engineer/tables/sd_claims.md`.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Verified sweep detects fallback markers during live coordinator session
- [x] Verified Desktop sessions no longer falsely released
- [x] Verified 30-min cap prevents infinite hold on dead Desktop sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)