### PR TITLE
fix(SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001): FR-1 matcher scope + FR-4 heartbeat_at

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,6 @@
         ]
       },
       {
-        "matcher": "startup",
         "hooks": [
           {
             "type": "command",

--- a/docs/reference/source-side-telemetry.md
+++ b/docs/reference/source-side-telemetry.md
@@ -29,7 +29,8 @@ All signals live in `public.claude_sessions`. Every reader treats **NULL as "inf
 | `last_activity_kind` | TEXT (CHECK) | Pre/PostToolUse hooks | `executing`, `waiting_tool`, `waiting_agent`, `thinking`, `idle`, `exiting`. |
 | `commits_since_claim` | INT | PostToolUse hook (throttled 30s) | Git commits on the SD branch since `claimed_at`. |
 | `files_modified_since_claim` | INT | PostToolUse hook (throttled 30s) | Files touched since `claimed_at`. |
-| `process_alive_at` | TIMESTAMPTZ | `scripts/session-tick.cjs` | Authoritative short-window liveness. Refreshed every 30s. |
+| `process_alive_at` | TIMESTAMPTZ | `scripts/session-tick.cjs` | Source-side fleet-liveness signal. Refreshed every 30s. Consumed by sweep dashboards. |
+| `heartbeat_at` | TIMESTAMPTZ | `scripts/session-tick.cjs` + claim-guard | Claim-TTL authority. `lib/claim-guard.mjs` flags the claim as stale at 300s and releasable at 900s. Refreshed by the tick every 30s alongside `process_alive_at` (since SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4). Before FR-4 the tick updated only `process_alive_at`, leaving long Edit/Write/Read sessions vulnerable to stale-claim cleanup. |
 | `expected_silence_until` | TIMESTAMPTZ | PreToolUse hook | Worker-declared silent window. **Hard-capped at 30 minutes** in both hook and sweep. |
 
 ## Writers
@@ -70,7 +71,7 @@ spawn(process.execPath, [tickScript], {
 
 The tick:
 1. Writes marker at `.claude/pids/tick-<session_id>.json` so sweep can find orphans.
-2. Every **30 seconds**: `UPDATE claude_sessions SET process_alive_at = NOW()` via raw `fetch` (no SDK — keeps cold-start small).
+2. Every **30 seconds**: `UPDATE claude_sessions SET process_alive_at = NOW(), heartbeat_at = NOW()` via raw `fetch` (no SDK — keeps cold-start small). Both columns are written from a single `now` timestamp per SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4 so claim-TTL (`heartbeat_at`) and fleet-liveness (`process_alive_at`) stay in lockstep.
 3. Every **5 seconds**: `process.kill(CC_PARENT_PID, 0)` — on `ESRCH` it deletes its marker and `process.exit(0)` within seconds of the parent dying.
 
 ## Readers

--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -98,6 +98,11 @@ async function tickOnce() {
   const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
 
   try {
+    // SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4: update BOTH columns.
+    // claim-guard.mjs keys claim TTL on heartbeat_at (300s stale threshold).
+    // Updating only process_alive_at leaves the claim vulnerable to stale-claim
+    // cleanup during long Edit/Write/Read bursts that don't invoke any CLI script.
+    const now = new Date().toISOString();
     await fetch(url, {
       method: 'PATCH',
       headers: {
@@ -107,7 +112,8 @@ async function tickOnce() {
         Prefer: 'return=minimal',
       },
       body: JSON.stringify({
-        process_alive_at: new Date().toISOString(),
+        process_alive_at: now,
+        heartbeat_at: now,
       }),
       signal: controller.signal,
     });

--- a/tests/capture-session-id-hook.test.js
+++ b/tests/capture-session-id-hook.test.js
@@ -1,11 +1,13 @@
 /**
  * Regression tests for capture-session-id.cjs hook
  * SD-LEO-INFRA-SESSION-PID-MARKER-001
+ * SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 (FR-1 matcher scope)
  *
  * Covers:
  *   TS-5: 3 concurrent invocations produce 3 pid-*.json markers
  *   TR-2: settings.json registered timeout ≥ internal PowerShell budget + margin
  *   FR-3: Discovery log line emitted on every invocation
+ *   FR-1: hook fires on all SessionStart sub-events (no matcher:"startup" gate)
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -88,6 +90,29 @@ describe('capture-session-id.cjs — timing budget invariant', () => {
     const outer = extractOuterSetTimeout(src);
     const registeredMs = getRegisteredHookTimeoutSeconds() * 1000;
     expect(outer).toBeLessThan(registeredMs);
+  });
+});
+
+describe('capture-session-id.cjs — SessionStart matcher scope (FR-1)', () => {
+  it('hook is NOT gated behind matcher:"startup"', () => {
+    // Regression: when the hook was registered with matcher:"startup", it fired only
+    // for fresh sessions — resume/compact/reconnect sub-events produced no marker,
+    // no env var export, and no tick daemon. This stranded ~67% of sessions with
+    // stale heartbeats. The hook must fire for all SessionStart sub-events.
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    const sessionStart = settings?.hooks?.SessionStart || [];
+    const hostingBlocks = sessionStart.filter(entry =>
+      (entry.hooks || []).some(h =>
+        typeof h.command === 'string' && h.command.includes('capture-session-id.cjs')
+      )
+    );
+    expect(hostingBlocks.length).toBeGreaterThanOrEqual(1);
+    for (const block of hostingBlocks) {
+      expect(
+        block.matcher,
+        `capture-session-id.cjs must not be behind matcher:"${block.matcher}" — that skips resume/compact/reconnect events`
+      ).toBeUndefined();
+    }
   });
 });
 

--- a/tests/unit/sd-key-generator-coverage.test.mjs
+++ b/tests/unit/sd-key-generator-coverage.test.mjs
@@ -4,6 +4,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { unionRangeCoverage } from '../../scripts/modules/sd-key-generator.js';
 
 test('unionRangeCoverage: two non-overlapping ranges covering 100%', () => {
@@ -80,4 +83,111 @@ test('unionRangeCoverage: real scenario — 2 partial reads on CLAUDE_CORE.md (1
   );
   assert.equal(r.covered, 1419);
   assert.equal(r.uncovered.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FR-5: end-to-end gate behavior via validateCoreFileRead / validateLeadFileRead
+// Mocks a session state directory via CLAUDE_PROJECT_DIR so the gate reads a
+// synthetic state file and synthetic CLAUDE_CORE.md / CLAUDE_LEAD.md.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeSyntheticProjectDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sd-key-gate-'));
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  // 1000-line synthetic protocol files so coverage math is easy to reason about.
+  const body = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`).join('\n');
+  fs.writeFileSync(path.join(dir, 'CLAUDE_CORE.md'), body);
+  fs.writeFileSync(path.join(dir, 'CLAUDE_LEAD.md'), body);
+  return dir;
+}
+
+function writeState(dir, state) {
+  fs.writeFileSync(
+    path.join(dir, '.claude', 'unified-session-state.json'),
+    JSON.stringify(state, null, 2)
+  );
+}
+
+async function importFreshModule() {
+  // Force a re-import so the module picks up the new CLAUDE_PROJECT_DIR.
+  // Node's ESM loader caches by URL — adding a cache-busting query string
+  // forces re-evaluation.
+  const bust = `?t=${Date.now()}-${Math.random()}`;
+  return await import(`../../scripts/modules/sd-key-generator.js${bust}`);
+}
+
+test('FR-5 end-to-end: two partial reads covering 100% → gate PASSES', async () => {
+  const dir = makeSyntheticProjectDir();
+  const prev = process.env.CLAUDE_PROJECT_DIR;
+  try {
+    process.env.CLAUDE_PROJECT_DIR = dir;
+    // Two partial reads: (offset=1, limit=500) + (offset=501, limit=500) = 100%.
+    // lastReadWasPartial must be true so the gate uses the coverage path.
+    writeState(dir, {
+      protocolFileReadStatus: {
+        'CLAUDE_CORE.md': {
+          lastReadWasPartial: true,
+          lastPartialRead: { offset: 501, limit: 500, readAt: new Date().toISOString() },
+        },
+        'CLAUDE_LEAD.md': {
+          lastReadWasPartial: true,
+          lastPartialRead: { offset: 501, limit: 500, readAt: new Date().toISOString() },
+        },
+      },
+      protocolFileReadRanges: {
+        'CLAUDE_CORE.md': {
+          ranges: [{ offset: 1, limit: 500 }, { offset: 501, limit: 500 }],
+        },
+        'CLAUDE_LEAD.md': {
+          ranges: [{ offset: 1, limit: 500 }, { offset: 501, limit: 500 }],
+        },
+      },
+      protocolFilesRead: { 'CLAUDE_CORE.md': true, 'CLAUDE_LEAD.md': true },
+    });
+    const mod = await importFreshModule();
+    const core = mod.validateCoreFileRead();
+    const lead = mod.validateLeadFileRead();
+    assert.equal(core.valid, true, `core gate should pass but got: ${core.error}`);
+    assert.equal(lead.valid, true, `lead gate should pass but got: ${lead.error}`);
+    assert.equal(core.error, null);
+    assert.equal(lead.error, null);
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = prev;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('FR-5 end-to-end: 40% coverage → gate REJECTS with uncovered range', async () => {
+  const dir = makeSyntheticProjectDir();
+  const prev = process.env.CLAUDE_PROJECT_DIR;
+  try {
+    process.env.CLAUDE_PROJECT_DIR = dir;
+    // Single partial read covering only first 400 of 1000 lines = 40%.
+    writeState(dir, {
+      protocolFileReadStatus: {
+        'CLAUDE_CORE.md': {
+          lastReadWasPartial: true,
+          lastPartialRead: { offset: 1, limit: 400, readAt: new Date().toISOString() },
+        },
+      },
+      protocolFileReadRanges: {
+        'CLAUDE_CORE.md': {
+          ranges: [{ offset: 1, limit: 400 }],
+        },
+      },
+      protocolFilesRead: { 'CLAUDE_CORE.md': true },
+    });
+    const mod = await importFreshModule();
+    const core = mod.validateCoreFileRead();
+    assert.equal(core.valid, false, 'core gate should reject 40% coverage');
+    assert.match(core.error, /40%.*95%|coverage.*below/i, `expected coverage error, got: ${core.error}`);
+    // Uncovered range 401-1000 must be mentioned in the error or remediation.
+    const combined = `${core.error}\n${core.remediation || ''}`;
+    assert.match(combined, /401/, 'uncovered range should name the missing offset');
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = prev;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/session-tick-heartbeat.test.mjs
+++ b/tests/unit/session-tick-heartbeat.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * Regression tests for scripts/session-tick.cjs
+ * SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4
+ *
+ * Asserts the tick updates both heartbeat_at and process_alive_at.
+ * claim-guard.mjs keys claim TTL on heartbeat_at (300s stale threshold).
+ * If the tick only patches process_alive_at, long Edit/Write/Read bursts
+ * that don't invoke any CLI script will lose the claim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '../..');
+const tickPath = resolve(repoRoot, 'scripts/session-tick.cjs');
+const claimGuardPath = resolve(repoRoot, 'lib/claim-guard.mjs');
+
+describe('session-tick.cjs — heartbeat update (FR-4)', () => {
+  const src = readFileSync(tickPath, 'utf8');
+
+  it('tickOnce() PATCH body includes heartbeat_at', () => {
+    // The PATCH body was previously { process_alive_at: ... } which left
+    // heartbeat_at to decay. claim-guard's stale threshold is 300s on
+    // heartbeat_at, so a 60-min Edit/Write session would lose its claim.
+    expect(src).toMatch(/heartbeat_at:\s*now\b/);
+  });
+
+  it('tickOnce() PATCH body still includes process_alive_at', () => {
+    // process_alive_at is consumed by source-side fleet liveness dashboards.
+    // Keep it — FR-4 adds heartbeat_at, doesn't replace process_alive_at.
+    expect(src).toMatch(/process_alive_at:\s*now\b/);
+  });
+
+  it('both timestamps come from a single "now" so they match exactly', () => {
+    // Minimize drift across consumers inspecting both columns.
+    const m = src.match(/const\s+now\s*=\s*new\s+Date\(\)\.toISOString\(\)/);
+    expect(m, 'tickOnce should compute `const now = new Date().toISOString()` once').not.toBeNull();
+  });
+});
+
+describe('session-tick.cjs — FR-4 alignment with claim-guard', () => {
+  it('claim-guard still keys TTL on heartbeat_at (sanity check)', () => {
+    // If someone changes claim-guard to use a different column, this test
+    // will fire a reminder to re-check the tick's PATCH body.
+    const guardSrc = readFileSync(claimGuardPath, 'utf8');
+    expect(guardSrc).toMatch(/heartbeat_at/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two remaining gaps in SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 that PR #3241 did not cover:

- **FR-1** (`ec21cfbb9e`) — Removes `matcher: "startup"` from the `capture-session-id.cjs` SessionStart hook registration. The hook was only firing on fresh startup events; resume/compact/reconnect sub-events silently skipped it, so ~67% of sessions got no session-identity marker, no `CLAUDE_SESSION_ID` env export, and no spawned `session-tick.cjs` daemon. Repro'd live in this session (session `1f88aef5...`: resume variant, tick never spawned, sd-start saw `status='stale'`, `process_alive_at=null`).
- **FR-4** (`b7763e1551`) — `session-tick.cjs` now PATCHes both `heartbeat_at` AND `process_alive_at` in each tick (single `now` timestamp, same request). `lib/claim-guard.mjs:207` keys claim-TTL on `heartbeat_at` (300s stale threshold), so updating only `process_alive_at` left long Edit/Write/Read sessions vulnerable to stale-claim cleanup.
- **FR-5** (`a233b4f92a`) — End-to-end gate tests via synthetic `CLAUDE_PROJECT_DIR`: two partial reads covering 100% → `validateCoreFileRead` PASSes; 40% coverage → REJECTS naming the uncovered range.
- **Doc drift fix** (`e5f68de527`) — `docs/reference/source-side-telemetry.md` now covers both liveness columns in the signals table and the tick-writes-both behavior.

## DOCMON

Sub-agent execution stored in `sub_agent_execution_results` row `e2818e06-1319-480a-b17f-a77e9f1bb7de` — verdict **PASS** (85 confidence, >80% infrastructure threshold). 0 critical issues, 4 warnings (LOW/MEDIUM) filed as follow-up doc-debt candidates.

## Prior shipped work on this SD

- **FR-2** — default-on telemetry for session-tick spawn failures (merged as PR #3241 via `b702fbaa4f`)
- **FR-3** — cumulative-coverage gate in `sd-key-generator.js` (merged as PR #3241 via `bedad5fa0b`)
- **FR-6** — cross-platform verification: all changes in this PR use `node:path`, `node:fs`, `process.platform`-agnostic patterns

## Test plan

- [ ] CI runs `tests/capture-session-id-hook.test.js` — new FR-1 assertion that no hosting block has `matcher` set for the hook.
- [ ] CI runs `tests/unit/session-tick-heartbeat.test.mjs` — asserts tick PATCH body includes both `heartbeat_at` and `process_alive_at` from a single `now`, plus sanity check that `claim-guard.mjs` still keys on `heartbeat_at`.
- [ ] CI runs `tests/unit/sd-key-generator-coverage.test.mjs` — existing unit tests + two new end-to-end gate tests for PASS/REJECT paths.
- [ ] After merge, any new SessionStart sub-event (resume/compact/reconnect) produces a `.claude/pids/tick-<sid>.json` marker within 5 seconds.
- [ ] After merge, a 60-minute Edit/Write/Read session ends with `claude_sessions.heartbeat_at` fresh (< 60s old).

🤖 Generated with [Claude Code](https://claude.com/claude-code)