### PR TITLE
fix(QF-20260424-803): post-merge-worktree-cleanup falsely reports unpushed_commits after squash merge

### DIFF
--- a/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup.test.js
+++ b/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup.test.js
@@ -1,0 +1,99 @@
+/**
+ * Regression test for QF-20260424-803.
+ *
+ * Verifies that hasUnpushedCommits correctly recognizes commits that have
+ * already been shipped to origin/main (squash-merge or otherwise) and does
+ * NOT falsely flag them as unpushed_commits.
+ *
+ * Strategy: build a tiny throw-away git repo that mirrors the post-merge
+ * state (worktree HEAD has commits whose patches exist on origin/main),
+ * call hasUnpushedCommits against it, and assert clean.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { hasUnpushedCommits } from '../post-merge-worktree-cleanup.js';
+
+const sh = (cmd, opts) => execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], ...opts }).trim();
+
+function setupRepoWithRemote() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-803-'));
+  const remote = path.join(root, 'remote.git');
+  const work = path.join(root, 'work');
+
+  sh(`git init --bare "${remote}"`);
+  sh(`git init "${work}"`);
+  sh('git config user.email test@example.com', { cwd: work });
+  sh('git config user.name test', { cwd: work });
+  sh('git config commit.gpgsign false', { cwd: work });
+  sh(`git remote add origin "${remote}"`, { cwd: work });
+
+  // Initial commit on main
+  fs.writeFileSync(path.join(work, 'README.md'), 'init\n');
+  sh('git add README.md', { cwd: work });
+  sh('git commit -m "init"', { cwd: work });
+  sh('git branch -M main', { cwd: work });
+  sh('git push -u origin main', { cwd: work });
+
+  return { root, remote, work };
+}
+
+describe('hasUnpushedCommits — QF-20260424-803 regression', () => {
+  let env;
+
+  beforeEach(() => { env = setupRepoWithRemote(); });
+  afterEach(() => { try { fs.rmSync(env.root, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+  it('returns clean when worktree HEAD has no extra commits vs origin/main', () => {
+    const result = hasUnpushedCommits(env.work);
+    expect(result.unpushed).toBe(false);
+    expect(result.commits).toEqual([]);
+  });
+
+  it('flags genuinely-unpushed commits', () => {
+    fs.writeFileSync(path.join(env.work, 'feature.js'), 'export const x = 1;\n');
+    sh('git add feature.js', { cwd: env.work });
+    sh('git commit -m "feat: x"', { cwd: env.work });
+    const result = hasUnpushedCommits(env.work);
+    expect(result.unpushed).toBe(true);
+    expect(result.commits.length).toBe(1);
+  });
+
+  it('does NOT flag commits whose patches were squash-merged into origin/main', () => {
+    // Step 1: create feature commit on a branch
+    sh('git checkout -b feature/x', { cwd: env.work });
+    fs.writeFileSync(path.join(env.work, 'feature.js'), 'export const x = 1;\n');
+    sh('git add feature.js', { cwd: env.work });
+    sh('git commit -m "feat: x"', { cwd: env.work });
+    sh('git push -u origin feature/x', { cwd: env.work });
+
+    // Step 2: simulate squash-merge into main (same patch, different sha)
+    sh('git checkout main', { cwd: env.work });
+    sh('git merge --squash feature/x', { cwd: env.work });
+    sh('git commit -m "feat: x (squashed)"', { cwd: env.work });
+    sh('git push origin main', { cwd: env.work });
+
+    // Step 3: simulate post-merge state — worktree on feature branch with
+    // its original commit, origin/main carries the squashed equivalent.
+    sh('git checkout feature/x', { cwd: env.work });
+
+    const result = hasUnpushedCommits(env.work);
+    expect(result.unpushed).toBe(false);
+    expect(result.commits).toEqual([]);
+  });
+
+  it('does NOT flag commits that are direct ancestors of origin/main (fast-forward merge)', () => {
+    // Create a commit, push to origin/main directly (mimics merge with no squash)
+    fs.writeFileSync(path.join(env.work, 'feature.js'), 'export const y = 2;\n');
+    sh('git add feature.js', { cwd: env.work });
+    sh('git commit -m "feat: y"', { cwd: env.work });
+    sh('git push origin main', { cwd: env.work });
+
+    // HEAD == origin/main → no commits in origin/main..HEAD
+    const result = hasUnpushedCommits(env.work);
+    expect(result.unpushed).toBe(false);
+    expect(result.commits).toEqual([]);
+  });
+});

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -10,30 +10,61 @@ const gitExec = (cmd, opts = {}) =>
 
 /**
  * Check if a worktree has commits that have not been pushed to the remote.
- * SD-MAN-INFRA-WORKTREE-CODE-LOSS-001 (FR-1)
+ * SD-MAN-INFRA-WORKTREE-CODE-LOSS-001 (FR-1).
+ *
+ * QF-20260424-803: After `gh pr merge --delete-branch`, the local branch is
+ * gone, so a naive `git log origin/main..HEAD` either returns the now-orphaned
+ * commits (false unpushed) or throws (silently fell back to "treat as safe").
+ * Filter the listed commits through `git cherry` (patch-id match — handles
+ * squash merges) with a per-commit `merge-base --is-ancestor` fallback so a
+ * shipped commit is correctly recognized as not-unpushed.
  */
 function hasUnpushedCommits(wtPath) {
+  const opts = { cwd: wtPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] };
+  let commits = [];
   try {
-    const log = execSync('git log origin/main..HEAD --oneline', {
-      cwd: wtPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']
-    }).trim();
-    if (!log) return { unpushed: false, commits: [] };
-    const commits = log.split('\n').filter(Boolean);
-    return { unpushed: true, commits };
+    const log = execSync('git log origin/main..HEAD --oneline', opts).trim();
+    if (log) commits = log.split('\n').filter(Boolean);
   } catch {
-    // If origin/main doesn't exist or git fails, try @{upstream}
     try {
-      const log = execSync('git log @{upstream}..HEAD --oneline', {
-        cwd: wtPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']
-      }).trim();
-      if (!log) return { unpushed: false, commits: [] };
-      const commits = log.split('\n').filter(Boolean);
-      return { unpushed: true, commits };
+      const log = execSync('git log @{upstream}..HEAD --oneline', opts).trim();
+      if (log) commits = log.split('\n').filter(Boolean);
     } catch {
-      // Cannot determine remote state — treat as safe (unpushed)
-      return { unpushed: true, commits: ['(unable to determine remote state)'] };
+      // Cannot resolve any upstream from this worktree (branch deleted, etc.).
+      // If origin/main is reachable at all, treat as clean — there is nothing
+      // to compare to. Otherwise fail safe.
+      try {
+        execSync('git rev-parse --verify --quiet origin/main', opts);
+        return { unpushed: false, commits: [] };
+      } catch {
+        return { unpushed: true, commits: ['(unable to determine remote state)'] };
+      }
     }
   }
+  if (commits.length === 0) return { unpushed: false, commits: [] };
+
+  // QF-20260424-803: filter out commits already on origin/main (by patch-id
+  // for squash-merge cases, then by ancestor as a belt-and-suspenders check).
+  try {
+    const cherry = execSync('git cherry origin/main HEAD', opts).trim();
+    if (cherry) {
+      const truly = cherry.split('\n').filter(l => l.startsWith('+ ')).map(l => l.slice(2).trim()).filter(Boolean);
+      if (truly.length === 0) return { unpushed: false, commits: [] };
+      return { unpushed: true, commits: truly };
+    }
+  } catch { /* fall through to per-commit ancestor check */ }
+
+  const truly = commits.filter(line => {
+    const sha = line.split(/\s+/)[0];
+    try {
+      execSync(`git merge-base --is-ancestor ${sha} origin/main`, opts);
+      return false; // ancestor of origin/main -> already shipped
+    } catch {
+      return true; // genuinely not on origin/main
+    }
+  });
+  if (truly.length === 0) return { unpushed: false, commits: [] };
+  return { unpushed: true, commits: truly };
 }
 
 /**


### PR DESCRIPTION
## Summary

After ` + "`gh pr merge --delete-branch`" + `, the local branch is gone but its commits remain in the worktree's HEAD reflog. ` + "`git log origin/main..HEAD`" + ` returned the now-orphaned commits because their SHAs differ from the squashed equivalents on origin/main. The script then archived the worktree to ` + "`.worktrees/_archive/`" + ` instead of removing it, contributing to orphan-directory quota pressure that ` + "`SD-LEO-FIX-WORKTREE-QUOTA-COUNTER-001`" + ` (PR #3304) defends against. This QF closes the loop by removing the upstream generator.

**Fix**: filter the commit list through ` + "`git cherry origin/main HEAD`" + ` (patch-id match, recognizes squash merges) with ` + "`git merge-base --is-ancestor`" + ` as a per-commit fallback.

**Witnessed live this session**: SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 LEAD-FINAL cleanup got the false-positive even though the PR had merged at ` + "`d94076b2`" + `.

## Test plan

- [x] ` + "`npx vitest run scripts/modules/shipping/__tests__/post-merge-worktree-cleanup.test.js`" + ` — 4/4 pass
- [x] Test cases: clean state, genuinely-unpushed, squash-merged, ff-pushed
- [x] Each test bootstraps an isolated git repo + remote so the regression is repeatable in CI without seeded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)