### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-125): convert OpenAI image format to Gemini inlineData

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -446,9 +446,21 @@ export class GoogleAdapter {
           ? `${this.baseUrl}/models/${model}:streamGenerateContent?key=${this.apiKey}&alt=sse`
           : `${this.baseUrl}/models/${model}:generateContent?key=${this.apiKey}`;
 
-        // Build user content — preserve array content blocks for multimodal
+        // Build user content — convert OpenAI multimodal format to Gemini format
+        // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-125: Convert image_url parts to inlineData
+        // (OpenAI uses {type: "image_url", image_url: {url: "data:..."}},
+        //  Gemini uses {inlineData: {mimeType: "...", data: "..."}})
         const userParts = Array.isArray(userPrompt)
-          ? userPrompt.map(p => p.type === 'text' ? { text: sanitizeUnicode(p.text) } : p)
+          ? userPrompt.map(p => {
+              if (p.type === 'text') return { text: sanitizeUnicode(p.text) };
+              if (p.type === 'image_url' && p.image_url?.url) {
+                const match = p.image_url.url.match(/^data:([^;]+);base64,(.+)$/);
+                if (match) {
+                  return { inlineData: { mimeType: match[1], data: match[2] } };
+                }
+              }
+              return p;
+            })
           : [{ text: sanitizeUnicode(userPrompt || 'Hello') }];
 
         const response = await fetch(endpoint, {


### PR DESCRIPTION
## Summary
- Fix GoogleAdapter to convert OpenAI `image_url` message parts to Gemini `inlineData` format
- Resolves PAT-AUTO-eae45d21 (12 occurrences of Google API 400 errors)
- Also resolved PAT-HF-PLANTOEXEC-1633abc4 and PAT-HF-PLANTOEXEC-24fa854c as working-as-designed

## Test plan
- [ ] Verify Google Gemini API calls with multimodal content don't error
- [ ] Verify text-only messages still work normally
- [ ] Verify unknown part formats pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)