### PR TITLE
feat(SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001): Stage 17 stitch HTML variation pipeline

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -1,0 +1,251 @@
+/**
+ * Stage 17 Archetype Generation Engine
+ *
+ * Generates 6 distinct HTML design archetypes per screen by calling Claude Sonnet
+ * with each stitch_design_export artifact and locked brand token constraints.
+ * Results are persisted as stage_17_archetype venture_artifacts.
+ *
+ * Exports:
+ *   generateArchetypes(ventureId, supabase) — generate 6 archetypes per screen
+ *
+ * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-A
+ * @module lib/eva/stage-17/archetype-generator
+ */
+
+import { getTokenConstraints } from './token-manifest.js';
+import { writeArtifact } from '../artifact-persistence-service.js';
+
+const ARCHETYPE_LAYOUTS = [
+  'hero-centric with full-width header and content below',
+  'card-grid layout with equal-weight content tiles',
+  'sidebar navigation with content-right panel',
+  'single-column minimal with generous whitespace',
+  'split-screen with media left and text right',
+  'dashboard-style with data visualization prominence',
+];
+
+/**
+ * Named error for missing Stage 15/16 source artifacts.
+ */
+export class ArchetypeGenerationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ArchetypeGenerationError';
+  }
+}
+
+/**
+ * Fetch all current stitch_design_export artifacts for a venture.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @returns {Promise<Array>} artifact rows
+ */
+async function fetchStitchArtifacts(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, artifact_data, content, metadata, title')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'stitch_design_export')
+    .eq('is_current', true)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(`[archetype-generator] DB fetch error: ${error.message}`);
+  return data ?? [];
+}
+
+/**
+ * Build the Claude prompt for a single archetype variant.
+ *
+ * @param {string} screenHtml - Truncated screen HTML (max 4000 chars)
+ * @param {object} tokens - Brand token manifest {colors, typeScale, spacing}
+ * @param {string} layoutDescription - One of the 6 archetype layout descriptions
+ * @param {number} variantIndex - 1–6
+ * @returns {string} prompt text
+ */
+function buildArchetypePrompt(screenHtml, tokens, layoutDescription, variantIndex) {
+  const colorList = (tokens?.colors ?? []).slice(0, 5).join(', ') || 'brand primary, brand secondary, neutral';
+  const headingFont = tokens?.typeScale?.heading ?? 'serif';
+  const bodyFont = tokens?.typeScale?.body ?? 'sans-serif';
+
+  return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 6 for this screen.
+
+BRAND TOKENS (LOCKED — do not deviate):
+- Colors: ${colorList}
+- Heading font: ${headingFont}
+- Body font: ${bodyFont}
+- Spacing base: 4px grid (4, 8, 16, 24, 32, 48px)
+
+LAYOUT APPROACH: ${layoutDescription}
+
+SOURCE SCREEN (reference for content and structure):
+${screenHtml.slice(0, 4000)}
+
+REQUIREMENTS:
+1. Produce one complete HTML document with inline CSS only (no external links)
+2. Apply the locked brand colors using CSS custom properties
+3. Use the locked fonts via font-family declarations
+4. Implement the specified layout approach distinctly
+5. Preserve all content elements from the source screen
+6. Output ONLY the HTML — no explanation, no markdown fences`;
+}
+
+/**
+ * Generate 6 HTML design archetypes for each stitch screen artifact.
+ * Writes stage_17_archetype venture_artifacts (6 per screen).
+ *
+ * @param {string} ventureId
+ * @param {object} supabase - Supabase service client
+ * @returns {Promise<{ screenCount: number, artifactIds: string[] }>}
+ * @throws {ArchetypeGenerationError} if no stitch_design_export artifacts found
+ */
+export async function generateArchetypes(ventureId, supabase) {
+  // 1. Load source stitch artifacts
+  const stitchArtifacts = await fetchStitchArtifacts(supabase, ventureId);
+
+  if (stitchArtifacts.length === 0) {
+    throw new ArchetypeGenerationError(
+      `No stitch_design_export artifacts found for venture ${ventureId}. ` +
+      'Stage 15/16 Stitch export must complete before Stage 17 archetype generation.'
+    );
+  }
+
+  // 2. Load brand token manifest
+  const tokens = await getTokenConstraints(ventureId, supabase);
+
+  // 3. Import LLM client
+  const { createLLMClient } = await import('../../llm/client-factory.js');
+  const client = await createLLMClient('sonnet');
+
+  const artifactIds = [];
+
+  // 4. Generate 6 archetypes per screen (sequential to avoid rate limits)
+  for (const screenArtifact of stitchArtifacts) {
+    const screenHtml = screenArtifact.content
+      || JSON.stringify(screenArtifact.artifact_data ?? {});
+
+    const screenTitle = screenArtifact.title ?? screenArtifact.metadata?.screenName ?? `screen-${screenArtifact.id.slice(0, 8)}`;
+
+    for (let i = 0; i < 6; i++) {
+      const prompt = buildArchetypePrompt(screenHtml, tokens, ARCHETYPE_LAYOUTS[i], i + 1);
+
+      const response = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4096,
+        messages: [{ role: 'user', content: prompt }],
+      });
+
+      const archetypeHtml = response.content[0]?.text ?? '';
+
+      const artifactId = await writeArtifact(supabase, {
+        ventureId,
+        lifecycleStage: 17,
+        artifactType: 'stage_17_archetype',
+        title: `${screenTitle} — Archetype ${i + 1}: ${ARCHETYPE_LAYOUTS[i].split(' ')[0]}`,
+        content: archetypeHtml,
+        artifactData: {
+          variantIndex: i + 1,
+          layoutDescription: ARCHETYPE_LAYOUTS[i],
+          sourceArtifactId: screenArtifact.id,
+          screenName: screenTitle,
+        },
+        qualityScore: 80,
+        validationStatus: 'pending',
+        source: 'stage-17-archetype-generator',
+        metadata: {
+          screenArtifactId: screenArtifact.id,
+          variantIndex: i + 1,
+          tokensApplied: !!tokens,
+        },
+      });
+
+      artifactIds.push(artifactId);
+    }
+  }
+
+  return { screenCount: stitchArtifacts.length, artifactIds };
+}
+
+/**
+ * Generate 4 refined variants from 2 selected archetype HTMLs.
+ * Used by selection-flow.js Pass 1.
+ *
+ * @param {string} ventureId
+ * @param {string} screenName - Screen identifier for artifact titles
+ * @param {string[]} selectedHtmls - Array of 2 selected archetype HTML strings
+ * @param {object} tokens - Brand token manifest
+ * @param {object} supabase
+ * @param {object} [options]
+ * @param {string} [options.mobileContextHtml] - Approved mobile HTML for desktop reference
+ * @returns {Promise<string[]>} Array of 4 artifact IDs
+ */
+export async function generateRefinedVariants(ventureId, screenName, selectedHtmls, tokens, supabase, options = {}) {
+  const { createLLMClient } = await import('../../llm/client-factory.js');
+  const client = await createLLMClient('sonnet');
+
+  const mobileContext = options.mobileContextHtml
+    ? `\n\nMOBILE REFERENCE (approved mobile design for this screen — desktop must maintain visual coherence):\n${options.mobileContextHtml.slice(0, 2000)}`
+    : '';
+
+  const colorList = (tokens?.colors ?? []).slice(0, 5).join(', ') || 'brand primary';
+  const headingFont = tokens?.typeScale?.heading ?? 'serif';
+  const bodyFont = tokens?.typeScale?.body ?? 'sans-serif';
+
+  const refinementStyles = [
+    'elevated visual polish with refined spacing and micro-interactions',
+    'high contrast with strong typographic hierarchy',
+    'warm and approachable with softer transitions',
+    'minimal and focused with reduced visual noise',
+  ];
+
+  const artifactIds = [];
+
+  for (let i = 0; i < 4; i++) {
+    const prompt = `You are a senior UI designer refining selected design archetypes. Generate Refined Variant ${i + 1} of 4 by synthesizing the best elements of the two selected archetypes below.
+
+BRAND TOKENS (LOCKED):
+- Colors: ${colorList}
+- Heading font: ${headingFont}
+- Body font: ${bodyFont}
+- Spacing: 4px grid
+
+REFINEMENT DIRECTION: ${refinementStyles[i]}
+
+SELECTED ARCHETYPE 1:
+${selectedHtmls[0].slice(0, 2000)}
+
+SELECTED ARCHETYPE 2:
+${selectedHtmls[1].slice(0, 2000)}${mobileContext}
+
+Produce one complete, self-contained HTML document with inline CSS. Output ONLY the HTML.`;
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const refinedHtml = response.content[0]?.text ?? '';
+
+    const artifactId = await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 17,
+      artifactType: 'stage_17_refined',
+      title: `${screenName} — Refined ${i + 1}: ${refinementStyles[i].split(' ')[0]}`,
+      content: refinedHtml,
+      artifactData: {
+        variantIndex: i + 1,
+        refinementDirection: refinementStyles[i],
+        screenName,
+      },
+      qualityScore: 85,
+      validationStatus: 'pending',
+      source: 'stage-17-archetype-generator',
+      metadata: { variantIndex: i + 1 },
+    });
+
+    artifactIds.push(artifactId);
+  }
+
+  return artifactIds;
+}

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -201,7 +201,7 @@ export async function generateRefinedVariants(ventureId, screenName, selectedHtm
   const artifactIds = [];
 
   for (let i = 0; i < 4; i++) {
-    const prompt = `You are a senior UI designer refining selected design archetypes. Generate Refined Variant ${i + 1} of 4 by synthesizing the best elements of the two selected archetypes below.
+    const prompt = `You are a senior UI designer refining chosen design archetypes. Generate Refined Variant ${i + 1} of 4 by synthesizing the best elements of the two chosen archetypes below.
 
 BRAND TOKENS (LOCKED):
 - Colors: ${colorList}

--- a/lib/eva/stage-17/qa-rubric.js
+++ b/lib/eva/stage-17/qa-rubric.js
@@ -1,0 +1,328 @@
+/**
+ * Stage 17 QA Rubric and GitHub Upload
+ *
+ * Executes 3-layer gap analysis on completed Stage 17 design artifacts:
+ *   Layer 1 (base): checks all 14 sessions have approved artifacts
+ *   Layer 2 (product): validates HTML structure against product spec patterns
+ *   Layer 3 (venture): checks brand token consistency against locked manifest
+ *
+ * On approval, uploads all 14 HTML files to the venture GitHub repository
+ * at ventures/{id}/documents/stage-17/{screen}-{platform}.html.
+ * Upload blocks if HIGH-severity QA gaps exist.
+ *
+ * Exports:
+ *   runQARubric(ventureId, supabase)
+ *   uploadToGitHub(ventureId, supabase, options)
+ *
+ * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-E
+ * @module lib/eva/stage-17/qa-rubric
+ */
+
+import { getTokenConstraints } from './token-manifest.js';
+
+const EXPECTED_APPROVED_COUNT = 14; // 7 screens × 2 platforms
+
+/**
+ * Upload error thrown when HIGH-severity QA gaps block GitHub upload.
+ */
+export class UploadError extends Error {
+  constructor(message, gaps) {
+    super(message);
+    this.name = 'UploadError';
+    this.gaps = gaps;
+  }
+}
+
+// ── Layer helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all approved stage_17 artifacts for the venture.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @returns {Promise<Array>} artifact rows
+ */
+async function fetchApprovedArtifacts(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, content, metadata, title')
+    .eq('venture_id', ventureId)
+    .eq('is_current', true)
+    .in('artifact_type', ['stage_17_approved_mobile', 'stage_17_approved_desktop']);
+
+  if (error) throw new Error(`[qa-rubric] DB fetch error: ${error.message}`);
+  return data ?? [];
+}
+
+/**
+ * Layer 1: Base completeness check — all 14 sessions present.
+ *
+ * @param {Array} approvedArtifacts
+ * @returns {{ score: number, items: Array }}
+ */
+function runLayer1(approvedArtifacts) {
+  const items = [];
+  const mobileCount = approvedArtifacts.filter(a => a.artifact_type === 'stage_17_approved_mobile').length;
+  const desktopCount = approvedArtifacts.filter(a => a.artifact_type === 'stage_17_approved_desktop').length;
+  const totalCount = approvedArtifacts.length;
+
+  if (totalCount < EXPECTED_APPROVED_COUNT) {
+    const missing = EXPECTED_APPROVED_COUNT - totalCount;
+    items.push({
+      description: `Missing ${missing} approved artifact(s). Have ${mobileCount} mobile + ${desktopCount} desktop, need 7 + 7.`,
+      severity: 'HIGH',
+      layer: 1,
+    });
+  }
+
+  if (mobileCount < 7) {
+    items.push({
+      description: `Only ${mobileCount}/7 mobile designs approved. Complete mobile sessions before desktop.`,
+      severity: 'HIGH',
+      layer: 1,
+    });
+  }
+
+  if (desktopCount < 7) {
+    items.push({
+      description: `Only ${desktopCount}/7 desktop designs approved.`,
+      severity: 'HIGH',
+      layer: 1,
+    });
+  }
+
+  const score = totalCount >= EXPECTED_APPROVED_COUNT ? 100 : Math.round((totalCount / EXPECTED_APPROVED_COUNT) * 100);
+  return { score, items };
+}
+
+/**
+ * Layer 2: Product spec conformance — navigation, CTA, data visualization.
+ * Uses HTML pattern matching against common product spec requirements.
+ *
+ * @param {Array} approvedArtifacts
+ * @returns {{ score: number, items: Array }}
+ */
+function runLayer2(approvedArtifacts) {
+  const items = [];
+  let passCount = 0;
+  let totalChecks = 0;
+
+  for (const artifact of approvedArtifacts) {
+    const html = artifact.content ?? '';
+    const screenLabel = artifact.metadata?.screenId ?? artifact.title ?? artifact.id.slice(0, 8);
+
+    // Navigation structure check
+    totalChecks++;
+    if (/<nav[\s>]|role="navigation"|aria-label.*nav/i.test(html)) {
+      passCount++;
+    } else {
+      items.push({
+        description: `${screenLabel}: Missing navigation structure (<nav> or role="navigation")`,
+        severity: 'MED',
+        layer: 2,
+      });
+    }
+
+    // CTA presence check (buttons or primary action links)
+    totalChecks++;
+    if (/<button[\s>]|type="submit"|class=".*cta.*"|class=".*btn-primary.*"|href.*cta/i.test(html)) {
+      passCount++;
+    } else {
+      items.push({
+        description: `${screenLabel}: No clear CTA element found (button, submit, or primary action)`,
+        severity: 'MED',
+        layer: 2,
+      });
+    }
+  }
+
+  const score = totalChecks > 0 ? Math.round((passCount / totalChecks) * 100) : 100;
+  return { score, items };
+}
+
+/**
+ * Layer 3: Venture brand token consistency.
+ * Checks CSS custom properties or inline color values match the locked token manifest.
+ *
+ * @param {Array} approvedArtifacts
+ * @param {object|null} tokens - Locked token manifest
+ * @returns {{ score: number, items: Array }}
+ */
+function runLayer3(approvedArtifacts, tokens) {
+  const items = [];
+
+  if (!tokens) {
+    items.push({
+      description: 'No locked token manifest found. Cannot validate brand token consistency.',
+      severity: 'HIGH',
+      layer: 3,
+    });
+    return { score: 0, items };
+  }
+
+  const brandColors = (tokens.colors ?? []).map(c => c.toLowerCase());
+  if (brandColors.length === 0) {
+    return { score: 100, items }; // No colors to validate against
+  }
+
+  let passCount = 0;
+  const total = approvedArtifacts.length;
+
+  for (const artifact of approvedArtifacts) {
+    const html = (artifact.content ?? '').toLowerCase();
+    const screenLabel = artifact.metadata?.screenId ?? artifact.title ?? artifact.id.slice(0, 8);
+
+    // Check if any brand color appears in the HTML
+    const hasBrandColor = brandColors.some(color => html.includes(color));
+    if (hasBrandColor) {
+      passCount++;
+    } else {
+      items.push({
+        description: `${screenLabel}: No brand colors detected. Possible token drift.`,
+        severity: 'HIGH',
+        layer: 3,
+      });
+    }
+  }
+
+  const score = total > 0 ? Math.round((passCount / total) * 100) : 100;
+  return { score, items };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Run 3-layer QA rubric on all Stage 17 approved artifacts.
+ *
+ * @param {string} ventureId
+ * @param {object} supabase
+ * @returns {Promise<{ layers: { base: object, product: object, venture: object }, items: Array, overallScore: number }>}
+ */
+export async function runQARubric(ventureId, supabase) {
+  const [approvedArtifacts, tokens] = await Promise.all([
+    fetchApprovedArtifacts(supabase, ventureId),
+    getTokenConstraints(ventureId, supabase),
+  ]);
+
+  const layer1 = runLayer1(approvedArtifacts);
+  const layer2 = runLayer2(approvedArtifacts);
+  const layer3 = runLayer3(approvedArtifacts, tokens);
+
+  const allItems = [...layer1.items, ...layer2.items, ...layer3.items];
+  const overallScore = Math.round((layer1.score + layer2.score + layer3.score) / 3);
+
+  return {
+    layers: {
+      base: layer1,
+      product: layer2,
+      venture: layer3,
+    },
+    items: allItems,
+    overallScore,
+    highCount: allItems.filter(i => i.severity === 'HIGH').length,
+    medCount: allItems.filter(i => i.severity === 'MED').length,
+    lowCount: allItems.filter(i => i.severity === 'LOW').length,
+  };
+}
+
+/**
+ * Upload all 14 approved HTML artifacts to the venture GitHub repository.
+ * Blocks if runQARubric returns HIGH-severity gaps.
+ *
+ * Files are committed to: ventures/{ventureId}/documents/stage-17/{screenId}-{platform}.html
+ *
+ * @param {string} ventureId
+ * @param {object} supabase
+ * @param {object} [options]
+ * @param {string} [options.githubToken] - GitHub token (falls back to GITHUB_TOKEN env)
+ * @param {string} [options.repoFullName] - e.g. "org/venture-repo" (falls back to ventures table)
+ * @returns {Promise<{ filesUploaded: number, commitSha: string|null }>}
+ * @throws {UploadError} if HIGH QA gaps exist
+ */
+export async function uploadToGitHub(ventureId, supabase, options = {}) {
+  // 1. Run QA rubric first — block on HIGH severity
+  const rubric = await runQARubric(ventureId, supabase);
+  const highGaps = rubric.items.filter(i => i.severity === 'HIGH');
+
+  if (highGaps.length > 0) {
+    throw new UploadError(
+      `GitHub upload blocked: ${highGaps.length} HIGH-severity QA gap(s) must be resolved first.`,
+      highGaps
+    );
+  }
+
+  // 2. Fetch approved artifacts
+  const approvedArtifacts = await fetchApprovedArtifacts(supabase, ventureId);
+
+  if (approvedArtifacts.length === 0) {
+    throw new UploadError('No approved artifacts found for upload.', []);
+  }
+
+  // 3. Resolve GitHub repo
+  const token = options.githubToken ?? process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('[qa-rubric] GITHUB_TOKEN not set. Cannot upload to GitHub.');
+
+  let repoFullName = options.repoFullName;
+  if (!repoFullName) {
+    const { data: venture } = await supabase
+      .from('ventures')
+      .select('metadata')
+      .eq('id', ventureId)
+      .single();
+    repoFullName = venture?.metadata?.github_repo ?? null;
+  }
+
+  if (!repoFullName) {
+    throw new Error(`[qa-rubric] No GitHub repository configured for venture ${ventureId}`);
+  }
+
+  const GITHUB_API = 'https://api.github.com';
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+
+  // 4. Commit each HTML file
+  let filesUploaded = 0;
+  let lastCommitSha = null;
+
+  for (const artifact of approvedArtifacts) {
+    const screenId = artifact.metadata?.screenId ?? artifact.id.slice(0, 8);
+    const platform = artifact.artifact_type === 'stage_17_approved_mobile' ? 'mobile' : 'desktop';
+    const filePath = `ventures/${ventureId}/documents/stage-17/${screenId}-${platform}.html`;
+    const content = artifact.content ?? '';
+
+    // Check if file exists (to get current SHA for updates)
+    let existingSha = null;
+    const checkRes = await fetch(`${GITHUB_API}/repos/${repoFullName}/contents/${filePath}`, { headers });
+    if (checkRes.ok) {
+      const existing = await checkRes.json();
+      existingSha = existing.sha;
+    }
+
+    const body = {
+      message: `feat(stage-17): add approved ${platform} design for screen ${screenId}`,
+      content: Buffer.from(content).toString('base64'),
+      ...(existingSha ? { sha: existingSha } : {}),
+    };
+
+    const putRes = await fetch(`${GITHUB_API}/repos/${repoFullName}/contents/${filePath}`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!putRes.ok) {
+      const errBody = await putRes.text();
+      throw new Error(`[qa-rubric] GitHub upload failed for ${filePath}: ${putRes.status} ${errBody}`);
+    }
+
+    const result = await putRes.json();
+    lastCommitSha = result.commit?.sha ?? null;
+    filesUploaded++;
+  }
+
+  return { filesUploaded, commitSha: lastCommitSha };
+}

--- a/lib/eva/stage-17/selection-flow.js
+++ b/lib/eva/stage-17/selection-flow.js
@@ -1,0 +1,198 @@
+/**
+ * Stage 17 Chairman Selection Flow
+ *
+ * Manages the two-pass design selection funnel across 14 sessions
+ * (7 screens × 2 platforms). Pass 1 narrows 6 archetypes to 2 selections
+ * and triggers generation of 4 refined variants. Pass 2 produces 1 final
+ * approved design per screen+platform. Desktop sessions inject the approved
+ * mobile thumbnail as context.
+ *
+ * Exports:
+ *   submitPass1Selection(ventureId, screenId, selectedIds, supabase)
+ *   submitPass2Selection(ventureId, screenId, platform, artifactId, supabase)
+ *   isDesignPassComplete(ventureId, supabase)
+ *
+ * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-B
+ * @module lib/eva/stage-17/selection-flow
+ */
+
+import { generateRefinedVariants } from './archetype-generator.js';
+import { getTokenConstraints } from './token-manifest.js';
+import { writeArtifact } from '../artifact-persistence-service.js';
+
+const VALID_PLATFORMS = ['mobile', 'desktop'];
+
+/**
+ * Validation error for incorrect selection counts or invalid inputs.
+ */
+export class SelectionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SelectionError';
+  }
+}
+
+/**
+ * Fetch artifact content by ID.
+ *
+ * @param {object} supabase
+ * @param {string} artifactId
+ * @returns {Promise<{ content: string, artifact_data: object, metadata: object, title: string }>}
+ */
+async function fetchArtifactById(supabase, artifactId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, content, artifact_data, metadata, title, artifact_type')
+    .eq('id', artifactId)
+    .single();
+
+  if (error || !data) throw new Error(`[selection-flow] Artifact ${artifactId} not found: ${error?.message}`);
+  return data;
+}
+
+/**
+ * Fetch the approved mobile design artifact for a given screen.
+ * Used to inject mobile context when generating desktop archetypes.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @param {string} screenId
+ * @returns {Promise<string|null>} HTML content string or null
+ */
+async function fetchApprovedMobileHtml(supabase, ventureId, screenId) {
+  const { data } = await supabase
+    .from('venture_artifacts')
+    .select('content')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'stage_17_approved_mobile')
+    .eq('is_current', true)
+    .contains('metadata', { screenId })
+    .limit(1);
+
+  return data?.[0]?.content ?? null;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Pass 1: Accept exactly 2 selected archetype artifact IDs.
+ * Reads their HTML, generates 4 refined variants, and persists them.
+ * For desktop sessions, injects the approved mobile design as context.
+ *
+ * @param {string} ventureId
+ * @param {string} screenId - Identifier for the screen being reviewed
+ * @param {string[]} selectedIds - Exactly 2 stage_17_archetype artifact IDs
+ * @param {object} supabase
+ * @param {object} [options]
+ * @param {string} [options.platform='mobile'] - 'mobile' or 'desktop'
+ * @returns {Promise<{ refinedArtifactIds: string[] }>} 4 stage_17_refined artifact IDs
+ * @throws {SelectionError} if selectedIds.length !== 2 or platform invalid
+ */
+export async function submitPass1Selection(ventureId, screenId, selectedIds, supabase, options = {}) {
+  const platform = options.platform ?? 'mobile';
+
+  if (!VALID_PLATFORMS.includes(platform)) {
+    throw new SelectionError(`Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
+  }
+
+  if (!Array.isArray(selectedIds) || selectedIds.length !== 2) {
+    throw new SelectionError(
+      `Pass 1 requires exactly 2 selections. Got ${Array.isArray(selectedIds) ? selectedIds.length : typeof selectedIds}.`
+    );
+  }
+
+  // Load selected archetype HTML content
+  const [artifact1, artifact2] = await Promise.all([
+    fetchArtifactById(supabase, selectedIds[0]),
+    fetchArtifactById(supabase, selectedIds[1]),
+  ]);
+
+  const selectedHtmls = [
+    artifact1.content ?? JSON.stringify(artifact1.artifact_data ?? {}),
+    artifact2.content ?? JSON.stringify(artifact2.artifact_data ?? {}),
+  ];
+
+  // Load tokens
+  const tokens = await getTokenConstraints(ventureId, supabase);
+
+  // Desktop: inject approved mobile thumbnail as context
+  let mobileContextHtml = null;
+  if (platform === 'desktop') {
+    mobileContextHtml = await fetchApprovedMobileHtml(supabase, ventureId, screenId);
+  }
+
+  const screenName = artifact1.metadata?.screenName ?? artifact1.artifact_data?.screenName ?? screenId;
+
+  const refinedArtifactIds = await generateRefinedVariants(
+    ventureId,
+    screenName,
+    selectedHtmls,
+    tokens,
+    supabase,
+    { mobileContextHtml }
+  );
+
+  return { refinedArtifactIds };
+}
+
+/**
+ * Pass 2: Select 1 final design from 4 refined variants.
+ * Persists the chosen artifact as stage_17_approved_mobile or stage_17_approved_desktop.
+ *
+ * @param {string} ventureId
+ * @param {string} screenId - Identifier for the screen
+ * @param {'mobile'|'desktop'} platform
+ * @param {string} artifactId - ID of the selected stage_17_refined artifact
+ * @param {object} supabase
+ * @returns {Promise<{ approvedArtifactId: string }>}
+ * @throws {SelectionError} if platform invalid
+ */
+export async function submitPass2Selection(ventureId, screenId, platform, artifactId, supabase) {
+  if (!VALID_PLATFORMS.includes(platform)) {
+    throw new SelectionError(`Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
+  }
+
+  const source = await fetchArtifactById(supabase, artifactId);
+  const approvedType = platform === 'mobile' ? 'stage_17_approved_mobile' : 'stage_17_approved_desktop';
+
+  const approvedArtifactId = await writeArtifact(supabase, {
+    ventureId,
+    lifecycleStage: 17,
+    artifactType: approvedType,
+    title: `${source.metadata?.screenName ?? screenId} — Approved ${platform.charAt(0).toUpperCase() + platform.slice(1)}`,
+    content: source.content,
+    artifactData: source.artifact_data,
+    qualityScore: 90,
+    validationStatus: 'validated',
+    source: 'stage-17-selection-flow',
+    metadata: {
+      screenId,
+      platform,
+      sourceRefinedArtifactId: artifactId,
+      approvedAt: new Date().toISOString(),
+    },
+  });
+
+  return { approvedArtifactId };
+}
+
+/**
+ * Check whether all 14 design sessions are complete.
+ * Returns true when stage_17_approved_mobile + stage_17_approved_desktop
+ * artifact count is ≥ 14 (7 screens × 2 platforms).
+ *
+ * @param {string} ventureId
+ * @param {object} supabase
+ * @returns {Promise<boolean>}
+ */
+export async function isDesignPassComplete(ventureId, supabase) {
+  const { count, error } = await supabase
+    .from('venture_artifacts')
+    .select('id', { count: 'exact', head: true })
+    .eq('venture_id', ventureId)
+    .eq('is_current', true)
+    .in('artifact_type', ['stage_17_approved_mobile', 'stage_17_approved_desktop']);
+
+  if (error) throw new Error(`[selection-flow] isDesignPassComplete DB error: ${error.message}`);
+  return (count ?? 0) >= 14;
+}


### PR DESCRIPTION
## Summary

- **archetype-generator.js**: Generates 6 HTML layout archetypes per stitch screen by calling Claude Sonnet with locked brand token constraints (stage_17_archetype artifacts); also generates 4 refined variants from 2 chosen archetypes (stage_17_refined)
- **selection-flow.js**: Orchestrates 2-pass design review — Pass 1 (select 2 of 6 archetypes → generate 4 refined), Pass 2 (approve 1 of 4 refined per screen+platform); tracks 14-session completion (7 screens × 2 platforms) via stage_17_approved_* artifacts
- **qa-rubric.js**: 3-layer QA gate (base: count 14 approved, product: nav+CTA checks, venture: brand token color consistency); blocks GitHub upload on HIGH-severity gaps

Part of SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001 (Stage 17 Design Refinement Workflow).

## Test plan
- [ ] `generateArchetypes(ventureId, sb)` returns 6 artifacts per stitch screen
- [ ] `submitPass1Selection` with exactly 2 IDs triggers `generateRefinedVariants` → 4 stage_17_refined artifacts
- [ ] `submitPass2Selection` writes stage_17_approved_mobile or stage_17_approved_desktop
- [ ] `isDesignPassComplete` returns true after 14 approvals
- [ ] `runQARubric` returns gaps array; HIGH gaps block `uploadToGitHub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)