### PR TITLE
fix(session-lifecycle): followups #1 + #3 — call-site heartbeat + post-handoff SD state reconciliation

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -48,8 +48,18 @@ export {
 // CLI entry point - delegate to modular index
 import { addPRDToDatabase } from './prd/index.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { startHeartbeat } from '../lib/heartbeat-manager.mjs';
 
 if (isMainModule(import.meta.url)) {
+  // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
+  // PRD creation is sub-agent-heavy and regularly exceeds the 15-min claim
+  // TTL (validation-agent + LLM generation + STORIES sub-agent). Start an
+  // in-process heartbeat in cooperative mode so the parent session's
+  // claim is preserved throughout. No-op when CLAUDE_SESSION_ID is absent.
+  if (process.env.CLAUDE_SESSION_ID) {
+    startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
+  }
+
   const args = process.argv.slice(2);
   if (args.length < 1) {
     console.log('Usage: node scripts/add-prd-to-database.js <SD-ID> [PRD-Title]');

--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -18,6 +18,18 @@
 
 import { main } from './modules/handoff/cli/index.js';
 import { claimGuard } from '../lib/claim-guard.mjs';
+import { startHeartbeat } from '../lib/heartbeat-manager.mjs';
+
+// SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
+// Start an in-process heartbeat for the duration of this script. Cooperative
+// ownership mode means the parent Claude Code session retains claim
+// ownership — we don't release on exit. This closes the "long gate
+// evaluation triggers stale-sweep auto-release" race that caused live
+// claim loss during validation-agent runs on 2026-04-24.
+// No-op when CLAUDE_SESSION_ID is absent (CI, ad-hoc manual runs).
+if (process.env.CLAUDE_SESSION_ID) {
+  startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
+}
 
 // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Pre-delegate claim assertion
 // Ensures claim exists before forwarding to the handoff executor

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -15,6 +15,72 @@ import { validateBypassReason } from '../bypass-rubric.js';
 import { resolveAutoProceed } from '../auto-proceed-resolver.js';
 
 /**
+ * SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 followup: post-handoff state
+ * reconciliation. The per-executor state-transitions.js modules are
+ * authoritative setters, but silent failures have been observed (SD stays
+ * at status='draft' phase='LEAD' after an accepted LEAD-TO-PLAN). This
+ * helper re-queries the SD and force-updates status/phase when drift is
+ * detected. Fail-soft: any error is logged but does not fail the handoff.
+ *
+ * Expected post-handoff SD state per handoff type (matches the DB writes
+ * in each executor's state-transitions.js):
+ */
+const POST_HANDOFF_SD_STATE = {
+  'LEAD-TO-PLAN': { status: 'in_progress', current_phase: 'PLAN_PRD' },
+  'PLAN-TO-EXEC': { status: 'in_progress', current_phase: 'EXEC' },
+  'EXEC-TO-PLAN': { status: 'in_progress', current_phase: 'PLAN_VERIFICATION' },
+  'PLAN-TO-LEAD': { status: 'pending_approval', current_phase: 'LEAD_FINAL' },
+  'LEAD-FINAL-APPROVAL': { status: 'completed', current_phase: 'COMPLETED' },
+};
+
+async function reconcileSDStateAfterHandoff(handoffType, sdId, supabase) {
+  const expected = POST_HANDOFF_SD_STATE[handoffType.toUpperCase()];
+  if (!expected || !sdId) return;
+
+  try {
+    const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
+    const queryField = isUUID ? 'id' : 'sd_key';
+
+    const { data: sd, error: readErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status, current_phase')
+      .eq(queryField, sdId)
+      .maybeSingle();
+
+    if (readErr || !sd) {
+      // Silent skip — the handoff already succeeded; a read failure here
+      // doesn't justify louder noise. Log only in debug mode.
+      if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+        console.log(`[reconcile-sd-state] read failed for ${sdId}: ${readErr?.message || 'no row'}`);
+      }
+      return;
+    }
+
+    const drift = sd.status !== expected.status || sd.current_phase !== expected.current_phase;
+    if (!drift) return;
+
+    const { error: updErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({
+        status: expected.status,
+        current_phase: expected.current_phase,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sd.id);
+
+    if (updErr) {
+      console.log(`   ⚠️  Post-handoff state reconciliation failed: ${updErr.message}`);
+    } else {
+      console.log(`   🔧 Post-handoff state reconciled: ${sd.status}/${sd.current_phase} → ${expected.status}/${expected.current_phase}`);
+    }
+  } catch (e) {
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      console.log(`[reconcile-sd-state] error: ${e?.message || e}`);
+    }
+  }
+}
+
+/**
  * Check bypass rate limits and log to audit
  *
  * @param {string} sdId - Strategic Directive ID
@@ -265,6 +331,18 @@ export async function displayExecutionResult(result, handoffType, sdId) {
 
       // LEO 5.0: Hydrate tasks for next phase
       await hydrateAndOutputTasks(sdId, handoffType, supabase);
+
+      // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 followup (2026-04-24):
+      // Defensive reconciliation for the "SD status stays at 'draft' after
+      // accepted handoffs" drift. Each executor's state-transitions.js is
+      // the authoritative setter, but silent failures have been observed
+      // (e.g., atomic RPC unavailable AND legacy fallback's .update() returns
+      // no error yet doesn't persist — root cause unclear; defense-in-depth
+      // instead of chasing it). Re-queries the SD post-handoff and
+      // force-updates status/phase when they don't match the expected
+      // post-handoff values. Fail-soft — any error here is logged but doesn't
+      // fail the handoff (which already succeeded).
+      await reconcileSDStateAfterHandoff(handoffType, canonicalId || sdId, supabase);
     }
 
     // SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001: Machine-readable result summary
@@ -282,7 +360,7 @@ export async function displayExecutionResult(result, handoffType, sdId) {
         if (autoProceedResult.enabled) {
           const commitOutput = execSync('git log origin/main..HEAD --oneline 2>/dev/null || true', { encoding: 'utf-8' }).trim();
           if (commitOutput.length > 0) {
-            console.log(`\nHANDOFF_POST_ACTION=ship`);
+            console.log('\nHANDOFF_POST_ACTION=ship');
           }
         }
       } catch (e) {

--- a/scripts/phase-preflight.js
+++ b/scripts/phase-preflight.js
@@ -18,9 +18,18 @@ import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { IssueKnowledgeBase } from '../lib/learning/issue-knowledge-base.js';
 import { enforceChildProgressionGate } from './modules/child-progression-gate.js';
 import { validateDecompositionGate } from './modules/decomposition-gate.js';
+import { startHeartbeat } from '../lib/heartbeat-manager.mjs';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+// SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
+// Phase preflight triggers sub-agent queries and issue-pattern lookups that
+// can exceed the 15-min claim TTL. Cooperative-mode heartbeat keeps the
+// parent session's claim alive during the run. No-op without CLAUDE_SESSION_ID.
+if (process.env.CLAUDE_SESSION_ID) {
+  startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
+}
 
 // FIX: Use service role key for server-side scripts that need full database access
 // The anon key may have RLS restrictions or be invalid for backend operations


### PR DESCRIPTION
## Summary

Two defensive fixes that follow up on SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (PR #3305, merged today). Both were captured in that SD's retrospective \`action_items\`.

**Followup #1 — FR1 call-site migration (~31 LOC)**: Start an in-process heartbeat in \`scripts/handoff.js\`, \`scripts/add-prd-to-database.js\`, \`scripts/phase-preflight.js\` when \`CLAUDE_SESSION_ID\` is set. Cooperative ownership mode means the parent Claude Code session retains claim ownership — these scripts refresh \`heartbeat_at\` during their work but do NOT release on exit. Closes the gap that let claims auto-release during multi-minute validation-agent / LLM-heavy runs. Chose this approach over wiring the Proxy-based \`withHeartbeat\` wrapper because that would require breaking a circular import (supabase-client → heartbeat-manager → session-manager → supabase-client).

**Followup #3 — Post-handoff SD state reconciliation (~78 LOC)**: The per-executor \`state-transitions.js\` modules are the authoritative setters for \`strategic_directives_v2.status/current_phase\`, but silent failures have been observed live (2026-04-24: LEAD-TO-PLAN accepted at 95% yet SD stayed at \`status='draft' phase='LEAD'\` — confused \`sd-start\` into suggesting LEAD-TO-PLAN again as the \"next action\"). Adds a defensive reconciliation in \`scripts/modules/handoff/cli/execution-helpers.js\` that re-queries the SD post-handoff and force-updates on drift. Fail-soft: any error is logged but doesn't fail the handoff.

Mapping (matches each executor's \`state-transitions.js\`):

| Handoff | Expected status | Expected phase |
|---------|-----------------|----------------|
| LEAD-TO-PLAN | in_progress | PLAN_PRD |
| PLAN-TO-EXEC | in_progress | EXEC |
| EXEC-TO-PLAN | in_progress | PLAN_VERIFICATION |
| PLAN-TO-LEAD | pending_approval | LEAD_FINAL |
| LEAD-FINAL-APPROVAL | completed | COMPLETED |

When reconciliation fires it prints: \`🔧 Post-handoff state reconciled: <old> → <expected>\`.

## Deferred

- **Followup #2 (libuv \`UV_HANDLE_CLOSING\`)**: cosmetic Windows Node 24 assertion in supabase-js fetch keep-alive path. Mitigation requires forking the fetch adapter — blast radius too large for a cosmetic log-line. Retro flagged low priority.
- **Vision-scorer auto-zero for EHG_Engineer SDs**: explicitly marked optional by user. Can be filed as its own SD/QF when it recurs.

## Test plan

- [x] Smoke: \`node scripts/handoff.js list <SD>\` emits \`[Heartbeat] Started automatic heartbeat (every 30s)\` and \`[Heartbeat] Process exiting (code 0)\` at exit.
- [x] Module imports clean (\`execution-helpers.js\`, \`handoff.js\`, \`add-prd-to-database.js\`, \`phase-preflight.js\`)
- [ ] End-to-end: reconciliation visible on next actual handoff run (will be observed in production when the next SD cycles through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)