### PR TITLE
fix(SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A): add strategy gate before S17 archetype generation

### DIFF
--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -115,6 +115,10 @@ export const ARTIFACT_TYPES = Object.freeze({
   BLUEPRINT_S17_STRATEGY_RECOMMENDATION: 's17_strategy_recommendation',
   /** S17 preview variants (2 screens × 2 strategies) — SD-S17-STRATEGYFIRST */
   BLUEPRINT_S17_PREVIEW: 's17_preview',
+  /** S17 design system tokens derived from approved designs — SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A */
+  BLUEPRINT_S17_DESIGN_SYSTEM: 's17_design_system',
+  /** S17 strategy usage statistics (feedback loop) — SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A */
+  BLUEPRINT_S17_STRATEGY_STATS: 's17_strategy_stats',
 
   // Stage 15 — Wireframe screen data (replaces Stitch provisioning)
   BLUEPRINT_WIREFRAME_SCREENS: 'wireframe_screens',
@@ -239,6 +243,8 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
     ARTIFACT_TYPES.BLUEPRINT_S17_VARIANT_WIP,
     ARTIFACT_TYPES.BLUEPRINT_S17_STRATEGY_RECOMMENDATION,
     ARTIFACT_TYPES.BLUEPRINT_S17_PREVIEW,
+    ARTIFACT_TYPES.BLUEPRINT_S17_DESIGN_SYSTEM,
+    ARTIFACT_TYPES.BLUEPRINT_S17_STRATEGY_STATS,
   ],
   20: [ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
   21: [ARTIFACT_TYPES.LAUNCH_TEST_PLAN, ARTIFACT_TYPES.LAUNCH_UAT_REPORT],

--- a/lib/eva/stage-17/selection-flow.js
+++ b/lib/eva/stage-17/selection-flow.js
@@ -20,6 +20,7 @@ import { generateRefinedVariants } from './archetype-generator.js';
 import { getTokenConstraints } from './token-manifest.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { masterDesign } from './design-mastering.js';
+import { aggregateStrategyStats } from './strategy-stats.js';
 
 const VALID_PLATFORMS = ['mobile', 'desktop'];
 
@@ -231,6 +232,14 @@ export async function submitPass2Selection(ventureId, screenId, platform, artifa
     });
   } catch (e) {
     console.warn('[selection-flow] Design mastering failed (non-blocking):', e.message);
+  }
+
+  // SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A: aggregate strategy stats after all screens approved (fire-and-forget)
+  const allComplete = await isDesignPassComplete(ventureId, supabase);
+  if (allComplete) {
+    aggregateStrategyStats(ventureId, supabase).catch(e => {
+      console.warn('[selection-flow] aggregateStrategyStats failed (non-blocking):', e.message);
+    });
   }
 
   return { approvedArtifactId, replaced: !!previousApproval, previousApprovalId: previousApproval?.id ?? null };

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2474,8 +2474,14 @@ export class StageExecutionWorker {
     if (existingDecision?.status === 'pending') {
       // Re-entry: block on existing pending decision
       this._logger.log('[Worker] S17 strategy gate: re-blocking on existing pending decision');
-      const result = await waitForDecision(existingDecision.id, this._supabase, { timeoutMs: 0 });
-      return result?.metadata?.strategy || null;
+      await waitForDecision({ decisionId: existingDecision.id, supabase: this._supabase, logger: this._logger, timeoutMs: 0 });
+      // Re-query decision to get metadata.strategy (waitForDecision doesn't return full row)
+      const { data: resolved } = await this._supabase
+        .from('chairman_decisions')
+        .select('metadata')
+        .eq('id', existingDecision.id)
+        .single();
+      return resolved?.metadata?.strategy || null;
     }
 
     // No decision exists — run strategy recommender and create one
@@ -2500,8 +2506,14 @@ export class StageExecutionWorker {
     });
 
     this._logger.log(`[Worker] S17 strategy gate: blocking on decision ${decisionId}`);
-    const result = await waitForDecision(decisionId, this._supabase, { timeoutMs: 0 });
-    const selectedStrategy = result?.metadata?.strategy || null;
+    await waitForDecision({ decisionId, supabase: this._supabase, logger: this._logger, timeoutMs: 0 });
+    // Re-query decision to get metadata.strategy (waitForDecision doesn't return full row)
+    const { data: decided } = await this._supabase
+      .from('chairman_decisions')
+      .select('metadata')
+      .eq('id', decisionId)
+      .single();
+    const selectedStrategy = decided?.metadata?.strategy || null;
     this._logger.log(`[Worker] S17 strategy gate: approved (strategy: ${selectedStrategy || 'all'})`);
     return selectedStrategy;
   }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1882,14 +1882,27 @@ export class StageExecutionWorker {
 
         if ((count ?? 0) >= expectedScreens) continue; // All done
 
+        // SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A: Skip ventures without approved strategy decision
+        const { data: strategyDecision } = await this._supabase
+          .from('chairman_decisions')
+          .select('status, metadata')
+          .eq('venture_id', venture.id)
+          .eq('lifecycle_stage', 17)
+          .eq('metadata->>decision_type', 'strategy_selection')
+          .limit(1)
+          .maybeSingle();
+
+        if (!strategyDecision || strategyDecision.status !== 'approved') continue;
+        const reconStrategy = strategyDecision.metadata?.strategy || undefined;
+
         // Trigger generation
-        this._logger.log(`[Worker] S17 reconciler: ${venture.name} has ${count ?? 0}/${expectedScreens} archetypes — triggering generation`);
+        this._logger.log(`[Worker] S17 reconciler: ${venture.name} has ${count ?? 0}/${expectedScreens} archetypes — triggering generation (strategy: ${reconStrategy || 'all'})`);
         this._s17ReconcileAttempts.set(venture.id, Date.now());
         this._s17ActiveGenerations.add(venture.id);
 
         // Fire-and-forget with concurrency tracking — don't block the tick loop
         import('./stage-17/archetype-generator.js').then(({ generateArchetypes }) => {
-          generateArchetypes(venture.id, this._supabase)
+          generateArchetypes(venture.id, this._supabase, reconStrategy ? { strategy: reconStrategy } : undefined)
             .then(result => {
               this._logger.log(`[Worker] S17 reconciler: ${venture.name} complete — ${result.artifactIds.length} artifacts`);
             })
@@ -2414,18 +2427,83 @@ export class StageExecutionWorker {
     });
     this._logger.log('[Worker] S17 post-stage hook: vision + architecture docs generated');
 
+    // SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A: Strategy gate — block until chairman selects strategy
+    // Before archetype generation, ensure strategy recommendation exists and is approved.
+    const selectedStrategy = await this._ensureS17StrategySelected(ventureId);
+
     // SD-MAN-REFAC-S17-SIMPLIFY-FRONTEND-001: Auto-trigger archetype generation
     // from the durable worker process (not fire-and-forget Express promise).
     // Uses stateless resume — skips screens that already have completed artifacts.
     try {
       const { generateArchetypes } = await import('./stage-17/archetype-generator.js');
-      this._logger.log('[Worker] S17 post-stage hook: starting archetype generation...');
-      const result = await generateArchetypes(ventureId, this._supabase);
+      this._logger.log(`[Worker] S17 post-stage hook: starting archetype generation (strategy: ${selectedStrategy || 'all'})...`);
+      const result = await generateArchetypes(ventureId, this._supabase, selectedStrategy ? { strategy: selectedStrategy } : undefined);
       this._logger.log(`[Worker] S17 archetypes complete: ${result.screenCount} screens, ${result.artifactIds.length} artifacts`);
     } catch (archErr) {
       // Non-fatal: chairman can re-trigger from frontend if worker generation fails
       this._logger.warn(`[Worker] S17 archetype generation failed (non-fatal): ${archErr.message}`);
     }
+  }
+
+  /**
+   * SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A: Ensure strategy selection is complete.
+   * Checks for existing approved strategy_selection decision. If none exists,
+   * runs strategy-recommender, creates a chairman_decision, and blocks.
+   * Returns the selected strategy name (or null if chairman chose "use all").
+   *
+   * @param {string} ventureId
+   * @returns {Promise<string|null>} selected strategy name or null
+   */
+  async _ensureS17StrategySelected(ventureId) {
+    // Check for existing strategy_selection decision (re-entry safe)
+    const { data: existingDecision } = await this._supabase
+      .from('chairman_decisions')
+      .select('id, status, decision, metadata')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 17)
+      .eq('metadata->>decision_type', 'strategy_selection')
+      .limit(1)
+      .maybeSingle();
+
+    if (existingDecision?.status === 'approved') {
+      const strategy = existingDecision.metadata?.strategy || null;
+      this._logger.log(`[Worker] S17 strategy gate: already approved (strategy: ${strategy || 'all'})`);
+      return strategy;
+    }
+
+    if (existingDecision?.status === 'pending') {
+      // Re-entry: block on existing pending decision
+      this._logger.log('[Worker] S17 strategy gate: re-blocking on existing pending decision');
+      const result = await waitForDecision(existingDecision.id, this._supabase, { timeoutMs: 0 });
+      return result?.metadata?.strategy || null;
+    }
+
+    // No decision exists — run strategy recommender and create one
+    this._logger.log('[Worker] S17 strategy gate: running strategy recommender...');
+    const { recommendStrategies } = await import('./stage-17/strategy-recommender.js');
+    const recommendation = await recommendStrategies(ventureId, this._supabase);
+    this._logger.log(`[Worker] S17 strategy gate: recommendation complete (top: ${recommendation?.ranked_strategies?.[0]?.strategy || 'unknown'})`);
+
+    // Create chairman_decision for strategy selection
+    const { id: decisionId } = await createOrReusePendingDecision({
+      ventureId,
+      stageNumber: 17,
+      briefData: {
+        stage: 17,
+        gate_recommendation: 'STRATEGY_SELECTION',
+        decision_type: 'strategy_selection',
+        ranked_strategies: recommendation?.ranked_strategies || [],
+      },
+      summary: 'Select design strategy direction before archetype generation',
+      decisionType: 'strategy_selection',
+      supabase: this._supabase,
+    });
+
+    this._logger.log(`[Worker] S17 strategy gate: blocking on decision ${decisionId}`);
+    const result = await waitForDecision(decisionId, this._supabase, { timeoutMs: 0 });
+    const selectedStrategy = result?.metadata?.strategy || null;
+    this._logger.log(`[Worker] S17 strategy gate: approved (strategy: ${selectedStrategy || 'all'})`);
+    return selectedStrategy;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds strategy selection gate in EVA stage-execution-worker at S17 — worker now blocks until chairman selects a design strategy before generating archetypes
- Wires aggregateStrategyStats feedback loop into selection-flow after Pass2 completion
- Registers BLUEPRINT_S17_DESIGN_SYSTEM and BLUEPRINT_S17_STRATEGY_STATS artifact type constants

## Changes
- `lib/eva/stage-execution-worker.js`: New `_ensureS17StrategySelected()` method with re-entry safety; reconciler now checks for approved strategy decision before generating
- `lib/eva/stage-17/selection-flow.js`: Fire-and-forget `aggregateStrategyStats()` after `isDesignPassComplete`
- `lib/eva/artifact-types.js`: 2 new constants + stage 17 registry entries

## Test plan
- [x] Smoke tests pass (15/15)
- [x] TESTING sub-agent validated (score 72/100, found and fixed 2 bugs)
- [ ] Verify worker blocks at S17 on next venture run
- [ ] Verify Stage17StrategySelector appears in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)