### PR TITLE
fix(S17): auto-resume calls generateArchetypes directly

### DIFF
--- a/lib/eva/stage-17/auto-resume.js
+++ b/lib/eva/stage-17/auto-resume.js
@@ -1,0 +1,85 @@
+/**
+ * S17 Archetype Generation Auto-Resume
+ *
+ * Scans for ventures with incomplete archetype generation on server startup
+ * and queues sequential resume for each. Uses venture_artifacts as the
+ * checkpoint — no new tables needed.
+ *
+ * SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A
+ * @module lib/eva/stage-17/auto-resume
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Find ventures with partial S17 archetype coverage and resume generation.
+ * A venture is "incomplete" if it has a stitch_design_export with N screens
+ * but fewer than N s17_archetypes artifacts.
+ */
+export async function resumeIncompleteArchetypeJobs() {
+  // Find all ventures with stitch exports (candidates for S17)
+  const { data: exports } = await supabase
+    .from('venture_artifacts')
+    .select('venture_id, metadata')
+    .eq('artifact_type', 'stitch_design_export')
+    .eq('is_current', true);
+
+  if (!exports?.length) {
+    console.log('[auto-resume] No stitch exports found — nothing to resume');
+    return;
+  }
+
+  const incompleteJobs = [];
+
+  for (const exp of exports) {
+    const totalScreens = exp.metadata?.html_files?.length ?? 0;
+    if (totalScreens === 0) continue;
+
+    // Count completed S17 archetypes for this venture
+    const { count } = await supabase
+      .from('venture_artifacts')
+      .select('id', { count: 'exact', head: true })
+      .eq('venture_id', exp.venture_id)
+      .eq('artifact_type', 's17_archetypes')
+      .eq('lifecycle_stage', 17)
+      .eq('is_current', true);
+
+    if ((count ?? 0) > 0 && (count ?? 0) < totalScreens) {
+      incompleteJobs.push({
+        ventureId: exp.venture_id,
+        completed: count,
+        total: totalScreens,
+      });
+    }
+  }
+
+  if (incompleteJobs.length === 0) {
+    console.log('[auto-resume] No incomplete S17 jobs found');
+    return;
+  }
+
+  console.log(`[auto-resume] Found ${incompleteJobs.length} incomplete S17 job(s):`);
+  for (const job of incompleteJobs) {
+    console.log(`  ${job.ventureId}: ${job.completed}/${job.total} screens`);
+  }
+
+  // Call generateArchetypes directly (no HTTP auth needed)
+  const { generateArchetypes } = await import('./archetype-generator.js');
+
+  for (const job of incompleteJobs) {
+    console.log(`[auto-resume] Resuming ${job.ventureId} (${job.completed}/${job.total})...`);
+    try {
+      const result = await generateArchetypes(job.ventureId, supabase);
+      console.log(`[auto-resume] Completed ${job.ventureId}: ${result.screenCount} screens, ${result.artifactIds.length} new artifacts`);
+    } catch (err) {
+      console.error(`[auto-resume] Resume error for ${job.ventureId}:`, err.message);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix 401 auth error in auto-resume by calling `generateArchetypes()` directly instead of HTTP self-call
- The stitch API endpoint requires auth; server-side startup hook bypasses this by importing the function directly

## Test plan
- [x] Smoke tests pass
- [ ] Restart server — verify auto-resume triggers and generates remaining screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)