### PR TITLE
fix(hooks): recognize claude.exe in tick daemon ancestor discovery (SD-LEO-INFRA-FIX-CLAUDE-CODE-001)

### DIFF
--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -115,6 +115,46 @@ function sotAtomicWrite(targetPath, content) {
 }
 
 /**
+ * Select the long-lived Claude Code ancestor from a parsed process chain.
+ * Pure function: takes [{pid, name, ppid}, ...] (chain[0] is current process),
+ * returns the chosen entry or null. Exported for unit tests.
+ *
+ * SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-1, FR-3):
+ *   Pass 1 — outermost claude.exe wins (claude.exe is the modern long-lived
+ *            Claude Code process on Windows; node.exe is often a transient
+ *            subprocess that dies within seconds).
+ *   Pass 2 — original "first node.exe with non-shell parent" rule, with broadened
+ *            skip-set including cmd.exe / pwsh.exe / powershell.exe, preserving
+ *            backward compatibility for environments without claude.exe.
+ *   Pass 3 — defensive fallback: outermost node.exe in chain.
+ */
+function selectAncestorFromChain(chain) {
+  if (!Array.isArray(chain) || chain.length < 2) return null;
+  const skipParents = ['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh', 'cmd.exe', 'pwsh.exe', 'powershell.exe'];
+
+  // Pass 1: outermost claude.exe wins.
+  for (let i = chain.length - 1; i >= 1; i--) {
+    if (chain[i].name === 'claude.exe') return chain[i];
+  }
+
+  // Pass 2: original semantics with broadened skip-set.
+  for (let i = 1; i < chain.length; i++) {
+    const proc = chain[i];
+    if (proc.name === 'node.exe' || proc.name === 'node') {
+      const parent = chain[i + 1];
+      if (!parent || !skipParents.includes(parent.name)) return proc;
+    }
+  }
+
+  // Pass 3: outermost node.exe defensive fallback.
+  for (let i = chain.length - 1; i >= 1; i--) {
+    if (chain[i].name === 'node.exe' || chain[i].name === 'node') return chain[i];
+  }
+
+  return null;
+}
+
+/**
  * Find the Claude Code node.exe PID by walking the process ancestry chain.
  * Mirrors the logic in lib/terminal-identity.js findClaudeCodePid(), but in CJS
  * for use in this hook. Falls back to process scan if tree walk fails.
@@ -155,17 +195,11 @@ function findClaudeCodePid(entryPath = 'unknown') {
         return { pid, name: (name || '').toLowerCase(), ppid };
       });
 
-      // Find the first node.exe whose parent is NOT node/bash/sh
-      for (let i = 1; i < chain.length; i++) {
-        const proc = chain[i];
-        if (proc.name === 'node.exe' || proc.name === 'node') {
-          const parent = chain[i + 1];
-          if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'].includes(parent.name)) {
-            const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
-            logDiscoveryEvent({ entry_path: entryPath, method_used: 'tree_walk', outcome: 'success', duration_ms: dur, chain_depth: chain.length });
-            return proc.pid;
-          }
-        }
+      const selected = selectAncestorFromChain(chain);
+      if (selected) {
+        const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
+        logDiscoveryEvent({ entry_path: entryPath, method_used: 'tree_walk', outcome: 'success', duration_ms: dur, chain_depth: chain.length, resolved_name: selected.name });
+        return selected.pid;
       }
     }
     const dur = Number((process.hrtime.bigint() - walkStart) / 1000000n);
@@ -176,7 +210,9 @@ function findClaudeCodePid(entryPath = 'unknown') {
     /* fall through to scan */
   }
 
-  // Method 2: Scan all node.exe processes for SSE port match
+  // Method 2: Scan all node.exe / claude.exe processes for SSE port match.
+  // SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-2): single CIM round-trip with WQL OR-filter so the
+  // fallback path also discovers claude.exe and stays within SCAN_TIMEOUT_MS.
   const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
   if (!ssePort) {
     logDiscoveryEvent({ entry_path: entryPath, method_used: 'scan', outcome: 'skipped_no_sse_port' });
@@ -185,7 +221,7 @@ function findClaudeCodePid(entryPath = 'unknown') {
   const scanStart = process.hrtime.bigint();
   try {
     const script = [
-      'Get-CimInstance Win32_Process -Filter "Name=\'node.exe\'" -ErrorAction SilentlyContinue |',
+      'Get-CimInstance Win32_Process -Filter "Name=\'node.exe\' OR Name=\'claude.exe\'" -ErrorAction SilentlyContinue |',
       `  Where-Object { $_.ProcessId -ne ${process.pid} -and $_.CommandLine -match '${ssePort}' } |`,
       '  ForEach-Object { $_.ProcessId } |',
       '  Select-Object -First 1'
@@ -471,4 +507,9 @@ function main() {
   });
 }
 
-main().then(() => process.exit(0)).catch(() => process.exit(0));
+// SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-5): expose pure helpers for unit tests.
+module.exports = { selectAncestorFromChain, findClaudeCodePid };
+
+if (require.main === module) {
+  main().then(() => process.exit(0)).catch(() => process.exit(0));
+}

--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -31,6 +31,14 @@ const TICK_MS = 30 * 1000;
 const PARENT_POLL_MS = 5 * 1000;
 const HTTP_TIMEOUT_MS = 3000;
 
+// SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-4): early-exit telemetry threshold + sinks.
+// If cleanupAndExit fires within EARLY_EXIT_THRESHOLD_MS of process start, emit a
+// structured tick.early_exit event so operators can detect ancestor-discovery regressions.
+const EARLY_EXIT_THRESHOLD_MS = 60 * 1000;
+const EARLY_EXIT_HTTP_TIMEOUT_MS = 1000;
+const startedAt = Date.now();
+const earlyExitNdjsonPath = path.resolve(__dirname, '../.claude/pids/spawn-errors.log');
+
 const sessionId = process.env.CLAUDE_SESSION_ID || '';
 const parentPid = Number(process.env.CC_PARENT_PID) || 0;
 
@@ -126,7 +134,68 @@ async function tickOnce() {
 
 // ── Main loop ────────────────────────────────────────────────────────────────
 
+// SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-4): emit tick.early_exit telemetry when
+// cleanupAndExit runs within 60s of process start. Two sinks:
+//   1. NDJSON append to .claude/pids/spawn-errors.log (sync-safe, signal-handler-tolerant)
+//   2. Best-effort PostgREST POST to session_lifecycle_events (queryable across fleet)
+// Sink 1 is the durable record. Sink 2 is opportunistic — sync handlers may exit
+// before the fetch resolves, so we do not await it.
+function emitEarlyExitTelemetry(exitCode, lifetimeMs) {
+  const event = {
+    timestamp: new Date().toISOString(),
+    event: 'tick.early_exit',
+    session_id: sessionId,
+    tick_pid: process.pid,
+    cc_parent_pid: parentPid,
+    lifetime_ms: lifetimeMs,
+    exit_code: exitCode,
+    hostname: require('os').hostname(),
+  };
+
+  // Sink 1: synchronous NDJSON append (guaranteed durability under signal teardown).
+  try {
+    fs.mkdirSync(path.dirname(earlyExitNdjsonPath), { recursive: true });
+    fs.appendFileSync(earlyExitNdjsonPath, JSON.stringify(event) + '\n');
+  } catch {
+    // file write failures are non-fatal — DB sink may still capture the event
+  }
+
+  // Sink 2: best-effort PostgREST POST to session_lifecycle_events.
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) return;
+  try {
+    const url = `${supabaseUrl.replace(/\/$/, '')}/rest/v1/session_lifecycle_events`;
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), EARLY_EXIT_HTTP_TIMEOUT_MS);
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        event_type: 'tick.early_exit',
+        session_id: sessionId,
+        pid: process.pid,
+        reason: 'ancestor_pid_exited',
+        latency_ms: lifetimeMs,
+        metadata: { cc_parent_pid: parentPid, exit_code: exitCode, hostname: event.hostname },
+      }),
+      signal: controller.signal,
+    }).catch(() => { /* best-effort */ });
+  } catch {
+    /* best-effort */
+  }
+}
+
 function cleanupAndExit(code) {
+  const lifetimeMs = Date.now() - startedAt;
+  if (lifetimeMs < EARLY_EXIT_THRESHOLD_MS) {
+    try { emitEarlyExitTelemetry(code, lifetimeMs); } catch { /* never block exit */ }
+  }
   deleteMarker();
   process.exit(code);
 }

--- a/tests/unit/hooks/capture-session-id.test.cjs
+++ b/tests/unit/hooks/capture-session-id.test.cjs
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for scripts/hooks/capture-session-id.cjs
+ * SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-5)
+ *
+ * Covers TS-1..TS-6:
+ *   TS-1: Mixed claude.exe/node.exe chain returns claude.exe PID
+ *   TS-2: node.exe-only chain returns outermost node.exe (backward compat)
+ *   TS-3: Outermost-ancestor selection prevents wrong-process latching
+ *   TS-4: tick.early_exit telemetry fires when cleanupAndExit <60s after start
+ *   TS-5: SSE-port scan filter accepts claude.exe via WQL OR (verified by string inspection)
+ *   TS-6: cleanupAndExit beyond 60s does NOT emit early_exit telemetry
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawn } = require('child_process');
+
+const { selectAncestorFromChain } = require(path.resolve(__dirname, '../../../scripts/hooks/capture-session-id.cjs'));
+
+// ── TS-1, TS-2, TS-3: selectAncestorFromChain ────────────────────────────────
+
+test('TS-1: mixed claude.exe/node.exe chain returns claude.exe PID', () => {
+  const chain = [
+    { pid: '100', name: 'capture-session-id', ppid: '200' },          // hook process
+    { pid: '200', name: 'bash.exe',           ppid: '300' },
+    { pid: '300', name: 'node.exe',           ppid: '400' },          // npm worker (transient)
+    { pid: '400', name: 'claude.exe',         ppid: '500' },          // long-lived target
+    { pid: '500', name: 'cmd.exe',            ppid: '0' },
+  ];
+  const selected = selectAncestorFromChain(chain);
+  assert.equal(selected.pid, '400');
+  assert.equal(selected.name, 'claude.exe');
+});
+
+test('TS-2: node.exe-only chain returns the correct node (backward compatibility)', () => {
+  // Original semantics: first node.exe whose parent is non-shell.
+  const chain = [
+    { pid: '100', name: 'capture-session-id', ppid: '200' },
+    { pid: '200', name: 'node.exe',           ppid: '300' },          // inner — parent IS node, skip
+    { pid: '300', name: 'node.exe',           ppid: '400' },          // outer — parent NOT in skip-set → win
+    { pid: '400', name: 'cmd.exe',            ppid: '0' },
+  ];
+  const selected = selectAncestorFromChain(chain);
+  assert.equal(selected.pid, '300');
+  assert.equal(selected.name, 'node.exe');
+});
+
+test('TS-3: outermost-ancestor selection — claude.exe wins over earlier transient node.exe', () => {
+  const chain = [
+    { pid: '100', name: 'capture-session-id', ppid: '200' },
+    { pid: '200', name: 'node.exe',           ppid: '300' },          // worker dies in 5s
+    { pid: '300', name: 'node.exe',           ppid: '400' },          // npm
+    { pid: '400', name: 'claude.exe',         ppid: '500' },          // <- expected
+    { pid: '500', name: 'cmd.exe',            ppid: '0' },
+  ];
+  const selected = selectAncestorFromChain(chain);
+  assert.equal(selected.pid, '400');
+  assert.equal(selected.name, 'claude.exe');
+});
+
+test('TS-3b: walk does not stop early on cmd.exe / powershell.exe / pwsh.exe parents', () => {
+  // node.exe whose parent is powershell.exe — broadened skip-set should keep walking.
+  const chain = [
+    { pid: '100', name: 'capture-session-id', ppid: '200' },
+    { pid: '200', name: 'node.exe',           ppid: '300' },          // inner node, parent in broadened skip
+    { pid: '300', name: 'powershell.exe',     ppid: '400' },
+    { pid: '400', name: 'node.exe',           ppid: '500' },          // outer node, parent NOT in skip → win
+    { pid: '500', name: 'cmd.exe',            ppid: '0' },
+  ];
+  const selected = selectAncestorFromChain(chain);
+  assert.equal(selected.pid, '400');
+});
+
+test('selectAncestorFromChain returns null for empty/single-element chains', () => {
+  assert.equal(selectAncestorFromChain([]), null);
+  assert.equal(selectAncestorFromChain([{ pid: '100', name: 'x', ppid: '0' }]), null);
+  assert.equal(selectAncestorFromChain(null), null);
+});
+
+test('selectAncestorFromChain falls back to outermost node.exe when no claude.exe and Pass 2 fails', () => {
+  // Both node.exe entries have parents in skip-set (chain of node-only); Pass 2 finds nothing,
+  // Pass 3 returns the outermost.
+  const chain = [
+    { pid: '100', name: 'capture-session-id', ppid: '200' },
+    { pid: '200', name: 'node.exe',           ppid: '300' },
+    { pid: '300', name: 'node.exe',           ppid: '400' },
+    { pid: '400', name: 'bash.exe',           ppid: '500' }, // chain ends in bash
+  ];
+  const selected = selectAncestorFromChain(chain);
+  // Pass 2 finds pid 300 (parent bash.exe is in skip-set → keep walking past 200; 300's parent is bash → skip; loop ends with no match)
+  // Wait: Pass 2 returns the FIRST node.exe whose parent is NOT in skip-set. Both 200 and 300 have parents in skip-set, so Pass 2 finds nothing.
+  // Pass 3 returns outermost node.exe → pid 300.
+  assert.equal(selected.pid, '300');
+});
+
+// ── TS-5: SSE-port scan filter contains WQL OR for claude.exe ────────────────
+// Static inspection of the source ensures the filter string change shipped.
+
+test('TS-5: SSE-port scan filter includes claude.exe via WQL OR-syntax', () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '../../../scripts/hooks/capture-session-id.cjs'),
+    'utf8'
+  );
+  // Source has the inner single quotes JS-escaped: Name=\'node.exe\' OR Name=\'claude.exe\'.
+  // Match both names with any quoting in between, plus the literal OR keyword.
+  assert.match(src, /Name=\\?'node\.exe\\?'\s+OR\s+Name=\\?'claude\.exe\\?'/);
+});
+
+// ── TS-4 + TS-6: session-tick.cjs early-exit telemetry ───────────────────────
+// Spawn session-tick.cjs as a child with a parent PID guaranteed to be dead
+// (parentPid = 1, which is reserved on Windows for the Idle process — process.kill(1, 0)
+// raises EPERM on some setups, so we use a clearly-invalid PID instead).
+
+test('TS-4: cleanupAndExit within 60s appends NDJSON event=tick.early_exit', async () => {
+  const tickPath = path.resolve(__dirname, '../../../scripts/session-tick.cjs');
+  const ndjsonPath = path.resolve(__dirname, '../../../.claude/pids/spawn-errors.log');
+  const sessionId = `test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  // Use a definitely-dead PID. Pick a high random number unlikely to be alive.
+  // process.kill(<dead>, 0) raises ESRCH which session-tick treats as parentAlive=false.
+  const deadPid = 999999999;
+
+  const sizeBefore = fs.existsSync(ndjsonPath) ? fs.statSync(ndjsonPath).size : 0;
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tickPath], {
+      env: {
+        ...process.env,
+        CLAUDE_SESSION_ID: sessionId,
+        CC_PARENT_PID: String(deadPid),
+        // Disable PostgREST POST during tests (no SUPABASE_* vars => sink 2 skipped).
+        SUPABASE_URL: '',
+        NEXT_PUBLIC_SUPABASE_URL: '',
+        SUPABASE_SERVICE_ROLE_KEY: '',
+      },
+      stdio: 'ignore',
+      timeout: 15000,
+    });
+    child.on('exit', () => resolve());
+    child.on('error', reject);
+  });
+
+  // The tick polls parent every 5s; on the first poll the parent (deadPid) is ESRCH,
+  // so cleanupAndExit fires within ~5s — well under the 60s threshold.
+  // Verify NDJSON contains a tick.early_exit entry for our sessionId.
+  assert.ok(fs.existsSync(ndjsonPath), 'spawn-errors.log should exist after early exit');
+
+  const allBytes = fs.readFileSync(ndjsonPath, 'utf8');
+  const newBytes = allBytes.slice(sizeBefore);
+  const matchingLines = newBytes
+    .split('\n')
+    .map(line => { try { return JSON.parse(line); } catch { return null; } })
+    .filter(obj => obj && obj.event === 'tick.early_exit' && obj.session_id === sessionId);
+
+  assert.ok(matchingLines.length >= 1, `expected tick.early_exit row for ${sessionId} in NDJSON; new bytes: ${newBytes.slice(0, 500)}`);
+  const evt = matchingLines[0];
+  assert.equal(evt.session_id, sessionId);
+  assert.equal(evt.cc_parent_pid, deadPid);
+  assert.ok(evt.lifetime_ms < 60000, `lifetime_ms should be <60000, got ${evt.lifetime_ms}`);
+  assert.ok(typeof evt.tick_pid === 'number');
+  assert.ok(typeof evt.hostname === 'string');
+});
+
+test('TS-6: cleanupAndExit beyond 60s does NOT emit tick.early_exit (negative case)', () => {
+  // Static inspection of session-tick.cjs to verify the threshold guard is in place.
+  // A live integration test would require waiting >60s; we verify the guard logic exists.
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '../../../scripts/session-tick.cjs'),
+    'utf8'
+  );
+  assert.match(src, /EARLY_EXIT_THRESHOLD_MS\s*=\s*60\s*\*\s*1000/);
+  assert.match(src, /lifetimeMs\s*<\s*EARLY_EXIT_THRESHOLD_MS/);
+  assert.match(src, /event:\s*'tick\.early_exit'/);
+});


### PR DESCRIPTION
## Summary

**SD**: SD-LEO-INFRA-FIX-CLAUDE-CODE-001 — *Fix Claude Code ancestor-PID discovery for tick daemon (claude.exe vs node.exe)*

The SessionStart hook's `findClaudeCodePid()` only recognized `node.exe` in the ancestor chain, so on modern Windows Claude Code builds (which run as `claude.exe`) the tick daemon would latch onto a transient `node.exe` npm worker that died within seconds, causing the daemon to suicide on its first 5s parent-liveness poll. Operators hit this often enough to memorize a manual re-spawn workaround (memory: `feedback_tick_daemon_manual_spawn`).

### Functional Requirements (LEAD-locked scope: FR-1, FR-2, FR-3)

- **FR-1**: Tree-walk in `scripts/hooks/capture-session-id.cjs` recognizes `claude.exe`
- **FR-2**: SSE-port scan WQL filter widened with OR-syntax: `Name='node.exe' OR Name='claude.exe'` (single CIM round-trip preserves SCAN_TIMEOUT_MS)
- **FR-3**: Outermost long-lived `claude.exe` wins over earlier transient `node.exe`; parent skip-set broadened to include `cmd.exe` / `pwsh.exe` / `powershell.exe`
- **FR-4** (telemetry): `scripts/session-tick.cjs` `cleanupAndExit` emits structured `tick.early_exit` event when daemon dies <60s after spawn — synchronous NDJSON append to `.claude/pids/spawn-errors.log` (durable under signal teardown) plus best-effort POST to `session_lifecycle_events` table (queryable across fleet)
- **FR-5** (tests): New `tests/unit/hooks/capture-session-id.test.cjs` covers TS-1..TS-6 (mixed chain, node-only backward compat, outermost selection, broadened skip-set, OR-filter shipped, live `tick.early_exit` integration). 9 tests pass in ~5s.

### Out of scope (deferred at LEAD; original FR-4/5/6)

- Sweep-orphan-session-markers script
- claim-validity-gate error message improvement
- spawn-tick-canonical disposition

### Backward compatibility

- TS-2 verifies `node.exe`-only chains still return the outermost `node.exe`
- TS-3b verifies wrapper-shell parent layouts (powershell.exe in chain) work
- Linux/macOS unchanged (existing early-return preserved)

### Sub-agent gates (PLAN-TO-EXEC handoff: 91% / 25 gates green)

| Sub-agent | Verdict | Confidence |
|-----------|---------|------------|
| DESIGN | PASS | 95% |
| DATABASE | PASS | 100% |
| RISK | PASS | 85% (LOW) |

Database-agent independently identified `session_lifecycle_events` as the canonical telemetry sink (existing 6,254-row table, indexed on `(event_type, created_at DESC)`, service_role write RLS). Design-agent confirmed identity-based outermost selection (no start-time CIM queries) and single-WQL-OR-filter scan.

### Refactor

Chain selection extracted to a pure `selectAncestorFromChain(chain)` exported via `module.exports` so unit tests need no `execSync` mocking. `main()` guarded by `require.main === module` so importing the file does not trigger the hook.

## Test plan

- [x] Unit: `node --test tests/unit/hooks/capture-session-id.test.cjs` — 9 pass, 0 fail (~5s)
- [x] Backward compat: `node --test tests/unit/hooks/tool-timeout.test.cjs` — 18 pass, 0 fail
- [x] Static: TS-5 inspects source for the WQL OR-filter literal
- [x] Live integration: TS-4 spawns `session-tick.cjs` with a doomed parent PID, asserts `tick.early_exit` NDJSON line appears in `.claude/pids/spawn-errors.log` with correct `lifetime_ms`, `cc_parent_pid`, `session_id`
- [ ] Manual: trigger SessionStart on a fresh CC Windows session post-merge; observe `process_alive_at` updates within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>