### PR TITLE
feat(SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A): disable Stitch, wire archetype generator to wireframe artifacts

### DIFF
--- a/database/migrations/20260419_add_wireframe_screens_artifact_type.sql
+++ b/database/migrations/20260419_add_wireframe_screens_artifact_type.sql
@@ -1,0 +1,117 @@
+-- Migration: Add wireframe_screens artifact type to venture_artifacts CHECK constraint
+-- SD: SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A
+-- Date: 2026-04-19
+--
+-- New type: wireframe_screens (S15 post-hook stores screen data here instead of calling Stitch)
+-- archetype-generator.js reads this artifact for S17 design generation.
+--
+-- Safety: CHECK constraint replacement — brief AccessExclusive lock, zero downtime.
+
+BEGIN;
+
+ALTER TABLE venture_artifacts
+  DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+-- Recreate with all 94 existing types + 1 new type (total: 95)
+ALTER TABLE venture_artifacts
+  ADD CONSTRAINT venture_artifacts_artifact_type_check
+  CHECK (((artifact_type)::text = ANY (ARRAY[
+    'intake_venture_analysis'::text,
+    'truth_idea_brief'::text,
+    'truth_ai_critique'::text,
+    'truth_validation_decision'::text,
+    'truth_competitive_analysis'::text,
+    'truth_financial_model'::text,
+    'truth_problem_statement'::text,
+    'truth_target_market_analysis'::text,
+    'truth_value_proposition'::text,
+    'engine_risk_matrix'::text,
+    'engine_pricing_model'::text,
+    'engine_business_model_canvas'::text,
+    'engine_exit_strategy'::text,
+    'engine_risk_assessment'::text,
+    'engine_revenue_model'::text,
+    'identity_persona_brand'::text,
+    'identity_brand_guidelines'::text,
+    'identity_naming_visual'::text,
+    'identity_brand_name'::text,
+    'identity_gtm_sales_strategy'::text,
+    'blueprint_product_roadmap'::text,
+    'blueprint_technical_architecture'::text,
+    'blueprint_data_model'::text,
+    'blueprint_erd_diagram'::text,
+    'blueprint_api_contract'::text,
+    'blueprint_schema_spec'::text,
+    'blueprint_risk_register'::text,
+    'blueprint_user_story_pack'::text,
+    'blueprint_wireframes'::text,
+    'blueprint_financial_projection'::text,
+    'blueprint_launch_readiness'::text,
+    'blueprint_sprint_plan'::text,
+    'blueprint_promotion_gate'::text,
+    'blueprint_project_plan'::text,
+    'blueprint_review_summary'::text,
+    'build_system_prompt'::text,
+    'build_cicd_config'::text,
+    'build_security_audit'::text,
+    'build_mvp_build'::text,
+    'build_test_coverage_report'::text,
+    'launch_test_plan'::text,
+    'launch_uat_report'::text,
+    'launch_deployment_runbook'::text,
+    'launch_marketing_checklist'::text,
+    'launch_analytics_dashboard'::text,
+    'launch_health_scoring'::text,
+    'launch_churn_triggers'::text,
+    'launch_retention_playbook'::text,
+    'launch_optimization_roadmap'::text,
+    'launch_assumptions_vs_reality'::text,
+    'launch_launch_metrics'::text,
+    'launch_user_feedback_summary'::text,
+    'launch_production_app'::text,
+    'system_devils_advocate_review'::text,
+    'value_multiplier_assessment'::text,
+    'economic_lens'::text,
+    'lifecycle_sd_bridge'::text,
+    'post_lifecycle_decision'::text,
+    'stitch_project'::text,
+    'stitch_curation'::text,
+    'stitch_budget'::text,
+    'stage_0_analysis'::text,
+    'stage_1_analysis'::text,
+    'stage_2_analysis'::text,
+    'stage_3_analysis'::text,
+    'stage_4_analysis'::text,
+    'stage_5_analysis'::text,
+    'stage_6_analysis'::text,
+    'stage_7_analysis'::text,
+    'stage_8_analysis'::text,
+    'stage_9_analysis'::text,
+    'stage_10_analysis'::text,
+    'stage_11_analysis'::text,
+    'stage_12_analysis'::text,
+    'stage_13_analysis'::text,
+    'stage_14_analysis'::text,
+    'stage_15_analysis'::text,
+    'stage_16_analysis'::text,
+    'stage_17_analysis'::text,
+    'stage_18_analysis'::text,
+    'stage_19_analysis'::text,
+    'stage_20_analysis'::text,
+    'stage_21_analysis'::text,
+    'stage_22_analysis'::text,
+    'stage_23_analysis'::text,
+    'stage_24_analysis'::text,
+    'stage_25_analysis'::text,
+    'stage_26_analysis'::text,
+    'stitch_design_export'::text,
+    'stitch_qa_report'::text,
+    'design_token_manifest'::text,
+    's17_archetypes'::text,
+    's17_session_state'::text,
+    's17_approved'::text,
+    -- New: wireframe_screens (replaces Stitch provisioning)
+    'wireframe_screens'::text
+  ])));
+
+COMMIT;

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -106,7 +106,10 @@ export const ARTIFACT_TYPES = Object.freeze({
   /** S17 variant scoring results (per-screen) — SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A */
   BLUEPRINT_S17_VARIANT_SCORES: 's17_variant_scores',
 
-  // Cross-cutting — Stitch Integration
+  // Stage 15 — Wireframe screen data (replaces Stitch provisioning)
+  BLUEPRINT_WIREFRAME_SCREENS: 'wireframe_screens',
+
+  // Cross-cutting — Stitch Integration (legacy, kept for backward compat)
   BLUEPRINT_STITCH_PROJECT: 'stitch_project',
   BLUEPRINT_STITCH_CURATION: 'stitch_curation',
 
@@ -208,6 +211,7 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
   15: [
     ARTIFACT_TYPES.BLUEPRINT_USER_STORY_PACK,
     ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES,
+    ARTIFACT_TYPES.BLUEPRINT_WIREFRAME_SCREENS,
   ],
   16: [
     ARTIFACT_TYPES.BLUEPRINT_FINANCIAL_PROJECTION,

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -65,11 +65,49 @@ export class ArchetypeGenerationError extends Error {
 }
 
 /**
- * Fetch all current stitch_design_export artifacts for a venture.
+ * Fetch wireframe_screens artifact for a venture (primary source).
+ * Falls back to stitch_design_export for backward compatibility with
+ * ventures that completed S15 before the Stitch replacement.
  *
  * @param {object} supabase
  * @param {string} ventureId
- * @returns {Promise<Array>} artifact rows
+ * @returns {Promise<{ source: 'wireframe_screens'|'stitch_design_export', artifact: object|null }>}
+ */
+async function fetchScreenSourceArtifact(supabase, ventureId) {
+  // Primary: wireframe_screens (SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A)
+  const { data: wireframeArt } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, artifact_data, content, metadata, title')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'wireframe_screens')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (wireframeArt) {
+    return { source: 'wireframe_screens', artifact: wireframeArt };
+  }
+
+  // Fallback: stitch_design_export (legacy ventures)
+  const { data: stitchArt } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, artifact_data, content, metadata, title')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'stitch_design_export')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (stitchArt) {
+    return { source: 'stitch_design_export', artifact: stitchArt };
+  }
+
+  return { source: 'wireframe_screens', artifact: null };
+}
+
+/**
+ * Fetch all current stitch_design_export artifacts for a venture.
+ * @deprecated Use fetchScreenSourceArtifact instead
  */
 async function fetchStitchArtifacts(supabase, ventureId) {
   const { data, error } = await supabase
@@ -202,58 +240,84 @@ REQUIREMENTS:
  */
 export async function generateArchetypes(ventureId, supabase, options = {}) {
   const { signal } = options;
-  // 1. Load the single stitch_design_export artifact containing all screens
-  const { data: exportArt } = await supabase
-    .from('venture_artifacts')
-    .select('id, metadata')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_design_export')
-    .eq('is_current', true)
-    .limit(1)
-    .maybeSingle();
 
-  if (!exportArt?.metadata?.html_files?.length) {
+  // 1. Load screen source — wireframe_screens (primary) or stitch_design_export (legacy fallback)
+  // SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A
+  const { source: screenSource, artifact: sourceArt } = await fetchScreenSourceArtifact(supabase, ventureId);
+  console.log(`[archetype-generator] Screen source: ${screenSource}`);
+
+  // Build unified screen list from whichever source we found
+  let screenList = [];     // [{ screen_id, screen_name, description, deviceType, html?, png? }]
+  let sourceArtifactId = null;
+
+  if (screenSource === 'wireframe_screens' && sourceArt) {
+    // New path: wireframe_screens artifact from S15 post-hook
+    sourceArtifactId = sourceArt.id;
+    const screens = sourceArt.artifact_data?.screens ?? [];
+    if (!screens.length) {
+      throw new ArchetypeGenerationError(
+        `wireframe_screens artifact found but contains no screens for venture ${ventureId}.`
+      );
+    }
+    screenList = screens.map((s, idx) => ({
+      screen_id: s.screen_id ?? `screen-${idx}`,
+      screen_name: s.screen_name ?? s.name ?? `Screen ${idx + 1}`,
+      description: s.description ?? '',
+      deviceType: s.deviceType ?? 'DESKTOP',
+      html: null,   // wireframe path has no pre-rendered HTML
+      png: null,
+    }));
+  } else if (screenSource === 'stitch_design_export' && sourceArt) {
+    // Legacy path: stitch_design_export with HTML URLs
+    sourceArtifactId = sourceArt.id;
+    const htmlFiles = sourceArt.metadata?.html_files ?? [];
+    if (!htmlFiles.length) {
+      throw new ArchetypeGenerationError(
+        `stitch_design_export found but has no html_files for venture ${ventureId}.`
+      );
+    }
+    const pngFiles = sourceArt.metadata?.png_files_base64 ?? [];
+    const pngMap = new Map();
+    for (const png of pngFiles) {
+      if (png.screen_id && png.base64) pngMap.set(png.screen_id, png.base64);
+    }
+
+    // Load screen names from stitch_curation for legacy path
+    const { data: curationArt } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'stitch_curation')
+      .eq('lifecycle_stage', 15)
+      .limit(1)
+      .maybeSingle();
+    const screenPrompts = curationArt?.artifact_data?.screen_prompts ?? [];
+    const genResults = curationArt?.artifact_data?.generation_results ?? [];
+
+    screenList = htmlFiles.map((file, idx) => {
+      const id = file.screen_id ?? `screen-${idx}`;
+      return {
+        screen_id: id,
+        screen_name: screenPrompts[idx]?.screen_name ?? screenPrompts[idx]?._screenName ?? `Screen ${idx + 1}`,
+        description: screenPrompts[idx]?.prompt ?? screenPrompts[idx]?.text ?? '',
+        deviceType: screenPrompts[idx]?.deviceType ?? 'DESKTOP',
+        htmlUrl: file.html,
+        png: pngMap.get(id) ?? null,
+      };
+    });
+  } else {
     throw new ArchetypeGenerationError(
-      `No stitch_design_export with html_files found for venture ${ventureId}. ` +
-      'Stage 15/16 Stitch export must complete before Stage 17 archetype generation.'
+      `No wireframe_screens or stitch_design_export artifact found for venture ${ventureId}. ` +
+      'Stage 15 must complete before Stage 17 archetype generation.'
     );
   }
 
-  const htmlFiles = exportArt.metadata.html_files;     // [{ screen_id, html (URL), size }]
-  const pngFiles = exportArt.metadata.png_files_base64 ?? [];
-  const pngMap = new Map();
-  for (const png of pngFiles) {
-    if (png.screen_id && png.base64) pngMap.set(png.screen_id, png.base64);
-  }
+  console.log(`[archetype-generator] ${screenList.length} screens to process (source: ${screenSource})`);
 
-  // 1b. Load screen names and deviceType from S15 stitch_curation artifact
-  const { data: curationArt } = await supabase
-    .from('venture_artifacts')
-    .select('artifact_data')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_curation')
-    .eq('lifecycle_stage', 15)
-    .limit(1)
-    .maybeSingle();
-  const screenPrompts = curationArt?.artifact_data?.screen_prompts ?? [];
-  const screenNameMap = new Map();
-  const deviceTypeMap = new Map();
-  const genResults = curationArt?.artifact_data?.generation_results ?? [];
-  for (let i = 0; i < screenPrompts.length; i++) {
-    const id = genResults[i]?.screen_id ?? htmlFiles[i]?.screen_id;
-    // Screen name: try screen_name, _screenName, screenName (provisioner uses different conventions)
-    const name = screenPrompts[i]?.screen_name ?? screenPrompts[i]?._screenName ?? screenPrompts[i]?.screenName;
-    const device = screenPrompts[i]?.deviceType ?? 'DESKTOP';
-    if (id && name) screenNameMap.set(id, name);
-    if (id) deviceTypeMap.set(id, device);
-  }
-
-  console.log(`[archetype-generator] ${htmlFiles.length} screens to process, ${screenPrompts.length} prompts loaded`);
-
-  // 1c. Resume: check which screens already have completed artifacts
+  // 1b. Resume: check which screens already have completed artifacts
   const completedScreens = await getCompletedScreens(supabase, ventureId);
   if (completedScreens.size > 0) {
-    console.log(`[archetype-generator] Resume: ${completedScreens.size}/${htmlFiles.length} screens already completed, skipping`);
+    console.log(`[archetype-generator] Resume: ${completedScreens.size}/${screenList.length} screens already completed, skipping`);
   }
 
   // 2. Load brand token manifest
@@ -264,47 +328,50 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   const client = getLLMClient({ purpose: 'generation' });
 
   const artifactIds = [];
-  const totalScreens = htmlFiles.length;
+  const totalScreens = screenList.length;
 
-  // 4. Generate 6 archetypes per screen, writing ONE artifact per screen
-  for (let screenIdx = 0; screenIdx < htmlFiles.length; screenIdx++) {
+  // 4. Generate 6 archetypes per screen
+  for (let screenIdx = 0; screenIdx < screenList.length; screenIdx++) {
     if (signal?.aborted) {
       console.info(`[archetype-generator] Cancelled after ${screenIdx}/${totalScreens} screens (${artifactIds.length} artifacts written)`);
       return { screenCount: screenIdx, artifactIds, cancelled: true };
     }
-    const screenFile = htmlFiles[screenIdx];
-    const screenId = screenFile.screen_id ?? `screen-${screenIdx}`;
+    const screen = screenList[screenIdx];
+    const screenId = screen.screen_id;
 
-    // Resume: skip screens that already have completed artifacts
     if (completedScreens.has(screenId)) {
       console.log(`[archetype-generator] Skipping ${screenId} (already completed)`);
       continue;
     }
-    const screenTitle = screenNameMap.get(screenId)
-      ?? screenPrompts[screenIdx]?.screen_name
-      ?? screenPrompts[screenIdx]?._screenName
-      ?? `Screen ${screenIdx + 1}`;
-    const screenPromptText = screenPrompts[screenIdx]?.prompt ?? screenPrompts[screenIdx]?.text ?? '';
 
-    // Fetch actual HTML content from the download URL
+    const screenTitle = screen.screen_name;
+    const deviceType = screen.deviceType;
+
+    // Resolve screen content: fetch HTML for legacy path, use description for wireframe path
     let screenHtml = '';
-    try {
-      const res = await fetch(screenFile.html);
-      if (res.ok) screenHtml = await res.text();
-      else console.warn(`[archetype-generator] Failed to fetch HTML for ${screenTitle}: ${res.status}`);
-    } catch (err) {
-      console.warn(`[archetype-generator] HTML fetch error for ${screenTitle}: ${err.message}`);
+    if (screen.htmlUrl) {
+      // Legacy stitch path: fetch HTML from URL
+      try {
+        const res = await fetch(screen.htmlUrl);
+        if (res.ok) screenHtml = await res.text();
+        else console.warn(`[archetype-generator] Failed to fetch HTML for ${screenTitle}: ${res.status}`);
+      } catch (err) {
+        console.warn(`[archetype-generator] HTML fetch error for ${screenTitle}: ${err.message}`);
+      }
     }
+
+    // For wireframe path (no HTML), use the screen description as source content
+    if (!screenHtml && screen.description) {
+      screenHtml = `<!-- Wireframe description for: ${screenTitle} -->\n<div class="wireframe-description">\n<h1>${screenTitle}</h1>\n<p>${screen.description}</p>\n</div>`;
+    }
+
     if (!screenHtml) {
-      console.warn(`[archetype-generator] Skipping ${screenTitle} — no HTML content`);
+      console.warn(`[archetype-generator] Skipping ${screenTitle} — no content available`);
       continue;
     }
 
-    // Extract device type from curation prompt metadata (SD-S17-DESIGN-INTELLIGENCE-ORCH-001-C)
-    const deviceType = deviceTypeMap.get(screenId) ?? screenPrompts[screenIdx]?.deviceType ?? 'DESKTOP';
-
-    // Classify page type for this screen (SD-S17-DESIGN-INTELLIGENCE-ORCH-001-B)
-    const classification = classifyPageType(screenTitle, screenPromptText);
+    // Classify page type
+    const classification = classifyPageType(screenTitle, screen.description);
     const layouts = classification.confidence >= 0.5
       ? getArchetypesForPageType(classification.pageType)
       : FALLBACK_LAYOUTS;
@@ -312,23 +379,20 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
 
     const variants = [];
 
-    const pngBase64 = pngMap.get(screenId);
-
     for (let i = 0; i < 6; i++) {
       const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType, deviceType });
 
-      // Build multimodal prompt: PNG screenshot (visual reference) + text prompt
       const userContent = [];
-      if (pngBase64) {
+      if (screen.png) {
         userContent.push({
           type: 'image',
-          source: { type: 'base64', media_type: 'image/png', data: pngBase64 }
+          source: { type: 'base64', media_type: 'image/png', data: screen.png }
         });
       }
       userContent.push({ type: 'text', text: promptText });
 
       const archetypeResult = await client.complete(
-        'You are a senior UI designer creating static visual mockup HTML. You are given both a screenshot and the HTML source of the original screen. Use both to understand the design intent, then create your variant. Return only the complete HTML.',
+        'You are a senior UI designer creating static visual mockup HTML. Generate a complete, self-contained HTML page based on the screen description and brand constraints. Return only the complete HTML.',
         userContent,
         { stream: true, timeout: 120000, cacheTTLMs: 0 }
       );
@@ -343,9 +407,6 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       console.log(`[archetype-generator] ${screenTitle} variant ${i + 1}/6 complete (${archetypeHtml.length} chars)`);
     }
 
-    // Write all 6 variants as ONE per-screen artifact.
-    // The unique index discriminates by metadata.screenId, so each screen
-    // gets its own is_current=true row.
     const artifactId = await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 17,
@@ -369,7 +430,8 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         screenId,
         pageType: classification.pageType,
         deviceType,
-        sourceArtifactId: exportArt.id,
+        sourceArtifactId,
+        screenSource,
         tokensApplied: !!tokens,
       },
     });
@@ -377,8 +439,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     artifactIds.push(artifactId);
     console.log(`[archetype-generator] Screen "${screenTitle}" complete (${screenIdx + 1}/${totalScreens})`);
 
-    // Auto-score variants async (fire-and-forget — scoring failures do not block generation)
-    // SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A: decoupled from generation loop
+    // Auto-score variants async (fire-and-forget)
     scoreVariants(ventureId, screenId, variants, {
       pageType: classification.pageType,
       deviceType,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2236,11 +2236,12 @@ export class StageExecutionWorker {
    * SD-LEO-FIX-FIX-STAGE-VENTURE-001: Wire postStage15Hook into pipeline.
    */
   async _postStageHook_S15_StitchProvision(ventureId) {
-    // SD-LEO-FIX-STITCH-INTEGRATION-WIRING-001: Route through provisioner for full business logic + artifact storage
-    const { postStage15Hook } = await import('./bridge/stitch-provisioner.js');
-    const { logStitchEvent } = await import('./bridge/stitch-adapter.js');
+    // SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A: Store wireframe screen data
+    // as venture_artifact instead of calling Stitch APIs. The archetype
+    // generator reads this artifact directly for S17 design generation.
+    const { writeArtifact } = await import('./artifact-persistence-service.js');
+
     // Read S15 data from venture_stage_work, falling back to venture_artifacts
-    // when advisory_data has null wireframes (wireframe sub-step may have failed)
     let s15Work = null;
     const { data: vsw } = await this._supabase
       .from('venture_stage_work')
@@ -2254,7 +2255,7 @@ export class StageExecutionWorker {
     if (vsw?.advisory_data && (vsw.advisory_data.wireframes || vsw.advisory_data.screens || vsw.advisory_data.ia_sitemap)) {
       s15Work = vsw;
     } else {
-      // Fallback: read from blueprint_wireframes artifact (has ia_sitemap even when wireframes are null)
+      // Fallback: read from blueprint_wireframes artifact
       const { data: artifact } = await this._supabase
         .from('venture_artifacts')
         .select('artifact_data')
@@ -2268,77 +2269,50 @@ export class StageExecutionWorker {
       }
     }
 
-    // Hard safety cap only. The provisioner and generateScreens own their own
-    // per-screen timeouts (~60s GFE + 300s SDK). Trying to estimate the screen
-    // count here is brittle — the provisioner injects pages, applies platform
-    // logic, and may change independently. A generous hard cap prevents infinite
-    // hangs without silently truncating generation.
-    const STITCH_PROVISION_TIMEOUT_MS = parseInt(process.env.STITCH_PROVISION_TIMEOUT_MS || '2700000', 10); // 45 min
-    const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), STITCH_PROVISION_TIMEOUT_MS);
-    let result;
-    try {
-      result = await Promise.race([
-        postStage15Hook(ventureId, s15Work),
-        new Promise((_, reject) => {
-          ac.signal.addEventListener('abort', () =>
-            reject(new Error(`[S15] Stitch provisioner timed out after ${STITCH_PROVISION_TIMEOUT_MS / 1000}s`))
-          );
-        }),
-      ]);
-    } catch (provisionerErr) {
-      // Provisioner timed out or errored — still try reconciliation
-      this._logger.warn(`[Worker] S15 provisioner error (non-fatal, reconciling): ${provisionerErr.message}`);
-    } finally {
-      clearTimeout(timer);
+    if (!s15Work?.advisory_data) {
+      this._logger.warn('[Worker] S15 post-hook: no wireframe data found, skipping artifact creation');
+      return;
     }
 
-    // Post-S15: Reconcile screen IDs regardless of provisioner outcome.
-    // The provisioner may have timed out (abort guard), but Stitch generates
-    // screens server-side. The reconciler polls get_project to capture IDs.
-    try {
-      const { reconcileScreenIds } = await import('./bridge/stitch-reconciler.js');
-      const reconciled = await reconcileScreenIds(ventureId, { maxWaitMs: 300_000, pollIntervalMs: 30_000 });
-      this._logger.info(`[Worker] S15 reconciliation: ${reconciled.confirmed}/${reconciled.total} screens confirmed`);
-    } catch (reconcileErr) {
-      this._logger.warn(`[Worker] S15 reconciliation failed (non-fatal): ${reconcileErr.message}`);
-    }
+    const advisoryData = s15Work.advisory_data;
 
-    // Fallback: when Stitch unavailable, continue with ASCII wireframes
-    if (result?.status === 'unavailable' || result?.status === 'no_op') {
-      logStitchEvent({ event: 's15_fallback', ventureId, stage: 15, status: 'fallback_ascii' });
-      this._logger.warn(`[Worker] S15 Stitch unavailable (${result.reason || result.status}), continuing with ASCII wireframes`);
-      await this._supabase
-        .from('venture_stage_work')
-        .update({
-          advisory_data: {
-            ...(s15Work?.advisory_data || {}),
-            stitch_hook_status: 'unavailable',
-            stitch_fallback: 'ascii_wireframes',
-          },
-        })
-        .eq('venture_id', ventureId)
-        .eq('lifecycle_stage', 15)
-        .order('created_at', { ascending: false })
-        .limit(1);
-      return; // S15 continues normally with ASCII wireframes
-    }
+    // Extract screens from advisory_data — S15 stores them in different shapes
+    const rawScreens = advisoryData.screens
+      ?? advisoryData.wireframes?.screens
+      ?? advisoryData.ia_sitemap?.pages
+      ?? [];
 
-    this._logger.log(`[Worker] S15 post-stage hook: stitch provisioner ${result?.status || 'completed'}`);
-    if (s15Work) {
-      await this._supabase
-        .from('venture_stage_work')
-        .update({
-          advisory_data: {
-            ...(s15Work?.advisory_data || {}),
-            stitch_hook_status: result?.status || 'completed',
-          },
-        })
-        .eq('venture_id', ventureId)
-        .eq('lifecycle_stage', 15)
-        .order('created_at', { ascending: false })
-        .limit(1);
-    }
+    // Normalize screen data for downstream consumption by archetype-generator
+    const screens = rawScreens.map((screen, idx) => ({
+      screen_id: screen.screen_id ?? screen.id ?? `screen-${idx}`,
+      screen_name: screen.screen_name ?? screen.name ?? screen.title ?? `Screen ${idx + 1}`,
+      description: screen.description ?? screen.prompt ?? screen.text ?? '',
+      deviceType: screen.deviceType ?? screen.device_type ?? 'DESKTOP',
+      page_type: screen.page_type ?? screen.pageType ?? null,
+    }));
+
+    // Write wireframe_screens artifact for archetype-generator consumption
+    await writeArtifact(this._supabase, {
+      ventureId,
+      lifecycleStage: 15,
+      artifactType: 'wireframe_screens',
+      title: `Wireframe Screens (${screens.length} screens)`,
+      content: JSON.stringify({ screens, source: 'S15_advisory_data' }),
+      artifactData: {
+        screens,
+        screenCount: screens.length,
+        ia_sitemap: advisoryData.ia_sitemap ?? null,
+      },
+      qualityScore: 80,
+      validationStatus: 'validated',
+      source: 'stage-15-post-hook',
+      metadata: {
+        screenCount: screens.length,
+        deviceTypes: [...new Set(screens.map(s => s.deviceType))],
+      },
+    });
+
+    this._logger.log(`[Worker] S15 post-hook: stored ${screens.length} wireframe screens as artifact (Stitch bypassed)`);
   }
 
   async _postStageHook_S17_DocGen(ventureId) {


### PR DESCRIPTION
## Summary
- S15 post-hook stores wireframe screen data as `wireframe_screens` artifact instead of calling Stitch APIs
- archetype-generator.js reads from `wireframe_screens` with fallback to `stitch_design_export` for legacy ventures
- Adds `wireframe_screens` to artifact type registry and DB constraint (migration included + executed)
- Eliminates Stitch 60s GFE timeouts, broken listScreens, and 35-70% capture rate failures

## Test plan
- [ ] Verify `artifact-types.js` exports `wireframe_screens` and `isValidArtifactType('wireframe_screens')` returns true
- [ ] Verify `archetype-generator.js` compiles and exports correctly
- [ ] Push a venture to S17 — archetypes should generate without Stitch calls in server logs
- [ ] Legacy ventures with `stitch_design_export` should still generate correctly (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)