### PR TITLE
fix(S17): auto-resume startup hook + review panel artifact type

### DIFF
--- a/lib/eva/stage-17/auto-resume.js
+++ b/lib/eva/stage-17/auto-resume.js
@@ -1,0 +1,90 @@
+/**
+ * S17 Archetype Generation Auto-Resume
+ *
+ * Scans for ventures with incomplete archetype generation on server startup
+ * and queues sequential resume for each. Uses venture_artifacts as the
+ * checkpoint — no new tables needed.
+ *
+ * SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A
+ * @module lib/eva/stage-17/auto-resume
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Find ventures with partial S17 archetype coverage and resume generation.
+ * A venture is "incomplete" if it has a stitch_design_export with N screens
+ * but fewer than N s17_archetypes artifacts.
+ */
+export async function resumeIncompleteArchetypeJobs() {
+  // Find all ventures with stitch exports (candidates for S17)
+  const { data: exports } = await supabase
+    .from('venture_artifacts')
+    .select('venture_id, metadata')
+    .eq('artifact_type', 'stitch_design_export')
+    .eq('is_current', true);
+
+  if (!exports?.length) {
+    console.log('[auto-resume] No stitch exports found — nothing to resume');
+    return;
+  }
+
+  const incompleteJobs = [];
+
+  for (const exp of exports) {
+    const totalScreens = exp.metadata?.html_files?.length ?? 0;
+    if (totalScreens === 0) continue;
+
+    // Count completed S17 archetypes for this venture
+    const { count } = await supabase
+      .from('venture_artifacts')
+      .select('id', { count: 'exact', head: true })
+      .eq('venture_id', exp.venture_id)
+      .eq('artifact_type', 's17_archetypes')
+      .eq('lifecycle_stage', 17)
+      .eq('is_current', true);
+
+    if ((count ?? 0) > 0 && (count ?? 0) < totalScreens) {
+      incompleteJobs.push({
+        ventureId: exp.venture_id,
+        completed: count,
+        total: totalScreens,
+      });
+    }
+  }
+
+  if (incompleteJobs.length === 0) {
+    console.log('[auto-resume] No incomplete S17 jobs found');
+    return;
+  }
+
+  console.log(`[auto-resume] Found ${incompleteJobs.length} incomplete S17 job(s):`);
+  for (const job of incompleteJobs) {
+    console.log(`  ${job.ventureId}: ${job.completed}/${job.total} screens`);
+  }
+
+  // Queue sequential resume via the existing API endpoint
+  for (const job of incompleteJobs) {
+    console.log(`[auto-resume] Triggering resume for ${job.ventureId} (${job.completed}/${job.total})...`);
+    try {
+      const res = await fetch(`http://localhost:${process.env.PORT || 3000}/api/stitch/${job.ventureId}/stage17/archetypes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (res.ok) {
+        console.log(`[auto-resume] Resume triggered for ${job.ventureId}`);
+      } else {
+        console.warn(`[auto-resume] Resume failed for ${job.ventureId}: ${res.status}`);
+      }
+    } catch (err) {
+      console.error(`[auto-resume] Resume error for ${job.ventureId}:`, err.message);
+    }
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -58,6 +58,7 @@ import evaChatRoutes from './routes/eva-chat.js';
 import evaEconomicLensRoutes from './routes/eva-economic-lens.js';
 import stitchRoutes from './routes/stitch.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
+import { resumeIncompleteArchetypeJobs } from '../lib/eva/stage-17/auto-resume.js';
 
 // Import Story API
 import * as storiesAPI from '../src/api/stories.js';
@@ -281,6 +282,12 @@ async function startServer() {
     if (sd2025) {
       console.log('✨ SD-2025-001 (OpenAI Realtime Voice) is loaded and ready!');
     }
+
+    // S17 archetype generation auto-resume on startup
+    // SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A
+    resumeIncompleteArchetypeJobs().catch(err =>
+      console.error('[startup] Auto-resume scan failed:', err.message)
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- Add auto-resume startup hook that scans for ventures with incomplete S17 archetype generation and triggers resume sequentially
- New module: `lib/eva/stage-17/auto-resume.js` — called from `server/index.js` on startup

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Restart server with incomplete S17 venture — verify auto-resume triggers
- [ ] Verify completed screens are skipped on resume

SD: SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)