### PR TITLE
fix(QF-20260424-674): gate QF worktree creation on held DB claim

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1027,6 +1027,33 @@ export async function cleanupStaleWorktrees({ dryRun = false, maxAgeMs, supabase
 }
 
 /**
+ * QF-20260424-674: Assert the given session holds the DB claim for a work item
+ * before its worktree is materialized. Pure function — caller supplies the
+ * current claim state (no DB coupling in lib/).
+ *
+ * Philosophy: unclaimed QF/SD work MUST NOT have a pre-registered worktree.
+ * Otherwise two sessions running `/leo next` can land in the same directory
+ * before the DB claim race resolves.
+ *
+ * @param {Object} opts
+ * @param {WorkType} opts.workType   - 'SD' | 'QF' | 'ADHOC'
+ * @param {string|null} opts.claimedBy - Session ID currently holding the claim, or null
+ * @param {string} [opts.sessionId]  - Session attempting to create the worktree
+ * @throws {Error} code=CLAIM_NOT_HELD when the claim is missing or mismatched
+ */
+export function assertClaimForWorktree({ workType, claimedBy, sessionId }) {
+  if (workType === 'ADHOC') return;
+  if (!sessionId || claimedBy !== sessionId) {
+    const err = new Error(
+      `Worktree creation for ${workType} requires a held claim: ` +
+      `sessionId=${sessionId || 'MISSING'}, claimedBy=${claimedBy || 'UNCLAIMED'}`
+    );
+    err.code = 'CLAIM_NOT_HELD';
+    throw err;
+  }
+}
+
+/**
  * Reset deprecation warning state (for testing).
  * @internal
  */

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -277,8 +277,27 @@ async function createQuickFix(options = {}) {
   console.log(`   Status: ${data.status}\n`);
 
   // Worktree Isolation for Quick-Fix work
+  // QF-20260424-674: worktree creation is gated on a held DB claim.
+  // Unclaimed QFs are queued with NO registered worktree — the session that
+  // later runs `/leo QF-<id>` is the one that materializes it.
   if (options.autoBranch !== false) { // Default to true
-    console.log('🌲 Worktree Isolation\n');
+    const creatorSessionId = process.env.CLAUDE_SESSION_ID;
+    if (!creatorSessionId) {
+      console.log('🌲 Worktree Isolation skipped — QF queued unclaimed.');
+      console.log(`   Run /leo ${qfId} to claim and create a worktree when picking up.\n`);
+      return printNextSteps(qfId, false, null);
+    }
+    // Atomically set claiming_session_id; if another session already holds it, bail.
+    const { data: claimed } = await supabase
+      .from('quick_fixes')
+      .update({ claiming_session_id: creatorSessionId, started_at: new Date().toISOString() })
+      .eq('id', qfId).is('claiming_session_id', null)
+      .select('id,claiming_session_id').maybeSingle();
+    if (!claimed) {
+      console.log('   ⚠️  Could not claim QF atomically — skipping worktree creation.\n');
+      return printNextSteps(qfId, false, null);
+    }
+    console.log(`🌲 Worktree Isolation (claimed by ${creatorSessionId})\n`);
 
     try {
       // Check if git repo

--- a/tests/unit/lib/worktree-manager-claim-gate.test.js
+++ b/tests/unit/lib/worktree-manager-claim-gate.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { assertClaimForWorktree } from '../../../lib/worktree-manager.js';
+
+describe('assertClaimForWorktree (QF-20260424-674)', () => {
+  it('is a no-op for ADHOC work regardless of claim state', () => {
+    expect(() => assertClaimForWorktree({ workType: 'ADHOC', claimedBy: null })).not.toThrow();
+    expect(() => assertClaimForWorktree({ workType: 'ADHOC', claimedBy: 'someone', sessionId: 'me' })).not.toThrow();
+  });
+
+  it('throws CLAIM_NOT_HELD for QF when no session is holding the claim', () => {
+    try {
+      assertClaimForWorktree({ workType: 'QF', claimedBy: null, sessionId: 'sess-1' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('CLAIM_NOT_HELD');
+      expect(err.message).toMatch(/UNCLAIMED/);
+    }
+  });
+
+  it('throws CLAIM_NOT_HELD for SD when a different session holds the claim', () => {
+    try {
+      assertClaimForWorktree({ workType: 'SD', claimedBy: 'other-sess', sessionId: 'me' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('CLAIM_NOT_HELD');
+      expect(err.message).toMatch(/other-sess/);
+    }
+  });
+
+  it('passes for QF when claim matches current session', () => {
+    expect(() =>
+      assertClaimForWorktree({ workType: 'QF', claimedBy: 'sess-1', sessionId: 'sess-1' })
+    ).not.toThrow();
+  });
+
+  it('throws when sessionId is missing for non-ADHOC work', () => {
+    try {
+      assertClaimForWorktree({ workType: 'QF', claimedBy: 'sess-1' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('CLAIM_NOT_HELD');
+      expect(err.message).toMatch(/MISSING/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **QF-20260424-674**: `lib/worktree-manager.js` was creating a git worktree for a QF branch before any session held `quick_fixes.claiming_session_id`. Two sessions running `/leo next` could both land in the pre-allocated worktree before the DB claim race resolved — the losing session's uncommitted edits would contaminate a worktree it didn't own.

Observed live 2026-04-24: worktree `.worktrees/qf/QF-20260424-143` existed with dirty `.worktree.json` + untracked `.ehg-session.json` BEFORE any session had claimed it.

## Changes

- **`lib/worktree-manager.js`** (+27 LOC): new pure helper `assertClaimForWorktree({ workType, claimedBy, sessionId })`. ADHOC passes through; QF/SD throw `CLAIM_NOT_HELD` when the claim is null, missing, or mismatched. No DB coupling in `lib/` — caller supplies claim state.
- **`scripts/create-quick-fix.js`** (+20 LOC): gate the Worktree Isolation block on `CLAUDE_SESSION_ID`. If absent → skip creation (QF queued unclaimed, instruct user to run `/leo <QF-ID>` when picking up). If present → atomically claim via `UPDATE ... WHERE claiming_session_id IS NULL` BEFORE touching the filesystem.
- **`tests/unit/lib/worktree-manager-claim-gate.test.js`** (+46 LOC): 5-case unit test (ADHOC pass-through, null/missing/mismatched claim failure, happy path).

Non-test LOC: 47 — Tier 2 budget of 75.

## Behavior after fix

- Unclaimed QFs have NO registered worktree. The session running `/leo QF-<id>` later is the one that materializes it.
- `.husky/pre-push` retains its inline worktree creation (separate surface, tracked for follow-up).

## Test plan
- [x] Unit tests pass: `npx vitest run tests/unit/lib/worktree-manager-claim-gate.test.js` (5/5 passing)
- [ ] CI green on PR
- [ ] Verify that a new QF created via `scripts/create-quick-fix.js` with `CLAUDE_SESSION_ID` unset does NOT materialize a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)