### PR TITLE
feat(SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A): scope_slice inheritance model + PRD deliverable validation

### DIFF
--- a/database/migrations/20260423_add_scope_slice_to_sds.sql
+++ b/database/migrations/20260423_add_scope_slice_to_sds.sql
@@ -1,0 +1,28 @@
+-- Migration: Add scope_slice JSONB column to strategic_directives_v2
+-- SD: SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A
+-- Purpose: Child SDs can declare the slice of their parent orchestrator arch plan
+--          they claim, so scope-completion-gate filters parent deliverables before scoring.
+-- Shape:   {stages?: number[], deliverable_globs?: string[]}
+-- Safety:  Nullable, no default — metadata-only ADD COLUMN on PostgreSQL 11+ (confirmed by DATABASE sub-agent).
+--          Wrapped with lock_timeout=5s to avoid queuing behind long-running reads on pooler connections.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE strategic_directives_v2
+  ADD COLUMN IF NOT EXISTS scope_slice JSONB;
+
+COMMENT ON COLUMN strategic_directives_v2.scope_slice IS
+  'Optional slice of parent orchestrator scope this child claims. Shape: {stages?: number[], deliverable_globs?: string[]}. When set, scope-completion-gate filters parent arch plan deliverables through this slice before scoring. When NULL, gate scores the full parent deliverable set (pre-SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A behavior).';
+
+COMMIT;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- ROLLBACK (commented — uncomment and run to revert):
+--
+-- BEGIN;
+-- SET LOCAL lock_timeout = '5s';
+-- ALTER TABLE strategic_directives_v2 DROP COLUMN IF EXISTS scope_slice;
+-- COMMIT;
+-- ─────────────────────────────────────────────────────────────────────────

--- a/docs/reference/sd-key-generator-guide.md
+++ b/docs/reference/sd-key-generator-guide.md
@@ -514,8 +514,40 @@ The `/leo create` command uses SDKeyGenerator through `leo-create-sd.js`:
 /leo create --from-uat <test-id>
 /leo create --from-learn <pattern-id>
 /leo create --from-feedback <feedback-id>
-/leo create --from-plan [path]      # NEW: Create from Claude Code plan
-/leo create --child <parent-key> [index]
+/leo create --from-plan [path]      # Create from Claude Code plan
+/leo create --child <parent-key> [index] [--scope-slice <JSON>]
+```
+
+### `--scope-slice` flag (child SDs only)
+
+When creating a child of an orchestrator, use `--scope-slice` to declare the
+slice of parent scope this child claims. The scope-completion gate will then
+filter parent deliverables through this slice before scoring, preventing
+false-positive completion failures on inherited children.
+
+**Shape**: `{stages?: number[], deliverable_globs?: string[]}` — both fields
+optional; if both are present, filter is intersection (deliverable must match
+both).
+
+**Example**:
+```bash
+# Child claims only stage-18 deliverables from parent arch plan
+/leo create --child SD-PARENT-ORCH-001 --scope-slice='{"stages":[18]}'
+
+# Child claims specific file globs
+/leo create --child SD-PARENT-ORCH-001 --scope-slice='{"deliverable_globs":["src/auth/**"]}'
+
+# Intersection: stage-18 AND inside src/
+/leo create --child SD-PARENT-ORCH-001 --scope-slice='{"stages":[18],"deliverable_globs":["src/**"]}'
+```
+
+Malformed JSON exits non-zero with a clear error. Omitting the flag produces
+a child with `scope_slice=NULL` (gate falls back to pre-slice behavior, or to
+a soft-pass when `metadata.inherited_from_parent` is set).
+
+See `database/migrations/20260423_add_scope_slice_to_sds.sql` for the column
+definition and `scripts/modules/handoff/gates/scope-completion-gate.js` for
+filter/soft-pass implementation.
 ```
 
 See `.claude/commands/leo.md` for full command documentation.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -455,6 +455,21 @@ async function createChild(parentKey, index = 0, overrides = {}) {
       .eq('sd_key', sdKey);
   }
 
+  // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-001):
+  // Persist scope_slice when provided via --scope-slice flag.
+  // Note: separate UPDATE to avoid changing createSD signature; schema added 2026-04-23.
+  if (overrides.scopeSlice) {
+    const { error: sliceErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ scope_slice: overrides.scopeSlice })
+      .eq('sd_key', sdKey);
+    if (sliceErr) {
+      console.warn(`[createChild] ⚠️  Failed to persist scope_slice (non-fatal): ${sliceErr.message}`);
+    } else {
+      console.log(`   scope_slice set: ${JSON.stringify(overrides.scopeSlice)}`);
+    }
+  }
+
   // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Assert parent claim before returning child
   // Verifies the creating session holds the parent SD claim
   try {
@@ -1525,6 +1540,9 @@ Flags:
                         guardrail (required when scope contains migration/schema keywords).
   --security-reviewed   Set metadata.security_reviewed=true to satisfy GR-SECURITY-BASELINE
                         guardrail (required when scope contains auth/credential/RLS keywords).
+  --scope-slice <JSON>  (--child only) Declare the slice of parent orchestrator scope this
+                        child claims. JSON shape: {stages?: number[], deliverable_globs?: string[]}.
+                        Example: --scope-slice='{"stages":[18]}'
   --help             Show this help message
 
 Dependency Field Guide:
@@ -1637,12 +1655,52 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       if (childArchKeyIdx !== -1 && args[childArchKeyIdx + 1]) {
         childOverrides.archKey = args[childArchKeyIdx + 1];
       }
+      // Parse --scope-slice for child creation (SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A, US-001)
+      // Accepts both `--scope-slice=<json>` and `--scope-slice <json>` forms.
+      let childScopeSliceIdx = -1;
+      let childScopeSliceRaw = null;
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--scope-slice') {
+          childScopeSliceIdx = i;
+          childScopeSliceRaw = args[i + 1];
+          break;
+        }
+        if (args[i].startsWith('--scope-slice=')) {
+          childScopeSliceIdx = i;
+          childScopeSliceRaw = args[i].slice('--scope-slice='.length);
+          break;
+        }
+      }
+      if (childScopeSliceRaw != null) {
+        try {
+          const parsed = JSON.parse(childScopeSliceRaw);
+          if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
+            throw new Error('scope_slice must be a JSON object');
+          }
+          if (parsed.stages !== undefined && !Array.isArray(parsed.stages)) {
+            throw new Error('scope_slice.stages must be an array of numbers');
+          }
+          if (parsed.deliverable_globs !== undefined && !Array.isArray(parsed.deliverable_globs)) {
+            throw new Error('scope_slice.deliverable_globs must be an array of glob strings');
+          }
+          childOverrides.scopeSlice = parsed;
+        } catch (err) {
+          console.error(`\n❌ Invalid --scope-slice JSON: ${err.message}`);
+          console.error(`   Received: ${childScopeSliceRaw}`);
+          console.error(`   Expected shape: {"stages": [18], "deliverable_globs": ["src/stage18/**"]}`);
+          process.exit(1);
+        }
+      }
       // args[1] = parent key, args[2] = index (skip flag positions)
       const childParentKey = args[1];
       const flagValuePositionsChild = new Set(
         [childTypeIdx, childTitleIdx, childVisionKeyIdx, childArchKeyIdx]
           .filter(i => i !== -1).map(i => i + 1)
       );
+      // --scope-slice value (next arg) is also a flag value to skip when finding the index arg
+      if (childScopeSliceIdx !== -1 && args[childScopeSliceIdx] === '--scope-slice') {
+        flagValuePositionsChild.add(childScopeSliceIdx + 1);
+      }
       const childIndexArg = args.find((a, i) =>
         i >= 2 && !a.startsWith('-') && !flagValuePositionsChild.has(i) && i !== childTypeIdx + 1 && i !== childTitleIdx + 1
       );

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -458,16 +458,21 @@ async function createChild(parentKey, index = 0, overrides = {}) {
   // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-001):
   // Persist scope_slice when provided via --scope-slice flag.
   // Note: separate UPDATE to avoid changing createSD signature; schema added 2026-04-23.
+  // Persistence failure is FATAL — silent fallback would invert the safety direction
+  // (caller requested strictness; undo on failure to avoid surprise soft-pass behavior).
+  // Review finding (PR #3232 adversarial review).
   if (overrides.scopeSlice) {
     const { error: sliceErr } = await supabase
       .from('strategic_directives_v2')
       .update({ scope_slice: overrides.scopeSlice })
       .eq('sd_key', sdKey);
     if (sliceErr) {
-      console.warn(`[createChild] ⚠️  Failed to persist scope_slice (non-fatal): ${sliceErr.message}`);
-    } else {
-      console.log(`   scope_slice set: ${JSON.stringify(overrides.scopeSlice)}`);
+      console.error(`[createChild] ❌ Failed to persist scope_slice: ${sliceErr.message}`);
+      // Roll back the child SD row so the caller can retry from a clean state.
+      await supabase.from('strategic_directives_v2').delete().eq('sd_key', sdKey);
+      throw new Error(`scope_slice persistence failed for ${sdKey}: ${sliceErr.message}. Child SD row rolled back.`);
     }
+    console.log(`   scope_slice set: ${JSON.stringify(overrides.scopeSlice)}`);
   }
 
   // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Assert parent claim before returning child

--- a/scripts/modules/handoff/gates/scope-completion-gate.js
+++ b/scripts/modules/handoff/gates/scope-completion-gate.js
@@ -180,6 +180,82 @@ function grepRecursive(dir, pattern) {
   return null;
 }
 
+// Convert a glob (**/ for 0+ path segments, * for chars-in-segment, ? for one char) to RegExp.
+function globToRegExp(glob) {
+  let src = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*' && glob[i + 1] === '*') {
+      if (glob[i + 2] === '/') {
+        // **/ matches zero or more path segments
+        src += '(?:.*/)?';
+        i += 2; // skip **/
+      } else {
+        // ** alone matches any chars
+        src += '.*';
+        i += 1; // skip second *
+      }
+    } else if (c === '*') {
+      src += '[^/]*';
+    } else if (c === '?') {
+      src += '.';
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      src += '\\' + c;
+    } else {
+      src += c;
+    }
+  }
+  return new RegExp('^' + src + '$');
+}
+
+// True when the child SD inherits arch scope from its parent but has not declared a scope_slice.
+// Added for SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A.
+function isInheritedWithoutSlice(sd) {
+  if (sd?.scope_slice != null) return false;
+  const flag = sd?.metadata?.inherited_from_parent;
+  if (flag === true) return true;
+  if (Array.isArray(flag) && flag.length > 0) return true;
+  return false;
+}
+
+// Filter parent arch plan deliverables through the child's scope_slice.
+// stages: keep deliverables whose name/path references one of the listed stage numbers.
+// deliverable_globs: keep deliverables whose checkPattern matches one of the globs.
+// When both set, deliverable must match BOTH (intersection).
+function filterBySlice(deliverables, scopeSlice) {
+  if (!scopeSlice || typeof scopeSlice !== 'object') return deliverables;
+
+  const stages = Array.isArray(scopeSlice.stages) ? scopeSlice.stages : null;
+  const globs = Array.isArray(scopeSlice.deliverable_globs) ? scopeSlice.deliverable_globs : null;
+
+  if ((!stages || stages.length === 0) && (!globs || globs.length === 0)) {
+    return deliverables;
+  }
+
+  const globRegexes = globs ? globs.map(globToRegExp) : null;
+
+  return deliverables.filter(d => {
+    const target = (d.checkPattern || d.name || '').toLowerCase();
+
+    if (stages && stages.length > 0) {
+      const stageMatches = stages.some(n => {
+        const s = String(n);
+        const patterns = [`stage${s}`, `stage_${s}`, `stage-${s}`, `stage ${s}`, `/${s}/`, `s${s}_`, `_s${s}`];
+        return patterns.some(p => target.includes(p));
+      });
+      if (!stageMatches) return false;
+    }
+
+    if (globRegexes && globRegexes.length > 0) {
+      const cleanPath = d.checkPattern || d.name || '';
+      const globMatches = globRegexes.some(rx => rx.test(cleanPath));
+      if (!globMatches) return false;
+    }
+
+    return true;
+  });
+}
+
 /**
  * Validate that all architecture plan deliverables are present in the codebase.
  *
@@ -193,12 +269,33 @@ export async function validateScopeCompletion(sdKey) {
 
   const supabase = createSupabaseServiceClient();
 
-  // 1. Get the SD's arch_key from metadata
+  // 1. Get the SD's arch_key + scope_slice from metadata
   const { data: sd } = await supabase
     .from('strategic_directives_v2')
-    .select('metadata')
+    .select('metadata, scope_slice, parent_sd_id')
     .eq('sd_key', sdKey)
     .single();
+
+  // Soft-pass path (SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A):
+  // children that inherit parent arch_key but have not declared a scope_slice
+  // would otherwise be scored against the full parent deliverable set.
+  if (isInheritedWithoutSlice(sd)) {
+    console.log('   ℹ️  SD inherits scope from parent but has no scope_slice declared — soft-pass');
+    return {
+      pass: true,
+      score: 70,
+      issues: [],
+      warnings: [
+        `SD inherits scope from parent orchestrator (metadata.inherited_from_parent set) but has no scope_slice declared. Gate returns soft-pass (score=70). Declare scope_slice on the child to score only the claimed subset of parent deliverables.`
+      ],
+      checklist: [],
+      details: {
+        type: 'inherited-no-slice',
+        inherited_from_parent: sd.metadata.inherited_from_parent,
+        parent_sd_id: sd.parent_sd_id || null
+      }
+    };
+  }
 
   const archKey = sd?.metadata?.arch_key;
   if (!archKey) {
@@ -221,8 +318,17 @@ export async function validateScopeCompletion(sdKey) {
   console.log(`   Architecture plan: ${archKey}`);
 
   // 3. Extract deliverables
-  const deliverables = extractDeliverables(archPlan.content);
-  console.log(`   Deliverables extracted: ${deliverables.length}`);
+  let deliverables = extractDeliverables(archPlan.content);
+  const rawDeliverableCount = deliverables.length;
+  console.log(`   Deliverables extracted: ${rawDeliverableCount}`);
+
+  // 3a. Apply child's scope_slice filter if declared
+  if (sd?.scope_slice) {
+    deliverables = filterBySlice(deliverables, sd.scope_slice);
+    if (deliverables.length < rawDeliverableCount) {
+      console.log(`   scope_slice filter applied: ${deliverables.length}/${rawDeliverableCount} deliverables retained`);
+    }
+  }
 
   if (deliverables.length === 0) {
     console.log('   ⚠️  No parseable deliverables found in architecture plan');
@@ -290,4 +396,4 @@ export function createScopeCompletionGate() {
   };
 }
 
-export { extractDeliverables, checkDeliverable, grepRecursive };
+export { extractDeliverables, checkDeliverable, grepRecursive, filterBySlice, globToRegExp, isInheritedWithoutSlice };

--- a/scripts/modules/handoff/gates/scope-completion-gate.js
+++ b/scripts/modules/handoff/gates/scope-completion-gate.js
@@ -209,9 +209,11 @@ function globToRegExp(glob) {
 }
 
 // True when the child SD inherits arch scope from its parent but has not declared a scope_slice.
-// Added for SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A.
+// Requires BOTH a real parent_sd_id AND metadata.inherited_from_parent to prevent soft-pass
+// abuse via metadata-only flag. Added for SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A.
 function isInheritedWithoutSlice(sd) {
   if (sd?.scope_slice != null) return false;
+  if (!sd?.parent_sd_id) return false;
   const flag = sd?.metadata?.inherited_from_parent;
   if (flag === true) return true;
   if (Array.isArray(flag) && flag.length > 0) return true;
@@ -323,7 +325,8 @@ export async function validateScopeCompletion(sdKey) {
   console.log(`   Deliverables extracted: ${rawDeliverableCount}`);
 
   // 3a. Apply child's scope_slice filter if declared
-  if (sd?.scope_slice) {
+  const sliceDeclared = sd?.scope_slice != null;
+  if (sliceDeclared) {
     deliverables = filterBySlice(deliverables, sd.scope_slice);
     if (deliverables.length < rawDeliverableCount) {
       console.log(`   scope_slice filter applied: ${deliverables.length}/${rawDeliverableCount} deliverables retained`);
@@ -331,6 +334,20 @@ export async function validateScopeCompletion(sdKey) {
   }
 
   if (deliverables.length === 0) {
+    // When scope_slice was declared AND raw deliverables existed but the filter eliminated
+    // all of them, this is not a free pass — the author-controlled slice is mis-targeted.
+    // Review finding (PR #3232 adversarial review): prevent gate evasion via matchless slice.
+    if (sliceDeclared && rawDeliverableCount > 0) {
+      console.log(`   ❌ scope_slice filtered all ${rawDeliverableCount} deliverables — mis-targeted slice`);
+      return {
+        pass: false,
+        score: 0,
+        issues: [`scope_slice filtered out all ${rawDeliverableCount} parent arch plan deliverables — the slice matches no parent deliverable. Review stages/deliverable_globs values against parent arch plan.`],
+        warnings: [],
+        checklist: [],
+        details: { type: 'slice-matches-nothing', raw_deliverable_count: rawDeliverableCount, scope_slice: sd.scope_slice }
+      };
+    }
     console.log('   ⚠️  No parseable deliverables found in architecture plan');
     return { pass: true, score: 100, issues: [], warnings: ['No deliverables extracted from architecture plan'], checklist: [] };
   }

--- a/scripts/prd/validate-prd-fields.js
+++ b/scripts/prd/validate-prd-fields.js
@@ -12,6 +12,9 @@
  *   if (!result.valid) console.warn(result.warnings.join('\n'));
  */
 
+import fs from 'fs';
+import path from 'path';
+
 const REQUIRED_FIELDS = [
   'executive_summary',
   'functional_requirements',
@@ -88,6 +91,171 @@ export function validatePRDFields(prd) {
 
   const valid = missing.length === 0 && lowQuality.length === 0;
   return { valid, warnings, missing, lowQuality };
+}
+
+// File extensions that trigger existence checking.
+// SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-003).
+const CHECKED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs', '.sql', '.sh', '.md', '.json', '.yaml', '.yml']);
+
+// Extract path-like tokens from a string. A path token starts with a word char or
+// 'src/' / 'scripts/' / 'lib/' / 'database/' / 'tests/' / 'docs/' style prefix and
+// ends in a recognized extension.
+function extractFilePaths(text) {
+  if (typeof text !== 'string') return [];
+  const out = [];
+  // Longer extensions must precede shorter prefixes (tsx before ts, mjs before js, yaml before yml-free js).
+  const rx = /(?:^|[\s`"'(\[])((?:src|scripts|lib|database|tests|docs|public|config)[\/\\][\w.\-\/\\]+\.(?:tsx|ts|mjs|cjs|js|sql|sh|md|json|yaml|yml))\b/gi;
+  let m;
+  while ((m = rx.exec(text)) !== null) {
+    out.push(m[1].replace(/\\/g, '/'));
+  }
+  return out;
+}
+
+// Walk any PRD field value and collect path tokens.
+function harvestPaths(value, acc = []) {
+  if (value == null) return acc;
+  if (typeof value === 'string') {
+    acc.push(...extractFilePaths(value));
+    return acc;
+  }
+  if (Array.isArray(value)) {
+    value.forEach(v => harvestPaths(v, acc));
+    return acc;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach(v => harvestPaths(v, acc));
+    return acc;
+  }
+  return acc;
+}
+
+// Convert a glob (**/ for 0+ segments, * for chars-in-segment, ? for one char) to RegExp.
+// Mirror of scope-completion-gate.globToRegExp (duplicated to avoid cross-module dep).
+function globToRegExpLocal(glob) {
+  let src = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*' && glob[i + 1] === '*') {
+      if (glob[i + 2] === '/') { src += '(?:.*/)?'; i += 2; }
+      else { src += '.*'; i += 1; }
+    } else if (c === '*') src += '[^/]*';
+    else if (c === '?') src += '.';
+    else if ('.+^${}()|[]\\'.includes(c)) src += '\\' + c;
+    else src += c;
+  }
+  return new RegExp('^' + src + '$');
+}
+
+// Find the nearest matching file in the same directory (basename-prefix match).
+function findNearestMatch(candidate, projectRoot, fs, path) {
+  try {
+    const abs = path.resolve(projectRoot, candidate);
+    const dir = path.dirname(abs);
+    const base = path.basename(candidate, path.extname(candidate));
+    if (!fs.existsSync(dir)) return null;
+    const siblings = fs.readdirSync(dir);
+    const match = siblings.find(f => path.basename(f, path.extname(f)) === base && f !== path.basename(candidate));
+    return match ? path.join(path.dirname(candidate), match).replace(/\\/g, '/') : null;
+  } catch { return null; }
+}
+
+/**
+ * Validate that file references inside PRD string fields resolve to actual files.
+ * Emits warn-level findings (non-blocking). Synchronous fs checks.
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-003).
+ *
+ * @param {Object} prd - PRD object
+ * @param {Object} [deps] - optional injectable deps for testing ({ fs, path, projectRoot })
+ * @returns {{ warnings: string[], checked: number, missing: number }}
+ */
+export function validateFileExtensions(prd, deps = {}) {
+  const fsImpl = deps.fs || fs;
+  const pathImpl = deps.path || path;
+  const projectRoot = deps.projectRoot || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  const scanFields = ['executive_summary', 'system_architecture', 'implementation_approach', 'functional_requirements', 'acceptance_criteria', 'test_scenarios', 'risks'];
+  const candidates = new Set();
+  for (const f of scanFields) {
+    harvestPaths(prd?.[f], Array.from({ length: 0 })).forEach(p => candidates.add(p));
+    const arr = [];
+    harvestPaths(prd?.[f], arr);
+    arr.forEach(p => candidates.add(p));
+  }
+
+  const warnings = [];
+  let missing = 0;
+  for (const candidate of candidates) {
+    const ext = pathImpl.extname(candidate).toLowerCase();
+    if (!CHECKED_EXTENSIONS.has(ext)) continue;
+    const abs = pathImpl.resolve(projectRoot, candidate);
+    if (fsImpl.existsSync(abs)) continue;
+    missing += 1;
+    const nearest = findNearestMatch(candidate, projectRoot, fsImpl, pathImpl);
+    const hint = nearest ? ` (nearest match: ${nearest})` : '';
+    warnings.push(`⚠️  File reference not found: ${candidate}${hint}`);
+  }
+
+  return { warnings, checked: candidates.size, missing };
+}
+
+/**
+ * Detect parent-scope leakage: when SD has scope_slice declared but PRD deliverables
+ * reference paths/stages outside the declared slice. Warn-only.
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-004).
+ *
+ * @param {Object} prd - PRD object
+ * @param {Object} sd - SD row (must include scope_slice + parent_sd_id)
+ * @returns {{ warnings: string[], leaked: number, total: number, skipped: boolean }}
+ */
+export function detectParentScopeLeakage(prd, sd) {
+  if (!sd?.parent_sd_id || !sd?.scope_slice) {
+    return { warnings: [], leaked: 0, total: 0, skipped: true };
+  }
+
+  const stages = Array.isArray(sd.scope_slice.stages) ? sd.scope_slice.stages.map(String) : null;
+  const globs = Array.isArray(sd.scope_slice.deliverable_globs) ? sd.scope_slice.deliverable_globs : null;
+  if ((!stages || stages.length === 0) && (!globs || globs.length === 0)) {
+    return { warnings: [], leaked: 0, total: 0, skipped: true };
+  }
+
+  const paths = [];
+  const scanFields = ['acceptance_criteria', 'functional_requirements', 'test_scenarios', 'system_architecture', 'implementation_approach'];
+  for (const f of scanFields) harvestPaths(prd?.[f], paths);
+
+  const unique = Array.from(new Set(paths));
+  if (unique.length === 0) {
+    return { warnings: [], leaked: 0, total: 0, skipped: true };
+  }
+
+  const warnings = [];
+  let leaked = 0;
+  for (const p of unique) {
+    const lp = p.toLowerCase();
+    let inSlice = false;
+
+    if (stages && stages.length > 0) {
+      inSlice = stages.some(s => [`stage${s}`, `stage_${s}`, `stage-${s}`, `stage ${s}`, `/${s}/`, `s${s}_`, `_s${s}`].some(pat => lp.includes(pat)));
+    }
+
+    if (!inSlice && globs && globs.length > 0) {
+      inSlice = globs.some(g => globToRegExpLocal(g).test(p));
+    }
+
+    if (!inSlice) {
+      leaked += 1;
+      warnings.push(`⚠️  Deliverable outside scope_slice: ${p}`);
+    }
+  }
+
+  if (leaked / unique.length > 0.5) {
+    warnings.unshift(`⚠️  Parent-scope leakage detected: ${leaked}/${unique.length} deliverables reference paths outside scope_slice (>50% threshold)`);
+  } else {
+    // Below threshold — suppress warnings but still report for telemetry
+    return { warnings: [], leaked, total: unique.length, skipped: false };
+  }
+
+  return { warnings, leaked, total: unique.length, skipped: false };
 }
 
 /**

--- a/tests/unit/scope-inheritance/gate-filter.test.js
+++ b/tests/unit/scope-inheritance/gate-filter.test.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for scope-completion-gate filter logic.
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-001, US-002)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  filterBySlice,
+  globToRegExp,
+  isInheritedWithoutSlice,
+  extractDeliverables,
+} from '../../../scripts/modules/handoff/gates/scope-completion-gate.js';
+
+describe('globToRegExp', () => {
+  it('matches simple star as a single segment', () => {
+    const rx = globToRegExp('src/*.js');
+    expect(rx.test('src/foo.js')).toBe(true);
+    expect(rx.test('src/nested/foo.js')).toBe(false);
+  });
+
+  it('matches double star across segments', () => {
+    const rx = globToRegExp('src/**/*.ts');
+    expect(rx.test('src/foo.ts')).toBe(true);
+    expect(rx.test('src/a/b/c.ts')).toBe(true);
+    expect(rx.test('other/foo.ts')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in literal path', () => {
+    const rx = globToRegExp('src/foo.bar.js');
+    expect(rx.test('src/foo.bar.js')).toBe(true);
+    expect(rx.test('src/fooxbar.js')).toBe(false);
+  });
+});
+
+describe('isInheritedWithoutSlice', () => {
+  it('returns true when inherited_from_parent is a non-empty array and scope_slice is null', () => {
+    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: ['title', 'desc'] }, scope_slice: null })).toBe(true);
+  });
+
+  it('returns true when inherited_from_parent === true and scope_slice is undefined', () => {
+    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: true } })).toBe(true);
+  });
+
+  it('returns false when scope_slice is set (even if inheritance flag is also set)', () => {
+    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: true }, scope_slice: { stages: [1] } })).toBe(false);
+  });
+
+  it('returns false when no inheritance flag and no scope_slice', () => {
+    expect(isInheritedWithoutSlice({ metadata: {}, scope_slice: null })).toBe(false);
+  });
+
+  it('returns false when inherited_from_parent is an empty array', () => {
+    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: [] }, scope_slice: null })).toBe(false);
+  });
+
+  it('returns false on missing SD object', () => {
+    expect(isInheritedWithoutSlice(null)).toBe(false);
+    expect(isInheritedWithoutSlice(undefined)).toBe(false);
+  });
+});
+
+describe('filterBySlice', () => {
+  const deliverables = [
+    { name: 'src/stage18/foo.tsx', type: 'file', checkPattern: 'src/stage18/foo.tsx' },
+    { name: 'src/stage19/bar.ts', type: 'file', checkPattern: 'src/stage19/bar.ts' },
+    { name: 'Table: stage_18_results', type: 'table', checkPattern: 'stage_18_results' },
+    { name: 'Function: handleStage20', type: 'function', checkPattern: 'handleStage20' },
+    { name: 'scripts/shared/util.js', type: 'file', checkPattern: 'scripts/shared/util.js' },
+  ];
+
+  it('returns input unchanged when scope_slice is null', () => {
+    expect(filterBySlice(deliverables, null)).toEqual(deliverables);
+  });
+
+  it('returns input unchanged when scope_slice is empty object', () => {
+    expect(filterBySlice(deliverables, {})).toEqual(deliverables);
+  });
+
+  it('filters by stages: keeps only deliverables referencing stage 18', () => {
+    const result = filterBySlice(deliverables, { stages: [18] });
+    expect(result).toHaveLength(2);
+    expect(result.map(d => d.checkPattern)).toEqual(['src/stage18/foo.tsx', 'stage_18_results']);
+  });
+
+  it('filters by multiple stages (OR-union across stages)', () => {
+    const result = filterBySlice(deliverables, { stages: [18, 19] });
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters by deliverable_globs: keeps only files under src/stage18/**', () => {
+    const result = filterBySlice(deliverables, { deliverable_globs: ['src/stage18/**'] });
+    expect(result).toHaveLength(1);
+    expect(result[0].checkPattern).toBe('src/stage18/foo.tsx');
+  });
+
+  it('combines stages AND globs (intersection)', () => {
+    const result = filterBySlice(deliverables, {
+      stages: [18, 19],
+      deliverable_globs: ['src/stage18/**'],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].checkPattern).toBe('src/stage18/foo.tsx');
+  });
+
+  it('empty stages array is treated as absent (no filter)', () => {
+    const result = filterBySlice(deliverables, { stages: [] });
+    expect(result).toEqual(deliverables);
+  });
+});
+
+describe('extractDeliverables backward compat', () => {
+  it('still extracts file paths from arch plan content', () => {
+    const content = '- `scripts/foo.js`\n- `lib/bar.ts`\n';
+    const items = extractDeliverables(content);
+    expect(items).toHaveLength(2);
+    expect(items.find(i => i.checkPattern === 'scripts/foo.js')).toBeDefined();
+    expect(items.find(i => i.checkPattern === 'lib/bar.ts')).toBeDefined();
+  });
+});

--- a/tests/unit/scope-inheritance/gate-filter.test.js
+++ b/tests/unit/scope-inheritance/gate-filter.test.js
@@ -33,24 +33,31 @@ describe('globToRegExp', () => {
 });
 
 describe('isInheritedWithoutSlice', () => {
-  it('returns true when inherited_from_parent is a non-empty array and scope_slice is null', () => {
-    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: ['title', 'desc'] }, scope_slice: null })).toBe(true);
+  const parentId = 'parent-uuid-123';
+
+  it('returns true when inherited_from_parent is a non-empty array AND parent_sd_id is set AND scope_slice is null', () => {
+    expect(isInheritedWithoutSlice({ parent_sd_id: parentId, metadata: { inherited_from_parent: ['title', 'desc'] }, scope_slice: null })).toBe(true);
   });
 
-  it('returns true when inherited_from_parent === true and scope_slice is undefined', () => {
-    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: true } })).toBe(true);
+  it('returns true when inherited_from_parent === true AND parent_sd_id is set AND scope_slice is undefined', () => {
+    expect(isInheritedWithoutSlice({ parent_sd_id: parentId, metadata: { inherited_from_parent: true } })).toBe(true);
   });
 
-  it('returns false when scope_slice is set (even if inheritance flag is also set)', () => {
-    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: true }, scope_slice: { stages: [1] } })).toBe(false);
+  it('returns false when scope_slice is set (even if inheritance flag + parent are also set)', () => {
+    expect(isInheritedWithoutSlice({ parent_sd_id: parentId, metadata: { inherited_from_parent: true }, scope_slice: { stages: [1] } })).toBe(false);
   });
 
   it('returns false when no inheritance flag and no scope_slice', () => {
-    expect(isInheritedWithoutSlice({ metadata: {}, scope_slice: null })).toBe(false);
+    expect(isInheritedWithoutSlice({ parent_sd_id: parentId, metadata: {}, scope_slice: null })).toBe(false);
   });
 
   it('returns false when inherited_from_parent is an empty array', () => {
-    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: [] }, scope_slice: null })).toBe(false);
+    expect(isInheritedWithoutSlice({ parent_sd_id: parentId, metadata: { inherited_from_parent: [] }, scope_slice: null })).toBe(false);
+  });
+
+  it('returns false when inherited_from_parent is set but parent_sd_id is missing (PR #3232 review: prevent metadata-only soft-pass)', () => {
+    expect(isInheritedWithoutSlice({ parent_sd_id: null, metadata: { inherited_from_parent: true }, scope_slice: null })).toBe(false);
+    expect(isInheritedWithoutSlice({ metadata: { inherited_from_parent: ['title'] }, scope_slice: null })).toBe(false);
   });
 
   it('returns false on missing SD object', () => {

--- a/tests/unit/scope-inheritance/prd-validators.test.js
+++ b/tests/unit/scope-inheritance/prd-validators.test.js
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for PRD file-extension validation and parent-scope leakage heuristic.
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-A (US-003, US-004)
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import {
+  validateFileExtensions,
+  detectParentScopeLeakage,
+} from '../../../scripts/prd/validate-prd-fields.js';
+
+// Mock fs: only these paths exist. Paths are relative; suffix-match handles abs resolution.
+function makeMockFs(existingPaths) {
+  const set = new Set(existingPaths.map(p => p.replace(/\\/g, '/')));
+  const byDir = new Map();
+  for (const p of existingPaths) {
+    const norm = p.replace(/\\/g, '/');
+    const lastSlash = norm.lastIndexOf('/');
+    const dir = lastSlash >= 0 ? norm.slice(0, lastSlash) : '';
+    const base = lastSlash >= 0 ? norm.slice(lastSlash + 1) : norm;
+    if (!byDir.has(dir)) byDir.set(dir, []);
+    byDir.get(dir).push(base);
+  }
+  const suffixMatch = (needle, absNorm) =>
+    absNorm === needle || absNorm.endsWith('/' + needle);
+  return {
+    existsSync: (abs) => {
+      const norm = abs.replace(/\\/g, '/');
+      for (const p of set) if (suffixMatch(p, norm)) return true;
+      for (const dir of byDir.keys()) if (dir && suffixMatch(dir, norm)) return true;
+      return false;
+    },
+    readdirSync: (abs) => {
+      const norm = abs.replace(/\\/g, '/');
+      for (const [dir, files] of byDir) {
+        if (dir && suffixMatch(dir, norm)) return files;
+      }
+      return [];
+    },
+  };
+}
+
+describe('validateFileExtensions', () => {
+  it('emits no warnings when all referenced files exist', () => {
+    const mockFs = makeMockFs(['scripts/foo.ts', 'src/bar.tsx']);
+    const prd = {
+      executive_summary: 'Modify `scripts/foo.ts` and `src/bar.tsx` to add feature X.',
+    };
+    const result = validateFileExtensions(prd, { fs: mockFs, path, projectRoot: '/repo' });
+    expect(result.missing).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.checked).toBeGreaterThanOrEqual(2);
+  });
+
+  it('warns when a .ts reference does not exist but a .tsx sibling does', () => {
+    // repo has Foo.tsx but not Foo.ts; PRD references Foo.ts
+    const mockFs = makeMockFs(['src/components/Foo.tsx']);
+    const prd = {
+      system_architecture: 'Update src/components/Foo.ts to render the new field.',
+    };
+    const result = validateFileExtensions(prd, { fs: mockFs, path, projectRoot: '/repo' });
+    expect(result.missing).toBeGreaterThanOrEqual(1);
+    expect(result.warnings.some(w => w.includes('Foo.ts') && w.includes('Foo.tsx'))).toBe(true);
+  });
+
+  it('returns zero checked when PRD has no file-path-like tokens', () => {
+    const mockFs = makeMockFs([]);
+    const prd = {
+      executive_summary: 'Add authentication system with JWT tokens and refresh flow.',
+    };
+    const result = validateFileExtensions(prd, { fs: mockFs, path, projectRoot: '/repo' });
+    expect(result.checked).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('scans multiple fields (acceptance_criteria, test_scenarios, risks)', () => {
+    const mockFs = makeMockFs([]);
+    const prd = {
+      acceptance_criteria: [{ criterion: 'Update scripts/a.js' }],
+      test_scenarios: [{ given: 'Edit lib/b.ts' }],
+      risks: [{ risk: 'Breaking change in database/migrations/c.sql' }],
+    };
+    const result = validateFileExtensions(prd, { fs: mockFs, path, projectRoot: '/repo' });
+    expect(result.checked).toBe(3);
+    expect(result.missing).toBe(3); // all three are missing (mockFs empty)
+  });
+});
+
+describe('detectParentScopeLeakage', () => {
+  it('skips when SD has no parent_sd_id', () => {
+    const result = detectParentScopeLeakage({}, { scope_slice: { stages: [18] } });
+    expect(result.skipped).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('skips when SD has no scope_slice', () => {
+    const result = detectParentScopeLeakage({}, { parent_sd_id: 'p', scope_slice: null });
+    expect(result.skipped).toBe(true);
+  });
+
+  it('skips when scope_slice has no stages or globs', () => {
+    const result = detectParentScopeLeakage(
+      { acceptance_criteria: ['src/stage20/leaked.ts'] },
+      { parent_sd_id: 'p', scope_slice: {} }
+    );
+    expect(result.skipped).toBe(true);
+  });
+
+  it('does not warn when leakage is below 50%', () => {
+    const prd = {
+      acceptance_criteria: [
+        'Implement src/stage18/a.ts',
+        'Implement src/stage18/b.ts',
+        'Add util in src/stage20/leaked.ts',
+      ],
+    };
+    const sd = { parent_sd_id: 'p', scope_slice: { stages: [18] } };
+    const result = detectParentScopeLeakage(prd, sd);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.leaked).toBe(1);
+    expect(result.total).toBe(3);
+  });
+
+  it('warns when leakage exceeds 50%', () => {
+    const prd = {
+      acceptance_criteria: [
+        'Implement src/stage18/a.ts',
+        'Add util in src/stage20/leaked.ts',
+        'Fix src/stage21/other.ts',
+      ],
+    };
+    const sd = { parent_sd_id: 'p', scope_slice: { stages: [18] } };
+    const result = detectParentScopeLeakage(prd, sd);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('2/3');
+    expect(result.leaked).toBe(2);
+  });
+
+  it('respects deliverable_globs filter', () => {
+    const prd = {
+      acceptance_criteria: [
+        'src/stage18/in.ts',
+        'scripts/stage18/out.ts',
+        'scripts/stage18/also-out.ts',
+      ],
+    };
+    const sd = { parent_sd_id: 'p', scope_slice: { deliverable_globs: ['src/stage18/**'] } };
+    const result = detectParentScopeLeakage(prd, sd);
+    expect(result.leaked).toBe(2);
+    expect(result.total).toBe(3);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of LEO Protocol infrastructure orchestrator. Eliminates false-positive SCOPE_COMPLETION_VERIFICATION failures on child SDs that inherit parent architecture plans, and catches bad PRD deliverables at authoring time.

- **Schema**: Adds nullable `scope_slice` JSONB column to `strategic_directives_v2`. Migration executed in 33.74ms (metadata-only ADD COLUMN, 2811 rows verified NULL). Rollback block included.
- **Gate** (`scripts/modules/handoff/gates/scope-completion-gate.js`): `.select()` projection now includes `scope_slice` and `parent_sd_id` (DATABASE sub-agent action item). Adds soft-pass path (score=70 + WARN) when `metadata.inherited_from_parent` is set but `scope_slice IS NULL`. Adds slice filter that intersects parent deliverables with child's `{stages?, deliverable_globs?}`.
- **PRD validators** (`scripts/prd/validate-prd-fields.js`): `validateFileExtensions` warns when file references don't resolve (nearest-match hint). `detectParentScopeLeakage` warns when >50% of PRD deliverables leak outside `scope_slice`. Warn-only (non-blocking) per PRD TR-4.
- **SD creator** (`scripts/leo-create-sd.js`): `--child` branch accepts `--scope-slice=<JSON>` (space and equals forms). Parse failure exits non-zero with clear error. Persisted via separate UPDATE to avoid changing `createSD` signature.
- **Docs** (`docs/reference/sd-key-generator-guide.md`): `--scope-slice` flag documented with shape, examples, cross-references.

Backward compatible: SDs without `scope_slice` and without `inherited_from_parent` follow the original gate path unchanged.

## Test plan
- [x] Unit tests: 27/27 pass (`npx vitest run tests/unit/scope-inheritance/`)
  - `gate-filter.test.js`: globToRegExp, isInheritedWithoutSlice, filterBySlice, extractDeliverables backward-compat (17 tests)
  - `prd-validators.test.js`: validateFileExtensions, detectParentScopeLeakage (10 tests)
- [x] Migration smoke test: executed live against dedlbzhpgkmetvhbkyzq — column exists jsonb/nullable/no default, 2811 rows NULL, duration 33.74ms
- [x] Syntax check: all 3 modified scripts pass `node --check`
- [x] Handoff gates: LEAD-TO-PLAN 93%, PLAN-TO-EXEC 97%, EXEC-TO-PLAN 84%, PLAN-TO-LEAD 91%

## Sub-agents
- **DATABASE**: PASS (95%) — pre-execution analysis + live migration execution (recorded in `sub_agent_execution_results`)
- **DOCMON**: PASS with warnings — identified 5 doc update targets; highest-priority one (sd-key-generator-guide.md) shipped in this PR; others deferred to follow-up

## Follow-up work
- Remaining DOCMON doc updates (handoff-system-guide.md, prd-creation-process.md, sd-hierarchy-schema-guide.md, CLAUDE_PLAN.md/CLAUDE_EXEC.md pointers)
- Backfill `eva_architecture_plans` row for parent orchestrator SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001
- Filed separately: SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D (validator unification + transactional handoff rollback — surfaced during this SD's execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)