### PR TITLE
fix(QF-20260420-405): remove dual-write duplicate artifacts at S12/S15

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -248,7 +248,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const { data: artReqs } = await supabase
       .from('stage_artifact_requirements')
       .select('artifact_type')
-      .eq('stage_number', resolvedStage);
+      .eq('lifecycle_stage', resolvedStage); // QF-20260420-405: was 'stage_number' (wrong column)
     if (artReqs?.length > 0) {
       requiredArtifacts = artReqs.map(r => r.artifact_type);
       logger.log(`[Eva] Stage ${resolvedStage} requires artifacts: ${requiredArtifacts.join(', ')}`);
@@ -449,7 +449,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
           .from('venture_artifacts')
           .select('artifact_type')
           .eq('venture_id', ventureId)
-          .eq('stage_number', resolvedStage);
+          .eq('lifecycle_stage', resolvedStage); // QF-20260420-405: was 'stage_number' (wrong column)
         const existingTypes = (existingRows || []).map(r => r.artifact_type);
 
         const extracted = extractMultiArtifacts(stageOutput, requiredArtifacts, resolvedStage, existingTypes);

--- a/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
@@ -18,7 +18,6 @@ import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../util
 // stage-12.js imports analyzeStage12 from this file; this file imports evaluateRealityGate back.
 import { evaluateRealityGate } from '../stage-12.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
-import { writeArtifact } from '../../artifact-persistence-service.js';
 
 // Duplicated from stage-12.js to avoid circular dependency at module-level evaluation.
 const SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
@@ -367,25 +366,8 @@ Output ONLY valid JSON.`;
     phase3GatePass: reality_gate.pass,
   });
 
-  // SD-LEO-ORCH-PIPELINE-INTEGRITY-FIX-002-B: Write identity_gtm_strategy artifact with EVA keys
-  // Matches pattern from stage-10-customer-brand.js and stage-11-visual-identity.js
-  if (supabase && ventureId) {
-    try {
-      await writeArtifact(supabase, {
-        ventureId,
-        lifecycleStage: 12,
-        artifactType: 'identity_gtm_sales_strategy',
-        title: 'GTM & Sales Strategy (Stage 12)',
-        artifactData: { marketTiers, channels, salesModel, sales_cycle_days, deal_stages, funnel_stages, customer_journey, economyCheck },
-        metadata: { channel_count: channels.length, tier_count: marketTiers.length, reality_gate_pass: reality_gate.pass, source: 'stage-12-analysis' },
-        source: 'stage-12-analysis',
-        visionKey,
-        planKey,
-      });
-    } catch (artifactErr) {
-      logger.warn('[Stage12] GTM artifact write failed (non-blocking)', { error: artifactErr.message });
-    }
-  }
+  // QF-20260420-405: Removed direct writeArtifact call — orchestrator's persistArtifacts is the sole writer
+  // (was dual-writing identity_gtm_sales_strategy, creating duplicate rows in venture_artifacts)
 
   return {
     marketTiers,

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -16,7 +16,6 @@
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wireframe-generator.js';
 import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
-import { writeArtifact } from '../artifact-persistence-service.js';
 import { generateUserStoryPack } from './analysis-steps/stage-15-user-story-pack.js';
 import { generateInformationArchitecture } from './analysis-steps/stage-15-ia-generator.js';
 
@@ -98,21 +97,9 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
   let userStoryResult = null;
   try {
     userStoryResult = await generateUserStoryPack(ctx);
-    if (userStoryResult && ctx.supabase && ctx.ventureId) {
-      await writeArtifact(ctx.supabase, {
-        ventureId: ctx.ventureId,
-        lifecycleStage: 15,
-        artifactType: 'blueprint_user_story_pack',
-        title: 'User Story Pack (Stage 15)',
-        artifactData: userStoryResult,
-        content: JSON.stringify(userStoryResult),
-        qualityScore: 70,
-        validationStatus: 'validated',
-        source: 'stage-15-user-story-pack',
-        visionKey: ctx.visionKey || null,
-        planKey: ctx.planKey || null,
-      });
-      logger.log('[Stage15-DesignStudio] User story pack artifact persisted', {
+    // QF-20260420-405: Removed direct writeArtifact — orchestrator's persistArtifacts is sole writer
+    if (userStoryResult) {
+      logger.log('[Stage15-DesignStudio] User story pack generated', {
         epicCount: userStoryResult?.epics?.length || 0,
       });
     }
@@ -167,27 +154,8 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
           screenCount: wireframeResult?.screens?.length || 0,
         });
 
-        // Persist wireframes as a separate artifact
-        if (wireframeResult && ctx.supabase && ctx.ventureId) {
-          try {
-            await writeArtifact(ctx.supabase, {
-              ventureId: ctx.ventureId,
-              lifecycleStage: 15,
-              artifactType: 'blueprint_wireframes',
-              title: 'Design Studio Wireframes (Stage 15)',
-              artifactData: { wireframes: wireframeResult, ia_sitemap: iaResult || null },
-              content: JSON.stringify({ wireframes: wireframeResult, ia_sitemap: iaResult || null }),
-              qualityScore: 70,
-              validationStatus: 'validated',
-              source: 'stage-15-design-studio',
-              visionKey: ctx.visionKey || null,
-              planKey: ctx.planKey || null,
-            });
-            logger.log('[Stage15-DesignStudio] Wireframe artifact persisted');
-          } catch (persistErr) {
-            logger.warn('[Stage15-DesignStudio] Wireframe artifact persist failed (non-fatal)', { error: persistErr.message });
-          }
-        }
+        // QF-20260420-405: Removed direct writeArtifact — orchestrator's persistArtifacts is sole writer
+        // (was dual-writing blueprint_wireframes, creating duplicate rows in venture_artifacts)
         break; // Success — exit retry loop
       } catch (err) {
         if (wireframeGatingEnabled) {


### PR DESCRIPTION
## Summary
- **Root cause**: Analysis steps (S12, S15) called `writeArtifact()` directly, then the orchestrator wrote the same artifact type again via `persistArtifacts()` — creating duplicate rows in `venture_artifacts`
- **Secondary bug**: Dedup check at `eva-orchestrator.js` queried wrong column `stage_number` (should be `lifecycle_stage`), silently failing
- Removed direct `writeArtifact` calls from `stage-12-gtm-sales.js` and `stage-15.js`
- Fixed column name in 2 dedup queries in `eva-orchestrator.js`
- Removed unused `writeArtifact` imports

## Root Cause
Added by SD-LEO-ORCH-PIPELINE-INTEGRITY-FIX-002-B without removing types from orchestrator batch-persist path.

## Test plan
- [ ] Run venture through S12 — verify exactly 1 `identity_gtm_sales_strategy` row in `venture_artifacts`
- [ ] Run venture through S15 — verify exactly 1 `blueprint_wireframes` row
- [ ] Verify reality gates for S13+ and S16+ still pass
- [ ] Pre-existing test failures (eva-master-scheduler.test.js) confirmed on main — not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)