### PR TITLE
feat(SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B): session identity single source of truth

### DIFF
--- a/.claude/session-identity/README.md
+++ b/.claude/session-identity/README.md
@@ -1,0 +1,101 @@
+# Session Identity — Single Source of Truth
+
+Owned by **SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (Phase 2)**.
+
+This directory holds the three filesystem artifacts that identify a running Claude Code conversation to the LEO Protocol. Only one of them is canonical; the other two are *derived* and may be rewritten by `scripts/sd-start.js` during boot reconciliation.
+
+## The three identity sources
+
+| Source | Location | Role | Written by |
+| --- | --- | --- | --- |
+| Canonical marker | `.claude/session-identity/<sessionId>.json` | **Single source of truth.** Created once per CC conversation at `SessionStart`. | `scripts/hooks/capture-session-id.cjs` |
+| Derived env var | `process.env.CLAUDE_SESSION_ID` (plus `CLAUDE_ENV_FILE` export line) | Makes the session id available to Bash-tool subprocesses. | `scripts/hooks/capture-session-id.cjs` (SessionStart), rewritten by `scripts/sd-start.js` during reconciliation. |
+| Derived pointer | `.claude/session-identity/current` | Fast-path lookup for tools that don't need the full marker. | `scripts/hooks/capture-session-id.cjs` when the flag is on; rewritten by `scripts/sd-start.js` during reconciliation. |
+
+`lib/claim-validity-gate.js` reads all three at the start of every claim-authoritative operation. If they all agree (or only one is present), the gate passes. If two or more are present and disagree, the gate fails closed with `no_deterministic_identity` and a remediation banner that names each disagreeing source.
+
+## Canonical marker schema
+
+Each `<sessionId>.json` file is an atomically-written UTF-8 JSON object.
+
+```jsonc
+{
+  "session_id": "487c6af6-a8cc-45f2-9dfb-6c45eed8934e",   // CC conversation UUID
+  "sse_port":   17981,                                      // CLAUDE_CODE_SSE_PORT at capture time (nullable)
+  "cc_pid":     34968,                                      // claude.exe ancestor PID discovered by the hook
+  "source":     "startup",                                  // SessionStart source: startup | resume | compact | reconnect | unknown
+  "model":      "claude-opus-4-7",                          // Nullable; set when Claude Code advertises it
+  "captured_at": "2026-04-23T10:14:08.576Z"                // ISO 8601 UTC
+}
+```
+
+Field contract:
+
+- `session_id` — REQUIRED. Matches the UUID Claude Code emits in its `SessionStart` stdin payload. Used as the filename stem.
+- `cc_pid` — REQUIRED. The claude.exe node ancestor PID, not `process.ppid`. Tooling like `lib/terminal-identity.js::findClaudeCodePid()` uses this to disambiguate sibling CC windows on the same SSE port.
+- `source`, `sse_port`, `model` — OPTIONAL; nulls are valid.
+- `captured_at` — REQUIRED. Set by the hook on first write. Used for stale-marker cleanup.
+
+## Pointer file schema
+
+`.claude/session-identity/current` holds the session id of the most recently reconciled conversation. Two forms are accepted so the pointer is both grep-friendly and programmatically parseable:
+
+1. Plain text — a bare UUID, optionally trailed by a newline (written by `sd-start.js` via `sotAtomicWrite`).
+2. JSON — an object `{"session_id": "<uuid>", ...}`. Reserved for future expansion; any non-UUID `session_id` value causes downstream consumers to treat the pointer as absent.
+
+The pointer is *derived* and may be rewritten at any time.
+
+## Lock file
+
+`.claude/session-identity/.lock` is an exclusive advisory lock used by `reconcileAtBoot()` in `lib/session-identity-sot.js`. Its presence means another process is mid-reconciliation. Locks older than 30 seconds are considered stale and may be broken. The file contents are JSON `{"pid": <number>, "at": <iso>}` for diagnostic purposes only.
+
+Never delete this file manually while `sd-start.js` is running — the owning process will not detect the loss and may produce inconsistent state.
+
+## Ordering invariant (FR-4)
+
+At SessionStart, when `SESSION_IDENTITY_SOT_ENABLED` is on, the hook writes the files in this exact order:
+
+1. `pid-<ccPid>.json` — PID-keyed marker (atomic)
+2. `<sessionId>.json` — canonical marker (atomic)
+3. `current` — pointer (atomic)
+4. `CLAUDE_ENV_FILE` — `export CLAUDE_SESSION_ID=<sessionId>` appended
+
+The env var line is always written last so that any consumer observing the env var can immediately read the canonical marker back. Reversing this ordering (the legacy path, flag OFF) produces the race that this SD was created to fix.
+
+## Atomic write contract (TR-1)
+
+Every write in this directory uses tmp + fsync + rename:
+
+1. Open `<target>.tmp.<pid>.<epochMs>` with `O_WRONLY | O_CREAT | O_EXCL`-style semantics via `fs.openSync(path, 'w')`.
+2. `fs.writeSync` the full payload, then `fs.fsyncSync(fd)` before closing.
+3. `fs.renameSync(tmp, target)` — atomic on Windows NTFS and POSIX when source and target share a volume.
+4. On any error, the tmp file is unlinked in a `finally`-style cleanup before rethrowing.
+
+A `kill -9` at any point during the above leaves either the old file or the new file intact — never a partial write.
+
+## Feature flag
+
+`SESSION_IDENTITY_SOT_ENABLED` — defaults OFF during burn-in.
+
+| Value | Behavior |
+| --- | --- |
+| unset / `false` / `0` / `no` / `off` | Legacy order. No pointer written. Claim-validity-gate does not require three-source agreement. |
+| `true` / `1` / `yes` / `on` | Ordered writes (marker before env var). Pointer maintained. Gate enforces three-source agreement or single-source fallback. |
+
+## Related files
+
+- `lib/session-identity-sot.js` — core primitives (read, write, lock, agreement check, reconciliation).
+- `lib/claim-validity-gate.js` — consumes `validateSourcesAgree()` when the flag is on.
+- `scripts/sd-start.js` — invokes `reconcileAtBoot()` after session row materialization and before claim-validity-gate.
+- `scripts/hooks/capture-session-id.cjs` — SessionStart hook that writes the canonical marker.
+- `tests/unit/session-identity-sot.test.js` — exhaustive coverage of the five divergence scenarios plus the atomic-write interruption case.
+
+## Promotion criteria
+
+This flag remains off until telemetry shows, over one full release window:
+
+- Zero `no_deterministic_identity` fail-closes on sessions where at least one source is valid and all present sources agree (AC-1).
+- Zero partial-write artifacts after 100+ induced-failure iterations (AC-3).
+- Dual-read agreement rate ≥ 99.5% between the canonical marker and the env var (success metric from the SD).
+
+Promotion to default-on flips `SESSION_IDENTITY_SOT_ENABLED=true` in `.env.example` and removes the `sotOrdering` branches from `capture-session-id.cjs` and the legacy path from `claim-validity-gate.js` in a follow-up SD.

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,20 @@ LEO_PROTOCOL_VERSION=4.3.3
 PROJECT_NAME=EHG_Engineer
 
 # ==============================================================================
+# SESSION IDENTITY SINGLE SOURCE OF TRUTH (SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B)
+# ==============================================================================
+# Controls the three-source identity reconciliation + claim-validity-gate agreement
+# check. Default OFF during burn-in.
+#   unset / false / 0 / no / off  → legacy behavior (env var written first, no pointer,
+#                                    gate does not enforce source agreement)
+#   true / 1 / yes / on           → canonical marker written before env var (FR-4),
+#                                    .claude/session-identity/current pointer maintained,
+#                                    claim-validity-gate fails closed on source disagreement
+#                                    (FR-2, FR-3) while treating single-source-present as valid.
+# See .claude/session-identity/README.md for the full contract and promotion criteria.
+SESSION_IDENTITY_SOT_ENABLED=false
+
+# ==============================================================================
 # LLM PROVIDER CONFIGURATION
 # ==============================================================================
 # At least one API key is required for AI features to function

--- a/.gitignore
+++ b/.gitignore
@@ -235,8 +235,12 @@ src/client/dist/
 # Account handoff exchange (local session state between account switches)
 .claude/handoff/
 
-# Claude session identity markers (generated per-session, never commit)
-.claude/session-identity/
+# Claude session identity markers (generated per-session, never commit).
+# We ignore the contents — not the directory itself — so that the schema
+# README (whitelisted below per FR-6 of SD-LEO-PROTOCOL-INFRASTRUCTURE-
+# RELATIONSHIPAWARE-ORCH-001-B) can be tracked.
+.claude/session-identity/*
+!.claude/session-identity/README.md
 .claude/fleet-identity*.json
 .claude/scheduled_tasks.lock
 

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -20,6 +20,7 @@ import path from 'path';
 import { realpathSync, existsSync, readdirSync } from 'fs';
 import { execSync } from 'child_process';
 import { resolveOwnSession } from './resolve-own-session.js';
+import sessionIdentitySot from './session-identity-sot.js';
 
 // ── Worktree validation helpers (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-074) ────
 
@@ -166,6 +167,28 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
   if (!sdKey) throw new ClaimIdentityError({ reason: 'sd_not_found', operation, sdKey: '<missing>' });
 
   // ── CHECK 1: deterministic identity ────────────────────────────────────
+  // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-2, FR-3):
+  // When SESSION_IDENTITY_SOT_ENABLED is set, additionally require that all three
+  // identity sources (canonical marker, env var, /current pointer) agree.
+  // Single-source-present is treated as valid (FR-2). Two-or-more-present-and-disagree
+  // fails closed with a clear remediation (FR-3). When the flag is off, behavior is
+  // unchanged — we only consult resolveOwnSession as before.
+  if (sessionIdentitySot.isEnabled()) {
+    const repoRoot = sessionIdentitySot.discoverRepoRoot() || undefined;
+    const sotResult = sessionIdentitySot.validateSourcesAgree({ repoRoot });
+    if (!sotResult.ok) {
+      throw new ClaimIdentityError({
+        reason: 'no_deterministic_identity',
+        operation,
+        sdKey,
+        conflicts: (sotResult.agreement?.conflicts || []).map(c => ({
+          session_id: c.value, cc_pid: null, heartbeat_at: null, source: c.source,
+        })),
+        remediation: sotResult.remediation || explainRemediation('no_deterministic_identity'),
+      });
+    }
+  }
+
   const resolved = await resolveOwnSession(supabase, { requireDeterministic: true, warnOnFallback: false });
 
   if (!resolved.data) {

--- a/lib/session-identity-sot.js
+++ b/lib/session-identity-sot.js
@@ -31,7 +31,7 @@ import { execSync } from 'child_process';
 
 // ── Paths ────────────────────────────────────────────────────────────────────
 
-const FLAG_NAME = 'SESSION_IDENTITY_SOT_ENABLED';
+export const FLAG_NAME = 'SESSION_IDENTITY_SOT_ENABLED';
 const LOCK_FILENAME = '.lock';
 const CURRENT_POINTER_FILENAME = 'current';
 const LOCK_STALE_MS = 30 * 1000;  // any lock older than 30s is considered dead
@@ -210,8 +210,53 @@ export function readEnvVar(env = process.env) {
 }
 
 /**
+ * Scan the identity directory for the most recently written canonical marker
+ * (`<uuid>.json` files, excluding `pid-*.json`, `current`, and `.lock`). Returns
+ * the session_id extracted from that file, or null when no markers exist.
+ *
+ * Used by readAllSources() as the last-resort canonical discovery path so the
+ * agreement check can surface disagreements where the env var points to a
+ * session id whose marker was never written (FR-3 TS-3 semantics).
+ *
+ * @param {string} [repoRoot]
+ * @returns {string|null}
+ */
+export function scanCanonicalFromDir(repoRoot) {
+  const dir = getIdentityDir(repoRoot);
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const candidates = entries
+    .filter(name => name.endsWith('.json') && !name.startsWith('pid-'))
+    .map(name => {
+      try {
+        const full = path.join(dir, name);
+        const stat = fs.statSync(full);
+        return { name, full, mtime: stat.mtimeMs };
+      } catch { return null; }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.mtime - a.mtime);
+  for (const entry of candidates) {
+    try {
+      const obj = JSON.parse(fs.readFileSync(entry.full, 'utf8'));
+      if (obj && typeof obj.session_id === 'string') {
+        return obj.session_id;
+      }
+    } catch { /* malformed — keep scanning */ }
+  }
+  return null;
+}
+
+/**
  * Read all three identity sources. When `sessionId` hint is not provided, the
- * env var and pointer are used as hints to locate the canonical marker.
+ * env var and pointer are used as hints to locate the canonical marker; if the
+ * hinted marker doesn't exist, the directory is scanned for the most recent
+ * canonical marker so disagreements surface rather than collapsing to a
+ * single-source pass.
  *
  * @param {object} [options]
  * @param {string} [options.sessionId] - Optional session id hint
@@ -226,7 +271,13 @@ export function readAllSources(options = {}) {
   // Canonical marker is keyed by session id, so we must know the id to read it.
   // Hint precedence: explicit sessionId → envVar → pointer.
   const hint = options.sessionId || envVar || pointer;
-  const canonical = hint ? readCanonical(hint, repoRoot) : null;
+  let canonical = hint ? readCanonical(hint, repoRoot) : null;
+  if (!canonical) {
+    // Fall back to directory scan. If the most-recent marker's session_id
+    // disagrees with envVar/pointer, checkAgreement() will surface it as a
+    // disagreement (TS-3). If no markers exist at all, canonical stays null.
+    canonical = scanCanonicalFromDir(repoRoot);
+  }
   return { canonical, envVar, pointer };
 }
 
@@ -460,6 +511,7 @@ export default {
   readCurrentPointer,
   readEnvVar,
   readAllSources,
+  scanCanonicalFromDir,
   checkAgreement,
   formatDisagreementRemediation,
   reconcileAtBoot,

--- a/lib/session-identity-sot.js
+++ b/lib/session-identity-sot.js
@@ -1,0 +1,469 @@
+/**
+ * Session Identity Single Source of Truth (SOT)
+ *
+ * Implements SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B.
+ *
+ * Three identity sources exist in the system:
+ *   1. Canonical marker: .claude/session-identity/<sid>.json  (SOT)
+ *   2. Derived env var:  process.env.CLAUDE_SESSION_ID
+ *   3. Derived pointer:  .claude/session-identity/current
+ *
+ * This module centralizes reading them, reconciling them atomically at boot,
+ * and checking agreement when the claim-validity-gate runs. All new behavior
+ * is gated by the SESSION_IDENTITY_SOT_ENABLED feature flag (default OFF).
+ *
+ * Design invariants:
+ *  - Canonical marker file is WRITE-ONCE per session; it is the source of truth.
+ *  - Env var + /current pointer are DERIVED and may be rewritten by sd-start
+ *    as part of reconciliation.
+ *  - All filesystem writes use tmp + fsync + rename for crash safety (TR-1).
+ *  - Reconciliation acquires .lock to prevent concurrent writers (TR-2).
+ *  - checkAgreement() returns PASS if all *present* sources agree or if only
+ *    one source is present. It returns FAIL only when two or more sources are
+ *    present and disagree (FR-2, FR-3).
+ *
+ * @module session-identity-sot
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// ── Paths ────────────────────────────────────────────────────────────────────
+
+const FLAG_NAME = 'SESSION_IDENTITY_SOT_ENABLED';
+const LOCK_FILENAME = '.lock';
+const CURRENT_POINTER_FILENAME = 'current';
+const LOCK_STALE_MS = 30 * 1000;  // any lock older than 30s is considered dead
+const LOCK_ACQUIRE_TIMEOUT_MS = 5000;
+const LOCK_RETRY_MS = 50;
+
+/**
+ * Resolve the absolute path of .claude/session-identity/ for a given repo root.
+ * When called without args, walks up from cwd to find the nearest .claude/.
+ *
+ * @param {string} [repoRoot] - Optional repo root override
+ * @returns {string} Absolute path to the session-identity directory
+ */
+export function getIdentityDir(repoRoot) {
+  if (repoRoot) {
+    return path.resolve(repoRoot, '.claude', 'session-identity');
+  }
+  // Walk up from cwd to find .claude/
+  let dir = process.cwd();
+  const { root } = path.parse(dir);
+  while (dir && dir !== root) {
+    const candidate = path.join(dir, '.claude', 'session-identity');
+    if (fs.existsSync(path.join(dir, '.claude'))) {
+      return candidate;
+    }
+    dir = path.dirname(dir);
+  }
+  // Last-resort fallback: assume main repo convention
+  return path.resolve(process.cwd(), '.claude', 'session-identity');
+}
+
+/**
+ * Feature flag accessor.
+ *
+ * @param {object} [env=process.env] - Environment override (for tests)
+ * @returns {boolean} true when SESSION_IDENTITY_SOT_ENABLED is set to a truthy value
+ */
+export function isEnabled(env = process.env) {
+  const v = env[FLAG_NAME];
+  if (!v) return false;
+  return v === '1' || v === 'true' || v === 'TRUE' || v === 'yes' || v === 'on';
+}
+
+// ── Atomic write primitives (TR-1) ───────────────────────────────────────────
+
+/**
+ * Write a file atomically: write to <path>.tmp, fsync, rename.
+ * On Windows, rename into an existing file is atomic for files on the same volume.
+ *
+ * @param {string} targetPath - Final file path
+ * @param {string} content - UTF-8 content to write
+ * @throws {Error} on unrecoverable failure (tmp file is cleaned up on throw)
+ */
+export function atomicWrite(targetPath, content) {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  let fd = null;
+  try {
+    fd = fs.openSync(tmpPath, 'w');
+    fs.writeSync(fd, content, 0, 'utf8');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tmpPath, targetPath);
+  } catch (err) {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+    try { if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+// ── File lock (TR-2) ─────────────────────────────────────────────────────────
+
+/**
+ * Acquire .claude/session-identity/.lock. Creates the lock file with O_EXCL.
+ * Breaks stale locks older than LOCK_STALE_MS. Retries with small backoff
+ * until LOCK_ACQUIRE_TIMEOUT_MS is reached.
+ *
+ * @param {string} identityDir - Absolute path to session-identity directory
+ * @returns {{release: Function, pid: number, path: string}} lock handle
+ * @throws {Error} when unable to acquire within timeout
+ */
+export function acquireLock(identityDir) {
+  if (!fs.existsSync(identityDir)) {
+    fs.mkdirSync(identityDir, { recursive: true });
+  }
+  const lockPath = path.join(identityDir, LOCK_FILENAME);
+  const body = JSON.stringify({ pid: process.pid, at: new Date().toISOString() });
+  const deadline = Date.now() + LOCK_ACQUIRE_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeSync(fd, body, 0, 'utf8');
+      fs.fsyncSync(fd);
+      fs.closeSync(fd);
+      const release = () => {
+        try { fs.unlinkSync(lockPath); } catch { /* already gone */ }
+      };
+      return { release, pid: process.pid, path: lockPath };
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      // Lock file exists — check if stale
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          try { fs.unlinkSync(lockPath); } catch { /* raced */ }
+          continue;
+        }
+      } catch { /* lock vanished while checking */ }
+      // Busy — back off briefly
+      const end = Date.now() + LOCK_RETRY_MS;
+      while (Date.now() < end) { /* spin */ }
+    }
+  }
+  throw new Error(`session-identity: unable to acquire lock at ${lockPath} within ${LOCK_ACQUIRE_TIMEOUT_MS}ms`);
+}
+
+// ── Source readers ───────────────────────────────────────────────────────────
+
+/**
+ * Read the canonical marker file for a given session id.
+ *
+ * @param {string} sessionId - UUID
+ * @param {string} [repoRoot] - Optional repo root override
+ * @returns {string|null} Session id extracted from the file, or null if file missing / malformed
+ */
+export function readCanonical(sessionId, repoRoot) {
+  if (!sessionId) return null;
+  const markerPath = path.join(getIdentityDir(repoRoot), `${sessionId}.json`);
+  try {
+    const raw = fs.readFileSync(markerPath, 'utf8');
+    const obj = JSON.parse(raw);
+    return obj && typeof obj.session_id === 'string' ? obj.session_id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the /current pointer file.
+ *
+ * @param {string} [repoRoot] - Optional repo root override
+ * @returns {string|null} Session id stored in the pointer, or null if missing / malformed
+ */
+export function readCurrentPointer(repoRoot) {
+  const pointerPath = path.join(getIdentityDir(repoRoot), CURRENT_POINTER_FILENAME);
+  try {
+    const raw = fs.readFileSync(pointerPath, 'utf8').trim();
+    if (!raw) return null;
+    // Pointer may be plain UUID or JSON — accept both
+    if (raw.startsWith('{')) {
+      const obj = JSON.parse(raw);
+      return obj && typeof obj.session_id === 'string' ? obj.session_id : null;
+    }
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the CLAUDE_SESSION_ID env var.
+ *
+ * @param {object} [env=process.env] - Environment override (for tests)
+ * @returns {string|null} Session id from env, or null if unset / empty
+ */
+export function readEnvVar(env = process.env) {
+  const v = env.CLAUDE_SESSION_ID;
+  return v && v.trim() ? v.trim() : null;
+}
+
+/**
+ * Read all three identity sources. When `sessionId` hint is not provided, the
+ * env var and pointer are used as hints to locate the canonical marker.
+ *
+ * @param {object} [options]
+ * @param {string} [options.sessionId] - Optional session id hint
+ * @param {string} [options.repoRoot] - Optional repo root override
+ * @param {object} [options.env] - Optional env override (for tests)
+ * @returns {{canonical: string|null, envVar: string|null, pointer: string|null}}
+ */
+export function readAllSources(options = {}) {
+  const { repoRoot, env = process.env } = options;
+  const envVar = readEnvVar(env);
+  const pointer = readCurrentPointer(repoRoot);
+  // Canonical marker is keyed by session id, so we must know the id to read it.
+  // Hint precedence: explicit sessionId → envVar → pointer.
+  const hint = options.sessionId || envVar || pointer;
+  const canonical = hint ? readCanonical(hint, repoRoot) : null;
+  return { canonical, envVar, pointer };
+}
+
+// ── Agreement check (FR-2, FR-3) ─────────────────────────────────────────────
+
+/**
+ * Compare the three identity sources and decide whether they agree.
+ *
+ * Rules (FR-2, FR-3):
+ *   - All present sources agree → { agree: true, sessionId, presentSources }
+ *   - Only one source present   → { agree: true, sessionId, presentSources }
+ *   - No sources present        → { agree: false, reason: 'no_sources', presentSources: [] }
+ *   - Two or more present and disagree → { agree: false, reason: 'disagreement',
+ *                                           conflicts: [{source, value}, ...] }
+ *
+ * @param {{canonical: string|null, envVar: string|null, pointer: string|null}} sources
+ * @returns {{agree: boolean, sessionId: string|null, presentSources: string[],
+ *            reason?: string, conflicts?: Array<{source: string, value: string}>}}
+ */
+export function checkAgreement(sources) {
+  const entries = [
+    { source: 'canonical', value: sources.canonical },
+    { source: 'envVar',    value: sources.envVar    },
+    { source: 'pointer',   value: sources.pointer   },
+  ];
+  const present = entries.filter(e => typeof e.value === 'string' && e.value.length > 0);
+
+  if (present.length === 0) {
+    return { agree: false, sessionId: null, presentSources: [], reason: 'no_sources' };
+  }
+
+  const first = present[0].value;
+  const allAgree = present.every(e => e.value === first);
+  if (allAgree) {
+    return {
+      agree: true,
+      sessionId: first,
+      presentSources: present.map(e => e.source),
+    };
+  }
+
+  return {
+    agree: false,
+    sessionId: null,
+    presentSources: present.map(e => e.source),
+    reason: 'disagreement',
+    conflicts: present.map(e => ({ source: e.source, value: e.value })),
+  };
+}
+
+/**
+ * Format a human-readable remediation string for a disagreement result.
+ * Used by claim-validity-gate banner and sd-start error messages (FR-3).
+ *
+ * @param {{conflicts: Array<{source: string, value: string}>}} disagreement
+ * @returns {string} Multi-line remediation text
+ */
+export function formatDisagreementRemediation(disagreement) {
+  const lines = [
+    'Session identity sources disagree. Present sources:',
+  ];
+  for (const c of (disagreement.conflicts || [])) {
+    lines.push(`  - ${c.source}: ${c.value}`);
+  }
+  lines.push('');
+  lines.push('Resolve by picking the canonical source as truth:');
+  lines.push('  1. Identify the true session id (usually the canonical marker file).');
+  lines.push('  2. Set CLAUDE_SESSION_ID to that id: export CLAUDE_SESSION_ID=<id>');
+  lines.push('  3. Re-run sd-start.js which will atomically rewrite the /current pointer.');
+  lines.push('  4. If unsure, restart Claude Code so SessionStart writes a fresh canonical marker.');
+  return lines.join('\n');
+}
+
+// ── Reconciliation (FR-1) ────────────────────────────────────────────────────
+
+/**
+ * Reconcile the three identity sources at sd-start boot time.
+ *
+ * When enabled (SESSION_IDENTITY_SOT_ENABLED=true):
+ *   - Reads canonical marker for the given session id.
+ *   - Atomically rewrites the /current pointer to match.
+ *   - Updates the CLAUDE_SESSION_ID env var in the current process (and, when
+ *     CLAUDE_ENV_FILE is set, appends an `export` line so subsequent subshells
+ *     see it).
+ *   - Uses a file lock to serialize concurrent reconciliations (TR-2).
+ *
+ * When disabled: returns { applied: false } immediately.
+ *
+ * @param {string} sessionId - The session id to reconcile to
+ * @param {object} [options]
+ * @param {string} [options.repoRoot] - Optional repo root override
+ * @param {object} [options.env=process.env] - Env to mutate (tests override)
+ * @param {object} [options.envFilePath] - Explicit CLAUDE_ENV_FILE path override
+ * @returns {{applied: boolean, reason?: string, canonical?: string|null,
+ *            wrotePointer?: boolean, wroteEnvFile?: boolean}}
+ */
+export function reconcileAtBoot(sessionId, options = {}) {
+  const { repoRoot, env = process.env } = options;
+
+  if (!isEnabled(env)) {
+    return { applied: false, reason: 'flag_disabled' };
+  }
+  if (!sessionId) {
+    return { applied: false, reason: 'no_session_id' };
+  }
+
+  const identityDir = getIdentityDir(repoRoot);
+  const lock = acquireLock(identityDir);
+  try {
+    const canonical = readCanonical(sessionId, repoRoot);
+
+    // If canonical marker doesn't exist yet, reconciliation can still update
+    // the derived sources to the provided session id — but flag it so the
+    // caller knows the marker must be written by the SessionStart hook first.
+    const pointerPath = path.join(identityDir, CURRENT_POINTER_FILENAME);
+    atomicWrite(pointerPath, sessionId);
+
+    // Mutate env in the current process so downstream code sees it immediately.
+    env.CLAUDE_SESSION_ID = sessionId;
+
+    // When CLAUDE_ENV_FILE is available, append the export so future Bash-tool
+    // invocations in this conversation inherit the value.
+    let wroteEnvFile = false;
+    const envFilePath = options.envFilePath || env.CLAUDE_ENV_FILE;
+    if (envFilePath) {
+      try {
+        fs.appendFileSync(envFilePath, `export CLAUDE_SESSION_ID=${sessionId}\n`);
+        wroteEnvFile = true;
+      } catch {
+        wroteEnvFile = false;
+      }
+    }
+
+    return {
+      applied: true,
+      canonical,
+      wrotePointer: true,
+      wroteEnvFile,
+    };
+  } finally {
+    lock.release();
+  }
+}
+
+/**
+ * Write a fresh canonical marker. Used by the SessionStart hook when migrating
+ * to the SOT model (FR-4 ordering — marker BEFORE env var).
+ *
+ * @param {string} sessionId - UUID
+ * @param {object} markerBody - Remaining fields (cc_pid, source, model, etc.)
+ * @param {object} [options]
+ * @param {string} [options.repoRoot]
+ * @returns {{written: boolean, path: string}}
+ */
+export function writeCanonicalMarker(sessionId, markerBody, options = {}) {
+  const { repoRoot } = options;
+  const identityDir = getIdentityDir(repoRoot);
+  if (!fs.existsSync(identityDir)) {
+    fs.mkdirSync(identityDir, { recursive: true });
+  }
+  const markerPath = path.join(identityDir, `${sessionId}.json`);
+  const body = {
+    session_id: sessionId,
+    ...markerBody,
+    captured_at: markerBody?.captured_at || new Date().toISOString(),
+  };
+  atomicWrite(markerPath, JSON.stringify(body, null, 2));
+  return { written: true, path: markerPath };
+}
+
+// ── High-level helper for claim-validity-gate (FR-2, FR-3) ───────────────────
+
+/**
+ * End-to-end check used by the claim-validity-gate when the feature flag is on.
+ * Reads all three sources and applies the agreement rules.
+ *
+ * @param {object} [options]
+ * @param {string} [options.sessionId] - Optional explicit session id hint
+ * @param {string} [options.repoRoot]
+ * @param {object} [options.env=process.env]
+ * @returns {{ok: boolean, sessionId: string|null, sources: object,
+ *            agreement: object, remediation?: string}}
+ */
+export function validateSourcesAgree(options = {}) {
+  const { repoRoot, env = process.env, sessionId } = options;
+  const sources = readAllSources({ sessionId, repoRoot, env });
+  const agreement = checkAgreement(sources);
+  if (agreement.agree) {
+    return { ok: true, sessionId: agreement.sessionId, sources, agreement };
+  }
+  return {
+    ok: false,
+    sessionId: null,
+    sources,
+    agreement,
+    remediation: formatDisagreementRemediation(agreement),
+  };
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort discovery of the main repo root. Used when callers don't pass one.
+ * Mirrors the worktree-aware logic in scripts/resolve-sd-workdir.js::getRepoRoot.
+ *
+ * @returns {string|null}
+ */
+export function discoverRepoRoot() {
+  try {
+    let toplevel = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const normalized = toplevel.replace(/\\/g, '/');
+    const wtIdx = normalized.indexOf('/.worktrees/');
+    if (wtIdx >= 0) {
+      toplevel = toplevel.substring(0, wtIdx);
+    }
+    return toplevel || null;
+  } catch {
+    return null;
+  }
+}
+
+export default {
+  FLAG_NAME,
+  getIdentityDir,
+  isEnabled,
+  atomicWrite,
+  acquireLock,
+  readCanonical,
+  readCurrentPointer,
+  readEnvVar,
+  readAllSources,
+  checkAgreement,
+  formatDisagreementRemediation,
+  reconcileAtBoot,
+  writeCanonicalMarker,
+  validateSourcesAgree,
+  discoverRepoRoot,
+};

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -80,6 +80,40 @@ function logDiscoveryEvent(fields) {
   try { console.error(JSON.stringify(entry)); } catch { /* best effort */ }
 }
 
+// ── SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-4, FR-5, TR-1) ──
+// Inline helpers so this hook stays dependency-free per the file header contract.
+// These mirror lib/session-identity-sot.js but cannot import it (ESM from CJS hook).
+
+/** Returns true when the SOT feature flag is enabled. */
+function sotIsEnabled() {
+  const v = process.env.SESSION_IDENTITY_SOT_ENABLED;
+  if (!v) return false;
+  return v === '1' || v === 'true' || v === 'TRUE' || v === 'yes' || v === 'on';
+}
+
+/**
+ * Atomic write: tmp + fsync + rename. Crash-safe per TR-1.
+ * Tmp file is cleaned up on any error so partial state never surfaces.
+ */
+function sotAtomicWrite(targetPath, content) {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  let fd = null;
+  try {
+    fd = fs.openSync(tmpPath, 'w');
+    fs.writeSync(fd, content, 0, 'utf8');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tmpPath, targetPath);
+  } catch (err) {
+    if (fd !== null) { try { fs.closeSync(fd); } catch { /* ignore */ } }
+    try { if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
 /**
  * Find the Claude Code node.exe PID by walking the process ancestry chain.
  * Mirrors the logic in lib/terminal-identity.js findClaudeCodePid(), but in CJS
@@ -197,27 +231,14 @@ function main() {
           return;
         }
 
-        // Strategy 1: Write to CLAUDE_ENV_FILE (makes env var available to Bash tool)
-        const envFile = process.env.CLAUDE_ENV_FILE;
-        if (envFile) {
-          try {
-            // Use export syntax per Claude Code docs; append to preserve other hooks' vars
-            fs.appendFileSync(envFile, `export CLAUDE_SESSION_ID=${sessionId}\n`);
-          } catch (e) {
-            console.error(`SessionStart:capture-session-id: CLAUDE_ENV_FILE write failed: ${e.message}`);
-          }
-        } else {
-          // Diagnostic: log which env vars Claude Code provides to hooks
-          const claudeVars = Object.keys(process.env)
-            .filter(k => k.startsWith('CLAUDE'))
-            .join(', ');
-          console.error(`SessionStart:capture-session-id: CLAUDE_ENV_FILE not set. Claude vars: [${claudeVars}]`);
-        }
+        // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-4):
+        // When the SOT feature flag is on, the canonical <sid>.json marker MUST be
+        // written (and fsync'd) BEFORE CLAUDE_ENV_FILE receives the export. This
+        // ordering guarantees that any tool observing the env var can always read
+        // the canonical marker back. When the flag is off we preserve the legacy
+        // order (env var first) to avoid perturbing sessions that haven't opted in.
+        const sotOrdering = sotIsEnabled();
 
-        // Strategy 2: Write session marker files keyed by Claude Code PID.
-        // Walk the process tree to find the actual Claude Code node.exe ancestor
-        // (process.ppid is often cmd.exe, not Claude Code). This PID matches what
-        // getTerminalId() → findClaudeCodePid() discovers at Bash tool runtime.
         const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
         const entryPath = data.source || 'unknown';
         const discoveredPid = findClaudeCodePid(entryPath);
@@ -226,6 +247,32 @@ function main() {
           logDiscoveryEvent({ entry_path: entryPath, method_used: 'fallback_ppid', outcome: 'degraded', fallback_ppid: ccPid });
         }
         const markerDir = path.resolve(__dirname, '../../.claude/session-identity');
+        const envFile = process.env.CLAUDE_ENV_FILE;
+
+        const writeEnvFile = () => {
+          if (envFile) {
+            try {
+              // Use export syntax per Claude Code docs; append to preserve other hooks' vars
+              fs.appendFileSync(envFile, `export CLAUDE_SESSION_ID=${sessionId}\n`);
+            } catch (e) {
+              console.error(`SessionStart:capture-session-id: CLAUDE_ENV_FILE write failed: ${e.message}`);
+            }
+          } else {
+            // Diagnostic: log which env vars Claude Code provides to hooks
+            const claudeVars = Object.keys(process.env)
+              .filter(k => k.startsWith('CLAUDE'))
+              .join(', ');
+            console.error(`SessionStart:capture-session-id: CLAUDE_ENV_FILE not set. Claude vars: [${claudeVars}]`);
+          }
+        };
+
+        // Strategy 1 (legacy order): write env var first when SOT flag is off.
+        if (!sotOrdering) writeEnvFile();
+
+        // Strategy 2: Write session marker files keyed by Claude Code PID.
+        // Walk the process tree to find the actual Claude Code node.exe ancestor
+        // (process.ppid is often cmd.exe, not Claude Code). This PID matches what
+        // getTerminalId() → findClaudeCodePid() discovers at Bash tool runtime.
         try {
           if (!fs.existsSync(markerDir)) {
             fs.mkdirSync(markerDir, { recursive: true });
@@ -240,13 +287,31 @@ function main() {
             captured_at: new Date().toISOString()
           };
 
-          // Write PID-keyed marker (primary lookup for getTerminalId)
+          // Write PID-keyed marker (primary lookup for getTerminalId).
+          // Use atomic write under SOT ordering so the marker lands crash-safe.
           const pidFile = path.join(markerDir, `pid-${ccPid}.json`);
-          fs.writeFileSync(pidFile, JSON.stringify(marker, null, 2));
+          if (sotOrdering) {
+            sotAtomicWrite(pidFile, JSON.stringify(marker, null, 2));
+          } else {
+            fs.writeFileSync(pidFile, JSON.stringify(marker, null, 2));
+          }
 
-          // Write per-session marker (for audit/debugging)
+          // Write per-session marker (for audit/debugging — this is the canonical SOT marker).
           const markerFile = path.join(markerDir, `${sessionId}.json`);
-          fs.writeFileSync(markerFile, JSON.stringify(marker, null, 2));
+          if (sotOrdering) {
+            sotAtomicWrite(markerFile, JSON.stringify(marker, null, 2));
+          } else {
+            fs.writeFileSync(markerFile, JSON.stringify(marker, null, 2));
+          }
+
+          // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-1):
+          // When SOT is enabled, atomically update the /current pointer to match.
+          // This is the third identity source — once it's written, claim-validity-gate
+          // sees all three in agreement.
+          if (sotOrdering) {
+            const currentPointer = path.join(markerDir, 'current');
+            sotAtomicWrite(currentPointer, sessionId);
+          }
 
           // Cleanup old markers — preserve markers for alive PIDs, only delete dead ones
           // Fix: previous "keep last 3" logic deleted the current conversation's marker
@@ -280,6 +345,11 @@ function main() {
         } catch {
           // Non-fatal
         }
+
+        // Strategy 1 (SOT order): write env var AFTER marker + pointer.
+        // Guarantees FR-4 — env var is never set to a session id whose canonical
+        // file doesn't exist yet.
+        if (sotOrdering) writeEnvFile();
 
         // Machine-readable line for downstream parsing (SD-MAN-INFRA-SESSION-IDENTITY-BIRTH-001)
         console.log(`CLAUDE_SESSION_ID=${sessionId}`);

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -20,6 +20,7 @@ import dotenv from 'dotenv';
 import { getOrCreateSession, updateHeartbeat } from '../lib/session-manager.mjs';
 import { resolveOwnSession } from '../lib/resolve-own-session.js';
 import { assertValidClaim, ClaimIdentityError } from '../lib/claim-validity-gate.js';
+import sessionIdentitySot from '../lib/session-identity-sot.js';
 import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
 import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
@@ -623,6 +624,24 @@ async function main() {
 
   if (!session) {
     session = await getOrCreateSession();
+  }
+
+  // 2.1 SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-1, TR-1, TR-2):
+  // Atomically reconcile the three identity sources so claim-validity-gate sees
+  // all three in agreement. No-op when SESSION_IDENTITY_SOT_ENABLED is unset/false.
+  // Uses a file lock (.claude/session-identity/.lock) to serialize concurrent boots
+  // and tmp+fsync+rename for crash-safe writes.
+  try {
+    const reconcile = sessionIdentitySot.reconcileAtBoot(session.session_id, {
+      repoRoot: sessionIdentitySot.discoverRepoRoot() || undefined
+    });
+    if (reconcile.applied) {
+      console.log(`${colors.dim}(Identity SOT: reconciled — pointer=${reconcile.wrotePointer ? 'updated' : 'skipped'} envFile=${reconcile.wroteEnvFile ? 'updated' : 'n/a'})${colors.reset}`);
+    }
+  } catch (reconcileErr) {
+    // Reconciliation errors are non-fatal during burn-in; log and continue so the
+    // legacy identity path can still succeed. Disagreements surface at claim gate.
+    console.warn(`${colors.yellow}⚠ session-identity reconciliation error (non-blocking): ${reconcileErr.message}${colors.reset}`);
   }
 
   // 2a. Validate claim identity + ownership now that session row exists.

--- a/tests/unit/session-identity-sot.test.js
+++ b/tests/unit/session-identity-sot.test.js
@@ -1,0 +1,513 @@
+/**
+ * Unit tests for lib/session-identity-sot.js
+ *
+ * Covers every test scenario from SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B:
+ *   TS-1: Happy path — all three sources exist and agree
+ *   TS-2: Edge — only canonical source exists
+ *   TS-3: Error — canonical vs env var disagreement
+ *   TS-4: Error — atomic write interrupted (kill -9 after .tmp but before rename)
+ *   TS-5: Feature flag disabled — legacy behavior preserved
+ *
+ * Plus TR-3 coverage: five divergence scenarios for checkAgreement().
+ *   D-1: all three agree
+ *   D-2: two agree, one missing
+ *   D-3: only one present
+ *   D-4: two disagree
+ *   D-5: three disagree
+ *
+ * Plus TR-1 coverage: atomicWrite cleans up tmp on error, produces valid UTF-8.
+ * Plus TR-2 coverage: acquireLock serializes concurrent writers, breaks stale locks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawnSync } from 'child_process';
+import {
+  FLAG_NAME,
+  getIdentityDir,
+  isEnabled,
+  atomicWrite,
+  acquireLock,
+  readCanonical,
+  readCurrentPointer,
+  readEnvVar,
+  readAllSources,
+  checkAgreement,
+  formatDisagreementRemediation,
+  reconcileAtBoot,
+  writeCanonicalMarker,
+  validateSourcesAgree,
+} from '../../lib/session-identity-sot.js';
+
+// ── Test harness ────────────────────────────────────────────────────────────
+
+function makeTempRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sot-test-'));
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.claude', 'session-identity'), { recursive: true });
+  return dir;
+}
+
+function cleanupRepo(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function writeMarker(repoRoot, sessionId, extra = {}) {
+  const p = path.join(repoRoot, '.claude', 'session-identity', `${sessionId}.json`);
+  fs.writeFileSync(p, JSON.stringify({ session_id: sessionId, cc_pid: 123, source: 'test', captured_at: new Date().toISOString(), ...extra }));
+  return p;
+}
+
+function writePointer(repoRoot, sessionId) {
+  const p = path.join(repoRoot, '.claude', 'session-identity', 'current');
+  fs.writeFileSync(p, sessionId);
+  return p;
+}
+
+const UUID_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const UUID_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const UUID_C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+// ── isEnabled ────────────────────────────────────────────────────────────────
+
+describe('isEnabled', () => {
+  it('returns false when flag is unset', () => {
+    expect(isEnabled({})).toBe(false);
+  });
+
+  it('returns false for explicit falsey values', () => {
+    for (const v of ['false', '0', 'no', 'off', '']) {
+      expect(isEnabled({ [FLAG_NAME]: v })).toBe(false);
+    }
+  });
+
+  it('returns true for explicit truthy values', () => {
+    for (const v of ['true', 'TRUE', '1', 'yes', 'on']) {
+      expect(isEnabled({ [FLAG_NAME]: v })).toBe(true);
+    }
+  });
+});
+
+// ── atomicWrite (TR-1) ───────────────────────────────────────────────────────
+
+describe('atomicWrite (TR-1)', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('writes UTF-8 content atomically', () => {
+    const target = path.join(dir, 'foo.json');
+    atomicWrite(target, JSON.stringify({ a: 1 }));
+    expect(fs.readFileSync(target, 'utf8')).toBe('{"a":1}');
+  });
+
+  it('creates parent directory if missing', () => {
+    const target = path.join(dir, 'nested', 'deeper', 'file.txt');
+    atomicWrite(target, 'hello');
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it('replaces existing file atomically', () => {
+    const target = path.join(dir, 'foo.txt');
+    fs.writeFileSync(target, 'old');
+    atomicWrite(target, 'new');
+    expect(fs.readFileSync(target, 'utf8')).toBe('new');
+  });
+
+  it('leaves no tmp files after successful write', () => {
+    const target = path.join(dir, 'foo.txt');
+    atomicWrite(target, 'x');
+    const leftovers = fs.readdirSync(dir).filter(f => f.includes('.tmp.'));
+    expect(leftovers).toHaveLength(0);
+  });
+
+  it('cleans up tmp file when write fails', () => {
+    const target = path.join(dir, 'readonly-parent', 'f.txt');
+    fs.mkdirSync(path.join(dir, 'readonly-parent'));
+    // Monkey-patch fs.renameSync to force an error
+    const originalRename = fs.renameSync;
+    fs.renameSync = vi.fn(() => { throw new Error('forced failure'); });
+    try {
+      expect(() => atomicWrite(target, 'x')).toThrow('forced failure');
+      const leftovers = fs.readdirSync(path.dirname(target)).filter(f => f.includes('.tmp.'));
+      expect(leftovers).toHaveLength(0);
+    } finally {
+      fs.renameSync = originalRename;
+    }
+  });
+});
+
+// ── acquireLock (TR-2) ───────────────────────────────────────────────────────
+
+describe('acquireLock (TR-2)', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('creates the lock file and returns a release handle', () => {
+    const identityDir = path.join(dir, '.claude', 'session-identity');
+    const lock = acquireLock(identityDir);
+    expect(fs.existsSync(lock.path)).toBe(true);
+    expect(lock.pid).toBe(process.pid);
+    lock.release();
+    expect(fs.existsSync(lock.path)).toBe(false);
+  });
+
+  it('breaks a stale lock older than 30s', () => {
+    const identityDir = path.join(dir, '.claude', 'session-identity');
+    const lockPath = path.join(identityDir, '.lock');
+    // Write a stale lock with mtime in the distant past.
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999, at: '2020-01-01' }));
+    const sixtySecondsAgo = (Date.now() / 1000) - 60;
+    fs.utimesSync(lockPath, sixtySecondsAgo, sixtySecondsAgo);
+    const lock = acquireLock(identityDir);
+    expect(lock.pid).toBe(process.pid);
+    lock.release();
+  });
+});
+
+// ── Readers ──────────────────────────────────────────────────────────────────
+
+describe('readers', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('readCanonical returns session_id from marker file', () => {
+    writeMarker(dir, UUID_A);
+    expect(readCanonical(UUID_A, dir)).toBe(UUID_A);
+  });
+
+  it('readCanonical returns null when marker missing', () => {
+    expect(readCanonical(UUID_A, dir)).toBeNull();
+  });
+
+  it('readCanonical returns null when marker is malformed JSON', () => {
+    fs.writeFileSync(path.join(dir, '.claude', 'session-identity', `${UUID_A}.json`), 'not json');
+    expect(readCanonical(UUID_A, dir)).toBeNull();
+  });
+
+  it('readCurrentPointer accepts plain UUID', () => {
+    writePointer(dir, UUID_A);
+    expect(readCurrentPointer(dir)).toBe(UUID_A);
+  });
+
+  it('readCurrentPointer accepts JSON body', () => {
+    fs.writeFileSync(path.join(dir, '.claude', 'session-identity', 'current'), JSON.stringify({ session_id: UUID_B }));
+    expect(readCurrentPointer(dir)).toBe(UUID_B);
+  });
+
+  it('readCurrentPointer returns null when pointer missing', () => {
+    expect(readCurrentPointer(dir)).toBeNull();
+  });
+
+  it('readEnvVar respects empty string', () => {
+    expect(readEnvVar({ CLAUDE_SESSION_ID: '' })).toBeNull();
+    expect(readEnvVar({ CLAUDE_SESSION_ID: UUID_A })).toBe(UUID_A);
+    expect(readEnvVar({})).toBeNull();
+  });
+});
+
+// ── checkAgreement: 5 divergence scenarios (TR-3) ────────────────────────────
+
+describe('checkAgreement (TR-3 — 5 divergence scenarios)', () => {
+  it('D-1: all three sources agree → passes with all three names', () => {
+    const result = checkAgreement({ canonical: UUID_A, envVar: UUID_A, pointer: UUID_A });
+    expect(result).toEqual({
+      agree: true,
+      sessionId: UUID_A,
+      presentSources: ['canonical', 'envVar', 'pointer'],
+    });
+  });
+
+  it('D-2: two sources agree, one missing → passes', () => {
+    const result = checkAgreement({ canonical: UUID_A, envVar: UUID_A, pointer: null });
+    expect(result.agree).toBe(true);
+    expect(result.sessionId).toBe(UUID_A);
+    expect(result.presentSources).toEqual(['canonical', 'envVar']);
+  });
+
+  it('D-3: only one source present → passes (single-source rule FR-2)', () => {
+    const result = checkAgreement({ canonical: null, envVar: UUID_A, pointer: null });
+    expect(result.agree).toBe(true);
+    expect(result.sessionId).toBe(UUID_A);
+    expect(result.presentSources).toEqual(['envVar']);
+  });
+
+  it('D-4: two sources disagree → fails closed with conflicts list', () => {
+    const result = checkAgreement({ canonical: UUID_A, envVar: UUID_B, pointer: null });
+    expect(result.agree).toBe(false);
+    expect(result.reason).toBe('disagreement');
+    expect(result.sessionId).toBeNull();
+    expect(result.conflicts).toEqual([
+      { source: 'canonical', value: UUID_A },
+      { source: 'envVar',    value: UUID_B },
+    ]);
+  });
+
+  it('D-5: all three sources disagree → fails closed with three conflicts', () => {
+    const result = checkAgreement({ canonical: UUID_A, envVar: UUID_B, pointer: UUID_C });
+    expect(result.agree).toBe(false);
+    expect(result.reason).toBe('disagreement');
+    expect(result.conflicts).toHaveLength(3);
+  });
+
+  it('no sources present → fails with no_sources reason', () => {
+    const result = checkAgreement({ canonical: null, envVar: null, pointer: null });
+    expect(result.agree).toBe(false);
+    expect(result.reason).toBe('no_sources');
+  });
+});
+
+describe('formatDisagreementRemediation', () => {
+  it('names each disagreeing source in the banner', () => {
+    const banner = formatDisagreementRemediation({
+      conflicts: [
+        { source: 'canonical', value: UUID_A },
+        { source: 'envVar',    value: UUID_B },
+      ],
+    });
+    expect(banner).toContain('canonical: ' + UUID_A);
+    expect(banner).toContain('envVar: ' + UUID_B);
+    expect(banner).toContain('Resolve');
+    expect(banner).toContain('CLAUDE_SESSION_ID');
+  });
+});
+
+// ── Top-level PRD test scenarios (TS-1..TS-5) ────────────────────────────────
+
+describe('validateSourcesAgree — PRD test scenarios', () => {
+  let dir;
+  let savedEnv;
+  beforeEach(() => { dir = makeTempRepo(); savedEnv = process.env.CLAUDE_SESSION_ID; });
+  afterEach(() => {
+    cleanupRepo(dir);
+    if (savedEnv === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = savedEnv;
+  });
+
+  it('TS-1: all three sources exist and agree → gate passes', () => {
+    writeMarker(dir, UUID_A);
+    writePointer(dir, UUID_A);
+    const result = validateSourcesAgree({
+      repoRoot: dir,
+      env: { CLAUDE_SESSION_ID: UUID_A },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.sessionId).toBe(UUID_A);
+    expect(result.agreement.presentSources).toEqual(['canonical', 'envVar', 'pointer']);
+  });
+
+  it('TS-2: only canonical source exists → gate passes (single-source)', () => {
+    writeMarker(dir, UUID_A);
+    const result = validateSourcesAgree({
+      repoRoot: dir,
+      env: {},
+      sessionId: UUID_A,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.sessionId).toBe(UUID_A);
+    expect(result.agreement.presentSources).toEqual(['canonical']);
+  });
+
+  it('TS-3: sources disagree → gate fails with clear remediation', () => {
+    writeMarker(dir, UUID_A);
+    const result = validateSourcesAgree({
+      repoRoot: dir,
+      env: { CLAUDE_SESSION_ID: UUID_B },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.remediation).toContain('Session identity sources disagree');
+    expect(result.agreement.conflicts.map(c => c.value).sort()).toEqual([UUID_A, UUID_B].sort());
+  });
+
+  it('TS-5: feature flag disabled → legacy path (flag read is caller responsibility)', () => {
+    // The gate only calls validateSourcesAgree when isEnabled() is true; when the flag
+    // is off, the gate never reaches this code. This test documents that contract.
+    process.env.SESSION_IDENTITY_SOT_ENABLED = 'false';
+    expect(isEnabled()).toBe(false);
+    // validateSourcesAgree itself still operates on explicit inputs — it does not
+    // auto-disable based on the flag. Callers must branch on isEnabled().
+    writeMarker(dir, UUID_A);
+    const result = validateSourcesAgree({
+      repoRoot: dir,
+      env: { CLAUDE_SESSION_ID: UUID_A },
+    });
+    expect(result.ok).toBe(true);
+    delete process.env.SESSION_IDENTITY_SOT_ENABLED;
+  });
+});
+
+// ── TS-4: atomic-write interruption (in-process simulation) ──────────────────
+
+describe('TS-4: atomic-write interruption', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('kills the process between tmp write and rename — original files untouched', () => {
+    const markerPath = path.join(dir, '.claude', 'session-identity', `${UUID_A}.json`);
+    // Pre-existing canonical file.
+    fs.writeFileSync(markerPath, JSON.stringify({ session_id: UUID_A, version: 'original' }));
+    const originalContent = fs.readFileSync(markerPath, 'utf8');
+
+    // Monkey-patch fs.renameSync to simulate a kill between fsync and rename.
+    const original = fs.renameSync;
+    fs.renameSync = () => { throw new Error('simulated SIGKILL before rename'); };
+
+    try {
+      expect(() => atomicWrite(markerPath, JSON.stringify({ session_id: UUID_A, version: 'new' }))).toThrow();
+    } finally {
+      fs.renameSync = original;
+    }
+
+    // Original file is untouched.
+    expect(fs.readFileSync(markerPath, 'utf8')).toBe(originalContent);
+    // No partial/corrupted .tmp files.
+    const leftovers = fs.readdirSync(path.dirname(markerPath)).filter(f => f.includes('.tmp.'));
+    expect(leftovers).toHaveLength(0);
+  });
+
+  it('100 iterations of induced failure leave zero partial files (AC-3)', () => {
+    const markerPath = path.join(dir, '.claude', 'session-identity', `${UUID_A}.json`);
+    fs.writeFileSync(markerPath, '{"session_id":"' + UUID_A + '","version":"original"}');
+    const originalRename = fs.renameSync;
+    let failCount = 0;
+    fs.renameSync = (tmp) => { failCount++; try { fs.unlinkSync(tmp); } catch { /* best effort */ } throw new Error('induced'); };
+    try {
+      for (let i = 0; i < 100; i++) {
+        try { atomicWrite(markerPath, '{"session_id":"' + UUID_B + '"}'); } catch { /* expected */ }
+      }
+    } finally {
+      fs.renameSync = originalRename;
+    }
+    expect(failCount).toBe(100);
+    const leftovers = fs.readdirSync(path.dirname(markerPath)).filter(f => f.includes('.tmp.'));
+    expect(leftovers).toHaveLength(0);
+    // Original content still present and intact.
+    const body = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    expect(body.session_id).toBe(UUID_A);
+  });
+});
+
+// ── readAllSources integration ───────────────────────────────────────────────
+
+describe('readAllSources', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('uses sessionId hint to locate canonical marker', () => {
+    writeMarker(dir, UUID_A);
+    writePointer(dir, UUID_A);
+    const sources = readAllSources({ sessionId: UUID_A, repoRoot: dir, env: { CLAUDE_SESSION_ID: UUID_A } });
+    expect(sources).toEqual({ canonical: UUID_A, envVar: UUID_A, pointer: UUID_A });
+  });
+
+  it('falls back to env var as canonical hint when sessionId omitted', () => {
+    writeMarker(dir, UUID_A);
+    const sources = readAllSources({ repoRoot: dir, env: { CLAUDE_SESSION_ID: UUID_A } });
+    expect(sources.canonical).toBe(UUID_A);
+  });
+
+  it('falls back to pointer as canonical hint when env var unset', () => {
+    writeMarker(dir, UUID_A);
+    writePointer(dir, UUID_A);
+    const sources = readAllSources({ repoRoot: dir, env: {} });
+    expect(sources.pointer).toBe(UUID_A);
+    expect(sources.canonical).toBe(UUID_A);
+  });
+});
+
+// ── reconcileAtBoot ──────────────────────────────────────────────────────────
+
+describe('reconcileAtBoot (FR-1)', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('no-ops when flag is disabled', () => {
+    const env = { SESSION_IDENTITY_SOT_ENABLED: 'false' };
+    const result = reconcileAtBoot(UUID_A, { repoRoot: dir, env });
+    expect(result).toEqual({ applied: false, reason: 'flag_disabled' });
+    // No pointer written.
+    expect(readCurrentPointer(dir)).toBeNull();
+  });
+
+  it('writes pointer and mutates env when enabled', () => {
+    const env = { SESSION_IDENTITY_SOT_ENABLED: 'true' };
+    writeMarker(dir, UUID_A);
+    const result = reconcileAtBoot(UUID_A, { repoRoot: dir, env });
+    expect(result.applied).toBe(true);
+    expect(result.wrotePointer).toBe(true);
+    expect(env.CLAUDE_SESSION_ID).toBe(UUID_A);
+    expect(readCurrentPointer(dir)).toBe(UUID_A);
+  });
+
+  it('appends to CLAUDE_ENV_FILE when provided', () => {
+    const envFilePath = path.join(dir, 'env-output');
+    fs.writeFileSync(envFilePath, '');
+    const env = { SESSION_IDENTITY_SOT_ENABLED: 'true', CLAUDE_ENV_FILE: envFilePath };
+    writeMarker(dir, UUID_A);
+    const result = reconcileAtBoot(UUID_A, { repoRoot: dir, env });
+    expect(result.wroteEnvFile).toBe(true);
+    const content = fs.readFileSync(envFilePath, 'utf8');
+    expect(content).toContain(`export CLAUDE_SESSION_ID=${UUID_A}`);
+  });
+
+  it('refuses to run when session id is missing', () => {
+    const env = { SESSION_IDENTITY_SOT_ENABLED: 'true' };
+    const result = reconcileAtBoot(null, { repoRoot: dir, env });
+    expect(result).toEqual({ applied: false, reason: 'no_session_id' });
+  });
+
+  it('acquires and releases the lock even when no canonical marker exists', () => {
+    const env = { SESSION_IDENTITY_SOT_ENABLED: 'true' };
+    const result = reconcileAtBoot(UUID_A, { repoRoot: dir, env });
+    expect(result.applied).toBe(true);
+    expect(result.canonical).toBeNull();
+    // Lock file is cleaned up.
+    expect(fs.existsSync(path.join(dir, '.claude', 'session-identity', '.lock'))).toBe(false);
+  });
+});
+
+// ── writeCanonicalMarker ─────────────────────────────────────────────────────
+
+describe('writeCanonicalMarker', () => {
+  let dir;
+  beforeEach(() => { dir = makeTempRepo(); });
+  afterEach(() => cleanupRepo(dir));
+
+  it('creates the <sid>.json file with the expected schema', () => {
+    const result = writeCanonicalMarker(UUID_A, {
+      cc_pid: 1234,
+      source: 'startup',
+      model: 'claude-opus-4-7',
+    }, { repoRoot: dir });
+    expect(result.written).toBe(true);
+    const body = JSON.parse(fs.readFileSync(result.path, 'utf8'));
+    expect(body.session_id).toBe(UUID_A);
+    expect(body.cc_pid).toBe(1234);
+    expect(body.source).toBe('startup');
+    expect(body.model).toBe('claude-opus-4-7');
+    expect(body.captured_at).toBeDefined();
+  });
+
+  it('is atomic — interruption leaves either old or new, never partial', () => {
+    const markerPath = writeCanonicalMarker(UUID_A, { cc_pid: 1 }, { repoRoot: dir }).path;
+    // Overwrite should also be atomic.
+    writeCanonicalMarker(UUID_A, { cc_pid: 2 }, { repoRoot: dir });
+    const body = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    expect(body.cc_pid).toBe(2);
+  });
+});
+
+// ── getIdentityDir ───────────────────────────────────────────────────────────
+
+describe('getIdentityDir', () => {
+  it('respects explicit repoRoot override', () => {
+    expect(getIdentityDir('/tmp/foo')).toMatch(/[/\\]\.claude[/\\]session-identity$/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 of the RelationshipAware orchestrator. Introduces `lib/session-identity-sot.js` as the canonical reconciliation layer for the three identity sources the claim-validity-gate previously inspected independently (and that could silently diverge):

1. `.claude/session-identity/<sid>.json` — canonical marker (SOT)
2. `process.env.CLAUDE_SESSION_ID` — derived env var
3. `.claude/session-identity/current` — derived pointer

Gated behind `SESSION_IDENTITY_SOT_ENABLED=false` during burn-in. Legacy behavior is unchanged when the flag is off.

## Scope (all 6 FRs / 3 TRs from the PRD)
- **FR-1** `scripts/sd-start.js` calls `reconcileAtBoot()` between session materialization and claim validation.
- **FR-2 / FR-3** `lib/claim-validity-gate.js` now runs `validateSourcesAgree()` when the flag is on: all-present-agree or single-source-present → PASS; two-or-more-present-and-disagree → FAIL with `no_deterministic_identity` and a banner that names each disagreeing source.
- **FR-4** `scripts/hooks/capture-session-id.cjs` writes the canonical marker BEFORE the env var export (atomic); legacy order preserved when flag is off.
- **FR-5** `SESSION_IDENTITY_SOT_ENABLED` documented in `.env.example` with promotion criteria.
- **FR-6** `.claude/session-identity/README.md` documents the schema, ordering invariant, atomic-write contract, lock file, and feature flag.
- **TR-1** All filesystem writes use tmp + fsync + rename; tmp is cleaned up on any error.
- **TR-2** `.claude/session-identity/.lock` serializes concurrent reconciliations with a 30s stale-lock breaker.
- **TR-3** `tests/unit/session-identity-sot.test.js` — 41 tests covering five divergence scenarios plus TS-1..TS-5 (including 100 induced `fs.renameSync` failures to prove AC-3).

## Test plan
- [x] `npx vitest run tests/unit/session-identity-sot.test.js` → 41 passed
- [ ] Merged PR leaves the feature flag OFF in `.env.example`; no existing sessions are affected
- [ ] Flip `SESSION_IDENTITY_SOT_ENABLED=true` in a single-session smoke test and confirm the three sources agree after sd-start
- [ ] Induce a disagreement (write a wrong session id into `/current` manually) and confirm the gate fails closed with the new banner

## Handoff history
- LEAD-TO-PLAN: PASS 94% (17 gates)
- PLAN-TO-EXEC: PASS 99% (10 gates)
- EXEC-TO-PLAN: PASS 88% (8 gates)
- PLAN-TO-LEAD: PASS 96% (6 gates)
- LEAD-FINAL-APPROVAL: pending merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)