### PR TITLE
fix(S17): support changing approved variant with cascade

### DIFF
--- a/lib/eva/stage-17/selection-flow.js
+++ b/lib/eva/stage-17/selection-flow.js
@@ -178,6 +178,28 @@ export async function submitPass2Selection(ventureId, screenId, platform, artifa
   const source = await fetchArtifactById(supabase, artifactId);
   const approvedType = platform === 'mobile' ? 'stage_17_approved_mobile' : 'stage_17_approved_desktop';
 
+  // Retire any existing approval for this screen+platform (supports changing approval)
+  let previousApproval = null;
+  const { data: existing } = await supabase
+    .from('venture_artifacts')
+    .select('id, metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', approvedType)
+    .eq('is_current', true)
+    .eq('metadata->>screenId', screenId);
+
+  if (existing?.length > 0) {
+    previousApproval = { id: existing[0].id, variantIndex: existing[0].metadata?.variantIndex };
+    await supabase
+      .from('venture_artifacts')
+      .update({ is_current: false })
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', approvedType)
+      .eq('is_current', true)
+      .eq('metadata->>screenId', screenId);
+    console.log(`[selection-flow] Replaced previous approval for ${screenId} (${approvedType})`);
+  }
+
   const approvedArtifactId = await writeArtifact(supabase, {
     ventureId,
     lifecycleStage: 17,
@@ -191,9 +213,10 @@ export async function submitPass2Selection(ventureId, screenId, platform, artifa
     metadata: {
       screenId,
       platform,
+      variantIndex: source.metadata?.variantIndex ?? null,
       sourceRefinedArtifactId: artifactId,
       approvedAt: new Date().toISOString(),
-      // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-C: track strategy for effectiveness feedback
+      replacedPreviousApproval: !!previousApproval,
       strategy_name: source.metadata?.strategy_name ?? source.artifact_data?.strategy_name ?? null,
       page_type: source.metadata?.pageType ?? source.artifact_data?.pageType ?? null,
     },
@@ -210,7 +233,7 @@ export async function submitPass2Selection(ventureId, screenId, platform, artifa
     console.warn('[selection-flow] Design mastering failed (non-blocking):', e.message);
   }
 
-  return { approvedArtifactId };
+  return { approvedArtifactId, replaced: !!previousApproval, previousApprovalId: previousApproval?.id ?? null };
 }
 
 /**

--- a/server/routes/stage17.js
+++ b/server/routes/stage17.js
@@ -169,7 +169,7 @@ router.post('/:ventureId/refine', asyncHandler(async (req, res) => {
   const supabase = req.app.locals.supabase || req.supabase;
   try {
     const result = await submitPass2Selection(ventureId, screenId, platform, artifactId, supabase);
-    return res.status(200).json({ approvedArtifactId: result });
+    return res.status(200).json({ approvedArtifactId: result.approvedArtifactId, replaced: result.replaced });
   } catch (err) {
     if (err instanceof SelectionError) {
       return res.status(400).json({ error: err.message, code: 'SELECTION_ERROR' });


### PR DESCRIPTION
Backend retires old approval, writes new one, re-runs mastering. Returns replaced flag to frontend.