### PR TITLE
fix: update Replit prompts to reference designs + color palette

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -499,18 +499,22 @@ Read these files in order when starting a new feature:
 
 | File | Purpose | When to Read |
 |------|---------|-------------|
-| **docs/spec.md** | Complete specification: problem, users, architecture, screens | **First** — before writing any code |
-| **docs/tasks.md** | Pre-decomposed implementation steps with acceptance criteria | **Second** — pick your next task from here |
+| **docs/designs/** | Approved HTML designs for each screen — pixel-perfect reference | **First** — open the relevant screen's HTML before building any UI |
+| **docs/color-palette.md** | Brand colors as CSS custom properties — copy into global CSS | **First** — import :root block before writing any styles |
+| **docs/spec.md** | Complete specification: problem, users, architecture, screens | Before writing any code |
+| **docs/tasks.md** | Pre-decomposed implementation steps with acceptance criteria | Pick your next task from here |
 | **docs/architecture.md** | Tech stack, data model, API surface | When implementing backend/database work |
-| **docs/branding.md** | Colors, fonts, personas, brand voice | When implementing any UI |
-${stitchManifest ? '| **docs/stitch/** | High-fidelity HTML screens + design tokens | When building UI pages |\n' : ''}
+| **docs/branding.md** | Typography, personas, brand voice | When implementing any UI |
+| **docs/product-roadmap.md** | Feature priorities and MVP phasing | When deciding build order |
+
 ## Build Workflow
 
 For each feature or task:
-1. **Read docs/tasks.md** and pick the next uncompleted task
-2. **Read docs/spec.md** for the full context on that feature
-3. **Follow docs/branding.md** for all visual styling (colors, fonts, product name)
-4. **Use docs/architecture.md** for data model and API patterns${stitchBuildStep}
+1. **Open docs/designs/** and find the HTML file for the screen you're building — match it closely
+2. **Copy the CSS custom properties** from docs/color-palette.md into your global stylesheet (do this once)
+3. **Read docs/tasks.md** and pick the next uncompleted task
+4. **Read docs/spec.md** for the full context on that feature
+5. **Use docs/architecture.md** for data model and API patterns
 6. **Check off** the task's acceptance criteria when done
 
 ## Coding Standards
@@ -521,10 +525,21 @@ For each feature or task:
 - Use environment variables for all secrets
 - Follow existing patterns in the codebase
 
+## Design Consistency
+The approved HTML designs in docs/designs/ were generated independently per screen.
+There may be inconsistencies between them (e.g., one screen missing a sidebar that all
+others have, different header layouts, inconsistent navigation patterns). When you notice
+inconsistencies:
+- Identify the **majority pattern** across all screens (e.g., 5 of 6 screens have a sidebar)
+- Apply the majority pattern to ALL screens — normalize the shared layout elements
+- Shared elements to keep consistent: navigation/sidebar, header, footer, color usage, typography scale, spacing system
+- Screen-specific elements (hero sections, data tables, forms) should follow the individual design
+
 ## Key Rules
 - Do NOT invent features not in docs/tasks.md
 - Do NOT change the data model without checking docs/architecture.md
-- Do NOT use colors or fonts not in docs/branding.md
+- Do NOT use colors not in docs/color-palette.md — use the CSS custom properties
+- Do NOT deviate from the approved screen designs in docs/designs/ (except to normalize inconsistencies as described above)
 - Complete one task fully before starting the next
 `;
 }
@@ -532,19 +547,25 @@ For each feature or task:
 export function generateInitialPrompt(ventureName, framework = 'Vite') {
   return `Create a new ${framework} + TypeScript project called "${ventureName}".
 
+IMPORTANT: This repo already contains a docs/ folder with reference documents.
+Read docs/color-palette.md first and copy the CSS custom properties into your global stylesheet.
+Read docs/designs/ to see the approved HTML designs for each screen.
+
 Setup:
 - ${framework} with TypeScript (strict mode)
 - Tailwind CSS for styling
 - React Router for navigation
 - A clean folder structure: src/components/, src/pages/, src/lib/
+- Import the brand colors from docs/color-palette.md as CSS custom properties
 
 Do NOT build any features yet. Just:
 1. Initialize the project with the tech stack above
-2. Create a basic App.tsx with a router placeholder
-3. Add a simple home page that says "${ventureName}" with a subtitle
-4. Ensure the dev server runs without errors
+2. Copy the :root CSS custom properties from docs/color-palette.md into your global CSS
+3. Create a basic App.tsx with a router and navigation layout matching the majority pattern in docs/designs/
+4. Add a simple home page that says "${ventureName}" with a subtitle using the brand colors
+5. Ensure the dev server runs without errors
 
-I will add reference documents and feature prompts in the next steps.`;
+Then proceed to replit.md for the full build workflow.`;
 }
 
 // ── Main Seeder Function ───────────────────────────
@@ -1014,9 +1035,10 @@ export async function generateBuildPrompts(ventureId) {
       prompt: `Build the "${name}" screen.
 
 Reference files:
-- See docs/wireframes.md section "${name}" for the layout
-- See docs/branding.md for colors and typography
+- See docs/designs/${name.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}.html for the approved visual design
+- See docs/color-palette.md for brand colors (use the CSS custom properties)
 - See docs/architecture.md for data model and API endpoints
+- See docs/wireframes.md section "${name}" for additional layout context
 
 ${screen.purpose ? `Purpose: ${screen.purpose}` : ''}
 ${screen.persona ? `Primary user: ${screen.persona}` : ''}
@@ -1024,9 +1046,10 @@ ${screen.persona ? `Primary user: ${screen.persona}` : ''}
 ${screens.length > 1 ? `This is screen ${i + 1} of ${screens.length}.${i > 0 ? ` Build after: ${screens[i - 1].name || `Screen ${i}`}` : ''}` : ''}
 
 Instructions:
-- Match the wireframe layout as closely as possible
-- Use the brand colors from docs/branding.md
-- Implement all interactive elements shown in the wireframe
+- Match the approved HTML design in docs/designs/ as closely as possible
+- Use the CSS custom properties from docs/color-palette.md for all colors
+- Ensure shared layout elements (nav, sidebar, header) are consistent across all screens
+- Implement all interactive elements shown in the design
 - Ensure responsive design (mobile-first)
 ${screen.micro_animations ? `- Add micro-animations (designed for this screen's brand feel):
   ${screen.micro_animations.entry_transition ? `• Entry: ${screen.micro_animations.entry_transition}` : ''}


### PR DESCRIPTION
Replaces stitch references with docs/designs/, adds design consistency guidance, updates initial/feature prompts.