### PR TITLE
feat(SD-LEARN-109): add PLAN-TO-EXEC checklist and improve USER_STORIES_MISSING remediation

### DIFF
--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -456,6 +456,21 @@ export async function handlePrecheckCommand(precheckType, precheckSdId) {
     console.log('');
   }
 
+  // PLAN-TO-EXEC checklist (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-109)
+  if (normalizedType === 'PLAN-TO-EXEC') {
+    console.log('');
+    console.log('📋 PLAN-TO-EXEC CHECKLIST REMINDERS');
+    console.log('─'.repeat(50));
+    console.log('   ⚠️  PRD executive_summary must be 50+ chars — one-liners cause PRD_SUMMARY_SHORT (0%).');
+    console.log('   Fix: update executive_summary in product_requirements_v2 WHERE sd_id=\'<SD-ID>\'.');
+    console.log('   ⚠️  User stories must exist BEFORE this gate. Format: story_key=\'SD-KEY:US-001\'.');
+    console.log('   Create via DB insert into user_stories with fields: story_key, sd_id, title, user_role,');
+    console.log('   user_want, user_benefit, acceptance_criteria, implementation_context.');
+    console.log('   ⚠️  CLAUDE_SESSION_ID must be set or no_deterministic_identity blocks the claim gate.');
+    console.log('   Run: CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute PLAN-TO-EXEC <SD-ID>');
+    console.log('');
+  }
+
   // Step 2: Run all handoff gates
   console.log('');
   console.log('STEP 2: HANDOFF GATE VALIDATION');

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -199,7 +199,12 @@ async function checkPlanToExecPrereqs(supabase, sd, sdId) {
     issues.push({
       code: 'USER_STORIES_MISSING',
       message: 'No user stories found for this SD',
-      remediation: `Create user stories linked to ${sdId}. Each story needs: story_key, title, user_role, user_want, user_benefit, acceptance_criteria, implementation_context`
+      remediation: [
+        `Create user stories linked to ${sdId}. story_key format: '${sdId}:US-001'.`,
+        'Required fields: story_key, sd_id, title, user_role, user_want, user_benefit,',
+        '  acceptance_criteria (array), implementation_context (string).',
+        'Example story_key values: ' + sdId + ':US-001, ' + sdId + ':US-002'
+      ].join('\n')
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds PLAN-TO-EXEC checklist block to `handlePrecheckCommand()` in `cli-main.js` with three proactive warnings:
  - PRD `executive_summary` must be 50+ chars (avoids PRD_SUMMARY_SHORT/0% gate failure)
  - User stories must exist before PLAN-TO-EXEC, with `story_key` format `SD-KEY:US-NNN`
  - `CLAUDE_SESSION_ID` must be set to avoid `no_deterministic_identity` claim gate failure
- Improves `USER_STORIES_MISSING` remediation in `prerequisite-preflight.js` to include concrete `story_key` format example and required field list

## Test plan
- [ ] Run `node scripts/handoff.js precheck PLAN-TO-EXEC <any-SD>` and verify PLAN-TO-EXEC CHECKLIST REMINDERS section appears
- [ ] Verify EXEC-TO-PLAN precheck output unchanged (no regression)
- [ ] Verify USER_STORIES_MISSING error message shows `story_key` format example

Resolves: PAT-RETRO-PLANTOEXEC-c73db06a, PAT-HF-PLANTOEXEC-c73db06a, PAT-HF-PLANTOEXEC-7d52da5e, PAT-RETRO-PLANTOEXEC-b3a3eca1, PAT-HF-PLANTOEXEC-b3a3eca1

🤖 Generated with [Claude Code](https://claude.com/claude-code)