### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PAT-RETRO-003): bypass USER_STORIES_MISSING for non-feature SD types

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -16,6 +16,35 @@
 import { SD_TYPE_THRESHOLDS, DEFAULT_THRESHOLD, JSONB_FIELDS } from '../../sd-quality-scoring.js';
 
 /**
+ * SD-LEARN-FIX-ADDRESS-PAT-RETRO-003 (US-001):
+ * Determines whether an SD requires user stories at PLAN-TO-EXEC time.
+ *
+ * Aligns with the "Required Sub-Agents by Type" matrix in CLAUDE_CORE.md —
+ * only feature (and conservatively, bugfix) SDs require STORIES. Infrastructure,
+ * documentation, database, security, and refactor types are exempt.
+ *
+ * Returns true (stories required) for unknown/null types as a safe default.
+ *
+ * Future: SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001 will centralize this in
+ * lib/protocol-policies/orchestrator-bypass.js. When that ships, refactor
+ * this to import the shared helper.
+ *
+ * @param {string|null|undefined} sdType - The sd_type field value
+ * @returns {boolean} true if the SD requires user stories at PLAN-TO-EXEC
+ */
+export function shouldRequireUserStories(sdType) {
+  const STORY_EXEMPT_TYPES = new Set([
+    'infrastructure',
+    'documentation',
+    'database',
+    'security',
+    'refactor'
+  ]);
+  if (!sdType || typeof sdType !== 'string') return true;
+  return !STORY_EXEMPT_TYPES.has(sdType);
+}
+
+/**
  * Run prerequisite preflight checks for a given handoff type.
  * Returns { passed, issues[] } where each issue has { code, message, remediation }.
  */
@@ -285,22 +314,33 @@ async function checkPlanToExecPrereqs(supabase, sd, sdId) {
     }
   }
 
-  // Check user stories exist
-  const { data: stories, error: storiesErr } = await supabase
-    .from('user_stories')
-    .select('story_key')
-    .eq('sd_id', sd.id);
+  // SD-LEARN-FIX-ADDRESS-PAT-RETRO-003 (US-001/US-002):
+  // Skip USER_STORIES_MISSING for SD types where STORIES is not required per
+  // CLAUDE_CORE.md sub-agent matrix. Feature/bugfix still enforce.
+  if (shouldRequireUserStories(sd.sd_type)) {
+    const { data: stories, error: storiesErr } = await supabase
+      .from('user_stories')
+      .select('story_key')
+      .eq('sd_id', sd.id);
 
-  if (storiesErr || !stories || stories.length === 0) {
+    if (storiesErr || !stories || stories.length === 0) {
+      issues.push({
+        code: 'USER_STORIES_MISSING',
+        message: 'No user stories found for this SD',
+        remediation: [
+          `Create user stories linked to ${sdId}. story_key format: '${sdId}:US-001'.`,
+          'Required fields: story_key, sd_id, title, user_role, user_want, user_benefit,',
+          '  acceptance_criteria (array), implementation_context (string).',
+          'Example story_key values: ' + sdId + ':US-001, ' + sdId + ':US-002'
+        ].join('\n')
+      });
+    }
+  } else {
     issues.push({
-      code: 'USER_STORIES_MISSING',
-      message: 'No user stories found for this SD',
-      remediation: [
-        `Create user stories linked to ${sdId}. story_key format: '${sdId}:US-001'.`,
-        'Required fields: story_key, sd_id, title, user_role, user_want, user_benefit,',
-        '  acceptance_criteria (array), implementation_context (string).',
-        'Example story_key values: ' + sdId + ':US-001, ' + sdId + ':US-002'
-      ].join('\n')
+      code: 'USER_STORIES_BYPASSED',
+      severity: 'info',
+      message: `sd_type '${sd.sd_type}' exempt from STORIES requirement per CLAUDE_CORE.md sub-agent matrix`,
+      remediation: 'No action required — informational entry only.'
     });
   }
 

--- a/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
@@ -1,0 +1,196 @@
+/**
+ * Tests for sd_type-aware exemption of USER_STORIES_MISSING preflight check.
+ * SD-LEARN-FIX-ADDRESS-PAT-RETRO-003 (US-001, US-002)
+ *
+ * Verifies:
+ * - shouldRequireUserStories() returns false for exempt sd_types
+ * - shouldRequireUserStories() returns true for feature/bugfix/null/unknown
+ * - checkPlanToExecPrereqs bypasses USER_STORIES_MISSING for exempt types
+ * - checkPlanToExecPrereqs preserves USER_STORIES_MISSING for non-exempt types
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  shouldRequireUserStories,
+  runPrerequisitePreflight
+} from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+describe('shouldRequireUserStories() helper', () => {
+  describe('exempt sd_types (should return false)', () => {
+    const EXEMPT = ['infrastructure', 'documentation', 'database', 'security', 'refactor'];
+    EXEMPT.forEach((type) => {
+      it(`returns false for sd_type='${type}'`, () => {
+        expect(shouldRequireUserStories(type)).toBe(false);
+      });
+    });
+  });
+
+  describe('non-exempt sd_types (should return true)', () => {
+    const REQUIRED = ['feature', 'bugfix'];
+    REQUIRED.forEach((type) => {
+      it(`returns true for sd_type='${type}'`, () => {
+        expect(shouldRequireUserStories(type)).toBe(true);
+      });
+    });
+  });
+
+  describe('safe defaults (should return true)', () => {
+    it('returns true for null', () => {
+      expect(shouldRequireUserStories(null)).toBe(true);
+    });
+
+    it('returns true for undefined', () => {
+      expect(shouldRequireUserStories(undefined)).toBe(true);
+    });
+
+    it('returns true for empty string', () => {
+      expect(shouldRequireUserStories('')).toBe(true);
+    });
+
+    it('returns true for unknown sd_type string', () => {
+      expect(shouldRequireUserStories('unknown_type')).toBe(true);
+    });
+
+    it('returns true for non-string types (numbers, objects)', () => {
+      expect(shouldRequireUserStories(42)).toBe(true);
+      expect(shouldRequireUserStories({})).toBe(true);
+      expect(shouldRequireUserStories([])).toBe(true);
+    });
+  });
+});
+
+describe('checkPlanToExecPrereqs USER_STORIES bypass behavior', () => {
+  function makeMockSupabase({ sdRow, prdRow, storyRows = [] }) {
+    return {
+      from: (table) => {
+        if (table === 'user_stories') {
+          return {
+            select: () => ({
+              eq: async () => ({ data: storyRows, error: null })
+            })
+          };
+        }
+        const builder = {
+          select: () => builder,
+          eq: () => builder,
+          single: async () => {
+            if (table === 'strategic_directives_v2') return { data: sdRow, error: null };
+            if (table === 'product_requirements_v2') return { data: prdRow || null, error: null };
+            return { data: null, error: null };
+          }
+        };
+        return builder;
+      }
+    };
+  }
+
+  it('bypasses USER_STORIES_MISSING for sd_type=infrastructure (no stories)', async () => {
+    const sd = {
+      id: 'SD-TEST-INFRA-001',
+      sd_key: 'SD-TEST-INFRA-001',
+      sd_type: 'infrastructure',
+      smoke_test_steps: [],
+      success_criteria: [{ criterion: 'x', measure: 'y' }]
+    };
+    const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+    const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: [] });
+
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', 'SD-TEST-INFRA-001');
+
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).not.toContain('USER_STORIES_MISSING');
+    expect(codes).toContain('USER_STORIES_BYPASSED');
+    const bypass = result.issues.find((i) => i.code === 'USER_STORIES_BYPASSED');
+    expect(bypass.severity).toBe('info');
+    expect(bypass.message).toContain('infrastructure');
+    expect(bypass.message).toContain('CLAUDE_CORE.md');
+  });
+
+  it('bypasses USER_STORIES_MISSING for sd_type=documentation, database, security, refactor', async () => {
+    const exemptTypes = ['documentation', 'database', 'security', 'refactor'];
+    for (const sdType of exemptTypes) {
+      const sd = {
+        id: `SD-TEST-${sdType.toUpperCase()}-001`,
+        sd_key: `SD-TEST-${sdType.toUpperCase()}-001`,
+        sd_type: sdType,
+        smoke_test_steps: [],
+        success_criteria: [{ criterion: 'x', measure: 'y' }]
+      };
+      const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+      const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: [] });
+
+      const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', sd.sd_key);
+      const codes = result.issues.map((i) => i.code);
+      expect(codes, `${sdType} should bypass`).not.toContain('USER_STORIES_MISSING');
+      expect(codes, `${sdType} should log bypass`).toContain('USER_STORIES_BYPASSED');
+    }
+  });
+
+  it('preserves USER_STORIES_MISSING for sd_type=feature (no stories)', async () => {
+    const sd = {
+      id: 'SD-TEST-FEAT-001',
+      sd_key: 'SD-TEST-FEAT-001',
+      sd_type: 'feature',
+      smoke_test_steps: [],
+      success_criteria: [{ criterion: 'x', measure: 'y' }]
+    };
+    const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+    const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: [] });
+
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', 'SD-TEST-FEAT-001');
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('USER_STORIES_MISSING');
+    expect(codes).not.toContain('USER_STORIES_BYPASSED');
+  });
+
+  it('preserves USER_STORIES_MISSING for sd_type=bugfix (no stories)', async () => {
+    const sd = {
+      id: 'SD-TEST-BUG-001',
+      sd_key: 'SD-TEST-BUG-001',
+      sd_type: 'bugfix',
+      smoke_test_steps: [],
+      success_criteria: [{ criterion: 'x', measure: 'y' }]
+    };
+    const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+    const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: [] });
+
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', 'SD-TEST-BUG-001');
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('USER_STORIES_MISSING');
+    expect(codes).not.toContain('USER_STORIES_BYPASSED');
+  });
+
+  it('does not push USER_STORIES_MISSING when sd_type=feature has stories', async () => {
+    const sd = {
+      id: 'SD-TEST-FEAT-002',
+      sd_key: 'SD-TEST-FEAT-002',
+      sd_type: 'feature',
+      smoke_test_steps: [],
+      success_criteria: [{ criterion: 'x', measure: 'y' }]
+    };
+    const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+    const stories = [{ story_key: 'SD-TEST-FEAT-002:US-001' }];
+    const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: stories });
+
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', 'SD-TEST-FEAT-002');
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).not.toContain('USER_STORIES_MISSING');
+    expect(codes).not.toContain('USER_STORIES_BYPASSED');
+  });
+
+  it('treats null sd_type as enforcement (safe default)', async () => {
+    const sd = {
+      id: 'SD-TEST-NULL-001',
+      sd_key: 'SD-TEST-NULL-001',
+      sd_type: null,
+      smoke_test_steps: [],
+      success_criteria: [{ criterion: 'x', measure: 'y' }]
+    };
+    const prd = { id: 'PRD-1', status: 'approved', executive_summary: 'a'.repeat(60) };
+    const supabase = makeMockSupabase({ sdRow: sd, prdRow: prd, storyRows: [] });
+
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', 'SD-TEST-NULL-001');
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('USER_STORIES_MISSING');
+    expect(codes).not.toContain('USER_STORIES_BYPASSED');
+  });
+});


### PR DESCRIPTION
## Summary

Aligns `prerequisite-preflight.js` with **CLAUDE_CORE.md "Required Sub-Agents by Type"** matrix. Only `feature` and `bugfix` SDs require user stories at PLAN-TO-EXEC time. Infrastructure, documentation, database, security, and refactor SD types are now exempt.

## Why
- 5 active issue patterns / 12 occurrences blocking PLAN-TO-EXEC for SDs that should never have hit USER_STORIES_MISSING per the sub-agent matrix
- 38% of affected SDs are sd_type=infrastructure (5 of 13 distinct SDs)
- Original PAT-RETRO-PLANTOEXEC-f52adebf bundled USER_STORIES_MISSING with `no_deterministic_identity`; the latter is being addressed by SD-LEO-INFRA-SESSION-PID-MARKER-001 + SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001

## What
- Adds `shouldRequireUserStories(sdType)` exported helper (10 LOC)
- Wraps existing user_stories DB query in `if (shouldRequireUserStories(sd.sd_type))` guard (additive — no removal of existing logic)
- Pushes informational `USER_STORIES_BYPASSED` issue (severity: info) when bypass triggers
- 18 new unit tests covering all sd_type cases + edge cases (null, undefined, unknown)

## Coordination with sibling SDs
- **SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001** plans `shouldRequireUserStories()` in `lib/protocol-policies/orchestrator-bypass.js`. Helper signature here is designed to be merge-compatible — when POLICY-001 ships, refactor to import the shared helper
- **SD-LEO-INFRA-SESSION-PID-MARKER-001** addresses the no_deterministic_identity portion of the original pattern (different mechanism — out of scope here)

## Test plan
- [x] 18 new unit tests pass locally (vitest)
- [x] 15 smoke tests pass locally (no regressions)
- [ ] CI green
- [ ] After merge: re-run PLAN-TO-EXEC handoff for an infrastructure SD without user stories — should pass with USER_STORIES_BYPASSED in issues

## Risk profile (per Risk sub-agent)
Overall: **3.5/10 LOW**. Single-file behavior change with strictly additive guard; safe-fail default for unknown sd_types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)