### PR TITLE
docs(QF-20260422-862): fix Q9 exemption matrix — infrastructure SDs are CONDITIONAL

### DIFF
--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -945,9 +945,15 @@ Feature SDs MUST include `smoke_test_steps` JSONB array:
 | bugfix | ✅ YES | Fix must be observable |
 | security | ⚠️ API test | Verify auth/authz works |
 | database | ⚠️ API test | Verify data flows correctly |
-| infrastructure | ❌ NO | Internal tooling |
+| infrastructure | ⚠️ CONDITIONAL | REQUIRED if SD produces code (see below); exempt for pure protocol/policy changes |
 | documentation | ❌ NO | No runtime behavior |
 | refactor | ❌ NO | Behavior unchanged by definition |
+
+**Code-producing infrastructure SDs require `smoke_test_steps`** (SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001). The gate auto-detects code production by scanning `scope`, `key_changes`, and `title` for:
+- Code file references: `.js`, `.ts`, `.cjs`, `.mjs`, `.jsx`, `.tsx`, `.py`, `.sh`, `.ps1`, `.bash`
+- Code-production keywords: `script`, `utility`, `function`, `module`, `handler`, `gate`, `validator`, `middleware`, `endpoint`, `api`, `worker`, `plugin`, `hook`, `adapter`, `factory`, `engine`, `executor`, `runner`
+
+If any match, the LEAD-TO-PLAN preflight will block with `SMOKE_TEST_MISSING`. Plain config/doc/protocol infrastructure SDs (e.g. "update CLAUDE.md", "add environment variable") are exempt. Detection logic: `scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction`.
 
 ### Integration with Validation Gates
 

--- a/database/migrations/20260422_fix_q9_matrix_infrastructure_row.sql
+++ b/database/migrations/20260422_fix_q9_matrix_infrastructure_row.sql
@@ -1,0 +1,83 @@
+-- QF-20260422-862: Fix Q9 SD Type Exemptions matrix — infrastructure is CONDITIONAL, not exempt.
+--
+-- The "Strategic Validation Question 9: Human-Verifiable Outcome" section (id=365)
+-- previously said `infrastructure | ❌ NO | Internal tooling`, which contradicts the
+-- actual gate behavior established by SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001:
+-- code-producing infrastructure SDs DO require smoke_test_steps.
+--
+-- Gate implementation:
+--   scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
+--   scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction
+--
+-- This migration updates only the content column; no schema change.
+
+UPDATE public.leo_protocol_sections
+SET content = $MD$## Strategic Validation Question 9: Human-Verifiable Outcome
+
+**Added in LEO v4.4.0** - Part of LEAD Pre-Approval Gate
+
+### The Question
+> "Describe the 30-second demo that proves this SD delivered value."
+> Why: If you cannot describe a demo, the SD is defining behavior at the wrong layer of abstraction — observable by engineers but not by users. The 30-second demo forces the SD to ground out in user-visible value rather than internal correctness.
+
+If you cannot answer this question concretely, the SD is too vague to approve.
+
+### Evaluation Criteria
+
+| Rating | Criteria |
+|--------|----------|
+| ✅ YES | SD has concrete `smoke_test_steps` with user-observable outcomes |
+| ⚠️ PARTIAL | Some verification steps exist but are too technical or vague |
+| ❌ NO | No smoke test steps defined, or all criteria are technical-only |
+
+### Required Format: smoke_test_steps
+
+Feature SDs MUST include `smoke_test_steps` JSONB array:
+
+```json
+[
+  {"step_number": 1, "instruction": "Navigate to /dashboard", "expected_outcome": "Dashboard loads with venture list visible"},
+  {"step_number": 2, "instruction": "Click Create Venture button", "expected_outcome": "New venture form appears"},
+  {"step_number": 3, "instruction": "Fill form and click Save", "expected_outcome": "Success toast + venture appears in list"}
+]
+```
+
+### LEAD Agent Actions
+
+**If YES**: Proceed with approval
+**If PARTIAL**:
+- Require concrete user-observable outcomes
+- Reject technical-only criteria ("API returns 200", "data in database")
+
+**If NO**:
+- **BLOCK approval** until `smoke_test_steps` is populated
+> Why: `smoke_test_steps` is the contract between PLAN and EXEC. Without it, EXEC has no acceptance criteria and the AIQualityEvaluator caps scores at 70% — gates will fail and the SD will be sent back for rework anyway.
+- Prompt: "What will a user SEE that proves this works?"
+
+### SD Type Exemptions
+
+| SD Type | Requires Q9? | Reason |
+|---------|--------------|--------|
+| feature | ✅ YES | User-facing, must be verifiable |
+| bugfix | ✅ YES | Fix must be observable |
+| security | ⚠️ API test | Verify auth/authz works |
+| database | ⚠️ API test | Verify data flows correctly |
+| infrastructure | ⚠️ CONDITIONAL | REQUIRED if SD produces code (see below); exempt for pure protocol/policy changes |
+| documentation | ❌ NO | No runtime behavior |
+| refactor | ❌ NO | Behavior unchanged by definition |
+
+**Code-producing infrastructure SDs require `smoke_test_steps`** (SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001). The gate auto-detects code production by scanning `scope`, `key_changes`, and `title` for:
+- Code file references: `.js`, `.ts`, `.cjs`, `.mjs`, `.jsx`, `.tsx`, `.py`, `.sh`, `.ps1`, `.bash`
+- Code-production keywords: `script`, `utility`, `function`, `module`, `handler`, `gate`, `validator`, `middleware`, `endpoint`, `api`, `worker`, `plugin`, `hook`, `adapter`, `factory`, `engine`, `executor`, `runner`
+
+If any match, the LEAD-TO-PLAN preflight will block with `SMOKE_TEST_MISSING`. Plain config/doc/protocol infrastructure SDs (e.g. "update CLAUDE.md", "add environment variable") are exempt. Detection logic: `scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction`.
+
+### Integration with Validation Gates
+
+This question is ENFORCED by:
+1. **LeadToPlanExecutor** - `SMOKE_TEST_SPECIFICATION` gate blocks without steps
+2. **ExecToPlanExecutor** - `HUMAN_VERIFICATION_GATE` validates execution
+3. **AIQualityEvaluator** - Caps scores at 70% if no human-verifiable outcomes
+4. **UserStoryQualityRubric** - Caps at 6/10 for technical-only acceptance criteria
+$MD$
+WHERE id = 365;

--- a/database/migrations/20260422_fix_q9_matrix_infrastructure_row.sql
+++ b/database/migrations/20260422_fix_q9_matrix_infrastructure_row.sql
@@ -1,83 +1,21 @@
--- QF-20260422-862: Fix Q9 SD Type Exemptions matrix — infrastructure is CONDITIONAL, not exempt.
---
--- The "Strategic Validation Question 9: Human-Verifiable Outcome" section (id=365)
--- previously said `infrastructure | ❌ NO | Internal tooling`, which contradicts the
--- actual gate behavior established by SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001:
--- code-producing infrastructure SDs DO require smoke_test_steps.
---
--- Gate implementation:
---   scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
---   scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction
---
--- This migration updates only the content column; no schema change.
+-- QF-20260422-862: Q9 exemption matrix — infrastructure is CONDITIONAL, not exempt.
+-- Code-producing infrastructure SDs require smoke_test_steps per SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001.
+-- Idempotent: runs only when the old row text is still present.
 
 UPDATE public.leo_protocol_sections
-SET content = $MD$## Strategic Validation Question 9: Human-Verifiable Outcome
-
-**Added in LEO v4.4.0** - Part of LEAD Pre-Approval Gate
-
-### The Question
-> "Describe the 30-second demo that proves this SD delivered value."
-> Why: If you cannot describe a demo, the SD is defining behavior at the wrong layer of abstraction — observable by engineers but not by users. The 30-second demo forces the SD to ground out in user-visible value rather than internal correctness.
-
-If you cannot answer this question concretely, the SD is too vague to approve.
-
-### Evaluation Criteria
-
-| Rating | Criteria |
-|--------|----------|
-| ✅ YES | SD has concrete `smoke_test_steps` with user-observable outcomes |
-| ⚠️ PARTIAL | Some verification steps exist but are too technical or vague |
-| ❌ NO | No smoke test steps defined, or all criteria are technical-only |
-
-### Required Format: smoke_test_steps
-
-Feature SDs MUST include `smoke_test_steps` JSONB array:
-
-```json
-[
-  {"step_number": 1, "instruction": "Navigate to /dashboard", "expected_outcome": "Dashboard loads with venture list visible"},
-  {"step_number": 2, "instruction": "Click Create Venture button", "expected_outcome": "New venture form appears"},
-  {"step_number": 3, "instruction": "Fill form and click Save", "expected_outcome": "Success toast + venture appears in list"}
-]
-```
-
-### LEAD Agent Actions
-
-**If YES**: Proceed with approval
-**If PARTIAL**:
-- Require concrete user-observable outcomes
-- Reject technical-only criteria ("API returns 200", "data in database")
-
-**If NO**:
-- **BLOCK approval** until `smoke_test_steps` is populated
-> Why: `smoke_test_steps` is the contract between PLAN and EXEC. Without it, EXEC has no acceptance criteria and the AIQualityEvaluator caps scores at 70% — gates will fail and the SD will be sent back for rework anyway.
-- Prompt: "What will a user SEE that proves this works?"
-
-### SD Type Exemptions
-
-| SD Type | Requires Q9? | Reason |
-|---------|--------------|--------|
-| feature | ✅ YES | User-facing, must be verifiable |
-| bugfix | ✅ YES | Fix must be observable |
-| security | ⚠️ API test | Verify auth/authz works |
-| database | ⚠️ API test | Verify data flows correctly |
-| infrastructure | ⚠️ CONDITIONAL | REQUIRED if SD produces code (see below); exempt for pure protocol/policy changes |
-| documentation | ❌ NO | No runtime behavior |
-| refactor | ❌ NO | Behavior unchanged by definition |
-
-**Code-producing infrastructure SDs require `smoke_test_steps`** (SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001). The gate auto-detects code production by scanning `scope`, `key_changes`, and `title` for:
-- Code file references: `.js`, `.ts`, `.cjs`, `.mjs`, `.jsx`, `.tsx`, `.py`, `.sh`, `.ps1`, `.bash`
-- Code-production keywords: `script`, `utility`, `function`, `module`, `handler`, `gate`, `validator`, `middleware`, `endpoint`, `api`, `worker`, `plugin`, `hook`, `adapter`, `factory`, `engine`, `executor`, `runner`
-
-If any match, the LEAD-TO-PLAN preflight will block with `SMOKE_TEST_MISSING`. Plain config/doc/protocol infrastructure SDs (e.g. "update CLAUDE.md", "add environment variable") are exempt. Detection logic: `scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction`.
-
-### Integration with Validation Gates
-
-This question is ENFORCED by:
-1. **LeadToPlanExecutor** - `SMOKE_TEST_SPECIFICATION` gate blocks without steps
-2. **ExecToPlanExecutor** - `HUMAN_VERIFICATION_GATE` validates execution
-3. **AIQualityEvaluator** - Caps scores at 70% if no human-verifiable outcomes
-4. **UserStoryQualityRubric** - Caps at 6/10 for technical-only acceptance criteria
-$MD$
-WHERE id = 365;
+SET content = REPLACE(
+  REPLACE(
+    content,
+    '| infrastructure | ❌ NO | Internal tooling |',
+    '| infrastructure | ⚠️ CONDITIONAL | REQUIRED if SD produces code (see below); exempt for pure protocol/policy changes |'
+  ),
+  '| refactor | ❌ NO | Behavior unchanged by definition |' || E'\n\n' || '### Integration with Validation Gates',
+  '| refactor | ❌ NO | Behavior unchanged by definition |' || E'\n\n' ||
+  '**Code-producing infrastructure SDs require `smoke_test_steps`** (SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001). The gate auto-detects code production by scanning `scope`, `key_changes`, and `title` for:' || E'\n' ||
+  '- Code file references: `.js`, `.ts`, `.cjs`, `.mjs`, `.jsx`, `.tsx`, `.py`, `.sh`, `.ps1`, `.bash`' || E'\n' ||
+  '- Code-production keywords: `script`, `utility`, `function`, `module`, `handler`, `gate`, `validator`, `middleware`, `endpoint`, `api`, `worker`, `plugin`, `hook`, `adapter`, `factory`, `engine`, `executor`, `runner`' || E'\n\n' ||
+  'If any match, the LEAD-TO-PLAN preflight will block with `SMOKE_TEST_MISSING`. Plain config/doc/protocol infrastructure SDs (e.g. "update CLAUDE.md", "add environment variable") are exempt. Detection logic: `scripts/modules/handoff/validation/sd-type-applicability-policy.js::detectCodeProduction`.' || E'\n\n' ||
+  '### Integration with Validation Gates'
+)
+WHERE id = 365
+  AND content LIKE '%| infrastructure | ❌ NO | Internal tooling |%';


### PR DESCRIPTION
## Summary

Quick-Fix `QF-20260422-862`: Q9 exemption matrix in `CLAUDE_LEAD.md` incorrectly said `infrastructure | ❌ NO | Internal tooling`, but `SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001` established that code-producing infrastructure SDs REQUIRE `smoke_test_steps`. LEAD agents followed the doc, then hit `SMOKE_TEST_MISSING` at LEAD-TO-PLAN preflight.

## Changes

Three commits on this branch:

- `10b565ff` — Database migration to update `leo_protocol_sections` id=365 (full-replacement version)
- `1990e2fd` — Rewrite migration as idempotent ≤21 LOC Tier 1 (uses REPLACE + `WHERE content LIKE` guard)
- `895b0fa2` — Sync rendered `CLAUDE_LEAD.md` with the DB content (surgical +7 / -1, Tier 1)

## Result

- DB source of truth (id=365) now says `⚠️ CONDITIONAL | REQUIRED if SD produces code...` with the full detection-keyword paragraph.
- Rendered `CLAUDE_LEAD.md` matches, so LEAD agents get accurate guidance immediately without waiting for the next full CLAUDE-KB-refresh.
- Net scope: well under Tier 1 (≤30 LOC) threshold.

## Test plan

- [x] Verified DB section id=365 content includes `⚠️ CONDITIONAL` and detection-keyword paragraph
- [x] Migration is idempotent (WHERE clause guards on stale text existence)
- [x] `git diff` on CLAUDE_LEAD.md shows only the Q9 matrix rows + explanatory paragraph
- [x] No unrelated files changed (full CLAUDE-KB-refresh deferred to CI workflow)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)