### PR TITLE
fix(stitch): reconciler metric name matching — was never updating fired→confirmed

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -764,9 +764,9 @@ function _assignScreenIdsToFiredResults(results, newScreenIds, ventureId) {
  * @private
  */
 async function _fireOneScreen({ rawPrompt, globalIdx, totalPrompts, sdk, apiKey, projectId, modelId, ventureId }) {
-  const promptText = typeof rawPrompt === 'string' ? rawPrompt : rawPrompt.text;
+  const promptText = typeof rawPrompt === 'string' ? rawPrompt : (rawPrompt.text || rawPrompt.prompt);
   const deviceType = typeof rawPrompt === 'object' ? rawPrompt.deviceType : undefined;
-  const screenName = typeof rawPrompt === 'object' ? (rawPrompt.name || promptText.substring(0, 30)) : promptText.substring(0, 30);
+  const screenName = typeof rawPrompt === 'object' ? (rawPrompt.screen_name || rawPrompt.name || rawPrompt._screenName || promptText.substring(0, 30)) : promptText.substring(0, 30);
   const label = `[${globalIdx + 1}/${totalPrompts}]`;
 
   const fireStart = Date.now();

--- a/lib/eva/bridge/stitch-reconciler.js
+++ b/lib/eva/bridge/stitch-reconciler.js
@@ -148,26 +148,31 @@ export async function reconcileScreenIds(ventureId, options = {}) {
     console.info(`[stitch-reconciler] Updated artifact: ${screenIds.length}/${expectedCount} confirmed`);
   }
 
-  // Also update stitch_generation_metrics for fired screens that are now confirmed
+  // Update stitch_generation_metrics: change 'fired' → 'confirmed' for reconciled screens.
+  // Metrics store the full prompt text truncated to 30 chars (e.g. "Design a Landing Page for Aeth")
+  // while prompts store the short screen name (e.g. "Landing Page"). Use ilike contains match.
   for (let i = 0; i < screenIds.length; i++) {
     const prompt = prompts[i];
     if (!prompt) continue;
     const screenName = prompt.screen_name || prompt.name || 'unknown';
-    // Check if there's a 'fired' metric for this screen that needs confirming
-    const { data: metric } = await supabase
+    const deviceType = prompt.deviceType || null;
+
+    // Build query: match by screen_name contains + device_type + status=fired
+    let query = supabase
       .from('stitch_generation_metrics')
       .select('id, status')
       .eq('venture_id', ventureId)
-      .eq('screen_name', screenName.slice(0, 30))
-      .eq('status', 'fired')
-      .limit(1)
-      .maybeSingle();
+      .ilike('screen_name', `%${screenName}%`)
+      .eq('status', 'fired');
+    if (deviceType) query = query.eq('device_type', deviceType);
+    const { data: metric } = await query.limit(1).maybeSingle();
 
     if (metric) {
       await supabase
         .from('stitch_generation_metrics')
         .update({ status: 'confirmed' })
         .eq('id', metric.id);
+      console.info(`[stitch-reconciler] Metric confirmed: ${screenName} [${deviceType || '?'}]`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Reconciler metric update used `.eq('screen_name', ...)` but metrics store truncated prompt text while reconciler has short screen names. Changed to `.ilike('%name%')` + device_type match.
- `_fireOneScreen` now reads `rawPrompt.screen_name` so future metrics store clean names.
- Verified: 4 metrics updated from fired→confirmed matching the 5 screens in Stitch.

## Test plan
- [x] Reconciler confirmed 4 metrics (verified via DB query)
- [ ] Screen Generation Progress shows 5/14 matching Design Curation's 5/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)