### PR TITLE
fix(LLM): cache key broken for multimodal + per-call cacheTTLMs ignored

### DIFF
--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -420,9 +420,11 @@ function _wrapAdapter(adapter, options = {}) {
 
   adapter.complete = async function(systemPrompt, userPrompt, callOptions = {}) {
     const modelName = adapter.model || adapter.modelId || 'unknown';
+    // Per-call cacheTTLMs overrides constructor-level setting
+    const effectiveCacheTTL = callOptions.cacheTTLMs !== undefined ? callOptions.cacheTTLMs : cacheTTLMs;
 
     // Check cache (skip if TTL explicitly set to 0)
-    if (cacheTTLMs !== 0) {
+    if (effectiveCacheTTL !== 0) {
       const cached = responseCache.get(systemPrompt, userPrompt, modelName);
       if (cached) {
         logUsage({
@@ -446,8 +448,8 @@ function _wrapAdapter(adapter, options = {}) {
     const durationMs = Date.now() - startMs;
 
     // Cache the result (skip if TTL explicitly set to 0)
-    if (cacheTTLMs !== 0 && result) {
-      responseCache.set(systemPrompt, userPrompt, modelName, result, cacheTTLMs);
+    if (effectiveCacheTTL !== 0 && result) {
+      responseCache.set(systemPrompt, userPrompt, modelName, result, effectiveCacheTTL);
     }
 
     // Log usage (fire-and-forget)

--- a/lib/llm/response-cache.js
+++ b/lib/llm/response-cache.js
@@ -24,7 +24,10 @@ class LLMResponseCache {
    * Generate deterministic cache key from prompt content and model.
    */
   _makeKey(systemPrompt, userPrompt, model) {
-    const raw = `${systemPrompt || ''}|${userPrompt || ''}|${model || ''}`;
+    // JSON.stringify handles arrays/objects (multimodal content) correctly;
+    // plain string concatenation produces "[object Object]" for all inputs.
+    const normalizePrompt = (p) => typeof p === 'string' ? p : JSON.stringify(p);
+    const raw = `${normalizePrompt(systemPrompt)}|${normalizePrompt(userPrompt)}|${model || ''}`;
     return createHash('sha256').update(raw).digest('hex').slice(0, 32);
   }
 


### PR DESCRIPTION
## Summary
- Fix `response-cache._makeKey()` to `JSON.stringify` non-string prompts (multimodal arrays were all hashing to `[object Object]`)
- Fix `_wrapAdapter` to respect per-call `cacheTTLMs` override (was only reading constructor-level value)

## Root cause
S17 archetype generator sent 6 different layout prompts as multimodal arrays (image + text). The cache key used string concatenation (`${userPrompt}`) which produced `[object Object],[object Object]` for all 6. Call 1 was a cache miss (real API call), calls 2-6 were cache hits returning the same HTML.

The generator passed `cacheTTLMs: 0` to disable caching, but the wrapper read this from constructor options (where it was `undefined`), not per-call options.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Re-run archetype generation — verify 6 distinct variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)