### PR TITLE
feat(SD-MAN-INFRA-NEXT-CONTENTION-DETECTOR-001): sd:next enrichment-signal upgrade for cycling claims

### DIFF
--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -157,6 +157,76 @@ export async function hasActiveWorkEvidence(supabase, sdId, sd, recencyMinutes =
 }
 
 /**
+ * Detect contention via SD enrichment metadata (updated_by + updated_at).
+ *
+ * SD-MAN-INFRA-NEXT-CONTENTION-DETECTOR-001: covers the "cycling claim" case
+ * where another active session has just touched an SD (writing updated_by /
+ * updated_at) but does not currently hold the formal claim. Today sd:next
+ * recommends such SDs as workable; this signal upgrades the LOCAL_ACTIVITY
+ * badge to CLAIMED for the duration of the window.
+ *
+ * Pivoted from the SD's original `enriched_by_session`/`enriched_at` design
+ * because those columns do not exist on strategic_directives_v2; we use the
+ * always-present updated_by + updated_at instead. Window is configurable via
+ * env CONTENTION_DETECTOR_WINDOW_MIN (default 10 minutes).
+ *
+ * @param {Object} params
+ * @param {Object} params.sd - SD row (must include updated_by and updated_at)
+ * @param {Array}  params.activeSessions - claude_sessions rows with status='active'
+ * @param {number} [params.recencyMinutes=10] - Window in minutes; values <=0 disable the check
+ * @returns {{ inProgress: boolean, sessionId: string|null, ageMin: number|null, reason: string }}
+ *   inProgress=true means the SD was touched by an active session within the window.
+ *   reason is a short diagnostic string suitable for display.
+ */
+export function checkEnrichmentSignal({ sd, activeSessions, recencyMinutes } = {}) {
+  const envWindow = process.env.CONTENTION_DETECTOR_WINDOW_MIN
+    ? Number(process.env.CONTENTION_DETECTOR_WINDOW_MIN)
+    : null;
+  const windowMin = Number.isFinite(recencyMinutes) ? recencyMinutes
+                  : Number.isFinite(envWindow) ? envWindow
+                  : 10;
+
+  if (windowMin <= 0) {
+    return { inProgress: false, sessionId: null, ageMin: null, reason: 'window_disabled' };
+  }
+  if (!sd || typeof sd !== 'object') {
+    return { inProgress: false, sessionId: null, ageMin: null, reason: 'no_sd' };
+  }
+
+  // Fail-fast on missing source columns (per validation-agent condition).
+  // updated_by may be a UUID (session_id) or a username/system string; we
+  // accept both and rely on activeSessions lookup to disambiguate.
+  if (!Object.prototype.hasOwnProperty.call(sd, 'updated_by') || !Object.prototype.hasOwnProperty.call(sd, 'updated_at')) {
+    return { inProgress: false, sessionId: null, ageMin: null, reason: 'missing_source_columns' };
+  }
+  if (!sd.updated_by || !sd.updated_at) {
+    return { inProgress: false, sessionId: null, ageMin: null, reason: 'no_enrichment' };
+  }
+
+  const updatedAt = new Date(sd.updated_at);
+  if (Number.isNaN(updatedAt.getTime())) {
+    return { inProgress: false, sessionId: null, ageMin: null, reason: 'invalid_updated_at' };
+  }
+  const ageMin = (Date.now() - updatedAt.getTime()) / 60_000;
+  if (ageMin > windowMin) {
+    return { inProgress: false, sessionId: sd.updated_by, ageMin: Math.round(ageMin), reason: 'window_expired' };
+  }
+
+  const sessions = Array.isArray(activeSessions) ? activeSessions : [];
+  const match = sessions.find(s => s && s.session_id === sd.updated_by && s.status === 'active');
+  if (!match) {
+    return { inProgress: false, sessionId: sd.updated_by, ageMin: Math.round(ageMin), reason: 'no_active_match' };
+  }
+
+  return {
+    inProgress: true,
+    sessionId: sd.updated_by,
+    ageMin: Math.round(ageMin),
+    reason: 'active_match_within_window',
+  };
+}
+
+/**
  * Auto-release a stale dead claim. Only call when relationship is 'stale_dead'
  * (triple-confirmed: heartbeat stale + same host + PID dead).
  *

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -7,7 +7,7 @@ import { colors, trackColors } from '../colors.js';
 import { getPhaseAwareStatus } from '../status-helpers.js';
 import { parseDependencies } from '../dependency-resolver.js';
 import { formatVisionBadge } from './vision-scorecard.js';
-import { analyzeClaimRelationship, autoReleaseStaleDeadClaim } from '../claim-analysis.js';
+import { analyzeClaimRelationship, autoReleaseStaleDeadClaim, checkEnrichmentSignal } from '../claim-analysis.js';
 
 /**
  * Display a track section with hierarchical SD items
@@ -100,7 +100,28 @@ async function displaySDItem(item, indent, childItems, allItems, sessionContext)
 
   // SD-LEO-INFRA-SESSION-COMPACTION-CLAIM-001: Check local signals
   const localSignal = localSignals.get(sdId);
-  const hasLocalActivity = localSignal && !localSignal.staleWorktree && !isClaimedByOther && !isClaimedByMe;
+  let hasLocalActivity = localSignal && !localSignal.staleWorktree && !isClaimedByOther && !isClaimedByMe;
+
+  // SD-MAN-INFRA-NEXT-CONTENTION-DETECTOR-001: enrichment-signal upgrade.
+  // If another active session has touched this SD inside the recency window
+  // but does not currently hold the formal claim, upgrade to CLAIMED so we
+  // do not recommend SDs that are being actively worked.
+  let enrichmentSignal = null;
+  if (!isClaimedByOther && !isClaimedByMe && currentSession) {
+    enrichmentSignal = checkEnrichmentSignal({ sd: item, activeSessions });
+    if (enrichmentSignal.inProgress && enrichmentSignal.sessionId !== currentSession.session_id) {
+      isClaimedByOther = true;
+      hasLocalActivity = false;
+      const claimingSession = activeSessions.find(s => s.session_id === enrichmentSignal.sessionId);
+      if (claimingSession) {
+        claimAnalysis = analyzeClaimRelationship({
+          claimingSessionId: enrichmentSignal.sessionId,
+          claimingSession,
+          currentSession,
+        });
+      }
+    }
+  }
 
   // Status icon logic - now phase-aware with claim analysis
   let statusIcon;

--- a/tests/unit/sd-next/claim-analysis.test.js
+++ b/tests/unit/sd-next/claim-analysis.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for SD-MAN-INFRA-NEXT-CONTENTION-DETECTOR-001
+ * Covers checkEnrichmentSignal in scripts/modules/sd-next/claim-analysis.js
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { checkEnrichmentSignal } from '../../../scripts/modules/sd-next/claim-analysis.js';
+
+const SESSION_A = '11111111-1111-1111-1111-111111111111';
+const SESSION_B = '22222222-2222-2222-2222-222222222222';
+
+function minutesAgo(min) {
+  return new Date(Date.now() - min * 60_000).toISOString();
+}
+
+describe('checkEnrichmentSignal — FR for SD-MAN-INFRA-NEXT-CONTENTION-DETECTOR-001', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env.CONTENTION_DETECTOR_WINDOW_MIN;
+    delete process.env.CONTENTION_DETECTOR_WINDOW_MIN;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.CONTENTION_DETECTOR_WINDOW_MIN;
+    else process.env.CONTENTION_DETECTOR_WINDOW_MIN = originalEnv;
+  });
+
+  it('Case (a): updated_by matches an active session within window → inProgress:true', () => {
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(3) };
+    const activeSessions = [
+      { session_id: SESSION_A, status: 'active', heartbeat_age_seconds: 30 },
+      { session_id: SESSION_B, status: 'active', heartbeat_age_seconds: 5 },
+    ];
+    const result = checkEnrichmentSignal({ sd, activeSessions });
+    expect(result.inProgress).toBe(true);
+    expect(result.sessionId).toBe(SESSION_A);
+    expect(result.ageMin).toBe(3);
+    expect(result.reason).toBe('active_match_within_window');
+  });
+
+  it('Case (b): updated_by matches a released session → inProgress:false (no upgrade)', () => {
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(2) };
+    const activeSessions = [
+      { session_id: SESSION_A, status: 'released', heartbeat_age_seconds: 30 },
+    ];
+    const result = checkEnrichmentSignal({ sd, activeSessions });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('no_active_match');
+    expect(result.sessionId).toBe(SESSION_A);
+  });
+
+  it('Case (c): updated_at older than window → inProgress:false (window expired)', () => {
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(60) };
+    const activeSessions = [
+      { session_id: SESSION_A, status: 'active', heartbeat_age_seconds: 30 },
+    ];
+    const result = checkEnrichmentSignal({ sd, activeSessions, recencyMinutes: 10 });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('window_expired');
+    expect(result.ageMin).toBe(60);
+  });
+
+  it('returns no_sd when sd is missing or wrong type', () => {
+    expect(checkEnrichmentSignal({ sd: null, activeSessions: [] }).reason).toBe('no_sd');
+    expect(checkEnrichmentSignal({ sd: undefined, activeSessions: [] }).reason).toBe('no_sd');
+    expect(checkEnrichmentSignal({ sd: 'not-an-object', activeSessions: [] }).reason).toBe('no_sd');
+  });
+
+  it('fail-fast on missing source columns (no silent-false fallback)', () => {
+    const sd = { /* no updated_by, no updated_at */ };
+    const result = checkEnrichmentSignal({ sd, activeSessions: [] });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('missing_source_columns');
+  });
+
+  it('returns no_enrichment when columns exist but values are null', () => {
+    const sd = { updated_by: null, updated_at: null };
+    const result = checkEnrichmentSignal({ sd, activeSessions: [] });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('no_enrichment');
+  });
+
+  it('returns invalid_updated_at on unparseable timestamp', () => {
+    const sd = { updated_by: SESSION_A, updated_at: 'not-a-date' };
+    const result = checkEnrichmentSignal({ sd, activeSessions: [] });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('invalid_updated_at');
+  });
+
+  it('respects recencyMinutes argument over the env default', () => {
+    process.env.CONTENTION_DETECTOR_WINDOW_MIN = '60';
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(8) };
+    const activeSessions = [{ session_id: SESSION_A, status: 'active' }];
+    // Explicit recencyMinutes=5 should win over env CONTENTION_DETECTOR_WINDOW_MIN=60
+    const result = checkEnrichmentSignal({ sd, activeSessions, recencyMinutes: 5 });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('window_expired');
+  });
+
+  it('respects CONTENTION_DETECTOR_WINDOW_MIN env when no explicit recencyMinutes', () => {
+    process.env.CONTENTION_DETECTOR_WINDOW_MIN = '30';
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(20) };
+    const activeSessions = [{ session_id: SESSION_A, status: 'active' }];
+    const result = checkEnrichmentSignal({ sd, activeSessions });
+    // 20 min < 30 min env window, and session active → upgrade
+    expect(result.inProgress).toBe(true);
+    expect(result.sessionId).toBe(SESSION_A);
+  });
+
+  it('disables the check when recencyMinutes <= 0 (emergency disable)', () => {
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(1) };
+    const activeSessions = [{ session_id: SESSION_A, status: 'active' }];
+    const result = checkEnrichmentSignal({ sd, activeSessions, recencyMinutes: 0 });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('window_disabled');
+  });
+
+  it('ignores activeSessions whose status is not exactly "active"', () => {
+    const sd = { updated_by: SESSION_A, updated_at: minutesAgo(2) };
+    const activeSessions = [
+      { session_id: SESSION_A, status: 'idle' },
+      { session_id: SESSION_A, status: 'stale' },
+    ];
+    const result = checkEnrichmentSignal({ sd, activeSessions });
+    expect(result.inProgress).toBe(false);
+    expect(result.reason).toBe('no_active_match');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `checkEnrichmentSignal()` to `scripts/modules/sd-next/claim-analysis.js` and wires it into `displaySDItem` in `tracks.js`. SDs touched by another active session within a configurable recency window (default 10 min) are now rendered as **CLAIMED** rather than LOCAL_ACTIVITY, closing the cycling-claim case where the formal claim has rotated but a peer is still actively working on the row.

## Pivot from original scope (per validation-agent)

The SD as drafted assumed `enriched_by_session` and `enriched_at` columns on `strategic_directives_v2` — those columns **do not exist**. Pivoted to use the always-present `updated_by` + `updated_at`. Stays ~50 LOC, no schema migration. Validation evidence: `sub_agent_execution_results` row `47313222-b74f-43a9-a6c6-83aae613f9a5`.

## Behavior

- **inProgress=true** when `sd.updated_by` matches an `activeSessions[].session_id` with `status='active'` AND `ageMin <= window`.
- **Window**: default 10 min; tunable via `CONTENTION_DETECTOR_WINDOW_MIN`; values <= 0 disable the check (emergency).
- **Fail-fast**: missing source columns return `reason: 'missing_source_columns'` rather than silently passing.
- **Idempotent diagnostic returns**: `reason ∈ {window_disabled, no_sd, missing_source_columns, no_enrichment, invalid_updated_at, window_expired, no_active_match, active_match_within_window}`.

## Integration in `tracks.js`

- Only consulted when not already `isClaimedByOther` / `isClaimedByMe`.
- Upgrade flips `isClaimedByOther=true` and clears `hasLocalActivity`, then re-runs `analyzeClaimRelationship` to derive a richer status badge.

## Complementary to (NOT duplicative of) SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001

Echo's HYGIENE-001 fixes claim **preservation** (heartbeat-on-DB-write). This SD adds the orthogonal claim **detection** signal in sd:next display. Defense in depth.

## Test plan

- [x] `npx vitest run tests/unit/sd-next/claim-analysis.test.js` — 11/11 tests pass
- [x] All 3 SD-required cases verified: (a) active match within window → CLAIMED, (b) released session → no upgrade, (c) stale window → no upgrade
- [x] Smoke import of `tracks.js` after wiring change
- [x] Full handoff pipeline ran clean: LEAD-TO-PLAN 97, PLAN-TO-EXEC 97, EXEC-TO-PLAN 91, PLAN-TO-LEAD 96

🤖 Generated with [Claude Code](https://claude.com/claude-code)