### PR TITLE
refactor(S17): modularize prompt builder with strategy-driven variants

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-120",
+  "currentSd": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing Address handoff failure patterns: auto-populate required PRD/SD fields",
+  "currentTask": "Implementing S17 Prompt Enrichment + Strategy-Driven Variant Framework",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
   "clearedAt": "2026-04-15T00:32:06.617Z",
-  "lastUpdatedAt": "2026-04-18T11:38:33.821Z"
+  "lastUpdatedAt": "2026-04-19T20:54:48.605Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-120",
-  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-120",
-  "createdAt": "2026-04-18T11:09:46.645Z",
+  "sdKey": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
+  "expectedBranch": "feat/SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
+  "createdAt": "2026-04-19T20:41:46.046Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -18,7 +18,9 @@
 
 import { getTokenConstraints } from './token-manifest.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
-import { classifyPageType, getArchetypesForPageType } from './page-type-classifier.js';
+import { classifyPageType, getArchetypesForPageType, getStrategyLayouts } from './page-type-classifier.js';
+import { buildDesignBrief, formatDesignBrief } from './design-system-brief.js';
+import { buildContentBrief, formatContentBrief } from './content-brief-builder.js';
 // SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: LLM scoring removed, deterministic only
 
 /**
@@ -147,6 +149,10 @@ async function fetchScreenSourceArtifact(supabase, ventureId) {
  * @param {number} variantIndex - 1–6
  * @param {object} [options]
  * @param {string} [options.pageType] - Classified page type (e.g., 'landing', 'dashboard')
+ * @param {string} [options.deviceType] - 'MOBILE' or 'DESKTOP'
+ * @param {object} [options.designBrief] - Pre-built design brief from design-system-brief.js
+ * @param {object} [options.contentBrief] - Pre-built content brief from content-brief-builder.js
+ * @param {string} [options.strategyName] - Design strategy name (conversion/trust/education/engagement)
  * @returns {string} prompt text
  */
 function buildArchetypePrompt(screenHtml, tokens, layoutDescription, variantIndex, options = {}) {
@@ -217,8 +223,15 @@ editorial touch, or non-template component treatment. Annotate it with an HTML c
 <!-- distinctive move: [describe your deliberate design choice] -->
 This is MANDATORY. Variants without a distinctive move score poorly on U7.`;
 
+  // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A: compose from brief modules
+  const designBriefSection = options.designBrief ? formatDesignBrief(options.designBrief) : '';
+  const contentBriefSection = options.contentBrief ? formatContentBrief(options.contentBrief) : '';
+  const strategyDirective = options.strategyName
+    ? `\nDESIGN STRATEGY: ${options.strategyName.toUpperCase()} — every design decision should serve the ${options.strategyName} goal for this page type.\n`
+    : '';
+
   return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 4 for this screen.
-${pageTypeContext}${deviceInstructions}
+${pageTypeContext}${strategyDirective}${designBriefSection}${contentBriefSection}${deviceInstructions}
 ${rubricGuidance}
 
 BRAND TOKENS (LOCKED — do not deviate):
@@ -300,6 +313,36 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
   // 2. Load brand token manifest
   const tokens = await getTokenConstraints(ventureId, supabase);
 
+  // 2b. Load upstream artifacts for design brief (SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A)
+  let designBrief = null;
+  try {
+    const [identityRes, tokenManifestRes] = await Promise.all([
+      supabase.from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .in('artifact_type', ['stage11_identity', 's11_identity'])
+        .eq('is_current', true)
+        .limit(1)
+        .maybeSingle(),
+      supabase.from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'design_token_manifest')
+        .eq('is_current', true)
+        .limit(1)
+        .maybeSingle(),
+    ]);
+    designBrief = buildDesignBrief({
+      identityArtifact: identityRes?.data?.artifact_data ?? null,
+      tokenManifest: tokenManifestRes?.data?.artifact_data ?? null,
+    });
+    if (designBrief.positioning !== 'Modern, professional digital product') {
+      console.log(`[archetype-generator] Design brief loaded: positioning="${designBrief.positioning.slice(0, 60)}..."`);
+    }
+  } catch (e) {
+    console.warn('[archetype-generator] Design brief skipped:', e.message);
+  }
+
   // 3. Import LLM client — use Anthropic Claude for design generation
   const { getLLMClient } = await import('../../llm/client-factory.js');
   const { getClaudeModel } = await import('../../config/model-config.js');
@@ -372,12 +415,17 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
 
     // Classify page type
     const classification = classifyPageType(screenTitle, screen.description);
-    const layouts = classification.confidence >= 0.5
-      ? getArchetypesForPageType(classification.pageType)
-      : FALLBACK_LAYOUTS;
+
+    // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A: Use strategy-driven layouts when confidence is sufficient
+    const strategyLayouts = classification.confidence >= 0.5
+      ? getStrategyLayouts(classification.pageType)
+      : null;
+    const layouts = strategyLayouts
+      ? strategyLayouts.map(sl => sl.description)
+      : (classification.confidence >= 0.5 ? getArchetypesForPageType(classification.pageType) : FALLBACK_LAYOUTS);
     const variantCount = layouts.length;
     console.log(`[archetype-generator] ┌── Screen ${screenIdx + 1}/${totalScreens}: ${screenTitle} (${deviceType})`);
-    console.log(`[archetype-generator] │   pageType=${classification.pageType} (confidence=${classification.confidence}), generating ${variantCount} variants`);
+    console.log(`[archetype-generator] │   pageType=${classification.pageType} (confidence=${classification.confidence}), generating ${variantCount} variants${strategyLayouts ? ' [strategy-driven]' : ''}`);
 
     const variants = [];
     const screenStartTime = Date.now();
@@ -414,7 +462,16 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       }
 
       const variantStart = Date.now();
-      const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, { pageType: classification.pageType, deviceType });
+      // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A: build content brief per screen, pass strategy + design brief
+      const contentBrief = buildContentBrief(screenHtml, classification.pageType);
+      const strategyName = strategyLayouts ? strategyLayouts[i]?.strategy : null;
+      const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, {
+        pageType: classification.pageType,
+        deviceType,
+        designBrief,
+        contentBrief,
+        strategyName,
+      });
 
       const userContent = [];
       if (screen.png) {

--- a/lib/eva/stage-17/content-brief-builder.js
+++ b/lib/eva/stage-17/content-brief-builder.js
@@ -1,0 +1,120 @@
+/**
+ * Content Brief Builder for S17 Archetype Generation
+ *
+ * Synthesizes screen content structure and page purpose
+ * from wireframe_screens artifact HTML into a structured brief
+ * that enriches archetype prompts with screen-specific context.
+ *
+ * SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A (US-002)
+ * @module lib/eva/stage-17/content-brief-builder
+ */
+
+const MAX_BRIEF_CHARS = 1000;
+
+/**
+ * Build a content brief from screen HTML and page type context.
+ * Pure function — no database calls, only data transformation.
+ *
+ * @param {string} screenHtml - Screen HTML content (wireframe description)
+ * @param {string} pageType - Classified page type (e.g., 'landing', 'dashboard')
+ * @returns {{ sections: string[], ctas: string[], navigation: string, purpose: string }}
+ */
+export function buildContentBrief(screenHtml, pageType) {
+  if (!screenHtml || typeof screenHtml !== 'string') {
+    return { sections: [], ctas: [], navigation: '', purpose: getDefaultPurpose(pageType) };
+  }
+
+  const sections = extractSections(screenHtml);
+  const ctas = extractCTAs(screenHtml);
+  const navigation = extractNavigation(screenHtml);
+  const purpose = getDefaultPurpose(pageType);
+
+  return { sections, ctas, navigation, purpose };
+}
+
+/**
+ * Format the content brief as a prompt section string.
+ *
+ * @param {{ sections: string[], ctas: string[], navigation: string, purpose: string }} brief
+ * @returns {string} Formatted prompt section (empty string if no meaningful content)
+ */
+export function formatContentBrief(brief) {
+  if (!brief || (brief.sections.length === 0 && brief.ctas.length === 0 && !brief.navigation)) {
+    if (brief?.purpose) {
+      return `\nSCREEN PURPOSE: ${brief.purpose}`;
+    }
+    return '';
+  }
+
+  const lines = ['\nCONTENT STRUCTURE (from wireframe analysis):'];
+
+  if (brief.purpose) {
+    lines.push(`- Purpose: ${brief.purpose}`);
+  }
+  if (brief.sections.length > 0) {
+    lines.push(`- Sections: ${brief.sections.slice(0, 5).join(', ')}`);
+  }
+  if (brief.ctas.length > 0) {
+    lines.push(`- Key CTAs: ${brief.ctas.slice(0, 3).join(', ')}`);
+  }
+  if (brief.navigation) {
+    lines.push(`- Navigation: ${brief.navigation}`);
+  }
+
+  const result = lines.join('\n');
+  return result.length > MAX_BRIEF_CHARS ? result.slice(0, MAX_BRIEF_CHARS - 3) + '...' : result;
+}
+
+function extractSections(html) {
+  const sections = [];
+  const headingPattern = /<h[1-3][^>]*>([^<]+)<\/h[1-3]>/gi;
+  let match;
+  while ((match = headingPattern.exec(html)) !== null) {
+    const text = match[1].trim();
+    if (text && text.length > 2) sections.push(text);
+  }
+  if (sections.length === 0) {
+    const divPattern = /<div[^>]*class="([^"]*section[^"]*)"[^>]*>/gi;
+    while ((match = divPattern.exec(html)) !== null) {
+      sections.push(match[1].replace(/[-_]/g, ' ').trim());
+    }
+  }
+  return sections.slice(0, 6);
+}
+
+function extractCTAs(html) {
+  const ctas = [];
+  const buttonPattern = /<button[^>]*>([^<]+)<\/button>/gi;
+  let match;
+  while ((match = buttonPattern.exec(html)) !== null) {
+    const text = match[1].trim();
+    if (text && text.length > 1 && text.length < 40) ctas.push(text);
+  }
+  const linkCtaPattern = /<a[^>]*class="[^"]*(?:btn|cta|button)[^"]*"[^>]*>([^<]+)<\/a>/gi;
+  while ((match = linkCtaPattern.exec(html)) !== null) {
+    const text = match[1].trim();
+    if (text && text.length > 1 && text.length < 40) ctas.push(text);
+  }
+  return [...new Set(ctas)].slice(0, 4);
+}
+
+function extractNavigation(html) {
+  if (/<nav[^>]*>/i.test(html)) return 'Navigation bar present';
+  if (/<ul[^>]*class="[^"]*nav[^"]*"/i.test(html)) return 'Navigation list present';
+  if (/<aside[^>]*>/i.test(html)) return 'Sidebar navigation';
+  return '';
+}
+
+const PAGE_PURPOSE_MAP = {
+  landing: 'Convert visitors — communicate value proposition and drive primary CTA engagement',
+  signup: 'Capture user registration — minimize friction, build trust through progressive disclosure',
+  dashboard: 'Surface key metrics — enable quick status assessment and navigation to detail views',
+  insights: 'Reveal data patterns — present analytics with context and actionable takeaways',
+  settings: 'Enable configuration — organize preferences logically with clear save/cancel flows',
+  listing: 'Facilitate discovery — help users browse, filter, and compare items efficiently',
+  detail: 'Deliver depth — present comprehensive item information with clear action paths',
+};
+
+function getDefaultPurpose(pageType) {
+  return PAGE_PURPOSE_MAP[pageType] ?? 'Serve the user\'s primary task on this screen';
+}

--- a/lib/eva/stage-17/design-system-brief.js
+++ b/lib/eva/stage-17/design-system-brief.js
@@ -1,0 +1,101 @@
+/**
+ * Design System Brief Generator for S17 Archetype Generation
+ *
+ * Extracts venture positioning, brand voice, and competitive context
+ * from upstream Stage 11-12 artifacts to produce a venture-specific
+ * design brief that enriches archetype prompts.
+ *
+ * SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A (US-001)
+ * @module lib/eva/stage-17/design-system-brief
+ */
+
+const MAX_BRIEF_CHARS = 500;
+
+const GENERIC_FALLBACK = {
+  positioning: 'Modern, professional digital product',
+  voice: 'Clear, confident, approachable',
+  context: '',
+};
+
+/**
+ * Build a design system brief from upstream venture artifacts.
+ * Pure function — no database calls, only data transformation.
+ *
+ * @param {object} params
+ * @param {object|null} params.identityArtifact - Stage 11 identity artifact (artifact_data)
+ * @param {object|null} params.tokenManifest - design_token_manifest artifact (artifact_data)
+ * @returns {{ positioning: string, voice: string, context: string }}
+ */
+export function buildDesignBrief({ identityArtifact, tokenManifest } = {}) {
+  const positioning = extractPositioning(identityArtifact);
+  const voice = extractVoice(identityArtifact);
+  const context = extractContext(identityArtifact, tokenManifest);
+
+  const brief = {
+    positioning: truncate(positioning || GENERIC_FALLBACK.positioning, 200),
+    voice: truncate(voice || GENERIC_FALLBACK.voice, 150),
+    context: truncate(context || GENERIC_FALLBACK.context, 150),
+  };
+
+  return brief;
+}
+
+/**
+ * Format the design brief as a prompt section string.
+ *
+ * @param {{ positioning: string, voice: string, context: string }} brief
+ * @returns {string} Formatted prompt section (empty string if all generic)
+ */
+export function formatDesignBrief(brief) {
+  if (!brief || (!brief.context && brief.positioning === GENERIC_FALLBACK.positioning)) {
+    return '';
+  }
+
+  const lines = [
+    '\nDESIGN STRATEGY BRIEF (venture-specific context):',
+    `- Positioning: ${brief.positioning}`,
+    `- Brand Voice: ${brief.voice}`,
+  ];
+
+  if (brief.context) {
+    lines.push(`- Context: ${brief.context}`);
+  }
+
+  return lines.join('\n');
+}
+
+function extractPositioning(identity) {
+  if (!identity) return null;
+  const data = identity.brand ?? identity;
+  return data.positioning
+    ?? data.tagline
+    ?? data.value_proposition
+    ?? data.brand_essence
+    ?? null;
+}
+
+function extractVoice(identity) {
+  if (!identity) return null;
+  const data = identity.brand ?? identity;
+  if (data.voice) return data.voice;
+  if (data.tone) return data.tone;
+  if (Array.isArray(data.brand_attributes)) {
+    return data.brand_attributes.slice(0, 3).join(', ');
+  }
+  return null;
+}
+
+function extractContext(identity, tokenManifest) {
+  if (!identity) return null;
+  const parts = [];
+  const data = identity.brand ?? identity;
+  if (data.target_audience) parts.push(`Audience: ${data.target_audience}`);
+  if (data.industry) parts.push(`Industry: ${data.industry}`);
+  if (tokenManifest?.style_direction) parts.push(`Style: ${tokenManifest.style_direction}`);
+  return parts.length > 0 ? parts.join('. ') : null;
+}
+
+function truncate(str, max) {
+  if (!str || str.length <= max) return str || '';
+  return str.slice(0, max - 3) + '...';
+}

--- a/lib/eva/stage-17/page-type-classifier.js
+++ b/lib/eva/stage-17/page-type-classifier.js
@@ -146,3 +146,72 @@ export function getArchetypesForPageType(pageType) {
   const layouts = PAGE_TYPE_ARCHETYPES[pageType] ?? PAGE_TYPE_ARCHETYPES.landing;
   return layouts.slice(0, 4);
 }
+
+/**
+ * Design strategy names mapped to variant indices (1-based).
+ * @type {string[]}
+ */
+export const STRATEGY_NAMES = ['conversion', 'trust', 'education', 'engagement'];
+
+/**
+ * Strategy-driven layout descriptions per page type.
+ * Each page type has 4 strategy variants that implement a distinct design approach.
+ *
+ * SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A (US-004)
+ * @type {Record<PageType, Array<{strategy: string, description: string}>>}
+ */
+export const STRATEGY_LAYOUTS = {
+  landing: [
+    { strategy: 'conversion', description: 'Hero with bold headline, single dominant CTA above the fold, benefit bullets, and urgency element. Every section funnels toward the primary action.' },
+    { strategy: 'trust', description: 'Social proof-led layout opening with testimonials, client logos, and case study snippets. CTA positioned after credibility signals.' },
+    { strategy: 'education', description: 'Content-rich scroll with feature explanations, how-it-works steps, and comparison tables. CTA follows informed decision point.' },
+    { strategy: 'engagement', description: 'Interactive hero with hover-reveal features, animated value proposition, and micro-interactions. Exploration-first, CTA as natural destination.' },
+  ],
+  signup: [
+    { strategy: 'conversion', description: 'Minimal single-column form with progressive disclosure, social login shortcuts, and inline validation. Zero distractions.' },
+    { strategy: 'trust', description: 'Split-screen with security badges, privacy promise, and testimonial beside a compact form. Trust signals outnumber form fields.' },
+    { strategy: 'education', description: 'Wizard-style multi-step flow with contextual help tooltips, benefit callouts per step, and a clear progress indicator.' },
+    { strategy: 'engagement', description: 'Conversational one-field-at-a-time flow with friendly micro-copy, personality, and celebration on completion.' },
+  ],
+  dashboard: [
+    { strategy: 'conversion', description: 'Action-oriented layout with KPI cards highlighting growth opportunities, prominent "next step" prompts, and quick-action buttons.' },
+    { strategy: 'trust', description: 'Data-transparent layout with sourced metrics, last-updated timestamps, trend arrows, and confidence indicators on every number.' },
+    { strategy: 'education', description: 'Guided dashboard with contextual tooltips on metrics, "what this means" expandable sections, and suggested reading links.' },
+    { strategy: 'engagement', description: 'Gamified dashboard with achievement badges, streak counters, progress bars toward goals, and celebration states.' },
+  ],
+  insights: [
+    { strategy: 'conversion', description: 'Actionable insights layout with each chart paired with a recommended action button. Key takeaways above the fold.' },
+    { strategy: 'trust', description: 'Methodological layout showing data sources, sample sizes, confidence intervals, and comparison benchmarks alongside each visualization.' },
+    { strategy: 'education', description: 'Narrative analytics with explanatory text blocks between charts, "why this matters" sections, and glossary tooltips.' },
+    { strategy: 'engagement', description: 'Interactive exploration layout with filter controls, drill-down paths, hover-reveal details, and shareable chart snapshots.' },
+  ],
+  settings: [
+    { strategy: 'conversion', description: 'Quick-setup flow highlighting the 3 most impactful settings first, with "recommended" badges and one-click optimal presets.' },
+    { strategy: 'trust', description: 'Privacy-first layout with clear data usage explanations per setting, permission scopes visible, and audit log link.' },
+    { strategy: 'education', description: 'Documented settings with inline help text, "what happens when" previews, and contextual documentation links.' },
+    { strategy: 'engagement', description: 'Personalization-forward layout with live preview of changes, undo history, and satisfaction feedback on each setting group.' },
+  ],
+  listing: [
+    { strategy: 'conversion', description: 'Browse-to-buy layout with prominent filter bar, "best match" sorting default, quick-add buttons, and comparison checkboxes.' },
+    { strategy: 'trust', description: 'Verified listing layout with rating badges, verified seller marks, price transparency indicators, and review counts per item.' },
+    { strategy: 'education', description: 'Category-guided layout with educational headers per section, "why these items" explanations, and buying guide links.' },
+    { strategy: 'engagement', description: 'Discovery-driven layout with saved searches, "similar items" carousels, recently viewed trail, and personalized recommendations.' },
+  ],
+  detail: [
+    { strategy: 'conversion', description: 'Purchase-focused layout with sticky CTA bar, key specs above the fold, comparison widget, and urgency indicators.' },
+    { strategy: 'trust', description: 'Evidence-rich layout with verified reviews, expert endorsements, source citations, and transparent pricing breakdown.' },
+    { strategy: 'education', description: 'Comprehensive layout with tabbed specifications, how-to-use guides, FAQ accordion, and related resource links.' },
+    { strategy: 'engagement', description: 'Immersive layout with full-width media, interactive galleries, community discussion section, and share/save actions.' },
+  ],
+};
+
+/**
+ * Get strategy-driven layout descriptions for a given page type.
+ * Returns 4 objects, each with a strategy name and layout description.
+ *
+ * @param {PageType} pageType
+ * @returns {Array<{strategy: string, description: string}>} Array of 4 strategy-tagged layouts
+ */
+export function getStrategyLayouts(pageType) {
+  return STRATEGY_LAYOUTS[pageType] ?? STRATEGY_LAYOUTS.landing;
+}


### PR DESCRIPTION
## Summary
- Extract monolithic `buildArchetypePrompt()` into 3 composable modules: `design-system-brief.js`, `content-brief-builder.js`, and strategy-enhanced `page-type-classifier.js`
- Each variant now implements a distinct design strategy (conversion/trust/education/engagement) per page type
- Venture identity context injected from upstream Stage 11-12 artifacts via pure-function brief generators

## Test plan
- [x] All 3 new modules tested with unit validation (compile, fallback behavior, output format)
- [x] Existing S17 tests pass (pre-existing mock failures unchanged)
- [x] archetype-generator.js imports and compiles successfully
- [x] Backward compatible — function signature unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)