### PR TITLE
feat(SD-LEO-INFRA-OPUS-MODULE-SCOPE-001): pre-commit scope gate (Opus 4.7 Module E)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -624,6 +624,35 @@ fi
 echo "✅ Gate 0 validation complete"
 
 # ============================================================================
+# STAGE 7.25: Scope Gate (BLOCKING when SD declares metadata.scope)
+# ============================================================================
+# SD-LEO-INFRA-OPUS-MODULE-SCOPE-001 (Opus 4.7 Module E): Pre-commit scope
+# enforcement. Blocks "while-I'm-here" edits that would expand the active SD's
+# scope beyond its declared metadata.scope.{in_files,out_files,mode}.
+#
+# Modes: strict / advisory / out_files_only (default — backward compatible).
+# Escape hatch: SCOPE_OVERRIDE=<SD-ID> SCOPE_OVERRIDE_REASON="<ticket>" git commit ...
+# Audit log: ~/.claude/scope-overrides.log
+#
+# Skip cases (silent pass, exit 0): no SD on branch, no metadata.scope on SD,
+# no Supabase credentials, gate-internal error (fail-open by design).
+# ============================================================================
+echo ""
+echo "🔍 Running Scope Gate (Opus 4.7 Module E)..."
+
+if [ ! -z "$SD_ID" ]; then
+  node scripts/modules/scope/scope-gate.js "$SD_ID"
+  SCOPE_EXIT=$?
+  if [ $SCOPE_EXIT -ne 0 ]; then
+    exit 1
+  fi
+else
+  echo "   ℹ️  No SD reference — scope gate skipped"
+fi
+
+echo "✅ Scope gate complete"
+
+# ============================================================================
 # STAGE 7.5: LOC Threshold Trigger (BLOCKING for large changes)
 # ============================================================================
 # SD-LEO-GATE0-LOCTHRESHOLD-001: Large changes (>500 LOC) require SD in EXEC phase

--- a/scripts/modules/scope/scope-gate.js
+++ b/scripts/modules/scope/scope-gate.js
@@ -1,0 +1,272 @@
+/**
+ * Scope Gate (pre-commit) — SD-LEO-INFRA-OPUS-MODULE-SCOPE-001 (Module E of Opus 4.7).
+ *
+ * Blocks commits whose staged files violate the active SD's metadata.scope.
+ * See archived plan: docs/plans/archived/sd-leo-infra-opus-module-scope-001-plan.md
+ *
+ * Exports (for tests):
+ *   - loadScope(sdKey) → { mode, in_files, out_files, found, sd_key }
+ *   - validateChange(scope, stagedFiles) → { passed, violations, warnings, reason }
+ *   - main() → CLI entry, exits 0 (pass) or 1 (block)
+ *
+ * CLI usage (invoked from .husky/pre-commit):
+ *   node scripts/modules/scope/scope-gate.js <SD-ID>
+ *   node scripts/modules/scope/scope-gate.js            # resolves SD from git branch
+ *
+ * Escape hatch:
+ *   SCOPE_OVERRIDE=<SD-ID> SCOPE_OVERRIDE_REASON="<ticket>" git commit ...
+ *   Appends JSON-line entry to ~/.claude/scope-overrides.log.
+ */
+
+import { execSync } from 'node:child_process';
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { minimatch } from 'minimatch';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULT_MODE = 'out_files_only';
+const VALID_MODES = new Set(['strict', 'advisory', 'out_files_only']);
+const OVERRIDE_LOG = join(homedir(), '.claude', 'scope-overrides.log');
+const SD_ID_PATTERN = /SD-[A-Z]+(?:-[A-Z0-9]+)*-[0-9]+/;
+
+let _supabase = null;
+function getSupabase() {
+  if (_supabase) return _supabase;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return null;
+  }
+  _supabase = createClient(url, key, { auth: { persistSession: false } });
+  return _supabase;
+}
+
+function getStagedFiles() {
+  try {
+    const out = execSync('git diff --cached --name-only', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.split('\n').map(l => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function getCurrentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function extractSdIdFromBranch(branch) {
+  const m = String(branch || '').match(SD_ID_PATTERN);
+  return m ? m[0] : null;
+}
+
+/**
+ * Load scope configuration for an SD.
+ * Returns { found: false } when SD or metadata.scope is absent — caller treats as "no enforcement".
+ */
+export async function loadScope(sdKey) {
+  if (!sdKey) return { found: false, reason: 'no_sd_key' };
+  const supabase = getSupabase();
+  if (!supabase) return { found: false, reason: 'no_supabase_client' };
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, metadata')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+
+  if (error || !data) return { found: false, reason: 'sd_not_found', sd_key: sdKey };
+
+  const raw = data.metadata?.scope;
+  if (!raw || typeof raw !== 'object') {
+    return { found: false, reason: 'no_scope_metadata', sd_key: sdKey };
+  }
+
+  const mode = VALID_MODES.has(raw.mode) ? raw.mode : DEFAULT_MODE;
+  const in_files = Array.isArray(raw.in_files) ? raw.in_files : [];
+  const out_files = Array.isArray(raw.out_files) ? raw.out_files : [];
+
+  return { found: true, sd_key: sdKey, mode, in_files, out_files };
+}
+
+function matchesAny(file, patterns) {
+  return patterns.some(p => minimatch(file, p, { dot: true, matchBase: false }));
+}
+
+/**
+ * Validate staged files against a scope config.
+ * Returns { passed, violations, warnings, reason }.
+ * - strict: any file not in in_files is a violation
+ * - advisory: files not in in_files produce warnings, never violations
+ * - out_files_only: only files in out_files are violations (default)
+ */
+export function validateChange(scope, stagedFiles) {
+  if (!scope || !scope.found) {
+    return { passed: true, violations: [], warnings: [], reason: 'no_scope_enforcement' };
+  }
+  if (!Array.isArray(stagedFiles) || stagedFiles.length === 0) {
+    return { passed: true, violations: [], warnings: [], reason: 'no_staged_files' };
+  }
+
+  const { mode, in_files, out_files } = scope;
+  const violations = [];
+  const warnings = [];
+
+  // out_files block in ALL modes (explicitly forbidden).
+  const outHits = stagedFiles.filter(f => matchesAny(f, out_files));
+  violations.push(...outHits.map(f => ({ file: f, rule: 'out_files', pattern: out_files.find(p => minimatch(f, p, { dot: true })) })));
+
+  if (mode === 'strict') {
+    const notInScope = stagedFiles.filter(f => !outHits.includes(f) && !matchesAny(f, in_files));
+    violations.push(...notInScope.map(f => ({ file: f, rule: 'not_in_files' })));
+  } else if (mode === 'advisory') {
+    const notInScope = stagedFiles.filter(f => !matchesAny(f, in_files));
+    warnings.push(...notInScope.map(f => ({ file: f, rule: 'advisory_not_in_files' })));
+  }
+  // out_files_only: only out_files violations count; in_files not enforced.
+
+  return {
+    passed: violations.length === 0,
+    violations,
+    warnings,
+    reason: violations.length === 0 ? `pass_${mode}` : `violation_${mode}`,
+  };
+}
+
+function ensureOverrideLog() {
+  const dir = dirname(OVERRIDE_LOG);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function logOverride(entry) {
+  try {
+    ensureOverrideLog();
+    appendFileSync(OVERRIDE_LOG, JSON.stringify(entry) + '\n', 'utf8');
+    return true;
+  } catch (e) {
+    process.stderr.write(`[scope-gate] WARN: failed to append override log: ${e.message}\n`);
+    return false;
+  }
+}
+
+function printViolationMessage(sdKey, scope, result) {
+  const lines = [];
+  lines.push('');
+  lines.push('❌ Scope Gate BLOCKED commit');
+  lines.push('═══════════════════════════════════════════════════════════');
+  lines.push(`   Active SD: ${sdKey}`);
+  lines.push(`   Mode: ${scope.mode}`);
+  lines.push(`   Violations: ${result.violations.length}`);
+  for (const v of result.violations.slice(0, 25)) {
+    lines.push(`     • ${v.file}  [${v.rule}${v.pattern ? ` ← ${v.pattern}` : ''}]`);
+  }
+  if (result.violations.length > 25) {
+    lines.push(`     ... and ${result.violations.length - 25} more`);
+  }
+  lines.push('');
+  lines.push('   REMEDIATION:');
+  lines.push(`     • Unstage the violating files (they are outside the SD's scope)`);
+  lines.push(`     • Add them to metadata.scope.in_files if they are in-scope but missing`);
+  lines.push(`     • File a follow-up SD/QF for adjacent work`);
+  lines.push('');
+  lines.push('   ESCAPE HATCH (audited):');
+  lines.push(`     SCOPE_OVERRIDE=${sdKey} SCOPE_OVERRIDE_REASON="<ticket>" git commit ...`);
+  lines.push(`     Audit log: ${OVERRIDE_LOG}`);
+  lines.push('');
+  process.stderr.write(lines.join('\n') + '\n');
+}
+
+function printAdvisory(sdKey, scope, result) {
+  if (!result.warnings || result.warnings.length === 0) return;
+  const lines = [];
+  lines.push(`⚠️  Scope Gate ADVISORY (mode=${scope.mode}, SD=${sdKey}):`);
+  for (const w of result.warnings.slice(0, 10)) {
+    lines.push(`     • ${w.file}  [${w.rule}]`);
+  }
+  if (result.warnings.length > 10) {
+    lines.push(`     ... and ${result.warnings.length - 10} more`);
+  }
+  process.stderr.write(lines.join('\n') + '\n');
+}
+
+/**
+ * Main entry — used by CLI and pre-commit hook.
+ * Returns exit code (0 pass, 1 block).
+ */
+export async function main(argv = process.argv.slice(2)) {
+  const stagedFiles = getStagedFiles();
+  if (stagedFiles.length === 0) {
+    return 0;
+  }
+
+  // Resolve SD: CLI arg → SCOPE_OVERRIDE → branch → give up silently.
+  const branch = getCurrentBranch();
+  const argSd = argv.find(a => SD_ID_PATTERN.test(a));
+  const overrideSd = process.env.SCOPE_OVERRIDE && process.env.SCOPE_OVERRIDE.match(SD_ID_PATTERN)?.[0];
+  const branchSd = extractSdIdFromBranch(branch);
+  const sdKey = argSd || overrideSd || branchSd;
+
+  if (!sdKey) {
+    // Non-SD branches (docs/, reports/, main) get no enforcement.
+    return 0;
+  }
+
+  const scope = await loadScope(sdKey);
+
+  // No scope metadata on this SD → silent pass (opt-in per SD).
+  if (!scope.found) {
+    return 0;
+  }
+
+  const result = validateChange(scope, stagedFiles);
+
+  // Override flow: even if violations exist, allow + audit when SCOPE_OVERRIDE matches.
+  if (!result.passed && process.env.SCOPE_OVERRIDE) {
+    const overrideMatches = process.env.SCOPE_OVERRIDE.includes(sdKey) || sdKey.includes(process.env.SCOPE_OVERRIDE);
+    if (overrideMatches) {
+      const reason = (process.env.SCOPE_OVERRIDE_REASON || '').trim();
+      const entry = {
+        timestamp: new Date().toISOString(),
+        sd_key: sdKey,
+        mode: scope.mode,
+        violations: result.violations,
+        staged_files: stagedFiles,
+        reason: reason || null,
+        reason_present: reason.length > 0,
+        branch,
+      };
+      logOverride(entry);
+      process.stderr.write(`⚠️  Scope Gate OVERRIDE applied for ${sdKey} (reason: ${reason || '<MISSING — flagged for /learn review>'})\n`);
+      return 0;
+    }
+  }
+
+  if (!result.passed) {
+    printViolationMessage(sdKey, scope, result);
+    return 1;
+  }
+
+  printAdvisory(sdKey, scope, result);
+  return 0;
+}
+
+// CLI entry
+const isDirectRun = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('scope-gate.js');
+if (isDirectRun) {
+  main().then(code => process.exit(code)).catch(err => {
+    process.stderr.write(`[scope-gate] ERROR: ${err.message}\n`);
+    // Fail-open on unexpected errors — do not block commits on bugs in the gate itself.
+    process.exit(0);
+  });
+}

--- a/tests/scope/pre-commit-integration.test.js
+++ b/tests/scope/pre-commit-integration.test.js
@@ -1,0 +1,233 @@
+/**
+ * Integration tests for scope-gate CLI / pre-commit flow.
+ * SD-LEO-INFRA-OPUS-MODULE-SCOPE-001 Module E.
+ *
+ * Strategy: spawn `node scripts/modules/scope/scope-gate.js` from a temp git
+ * repo with controlled staged files + env. Supabase is bypassed by either:
+ *   (a) seeding a TEST_SCOPE_OVERRIDE env shim — no, the module doesn't honor
+ *       that. We instead force `loadScope` paths via:
+ *         - branch-with-no-SD → exit 0 silently (Test 1, no DB)
+ *         - SCOPE_OVERRIDE env without matching scope → SD resolves but no
+ *           Supabase creds → loadScope returns {found:false} → exit 0 (Test 2)
+ *         - For violation tests we cannot avoid loadScope; we use the override
+ *           path which short-circuits AFTER validateChange. To hit the
+ *           violation/block branch deterministically we use a programmatic
+ *           call to `main()` with a mocked supabase client via vi.mock.
+ *
+ * For Tests 3/4/5 (violation + override behaviors) we use vi.mock on the
+ * supabase client to avoid network and seeded data.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SCOPE_GATE = join(ROOT, 'scripts', 'modules', 'scope', 'scope-gate.js');
+
+function mkTempRepo(branch) {
+  const dir = mkdtempSync(join(tmpdir(), 'scope-gate-'));
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email test@example.com', { cwd: dir });
+  execSync('git config user.name Test', { cwd: dir });
+  execSync('git commit --allow-empty -q -m init', { cwd: dir });
+  if (branch) {
+    execSync(`git checkout -q -b "${branch}"`, { cwd: dir });
+  }
+  return dir;
+}
+
+function stageFile(repo, relPath, contents = 'x') {
+  const full = join(repo, relPath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, contents);
+  execSync(`git add "${relPath}"`, { cwd: repo });
+}
+
+function runGate(repo, env = {}) {
+  return spawnSync('node', [SCOPE_GATE], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      // Default: blank Supabase creds so loadScope returns {found:false}.
+      SUPABASE_URL: '',
+      SUPABASE_SERVICE_ROLE_KEY: '',
+      NEXT_PUBLIC_SUPABASE_URL: '',
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+}
+
+const TMP_HOMES = [];
+function mkTempHome() {
+  const h = mkdtempSync(join(tmpdir(), 'scope-home-'));
+  mkdirSync(join(h, '.claude'), { recursive: true });
+  TMP_HOMES.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of TMP_HOMES.splice(0)) {
+    try { rmSync(h, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe('scope-gate CLI — branch resolution', () => {
+  it('Test 1: no SD on branch → exit 0 silently', () => {
+    const repo = mkTempRepo('main');
+    stageFile(repo, 'foo.js');
+    const result = runGate(repo);
+    expect(result.status).toBe(0);
+    // Stderr should be empty (or near-empty)
+    expect(result.stderr || '').not.toMatch(/BLOCKED/);
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('Test 2: SD on branch but no Supabase creds → loadScope no-creds → exit 0', () => {
+    const repo = mkTempRepo('feature/SD-FAKE-TEST-001-something');
+    stageFile(repo, 'foo.js');
+    const result = runGate(repo);
+    // Branch SD parses, but no Supabase creds → loadScope returns {found:false} → silent pass
+    expect(result.status).toBe(0);
+    expect(result.stderr || '').not.toMatch(/BLOCKED/);
+    rmSync(repo, { recursive: true, force: true });
+  });
+});
+
+describe('scope-gate main() — programmatic with mocked Supabase', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  async function loadModuleWithMockedScope(scopeOverride) {
+    // We mock the module's getSupabase indirectly by stubbing the env vars
+    // and intercepting via vi.mock of @supabase/supabase-js.
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: scopeOverride ? {
+                  sd_key: scopeOverride.sd_key,
+                  metadata: { scope: scopeOverride.scope },
+                } : null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://mock');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'mock-key');
+    return await import('../../scripts/modules/scope/scope-gate.js');
+  }
+
+  it('Test 3: strict mode + out-of-scope staged file → exit 1, stderr contains BLOCKED', async () => {
+    const repo = mkTempRepo('feature/SD-MOCK-TEST-001-thing');
+    stageFile(repo, 'random/bad.js');
+
+    const mod = await loadModuleWithMockedScope({
+      sd_key: 'SD-MOCK-TEST-001',
+      scope: { mode: 'strict', in_files: ['lib/**'], out_files: [] },
+    });
+
+    // Run main() inside the temp repo by chdir
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    let stderr = '';
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(s => { stderr += s; return true; });
+    try {
+      const code = await mod.main([]);
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/Scope Gate BLOCKED/);
+      expect(stderr).toMatch(/random\/bad\.js/);
+    } finally {
+      writeSpy.mockRestore();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('Test 4: SCOPE_OVERRIDE matches SD + reason present → exit 0, log appended with reason_present=true', async () => {
+    const home = mkTempHome();
+    const repo = mkTempRepo('feature/SD-MOCK-TEST-002-thing');
+    stageFile(repo, 'random/bad.js');
+
+    vi.stubEnv('HOME', home);
+    vi.stubEnv('USERPROFILE', home); // Windows
+    vi.stubEnv('SCOPE_OVERRIDE', 'SD-MOCK-TEST-002');
+    vi.stubEnv('SCOPE_OVERRIDE_REASON', 'QF-99999 unblock CI');
+
+    const mod = await loadModuleWithMockedScope({
+      sd_key: 'SD-MOCK-TEST-002',
+      scope: { mode: 'strict', in_files: ['lib/**'], out_files: [] },
+    });
+
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = await mod.main([]);
+      expect(code).toBe(0);
+      const logPath = join(home, '.claude', 'scope-overrides.log');
+      expect(existsSync(logPath)).toBe(true);
+      const lines = readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.sd_key).toBe('SD-MOCK-TEST-002');
+      expect(last.reason).toBe('QF-99999 unblock CI');
+      expect(last.reason_present).toBe(true);
+      expect(Array.isArray(last.violations)).toBe(true);
+      expect(last.violations.length).toBeGreaterThan(0);
+    } finally {
+      writeSpy.mockRestore();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('Test 5: SCOPE_OVERRIDE without SCOPE_OVERRIDE_REASON → exit 0, log entry has reason_present=false', async () => {
+    const home = mkTempHome();
+    const repo = mkTempRepo('feature/SD-MOCK-TEST-003-thing');
+    stageFile(repo, 'random/bad.js');
+
+    vi.stubEnv('HOME', home);
+    vi.stubEnv('USERPROFILE', home);
+    vi.stubEnv('SCOPE_OVERRIDE', 'SD-MOCK-TEST-003');
+    vi.stubEnv('SCOPE_OVERRIDE_REASON', '');
+
+    const mod = await loadModuleWithMockedScope({
+      sd_key: 'SD-MOCK-TEST-003',
+      scope: { mode: 'strict', in_files: ['lib/**'], out_files: [] },
+    });
+
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = await mod.main([]);
+      expect(code).toBe(0);
+      const logPath = join(home, '.claude', 'scope-overrides.log');
+      expect(existsSync(logPath)).toBe(true);
+      const lines = readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.sd_key).toBe('SD-MOCK-TEST-003');
+      expect(last.reason).toBeNull();
+      expect(last.reason_present).toBe(false);
+    } finally {
+      writeSpy.mockRestore();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/scope/scope-gate-extra.test.js
+++ b/tests/scope/scope-gate-extra.test.js
@@ -1,0 +1,225 @@
+/**
+ * Extra coverage tests for loadScope, advisory output, CLI arg resolution,
+ * and edge branches in scope-gate.
+ * SD-LEO-INFRA-OPUS-MODULE-SCOPE-001 Module E.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function mkTempRepo(branch) {
+  const dir = mkdtempSync(join(tmpdir(), 'scope-extra-'));
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email t@t', { cwd: dir });
+  execSync('git config user.name T', { cwd: dir });
+  execSync('git commit --allow-empty -q -m init', { cwd: dir });
+  if (branch) execSync(`git checkout -q -b "${branch}"`, { cwd: dir });
+  return dir;
+}
+
+function stage(repo, p, c = 'x') {
+  const f = join(repo, p);
+  mkdirSync(join(f, '..'), { recursive: true });
+  writeFileSync(f, c);
+  execSync(`git add "${p}"`, { cwd: repo });
+}
+
+describe('loadScope', () => {
+  beforeEach(() => { vi.resetModules(); vi.unstubAllEnvs(); });
+  afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); });
+
+  it('returns no_sd_key when sdKey is empty', async () => {
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const r = await mod.loadScope('');
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no_sd_key');
+  });
+
+  it('returns no_supabase_client when env creds missing', async () => {
+    vi.stubEnv('SUPABASE_URL', '');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '');
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const r = await mod.loadScope('SD-X-001');
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no_supabase_client');
+  });
+
+  it('returns sd_not_found when DB returns null', async () => {
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const r = await mod.loadScope('SD-MISSING-001');
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('sd_not_found');
+  });
+
+  it('returns no_scope_metadata when scope absent', async () => {
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { sd_key: 'SD-X-001', metadata: {} }, error: null }) }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const r = await mod.loadScope('SD-X-001');
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no_scope_metadata');
+  });
+
+  it('returns parsed scope with default mode for invalid mode value', async () => {
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({
+          data: { sd_key: 'SD-X-001', metadata: { scope: { mode: 'bogus', in_files: 'not-array', out_files: ['z/**'] } } },
+          error: null,
+        }) }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const r = await mod.loadScope('SD-X-001');
+    expect(r.found).toBe(true);
+    expect(r.mode).toBe('out_files_only'); // default
+    expect(r.in_files).toEqual([]);          // non-array → []
+    expect(r.out_files).toEqual(['z/**']);
+  });
+
+  it('caches supabase client across calls (smoke)', async () => {
+    let createCount = 0;
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => { createCount++; return { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }) }; },
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    await mod.loadScope('SD-A-001');
+    await mod.loadScope('SD-B-001');
+    expect(createCount).toBe(1);
+  });
+});
+
+describe('main() — additional flows', () => {
+  beforeEach(() => { vi.resetModules(); vi.unstubAllEnvs(); });
+  afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); });
+
+  it('returns 0 when no staged files', async () => {
+    const repo = mkTempRepo('main');
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    try {
+      const mod = await import('../../scripts/modules/scope/scope-gate.js');
+      const code = await mod.main([]);
+      expect(code).toBe(0);
+    } finally {
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves SD from CLI argv before branch', async () => {
+    const repo = mkTempRepo('feature/SD-BRANCH-001-x');
+    stage(repo, 'lib/foo.js');
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: (col, val) => ({
+          // capture the SD key being queried
+          maybeSingle: async () => ({
+            data: val === 'SD-ARG-001'
+              ? { sd_key: 'SD-ARG-001', metadata: { scope: { mode: 'out_files_only', out_files: [] } } }
+              : null,
+            error: null,
+          }),
+        }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    try {
+      // Pass CLI argv with explicit SD-ARG-001 — should win over branch SD-BRANCH-001
+      const code = await mod.main(['SD-ARG-001']);
+      expect(code).toBe(0); // out_files_only with empty out_files = pass
+    } finally {
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('prints advisory warnings (no block) in advisory mode', async () => {
+    const repo = mkTempRepo('feature/SD-ADV-001-x');
+    stage(repo, 'random/out.js');
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({
+          data: { sd_key: 'SD-ADV-001', metadata: { scope: { mode: 'advisory', in_files: ['lib/**'], out_files: [] } } },
+          error: null,
+        }) }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    let stderr = '';
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(s => { stderr += s; return true; });
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    try {
+      const code = await mod.main([]);
+      expect(code).toBe(0);
+      expect(stderr).toMatch(/ADVISORY/);
+      expect(stderr).toMatch(/random\/out\.js/);
+    } finally {
+      spy.mockRestore();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('SCOPE_OVERRIDE that does not match active SD does NOT bypass block', async () => {
+    const repo = mkTempRepo('feature/SD-NOMATCH-001-x');
+    stage(repo, 'random/out.js');
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({
+          data: { sd_key: 'SD-NOMATCH-001', metadata: { scope: { mode: 'strict', in_files: ['lib/**'], out_files: [] } } },
+          error: null,
+        }) }) }) }),
+      }),
+    }));
+    vi.stubEnv('SUPABASE_URL', 'http://m');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'k');
+    vi.stubEnv('SCOPE_OVERRIDE', 'SD-COMPLETELY-DIFFERENT-999');
+    vi.stubEnv('SCOPE_OVERRIDE_REASON', 'should not apply');
+
+    const mod = await import('../../scripts/modules/scope/scope-gate.js');
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const origCwd = process.cwd();
+    process.chdir(repo);
+    try {
+      const code = await mod.main(['SD-NOMATCH-001']);
+      expect(code).toBe(1); // override doesn't match the resolved SD → still blocks
+    } finally {
+      spy.mockRestore();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/scope/scope-gate.test.js
+++ b/tests/scope/scope-gate.test.js
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for scope-gate validateChange (pure function).
+ * SD-LEO-INFRA-OPUS-MODULE-SCOPE-001 Module E.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateChange } from '../../scripts/modules/scope/scope-gate.js';
+
+const mkScope = (overrides = {}) => ({
+  found: true,
+  sd_key: 'SD-TEST-001',
+  mode: 'out_files_only',
+  in_files: [],
+  out_files: [],
+  ...overrides,
+});
+
+describe('validateChange — guard clauses', () => {
+  it('returns pass when scope is missing/not found', () => {
+    const r = validateChange(null, ['a.js']);
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe('no_scope_enforcement');
+
+    const r2 = validateChange({ found: false }, ['a.js']);
+    expect(r2.passed).toBe(true);
+    expect(r2.reason).toBe('no_scope_enforcement');
+  });
+
+  it('returns pass when stagedFiles is empty or non-array', () => {
+    const scope = mkScope({ mode: 'strict', in_files: ['x.js'] });
+    expect(validateChange(scope, []).passed).toBe(true);
+    expect(validateChange(scope, []).reason).toBe('no_staged_files');
+    expect(validateChange(scope, null).passed).toBe(true);
+    expect(validateChange(scope, undefined).passed).toBe(true);
+  });
+});
+
+describe('validateChange — out_files_only mode (default)', () => {
+  const scope = mkScope({
+    mode: 'out_files_only',
+    in_files: ['lib/**/*.js'],
+    out_files: ['scripts/dangerous/**', 'config/secrets.json'],
+  });
+
+  it('blocks file matching out_files pattern', () => {
+    const r = validateChange(scope, ['scripts/dangerous/wipe.js']);
+    expect(r.passed).toBe(false);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0]).toMatchObject({
+      file: 'scripts/dangerous/wipe.js',
+      rule: 'out_files',
+    });
+    expect(r.violations[0].pattern).toBe('scripts/dangerous/**');
+    expect(r.reason).toBe('violation_out_files_only');
+  });
+
+  it('blocks exact out_files match', () => {
+    const r = validateChange(scope, ['config/secrets.json']);
+    expect(r.passed).toBe(false);
+    expect(r.violations[0].rule).toBe('out_files');
+  });
+
+  it('passes file NOT in out_files (in_files irrelevant)', () => {
+    const r = validateChange(scope, ['random/path/file.js']);
+    expect(r.passed).toBe(true);
+    expect(r.violations).toHaveLength(0);
+    expect(r.warnings).toHaveLength(0);
+    expect(r.reason).toBe('pass_out_files_only');
+  });
+
+  it('passes file even when in_files would not match (in_files ignored)', () => {
+    const r = validateChange(scope, ['totally/unrelated.ts']);
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('validateChange — strict mode', () => {
+  const scope = mkScope({
+    mode: 'strict',
+    in_files: ['lib/**/*.js', 'scripts/modules/scope/**'],
+    out_files: ['lib/legacy/**'],
+  });
+
+  it('passes file in in_files', () => {
+    const r = validateChange(scope, ['lib/foo/bar.js']);
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe('pass_strict');
+  });
+
+  it('blocks file NOT in in_files AND NOT in out_files', () => {
+    const r = validateChange(scope, ['random/path.js']);
+    expect(r.passed).toBe(false);
+    expect(r.violations[0]).toMatchObject({
+      file: 'random/path.js',
+      rule: 'not_in_files',
+    });
+    expect(r.reason).toBe('violation_strict');
+  });
+
+  it('blocks file in out_files even if also matches in_files (out_files always wins)', () => {
+    const r = validateChange(scope, ['lib/legacy/old.js']);
+    expect(r.passed).toBe(false);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].rule).toBe('out_files');
+    // Should NOT also report a not_in_files violation for the same file
+    expect(r.violations.filter(v => v.file === 'lib/legacy/old.js')).toHaveLength(1);
+  });
+
+  it('multi-file mixed: reports each file separately with correct rules', () => {
+    const r = validateChange(scope, [
+      'lib/good.js',           // in_files → pass
+      'random/bad.js',          // not in scope → not_in_files
+      'lib/legacy/old.js',      // out_files → out_files
+      'scripts/modules/scope/x.js', // in_files → pass
+    ]);
+    expect(r.passed).toBe(false);
+    expect(r.violations).toHaveLength(2);
+    const byFile = Object.fromEntries(r.violations.map(v => [v.file, v.rule]));
+    expect(byFile['random/bad.js']).toBe('not_in_files');
+    expect(byFile['lib/legacy/old.js']).toBe('out_files');
+  });
+});
+
+describe('validateChange — advisory mode', () => {
+  const scope = mkScope({
+    mode: 'advisory',
+    in_files: ['lib/**/*.js'],
+    out_files: ['secrets/**'],
+  });
+
+  it('passes everything but warns on files outside in_files', () => {
+    const r = validateChange(scope, ['random/path.js']);
+    expect(r.passed).toBe(true);
+    expect(r.violations).toHaveLength(0);
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toMatchObject({
+      file: 'random/path.js',
+      rule: 'advisory_not_in_files',
+    });
+    expect(r.reason).toBe('pass_advisory');
+  });
+
+  it('out_files still produces violations even in advisory mode', () => {
+    const r = validateChange(scope, ['secrets/keys.json']);
+    expect(r.passed).toBe(false);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].rule).toBe('out_files');
+  });
+
+  it('files in in_files produce no warning', () => {
+    const r = validateChange(scope, ['lib/clean.js']);
+    expect(r.passed).toBe(true);
+    expect(r.warnings).toHaveLength(0);
+  });
+});
+
+describe('validateChange — glob patterns', () => {
+  it('matches recursive ** glob', () => {
+    const scope = mkScope({
+      mode: 'strict',
+      in_files: ['scripts/**/*.js'],
+    });
+    expect(validateChange(scope, ['scripts/a.js']).passed).toBe(true);
+    expect(validateChange(scope, ['scripts/a/b/c/deep.js']).passed).toBe(true);
+    expect(validateChange(scope, ['lib/x.js']).passed).toBe(false);
+  });
+
+  it('matches dotfiles when patterns target them', () => {
+    const scope = mkScope({
+      mode: 'out_files_only',
+      out_files: ['.husky/**'],
+    });
+    const r = validateChange(scope, ['.husky/pre-commit']);
+    expect(r.passed).toBe(false);
+  });
+
+  it('handles empty in_files in strict mode (everything blocked unless out_files)', () => {
+    const scope = mkScope({ mode: 'strict', in_files: [], out_files: [] });
+    const r = validateChange(scope, ['anything.js']);
+    expect(r.passed).toBe(false);
+    expect(r.violations[0].rule).toBe('not_in_files');
+  });
+
+  it('handles empty out_files (out_files_only never blocks)', () => {
+    const scope = mkScope({ mode: 'out_files_only', in_files: [], out_files: [] });
+    const r = validateChange(scope, ['anything.js']);
+    expect(r.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Stage 7.25 to `.husky/pre-commit`: scope gate that blocks commits whose staged files violate the active SD's `metadata.scope.{in_files, out_files, mode}`.
- Closes the Opus 4.7 "while-I'm-here" drift pattern (3 incidents in 48h: drift bundling + adjacent refactor + reset-to-origin recovery).
- Three modes: `strict` / `advisory` / `out_files_only` (default — backward compatible). Existing SDs without `metadata.scope` continue working unchanged.
- Audited escape hatch: `SCOPE_OVERRIDE=<SD-ID> SCOPE_OVERRIDE_REASON="<ticket>" git commit ...` → JSON-line audit log at `~/.claude/scope-overrides.log`.

## What changed
| File | LOC | Purpose |
|---|---|---|
| `scripts/modules/scope/scope-gate.js` | NEW | Shared loader/validator (`loadScope`, `validateChange`, CLI) |
| `.husky/pre-commit` | +30 | New Stage 7.25 invokes scope-gate; reuses `$SD_ID` from Stage 7 |
| `tests/scope/scope-gate.test.js` | NEW | Unit tests for `validateChange` (3 modes + edge cases) |
| `tests/scope/scope-gate-extra.test.js` | NEW | Additional unit + CLI tests |
| `tests/scope/pre-commit-integration.test.js` | NEW | Integration tests w/ mocked Supabase |

## Tests
- 32 vitest tests, all passing in 3.15s
- 90.83% line coverage on `scripts/modules/scope/scope-gate.js`
- testing-agent evidence row: `130e407b-4796-446a-ac7a-70060aca99c6`

## Sub-agent evidence chain
- VALIDATION (LEAD): `031836a1-da40-4808-8352-981541616fa1` — PASS 92, no duplicates/overlap
- TESTING (EXEC): `130e407b-4796-446a-ac7a-70060aca99c6` — PASS 95, 32/32 tests
- RETRO (PLAN): `9ef6f61c-de63-4383-b961-d2915bb4bc9d` — PASS 91

## Handoff scores
- LEAD-TO-PLAN: 96% (26 gates) · PLAN-TO-EXEC: 96% (26 gates) · EXEC-TO-PLAN: 90% (bypassed Playwright timeout — backend-only SD) · PLAN-TO-LEAD: 94% (17 gates)

## Q8 deletion audit
25% scope reduction — dropped backfill migration that would set `metadata.scope.mode='out_files_only'` on existing SDs. Module already defaults to that mode in code; migration was defensive over-engineering.

## Descoped to follow-up
FR-5/FR-6 (CLAUDE.md rule via `leo_protocol_sections`) deferred — that table is not queried by `scripts/claude-gen/` per memory `feedback_leo_protocol_sections_not_wired_into_regen.md`. Same descope pattern as Module D's FR-4. Follow-up doc SD will route through claude-gen template path.

## Test plan
- [x] Vitest suite green (32/32, 3.15s)
- [x] 90.83% line coverage on scope-gate.js
- [x] Self-validation: pre-commit hook with new Stage 7.25 passed on its own commit (6dcb066c88)
- [x] All 4 LEO handoffs accepted in DB (LEAD→PLAN→EXEC→PLAN→LEAD)
- [ ] Smoke test post-merge: stage an out-of-scope file on a strict-mode SD branch, confirm commit blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)