### PR TITLE
fix(SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001): remove Stitch legacy fallbacks, fix S17 config

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -74,7 +74,6 @@ export class ArchetypeGenerationError extends Error {
  * @returns {Promise<{ source: 'wireframe_screens'|'stitch_design_export', artifact: object|null }>}
  */
 async function fetchScreenSourceArtifact(supabase, ventureId) {
-  // Primary: wireframe_screens (SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-A)
   const { data: wireframeArt } = await supabase
     .from('venture_artifacts')
     .select('id, artifact_type, artifact_data, content, metadata, title')
@@ -84,42 +83,7 @@ async function fetchScreenSourceArtifact(supabase, ventureId) {
     .limit(1)
     .maybeSingle();
 
-  if (wireframeArt) {
-    return { source: 'wireframe_screens', artifact: wireframeArt };
-  }
-
-  // Fallback: stitch_design_export (legacy ventures)
-  const { data: stitchArt } = await supabase
-    .from('venture_artifacts')
-    .select('id, artifact_type, artifact_data, content, metadata, title')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_design_export')
-    .eq('is_current', true)
-    .limit(1)
-    .maybeSingle();
-
-  if (stitchArt) {
-    return { source: 'stitch_design_export', artifact: stitchArt };
-  }
-
-  return { source: 'wireframe_screens', artifact: null };
-}
-
-/**
- * Fetch all current stitch_design_export artifacts for a venture.
- * @deprecated Use fetchScreenSourceArtifact instead
- */
-async function fetchStitchArtifacts(supabase, ventureId) {
-  const { data, error } = await supabase
-    .from('venture_artifacts')
-    .select('id, artifact_type, artifact_data, content, metadata, title')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 'stitch_design_export')
-    .eq('is_current', true)
-    .order('created_at', { ascending: false });
-
-  if (error) throw new Error(`[archetype-generator] DB fetch error: ${error.message}`);
-  return data ?? [];
+  return { source: 'wireframe_screens', artifact: wireframeArt ?? null };
 }
 
 /**
@@ -250,67 +214,28 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   let screenList = [];     // [{ screen_id, screen_name, description, deviceType, html?, png? }]
   let sourceArtifactId = null;
 
-  if (screenSource === 'wireframe_screens' && sourceArt) {
-    // New path: wireframe_screens artifact from S15 post-hook
-    sourceArtifactId = sourceArt.id;
-    const screens = sourceArt.artifact_data?.screens ?? [];
-    if (!screens.length) {
-      throw new ArchetypeGenerationError(
-        `wireframe_screens artifact found but contains no screens for venture ${ventureId}.`
-      );
-    }
-    screenList = screens.map((s, idx) => ({
-      screen_id: s.screen_id ?? `screen-${idx}`,
-      screen_name: s.screen_name ?? s.name ?? `Screen ${idx + 1}`,
-      description: s.description ?? '',
-      deviceType: s.deviceType ?? 'DESKTOP',
-      html: null,   // wireframe path has no pre-rendered HTML
-      png: null,
-    }));
-  } else if (screenSource === 'stitch_design_export' && sourceArt) {
-    // Legacy path: stitch_design_export with HTML URLs
-    sourceArtifactId = sourceArt.id;
-    const htmlFiles = sourceArt.metadata?.html_files ?? [];
-    if (!htmlFiles.length) {
-      throw new ArchetypeGenerationError(
-        `stitch_design_export found but has no html_files for venture ${ventureId}.`
-      );
-    }
-    const pngFiles = sourceArt.metadata?.png_files_base64 ?? [];
-    const pngMap = new Map();
-    for (const png of pngFiles) {
-      if (png.screen_id && png.base64) pngMap.set(png.screen_id, png.base64);
-    }
-
-    // Load screen names from stitch_curation for legacy path
-    const { data: curationArt } = await supabase
-      .from('venture_artifacts')
-      .select('artifact_data')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', 'stitch_curation')
-      .eq('lifecycle_stage', 15)
-      .limit(1)
-      .maybeSingle();
-    const screenPrompts = curationArt?.artifact_data?.screen_prompts ?? [];
-    const genResults = curationArt?.artifact_data?.generation_results ?? [];
-
-    screenList = htmlFiles.map((file, idx) => {
-      const id = file.screen_id ?? `screen-${idx}`;
-      return {
-        screen_id: id,
-        screen_name: screenPrompts[idx]?.screen_name ?? screenPrompts[idx]?._screenName ?? `Screen ${idx + 1}`,
-        description: screenPrompts[idx]?.prompt ?? screenPrompts[idx]?.text ?? '',
-        deviceType: screenPrompts[idx]?.deviceType ?? 'DESKTOP',
-        htmlUrl: file.html,
-        png: pngMap.get(id) ?? null,
-      };
-    });
-  } else {
+  if (!sourceArt) {
     throw new ArchetypeGenerationError(
-      `No wireframe_screens or stitch_design_export artifact found for venture ${ventureId}. ` +
+      `No wireframe_screens artifact found for venture ${ventureId}. ` +
       'Stage 15 must complete before Stage 17 archetype generation.'
     );
   }
+
+  sourceArtifactId = sourceArt.id;
+  const screens = sourceArt.artifact_data?.screens ?? [];
+  if (!screens.length) {
+    throw new ArchetypeGenerationError(
+      `wireframe_screens artifact found but contains no screens for venture ${ventureId}.`
+    );
+  }
+  screenList = screens.map((s, idx) => ({
+    screen_id: s.screen_id ?? `screen-${idx}`,
+    screen_name: s.screen_name ?? s.name ?? `Screen ${idx + 1}`,
+    description: s.description ?? '',
+    deviceType: s.deviceType ?? 'DESKTOP',
+    html: null,
+    png: null,
+  }));
 
   console.log(`[archetype-generator] ${screenList.length} screens to process (source: ${screenSource})`);
 
@@ -347,28 +272,11 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     const screenTitle = screen.screen_name;
     const deviceType = screen.deviceType;
 
-    // Resolve screen content: fetch HTML for legacy path, use description for wireframe path
-    let screenHtml = '';
-    if (screen.htmlUrl) {
-      // Legacy stitch path: fetch HTML from URL
-      try {
-        const res = await fetch(screen.htmlUrl);
-        if (res.ok) screenHtml = await res.text();
-        else console.warn(`[archetype-generator] Failed to fetch HTML for ${screenTitle}: ${res.status}`);
-      } catch (err) {
-        console.warn(`[archetype-generator] HTML fetch error for ${screenTitle}: ${err.message}`);
-      }
-    }
+    // Build source content from wireframe screen description
+    const screenHtml = screen.description
+      ? `<!-- Wireframe: ${screenTitle} -->\n<div class="wireframe-description">\n<h1>${screenTitle}</h1>\n<p>${screen.description}</p>\n</div>`
+      : `<div><h1>${screenTitle}</h1><p>Screen design for ${deviceType} viewport</p></div>`;
 
-    // For wireframe path (no HTML), use the screen description as source content
-    if (!screenHtml && screen.description) {
-      screenHtml = `<!-- Wireframe description for: ${screenTitle} -->\n<div class="wireframe-description">\n<h1>${screenTitle}</h1>\n<p>${screen.description}</p>\n</div>`;
-    }
-
-    if (!screenHtml) {
-      console.warn(`[archetype-generator] Skipping ${screenTitle} — no content available`);
-      continue;
-    }
 
     // Classify page type
     const classification = classifyPageType(screenTitle, screen.description);

--- a/scripts/config/stage-artifact-config.json
+++ b/scripts/config/stage-artifact-config.json
@@ -115,10 +115,10 @@
     },
     {
       "stage_number": 17,
-      "artifact_type": "stitch_curation",
-      "required_status": "curated",
+      "artifact_type": "s17_archetypes",
+      "required_status": "completed",
       "is_blocking": true,
-      "description": "Stitch curation must be curated before leaving Stage 17 (Design Review)"
+      "description": "S17 archetypes must be completed before leaving Stage 17 (Design Review)"
     },
     {
       "stage_number": 18,

--- a/scripts/seed-stage-artifact-requirements.js
+++ b/scripts/seed-stage-artifact-requirements.js
@@ -69,7 +69,7 @@ async function seed() {
     .from('stage_artifact_requirements')
     .select('artifact_type, is_blocking, required_status')
     .eq('stage_number', 17)
-    .eq('artifact_type', 'stitch_curation')
+    .eq('artifact_type', 's17_archetypes')
     .single();
 
   if (stage15) {
@@ -79,9 +79,9 @@ async function seed() {
   }
 
   if (stage17) {
-    console.log(`  Stage 17: stitch_curation, required_status=${stage17.required_status}, is_blocking=${stage17.is_blocking}`);
+    console.log(`  Stage 17: s17_archetypes, required_status=${stage17.required_status}, is_blocking=${stage17.is_blocking}`);
   } else {
-    console.error('  ❌ Stage 17 stitch_curation requirement NOT found');
+    console.error('  ❌ Stage 17 s17_archetypes requirement NOT found');
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove stitch_design_export legacy fallback from archetype-generator.js — wireframe_screens is sole source
- Fix stage-artifact-config.json: S17 requires s17_archetypes (not stitch_curation)
- Fix seed-stage-artifact-requirements.js verification

## Context
RCA from ComplyBot venture run discovered `stage_artifact_requirements` table and seed config still required `stitch_curation` at S17, and DB CHECK constraint was missing `wireframe_screens`. Both fixed in DB (live) and config (this PR).

## Test plan
- [x] CodeDoc AI venture ran S3-S17 with zero Stitch artifacts
- [x] `wireframe_screens` artifact created at S15
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)