### PR TITLE
feat(SD-FIX-S17-WIRING-GAPS-ORCH-001-A): wire 6 S17 endpoints to orphaned backend modules

### DIFF
--- a/server/routes/stitch.js
+++ b/server/routes/stitch.js
@@ -20,6 +20,9 @@ import { isValidUuid } from '../middleware/validate.js';
 import { exportStitchArtifacts } from '../../lib/eva/bridge/stitch-exporter.js';
 import { getVentureMetrics, getFleetHealth, detectDegradation } from '../../lib/eva/bridge/stitch-metrics.js';
 import { checkCurationStatus } from '../../lib/eva/bridge/stitch-provisioner.js';
+import { generateArchetypes, ArchetypeGenerationError } from '../../lib/eva/stage-17/archetype-generator.js';
+import { submitPass1Selection, submitPass2Selection, isDesignPassComplete, SelectionError } from '../../lib/eva/stage-17/selection-flow.js';
+import { runQARubric, uploadToGitHub, UploadError } from '../../lib/eva/stage-17/qa-rubric.js';
 
 const router = Router();
 
@@ -240,6 +243,255 @@ router.post('/seed-repo', asyncHandler(async (req, res) => {
   } catch (err) {
     console.error('[stitch-route] seed-repo failed:', err);
     res.status(500).json({ error: err.message, code: 'SEED_FAILED' });
+  }
+}));
+
+// ── Stage 17 Design Refinement Endpoints ────────────────────────────────────
+// SD-FIX-S17-WIRING-GAPS-ORCH-001-A: Wire 4 orphaned S17 modules into production API path.
+// Auth is applied at the router mount level (requireAuth in server/index.js).
+
+/** Per-venture rate limiter for archetype generation (1 call per 10s per venture). */
+const archetypeRateLimiter = new Map();
+const ARCHETYPE_RATE_LIMIT_TTL_MS = 10_000;
+
+// Clean up stale rate limiter entries every 60s
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, ts] of archetypeRateLimiter) {
+    if (now - ts > ARCHETYPE_RATE_LIMIT_TTL_MS) archetypeRateLimiter.delete(key);
+  }
+  for (const [key, ts] of curationRateLimiter) {
+    if (now - ts > RATE_LIMIT_TTL_MS) curationRateLimiter.delete(key);
+  }
+}, 60_000).unref();
+
+/**
+ * POST /api/stitch/:ventureId/stage17/archetypes
+ *
+ * Generates 6 HTML design archetypes per screen by invoking archetype-generator.js.
+ * Rate-limited to 1 call per 10s per venture (generation is expensive — Claude API calls).
+ *
+ * Returns:
+ *   200 { screenCount, artifactIds }
+ *   400 { error, code } — invalid ventureId or missing source artifacts
+ *   429 { error, code, retryAfter } — rate limited
+ *   500 { error, code } — generation error
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-001, US-008)
+ */
+router.post('/:ventureId/stage17/archetypes', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  // Per-venture rate limiting
+  const now = Date.now();
+  const lastCall = archetypeRateLimiter.get(ventureId);
+  if (lastCall && now - lastCall < ARCHETYPE_RATE_LIMIT_TTL_MS) {
+    const retryAfter = Math.ceil((ARCHETYPE_RATE_LIMIT_TTL_MS - (now - lastCall)) / 1000);
+    return res.status(429).json({
+      error: 'Too Many Requests',
+      code: 'RATE_LIMITED',
+      retryAfter,
+    });
+  }
+  archetypeRateLimiter.set(ventureId, now);
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const result = await generateArchetypes(ventureId, supabase);
+    return res.status(200).json(result);
+  } catch (err) {
+    if (err instanceof ArchetypeGenerationError) {
+      return res.status(400).json({ error: err.message, code: 'ARCHETYPE_GENERATION_FAILED' });
+    }
+    console.error('[stitch-route] stage17/archetypes failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'ARCHETYPE_ERROR' });
+  }
+}));
+
+/**
+ * POST /api/stitch/:ventureId/stage17/select
+ *
+ * Pass 1 selection: Chairman selects 2 of 6 archetypes → triggers 4 refined variants.
+ * Body: { screenId: string, selectedIds: string[2] }
+ *
+ * Returns:
+ *   200 { refinedArtifactIds: string[4] }
+ *   400 { error, code } — validation error (wrong count, invalid IDs)
+ *   500 { error, code }
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-002)
+ */
+router.post('/:ventureId/stage17/select', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  const { screenId, selectedIds } = req.body || {};
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  if (!screenId || typeof screenId !== 'string') {
+    return res.status(400).json({ error: 'screenId is required', code: 'MISSING_SCREEN_ID' });
+  }
+
+  if (!Array.isArray(selectedIds) || selectedIds.length !== 2) {
+    return res.status(400).json({ error: 'selectedIds must be an array of exactly 2 IDs', code: 'INVALID_SELECTION_COUNT' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const refinedArtifactIds = await submitPass1Selection(ventureId, screenId, selectedIds, supabase);
+    return res.status(200).json({ refinedArtifactIds });
+  } catch (err) {
+    if (err instanceof SelectionError) {
+      return res.status(400).json({ error: err.message, code: 'SELECTION_ERROR' });
+    }
+    console.error('[stitch-route] stage17/select failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'SELECT_ERROR' });
+  }
+}));
+
+/**
+ * POST /api/stitch/:ventureId/stage17/refine
+ *
+ * Pass 2 selection: Chairman picks final approved design from 4 refined variants.
+ * Body: { screenId: string, platform: "mobile"|"desktop", artifactId: string }
+ *
+ * Returns:
+ *   200 { approvedArtifactId: string }
+ *   400 { error, code } — invalid platform or missing fields
+ *   500 { error, code }
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-003)
+ */
+router.post('/:ventureId/stage17/refine', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  const { screenId, platform, artifactId } = req.body || {};
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  if (!screenId || typeof screenId !== 'string') {
+    return res.status(400).json({ error: 'screenId is required', code: 'MISSING_SCREEN_ID' });
+  }
+
+  if (!platform || !['mobile', 'desktop'].includes(platform)) {
+    return res.status(400).json({ error: 'platform must be "mobile" or "desktop"', code: 'INVALID_PLATFORM' });
+  }
+
+  if (!artifactId || typeof artifactId !== 'string') {
+    return res.status(400).json({ error: 'artifactId is required', code: 'MISSING_ARTIFACT_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const result = await submitPass2Selection(ventureId, screenId, platform, artifactId, supabase);
+    return res.status(200).json({ approvedArtifactId: result });
+  } catch (err) {
+    if (err instanceof SelectionError) {
+      return res.status(400).json({ error: err.message, code: 'SELECTION_ERROR' });
+    }
+    console.error('[stitch-route] stage17/refine failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'REFINE_ERROR' });
+  }
+}));
+
+/**
+ * POST /api/stitch/:ventureId/stage17/approve
+ *
+ * Checks whether all 14 design sessions (7 screens × 2 platforms) are complete.
+ *
+ * Returns:
+ *   200 { complete: boolean, threshold: 14, current: number }
+ *   400 { error, code } — invalid ventureId
+ *   500 { error, code }
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-004)
+ */
+router.post('/:ventureId/stage17/approve', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const result = await isDesignPassComplete(ventureId, supabase);
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error('[stitch-route] stage17/approve failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'APPROVE_ERROR' });
+  }
+}));
+
+/**
+ * POST /api/stitch/:ventureId/stage17/qa
+ *
+ * Runs 3-layer QA rubric on all Stage 17 approved design artifacts.
+ * Layer 1: Completeness (14/14 sessions approved)
+ * Layer 2: HTML product spec validation
+ * Layer 3: Brand token consistency vs locked manifest
+ *
+ * Returns:
+ *   200 { layers, overallScore, counts }
+ *   400 { error, code } — invalid ventureId
+ *   500 { error, code }
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-005)
+ */
+router.post('/:ventureId/stage17/qa', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const result = await runQARubric(ventureId, supabase);
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error('[stitch-route] stage17/qa failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'QA_ERROR' });
+  }
+}));
+
+/**
+ * POST /api/stitch/:ventureId/stage17/upload
+ *
+ * Uploads all 14 approved HTML designs to the venture GitHub repository.
+ * Blocks if HIGH-severity QA gaps exist (must pass QA first).
+ * Validates HTML contains no external <script src="..."> (allow-same-origin sandbox policy).
+ *
+ * Returns:
+ *   200 { filesUploaded, commitSha }
+ *   400 { error, code, gaps } — blocked by QA gaps or script validation
+ *   500 { error, code }
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A (US-006)
+ */
+router.post('/:ventureId/stage17/upload', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  try {
+    const result = await uploadToGitHub(ventureId, supabase, {});
+    return res.status(200).json(result);
+  } catch (err) {
+    if (err instanceof UploadError) {
+      return res.status(400).json({ error: err.message, code: 'UPLOAD_BLOCKED', gaps: err.gaps });
+    }
+    console.error('[stitch-route] stage17/upload failed:', err);
+    return res.status(500).json({ error: sanitizeErrorMessage(err?.message), code: 'UPLOAD_ERROR' });
   }
 }));
 

--- a/tests/integration/api-routes/stage17-endpoints.test.js
+++ b/tests/integration/api-routes/stage17-endpoints.test.js
@@ -1,0 +1,421 @@
+/**
+ * Integration tests for Stage 17 Design Refinement API Endpoints
+ * Tests: POST /stage17/archetypes, /select, /refine, /approve, /qa, /upload
+ *
+ * SD-FIX-S17-WIRING-GAPS-ORCH-001-A
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — S17 modules
+// ---------------------------------------------------------------------------
+
+const mockGenerateArchetypes = vi.fn();
+const mockArchetypeGenerationError = class extends Error {
+  constructor(msg) { super(msg); this.name = 'ArchetypeGenerationError'; }
+};
+
+vi.mock('../../../lib/eva/stage-17/archetype-generator.js', () => ({
+  generateArchetypes: (...args) => mockGenerateArchetypes(...args),
+  ArchetypeGenerationError: mockArchetypeGenerationError,
+}));
+
+const mockSubmitPass1Selection = vi.fn();
+const mockSubmitPass2Selection = vi.fn();
+const mockIsDesignPassComplete = vi.fn();
+const mockSelectionError = class extends Error {
+  constructor(msg) { super(msg); this.name = 'SelectionError'; }
+};
+
+vi.mock('../../../lib/eva/stage-17/selection-flow.js', () => ({
+  submitPass1Selection: (...args) => mockSubmitPass1Selection(...args),
+  submitPass2Selection: (...args) => mockSubmitPass2Selection(...args),
+  isDesignPassComplete: (...args) => mockIsDesignPassComplete(...args),
+  SelectionError: mockSelectionError,
+}));
+
+const mockRunQARubric = vi.fn();
+const mockUploadToGitHub = vi.fn();
+const mockUploadError = class extends Error {
+  constructor(msg, gaps) { super(msg); this.name = 'UploadError'; this.gaps = gaps; }
+};
+
+vi.mock('../../../lib/eva/stage-17/qa-rubric.js', () => ({
+  runQARubric: (...args) => mockRunQARubric(...args),
+  uploadToGitHub: (...args) => mockUploadToGitHub(...args),
+  UploadError: mockUploadError,
+}));
+
+// Mock bridge modules (already in stitch.js imports)
+vi.mock('../../../lib/eva/bridge/stitch-exporter.js', () => ({
+  exportStitchArtifacts: vi.fn(),
+}));
+vi.mock('../../../lib/eva/bridge/stitch-metrics.js', () => ({
+  getVentureMetrics: vi.fn(),
+  getFleetHealth: vi.fn(),
+  detectDegradation: vi.fn(),
+}));
+vi.mock('../../../lib/eva/bridge/stitch-provisioner.js', () => ({
+  checkCurationStatus: vi.fn(),
+}));
+
+// Mock validation
+vi.mock('../../../server/middleware/validate.js', () => ({
+  isValidUuid: (value) => {
+    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return typeof value === 'string' && UUID_REGEX.test(value);
+  },
+}));
+
+// Mock error handler
+vi.mock('../../../lib/middleware/eva-error-handler.js', () => ({
+  asyncHandler: (fn) => fn,
+}));
+
+// ---------------------------------------------------------------------------
+// Import router after mocks
+// ---------------------------------------------------------------------------
+const { default: router } = await import('../../../server/routes/stitch.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const VALID_ARTIFACT_ID = '11111111-2222-3333-4444-555555555555';
+const mockSupabase = { from: vi.fn() };
+
+function createMockReq(body = {}, params = {}, query = {}) {
+  return {
+    body,
+    params,
+    query,
+    app: { locals: { supabase: mockSupabase } },
+  };
+}
+
+function createMockRes() {
+  const res = {
+    statusCode: 200,
+    jsonData: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.jsonData = data; return this; },
+  };
+  return res;
+}
+
+function findRoute(method, path) {
+  for (const layer of router.stack) {
+    if (layer.route) {
+      const routePath = layer.route.path;
+      const routeMethod = Object.keys(layer.route.methods)[0];
+      if (routeMethod === method && routePath === path) {
+        return layer.route.stack.map(s => s.handle);
+      }
+    }
+  }
+  throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+}
+
+async function runHandlerChain(handlers, req, res) {
+  let idx = 0;
+  const next = async (err) => {
+    if (err) throw err;
+    if (idx < handlers.length) {
+      const fn = handlers[idx++];
+      await fn(req, res, next);
+    }
+  };
+  await next();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Stage 17 API Endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // === POST /:ventureId/stage17/archetypes ===
+  describe('POST /:ventureId/stage17/archetypes', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/archetypes');
+
+    it('generates archetypes and returns result', async () => {
+      const result = { screenCount: 3, artifactIds: ['a1', 'a2', 'a3'] };
+      mockGenerateArchetypes.mockResolvedValue(result);
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData).toEqual(result);
+      expect(mockGenerateArchetypes).toHaveBeenCalledWith(VALID_UUID, mockSupabase);
+    });
+
+    it('returns 400 for invalid ventureId', async () => {
+      const req = createMockReq({}, { ventureId: 'not-a-uuid' });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('INVALID_VENTURE_ID');
+    });
+
+    it('returns 400 when ArchetypeGenerationError thrown', async () => {
+      // Use unique UUID to avoid rate limiter interference from prior tests
+      const uniqueUuid = 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
+      mockGenerateArchetypes.mockRejectedValue(new mockArchetypeGenerationError('No source artifacts'));
+
+      const req = createMockReq({}, { ventureId: uniqueUuid });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('ARCHETYPE_GENERATION_FAILED');
+    });
+
+    it('returns 429 on rate limit (second call within 10s)', async () => {
+      // Use unique UUID so prior tests don't interfere with rate limiter
+      const rateLimitUuid = 'cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa';
+      mockGenerateArchetypes.mockResolvedValue({ screenCount: 1, artifactIds: ['a1'] });
+
+      const req1 = createMockReq({}, { ventureId: rateLimitUuid });
+      const res1 = createMockRes();
+      await runHandlerChain(handlers, req1, res1);
+      expect(res1.statusCode).toBe(200);
+
+      const req2 = createMockReq({}, { ventureId: rateLimitUuid });
+      const res2 = createMockRes();
+      await runHandlerChain(handlers, req2, res2);
+      expect(res2.statusCode).toBe(429);
+      expect(res2.jsonData.code).toBe('RATE_LIMITED');
+      expect(res2.jsonData.retryAfter).toBeGreaterThan(0);
+    });
+  });
+
+  // === POST /:ventureId/stage17/select ===
+  describe('POST /:ventureId/stage17/select', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/select');
+
+    it('submits pass 1 selection and returns refined IDs', async () => {
+      mockSubmitPass1Selection.mockResolvedValue(['r1', 'r2', 'r3', 'r4']);
+
+      const req = createMockReq(
+        { screenId: 'screen-home', selectedIds: ['a1', 'a2'] },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData.refinedArtifactIds).toHaveLength(4);
+      expect(mockSubmitPass1Selection).toHaveBeenCalledWith(VALID_UUID, 'screen-home', ['a1', 'a2'], mockSupabase);
+    });
+
+    it('returns 400 when selectedIds count is not 2', async () => {
+      const req = createMockReq(
+        { screenId: 'screen-home', selectedIds: ['a1'] },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('INVALID_SELECTION_COUNT');
+    });
+
+    it('returns 400 when screenId is missing', async () => {
+      const req = createMockReq(
+        { selectedIds: ['a1', 'a2'] },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('MISSING_SCREEN_ID');
+    });
+
+    it('returns 400 on SelectionError', async () => {
+      mockSubmitPass1Selection.mockRejectedValue(new mockSelectionError('Invalid selection'));
+
+      const req = createMockReq(
+        { screenId: 'screen-home', selectedIds: ['a1', 'a2'] },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('SELECTION_ERROR');
+    });
+  });
+
+  // === POST /:ventureId/stage17/refine ===
+  describe('POST /:ventureId/stage17/refine', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/refine');
+
+    it('submits pass 2 selection and returns approved artifact', async () => {
+      mockSubmitPass2Selection.mockResolvedValue(VALID_ARTIFACT_ID);
+
+      const req = createMockReq(
+        { screenId: 'screen-home', platform: 'mobile', artifactId: VALID_ARTIFACT_ID },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData.approvedArtifactId).toBe(VALID_ARTIFACT_ID);
+      expect(mockSubmitPass2Selection).toHaveBeenCalledWith(
+        VALID_UUID, 'screen-home', 'mobile', VALID_ARTIFACT_ID, mockSupabase
+      );
+    });
+
+    it('returns 400 for invalid platform', async () => {
+      const req = createMockReq(
+        { screenId: 'screen-home', platform: 'tablet', artifactId: VALID_ARTIFACT_ID },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('INVALID_PLATFORM');
+    });
+
+    it('returns 400 when artifactId is missing', async () => {
+      const req = createMockReq(
+        { screenId: 'screen-home', platform: 'desktop' },
+        { ventureId: VALID_UUID }
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('MISSING_ARTIFACT_ID');
+    });
+  });
+
+  // === POST /:ventureId/stage17/approve ===
+  describe('POST /:ventureId/stage17/approve', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/approve');
+
+    it('returns design pass completeness status', async () => {
+      mockIsDesignPassComplete.mockResolvedValue({ complete: false, threshold: 14, current: 8 });
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData.complete).toBe(false);
+      expect(res.jsonData.threshold).toBe(14);
+      expect(mockIsDesignPassComplete).toHaveBeenCalledWith(VALID_UUID, mockSupabase);
+    });
+
+    it('returns 400 for invalid ventureId', async () => {
+      const req = createMockReq({}, { ventureId: 'bad-id' });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('INVALID_VENTURE_ID');
+    });
+  });
+
+  // === POST /:ventureId/stage17/qa ===
+  describe('POST /:ventureId/stage17/qa', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/qa');
+
+    it('runs QA rubric and returns 3-layer results', async () => {
+      const qaResult = {
+        layers: { base: { score: 100 }, product: { score: 85 }, venture: { score: 92 } },
+        overallScore: 92,
+        counts: { pass: 12, warn: 2, fail: 0 },
+      };
+      mockRunQARubric.mockResolvedValue(qaResult);
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData.overallScore).toBe(92);
+      expect(res.jsonData.layers).toBeDefined();
+      expect(mockRunQARubric).toHaveBeenCalledWith(VALID_UUID, mockSupabase);
+    });
+
+    it('returns 400 for invalid ventureId', async () => {
+      const req = createMockReq({}, { ventureId: 'invalid' });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // === POST /:ventureId/stage17/upload ===
+  describe('POST /:ventureId/stage17/upload', () => {
+    const handlers = findRoute('post', '/:ventureId/stage17/upload');
+
+    it('uploads to GitHub and returns commit info', async () => {
+      mockUploadToGitHub.mockResolvedValue({ filesUploaded: 14, commitSha: 'abc123' });
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData.filesUploaded).toBe(14);
+      expect(res.jsonData.commitSha).toBe('abc123');
+      expect(mockUploadToGitHub).toHaveBeenCalledWith(VALID_UUID, mockSupabase, {});
+    });
+
+    it('returns 400 when UploadError thrown (QA gaps)', async () => {
+      const gaps = [{ severity: 'HIGH', description: 'Brand color mismatch' }];
+      mockUploadToGitHub.mockRejectedValue(new mockUploadError('Upload blocked', gaps));
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('UPLOAD_BLOCKED');
+      expect(res.jsonData.gaps).toEqual(gaps);
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      mockUploadToGitHub.mockRejectedValue(new Error('GitHub API timeout'));
+
+      const req = createMockReq({}, { ventureId: VALID_UUID });
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.jsonData.code).toBe('UPLOAD_ERROR');
+    });
+  });
+
+  // === Auth enforcement (all endpoints require requireAuth at mount level) ===
+  describe('Auth enforcement', () => {
+    it('all 6 S17 routes exist in the router', () => {
+      const s17Paths = [
+        '/:ventureId/stage17/archetypes',
+        '/:ventureId/stage17/select',
+        '/:ventureId/stage17/refine',
+        '/:ventureId/stage17/approve',
+        '/:ventureId/stage17/qa',
+        '/:ventureId/stage17/upload',
+      ];
+
+      for (const path of s17Paths) {
+        expect(() => findRoute('post', path)).not.toThrow();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wire 6 POST route handlers in `server/routes/stitch.js` to the 4 orphaned Stage 17 design refinement modules (archetype-generator, selection-flow, qa-rubric)
- Add venture-keyed rate limiting on archetypes endpoint (1 req/10s per venture)
- 19 integration tests covering all 6 endpoints' happy paths, validation errors, and domain error handling

## Endpoints Added
| Endpoint | Module | Purpose |
|----------|--------|---------|
| `POST /:ventureId/stage17/archetypes` | archetype-generator.js | Generate 6 HTML archetypes per screen |
| `POST /:ventureId/stage17/select` | selection-flow.js | Pass 1 selection (2 of 6 → 4 refined) |
| `POST /:ventureId/stage17/refine` | selection-flow.js | Pass 2 selection (final approved design) |
| `POST /:ventureId/stage17/approve` | selection-flow.js | Check 14-session completeness |
| `POST /:ventureId/stage17/qa` | qa-rubric.js | Run 3-layer QA rubric |
| `POST /:ventureId/stage17/upload` | qa-rubric.js | Upload to GitHub (blocks on HIGH gaps) |

## Test plan
- [x] 19 integration tests pass (all 6 endpoints × happy path + error cases)
- [x] 36 existing S17 unit tests pass (no regression)
- [x] 15 smoke tests pass
- [x] Auth enforced via `requireAuth` at router mount level in server/index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)