### PR TITLE
feat(SD-FIX-S17-WIRING-GAPS-ORCH-001-C): S17 module tests + generateFillScreens

### DIFF
--- a/lib/eva/stage-17/qa-rubric.js
+++ b/lib/eva/stage-17/qa-rubric.js
@@ -13,14 +13,28 @@
  * Exports:
  *   runQARubric(ventureId, supabase)
  *   uploadToGitHub(ventureId, supabase, options)
+ *   generateFillScreens(missingScreens, context) — auto-generate missing screen HTML
  *
  * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-E
  * @module lib/eva/stage-17/qa-rubric
  */
 
 import { getTokenConstraints } from './token-manifest.js';
+import { writeArtifact } from '../artifact-persistence-service.js';
 
 const EXPECTED_APPROVED_COUNT = 14; // 7 screens × 2 platforms
+const MAX_FILL_CALLS_PER_RUN = 3;
+
+/** Per-run meter tracking fill generation calls. Keyed by `${ventureId}:${qaRunId}`. */
+const fillMeter = new Map();
+
+// Clean up stale meter entries after 1 hour
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of fillMeter) {
+    if (now - entry.createdAt > 3_600_000) fillMeter.delete(key);
+  }
+}, 300_000).unref();
 
 /**
  * Upload error thrown when HIGH-severity QA gaps block GitHub upload.
@@ -325,4 +339,92 @@ export async function uploadToGitHub(ventureId, supabase, options = {}) {
   }
 
   return { filesUploaded, commitSha: lastCommitSha };
+}
+
+/**
+ * Generate HTML fill screens for missing screens identified by QA rubric.
+ * Calls Claude via getValidationClient() and caches results in venture_artifacts.
+ * Metered: max 3 LLM calls per QA run to prevent runaway cost.
+ *
+ * @param {string[]} missingScreens - Array of missing screen name strings
+ * @param {object} context
+ * @param {string} context.ventureId - Venture ID for artifact storage
+ * @param {object} [context.brandTokens] - Locked brand token manifest
+ * @param {string} [context.existingHtml] - Reference HTML from existing screens
+ * @param {string} [context.qaRunId] - Unique QA run identifier (auto-generated if omitted)
+ * @param {object} [context.supabase] - Supabase client for caching
+ * @returns {Promise<{ screens: Array<{screenName: string, html: string}>, capped: boolean, generated: number }>}
+ */
+export async function generateFillScreens(missingScreens, context = {}) {
+  const { ventureId, brandTokens, existingHtml, supabase } = context;
+  const qaRunId = context.qaRunId ?? `run-${Date.now()}`;
+  const meterKey = `${ventureId}:${qaRunId}`;
+
+  if (!fillMeter.has(meterKey)) {
+    fillMeter.set(meterKey, { count: 0, createdAt: Date.now() });
+  }
+  const meter = fillMeter.get(meterKey);
+
+  if (meter.count >= MAX_FILL_CALLS_PER_RUN) {
+    return { screens: [], capped: true, generated: meter.count };
+  }
+
+  const remaining = MAX_FILL_CALLS_PER_RUN - meter.count;
+  const screensToFill = missingScreens.slice(0, remaining);
+
+  const { getValidationClient } = await import('../../llm/client-factory.js');
+  const client = getValidationClient();
+
+  const colorList = (brandTokens?.colors ?? []).slice(0, 5).join(', ') || 'brand primary, brand secondary';
+  const headingFont = brandTokens?.typeScale?.heading ?? 'serif';
+  const bodyFont = brandTokens?.typeScale?.body ?? 'sans-serif';
+
+  const screens = [];
+
+  for (const screenName of screensToFill) {
+    const prompt = `Generate a complete, self-contained HTML page for the missing screen "${screenName}".
+
+BRAND TOKENS (LOCKED — do not deviate):
+- Colors: ${colorList}
+- Heading font: ${headingFont}
+- Body font: ${bodyFont}
+- Spacing: 4px grid (4, 8, 16, 24, 32, 48px)
+
+${existingHtml ? `REFERENCE (existing screen for style consistency):\n${existingHtml.slice(0, 2000)}\n` : ''}
+REQUIREMENTS:
+1. Self-contained HTML with inline CSS only (no external links or scripts)
+2. Apply locked brand colors using CSS custom properties
+3. Use locked fonts via font-family declarations
+4. Include navigation structure and at least one CTA element
+5. Output ONLY the HTML — no explanation, no markdown fences`;
+
+    const response = await client.complete(prompt);
+    const html = typeof response === 'string' ? response : (response?.text ?? response?.content?.[0]?.text ?? '');
+
+    screens.push({ screenName, html });
+    meter.count++;
+
+    // Cache in venture_artifacts if supabase provided
+    if (supabase && ventureId) {
+      try {
+        await writeArtifact(supabase, {
+          ventureId,
+          lifecycleStage: 17,
+          artifactType: 's17_archetypes',
+          title: `Gap Fill: ${screenName}`,
+          content: html,
+          artifactData: { screenName, source: 'generateFillScreens', qaRunId },
+          qualityScore: 70,
+          validationStatus: 'pending',
+          source: 'stage-17-qa-rubric-fill',
+          metadata: { screenName, qaRunId, generatedAt: new Date().toISOString() },
+        });
+      } catch (e) {
+        // Non-blocking: cache failure should not prevent fill screen return
+        console.warn(`[qa-rubric] Failed to cache fill screen ${screenName}:`, e?.message);
+      }
+    }
+  }
+
+  return { screens, capped: false, generated: meter.count };
 }

--- a/tests/unit/stage-17/archetype-generator.test.js
+++ b/tests/unit/stage-17/archetype-generator.test.js
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import {
+  generateArchetypes,
+  generateRefinedVariants,
+  ArchetypeGenerationError,
+} from '../../../lib/eva/stage-17/archetype-generator.js';
+
+vi.mock('../../../lib/eva/stage-17/token-manifest.js', () => ({
+  getTokenConstraints: vi.fn().mockResolvedValue({
+    colors: ['#FF5733', '#3366CC', '#22AA44'],
+    typeScale: { heading: 'Inter', body: 'Roboto' },
+    spacing: { base: 4 },
+  }),
+}));
+
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: vi.fn().mockResolvedValue('artifact-id-mock'),
+}));
+
+const mockMessagesCreate = vi.fn().mockResolvedValue({
+  content: [{ text: '<html><body style="color:#FF5733;font-family:Inter"><h1>Archetype</h1></body></html>' }],
+});
+
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  createLLMClient: vi.fn().mockResolvedValue({
+    messages: { create: mockMessagesCreate },
+  }),
+}));
+
+import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
+
+function createMockSupabase(artifacts = []) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: artifacts, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('archetype-generator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMessagesCreate.mockResolvedValue({
+      content: [{ text: '<html><body style="color:#FF5733;font-family:Inter"><h1>Archetype</h1></body></html>' }],
+    });
+  });
+
+  describe('generateArchetypes()', () => {
+    test('returns 6 artifact IDs per screen', async () => {
+      const artifacts = [
+        { id: 'screen-1', content: '<div>Screen 1</div>', title: 'Home', metadata: { screenName: 'Home' } },
+      ];
+      const result = await generateArchetypes('venture-123', createMockSupabase(artifacts));
+
+      expect(result.screenCount).toBe(1);
+      expect(result.artifactIds).toHaveLength(6);
+      expect(mockMessagesCreate).toHaveBeenCalledTimes(6);
+    });
+
+    test('applies brand tokens in prompt', async () => {
+      const artifacts = [{ id: 's1', content: '<div>S</div>', title: 'Home', metadata: {} }];
+      await generateArchetypes('v-1', createMockSupabase(artifacts));
+
+      const prompt = mockMessagesCreate.mock.calls[0][0].messages[0].content;
+      expect(prompt).toContain('#FF5733');
+      expect(prompt).toContain('Inter');
+      expect(prompt).toContain('Roboto');
+    });
+
+    test('throws ArchetypeGenerationError when no stitch artifacts', async () => {
+      await expect(generateArchetypes('v-empty', createMockSupabase([]))).rejects.toThrow(ArchetypeGenerationError);
+    });
+
+    test('propagates LLM client errors', async () => {
+      mockMessagesCreate.mockRejectedValueOnce(new Error('Claude API unavailable'));
+      const artifacts = [{ id: 's1', content: '<div>S</div>', title: 'Home', metadata: {} }];
+
+      await expect(generateArchetypes('v-1', createMockSupabase(artifacts))).rejects.toThrow('Claude API unavailable');
+    });
+
+    test('writes self-contained HTML (no external scripts/links)', async () => {
+      const html = '<html><style>body{color:#FF5733}</style><body><h1>Test</h1></body></html>';
+      mockMessagesCreate.mockResolvedValue({ content: [{ text: html }] });
+      const artifacts = [{ id: 's1', content: '<div>S</div>', title: 'Home', metadata: {} }];
+
+      await generateArchetypes('v-1', createMockSupabase(artifacts));
+
+      const written = writeArtifact.mock.calls[0][1].content;
+      expect(written).not.toContain('<script src=');
+      expect(written).not.toContain('<link rel="stylesheet"');
+    });
+
+    test('processes multiple screens (12 artifacts for 2 screens)', async () => {
+      const artifacts = [
+        { id: 's1', content: '<div>S1</div>', title: 'Home', metadata: {} },
+        { id: 's2', content: '<div>S2</div>', title: 'About', metadata: {} },
+      ];
+      const result = await generateArchetypes('v-1', createMockSupabase(artifacts));
+
+      expect(result.screenCount).toBe(2);
+      expect(result.artifactIds).toHaveLength(12);
+    });
+  });
+
+  describe('generateRefinedVariants()', () => {
+    test('generates 4 refined variants', async () => {
+      const ids = await generateRefinedVariants('v-1', 'Home', ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } }, {});
+      expect(ids).toHaveLength(4);
+      expect(mockMessagesCreate).toHaveBeenCalledTimes(4);
+    });
+
+    test('injects mobile context for desktop', async () => {
+      await generateRefinedVariants('v-1', 'Home', ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } }, {},
+        { mobileContextHtml: '<html>Mobile</html>' });
+
+      const prompt = mockMessagesCreate.mock.calls[0][0].messages[0].content;
+      expect(prompt).toContain('MOBILE REFERENCE');
+    });
+  });
+});

--- a/tests/unit/stage-17/qa-rubric.test.js
+++ b/tests/unit/stage-17/qa-rubric.test.js
@@ -1,0 +1,199 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { runQARubric, generateFillScreens, UploadError } from '../../../lib/eva/stage-17/qa-rubric.js';
+
+vi.mock('../../../lib/eva/stage-17/token-manifest.js', () => ({
+  getTokenConstraints: vi.fn().mockResolvedValue({
+    colors: ['#ff5733', '#3366cc'],
+    typeScale: { heading: 'Inter', body: 'Roboto' },
+  }),
+}));
+
+const mockWriteArtifact = vi.fn().mockResolvedValue('cached-artifact-id');
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: (...args) => mockWriteArtifact(...args),
+}));
+
+const mockComplete = vi.fn().mockResolvedValue(
+  '<html><nav>Nav</nav><button>CTA</button><body style="color:#ff5733">Generated</body></html>'
+);
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  getValidationClient: vi.fn(() => ({ complete: mockComplete })),
+}));
+
+import { getTokenConstraints } from '../../../lib/eva/stage-17/token-manifest.js';
+
+function makeArtifact(id, type, content, metadata = {}) {
+  return { id, artifact_type: type, content, metadata, title: `Screen ${id}` };
+}
+
+function createMockSupabase(artifacts = []) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: artifacts, error: null }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('qa-rubric', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComplete.mockResolvedValue(
+      '<html><nav>Nav</nav><button>CTA</button><body style="color:#ff5733">Generated</body></html>'
+    );
+  });
+
+  describe('runQARubric() — Layer 1: Base completeness', () => {
+    test('returns HIGH when fewer than 14 artifacts', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile', '<html><nav></nav><button>CTA</button></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.highCount).toBeGreaterThan(0);
+      expect(result.layers.base.score).toBeLessThan(100);
+    });
+
+    test('returns 100 base score with all 14 artifacts', async () => {
+      const artifacts = [];
+      for (let i = 0; i < 7; i++) {
+        artifacts.push(makeArtifact(`m${i}`, 'stage_17_approved_mobile',
+          '<html><nav></nav><button>CTA</button><body style="color:#ff5733">M</body></html>'));
+        artifacts.push(makeArtifact(`d${i}`, 'stage_17_approved_desktop',
+          '<html><nav></nav><button>CTA</button><body style="color:#ff5733">D</body></html>'));
+      }
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.layers.base.score).toBe(100);
+    });
+  });
+
+  describe('runQARubric() — Layer 2: Product spec', () => {
+    test('flags missing navigation as MED', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile', '<html><button>CTA</button></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      const navGap = result.items.find(i => i.layer === 2 && i.description.includes('navigation'));
+      expect(navGap).toBeTruthy();
+      expect(navGap.severity).toBe('MED');
+    });
+
+    test('flags missing CTA as MED', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile', '<html><nav>Nav</nav><p>Text</p></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      const ctaGap = result.items.find(i => i.layer === 2 && i.description.includes('CTA'));
+      expect(ctaGap).toBeTruthy();
+    });
+
+    test('passes when nav and CTA present', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile',
+        '<html><nav>Menu</nav><button type="submit">Go</button></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.layers.product.score).toBe(100);
+    });
+  });
+
+  describe('runQARubric() — Layer 3: Brand token consistency', () => {
+    test('flags missing brand colors as HIGH', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile',
+        '<html><nav></nav><button>CTA</button><body style="color:blue">X</body></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      const brandGap = result.items.find(i => i.layer === 3 && i.description.includes('brand colors'));
+      expect(brandGap).toBeTruthy();
+      expect(brandGap.severity).toBe('HIGH');
+    });
+
+    test('passes when brand color detected', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile',
+        '<html><nav></nav><button>CTA</button><body style="color:#ff5733">X</body></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.layers.venture.score).toBe(100);
+    });
+
+    test('returns 0 score when no token manifest', async () => {
+      getTokenConstraints.mockResolvedValueOnce(null);
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile', '<html></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.layers.venture.score).toBe(0);
+    });
+  });
+
+  describe('runQARubric() — Overall', () => {
+    test('overall score is average of 3 layers', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile',
+        '<html><nav></nav><button>CTA</button><body style="color:#ff5733">X</body></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      const expected = Math.round((result.layers.base.score + result.layers.product.score + result.layers.venture.score) / 3);
+      expect(result.overallScore).toBe(expected);
+    });
+
+    test('returns correct severity counts', async () => {
+      const artifacts = [makeArtifact('1', 'stage_17_approved_mobile', '<html><p>bare</p></html>')];
+      const result = await runQARubric('v-1', createMockSupabase(artifacts));
+      expect(result.highCount + result.medCount + result.lowCount).toBe(result.items.length);
+    });
+  });
+
+  describe('generateFillScreens()', () => {
+    test('generates HTML for missing screens', async () => {
+      const result = await generateFillScreens(['Dashboard', 'Settings'], {
+        ventureId: 'v-test',
+        brandTokens: { colors: ['#ff5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        qaRunId: 'test-run-1',
+      });
+      expect(result.screens).toHaveLength(2);
+      expect(result.screens[0].screenName).toBe('Dashboard');
+      expect(result.screens[0].html).toBeTruthy();
+      expect(result.capped).toBe(false);
+      expect(result.generated).toBe(2);
+    });
+
+    test('calls Claude via getValidationClient().complete()', async () => {
+      await generateFillScreens(['Screen1'], {
+        ventureId: 'v-test', qaRunId: 'test-run-2',
+      });
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('caps at 3 calls per QA run', async () => {
+      const qaRunId = 'test-run-cap-' + Date.now();
+      const r1 = await generateFillScreens(['A', 'B', 'C'], { ventureId: 'v-test', qaRunId });
+      expect(r1.screens).toHaveLength(3);
+      expect(r1.capped).toBe(false);
+      expect(r1.generated).toBe(3);
+
+      const r2 = await generateFillScreens(['D'], { ventureId: 'v-test', qaRunId });
+      expect(r2.screens).toHaveLength(0);
+      expect(r2.capped).toBe(true);
+      expect(r2.generated).toBe(3);
+    });
+
+    test('caches in venture_artifacts when supabase provided', async () => {
+      await generateFillScreens(['Dashboard'], {
+        ventureId: 'v-test',
+        qaRunId: 'test-run-cache-' + Date.now(),
+        supabase: createMockSupabase(),
+      });
+      expect(mockWriteArtifact).toHaveBeenCalledTimes(1);
+      expect(mockWriteArtifact.mock.calls[0][1].artifactType).toBe('s17_archetypes');
+    });
+
+    test('returns {screenName, html}[] shape', async () => {
+      const result = await generateFillScreens(['TestScreen'], {
+        ventureId: 'v-test', qaRunId: 'test-run-shape-' + Date.now(),
+      });
+      expect(Array.isArray(result.screens)).toBe(true);
+      expect(result.screens[0]).toHaveProperty('screenName');
+      expect(result.screens[0]).toHaveProperty('html');
+    });
+  });
+
+  describe('UploadError', () => {
+    test('captures gaps array', () => {
+      const gaps = [{ description: 'Missing screen', severity: 'HIGH' }];
+      const err = new UploadError('Blocked', gaps);
+      expect(err.name).toBe('UploadError');
+      expect(err.gaps).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/stage-17/selection-flow.test.js
+++ b/tests/unit/stage-17/selection-flow.test.js
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import {
+  submitPass1Selection,
+  submitPass2Selection,
+  isDesignPassComplete,
+  SelectionError,
+} from '../../../lib/eva/stage-17/selection-flow.js';
+
+const mockGenerateRefinedVariants = vi.fn().mockResolvedValue(['ref-1', 'ref-2', 'ref-3', 'ref-4']);
+
+vi.mock('../../../lib/eva/stage-17/archetype-generator.js', () => ({
+  generateRefinedVariants: (...args) => mockGenerateRefinedVariants(...args),
+}));
+
+vi.mock('../../../lib/eva/stage-17/token-manifest.js', () => ({
+  getTokenConstraints: vi.fn().mockResolvedValue({
+    colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' },
+  }),
+}));
+
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: vi.fn().mockResolvedValue('approved-artifact-id'),
+}));
+
+import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
+
+function createMockSupabase(opts = {}) {
+  const { artifactContent = '<html>Test</html>', metadata = {}, count = 0 } = opts;
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockImplementation((sel, selectOpts) => {
+        if (selectOpts?.count === 'exact') {
+          return {
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockResolvedValue({ count, error: null }),
+              }),
+            }),
+          };
+        }
+        return {
+          eq: vi.fn().mockImplementation((col, val) => ({
+            single: vi.fn().mockResolvedValue({
+              data: { id: val, content: artifactContent, artifact_data: {}, metadata, title: 'Screen', artifact_type: 'stage_17_archetype' },
+              error: null,
+            }),
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                contains: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: [{ content: '<html>Mobile</html>' }], error: null }),
+                }),
+              }),
+            }),
+          })),
+        };
+      }),
+    }),
+  };
+}
+
+describe('selection-flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateRefinedVariants.mockResolvedValue(['ref-1', 'ref-2', 'ref-3', 'ref-4']);
+  });
+
+  describe('submitPass1Selection()', () => {
+    test('accepts 2 selections and returns 4 refined IDs', async () => {
+      const result = await submitPass1Selection('v-1', 'home', ['id-1', 'id-2'], createMockSupabase());
+      expect(result.refinedArtifactIds).toHaveLength(4);
+    });
+
+    test('throws SelectionError for 3 selections (max-2)', async () => {
+      await expect(
+        submitPass1Selection('v-1', 'home', ['a', 'b', 'c'], createMockSupabase())
+      ).rejects.toThrow(SelectionError);
+    });
+
+    test('throws SelectionError for 1 selection', async () => {
+      await expect(
+        submitPass1Selection('v-1', 'home', ['a'], createMockSupabase())
+      ).rejects.toThrow(SelectionError);
+    });
+
+    test('throws SelectionError for invalid platform', async () => {
+      await expect(
+        submitPass1Selection('v-1', 'home', ['a', 'b'], createMockSupabase(), { platform: 'tablet' })
+      ).rejects.toThrow(SelectionError);
+    });
+
+    test('is idempotent — consistent output shape', async () => {
+      const r1 = await submitPass1Selection('v-1', 'home', ['a', 'b'], createMockSupabase());
+      const r2 = await submitPass1Selection('v-1', 'home', ['a', 'b'], createMockSupabase());
+      expect(r1.refinedArtifactIds.length).toBe(r2.refinedArtifactIds.length);
+    });
+
+    test('passes mobile context for desktop platform', async () => {
+      await submitPass1Selection('v-1', 'home', ['a', 'b'], createMockSupabase(), { platform: 'desktop' });
+      const callArgs = mockGenerateRefinedVariants.mock.calls[0];
+      expect(callArgs[5].mobileContextHtml).toBeTruthy();
+    });
+  });
+
+  describe('submitPass2Selection()', () => {
+    test('creates approved mobile artifact', async () => {
+      const result = await submitPass2Selection('v-1', 'home', 'mobile', 'ref-1', createMockSupabase());
+      expect(result.approvedArtifactId).toBe('approved-artifact-id');
+      expect(writeArtifact.mock.calls[0][1].artifactType).toBe('stage_17_approved_mobile');
+    });
+
+    test('creates approved desktop artifact', async () => {
+      await submitPass2Selection('v-1', 'home', 'desktop', 'ref-1', createMockSupabase());
+      expect(writeArtifact.mock.calls[0][1].artifactType).toBe('stage_17_approved_desktop');
+    });
+
+    test('rejects invalid platform', async () => {
+      await expect(
+        submitPass2Selection('v-1', 'home', 'tablet', 'ref-1', createMockSupabase())
+      ).rejects.toThrow(SelectionError);
+    });
+  });
+
+  describe('isDesignPassComplete()', () => {
+    test('returns true at 14 approved artifacts', async () => {
+      expect(await isDesignPassComplete('v-1', createMockSupabase({ count: 14 }))).toBe(true);
+    });
+
+    test('returns false below 14', async () => {
+      expect(await isDesignPassComplete('v-1', createMockSupabase({ count: 10 }))).toBe(false);
+    });
+
+    test('returns true above 14', async () => {
+      expect(await isDesignPassComplete('v-1', createMockSupabase({ count: 20 }))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 3 untested S17 modules: archetype-generator.js, selection-flow.js, qa-rubric.js
- Implement `generateFillScreens()` in qa-rubric.js to auto-generate missing screen HTML via Claude
- 36 tests across 3 vitest test files, all passing
- Metered LLM calls (max 3 per QA run), caches in venture_artifacts

## Test plan
- [x] `npx vitest run tests/unit/stage-17/` — 36/36 tests pass
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [ ] Integration test for end-to-end auto-fill path (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)