### PR TITLE
fix(LEARN-005): surface translation fidelity gaps before LEAD-TO-PLAN gates run

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
@@ -129,7 +129,8 @@ export function createTranslationFidelityGate(supabase) {
           score,
           confidence: 1.0,
           issues: passed ? [] : [
-            `Translation fidelity score ${score}/100 below threshold ${passingScore} (${sdType})`,
+            ...(score < passingScore ? [`Translation fidelity score ${score}/100 below threshold ${passingScore} (${sdType})`] : []),
+            ...(criticalGaps.length > 0 ? [`Translation fidelity blocked by ${criticalGaps.length} critical gap(s) in architecture → SD translation`] : []),
             ...criticalGaps.map(g => `Critical gap: ${g.item}`)
           ],
           warnings: result.gaps

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -44,7 +44,7 @@ import { createDFEEscalationGate } from '../../gates/dfe-escalation-gate.js';
 
 // Helper modules
 import { transitionSdToPlan } from './state-transitions.js';
-import { displayPreHandoffWarnings } from './pre-handoff-warnings.js';
+import { displayPreHandoffWarnings, displayTranslationFidelityPreview } from './pre-handoff-warnings.js';
 import { createHandoffRetrospective } from './retrospective.js';
 
 // External verifier (will be lazy loaded)
@@ -68,8 +68,11 @@ export class LeadToPlanExecutor extends BaseExecutor {
     return 'LEAD-TO-PLAN';
   }
 
-  async setup(_sdId, _sd, _options) {
+  async setup(_sdId, sd, _options) {
     await this._loadVerifier();
+    // PAT-HF-LEADTOPLAN-b891d12d: Show translation fidelity gaps BEFORE gates run.
+    // Surfaces known gaps from prior failed runs so they can be fixed without a full retry cycle.
+    await displayTranslationFidelityPreview(sd, this.supabase);
     return null;
   }
 

--- a/scripts/modules/handoff/executors/lead-to-plan/pre-handoff-warnings.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/pre-handoff-warnings.js
@@ -42,6 +42,108 @@ function displayTypeRequirements(sd) {
 }
 
 /**
+ * PAT-HF-LEADTOPLAN-b891d12d: Surface translation fidelity gaps BEFORE gates run.
+ *
+ * When an SD has an architecture plan linked (arch_key), query the most recent
+ * eva_translation_gates result for this SD and show any gaps with remediation
+ * instructions. This turns a blocking gate failure into an actionable pre-check
+ * that teams can fix before the handoff is attempted.
+ *
+ * Called from LeadToPlanExecutor.setup() — runs before gate validation.
+ *
+ * @param {Object} sd - Strategic Directive
+ * @param {Object} supabase - Supabase client
+ */
+export async function displayTranslationFidelityPreview(sd, supabase) {
+  const archKey = sd?.metadata?.arch_key || sd?.metadata?.architecture_plan_key;
+  if (!archKey) return;
+
+  console.log('\n🔍 TRANSLATION FIDELITY PRE-CHECK (Architecture Plan → SD)');
+  console.log('='.repeat(70));
+  console.log(`   Arch Plan: ${archKey}`);
+
+  try {
+    const sdKey = sd?.sd_key || sd?.id;
+    const { data, error } = await supabase
+      .from('eva_translation_gates')
+      .select('coverage_score, gaps, passed, created_at')
+      .eq('gate_type', 'architecture_to_sd')
+      .filter('target_ref->>key', 'eq', sdKey)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (error) {
+      console.log(`   ⚠️  Could not query gate history: ${error.message}`);
+      _showTranslationChecklist();
+      console.log('');
+      return;
+    }
+
+    if (!data || data.length === 0) {
+      console.log('   ℹ️  No prior gate result found — checklist for first run:');
+      _showTranslationChecklist();
+      console.log('');
+      return;
+    }
+
+    const latest = data[0];
+    const age = Math.round((Date.now() - new Date(latest.created_at).getTime()) / 60000);
+
+    if (latest.passed) {
+      console.log(`   ✅ Last run PASSED (score: ${latest.coverage_score}/100, ${age}m ago)`);
+      console.log('');
+      return;
+    }
+
+    console.log(`   ❌ Last run FAILED (score: ${latest.coverage_score}/100, ${age}m ago)`);
+    console.log('   Fix these gaps in SD description / key_changes / success_criteria BEFORE retrying:\n');
+
+    const gaps = latest.gaps || [];
+    const critical = gaps.filter(g => g.severity === 'critical');
+    const major = gaps.filter(g => g.severity === 'major');
+    const minor = gaps.filter(g => g.severity === 'minor');
+
+    for (const gap of critical) {
+      console.log(`   ❌ [CRITICAL] ${gap.item}`);
+      console.log(`      Source: ${gap.source}`);
+    }
+    for (const gap of major) {
+      console.log(`   ⚠️  [MAJOR]    ${gap.item}`);
+      console.log(`      Source: ${gap.source}`);
+    }
+    for (const gap of minor) {
+      console.log(`   ℹ️  [MINOR]    ${gap.item}`);
+    }
+
+    if (critical.length > 0 || major.length > 0) {
+      console.log('\n   📋 Remediation: Update the SD fields to explicitly mention each gap above.');
+      console.log('      • description: add workflow constraints, tool restrictions, platform rules');
+      console.log('      • key_changes: list specific API endpoints, components, and constraints');
+      console.log('      • success_criteria: include vision-level success criteria');
+    }
+
+    console.log('');
+  } catch (err) {
+    console.log(`   ⚠️  Translation fidelity preview error: ${err.message}`);
+    _showTranslationChecklist();
+    console.log('');
+  }
+}
+
+/**
+ * General checklist for orchestrator SDs derived from architecture plans.
+ * Shown when no historical gate result is available.
+ */
+function _showTranslationChecklist() {
+  console.log('   📋 Orchestrator SD checklist (common translation gaps):');
+  console.log('      • description:    workflow sequencing constraints (e.g., mobile-first, desktop inherits)');
+  console.log('      • description:    tool/system restrictions (e.g., "generate X via Claude, not Stitch")');
+  console.log('      • key_changes:    all API endpoints (e.g., /qa, /upload) mentioned in arch plan');
+  console.log('      • key_changes:    platform-specific requirements (PWA, mobile touch targets)');
+  console.log('      • success_criteria: strategic success criteria from Vision Document');
+}
+
+/**
  * Display pre-handoff warnings from recent retrospectives
  *
  * @param {string} handoffType - Type of handoff


### PR DESCRIPTION
## Summary

- **pre-handoff-warnings.js**: Add `displayTranslationFidelityPreview()` that queries `eva_translation_gates` for prior failed runs and displays gaps (critical/major/minor) with field-level remediation hints before gates execute; shows an orchestrator checklist when no prior result exists
- **index.js**: Call `displayTranslationFidelityPreview()` in `setup()` so the preview runs before gate validation on every LEAD-TO-PLAN attempt
- **translation-fidelity.js**: Fix misleading "score below threshold" error message that appeared even when score was above the threshold (failure was due to critical gaps, not score); now correctly distinguishes the two failure modes

Addresses **PAT-HF-LEADTOPLAN-b891d12d** (7 occurrences): LEAD-TO-PLAN was failing with `TRANSLATION_FIDELITY` errors but engineers had no actionable guidance until after the blocking failure. This turns reactive gate blocking into proactive pre-flight guidance.

## Test plan
- [ ] Run `node scripts/handoff.js execute LEAD-TO-PLAN <SD-with-arch-key>` — pre-check section now appears before gate validation
- [ ] Verify pre-check shows prior failed gaps (critical/major/minor) when `eva_translation_gates` has a failed result for the SD
- [ ] Verify pre-check shows orchestrator checklist when no prior gate result exists
- [ ] Verify error message now correctly says "blocked by N critical gap(s)" (not "score below threshold") when score ≥ threshold but critical gaps exist
- [ ] Verify "score below threshold" message still appears correctly when score is actually below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>