### PR TITLE
fix(claude-md): reword router SD Continuation table — remove contradictory TERMINAL label

### DIFF
--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -128,15 +128,17 @@ User may override at any point by stating \`[MODE: product]\` or \`[MODE: campai
 
 ## SD Continuation
 
+**AUTO-PROCEED default: ON. Orchestrator Chaining default: OFF.** (Both configurable via \`/leo settings\`.)
+
 | Transition | AUTO-PROCEED | Chaining | Behavior |
 |-----------|:---:|:---:|----------|
-| Handoff (not final) | * | * | **TERMINAL** - phase work required |
+| Handoff completes (not LEAD-FINAL-APPROVAL) | * | * | **Phase work required** — do the phase's work, then invoke next handoff. No auto-chaining between handoffs. |
 | Child → next child | ON | * | Auto-continue |
 | Orchestrator done | ON | ON | /learn → auto-continue |
 | Orchestrator done | ON | OFF | /learn → show queue → PAUSE |
 | All blocked | * | * | PAUSE |
 
-> Why (TERMINAL): A non-final handoff means gate-validated state must be written to the DB before the next phase begins. Skipping this orphans the SD — the next session finds no handoff record and cannot determine what was approved or completed.
+> Why ("Phase work required"): Handoffs are sequence points, not session-stop points. A non-final handoff means the current phase's artifact (PRD, implementation, verification) is committed to the DB, and the next phase's work must be done before the next handoff fires. AUTO-PROCEED keeps the session moving through that work autonomously; it does NOT skip the work. The **SD Continuation Truth Table** (in CLAUDE_CORE.md) is the authoritative, fully-enumerated version of this matrix — consult it when behavior is ambiguous.
 
 ## Work Item Routing
 


### PR DESCRIPTION
## Summary

- Replaces the CLAUDE.md router's `TERMINAL` label for non-final handoffs with `Phase work required`, which doesn't read as "session stops here".
- Clarifies the "Why" line: handoffs are sequence points, not session-stop points; AUTO-PROCEED keeps the session moving through phase work autonomously, it does NOT skip the work.
- Adds explicit `AUTO-PROCEED default: ON. Orchestrator Chaining default: OFF.` line (Chaining default was previously only buried in D15 of the AUTO-PROCEED Mode section in CLAUDE_CORE.md).

## Why

The `TERMINAL` wording contradicted the **Autonomous Continuation** directive in `CLAUDE_LEAD.md` / `CLAUDE_PLAN.md` / `CLAUDE_EXEC.md`, which instructs sessions to continue through handoffs without asking permission. The intended meaning was "phase work is required before the next handoff fires" — i.e., don't auto-chain handoffs, but DO autonomously do the phase work between them. As written, two different parts of the protocol told a reader two different things.

This was Issue #3 (TERMINAL vs autonomous continuation) and Issue #15 (Orchestrator Chaining default not stated in router) of the 2026-04-22 protocol-contradiction audit (16 issues total).

## Relationship to the other 14 issues

The other 14 audit findings were fixes to DB content in `leo_protocol_sections` (threshold values, sd_type enum membership, N-question gate phrasing, pause-condition list harmonization, etc.). Those were applied via a one-shot migration (the gitignored `scripts/apply-*.mjs` pattern) and are already live in the DB. This PR contains only the **code-level** piece of the harmonization — specifically the hardcoded router-summary table in `file-generators.js` that can't be addressed via DB update.

## Test plan

- [x] `node scripts/generate-claude-md-from-db.js` produces CLAUDE.md with the new wording (verified during the session).
- [x] The longer, canonical `SD Continuation Truth Table` in CLAUDE_CORE.md (already DB-sourced) is still the authoritative version; the router summary now points to it explicitly.
- [ ] Downstream readers of CLAUDE.md (no automated consumers today; verified by grep that no scripts key on the literal string \`TERMINAL\`).

## Follow-up

A Strategic Directive for a **protocol consistency linter** (`SD-PROTOCOL-LINTER-001`) is already registered to prevent this class of drift from recurring. This PR addresses the single code-level instance that slipped through pre-linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)