### PR TITLE
fix(stitch): correct reconciler import path — was never executing

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2303,7 +2303,7 @@ export class StageExecutionWorker {
     // The provisioner may have timed out (abort guard), but Stitch generates
     // screens server-side. The reconciler polls get_project to capture IDs.
     try {
-      const { reconcileScreenIds } = await import('../eva/bridge/stitch-reconciler.js');
+      const { reconcileScreenIds } = await import('./bridge/stitch-reconciler.js');
       const reconciled = await reconcileScreenIds(ventureId, { maxWaitMs: 300_000, pollIntervalMs: 30_000 });
       this._logger.info(`[Worker] S15 reconciliation: ${reconciled.confirmed}/${reconciled.total} screens confirmed`);
     } catch (reconcileErr) {


### PR DESCRIPTION
## Summary
The post-S15 reconciler (`stitch-reconciler.js`) never ran because the import path was `'../eva/bridge/stitch-reconciler.js'` (resolves to `lib/bridge/` which doesn't exist). Fixed to `'./bridge/stitch-reconciler.js'` (resolves to `lib/eva/bridge/`). The catch block at line 2309 silently swallowed the MODULE_NOT_FOUND error.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Next venture run: verify reconciler runs and confirms screen IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)