### PR TITLE
feat(SD-LEO-INFRA-CROSS-FILE-OVERLAP-001): Cross-SD file-overlap compatibility gate

### DIFF
--- a/config/high-risk-files.json
+++ b/config/high-risk-files.json
@@ -1,0 +1,23 @@
+{
+  "_doc": "High-risk file patterns for CROSS_SD_FILE_OVERLAP_TEMPORAL_* gates. SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 (FR-4). Patterns are minimatch globs. An overlap on any of these files = hard FAIL with no acknowledgment path.",
+  "version": 1,
+  "patterns": [
+    "scripts/modules/sd-key-generator.js",
+    "scripts/modules/handoff/**",
+    "scripts/handoff.js",
+    "scripts/sd-start.js",
+    "lib/gates/**",
+    "lib/auth/**",
+    "lib/security/**",
+    "**/auth/**",
+    "**/migrations/**",
+    "database/schema/**",
+    "database/migrations/**",
+    "supabase/migrations/**",
+    "CLAUDE.md",
+    "CLAUDE_CORE.md",
+    "CLAUDE_LEAD.md",
+    "CLAUDE_PLAN.md",
+    "CLAUDE_EXEC.md"
+  ]
+}

--- a/lib/config/cross-sd-config.js
+++ b/lib/config/cross-sd-config.js
@@ -1,0 +1,78 @@
+/**
+ * cross-sd-config -- Loader for the cross-SD overlap gate configuration.
+ * SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 (FR-4).
+ *
+ * Resolves configuration with this precedence:
+ *   1. Env var override (CROSS_SD_WINDOW_HOURS)
+ *   2. config/high-risk-files.json (committed)
+ *   3. Built-in defaults
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CONFIG_PATH = path.join(REPO_ROOT, 'config', 'high-risk-files.json');
+
+const DEFAULT_WINDOW_HOURS = 48;
+const DEFAULT_HIGH_RISK_PATTERNS = Object.freeze([
+  'scripts/modules/sd-key-generator.js',
+  'scripts/modules/handoff/**',
+  'scripts/handoff.js',
+  '**/auth/**',
+  '**/migrations/**',
+  'database/schema/**',
+  'CLAUDE.md',
+  'CLAUDE_CORE.md',
+  'CLAUDE_LEAD.md',
+  'CLAUDE_PLAN.md',
+  'CLAUDE_EXEC.md',
+]);
+
+let cachedPatterns = null;
+
+/**
+ * Window in milliseconds for "recently shipped" SDs. Env override wins.
+ * Set CROSS_SD_WINDOW_HOURS=0 to disable the gate (useful for emergency).
+ */
+export function getWindowMs() {
+  const raw = process.env.CROSS_SD_WINDOW_HOURS;
+  const hours = raw !== undefined && raw !== ''
+    ? Number(raw)
+    : DEFAULT_WINDOW_HOURS;
+  if (!Number.isFinite(hours) || hours < 0) return DEFAULT_WINDOW_HOURS * 3_600_000;
+  return Math.floor(hours * 3_600_000);
+}
+
+/**
+ * High-risk file patterns (minimatch globs). File loaded once and cached.
+ * Returns the built-in defaults when the file is missing or malformed.
+ */
+export function getHighRiskPatterns() {
+  if (cachedPatterns) return cachedPatterns;
+  try {
+    if (!fs.existsSync(CONFIG_PATH)) {
+      cachedPatterns = [...DEFAULT_HIGH_RISK_PATTERNS];
+      return cachedPatterns;
+    }
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    const patterns = Array.isArray(parsed?.patterns) ? parsed.patterns.filter(p => typeof p === 'string' && p.length > 0) : null;
+    cachedPatterns = patterns && patterns.length > 0 ? patterns : [...DEFAULT_HIGH_RISK_PATTERNS];
+  } catch {
+    cachedPatterns = [...DEFAULT_HIGH_RISK_PATTERNS];
+  }
+  return cachedPatterns;
+}
+
+/** Reset cache — used by tests. */
+export function _resetCache() {
+  cachedPatterns = null;
+}
+
+export const CROSS_SD_DEFAULTS = Object.freeze({
+  windowHours: DEFAULT_WINDOW_HOURS,
+  highRiskPatterns: DEFAULT_HIGH_RISK_PATTERNS,
+});

--- a/lib/cross-sd-overlap.js
+++ b/lib/cross-sd-overlap.js
@@ -1,0 +1,230 @@
+/**
+ * cross-sd-overlap -- Shared helpers for CROSS_SD_FILE_OVERLAP_TEMPORAL_* gates.
+ * SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 (FR-1, FR-3, FR-5).
+ *
+ * Responsibilities:
+ *   - Query recently-shipped SDs within a configurable window (windowMs)
+ *   - Resolve each recent SD's file-set via PRD target_files (PLAN oracle) or
+ *     git diff against its merge commit (SHIP oracle)
+ *   - Compare against the current SD's file-set, classifying overlaps as
+ *     high-risk (registry-matched) or medium-risk
+ *   - Parse `--acknowledge-cross-sd-overlap` + `--ack-reason` CLI flags
+ *   - Append a structured FR-5 metadata entry to sd_phase_handoffs.metadata
+ */
+import { execSync } from 'node:child_process';
+import { minimatch } from 'minimatch';
+import { extractTargetFiles } from '../scripts/modules/cross-sd-consistency-validation.js';
+import { getHighRiskPatterns, getWindowMs } from './config/cross-sd-config.js';
+
+// Regex split: SD-/QF-/PAT- anchored on word boundaries; #\d+ anchored on
+// non-digit-prefix instead of \b (since `#` is non-word, \b doesn't anchor it).
+const TICKET_REF_RE = /\b(?:SD|QF|PAT)-[A-Z0-9-]+\b|(?:^|[^\d])#\d+/i;
+
+/**
+ * Validate that a PRD object can be safely passed to extractTargetFiles.
+ * The orphaned module silently swallows null/undefined inputs; this surfaces
+ * problems explicitly so a caller can decide whether to skip or error.
+ *
+ * @param {*} prd
+ * @returns {{valid: boolean, reason?: string}}
+ */
+export function validatePrdShape(prd) {
+  if (prd == null) return { valid: false, reason: 'PRD is null/undefined' };
+  if (typeof prd !== 'object') return { valid: false, reason: `PRD is ${typeof prd}, expected object` };
+  // Empty PRD is technically valid — extractor will return an empty Set
+  return { valid: true };
+}
+
+/**
+ * Extract changed file paths from a `git diff --name-only` payload (or
+ * equivalent newline-separated string). Empty lines are dropped.
+ *
+ * @param {string} gitDiffOutput
+ * @returns {string[]}
+ */
+export function extractChangedFiles(gitDiffOutput) {
+  if (!gitDiffOutput || typeof gitDiffOutput !== 'string') return [];
+  return gitDiffOutput
+    .split(/\r?\n/)
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Get the file-set shipped by a single merge commit.
+ * Uses `git diff <sha>^..<sha> --name-only` (handles squash merges and merges).
+ * For root commits the parent ref is unavailable — returns [] in that case.
+ *
+ * @param {string} sha - merge commit SHA
+ * @param {{cwd?: string}} [opts]
+ * @returns {string[]}
+ */
+export function getDiffForCommit(sha, opts = {}) {
+  if (!sha || typeof sha !== 'string') return [];
+  const execOpts = { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
+  if (opts.cwd) execOpts.cwd = opts.cwd;
+  try {
+    const out = execSync(`git diff --name-only ${sha}^..${sha}`, execOpts);
+    return extractChangedFiles(out);
+  } catch {
+    // Root commit, missing ref, or shallow clone — surface as empty
+    return [];
+  }
+}
+
+/**
+ * Match a path against any glob pattern from the high-risk registry.
+ *
+ * @param {string} filePath
+ * @param {string[]} [patterns]
+ * @returns {boolean}
+ */
+export function isHighRisk(filePath, patterns) {
+  const list = patterns ?? getHighRiskPatterns();
+  return list.some(p => minimatch(filePath, p, { dot: true, matchBase: false }));
+}
+
+/**
+ * Classify an array of overlapping files into high-risk vs medium-risk buckets.
+ *
+ * @param {string[]} overlapFiles
+ * @param {string[]} [patterns]
+ * @returns {{high: string[], medium: string[]}}
+ */
+export function classifyOverlap(overlapFiles, patterns) {
+  const high = [];
+  const medium = [];
+  for (const f of overlapFiles) {
+    if (isHighRisk(f, patterns)) high.push(f);
+    else medium.push(f);
+  }
+  return { high, medium };
+}
+
+/**
+ * Parse CLI argv for `--acknowledge-cross-sd-overlap` and `--ack-reason`.
+ * Mutates nothing. Designed to be called inside handoff.js arg parsing.
+ *
+ * Returns:
+ *   acknowledged: true if both the flag and a non-empty reason are present
+ *   reason:       the trimmed reason string (or null)
+ *   ticketRefValid: true when reason cites an SD/QF/PAT/#issue identifier
+ *
+ * @param {string[]} argv
+ */
+export function parseAckFlags(argv) {
+  const out = { acknowledged: false, reason: null, ticketRefValid: false };
+  if (!Array.isArray(argv)) return out;
+  const flagIdx = argv.indexOf('--acknowledge-cross-sd-overlap');
+  if (flagIdx === -1) return out;
+  out.acknowledged = true;
+  const reasonIdx = argv.indexOf('--ack-reason');
+  if (reasonIdx !== -1 && argv[reasonIdx + 1]) {
+    const raw = String(argv[reasonIdx + 1]).trim();
+    if (raw.length > 0) {
+      out.reason = raw;
+      out.ticketRefValid = TICKET_REF_RE.test(raw);
+    }
+  }
+  return out;
+}
+
+/**
+ * Query SDs that completed within the temporal window. Excludes self.
+ *
+ * @param {Object} supabase
+ * @param {string} currentSdUuid - UUID of the SD whose handoff is running
+ * @param {number} [windowMs] - lookback window in milliseconds (defaults to env-driven config)
+ * @returns {Promise<Array<{id: string, sd_key: string, completed_at: string, status: string, title: string, metadata: object|null}>>}
+ */
+export async function listRecentShippedSds(supabase, currentSdUuid, windowMs) {
+  const ms = Number.isFinite(windowMs) ? windowMs : getWindowMs();
+  if (ms <= 0) return [];
+  const since = new Date(Date.now() - ms).toISOString();
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, completed_at, status, title, metadata')
+    .in('status', ['completed', 'shipped'])
+    .gte('completed_at', since)
+    .neq('id', currentSdUuid);
+  if (error) return [];
+  return data || [];
+}
+
+/**
+ * Append an FR-5 metadata entry to sd_phase_handoffs.metadata.cross_sd_overlap[].
+ * Always non-blocking — gate result is preserved even if persistence fails.
+ *
+ * @param {Object} supabase
+ * @param {string} handoffId - sd_phase_handoffs.id of the handoff being executed
+ * @param {Object} entry - structured per FR-5
+ */
+export async function appendOverlapMetadata(supabase, handoffId, entry) {
+  if (!supabase || !handoffId || !entry) return;
+  try {
+    const { data: existing } = await supabase
+      .from('sd_phase_handoffs')
+      .select('metadata')
+      .eq('id', handoffId)
+      .single();
+    const metadata = existing?.metadata && typeof existing.metadata === 'object' ? { ...existing.metadata } : {};
+    const list = Array.isArray(metadata.cross_sd_overlap) ? [...metadata.cross_sd_overlap] : [];
+    list.push({ ...entry, checked_at: entry.checked_at || new Date().toISOString() });
+    metadata.cross_sd_overlap = list;
+    await supabase.from('sd_phase_handoffs').update({ metadata }).eq('id', handoffId);
+  } catch {
+    // Telemetry-only path; never block the gate
+  }
+}
+
+/**
+ * Build a structured FR-5 entry for a single colliding-SD detection.
+ *
+ * @param {Object} args
+ * @param {'PLAN-TO-EXEC'|'LEAD-FINAL-APPROVAL'} args.phase
+ * @param {string} args.collidingSdKey
+ * @param {string[]} args.overlappingFiles
+ * @param {'high'|'medium'|'low'|'none'} args.riskTier
+ * @param {'PASS'|'WARN'|'FAIL'} args.verdict
+ * @param {string|null} [args.acknowledgedAt]
+ * @param {string|null} [args.ackReason]
+ */
+export function buildOverlapEntry({ phase, collidingSdKey, overlappingFiles, riskTier, verdict, acknowledgedAt = null, ackReason = null }) {
+  return {
+    phase,
+    colliding_sd_key: collidingSdKey,
+    overlapping_files: overlappingFiles,
+    risk_tier: riskTier,
+    verdict,
+    acknowledged_at: acknowledgedAt,
+    ack_reason: ackReason,
+    checked_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Determine the overall gate verdict given per-SD overlap classifications and
+ * acknowledgment state.
+ *
+ * Rules:
+ *   - Any high-risk overlap        => FAIL (no bypass; FR-4)
+ *   - Medium-risk + acknowledged   => PASS-WITH-ACK (FR-3)
+ *   - Medium-risk + not ack'd      => WARN (block until ack provided)
+ *   - No overlap                   => PASS
+ */
+export function decideVerdict(overlapEntries, ackState) {
+  if (!overlapEntries || overlapEntries.length === 0) {
+    return { verdict: 'PASS', risk_tier: 'none' };
+  }
+  const anyHigh = overlapEntries.some(e => e.risk_tier === 'high');
+  if (anyHigh) return { verdict: 'FAIL', risk_tier: 'high' };
+  if (ackState && ackState.acknowledged && ackState.reason && ackState.ticketRefValid) {
+    return { verdict: 'PASS', risk_tier: 'medium' };
+  }
+  return { verdict: 'WARN', risk_tier: 'medium' };
+}
+
+/**
+ * Re-export FR-1 extractor so consumers don't need a second import.
+ */
+export { extractTargetFiles };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:unit": "vitest run tests/unit/",
     "test:integration": "vitest run tests/integration/",
     "test:integration:sd-creation": "vitest run tests/integration/sd-creation/",
+    "test:integration:cross-sd-gate": "vitest run tests/integration/cross-sd-overlap-gate/",
     "test:pipeline": "vitest run tests/integration/pipeline-s0-s17.test.js --testTimeout 1200000",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",

--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -552,6 +552,7 @@ export async function handleExecuteCommand(handoffType, sdId, args) {
 
   if (!handoffType || !sdId) {
     console.log('Usage: node scripts/handoff.js execute HANDOFF_TYPE SD-ID [PRD-ID] [--bypass-validation --bypass-reason "reason"]');
+    console.log('       node scripts/handoff.js execute HANDOFF_TYPE SD-ID --acknowledge-cross-sd-overlap --ack-reason "<SD-/QF-/PAT-/#issue> reason"');
     console.log('');
     console.log('Handoff Types (case-insensitive):');
     console.log('  LEAD-TO-PLAN        - Strategic to Planning handoff');
@@ -559,6 +560,10 @@ export async function handleExecuteCommand(handoffType, sdId, args) {
     console.log('  EXEC-TO-PLAN        - Execution to Verification handoff');
     console.log('  PLAN-TO-LEAD        - Verification to Final Approval handoff');
     console.log('  LEAD-FINAL-APPROVAL - Mark SD as completed (final step)');
+    console.log('');
+    console.log('Cross-SD Overlap Gate Flags (FR-3, SD-LEO-INFRA-CROSS-FILE-OVERLAP-001):');
+    console.log('  --acknowledge-cross-sd-overlap  Acknowledge a medium-risk file overlap warning');
+    console.log('  --ack-reason "TEXT"             Required with above; must cite SD-/QF-/PAT-/#issue');
     console.log('');
     console.log('TIP: Run "node scripts/handoff.js workflow SD-ID" to see recommended workflow');
     return { success: false };

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -35,6 +35,10 @@ export { createWireCheckGate };
 import { createLearningOrBypassResolvedGate } from './gates/learning-or-bypass-resolved-gate.js';
 export { createLearningOrBypassResolvedGate };
 
+// Cross-SD File-Overlap Temporal Gate — SHIP oracle (SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 FR-2b)
+import { createCrossSdFileOverlapTemporalShipGate } from './gates/cross-sd-file-overlap-temporal-ship.js';
+export { createCrossSdFileOverlapTemporalShipGate };
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -1070,6 +1074,11 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // set ENFORCE_LEARNING_GATE=true to block.
   gates.push(createLearningOrBypassResolvedGate(supabase));
 
+  // Cross-SD File-Overlap Temporal Gate — SHIP oracle (FR-2b)
+  // Compares this PR's diff against the merge-commit diffs of SDs shipped
+  // within the configured window. High-risk = FAIL, medium = WARN unless ack'd.
+  gates.push(createCrossSdFileOverlapTemporalShipGate(supabase));
+
   return gates;
 }
 
@@ -1087,5 +1096,6 @@ export default {
   createAutomatedUatGate,
   createWireCheckGate,
   createLearningOrBypassResolvedGate,
+  createCrossSdFileOverlapTemporalShipGate,
   getRequiredGates
 };

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/cross-sd-file-overlap-temporal-ship.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/cross-sd-file-overlap-temporal-ship.js
@@ -1,0 +1,155 @@
+/**
+ * CROSS_SD_FILE_OVERLAP_TEMPORAL_SHIP gate (FR-2b).
+ * Runs at LEAD-FINAL-APPROVAL. Oracle = current SD's PR diff (via
+ * SharedGitContext) vs each recently-shipped SD's merge-commit diff.
+ *
+ * Verdict tiers identical to the PLAN gate. See lib/cross-sd-overlap.js for
+ * details. Part of SD-LEO-INFRA-CROSS-FILE-OVERLAP-001.
+ */
+import { execSync } from 'node:child_process';
+import {
+  appendOverlapMetadata,
+  buildOverlapEntry,
+  classifyOverlap,
+  decideVerdict,
+  getDiffForCommit,
+  listRecentShippedSds,
+  parseAckFlags,
+} from '../../../../../../lib/cross-sd-overlap.js';
+import { SharedGitContext, getMainRef } from '../../../shared-git-context.js';
+
+const GATE_NAME = 'CROSS_SD_FILE_OVERLAP_TEMPORAL_SHIP';
+
+function buildResult(verdict, entries) {
+  const high = entries.filter(e => e.risk_tier === 'high');
+  const medium = entries.filter(e => e.risk_tier === 'medium');
+  const issues = [];
+  const warnings = [];
+  if (verdict === 'FAIL') {
+    for (const e of high) {
+      issues.push(
+        `HIGH-RISK ship-overlap with ${e.colliding_sd_key} on file(s): ${e.overlapping_files.join(', ')} (no bypass available)`
+      );
+    }
+  } else if (verdict === 'WARN') {
+    for (const e of medium) {
+      warnings.push(
+        `Medium-risk ship-overlap with ${e.colliding_sd_key} on file(s): ${e.overlapping_files.join(', ')}. Re-run LEAD-FINAL with --acknowledge-cross-sd-overlap --ack-reason "<SD-/QF-/PAT-/#issue> <text>" to proceed.`
+      );
+    }
+  } else if (verdict === 'PASS' && medium.length > 0) {
+    warnings.push(`Acknowledged medium-risk overlap with ${medium.length} SD(s)`);
+  }
+  return {
+    passed: verdict !== 'FAIL' && verdict !== 'WARN',
+    score: verdict === 'PASS' ? 100 : verdict === 'WARN' ? 50 : 0,
+    max_score: 100,
+    issues,
+    warnings,
+    details: `Verdict ${verdict} from ${entries.length} colliding SD(s)`,
+  };
+}
+
+/**
+ * Resolve a recent SD's merge-commit SHA. Strategy:
+ *  1. metadata.merge_commit_sha (if recorded by /ship)
+ *  2. fallback: `git log` on origin/main filtering by sd_key in commit message
+ */
+function resolveMergeCommit(other, mainRef) {
+  const fromMeta = other?.metadata?.merge_commit_sha || other?.metadata?.commit_sha;
+  if (fromMeta && typeof fromMeta === 'string' && fromMeta.length >= 7) return fromMeta;
+  try {
+    const sha = execSync(
+      `git log ${mainRef} --grep "${other.sd_key}" --pretty=format:%H -n 1`,
+      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+export function createCrossSdFileOverlapTemporalShipGate(supabase) {
+  return {
+    name: GATE_NAME,
+    validator: async (ctx) => {
+      console.log(`\n🔍 GATE: ${GATE_NAME} (SHIP oracle)`);
+      console.log('-'.repeat(50));
+
+      const sd = ctx?.sd;
+      const sdUuid = sd?.id;
+      const handoffId = ctx?.handoff_id || ctx?.handoffId || null;
+      const argv = ctx?.argv || process.argv.slice(2) || [];
+      const ackState = parseAckFlags(argv);
+
+      if (!sdUuid) {
+        console.log('   ⚠️  No SD context — skipping');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No SD context'], details: 'skipped' };
+      }
+
+      const git = ctx?.gitCtx instanceof SharedGitContext ? ctx.gitCtx : new SharedGitContext();
+      const myFiles = git.diffFiles;
+      if (!myFiles || myFiles.length === 0) {
+        console.log('   ℹ️  No PR diff vs main — gate trivially passes');
+        const result = buildResult('PASS', []);
+        await appendOverlapMetadata(supabase, handoffId, buildOverlapEntry({
+          phase: 'LEAD-FINAL-APPROVAL', collidingSdKey: '(none)', overlappingFiles: [], riskTier: 'none', verdict: 'PASS',
+        }));
+        return result;
+      }
+      const myFileSet = new Set(myFiles);
+
+      const recent = await listRecentShippedSds(supabase, sdUuid);
+      console.log(`   📅 Comparing against ${recent.length} recently-shipped SD(s)`);
+
+      const { ref: mainRef } = getMainRef({ skipFetch: true });
+      const entries = [];
+      for (const other of recent) {
+        const sha = resolveMergeCommit(other, mainRef);
+        if (!sha) {
+          console.log(`   ℹ️  ${other.sd_key}: no merge commit resolvable — skipped`);
+          continue;
+        }
+        const otherFiles = getDiffForCommit(sha);
+        if (otherFiles.length === 0) continue;
+        const overlap = otherFiles.filter(f => myFileSet.has(f));
+        if (overlap.length === 0) continue;
+        const { high, medium } = classifyOverlap(overlap);
+        const riskTier = high.length > 0 ? 'high' : medium.length > 0 ? 'medium' : 'low';
+        entries.push(buildOverlapEntry({
+          phase: 'LEAD-FINAL-APPROVAL',
+          collidingSdKey: other.sd_key || other.id,
+          overlappingFiles: overlap,
+          riskTier,
+          verdict: 'PENDING',
+          acknowledgedAt: ackState.acknowledged ? new Date().toISOString() : null,
+          ackReason: ackState.reason || null,
+        }));
+        console.log(`   ⚠️  Ship-overlap with ${other.sd_key || other.id}: ${overlap.length} file(s) (${riskTier})`);
+      }
+
+      const decision = decideVerdict(entries, ackState);
+      for (const e of entries) e.verdict = decision.verdict;
+      const result = buildResult(decision.verdict, entries);
+
+      if (entries.length === 0) {
+        await appendOverlapMetadata(supabase, handoffId, buildOverlapEntry({
+          phase: 'LEAD-FINAL-APPROVAL', collidingSdKey: '(none)', overlappingFiles: [], riskTier: 'none', verdict: 'PASS',
+        }));
+      } else {
+        for (const e of entries) {
+          await appendOverlapMetadata(supabase, handoffId, e);
+        }
+      }
+
+      if (decision.verdict === 'FAIL') console.log(`   ❌ ${decision.verdict} — high-risk overlap`);
+      else if (decision.verdict === 'WARN') console.log(`   ⚠️  ${decision.verdict} — medium-risk overlap, ack required`);
+      else console.log(`   ✅ ${decision.verdict}`);
+      return result;
+    },
+    required: false,
+    remediation: 'For HIGH-risk ship-overlaps, wait for the window to expire or coordinate manually. For MEDIUM-risk, re-run LEAD-FINAL with --acknowledge-cross-sd-overlap --ack-reason "<ticket-ref> <reason>".',
+  };
+}
+
+export default { createCrossSdFileOverlapTemporalShipGate };

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/cross-sd-file-overlap-temporal.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/cross-sd-file-overlap-temporal.js
@@ -1,0 +1,167 @@
+/**
+ * CROSS_SD_FILE_OVERLAP_TEMPORAL_PLAN gate (FR-2a).
+ * Runs at PLAN-TO-EXEC. Oracle = current SD's PRD target_files vs each
+ * recently-shipped SD's PRD target_files (no PR exists yet at this phase).
+ *
+ * Verdict tiers (see decideVerdict in lib/cross-sd-overlap.js):
+ *   - high-risk overlap        -> FAIL (no bypass; FR-4)
+ *   - medium-risk + ack flag   -> PASS (FR-3)
+ *   - medium-risk no ack       -> WARN (blocks until --acknowledge-... provided with ticketed --ack-reason)
+ *   - no overlap               -> PASS
+ *
+ * Part of SD-LEO-INFRA-CROSS-FILE-OVERLAP-001.
+ */
+import {
+  appendOverlapMetadata,
+  buildOverlapEntry,
+  classifyOverlap,
+  decideVerdict,
+  extractTargetFiles,
+  listRecentShippedSds,
+  parseAckFlags,
+  validatePrdShape,
+} from '../../../../../../lib/cross-sd-overlap.js';
+
+const GATE_NAME = 'CROSS_SD_FILE_OVERLAP_TEMPORAL_PLAN';
+
+/**
+ * Build the gate result object that handoff.js consumes.
+ * @param {string} verdict
+ * @param {Array} entries
+ * @param {string} [extraDetail]
+ */
+function buildResult(verdict, entries, extraDetail = '') {
+  const high = entries.filter(e => e.risk_tier === 'high');
+  const medium = entries.filter(e => e.risk_tier === 'medium');
+  const issues = [];
+  const warnings = [];
+
+  if (verdict === 'FAIL') {
+    for (const e of high) {
+      issues.push(
+        `HIGH-RISK overlap with ${e.colliding_sd_key} on file(s): ${e.overlapping_files.join(', ')} (no bypass available — wait for window expiry or coordinate manually)`
+      );
+    }
+  } else if (verdict === 'WARN') {
+    for (const e of medium) {
+      warnings.push(
+        `Medium-risk overlap with ${e.colliding_sd_key} on file(s): ${e.overlapping_files.join(', ')}. Re-run with --acknowledge-cross-sd-overlap --ack-reason "<SD-/QF-/PAT-/#issue> <text>" to proceed.`
+      );
+    }
+  } else if (verdict === 'PASS' && medium.length > 0) {
+    warnings.push(`Acknowledged medium-risk overlap with ${medium.length} SD(s): ${medium.map(e => e.colliding_sd_key).join(', ')}`);
+  }
+
+  return {
+    passed: verdict !== 'FAIL' && verdict !== 'WARN',
+    score: verdict === 'PASS' ? 100 : verdict === 'WARN' ? 50 : 0,
+    max_score: 100,
+    issues,
+    warnings,
+    details: extraDetail || `Verdict ${verdict} from ${entries.length} colliding SD(s)`,
+  };
+}
+
+export function createCrossSdFileOverlapTemporalGate(supabase) {
+  return {
+    name: GATE_NAME,
+    validator: async (ctx) => {
+      console.log(`\n🔍 GATE: ${GATE_NAME} (PLAN oracle)`);
+      console.log('-'.repeat(50));
+
+      const sd = ctx?.sd;
+      const sdUuid = sd?.id;
+      const sdKey = sd?.sd_key || sdUuid;
+      const handoffId = ctx?.handoff_id || ctx?.handoffId || null;
+      const argv = ctx?.argv || process.argv.slice(2) || [];
+      const ackState = parseAckFlags(argv);
+
+      if (!sdUuid) {
+        console.log('   ⚠️  No SD context available — skipping');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No SD context'], details: 'skipped' };
+      }
+
+      // Pull current SD's PRD
+      const { data: currentPRD } = await supabase
+        .from('product_requirements_v2')
+        .select('*')
+        .eq('sd_id', sdUuid)
+        .single();
+
+      const prdShape = validatePrdShape(currentPRD);
+      if (!prdShape.valid) {
+        console.log(`   ⚠️  Current PRD invalid: ${prdShape.reason} — skipping (advisory)`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`Skipped: ${prdShape.reason}`], details: 'skipped' };
+      }
+      const currentFiles = extractTargetFiles(currentPRD);
+      if (currentFiles.size === 0) {
+        console.log('   ℹ️  Current PRD declares no target files — gate trivially passes');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: 'No target files in PRD' };
+      }
+
+      const recent = await listRecentShippedSds(supabase, sdUuid);
+      console.log(`   📅 Comparing against ${recent.length} recently-shipped SD(s)`);
+      if (recent.length === 0) {
+        const result = buildResult('PASS', [], 'No recent shipped SDs in window');
+        await appendOverlapMetadata(supabase, handoffId, buildOverlapEntry({
+          phase: 'PLAN-TO-EXEC', collidingSdKey: '(none)', overlappingFiles: [], riskTier: 'none', verdict: 'PASS',
+        }));
+        return result;
+      }
+
+      const entries = [];
+      for (const other of recent) {
+        const { data: otherPRD } = await supabase
+          .from('product_requirements_v2')
+          .select('*')
+          .eq('sd_id', other.id)
+          .single();
+        if (!otherPRD) continue;
+        const otherFiles = extractTargetFiles(otherPRD);
+        const overlap = [...currentFiles].filter(f => otherFiles.has(f));
+        if (overlap.length === 0) continue;
+        const { high, medium } = classifyOverlap(overlap);
+        const riskTier = high.length > 0 ? 'high' : medium.length > 0 ? 'medium' : 'low';
+        entries.push(buildOverlapEntry({
+          phase: 'PLAN-TO-EXEC',
+          collidingSdKey: other.sd_key || other.id,
+          overlappingFiles: overlap,
+          riskTier,
+          verdict: 'PENDING',
+          acknowledgedAt: ackState.acknowledged ? new Date().toISOString() : null,
+          ackReason: ackState.reason || null,
+        }));
+        console.log(`   ⚠️  Overlap with ${other.sd_key || other.id}: ${overlap.length} file(s) (${riskTier})`);
+      }
+
+      const decision = decideVerdict(entries, ackState);
+      for (const e of entries) e.verdict = decision.verdict;
+      const result = buildResult(decision.verdict, entries);
+
+      // Persist FR-5 metadata for every detected overlap (one row per collider)
+      // plus a summary row when entries is empty.
+      if (entries.length === 0) {
+        await appendOverlapMetadata(supabase, handoffId, buildOverlapEntry({
+          phase: 'PLAN-TO-EXEC', collidingSdKey: '(none)', overlappingFiles: [], riskTier: 'none', verdict: 'PASS',
+        }));
+      } else {
+        for (const e of entries) {
+          await appendOverlapMetadata(supabase, handoffId, e);
+        }
+      }
+
+      if (decision.verdict === 'FAIL') {
+        console.log(`   ❌ ${decision.verdict} — high-risk overlap`);
+      } else if (decision.verdict === 'WARN') {
+        console.log(`   ⚠️  ${decision.verdict} — medium-risk overlap, ack required`);
+      } else {
+        console.log(`   ✅ ${decision.verdict}`);
+      }
+      return result;
+    },
+    required: false,
+    remediation: `For HIGH-risk overlaps, wait for the ${process.env.CROSS_SD_WINDOW_HOURS || 48}h window to expire OR coordinate manually with the colliding SD. For MEDIUM-risk, re-run with --acknowledge-cross-sd-overlap --ack-reason "<SD-/QF-/PAT-/#issue> <reason>".`,
+  };
+}
+
+export default { createCrossSdFileOverlapTemporalGate };

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/index.js
@@ -32,3 +32,8 @@ export { createTranslationFidelityGate } from './translation-fidelity.js';
 // Bugfix Coverage Preflight — advisory only, shifts EXEC-TO-PLAN discovery left
 // Part of SD-LEARN-FIX-ADDRESS-PAT-EXECTOPLAN-001 (FR-3) addressing PAT-HF-EXECTOPLAN-a14ec7de
 export { createBugfixCoveragePreflightGate } from './bugfix-coverage-preflight.js';
+
+// Cross-SD File-Overlap Temporal Gate (SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 FR-2a)
+// Detects file overlap with SDs shipped within the configured window
+// (default 48h) using PRD target_files as the oracle.
+export { createCrossSdFileOverlapTemporalGate } from './cross-sd-file-overlap-temporal.js';

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -32,7 +32,9 @@ import {
   // Translation Fidelity Gate — second invocation (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001)
   createTranslationFidelityGate,
   // Bugfix Coverage Preflight — advisory (SD-LEARN-FIX-ADDRESS-PAT-EXECTOPLAN-001, FR-3)
-  createBugfixCoveragePreflightGate
+  createBugfixCoveragePreflightGate,
+  // Cross-SD File-Overlap Temporal Gate (SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 FR-2a)
+  createCrossSdFileOverlapTemporalGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -253,6 +255,11 @@ export class PlanToExecExecutor extends BaseExecutor {
     // Advisory — shifts EXEC-TO-PLAN discovery left by enumerating upcoming requirements
     // (user story AC coverage + TESTING sub-agent) at PLAN-TO-EXEC time. Never blocks.
     gates.push(createBugfixCoveragePreflightGate(this.supabase));
+
+    // Cross-SD File-Overlap Temporal Gate — PLAN oracle (SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 FR-2a)
+    // Detects file overlap with SDs shipped within the configured 48h window
+    // using PRD target_files as the comparison oracle. High-risk = FAIL, medium = WARN unless ack'd.
+    gates.push(createCrossSdFileOverlapTemporalGate(this.supabase));
 
     return gates;
   }

--- a/tests/integration/cross-sd-overlap-gate/cross-sd-overlap.test.js
+++ b/tests/integration/cross-sd-overlap-gate/cross-sd-overlap.test.js
@@ -1,0 +1,269 @@
+/**
+ * Integration tests for SD-LEO-INFRA-CROSS-FILE-OVERLAP-001.
+ *
+ * Covers:
+ *   FR-1   resurrected `cross-sd-consistency-validation.js` extractors
+ *   FR-3   --acknowledge-cross-sd-overlap + --ack-reason flag parsing
+ *   FR-4   high-risk registry pattern matching
+ *   FR-5   metadata writer entry shape
+ *   FR-6   retro-replay harness against historical fixtures
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  buildOverlapEntry,
+  classifyOverlap,
+  decideVerdict,
+  extractChangedFiles,
+  extractTargetFiles,
+  isHighRisk,
+  parseAckFlags,
+  validatePrdShape,
+} from '../../../lib/cross-sd-overlap.js';
+import { _resetCache, getHighRiskPatterns, getWindowMs } from '../../../lib/config/cross-sd-config.js';
+
+beforeAll(() => {
+  _resetCache();
+});
+
+describe('FR-1 — extractTargetFiles + validatePrdShape', () => {
+  it('extracts file paths from a realistic PRD shape', () => {
+    const prd = {
+      implementation_approach: 'Modify scripts/handoff.js and lib/gates/foo.js',
+      system_architecture: 'New file: scripts/modules/handoff/executors/plan-to-exec/gates/cross-sd-file-overlap-temporal.js',
+      technical_context: '',
+      functional_requirements: [{ description: 'Wire CLAUDE.md updates' }],
+    };
+    const files = extractTargetFiles(prd);
+    expect(files.size).toBeGreaterThan(0);
+    expect([...files].some(f => f.endsWith('handoff.js'))).toBe(true);
+  });
+
+  it('returns an empty set for an empty PRD', () => {
+    const files = extractTargetFiles({});
+    expect(files.size).toBe(0);
+  });
+
+  it('flags null/undefined PRD shapes', () => {
+    expect(validatePrdShape(null).valid).toBe(false);
+    expect(validatePrdShape(undefined).valid).toBe(false);
+    expect(validatePrdShape('hello').valid).toBe(false);
+    expect(validatePrdShape({}).valid).toBe(true);
+    expect(validatePrdShape({ implementation_approach: 'x' }).valid).toBe(true);
+  });
+});
+
+describe('FR-1 — extractChangedFiles', () => {
+  it('parses git-diff-style newline output', () => {
+    const out = 'a/file1.js\nb/file2.ts\n\n  c/file3.json  \n';
+    const files = extractChangedFiles(out);
+    expect(files).toEqual(['a/file1.js', 'b/file2.ts', 'c/file3.json']);
+  });
+  it('returns [] on empty/non-string input', () => {
+    expect(extractChangedFiles('')).toEqual([]);
+    expect(extractChangedFiles(null)).toEqual([]);
+    expect(extractChangedFiles(undefined)).toEqual([]);
+    expect(extractChangedFiles(42)).toEqual([]);
+  });
+});
+
+describe('FR-3 — parseAckFlags', () => {
+  it('returns acknowledged=false when flag absent', () => {
+    expect(parseAckFlags(['--bypass-validation'])).toEqual({ acknowledged: false, reason: null, ticketRefValid: false });
+  });
+  it('detects flag without reason', () => {
+    const r = parseAckFlags(['--acknowledge-cross-sd-overlap']);
+    expect(r.acknowledged).toBe(true);
+    expect(r.reason).toBe(null);
+    expect(r.ticketRefValid).toBe(false);
+  });
+  it('detects flag + reason without ticket reference', () => {
+    const r = parseAckFlags(['--acknowledge-cross-sd-overlap', '--ack-reason', 'just trust me']);
+    expect(r.acknowledged).toBe(true);
+    expect(r.reason).toBe('just trust me');
+    expect(r.ticketRefValid).toBe(false);
+  });
+  it('validates SD-/QF-/PAT-/#issue prefixes in reason', () => {
+    expect(parseAckFlags(['--acknowledge-cross-sd-overlap', '--ack-reason', 'SD-FOO-001 coordinated']).ticketRefValid).toBe(true);
+    expect(parseAckFlags(['--acknowledge-cross-sd-overlap', '--ack-reason', 'QF-20260424-001 hotfix']).ticketRefValid).toBe(true);
+    expect(parseAckFlags(['--acknowledge-cross-sd-overlap', '--ack-reason', 'fixes #1234']).ticketRefValid).toBe(true);
+    expect(parseAckFlags(['--acknowledge-cross-sd-overlap', '--ack-reason', 'PAT-RETRO-001 known']).ticketRefValid).toBe(true);
+  });
+  it('handles non-array argv defensively', () => {
+    expect(parseAckFlags(null)).toEqual({ acknowledged: false, reason: null, ticketRefValid: false });
+  });
+});
+
+describe('FR-4 — high-risk registry + isHighRisk', () => {
+  it('loads built-in patterns when config file missing', () => {
+    _resetCache();
+    const patterns = getHighRiskPatterns();
+    expect(patterns.length).toBeGreaterThan(0);
+    expect(patterns).toContain('CLAUDE.md');
+  });
+  it('matches known high-risk paths', () => {
+    expect(isHighRisk('scripts/modules/sd-key-generator.js')).toBe(true);
+    expect(isHighRisk('scripts/modules/handoff/executors/foo/bar.js')).toBe(true);
+    expect(isHighRisk('CLAUDE.md')).toBe(true);
+    expect(isHighRisk('database/migrations/001_init.sql')).toBe(true);
+    expect(isHighRisk('lib/auth/session.js')).toBe(true);
+  });
+  it('does NOT match medium-risk paths', () => {
+    expect(isHighRisk('docs/plans/foo.md')).toBe(false);
+    expect(isHighRisk('scripts/sd-next.js')).toBe(false);
+    expect(isHighRisk('lib/prd/formatter.js')).toBe(false);
+    expect(isHighRisk('tests/unit/sample.test.js')).toBe(false);
+  });
+});
+
+describe('FR-4 — classifyOverlap', () => {
+  it('separates high vs medium risk files', () => {
+    const overlap = ['scripts/sd-next.js', 'scripts/handoff.js', 'docs/plans/foo.md'];
+    const { high, medium } = classifyOverlap(overlap);
+    expect(high).toEqual(['scripts/handoff.js']);
+    expect(medium).toEqual(['scripts/sd-next.js', 'docs/plans/foo.md']);
+  });
+});
+
+describe('window config', () => {
+  it('respects CROSS_SD_WINDOW_HOURS env var', () => {
+    const original = process.env.CROSS_SD_WINDOW_HOURS;
+    process.env.CROSS_SD_WINDOW_HOURS = '24';
+    expect(getWindowMs()).toBe(24 * 3_600_000);
+    process.env.CROSS_SD_WINDOW_HOURS = '0';
+    expect(getWindowMs()).toBe(0);
+    process.env.CROSS_SD_WINDOW_HOURS = original ?? '';
+    if (!original) delete process.env.CROSS_SD_WINDOW_HOURS;
+  });
+});
+
+describe('FR-5 — buildOverlapEntry', () => {
+  it('produces a structured entry per FR-5 schema', () => {
+    const e = buildOverlapEntry({
+      phase: 'PLAN-TO-EXEC',
+      collidingSdKey: 'SD-FOO-001',
+      overlappingFiles: ['x.js', 'y.js'],
+      riskTier: 'medium',
+      verdict: 'WARN',
+      acknowledgedAt: null,
+      ackReason: null,
+    });
+    expect(e).toMatchObject({
+      phase: 'PLAN-TO-EXEC',
+      colliding_sd_key: 'SD-FOO-001',
+      overlapping_files: ['x.js', 'y.js'],
+      risk_tier: 'medium',
+      verdict: 'WARN',
+      acknowledged_at: null,
+      ack_reason: null,
+    });
+    expect(typeof e.checked_at).toBe('string');
+  });
+});
+
+describe('decideVerdict', () => {
+  it('returns PASS / risk_tier=none for empty entries', () => {
+    expect(decideVerdict([], { acknowledged: false })).toEqual({ verdict: 'PASS', risk_tier: 'none' });
+  });
+  it('returns FAIL when any high-risk overlap present', () => {
+    const r = decideVerdict([{ risk_tier: 'high' }, { risk_tier: 'medium' }], { acknowledged: true, reason: 'SD-X', ticketRefValid: true });
+    expect(r.verdict).toBe('FAIL');
+  });
+  it('returns WARN for medium-risk overlap with no ack', () => {
+    expect(decideVerdict([{ risk_tier: 'medium' }], { acknowledged: false }).verdict).toBe('WARN');
+  });
+  it('returns PASS for medium-risk overlap with valid ticketed ack', () => {
+    expect(decideVerdict([{ risk_tier: 'medium' }], { acknowledged: true, reason: 'SD-FOO-001 ok', ticketRefValid: true }).verdict).toBe('PASS');
+  });
+  it('returns WARN when ack lacks ticket reference (FR-3 ticketed reason)', () => {
+    expect(decideVerdict([{ risk_tier: 'medium' }], { acknowledged: true, reason: 'just because', ticketRefValid: false }).verdict).toBe('WARN');
+  });
+});
+
+/**
+ * FR-6 — Retro-replay harness.
+ *
+ * Each fixture exercises the gate decision pipeline using *synthetic* file
+ * lists derived from publicly-documented historical SD pairs. The data is
+ * intentionally local to this test (no DB calls) so the harness can run on
+ * any developer machine without seeded state.
+ */
+describe('FR-6 — retro-replay fixtures', () => {
+  const fixtures = [
+    {
+      name: 'fixture-1: ENFORCEMENT-001 × E2E-REGRESSION-TEST-001',
+      currentFiles: new Set(['scripts/modules/sd-key-generator.js']),
+      otherFiles: new Set(['scripts/modules/sd-key-generator.js']),
+      expectedVerdict: 'FAIL',
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-2: PR #3301 × PR #3299 (sd-start.js)',
+      currentFiles: new Set(['scripts/sd-start.js']),
+      otherFiles: new Set(['scripts/sd-start.js']),
+      expectedVerdict: 'FAIL', // sd-start.js IS in the registry
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-3: PR #3296 × PR #3295 (CLAUDE.md)',
+      currentFiles: new Set(['CLAUDE.md']),
+      otherFiles: new Set(['CLAUDE.md']),
+      expectedVerdict: 'FAIL',
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-4: PR #3293 × PR #3291 (CLAUDE.md + migrations)',
+      currentFiles: new Set(['CLAUDE.md', 'database/migrations/2026_04_24_x.sql']),
+      otherFiles: new Set(['CLAUDE.md', 'database/migrations/2026_04_24_x.sql']),
+      expectedVerdict: 'FAIL',
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-5: PR #3284 × PR #3283 (handoff executor)',
+      currentFiles: new Set(['scripts/modules/handoff/executors/lead-to-plan/gates/foo.js']),
+      otherFiles: new Set(['scripts/modules/handoff/executors/lead-to-plan/gates/foo.js']),
+      expectedVerdict: 'FAIL',
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-6 (negative): unrelated SDs do not collide',
+      currentFiles: new Set(['lib/feature-x.js']),
+      otherFiles: new Set(['lib/feature-y.js']),
+      expectedVerdict: 'PASS',
+      ackState: { acknowledged: false },
+    },
+    {
+      name: 'fixture-7 (medium-risk passes when properly acknowledged)',
+      currentFiles: new Set(['docs/plans/cross-sd-overlap-gate-plan.md']),
+      otherFiles: new Set(['docs/plans/cross-sd-overlap-gate-plan.md']),
+      expectedVerdict: 'PASS',
+      ackState: { acknowledged: true, reason: 'SD-FOO-001 coordinated', ticketRefValid: true },
+    },
+    {
+      name: 'fixture-8 (medium-risk WARNs without ack)',
+      currentFiles: new Set(['docs/plans/cross-sd-overlap-gate-plan.md']),
+      otherFiles: new Set(['docs/plans/cross-sd-overlap-gate-plan.md']),
+      expectedVerdict: 'WARN',
+      ackState: { acknowledged: false },
+    },
+  ];
+
+  for (const fx of fixtures) {
+    it(fx.name, () => {
+      const overlap = [...fx.currentFiles].filter(f => fx.otherFiles.has(f));
+      const entries = [];
+      if (overlap.length > 0) {
+        const { high, medium } = classifyOverlap(overlap);
+        const riskTier = high.length > 0 ? 'high' : medium.length > 0 ? 'medium' : 'low';
+        entries.push(buildOverlapEntry({
+          phase: 'PLAN-TO-EXEC',
+          collidingSdKey: 'fixture',
+          overlappingFiles: overlap,
+          riskTier,
+          verdict: 'PENDING',
+        }));
+      }
+      const decision = decideVerdict(entries, fx.ackState);
+      expect(decision.verdict).toBe(fx.expectedVerdict);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds two temporal file-overlap gates to the handoff pipeline that flag when the current SD's change set intersects files recently shipped by another SD (default 48h window), and **hard-fails** when the overlap hits a high-risk registry (protocol/auth/migrations/handoff-pipeline).

**Motivation**: 2026-04-24 P1 outage where `SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001` (07:52Z, tightened `sd-key-generator.js` guard) and `SD-MAN-INFRA-E2E-REGRESSION-TEST-001` (19:24Z, integration tests calling `generateSDKey()`) shipped 11h32m apart and broke main for 12+ hours until QF-20260424-603 patched call sites. The existing `OVERLAPPING_SCOPE_DETECTION` gate uses scope-text Jaccard on currently-active SDs and would NOT have caught the pair — this gate adds the missing file-path layer on recently-shipped SDs.

## Functional requirements delivered

- **FR-1**: Resurrected `scripts/modules/cross-sd-consistency-validation.js` (was orphaned from SD-LEO-PROTOCOL-V434-001 with zero callers); added `validatePrdShape()` and `extractChangedFiles()` helpers.
- **FR-2a**: `CROSS_SD_FILE_OVERLAP_TEMPORAL_PLAN` gate at PLAN-TO-EXEC. Oracle = PRD `target_files` vs each recently-shipped SD's PRD `target_files`.
- **FR-2b**: `CROSS_SD_FILE_OVERLAP_TEMPORAL_SHIP` gate at LEAD-FINAL-APPROVAL. Oracle = current PR diff (`SharedGitContext.diffFiles`) vs each recent SD's merge-commit diff. Resolves merge SHA from `metadata.merge_commit_sha` or `git log origin/main`.
- **FR-3**: `--acknowledge-cross-sd-overlap` + `--ack-reason` CLI flags in `handoff.js`. Reason must cite `SD-/QF-/PAT-/#issue` reference.
- **FR-4**: `config/high-risk-files.json` registry (minimatch globs) with seed list. `CROSS_SD_WINDOW_HOURS=0` for emergency disable.
- **FR-5**: Metadata writer appends structured entries to `sd_phase_handoffs.metadata.cross_sd_overlap[]`. Non-blocking on persistence failure.
- **FR-6**: Retro-replay vitest harness with 8 fixtures (5 historical FAIL + 1 negative PASS + 1 ack-PASS + 1 unack-WARN). All 29 tests pass: ` + "`npm run test:integration:cross-sd-gate`" + `.

## Verdict tiers

- **HIGH-risk overlap** → FAIL (no bypass; FR-4)
- **MEDIUM-risk + ticketed ack** → PASS (FR-3, must cite SD-/QF-/PAT-/#issue)
- **MEDIUM-risk no ack** → WARN (block until ack provided)
- **No overlap** → PASS

## PRD-condition decisions (from validation-agent + Explore review)

- 48h-window data source: ` + "`sd.completed_at`" + `
- ` + "`SharedGitContext.extractChangedFiles`" + ` helper landed in ` + "`lib/cross-sd-overlap.js`" + ` (cleaner separation; gate uses SharedGitContext's existing ` + "`diffFiles`" + ` getter for the SHIP oracle)
- Gates register via code exports (gates/index.js) per the existing convention; ` + "`validation_gate_registry`" + ` policy-tuning is a follow-up
- FR-6 fixture #1 timing tightened to ~12h apart (both shipped 2026-04-23) per Explore evidence

## Test plan

- [x] Unit: ` + "`npm run test:integration:cross-sd-gate`" + ` — 29/29 tests pass
- [x] Smoke import of all new + modified modules
- [x] Both gates load in their respective executor pipelines (verified via plan-to-exec/index.js + lead-final-approval/gates.js import)
- [x] LEAD-TO-PLAN handoff PASS (97), PLAN-TO-EXEC PASS (97), EXEC-TO-PLAN PASS (90), PLAN-TO-LEAD PASS (96)
- [ ] First post-merge SD that touches ` + "`scripts/modules/handoff/**`" + ` will exercise the SHIP gate against this PR's merge commit (live retro-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)