### PR TITLE
fix(inbox): map wont_fix feedback and assigned patterns correctly

### DIFF
--- a/lib/inbox/unified-inbox-builder.js
+++ b/lib/inbox/unified-inbox-builder.js
@@ -17,6 +17,7 @@ function mapFeedbackLifecycle(status) {
   switch (status) {
     case 'new': return 'NEW';
     case 'backlog': return 'ON_THE_SHELF';
+    case 'wont_fix':
     case 'resolved': return 'COMPLETED';
     default: return 'NEW';
   }
@@ -25,6 +26,7 @@ function mapFeedbackLifecycle(status) {
 function mapPatternLifecycle(status) {
   switch (status) {
     case 'active': return 'NEW';
+    case 'assigned': return 'IN_PROGRESS';
     case 'resolved': return 'COMPLETED';
     default: return 'NEW';
   }

--- a/tests/unit/inbox/unified-inbox-builder.test.js
+++ b/tests/unit/inbox/unified-inbox-builder.test.js
@@ -31,11 +31,13 @@ describe('Lifecycle mapping', () => {
     it('maps "new" to NEW', () => expect(mapFeedbackLifecycle('new')).toBe('NEW'));
     it('maps "backlog" to ON_THE_SHELF', () => expect(mapFeedbackLifecycle('backlog')).toBe('ON_THE_SHELF'));
     it('maps "resolved" to COMPLETED', () => expect(mapFeedbackLifecycle('resolved')).toBe('COMPLETED'));
+    it('maps "wont_fix" to COMPLETED', () => expect(mapFeedbackLifecycle('wont_fix')).toBe('COMPLETED'));
     it('defaults unknown to NEW', () => expect(mapFeedbackLifecycle('unknown')).toBe('NEW'));
   });
 
   describe('mapPatternLifecycle', () => {
     it('maps "active" to NEW', () => expect(mapPatternLifecycle('active')).toBe('NEW'));
+    it('maps "assigned" to IN_PROGRESS', () => expect(mapPatternLifecycle('assigned')).toBe('IN_PROGRESS'));
     it('maps "resolved" to COMPLETED', () => expect(mapPatternLifecycle('resolved')).toBe('COMPLETED'));
     it('defaults unknown to NEW', () => expect(mapPatternLifecycle('foo')).toBe('NEW'));
   });


### PR DESCRIPTION
## Summary
- `mapFeedbackLifecycle` fell through to `NEW` for `wont_fix` — 59 properly disposed feedback items displayed as untriaged.
- `mapPatternLifecycle` fell through to `NEW` for `assigned` — patterns with a corrective SD displayed as un-addressed.

## Fix
- `wont_fix` → `COMPLETED`
- `assigned` → `IN_PROGRESS`

## Verification
Against live DB (pre/post):
- **NEW**: 851 → 772
- **COMPLETED**: 1058 → 1117
- **IN_PROGRESS**: 1 → 21
- Feedback NEW collapsed from 60 → 1 (the single genuinely-new item)

Unit tests: 49 → 51 (added one case for each new mapping).

## Test plan
- [x] `npx vitest run tests/unit/inbox/unified-inbox-builder.test.js` — 51/51 passing
- [x] Live inbox re-run shows corrected section counts
- [x] Pre-commit smoke tests passing (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)