### PR TITLE
fix(QF-20260423-778): isValidWorktree must pass cwd for cross-repo SDs

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -67,7 +67,11 @@ function isValidWorktree(wtPath) {
     // may still exist but git no longer tracks it, causing module resolution
     // failures when scripts run from the orphaned directory.
     const absPath = path.resolve(wtPath).replace(/\\/g, '/');
-    const listed = execSync('git worktree list --porcelain', { encoding: 'utf8', stdio: 'pipe' });
+    // cwd must be wtPath so the command inspects the *target* repo's worktree list.
+    // Without cwd, this runs from process.cwd() (usually EHG_Engineer), and cross-repo
+    // SDs (targetApp != 'EHG_Engineer') always fail the registration check because
+    // their worktree belongs to a different repo entirely.
+    const listed = execSync('git worktree list --porcelain', { cwd: wtPath, encoding: 'utf8', stdio: 'pipe' });
     const registeredPaths = listed
       .split('\n')
       .filter(l => l.startsWith('worktree '))

--- a/tests/unit/resolve-sd-workdir/worktree-atomicity.test.js
+++ b/tests/unit/resolve-sd-workdir/worktree-atomicity.test.js
@@ -75,7 +75,7 @@ test('post-condition: directory not in git worktree list is detectable via porce
     const expected = wtPath.replace(/\\/g, '/');
     assert.ok(
       !paths.some(p => p.replace(/\\/g, '/') === expected),
-      `Orphan dir should NOT appear in worktree list`
+      'Orphan dir should NOT appear in worktree list'
     );
     // .git pointer should not exist
     assert.ok(!existsSync(join(wtPath, '.git')), '.git pointer must NOT exist for plain dir');
@@ -131,6 +131,63 @@ test('pre-condition: plain directory at worktree path fails isValidWorktree chec
     assert.ok(!paths.some(p => p.replace(/\\/g, '/') === expected), 'Junk dir must NOT be in worktree list');
   } finally {
     rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// QF-20260423-778: Cross-repo isValidWorktree — the porcelain check must
+// inspect the *target* repo's worktree list, not the caller's cwd.
+// Regression test for: sd-start hard-failing with WORKTREE_CREATE_FAILED
+// on cross-repo SDs (targetApp != 'EHG_Engineer') even when the worktree
+// is valid and registered in the target repo.
+// ---------------------------------------------------------------------------
+test('cross-repo: worktree in repo B is NOT listed by porcelain run from repo A (bug reproducer)', () => {
+  const repoA = createFixtureRepo();
+  const repoB = createFixtureRepo();
+  try {
+    const wtPath = join(repoB, '.worktrees', 'SD-CROSS-REPO');
+    mkdirSync(join(repoB, '.worktrees'), { recursive: true });
+    execSync(`git worktree add "${wtPath}" -b feat/SD-CROSS-REPO`, { cwd: repoB, stdio: 'pipe' });
+
+    // Bug condition: porcelain run from repo A's cwd returns repo A's worktrees,
+    // NOT repo B's. Cross-repo worktree validation therefore always fails.
+    const listedFromA = execSync('git worktree list --porcelain', { cwd: repoA, encoding: 'utf8' });
+    const pathsFromA = listedFromA.split('\n')
+      .filter(l => l.startsWith('worktree '))
+      .map(l => l.replace('worktree ', '').trim().replace(/\\/g, '/'));
+    const expected = wtPath.replace(/\\/g, '/');
+    assert.ok(
+      !pathsFromA.some(p => p.replace(/\\/g, '/') === expected),
+      'From repo A, porcelain must NOT list repo B\'s worktree (reproduces the bug)'
+    );
+  } finally {
+    rmSync(repoA, { recursive: true, force: true });
+    rmSync(repoB, { recursive: true, force: true });
+  }
+});
+
+test('cross-repo: porcelain with cwd=wtPath correctly lists the worktree (fix verification)', () => {
+  const repoA = createFixtureRepo();
+  const repoB = createFixtureRepo();
+  try {
+    const wtPath = join(repoB, '.worktrees', 'SD-CROSS-REPO-FIX');
+    mkdirSync(join(repoB, '.worktrees'), { recursive: true });
+    execSync(`git worktree add "${wtPath}" -b feat/SD-CROSS-REPO-FIX`, { cwd: repoB, stdio: 'pipe' });
+
+    // Fix condition: porcelain run from the worktree path itself resolves to
+    // repo B's worktree list — the registration check succeeds.
+    const listedFromWt = execSync('git worktree list --porcelain', { cwd: wtPath, encoding: 'utf8' });
+    const pathsFromWt = listedFromWt.split('\n')
+      .filter(l => l.startsWith('worktree '))
+      .map(l => l.replace('worktree ', '').trim().replace(/\\/g, '/'));
+    const expected = wtPath.replace(/\\/g, '/');
+    assert.ok(
+      pathsFromWt.some(p => p.replace(/\\/g, '/') === expected),
+      `With cwd=wtPath, porcelain must list ${expected}`
+    );
+  } finally {
+    rmSync(repoA, { recursive: true, force: true });
+    rmSync(repoB, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

- `scripts/resolve-sd-workdir.js:70` invoked `git worktree list --porcelain` without a `cwd`, causing cross-repo worktree validation to query the wrong repo and always fail.
- Impact: any session claiming an SD whose `target_application != 'EHG_Engineer'` (e.g. `EHG`) could not validate a pre-existing, git-registered worktree — `sd-start` threw `WORKTREE_CREATE_FAILED` with a misleading "not a registered worktree" message.
- Fix: pass `cwd: wtPath` to the `execSync` call so the porcelain list reflects the target repo.
- Added two regression tests in `tests/unit/resolve-sd-workdir/worktree-atomicity.test.js`: one reproduces the bug (query from wrong cwd returns empty), one verifies the fix (query from wtPath returns the registered worktree).

## Discovery

Hit while attempting `sd-start SD-PROTOCOL-LINTER-DASHBOARD-001` (targets EHG). Worktree at `C:/Users/rickf/Projects/_EHG/ehg/.worktrees/SD-PROTOCOL-LINTER-DASHBOARD-001` was valid and git-registered in the EHG repo, but `isValidWorktree` running from EHG_Engineer's cwd saw only EHG_Engineer's worktree list — match always false.

## Test plan

- [x] 9/9 unit tests pass (`node --test tests/unit/resolve-sd-workdir/worktree-atomicity.test.js`)
- [x] Manually re-ran `sd-start SD-PROTOCOL-LINTER-DASHBOARD-001` post-fix — worktree validation step passed (subsequent block was a legitimate `foreign_claim`, not a `WORKTREE_CREATE_FAILED`)
- [x] Pre-commit gates: LOC 65 below threshold, no blacklisted words, no root temp files

🤖 Generated with [Claude Code](https://claude.com/claude-code)