### PR TITLE
feat(SD-LEO-WIRING-VERIFICATION-FRAMEWORK-ORCH-001-C): vision traceability checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ handoff-result.txt
 *.log
 verification-packages/
 .worktrees/
+.cache/
 
 # Backup files (git already provides versioning)
 *.backup

--- a/scripts/wiring-validators/vision-traceability-checker.js
+++ b/scripts/wiring-validators/vision-traceability-checker.js
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+/**
+ * Vision Traceability Checker — Verifier #3 of 5 in the LEO Wiring Verification Framework.
+ *
+ * For an SD with an associated vision_key, extracts the structured UX-element list
+ * from the vision document (via LLM, cached per version), then greps the codebase
+ * for each element. Emits a leo_wiring_validations-shaped JSON to stdout.
+ *
+ * Vision: VISION-LEO-WIRING-VERIFICATION-L2-001
+ * Arch:   ARCH-LEO-WIRING-VERIFICATION-001 (Phase 3)
+ * SD:     SD-LEO-WIRING-VERIFICATION-FRAMEWORK-ORCH-001-C
+ *
+ * Usage:
+ *   node scripts/wiring-validators/vision-traceability-checker.js <SD-KEY> \
+ *     [--vision-key <key>] [--root <path>] [--no-persist]
+ *
+ * Output: JSON array on stdout (matches sibling A shape).
+ *   [{ sd_key, check_type: 'vision_traceability', status, signals_detected, evidence }]
+ *
+ * Exit codes:
+ *   0 — pass or skip
+ *   1 — fail (at least one UX element unfound)
+ *   2 — invalid args / unrecoverable setup error
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, extname, join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT_DEFAULT = resolve(__filename, '..', '..', '..');
+
+const SOURCE_FILE_EXTENSIONS = new Set(['.js', '.ts', '.tsx', '.jsx', '.mjs']);
+const DEFAULT_SEARCH_ROOTS = ['ehg/src', 'scripts', 'lib', 'server', 'src'];
+const SKIP_DIR_RE = /[/\\](node_modules|\.git|\.worktrees|dist|build|coverage)([/\\]|$)/;
+const TEST_FILE_RE = /[/\\](__tests__|tests?|\.test\.|\.spec\.)/i;
+
+const CHECK_TYPE = 'vision_traceability';
+const SAFE_REF_RE = /^[\w./-]+$/;
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = { sdKey: null, root: REPO_ROOT_DEFAULT, visionKey: null, persist: true };
+  let i = 0;
+  while (i < args.length) {
+    const a = args[i];
+    if (a === '--root') opts.root = resolve(args[++i]);
+    else if (a === '--vision-key') {
+      const raw = args[++i];
+      if (raw != null && !SAFE_REF_RE.test(raw)) {
+        process.stderr.write(`[vision-traceability-checker] invalid vision-key rejected: ${raw}\n`);
+        process.exit(2);
+      }
+      opts.visionKey = raw;
+    } else if (a === '--no-persist') opts.persist = false;
+    else if (!a.startsWith('--') && !opts.sdKey) opts.sdKey = a;
+    i++;
+  }
+  if (!opts.sdKey) {
+    process.stderr.write('Usage: vision-traceability-checker.js <SD-KEY> [--vision-key <key>] [--root <path>] [--no-persist]\n');
+    process.exit(2);
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Supabase (lazy, optional)
+// ---------------------------------------------------------------------------
+async function loadSupabase() {
+  try {
+    const { createClient } = await import('@supabase/supabase-js');
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return null;
+    return createClient(url, key);
+  } catch (err) {
+    process.stderr.write(`[vision-traceability-checker] supabase import failed: ${err.message}\n`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vision resolution
+// ---------------------------------------------------------------------------
+async function resolveVisionKey(supabase, sdKey, cliVisionKey) {
+  if (cliVisionKey) return cliVisionKey;
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('metadata')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  return data?.metadata?.vision_key || null;
+}
+
+async function loadVisionDocument(supabase, visionKey) {
+  if (!supabase || !visionKey) return null;
+  const { data } = await supabase
+    .from('eva_vision_documents')
+    .select('id, vision_key, version, content, sections, addendums')
+    .eq('vision_key', visionKey)
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data || null;
+}
+
+// ---------------------------------------------------------------------------
+// Matrix extraction (LLM + file cache)
+// ---------------------------------------------------------------------------
+function cachePath(repoRoot, visionKey, version) {
+  return join(repoRoot, '.cache', 'vision-matrices', `${visionKey}-v${version}.json`);
+}
+
+function readCache(repoRoot, visionKey, version) {
+  const p = cachePath(repoRoot, visionKey, version);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8'));
+    if (parsed.vision_key !== visionKey || parsed.version !== version) return null;
+    if (!Array.isArray(parsed.ux_elements)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(repoRoot, visionKey, version, matrix) {
+  const p = cachePath(repoRoot, visionKey, version);
+  mkdirSync(resolve(p, '..'), { recursive: true });
+  writeFileSync(p, JSON.stringify({ vision_key: visionKey, version, ux_elements: matrix, extracted_at: new Date().toISOString() }, null, 2));
+}
+
+function buildExtractionPrompt(vision) {
+  const systemPrompt = [
+    'You are extracting a structured UX-element list from a Vision document.',
+    'Output MUST be valid JSON and ONLY JSON (no prose, no code fences).',
+    'Schema:',
+    '{ "ux_elements": [{ "name": string, "type": "component"|"function"|"page"|"workflow", "grep_patterns": [string, ...], "source_quote": string }] }',
+    'Rules:',
+    '- Each ux_element represents a concrete user-observable capability promised by the vision (not an abstract principle).',
+    '- grep_patterns should be regex-escaped literal strings or simple identifier patterns that would plausibly appear in code (component names, function names, CSS classes, route paths).',
+    '- Provide 1-3 grep_patterns per element, ordered from most-specific to least-specific.',
+    '- source_quote must be a verbatim sentence (<= 200 chars) from the vision prose.',
+    '- Skip infrastructure/governance concepts that have no user-observable surface.',
+    '- Limit output to 20 elements max.',
+  ].join('\n');
+
+  const sections = vision.sections && typeof vision.sections === 'object'
+    ? Object.entries(vision.sections).map(([k, v]) => `### ${k}\n${v}`).join('\n\n')
+    : '';
+  const addendums = Array.isArray(vision.addendums) && vision.addendums.length > 0
+    ? vision.addendums.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join('\n---\n')
+    : '';
+
+  const userPrompt = [
+    `Vision key: ${vision.vision_key} (version ${vision.version})`,
+    '',
+    '## Vision Content',
+    vision.content || '',
+    sections ? '\n## Sections\n' + sections : '',
+    addendums ? '\n## Addendums\n' + addendums : '',
+    '',
+    'Return the JSON object described in the system prompt.',
+  ].join('\n');
+
+  return { systemPrompt, userPrompt };
+}
+
+function parseLlmMatrix(raw) {
+  if (typeof raw !== 'string') throw new Error('LLM returned non-string response');
+  let text = raw.trim();
+  // Strip fenced code blocks if the model ignored our instruction
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  const parsed = JSON.parse(text);
+  if (!parsed || !Array.isArray(parsed.ux_elements)) {
+    throw new Error('missing ux_elements array');
+  }
+  for (const el of parsed.ux_elements) {
+    if (!el || typeof el.name !== 'string' || !Array.isArray(el.grep_patterns)) {
+      throw new Error('malformed ux_element entry');
+    }
+  }
+  return parsed.ux_elements;
+}
+
+async function extractMatrix({ vision, repoRoot, llmClientOverride, fixtureMatrix }) {
+  if (fixtureMatrix) {
+    return { ux_elements: fixtureMatrix, source: 'fixture', llm_called: false };
+  }
+  const cached = readCache(repoRoot, vision.vision_key, vision.version);
+  if (cached) {
+    return { ux_elements: cached.ux_elements, source: 'cache', llm_called: false };
+  }
+  let client = llmClientOverride;
+  if (!client) {
+    const mod = await import('../../lib/llm/client-factory.js');
+    client = mod.getValidationClient();
+  }
+  const { systemPrompt, userPrompt } = buildExtractionPrompt(vision);
+  const result = await client.complete(systemPrompt, userPrompt, { maxTokens: 4000, timeout: 180000 });
+  const elements = parseLlmMatrix(result.content);
+  writeCache(repoRoot, vision.vision_key, vision.version, elements);
+  return { ux_elements: elements, source: 'llm', llm_called: true };
+}
+
+// ---------------------------------------------------------------------------
+// Codebase grep
+// ---------------------------------------------------------------------------
+function walkSourceFiles(repoRoot, roots) {
+  const files = [];
+  const stack = roots.map((r) => resolve(repoRoot, r)).filter((p) => existsSync(p));
+  while (stack.length) {
+    const cur = stack.pop();
+    let st;
+    try { st = statSync(cur); } catch { continue; }
+    // Test skip patterns against the path relative to repoRoot so we don't
+    // falsely skip when the repo itself lives inside .worktrees/ during fleet runs.
+    const rel = cur.startsWith(repoRoot) ? cur.slice(repoRoot.length) : cur;
+    if (st.isDirectory()) {
+      if (SKIP_DIR_RE.test(rel)) continue;
+      for (const entry of readdirSync(cur)) stack.push(join(cur, entry));
+    } else if (st.isFile() && SOURCE_FILE_EXTENSIONS.has(extname(cur))) {
+      files.push(cur);
+    }
+  }
+  return files;
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildPatternRegex(pattern) {
+  // Treat grep_patterns as literal unless they look like intentional regex (contain \b or \\).
+  // Keep it simple: always escape, relying on substring semantics. Callers wanting regex
+  // can still produce literal tokens that match.
+  return new RegExp(escapeRegex(pattern));
+}
+
+function classifyElement(element, sourceFiles, repoRoot) {
+  const patterns = (element.grep_patterns || []).filter((p) => typeof p === 'string' && p.length >= 3);
+  const regexes = patterns.map(buildPatternRegex);
+  let matchCount = 0;
+  const sampleFiles = [];
+  for (const f of sourceFiles) {
+    if (TEST_FILE_RE.test(f)) continue;
+    let src;
+    try { src = readFileSync(f, 'utf8'); } catch { continue; }
+    const hit = regexes.some((re) => re.test(src));
+    if (hit) {
+      matchCount += 1;
+      if (sampleFiles.length < 3) {
+        const rel = f.startsWith(repoRoot) ? f.slice(repoRoot.length + 1).replace(/\\/g, '/') : f;
+        sampleFiles.push(rel);
+      }
+    }
+  }
+  return {
+    name: element.name,
+    type: element.type || 'unknown',
+    found: matchCount > 0,
+    match_count: matchCount,
+    sample_files: sampleFiles,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+export async function runChecker({ sdKey, supabase, root, visionKey, fixtureMatrix, visionOverride, llmClientOverride } = {}) {
+  if (!sdKey) throw new Error('runChecker: sdKey required');
+  const repoRoot = root || REPO_ROOT_DEFAULT;
+
+  let vision = visionOverride || null;
+  if (!vision) {
+    const resolvedKey = visionKey || (await resolveVisionKey(supabase, sdKey, null));
+    if (!resolvedKey) {
+      process.stderr.write(`[vision-traceability-checker] ${sdKey}: no vision_key — skipping\n`);
+      return [{
+        sd_key: sdKey,
+        check_type: CHECK_TYPE,
+        status: 'skip',
+        signals_detected: [],
+        evidence: { reason: 'no_vision_key' },
+      }];
+    }
+    vision = await loadVisionDocument(supabase, resolvedKey);
+    if (!vision) {
+      process.stderr.write(`[vision-traceability-checker] ${sdKey}: vision document ${resolvedKey} not found — skipping\n`);
+      return [{
+        sd_key: sdKey,
+        check_type: CHECK_TYPE,
+        status: 'skip',
+        signals_detected: [],
+        evidence: { reason: 'vision_document_not_found', vision_key: resolvedKey },
+      }];
+    }
+  }
+
+  let matrix;
+  try {
+    matrix = await extractMatrix({ vision, repoRoot, llmClientOverride, fixtureMatrix });
+  } catch (err) {
+    process.stderr.write(`[vision-traceability-checker] matrix extraction failed: ${err.message}\n`);
+    return [{
+      sd_key: sdKey,
+      check_type: CHECK_TYPE,
+      status: 'fail',
+      signals_detected: [],
+      evidence: { llm_error: err.message, vision_key: vision.vision_key, vision_version: vision.version },
+    }];
+  }
+
+  const sourceFiles = walkSourceFiles(repoRoot, DEFAULT_SEARCH_ROOTS);
+  const signals = matrix.ux_elements.map((el) => classifyElement(el, sourceFiles, repoRoot));
+  const anyUnfound = signals.some((s) => !s.found);
+
+  return [{
+    sd_key: sdKey,
+    check_type: CHECK_TYPE,
+    status: anyUnfound ? 'fail' : 'pass',
+    signals_detected: signals,
+    evidence: {
+      source: matrix.source,
+      llm_called: matrix.llm_called,
+      vision_key: vision.vision_key,
+      vision_version: vision.version,
+      elements_total: signals.length,
+      elements_missing: signals.filter((s) => !s.found).length,
+    },
+  }];
+}
+
+/**
+ * Persist a single result row to leo_wiring_validations. No-ops gracefully when:
+ *   - supabase client is null/undefined
+ *   - the table does not yet exist (Child D creates it)
+ *
+ * Mirrors scripts/wiring-validators/orphan-detector.js persistResults.
+ */
+export async function persistResults(supabase, result) {
+  if (!supabase) {
+    process.stderr.write('[vision-traceability-checker] persistResults: no supabase client, skipping\n');
+    return { skipped: true, reason: 'no_client' };
+  }
+  const { error } = await supabase
+    .from('leo_wiring_validations')
+    .upsert({ ...result, updated_at: new Date().toISOString() }, { onConflict: 'sd_key,check_type' });
+  if (error) {
+    const msg = error.message || '';
+    if (error.code === 'PGRST205' || /Could not find the table/i.test(msg)) {
+      process.stderr.write('[vision-traceability-checker] persistResults: table leo_wiring_validations absent, skipping\n');
+      return { skipped: true, reason: 'table_absent' };
+    }
+    return { skipped: false, error: msg };
+  }
+  return { skipped: false, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+async function main() {
+  const opts = parseArgs(process.argv);
+  const supabase = await loadSupabase();
+  const results = await runChecker({ sdKey: opts.sdKey, supabase, root: opts.root, visionKey: opts.visionKey });
+  if (opts.persist && supabase) {
+    for (const row of results) await persistResults(supabase, row);
+  }
+  process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+  const anyFail = results.some((r) => r.status === 'fail');
+  process.exit(anyFail ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('vision-traceability-checker.js')) {
+  main().catch((err) => {
+    process.stderr.write(`[vision-traceability-checker] fatal: ${err.message}\n`);
+    process.exit(2);
+  });
+}

--- a/tests/unit/wiring-validators/vision-traceability.test.js
+++ b/tests/unit/wiring-validators/vision-traceability.test.js
@@ -1,0 +1,191 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { runChecker, persistResults } from '../../../scripts/wiring-validators/vision-traceability-checker.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const WORKTREE_ROOT = resolve(__filename, '..', '..', '..', '..');
+
+function makeTempRoot() {
+  const dir = join(tmpdir(), `vtc-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  return dir;
+}
+
+// -----------------------------------------------------------------------------
+// US-005 — Persistence no-ops
+// -----------------------------------------------------------------------------
+test('persistResults: no-ops when supabase is null', async () => {
+  const r = await persistResults(null, {
+    sd_key: 'SD-TEST', check_type: 'vision_traceability', status: 'pass',
+    signals_detected: [], evidence: {},
+  });
+  assert.equal(r.skipped, true);
+  assert.equal(r.reason, 'no_client');
+});
+
+test('persistResults: no-ops when leo_wiring_validations table absent', async () => {
+  // Fake supabase that emulates the PostgREST "table missing" error
+  const fakeSupabase = {
+    from: () => ({
+      upsert: async () => ({ error: { code: 'PGRST205', message: "Could not find the table 'public.leo_wiring_validations'" } }),
+    }),
+  };
+  const r = await persistResults(fakeSupabase, {
+    sd_key: 'SD-TEST', check_type: 'vision_traceability', status: 'pass',
+    signals_detected: [], evidence: {},
+  });
+  assert.equal(r.skipped, true);
+  assert.equal(r.reason, 'table_absent');
+});
+
+// -----------------------------------------------------------------------------
+// US-001 — Output shape
+// -----------------------------------------------------------------------------
+test('runChecker: output shape matches leo_wiring_validations row schema', async () => {
+  const fixture = [{ name: 'Orphan Detector', type: 'function', grep_patterns: ['runDetector'], source_quote: 'runs detector' }];
+  const visionOverride = { vision_key: 'VISION-UNIT-TEST', version: 1, content: '', sections: null, addendums: [] };
+  const results = await runChecker({
+    sdKey: 'SD-TEST', supabase: null, root: WORKTREE_ROOT, visionOverride, fixtureMatrix: fixture,
+  });
+  assert.equal(Array.isArray(results), true);
+  assert.equal(results.length, 1);
+  const row = results[0];
+  assert.equal(row.sd_key, 'SD-TEST');
+  assert.equal(row.check_type, 'vision_traceability');
+  assert.ok(['pass', 'fail', 'skip'].includes(row.status));
+  assert.ok(Array.isArray(row.signals_detected));
+  assert.equal(typeof row.evidence, 'object');
+});
+
+// -----------------------------------------------------------------------------
+// US-004 — Grep classification: happy path (pattern exists in repo)
+// -----------------------------------------------------------------------------
+test('runChecker: found=true when grep pattern hits a non-test source file', async () => {
+  const fixture = [{ name: 'runDetector', type: 'function', grep_patterns: ['runDetector'], source_quote: 'exists in sibling A' }];
+  const visionOverride = { vision_key: 'VISION-UNIT-TEST', version: 1, content: '', sections: null, addendums: [] };
+  const results = await runChecker({
+    sdKey: 'SD-TEST', supabase: null, root: WORKTREE_ROOT, visionOverride, fixtureMatrix: fixture,
+  });
+  const sig = results[0].signals_detected[0];
+  assert.equal(sig.found, true);
+  assert.ok(sig.match_count >= 1);
+  assert.ok(sig.sample_files.length >= 1);
+  // None of the sample files should be test files
+  for (const f of sig.sample_files) {
+    assert.ok(!/\.(test|spec)\./.test(f), `sample_file must not be a test file: ${f}`);
+  }
+  assert.equal(results[0].status, 'pass');
+});
+
+// -----------------------------------------------------------------------------
+// US-004 — Grep classification: fail path
+// -----------------------------------------------------------------------------
+test('runChecker: found=false when grep pattern is absent; overall status=fail', async () => {
+  const fixture = [
+    { name: 'Missing Widget', type: 'component', grep_patterns: ['ZzzNonExistentSymbolXyz_12345'], source_quote: 'does not exist' },
+  ];
+  const visionOverride = { vision_key: 'VISION-UNIT-TEST', version: 1, content: '', sections: null, addendums: [] };
+  const results = await runChecker({
+    sdKey: 'SD-TEST', supabase: null, root: WORKTREE_ROOT, visionOverride, fixtureMatrix: fixture,
+  });
+  const sig = results[0].signals_detected[0];
+  assert.equal(sig.found, false);
+  assert.equal(sig.match_count, 0);
+  assert.deepEqual(sig.sample_files, []);
+  assert.equal(results[0].status, 'fail');
+});
+
+// -----------------------------------------------------------------------------
+// US-002 — Skip when no vision_key and no supabase
+// -----------------------------------------------------------------------------
+test('runChecker: status=skip when no vision_key resolvable and no visionOverride', async () => {
+  const results = await runChecker({
+    sdKey: 'SD-NO-VISION', supabase: null, root: WORKTREE_ROOT,
+  });
+  assert.equal(results[0].status, 'skip');
+  assert.equal(results[0].evidence.reason, 'no_vision_key');
+  assert.equal(results[0].signals_detected.length, 0);
+});
+
+// -----------------------------------------------------------------------------
+// US-003 — Cache hit avoids LLM call on second run (file-based cache)
+// -----------------------------------------------------------------------------
+test('runChecker: cache hit sets source=cache and llm_called=false without fixture', async () => {
+  const tempRoot = makeTempRoot();
+  try {
+    const visionKey = 'VISION-CACHE-HIT';
+    const version = 1;
+    // Pre-write cache file
+    const cacheDir = join(tempRoot, '.cache', 'vision-matrices');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, `${visionKey}-v${version}.json`), JSON.stringify({
+      vision_key: visionKey,
+      version,
+      ux_elements: [{ name: 'CachedEl', type: 'function', grep_patterns: ['__never_match__'], source_quote: 'cached' }],
+      extracted_at: new Date().toISOString(),
+    }));
+
+    const visionOverride = { vision_key: visionKey, version, content: 'irrelevant', sections: null, addendums: [] };
+    const results = await runChecker({
+      sdKey: 'SD-CACHE', supabase: null, root: tempRoot, visionOverride,
+      // Deliberately NOT passing fixtureMatrix — force the extractMatrix path so cache read is exercised.
+      llmClientOverride: { complete: async () => { throw new Error('LLM must not be called when cache hits'); } },
+    });
+    assert.equal(results[0].evidence.source, 'cache');
+    assert.equal(results[0].evidence.llm_called, false);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// US-003 — LLM returns malformed JSON → status=fail, no cache write
+// -----------------------------------------------------------------------------
+test('runChecker: malformed LLM response produces status=fail and does NOT write cache', async () => {
+  const tempRoot = makeTempRoot();
+  try {
+    const visionKey = 'VISION-BAD-LLM';
+    const version = 1;
+    const visionOverride = { vision_key: visionKey, version, content: 'prose', sections: null, addendums: [] };
+    const results = await runChecker({
+      sdKey: 'SD-BAD-LLM', supabase: null, root: tempRoot, visionOverride,
+      llmClientOverride: { complete: async () => ({ content: '{malformed' }) },
+    });
+    assert.equal(results[0].status, 'fail');
+    assert.ok(results[0].evidence.llm_error, 'llm_error must be populated');
+    const cacheFile = join(tempRoot, '.cache', 'vision-matrices', `${visionKey}-v${version}.json`);
+    assert.equal(existsSync(cacheFile), false, 'cache must NOT be written for malformed response');
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// US-003 — LLM success writes cache for next run
+// -----------------------------------------------------------------------------
+test('runChecker: LLM success writes cache file for subsequent runs', async () => {
+  const tempRoot = makeTempRoot();
+  try {
+    const visionKey = 'VISION-WRITE-CACHE';
+    const version = 1;
+    const visionOverride = { vision_key: visionKey, version, content: 'prose', sections: null, addendums: [] };
+    const llmResponse = JSON.stringify({
+      ux_elements: [{ name: 'NewEl', type: 'component', grep_patterns: ['NeverMatchesZzz'], source_quote: 'from llm' }],
+    });
+    const results = await runChecker({
+      sdKey: 'SD-WRITE-CACHE', supabase: null, root: tempRoot, visionOverride,
+      llmClientOverride: { complete: async () => ({ content: llmResponse }) },
+    });
+    assert.equal(results[0].evidence.source, 'llm');
+    assert.equal(results[0].evidence.llm_called, true);
+    const cacheFile = join(tempRoot, '.cache', 'vision-matrices', `${visionKey}-v${version}.json`);
+    assert.equal(existsSync(cacheFile), true, 'cache must be written on LLM success');
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Verifier #3 of 5 in the LEO Wiring Verification Framework. Loads a vision document by `vision_key`, extracts structured UX elements via the validation LLM (cached per-version in `.cache/vision-matrices/`), then greps the codebase for each element and emits a `leo_wiring_validations`-shaped JSON row.

- `scripts/wiring-validators/vision-traceability-checker.js` (385 LOC) — exports `runChecker()` + `persistResults()`, CLI invokable. Mirrors sibling A (orphan-detector) API exactly so Child D's runner harness can iterate validators uniformly.
- `tests/unit/wiring-validators/vision-traceability.test.js` (9 tests, <1s, zero live LLM calls via `fixtureMatrix` / `llmClientOverride` injection).
- `.gitignore`: add `.cache/` so cached matrices stay out of version control.

**Schema deviation documented**: The SD spec referenced `eva_vision_documents.metadata.artifacts` for cache, but DB introspection confirmed the `metadata` column does not exist. Cache is file-based at `.cache/vision-matrices/<vision_key>-v<version>.json`. Child D may later migrate to a proper `vision_artifacts` table without breaking Child C.

**Walker fix vs sibling A**: `SKIP_DIR_RE` is tested against paths relative to `repoRoot`, not absolute paths — so scans still work when the repo lives inside `.worktrees/` during fleet runs.

**Safety**: `--vision-key` CLI input sanitized via `/^[\w./-]+$/` allowlist (matches sibling A hardening from #3102). `persistResults` gracefully no-ops when `supabase` is null OR when `leo_wiring_validations` table is absent (Child D creates it).

**LEO gate scores**:
- LEAD-TO-PLAN: 95%
- PLAN-TO-EXEC: 96%
- PLAN-TO-LEAD: 86%
- LEAD-FINAL-APPROVAL: 96%

Covers PRD FR-1..FR-6 and US-001..US-006.

## Test plan

- [x] `node --test tests/unit/wiring-validators/vision-traceability.test.js` — 9/9 pass in <1s
- [x] `node scripts/wiring-validators/vision-traceability-checker.js SD-TEST` returns skip for SD without vision_key
- [x] `--vision-key "v; rm -rf /"` rejected with exit 2
- [ ] Live run against `SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001` detects S17 UX gaps (requires LLM credentials; deferred to Child D integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>