### PR TITLE
fix(SD-LEO-INFRA-CROSS-REPO-ORPHAN-001): worktree orphan detection + wiring gate at final approval + blocking cross-child gate

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-EVA-FRIDAY-MEETING-ENHANCEMENT-ORCH-001-D",
+  "currentSd": "SD-LEO-INFRA-CROSS-REPO-ORPHAN-001",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing Knowledge Base VIEW over Learning Decisions and Issue Patterns PRD",
+  "currentTask": "Implementing Cross-repo orphan detection and orchestrator boundary gate enforcement",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
   "clearedAt": "2026-04-15T00:32:06.617Z",
-  "lastUpdatedAt": "2026-04-15T13:53:04.796Z"
+  "lastUpdatedAt": "2026-04-18T10:55:23.475Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C",
-  "expectedBranch": "feat/SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-A-C",
-  "createdAt": "2026-04-14T10:52:09.658Z",
+  "sdKey": "SD-LEO-INFRA-CROSS-REPO-ORPHAN-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CROSS-REPO-ORPHAN-001",
+  "createdAt": "2026-04-18T10:16:06.640Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js
@@ -204,8 +204,8 @@ export function detectMismatches(contractMaps) {
 export function createCrossChildIntegrationGate(supabase) {
   return {
     name: GATE_NAME,
-    required: false, // Advisory mode
-    weight: 5,
+    required: true,
+    weight: 15,
     async validator(ctx) {
       const { sd } = ctx;
 
@@ -258,22 +258,31 @@ export function createCrossChildIntegrationGate(supabase) {
       const mismatches = detectMismatches(contractMaps);
 
       const totalContracts = contractMaps.reduce((sum, c) => sum + c.tables.length, 0);
-      const warnings = mismatches.map(m => m.details);
-      const hasWarnings = mismatches.filter(m => m.severity === 'warning').length > 0;
+      const criticalMismatches = mismatches.filter(m => m.severity === 'warning');
+      const infoMismatches = mismatches.filter(m => m.severity === 'info');
+      const hasCritical = criticalMismatches.length > 0;
+      const hasInfo = infoMismatches.length > 0;
 
-      // Advisory: always pass, report warnings
-      const score = hasWarnings ? 70 : 100;
+      // Block on warning-severity mismatches (producer/consumer gaps),
+      // pass with warnings for info-severity (minor contract differences)
+      const score = hasCritical ? 40 : hasInfo ? 80 : 100;
+      const passed = !hasCritical;
+
+      const issues = hasCritical
+        ? criticalMismatches.map(m => m.details)
+        : [];
+      const warnings = infoMismatches.map(m => m.details);
 
       const result = {
-        passed: true, // Advisory — never blocks
+        passed,
         score,
         max_score: 100,
-        issues: [],
+        issues,
         warnings,
         details: {
           gate: GATE_NAME,
-          advisory: true,
-          blocking: false,
+          advisory: false,
+          blocking: hasCritical,
           children_analyzed: children.length,
           children_with_manifests: manifestsByChild.size,
           contracts_extracted: totalContracts,
@@ -287,7 +296,7 @@ export function createCrossChildIntegrationGate(supabase) {
           cross_child_integration: {
             contracts_extracted: totalContracts,
             mismatches: mismatches,
-            verdict: hasWarnings ? 'WARN' : 'PASS',
+            verdict: hasCritical ? 'FAIL' : hasInfo ? 'WARN' : 'PASS',
           },
         },
       };

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -25,6 +25,10 @@ export { createSmokeTestGate };
 import { createAutomatedUatGate } from './gates/automated-uat-gate.js';
 export { createAutomatedUatGate };
 
+// Wiring Validation Gate (SD-LEO-INFRA-CROSS-REPO-ORPHAN-001)
+import { createWiringValidationGate } from '../exec-to-plan/gates/wiring-validation.js';
+export { createWiringValidationGate };
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -1044,6 +1048,10 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
 
   // Automated UAT Gate (SD-ORCHESTRATOR-COMPLETION-VALIDATION-GATES-ORCH-001-D)
   gates.push(createAutomatedUatGate(supabase));
+
+  // Wiring Validation Gate — catch orphaned components before final merge
+  // (SD-LEO-INFRA-CROSS-REPO-ORPHAN-001)
+  gates.push(createWiringValidationGate(supabase));
 
   return gates;
 }

--- a/scripts/wiring-validators/wiring-validation-runner.js
+++ b/scripts/wiring-validators/wiring-validation-runner.js
@@ -40,6 +40,23 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const REPO_ROOT_DEFAULT = resolve(__dirname, '..', '..');
 
+/**
+ * Resolve the root path for orphan-detector.
+ * orphan-detector expects the PARENT of EHG_Engineer as root so that
+ * sibling repos (ehg/src) resolve correctly.
+ * In a worktree (.worktrees/SD-X/), the runner root points to the
+ * worktree dir — walk up to find the main EHG_Engineer root first.
+ */
+function resolveOrphanDetectorRoot(runnerRoot) {
+  const normalized = runnerRoot.replace(/\\/g, '/');
+  const worktreeIdx = normalized.indexOf('/.worktrees/');
+  if (worktreeIdx !== -1) {
+    const mainRepoRoot = normalized.substring(0, worktreeIdx);
+    return resolve(mainRepoRoot, '..');
+  }
+  return resolve(runnerRoot, '..');
+}
+
 // ---------------------------------------------------------------------------
 // Detector registry — maps check_type → script path (relative to repo root).
 // Scripts must emit JSON on stdout matching the leo_wiring_validations shape.
@@ -250,7 +267,9 @@ async function main() {
   const allRows = [];
   const detectorReport = [];
   for (const { check_type, script } of runOrder) {
-    const extra = script.includes('orphan-detector') ? ['--base', opts.base] : [];
+    const extra = script.includes('orphan-detector')
+      ? ['--base', opts.base, '--root', resolveOrphanDetectorRoot(opts.root)]
+      : [];
     process.stderr.write(`[wiring-runner]   running ${script} (for ${check_type}) ...\n`);
     const result = invokeDetector(opts.root, script, opts.sdKey, extra);
     if (!result.ok) {


### PR DESCRIPTION
## Summary
- **P1**: Fix worktree path resolution in wiring-validation-runner.js — pass `--root` to orphan-detector so it resolves to main repo parent (where `ehg/` sibling lives) instead of worktree dir
- **P2**: Register existing wiring-validation gate at LEAD-FINAL-APPROVAL phase so orphaned components are caught before final merge
- **P3**: Promote cross-child-integration-gate from advisory (always passes) to conditional blocking on warning-severity mismatches

## Context
RCA for SD-LEO-FIX-WIRE-STAGE17REVIEWPANEL-INTO-001 identified Stage17ReviewPanel.tsx was merged but never imported. Investigation verified the orphan-detector already scans both repos, but worktree path resolution prevents it from working. The wiring gate also wasn't present at final approval, and the orchestrator boundary gate was permanently advisory.

## Test plan
- [ ] Run orphan-detector from a `.worktrees/` directory — verify `ehg/src` resolves
- [ ] Run `handoff.js precheck LEAD-FINAL-APPROVAL` — verify wiring-validation gate listed
- [ ] Verify cross-child-integration-gate blocks on warning-severity mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)