### PR TITLE
feat(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-111): improve DESCRIPTION_TOO_SHORT and PRD_QUALITY error messages

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -109,10 +109,19 @@ function checkLeadToPlanPrereqs(sd) {
   const descWords = (sd.description || '').split(/\s+/).filter(w => w.length > 0).length;
   const minWords = threshold.minDescriptionWords;
   if (descWords < minWords) {
+    const wordsNeeded = minWords - descWords;
+    const sdKey = sd.sd_key || sd.id || 'SD-XXX-001';
     issues.push({
       code: 'DESCRIPTION_TOO_SHORT',
-      message: `SD description has ${descWords} words (minimum: ${minWords} for ${sdType})`,
-      remediation: `Expand the description field to at least ${minWords} words.`
+      message: `SD description has ${descWords} words (minimum: ${minWords} for ${sdType}) — need ${wordsNeeded} more word(s)`,
+      remediation: [
+        `Add ${wordsNeeded} more word(s) to the description. Consider expanding with:`,
+        `  - Technical approach: which files/modules change and how`,
+        `  - Root cause context: why this problem exists`,
+        `  - Success definition: what "fixed" looks like`,
+        `Update command:`,
+        `  node -e "require('dotenv').config(); const {createClient}=require('@supabase/supabase-js'); const s=createClient(process.env.SUPABASE_URL||process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY); s.from('strategic_directives_v2').update({description:'<expanded description here>'}).eq('sd_key','${sdKey}').then(r=>console.log(r.error||'Updated'));"`
+      ].join('\n')
     });
   }
 

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -273,11 +273,15 @@ export class PlanToExecVerifier {
 
         console.log(`\n📊 PRD Quality Score: ${prdValidation.percentage || prdValidation.score}%`);
 
-        if (!prdValidation.valid || (prdValidation.percentage || prdValidation.score) < this.prdRequirements.minimumScore) {
-          return rejectHandoff(this.supabase,sdId, 'PRD_QUALITY', 'PRD does not meet quality standards', {
+        const actualScore = prdValidation.percentage || prdValidation.score;
+        if (!prdValidation.valid || actualScore < this.prdRequirements.minimumScore) {
+          const topErrors = (prdValidation?.errors || []).slice(0, 3);
+          const errorSuffix = topErrors.length > 0 ? `: ${topErrors.join('; ')}` : '';
+          const prdQualityMsg = `PRD does not meet quality standards (score: ${actualScore}% / required: ${this.prdRequirements.minimumScore}%)${errorSuffix}`;
+          return rejectHandoff(this.supabase, sdId, 'PRD_QUALITY', prdQualityMsg, {
             prdValidation,
             requiredScore: this.prdRequirements.minimumScore,
-            actualScore: prdValidation.percentage || prdValidation.score
+            actualScore
           });
         }
       }


### PR DESCRIPTION
## Summary

- **prerequisite-preflight.js**: `DESCRIPTION_TOO_SHORT` now shows exact word deficit ("need N more word(s)"), 3 content expansion hints (technical approach, root cause, success definition), and a pre-filled `node -e` DB update command with the SD key substituted
- **PlanToExecVerifier.js**: `PRD_QUALITY` rejection message now includes actual score vs required score (`score: X% / required: Y%`) and up to 3 specific validation errors from `prdValidation.errors`

Addresses PAT-RETRO-LEADTOPLAN-11c30ce9 (5 LEAD-TO-PLAN rejections) and PAT-RETRO-PLANTOEXEC-11c30ce9 (3 PLAN-TO-EXEC rejections). Both changes are message-only — no gate logic or threshold changes.

## Test plan

- [ ] DESCRIPTION_TOO_SHORT fires: verify message shows "need N more word(s)"
- [ ] DESCRIPTION_TOO_SHORT fires: verify remediation contains `node -e` command with SD key
- [ ] PRD_QUALITY fails: verify rejection_reason includes score values
- [ ] PRD_QUALITY fails with empty errors array: no crash, score shown cleanly
- [ ] Passing SDs continue to pass both handoffs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)