### PR TITLE
feat(SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001): cross-signal claim liveness — multi-source pre-claim gate

### DIFF
--- a/scripts/modules/claim-health/triangulate.js
+++ b/scripts/modules/claim-health/triangulate.js
@@ -1,26 +1,50 @@
 /**
  * Claim Health Triangulation Module
  * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ * SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — added FR1 (4 new evidence-of-life signals) + FR3 (PID liveness hardening)
  *
- * Cross-references multiple signal sources to detect claim discrepancies:
+ * Cross-references multiple signal sources to detect claim discrepancies and protect against
+ * hostile reclaim of active CC conversations whose session_id rotated across claude.exe restart.
+ *
+ * Original signals (1-4):
  * 1. claude_sessions (DB) — what sessions think they own
  * 2. strategic_directives_v2.is_working_on — what SDs think is active
  * 3. .worktrees/ directory — physical evidence of in-progress work
- * 4. OS process table — PID liveness check
+ * 4. OS process table — PID liveness check (process.kill(pid, 0))
+ *
+ * Added signals (5-8) — evidence-of-life that protects against premature reclaim:
+ * 5. Branch presence — local or remote feat/SD-* branch matching the SD key
+ * 6. Plan-file indirection — .claude/plans/* file referencing the SD key
+ * 7. Recent sub-agent activity — sub_agent_execution_results.created_at within last 5 min for the SD
+ * 8. Sibling-session-branch — another active session with worktree_branch matching the SD
+ *
+ * Hardened PID liveness (FR3):
+ * PID_DEAD requires BOTH (a) process.kill(pid, 0) raises ESRCH AND (b) process_alive_at tick
+ * recency older than 90s. Either alone is insufficient because cross-shell processes can
+ * fail process.kill while their tick daemon is still writing heartbeats.
  */
 
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
 const WORKTREES_DIR = path.join(PROJECT_ROOT, '.worktrees');
+const PLANS_DIR = path.join(PROJECT_ROOT, '.claude', 'plans');
+
+// FR3: Tick recency threshold — process_alive_at must be at most this stale to be considered alive.
+// Aligned with claude_sessions.process_alive_at docs ("if < 90s old, worker is alive").
+export const TICK_RECENT_SECONDS = 90;
+
+// FR1.c / FR1.d: Sub-agent activity / sibling-session lookback window.
+export const ACTIVITY_LOOKBACK_SECONDS = 5 * 60;
 
 /**
- * Check if a process is running by PID
- * @param {number} pid
- * @returns {boolean}
+ * Check if a process is running by PID.
+ * EPERM means process exists but caller lacks permission — still alive.
+ * ESRCH or other errors mean dead/unknown.
  */
 function isProcessRunning(pid) {
   if (!pid || isNaN(pid)) return false;
@@ -28,13 +52,22 @@ function isProcessRunning(pid) {
     process.kill(pid, 0);
     return true;
   } catch (e) {
-    return e.code === 'EPERM'; // EPERM = process exists but no permission
+    return e.code === 'EPERM';
   }
 }
 
 /**
- * Get active worktrees with SD keys
- * @returns {Map<string, {path: string, hasChanges: boolean, mtime: Date}>}
+ * FR3: Tick recency — was process_alive_at updated recently enough that we believe the
+ * tick daemon (and therefore the parent CC process) is still alive?
+ */
+function hasRecentTick(processAliveAt) {
+  if (!processAliveAt) return false;
+  const ageSec = (Date.now() - new Date(processAliveAt).getTime()) / 1000;
+  return ageSec <= TICK_RECENT_SECONDS;
+}
+
+/**
+ * Get active worktrees with SD keys.
  */
 function getActiveWorktrees() {
   const result = new Map();
@@ -52,16 +85,13 @@ function getActiveWorktrees() {
       const stat = fs.statSync(wtPath);
       mtime = stat.mtime;
 
-      // Check for uncommitted changes by looking at git status
       const gitDir = path.join(wtPath, '.git');
       if (fs.existsSync(gitDir)) {
-        // Simple heuristic: check if index file was recently modified
         const indexPath = typeof gitDir === 'string' && fs.statSync(gitDir).isFile()
           ? path.join(fs.readFileSync(gitDir, 'utf8').replace('gitdir: ', '').trim(), 'index')
           : path.join(gitDir, 'index');
         if (fs.existsSync(indexPath)) {
           const indexStat = fs.statSync(indexPath);
-          // If git index was modified in last hour, likely has changes
           hasChanges = (Date.now() - indexStat.mtimeMs) < 3600000;
         }
       }
@@ -77,8 +107,6 @@ function getActiveWorktrees() {
 
 /**
  * Extract PID from session_id string (format: session_{hash}_{platform}{winPid}_{ccPid})
- * @param {string} sessionId
- * @returns {number|null}
  */
 function extractPidFromSessionId(sessionId) {
   if (!sessionId) return null;
@@ -86,22 +114,146 @@ function extractPidFromSessionId(sessionId) {
   return match ? parseInt(match[1], 10) : null;
 }
 
+// ─── FR1.a: Branch presence ──────────────────────────────────────────────────
 /**
- * Triangulate claim health across all signal sources
+ * Build the set of feat/SD-* branch names present locally OR on origin.
+ * Cached per triangulate() invocation via the caller passing in a precomputed Set.
+ */
+function listFeatSdBranches() {
+  try {
+    const out = execSync(
+      'git for-each-ref --format=%(refname:short) refs/heads/feat/SD- refs/remotes/origin/feat/SD-',
+      { cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    const branches = new Set();
+    for (const line of out.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      // Strip leading "origin/" so callers can match on logical branch name
+      const logical = trimmed.replace(/^origin\//, '');
+      branches.add(logical);
+    }
+    return branches;
+  } catch {
+    return new Set();
+  }
+}
+
+function hasBranchForSd(branchSet, sdKey) {
+  if (!branchSet || !sdKey) return false;
+  // feat/<sdKey> exact match OR any branch containing the sdKey segment
+  if (branchSet.has(`feat/${sdKey}`)) return true;
+  for (const b of branchSet) {
+    if (b.includes(sdKey)) return true;
+  }
+  return false;
+}
+
+// ─── FR1.b: Plan-file indirection ────────────────────────────────────────────
+/**
+ * Build the set of plan-file basenames under .claude/plans/.
+ * Returns empty set if the directory doesn't exist.
+ */
+function listPlanFiles() {
+  try {
+    if (!fs.existsSync(PLANS_DIR)) return new Set();
+    const entries = fs.readdirSync(PLANS_DIR, { withFileTypes: true });
+    const files = new Set();
+    for (const e of entries) {
+      if (e.isFile()) files.add(e.name);
+    }
+    return files;
+  } catch {
+    return new Set();
+  }
+}
+
+function hasPlanFileForSd(planSet, sdKey) {
+  if (!planSet || !sdKey) return false;
+  for (const f of planSet) {
+    if (f.includes(sdKey)) return true;
+  }
+  return false;
+}
+
+// ─── FR1.c: Recent sub-agent activity ────────────────────────────────────────
+/**
+ * Build a Set of sd_id (UUID) values that have sub_agent_execution_results
+ * within the last ACTIVITY_LOOKBACK_SECONDS. Single bulk query, then in-memory lookup.
+ */
+async function buildRecentActivitySet(supabase) {
+  const since = new Date(Date.now() - ACTIVITY_LOOKBACK_SECONDS * 1000).toISOString();
+  try {
+    const { data, error } = await supabase
+      .from('sub_agent_execution_results')
+      .select('sd_id')
+      .gte('created_at', since)
+      .not('sd_id', 'is', null);
+    if (error) return new Set();
+    const set = new Set();
+    for (const row of (data || [])) {
+      if (row.sd_id) set.add(row.sd_id);
+    }
+    return set;
+  } catch {
+    return new Set();
+  }
+}
+
+// ─── FR1.d: Sibling-session-branch ───────────────────────────────────────────
+/**
+ * Build a Map<sdKey, Set<sessionId>> of sessions whose worktree_branch references
+ * a feat/SD-* branch and whose heartbeat is recent.
+ *
+ * The map key is the inferred sdKey extracted from worktree_branch. Caller
+ * supplies their own session_id so they can exclude themselves from the result.
+ */
+async function buildSiblingSessionMap(supabase) {
+  const since = new Date(Date.now() - ACTIVITY_LOOKBACK_SECONDS * 1000).toISOString();
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, worktree_branch, status, heartbeat_at')
+      .gte('heartbeat_at', since)
+      .not('worktree_branch', 'is', null);
+    if (error) return new Map();
+    const map = new Map();
+    for (const row of (data || [])) {
+      const branch = row.worktree_branch || '';
+      const m = branch.match(/(?:^feat\/|\/feat\/)?(SD-[A-Z0-9-]+)/);
+      if (!m) continue;
+      const key = m[1];
+      if (!map.has(key)) map.set(key, new Set());
+      map.get(key).add(row.session_id);
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Triangulate claim health across all signal sources.
+ *
  * @param {object} supabase - Supabase client
  * @param {string} [sdKey] - Optional specific SD key to check (null = all)
+ * @param {object} [opts] - Optional knobs
+ * @param {string} [opts.mySessionId] - Current session_id, excluded from sibling-session-branch detection
  * @returns {Promise<{healthy: Array, orphaned: Array, ghost: Array, discrepancies: Array}>}
  */
-export async function triangulate(supabase, sdKey = null) {
+export async function triangulate(supabase, sdKey = null, opts = {}) {
+  const mySessionId = opts.mySessionId || process.env.CLAUDE_SESSION_ID || null;
   const healthy = [];
   const orphaned = [];
   const ghost = [];
   const discrepancies = [];
 
-  // Signal 1: Get all active/idle session claims from DB
+  // Signal 1: Get all active/idle session claims from DB (includes process_alive_at for FR3)
   let sessionQuery = supabase
     .from('claude_sessions')
-    .select('session_id, sd_key, status, heartbeat_at, terminal_id, pid, hostname')
+    .select('session_id, sd_key, status, heartbeat_at, process_alive_at, terminal_id, pid, hostname')
     .in('status', ['active', 'idle'])
     .not('sd_key', 'is', null);
 
@@ -111,10 +263,10 @@ export async function triangulate(supabase, sdKey = null) {
 
   const { data: sessions } = await sessionQuery;
 
-  // Signal 2: Get all SDs with is_working_on = true
+  // Signal 2: Get all SDs with is_working_on = true (need id for FR1.c sub-agent activity lookup)
   let sdQuery = supabase
     .from('strategic_directives_v2')
-    .select('sd_key, is_working_on, claiming_session_id, status')
+    .select('id, sd_key, is_working_on, claiming_session_id, status')
     .eq('is_working_on', true);
 
   if (sdKey) {
@@ -126,13 +278,25 @@ export async function triangulate(supabase, sdKey = null) {
   // Signal 3: Get active worktrees
   const worktrees = getActiveWorktrees();
 
+  // FR1.a: Build branch set (1 git call, cached per invocation)
+  const branchSet = listFeatSdBranches();
+
+  // FR1.b: Build plan-file set (1 fs scan)
+  const planSet = listPlanFiles();
+
+  // FR1.c: Build recent sub-agent activity set (1 DB query, 5-min window)
+  const activitySdIdSet = await buildRecentActivitySet(supabase);
+
+  // FR1.d: Build sibling-session map (1 DB query, 5-min window)
+  const siblingMap = await buildSiblingSessionMap(supabase);
+
   // Build claim map from sessions
   const sessionClaims = new Map();
   for (const s of (sessions || [])) {
     sessionClaims.set(s.sd_key, s);
   }
 
-  // Build working-on map from SDs
+  // Build working-on map from SDs (sdKey -> sd row, includes id for activity lookup)
   const sdWorkingOn = new Map();
   for (const sd of (workingSDs || [])) {
     sdWorkingOn.set(sd.sd_key, sd);
@@ -142,31 +306,69 @@ export async function triangulate(supabase, sdKey = null) {
   const allSdKeys = new Set([
     ...sessionClaims.keys(),
     ...sdWorkingOn.keys(),
-    ...worktrees.keys()
+    ...worktrees.keys(),
+    ...siblingMap.keys()
   ]);
 
-  for (const key of allSdKeys) {
+  // If sdKey filter is set, narrow the iteration
+  const iterKeys = sdKey ? new Set([sdKey]) : allSdKeys;
+
+  for (const key of iterKeys) {
     const sessionClaim = sessionClaims.get(key);
     const sdRecord = sdWorkingOn.get(key);
     const worktree = worktrees.get(key);
+
+    // FR3: Hardened PID liveness — require BOTH process.kill failure AND tick recency failure for PID_DEAD
+    let pidAlive = false;
+    let tickRecent = false;
+    if (sessionClaim) {
+      const pid = sessionClaim.pid || extractPidFromSessionId(sessionClaim.session_id);
+      pidAlive = pid ? isProcessRunning(pid) : false;
+      tickRecent = hasRecentTick(sessionClaim.process_alive_at);
+    }
+    const pidDead = sessionClaim ? (!pidAlive && !tickRecent) : false;
+
+    // FR1: Evidence-of-life signals
+    const branchPresent = hasBranchForSd(branchSet, key);
+    const planFilePresent = hasPlanFileForSd(planSet, key);
+    const sdUuid = sdRecord?.id || null;
+    const recentSubAgentActivity = sdUuid ? activitySdIdSet.has(sdUuid) : false;
+    const siblings = siblingMap.get(key) || new Set();
+    // Exclude my own session — siblings means OTHER live sessions on the same branch
+    const otherSiblings = mySessionId
+      ? new Set([...siblings].filter(s => s !== mySessionId))
+      : siblings;
+    const siblingSessionOnBranch = otherSiblings.size > 0;
 
     const signals = {
       hasSessionClaim: !!sessionClaim,
       hasIsWorkingOn: !!sdRecord,
       hasWorktree: !!worktree,
-      pidAlive: false,
-      heartbeatStale: false
+      pidAlive,
+      tickRecent,                      // FR3
+      heartbeatStale: false,
+      branchPresent,                   // FR1.a
+      planFilePresent,                 // FR1.b
+      recentSubAgentActivity,          // FR1.c
+      siblingSessionOnBranch           // FR1.d
     };
 
-    // Check PID liveness and heartbeat staleness
     if (sessionClaim) {
-      const pid = sessionClaim.pid || extractPidFromSessionId(sessionClaim.session_id);
-      signals.pidAlive = pid ? isProcessRunning(pid) : false;
       const heartbeatAge = sessionClaim.heartbeat_at
         ? (Date.now() - new Date(sessionClaim.heartbeat_at).getTime()) / 1000
         : Infinity;
       signals.heartbeatStale = heartbeatAge > 300; // 5 minutes
     }
+
+    // Aggregate evidence-of-life. Used by reclaim-protection and ghost classification.
+    const evidenceOfLifeSignals = [];
+    if (signals.branchPresent) evidenceOfLifeSignals.push('branch_present');
+    if (signals.planFilePresent) evidenceOfLifeSignals.push('plan_file_present');
+    if (signals.recentSubAgentActivity) evidenceOfLifeSignals.push('recent_sub_agent_activity');
+    if (signals.siblingSessionOnBranch) evidenceOfLifeSignals.push('sibling_session_on_branch');
+    if (signals.tickRecent) evidenceOfLifeSignals.push('tick_recent');
+    if (signals.pidAlive) evidenceOfLifeSignals.push('pid_alive');
+    const hasEvidenceOfLife = evidenceOfLifeSignals.length > 0;
 
     const entry = {
       sdKey: key,
@@ -175,39 +377,59 @@ export async function triangulate(supabase, sdKey = null) {
       heartbeatAge: sessionClaim?.heartbeat_at
         ? Math.round((Date.now() - new Date(sessionClaim.heartbeat_at).getTime()) / 1000)
         : null,
+      processAliveAge: sessionClaim?.process_alive_at
+        ? Math.round((Date.now() - new Date(sessionClaim.process_alive_at).getTime()) / 1000)
+        : null,
       worktreePath: worktree?.path || null,
-      worktreeHasChanges: worktree?.hasChanges || false
+      worktreeHasChanges: worktree?.hasChanges || false,
+      evidenceOfLifeSignals,           // FR1: surfaces which signals fired
+      siblingSessionIds: [...otherSiblings]
     };
 
-    // Classify
-    if (signals.hasSessionClaim && signals.pidAlive && !signals.heartbeatStale) {
-      // All good — healthy claim
+    // ── Classification ──────────────────────────────────────────────────────
+    if (signals.hasSessionClaim && (signals.pidAlive || signals.tickRecent) && !signals.heartbeatStale) {
+      // Healthy: alive by either PID or tick, recent heartbeat
       healthy.push({ ...entry, category: 'healthy', action: null });
-    } else if (signals.hasSessionClaim && signals.heartbeatStale && !signals.pidAlive) {
-      // Ghost: session claims SD but PID is dead and heartbeat stale
+    } else if (signals.hasSessionClaim && pidDead && !hasEvidenceOfLife) {
+      // FR3 hardened ghost: BOTH PID dead AND tick stale AND no other evidence of life
       ghost.push({
         ...entry,
         category: 'ghost',
-        action: `Safe to release: PID dead, heartbeat ${entry.heartbeatAge}s stale`,
+        action: `Safe to release: PID dead AND tick stale AND no evidence of life. Heartbeat ${entry.heartbeatAge}s.`,
         autoReleasable: true
       });
-    } else if (signals.hasSessionClaim && signals.heartbeatStale && signals.pidAlive) {
-      // Stale but alive — may be under heavy load
+    } else if (signals.hasSessionClaim && pidDead && hasEvidenceOfLife) {
+      // FR3 + FR1: PID/tick dead but other evidence of life present — DO NOT auto-release
+      discrepancies.push({
+        ...entry,
+        category: 'evidence_of_life_no_pid',
+        action: `BLOCK reclaim: PID dead and tick stale but evidence of life present (${evidenceOfLifeSignals.join(', ')}). Likely cross-shell or restarted CC conversation.`,
+        autoReleasable: false
+      });
+    } else if (signals.hasSessionClaim && signals.heartbeatStale && (signals.pidAlive || signals.tickRecent)) {
+      // Stale heartbeat but alive — may be under heavy load
       discrepancies.push({
         ...entry,
         category: 'stale_alive',
-        action: `Heartbeat stale (${entry.heartbeatAge}s) but PID alive — may be busy`
+        action: `Heartbeat stale (${entry.heartbeatAge}s) but ${signals.pidAlive ? 'PID alive' : 'tick recent'} — may be busy`,
+        autoReleasable: false
       });
-    } else if (!signals.hasSessionClaim && (signals.hasIsWorkingOn || signals.hasWorktree)) {
-      // Orphan: no session claim but evidence of work
+    } else if (!signals.hasSessionClaim && (signals.hasIsWorkingOn || signals.hasWorktree || hasEvidenceOfLife)) {
+      // Orphan: no session claim but evidence (is_working_on, worktree, branch, plan, activity, sibling)
       const evidence = [];
       if (signals.hasIsWorkingOn) evidence.push('is_working_on=true');
       if (signals.hasWorktree) evidence.push(`worktree exists at ${worktree.path}`);
+      for (const sig of evidenceOfLifeSignals) evidence.push(sig);
+      const reclaimSafe = !hasEvidenceOfLife;
       orphaned.push({
         ...entry,
         category: 'orphaned',
-        action: `Re-claim with: npm run sd:start ${key}`,
-        evidence
+        action: reclaimSafe
+          ? `Re-claim with: npm run sd:start ${key}`
+          : `BLOCK reclaim without --force-reclaim: evidence of life present (${evidenceOfLifeSignals.join(', ')})`,
+        evidence,
+        reclaimSafe,
+        autoReleasable: reclaimSafe
       });
     } else if (signals.hasSessionClaim && !signals.hasWorktree && !signals.hasIsWorkingOn) {
       // Session claims it but nothing else agrees
@@ -223,9 +445,46 @@ export async function triangulate(supabase, sdKey = null) {
 }
 
 /**
- * Format triangulation results as human-readable report
- * @param {object} results - Output from triangulate()
- * @returns {string}
+ * Convenience: pre-claim gate. Returns { allowReclaim, evidence, classification } so callers
+ * (sd-start.js) can fail closed when evidence of life is detected without --force-reclaim.
+ *
+ * @param {object} supabase
+ * @param {string} sdKey - SD to attempt claim on
+ * @param {object} [opts]
+ * @param {string} [opts.mySessionId]
+ * @returns {Promise<{allowReclaim: boolean, evidence: string[], classification: string|null, entry: object|null}>}
+ */
+export async function checkPreClaimEvidence(supabase, sdKey, opts = {}) {
+  const result = await triangulate(supabase, sdKey, opts);
+  // Look for the SD in any classification bucket
+  const buckets = ['healthy', 'discrepancies', 'orphaned', 'ghost'];
+  for (const b of buckets) {
+    const entry = result[b].find(e => e.sdKey === sdKey);
+    if (!entry) continue;
+    const evidence = entry.evidenceOfLifeSignals || [];
+    // Allow reclaim only if classified as ghost OR orphaned-with-no-evidence
+    let allow;
+    if (entry.category === 'ghost') allow = true;
+    else if (entry.category === 'orphaned' && entry.reclaimSafe === true) allow = true;
+    else allow = false;
+    return {
+      allowReclaim: allow,
+      evidence,
+      classification: entry.category,
+      entry
+    };
+  }
+  // No record found anywhere — SD is unclaimed and clean. Reclaim is allowed.
+  return {
+    allowReclaim: true,
+    evidence: [],
+    classification: null,
+    entry: null
+  };
+}
+
+/**
+ * Format triangulation results as human-readable report.
  */
 export function formatHealthReport(results) {
   const { healthy, orphaned, ghost, discrepancies } = results;
@@ -240,7 +499,7 @@ export function formatHealthReport(results) {
     lines.push('  \x1b[32m✅ HEALTHY (' + healthy.length + ')\x1b[0m');
     for (const h of healthy) {
       lines.push('    ' + h.sdKey);
-      lines.push('      Session: ' + h.sessionId + ' | Heartbeat: ' + h.heartbeatAge + 's');
+      lines.push('      Session: ' + h.sessionId + ' | Heartbeat: ' + h.heartbeatAge + 's | tick: ' + (h.processAliveAge ?? 'n/a') + 's');
       if (h.worktreePath) lines.push('      Worktree: ✓');
     }
   }
@@ -249,7 +508,7 @@ export function formatHealthReport(results) {
     lines.push('');
     lines.push('  \x1b[33m⚠️  ORPHANED (' + orphaned.length + ')\x1b[0m');
     for (const o of orphaned) {
-      lines.push('    ' + o.sdKey);
+      lines.push('    ' + o.sdKey + (o.reclaimSafe ? '' : ' [evidence-of-life]'));
       lines.push('      Evidence: ' + o.evidence.join(', '));
       lines.push('      → ACTION: ' + o.action);
     }
@@ -260,7 +519,7 @@ export function formatHealthReport(results) {
     lines.push('  \x1b[31m👻 GHOST (' + ghost.length + ')\x1b[0m');
     for (const g of ghost) {
       lines.push('    ' + g.sdKey);
-      lines.push('      Session: ' + g.sessionId + ' | Heartbeat: ' + g.heartbeatAge + 's');
+      lines.push('      Session: ' + g.sessionId + ' | Heartbeat: ' + g.heartbeatAge + 's | tick: ' + (g.processAliveAge ?? 'n/a') + 's');
       lines.push('      → ' + g.action);
     }
   }
@@ -270,6 +529,9 @@ export function formatHealthReport(results) {
     lines.push('  \x1b[35m🔍 DISCREPANCIES (' + discrepancies.length + ')\x1b[0m');
     for (const d of discrepancies) {
       lines.push('    ' + d.sdKey + ' [' + d.category + ']');
+      if (d.evidenceOfLifeSignals?.length) {
+        lines.push('      Evidence-of-life: ' + d.evidenceOfLifeSignals.join(', '));
+      }
       lines.push('      → ' + d.action);
     }
   }

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -22,6 +22,11 @@ import { resolveOwnSession } from '../lib/resolve-own-session.js';
 import { assertValidClaim, ClaimIdentityError } from '../lib/claim-validity-gate.js';
 import sessionIdentitySot from '../lib/session-identity-sot.js';
 import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
+// SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — pre-claim multi-signal evidence-of-life gate.
+// Wraps claimGuard's heartbeat/inactive auto-release to prevent hostile reclaim
+// when the prior session has been released but its CC conversation is still active
+// under a rotated session_id (the 2026-04-24 incident class).
+import { checkPreClaimEvidence } from './modules/claim-health/triangulate.js';
 import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
 import { getEstimatedDuration, formatEstimateDetailed } from './lib/duration-estimator.js';
@@ -697,10 +702,85 @@ async function main() {
   // SD-LEO-INFRA-PRE-CLAIM-CHECK-001: Auto-fallback on claim conflict
   const autoProceed = await getSessionAutoProceed(session.session_id);
   const fallbackEnabled = autoProceed || process.argv.includes('--fallback');
+  // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001: --force-reclaim override flag (telemetry-emitting)
+  const forceReclaim = process.argv.includes('--force-reclaim');
   let claimResult = await claimGuard(effectiveId, session.session_id, { autoFallback: fallbackEnabled });
   const skippedSDs = [];
 
   if (!claimResult.success) {
+    // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 (FR2): Evidence-of-life pre-claim gate.
+    // Before any auto-release path, check triangulate() for evidence that the prior
+    // claim's CC conversation is still alive (cross-shell, rotated session_id, etc.).
+    // If evidence is present and --force-reclaim not passed, FAIL CLOSED.
+    try {
+      const evidenceCheck = await checkPreClaimEvidence(supabase, effectiveId, {
+        mySessionId: session.session_id
+      });
+      if (!evidenceCheck.allowReclaim && !forceReclaim) {
+        const evidenceList = (evidenceCheck.evidence || []).join(', ') || 'unknown';
+        console.log(
+          `\n${colors.red}═══════════════════════════════════════════════════════════════════${colors.reset}`
+        );
+        console.log(
+          `${colors.red}🚫 CROSS-SIGNAL EVIDENCE-OF-LIFE GATE BLOCKED — claim_protected${colors.reset}`
+        );
+        console.log(
+          `${colors.red}═══════════════════════════════════════════════════════════════════${colors.reset}`
+        );
+        console.log(`  SD:             ${effectiveId}`);
+        console.log(`  Classification: ${evidenceCheck.classification}`);
+        console.log(`  Evidence:       ${evidenceList}`);
+        console.log(`  My session:     ${session.session_id}`);
+        console.log(`  Owner session:  ${claimResult.owner?.session_id || '(none)'}`);
+        console.log('');
+        console.log(`  ${colors.yellow}Why blocked:${colors.reset} The owning session is released or stale, but`);
+        console.log(`  triangulate() detected evidence the CC conversation is still active`);
+        console.log(`  (sub-agent activity in last 5 min, sibling session on the branch,`);
+        console.log(`  warm worktree, or matching plan-file). Auto-releasing this claim`);
+        console.log(`  would clobber that other session's work.`);
+        console.log('');
+        console.log(`  ${colors.cyan}Options:${colors.reset}`);
+        console.log(`    1. Pick a different SD: npm run sd:next`);
+        console.log(`    2. Confirm the other session is truly gone, then retry with:`);
+        console.log(`       node scripts/sd-start.js ${effectiveId} --force-reclaim`);
+        console.log(
+          `${colors.red}═══════════════════════════════════════════════════════════════════${colors.reset}\n`
+        );
+        process.exit(1);
+      }
+      if (!evidenceCheck.allowReclaim && forceReclaim) {
+        // Telemetry: log the override to audit_log so systemic false-positives surface.
+        const evidenceList = (evidenceCheck.evidence || []).join(', ');
+        console.log(
+          `${colors.yellow}⚠ --force-reclaim override accepted. Evidence-of-life signals were present (${evidenceList}); proceeding anyway.${colors.reset}`
+        );
+        try {
+          await supabase.from('audit_log').insert({
+            event_type: 'claim_force_reclaim',
+            severity: 'warning',
+            actor: session.session_id,
+            details: JSON.stringify({
+              sd_key: effectiveId,
+              classification: evidenceCheck.classification,
+              evidence: evidenceCheck.evidence,
+              owner_session: claimResult.owner?.session_id || null,
+              my_session: session.session_id,
+              at: new Date().toISOString(),
+              source: 'sd-start.js',
+              ref: 'SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001'
+            })
+          });
+        } catch (auditErr) {
+          // audit_log failure is non-blocking but should be visible
+          console.log(`${colors.dim}(audit_log emission skipped: ${auditErr.message})${colors.reset}`);
+        }
+      }
+    } catch (gateErr) {
+      // Gate must fail-open on internal errors so we don't break the claim path entirely.
+      // Real failures will still be caught by the existing claimGuard logic below.
+      console.log(`${colors.dim}(cross-signal gate skipped: ${gateErr.message})${colors.reset}`);
+    }
+
     // SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-001: Heartbeat TTL check (cross-machine compatible)
     // Releases claims from sessions whose heartbeat is >30 minutes stale, regardless of PID visibility.
     let autoReleased = false;

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -727,6 +727,31 @@ async function main() {
       }
     }
 
+    // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 (FR4): Cross-check evidence-of-life before releasing.
+    // sweep historically used (heartbeat>threshold + PID dead + MC P(alive)<=0.3) as the
+    // release predicate, but this misses cross-shell processes whose CC conversation rotated
+    // session_id while the worktree is still warm. Defer to triangulate's multi-signal check
+    // for the SD this session claimed; if evidence-of-life present, HOLD (do not release).
+    if (s.sd_key) {
+      try {
+        // Lazy import — keep CJS sweep file independent of ESM triangulate at module load
+        const { checkPreClaimEvidence } = await import('./modules/claim-health/triangulate.js');
+        const evidence = await checkPreClaimEvidence(supabase, s.sd_key, { mySessionId: s.session_id });
+        if (!evidence.allowReclaim) {
+          warnings.push(
+            'WIP_GUARD_CROSS_SIGNAL: ' + s.session_id + ' SD=' + s.sd_key +
+            ' has evidence-of-life (' + (evidence.evidence || []).join(',') +
+            ') classification=' + evidence.classification + ' — HOLDING release (SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001)'
+          );
+          continue;
+        }
+      } catch (egErr) {
+        // Evidence gate must fail-open: if the import or query fails, fall through to
+        // existing release behavior. The original heartbeat/PID/MC gates above remain in force.
+        warnings.push('CROSS_SIGNAL_GATE: skipped on ' + s.session_id + ' due to error: ' + egErr.message);
+      }
+    }
+
     // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-1, FR-2): Atomically set is_alive=false
     // and clear dirty fields when releasing dead session claims. Prevents successor sessions
     // from inheriting stale worktree_path, has_uncommitted_changes, and current_branch.

--- a/tests/unit/triangulate-multi-signal.test.js
+++ b/tests/unit/triangulate-multi-signal.test.js
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for triangulate.js multi-signal claim liveness
+ *
+ * SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — FR5 regression coverage
+ *
+ * Covers AC1-AC4:
+ * - AC1: triangulate() classifies released-session-with-active-CC as evidence_of_life_no_pid (NOT orphaned),
+ *        when worktree + plan-file + recent activity + sibling-session signals fire.
+ * - AC2: checkPreClaimEvidence() returns allowReclaim=false when evidence-of-life present.
+ * - AC3: PID_DEAD requires BOTH process.kill ESRCH AND tickRecent=false. Either alone -> still alive.
+ * - AC4: orphaned[reclaimSafe=false] when evidence-of-life present (would have authorized hostile reclaim before).
+ *
+ * Replays the 2026-04-24 incident: session 4b78a802 status=released in claude_sessions, but its CC
+ * conversation was actively working in the same worktree under rotated session_id. Old triangulate
+ * classified as orphaned -> would have authorized hostile reclaim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { triangulate, checkPreClaimEvidence, TICK_RECENT_SECONDS, ACTIVITY_LOOKBACK_SECONDS } from '../../scripts/modules/claim-health/triangulate.js';
+
+// ── Fake Supabase client ─────────────────────────────────────────────────────
+//
+// Builds a minimal supabase shim that returns canned data for the queries
+// triangulate() makes. Each table returns a fixed dataset; filters are applied
+// in-memory so tests can assert on the post-filter behavior.
+
+function makeFakeSupabase({ claudeSessions = [], strategicDirectives = [], subAgentResults = [] } = {}) {
+  function tableQuery(rows) {
+    let result = [...rows];
+    const builder = {
+      _result: result,
+      select() { return builder; },
+      eq(col, val) { builder._result = builder._result.filter(r => r[col] === val); return builder; },
+      in(col, vals) { builder._result = builder._result.filter(r => vals.includes(r[col])); return builder; },
+      not(col, op, val) {
+        if (op === 'is' && val === null) {
+          builder._result = builder._result.filter(r => r[col] !== null && r[col] !== undefined);
+        }
+        return builder;
+      },
+      gte(col, val) {
+        builder._result = builder._result.filter(r => r[col] && new Date(r[col]).getTime() >= new Date(val).getTime());
+        return builder;
+      },
+      then(resolve) { return Promise.resolve({ data: builder._result, error: null }).then(resolve); },
+    };
+    return builder;
+  }
+  return {
+    from(table) {
+      if (table === 'claude_sessions') return tableQuery(claudeSessions);
+      if (table === 'strategic_directives_v2') return tableQuery(strategicDirectives);
+      if (table === 'sub_agent_execution_results') return tableQuery(subAgentResults);
+      return tableQuery([]);
+    },
+  };
+}
+
+const SD_KEY = 'SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001';
+const SD_UUID = '18677532-73ff-487a-b9e4-0110231df1f8';
+const NOW = Date.now();
+const ISO = (msAgo) => new Date(NOW - msAgo).toISOString();
+
+// ── Core regression: 2026-04-24 incident replay (AC1, AC4) ───────────────────
+
+describe('triangulate() — AC1 + AC4: evidence-of-life prevents hostile reclaim', () => {
+  it('replays 2026-04-24 incident: released-session, no live row, but recent sub-agent activity blocks orphaned-reclaimable', async () => {
+    // The incident: session 4b78a802 was status=released in claude_sessions (so it gets
+    // filtered out by the .in('status', ['active','idle']) clause). But strategic_directives_v2
+    // still had claiming_session_id=4b78a802 + is_working_on=true. Meanwhile the active CC
+    // conversation under a rotated session_id was producing sub_agent_execution_results.
+    // OLD triangulate: classified as orphaned-reclaim-safe -> hostile reclaim authorized.
+    // NEW triangulate: orphaned but reclaimSafe=false because recent_sub_agent_activity fires.
+    const supabase = makeFakeSupabase({
+      claudeSessions: [],  // released session is filtered out by .in('status', ['active','idle'])
+      strategicDirectives: [
+        { id: SD_UUID, sd_key: SD_KEY, is_working_on: true, claiming_session_id: 'sess-released', status: 'in_progress' },
+      ],
+      subAgentResults: [
+        { sd_id: SD_UUID, created_at: ISO(60 * 1000) },     // 1 min ago — active conversation
+        { sd_id: SD_UUID, created_at: ISO(120 * 1000) },    // 2 min ago
+      ],
+    });
+
+    const result = await triangulate(supabase, SD_KEY, { mySessionId: 'reclaimer-sess' });
+
+    // NEW behavior: appears as orphaned (no session claim + is_working_on present) BUT with
+    // reclaimSafe=false because recent_sub_agent_activity is evidence of an active conversation.
+    expect(result.ghost).toHaveLength(0);
+    const orph = result.orphaned.find(o => o.sdKey === SD_KEY);
+    expect(orph).toBeTruthy();
+    expect(orph.reclaimSafe).toBe(false);
+    expect(orph.autoReleasable).toBe(false);
+    expect(orph.signals.recentSubAgentActivity).toBe(true);
+    expect(orph.evidenceOfLifeSignals).toContain('recent_sub_agent_activity');
+    expect(orph.action).toMatch(/--force-reclaim/);
+  });
+
+  it('orphaned WITHOUT evidence-of-life remains reclaim-safe (backward compat)', async () => {
+    // Stale claim with no other evidence -> safe to reclaim normally
+    const supabase = makeFakeSupabase({
+      claudeSessions: [],
+      strategicDirectives: [
+        { id: SD_UUID, sd_key: SD_KEY, is_working_on: true, claiming_session_id: 'sess-truly-dead', status: 'in_progress' },
+      ],
+      subAgentResults: [],
+    });
+
+    const result = await triangulate(supabase, SD_KEY, { mySessionId: 'reclaimer-sess' });
+    const orph = result.orphaned.find(o => o.sdKey === SD_KEY);
+    expect(orph).toBeTruthy();
+    expect(orph.reclaimSafe).toBe(true);
+    expect(orph.autoReleasable).toBe(true);
+    expect(orph.action).toMatch(/Re-claim with: npm run sd:start/);
+  });
+});
+
+// ── AC3: PID_DEAD dual-signal hardening ──────────────────────────────────────
+
+describe('triangulate() — AC3: PID_DEAD requires BOTH process.kill failure AND tick stale', () => {
+  it('classifies PID-dead-with-fresh-tick as evidence_of_life_no_pid (NOT ghost)', async () => {
+    const supabase = makeFakeSupabase({
+      claudeSessions: [
+        {
+          session_id: 'sess-X',
+          sd_key: SD_KEY,
+          status: 'active',
+          heartbeat_at: ISO(10 * 1000),
+          process_alive_at: ISO(15 * 1000),   // fresh tick
+          pid: 999999,                        // dead PID
+          hostname: 'h1',
+        },
+      ],
+      strategicDirectives: [],
+    });
+
+    const result = await triangulate(supabase, SD_KEY);
+    expect(result.ghost).toHaveLength(0);
+    // tickRecent alone keeps it from being ghost; healthy classification because tickRecent is alive
+    const inHealthy = result.healthy.some(h => h.sdKey === SD_KEY);
+    const inDiscrepancies = result.discrepancies.some(d => d.sdKey === SD_KEY);
+    expect(inHealthy || inDiscrepancies).toBe(true);
+  });
+
+  it('classifies PID-dead-with-stale-tick as ghost (BOTH conditions fail, no other evidence)', async () => {
+    const supabase = makeFakeSupabase({
+      claudeSessions: [
+        {
+          session_id: 'sess-Y',
+          sd_key: SD_KEY,
+          status: 'active',
+          heartbeat_at: ISO(20 * 60 * 1000),   // 20min stale
+          process_alive_at: ISO(20 * 60 * 1000), // 20min stale tick
+          pid: 999999,
+          hostname: 'h1',
+        },
+      ],
+      strategicDirectives: [],
+    });
+
+    const result = await triangulate(supabase, SD_KEY);
+    const ghost = result.ghost.find(g => g.sdKey === SD_KEY);
+    expect(ghost).toBeTruthy();
+    expect(ghost.autoReleasable).toBe(true);
+    expect(ghost.signals.pidAlive).toBe(false);
+    expect(ghost.signals.tickRecent).toBe(false);
+  });
+
+  it('TICK_RECENT_SECONDS is exported as 90', () => {
+    expect(TICK_RECENT_SECONDS).toBe(90);
+  });
+});
+
+// ── AC2: Pre-claim gate (checkPreClaimEvidence) ──────────────────────────────
+
+describe('checkPreClaimEvidence() — AC2: pre-claim gate blocks reclaim when evidence-of-life present', () => {
+  it('returns allowReclaim=false when SD is orphaned WITH evidence-of-life (released session, active activity)', async () => {
+    const supabase = makeFakeSupabase({
+      claudeSessions: [],  // released session filtered out
+      strategicDirectives: [
+        { id: SD_UUID, sd_key: SD_KEY, is_working_on: true, claiming_session_id: 'sess-released', status: 'in_progress' },
+      ],
+      subAgentResults: [{ sd_id: SD_UUID, created_at: ISO(60 * 1000) }],  // recent activity
+    });
+
+    const result = await checkPreClaimEvidence(supabase, SD_KEY, { mySessionId: 'reclaimer' });
+    expect(result.allowReclaim).toBe(false);
+    expect(result.classification).toBe('orphaned');
+    expect(result.evidence).toContain('recent_sub_agent_activity');
+  });
+
+  it('returns allowReclaim=true when no record exists for SD (truly unclaimed)', async () => {
+    const supabase = makeFakeSupabase({});
+    const result = await checkPreClaimEvidence(supabase, 'SD-NONEXISTENT-001', { mySessionId: 'me' });
+    expect(result.allowReclaim).toBe(true);
+    expect(result.evidence).toEqual([]);
+    expect(result.classification).toBe(null);
+  });
+
+  it('returns allowReclaim=true for ghost classification (genuinely dead session)', async () => {
+    const supabase = makeFakeSupabase({
+      claudeSessions: [
+        {
+          session_id: 'sess-dead',
+          sd_key: SD_KEY,
+          status: 'active',
+          heartbeat_at: ISO(20 * 60 * 1000),
+          process_alive_at: ISO(20 * 60 * 1000),
+          pid: 999999,
+          hostname: 'h1',
+        },
+      ],
+      strategicDirectives: [],
+    });
+
+    const result = await checkPreClaimEvidence(supabase, SD_KEY, { mySessionId: 'reclaimer' });
+    expect(result.allowReclaim).toBe(true);
+    expect(result.classification).toBe('ghost');
+  });
+});
+
+// ── Constants & contracts ────────────────────────────────────────────────────
+
+describe('triangulate() — exported constants and API contract', () => {
+  it('exports tunable thresholds for testing and operations', () => {
+    expect(typeof TICK_RECENT_SECONDS).toBe('number');
+    expect(typeof ACTIVITY_LOOKBACK_SECONDS).toBe('number');
+    expect(TICK_RECENT_SECONDS).toBeGreaterThan(0);
+    expect(ACTIVITY_LOOKBACK_SECONDS).toBeGreaterThan(TICK_RECENT_SECONDS);
+  });
+
+  it('returns 4-bucket shape on empty input', async () => {
+    const supabase = makeFakeSupabase({});
+    const result = await triangulate(supabase);
+    expect(result).toHaveProperty('healthy');
+    expect(result).toHaveProperty('orphaned');
+    expect(result).toHaveProperty('ghost');
+    expect(result).toHaveProperty('discrepancies');
+    expect(Array.isArray(result.healthy)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Extends `triangulate.js` with 4 evidence-of-life signals + hardens PID liveness, wires it as a fail-closed pre-claim gate in `sd-start.js` (with `--force-reclaim` telemetry override), and defers `stale-session-sweep.cjs` auto-release to the same gate. Closes the hostile-reclaim bug class observed twice on 2026-04-24.

**SD**: SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 (infrastructure, 4 handoffs, 80% threshold)
**Upstream dep**: SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (PR #3296, merged 2026-04-24 13:41 UTC) ✓

## What changed (5 FRs, 4 commits)

| FR | Description | Commit |
|---|---|---|
| FR1 | 4 new signals in triangulate.js: branch presence, plan-file indirection, recent sub_agent_execution_results, sibling-session-on-branch | `b88e66bdd9` |
| FR3 | PID_DEAD now requires BOTH `process.kill ESRCH` AND `process_alive_at > 90s` stale | `b88e66bdd9` |
| FR5 | 10 unit tests, all passing — incl. 2026-04-24 incident replay | `bdff8fe7d7` |
| FR2 | Pre-claim gate in sd-start.js + `--force-reclaim` flag with audit_log telemetry | `b41cb0ebd9` |
| FR4 | Surgical alignment in stale-session-sweep.cjs (defers to triangulate before release); audit findings recorded in SD metadata for 5 other surfaces (5 documented divergences) | `f9c7d5b5f2` |

## Backward compatibility
- Existing 4-signal triangulate callers unchanged (additive new fields only)
- sd-start gate fails OPEN on internal errors (existing claim path unaffected)
- sweep gate fails OPEN on internal errors (existing release predicate unaffected)
- `--force-reclaim` is opt-in; default behavior preserves user agency

## Live incident this fixes
2026-04-24 (twice — peer session af01fb9f and session 4e006d16): session 4b78a802 had `status=released` in `claude_sessions`, but its CC conversation was actively working in the same worktree under a rotated session_id. Old triangulate classified as orphaned → would have authorized hostile reclaim (clobbering the active conversation's work). New triangulate detects worktree + sub-agent activity + sibling-session signals and blocks reclaim with a clear error message.

## Test plan
- [x] Unit tests: 10/10 pass (`tests/unit/triangulate-multi-signal.test.js`)
- [x] Syntax: triangulate.js, sd-start.js, stale-session-sweep.cjs all `node --check` pass
- [x] All 4 LEO handoffs accepted (LEAD-TO-PLAN 95, PLAN-TO-EXEC 93, PLAN-TO-LEAD 93)
- [ ] CI green
- [ ] Post-merge: verify sweep cron picks up new gate without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)