### PR TITLE
fix(S17): stop generation writes log entry, checks abort between variants

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -350,6 +350,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   for (let screenIdx = 0; screenIdx < screenList.length; screenIdx++) {
     if (signal?.aborted) {
       console.info(`[archetype-generator] Cancelled after ${screenIdx}/${totalScreens} screens (${artifactIds.length} artifacts written)`);
+      await updateProgress({ type: 'generation_stopped', completedScreens: artifactIds.length, totalScreens, reason: 'User cancelled', timestamp: new Date().toISOString() });
       return { screenCount: screenIdx, artifactIds, cancelled: true };
     }
     const screen = screenList[screenIdx];
@@ -396,6 +397,13 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     });
 
     for (let i = 0; i < variantCount; i++) {
+      // Check abort signal between variants (not just between screens)
+      if (signal?.aborted) {
+        console.info(`[archetype-generator] Cancelled mid-screen "${screenTitle}" after variant ${i}/${variantCount}`);
+        await updateProgress({ type: 'generation_stopped', completedScreens: artifactIds.length, totalScreens, reason: 'User cancelled', timestamp: new Date().toISOString() });
+        return { screenCount: screenIdx, artifactIds, cancelled: true };
+      }
+
       // Skip variants that were already persisted in a prior run
       if (existingWip.has(i + 1)) {
         const wip = existingWip.get(i + 1);


### PR DESCRIPTION
## Summary
- Added abort signal check between **variants** (not just between screens) so cancellation is responsive mid-screen
- When cancelled, writes a `generation_stopped` entry to the `s17_session_state` progress log so the frontend can display the stopped state

## Test plan
- [ ] Trigger S17 archetype generation, press Stop mid-screen — verify it stops after current variant (not after whole screen)
- [ ] After stop, verify `s17_session_state` artifact contains a `generation_stopped` log entry
- [ ] Resume generation — verify it picks up where it left off (skips completed screens/variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)