### PR TITLE
fix: undefined scope variable in createSD for child SDs

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1111,7 +1111,7 @@ async function createSD(options) {
     : buildDefaultKeyChanges(type, title);
   const finalSmokeTestSteps = (Array.isArray(smoke_test_steps) && smoke_test_steps.length > 0)
     ? smoke_test_steps
-    : buildDefaultSmokeTestSteps(type, title, scope);
+    : buildDefaultSmokeTestSteps(type, title, options.scope ?? description);
 
   // ========================================================================
   // GOVERNANCE GUARDRAILS (SD-MAN-FEAT-CORRECTIVE-VISION-GAP-007)


### PR DESCRIPTION
Child SD creation crashed because scope was only defined in --from-plan path. Fixed with fallback.