### PR TITLE
fix(S17): add timestamps and screen boundaries to generation log

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -387,13 +387,21 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       console.log(`[archetype-generator] │   Resuming: ${existingWip.size}/${variantCount} variants already persisted for ${screenId}`);
     }
 
+    // Emit screen_start entry for frontend traceability
+    await updateProgress({
+      type: 'screen_start', screen: screenTitle, screenIdx: screenIdx + 1,
+      totalScreens, variantCount, deviceType,
+      resumedVariants: existingWip.size,
+      timestamp: new Date().toISOString(),
+    });
+
     for (let i = 0; i < variantCount; i++) {
       // Skip variants that were already persisted in a prior run
       if (existingWip.has(i + 1)) {
         const wip = existingWip.get(i + 1);
         variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html });
         console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: resumed from WIP — ${wip.html.length} chars`);
-        await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: wip.html.length, seconds: 0, layout: wip.layoutDescription.slice(0, 50), resumed: true });
+        await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: wip.html.length, seconds: 0, layout: wip.layoutDescription.slice(0, 50), resumed: true, timestamp: new Date().toISOString() });
         continue;
       }
 
@@ -439,7 +447,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       });
 
       console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: ${layouts[i].slice(0, 40)} — ${archetypeHtml.length} chars (${variantSec}s) [persisted]`);
-      await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: archetypeHtml.length, seconds: parseInt(variantSec), layout: layouts[i].slice(0, 50) });
+      await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: archetypeHtml.length, seconds: parseInt(variantSec), layout: layouts[i].slice(0, 50), persisted: true, timestamp: new Date().toISOString() });
     }
 
     const screenSec = ((Date.now() - screenStartTime) / 1000).toFixed(0);
@@ -481,7 +489,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     const remaining = totalScreens - (screenIdx + 1);
     const avgPerScreen = remaining > 0 ? ` (~${Math.round(remaining * parseInt(screenSec) / 60)}m remaining)` : '';
     console.log(`[archetype-generator] └── Screen "${screenTitle}" saved — ${screenIdx + 1}/${totalScreens} complete (${screenSec}s)${avgPerScreen}`);
-    await updateProgress({ type: 'screen_complete', screen: screenTitle, screenIdx: screenIdx + 1, totalScreens, seconds: parseInt(screenSec), remaining });
+    await updateProgress({ type: 'screen_complete', screen: screenTitle, screenIdx: screenIdx + 1, totalScreens, seconds: parseInt(screenSec), remaining, artifactWritten: true, timestamp: new Date().toISOString() });
 
     // SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: LLM scoring removed.
     // Deterministic scoring (CSS/HTML signals) applied at frontend display time.


### PR DESCRIPTION
## Summary
- Added `timestamp` (ISO 8601) to every generation log entry
- Added `screen_start` entry type with screen index, total, device type, and resume count
- Added `persisted` flag on variant entries confirming DB write
- Added `artifactWritten` flag on screen_complete confirming final artifact saved

## Test plan
- [x] Smoke tests pass
- [x] Log entries include all new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)