### PR TITLE
fix(QF-20260424-371): orphan-qf-reaper uses --ignore-scripts to avoid husky prepare failure

### DIFF
--- a/.github/workflows/orphan-qf-reaper.yml
+++ b/.github/workflows/orphan-qf-reaper.yml
@@ -49,7 +49,11 @@ jobs:
           cache: 'npm'
 
       - name: Install minimal deps
-        run: npm ci --omit=dev --prefer-offline --no-audit
+        # QF-20260424-371: --ignore-scripts matches canonical repo CI pattern
+        # (8/9 peer workflows). --omit=dev alone stripped husky then fired the
+        # prepare lifecycle -> "husky: not found" exit 127. See RCA for
+        # pattern PAT-CI-WORKFLOW-LIFECYCLE-001.
+        run: npm ci --ignore-scripts --prefer-offline --no-audit
 
       - name: Run reaper
         id: run


### PR DESCRIPTION
## Summary

Workflow `orphan-qf-reaper.yml` used `npm ci --omit=dev` alone; `--omit=dev` stripped husky but npm still ran the `prepare` lifecycle which invokes husky, failing with `sh: 1: husky: not found` exit 127. Reaper 100% broken on main since commit 3f7b4bc6 (2026-04-24 07:04 EDT).

- Single-line fix: switch to `npm ci --ignore-scripts --prefer-offline --no-audit`, matching the canonical CI install pattern used by 8/9 peer workflows.
- Dropped `--omit=dev` (redundant with `--ignore-scripts` for this script-only job).
- Surfaced via `/leo assist` Phase 1 → 2x RCA sub-agent runs on feedback rows `fdd989af` + `98bcfa1f`.

## RCA root cause (5-whys summary)

- **Surface**: workflow uses `npm ci --omit=dev` without `--ignore-scripts`; prepare lifecycle still runs and invokes husky binary stripped by `--omit=dev`.
- **Systemic**: no repo-level lint enforces the canonical `npm ci --ignore-scripts` pattern on workflow YAML; lone deviations only surface on first scheduled run on main.

## Follow-ups (not in this PR)

- Register pattern `PAT-CI-WORKFLOW-LIFECYCLE-001` in `issue_patterns`.
- File preventive SD extending `SD-PROTOCOL-LINTER-001` — workflow-YAML rule catching `npm ci|install` without `--ignore-scripts`.

## Test plan

- [ ] CI: existing pre-merge checks on this PR pass (no new tests required for workflow-YAML edit).
- [ ] Post-merge: verify next scheduled `orphan-qf-reaper` run on main succeeds past "Install minimal deps" step (≤15min after merge).
- [ ] Post-merge: verify reaper actually processes any orphan QF rows (check `quick_fixes` status transitions for rows with merged PRs).
- [ ] Smoke tests pass locally (pre-commit hook verified — 15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)