### PR TITLE
fix(SD-LEARN-106): improve claim-validity-gate diagnostics and sd-start CLAUDE_SESSION_ID reminder

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -139,7 +139,7 @@ function explainRemediation(reason) {
     case 'ambiguous':
       return 'Multiple sessions share this terminal_id. Run `/claim list` to see all active sessions. This usually means two Claude Code instances are running on the same host without unique CLAUDE_SESSION_ID env vars.';
     case 'no_deterministic_identity':
-      return 'CLAUDE_SESSION_ID env var is not set and no matching marker file was found. Restart Claude Code so the SessionStart hook can populate .claude/session-identity/. Do NOT fall back to heartbeat guessing.';
+      return 'CLAUDE_SESSION_ID env var is not set and no matching marker file was found.\n  Quick fix: prefix all handoff.js calls with the session ID from sd-start output:\n    CLAUDE_SESSION_ID=<uuid-from-sd-start> node scripts/handoff.js execute <PHASE> <SD-ID>\n  Permanent fix: Restart Claude Code so the SessionStart hook can populate .claude/session-identity/. Do NOT fall back to heartbeat guessing.';
     case 'error':
       return 'Identity resolution query failed. Check Supabase connectivity and SUPABASE_URL env var.';
     default:

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1097,10 +1097,11 @@ async function main() {
     console.log(`\n${colors.bold}Next Action:${colors.reset}`);
     console.log(`   ${colors.cyan}/brainstorm ${sd.title}${colors.reset}`);
     console.log(`${colors.dim}   After brainstorm completes with vision+arch, then:${colors.reset}`);
-    console.log(`   ${colors.dim}node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+    console.log(`   ${colors.dim}CLAUDE_SESSION_ID=${session.session_id} node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
   } else {
     console.log(`\n${colors.bold}Next Action:${colors.reset}`);
-    console.log(`   ${colors.cyan}node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+    console.log(`   ${colors.cyan}CLAUDE_SESSION_ID=${session.session_id} node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+    console.log(`${colors.dim}   All subsequent node script invocations must include CLAUDE_SESSION_ID=<uuid> as an inline env var prefix.${colors.reset}`);
   }
 
   console.log(`\n${colors.dim}Session: ${session.session_id}${colors.reset}`);


### PR DESCRIPTION
## Summary

- **`lib/claim-validity-gate.js`**: Improved `no_deterministic_identity` remediation message to include a quick-fix (inline `CLAUDE_SESSION_ID=<uuid>` prefix) alongside the permanent fix (restart Claude Code). Previously the error message only told users to restart, leaving them stuck when the session already exists.
- **`scripts/sd-start.js`**: Updated the next-action block to output `CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js ...` instead of bare `node scripts/handoff.js ...`, so the session ID is visible and ready to copy-paste. Added a dim reminder that all subsequent invocations require the prefix.

## Test plan

- [ ] `lib/claim-validity-gate.js` `no_deterministic_identity` branch now includes quick-fix instructions
- [ ] `scripts/sd-start.js` next-action output includes `CLAUDE_SESSION_ID=<uuid>` prefix on handoff command

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-106

🤖 Generated with [Claude Code](https://claude.com/claude-code)