### PR TITLE
fix(QF-20260423-323): gh-merge-safe uses gh repo view for owner/name

### DIFF
--- a/scripts/gh-merge-safe.mjs
+++ b/scripts/gh-merge-safe.mjs
@@ -43,9 +43,13 @@ function main() {
   if (values.merge) method = 'merge';
   if (values.rebase) method = 'rebase';
 
-  // Detect already-merged PRs up front to be idempotent.
-  const preview = JSON.parse(sh(`gh pr view ${prNumber} --json state,mergeCommit,headRefName,baseRepository`));
-  const { owner: { login: owner }, name: repo } = preview.baseRepository;
+  // Detect already-merged PRs up front to be idempotent. gh pr view does not expose
+  // baseRepository, so resolve owner/name via gh repo view (works because the wrapper
+  // already requires being inside the repo's working tree).
+  const preview = JSON.parse(sh(`gh pr view ${prNumber} --json state,mergeCommit,headRefName`));
+  const repoInfo = JSON.parse(sh(`gh repo view --json owner,name`));
+  const owner = repoInfo.owner.login;
+  const repo = repoInfo.name;
 
   if (preview.state === 'MERGED') {
     const sha = preview.mergeCommit?.oid || 'unknown';


### PR DESCRIPTION
## Summary

PR #3285 shipped \`scripts/gh-merge-safe.mjs\` calling \`gh pr view --json baseRepository\` — but \`baseRepository\` isn't a valid \`gh pr view\` field. \`gh\` errors with \`Unknown JSON field\`. Wrapper exits 1 before merge.

Discovered during dogfood on PR #3285 itself.

## Fix

Drop \`baseRepository\` from \`gh pr view\`, resolve owner/name via \`gh repo view\` (works because wrapper already requires being inside repo working tree).

## Diff

\`scripts/gh-merge-safe.mjs\` (+7 / -3)

## Test plan

- [x] Verified wrapper invocation now resolves owner/repo correctly
- [x] Successfully dogfooded merging PRs #3285 (with hot-patched local copy) — same code path as this fix