### PR TITLE
fix(QF-20260423-753): --skip-tests works standalone in complete-quick-fix

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260423-964",
+  "sdKey": "QF-20260423-753",
   "workType": "QF",
-  "workKey": "QF-20260423-964",
-  "expectedBranch": "qf/QF-20260423-964",
-  "createdAt": "2026-04-24T03:02:13.820Z",
+  "workKey": "QF-20260423-753",
+  "expectedBranch": "qf/QF-20260423-753",
+  "createdAt": "2026-04-24T03:12:51.804Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -80,8 +80,8 @@ Options:
   --branch-name         Git branch name (auto-detected if not provided)
   --actual-loc          Actual lines of code changed (auto-detected from git diff)
   --pr-url              GitHub PR URL (REQUIRED)
-  --skip-tests          Skip running tests (use with --tests-pass to use cached results)
-  --tests-pass          Use cached test result (requires --skip-tests flag)
+  --skip-tests          Skip running tests (trusts CI; testsPass=true by default)
+  --tests-pass          Override testsPass explicitly (yes/no); optional with --skip-tests
   --skip-typecheck      Skip TypeScript verification (not recommended)
   --uat-verified        UAT verified (yes/no, will prompt if not provided)
   --verification-notes  Optional notes about verification

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -116,10 +116,12 @@ export async function completeQuickFix(qfId, options = {}) {
   let e2eTestResult = null;
   let testsPass;
 
-  // Allow skipping if explicitly passed and --skip-tests flag
-  if (options.testsPass !== undefined && options.skipTestRun) {
-    console.log('   ⚠️  Using cached test results (--skip-tests flag)\n');
-    testsPass = options.testsPass;
+  // --skip-tests alone means "trust CI / cached results". Default testsPass=true unless
+  // the caller explicitly says otherwise via --tests-pass no. This matches the sibling
+  // pattern at test-runner.js:108-113 (--skip-typecheck works standalone).
+  if (options.skipTestRun) {
+    testsPass = options.testsPass !== undefined ? options.testsPass : true;
+    console.log(`   ⚠️  Skipping test run (--skip-tests); testsPass=${testsPass}\n`);
   } else {
     // Run unit tests in target application directory
     console.log('━━━ Unit Tests ━━━\n');

--- a/tests/unit/complete-quick-fix-skip-flags.test.js
+++ b/tests/unit/complete-quick-fix-skip-flags.test.js
@@ -1,0 +1,46 @@
+/**
+ * Regression test: complete-quick-fix --skip-tests must work standalone
+ * QF-20260423-753
+ *
+ * RCA traced the bug to orchestrator.js:119-136 where an AND-gate required
+ * BOTH --skip-tests AND --tests-pass before honoring the skip path. Fixed
+ * by making --skip-tests alone default testsPass=true (matches sibling
+ * --skip-typecheck pattern at test-runner.js:108-113).
+ *
+ * Bug introduced by commit 20f80b8e95 (2026-04-19), first reported 2026-04-24.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const ORCH_PATH = path.resolve(process.cwd(), 'scripts/modules/complete-quick-fix/orchestrator.js');
+const CLI_PATH = path.resolve(process.cwd(), 'scripts/modules/complete-quick-fix/cli.js');
+
+describe('complete-quick-fix --skip-tests flag semantics', () => {
+  const orchSrc = readFileSync(ORCH_PATH, 'utf8');
+  const cliSrc = readFileSync(CLI_PATH, 'utf8');
+
+  it('orchestrator gates the skip path on skipTestRun alone (no AND with testsPass)', () => {
+    // Must NOT contain the old AND-gate
+    expect(orchSrc).not.toMatch(/options\.testsPass\s*!==\s*undefined\s*&&\s*options\.skipTestRun/);
+    // Must contain the new single-flag gate
+    expect(orchSrc).toMatch(/if\s*\(\s*options\.skipTestRun\s*\)/);
+  });
+
+  it('orchestrator defaults testsPass=true when --skip-tests is passed without --tests-pass', () => {
+    // The default-when-skipping logic must be present
+    expect(orchSrc).toMatch(/testsPass\s*=\s*options\.testsPass\s*!==\s*undefined\s*\?\s*options\.testsPass\s*:\s*true/);
+  });
+
+  it('cli help text no longer says --tests-pass is required with --skip-tests', () => {
+    // Old wording: "use with --tests-pass" / "requires --skip-tests flag"
+    expect(cliSrc).not.toMatch(/use with --tests-pass to use cached results/);
+    expect(cliSrc).not.toMatch(/requires --skip-tests flag/);
+    // New wording mentions trusts-CI and optional override
+    expect(cliSrc).toMatch(/trusts CI|testsPass=true by default|Override testsPass/);
+  });
+
+  it('orchestrator logs the chosen testsPass value when skipping', () => {
+    expect(orchSrc).toMatch(/Skipping test run.*testsPass=/);
+  });
+});


### PR DESCRIPTION
## Summary

\`scripts/modules/complete-quick-fix/orchestrator.js:119\` gated the skip path on \`AND(options.testsPass !== undefined, options.skipTestRun)\`, so \`--skip-tests\` alone never skipped. Tests ran, hit pre-existing main failures, aborted with \`CANNOT COMPLETE - TESTS NOT PASSING\`. Operators were forced to bypass via direct DB upsert, losing the compliance-rubric audit trail.

**RCA finding** (rca-agent, 2026-04-24): Bug introduced by commit \`20f80b8e95\` on 2026-04-19 (SD-S17 "4 improvements"). Three prior memory feedback notes predate the commit — this was already a UX issue and the 2026-04-19 change compounded it by closing the only working path.

**Recurring**: 3+ documented occurrences (memory: \`feedback_complete_quick_fix_loc_and_test_bugs.md\`, \`feedback_complete_quick_fix_hang_bug.md\`, \`feedback_qf_db_stale_after_merge.md\`).

## Fix

- Gate on \`options.skipTestRun\` alone
- Default \`testsPass=true\` unless \`--tests-pass\` explicitly overrides
- Matches the sibling pattern at \`test-runner.js:108-113\` where \`--skip-typecheck\` works standalone

## Diff

- \`scripts/modules/complete-quick-fix/orchestrator.js\` (+5 / -3) — gate reshape
- \`scripts/modules/complete-quick-fix/cli.js\` (+2 / -2) — help text
- \`tests/unit/complete-quick-fix-skip-flags.test.js\` (+46) — 4 regression tests

## Test plan

- [x] 4 unit tests pass locally (vitest)
- [ ] CI green
- [ ] Dogfood: complete this QF using the new \`--skip-tests\` standalone (after merge)