### PR TITLE
fix(QF-20260422-155): raise MAX_WORKTREE_COUNT from 10 to 20

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -313,7 +313,7 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
   const worktreesDir = getWorktreesDir(repoRoot);
 
   // US-005: Hard cap on total worktree count to prevent unbounded growth
-  const MAX_WORKTREE_COUNT = 10;
+  const MAX_WORKTREE_COUNT = 20;
   try {
     if (fs.existsSync(worktreesDir)) {
       const allEntries = fs.readdirSync(worktreesDir);

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -161,7 +161,7 @@ function resolveFromScan(sdKey, repoRoot) {
  * Max worktrees under .worktrees/. Parity with lib/worktree-manager.js.
  * Helper dirs (_archive, qf) are excluded from the count.
  */
-const MAX_WORKTREE_COUNT = 10;
+const MAX_WORKTREE_COUNT = 20;
 const WORKTREE_QUOTA_HELPERS = new Set(['_archive', 'qf', 'sd', 'adhoc']);
 
 /**
@@ -266,7 +266,7 @@ function createWorktree(sdKey, repoRoot) {
   if (existingCount >= MAX_WORKTREE_COUNT) {
     const err = new Error(
       `Worktree limit reached (${existingCount}/${MAX_WORKTREE_COUNT}). ` +
-      `Run cleanup or remove stale worktrees before creating new ones.`
+      'Run cleanup or remove stale worktrees before creating new ones.'
     );
     err.errorCode = 'WORKTREE_QUOTA_EXCEEDED';
     throw err;


### PR DESCRIPTION
## Summary
- Raises hard-coded worktree limit from **10 → 20** in both files where the constant lives (parity comment is honoured).
- Unblocks new SD claims when 5+ Claude Code sessions run in parallel on EHG_Engineer.

## Why
The 10-worktree cap was sized for ≤3 parallel sessions. With the current parallel-tick experiment (5 ticks + 1 interactive = 6 sessions, each typically holding 1-2 worktrees, plus 2-3 QF worktrees), steady-state demand routinely sits at or above 10. New SD claims fail with `WORKTREE_QUOTA_EXCEEDED` even when no SD/session is stuck — second occurrence in 24 hours.

## Files changed
- `scripts/resolve-sd-workdir.js` (US-003 quota check)
- `lib/worktree-manager.js` (US-005 hard cap)

Both copies stay in parity per the existing comment.

## Test plan
- [x] Pre-commit smoke tests pass (15/15)
- [ ] CI green
- [ ] After merge: rerun `sd-start.js` for SD-LEARN-FIX-ADDRESS-PAT-RETRO-003 and confirm worktree creation succeeds

## Tier
Tier 1 quick-fix (2 LOC of logic, auto-approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)