### PR TITLE
feat(SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-001-C): wire AST call graph gate into LEAD-FINAL-APPROVAL

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -29,6 +29,10 @@ export { createAutomatedUatGate };
 import { createWiringValidationGate } from '../exec-to-plan/gates/wiring-validation.js';
 export { createWiringValidationGate };
 
+// Wire Check Gate — AST call graph reachability (SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-001-C)
+import { createWireCheckGate } from './gates/wire-check-gate.js';
+export { createWireCheckGate };
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -1053,6 +1057,10 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // (SD-LEO-INFRA-CROSS-REPO-ORPHAN-001)
   gates.push(createWiringValidationGate(supabase));
 
+  // Wire Check Gate — AST call graph reachability for new files
+  // (SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-001-C)
+  gates.push(createWireCheckGate(supabase));
+
   return gates;
 }
 
@@ -1068,5 +1076,6 @@ export default {
   createPhaseCoverageExitGate,
   createSmokeTestGate,
   createAutomatedUatGate,
+  createWireCheckGate,
   getRequiredGates
 };

--- a/tests/unit/gates/wire-check-gate.test.js
+++ b/tests/unit/gates/wire-check-gate.test.js
@@ -231,7 +231,7 @@ describe('wire-check-gate', () => {
   it('should have correct gate name and structure', () => {
     const gate = createWireCheckGate(null);
     expect(gate.name).toBe('WIRE_CHECK_GATE');
-    expect(gate.required).toBe(false);
+    expect(gate.required).toBe(true);
     expect(typeof gate.validator).toBe('function');
   });
 


### PR DESCRIPTION
## Summary
- Register existing `createWireCheckGate` in `getRequiredGates()` so the static analysis library is invoked during LEAD-FINAL-APPROVAL
- The library modules (`call-graph-builder`, `module-resolver`, `reachability-checker`) already existed but the gate was never wired in
- Update test to match promoted `required: true` enforcement status

## Test plan
- [x] 18/18 wire-check-gate unit tests pass
- [x] Gate correctly registered in `getRequiredGates()` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)