### PR TITLE
fix(S17): archetype reconciler in worker poll loop

### DIFF
--- a/lib/eva/stage-17/auto-resume.js
+++ b/lib/eva/stage-17/auto-resume.js
@@ -5,7 +5,7 @@
  * and queues sequential resume for each. Uses venture_artifacts as the
  * checkpoint — no new tables needed.
  *
- * SD-S17-ARCHETYPE-GENERATION-RESILIENCE-ORCH-001-A
+ * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Updated for wireframe_screens path.
  * @module lib/eva/stage-17/auto-resume
  */
 
@@ -19,42 +19,43 @@ const supabase = createClient(
 );
 
 /**
- * Find ventures with partial S17 archetype coverage and resume generation.
- * A venture is "incomplete" if it has a stitch_design_export with N screens
+ * Find ventures with missing or partial S17 archetype coverage and resume generation.
+ * A venture is "incomplete" if it has a wireframe_screens artifact with N screens
  * but fewer than N s17_archetypes artifacts.
  */
 export async function resumeIncompleteArchetypeJobs() {
-  // Find all ventures with stitch exports (candidates for S17)
-  const { data: exports } = await supabase
+  // Find ventures at S17 with wireframe_screens artifacts
+  const { data: wireframes } = await supabase
     .from('venture_artifacts')
-    .select('venture_id, metadata')
-    .eq('artifact_type', 'stitch_design_export')
+    .select('venture_id, artifact_data')
+    .eq('artifact_type', 'wireframe_screens')
     .eq('is_current', true);
 
-  if (!exports?.length) {
-    console.log('[auto-resume] No stitch exports found — nothing to resume');
+  if (!wireframes?.length) {
+    console.log('[auto-resume] No wireframe_screens found — nothing to resume');
     return;
   }
 
   const incompleteJobs = [];
 
-  for (const exp of exports) {
-    const totalScreens = exp.metadata?.html_files?.length ?? 0;
+  for (const wf of wireframes) {
+    const totalScreens = wf.artifact_data?.screens?.length ?? 0;
     if (totalScreens === 0) continue;
 
     // Count completed S17 archetypes for this venture
     const { count } = await supabase
       .from('venture_artifacts')
       .select('id', { count: 'exact', head: true })
-      .eq('venture_id', exp.venture_id)
+      .eq('venture_id', wf.venture_id)
       .eq('artifact_type', 's17_archetypes')
       .eq('lifecycle_stage', 17)
       .eq('is_current', true);
 
-    if ((count ?? 0) > 0 && (count ?? 0) < totalScreens) {
+    // Detect both zero-archetype AND partial-archetype ventures
+    if ((count ?? 0) < totalScreens) {
       incompleteJobs.push({
-        ventureId: exp.venture_id,
-        completed: count,
+        ventureId: wf.venture_id,
+        completed: count ?? 0,
         total: totalScreens,
       });
     }
@@ -70,7 +71,6 @@ export async function resumeIncompleteArchetypeJobs() {
     console.log(`  ${job.ventureId}: ${job.completed}/${job.total} screens`);
   }
 
-  // Call generateArchetypes directly (no HTTP auth needed)
   const { generateArchetypes } = await import('./archetype-generator.js');
 
   for (const job of incompleteJobs) {

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -424,6 +424,7 @@ export class StageExecutionWorker {
       );
       await this._releaseStaleLocks();
       await this._checkResolvedBlocks();
+      await this._reconcileS17Archetypes();
       await this._markStaleExecutions();
 
       const ventures = await this._pollForWork();
@@ -1820,6 +1821,79 @@ export class StageExecutionWorker {
       this._logger.log(`[Worker] Startup recovery complete: ${orphaned.length} venture(s) reset`);
     } catch (err) {
       this._logger.error(`[Worker] Startup recovery error: ${err.message}`);
+    }
+  }
+
+  /**
+   * S17 Archetype Reconciler — detect ventures at S17 with wireframe_screens
+   * but incomplete s17_archetypes and trigger generation.
+   *
+   * Runs every tick but rate-limited: skips ventures attempted in last 5 minutes.
+   * Uses stateless resume (generateArchetypes skips completed screens).
+   *
+   * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Systemic recovery for stuck S17 ventures.
+   */
+  async _reconcileS17Archetypes() {
+    try {
+      // Find active ventures at S17
+      const { data: s17Ventures } = await this._supabase
+        .from('ventures')
+        .select('id, name')
+        .eq('status', 'active')
+        .eq('current_lifecycle_stage', 17);
+
+      if (!s17Ventures || s17Ventures.length === 0) return;
+
+      for (const venture of s17Ventures) {
+        // Rate limit: skip if attempted in last 5 minutes
+        const lastAttempt = this._s17ReconcileAttempts?.get(venture.id);
+        if (lastAttempt && Date.now() - lastAttempt < 300_000) continue;
+
+        // Check if wireframe_screens exists
+        const { data: wireframes } = await this._supabase
+          .from('venture_artifacts')
+          .select('artifact_data')
+          .eq('venture_id', venture.id)
+          .eq('artifact_type', 'wireframe_screens')
+          .eq('is_current', true)
+          .limit(1)
+          .maybeSingle();
+
+        if (!wireframes?.artifact_data?.screens?.length) continue;
+
+        const expectedScreens = wireframes.artifact_data.screens.length;
+
+        // Count existing archetypes
+        const { count } = await this._supabase
+          .from('venture_artifacts')
+          .select('id', { count: 'exact', head: true })
+          .eq('venture_id', venture.id)
+          .eq('artifact_type', 's17_archetypes')
+          .eq('is_current', true);
+
+        if ((count ?? 0) >= expectedScreens) continue; // All done
+
+        // Trigger generation
+        this._logger.log(`[Worker] S17 reconciler: ${venture.name} has ${count ?? 0}/${expectedScreens} archetypes — triggering generation`);
+        if (!this._s17ReconcileAttempts) this._s17ReconcileAttempts = new Map();
+        this._s17ReconcileAttempts.set(venture.id, Date.now());
+
+        // Fire-and-forget — don't block the tick loop
+        import('./stage-17/archetype-generator.js').then(({ generateArchetypes }) => {
+          generateArchetypes(venture.id, this._supabase)
+            .then(result => {
+              this._logger.log(`[Worker] S17 reconciler: ${venture.name} complete — ${result.artifactIds.length} artifacts`);
+            })
+            .catch(err => {
+              this._logger.warn(`[Worker] S17 reconciler: ${venture.name} failed — ${err.message}`);
+            });
+        }).catch(importErr => {
+          this._logger.warn(`[Worker] S17 reconciler import error: ${importErr.message}`);
+        });
+      }
+    } catch (err) {
+      // Non-fatal — don't crash the tick loop
+      this._logger.warn(`[Worker] S17 reconciler error: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
Systemic fix for S17 ventures stuck with 0 archetypes. New `_reconcileS17Archetypes()` method runs every worker tick, detects ventures at S17 with wireframe_screens but incomplete s17_archetypes, and triggers generation. Rate-limited to 1 attempt per 5 min per venture.

Also fixes auto-resume.js: stitch_design_export → wireframe_screens, detects zero-archetype ventures.

## Root cause
No recovery mechanism existed for ventures at S17 with missing archetypes. Post-hook fires on S17 completion (too late), frontend trigger requires browser load with correct code.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Restart server with CodeDoc AI at S17 → reconciler detects and triggers generation within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)