### PR TITLE
feat(SD-REDESIGN-S18S26-B): S18 Marketing Copy Studio backend

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -289,16 +289,34 @@ const STAGE_CONTRACTS = new Map([
     },
   }],
 
+  // 2026-04-21: S18 redesigned from Pre-Build Checklist to Marketing Copy Studio
+  // (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-B)
   [18, {
     consumes: [
-      { stage: 13, fields: { milestones: { type: 'array' } }},
-      { stage: 14, fields: { layers: { type: 'object' } }},
-      { stage: 17, fields: { decision: { type: 'string' } }},
+      { stage: 1,  fields: { content: { type: 'object', required: false } }},  // idea brief
+      { stage: 4,  fields: { content: { type: 'object', required: false } }},  // competitive analysis
+      { stage: 7,  fields: { content: { type: 'object', required: false } }},  // pricing model
+      { stage: 8,  fields: { content: { type: 'object', required: false } }},  // business model canvas
+      { stage: 10, fields: { content: { type: 'object', required: true  } }},  // persona + brand (required)
+      { stage: 11, fields: { content: { type: 'object', required: false } }},  // naming + visual
+      { stage: 12, fields: { content: { type: 'object', required: false } }},  // GTM strategy
+      { stage: 13, fields: { content: { type: 'object', required: false } }},  // product roadmap
+      { stage: 15, fields: { content: { type: 'object', required: false } }},  // user story pack
+      { stage: 16, fields: { content: { type: 'object', required: false } }},  // financial projection
     ],
     produces: {
-      checklist: { type: 'object' },
-      readiness_pct: { type: 'number' },
-      buildReadiness: { type: 'object' },
+      tagline: { type: 'object' },
+      app_store_desc: { type: 'object' },
+      landing_hero: { type: 'object' },
+      email_welcome: { type: 'object' },
+      email_onboarding: { type: 'object' },
+      email_reengagement: { type: 'object' },
+      social_posts: { type: 'object' },
+      seo_meta: { type: 'object' },
+      blog_draft: { type: 'object' },
+      totalSections: { type: 'number' },
+      completedSections: { type: 'number' },
+      personaCoveragePct: { type: 'number' },
     },
   }],
 

--- a/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
@@ -1,0 +1,315 @@
+/**
+ * Stage 18 Analysis Step — Marketing Copy Studio
+ * Phase: BUILD & MARKET (Stages 18-22)
+ * SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-B
+ *
+ * Reads 12 upstream venture artifacts and generates persona-targeted
+ * marketing copy across 9 sections via LLM.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+
+const COPY_SECTIONS = [
+  'tagline', 'app_store_desc', 'landing_hero',
+  'email_welcome', 'email_onboarding', 'email_reengagement',
+  'social_posts', 'seo_meta', 'blog_draft',
+];
+
+const UPSTREAM_ARTIFACT_TYPES = [
+  'truth_idea_brief',            // S1  — problem statement, value prop
+  'truth_competitive_analysis',  // S4  — competitor names, differentiation
+  'engine_pricing_model',        // S7  — pricing tiers
+  'engine_business_model_canvas',// S8  — value proposition, customer segments
+  'identity_persona_brand',      // S10 — customer personas with pain points
+  'identity_brand_guidelines',   // S10 — brand voice, messaging pillars
+  'identity_naming_visual',      // S11 — brand name, color palette, tagline
+  'identity_brand_name',         // S11 — selected name + rationale
+  'identity_gtm_sales_strategy', // S12 — channels, positioning, launch strategy
+  'blueprint_product_roadmap',   // S13 — top features
+  'blueprint_user_story_pack',   // S15 — user stories in user language
+  'blueprint_financial_projection', // S16 — revenue projections
+];
+
+// 2026-04-21: LLM strategy — use getLLMClient() cascade (Anthropic > Google > Ollama)
+// for marketing copy generation. Long-form content benefits from higher-quality models.
+const SYSTEM_PROMPT = `You are EVA's Marketing Copy Studio. Generate persona-targeted marketing copy for a venture using upstream artifacts.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "tagline": {
+    "text": "A compelling tagline (max 10 words)",
+    "persona_target": "Primary persona name this targets"
+  },
+  "app_store_desc": {
+    "text": "App store description (300-500 words). Include: what the product does, who it's for, key features, pricing mention, CTA.",
+    "persona_target": "Primary persona name"
+  },
+  "landing_hero": {
+    "headline": "Landing page headline (max 12 words)",
+    "subheadline": "Supporting subheadline (max 25 words)",
+    "cta_text": "Call-to-action button text (max 5 words)",
+    "persona_target": "Primary persona name"
+  },
+  "email_welcome": {
+    "subject": "Email subject line",
+    "body": "Welcome email body (150-300 words). Warm, personal tone. Reference the problem they signed up to solve.",
+    "persona_target": "Primary persona name"
+  },
+  "email_onboarding": {
+    "subject": "Email subject line",
+    "body": "Day-3 onboarding email (150-300 words). Show key features, quick wins.",
+    "persona_target": "Primary persona name"
+  },
+  "email_reengagement": {
+    "subject": "Email subject line",
+    "body": "Re-engagement email (100-200 words). Remind of value, offer incentive.",
+    "persona_target": "Primary persona name"
+  },
+  "social_posts": {
+    "twitter": "Tweet-length post (max 280 chars)",
+    "linkedin": "Professional post (100-200 words)",
+    "instagram": "Visual-first caption with hashtags (100-150 words)",
+    "facebook": "Conversational post (100-200 words)",
+    "product_hunt": "Launch tagline for Product Hunt (max 60 chars)",
+    "persona_target": "Primary persona name"
+  },
+  "seo_meta": {
+    "title": "SEO meta title (max 60 chars)",
+    "description": "SEO meta description (max 160 chars)",
+    "keywords": ["keyword1", "keyword2", "...up to 10 keywords"],
+    "persona_target": "Primary persona name"
+  },
+  "blog_draft": {
+    "title": "Blog post title",
+    "intro": "Opening paragraph (100-150 words) that hooks the reader with the problem",
+    "sections": ["Section 1 heading", "Section 2 heading", "Section 3 heading"],
+    "conclusion": "Closing paragraph with CTA (50-100 words)",
+    "persona_target": "Primary persona name"
+  }
+}
+
+Rules:
+- ALWAYS use the primary persona's NAME in the copy where it makes sense naturally
+- Address the persona's specific PAIN POINTS — do not use generic benefits
+- Match the BRAND VOICE from brand guidelines (formal vs casual, technical vs simple)
+- Include PRICING mention in app store description if pricing data available
+- Use COMPETITOR DIFFERENTIATION from competitive analysis to position uniquely
+- Social posts should be PLATFORM-SPECIFIC in tone and format
+- SEO keywords should reflect the venture's domain and target audience search terms
+- All copy must feel authentic and human, not AI-generated boilerplate`;
+
+function buildUserPrompt(upstreamData, ventureName) {
+  const sections = [];
+
+  sections.push(`## Venture: ${ventureName || 'Unknown Venture'}\n`);
+
+  if (upstreamData.truth_idea_brief) {
+    sections.push(`## Idea Brief (S1)\n${JSON.stringify(upstreamData.truth_idea_brief, null, 2)}\n`);
+  }
+  if (upstreamData.truth_competitive_analysis) {
+    sections.push(`## Competitive Analysis (S4)\n${JSON.stringify(upstreamData.truth_competitive_analysis, null, 2)}\n`);
+  }
+  if (upstreamData.engine_pricing_model) {
+    sections.push(`## Pricing Model (S7)\n${JSON.stringify(upstreamData.engine_pricing_model, null, 2)}\n`);
+  }
+  if (upstreamData.engine_business_model_canvas) {
+    sections.push(`## Business Model Canvas (S8)\n${JSON.stringify(upstreamData.engine_business_model_canvas, null, 2)}\n`);
+  }
+  if (upstreamData.identity_persona_brand) {
+    sections.push(`## Personas & Brand (S10) — USE THIS PERSONA NAME IN COPY\n${JSON.stringify(upstreamData.identity_persona_brand, null, 2)}\n`);
+  }
+  if (upstreamData.identity_brand_guidelines) {
+    sections.push(`## Brand Guidelines (S10) — MATCH THIS VOICE\n${JSON.stringify(upstreamData.identity_brand_guidelines, null, 2)}\n`);
+  }
+  if (upstreamData.identity_naming_visual) {
+    sections.push(`## Naming & Visual Identity (S11)\n${JSON.stringify(upstreamData.identity_naming_visual, null, 2)}\n`);
+  }
+  if (upstreamData.identity_brand_name) {
+    sections.push(`## Brand Name (S11)\n${JSON.stringify(upstreamData.identity_brand_name, null, 2)}\n`);
+  }
+  if (upstreamData.identity_gtm_sales_strategy) {
+    sections.push(`## GTM Strategy (S12)\n${JSON.stringify(upstreamData.identity_gtm_sales_strategy, null, 2)}\n`);
+  }
+  if (upstreamData.blueprint_product_roadmap) {
+    sections.push(`## Product Roadmap (S13)\n${JSON.stringify(upstreamData.blueprint_product_roadmap, null, 2)}\n`);
+  }
+  if (upstreamData.blueprint_user_story_pack) {
+    sections.push(`## User Stories (S15)\n${JSON.stringify(upstreamData.blueprint_user_story_pack, null, 2)}\n`);
+  }
+  if (upstreamData.blueprint_financial_projection) {
+    sections.push(`## Financial Projections (S16)\n${JSON.stringify(upstreamData.blueprint_financial_projection, null, 2)}\n`);
+  }
+
+  const availableCount = sections.length - 1; // minus the venture header
+  sections.push(`\n## Available Upstream Data: ${availableCount}/12 artifacts`);
+  if (availableCount < 6) {
+    sections.push('⚠️ Limited upstream data. Generate copy from what is available. Flag gaps.');
+  }
+
+  sections.push('\nGenerate the complete marketing copy JSON now.');
+  return sections.join('\n');
+}
+
+function extractUpstreamByType(stageDataMap) {
+  const result = {};
+  for (const [key, value] of Object.entries(stageDataMap || {})) {
+    if (value?.__byType) {
+      for (const [type, artifact] of Object.entries(value.__byType)) {
+        if (UPSTREAM_ARTIFACT_TYPES.includes(type)) {
+          result[type] = artifact?.artifact_data || artifact?.content || artifact;
+        }
+      }
+    }
+    // Also check direct artifact_type matches
+    if (value?.artifact_type && UPSTREAM_ARTIFACT_TYPES.includes(value.artifact_type)) {
+      result[value.artifact_type] = value?.artifact_data || value?.content || value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Generate marketing copy from upstream artifacts via LLM.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data  - Truth: idea brief
+ * @param {Object} params.stage4Data  - Truth: competitive analysis
+ * @param {Object} params.stage7Data  - Engine: pricing model
+ * @param {Object} params.stage8Data  - Engine: business model canvas
+ * @param {Object} params.stage10Data - Identity: persona + brand guidelines
+ * @param {Object} params.stage11Data - Identity: naming + visual
+ * @param {Object} params.stage12Data - Identity: GTM strategy
+ * @param {Object} params.stage13Data - Blueprint: product roadmap
+ * @param {Object} params.stage15Data - Blueprint: user story pack
+ * @param {Object} params.stage16Data - Blueprint: financial projection
+ * @param {string} params.ventureName
+ * @param {Object} [params.logger]
+ * @returns {Promise<Object>} Marketing copy output
+ */
+export async function analyzeStage18MarketingCopy(params) {
+  const {
+    stage1Data, stage4Data, stage7Data, stage8Data,
+    stage10Data, stage11Data, stage12Data, stage13Data,
+    stage15Data, stage16Data,
+    ventureName,
+    logger = console,
+  } = params;
+
+  logger.info?.('[S18-MarketingCopy] Starting copy generation for', ventureName || 'unknown venture');
+
+  // Merge upstream data, extracting by artifact type
+  const allStageData = { stage1Data, stage4Data, stage7Data, stage8Data, stage10Data, stage11Data, stage12Data, stage13Data, stage15Data, stage16Data };
+  const upstreamByType = extractUpstreamByType(allStageData);
+
+  // Also check direct data shapes (some stages pass data directly, not via __byType)
+  for (const [key, value] of Object.entries(allStageData)) {
+    if (value && typeof value === 'object' && !value.__byType) {
+      // Heuristic: map stageNData to known artifact types
+      const stageNum = parseInt(key.replace('stage', '').replace('Data', ''), 10);
+      const typeMap = { 1: 'truth_idea_brief', 4: 'truth_competitive_analysis', 7: 'engine_pricing_model', 8: 'engine_business_model_canvas', 10: 'identity_persona_brand', 11: 'identity_naming_visual', 12: 'identity_gtm_sales_strategy', 13: 'blueprint_product_roadmap', 15: 'blueprint_user_story_pack', 16: 'blueprint_financial_projection' };
+      if (typeMap[stageNum] && !upstreamByType[typeMap[stageNum]]) {
+        upstreamByType[typeMap[stageNum]] = value;
+      }
+    }
+  }
+
+  const availableTypes = Object.keys(upstreamByType);
+  logger.info?.(`[S18-MarketingCopy] Available upstream artifacts: ${availableTypes.length}/12`, availableTypes);
+
+  // Build LLM prompt
+  const userPrompt = buildUserPrompt(upstreamByType, ventureName);
+
+  let copyOutput;
+  let usage = {};
+  let llmFallbackCount = 0;
+
+  try {
+    const client = getLLMClient();
+    const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+    const parsed = parseJSON(response);
+    usage = extractUsage(response) || {};
+
+    if (parsed && parsed.tagline) {
+      copyOutput = parsed;
+    } else {
+      logger.warn('[S18-MarketingCopy] LLM returned invalid structure, using fallback');
+      llmFallbackCount = 1;
+      copyOutput = buildFallbackCopy(ventureName, upstreamByType);
+    }
+  } catch (err) {
+    logger.error('[S18-MarketingCopy] LLM error:', err.message);
+    llmFallbackCount = 1;
+    copyOutput = buildFallbackCopy(ventureName, upstreamByType);
+  }
+
+  // Validate persona coverage
+  const personaName = extractPersonaName(upstreamByType);
+  const personaCoverage = personaName ? checkPersonaCoverage(copyOutput, personaName) : { covered: 0, total: COPY_SECTIONS.length, pct: 0 };
+
+  // Build final output
+  const result = {
+    ...copyOutput,
+    metadata: {
+      upstream_artifacts_available: availableTypes.length,
+      upstream_artifacts_used: availableTypes,
+      missing_artifacts: UPSTREAM_ARTIFACT_TYPES.filter(t => !availableTypes.includes(t)),
+      persona_name: personaName,
+      persona_coverage: personaCoverage,
+      venture_name: ventureName,
+    },
+    totalSections: COPY_SECTIONS.length,
+    completedSections: COPY_SECTIONS.filter(s => copyOutput[s]).length,
+    personaCoveragePct: personaCoverage.pct,
+    llmFallbackCount,
+    usage,
+  };
+
+  logger.info?.(`[S18-MarketingCopy] Complete: ${result.completedSections}/${result.totalSections} sections, persona coverage ${result.personaCoveragePct}%`);
+  return result;
+}
+
+function extractPersonaName(upstreamByType) {
+  const persona = upstreamByType.identity_persona_brand;
+  if (!persona) return null;
+  // Try common persona data shapes
+  if (typeof persona === 'string') return persona;
+  if (persona.primary_persona?.name) return persona.primary_persona.name;
+  if (persona.personas?.[0]?.name) return persona.personas[0].name;
+  if (persona.name) return persona.name;
+  if (persona.persona_name) return persona.persona_name;
+  return null;
+}
+
+function checkPersonaCoverage(copyOutput, personaName) {
+  if (!personaName) return { covered: 0, total: COPY_SECTIONS.length, pct: 0 };
+  const nameLower = personaName.toLowerCase();
+  let covered = 0;
+  for (const section of COPY_SECTIONS) {
+    const sectionData = copyOutput[section];
+    if (!sectionData) continue;
+    const text = JSON.stringify(sectionData).toLowerCase();
+    if (text.includes(nameLower)) covered++;
+  }
+  return { covered, total: COPY_SECTIONS.length, pct: Math.round((covered / COPY_SECTIONS.length) * 100) };
+}
+
+function buildFallbackCopy(ventureName, upstreamByType) {
+  const name = ventureName || 'Our Product';
+  const personaName = extractPersonaName(upstreamByType) || 'our target user';
+  return {
+    tagline: { text: `${name} — Built for ${personaName}`, persona_target: personaName },
+    app_store_desc: { text: `${name} helps ${personaName} solve their challenges. [Fallback — LLM unavailable. Regenerate for full copy.]`, persona_target: personaName },
+    landing_hero: { headline: `${name}: Your Solution`, subheadline: `Built specifically for ${personaName}`, cta_text: 'Get Started', persona_target: personaName },
+    email_welcome: { subject: `Welcome to ${name}!`, body: `Hi ${personaName}, welcome aboard. [Fallback copy — regenerate for full version.]`, persona_target: personaName },
+    email_onboarding: { subject: `Getting started with ${name}`, body: `Here are your first steps. [Fallback copy — regenerate for full version.]`, persona_target: personaName },
+    email_reengagement: { subject: `We miss you at ${name}`, body: `Come back and see what's new. [Fallback copy — regenerate for full version.]`, persona_target: personaName },
+    social_posts: { twitter: `Introducing ${name} for ${personaName}`, linkedin: `${name} launch. [Fallback]`, instagram: `${name} is here! [Fallback]`, facebook: `${name} for ${personaName}. [Fallback]`, product_hunt: `${name} — for ${personaName}`, persona_target: personaName },
+    seo_meta: { title: name, description: `${name} helps ${personaName}`, keywords: [name.toLowerCase()], persona_target: personaName },
+    blog_draft: { title: `Introducing ${name}`, intro: `[Fallback — regenerate for full blog draft.]`, sections: ['The Problem', 'Our Solution', 'Getting Started'], conclusion: `Try ${name} today.`, persona_target: personaName },
+  };
+}
+
+export { COPY_SECTIONS, UPSTREAM_ARTIFACT_TYPES };

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -1,129 +1,100 @@
 /**
- * Stage 18 Template - Pre-Build Checklist
- * Phase: THE BUILD LOOP (Stages 18-22)
- * Part of SD-LEO-FEAT-TMPL-BUILD-001
+ * Stage 18 Template — Marketing Copy Studio
+ * Phase: BUILD & MARKET (Stages 18-22)
+ * SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-B
  *
- * Pre-build readiness checklist covering architecture, team,
- * tooling, and environment prerequisites.
+ * Persona-targeted marketing copy generation from 12 upstream artifacts.
+ * Produces 9 copy sections: tagline, app store description, landing page hero,
+ * 3 email sequences, social posts, SEO meta, and blog draft.
  *
  * @module lib/eva/stage-templates/stage-18
  */
 
-import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { validateString, validateArray, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage18 } from './analysis-steps/stage-18-build-readiness.js';
-
-const CHECKLIST_CATEGORIES = [
-  'architecture',
-  'team_readiness',
-  'tooling',
-  'environment',
-  'dependencies',
-];
-const ITEM_STATUSES = ['not_started', 'in_progress', 'complete', 'blocked'];
-const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
-const BUILD_READINESS_DECISIONS = ['go', 'conditional_go', 'no_go'];
-const MIN_ITEMS_PER_CATEGORY = 1;
+import { analyzeStage18MarketingCopy, COPY_SECTIONS } from './analysis-steps/stage-18-marketing-copy.js';
 
 const TEMPLATE = {
   id: 'stage-18',
-  slug: 'pre-build-checklist',
-  title: 'Pre-Build Checklist',
-  version: '2.0.0',
+  slug: 'marketing-copy-studio',
+  title: 'Marketing Copy Studio',
+  version: '3.0.0',
   schema: {
-    checklist: {
-      type: 'object',
-      required: true,
-      properties: Object.fromEntries(CHECKLIST_CATEGORIES.map(cat => [cat, {
-        type: 'array',
-        minItems: MIN_ITEMS_PER_CATEGORY,
-        items: {
-          name: { type: 'string', required: true },
-          status: { type: 'enum', values: ITEM_STATUSES, required: true },
-          owner: { type: 'string' },
-          notes: { type: 'string' },
-        },
-      }])),
-    },
-    blockers: {
-      type: 'array',
-      items: {
-        description: { type: 'string', required: true },
-        severity: { type: 'enum', values: SEVERITY_LEVELS, required: true },
-        mitigation: { type: 'string', required: true },
-      },
-    },
+    tagline: { type: 'object', required: true, properties: { text: { type: 'string', required: true }, persona_target: { type: 'string' } } },
+    app_store_desc: { type: 'object', required: true, properties: { text: { type: 'string', required: true }, persona_target: { type: 'string' } } },
+    landing_hero: { type: 'object', required: true, properties: { headline: { type: 'string', required: true }, subheadline: { type: 'string' }, cta_text: { type: 'string' }, persona_target: { type: 'string' } } },
+    email_welcome: { type: 'object', required: true, properties: { subject: { type: 'string', required: true }, body: { type: 'string', required: true }, persona_target: { type: 'string' } } },
+    email_onboarding: { type: 'object', required: true, properties: { subject: { type: 'string', required: true }, body: { type: 'string', required: true }, persona_target: { type: 'string' } } },
+    email_reengagement: { type: 'object', required: true, properties: { subject: { type: 'string', required: true }, body: { type: 'string', required: true }, persona_target: { type: 'string' } } },
+    social_posts: { type: 'object', required: true, properties: { twitter: { type: 'string' }, linkedin: { type: 'string' }, instagram: { type: 'string' }, facebook: { type: 'string' }, product_hunt: { type: 'string' }, persona_target: { type: 'string' } } },
+    seo_meta: { type: 'object', required: true, properties: { title: { type: 'string', required: true }, description: { type: 'string', required: true }, keywords: { type: 'array' }, persona_target: { type: 'string' } } },
+    blog_draft: { type: 'object', required: true, properties: { title: { type: 'string', required: true }, intro: { type: 'string' }, sections: { type: 'array' }, conclusion: { type: 'string' }, persona_target: { type: 'string' } } },
     // Derived
-    total_items: { type: 'number', derived: true },
-    completed_items: { type: 'number', derived: true },
-    readiness_pct: { type: 'number', derived: true },
-    all_categories_present: { type: 'boolean', derived: true },
-    blocker_count: { type: 'number', derived: true },
-    buildReadiness: { type: 'object', derived: true },
+    metadata: { type: 'object', derived: true },
+    totalSections: { type: 'number', derived: true },
+    completedSections: { type: 'number', derived: true },
+    personaCoveragePct: { type: 'number', derived: true },
   },
   defaultData: {
-    checklist: {},
-    blockers: [],
-    total_items: 0,
-    completed_items: 0,
-    readiness_pct: 0,
-    all_categories_present: false,
-    blocker_count: 0,
-    buildReadiness: null,
+    tagline: null,
+    app_store_desc: null,
+    landing_hero: null,
+    email_welcome: null,
+    email_onboarding: null,
+    email_reengagement: null,
+    social_posts: null,
+    seo_meta: null,
+    blog_draft: null,
+    metadata: {},
+    totalSections: 0,
+    completedSections: 0,
+    personaCoveragePct: 0,
   },
 
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    if (!data?.checklist || typeof data.checklist !== 'object') {
-      errors.push('checklist is required and must be an object');
-      return { valid: false, errors };
-    }
-
-    for (const cat of CHECKLIST_CATEGORIES) {
-      const items = data.checklist[cat];
-      const arrCheck = validateArray(items, `checklist.${cat}`, MIN_ITEMS_PER_CATEGORY);
-      if (!arrCheck.valid) {
-        errors.push(arrCheck.error);
+    for (const section of COPY_SECTIONS) {
+      if (!data?.[section]) {
+        errors.push(`${section} is required`);
         continue;
       }
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        const prefix = `checklist.${cat}[${i}]`;
-        const results = [
-          validateString(item?.name, `${prefix}.name`, 1),
-          validateEnum(item?.status, `${prefix}.status`, ITEM_STATUSES),
-        ];
-        errors.push(...collectErrors(results));
+      const sectionData = data[section];
+      // Validate required text fields per section
+      if (section === 'tagline' || section === 'app_store_desc') {
+        const textCheck = validateString(sectionData?.text, `${section}.text`, 1);
+        if (!textCheck.valid) errors.push(textCheck.error);
+      } else if (section === 'landing_hero') {
+        const headlineCheck = validateString(sectionData?.headline, `${section}.headline`, 1);
+        if (!headlineCheck.valid) errors.push(headlineCheck.error);
+      } else if (section.startsWith('email_')) {
+        const subjectCheck = validateString(sectionData?.subject, `${section}.subject`, 1);
+        const bodyCheck = validateString(sectionData?.body, `${section}.body`, 1);
+        if (!subjectCheck.valid) errors.push(subjectCheck.error);
+        if (!bodyCheck.valid) errors.push(bodyCheck.error);
+      } else if (section === 'seo_meta') {
+        const titleCheck = validateString(sectionData?.title, `${section}.title`, 1);
+        const descCheck = validateString(sectionData?.description, `${section}.description`, 1);
+        if (!titleCheck.valid) errors.push(titleCheck.error);
+        if (!descCheck.valid) errors.push(descCheck.error);
+      } else if (section === 'blog_draft') {
+        const titleCheck = validateString(sectionData?.title, `${section}.title`, 1);
+        if (!titleCheck.valid) errors.push(titleCheck.error);
       }
     }
 
-    if (data?.blockers && Array.isArray(data.blockers)) {
-      for (let i = 0; i < data.blockers.length; i++) {
-        const b = data.blockers[i];
-        const prefix = `blockers[${i}]`;
-        const results = [
-          validateString(b?.description, `${prefix}.description`, 1),
-          validateEnum(b?.severity, `${prefix}.severity`, SEVERITY_LEVELS),
-          validateString(b?.mitigation, `${prefix}.mitigation`, 1),
-        ];
-        errors.push(...collectErrors(results));
-      }
-    }
-
-    if (errors.length > 0) { logger.warn('[Stage17] Validation failed', { errorCount: errors.length, errors }); }
+    if (errors.length > 0) { logger.warn('[Stage18-MarketingCopy] Validation failed', { errorCount: errors.length, errors }); }
     return { valid: errors.length === 0, errors };
   },
 
   computeDerived(data, { logger: _logger = console } = {}) {
-    // Dead code: all derivations handled by analysisStep.
     return { ...data };
   },
 };
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
-TEMPLATE.analysisStep = analyzeStage18;
+TEMPLATE.analysisStep = analyzeStage18MarketingCopy;
 ensureOutputSchema(TEMPLATE);
 
-export { CHECKLIST_CATEGORIES, ITEM_STATUSES, SEVERITY_LEVELS, BUILD_READINESS_DECISIONS, MIN_ITEMS_PER_CATEGORY };
+export { COPY_SECTIONS };
 export default TEMPLATE;


### PR DESCRIPTION
## Summary
- Rewrite stage-18 template from Pre-Build Checklist to Marketing Copy Studio
- New analysis step reads 12 upstream artifacts, generates 9 persona-targeted copy sections via LLM
- Update stage contracts for new upstream dependencies (S1,S4,S7,S8,S10,S11,S12,S13,S15,S16)
- Fallback copy generation when LLM unavailable
- Persona coverage validation

## Related
- Frontend: rickfelix/ehg (separate PR)
- Parent: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001

## Test plan
- [x] Template exports Marketing Copy Studio schema with 9 sections
- [x] Analysis step generates copy from upstream artifacts
- [x] Stage contracts declare correct upstream dependencies
- [x] Fallback copy includes persona name
- [ ] E2E: Create venture, process S18, verify 9 artifact types stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)