### PR TITLE
fix(S121): auto-resolve worktree in claim-validity gate

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -289,13 +289,26 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
         const normalActual = normalize(actualCwd);
         const insideWorktree = normalActual === normalExpected || normalActual.startsWith(normalExpected + path.sep);
         if (!insideWorktree) {
-          throw new ClaimIdentityError({
-            reason: 'wrong_worktree',
-            operation, sdKey,
-            expectedWorktree: expectedWt,
-            actualCwd,
-            remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your handoff command with the session prefix:\n    CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute <PHASE> ${sdKey}\n  Fleet note: in parallel execution each child SD must run from its OWN worktree,\n  not from the parent orchestrator's worktree or the main repo root.`
-          });
+          // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-121: Auto-resolve worktree instead of blocking.
+          // The worktree is confirmed to exist (isRealWorktree passed at step 3a).
+          // chdir to the correct worktree so downstream operations target the right branch.
+          try {
+            process.chdir(expectedWt);
+            console.warn(
+              `[claim-validity-gate] ⚠️  Auto-resolved worktree for ${sdKey}: ` +
+              `was in ${actualCwd}, now in ${expectedWt}. ` +
+              `Tip: cd to the worktree before running handoff to avoid this warning.`
+            );
+          } catch (cdErr) {
+            // chdir failed — fall back to original blocking behavior
+            throw new ClaimIdentityError({
+              reason: 'wrong_worktree',
+              operation, sdKey,
+              expectedWorktree: expectedWt,
+              actualCwd,
+              remediation: `This SD is claimed and has a registered worktree. All work must run from inside it.\n  Run:  cd "${expectedWt}"\n  Then re-run your handoff command with the session prefix:\n    CLAUDE_SESSION_ID=<uuid> node scripts/handoff.js execute <PHASE> ${sdKey}\n  Fleet note: in parallel execution each child SD must run from its OWN worktree,\n  not from the parent orchestrator's worktree or the main repo root.`
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- When handoff.js runs from the wrong directory, the claim-validity gate now auto-resolves to the correct worktree via `process.chdir()` instead of blocking with `wrong_worktree`
- Falls back to original blocking behavior if chdir fails (worktree deleted/inaccessible)
- Resolves 5 issue patterns (25 total occurrences) from `/learn` retrospective analysis

## Changes
- `lib/claim-validity-gate.js`: Replace `throw ClaimIdentityError` with try/chdir/catch pattern (+20/-7 lines)
- Database: 5 patterns marked resolved in `issue_patterns` table

## Test plan
- [x] Unit tests pass (10/10 in claim-validity-gate.test.js)
- [x] Handoff tests pass (460/460, 1 pre-existing failure in unrelated file)
- [x] Smoke tests pass (15/15)
- [ ] Verify handoff from main repo succeeds via auto-resolution
- [ ] Verify warning logged when auto-resolution activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)