### PR TITLE
feat(S17): strategy effectiveness tracking and feedback loop

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
+  "currentSd": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing S17 Prompt Enrichment + Strategy-Driven Variant Framework",
+  "currentTask": "Implementing S17 Strategy Effectiveness Feedback Loop",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
   "clearedAt": "2026-04-15T00:32:06.617Z",
-  "lastUpdatedAt": "2026-04-19T20:54:48.605Z"
+  "lastUpdatedAt": "2026-04-19T21:28:08.287Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
-  "expectedBranch": "feat/SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A",
-  "createdAt": "2026-04-19T20:41:46.046Z",
+  "sdKey": "SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C",
+  "expectedBranch": "feat/SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C",
+  "createdAt": "2026-04-19T21:24:09.742Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/stage-17/selection-flow.js
+++ b/lib/eva/stage-17/selection-flow.js
@@ -171,6 +171,9 @@ export async function submitPass2Selection(ventureId, screenId, platform, artifa
       platform,
       sourceRefinedArtifactId: artifactId,
       approvedAt: new Date().toISOString(),
+      // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C: track strategy for effectiveness feedback
+      strategy_name: source.metadata?.strategy_name ?? source.artifact_data?.strategy_name ?? null,
+      page_type: source.metadata?.pageType ?? source.artifact_data?.pageType ?? null,
     },
   });
 

--- a/lib/eva/stage-17/strategy-stats.js
+++ b/lib/eva/stage-17/strategy-stats.js
@@ -1,0 +1,109 @@
+/**
+ * Strategy Effectiveness Stats for S17
+ *
+ * Aggregates strategy selection patterns from approved S17 artifacts
+ * to track which design strategies (conversion, trust, education, engagement)
+ * are preferred per page type. Detects normalization imbalance.
+ *
+ * SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C
+ * @module lib/eva/stage-17/strategy-stats
+ */
+
+import { writeArtifact } from '../artifact-persistence-service.js';
+
+const DOMINANCE_THRESHOLD = 0.6;
+const MIN_SAMPLES_FOR_WARNING = 5;
+
+/**
+ * Aggregate strategy selection statistics for a venture.
+ * Reads all approved S17 artifacts, groups by page type and strategy,
+ * and produces an s17_strategy_stats artifact.
+ *
+ * @param {string} ventureId
+ * @param {object} supabase - Supabase client
+ * @returns {Promise<{ stats: object, artifactId: string|null }>}
+ */
+export async function aggregateStrategyStats(ventureId, supabase) {
+  const { data: approved, error } = await supabase
+    .from('venture_artifacts')
+    .select('metadata')
+    .eq('venture_id', ventureId)
+    .eq('is_current', true)
+    .in('artifact_type', ['stage_17_approved_mobile', 'stage_17_approved_desktop']);
+
+  if (error) {
+    console.error('[strategy-stats] DB error:', error.message);
+    return { stats: null, artifactId: null };
+  }
+
+  if (!approved || approved.length === 0) {
+    return { stats: { per_page_type: {}, total_selections: 0, dominant_strategies: [] }, artifactId: null };
+  }
+
+  // Aggregate by page type and strategy
+  const perPageType = {};
+  let totalSelections = 0;
+
+  for (const art of approved) {
+    const meta = art.metadata ?? {};
+    const pageType = meta.page_type ?? 'unknown';
+    const strategy = meta.strategy_name ?? 'unknown';
+
+    if (!perPageType[pageType]) {
+      perPageType[pageType] = { total: 0, strategies: {} };
+    }
+    perPageType[pageType].total++;
+    perPageType[pageType].strategies[strategy] = (perPageType[pageType].strategies[strategy] || 0) + 1;
+    totalSelections++;
+  }
+
+  // Detect dominant strategies
+  const dominantStrategies = [];
+  for (const [pageType, data] of Object.entries(perPageType)) {
+    if (data.total < MIN_SAMPLES_FOR_WARNING) continue;
+
+    for (const [strategy, count] of Object.entries(data.strategies)) {
+      const share = count / data.total;
+      if (share > DOMINANCE_THRESHOLD) {
+        dominantStrategies.push({
+          page_type: pageType,
+          strategy,
+          share: Math.round(share * 100),
+          count,
+          total: data.total,
+        });
+        console.warn(
+          `[strategy-stats] ⚠ Dominant strategy detected: "${strategy}" has ${Math.round(share * 100)}% share for "${pageType}" (${count}/${data.total} selections)`
+        );
+      }
+    }
+  }
+
+  const stats = {
+    per_page_type: perPageType,
+    total_selections: totalSelections,
+    dominant_strategies: dominantStrategies,
+    aggregated_at: new Date().toISOString(),
+  };
+
+  // Write stats artifact
+  let artifactId = null;
+  try {
+    artifactId = await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 17,
+      artifactType: 's17_strategy_stats',
+      title: 'Strategy Effectiveness Statistics',
+      content: JSON.stringify(stats),
+      artifactData: stats,
+      qualityScore: null,
+      validationStatus: null,
+      source: 'stage-17-strategy-stats',
+      metadata: { totalSelections, dominantCount: dominantStrategies.length },
+    });
+  } catch (e) {
+    console.warn('[strategy-stats] Artifact write failed:', e.message);
+  }
+
+  return { stats, artifactId };
+}


### PR DESCRIPTION
## Summary
- Track `strategy_name` and `page_type` in approved S17 artifact metadata
- New `strategy-stats.js` module aggregates selection patterns per page type
- Detects dominant strategies (>60% share at N>=5) with console warnings
- Produces `s17_strategy_stats` artifact for data-driven refinement

## Test plan
- [x] All modules compile and import successfully
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass
- [x] Strategy metadata added to selection-flow.js (backward compatible with null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)