### PR TITLE
fix(S17): handle variant-suffixed artifact IDs in selection flow

### DIFF
--- a/lib/eva/stage-17/selection-flow.js
+++ b/lib/eva/stage-17/selection-flow.js
@@ -41,13 +41,35 @@ export class SelectionError extends Error {
  * @returns {Promise<{ content: string, artifact_data: object, metadata: object, title: string }>}
  */
 async function fetchArtifactById(supabase, artifactId) {
+  // Handle variant-suffixed IDs from frontend (e.g., "uuid__v1" → artifact uuid, variant index 1)
+  let rawId = artifactId;
+  let variantIndex = null;
+  const suffixMatch = artifactId.match(/^(.+?)__v(\d+)$/);
+  if (suffixMatch) {
+    rawId = suffixMatch[1];
+    variantIndex = parseInt(suffixMatch[2], 10);
+  }
+
   const { data, error } = await supabase
     .from('venture_artifacts')
     .select('id, content, artifact_data, metadata, title, artifact_type')
-    .eq('id', artifactId)
+    .eq('id', rawId)
     .single();
 
-  if (error || !data) throw new Error(`[selection-flow] Artifact ${artifactId} not found: ${error?.message}`);
+  if (error || !data) throw new Error(`[selection-flow] Artifact ${rawId} not found: ${error?.message}`);
+
+  // If variant-suffixed, extract the specific variant from a multi-variant artifact
+  if (variantIndex !== null && data.artifact_data?.variants) {
+    const variant = data.artifact_data.variants.find(v => v.variantIndex === variantIndex);
+    if (variant) {
+      return {
+        ...data,
+        content: variant.html ?? data.content,
+        metadata: { ...data.metadata, strategy_name: variant.strategy_name, variantIndex },
+      };
+    }
+  }
+
   return data;
 }
 


### PR DESCRIPTION
## Summary
Frontend builds compound artifact IDs (`uuid__v1`) in Stage17ReviewPanel.tsx line 92 to identify which variant was selected from a multi-variant `s17_archetypes` artifact. `fetchArtifactById` in selection-flow.js passed this directly to `.eq('id', ...)`, causing "invalid input syntax for type uuid" on every Pass 2 selection.

Fix: parse `__vN` suffix, look up raw UUID, extract specific variant's HTML and `strategy_name` from `artifact_data.variants`.

Found during ImpactPath S17 live monitoring — `/api/stitch/.../stage17/refine` returning 500.

## Test plan
- [x] Verified frontend compound ID pattern in Stage17ReviewPanel.tsx
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)