### PR TITLE
fix(QF-20260423-812): vision-dimension-completeness uses correct eva_vision_scores columns

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/vision-dimension-completeness.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/vision-dimension-completeness.js
@@ -42,10 +42,13 @@ export function createVisionDimensionCompletenessGate(supabase) {
       }
 
       try {
-        // Query vision scores for this SD
+        // QF-20260423-812: eva_vision_scores exposes `total_score` and
+        // `dimension_scores` columns. The obsolete `score` / `dimensions` names
+        // caused PostgreSQL errors on every invocation, which the self-catch
+        // below masked as passed=true score=50 — silently falsifying the gate.
         const { data: visionScores, error } = await supabase
           .from('eva_vision_scores')
-          .select('score, dimensions, scored_at')
+          .select('total_score, dimension_scores, scored_at')
           .eq('sd_id', sdId)
           .order('scored_at', { ascending: false })
           .limit(1);
@@ -71,8 +74,8 @@ export function createVisionDimensionCompletenessGate(supabase) {
         }
 
         const latest = visionScores[0];
-        const overallScore = latest.score || 0;
-        const dimensions = latest.dimensions || {};
+        const overallScore = latest.total_score || 0;
+        const dimensions = latest.dimension_scores || {};
 
         // Check individual dimension coverage
         const dimensionKeys = Object.keys(dimensions);


### PR DESCRIPTION
## Summary

Tier 1 QF: 7-line column-name fix. `scripts/modules/handoff/executors/plan-to-exec/gates/vision-dimension-completeness.js:48` queried `score, dimensions` — obsolete column names. Actual table exposes `total_score` and `dimension_scores`. Gate's self-catch masked the PostgreSQL error as `passed=true score=50`, silently falsifying the dimensional-coverage check on every PLAN-TO-EXEC handoff.

**Ref:** rca-agent finding during SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129 RCA (2026-04-23). Separate from QF-20260423-200 (opaque SYSTEM_ERROR diagnostics, PR #3280, merged).

**Diff:** +7/-4. No new tests needed — functionality was masked before; CI will confirm the gate now executes as intended.

## Test plan
- [x] Live: re-run vision-scorer for any SD that has a score row → query returns data without DB error
- [ ] CI passes (no new tests needed — existing gate callers exercise the code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)