### PR TITLE
fix(stitch): RCA fixes — RLS, filter relaxation, poll error recovery

### DIFF
--- a/database/migrations/20260416_stitch_metrics_authenticated_rls.sql
+++ b/database/migrations/20260416_stitch_metrics_authenticated_rls.sql
@@ -1,0 +1,7 @@
+-- Migration: Add authenticated SELECT policy to stitch_generation_metrics
+-- RCA: Frontend useStitchCuration hook queries this table via authenticated
+-- Supabase client, but RLS blocks it (no policy for authenticated role).
+-- Result: generation_metrics is always undefined, fallback shows wrong data.
+
+CREATE POLICY "authenticated_select" ON stitch_generation_metrics
+  FOR SELECT TO authenticated USING (true);

--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -628,11 +628,24 @@ export async function generateScreens(projectId, prompts, ventureId) {
     console.info(`[stitch-client] Phase 2: polling get_project for ${firedResults.length} fired screen(s)...`);
     const pollStart = Date.now();
     let lastKnownCount = baselineScreenIds.size;
+    let consecutivePollErrors = 0;
 
     while (Date.now() - pollStart < POLL_MAX_WAIT_MS) {
       await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
 
       const currentScreenIds = await _getProjectScreenIds(sdk, apiKey, projectId);
+      if (currentScreenIds.size === 0) {
+        consecutivePollErrors++;
+        if (consecutivePollErrors >= 3) {
+          console.warn(`[stitch-client] ${consecutivePollErrors} consecutive poll failures — SDK transport may be broken. Reloading SDK...`);
+          // Force SDK reload to get fresh transport state
+          _sdk = null;
+          try { const freshSdk = await getSDK(); } catch { /* ignore */ }
+          consecutivePollErrors = 0;
+        }
+      } else {
+        consecutivePollErrors = 0;
+      }
       const newScreenIds = [...currentScreenIds].filter(id => !baselineScreenIds.has(id));
 
       if (newScreenIds.length > lastKnownCount - baselineScreenIds.size) {
@@ -689,16 +702,26 @@ async function _getProjectScreenIds(sdk, apiKey, projectId) {
       name: `projects/${projectId}`
     });
     const instances = result?.screenInstances || [];
-    // Filter to real screens (have sourceScreen), exclude design system instances
-    const screenIds = new Set(
-      instances
-        .filter(s => s.sourceScreen && s.type !== 'DESIGN_SYSTEM_INSTANCE')
-        .map(s => s.id)
-        .filter(Boolean)
-    );
+    console.info(`[stitch-client] get_project raw: ${instances.length} screenInstances`);
+
+    // Filter to real screens — include anything with an id that isn't a design system instance.
+    // Previously required s.sourceScreen, but generated screens may not always have this property.
+    const filtered = instances.filter(s => s.id && s.type !== 'DESIGN_SYSTEM_INSTANCE');
+    const excluded = instances.length - filtered.length;
+    if (excluded > 0) {
+      const reasons = instances
+        .filter(s => !s.id || s.type === 'DESIGN_SYSTEM_INSTANCE')
+        .map(s => `${s.id || 'no-id'}(type=${s.type || 'none'},src=${s.sourceScreen ? 'yes' : 'no'})`)
+        .slice(0, 5);
+      console.info(`[stitch-client] get_project filtered out ${excluded}: ${reasons.join(', ')}`);
+    }
+
+    const screenIds = new Set(filtered.map(s => s.id));
+    console.info(`[stitch-client] get_project result: ${screenIds.size} screen(s) after filter`);
     return screenIds;
   } catch (err) {
-    console.warn(`[stitch-client] get_project failed: ${err.message}`);
+    const errType = /abort/i.test(err.message) ? 'AbortError' : /socket|fetch failed/i.test(err.message) ? 'TransportError' : 'Unknown';
+    console.warn(`[stitch-client] get_project failed (${errType}): ${err.message}`);
     return new Set();
   } finally {
     try { await toolClient.close(); } catch { /* ignore */ }

--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -640,7 +640,7 @@ export async function generateScreens(projectId, prompts, ventureId) {
           console.warn(`[stitch-client] ${consecutivePollErrors} consecutive poll failures — SDK transport may be broken. Reloading SDK...`);
           // Force SDK reload to get fresh transport state
           _sdk = null;
-          try { const freshSdk = await getSDK(); } catch { /* ignore */ }
+          try { await getSDK(); } catch { /* ignore */ }
           consecutivePollErrors = 0;
         }
       } else {

--- a/lib/eva/bridge/stitch-reconciler.js
+++ b/lib/eva/bridge/stitch-reconciler.js
@@ -91,12 +91,16 @@ export async function reconcileScreenIds(ventureId, options = {}) {
         name: `projects/${projectId}`
       });
       const instances = result?.screenInstances || [];
-      screenIds = instances
-        .filter(s => s.sourceScreen && s.type !== 'DESIGN_SYSTEM_INSTANCE')
-        .map(s => s.id)
-        .filter(Boolean);
+      console.info(`[stitch-reconciler] get_project raw: ${instances.length} screenInstances`);
+      // Match stitch-client.js filter: include anything with an id, exclude design system instances
+      const filtered = instances.filter(s => s.id && s.type !== 'DESIGN_SYSTEM_INSTANCE');
+      if (instances.length !== filtered.length) {
+        console.info(`[stitch-reconciler] Filtered out ${instances.length - filtered.length} non-screen instances`);
+      }
+      screenIds = filtered.map(s => s.id);
     } catch (err) {
-      console.warn(`[stitch-reconciler] get_project failed: ${err.message}`);
+      const errType = /abort/i.test(err.message) ? 'AbortError' : /socket|fetch failed/i.test(err.message) ? 'TransportError' : 'Unknown';
+      console.warn(`[stitch-reconciler] get_project failed (${errType}): ${err.message}`);
     } finally {
       try { await toolClient.close(); } catch { /* ignore */ }
     }


### PR DESCRIPTION
## Summary
RCA-driven fixes for 3 issues found during Ascent Prep venture run:

- **RLS policy**: Add authenticated SELECT on `stitch_generation_metrics` — frontend query was silently returning 0 rows
- **Filter relaxation**: `_getProjectScreenIds` no longer requires `sourceScreen` — generated screens may not have this property
- **Diagnostic logging**: Raw `screenInstances` count logged before/after filter in both `stitch-client.js` and `stitch-reconciler.js`
- **Poll error recovery**: After 3 consecutive `get_project` failures, resets SDK module to get fresh transport state

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Apply RLS migration via Supabase SQL Editor
- [ ] Restart servers, verify frontend metrics query returns real data
- [ ] Verify diagnostic logs appear in stage-worker log during S15

🤖 Generated with [Claude Code](https://claude.com/claude-code)