### PR TITLE
fix(QF-20260423-417): filter info-severity entries from preflight pass check

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -105,7 +105,7 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
   }
 
   return {
-    passed: issues.length === 0,
+    passed: issues.filter(i => i.severity !== 'info').length === 0,
     issues
   };
 }


### PR DESCRIPTION
## Summary
- 1-LOC fix: `prerequisite-preflight.js:108` now filters `severity==='info'` entries before counting failures
- Fixes a second-order bug on PR #3240 — the exemption logic was added but the consumer-side severity handling wasn't updated
- `--bypass-validation` does NOT override preflight, so there was no workaround

## Why
For sd_types exempt from user stories (infrastructure, documentation, database, security, refactor per CLAUDE_CORE.md sub-agent matrix), PR #3240 correctly emits `USER_STORIES_BYPASSED` with `severity: 'info'` and remediation text "No action required — informational entry only." But line 108 returned `passed: issues.length === 0` which counted the info entry as a failure, causing every exempt SD's PLAN-TO-EXEC handoff to fail with `PREREQUISITE_PREFLIGHT_FAILED`.

## Impact
Unblocks PLAN-TO-EXEC for all exempt sd_types. Currently blocked:
- `SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B` (my current SD)
- `SD-LEO-INFRA-SD-INTRAPHASE-PROGRESS-001` (documented in memory, blocked since 2026-04-22)

## Test plan
- [x] `git diff` shows exactly 1 line changed
- [ ] After merge, retry `handoff.js execute PLAN-TO-EXEC SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B` — should proceed past preflight to the 10-gate pipeline (97% in precheck)
- [ ] Warning and error severity entries still block (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)