### PR TITLE
docs(SD-PROTOCOL-LINTER-001): document protocol:lint in CLAUDE_CORE.md (slice 6/n)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ Invoke the RCA Sub-Agent (`subagent_type="rca-agent"`). Your prompt MUST contain
 > Why: Sub-agents run formal, database-backed gate checks stored in `sub_agent_execution_results`. Handoff gates query this table — without sub-agent runs, gates block regardless of actual code quality.
 3. **Database-first** - No markdown files as source of truth
 > Why: Markdown files drift silently and are never validated. The DB enforces schema constraints, tracks state transitions, and is the only source future sessions can query reliably to resume work.
-4. **USE PROCESS SCRIPTS** - ⚠️ NEVER bypass add-prd-to-database.js, handoff.js ⚠️
-> Why: `handoff.js` and `add-prd-to-database.js` run the full gate pipeline and write canonical phase state to the DB. Bypassing them skips validation, leaves DB state inconsistent, and produces false-pass handoffs that corrupt downstream phases.
-5. **Small PRs** - Target ≤100 lines, max 400 with justification
+4. **USE PROCESS SCRIPTS** - ⚠️ Never bypass add-prd-to-database.js or handoff.js outside a documented emergency path ⚠️
+> Why: `handoff.js` and `add-prd-to-database.js` run the full gate pipeline and write canonical phase state to the DB. Bypassing them skips validation, leaves DB state inconsistent, and produces false-pass handoffs that corrupt downstream phases. Documented exceptions exist (`--bypass-validation --bypass-reason` on handoff.js, rate-limited to 3/SD and 10/day; `EMERGENCY_PUSH` for push enforcement) — use them with a ticket reference in the reason field.
+5. **Small PRs** - ≤100 LOC ideal; up to 400 LOC with justification per tiered PR Size Guidelines
 > Why: Large PRs fail review at higher rates, introduce more merge conflicts, and are harder to roll back. Retrospective analysis shows ≤100 LOC correlates with faster cycle time and fewer post-merge defects.
 6. **Priority-first** - Use `npm run prio:top3` to justify work
 > Why: Without priority justification, the highest-ROI SD can be overlooked in favour of something familiar. `prio:top3` enforces objective ordering, not recency ordering.
@@ -30,20 +30,27 @@ Invoke the RCA Sub-Agent (`subagent_type="rca-agent"`). Your prompt MUST contain
 > Why: CLAUDE.md is auto-generated from the DB. Operating on a stale file means reading outdated rules without knowing it — the session follows a protocol that has since been superseded.
 
 *For copy-paste version: see `templates/session-prologue.md` (generate via `npm run session:prologue`)*
+8. **Parallel-session safety** - In shared-working-tree sessions, run `npm run session:check-concurrency` before Write/Edit work; if contention is detected, isolate with `npm run session:worktree`
+> Why: Parallel Claude Code sessions sharing one working tree cause tool-result "internal error" messages when one session's `git checkout` mutates files mid-PostToolUse-hook in another session. The SessionStart auto-worktree hook (`scripts/hooks/concurrent-session-worktree.cjs`) catches some cases but is point-in-time; the CLI gives any session an explicit isolation check.
 
 ## AUTO-PROCEED Mode
 
 AUTO-PROCEED is **ON by default**. Phase transitions execute automatically, no confirmation prompts.
 > Why: The user approved the SD. Every unnecessary pause adds friction without adding value — AUTO-PROCEED respects that approval by eliminating confirmation theater.
 
-**Pause points** (even when ON): Orchestrator completion, blocking errors, test failures (2 retries), merge conflicts, all children blocked.
-> Why: These are the only states where user input can actually change the outcome. All others are decisions the orchestrator is authorized and expected to make autonomously.
+**Canonical Pause Points** (applies to AUTO-PROCEED, Continue Autonomously, and Orchestrator STOP):
+1. **Orchestrator completion** — after all children complete, pause for /learn review (only when Chaining is OFF; see SD Continuation Truth Table)
+2. **Blocking error requiring human decision** — e.g., merge conflicts, ambiguous requirements escalated from EXEC
+3. **Test failures after 2 retry attempts** — auto-retry exhausted, RCA sub-agent invoked before pause
+4. **All children blocked** — no ready work remains, human decision required
+5. **Critical security or data-loss scenario** — includes DB/code status mismatch (code shipped but DB shows incomplete)
 
-**NOT pause triggers**: scope size, "substantial" upcoming work, decomposition into multiple children, PRD creation, large refactors, "warrants confirmation". Phase boundaries are NOT pause points. If your reason isn't in the list above, KEEP WORKING.
-> Why: Each item on this list is a judgment call the orchestrator is empowered to make without escalation. Pausing on these trains the user to expect interruptions and undermines the AUTO-PROCEED contract.
-
-Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
+**NOT pause triggers**: scope size, "substantial" upcoming work, decomposition into children, PRD creation, large refactors, phase boundaries, or any "warrants confirmation" rationalization. If your reason is not on the five-point list above, KEEP WORKING. Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
 > Why: Confirmation-fishing is the most common AUTO-PROCEED failure mode. Naming it explicitly as a violation prevents the LLM from treating asking as a safe default when uncertain.
+
+> **For the authoritative transition matrix** (which handoffs require phase work before the next handoff, when chaining kicks in, orchestrator completion behavior), see the **SD Continuation Truth Table** below. It is canonical when any other doc conflicts with it.
+
+> **Chaining default**: **OFF** (pause at orchestrator boundary). See "Orchestrator Chaining Mode" for full details.
 
 ## SD Continuation
 
@@ -143,4 +150,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-04-22 9:01:21 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-04-23 9:43:54 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,7 +1,7 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-04-22 9:01:21 AM
-**Protocol**: LEO 4.3.3
+**Generated**: 2026-04-23 9:43:55 PM
+**Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 
 > Sub-agent routing enforced by PreToolUse hook. See `scripts/hooks/pre-tool-enforce.cjs`.
@@ -86,46 +86,6 @@ Task tool with subagent_type="database-agent":
 bash scripts/leo-stack.sh restart   # All 3 servers
 ```
 
-## 🚀 Session Verification & Quick Start (MANDATORY)
-
-## Session Start Checklist
-
-### Required Verification
-1. **Check Priority**: `npm run prio:top3`
-2. **Git Status**: Clean working directory?
-3. **Context Load**: CLAUDE_CORE.md + phase file
-
-### ⚠️ MANDATORY: Read Entire Files (No Partial Reads)
-
-**When reading any file that contains instructions, requirements, or critical context, you MUST read the ENTIRE file from start to finish.**
-
-**General Rule**: If a file is important enough to read, read it completely. Partial reads lead to missed requirements.
-
-**Files that MUST be read in full (no `limit` parameter):**
-- CLAUDE.md, CLAUDE_CORE.md, CLAUDE_LEAD.md, CLAUDE_PLAN.md, CLAUDE_EXEC.md
-- PRD content from database
-- Any file containing protocol instructions, requirements, or acceptance criteria
-- Configuration files (.json, .yaml, .env.example)
-- Test files when debugging failures
-- Migration files when working on database changes
-
-**When `limit` parameter IS acceptable:**
-- Log files (reading recent entries)
-- Large data files where you only need a sample
-- Files explicitly marked as "preview only"
-
-### Before Starting Work
-- Verify SD is in correct phase
-- Check for blockers: `SELECT * FROM v_sd_blockers WHERE sd_id = 'SD-XXX'`
-- Review recent handoffs if continuing
-
-### Key Commands
-| Command | Purpose |
-|---------|---------|
-| `npm run prio:top3` | Top priority SDs |
-| `git status` | Working tree status |
-| `npm run handoff:latest` | Latest handoff |
-
 ## 🔍 Session Start Verification (MANDATORY)
 
 **Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
@@ -160,6 +120,48 @@ SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID
 - If records don't exist, CREATE them before proceeding
 
 **Pattern Reference**: PAT-SESS-VER-001
+
+## 🚀 Session Verification & Quick Start (MANDATORY)
+
+## Session Start Checklist
+
+### Required Verification
+1. **Check Priority**: `npm run prio:top3`
+2. **Git Status**: Clean working directory?
+3. **Context Load**: CLAUDE_CORE.md + phase file
+
+### ⚠️ MANDATORY: Read Complete Files (Chunked Reads Allowed)
+
+**When reading any file that contains instructions, requirements, or critical context, you MUST read the complete file end-to-end — no skipping sections.**
+
+**General Rule**: If a file is important enough to read, read it completely. Partial reads lead to missed requirements.
+
+**Files that MUST be read completely:**
+- CLAUDE.md, CLAUDE_CORE.md, CLAUDE_LEAD.md, CLAUDE_PLAN.md, CLAUDE_EXEC.md
+- PRD content from database
+- Any file containing protocol instructions, requirements, or acceptance criteria
+- Configuration files (.json, .yaml, .env.example)
+- Test files when debugging failures
+- Migration files when working on database changes
+
+**Chunked reads**: Some CLAUDE files exceed the single-Read token cap. In that case, use sequential `offset`/`limit` calls until you reach end of file — the rule is "no skipped sections", not "one call". Do not substitute a Grep sample for full reading; Grep is for targeted lookups, not comprehension of protocol files.
+
+**When `limit` parameter alone (sample-only read) IS acceptable:**
+- Log files (reading recent entries)
+- Large data files where you only need a sample
+- Files explicitly marked as "preview only"
+
+### Before Starting Work
+- Verify SD is in correct phase
+- Check for blockers: `SELECT * FROM v_sd_blockers WHERE sd_id = 'SD-XXX'`
+- Review recent handoffs if continuing
+
+### Key Commands
+| Command | Purpose |
+|---------|---------|
+| `npm run prio:top3` | Top priority SDs |
+| `git status` | Working tree status |
+| `npm run handoff:latest` | Latest handoff |
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -306,14 +308,16 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 **ALL changes to main must be tracked** as either:
 
 ### Strategic Directive (SD) - For Substantial Work
-- Features, refactors, infrastructure (>50 LOC)
+- Features, refactors, infrastructure (>75 LOC, see Work Item Routing)
 - Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
 - Command: `npm run sd:create`
 
 ### Quick-Fix (QF) - For Small Fixes
-- Bugs, polish, docs (<=50 LOC)
+- Bugs, polish, docs (≤75 LOC per Tier 1/Tier 2 in Work Item Routing)
 - Branch: `quick-fix/QF-YYYYMMDD-NNN`
 - Command: `node scripts/create-quick-fix.js --interactive`
+
+> **LOC thresholds** are defined once in **Work Item Routing** (CLAUDE.md): Tier 1 ≤30 (auto-approve QF), Tier 2 31-75 (standard QF), Tier 3 >75 (full SD). Risk keywords (auth, migration, schema, feature) always force Tier 3 regardless of LOC.
 
 ### Why This Matters
 - All work tracked in database
@@ -374,39 +378,6 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 > **Team Capabilities**: All sub-agents are universal leaders — any agent can spawn specialist teams when a task requires cross-domain expertise. See **Teams Protocol** in CLAUDE.md for templates, dynamic agent creation, and knowledge enrichment.
 
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
-
 ## Execution Philosophy
 
 ### Quality-First (PARAMOUNT)
@@ -443,6 +414,39 @@ Before marking any stage/feature as complete:
 - Skip LEAD approval for child SDs
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
+
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## Sub-Agent Routing Reference
 
@@ -558,6 +562,38 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
+
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -599,38 +635,6 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 **Rule**: "Non-fatal" means the hook threw an unexpected exception. "Hook ran but wrote zero rows to its target table" is a **data integrity failure** that must surface.
 
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
-
 ## 🔄 Git Commit Guidelines
 
 **Git Commit Guidelines**: `<type>(<SD-ID>): <subject>` format MANDATORY
@@ -638,7 +642,7 @@ node scripts/child-sd-preflight.js SD-XXX-001
 **Required**: Type (feat/fix/docs/etc), SD-ID scope, imperative subject, AI attribution in footer
 **Timing**: After checklist items, before context switches, at logical breakpoints
 **Branch Strategy**: `eng/` prefix for EHG_Engineer, standard prefixes for EHG app features
-**Size**: <100 lines ideal, <200 max
+**Size**: ≤100 LOC ideal; 101-200 LOC acceptable with brief justification; 201-400 LOC requires detailed rationale; >400 LOC generally prohibited. See **PR Size Guidelines** in CLAUDE_CORE.md for the canonical tiered table.
 
 **Full Guidelines**: See `docs/03_protocols_and_standards/leo_git_commit_guidelines_v4.2.0.md`
 
@@ -685,17 +689,21 @@ These definitions are BINDING. Misinterpretation is a protocol violation.
 4. Retrospective created
 5. LEO Protocol validation trigger passes
 
-**NOT complete**: Code shipped but database shows 'draft'/'in_progress'
+**NOT complete**: Code shipped but database shows 'draft' / 'in_progress' / 'active'
 
 ### "Continue autonomously"
 **Definition**: Execute the current SD through its full LEO Protocol workflow WITHOUT stopping to ask for user confirmation at each step.
 **NOT**: Skip workflow steps for efficiency.
-**AUTO-PROCEED**: Phase transitions, post-completion sequence, and next SD selection all happen automatically.
-**ONLY STOP IF**:
-- Blocking error requires human decision (e.g., merge conflicts)
-- Tests fail after 2 retry attempts
-- Critical security or data-loss scenario
-- **NOT a stop condition**: scope size, "substantial" upcoming work, decomposition into multiple children, PRD creation, large refactors, or any "warrants confirmation" rationalization. Phase boundaries are NOT pause points. If your reason for stopping is not in the three bullets above, KEEP WORKING. Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
+**AUTO-PROCEED**: Phase transitions *within* an SD run automatically. Post-completion sequence (/document → /ship → /learn) and next-SD selection also run automatically — modulated by the SD Continuation Truth Table (which handoffs are TERMINAL / require phase work) and Chaining setting (orchestrator-to-orchestrator).
+
+**ONLY STOP IF** (Canonical Pause Points — same list as AUTO-PROCEED Mode):
+1. **Orchestrator completion** — after all children, when Chaining is OFF
+2. **Blocking error requiring human decision** — merge conflicts, ambiguous requirements
+3. **Test failures after 2 retry attempts**
+4. **All children blocked**
+5. **Critical security or data-loss scenario** (includes DB/code status mismatch)
+
+**NOT a stop condition**: scope size, "substantial" upcoming work, decomposition into multiple children, PRD creation, large refactors, or any "warrants confirmation" rationalization. Phase boundaries are NOT pause points. If your reason for stopping is not on the five-point list above, KEEP WORKING. Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
 
 ### "Child SD"
 **Definition**: An INDEPENDENT Strategic Directive that requires its own full LEAD→PLAN→EXEC cycle.
@@ -780,21 +788,29 @@ Parent SDs coordinate children; **every child goes through full LEAD→PLAN→EX
 | Type | Workflow | Use Case |
 |------|----------|----------|
 | `standalone` | LEAD→PLAN→EXEC | Normal SDs |
-| `parent` | LEAD→PLAN→waits→Complete | Multi-phase coordinator |
+| `parent` | LEAD→PLAN→EXEC (coordinates children)→Complete | Multi-phase coordinator |
 | `child` | LEAD→PLAN→EXEC→Complete | Sequential execution units |
+
+**Why parents enter EXEC**: The DB trigger `enforce_sd_phase_transition_rules` blocks child activation while the parent is in PLAN. The parent MUST transition to EXEC before any child can start — this is the parent's "EXEC work": coordinating, sequencing, and monitoring children rather than writing application code itself. See "Parent-Child SD Phase Governance" for the resolution pattern when a parent returns to PLAN for v2 planning.
 
 ### Key Rules
 1. **Every child gets full LEAD→PLAN→EXEC** - no shortcuts
 2. **Parent PLAN creates children** - PLAN agent proposes decomposition
-3. **Parent SDs bypass user story gates** - stories exist in child SDs
-4. **Children execute sequentially** - Child B waits for Child A
-5. **Parent completes last** - after all children finish
+3. **Parent enters EXEC before first child activation** - required by DB trigger; parent's EXEC work is coordination, not coding
+4. **Parent SDs bypass user story gates** - stories exist in child SDs
+5. **Children execute sequentially** - Child B waits for Child A
+6. **Parent completes last** - after all children finish
 
-### Orchestrator STOP Conditions
-STOP and verify ONLY if:
-- **Blocking dependency**: Child depends on incomplete child
-- **Critical error**: Tests fail after 2 retries, merge conflicts
-- **Database status mismatch**: Code shipped but DB shows incomplete
+### Canonical Pause Points (Orchestrator / Parent)
+
+**Canonical Pause Points** (applies to AUTO-PROCEED, Continue Autonomously, and Orchestrator STOP):
+1. **Orchestrator completion** — after all children complete, pause for /learn review (only when Chaining is OFF; see SD Continuation Truth Table)
+2. **Blocking error requiring human decision** — e.g., merge conflicts, ambiguous requirements escalated from EXEC
+3. **Test failures after 2 retry attempts** — auto-retry exhausted, RCA sub-agent invoked before pause
+4. **All children blocked** — no ready work remains, human decision required
+5. **Critical security or data-loss scenario** — includes DB/code status mismatch (code shipped but DB shows incomplete)
+
+**NOT pause triggers**: scope size, "substantial" upcoming work, decomposition into children, PRD creation, large refactors, phase boundaries, or any "warrants confirmation" rationalization. If your reason is not on the five-point list above, KEEP WORKING. Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
 
 ### Child SD Completion Checklist
 - [ ] Child has PRD in `product_requirements_v2`
@@ -825,7 +841,7 @@ SELECT get_next_child_sd('SD-PARENT-001');
 | `database` | 85% | All 5 | May skip UI-dependent E2E |
 | `security` | 90% | All 5 | Strictest validation |
 | `refactor` | 75-90% | All 5 | Varies by intensity |
-| `infrastructure` | 80% | 4 (skip EXEC-TO-PLAN) | No production code |
+| `infrastructure` | 80% | 4 (skip EXEC-TO-PLAN) | No customer-facing UI; CI/scripts ARE production backend code |
 | `documentation` | 60% | 4 (skip EXEC-TO-PLAN) | No code changes |
 | `orchestrator` | 70% | Coordinates children | USER_STORY gate bypassed |
 
@@ -856,7 +872,7 @@ LEAD-TO-PLAN → PLAN-TO-EXEC → [EXEC] → PLAN-TO-LEAD → LEAD-FINAL-APPROVA
 |---------|-------------|-------|
 | `feature` | **YES** | Human-verifiable outcome |
 | `bugfix` | **YES** | Verify fix works |
-| `infrastructure` | **EXEMPT** | Internal tooling |
+| `infrastructure` | **EXEMPT** | Internal tooling (no customer-facing UI) |
 | `documentation` | No | No runtime behavior |
 
 ### Pre-Handoff Check
@@ -1022,6 +1038,40 @@ node scripts/handoff.js history SD-XXX-001
 
 ### Rule
 **Never patch a downstream stage to compensate for upstream data.** The fix belongs where the bad data originates.
+
+## Protocol Consistency Linter
+
+Static checks for the LEO Protocol CLAUDE.md family. Detects threshold drift, enum drift, version drift, duplicate authoritative lists, and other consistency violations.
+
+### Commands
+| Command | Purpose |
+|---------|---------|
+| `npm run protocol:lint` | On-demand audit. Writes violations to `leo_lint_violations`. Exit non-zero on blocking violations. |
+| `npm run protocol:lint:test` | Run rule fixtures (positive/negative). CI uses this to verify rules. |
+| `npm run protocol:lint:promote <rule-id>` | Promote a warn-severity rule to block-severity. Requires 2+ clean regen runs. |
+
+### Auto-run
+The linter runs inside `generate-claude-md-from-db.js` after DB fetch and before file writes. Block-severity violations abort the regen — CLAUDE*.md files are not overwritten when drift is detected.
+
+### Bypass (rate-limited)
+```bash
+node scripts/generate-claude-md-from-db.js --skip-lint --skip-reason "<text>"
+```
+Limit: 3 bypasses per repository per week. All bypasses logged to `leo_lint_run_history`.
+
+### Where things live
+| Item | Location |
+|------|----------|
+| Declarative rules (JSON pattern) | `scripts/protocol-lint/rules/declarative/*.json` |
+| Code rules (semantic) | `scripts/protocol-lint/rules/code/*.mjs` |
+| Fixtures (positive + negative per rule) | `scripts/protocol-lint/fixtures/*.json` |
+| Engine | `scripts/protocol-lint/engine.mjs` |
+| Audit tables | `leo_lint_violations`, `leo_lint_run_history`, `leo_lint_rules` |
+
+### Adding a rule
+New rules ship at `severity='warn'`. After 2+ consecutive regen runs with zero violations on a rule, run `npm run protocol:lint:promote <rule-id>` to elevate to `severity='block'`. Every rule must include a positive fixture (triggers detection) and a negative fixture (does not trigger).
+
+*Added: SD-PROTOCOL-LINTER-001*
 
 ## 🗄️ Supabase Database Operations
 
@@ -1286,6 +1336,20 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 
 
+## Hot Issue Patterns (Auto-Updated)
+
+**CRITICAL**: These are active patterns detected from retrospectives. Review before starting work.
+
+| Pattern ID | Category | Severity | Count | Trend | Top Solution |
+|------------|----------|----------|-------|-------|--------------|
+| PAT-HF-EXECTOPLAN-0bda95fe | handoff_failure | [HIGH] high | 5 | [STABLE] | N/A |
+| PAT-RETRO-EXECTOPLAN-0bda95fe | session_retrospective | [HIGH] high | 5 | [STABLE] | N/A |
+| PAT-HF-PLANTOEXEC-eaccd2b3 | handoff_failure | [HIGH] high | 4 | [STABLE] | N/A |
+
+### Prevention Checklists
+
+
+*Patterns auto-updated from `issue_patterns` table. Use `npm run pattern:resolve PAT-XXX` to mark resolved.*
 
 
 
@@ -1294,52 +1358,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. PLAN_TO_EXEC Handoff Retrospective: Iterator Stage 19 Visual Convergence Loop [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 3/23/2026 | **Score**: 100
-
-**Key Improvements**:
-- [PAT-AUTO-c9b12816] google API error: 404 - Google API error 404: {
-  "error": {
-    "code": 404,
-  ...
-- [PAT-AUTO-0634bf78] Gate 4:valueDelivered failed: score 70/100
-
-**Action Items**:
-- [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
-
-### 2. PLAN_TO_EXEC Handoff Retrospective: Address PAT-AUTO-c9b12816: google API error: 404 - Google API error 404: {
-  "error": { [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 3/23/2026 | **Score**: 100
-
-**Key Improvements**:
-- [PAT-AUTO-58a34ffe] Gate RETROSPECTIVE_QUALITY_GATE failed: score 17/100
-- [PAT-AUTO-0634bf78] Gate 4:valueDelivered failed: score 70/100
-
-**Action Items**:
-- [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
-
-### 3. SD Completion Retrospective: Product Hunt GraphQL Integration [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 3/23/2026 | **Score**: 100
-
-**Key Improvements**:
-- Nested worktree session claim conflicts caused 30 minutes of debugging time
-- PRD inline mode requires manual DB inserts when standard scripts are unavailable in worktree
-
-**Action Items**:
-- [ ] Document nested worktree session claim conflict pattern in MEMORY.md
-- [ ] Monitor Product Hunt API rate limit usage in production for 2 weeks
-
-### 4. PLAN_TO_EXEC Handoff Retrospective: Awwwards Curated Design Reference Library [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 3/23/2026 | **Score**: 100
-
-**Key Improvements**:
-- [PAT-AUTO-0634bf78] Gate 4:valueDelivered failed: score 70/100
-- [PAT-AUTO-f5086216] Gate 2C:databaseQueriesIntegrated failed: score 52/100
-
-**Action Items**:
-- [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
-
-### 5. PLAN_TO_EXEC Handoff Retrospective: B1: leo_adrs Population During Stage 14 [QUALITY]
+### 1. PLAN_TO_EXEC Handoff Retrospective: C3: Auto-Iterate PRD Quality Loop [QUALITY]
 **Category**: PROCESS_IMPROVEMENT | **Date**: 3/25/2026 | **Score**: 100
 
 **Key Improvements**:
@@ -1348,6 +1367,48 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **Action Items**:
 - [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
+
+### 2. PLAN_TO_EXEC Handoff Retrospective: C5: Auto-Decompose SD Hierarchy from Architecture Plans [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 3/25/2026 | **Score**: 100
+
+**Key Improvements**:
+- [PAT-AUTO-360448d5] Gate SUCCESS_METRICS failed: score 66/100
+- [PAT-AUTO-58a34ffe] Gate RETROSPECTIVE_QUALITY_GATE failed: score 17/100
+
+**Action Items**:
+- [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
+
+### 3. PLAN_TO_EXEC Handoff Retrospective: B1: leo_adrs Population During Stage 14 [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 3/25/2026 | **Score**: 100
+
+**Key Improvements**:
+- [PAT-AUTO-360448d5] Gate SUCCESS_METRICS failed: score 66/100
+- [PAT-AUTO-58a34ffe] Gate RETROSPECTIVE_QUALITY_GATE failed: score 17/100
+
+**Action Items**:
+- [ ] Review PLAN-TO-EXEC outcomes and verify PRD acceptance criteria are met during i...
+
+### 4. LEAD_TO_PLAN Handoff Retrospective: C3: Auto-Iterate PRD Quality Loop [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 3/25/2026 | **Score**: 100
+
+**Key Improvements**:
+- [PAT-AUTO-360448d5] Gate SUCCESS_METRICS failed: score 66/100
+- [PAT-AUTO-58a34ffe] Gate RETROSPECTIVE_QUALITY_GATE failed: score 17/100
+
+**Action Items**:
+- [ ] Verify: PRDs below threshold are auto-enriched for SD-LEO-INFRA-STREAM-SPRINT-BR...
+- [ ] Validate: Enrichment is deterministic (no LLM) for SD-LEO-INFRA-STREAM-SPRINT-BR...
+
+### 5. LEAD_TO_PLAN Handoff Retrospective: Corrective: Vision Gap — semantic (semantic) (score 79/100) [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 3/25/2026 | **Score**: 100
+
+**Key Improvements**:
+- [PAT-AUTO-360448d5] Gate SUCCESS_METRICS failed: score 66/100
+- [PAT-AUTO-58a34ffe] Gate RETROSPECTIVE_QUALITY_GATE failed: score 17/100
+
+**Action Items**:
+- [ ] Verify: Semantic dimension score >= 93 for SD-MAN-GEN-CORRECTIVE-VISION-GAP-019
+- [ ] Validate: Evidence artifacts committed for SD-MAN-GEN-CORRECTIVE-VISION-GAP-019
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1413,7 +1474,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-04-22*
-*Protocol Version: 4.3.3*
-*Includes: Proposals (0) + Hot Patterns (0) + Lessons (5)*
+*Generated from database: 2026-04-23*
+*Protocol Version: 4.4.1*
+*Includes: Proposals (0) + Hot Patterns (3) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,12 +1,12 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-22T13:01:21.412Z -->
-<!-- git_commit: af3b313f -->
-<!-- db_snapshot_hash: 1d8fe83996199ce0 -->
+<!-- generated_at: 2026-04-23T01:43:54.948Z -->
+<!-- git_commit: dd4af67c -->
+<!-- db_snapshot_hash: 1b7482beab585910 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
-**Protocol**: LEO 4.3.3
+**Protocol**: LEO 4.4.1
 **Purpose**: Essential enforcement rules (<10k chars)
 
 ---
@@ -149,20 +149,19 @@ These definitions are BINDING. Misinterpretation is a protocol violation.
 4. Retrospective created
 5. LEO Protocol validation trigger passes
 
-**NOT complete**: Code shipped but database shows 'draft'/'in_progress'
+**NOT complete**: Code shipped but database shows 'draft' / 'in_progress' / 'active'
 
 ### "Continue autonomously"
 **Definition**: Execute the current SD through its full LEO Protocol workflow WITHOUT stopping to ask for user confirmation at each step.
 **NOT**: Skip workflow steps for efficiency.
-**AUTO-PROCEED**: Phase transitions, post-completion sequence, and next SD selection all happen automatically.
-**ONLY STOP IF**:
-- Blocking error requires human decision (e.g., merge conflicts)
-- Tests fail after 2 retry attempts
-- Critical security or data-loss scenario
-- **NOT a stop condition**: scope size, "substantial" upcoming work, decomposition into multiple children, PRD creation, large refactors, or any "warrants confirmation" rationalization. Phase boundaries are NOT pause points. If your reason for stopping is not in the three bullets above, KEEP WORKING. Asking "want me to continue or pause here?" at a phase transition is a protocol violation.
+**AUTO-PROCEED**: Phase transitions *within* an SD run automatically. Post-completion sequence (/document → /ship → /learn) and next-SD selection also run automatically — modulated by the SD Continuation Truth Table (which handoffs are TERMINAL / require phase work) and Chaining setting (orchestrator-to-orchestrator).
 
-### "Child SD"
-**Definition**: An INDEPENDENT Strategi
+**ONLY STOP IF** (Canonical Pause Points — same list as AUTO-PROCEED Mode):
+1. **Orchestrator completion** — after all children, when Chaining is OFF
+2. **Blocking error requiring human decision** — merge conflicts, ambiguous requirements
+3. **Test failures after 2 retry attempts**
+4. **All children blocked**
+5. **Critical security or data-loss scenario** (includes DB/code status mis
 
 *...truncated. Read full file for complete section.*
 
@@ -199,7 +198,7 @@ These definitions are BINDING. Misinterpretation is a protocol violation.
 |---------|-------------|-------|
 | `feature` | **YES** | Human-verifiable outcome |
 | `bugfix` | **YES** | Verify fix works |
-| `infrastructure` | **EXEMPT** | Internal tooling |
+| `infrastructure` | **EXEMPT** | Internal tooling (no customer-facing UI) |
 | `documentation` | No | No runtime behavior |
 
 ### Pre-Handoff Check
@@ -266,5 +265,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-04-22 9:01:21 AM*
-*Protocol: 4.3.3*
+*DIGEST generated: 2026-04-23 9:43:55 PM*
+*Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,12 +1,12 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-22T13:01:21.412Z -->
-<!-- git_commit: af3b313f -->
-<!-- db_snapshot_hash: 1d8fe83996199ce0 -->
+<!-- generated_at: 2026-04-23T01:43:54.948Z -->
+<!-- git_commit: dd4af67c -->
+<!-- db_snapshot_hash: 1b7482beab585910 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
-**Protocol**: LEO 4.3.3
+**Protocol**: LEO 4.4.1
 **Purpose**: Minimal router for gate enforcement (<3k chars)
 
 ---
@@ -89,9 +89,9 @@ Skipping CLAUDE_CORE.md causes: unknown SD type requirements, missed gate thresh
 > Why: Sub-agents run formal, database-backed gate checks stored in `sub_agent_execution_results`. Handoff gates query this table — without sub-agent runs, gates block regardless of actual code quality.
 3. **Database-first** - No markdown files as source of truth
 > Why: Markdown files drift silently and are never validated. The DB enforces schema constraints, tracks state transitions, and is the only source future sessions can query reliably to resume work.
-4. **USE PROCESS SCRIPTS** - ⚠️ NEVER bypass add-prd-to-database.js, handoff.js ⚠️
-> Why: `handoff.js` and `add-prd-to-database.js` run the full gate pipeline and write canonical phase state to the DB. Bypassing them skips validation, leaves DB state inconsistent, and produces false-pass handoffs that corrupt downstream phases.
-5. **Small PRs** - Target ≤100 lines, max 400 with justification
+4. **USE PROCESS SCRIPTS** - ⚠️ Never bypass add-prd-to-database.js or handoff.js outside a documented emergency path ⚠️
+> Why: `handoff.js` and `add-prd-to-database.js` run the full gate pipeline and write canonical phase state to the DB. Bypassing them skips validation, leaves DB state inconsistent, and produces false-pass handoffs that corrupt downstream phases. Documented exceptions exist (`--bypass-validation --bypass-reason` on handoff.js, rate-limited to 3/SD and 10/day; `EMERGENCY_PUSH` for push enforcement) — use them with a ticket reference in the reason field.
+5. **Small PRs** - ≤100 LOC ideal; up to 400 LOC with justification per tiered PR Size Guidelines
 > Why: Large PRs fail review at higher rates, introduce more merge conflicts, and are harder to roll back. Retrospective analysis shows ≤100 LOC correlates with faster cycle time and fewer post-merge defects.
 6. **Priority-first** - Use `npm run prio:top3` to justify work
 > Why: Without priority justification, the highest-ROI SD can be overlooked in favour of something familiar. `prio:top3` enforces objective ordering, not recency ordering.
@@ -99,6 +99,8 @@ Skipping CLAUDE_CORE.md causes: unknown SD type requirements, missed gate thresh
 > Why: CLAUDE.md is auto-generated from the DB. Operating on a stale file means reading outdated rules without knowing it — the session follows a protocol that has since been superseded.
 
 *For copy-paste version: see `templates/session-prologue.md` (generate via `npm run session:prologue`)*
+8. **Parallel-session safety** - In shared-working-tree sessions, run `npm run session:check-concurrency` before Write/Edit work; if contention is detected, isolate with `npm run session:worktree`
+> Why: Parallel Claude Code sessions sharing one working tree cause tool-result "internal error" messages when one session's `git checkout` mutates files mid-PostToolUse-hook in another session. The SessionStart auto-worktree hook (`scripts/hooks/concurrent-session-worktree.cjs`) catches some cases but is point-in-time; the CLI gives any session an explicit isolation check.
 
 ## Session Initialization - SD Selection
 
@@ -160,5 +162,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-04-22 9:01:21 AM*
-*Protocol: 4.3.3*
+*DIGEST generated: 2026-04-23 9:43:55 PM*
+*Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,7 +1,7 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-04-22 9:01:21 AM
-**Protocol**: LEO 4.3.3
+**Generated**: 2026-04-23 9:43:55 PM
+**Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 
 > For Issue Resolution Protocol + Five-Point Brief, see CLAUDE.md.
@@ -194,70 +194,6 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-# Branch was auto-created at LEAD-TO-PLAN handoff
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
-
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -346,6 +282,70 @@ If `research_confidence_score = 0.00`, you skipped this step.
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
 
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+# Branch was auto-created at LEAD-TO-PLAN handoff
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
+
 ## Vision/Architecture Doc Pre-Check
 
 ## Vision/Architecture Doc Pre-Check (Step 0.25)
@@ -361,12 +361,14 @@ If `research_confidence_score = 0.00`, you skipped this step.
 |-----------|-----------|--------|
 | Exists, current | Exists, current | Proceed — implementation is governed |
 | Exists, current | Missing or stale | Flag to PLAN — create/update arch plan first |
-| Missing | — | Check if SD is tactical (fix/QF) — OK to proceed. If strategic (feature/infra), flag for brainstorm |
+| Missing | — | Check if SD is tactical (bugfix/QF) — OK to proceed. If strategic (feature/infrastructure), flag for brainstorm |
 
 ### Skip Conditions
-- `sd_type` is `fix` or `documentation` — skip this check
+- `sd_type` is `bugfix` or `documentation` — skip this check
 - SD has `--from-uat` or `--from-feedback` provenance — skip (corrective work)
 - Parent orchestrator already passed this check — skip for children
+
+> Note: `bugfix` is the canonical sd_type value; the SDKeyGenerator maps user-facing `fix` → `bugfix` automatically (see CLAUDE_LEAD.md "SDKeyGenerator Errors").
 
 ## EXEC Phase Negative Constraints
 
@@ -428,6 +430,41 @@ Sub-agents are FIRST RESPONDERS in EXEC phase. When you encounter a problem that
 
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
+## Migration Script Pattern (MANDATORY)
+
+**Issue Pattern**: PAT-DB-MIGRATION-001
+
+When writing migration scripts, you MUST use the established pattern:
+
+### Correct Pattern
+```javascript
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+
+const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
+const client = await createDatabaseClient('engineer', { verify: true });
+const statements = splitPostgreSQLStatements(migrationSQL);
+
+for (const statement of statements) {
+  await client.query(statement);
+}
+
+await client.end();
+```
+
+### NEVER Use This Pattern
+```javascript
+// WRONG - exec_sql RPC does not exist
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(url, key);
+await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
+```
+
+### Before Writing Migration Scripts
+1. Search for existing patterns: `Glob *migration*.js`
+2. Read `scripts/run-sql-migration.js` as canonical template
+3. Use `lib/supabase-connection.js` utilities
+
 ## 📚 Skill Integration (EXEC Phase)
 
 ## Skill Integration During EXEC
@@ -456,12 +493,15 @@ Skills provide patterns, templates, and examples. Apply them to your specific im
 
 ### Skills vs Sub-Agents in EXEC
 
+Both are valid in EXEC — use them for different purposes:
+
 | Layer | When | Purpose | Example |
 |-------|------|---------|---------|
-| **Skills** | During implementation | Pattern guidance (creative) | "How do I structure this component?" |
-| **Sub-agents** | After implementation | Validation (verification) | "Is this migration safe?" |
+| **Skills** | While writing code | Creative guidance — "how do I structure this?" | `skill: "component-architecture"` |
+| **Sub-agents (first responders)** | On errors or domain-specific tasks | Immediate domain expertise | DB write error → `database-agent`; test failure → `rca-agent` then `testing-agent` |
+| **Sub-agents (validation gates)** | Before EXEC-TO-PLAN handoff | Formal, database-backed validation | `testing-agent` for coverage, `uat-agent` for acceptance |
 
-**Do NOT** invoke sub-agents during EXEC implementation. Save validation for PLAN_VERIFY phase.
+**Clarification**: Sub-agents ARE first responders in EXEC — invoke them immediately when you encounter a problem matching their domain (see "Phase-Specific Sub-Agent Guidance: EXEC" in this file). What belongs in PLAN_VERIFY is the *full formal validation sweep* (Gate 2 DESIGN + DATABASE fidelity, Gate 2.5 UI parity, Russian Judge quality scoring). Do not pre-run PLAN_VERIFY gates mid-implementation — but DO invoke domain sub-agents the instant you need them.
 
 ### Common Skill Chains by Task
 
@@ -502,43 +542,8 @@ Skills provide patterns, templates, and examples. Apply them to your specific im
 ### Remember
 
 Skills are for **creative guidance** (how to build).
-Sub-agents are for **validation** (did you build it right).
-Use skills during EXEC, save sub-agents for PLAN_VERIFY.
-
-## Migration Script Pattern (MANDATORY)
-
-**Issue Pattern**: PAT-DB-MIGRATION-001
-
-When writing migration scripts, you MUST use the established pattern:
-
-### Correct Pattern
-```javascript
-import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
-import { readFileSync } from 'fs';
-
-const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
-const client = await createDatabaseClient('engineer', { verify: true });
-const statements = splitPostgreSQLStatements(migrationSQL);
-
-for (const statement of statements) {
-  await client.query(statement);
-}
-
-await client.end();
-```
-
-### NEVER Use This Pattern
-```javascript
-// WRONG - exec_sql RPC does not exist
-import { createClient } from '@supabase/supabase-js';
-const supabase = createClient(url, key);
-await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
-```
-
-### Before Writing Migration Scripts
-1. Search for existing patterns: `Glob *migration*.js`
-2. Read `scripts/run-sql-migration.js` as canonical template
-3. Use `lib/supabase-connection.js` utilities
+Sub-agents act as **first responders** on domain-specific errors AND as **formal validators** before EXEC-TO-PLAN.
+Use both during EXEC — the distinction is about *purpose*, not *phase*.
 
 ## Validation Rules (SD-LEARN-008)
 
@@ -737,6 +742,24 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
+
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -820,24 +843,6 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
-
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 
@@ -1994,6 +1999,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-04-22*
-*Protocol Version: 4.3.3*
+*Generated from database: 2026-04-23*
+*Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,12 +1,12 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-22T13:01:21.412Z -->
-<!-- git_commit: af3b313f -->
-<!-- db_snapshot_hash: 1d8fe83996199ce0 -->
+<!-- generated_at: 2026-04-23T01:43:54.948Z -->
+<!-- git_commit: dd4af67c -->
+<!-- db_snapshot_hash: 1b7482beab585910 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
-**Protocol**: LEO 4.3.3
+**Protocol**: LEO 4.4.1
 **Purpose**: Implementation requirements and constraints (<10k chars)
 
 ---
@@ -211,5 +211,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-04-22 9:01:21 AM*
-*Protocol: 4.3.3*
+*DIGEST generated: 2026-04-23 9:43:55 PM*
+*Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,7 +1,7 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-04-22 9:01:21 AM
-**Protocol**: LEO 4.3.3
+**Generated**: 2026-04-23 9:43:55 PM
+**Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 
 > For Issue Resolution Protocol + Five-Point Brief, see CLAUDE.md.
@@ -100,10 +100,12 @@ Task(subagent_type="Explore", prompt="Identify affected areas and dependencies")
 - Similar patterns? → Inform PRD design, reuse existing code
 - Affected areas identified? → Scope boundaries are clear
 
-**Step 3: Run Formal Validation**
-```bash
-node lib/sub-agent-executor.js VALIDATION <SD-ID>
+**Step 3: Run Formal Validation (Task tool in interactive sessions)**
 ```
+Task(subagent_type="validation-agent", prompt="Execute VALIDATION analysis for SD-XXX. Check for duplicate implementations, overlapping SDs, and existing infrastructure. Store results in sub_agent_execution_results table.")
+```
+
+> **Interactive vs automated**: Use the Task tool in interactive sessions — it routes with full context and writes to `sub_agent_execution_results` where gates look for evidence. The `node lib/sub-agent-executor.js VALIDATION <SD-ID>` CLI is reserved for automated pipelines (CI jobs, cron scripts) where no session context exists. This rule is consistent across LEAD, PLAN, and EXEC.
 
 ### Why This Order?
 
@@ -134,7 +136,7 @@ Task(subagent_type="Explore", prompt="very thorough - Search for existing user p
 
 Claude: "Found existing user preferences in the EHG app. Let me now run formal validation to check for duplicates."
 
-node lib/sub-agent-executor.js VALIDATION <SD-ID>
+Task(subagent_type="validation-agent", prompt="Execute VALIDATION analysis for SD-XXX...")
 ```
 
 ## SD to Quick Fix Reverse Rubric (LEO v4.3.3)
@@ -415,9 +417,9 @@ node scripts/leo-create-sd.js --from-plan ~/.claude/plans/my-plan.md
 | `documentation` | None | Minimal validation |
 | `performance` | None | PERFORMANCE sub-agent recommended |
 
-### Step 2: LEAD Strategic Validation (9-Question Gate)
+### Step 2: LEAD Strategic Validation (Canonical 9-Question Gate)
 
-LEAD MUST answer these questions before approval:
+LEAD MUST answer all 9 questions before approval. This is the single canonical list — prior docs that reference "6-Question" or "8-Question" gates are superseded.
 
 1. **Need Validation**: Is this solving a real user problem?
 2. **Solution Assessment**: Does it align with business objectives?
@@ -426,8 +428,8 @@ LEAD MUST answer these questions before approval:
 5. **Existing Tools**: Can we leverage existing infrastructure?
 6. **Risk Assessment**: What are key risks and mitigations?
 7. **UI Inspectability**: Can users see and interpret the outputs?
-8. **Scope Reduction**: What was REMOVED? (Target >10% reduction)
-9. **Human-Verifiable Outcome**: What's the 30-second demo? (`smoke_test_steps`)
+8. **Scope Reduction (Deletion Audit)**: What was REMOVED? (Target >10% reduction, record in `scope_reduction_percentage`)
+9. **Human-Verifiable Outcome**: What's the 30-second demo? (populate `smoke_test_steps`)
 
 ### Step 3: Execute Handoff Chain
 
@@ -438,7 +440,7 @@ node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001
 # PLAN → EXEC (PRD complete, ready for implementation)
 node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX-001
 
-# EXEC → PLAN (Implementation complete, ready for verification)
+# EXEC → PLAN (Implementation complete, ready for verification) — CONDITIONAL by sd_type
 node scripts/handoff.js execute EXEC-TO-PLAN SD-XXX-001
 
 # PLAN → LEAD (Verification complete, ready for final approval)
@@ -449,10 +451,23 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 
 | Handoff | Key Gates | Threshold |
 |---------|-----------|-----------|
-| LEAD-TO-PLAN | SD_TRANSITION_READINESS, TARGET_APPLICATION, BASELINE_DEBT_CHECK | 85% |
-| PLAN-TO-EXEC | PREREQUISITE_CHECK, BMAD_VALIDATION, BRANCH_ENFORCEMENT | 85% |
-| EXEC-TO-PLAN | IMPLEMENTATION_FIDELITY, TESTING_REQUIRED, GIT_COMMIT | 85% |
-| PLAN-TO-LEAD | SUB_AGENT_ORCHESTRATION, RETROSPECTIVE_QUALITY | 85% |
+| LEAD-TO-PLAN | SD_TRANSITION_READINESS, TARGET_APPLICATION, BASELINE_DEBT_CHECK | SD-type-specific † |
+| PLAN-TO-EXEC | PREREQUISITE_CHECK, BMAD_VALIDATION, BRANCH_ENFORCEMENT | SD-type-specific † |
+| EXEC-TO-PLAN | IMPLEMENTATION_FIDELITY, TESTING_REQUIRED, GIT_COMMIT | SD-type-specific † |
+| PLAN-TO-LEAD | SUB_AGENT_ORCHESTRATION, RETROSPECTIVE_QUALITY | SD-type-specific † |
+
+**† SD-type-specific thresholds** (see "SD Type-Aware Workflow Paths" in CLAUDE_CORE.md for the canonical table):
+
+| SD Type | Threshold |
+|---------|-----------|
+| `feature`, `bugfix`, `database` | 85% |
+| `security` | 90% |
+| `refactor` | 75-90% (by intensity) |
+| `infrastructure` | 80% |
+| `orchestrator` | 70% |
+| `documentation` | 60% |
+
+**Default** when type is ambiguous: 85%.
 
 ### Reference Documents
 
@@ -855,7 +870,7 @@ node scripts/lead-review-submissions.js
 
 ## Strategic Validation Question 7: UI Inspectability
 
-**Added in LEO v4.3.3** - Part of LEAD Pre-Approval Gate
+**Part of the canonical 9-Question LEAD Pre-Approval Gate** (see "Strategic Directive Creation Process" → Step 2 in CLAUDE_LEAD.md for the full list).
 
 ### The Question
 > "Can users see and interpret the outputs this feature produces?"
@@ -882,16 +897,20 @@ node scripts/lead-review-submissions.js
 - Either expand SD scope to include UI OR
 - Create linked child SD for UI implementation
 
-### Integration with 6-Question Gate
+### Position in the 9-Question Gate
 
-This question is MANDATORY for all SDs that produce user-facing data. It should be evaluated alongside:
-1. Is this minimal scope?
-2. Does it fit the current phase?
-3. Are there simpler alternatives?
-4. What is the maintenance cost?
-5. Does it follow existing patterns?
-6. Is it required for the stated goal?
-**7. Can users see and interpret the outputs?** ← NEW
+This question is Q7 in the canonical 9-question sequence:
+1. Need Validation
+2. Solution Assessment
+3. Feasibility Review
+4. Value Analysis
+5. Existing Tools
+6. Risk Assessment
+**7. UI Inspectability** ← this question
+8. Scope Reduction (deletion audit, target >10%)
+9. Human-Verifiable Outcome (30-second demo / smoke_test_steps)
+
+This question is MANDATORY for all SDs that produce user-facing data.
 
 ## 🎯 Strategic Validation Question 9: Human-Verifiable Outcome
 
@@ -1503,6 +1522,6 @@ Check `objectives` (active, current period) and `key_results` (status != 'achiev
 
 ---
 
-*Generated from database: 2026-04-22*
-*Protocol Version: 4.3.3*
+*Generated from database: 2026-04-23*
+*Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,12 +1,12 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-22T13:01:21.412Z -->
-<!-- git_commit: af3b313f -->
-<!-- db_snapshot_hash: 1d8fe83996199ce0 -->
+<!-- generated_at: 2026-04-23T01:43:54.948Z -->
+<!-- git_commit: dd4af67c -->
+<!-- db_snapshot_hash: 1b7482beab585910 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
-**Protocol**: LEO 4.3.3
+**Protocol**: LEO 4.4.1
 **Purpose**: LEAD approval gates and constraints (<5k chars)
 
 ---
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-04-22 9:01:21 AM*
-*Protocol: 4.3.3*
+*DIGEST generated: 2026-04-23 9:43:55 PM*
+*Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,7 +1,7 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-04-22 9:01:21 AM
-**Protocol**: LEO 4.3.3
+**Generated**: 2026-04-23 9:43:55 PM
+**Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
 > For Issue Resolution Protocol + Five-Point Brief, see CLAUDE.md.
@@ -199,6 +199,30 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
+
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -236,30 +260,6 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
-
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
 
 ## Phase-Specific Sub-Agent Guidance: PLAN
 
@@ -697,33 +697,6 @@ When a pipeline has cascading failures, the architecture plan MUST:
 
 **Detection**: The gate checks architecture plan content for failure chain diagrams and upstream-first child ordering language.
 
-## 🔬 BMAD Method Enhancements
-
-## BMAD Enhancements
-
-### 6 Key Improvements
-1. **Unified Handoff System** - All handoffs via `handoff.js`
-2. **Database-First PRDs** - PRDs stored in database, not markdown
-3. **Validation Gates** - 4-gate validation before EXEC
-4. **Progress Tracking** - Automatic progress % calculation
-5. **Context Management** - Proactive monitoring, compression strategies
-6. **Sub-Agent Compression** - 3-tier output reduction
-
-### Using Handoff System
-```bash
-node scripts/handoff.js create "{message}"
-```
-
-### PRD Creation
-```bash
-node scripts/add-prd-to-database.js {SD-ID}
-```
-
-### Never Bypass
-- ⚠️ Always use process scripts
-- ⚠️ Never create PRDs as markdown files
-- ⚠️ Never skip validation gates
-
 ## Research Lookup Before PRD Creation
 
 ## Research Lookup Before PRD Creation (MANDATORY)
@@ -821,6 +794,33 @@ node scripts/add-prd-to-database.js SD-RESEARCH-106
 # → PRD includes research findings in technical_approach
 ```
 
+
+## 🔬 BMAD Method Enhancements
+
+## BMAD Enhancements
+
+### 6 Key Improvements
+1. **Unified Handoff System** - All handoffs via `handoff.js`
+2. **Database-First PRDs** - PRDs stored in database, not markdown
+3. **Validation Gates** - 4-gate validation before EXEC
+4. **Progress Tracking** - Automatic progress % calculation
+5. **Context Management** - Proactive monitoring, compression strategies
+6. **Sub-Agent Compression** - 3-tier output reduction
+
+### Using Handoff System
+```bash
+node scripts/handoff.js create "{message}"
+```
+
+### PRD Creation
+```bash
+node scripts/add-prd-to-database.js {SD-ID}
+```
+
+### Never Bypass
+- ⚠️ Always use process scripts
+- ⚠️ Never create PRDs as markdown files
+- ⚠️ Never skip validation gates
 
 ## CI/CD Pipeline Verification
 
@@ -1665,6 +1665,34 @@ for (const childId of childIds) {
 
 > **Team Capabilities**: When planning complex SDs, consider whether team spawning (any agent leading specialists) could parallelize cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
+
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1705,34 +1733,6 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
-
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
 
 ## Quality Assessment Integration in Handoffs
 
@@ -2413,6 +2413,6 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*Generated from database: 2026-04-22*
-*Protocol Version: 4.3.3*
+*Generated from database: 2026-04-23*
+*Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,12 +1,12 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-22T13:01:21.412Z -->
-<!-- git_commit: af3b313f -->
-<!-- db_snapshot_hash: 1d8fe83996199ce0 -->
+<!-- generated_at: 2026-04-23T01:43:54.948Z -->
+<!-- git_commit: dd4af67c -->
+<!-- db_snapshot_hash: 1b7482beab585910 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
-**Protocol**: LEO 4.3.3
+**Protocol**: LEO 4.4.1
 **Purpose**: PRD requirements and constraints (<5k chars)
 
 ---
@@ -157,5 +157,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-04-22 9:01:21 AM*
-*Protocol: 4.3.3*
+*DIGEST generated: 2026-04-23 9:43:55 PM*
+*Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-04-22T13:01:21.412Z",
-  "git_commit": "af3b313f",
-  "db_snapshot_hash": "1d8fe83996199ce0",
+  "generated_at": "2026-04-23T01:43:54.948Z",
+  "git_commit": "dd4af67c",
+  "db_snapshot_hash": "1b7482beab585910",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 9902,
-      "estimated_tokens": 2476,
-      "content_hash": "f299942eec1b49a4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
+      "chars": 11288,
+      "estimated_tokens": 2822,
+      "content_hash": "d83252b81625b7fd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 60557,
-      "estimated_tokens": 15140,
-      "content_hash": "b37b95aa5fde06f9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
+      "chars": 65841,
+      "estimated_tokens": 16461,
+      "content_hash": "2914ac08f6c32116",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 56640,
-      "estimated_tokens": 14160,
-      "content_hash": "6bbd4a6f956c9c0d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
+      "chars": 58959,
+      "estimated_tokens": 14740,
+      "content_hash": "5ca2a4dfe315133a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 87716,
       "estimated_tokens": 21929,
-      "content_hash": "ab55a3fc54eed3e2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
+      "content_hash": "5e0910818bdfbb73",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 75753,
-      "estimated_tokens": 18939,
-      "content_hash": "59f79511c6cb1c46",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
+      "chars": 76697,
+      "estimated_tokens": 19175,
+      "content_hash": "cf59d1696d4475bf",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 8286,
-      "estimated_tokens": 2072,
-      "content_hash": "42c8473c948bd2db",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
+      "chars": 9141,
+      "estimated_tokens": 2286,
+      "content_hash": "a87d11c58704a8cc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10903,
-      "estimated_tokens": 2726,
-      "content_hash": "774ee2fe021ac359",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
+      "chars": 10927,
+      "estimated_tokens": 2732,
+      "content_hash": "589fe60b6ffbb8d7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 4801,
       "estimated_tokens": 1201,
-      "content_hash": "4cf50fbabeae936e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "20e29712e69272d6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 7809,
       "estimated_tokens": 1953,
-      "content_hash": "7dde434d1937faf9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "af2213646f23f4ff",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10207,
       "estimated_tokens": 2552,
-      "content_hash": "af343b824c8e1e36",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "33a222c035c83811",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-PROTOCOL-LINTER-001\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -48,7 +48,8 @@
       "db_ops_protocol",
       "gate_failure_protocol",
       "pipeline_debugging_protocol",
-      "claim_heartbeat_protocol"
+      "claim_heartbeat_protocol",
+      "protocol_lint_tooling"
     ],
     "_removed_sections_note": "weighted_keyword_scoring (implementation detail of keyword-intent-scorer.js, hook handles routing), mandatory_agent_invocation (covered by PreToolUse hook routing advisory), sub_agent_prompt_quality (duplicate of Five-Point Brief in CLAUDE.md router), sustainable_issue_resolution (overlaps RCA mandate and execution philosophy), skill_integration (skills are self-documenting, reference pointer sufficient), communication_context (common sense for Opus 4.6), parallel_execution (common sense - read-safe, write-sequential), development_workflow (duplicate of application_architecture), strunkian_writing_standards (moved to docs/reference/), rca_multi_expert_protocol (RCA agent knows its own collaboration protocol)"
   },


### PR DESCRIPTION
## Summary

Closes **AC-10** of SD-PROTOCOL-LINTER-001 PRD: documents `npm run protocol:lint` in CLAUDE_CORE.md.

This is the final docs slice for SD-PROTOCOL-LINTER-001. Slices 1-5 delivered the engine, rules, regen integration, CLI, and audit schema. This slice adds the user-facing documentation.

## Changes

- **scripts/section-file-mapping.json**: register `protocol_lint_tooling` section_type so regen routes the new section into CLAUDE_CORE.md
- **DB section 576** (added out-of-band into `leo_protocol_sections`): describes commands, auto-run, bypass policy, file locations, and how to add new rules
- **All 10 CLAUDE files**: regenerated against current DB. Last regen was 2026-04-22 09:01 (~12 hrs ago) so the diff captures both my new section and accumulated DB drift

## Linter dogfood

The protocol-lint hook ran during regen (FR-3 working as designed):
- 12 rules evaluated in **5ms** (AC-5: P95 < 500ms ✓)
- 4 warning-severity violations detected in pre-existing content (LINT-PHRASE-004 on section 460, LINT-THRESH-003 on sections 308/309/310)
- These are real drift, not blockers — exactly the kind of regression this SD prevents

## PR size justification (>400 LOC)

11 files of auto-generated content. Splitting would either require two regen passes producing different DB-snapshot-hashes, or shipping an inconsistent CLAUDE family. Net semantic change is ~50 lines of new docs + DB-driven drift.

## Test plan
- [x] CLAUDE_CORE.md contains "Protocol Consistency Linter" section at line 1042
- [x] section-file-mapping.json includes `protocol_lint_tooling`
- [x] Regen completes successfully (manifest written)
- [x] Linter runs during regen and produces structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)