### PR TITLE
fix(S19): block auto-advance when Replit is selected

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1146,6 +1146,30 @@ export class StageExecutionWorker {
           break;
         }
 
+        // Replit build method gate: block at S19 when build_method is replit_agent
+        // to give the chairman time to create & seed the GitHub repo, import into Replit,
+        // and copy prompts before the worker auto-advances to S20.
+        if (currentStage === 19) {
+          const { data: s19Work } = await this._supabase
+            .from('venture_stage_work')
+            .select('advisory_data')
+            .eq('venture_id', ventureId)
+            .eq('lifecycle_stage', 19)
+            .maybeSingle();
+          const buildMethod = s19Work?.advisory_data?.build_method || 'replit_agent';
+          if (buildMethod === 'replit_agent') {
+            // Check if the chairman has signaled Replit setup is complete
+            const repoUrl = s19Work?.advisory_data?.replit_repo_url;
+            if (!repoUrl) {
+              this._logger.log('[Worker] S19 Replit gate: blocking — build_method=replit_agent but no repo URL set. Chairman needs to create & seed repo first.');
+              releaseState = ORCHESTRATOR_STATES.BLOCKED;
+              lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'replit_setup_pending' };
+              break;
+            }
+            this._logger.log(`[Worker] S19 Replit gate: repo URL set (${repoUrl}) — proceeding`);
+          }
+        }
+
         // SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D: Sprint iteration loop
         // After Stage 19 completes, check if the sprint plan indicates remaining work
         // that needs additional sprints. If so, loop back to Stage 19.


### PR DESCRIPTION
Worker blocks at S19 until repo URL is set. Prevents runaway advancement past Sprint Planning when chairman needs to do Replit setup.