### PR TITLE
fix(migrations): correct/neutralize SQL files targeting non-existent llm_model_registry table

### DIFF
--- a/database/migrations/20260404_upgrade_llm_model_registry_frontier.sql
+++ b/database/migrations/20260404_upgrade_llm_model_registry_frontier.sql
@@ -2,39 +2,62 @@
 -- SD: SD-LEO-INFRA-LLM-MODEL-CONFIG-001
 -- Date: 2026-04-04
 -- Verified against live provider APIs on 2026-04-04
+--
+-- STATUS: NEVER EXECUTED AS WRITTEN. This migration targets a table
+-- named `llm_model_registry` which does not exist in this database.
+-- The actual table is `public.llm_models`. See
+-- database/migrations/20260422_add_claude_opus_4_7.sql for the pattern
+-- that should have been used.
+--
+-- The intended renames below were nevertheless applied to `llm_models`
+-- (verified 2026-04-22: rows `gpt-5.4`, `gpt-5.4-mini`,
+-- `claude-sonnet-4-6`, `claude-opus-4-6`, and `gemini-2.5-pro` are all
+-- present with the expected names and attributes). That state was
+-- achieved via a different code path — not this file.
+--
+-- To keep the historical record while preventing accidental execution
+-- (any runner that tries this would error on the missing table), the
+-- original UPDATE statements are commented out below. Read them as
+-- documentation of intent, not as active SQL.
 
 -- OpenAI: gpt-5.2 → gpt-5.4
-UPDATE llm_model_registry
-SET model_key = 'gpt-5.4',
-    model_name = 'GPT-5.4',
-    metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gpt-5.2", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
-WHERE model_key = 'gpt-5.2' AND provider_key = 'openai';
+-- UPDATE llm_model_registry
+-- SET model_key = 'gpt-5.4',
+--     model_name = 'GPT-5.4',
+--     metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gpt-5.2", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
+-- WHERE model_key = 'gpt-5.2' AND provider_key = 'openai';
 
 -- OpenAI: gpt-5-mini → gpt-5.4-mini
-UPDATE llm_model_registry
-SET model_key = 'gpt-5.4-mini',
-    model_name = 'GPT-5.4 Mini',
-    metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gpt-5-mini", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
-WHERE model_key = 'gpt-5-mini' AND provider_key = 'openai';
+-- UPDATE llm_model_registry
+-- SET model_key = 'gpt-5.4-mini',
+--     model_name = 'GPT-5.4 Mini',
+--     metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gpt-5-mini", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
+-- WHERE model_key = 'gpt-5-mini' AND provider_key = 'openai';
 
 -- Anthropic: claude-sonnet-4-20250514 → claude-sonnet-4-6
-UPDATE llm_model_registry
-SET model_key = 'claude-sonnet-4-6',
-    model_name = 'Claude Sonnet 4.6',
-    metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "claude-sonnet-4-20250514", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
-WHERE model_key = 'claude-sonnet-4-20250514' AND provider_key = 'anthropic';
+-- UPDATE llm_model_registry
+-- SET model_key = 'claude-sonnet-4-6',
+--     model_name = 'Claude Sonnet 4.6',
+--     metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "claude-sonnet-4-20250514", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
+-- WHERE model_key = 'claude-sonnet-4-20250514' AND provider_key = 'anthropic';
 
 -- Anthropic: claude-opus-4-5-20251101 → claude-opus-4-6
-UPDATE llm_model_registry
-SET model_key = 'claude-opus-4-6',
-    model_name = 'Claude Opus 4.6',
-    context_window = 1000000,
-    metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "claude-opus-4-5-20251101", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
-WHERE model_key = 'claude-opus-4-5-20251101' AND provider_key = 'anthropic';
+-- UPDATE llm_model_registry
+-- SET model_key = 'claude-opus-4-6',
+--     model_name = 'Claude Opus 4.6',
+--     context_window = 1000000,
+--     metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "claude-opus-4-5-20251101", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
+-- WHERE model_key = 'claude-opus-4-5-20251101' AND provider_key = 'anthropic';
 
 -- Google: gemini-1.5-pro → gemini-2.5-pro (was outdated in registry)
-UPDATE llm_model_registry
-SET model_key = 'gemini-2.5-pro',
-    model_name = 'Gemini 2.5 Pro',
-    metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gemini-1.5-pro", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
-WHERE model_key = 'gemini-1.5-pro' AND provider_key = 'google';
+-- UPDATE llm_model_registry
+-- SET model_key = 'gemini-2.5-pro',
+--     model_name = 'Gemini 2.5 Pro',
+--     metadata = COALESCE(metadata, '{}'::jsonb) || '{"upgraded_from": "gemini-1.5-pro", "upgraded_at": "2026-04-04", "upgrade_sd": "SD-LEO-INFRA-LLM-MODEL-CONFIG-001"}'::jsonb
+-- WHERE model_key = 'gemini-1.5-pro' AND provider_key = 'google';
+
+-- Verify current state (real table, run manually):
+--   SELECT model_key, model_name, status FROM llm_models
+--   WHERE model_key IN ('gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6',
+--                       'claude-opus-4-6', 'gemini-2.5-pro')
+--   ORDER BY model_key;

--- a/database/migrations/20260422_add_claude_opus_4_7.sql
+++ b/database/migrations/20260422_add_claude_opus_4_7.sql
@@ -1,53 +1,54 @@
 -- Migration: Add Claude Opus 4.7 to model registry, deprecate Opus 4.6
 -- Date: 2026-04-22
--- Context: Anthropic released Opus 4.7. Sonnet remains at 4.6 and Haiku at 4.5 —
--- only Opus advanced. Codebase default for 'generation' and 'complex-reasoning'
--- updated to claude-opus-4-7 in the same commit. See:
---   lib/config/model-config.js
---   lib/ai/multimodal-client.js
---   lib/brainstorm/provider-rotation.js
---   docs/reference/model-version-upgrade-runbook.md (Section 3)
+-- Applied: 2026-04-22 (manually, via corrected SQL; see HISTORY below)
+--
+-- HISTORY: The first version of this file (shipped in PR #3217, commit
+-- cc0a1e92c3) targeted table `llm_model_registry`, which does not exist
+-- in this database. The actual table is `llm_models`. This file has been
+-- rewritten to target the real table and uses INSERT WHERE NOT EXISTS so
+-- it is safe to re-run. DB state was applied manually on 2026-04-22.
+--
+-- Context: Anthropic released Opus 4.7. Sonnet stayed at 4.6 and Haiku
+-- at 4.5 — only Opus advanced. Code defaults for `generation` and
+-- `complex-reasoning` were updated to claude-opus-4-7 in PR #3217.
 
--- 1. Insert new Opus 4.7 row
-INSERT INTO llm_model_registry (
-  provider_key,
-  model_key,
-  model_name,
-  context_window,
-  metadata
+-- 1. Insert Opus 4.7 (leo_tier copied from the existing 4.6 row to preserve routing)
+INSERT INTO llm_models (
+  provider_id, model_key, model_name, model_family, model_version,
+  model_tier, context_window, max_output_tokens,
+  supports_function_calling, supports_vision, supports_streaming, supports_system_prompt,
+  pricing, status, release_date, metadata, leo_tier
 )
-VALUES (
-  'anthropic',
-  'claude-opus-4-7',
-  'Claude Opus 4.7',
-  1000000,
+SELECT
+  (SELECT id FROM llm_providers WHERE provider_key = 'anthropic'),
+  'claude-opus-4-7', 'Claude Opus 4.7', 'claude', '4.7',
+  'flagship', 1000000, 8192,
+  true, true, true, true,
+  '{"input_per_1m": 15.00, "output_per_1m": 75.00}'::jsonb,
+  'active', '2026-04-22',
   jsonb_build_object(
-    'added_at', '2026-04-22',
-    'added_sd', 'ad-hoc model upgrade (2026-04-22)',
     'supersedes', 'claude-opus-4-6',
-    'pricing_per_1m', jsonb_build_object('input', 15.00, 'output', 75.00),
-    'supports_1m_context', true,
-    'supports_vision', true,
-    'supports_function_calling', true
-  )
-)
-ON CONFLICT (provider_key, model_key) DO UPDATE
-SET model_name    = EXCLUDED.model_name,
-    context_window = EXCLUDED.context_window,
-    metadata      = llm_model_registry.metadata || EXCLUDED.metadata;
+    'added_at', '2026-04-22',
+    'added_by', 'ad-hoc model upgrade'
+  ),
+  (SELECT leo_tier FROM llm_models WHERE model_key = 'claude-opus-4-6')
+WHERE NOT EXISTS (
+  SELECT 1 FROM llm_models WHERE model_key = 'claude-opus-4-7'
+);
 
--- 2. Deprecate Opus 4.6 (keep the row — referenced by usage logs)
-UPDATE llm_model_registry
-SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
-  'status', 'deprecated',
-  'deprecated_at', '2026-04-22',
-  'superseded_by', 'claude-opus-4-7'
-)
-WHERE provider_key = 'anthropic'
-  AND model_key    = 'claude-opus-4-6';
+-- 2. Deprecate Opus 4.6 (row kept — usage logs reference it)
+UPDATE llm_models
+SET status = 'deprecated',
+    deprecation_date = CURRENT_DATE,
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'superseded_by', 'claude-opus-4-7',
+      'deprecated_at', CURRENT_DATE::text
+    )
+WHERE model_key = 'claude-opus-4-6'
+  AND status != 'deprecated';
 
 -- 3. Verify
---   SELECT model_key, model_name, metadata->>'status' AS status
---   FROM llm_model_registry
---   WHERE provider_key = 'anthropic' AND model_key LIKE 'claude-opus-4-%'
+--   SELECT model_key, status, deprecation_date, context_window
+--   FROM llm_models
+--   WHERE model_key LIKE 'claude-opus-4-%'
 --   ORDER BY model_key;


### PR DESCRIPTION
## Summary

Two checked-in migration files target a table named `llm_model_registry` that does not exist in this database. The actual table is `public.llm_models`. Running either file against the current schema would error.

### Files

**`database/migrations/20260422_add_claude_opus_4_7.sql`** — shipped in PR #3217 earlier today. Rewritten to target `llm_models` with the correct schema (status/deprecation_date as top-level columns; leo_tier copied from the existing 4.6 row to preserve routing). Uses `INSERT ... WHERE NOT EXISTS` so it is safe to re-run. The DB state (`claude-opus-4-7` row added, `claude-opus-4-6` marked deprecated) was applied manually on 2026-04-22 before this rewrite — the SQL file is now correct for anyone reading it as a record of what happened.

**`database/migrations/20260404_upgrade_llm_model_registry_frontier.sql`** — pre-existing, same wrong-table-name bug. The intended renames (`gpt-5.2`→`gpt-5.4`, `gpt-5-mini`→`gpt-5.4-mini`, `claude-sonnet-4-20250514`→`claude-sonnet-4-6`, `claude-opus-4-5-20251101`→`claude-opus-4-6`, `gemini-1.5-pro`→`gemini-2.5-pro`) were evidently applied via a different code path — verified on 2026-04-22 that all target rows are present in `llm_models` with the expected attributes. This PR preserves the historical record (the UPDATE statements stay as documentation of intent) but comments them all out so a naïve migration runner cannot accidentally execute them and error.

## Scope

Small: two files, no behavior change, no DB writes in this PR. The DB itself was already reconciled in a separate manual step documented in the rewritten 20260422 header.

Not attempting to back-fill which mechanism originally wrote those rows to `llm_models` — that's out of scope and probably not recoverable from here.

## Test plan

- [ ] Review the 20260422 rewrite and confirm the INSERT/UPDATE logic matches what's in the DB today:
      `SELECT model_key, status, deprecation_date, context_window, leo_tier FROM llm_models WHERE model_key LIKE 'claude-opus-4-%' ORDER BY model_key;`
- [ ] Run the rewritten 20260422 against the DB — it should be a no-op (INSERT WHERE NOT EXISTS sees the row already; UPDATE WHERE status != 'deprecated' sees 4.6 already deprecated)
- [ ] Attempt to execute the 20260404 file — expected: no SQL runs because all UPDATE lines are commented out; migration runner should complete successfully as a no-op

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>