### PR TITLE
fix(S17): CRITICAL — never regenerate screens with existing approvals

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -38,19 +38,33 @@ import { buildVariantSummary } from './design-mastering.js';
 const GENERATION_VERSION = 2; // v2: strategy-driven variants + design briefs
 
 async function getCompletedScreens(supabase, ventureId) {
-  const { data } = await supabase
-    .from('venture_artifacts')
-    .select('metadata')
-    .eq('venture_id', ventureId)
-    .eq('artifact_type', 's17_archetypes')
-    .eq('lifecycle_stage', 17)
-    .eq('is_current', true);
+  // Query both archetypes AND approved artifacts — approved screens must NEVER be regenerated
+  const [archetypeRes, approvedRes] = await Promise.all([
+    supabase.from('venture_artifacts')
+      .select('metadata')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 's17_archetypes')
+      .eq('lifecycle_stage', 17)
+      .eq('is_current', true),
+    supabase.from('venture_artifacts')
+      .select('metadata')
+      .eq('venture_id', ventureId)
+      .in('artifact_type', ['stage_17_approved_desktop', 'stage_17_approved_mobile'])
+      .eq('is_current', true),
+  ]);
 
-  const completed = new Set();
-  for (const row of data ?? []) {
+  // Screens with approvals are ALWAYS completed — regenerating would destroy user's choice
+  const approvedScreenIds = new Set();
+  for (const row of approvedRes.data ?? []) {
+    const screenId = row.metadata?.screenId;
+    if (screenId) approvedScreenIds.add(screenId);
+  }
+
+  const completed = new Set(approvedScreenIds);
+  for (const row of archetypeRes.data ?? []) {
     const screenId = row.metadata?.screenId;
     const version = row.metadata?.generation_version ?? 0;
-    // Only count as completed if artifact was generated with current pipeline version
+    // Count as completed if: already approved OR generated with current pipeline version
     if (screenId && version >= GENERATION_VERSION) completed.add(screenId);
   }
   return completed;
@@ -645,7 +659,12 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
  */
 export async function generateRefinedVariants(ventureId, screenName, selectedHtmls, tokens, supabase, options = {}) {
   const { getLLMClient } = await import('../../llm/client-factory.js');
-  const client = getLLMClient({ purpose: 'generation' });
+  // COST CONTROL (2026-04-19): Refined variant HTML generation uses Opus 4.7 explicitly.
+  // Same rationale as generateArchetypeVariants above — variant HTML requires Opus-level
+  // design fidelity. All other LLM calls default to Google Gemini for cost savings.
+  // Override via CLAUDE_MODEL_S17_GENERATION env var if needed.
+  const generationModel = process.env.CLAUDE_MODEL_S17_GENERATION || 'claude-opus-4-7';
+  const client = getLLMClient({ purpose: 'generation', provider: 'anthropic', model: generationModel });
 
   const mobileContext = options.mobileContextHtml
     ? `\n\nMOBILE REFERENCE (approved mobile design for this screen — desktop must maintain visual coherence):\n${options.mobileContextHtml.slice(0, 2000)}`


### PR DESCRIPTION
Approved screens are now protected from regeneration regardless of generation version. Prevents data loss when server restarts.