### PR TITLE
fix(SD-LEO-INFRA-SESSION-PID-MARKER-001): align capture-session-id hook timeout so PID markers are written

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,7 +59,7 @@
           {
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/capture-session-id.cjs",
-            "timeout": 3
+            "timeout": 15
           }
         ]
       }

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -67,17 +67,35 @@ function logSpawnError(sessionId, ccPid, err, code) {
   console.error(`SessionStart:session-tick: spawn failed: ${entry.error_message} (code=${entry.error_code} platform=${entry.platform})`);
 }
 
+// SD-LEO-INFRA-SESSION-PID-MARKER-001: timeouts sized so max internal work
+// (tree_walk + scan) stays under the registered hook timeout in settings.json.
+// Hook timeout = 15s; internal budget = tree_walk(6s) + scan(3s) = 9s → 6s margin.
+const TREE_WALK_TIMEOUT_MS = 6000;
+const SCAN_TIMEOUT_MS = 3000;
+
+function logDiscoveryEvent(fields) {
+  // Structured JSON log on stderr (hook stdout is reserved for env-file exports).
+  // Always-on at INFO per PRD FR-3.
+  const entry = { event: 'capture-session-id.discovery', timestamp: new Date().toISOString(), ...fields };
+  try { console.error(JSON.stringify(entry)); } catch { /* best effort */ }
+}
+
 /**
  * Find the Claude Code node.exe PID by walking the process ancestry chain.
  * Mirrors the logic in lib/terminal-identity.js findClaudeCodePid(), but in CJS
  * for use in this hook. Falls back to process scan if tree walk fails.
  *
+ * @param {string} entryPath - SessionStart source from Claude Code (startup|resume|compact|reconnect|unknown)
  * @returns {string|null} Claude Code process PID
  */
-function findClaudeCodePid() {
-  if (process.platform !== 'win32') return null;
+function findClaudeCodePid(entryPath = 'unknown') {
+  if (process.platform !== 'win32') {
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'none', outcome: 'skipped_non_windows', platform: process.platform });
+    return null;
+  }
 
   // Method 1: Walk process ancestry
+  const walkStart = process.hrtime.bigint();
   try {
     const script = [
       `$p = ${process.pid}`,
@@ -94,7 +112,7 @@ function findClaudeCodePid() {
     const raw = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
-      timeout: 10000
+      timeout: TREE_WALK_TIMEOUT_MS
     }).trim();
 
     if (raw) {
@@ -109,16 +127,28 @@ function findClaudeCodePid() {
         if (proc.name === 'node.exe' || proc.name === 'node') {
           const parent = chain[i + 1];
           if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'].includes(parent.name)) {
+            const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
+            logDiscoveryEvent({ entry_path: entryPath, method_used: 'tree_walk', outcome: 'success', duration_ms: dur, chain_depth: chain.length });
             return proc.pid;
           }
         }
       }
     }
-  } catch { /* fall through to scan */ }
+    const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'tree_walk', outcome: 'no_match', duration_ms: dur });
+  } catch (err) {
+    const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'tree_walk', outcome: 'error', duration_ms: dur, error: err && err.message ? String(err.message).slice(0, 200) : 'unknown' });
+    /* fall through to scan */
+  }
 
   // Method 2: Scan all node.exe processes for SSE port match
   const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
-  if (!ssePort) return null;
+  if (!ssePort) {
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'scan', outcome: 'skipped_no_sse_port' });
+    return null;
+  }
+  const scanStart = process.hrtime.bigint();
   try {
     const script = [
       'Get-CimInstance Win32_Process -Filter "Name=\'node.exe\'" -ErrorAction SilentlyContinue |',
@@ -130,10 +160,19 @@ function findClaudeCodePid() {
     const raw = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
-      timeout: 5000
+      timeout: SCAN_TIMEOUT_MS
     }).trim();
-    if (raw && /^\d+$/.test(raw)) return raw;
-  } catch { /* give up */ }
+    const dur = Number((process.hrtime.bigint() - scanStart) / 1000000n);
+    if (raw && /^\d+$/.test(raw)) {
+      logDiscoveryEvent({ entry_path: entryPath, method_used: 'scan', outcome: 'success', duration_ms: dur, sse_port: ssePort });
+      return raw;
+    }
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'scan', outcome: 'no_match', duration_ms: dur, sse_port: ssePort });
+  } catch (err) {
+    const dur = Number((process.hrtime.bigint() - scanStart) / 1000000n);
+    logDiscoveryEvent({ entry_path: entryPath, method_used: 'scan', outcome: 'error', duration_ms: dur, error: err && err.message ? String(err.message).slice(0, 200) : 'unknown' });
+    /* give up */
+  }
 
   return null;
 }
@@ -180,7 +219,12 @@ function main() {
         // (process.ppid is often cmd.exe, not Claude Code). This PID matches what
         // getTerminalId() → findClaudeCodePid() discovers at Bash tool runtime.
         const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
-        const ccPid = findClaudeCodePid() || process.ppid || process.pid;
+        const entryPath = data.source || 'unknown';
+        const discoveredPid = findClaudeCodePid(entryPath);
+        const ccPid = discoveredPid || process.ppid || process.pid;
+        if (!discoveredPid) {
+          logDiscoveryEvent({ entry_path: entryPath, method_used: 'fallback_ppid', outcome: 'degraded', fallback_ppid: ccPid });
+        }
         const markerDir = path.resolve(__dirname, '../../.claude/session-identity');
         try {
           if (!fs.existsSync(markerDir)) {
@@ -288,9 +332,10 @@ function main() {
       resolve();
     });
 
-    // Timeout after 8 seconds if stdin doesn't close.
-    // Increased from 2s to accommodate PowerShell process tree walk on Windows.
-    setTimeout(resolve, 8000);
+    // Timeout must exceed the internal PowerShell budget (tree_walk + scan = 9s).
+    // Registered hook timeout in .claude/settings.json is 15s; 12s leaves 3s margin
+    // for marker write + cleanup before Claude Code kills the process.
+    setTimeout(resolve, 12000);
   });
 }
 

--- a/tests/capture-session-id-hook.test.js
+++ b/tests/capture-session-id-hook.test.js
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for capture-session-id.cjs hook
+ * SD-LEO-INFRA-SESSION-PID-MARKER-001
+ *
+ * Covers:
+ *   TS-5: 3 concurrent invocations produce 3 pid-*.json markers
+ *   TR-2: settings.json registered timeout ≥ internal PowerShell budget + margin
+ *   FR-3: Discovery log line emitted on every invocation
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, existsSync, readdirSync, unlinkSync, statSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+const hookPath = resolve(repoRoot, 'scripts/hooks/capture-session-id.cjs');
+const settingsPath = resolve(repoRoot, '.claude/settings.json');
+const markerDir = resolve(repoRoot, '.claude/session-identity');
+
+function readHookSource() {
+  return readFileSync(hookPath, 'utf8');
+}
+
+function extractNumberConstant(src, name) {
+  const m = src.match(new RegExp(`const\\s+${name}\\s*=\\s*(\\d+)`));
+  return m ? Number(m[1]) : null;
+}
+
+function extractOuterSetTimeout(src) {
+  const m = src.match(/setTimeout\(\s*resolve\s*,\s*(\d+)\s*\)/);
+  return m ? Number(m[1]) : null;
+}
+
+function getRegisteredHookTimeoutSeconds() {
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+  const sessionStart = settings?.hooks?.SessionStart || [];
+  for (const entry of sessionStart) {
+    for (const hook of entry.hooks || []) {
+      if (typeof hook.command === 'string' && hook.command.includes('capture-session-id.cjs')) {
+        return hook.timeout;
+      }
+    }
+  }
+  return null;
+}
+
+describe('capture-session-id.cjs — timing budget invariant', () => {
+  let src;
+  beforeAll(() => { src = readHookSource(); });
+
+  it('registered hook timeout is in seconds, not milliseconds', () => {
+    // Claude Code hook timeouts are in SECONDS per its documented schema.
+    // A 3-digit timeout would signal someone confused the unit.
+    const t = getRegisteredHookTimeoutSeconds();
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(120);
+  });
+
+  it('settings.json hook timeout is at least 15s', () => {
+    const t = getRegisteredHookTimeoutSeconds();
+    expect(t).toBeGreaterThanOrEqual(15);
+  });
+
+  it('internal PowerShell budget fits within the registered hook timeout (+3s margin)', () => {
+    const treeWalk = extractNumberConstant(src, 'TREE_WALK_TIMEOUT_MS');
+    const scan = extractNumberConstant(src, 'SCAN_TIMEOUT_MS');
+    const registeredMs = getRegisteredHookTimeoutSeconds() * 1000;
+    expect(treeWalk).not.toBeNull();
+    expect(scan).not.toBeNull();
+    const internalBudget = treeWalk + scan;
+    expect(registeredMs - internalBudget).toBeGreaterThanOrEqual(3000);
+  });
+
+  it('outer setTimeout exceeds the internal PowerShell budget', () => {
+    const treeWalk = extractNumberConstant(src, 'TREE_WALK_TIMEOUT_MS');
+    const scan = extractNumberConstant(src, 'SCAN_TIMEOUT_MS');
+    const outer = extractOuterSetTimeout(src);
+    expect(outer).not.toBeNull();
+    expect(outer).toBeGreaterThanOrEqual(treeWalk + scan);
+  });
+
+  it('outer setTimeout fits within the registered hook timeout', () => {
+    const outer = extractOuterSetTimeout(src);
+    const registeredMs = getRegisteredHookTimeoutSeconds() * 1000;
+    expect(outer).toBeLessThan(registeredMs);
+  });
+});
+
+describe('capture-session-id.cjs — discovery instrumentation', () => {
+  it('includes entry_path, method_used, duration_ms, outcome fields per FR-3', () => {
+    const src = readHookSource();
+    expect(src).toMatch(/entry_path/);
+    expect(src).toMatch(/method_used/);
+    expect(src).toMatch(/duration_ms/);
+    expect(src).toMatch(/outcome/);
+    expect(src).toMatch(/fallback_ppid/);
+  });
+
+  it('uses process.hrtime.bigint for timing per TR-1', () => {
+    const src = readHookSource();
+    expect(src).toMatch(/process\.hrtime\.bigint\(\)/);
+  });
+});
+
+// Integration test: spawn the hook with JSON input and verify marker write.
+// Windows-only per TR-3 platform skip.
+const runOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+async function invokeHook(sessionId, source = 'startup') {
+  return new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [hookPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_ENV_FILE: '' },
+      windowsHide: true,
+    });
+    let stderr = '';
+    child.stderr.on('data', (b) => { stderr += b.toString(); });
+    child.on('close', (code) => resolvePromise({ code, stderr }));
+    child.on('error', () => resolvePromise({ code: -1, stderr }));
+    child.stdin.write(JSON.stringify({ session_id: sessionId, source }));
+    child.stdin.end();
+  });
+}
+
+runOnWindows('capture-session-id.cjs — concurrent invocations (Windows only)', () => {
+  it('three parallel invocations each produce a marker within 15s', async () => {
+    const testRunId = crypto.randomUUID().slice(0, 8);
+    const sessionIds = [0, 1, 2].map(i => `test-${testRunId}-${i}`);
+
+    const start = Date.now();
+    const results = await Promise.all(sessionIds.map(sid => invokeHook(sid, 'startup')));
+    const duration = Date.now() - start;
+
+    // All invocations should exit cleanly
+    for (const r of results) {
+      expect(r.code).toBe(0);
+    }
+
+    // Each session should have a per-session marker written
+    for (const sid of sessionIds) {
+      const markerFile = resolve(markerDir, `${sid}.json`);
+      expect(existsSync(markerFile), `marker missing for ${sid}`).toBe(true);
+      const marker = JSON.parse(readFileSync(markerFile, 'utf8'));
+      expect(marker.session_id).toBe(sid);
+      expect(marker.cc_pid).toBeTruthy();
+    }
+
+    // Total wall-clock must fit within the registered hook timeout budget
+    expect(duration).toBeLessThan(15000);
+
+    // Cleanup: remove only the test-run markers we created (leave real markers alone)
+    try {
+      for (const sid of sessionIds) {
+        const f = resolve(markerDir, `${sid}.json`);
+        if (existsSync(f)) unlinkSync(f);
+      }
+    } catch { /* best effort */ }
+  }, 30_000);
+
+  it('discovery log line is emitted on stderr for every invocation', async () => {
+    const sid = `test-telemetry-${crypto.randomUUID().slice(0, 8)}`;
+    const { code, stderr } = await invokeHook(sid, 'startup');
+    expect(code).toBe(0);
+    const lines = stderr.split('\n').filter(Boolean);
+    const discovery = lines
+      .map(l => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(e => e && e.event === 'capture-session-id.discovery');
+    expect(discovery.length).toBeGreaterThanOrEqual(1);
+    expect(discovery[0]).toMatchObject({
+      entry_path: 'startup',
+      method_used: expect.any(String),
+      outcome: expect.any(String),
+    });
+    // Cleanup
+    try {
+      const f = resolve(markerDir, `${sid}.json`);
+      if (existsSync(f)) unlinkSync(f);
+    } catch { /* best effort */ }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `.claude/settings.json` registered `capture-session-id.cjs` with a **3s** timeout, but the hook's internal PowerShell process-tree walk has a **10s** timeout. Claude Code was killing the hook before the `pid-{ccPid}.json` marker could be written, leaving `concurrent-session-worktree.cjs` with no PID-liveness fallback when heartbeats go stale.
- **Fix**: raise settings.json hook timeout 3s → 15s; lower internal PowerShell timeouts (tree_walk 10s → 6s, scan 5s → 3s); raise outer `setTimeout` 8s → 12s; add always-on structured discovery telemetry (entry_path, method_used, duration_ms, outcome, fallback_ppid) per PRD FR-3.
- **Downstream**: `lib/terminal-identity.js` stops writing `fallback-*.json` files once future sessions reliably have `pid-{ccPid}.json` markers.

## Test plan

- [x] `npx vitest run tests/capture-session-id-hook.test.js` → 9/9 passing (7.31s)
- [x] Timing budget invariant: `settings_timeout_ms (15000) - (TREE_WALK_TIMEOUT_MS + SCAN_TIMEOUT_MS) >= 3000` (margin check)
- [x] Windows-only: 3 concurrent hook invocations each write a per-session marker within 15s
- [x] Discovery telemetry line emitted on stderr with all required FR-3 fields
- [ ] Post-merge manual verification: fresh / resume / reconnect / compaction entry paths each emit a `capture-session-id.discovery` log with `entry_path` populated

## SD

`SD-LEO-INFRA-SESSION-PID-MARKER-001` — PRD acceptance criteria AC-1..AC-6, exec_checklist EX-1, EX-3, EX-4, EX-5, EX-7 addressed. EX-2 (20 SessionStart observations) and EX-6 (manual entry-path verification) deferred to post-merge production observation — instrumentation is now in place to support them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)