### PR TITLE
fix(S17): durable archetype generation + 4 provider adapter bugs

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -249,9 +249,11 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   // 2. Load brand token manifest
   const tokens = await getTokenConstraints(ventureId, supabase);
 
-  // 3. Import LLM client
+  // 3. Import LLM client — use Anthropic Claude for design generation
   const { getLLMClient } = await import('../../llm/client-factory.js');
-  const client = getLLMClient({ purpose: 'generation' });
+  const { getClaudeModel } = await import('../../config/model-config.js');
+  const generationModel = getClaudeModel('generation'); // claude-opus-4-6 or newer
+  const client = getLLMClient({ purpose: 'generation', provider: 'anthropic', model: generationModel });
 
   const artifactIds = [];
   const totalScreens = screenList.length;
@@ -303,7 +305,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       const archetypeResult = await client.complete(
         'You are a senior UI designer creating static visual mockup HTML. Generate a complete, self-contained HTML page based on the screen description and brand constraints. Return only the complete HTML.',
         userContent,
-        { stream: true, timeout: 120000, cacheTTLMs: 0 }
+        { stream: true, timeout: 300000, cacheTTLMs: 0, maxTokens: 32768, purpose: 'content-generation' }
       );
       const archetypeHtml = archetypeResult?.content ?? String(archetypeResult);
 
@@ -411,7 +413,7 @@ Produce one complete, self-contained HTML document with inline CSS. Output ONLY 
     const refinedResult = await client.complete(
       'You are a senior UI designer refining chosen design archetypes. Return only the complete HTML.',
       prompt,
-      { stream: true, timeout: 120000, cacheTTLMs: 0 }
+      { stream: true, timeout: 120000, cacheTTLMs: 0, maxTokens: 32768, purpose: 'content-generation' }
     );
     const refinedHtml = refinedResult?.content ?? String(refinedResult);
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2286,7 +2286,7 @@ export class StageExecutionWorker {
     const screens = rawScreens.map((screen, idx) => ({
       screen_id: screen.screen_id ?? screen.id ?? `screen-${idx}`,
       screen_name: screen.screen_name ?? screen.name ?? screen.title ?? `Screen ${idx + 1}`,
-      description: screen.description ?? screen.prompt ?? screen.text ?? '',
+      description: screen.description ?? screen.purpose ?? screen.prompt ?? screen.text ?? '',
       deviceType: screen.deviceType ?? screen.device_type ?? 'DESKTOP',
       page_type: screen.page_type ?? screen.pageType ?? null,
     }));
@@ -2327,8 +2327,18 @@ export class StageExecutionWorker {
     });
     this._logger.log('[Worker] S17 post-stage hook: vision + architecture docs generated');
 
-    // SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-B: Stitch export removed.
-    // S17 archetype generation now uses wireframe_screens artifact (Phase 1).
+    // SD-MAN-REFAC-S17-SIMPLIFY-FRONTEND-001: Auto-trigger archetype generation
+    // from the durable worker process (not fire-and-forget Express promise).
+    // Uses stateless resume — skips screens that already have completed artifacts.
+    try {
+      const { generateArchetypes } = await import('./stage-17/archetype-generator.js');
+      this._logger.log('[Worker] S17 post-stage hook: starting archetype generation...');
+      const result = await generateArchetypes(ventureId, this._supabase);
+      this._logger.log(`[Worker] S17 archetypes complete: ${result.screenCount} screens, ${result.artifactIds.length} artifacts`);
+    } catch (archErr) {
+      // Non-fatal: chairman can re-trigger from frontend if worker generation fails
+      this._logger.warn(`[Worker] S17 archetype generation failed (non-fatal): ${archErr.message}`);
+    }
   }
 
   /**

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -44,6 +44,17 @@ function sleep(ms) {
  */
 function sanitizeUnicode(value) {
   if (value == null) return '';
+  // Preserve arrays (content block arrays for multimodal prompts)
+  if (Array.isArray(value)) {
+    return value.map(item => {
+      if (typeof item === 'object' && item !== null) {
+        return Object.fromEntries(
+          Object.entries(item).map(([k, v]) => [k, typeof v === 'string' ? sanitizeUnicode(v) : v])
+        );
+      }
+      return typeof item === 'string' ? sanitizeUnicode(item) : item;
+    });
+  }
   if (typeof value !== 'string') return typeof value === 'object' ? JSON.stringify(value) : String(value);
 
   let result = '';
@@ -152,7 +163,8 @@ export class AnthropicAdapter {
           model,
           max_tokens: options.maxTokens || options.max_tokens || 8192,
           system: sanitizeUnicode(systemPrompt),
-          messages: [{ role: 'user', content: sanitizeUnicode(userPrompt) }]
+          // Preserve array content blocks for multimodal (images + text)
+          messages: [{ role: 'user', content: Array.isArray(userPrompt) ? sanitizeUnicode(userPrompt) : sanitizeUnicode(userPrompt) }]
         };
 
         // Add thinking support when budget_tokens specified
@@ -232,20 +244,24 @@ export class AnthropicAdapter {
    */
   async _completeWithStreaming(requestParams, options = {}) {
     const timeout = options.timeout || PROVIDER_TIMEOUT_MS;
-
     const stream = this.client.messages.stream(requestParams);
 
-    const finalMessage = await Promise.race([
-      stream.finalMessage(),
-      new Promise((_, reject) =>
-        setTimeout(() => {
-          stream.abort();
-          reject(new Error('TIMEOUT'));
-        }, timeout)
-      )
-    ]);
+    let timeoutId;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        stream.abort();
+        reject(new Error('TIMEOUT'));
+      }, timeout);
+    });
 
-    return finalMessage;
+    try {
+      const finalMessage = await Promise.race([stream.finalMessage(), timeoutPromise]);
+      clearTimeout(timeoutId);
+      return finalMessage;
+    } catch (err) {
+      clearTimeout(timeoutId);
+      throw err;
+    }
   }
 }
 
@@ -397,7 +413,10 @@ export class GoogleAdapter {
           generationConfig.responseMimeType = 'application/json';
         }
 
-        // Thinking level support
+        // Thinking level support — skip for pure content generation to maximize output tokens
+        if (options.thinking === false || options.purpose === 'content-generation') {
+          // No thinking config — all output tokens go to content
+        } else {
         const effortLevel = options.effortLevel || this.effortLevel;
         const isGemini3x = /^gemini-3/.test(model);
         const isGemini2_5 = /^gemini-2\.5/.test(model);
@@ -420,22 +439,28 @@ export class GoogleAdapter {
           const cappedBudget = Math.min(budget, Math.floor(maxOutput * 0.5));
           generationConfig.thinkingConfig = { thinkingBudget: cappedBudget };
         }
+        } // end thinking config else block
 
-        const response = await fetch(
-          `${this.baseUrl}/models/${model}:generateContent?key=${this.apiKey}`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              ...(systemPrompt ? { systemInstruction: { parts: [{ text: sanitizeUnicode(systemPrompt) }] } } : {}),
-              contents: [{ role: 'user', parts: [{ text: sanitizeUnicode(userPrompt || 'Hello') }] }],
-              generationConfig
-            }),
-            signal: controller.signal
-          }
-        );
+        // Use streaming endpoint for long-form generation to avoid connection drops
+        const endpoint = options.stream
+          ? `${this.baseUrl}/models/${model}:streamGenerateContent?key=${this.apiKey}&alt=sse`
+          : `${this.baseUrl}/models/${model}:generateContent?key=${this.apiKey}`;
+
+        // Build user content — preserve array content blocks for multimodal
+        const userParts = Array.isArray(userPrompt)
+          ? userPrompt.map(p => p.type === 'text' ? { text: sanitizeUnicode(p.text) } : p)
+          : [{ text: sanitizeUnicode(userPrompt || 'Hello') }];
+
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...(systemPrompt ? { systemInstruction: { parts: [{ text: sanitizeUnicode(systemPrompt) }] } } : {}),
+            contents: [{ role: 'user', parts: userParts }],
+            generationConfig
+          }),
+          signal: controller.signal
+        });
 
         clearTimeout(timeoutId);
 
@@ -444,7 +469,23 @@ export class GoogleAdapter {
           throw new Error(`Google API error ${response.status}: ${errorBody}`);
         }
 
-        const data = await response.json();
+        let data;
+        if (options.stream) {
+          // Parse SSE stream — accumulate text chunks
+          const text = await response.text();
+          const chunks = text.split('\n').filter(l => l.startsWith('data: ')).map(l => {
+            try { return JSON.parse(l.slice(6)); } catch { return null; }
+          }).filter(Boolean);
+          // Merge chunks into single response
+          const allText = chunks.map(c => c.candidates?.[0]?.content?.parts?.[0]?.text ?? '').join('');
+          const lastChunk = chunks[chunks.length - 1] ?? {};
+          data = {
+            candidates: [{ content: { parts: [{ text: allText }] }, finishReason: lastChunk.candidates?.[0]?.finishReason }],
+            usageMetadata: lastChunk.usageMetadata
+          };
+        } else {
+          data = await response.json();
+        }
         const durationMs = Date.now() - startTime;
 
         const content = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
@@ -483,7 +524,7 @@ export class GoogleAdapter {
     }
 
     // Fallback: if rate-limited (429) or service unavailable (503), try fallback models before giving up
-    const isRetryableError = lastError?.message?.includes('429') || lastError?.message?.includes('503');
+    const isRetryableError = lastError?.message?.includes('429') || lastError?.message?.includes('503') || lastError?.message?.includes('fetch failed');
     if (this.fallbackEnabled && !options._fallbackAttempt && isRetryableError) {
       const triedModel = model;
       const fallbacks = GoogleAdapter.FALLBACK_MODELS.filter(m => m !== triedModel);

--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -178,6 +178,19 @@ function Start-App {
         }
     }
 
+    # Auto-pull latest from remote before starting (SD-MAN-REFAC-S17-SIMPLIFY-FRONTEND-001)
+    Push-Location $AppDir
+    $gitPull = & git pull origin main 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $changes = ($gitPull | Select-String "files changed|Already up to date" | Out-String).Trim()
+        if ($changes -and -not ($changes -match "Already up to date")) {
+            Write-Log "INFO" "[UI] Pulled latest: $changes" "Cyan"
+        }
+    } else {
+        Write-Log "WARN" "[UI] git pull failed (non-blocking): $gitPull" "Yellow"
+    }
+    Pop-Location
+
     # Auto-install if node_modules missing (fleet ops can clobber them)
     $viteBin = Join-Path $AppDir "node_modules\.bin\vite.cmd"
     if (-not (Test-Path $viteBin)) {


### PR DESCRIPTION
## Summary
- Wire archetype generation into S17 post-stage hook (durable worker, not fire-and-forget Express promise)
- Fix 4 provider adapter bugs identified by RCA:
  1. sanitizeUnicode: preserve array content blocks for multimodal prompts
  2. GoogleAdapter: add SSE streaming for long-form generation
  3. GoogleAdapter: skip thinking budget for content-generation
  4. AnthropicAdapter: fix timer leak in _completeWithStreaming
- archetype-generator: Anthropic Opus, 300s timeout, 32768 maxTokens
- leo-stack.ps1: auto git-pull ehg repo before starting frontend

## Test plan
- [x] Smoke tests pass (15/15)
- [x] provider-adapters compiles with all 4 fixes
- [x] archetype-generator compiles with Anthropic routing
- [ ] New venture reaching S17 auto-generates archetypes via worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)