### PR TITLE
fix(S17): prerequisite chain diagnostic for LEAD-FINAL-APPROVAL

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -25,6 +25,9 @@ import { recordSdCompleted } from '../../../../../lib/learning/outcome-tracker.j
 // Worktree cleanup (SD-LEO-INFRA-INTEGRATE-WORKTREE-CREATION-001)
 import { cleanupWorktree, validateSdKey } from '../../../../../lib/worktree-manager.js';
 
+// Workflow definitions for prerequisite chain diagnosis (SD-LEARN-FIX-ADDRESS-PAT-RETRO-002)
+import { getWorkflowForType } from '../../cli/workflow-definitions.js';
+
 /**
  * Auto-rescore the original SD after a corrective SD completes.
  * SD-MAN-INFRA-VISION-RESCORE-ON-COMPLETION-001
@@ -220,10 +223,37 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         console.log('   ℹ️  SD is already completed - will verify and confirm');
         options._alreadyCompleted = true;
       } else {
+        // Diagnose which prerequisite handoffs are missing (SD-LEARN-FIX-ADDRESS-PAT-RETRO-002)
+        const workflow = getWorkflowForType(sd.sd_type || 'feature');
+        const requiredHandoffs = workflow.required.filter(h => h !== 'LEAD-FINAL-APPROVAL');
+        let missingHandoffs = [...requiredHandoffs];
+        let nextCommand = `node scripts/handoff.js execute LEAD-TO-PLAN ${sdId}`;
+
+        try {
+          const { data: completedHandoffs } = await this.supabase
+            .from('sd_phase_handoffs')
+            .select('handoff_type')
+            .eq('sd_id', sd.id)
+            .eq('status', 'accepted');
+
+          const completedTypes = new Set((completedHandoffs || []).map(h => h.handoff_type));
+          missingHandoffs = requiredHandoffs.filter(h => !completedTypes.has(h));
+
+          if (missingHandoffs.length > 0) {
+            nextCommand = `node scripts/handoff.js execute ${missingHandoffs[0]} ${sdId}`;
+          }
+        } catch (err) {
+          // Non-fatal: fall back to generic message if query fails
+        }
+
+        const missingList = missingHandoffs.length > 0
+          ? `\n   Missing handoffs: ${missingHandoffs.join(' → ')}\n   Next command: ${nextCommand}`
+          : '';
+
         return ResultBuilder.rejected(
           'INVALID_STATUS',
-          `SD status must be 'pending_approval' for final approval (current: '${sd.status}'). Run PLAN-TO-LEAD handoff first.`,
-          { currentStatus: sd.status, requiredStatus: 'pending_approval' }
+          `SD status must be 'pending_approval' for final approval (current: '${sd.status}').${missingList}`,
+          { currentStatus: sd.status, requiredStatus: 'pending_approval', missingHandoffs, nextCommand }
         );
       }
     }

--- a/tests/unit/lead-final-approval-prereq-check.test.js
+++ b/tests/unit/lead-final-approval-prereq-check.test.js
@@ -1,0 +1,145 @@
+/**
+ * Unit Tests: Prerequisite Chain Diagnostic in LEAD-FINAL-APPROVAL setup()
+ * SD: SD-LEARN-FIX-ADDRESS-PAT-RETRO-002
+ *
+ * Verifies that when LEAD-FINAL-APPROVAL is attempted with wrong SD status,
+ * the error includes which prerequisite handoffs are missing and the exact
+ * remediation command.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test setup() indirectly by importing the executor and calling setup()
+// with mock supabase clients.
+
+function makeSupabaseMock(completedHandoffs = []) {
+  return {
+    from: (table) => {
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: () => ({
+            eq: function () { return this; },
+            then: undefined,
+            // Chain eq calls
+            data: completedHandoffs.map(h => ({ handoff_type: h })),
+          }),
+        };
+      }
+      return { select: () => ({ eq: () => ({ single: () => ({ data: null, error: null }) }) }) };
+    },
+  };
+}
+
+// Build a chainable supabase mock
+function buildSupabaseMock(completedHandoffs = []) {
+  const handoffData = completedHandoffs.map(h => ({ handoff_type: h }));
+  return {
+    from: (table) => {
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        data: handoffData,
+        error: null,
+      };
+      // Make it thenable for async
+      chain.then = (resolve) => resolve({ data: handoffData, error: null });
+      return chain;
+    },
+  };
+}
+
+describe('LEAD-FINAL-APPROVAL Prerequisite Chain Diagnostic', () => {
+  let LeadFinalApprovalExecutor;
+
+  beforeEach(async () => {
+    // Dynamic import to get the class
+    const mod = await import('../../scripts/modules/handoff/executors/lead-final-approval/index.js');
+    LeadFinalApprovalExecutor = mod.LeadFinalApprovalExecutor;
+  });
+
+  it('should include missing handoffs when status is draft with no handoffs', async () => {
+    const supabase = buildSupabaseMock([]);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'draft', sd_type: 'feature' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    expect(result).not.toBeNull();
+    expect(result.reasonCode).toBe('INVALID_STATUS');
+    expect(result.message).toContain('Missing handoffs');
+    expect(result.message).toContain('LEAD-TO-PLAN');
+    expect(result.details.missingHandoffs).toBeInstanceOf(Array);
+    expect(result.details.missingHandoffs.length).toBeGreaterThan(0);
+  });
+
+  it('should show only remaining missing handoffs when some are completed', async () => {
+    const supabase = buildSupabaseMock(['LEAD-TO-PLAN', 'PLAN-TO-EXEC']);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'draft', sd_type: 'feature' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    expect(result).not.toBeNull();
+    expect(result.details.missingHandoffs).toContain('EXEC-TO-PLAN');
+    expect(result.details.missingHandoffs).not.toContain('LEAD-TO-PLAN');
+  });
+
+  it('should provide remediation command for next missing handoff', async () => {
+    const supabase = buildSupabaseMock(['LEAD-TO-PLAN']);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'draft', sd_type: 'feature' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    expect(result).not.toBeNull();
+    expect(result.details.nextCommand).toBe('node scripts/handoff.js execute PLAN-TO-EXEC SD-TEST-001');
+    expect(result.message).toContain('PLAN-TO-EXEC');
+  });
+
+  it('should pass when status is pending_approval', async () => {
+    const supabase = buildSupabaseMock([]);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'pending_approval', sd_type: 'feature' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    // null means setup passed
+    expect(result).toBeNull();
+  });
+
+  it('should handle completed status idempotently', async () => {
+    const supabase = buildSupabaseMock([]);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'completed', sd_type: 'feature' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    expect(result).toBeNull();
+    expect(options._alreadyCompleted).toBe(true);
+  });
+
+  it('should use infrastructure workflow for infrastructure SDs', async () => {
+    const supabase = buildSupabaseMock([]);
+    const executor = new LeadFinalApprovalExecutor({ supabase });
+    executor.supabase = supabase;
+
+    const sd = { id: 'uuid-123', sd_key: 'SD-TEST-001', status: 'draft', sd_type: 'infrastructure' };
+    const options = {};
+    const result = await executor.setup('SD-TEST-001', sd, options);
+
+    expect(result).not.toBeNull();
+    // Infrastructure workflow doesn't include EXEC-TO-PLAN
+    expect(result.details.missingHandoffs).not.toContain('EXEC-TO-PLAN');
+    expect(result.details.missingHandoffs).toContain('LEAD-TO-PLAN');
+  });
+});


### PR DESCRIPTION
## Summary
- Enhanced LEAD-FINAL-APPROVAL executor to diagnose missing prerequisite handoffs when SD status is wrong
- Error now shows which handoffs are missing and the exact `node scripts/handoff.js execute` command to run
- Resolves PAT-RETRO-LEADFINALAPPROVAL-2401064c (4 rejections) and PAT-HF-LEADFINALAPPROVAL-2401064c

## Changes
- `scripts/modules/handoff/executors/lead-final-approval/index.js`: Added prerequisite chain query in `setup()` using `getWorkflowForType()` to identify missing handoffs
- `tests/unit/lead-final-approval-prereq-check.test.js`: 6 unit tests covering all scenarios (draft, partial, valid, completed, infrastructure type)

## Test plan
- [x] 6 new unit tests pass (draft/no handoffs, draft/some handoffs, remediation command, pending_approval passes, completed idempotent, infrastructure workflow)
- [x] 9 existing lead-final-approval-rescore tests still pass (no regression)
- [x] 15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)