### PR TITLE
feat(SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A): per-screen S17 artifact storage

### DIFF
--- a/database/migrations/20260417_per_screen_unique_index.sql
+++ b/database/migrations/20260417_per_screen_unique_index.sql
@@ -1,0 +1,60 @@
+-- Migration: Per-screen S17 artifact storage
+-- SD: SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A
+--
+-- Adds screenId discriminator to the unique current artifact index.
+-- This allows S17 to store one artifact per screen (14 rows) instead of
+-- one blob containing all screens.
+--
+-- Backward compatible: non-S17 artifacts have metadata->>'screenId' IS NULL,
+-- so COALESCE returns '__no_screen__' — existing uniqueness is preserved.
+
+-- Step 1: Drop the existing index
+DROP INDEX IF EXISTS idx_unique_current_artifact;
+
+-- Step 2: Recreate with screenId discriminator
+CREATE UNIQUE INDEX idx_unique_current_artifact
+  ON venture_artifacts (
+    venture_id,
+    lifecycle_stage,
+    artifact_type,
+    COALESCE(metadata->>'screenId', '__no_screen__')
+  )
+  WHERE is_current = true;
+
+-- Step 3: Register s17_variant_scores artifact type
+-- Get the current CHECK constraint definition, drop it, and recreate with the new type.
+-- Note: This is additive — all existing types remain valid.
+DO $$
+DECLARE
+  current_types text[];
+BEGIN
+  -- Check if s17_variant_scores already exists in the constraint
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'artifact_type_check'
+    AND check_clause LIKE '%s17_variant_scores%'
+  ) THEN
+    -- Drop and recreate with new type added
+    ALTER TABLE venture_artifacts DROP CONSTRAINT IF EXISTS artifact_type_check;
+
+    ALTER TABLE venture_artifacts ADD CONSTRAINT artifact_type_check CHECK (
+      artifact_type IN (
+        'stage_analysis', 'devils_advocate_review', 'competitive_review',
+        'market_validation', 'market_analysis', 'financial_projection',
+        'financial_analysis', 'risk_assessment', 'strategy_recommendation',
+        'executive_summary', 'stitch_curation', 'stitch_design_export',
+        'soul_extraction', 'soul_document', 'brand_tokens',
+        's17_archetypes', 's17_approved', 's17_qa_report',
+        's17_fill_screen', 's17_variant_scores',
+        'venture_report', 'stage_gate_result', 'sprint_plan',
+        'sprint_execution', 'launch_checklist', 'post_launch_review',
+        'growth_metrics', 'pivot_analysis', 'exit_readiness',
+        'final_report'
+      )
+    );
+
+    RAISE NOTICE 'Added s17_variant_scores to artifact_type_check constraint';
+  ELSE
+    RAISE NOTICE 's17_variant_scores already in artifact_type_check — no change';
+  END IF;
+END $$;

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -70,14 +70,24 @@ export async function writeArtifact(supabase, opts) {
   // Dedup: if a current artifact of the same type exists for this stage,
   // UPDATE it instead of creating a duplicate row.
   // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-C: prevents duplicate artifacts at S10/S12/S15.
+  // SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A: scope dedup by metadata.screenId when present,
+  // matching the idx_unique_current_artifact index that uses COALESCE(metadata->>'screenId', '__no_screen__').
   if (isCurrent && !skipDedup) {
-    const { data: existing } = await supabase
+    let dedupQuery = supabase
       .from('venture_artifacts')
       .select('id')
       .eq('venture_id', ventureId)
       .eq('lifecycle_stage', lifecycleStage)
       .eq('artifact_type', artifactType)
-      .eq('is_current', true)
+      .eq('is_current', true);
+
+    // Scope by screenId if present in metadata — matches the unique index discriminator
+    const screenId = metadata?.screenId;
+    if (screenId) {
+      dedupQuery = dedupQuery.eq('metadata->>screenId', screenId);
+    }
+
+    const { data: existing } = await dedupQuery
       .limit(1)
       .maybeSingle();
 

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -103,6 +103,8 @@ export const ARTIFACT_TYPES = Object.freeze({
   BLUEPRINT_S17_SESSION_STATE: 's17_session_state',
   /** Final S17-approved design refinement output */
   BLUEPRINT_S17_APPROVED: 's17_approved',
+  /** S17 variant scoring results (per-screen) — SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A */
+  BLUEPRINT_S17_VARIANT_SCORES: 's17_variant_scores',
 
   // Cross-cutting — Stitch Integration
   BLUEPRINT_STITCH_PROJECT: 'stitch_project',

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -1,14 +1,16 @@
 /**
  * Stage 17 Archetype Generation Engine
  *
- * Generates 6 distinct HTML design archetypes per screen by calling Claude Sonnet
+ * Generates 6 distinct HTML design archetypes per screen by calling Claude
  * with each stitch_design_export artifact and locked brand token constraints.
- * Results are persisted as stage_17_archetype venture_artifacts.
+ * Results are persisted as s17_archetypes venture_artifacts — one artifact
+ * per screen (containing all 6 variants), discriminated by metadata.screenId.
  *
  * Exports:
  *   generateArchetypes(ventureId, supabase) — generate 6 archetypes per screen
  *
  * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-A
+ * SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A (per-screen storage migration)
  * @module lib/eva/stage-17/archetype-generator
  */
 
@@ -92,7 +94,8 @@ REQUIREMENTS:
 
 /**
  * Generate 6 HTML design archetypes for each stitch screen artifact.
- * Writes stage_17_archetype venture_artifacts (6 per screen).
+ * Writes one s17_archetypes artifact per screen (containing all 6 variants),
+ * using metadata.screenId to discriminate per-screen rows in the unique index.
  *
  * @param {string} ventureId
  * @param {object} supabase - Supabase service client
@@ -118,13 +121,19 @@ export async function generateArchetypes(ventureId, supabase) {
   const client = await createLLMClient('sonnet');
 
   const artifactIds = [];
+  const totalScreens = stitchArtifacts.length;
 
-  // 4. Generate 6 archetypes per screen (sequential to avoid rate limits)
-  for (const screenArtifact of stitchArtifacts) {
+  // 4. Generate 6 archetypes per screen, writing ONE artifact per screen
+  for (let screenIdx = 0; screenIdx < stitchArtifacts.length; screenIdx++) {
+    const screenArtifact = stitchArtifacts[screenIdx];
+    const screenId = screenArtifact.metadata?.screen_id ?? screenArtifact.id;
     const screenHtml = screenArtifact.content
       || JSON.stringify(screenArtifact.artifact_data ?? {});
+    const screenTitle = screenArtifact.title
+      ?? screenArtifact.metadata?.screenName
+      ?? `screen-${screenId.slice(0, 8)}`;
 
-    const screenTitle = screenArtifact.title ?? screenArtifact.metadata?.screenName ?? `screen-${screenArtifact.id.slice(0, 8)}`;
+    const variants = [];
 
     for (let i = 0; i < 6; i++) {
       const prompt = buildArchetypePrompt(screenHtml, tokens, ARCHETYPE_LAYOUTS[i], i + 1);
@@ -137,33 +146,46 @@ export async function generateArchetypes(ventureId, supabase) {
 
       const archetypeHtml = response.content[0]?.text ?? '';
 
-      const artifactId = await writeArtifact(supabase, {
-        ventureId,
-        lifecycleStage: 17,
-        artifactType: 'stage_17_archetype',
-        title: `${screenTitle} — Archetype ${i + 1}: ${ARCHETYPE_LAYOUTS[i].split(' ')[0]}`,
-        content: archetypeHtml,
-        artifactData: {
-          variantIndex: i + 1,
-          layoutDescription: ARCHETYPE_LAYOUTS[i],
-          sourceArtifactId: screenArtifact.id,
-          screenName: screenTitle,
-        },
-        qualityScore: 80,
-        validationStatus: 'pending',
-        source: 'stage-17-archetype-generator',
-        metadata: {
-          screenArtifactId: screenArtifact.id,
-          variantIndex: i + 1,
-          tokensApplied: !!tokens,
-        },
+      variants.push({
+        variantIndex: i + 1,
+        layoutDescription: ARCHETYPE_LAYOUTS[i],
+        html: archetypeHtml,
       });
 
-      artifactIds.push(artifactId);
+      console.log(`[archetype-generator] ${screenTitle} variant ${i + 1}/6 complete (${archetypeHtml.length} chars)`);
     }
+
+    // Write all 6 variants as ONE per-screen artifact.
+    // The unique index discriminates by metadata.screenId, so each screen
+    // gets its own is_current=true row.
+    const artifactId = await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 17,
+      artifactType: 's17_archetypes',
+      title: `${screenTitle} — 6 Archetypes`,
+      content: JSON.stringify({ screenName: screenTitle, variants }),
+      artifactData: {
+        screenId,
+        screenName: screenTitle,
+        variantCount: variants.length,
+        completedScreens: screenIdx + 1,
+        totalScreens,
+      },
+      qualityScore: 80,
+      validationStatus: 'pending',
+      source: 'stage-17-archetype-generator',
+      metadata: {
+        screenId,
+        sourceArtifactId: screenArtifact.id,
+        tokensApplied: !!tokens,
+      },
+    });
+
+    artifactIds.push(artifactId);
+    console.log(`[archetype-generator] Screen "${screenTitle}" complete (${screenIdx + 1}/${totalScreens})`);
   }
 
-  return { screenCount: stitchArtifacts.length, artifactIds };
+  return { screenCount: totalScreens, artifactIds };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add screenId discriminator to `idx_unique_current_artifact` unique index via `COALESCE(metadata->>'screenId', '__no_screen__')` — backward compatible for all non-S17 artifact types
- Refactor `archetype-generator.js` to write one `s17_archetypes` artifact per screen (14 rows for 14 screens) instead of 84 individual variant rows or 1 blob
- Scope dedup logic in `artifact-persistence-service.js` by `metadata.screenId` when present, matching the updated unique index
- Register `s17_variant_scores` artifact type in both JS registry and DB CHECK constraint

## Test plan
- [ ] Migration applies cleanly on staging DB
- [ ] Multiple `s17_archetypes` rows with different `screenId` coexist as `is_current=true`
- [ ] Non-S17 artifacts still enforce one-per-type uniqueness
- [ ] `writeArtifact` with `artifactType='s17_variant_scores'` succeeds
- [ ] Dedup for screen X only affects screen X (not other screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)