### PR TITLE
feat(SD-LEO-INFRA-CLEANUP-ENGINE-HARDENING-001): bulk classify + git-history rule auto-derive + --auto-safe

### DIFF
--- a/.claude/cleanup-rules.json
+++ b/.claude/cleanup-rules.json
@@ -27,10 +27,15 @@
       {"pattern": ".claude/fleet-identity*.json", "reason": "Session-generated fleet identity"},
       {"pattern": ".claude/scheduled_tasks.lock", "reason": "Runtime lock file"},
       {"pattern": ".leo-validation/", "reason": "Runtime validation directory"},
-      {"pattern": ".quickfix-evidence/", "reason": "Runtime QF evidence directory"}
+      {"pattern": ".quickfix-evidence/", "reason": "Runtime QF evidence directory"},
+      {"pattern": ".claude-work/", "reason": "Runtime work directory (sibling of .claude-locks/)"},
+      {"pattern": ".claude/pids/", "reason": "Daemon PID files (sibling of .claude/logs/)"},
+      {"pattern": ".claude/*-state.json", "reason": "Runtime state files (worktree-reaper, etc.)"},
+      {"pattern": ".claude/session-*.md", "reason": "Ephemeral per-session notes"}
     ],
     "commit": [
-      {"pattern": "database/migrations/*.sql", "reason": "Applied but untracked migrations"}
+      {"pattern": "database/migrations/*.sql", "reason": "Applied but untracked migrations"},
+      {"pattern": "docs/plans/archived/*-plan.md", "reason": "Archived SD planning artifacts (sibling of tracked *-vision.md / *-architecture.md)"}
     ]
   },
   "learned": [],

--- a/.claude/commands/leo-cleanup.md
+++ b/.claude/commands/leo-cleanup.md
@@ -33,7 +33,32 @@ This will:
 3. Stage files matching commit rules (actual commit done via /ship)
 4. Skip REVIEW items for interactive handling
 
-### For REVIEW items (files with no matching rule):
+### Bulk classification (recommended when REVIEW has clusters):
+
+The engine groups REVIEW items by inferred dirname/glob (≥3 files per cluster).
+For each cluster, present a single AskUserQuestion to classify the whole group
+in one round-trip instead of one prompt per file:
+
+```javascript
+{
+  "questions": [{
+    "question": "Cluster: <pattern> (<N> files matching).\nExamples: <first 3 filenames>",
+    "header": "Classify cluster",
+    "multiSelect": false,
+    "options": [
+      {"label": "Delete all", "description": "Remove all <N> files matching this pattern"},
+      {"label": "Gitignore", "description": "Add the pattern to .gitignore"},
+      {"label": "Commit all", "description": "Stage all <N> files for commit"},
+      {"label": "Skip", "description": "Fall through to per-file review"}
+    ]
+  }]
+}
+```
+
+After bulk classification, optionally persist the cluster pattern as a learned rule
+via learnRule() so future scans auto-categorize the same shape.
+
+### For unclustered REVIEW items (files with no matching rule):
 
 Present each unknown file to the user one at a time using AskUserQuestion:
 
@@ -81,7 +106,23 @@ learnRule(filepath, category, reason);
 node scripts/repo-cleanup.js --json
 ```
 
-Returns structured JSON for programmatic use by other scripts.
+Returns structured JSON for programmatic use by other scripts. Each item
+includes `size_bytes` and `age_days` fields (null for paths that cannot be stat'd).
+
+### Auto-safe mode (CI / scheduled runs):
+
+```bash
+AUTO_PROCEED=true node scripts/repo-cleanup.js --auto-safe --execute
+```
+
+Under AUTO-PROCEED, `--auto-safe` auto-applies clusters that match a
+high-confidence rule suggestion derived from `git log --diff-filter=A`
+(default: ≥2 prior commits introduced files matching the inferred pattern).
+Safety guarantees:
+- Never auto-applies category=delete (irreversible actions stay interactive)
+- Each applied action appended to `.claude/cleanup-audit-log.jsonl`
+- Disable globally via `CLEANUP_AUTO_SAFE_ENABLED=false` env var
+- No-op without AUTO-PROCEED — flag falls through to standard prompt flow
 
 ## Integration
 
@@ -96,4 +137,12 @@ This command is integrated at these pipeline points:
 | (none) | Dry run — scan and display |
 | `--execute` | Apply all rule-matched actions |
 | `--no-learn` | Disable rule learning prompts |
-| `--json` | Output JSON instead of table |
+| `--json` | Output JSON instead of table (items include size_bytes + age_days) |
+| `--auto-safe` | Auto-apply high-confidence cluster verdicts under AUTO-PROCEED (no-op otherwise; never deletes) |
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `AUTO_PROCEED=true` | Required for `--auto-safe` to take effect |
+| `CLEANUP_AUTO_SAFE_ENABLED=false` | Kill switch — `--auto-safe` becomes a no-op |

--- a/scripts/modules/cleanup/audit-log.js
+++ b/scripts/modules/cleanup/audit-log.js
@@ -1,0 +1,31 @@
+/**
+ * Append-only JSONL audit logger for --auto-safe applied actions.
+ *
+ * Failure to write does not block the underlying cleanup action; the
+ * warning surfaces on stderr so orchestration can still complete.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export const DEFAULT_AUDIT_LOG_PATH = '.claude/cleanup-audit-log.jsonl';
+
+export function appendAuditEntry(entry, options = {}) {
+  const repoRoot = options.repoRoot || process.cwd();
+  const relativePath = options.logPath || DEFAULT_AUDIT_LOG_PATH;
+  const fullPath = path.isAbsolute(relativePath) ? relativePath : path.join(repoRoot, relativePath);
+
+  const record = {
+    timestamp: new Date().toISOString(),
+    ...entry
+  };
+
+  try {
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.appendFileSync(fullPath, JSON.stringify(record) + '\n');
+    return { ok: true, path: fullPath };
+  } catch (err) {
+    console.warn(`⚠️  cleanup-audit-log: failed to write ${fullPath}: ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+}

--- a/scripts/modules/cleanup/audit-log.test.js
+++ b/scripts/modules/cleanup/audit-log.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { appendAuditEntry, DEFAULT_AUDIT_LOG_PATH } from './audit-log.js';
+
+let tmpRoot;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-log-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('appendAuditEntry', () => {
+  it('writes one JSON line with timestamp + payload fields', () => {
+    const result = appendAuditEntry(
+      { file: 'a.md', category: 'commit', pattern: 'docs/*.md', occurrences: 4 },
+      { repoRoot: tmpRoot }
+    );
+    expect(result.ok).toBe(true);
+    const written = fs.readFileSync(result.path, 'utf8').trim().split('\n');
+    expect(written).toHaveLength(1);
+    const record = JSON.parse(written[0]);
+    expect(record.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(record.file).toBe('a.md');
+    expect(record.category).toBe('commit');
+    expect(record.occurrences).toBe(4);
+  });
+
+  it('appends without overwriting existing lines', () => {
+    appendAuditEntry({ file: 'one.md' }, { repoRoot: tmpRoot });
+    appendAuditEntry({ file: 'two.md' }, { repoRoot: tmpRoot });
+    const fullPath = path.join(tmpRoot, DEFAULT_AUDIT_LOG_PATH);
+    const lines = fs.readFileSync(fullPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).file).toBe('one.md');
+    expect(JSON.parse(lines[1]).file).toBe('two.md');
+  });
+
+  it('returns ok:false on write failure (parent path is a file, not a directory)', () => {
+    const blockingFile = path.join(tmpRoot, 'blocking-file');
+    fs.writeFileSync(blockingFile, 'I am a file, not a directory');
+    const result = appendAuditEntry(
+      { file: 'a.md' },
+      { logPath: path.join(blockingFile, 'audit.jsonl') }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/scripts/modules/cleanup/auto-safe.test.js
+++ b/scripts/modules/cleanup/auto-safe.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { applyAutoSafe } from '../../repo-cleanup.js';
+
+function r(file) { return { file, reason: 'no matching rule' }; }
+
+describe('applyAutoSafe', () => {
+  it('promotes a high-confidence cluster from review to commit', () => {
+    const review = Array.from({ length: 5 }, (_, i) => r(`docs/plans/archived/sd-${i}.md`));
+    const categories = { delete: [], gitignore: [], commit: [], review };
+    const suggestions = [{ pattern: 'docs/plans/archived/*.md', category: 'commit', occurrences: 4, reason: 'seed' }];
+    const result = applyAutoSafe(categories, { suggestions });
+    expect(result.stats.applied).toBe(5);
+    expect(result.categories.commit).toHaveLength(5);
+    expect(result.categories.review).toHaveLength(0);
+    expect(result.applied[0].pattern).toBe('docs/plans/archived/*.md');
+  });
+
+  it('defers low-confidence clusters (occurrences < minOccurrences)', () => {
+    const review = Array.from({ length: 3 }, (_, i) => r(`docs/plans/archived/sd-${i}.md`));
+    const categories = { delete: [], gitignore: [], commit: [], review };
+    const suggestions = [{ pattern: 'docs/plans/archived/*.md', category: 'commit', occurrences: 1, reason: 'noise' }];
+    const result = applyAutoSafe(categories, { suggestions, minOccurrences: 2 });
+    expect(result.stats.applied).toBe(0);
+    expect(result.stats.deferred).toBe(3);
+    expect(result.categories.review).toHaveLength(3);
+  });
+
+  it('refuses to auto-apply delete category even at high confidence', () => {
+    const review = Array.from({ length: 4 }, (_, i) => r(`scripts/oneoff-${i}.js`));
+    const categories = { delete: [], gitignore: [], commit: [], review };
+    const suggestions = [{ pattern: 'scripts/*.js', category: 'delete', occurrences: 99, reason: 'whatever' }];
+    const result = applyAutoSafe(categories, { suggestions });
+    expect(result.stats.applied).toBe(0);
+    expect(result.stats.skipped_delete).toBe(4);
+    expect(result.categories.delete).toHaveLength(0);
+  });
+
+  it('returns categories unchanged when no suggestions provided', () => {
+    const categories = { delete: [], gitignore: [], commit: [], review: [r('a/b.md')] };
+    const result = applyAutoSafe(categories, { suggestions: [] });
+    expect(result.applied).toHaveLength(0);
+    expect(result.categories).toBe(categories);
+  });
+
+  it('skips when no clusters meet the size threshold', () => {
+    const categories = { delete: [], gitignore: [], commit: [], review: [r('a/b.md'), r('a/c.md')] };
+    const suggestions = [{ pattern: 'a/*.md', category: 'commit', occurrences: 5, reason: 'x' }];
+    const result = applyAutoSafe(categories, { suggestions });
+    expect(result.stats.applied).toBe(0);
+    expect(result.applied).toHaveLength(0);
+  });
+});

--- a/scripts/modules/cleanup/derive-rules.js
+++ b/scripts/modules/cleanup/derive-rules.js
@@ -1,0 +1,64 @@
+/**
+ * Derive commit-category rule suggestions from git log.
+ *
+ * Mines added-file paths (--diff-filter=A) and proposes patterns whose
+ * inferred dirname/extension recurs across enough prior commits to be
+ * non-coincidental. Suggestions are commit-only by design — never delete.
+ */
+
+import { execSync } from 'child_process';
+import { inferPattern } from './group-review.js';
+
+export const DEFAULT_MIN_COMMITS = 2;
+export const DEFAULT_MAX_COMMITS_SCANNED = 1000;
+
+export function parseAddedFiles(output) {
+  if (!output) return [];
+  const paths = [];
+  for (const raw of output.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    paths.push(line.replace(/\\/g, '/'));
+  }
+  return paths;
+}
+
+function runGitLog(repoPath, maxCommits) {
+  const cmd = `git -C "${repoPath}" log --diff-filter=A --pretty= --name-only -n ${maxCommits}`;
+  return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+export function deriveRulesFromGitLog(options = {}) {
+  const {
+    repoPath = process.cwd(),
+    minCommits = DEFAULT_MIN_COMMITS,
+    maxCommitsScanned = DEFAULT_MAX_COMMITS_SCANNED,
+    rawLog
+  } = options;
+
+  let output;
+  try {
+    output = rawLog ?? runGitLog(repoPath, maxCommitsScanned);
+  } catch {
+    return [];
+  }
+
+  const counts = new Map();
+  for (const filePath of parseAddedFiles(output)) {
+    const pattern = inferPattern(filePath);
+    counts.set(pattern, (counts.get(pattern) || 0) + 1);
+  }
+
+  const suggestions = [];
+  for (const [pattern, occurrences] of counts) {
+    if (occurrences < minCommits) continue;
+    suggestions.push({
+      pattern,
+      category: 'commit',
+      reason: `Recurring added-file pattern (${occurrences} prior commits)`,
+      occurrences
+    });
+  }
+  suggestions.sort((a, b) => b.occurrences - a.occurrences || a.pattern.localeCompare(b.pattern));
+  return suggestions;
+}

--- a/scripts/modules/cleanup/derive-rules.test.js
+++ b/scripts/modules/cleanup/derive-rules.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { deriveRulesFromGitLog, parseAddedFiles, DEFAULT_MIN_COMMITS } from './derive-rules.js';
+
+const SAMPLE_LOG = [
+  'scripts/migration-2024-01.sql',
+  '',
+  'scripts/migration-2024-02.sql',
+  '',
+  'scripts/migration-2024-03.sql',
+  '',
+  'scripts/migration-2024-04.sql',
+  '',
+  'scripts/oneoff.js',
+  '',
+  'docs/plans/archived/sd-foo-plan.md',
+  'docs/plans/archived/sd-bar-plan.md'
+].join('\n');
+
+describe('parseAddedFiles', () => {
+  it('returns one entry per non-empty line, normalised', () => {
+    const paths = parseAddedFiles('a/b.js\n\n c\\d.js\n');
+    expect(paths).toEqual(['a/b.js', 'c/d.js']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseAddedFiles('')).toEqual([]);
+    expect(parseAddedFiles(undefined)).toEqual([]);
+  });
+});
+
+describe('deriveRulesFromGitLog', () => {
+  it('suggests rule for recurring scripts/migration-*.sql pattern', () => {
+    const suggestions = deriveRulesFromGitLog({ rawLog: SAMPLE_LOG });
+    const migration = suggestions.find(s => s.pattern === 'scripts/*.sql');
+    expect(migration).toBeDefined();
+    expect(migration.category).toBe('commit');
+    expect(migration.occurrences).toBe(4);
+  });
+
+  it('honours minCommits floor (1 prior commit excluded)', () => {
+    const suggestions = deriveRulesFromGitLog({ rawLog: SAMPLE_LOG });
+    const oneoff = suggestions.find(s => s.pattern === 'scripts/*.js');
+    expect(oneoff).toBeUndefined();
+  });
+
+  it('never returns delete category', () => {
+    const suggestions = deriveRulesFromGitLog({ rawLog: SAMPLE_LOG });
+    expect(suggestions.every(s => s.category === 'commit')).toBe(true);
+  });
+
+  it('returns empty array on git failure', () => {
+    expect(deriveRulesFromGitLog({ repoPath: '/nonexistent/path-does-not-exist' })).toEqual([]);
+  });
+
+  it('orders suggestions by occurrences descending', () => {
+    const suggestions = deriveRulesFromGitLog({ rawLog: SAMPLE_LOG, minCommits: 2 });
+    for (let i = 1; i < suggestions.length; i++) {
+      expect(suggestions[i - 1].occurrences).toBeGreaterThanOrEqual(suggestions[i].occurrences);
+    }
+  });
+
+  it('respects custom minCommits override', () => {
+    const suggestions = deriveRulesFromGitLog({ rawLog: SAMPLE_LOG, minCommits: 5 });
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('default minCommits matches DEFAULT_MIN_COMMITS', () => {
+    expect(DEFAULT_MIN_COMMITS).toBe(2);
+  });
+});

--- a/scripts/modules/cleanup/group-review.js
+++ b/scripts/modules/cleanup/group-review.js
@@ -1,0 +1,51 @@
+/**
+ * Cluster REVIEW items by inferred dirname + extension glob.
+ *
+ * Below the cluster-size threshold, items fall through to per-file REVIEW.
+ * Pattern format mirrors existing rule patterns in .claude/cleanup-rules.json
+ * so any cluster verdict can later be persisted as a learned rule.
+ */
+
+import path from 'path';
+
+export const DEFAULT_MIN_CLUSTER_SIZE = 3;
+
+function inferPattern(filePath) {
+  const normalized = filePath.replace(/\\/g, '/').replace(/\/$/, '');
+  const dir = path.posix.dirname(normalized);
+  const base = path.posix.basename(normalized);
+  const ext = path.posix.extname(base);
+  if (!ext) {
+    return dir === '.' ? `/${base}` : `${dir}/${base}`;
+  }
+  return dir === '.' ? `/*${ext}` : `${dir}/*${ext}`;
+}
+
+export function groupReviewItems(items, options = {}) {
+  const minSize = options.minSize ?? DEFAULT_MIN_CLUSTER_SIZE;
+  if (!Array.isArray(items)) {
+    return { clusters: new Map(), unclustered: [] };
+  }
+
+  const buckets = new Map();
+  for (const item of items) {
+    const file = typeof item === 'string' ? item : item?.file;
+    if (!file) continue;
+    const pattern = inferPattern(file);
+    if (!buckets.has(pattern)) buckets.set(pattern, []);
+    buckets.get(pattern).push(item);
+  }
+
+  const clusters = new Map();
+  const unclustered = [];
+  for (const [pattern, members] of buckets) {
+    if (members.length >= minSize) {
+      clusters.set(pattern, members);
+    } else {
+      unclustered.push(...members);
+    }
+  }
+  return { clusters, unclustered };
+}
+
+export { inferPattern };

--- a/scripts/modules/cleanup/group-review.test.js
+++ b/scripts/modules/cleanup/group-review.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { groupReviewItems, inferPattern, DEFAULT_MIN_CLUSTER_SIZE } from './group-review.js';
+
+describe('inferPattern', () => {
+  it('produces a directory + extension glob for nested files', () => {
+    expect(inferPattern('docs/plans/archived/sd-leo-foo-plan.md')).toBe('docs/plans/archived/*.md');
+  });
+
+  it('anchors root-level files with leading slash', () => {
+    expect(inferPattern('foo.json')).toBe('/*.json');
+  });
+
+  it('preserves directory paths with trailing-slash inputs', () => {
+    expect(inferPattern('.claude-work/')).toBe('/.claude-work');
+  });
+});
+
+describe('groupReviewItems', () => {
+  it('clusters 10 plan files under one pattern', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      file: `docs/plans/archived/sd-leo-${i.toString().padStart(3, '0')}-plan.md`
+    }));
+    const { clusters, unclustered } = groupReviewItems(items);
+    expect(clusters.size).toBe(1);
+    expect(clusters.get('docs/plans/archived/*.md')?.length).toBe(10);
+    expect(unclustered).toHaveLength(0);
+  });
+
+  it('drops below-threshold groups to unclustered', () => {
+    const items = [
+      { file: 'docs/plans/archived/a.md' },
+      { file: 'docs/plans/archived/b.md' }
+    ];
+    const { clusters, unclustered } = groupReviewItems(items);
+    expect(clusters.size).toBe(0);
+    expect(unclustered).toHaveLength(2);
+  });
+
+  it('emits multiple clusters for mixed input', () => {
+    const items = [
+      ...Array.from({ length: 4 }, (_, i) => ({ file: `docs/plans/archived/p${i}.md` })),
+      ...Array.from({ length: 3 }, (_, i) => ({ file: `.claude/session-${i}.md` })),
+      ...Array.from({ length: 3 }, (_, i) => ({ file: `scripts/migration-${i}.sql` })),
+      { file: 'odd-one.txt' }
+    ];
+    const { clusters, unclustered } = groupReviewItems(items);
+    expect(clusters.size).toBe(3);
+    expect(clusters.get('docs/plans/archived/*.md')?.length).toBe(4);
+    expect(clusters.get('.claude/*.md')?.length).toBe(3);
+    expect(clusters.get('scripts/*.sql')?.length).toBe(3);
+    expect(unclustered.map(i => i.file)).toEqual(['odd-one.txt']);
+  });
+
+  it('respects custom minSize option', () => {
+    const items = [
+      { file: 'a/x.md' },
+      { file: 'a/y.md' }
+    ];
+    const { clusters } = groupReviewItems(items, { minSize: 2 });
+    expect(clusters.size).toBe(1);
+  });
+
+  it('accepts plain string items alongside objects', () => {
+    const items = ['docs/plans/archived/a.md', 'docs/plans/archived/b.md', 'docs/plans/archived/c.md'];
+    const { clusters } = groupReviewItems(items);
+    expect(clusters.size).toBe(1);
+    expect(clusters.get('docs/plans/archived/*.md')?.length).toBe(3);
+  });
+
+  it('default minSize matches DEFAULT_MIN_CLUSTER_SIZE', () => {
+    expect(DEFAULT_MIN_CLUSTER_SIZE).toBe(3);
+  });
+});

--- a/scripts/modules/cleanup/seed-pack.test.js
+++ b/scripts/modules/cleanup/seed-pack.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { categorize } from '../../repo-cleanup.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const RULES_PATH = path.resolve(__dirname, '..', '..', '..', '.claude', 'cleanup-rules.json');
+
+function loadRules() {
+  return JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+}
+
+const FIXTURE_2026_04_25 = [
+  '.claude-work/',
+  '.claude/pids/',
+  '.claude/session-module-refactor-opus47.md',
+  '.claude/worktree-reaper-state.json',
+  'docs/plans/archived/sd-leo-fix-cross-signal-claim-001-plan.md',
+  'docs/plans/archived/sd-leo-fix-plan-learn-composite-001-plan.md',
+  'docs/plans/archived/sd-leo-fix-plan-opus-harness-001-plan.md',
+  'docs/plans/archived/sd-leo-fix-session-lifecycle-hygiene-001-plan.md',
+  'docs/plans/archived/sd-leo-fix-worktree-quota-counter-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-creation-parser-hardening-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-cross-file-overlap-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-feedback-pipeline-health-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-fix-gate-file-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-formalized-worktree-reaper-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-lifecycle-reconciliation-orphan-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-opus-module-memory-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-opus-module-scope-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-opus-module-sub-001-plan.md',
+  'docs/plans/archived/sd-leo-infra-retrospective-gates-fail-001-plan.md',
+  'docs/plans/archived/sd-leo-refac-plan-memory-index-001-plan.md',
+  'scripts/spawn-tick-canonical.mjs'
+];
+
+describe('seed-pack regression (2026-04-25 working tree fixture)', () => {
+  const result = categorize(FIXTURE_2026_04_25, loadRules());
+
+  it('categorises 4 .claude/ runtime files to GITIGNORE', () => {
+    expect(result.gitignore.length).toBe(4);
+    const gitignoredPaths = result.gitignore.map(i => i.file);
+    expect(gitignoredPaths).toContain('.claude-work/');
+    expect(gitignoredPaths).toContain('.claude/pids/');
+    expect(gitignoredPaths).toContain('.claude/session-module-refactor-opus47.md');
+    expect(gitignoredPaths).toContain('.claude/worktree-reaper-state.json');
+  });
+
+  it('categorises 16 docs/plans/archived/*-plan.md files to COMMIT', () => {
+    expect(result.commit.length).toBe(16);
+    expect(result.commit.every(i => i.file.startsWith('docs/plans/archived/'))).toBe(true);
+  });
+
+  it('leaves only scripts/spawn-tick-canonical.mjs in REVIEW', () => {
+    expect(result.review.length).toBe(1);
+    expect(result.review[0].file).toBe('scripts/spawn-tick-canonical.mjs');
+  });
+
+  it('total categorisation matches the 21-file input', () => {
+    const total = result.delete.length + result.gitignore.length + result.commit.length + result.review.length;
+    expect(total).toBe(FIXTURE_2026_04_25.length);
+  });
+});

--- a/scripts/repo-cleanup.js
+++ b/scripts/repo-cleanup.js
@@ -15,11 +15,16 @@ import fs from 'fs';
 import path from 'path';
 import { minimatch } from 'minimatch';
 import { fileURLToPath } from 'url';
+import { groupReviewItems } from './modules/cleanup/group-review.js';
+import { deriveRulesFromGitLog } from './modules/cleanup/derive-rules.js';
+import { appendAuditEntry } from './modules/cleanup/audit-log.js';
+import { parseCliFlags as parseAutoProceedCli, parseEnvVar as parseAutoProceedEnv } from './modules/handoff/auto-proceed-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 const RULES_PATH = path.join(REPO_ROOT, '.claude', 'cleanup-rules.json');
+const AUTO_SAFE_KILL_SWITCH = process.env.CLEANUP_AUTO_SAFE_ENABLED !== 'false';
 
 // ── Rules ──────────────────────────────────────────────────────
 
@@ -105,12 +110,36 @@ export function categorize(files, rules) {
   return result;
 }
 
+// ── Enrichment ────────────────────────────────────────────────
+
+function enrichItem(item) {
+  const file = typeof item === 'string' ? { file: item } : item;
+  try {
+    const stat = fs.statSync(path.join(REPO_ROOT, file.file));
+    const size_bytes = stat.isDirectory() ? null : stat.size;
+    const age_days = Math.floor((Date.now() - stat.mtimeMs) / 86400000);
+    return { ...file, size_bytes, age_days };
+  } catch {
+    return { ...file, size_bytes: null, age_days: null };
+  }
+}
+
+function enrichCategories(categories) {
+  return {
+    delete: categories.delete.map(enrichItem),
+    gitignore: categories.gitignore.map(enrichItem),
+    commit: categories.commit.map(enrichItem),
+    review: categories.review.map(enrichItem)
+  };
+}
+
 // ── Scan API ───────────────────────────────────────────────────
 
-export function scan() {
+export function scan(options = {}) {
   const files = scanUntracked();
   const rules = loadRules();
-  return categorize(files, rules);
+  const categories = categorize(files, rules);
+  return options.enrich === false ? categories : enrichCategories(categories);
 }
 
 // ── Summary Display ────────────────────────────────────────────
@@ -247,20 +276,93 @@ export function learnRule(file, category, reason) {
 
 // ── CLI ────────────────────────────────────────────────────────
 
+function isAutoProceedActive(args) {
+  const cli = parseAutoProceedCli(args);
+  if (cli.value !== null) return cli.value;
+  const env = parseAutoProceedEnv();
+  if (env.value !== null) return env.value;
+  return false;
+}
+
+export function applyAutoSafe(categories, options = {}) {
+  const { suggestions = [], minOccurrences = 2 } = options;
+  const stats = { applied: 0, deferred: 0, skipped_delete: 0 };
+  if (!suggestions.length) {
+    return { categories, stats, applied: [] };
+  }
+  const suggestionByPattern = new Map(suggestions.map(s => [s.pattern, s]));
+  const { clusters } = groupReviewItems(categories.review);
+  if (!clusters.size) {
+    return { categories, stats, applied: [] };
+  }
+  const next = {
+    delete: [...categories.delete],
+    gitignore: [...categories.gitignore],
+    commit: [...categories.commit],
+    review: [...categories.review]
+  };
+  const applied = [];
+  for (const [pattern, members] of clusters) {
+    const sugg = suggestionByPattern.get(pattern);
+    if (!sugg || sugg.occurrences < minOccurrences) {
+      stats.deferred += members.length;
+      continue;
+    }
+    if (sugg.category === 'delete') {
+      stats.skipped_delete += members.length;
+      continue;
+    }
+    for (const member of members) {
+      const file = typeof member === 'string' ? member : member.file;
+      next[sugg.category].push({ file, reason: sugg.reason, source: 'auto-safe' });
+      next.review = next.review.filter(r => (typeof r === 'string' ? r : r.file) !== file);
+      applied.push({ file, category: sugg.category, pattern, occurrences: sugg.occurrences });
+      stats.applied++;
+    }
+  }
+  return { categories: next, stats, applied };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const execute = args.includes('--execute');
   const noLearn = args.includes('--no-learn');
   const jsonOutput = args.includes('--json');
+  const autoSafeFlag = args.includes('--auto-safe');
 
-  const categories = scan();
+  let categories = scan();
+
+  let autoSafeReport = null;
+  if (autoSafeFlag) {
+    if (!AUTO_SAFE_KILL_SWITCH) {
+      autoSafeReport = { skipped: 'CLEANUP_AUTO_SAFE_ENABLED=false (kill switch active)' };
+    } else if (!isAutoProceedActive(args)) {
+      autoSafeReport = { skipped: '--auto-safe is a no-op without AUTO-PROCEED (set AUTO_PROCEED=true or pass --auto-proceed)' };
+    } else {
+      const suggestions = deriveRulesFromGitLog({ repoPath: REPO_ROOT });
+      const result = applyAutoSafe(categories, { suggestions });
+      categories = result.categories;
+      autoSafeReport = { stats: result.stats, applied_count: result.applied.length };
+      for (const action of result.applied) {
+        appendAuditEntry(action, { repoRoot: REPO_ROOT });
+      }
+    }
+  }
 
   if (jsonOutput) {
-    console.log(JSON.stringify(categories, null, 2));
+    const payload = autoSafeReport ? { ...categories, auto_safe: autoSafeReport } : categories;
+    console.log(JSON.stringify(payload, null, 2));
     return;
   }
 
   presentSummary(categories);
+  if (autoSafeReport) {
+    if (autoSafeReport.skipped) {
+      console.log(`\n  --auto-safe: ${autoSafeReport.skipped}`);
+    } else {
+      console.log(`\n  --auto-safe: ${autoSafeReport.applied_count} action(s) auto-applied (deferred=${autoSafeReport.stats.deferred}, skipped_delete=${autoSafeReport.stats.skipped_delete})`);
+    }
+  }
 
   if (execute) {
     const total = categories.delete.length + categories.gitignore.length + categories.commit.length;


### PR DESCRIPTION
## Summary
Hardens `scripts/repo-cleanup.js` so cleanup scans do not require dozens of round-trip prompts. Verified seed-pack drops REVIEW count from 21 → 1 on the 2026-04-25 working tree.

- New `scripts/modules/cleanup/`: `group-review.js`, `derive-rules.js`, `audit-log.js`
- `scripts/repo-cleanup.js`: new `--auto-safe` CLI flag (under AUTO-PROCEED applies high-confidence ≥2-prior-commit cluster verdicts; never auto-deletes; honors `CLEANUP_AUTO_SAFE_ENABLED` kill switch); `size_bytes`+`age_days` enrichment on each scan() item
- `.claude/cleanup-rules.json` seed pack (5 rules): 4 gitignore + 1 commit
- `.claude/commands/leo-cleanup.md` documents bulk classify UX, `--auto-safe` flag

Backward compatible: scan() / categorize() / executeActions() / learnRule() signatures unchanged. /ship preflight integration shape preserved. No new external npm deps.

## Test plan
- [x] 30 vitest cases across 5 files all passing
- [x] Manual dry-run confirms JSON shape backward-compat + new fields
- [x] Seed-pack regression categorizes 21-file fixture as 4 GITIGNORE + 16 COMMIT + 1 REVIEW
- [x] Handoffs: LEAD-TO-PLAN @ 97%, PLAN-TO-EXEC @ 97%, PLAN-TO-LEAD @ 88%
- [ ] Post-merge: confirm /ship preflight unchanged on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)