### PR TITLE
feat: add S17 designs + roadmap + GTM + colors to repo seeder

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -743,6 +743,167 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
     }
   }
 
+  // ── S17 Approved Designs (HTML files) ──────────────────────────
+  // Write each approved desktop design as a standalone HTML file in docs/designs/
+  try {
+    const { data: approvedDesigns } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data, metadata, title')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'stage_17_approved_desktop')
+      .eq('is_current', true)
+      .order('created_at');
+
+    if (approvedDesigns?.length) {
+      const designsDir = join(docsDir, 'designs');
+      mkdirSync(designsDir, { recursive: true });
+
+      // Also load screen names from wireframe_screens for better filenames
+      const { data: wfArt } = await supabase
+        .from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'wireframe_screens')
+        .eq('is_current', true)
+        .limit(1)
+        .maybeSingle();
+      const screenNames = new Map();
+      for (const s of (wfArt?.artifact_data?.screens || [])) {
+        if (s.id && s.name) screenNames.set(s.id, s.name);
+      }
+
+      for (const design of approvedDesigns) {
+        const html = design.artifact_data?.html;
+        if (!html || typeof html !== 'string') continue;
+        const screenId = design.metadata?.screenId || 'unknown';
+        const screenName = screenNames.get(screenId) || design.title?.replace(/\s*—.*$/, '') || screenId;
+        const filename = screenName.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase().replace(/^-|-$/g, '') + '.html';
+        try {
+          writeFileSync(join(designsDir, filename), html, 'utf-8');
+          docsCommitted.push(`docs/designs/${filename}`);
+        } catch (err) {
+          errors.push(`docs/designs/${filename}: ${err.message}`);
+        }
+      }
+    }
+  } catch (err) {
+    errors.push(`docs/designs/: ${err.message}`);
+  }
+
+  // ── Product Roadmap (S13) ─────────────────────────────────────
+  try {
+    const { data: roadmapArt } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'blueprint_product_roadmap')
+      .eq('is_current', true)
+      .limit(1)
+      .maybeSingle();
+
+    if (roadmapArt?.artifact_data) {
+      const rd = roadmapArt.artifact_data;
+      const lines = ['# Product Roadmap\n'];
+      if (rd.vision_statement) lines.push(`> ${rd.vision_statement}\n`);
+      for (const phase of (rd.phases || [])) {
+        lines.push(`## ${phase.name || 'Phase'}`);
+        if (phase.start_date && phase.end_date) lines.push(`_${phase.start_date} — ${phase.end_date}_\n`);
+        for (const ms of (phase.milestones || rd.milestones || [])) {
+          lines.push(`### ${ms.name || 'Milestone'} (${ms.priority || 'now'})`);
+          for (const d of (ms.deliverables || [])) {
+            lines.push(`- ${d}`);
+          }
+          lines.push('');
+        }
+      }
+      const content = lines.join('\n');
+      if (content.length > 50) {
+        writeFileSync(join(docsDir, 'product-roadmap.md'), content);
+        docsCommitted.push('docs/product-roadmap.md');
+      }
+    }
+  } catch (err) {
+    errors.push(`docs/product-roadmap.md: ${err.message}`);
+  }
+
+  // ── GTM & Sales Strategy (S12) ────────────────────────────────
+  try {
+    const { data: gtmArt } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data, content')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'identity_gtm_sales_strategy')
+      .eq('is_current', true)
+      .limit(1)
+      .maybeSingle();
+
+    if (gtmArt) {
+      const d = gtmArt.artifact_data || parseContent(gtmArt.content);
+      if (d) {
+        const lines = ['# Go-To-Market & Sales Strategy\n'];
+        if (d.positioning) lines.push(`## Positioning\n${d.positioning}\n`);
+        if (d.messaging_pillars) {
+          lines.push('## Messaging Pillars');
+          (Array.isArray(d.messaging_pillars) ? d.messaging_pillars : [d.messaging_pillars]).forEach(p => lines.push(`- ${p}`));
+          lines.push('');
+        }
+        if (d.channels) {
+          lines.push('## Channels');
+          (Array.isArray(d.channels) ? d.channels : [d.channels]).forEach(c => lines.push(`- ${typeof c === 'object' ? c.name || JSON.stringify(c) : c}`));
+          lines.push('');
+        }
+        if (d.launch_strategy) lines.push(`## Launch Strategy\n${d.launch_strategy}\n`);
+        const content = lines.join('\n');
+        if (content.length > 50) {
+          writeFileSync(join(docsDir, 'gtm-strategy.md'), content);
+          docsCommitted.push('docs/gtm-strategy.md');
+        }
+      }
+    }
+  } catch (err) {
+    errors.push(`docs/gtm-strategy.md: ${err.message}`);
+  }
+
+  // ── Color Palette as CSS (from S11 identity_naming_visual) ────
+  try {
+    const { data: visualArt } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'identity_naming_visual')
+      .eq('is_current', true)
+      .limit(1)
+      .maybeSingle();
+
+    const palette = visualArt?.artifact_data?.visualIdentity?.colorPalette;
+    if (palette?.length) {
+      const lines = ['# Brand Color Palette\n', '## CSS Custom Properties\n', '```css', ':root {'];
+      palette.forEach((c, i) => {
+        const name = (c.usage || '').split(/[,.]/)[ 0].trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || `color-${i + 1}`;
+        lines.push(`  --brand-${name}: ${c.hex}; /* ${c.usage || ''} */`);
+      });
+      lines.push('}', '```\n');
+      lines.push('## Palette Reference\n');
+      lines.push('| Hex | Usage |', '|-----|-------|');
+      palette.forEach(c => lines.push(`| \`${c.hex}\` | ${c.usage || ''} |`));
+      lines.push('');
+
+      // Add imagery guidance if available
+      const imagery = visualArt?.artifact_data?.visualIdentity?.imageryGuidance;
+      if (imagery) lines.push(`## Imagery Direction\n${imagery}\n`);
+
+      // Add typography if available
+      const typo = visualArt?.artifact_data?.logoSpec?.typography;
+      if (typo) lines.push(`## Typography\n- Heading: ${typo.heading || typo}\n- Body: ${typo.body || ''}\n`);
+
+      const content = lines.join('\n');
+      writeFileSync(join(docsDir, 'color-palette.md'), content);
+      docsCommitted.push('docs/color-palette.md');
+    }
+  } catch (err) {
+    errors.push(`docs/color-palette.md: ${err.message}`);
+  }
+
   // Update replit.md — use agent-optimized template or legacy
   if (docFormat === 'agent-optimized') {
     const replitMd = generateAgentOptimizedReplitMd(ventureName, stitchManifest);
@@ -779,14 +940,20 @@ All planning artifacts are in the \`docs/\` folder:
 - **docs/wireframes.md** — All screen layouts with ASCII mockups
 - **docs/context.md** — Problem statement, value proposition, competitive landscape, roadmap
 - **docs/pricing.md** — Pricing model and tiers (if applicable)
+- **docs/designs/*.html** — Approved HTML designs for each screen (pixel-perfect reference)
+- **docs/product-roadmap.md** — Feature priorities and phases
+- **docs/gtm-strategy.md** — Marketing messaging and positioning
+- **docs/color-palette.md** — Brand colors as CSS custom properties
 ${stitchSection}
 ## Build Instructions
 
 When given a feature prompt, always:
 1. Read the relevant docs/ file referenced in the prompt
-2. Follow the branding (colors, typography, product name) from docs/branding.md
-3. Match the wireframe layout from docs/wireframes.md
-4. Use the data model from docs/architecture.md for database operations${stitchManifest ? '\n5. Check docs/stitch/ for high-fidelity design references before building UI' : ''}
+2. **Check docs/designs/ first** — these are approved HTML designs for each screen. Match them as closely as possible.
+3. Use the CSS custom properties from docs/color-palette.md for all colors
+4. Follow the branding (typography, product name) from docs/branding.md
+5. Use the data model from docs/architecture.md for database operations
+6. Reference docs/product-roadmap.md for feature priority and phasing
 
 ## Coding Standards
 - TypeScript strict mode
@@ -804,7 +971,7 @@ When given a feature prompt, always:
   try {
     execSync('git add docs/ replit.md', { cwd: repoDir, encoding: 'utf-8' });
     execSync(
-      'git commit -m "docs: seed reference documents from EHG venture pipeline\n\nAdds branding, architecture, wireframes, context, and pricing\ndocuments extracted from Stages 0-19 planning artifacts."',
+      'git commit -m "docs: seed reference documents from EHG venture pipeline\n\nAdds branding, architecture, wireframes, approved designs, roadmap,\nGTM strategy, and color palette from Stages 0-17 planning artifacts."',
       { cwd: repoDir, encoding: 'utf-8' }
     );
     execSync('git push', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });


### PR DESCRIPTION
## Summary
- S17 approved HTML designs saved as `docs/designs/*.html` (pixel-perfect reference)
- Product roadmap from S13 as `docs/product-roadmap.md`
- GTM strategy from S12 as `docs/gtm-strategy.md`
- Brand colors from S11 as `docs/color-palette.md` (CSS custom properties ready to paste)
- Updated `replit.md` build instructions to prioritize approved designs

## Test plan
- [ ] Run seedRepo for a venture with S17 approved designs
- [ ] Verify docs/designs/ contains HTML files named by screen
- [ ] Verify color-palette.md has CSS custom properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)