### PR TITLE
feat(SD-MAN-ORCH-S18-S26-PIPELINE-001-C): S24 go-live API endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -57,6 +57,7 @@ import evaExitRoutes from './routes/eva-exit.js';
 import evaChatRoutes from './routes/eva-chat.js';
 import evaEconomicLensRoutes from './routes/eva-economic-lens.js';
 import stage17Routes from './routes/stage17.js';
+import stage24Routes from './routes/stage24.js';
 import githubRepoRoutes from './routes/github-repo.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 import { resumeIncompleteArchetypeJobs } from '../lib/eva/stage-17/auto-resume.js';
@@ -164,6 +165,8 @@ app.use('/api/eva/chat', requireAuth, evaChatRoutes);
 app.use('/api/eva/economic-lens', requireAuth, evaEconomicLensRoutes);
 // Stage 17 Design Refinement
 app.use('/api/stage17', requireAuth, stage17Routes);
+// Stage 24 Go Live
+app.use('/api/stage24', requireAuth, stage24Routes);
 app.use('/api/github', requireAuth, githubRepoRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);

--- a/server/routes/stage24.js
+++ b/server/routes/stage24.js
@@ -1,0 +1,90 @@
+/**
+ * Stage 24 Go Live API Routes
+ *
+ * Path: /api/stage24
+ *
+ * Endpoints:
+ *   POST /:ventureId/go-live - Mark venture as launched, record timestamp
+ *
+ * SD-MAN-ORCH-S18-S26-PIPELINE-001-C
+ *
+ * @module server/routes/stage24
+ */
+
+import { Router } from 'express';
+import { asyncHandler } from '../../lib/middleware/eva-error-handler.js';
+import { isValidUuid } from '../middleware/validate.js';
+
+const router = Router();
+
+/**
+ * POST /api/stage24/:ventureId/go-live
+ * Marks venture as launched and records the timestamp.
+ * Idempotent: returns 400 if already launched.
+ */
+router.post('/:ventureId/go-live', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+
+  // Verify venture exists
+  const { data: venture, error: ventureErr } = await supabase
+    .from('ventures')
+    .select('id, name')
+    .eq('id', ventureId)
+    .single();
+
+  if (ventureErr || !venture) {
+    return res.status(404).json({ error: 'Venture not found', code: 'VENTURE_NOT_FOUND' });
+  }
+
+  // Check if already launched by looking for existing artifact with launched_at
+  const { data: existing } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'blueprint_go_live')
+    .single();
+
+  if (existing?.artifact_data?.launched_at) {
+    return res.status(400).json({
+      error: 'Venture already launched',
+      code: 'ALREADY_LAUNCHED',
+      launched_at: existing.artifact_data.launched_at,
+    });
+  }
+
+  const launchedAt = new Date().toISOString();
+
+  // Store go-live artifact
+  const { error: artifactErr } = await supabase
+    .from('venture_artifacts')
+    .upsert({
+      venture_id: ventureId,
+      artifact_type: 'blueprint_go_live',
+      stage_number: 24,
+      artifact_data: {
+        launched_at: launchedAt,
+        launched_by: 'chairman',
+        venture_name: venture.name,
+      },
+    }, { onConflict: 'venture_id,artifact_type' });
+
+  if (artifactErr) {
+    console.error('[stage24-route] go-live artifact upsert error:', artifactErr.message);
+    return res.status(500).json({ error: 'Failed to record launch', code: 'ARTIFACT_ERROR' });
+  }
+
+  return res.status(200).json({
+    status: 'success',
+    data: {
+      launched_at: launchedAt,
+      venture_name: venture.name,
+    },
+  });
+}));
+
+export default router;


### PR DESCRIPTION
## Summary
- Add POST `/api/stage24/:ventureId/go-live` endpoint for chairman-triggered venture launch
- Register route in `server/index.js` behind `requireAuth` middleware
- Idempotent: returns 400 if already launched, 404 if venture not found

## Test plan
- [ ] POST with valid venture ID returns 200 + launched_at timestamp
- [ ] POST with already-launched venture returns 400
- [ ] POST with invalid UUID returns 400
- [ ] POST with non-existent venture returns 404
- [ ] Verify `venture_artifacts` has `blueprint_go_live` artifact after launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)