### PR TITLE
fix(sessions): worktree hook fires for all SessionStart + mid-session check CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,11 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/agent-compiler-hook.cjs",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
+            "timeout": 10
           }
         ]
       },
@@ -55,11 +60,6 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/capture-session-id.cjs",
             "timeout": 3
-          },
-          {
-            "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
-            "timeout": 10
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
     "session:cleanup": "node scripts/claude-session-coordinator.mjs cleanup",
     "session:info": "node scripts/claude-session-coordinator.mjs info",
     "session:worktree": "node scripts/session-worktree.js",
+    "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "handoff": "node scripts/handoff.js",
     "handoff:dry-run": "node scripts/unified-handoff-system-v2.js execute --dry-run",
     "handoff:list": "node scripts/handoff.js list",

--- a/scripts/session-check-concurrency.js
+++ b/scripts/session-check-concurrency.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Session Concurrency Check
+ *
+ * Detects other active Claude Code sessions on the same repo and reports
+ * whether working-tree contention is likely. Run at any time during a
+ * session (not only at start) to verify isolation before multi-file
+ * Write/Edit work.
+ *
+ * Exit codes:
+ *   0 - isolated (no concurrent sessions on same branch)
+ *   1 - concurrent session(s) detected on same or ambiguous branch
+ *   2 - could not determine state (missing credentials, query error)
+ *
+ * Usage:
+ *   node scripts/session-check-concurrency.js
+ *   npm run session:check-concurrency
+ *
+ * Complements the SessionStart auto-worktree hook
+ * (scripts/hooks/concurrent-session-worktree.cjs) which only fires once
+ * at session start based on point-in-time data. This CLI gives any
+ * session a way to re-check mid-run.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { execSync } from 'child_process';
+
+function getCurrentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore']
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getMySessionId() {
+  return process.env.CLAUDE_SESSION_ID || null;
+}
+
+async function main() {
+  const branch = getCurrentBranch();
+  const mySid = getMySessionId();
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[session:check-concurrency] missing SUPABASE_URL/SERVICE_ROLE_KEY — cannot query sessions');
+    process.exit(2);
+  }
+
+  const supabase = createClient(url, key);
+  const { data, error } = await supabase
+    .from('v_active_sessions')
+    .select('session_id,sd_key,current_branch,heartbeat_age_human,computed_status,hostname')
+    .eq('computed_status', 'active');
+
+  if (error) {
+    console.error('[session:check-concurrency] query failed:', error.message);
+    process.exit(2);
+  }
+
+  const others = (data || []).filter(s => s.session_id !== mySid);
+
+  // Same-branch contention: branch match, or either side is on main, or
+  // the other session's branch is unknown (null).
+  const onSameOrAmbiguousBranch = others.filter(s => {
+    if (!s.current_branch) return true;
+    if (!branch) return true;
+    if (s.current_branch === branch) return true;
+    if (s.current_branch === 'main' || branch === 'main') return true;
+    return false;
+  });
+
+  if (onSameOrAmbiguousBranch.length === 0) {
+    console.log('[ISOLATED] No contention detected.');
+    console.log(`  Branch: ${branch || '(unknown)'}`);
+    console.log(`  My session: ${mySid || '(CLAUDE_SESSION_ID not set)'}`);
+    if (others.length > 0) {
+      console.log(`  (${others.length} active session(s) on other branches — no contention)`);
+    }
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('[CONCURRENT SESSIONS DETECTED]');
+  console.log('='.repeat(60));
+  console.log(`  My branch:  ${branch || '(unknown)'}`);
+  console.log(`  My session: ${mySid || '(CLAUDE_SESSION_ID not set)'}`);
+  console.log('');
+  console.log(`  Other active sessions (same or ambiguous branch):`);
+  for (const s of onSameOrAmbiguousBranch) {
+    console.log(`    - ${s.session_id}`);
+    console.log(`        sd_key:    ${s.sd_key || '(none)'}`);
+    console.log(`        branch:    ${s.current_branch || '(unknown)'}`);
+    console.log(`        heartbeat: ${s.heartbeat_age_human || '(unknown)'}`);
+    console.log(`        host:      ${s.hostname || '(unknown)'}`);
+  }
+  console.log('');
+  console.log('  Working-tree contention risk. Options:');
+  console.log('    1. Create a worktree for this session:   npm run session:worktree');
+  console.log('    2. Coordinate writes with the other session(s)');
+  console.log('    3. If the other session is dead but its heartbeat is recent,');
+  console.log('       release via the LEO claim CLI before proceeding');
+  console.log('');
+  process.exit(1);
+}
+
+main().catch(e => {
+  console.error('[session:check-concurrency] error:', e.message);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Two fixes to prevent the working-tree contention that caused three parallel Claude Code sessions to experience stalled Writes earlier today.

### A. Move concurrent-session-worktree hook out of the `"startup"` matcher

Root cause of the incident: `scripts/hooks/concurrent-session-worktree.cjs` was configured with `matcher: "startup"` in `.claude/settings.json`, so it only fired for the specific *startup* SessionStart subtype. Resumed sessions, compaction-recovered sessions, and reconnect paths all skipped the hook entirely, so no worktree was ever auto-created — and four sessions ended up sharing one working tree. Git checkouts in one session then mutated the tree mid-PostToolUse-hook in the others, causing the **tool-result channel to emit `[Tool result missing due to internal error]` even though the Writes succeeded on disk**.

This PR moves the hook into the matcher-less SessionStart block so it runs for every session start path. `capture-session-id.cjs` stays in the `"startup"` block because it legitimately consumes the startup-event stdin payload.

### B. New `npm run session:check-concurrency` CLI

The SessionStart hook is point-in-time. If another session's heartbeat was stale at startup (common, since `v_active_sessions` filters by a 5-minute staleness window), the hook silently misses it. And if a session appears mid-run, there's no recheck.

New script `scripts/session-check-concurrency.js` gives any session an explicit way to verify isolation before Write/Edit work:
- Exit 0: isolated
- Exit 1: concurrent session(s) detected on same/ambiguous branch
- Exit 2: can't determine (credentials missing, query error)

Recommended workflow when contention is detected: `npm run session:worktree` to create an isolated `.worktrees/concurrent-<sid>/` directory.

## Deferred to follow-up

**Fix F (CLAUDE.md documentation)** — adding a *Parallel Session Safety* section. CLAUDE.md is auto-generated from the `leo_protocol_sections` DB table, so this needs a proper DB migration rather than an inline file edit. Deferred to keep this PR focused.

Also out of scope (separate investigations warranted, each worth its own SD):
- Why 3 of 4 active sessions lack PID marker files in `.claude/session-identity/` (breaks the hook's `getAliveMarkerSessionIds()` liveness fallback)
- Why 2 of 4 sessions have `current_branch=NULL` in `claude_sessions` (weakens any branch-aware logic)

## Test plan

- [ ] In a fresh Claude Code session, confirm `concurrent-session-worktree.cjs` now fires by checking its console output at SessionStart
- [ ] With at least one other active session on the same branch, run `npm run session:check-concurrency` and confirm exit code 1 + the advisory output
- [ ] With no concurrent sessions, run `npm run session:check-concurrency` and confirm exit code 0 + "ISOLATED" message
- [ ] Trigger the `"startup"` SessionStart subtype and confirm `capture-session-id.cjs` still fires correctly

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>