### PR TITLE
fix: archplan upsert writes vision_key alongside vision_id

### DIFF
--- a/lib/eva/archplan-upsert.js
+++ b/lib/eva/archplan-upsert.js
@@ -93,6 +93,7 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
   const record = {
     plan_key: planKey,
     vision_id: visionDoc.id,
+    vision_key: visionDoc.vision_key,
     vision_version_aligned_to: visionDoc.version || 1,
     content,
     extracted_dimensions: dimensions || null,


### PR DESCRIPTION
1-line fix. vision_key was always null because only vision_id was set.