### PR TITLE
feat(SD-LEO-INFRA-UNIFY-QUICK-FIX-001): unify SD/QF queue ranking

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -15,7 +15,6 @@ import { checkDependencyStatus } from '../../child-sd-preflight.js';
 import { VentureContextManager } from '../../../lib/eva/venture-context-manager.js';
 import { normalizeVenturePrefix } from '../sd-key-generator.js';
 
-import { scoreToBand, bandToNumeric } from '../auto-proceed/urgency-scorer.js';
 import { colors } from './colors.js';
 
 /** Maximum time (ms) allowed for the displayTracks loop before preemption */
@@ -42,7 +41,8 @@ function computeOKRScore(alignments, krMap) {
   }
   return Math.min(total, 90); // Cap at 90
 }
-import { checkDependenciesResolved, scanMetadataForMisplacedDependencies } from './dependency-resolver.js';
+import { checkDependenciesResolved } from './dependency-resolver.js';
+import { rankItems } from './rank-items.js';
 import { detectLocalSignals } from './local-signals.js';
 import {
   loadActiveBaseline,
@@ -606,7 +606,7 @@ export class SDNextSelector {
   }
 
   async displayTracks() {
-    const tracks = { A: [], B: [], C: [], STANDALONE: [] };
+    // `tracks` is populated later by rankItems() (SD-LEO-INFRA-UNIFY-QUICK-FIX-001).
 
     // SINGLE SOURCE OF TRUTH: Query all active SDs directly from strategic_directives_v2
     // This ensures SDs appear even if baseline sync trigger failed (SD-LEO-INFRA-QUEUE-SIMPLIFY-001)
@@ -743,62 +743,20 @@ export class SDNextSelector {
       baselineMap.set(item.sd_id, item);
     }
 
-    // Track SDs with misplaced dependency info in metadata
-    const misplacedDeps = [];
-
-    // Process each SD (uses filtered list when venture context is active)
+    // Pre-enrich filtered SDs with async dependency fields (rankItems is pure;
+    // async DB calls stay out of it). Preemption loop guard remains here.
     const displayStartTime = Date.now();
     let preempted = false;
+    const enrichedSDs = [];
     for (const sd of filteredSDs) {
-      // Preemption check: abort if display loop exceeds timeout
       if (Date.now() - displayStartTime > MAX_DISPLAY_DURATION_MS) {
-        console.log(`${colors.yellow}⚠️  Display preempted after ${MAX_DISPLAY_DURATION_MS / 1000}s — showing ${Object.values(tracks).flat().length} of ${filteredSDs.length} SDs${colors.reset}`);
+        console.log(`${colors.yellow}⚠️  Display preempted after ${MAX_DISPLAY_DURATION_MS / 1000}s — enriched ${enrichedSDs.length} of ${filteredSDs.length} SDs${colors.reset}`);
         preempted = true;
         break;
       }
       if (sd.status === 'completed' || sd.status === 'cancelled') continue;
 
-      // Governance: skip deferred SDs from recommendation pipeline (keep in display with badge)
-      const isDeferred = sd.metadata?.do_not_advance_without_trigger === true;
-
-      // QA: Check for dependency info in metadata with empty dependencies column
-      const depsEmpty = !sd.dependencies || (Array.isArray(sd.dependencies) && sd.dependencies.length === 0);
-      if (depsEmpty && sd.metadata) {
-        const scan = scanMetadataForMisplacedDependencies(sd.metadata);
-        if (scan.hasMisplacedDeps) {
-          misplacedDeps.push({ sd_key: sd.sd_key || sd.id, findings: scan.findings });
-        }
-      }
-
-      // Look up baseline item by sd_key or id
-      const baselineItem = baselineMap.get(sd.sd_key) || baselineMap.get(sd.id);
-
-      // Derive track: baseline > metadata > category > STANDALONE
-      let trackKey;
-      if (baselineItem?.track) {
-        trackKey = baselineItem.track;
-      } else if (sd.metadata?.execution_track) {
-        const track = sd.metadata.execution_track;
-        trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
-                   track === 'Feature' ? 'B' :
-                   track === 'Quality' ? 'C' : 'STANDALONE';
-      } else if (sd.category) {
-        const cat = sd.category.toLowerCase();
-        trackKey = cat === 'infrastructure' || cat === 'platform' ? 'A' :
-                   cat === 'quality' || cat === 'testing' || cat === 'qa' ? 'C' : 'B';
-      } else {
-        trackKey = 'STANDALONE';
-      }
-
-      // Log warning if SD not in baseline (helps detect sync failures)
-      if (!baselineItem && sd.status !== 'draft') {
-        console.log(`${colors.yellow}⚠️  SD ${sd.sd_key || sd.id} not in baseline - using category-based track${colors.reset}`);
-      }
-
-      if (!tracks[trackKey]) trackKey = 'STANDALONE';
-
       const depsResolved = await checkDependenciesResolved(this.supabase, sd.dependencies);
-
       let childDepStatus = null;
       if (sd.parent_sd_id) {
         try {
@@ -808,65 +766,26 @@ export class SDNextSelector {
         }
       }
 
-      // SD-MAN-INFRA-PRIORITY-QUEUE-ROUTING-001: Vision-score-weighted priority
-      // gap_weight = (100 - vision_score) / 100; composite_rank = sequence_rank / (1 + gap_weight)
-      const sequenceRank = baselineItem?.sequence_rank || 9999;
-      const hasVisionOrigin = !!sd.vision_origin_score_id;
-      const visionScoreVal = sd.vision_score ?? null;
-      const gapWeight = (hasVisionOrigin && visionScoreVal !== null)
-        ? (100 - Math.max(0, Math.min(100, visionScoreVal))) / 100
-        : 0;
-      let compositeRank = gapWeight > 0 ? sequenceRank / (1 + gapWeight) : sequenceRank;
-
-      // SD-LEO-INFRA-OKR-PIPELINE-AUTOMATION-001: OKR impact scoring
-      // Higher OKR score = more strategic alignment = lower rank (higher priority)
-      const okrScore = okrScoreMap.get(sd.id) || 0;
-      const okrBoost = okrBoostMap.get(sd.id) || 1.0;
-      // Blend: subtract OKR-proportional amount from rank (max 90 * 0.30 = 27 rank points)
-      compositeRank = (compositeRank * okrBoost) - (okrScore * okrBlendWeight);
-
-      // SD-LEO-INFRA-EHG-PORTFOLIO-ALLOCATION-001: Glide path policy boost
-      // Venture-scoped SDs get a multiplier based on their growth_strategy alignment
-      // with the active policy weights. Infrastructure SDs are policy-neutral (1.0x).
-      const policyBoost = policyBoostMap.get(sd.venture_id) ?? 1.0;
-      if (policyBoost !== 1.0) {
-        compositeRank = compositeRank * policyBoost;
-      }
-
-      // SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-A: Extract urgency from metadata
-      const urgencyScore = sd.metadata?.urgency_score ?? null;
-      const urgencyBand = sd.metadata?.urgency_band ?? (urgencyScore !== null ? scoreToBand(urgencyScore) : 'P3');
-      const urgencyNumeric = bandToNumeric(urgencyBand);
-
-      tracks[trackKey].push({
-        ...(baselineItem || {}),
-        ...sd,
-        sd_id: sd.sd_key || sd.id,
-        sequence_rank: sequenceRank,
-        gap_weight: gapWeight,
-        composite_rank: compositeRank,
-        okr_boost: okrBoost < 1.0 ? okrBoost : null,
-        okr_score: okrScore > 0 ? okrScore : null, // OKR impact score (0-90)
-        policy_boost: policyBoost !== 1.0 ? policyBoost : null, // Glide path weight
-        urgency_score: urgencyScore,
-        urgency_band: urgencyBand,
-        urgency_numeric: urgencyNumeric,
-        deps_resolved: depsResolved,
-        is_deferred: isDeferred,
-        childDepStatus,
-        actual: this.actuals[sd.sd_key] || this.actuals[sd.id]
-      });
+      enrichedSDs.push({ ...sd, deps_resolved: depsResolved, childDepStatus });
     }
 
-    // Sort each track: urgency band (P0 first) → urgency score (desc) → composite_rank fallback
-    for (const trackKey of Object.keys(tracks)) {
-      tracks[trackKey].sort((a, b) => {
-        const bandDiff = (a.urgency_numeric ?? 3) - (b.urgency_numeric ?? 3);
-        if (bandDiff !== 0) return bandDiff;
-        const scoreDiff = (b.urgency_score ?? 0) - (a.urgency_score ?? 0);
-        if (scoreDiff !== 0) return scoreDiff;
-        return (a.composite_rank ?? a.sequence_rank ?? 9999) - (b.composite_rank ?? b.sequence_rank ?? 9999);
-      });
+    // Pure ranking (SD-LEO-INFRA-UNIFY-QUICK-FIX-001): single source of truth for
+    // urgency bands + vision gap weight + OKR blend + policy boost + track grouping.
+    const rankResult = rankItems(enrichedSDs, {
+      baselineItemsMap: baselineMap,
+      okrScoreMap,
+      okrBoostMap,
+      okrBlendWeight,
+      policyBoostMap,
+      actuals: this.actuals,
+    });
+
+    const tracks = rankResult.tracks;
+    const misplacedDeps = rankResult.misplacedDeps;
+
+    // Emit orphan-baseline warnings (previously inline per SD)
+    for (const orphan of rankResult.orphanBaseline) {
+      console.log(`${colors.yellow}⚠️  SD ${orphan.sd_key} not in baseline - using category-based track${colors.reset}`);
     }
 
     // SD-LEO-INFRA-HANDOFF-INTEGRITY-RECOVERY-001: Annotate stuck SDs

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -74,6 +74,7 @@ import {
   isOrchestratorBlocked,
   displayTelemetryFindings,
   displayQuickFixes,
+  classifyQuickFixes,
   displayRoadmapAwareness,
   displayBrainstormPipelineAdvisory
 } from './display/index.js';
@@ -210,11 +211,15 @@ export class SDNextSelector {
     // Display scheduled job failure alerts from feedback table
     await this.displayScheduledJobAlerts();
 
+    // SD-LEO-INFRA-UNIFY-QUICK-FIX-001 (Phase 3): QFs now interleave with SDs
+    // inside the track sections; no separate OPEN QUICK FIXES render call.
+    // showFallbackQueue / displayTracks return the QF summary for AUTO_PROCEED_ACTION.
     if (!this.baseline) {
-      await showFallbackQueue(this.supabase, {
-        sessionContext: this.getSessionContext()
+      const qfSummaryNoBaseline = await showFallbackQueue(this.supabase, {
+        sessionContext: this.getSessionContext(),
+        openQuickFixes: this.openQuickFixes,
+        qfTriageResults: this.qfTriageResults,
       });
-      const qfSummaryNoBaseline = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
       this.displayFeedbackItems();
       if (qfSummaryNoBaseline.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
@@ -226,13 +231,13 @@ export class SDNextSelector {
     const actionableCount = await countActionableBaselineItems(this.supabase, this.baselineItems);
 
     if (actionableCount === 0) {
-      // Baseline exists but is exhausted - show helpful message and fallback
       showExhaustedBaselineMessage(this.baseline, this.baselineItems);
-      await showFallbackQueue(this.supabase, {
+      const qfSummaryExhausted = await showFallbackQueue(this.supabase, {
         skipBaselineWarning: true,
-        sessionContext: this.getSessionContext()
+        sessionContext: this.getSessionContext(),
+        openQuickFixes: this.openQuickFixes,
+        qfTriageResults: this.qfTriageResults,
       });
-      const qfSummaryExhausted = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
       this.displayFeedbackItems();
       if (qfSummaryExhausted.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
@@ -240,11 +245,8 @@ export class SDNextSelector {
       return { action: 'none', sd_id: null, reason: 'Baseline exhausted - all items completed' };
     }
 
-    // Display tracks
-    await this.displayTracks();
-
-    // Display open quick fixes with re-triage escalation warnings
-    const qfSummary = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
+    // Display tracks (QFs interleaved inside; qfSummary returned for routing)
+    const qfSummary = await this.displayTracks();
 
     // Display actionable feedback items (SD-LEO-INFRA-FEEDBACK-PIPELINE-ACTIVATION-001-C)
     this.displayFeedbackItems();
@@ -769,9 +771,16 @@ export class SDNextSelector {
       enrichedSDs.push({ ...sd, deps_resolved: depsResolved, childDepStatus });
     }
 
-    // Pure ranking (SD-LEO-INFRA-UNIFY-QUICK-FIX-001): single source of truth for
-    // urgency bands + vision gap weight + OKR blend + policy boost + track grouping.
-    const rankResult = rankItems(enrichedSDs, {
+    // SD-LEO-INFRA-UNIFY-QUICK-FIX-001 Phase 3: classify QFs, tag with kind='qf',
+    // feed into rankItems alongside SDs so they interleave in the track sections.
+    const { summary: qfSummary, classified: classifiedQFs } = classifyQuickFixes(
+      this.openQuickFixes, this.qfTriageResults, this.getSessionContext()
+    );
+    const qfItems = classifiedQFs.map(qf => ({ ...qf, kind: 'qf' }));
+
+    // Pure ranking: single source of truth for urgency bands + vision gap weight +
+    // OKR blend + policy boost + track grouping, across both SDs and QFs.
+    const rankResult = rankItems([...enrichedSDs, ...qfItems], {
       baselineItemsMap: baselineMap,
       okrScoreMap,
       okrBoostMap,
@@ -815,6 +824,8 @@ export class SDNextSelector {
       console.log(`  ${colors.dim}These dependencies are NOT enforced by the queue system.${colors.reset}`);
       console.log(`  ${colors.dim}Move them to the "dependencies" column for proper blocking/readiness control.${colors.reset}`);
     }
+
+    return qfSummary;
   }
 }
 

--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -7,19 +7,29 @@ import { colors } from '../colors.js';
 import { checkDependenciesResolved } from '../dependency-resolver.js';
 import { displayTrackSection } from './tracks.js';
 import { rankItems } from '../rank-items.js';
+import { classifyQuickFixes } from './quick-fixes.js';
 
 /**
  * Show fallback queue when no baseline is active.
  *
- * SD-LEO-INFRA-UNIFY-QUICK-FIX-001 (Phase 2): delegates all ranking to
- * rank-items.js so the no-baseline path applies the same urgency bands,
- * vision gap weight, OKR blend, and policy boost as the baseline path.
+ * SD-LEO-INFRA-UNIFY-QUICK-FIX-001:
+ *   - Phase 2: delegates ranking to rank-items.js so urgency, vision gap,
+ *     OKR blend, and policy boost apply in no-baseline mode.
+ *   - Phase 3: interleaves Quick Fixes with SDs in their inferred tracks
+ *     via rank-items.js, removing the separate OPEN QUICK FIXES section.
+ *     Returns a summary the orchestrator uses for AUTO_PROCEED_ACTION.
  *
  * @param {Object} supabase - Supabase client
- * @param {Object} options  - Display options
+ * @param {Object} options  - { skipBaselineWarning, sessionContext, openQuickFixes, qfTriageResults }
+ * @returns {Promise<Object>} qfSummary with topStartableQF (or empty summary if no QFs passed)
  */
 export async function showFallbackQueue(supabase, options = {}) {
-  const { skipBaselineWarning = false, sessionContext = {} } = options;
+  const {
+    skipBaselineWarning = false,
+    sessionContext = {},
+    openQuickFixes = [],
+    qfTriageResults = new Map(),
+  } = options;
 
   // Load configurable OKR blend weight (shared with baseline path).
   let okrBlendWeight = 0.30;
@@ -86,9 +96,18 @@ export async function showFallbackQueue(supabase, options = {}) {
     enrichedSDs.push({ ...sd, deps_resolved: depsResolved });
   }
 
-  // Pure ranking: no baseline map — caller passes an empty Map to signal fallback mode.
-  // rankItems resolves sequence_rank from the SD row itself and track from metadata/category.
-  const { tracks } = rankItems(enrichedSDs, {
+  // Phase 3: classify QFs (computes escalation + claim badges, returns summary
+  // for AUTO_PROCEED_ACTION routing), tag with kind='qf', and feed into the
+  // same ranking call so QFs interleave with SDs in their inferred tracks.
+  const { summary: qfSummary, classified: classifiedQFs } = classifyQuickFixes(
+    openQuickFixes, qfTriageResults, sessionContext
+  );
+  const qfItems = classifiedQFs.map(qf => ({ ...qf, kind: 'qf' }));
+
+  // Pure ranking: no baseline map — empty Map signals fallback mode.
+  // rank-items resolves sequence_rank from the SD row and track from
+  // metadata/category, and routes QFs via their severity + type.
+  const { tracks } = rankItems([...enrichedSDs, ...qfItems], {
     baselineItemsMap: new Map(),
     okrScoreMap,
     okrBlendWeight,
@@ -125,6 +144,8 @@ export async function showFallbackQueue(supabase, options = {}) {
   if (!skipBaselineWarning) {
     displayNoBaselineWarning();
   }
+
+  return qfSummary;
 }
 
 /**

--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -6,18 +6,22 @@
 import { colors } from '../colors.js';
 import { checkDependenciesResolved } from '../dependency-resolver.js';
 import { displayTrackSection } from './tracks.js';
+import { rankItems } from '../rank-items.js';
 
 /**
- * Show fallback queue when no baseline is active
+ * Show fallback queue when no baseline is active.
+ *
+ * SD-LEO-INFRA-UNIFY-QUICK-FIX-001 (Phase 2): delegates all ranking to
+ * rank-items.js so the no-baseline path applies the same urgency bands,
+ * vision gap weight, OKR blend, and policy boost as the baseline path.
  *
  * @param {Object} supabase - Supabase client
- * @param {Object} options - Display options
+ * @param {Object} options  - Display options
  */
 export async function showFallbackQueue(supabase, options = {}) {
   const { skipBaselineWarning = false, sessionContext = {} } = options;
 
-  // SD-LEO-INFRA-OKR-PIPELINE-AUTOMATION-001: Load OKR scores for fallback ranking
-  // Load configurable blend weight
+  // Load configurable OKR blend weight (shared with baseline path).
   let okrBlendWeight = 0.30;
   try {
     const { data: configRow } = await supabase
@@ -30,10 +34,11 @@ export async function showFallbackQueue(supabase, options = {}) {
     }
   } catch { /* non-fatal */ }
 
-  // No baseline - fall back to sequence_rank on SDs directly
+  // No baseline — use strategic_directives_v2.sequence_rank + category as baseline substitutes.
+  // Column list mirrors what rankItems() reads: sequence_rank, category, metadata, vision_*, venture_id.
   const { data: sds, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, priority, status, sequence_rank, progress_percentage, dependencies, metadata, is_working_on, parent_sd_id')
+    .select('id, sd_key, title, priority, status, sequence_rank, progress_percentage, dependencies, metadata, is_working_on, parent_sd_id, category, vision_score, vision_origin_score_id, venture_id')
     .eq('is_active', true)
     .in('status', ['draft', 'lead_review', 'plan_active', 'exec_active', 'active', 'in_progress'])
     .in('priority', ['critical', 'high', 'medium'])
@@ -45,8 +50,8 @@ export async function showFallbackQueue(supabase, options = {}) {
     return;
   }
 
-  // Batch-load OKR alignment scores for fallback SDs
-  const okrScores = new Map();
+  // Batch-load OKR alignment scores. Map shape: sd_uuid -> score (0-90).
+  const okrScoreMap = new Map();
   try {
     const sdUUIDs = sds.map(s => s.id);
     const { data: krAlignments } = await supabase
@@ -69,78 +74,54 @@ export async function showFallbackQueue(supabase, options = {}) {
           const contrib = CONTRIB[a.contribution_type] ?? 0.5;
           total += 10 * urgency * contrib * (a.contribution_weight ?? 1.0);
         }
-        okrScores.set(sdId, Math.min(total, 90));
+        okrScoreMap.set(sdId, Math.min(total, 90));
       }
     }
   } catch { /* non-fatal */ }
 
-  // Group by track from metadata
-  const tracks = { A: [], B: [], C: [], STANDALONE: [], UNASSIGNED: [] };
-
+  // Pre-enrich SDs with async dependency resolution (rankItems() is pure).
+  const enrichedSDs = [];
   for (const sd of sds) {
-    const track = sd.metadata?.execution_track || 'UNASSIGNED';
-    const trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
-                     track === 'Feature' ? 'B' :
-                     track === 'Quality' ? 'C' :
-                     track === 'STANDALONE' ? 'STANDALONE' : 'UNASSIGNED';
-
     const depsResolved = await checkDependenciesResolved(supabase, sd.dependencies);
-    const okrScore = okrScores.get(sd.id) || 0;
-
-    tracks[trackKey].push({
-      ...sd,
-      deps_resolved: depsResolved,
-      track: trackKey,
-      okr_score: okrScore,
-      composite_rank: (sd.sequence_rank || 9999) - (okrScore * okrBlendWeight)
-    });
+    enrichedSDs.push({ ...sd, deps_resolved: depsResolved });
   }
 
-  // Sort each track by OKR-blended composite rank
-  for (const trackSDs of Object.values(tracks)) {
-    trackSDs.sort((a, b) => (a.composite_rank ?? 9999) - (b.composite_rank ?? 9999));
-  }
+  // Pure ranking: no baseline map — caller passes an empty Map to signal fallback mode.
+  // rankItems resolves sequence_rank from the SD row itself and track from metadata/category.
+  const { tracks } = rankItems(enrichedSDs, {
+    baselineItemsMap: new Map(),
+    okrScoreMap,
+    okrBlendWeight,
+  });
 
-  // Display tracks
-  displayTrackSection('A', 'Infrastructure/Safety', tracks.A, sessionContext);
-  displayTrackSection('B', 'Feature/Stages', tracks.B, sessionContext);
-  displayTrackSection('C', 'Quality', tracks.C, sessionContext);
+  // Display tracks (shared shape with baseline path). Must await — displaySDItem
+  // runs async claim checks that otherwise interleave output with later sections.
+  await displayTrackSection('A', 'Infrastructure/Safety', tracks.A, sessionContext);
+  await displayTrackSection('B', 'Feature/Stages', tracks.B, sessionContext);
+  await displayTrackSection('C', 'Quality', tracks.C, sessionContext);
   if (tracks.STANDALONE.length > 0) {
-    displayTrackSection('STANDALONE', 'Standalone (No Dependencies)', tracks.STANDALONE, sessionContext);
-  }
-  if (tracks.UNASSIGNED.length > 0) {
-    displayTrackSection('UNASSIGNED', 'Unassigned (Needs Track)', tracks.UNASSIGNED, sessionContext);
-  }
-
-  // Find ready SDs (include unassigned)
-  const readySDs = [];
-  for (const sd of sds) {
-    const depsResolved = await checkDependenciesResolved(supabase, sd.dependencies);
-    if (depsResolved) {
-      readySDs.push(sd);
-    }
+    await displayTrackSection('STANDALONE', 'Standalone (No Dependencies)', tracks.STANDALONE, sessionContext);
   }
 
   console.log(`\n${colors.bold}${colors.green}RECOMMENDED STARTING POINTS:${colors.reset}`);
 
-  if (sds.find(s => s.is_working_on)) {
-    const workingOn = sds.find(s => s.is_working_on);
+  const workingOn = sds.find(s => s.is_working_on);
+  if (workingOn) {
     console.log(`${colors.bgYellow}${colors.bold} CONTINUE ${colors.reset} ${workingOn.sd_key || workingOn.id} - ${workingOn.title}`);
     console.log(`${colors.dim}   (Marked as "Working On" in UI)${colors.reset}`);
   }
 
-  // Show top ready SD per track (including unassigned)
+  // Show top ready SD per track.
   for (const [trackKey, trackSDs] of Object.entries(tracks)) {
     const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on);
     if (ready) {
-      const trackLabel = trackKey === 'UNASSIGNED' ? 'Unassigned' : `Track ${trackKey}`;
+      const trackLabel = `Track ${trackKey}`;
       console.log(`${colors.green}  ${trackLabel}:${colors.reset} ${ready.sd_key || ready.id} - ${ready.title.substring(0, 50)}...`);
     }
   }
 
   console.log(`\n${colors.dim}To begin: "I'm working on <SD-ID>"${colors.reset}`);
 
-  // Baseline creation prompt (skip if we already showed exhausted baseline message)
   if (!skipBaselineWarning) {
     displayNoBaselineWarning();
   }

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -26,7 +26,7 @@ export {
 } from './blocked-state.js';
 export { displayTelemetryFindings } from './telemetry-findings.js';
 export { displayVisionPortfolioHeader, formatVisionBadge } from './vision-scorecard.js';
-export { displayQuickFixes } from './quick-fixes.js';
+export { displayQuickFixes, classifyQuickFixes, renderQFRow } from './quick-fixes.js';
 export { displayRoadmapAwareness } from './roadmap-awareness.js';
 export { displayHealthFreshness } from './health-freshness.js';
 export { displayBrainstormPipelineAdvisory } from './brainstorm-pipeline.js';

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -12,29 +12,34 @@ const MAX_DISPLAY = 10;
 const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
 
 /**
- * Display open quick fixes section.
+ * Classify open quick fixes: compute per-QF escalation flag, claim badge,
+ * and return the summary + classified list. Pure presentation-adjacent logic;
+ * does not print.
  *
- * @param {Array} quickFixes - Open quick fixes from loadOpenQuickFixes
- * @param {Map} triageResults - Re-triage results from triageQuickFixes (qfId -> TriageResult)
- * @param {Object} sessionContext - Session context for claim analysis
- * @returns {{ escalationCount: number, totalCount: number, topQF: Object|null }}
+ * Used by:
+ *   - showFallbackQueue / displayTracks: pre-ranking enrichment so QFs can
+ *     be interleaved with SDs (SD-LEO-INFRA-UNIFY-QUICK-FIX-001).
+ *   - displayQuickFixes: legacy separate-section display (kept for back-compat).
+ *
+ * @returns {{
+ *   summary: { totalCount: number, escalationCount: number, topQF: Object|null, topStartableQF: Object|null },
+ *   classified: Array<Object>
+ * }}
  */
-export function displayQuickFixes(quickFixes, triageResults = new Map(), sessionContext = {}) {
-  const summary = { escalationCount: 0, totalCount: 0, topQF: null };
+export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessionContext = {}) {
+  const summary = { escalationCount: 0, totalCount: 0, topQF: null, topStartableQF: null };
 
-  if (!quickFixes || quickFixes.length === 0) return summary;
+  if (!quickFixes || quickFixes.length === 0) return { summary, classified: [] };
 
   summary.totalCount = quickFixes.length;
 
   const { claimedSDs = new Map(), currentSession = null, activeSessions = [] } = sessionContext;
 
-  // Classify each QF: escalation-flagged (tier 3 re-triage) vs normal, plus claim status
   const classified = quickFixes.map(qf => {
     const triage = triageResults.get(qf.id);
     const escalate = triage && triage.tier === 3;
     if (escalate) summary.escalationCount++;
 
-    // Claim analysis
     let claimBadge = '';
     let isClaimedByOther = false;
 
@@ -44,14 +49,9 @@ export function displayQuickFixes(quickFixes, triageResults = new Map(), session
         claimBadge = `${colors.green}YOURS${colors.reset} `;
       } else {
         isClaimedByOther = true;
-        // Try richer analysis if we have session data
         const claimingSession = activeSessions.find(s => s.session_id === claimingSessionId);
         if (claimingSession) {
-          const analysis = analyzeClaimRelationship({
-            claimingSessionId,
-            claimingSession,
-            currentSession
-          });
+          const analysis = analyzeClaimRelationship({ claimingSessionId, claimingSession, currentSession });
           if (analysis.relationship === 'same_conversation') {
             claimBadge = `${colors.green}${analysis.displayLabel}${colors.reset} `;
             isClaimedByOther = false;
@@ -69,7 +69,6 @@ export function displayQuickFixes(quickFixes, triageResults = new Map(), session
     return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther };
   });
 
-  // Sort: escalation first, then severity, then age (oldest first — already sorted by created_at ASC from DB)
   classified.sort((a, b) => {
     if (a._escalate !== b._escalate) return a._escalate ? -1 : 1;
     const sevA = SEVERITY_ORDER[a.severity] ?? 4;
@@ -79,35 +78,61 @@ export function displayQuickFixes(quickFixes, triageResults = new Map(), session
   });
 
   summary.topQF = classified[0] || null;
-  // Skip claimed-by-others QFs from topStartableQF selection
   summary.topStartableQF = classified.find(qf => !qf._escalate && !qf._isClaimedByOther) || null;
 
-  // Display header
+  return { summary, classified };
+}
+
+/**
+ * Render a single QF row inline within a track. Used by tracks.js when
+ * interleaving QFs with SDs in the unified queue display (FR-4).
+ *
+ * Output format matches the legacy OPEN QUICK FIXES section row format so
+ * visual muscle-memory is preserved — tier badge, claim badge, severity,
+ * age, and (for escalations) the triage reason + action.
+ *
+ * @param {Object} qf - Classified QF (from classifyQuickFixes)
+ * @param {string} indent - Leading whitespace for hierarchical placement
+ */
+export function renderQFRow(qf, indent = '') {
+  const age = formatAge(qf.created_at);
+  const loc = qf.estimated_loc ? `~${qf.estimated_loc} LOC` : 'LOC unknown';
+  const target = qf.target_application || 'N/A';
+  const badge = qf._claimBadge || '';
+
+  if (qf._escalate) {
+    const reason = qf._triage?.escalationReason || 'Re-triage returned Tier 3';
+    console.log(`${indent}  ${colors.red}${colors.bold}⚠ ESCALATE${colors.reset}  ${badge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+    console.log(`${indent}       ${colors.dim}Re-triage: Tier 3 — ${reason}${colors.reset}`);
+    console.log(`${indent}       ${colors.dim}Action: /leo create --from-qf ${qf.id}${colors.reset}`);
+  } else {
+    const tier = qf._triage ? qf._triage.tier : inferTier(qf.estimated_loc);
+    const tierBadge = `[T${tier}]`;
+    const statusBadge = qf.status === 'in_progress' ? `${colors.cyan}WIP${colors.reset} ` : '';
+    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+    console.log(`${indent}       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
+  }
+}
+
+/**
+ * Legacy display: print a separate OPEN QUICK FIXES section at the bottom of
+ * the queue. Kept for back-compat; the preferred path is to interleave QFs
+ * with SDs via rankItems() + renderQFRow() (SD-LEO-INFRA-UNIFY-QUICK-FIX-001).
+ *
+ * Returns the summary so callers can still compute AUTO_PROCEED_ACTION.
+ *
+ * @deprecated Prefer classifyQuickFixes() + inline rendering via tracks.js.
+ */
+export function displayQuickFixes(quickFixes, triageResults = new Map(), sessionContext = {}) {
+  const { summary, classified } = classifyQuickFixes(quickFixes, triageResults, sessionContext);
+  if (!quickFixes || quickFixes.length === 0) return summary;
+
   console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
   console.log(`${colors.bold}${colors.yellow}OPEN QUICK FIXES (${summary.totalCount}):${colors.reset}\n`);
 
   const displayed = classified.slice(0, MAX_DISPLAY);
-
   for (const qf of displayed) {
-    const age = formatAge(qf.created_at);
-    const loc = qf.estimated_loc ? `~${qf.estimated_loc} LOC` : 'LOC unknown';
-    const target = qf.target_application || 'N/A';
-    const badge = qf._claimBadge;
-
-    if (qf._escalate) {
-      // Escalation row
-      const reason = qf._triage?.escalationReason || 'Re-triage returned Tier 3';
-      console.log(`  ${colors.red}${colors.bold}⚠ ESCALATE${colors.reset}  ${badge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
-      console.log(`       ${colors.dim}Re-triage: Tier 3 — ${reason}${colors.reset}`);
-      console.log(`       ${colors.dim}Action: /leo create --from-qf ${qf.id}${colors.reset}`);
-    } else {
-      // Normal row
-      const tier = qf._triage ? qf._triage.tier : inferTier(qf.estimated_loc);
-      const tierBadge = `[T${tier}]`;
-      const statusBadge = qf.status === 'in_progress' ? `${colors.cyan}WIP${colors.reset} ` : '';
-      console.log(`  ${colors.bold}${tierBadge}${colors.reset} ${badge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
-      console.log(`       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
-    }
+    renderQFRow(qf);
   }
 
   if (summary.totalCount > MAX_DISPLAY) {

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -8,6 +8,7 @@ import { getPhaseAwareStatus } from '../status-helpers.js';
 import { parseDependencies } from '../dependency-resolver.js';
 import { formatVisionBadge } from './vision-scorecard.js';
 import { analyzeClaimRelationship, autoReleaseStaleDeadClaim, checkEnrichmentSignal } from '../claim-analysis.js';
+import { renderQFRow } from './quick-fixes.js';
 
 /**
  * Display a track section with hierarchical SD items
@@ -65,6 +66,13 @@ export async function displayTrackSection(trackKey, trackName, items, sessionCon
  * @param {Object} sessionContext - Session context
  */
 async function displaySDItem(item, indent, childItems, allItems, sessionContext) {
+  // SD-LEO-INFRA-UNIFY-QUICK-FIX-001 (Phase 3): QFs render with their own row
+  // format (tier badge + severity + age), not the SD hierarchical format.
+  if (item.kind === 'qf') {
+    renderQFRow(item, indent);
+    return;
+  }
+
   const { claimedSDs = new Map(), currentSession = null, activeSessions = [], localSignals = new Map(), supabase = null } = sessionContext;
 
   const sdId = item.sd_key || item.sd_id;

--- a/scripts/modules/sd-next/rank-items.js
+++ b/scripts/modules/sd-next/rank-items.js
@@ -73,14 +73,32 @@ export function qfUrgencyBand(severity, createdAt, now = Date.now()) {
 /**
  * Infer a QF's track from its type + branch-name signals.
  *
+ * QF-TO-TRACK INFERENCE RULE (canonical reference, AC7 of SD-LEO-INFRA-UNIFY-QUICK-FIX-001):
+ *
  *   bug, polish             → C (Quality)
  *   documentation           → STANDALONE
  *   anything else           → STANDALONE
  *
  * Track A override (Infrastructure): any bug/polish QF whose branch_name
- * contains an infrastructure-signaling keyword is promoted to A. Conservative
- * by design (TR-5): the branch_name prefix 'quick-fix/' is assumed; we require
- * an *additional* signal beyond that.
+ * contains an infrastructure-signaling keyword (see TRACK_A_BRANCH_KEYWORDS)
+ * is promoted to A. Conservative by design (TR-5): the branch_name prefix
+ * 'quick-fix/' is assumed; we require an *additional* signal beyond that.
+ *
+ * ANTI-PATTERN: DO NOT add a `quick_fixes.track` column.
+ * Track is *inferred* from QF type + branch_name signals at ranking time —
+ * never persisted on the row. Reasons:
+ *   1. Track taxonomy (A/B/C/STANDALONE) belongs to the queue-ranking layer,
+ *      not to the QF data model. A persisted column would couple QF schema to
+ *      a presentation concern that may evolve independently.
+ *   2. Inference is cheap, deterministic, and centrally tunable here. A column
+ *      would create two sources of truth (column vs. inference) and require
+ *      backfill + sync logic the moment the rule changes.
+ *   3. Branch-name signals (TRACK_A_BRANCH_KEYWORDS) are operational metadata
+ *      that may change per branching convention; baking them into a stored
+ *      column would calcify yesterday's heuristics.
+ *
+ * If the inference rule must be customised, edit this function — never the
+ * QF row.
  *
  * @param {Object} qf - QF row with `type` and optional `branch_name`
  * @returns {'A' | 'B' | 'C' | 'STANDALONE'}

--- a/scripts/modules/sd-next/rank-items.js
+++ b/scripts/modules/sd-next/rank-items.js
@@ -26,6 +26,79 @@ import { scoreToBand, bandToNumeric } from '../auto-proceed/urgency-scorer.js';
 import { scanMetadataForMisplacedDependencies } from './dependency-resolver.js';
 
 /**
+ * QF severity → sequence_rank. Lower rank = higher priority, matching the SD
+ * sequence_rank convention. Tuning lives here (single-edit), not inline.
+ */
+export const SEVERITY_TO_RANK = {
+  critical: 100,
+  high:     200,
+  medium:   500,
+  low:      1000,
+};
+
+/** Branch-name keywords that promote a bug-type QF to Track A (Infrastructure). */
+const TRACK_A_BRANCH_KEYWORDS = [
+  'infra',
+  'hook',
+  'gate',
+  'protocol',
+  'workflow',
+  'sd-next',
+  'handoff',
+];
+
+/**
+ * Derive a QF's urgency band from severity + age.
+ *   critical                                          → P0
+ *   medium/high aged > 7 days                         → P0
+ *   high                                              → P1
+ *   medium                                            → P2
+ *   everything else                                   → P3
+ *
+ * @param {string} severity
+ * @param {string} createdAt - ISO timestamp
+ * @param {number} now - ms since epoch
+ * @returns {'P0' | 'P1' | 'P2' | 'P3'}
+ */
+export function qfUrgencyBand(severity, createdAt, now = Date.now()) {
+  const sev = (severity || '').toLowerCase();
+  if (sev === 'critical') return 'P0';
+  const ageDays = createdAt ? (now - new Date(createdAt).getTime()) / 86_400_000 : 0;
+  if (ageDays > 7 && (sev === 'high' || sev === 'medium')) return 'P0';
+  if (sev === 'high') return 'P1';
+  if (sev === 'medium') return 'P2';
+  return 'P3';
+}
+
+/**
+ * Infer a QF's track from its type + branch-name signals.
+ *
+ *   bug, polish             → C (Quality)
+ *   documentation           → STANDALONE
+ *   anything else           → STANDALONE
+ *
+ * Track A override (Infrastructure): any bug/polish QF whose branch_name
+ * contains an infrastructure-signaling keyword is promoted to A. Conservative
+ * by design (TR-5): the branch_name prefix 'quick-fix/' is assumed; we require
+ * an *additional* signal beyond that.
+ *
+ * @param {Object} qf - QF row with `type` and optional `branch_name`
+ * @returns {'A' | 'B' | 'C' | 'STANDALONE'}
+ */
+export function qfTrack(qf) {
+  const type = (qf.type || '').toLowerCase();
+  const branch = (qf.branch_name || '').toLowerCase();
+
+  const infraSignal = branch && TRACK_A_BRANCH_KEYWORDS.some(k => branch.includes(k));
+
+  if (type === 'bug' || type === 'polish') {
+    return infraSignal ? 'A' : 'C';
+  }
+  if (type === 'documentation') return 'STANDALONE';
+  return 'STANDALONE';
+}
+
+/**
  * @typedef {Object} RankContext
  * @property {Map<string, Object>} [baselineItemsMap] sd_id (key or uuid) -> baseline item { sequence_rank, track, ... }
  * @property {Map<string, number>} [okrScoreMap]      SD uuid -> OKR impact score (0-90)
@@ -67,11 +140,24 @@ export function rankItems(items, context = {}) {
     actuals          = {},
   } = context;
 
+  const now = context.now ?? Date.now();
   const tracks = { A: [], B: [], C: [], STANDALONE: [] };
   const misplacedDeps = [];
   const orphanBaseline = [];
 
-  for (const sd of items) {
+  for (const item of items) {
+    // QF branch (SD-LEO-INFRA-UNIFY-QUICK-FIX-001 Phase 3).
+    // Discriminator: item.kind === 'qf'. We intentionally do NOT use item.type
+    // because that column on quick_fixes rows holds the QF category
+    // (bug/polish/documentation), which qfTrack() reads separately.
+    if (item.kind === 'qf') {
+      const ranked = rankQF(item, now);
+      if (ranked) tracks[ranked.track_key].push(ranked);
+      continue;
+    }
+
+    // SD branch
+    const sd = item;
     if (sd.status === 'completed' || sd.status === 'cancelled') continue;
 
     // Governance: deferred SDs skip recommendation pipeline but stay in display.
@@ -139,6 +225,7 @@ export function rankItems(items, context = {}) {
     tracks[trackKey].push({
       ...(baselineItem || {}),
       ...sd,
+      kind: 'sd',
       sd_id: sd.sd_key || sd.id,
       sequence_rank: sequenceRank,
       gap_weight: gapWeight,
@@ -166,4 +253,39 @@ export function rankItems(items, context = {}) {
   }
 
   return { tracks, misplacedDeps, orphanBaseline };
+}
+
+/**
+ * Rank a single Quick Fix into a ranked item with the same shape as a ranked SD,
+ * so the per-track sort (urgency band → urgency score → composite_rank) treats
+ * both uniformly.
+ *
+ * @param {Object} qf - Raw quick_fixes row (must include id/severity/type at minimum)
+ * @param {number} now - ms since epoch (for age calculation)
+ * @returns {Object | null}
+ */
+function rankQF(qf, now) {
+  if (!qf || !qf.id) return null;
+  if (qf.status && !['open', 'in_progress'].includes(qf.status)) return null;
+
+  const severity = (qf.severity || 'low').toLowerCase();
+  const sequenceRank = SEVERITY_TO_RANK[severity] ?? SEVERITY_TO_RANK.low;
+  const urgencyBand = qfUrgencyBand(severity, qf.created_at, now);
+  const urgencyNumeric = bandToNumeric(urgencyBand);
+  const trackKey = qfTrack(qf);
+
+  return {
+    ...qf,
+    kind: 'qf',
+    sd_id: qf.id,              // so display code that reads sd_id shows the QF-ID
+    track: trackKey,
+    track_key: trackKey,       // private — tells the caller which bucket to push to
+    sequence_rank: sequenceRank,
+    composite_rank: sequenceRank, // QFs have no vision/OKR/policy blend
+    urgency_band: urgencyBand,
+    urgency_numeric: urgencyNumeric,
+    urgency_score: null,
+    is_deferred: false,
+    deps_resolved: true,       // QFs have no declared dependencies
+  };
 }

--- a/scripts/modules/sd-next/rank-items.js
+++ b/scripts/modules/sd-next/rank-items.js
@@ -1,0 +1,169 @@
+/**
+ * Rank Items - Pure Ranking Function for SD Queue
+ * Part of SD-LEO-INFRA-UNIFY-QUICK-FIX-001
+ *
+ * Single source of truth for queue ranking logic. Called by both the
+ * baseline-active path (SDNextSelector.js) and the no-baseline fallback
+ * path (display/fallback-queue.js) so that /leo next queue ordering is
+ * deterministic regardless of baseline presence.
+ *
+ * Phase 1 (this file): Extracts the baseline-path ranking stack from
+ * SDNextSelector.js. Accepts SDs only.
+ *
+ * Phase 3 (future, per PRD): Extended to also accept Quick Fixes with
+ * severity-derived sequence_rank, age-weighted urgency band, and
+ * type-inferred track.
+ *
+ * PURE FUNCTION CONTRACT
+ * ----------------------
+ * No Supabase calls. No filesystem IO. No network.  All external data
+ * (baseline, OKR scores, policy boosts, dependency resolution) must be
+ * pre-computed by the caller and passed via the context object or
+ * pre-set on the items themselves.
+ */
+
+import { scoreToBand, bandToNumeric } from '../auto-proceed/urgency-scorer.js';
+import { scanMetadataForMisplacedDependencies } from './dependency-resolver.js';
+
+/**
+ * @typedef {Object} RankContext
+ * @property {Map<string, Object>} [baselineItemsMap] sd_id (key or uuid) -> baseline item { sequence_rank, track, ... }
+ * @property {Map<string, number>} [okrScoreMap]      SD uuid -> OKR impact score (0-90)
+ * @property {Map<string, number>} [okrBoostMap]      SD uuid -> rank multiplier (1.0 = neutral, <1 = boost)
+ * @property {number}              [okrBlendWeight]   Multiplier for OKR score subtraction (default 0.30)
+ * @property {Map<string, number>} [policyBoostMap]   venture_id -> rank multiplier
+ * @property {Object}              [actuals]          baseline actuals keyed by sd_key/id
+ */
+
+/**
+ * @typedef {Object} RankedTracks
+ * @property {Array<Object>} A           Infrastructure / Safety
+ * @property {Array<Object>} B           Feature / Stages
+ * @property {Array<Object>} C           Quality
+ * @property {Array<Object>} STANDALONE  No explicit track
+ */
+
+/**
+ * @typedef {Object} RankResult
+ * @property {RankedTracks} tracks
+ * @property {Array<{sd_key: string, findings: Array}>} misplacedDeps  SDs with dependency info in metadata but empty dependencies column
+ * @property {Array<{sd_key: string}>}                  orphanBaseline SDs not found in baseline (informational)
+ */
+
+/**
+ * Rank a list of SDs and group them into tracks.
+ *
+ * @param {Array<Object>} items Strategic Directives (may include pre-computed deps_resolved / childDepStatus fields)
+ * @param {RankContext}   context
+ * @returns {RankResult}
+ */
+export function rankItems(items, context = {}) {
+  const {
+    baselineItemsMap = new Map(),
+    okrScoreMap      = new Map(),
+    okrBoostMap      = new Map(),
+    okrBlendWeight   = 0.30,
+    policyBoostMap   = new Map(),
+    actuals          = {},
+  } = context;
+
+  const tracks = { A: [], B: [], C: [], STANDALONE: [] };
+  const misplacedDeps = [];
+  const orphanBaseline = [];
+
+  for (const sd of items) {
+    if (sd.status === 'completed' || sd.status === 'cancelled') continue;
+
+    // Governance: deferred SDs skip recommendation pipeline but stay in display.
+    const isDeferred = sd.metadata?.do_not_advance_without_trigger === true;
+
+    // QA: dependency info in metadata with empty dependencies column is a data-quality smell.
+    const depsEmpty = !sd.dependencies || (Array.isArray(sd.dependencies) && sd.dependencies.length === 0);
+    if (depsEmpty && sd.metadata) {
+      const scan = scanMetadataForMisplacedDependencies(sd.metadata);
+      if (scan.hasMisplacedDeps) {
+        misplacedDeps.push({ sd_key: sd.sd_key || sd.id, findings: scan.findings });
+      }
+    }
+
+    const baselineItem = baselineItemsMap.get(sd.sd_key) || baselineItemsMap.get(sd.id);
+
+    // Track derivation: baseline > metadata > category > STANDALONE
+    let trackKey;
+    if (baselineItem?.track) {
+      trackKey = baselineItem.track;
+    } else if (sd.metadata?.execution_track) {
+      const track = sd.metadata.execution_track;
+      trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
+                 track === 'Feature' ? 'B' :
+                 track === 'Quality' ? 'C' : 'STANDALONE';
+    } else if (sd.category) {
+      const cat = sd.category.toLowerCase();
+      trackKey = cat === 'infrastructure' || cat === 'platform' ? 'A' :
+                 cat === 'quality' || cat === 'testing' || cat === 'qa' ? 'C' : 'B';
+    } else {
+      trackKey = 'STANDALONE';
+    }
+
+    if (!baselineItem && sd.status !== 'draft') {
+      orphanBaseline.push({ sd_key: sd.sd_key || sd.id });
+    }
+
+    if (!tracks[trackKey]) trackKey = 'STANDALONE';
+
+    // Vision-score-weighted priority (SD-MAN-INFRA-PRIORITY-QUEUE-ROUTING-001)
+    const sequenceRank = baselineItem?.sequence_rank || 9999;
+    const hasVisionOrigin = !!sd.vision_origin_score_id;
+    const visionScoreVal = sd.vision_score ?? null;
+    const gapWeight = (hasVisionOrigin && visionScoreVal !== null)
+      ? (100 - Math.max(0, Math.min(100, visionScoreVal))) / 100
+      : 0;
+    let compositeRank = gapWeight > 0 ? sequenceRank / (1 + gapWeight) : sequenceRank;
+
+    // OKR impact scoring (SD-LEO-INFRA-OKR-PIPELINE-AUTOMATION-001)
+    const okrScore = okrScoreMap.get(sd.id) || 0;
+    const okrBoost = okrBoostMap.get(sd.id) || 1.0;
+    compositeRank = (compositeRank * okrBoost) - (okrScore * okrBlendWeight);
+
+    // Glide-path policy boost (SD-LEO-INFRA-EHG-PORTFOLIO-ALLOCATION-001)
+    const policyBoost = policyBoostMap.get(sd.venture_id) ?? 1.0;
+    if (policyBoost !== 1.0) {
+      compositeRank = compositeRank * policyBoost;
+    }
+
+    // Urgency from metadata (SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-A)
+    const urgencyScore = sd.metadata?.urgency_score ?? null;
+    const urgencyBand = sd.metadata?.urgency_band ?? (urgencyScore !== null ? scoreToBand(urgencyScore) : 'P3');
+    const urgencyNumeric = bandToNumeric(urgencyBand);
+
+    tracks[trackKey].push({
+      ...(baselineItem || {}),
+      ...sd,
+      sd_id: sd.sd_key || sd.id,
+      sequence_rank: sequenceRank,
+      gap_weight: gapWeight,
+      composite_rank: compositeRank,
+      okr_boost: okrBoost < 1.0 ? okrBoost : null,
+      okr_score: okrScore > 0 ? okrScore : null,
+      policy_boost: policyBoost !== 1.0 ? policyBoost : null,
+      urgency_score: urgencyScore,
+      urgency_band: urgencyBand,
+      urgency_numeric: urgencyNumeric,
+      is_deferred: isDeferred,
+      actual: actuals[sd.sd_key] || actuals[sd.id]
+    });
+  }
+
+  // Sort within each track: urgency band (P0 first) → urgency score (desc) → composite_rank
+  for (const trackKey of Object.keys(tracks)) {
+    tracks[trackKey].sort((a, b) => {
+      const bandDiff = (a.urgency_numeric ?? 3) - (b.urgency_numeric ?? 3);
+      if (bandDiff !== 0) return bandDiff;
+      const scoreDiff = (b.urgency_score ?? 0) - (a.urgency_score ?? 0);
+      if (scoreDiff !== 0) return scoreDiff;
+      return (a.composite_rank ?? a.sequence_rank ?? 9999) - (b.composite_rank ?? b.sequence_rank ?? 9999);
+    });
+  }
+
+  return { tracks, misplacedDeps, orphanBaseline };
+}

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -42,6 +42,7 @@
       "sd_type_workflow_paths",
       "work_tracking_policy",
       "qf_lifecycle_reconciliation",
+      "queue_ranking_unified",
       "genesis_codebase",
       "governance_strategic_hierarchy",
       "governance_chairman_ceo_roles",

--- a/tests/rank-items.test.js
+++ b/tests/rank-items.test.js
@@ -1,0 +1,187 @@
+/**
+ * rank-items tests — Phase 1 (SDs only; QF ranking added in Phase 3).
+ * SD: SD-LEO-INFRA-UNIFY-QUICK-FIX-001
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { rankItems } from '../scripts/modules/sd-next/rank-items.js';
+
+/** Minimal SD factory so each test only spells out what it cares about. */
+function sd(overrides = {}) {
+  return {
+    id: 'uuid-default',
+    sd_key: 'SD-DEFAULT-001',
+    status: 'draft',
+    metadata: {},
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+describe('rankItems — Phase 1 baseline parity', () => {
+  it('excludes completed and cancelled SDs', () => {
+    const result = rankItems([
+      sd({ id: 'u1', sd_key: 'SD-A-001', status: 'completed' }),
+      sd({ id: 'u2', sd_key: 'SD-A-002', status: 'cancelled' }),
+      sd({ id: 'u3', sd_key: 'SD-A-003', status: 'draft', category: 'infrastructure' }),
+    ]);
+    assert.equal(result.tracks.A.length, 1);
+    assert.equal(result.tracks.A[0].sd_key, 'SD-A-003');
+  });
+
+  it('derives track from baseline, then metadata.execution_track, then category, then STANDALONE', () => {
+    const baselineMap = new Map([
+      ['SD-BL-001', { sd_id: 'SD-BL-001', track: 'C', sequence_rank: 10 }],
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-BL-001', status: 'draft' }),
+      sd({ sd_key: 'SD-META-001', metadata: { execution_track: 'Feature' } }),
+      sd({ sd_key: 'SD-CAT-001', category: 'quality' }),
+      sd({ sd_key: 'SD-NONE-001' }),
+    ], { baselineItemsMap: baselineMap });
+
+    assert.equal(result.tracks.C.find(x => x.sd_key === 'SD-BL-001')?.sd_key, 'SD-BL-001', 'baseline wins');
+    assert.equal(result.tracks.B[0].sd_key, 'SD-META-001', 'metadata wins over category');
+    assert.equal(result.tracks.C.find(x => x.sd_key === 'SD-CAT-001')?.sd_key, 'SD-CAT-001', 'category-based');
+    assert.equal(result.tracks.STANDALONE[0].sd_key, 'SD-NONE-001', 'no signal → STANDALONE');
+  });
+
+  it('applies vision gap weight to composite_rank', () => {
+    const baselineMap = new Map([
+      ['SD-HIGH-VISION', { sd_id: 'SD-HIGH-VISION', sequence_rank: 100 }],
+      ['SD-LOW-VISION',  { sd_id: 'SD-LOW-VISION',  sequence_rank: 100 }],
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-HIGH-VISION', category: 'infrastructure', vision_origin_score_id: 'v1', vision_score: 90 }),
+      sd({ sd_key: 'SD-LOW-VISION',  category: 'infrastructure', vision_origin_score_id: 'v2', vision_score: 10 }),
+    ], { baselineItemsMap: baselineMap });
+
+    const [first, second] = result.tracks.A;
+    // LOW vision → larger gap_weight → smaller composite_rank → higher priority
+    assert.ok(first.composite_rank < second.composite_rank,
+      'low-vision SD ranks first (smaller composite_rank because gap_weight grows the denominator)');
+    assert.equal(first.sd_key, 'SD-LOW-VISION', 'low-vision gap closes first');
+    assert.equal(second.sd_key, 'SD-HIGH-VISION');
+  });
+
+  it('blends OKR score — higher OKR pulls composite_rank lower (higher priority)', () => {
+    const baselineMap = new Map([
+      ['SD-OKR-HIGH', { sd_id: 'SD-OKR-HIGH', sequence_rank: 500 }],
+      ['SD-OKR-NONE', { sd_id: 'SD-OKR-NONE', sequence_rank: 500 }],
+    ]);
+    const okrScoreMap = new Map([['uuid-high', 90]]);
+    const result = rankItems([
+      sd({ id: 'uuid-high', sd_key: 'SD-OKR-HIGH', category: 'infrastructure' }),
+      sd({ id: 'uuid-none', sd_key: 'SD-OKR-NONE', category: 'infrastructure' }),
+    ], { baselineItemsMap: baselineMap, okrScoreMap });
+
+    const [first] = result.tracks.A;
+    assert.equal(first.sd_key, 'SD-OKR-HIGH', 'OKR-aligned SD ranks first');
+    // With default 0.30 blend: 500 - (90 * 0.30) = 473
+    assert.equal(first.composite_rank, 500 - (90 * 0.30));
+    assert.equal(first.okr_score, 90);
+  });
+
+  it('applies policy boost multiplier when venture_id has a policy weight', () => {
+    const baselineMap = new Map([
+      ['SD-CASH', { sd_id: 'SD-CASH', sequence_rank: 300 }],
+      ['SD-MOON', { sd_id: 'SD-MOON', sequence_rank: 300 }],
+    ]);
+    const policyBoostMap = new Map([
+      ['venture-cash', 0.4], // heavy boost
+      ['venture-moon', 0.9], // small boost
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-CASH', category: 'infrastructure', venture_id: 'venture-cash' }),
+      sd({ sd_key: 'SD-MOON', category: 'infrastructure', venture_id: 'venture-moon' }),
+    ], { baselineItemsMap: baselineMap, policyBoostMap });
+
+    const [first, second] = result.tracks.A;
+    assert.equal(first.sd_key, 'SD-CASH', 'more-boosted venture ranks first');
+    assert.equal(first.composite_rank, 300 * 0.4);
+    assert.equal(second.composite_rank, 300 * 0.9);
+  });
+
+  it('urgency band dominates composite_rank (P0 before everything else)', () => {
+    const baselineMap = new Map([
+      ['SD-P0-BIG-RANK', { sd_id: 'SD-P0-BIG-RANK', sequence_rank: 9000 }],
+      ['SD-P3-LOW-RANK', { sd_id: 'SD-P3-LOW-RANK', sequence_rank: 10 }],
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-P0-BIG-RANK', category: 'infrastructure', metadata: { urgency_band: 'P0' } }),
+      sd({ sd_key: 'SD-P3-LOW-RANK', category: 'infrastructure', metadata: { urgency_band: 'P3' } }),
+    ], { baselineItemsMap: baselineMap });
+
+    assert.equal(result.tracks.A[0].sd_key, 'SD-P0-BIG-RANK');
+    assert.equal(result.tracks.A[1].sd_key, 'SD-P3-LOW-RANK');
+  });
+
+  it('sequence_rank defaults to 9999 when SD has no baseline entry', () => {
+    const result = rankItems([
+      sd({ sd_key: 'SD-ORPHAN-001', category: 'infrastructure', status: 'in_progress' }),
+    ]);
+    assert.equal(result.tracks.A[0].sequence_rank, 9999);
+    assert.equal(result.orphanBaseline.length, 1, 'orphan warning emitted for non-draft missing baseline');
+    assert.equal(result.orphanBaseline[0].sd_key, 'SD-ORPHAN-001');
+  });
+
+  it('does not emit orphan warning for draft SDs missing from baseline', () => {
+    const result = rankItems([
+      sd({ sd_key: 'SD-DRAFT-001', category: 'infrastructure', status: 'draft' }),
+    ]);
+    assert.equal(result.orphanBaseline.length, 0);
+  });
+
+  it('collects misplacedDeps when dependency info lives in metadata but column is empty', () => {
+    const result = rankItems([
+      sd({
+        sd_key: 'SD-MISPLACED-001',
+        category: 'infrastructure',
+        dependencies: [],
+        metadata: { depends_on: ['SD-UPSTREAM-001'] },
+      }),
+    ]);
+    assert.equal(result.misplacedDeps.length, 1);
+    assert.equal(result.misplacedDeps[0].sd_key, 'SD-MISPLACED-001');
+  });
+
+  it('preserves baseline fields on the output item (spread before sd fields)', () => {
+    const baselineMap = new Map([
+      ['SD-BL-002', { sd_id: 'SD-BL-002', track: 'B', sequence_rank: 42, sprint: 'S1' }],
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-BL-002', title: 'Feature work', category: 'feature' }),
+    ], { baselineItemsMap: baselineMap });
+
+    const ranked = result.tracks.B[0];
+    assert.equal(ranked.sprint, 'S1', 'baseline field carried through');
+    assert.equal(ranked.title, 'Feature work', 'sd field wins on conflict');
+    assert.equal(ranked.sequence_rank, 42);
+  });
+
+  it('attaches actuals from context by sd_key or id', () => {
+    const actuals = { 'SD-ACT-001': { effort: 5 } };
+    const result = rankItems([
+      sd({ sd_key: 'SD-ACT-001', category: 'infrastructure' }),
+    ], { actuals });
+    assert.deepEqual(result.tracks.A[0].actual, { effort: 5 });
+  });
+
+  it('sorts within track: band → score (desc) → composite_rank (asc)', () => {
+    const baselineMap = new Map([
+      ['SD-P1-A', { sd_id: 'SD-P1-A', sequence_rank: 200 }],
+      ['SD-P1-B', { sd_id: 'SD-P1-B', sequence_rank: 100 }],
+      ['SD-P1-C', { sd_id: 'SD-P1-C', sequence_rank: 100 }],
+    ]);
+    const result = rankItems([
+      sd({ sd_key: 'SD-P1-A', category: 'infrastructure', metadata: { urgency_band: 'P1', urgency_score: 50 } }),
+      sd({ sd_key: 'SD-P1-B', category: 'infrastructure', metadata: { urgency_band: 'P1', urgency_score: 70 } }),
+      sd({ sd_key: 'SD-P1-C', category: 'infrastructure', metadata: { urgency_band: 'P1', urgency_score: 70 } }),
+    ], { baselineItemsMap: baselineMap });
+
+    // P1-B and P1-C share higher urgency_score than P1-A; within that, composite_rank breaks the tie.
+    assert.equal(result.tracks.A[0].sd_key, 'SD-P1-B', 'first: highest urgency_score, tied composite_rank');
+    assert.equal(result.tracks.A[1].sd_key, 'SD-P1-C');
+    assert.equal(result.tracks.A[2].sd_key, 'SD-P1-A', 'last: lower urgency_score');
+  });
+});

--- a/tests/rank-items.test.js
+++ b/tests/rank-items.test.js
@@ -4,7 +4,12 @@
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { rankItems } from '../scripts/modules/sd-next/rank-items.js';
+import {
+  rankItems,
+  SEVERITY_TO_RANK,
+  qfUrgencyBand,
+  qfTrack,
+} from '../scripts/modules/sd-next/rank-items.js';
 
 /** Minimal SD factory so each test only spells out what it cares about. */
 function sd(overrides = {}) {
@@ -183,5 +188,154 @@ describe('rankItems — Phase 1 baseline parity', () => {
     assert.equal(result.tracks.A[0].sd_key, 'SD-P1-B', 'first: highest urgency_score, tied composite_rank');
     assert.equal(result.tracks.A[1].sd_key, 'SD-P1-C');
     assert.equal(result.tracks.A[2].sd_key, 'SD-P1-A', 'last: lower urgency_score');
+  });
+});
+
+describe('rankItems — Phase 3 Quick Fix interleaving', () => {
+  const NOW = Date.parse('2026-04-24T12:00:00Z');
+  const FRESH = '2026-04-24T11:00:00Z'; // 1 hour before NOW
+  const OLD   = '2026-04-15T00:00:00Z'; // 9 days before NOW
+
+  /**
+   * Mirrors how callers should shape a QF row: the DB `type` column
+   * (bug/polish/documentation) remains untouched; we set kind='qf' as the
+   * rankItems discriminator alongside it.
+   */
+  function qf({ id = 'QF-X', severity = 'medium', type = 'bug', created_at = FRESH, branch_name = null, status = 'open', title = 'Some QF' } = {}) {
+    return {
+      kind: 'qf',
+      id,
+      title,
+      severity,
+      status,
+      type,                // DB column — bug/polish/documentation
+      created_at,
+      branch_name,
+    };
+  }
+
+  // --- severity / urgency helpers ---
+
+  it('SEVERITY_TO_RANK exports match PRD-specified values', () => {
+    assert.equal(SEVERITY_TO_RANK.critical, 100);
+    assert.equal(SEVERITY_TO_RANK.high,     200);
+    assert.equal(SEVERITY_TO_RANK.medium,   500);
+    assert.equal(SEVERITY_TO_RANK.low,      1000);
+  });
+
+  it('qfUrgencyBand — critical always P0', () => {
+    assert.equal(qfUrgencyBand('critical', FRESH, NOW), 'P0');
+    assert.equal(qfUrgencyBand('critical', OLD,   NOW), 'P0');
+  });
+
+  it('qfUrgencyBand — medium/high aged > 7 days escalates to P0; low does not', () => {
+    assert.equal(qfUrgencyBand('medium', OLD, NOW), 'P0');
+    assert.equal(qfUrgencyBand('high',   OLD, NOW), 'P0');
+    assert.equal(qfUrgencyBand('low',    OLD, NOW), 'P3');
+  });
+
+  it('qfUrgencyBand — fresh QFs map severity → band directly', () => {
+    assert.equal(qfUrgencyBand('high',   FRESH, NOW), 'P1');
+    assert.equal(qfUrgencyBand('medium', FRESH, NOW), 'P2');
+    assert.equal(qfUrgencyBand('low',    FRESH, NOW), 'P3');
+  });
+
+  // --- track inference (qfTrack helper) ---
+
+  it('qfTrack — bug/polish default to C, documentation to STANDALONE', () => {
+    assert.equal(qfTrack({ type: 'bug' }),           'C');
+    assert.equal(qfTrack({ type: 'polish' }),        'C');
+    assert.equal(qfTrack({ type: 'documentation' }), 'STANDALONE');
+    assert.equal(qfTrack({ type: 'something-new' }), 'STANDALONE');
+  });
+
+  it('qfTrack — bug/polish promoted to A when branch_name contains infra keyword', () => {
+    assert.equal(qfTrack({ type: 'bug',    branch_name: 'quick-fix/QF-INFRA-REAPER' }), 'A');
+    assert.equal(qfTrack({ type: 'polish', branch_name: 'quick-fix/QF-HOOK-FIX' }),    'A');
+    assert.equal(qfTrack({ type: 'bug',    branch_name: 'quick-fix/QF-RANDOM' }),       'C', 'no keyword → stays C');
+  });
+
+  // --- TS-3: P0 bug QF outranks medium-priority SDs in Track C ---
+
+  it('TS-3: P0 bug QF ranks above medium-priority SDs in Track C', () => {
+    const items = [
+      sd({ sd_key: 'SD-C-1', category: 'quality', metadata: { urgency_band: 'P2' } }),
+      sd({ sd_key: 'SD-C-2', category: 'quality', metadata: { urgency_band: 'P2' } }),
+      qf({ id: 'QF-001', severity: 'critical', type: 'bug' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    assert.equal(tracks.C.length, 3);
+    assert.equal(tracks.C[0].id, 'QF-001', 'P0 QF tops Track C');
+    assert.equal(tracks.C[0].urgency_band, 'P0');
+  });
+
+  // --- TS-4: Type distribution mapping ---
+
+  it('TS-4: bug=89 / polish=8 / documentation=6 distribution routes correctly', () => {
+    const items = [
+      qf({ id: 'QF-BUG',   type: 'bug' }),
+      qf({ id: 'QF-POL',   type: 'polish' }),
+      qf({ id: 'QF-DOC',   type: 'documentation' }),
+      qf({ id: 'QF-OTHER', type: 'something-new' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    assert.deepEqual(tracks.C.map(x => x.id).sort(), ['QF-BUG', 'QF-POL']);
+    assert.deepEqual(tracks.STANDALONE.map(x => x.id).sort(), ['QF-DOC', 'QF-OTHER']);
+    assert.equal(tracks.A.length, 0);
+    assert.equal(tracks.B.length, 0);
+  });
+
+  // --- TS-5: Track A inference via branch heuristic ---
+
+  it('TS-5: branch-name heuristic promotes infra QF to Track A', () => {
+    const items = [
+      qf({ id: 'QF-INFRA', type: 'bug', branch_name: 'quick-fix/QF-INFRA-FIX' }),
+      qf({ id: 'QF-NORMAL', type: 'bug', branch_name: 'quick-fix/QF-NORMAL' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    assert.equal(tracks.A.length, 1);
+    assert.equal(tracks.A[0].id, 'QF-INFRA');
+    assert.equal(tracks.C.length, 1);
+    assert.equal(tracks.C[0].id, 'QF-NORMAL');
+  });
+
+  // --- Ranking semantics for mixed SD+QF fleets ---
+
+  it('Mixed fleet: sort within track treats SDs and QFs uniformly', () => {
+    const items = [
+      sd({ sd_key: 'SD-P2', category: 'quality', metadata: { urgency_band: 'P2' } }),
+      qf({ id: 'QF-HI',    severity: 'high', type: 'bug' }),   // P1 urgency
+      qf({ id: 'QF-LO',    severity: 'low',  type: 'bug' }),   // P3 urgency
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    assert.deepEqual(
+      tracks.C.map(x => x.sd_key || x.id),
+      ['QF-HI', 'SD-P2', 'QF-LO'],
+      'P1 QF < P2 SD < P3 QF by urgency_numeric'
+    );
+  });
+
+  it('rankQF discriminator: kind="qf" routes into QF path, not SD path', () => {
+    const items = [
+      { kind: 'qf', id: 'QF-A', type: 'bug', severity: 'high', status: 'open', created_at: FRESH },
+      // An SD with id that looks like a QF shouldn't be mistaken
+      sd({ id: 'QF-LOOKALIKE', sd_key: 'SD-LOOKALIKE', category: 'quality' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    assert.equal(tracks.C.length, 2);
+    const qfRanked = tracks.C.find(x => x.id === 'QF-A');
+    assert.equal(qfRanked.kind, 'qf');
+    const sdRanked = tracks.C.find(x => x.sd_key === 'SD-LOOKALIKE');
+    assert.equal(sdRanked.kind, 'sd');
+  });
+
+  it('QF with non-open status is filtered out', () => {
+    const items = [
+      qf({ id: 'QF-COMPLETED', status: 'completed' }),
+      qf({ id: 'QF-OPEN',      status: 'open' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    const allIds = [...tracks.A, ...tracks.B, ...tracks.C, ...tracks.STANDALONE].map(x => x.id);
+    assert.deepEqual(allIds, ['QF-OPEN']);
   });
 });


### PR DESCRIPTION
## Summary

Unifies queue ranking across baseline-active and no-baseline fallback paths so `/leo next` produces consistent ordering regardless of baseline state. Quick Fixes now interleave with SDs inside Track sections instead of rendering as a separate bottom block.

- **Phase 1**: Extracted `rank-items.js` (pure module, 291 LOC) from `SDNextSelector.js` — single source of truth for ranking logic.
- **Phase 2**: Routed `display/fallback-queue.js` through `rank-items.js` so urgency bands + vision gap + OKR blend + policy boost apply in no-baseline mode (parity with baseline mode).
- **Phase 3**: Extended `rank-items.js` with QF support (severity → sequence_rank, age-weighted urgency band, type+branch-name → track inference). Removed separate `OPEN QUICK FIXES` bottom section; QFs render inside their inferred track.
- **Phase 4**: Documented the QF-to-track inference rule + anti-pattern (NO `quick_fixes.track` column) at the canonical reference site (`qfTrack()` docstring). Companion DB row in `leo_protocol_sections` (id=589) and `section-file-mapping.json` registration ensure CLAUDE_CORE.md surfaces this on next clean regen.

## Acceptance Criteria

All 7 PRD ACs addressed:
1. ✅ `rank-items.js` is the single import point; zero inline `composite_rank`/`.sort()` in either consumer
2. ✅ Baseline-active byte-equivalent ranking (12 baseline-parity unit tests)
3. ✅ No-baseline mode applies full ranking stack (parity tests pass)
4. ✅ QFs interleave inside tracks; no bottom OPEN QUICK FIXES section (verified live)
5. ✅ AUTO_PROCEED_ACTION envelope contract preserved (`action=start` + `action=qf_start` paths intact with id fields)
6. ✅ 24/24 unit tests pass (`node --test tests/rank-items.test.js`); integration TS-6/7/8 verified via `npm run sd:next` harness
7. ✅ QF-track inference rule + anti-pattern documented (DB row id=589 + source-doc reference)

## Test Plan

- [x] `node --test tests/rank-items.test.js` → 24/24 pass
- [x] `npm run sd:next` from worktree shows QFs inside Track C, no bottom section
- [x] EXEC-TO-PLAN handoff: 92% (38/38 gates green)
- [x] PLAN-TO-LEAD handoff: 97% (24/24 gates green)
- [x] TESTING sub-agent: PASS (92% confidence)
- [x] VALIDATION sub-agent: PASS (94% confidence)
- [x] Zero TODO/FIXME/stub markers in deliverables

## Stats

597 net source LOC + 341 test LOC across 7 files. Justified for an infrastructure refactor per CLAUDE.md tiered PR-size guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)