### PR TITLE
fix(QF-20260424-081): stop setting retrospective_type on orchestrator retros

### DIFF
--- a/docs/guides/self-improvement-system-guide.md
+++ b/docs/guides/self-improvement-system-guide.md
@@ -265,7 +265,6 @@ When creating a retrospective, include protocol improvements in the `protocol_im
 const retroData = {
   sd_id: 'SD-TEST-001',
   retro_type: 'SD_COMPLETION',
-  retrospective_type: 'SD_COMPLETION',
   title: 'SD-TEST-001 Completion Retrospective',
   quality_score: 85,
   target_application: 'EHG_Engineer',

--- a/scripts/modules/handoff/orchestrator-completion-guardian-retro-shape.test.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian-retro-shape.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+const GUARDIAN_FILES = [
+  resolve(REPO_ROOT, 'scripts/modules/orchestrator-completion-guardian.js'),
+  resolve(REPO_ROOT, 'scripts/modules/handoff/orchestrator-completion-guardian.js'),
+];
+
+describe('orchestrator-completion-guardian retrospective shape', () => {
+  it.each(GUARDIAN_FILES)(
+    '%s does not set retrospective_type on SD-completion retro INSERT (gate filter requires NULL)',
+    (file) => {
+      const src = readFileSync(file, 'utf8');
+      expect(src).toMatch(/retro_type:\s*'SD_COMPLETION'/);
+      expect(src).not.toMatch(/retrospective_type\s*:/);
+    }
+  );
+});

--- a/scripts/modules/handoff/orchestrator-completion-guardian.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian.js
@@ -585,7 +585,6 @@ export class OrchestratorCompletionGuardian {
         title: `${this.parentData.title} - Orchestrator Retrospective`,
         description: `Aggregated retrospective for orchestrator coordinating ${this.childData.length} child SDs`,
         retro_type: 'SD_COMPLETION',
-        retrospective_type: 'SD_COMPLETION',
         conducted_date: new Date().toISOString(),
         what_went_well: uniqueWentWell.length > 0 ? uniqueWentWell : [
           `All ${this.childData.length} child SDs completed successfully`,

--- a/scripts/modules/orchestrator-completion-guardian.js
+++ b/scripts/modules/orchestrator-completion-guardian.js
@@ -496,7 +496,6 @@ export class OrchestratorCompletionGuardian {
         title: `${this.parentData.title} - Orchestrator Retrospective`,
         description: `Aggregated retrospective for orchestrator coordinating ${this.childData.length} child SDs`,
         retro_type: 'SD_COMPLETION',
-        retrospective_type: 'SD_COMPLETION',
         conducted_date: new Date().toISOString(),
         what_went_well: uniqueWentWell.length > 0 ? uniqueWentWell : [
           `All ${this.childData.length} child SDs completed successfully`,


### PR DESCRIPTION
## Summary
- Both `orchestrator-completion-guardian.js` paths (modules/ and modules/handoff/) set `retrospective_type='SD_COMPLETION'` alongside `retro_type='SD_COMPLETION'` when auto-generating orchestrator retros
- The PLAN-TO-LEAD / LEAD-FINAL-APPROVAL gates filter `retro-filters.js:64` with `.is('retrospective_type', null)` and treat any non-null `retrospective_type` as a handoff-time retro — excluding the row
- Result: `RETROSPECTIVE_QUALITY_GATE_FAILED` until the column is manually nulled out
- This PR removes the offending field from both INSERTs and from the doc snippet, and adds a source-shape regression test

## Why this is correct
- `retro_type` alone distinguishes SD-completion retros from SPRINT/INCIDENT/AUDIT (per `retro-filters.js:13-17` docstring)
- `retrospective_type` is reserved for handoff-phase retros (`LEAD_TO_PLAN`, `PLAN_TO_EXEC`, etc., set by `executors/lead-to-plan/retrospective.js:283-284`)
- Setting both fields was belt-and-suspenders that broke the very gate it was trying to satisfy

## Files
- `scripts/modules/orchestrator-completion-guardian.js` — drop one line
- `scripts/modules/handoff/orchestrator-completion-guardian.js` — drop one line
- `docs/guides/self-improvement-system-guide.md` — drop matching example line
- `scripts/modules/handoff/orchestrator-completion-guardian-retro-shape.test.js` — new (locks in the shape)

## Test plan
- [x] New regression test passes (2 cases, one per guardian file)
- [x] Existing `retro-filters.test.js` still green (12 tests)
- [x] `retrospective-quality.test.js` still green (8 tests)
- [x] `retrospective-exists.test.js` still green (4 tests)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)