### PR TITLE
fix(QF-20260424-805): stop heartbeat after PRD create so process exits cleanly

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -48,7 +48,7 @@ export {
 // CLI entry point - delegate to modular index
 import { addPRDToDatabase } from './prd/index.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
-import { startHeartbeat } from '../lib/heartbeat-manager.mjs';
+import { startHeartbeat, stopHeartbeat } from '../lib/heartbeat-manager.mjs';
 
 if (isMainModule(import.meta.url)) {
   // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
@@ -56,7 +56,8 @@ if (isMainModule(import.meta.url)) {
   // TTL (validation-agent + LLM generation + STORIES sub-agent). Start an
   // in-process heartbeat in cooperative mode so the parent session's
   // claim is preserved throughout. No-op when CLAUDE_SESSION_ID is absent.
-  if (process.env.CLAUDE_SESSION_ID) {
+  const heartbeatActive = Boolean(process.env.CLAUDE_SESSION_ID);
+  if (heartbeatActive) {
     startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
   }
 
@@ -69,5 +70,13 @@ if (isMainModule(import.meta.url)) {
 
   const sdId = args[0];
   const prdTitle = args.slice(1).filter(a => !a.startsWith('--')).join(' ');
-  addPRDToDatabase(sdId, prdTitle);
+  // QF-20260424-805: Stop the heartbeat interval after addPRDToDatabase resolves
+  // so Node can exit naturally. Without this, setInterval keeps the event loop
+  // alive forever and Bash SIGTERMs the process at its 10-min default timeout
+  // (exit 143) — even though the PRD + user-story rows already landed in the DB.
+  // Cooperative mode means stopHeartbeat does NOT release the parent session's
+  // claim; only the in-process timer is cleared.
+  addPRDToDatabase(sdId, prdTitle).finally(() => {
+    if (heartbeatActive) stopHeartbeat();
+  });
 }

--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -185,6 +185,11 @@ export async function addPRDToDatabase(sdId, prdTitle) {
         stakeholderPersonas
       );
       console.log(`\n✅ PRD ${prdId} created with validated LLM content!`);
+      // QF-20260424-805: machine-readable success marker emitted BEFORE the
+      // slow post-insert hooks (component recommendations, sub-agent
+      // orchestration). Callers can grep this marker to detect persistence
+      // success even if the process is later SIGTERMed mid-post-hook.
+      console.log(`>>> PRD_PERSISTED=${prdId}`);
       console.log(`   Progress: ${data.progress}%`);
       console.log(`   Functional Requirements: ${llmContent.functional_requirements?.length || 0}`);
       console.log(`   Test Scenarios: ${llmContent.test_scenarios?.length || 0}`);
@@ -201,6 +206,9 @@ export async function addPRDToDatabase(sdId, prdTitle) {
             supabase, prdId, sdId, sdIdValue, prdTitle, sdData, llmContent, stakeholderPersonas
           );
           console.log(`\n⚠️  PRD ${prdId} created with pre_validation_warning flag`);
+          // QF-20260424-805: same machine-readable marker on the retry success
+          // path so callers don't need to special-case the warn variant.
+          console.log(`>>> PRD_PERSISTED=${prdId}`);
         } catch (retryError) {
           console.error('Retry also failed:', retryError.message);
           process.exit(1);


### PR DESCRIPTION
## Summary

`scripts/add-prd-to-database.js` calls `startHeartbeat()` in cooperative mode but never stops it. The `setInterval(30s)` keeps the event loop alive forever after `addPRDToDatabase()` returns. Bash then SIGTERMs the process at its 10-min default timeout (exit 143) — even though the PRD + user-story rows already landed in the DB. **Cosmetic failure that looks like a real failure.**

Witnessed during SD-LEO-DOC-FIX-CLAUDE-PLAN-001 PRD creation (per QF-805 description).

## Root Cause

- `add-prd-to-database.js:60` → `startHeartbeat(...)` with cooperative mode
- `addPRDToDatabase()` body has many `process.exit()` calls in error paths (those work fine — explicit exit clears the interval via heartbeat exit handlers)
- The **success path** (line 234) just `return`s. The setInterval keeps Node alive indefinitely → Bash SIGTERMs → exit 143

## Fix (~23 LOC, Tier 1 QF)

1. **`scripts/add-prd-to-database.js`** — wrap `addPRDToDatabase(...)` in `.finally(stopHeartbeat)`. Cooperative mode means the parent session's claim is preserved; only the in-process timer is cleared.
2. **`scripts/prd/index.js`** — emit machine-readable `>>> PRD_PERSISTED=<prd-id>` marker BEFORE the slow post-insert hooks (component recommendations, sub-agent orchestration). Callers can grep for this marker to detect persistence regardless of exit code. Marker added on both success and warn-retry paths.

## Test Plan

- [x] `node --check` syntax OK on both files
- [x] 37/37 `heartbeat-manager-{ownership-mode,withHeartbeat}` unit tests pass
- [x] 15/15 smoke tests pass (pre-commit hook)
- [x] PRD schema validation passes (pre-commit hook)
- [x] LOC: 23 (below Tier 1 threshold)
- [ ] Real-world: next `LLM_PRD_INLINE=false node scripts/add-prd-to-database.js <SD>` should exit 0 cleanly within reasonable time and emit `>>> PRD_PERSISTED=PRD-...` to stdout

## Out of Scope (follow-ups)

- `scripts/handoff.js` has the **same SIGTERM-after-success pattern** (memory `feedback_lead_final_approval_sigterm_post_write.md`). One-line fix candidate.
- `classify-quick-fix.js` flags forbidden-keyword "database" on the literal script filename — caused this QF to require classifier bypass. Filename-vs-content disambiguation is a separate harness improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)