### PR TITLE
docs(protocol): add parallel-session safety to Session Prologue (DB migration)

### DIFF
--- a/database/migrations/20260422_add_parallel_session_safety_to_prologue.sql
+++ b/database/migrations/20260422_add_parallel_session_safety_to_prologue.sql
@@ -1,0 +1,25 @@
+-- Migration: Add parallel-session safety to Session Prologue
+-- Date: 2026-04-22
+-- Context: Four parallel Claude Code sessions collided in a shared
+-- working tree today, causing tool-result "internal error" responses
+-- on writes that actually succeeded (PR #3219 root-caused and fixed
+-- the auto-worktree hook; PR #3219 also introduced
+-- `npm run session:check-concurrency`). This adds a prologue rule so
+-- future sessions surface the safety check proactively.
+--
+-- Appends item 8 to the leo_protocol_sections row with
+-- section_type='session_prologue' (id=209 under protocol
+-- leo-v4-3-3-ui-parity).
+
+-- Safety check: only apply if the text is not already present
+UPDATE leo_protocol_sections
+SET content = content || E'\n' ||
+'8. **Parallel-session safety** - In shared-working-tree sessions, run `npm run session:check-concurrency` before Write/Edit work; if contention is detected, isolate with `npm run session:worktree`
+> Why: Parallel Claude Code sessions sharing one working tree cause tool-result "internal error" messages when one session''s `git checkout` mutates files mid-PostToolUse-hook in another session. The SessionStart auto-worktree hook (`scripts/hooks/concurrent-session-worktree.cjs`) catches some cases but is point-in-time; the CLI gives any session an explicit isolation check.'
+WHERE section_type = 'session_prologue'
+  AND protocol_id = 'leo-v4-3-3-ui-parity'
+  AND content NOT LIKE '%Parallel-session safety%';
+
+-- Verify
+--   SELECT LENGTH(content), content FROM leo_protocol_sections
+--   WHERE section_type = 'session_prologue' AND protocol_id = 'leo-v4-3-3-ui-parity';


### PR DESCRIPTION
## Summary

Completes **Fix F** from the earlier process-review session. Adds item 8 to the `session_prologue` section of the LEO protocol via an idempotent DB UPDATE, so future Claude Code sessions surface the parallel-session safety check proactively.

### The new prologue item

> **8. Parallel-session safety** - In shared-working-tree sessions, run `npm run session:check-concurrency` before Write/Edit work; if contention is detected, isolate with `npm run session:worktree`
>
> Why: Parallel Claude Code sessions sharing one working tree cause tool-result "internal error" messages when one session's `git checkout` mutates files mid-PostToolUse-hook in another session. The SessionStart auto-worktree hook (`scripts/hooks/concurrent-session-worktree.cjs`) catches some cases but is point-in-time; the CLI gives any session an explicit isolation check.

## Why this had to be a DB migration, not an inline CLAUDE.md edit

CLAUDE.md (and the other CLAUDE_*.md files) is auto-generated from the `leo_protocol_sections` table by `scripts/generate-claude-md-from-db.js`. Editing the file directly would be clobbered on the next regen. The DB is the source of truth, so the addition is UPDATE-driven.

## State of things

- **DB change applied** 2026-04-22 before this commit was pushed. Verified: section length went from 2343 → 2917 chars; tail now contains "Parallel-session safety" text.
- **CLAUDE.md not regenerated in this PR** — deliberate. The generator rebuilds all CLAUDE_*.md files at once and would mingle any other pending DB changes into the diff. The next natural `generate-claude-md-from-db.js` run (which happens frequently during normal protocol maintenance) will materialize the new item.
- **Re-run guard**: SQL uses `content NOT LIKE '%Parallel-session safety%'` so the migration is idempotent.

## Context chain

This is the 5th and final PR in a batch addressing a multi-session infrastructure incident discovered earlier today:
1. #3217 — model Opus 4.6→4.7 refresh + PostToolUse tsc hook regression fix (the original root cause of tool-result "internal error")
2. #3219 — auto-worktree hook matcher fix + `session:check-concurrency` CLI
3. #3220 — migration files targeting non-existent `llm_model_registry` table
4. #3221 — PostToolUse Bash `$env` escape fix (cosmetic, removed per-call error noise)
5. **#3222 (this PR)** — prologue docs for parallel-session safety

## Test plan

- [ ] Run `node scripts/generate-claude-md-from-db.js` and confirm CLAUDE.md's Session Prologue section now has 8 items ending with "Parallel-session safety"
- [ ] Inspect the DB row:
      `SELECT LENGTH(content), RIGHT(content, 400) FROM leo_protocol_sections WHERE section_type='session_prologue' AND protocol_id='leo-v4-3-3-ui-parity';`
- [ ] Re-run the migration SQL — verify it is a no-op the second time (NOT LIKE guard prevents duplicate text)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>