### PR TITLE
feat(SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001): professional designer prompt engineering for S17 HTML generation

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -26,6 +26,157 @@ import { buildVariantSummary } from './design-mastering.js';
 import { recommendStrategies } from './strategy-recommender.js';
 // SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: LLM scoring removed, deterministic only
 
+// SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: Professional designer prompt engineering
+/**
+ * Load upstream venture artifacts that inform design decisions.
+ * Returns a ventureContext object with all available design-relevant data.
+ * Non-blocking — missing artifacts return null fields.
+ */
+async function loadVentureContext(ventureId, supabase) {
+  const ctx = {
+    ideaBrief: null,       // Stage 1: problem, target market, value prop
+    competitiveAnalysis: null, // Stage 4: competitors, differentiation
+    pricingModel: null,    // Stage 7: pricing tiers, strategy
+    businessModel: null,   // Stage 8: BMC value prop, customer segments
+    customerPersonas: null, // Stage 10: personas, brand archetype
+    brandGuidelines: null, // Stage 10: voice, visual tone, industry
+    brandName: null,       // Stage 11: selected name, rationale
+    productRoadmap: null,  // Stage 13: top features
+    userStories: null,     // Stage 15: user stories in user language
+  };
+
+  const artifactTypes = [
+    'truth_idea_brief',
+    'truth_competitive_analysis',
+    'engine_pricing_model',
+    'engine_business_model_canvas',
+    'identity_persona_brand',
+    'identity_brand_guidelines',
+    'identity_brand_name',
+    'blueprint_product_roadmap',
+    'blueprint_user_story_pack',
+  ];
+
+  try {
+    const { data: artifacts } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_type, artifact_data')
+      .eq('venture_id', ventureId)
+      .in('artifact_type', artifactTypes)
+      .eq('is_current', true);
+
+    for (const a of (artifacts || [])) {
+      const d = a.artifact_data;
+      if (!d) continue;
+      switch (a.artifact_type) {
+        case 'truth_idea_brief':
+          ctx.ideaBrief = { problem: d.problem_statement, targetMarket: d.target_market, valueProp: d.value_proposition };
+          break;
+        case 'truth_competitive_analysis':
+          ctx.competitiveAnalysis = { competitors: (d.competitors || []).slice(0, 3).map(c => c.name || c), differentiation: d.differentiation || d.positioning };
+          break;
+        case 'engine_pricing_model':
+          ctx.pricingModel = { strategy: d.pricing_strategy, tiers: (d.pricing_tiers || []).slice(0, 3).map(t => t.name || t) };
+          break;
+        case 'engine_business_model_canvas':
+          ctx.businessModel = { valueProposition: d.bmc_components?.value_prop || d.value_prop, customers: d.bmc_components?.customers || d.customers, channels: d.bmc_components?.channels };
+          break;
+        case 'identity_persona_brand':
+          ctx.customerPersonas = {
+            primary: (d.customerPersonas || d.personas || [])[0] || null,
+            archetype: d.brandGenome?.archetype || d.brand?.archetype,
+            values: d.brandGenome?.values || d.brand?.values,
+            tone: d.brandGenome?.tone || d.brand?.tone,
+            personality: d.brandPersonality || d.brand_personality,
+          };
+          break;
+        case 'identity_brand_guidelines':
+          ctx.brandGuidelines = {
+            voice: d.brand_guidelines?.voice_guidelines || d.voice_guidelines,
+            visualTone: d.brand_guidelines?.visual_tone || d.visual_tone,
+            messagingPillars: d.brand_guidelines?.messaging_pillars || d.messaging_pillars,
+            industry: d.brand_guidelines?.industry_context || d.industry_context,
+          };
+          break;
+        case 'identity_brand_name':
+          ctx.brandName = { name: d.selected_name || d.name, rationale: d.rationale };
+          break;
+        case 'blueprint_product_roadmap':
+          ctx.productRoadmap = { topFeatures: (d.features || d.phases?.[0]?.features || []).slice(0, 5).map(f => f.name || f.title || f) };
+          break;
+        case 'blueprint_user_story_pack':
+          ctx.userStories = (d.user_stories || d.stories || []).slice(0, 3).map(s => ({
+            role: s.role || s.user_role || 'user',
+            want: s.want || s.title || s.description,
+            benefit: s.benefit || s.so_that || '',
+          }));
+          break;
+      }
+    }
+
+    const loaded = Object.entries(ctx).filter(([, v]) => v !== null).map(([k]) => k);
+    if (loaded.length > 0) {
+      console.log(`[archetype-generator] Venture context loaded: ${loaded.join(', ')}`);
+    }
+  } catch (e) {
+    console.warn('[archetype-generator] Venture context load failed (non-blocking):', e.message);
+  }
+
+  return ctx;
+}
+
+/**
+ * Format venture context into a prompt section string.
+ * Only includes sections that have data — no placeholder text.
+ */
+function formatVentureContext(ctx) {
+  if (!ctx) return '';
+  const lines = [];
+
+  // WHO IS THIS FOR?
+  const hasWho = ctx.ideaBrief || ctx.customerPersonas || ctx.brandGuidelines || ctx.businessModel;
+  if (hasWho) {
+    lines.push('\n═══ WHO IS THIS FOR? ═══');
+    if (ctx.ideaBrief?.valueProp) lines.push(`Value Proposition: ${ctx.ideaBrief.valueProp}`);
+    if (ctx.ideaBrief?.targetMarket) lines.push(`Target Market: ${ctx.ideaBrief.targetMarket}`);
+    if (ctx.customerPersonas?.primary) {
+      const p = ctx.customerPersonas.primary;
+      lines.push(`Primary Customer: ${p.name || p.role || 'Unknown'} — ${p.description || p.demographics || p.pain_points || ''}`);
+    }
+    if (ctx.customerPersonas?.archetype) lines.push(`Brand Archetype: ${ctx.customerPersonas.archetype}`);
+    if (ctx.customerPersonas?.values) lines.push(`Brand Values: ${Array.isArray(ctx.customerPersonas.values) ? ctx.customerPersonas.values.join(', ') : ctx.customerPersonas.values}`);
+    if (ctx.brandGuidelines?.voice) lines.push(`Voice: ${ctx.brandGuidelines.voice}`);
+    if (ctx.brandGuidelines?.visualTone) lines.push(`Visual Tone: ${ctx.brandGuidelines.visualTone}`);
+    if (ctx.brandGuidelines?.industry) lines.push(`Industry: ${ctx.brandGuidelines.industry}`);
+    if (ctx.businessModel?.valueProposition) lines.push(`Business Model: ${ctx.businessModel.valueProposition}`);
+    if (ctx.pricingModel?.strategy) lines.push(`Pricing: ${ctx.pricingModel.strategy}${ctx.pricingModel.tiers?.length ? ' (' + ctx.pricingModel.tiers.join(', ') + ')' : ''}`);
+  }
+
+  // COMPETITIVE CONTEXT
+  if (ctx.competitiveAnalysis) {
+    lines.push('\n═══ COMPETITIVE CONTEXT ═══');
+    if (ctx.competitiveAnalysis.competitors?.length) lines.push(`Competitors: ${ctx.competitiveAnalysis.competitors.join(', ')}`);
+    if (ctx.competitiveAnalysis.differentiation) lines.push(`Our Angle: ${ctx.competitiveAnalysis.differentiation}`);
+    lines.push('Design implication: make sure this page does NOT look like a clone of these competitors.');
+  }
+
+  // KEY FEATURES & USER NEEDS
+  const hasFeatures = ctx.productRoadmap?.topFeatures?.length || ctx.userStories?.length;
+  if (hasFeatures) {
+    lines.push('\n═══ KEY FEATURES & USER NEEDS ═══');
+    if (ctx.productRoadmap?.topFeatures?.length) {
+      lines.push('Top features to highlight:');
+      ctx.productRoadmap.topFeatures.forEach(f => lines.push(`  - ${f}`));
+    }
+    if (ctx.userStories?.length) {
+      lines.push('User stories (write copy that speaks to these):');
+      ctx.userStories.forEach(s => lines.push(`  - As a ${s.role}, I want ${s.want}${s.benefit ? ' so I can ' + s.benefit : ''}`));
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : '';
+}
+
 /**
  * Query venture_artifacts for screens that already have completed s17_archetypes.
  * Used for stateless resume: generation skips screens whose artifacts already exist.
@@ -211,48 +362,75 @@ DEVICE FORMAT: DESKTOP — design for pointer/keyboard interaction on a 1440px v
 - Desktop Nav (D3, 8%): Visible sidebar/top nav, breadcrumbs for deep hierarchies
 - Hover/Keyboard (D4, 10%): :hover on all interactives, :focus-visible, shortcuts`;
 
+  // SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: Design seed for variation (1-100)
+  const designSeed = options.designSeed ?? (Math.floor(Math.random() * 100) + 1);
+  const seedEnergy = designSeed <= 25 ? 'bold and dramatic (large type, high contrast, dark sections)'
+    : designSeed <= 50 ? 'refined and minimal (generous white space, thin type, subtle palette)'
+    : designSeed <= 75 ? 'warm and editorial (magazine feel, mixed media, layered depth)'
+    : 'technical and precise (data-forward, grid-heavy, structured density)';
+  const seedLayout = designSeed % 2 === 1 ? 'asymmetric with left-heavy or off-center content' : 'centered hero with editorial vertical scroll';
+
   const rubricGuidance = `
-SCORING RUBRIC AWARENESS (your output will be scored on these dimensions):
-Universal (60% total):
+SCORING RUBRIC (your output will be scored on these dimensions):
+Universal (60%):
 - Visual Hierarchy (U1, 10%): Single H1, clear heading ramp, one dominant focal point
 - Typography (U2, 7%): Body ≥16px, line-height 1.4-1.65, ≤2 font families, measure 45-75ch
 - Layout Structure (U3, 9%): Spacing snaps to 4/8px grid, ≤8 distinct spacing values, grid/flex
 - Brand Consistency (U4, 7%): Use CSS custom properties (var(--token)) for ≥80% of color values
 - Accessibility (U5, 10%): WCAG AAA contrast (7:1 text), semantic HTML, :focus-visible, prefers-reduced-motion
 - Task Clarity (U6, 8%): One unmistakable primary CTA, above the fold
-- Design Distinctiveness (U7, 9%): NON-TEMPLATE design. Avoid cookie-cutter patterns. Take a deliberate risk.
+- Design Distinctiveness (U7, 9%): NON-TEMPLATE design. Take a deliberate creative risk.
 ${platformWeights}
 
-QUALITY DEFAULTS (from scoring rubric Appendix B):
-1. Use declared brand tokens (CSS custom properties) for ≥80% of color/spacing values
-2. Include :hover, :focus-visible, and @media (prefers-reduced-motion) rules
-3. Target WCAG AAA contrast (7:1 normal text) — fall to AA only when design-critical
-4. Use semantic HTML: <nav>, <main>, <header>, <footer>, <button>, <article>
+═══ DESIGN DIRECTION (seed ${designSeed}) ═══
+Energy: ${seedEnergy}
+Layout bias: ${seedLayout}
+Pick ONE distinctive technique from this toolkit (choose based on your seed and the brand personality):
+- Oversized display heading (120px+) that bleeds near viewport edges
+- Asymmetric two-column with one column offset 40-80px vertically
+- Full-bleed section with text overlay using backdrop-filter: blur()
+- One "hero" card breaking out of an otherwise uniform grid at 2x size
+- Horizontal scroll section for testimonials or features (overflow-x: auto)
+- Monochrome section punctuated by a single accent color pop
+- Editorial pull quote with oversized quotation marks
+- Gradient mesh or radial gradient as section background
+- Split-screen layout with contrasting left/right treatments
 
-DISTINCTIVE MOVE REQUIREMENT:
-Take ONE intentional design risk per variant — a typographic choice, layout asymmetry, color pairing,
-editorial touch, or non-template component treatment. Annotate it with an HTML comment:
-<!-- distinctive move: [describe your deliberate design choice] -->
-This is MANDATORY. Variants without a distinctive move score poorly on U7.
+═══ CSS ARCHITECTURE (mandatory) ═══
+1. :root block with ALL tokens FIRST (colors, fonts, spacing, radius, shadows)
+2. Use clamp() for responsive type: e.g. clamp(1rem, 2.5vw, 1.125rem) for body
+3. Use grid-template-areas for major layout sections
+4. ONE transition timing: cubic-bezier(0.25, 0.1, 0.25, 1) throughout
+5. Use gap (not margin) for spacing between siblings
+6. Include ONE cohesive page-load animation (@keyframes + animation-delay)
+7. Include @media (prefers-reduced-motion: reduce) to disable animations
+8. WCAG AAA contrast (7:1) for body text, AA (4.5:1) minimum for large text
+9. Semantic HTML: <nav>, <main>, <header>, <footer>, <button>, <article>
 
-HIGH-END AESTHETIC DIRECTIVES (Awwwards-level quality expected):
-- Spatial Composition: Use unexpected layouts — grid-breaking elements, overlapping layers, generous
-  negative space. Do NOT default to safe, symmetrical, template-like grids.
-- Typography: Pair a distinctive display/heading font treatment (weight, size, letter-spacing, case)
-  against a refined body font. Avoid bland uniform sizing. Create typographic tension and hierarchy.
-- Motion: Include ONE well-orchestrated, staggered page-load animation using CSS-only (@keyframes +
-  animation-delay). Do NOT scatter multiple disconnected micro-interactions. One cohesive entrance
-  moment is better than many fragmented ones. Use @media (prefers-reduced-motion: reduce) to disable.
+═══ NEVER DO THESE (instant quality fail) ═══
+- No centered-everything layouts (centered H1 + centered P + centered button stacked vertically)
+- No icon-in-circle + heading + paragraph × 3 in a row ("features grid of death")
+- No generic gradient buttons with rounded corners and drop shadows
+- No uniform card grids where every card is identical size and spacing
+- No more than one box-shadow per page — prefer border, backdrop-filter, or layering
+- No generic hero (big stock image, dark overlay, white text, CTA) unless the seed demands drama
+- No placeholder-looking content — adapt the source wireframe content with editorial intent
 
-SELF-VERIFICATION (mandatory before finalizing output):
-After generating the HTML, mentally review your output against these checks:
-1. Does the layout break away from generic template patterns? (Spatial Composition)
-2. Is there clear typographic tension between heading and body treatments? (Typography)
-3. Is there exactly one cohesive CSS entrance animation, not scattered micro-interactions? (Motion)
-4. Does the distinctive move actually create visual impact, not just a token difference?
-5. Are all brand tokens applied via CSS custom properties (var(--token))?
-If any check fails, revise before outputting. Annotate your verification with:
-<!-- verified: spatial=[pass/revised], typography=[pass/revised], motion=[pass/revised] -->`;
+═══ OUTPUT FORMAT ═══
+Start your HTML with this comment block (fill in ALL fields):
+<!--
+  DESIGN INTENT:
+  Seed: ${designSeed}
+  Mood: [one word — e.g., confident, playful, austere, warm]
+  Customer: [who this design is meant to attract, from the context above]
+  Layout thesis: [one sentence — what makes this layout non-obvious]
+  Distinctive move: [which toolkit technique you chose and why it fits this brand]
+  Color strategy: [how the palette creates hierarchy — not just "uses brand colors"]
+-->
+Then output the complete <!DOCTYPE html> through </html>.`;
+
+  // Venture context section (SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001)
+  const ventureContextSection = options.ventureContext ? formatVentureContext(options.ventureContext) : '';
 
   // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A: compose from brief modules
   const designBriefSection = options.designBrief ? formatDesignBrief(options.designBrief) : '';
@@ -261,31 +439,36 @@ If any check fails, revise before outputting. Annotate your verification with:
     ? `\nDESIGN STRATEGY: ${options.strategyName.toUpperCase()} — every design decision should serve the ${options.strategyName} goal for this page type.\n`
     : '';
 
-  return `You are a senior UI designer creating HTML design archetypes. Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 4 for this screen.
-${pageTypeContext}${strategyDirective}${designBriefSection}${contentBriefSection}${deviceInstructions}
+  // SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: brand name for typography treatment
+  const brandNameSection = options.ventureContext?.brandName?.name
+    ? `\nBRAND NAME: "${options.ventureContext.brandName.name}" — consider how this name's length and character affect typography treatment (short punchy names → oversized display; longer names → refined weight/spacing).\n`
+    : '';
+
+  return `Generate a complete, self-contained HTML page as Archetype Variant ${variantIndex} of 4 for this screen.
+${pageTypeContext}${strategyDirective}${brandNameSection}${ventureContextSection}${designBriefSection}${contentBriefSection}${deviceInstructions}
 ${rubricGuidance}
 
-BRAND TOKENS (LOCKED — do not deviate):
-- Colors: ${colorList}
-- Heading font: ${headingFont}
-- Body font: ${bodyFont}
-- Spacing base: 4px grid (4, 8, 16, 24, 32, 48px)
+═══ BRAND TOKENS (LOCKED — do not deviate) ═══
+Colors: ${colorList}
+Heading font: ${headingFont}
+Body font: ${bodyFont}
+Spacing: 4px grid (4, 8, 12, 16, 24, 32, 48, 64, 80px)
 
 LAYOUT APPROACH: ${layoutDescription}
 ${options.priorVariants?.length > 0 ? `
-PRIOR VARIANTS (differentiate from these — do NOT repeat their approach):
+PRIOR VARIANTS (differentiate — do NOT repeat their approach):
 ${options.priorVariants.map(pv => `- Variant ${pv.index}: ${pv.summary}`).join('\n')}
 ` : ''}
-SOURCE SCREEN (reference for content and structure):
+SOURCE SCREEN (adapt content and structure — don't copy the wireframe literally):
 ${screenHtml.slice(0, 4000)}
 
 REQUIREMENTS:
-1. Produce one complete HTML document with inline CSS only (no external links)
-2. Apply the locked brand colors using CSS custom properties (var(--token-name))
-3. Use the locked fonts via font-family declarations
-4. Implement the specified layout approach distinctly for the ${deviceType === 'MOBILE' ? 'mobile' : 'desktop'} format
-5. Preserve all content elements from the source screen
-6. Include one <!-- distinctive move: ... --> HTML comment (MANDATORY)
+1. Complete HTML document with inline CSS only (no external links)
+2. Locked brand colors via CSS custom properties (var(--token-name))
+3. Locked fonts via font-family declarations
+4. The layout approach specified above, optimized for ${deviceType === 'MOBILE' ? 'mobile (375px)' : 'desktop (1440px)'}
+5. Preserve all content elements from the source screen but improve the copy
+6. Start with the DESIGN INTENT comment block (MANDATORY — see output format above)
 7. Output ONLY the HTML — no explanation, no markdown fences`;
 }
 
@@ -402,6 +585,14 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     }
   } catch (e) {
     console.warn('[archetype-generator] Design brief skipped:', e.message);
+  }
+
+  // 2b2. Load upstream venture context for professional design prompts (SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001)
+  let ventureContext = null;
+  try {
+    ventureContext = await loadVentureContext(ventureId, supabase);
+  } catch (e) {
+    console.warn('[archetype-generator] Venture context skipped:', e.message);
   }
 
   // 2c. Load strategy reorder hints from prior stats (feedback loop)
@@ -567,12 +758,16 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-B: cross-variant awareness
       const contentBrief = buildContentBrief(screenHtml, classification.pageType);
       const strategyName = strategyLayouts ? strategyLayouts[i]?.strategy : null;
+      // SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: unique seed per variant for design variation
+      const designSeed = Math.floor(Math.random() * 100) + 1;
       const promptText = buildArchetypePrompt(screenHtml, tokens, layouts[i], i + 1, {
         pageType: classification.pageType,
         deviceType,
         designBrief,
         contentBrief,
         strategyName,
+        ventureContext,
+        designSeed,
         priorVariants: priorVariantSummaries.length > 0 ? [...priorVariantSummaries] : undefined,
       });
 
@@ -586,22 +781,26 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       userContent.push({ type: 'text', text: promptText });
 
       let archetypeHtml;
-      const systemPrompt = 'You are a senior UI designer creating static visual mockup HTML. Generate a complete, self-contained HTML page based on the screen description and brand constraints. Return only the complete HTML.';
+      // SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: Professional designer persona
+      // 2026-04-20: Replaced generic "senior UI designer" with opinionated design director persona
+      const systemPrompt = 'You are an independent design director who has shipped award-winning websites for startups and established brands. You favor restraint over decoration. You believe whitespace is a design element, not empty space. Your work is recognized for typographic precision, unexpected layout decisions, and the feeling that every pixel was placed with intention. You never produce work that looks like a template or AI-generated. You think about who the customer is before choosing a layout. Return only complete HTML.';
       const llmOpts = { stream: true, timeout: 300000, cacheTTLMs: 0, maxTokens: 32768, purpose: 'content-generation' };
 
       const result = await client.complete(systemPrompt, userContent, llmOpts);
       archetypeHtml = result?.content ?? String(result);
 
-      // Validate distinctive move comment — retry once if missing
-      if (!/<!-- distinctive move:/i.test(archetypeHtml)) {
-        console.warn(`[archetype-generator] │   v${i + 1}: distinctive move MISSING — retrying with reminder`);
-        const retryContent = [...userContent, { type: 'text', text: '\n\nIMPORTANT: Your output is missing the required <!-- distinctive move: ... --> HTML comment. You MUST include exactly one. Add it now.' }];
+      // Validate DESIGN INTENT comment block — retry once if missing
+      // SD-LEO-INFRA-S17-PROMPT-ENGINEERING-001: check for new intent block (backward compat with distinctive move)
+      const hasIntent = /<!-- *\n? *DESIGN INTENT:/i.test(archetypeHtml) || /<!-- distinctive move:/i.test(archetypeHtml);
+      if (!hasIntent) {
+        console.warn(`[archetype-generator] │   v${i + 1}: DESIGN INTENT block MISSING — retrying with reminder`);
+        const retryContent = [...userContent, { type: 'text', text: '\n\nIMPORTANT: Your output is missing the required DESIGN INTENT comment block at the top of the HTML. You MUST include it with Mood, Customer, Layout thesis, Distinctive move, and Color strategy fields. Add it now before <!DOCTYPE html>.' }];
         const retryResult = await client.complete(systemPrompt, retryContent, llmOpts);
         const retryHtml = retryResult?.content ?? String(retryResult);
-        if (/<!-- distinctive move:/i.test(retryHtml)) {
+        if (/DESIGN INTENT:/i.test(retryHtml) || /<!-- distinctive move:/i.test(retryHtml)) {
           archetypeHtml = retryHtml;
         } else {
-          console.warn(`[archetype-generator] │   v${i + 1}: distinctive move still missing after retry — flagging`);
+          console.warn(`[archetype-generator] │   v${i + 1}: DESIGN INTENT still missing after retry — flagging`);
         }
       }
 


### PR DESCRIPTION
## Summary
- Rewrite S17 archetype generation prompts to produce landing page HTML indistinguishable from professional designer output
- Load 9 additional upstream venture artifacts (personas, competitive analysis, brand name, pricing, user stories, etc.) giving the LLM the same brief a real designer would get
- Add design seed (1-100) per variant for creative variation in energy and layout
- Add explicit negative constraints banning 7 AI anti-patterns (centered-everything, feature grid of death, etc.)
- Require Design Intent Statement at top of HTML (mood, customer, thesis, color strategy)
- Mandate systematic CSS architecture (clamp, grid-template-areas, cubic-bezier)
- Artifact utilization goes from 12% to 48% of available venture data

## Test plan
- [ ] Module loads without errors (verified: `import('./lib/eva/stage-17/archetype-generator.js')`)
- [ ] Smoke tests pass (verified: 15/15)
- [ ] Run S17 on a test venture and compare output quality before/after
- [ ] Verify venture context loads gracefully when artifacts are missing (null handling)
- [ ] Verify design seed produces different layouts across variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)