### PR TITLE
fix(S14): correct artifact type to blueprint_technical_architecture

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
@@ -341,6 +341,7 @@ Output ONLY valid JSON.`;
   logger.log('[Stage14] Risk register complete', { riskCount: risks.length });
   logger.log('[Stage14] Analysis complete', { duration: Date.now() - startTime });
   return {
+    artifactType: 'blueprint_technical_architecture',
     architecture_summary,
     layers,
     security,

--- a/scripts/config/stage-artifact-config.json
+++ b/scripts/config/stage-artifact-config.json
@@ -94,10 +94,10 @@
     },
     {
       "stage_number": 14,
-      "artifact_type": "blueprint_data_model",
+      "artifact_type": "blueprint_technical_architecture",
       "required_status": "completed",
       "is_blocking": true,
-      "description": "Data model required before leaving Stage 14 (Data Model)"
+      "description": "Technical architecture required before leaving Stage 14 (Technical Architecture & Risk Register)"
     },
     {
       "stage_number": 15,


### PR DESCRIPTION
## Summary
- Fixed seed config (`stage-artifact-config.json`) listing wrong artifact type for S14: `blueprint_data_model` → `blueprint_technical_architecture`
- Added explicit `artifactType` return in `analyzeStage14()` as defense-in-depth against fallback chain resolving wrong type
- Re-seeded `stage_artifact_requirements` table and removed stale row (done in-session, not in code)

**RCA**: Seed config authored Apr 6 with one-artifact-per-stage pattern chose wrong artifact for S14. Every other source (`ARTIFACT_TYPE_BY_STAGE`, `stage-config.js`, `monitor-venture-run.cjs`) expected `blueprint_technical_architecture`.

## Test plan
- [x] Verified DB now has correct `blueprint_technical_architecture` row for S14
- [x] Verified stale `blueprint_data_model` row removed
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)