### PR TITLE
refactor(SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001): S17 simplification — 4 variants, no LLM scoring, fix qa-rubric

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -1,13 +1,15 @@
 /**
  * Stage 17 Archetype Generation Engine
  *
- * Generates 6 distinct HTML design archetypes per screen by calling Claude
- * with each stitch_design_export artifact and locked brand token constraints.
- * Results are persisted as s17_archetypes venture_artifacts — one artifact
- * per screen (containing all 6 variants), discriminated by metadata.screenId.
+ * Generates 4 distinct HTML design archetypes per screen using wireframe_screens
+ * artifact and locked brand token constraints. Results are persisted as
+ * s17_archetypes venture_artifacts — one artifact per screen (containing all
+ * 4 variants), discriminated by metadata.screenId.
+ *
+ * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Reduced to 4 variants, removed LLM scoring.
  *
  * Exports:
- *   generateArchetypes(ventureId, supabase) — generate 6 archetypes per screen
+ *   generateArchetypes(ventureId, supabase) — generate 4 archetypes per screen
  *
  * SD-MAN-ORCH-STAGE-DESIGN-REFINEMENT-001-A
  * SD-S17-DESIGN-INTELLIGENCE-ORCH-001-A (per-screen storage migration)
@@ -17,7 +19,7 @@
 import { getTokenConstraints } from './token-manifest.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { classifyPageType, getArchetypesForPageType } from './page-type-classifier.js';
-import { scoreVariants } from './scoring-engine.js';
+// SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: LLM scoring removed, deterministic only
 
 /**
  * Query venture_artifacts for screens that already have completed s17_archetypes.
@@ -44,14 +46,13 @@ async function getCompletedScreens(supabase, ventureId) {
   return completed;
 }
 
-/** Fallback layouts used when page-type classification fails. */
+/** Fallback layouts used when page-type classification fails.
+ * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Reduced from 6 to 4 variants. */
 const FALLBACK_LAYOUTS = [
   'hero-centric with full-width header and content below',
   'card-grid layout with equal-weight content tiles',
   'sidebar navigation with content-right panel',
   'single-column minimal with generous whitespace',
-  'split-screen with media left and text right',
-  'dashboard-style with data visualization prominence',
 ];
 
 /**
@@ -165,7 +166,7 @@ editorial touch, or non-template component treatment. Annotate it with an HTML c
 <!-- distinctive move: [describe your deliberate design choice] -->
 This is MANDATORY. Variants without a distinctive move score poorly on U7.`;
 
-  return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 6 for this screen.
+  return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 4 for this screen.
 ${pageTypeContext}${deviceInstructions}
 ${rubricGuidance}
 
@@ -287,7 +288,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
 
     const variants = [];
 
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < 4; i++) {
       const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType, deviceType });
 
       const userContent = [];
@@ -319,7 +320,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       ventureId,
       lifecycleStage: 17,
       artifactType: 's17_archetypes',
-      title: `${screenTitle} — 6 Archetypes`,
+      title: `${screenTitle} — 4 Archetypes`,
       content: JSON.stringify({ screenName: screenTitle, pageType: classification.pageType, deviceType, variants }),
       artifactData: {
         screenId,
@@ -347,18 +348,8 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     artifactIds.push(artifactId);
     console.log(`[archetype-generator] Screen "${screenTitle}" complete (${screenIdx + 1}/${totalScreens})`);
 
-    // Auto-score variants async (fire-and-forget)
-    scoreVariants(ventureId, screenId, variants, {
-      pageType: classification.pageType,
-      deviceType,
-    }, supabase).then(scoringResult => {
-      const bestScore = scoringResult.variants[0]?.finalScore ?? 0;
-      console.log(`[archetype-generator] Scored ${screenTitle}: best=${bestScore.toFixed(1)}, anti-patterns=${scoringResult.variants[0]?.triggeredAntiPatterns?.length ?? 0}`);
-    }).catch(scoreErr => {
-      console.error(`[archetype-generator] Scoring FAILED for ${screenTitle}: ${scoreErr.message}`, {
-        ventureId, screenId, error: scoreErr.message,
-      });
-    });
+    // SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: LLM scoring removed.
+    // Deterministic scoring (CSS/HTML signals) applied at frontend display time.
   }
 
   return { screenCount: totalScreens, artifactIds };

--- a/lib/eva/stage-17/qa-rubric.js
+++ b/lib/eva/stage-17/qa-rubric.js
@@ -62,7 +62,7 @@ async function fetchApprovedArtifacts(supabase, ventureId) {
     .select('id, artifact_type, content, metadata, title')
     .eq('venture_id', ventureId)
     .eq('is_current', true)
-    .in('artifact_type', ['stage_17_approved_mobile', 'stage_17_approved_desktop']);
+    .eq('artifact_type', 's17_approved');
 
   if (error) throw new Error(`[qa-rubric] DB fetch error: ${error.message}`);
   return data ?? [];
@@ -76,8 +76,8 @@ async function fetchApprovedArtifacts(supabase, ventureId) {
  */
 function runLayer1(approvedArtifacts) {
   const items = [];
-  const mobileCount = approvedArtifacts.filter(a => a.artifact_type === 'stage_17_approved_mobile').length;
-  const desktopCount = approvedArtifacts.filter(a => a.artifact_type === 'stage_17_approved_desktop').length;
+  const desktopCount = approvedArtifacts.filter(a => a.metadata?.platform !== 'mobile').length;
+  const mobileCount = approvedArtifacts.filter(a => a.metadata?.platform === 'mobile').length;
   const totalCount = approvedArtifacts.length;
 
   if (totalCount < EXPECTED_APPROVED_COUNT) {
@@ -304,7 +304,7 @@ export async function uploadToGitHub(ventureId, supabase, options = {}) {
 
   for (const artifact of approvedArtifacts) {
     const screenId = artifact.metadata?.screenId ?? artifact.id.slice(0, 8);
-    const platform = artifact.artifact_type === 'stage_17_approved_mobile' ? 'mobile' : 'desktop';
+    const platform = artifact.metadata?.platform ?? 'desktop';
     const filePath = `ventures/${ventureId}/documents/stage-17/${screenId}-${platform}.html`;
     const content = artifact.content ?? '';
 


### PR DESCRIPTION
## Summary
- Reduce archetype variants from 6 to 4 per screen (~33% faster generation)
- Remove LLM scoring dependency (scoring-engine.js no longer imported — eliminates 270 LLM calls per venture)
- Fix qa-rubric.js artifact type mismatch: `stage_17_approved_mobile/desktop` → `s17_approved`

## Context
Part of S17 simplification brainstorm. Vision: VISION-S17-SIMPLIFY-L2-001. Arch: ARCH-S17-SIMPLIFY-001.
Backend-only changes in this PR. Frontend changes (single-pick UI, completion celebration) follow in Phase 2.

## Test plan
- [x] archetype-generator.js compiles with 4 variants
- [x] qa-rubric.js compiles with correct artifact types
- [ ] Next venture run generates 4 variants per screen (not 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)