### PR TITLE
fix(S17): progress writer uses writeArtifact (not direct DB)

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -263,19 +263,19 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   const updateProgress = async (entry) => {
     progressLog.push(entry);
     try {
-      await supabase.from('venture_artifacts')
-        .upsert({
-          venture_id: ventureId,
-          lifecycle_stage: 17,
-          artifact_type: 's17_session_state',
-          is_current: true,
-          title: 'Generation Progress',
-          content: JSON.stringify({ log: progressLog, updatedAt: new Date().toISOString() }),
-          artifact_data: { totalScreens, completedScreens: artifactIds.length, log: progressLog },
-          source: 'stage-17-archetype-generator',
-        }, { onConflict: 'venture_id,lifecycle_stage,artifact_type' })
-        .eq('is_current', true);
-    } catch { /* non-fatal */ }
+      await writeArtifact(supabase, {
+        ventureId,
+        lifecycleStage: 17,
+        artifactType: 's17_session_state',
+        title: 'Generation Progress',
+        content: JSON.stringify({ log: progressLog, updatedAt: new Date().toISOString() }),
+        artifactData: { totalScreens, completedScreens: artifactIds.length, log: progressLog },
+        qualityScore: null,
+        validationStatus: null,
+        source: 'stage-17-archetype-generator',
+        metadata: { progressUpdate: true },
+      });
+    } catch (e) { console.warn('[archetype-generator] Progress write failed:', e.message); }
   };
 
   // 4. Generate 4 archetypes per screen


### PR DESCRIPTION
Uses artifact-persistence-service which handles per-screen unique index correctly.