### PR TITLE
feat(SD-REDESIGN-S18S26-A): redesign S18-S26 DB config for marketing-first pipeline

### DIFF
--- a/database/migrations/20260421_expand_venture_artifacts_marketing_types.sql
+++ b/database/migrations/20260421_expand_venture_artifacts_marketing_types.sql
@@ -1,0 +1,84 @@
+-- SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-A
+-- Purpose: Expand venture_artifacts CHECK constraint with marketing/distribution artifact types
+-- Vision: VISION-S18-S26-PIPELINE-REDESIGN-L2-001
+-- Date: 2026-04-21
+--
+-- Adds 16 new artifact types for the redesigned S18-S26 pipeline:
+--   S18 Marketing Copy Studio: marketing_tagline, marketing_app_store_desc, marketing_landing_hero,
+--     marketing_email_welcome, marketing_email_onboarding, marketing_email_reengagement,
+--     marketing_social_posts, marketing_seo_meta, marketing_blog_draft
+--   S20 Code Quality Gate: code_quality_report
+--   S21 Visual Assets: visual_device_screenshots, visual_social_graphics
+--   S22 Distribution Setup: distribution_channel_config, distribution_ad_copy
+--   S23 Launch Readiness: launch_readiness_checklist
+--   S26 Growth Playbook: growth_playbook
+
+BEGIN;
+
+ALTER TABLE venture_artifacts DROP CONSTRAINT IF EXISTS venture_artifacts_artifact_type_check;
+
+ALTER TABLE venture_artifacts ADD CONSTRAINT venture_artifacts_artifact_type_check
+CHECK (((artifact_type)::text = ANY (ARRAY[
+  -- Intake (Stage 0)
+  'intake_venture_analysis',
+  -- Truth (Stages 1-5)
+  'truth_idea_brief', 'truth_ai_critique', 'truth_validation_decision',
+  'truth_competitive_analysis', 'truth_financial_model',
+  'truth_problem_statement', 'truth_target_market_analysis', 'truth_value_proposition',
+  -- Engine (Stages 6-9)
+  'engine_risk_matrix', 'engine_pricing_model', 'engine_business_model_canvas',
+  'engine_exit_strategy', 'engine_risk_assessment', 'engine_revenue_model',
+  -- Identity (Stages 10-12)
+  'identity_persona_brand', 'identity_brand_guidelines', 'identity_naming_visual',
+  'identity_brand_name', 'identity_gtm_sales_strategy',
+  -- Blueprint (Stages 13-17)
+  'blueprint_product_roadmap', 'blueprint_technical_architecture', 'blueprint_data_model',
+  'blueprint_erd_diagram', 'blueprint_api_contract', 'blueprint_schema_spec',
+  'blueprint_risk_register', 'blueprint_user_story_pack', 'blueprint_wireframes',
+  'blueprint_financial_projection', 'blueprint_launch_readiness', 'blueprint_sprint_plan',
+  'blueprint_promotion_gate', 'blueprint_project_plan', 'blueprint_review_summary',
+  -- Build (Stages 18-22) — existing
+  'build_system_prompt', 'build_cicd_config', 'build_security_audit', 'build_mvp_build',
+  'build_test_coverage_report',
+  -- Marketing Copy Studio (Stage 18) — NEW
+  'marketing_tagline', 'marketing_app_store_desc', 'marketing_landing_hero',
+  'marketing_email_welcome', 'marketing_email_onboarding', 'marketing_email_reengagement',
+  'marketing_social_posts', 'marketing_seo_meta', 'marketing_blog_draft',
+  -- Code Quality Gate (Stage 20) — NEW
+  'code_quality_report',
+  -- Visual Assets (Stage 21) — NEW
+  'visual_device_screenshots', 'visual_social_graphics',
+  -- Distribution Setup (Stage 22) — NEW
+  'distribution_channel_config', 'distribution_ad_copy',
+  -- Launch (Stages 23-26) — existing + new
+  'launch_test_plan', 'launch_uat_report', 'launch_deployment_runbook',
+  'launch_marketing_checklist', 'launch_analytics_dashboard', 'launch_health_scoring',
+  'launch_churn_triggers', 'launch_retention_playbook', 'launch_optimization_roadmap',
+  'launch_assumptions_vs_reality', 'launch_launch_metrics', 'launch_user_feedback_summary',
+  'launch_production_app',
+  'launch_readiness_checklist',
+  -- Growth Playbook (Stage 26) — NEW
+  'growth_playbook',
+  -- Cross-cutting / System
+  'system_devils_advocate_review',
+  -- Gate & Analysis artifacts
+  'value_multiplier_assessment',
+  'economic_lens',
+  'lifecycle_sd_bridge',
+  'post_lifecycle_decision',
+  -- Stitch integration (legacy, preserved)
+  'stitch_project', 'stitch_curation', 'stitch_budget',
+  -- S17 Design stage legacy artifacts (in use in production data)
+  's17_archetypes', 's17_session_state', 's17_strategy_recommendation', 's17_variant_wip',
+  'stage_17_approved_desktop', 'wireframe_screens',
+  -- Dynamic stage analysis artifacts
+  'stage_0_analysis', 'stage_1_analysis', 'stage_2_analysis', 'stage_3_analysis',
+  'stage_4_analysis', 'stage_5_analysis', 'stage_6_analysis', 'stage_7_analysis',
+  'stage_8_analysis', 'stage_9_analysis', 'stage_10_analysis', 'stage_11_analysis',
+  'stage_12_analysis', 'stage_13_analysis', 'stage_14_analysis', 'stage_15_analysis',
+  'stage_16_analysis', 'stage_17_analysis', 'stage_18_analysis', 'stage_19_analysis',
+  'stage_20_analysis', 'stage_21_analysis', 'stage_22_analysis', 'stage_23_analysis',
+  'stage_24_analysis', 'stage_25_analysis', 'stage_26_analysis'
+]::text[])));
+
+COMMIT;

--- a/database/migrations/20260421_redesign_s18_s26_lifecycle_stage_config.sql
+++ b/database/migrations/20260421_redesign_s18_s26_lifecycle_stage_config.sql
@@ -1,0 +1,89 @@
+-- SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-A
+-- Purpose: Redesign lifecycle_stage_config S18-S26 for marketing-first post-build pipeline
+-- Vision: VISION-S18-S26-PIPELINE-REDESIGN-L2-001
+-- Date: 2026-04-21
+--
+-- Changes:
+--   1. Update S18-S25 with new stage names, descriptions, work_types, required_artifacts
+--   2. Insert S26 (Growth Playbook) — previously MAX_STAGE=26 but no config row existed
+--   3. Update lifecycle_phases for phases 5 and 6
+--
+-- Stage flow (new):
+--   S17 (Design) -> S18 (Marketing Copy Studio) -> S19 (Build in Replit) ->
+--   S20 (Code Quality Gate) -> S21 (Visual Assets) -> S22 (Distribution Setup) ->
+--   S23 (Launch Readiness Kill Gate) -> S24 (Go Live & Announce) ->
+--   S25 (Post-Launch Review) -> S26 (Growth Playbook)
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Update lifecycle_stage_config S18-S26
+-- ============================================================================
+
+INSERT INTO lifecycle_stage_config (stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, sd_suffix, advisory_enabled, depends_on, required_artifacts, metadata) VALUES
+
+-- PHASE 5: BUILD & MARKET (Stages 17-22) — S17 unchanged, S18-S22 redesigned
+(18, 'Marketing Copy Studio', 'Persona-targeted marketing copy generation from 12 upstream artifacts. Produces taglines, app store descriptions, email sequences, social posts, landing page copy, SEO meta, and blog drafts. Copy is seeded into the GitHub repo for Replit builds.', 5, 'BUILD & MARKET', 'sd_required', true, 'MARKETING', false, ARRAY[17], ARRAY['marketing_tagline', 'marketing_app_store_desc', 'marketing_landing_hero', 'marketing_email_welcome', 'marketing_email_onboarding', 'marketing_email_reengagement', 'marketing_social_posts', 'marketing_seo_meta', 'marketing_blog_draft'], '{"upstream_artifacts": ["truth_idea_brief", "truth_competitive_analysis", "engine_pricing_model", "engine_business_model_canvas", "identity_persona_brand", "identity_brand_guidelines", "identity_naming_visual", "identity_brand_name", "identity_gtm_sales_strategy", "blueprint_product_roadmap", "blueprint_user_story_pack", "blueprint_financial_projection"], "copy_sections": ["tagline", "app_store_description", "landing_page_hero", "email_welcome", "email_onboarding", "email_reengagement", "social_posts", "seo_meta", "blog_draft"]}'),
+
+(19, 'Build in Replit', 'Venture build execution via Replit Agent using seeded GitHub repo containing docs, designs, and marketing copy. Produces the deployed application URL and GitHub repo URL.', 5, 'BUILD & MARKET', 'sd_required', true, 'BUILD', false, ARRAY[18], ARRAY['build_mvp_build'], '{"build_method": "replit_agent", "gates": {"entry": ["Marketing copy complete", "GitHub repo seeded"], "exit": ["Application deployed", "GitHub repo URL stored in venture_resources"]}}'),
+
+(20, 'Code Quality Gate', 'Claude Code validates the actual GitHub repo: npm audit, secret detection, lint, test suite execution. Produces pass/fail quality report. Blocks advancement if critical issues found.', 5, 'BUILD & MARKET', 'automated_check', false, NULL, false, ARRAY[19], ARRAY['code_quality_report'], '{"validation_methods": ["npm_audit", "secret_detection", "lint", "test_suite"], "gates": {"exit": ["No critical security issues", "No exposed secrets", "Lint passes"]}}'),
+
+(21, 'Visual Assets', 'Generate device-framed screenshots from live app, social media graphics sized per platform, and video storyboard cards. Uses S17 approved designs and the built application.', 5, 'BUILD & MARKET', 'artifact_only', false, NULL, false, ARRAY[20], ARRAY['visual_device_screenshots', 'visual_social_graphics'], '{"asset_types": ["device_screenshots", "social_graphics", "video_storyboards"], "device_frames": ["iphone", "macbook"], "social_sizes": ["instagram_square", "twitter_banner", "facebook_cover"]}'),
+
+(22, 'Distribution Setup', 'Configure distribution channels based on GTM strategy. Generate platform-specific ad copy with targeting parameters. Export email sequences. Each channel shows status and content preview.', 5, 'BUILD & MARKET', 'artifact_only', false, NULL, false, ARRAY[21], ARRAY['distribution_channel_config', 'distribution_ad_copy'], '{"channels": ["app_store", "google_ads", "facebook_instagram", "twitter_x", "email", "blog_seo"], "targeting_sources": ["identity_persona_brand", "engine_pricing_model"]}'),
+
+-- PHASE 6: LAUNCH & GROW (Stages 23-26)
+(23, 'Launch Readiness Kill Gate', 'Aggregates readiness signals from S20-S22. Checklist: code quality, marketing assets, distribution channels, analytics wiring, monitoring, legal. Kill gate blocks if any category incomplete. Chairman can override.', 6, 'LAUNCH & GROW', 'decision_gate', false, NULL, false, ARRAY[22], ARRAY['launch_readiness_checklist'], '{"decision_options": ["launch", "hold", "reject"], "checklist_categories": ["code_quality", "marketing_assets", "distribution_channels", "analytics", "monitoring", "legal"], "gates": {"exit": ["All categories green OR chairman override"]}}'),
+
+(24, 'Go Live & Announce', 'Chairman explicitly triggers launch across all configured channels. Multi-channel announcement: app store publish, ad campaigns activate, email sequences start, social posts publish.', 6, 'LAUNCH & GROW', 'decision_gate', false, NULL, false, ARRAY[23], ARRAY['launch_launch_metrics'], '{"decision_options": ["launch_now", "schedule", "abort"], "gates": {"entry": ["Launch readiness PASS"], "exit": ["Launch triggered", "All channels activated"]}}'),
+
+(25, 'Post-Launch Review', 'Collect real-world performance data: user signups, engagement metrics, revenue, churn indicators. Compare against S16 financial projections. Identify what worked and what needs adjustment.', 6, 'LAUNCH & GROW', 'artifact_only', false, NULL, false, ARRAY[24], ARRAY['launch_assumptions_vs_reality', 'launch_user_feedback_summary'], '{"metrics_collected": ["signups", "engagement", "revenue", "churn", "nps"], "comparison_baseline": "blueprint_financial_projection"}'),
+
+(26, 'Growth Playbook', 'Generate growth strategy playbook based on post-launch data. Define optimization experiments, scaling priorities, and operational handoff to the Operations dashboard for ongoing monitoring.', 6, 'LAUNCH & GROW', 'artifact_only', false, NULL, false, ARRAY[25], ARRAY['growth_playbook', 'launch_optimization_roadmap'], '{"outputs": ["growth_experiments", "scaling_priorities", "operations_handoff"], "feeds_into": "operations_dashboard"}')
+
+ON CONFLICT (stage_number) DO UPDATE SET
+  stage_name = EXCLUDED.stage_name,
+  description = EXCLUDED.description,
+  phase_number = EXCLUDED.phase_number,
+  phase_name = EXCLUDED.phase_name,
+  work_type = EXCLUDED.work_type,
+  sd_required = EXCLUDED.sd_required,
+  sd_suffix = EXCLUDED.sd_suffix,
+  advisory_enabled = EXCLUDED.advisory_enabled,
+  depends_on = EXCLUDED.depends_on,
+  required_artifacts = EXCLUDED.required_artifacts,
+  metadata = EXCLUDED.metadata,
+  updated_at = NOW();
+
+-- ============================================================================
+-- 2. Update lifecycle_phases for phases 5 and 6
+-- ============================================================================
+
+UPDATE lifecycle_phases SET
+  phase_name = 'BUILD & MARKET',
+  description = 'Marketing copy, build execution, code validation, visual assets, and distribution setup',
+  stages = ARRAY[17, 18, 19, 20, 21, 22]
+WHERE phase_number = 5;
+
+UPDATE lifecycle_phases SET
+  phase_name = 'LAUNCH & GROW',
+  description = 'Launch readiness, go-live execution, post-launch review, and growth playbook',
+  stages = ARRAY[23, 24, 25, 26]
+WHERE phase_number = 6;
+
+COMMIT;
+
+-- ============================================================================
+-- Verification queries (run after migration):
+-- ============================================================================
+-- SELECT stage_number, stage_name, work_type, phase_name
+-- FROM lifecycle_stage_config
+-- WHERE stage_number BETWEEN 18 AND 26
+-- ORDER BY stage_number;
+-- Expected: 9 rows with new names
+--
+-- SELECT phase_number, phase_name, stages
+-- FROM lifecycle_phases
+-- WHERE phase_number IN (5, 6);
+-- Expected: Phase 5 stages={17,18,19,20,21,22}, Phase 6 stages={23,24,25,26}

--- a/lib/eva/gate-constants.js
+++ b/lib/eva/gate-constants.js
@@ -12,15 +12,20 @@
  * Kill gate stages — checkpoints where ventures may be terminated.
  * Must always require manual chairman review regardless of autonomy level.
  * Synced with frontend: KILL_GATE_STAGES in venture-workflow.ts
+ * Updated 2026-04-21: S23 Launch Readiness Kill Gate added, S24 moved to promotion
+ * (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-A)
  */
-export const KILL_GATE_STAGES = new Set([3, 5, 13, 24]);
+export const KILL_GATE_STAGES = new Set([3, 5, 13, 23]);
 
 /**
  * Promotion gate stages — checkpoints where ventures need chairman
  * approval to advance to the next operating mode.
  * Manual at L0-L1, auto at L2+.
+ * Updated 2026-04-21: S18 Marketing Copy needs review, S19 Build needs approval,
+ * S24 Go Live requires explicit chairman trigger
+ * (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-A)
  */
-export const PROMOTION_GATE_STAGES = new Set([10, 17, 18, 19, 23, 25]);
+export const PROMOTION_GATE_STAGES = new Set([10, 17, 18, 19, 24, 25]);
 
 /**
  * Taste gate stages — checkpoints where ventures require human taste
@@ -34,9 +39,11 @@ export const TASTE_GATE_STAGES = new Set([10, 13, 16]);
 /**
  * Chairman gate stages where pipeline pauses for human decision.
  * BLOCKING = union of KILL_GATE_STAGES and PROMOTION_GATE_STAGES.
+ * Updated 2026-04-21: S23 is kill gate (launch readiness), S24 is promotion (go live)
+ * (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-A)
  */
 export const CHAIRMAN_GATES = Object.freeze({
-  BLOCKING: new Set([3, 5, 10, 13, 17, 18, 19, 20, 23, 24, 25]),
+  BLOCKING: new Set([3, 5, 10, 13, 17, 18, 19, 23, 24, 25]),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Update lifecycle_stage_config S18-S26 with new marketing-first pipeline stage names, work_types, descriptions
- Add S26 Growth Playbook row (previously missing despite MAX_STAGE=26)
- Expand venture_artifacts CHECK constraint with 16 new marketing/distribution artifact types
- Update gate-constants.js: S23 → KILL_GATE (Launch Readiness), S24 → PROMOTION (Go Live)
- Update lifecycle_phases: Phase 5=BUILD & MARKET (17-22), Phase 6=LAUNCH & GROW (23-26)

## Test plan
- [x] Migrations executed and verified against Supabase
- [x] 9 rows in lifecycle_stage_config for S18-S26 with correct names
- [x] S26 Growth Playbook exists with correct metadata
- [x] All 16 new artifact types accepted by CHECK constraint
- [x] Existing 60+ artifact types preserved
- [x] gate-constants.js Sets updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)