### PR TITLE
fix(S17): reserve Opus 4.7 for variant generation, downgrade rest to Sonnet 4.6

### DIFF
--- a/lib/config/model-config.js
+++ b/lib/config/model-config.js
@@ -40,7 +40,7 @@ const MODEL_DEFAULTS = {
   claude: {
     validation: 'claude-sonnet-4-6',
     classification: 'claude-haiku-4-5-20251001',
-    generation: 'claude-opus-4-7',    // Upgraded from 4.6 (legacy) — released 2026-04-16
+    generation: 'claude-sonnet-4-6',   // Downgraded from opus-4-7 (2026-04-19) to cut API costs. Opus 4.7 only used in archetype-generator.js for S17 variant HTML.
     fast: 'claude-haiku-4-5-20251001',
     vision: 'claude-haiku-4-5-20251001',
   },

--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -361,8 +361,13 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
 
   // 3. Import LLM client — use Anthropic Claude for design generation
   const { getLLMClient } = await import('../../llm/client-factory.js');
-  const { getClaudeModel } = await import('../../config/model-config.js');
-  const generationModel = getClaudeModel('generation'); // claude-opus-4-6 or newer
+  // COST CONTROL (2026-04-19): S17 variant generation is the ONLY place we use Opus 4.7.
+  // Everything else routes through model-config.js which defaults to Sonnet 4.6.
+  // Opus 4.7 is hardcoded here (not via getClaudeModel('generation')) because:
+  //   1. Variant HTML generation requires Opus-level quality for design fidelity
+  //   2. The centralized 'generation' tier was downgraded to Sonnet to cut API costs
+  //   3. Override via CLAUDE_MODEL_S17_GENERATION env var if needed
+  const generationModel = process.env.CLAUDE_MODEL_S17_GENERATION || 'claude-opus-4-7';
   const client = getLLMClient({ purpose: 'generation', provider: 'anthropic', model: generationModel });
 
   const artifactIds = [];

--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -1,9 +1,11 @@
 /**
- * Venture Pipeline Monitor — NichePulse run
- * Push S3-S16 via chairman approval RPC, stop at S17
+ * Venture Pipeline Monitor — ImpactPath run
+ * Push S3-S16 via chairman approval RPC, HARD STOP at S17
  * Monitors wireframe_screens artifact (Stitch replacement) and flags pipeline issues
  *
  * SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001: Stitch replaced with wireframe_screens artifact path
+ * SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001: Watch for strategy-driven variants, design mastering,
+ *   cross-variant awareness, strategy stats feedback loop
  */
 'use strict';
 
@@ -11,8 +13,8 @@ require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-const VENTURE_ID = '7397c1f7-35b9-44b1-a795-c0dddd42eb54';
-const VENTURE_NAME = 'API Compliance Shield';
+const VENTURE_ID = '3dc5d898-7fa5-45bb-84e2-6c15fe7e7ef3';
+const VENTURE_NAME = 'ImpactPath';
 const STOP_AT_STAGE = 17;
 const POLL_MS = 30000;
 
@@ -31,14 +33,16 @@ const STAGE_NAMES = {
 
 // Post-Stitch-replacement: monitor wireframe_screens instead of stitch artifacts
 const DESIGN_ARTIFACT_TYPES = [
-  'wireframe_screens',        // NEW: S15 post-hook writes this (replaces stitch provisioning)
+  'wireframe_screens',        // S15 post-hook writes this (replaces stitch provisioning)
   'blueprint_wireframes',     // S15 wireframes
   'design_token_manifest',    // S17 brand tokens
   's17_archetypes',           // S17 archetype variants
   's17_session_state',        // S17 session resume
   's17_approved',             // S17 final selections
-  's17_approved_png',         // NEW: Playwright PNG screenshots
+  's17_approved_png',         // Playwright PNG screenshots
   's17_variant_scores',       // S17 scoring results
+  's17_design_system',        // NEW: Design mastering output (SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-B)
+  's17_strategy_stats',       // NEW: Strategy effectiveness tracking (SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C)
   // Legacy (should NOT appear for new ventures post-Stitch-replacement)
   'stitch_curation', 'stitch_project', 'stitch_design_export',
 ];
@@ -335,9 +339,10 @@ function validateStageArtifacts(stage, arts) {
 async function main() {
   console.log(`\n${'='.repeat(70)}`);
   console.log(` VENTURE MONITOR — ${VENTURE_NAME} (${VENTURE_ID.slice(0,8)})`);
-  console.log(` Poll every ${POLL_MS/1000}s | Auto-push S3-S16 | STOP at S${STOP_AT_STAGE}`);
+  console.log(` Poll every ${POLL_MS/1000}s | Auto-push S3-S16 | HARD STOP at S${STOP_AT_STAGE}`);
   console.log(` Kill gates: S3, S5, S13 | Promotion gates: S10, S17`);
   console.log(` Stitch replacement: watching wireframe_screens (S15), s17_archetypes (S17)`);
+  console.log(` Design mastery: s17_design_system, s17_strategy_stats, cross-variant awareness`);
   console.log(` Legacy Stitch artifacts should NOT appear for new ventures`);
   console.log(`${'='.repeat(70)}\n`);
 


### PR DESCRIPTION
## Summary
- Downgraded default Claude `generation` tier from `claude-opus-4-7` to `claude-sonnet-4-6` in `model-config.js`
- Hardcoded `claude-opus-4-7` in `archetype-generator.js` with env var override (`CLAUDE_MODEL_S17_GENERATION`)
- All sub-agent calls (thinking-effort routing, opus tier, canary router) now use Sonnet 4.6 instead of Opus 4.7
- Only S17 HTML variant generation retains Opus 4.7 for design fidelity
- Updated venture monitor for ImpactPath run with S17 design mastery watch points

## Why
Opus 4.7 was consuming API credits at a high rate because every sub-agent call routed through the centralized `generation` tier. Most tasks don't need Opus-level quality — only the S17 variant HTML generation benefits from it.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify S17 variant generation still uses Opus 4.7 via logs
- [ ] Verify sub-agent calls show Sonnet 4.6 in LLM Factory logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)