### PR TITLE
fix(SD-LEO-FIX-COMPLETE-QUICK-FIX-001): use PR metadata as authoritative source in autoDetectGitInfo

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -46,9 +46,82 @@ function sanitizeCommitMessage(message) {
 }
 
 /**
- * Auto-detect git information from repository
- * @param {string} testDir - Directory to run git commands in
- * @param {object} options - Existing options that may override detection
+ * Extract PR number from a GitHub PR URL.
+ * @param {string} prUrl
+ * @returns {number|null}
+ */
+export function extractPRNumber(prUrl) {
+  if (!prUrl || typeof prUrl !== 'string') return null;
+  const match = prUrl.match(/\/pull\/(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Detect whether testDir is inside a recognized QF worktree
+ * (i.e. .worktrees/qf/QF-* or .worktrees/QF-*). Used to decide whether the
+ * legacy CWD-HEAD auto-detect is safe to run.
+ * @param {string} testDir
+ * @returns {boolean}
+ */
+export function isInQFWorktree(testDir) {
+  try {
+    const gitDir = execSync('git rev-parse --git-dir', { cwd: testDir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    if (!gitDir.includes('worktrees')) return false;
+    const normalized = (testDir || '').replace(/\\/g, '/');
+    return /\/\.worktrees\/(qf\/)?QF-/i.test(normalized);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch PR metadata via the gh CLI. Loud-fails on any error — callers MUST
+ * NOT silently fall back to CWD HEAD; that is the bug class this fix closes.
+ * @param {number} prNumber
+ * @param {string} testDir
+ * @returns {object} Parsed JSON: { state, headRefName, mergeCommit, additions, deletions, url }
+ */
+export function fetchPRMetadata(prNumber, testDir) {
+  const fields = 'state,headRefName,mergeCommit,additions,deletions,url';
+  let raw;
+  try {
+    raw = execSync(`gh pr view ${prNumber} --json ${fields}`, {
+      cwd: testDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+  } catch (e) {
+    const code = e.status ?? '?';
+    const stderr = (e.stderr ? e.stderr.toString() : '').trim().split('\n')[0];
+    throw new Error(`gh pr view ${prNumber} exited ${code}${stderr ? `: ${stderr}` : ''}. Cannot resolve PR metadata; pass --commit-sha/--branch-name/--actual-loc explicitly or fix gh auth.`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`gh pr view ${prNumber} returned non-JSON output. Cannot resolve PR metadata.`);
+  }
+  if (!parsed || typeof parsed.state !== 'string') {
+    throw new Error(`gh pr view ${prNumber} returned malformed JSON (missing state). Cannot resolve PR metadata.`);
+  }
+  return parsed;
+}
+
+/**
+ * Auto-detect git information for a quick-fix completion.
+ *
+ * Priority order:
+ *   1. Explicit values from `options` (commitSha / branchName / actualLoc) win.
+ *   2. If `options.prUrl` is supplied → drive detection from `gh pr view <#>`
+ *      (canonical post-merge artifact). Failures are LOUD — no silent
+ *      fallback to CWD HEAD.
+ *   3. Else if testDir is inside a QF worktree → legacy git-rev-parse path.
+ *   4. Else → throw with operator-readable remediation. Refusing to act is
+ *      strictly better than silently producing wrong values (witnessed twice
+ *      in 24h: QF-20260424-808, QF-20260424-081).
+ *
+ * @param {string} testDir - Directory to run git/gh commands in
+ * @param {object} options - May contain commitSha / branchName / actualLoc / prUrl
  * @returns {object} Git info with commitSha, branchName, actualLoc
  */
 export function autoDetectGitInfo(testDir, options = {}) {
@@ -58,6 +131,56 @@ export function autoDetectGitInfo(testDir, options = {}) {
     actualLoc: options.actualLoc
   };
 
+  // Fast path: nothing to detect.
+  if (result.commitSha && result.branchName && result.actualLoc) {
+    return result;
+  }
+
+  // ── PR-metadata authoritative path ────────────────────────────────────
+  if (options.prUrl) {
+    const prNumber = extractPRNumber(options.prUrl);
+    if (!prNumber) {
+      throw new Error(`Invalid --pr-url '${options.prUrl}': expected GitHub PR URL (e.g., https://github.com/org/repo/pull/123)`);
+    }
+    const pr = fetchPRMetadata(prNumber, testDir);
+
+    if (!result.commitSha) {
+      if (pr.state === 'MERGED' && pr.mergeCommit?.oid) {
+        result.commitSha = pr.mergeCommit.oid;
+        console.log(`🔍 PR #${prNumber} (merged) → commit SHA: ${result.commitSha.substring(0, 7)}`);
+      } else if (pr.state === 'OPEN') {
+        console.log(`🔍 PR #${prNumber} is OPEN — commit SHA not derivable from PR metadata yet`);
+      } else {
+        throw new Error(`PR #${prNumber} is in unexpected state '${pr.state}' (expected MERGED or OPEN). Cannot derive commit SHA.`);
+      }
+    }
+
+    if (!result.branchName && pr.headRefName) {
+      result.branchName = pr.headRefName;
+      console.log(`🔍 PR #${prNumber} → branch: ${result.branchName}`);
+    }
+
+    if (!result.actualLoc) {
+      // gh additions+deletions overcounts vs git --shortstat for renames, but feeds the
+      // 50-LOC hard-cap fail-safely (stricter, never under-rejects).
+      const additions = typeof pr.additions === 'number' ? pr.additions : 0;
+      const deletions = typeof pr.deletions === 'number' ? pr.deletions : 0;
+      result.actualLoc = additions + deletions;
+      console.log(`🔍 PR #${prNumber} → actual LOC: ${result.actualLoc} (${additions} additions + ${deletions} deletions)\n`);
+    }
+    return result;
+  }
+
+  // ── No --pr-url: refuse-to-auto-detect outside QF worktree ─────────────
+  if (!isInQFWorktree(testDir)) {
+    throw new Error(
+      `Cannot auto-detect git info: CWD '${testDir}' is not a recognized QF worktree, ` +
+      `and --pr-url was not supplied. Pass --commit-sha / --branch-name / --actual-loc explicitly, ` +
+      `or pass --pr-url <github-pr-url> for post-merge auto-detection.`
+    );
+  }
+
+  // ── Legacy in-worktree path (regression-safe) ──────────────────────────
   try {
     if (!result.commitSha) {
       result.commitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd: testDir }).trim();

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -92,8 +92,16 @@ export async function completeQuickFix(qfId, options = {}) {
     return qf;
   }
 
-  // Auto-detect git info
-  const gitInfo = autoDetectGitInfo(testDir, options);
+  // Auto-detect git info. autoDetectGitInfo NOW throws on PR-metadata failure
+  // and on refuse-to-auto-detect-outside-QF-worktree (SD-LEO-FIX-COMPLETE-QUICK-FIX-001).
+  // Surface the operator-readable message without the Node stack trace.
+  let gitInfo;
+  try {
+    gitInfo = autoDetectGitInfo(testDir, options);
+  } catch (e) {
+    console.error(`\n❌ ${e.message}\n`);
+    process.exit(1);
+  }
   let { commitSha, branchName, actualLoc } = gitInfo;
 
   // Manual input if not provided

--- a/tests/unit/complete-quick-fix/autodetect-git-info.test.js
+++ b/tests/unit/complete-quick-fix/autodetect-git-info.test.js
@@ -1,0 +1,205 @@
+/**
+ * autoDetectGitInfo unit tests
+ * SD-LEO-FIX-COMPLETE-QUICK-FIX-001
+ *
+ * Covers the four runtime paths:
+ *   1. PR merged + branch deleted → mergeCommit.oid + headRefName + summed LOC
+ *   2. gh exits non-zero → throws operator-readable error (no silent fallback)
+ *   3. No --pr-url + CWD NOT a QF worktree → refuse-to-auto-detect throws
+ *   4. No --pr-url + CWD IS a QF worktree → legacy git rev-parse path (regression)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const {
+  autoDetectGitInfo,
+  extractPRNumber,
+  isInQFWorktree,
+  fetchPRMetadata,
+} = await import('../../../scripts/modules/complete-quick-fix/git-operations.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('extractPRNumber', () => {
+  it('parses standard GitHub PR URL', () => {
+    expect(extractPRNumber('https://github.com/rickfelix/EHG_Engineer/pull/3331')).toBe(3331);
+  });
+  it('returns null for non-PR URL', () => {
+    expect(extractPRNumber('https://github.com/rickfelix/EHG_Engineer/issues/5')).toBeNull();
+  });
+  it('returns null for empty/invalid input', () => {
+    expect(extractPRNumber(null)).toBeNull();
+    expect(extractPRNumber('')).toBeNull();
+    expect(extractPRNumber(123)).toBeNull();
+  });
+});
+
+describe('autoDetectGitInfo — PR-metadata authoritative path', () => {
+  it('Path 1: PR merged + branch deleted → returns mergeCommit.oid + headRefName + (additions+deletions)', () => {
+    execSync.mockReturnValueOnce(JSON.stringify({
+      state: 'MERGED',
+      headRefName: 'qf/QF-EXAMPLE-001',
+      mergeCommit: { oid: 'a1b2c3d4e5f6789012345678901234567890abcd' },
+      additions: 80,
+      deletions: 5,
+      url: 'https://github.com/org/repo/pull/999',
+    }));
+
+    const result = autoDetectGitInfo('C:/main-repo', {
+      prUrl: 'https://github.com/org/repo/pull/999',
+    });
+
+    expect(result.commitSha).toBe('a1b2c3d4e5f6789012345678901234567890abcd');
+    expect(result.branchName).toBe('qf/QF-EXAMPLE-001');
+    expect(result.actualLoc).toBe(85);
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync.mock.calls[0][0]).toContain('gh pr view 999');
+  });
+
+  it('Path 2: gh exits non-zero → throws operator-readable error (no silent fallback to CWD HEAD)', () => {
+    const ghError = Object.assign(new Error('gh failed'), {
+      status: 1,
+      stderr: Buffer.from('gh: authentication required\n'),
+    });
+    execSync.mockImplementationOnce(() => { throw ghError; });
+
+    expect(() => autoDetectGitInfo('C:/main-repo', {
+      prUrl: 'https://github.com/org/repo/pull/999',
+    })).toThrow(/gh pr view 999 exited 1/);
+
+    // Must NOT fall back to git rev-parse HEAD on gh failure
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync.mock.calls[0][0]).toContain('gh pr view 999');
+  });
+
+  it('Open PR returns headRefName + summed LOC even when mergeCommit is null', () => {
+    execSync.mockReturnValueOnce(JSON.stringify({
+      state: 'OPEN',
+      headRefName: 'feat/SD-FOO-001',
+      mergeCommit: null,
+      additions: 30,
+      deletions: 10,
+      url: 'https://github.com/org/repo/pull/100',
+    }));
+
+    const result = autoDetectGitInfo('C:/main-repo', {
+      prUrl: 'https://github.com/org/repo/pull/100',
+    });
+
+    expect(result.commitSha).toBeUndefined(); // open PR — caller must source commitSha elsewhere
+    expect(result.branchName).toBe('feat/SD-FOO-001');
+    expect(result.actualLoc).toBe(40);
+  });
+
+  it('Throws on unexpected PR state (e.g., CLOSED)', () => {
+    execSync.mockReturnValueOnce(JSON.stringify({
+      state: 'CLOSED',
+      headRefName: 'feat/old-branch',
+      mergeCommit: null,
+      additions: 0,
+      deletions: 0,
+    }));
+
+    expect(() => autoDetectGitInfo('C:/main-repo', {
+      prUrl: 'https://github.com/org/repo/pull/777',
+    })).toThrow(/unexpected state 'CLOSED'/);
+  });
+
+  it('Throws on invalid --pr-url', () => {
+    expect(() => autoDetectGitInfo('C:/main-repo', {
+      prUrl: 'not-a-url',
+    })).toThrow(/Invalid --pr-url/);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('autoDetectGitInfo — no --pr-url paths', () => {
+  it('Path 3: CWD NOT in a QF worktree → throws refuse-to-auto-detect', () => {
+    // git rev-parse --git-dir succeeds but path does NOT match worktrees pattern
+    execSync.mockReturnValueOnce('.git\n');
+
+    expect(() => autoDetectGitInfo('C:/Users/rickf/Projects/_EHG/EHG_Engineer', {})).toThrow(
+      /Cannot auto-detect git info/
+    );
+
+    // Must NOT proceed to git rev-parse HEAD
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync.mock.calls[0][0]).toContain('git rev-parse --git-dir');
+  });
+
+  it('Path 4: CWD IS in a QF worktree → legacy git rev-parse path runs (regression-safe)', () => {
+    const wtPath = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/qf/QF-20260424-808';
+    execSync
+      .mockReturnValueOnce('C:/Users/rickf/Projects/_EHG/EHG_Engineer/.git/worktrees/QF-20260424-808\n') // git rev-parse --git-dir (isInQFWorktree)
+      .mockReturnValueOnce('2f97e7a78a516eed10172f328df5421f0d7fa8cf\n') // git rev-parse HEAD
+      .mockReturnValueOnce('qf/QF-20260424-808\n') // git rev-parse --abbrev-ref HEAD
+      .mockReturnValueOnce(' 1 file changed, 90 insertions(+)\n'); // git diff --shortstat
+
+    const result = autoDetectGitInfo(wtPath, {});
+
+    expect(result.commitSha).toBe('2f97e7a78a516eed10172f328df5421f0d7fa8cf');
+    expect(result.branchName).toBe('qf/QF-20260424-808');
+    expect(result.actualLoc).toBe(90);
+  });
+});
+
+describe('autoDetectGitInfo — explicit options short-circuit', () => {
+  it('returns immediately when all three values are explicit', () => {
+    const result = autoDetectGitInfo('C:/anywhere', {
+      commitSha: 'deadbeef',
+      branchName: 'feat/explicit',
+      actualLoc: 42,
+    });
+    expect(result).toEqual({
+      commitSha: 'deadbeef',
+      branchName: 'feat/explicit',
+      actualLoc: 42,
+    });
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('isInQFWorktree', () => {
+  it('returns true for .worktrees/qf/QF-* path', () => {
+    execSync.mockReturnValueOnce('/some/.git/worktrees/X\n');
+    expect(isInQFWorktree('C:/repo/.worktrees/qf/QF-20260424-808')).toBe(true);
+  });
+  it('returns true for .worktrees/QF-* path', () => {
+    execSync.mockReturnValueOnce('/some/.git/worktrees/X\n');
+    expect(isInQFWorktree('C:/repo/.worktrees/QF-20260424-808')).toBe(true);
+  });
+  it('returns false for SD worktree (not QF)', () => {
+    execSync.mockReturnValueOnce('/some/.git/worktrees/X\n');
+    expect(isInQFWorktree('C:/repo/.worktrees/SD-FOO-001')).toBe(false);
+  });
+  it('returns false when git rev-parse fails', () => {
+    execSync.mockImplementationOnce(() => { throw new Error('not a git repo'); });
+    expect(isInQFWorktree('C:/some/random/path')).toBe(false);
+  });
+});
+
+describe('fetchPRMetadata', () => {
+  it('parses valid JSON response', () => {
+    execSync.mockReturnValueOnce(JSON.stringify({ state: 'MERGED', headRefName: 'x' }));
+    const result = fetchPRMetadata(123, 'C:/repo');
+    expect(result.state).toBe('MERGED');
+    expect(result.headRefName).toBe('x');
+  });
+  it('throws on non-JSON response', () => {
+    execSync.mockReturnValueOnce('not json at all');
+    expect(() => fetchPRMetadata(123, 'C:/repo')).toThrow(/non-JSON/);
+  });
+  it('throws on JSON missing state field', () => {
+    execSync.mockReturnValueOnce(JSON.stringify({ headRefName: 'x' }));
+    expect(() => fetchPRMetadata(123, 'C:/repo')).toThrow(/malformed JSON/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the silent-wrong-answer flow in `complete-quick-fix.js` that surfaced twice in 24 hours (QF-20260424-808 and QF-20260424-081). When `--pr-url` is supplied, `autoDetectGitInfo` now drives commit SHA / branch / LOC from `gh pr view <#> --json` instead of `git rev-parse HEAD` against a CWD that no longer corresponds to the QF after worktree cleanup.

## Behavior changes (`scripts/modules/complete-quick-fix/git-operations.js`)
1. **PR-metadata authoritative path** — when `--pr-url` is supplied, the merged/open PR is the source of truth (canonical post-merge artifact).
   - `state=MERGED` → `mergeCommit.oid` + `headRefName` + `(additions+deletions)`
   - `state=OPEN` → `headRefName` + summed LOC
   - `gh` failure → throws operator-readable error. **No silent fallback to CWD HEAD.** This is the bug-class this fix closes.
2. **Refuse-to-auto-detect outside QF worktree** — when `--pr-url` is not supplied AND CWD is not a recognized QF worktree (`.worktrees/qf/QF-*` or `.worktrees/QF-*`), throws with remediation hint.
3. **Legacy in-worktree path preserved** — byte-identical `git rev-parse` flow when CWD is a real QF worktree (regression-safe).
4. **Fast path** — explicit `--commit-sha`/`--branch-name`/`--actual-loc` short-circuit before any shell invocation.

New exports: `extractPRNumber`, `isInQFWorktree`, `fetchPRMetadata`.

`orchestrator.js` wraps the call in try/catch so the new throws print operator-readable messages instead of Node stack traces (REGRESSION-agent's CONDITIONAL_PASS recommendation).

## Tests
First test file for `complete-quick-fix` module: `tests/unit/complete-quick-fix/autodetect-git-info.test.js` — 18 vitest assertions across 5 describe blocks, mocks `child_process.execSync` via `vi.mock`. Mock JSON shapes verified against live `gh pr view 3331` output.

```
Test Files  1 passed (1)
     Tests  18 passed (18)
   Duration  348ms
```

## Test plan
- [x] `node --check` passes on both modified files
- [x] `npx vitest run tests/unit/complete-quick-fix/autodetect-git-info.test.js` — 18/18 PASS in 348ms
- [x] TESTING sub-agent: PASS (confidence 95) — `sub_agent_execution_results` row `3073b8f5-539a-4775-b902-2b23bdee4972`
- [x] REGRESSION sub-agent: CONDITIONAL_PASS (confidence 92) — recommendation applied — row `ef1a6f4e-6bda-499d-8ffe-dd0215ddae06`
- [x] Live `gh pr view 3331` output schema matches mock JSON shape
- [ ] Post-merge dogfood: invoke `complete-quick-fix.js QF-XXX --pr-url <url>` from main repo with QF branch already deleted → script extracts mergeCommit.oid + headRefName + summed LOC without prompting (cannot test in-tree because the QF that fixes its own escalation is the target)

## PR size justification (Tier 3, 334 LOC)
- Implementation alone is 126 LOC net (Tier 2)
- Tests are 205 LOC — necessary for resilience: this is the third attempt-class of fix on this surface (QF-808 fix opened, QF-081 noted Windows-side fragility, this SD adds the structural guard)
- Splitting impl from tests would leave the new branches uncovered for an unknown merge window — exactly the class of risk the fix exists to eliminate

## Cross-references
- Source QF: QF-20260425-863 (escalated to this SD via the brand-new `--from-qf` flag from QF-808 — first real-world dogfood of that fix)
- Sibling SD: `SD-LEO-INFRA-SHIP-INVOKE-COMPLETE-001` (draft) closes the companion workflow gap inside `/ship`'s post-merge ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)