### PR TITLE
feat(SD-LEO-INFRA-FIX-GATE-FILE-001): branch-aware gate file reading

### DIFF
--- a/docs/reference/branch-aware-gate-reads.md
+++ b/docs/reference/branch-aware-gate-reads.md
@@ -1,0 +1,68 @@
+---
+category: reference
+status: published
+version: 1.0.0
+last_updated: 2026-04-24
+tags: [reference, handoff-gates, parallel-sessions]
+---
+# Branch-Aware Gate File Reads
+
+**SD**: SD-LEO-INFRA-FIX-GATE-FILE-001
+
+## Rule
+
+Any LEO handoff gate that reads source files from a cross-repo checkout (e.g. the shared `ehg` frontend tree) **MUST** read them from `origin/<sd_branch>`, never directly from the local checkout.
+
+## Why
+
+The shared `ehg` checkout has its branch flipped by whichever parallel Claude Code session is active. When a gate reads via `fs.readFileSync(path.join(EHG_REPO_PATH, file))`, its verdict depends on which branch happens to be checked out at gate-run time — not the SD under review. This produces:
+
+- False-fails on SDs whose content is correct but absent from the current checkout.
+- False-passes on SDs whose issues exist on their own branch but not in the checkout.
+- A compensation pattern of `--bypass-validation`, which masks real gate signal.
+
+Evidence: three consecutive `--bypass-validation` uses on SD-PROTOCOL-LINTER-DASHBOARD-001 (2026-04-24), all for this exact class.
+
+## Canonical Pattern
+
+Use `createBranchFileReader` from `scripts/modules/handoff/lib/branch-file-reader.js`:
+
+```js
+import { createBranchFileReader } from '../../../lib/branch-file-reader.js';
+
+const reader = createBranchFileReader(EHG_REPO_PATH);
+const content = reader.readFile(branchName, 'src/components/Foo.tsx');
+```
+
+The helper routes each read through `git show origin/<branch>:<path>`, retries with `git fetch origin <branch>` on first-miss, and caches `(branch, path) → content` per instance so repeat reads (common in `/heal` and batch precheck) do not pay the git-show cost twice.
+
+For gates that must build or execute against branch contents (not just read them), use a disposable worktree:
+
+```js
+execSync(`git -C "${repoRoot}" worktree add --detach "${tempDir}" origin/${branch}`);
+// ... run build / script in tempDir ...
+execSync(`git -C "${repoRoot}" worktree remove --force "${tempDir}"`); // in finally{}
+```
+
+`lib/gates/cross-repo-build-check.js` is the reference implementation.
+
+## Anti-Pattern
+
+```js
+// ❌ DO NOT DO THIS in any cross-repo gate
+const content = fs.readFileSync(path.join(EHG_REPO_PATH, file), 'utf8');
+```
+
+Reading via `fs.readFileSync` against a shared checkout couples the gate verdict to parallel-session state. If you find this pattern in a new gate, migrate it to `createBranchFileReader` (or a temp worktree for execution paths) before shipping.
+
+## Scope of the Rule
+
+This rule applies only to **cross-repo** reads — gates that look at files outside the EHG_Engineer repo. Within-repo reads (e.g. `scripts/modules/handoff/*` reading other EHG_Engineer files on its own branch) are unaffected, because the worktree is already scoped to the SD.
+
+## References
+
+- Helper: `scripts/modules/handoff/lib/branch-file-reader.js`
+- Unit tests: `tests/unit/branch-file-reader.test.js`
+- Consumer 1: `scripts/modules/handoff/executors/exec-to-plan/gates/ui-interactivity-check.js`
+- Consumer 2: `lib/gates/cross-repo-build-check.js`
+- Regression tests: `tests/unit/handoff/cross-repo-build-check-branch-aware.test.js`

--- a/lib/gates/cross-repo-build-check.js
+++ b/lib/gates/cross-repo-build-check.js
@@ -9,42 +9,106 @@
  */
 
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { getPrimaryRepos } from '../multi-repo/index.js';
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const WORKTREE_OP_TIMEOUT_MS = 30_000;
+
+/**
+ * Create a temp worktree at origin/<branch> from the ehg repo.
+ * SD-LEO-INFRA-FIX-GATE-FILE-001: build must target the SD's branch contents,
+ * not the shared checkout state (which may be on an unrelated branch).
+ *
+ * @param {string} repoRoot - ehg repo root
+ * @param {string} branch - SD branch name (without origin/ prefix)
+ * @returns {{ path: string, cleanup: () => void }}
+ */
+function createTempWorktreeFromBranch(repoRoot, branch) {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ehg-build-'));
+  try {
+    execSync(`git -C "${repoRoot}" fetch origin ${branch} --quiet --no-tags`, {
+      timeout: WORKTREE_OP_TIMEOUT_MS,
+      stdio: 'pipe',
+    });
+  } catch {
+    // Fetch may fail if branch is already local — proceed and let worktree add surface a clearer error.
+  }
+  execSync(`git -C "${repoRoot}" worktree add --detach "${tempDir}" origin/${branch}`, {
+    timeout: WORKTREE_OP_TIMEOUT_MS,
+    stdio: 'pipe',
+  });
+  return {
+    path: tempDir,
+    cleanup: () => {
+      try {
+        execSync(`git -C "${repoRoot}" worktree remove --force "${tempDir}"`, {
+          timeout: WORKTREE_OP_TIMEOUT_MS,
+          stdio: 'pipe',
+        });
+      } catch {
+        try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    },
+  };
+}
 
 /**
  * Run `npm run build` in the ehg repo and report pass/fail.
  *
  * @param {Object} [options]
  * @param {number} [options.timeout] - Build timeout in ms (default 120s)
+ * @param {string} [options.branch] - SD branch name to build from origin/<branch>.
+ *   When supplied, the build runs in a disposable worktree created from origin/<branch>,
+ *   so the verdict reflects the SD's committed state, not the shared checkout.
+ *   Omit to keep legacy behavior (build in shared checkout).
  * @returns {{ pass: boolean, output: string, duration: number }}
  */
 export function checkEhgBuild(options = {}) {
   const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
   const start = Date.now();
 
+  let repos, ehg;
   try {
-    const repos = getPrimaryRepos();
-    const ehg = repos.ehg;
+    repos = getPrimaryRepos();
+    ehg = repos.ehg;
+  } catch (err) {
+    return { pass: false, output: err.message, duration: Date.now() - start };
+  }
 
-    if (!ehg?.path || !existsSync(ehg.path)) {
-      return { pass: false, output: 'ehg repo not found locally', duration: Date.now() - start };
+  if (!ehg?.path || !existsSync(ehg.path)) {
+    return { pass: false, output: 'ehg repo not found locally', duration: Date.now() - start };
+  }
+
+  const packageJson = `${ehg.path}/package.json`;
+  if (!existsSync(packageJson)) {
+    return { pass: false, output: `No package.json at ${ehg.path}`, duration: Date.now() - start };
+  }
+
+  let buildCwd = ehg.path;
+  let tempWorktree = null;
+  if (options.branch) {
+    try {
+      tempWorktree = createTempWorktreeFromBranch(ehg.path, options.branch);
+      buildCwd = tempWorktree.path;
+    } catch (err) {
+      return {
+        pass: false,
+        output: `temp worktree creation failed for origin/${options.branch}: ${err.message?.slice(0, 200) || err}`,
+        duration: Date.now() - start,
+      };
     }
+  }
 
-    const packageJson = `${ehg.path}/package.json`;
-    if (!existsSync(packageJson)) {
-      return { pass: false, output: `No package.json at ${ehg.path}`, duration: Date.now() - start };
-    }
-
+  try {
     const output = execSync('npm run build', {
-      cwd: ehg.path,
+      cwd: buildCwd,
       encoding: 'utf8',
       timeout,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-
     return { pass: true, output: output.slice(-500), duration: Date.now() - start };
   } catch (err) {
     const duration = Date.now() - start;
@@ -53,6 +117,8 @@ export function checkEhgBuild(options = {}) {
     }
     const stderr = err.stderr ? err.stderr.slice(-500) : err.message;
     return { pass: false, output: stderr, duration };
+  } finally {
+    if (tempWorktree) tempWorktree.cleanup();
   }
 }
 
@@ -88,12 +154,41 @@ export function shouldForceCheck(changedFiles) {
  * @param {string[]} [options.changedFiles] - Changed file paths for auth-pattern escalation
  * @returns {Object} Gate definition compatible with handoff executor gates
  */
+/**
+ * Resolve the SD branch name in the ehg repo.
+ * SD-LEO-INFRA-FIX-GATE-FILE-001: the build must target origin/<sd_branch>,
+ * not the shared checkout. Probes `feat/<sdKey>` then `fix/<sdKey>`.
+ *
+ * @param {Object} ctx - gate ctx (contains ctx.sd with sd_key)
+ * @returns {string | null} branch name without origin/ prefix, or null if none found
+ */
+function resolveSdBranch(ctx) {
+  const sdKey = ctx?.sd?.sd_key || ctx?.sdKey;
+  if (!sdKey) return null;
+  let repoPath;
+  try {
+    repoPath = getPrimaryRepos().ehg?.path;
+  } catch { return null; }
+  if (!repoPath || !existsSync(repoPath)) return null;
+  let branches;
+  try {
+    branches = execSync(`git -C "${repoPath}" branch -r`, {
+      encoding: 'utf8', timeout: 10_000, stdio: ['pipe', 'pipe', 'pipe'],
+    }).split('\n').map(b => b.trim());
+  } catch { return null; }
+  for (const pattern of [`feat/${sdKey}`, `fix/${sdKey}`]) {
+    const match = branches.find(b => b.toLowerCase().includes(pattern.toLowerCase()));
+    if (match) return match.replace('origin/', '');
+  }
+  return null;
+}
+
 export function createCrossRepoBuildGate(options = {}) {
   const forceRequired = shouldForceCheck(options.changedFiles || []);
 
   return {
     name: 'CROSS_REPO_BUILD_CHECK',
-    validator: async () => {
+    validator: async (ctx) => {
       const mode = forceRequired ? 'REQUIRED (auth-pattern detected)' : 'Advisory';
       console.log(`\n\u{1f3d7}\ufe0f  GATE: Cross-Repo Build Verification (${mode})`);
       console.log('-'.repeat(50));
@@ -102,7 +197,17 @@ export function createCrossRepoBuildGate(options = {}) {
         console.log('   \u{1f6a8} Auth-pattern escalation: gate is REQUIRED');
       }
 
-      const result = checkEhgBuild();
+      // SD-LEO-INFRA-FIX-GATE-FILE-001: build from origin/<sd_branch> via a
+      // disposable worktree so the verdict is independent of whichever branch
+      // the shared checkout is on (parallel-session-safe).
+      const sdBranch = resolveSdBranch(ctx);
+      if (sdBranch) {
+        console.log(`   Building from origin/${sdBranch} in a disposable worktree`);
+      } else {
+        console.log('   No SD branch resolved — falling back to shared checkout (legacy path)');
+      }
+
+      const result = checkEhgBuild(sdBranch ? { branch: sdBranch } : {});
       const warnings = [];
       const issues = [];
 

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/ui-interactivity-check.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/ui-interactivity-check.js
@@ -15,8 +15,7 @@
  */
 
 import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import { createBranchFileReader } from '../../../lib/branch-file-reader.js';
 
 const GATE_NAME = 'UI_INTERACTIVITY_CHECK';
 const INTERACTIVE_PATTERNS = ['onClick', 'onSubmit', 'authedFetch', 'onChange', 'onSelect'];
@@ -90,15 +89,21 @@ export function createUiInteractivityCheckGate(supabase) {
           return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No component files changed'] };
         }
 
-        // Check each changed file for interactive patterns
+        // Check each changed file for interactive patterns.
+        // SD-LEO-INFRA-FIX-GATE-FILE-001: read from origin/<branch>, not the shared
+        // working tree (which may be on an unrelated branch in parallel sessions).
+        const reader = createBranchFileReader(EHG_REPO_PATH);
         let interactiveFiles = 0;
         const displayOnlyFiles = [];
 
         for (const file of changedFiles) {
-          const fullPath = path.join(EHG_REPO_PATH, file);
-          if (!fs.existsSync(fullPath)) continue;
-
-          const content = fs.readFileSync(fullPath, 'utf8');
+          let content;
+          try {
+            content = reader.readFile(branchName, file);
+          } catch {
+            // File may have been deleted on branch — skip like the old fs.existsSync path
+            continue;
+          }
           const hasInteractivity = INTERACTIVE_PATTERNS.some(p => content.includes(p));
 
           if (hasInteractivity) {

--- a/scripts/modules/handoff/lib/branch-file-reader.js
+++ b/scripts/modules/handoff/lib/branch-file-reader.js
@@ -1,0 +1,84 @@
+/**
+ * Branch-aware file reader for LEO handoff gates.
+ * SD: SD-LEO-INFRA-FIX-GATE-FILE-001
+ *
+ * Reads file contents from `origin/<branch>:<path>` via `git show` so
+ * gate logic is independent of whichever branch a shared checkout
+ * happens to be on at gate-run time. Includes a per-instance cache to
+ * keep repeat reads cheap (important for /heal and batch precheck).
+ *
+ * Usage:
+ *   const reader = createBranchFileReader(repoRoot);
+ *   const content = await reader.readFile(branchName, 'src/components/Foo.tsx');
+ */
+
+import { execSync } from 'child_process';
+
+const SHOW_TIMEOUT_MS = 3000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * @param {string} repoRoot - Absolute path to the git repo root
+ * @returns {{ readFile: (branch: string, path: string) => string, stats: () => {hits: number, misses: number} }}
+ */
+export function createBranchFileReader(repoRoot) {
+  const cache = new Map();
+  let hits = 0;
+  let misses = 0;
+
+  function cacheKey(branch, path) {
+    return `${branch}::${path}`;
+  }
+
+  function fetchBranch(branch) {
+    try {
+      execSync(`git -C "${repoRoot}" fetch origin ${branch} --quiet --no-tags`, {
+        timeout: FETCH_TIMEOUT_MS,
+        stdio: 'pipe',
+      });
+    } catch (err) {
+      // Fetch failure is not always fatal — the ref may already be local.
+      // Let the subsequent show attempt surface a clearer error.
+    }
+  }
+
+  function gitShow(branch, path) {
+    const ref = `origin/${branch}:${path}`;
+    return execSync(`git -C "${repoRoot}" show "${ref}"`, {
+      encoding: 'utf8',
+      timeout: SHOW_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+
+  return {
+    readFile(branch, path) {
+      const key = cacheKey(branch, path);
+      if (cache.has(key)) {
+        hits++;
+        return cache.get(key);
+      }
+      misses++;
+
+      let content;
+      try {
+        content = gitShow(branch, path);
+      } catch (err) {
+        // First attempt failed — try fetching the branch, then retry once.
+        fetchBranch(branch);
+        try {
+          content = gitShow(branch, path);
+        } catch (err2) {
+          throw new Error(
+            `branch-file-reader: cannot read origin/${branch}:${path} from ${repoRoot} — ${err2.message?.slice(0, 200) || err2}`
+          );
+        }
+      }
+      cache.set(key, content);
+      return content;
+    },
+    stats() {
+      return { hits, misses, size: cache.size };
+    },
+  };
+}

--- a/tests/unit/branch-file-reader.test.js
+++ b/tests/unit/branch-file-reader.test.js
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for branch-file-reader.
+ * SD: SD-LEO-INFRA-FIX-GATE-FILE-001
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync as realExecSync } from 'child_process';
+
+let execSyncMock;
+
+vi.mock('child_process', () => ({
+  execSync: (...args) => execSyncMock(...args),
+}));
+
+async function importModule() {
+  vi.resetModules();
+  return import('../../scripts/modules/handoff/lib/branch-file-reader.js');
+}
+
+describe('branch-file-reader', () => {
+  beforeEach(() => {
+    execSyncMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads file contents via git show origin/<branch>:<path>', async () => {
+    execSyncMock.mockReturnValue('file contents from origin');
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/repos/ehg');
+    const content = reader.readFile('feat/some-branch', 'src/App.tsx');
+    expect(content).toBe('file contents from origin');
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const call = execSyncMock.mock.calls[0][0];
+    expect(call).toContain('git -C');
+    expect(call).toContain('show "origin/feat/some-branch:src/App.tsx"');
+  });
+
+  it('caches repeat reads for same (branch, path)', async () => {
+    execSyncMock.mockReturnValue('cached contents');
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/repos/ehg');
+    reader.readFile('feat/x', 'src/A.tsx');
+    reader.readFile('feat/x', 'src/A.tsx');
+    reader.readFile('feat/x', 'src/A.tsx');
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const s = reader.stats();
+    expect(s.hits).toBe(2);
+    expect(s.misses).toBe(1);
+    expect(s.size).toBe(1);
+  });
+
+  it('does not cache across different paths', async () => {
+    execSyncMock.mockReturnValue('contents');
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/repos/ehg');
+    reader.readFile('feat/x', 'src/A.tsx');
+    reader.readFile('feat/x', 'src/B.tsx');
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries with git fetch when first show fails', async () => {
+    execSyncMock.mockImplementationOnce(() => { throw new Error('unknown ref'); });
+    execSyncMock.mockImplementationOnce(() => ''); // fetch succeeds
+    execSyncMock.mockImplementationOnce(() => 'contents after fetch');
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/repos/ehg');
+    const content = reader.readFile('feat/new', 'src/C.tsx');
+    expect(content).toBe('contents after fetch');
+    expect(execSyncMock).toHaveBeenCalledTimes(3);
+    const fetchCall = execSyncMock.mock.calls[1][0];
+    expect(fetchCall).toContain('fetch origin feat/new');
+  });
+
+  it('throws with clear error when both show attempts fail', async () => {
+    execSyncMock.mockImplementation(() => { throw new Error('fatal: bad revision'); });
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/repos/ehg');
+    expect(() => reader.readFile('nonexistent', 'f.txt')).toThrow(/cannot read origin\/nonexistent:f\.txt/);
+  });
+
+  it('uses repoRoot in git -C argument', async () => {
+    execSyncMock.mockReturnValue('x');
+    const { createBranchFileReader } = await importModule();
+    const reader = createBranchFileReader('/custom/path');
+    reader.readFile('br', 'p.js');
+    expect(execSyncMock.mock.calls[0][0]).toContain('git -C "/custom/path"');
+  });
+});

--- a/tests/unit/handoff/cross-repo-build-check-branch-aware.test.js
+++ b/tests/unit/handoff/cross-repo-build-check-branch-aware.test.js
@@ -1,0 +1,149 @@
+/**
+ * Regression tests for SD-LEO-INFRA-FIX-GATE-FILE-001 Phase 2.
+ *
+ * Verifies the branch-aware path of `cross-repo-build-check`:
+ *   - With a branch option, build runs in a disposable worktree created from
+ *     origin/<branch> (not the shared ehg checkout).
+ *   - Temp worktree is removed via `git worktree remove --force` on both pass
+ *     and fail (finally-block cleanup).
+ *   - Without a branch option, legacy shared-checkout behavior is preserved.
+ *   - Auth-pattern escalation (shouldForceCheck) is unchanged.
+ *
+ * Addresses the bug class where gates read from the shared checkout and
+ * false-pass / false-fail when parallel sessions toggle its branch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+let execSyncMock;
+let existsSyncMock;
+let mkdtempSyncMock;
+let rmSyncMock;
+
+vi.mock('child_process', () => ({
+  execSync: (...args) => execSyncMock(...args),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: (...args) => existsSyncMock(...args),
+  mkdtempSync: (...args) => mkdtempSyncMock(...args),
+  rmSync: (...args) => rmSyncMock(...args),
+}));
+
+vi.mock('../../../lib/multi-repo/index.js', () => ({
+  getPrimaryRepos: () => ({ ehg: { path: '/repos/ehg' } }),
+}));
+
+async function importModule() {
+  vi.resetModules();
+  return import('../../../lib/gates/cross-repo-build-check.js');
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+function stubFsDefaults() {
+  existsSyncMock = vi.fn().mockReturnValue(true);
+  mkdtempSyncMock = vi.fn().mockReturnValue('/tmp/ehg-build-abc123');
+  rmSyncMock = vi.fn();
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+describe('cross-repo-build-check branch-aware path (SD-LEO-INFRA-FIX-GATE-FILE-001)', () => {
+  beforeEach(() => {
+    stubFsDefaults();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('with { branch } creates a temp worktree from origin/<branch> and builds there', async () => {
+    const calls = [];
+    execSyncMock = vi.fn((cmd, opts) => {
+      calls.push({ cmd, cwd: opts?.cwd });
+      return 'build ok';
+    });
+
+    const { checkEhgBuild } = await importModule();
+    const result = checkEhgBuild({ branch: 'feat/SD-X-001', timeout: 5000 });
+
+    expect(result.pass).toBe(true);
+    // Verify the command sequence: fetch → worktree add → build (in temp dir) → worktree remove
+    expect(calls[0].cmd).toMatch(/git -C "\/repos\/ehg" fetch origin feat\/SD-X-001/);
+    expect(calls[1].cmd).toMatch(/git -C "\/repos\/ehg" worktree add --detach ".*ehg-build-abc123" origin\/feat\/SD-X-001/);
+    expect(calls[2].cmd).toBe('npm run build');
+    expect(calls[2].cwd).toBe('/tmp/ehg-build-abc123');
+    expect(calls[3].cmd).toMatch(/git -C "\/repos\/ehg" worktree remove --force ".*ehg-build-abc123"/);
+  });
+
+  it('cleans up the temp worktree even when the build fails', async () => {
+    const err = Object.assign(new Error('build failed'), { stderr: 'tsc error' });
+    execSyncMock = vi.fn((cmd) => {
+      if (cmd === 'npm run build') throw err;
+      return '';
+    });
+
+    const { checkEhgBuild } = await importModule();
+    const result = checkEhgBuild({ branch: 'feat/SD-X-001' });
+
+    expect(result.pass).toBe(false);
+    // worktree remove MUST still be called in the finally block
+    const removed = execSyncMock.mock.calls.some(([cmd]) => /worktree remove --force/.test(cmd));
+    expect(removed).toBe(true);
+  });
+
+  it('falls back to rmSync if `git worktree remove` fails (defensive cleanup)', async () => {
+    execSyncMock = vi.fn((cmd) => {
+      if (/worktree remove/.test(cmd)) throw new Error('worktree locked');
+      if (cmd === 'npm run build') return 'build ok';
+      return '';
+    });
+
+    const { checkEhgBuild } = await importModule();
+    checkEhgBuild({ branch: 'feat/SD-X-001' });
+
+    expect(rmSyncMock).toHaveBeenCalledWith('/tmp/ehg-build-abc123', { recursive: true, force: true });
+  });
+
+  it('without { branch } builds in the shared checkout (legacy path, no worktree)', async () => {
+    const calls = [];
+    execSyncMock = vi.fn((cmd, opts) => {
+      calls.push({ cmd, cwd: opts?.cwd });
+      return 'build ok';
+    });
+
+    const { checkEhgBuild } = await importModule();
+    const result = checkEhgBuild();
+
+    expect(result.pass).toBe(true);
+    expect(mkdtempSyncMock).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ cmd: 'npm run build', cwd: '/repos/ehg' });
+  });
+
+  it('shouldForceCheck detects auth-pattern files (advisory → required escalation)', async () => {
+    const { shouldForceCheck } = await importModule();
+    expect(shouldForceCheck(['src/lib/authedFetch.ts'])).toBe(true);
+    expect(shouldForceCheck(['src/session/login.ts'])).toBe(true);
+    expect(shouldForceCheck(['README.md', 'src/components/Foo.tsx'])).toBe(false);
+    expect(shouldForceCheck([])).toBe(false);
+    expect(shouldForceCheck(undefined)).toBe(false);
+  });
+
+  it('createCrossRepoBuildGate routes the resolved SD branch into checkEhgBuild', async () => {
+    const calls = [];
+    // branch lookup returns feat/SD-Y-001, then build/cleanup
+    execSyncMock = vi.fn((cmd, opts) => {
+      calls.push({ cmd, cwd: opts?.cwd });
+      if (/branch -r/.test(cmd)) return '  origin/main\n  origin/feat/SD-Y-001\n';
+      if (cmd === 'npm run build') return 'build ok';
+      return '';
+    });
+
+    const { createCrossRepoBuildGate } = await importModule();
+    const gate = createCrossRepoBuildGate();
+    const result = await gate.validator({ sd: { sd_key: 'SD-Y-001' } });
+
+    expect(result.pass).toBe(true);
+    // Must have used the temp worktree (legacy path would not call git worktree add)
+    const usedWorktree = execSyncMock.mock.calls.some(([cmd]) => /worktree add --detach/.test(cmd));
+    expect(usedWorktree).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the bug class where LEO handoff gates read SD artifact contents from the shared EHG checkout (whose branch is controlled by parallel sessions) instead of from `origin/<sd_branch>`. The old behavior forced `--bypass-validation` on every cross-repo SD that touched EHG UI, masking real gate signal and normalizing bypass as an escape hatch.

## What changed

**Phase 1 — helper + UI_INTERACTIVITY_CHECK migration** (`226ff82a51`)
- New `scripts/modules/handoff/lib/branch-file-reader.js`: `createBranchFileReader(repoRoot).readFile(branch, path)` wraps `git show origin/<branch>:<path>` with a per-instance cache and a fetch-then-retry fallback.
- `ui-interactivity-check.js`: replaces `fs.readFileSync(path.join(EHG_REPO_PATH, file))` with the helper. Gate verdicts now depend on origin/<sd_branch>, independent of the shared checkout state.
- `tests/unit/branch-file-reader.test.js`: 6 tests covering read, cache, fetch-retry, error, and repoRoot plumbing. All pass.

**Phase 2 — CROSS_REPO_BUILD_CHECK temp-worktree refactor** (`9b263e7676`)
- `lib/gates/cross-repo-build-check.js`: when an SD branch is resolvable from `ctx.sd.sd_key`, the build runs in a disposable worktree created via `git worktree add --detach <tmp> origin/<branch>`, with `git worktree remove --force` cleanup in `finally` (rmSync fallback for orphans). Falls back to legacy shared-checkout path when no SD branch is found, preserving advisory-only semantics.
- `resolveSdBranch(ctx)` helper probes `feat/<sdKey>` then `fix/<sdKey>` in origin.

## Scope correction

SD description claimed "3+ gates" affected. Discovery found only 1 confirmed (`ui-interactivity-check.js`) and 1 similar-class (`cross-repo-build-check.js`). Other gates named in the plan file (`heal-before-complete.js`, `acceptance-criteria-validation.js`, `git-commit-enforcement.js`, `design-agent-diff.js`) either don't use EHG_REPO_PATH directly (`heal`, `git-commit-enforcement`), are DB-only (`acceptance-criteria`), or don't exist (`design-agent-diff.js`). Scope recorded in PRD exploration_summary.

## Deferred

- Integration regression test with multi-branch ehg fixture — noted in Phase 2 commit message; requires a test-fixture ehg clone that's out of scope for this PR.
- Brief doc section in handoff-system-guide.md — small enough to roll into the next docs-touching SD.

## Test plan

- [x] vitest run tests/unit/branch-file-reader.test.js → 6/6 pass
- [x] `node --check` on both modified gate files
- [x] Grep confirms no remaining `fs.readFileSync(...EHG_REPO_PATH)` sites in gate code
- [ ] Post-merge: verify next cross-repo SD passes UI_INTERACTIVITY_CHECK without `--bypass-validation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)