### PR TITLE
feat(SD-LEO-REFAC-PLAN-MEMORY-INDEX-001): MEMORY.md reindex operator tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "context:analyze": "node scripts/sync-context-usage.js --analyze",
     "context:monitor": "node scripts/context-monitor.js check",
     "memory:view": "node scripts/view-memory.js",
+    "memory:reindex": "node scripts/modules/memory/reindex.mjs",
     "cli": "node scripts/cli.cjs",
     "agent:metrics": "node lib/agents/metrics-dashboard.cjs",
     "agent:metrics:agent": "node lib/agents/metrics-dashboard.cjs agent",

--- a/scripts/modules/memory/clustering.mjs
+++ b/scripts/modules/memory/clustering.mjs
@@ -1,0 +1,58 @@
+const PREFIX_RE = /^([a-z]+(?:_[a-z]+){0,2})_/;
+const MIN_GROUP_SIZE = 3;
+
+export function clusterByPrefix(entries, { minGroupSize = MIN_GROUP_SIZE } = {}) {
+  const buckets = new Map();
+  const noPrefix = [];
+
+  for (const entry of entries) {
+    const m = entry.filename.match(PREFIX_RE);
+    if (!m) { noPrefix.push(entry); continue; }
+    const prefix = m[1];
+    if (!buckets.has(prefix)) buckets.set(prefix, []);
+    buckets.get(prefix).push(entry);
+  }
+
+  const topics = [];
+  const standalone = [...noPrefix];
+
+  for (const [prefix, members] of [...buckets.entries()].sort()) {
+    if (members.length >= minGroupSize) {
+      topics.push({ prefix, members: members.slice().sort((a, b) => a.filename.localeCompare(b.filename)) });
+    } else {
+      standalone.push(...members);
+    }
+  }
+
+  standalone.sort((a, b) => a.filename.localeCompare(b.filename));
+  return { topics, standalone };
+}
+
+export function buildTopicFilename(prefix) {
+  return `topic_${prefix}.md`;
+}
+
+export function buildTopicContent(prefix, members) {
+  const title = `Topic: ${prefix.replace(/_/g, ' ')}`;
+  const description = `${members.length} related memories grouped from ${prefix}_*`;
+  const lines = [
+    '---',
+    `name: ${title}`,
+    `description: ${description}`,
+    'type: topic',
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    `Auto-generated topic clustering ${members.length} memories under prefix \`${prefix}_*\`.`,
+    '',
+    '## Members',
+    '',
+    ...members.map(m => {
+      const memTitle = m.parsed.name || m.filename.replace(/\.md$/, '');
+      return `- [${memTitle}](${m.filename})`;
+    }),
+    '',
+  ];
+  return lines.join('\n');
+}

--- a/scripts/modules/memory/reindex.mjs
+++ b/scripts/modules/memory/reindex.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import process from 'node:process';
+import { parseMemoryFrontmatter } from './frontmatter.js';
+import { clusterByPrefix, buildTopicFilename, buildTopicContent } from './clustering.mjs';
+
+const INDEX_FILENAME = 'MEMORY.md';
+const TOPIC_PREFIX = 'topic_';
+const MAX_LINE_CHARS = 120;
+const TARGET_BYTES = 15 * 1024;
+const EXPIRED_PREFIX = '(!) ';
+
+function resolveMemoryDir(arg) {
+  if (arg) return arg;
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const cwd = process.cwd();
+  const encoded = cwd.replace(/[\\/:]/g, '-').replace(/^-+/, '');
+  return join(home, '.claude', 'projects', `C--${encoded.replace(/^C--/, '')}`, 'memory');
+}
+
+function buildIndexLine(filename, parsed) {
+  const title = parsed.name || basename(filename, '.md');
+  const desc = parsed.description || '';
+  const prefix = parsed.is_expired ? EXPIRED_PREFIX : '';
+  let line = `${prefix}- [${title}](${filename})${desc ? ` — ${desc}` : ''}`;
+  if (line.length > MAX_LINE_CHARS) {
+    const overflow = line.length - MAX_LINE_CHARS + 1;
+    const truncatedDesc = desc.slice(0, Math.max(0, desc.length - overflow)) + '…';
+    line = `${prefix}- [${title}](${filename})${truncatedDesc ? ` — ${truncatedDesc}` : ''}`;
+  }
+  return line;
+}
+
+function buildTopicLine(prefix, filename, members) {
+  const sample = members.slice(0, 2).map(m => m.parsed.name || basename(m.filename, '.md')).join(', ');
+  const more = members.length > 2 ? `, +${members.length - 2} more` : '';
+  let line = `- [Topic: ${prefix}](${filename}) — ${members.length} memories: ${sample}${more}`;
+  if (line.length > MAX_LINE_CHARS) {
+    line = `- [Topic: ${prefix}](${filename}) — ${members.length} memories`;
+  }
+  return line;
+}
+
+export function reindex({ memoryDir, dryRun = false, stderr = process.stderr } = {}) {
+  const dir = resolveMemoryDir(memoryDir);
+  if (!existsSync(dir)) {
+    stderr.write(`[memory/reindex] ERROR: memory directory not found: ${dir}\n`);
+    return { ok: false, reason: 'missing_dir', dir };
+  }
+
+  const files = readdirSync(dir)
+    .filter(f => f.endsWith('.md'))
+    .filter(f => f !== INDEX_FILENAME)
+    .filter(f => !f.startsWith(TOPIC_PREFIX))
+    .sort();
+
+  const entries = [];
+  for (const filename of files) {
+    try {
+      entries.push({ filename, parsed: parseMemoryFrontmatter(join(dir, filename)) });
+    } catch (err) {
+      stderr.write(`[memory/reindex] WARN: skipping ${filename}: ${err.message}\n`);
+    }
+  }
+
+  const { topics, standalone } = clusterByPrefix(entries);
+
+  const indexLines = [];
+  for (const t of topics) {
+    indexLines.push(buildTopicLine(t.prefix, buildTopicFilename(t.prefix), t.members));
+  }
+  for (const s of standalone) {
+    indexLines.push(buildIndexLine(s.filename, s.parsed));
+  }
+
+  const indexOutput = indexLines.join('\n') + '\n';
+  const indexBytes = Buffer.byteLength(indexOutput, 'utf8');
+  const overBudget = indexBytes > TARGET_BYTES;
+
+  if (dryRun) {
+    process.stdout.write(`# Preview: MEMORY.md (${indexBytes} bytes, ${indexLines.length} lines)\n`);
+    process.stdout.write(`# Topic files to create: ${topics.length}\n`);
+    process.stdout.write(`# Budget: ${TARGET_BYTES} bytes; over budget: ${overBudget}\n\n`);
+    process.stdout.write(indexOutput);
+    return { ok: !overBudget, dryRun: true, indexBytes, lineCount: indexLines.length, topicCount: topics.length, overBudget };
+  }
+
+  for (const t of topics) {
+    const path = join(dir, buildTopicFilename(t.prefix));
+    writeFileSync(path, buildTopicContent(t.prefix, t.members), 'utf8');
+  }
+  writeFileSync(join(dir, INDEX_FILENAME), indexOutput, 'utf8');
+
+  return { ok: !overBudget, dryRun: false, indexBytes, lineCount: indexLines.length, topicCount: topics.length, overBudget };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}` ||
+               import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/'));
+if (isMain) {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--preview') || args.includes('--dry-run');
+  const dirArg = args.find(a => !a.startsWith('--'));
+  const result = reindex({ memoryDir: dirArg, dryRun });
+  if (!result.ok) {
+    process.stderr.write(`[memory/reindex] FAIL: ${JSON.stringify(result)}\n`);
+    process.exit(1);
+  }
+  if (!dryRun) {
+    process.stdout.write(`[memory/reindex] OK: ${result.lineCount} lines, ${result.indexBytes} bytes, ${result.topicCount} topic files\n`);
+  }
+}

--- a/tests/memory/reindex.test.js
+++ b/tests/memory/reindex.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for MEMORY.md reindex tooling
+ * SD-LEO-REFAC-PLAN-MEMORY-INDEX-001
+ *
+ * Covers TR-1 (no content loss), TR-2 (fixture coverage),
+ * TR-3 (byte budget), TR-4 (idempotency) from the PRD.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+
+import { reindex } from '../../scripts/modules/memory/reindex.mjs';
+import { clusterByPrefix, buildTopicFilename, buildTopicContent } from '../../scripts/modules/memory/clustering.mjs';
+
+const TARGET_BYTES = 15 * 1024;
+const MAX_LINE_CHARS = 120;
+
+function fixtureBody(name, description, extras = {}) {
+  const kv = { name, description, type: 'feedback', ...extras };
+  const yaml = Object.entries(kv).map(([k, v]) => `${k}: ${v}`).join('\n');
+  return `---\n${yaml}\n---\n\nBody for ${name}.\n`;
+}
+
+function makeMemoryDir() {
+  return mkdtempSync(join(tmpdir(), 'memreindex-'));
+}
+
+describe('clustering.mjs', () => {
+  it('groups by prefix when group >= 3', () => {
+    const entries = [
+      { filename: 'feedback_claim_one.md', parsed: {} },
+      { filename: 'feedback_claim_two.md', parsed: {} },
+      { filename: 'feedback_claim_three.md', parsed: {} },
+      { filename: 'project_x.md', parsed: {} },
+      { filename: 'project_y.md', parsed: {} },
+      { filename: 'reference_solo.md', parsed: {} },
+    ];
+    const { topics, standalone } = clusterByPrefix(entries);
+    expect(topics).toHaveLength(1);
+    expect(topics[0].prefix).toBe('feedback_claim');
+    expect(topics[0].members).toHaveLength(3);
+    expect(standalone.map(s => s.filename).sort()).toEqual([
+      'project_x.md', 'project_y.md', 'reference_solo.md',
+    ]);
+  });
+
+  it('produces stable ordering (idempotency precondition)', () => {
+    const entries = [
+      { filename: 'a_one_x.md', parsed: {} },
+      { filename: 'a_one_z.md', parsed: {} },
+      { filename: 'a_one_y.md', parsed: {} },
+    ];
+    const r1 = clusterByPrefix(entries);
+    const r2 = clusterByPrefix(entries);
+    expect(JSON.stringify(r1)).toBe(JSON.stringify(r2));
+  });
+
+  it('topic content has type:topic frontmatter and member links', () => {
+    const content = buildTopicContent('feedback_claim', [
+      { filename: 'feedback_claim_one.md', parsed: { name: 'Claim one' } },
+      { filename: 'feedback_claim_two.md', parsed: { name: 'Claim two' } },
+    ]);
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain('type: topic');
+    expect(content).toContain('[Claim one](feedback_claim_one.md)');
+    expect(content).toContain('[Claim two](feedback_claim_two.md)');
+  });
+});
+
+describe('reindex.mjs', () => {
+  let dir;
+  beforeEach(() => { dir = makeMemoryDir(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('TR-3: MEMORY.md output is <= 15KB on a realistic 50+ file fixture', () => {
+    // TR-2 + TR-3: build 50+ files across 8 prefixes, assert byte budget
+    const prefixes = ['feedback_claim', 'feedback_auto', 'feedback_tool', 'feedback_session',
+                      'project_sd_leo', 'project_sd_uat', 'reference_api', 'user_pref'];
+    let count = 0;
+    for (const p of prefixes) {
+      for (let i = 1; i <= 7; i++) {
+        const fn = `${p}_${i}.md`;
+        const desc = 'Description text long enough to make the index line exceed the 120-char budget if not truncated by buildIndexLine';
+        writeFileSync(join(dir, fn), fixtureBody(`${p} entry ${i}`, desc), 'utf8');
+        count++;
+      }
+    }
+    expect(count).toBeGreaterThanOrEqual(50);
+
+    const result = reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+    expect(result.ok).toBe(true);
+    expect(result.indexBytes).toBeLessThanOrEqual(TARGET_BYTES);
+
+    const indexPath = join(dir, 'MEMORY.md');
+    const indexContent = readFileSync(indexPath, 'utf8');
+    for (const line of indexContent.split('\n').filter(Boolean)) {
+      expect(line.length).toBeLessThanOrEqual(MAX_LINE_CHARS);
+    }
+  });
+
+  it('TR-1: zero memory-content loss (every original file is reachable)', () => {
+    const filenames = [];
+    for (let i = 1; i <= 5; i++) {
+      const fn = `feedback_a_${i}.md`;
+      writeFileSync(join(dir, fn), fixtureBody(`Memory ${i}`, 'd'), 'utf8');
+      filenames.push(fn);
+    }
+    for (let i = 1; i <= 2; i++) {
+      const fn = `solo_${i}.md`;
+      writeFileSync(join(dir, fn), fixtureBody(`Solo ${i}`, 'd'), 'utf8');
+      filenames.push(fn);
+    }
+
+    reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+
+    const indexContent = readFileSync(join(dir, 'MEMORY.md'), 'utf8');
+    const topicFiles = readdirSync(dir).filter(f => f.startsWith('topic_')).map(f => readFileSync(join(dir, f), 'utf8'));
+    const allRefs = [indexContent, ...topicFiles].join('\n');
+
+    for (const fn of filenames) {
+      expect(allRefs).toContain(fn);
+    }
+  });
+
+  it('TR-4: idempotency — running twice produces identical MEMORY.md', () => {
+    const prefixes = ['feedback_x', 'project_y'];
+    for (const p of prefixes) {
+      for (let i = 1; i <= 4; i++) {
+        writeFileSync(join(dir, `${p}_${i}.md`), fixtureBody(`${p} ${i}`, 'd'), 'utf8');
+      }
+    }
+
+    reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+    const first = readFileSync(join(dir, 'MEMORY.md'), 'utf8');
+    const firstTopics = readdirSync(dir).filter(f => f.startsWith('topic_')).sort();
+
+    reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+    const second = readFileSync(join(dir, 'MEMORY.md'), 'utf8');
+    const secondTopics = readdirSync(dir).filter(f => f.startsWith('topic_')).sort();
+
+    expect(second).toBe(first);
+    expect(secondTopics).toEqual(firstTopics);
+  });
+
+  it('TS-3: --preview (dryRun:true) does not write any file', () => {
+    writeFileSync(join(dir, 'feedback_a_1.md'), fixtureBody('A1', 'd'), 'utf8');
+    writeFileSync(join(dir, 'feedback_a_2.md'), fixtureBody('A2', 'd'), 'utf8');
+
+    const before = readdirSync(dir).sort();
+    reindex({ memoryDir: dir, dryRun: true, stderr: new PassThrough() });
+    const after = readdirSync(dir).sort();
+
+    expect(after).toEqual(before);
+    expect(existsSync(join(dir, 'MEMORY.md'))).toBe(false);
+  });
+
+  it('TS-4: empty memory directory produces no topic files and no error', () => {
+    const result = reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+    expect(result.ok).toBe(true);
+    expect(result.lineCount).toBe(0);
+    expect(result.topicCount).toBe(0);
+    expect(readdirSync(dir).filter(f => f.startsWith('topic_'))).toHaveLength(0);
+  });
+
+  it('TS-5: all entries below clustering threshold => flat index, no topic files', () => {
+    writeFileSync(join(dir, 'a_one.md'), fixtureBody('A', 'd'), 'utf8');
+    writeFileSync(join(dir, 'b_two.md'), fixtureBody('B', 'd'), 'utf8');
+    writeFileSync(join(dir, 'c_three.md'), fixtureBody('C', 'd'), 'utf8');
+
+    const result = reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+    expect(result.ok).toBe(true);
+    expect(result.topicCount).toBe(0);
+    expect(result.lineCount).toBe(3);
+    expect(readdirSync(dir).filter(f => f.startsWith('topic_'))).toHaveLength(0);
+  });
+
+  it('TR-1 sanity: original memory files are unchanged (sha-equivalent via content read)', () => {
+    const fn = 'feedback_immutable_one.md';
+    const body = fixtureBody('Immutable', 'do not modify me');
+    writeFileSync(join(dir, fn), body, 'utf8');
+    writeFileSync(join(dir, 'feedback_immutable_two.md'), fixtureBody('I2', 'd'), 'utf8');
+    writeFileSync(join(dir, 'feedback_immutable_three.md'), fixtureBody('I3', 'd'), 'utf8');
+
+    reindex({ memoryDir: dir, dryRun: false, stderr: new PassThrough() });
+
+    const after = readFileSync(join(dir, fn), 'utf8');
+    expect(after).toBe(body);
+  });
+
+  it('REUSE assertion: reindex.mjs imports parseMemoryFrontmatter from frontmatter.js', () => {
+    const source = readFileSync(join(import.meta.url.replace('file://', '').replace(/^\/([A-Z]:)/, '$1').replace('tests/memory/reindex.test.js', 'scripts/modules/memory/reindex.mjs')), 'utf8');
+    expect(source).toContain("from './frontmatter.js'");
+    expect(source).toContain('parseMemoryFrontmatter');
+  });
+});


### PR DESCRIPTION
## Summary

Adds operator-invoked re-indexing for the auto-memory MEMORY.md context-index file. New script `npm run memory:reindex` clusters individual memory files by filename prefix, creates topic files for groups of three or more, and rewrites MEMORY.md with one-line entries (max 120 chars each), targeting <=15KB output.

- New: `scripts/modules/memory/clustering.mjs` (58 LOC) — prefix grouping helper
- New: `scripts/modules/memory/reindex.mjs` (112 LOC) — CLI with `--preview` mode
- New: `tests/memory/reindex.test.js` (198 LOC) — 11 vitest tests covering all 4 PRD TRs + edge cases
- Modified: `package.json` — adds `memory:reindex` npm script

**Reuses** `scripts/modules/memory/frontmatter.js::parseMemoryFrontmatter` shipped in PR #3323 (SD-LEO-INFRA-OPUS-MODULE-MEMORY-001) — no parallel reimplementation. Sequenced-pair design with Module D.

**Pure additive**: zero individual memory files are modified by the script.

## Known limitation (documented in retro)

On hand-curated MEMORY.md files (like the user's live one at `~/.claude/projects/.../memory/MEMORY.md`) the script regenerates exhaustively and may exceed 15KB even after clustering — most live entries have unique filename prefixes that don't cluster. Operator gets explicit `over budget: true` signal via FR-7 dry-run exit. Closing the live-dir gap is follow-up work (manual triage or more aggressive trimming heuristics).

## Test plan

- [x] `npx vitest run tests/memory/reindex.test.js` — 11/11 pass locally
- [x] Smoke test: `npm run memory:reindex -- --preview` against live `~/.claude/projects/.../memory/` → correctly reports `over budget: true` (37.8KB / 309 lines / 8 topic groups)
- [x] LEAD-TO-PLAN handoff: 93/100
- [x] PLAN-TO-EXEC handoff: 96/100
- [x] PLAN-TO-LEAD handoff: 91/100
- [x] Retrospective inserted (`a55cf586-42ca-4106-9487-75ffd9b63f6c`, retro_type=SD_COMPLETION, quality_score=100)
- [ ] LEAD-FINAL-APPROVAL after merge

## Gate scores
- LEAD-TO-PLAN: 93/100 (1 description-word-count remediation cycle)
- PLAN-TO-EXEC: 96/100 (1 PRD-status update cycle)
- PLAN-TO-LEAD: 91/100 (1 retrospective creation cycle)

## PR Size

369 LOC, Tier 3. Code/test split 170/198 (1.16:1, healthy for byte-budget-critical script). Plan estimated 150-200 LOC; 84% over plan, primarily because tests went thicker than estimated to cover all 6 PRD test scenarios + REUSE assertion + edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>