### PR TITLE
feat(SD-PROTOCOL-LINTER-001): audit schema for protocol consistency linter (slice 1/n)

### DIFF
--- a/database/migrations/20260422_protocol_linter_tables.sql
+++ b/database/migrations/20260422_protocol_linter_tables.sql
@@ -1,0 +1,136 @@
+-- SD-PROTOCOL-LINTER-001: Protocol Consistency Linter audit schema
+-- Creates three tables for the linter's audit trail and adds an anchor_topic
+-- column to leo_protocol_sections for the anchor-uniqueness rule.
+--
+-- Idempotent: all DDL uses IF EXISTS / IF NOT EXISTS guards so re-running
+-- is safe across dev, staging, and prod environments.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. leo_lint_rules — rule registry with promotion state
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS leo_lint_rules (
+  rule_id              TEXT PRIMARY KEY,
+  severity             TEXT NOT NULL CHECK (severity IN ('warn', 'block')),
+  description          TEXT NOT NULL,
+  source_path          TEXT NOT NULL,
+  enabled              BOOLEAN NOT NULL DEFAULT TRUE,
+  promoted_from_warn_at TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE leo_lint_rules IS
+  'Registry of protocol-lint rules. Severity defaults to warn; promotion to block requires 2+ clean regens (see /admin/protocol-lint). SD-PROTOCOL-LINTER-001.';
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_rules_enabled
+  ON leo_lint_rules (enabled)
+  WHERE enabled = TRUE;
+
+-- ============================================================================
+-- 2. leo_lint_run_history — one row per regen/audit/bypass run
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS leo_lint_run_history (
+  run_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trigger           TEXT NOT NULL CHECK (trigger IN ('regen', 'audit', 'bypass', 'precommit')),
+  total_violations  INTEGER NOT NULL DEFAULT 0,
+  critical_count    INTEGER NOT NULL DEFAULT 0,
+  passed            BOOLEAN NOT NULL,
+  bypass_reason     TEXT,
+  started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at          TIMESTAMPTZ,
+  duration_ms       INTEGER,
+  initiator         TEXT,
+  metadata          JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+COMMENT ON TABLE leo_lint_run_history IS
+  'Append-only log of every linter run. trigger=bypass rows track --skip-lint invocations for rate-limiting (3/week) and chairman dashboard reporting. SD-PROTOCOL-LINTER-001.';
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_run_history_trigger_started
+  ON leo_lint_run_history (trigger, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_run_history_started
+  ON leo_lint_run_history (started_at DESC);
+
+-- ============================================================================
+-- 3. leo_lint_violations — one row per violation detected
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS leo_lint_violations (
+  violation_id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id         UUID REFERENCES leo_lint_run_history (run_id) ON DELETE SET NULL,
+  rule_id        TEXT NOT NULL REFERENCES leo_lint_rules (rule_id) ON DELETE RESTRICT,
+  section_id     UUID,
+  file_path      TEXT,
+  severity       TEXT NOT NULL CHECK (severity IN ('warn', 'block')),
+  message        TEXT NOT NULL,
+  context        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status         TEXT NOT NULL DEFAULT 'open'
+                   CHECK (status IN ('open', 'acknowledged', 'resolved', 'false_positive')),
+  status_reason  TEXT,
+  detected_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at    TIMESTAMPTZ,
+  resolved_by    TEXT
+);
+
+COMMENT ON TABLE leo_lint_violations IS
+  'Append-only audit of every violation produced by the protocol linter. status=false_positive flags rules for review when FP rate exceeds 10%. SD-PROTOCOL-LINTER-001.';
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_violations_rule_detected
+  ON leo_lint_violations (rule_id, detected_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_violations_status_detected
+  ON leo_lint_violations (status, detected_at DESC)
+  WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_violations_run
+  ON leo_lint_violations (run_id);
+
+CREATE INDEX IF NOT EXISTS idx_leo_lint_violations_section
+  ON leo_lint_violations (section_id)
+  WHERE section_id IS NOT NULL;
+
+-- ============================================================================
+-- 4. anchor_topic column on leo_protocol_sections
+--    Supports the anchor-uniqueness rule (detects duplicated authoritative
+--    lists across sections).
+-- ============================================================================
+ALTER TABLE leo_protocol_sections
+  ADD COLUMN IF NOT EXISTS anchor_topic TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_leo_protocol_sections_anchor_topic
+  ON leo_protocol_sections (anchor_topic)
+  WHERE anchor_topic IS NOT NULL;
+
+COMMENT ON COLUMN leo_protocol_sections.anchor_topic IS
+  'Tags a section as the authoritative source for a specific topic (e.g., "9-question-gate", "pause-points"). Enables anchor-uniqueness rule: more than one section with the same anchor_topic is a violation. SD-PROTOCOL-LINTER-001.';
+
+-- ============================================================================
+-- 5. updated_at trigger for leo_lint_rules
+-- ============================================================================
+CREATE OR REPLACE FUNCTION tg_leo_lint_rules_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_leo_lint_rules_updated_at ON leo_lint_rules;
+CREATE TRIGGER trg_leo_lint_rules_updated_at
+  BEFORE UPDATE ON leo_lint_rules
+  FOR EACH ROW
+  EXECUTE FUNCTION tg_leo_lint_rules_updated_at();
+
+COMMIT;
+
+-- Rollback (manual, for reference):
+-- BEGIN;
+-- DROP TRIGGER IF EXISTS trg_leo_lint_rules_updated_at ON leo_lint_rules;
+-- DROP FUNCTION IF EXISTS tg_leo_lint_rules_updated_at();
+-- DROP TABLE IF EXISTS leo_lint_violations;
+-- DROP TABLE IF EXISTS leo_lint_run_history;
+-- DROP TABLE IF EXISTS leo_lint_rules;
+-- ALTER TABLE leo_protocol_sections DROP COLUMN IF EXISTS anchor_topic;
+-- COMMIT;


### PR DESCRIPTION
## Summary

First slice of **SD-PROTOCOL-LINTER-001** (Protocol Consistency Linter for LEO CLAUDE.md Family). Lays the audit-schema foundation that every subsequent slice writes to.

### What this PR contains

`database/migrations/20260422_protocol_linter_tables.sql` (~110 LOC SQL):

- **`leo_lint_rules`** — rule registry with `severity` (warn|block), `promoted_from_warn_at` timestamp. New rules default to warn; promotion requires 2+ clean regens (slice 4).
- **`leo_lint_run_history`** — append-only run log (regen/audit/bypass/precommit). Bypass rate-limit (3/week) queries this table.
- **`leo_lint_violations`** — append-only violation audit. `status` supports `open|acknowledged|resolved|false_positive` for per-violation FP overrides (rules with >10% FP rate auto-flagged for review).
- **`leo_protocol_sections.anchor_topic`** — nullable column tagging the authoritative section for a topic (e.g., "9-question-gate", "pause-points"). Anchor-uniqueness rule fires if >1 section shares an `anchor_topic`.
- Indexes on the two hot-path queries: rule-filtered violation lookup (dashboard) and status-open filter (active-violations widget).
- `updated_at` trigger on `leo_lint_rules`.

Migration is **idempotent** (`CREATE ... IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`) with a commented rollback block inline.

### Why ship as a slice

Full EXEC for this SD is ~2000 LOC (engine + CLI + 12 rules + dashboard + docs). Infrastructure PRs cap at 150 LOC per CLAUDE_CORE. Slicing keeps reviews tractable and each slice independently deployable:

| Slice | Contents | LOC est |
|------|----------|---------|
| **1 (this PR)** | Audit schema migration | 136 |
| 2 | Rule-loader + engine + 3 fixtures | ~250 |
| 3 | Regen integration (warn-only) | ~60 |
| 4 | CLI: `protocol:lint / :test / :promote` | ~200 |
| 5 | 9 additional seed rules with fixtures | ~400 |
| 6 | `/admin/protocol-lint` dashboard page | ~300 |
| 7 | `CLAUDE_CORE.md` docs + LEAD-FINAL handoff | ~50 |

### LEO phase state

- **SD**: SD-PROTOCOL-LINTER-001 (infrastructure, priority=high)
- **Status**: in_progress (EXEC phase)
- **LEAD-TO-PLAN**: PASS 93%
- **PLAN-TO-EXEC**: PASS 96%
- PRD: PRD-SD-PROTOCOL-LINTER-001 (approved, 7 FRs + 8 user stories)
- **Vision**: VISION-PROTOCOL-LINTER-L2-001
- **Arch**: ARCH-PROTOCOL-LINTER-001

### Test plan

- [ ] `database-agent` applies migration against staging DB (DRY RUN first)
- [ ] Verify 3 tables created: `leo_lint_rules`, `leo_lint_run_history`, `leo_lint_violations`
- [ ] Verify `leo_protocol_sections.anchor_topic` column present and nullable
- [ ] Confirm all 4 indexes created
- [ ] Confirm `trg_leo_lint_rules_updated_at` trigger fires on UPDATE
- [ ] Re-run migration — confirm idempotent (no errors, no duplicate objects)
- [ ] Run rollback block — confirm clean teardown

### Not in this PR
No rules, no engine code, no CLI, no dashboard, no regen integration. All arrive in subsequent slices. The `leo_lint_rules` table starts empty; the linter is a no-op until slice 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)