### PR TITLE
fix(stitch): mobile/desktop prompt differentiation + metric reconciliation

### DIFF
--- a/lib/eva/bridge/stitch-client.js
+++ b/lib/eva/bridge/stitch-client.js
@@ -736,6 +736,19 @@ export async function generateScreens(projectId, prompts, ventureId) {
   const errors = results.filter(r => r.status === 'error').length;
   console.info(`[stitch-client] Generation complete: ${confirmed} confirmed, ${fired} unconfirmed, ${errors} errors`);
 
+  // Final reconciliation: if any rows remain 'fired', do a server-side reconcile
+  // by checking the actual Stitch project. This ensures the DB always reflects
+  // the true state regardless of frontend polling.
+  if (fired > 0 && ventureId) {
+    try {
+      const { checkCurationStatus } = await import('./stitch-provisioner.js');
+      await checkCurationStatus(ventureId);
+      console.info(`[stitch-client] Post-generation reconcile complete for ${ventureId.slice(0, 8)}`);
+    } catch (err) {
+      console.warn(`[stitch-client] Post-generation reconcile failed (non-blocking): ${err.message}`);
+    }
+  }
+
   return results;
 }
 
@@ -794,16 +807,44 @@ function _assignScreenIdsToFiredResults(results, newScreenIds, ventureId) {
       result.screen_id = availableIds[idIdx++];
       result.status = 'confirmed';
       console.info(`[stitch-client] Confirmed: ${result.prompt?.slice(0, 40)} → ${result.screen_id}`);
+      // Update existing fired row in-place instead of inserting a duplicate.
+      // This prevents the UI from seeing both a 'fired' and 'confirmed' row
+      // for the same screen, which causes the progress count to stall.
+      _updateFiredToConfirmed(ventureId, result._screenName || result.prompt, result.deviceType);
+    }
+  }
+}
+
+/**
+ * Update an existing 'fired' metric row to 'confirmed' in the DB.
+ * Falls back to insert if no fired row exists. Fire-and-forget.
+ * @private
+ */
+async function _updateFiredToConfirmed(ventureId, screenName, deviceType) {
+  try {
+    const { data: updated } = await supabase
+      .from('stitch_generation_metrics')
+      .update({ status: 'confirmed' })
+      .eq('venture_id', ventureId)
+      .eq('screen_name', screenName)
+      .eq('status', 'fired')
+      .select('id')
+      .limit(1);
+
+    if (!updated || updated.length === 0) {
+      // No fired row found — insert a confirmed row as fallback
       recordMetric({
         ventureId,
-        screenName: result.prompt || 'unknown',
-        deviceType: result.deviceType,
-        promptText: result.prompt,
+        screenName,
+        deviceType,
+        promptText: '',
         status: 'confirmed',
         attemptCount: 1,
-        durationMs: 0, // not meaningful for poll-confirmed screens
+        durationMs: 0,
       });
     }
+  } catch (err) {
+    console.warn(`[stitch-client] fired→confirmed update failed (non-blocking): ${err.message}`);
   }
 }
 
@@ -838,7 +879,7 @@ async function _fireOneScreen({ rawPrompt, globalIdx, totalPrompts, sdk, apiKey,
     }
     console.info(`[stitch-client] ${label} returned without screen ID — will poll`);
     recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: 1, durationMs: Date.now() - fireStart });
-    return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1 };
+    return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1, _screenName: screenName };
   } catch (err) {
     const msg = err.message || '';
     const isTransport = /fetch failed|socket|ECONNRESET|other side closed|timed out/i.test(msg);
@@ -859,12 +900,12 @@ async function _fireOneScreen({ rawPrompt, globalIdx, totalPrompts, sdk, apiKey,
     if (isServerError) {
       console.info(`[stitch-client] ${label} server ${statusCode} after ${Date.now() - fireStart}ms — treating as fired (browser activation may recover)`);
       recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: 1, durationMs: Date.now() - fireStart, errorCategory: 'server_5xx', errorMessage: msg.slice(0, 500) });
-      return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1 };
+      return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1, _screenName: screenName };
     }
     if (isTransport) {
       console.info(`[stitch-client] ${label} fired (GFE timeout after ${Date.now() - fireStart}ms — generation continues server-side)`);
       recordMetric({ ventureId, screenName, deviceType, promptText, status: 'fired', attemptCount: 1, durationMs: Date.now() - fireStart });
-      return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1 };
+      return { prompt: promptText.slice(0, 60), status: 'fired', deviceType, attempt: 1, _screenName: screenName };
     }
     console.error(`[stitch-client] ${label} unexpected error: ${msg.slice(0, 120)}`);
     recordMetric({ ventureId, screenName, deviceType, promptText, status: 'error', attemptCount: 1, durationMs: Date.now() - fireStart, errorCategory: 'sdk_error', errorMessage: msg.slice(0, 500) });

--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -214,12 +214,15 @@ function distillBrand(tokens) {
   return parts.join('. ');
 }
 
-function buildScreenPrompt(screen, brandTokens, ventureName, designReferenceSection) {
+function buildScreenPrompt(screen, brandTokens, ventureName, designReferenceSection, deviceType) {
   // Budget-based construction: each section has a char budget
   const sections = [];
 
-  // Intro + Purpose (~170 chars)
-  sections.push(`Design a ${screen.name || 'screen'} for ${ventureName || 'the application'}.`);
+  // Intro + Purpose (~170 chars) — include device format when dual-platform
+  const deviceLabel = deviceType === 'MOBILE' ? ' (mobile layout)' : deviceType === 'DESKTOP' ? ' (desktop layout)' : '';
+  sections.push(`Design a ${screen.name || 'screen'}${deviceLabel} for ${ventureName || 'the application'}.`);
+  if (deviceType === 'MOBILE') sections.push('Optimize for narrow viewport: single-column, touch targets, bottom navigation.');
+  if (deviceType === 'DESKTOP') sections.push('Optimize for wide viewport: multi-column, sidebar navigation, hover states.');
   if (screen.purpose) sections.push(`Purpose: ${truncateAtWord(screen.purpose, 100)}`);
 
   // Layout (~250 chars) — compressed from ASCII art to structural notation
@@ -387,7 +390,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   if (includeMobile) {
     for (const screen of screens) {
       curationPrompts.push({
-        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
+        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection, 'MOBILE'),
         deviceType: 'MOBILE',
         _platform: 'mobile',
         _screenName: screen.name || screen.title || 'Unknown',
@@ -397,7 +400,7 @@ export async function provisionStitchProject(ventureId, stage11Artifacts, stage1
   if (includeDesktop) {
     for (const screen of screens) {
       curationPrompts.push({
-        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection),
+        text: buildScreenPrompt(screen, brandTokens, options.ventureName, designRefSection, 'DESKTOP'),
         deviceType: 'DESKTOP', // QF-20260412-625: always DESKTOP in desktop pass (was leaking AGNOSTIC)
         _platform: 'desktop',
         _screenName: screen.name || screen.title || 'Unknown',

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2353,24 +2353,26 @@ export class StageExecutionWorker {
     });
     this._logger.log('[Worker] S17 post-stage hook: vision + architecture docs generated');
 
-    // SD-LEO-FIX-STITCH-INTEGRATION-WIRING-001: Look up stitch_project artifact for project_id
+    // SD-LEO-FIX-STITCH-INTEGRATION-WIRING-001: Look up stitch artifact for project_id
+    // Fix: provisioner writes 'stitch_curation', not 'stitch_project' — query both for compat
     try {
       const { exportScreens, logStitchEvent } = await import('./bridge/stitch-adapter.js');
       const { data: stitchArtifact } = await this._supabase
         .from('venture_artifacts')
         .select('artifact_data')
         .eq('venture_id', ventureId)
-        .eq('artifact_type', 'stitch_project')
+        .in('artifact_type', ['stitch_curation', 'stitch_project'])
+        .order('created_at', { ascending: false })
         .maybeSingle();
 
       const projectId = stitchArtifact?.artifact_data?.project_id || null;
       if (!projectId) {
         const wireframeGating = process.env.EVA_WIREFRAME_GATING_ENABLED === 'true';
         if (wireframeGating) {
-          this._logger.error('[Worker] S17 no stitch_project artifact found — fail-closed (EVA_WIREFRAME_GATING_ENABLED=true)');
-          throw new Error('[Worker] S17 export blocked: no stitch_project artifact (wireframe gating enabled)');
+          this._logger.error('[Worker] S17 no stitch artifact found — fail-closed (EVA_WIREFRAME_GATING_ENABLED=true)');
+          throw new Error('[Worker] S17 export blocked: no stitch artifact (wireframe gating enabled)');
         }
-        this._logger.warn('[Worker] S17 no stitch_project artifact found, skipping Stitch export');
+        this._logger.warn('[Worker] S17 no stitch artifact found, skipping Stitch export');
         return;
       }
 

--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -9,8 +9,8 @@ require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-const VENTURE_ID = '8cc661a8-baea-4f20-8405-35a94b59cbed';
-const VENTURE_NAME = 'Podcast Repurpose Engine';
+const VENTURE_ID = 'ef9a1d12-9703-4a97-b432-4a3ea8452647';
+const VENTURE_NAME = 'Aeterna Wills';
 const STOP_AT_STAGE = 17;
 const POLL_MS = 30000;
 
@@ -102,6 +102,11 @@ async function getStageTransitions() {
 }
 
 async function approveDecision(decisionId, stage) {
+  // Defense-in-depth: never approve at or past STOP_AT_STAGE
+  if (stage >= STOP_AT_STAGE) {
+    console.log(`[${ts()}]    BLOCKED: Refusing to approve S${stage} — at or past STOP_AT_STAGE (${STOP_AT_STAGE})`);
+    return { data: null, error: { message: `Stage ${stage} >= STOP_AT_STAGE ${STOP_AT_STAGE}` } };
+  }
   const gateType = KILL_GATES.has(stage) ? 'kill_gate' : PROMOTION_GATES.has(stage) ? 'promotion_gate' : 'standard';
   const { data, error } = await sb.rpc('approve_chairman_decision', {
     p_decision_id: decisionId,


### PR DESCRIPTION
## Summary
- **Prompt differentiation**: `buildScreenPrompt()` now includes device-specific layout instructions — mobile gets "narrow viewport, single-column, touch targets", desktop gets "wide viewport, multi-column, sidebar navigation". Prevents Stitch from deduplicating identical prompts.
- **Metric reconciliation fix**: `_assignScreenIdsToFiredResults()` updates existing `fired` DB rows to `confirmed` in-place instead of inserting duplicates. Screen Generation Progress now reflects actual Stitch state immediately.
- **Server-side reconcile**: `generateScreens()` calls `checkCurationStatus()` after generation when `fired` rows remain — eliminates dependency on frontend polling for metric accuracy.
- **S17 post-hook compat**: Worker queries both `stitch_curation` and `stitch_project` artifact types.
- **Monitor guard**: `approveDecision()` refuses stages >= `STOP_AT_STAGE` (defense-in-depth).

## Test plan
- [x] `buildScreenPrompt()` produces differentiated text for MOBILE vs DESKTOP (verified with Aeterna Wills — 14 prompts, 7 unique screens x 2 platforms)
- [x] Smoke tests pass (15/15)
- [x] Syntax check passes on all 4 files
- [x] Monitor script correctly stops at S17 (verified with Aeterna Wills push-through)
- [x] Aeterna Wills S17 shows correct screen generation progress after reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)