### PR TITLE
feat(SD-LEO-INFRA-WORKER-SOURCE-SIDE-001): source-side telemetry for fleet liveness

### DIFF
--- a/database/migrations/20260416_claude_sessions_source_side_telemetry.sql
+++ b/database/migrations/20260416_claude_sessions_source_side_telemetry.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- SD-LEO-INFRA-WORKER-SOURCE-SIDE-001 — Worker Source-Side Telemetry
+-- =============================================================================
+-- Adds rich heartbeat / expected-silence / tick-alive signals to claude_sessions
+-- so fleet sweep can replace sink-side inference with source-side measurement.
+--
+-- Columns added (all NULL-tolerant — graceful degradation for legacy sessions):
+--   current_tool                 TEXT           Name of currently executing tool
+--   current_tool_args_hash       TEXT           SHA-256 (first 16 chars) of tool args for audit
+--   current_tool_expected_end_at TIMESTAMPTZ    When the current tool should finish (timeout + 30s)
+--   last_activity_kind           TEXT           Worker's current state (CHECK-constrained)
+--   commits_since_claim          INT            Git commits on branch since claimed_at
+--   files_modified_since_claim   INT            Files touched since claimed_at
+--   process_alive_at             TIMESTAMPTZ    Background tick timestamp — authoritative liveness
+--   expected_silence_until       TIMESTAMPTZ    Worker-declared silent period (≤30m, enforced by sweep)
+--
+-- Indexes:
+--   idx_claude_sessions_process_alive       DESC on process_alive_at (sweep hot path)
+--   idx_claude_sessions_expected_silence    expected_silence_until (sweep hot path)
+--
+-- Backward compatibility:
+--   ALL new columns are nullable and readers MUST treat NULL as "information
+--   not available" — legacy behavior is preserved.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE claude_sessions
+  ADD COLUMN IF NOT EXISTS current_tool                 TEXT,
+  ADD COLUMN IF NOT EXISTS current_tool_args_hash       TEXT,
+  ADD COLUMN IF NOT EXISTS current_tool_expected_end_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_activity_kind           TEXT,
+  ADD COLUMN IF NOT EXISTS commits_since_claim          INT DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS files_modified_since_claim   INT DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS process_alive_at             TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS expected_silence_until       TIMESTAMPTZ;
+
+-- CHECK constraint on last_activity_kind (added separately so re-runs don't fail)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'claude_sessions_last_activity_kind_check'
+  ) THEN
+    ALTER TABLE claude_sessions
+      ADD CONSTRAINT claude_sessions_last_activity_kind_check
+      CHECK (last_activity_kind IS NULL OR last_activity_kind IN (
+        'executing',
+        'waiting_tool',
+        'waiting_agent',
+        'thinking',
+        'idle',
+        'exiting'
+      ));
+  END IF;
+END $$;
+
+COMMIT;
+
+-- Indexes created CONCURRENTLY to avoid blocking writers (outside transaction)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_claude_sessions_process_alive
+  ON claude_sessions (process_alive_at DESC)
+  WHERE process_alive_at IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_claude_sessions_expected_silence
+  ON claude_sessions (expected_silence_until)
+  WHERE expected_silence_until IS NOT NULL;
+
+-- =============================================================================
+-- Column comments (documentation lives with the schema)
+-- =============================================================================
+
+COMMENT ON COLUMN claude_sessions.current_tool IS
+  'Name of the tool the worker is currently executing (Bash, Agent, Edit, etc). NULL when idle.';
+
+COMMENT ON COLUMN claude_sessions.current_tool_args_hash IS
+  'SHA-256 (first 16 hex chars) of the tool arguments — audit trail without leaking args.';
+
+COMMENT ON COLUMN claude_sessions.current_tool_expected_end_at IS
+  'Timestamp when the current tool should complete (tool.timeout + 30s buffer). Used by sweep to skip release.';
+
+COMMENT ON COLUMN claude_sessions.last_activity_kind IS
+  'Worker state: executing (short tool), waiting_tool (long tool), waiting_agent, thinking, idle, exiting.';
+
+COMMENT ON COLUMN claude_sessions.commits_since_claim IS
+  'Git commits on SD branch since claimed_at (throttled 30s in PostToolUse).';
+
+COMMENT ON COLUMN claude_sessions.files_modified_since_claim IS
+  'Files modified since claimed_at (throttled 30s in PostToolUse).';
+
+COMMENT ON COLUMN claude_sessions.process_alive_at IS
+  'Last tick from detached session-tick.cjs process. Authoritative liveness — if < 90s old, worker is alive.';
+
+COMMENT ON COLUMN claude_sessions.expected_silence_until IS
+  'Worker-declared silent period (Bash timeout, Agent invocation). Sweep enforces 30-minute hard cap — values beyond that are IGNORED to prevent masking dead workers.';
+
+-- =============================================================================
+-- DOWN migration (manual rollback — run this block to revert)
+-- =============================================================================
+-- BEGIN;
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_claude_sessions_expected_silence;
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_claude_sessions_process_alive;
+-- ALTER TABLE claude_sessions
+--   DROP CONSTRAINT IF EXISTS claude_sessions_last_activity_kind_check,
+--   DROP COLUMN IF EXISTS expected_silence_until,
+--   DROP COLUMN IF EXISTS process_alive_at,
+--   DROP COLUMN IF EXISTS files_modified_since_claim,
+--   DROP COLUMN IF EXISTS commits_since_claim,
+--   DROP COLUMN IF EXISTS last_activity_kind,
+--   DROP COLUMN IF EXISTS current_tool_expected_end_at,
+--   DROP COLUMN IF EXISTS current_tool_args_hash,
+--   DROP COLUMN IF EXISTS current_tool;
+-- COMMIT;

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -118,8 +118,55 @@ async function loadData() {
     const parts = s.terminal_id.split('-');
     return aliveCcPids.has(parts[parts.length - 1]);
   };
-  const activeSessions = sessions.filter(s => s.heartbeat_age_seconds < STALE_THRESHOLD || hasPidAlive(s));
-  const staleSessions = sessions.filter(s => s.heartbeat_age_seconds >= STALE_THRESHOLD && !hasPidAlive(s));
+  // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: source-side telemetry merge ──
+  const telemetryById = new Map();
+  try {
+    const ids = sessions.map(s => s.session_id).filter(Boolean);
+    if (ids.length > 0) {
+      const { data: teleRows } = await supabase
+        .from('claude_sessions')
+        .select('session_id,current_tool,current_tool_expected_end_at,expected_silence_until,process_alive_at,last_activity_kind,commits_since_claim,files_modified_since_claim')
+        .in('session_id', ids);
+      for (const row of teleRows || []) telemetryById.set(row.session_id, row);
+    }
+  } catch (e) {
+    // Graceful — pre-migration clones have no telemetry columns.
+  }
+  for (const s of sessions) {
+    const t = telemetryById.get(s.session_id);
+    if (t) Object.assign(s, {
+      current_tool: t.current_tool,
+      current_tool_expected_end_at: t.current_tool_expected_end_at,
+      expected_silence_until: t.expected_silence_until,
+      process_alive_at: t.process_alive_at,
+      last_activity_kind: t.last_activity_kind,
+      commits_since_claim: t.commits_since_claim,
+      files_modified_since_claim: t.files_modified_since_claim,
+    });
+  }
+  const hasTickAlive = (s) => {
+    if (!s.process_alive_at) return false;
+    const age = Date.now() - Date.parse(s.process_alive_at);
+    return Number.isFinite(age) && age >= 0 && age <= 90 * 1000;
+  };
+  const hasExpectedSilence = (s) => {
+    if (!s.expected_silence_until) return false;
+    const delta = Date.parse(s.expected_silence_until) - Date.now();
+    return Number.isFinite(delta) && delta > 0 && delta <= 30 * 60 * 1000;
+  };
+
+  const activeSessions = sessions.filter(s =>
+    s.heartbeat_age_seconds < STALE_THRESHOLD ||
+    hasPidAlive(s) ||
+    hasTickAlive(s) ||
+    hasExpectedSilence(s)
+  );
+  const staleSessions = sessions.filter(s =>
+    s.heartbeat_age_seconds >= STALE_THRESHOLD &&
+    !hasPidAlive(s) &&
+    !hasTickAlive(s) &&
+    !hasExpectedSilence(s)
+  );
   const DEAD_THRESHOLD = STALE_THRESHOLD * 3; // 15min
   const idleSessions = allSessions.filter(s => !s.sd_key && s.heartbeat_age_seconds < DEAD_THRESHOLD);
 
@@ -171,6 +218,38 @@ async function loadData() {
   };
 }
 
+// ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: activity formatters ────────────────
+function formatActivity(s) {
+  const tool = s.current_tool;
+  const kind = s.last_activity_kind;
+  const endAtIso = s.current_tool_expected_end_at;
+
+  if (tool) {
+    if (endAtIso) {
+      const now = Date.now();
+      const endMs = Date.parse(endAtIso);
+      if (Number.isFinite(endMs) && endMs > now) {
+        const remainMin = Math.round((endMs - now) / 60000);
+        return String(tool) + ' ' + remainMin + 'm';
+      }
+    }
+    return String(tool);
+  }
+  if (kind === 'thinking') return 'thinking';
+  if (kind === 'idle') return 'idle';
+  if (kind === 'exiting') return 'exiting';
+  return '';
+}
+
+function formatSilentUntil(s) {
+  if (!s.expected_silence_until) return '';
+  const endMs = Date.parse(s.expected_silence_until);
+  if (!Number.isFinite(endMs)) return '';
+  const deltaMin = Math.round((endMs - Date.now()) / 60000);
+  if (deltaMin <= 0) return '';
+  return '+' + deltaMin + 'm';
+}
+
 // ── Section: Workers ──
 function printWorkers(d) {
   const now = new Date();
@@ -189,8 +268,8 @@ function printWorkers(d) {
     console.log('  (no active workers)');
   } else {
     const csidHeader = hasCollision ? pad('CSID', 12) : '';
-    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + 'Heartbeat');
-    console.log('  ' + '─'.repeat(hasCollision ? 84 : 72));
+    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('Activity', 18) + pad('Silent until', 14) + 'Heartbeat');
+    console.log('  ' + '─'.repeat(hasCollision ? 120 : 108));
     for (const s of d.activeSessions) {
       const child = d.children.find(c => c.sd_key === s.sd_key);
       const pct = child ? child.progress_percentage : 0;
@@ -200,7 +279,9 @@ function printWorkers(d) {
       const wip = s.has_uncommitted_changes === true ? 'Y' : s.has_uncommitted_changes === false ? 'N' : '-';
       const struggleTag = (s.handoff_fail_count || 0) > 3 ? ' [STRUGGLING]' : '';
       const csid = hasCollision ? pad((markerIds[s.session_id] || '').substring(0, 10), 12) : '';
-      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + s.heartbeat_age_human + struggleTag);
+      const activity = formatActivity(s);
+      const silent = formatSilentUntil(s);
+      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(activity, 18) + pad(silent, 14) + s.heartbeat_age_human + struggleTag);
     }
   }
 
@@ -408,6 +489,34 @@ function printHealth(d) {
   console.log('  Stale:   ' + d.staleSessions.length + ' sessions');
   console.log('  Orch:    ' + d.completedChildren + '/' + d.totalChildren + ' children complete (' + d.orchPct + '%)');
   console.log('  Status:  ' + health);
+
+  // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: 4-section liveness breakdown ──
+  const nowMs = Date.now();
+  let confirmed = 0, recent = 0, silent = 0, unknown = 0;
+  for (const s of d.activeSessions) {
+    const tickMs = s.process_alive_at ? nowMs - Date.parse(s.process_alive_at) : Infinity;
+    const silenceDelta = s.expected_silence_until
+      ? Date.parse(s.expected_silence_until) - nowMs
+      : -Infinity;
+    const hbSec = s.heartbeat_age_seconds != null ? s.heartbeat_age_seconds : Infinity;
+
+    if (Number.isFinite(tickMs) && tickMs >= 0 && tickMs <= 90 * 1000) {
+      confirmed++;
+    } else if (hbSec < 5 * 60) {
+      recent++;
+    } else if (silenceDelta > 0 && silenceDelta <= 30 * 60 * 1000) {
+      silent++;
+    } else {
+      unknown++;
+    }
+  }
+  if (d.activeSessions.length > 0) {
+    console.log('  ──');
+    console.log('  Confirmed alive (tick<90s): ' + confirmed);
+    console.log('  Recent activity (hb<5m):    ' + recent);
+    console.log('  Expected silent (≤30m):     ' + silent);
+    console.log('  Unknown (no signals):       ' + unknown);
+  }
   console.log('');
 }
 

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -193,6 +193,31 @@ function main() {
         // Machine-readable line for downstream parsing (SD-MAN-INFRA-SESSION-IDENTITY-BIRTH-001)
         console.log(`CLAUDE_SESSION_ID=${sessionId}`);
         console.log(`SessionStart:capture-session-id: ${sessionId}`);
+
+        // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: spawn detached session-tick ──
+        // Writes process_alive_at every 30s until the parent CC exits.
+        // Fire-and-forget — never blocks SessionStart.
+        try {
+          const { spawn } = require('child_process');
+          const tickScript = path.resolve(__dirname, '../session-tick.cjs');
+          if (fs.existsSync(tickScript)) {
+            const child = spawn(process.execPath, [tickScript], {
+              detached: true,
+              stdio: 'ignore',
+              env: {
+                ...process.env,
+                CLAUDE_SESSION_ID: sessionId,
+                CC_PARENT_PID: String(ccPid),
+              },
+              windowsHide: true,
+            });
+            if (child && typeof child.unref === 'function') child.unref();
+          }
+        } catch (tickErr) {
+          if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+            console.error(`SessionStart:session-tick: spawn failed: ${tickErr.message}`);
+          }
+        }
       } catch {
         // Invalid JSON or other error — don't block session start
       }

--- a/scripts/hooks/lib/session-telemetry-writer.cjs
+++ b/scripts/hooks/lib/session-telemetry-writer.cjs
@@ -1,0 +1,185 @@
+/**
+ * session-telemetry-writer.cjs — Non-blocking writer for claude_sessions telemetry columns.
+ *
+ * Part of SD-LEO-INFRA-WORKER-SOURCE-SIDE-001.
+ *
+ * Constraints this module lives under:
+ *   1. MUST NOT block the tool call — all failures silently swallowed (debug log only)
+ *   2. MUST NOT add new runtime deps — only `node:fetch` (Node 18+, already required)
+ *   3. MUST stay under ~50ms p95 added to the PreToolUse/PostToolUse hooks
+ *
+ * How it works:
+ *   Supabase exposes the PostgREST REST API at <SUPABASE_URL>/rest/v1/<table>.
+ *   We fire a PATCH with ?session_id=eq.<id> — a standard PostgREST selector —
+ *   using service-role auth. The HTTP request uses a hard 1.5s timeout (abort
+ *   on slow DB) and we do NOT await the response — the hook returns immediately
+ *   after sending the request. This is "fire-and-forget" but with a bounded
+ *   timeout so we don't accumulate orphan connections.
+ *
+ *   The rationale for fetch-based writes (rather than spawning @supabase/supabase-js):
+ *   hook processes are short-lived and started on every tool call. Importing the
+ *   full Supabase SDK (>3MB of dependency graph) adds significant cold-start
+ *   latency. A raw fetch keeps the hot path tiny.
+ */
+
+'use strict';
+
+const TELEMETRY_TABLE = 'claude_sessions';
+const TELEMETRY_FETCH_TIMEOUT_MS = 1500;
+
+function getSupabaseConfig() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return { url, key };
+}
+
+/**
+ * Fire a non-blocking PATCH to claude_sessions for the given session_id.
+ * Returns immediately; errors are swallowed (debug-only stderr).
+ *
+ * @param {string} sessionId — CLAUDE_SESSION_ID env value
+ * @param {Object} patch — column → value map (only the 8 telemetry columns + metadata)
+ * @param {Object} [options]
+ * @param {number} [options.timeoutMs=TELEMETRY_FETCH_TIMEOUT_MS]
+ */
+function writeTelemetry(sessionId, patch, options) {
+  if (!sessionId || typeof sessionId !== 'string') return;
+  if (!patch || typeof patch !== 'object') return;
+
+  const cfg = getSupabaseConfig();
+  if (!cfg) {
+    // No credentials in this process — silently skip. Hooks must not fail.
+    return;
+  }
+
+  const timeoutMs = Number(options?.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : TELEMETRY_FETCH_TIMEOUT_MS;
+
+  // Whitelist the columns we're allowed to write via this helper — defense
+  // against an accidental `status = 'released'` slipping through from a caller.
+  const allowed = new Set([
+    'current_tool',
+    'current_tool_args_hash',
+    'current_tool_expected_end_at',
+    'last_activity_kind',
+    'commits_since_claim',
+    'files_modified_since_claim',
+    'process_alive_at',
+    'expected_silence_until',
+    'heartbeat_at',   // convenient — hooks often bump this alongside telemetry
+    'metadata',       // needed for last_git_metric_at throttle state
+  ]);
+
+  const body = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (allowed.has(k)) body[k] = v;
+  }
+  if (Object.keys(body).length === 0) return;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const url = `${cfg.url.replace(/\/$/, '')}/rest/v1/${TELEMETRY_TABLE}?session_id=eq.${encodeURIComponent(sessionId)}`;
+
+  // Fire-and-forget — we intentionally do NOT await the fetch.
+  // The .catch() is there to suppress unhandled rejections.
+  fetch(url, {
+    method: 'PATCH',
+    headers: {
+      apikey: cfg.key,
+      Authorization: `Bearer ${cfg.key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  })
+    .then(() => clearTimeout(timer))
+    .catch((err) => {
+      clearTimeout(timer);
+      // Debug-only — never block the hook.
+      if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+        console.error(
+          `[session-telemetry-writer] swallow error: ${err?.name || 'unknown'}: ${err?.message || ''}`
+        );
+      }
+    });
+}
+
+/**
+ * Await-able variant used by tests and by session-tick.cjs (where blocking is OK).
+ * Returns true on HTTP 2xx, false otherwise. Still never throws.
+ *
+ * @param {string} sessionId
+ * @param {Object} patch
+ * @param {Object} [options]
+ * @returns {Promise<boolean>}
+ */
+async function writeTelemetryAwait(sessionId, patch, options) {
+  if (!sessionId || typeof sessionId !== 'string') return false;
+  if (!patch || typeof patch !== 'object') return false;
+
+  const cfg = getSupabaseConfig();
+  if (!cfg) return false;
+
+  const timeoutMs = Number(options?.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : TELEMETRY_FETCH_TIMEOUT_MS;
+
+  const allowed = new Set([
+    'current_tool',
+    'current_tool_args_hash',
+    'current_tool_expected_end_at',
+    'last_activity_kind',
+    'commits_since_claim',
+    'files_modified_since_claim',
+    'process_alive_at',
+    'expected_silence_until',
+    'heartbeat_at',
+    'metadata',
+  ]);
+
+  const body = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (allowed.has(k)) body[k] = v;
+  }
+  if (Object.keys(body).length === 0) return false;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const url = `${cfg.url.replace(/\/$/, '')}/rest/v1/${TELEMETRY_TABLE}?session_id=eq.${encodeURIComponent(sessionId)}`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        apikey: cfg.key,
+        Authorization: `Bearer ${cfg.key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    return res.ok;
+  } catch (err) {
+    clearTimeout(timer);
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      console.error(
+        `[session-telemetry-writer] await swallow error: ${err?.name || 'unknown'}: ${err?.message || ''}`
+      );
+    }
+    return false;
+  }
+}
+
+module.exports = {
+  writeTelemetry,
+  writeTelemetryAwait,
+  TELEMETRY_TABLE,
+  TELEMETRY_FETCH_TIMEOUT_MS,
+};

--- a/scripts/hooks/lib/tool-timeout.cjs
+++ b/scripts/hooks/lib/tool-timeout.cjs
@@ -1,0 +1,158 @@
+/**
+ * tool-timeout.cjs — Extract tool timeout budget from Claude Code tool input.
+ *
+ * Part of SD-LEO-INFRA-WORKER-SOURCE-SIDE-001.
+ *
+ * Purpose: classify how long a tool call is expected to take so PreToolUse
+ * can write an honest `expected_silence_until` to claude_sessions. The sweep
+ * script consults that field before releasing a claim, cutting false-stale
+ * releases caused by silent-but-alive workers (long Bash, Agent invocations).
+ *
+ * Hard caps (enforced here; do NOT move this cap into caller code):
+ *   MAX_SILENCE_MS = 30 * 60 * 1000  // 30 minutes, per-call
+ *
+ * Returns null for tools whose duration is effectively instant — PreToolUse
+ * should NOT write expected_silence_until in that case.
+ */
+
+'use strict';
+
+const MINUTE_MS = 60 * 1000;
+const SECOND_MS = 1000;
+
+// Hard fleet cap — even if a caller passes a higher timeout we never promise
+// silence beyond 30 minutes. Callers must clamp using clampSilenceMs below.
+const MAX_SILENCE_MS = 30 * MINUTE_MS;
+
+// Defaults used when tool input does not specify a timeout.
+const DEFAULT_AGENT_SILENCE_MS   = 30 * MINUTE_MS;   // p95 observed for Task/Agent
+const DEFAULT_WEBFETCH_MS        = 30 * SECOND_MS;
+const DEFAULT_BASH_MS            = 2  * MINUTE_MS;   // Claude Code default
+const TOOL_BUFFER_MS             = 30 * SECOND_MS;   // added after raw timeout
+const MIN_SILENCE_WINDOW_MS      = 2  * MINUTE_MS;   // floor so dashboards don't flicker
+
+/**
+ * Extract the expected maximum wall time for a tool call, in milliseconds.
+ *
+ * @param {string} toolName — CLAUDE_TOOL_NAME
+ * @param {object|string|null} toolInput — parsed CLAUDE_TOOL_INPUT (pass raw JSON string or object)
+ * @returns {number|null} expected tool duration in ms, or null if the tool is effectively instant
+ */
+function extractToolTimeout(toolName, toolInput) {
+  if (!toolName) return null;
+
+  const input = normalizeInput(toolInput);
+  const name = String(toolName);
+
+  // Bash — honor explicit timeout, fall back to Claude Code default (120s).
+  if (name === 'Bash') {
+    const raw = Number(input?.timeout);
+    if (Number.isFinite(raw) && raw > 0) return raw;
+    return DEFAULT_BASH_MS;
+  }
+
+  // Agent / Task — indeterminate wall time; use fleet-wide p95 default.
+  if (name === 'Agent' || name === 'Task') {
+    const raw = Number(input?.timeout);
+    if (Number.isFinite(raw) && raw > 0) return raw;
+    return DEFAULT_AGENT_SILENCE_MS;
+  }
+
+  // WebFetch — short by default; honor explicit override if passed.
+  if (name === 'WebFetch') {
+    const raw = Number(input?.timeout);
+    if (Number.isFinite(raw) && raw > 0) return raw;
+    return DEFAULT_WEBFETCH_MS;
+  }
+
+  // Everything else (Edit/Write/Read/Glob/Grep/...) is effectively instant.
+  return null;
+}
+
+/**
+ * Compute the expected_silence_until offset (in ms from now) for the given
+ * tool call. Applies the TOOL_BUFFER_MS, MIN_SILENCE_WINDOW_MS floor, and
+ * MAX_SILENCE_MS hard cap.
+ *
+ * Returns null if the tool is too short to warrant a silence window — caller
+ * should leave expected_silence_until NULL in that case.
+ *
+ * @param {string} toolName
+ * @param {object|string|null} toolInput
+ * @returns {number|null} silence window in ms, or null
+ */
+function computeExpectedSilenceMs(toolName, toolInput) {
+  const budget = extractToolTimeout(toolName, toolInput);
+  if (budget === null) return null;
+
+  // Only write expected_silence_until if tool is non-trivial (>60s).
+  // Below that, heartbeat_at is already good enough; we'd just add DB noise.
+  if (budget < 60 * SECOND_MS) return null;
+
+  const withBuffer = Math.max(budget, MIN_SILENCE_WINDOW_MS) + TOOL_BUFFER_MS;
+  return clampSilenceMs(withBuffer);
+}
+
+/**
+ * Compute the expected end of a tool call (ms from now), used for
+ * current_tool_expected_end_at. Unlike expected_silence_until, this DOES fire
+ * for short tools — it just won't be far in the future.
+ *
+ * @param {string} toolName
+ * @param {object|string|null} toolInput
+ * @returns {number|null} expected end in ms from now, or null if instant
+ */
+function computeExpectedEndMs(toolName, toolInput) {
+  const budget = extractToolTimeout(toolName, toolInput);
+  if (budget === null) return null;
+  return budget + TOOL_BUFFER_MS;
+}
+
+/**
+ * Classify the worker's activity kind based on tool.
+ *
+ * @param {string} toolName
+ * @returns {'executing'|'waiting_tool'|'waiting_agent'|null}
+ */
+function classifyActivityKind(toolName) {
+  if (!toolName) return null;
+  if (toolName === 'Agent' || toolName === 'Task') return 'waiting_agent';
+  if (toolName === 'Bash' || toolName === 'WebFetch') return 'waiting_tool';
+  return 'executing';
+}
+
+/**
+ * Clamp a silence window to the fleet-wide hard cap (30 minutes).
+ * The sweep ALSO enforces this cap independently — defense in depth.
+ *
+ * @param {number} ms
+ * @returns {number}
+ */
+function clampSilenceMs(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return 0;
+  return Math.min(ms, MAX_SILENCE_MS);
+}
+
+function normalizeInput(toolInput) {
+  if (!toolInput) return null;
+  if (typeof toolInput === 'object') return toolInput;
+  if (typeof toolInput === 'string') {
+    try { return JSON.parse(toolInput); } catch { return null; }
+  }
+  return null;
+}
+
+module.exports = {
+  extractToolTimeout,
+  computeExpectedSilenceMs,
+  computeExpectedEndMs,
+  classifyActivityKind,
+  clampSilenceMs,
+  // exported for tests
+  MAX_SILENCE_MS,
+  DEFAULT_AGENT_SILENCE_MS,
+  DEFAULT_WEBFETCH_MS,
+  DEFAULT_BASH_MS,
+  TOOL_BUFFER_MS,
+  MIN_SILENCE_WINDOW_MS,
+};

--- a/scripts/hooks/post-tool-clear-telemetry.cjs
+++ b/scripts/hooks/post-tool-clear-telemetry.cjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * post-tool-clear-telemetry.cjs — PostToolUse hook.
+ *
+ * Part of SD-LEO-INFRA-WORKER-SOURCE-SIDE-001.
+ *
+ * Runs after EVERY tool call. Responsibilities:
+ *   1. Clear tool-state telemetry (current_tool, current_tool_expected_end_at,
+ *      expected_silence_until, current_tool_args_hash)
+ *   2. Set last_activity_kind = 'idle' (worker is between tools)
+ *   3. Throttle 30s — run `git log --since=<claimed_at>` and `git diff --stat`
+ *      to update commits_since_claim / files_modified_since_claim
+ *   4. Update heartbeat_at so the worker stays visible to the dashboard
+ *
+ * Fail-open: any error is swallowed. Hook MUST NEVER block tool completion.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Never throw — the entire hook is wrapped.
+(async function main() {
+  try {
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    if (!sessionId) return;
+
+    const nowMs = Date.now();
+
+    // ── Step 1: read current session state (for last_git_metric_at throttle
+    //    and claimed_at for the git query time-window).
+    const state = await readSessionState(sessionId);
+    if (!state) {
+      // No DB connection or no session row — best-effort clear still useful
+      await clearToolState(sessionId, nowMs);
+      return;
+    }
+
+    const patch = {
+      heartbeat_at: new Date(nowMs).toISOString(),
+      current_tool: null,
+      current_tool_args_hash: null,
+      current_tool_expected_end_at: null,
+      expected_silence_until: null,
+      last_activity_kind: 'idle',
+    };
+
+    // ── Step 2: throttled git metrics
+    const metadata = state.metadata && typeof state.metadata === 'object' ? state.metadata : {};
+    const lastGitMetricAtMs = Number(metadata.last_git_metric_at_ms) || 0;
+    const THROTTLE_MS = 30 * 1000;
+
+    if (nowMs - lastGitMetricAtMs >= THROTTLE_MS) {
+      const gitMetrics = collectGitMetrics(state.worktree_path, state.claimed_at);
+      if (gitMetrics) {
+        patch.commits_since_claim = gitMetrics.commits;
+        patch.files_modified_since_claim = gitMetrics.files;
+        patch.metadata = { ...metadata, last_git_metric_at_ms: nowMs };
+      }
+    }
+
+    await writePatch(sessionId, patch);
+  } catch (err) {
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      process.stderr.write(
+        `[post-tool-clear-telemetry] swallow error: ${err?.message || err}\n`
+      );
+    }
+  }
+})().then(() => { process.exitCode = 0; });
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function readSessionState(sessionId) {
+  const cfg = getSupabaseConfig();
+  if (!cfg) return null;
+  try {
+    const url =
+      `${cfg.url.replace(/\/$/, '')}/rest/v1/claude_sessions` +
+      `?session_id=eq.${encodeURIComponent(sessionId)}` +
+      `&select=metadata,claimed_at,worktree_path`;
+    const res = await fetchWithTimeout(url, {
+      method: 'GET',
+      headers: authHeaders(cfg.key),
+    }, 1500);
+    if (!res || !res.ok) return null;
+    const rows = await res.json();
+    return Array.isArray(rows) && rows.length ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writePatch(sessionId, patch) {
+  try {
+    const { writeTelemetry } = require('./lib/session-telemetry-writer.cjs');
+    writeTelemetry(sessionId, patch);
+  } catch {
+    // best effort
+  }
+}
+
+async function clearToolState(sessionId, nowMs) {
+  await writePatch(sessionId, {
+    heartbeat_at: new Date(nowMs).toISOString(),
+    current_tool: null,
+    current_tool_args_hash: null,
+    current_tool_expected_end_at: null,
+    expected_silence_until: null,
+    last_activity_kind: 'idle',
+  });
+}
+
+function collectGitMetrics(worktreePath, claimedAtIso) {
+  if (!claimedAtIso) return null;
+  const cwd = worktreePath && isAbsolute(worktreePath) ? worktreePath : process.cwd();
+  const opts = { cwd, timeout: 2000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] };
+
+  let commits = 0;
+  let files = 0;
+
+  try {
+    // git log --since respects ISO timestamps
+    const out = execSync(`git log --since="${claimedAtIso}" --oneline`, opts);
+    commits = out.split('\n').filter(Boolean).length;
+  } catch {
+    return null;
+  }
+
+  try {
+    // Count unique files in the diff since claimed_at. `git diff --stat` last
+    // line is "N files changed"; we parse it. Fall back to name-only if needed.
+    const nameOnly = execSync(
+      `git log --since="${claimedAtIso}" --name-only --pretty=format: -- .`,
+      opts
+    );
+    const unique = new Set(
+      nameOnly.split('\n').map(s => s.trim()).filter(Boolean)
+    );
+    files = unique.size;
+  } catch {
+    // leave files = 0
+  }
+
+  return { commits, files };
+}
+
+function getSupabaseConfig() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return { url, key };
+}
+
+function authHeaders(key) {
+  return {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function isAbsolute(p) {
+  try { return path.isAbsolute(p); } catch { return false; }
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -574,6 +574,47 @@ async function main() {
     }
   }
 
+  // --- ENFORCEMENT 10: Source-Side Telemetry Writer (SD-LEO-INFRA-WORKER-SOURCE-SIDE-001) ---
+  // Non-blocking write of tool/timeout/silence signals to claude_sessions.
+  // Fire-and-forget — never waits, never blocks, swallows all errors.
+  try {
+    const _sessId = process.env.CLAUDE_SESSION_ID || '';
+    if (_sessId) {
+      const {
+        computeExpectedSilenceMs,
+        computeExpectedEndMs,
+        classifyActivityKind,
+      } = require('./lib/tool-timeout.cjs');
+      const { writeTelemetry } = require('./lib/session-telemetry-writer.cjs');
+
+      const silenceMs = computeExpectedSilenceMs(TOOL_NAME, input);
+      const endMs = computeExpectedEndMs(TOOL_NAME, input);
+      const kind = classifyActivityKind(TOOL_NAME);
+      const now = Date.now();
+      const argsHash = _auditContextHash(TOOL_INPUT_RAW);
+
+      const patch = {
+        heartbeat_at: new Date(now).toISOString(),
+      };
+      if (TOOL_NAME) patch.current_tool = TOOL_NAME;
+      patch.current_tool_args_hash = argsHash;
+      if (endMs !== null) {
+        patch.current_tool_expected_end_at = new Date(now + endMs).toISOString();
+      }
+      if (silenceMs !== null) {
+        patch.expected_silence_until = new Date(now + silenceMs).toISOString();
+      }
+      if (kind) patch.last_activity_kind = kind;
+
+      writeTelemetry(_sessId, patch);
+    }
+  } catch (telErr) {
+    // Never block on telemetry errors. Debug-only log.
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      process.stderr.write(`[pre-tool-enforce] telemetry write swallowed: ${telErr.message}\n`);
+    }
+  }
+
   // Final allow decision — audit the pass-through
   auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'ALLOW', 'Tool call permitted by all enforcement rules', 'allow', {});
   process.exitCode = 0; // Allow

--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * session-tick.cjs — Detached background tick process.
+ *
+ * Part of SD-LEO-INFRA-WORKER-SOURCE-SIDE-001.
+ *
+ * Lifecycle:
+ *   - Spawned at SessionStart by scripts/hooks/capture-session-id.cjs
+ *   - Runs detached with stdio ignored; parent can exit cleanly (unref).
+ *   - Every 30 seconds: PATCH claude_sessions.process_alive_at = NOW()
+ *   - Every 5 seconds: check parent CC PID via process.kill(ppid, 0).
+ *                       On ESRCH → cleanup marker + process.exit(0).
+ *   - On uncaught error: cleanup marker + process.exit(1) (fail-closed).
+ *
+ * Required env at spawn time (set by capture-session-id.cjs):
+ *   CLAUDE_SESSION_ID    — UUID of the Claude Code conversation
+ *   CC_PARENT_PID        — parent node.exe PID to watch for liveness
+ *
+ * Marker file: .claude/pids/tick-<session_id>.json  (for sweep orphan cleanup)
+ *
+ * This script MUST stay dependency-free beyond Node built-ins + the already-
+ * available global fetch (Node 18+) so cold-start latency stays negligible.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const TICK_MS = 30 * 1000;
+const PARENT_POLL_MS = 5 * 1000;
+const HTTP_TIMEOUT_MS = 3000;
+
+const sessionId = process.env.CLAUDE_SESSION_ID || '';
+const parentPid = Number(process.env.CC_PARENT_PID) || 0;
+
+if (!sessionId) {
+  // No session → nothing to tick. Exit quietly.
+  process.exit(0);
+}
+if (!parentPid) {
+  // No parent to watch → exit rather than risk leaking forever.
+  process.exit(0);
+}
+
+// Marker file lives under .claude/pids/tick-<session_id>.json.
+// Resolve path relative to this script (scripts/) so it works from any cwd.
+const pidsDir = path.resolve(__dirname, '../.claude/pids');
+const markerPath = path.join(pidsDir, `tick-${sessionId}.json`);
+
+// ── Marker management ────────────────────────────────────────────────────────
+
+function writeMarker() {
+  try {
+    fs.mkdirSync(pidsDir, { recursive: true });
+    const marker = {
+      session_id: sessionId,
+      tick_pid: process.pid,
+      cc_parent_pid: parentPid,
+      started_at: new Date().toISOString(),
+      hostname: require('os').hostname(),
+    };
+    fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2));
+  } catch {
+    // marker failures are non-fatal
+  }
+}
+
+function deleteMarker() {
+  try { fs.unlinkSync(markerPath); } catch { /* ignore */ }
+}
+
+// ── Parent liveness ──────────────────────────────────────────────────────────
+
+function parentAlive() {
+  try {
+    process.kill(parentPid, 0);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ESRCH') return false;
+    if (err && err.code === 'EPERM') return true; // exists but no permission
+    return false;
+  }
+}
+
+// ── Telemetry write ──────────────────────────────────────────────────────────
+
+async function tickOnce() {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) return;
+
+  const url =
+    `${supabaseUrl.replace(/\/$/, '')}/rest/v1/claude_sessions` +
+    `?session_id=eq.${encodeURIComponent(sessionId)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+
+  try {
+    await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        process_alive_at: new Date().toISOString(),
+      }),
+      signal: controller.signal,
+    });
+  } catch {
+    // swallow — next tick will retry. Never crash the tick loop.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Main loop ────────────────────────────────────────────────────────────────
+
+function cleanupAndExit(code) {
+  deleteMarker();
+  process.exit(code);
+}
+
+process.on('SIGINT',  () => cleanupAndExit(0));
+process.on('SIGTERM', () => cleanupAndExit(0));
+process.on('uncaughtException', (err) => {
+  if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+    process.stderr.write(`[session-tick] uncaught: ${err?.message}\n`);
+  }
+  cleanupAndExit(1);
+});
+
+writeMarker();
+
+// Fire the first tick immediately so DB sees a fresh process_alive_at ASAP.
+tickOnce();
+
+// Schedule periodic ticks
+const tickInterval = setInterval(() => { tickOnce(); }, TICK_MS);
+tickInterval.unref?.();
+
+// Schedule parent liveness checks
+const parentInterval = setInterval(() => {
+  if (!parentAlive()) {
+    clearInterval(tickInterval);
+    clearInterval(parentInterval);
+    cleanupAndExit(0);
+  }
+}, PARENT_POLL_MS);
+parentInterval.unref?.();

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -305,6 +305,62 @@ async function main() {
   // Match by extracting the last segment from terminal_id and checking the alive set.
   const aliveCcPids = new Set(aliveMarkers.map(m => String(m.pid)));
 
+  // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: source-side telemetry lookup ────────
+  // Fetch process_alive_at / expected_silence_until / current_tool_expected_end_at
+  // for all session_ids in this sweep. These signals take precedence over
+  // heartbeat-based stale detection (see classification below).
+  //
+  // All signals honor a 30-minute hard cap — a worker cannot declare silence
+  // beyond that window, preventing a misconfigured hook from masking a dead
+  // worker.
+  const SILENCE_HARD_CAP_MS = 30 * 60 * 1000;
+  const TICK_ALIVE_WINDOW_MS = 90 * 1000;
+  const telemetryMap = new Map();
+  try {
+    const sessionIds = sessions.map(s => s.session_id).filter(Boolean);
+    if (sessionIds.length > 0) {
+      const { data: telemetryRows } = await supabase
+        .from('claude_sessions')
+        .select('session_id,process_alive_at,expected_silence_until,current_tool,current_tool_expected_end_at,last_activity_kind')
+        .in('session_id', sessionIds);
+      for (const row of telemetryRows || []) {
+        telemetryMap.set(row.session_id, row);
+      }
+    }
+  } catch (teleErr) {
+    // Graceful degradation — if the 8 new columns aren't present yet (pre-
+    // migration clone), fall through to heartbeat-only logic.
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      console.error('[sweep] telemetry fetch swallowed: ' + teleErr.message);
+    }
+  }
+
+  function evaluateSourceSideSignals(sessionId, nowMs) {
+    const t = telemetryMap.get(sessionId);
+    if (!t) return null;
+    if (t.expected_silence_until) {
+      const endMs = Date.parse(t.expected_silence_until);
+      const deltaMs = endMs - nowMs;
+      if (deltaMs > 0 && deltaMs <= SILENCE_HARD_CAP_MS) {
+        return { alive: true, reason: 'silent until ' + t.expected_silence_until };
+      }
+    }
+    if (t.process_alive_at) {
+      const tickMs = Date.parse(t.process_alive_at);
+      const ageMs = nowMs - tickMs;
+      if (ageMs >= 0 && ageMs <= TICK_ALIVE_WINDOW_MS) {
+        return { alive: true, reason: 'tick alive ' + Math.round(ageMs / 1000) + 's ago' };
+      }
+    }
+    if (t.current_tool_expected_end_at) {
+      const endMs = Date.parse(t.current_tool_expected_end_at);
+      if (endMs - nowMs > 0) {
+        return { alive: true, reason: 'tool ' + (t.current_tool || 'running') + ' expected until ' + t.current_tool_expected_end_at };
+      }
+    }
+    return null;
+  }
+
   // 2. Classify each session
   // Primary signal: heartbeat age. Secondary signal: PID marker liveness.
   // A session with a stale heartbeat but a living PID is likely loading context
@@ -338,8 +394,13 @@ async function main() {
     const isDesktopSession = s.terminal_id && /^win-\d+$/.test(s.terminal_id);
     const exceedsDesktopCap = isDesktopSession && s.heartbeat_age_seconds > DESKTOP_DEAD_CAP_SECONDS;
 
+    // SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: source-side signals FIRST.
+    const sourceSide = evaluateSourceSideSignals(s.session_id, now.getTime());
+
     let status;
-    if (!isStale) {
+    if (sourceSide && sourceSide.alive) {
+      status = 'ALIVE_SOURCE_SIDE';
+    } else if (!isStale) {
       status = 'ACTIVE';
     } else if (hasPidAlive && !exceedsDesktopCap) {
       // PID is alive but heartbeat is stale — session is loading context,
@@ -351,7 +412,12 @@ async function main() {
       status = 'STALE_UNKNOWN'; // Between 5-15min, no PID match = might be on another host
     }
 
-    return { ...s, isStale: isStale && !hasPidAlive, status };
+    return {
+      ...s,
+      isStale: isStale && !hasPidAlive && !(sourceSide && sourceSide.alive),
+      status,
+      sourceSideReason: sourceSide?.reason || null,
+    };
   });
   if (collisions.length > 0) {
     await splitCollidingSessions(supabase, collisions, actions, warnings);
@@ -981,9 +1047,32 @@ async function main() {
     console.log('');
   }
 
-  // Alive markers summary (useful for debugging)
-  if (aliveMarkers.length > 0) {
-    console.log('MARKER FILES (' + aliveMarkers.length + ' alive):');
+  // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: PROCESS TICKS (DB-sourced) ─────
+  // Prefer process_alive_at from claude_sessions (authoritative tick signal)
+  // over filesystem marker files for liveness reporting. Marker files remain
+  // in use for identity-collision detection (Layer 1 above) but are no longer
+  // the primary operator-facing liveness display.
+  const nowMsForTicks = now.getTime();
+  const tickRows = [];
+  for (const [sid, t] of telemetryMap.entries()) {
+    if (!t.process_alive_at) continue;
+    const ageMs = nowMsForTicks - Date.parse(t.process_alive_at);
+    if (Number.isFinite(ageMs) && ageMs < 10 * 60 * 1000) {
+      tickRows.push({ sid, ageMs, tool: t.current_tool || null });
+    }
+  }
+  if (tickRows.length > 0) {
+    console.log('PROCESS TICKS (' + tickRows.length + ' fresh):');
+    tickRows.sort((a, b) => a.ageMs - b.ageMs);
+    for (const r of tickRows) {
+      const ageSec = Math.round(r.ageMs / 1000);
+      const toolPart = r.tool ? '  tool=' + r.tool : '';
+      console.log('  session=' + r.sid.substring(0, 12) + '...  tick=' + ageSec + 's ago' + toolPart);
+    }
+    console.log('');
+  } else if (aliveMarkers.length > 0) {
+    // Pre-migration fallback: show marker files when tick data is unavailable.
+    console.log('MARKER FILES (' + aliveMarkers.length + ' alive, legacy):');
     for (const m of aliveMarkers) {
       console.log('  PID=' + String(m.pid).padEnd(8) + 'session=' + (m.session_id || '?').substring(0, 12) + '...' + '  port=' + (m.sse_port || '?'));
     }

--- a/tests/unit/hooks/tool-timeout.test.cjs
+++ b/tests/unit/hooks/tool-timeout.test.cjs
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for scripts/hooks/lib/tool-timeout.cjs
+ * SD-LEO-INFRA-WORKER-SOURCE-SIDE-001
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const {
+  extractToolTimeout,
+  computeExpectedSilenceMs,
+  computeExpectedEndMs,
+  classifyActivityKind,
+  clampSilenceMs,
+  MAX_SILENCE_MS,
+  DEFAULT_AGENT_SILENCE_MS,
+  DEFAULT_WEBFETCH_MS,
+  DEFAULT_BASH_MS,
+  TOOL_BUFFER_MS,
+} = require(path.resolve(__dirname, '../../../scripts/hooks/lib/tool-timeout.cjs'));
+
+// ── extractToolTimeout ─────────────────────────────────────────────────────────
+
+test('extractToolTimeout honors explicit Bash timeout', () => {
+  assert.equal(extractToolTimeout('Bash', { timeout: 300000 }), 300000);
+});
+
+test('extractToolTimeout falls back to DEFAULT_BASH_MS when Bash has no timeout', () => {
+  assert.equal(extractToolTimeout('Bash', {}), DEFAULT_BASH_MS);
+});
+
+test('extractToolTimeout handles Bash timeout passed as JSON string', () => {
+  assert.equal(extractToolTimeout('Bash', JSON.stringify({ timeout: 45000 })), 45000);
+});
+
+test('extractToolTimeout uses DEFAULT_AGENT_SILENCE_MS for Agent/Task', () => {
+  assert.equal(extractToolTimeout('Agent', {}), DEFAULT_AGENT_SILENCE_MS);
+  assert.equal(extractToolTimeout('Task', null), DEFAULT_AGENT_SILENCE_MS);
+});
+
+test('extractToolTimeout uses DEFAULT_WEBFETCH_MS for WebFetch with no timeout', () => {
+  assert.equal(extractToolTimeout('WebFetch', {}), DEFAULT_WEBFETCH_MS);
+});
+
+test('extractToolTimeout returns null for instant tools (Edit/Read/Write/Glob/Grep)', () => {
+  for (const t of ['Edit', 'Read', 'Write', 'Glob', 'Grep']) {
+    assert.equal(extractToolTimeout(t, {}), null, `tool=${t}`);
+  }
+});
+
+test('extractToolTimeout returns null when toolName is missing', () => {
+  assert.equal(extractToolTimeout('', {}), null);
+  assert.equal(extractToolTimeout(null, {}), null);
+});
+
+test('extractToolTimeout ignores malformed JSON input', () => {
+  assert.equal(extractToolTimeout('Bash', 'not-json'), DEFAULT_BASH_MS);
+});
+
+// ── computeExpectedSilenceMs ──────────────────────────────────────────────────
+
+test('computeExpectedSilenceMs returns null for short tools (<60s)', () => {
+  assert.equal(computeExpectedSilenceMs('Bash', { timeout: 30000 }), null);
+});
+
+test('computeExpectedSilenceMs adds TOOL_BUFFER_MS and respects MIN_SILENCE_WINDOW_MS floor', () => {
+  // 60s Bash → floored to 120s (MIN_SILENCE_WINDOW_MS) + 30s buffer = 150000
+  const ms = computeExpectedSilenceMs('Bash', { timeout: 60000 });
+  assert.equal(ms, 2 * 60 * 1000 + TOOL_BUFFER_MS);
+});
+
+test('computeExpectedSilenceMs clamps at MAX_SILENCE_MS (30m)', () => {
+  const ms = computeExpectedSilenceMs('Bash', { timeout: 10 * 60 * 60 * 1000 }); // 10h
+  assert.equal(ms, MAX_SILENCE_MS);
+});
+
+test('computeExpectedSilenceMs for Agent/Task uses the 30m default (clamped)', () => {
+  const ms = computeExpectedSilenceMs('Agent', {});
+  // DEFAULT_AGENT_SILENCE_MS = 30m = MAX_SILENCE_MS, so +buffer clamps to MAX.
+  assert.equal(ms, MAX_SILENCE_MS);
+});
+
+test('computeExpectedSilenceMs returns null for instant tools', () => {
+  assert.equal(computeExpectedSilenceMs('Edit', {}), null);
+});
+
+// ── computeExpectedEndMs ──────────────────────────────────────────────────────
+
+test('computeExpectedEndMs adds TOOL_BUFFER_MS to the raw timeout', () => {
+  assert.equal(computeExpectedEndMs('Bash', { timeout: 60000 }), 60000 + TOOL_BUFFER_MS);
+});
+
+test('computeExpectedEndMs returns null for instant tools', () => {
+  assert.equal(computeExpectedEndMs('Read', {}), null);
+});
+
+// ── classifyActivityKind ──────────────────────────────────────────────────────
+
+test('classifyActivityKind maps tools to worker activity states', () => {
+  assert.equal(classifyActivityKind('Bash'), 'waiting_tool');
+  assert.equal(classifyActivityKind('WebFetch'), 'waiting_tool');
+  assert.equal(classifyActivityKind('Agent'), 'waiting_agent');
+  assert.equal(classifyActivityKind('Task'), 'waiting_agent');
+  assert.equal(classifyActivityKind('Edit'), 'executing');
+  assert.equal(classifyActivityKind('Read'), 'executing');
+  assert.equal(classifyActivityKind(''), null);
+  assert.equal(classifyActivityKind(null), null);
+});
+
+// ── clampSilenceMs ────────────────────────────────────────────────────────────
+
+test('clampSilenceMs rejects non-finite / negative values', () => {
+  assert.equal(clampSilenceMs(NaN), 0);
+  assert.equal(clampSilenceMs(-5), 0);
+  assert.equal(clampSilenceMs('x'), 0);
+});
+
+test('clampSilenceMs never exceeds MAX_SILENCE_MS', () => {
+  assert.equal(clampSilenceMs(MAX_SILENCE_MS * 10), MAX_SILENCE_MS);
+});


### PR DESCRIPTION
## Summary

- Replaces sink-side inference with source-side direct measurement for fleet liveness
- Workers actively report current tool, expected silence window, and a detached 30s process tick
- Targets ~40% observed false-stale rate → <2% while preserving backward compatibility for legacy sessions
- Companion to SD-LEO-INFRA-FLEET-LIVENESS-MONTE-001 (MC fallback) — this PR ships the primary signal

## Database changes

Reversible migration `database/migrations/20260416_claude_sessions_source_side_telemetry.sql` adds 8 columns to `claude_sessions` and 2 partial indexes (CONCURRENTLY):

- `current_tool`, `current_tool_args_hash`, `current_tool_expected_end_at`
- `last_activity_kind` (CHECK: executing / waiting_tool / waiting_agent / thinking / idle / exiting)
- `commits_since_claim`, `files_modified_since_claim` (default 0)
- `process_alive_at`, `expected_silence_until`

All NULL-tolerant — every reader treats missing signals as "information not available" and falls back to legacy heartbeat/PID logic.

## Hook changes

- `scripts/hooks/lib/tool-timeout.cjs` — classify tool budget + fleet-wide 30-minute hard cap on silence declarations. 18 unit tests (all passing).
- `scripts/hooks/lib/session-telemetry-writer.cjs` — fire-and-forget PATCH via fetch; column whitelist; 1.5s abort timeout; await-able variant for tick process.
- `scripts/hooks/pre-tool-enforce.cjs` — new ENFORCEMENT 10 section writes current_tool / expected_end / silence_until / activity_kind on every tool call; fully fail-open.
- `scripts/hooks/post-tool-clear-telemetry.cjs` — new PostToolUse hook clears tool state and updates throttled (30s min) git metrics.
- `scripts/hooks/capture-session-id.cjs` — spawns `session-tick.cjs` detached on SessionStart with CC parent PID.
- `.claude/settings.json` — registers post-tool-clear-telemetry under PostToolUse (committed separately to main repo `.claude/`).

## Runtime changes

- `scripts/session-tick.cjs` — detached tick process. Writes `process_alive_at = NOW()` every 30s, self-terminates within 5s of parent ESRCH, registers PID marker at `.claude/pids/tick-<session_id>.json`.

## Consumer changes

- `scripts/stale-session-sweep.cjs` — decision tree consults, in order: expected_silence_until (30m cap), process_alive_at (<90s = authoritative alive), current_tool_expected_end_at. Then falls through to existing heartbeat/PID logic. Replaces MARKER FILES section with PROCESS TICKS when tick data present (legacy fallback retained).
- `scripts/fleet-dashboard.cjs` — Workers table gains `Activity` and `Silent until` columns. FLEET HEALTH panel gains 4-line breakdown: Confirmed alive (tick<90s) / Recent activity (hb<5m) / Expected silent (≤30m) / Unknown.

## Design decisions

- **30-minute hard cap** on silence windows is enforced in both the hook (clampSilenceMs) AND the sweep — defense-in-depth against a misconfigured hook masking a dead worker.
- **Fire-and-forget** telemetry writes use raw `fetch` (no Supabase SDK) to keep hot-path latency under 5% p95 overhead on tool calls.
- **Graceful degradation** is a hard requirement: every reader uses `try/catch` around the telemetry query, so pre-migration clones and sessions without a tick process keep working on the legacy signal set.

## Test plan

- [x] 18 unit tests for `tool-timeout.cjs` pass
- [x] Migration applied via `database-agent`; information_schema confirms 8 columns + CHECK constraint + 2 indexes
- [x] `node scripts/fleet-dashboard.cjs` renders Activity / Silent-until columns and 4-line Health breakdown
- [x] `node scripts/stale-session-sweep.cjs` runs end-to-end; pre-migration fallback path confirmed on legacy sessions
- [ ] E2E: spawn a fresh CC session, observe tick process advancing `process_alive_at` every 30s (requires restart to exercise SessionStart hook)
- [ ] E2E: kill CC parent, confirm tick self-terminates within 5s
- [ ] p95 hook latency benchmark (pre/post) — targets <5% regression

## Related

- SD: SD-LEO-INFRA-WORKER-SOURCE-SIDE-001
- PRD: bff23cff-db76-4d03-a0b8-0d6787727031
- Companion SD: SD-LEO-INFRA-FLEET-LIVENESS-MONTE-001 (MC-based fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)