### PR TITLE
fix(SD-LEARN-110): improve wrong_worktree remediation with fleet execution guidance

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -294,7 +294,7 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
             operation, sdKey,
             expectedWorktree: expectedWt,
             actualCwd,
-            remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your command.`
+            remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your handoff command with the session prefix:\n    CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute <PHASE> ${sdKey}\n  Fleet note: in parallel execution each child SD must run from its OWN worktree,\n  not from the parent orchestrator's worktree or the main repo root.`
           });
         }
       }

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -140,6 +140,8 @@ function explainRemediation(reason) {
       return 'Multiple sessions share this terminal_id. Run `/claim list` to see all active sessions. This usually means two Claude Code instances are running on the same host without unique CLAUDE_SESSION_ID env vars.';
     case 'no_deterministic_identity':
       return 'CLAUDE_SESSION_ID env var is not set and no matching marker file was found.\n  Quick fix: prefix all handoff.js calls with the session ID from sd-start output:\n    CLAUDE_SESSION_ID=<uuid-from-sd-start> node scripts/handoff.js execute <PHASE> <SD-ID>\n  Permanent fix: Restart Claude Code so the SessionStart hook can populate .claude/session-identity/. Do NOT fall back to heartbeat guessing.';
+    case 'wrong_worktree':
+      return 'Handoff is running from the wrong directory. Fix:\n  1. cd to the SD\'s worktree: cd .worktrees/<SD-KEY>  (path shown in "Expected worktree" above)\n  2. Re-run the handoff from there: CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute <PHASE> <SD-ID>\n  In fleet execution, each child SD must run from its own worktree — never from the parent orchestrator\'s worktree.';
     case 'error':
       return 'Identity resolution query failed. Check Supabase connectivity and SUPABASE_URL env var.';
     default:


### PR DESCRIPTION
## Summary
- Improves `wrong_worktree` error remediation in `claim-validity-gate.js` to include:
  - Explicit full `cd "<worktree-path>"` command (path already shown in banner header)
  - Full handoff re-run command with `CLAUDE_SESSION_ID` prefix
  - Fleet execution note: each child SD must run from its OWN worktree, not the parent orchestrator's worktree
- Populated `proven_solutions` and `prevention_checklist` in `issue_patterns` table for 3 patterns (DB update, no code artifact)

## Test plan
- [ ] Trigger `wrong_worktree` condition by running handoff from wrong directory — verify banner includes `CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute <PHASE> <SD-KEY>` with fleet note
- [ ] Query `issue_patterns` for `PAT-HF-LEADTOPLAN-11c30ce9`, `PAT-RETRO-LEADTOPLAN-fc6c4a8c`, `PAT-HF-PLANTOEXEC-11c30ce9` — verify `proven_solutions` non-null

Resolves: PAT-HF-LEADTOPLAN-11c30ce9, PAT-RETRO-LEADTOPLAN-fc6c4a8c, PAT-HF-PLANTOEXEC-11c30ce9

🤖 Generated with [Claude Code](https://claude.com/claude-code)