### PR TITLE
fix(QF-20260423): four fixes to /handoff-out and /handoff-in flow

### DIFF
--- a/.claude/commands/handoff-in.md
+++ b/.claude/commands/handoff-in.md
@@ -59,14 +59,29 @@ The script already printed the briefing. Summarize the key points for the user:
 - Git state (branch, recent commits)
 - Any pending actions
 
-### Step 4: Suggest Next Action
+### Step 4: Re-acquire the DB Claim (CRITICAL)
+
+If `HANDOFF_IMPORT_RESULT.activeSD` is non-null, the DB `claiming_session_id` is still the **source account's** session. You must re-acquire the claim on this account before any phase work, or the claim gate will reject handoffs with `no_deterministic_identity`.
+
+The script emits a `HANDOFF_NEXT_CMD=` line with the exact command. Run it:
+
+```bash
+node scripts/sd-start.js <sd-key>
+```
+
+`sd-start.js` will claim the SD for this account's session and set up the worktree/phase context. Verify `claiming_session_id` in the output matches the current session before continuing.
+
+**If no active SD** (`activeSD` is null): skip to Step 5.
+
+### Step 5: Suggest Next Action
 
 Based on the briefing:
-- **If active SD exists**: Suggest running `/leo continue` or `npm run sd:next`
+- **If active SD exists AND re-acquired**: Suggest running `/leo continue`
 - **If no active SD**: Suggest running `npm run sd:next` to see the queue
 - **If handoff is stale (>24h)**: Warn that the context may be outdated and suggest checking `npm run sd:next` fresh
+- **If `stateBackupDir` is set**: Mention that the destination's previous state files were backed up to that path (rollback is `cp <backup>/*.json .claude/`)
 
-### Step 5: Summary
+### Step 6: Summary
 
 Display a clean summary:
 

--- a/scripts/handoff-export.cjs
+++ b/scripts/handoff-export.cjs
@@ -84,12 +84,14 @@ async function getActiveSD() {
       process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     );
 
-    // Check for SD marked as working on
+    // Check for SD marked as working on (exclude completed/cancelled —
+    // is_working_on can be stale after an SD finishes)
     const { data: workingOn } = await supabase
       .from('strategic_directives_v2')
       .select('id, sd_key, title, status, priority, current_phase, progress, description')
       .eq('is_working_on', true)
-      .lt('progress', 100);
+      .lt('progress', 100)
+      .not('status', 'in', '("completed","cancelled","deferred","archived")');
 
     if (workingOn && workingOn.length > 0) {
       return workingOn[0];

--- a/scripts/handoff-import.cjs
+++ b/scripts/handoff-import.cjs
@@ -51,17 +51,28 @@ function formatAge(ms) {
 function restoreStateFiles() {
   const stateDir = path.join(HANDOFF_DIR, 'state');
   const restored = [];
+  const backedUp = [];
 
-  if (!fs.existsSync(stateDir)) return restored;
+  if (!fs.existsSync(stateDir)) return { restored, backedUp, backupDir: null };
+
+  // Backup any existing destination state files before overwrite so the
+  // destination account can roll back if the handoff contained wrong state.
+  const backupDir = path.join(CLAUDE_DIR, `handoff-backup-${Date.now()}`);
 
   const files = fs.readdirSync(stateDir).filter(f => f.endsWith('.json'));
   for (const file of files) {
     const src = path.join(stateDir, file);
     const dest = path.join(CLAUDE_DIR, file);
+
+    if (fs.existsSync(dest)) {
+      if (!fs.existsSync(backupDir)) fs.mkdirSync(backupDir, { recursive: true });
+      fs.copyFileSync(dest, path.join(backupDir, file));
+      backedUp.push(file);
+    }
     fs.copyFileSync(src, dest);
     restored.push(file);
   }
-  return restored;
+  return { restored, backedUp, backupDir: backedUp.length > 0 ? backupDir : null };
 }
 
 function analyzeMemoryFiles() {
@@ -159,11 +170,15 @@ function main() {
   }
   console.log('');
 
-  // 3. Restore state files
+  // 3. Restore state files (backing up any existing destination copies first)
   console.log('  Restoring state files...');
-  const restoredState = restoreStateFiles();
+  const stateResult = restoreStateFiles();
+  const restoredState = stateResult.restored;
   for (const f of restoredState) {
     console.log(`    Restored: ${f}`);
+  }
+  if (stateResult.backedUp.length > 0) {
+    console.log(`    Backed up ${stateResult.backedUp.length} existing file(s) to: ${path.relative(PROJECT_ROOT, stateResult.backupDir)}`);
   }
   if (restoredState.length === 0) {
     console.log('    No state files to restore');
@@ -177,7 +192,8 @@ function main() {
   // Copy non-conflicting files
   copyNonConflictingMemory(analysis);
 
-  // Report
+  // Report (summarize identicals — common case for same-machine account switches
+  // where both accounts share ~/.claude/projects/<path>/memory/)
   console.log('');
   console.log('  Memory Merge Results:');
   for (const f of analysis.copy) {
@@ -186,8 +202,8 @@ function main() {
   for (const f of analysis.keep) {
     console.log(`    ${f}: KEPT (only at destination, not in handoff)`);
   }
-  for (const f of analysis.identical) {
-    console.log(`    ${f}: IDENTICAL (no changes needed)`);
+  if (analysis.identical.length > 0) {
+    console.log(`    ${analysis.identical.length} file(s): IDENTICAL (no changes needed)`);
   }
   for (const f of analysis.merge) {
     console.log(`    ${f}: NEEDS MERGE (different in handoff vs destination)`);
@@ -209,12 +225,22 @@ function main() {
   }
   console.log('');
 
-  // 6. Output structured data for Claude to use
+  // 6. Output structured data for Claude to use. If an active SD exists the
+  // destination account does NOT yet own the DB claim (claiming_session_id is
+  // still the source account's session). Emit an explicit re-acquire command
+  // so /handoff-in can run it before suggesting /leo continue.
+  const reacquireCmd = metadata.activeSD
+    ? `node scripts/sd-start.js ${metadata.activeSD.sdKey}`
+    : null;
+
   const output = {
     success: true,
     age: ageStr,
     isStale,
     restoredState,
+    stateBackupDir: stateResult.backupDir
+      ? path.relative(PROJECT_ROOT, stateResult.backupDir)
+      : null,
     memoryAnalysis: {
       copied: analysis.copy,
       kept: analysis.keep,
@@ -224,10 +250,14 @@ function main() {
     activeSD: metadata.activeSD,
     sessionSettings: metadata.sessionSettings,
     handoffMemoryDir: path.join(HANDOFF_DIR, 'memory'),
-    memoryDestDir: MEMORY_DEST
+    memoryDestDir: MEMORY_DEST,
+    nextCmd: reacquireCmd
   };
 
   console.log('HANDOFF_IMPORT_RESULT=' + JSON.stringify(output));
+  if (reacquireCmd) {
+    console.log(`HANDOFF_NEXT_CMD=${reacquireCmd}`);
+  }
   console.log('');
 
   // 7. Suggest next action
@@ -237,7 +267,8 @@ function main() {
   }
 
   if (metadata.activeSD) {
-    console.log(`  Suggested: /leo continue (to resume ${metadata.activeSD.sdKey})`);
+    console.log(`  Suggested (re-acquire claim): ${reacquireCmd}`);
+    console.log(`  Then: /leo continue (to resume ${metadata.activeSD.sdKey})`);
   } else {
     console.log('  Suggested: npm run sd:next (to see the queue)');
   }


### PR DESCRIPTION
## Summary

Four independent bugs in the account-switch handoff flow, all found by running `/handoff-out` → `/handoff-in` end-to-end on the same machine:

- **Export surfaced COMPLETED SDs as active** — `is_working_on` can be stale after a merge; now also filters by `status NOT IN (completed/cancelled/deferred/archived)`
- **Import never re-acquired the DB claim** — destination would hit `no_deterministic_identity` on first handoff. Import now emits `HANDOFF_NEXT_CMD=node scripts/sd-start.js <sd-key>` and the skill runs it before `/leo continue`
- **State files clobbered destination with no rollback** — now backs up existing `.claude/*.json` to `.claude/handoff-backup-<ts>/` before overwriting
- **Memory-merge output logged 283 IDENTICAL lines** on same-machine switches (shared `~/.claude/projects/<path>/memory/` dir) — collapsed to a single count

## Files changed

- `scripts/handoff-export.cjs` — status filter in `getActiveSD()`
- `scripts/handoff-import.cjs` — backup before restore, emit `HANDOFF_NEXT_CMD=`, summarize identical files
- `.claude/commands/handoff-in.md` — new Step 4 "Re-acquire the DB Claim" before suggesting `/leo continue`

## Test plan

- [x] Run `/handoff-out` with a COMPLETED SD flagged `is_working_on=true` → active SD now resolves to a genuinely-active SD instead
- [x] Run `/handoff-in` → `HANDOFF_NEXT_CMD=node scripts/sd-start.js <sd-key>` emitted
- [x] Run `/handoff-in` with existing destination state → `.claude/handoff-backup-<ts>/` created with pre-overwrite copies; `stateBackupDir` set in `HANDOFF_IMPORT_RESULT`
- [x] Run `/handoff-in` with 283 identical memory files → single-line summary instead of 283 per-file lines

## Notes

Not covered by this QF (flagged for future work):

- `is_working_on=true` is a global flag, not per-session, so export can still surface *another session's* active SD after the cross-session session flagged it. Needs separate session-scoped ownership filter.
- Export unconditionally copies 283 memory files to `.claude/handoff/memory/` even when source and dest resolve to the same path on same-machine switches. Optimization opportunity — not a correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)