### PR TITLE
fix(SD-MAN-INFRA-WIRE-CHECK-GATE-001): extend EXCLUSION_PATTERNS to cover test/ singular + nested tests?/

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -26,15 +26,22 @@ const GATE_NAME = 'WIRE_CHECK_GATE';
  * runtime entry point by design — exclude them from the reachability check
  * so co-located tests do not false-positive PAT-AUTO-855d11b1.
  *
- * Patterns are canonical only (*.test.ext, *.spec.ext, __tests__/, tests/);
+ * SD-MAN-INFRA-WIRE-CHECK-GATE-001 extension: broadened the tests?/ rule to
+ * cover both singular `test/` (used by this repo under `test/eva/experiments/`)
+ * and nested `tests/` paths (e.g. `scripts/archive/one-time/tests/`), since
+ * the previous `^tests/` anchor missed those entirely.
+ *
+ * Patterns are canonical only (*.test.ext, *.spec.ext, __tests__/, test/, tests/);
  * intentionally NOT matching *.test-* or similar variants to avoid
  * over-matching production files (mitigation for TS-7 negative control).
+ * The `(^|\/)tests?\/` form requires a directory-boundary, so `lib/testing/`
+ * and `scripts/test-helpers.js` do NOT match.
  */
 export const EXCLUSION_PATTERNS = [
   /\.test\.(js|mjs|cjs|jsx|tsx)$/,
   /\.spec\.(js|mjs|cjs|jsx|tsx)$/,
   /(^|\/)__tests__\//,
-  /^tests\//
+  /(^|\/)tests?\//
 ];
 
 /**

--- a/tests/unit/handoff/wire-check-gate.test.js
+++ b/tests/unit/handoff/wire-check-gate.test.js
@@ -37,12 +37,31 @@ describe('EXCLUSION_PATTERNS (FR-1)', () => {
     expect(isExcludedFromWireCheck('tests/unit/handoff/foo.js')).toBe(true);
   });
 
+  // SD-MAN-INFRA-WIRE-CHECK-GATE-001: extend coverage to singular test/ and nested tests/
+  it('matches top-level singular test/ directory (TS-3 canonical extension)', () => {
+    expect(isExcludedFromWireCheck('test/unit/bias-detection.test.js')).toBe(true);
+    expect(isExcludedFromWireCheck('test/eva/experiments/chairman-report.test.js')).toBe(true);
+  });
+
+  it('matches nested tests/ directories below lib/ or scripts/ (TS-5 nested coverage)', () => {
+    expect(isExcludedFromWireCheck('scripts/archive/one-time/tests/test-aegis-adapters.js')).toBe(true);
+    expect(isExcludedFromWireCheck('lib/feature/tests/util.js')).toBe(true);
+  });
+
+  it('matches nested singular test/ directories (TS-6 nested singular)', () => {
+    expect(isExcludedFromWireCheck('scripts/module/test/helper.js')).toBe(true);
+  });
+
   it('does NOT match production files with test-like substrings (TS-7 risk guard)', () => {
     // Production files named like `test-helpers.js` or `.test-fixtures.js` must NOT be excluded —
     // the PRD risk section explicitly forbids this over-match.
     expect(isExcludedFromWireCheck('scripts/x/test-helpers.js')).toBe(false);
     expect(isExcludedFromWireCheck('lib/testing/foo.js')).toBe(false);
     expect(isExcludedFromWireCheck('scripts/mytest.js')).toBe(false);
+    // SD-MAN-INFRA-WIRE-CHECK-GATE-001 guardrails: directory name must be exactly
+    // `test` or `tests` — close substrings must not trigger the extended pattern.
+    expect(isExcludedFromWireCheck('scripts/integration-test-setup.js')).toBe(false);
+    expect(isExcludedFromWireCheck('lib/tester/foo.js')).toBe(false);
   });
 
   it('exports EXCLUSION_PATTERNS as a regex list (per TR-2 declarative requirement)', () => {


### PR DESCRIPTION
## Summary
- Extends the EXCLUSION_PATTERNS regex shipped in [#3273](https://github.com/rickfelix/EHG_Engineer/pull/3273) (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-127 FR-1) from `^tests\/` to `(^|\/)tests?\/`, covering two real false-positive surfaces that the original anchor missed:
  - Top-level `test/` directory (singular) — 5+ real files in `test/eva/experiments/` and `test/unit/`
  - Nested `tests/` paths below `lib/` or `scripts/` (e.g. `scripts/archive/one-time/tests/*`)
- Adds 3 new assertions to `tests/unit/handoff/wire-check-gate.test.js`:
  - `test/` singular at repo root
  - Nested `tests/` directories
  - Nested singular `test/` directories
- Extends TS-7 negative-control to prove `integration-test-setup.js` and `lib/tester/` still pass through (the new regex does not over-match).

## Scope
Additive only: 1 regex widened, 3 tests added, 6 lines of comment updated. Existing 9 wire-check-gate tests unchanged and still pass. Net change: +28 / -2.

## Test plan
- [x] `npx vitest run tests/unit/handoff/wire-check-gate.test.js` — 12/12 pass (9 pre-existing + 3 new)
- [x] Broader `tests/unit/handoff/` regression — 474/476 pass; 1 failure is pre-existing in `orchestrator-completion-hook.test.js` (verified on origin/main before changes), unrelated to this SD.
- [x] Negative control: `scripts/integration-test-setup.js`, `scripts/x/test-helpers.js`, `lib/testing/foo.js`, `lib/tester/foo.js` all still pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)