### PR TITLE
feat(SD-PROTOCOL-LINTER-DASHBOARD-001): protocol-lint API + reference docs

### DIFF
--- a/docs/reference/protocol-linter.md
+++ b/docs/reference/protocol-linter.md
@@ -1,0 +1,111 @@
+# LEO Protocol Consistency Linter — Reference
+
+Owners: Protocol maintainers
+Related SDs: **SD-PROTOCOL-LINTER-001** (detection engine), **SD-PROTOCOL-LINTER-DASHBOARD-001** (dashboard)
+
+The Protocol Consistency Linter detects drift across the `CLAUDE.md` family (thresholds, enums, versions, duplicate authoritative lists, etc.). This document covers day-to-day usage: CLI, audit tables, and the admin dashboard.
+
+---
+
+## CLI
+
+| Command | Purpose |
+|---|---|
+| `npm run protocol:lint` | On-demand audit. Writes to `leo_lint_violations`, `leo_lint_run_history`. Exits non-zero on block-severity violations. |
+| `npm run protocol:lint:test` | Run rule fixtures (positive + negative). CI uses this to verify rules themselves. |
+| `npm run protocol:lint:promote <rule-id>` | Promote a warn-severity rule to block after ≥2 consecutive clean regen runs. |
+
+**Auto-run**: The linter executes inside `generate-claude-md-from-db.js` after DB fetch and before file writes. Block-severity violations abort the regen.
+
+**Bypass (rate-limited, 3/week)**:
+```bash
+node scripts/generate-claude-md-from-db.js --skip-lint --skip-reason "<text>"
+```
+Bypasses log to `leo_lint_run_history` with `trigger='bypass'` and non-null `bypass_reason`.
+
+---
+
+## Admin Dashboard (`/admin/protocol-lint`)
+
+SD-PROTOCOL-LINTER-DASHBOARD-001 ships a read-only React dashboard in the EHG app surfacing the linter's audit tables without requiring SQL.
+
+**Access**: `/admin/protocol-lint` (port 8080), gated by `AdminRoute` (requires role = chairman / executive / system_admin_ops / admin).
+
+**What it shows**:
+- **7-day trend chart**: daily violation counts (total / block / warn) at the top of the page.
+- **Violations tab** (default): filterable table by severity, rule_id, file path. Paginated 25/page. Empty-state renders when pre-corrective-migration.
+- **Rules tab**: active rule registry with occurrence count (last 7 days) and `promotion_eligible` badge for warn-severity rules with zero violations across the last 2 regen runs.
+- **Runs tab**: last 30 days of lint runs (trigger, exit-code, duration, `bypass_reason` for audit).
+
+**Refresh cadence**: Each table polls every 30s via the `adminApi` service. No WebSocket/SSE — matches `AdminDashboard` convention.
+
+**Empty-state behavior**: Before `leo_lint_violations` is populated by the corrective migration, each section renders a card explaining the state instead of a blank screen.
+
+### API (consumed by the dashboard)
+
+Mounted under `/api/admin/protocol-lint` in EHG_Engineer (port 3000), gated by `requireAuth + requireAdminRole`:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /violations?page=&pageSize=&severity=&rule_id=&file=&section_id=&status=` | `{ data: LintViolation[], total, page, pageSize, generated_at }` |
+| `GET /rules` | `{ data: LintRule[], total, regen_runs_considered, generated_at }` (includes server-computed `promotion_eligible` + `occurrence_count_last_7d`) |
+| `GET /runs` | `{ data: LintRun[], total, window_days, generated_at }` — 30-day window |
+| `GET /trend` | `{ data: TrendBucket[], window_days, generated_at }` — 7-day UTC-aligned daily buckets |
+
+All endpoints:
+- Set `Cache-Control: no-store`
+- Are read-only (promotion stays on the CLI per SD key_principle)
+- Do not mutate any audit tables
+
+### Common workflows
+
+**Triage drift weekly** (~2 min):
+1. Open `/admin/protocol-lint`
+2. Inspect the 7-day trend chart — is the count climbing?
+3. If yes, switch to the Violations tab, filter by `severity=block`
+4. For each unique `rule_id`, open the Rules tab and read the description to decide fix vs. dismiss.
+
+**Find promotion candidates**:
+1. Open the Rules tab.
+2. Look for the "Eligible to promote" badge (warn-severity + 0 violations in last 2 regen runs).
+3. Run `npm run protocol:lint:promote <rule-id>` in a terminal.
+
+**Audit a linter bypass**:
+1. Open the Runs tab.
+2. Filter rows where `trigger=bypass` (destructive-badge styling).
+3. `bypass_reason` column shows the explanation provided at `--skip-reason`.
+
+---
+
+## Audit tables
+
+| Table | Purpose |
+|---|---|
+| `leo_lint_rules` | Rule registry. `severity IN (warn, block)`. Promotion tracked via `promoted_from_warn_at`. |
+| `leo_lint_violations` | Append-only violations. Columns: `violation_id, run_id, rule_id, section_id, file_path, severity, message, context, status, status_reason, detected_at, resolved_at, resolved_by`. |
+| `leo_lint_run_history` | One row per run. `trigger IN (regen, audit, bypass, precommit)`. `passed` reflects whether any block-severity violation fired. |
+
+**Indexes** (already applied by SD-PROTOCOL-LINTER-001):
+- `idx_leo_lint_violations_status_detected (status, detected_at DESC) WHERE status=open`
+- `idx_leo_lint_violations_rule_detected (rule_id, detected_at DESC)`
+- `idx_leo_lint_run_history_started (started_at DESC)`
+- `idx_leo_lint_run_history_trigger_started (trigger, started_at DESC)`
+- `idx_leo_lint_rules_enabled (enabled) WHERE enabled=true`
+
+---
+
+## Implementation locations
+
+| Item | Path |
+|---|---|
+| Rule engine | `scripts/protocol-lint/engine.mjs` |
+| Declarative rules | `scripts/protocol-lint/rules/declarative/*.json` |
+| Code rules | `scripts/protocol-lint/rules/code/*.mjs` |
+| Rule fixtures | `scripts/protocol-lint/fixtures/*.json` |
+| Dashboard API | `server/routes/protocol-lint.js` (EHG_Engineer) |
+| Dashboard UI | `src/pages/admin/ProtocolLint.tsx` + `src/components/admin/protocol-lint/*.tsx` (EHG app) |
+| Migration | `database/migrations/20260422_protocol_linter_tables.sql` |
+
+## Adding a rule
+
+New rules ship at `severity='warn'`. After 2+ consecutive regen runs with zero violations, run `npm run protocol:lint:promote <rule-id>` to elevate to `severity='block'`. Every rule must include a positive fixture (triggers detection) and a negative fixture (does not trigger).

--- a/server/index.js
+++ b/server/index.js
@@ -59,6 +59,7 @@ import evaEconomicLensRoutes from './routes/eva-economic-lens.js';
 import stage17Routes from './routes/stage17.js';
 import stage24Routes from './routes/stage24.js';
 import githubRepoRoutes from './routes/github-repo.js';
+import protocolLintRoutes, { requireAdminRole } from './routes/protocol-lint.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 import { resumeIncompleteArchetypeJobs } from '../lib/eva/stage-17/auto-resume.js';
 
@@ -168,6 +169,8 @@ app.use('/api/stage17', requireAuth, stage17Routes);
 // Stage 24 Go Live
 app.use('/api/stage24', requireAuth, stage24Routes);
 app.use('/api/github', requireAuth, githubRepoRoutes);
+// Protocol Linter Dashboard (SD-PROTOCOL-LINTER-DASHBOARD-001): read-only admin-gated
+app.use('/api/admin/protocol-lint', requireAuth, requireAdminRole, protocolLintRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);
 

--- a/server/routes/protocol-lint.js
+++ b/server/routes/protocol-lint.js
@@ -1,0 +1,247 @@
+/**
+ * Protocol Linter Dashboard API Routes
+ * SD-PROTOCOL-LINTER-DASHBOARD-001
+ *
+ * Read-only endpoints consumed by /admin/protocol-lint in the EHG repo.
+ * Backed by leo_lint_violations / leo_lint_rules / leo_lint_run_history
+ * (shipped by parent SD-PROTOCOL-LINTER-001).
+ *
+ * Mount pattern: requireAuth + requireAdminRole at /api/admin/protocol-lint.
+ *
+ * Endpoints:
+ *   GET /violations   paginated, filterable violations list
+ *   GET /rules        rule registry with promotion eligibility
+ *   GET /runs         last 30 days of lint run history
+ */
+
+import { Router } from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+const ADMIN_ROLES = ['chairman', 'executive', 'system_admin_ops', 'admin'];
+const PAGE_SIZE_DEFAULT = 25;
+const PAGE_SIZE_MAX = 100;
+const RUNS_WINDOW_DAYS = 30;
+const TREND_WINDOW_DAYS = 7;
+const PROMOTION_RUN_LOOKBACK = 2;
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+/**
+ * Require admin role on req.user.
+ *
+ * req.user is populated by requireAuth. Accepts either top-level role
+ * or Supabase-style user_metadata.role. req.isAdmin (set by internal API key
+ * path) short-circuits.
+ */
+export function requireAdminRole(req, res, next) {
+  if (req.isAdmin) return next();
+  const role = req.user?.user_metadata?.role ?? req.user?.role;
+  if (!role || !ADMIN_ROLES.includes(role)) {
+    return res.status(403).json({
+      error: 'Forbidden',
+      message: 'Admin role required',
+      code: 'NOT_ADMIN'
+    });
+  }
+  next();
+}
+
+function parsePagination(query) {
+  const page = Math.max(1, parseInt(query.page, 10) || 1);
+  const pageSizeRaw = parseInt(query.pageSize, 10) || PAGE_SIZE_DEFAULT;
+  const pageSize = Math.min(PAGE_SIZE_MAX, Math.max(1, pageSizeRaw));
+  return { page, pageSize, from: (page - 1) * pageSize, to: page * pageSize - 1 };
+}
+
+const router = Router();
+
+router.use((req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
+  next();
+});
+
+// ────────────────────────────────────────────────────────────────────
+// GET /violations — paginated, filterable
+// ────────────────────────────────────────────────────────────────────
+router.get('/violations', async (req, res) => {
+  if (req.query.page !== undefined && parseInt(req.query.page, 10) < 1) {
+    return res.status(400).json({ error: 'InvalidRequest', message: 'page must be >= 1', code: 'BAD_PAGE' });
+  }
+
+  const { page, pageSize, from, to } = parsePagination(req.query);
+  const supabase = getSupabase();
+
+  let q = supabase
+    .from('leo_lint_violations')
+    .select('violation_id, run_id, rule_id, section_id, file_path, severity, message, context, status, status_reason, detected_at, resolved_at, resolved_by', { count: 'exact' })
+    .order('detected_at', { ascending: false })
+    .range(from, to);
+
+  if (req.query.severity) q = q.eq('severity', req.query.severity);
+  if (req.query.rule_id) q = q.eq('rule_id', req.query.rule_id);
+  if (req.query.file) q = q.eq('file_path', req.query.file);
+  if (req.query.section_id) q = q.eq('section_id', req.query.section_id);
+  if (req.query.status) q = q.eq('status', req.query.status);
+
+  const { data, error, count } = await q;
+
+  if (error) {
+    console.error('[protocol-lint] violations query failed:', error.message);
+    return res.status(500).json({ error: 'InternalError', message: error.message, code: 'QUERY_FAILED' });
+  }
+
+  res.json({
+    data: data ?? [],
+    total: count ?? 0,
+    page,
+    pageSize,
+    generated_at: new Date().toISOString()
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// GET /rules — registry with promotion_eligible flag
+// ────────────────────────────────────────────────────────────────────
+router.get('/rules', async (req, res) => {
+  const supabase = getSupabase();
+
+  const { data: rules, error: rulesErr } = await supabase
+    .from('leo_lint_rules')
+    .select('rule_id, severity, description, source_path, enabled, promoted_from_warn_at, created_at, updated_at')
+    .eq('enabled', true)
+    .order('rule_id', { ascending: true });
+
+  if (rulesErr) {
+    console.error('[protocol-lint] rules query failed:', rulesErr.message);
+    return res.status(500).json({ error: 'InternalError', message: rulesErr.message, code: 'QUERY_FAILED' });
+  }
+
+  const { data: recentRuns } = await supabase
+    .from('leo_lint_run_history')
+    .select('run_id, started_at, trigger, passed')
+    .eq('trigger', 'regen')
+    .order('started_at', { ascending: false })
+    .limit(PROMOTION_RUN_LOOKBACK);
+
+  const recentRunIds = (recentRuns ?? []).map(r => r.run_id);
+
+  let violationsByRule = new Map();
+  if (recentRunIds.length > 0) {
+    const { data: recentViolations } = await supabase
+      .from('leo_lint_violations')
+      .select('rule_id, run_id')
+      .in('run_id', recentRunIds);
+    for (const v of recentViolations ?? []) {
+      const key = v.rule_id;
+      violationsByRule.set(key, (violationsByRule.get(key) ?? 0) + 1);
+    }
+  }
+
+  const sevenDaysAgo = new Date(Date.now() - TREND_WINDOW_DAYS * 86400_000).toISOString();
+  const { data: recent7d } = await supabase
+    .from('leo_lint_violations')
+    .select('rule_id')
+    .gte('detected_at', sevenDaysAgo);
+
+  const countsByRule7d = new Map();
+  for (const v of recent7d ?? []) {
+    countsByRule7d.set(v.rule_id, (countsByRule7d.get(v.rule_id) ?? 0) + 1);
+  }
+
+  const enriched = (rules ?? []).map(r => ({
+    ...r,
+    occurrence_count_last_7d: countsByRule7d.get(r.rule_id) ?? 0,
+    promotion_eligible: r.severity === 'warn'
+      && recentRunIds.length >= PROMOTION_RUN_LOOKBACK
+      && (violationsByRule.get(r.rule_id) ?? 0) === 0
+  }));
+
+  enriched.sort((a, b) => {
+    if (a.promotion_eligible !== b.promotion_eligible) return a.promotion_eligible ? -1 : 1;
+    return a.rule_id.localeCompare(b.rule_id);
+  });
+
+  res.json({
+    data: enriched,
+    total: enriched.length,
+    regen_runs_considered: recentRunIds.length,
+    generated_at: new Date().toISOString()
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// GET /runs — last 30 days of lint run history
+// ────────────────────────────────────────────────────────────────────
+router.get('/runs', async (req, res) => {
+  const supabase = getSupabase();
+  const since = new Date(Date.now() - RUNS_WINDOW_DAYS * 86400_000).toISOString();
+
+  const { data, error, count } = await supabase
+    .from('leo_lint_run_history')
+    .select('run_id, trigger, total_violations, critical_count, passed, bypass_reason, started_at, ended_at, duration_ms, initiator, metadata', { count: 'exact' })
+    .gte('started_at', since)
+    .order('started_at', { ascending: false });
+
+  if (error) {
+    console.error('[protocol-lint] runs query failed:', error.message);
+    return res.status(500).json({ error: 'InternalError', message: error.message, code: 'QUERY_FAILED' });
+  }
+
+  res.json({
+    data: data ?? [],
+    total: count ?? 0,
+    window_days: RUNS_WINDOW_DAYS,
+    generated_at: new Date().toISOString()
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// GET /trend — 7-day daily violation count (for dashboard chart)
+// ────────────────────────────────────────────────────────────────────
+router.get('/trend', async (req, res) => {
+  const supabase = getSupabase();
+  // Bucket window: today + (TREND_WINDOW_DAYS-1) prior days, inclusive, UTC-aligned
+  const since = new Date();
+  since.setUTCHours(0, 0, 0, 0);
+  since.setUTCDate(since.getUTCDate() - (TREND_WINDOW_DAYS - 1));
+
+  const { data, error } = await supabase
+    .from('leo_lint_violations')
+    .select('detected_at, severity')
+    .gte('detected_at', since.toISOString())
+    .order('detected_at', { ascending: true });
+
+  if (error) {
+    console.error('[protocol-lint] trend query failed:', error.message);
+    return res.status(500).json({ error: 'InternalError', message: error.message, code: 'QUERY_FAILED' });
+  }
+
+  const buckets = new Map();
+  for (let i = 0; i < TREND_WINDOW_DAYS; i++) {
+    const d = new Date(since);
+    d.setUTCDate(since.getUTCDate() + i);
+    const key = d.toISOString().slice(0, 10);
+    buckets.set(key, { date: key, total: 0, block: 0, warn: 0 });
+  }
+
+  for (const v of data ?? []) {
+    const key = v.detected_at.slice(0, 10);
+    const b = buckets.get(key);
+    if (!b) continue;
+    b.total += 1;
+    if (v.severity === 'block') b.block += 1;
+    else if (v.severity === 'warn') b.warn += 1;
+  }
+
+  res.json({
+    data: Array.from(buckets.values()),
+    window_days: TREND_WINDOW_DAYS,
+    generated_at: new Date().toISOString()
+  });
+});
+
+export default router;

--- a/server/routes/protocol-lint.test.js
+++ b/server/routes/protocol-lint.test.js
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for Protocol Linter Dashboard API Routes
+ * SD-PROTOCOL-LINTER-DASHBOARD-001
+ *
+ * Covers: requireAdminRole middleware, /violations, /rules, /runs, /trend
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Supabase BEFORE importing the route module
+const mockSupabaseFromBuilder = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: (...args) => mockSupabaseFromBuilder(...args),
+    auth: { persistSession: false }
+  }))
+}));
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+const { default: protocolLintRouter, requireAdminRole } = await import('./protocol-lint.js');
+
+function mockReq(overrides = {}) {
+  return { query: {}, headers: {}, user: null, isAdmin: false, ...overrides };
+}
+function mockRes() {
+  const res = { headers: {} };
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.setHeader = vi.fn((k, v) => { res.headers[k] = v; });
+  return res;
+}
+
+describe('requireAdminRole', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('allows when req.isAdmin=true (internal API key path)', () => {
+    const req = mockReq({ isAdmin: true });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows user with user_metadata.role=chairman', () => {
+    const req = mockReq({ user: { user_metadata: { role: 'chairman' } } });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows user with top-level role=system_admin_ops', () => {
+    const req = mockReq({ user: { role: 'system_admin_ops' } });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects user with role=viewer with 403 NOT_ADMIN', () => {
+    const req = mockReq({ user: { user_metadata: { role: 'viewer' } } });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_ADMIN' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects user with no role field', () => {
+    const req = mockReq({ user: {} });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects null user (requireAuth should catch first, defensive)', () => {
+    const req = mockReq({ user: null });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+describe('Router behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseFromBuilder.mockReset();
+  });
+
+  /**
+   * Invoke a router handler directly via its stack, without spinning up Express.
+   * The router mounts a no-store middleware first, then 4 handlers.
+   */
+  async function invokeRoute(method, path, query = {}) {
+    const layer = protocolLintRouter.stack.find(
+      l => l.route && l.route.path === path && l.route.methods[method.toLowerCase()]
+    );
+    if (!layer) throw new Error(`Route ${method} ${path} not found`);
+    const handler = layer.route.stack[0].handle;
+    const req = mockReq({ query });
+    const res = mockRes();
+    await handler(req, res);
+    return { req, res };
+  }
+
+  // ── /violations ───────────────────────────────────────────────
+  it('GET /violations returns empty data when table is empty', async () => {
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        order: () => ({
+          range: () => Promise.resolve({ data: [], error: null, count: 0 })
+        })
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/violations');
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data).toEqual([]);
+    expect(payload.total).toBe(0);
+    expect(payload.page).toBe(1);
+    expect(payload.pageSize).toBe(25);
+    expect(payload.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('GET /violations with page=-1 returns 400 BAD_PAGE', async () => {
+    const { res } = await invokeRoute('GET', '/violations', { page: '-1' });
+    expect(res.status).toHaveBeenCalledWith(400);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.code).toBe('BAD_PAGE');
+  });
+
+  it('GET /violations caps pageSize at 100', async () => {
+    const captured = { from: null, to: null };
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        order: () => ({
+          range: (from, to) => {
+            captured.from = from;
+            captured.to = to;
+            return Promise.resolve({ data: [], error: null, count: 0 });
+          }
+        })
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/violations', { pageSize: '9999' });
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.pageSize).toBe(100);
+    expect(captured.from).toBe(0);
+    expect(captured.to).toBe(99); // pageSize*1 - 1
+  });
+
+  it('GET /violations propagates Supabase errors as 500 QUERY_FAILED', async () => {
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        order: () => ({
+          range: () => Promise.resolve({ data: null, error: { message: 'pg error' }, count: null })
+        })
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/violations');
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json.mock.calls[0][0].code).toBe('QUERY_FAILED');
+  });
+
+  // ── /rules ──────────────────────────────────────────────────
+  it('GET /rules flags warn-severity rule with zero recent violations as promotion_eligible', async () => {
+    const recentRuns = [
+      { run_id: 'r1', started_at: '2026-04-22T10:00:00Z', trigger: 'regen', passed: true },
+      { run_id: 'r2', started_at: '2026-04-21T10:00:00Z', trigger: 'regen', passed: true }
+    ];
+    const rules = [
+      { rule_id: 'R-WARN-CLEAN', severity: 'warn', description: '', source_path: '', enabled: true, promoted_from_warn_at: null, created_at: '', updated_at: '' },
+      { rule_id: 'R-WARN-DIRTY', severity: 'warn', description: '', source_path: '', enabled: true, promoted_from_warn_at: null, created_at: '', updated_at: '' },
+      { rule_id: 'R-BLOCK', severity: 'block', description: '', source_path: '', enabled: true, promoted_from_warn_at: null, created_at: '', updated_at: '' }
+    ];
+
+    mockSupabaseFromBuilder.mockImplementation((table) => {
+      if (table === 'leo_lint_rules') {
+        return { select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: rules, error: null }) }) }) };
+      }
+      if (table === 'leo_lint_run_history') {
+        return { select: () => ({ eq: () => ({ order: () => ({ limit: () => Promise.resolve({ data: recentRuns, error: null }) }) }) }) };
+      }
+      if (table === 'leo_lint_violations') {
+        // Two calls: one for .in('run_id', recentRunIds), one for .gte('detected_at', 7d)
+        const builder = {
+          select: () => ({
+            in: () => Promise.resolve({ data: [{ rule_id: 'R-WARN-DIRTY', run_id: 'r1' }], error: null }),
+            gte: () => Promise.resolve({ data: [{ rule_id: 'R-WARN-DIRTY' }, { rule_id: 'R-WARN-DIRTY' }], error: null })
+          })
+        };
+        return builder;
+      }
+    });
+
+    const { res } = await invokeRoute('GET', '/rules');
+    const payload = res.json.mock.calls[0][0];
+    const clean = payload.data.find(r => r.rule_id === 'R-WARN-CLEAN');
+    const dirty = payload.data.find(r => r.rule_id === 'R-WARN-DIRTY');
+    const block = payload.data.find(r => r.rule_id === 'R-BLOCK');
+    expect(clean.promotion_eligible).toBe(true);
+    expect(dirty.promotion_eligible).toBe(false);
+    expect(block.promotion_eligible).toBe(false);
+    expect(dirty.occurrence_count_last_7d).toBe(2);
+    expect(clean.occurrence_count_last_7d).toBe(0);
+    // Sort order: promotion_eligible DESC then rule_id ASC
+    expect(payload.data[0].rule_id).toBe('R-WARN-CLEAN');
+  });
+
+  it('GET /rules sets promotion_eligible=false when fewer than 2 regen runs exist', async () => {
+    mockSupabaseFromBuilder.mockImplementation((table) => {
+      if (table === 'leo_lint_rules') {
+        return { select: () => ({ eq: () => ({ order: () => Promise.resolve({
+          data: [{ rule_id: 'R1', severity: 'warn', description: '', source_path: '', enabled: true, promoted_from_warn_at: null, created_at: '', updated_at: '' }],
+          error: null
+        }) }) }) };
+      }
+      if (table === 'leo_lint_run_history') {
+        return { select: () => ({ eq: () => ({ order: () => ({ limit: () => Promise.resolve({ data: [{ run_id: 'r1', started_at: '', trigger: 'regen', passed: true }], error: null }) }) }) }) };
+      }
+      if (table === 'leo_lint_violations') {
+        return { select: () => ({ in: () => Promise.resolve({ data: [], error: null }), gte: () => Promise.resolve({ data: [], error: null }) }) };
+      }
+    });
+
+    const { res } = await invokeRoute('GET', '/rules');
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data[0].promotion_eligible).toBe(false);
+    expect(payload.regen_runs_considered).toBe(1);
+  });
+
+  // ── /runs ───────────────────────────────────────────────────
+  it('GET /runs filters to 30-day window via gte(started_at, since)', async () => {
+    const captured = { sinceIso: null };
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        gte: (col, iso) => {
+          captured.sinceIso = iso;
+          return { order: () => Promise.resolve({ data: [], error: null, count: 0 }) };
+        }
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/runs');
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.window_days).toBe(30);
+    // since should be ~30 days ago
+    const sinceMs = new Date(captured.sinceIso).getTime();
+    const expected = Date.now() - 30 * 86400_000;
+    expect(Math.abs(sinceMs - expected)).toBeLessThan(5_000); // 5s tolerance
+  });
+
+  // ── /trend ──────────────────────────────────────────────────
+  it('GET /trend returns 7 daily buckets even when no violations exist', async () => {
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        gte: () => ({
+          order: () => Promise.resolve({ data: [], error: null })
+        })
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/trend');
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data).toHaveLength(7);
+    expect(payload.data.every(b => b.total === 0 && b.block === 0 && b.warn === 0)).toBe(true);
+    expect(payload.window_days).toBe(7);
+  });
+
+  it('GET /trend buckets violations by severity and day', async () => {
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+
+    mockSupabaseFromBuilder.mockImplementation(() => ({
+      select: () => ({
+        gte: () => ({
+          order: () => Promise.resolve({ data: [
+            { detected_at: today.toISOString(), severity: 'block' },
+            { detected_at: today.toISOString(), severity: 'warn' },
+            { detected_at: yesterday.toISOString(), severity: 'block' }
+          ], error: null })
+        })
+      })
+    }));
+
+    const { res } = await invokeRoute('GET', '/trend');
+    const payload = res.json.mock.calls[0][0];
+    const todayKey = today.toISOString().slice(0, 10);
+    const yKey = yesterday.toISOString().slice(0, 10);
+    const todayBucket = payload.data.find(b => b.date === todayKey);
+    const yBucket = payload.data.find(b => b.date === yKey);
+    expect(todayBucket.total).toBe(2);
+    expect(todayBucket.block).toBe(1);
+    expect(todayBucket.warn).toBe(1);
+    expect(yBucket.total).toBe(1);
+    expect(yBucket.block).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 4 read-only GET endpoints under `/api/admin/protocol-lint` (`/violations`, `/rules`, `/runs`, `/trend`) gated by `requireAuth + requireAdminRole`
- Server-side computation of `promotion_eligible` (warn-severity + 0 violations across last 2 regen runs)
- Trend endpoint pre-aggregates 7-day UTC-aligned buckets so the client never receives raw rows
- Adds `docs/reference/protocol-linter.md` documenting CLI, dashboard, API, audit tables, and common workflows

## Context
This is the API half of **SD-PROTOCOL-LINTER-DASHBOARD-001** (deferred dashboard from completed SD-PROTOCOL-LINTER-001 FR-6). The React UI consuming these endpoints lives in the companion PR on `rickfelix/ehg` (branch `feat/SD-PROTOCOL-LINTER-DASHBOARD-001`).

No new migrations, no new tables. All backing tables (`leo_lint_violations`, `leo_lint_rules`, `leo_lint_run_history`) and their indexes were shipped by parent SD-PROTOCOL-LINTER-001.

Per DATABASE sub-agent review: confirmed column is `detected_at` (not `first_seen` as initially written in the PRD).

## Test plan
- [x] `vitest run server/routes/protocol-lint.test.js` — 15/15 passing
- [x] Unit coverage on `requireAdminRole` (6 cases: internal-API admin, chairman, system_admin_ops, viewer rejection, missing role, null user)
- [x] `/violations` pagination clamping (pageSize >100 caps to 100), `page=-1` returns 400
- [x] `/rules` promotion_eligible edge cases (warn+clean→true, warn+dirty→false, block→false, <2 runs→false)
- [x] `/runs` 30-day window + gte(started_at) check
- [x] `/trend` UTC-aligned 7 buckets, empty and populated
- [ ] Manual smoke against staging via `curl -H "Authorization: Bearer <admin-token>" http://localhost:3000/api/admin/protocol-lint/violations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)