### PR TITLE
docs(SD-LEO-DOC-FIX-CLAUDE-PLAN-001): fix CLAUDE_PLAN.md JSONB-key drift (from QF-20260424-804)

### DIFF
--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -238,7 +238,7 @@ These anti-patterns are specific to the PLAN phase. Violating them leads to inco
 ### NC-PLAN-002: No PRD Without Exploration
 **Anti-Pattern**: Creating PRD immediately after SD approval without reading codebase
 **Why Wrong**: PRDs miss existing infrastructure, create duplicate work, conflict with patterns
-**Correct Approach**: Read ≥5 relevant files, document findings in exploration_summary
+**Correct Approach**: Read ≥5 relevant files, document findings at `strategic_directives_v2.exploration_summary.files_explored` (the exact path `phase-preflight.js` Discovery Gate reads)
 
 ### NC-PLAN-003: No Boilerplate Acceptance Criteria
 **Anti-Pattern**: Using generic criteria like "all tests pass", "code review done", "meets requirements"
@@ -292,7 +292,7 @@ Before running `node scripts/add-prd-to-database.js`:
 
 1. **Exploration Complete?** (Discovery Gate)
    - [ ] Read ≥5 relevant files
-   - [ ] Documented findings in exploration_summary
+   - [ ] Documented findings at `sd.exploration_summary.files_explored` (the exact JSONB path checked by `phase-preflight.js` Discovery Gate)
    - [ ] Identified existing patterns to follow
 
 2. **Requirements Specific?** (Russian Judge)
@@ -402,12 +402,13 @@ Before running `node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX`, verify ALL
 - [ ] Technical architecture documented
 
 ### 2. Integration & Operationalization Complete ✅
-- [ ] PRD has `integration_operationalization` section with 5 subsections:
-  - [ ] **Consumers & User Journeys**: Who/what uses this feature
-  - [ ] **Upstream/Downstream Dependencies**: External systems, failure modes
-  - [ ] **Data Contracts & Schema**: Tables, columns, API contracts
-  - [ ] **Runtime Configuration**: Env vars, feature flags, deployment sequence
-  - [ ] **Observability, Rollout & Rollback**: Metrics, rollout plan, rollback procedure
+- [ ] PRD has `integration_operationalization` section with 5 subsections.
+  Canonical JSONB keys below match the `product_requirements_v2` CHECK constraint verbatim — use these exact keys. Alternative names (`upstream_dependencies`, `runtime_configuration`, `observability_rollout_rollback`, etc.) are REJECTED by the constraint.
+  - [ ] `consumers` — **Consumers & User Journeys**: Who/what uses this feature
+  - [ ] `dependencies` — **Upstream/Downstream Dependencies**: External systems, failure modes (single array with `direction` field per entry; NOT split into `upstream_dependencies`/`downstream_dependencies`)
+  - [ ] `data_contracts` — **Data Contracts & Schema**: Tables, columns, API contracts
+  - [ ] `runtime_config` — **Runtime Configuration**: Env vars, feature flags, deployment sequence
+  - [ ] `observability_rollout` — **Observability, Rollout & Rollback**: Metrics, rollout plan, rollback procedure
 - [ ] For infrastructure SDs: Consumers identified OR justification provided (≥30 chars)
 - [ ] Dependencies have `name`, `direction`, `failure_mode` fields
 


### PR DESCRIPTION
## Summary

CLAUDE_PLAN.md PLAN-TO-EXEC checklist documented `integration_operationalization` subsections with English labels only. PRD authors copying the labels verbatim (upstream_dependencies, runtime_configuration, observability_rollout_rollback) hit the `product_requirements_v2` CHECK constraint on every insert. This PR prefixes each bullet with the canonical JSONB key and adds an inline note about the REJECTED alternative names.

Secondary drift: `phase-preflight.js` Discovery Gate reads `sd.exploration_summary.files_explored` specifically; the checklist now points there explicitly.

**Escalated from QF-20260424-804** (auto-escalated to Tier 3 by the schema-keyword detector — false-positive because no schema changes are involved; handled as documentation-type SD).

## Changes

- `CLAUDE_PLAN.md:405-413` — canonical keys inline (consumers, dependencies, data_contracts, runtime_config, observability_rollout)
- `CLAUDE_PLAN.md:241` — point `exploration_summary` to `sd.exploration_summary.files_explored`
- `CLAUDE_PLAN.md:295` — same clarification in the checklist

## Test plan

- [x] Doc-only change, no code tests required
- [x] Handoff pipeline ran: LEAD-TO-PLAN 97, PLAN-TO-EXEC 97, PLAN-TO-LEAD 95 (bypass for known SD-ID-NORMALIZER retro-lookup bug)
- [ ] Future PRD insert via `add-prd-to-database.js` that copy-pastes the checklist should succeed without CHECK-constraint rejection (validated by the next SD that creates a PRD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)