### PR TITLE
fix(hooks): escape $env in PostToolUse Bash handoff-reminder command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -Command \"if ($env:CLAUDE_TOOL_INPUT -match 'handoff') { Write-Output '[REMINDER] Quality over speed. Follow the LEO protocol diligently.' }\"",
+            "command": "powershell.exe -NoProfile -Command \"if (\\$env:CLAUDE_TOOL_INPUT -match 'handoff') { Write-Output '[REMINDER] Quality over speed. Follow the LEO protocol diligently.' }\"",
             "timeout": 2
           },
           {


### PR DESCRIPTION
## Summary

Every Bash tool call on Windows currently emits a non-blocking error that clutters the tool output:

```
:CLAUDE_TOOL_INPUT : The term ':CLAUDE_TOOL_INPUT' is not recognized
as the name of a cmdlet, function, script file, ...
```

Observed in three concurrent Claude Code sessions today.

## Root cause

The `PostToolUse` hook for `matcher: "Bash"` in `.claude/settings.json` line 92 invokes PowerShell inline:

```
powershell.exe -NoProfile -Command "if ($env:CLAUDE_TOOL_INPUT -match 'handoff') { ... }"
```

Claude Code's hook runner on Windows pipes this command string through bash (git-bash/MSYS2) before handing it to `powershell.exe`. Bash sees `$env` as an unset shell variable and expands it to the empty string, leaving PowerShell with:

```
if (:CLAUDE_TOOL_INPUT -match 'handoff') { ... }
```

— which PowerShell rejects because `:CLAUDE_TOOL_INPUT` isn't a valid identifier.

## Fix

Escape the dollar (`\$env` in the JSON string value) so bash passes `$env` through literally. PowerShell then parses `$env:CLAUDE_TOOL_INPUT` as the environment-variable accessor it was always meant to be.

The hook is cosmetic — it prints a reminder when the handled Bash command's input matches `'handoff'` — so the regression produced noise rather than broken behavior. But the noise appeared on every Bash tool call across all active sessions.

## Test plan

- [ ] Invoke any Bash tool call in a fresh Claude Code session — the `:CLAUDE_TOOL_INPUT` error should no longer appear
- [ ] Invoke a Bash call whose input contains the word `handoff` — the reminder `[REMINDER] Quality over speed...` should appear
- [ ] Invoke a Bash call without `handoff` — no output from this hook

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>