### PR TITLE
fix(QF-20260417-029): stop filtering DESIGN_SYSTEM_INSTANCE screens

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -741,7 +741,7 @@ export async function generateScreens(projectId, prompts, ventureId) {
 
 /**
  * Get screen IDs from a Stitch project via get_project.
- * Returns only real screen IDs (filters out DESIGN_SYSTEM_INSTANCE entries).
+ * Returns all screen IDs that have an id property.
  * @private
  */
 async function _getProjectScreenIds(sdk, apiKey, projectId) {
@@ -753,16 +753,16 @@ async function _getProjectScreenIds(sdk, apiKey, projectId) {
     const instances = result?.screenInstances || [];
     console.info(`[stitch-client] get_project raw: ${instances.length} screenInstances`);
 
-    // Filter to real screens — include anything with an id that isn't a design system instance.
-    // Previously required s.sourceScreen, but generated screens may not always have this property.
-    const filtered = instances.filter(s => s.id && s.type !== 'DESIGN_SYSTEM_INSTANCE');
+    // Include all screens with an id — Stitch may assign DESIGN_SYSTEM_INSTANCE
+    // type to real content screens, so we cannot filter by type.
+    const filtered = instances.filter(s => s.id);
     const excluded = instances.length - filtered.length;
     if (excluded > 0) {
       const reasons = instances
-        .filter(s => !s.id || s.type === 'DESIGN_SYSTEM_INSTANCE')
-        .map(s => `${s.id || 'no-id'}(type=${s.type || 'none'},src=${s.sourceScreen ? 'yes' : 'no'})`)
+        .filter(s => !s.id)
+        .map(s => `no-id(type=${s.type || 'none'})`)
         .slice(0, 5);
-      console.info(`[stitch-client] get_project filtered out ${excluded}: ${reasons.join(', ')}`);
+      console.info(`[stitch-client] get_project filtered out ${excluded} id-less: ${reasons.join(', ')}`);
     }
 
     const screenIds = new Set(filtered.map(s => s.id));

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -629,9 +629,8 @@ export async function checkCurationStatus(ventureId) {
     source: 'stitch-provisioner',
   });
 
-  // Design system pages are already filtered upstream by _getProjectScreenIds()
-  // in stitch-client.js (type !== 'DESIGN_SYSTEM_INSTANCE'). All screens returned
-  // by listScreens() are real generated screens — no second filter needed.
+  // All screens returned by listScreens() are real generated screens.
+  // stitch-client.js includes any screen with an id (no type-based filter).
   //
   // Update existing fired rows to confirmed. We can't match Stitch screen UUIDs
   // back to specific fired rows (listScreens only returns IDs, not display names),

--- a/lib/eva/bridge/stitch-reconciler.js
+++ b/lib/eva/bridge/stitch-reconciler.js
@@ -92,10 +92,11 @@ export async function reconcileScreenIds(ventureId, options = {}) {
       });
       const instances = result?.screenInstances || [];
       console.info(`[stitch-reconciler] get_project raw: ${instances.length} screenInstances`);
-      // Match stitch-client.js filter: include anything with an id, exclude design system instances
-      const filtered = instances.filter(s => s.id && s.type !== 'DESIGN_SYSTEM_INSTANCE');
+      // Include all screens with an id — Stitch may assign DESIGN_SYSTEM_INSTANCE
+      // type to real content screens, so we cannot filter by type (matches stitch-client.js).
+      const filtered = instances.filter(s => s.id);
       if (instances.length !== filtered.length) {
-        console.info(`[stitch-reconciler] Filtered out ${instances.length - filtered.length} non-screen instances`);
+        console.info(`[stitch-reconciler] Filtered out ${instances.length - filtered.length} id-less instances`);
       }
 
       // Multi-signal completion detection: log rich completion signals so operators


### PR DESCRIPTION
## Summary
- Stitch assigns `DESIGN_SYSTEM_INSTANCE` type to some real content screens, causing 3/16 screens to be silently dropped from exports
- Removed the type-based filter from `stitch-client.js`, `stitch-reconciler.js`, and updated stale comment in `stitch-provisioner.js`
- All three modules now include any screen with an `id` property, matching the fix intent from QF-20260417-667

## Test plan
- [ ] Run stitch export for a venture with 16+ screens and verify all screens are included
- [ ] Verify `html_files` count in `stitch_design_export` artifact matches expected screen count
- [ ] Check stitch-reconciler correctly counts all screens during poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)