### PR TITLE
fix(QF-20260423-725): filter info-severity entries in preflight pass check

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -104,8 +104,12 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
     return { passed: true, issues: [] };
   }
 
+  // Quick-fix QF-20260423-725: Filter informational entries before determining pass/fail.
+  // Info entries (e.g. USER_STORIES_BYPASSED for exempt SD types per PR #3240) must not
+  // block the handoff — they are audit trail, not blockers.
+  const blockingIssues = issues.filter(i => i.severity !== 'info');
   return {
-    passed: issues.length === 0,
+    passed: blockingIssues.length === 0,
     issues
   };
 }


### PR DESCRIPTION
## Summary

- Fixes `prerequisite-preflight.js` returning `passed=false` when the only entry in the issues list is informational.
- Unblocks PLAN-TO-EXEC handoff for all SD types that PR #3240 marked exempt from user-story preflight (infrastructure, documentation, database, refactor, and the auth-category type).
- Second-order bug on top of SD-LEARN-FIX-ADDRESS-PAT-RETRO-003 (PR #3240): the exemption logic correctly emitted an `{ severity: 'info' }` audit entry but the caller's pass/fail check never distinguished severity.

## Root cause

```js
// before
return { passed: issues.length === 0, issues };
```

The `USER_STORIES_BYPASSED` entry emitted by the type-exemption helper had `severity: 'info'` and remediation text `"No action required — informational entry only."`, yet it still flipped `passed` to `false`. `--bypass-validation` does not apply to preflight (only to the post-preflight 24-gate pipeline), so there was no clean workaround.

## Fix

```js
// after — 5 added / 1 removed
const blockingIssues = issues.filter(i => i.severity !== 'info');
return { passed: blockingIssues.length === 0, issues };
```

Informational entries remain in the returned `issues` array for audit/logging; only non-`info` entries affect the boolean verdict.

## Reproduced on

`SD-LEO-INFRA-SD-INTRAPHASE-PROGRESS-001` (sd_type=infrastructure): PRD approved, 20/20 precheck gates passing at 96%, handoff still blocking on `PREREQUISITE_PREFLIGHT_FAILED`.

## Test plan

- [x] Inline smoke test with mocked supabase — infrastructure SD with approved PRD: `passed=true`, issues array still carries the `USER_STORIES_BYPASSED[info]` entry for audit.
- [ ] Post-merge: retry PLAN-TO-EXEC on SD-LEO-INFRA-SD-INTRAPHASE-PROGRESS-001 and confirm it transitions cleanly.
- [ ] No regression on non-exempt types (feature/bugfix): those still emit `USER_STORIES_MISSING` without `severity:'info'`, so the filter does not affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)