### PR TITLE
feat(SD-PROTOCOL-LINTER-001): +9 rules + corrective migration (slice 5/n)

### DIFF
--- a/database/migrations/20260422_protocol_linter_section_id_type_fix.sql
+++ b/database/migrations/20260422_protocol_linter_section_id_type_fix.sql
@@ -1,0 +1,26 @@
+-- SD-PROTOCOL-LINTER-001 slice 5 corrective migration.
+--
+-- Slice 1's migration declared leo_lint_violations.section_id as UUID, but
+-- the referenced leo_protocol_sections.id column is actually BIGINT. This
+-- migration widens section_id to TEXT so IDs from any section store can be
+-- referenced without type coercion at the schema level.
+--
+-- Safe to run: the table is empty pre-slice-5 (no violations inserted), and
+-- the ALTER is idempotent because TEXT is a superset of UUID representations.
+
+BEGIN;
+
+ALTER TABLE leo_lint_violations
+  ALTER COLUMN section_id TYPE TEXT USING section_id::TEXT;
+
+COMMENT ON COLUMN leo_lint_violations.section_id IS
+  'Free-form reference to the section this violation concerns. Stored as TEXT so callers can pass integer, UUID, or string-keyed section identifiers from any source. Nullable — rules that are dataset-wide (not section-scoped) leave this null. SD-PROTOCOL-LINTER-001.';
+
+COMMIT;
+
+-- Rollback (manual, for reference only — destructive if section_id already
+-- contains non-UUID values):
+-- BEGIN;
+-- ALTER TABLE leo_lint_violations
+--   ALTER COLUMN section_id TYPE UUID USING section_id::UUID;
+-- COMMIT;

--- a/scripts/protocol-lint/audit-writer.mjs
+++ b/scripts/protocol-lint/audit-writer.mjs
@@ -69,14 +69,26 @@ export async function recordRun({ supabase, runId, rules, result, bypassReason }
     const rows = result.violations.map(v => ({
       run_id: runId,
       rule_id: v.rule_id,
-      section_id: v.section_id || null,
+      // section_id is TEXT (post-corrective-migration) — coerce any int/UUID to string.
+      section_id: v.section_id == null ? null : String(v.section_id),
       file_path: v.file_path || null,
       severity: v.severity,
       message: v.message,
       context: v.context || {}
     }));
     const { error: vErr } = await supabase.from('leo_lint_violations').insert(rows);
-    if (vErr) throw new Error(`violation insert failed: ${vErr.message}`);
+    if (vErr) {
+      // Tolerate the known-in-flight schema drift where section_id is still
+      // UUID pre-corrective-migration. Log loudly; do not abort — the
+      // in-memory result remains useful to callers. Remove this shim once
+      // 20260422_protocol_linter_section_id_type_fix.sql has been applied
+      // to every environment.
+      if (/invalid input syntax for type uuid/i.test(vErr.message)) {
+        console.warn('[audit-writer] violation persistence skipped — corrective migration 20260422_protocol_linter_section_id_type_fix.sql not yet applied. Error:', vErr.message);
+      } else {
+        throw new Error(`violation insert failed: ${vErr.message}`);
+      }
+    }
   }
 
   // 3. Finalise the run row

--- a/scripts/protocol-lint/fixtures/LINT-BYPASS-001.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-BYPASS-001.negative.json
@@ -1,0 +1,8 @@
+{
+  "description": "NEVER claims against subjects with no documented bypass should NOT trigger LINT-BYPASS-001.",
+  "sections": [
+    { "id": "sec-1", "section_name": "Security Rules", "content": "NEVER bypass authentication checks on admin endpoints." },
+    { "id": "sec-2", "section_name": "Unrelated Overrides", "content": "handoff.js accepts --bypass-validation for production outages with a rate-limited --bypass-reason." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-BYPASS-001.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-BYPASS-001.positive.json
@@ -1,0 +1,8 @@
+{
+  "description": "A 'NEVER bypass handoff.js' claim coexisting with a documented --bypass-validation flag should trigger LINT-BYPASS-001.",
+  "sections": [
+    { "id": "sec-absolute", "section_name": "Handoff Rules", "content": "NEVER bypass handoff.js — this is a hard invariant of the protocol." },
+    { "id": "sec-bypass", "section_name": "Emergency Overrides", "content": "handoff.js accepts --bypass-validation --bypass-reason \"ticket\" for production outages. Rate-limited to 3 per SD, 10 per day." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-BYPASS-001", "section_id": "sec-absolute" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-ENUM-001.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-ENUM-001.negative.json
@@ -1,0 +1,7 @@
+{
+  "description": "Sections using canonical sd_type='bugfix' should NOT trigger LINT-ENUM-001.",
+  "sections": [
+    { "id": "sec-1", "section_name": "SD Types", "content": "Set sd_type = 'bugfix' when the work is a bug resolution." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-ENUM-001.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-ENUM-001.positive.json
@@ -1,0 +1,7 @@
+{
+  "description": "A section using the stale 'fix' sd_type should trigger LINT-ENUM-001.",
+  "sections": [
+    { "id": "sec-1", "section_name": "SD Types", "content": "Set sd_type = 'fix' when the work is a bug resolution." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-ENUM-001", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-002.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-002.negative.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section using canonical '9-Question Gate' should NOT trigger LINT-PHRASE-002.",
+  "sections": [
+    { "id": "sec-1", "section_name": "LEAD Validation", "content": "LEAD MUST complete the 9-Question Gate before approval." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-002.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-002.positive.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section referring to the stale '6-Question Gate' should trigger LINT-PHRASE-002.",
+  "sections": [
+    { "id": "sec-1", "section_name": "LEAD Validation", "content": "LEAD MUST complete the 6-Question Gate before approval." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-PHRASE-002", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-003.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-003.negative.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section describing canonical sub-agent usage should NOT trigger LINT-PHRASE-003.",
+  "sections": [
+    { "id": "sec-1", "section_name": "EXEC Rules", "content": "Sub-agents are first responders during EXEC. Invoke DATABASE on schema tasks, TESTING on coverage gaps." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-003.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-003.positive.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section using stale phrase 'Do NOT invoke sub-agents' should trigger LINT-PHRASE-003.",
+  "sections": [
+    { "id": "sec-1", "section_name": "EXEC Rules", "content": "Do NOT invoke sub-agents during EXEC — stay focused on implementation." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-PHRASE-003", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-004.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-004.negative.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section describing infrastructure work accurately should NOT trigger LINT-PHRASE-004.",
+  "sections": [
+    { "id": "sec-1", "section_name": "Infra SD Rules", "content": "Infrastructure SDs typically target build scripts, generators, and tooling, but may also ship production code (e.g., migrations, server modules)." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-004.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-004.positive.json
@@ -1,0 +1,7 @@
+{
+  "description": "Section claiming 'No production code' should trigger LINT-PHRASE-004.",
+  "sections": [
+    { "id": "sec-1", "section_name": "Infra SD Rules", "content": "Infrastructure SDs: No production code is produced — tooling changes only." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-PHRASE-004", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-005.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-005.negative.json
@@ -1,0 +1,8 @@
+{
+  "description": "A continuation_policy section explicitly referencing TERMINAL should NOT trigger LINT-PHRASE-005.",
+  "sections": [
+    { "id": "sec-1", "section_name": "SD Continuation", "section_type": "continuation_policy", "content": "Non-final handoffs are TERMINAL under AUTO-PROCEED — phase work is required before the next handoff fires." },
+    { "id": "sec-2", "section_name": "Unrelated", "section_type": "pause_policy", "content": "AUTO-PROCEED pauses at blocking errors." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-PHRASE-005.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-PHRASE-005.positive.json
@@ -1,0 +1,7 @@
+{
+  "description": "A continuation_policy section omitting TERMINAL should trigger LINT-PHRASE-005.",
+  "sections": [
+    { "id": "sec-1", "section_name": "SD Continuation", "section_type": "continuation_policy", "content": "Handoffs pause unless both AUTO-PROCEED and Chaining are ON." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-PHRASE-005", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-THRESH-002.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-THRESH-002.negative.json
@@ -1,0 +1,8 @@
+{
+  "description": "Sections agreeing on the same PR size ceiling should NOT trigger LINT-THRESH-002.",
+  "sections": [
+    { "id": "sec-a", "section_name": "PR Rules", "content": "PR size max 400 LOC with justification." },
+    { "id": "sec-b", "section_name": "PR Guidelines", "content": "Max PR is 400 LOC when split isn't practical." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-THRESH-002.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-THRESH-002.positive.json
@@ -1,0 +1,11 @@
+{
+  "description": "Sections declaring different PR size ceilings (200 vs 400) should trigger LINT-THRESH-002 on each.",
+  "sections": [
+    { "id": "sec-a", "section_name": "PR Rules", "content": "PR size max 200 LOC for enhancements." },
+    { "id": "sec-b", "section_name": "PR Guidelines", "content": "Max PR is 400 LOC with strong justification." }
+  ],
+  "expected_violations": [
+    { "rule_id": "LINT-THRESH-002", "section_id": "sec-a" },
+    { "rule_id": "LINT-THRESH-002", "section_id": "sec-b" }
+  ]
+}

--- a/scripts/protocol-lint/fixtures/LINT-THRESH-003.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-THRESH-003.negative.json
@@ -1,0 +1,7 @@
+{
+  "description": "Only type-specific ranges declared (no universal claim) should NOT trigger LINT-THRESH-003.",
+  "sections": [
+    { "id": "sec-typed", "section_name": "SD Type Thresholds", "content": "Per sd_type: feature 85%, infrastructure 80%, documentation 60%. Range is 60-90% across types." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-THRESH-003.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-THRESH-003.positive.json
@@ -1,0 +1,8 @@
+{
+  "description": "A universal 85% claim coexisting with an SD-type-specific 60-90% range should trigger LINT-THRESH-003 on the universal claim.",
+  "sections": [
+    { "id": "sec-universal", "section_name": "Gate Threshold", "content": "All handoffs require 85% to pass." },
+    { "id": "sec-typed", "section_name": "SD Type Thresholds", "content": "Per sd_type: feature 85%, infrastructure 80%, documentation 60%. Range is 60-90% across types." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-THRESH-003", "section_id": "sec-universal" }]
+}

--- a/scripts/protocol-lint/fixtures/LINT-VERSION-001.negative.json
+++ b/scripts/protocol-lint/fixtures/LINT-VERSION-001.negative.json
@@ -1,0 +1,9 @@
+{
+  "description": "In-content version claim at or below active protocol version should NOT trigger LINT-VERSION-001.",
+  "protocol": { "protocol_version": "4.3.3" },
+  "sections": [
+    { "id": "sec-1", "section_name": "Historical Rule", "content": "Added in v4.2.0 — this behavior is now canonical." },
+    { "id": "sec-2", "section_name": "Current Rule", "content": "Since v4.3.0 the gate threshold is SD-type specific." }
+  ],
+  "expected_violations": []
+}

--- a/scripts/protocol-lint/fixtures/LINT-VERSION-001.positive.json
+++ b/scripts/protocol-lint/fixtures/LINT-VERSION-001.positive.json
@@ -1,0 +1,8 @@
+{
+  "description": "Content claiming v4.5.0 when active protocol is v4.3.3 should trigger LINT-VERSION-001.",
+  "protocol": { "protocol_version": "4.3.3" },
+  "sections": [
+    { "id": "sec-1", "section_name": "New Rule", "content": "Added in v4.5.0 — this behavior is new." }
+  ],
+  "expected_violations": [{ "rule_id": "LINT-VERSION-001", "section_id": "sec-1" }]
+}

--- a/scripts/protocol-lint/rules/code/LINT-BYPASS-001.mjs
+++ b/scripts/protocol-lint/rules/code/LINT-BYPASS-001.mjs
@@ -1,0 +1,65 @@
+/**
+ * LINT-BYPASS-001 — "NEVER bypass X" paired with a documented bypass path.
+ *
+ * If a section declares something is "NEVER" to be bypassed while the same
+ * section (or the dataset) documents a bypass flag, emergency override, or
+ * rate-limited exception, the absolute claim is inaccurate. Mirrors class #7
+ * of the 2026-04-22 drift audit.
+ *
+ * Strategy: find every section declaring a NEVER-bypass constraint, then
+ * check whether the subject of that constraint also appears in a section
+ * that documents a bypass mechanism (--skip-*, --bypass-*, EMERGENCY,
+ * rate-limited, exception).
+ *
+ * SD-PROTOCOL-LINTER-001, slice 5/n.
+ */
+
+const NEVER_BYPASS_RE = /\bNEVER\s+(?:bypass|skip|override)\s+([A-Za-z0-9_.\-/]+)/g;
+const BYPASS_MECHANISM_RE = /(--skip[-_][\w-]+|--bypass[-_][\w-]+|EMERGENCY_(?:PUSH|BYPASS|SKIP)|rate[-\s]?limited|documented bypass|bypass path)/i;
+
+export default {
+  id: 'LINT-BYPASS-001',
+  severity: 'warn',
+  description: '"NEVER bypass X" is inaccurate when the dataset also documents a bypass for X. Say "rarely bypass" or list the exceptions inline. Detects class #7 of the 2026-04-22 audit.',
+  enabled: true,
+
+  check(ctx) {
+    const sections = ctx.sections || [];
+    const violations = [];
+
+    // Pass 1: find NEVER-bypass claims
+    const neverClaims = [];
+    for (const s of sections) {
+      const content = s.content || '';
+      NEVER_BYPASS_RE.lastIndex = 0;
+      let m;
+      while ((m = NEVER_BYPASS_RE.exec(content)) !== null) {
+        neverClaims.push({
+          section_id: s.id,
+          section_name: s.section_name,
+          subject: m[1],
+          matched_text: m[0]
+        });
+      }
+    }
+    if (neverClaims.length === 0) return [];
+
+    // Pass 2: for each never-claim, detect a bypass mechanism anywhere in the dataset
+    // referencing the same subject
+    for (const claim of neverClaims) {
+      const subjectLc = claim.subject.toLowerCase();
+      const evidence = sections.some(s => {
+        const content = (s.content || '').toLowerCase();
+        return content.includes(subjectLc) && BYPASS_MECHANISM_RE.test(s.content || '');
+      });
+      if (evidence) {
+        violations.push({
+          section_id: claim.section_id,
+          message: `"${claim.matched_text}" but a bypass mechanism is documented elsewhere for "${claim.subject}".`,
+          context: { subject: claim.subject, matched_text: claim.matched_text, section_name: claim.section_name }
+        });
+      }
+    }
+    return violations;
+  }
+};

--- a/scripts/protocol-lint/rules/code/LINT-THRESH-002.mjs
+++ b/scripts/protocol-lint/rules/code/LINT-THRESH-002.mjs
@@ -1,0 +1,59 @@
+/**
+ * LINT-THRESH-002 — PR size threshold consistency.
+ *
+ * Scans sections for "PR size" / "max PR" / "LOC max" declarations and flags
+ * disagreement on the numeric ceiling. Mirrors class #2 of the 2026-04-22
+ * drift audit (200 vs 400).
+ *
+ * SD-PROTOCOL-LINTER-001, slice 5/n.
+ */
+
+// Match any of: "max 400 LOC", "PR max 200 LOC", "max 400 lines", "400-line max"
+const PATTERNS = [
+  /(?:max|maximum|cap|ceiling)[^.\n]*?(\d{2,4})\s*(?:LOC|lines?)/gi,
+  /(\d{2,4})\s*(?:LOC|lines?)[^.\n]*?(?:max|maximum|cap|ceiling)/gi
+];
+
+export default {
+  id: 'LINT-THRESH-002',
+  severity: 'warn',
+  description: 'PR size ceiling must be declared identically across sections. Detects class #2 of the 2026-04-22 audit.',
+  enabled: true,
+
+  check(ctx) {
+    const sections = ctx.sections || [];
+    const mentions = [];
+
+    for (const section of sections) {
+      const content = section.content || '';
+      // Only consider sections that explicitly talk about PR size
+      if (!/PR\s+size|pull request size|max\s+PR/i.test(content)) continue;
+
+      for (const re of PATTERNS) {
+        re.lastIndex = 0;
+        let m;
+        while ((m = re.exec(content)) !== null) {
+          const value = Number.parseInt(m[1], 10);
+          // Ignore obviously-non-PR numbers (tiny, huge, or percent-adjacent)
+          if (value < 30 || value > 2000) continue;
+          mentions.push({
+            section_id: section.id,
+            section_name: section.section_name,
+            value,
+            matched_text: m[0].trim()
+          });
+        }
+      }
+    }
+
+    if (mentions.length < 2) return [];
+    const distinct = [...new Set(mentions.map(m => m.value))];
+    if (distinct.length === 1) return [];
+
+    return mentions.map(m => ({
+      section_id: m.section_id,
+      message: `PR size ceiling declared as ${m.value} here; other sections declare ${distinct.filter(v => v !== m.value).join(', ')}.`,
+      context: { found_values: distinct, matched_text: m.matched_text, section_name: m.section_name }
+    }));
+  }
+};

--- a/scripts/protocol-lint/rules/code/LINT-THRESH-003.mjs
+++ b/scripts/protocol-lint/rules/code/LINT-THRESH-003.mjs
@@ -1,0 +1,66 @@
+/**
+ * LINT-THRESH-003 — Gate pass threshold consistency.
+ *
+ * Protocol has two valid regimes:
+ *   - Flat: 85% across all SD types (older sections)
+ *   - SD-type-specific: 60-90% depending on type (canonical)
+ *
+ * This rule flags any section that declares ONE universal threshold (e.g.,
+ * "all handoffs require 85%") if another section declares type-specific
+ * ranges. Mirrors class #3 of the 2026-04-22 drift audit.
+ *
+ * SD-PROTOCOL-LINTER-001, slice 5/n.
+ */
+
+// Match universal threshold claims: "all handoffs 85%", "every gate requires 85%"
+const UNIVERSAL_RE = /(?:all|every|each|flat)[^.\n]*?(?:handoffs?|gates?|thresholds?)[^.\n]*?(\d{2,3})\s*%/gi;
+// Match type-specific range claims: "60-90%", "60%-90%", "between 60 and 90"
+const RANGE_RE = /(\d{2,3})\s*[-–]\s*(\d{2,3})\s*%/g;
+// Heuristic: type-specific declaration mentions `sd_type` or specific types
+const TYPE_HINT = /sd_type|infrastructure|feature|bugfix|documentation|security|refactor/i;
+
+export default {
+  id: 'LINT-THRESH-003',
+  severity: 'warn',
+  description: 'Gate pass threshold is SD-type specific (60-90%), not a flat 85%. Universal-threshold claims conflict with canonical type-specific rules. Detects class #3 of the 2026-04-22 audit.',
+  enabled: true,
+
+  check(ctx) {
+    const sections = ctx.sections || [];
+    const universalClaims = [];
+    const rangeClaims = [];
+
+    for (const s of sections) {
+      const content = s.content || '';
+      UNIVERSAL_RE.lastIndex = 0;
+      let m;
+      while ((m = UNIVERSAL_RE.exec(content)) !== null) {
+        universalClaims.push({
+          section_id: s.id,
+          section_name: s.section_name,
+          value: Number.parseInt(m[1], 10),
+          matched_text: m[0].trim()
+        });
+      }
+      if (TYPE_HINT.test(content)) {
+        RANGE_RE.lastIndex = 0;
+        while ((m = RANGE_RE.exec(content)) !== null) {
+          const lo = Number.parseInt(m[1], 10);
+          const hi = Number.parseInt(m[2], 10);
+          if (lo >= 50 && hi <= 100 && hi > lo) {
+            rangeClaims.push({ section_id: s.id, section_name: s.section_name, lo, hi });
+          }
+        }
+      }
+    }
+
+    // Only flag when BOTH a universal and a range claim coexist in the dataset
+    if (universalClaims.length === 0 || rangeClaims.length === 0) return [];
+
+    return universalClaims.map(u => ({
+      section_id: u.section_id,
+      message: `Universal gate threshold ${u.value}% claimed here; other sections declare an SD-type-specific range (e.g., ${rangeClaims[0].lo}-${rangeClaims[0].hi}%).`,
+      context: { universal_value: u.value, matched_text: u.matched_text, section_name: u.section_name }
+    }));
+  }
+};

--- a/scripts/protocol-lint/rules/code/LINT-VERSION-001.mjs
+++ b/scripts/protocol-lint/rules/code/LINT-VERSION-001.mjs
@@ -1,0 +1,56 @@
+/**
+ * LINT-VERSION-001 — Protocol version drift.
+ *
+ * Flags sections whose content claims "Added in vX.Y.Z" or "Since vX.Y.Z" at
+ * a version HIGHER than the active protocol version on record. Indicates
+ * content that was updated after the header was refreshed, or vice versa.
+ * Mirrors class #6 of the 2026-04-22 drift audit.
+ *
+ * Requires ctx.protocol.protocol_version (or ctx.protocol.version).
+ * No-op if protocol metadata is missing.
+ *
+ * SD-PROTOCOL-LINTER-001, slice 5/n.
+ */
+
+const VERSION_CLAIM_RE = /(?:Added|Introduced|Since|New)[^.\n]*?v(\d+)\.(\d+)(?:\.(\d+))?/gi;
+
+function compareSemver(a, b) {
+  for (let i = 0; i < 3; i++) if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) - (b[i] ?? 0);
+  return 0;
+}
+
+function parseSemver(str) {
+  const m = /^v?(\d+)\.(\d+)(?:\.(\d+))?/.exec(str || '');
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)];
+}
+
+export default {
+  id: 'LINT-VERSION-001',
+  severity: 'warn',
+  description: 'In-content "Added in vX.Y.Z" claims must not exceed the active protocol version declared by the header. Detects class #6 of the 2026-04-22 audit.',
+  enabled: true,
+
+  check(ctx) {
+    const active = parseSemver(ctx?.protocol?.protocol_version ?? ctx?.protocol?.version);
+    if (!active) return []; // no-op when protocol metadata is unavailable
+
+    const violations = [];
+    for (const section of ctx.sections || []) {
+      const content = section.content || '';
+      VERSION_CLAIM_RE.lastIndex = 0;
+      let m;
+      while ((m = VERSION_CLAIM_RE.exec(content)) !== null) {
+        const claimed = [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)];
+        if (compareSemver(claimed, active) > 0) {
+          violations.push({
+            section_id: section.id,
+            message: `Claims "v${claimed.join('.')}" but active protocol is v${active.join('.')}. Either header is stale or content anticipates a future version.`,
+            context: { claimed_version: claimed.join('.'), active_version: active.join('.'), matched_text: m[0] }
+          });
+        }
+      }
+    }
+    return violations;
+  }
+};

--- a/scripts/protocol-lint/rules/declarative/LINT-ENUM-001.json
+++ b/scripts/protocol-lint/rules/declarative/LINT-ENUM-001.json
@@ -1,0 +1,8 @@
+{
+  "id": "LINT-ENUM-001",
+  "severity": "warn",
+  "description": "Canonical sd_type for bugs is 'bugfix', never 'fix'. Detects class #5 of the 2026-04-22 drift audit.",
+  "pattern_type": "forbidden_phrase",
+  "pattern": "sd_type = 'fix'",
+  "enabled": true
+}

--- a/scripts/protocol-lint/rules/declarative/LINT-PHRASE-002.json
+++ b/scripts/protocol-lint/rules/declarative/LINT-PHRASE-002.json
@@ -1,0 +1,8 @@
+{
+  "id": "LINT-PHRASE-002",
+  "severity": "warn",
+  "description": "LEAD strategic validation gate is canonically the '9-Question Gate'. '6-Question Gate' references are stale and should be migrated. Detects class #4 of the 2026-04-22 drift audit.",
+  "pattern_type": "forbidden_phrase",
+  "pattern": "6-Question Gate",
+  "enabled": true
+}

--- a/scripts/protocol-lint/rules/declarative/LINT-PHRASE-003.json
+++ b/scripts/protocol-lint/rules/declarative/LINT-PHRASE-003.json
@@ -1,0 +1,8 @@
+{
+  "id": "LINT-PHRASE-003",
+  "severity": "warn",
+  "description": "Sub-agents ARE first responders in EXEC (see CLAUDE_CORE sub-agent routing). 'Do NOT invoke sub-agents' phrasing contradicts the canonical rule. Detects class #8 of the 2026-04-22 drift audit.",
+  "pattern_type": "forbidden_phrase",
+  "pattern": "Do NOT invoke sub-agents",
+  "enabled": true
+}

--- a/scripts/protocol-lint/rules/declarative/LINT-PHRASE-004.json
+++ b/scripts/protocol-lint/rules/declarative/LINT-PHRASE-004.json
@@ -1,0 +1,8 @@
+{
+  "id": "LINT-PHRASE-004",
+  "severity": "warn",
+  "description": "Infrastructure SDs CAN include production code; 'No production code' for infrastructure is a stale claim that contradicts observed reality (e.g., script modules, generators, migrations). Detects class #13 of the 2026-04-22 drift audit.",
+  "pattern_type": "forbidden_phrase",
+  "pattern": "No production code",
+  "enabled": true
+}

--- a/scripts/protocol-lint/rules/declarative/LINT-PHRASE-005.json
+++ b/scripts/protocol-lint/rules/declarative/LINT-PHRASE-005.json
@@ -1,0 +1,9 @@
+{
+  "id": "LINT-PHRASE-005",
+  "severity": "warn",
+  "description": "Sections with section_type='continuation_policy' must reference TERMINAL so readers can trace handoff-phase semantics. Detects class #9 of the 2026-04-22 drift audit.",
+  "pattern_type": "required_phrase",
+  "pattern": "TERMINAL",
+  "section_type_filter": "continuation_policy",
+  "enabled": true
+}

--- a/tests/unit/protocol-lint/engine.test.mjs
+++ b/tests/unit/protocol-lint/engine.test.mjs
@@ -1,11 +1,12 @@
 /**
  * Fixture-driven tests for the Protocol Consistency Linter engine.
  *
- * For every rule that ships a positive fixture, there MUST be a matching
- * negative fixture. Coverage test `every rule has both fixtures` enforces
- * this — CI fails if a rule is added without its negative case.
+ * Rule IDs are derived from the fixtures directory so adding a new rule
+ * (with fixtures) automatically extends coverage without test churn.
+ * Coverage gate `every rule has both fixtures` enforces positive AND
+ * negative fixture per rule.
  *
- * SD-PROTOCOL-LINTER-001, slice 2/n.
+ * SD-PROTOCOL-LINTER-001, slice 5/n.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -17,7 +18,15 @@ import { runProtocolLint } from '../../../scripts/protocol-lint/engine.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, '..', '..', '..', 'scripts', 'protocol-lint', 'fixtures');
 
-const RULE_IDS = ['LINT-PHRASE-001', 'LINT-THRESH-001', 'LINT-ANCHOR-001'];
+const RULE_IDS = await (async () => {
+  const files = await readdir(FIXTURES_DIR);
+  const ids = new Set();
+  for (const f of files) {
+    const m = f.match(/^(LINT-[A-Z]+-\d{3})\.(positive|negative)\.json$/);
+    if (m) ids.add(m[1]);
+  }
+  return [...ids].sort();
+})();
 
 async function loadFixture(name) {
   return JSON.parse(await readFile(join(FIXTURES_DIR, name), 'utf8'));
@@ -44,6 +53,10 @@ describe('Protocol Lint Engine', () => {
       expect(files, `missing negative fixture for ${id}`).toContain(`${id}.negative.json`);
     }
   });
+
+  it('at least 12 rules are registered', () => {
+    expect(RULE_IDS.length).toBeGreaterThanOrEqual(12);
+  });
 });
 
 describe.each(RULE_IDS)('Rule fixture round-trip: %s', (ruleId) => {
@@ -53,7 +66,6 @@ describe.each(RULE_IDS)('Rule fixture round-trip: %s', (ruleId) => {
     const hits = result.violations.filter(v => v.rule_id === ruleId);
     expect(hits.length, `expected ${ruleId} to produce violations on positive fixture`).toBeGreaterThan(0);
 
-    // If fixture declares expected_violations, every declared section_id should be flagged.
     const expected = fixture.expected_violations || [];
     for (const exp of expected.filter(e => e.rule_id === ruleId && e.section_id)) {
       expect(hits.some(h => h.section_id === exp.section_id),


### PR DESCRIPTION
## Summary

Slice 5 of **SD-PROTOCOL-LINTER-001**. Adds 9 seed rules covering 9 of the remaining 13 contradiction classes from the 2026-04-22 audit. **The linter now finds real drift in production** on first run.

Builds on PRs #3227 / #3228 / #3230 / #3231 — all merged. Total rules now: **12** (3 from slice 2 + 9 new).

### New rules

**Declarative (`rules/declarative/`)**
| Rule | Pattern type | Contradiction class |
|------|--------------|---------------------|
| `LINT-ENUM-001` | forbidden `sd_type = 'fix'` | #5 — `fix` vs canonical `bugfix` |
| `LINT-PHRASE-002` | forbidden "6-Question Gate" | #4 — canonical is 9-Question |
| `LINT-PHRASE-003` | forbidden "Do NOT invoke sub-agents" | #8 — sub-agents ARE first responders |
| `LINT-PHRASE-004` | forbidden "No production code" | #13 — infra SDs do ship prod code |
| `LINT-PHRASE-005` | required "TERMINAL" in continuation_policy sections | #9 — TERMINAL wording |

**Code (`rules/code/`)**
| Rule | Contradiction class |
|------|---------------------|
| `LINT-THRESH-002` | #2 — PR size numeric disagreement (200 vs 400) |
| `LINT-THRESH-003` | #3 — flat 85% vs SD-type-specific (60–90%) |
| `LINT-VERSION-001` | #6 — header version vs in-content `v*` claims |
| `LINT-BYPASS-001` | #7 — "NEVER bypass X" paired with documented bypass |

Each rule ships positive + negative fixtures. `engine.test.mjs` now derives rule IDs from the fixtures directory so new rules extend coverage automatically. **24/24 fixture round-trips pass locally.**

### Linter is finding real drift

First audit against live `leo_protocol_sections`:

```
[protocol-lint] 12 rule(s) evaluated in 7ms
[protocol-lint] ⚠️  4 warning(s):
  [warn] LINT-PHRASE-004  section=460  Contains forbidden phrase: "No production code"
  [warn] LINT-THRESH-003  section=308  Universal gate threshold 70% vs type-specific range
  [warn] LINT-THRESH-003  section=309  Universal gate threshold 70% vs type-specific range
  [warn] LINT-THRESH-003  section=310  Universal gate threshold 70% vs type-specific range
```

All warn-severity — don't block regen. Chairman review decides whether to edit the sections or mark `status='false_positive'`.

### Corrective migration included

`database/migrations/20260422_protocol_linter_section_id_type_fix.sql` — widens `leo_lint_violations.section_id` from UUID to TEXT. Slice 1 incorrectly declared UUID; `leo_protocol_sections.id` is BIGINT. TEXT is a superset.

**Not auto-applied** (5 parallel sessions share this DB — schema change is a decision you make). `audit-writer.recordRun` tolerates the pre-migration state gracefully: if the violation insert fails specifically on the UUID type error, it logs a clear warning and keeps the in-memory result intact. CLI `audit` output remains correct; persistence to `leo_lint_violations` resumes once the migration lands.

### Performance

12 rules × ~240 sections = **7ms** (~70× headroom against the <500ms PRD budget).

### LEO state

- SD: **SD-PROTOCOL-LINTER-001** (infrastructure, high) — EXEC/in_progress
- LEAD-TO-PLAN 93% · PLAN-TO-EXEC 96%
- User story advanced: **US-001** (detect contradiction classes) — 12 of 16 classes now covered
- Remaining classes (4): #11 parent-child phase wording, #12 read-entire-file + token cap, #14-#16 dupes caught by LINT-ANCHOR-001 once `anchor_topic` is populated. Classes #14-#16 addressable in slice 7 (tagging sections); #11-#12 deferred as future rules (needs structured phase/doc metadata, not just content scanning).

### Remaining slices

| Slice | Contents | LOC est |
|-------|----------|---------|
| 6/n | `/admin/protocol-lint` dashboard page | ~300 |
| 7/n | `CLAUDE_CORE.md` docs + anchor_topic tagging + LEAD-FINAL handoff | ~80 |

### Test plan

- [ ] `npm run protocol:lint:test` — 24 fixture lines all `OK:`
- [ ] Apply `20260422_protocol_linter_section_id_type_fix.sql` via database-agent or manual review (single ALTER COLUMN, table empty, low risk)
- [ ] `npm run protocol:lint` post-migration — violations persist to `leo_lint_violations` rather than being logged-and-skipped
- [ ] Review the 4 real violations detected: edit offending sections OR mark `status='false_positive'` via `UPDATE leo_lint_violations SET status='false_positive' WHERE id = ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)