### PR TITLE
feat(SD-LEO-INFRA-SD-CREATION-TOOLING-001): add target_application vs scope cross-check validator

### DIFF
--- a/scripts/create-sd.js
+++ b/scripts/create-sd.js
@@ -21,6 +21,8 @@ import dotenv from 'dotenv';
 import readline from 'readline';
 // SD-LEO-SDKEY-001: Centralized SD key generation
 import { generateSDKey as generateCentralizedSDKey } from './modules/sd-key-generator.js';
+// SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
+import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
 
 dotenv.config();
 
@@ -479,6 +481,21 @@ async function main() {
 
   // Close readline
   rl.close();
+
+  // SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
+  // Catches mismatches before INSERT. WARN by default; BLOCK via env var.
+  const crosscheck = validateTargetApplication({
+    scope: sdData.scope,
+    target_application: sdData.target_application
+  });
+  if (crosscheck.verdict !== 'PASS') {
+    console.log('\n' + formatCrosscheckResult(crosscheck));
+  }
+  if (crosscheck.verdict === 'BLOCK') {
+    console.error('\n❌ SD creation halted: target_application cross-check BLOCK.');
+    console.error('   Fix: correct --scope text or set target_application before retry.');
+    process.exit(1);
+  }
 
   // Create the SD
   console.log('\n📝 Creating Strategic Directive...');

--- a/scripts/modules/sd-validation/target-application-crosscheck.js
+++ b/scripts/modules/sd-validation/target-application-crosscheck.js
@@ -1,0 +1,110 @@
+/**
+ * target_application vs scope cross-check validator.
+ *
+ * Part of SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4.
+ *
+ * Pure function — no I/O. Imported by:
+ *   - scripts/create-sd.js (at INSERT time)
+ *   - scripts/leo-create-sd.js (at INSERT time)
+ *   - scripts/sd-start.js (before worktree creation)
+ *
+ * Purpose: catch the failure mode where an SD ships with scope text declaring
+ * one repo ("EHG_Engineer only") but target_application pointing at the other
+ * ("EHG"), which then causes sd-start.js to open the worktree in the wrong
+ * repo. Observed twice on 2026-04-22 on this SD and on
+ * SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
+ *
+ * Verdict levels:
+ *   PASS  — no mismatch detected, or scope is mixed-repo
+ *   WARN  — mismatch detected; advisory only (logs but does not block)
+ *   BLOCK — mismatch detected AND env var TARGET_APP_CROSSCHECK_VERDICT=BLOCK
+ *
+ * Default is WARN for a 2-week observation window before promotion to BLOCK.
+ * Callers decide whether to halt on WARN (none do by default).
+ */
+
+const ENGINEER_ONLY_PATTERNS = [
+  /\bEHG_Engineer only\b/i,
+  /\bengineer[-\s]only\b/i,
+  /\bbackend only\b/i,
+  /\bcli only\b/i,
+  /\bscripts only\b/i
+];
+
+const EHG_ONLY_PATTERNS = [
+  /\bEHG only\b/i,
+  /\bfrontend only\b/i,
+  /\bui only\b/i,
+  /\bapp only\b/i
+];
+
+const MIXED_PATTERNS = [
+  /\bEHG\s+and\s+EHG_Engineer\b/i,
+  /\bboth\s+repos?\b/i,
+  /\bmixed[-\s]repo\b/i,
+  /\bcross[-\s]repo\b/i
+];
+
+/**
+ * @param {{scope?: string|null, target_application?: string|null}} input
+ * @returns {{verdict: 'PASS'|'WARN'|'BLOCK', reasons: string[], matchedPhrase?: string}}
+ */
+export function validateTargetApplication({ scope, target_application }) {
+  const reasons = [];
+
+  // Missing inputs: can't cross-check, pass-through
+  if (!scope || typeof scope !== 'string') {
+    return { verdict: 'PASS', reasons: ['scope not provided — skipping cross-check'] };
+  }
+  if (!target_application) {
+    return { verdict: 'PASS', reasons: ['target_application not provided — skipping cross-check'] };
+  }
+
+  // Explicit mixed-repo scope always passes regardless of target_application
+  for (const pattern of MIXED_PATTERNS) {
+    if (pattern.test(scope)) {
+      return { verdict: 'PASS', reasons: [`scope explicitly mixed-repo (matched /${pattern.source}/)`] };
+    }
+  }
+
+  // Engineer-only scope with target_application=EHG is a mismatch
+  for (const pattern of ENGINEER_ONLY_PATTERNS) {
+    const match = scope.match(pattern);
+    if (match && target_application === 'EHG') {
+      reasons.push(`scope text contains "${match[0]}" but target_application="EHG"`);
+      reasons.push('sd-start.js will open a worktree in the wrong repo unless target_application is corrected to "EHG_Engineer"');
+      return finalize(reasons, match[0]);
+    }
+  }
+
+  // EHG-only scope with target_application=EHG_Engineer is a mismatch
+  for (const pattern of EHG_ONLY_PATTERNS) {
+    const match = scope.match(pattern);
+    if (match && target_application === 'EHG_Engineer') {
+      reasons.push(`scope text contains "${match[0]}" but target_application="EHG_Engineer"`);
+      reasons.push('sd-start.js will open a worktree in the wrong repo unless target_application is corrected to "EHG"');
+      return finalize(reasons, match[0]);
+    }
+  }
+
+  return { verdict: 'PASS', reasons: ['no repo-scope mismatch detected'] };
+}
+
+function finalize(reasons, matchedPhrase) {
+  const envVerdict = (process.env.TARGET_APP_CROSSCHECK_VERDICT || 'WARN').toUpperCase();
+  const verdict = envVerdict === 'BLOCK' ? 'BLOCK' : 'WARN';
+  return { verdict, reasons, matchedPhrase };
+}
+
+/**
+ * Format a cross-check result for console output.
+ * @param {{verdict: string, reasons: string[], matchedPhrase?: string}} result
+ * @returns {string}
+ */
+export function formatCrosscheckResult(result) {
+  const icon = result.verdict === 'BLOCK' ? '❌' : result.verdict === 'WARN' ? '⚠️' : '✓';
+  const header = `${icon} target_application cross-check: ${result.verdict}`;
+  if (result.reasons.length === 0) return header;
+  const lines = result.reasons.map(r => `   • ${r}`);
+  return [header, ...lines].join('\n');
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -28,6 +28,8 @@ import { resolve as resolveWorkdir } from './resolve-sd-workdir.js';
 import { classifyWorktreeError } from '../lib/worktree-manager.js';
 import { getNextReadyChild } from './modules/handoff/child-sd-selector.js';
 import { checkSDAge, handleTimelineViolation, formatBlockMessage } from './modules/governance/timeline-violation-handler.js';
+// SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
+import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
 
 dotenv.config();
 
@@ -227,7 +229,7 @@ async function getSDDetails(sdId) {
   // Note: legacy_id column was deprecated and removed - using sd_key instead
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id')
+    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id, scope')
     .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
@@ -813,6 +815,32 @@ async function main() {
     }
   } catch {
     // Non-blocking — cross-path verification is defense-in-depth
+  }
+
+  // 4.4. SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: scope vs target_application cross-check
+  // Catches SDs where scope text and target_application disagree, which causes
+  // sd-start to open a worktree in the wrong repo. Ships as WARN by default;
+  // promotable to BLOCK via TARGET_APP_CROSSCHECK_VERDICT=BLOCK env var.
+  try {
+    const crosscheck = validateTargetApplication({
+      scope: sd.scope,
+      target_application: sd.target_application
+    });
+    if (crosscheck.verdict !== 'PASS') {
+      console.log(`\n${colors.yellow}${formatCrosscheckResult(crosscheck)}${colors.reset}`);
+    }
+    if (crosscheck.verdict === 'BLOCK') {
+      console.error(`${colors.red}   ❌  Cross-check BLOCK: refusing worktree creation.${colors.reset}`);
+      console.error(`${colors.dim}   Fix: correct target_application or revise SD scope text.${colors.reset}`);
+      await supabase.rpc('release_sd', {
+        p_session_id: session.session_id,
+        p_reason: 'manual'
+      }).catch(() => {});
+      process.exit(1);
+    }
+  } catch (ccErr) {
+    // Non-blocking — cross-check is defense-in-depth
+    console.log(`${colors.dim}[crosscheck] skipped: ${ccErr.message}${colors.reset}`);
   }
 
   // 4.5. Resolve worktree (creates if needed in claim mode)


### PR DESCRIPTION
## Summary
- New pure-function module `scripts/modules/sd-validation/target-application-crosscheck.js` — catches SDs where scope text declares one repo ("EHG_Engineer only") but `target_application` points at the other ("EHG").
- Integrated at two call sites: `scripts/create-sd.js` runs it before INSERT; `scripts/sd-start.js` runs it after claim acquisition and before worktree creation (so a BLOCK verdict releases the claim instead of opening a worktree in the wrong repo).
- Verdict levels: `PASS`, `WARN` (advisory, default), `BLOCK` (via `TARGET_APP_CROSSCHECK_VERDICT=BLOCK` env var). 2-week observation window recommended before promotion.
- Mixed-repo scope phrases (e.g. "Both EHG and EHG_Engineer", "cross-repo") explicitly pass regardless of `target_application`, avoiding false positives.
- `getSDDetails()` in `sd-start.js` extended with the `scope` column so the check has data to consume.

## Context
Phase 4 of **SD-LEO-INFRA-SD-CREATION-TOOLING-001**. Motivated by two incidents on 2026-04-22 where SDs shipped with `scope="EHG_Engineer only"` but `target_application="EHG"`, causing `sd-start.js` to open worktrees in the wrong repo. Phase 1 (`create-sd.js` flag acceptance) merged as PR #3247. Phase 2 is a verified NOOP — the SD description pointed at `scripts/create-sd-intelligent.js`, which does not exist; the canonical LLM-backed creator `scripts/leo-create-sd.js` already implements non-empty-array fallbacks at lines 1116–1134 (`buildDefaultSuccessMetrics`, `buildDefaultStrategicObjectives`, etc.). Phases 3 (schema migration) and 5 (E2E regression test) remain.

## Test plan
- [ ] Unit test: `validateTargetApplication({scope: "EHG_Engineer only; CLI scripts", target_application: "EHG"})` returns `{verdict: "WARN", reasons: [...]}` by default; returns `{verdict: "BLOCK", ...}` with `TARGET_APP_CROSSCHECK_VERDICT=BLOCK`.
- [ ] Unit test: `scope: "Both EHG and EHG_Engineer"` with either `target_application` returns `{verdict: "PASS"}`.
- [ ] E2E: Create an SD via direct DB upsert with `scope="EHG_Engineer only"` and `target_application="EHG"`. Run `node scripts/sd-start.js <sd_key>` — expect warning printed before worktree block; with `TARGET_APP_CROSSCHECK_VERDICT=BLOCK`, expect exit 1 and claim released.
- [ ] Regression: Existing SDs with correct `scope`/`target_application` alignment pass silently (no output); `sd-start.js` and `create-sd.js` behavior unchanged for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)