### PR TITLE
fix(QF-20260423-000): bypass-detector handles multi-chain handoff histories

### DIFF
--- a/scripts/modules/bypass-detection-validator.js
+++ b/scripts/modules/bypass-detection-validator.js
@@ -125,82 +125,58 @@ async function validateSDTimeline(sdId, supabase) {
     console.warn(`Failed to fetch retrospectives for ${sdId}: ${retroError.message}`);
   }
 
-  // Build timestamp map for handoffs
-  const handoffTimestamps = {};
+  // Quick-fix QF-20260423-000: Group handoffs by type preserving all chains.
+  // An SD may have 2+ complete handoff chains (e.g. infrastructure SDs that re-handoff
+  // post-merge). The previous handoff_type-keyed map collapsed multi-chain histories
+  // and produced false positives by pairing Chain 1 artifacts with Chain 2 prerequisites.
+  const handoffsByType = {};
   for (const handoff of handoffs || []) {
-    handoffTimestamps[handoff.handoff_type] = {
+    if (!handoffsByType[handoff.handoff_type]) handoffsByType[handoff.handoff_type] = [];
+    handoffsByType[handoff.handoff_type].push({
       id: handoff.id,
       created_at: new Date(handoff.created_at).getTime(),
       accepted_at: handoff.accepted_at ? new Date(handoff.accepted_at).getTime() : null
-    };
+    });
   }
 
-  // Validate EXEC-TO-PLAN after PLAN-TO-EXEC
-  if (handoffTimestamps['EXEC-TO-PLAN'] && handoffTimestamps['PLAN-TO-EXEC']) {
-    const execToPlan = handoffTimestamps['EXEC-TO-PLAN'];
-    const planToExec = handoffTimestamps['PLAN-TO-EXEC'];
+  // Chain-aware pairing: for each artifact, a bypass exists only when NO accepted
+  // prerequisite of the required type predates the artifact (within skew tolerance).
+  const TIMELINE_RULES = [
+    { artifactType: 'EXEC-TO-PLAN',        prereqType: 'PLAN-TO-EXEC', artifactKey: 'handoff_exec_to_plan' },
+    { artifactType: 'PLAN-TO-LEAD',        prereqType: 'EXEC-TO-PLAN', artifactKey: 'handoff_plan_to_lead' },
+    { artifactType: 'LEAD-FINAL-APPROVAL', prereqType: 'PLAN-TO-LEAD', artifactKey: 'handoff_lead_final_approval' }
+  ];
 
-    // Grandfather clause: Skip artifacts created before bypass detection deployment
-    if (execToPlan.created_at < BYPASS_DETECTION_DEPLOYMENT_DATE) {
-      // Skip - artifact predates bypass detection rules
-    } else if (planToExec.accepted_at && execToPlan.created_at < planToExec.accepted_at - CLOCK_SKEW_TOLERANCE_MS) {
-      findings.push({
-        sd_id: sdId,
-        artifact_type: 'handoff_exec_to_plan',
-        artifact_id: execToPlan.id,
-        artifact_timestamp: new Date(execToPlan.created_at).toISOString(),
-        expected_min_timestamp: new Date(planToExec.accepted_at - CLOCK_SKEW_TOLERANCE_MS).toISOString(),
-        prerequisite_type: 'PLAN-TO-EXEC',
-        prerequisite_timestamp: new Date(planToExec.accepted_at).toISOString(),
-        time_delta_seconds: Math.round((planToExec.accepted_at - execToPlan.created_at) / 1000),
-        failure_category: 'bypass'
-      });
-    }
-  }
+  for (const rule of TIMELINE_RULES) {
+    const artifacts = handoffsByType[rule.artifactType] || [];
+    const prereqs = handoffsByType[rule.prereqType] || [];
+    if (prereqs.length === 0) continue; // No prerequisite rows exist — no pairing possible
 
-  // Validate PLAN-TO-LEAD after EXEC-TO-PLAN
-  if (handoffTimestamps['PLAN-TO-LEAD'] && handoffTimestamps['EXEC-TO-PLAN']) {
-    const planToLead = handoffTimestamps['PLAN-TO-LEAD'];
-    const execToPlan = handoffTimestamps['EXEC-TO-PLAN'];
+    for (const artifact of artifacts) {
+      // Grandfather clause: skip artifacts created before bypass detection deployment
+      if (artifact.created_at < BYPASS_DETECTION_DEPLOYMENT_DATE) continue;
 
-    // Grandfather clause: Skip artifacts created before bypass detection deployment
-    if (planToLead.created_at < BYPASS_DETECTION_DEPLOYMENT_DATE) {
-      // Skip - artifact predates bypass detection rules
-    } else if (execToPlan.accepted_at && planToLead.created_at < execToPlan.accepted_at - CLOCK_SKEW_TOLERANCE_MS) {
-      findings.push({
-        sd_id: sdId,
-        artifact_type: 'handoff_plan_to_lead',
-        artifact_id: planToLead.id,
-        artifact_timestamp: new Date(planToLead.created_at).toISOString(),
-        expected_min_timestamp: new Date(execToPlan.accepted_at - CLOCK_SKEW_TOLERANCE_MS).toISOString(),
-        prerequisite_type: 'EXEC-TO-PLAN',
-        prerequisite_timestamp: new Date(execToPlan.accepted_at).toISOString(),
-        time_delta_seconds: Math.round((execToPlan.accepted_at - planToLead.created_at) / 1000),
-        failure_category: 'bypass'
-      });
-    }
-  }
+      // Accepted prerequisite is valid when accepted_at <= artifact.created_at + skew tolerance
+      const validPrereq = prereqs.find(p => p.accepted_at !== null &&
+        p.accepted_at <= artifact.created_at + CLOCK_SKEW_TOLERANCE_MS);
 
-  // Validate LEAD-FINAL-APPROVAL after PLAN-TO-LEAD
-  if (handoffTimestamps['LEAD-FINAL-APPROVAL'] && handoffTimestamps['PLAN-TO-LEAD']) {
-    const leadFinal = handoffTimestamps['LEAD-FINAL-APPROVAL'];
-    const planToLead = handoffTimestamps['PLAN-TO-LEAD'];
-
-    // Grandfather clause: Skip artifacts created before bypass detection deployment
-    if (leadFinal.created_at < BYPASS_DETECTION_DEPLOYMENT_DATE) {
-      // Skip - artifact predates bypass detection rules
-    } else if (planToLead.accepted_at && leadFinal.created_at < planToLead.accepted_at - CLOCK_SKEW_TOLERANCE_MS) {
-      findings.push({
-        sd_id: sdId,
-        artifact_type: 'handoff_lead_final_approval',
-        artifact_id: leadFinal.id,
-        artifact_timestamp: new Date(leadFinal.created_at).toISOString(),
-        expected_min_timestamp: new Date(planToLead.accepted_at - CLOCK_SKEW_TOLERANCE_MS).toISOString(),
-        prerequisite_type: 'PLAN-TO-LEAD',
-        prerequisite_timestamp: new Date(planToLead.accepted_at).toISOString(),
-        time_delta_seconds: Math.round((planToLead.accepted_at - leadFinal.created_at) / 1000),
-        failure_category: 'bypass'
-      });
+      if (!validPrereq) {
+        // Bypass: no accepted prerequisite exists on or before this artifact's creation.
+        // Use earliest prerequisite accepted_at for the error message.
+        const earliestPrereq = prereqs.find(p => p.accepted_at !== null);
+        if (!earliestPrereq) continue; // No accepted prerequisite at all — nothing to compare
+        findings.push({
+          sd_id: sdId,
+          artifact_type: rule.artifactKey,
+          artifact_id: artifact.id,
+          artifact_timestamp: new Date(artifact.created_at).toISOString(),
+          expected_min_timestamp: new Date(earliestPrereq.accepted_at - CLOCK_SKEW_TOLERANCE_MS).toISOString(),
+          prerequisite_type: rule.prereqType,
+          prerequisite_timestamp: new Date(earliestPrereq.accepted_at).toISOString(),
+          time_delta_seconds: Math.round((earliestPrereq.accepted_at - artifact.created_at) / 1000),
+          failure_category: 'bypass'
+        });
+      }
     }
   }
 

--- a/tests/unit/validators/bypass-detection-validator.test.js
+++ b/tests/unit/validators/bypass-detection-validator.test.js
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for bypass-detection-validator::validateSDTimeline
+ *
+ * QF-20260423-000: Covers the multi-chain false-positive fix.
+ *
+ * Scenario motivation: infrastructure SDs re-handoff after PR merge per
+ * "Shipping != Completing an SD". A single SD can therefore have 2+ complete
+ * accepted chains of the same handoff types. The previous map-by-type logic
+ * paired Chain 1 artifacts with Chain 2 prerequisites and false-flagged them.
+ * The chain-aware pairing should recognize that an earlier artifact has its
+ * own earlier prerequisite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateSDTimeline } from '../../../scripts/modules/bypass-detection-validator.js';
+
+// Post-grandfather-date timestamps (BYPASS_DETECTION_DEPLOYMENT_DATE = 2026-02-01)
+const T = (iso) => new Date(iso).toISOString();
+
+function makeSupabaseMock(handoffs, retros = []) {
+  return {
+    from(table) {
+      const rowsForTable = table === 'sd_phase_handoffs' ? handoffs : retros;
+      let rows = rowsForTable;
+      const chain = {
+        select() { return chain; },
+        eq(_col, _val) { return chain; },
+        order() { return Promise.resolve({ data: rows, error: null }); }
+      };
+      return chain;
+    }
+  };
+}
+
+function makeHandoff({ id, type, createdAt, acceptedAt }) {
+  return {
+    id,
+    sd_id: 'test-sd',
+    handoff_type: type,
+    status: 'accepted',
+    created_at: T(createdAt),
+    accepted_at: acceptedAt ? T(acceptedAt) : null
+  };
+}
+
+describe('bypass-detection-validator: chain-aware pairing (QF-20260423-000)', () => {
+  it('returns zero findings for a single well-ordered chain', async () => {
+    const handoffs = [
+      makeHandoff({ id: 'h1', type: 'LEAD-TO-PLAN', createdAt: '2026-04-24T00:50:00Z', acceptedAt: '2026-04-24T00:51:00Z' }),
+      makeHandoff({ id: 'h2', type: 'PLAN-TO-EXEC', createdAt: '2026-04-24T00:57:00Z', acceptedAt: '2026-04-24T00:58:00Z' }),
+      makeHandoff({ id: 'h3', type: 'EXEC-TO-PLAN', createdAt: '2026-04-24T01:06:00Z', acceptedAt: '2026-04-24T01:07:00Z' }),
+      makeHandoff({ id: 'h4', type: 'PLAN-TO-LEAD', createdAt: '2026-04-24T01:08:00Z', acceptedAt: '2026-04-24T01:09:00Z' })
+    ];
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock(handoffs));
+    expect(findings).toEqual([]);
+  });
+
+  it('returns zero findings for two complete chains (multi-chain regression)', async () => {
+    // Chain 1: original work
+    // Chain 2: post-merge re-handoff (common for infrastructure SDs)
+    const handoffs = [
+      // Chain 1
+      makeHandoff({ id: 'c1-lead-plan',   type: 'LEAD-TO-PLAN', createdAt: '2026-04-24T00:50:00Z', acceptedAt: '2026-04-24T00:51:00Z' }),
+      makeHandoff({ id: 'c1-plan-exec',   type: 'PLAN-TO-EXEC', createdAt: '2026-04-24T00:57:00Z', acceptedAt: '2026-04-24T00:58:00Z' }),
+      makeHandoff({ id: 'c1-exec-plan',   type: 'EXEC-TO-PLAN', createdAt: '2026-04-24T01:06:00Z', acceptedAt: '2026-04-24T01:07:00Z' }),
+      makeHandoff({ id: 'c1-plan-lead',   type: 'PLAN-TO-LEAD', createdAt: '2026-04-24T01:08:00Z', acceptedAt: '2026-04-24T01:09:00Z' }),
+      // Chain 2 (starts 18 minutes after chain 1 finishes)
+      makeHandoff({ id: 'c2-lead-plan',   type: 'LEAD-TO-PLAN', createdAt: '2026-04-24T01:26:00Z', acceptedAt: '2026-04-24T01:26:30Z' }),
+      makeHandoff({ id: 'c2-plan-exec',   type: 'PLAN-TO-EXEC', createdAt: '2026-04-24T01:26:40Z', acceptedAt: '2026-04-24T01:26:45Z' }),
+      makeHandoff({ id: 'c2-exec-plan',   type: 'EXEC-TO-PLAN', createdAt: '2026-04-24T01:27:50Z', acceptedAt: '2026-04-24T01:27:52Z' }),
+      makeHandoff({ id: 'c2-plan-lead',   type: 'PLAN-TO-LEAD', createdAt: '2026-04-24T01:28:10Z', acceptedAt: '2026-04-24T01:28:15Z' })
+    ];
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock(handoffs));
+    expect(findings).toEqual([]);
+  });
+
+  it('flags a real bypass: PLAN-TO-LEAD created before any EXEC-TO-PLAN is accepted', async () => {
+    // Only PLAN-TO-LEAD exists, no prerequisite EXEC-TO-PLAN at all — genuine bypass.
+    const handoffs = [
+      makeHandoff({ id: 'h1', type: 'EXEC-TO-PLAN', createdAt: '2026-04-24T02:00:00Z', acceptedAt: '2026-04-24T02:00:30Z' }),
+      makeHandoff({ id: 'h2', type: 'PLAN-TO-LEAD', createdAt: '2026-04-24T01:58:00Z', acceptedAt: '2026-04-24T01:58:30Z' })
+    ];
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock(handoffs));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].artifact_type).toBe('handoff_plan_to_lead');
+    expect(findings[0].artifact_id).toBe('h2');
+    expect(findings[0].failure_category).toBe('bypass');
+  });
+
+  it('allows artifact within 60-second clock skew tolerance', async () => {
+    // PLAN-TO-LEAD created 30 seconds before EXEC-TO-PLAN accepted_at — within skew.
+    const handoffs = [
+      makeHandoff({ id: 'e1', type: 'EXEC-TO-PLAN', createdAt: '2026-04-24T03:00:00Z', acceptedAt: '2026-04-24T03:00:00Z' }),
+      makeHandoff({ id: 'p1', type: 'PLAN-TO-LEAD', createdAt: '2026-04-24T02:59:30Z', acceptedAt: '2026-04-24T03:00:30Z' })
+    ];
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock(handoffs));
+    expect(findings).toEqual([]);
+  });
+
+  it('skips grandfathered artifacts (pre-2026-02-01 deployment)', async () => {
+    // Artifact is before the bypass-detection deployment date → should be skipped.
+    const handoffs = [
+      makeHandoff({ id: 'e1', type: 'EXEC-TO-PLAN', createdAt: '2026-01-20T00:00:00Z', acceptedAt: '2026-01-20T00:05:00Z' }),
+      makeHandoff({ id: 'p1', type: 'PLAN-TO-LEAD', createdAt: '2026-01-15T00:00:00Z', acceptedAt: '2026-01-15T00:01:00Z' })
+    ];
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock(handoffs));
+    expect(findings).toEqual([]);
+  });
+
+  it('returns empty findings when no handoffs exist', async () => {
+    const findings = await validateSDTimeline('test-sd', makeSupabaseMock([]));
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a false-positive in `scripts/modules/bypass-detection-validator.js` that was blocking CI on infrastructure SDs with legitimate multi-chain handoff histories (first surfaced on PR #3277 / SD-LEO-INFRA-FEEDBACK-PIPELINE-HEALTH-001).

**Root cause** (RCA 92% confidence): the validator keyed a `handoff_type` map that collapsed multi-chain histories. Infrastructure SDs legitimately re-handoff after PR merge per the "Shipping ≠ Completing an SD" pattern, creating 2+ accepted rows of the same handoff_type. The earliest artifact of each type was paired with the latest prerequisite of the next type, producing a false-positive negative-timedelta finding.

**Fix**: chain-aware pairing — for each artifact, search for **any** accepted prerequisite whose `accepted_at` is on or before `artifact.created_at` (within 60s clock skew tolerance). Flag as bypass only when no such prerequisite exists.

Net validator size: -24 LOC (simplification + DRY).

## Test plan

- [x] 6 regression unit tests in `tests/unit/validators/bypass-detection-validator.test.js`:
  - Single well-ordered chain → 0 findings
  - Two complete chains (the actual regression) → 0 findings
  - Genuine bypass (no prerequisite) → 1 finding
  - Within 60s skew tolerance → 0 findings
  - Grandfathered pre-2026-02-01 artifact → 0 findings
  - Empty handoffs → 0 findings
- [x] Live verification: `node scripts/modules/bypass-detection-validator.js --sd=879cfa7b-...` → 0 findings (previously 1 false positive)
- [ ] CI runs the `LEO Protocol Bypass Detection` workflow → should now pass on this PR

## LEO Protocol trail

- Filed via `/quick-fix` after RCA on CI failure from PR #3277
- Routing: Tier 2 QF (50 LOC estimated, ~50 actual in validator)
- RCA agent invoked per `feedback_rca_agent_mandatory_on_any_issue.md` (new memory 2026-04-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)