### PR TITLE
fix(QF-20260424-806): wire sdId context to gate remediation prompts

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -294,7 +294,8 @@ export class HandoffOrchestrator {
         console.log('📋 REMEDIATION ACTIONS');
         console.log('─'.repeat(60));
         result.failedGates.forEach((gate, idx) => {
-          const remediation = executor.getRemediation ? executor.getRemediation(gate.name) : null;
+          // QF-20260424-806: pass sdId so remediation prompts interpolate correctly.
+          const remediation = executor.getRemediation ? executor.getRemediation(gate.name, { sdId }) : null;
           console.log(`   ${idx + 1}. ${gate.name}`);
           gate.issues.forEach(issue => console.log(`      ❌ ${issue}`));
           if (remediation) {

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -370,7 +370,8 @@ export class BaseExecutor {
           const failurePhase = this._getSourcePhaseFromHandoff();
           await this._displayOnFailureDirectives(failurePhase);
 
-          const remediation = this.getRemediation(gateResults.failedGate);
+          // QF-20260424-806: pass sdId so remediation prompts interpolate correctly.
+          const remediation = this.getRemediation(gateResults.failedGate, { sdId });
 
           // RCA Auto-Trigger on gate failure (SD-LEO-ENH-ENHANCE-RCA-SUB-001)
           // SD-LEARN-FIX-ADDRESS-PAT-AUTO-003: Use individual gate score, not overall aggregate.

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -516,8 +516,9 @@ export class ExecToPlanExecutor extends BaseExecutor {
     }
   }
 
-  getRemediation(gateName) {
-    return getRemediation(gateName);
+  // QF-20260424-806: forward context so promptFn(ctx) can interpolate sdId.
+  getRemediation(gateName, context = {}) {
+    return getRemediation(gateName, context);
   }
 }
 

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -231,7 +231,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         // FR-4: draft SDs get a distinct code so tooling can differentiate
         // "never approved" from "wrong state but approved at some point".
         const nextCommand = `node scripts/handoff.js execute PLAN-TO-LEAD ${sdId}`;
-        console.log(`   ❌ SD status is 'draft' — LEAD-FINAL-APPROVAL requires 'pending_approval'. Run PLAN-TO-LEAD first.`);
+        console.log('   ❌ SD status is \'draft\' — LEAD-FINAL-APPROVAL requires \'pending_approval\'. Run PLAN-TO-LEAD first.');
         return ResultBuilder.rejected(
           'DRAFT_SD_NOT_APPROVED',
           `SD status must be 'pending_approval' for final approval (current: 'draft'). Run PLAN-TO-LEAD first: ${nextCommand}`,
@@ -276,9 +276,9 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
           return ResultBuilder.rejected(
             'INVALID_STATUS',
             `SD status is '${sd.status}' but PLAN-TO-LEAD handoff is already recorded as accepted — ` +
-            `the status UPDATE to 'pending_approval' was never applied (silent pre-fix failure). ` +
+            'the status UPDATE to \'pending_approval\' was never applied (silent pre-fix failure). ' +
             `Remediation: manually update SD ${sdId} status to 'pending_approval' in strategic_directives_v2, ` +
-            `OR re-run PLAN-TO-LEAD (which now throws on UPDATE failure per SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-126).`,
+            'OR re-run PLAN-TO-LEAD (which now throws on UPDATE failure per SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-126).',
             {
               currentStatus: sd.status,
               requiredStatus: 'pending_approval',
@@ -749,8 +749,12 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     return { closedCount: updated?.length || 0 };
   }
 
-  getRemediation(gateName) {
-    return getRemediation(gateName);
+  // QF-20260424-806: accept context (sdId, details, score) and forward it to
+  // remediations.getRemediation, which forwards to rejection-subagent-mapping's
+  // promptFn(ctx). Without this, remediation prompts render `${ctx.sdId}` as
+  // the literal string "undefined" — making the Five-Point Brief unactionable.
+  getRemediation(gateName, context = {}) {
+    return getRemediation(gateName, context);
   }
 }
 

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -540,8 +540,9 @@ export class PlanToExecExecutor extends BaseExecutor {
     }
   }
 
-  getRemediation(gateName) {
-    return getRemediation(gateName);
+  // QF-20260424-806: forward context so promptFn(ctx) can interpolate sdId.
+  getRemediation(gateName, context = {}) {
+    return getRemediation(gateName, context);
   }
 
   async _loadValidators() {

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -529,8 +529,9 @@ export class PlanToLeadExecutor extends BaseExecutor {
     };
   }
 
-  getRemediation(gateName) {
-    return getRemediation(gateName);
+  // QF-20260424-806: forward context so promptFn(ctx) can interpolate sdId.
+  getRemediation(gateName, context = {}) {
+    return getRemediation(gateName, context);
   }
 }
 


### PR DESCRIPTION
## Summary

Gate remediation prompts in `scripts/modules/handoff/rejection-subagent-mapping.js` interpolate `${ctx.sdId}` into the Five-Point Brief. But the 4 executor wrappers and 2 call sites that surface those prompts call `getRemediation(gateName)` **without** a context argument — so `promptFn` receives `ctx={}` and renders the literal string `"undefined"` wherever `sdId` should appear.

Witnessed at LEAD-FINAL-APPROVAL and PLAN-TO-LEAD as:

```
Symptom: No quality retrospective found for undefined. ...
Location: sd_retrospectives table WHERE sd_id='undefined'
```

3 incidents in one session per QF-806 description. Each blocked handoff has required `--bypass-validation` citing the actual retro id by hand — inflating audit-log noise and consuming the 3-bypass rate limit.

## Fix (35 LOC, Tier 2)

Extend each executor wrapper to accept and forward an optional context, and have `BaseExecutor` + `HandoffOrchestrator` pass `{ sdId }` when invoking it.

**Files:**
- `executors/lead-final-approval/index.js` — wrapper signature
- `executors/exec-to-plan/index.js` — wrapper signature
- `executors/plan-to-exec/index.js` — wrapper signature
- `executors/plan-to-lead/index.js` — wrapper signature
- `executors/BaseExecutor.js:373` — pass `{ sdId }`
- `HandoffOrchestrator.js:297` — pass `{ sdId }`

## Test Plan

- [x] `node --check` syntax OK on all 6 files
- [x] 8/8 `lead-final-approval-status-gate` tests pass
- [x] 3/3 unrelated `transition-readiness-rejection` tests pass; the 4th failure (`REJECTED lowercase`) is **pre-existing on origin/main** — verified by checkout-and-rerun. Unrelated to this change.
- [x] 15/15 smoke tests pass (pre-commit)
- [x] DOCMON, schema validation, branch guard, secret scan all green

## Out of Scope

- Pre-existing `transition-readiness-rejection.test.js` lowercase-case-sensitivity bug
- Pre-existing lint warnings (10 `no-unused-vars` errors across the 6 files, all on lines I didn't touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)