### PR TITLE
feat(SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001): complete writer migration (PR-2 of 2)

### DIFF
--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -755,6 +755,14 @@ const solution = await kb.getSolution('PAT-003');
 - High severity: 7+ occurrences
 - Increasing trend: 4+ occurrences
 
+## claude_sessions.current_branch Contract
+
+**Invariant** (SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001): `current_branch` is non-null for every session row whose originating process runs inside a git working tree. NULL is reserved for sessions that legitimately have no git context — primarily virtual sessions (drain agents with no cwd) and the narrow window between process start and first heartbeat. Any other NULL row on an active non-virtual session is a bug.
+
+**Enforcement**: Application-layer. Every `claude_sessions.update(...)` call that performs a heartbeat-style write routes through `stampBranch()` in `lib/session-writer.cjs`, which resolves the branch via `git rev-parse --abbrev-ref HEAD`. Claim/release/status-only writes do not need `current_branch` and do not call `stampBranch`. A regression guard at `tests/unit/session-writer/no-bypass.test.js` fails CI if a new writer bypasses the helper.
+
+**Why not a NOT NULL constraint**: Pre-existing NULL rows would require a data migration. Virtual sessions are legitimately NULL. COALESCE semantics in `update_session_heartbeat_with_branch` already prevent null-overwrite from transient detector failures.
+
 ## Genesis Codebase Locations
 
 **CRITICAL**: Genesis spans TWO codebases:

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -22,9 +22,14 @@ import { createSupabaseServiceClient } from './supabase-client.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
+import { createRequire } from 'module';
 import { getStaleThresholdSeconds } from './claim/stale-threshold.js';
 import { isProcessRunning } from './heartbeat-manager.mjs';
 import os from 'os';
+
+// stampBranch keeps current_branch fresh on heartbeat writes — see
+// lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+const { stampBranch } = createRequire(import.meta.url)('./session-writer.cjs');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -248,10 +253,10 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       };
     }
 
-    // Update heartbeat to keep claim alive
+    // Update heartbeat to keep claim alive (also stamps current_branch)
     await supabase
       .from('claude_sessions')
-      .update({ heartbeat_at: new Date().toISOString() })
+      .update(stampBranch({ heartbeat_at: new Date().toISOString() }))
       .eq('session_id', sessionId);
 
     return {
@@ -291,7 +296,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
         console.log(`[claimGuard] IDENTITY_TRANSFER: prior_session=${claim.session_id}, new_session=${sessionId}, staleness_delta=${heartbeatAge}s, gate_result=ALLOW, my_terminal=${myTerminalId}, their_terminal=${claim.terminal_id}`);
         await supabase
           .from('claude_sessions')
-          .update({ heartbeat_at: new Date().toISOString() })
+          .update(stampBranch({ heartbeat_at: new Date().toISOString() }))
           .eq('session_id', sessionId);
         return {
           success: true,

--- a/lib/drain-progress.mjs
+++ b/lib/drain-progress.mjs
@@ -111,12 +111,21 @@ export class DrainProgress {
     const supabase = createSupabaseServiceClient();
     const summary = this.getSummary();
 
-    const { error } = await supabase.from('claude_sessions').update({
+    // Route through stampBranch so current_branch stays fresh on drain
+    // heartbeat updates. See lib/session-writer.cjs and
+    // SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+    const { createRequire } = await import('module');
+    const req = createRequire(import.meta.url);
+    const { stampBranch } = req('./session-writer.cjs');
+
+    const payload = stampBranch({
       metadata: {
         drain_progress: summary,
         drain_active_slots: this.getSlotStatuses()
       }
-    }).eq('session_id', parentSessionId);
+    });
+
+    const { error } = await supabase.from('claude_sessions').update(payload).eq('session_id', parentSessionId);
 
     return { error: error?.message };
   }

--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -234,9 +234,15 @@ export function getHeartbeatStats() {
  */
 async function setIsAlive(sessionId, alive) {
   try {
+    // Route through stampBranch so current_branch is populated alongside the
+    // liveness flag. See lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+    const { createRequire } = await import('module');
+    const req = createRequire(import.meta.url);
+    const { stampBranch } = req('./session-writer.cjs');
+    const payload = stampBranch({ is_alive: alive, updated_at: new Date().toISOString() });
     await hbSupabase
       .from('claude_sessions')
-      .update({ is_alive: alive, updated_at: new Date().toISOString() })
+      .update(payload)
       .eq('session_id', sessionId);
   } catch (err) {
     console.warn(`[Heartbeat] Failed to set is_alive=${alive}: ${err.message}`);

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -27,7 +27,9 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { createClient } = require('@supabase/supabase-js');
 const { detectCodebase } = require('./lib/detect-context.cjs');
+const { stampBranch } = require('../../lib/session-writer.cjs');
 
 // PID liveness check — complements heartbeat for sessions still loading context
 function isProcessRunning(pid) {
@@ -580,9 +582,13 @@ async function main() {
         const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
         if (sbUrl && sbKey) {
           const supabase = createClient(sbUrl, sbKey);
+          // stampBranch resolves current_branch via git and includes it in the
+          // UPDATE so downstream branch-aware concurrency routing stays accurate.
+          // See lib/session-writer.cjs. Part of SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+          const payload = stampBranch({ worktree_path: worktreePath, worktree_branch: worktreeBranch }, worktreePath);
           supabase
             .from('claude_sessions')
-            .update({ worktree_path: worktreePath, worktree_branch: worktreeBranch })
+            .update(payload)
             .eq('session_id', mySessionId)
             .then(({ error }) => {
               if (error) logEvent('session.worktree.db_persist_failed', { error: error.message });

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -73,9 +73,12 @@ async function updateHeartbeat(supabase, sessionId) {
   if (!shouldHeartbeat()) return;
   markHeartbeat();
   try {
+    // stampBranch keeps current_branch fresh on inbox-hook heartbeats — see
+    // lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+    const { stampBranch } = require('../../lib/session-writer.cjs');
     await supabase
       .from('claude_sessions')
-      .update({ heartbeat_at: new Date().toISOString() })
+      .update(stampBranch({ heartbeat_at: new Date().toISOString() }))
       .eq('session_id', sessionId);
   } catch { /* fail silently */ }
 }

--- a/scripts/hooks/precompact-unified.js
+++ b/scripts/hooks/precompact-unified.js
@@ -52,10 +52,15 @@ async function extendHeartbeat(sessionId) {
     }
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createSupabaseServiceClient();
+    // stampBranch keeps current_branch fresh on pre-compact heartbeat extension
+    // — see lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+    const { createRequire } = await import('module');
+    const req = createRequire(import.meta.url);
+    const { stampBranch } = req('../../lib/session-writer.cjs');
     // Include 'released' so sessions that were swept while between SDs can recover
     const { error } = await supabase
       .from('claude_sessions')
-      .update({ heartbeat_at: new Date().toISOString(), status: 'active' })
+      .update(stampBranch({ heartbeat_at: new Date().toISOString(), status: 'active' }))
       .eq('session_id', sessionId)
       .in('status', ['active', 'idle', 'released']);
     if (error) {

--- a/tests/unit/session-writer/no-bypass.test.js
+++ b/tests/unit/session-writer/no-bypass.test.js
@@ -1,0 +1,125 @@
+/**
+ * Regression guard: no raw claude_sessions writes outside lib/session-writer.cjs
+ * and a short, documented allow-list of exceptions.
+ *
+ * Part of SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001. Prevents future writers
+ * from silently re-introducing the NULL-current_branch bug by bypassing
+ * the shared helper. If you see this test fail, route your write through
+ * `stampBranch()` from lib/session-writer.cjs instead of calling
+ * `.from('claude_sessions').update(...)` or PATCH /claude_sessions directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+// Files allowed to write to claude_sessions without routing through stampBranch.
+// Fall into three legitimate categories per SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001:
+//
+//   A. The helper itself + the reference implementation that already resolves branch.
+//   B. Writes where current_branch is not applicable: claim/release/status-only
+//      transitions, metadata-only patches, telemetry counters, virtual sessions
+//      without a cwd. These writes intentionally do not touch current_branch.
+//   C. Archived / one-time scripts kept for audit but not run interactively.
+//
+// If you add a NEW file to this list, document which category and why. If your new
+// code path DOES perform heartbeat-style persistence and the process is inside a
+// git working tree, route through `stampBranch()` instead of extending the list.
+const ALLOWLIST = new Set([
+  // Category A — helper + already-branch-aware
+  'lib/session-writer.cjs',
+  'lib/session-manager.mjs',
+
+  // Category B — virtual sessions (no git cwd, NULL is legitimate per PRD)
+  'lib/virtual-session-factory.mjs',
+
+  // Category B — routing / session-identity lookups that read+touch metadata
+  'lib/eva/bridge/venture-session-routing.js',
+  'lib/eva/venture-context-manager.js',
+  'lib/resolve-own-session.js',
+  'scripts/resolve-sd-workdir.js',
+
+  // Category B — claim / release / status-only transitions (branch not relevant
+  // to the state being changed; heartbeat writers handle branch separately)
+  'scripts/sd-start.js',
+  'scripts/assign-fleet-identities.cjs',
+  'scripts/leo-continuous.js',
+  'scripts/stale-session-sweep.cjs',
+  'scripts/modules/handoff/auto-proceed-state.js',
+  'scripts/modules/handoff/claim-swapper.js',
+  'scripts/modules/handoff/continuation-state.js',
+  'scripts/modules/handoff/executors/BaseExecutor.js',
+  'scripts/modules/handoff/gates/multi-session-claim-gate.js',
+  'scripts/modules/handoff/recording/HandoffRecorder.js',
+  'scripts/modules/sd-next/claim-analysis.js',
+  'scripts/hooks/coordination-inbox.cjs',
+  'scripts/hooks/precompact-unified.js',
+
+  // Category C — archived / one-time
+  'scripts/archive/one-time/stale-session-sweep.cjs',
+
+  // Category B — release/status writes (branch not relevant to state transition)
+  'lib/commands/claim-command.js',
+  'lib/context/unified-state-manager.js',
+]);
+
+// Roots to scan (source code only — skip node_modules, tests, build output)
+const SCAN_ROOTS = ['lib', 'scripts'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts']);
+
+// Match `.from('claude_sessions').update(` or `.from("claude_sessions").update(`
+// as well as `.from(\`claude_sessions\`).update(` — these are the supabase-js write
+// patterns that could omit current_branch.
+const SUPABASE_WRITE_RE = /\.from\(\s*['"`]claude_sessions['"`]\s*\)\s*\.update\(/;
+
+function* walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      // Skip test directories — they may have fixtures that should be exempt
+      if (entry.name === 'tests' || entry.name === '__tests__' || entry.name === '.worktrees') continue;
+      // Skip archived / example dirs
+      if (entry.name === 'archived-sd-scripts') continue;
+      yield* walk(full);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name))) {
+      yield full;
+    }
+  }
+}
+
+// File is compliant if either (a) it's explicitly allowlisted above, OR (b) it
+// imports/requires `session-writer` and references `stampBranch`. This means
+// migrating a new writer to the helper immediately satisfies the guard without
+// editing this test.
+const STAMP_BRANCH_RE = /session-writer(?:\.cjs)?['"`]|\bstampBranch\b/;
+
+describe('LINT-SESSION-WRITER-001: no raw claude_sessions.update outside helper', () => {
+  it('source tree has no bypass writes', () => {
+    const violations = [];
+    for (const root of SCAN_ROOTS) {
+      const rootPath = path.join(repoRoot, root);
+      if (!fs.existsSync(rootPath)) continue;
+      for (const file of walk(rootPath)) {
+        const relative = path.relative(repoRoot, file).split(path.sep).join('/');
+        if (ALLOWLIST.has(relative)) continue;
+        let content;
+        try {
+          content = fs.readFileSync(file, 'utf8');
+        } catch {
+          continue;
+        }
+        if (!SUPABASE_WRITE_RE.test(content)) continue;
+        // Write present — check whether file has stampBranch usage
+        if (STAMP_BRANCH_RE.test(content)) continue;
+        violations.push(relative);
+      }
+    }
+    expect(violations, `Files writing raw to claude_sessions without going through lib/session-writer.cjs:\n  ${violations.join('\n  ')}\n\nRoute the write through stampBranch() from lib/session-writer.cjs, or add the file to the documented ALLOWLIST in this test with a rationale.`).toEqual([]);
+  });
+});

--- a/tests/unit/session-writer/no-bypass.test.js
+++ b/tests/unit/session-writer/no-bypass.test.js
@@ -56,8 +56,6 @@ const ALLOWLIST = new Set([
   'scripts/modules/handoff/gates/multi-session-claim-gate.js',
   'scripts/modules/handoff/recording/HandoffRecorder.js',
   'scripts/modules/sd-next/claim-analysis.js',
-  'scripts/hooks/coordination-inbox.cjs',
-  'scripts/hooks/precompact-unified.js',
 
   // Category C — archived / one-time
   'scripts/archive/one-time/stale-session-sweep.cjs',


### PR DESCRIPTION
## Summary

Completes **SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001** — every heartbeat-style write to \`claude_sessions\` now stamps \`current_branch\` via the shared helper shipped in PR-1 (#3246).

**6 files, +166 / -7 LOC.**

## What this PR migrates

| File | Change |
|------|--------|
| \`lib/heartbeat-manager.mjs::setIsAlive\` | Stamps branch alongside \`updated_at\` |
| \`lib/drain-progress.mjs::persistToSession\` | Drain metadata writes stamp branch |
| \`lib/claim-guard.mjs\` (2 heartbeat sites) | Claim-keepalive writes stamp branch |
| \`scripts/hooks/concurrent-session-worktree.cjs\` | Worktree-persistence writes stamp branch + **fixes latent bug: \`createClient\` was used without being imported** (would have thrown \`ReferenceError\` on the hot path) |

Release paths in \`claim-guard.mjs\` (lines 322, 401) intentionally do **not** stamp — release is a state transition, not a heartbeat. Virtual sessions in \`virtual-session-factory.mjs\` are legitimately NULL per PRD (no cwd).

## Regression guard

\`tests/unit/session-writer/no-bypass.test.js\` — scans \`lib/\` and \`scripts/\` for raw \`.from('claude_sessions').update(\` calls. A file is compliant if it (a) is explicitly allowlisted with a documented category, OR (b) imports \`session-writer\` and references \`stampBranch\`. Migrating to the helper auto-satisfies the guard.

The allowlist documents 21 existing writers grouped into categories: helper + reference impl, virtual sessions, claim/release transitions, archived one-time scripts. Each group has a rationale comment for future readers.

## Documentation

\`CLAUDE_CORE.md\` — new "claude_sessions.current_branch Contract" section stating the invariant (non-null for sessions in a git tree), the enforcement mechanism (app-layer via stampBranch, no DB constraint), and why.

## Deferred / not needed

- Optional backfill script for pre-existing NULL rows — not required for the app-layer contract to hold on new writes. Historical NULLs will naturally clear on next heartbeat tick.
- \`LINT-SESSION-WRITER-001\` as a protocol-lint-engine markdown rule — the test-based regression guard is strictly more capable for this class of check (scans actual code, not documentation).

## Test plan

- [x] \`node --check\` passes on all edited files
- [x] Regression scan exits clean (no bypass writes in current tree)
- [x] Seeded violation test: adding a raw write to a non-allowlisted file without stampBranch correctly fails the guard
- [ ] Post-merge: live session rows show \`current_branch\` populated from the first heartbeat cycle (already true in this session thanks to PR-1's session-register migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)