### PR TITLE
fix(S17): incremental variant persistence + reconciler scope fix

### DIFF
--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -107,6 +107,8 @@ export const ARTIFACT_TYPES = Object.freeze({
   BLUEPRINT_S17_VARIANT_SCORES: 's17_variant_scores',
   /** S17 PNG screenshots from approved HTML — SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001-C */
   BLUEPRINT_S17_APPROVED_PNG: 's17_approved_png',
+  /** S17 work-in-progress variant (per-variant checkpoint) — PAT-PERSIST-CHECKPOINT-001 */
+  BLUEPRINT_S17_VARIANT_WIP: 's17_variant_wip',
 
   // Stage 15 — Wireframe screen data (replaces Stitch provisioning)
   BLUEPRINT_WIREFRAME_SCREENS: 'wireframe_screens',
@@ -228,6 +230,7 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
     ARTIFACT_TYPES.BLUEPRINT_S17_SESSION_STATE,
     ARTIFACT_TYPES.BLUEPRINT_S17_APPROVED,
     ARTIFACT_TYPES.BLUEPRINT_S17_APPROVED_PNG,
+    ARTIFACT_TYPES.BLUEPRINT_S17_VARIANT_WIP,
   ],
   20: [ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
   21: [ARTIFACT_TYPES.LAUNCH_TEST_PLAN, ARTIFACT_TYPES.LAUNCH_UAT_REPORT],

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -326,7 +326,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       source: 'stage-17-archetype-generator',
       metadata: { progressUpdate: true },
     });
-  } catch (e) { /* non-blocking */ }
+  } catch (_e) { /* non-blocking */ }
 
   const updateProgress = async (entry) => {
     progressLog.push(entry);

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -46,6 +46,57 @@ async function getCompletedScreens(supabase, ventureId) {
   return completed;
 }
 
+/**
+ * Get WIP variant artifacts for a specific screen (PAT-PERSIST-CHECKPOINT-001).
+ * Returns a Map of variantIndex → variant data for variants that have already
+ * been persisted to DB. Used for sub-screen-level resume after interruption.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @param {string} screenId
+ * @returns {Promise<Map<number, {html: string, layoutDescription: string}>>}
+ */
+async function getWipVariants(supabase, ventureId, screenId) {
+  const { data } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data, metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 's17_variant_wip')
+    .eq('lifecycle_stage', 17)
+    .eq('is_current', true)
+    .eq('metadata->>screenId', screenId);
+
+  const wip = new Map();
+  for (const row of data ?? []) {
+    const idx = row.metadata?.variantIndex;
+    if (idx != null && row.artifact_data?.html) {
+      wip.set(idx, { html: row.artifact_data.html, layoutDescription: row.artifact_data.layoutDescription });
+    }
+  }
+  return wip;
+}
+
+/**
+ * Clean up WIP variant artifacts for a screen after the final s17_archetypes
+ * artifact has been assembled. Marks them as not current (soft delete).
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @param {string} screenId
+ */
+async function cleanupWipVariants(supabase, ventureId, screenId) {
+  const { error } = await supabase
+    .from('venture_artifacts')
+    .update({ is_current: false, updated_at: new Date().toISOString() })
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 's17_variant_wip')
+    .eq('lifecycle_stage', 17)
+    .eq('is_current', true)
+    .eq('metadata->>screenId', screenId);
+
+  if (error) console.warn(`[archetype-generator] WIP cleanup failed for ${screenId}: ${error.message}`);
+}
+
 /** Fallback layouts used when page-type classification fails.
  * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Reduced from 6 to 4 variants. */
 const FALLBACK_LAYOUTS = [
@@ -259,7 +310,24 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   const totalScreens = screenList.length;
 
   // Progress log — written to s17_session_state artifact for frontend consumption
+  // PAT-PERSIST-CHECKPOINT-001: Reset stale progress log from prior interrupted runs.
+  // Without this, the frontend shows variant entries from a run that never completed
+  // its artifact write, misleading the user into thinking screens are complete when
+  // no s17_archetypes artifact exists for them.
   const progressLog = [];
+  // Write an empty log immediately to clear any stale data from prior runs
+  try {
+    await writeArtifact(supabase, {
+      ventureId, lifecycleStage: 17, artifactType: 's17_session_state',
+      title: 'Generation Progress',
+      content: JSON.stringify({ log: [], updatedAt: new Date().toISOString(), generation: 'starting', completedScreens: completedScreens.size }),
+      artifactData: { totalScreens, completedScreens: completedScreens.size, log: [] },
+      qualityScore: null, validationStatus: null,
+      source: 'stage-17-archetype-generator',
+      metadata: { progressUpdate: true },
+    });
+  } catch (e) { /* non-blocking */ }
+
   const updateProgress = async (entry) => {
     progressLog.push(entry);
     try {
@@ -313,7 +381,22 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     const variants = [];
     const screenStartTime = Date.now();
 
+    // PAT-PERSIST-CHECKPOINT-001: Check for WIP variants from a prior interrupted run
+    const existingWip = await getWipVariants(supabase, ventureId, screenId);
+    if (existingWip.size > 0) {
+      console.log(`[archetype-generator] │   Resuming: ${existingWip.size}/${variantCount} variants already persisted for ${screenId}`);
+    }
+
     for (let i = 0; i < variantCount; i++) {
+      // Skip variants that were already persisted in a prior run
+      if (existingWip.has(i + 1)) {
+        const wip = existingWip.get(i + 1);
+        variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html });
+        console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: resumed from WIP — ${wip.html.length} chars`);
+        await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: wip.html.length, seconds: 0, layout: wip.layoutDescription.slice(0, 50), resumed: true });
+        continue;
+      }
+
       const variantStart = Date.now();
       const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType, deviceType });
 
@@ -334,18 +417,34 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       const archetypeHtml = archetypeResult?.content ?? String(archetypeResult);
       const variantSec = ((Date.now() - variantStart) / 1000).toFixed(0);
 
+      // PAT-PERSIST-CHECKPOINT-001: Persist each variant immediately to DB as WIP
+      // This eliminates the 5-6 min vulnerability window where variants only exist in memory
+      await writeArtifact(supabase, {
+        ventureId,
+        lifecycleStage: 17,
+        artifactType: 's17_variant_wip',
+        title: `${screenTitle} — WIP Variant ${i + 1}`,
+        content: archetypeHtml,
+        artifactData: { html: archetypeHtml, layoutDescription: layouts[i], variantIndex: i + 1, screenName: screenTitle },
+        qualityScore: null,
+        validationStatus: null,
+        source: 'stage-17-archetype-generator',
+        metadata: { screenId, variantIndex: i + 1, deviceType },
+      });
+
       variants.push({
         variantIndex: i + 1,
         layoutDescription: layouts[i],
         html: archetypeHtml,
       });
 
-      console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: ${layouts[i].slice(0, 40)} — ${archetypeHtml.length} chars (${variantSec}s)`);
+      console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: ${layouts[i].slice(0, 40)} — ${archetypeHtml.length} chars (${variantSec}s) [persisted]`);
       await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: archetypeHtml.length, seconds: parseInt(variantSec), layout: layouts[i].slice(0, 50) });
     }
 
     const screenSec = ((Date.now() - screenStartTime) / 1000).toFixed(0);
 
+    // Assemble final s17_archetypes artifact from all persisted variants
     const artifactId = await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 17,
@@ -374,6 +473,9 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         tokensApplied: !!tokens,
       },
     });
+
+    // Clean up WIP variants now that the final artifact is assembled
+    await cleanupWipVariants(supabase, ventureId, screenId);
 
     artifactIds.push(artifactId);
     const remaining = totalScreens - (screenIdx + 1);

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1835,12 +1835,16 @@ export class StageExecutionWorker {
    */
   async _reconcileS17Archetypes() {
     try {
-      // Find active ventures at S17
+      // Find active ventures at S17-S19 — PAT-RECONCILER-SCOPE-001:
+      // Reconciler must cover the full window where s17_archetypes are relevant.
+      // After chairman approval, _advanceStage moves the venture to S18+, but
+      // the fire-and-forget archetype generation may still be incomplete.
       const { data: s17Ventures } = await this._supabase
         .from('ventures')
         .select('id, name')
         .eq('status', 'active')
-        .eq('current_lifecycle_stage', 17);
+        .gte('current_lifecycle_stage', 17)
+        .lte('current_lifecycle_stage', 19);
 
       if (!s17Ventures || s17Ventures.length === 0) return;
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -684,7 +684,7 @@ export class StageExecutionWorker {
               // RCA: PAT-ORCH-STATE-001 (pending-decision shortcut artifact gap)
               if (currentStage >= 18 && currentStage <= 23) {
                 try {
-                  const { fetchUpstreamArtifacts, persistArtifact } = await import('./stage-execution-engine.js');
+                  const { fetchUpstreamArtifacts } = await import('./stage-execution-engine.js');
                   const { data: existingArt } = await this._supabase.from('venture_artifacts')
                     .select('id, artifact_data')
                     .eq('venture_id', ventureId).eq('lifecycle_stage', currentStage).eq('is_current', true)


### PR DESCRIPTION
## Summary
- **CAPA-1**: Each design variant is now persisted individually to DB (`s17_variant_wip`) as it completes, eliminating the 5-6 minute window where all variants were held only in memory. On resume, existing WIP variants are skipped. WIP cleaned up after final artifact assembly.
- **CAPA-2**: S17 reconciler scope expanded from `stage=17` to `stage 17-19` so ventures that advance past S17 with incomplete archetypes are still recovered.
- **CAPA-3**: Progress log cleared at generation start to prevent stale entries from interrupted runs misleading the frontend.
- Added `s17_variant_wip` artifact type to registry and DB CHECK constraint.

## Root Cause
RCA identified 3 systemic causes for lost archetype data: batch-only persistence model (no checkpointing during 5-6 min LLM generation per screen), reconciler scope gap (ventures that advance to S18+ become invisible), and stale progress log diverging from artifact state.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Verified WIP variant artifact written to DB after first variant completes
- [x] Verified reconciler detects venture at S17 with 1/7 archetypes and triggers generation
- [x] Verified progress log reset at generation start

🤖 Generated with [Claude Code](https://claude.com/claude-code)