### PR TITLE
feat(SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-BCD): EVA Friday Enhancement - Briefing Card, Finding Consolidator, Knowledge Base

### DIFF
--- a/.claude/.protocol-sync
+++ b/.claude/.protocol-sync
@@ -1,1 +1,1 @@
-{"timestamp":"2026-04-13T18:04:36.782Z","pid":57072,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}
+{"timestamp":"2026-04-15T15:42:02.069Z","pid":28808,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}

--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-096",
+  "currentSd": "SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-D",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing Fix Stale Worktree Gate Blocking",
+  "currentTask": "Implementing Knowledge Base VIEW over Learning Decisions and Issue Patterns PRD",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-04-13T17:54:31.100Z",
-  "lastUpdatedAt": "2026-04-14T16:31:42.277Z"
+  "clearedAt": "2026-04-15T00:32:06.617Z",
+  "lastUpdatedAt": "2026-04-15T13:53:04.796Z"
 }

--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-03-14T12:14:28.419Z"
+  "last_scan": "2026-04-15T13:27:08.232Z"
 }

--- a/lib/eva/services/eva-knowledge-view.js
+++ b/lib/eva/services/eva-knowledge-view.js
@@ -1,0 +1,47 @@
+/**
+ * EVA Knowledge Base View Service
+ * SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-D
+ *
+ * Queries v_eva_knowledge_base VIEW to surface LEO Protocol intelligence
+ * during Friday meeting conversation without direct table access.
+ */
+
+import { createSupabaseServiceClient } from '../../supabase-client.js';
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Query the v_eva_knowledge_base VIEW with optional filters.
+ *
+ * @param {Object} [options={}]
+ * @param {string} [options.status] - Filter by status (e.g. 'resolved', 'pending')
+ * @param {string} [options.source_type] - Filter by source ('learning_decision', 'issue_pattern', 'protocol_improvement', 'retrospective')
+ * @param {number} [options.limit=50] - Max rows to return
+ * @returns {Promise<Array<{ source_type: string, item_key: string, title: string, status: string, created_at: string, resolution_notes: string|null, score: number|null }>>}
+ */
+export async function getKnowledgeSummary(options = {}) {
+  const { status, source_type, limit = DEFAULT_LIMIT } = options;
+
+  try {
+    const supabase = createSupabaseServiceClient();
+    let query = supabase
+      .from('v_eva_knowledge_base')
+      .select('source_type, item_key, title, status, created_at, resolution_notes, score');
+
+    if (status) query = query.eq('status', status);
+    if (source_type) query = query.eq('source_type', source_type);
+    query = query.limit(limit);
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('[eva-knowledge-view] KNOWLEDGE_VIEW_UNAVAILABLE:', error.message);
+      return [];
+    }
+
+    return data || [];
+  } catch (err) {
+    console.error('[eva-knowledge-view] KNOWLEDGE_VIEW_UNAVAILABLE:', err.message);
+    return [];
+  }
+}

--- a/lib/eva/services/finding-consolidator.js
+++ b/lib/eva/services/finding-consolidator.js
@@ -1,0 +1,100 @@
+/**
+ * Finding Consolidator — Recommendation Grouping + Context Export
+ * SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-C
+ *
+ * Groups consultant recommendations by application_domain into consolidated
+ * insight cards for injection into eva-chat-service Friday meeting context.
+ *
+ * No dependency on the legacy friday-meeting.mjs render path.
+ * Output is a data primitive consumed by Child E eva-chat-service.
+ */
+
+import { applyRecommendationDecay } from '../../../scripts/eva/recommendation-feedback.mjs';
+
+let sanitizeLLMInput;
+try {
+  ({ sanitizeLLMInput } = await import('./input-sanitizer.js'));
+} catch {
+  console.warn('[finding-consolidator] SANITIZER_UNAVAILABLE: input-sanitizer.js could not be imported. Using raw strings.');
+  sanitizeLLMInput = (text) => ({ clean: text, warnings: [] });
+}
+
+/**
+ * Group recommendations by application_domain into consolidated insight cards.
+ *
+ * @param {Array<{ id: string, title: string, application_domain: string, priority_score: number, [key: string]: any }>} recommendations
+ * @returns {Array<{ domain: string, items: Array, count: number, combined_priority: number, summary: string }>}
+ */
+export function consolidateFindings(recommendations) {
+  if (!recommendations || recommendations.length === 0) return [];
+
+  const domainMap = new Map();
+
+  for (const rec of recommendations) {
+    const domain = rec.application_domain || 'unknown';
+    if (!domainMap.has(domain)) {
+      domainMap.set(domain, []);
+    }
+    domainMap.get(domain).push(rec);
+  }
+
+  const cards = [];
+  for (const [domain, items] of domainMap) {
+    const count = items.length;
+    const combined_priority = count > 0
+      ? items.reduce((sum, r) => sum + (r.priority_score || 0), 0) / count
+      : 0;
+
+    // summary: title of the highest-priority item
+    const topItem = items.reduce((best, r) =>
+      (r.priority_score || 0) > (best.priority_score || 0) ? r : best, items[0]);
+    const rawSummary = topItem?.title || domain;
+    const { clean: summary } = sanitizeLLMInput(rawSummary);
+
+    cards.push({ domain, items, count, combined_priority, summary });
+  }
+
+  // Sort by combined_priority descending
+  cards.sort((a, b) => b.combined_priority - a.combined_priority);
+
+  return cards;
+}
+
+/**
+ * Fetch pending recommendations, apply relevance decay, consolidate by domain,
+ * and return structured context for eva-chat-service.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{ consolidatedFindings: Array, totalCount: number, decayApplied: boolean }>}
+ */
+export async function getConsolidatedContext(supabase) {
+  try {
+    const { data: recs, error } = await supabase
+      .from('eva_consultant_recommendations')
+      .select('id, title, application_domain, priority_score, recommendation_type, description, status, feedback_weight')
+      .eq('status', 'pending')
+      .order('priority_score', { ascending: false });
+
+    if (error) {
+      console.warn('[finding-consolidator] Failed to fetch recommendations:', error.message);
+      return { consolidatedFindings: [], totalCount: 0, decayApplied: false };
+    }
+
+    const recommendations = recs || [];
+
+    // Apply decay for this cycle
+    const cycleDate = new Date().toISOString().slice(0, 10);
+    await applyRecommendationDecay(cycleDate);
+
+    const consolidatedFindings = consolidateFindings(recommendations);
+
+    return {
+      consolidatedFindings,
+      totalCount: recommendations.length,
+      decayApplied: true,
+    };
+  } catch (err) {
+    console.warn('[finding-consolidator] getConsolidatedContext error:', err.message);
+    return { consolidatedFindings: [], totalCount: 0, decayApplied: false };
+  }
+}

--- a/lib/eva/services/finding-consolidator.test.js
+++ b/lib/eva/services/finding-consolidator.test.js
@@ -1,0 +1,144 @@
+/**
+ * Tests for Finding Consolidator
+ * SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-C
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { consolidateFindings, getConsolidatedContext } from './finding-consolidator.js';
+
+describe('consolidateFindings', () => {
+  it('returns empty array for empty input', () => {
+    expect(consolidateFindings([])).toEqual([]);
+  });
+
+  it('returns empty array for null input', () => {
+    expect(consolidateFindings(null)).toEqual([]);
+  });
+
+  it('groups recs by application_domain into cards', () => {
+    const recs = [
+      { id: '1', title: 'A', application_domain: 'product', priority_score: 0.8 },
+      { id: '2', title: 'B', application_domain: 'product', priority_score: 0.6 },
+      { id: '3', title: 'C', application_domain: 'engineering', priority_score: 0.9 },
+      { id: '4', title: 'D', application_domain: 'engineering', priority_score: 0.7 },
+    ];
+    const cards = consolidateFindings(recs);
+    expect(cards).toHaveLength(2);
+    const productCard = cards.find(c => c.domain === 'product');
+    const engCard = cards.find(c => c.domain === 'engineering');
+    expect(productCard.count).toBe(2);
+    expect(productCard.items).toHaveLength(2);
+    expect(engCard.count).toBe(2);
+    expect(engCard.items).toHaveLength(2);
+  });
+
+  it('each card has domain, items, count, combined_priority, summary', () => {
+    const recs = [
+      { id: '1', title: 'Top rec', application_domain: 'product', priority_score: 0.9 },
+    ];
+    const [card] = consolidateFindings(recs);
+    expect(card).toHaveProperty('domain');
+    expect(card).toHaveProperty('items');
+    expect(card).toHaveProperty('count');
+    expect(card).toHaveProperty('combined_priority');
+    expect(card).toHaveProperty('summary');
+    expect(card.summary).toBe('Top rec');
+  });
+
+  it('combined_priority is average of priority_scores', () => {
+    const recs = [
+      { id: '1', title: 'A', application_domain: 'ops', priority_score: 0.4 },
+      { id: '2', title: 'B', application_domain: 'ops', priority_score: 0.6 },
+    ];
+    const [card] = consolidateFindings(recs);
+    expect(card.combined_priority).toBeCloseTo(0.5);
+  });
+
+  it('summary is highest-priority item title', () => {
+    const recs = [
+      { id: '1', title: 'Lower', application_domain: 'sales', priority_score: 0.3 },
+      { id: '2', title: 'Highest', application_domain: 'sales', priority_score: 0.9 },
+      { id: '3', title: 'Medium', application_domain: 'sales', priority_score: 0.5 },
+    ];
+    const [card] = consolidateFindings(recs);
+    expect(card.summary).toBe('Highest');
+  });
+
+  it('groups unknown domain recs together', () => {
+    const recs = [
+      { id: '1', title: 'No domain A', priority_score: 0.5 },
+      { id: '2', title: 'No domain B', priority_score: 0.3 },
+    ];
+    const cards = consolidateFindings(recs);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].domain).toBe('unknown');
+    expect(cards[0].count).toBe(2);
+  });
+
+  it('sorts cards by combined_priority descending', () => {
+    const recs = [
+      { id: '1', title: 'Low', application_domain: 'low', priority_score: 0.1 },
+      { id: '2', title: 'High', application_domain: 'high', priority_score: 0.9 },
+      { id: '3', title: 'Mid', application_domain: 'mid', priority_score: 0.5 },
+    ];
+    const cards = consolidateFindings(recs);
+    expect(cards[0].domain).toBe('high');
+    expect(cards[1].domain).toBe('mid');
+    expect(cards[2].domain).toBe('low');
+  });
+});
+
+describe('getConsolidatedContext', () => {
+  it('returns correct shape', async () => {
+    const mockSupabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      }),
+    };
+    const result = await getConsolidatedContext(mockSupabase);
+    expect(result).toHaveProperty('consolidatedFindings');
+    expect(result).toHaveProperty('totalCount');
+    expect(result).toHaveProperty('decayApplied');
+    expect(Array.isArray(result.consolidatedFindings)).toBe(true);
+  });
+
+  it('returns { consolidatedFindings: [], totalCount: 0 } for empty recs', async () => {
+    const mockSupabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      }),
+    };
+    const result = await getConsolidatedContext(mockSupabase);
+    expect(result.consolidatedFindings).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('consolidates mock recommendations by domain', async () => {
+    const mockRecs = [
+      { id: '1', title: 'Rec A', application_domain: 'product', priority_score: 0.8, status: 'pending', feedback_weight: 1.0 },
+      { id: '2', title: 'Rec B', application_domain: 'product', priority_score: 0.6, status: 'pending', feedback_weight: 1.0 },
+      { id: '3', title: 'Rec C', application_domain: 'engineering', priority_score: 0.9, status: 'pending', feedback_weight: 1.0 },
+    ];
+    const mockSupabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => Promise.resolve({ data: mockRecs, error: null }),
+          }),
+        }),
+      }),
+    };
+    const result = await getConsolidatedContext(mockSupabase);
+    expect(result.totalCount).toBe(3);
+    expect(result.consolidatedFindings).toHaveLength(2);
+    expect(result.decayApplied).toBe(true);
+  });
+});

--- a/lib/eva/services/friday-briefing-card.js
+++ b/lib/eva/services/friday-briefing-card.js
@@ -1,0 +1,109 @@
+/**
+ * Friday Pre-Flight Briefing Card + Decision Consequence Tracking
+ * SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-B
+ *
+ * Generates a canvas-renderable briefing card before Friday meetings and
+ * tracks decision consequences when the chairman accepts or dismisses.
+ */
+
+import { createSupabaseServiceClient } from '../../supabase-client.js';
+
+let sanitizeLLMInput;
+try {
+  ({ sanitizeLLMInput } = await import('./input-sanitizer.js'));
+} catch {
+  console.warn('[friday-briefing-card] SANITIZER_UNAVAILABLE: input-sanitizer.js could not be imported. Using raw strings.');
+  sanitizeLLMInput = (text) => ({ clean: text, warnings: [] });
+}
+
+/**
+ * Generate a canvas-renderable briefing card from Friday meeting data.
+ *
+ * @param {Object|null} fridayData - Friday meeting data with sections, decisions, risks, krs
+ * @returns {{ type: string, version: number, agenda_preview: string[], pending_decisions_count: number, risk_flags: string[], stale_krs_count: number }}
+ */
+export function generateBriefingCard(fridayData) {
+  if (!fridayData) {
+    return {
+      type: 'briefing_card',
+      version: 1,
+      agenda_preview: [],
+      pending_decisions_count: 0,
+      risk_flags: [],
+      stale_krs_count: 0,
+    };
+  }
+
+  const sections = Array.isArray(fridayData.sections) ? fridayData.sections : [];
+  const decisions = Array.isArray(fridayData.decisions) ? fridayData.decisions : [];
+  const risks = Array.isArray(fridayData.risks) ? fridayData.risks : [];
+  const krs = Array.isArray(fridayData.krs) ? fridayData.krs : [];
+
+  // agenda_preview: sanitize section titles/summaries
+  const agenda_preview = sections.map(s => {
+    const raw = s.title || s.summary || String(s);
+    const { clean } = sanitizeLLMInput(raw);
+    return clean;
+  }).filter(Boolean);
+
+  // pending_decisions_count: decisions not yet resolved
+  const pending_decisions_count = decisions.filter(
+    d => !d.resolved && d.status !== 'resolved' && d.status !== 'accepted' && d.status !== 'dismissed'
+  ).length;
+
+  // risk_flags: elevated/high risks
+  const risk_flags = risks
+    .filter(r => r.severity === 'high' || r.severity === 'elevated' || r.level === 'high' || r.level === 'elevated')
+    .map(r => {
+      const raw = r.title || r.description || String(r);
+      const { clean } = sanitizeLLMInput(raw);
+      return clean;
+    })
+    .filter(Boolean);
+
+  // stale_krs_count: KRs with no recent update (stale flag or missing progress)
+  const stale_krs_count = krs.filter(
+    kr => kr.stale === true || kr.is_stale === true || kr.status === 'stale'
+  ).length;
+
+  return {
+    type: 'briefing_card',
+    version: 1,
+    agenda_preview,
+    pending_decisions_count,
+    risk_flags,
+    stale_krs_count,
+  };
+}
+
+/**
+ * Populate decision consequences after chairman accepts or dismisses.
+ * Writes structured JSONB to eva_friday_decisions.consequences.
+ *
+ * @param {string} decisionId - UUID of the decision record
+ * @param {{ reasoning: string, action_implied: string, outcome_type: string }} outcome
+ * @returns {Promise<void>}
+ */
+export async function populateDecisionConsequences(decisionId, outcome) {
+  if (!decisionId || !outcome) return;
+
+  const { clean: reasoning } = sanitizeLLMInput(outcome.reasoning || '');
+  const { clean: action_implied } = sanitizeLLMInput(outcome.action_implied || '');
+
+  const consequences = {
+    reasoning,
+    action_implied,
+    decided_at: new Date().toISOString(),
+    outcome_type: outcome.outcome_type || 'unknown',
+  };
+
+  const supabase = createSupabaseServiceClient();
+  const { error } = await supabase
+    .from('eva_friday_decisions')
+    .update({ consequences })
+    .eq('id', decisionId);
+
+  if (error) {
+    console.error('[friday-briefing-card] populateDecisionConsequences failed:', error.message);
+  }
+}

--- a/lib/eva/services/friday-briefing-card.test.js
+++ b/lib/eva/services/friday-briefing-card.test.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for Friday Pre-Flight Briefing Card
+ * SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-B
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateBriefingCard } from './friday-briefing-card.js';
+
+// populateDecisionConsequences requires a live DB — tested via integration only
+
+describe('generateBriefingCard', () => {
+  describe('null / empty state', () => {
+    it('returns valid empty card when fridayData is null', () => {
+      const card = generateBriefingCard(null);
+      expect(card.type).toBe('briefing_card');
+      expect(card.version).toBe(1);
+      expect(card.agenda_preview).toEqual([]);
+      expect(card.pending_decisions_count).toBe(0);
+      expect(card.risk_flags).toEqual([]);
+      expect(card.stale_krs_count).toBe(0);
+    });
+
+    it('returns valid empty card when fridayData is empty object', () => {
+      const card = generateBriefingCard({});
+      expect(card.type).toBe('briefing_card');
+      expect(card.version).toBe(1);
+      expect(card.agenda_preview).toEqual([]);
+      expect(card.pending_decisions_count).toBe(0);
+      expect(card.risk_flags).toEqual([]);
+      expect(card.stale_krs_count).toBe(0);
+    });
+  });
+
+  describe('happy path', () => {
+    it('extracts agenda_preview from sections', () => {
+      const fridayData = {
+        sections: [
+          { title: 'Revenue Review' },
+          { title: 'Product Roadmap' },
+          { summary: 'Operations Update' },
+        ],
+      };
+      const card = generateBriefingCard(fridayData);
+      expect(card.agenda_preview).toEqual(['Revenue Review', 'Product Roadmap', 'Operations Update']);
+    });
+
+    it('counts pending decisions only (excludes resolved)', () => {
+      const fridayData = {
+        decisions: [
+          { id: '1', status: 'pending' },
+          { id: '2', status: 'resolved' },
+          { id: '3', status: 'accepted' },
+          { id: '4' }, // no status = pending
+        ],
+      };
+      const card = generateBriefingCard(fridayData);
+      expect(card.pending_decisions_count).toBe(2); // id 1 and 4
+    });
+
+    it('extracts risk_flags for high/elevated severity risks', () => {
+      const fridayData = {
+        risks: [
+          { title: 'Revenue risk', severity: 'high' },
+          { title: 'Low risk', severity: 'low' },
+          { title: 'Elevated issue', severity: 'elevated' },
+          { title: 'Medium risk', severity: 'medium' },
+        ],
+      };
+      const card = generateBriefingCard(fridayData);
+      expect(card.risk_flags).toHaveLength(2);
+      expect(card.risk_flags).toContain('Revenue risk');
+      expect(card.risk_flags).toContain('Elevated issue');
+    });
+
+    it('counts stale KRs', () => {
+      const fridayData = {
+        krs: [
+          { title: 'KR 1', stale: true },
+          { title: 'KR 2', stale: false },
+          { title: 'KR 3', is_stale: true },
+          { title: 'KR 4', status: 'stale' },
+        ],
+      };
+      const card = generateBriefingCard(fridayData);
+      expect(card.stale_krs_count).toBe(3);
+    });
+
+    it('returns all four required fields in output', () => {
+      const card = generateBriefingCard({
+        sections: [{ title: 'Q1 Review' }],
+        decisions: [{ status: 'pending' }, { status: 'pending' }],
+        risks: [{ title: 'Cash risk', severity: 'high' }],
+        krs: [{ stale: true }],
+      });
+      expect(card).toMatchObject({
+        type: 'briefing_card',
+        version: 1,
+        agenda_preview: ['Q1 Review'],
+        pending_decisions_count: 2,
+        risk_flags: ['Cash risk'],
+        stale_krs_count: 1,
+      });
+    });
+
+    it('completes in under 2 seconds with mock data', async () => {
+      const fridayData = {
+        sections: Array.from({ length: 10 }, (_, i) => ({ title: `Section ${i}` })),
+        decisions: Array.from({ length: 20 }, (_, i) => ({ status: i % 2 === 0 ? 'pending' : 'resolved' })),
+        risks: Array.from({ length: 5 }, (_, i) => ({ title: `Risk ${i}`, severity: 'high' })),
+        krs: Array.from({ length: 8 }, (_, i) => ({ stale: i % 3 === 0 })),
+      };
+      const start = Date.now();
+      generateBriefingCard(fridayData);
+      expect(Date.now() - start).toBeLessThan(2000);
+    });
+  });
+
+  describe('canvas schema', () => {
+    it('output has type and version fields required for EVACanvasPanel', () => {
+      const card = generateBriefingCard({});
+      expect(card.type).toBe('briefing_card');
+      expect(card.version).toBe(1);
+    });
+  });
+});

--- a/scripts/eva/recommendation-feedback.mjs
+++ b/scripts/eva/recommendation-feedback.mjs
@@ -149,6 +149,10 @@ const DECAY_FLOOR = 0.1;
  */
 export async function applyRecommendationDecay(cycleDate) {
   if (!cycleDate) return { decayed: 0 };
+  // Normalize to ISO date string regardless of whether a Date object or string was passed
+  const cycleDateStr = cycleDate instanceof Date
+    ? cycleDate.toISOString().slice(0, 10)
+    : String(cycleDate).slice(0, 10);
 
   // Fetch pending recs not yet decayed this cycle
   const { data: recs, error } = await supabase
@@ -165,14 +169,14 @@ export async function applyRecommendationDecay(cycleDate) {
 
   const toDecay = recs.filter(r => {
     const lastDecayAt = r.metadata?.last_decay_at;
-    return !lastDecayAt || lastDecayAt < cycleDate;
+    return !lastDecayAt || lastDecayAt < cycleDateStr;
   });
 
   let decayed = 0;
   for (const rec of toDecay) {
     const current = typeof rec.feedback_weight === 'number' ? rec.feedback_weight : 1.0;
     const newWeight = Math.max(DECAY_FLOOR, current - DECAY_AMOUNT);
-    const updatedMetadata = { ...(rec.metadata || {}), last_decay_at: cycleDate };
+    const updatedMetadata = { ...(rec.metadata || {}), last_decay_at: cycleDateStr };
 
     const { error: updateErr } = await supabase
       .from('eva_consultant_recommendations')

--- a/scripts/eva/recommendation-feedback.mjs
+++ b/scripts/eva/recommendation-feedback.mjs
@@ -134,6 +134,61 @@ async function boostTrendConfidence(trendId) {
   }
 }
 
+// ─── Recommendation Decay (SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-C) ──────
+
+const DECAY_AMOUNT = 0.02;
+const DECAY_FLOOR = 0.1;
+
+/**
+ * Apply relevance decay to pending recommendations that have not been interacted
+ * with this cycle. Reduces feedback_weight by DECAY_AMOUNT, floored at DECAY_FLOOR.
+ * Idempotent: skips recs where last_decay_at matches cycleDate.
+ *
+ * @param {string} cycleDate - ISO date string identifying this cycle (e.g. '2026-04-18')
+ * @returns {Promise<{ decayed: number }>}
+ */
+export async function applyRecommendationDecay(cycleDate) {
+  if (!cycleDate) return { decayed: 0 };
+
+  // Fetch pending recs not yet decayed this cycle
+  const { data: recs, error } = await supabase
+    .from('eva_consultant_recommendations')
+    .select('id, feedback_weight, metadata')
+    .eq('status', 'pending');
+
+  if (error) {
+    console.error('[recommendation-feedback] applyRecommendationDecay fetch error:', error.message);
+    return { decayed: 0 };
+  }
+
+  if (!recs || recs.length === 0) return { decayed: 0 };
+
+  const toDecay = recs.filter(r => {
+    const lastDecayAt = r.metadata?.last_decay_at;
+    return !lastDecayAt || lastDecayAt < cycleDate;
+  });
+
+  let decayed = 0;
+  for (const rec of toDecay) {
+    const current = typeof rec.feedback_weight === 'number' ? rec.feedback_weight : 1.0;
+    const newWeight = Math.max(DECAY_FLOOR, current - DECAY_AMOUNT);
+    const updatedMetadata = { ...(rec.metadata || {}), last_decay_at: cycleDate };
+
+    const { error: updateErr } = await supabase
+      .from('eva_consultant_recommendations')
+      .update({ feedback_weight: newWeight, metadata: updatedMetadata })
+      .eq('id', rec.id);
+
+    if (updateErr) {
+      console.error(`[recommendation-feedback] decay update failed for ${rec.id}:`, updateErr.message);
+    } else {
+      decayed++;
+    }
+  }
+
+  return { decayed };
+}
+
 // ─── Main ──────────────────────────────────────────────────
 
 async function main() {

--- a/supabase/migrations/20260415095508_v_eva_knowledge_base.sql
+++ b/supabase/migrations/20260415095508_v_eva_knowledge_base.sql
@@ -1,0 +1,60 @@
+-- Migration: v_eva_knowledge_base VIEW
+-- SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-D
+--
+-- Creates a unified VIEW over four LEO Protocol intelligence tables:
+--   learning_decisions, issue_patterns, protocol_improvement_queue, retrospectives
+--
+-- Columns: source_type, item_key, title, status, created_at, resolution_notes, score
+--
+-- UP
+
+CREATE OR REPLACE VIEW v_eva_knowledge_base AS
+
+  SELECT
+    'learning_decision'::TEXT            AS source_type,
+    id::TEXT                             AS item_key,
+    COALESCE(sd_id::TEXT, id::TEXT)      AS title,
+    status::TEXT                         AS status,
+    created_at                           AS created_at,
+    NULL::TEXT                           AS resolution_notes,
+    COALESCE(confidence_score, NULL)     AS score
+  FROM learning_decisions
+
+  UNION ALL
+
+  SELECT
+    'issue_pattern'::TEXT                AS source_type,
+    COALESCE(pattern_id, id::TEXT)       AS item_key,
+    COALESCE(issue_summary, id::TEXT)    AS title,
+    status::TEXT                         AS status,
+    created_at                           AS created_at,
+    resolution_notes::TEXT               AS resolution_notes,
+    COALESCE(success_rate, NULL)         AS score
+  FROM issue_patterns
+
+  UNION ALL
+
+  SELECT
+    'protocol_improvement'::TEXT         AS source_type,
+    id::TEXT                             AS item_key,
+    COALESCE(description, id::TEXT)      AS title,
+    status::TEXT                         AS status,
+    created_at                           AS created_at,
+    NULL::TEXT                           AS resolution_notes,
+    COALESCE(effectiveness_score, NULL)  AS score
+  FROM protocol_improvement_queue
+
+  UNION ALL
+
+  SELECT
+    'retrospective'::TEXT                AS source_type,
+    id::TEXT                             AS item_key,
+    COALESCE(title, id::TEXT)            AS title,
+    status::TEXT                         AS status,
+    created_at                           AS created_at,
+    NULL::TEXT                           AS resolution_notes,
+    COALESCE(quality_score::NUMERIC, NULL) AS score
+  FROM retrospectives;
+
+-- DOWN
+-- DROP VIEW IF EXISTS v_eva_knowledge_base;


### PR DESCRIPTION
## Summary

- **Child B**: `lib/eva/services/friday-briefing-card.js` — `generateBriefingCard(fridayData)` returns canvas-renderable briefing card with agenda_preview, pending_decisions_count, risk_flags, stale_krs_count; `populateDecisionConsequences(decisionId, outcome)` writes JSONB consequences to `eva_friday_decisions`
- **Child C**: `lib/eva/services/finding-consolidator.js` — `consolidateFindings(recs)` groups recommendations by domain; `applyRecommendationDecay(cycleDate)` decays feedback_weight with idempotency protection; `getConsolidatedContext(supabase)` assembles full context for EVA
- **Child C**: `scripts/eva/recommendation-feedback.mjs` — CLI tool for triggering recommendation decay cycles
- **Child D**: `lib/eva/services/eva-knowledge-view.js` — `getKnowledgeSummary(opts)` queries unified `v_eva_knowledge_base` VIEW with status/limit filtering
- **Child D**: `supabase/migrations/20260415095508_v_eva_knowledge_base.sql` — `CREATE OR REPLACE VIEW v_eva_knowledge_base` UNION ALL over learning_decisions, issue_patterns, protocol_improvement_queue, retrospectives
- Tests: `friday-briefing-card.test.js` (6 scenarios) and `finding-consolidator.test.js` (6 scenarios)

## Test plan
- [ ] Verify `generateBriefingCard` returns correct shape with all count fields
- [ ] Verify `populateDecisionConsequences` updates JSONB on `eva_friday_decisions`
- [ ] Verify `consolidateFindings` groups recs by domain
- [ ] Verify `applyRecommendationDecay` respects floor (0.1) and idempotency
- [ ] Verify `getKnowledgeSummary` with status/limit filters
- [ ] Verify migration applies cleanly and view returns rows from all 4 source tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)