### PR TITLE
fix(stitch): read stitch_curation artifact in checkCurationStatus (fixes 0/N screens)

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -565,12 +565,19 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
  * @returns {Promise<{ready: boolean, screen_count: number, project_id?: string}>}
  */
 export async function checkCurationStatus(ventureId) {
+  // stitch_curation at lifecycle_stage=15 is written by postStage15Hook and is the
+  // single source of truth for project_id, url, screen_prompts, and status.
+  // stitch_project was dead code (storeStitchArtifact was defined but never called),
+  // so querying it always returned null, causing screen_count to always be 0.
   const { data: artifact } = await supabase
     .from('venture_artifacts')
     .select('artifact_data')
     .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_project')
-    .single();
+    .eq('artifact_type', 'stitch_curation')
+    .eq('lifecycle_stage', 15)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
 
   if (!artifact?.artifact_data?.project_id) {
     return { ready: false, screen_count: 0, reason: 'no_project' };
@@ -583,23 +590,15 @@ export async function checkCurationStatus(ventureId) {
     return { ready: false, screen_count: 0, project_id: artifact.artifact_data.project_id };
   }
 
-  // Update project artifact with screen count
-  await writeArtifact(supabase, {
-    ventureId,
-    lifecycleStage: 15,
-    artifactType: 'stitch_project',
-    title: 'Stitch Design Project',
-    artifactData: { ...artifact.artifact_data, screen_count: screens.length, curation_checked_at: new Date().toISOString() },
-    source: 'stitch-provisioner',
-  });
-
-  // Mark curation as complete
+  // Update the existing stitch_curation artifact with screen count and completion status.
+  // writeArtifact upserts by venture_id+lifecycle_stage+artifact_type, so this merges
+  // screen_count/status into the existing record (preserving project_id, url, screen_prompts).
   await writeArtifact(supabase, {
     ventureId,
     lifecycleStage: 15,
     artifactType: 'stitch_curation',
     title: 'Stitch Curation Prompts',
-    artifactData: { status: 'curation_complete', screen_count: screens.length, completed_at: new Date().toISOString() },
+    artifactData: { ...artifact.artifact_data, status: 'curation_complete', screen_count: screens.length, completed_at: new Date().toISOString() },
     source: 'stitch-provisioner',
   });
 


### PR DESCRIPTION
## Summary
- **Root cause**: `checkCurationStatus()` queried `artifact_type='stitch_project'` — a type written by `storeStitchArtifact()`, a function that was defined but never called anywhere in the codebase. This meant `venture_artifacts` never had any `stitch_project` rows, so `screen_count` always returned 0 despite screens being generated.
- **Fix**: Changed read path to `artifact_type='stitch_curation'` at `lifecycle_stage=15`, which IS written by `postStage15Hook()`. Updated the same artifact with `screen_count + status='curation_complete'` using spread to preserve `project_id`, `url`, `screen_prompts`. Removed dead `stitch_project` write block.
- **Scope**: 1 file changed, ~27 LOC net. Backend fix only.

## Files Changed
- `lib/eva/bridge/stitch-provisioner.js` — `checkCurationStatus()`: stitch_project → stitch_curation read path, removed dead stitch_project write block

## Test plan
- [x] `checkCurationStatus()` now reads `stitch_curation` at `lifecycle_stage=15` (matches write path in `postStage15Hook`)
- [x] `writeArtifact` upsert merges `screen_count` + `status` into existing artifact, preserving `project_id`, `url`, `screen_prompts`
- [x] Smoke tests pass (15/15)
- [x] TESTING sub-agent verified: no regressions in stitch-adapter.js or getCurationContext callers

SD: SD-LEO-FIX-STITCH-CURATION-PROGRESS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)