### PR TITLE
fix(QF-20260423-200): handoff executor surfaces diagnostic info on uncaught exceptions

### DIFF
--- a/scripts/modules/handoff/ResultBuilder.js
+++ b/scripts/modules/handoff/ResultBuilder.js
@@ -58,17 +58,51 @@ export class ResultBuilder {
   }
 
   /**
-   * Create a system error response
+   * Create a system error response.
+   *
+   * QF-20260423-200: Enhanced to surface errorClass, stack frames, and source
+   * step so operators can diagnose uncaught exceptions instead of seeing an
+   * opaque "SYSTEM_ERROR" with empty message. If the error was wrapped with a
+   * structured name (ANALYSIS_SYNTHESIS_FAILED, RUSSIAN_JUDGE_FAILED,
+   * VERIFIER_EXCEPTION), that name is used as the reasonCode — the CLI surfaces
+   * the specific failure step via `REASON=<specific>` instead of generic.
+   *
    * @param {Error|string} error - Error object or message
-   * @returns {object} System error response
+   * @param {string} [sourceStep=null] - Optional hint about which step threw (e.g. 'executeSpecific')
+   * @returns {object} System error response with diagnostic fields
    */
-  static systemError(error) {
-    const message = error instanceof Error ? error.message : String(error);
+  static systemError(error, sourceStep = null) {
+    const isErrorInstance = error instanceof Error;
+    const rawMessage = isErrorInstance ? error.message : String(error);
+    const errorClass = isErrorInstance ? (error.constructor?.name || 'Error') : 'Unknown';
+    const errorName = isErrorInstance ? error.name : null;
+    const stack = isErrorInstance && error.stack
+      ? error.stack.split('\n').slice(0, 10).join('\n')
+      : null;
+
+    // Structured reason codes surface the precise failure step via CLI output
+    const STRUCTURED_NAMES = new Set([
+      'ANALYSIS_SYNTHESIS_FAILED',
+      'RUSSIAN_JUDGE_FAILED',
+      'VERIFIER_EXCEPTION'
+    ]);
+    const reasonCode = (errorName && STRUCTURED_NAMES.has(errorName)) ? errorName : 'SYSTEM_ERROR';
+    const message = rawMessage && rawMessage.length > 0
+      ? rawMessage
+      : `${errorClass} thrown with no message${sourceStep ? ` at ${sourceStep}` : ''}`;
+
     return {
       success: false,
       error: message,
-      reasonCode: 'SYSTEM_ERROR',
-      systemError: true
+      message,
+      errorClass,
+      errorStack: stack,
+      sourceStep: sourceStep || null,
+      reasonCode,
+      systemError: true,
+      remediation: stack
+        ? `Error class: ${errorClass}\nSource step: ${sourceStep || 'executor post-gate path'}\nStack (first 10 frames):\n${stack}`
+        : null
     };
   }
 

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -472,7 +472,13 @@ export class BaseExecutor {
       };
 
     } catch (error) {
-      console.error(`❌ ${this.handoffType} execution error:`, error.message);
+      // QF-20260423-200: Log with full diagnostic context (was: just error.message)
+      const errorClass = error?.constructor?.name || 'Unknown';
+      const errorName = error?.name || errorClass;
+      console.error(`❌ ${this.handoffType} execution error [${errorName}]:`, error?.message || '(no message)');
+      if (error?.stack) {
+        console.error(error.stack.split('\n').slice(0, 5).join('\n'));
+      }
 
       // SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A: Record error in telemetry
       try { endSpan(rootSpan, { result: 'error', error_class: error.constructor?.name, error_message: error.message }); persist(traceCtx, { supabase: this.supabase }); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }
@@ -481,7 +487,7 @@ export class BaseExecutor {
       const failurePhase = this._getSourcePhaseFromHandoff();
       await this._displayOnFailureDirectives(failurePhase);
 
-      return ResultBuilder.systemError(error);
+      return ResultBuilder.systemError(error, 'executeSpecific');
     }
   }
 

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -290,13 +290,34 @@ export class PlanToExecExecutor extends BaseExecutor {
     }
 
     // V03: AnalysisStep — Synthesize prior LEAD phase evaluation data (SD-MAN-GEN-CORRECTIVE-VISION-GAP-010)
-    const analysisStep = await this._synthesizeLeadAnalysis(sdId, sd, prd);
+    // QF-20260423-200: Wrap in diagnostic catch — any exception gets a structured
+    // reason code (ANALYSIS_SYNTHESIS_FAILED) so ResultBuilder.systemError surfaces
+    // the specific failure step in REASON= instead of generic SYSTEM_ERROR.
+    let analysisStep;
+    try {
+      analysisStep = await this._synthesizeLeadAnalysis(sdId, sd, prd);
+    } catch (error) {
+      const wrapped = new Error(`ANALYSIS_SYNTHESIS_FAILED: ${error.message || error.constructor?.name || 'unknown'}`);
+      wrapped.name = 'ANALYSIS_SYNTHESIS_FAILED';
+      wrapped.cause = error;
+      if (error.stack) wrapped.stack = `${wrapped.message}\nCaused by: ${error.stack}`;
+      throw wrapped;
+    }
     if (analysisStep) {
       options._analysisStep = analysisStep;
     }
 
     // AI Quality Assessment (Russian Judge) - PRD & User Stories
-    await this._runRussianJudgeAssessment(prd, sd);
+    // QF-20260423-200: Wrap in diagnostic catch (see above)
+    try {
+      await this._runRussianJudgeAssessment(prd, sd);
+    } catch (error) {
+      const wrapped = new Error(`RUSSIAN_JUDGE_FAILED: ${error.message || error.constructor?.name || 'unknown'}`);
+      wrapped.name = 'RUSSIAN_JUDGE_FAILED';
+      wrapped.cause = error;
+      if (error.stack) wrapped.stack = `${wrapped.message}\nCaused by: ${error.stack}`;
+      throw wrapped;
+    }
 
     // Standard PLAN-to-EXEC verification
     console.log('🔍 Step 2: Standard PLAN→EXEC Verification');
@@ -309,7 +330,16 @@ export class PlanToExecExecutor extends BaseExecutor {
       verificationResult = { success: true, bypassed: true };
     } else {
       const verifier = new PlanToExecVerifier();
-      verificationResult = await verifier.verifyHandoff(sdId, options.prdId);
+      // QF-20260423-200: Wrap in diagnostic catch (see above)
+      try {
+        verificationResult = await verifier.verifyHandoff(sdId, options.prdId);
+      } catch (error) {
+        const wrapped = new Error(`VERIFIER_EXCEPTION: ${error.message || error.constructor?.name || 'unknown'}`);
+        wrapped.name = 'VERIFIER_EXCEPTION';
+        wrapped.cause = error;
+        if (error.stack) wrapped.stack = `${wrapped.message}\nCaused by: ${error.stack}`;
+        throw wrapped;
+      }
 
       if (!verificationResult.success) {
         return verificationResult;

--- a/tests/unit/handoff/result-builder-diagnostic.test.js
+++ b/tests/unit/handoff/result-builder-diagnostic.test.js
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for ResultBuilder.systemError diagnostic enhancements.
+ *
+ * QF-20260423-200: Previously `systemError(error)` returned only
+ * { success: false, error: message, reasonCode: 'SYSTEM_ERROR' }.
+ * Now it also surfaces errorClass, errorStack, sourceStep, and
+ * structured reasonCode (ANALYSIS_SYNTHESIS_FAILED | RUSSIAN_JUDGE_FAILED
+ * | VERIFIER_EXCEPTION) when the error was wrapped by plan-to-exec.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ResultBuilder } from '../../../scripts/modules/handoff/ResultBuilder.js';
+
+describe('ResultBuilder.systemError diagnostic enhancement (QF-20260423-200)', () => {
+  it('returns structured fields from a plain Error', () => {
+    const err = new TypeError('Cannot read properties of undefined');
+    const result = ResultBuilder.systemError(err);
+
+    expect(result.success).toBe(false);
+    expect(result.systemError).toBe(true);
+    expect(result.error).toBe('Cannot read properties of undefined');
+    expect(result.message).toBe('Cannot read properties of undefined');
+    expect(result.errorClass).toBe('TypeError');
+    expect(result.reasonCode).toBe('SYSTEM_ERROR');
+    expect(result.errorStack).toBeTruthy();
+    expect(result.remediation).toContain('TypeError');
+    expect(result.remediation).toContain('Stack');
+  });
+
+  it('surfaces structured reasonCode when error.name is ANALYSIS_SYNTHESIS_FAILED', () => {
+    const err = new Error('ANALYSIS_SYNTHESIS_FAILED: downstream TypeError');
+    err.name = 'ANALYSIS_SYNTHESIS_FAILED';
+    const result = ResultBuilder.systemError(err);
+
+    expect(result.reasonCode).toBe('ANALYSIS_SYNTHESIS_FAILED');
+    expect(result.message).toContain('ANALYSIS_SYNTHESIS_FAILED');
+  });
+
+  it('surfaces structured reasonCode when error.name is RUSSIAN_JUDGE_FAILED', () => {
+    const err = new Error('RUSSIAN_JUDGE_FAILED: model timeout');
+    err.name = 'RUSSIAN_JUDGE_FAILED';
+    expect(ResultBuilder.systemError(err).reasonCode).toBe('RUSSIAN_JUDGE_FAILED');
+  });
+
+  it('surfaces structured reasonCode when error.name is VERIFIER_EXCEPTION', () => {
+    const err = new Error('VERIFIER_EXCEPTION: null chain in PlanToExecVerifier');
+    err.name = 'VERIFIER_EXCEPTION';
+    expect(ResultBuilder.systemError(err).reasonCode).toBe('VERIFIER_EXCEPTION');
+  });
+
+  it('includes sourceStep hint when provided', () => {
+    const err = new Error('thing broke');
+    const result = ResultBuilder.systemError(err, 'executeSpecific');
+    expect(result.sourceStep).toBe('executeSpecific');
+    expect(result.remediation).toContain('executeSpecific');
+  });
+
+  it('fills message when error has empty message (previously opaque)', () => {
+    const err = new TypeError('');
+    const result = ResultBuilder.systemError(err, 'executeSpecific');
+    expect(result.message).toBe('TypeError thrown with no message at executeSpecific');
+    expect(result.error).toBe('TypeError thrown with no message at executeSpecific');
+  });
+
+  it('handles non-Error inputs (string) without crashing', () => {
+    const result = ResultBuilder.systemError('raw string failure');
+    expect(result.errorClass).toBe('Unknown');
+    expect(result.error).toBe('raw string failure');
+    expect(result.reasonCode).toBe('SYSTEM_ERROR');
+    expect(result.errorStack).toBeNull();
+  });
+
+  it('truncates stack to first 10 frames for readability', () => {
+    // Construct an error with known deep stack
+    function deepThrow(depth) {
+      if (depth === 0) throw new Error('deep failure');
+      return deepThrow(depth - 1);
+    }
+    try {
+      deepThrow(30);
+    } catch (err) {
+      const result = ResultBuilder.systemError(err);
+      const stackLines = result.errorStack.split('\n');
+      expect(stackLines.length).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('preserves non-structured error names as SYSTEM_ERROR (backward compat)', () => {
+    const err = new Error('random failure');
+    err.name = 'SomeOtherError';
+    expect(ResultBuilder.systemError(err).reasonCode).toBe('SYSTEM_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes opaque `REASON=SYSTEM_ERROR` with empty message on `scripts/handoff.js execute` when the post-gate path throws an uncaught exception. Precheck would pass 20/20 gates at 91%+ but execute would fail with zero diagnostic info (first observed on SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129 PLAN-TO-EXEC, 2026-04-23).

**Root cause** (RCA by rca-agent, 2026-04-23):
`BaseExecutor.executeHandoff` catches uncaught exceptions from child `executeSpecific` and laundries them into `ResultBuilder.systemError(error)` — which only populated `error` field. CLI prints `result.message`, so the actual error content never surfaced. Three uncaught call sites in `PlanToExecExecutor.executeSpecific` (`_synthesizeLeadAnalysis`, `_runRussianJudgeAssessment`, `PlanToExecVerifier.verifyHandoff`) threw opaquely. Precheck/execute asymmetry compounded the issue: precheck never exercises the post-gate path.

## Fixes

1. **`ResultBuilder.systemError(error, sourceStep)`** — populates `message`, `errorClass`, `errorStack` (first 10 frames), `sourceStep`, and `remediation`. Structured reason codes (`ANALYSIS_SYNTHESIS_FAILED`, `RUSSIAN_JUDGE_FAILED`, `VERIFIER_EXCEPTION`) surface via `reasonCode` when the error was wrapped. Backward compatible — unchanged for ordinary errors.
2. **`BaseExecutor.executeHandoff` outer catch** — logs `error.name`/class + top 5 stack frames and passes `sourceStep='executeSpecific'` into systemError.
3. **`plan-to-exec/index.js`** — wraps the 3 uncaught sites with diagnostic catches that rethrow wrapped Errors carrying a structured `.name`. CLI output now reads e.g. `REASON=VERIFIER_EXCEPTION` instead of generic `REASON=SYSTEM_ERROR`, with the stack trace in the remediation block.

**Diff**: 3 files modified (+85/-15), 1 test file new (+93). Net +163 LOC.

## Test plan

- [x] 9 regression tests in `tests/unit/handoff/result-builder-diagnostic.test.js`:
  - Plain Error → structured fields populated
  - Wrapped Error with `ANALYSIS_SYNTHESIS_FAILED` name → reasonCode surfaces
  - Wrapped Error with `RUSSIAN_JUDGE_FAILED` name → reasonCode surfaces
  - Wrapped Error with `VERIFIER_EXCEPTION` name → reasonCode surfaces
  - sourceStep hint appears in remediation
  - Empty-message error → informative fallback (previously completely opaque)
  - Non-Error inputs (string) → handled
  - Stack truncated to 10 frames
  - Non-structured error names → backward compat `SYSTEM_ERROR`
- [x] `npx vitest run tests/unit/handoff/result-builder-diagnostic.test.js` → 9/9 pass (285ms)

## LEO Protocol trail

- Filed via `/quick-fix` (Tier 2, 40 LOC estimated, ~50 actual + 93 LOC test)
- RCA agent invoked per `feedback_rca_agent_mandatory_on_any_issue.md`
- Originating failure: SD-LEARN-129 PLAN-TO-EXEC (user/operator unblocked by `--bypass-validation QF-20260423-200` ticket ref while this fix ships)

## Related

- Operator workflow: failures now include `errorClass`, `sourceStep`, and first 10 stack frames in remediation — operators can diagnose without needing to re-run with verbose logging and grep.
- Does NOT fix the underlying `eva_vision_scores.score` column-missing (separate schema-drift class, deserves its own QF — currently task #8 in my local tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)