### PR TITLE
feat(SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D): 3-fix handoff pipeline bundle (validator unification + atomic transition + metrics dedup)

### DIFF
--- a/database/migrations/20260423_add_fn_atomic_lead_to_plan_transition.sql
+++ b/database/migrations/20260423_add_fn_atomic_lead_to_plan_transition.sql
@@ -1,0 +1,159 @@
+-- ============================================================================
+-- Migration: SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 2
+--   Create fn_atomic_lead_to_plan_transition — atomic SD phase/status
+--   promotion with advisory locking, idempotency via request_id, and
+--   pre/post state capture in sd_transition_audit.
+-- ============================================================================
+-- Parent orchestrator : SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001
+-- PRD                 : PRD-SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D
+-- Template            : fn_atomic_exec_to_plan_transition (deployed schema)
+-- Date                : 2026-04-23
+-- ============================================================================
+--
+-- Mirrors the deployed EXEC-TO-PLAN atomic-transition function exactly
+-- where possible. Differences vs EXEC-TO-PLAN version:
+--   - Only promotes the SD (status/current_phase); does not touch PRD or
+--     user stories (those promotions happen later in the workflow).
+--   - transition_type = 'LEAD_TO_PLAN'.
+--   - Target values: current_phase='PLAN_PRD', status='in_progress'.
+--
+-- Relies on existing `sd_transition_audit` table (deployed via
+-- fn_atomic_exec_to_plan_transition migration). Does NOT create the table.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_atomic_lead_to_plan_transition(
+  p_sd_id       TEXT,
+  p_session_id  TEXT,
+  p_request_id  TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_sd_uuid       UUID;
+  v_pre_state     JSONB;
+  v_post_state    JSONB;
+  v_audit_id      UUID;
+  v_request_id    TEXT;
+  v_sd_row        RECORD;
+  v_lock_acquired BOOLEAN;
+BEGIN
+  -- Generate request_id for idempotency if not provided.
+  v_request_id := COALESCE(
+    p_request_id,
+    p_sd_id || '-' || p_session_id || '-' || EXTRACT(EPOCH FROM NOW())::TEXT
+  );
+
+  -- Idempotency: prior success for this request_id returns immediately.
+  SELECT id INTO v_audit_id
+    FROM sd_transition_audit
+   WHERE request_id = v_request_id
+     AND status = 'completed';
+
+  IF v_audit_id IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'idempotent_hit', true,
+      'message', 'Transition already completed',
+      'audit_id', v_audit_id
+    );
+  END IF;
+
+  -- Resolve SD UUID from id (legacy text) or sd_key.
+  SELECT uuid_id INTO v_sd_uuid
+    FROM strategic_directives_v2
+   WHERE id = p_sd_id OR sd_key = p_sd_id
+   LIMIT 1;
+
+  IF v_sd_uuid IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'SD not found: ' || p_sd_id
+    );
+  END IF;
+
+  -- Advisory lock scoped per-SD (transaction-scoped, auto-released).
+  v_lock_acquired := pg_try_advisory_xact_lock(hashtext(p_sd_id));
+  IF NOT v_lock_acquired THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Concurrent transition in progress',
+      'code', 'CONCURRENT_LOCK'
+    );
+  END IF;
+
+  -- Capture pre-state with row-level lock.
+  SELECT id, status, current_phase, transition_version, progress
+    INTO v_sd_row
+    FROM strategic_directives_v2
+   WHERE uuid_id = v_sd_uuid
+   FOR UPDATE;
+
+  v_pre_state := jsonb_build_object(
+    'sd_id', p_sd_id,
+    'sd_status', v_sd_row.status,
+    'sd_phase', v_sd_row.current_phase,
+    'sd_version', v_sd_row.transition_version,
+    'sd_progress', v_sd_row.progress
+  );
+
+  -- Create audit record (in_progress).
+  INSERT INTO sd_transition_audit (
+    sd_id, transition_type, session_id, request_id, pre_state, status
+  )
+  VALUES (
+    v_sd_uuid, 'LEAD_TO_PLAN', p_session_id, v_request_id,
+    v_pre_state, 'in_progress'
+  )
+  RETURNING id INTO v_audit_id;
+
+  -- ============================== ATOMIC PROMOTION ============================
+  UPDATE strategic_directives_v2
+     SET current_phase     = 'PLAN_PRD',
+         status            = 'in_progress',
+         transition_version = COALESCE(transition_version, 1) + 1,
+         updated_at        = NOW()
+   WHERE uuid_id = v_sd_uuid;
+  -- ============================================================================
+
+  v_post_state := jsonb_build_object(
+    'sd_phase', 'PLAN_PRD',
+    'sd_status', 'in_progress'
+  );
+
+  UPDATE sd_transition_audit
+     SET status       = 'completed',
+         post_state   = v_post_state,
+         completed_at = NOW()
+   WHERE id = v_audit_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'audit_id', v_audit_id,
+    'pre_state', v_pre_state,
+    'post_state', v_post_state
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  IF v_audit_id IS NOT NULL THEN
+    UPDATE sd_transition_audit
+       SET status       = 'failed',
+           error_details = jsonb_build_object(
+             'code', SQLSTATE,
+             'message', SQLERRM,
+             'detail', COALESCE(v_pre_state, '{}'::JSONB)
+           ),
+           completed_at = NOW()
+     WHERE id = v_audit_id;
+  END IF;
+  RAISE;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.fn_atomic_lead_to_plan_transition IS
+  'Atomic LEAD → PLAN_PRD promotion of a Strategic Directive. '
+  'Mirrors fn_atomic_exec_to_plan_transition pattern: advisory-locked per '
+  'SD, idempotent via request_id, pre/post state captured in '
+  'sd_transition_audit, transactional rollback on exception. Added by '
+  'SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 2.';

--- a/scripts/modules/handoff/executors/lead-to-plan/atomic-transitions.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/atomic-transitions.js
@@ -1,0 +1,123 @@
+/**
+ * Atomic State Transitions for LEAD-TO-PLAN Handoff
+ *
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 2:
+ *   Replace the non-atomic `.update()` in state-transitions.js with a single
+ *   PG RPC call that handles advisory locking, idempotency, pre/post state
+ *   capture, and transactional rollback on failure.
+ *
+ *   Pattern mirrors the existing exec-to-plan atomic-transitions.js.
+ */
+
+/**
+ * Generate deterministic request ID for idempotency
+ *
+ * @param {string} sdId
+ * @param {string} sessionId
+ * @returns {string}
+ */
+export function generateRequestId(sdId, sessionId) {
+  const timestampBucket = Math.floor(Date.now() / 60000);
+  return `${sdId}-${sessionId || 'unknown'}-${timestampBucket}`;
+}
+
+/**
+ * Execute atomic LEAD-TO-PLAN state transition via PG RPC.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} sdId - SD UUID or sd_key
+ * @param {Object} [options]
+ * @param {string} [options.sessionId]
+ * @param {string} [options.requestId]
+ * @returns {Promise<{success: boolean, idempotent_hit?: boolean, audit_id?: string, pre_state?: object, post_state?: object, error?: string, code?: string}>}
+ */
+export async function executeAtomicLeadToPlanTransition(supabase, sdId, options = {}) {
+  const sessionId = options.sessionId || process.env.CLAUDE_SESSION_ID || 'unknown';
+  const requestId = options.requestId || generateRequestId(sdId, sessionId);
+
+  console.log('\n🔐 ATOMIC TRANSITION: LEAD → PLAN');
+  console.log('-'.repeat(50));
+  console.log(`   SD: ${sdId}`);
+  console.log(`   Request ID: ${requestId}`);
+
+  try {
+    const { data, error } = await supabase.rpc('fn_atomic_lead_to_plan_transition', {
+      p_sd_id: sdId,
+      p_session_id: sessionId,
+      p_request_id: requestId
+    });
+
+    if (error) {
+      console.error(`   ❌ RPC Error: ${error.message}`);
+      return { success: false, error: error.message, code: error.code };
+    }
+
+    if (!data?.success) {
+      console.error(`   ❌ Transition Failed: ${data?.error}`);
+      return { success: false, error: data?.error, code: data?.code };
+    }
+
+    if (data.idempotent_hit) {
+      console.log('   ⚡ Idempotent hit — transition already completed');
+      console.log(`   Audit ID: ${data.audit_id}`);
+    } else {
+      console.log('   ✅ Transition completed atomically');
+      console.log(`   Audit ID: ${data.audit_id}`);
+      if (data.pre_state) console.log(`   Pre-state:  ${JSON.stringify(data.pre_state)}`);
+      if (data.post_state) console.log(`   Post-state: ${JSON.stringify(data.post_state)}`);
+    }
+
+    return {
+      success: true,
+      idempotent_hit: !!data.idempotent_hit,
+      audit_id: data.audit_id,
+      pre_state: data.pre_state,
+      post_state: data.post_state
+    };
+
+  } catch (err) {
+    console.error(`   ❌ Exception: ${err.message}`);
+    return { success: false, error: err.message, code: 'EXCEPTION' };
+  }
+}
+
+/**
+ * Check whether the atomic RPC is available in the DB (graceful fallback
+ * detection).  Mirrors the availability check in exec-to-plan.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<boolean>}
+ */
+export async function isAtomicLeadToPlanTransitionAvailable(supabase) {
+  try {
+    const { error } = await supabase.rpc('fn_atomic_lead_to_plan_transition', {
+      p_sd_id: 'TEST-AVAILABILITY-CHECK-NOT-A-REAL-SD',
+      p_session_id: 'availability-check',
+      p_request_id: 'availability-check-' + Date.now()
+    });
+
+    if (error) {
+      const errorLower = (error.message || '').toLowerCase();
+      const code = error.code || '';
+      const notExistsPatterns = [
+        'does not exist',
+        'schema cache',
+        'could not find the function',
+        '42883' // PostgreSQL undefined-function code
+      ];
+      for (const p of notExistsPatterns) {
+        if (errorLower.includes(p) || code === p) return false;
+      }
+    }
+    // Function exists (either no error, or "SD not found" business error).
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default {
+  executeAtomicLeadToPlanTransition,
+  isAtomicLeadToPlanTransitionAvailable,
+  generateRequestId
+};

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
@@ -76,6 +76,14 @@ export { createPhaseCoverageGate } from './phase-coverage.js';
 // SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
 export { validateSdQuality, createSdQualityGate } from './sd-quality-gate.js';
 
+// SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1:
+// SD Metrics Sufficiency Gate — promotes the verifier's minimumMetrics
+// check into the gate chain so handoff.js precheck and execute agree.
+export {
+  validateSdMetricsSufficiency,
+  createSdMetricsSufficiencyGate
+} from './sd-metrics-sufficiency.js';
+
 // Translation Fidelity Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001)
 // LLM-powered comparison of architecture plan → SD to detect translation gaps
 export { createTranslationFidelityGate } from './translation-fidelity.js';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/sd-metrics-sufficiency.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/sd-metrics-sufficiency.js
@@ -1,0 +1,74 @@
+/**
+ * SD Metrics Sufficiency Gate for LEAD-TO-PLAN
+ *
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1:
+ *   Promotes the minimumMetrics + dedup check from the LEAD-TO-PLAN
+ *   VERIFIER into a named GATE so handoff.js precheck runs it too.
+ *
+ *   Previously the verifier ran only during execute, so precheck could
+ *   report PASS while execute returned FAIL on the same SD — observed
+ *   during ORCH-001-A on 2026-04-22 (precheck 94% → execute SD_INCOMPLETE).
+ *
+ *   Gate delegates to validateMetricsSufficiency() in sd-validation.js,
+ *   which is the canonical implementation (also called by the verifier).
+ *
+ * BLOCKING when metrics-sufficiency fails (issues non-empty).
+ */
+
+import { validateMetricsSufficiency, SD_REQUIREMENTS } from '../../../verifiers/lead-to-plan/sd-validation.js';
+
+/**
+ * Validate SD has sufficient unique success_metrics or success_criteria.
+ *
+ * @param {Object} sd - Strategic Directive
+ * @returns {Object} Gate result (pass, score, max_score, issues, warnings, details)
+ */
+export async function validateSdMetricsSufficiency(sd) {
+  const result = validateMetricsSufficiency(sd);
+
+  const score = result.pass
+    ? (result.warnings.length > 0 ? 90 : 100)
+    : 0;
+
+  return {
+    pass: result.pass,
+    score,
+    max_score: 100,
+    issues: result.issues,
+    warnings: result.warnings,
+    details: {
+      uniqueCount: result.uniqueCount,
+      originalCount: result.originalCount,
+      collapsedCount: result.collapsedCount,
+      minimumMetrics: SD_REQUIREMENTS.minimumMetrics
+    }
+  };
+}
+
+/**
+ * Create the SD Metrics Sufficiency gate.
+ */
+export function createSdMetricsSufficiencyGate() {
+  return {
+    name: 'GATE_SD_METRICS_SUFFICIENCY',
+    validator: async (ctx) => {
+      console.log('\n📏 GATE: SD Metrics Sufficiency (precheck/execute parity)');
+      console.log('-'.repeat(50));
+      const result = await validateSdMetricsSufficiency(ctx.sd);
+      const uc = result.details.uniqueCount;
+      const tot = result.details.originalCount;
+      const min = result.details.minimumMetrics;
+      if (result.pass) {
+        console.log(`   ✅ ${uc}/${min} unique metrics (${tot} total entries)`);
+        if (result.details.collapsedCount > 0) {
+          console.log(`   ℹ️  ${result.details.collapsedCount} duplicate(s) collapsed — check SD metadata if this was unintentional`);
+        }
+      } else {
+        console.log(`   ❌ ${uc}/${min} unique metrics (${tot} total entries)`);
+      }
+      return result;
+    },
+    required: true,
+    remediation: 'Add distinct success_metrics entries (each with metric, target, and measurement identity fields). The minimumMetrics threshold is ' + SD_REQUIREMENTS.minimumMetrics + '. Literal-duplicate entries are collapsed before the count.'
+  };
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -16,6 +16,8 @@ import {
   createBaselineDebtGate,
   createSmokeTestSpecificationGate,
   createPlaceholderContentGate,
+  // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1
+  createSdMetricsSufficiencyGate,
   createVisionScoreGate,
   createLeadEvaluationGate,
   createCrossRepoConsumerImpactGate,
@@ -109,6 +111,11 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
     // BLOCKING: validates field completeness, content depth, structural correctness
     gates.push(createSdQualityGate());
+
+    // SD Metrics Sufficiency Gate (SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1)
+    // BLOCKING: promotes the verifier's minimumMetrics check into the gate chain
+    // so handoff.js precheck and execute report the same verdict.
+    gates.push(createSdMetricsSufficiencyGate());
 
     // LEO v4.4.1: Proactive Branch Creation Gate (DISABLED)
     // See: ./gates/branch-preparation.js for code preserved for reference

--- a/scripts/modules/handoff/executors/lead-to-plan/state-transitions.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/state-transitions.js
@@ -56,6 +56,12 @@ export async function rollbackSdState(sdId, snapshot, supabase) {
 /**
  * STATE TRANSITION: Update SD current_phase on successful LEAD-TO-PLAN handoff
  *
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 2:
+ *   Prefer the atomic PG RPC (fn_atomic_lead_to_plan_transition) when
+ *   available. Fall back to the legacy non-atomic .update() if the RPC
+ *   is missing (e.g., pre-migration envs). This keeps the deploy order
+ *   tolerant: code can ship before or after the migration.
+ *
  * @param {string} sdId - SD ID
  * @param {Object} sd - Strategic Directive
  * @param {Object} supabase - Supabase client
@@ -64,6 +70,28 @@ export async function transitionSdToPlan(sdId, sd, supabase) {
   console.log('\n📊 STATE TRANSITION: SD Phase Update');
   console.log('-'.repeat(50));
 
+  // Try atomic path first.
+  try {
+    const { executeAtomicLeadToPlanTransition, isAtomicLeadToPlanTransitionAvailable } =
+      await import('./atomic-transitions.js');
+    const available = await isAtomicLeadToPlanTransitionAvailable(supabase);
+    if (available) {
+      const result = await executeAtomicLeadToPlanTransition(supabase, sdId);
+      if (result.success) {
+        const oldPhase = sd?.current_phase || 'LEAD';
+        console.log(`   ✅ SD phase transitioned (atomic RPC): ${oldPhase} → PLAN_PRD`);
+        console.log('   ✅ SD status transitioned: → in_progress');
+        return;
+      }
+      console.log(`   ⚠️  Atomic RPC failed: ${result.error} — falling back to legacy path`);
+    } else {
+      console.log('   ℹ️  Atomic RPC not available in this DB — using legacy path');
+    }
+  } catch (e) {
+    console.log(`   ⚠️  Atomic RPC import/availability error: ${e?.message || e} — falling back to legacy`);
+  }
+
+  // Legacy non-atomic fallback.
   try {
     // SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Query by id or sd_key (legacy_id removed 2026-01-24)
     const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
@@ -82,7 +110,7 @@ export async function transitionSdToPlan(sdId, sd, supabase) {
       console.log(`   ⚠️  Could not update SD phase: ${error.message}`);
     } else {
       const oldPhase = sd?.current_phase || 'LEAD';
-      console.log(`   ✅ SD phase transitioned: ${oldPhase} → PLAN_PRD`);
+      console.log(`   ✅ SD phase transitioned (legacy path): ${oldPhase} → PLAN_PRD`);
       console.log('   ✅ SD status transitioned: → in_progress');
     }
   } catch (error) {

--- a/scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js
+++ b/scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js
@@ -8,6 +8,130 @@
  */
 
 /**
+ * Deduplicate metrics array by identity fields before counting.
+ *
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 3:
+ *   literal-duplicate entries in success_metrics (common in auto-generated
+ *   SDs) inflate the minimumMetrics count.  Two entries with the same
+ *   identity subset (metric name + target + measurement) are considered
+ *   the same unique metric and collapsed.
+ *
+ * Non-object entries dedup by their full JSON form.
+ * Object entries dedup only by identity fields; irrelevant fields like
+ * `owner` do not participate in uniqueness.
+ *
+ * Gated by env var FLEET_METRICS_DEDUP — set to 'false' to disable.
+ *
+ * @param {Array} metrics - Input metrics array (possibly with duplicates)
+ * @returns {Array} - Array of unique metrics in first-seen order
+ */
+export function dedupMetrics(metrics) {
+  if (!Array.isArray(metrics)) return metrics;
+  if (process.env.FLEET_METRICS_DEDUP === 'false') return metrics;
+
+  const seen = new Set();
+  const unique = [];
+  for (const m of metrics) {
+    let key;
+    if (!m || typeof m !== 'object') {
+      key = JSON.stringify(m);
+    } else {
+      // Use only identity fields (metric name, target/goal, measurement).
+      // Accepts both success_metrics shape (metric/target/measurement) and
+      // success_criteria shape (criterion/measure/goal).
+      key = JSON.stringify({
+        metric: m.metric ?? m.criterion ?? null,
+        target: m.target ?? m.goal ?? null,
+        measurement: m.measurement ?? m.measure ?? null
+      });
+    }
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(m);
+    }
+  }
+  return unique;
+}
+
+/**
+ * Shared metrics-sufficiency check.
+ *
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1:
+ *   Canonical implementation of the minimumMetrics + measurability +
+ *   dedup (Fix 3) check.  Both the LEAD-TO-PLAN verifier AND the
+ *   GATE_SD_METRICS_SUFFICIENCY gate call this function so precheck
+ *   (gates only) and execute (gates + verifier) agree.
+ *
+ * @param {Object} sd - Strategic Directive
+ * @returns {{ pass: boolean, uniqueCount: number, originalCount: number,
+ *            collapsedCount: number, issues: string[], warnings: string[] }}
+ */
+export function validateMetricsSufficiency(sd) {
+  const hasSuccessMetrics = sd.success_metrics &&
+    (Array.isArray(sd.success_metrics) ? sd.success_metrics.length > 0 : sd.success_metrics);
+  const hasSuccessCriteria = sd.success_criteria &&
+    (typeof sd.success_criteria === 'string' ? sd.success_criteria.length > 0 :
+     Array.isArray(sd.success_criteria) ? sd.success_criteria.length > 0 : sd.success_criteria);
+  const metricsSource = hasSuccessMetrics ? sd.success_metrics :
+                        hasSuccessCriteria ? sd.success_criteria : null;
+
+  if (!metricsSource) {
+    return {
+      pass: false,
+      uniqueCount: 0, originalCount: 0, collapsedCount: 0,
+      issues: ['Missing success_metrics or success_criteria'],
+      warnings: []
+    };
+  }
+
+  let metrics = [];
+  try {
+    metrics = Array.isArray(metricsSource)
+      ? metricsSource
+      : (typeof metricsSource === 'string' ? JSON.parse(metricsSource) : []);
+  } catch (e) {
+    console.debug('[SDValidation] metrics parse suppressed:', e?.message || e);
+    metrics = [metricsSource];
+  }
+
+  // Fix 3: dedup before comparison
+  const uniqueMetrics = dedupMetrics(metrics);
+  const originalCount = Array.isArray(metrics) ? metrics.length : 0;
+  const uniqueCount = Array.isArray(uniqueMetrics) ? uniqueMetrics.length : 0;
+  const collapsedCount = originalCount - uniqueCount;
+  const warnings = [];
+
+  if (!Array.isArray(uniqueMetrics) || uniqueCount < SD_REQUIREMENTS.minimumMetrics) {
+    const dupNote = collapsedCount > 0
+      ? ` (${originalCount} entries collapsed to ${uniqueCount} unique after dedup — add distinct metrics rather than copies)`
+      : '';
+    return {
+      pass: false,
+      uniqueCount, originalCount, collapsedCount,
+      issues: [`Insufficient success_metrics/criteria: ${uniqueCount}/${SD_REQUIREMENTS.minimumMetrics}${dupNote}`],
+      warnings
+    };
+  }
+
+  // Measurable-target warning
+  if (uniqueMetrics.length > 0 && typeof uniqueMetrics[0] === 'object') {
+    const measurableCount = uniqueMetrics.filter(m => m.target || m.goal).length;
+    if (measurableCount < uniqueMetrics.length * 0.8) {
+      warnings.push('Some success metrics lack measurable targets');
+    }
+  }
+  if (collapsedCount > 0) {
+    warnings.push(`Dedup collapsed ${collapsedCount} duplicate metric(s) — SD still meets minimumMetrics with ${uniqueCount} unique.`);
+  }
+
+  return {
+    pass: true,
+    uniqueCount, originalCount, collapsedCount,
+    issues: [], warnings
+  };
+}
+
+/**
  * SD Quality Requirements (LEO Protocol v4.3.3)
  */
 export const SD_REQUIREMENTS = {
@@ -84,47 +208,17 @@ export function validateStrategicDirective(sd) {
   }
 
   // Validate success metrics OR success_criteria (20 points)
-  const hasSuccessMetrics = sd.success_metrics &&
-    (Array.isArray(sd.success_metrics) ? sd.success_metrics.length > 0 : sd.success_metrics);
-  const hasSuccessCriteria = sd.success_criteria &&
-    (typeof sd.success_criteria === 'string' ? sd.success_criteria.length > 0 :
-     Array.isArray(sd.success_criteria) ? sd.success_criteria.length > 0 : sd.success_criteria);
-  const metricsSource = hasSuccessMetrics ? sd.success_metrics :
-                        hasSuccessCriteria ? sd.success_criteria : null;
-  if (metricsSource) {
-    let metrics = [];
-    try {
-      metrics = Array.isArray(metricsSource)
-        ? metricsSource
-        : (typeof metricsSource === 'string' ? JSON.parse(metricsSource) : []);
-    } catch (e) {
-      // Intentionally suppressed: If parsing fails, treat as single item
-      console.debug('[SDValidation] metrics parse suppressed:', e?.message || e);
-      metrics = [metricsSource];
-    }
-
-    if (Array.isArray(metrics) && metrics.length >= SD_REQUIREMENTS.minimumMetrics) {
-      validation.score += 20;
-
-      // Check for measurable metrics (only if objects with target/goal)
-      if (metrics.length > 0 && typeof metrics[0] === 'object') {
-        let measurableCount = 0;
-        metrics.forEach(metric => {
-          if (metric.target || metric.goal) {
-            measurableCount++;
-          }
-        });
-
-        if (measurableCount < metrics.length * 0.8) {
-          validation.warnings.push('Some success metrics lack measurable targets');
-        }
-      }
-    } else {
-      validation.errors.push(`Insufficient success metrics/criteria: ${metrics?.length || 0}/${SD_REQUIREMENTS.minimumMetrics}`);
-      validation.valid = false;
-    }
+  // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1:
+  //   delegated to validateMetricsSufficiency() so the same logic runs in
+  //   both the verifier (here) and the GATE_SD_METRICS_SUFFICIENCY gate
+  //   (called during precheck).  This eliminates precheck/execute drift.
+  const metricsResult = validateMetricsSufficiency(sd);
+  if (metricsResult.pass) {
+    validation.score += 20;
+    validation.warnings.push(...metricsResult.warnings);
   } else {
-    validation.errors.push('Missing success_metrics or success_criteria');
+    validation.errors.push(...metricsResult.issues);
+    validation.warnings.push(...metricsResult.warnings);
     validation.valid = false;
   }
 

--- a/tests/unit/lead-to-plan-atomic-transition.test.js
+++ b/tests/unit/lead-to-plan-atomic-transition.test.js
@@ -1,0 +1,211 @@
+/**
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 2:
+ *   Tests for atomic-transitions.js and state-transitions.js fallback.
+ *
+ * Unit tests use a mocked supabase client.  Full DB integration against
+ * the deployed fn_atomic_lead_to_plan_transition is exercised by the
+ * handoff-chain smoke run, not here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  executeAtomicLeadToPlanTransition,
+  isAtomicLeadToPlanTransitionAvailable,
+  generateRequestId
+} from '../../scripts/modules/handoff/executors/lead-to-plan/atomic-transitions.js';
+
+function makeMockSupabase({ rpcResponse, rpcError = null } = {}) {
+  return {
+    _lastCall: null,
+    rpc(fn, params) {
+      this._lastCall = { fn, params };
+      return Promise.resolve(rpcError
+        ? { data: null, error: rpcError }
+        : { data: rpcResponse, error: null });
+    }
+  };
+}
+
+describe('generateRequestId', () => {
+  it('produces stable id within a minute-bucket', () => {
+    const a = generateRequestId('SD-X', 'sess-1');
+    const b = generateRequestId('SD-X', 'sess-1');
+    expect(a).toBe(b);
+  });
+
+  it('differs across sessions', () => {
+    const a = generateRequestId('SD-X', 'sess-1');
+    const b = generateRequestId('SD-X', 'sess-2');
+    expect(a).not.toBe(b);
+  });
+
+  it('defaults session to "unknown" when unset', () => {
+    expect(generateRequestId('SD-X')).toContain('-unknown-');
+  });
+});
+
+describe('executeAtomicLeadToPlanTransition', () => {
+  it('returns success on a normal RPC response', async () => {
+    const supa = makeMockSupabase({
+      rpcResponse: {
+        success: true,
+        idempotent_hit: false,
+        audit_id: 'aud-1',
+        pre_state: { sd_phase: 'LEAD', sd_status: 'draft' },
+        post_state: { sd_phase: 'PLAN_PRD', sd_status: 'in_progress' }
+      }
+    });
+    const r = await executeAtomicLeadToPlanTransition(supa, 'SD-T-001', {
+      sessionId: 'sess-a', requestId: 'req-a'
+    });
+    expect(r.success).toBe(true);
+    expect(r.audit_id).toBe('aud-1');
+    expect(r.idempotent_hit).toBe(false);
+    expect(supa._lastCall.fn).toBe('fn_atomic_lead_to_plan_transition');
+    expect(supa._lastCall.params).toEqual({
+      p_sd_id: 'SD-T-001',
+      p_session_id: 'sess-a',
+      p_request_id: 'req-a'
+    });
+  });
+
+  it('flags idempotent_hit when RPC reports one', async () => {
+    const supa = makeMockSupabase({
+      rpcResponse: { success: true, idempotent_hit: true, audit_id: 'aud-2' }
+    });
+    const r = await executeAtomicLeadToPlanTransition(supa, 'SD-T-002');
+    expect(r.success).toBe(true);
+    expect(r.idempotent_hit).toBe(true);
+  });
+
+  it('returns failure on RPC business error (success:false in data)', async () => {
+    const supa = makeMockSupabase({
+      rpcResponse: { success: false, error: 'SD not found: X', code: 'SD_NOT_FOUND' }
+    });
+    const r = await executeAtomicLeadToPlanTransition(supa, 'X');
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('SD not found');
+  });
+
+  it('returns failure on RPC-level error', async () => {
+    const supa = makeMockSupabase({
+      rpcError: { message: 'connection reset', code: 'ECONNRESET' }
+    });
+    const r = await executeAtomicLeadToPlanTransition(supa, 'SD-X');
+    expect(r.success).toBe(false);
+    expect(r.error).toBe('connection reset');
+    expect(r.code).toBe('ECONNRESET');
+  });
+
+  it('catches thrown exceptions from the client', async () => {
+    const supa = { rpc: () => { throw new Error('boom'); } };
+    const r = await executeAtomicLeadToPlanTransition(supa, 'SD-X');
+    expect(r.success).toBe(false);
+    expect(r.code).toBe('EXCEPTION');
+  });
+
+  it('fills session and request id defaults when not provided', async () => {
+    const supa = makeMockSupabase({ rpcResponse: { success: true } });
+    await executeAtomicLeadToPlanTransition(supa, 'SD-T-003');
+    expect(supa._lastCall.params.p_sd_id).toBe('SD-T-003');
+    expect(typeof supa._lastCall.params.p_session_id).toBe('string');
+    expect(typeof supa._lastCall.params.p_request_id).toBe('string');
+  });
+});
+
+describe('isAtomicLeadToPlanTransitionAvailable', () => {
+  it('returns false when RPC reports function does not exist (42883)', async () => {
+    const supa = makeMockSupabase({
+      rpcError: { message: 'function fn_... does not exist', code: '42883' }
+    });
+    expect(await isAtomicLeadToPlanTransitionAvailable(supa)).toBe(false);
+  });
+
+  it('returns false when error message mentions schema cache', async () => {
+    const supa = makeMockSupabase({
+      rpcError: { message: 'Could not find the function in schema cache', code: 'X' }
+    });
+    expect(await isAtomicLeadToPlanTransitionAvailable(supa)).toBe(false);
+  });
+
+  it('returns true when function exists but SD is fake (business error)', async () => {
+    const supa = makeMockSupabase({
+      rpcResponse: { success: false, error: 'SD not found: TEST-AVAILABILITY-CHECK-NOT-A-REAL-SD' }
+    });
+    expect(await isAtomicLeadToPlanTransitionAvailable(supa)).toBe(true);
+  });
+
+  it('returns true on clean RPC success', async () => {
+    const supa = makeMockSupabase({ rpcResponse: { success: true } });
+    expect(await isAtomicLeadToPlanTransitionAvailable(supa)).toBe(true);
+  });
+
+  it('returns false when client throws', async () => {
+    const supa = { rpc: () => { throw new Error('x'); } };
+    expect(await isAtomicLeadToPlanTransitionAvailable(supa)).toBe(false);
+  });
+});
+
+describe('state-transitions.js transitionSdToPlan integration (dynamic-import path)', () => {
+  let captured;
+
+  beforeEach(() => {
+    captured = {};
+
+    // Reset module cache so transitionSdToPlan re-imports atomic-transitions
+    vi.resetModules();
+
+    // Stub atomic-transitions to report RPC available + successful.
+    vi.doMock('../../scripts/modules/handoff/executors/lead-to-plan/atomic-transitions.js', () => ({
+      executeAtomicLeadToPlanTransition: async (_supa, sdId) => {
+        captured.atomicCalled = true;
+        captured.atomicSdId = sdId;
+        return { success: true, audit_id: 'aud-X' };
+      },
+      isAtomicLeadToPlanTransitionAvailable: async () => {
+        captured.availabilityChecked = true;
+        return true;
+      }
+    }));
+  });
+
+  it('uses the atomic path when RPC is available', async () => {
+    const { transitionSdToPlan } = await import(
+      '../../scripts/modules/handoff/executors/lead-to-plan/state-transitions.js'
+    );
+    const fakeSupa = { from: () => ({ update: () => ({ eq: async () => ({ error: null }) }) }) };
+    await transitionSdToPlan('SD-T', { current_phase: 'LEAD' }, fakeSupa);
+    expect(captured.availabilityChecked).toBe(true);
+    expect(captured.atomicCalled).toBe(true);
+    expect(captured.atomicSdId).toBe('SD-T');
+  });
+});
+
+describe('state-transitions.js falls back to legacy when RPC unavailable', () => {
+  it('runs the legacy .update() path when atomic reports unavailable', async () => {
+    vi.resetModules();
+    let legacyUpdateCalled = false;
+
+    vi.doMock('../../scripts/modules/handoff/executors/lead-to-plan/atomic-transitions.js', () => ({
+      executeAtomicLeadToPlanTransition: async () => ({ success: false, error: 'unused' }),
+      isAtomicLeadToPlanTransitionAvailable: async () => false
+    }));
+
+    const { transitionSdToPlan } = await import(
+      '../../scripts/modules/handoff/executors/lead-to-plan/state-transitions.js'
+    );
+
+    const fakeSupa = {
+      from: () => ({
+        update: () => ({
+          eq: async () => {
+            legacyUpdateCalled = true;
+            return { error: null };
+          }
+        })
+      })
+    };
+
+    await transitionSdToPlan('SD-T-Legacy', { current_phase: 'LEAD' }, fakeSupa);
+    expect(legacyUpdateCalled).toBe(true);
+  });
+});

--- a/tests/unit/sd-metrics-sufficiency.test.js
+++ b/tests/unit/sd-metrics-sufficiency.test.js
@@ -1,0 +1,179 @@
+/**
+ * SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 3:
+ *   Unit tests for dedupMetrics + validateStrategicDirective metrics path.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  dedupMetrics,
+  validateStrategicDirective,
+  SD_REQUIREMENTS
+} from '../../scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js';
+
+function baseSd(overrides = {}) {
+  return {
+    title: 'T',
+    description: 'd'.repeat(50),
+    scope: 'scope text',
+    strategic_objectives: 'a'.repeat(120),
+    key_principles: ['p1'],
+    risks: [],
+    priority: 'medium',
+    ...overrides
+  };
+}
+
+describe('dedupMetrics', () => {
+  it('returns non-array input unchanged', () => {
+    expect(dedupMetrics(null)).toBe(null);
+    expect(dedupMetrics(undefined)).toBe(undefined);
+    expect(dedupMetrics('not an array')).toBe('not an array');
+    expect(dedupMetrics({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('returns input unchanged when FLEET_METRICS_DEDUP=false', () => {
+    const prior = process.env.FLEET_METRICS_DEDUP;
+    process.env.FLEET_METRICS_DEDUP = 'false';
+    try {
+      const dupes = [{ metric: 'X' }, { metric: 'X' }, { metric: 'X' }];
+      const result = dedupMetrics(dupes);
+      expect(result).toBe(dupes);
+    } finally {
+      if (prior === undefined) delete process.env.FLEET_METRICS_DEDUP;
+      else process.env.FLEET_METRICS_DEDUP = prior;
+    }
+  });
+
+  it('collapses identical object entries to 1 unique', () => {
+    const dupes = [
+      { metric: 'Coverage', target: '>=90%', measurement: 'vitest --coverage' },
+      { metric: 'Coverage', target: '>=90%', measurement: 'vitest --coverage' },
+      { metric: 'Coverage', target: '>=90%', measurement: 'vitest --coverage' }
+    ];
+    expect(dedupMetrics(dupes)).toHaveLength(1);
+  });
+
+  it('keeps distinct objects', () => {
+    const distinct = [
+      { metric: 'Coverage', target: '>=90%', measurement: 'vitest --coverage' },
+      { metric: 'Latency', target: '<50ms p95', measurement: 'EXPLAIN ANALYZE' },
+      { metric: 'Fracture rate', target: '0 per day', measurement: 'claude_sessions query' }
+    ];
+    expect(dedupMetrics(distinct)).toHaveLength(3);
+  });
+
+  it('ignores non-identity fields (owner) when computing uniqueness', () => {
+    const sameIdentity = [
+      { metric: 'X', target: 'T', measurement: 'M', owner: 'team A' },
+      { metric: 'X', target: 'T', measurement: 'M', owner: 'team B' }
+    ];
+    expect(dedupMetrics(sameIdentity)).toHaveLength(1);
+  });
+
+  it('accepts success_criteria shape (criterion/measure/goal) as identity fields', () => {
+    const criteriaDupes = [
+      { criterion: 'Tests pass', measure: 'CI green', goal: 'PASS' },
+      { criterion: 'Tests pass', measure: 'CI green', goal: 'PASS' }
+    ];
+    expect(dedupMetrics(criteriaDupes)).toHaveLength(1);
+  });
+
+  it('treats string entries as unique by full JSON form', () => {
+    expect(dedupMetrics(['a', 'a', 'b', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves first-seen order of unique entries', () => {
+    const input = [
+      { metric: 'A' },
+      { metric: 'B' },
+      { metric: 'A' },
+      { metric: 'C' }
+    ];
+    expect(dedupMetrics(input)).toEqual([
+      { metric: 'A' },
+      { metric: 'B' },
+      { metric: 'C' }
+    ]);
+  });
+});
+
+describe('validateStrategicDirective metrics sufficiency', () => {
+  afterEach(() => {
+    // Ensure env flag does not leak between tests.
+    delete process.env.FLEET_METRICS_DEDUP;
+  });
+
+  it('PASSES when 3 distinct metrics are provided', () => {
+    const sd = baseSd({
+      success_metrics: [
+        { metric: 'A', target: '1', measurement: 'x' },
+        { metric: 'B', target: '2', measurement: 'y' },
+        { metric: 'C', target: '3', measurement: 'z' }
+      ]
+    });
+    const result = validateStrategicDirective(sd);
+    expect(result.valid).toBe(true);
+    const anyInsufficient = result.errors.some(e => e.includes('Insufficient success_metrics'));
+    expect(anyInsufficient).toBe(false);
+  });
+
+  it('FAILS with "1/3 unique" when 3 literal-duplicate metrics are provided', () => {
+    const sd = baseSd({
+      success_metrics: [
+        { metric: 'X', target: 'T', measurement: 'M' },
+        { metric: 'X', target: 'T', measurement: 'M' },
+        { metric: 'X', target: 'T', measurement: 'M' }
+      ]
+    });
+    const result = validateStrategicDirective(sd);
+    expect(result.valid).toBe(false);
+    const err = result.errors.find(e => e.includes('Insufficient success_metrics'));
+    expect(err).toBeDefined();
+    expect(err).toContain(`1/${SD_REQUIREMENTS.minimumMetrics}`);
+    expect(err).toContain('collapsed');
+  });
+
+  it('PASSES with dedup warning when 4 entries collapse to 3 unique', () => {
+    const sd = baseSd({
+      success_metrics: [
+        { metric: 'A', target: '1', measurement: 'x' },
+        { metric: 'A', target: '1', measurement: 'x' }, // duplicate of first
+        { metric: 'B', target: '2', measurement: 'y' },
+        { metric: 'C', target: '3', measurement: 'z' }
+      ]
+    });
+    const result = validateStrategicDirective(sd);
+    expect(result.valid).toBe(true);
+    const warn = result.warnings.find(w => w.includes('Dedup collapsed'));
+    expect(warn).toBeDefined();
+    expect(warn).toContain('1 duplicate');
+  });
+
+  it('FAILS when only 2 unique metrics even if 3 total entries', () => {
+    const sd = baseSd({
+      success_metrics: [
+        { metric: 'A', target: '1', measurement: 'x' },
+        { metric: 'B', target: '2', measurement: 'y' },
+        { metric: 'A', target: '1', measurement: 'x' } // dup of first
+      ]
+    });
+    const result = validateStrategicDirective(sd);
+    expect(result.valid).toBe(false);
+    const err = result.errors.find(e => e.includes('Insufficient success_metrics'));
+    expect(err).toContain(`2/${SD_REQUIREMENTS.minimumMetrics}`);
+  });
+
+  it('when dedup disabled, 3 literal-duplicate metrics pass (legacy behavior)', () => {
+    process.env.FLEET_METRICS_DEDUP = 'false';
+    const sd = baseSd({
+      success_metrics: [
+        { metric: 'X', target: 'T', measurement: 'M' },
+        { metric: 'X', target: 'T', measurement: 'M' },
+        { metric: 'X', target: 'T', measurement: 'M' }
+      ]
+    });
+    const result = validateStrategicDirective(sd);
+    // With flag off, legacy behavior: 3 entries counts as 3.
+    const err = result.errors.find(e => e.includes('Insufficient success_metrics'));
+    expect(err).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 (final) of parent orchestrator SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001. Three cohesive fixes in the LEAD-TO-PLAN handoff pipeline, all surfaced by a single precheck/execute divergence incident on ORCH-001-A (2026-04-22).

### Fix 1 — Validator unification (precheck/execute agreement)

New gate `GATE_SD_METRICS_SUFFICIENCY` in `executors/lead-to-plan/gates/` runs the minimumMetrics + measurability check during `handoff.js precheck` (not just execute). Extracted `validateMetricsSufficiency()` from the verifier as the canonical implementation — verifier delegates, gate wraps. One source of truth; precheck and execute can no longer diverge.

### Fix 2 — Atomic LEAD-TO-PLAN state transition

New PG function `fn_atomic_lead_to_plan_transition` (SECURITY DEFINER, mirrors `fn_atomic_exec_to_plan_transition`): advisory lock per-SD, idempotency via `request_id`, pre/post state in `sd_transition_audit`, `RAISE`-on-error → transactional rollback. New `atomic-transitions.js` wraps the RPC; `state-transitions.js::transitionSdToPlan()` tries atomic first, falls back to legacy `.update()` on RPC missing. **Migration already executed and smoke-tested** via DATABASE sub-agent.

### Fix 3 — Metrics dedup

`dedupMetrics()` helper in `sd-validation.js` collapses entries sharing identity fields (`metric` + `target` + `measurement`) before the `minimumMetrics` count. Gated by env `FLEET_METRICS_DEDUP` (default true). Shared by verifier and gate.

## Test plan

- [x] `npx vitest run tests/unit/sd-metrics-sufficiency.test.js` — 13/13 pass (dedup semantics, env-flag rollback, integration via `validateStrategicDirective`)
- [x] `npx vitest run tests/unit/lead-to-plan-atomic-transition.test.js` — 16/16 pass (RPC contract, availability detection, idempotency, graceful fallback)
- [x] Migration applied to engineer DB and verified (function exists, smoke calls return expected SD_NOT_FOUND for fake SD)
- [ ] Post-merge: observe precheck-execute agreement rate for 24h (target 0 divergence)
- [ ] Post-merge: observe `fn_atomic_lead_to_plan_transition` call count (should be >0 within 1h of fleet activity)

## Mini-incident note

A pre-correction smoke test was sent to the DATABASE sub-agent against a real SD before I amended the request. SD-C was briefly toggled (state immediately restored; `transition_version` bumped 2→3 as a side effect). Resulting audit row marked `rolled_back` with a documented note. No SD data loss. Lesson: don't include live-data smoke steps in agent prompts even with immediate rollback — use fake SDs only.

## Linked

- Parent orchestrator: SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001
- Predecessor phases: -A (completed), -B (completed), -C (completed today)
- Incident that surfaced this: ORCH-001-A LEAD-TO-PLAN handoff 2026-04-22 (precheck 94%, execute reject on SD_INCOMPLETE)
- Pattern template: `fn_atomic_exec_to_plan_transition` (mirrored exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)