### PR TITLE
fix(stitch-provisioner): store confirmed_screen_names from listScreens in artifact

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -598,7 +598,7 @@ export async function checkCurationStatus(ventureId) {
     lifecycleStage: 15,
     artifactType: 'stitch_curation',
     title: 'Stitch Curation Prompts',
-    artifactData: { ...artifact.artifact_data, status: 'curation_complete', screen_count: screens.length, completed_at: new Date().toISOString() },
+    artifactData: { ...artifact.artifact_data, status: 'curation_complete', screen_count: screens.length, confirmed_screen_names: screens.map(s => s.name || '').filter(Boolean), completed_at: new Date().toISOString() },
     source: 'stitch-provisioner',
   });
 


### PR DESCRIPTION
## Summary

- `checkCurationStatus()` now stores `confirmed_screen_names: string[]` (actual names returned by Stitch's `listScreens()`) alongside `screen_count` in the `stitch_curation` artifact
- Enables the frontend to do name-based confirmation matching instead of fragile positional index matching
- Correctly handles partial failures: if one screen variant (e.g. desktop) failed to generate, its name won't appear in `confirmed_screen_names` and the UI can flag that specific screen

## Why this was needed

The old approach used `i < screen_count` (positional). With `targetPlatform='both'`, `screen_prompts` has 14 entries but `screen_count=7` (Stitch returns one entry per unique screen name from `listScreens()`). This caused the UI to show 7/14 even when all screens were confirmed.

## Test plan

- [ ] After hitting Refresh, `confirmed_screen_names` is present in the artifact
- [ ] Contains the actual names as returned by Stitch (including any suffix Stitch adds for desktop variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)