### PR TITLE
feat(S17): persist prompt in variants + fix venture context loader

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -40,6 +40,7 @@ async function loadVentureContext(ventureId, supabase) {
     businessModel: null,   // Stage 8: BMC value prop, customer segments
     customerPersonas: null, // Stage 10: personas, brand archetype
     brandGuidelines: null, // Stage 10: voice, visual tone, industry
+    brandColors: null,     // Stage 11: color palette (hex codes + usage)
     brandName: null,       // Stage 11: selected name, rationale
     productRoadmap: null,  // Stage 13: top features
     userStories: null,     // Stage 15: user stories in user language
@@ -52,6 +53,7 @@ async function loadVentureContext(ventureId, supabase) {
     'engine_business_model_canvas',
     'identity_persona_brand',
     'identity_brand_guidelines',
+    'identity_naming_visual',
     'identity_brand_name',
     'blueprint_product_roadmap',
     'blueprint_user_story_pack',
@@ -70,16 +72,31 @@ async function loadVentureContext(ventureId, supabase) {
       if (!d) continue;
       switch (a.artifact_type) {
         case 'truth_idea_brief':
-          ctx.ideaBrief = { problem: d.problem_statement, targetMarket: d.target_market, valueProp: d.value_proposition };
+          // Data uses camelCase (problemStatement, targetMarket, valueProp)
+          ctx.ideaBrief = {
+            problem: d.problemStatement || d.problem_statement,
+            targetMarket: d.targetMarket || d.target_market,
+            valueProp: d.valueProp || d.value_proposition,
+          };
           break;
         case 'truth_competitive_analysis':
-          ctx.competitiveAnalysis = { competitors: (d.competitors || []).slice(0, 3).map(c => c.name || c), differentiation: d.differentiation || d.positioning };
+          ctx.competitiveAnalysis = {
+            competitors: (d.competitors || []).slice(0, 3).map(c => c.name || c),
+            differentiation: d.differentiation || d.positioning || d.fourBuckets?.summary,
+          };
           break;
         case 'engine_pricing_model':
-          ctx.pricingModel = { strategy: d.pricing_strategy, tiers: (d.pricing_tiers || []).slice(0, 3).map(t => t.name || t) };
+          ctx.pricingModel = {
+            strategy: d.pricing_strategy || d.pricingStrategy,
+            tiers: (d.tiers || d.pricing_tiers || []).slice(0, 3).map(t => t.name || t),
+          };
           break;
         case 'engine_business_model_canvas':
-          ctx.businessModel = { valueProposition: d.bmc_components?.value_prop || d.value_prop, customers: d.bmc_components?.customers || d.customers, channels: d.bmc_components?.channels };
+          ctx.businessModel = {
+            valueProposition: d.bmc_components?.value_prop || d.value_prop || d.valueProposition,
+            customers: d.bmc_components?.customers || d.customers || d.customerSegments,
+            channels: d.bmc_components?.channels || d.channels,
+          };
           break;
         case 'identity_persona_brand':
           ctx.customerPersonas = {
@@ -91,19 +108,59 @@ async function loadVentureContext(ventureId, supabase) {
           };
           break;
         case 'identity_brand_guidelines':
+          // This artifact may only contain personas — extract what exists
           ctx.brandGuidelines = {
-            voice: d.brand_guidelines?.voice_guidelines || d.voice_guidelines,
-            visualTone: d.brand_guidelines?.visual_tone || d.visual_tone,
-            messagingPillars: d.brand_guidelines?.messaging_pillars || d.messaging_pillars,
-            industry: d.brand_guidelines?.industry_context || d.industry_context,
+            voice: d.brand_guidelines?.voice_guidelines || d.voice_guidelines || d.brandVoice,
+            visualTone: d.brand_guidelines?.visual_tone || d.visual_tone || d.visualTone,
+            messagingPillars: d.brand_guidelines?.messaging_pillars || d.messaging_pillars || d.messagingPillars,
+            industry: d.brand_guidelines?.industry_context || d.industry_context || d.industry,
+          };
+          // Also extract personas from this artifact if identity_persona_brand didn't have them
+          if (!ctx.customerPersonas?.primary && d.personas?.length) {
+            ctx.customerPersonas = ctx.customerPersonas || {};
+            ctx.customerPersonas.primary = d.personas[0];
+          }
+          break;
+        case 'identity_naming_visual': {
+          // Color palette is nested under visualIdentity
+          const palette = d.visualIdentity?.colorPalette || d.colorPalette;
+          if (palette && Array.isArray(palette)) {
+            ctx.brandColors = palette.map(c => ({ hex: c.hex, usage: c.usage }));
+          }
+          // Also extract imagery guidance and typography
+          if (d.visualIdentity?.imageryGuidance) {
+            ctx.imageryGuidance = d.visualIdentity.imageryGuidance;
+          }
+          // Brand name may also be here
+          if (!ctx.brandName && d.decision?.selectedName) {
+            ctx.brandName = { name: d.decision.selectedName, rationale: d.decision.rationale };
+          }
+          // Brand expression (tagline, elevator pitch)
+          if (d.brandExpression) {
+            ctx.brandExpression = {
+              tagline: d.brandExpression.tagline,
+              elevatorPitch: d.brandExpression.elevator_pitch,
+              messagingPillars: d.brandExpression.messaging_pillars,
+            };
+          }
+          break;
+        }
+        case 'identity_brand_name':
+          // Name is nested under decision.selectedName
+          ctx.brandName = {
+            name: d.decision?.selectedName || d.selected_name || d.name,
+            rationale: d.decision?.rationale || d.rationale,
           };
           break;
-        case 'identity_brand_name':
-          ctx.brandName = { name: d.selected_name || d.name, rationale: d.rationale };
+        case 'blueprint_product_roadmap': {
+          // Features are nested under milestones[].deliverables or phases[].milestones
+          const features = d.features
+            || d.milestones?.flatMap(m => m.deliverables || [])
+            || d.phases?.flatMap(p => (p.milestones || []).flatMap(m => m.deliverables || []))
+            || [];
+          ctx.productRoadmap = { topFeatures: features.slice(0, 5).map(f => f.name || f.title || f) };
           break;
-        case 'blueprint_product_roadmap':
-          ctx.productRoadmap = { topFeatures: (d.features || d.phases?.[0]?.features || []).slice(0, 5).map(f => f.name || f.title || f) };
-          break;
+        }
         case 'blueprint_user_story_pack':
           ctx.userStories = (d.user_stories || d.stories || []).slice(0, 3).map(s => ({
             role: s.role || s.user_role || 'user',
@@ -150,6 +207,20 @@ function formatVentureContext(ctx) {
     if (ctx.brandGuidelines?.industry) lines.push(`Industry: ${ctx.brandGuidelines.industry}`);
     if (ctx.businessModel?.valueProposition) lines.push(`Business Model: ${ctx.businessModel.valueProposition}`);
     if (ctx.pricingModel?.strategy) lines.push(`Pricing: ${ctx.pricingModel.strategy}${ctx.pricingModel.tiers?.length ? ' (' + ctx.pricingModel.tiers.join(', ') + ')' : ''}`);
+    if (ctx.brandName?.name) lines.push(`Brand Name: ${ctx.brandName.name}`);
+    if (ctx.brandExpression?.tagline) lines.push(`Tagline: ${ctx.brandExpression.tagline}`);
+    if (ctx.brandExpression?.elevatorPitch) lines.push(`Elevator Pitch: ${ctx.brandExpression.elevatorPitch}`);
+    if (ctx.imageryGuidance) lines.push(`Imagery Direction: ${ctx.imageryGuidance}`);
+  }
+
+  // BRAND COLOR PALETTE (MANDATORY)
+  if (ctx.brandColors?.length) {
+    lines.push('\n═══ BRAND COLOR PALETTE (MANDATORY — you MUST use these exact colors) ═══');
+    ctx.brandColors.forEach(c => {
+      lines.push(`  ${c.hex} — ${c.usage}`);
+    });
+    lines.push('You MUST build your color scheme from these brand colors. Do NOT invent your own palette.');
+    lines.push('Your "Color strategy" in the DESIGN INTENT block must reference these hex values.');
   }
 
   // COMPETITIVE CONTEXT
@@ -747,7 +818,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
       // Skip variants that were already persisted in a prior run
       if (existingWip.has(i + 1)) {
         const wip = existingWip.get(i + 1);
-        variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html, strategy_name: wip.strategy_name });
+        variants.push({ variantIndex: i + 1, layoutDescription: wip.layoutDescription, html: wip.html, strategy_name: wip.strategy_name, prompt: wip.prompt, systemPrompt: wip.systemPrompt });
         console.log(`[archetype-generator] │   variant ${i + 1}/${variantCount}: resumed from WIP — ${wip.html.length} chars`);
         await updateProgress({ type: 'variant', screen: screenTitle, screenIdx: screenIdx + 1, variant: i + 1, totalVariants: variantCount, chars: wip.html.length, seconds: 0, layout: wip.layoutDescription.slice(0, 50), resumed: true, timestamp: new Date().toISOString() });
         continue;
@@ -814,7 +885,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         artifactType: 's17_variant_wip',
         title: `${screenTitle} — WIP Variant ${i + 1}`,
         content: archetypeHtml,
-        artifactData: { html: archetypeHtml, layoutDescription: layouts[i], variantIndex: i + 1, screenName: screenTitle },
+        artifactData: { html: archetypeHtml, layoutDescription: layouts[i], variantIndex: i + 1, screenName: screenTitle, prompt: promptText, systemPrompt },
         qualityScore: null,
         validationStatus: null,
         source: 'stage-17-archetype-generator',
@@ -826,6 +897,8 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         layoutDescription: layouts[i],
         html: archetypeHtml,
         strategy_name: strategyName,
+        prompt: promptText,
+        systemPrompt,
       });
 
       // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-B: build summary for cross-variant awareness


### PR DESCRIPTION
## Summary
- Store prompt + systemPrompt in WIP and final archetype artifacts for UI inspection
- Fix venture context loader: camelCase field paths, nested color palette, brand expression
- Add MANDATORY brand color palette injection into archetype generation prompt
- Add copy prompt button support (frontend in ehg PR #513)

## Test plan
- [x] Verify prompt appears in s17_variant_wip artifact_data
- [x] Verify brand colors from identity_naming_visual.visualIdentity.colorPalette are injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)