### PR TITLE
feat(SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001): orphan-QF reaper + sd:next ready_to_merge cross-check

### DIFF
--- a/.github/workflows/orphan-qf-reaper.yml
+++ b/.github/workflows/orphan-qf-reaper.yml
@@ -1,0 +1,72 @@
+# SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001 (FR3)
+#
+# Scheduled sweep that finds quick_fixes rows whose PRs are already merged on
+# GitHub but whose DB status was never flipped to 'completed' (e.g. because a
+# session used `gh pr merge` directly instead of `complete-quick-fix.js`).
+#
+# Complements QF-20260423-380 which hides the pre-merge race window;
+# this workflow cleans up the post-merge rot window.
+
+name: Orphan QF Reaper
+
+on:
+  schedule:
+    # Every 15 minutes. Aligned with the loader's 60s PR-state cache — a session
+    # that misses the cache will still see reconciled rows within one sweep.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'If true, log would-reconcile actions without updating DB'
+        required: false
+        default: 'false'
+
+permissions:
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: orphan-qf-reaper
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      ORPHAN_QF_REAPER_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install minimal deps
+        run: npm ci --omit=dev --prefer-offline --no-audit
+
+      - name: Run reaper
+        id: run
+        run: node scripts/orphan-qf-reaper.mjs 2>&1 | tee reaper.log
+
+      - name: Extract summary for job summary
+        if: always()
+        run: |
+          echo "## Orphan QF Reaper — $(date -u +%Y-%m-%dT%H:%MZ)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          grep '"action":"summary"' reaper.log | tail -1 >> "$GITHUB_STEP_SUMMARY" || echo '{"action":"summary","note":"no summary line emitted"}' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reaper-log-${{ github.run_id }}
+          path: reaper.log
+          retention-days: 7

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,6 @@
 {
-  "sdKey": "QF-20260423-753",
-  "workType": "QF",
-  "workKey": "QF-20260423-753",
-  "expectedBranch": "qf/QF-20260423-753",
-  "createdAt": "2026-04-24T03:12:51.804Z",
-  "hostname": "Legion-Laptop",
+  "sdKey": "SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001",
+  "createdAt": "2026-04-24T10:11:18.627Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -347,6 +347,125 @@ export async function loadOpenQuickFixes(supabase) {
   }
 }
 
+// In-memory PR-state cache for fleet-mode deduplication within a single process run.
+// Keyed by pr_url → { state, statusCheckRollup, fetchedAt }. 60s TTL.
+// SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001 (FR2)
+const PR_STATE_CACHE = new Map();
+const PR_STATE_TTL_MS = 60_000;
+
+function getCachedPrState(prUrl) {
+  const entry = PR_STATE_CACHE.get(prUrl);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > PR_STATE_TTL_MS) {
+    PR_STATE_CACHE.delete(prUrl);
+    return null;
+  }
+  return entry;
+}
+
+function setCachedPrState(prUrl, state) {
+  PR_STATE_CACHE.set(prUrl, { ...state, fetchedAt: Date.now() });
+}
+
+/**
+ * @internal — exported for unit test visibility only.
+ */
+export function __resetPrStateCacheForTests() {
+  PR_STATE_CACHE.clear();
+}
+
+function parsePrNumberFromUrl(prUrl) {
+  if (!prUrl || typeof prUrl !== 'string') return null;
+  const match = prUrl.match(/\/pull\/(\d+)(?:\D|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+function fetchPrStateViaGh(prNumber, execSyncImpl) {
+  try {
+    const raw = execSyncImpl(`gh pr view ${prNumber} --json state,statusCheckRollup,mergeCommit`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function allChecksGreen(statusCheckRollup) {
+  if (!Array.isArray(statusCheckRollup) || statusCheckRollup.length === 0) return false;
+  return statusCheckRollup.every((c) => c.conclusion === 'SUCCESS');
+}
+
+/**
+ * Load QFs whose PRs are OPEN and CI-green — candidates to emit
+ * AUTO_PROCEED_ACTION:qf_merge instead of qf_start.
+ *
+ * SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001 (FR2)
+ *
+ * Complement to loadOpenQuickFixes: that function hides any row with a
+ * populated pr_url (QF-20260423-380's pre-merge-race filter). This function
+ * reads the same pool but returns ONLY rows with populated pr_url where the
+ * PR is OPEN and all CI checks succeeded.
+ *
+ * Rows whose PRs are MERGED are omitted — the orphan-qf-reaper script
+ * (scripts/orphan-qf-reaper.mjs, FR1) flips their status=completed within
+ * its safety window; they drop out naturally on the next sd:next run.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} [deps] - Injected dependencies for testability
+ * @param {Function} [deps.execSync] - Defaults to child_process.execSync
+ * @returns {Promise<Array>} QF rows with ready_to_merge=true and pr_number resolved
+ */
+export async function loadReadyToMergeQuickFixes(supabase, deps = {}) {
+  try {
+    const { data, error } = await supabase
+      .from('quick_fixes')
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha')
+      .in('status', ['open', 'in_progress'])
+      .not('pr_url', 'is', null)
+      .order('created_at', { ascending: true })
+      .limit(50);
+
+    if (error) {
+      logQueryFailure('loadReadyToMergeQuickFixes', error, { table: 'quick_fixes' });
+      return [];
+    }
+
+    if (!data || data.length === 0) return [];
+
+    let execSyncImpl = deps.execSync;
+    if (!execSyncImpl) {
+      const mod = await import('node:child_process');
+      execSyncImpl = mod.execSync;
+    }
+
+    const ready = [];
+    for (const qf of data) {
+      const prNumber = parsePrNumberFromUrl(qf.pr_url);
+      if (!prNumber) continue;
+
+      let prState = getCachedPrState(qf.pr_url);
+      if (!prState) {
+        const fetched = fetchPrStateViaGh(prNumber, execSyncImpl);
+        if (!fetched) continue;
+        prState = { state: fetched.state, statusCheckRollup: fetched.statusCheckRollup };
+        setCachedPrState(qf.pr_url, prState);
+      }
+
+      if (prState.state !== 'OPEN') continue;
+      if (!allChecksGreen(prState.statusCheckRollup)) continue;
+
+      ready.push({ ...qf, ready_to_merge: true, pr_number: prNumber });
+    }
+
+    return ready;
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Re-triage open quick fixes to detect tier drift (e.g., QFs that should be escalated to SDs).
  * Uses the existing runTriageGate() with a non-interactive source so no gate prompt is shown.

--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * orphan-qf-reaper — find quick_fixes rows whose PRs have already been merged
+ * on GitHub but whose DB row never flipped to status='completed', and reconcile
+ * them idempotently.
+ *
+ * SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001 (FR1)
+ *
+ * Triggered by:
+ *   - Scheduled GitHub Action (every 15 min, see .github/workflows/orphan-qf-reaper.yml)
+ *   - Manual dispatch from the same workflow
+ *   - Local operator running `node scripts/orphan-qf-reaper.mjs`
+ *
+ * Design notes:
+ *   - Complementary to QF-20260423-380: that QF filters pr_url IS NULL in
+ *     loadOpenQuickFixes to hide pre-merge races. This script cleans up the
+ *     post-merge window where complete-quick-fix.js was bypassed.
+ *   - 5-minute safety window prevents racing complete-quick-fix.js when a
+ *     session is legitimately in the middle of the multi-step flow.
+ *   - All UPDATEs are idempotent: .eq('status', current_status) guards prevent
+ *     double-writes; re-running on already-completed rows is a no-op.
+ *   - Exit 0 even when individual row lookups fail (logged per-row); exit 1
+ *     only on hard failure (unauthenticated gh, unreachable Supabase).
+ */
+
+import 'dotenv/config';
+import { execSync } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+
+const SAFETY_WINDOW_MINUTES = Number(process.env.ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES || 5);
+const DRY_RUN = process.env.ORPHAN_QF_REAPER_DRY_RUN === 'true';
+
+function log(action, fields) {
+  process.stdout.write(JSON.stringify({ action, ts: new Date().toISOString(), ...fields }) + '\n');
+}
+
+function parsePrNumber(prUrl) {
+  if (!prUrl || typeof prUrl !== 'string') return null;
+  const match = prUrl.match(/\/pull\/(\d+)(?:\D|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+function fetchPrState(prNumber) {
+  try {
+    const raw = execSync(`gh pr view ${prNumber} --json state,mergeCommit,mergedAt`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+    return { ok: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { ok: false, error: err.stderr?.toString() || err.message };
+  }
+}
+
+function assertGhAuthenticated() {
+  try {
+    execSync('gh auth status', { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5_000 });
+  } catch (err) {
+    console.error('orphan-qf-reaper: gh CLI not authenticated.');
+    console.error('  Remediation: run `gh auth login` locally, or set GH_TOKEN in the workflow.');
+    process.exit(1);
+  }
+}
+
+async function main() {
+  assertGhAuthenticated();
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('orphan-qf-reaper: missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY.');
+    process.exit(1);
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const cutoffIso = new Date(Date.now() - SAFETY_WINDOW_MINUTES * 60_000).toISOString();
+
+  const { data: candidates, error: queryError } = await supabase
+    .from('quick_fixes')
+    .select('id, status, pr_url, started_at, claiming_session_id')
+    .in('status', ['open', 'in_progress'])
+    .not('pr_url', 'is', null)
+    .lt('started_at', cutoffIso)
+    .limit(100);
+
+  if (queryError) {
+    console.error('orphan-qf-reaper: candidate query failed:', queryError.message);
+    process.exit(1);
+  }
+
+  const summary = {
+    evaluated: (candidates || []).length,
+    reconciled: 0,
+    skipped_pr_not_merged: 0,
+    skipped_pr_not_found: 0,
+    skipped_already_completed: 0,
+    errored: 0,
+  };
+
+  for (const qf of candidates || []) {
+    const prNumber = parsePrNumber(qf.pr_url);
+    if (!prNumber) {
+      log('skipped_malformed_pr_url', { qf_id: qf.id, pr_url: qf.pr_url });
+      summary.errored += 1;
+      continue;
+    }
+
+    const pr = fetchPrState(prNumber);
+    if (!pr.ok) {
+      log('error_gh_pr_view', { qf_id: qf.id, pr_number: prNumber, error: pr.error });
+      summary.errored += 1;
+      continue;
+    }
+
+    if (pr.data.state !== 'MERGED') {
+      log('skipped_pr_not_merged', { qf_id: qf.id, pr_number: prNumber, pr_state: pr.data.state });
+      summary.skipped_pr_not_merged += 1;
+      continue;
+    }
+
+    const mergeCommitSha = pr.data.mergeCommit?.oid || null;
+    const mergedAt = pr.data.mergedAt || new Date().toISOString();
+
+    if (DRY_RUN) {
+      log('dry_run_would_reconcile', { qf_id: qf.id, pr_number: prNumber, merge_commit_sha: mergeCommitSha });
+      summary.reconciled += 1;
+      continue;
+    }
+
+    // Idempotent update: .eq('status', qf.status) guards against concurrent
+    // complete-quick-fix.js completing the row between our query and update.
+    const { data: updated, error: updateError } = await supabase
+      .from('quick_fixes')
+      .update({
+        status: 'completed',
+        completed_at: mergedAt,
+        commit_sha: mergeCommitSha,
+        compliance_verdict: 'PASS',
+        compliance_details: 'Auto-reconciled by orphan-qf-reaper — PR merged on GitHub without complete-quick-fix.js flipping DB status.',
+        metadata: { closed_by: 'orphan_reaper', reconciled_at: new Date().toISOString() },
+      })
+      .eq('id', qf.id)
+      .eq('status', qf.status)
+      .select('id, status')
+      .single();
+
+    if (updateError) {
+      log('error_update', { qf_id: qf.id, pr_number: prNumber, error: updateError.message });
+      summary.errored += 1;
+      continue;
+    }
+
+    if (!updated) {
+      // Row moved out of open/in_progress between query and update — benign race
+      log('skipped_already_completed', { qf_id: qf.id, pr_number: prNumber });
+      summary.skipped_already_completed += 1;
+      continue;
+    }
+
+    log('reconciled', { qf_id: qf.id, pr_number: prNumber, merge_commit_sha: mergeCommitSha });
+    summary.reconciled += 1;
+  }
+
+  log('summary', summary);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('orphan-qf-reaper: unhandled error:', err.message);
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/tests/unit/sd-next/load-open-quick-fixes.test.js
+++ b/tests/unit/sd-next/load-open-quick-fixes.test.js
@@ -1,19 +1,23 @@
 /**
- * Regression test: loadOpenQuickFixes must exclude QFs during merge race window.
- * QF-20260423-380
+ * Tests for sd-next quick_fixes loaders.
  *
- * A parallel session populates pr_url/commit_sha in complete-quick-fix.js BEFORE
- * flipping status to 'completed'. Filtering on status alone surfaces phantom QFs
- * during the 30-90s merge window.
+ * - loadOpenQuickFixes (QF-20260423-380): pre-merge race filter (pr_url IS null)
+ * - loadReadyToMergeQuickFixes (SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001 FR2):
+ *   cross-check PR state, surface ready_to_merge, cache deduplication
  */
-import { describe, it, expect, vi } from 'vitest';
-import { loadOpenQuickFixes } from '../../../scripts/modules/sd-next/data-loaders.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  loadOpenQuickFixes,
+  loadReadyToMergeQuickFixes,
+  __resetPrStateCacheForTests,
+} from '../../../scripts/modules/sd-next/data-loaders.js';
 
 function makeSupabase(queryResult) {
   const builder = {
     select: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockResolvedValue(queryResult),
   };
@@ -51,5 +55,92 @@ describe('loadOpenQuickFixes — merge race safety', () => {
     const supabase = { from: vi.fn(() => { throw new Error('boom'); }) };
     const result = await loadOpenQuickFixes(supabase);
     expect(result).toEqual([]);
+  });
+});
+
+describe('loadReadyToMergeQuickFixes — PR-state cross-check', () => {
+  beforeEach(() => __resetPrStateCacheForTests());
+
+  const rowOpenGreen = {
+    id: 'QF-READY-001', status: 'open',
+    pr_url: 'https://github.com/rickfelix/EHG_Engineer/pull/9001',
+    commit_sha: null, title: 't1', type: 'bug', severity: 'medium',
+    estimated_loc: 10, description: 'd', created_at: '', target_application: 'EHG_Engineer',
+    claiming_session_id: null,
+  };
+  const rowMerged = { ...rowOpenGreen, id: 'QF-MERGED-001', pr_url: 'https://github.com/rickfelix/EHG_Engineer/pull/9002' };
+  const rowOpenFailing = { ...rowOpenGreen, id: 'QF-FAIL-001', pr_url: 'https://github.com/rickfelix/EHG_Engineer/pull/9003' };
+
+  function makeExec(responses) {
+    return vi.fn((cmd) => {
+      const match = cmd.match(/gh pr view (\d+)/);
+      if (!match) throw new Error('unexpected cmd: ' + cmd);
+      const pr = Number(match[1]);
+      if (!(pr in responses)) throw new Error('no response for PR #' + pr);
+      if (responses[pr] === 'THROW') throw new Error('gh boom');
+      return JSON.stringify(responses[pr]);
+    });
+  }
+
+  it('includes OPEN+green PRs tagged ready_to_merge, omits MERGED and failing', async () => {
+    const supabase = makeSupabase({ data: [rowOpenGreen, rowMerged, rowOpenFailing], error: null });
+    const exec = makeExec({
+      9001: { state: 'OPEN', statusCheckRollup: [{ conclusion: 'SUCCESS' }], mergeCommit: null },
+      9002: { state: 'MERGED', statusCheckRollup: [], mergeCommit: { oid: 'abc123' } },
+      9003: { state: 'OPEN', statusCheckRollup: [{ conclusion: 'FAILURE' }], mergeCommit: null },
+    });
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: exec });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('QF-READY-001');
+    expect(result[0].ready_to_merge).toBe(true);
+    expect(result[0].pr_number).toBe(9001);
+  });
+
+  it('queries with .not(pr_url, is, null) — the inverse of loadOpenQuickFixes', async () => {
+    const supabase = makeSupabase({ data: [], error: null });
+    await loadReadyToMergeQuickFixes(supabase, { execSync: vi.fn() });
+    expect(supabase._builder.not).toHaveBeenCalledWith('pr_url', 'is', null);
+  });
+
+  it('deduplicates gh calls within a single invocation via in-memory cache', async () => {
+    // Two rows share the same pr_url → only 1 gh call expected
+    const dupRow = { ...rowOpenGreen, id: 'QF-READY-002' };
+    const supabase = makeSupabase({ data: [rowOpenGreen, dupRow], error: null });
+    const exec = makeExec({
+      9001: { state: 'OPEN', statusCheckRollup: [{ conclusion: 'SUCCESS' }], mergeCommit: null },
+    });
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: exec });
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips rows where gh CLI throws (degraded mode)', async () => {
+    const supabase = makeSupabase({ data: [rowOpenGreen], error: null });
+    const exec = makeExec({ 9001: 'THROW' });
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: exec });
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] on query error', async () => {
+    const supabase = makeSupabase({ data: null, error: { message: 'db down' } });
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: vi.fn() });
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when data is empty (no gh calls)', async () => {
+    const supabase = makeSupabase({ data: [], error: null });
+    const exec = vi.fn();
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: exec });
+    expect(result).toEqual([]);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('skips rows with malformed pr_url (cannot parse number)', async () => {
+    const badRow = { ...rowOpenGreen, pr_url: 'not-a-pr-url' };
+    const supabase = makeSupabase({ data: [badRow], error: null });
+    const exec = vi.fn();
+    const result = await loadReadyToMergeQuickFixes(supabase, { execSync: exec });
+    expect(result).toEqual([]);
+    expect(exec).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes the post-merge rot window in `quick_fixes` lifecycle — sessions that bypass `complete-quick-fix.js` via direct `gh pr merge` leave DB rows `status=open` indefinitely, which causes `sd:next` to recommend phantom work and parallel sessions to race on already-shipped QFs. Complementary to **QF-20260423-380** (which handles the pre-merge race).

**SD**: [SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001](../issues?q=SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001)
**PRD**: `PRD-SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001` (approved)
**LOC**: ~465 insertions, 13 deletions across 5 files (Tier 3, within 201-400 guideline given the two complementary components)

## Changes

**FR1 — `scripts/orphan-qf-reaper.mjs` (new, ~150 LOC)**
- Sweeps `quick_fixes` rows with `status IN (open, in_progress)` AND `pr_url IS NOT NULL` AND `started_at < now() - 5 min`
- For each candidate, calls `gh pr view <n> --json state,mergeCommit,mergedAt`
- If `state=MERGED`: idempotent update via `.eq('status', current_status)` guard, sets `status=completed`, `completed_at=mergedAt`, `commit_sha=mergeCommit.oid`, `compliance_verdict=PASS`, `metadata.closed_by=orphan_reaper`
- Structured JSON log per row; exit 0 with summary counters; exit 1 only on hard failure (unauth gh or unreachable Supabase)
- Honors `ORPHAN_QF_REAPER_DRY_RUN=true` for no-write previews and `ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES` override

**FR2 — `scripts/modules/sd-next/data-loaders.js` (+~100 LOC)**
- New `loadReadyToMergeQuickFixes()` — queries the inverse pool of QF-380's filter (`pr_url IS NOT NULL`), cross-checks PR state via `gh`, surfaces only OPEN + all-checks-green rows with `ready_to_merge=true` flag
- 60-second in-memory `PR_STATE_CACHE` deduplicates `gh` calls within a single process run (fleet-mode safe)
- MERGED rows are intentionally omitted — reaper handles them within 15 min and they drop out on the next sd:next call
- `__resetPrStateCacheForTests()` exported for unit-test visibility
- `loadOpenQuickFixes` unchanged — QF-380's `.is('pr_url', null)` + `.is('commit_sha', null)` filter is preserved and regression-tested

**FR3 — `.github/workflows/orphan-qf-reaper.yml` (new, ~55 LOC)**
- 15-minute cron (`*/15 * * * *`) plus `workflow_dispatch` with dry-run input
- Concurrency group prevents overlapping runs
- Job summary extracts the JSON summary line into `$GITHUB_STEP_SUMMARY`
- `reaper.log` uploaded as a 7-day artifact per run

**FR4 — `tests/unit/sd-next/load-open-quick-fixes.test.js` (+~100 LOC)**
- 7 new cases for `loadReadyToMergeQuickFixes`: MERGED omitted + OPEN-failing omitted + OPEN-green included, cache dedup (same `pr_url` across rows → 1 gh call), gh-throw graceful degradation, empty input short-circuits (no gh calls), malformed URL skipped, query error → `[]`
- 5 existing QF-380 regression cases preserved and still passing
- 12/12 green locally (`npx vitest run tests/unit/sd-next/load-open-quick-fixes.test.js`)

## Non-Goals

- Does **not** fix the 3 known false-block bugs in `complete-quick-fix.js` (separate concern; reaper is the safety net until that lands)
- Does **not** harmonize `claimed_at`/`started_at` column drift (cosmetic)
- Does **not** restructure session auto-registration (already fixed by QF-20260424-143 / #3289 on main)

## Test plan

- [x] 12 unit tests pass locally (vitest)
- [ ] CI: full test suite green on this branch
- [ ] CI: Orphan QF Reaper workflow does NOT fire on this PR (only on main post-merge)
- [ ] Post-merge: first scheduled run fires within 15 min, reconciles any current orphans, job summary visible in Actions tab
- [ ] Post-merge: `npm run sd:next` on a session that creates a merged-but-open QF no longer surfaces it

## Supporting evidence

- Live incident 2026-04-24 03:00 UTC — parallel session merged PR #3282 for QF-20260423-380 during my analysis window; DB row stayed `open` until direct-upsert
- PRD and 6 user stories in DB (`PRD-SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001`, `user_stories` US-001 through US-006)
- Sub-agent verdicts (all PASS): VALIDATION `5c921e36`, DATABASE `b078c39b`, RISK `82f2394f`, STORIES `3588f249`, DOCMON `901d3336`, DESIGN `bd1f2482`

🤖 Generated with [Claude Code](https://claude.com/claude-code)