### PR TITLE
fix(QF-20260423-909): guard stale-sweep against pending_approval reset

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -526,13 +526,34 @@ async function main() {
   const claimedKeys = new Set((claimedSdStatus || []).map(sd => sd.sd_key));
   const { data: allPendingApproval } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, status, current_phase, progress_percentage, completion_date')
+    .select('id, sd_key, status, current_phase, progress_percentage, completion_date')
     .eq('status', 'pending_approval');
 
   const activeClaimSdIds = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_key));
   const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key));
 
+  // QF-20260423-909: Guard against resetting SDs that legitimately completed
+  // PLAN-TO-LEAD and are resting in pending_approval awaiting LEAD-FINAL-APPROVAL.
+  // sd_phase_handoffs.sd_id holds BOTH uuid- and sd_key-style values; check both.
+  const stuckApprovalIds = stuckApproval.flatMap(sd => [sd.id, sd.sd_key].filter(Boolean));
+  let acceptedPlanToLeadSet = new Set();
+  if (stuckApprovalIds.length > 0) {
+    const { data: p2lHandoffs } = await supabase
+      .from('sd_phase_handoffs')
+      .select('sd_id')
+      .eq('handoff_type', 'PLAN-TO-LEAD')
+      .eq('status', 'accepted')
+      .in('sd_id', stuckApprovalIds);
+    acceptedPlanToLeadSet = new Set((p2lHandoffs || []).map(h => h.sd_id));
+  }
+
   for (const sd of stuckApproval) {
+    // QF-20260423-909: Skip reset if PLAN-TO-LEAD handoff already accepted —
+    // SD is legitimately awaiting LEAD-FINAL-APPROVAL, not stuck.
+    if (acceptedPlanToLeadSet.has(sd.sd_key) || acceptedPlanToLeadSet.has(sd.id)) {
+      actions.push('QA: skipped reset on ' + sd.sd_key + ' — PLAN-TO-LEAD accepted, awaiting LEAD-FINAL-APPROVAL');
+      continue;
+    }
     // FIX #1: STUCK_100 — if at 100% with completion_date, mark completed instead of resetting
     if (sd.progress_percentage >= 100 && sd.completion_date) {
       const { error } = await supabase

--- a/tests/unit/pending-approval-guard.test.js
+++ b/tests/unit/pending-approval-guard.test.js
@@ -1,0 +1,66 @@
+/**
+ * QF-20260423-909: Guard stale-session-sweep against pending_approval reset.
+ *
+ * Mirrors the decision logic inside scripts/stale-session-sweep.cjs section 3d
+ * (QA — detect SDs stuck in pending_approval with no claiming session) to
+ * validate that an SD with an accepted PLAN-TO-LEAD handoff is never reset
+ * to draft/LEAD/0%, while an SD without such a handoff still gets reset.
+ *
+ * The test pattern follows tests/unit/fleet-liveness-sweep-gate.test.js —
+ * replicate the gate rules here rather than stubbing supabase in production.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+function decideReset(sd, { acceptedPlanToLeadSet = new Set() } = {}) {
+  if (acceptedPlanToLeadSet.has(sd.sd_key) || acceptedPlanToLeadSet.has(sd.id)) {
+    return { action: 'SKIP', reason: 'PLAN_TO_LEAD_ACCEPTED' };
+  }
+  if (sd.progress_percentage >= 100 && sd.completion_date) {
+    return { action: 'COMPLETE', reason: 'STUCK_100_WITH_COMPLETION_DATE' };
+  }
+  return { action: 'RESET', reason: 'PENDING_APPROVAL_NO_HANDOFF' };
+}
+
+describe('stale-session-sweep — pending_approval guard (QF-20260423-909)', () => {
+  it('SKIP: accepted PLAN-TO-LEAD handoff keyed by sd_key', () => {
+    const sd = { id: 'uuid-1', sd_key: 'SD-FOO-001', progress_percentage: 50, completion_date: null };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set(['SD-FOO-001']) });
+    expect(d.action).toBe('SKIP');
+    expect(d.reason).toBe('PLAN_TO_LEAD_ACCEPTED');
+  });
+
+  it('SKIP: accepted PLAN-TO-LEAD handoff keyed by UUID (sd_phase_handoffs.sd_id can hold either)', () => {
+    const sd = { id: 'eca90cd8-f81c-40f6-b479-25bed230007b', sd_key: 'SD-BAR-002', progress_percentage: 50, completion_date: null };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set(['eca90cd8-f81c-40f6-b479-25bed230007b']) });
+    expect(d.action).toBe('SKIP');
+    expect(d.reason).toBe('PLAN_TO_LEAD_ACCEPTED');
+  });
+
+  it('RESET: no handoff signal, progress < 100 ⇒ genuine stuck state', () => {
+    const sd = { id: 'uuid-3', sd_key: 'SD-BAZ-003', progress_percentage: 40, completion_date: null };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set() });
+    expect(d.action).toBe('RESET');
+    expect(d.reason).toBe('PENDING_APPROVAL_NO_HANDOFF');
+  });
+
+  it('COMPLETE: progress=100 with completion_date ⇒ existing STUCK_100 fix takes precedence over RESET', () => {
+    const sd = { id: 'uuid-4', sd_key: 'SD-DONE-004', progress_percentage: 100, completion_date: '2026-04-24T00:00:00Z' };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set() });
+    expect(d.action).toBe('COMPLETE');
+    expect(d.reason).toBe('STUCK_100_WITH_COMPLETION_DATE');
+  });
+
+  it('SKIP precedes COMPLETE — handoff-accepted signal wins even at 100% (defensive: never reset, never double-transition)', () => {
+    const sd = { id: 'uuid-5', sd_key: 'SD-EDGE-005', progress_percentage: 100, completion_date: '2026-04-24T00:00:00Z' };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set(['SD-EDGE-005']) });
+    expect(d.action).toBe('SKIP');
+    expect(d.reason).toBe('PLAN_TO_LEAD_ACCEPTED');
+  });
+
+  it('RESET: unrelated SD key in the set does not match (no false positive)', () => {
+    const sd = { id: 'uuid-6', sd_key: 'SD-OTHER-006', progress_percentage: 50, completion_date: null };
+    const d = decideReset(sd, { acceptedPlanToLeadSet: new Set(['SD-FOO-001', 'SD-BAR-002']) });
+    expect(d.action).toBe('RESET');
+  });
+});


### PR DESCRIPTION
## Summary

- `scripts/stale-session-sweep.cjs` QA section 3d was resetting SDs in `pending_approval` to `draft/LEAD/progress=0` when no session was actively claiming them. But `pending_approval` is the designed resting state between PLAN-TO-LEAD and LEAD-FINAL-APPROVAL — no claim is expected there.
- Add a guard: before reset, batch-query `sd_phase_handoffs` for accepted PLAN-TO-LEAD handoffs scoped to the candidate set. If the SD is in that set, skip reset with a clear action log.
- Fixes `PAT-SWEEP-PENDING-APPROVAL-RESET-001` which was blocking `LEAD-FINAL-APPROVAL` with `INVALID_STATUS` after legit handoff completion.

## Changes

- **`scripts/stale-session-sweep.cjs`** (+22 / -1, 23 LOC): Add `id` to the `pending_approval` query, fetch accepted PLAN-TO-LEAD handoffs for the candidate set, add SKIP branch at the top of the stuckApproval loop.
- **`tests/unit/pending-approval-guard.test.js`** (+66): 6 test cases following the `fleet-liveness-sweep-gate` mirror-the-decision-logic pattern. Covers sd_key-keyed, UUID-keyed, negative cases, STUCK_100 interaction, and precedence.

## Implementation notes

- `sd_phase_handoffs.sd_id` stores **both** UUID and sd_key formats — the guard checks both.
- Batched via `.in('sd_id', stuckApprovalIds)` — one query per sweep cycle, flat cost.
- The existing `STUCK_100` branch (progress=100 + completion_date → mark completed) is untouched; the new SKIP branch takes precedence when the handoff signal is present.

## Test plan

- [x] Unit tests: 6 cases pass (vitest)
- [x] Syntax check (`node --check`)
- [x] Dry-run sweep (early-exits cleanly with no claimed sessions)
- [ ] CI green on PR
- [ ] Production sweep correctly skips `pending_approval` SDs with accepted PLAN-TO-LEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)