### PR TITLE
fix(stitch): use callTool to reliably capture screen IDs (no more socket drops)

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -539,17 +539,12 @@ export async function generateScreens(projectId, prompts, ventureId) {
     await consumeBudget(ventureId, prompts.length);
   }
 
-  // Deep research (2026-04-12): Google's Stitch MCP generation takes 45-90s server-side.
-  // The GFE drops TCP after ~30-60s, but the server ALWAYS completes the generation.
-  // listScreens() returns empty until the project is opened in a browser (confirmed bug).
-  //
-  // Pattern: Fire → Close → Assume Success
-  //   1. Fire generate() with a fresh client — expect socket drop as normal
-  //   2. Close the client immediately (transport is tainted after any error)
-  //   3. Mark as "fired" — the server completes generation regardless
-  //   4. No polling (listScreens is broken until browser activation)
-  //   5. Delay between screens — 10s default (increased from 5s: RCA showed 45-90s server-side
-  //      generation means 5s retries hit the same in-progress generation)
+  // 2026-04-15: Switched from project.generate() (SDK SSE wrapper) to
+  // callTool('generate_screen_from_text') (raw MCP). The SDK wrapper used an SSE
+  // transport that Google's GFE dropped after ~30-60s, losing the screen ID.
+  // The raw callTool path returns synchronously with the full screen object including
+  // its ID. listScreens() remains broken (confirmed Stitch server-side bug) but is
+  // no longer needed since every callTool call returns the ID directly.
   const SCREEN_DELAY_MS = parseInt(process.env.STITCH_SCREEN_DELAY_MS || '10000', 10);
 
   const results = [];
@@ -578,58 +573,44 @@ export async function generateScreens(projectId, prompts, ventureId) {
       const attemptLabel = attempt > 1 ? `${label} retry ${attempt}/${MAX_RETRIES}` : label;
       const attemptStart = Date.now();
 
+      const toolClient = new sdk.StitchToolClient({ apiKey, timeout: 180_000 });
       try {
-        const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
-        const project = client.project(projectId);
-        const SCREEN_TIMEOUT_MS = parseInt(process.env.STITCH_SCREEN_TIMEOUT_MS || '150000', 10);
-        try {
-          const screen = await Promise.race([
-            project.generate(promptText, deviceType, modelId),
-            new Promise((_, reject) => setTimeout(() => reject(new Error(`[watchdog] Screen "${screenName}" (${deviceType}) timed out after ${SCREEN_TIMEOUT_MS / 1000}s — SSE transport may be hung`)), SCREEN_TIMEOUT_MS)),
-          ]);
-          const screenId = screen?.id || screen?.screen_id;
-          console.info(`[stitch-client] ${attemptLabel} returned directly: ${screenId}`);
-          results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType, attempt });
-          succeeded = true;
-          recordMetric({ ventureId, screenName, deviceType, promptText, status: 'success', attemptCount: attempt, durationMs: Date.now() - attemptStart });
-        } catch (err) {
-          const msg = err.message || '';
-          const isWatchdog = /\[watchdog\]/.test(msg);
-          const isTransport = isWatchdog || /fetch failed|socket|ECONNRESET|other side closed|Already connected|AbortError|This operation was aborted/i.test(msg);
-          const isIncompleteResponse = /expected object at projection path|Incomplete API response/i.test(msg);
-          if (isTransport || isIncompleteResponse) {
-            // RCA: SDK projection path throws non-transport error for transient server timing
-            // issue. Incomplete responses mean server is likely still processing — treat as fired.
-            const reason = isWatchdog ? 'watchdog timeout — SSE transport hung' : isTransport ? 'socket dropped' : 'incomplete response — server likely still processing';
-            console.info(`[stitch-client] ${attemptLabel} fired (${reason})`);
-            results.push({ prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt });
-            succeeded = true;
-            recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: attempt, durationMs: Date.now() - attemptStart });
-          } else if (/resource has been exhausted|check quota/i.test(msg)) {
-            // Quota exhaustion is permanent for the day — do not retry
-            console.error(`[stitch-client] ${attemptLabel} QUOTA EXHAUSTED: ${msg.slice(0, 120)}`);
-            results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
-            recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'quota_exhausted', errorMessage: msg.slice(0, 500) });
-            consecutiveQuotaErrors++;
-            succeeded = true; // break retry loop — retrying won't help
-          } else if (attempt < MAX_RETRIES) {
-            consecutiveQuotaErrors = 0;
-            console.warn(`[stitch-client] ${attemptLabel} failed: ${msg.slice(0, 120)} — retrying in ${SCREEN_DELAY_MS / 1000}s`);
-            recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });
-            await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
-          } else {
-            console.error(`[stitch-client] ${attemptLabel} failed after ${MAX_RETRIES} attempts: ${msg.slice(0, 120)}`);
-            results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
-            recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });
-          }
+        // Use callTool('generate_screen_from_text') directly rather than project.generate().
+        // The SDK wrapper uses an SSE transport that the GFE drops after ~30-60s, losing the
+        // screen ID. The raw MCP tool call returns synchronously with the full screen object
+        // including its ID — no socket drop, no fire-and-forget.
+        const params = { projectId, prompt: promptText, modelId };
+        if (deviceType) params.deviceType = deviceType;
+        const result = await toolClient.callTool('generate_screen_from_text', params);
+        const screen = result?.outputComponents?.[0]?.design?.screens?.[0];
+        const screenId = screen?.id || screen?.screenId || screen?.screen_id;
+        if (!screenId) {
+          throw new Error(`generate_screen_from_text returned no screen ID (keys: ${Object.keys(screen || {}).join(', ')})`);
         }
-        try { await client.close(); } catch { /* ignore */ }
-      } catch (outerErr) {
-        if (attempt >= MAX_RETRIES) {
-          console.error(`[stitch-client] ${attemptLabel} unexpected after ${MAX_RETRIES} attempts: ${outerErr.message}`);
-          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: outerErr.message, deviceType, attempt });
-          recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'unexpected', errorMessage: outerErr.message?.slice(0, 500) });
+        console.info(`[stitch-client] ${attemptLabel} returned via callTool: ${screenId}`);
+        results.push({ prompt: promptText.slice(0, 60), status: 'returned', screen_id: screenId, name: screen?.name || promptText.substring(0, 30), deviceType, attempt });
+        succeeded = true;
+        recordMetric({ ventureId, screenName, deviceType, promptText, status: 'success', attemptCount: attempt, durationMs: Date.now() - attemptStart });
+      } catch (err) {
+        const msg = err.message || '';
+        if (/resource has been exhausted|check quota/i.test(msg)) {
+          console.error(`[stitch-client] ${attemptLabel} QUOTA EXHAUSTED: ${msg.slice(0, 120)}`);
+          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
+          recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'quota_exhausted', errorMessage: msg.slice(0, 500) });
+          consecutiveQuotaErrors++;
+          succeeded = true; // break retry loop — retrying won't help
+        } else if (attempt < MAX_RETRIES) {
+          consecutiveQuotaErrors = 0;
+          console.warn(`[stitch-client] ${attemptLabel} failed: ${msg.slice(0, 120)} — retrying in ${SCREEN_DELAY_MS / 1000}s`);
+          recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });
+          await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
+        } else {
+          console.error(`[stitch-client] ${attemptLabel} failed after ${MAX_RETRIES} attempts: ${msg.slice(0, 120)}`);
+          results.push({ prompt: promptText.slice(0, 60), status: 'error', error: msg, deviceType, attempt });
+          recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: attempt, durationMs: Date.now() - attemptStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });
         }
+      } finally {
+        try { await toolClient.close(); } catch { /* ignore */ }
       }
     }
 
@@ -644,7 +625,7 @@ export async function generateScreens(projectId, prompts, ventureId) {
       break;
     }
 
-    // Uniform delay between screens
+    // Brief delay between screens to avoid hammering the API
     if (i < prompts.length - 1) {
       console.info(`[stitch-client] Waiting ${SCREEN_DELAY_MS / 1000}s before next screen`);
       await new Promise(r => setTimeout(r, SCREEN_DELAY_MS));
@@ -798,9 +779,14 @@ export async function editScreen(screenId, editPrompt, projectId) {
  */
 export async function listScreens(projectId) {
   return instrumentedCall('listScreens', async () => {
-    const client = await getClient();
-    const project = client.project(projectId);
+    // Always use a fresh client — the shared singleton may have a tainted MCP transport
+    // from a prior generate() socket drop, causing "Already connected" errors.
+    const apiKey = getApiKey();
+    const sdk = await getSDK();
+    const freshClient = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 30_000 }));
+    const project = freshClient.project(projectId);
     const screens = await project.screens();
+    try { await freshClient.close?.(); } catch { /* ignore */ }
     if (!Array.isArray(screens)) {
       throw new StitchValidationError('listScreens: expected array of screens');
     }


### PR DESCRIPTION
## Summary

- **Root cause found**: `project.generate()` uses an SSE transport that Google's GFE drops after 30-60s, losing the screen ID every time (status='fired' with no ID)
- **Fix**: Replace `project.generate()` with direct `callTool('generate_screen_from_text')` via `StitchToolClient` — bypasses SSE entirely, returns synchronously with the full screen object including ID (~58s confirmed in live test)
- **`listScreens()` hardened**: Now always creates a fresh `StitchToolClient` instead of reusing a singleton that may have a tainted transport after prior socket drops
- **`listScreens()` bug confirmed**: Returns `{}` even after browser activation — permanently broken server-side. No longer needed since `callTool` returns IDs directly.

## Test plan

- [x] Live test: `callTool('generate_screen_from_text')` returned `screen_id=727de43323b34555be23dc9eb0998eca` in 58240ms without socket drop
- [x] Live test: `listScreens()` confirmed broken (`{}`) — not regressed by this change
- [x] Smoke tests passed (15/15)
- [ ] Run next venture pipeline end-to-end — expect all screens to have `status: 'returned'` with screen IDs instead of `status: 'fired'` with no IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>