### PR TITLE
feat(sentry): harden integration with framework SDK, PII scrubbing, health monitoring

### DIFF
--- a/lib/eva/bridge/documentation-generator.js
+++ b/lib/eva/bridge/documentation-generator.js
@@ -21,7 +21,8 @@ const FRAMEWORK_PATTERNS = {
 const ENV_VAR_PATTERNS = [
   { pattern: /SUPABASE_URL/i, name: 'VITE_SUPABASE_URL', description: 'Supabase project URL' },
   { pattern: /SUPABASE_ANON/i, name: 'VITE_SUPABASE_ANON_KEY', description: 'Supabase anonymous key (safe for client)' },
-  { pattern: /SENTRY_DSN/i, name: 'SENTRY_DSN', description: 'Sentry error tracking DSN' },
+  { pattern: /SENTRY_DSN/i, name: 'SENTRY_DSN', description: 'Sentry error tracking DSN (server-side)' },
+  { pattern: /VITE_SENTRY_DSN/i, name: 'VITE_SENTRY_DSN', description: 'Sentry DSN for Vite client-side apps' },
   { pattern: /STRIPE/i, name: 'STRIPE_SECRET_KEY', description: 'Stripe payment API key (server only)' },
   { pattern: /OPENAI/i, name: 'OPENAI_API_KEY', description: 'OpenAI API key (server only)' },
 ];

--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -494,19 +494,58 @@ export function formatReplitMd(groups, venture, summary) {
   lines.push('- Use environment variables for all secrets and configuration');
   lines.push('');
 
-  // Monitoring & Error Tracking
+  // Monitoring & Error Tracking (framework-conditional)
   lines.push('## Monitoring & Error Tracking');
   lines.push('');
   lines.push('This venture is monitored by the EHG Software Factory self-healing loop.');
   lines.push('');
-  lines.push('**Setup:**');
-  lines.push('1. Install: `npm install @sentry/node`');
-  lines.push('2. Initialize in entry point:');
-  lines.push('   ```javascript');
-  lines.push("   import * as Sentry from '@sentry/node';");
-  lines.push("   Sentry.init({ dsn: process.env.SENTRY_DSN, environment: 'production' });");
-  lines.push('   ```');
-  lines.push('3. Add `SENTRY_DSN` to Replit Secrets (value provided by EHG provisioner)');
+
+  const isVite = framework === 'Vite' || framework === 'React';
+  const isNextjs = framework === 'Next.js';
+
+  if (isNextjs) {
+    lines.push('**Setup (Next.js):**');
+    lines.push('1. Run: `npx @sentry/wizard@latest -i nextjs`');
+    lines.push('2. Configure `sentry.server.config.js` and `sentry.client.config.js` with DSN and `tracesSampleRate: 0.1`');
+    lines.push('3. Add `SENTRY_DSN` to Replit Secrets');
+  } else if (isVite) {
+    lines.push('**Setup (React/Vite):**');
+    lines.push('1. Install: `npm install @sentry/react`');
+    lines.push('2. Initialize in main.jsx/tsx:');
+    lines.push('   ```javascript');
+    lines.push("   import * as Sentry from '@sentry/react';");
+    lines.push('   Sentry.init({');
+    lines.push("     dsn: import.meta.env.VITE_SENTRY_DSN,");
+    lines.push("     environment: 'production',");
+    lines.push('     tracesSampleRate: 0.1,');
+    lines.push('     integrations: [Sentry.browserTracingIntegration()]');
+    lines.push('   });');
+    lines.push('   ```');
+    lines.push('3. Wrap App with `<Sentry.ErrorBoundary fallback={<p>Something went wrong</p>}>`');
+    lines.push('4. Add `VITE_SENTRY_DSN` to Replit Secrets');
+  } else {
+    lines.push('**Setup (Node.js/Express):**');
+    lines.push('1. Install: `npm install @sentry/node`');
+    lines.push('2. Initialize in entry point:');
+    lines.push('   ```javascript');
+    lines.push("   import * as Sentry from '@sentry/node';");
+    lines.push('   Sentry.init({');
+    lines.push("     dsn: process.env.SENTRY_DSN,");
+    lines.push("     environment: 'production',");
+    lines.push('     tracesSampleRate: 0.1, // 10% — governs free tier cost');
+    lines.push('     beforeSend(event) {');
+    lines.push('       if (event.request) {');
+    lines.push('         delete event.request.cookies;');
+    lines.push('         delete event.request.data;');
+    lines.push("         if (event.request.headers) { delete event.request.headers['authorization']; delete event.request.headers['cookie']; }");
+    lines.push('       }');
+    lines.push('       return event;');
+    lines.push('     }');
+    lines.push('   });');
+    lines.push("   process.on('SIGTERM', () => { Sentry.close(2000).then(() => process.exit(0)); });");
+    lines.push('   ```');
+    lines.push('3. Add `SENTRY_DSN` to Replit Secrets');
+  }
   lines.push('');
   if (venture?.metadata?.sentry?.dsn) {
     lines.push(`**DSN**: \`${venture.metadata.sentry.dsn}\``);

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -102,13 +102,53 @@ ${getSecurityInstructions(targetPlatform)}
 - Create separate policies for SELECT, INSERT, UPDATE, DELETE as needed
 
 ### Monitoring & Error Tracking
-1. Install Sentry SDK: \`npm install @sentry/node\`
-2. Add to your entry point (server.js / index.js / app.js):
+
+**Choose the correct Sentry SDK for your framework:**
+
+**Express / Node.js:**
+1. Install: \`npm install @sentry/node\`
+2. Add to entry point:
    \`\`\`javascript
    import * as Sentry from '@sentry/node';
-   Sentry.init({ dsn: process.env.SENTRY_DSN, environment: 'production' });
+   Sentry.init({
+     dsn: process.env.SENTRY_DSN,
+     environment: 'production',
+     tracesSampleRate: 0.1, // 10% sampling — governs free tier cost
+     beforeSend(event) {
+       if (event.request) {
+         delete event.request.cookies;
+         delete event.request.data;
+         if (event.request.headers) {
+           delete event.request.headers['authorization'];
+           delete event.request.headers['cookie'];
+         }
+       }
+       return event;
+     }
+   });
+   // Flush pending events on container shutdown
+   process.on('SIGTERM', () => { Sentry.close(2000).then(() => process.exit(0)); });
    \`\`\`
-3. Add \`SENTRY_DSN\` to environment variables (provided by EHG provisioner)
+
+**React / Vite:**
+1. Install: \`npm install @sentry/react\`
+2. Add to main.jsx/tsx:
+   \`\`\`javascript
+   import * as Sentry from '@sentry/react';
+   Sentry.init({
+     dsn: import.meta.env.VITE_SENTRY_DSN,
+     environment: 'production',
+     tracesSampleRate: 0.1,
+     integrations: [Sentry.browserTracingIntegration()]
+   });
+   \`\`\`
+3. Wrap your App with \`<Sentry.ErrorBoundary fallback={<p>Something went wrong</p>}>\`
+
+**Next.js:**
+1. Run: \`npx @sentry/wizard@latest -i nextjs\`
+2. Configure \`sentry.server.config.js\` and \`sentry.client.config.js\` with DSN and \`tracesSampleRate: 0.1\`
+
+3. Add \`SENTRY_DSN\` (and \`VITE_SENTRY_DSN\` for Vite apps) to environment variables (provided by EHG provisioner)
 4. Wrap error-prone operations with \`Sentry.captureException(error)\`
 
 > This enables the EHG Software Factory self-healing loop to detect and auto-fix errors.

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -445,6 +445,12 @@ services:
           canary_expires_at: null
         }, { onConflict: 'venture_id' });
 
+      // Also store VITE_SENTRY_DSN for Vite/React ventures (harmless for non-Vite)
+      if (sentryDsn) {
+        sentryConfig.vite_dsn = sentryDsn;
+        ctx.log('[monitoring_baseline] VITE_SENTRY_DSN provisioned for client-side Vite apps');
+      }
+
       ctx.log(`[monitoring_baseline] Sentry config registered for ${ctx.venture.repoName}`);
       ctx.log('[monitoring_baseline] Guardrail state initialized');
       if (!sentryDsn) ctx.log('[monitoring_baseline] Warning: DSN not obtained — Sentry project may need investigation');

--- a/scripts/factory/poll-errors.js
+++ b/scripts/factory/poll-errors.js
@@ -84,6 +84,8 @@ async function main() {
   let totalWritten = 0;
   let totalDeduped = 0;
   let totalInjection = 0;
+  const zeroErrorThreshold = parseInt(process.env.SENTRY_ZERO_ERROR_THRESHOLD || '5', 10);
+  const suspectedBroken = [];
 
   for (const venture of ventures) {
     const sentryConfig = venture.metadata?.sentry;
@@ -126,13 +128,32 @@ async function main() {
         totalInjection += result.injectionFlagged;
       }
 
-      // Update last poll timestamp
+      // Zero-error health monitoring: track consecutive polls with no errors
+      const prevCount = sentryConfig.consecutive_zero_error_count || 0;
+      const updatedSentryConfig = {
+        ...sentryConfig,
+        lastPollAt: new Date().toISOString()
+      };
+
+      if (errors.length === 0) {
+        updatedSentryConfig.consecutive_zero_error_count = prevCount + 1;
+        if (updatedSentryConfig.consecutive_zero_error_count >= zeroErrorThreshold) {
+          updatedSentryConfig.potentially_broken_sdk = true;
+          suspectedBroken.push(venture.name);
+          console.log(`[${venture.name}] ⚠️  ${updatedSentryConfig.consecutive_zero_error_count} consecutive zero-error polls — SDK may be broken`);
+        }
+      } else {
+        // Errors received — reset zero-error tracking
+        updatedSentryConfig.consecutive_zero_error_count = 0;
+        updatedSentryConfig.potentially_broken_sdk = false;
+      }
+
       await supabase
         .from('ventures')
         .update({
           metadata: {
             ...venture.metadata,
-            sentry: { ...sentryConfig, lastPollAt: new Date().toISOString() }
+            sentry: updatedSentryConfig
           }
         })
         .eq('id', venture.id);
@@ -149,6 +170,18 @@ async function main() {
   console.log(`Errors written:  ${totalWritten}`);
   console.log(`Deduped:         ${totalDeduped}`);
   console.log(`Injection flags: ${totalInjection}`);
+
+  if (suspectedBroken.length > 0) {
+    console.log('');
+    console.log('⚠️  Suspected Broken SDKs');
+    console.log('-------------------------');
+    for (const name of suspectedBroken) {
+      console.log(`  • ${name} (${zeroErrorThreshold}+ consecutive zero-error polls)`);
+    }
+    console.log('');
+    console.log('These ventures may have a silently broken Sentry SDK.');
+    console.log('Verify SDK initialization and DSN configuration.');
+  }
 }
 
 main().catch(err => {

--- a/tests/unit/eva/bridge/sentry-hardening.test.js
+++ b/tests/unit/eva/bridge/sentry-hardening.test.js
@@ -1,0 +1,152 @@
+/**
+ * Sentry Integration Hardening Tests
+ * SD-LEO-INFRA-SENTRY-INTEGRATION-HARDENING-001
+ *
+ * Tests framework-conditional SDK selection, PII scrubbing boilerplate,
+ * VITE_SENTRY_DSN provisioning, and zero-error health monitoring.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Read the source files to verify prompt template content
+const promptFormatterPath = resolve(import.meta.dirname, '../../../../lib/eva/bridge/replit-prompt-formatter.js');
+const formatStrategiesPath = resolve(import.meta.dirname, '../../../../lib/eva/bridge/replit-format-strategies.js');
+const pollErrorsPath = resolve(import.meta.dirname, '../../../../scripts/factory/poll-errors.js');
+const docGenPath = resolve(import.meta.dirname, '../../../../lib/eva/bridge/documentation-generator.js');
+const provisionerPath = resolve(import.meta.dirname, '../../../../lib/eva/bridge/venture-provisioner.js');
+
+const promptFormatter = readFileSync(promptFormatterPath, 'utf-8');
+const formatStrategies = readFileSync(formatStrategiesPath, 'utf-8');
+const pollErrors = readFileSync(pollErrorsPath, 'utf-8');
+const docGen = readFileSync(docGenPath, 'utf-8');
+const provisioner = readFileSync(provisionerPath, 'utf-8');
+
+describe('FR-1: Framework-Conditional SDK Selection', () => {
+  it('replit-prompt-formatter includes @sentry/node for Express', () => {
+    expect(promptFormatter).toContain("@sentry/node");
+    expect(promptFormatter).toContain("process.env.SENTRY_DSN");
+  });
+
+  it('replit-prompt-formatter includes @sentry/react for React/Vite', () => {
+    expect(promptFormatter).toContain("@sentry/react");
+    expect(promptFormatter).toContain("VITE_SENTRY_DSN");
+    expect(promptFormatter).toContain("ErrorBoundary");
+  });
+
+  it('replit-prompt-formatter includes Next.js setup instructions', () => {
+    expect(promptFormatter).toContain("@sentry/wizard");
+    expect(promptFormatter).toContain("nextjs");
+    expect(promptFormatter).toContain("sentry.server.config");
+  });
+
+  it('replit-format-strategies has framework-conditional logic', () => {
+    expect(formatStrategies).toContain("isVite");
+    expect(formatStrategies).toContain("isNextjs");
+    expect(formatStrategies).toContain("@sentry/react");
+    expect(formatStrategies).toContain("@sentry/wizard");
+    expect(formatStrategies).toContain("@sentry/node");
+  });
+});
+
+describe('FR-2: beforeSend PII Scrubbing', () => {
+  it('prompt-formatter includes beforeSend callback', () => {
+    expect(promptFormatter).toContain("beforeSend");
+  });
+
+  it('beforeSend strips Authorization headers', () => {
+    expect(promptFormatter).toContain("delete event.request.headers['authorization']");
+  });
+
+  it('beforeSend strips Cookie headers', () => {
+    expect(promptFormatter).toContain("delete event.request.headers['cookie']");
+  });
+
+  it('beforeSend strips request body', () => {
+    expect(promptFormatter).toContain("delete event.request.data");
+  });
+
+  it('beforeSend strips cookies', () => {
+    expect(promptFormatter).toContain("delete event.request.cookies");
+  });
+
+  it('format-strategies also includes PII scrubbing for Node/Express', () => {
+    expect(formatStrategies).toContain("beforeSend");
+    expect(formatStrategies).toContain("delete event.request.cookies");
+  });
+});
+
+describe('FR-3: VITE_SENTRY_DSN Environment Variable', () => {
+  it('prompt-formatter references VITE_SENTRY_DSN for Vite apps', () => {
+    expect(promptFormatter).toContain("VITE_SENTRY_DSN");
+  });
+
+  it('format-strategies references VITE_SENTRY_DSN for Vite apps', () => {
+    expect(formatStrategies).toContain("VITE_SENTRY_DSN");
+  });
+
+  it('documentation-generator recognizes VITE_SENTRY_DSN pattern', () => {
+    expect(docGen).toContain("VITE_SENTRY_DSN");
+    expect(docGen).toContain("Vite client-side");
+  });
+
+  it('venture-provisioner stores vite_dsn', () => {
+    expect(provisioner).toContain("vite_dsn");
+    expect(provisioner).toContain("VITE_SENTRY_DSN");
+  });
+});
+
+describe('FR-4: Graceful Shutdown via Sentry.close', () => {
+  it('prompt-formatter includes SIGTERM handler', () => {
+    expect(promptFormatter).toContain("SIGTERM");
+    expect(promptFormatter).toContain("Sentry.close(2000)");
+  });
+
+  it('format-strategies includes SIGTERM handler for Node/Express', () => {
+    expect(formatStrategies).toContain("SIGTERM");
+    expect(formatStrategies).toContain("Sentry.close(2000)");
+  });
+});
+
+describe('FR-5: Explicit tracesSampleRate', () => {
+  it('prompt-formatter sets tracesSampleRate: 0.1', () => {
+    expect(promptFormatter).toContain("tracesSampleRate: 0.1");
+  });
+
+  it('format-strategies sets tracesSampleRate: 0.1', () => {
+    expect(formatStrategies).toContain("tracesSampleRate: 0.1");
+  });
+
+  it('prompt-formatter explains free tier cost governance', () => {
+    expect(promptFormatter).toContain("free tier cost");
+  });
+});
+
+describe('FR-6: Zero-Error Health Monitoring', () => {
+  it('poll-errors tracks consecutive_zero_error_count', () => {
+    expect(pollErrors).toContain("consecutive_zero_error_count");
+  });
+
+  it('poll-errors flags potentially_broken_sdk', () => {
+    expect(pollErrors).toContain("potentially_broken_sdk");
+  });
+
+  it('poll-errors resets count when errors received', () => {
+    expect(pollErrors).toContain("consecutive_zero_error_count = 0");
+  });
+
+  it('poll-errors uses configurable threshold from env', () => {
+    expect(pollErrors).toContain("SENTRY_ZERO_ERROR_THRESHOLD");
+  });
+
+  it('poll-errors includes suspected broken SDK summary', () => {
+    expect(pollErrors).toContain("Suspected Broken SDKs");
+  });
+});
+
+describe('TR-1: Backward Compatibility', () => {
+  it('format-strategies defaults to @sentry/node for unknown frameworks', () => {
+    // The else branch handles non-Vite, non-Next.js cases (defaults to Node)
+    expect(formatStrategies).toContain("Setup (Node.js/Express)");
+  });
+});


### PR DESCRIPTION
## Summary
- **Framework-conditional SDK selection** in Replit build prompts: `@sentry/node` for Express, `@sentry/react` with ErrorBoundary for React/Vite, `@sentry/wizard` for Next.js
- **beforeSend PII scrubbing** strips Authorization/Cookie headers and request body from Sentry events before reaching Sentry cloud
- **VITE_SENTRY_DSN** env var provisioned alongside SENTRY_DSN for Vite client-side apps
- **Graceful shutdown** via `Sentry.close(2000)` on SIGTERM for ephemeral containers
- **tracesSampleRate: 0.1** (10%) explicit config to govern free tier cost
- **Zero-error health monitoring** in polling loop flags ventures with consecutive zero-error polls as `potentially_broken_sdk`

## Files Changed (5 implementation + 1 test)
- `lib/eva/bridge/replit-prompt-formatter.js` — Framework-conditional SDK, PII scrubbing, shutdown, sample rate
- `lib/eva/bridge/replit-format-strategies.js` — Same updates using existing `detectStack()` framework detection
- `lib/eva/bridge/venture-provisioner.js` — Provisions `vite_dsn` for client-side apps
- `lib/eva/bridge/documentation-generator.js` — Recognizes `VITE_SENTRY_DSN` pattern
- `scripts/factory/poll-errors.js` — Zero-error health monitoring with configurable threshold
- `tests/unit/eva/bridge/sentry-hardening.test.js` — 25 tests covering all 6 FRs

## Test plan
- [x] 25 unit tests pass (all FRs covered)
- [x] Existing bridge tests unaffected (pre-existing stitch-provisioner failures only)
- [x] Backward compatible: unknown frameworks default to `@sentry/node`

SD: SD-LEO-INFRA-SENTRY-INTEGRATION-HARDENING-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)