### PR TITLE
fix(QF-20260425-087): vision-scorer prefers SD metadata.vision_key + arch_key over L1 default

### DIFF
--- a/scripts/eva/vision-scorer.js
+++ b/scripts/eva/vision-scorer.js
@@ -708,7 +708,24 @@ async function runPersistMode(sdKey, visionKey, archKey, scoreJson) {
   }
 }
 
+export const DEFAULT_VISION_KEY = 'VISION-EHG-L1-001';
+export const DEFAULT_ARCH_KEY = 'ARCH-EHG-L1-001';
+
+export async function resolveDefaultKeysFromSD(supabase, sdKey) {
+  if (!sdKey) return { vision_key: null, arch_key: null };
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('metadata')
+    .or(`id.eq.${sdKey},sd_key.eq.${sdKey}`)
+    .maybeSingle();
+  return {
+    vision_key: data?.metadata?.vision_key || null,
+    arch_key: data?.metadata?.arch_key || null
+  };
+}
+
 if (isMainModule(import.meta.url)) {
+  (async () => {
   const args = process.argv.slice(2);
 
   const getArg = (flag) => {
@@ -717,8 +734,8 @@ if (isMainModule(import.meta.url)) {
   };
 
   const sdKey = getArg('--sd-id');
-  const visionKey = getArg('--vision-key') || 'VISION-EHG-L1-001';
-  const archKey = getArg('--arch-key') || 'ARCH-EHG-L1-001';
+  const explicitVision = getArg('--vision-key');
+  const explicitArch = getArg('--arch-key');
   const scope = getArg('--scope');
   const dryRun = args.includes('--dry-run');
   const inline = args.includes('--inline');
@@ -727,6 +744,18 @@ if (isMainModule(import.meta.url)) {
   if (!sdKey && !scope) {
     console.error('Usage: node scripts/eva/vision-scorer.js --sd-id <SD-KEY> [--inline] [--persist <JSON>] [--dry-run]');
     process.exit(1);
+  }
+
+  let visionKey = explicitVision;
+  let archKey = explicitArch;
+  if ((!visionKey || !archKey) && sdKey) {
+    const supabase = createSupabaseServiceClient();
+    const fromMeta = await resolveDefaultKeysFromSD(supabase, sdKey);
+    visionKey = visionKey || fromMeta.vision_key || DEFAULT_VISION_KEY;
+    archKey = archKey || fromMeta.arch_key || DEFAULT_ARCH_KEY;
+  } else {
+    visionKey = visionKey || DEFAULT_VISION_KEY;
+    archKey = archKey || DEFAULT_ARCH_KEY;
   }
 
   // Inline mode: output context for Claude Code
@@ -785,4 +814,5 @@ if (isMainModule(import.meta.url)) {
         process.exit(1);
       });
   }
+  })().catch((err) => { console.error(err); process.exit(1); });
 }

--- a/scripts/eva/vision-scorer.test.js
+++ b/scripts/eva/vision-scorer.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDefaultKeysFromSD, DEFAULT_VISION_KEY, DEFAULT_ARCH_KEY } from './vision-scorer.js';
+
+function fakeSupabase(row) {
+  return {
+    from() { return this; },
+    select() { return this; },
+    or() { return this; },
+    maybeSingle: async () => ({ data: row, error: null })
+  };
+}
+
+describe('resolveDefaultKeysFromSD', () => {
+  it('returns nulls when sdKey is empty', async () => {
+    const result = await resolveDefaultKeysFromSD(null, null);
+    expect(result).toEqual({ vision_key: null, arch_key: null });
+  });
+
+  it('returns nulls when SD has no metadata', async () => {
+    const supabase = fakeSupabase({ metadata: null });
+    const result = await resolveDefaultKeysFromSD(supabase, 'SD-X');
+    expect(result).toEqual({ vision_key: null, arch_key: null });
+  });
+
+  it('returns vision_key + arch_key from SD metadata', async () => {
+    const supabase = fakeSupabase({ metadata: { vision_key: 'VISION-X-L2-001', arch_key: 'ARCH-X-001' } });
+    const result = await resolveDefaultKeysFromSD(supabase, 'SD-X');
+    expect(result).toEqual({ vision_key: 'VISION-X-L2-001', arch_key: 'ARCH-X-001' });
+  });
+
+  it('returns nulls when row not found', async () => {
+    const supabase = fakeSupabase(null);
+    const result = await resolveDefaultKeysFromSD(supabase, 'SD-MISSING');
+    expect(result).toEqual({ vision_key: null, arch_key: null });
+  });
+
+  it('exports L1 fallback constants', () => {
+    expect(DEFAULT_VISION_KEY).toBe('VISION-EHG-L1-001');
+    expect(DEFAULT_ARCH_KEY).toBe('ARCH-EHG-L1-001');
+  });
+
+  it('returns vision_key only when arch_key missing in metadata', async () => {
+    const supabase = fakeSupabase({ metadata: { vision_key: 'VISION-X-L2-001' } });
+    const result = await resolveDefaultKeysFromSD(supabase, 'SD-X');
+    expect(result).toEqual({ vision_key: 'VISION-X-L2-001', arch_key: null });
+  });
+});


### PR DESCRIPTION
## Summary
Resolves a follow-up from SD-LEO-INFRA-CLEANUP-ENGINE-HARDENING-001 retrospective.

vision-scorer hard-coded `VISION-EHG-L1-001` / `ARCH-EHG-L1-001` as defaults when `--vision-key`/`--arch-key` flags were absent, ignoring the SD's own `metadata.vision_key`/`arch_key`. L2 dev-tool SDs scored ~30/100 against L1 governance dimensions, blocking GATE_VISION_SCORE.

Now: when CLI flags are absent, the resolver fetches SD's metadata fields via Supabase before falling back to L1. Explicit flags still take precedence. SDs without vision metadata resolve identically to the previous behaviour.

- New named export `resolveDefaultKeysFromSD(supabase, sdKey)`
- Exported `DEFAULT_VISION_KEY` + `DEFAULT_ARCH_KEY` constants
- Wrapped CLI block in async IIFE for the new await
- 6 vitest cases covering metadata hit, miss, partial, null inputs, fallback constants

## Test plan
- [x] `npx vitest run scripts/eva/vision-scorer.test.js` — 6/6 pass
- [x] `node -c scripts/eva/vision-scorer.js` — no syntax errors
- [ ] Post-merge: re-run vision-scorer on a typical L2 SD and confirm score uses SD's metadata.vision_key automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)