### PR TITLE
fix(stitch): sequential firing + timeout tuning + capability detection

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -72,6 +72,7 @@ async function recordMetric({ ventureId, screenName, deviceType, promptText, sta
 let _sdk = null;
 let _sdkLoader = null;
 let _cachedTools = null; // SD-WIREFRAME-FIDELITY-QA-WITH-ORCH-001-D: listTools() cache
+let _supportsTasks = false; // MCP Tasks API support (2025-11-25 spec) — auto-detected at connect
 
 /**
  * Set a custom SDK loader (for testing or tool-swapping).
@@ -117,6 +118,23 @@ export async function discoverTools() {
     const toolNames = tools.map(t => t.name || t).filter(Boolean);
     _cachedTools = toolNames;
     console.info(`[stitch-client] Available Stitch tools (${toolNames.length}): ${toolNames.join(', ')}`);
+
+    // MCP Tasks API capability detection (spec 2025-11-25).
+    // Inspect the SDK's underlying MCP client for server-advertised capabilities.
+    // When Stitch advertises tasks support, we can switch to async task-based
+    // execution which completely sidesteps the 60s GFE TCP timeout.
+    try {
+      const mcpClient = client.client || client._client;
+      const serverCaps = mcpClient?.getServerCapabilities?.() || mcpClient?.serverCapabilities;
+      const tasksSupport = !!serverCaps?.tasks?.requests?.tools?.call;
+      const toolTaskSupport = tools.some(t => t?.execution?.taskSupport);
+      _supportsTasks = tasksSupport || toolTaskSupport;
+      console.info(`[stitch-client] MCP Tasks capability: ${_supportsTasks ? 'SUPPORTED — ready to upgrade to async execution' : 'not_supported (still on synchronous fire-and-poll)'}`);
+    } catch (capErr) {
+      console.info(`[stitch-client] Capability inspection unavailable: ${capErr.message} (non-fatal)`);
+      _supportsTasks = false;
+    }
+
     try { await client.close(); } catch { /* ignore */ }
     return toolNames;
   } catch (err) {
@@ -124,6 +142,15 @@ export async function discoverTools() {
     _cachedTools = [];
     return [];
   }
+}
+
+/**
+ * Returns whether the Stitch MCP server supports task-based tool execution.
+ * Must be called after discoverTools(). Returns false if not yet detected.
+ * @returns {boolean}
+ */
+export function supportsTaskExecution() {
+  return _supportsTasks;
 }
 
 // ---------------------------------------------------------------------------
@@ -555,7 +582,15 @@ export async function generateScreens(projectId, prompts, ventureId) {
   // get_project to discover screen IDs after generation completes server-side.
   // listScreens() is permanently broken (returns {} — confirmed Stitch bug), but
   // get_project returns screenInstances[] with all screen IDs.
-  const BATCH_SIZE = parseInt(process.env.STITCH_BATCH_SIZE || '3', 10);
+  // 2026-04-16: Default 1 (sequential). SDK Issue #114 documents that concurrent
+  // StitchToolClient calls cause socket-level failures beyond the 60s GFE timeout.
+  // Sequential firing is slower wall-clock (~14min for 14 screens) but expected to
+  // lift capture rate from 35% to ~70%. Override via STITCH_BATCH_SIZE=3 to restore.
+  //
+  // Future: when @google/stitch-sdk forwards resetTimeoutOnProgress to callTool
+  // options, we can re-enable parallel batching with SSE progress events keeping
+  // connections alive past 60s. Today the SDK only accepts {timeout}.
+  const BATCH_SIZE = parseInt(process.env.STITCH_BATCH_SIZE || '1', 10);
   const BATCH_DELAY_MS = parseInt(process.env.STITCH_BATCH_DELAY_MS || '5000', 10);
   const POLL_INTERVAL_MS = parseInt(process.env.STITCH_POLL_INTERVAL_MS || '30000', 10);
   const POLL_MAX_WAIT_MS = parseInt(process.env.STITCH_POLL_MAX_WAIT_MS || '600000', 10); // 10 min
@@ -770,7 +805,10 @@ async function _fireOneScreen({ rawPrompt, globalIdx, totalPrompts, sdk, apiKey,
   const label = `[${globalIdx + 1}/${totalPrompts}]`;
 
   const fireStart = Date.now();
-  const toolClient = new sdk.StitchToolClient({ apiKey, timeout: 180_000 });
+  // 300_000ms matches @google/stitch-sdk's StitchConfigSchema default.
+  // Note: GFE still kills TCP at ~60s regardless — this just prevents our
+  // client-side MCP protocol from adding its own shorter timeout on top.
+  const toolClient = new sdk.StitchToolClient({ apiKey, timeout: 300_000 });
   try {
     const params = { projectId, prompt: promptText, modelId };
     if (deviceType) params.deviceType = deviceType;
@@ -822,7 +860,7 @@ export async function buildSite(projectId) {
   try {
     const apiKey = getApiKey();
     const sdk = await getSDK();
-    const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 60_000 }));
+    const client = new sdk.Stitch(new sdk.StitchToolClient({ apiKey, timeout: 120_000 }));
     const project = client.project(projectId);
     const result = await project.buildSite();
     try { await client.close(); } catch { /* ignore */ }

--- a/lib/eva/bridge/stitch-reconciler.js
+++ b/lib/eva/bridge/stitch-reconciler.js
@@ -97,6 +97,15 @@ export async function reconcileScreenIds(ventureId, options = {}) {
       if (instances.length !== filtered.length) {
         console.info(`[stitch-reconciler] Filtered out ${instances.length - filtered.length} non-screen instances`);
       }
+
+      // Multi-signal completion detection: log rich completion signals so operators
+      // can see which screens have thumbnails, source screens, etc.
+      const withThumbnails = filtered.filter(s => s.thumbnailScreenshot?.downloadUrl || s.thumbnail?.downloadUrl);
+      const withSourceScreen = filtered.filter(s => s.sourceScreen);
+      if (filtered.length > 0) {
+        console.info(`[stitch-reconciler] Signals: ${filtered.length} ids | ${withThumbnails.length} thumbnails | ${withSourceScreen.length} sourceScreen`);
+      }
+
       screenIds = filtered.map(s => s.id);
     } catch (err) {
       const errType = /abort/i.test(err.message) ? 'AbortError' : /socket|fetch failed/i.test(err.message) ? 'TransportError' : 'Unknown';

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2275,7 +2275,7 @@ export class StageExecutionWorker {
     const screenCount = s15Work?.advisory_data?.screens?.length || 7;
     const platformMultiplier = 2;
     const totalScreens = screenCount * platformMultiplier;
-    const batchSize = parseInt(process.env.STITCH_BATCH_SIZE || '3', 10);
+    const batchSize = parseInt(process.env.STITCH_BATCH_SIZE || '1', 10);
     const batchCount = Math.ceil(totalScreens / batchSize);
     const perBatchMs = 65_000 + 5_000; // ~60s GFE timeout + 5s inter-batch delay
     const pollPhaseMs = 300_000; // 5 min poll budget for get_project reconciliation


### PR DESCRIPTION
## Summary
Research-driven reliability tuning to lift Stitch screen ID capture from ~35% toward 70%+.

- **Sequential firing**: `STITCH_BATCH_SIZE` default `3` → `1`. Addresses @google/stitch-sdk Issue #114 (concurrent socket closures).
- **Consistent timeouts**: `_fireOneScreen` 180s→300s, `buildSite` 60s→120s
- **Capability detection**: auto-detects MCP Tasks API support at connect time, logs readiness
- **Multi-signal telemetry**: reconciler now logs thumbnail + sourceScreen counts

Trade-off: sequential firing is slower wall-clock (~14min for 14 screens vs ~5min) but expected to double capture rate. Override via `STITCH_BATCH_SIZE=3` env var.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Modules compile cleanly
- [ ] Next venture run: achieve ≥70% screens in success or confirmed status

🤖 Generated with [Claude Code](https://claude.com/claude-code)