### PR TITLE
fix(SD-LEO-INFRA-SD-CREATION-TOOLING-001): reconcile strategic_directives_v2 array column defaults

### DIFF
--- a/database/migrations/20260423_sd_array_defaults_reconciliation.sql
+++ b/database/migrations/20260423_sd_array_defaults_reconciliation.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- Migration: Reconcile JSONB array defaults with check constraints
+-- SD:        SD-LEO-INFRA-SD-CREATION-TOOLING-001 (Phase 3 / EXEC)
+-- Date:      2026-04-23
+-- Author:    database-agent (Opus 4.7)
+-- =============================================================================
+--
+-- BUG (failure mode #3 from SD description):
+--   strategic_directives_v2 has four JSONB array columns — key_principles,
+--   success_metrics, success_criteria, key_changes — with default '[]'::jsonb.
+--   Three of them also carry a *_not_empty CHECK constraint that requires
+--   `col IS NULL OR jsonb_array_length(col) >= 1`. Any INSERT that omits these
+--   columns receives the `[]` default and immediately trips the CHECK.
+--
+-- DECISION (per PRD metadata.plan_decision):
+--   Option A — drop the empty-array defaults. Columns are already nullable and
+--   the CHECK constraints already permit NULL, so INSERTs that omit these
+--   columns will simply get NULL and pass validation. Empty arrays are
+--   surfaced (not silently produced) if a caller explicitly supplies them.
+--
+-- PER-COLUMN DETERMINATION (inspected 2026-04-23):
+--   key_principles    — constraints: is_array + not_empty (both allow NULL) → OPTION A (drop default)
+--   success_metrics   — constraints: is_array + not_empty (both allow NULL) → OPTION A (drop default)
+--   success_criteria  — constraints: is_array + not_empty (both allow NULL) → OPTION A (drop default)
+--   key_changes       — constraint:  is_array ONLY (no not_empty)
+--                       '[]'::jsonb is LEGAL, so default does not trip any CHECK.
+--                       515 existing rows contain []. LEAVING AS-IS (NO-OP).
+--
+-- EXISTING DATA (pre-migration counts):
+--   key_principles:    11 NULL,  0 empty  (all-NULL except for populated rows)
+--   success_metrics:   16 NULL,  0 empty
+--   success_criteria:  10 NULL,  0 empty
+--   key_changes:        5 NULL, 515 empty  ← intentionally untouched
+--   No row-level data is modified by this migration.
+--
+-- ROLLBACK:
+--   ALTER TABLE public.strategic_directives_v2
+--       ALTER COLUMN key_principles   SET DEFAULT '[]'::jsonb,
+--       ALTER COLUMN success_metrics  SET DEFAULT '[]'::jsonb,
+--       ALTER COLUMN success_criteria SET DEFAULT '[]'::jsonb;
+-- =============================================================================
+
+BEGIN;
+
+-- Option A: drop the incompatible '[]'::jsonb defaults.
+-- DROP DEFAULT is idempotent (no error if already no default).
+ALTER TABLE public.strategic_directives_v2
+    ALTER COLUMN key_principles   DROP DEFAULT,
+    ALTER COLUMN success_metrics  DROP DEFAULT,
+    ALTER COLUMN success_criteria DROP DEFAULT;
+
+-- key_changes left alone — its only CHECK is is_array, which '[]' satisfies.
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Migration `database/migrations/20260423_sd_array_defaults_reconciliation.sql` changes defaults on three JSONB array columns on `strategic_directives_v2` from `'[]'::jsonb` to `NULL` (PRD's Option A):
  - `key_principles`
  - `success_metrics`
  - `success_criteria`
- Root cause: those three columns had `'[]'::jsonb` defaults but their `_not_empty` check constraints rejected empty arrays. Any `INSERT` omitting the columns tripped the check. The constraints already permitted `NULL`, so dropping the defaults is backward-compatible.
- `key_changes` is intentionally **NOT** changed. Its only constraint is `_is_array` (no not-empty requirement), which `'[]'::jsonb` satisfies, and 515 existing rows carry `'[]'` as legal data. Bug description was stale on that column — verified via database-agent inspection.
- Existing rows are not touched (`ALTER TABLE DROP DEFAULT` does not rewrite data). Migration is idempotent.
- Applied via `database-agent` against the consolidated DB (dedlbzhpgkmetvhbkyzq). Post-migration verification: INSERT omitting all 4 JSONB columns now succeeds; the three reconciled columns receive `NULL`.

## Context
Phase 3 of **SD-LEO-INFRA-SD-CREATION-TOOLING-001**. Prior phases:
- **Phase 1** (CLI flags on `scripts/create-sd.js`) — merged as PR #3247.
- **Phase 4** (target_application cross-check validator) — merged as PR #3251.
- **Phase 2** — verified NOOP. The SD description pointed at `scripts/create-sd-intelligent.js`, which does not exist; `scripts/leo-create-sd.js` already has non-empty-array fallbacks at lines 1116–1134.
- **Phase 5** (E2E regression test) — remaining; deferred due to globally-broken `node_modules` in the working tree.

Migration risk was rated CRITICAL (9/10) by RISK sub-agent at LEAD, but pre-migration inspection showed all three `_not_empty` constraints already permitted NULL, so no constraint relaxation was needed. No existing rows required remediation (pre-migration state: 11/16/10 rows already NULL; 0 empty-array rows).

## Test plan
- [ ] `INSERT INTO strategic_directives_v2 (id, sd_key, title, description, rationale, scope, category, priority, sd_type, target_application) VALUES (...)` omitting all 4 JSONB columns → succeeds, check constraints not violated.
- [ ] Same `INSERT` but with `success_metrics = '[]'::jsonb` explicitly → still fails on `_not_empty` (expected — the constraint still rejects empty arrays; the fix is just that defaults no longer produce empties).
- [ ] Same `INSERT` but with `success_metrics = '[{"metric":"x","target":"y"}]'::jsonb` → succeeds.
- [ ] Re-run migration → exits cleanly (idempotent; `DROP DEFAULT` on a column without a default is a no-op).
- [ ] Spot-check existing rows: count of NULL vs non-NULL per reconciled column unchanged pre/post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)