### PR TITLE
fix(stitch): reconciler recovers 'error' status when screen exists in get_project

### DIFF
--- a/lib/eva/bridge/stitch-reconciler.js
+++ b/lib/eva/bridge/stitch-reconciler.js
@@ -157,7 +157,15 @@ export async function reconcileScreenIds(ventureId, options = {}) {
     console.info(`[stitch-reconciler] Updated artifact: ${screenIds.length}/${expectedCount} confirmed`);
   }
 
-  // Update stitch_generation_metrics: change 'fired' → 'confirmed' for reconciled screens.
+  // Update stitch_generation_metrics: change 'fired' OR 'error' → 'confirmed' for
+  // reconciled screens. Recovery semantics:
+  // - 'fired' → 'confirmed': normal happy path (GFE timeout, screen completed server-side)
+  // - 'error' → 'confirmed': RECOVERY path (e.g., a 502/503 occurred but Stitch still
+  //   generated the screen — proven by it appearing in get_project). Common scenarios:
+  //     • 502 server errors that pre-PR-#3100 were classified as 'sdk_error'
+  //     • Future unknown error categories where the screen actually generated
+  //   We trust get_project as the source of truth: if the screen exists, it's confirmed.
+  //
   // Metrics store the full prompt text truncated to 30 chars (e.g. "Design a Landing Page for Aeth")
   // while prompts store the short screen name (e.g. "Landing Page"). Use ilike contains match.
   for (let i = 0; i < screenIds.length; i++) {
@@ -166,22 +174,29 @@ export async function reconcileScreenIds(ventureId, options = {}) {
     const screenName = prompt.screen_name || prompt.name || 'unknown';
     const deviceType = prompt.deviceType || null;
 
-    // Build query: match by screen_name contains + device_type + status=fired
+    // Build query: match by screen_name contains + device_type + status IN (fired, error)
     let query = supabase
       .from('stitch_generation_metrics')
-      .select('id, status')
+      .select('id, status, error_category')
       .eq('venture_id', ventureId)
       .ilike('screen_name', `%${screenName}%`)
-      .eq('status', 'fired');
+      .in('status', ['fired', 'error']);
     if (deviceType) query = query.eq('device_type', deviceType);
     const { data: metric } = await query.limit(1).maybeSingle();
 
     if (metric) {
+      // Preserve diagnostic info: if recovering from an 'error', tag the original
+      // error_category so we can audit which errors were actually transient.
+      const updates = { status: 'confirmed' };
+      if (metric.status === 'error' && metric.error_category) {
+        updates.error_category = `${metric.error_category}_recovered`;
+      }
       await supabase
         .from('stitch_generation_metrics')
-        .update({ status: 'confirmed' })
+        .update(updates)
         .eq('id', metric.id);
-      console.info(`[stitch-reconciler] Metric confirmed: ${screenName} [${deviceType || '?'}]`);
+      const recoveryNote = metric.status === 'error' ? ` (recovered from ${metric.error_category || 'error'})` : '';
+      console.info(`[stitch-reconciler] Metric confirmed: ${screenName} [${deviceType || '?'}]${recoveryNote}`);
     }
   }
 


### PR DESCRIPTION
## Summary
Sustainable fix for the LegacyGuard AI Pricing MOBILE issue (and class of similar issues). Reconciler now recovers metrics with status='error' when the screen actually exists in get_project, not just status='fired'.

## Why this isn't a band-aid
PR #3100 prevents FUTURE 502s from being classified as 'error'. This PR provides defense-in-depth by recovering ANY error record (regardless of error_category) when the screen is proven to exist server-side via get_project. Catches:
- Pre-PR-#3100 stuck records
- Future unknown error categories where Stitch generated despite the error

## Audit trail preserved
Recovered error_category gets '_recovered' suffix (e.g. 'sdk_error_recovered'). Future query reveals true 502 transience rate:
\`\`\`sql
SELECT error_category, COUNT(*) FROM stitch_generation_metrics
WHERE error_category LIKE '%_recovered' GROUP BY 1
\`\`\`

## Test plan
- [x] Smoke tests pass
- [ ] Next venture run with intentional 502: reconciler recovers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)