### PR TITLE
test(SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001): fix FR-5 fixtures + add smoke-test npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "protocol:lint:promote": "node scripts/protocol-lint/cli.mjs promote",
     "protocol:lint:review": "node scripts/protocol-lint/cli.mjs review",
     "test:smoke": "vitest run tests/smoke.test.js",
+    "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs",
+    "test:sd-key-generator-gate": "node --test tests/unit/sd-key-generator-coverage.test.mjs",
     "test:unit": "vitest run tests/unit/",
     "test:integration": "vitest run tests/integration/",
     "test:pipeline": "vitest run tests/integration/pipeline-s0-s17.test.js --testTimeout 1200000",

--- a/tests/unit/sd-key-generator-coverage.test.mjs
+++ b/tests/unit/sd-key-generator-coverage.test.mjs
@@ -142,7 +142,7 @@ test('FR-5 end-to-end: two partial reads covering 100% → gate PASSES', async (
           ranges: [{ offset: 1, limit: 500 }, { offset: 501, limit: 500 }],
         },
       },
-      protocolFilesRead: { 'CLAUDE_CORE.md': true, 'CLAUDE_LEAD.md': true },
+      protocolFilesRead: ['CLAUDE_CORE.md', 'CLAUDE_LEAD.md'],
     });
     const mod = await importFreshModule();
     const core = mod.validateCoreFileRead();
@@ -176,7 +176,7 @@ test('FR-5 end-to-end: 40% coverage → gate REJECTS with uncovered range', asyn
           ranges: [{ offset: 1, limit: 400 }],
         },
       },
-      protocolFilesRead: { 'CLAUDE_CORE.md': true },
+      protocolFilesRead: ['CLAUDE_CORE.md'],
     });
     const mod = await importFreshModule();
     const core = mod.validateCoreFileRead();

--- a/tests/unit/session-tick-heartbeat.test.mjs
+++ b/tests/unit/session-tick-heartbeat.test.mjs
@@ -8,7 +8,8 @@
  * that don't invoke any CLI script will lose the claim.
  */
 
-import { describe, it, expect } from 'vitest';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,34 +20,33 @@ const repoRoot = resolve(__dirname, '../..');
 const tickPath = resolve(repoRoot, 'scripts/session-tick.cjs');
 const claimGuardPath = resolve(repoRoot, 'lib/claim-guard.mjs');
 
-describe('session-tick.cjs — heartbeat update (FR-4)', () => {
-  const src = readFileSync(tickPath, 'utf8');
+const tickSrc = readFileSync(tickPath, 'utf8');
+const guardSrc = readFileSync(claimGuardPath, 'utf8');
 
-  it('tickOnce() PATCH body includes heartbeat_at', () => {
-    // The PATCH body was previously { process_alive_at: ... } which left
-    // heartbeat_at to decay. claim-guard's stale threshold is 300s on
-    // heartbeat_at, so a 60-min Edit/Write session would lose its claim.
-    expect(src).toMatch(/heartbeat_at:\s*now\b/);
-  });
-
-  it('tickOnce() PATCH body still includes process_alive_at', () => {
-    // process_alive_at is consumed by source-side fleet liveness dashboards.
-    // Keep it — FR-4 adds heartbeat_at, doesn't replace process_alive_at.
-    expect(src).toMatch(/process_alive_at:\s*now\b/);
-  });
-
-  it('both timestamps come from a single "now" so they match exactly', () => {
-    // Minimize drift across consumers inspecting both columns.
-    const m = src.match(/const\s+now\s*=\s*new\s+Date\(\)\.toISOString\(\)/);
-    expect(m, 'tickOnce should compute `const now = new Date().toISOString()` once').not.toBeNull();
-  });
+test('FR-4: tickOnce() PATCH body includes heartbeat_at', () => {
+  // The PATCH body was previously { process_alive_at: ... } which left
+  // heartbeat_at to decay. claim-guard's stale threshold is 300s on
+  // heartbeat_at, so a 60-min Edit/Write session would lose its claim.
+  assert.match(tickSrc, /heartbeat_at:\s*now\b/);
 });
 
-describe('session-tick.cjs — FR-4 alignment with claim-guard', () => {
-  it('claim-guard still keys TTL on heartbeat_at (sanity check)', () => {
-    // If someone changes claim-guard to use a different column, this test
-    // will fire a reminder to re-check the tick's PATCH body.
-    const guardSrc = readFileSync(claimGuardPath, 'utf8');
-    expect(guardSrc).toMatch(/heartbeat_at/);
-  });
+test('FR-4: tickOnce() PATCH body still includes process_alive_at', () => {
+  // process_alive_at is consumed by source-side fleet liveness dashboards.
+  // Keep it — FR-4 adds heartbeat_at, doesn't replace process_alive_at.
+  assert.match(tickSrc, /process_alive_at:\s*now\b/);
+});
+
+test('FR-4: both timestamps come from a single "now" so they match exactly', () => {
+  // Minimize drift across consumers inspecting both columns.
+  assert.match(
+    tickSrc,
+    /const\s+now\s*=\s*new\s+Date\(\)\.toISOString\(\)/,
+    'tickOnce should compute `const now = new Date().toISOString()` once'
+  );
+});
+
+test('FR-4: claim-guard still keys TTL on heartbeat_at (alignment sanity check)', () => {
+  // If someone changes claim-guard to use a different column, this test
+  // will fire a reminder to re-check the tick's PATCH body.
+  assert.match(guardSrc, /heartbeat_at/);
 });


### PR DESCRIPTION
## Summary

Follow-up fixes discovered when running tests locally after PR #3257 merged:

- **FR-5 fixtures** — `protocolFilesRead` was OBJECT in test fixtures but `isCoreFileRead()` calls `.includes()` (expects ARRAY). Changed to array form.
- **Test-runner mismatch** — session-tick-heartbeat.test.mjs used `vitest` imports but sibling `sd-key-generator-coverage.test.mjs` uses `node:test`. Mixing runners in the same dir broke `node --test`. Converted to `node:test`.
- **SMOKE_TEST_GATE npm scripts** — LEAD-FINAL-APPROVAL gate looks for `npm run test:session-tick` and `npm run test:sd-key-generator-gate` by convention; added both.

## Test plan

All 26 assertions (16 node:test + 10 vitest) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)