### PR TITLE
chore: add ESLint auto-fix to PostToolUse Edit/Write hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,6 +111,12 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/migration-execution-reminder.cjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "npx eslint --fix --no-error-on-unmatched-pattern $CLAUDE_FILE_PATHS 2>&1 | tail -5; npx tsc --noEmit --pretty 2>&1 | head -30 || true",
+            "timeout": 30,
+            "statusMessage": "Linting & type-checking..."
           }
         ]
       },
@@ -119,9 +125,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsc --noEmit --pretty 2>&1 | head -20 || true",
+            "command": "npx eslint --fix --no-error-on-unmatched-pattern $CLAUDE_FILE_PATHS 2>&1 | tail -5; npx tsc --noEmit --pretty 2>&1 | head -30 || true",
             "timeout": 30,
-            "statusMessage": "Type-checking..."
+            "statusMessage": "Linting & type-checking..."
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Upgrades PostToolUse Edit hook from tsc-only to ESLint --fix + tsc --noEmit
- Adds the same ESLint + tsc hook to PostToolUse Write (alongside existing migration reminder)
- Catches lint errors and orphaned syntax immediately after edits, not at commit time

## Test plan
- [x] Verify settings.json is valid JSON
- [x] Smoke tests pass (15/15)
- [ ] Edit a .js file and confirm ESLint + tsc runs automatically

Generated with [Claude Code](https://claude.com/claude-code)