### PR TITLE
feat(SD-FIX-S17-WIRING-GAPS-ORCH-001-B): register 4 S17 artifact types

### DIFF
--- a/database/migrations/20260417_s17_artifact_types.sql
+++ b/database/migrations/20260417_s17_artifact_types.sql
@@ -1,0 +1,136 @@
+-- Migration: Add 4 S17 Design Refinement artifact types to venture_artifacts CHECK constraint
+-- SD: SD-FIX-S17-WIRING-GAPS-ORCH-001-B
+-- Ref: ARCH-S17-DESIGN-REFINEMENT-001 § Data Layer
+-- Date: 2026-04-17
+--
+-- New types: design_token_manifest, s17_archetypes, s17_session_state, s17_approved
+-- Also adds partial composite index for Stage-17 query patterns.
+--
+-- Safety: CHECK constraint replacement does not rewrite the table.
+--         Brief AccessExclusive lock on the catalog only. Zero downtime.
+--         Existing rows are not re-validated.
+
+BEGIN;
+
+-- Drop existing constraint
+ALTER TABLE venture_artifacts
+  DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+-- Recreate with all existing 90 types + 4 new S17 types (total: 94)
+ALTER TABLE venture_artifacts
+  ADD CONSTRAINT venture_artifacts_artifact_type_check
+  CHECK (((artifact_type)::text = ANY (ARRAY[
+    'intake_venture_analysis'::text,
+    'truth_idea_brief'::text,
+    'truth_ai_critique'::text,
+    'truth_validation_decision'::text,
+    'truth_competitive_analysis'::text,
+    'truth_financial_model'::text,
+    'truth_problem_statement'::text,
+    'truth_target_market_analysis'::text,
+    'truth_value_proposition'::text,
+    'engine_risk_matrix'::text,
+    'engine_pricing_model'::text,
+    'engine_business_model_canvas'::text,
+    'engine_exit_strategy'::text,
+    'engine_risk_assessment'::text,
+    'engine_revenue_model'::text,
+    'identity_persona_brand'::text,
+    'identity_brand_guidelines'::text,
+    'identity_naming_visual'::text,
+    'identity_brand_name'::text,
+    'identity_gtm_sales_strategy'::text,
+    'blueprint_product_roadmap'::text,
+    'blueprint_technical_architecture'::text,
+    'blueprint_data_model'::text,
+    'blueprint_erd_diagram'::text,
+    'blueprint_api_contract'::text,
+    'blueprint_schema_spec'::text,
+    'blueprint_risk_register'::text,
+    'blueprint_user_story_pack'::text,
+    'blueprint_wireframes'::text,
+    'blueprint_financial_projection'::text,
+    'blueprint_launch_readiness'::text,
+    'blueprint_sprint_plan'::text,
+    'blueprint_promotion_gate'::text,
+    'blueprint_project_plan'::text,
+    'blueprint_review_summary'::text,
+    'build_system_prompt'::text,
+    'build_cicd_config'::text,
+    'build_security_audit'::text,
+    'build_mvp_build'::text,
+    'build_test_coverage_report'::text,
+    'launch_test_plan'::text,
+    'launch_uat_report'::text,
+    'launch_deployment_runbook'::text,
+    'launch_marketing_checklist'::text,
+    'launch_analytics_dashboard'::text,
+    'launch_health_scoring'::text,
+    'launch_churn_triggers'::text,
+    'launch_retention_playbook'::text,
+    'launch_optimization_roadmap'::text,
+    'launch_assumptions_vs_reality'::text,
+    'launch_launch_metrics'::text,
+    'launch_user_feedback_summary'::text,
+    'launch_production_app'::text,
+    'system_devils_advocate_review'::text,
+    'value_multiplier_assessment'::text,
+    'economic_lens'::text,
+    'lifecycle_sd_bridge'::text,
+    'post_lifecycle_decision'::text,
+    'stitch_project'::text,
+    'stitch_curation'::text,
+    'stitch_budget'::text,
+    'stage_0_analysis'::text,
+    'stage_1_analysis'::text,
+    'stage_2_analysis'::text,
+    'stage_3_analysis'::text,
+    'stage_4_analysis'::text,
+    'stage_5_analysis'::text,
+    'stage_6_analysis'::text,
+    'stage_7_analysis'::text,
+    'stage_8_analysis'::text,
+    'stage_9_analysis'::text,
+    'stage_10_analysis'::text,
+    'stage_11_analysis'::text,
+    'stage_12_analysis'::text,
+    'stage_13_analysis'::text,
+    'stage_14_analysis'::text,
+    'stage_15_analysis'::text,
+    'stage_16_analysis'::text,
+    'stage_17_analysis'::text,
+    'stage_18_analysis'::text,
+    'stage_19_analysis'::text,
+    'stage_20_analysis'::text,
+    'stage_21_analysis'::text,
+    'stage_22_analysis'::text,
+    'stage_23_analysis'::text,
+    'stage_24_analysis'::text,
+    'stage_25_analysis'::text,
+    'stage_26_analysis'::text,
+    'stitch_design_export'::text,
+    'stitch_qa_report'::text,
+    -- S17 Design Refinement types (new)
+    'design_token_manifest'::text,
+    's17_archetypes'::text,
+    's17_session_state'::text,
+    's17_approved'::text
+  ])));
+
+-- Partial composite index for Stage-17 read queries
+-- Only indexes the 4 new S17 types to minimize write overhead
+CREATE INDEX IF NOT EXISTS idx_venture_artifacts_s17
+  ON venture_artifacts (venture_id, artifact_type)
+  WHERE artifact_type IN ('design_token_manifest', 's17_archetypes', 's17_session_state', 's17_approved');
+
+COMMIT;
+
+-- ROLLBACK block (restore original constraint without S17 types):
+--   BEGIN;
+--   DROP INDEX IF EXISTS idx_venture_artifacts_s17;
+--   ALTER TABLE venture_artifacts DROP CONSTRAINT venture_artifacts_artifact_type_check;
+--   ALTER TABLE venture_artifacts ADD CONSTRAINT venture_artifacts_artifact_type_check
+--     CHECK (((artifact_type)::text = ANY (ARRAY[
+--       ... (90 original values from 20260409 migration) ...
+--     ])));
+--   COMMIT;

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -94,6 +94,16 @@ export const ARTIFACT_TYPES = Object.freeze({
   LAUNCH_USER_FEEDBACK_SUMMARY: 'launch_user_feedback_summary',
   LAUNCH_PRODUCTION_APP: 'launch_production_app',
 
+  // Stage 17 — Design Refinement (ARCH-S17-DESIGN-REFINEMENT-001 § Data Layer)
+  /** Immutable design token manifest produced by S17 archetype selection */
+  BLUEPRINT_DESIGN_TOKEN_MANIFEST: 'design_token_manifest',
+  /** S17 archetype candidates and selection rationale */
+  BLUEPRINT_S17_ARCHETYPES: 's17_archetypes',
+  /** S17 session state for resumable design refinement workflows */
+  BLUEPRINT_S17_SESSION_STATE: 's17_session_state',
+  /** Final S17-approved design refinement output */
+  BLUEPRINT_S17_APPROVED: 's17_approved',
+
   // Cross-cutting — Stitch Integration
   BLUEPRINT_STITCH_PROJECT: 'stitch_project',
   BLUEPRINT_STITCH_CURATION: 'stitch_curation',
@@ -203,7 +213,13 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
     ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN,
     ARTIFACT_TYPES.BLUEPRINT_PROMOTION_GATE,
   ],
-  17: [ARTIFACT_TYPES.BLUEPRINT_REVIEW_SUMMARY],
+  17: [
+    ARTIFACT_TYPES.BLUEPRINT_REVIEW_SUMMARY,
+    ARTIFACT_TYPES.BLUEPRINT_DESIGN_TOKEN_MANIFEST,
+    ARTIFACT_TYPES.BLUEPRINT_S17_ARCHETYPES,
+    ARTIFACT_TYPES.BLUEPRINT_S17_SESSION_STATE,
+    ARTIFACT_TYPES.BLUEPRINT_S17_APPROVED,
+  ],
   20: [ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
   21: [ARTIFACT_TYPES.LAUNCH_TEST_PLAN, ARTIFACT_TYPES.LAUNCH_UAT_REPORT],
   22: [ARTIFACT_TYPES.LAUNCH_DEPLOYMENT_RUNBOOK],

--- a/tests/database/s17-artifact-types.test.js
+++ b/tests/database/s17-artifact-types.test.js
@@ -1,0 +1,156 @@
+/**
+ * S17 Artifact Type Registration Tests
+ * SD: SD-FIX-S17-WIRING-GAPS-ORCH-001-B
+ * Ref: ARCH-S17-DESIGN-REFINEMENT-001 § Data Layer
+ *
+ * Validates:
+ * - 4 new S17 types exported from artifact-types.js
+ * - Migration file structure and content
+ * - No regression on existing types
+ * - Stage 17 mapping includes new types
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import {
+  ARTIFACT_TYPES,
+  ARTIFACT_TYPE_BY_STAGE,
+  isValidArtifactType,
+  getStageForArtifactType,
+} from '../../lib/eva/artifact-types.js';
+
+const S17_NEW_TYPES = [
+  'design_token_manifest',
+  's17_archetypes',
+  's17_session_state',
+  's17_approved',
+];
+
+const S17_CONSTANTS = [
+  'BLUEPRINT_DESIGN_TOKEN_MANIFEST',
+  'BLUEPRINT_S17_ARCHETYPES',
+  'BLUEPRINT_S17_SESSION_STATE',
+  'BLUEPRINT_S17_APPROVED',
+];
+
+describe('S17 Artifact Type Registration', () => {
+  describe('artifact-types.js exports', () => {
+    it('exports all 4 new S17 constants', () => {
+      for (const constant of S17_CONSTANTS) {
+        expect(ARTIFACT_TYPES).toHaveProperty(constant);
+      }
+    });
+
+    it('constants map to correct string values', () => {
+      expect(ARTIFACT_TYPES.BLUEPRINT_DESIGN_TOKEN_MANIFEST).toBe('design_token_manifest');
+      expect(ARTIFACT_TYPES.BLUEPRINT_S17_ARCHETYPES).toBe('s17_archetypes');
+      expect(ARTIFACT_TYPES.BLUEPRINT_S17_SESSION_STATE).toBe('s17_session_state');
+      expect(ARTIFACT_TYPES.BLUEPRINT_S17_APPROVED).toBe('s17_approved');
+    });
+
+    it('all 4 new types pass isValidArtifactType', () => {
+      for (const type of S17_NEW_TYPES) {
+        expect(isValidArtifactType(type)).toBe(true);
+      }
+    });
+
+    it('all 4 new types map to stage 17', () => {
+      for (const type of S17_NEW_TYPES) {
+        expect(getStageForArtifactType(type)).toBe(17);
+      }
+    });
+
+    it('stage 17 includes all 4 new types plus existing BLUEPRINT_REVIEW_SUMMARY', () => {
+      const stage17Types = ARTIFACT_TYPE_BY_STAGE[17];
+      expect(stage17Types).toContain('blueprint_review_summary');
+      for (const type of S17_NEW_TYPES) {
+        expect(stage17Types).toContain(type);
+      }
+    });
+  });
+
+  describe('no regression on existing types', () => {
+    const EXISTING_TYPES = [
+      'intake_venture_analysis',
+      'truth_idea_brief',
+      'truth_ai_critique',
+      'engine_risk_matrix',
+      'identity_persona_brand',
+      'blueprint_product_roadmap',
+      'blueprint_review_summary',
+      'build_system_prompt',
+      'launch_test_plan',
+      'system_devils_advocate_review',
+      'stitch_project',
+      'stitch_curation',
+      'value_multiplier_assessment',
+    ];
+
+    it('all sampled existing types still valid', () => {
+      for (const type of EXISTING_TYPES) {
+        expect(isValidArtifactType(type)).toBe(true);
+      }
+    });
+  });
+
+  describe('migration file', () => {
+    const migrationPath = resolve(
+      import.meta.dirname,
+      '../../database/migrations/20260417_s17_artifact_types.sql'
+    );
+    let migrationContent;
+
+    it('migration file exists', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      expect(migrationContent).toBeTruthy();
+    });
+
+    it('migration is transactional (BEGIN/COMMIT)', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      expect(migrationContent).toMatch(/^BEGIN;/m);
+      expect(migrationContent).toMatch(/^COMMIT;/m);
+    });
+
+    it('migration drops old constraint before recreating', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      const dropIdx = migrationContent.indexOf('DROP CONSTRAINT venture_artifacts_artifact_type_check');
+      const addIdx = migrationContent.indexOf('ADD CONSTRAINT venture_artifacts_artifact_type_check');
+      expect(dropIdx).toBeGreaterThan(-1);
+      expect(addIdx).toBeGreaterThan(dropIdx);
+    });
+
+    it('migration includes all 4 new S17 types', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      for (const type of S17_NEW_TYPES) {
+        expect(migrationContent).toContain(`'${type}'::text`);
+      }
+    });
+
+    it('migration preserves existing types (spot check)', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      expect(migrationContent).toContain("'intake_venture_analysis'::text");
+      expect(migrationContent).toContain("'stitch_qa_report'::text");
+      expect(migrationContent).toContain("'blueprint_review_summary'::text");
+    });
+
+    it('migration creates partial composite index', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      expect(migrationContent).toContain('idx_venture_artifacts_s17');
+      expect(migrationContent).toContain('venture_id, artifact_type');
+      expect(migrationContent).toMatch(/WHERE artifact_type IN/);
+    });
+
+    it('migration includes rollback documentation', () => {
+      migrationContent = readFileSync(migrationPath, 'utf-8');
+      expect(migrationContent).toMatch(/ROLLBACK/i);
+    });
+  });
+
+  describe('unknown types rejected', () => {
+    it('isValidArtifactType rejects unknown type', () => {
+      expect(isValidArtifactType('totally_fake_type')).toBe(false);
+      expect(isValidArtifactType('')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 S17 Design Refinement artifact types (`design_token_manifest`, `s17_archetypes`, `s17_session_state`, `s17_approved`) to `venture_artifacts` CHECK constraint
- Export new constants from `lib/eva/artifact-types.js` with Stage 17 mapping
- Create partial composite index `idx_venture_artifacts_s17` for S17 queries
- Unblocks Child A endpoint persistence (SD-FIX-S17-WIRING-GAPS-ORCH-001-A)

## Test plan
- [x] 14/14 unit tests pass (artifact-types exports, migration structure, regression checks)
- [x] Migration applied to production DB — CHECK constraint verified
- [x] Partial index `idx_venture_artifacts_s17` confirmed in DB
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)