### PR TITLE
fix(QF-20260425-465): export parseGitLog + parsePathsOnly from git-scanner.js

### DIFF
--- a/scripts/modules/cleanup/derive-rules.js
+++ b/scripts/modules/cleanup/derive-rules.js
@@ -8,20 +8,12 @@
 
 import { execSync } from 'child_process';
 import { inferPattern } from './group-review.js';
+import { parsePathsOnly } from '../../proving-run/pattern-discovery/git-scanner.js';
 
 export const DEFAULT_MIN_COMMITS = 2;
 export const DEFAULT_MAX_COMMITS_SCANNED = 1000;
 
-export function parseAddedFiles(output) {
-  if (!output) return [];
-  const paths = [];
-  for (const raw of output.split('\n')) {
-    const line = raw.trim();
-    if (!line) continue;
-    paths.push(line.replace(/\\/g, '/'));
-  }
-  return paths;
-}
+export const parseAddedFiles = parsePathsOnly;
 
 function runGitLog(repoPath, maxCommits) {
   const cmd = `git -C "${repoPath}" log --diff-filter=A --pretty= --name-only -n ${maxCommits}`;

--- a/scripts/proving-run/pattern-discovery/git-scanner.js
+++ b/scripts/proving-run/pattern-discovery/git-scanner.js
@@ -45,8 +45,16 @@ function scanRepoHistory(repoPath, pathPatterns, limit = MAX_COMMITS) {
 
 /**
  * Parse git log --oneline --name-only output into structured commits.
+ *
+ * Expects: hash+subject lines interleaved with file path lines.
+ *   abc1234 commit subject
+ *   path/to/file.js
+ *   path/to/other.js
+ *
+ *   def5678 next subject
+ *   path/to/another.js
  */
-function parseGitLog(output) {
+export function parseGitLog(output) {
   const commits = [];
   let current = null;
 
@@ -70,6 +78,26 @@ function parseGitLog(output) {
   if (current) commits.push(current);
 
   return commits;
+}
+
+/**
+ * Parse git log --pretty= --name-only output (paths only, no commit metadata).
+ *
+ * Expects: one file path per non-empty line. Used for added-file mining
+ * (--diff-filter=A --pretty= --name-only) where commit metadata is irrelevant.
+ *
+ * @param {string} output - Raw stdout from git log --pretty= --name-only
+ * @returns {string[]} Normalised file paths (forward slashes)
+ */
+export function parsePathsOnly(output) {
+  if (!output) return [];
+  const paths = [];
+  for (const raw of output.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    paths.push(line.replace(/\\/g, '/'));
+  }
+  return paths;
 }
 
 /**

--- a/scripts/proving-run/pattern-discovery/git-scanner.test.js
+++ b/scripts/proving-run/pattern-discovery/git-scanner.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { parseGitLog, parsePathsOnly } from './git-scanner.js';
+
+const ONELINE_OUTPUT = [
+  'abc1234 feat: add foo',
+  'src/foo.js',
+  'src/foo.test.js',
+  '',
+  'def5678 fix: bar',
+  'src/bar.js'
+].join('\n');
+
+describe('parseGitLog (oneline + name-only format)', () => {
+  it('parses commit + files into structured objects', () => {
+    const commits = parseGitLog(ONELINE_OUTPUT);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]).toMatchObject({
+      hash: 'abc1234',
+      subject: 'feat: add foo',
+      files: ['src/foo.js', 'src/foo.test.js']
+    });
+    expect(commits[1]).toMatchObject({
+      hash: 'def5678',
+      subject: 'fix: bar',
+      files: ['src/bar.js']
+    });
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseGitLog('')).toEqual([]);
+  });
+
+  it('skips file lines before any commit line is seen', () => {
+    expect(parseGitLog('orphan/file.js\nanother.js')).toEqual([]);
+  });
+});
+
+describe('parsePathsOnly (--pretty= format)', () => {
+  it('returns one normalised path per non-empty line', () => {
+    expect(parsePathsOnly('a/b.js\n\nc\\d.js\n')).toEqual(['a/b.js', 'c/d.js']);
+  });
+
+  it('returns empty array for falsy input', () => {
+    expect(parsePathsOnly('')).toEqual([]);
+    expect(parsePathsOnly(undefined)).toEqual([]);
+    expect(parsePathsOnly(null)).toEqual([]);
+  });
+
+  it('strips surrounding whitespace per line', () => {
+    expect(parsePathsOnly('  a.js  \n   b.js')).toEqual(['a.js', 'b.js']);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves duplicate-parser follow-up from SD-LEO-INFRA-CLEANUP-ENGINE-HARDENING-001 retrospective.

`parseGitLog` was internal-only; `derive-rules.js` had a local `parseAddedFiles` for `--pretty=` output. Now `git-scanner.js` exports two parsers covering distinct git log formats:

- `parseGitLog(output)` — oneline+name-only (commit metadata + files), unchanged behaviour
- `parsePathsOnly(output)` — `--pretty=`+name-only (paths only, no commit metadata) — new

`derive-rules.js`'s `parseAddedFiles` is now a re-export of `parsePathsOnly`. No call-site changes; existing tests still pass.

## Test plan
- [x] `npx vitest run scripts/proving-run/pattern-discovery/git-scanner.test.js scripts/modules/cleanup/derive-rules.test.js` — 15/15 pass
- [x] Backward compatible: `parseAddedFiles` export name preserved; `parseGitLog` signature unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)