### PR TITLE
feat(SD-S17-DESIGN-INTELLIGENCE-ORCH-001-C): mobile/desktop format awareness

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -78,8 +78,31 @@ function buildArchetypePrompt(screenHtml, tokens, layoutDescription, variantInde
     ? `\nPAGE TYPE: ${options.pageType} — this is a ${options.pageType} screen. Your layout must serve its primary purpose.\n`
     : '';
 
+  // Device-specific instructions (SD-S17-DESIGN-INTELLIGENCE-ORCH-001-C)
+  const deviceType = options.deviceType ?? 'DESKTOP';
+  const deviceInstructions = deviceType === 'MOBILE'
+    ? `
+DEVICE FORMAT: MOBILE — design for touch interaction on a 375px viewport.
+- Use bottom navigation (position: fixed/sticky; bottom: 0) for primary destinations
+- All interactive elements ≥48px tap target (buttons, links, form controls)
+- Single-column layout — no sidebars, no multi-column grids on narrow viewport
+- Body font-size ≥16px (prevents iOS input zoom)
+- Images max-width: 100%, full-width cards
+- Primary CTA in bottom half of viewport (thumb zone)
+- 32-64px vertical spacing between sections`
+    : `
+DEVICE FORMAT: DESKTOP — design for pointer/keyboard interaction on a 1440px viewport.
+- Use sidebar navigation or visible top nav (not hamburger for <7 items)
+- Multi-column layout at ≥1024px (sidebar + main, or 2-3 column grid)
+- Reading content constrained to 65-80ch max-width
+- Include :hover states on all interactive elements (color shift, elevation, or transform)
+- Include :focus-visible with ≥3px visible ring
+- Hover-reveal details where appropriate (tooltips, expanded previews)
+- Rich spacing: 48-80px section gaps, generous padding`;
+
   return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 6 for this screen.
-${pageTypeContext}
+${pageTypeContext}${deviceInstructions}
+
 BRAND TOKENS (LOCKED — do not deviate):
 - Colors: ${colorList}
 - Heading font: ${headingFont}
@@ -95,7 +118,7 @@ REQUIREMENTS:
 1. Produce one complete HTML document with inline CSS only (no external links)
 2. Apply the locked brand colors using CSS custom properties
 3. Use the locked fonts via font-family declarations
-4. Implement the specified layout approach distinctly
+4. Implement the specified layout approach distinctly for the ${deviceType === 'MOBILE' ? 'mobile' : 'desktop'} format
 5. Preserve all content elements from the source screen
 6. Output ONLY the HTML — no explanation, no markdown fences`;
 }
@@ -142,17 +165,20 @@ export async function generateArchetypes(ventureId, supabase) {
       ?? `screen-${screenId.slice(0, 8)}`;
     const screenPrompt = screenArtifact.metadata?.prompt ?? '';
 
+    // Extract device type from screen metadata (SD-S17-DESIGN-INTELLIGENCE-ORCH-001-C)
+    const deviceType = screenArtifact.metadata?.deviceType ?? 'DESKTOP';
+
     // Classify page type for this screen (SD-S17-DESIGN-INTELLIGENCE-ORCH-001-B)
     const classification = classifyPageType(screenTitle, screenPrompt);
     const layouts = classification.confidence >= 0.5
       ? getArchetypesForPageType(classification.pageType)
       : FALLBACK_LAYOUTS;
-    console.log(`[archetype-generator] ${screenTitle} → pageType=${classification.pageType} (confidence=${classification.confidence}, method=${classification.method})`);
+    console.log(`[archetype-generator] ${screenTitle} → pageType=${classification.pageType}, deviceType=${deviceType} (confidence=${classification.confidence})`);
 
     const variants = [];
 
     for (let i = 0; i < 6; i++) {
-      const prompt = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType });
+      const prompt = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType, deviceType });
 
       const response = await client.messages.create({
         model: 'claude-sonnet-4-6',
@@ -179,12 +205,13 @@ export async function generateArchetypes(ventureId, supabase) {
       lifecycleStage: 17,
       artifactType: 's17_archetypes',
       title: `${screenTitle} — 6 Archetypes`,
-      content: JSON.stringify({ screenName: screenTitle, pageType: classification.pageType, variants }),
+      content: JSON.stringify({ screenName: screenTitle, pageType: classification.pageType, deviceType, variants }),
       artifactData: {
         screenId,
         screenName: screenTitle,
         pageType: classification.pageType,
         pageTypeConfidence: classification.confidence,
+        deviceType,
         variantCount: variants.length,
         completedScreens: screenIdx + 1,
         totalScreens,
@@ -195,6 +222,7 @@ export async function generateArchetypes(ventureId, supabase) {
       metadata: {
         screenId,
         pageType: classification.pageType,
+        deviceType,
         sourceArtifactId: screenArtifact.id,
         tokensApplied: !!tokens,
       },


### PR DESCRIPTION
## Summary
- Extract `deviceType` from screen metadata, default to DESKTOP
- Add device-specific prompt instructions (mobile: touch targets, bottom nav; desktop: multi-column, hover states)
- Propagate `deviceType` to artifact content, artifactData, and metadata

## Test plan
- [ ] Mobile screen prompts include bottom nav, 48px targets, single-column
- [ ] Desktop screen prompts include multi-column, hover states, sidebar
- [ ] `metadata.deviceType` set on generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)