### PR TITLE
fix(S17): 4 generation quality fixes from ImpactPath monitoring

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -33,6 +33,10 @@ import { buildVariantSummary } from './design-mastering.js';
  * @param {string} ventureId
  * @returns {Promise<Set<string>>} Set of completed screenId values
  */
+// Minimum generation version required for an artifact to count as "completed".
+// Bump this when the generation pipeline changes materially (e.g., strategy-driven variants).
+const GENERATION_VERSION = 2; // v2: strategy-driven variants + design briefs
+
 async function getCompletedScreens(supabase, ventureId) {
   const { data } = await supabase
     .from('venture_artifacts')
@@ -45,7 +49,9 @@ async function getCompletedScreens(supabase, ventureId) {
   const completed = new Set();
   for (const row of data ?? []) {
     const screenId = row.metadata?.screenId;
-    if (screenId) completed.add(screenId);
+    const version = row.metadata?.generation_version ?? 0;
+    // Only count as completed if artifact was generated with current pipeline version
+    if (screenId && version >= GENERATION_VERSION) completed.add(screenId);
   }
   return completed;
 }
@@ -74,7 +80,11 @@ async function getWipVariants(supabase, ventureId, screenId) {
   for (const row of data ?? []) {
     const idx = row.metadata?.variantIndex;
     if (idx != null && row.artifact_data?.html) {
-      wip.set(idx, { html: row.artifact_data.html, layoutDescription: row.artifact_data.layoutDescription });
+      wip.set(idx, {
+        html: row.artifact_data.html,
+        layoutDescription: row.artifact_data.layoutDescription,
+        strategy_name: row.metadata?.strategy_name ?? null,
+      });
     }
   }
   return wip;
@@ -486,7 +496,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       // Skip variants that were already persisted in a prior run
       if (existingWip.has(i + 1)) {
         const wip = existingWip.get(i + 1);
-        variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html });
+        variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html, strategy_name: wip.strategy_name });
         console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: resumed from WIP — ${wip.html.length} chars`);
         await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: wip.html.length, seconds: 0, layout: wip.layoutDescription.slice(0, 50), resumed: true, timestamp: new Date().toISOString() });
         continue;
@@ -515,12 +525,26 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       }
       userContent.push({ type: 'text', text: promptText });
 
-      const archetypeResult = await client.complete(
-        'You are a senior UI designer creating static visual mockup HTML. Generate a complete, self-contained HTML page based on the screen description and brand constraints. Return only the complete HTML.',
-        userContent,
-        { stream: true, timeout: 300000, cacheTTLMs: 0, maxTokens: 32768, purpose: 'content-generation' }
-      );
-      const archetypeHtml = archetypeResult?.content ?? String(archetypeResult);
+      let archetypeHtml;
+      const systemPrompt = 'You are a senior UI designer creating static visual mockup HTML. Generate a complete, self-contained HTML page based on the screen description and brand constraints. Return only the complete HTML.';
+      const llmOpts = { stream: true, timeout: 300000, cacheTTLMs: 0, maxTokens: 32768, purpose: 'content-generation' };
+
+      const result = await client.complete(systemPrompt, userContent, llmOpts);
+      archetypeHtml = result?.content ?? String(result);
+
+      // Validate distinctive move comment — retry once if missing
+      if (!/<!-- distinctive move:/i.test(archetypeHtml)) {
+        console.warn(`[archetype-generator] │   v${i + 1}: distinctive move MISSING — retrying with reminder`);
+        const retryContent = [...userContent, { type: 'text', text: '\n\nIMPORTANT: Your output is missing the required <!-- distinctive move: ... --> HTML comment. You MUST include exactly one. Add it now.' }];
+        const retryResult = await client.complete(systemPrompt, retryContent, llmOpts);
+        const retryHtml = retryResult?.content ?? String(retryResult);
+        if (/<!-- distinctive move:/i.test(retryHtml)) {
+          archetypeHtml = retryHtml;
+        } else {
+          console.warn(`[archetype-generator] │   v${i + 1}: distinctive move still missing after retry — flagging`);
+        }
+      }
+
       const variantSec = ((Date.now() - variantStart) / 1000).toFixed(0);
 
       // PAT-PERSIST-CHECKPOINT-001: Persist each variant immediately to DB as WIP
@@ -585,6 +609,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         screenSource,
         tokensApplied: !!tokens,
         strategies_used: strategyLayouts ? strategyLayouts.map(sl => sl.strategy) : null,
+        generation_version: GENERATION_VERSION,
       },
     });
 

--- a/lib/eva/stage-17/page-type-classifier.js
+++ b/lib/eva/stage-17/page-type-classifier.js
@@ -18,12 +18,12 @@
  */
 const PAGE_TYPE_RULES = [
   { type: 'signup',    patterns: [/sign\s*up/i, /register/i, /login/i, /log\s*in/i, /auth/i, /onboard/i, /create\s*account/i] },
-  { type: 'dashboard', patterns: [/dashboard/i, /overview/i, /home\s*screen/i, /main\s*screen/i, /control\s*panel/i] },
+  { type: 'dashboard', patterns: [/dashboard/i, /overview/i, /home\s*screen/i, /main\s*screen/i, /control\s*panel/i, /my\s+portfolio/i, /my\s+account/i] },
   { type: 'insights',  patterns: [/insight/i, /analytics/i, /report/i, /metrics/i, /statistics/i, /data\s*view/i] },
-  { type: 'settings',  patterns: [/setting/i, /preference/i, /config/i, /account/i, /profile/i, /admin/i] },
-  { type: 'listing',   patterns: [/list/i, /search/i, /browse/i, /catalog/i, /directory/i, /results/i, /explore/i] },
-  { type: 'detail',    patterns: [/detail/i, /view/i, /item/i, /article/i, /post/i, /content\s*page/i] },
-  { type: 'landing',   patterns: [/landing/i, /home/i, /hero/i, /welcome/i, /marketing/i, /about/i, /pricing/i, /feature/i] },
+  { type: 'settings',  patterns: [/setting/i, /preference/i, /config/i, /account\s*settings/i, /profile\s*settings/i, /admin/i, /giving\s*profile/i] },
+  { type: 'listing',   patterns: [/list/i, /search/i, /browse/i, /catalog/i, /directory/i, /results/i, /explore/i, /discover/i, /portfolio/i] },
+  { type: 'detail',    patterns: [/detail/i, /view\s+\w+/i, /item/i, /article/i, /post/i, /content\s*page/i, /profile(?!\s*settings)/i, /cause\s*detail/i] },
+  { type: 'landing',   patterns: [/landing/i, /home(?!\s*screen)/i, /hero/i, /welcome/i, /marketing/i, /about/i, /pricing/i, /for\s+\w+s\b/i] },
 ];
 
 /**
@@ -129,6 +129,13 @@ export function classifyPageType(screenName, screenPrompt = '', options = {}) {
   const confidence = Math.min(1, (patternCoverage * 0.6 + exclusivity * 0.4) * (bestScore > 0 ? 1.5 : 0));
 
   if (confidence < confidenceThreshold || bestScore === 0) {
+    // Context-aware fallback instead of always defaulting to 'landing'
+    const name = screenName.toLowerCase();
+    if (/my\s|portfolio|dashboard|overview/i.test(name)) return { pageType: 'dashboard', confidence: 0.4, method: 'name_heuristic' };
+    if (/profile|giving|donation|impact/i.test(name)) return { pageType: 'detail', confidence: 0.4, method: 'name_heuristic' };
+    if (/discover|browse|explore|cause/i.test(name)) return { pageType: 'listing', confidence: 0.4, method: 'name_heuristic' };
+    if (/how\s+(it|to)|getting\s+started|process|steps/i.test(name)) return { pageType: 'detail', confidence: 0.4, method: 'name_heuristic' };
+    if (/for\s+\w+/i.test(name)) return { pageType: 'landing', confidence: 0.4, method: 'name_heuristic' };
     return { pageType: 'landing', confidence: 0.3, method: 'default' };
   }
 


### PR DESCRIPTION
## Summary
4 pattern fixes from RCA of ImpactPath S17 generation logs:

1. **Page type misclassification** — composite keywords + context-aware name heuristic fallback. 9/9 tests.
2. **WIP resume drops strategy_name** — getWipVariants() extracts strategy_name from metadata.
3. **Stale artifacts skip re-gen** — GENERATION_VERSION=2 stamp; old artifacts trigger re-generation.
4. **Distinctive move validation** — post-gen regex check + single LLM retry with reminder.

## Test plan
- [x] 9/9 page type classification tests pass
- [x] All modules compile
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)