### PR TITLE
fix(QF-20260424-001): keep session-tick.cjs daemon alive

### DIFF
--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -145,11 +145,15 @@ writeMarker();
 // Fire the first tick immediately so DB sees a fresh process_alive_at ASAP.
 tickOnce();
 
-// Schedule periodic ticks
+// Schedule periodic ticks.
+// QF-20260424-001: Do NOT unref tickInterval — this setInterval is what keeps
+// the detached daemon's Node event loop alive. If it is unref'd, the process
+// exits ~260ms after the initial tickOnce() fetch resolves, leaving only one
+// heartbeat write. Parent-liveness check (below) handles the exit path.
 const tickInterval = setInterval(() => { tickOnce(); }, TICK_MS);
-tickInterval.unref?.();
 
-// Schedule parent liveness checks
+// Schedule parent liveness checks. Unref is intentional here — the parent
+// poll never holds the loop alive on its own; tickInterval does.
 const parentInterval = setInterval(() => {
   if (!parentAlive()) {
     clearInterval(tickInterval);

--- a/tests/unit/session-tick-heartbeat.test.mjs
+++ b/tests/unit/session-tick-heartbeat.test.mjs
@@ -50,3 +50,18 @@ test('FR-4: claim-guard still keys TTL on heartbeat_at (alignment sanity check)'
   // will fire a reminder to re-check the tick's PATCH body.
   assert.match(guardSrc, /heartbeat_at/);
 });
+
+test('QF-20260424-001: tickInterval is NOT unref\'d so the daemon stays alive', () => {
+  // Regression: both setInterval handles were previously unref'd, causing Node
+  // to exit ~260ms after the initial tickOnce() fetch resolved. Only ONE
+  // heartbeat_at write made it to the DB per spawn; the 30-second periodic
+  // re-tick never fired. This broke claim TTL for every parallel-session
+  // workflow and was the proximate cause of foreign_claim on active work.
+  // The parent-liveness interval MAY be unref'd (it does not need to hold the
+  // loop open), but the tick interval MUST NOT be.
+  assert.doesNotMatch(
+    tickSrc,
+    /tickInterval\.unref\??\.\?\(\)/,
+    'tickInterval.unref()/.unref?.() reintroduces the daemon-exits-early bug'
+  );
+});


### PR DESCRIPTION
## Summary

- Remove `.unref?.()` from the 30-second tick interval in `scripts/session-tick.cjs`. The daemon was exiting in ~260ms because neither of its two `setInterval` handles held the event loop alive after the initial `tickOnce()` fetch resolved.
- Only ONE heartbeat_at / process_alive_at write made it to the DB per spawn, causing claim-guard's 300-second stale threshold to expire silently and leaving parallel sessions free to reclaim active SDs.
- Add a regression assertion in `tests/unit/session-tick-heartbeat.test.mjs` that greps the source to prevent reintroduction of `tickInterval.unref()`.

## Evidence

**Before fix** (measured from main):
```
START=$(date +%s%N); CLAUDE_SESSION_ID=diag CC_PARENT_PID=$$ \
  node --require dotenv/config scripts/session-tick.cjs
# exit=0 elapsed_ms=260
```

**After fix** (measured from this branch, with a real long-lived `CC_PARENT_PID`):
- Daemon survives ≥7 seconds (limited only by explicit `kill` in test harness).
- Parent-liveness check still runs every 5 seconds via `parentInterval` and exits cleanly on `ESRCH`.

## Discovery Context

Found during SD-LEO-INFRA-FEEDBACK-PIPELINE-HEALTH-001 LEAD phase. A parallel session (`d45cea4c-daff-4f27-b695-2e88edabff2c`) reclaimed my SD at `00:41:11` after my tick daemon (PID 47880) died silently shortly after `sd-start` spawned it. Further investigation showed the daemon consistently exits at ~260ms regardless of spawn method (capture-session-id hook, spawn-tick-canonical.mjs, or direct invocation). Root cause: both `tickInterval` and `parentInterval` are `.unref?.()`'d at module top-level, leaving Node with no active handles once the first fetch resolves.

## Test plan

- [x] Run existing FR-4 unit tests (all pass)
- [x] Run new QF-20260424-001 unit assertion (passes)
- [x] Empirical: daemon survives 7s+ with real claude.exe parent PID
- [ ] Post-merge: verify next SD claim survives beyond 5 minutes without manual heartbeat bumps

## Rollback

Revert the 10-line change to `scripts/session-tick.cjs`. No schema, no dependencies, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)