### PR TITLE
QF-20260422-740: Unify SD completeness threshold across LEAD-TO-PLAN output

### DIFF
--- a/scripts/verify-l2p/index.js
+++ b/scripts/verify-l2p/index.js
@@ -113,7 +113,7 @@ export class LeadToPlanVerifier {
       if (!sdValidation.valid || sdValidation.percentage < effectiveMinScore) {
         return rejectHandoff(this.supabase, sdId, 'SD_INCOMPLETE', 'Strategic Directive does not meet completeness standards', {
           sdValidation,
-          requiredScore: this.sdRequirements.minimumScore,
+          requiredScore: effectiveMinScore,
           actualScore: sdValidation.percentage
         });
       }
@@ -172,7 +172,7 @@ export class LeadToPlanVerifier {
       console.log('\n✅ HANDOFF APPROVED');
       console.log('='.repeat(50));
       console.log('✅ Strategic Directive is complete and approved');
-      console.log(`✅ SD completeness score: ${sdValidation.percentage}% (≥${this.sdRequirements.minimumScore}%)`);
+      console.log(`✅ SD completeness score: ${sdValidation.percentage}% (≥${effectiveMinScore}%)`);
       console.log('✅ Business objectives clearly defined');
       console.log('✅ Success metrics are measurable');
       console.log('✅ Feasibility confirmed');


### PR DESCRIPTION
## Summary

Fixes inconsistent completeness threshold reporting in `scripts/verify-l2p/index.js`. The gate decision used `effectiveMinScore` (SD-type-aware, e.g. 70% for infrastructure), but the rejection payload and the approval log reported the unadjusted base `SD_REQUIREMENTS.minimumScore` (90%). Within a single run, the operator saw two different thresholds — "threshold: 70%, type: infrastructure" in the header, "Minimum required: 90%" in the rejection message.

## Changes

- `scripts/verify-l2p/index.js:116` — rejectHandoff payload `requiredScore` now uses `effectiveMinScore` (matches the gate decision)
- `scripts/verify-l2p/index.js:175` — HANDOFF APPROVED log line now uses `effectiveMinScore`

Two lines changed. For SD types without overrides, `effectiveMinScore` equals `SD_REQUIREMENTS.minimumScore` so behavior is identical — no regression. For `bugfix / fix / refactor / documentation / infrastructure / database`, the reported threshold now matches what was actually enforced.

## Evidence

LEAD-TO-PLAN handoff for `SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001` on 2026-04-22 (failure_id `4b3c3f26-6cde-4b8a-9630-01b984571569`) printed:

- Header: `📊 SD Completeness Score: 70% (threshold: 70%, type: infrastructure)`
- Rejection: `Current SD score: 70%. Minimum required: 90%`

Same score, same run, two thresholds.

## Test plan

- [ ] Re-run the failed handoff and confirm both messages report 70% (type: infrastructure override applied)
- [ ] Run LEAD-TO-PLAN against a `feature` SD and confirm both messages report 90% (no override → effectiveMinScore falls back to base)
- [ ] No unit tests exist for `LeadToPlanVerifier`; fix is 2 lines with clear substitution semantics

## Quick-fix context

Tier 1 auto-approve QF (20 LOC estimated, 2 actual). Created during triage of systemic LEAD handoff issues surfaced on 2026-04-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)