### PR TITLE
feat(SD-LEO-INFRA-SHIP-INVOKE-COMPLETE-001): /ship Step 6.3 closes QF rows before worktree cleanup

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -500,6 +500,74 @@ Options:
 2. Run `git checkout main && git pull` to sync local
 3. Confirm: "✅ PR #X merged and branch deleted. You're on main with latest changes."
 
+### Step 6.3: Quick Fix Closure (AUTOMATED for `qf/*` and `quick-fix/*` branches)
+
+**Why this exists**: Without this step, `quick_fixes` rows stay `status=open` after merge — the orphan-QF rot pattern documented in QF-20260424-808 and QF-20260424-081 (both same-class incidents in 24 hours, 2026-04-25). Once Step 6.7 deletes the branch + worktree, `complete-quick-fix.js` can no longer auto-detect from a CWD that points at the right branch (the structural class of bug closed by SD-LEO-FIX-COMPLETE-QUICK-FIX-001 inside the script). This step closes the loop at the workflow level — invoke `complete-quick-fix.js` AFTER merge succeeds but BEFORE worktree cleanup runs.
+
+**This step runs strictly between Step 6 (merge complete) and Step 6.5 (auto-learning capture). It is a no-op for non-QF branches.**
+
+**1. Detect QF branch via the canonical helper:**
+
+```bash
+node -e "import('./lib/ship/qf-detector.mjs').then(({ isQuickFixBranch, extractQFId }) => {
+  const branch = process.argv[1];
+  console.log('IS_QF=' + isQuickFixBranch(branch));
+  console.log('QF_ID=' + (extractQFId(branch) || ''));
+});" "<branch-name-of-merged-pr>"
+```
+
+The helper accepts BOTH `qf/QF-<id>` AND `quick-fix/QF-<id>` prefixes — production data shows both are still in active use, and rolling-out a single canonical prefix is out of scope.
+
+**2. If `IS_QF=false`:** Skip directly to Step 6.5. Print no message — the silent no-op is the desired regression behavior for non-QF SDs.
+
+**3. If `IS_QF=true` AND `QF_ID` is non-empty:** Invoke `complete-quick-fix.js` with values captured from the just-merged PR:
+
+```bash
+# Required values (from earlier /ship steps):
+# - <QF_ID>          from extractQFId(branch)
+# - <PR_URL>         from Step 4 (gh pr create output) or `gh pr view <#> --json url`
+# - <COMMIT_SHA>     from gh-merge-safe.mjs output (look for "Merged PR #N (merge): <SHA>")
+# - <BRANCH_NAME>    the original branch name (e.g., qf/QF-...)
+
+node scripts/complete-quick-fix.js <QF_ID> \
+  --pr-url <PR_URL> \
+  --commit-sha <COMMIT_SHA> \
+  --branch-name <BRANCH_NAME> \
+  --skip-tests --tests-pass yes \
+  --skip-typecheck \
+  --uat-verified yes \
+  --verification-notes "Auto-closed by /ship Step 6.3 after merge of <PR_URL>"
+```
+
+**Why these flags:**
+- `--pr-url` makes `autoDetectGitInfo` use PR metadata as source of truth (the SD-LEO-FIX-COMPLETE-QUICK-FIX-001 fix), so this step is correct even on Windows worktrees.
+- `--skip-tests --tests-pass yes` — CI passed for the merge to succeed; re-running tests post-merge is redundant.
+- `--skip-typecheck` — same reasoning; the PR review gate already covered TypeScript.
+- `--uat-verified yes` — the merge gate IS the de-facto UAT for QFs (small, scoped fixes that PR-review validated).
+
+**4. Set a sentinel for Step 7:**
+
+After `complete-quick-fix.js` returns successfully, export `STEP_6_3_RAN_QF_CLOSURE=true` in the session so Step 7 (Post-Merge Command Ecosystem) can suppress the SD-flavored ecosystem prompt — QFs have their own implicit completion sequence and don't need `/learn` or `/leo next` follow-ups.
+
+**5. If `complete-quick-fix.js` fails** (non-zero exit or visible error):
+
+This is rare post-fix (SD-LEO-FIX-COMPLETE-QUICK-FIX-001 hardened the underlying script's auto-detection). When it does happen:
+- Surface the error message to the user
+- Do NOT block the rest of /ship (Step 6.5 + 6.7 still run; the QF row staying open is recoverable, an aborted ship is not)
+- The operator can manually close via `complete-quick-fix.js QF-<id> --pr-url <url> ...` or via `database-agent` UPDATE if the script has a deeper bug
+
+**6. Output format:**
+
+```
+🎯 Step 6.3: QF branch detected — closing QF-20260424-808 via complete-quick-fix.js
+   PR: https://github.com/rickfelix/EHG_Engineer/pull/3331
+   Commit: 2f97e7a78a516eed10172f328df5421f0d7fa8cf
+   Branch: qf/QF-20260424-808
+   ✓ Quick-Fix QF-20260424-808 → status=completed
+```
+
+For non-QF merges, no output appears — Step 6.5 follows directly.
+
 ### Step 6.5: Auto-Learning Capture (AUTOMATED)
 
 **After successful merge, the system automatically captures learnings for non-SD work.**
@@ -600,6 +668,8 @@ node scripts/modules/shipping/post-merge-worktree-cleanup.js --sdKey <SD-KEY-OR-
 ```
 ✅ PR #X merged and branch deleted.
 ```
+
+**Skip-when-QF-closed**: If `STEP_6_3_RAN_QF_CLOSURE=true` was set in Step 6.3, skip Step 7 entirely. Quick-Fix flow ends with the script's own completion summary; presenting `/learn` / `/leo next` after a QF close is noise (QFs are their own sequence, not SD work that benefits from learning capture or queue navigation). For SD merges, continue below.
 
 **AUTO-PROCEED Detection**: Check if AUTO-PROCEED mode is active (same check as Step 6).
 

--- a/lib/ship/qf-detector.mjs
+++ b/lib/ship/qf-detector.mjs
@@ -1,0 +1,44 @@
+/**
+ * QF Branch Detection
+ * SD-LEO-INFRA-SHIP-INVOKE-COMPLETE-001
+ *
+ * Centralizes the rule that decides whether a /ship merge corresponds to a
+ * Quick-Fix and therefore needs complete-quick-fix.js invoked BEFORE the
+ * post-merge worktree cleanup runs (or the QF row stays open forever — the
+ * QF-808 / QF-081 same-class incidents that motivated this fix).
+ *
+ * Production data shows TWO prefixes are in active use:
+ *   - `qf/QF-<id>`         (current canonical, used by recent QFs)
+ *   - `quick-fix/QF-<id>`  (older variant, still appears on some merges)
+ *
+ * Both are accepted. New skills (e.g. /ship Step 6.3) MUST consult these
+ * helpers rather than re-implementing the regex inline — that drift is
+ * exactly what kept production using two prefixes simultaneously.
+ */
+
+const QF_BRANCH_PREFIXES = ['qf/', 'quick-fix/'];
+const QF_ID_REGEX = /^(?:qf|quick-fix)\/(QF-[A-Za-z0-9-]+)$/i;
+
+/**
+ * @param {string|null|undefined} branchName
+ * @returns {boolean} true iff the branch name starts with a recognized QF prefix
+ */
+export function isQuickFixBranch(branchName) {
+  if (typeof branchName !== 'string' || branchName.length === 0) return false;
+  const lower = branchName.toLowerCase();
+  return QF_BRANCH_PREFIXES.some(p => lower.startsWith(p));
+}
+
+/**
+ * Extract the QF-ID portion of a quick-fix branch name.
+ * Returns null when the branch does not match a known QF pattern, including
+ * partial matches like `qf/something-else` without the `QF-` ID segment.
+ *
+ * @param {string|null|undefined} branchName
+ * @returns {string|null} e.g. "QF-20260424-808" or null
+ */
+export function extractQFId(branchName) {
+  if (typeof branchName !== 'string') return null;
+  const match = branchName.match(QF_ID_REGEX);
+  return match ? match[1] : null;
+}

--- a/tests/unit/ship/qf-detector.test.js
+++ b/tests/unit/ship/qf-detector.test.js
@@ -1,0 +1,84 @@
+/**
+ * lib/ship/qf-detector unit tests
+ * SD-LEO-INFRA-SHIP-INVOKE-COMPLETE-001
+ *
+ * Covers BOTH production prefix variants (qf/ and quick-fix/) plus the
+ * common false-positive shapes that should NOT be treated as QFs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isQuickFixBranch, extractQFId } from '../../../lib/ship/qf-detector.mjs';
+
+describe('isQuickFixBranch', () => {
+  it('returns true for canonical qf/QF-<id> prefix', () => {
+    expect(isQuickFixBranch('qf/QF-20260424-808')).toBe(true);
+  });
+
+  it('returns true for legacy quick-fix/QF-<id> prefix (still in production)', () => {
+    expect(isQuickFixBranch('quick-fix/QF-20260424-808')).toBe(true);
+  });
+
+  it('returns false for SD branches (feat/SD-*, fix/SD-*, etc.)', () => {
+    expect(isQuickFixBranch('feat/SD-LEO-INFRA-SHIP-INVOKE-COMPLETE-001')).toBe(false);
+    expect(isQuickFixBranch('fix/SD-FOO-001')).toBe(false);
+    expect(isQuickFixBranch('main')).toBe(false);
+  });
+
+  it('returns false for null/undefined/empty/non-string', () => {
+    expect(isQuickFixBranch(null)).toBe(false);
+    expect(isQuickFixBranch(undefined)).toBe(false);
+    expect(isQuickFixBranch('')).toBe(false);
+    expect(isQuickFixBranch(42)).toBe(false);
+    expect(isQuickFixBranch({})).toBe(false);
+  });
+
+  it('handles uppercase prefix variants (defensive)', () => {
+    expect(isQuickFixBranch('QF/QF-20260424-808')).toBe(true);
+    expect(isQuickFixBranch('Quick-Fix/QF-20260424-808')).toBe(true);
+  });
+
+  it('returns false when prefix matches but no QF- separator follows', () => {
+    // Prefix-only matches still register as QF branches per the prefix rule;
+    // extractQFId is the gate that requires the full ID. This separation is
+    // intentional: the skill prompt can warn on prefix-without-ID instead of
+    // silently treating the merge as a non-QF.
+    expect(isQuickFixBranch('qf/random-branch')).toBe(true);
+    expect(extractQFId('qf/random-branch')).toBeNull();
+  });
+});
+
+describe('extractQFId', () => {
+  it('extracts ID from qf/QF-<id>', () => {
+    expect(extractQFId('qf/QF-20260424-808')).toBe('QF-20260424-808');
+  });
+
+  it('extracts ID from quick-fix/QF-<id>', () => {
+    expect(extractQFId('quick-fix/QF-20260424-081')).toBe('QF-20260424-081');
+  });
+
+  it('preserves QF- ID hyphenation and digits', () => {
+    expect(extractQFId('qf/QF-CLAIM-CONFLICT-UX-001')).toBe('QF-CLAIM-CONFLICT-UX-001');
+  });
+
+  it('returns null when QF- segment is missing', () => {
+    expect(extractQFId('qf/something-else')).toBeNull();
+    expect(extractQFId('quick-fix/random')).toBeNull();
+  });
+
+  it('returns null for non-QF branches', () => {
+    expect(extractQFId('feat/SD-FOO-001')).toBeNull();
+    expect(extractQFId('main')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty/non-string', () => {
+    expect(extractQFId(null)).toBeNull();
+    expect(extractQFId(undefined)).toBeNull();
+    expect(extractQFId('')).toBeNull();
+    expect(extractQFId(42)).toBeNull();
+  });
+
+  it('is case-insensitive on prefix only', () => {
+    // The QF- prefix on the ID itself is case-insensitive too in the regex
+    expect(extractQFId('QF/QF-20260424-808')).toBe('QF-20260424-808');
+  });
+});


### PR DESCRIPTION
## Summary
Closes the workflow gap that complemented [SD-LEO-FIX-COMPLETE-QUICK-FIX-001 (PR #3332)](https://github.com/rickfelix/EHG_Engineer/pull/3332). That SD made `complete-quick-fix.js` robust to post-cleanup auto-detect failures (PR-metadata authoritative path). This SD eliminates the precondition: `/ship` now invokes `complete-quick-fix.js` BEFORE the worktree is gone, so the QF row closes even if the operator never manually runs the script.

Same-class incidents that motivated this pair within 24h:
- QF-20260424-808 (PR #3331): operator's main-repo branch picked post-cleanup, `actual_loc=1786` from CLAUDE.md DB drift, false escalation
- QF-20260424-081 (PR #3330): "complete-quick-fix.js SIGTERM-before-write on Windows tree → direct-DB completion required"

## What changes (+198 LOC across 3 files)

1. **`lib/ship/qf-detector.mjs`** (NEW, 44 LOC) — exports `isQuickFixBranch` and `extractQFId`. Accepts BOTH `qf/QF-*` and `quick-fix/QF-*` prefixes (production data shows both are in active use). Centralizing the regex outside the skill prompt removes drift risk.

2. **`tests/unit/ship/qf-detector.test.js`** (NEW, 84 LOC) — 13 vitest assertions across 2 describe blocks. Covers both production prefixes, SD-branch negatives, null/undefined/non-string, uppercase variants, and the explicit "prefix-without-ID" semantics (`isQuickFixBranch=true` but `extractQFId=null`).

3. **`.claude/commands/ship.md`** (+70 LOC) — strictly additive Step 6.3 inserted between Step 6 (`gh pr merge` succeeds) and Step 6.5 (auto-learning capture). When the just-merged branch matches `qf/*` or `quick-fix/*`, invoke `complete-quick-fix.js` with values captured from the PR (`--pr-url` + `--commit-sha` + `--branch-name` + `--skip-tests --tests-pass yes` + `--skip-typecheck` + `--uat-verified yes`). Sets a `STEP_6_3_RAN_QF_CLOSURE` sentinel so Step 7's ecosystem prompt skips the SD-flavored `/learn` / `/leo next` options for QF flow.

## Sub-agent evidence

| Phase | Agent | Verdict | Confidence | Row ID |
|-------|-------|---------|-----------:|--------|
| LEAD | VALIDATION | PASS | 95 | `9c839291-f903-45e0-a5d9-a6ff0eeb691e` |
| EXEC | DOCMON | PASS | 92 | `18c2e7ad-fea8-40a4-b9ac-6ffe22e4a9f5` |

VALIDATION confirmed the sibling SD is complementary (not colliding), recommended the Step 6.3 insertion point, and flagged the dual-prefix requirement that production data justifies. DOCMON verified all 8 referenced cli.js flags exist on `origin/main`, ship.md heading structure is preserved (existing headings unmodified), and JSDoc + test coverage are adequate.

## Test plan
- [x] `node --check` passes on both new files
- [x] `npx vitest run tests/unit/ship/qf-detector.test.js` — **13/13 PASS in 184ms**
- [x] `grep -n "^### Step" .claude/commands/ship.md` confirms Step 6.3 inserted between 6 and 6.5; no existing step heading mutated
- [x] All 8 `complete-quick-fix.js` flags referenced in Step 6.3 verified to exist at `scripts/modules/complete-quick-fix/cli.js:43-60`
- [ ] **Post-merge dogfood** (cannot in-tree): file a 1-LOC QF, run `/ship` from a `qf/*` worktree, observe Step 6.3 message + auto-closed `quick_fixes` row without operator intervention. THIS PR's merge uses the OLD /ship behavior; the new behavior takes effect on the NEXT QF.

## Cross-references
- **Sibling**: SD-LEO-FIX-COMPLETE-QUICK-FIX-001 (PR #3332, completed 2026-04-25) — fixed the symptom inside `complete-quick-fix.js`
- **This SD**: eliminates the precondition (workflow gap) inside `/ship`
- Together they close the QF post-merge auto-close loop end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)