### PR TITLE
fix(S17): remove auto-regeneration — user controls when to regenerate

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -33,39 +33,24 @@ import { buildVariantSummary } from './design-mastering.js';
  * @param {string} ventureId
  * @returns {Promise<Set<string>>} Set of completed screenId values
  */
-// Minimum generation version required for an artifact to count as "completed".
-// Bump this when the generation pipeline changes materially (e.g., strategy-driven variants).
+// Generation version stamped in metadata for provenance tracking (not used for auto-regeneration).
+// Auto-regeneration was removed — Opus 4.7 is expensive. User clicks Regenerate explicitly.
 const GENERATION_VERSION = 2; // v2: strategy-driven variants + design briefs
 
 async function getCompletedScreens(supabase, ventureId) {
-  // Query both archetypes AND approved artifacts — approved screens must NEVER be regenerated
-  const [archetypeRes, approvedRes] = await Promise.all([
-    supabase.from('venture_artifacts')
-      .select('metadata')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', 's17_archetypes')
-      .eq('lifecycle_stage', 17)
-      .eq('is_current', true),
-    supabase.from('venture_artifacts')
-      .select('metadata')
-      .eq('venture_id', ventureId)
-      .in('artifact_type', ['stage_17_approved_desktop', 'stage_17_approved_mobile'])
-      .eq('is_current', true),
-  ]);
+  const { data } = await supabase
+    .from('venture_artifacts')
+    .select('metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 's17_archetypes')
+    .eq('lifecycle_stage', 17)
+    .eq('is_current', true);
 
-  // Screens with approvals are ALWAYS completed — regenerating would destroy user's choice
-  const approvedScreenIds = new Set();
-  for (const row of approvedRes.data ?? []) {
+  const completed = new Set();
+  for (const row of data ?? []) {
     const screenId = row.metadata?.screenId;
-    if (screenId) approvedScreenIds.add(screenId);
-  }
-
-  const completed = new Set(approvedScreenIds);
-  for (const row of archetypeRes.data ?? []) {
-    const screenId = row.metadata?.screenId;
-    const version = row.metadata?.generation_version ?? 0;
-    // Count as completed if: already approved OR generated with current pipeline version
-    if (screenId && version >= GENERATION_VERSION) completed.add(screenId);
+    // Any existing archetype counts as completed — never auto-regenerate
+    if (screenId) completed.add(screenId);
   }
   return completed;
 }


### PR DESCRIPTION
Existing archetypes always count as completed. No auto-regeneration on restart. Regenerate button is the only path.