### PR TITLE
fix: artifact persistence fallback crashes on null data

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -150,8 +150,14 @@ export async function writeArtifact(supabase, opts) {
     .select('id')
     .single();
 
-  // Handle unique constraint violation from idx_unique_current_artifact
-  if (error && /unique|duplicate|idx_unique_current_artifact/i.test(error.message)) {
+  // Handle unique constraint violation from idx_unique_current_artifact.
+  // Fix: use PostgreSQL error code 23505 (unique_violation) instead of broad regex
+  // that could misroute CHECK constraint or other errors into this fallback path.
+  const isUniqueViolation = error && (
+    error.code === '23505' ||
+    /idx_unique_current_artifact|duplicate key value violates unique constraint/i.test(error.message)
+  );
+  if (isUniqueViolation) {
     // Include screenId in fallback query to match the per-screen unique index
     // (idx_unique_current_artifact includes COALESCE(metadata->>'screenId', '__no_screen__'))
     const screenId = row.metadata?.screenId;
@@ -175,9 +181,12 @@ export async function writeArtifact(supabase, opts) {
       }).eq('id', existing.id);
       return existing.id;
     }
-    // If we still can't find it, re-throw
-    error = null;
-    data = null;
+    // Existing row not found despite unique violation — re-throw the original error
+    throw new Error(
+      '[artifact-persistence-service] writeArtifact failed: INSERT hit unique constraint ' +
+      `but no existing row found for ${artifactType} at S${lifecycleStage} ` +
+      `(screenId=${screenId ?? 'none'}). Original error: ${error.message}`
+    );
   }
 
   // Graceful degradation: retry without optional columns if they cause schema errors
@@ -240,6 +249,12 @@ export async function writeArtifact(supabase, opts) {
     }
   }
 
+  if (!data?.id) {
+    throw new Error(
+      '[artifact-persistence-service] writeArtifact completed but returned no ID ' +
+      `for ${artifactType} at S${lifecycleStage} (venture=${ventureId})`
+    );
+  }
   return data.id;
 }
 


### PR DESCRIPTION
## Summary
- **Root cause of S17 generation stalling at 4/4**: `writeArtifact` INSERT hits an error, fallback path can't find existing row, silently sets `data=null` instead of re-throwing. `return data.id` crashes with NPE.
- Tightened unique constraint regex to use PostgreSQL error code `23505` instead of broad `/unique|duplicate/` that catches non-unique errors
- Re-throw original error when fallback can't find existing row (instead of silent null)
- Added null guard at return for defense-in-depth

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Error message now includes artifact type, stage, screenId, and original error for diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)