### PR TITLE
feat(SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001): replay test framework (PR #1 of 5)

### DIFF
--- a/.github/workflows/replay-tests.yml
+++ b/.github/workflows/replay-tests.yml
@@ -1,0 +1,51 @@
+name: Replay Framework Tests
+
+# Runs the inline-prompt replay test framework on every PR that touches it,
+# its golden corpus, or any of the 4 target production scripts whose prompts
+# the framework guards (PRs #2-5 of SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001).
+#
+# Blocking by design: FR-3 AC-3 requires CI failure to block PR merge.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/__tests__/replay/**'
+      - 'scripts/__tests__/golden/**'
+      - 'scripts/eva/srip/quality-checker.mjs'
+      - 'scripts/modules/ai-quality-judge/**'
+      - 'scripts/eva-intake-pipeline.js'
+      - 'scripts/modules/sd-creation/prd-sd-041c/**'
+      - '.github/workflows/replay-tests.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run replay framework tests
+        run: npx vitest run scripts/__tests__/replay/
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Replay Framework Tests" >> $GITHUB_STEP_SUMMARY
+          echo "Suite: scripts/__tests__/replay/*.test.js" >> $GITHUB_STEP_SUMMARY
+          echo "Guards V1→V2 prompt parity for 4 production scripts." >> $GITHUB_STEP_SUMMARY

--- a/scripts/__tests__/golden/README.md
+++ b/scripts/__tests__/golden/README.md
@@ -1,0 +1,15 @@
+# Golden Fixture Corpus
+
+Per-script golden fixtures for the replay test framework (`scripts/__tests__/replay/`).
+
+PRs #2–5 of `SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001` populate this directory with one subdirectory per target script:
+
+```
+golden/
+  quality-checker/        # PR #2
+  ai-quality-judge/       # PR #3
+  eva-intake-pipeline/    # PR #4
+  prd-sd-041c/            # PR #5
+```
+
+Each subdirectory contains ≥10 fixtures (per PRD FR-2 AC-1) named `fixture-<seq>.json`, conforming to `../replay/fixture-schema.json`. Fixtures are real production invocations, sanitized of secrets per `../replay/sanitization-checker.mjs`. The loader rejects any fixture missing `sanitized: true`.

--- a/scripts/__tests__/replay/README.md
+++ b/scripts/__tests__/replay/README.md
@@ -1,0 +1,68 @@
+# Replay Test Framework
+
+Reusable golden-corpus replay harness for `SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001`.
+
+PRs #2–5 of this campaign rewrite inline Claude prompts in 4 production scripts (`quality-checker.mjs`, `ai-quality-judge`, `eva-intake-pipeline.js`, `prd-sd-041c/technical-design.js`) from declarative to imperative voice. This framework verifies that each V2 prompt produces output that passes the same downstream validator the V1 output passed.
+
+## Layout
+
+```
+scripts/__tests__/replay/        # this framework
+  fixture-loader.mjs             # load + shape-validate golden JSON
+  validator-runner.mjs           # invoke downstream validator on V2 output
+  parity-asserter.mjs            # compare V1 vs V2 validator results
+  sanitization-checker.mjs       # scan fixtures for leaked secrets
+  fixture-schema.json            # JSON-schema doc of fixture shape
+  index.mjs                      # barrel export
+
+scripts/__tests__/golden/        # per-script fixture corpus (built in PRs #2–5)
+  <script-name>/
+    fixture-001.json
+    ...
+```
+
+## Usage in a script-rephrase PR
+
+```js
+import { describe, it } from 'vitest';
+import { loadFixturesForScript, runReplay, assertParity, assertSanitized } from '../replay/index.mjs';
+import { promptV2 } from '../../path/to/script.mjs';
+import { downstreamValidator } from '../../path/to/validator.mjs';
+
+const GOLDEN_ROOT = new URL('../golden/', import.meta.url).pathname;
+
+describe('replay: <script-name>', async () => {
+  const fixtures = await loadFixturesForScript('<script-name>', GOLDEN_ROOT);
+  for (const fixture of fixtures) {
+    it(`parity holds for ${fixture.captured_at}`, async () => {
+      assertSanitized(fixture, fixture.captured_at);
+      const { v2Result } = await runReplay({ promptFn: promptV2, fixture, validator: downstreamValidator });
+      assertParity({ v1Result: fixture.validator_result, v2Result, fixturePath: fixture.captured_at });
+    });
+  }
+});
+```
+
+## Fixture shape
+
+See `fixture-schema.json`. Every fixture must include:
+
+- `input` — the exact input passed to the V1 prompt
+- `v1_output` — the V1 prompt's observed output
+- `validator_result` — `{ passed: boolean, details? }` from the downstream validator
+- `captured_at` — ISO-8601 timestamp
+- `sanitized` — `true` (the loader refuses fixtures where this is anything other than literal `true`)
+
+## Sanitization
+
+`sanitization-checker.mjs` scans `input`, `v1_output`, and `validator_result` for: Anthropic API keys (incl. admin), OpenAI API keys (incl. `sk-proj-` / `sk-svcacct-` / `sk-admin-` scoped), AWS access keys, GitHub classic PATs (`ghp_`), GitHub fine-grained PATs (`github_pat_`), PEM private-key blocks, and JWTs. The loader (`loadFixture`) invokes `assertSanitized` automatically — refusal-on-suspicion is the policy, since the asymmetric cost (re-redact one fixture vs. leak a Supabase service-role key) favors aggression. Capture pipelines must redact these before writing the fixture.
+
+**Known false-positive class**: prose like `"eyJexample0.eyJexample0.signature"` will trip the JWT pattern. Either rephrase the example or redact it; do not add to allowlists. Coverage gaps not in scope for PR #1: Slack tokens, Stripe keys, Google API keys, SendGrid keys, postgres connection strings with embedded passwords, PII (email/phone/IP). Cover in a follow-up QF before reusing this framework for any script that touches those services.
+
+## Parity contract
+
+A V2 prompt rewrite is acceptable iff `v2Result.passed === fixture.validator_result.passed` for every fixture. We do not require byte-equal V2 output; we require the downstream validator to reach the same verdict. This is FR-3's "fail-fast on shape divergence" contract.
+
+## Rollback
+
+Per PRD FR-5: replay-test failure on a script-rephrase PR blocks the merge. If a regression slips past tests and breaks production, the rollback is a single `git revert` on the offending PR — no feature flags, no shadow tables.

--- a/scripts/__tests__/replay/fixture-loader.mjs
+++ b/scripts/__tests__/replay/fixture-loader.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { assertSanitized } from './sanitization-checker.mjs';
+
+const REQUIRED_FIELDS = ['input', 'v1_output', 'validator_result', 'captured_at', 'sanitized'];
+
+export class FixtureShapeError extends Error {
+  constructor(message, fixturePath) {
+    super(`${fixturePath}: ${message}`);
+    this.name = 'FixtureShapeError';
+    this.fixturePath = fixturePath;
+  }
+}
+
+export async function loadFixture(fixturePath) {
+  const raw = await fs.readFile(fixturePath, 'utf8');
+  let fixture;
+  try {
+    fixture = JSON.parse(raw);
+  } catch (err) {
+    throw new FixtureShapeError(`invalid JSON: ${err.message}`, fixturePath);
+  }
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in fixture)) {
+      throw new FixtureShapeError(`missing required field: ${field}`, fixturePath);
+    }
+  }
+  if (typeof fixture.sanitized !== 'boolean') {
+    throw new FixtureShapeError(`'sanitized' must be boolean, got ${typeof fixture.sanitized}`, fixturePath);
+  }
+  if (fixture.sanitized !== true) {
+    throw new FixtureShapeError(`fixture is not marked sanitized=true; refusing to load (FR-2 AC-2)`, fixturePath);
+  }
+  assertSanitized(fixture, fixturePath);
+  return fixture;
+}
+
+export async function loadFixturesForScript(scriptName, goldenRoot) {
+  const dir = path.join(goldenRoot, scriptName);
+  let entries;
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  const jsonFiles = entries.filter(e => e.endsWith('.json') && e !== 'schema.json');
+  return Promise.all(jsonFiles.map(f => loadFixture(path.join(dir, f))));
+}

--- a/scripts/__tests__/replay/fixture-loader.test.js
+++ b/scripts/__tests__/replay/fixture-loader.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { loadFixture, loadFixturesForScript, FixtureShapeError } from './fixture-loader.mjs';
+
+const VALID = {
+  input: { foo: 'bar' },
+  v1_output: { judgment: 'pass' },
+  validator_result: { passed: true },
+  captured_at: '2026-04-25T12:00:00Z',
+  sanitized: true,
+};
+
+let tmpDir;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'replay-fixture-loader-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeFixture(name, body) {
+  const p = path.join(tmpDir, name);
+  await fs.writeFile(p, JSON.stringify(body));
+  return p;
+}
+
+describe('loadFixture', () => {
+  it('loads a valid sanitized fixture', async () => {
+    const p = await writeFixture('valid.json', VALID);
+    const f = await loadFixture(p);
+    expect(f).toEqual(VALID);
+  });
+
+  it('throws FixtureShapeError on invalid JSON', async () => {
+    const p = path.join(tmpDir, 'bad.json');
+    await fs.writeFile(p, '{not valid json');
+    await expect(loadFixture(p)).rejects.toThrow(FixtureShapeError);
+  });
+
+  it('throws on missing required field', async () => {
+    const { sanitized: _drop, ...incomplete } = VALID;
+    const p = await writeFixture('missing.json', incomplete);
+    await expect(loadFixture(p)).rejects.toThrow(/missing required field: sanitized/);
+  });
+
+  it('throws on non-boolean sanitized', async () => {
+    const p = await writeFixture('non-bool.json', { ...VALID, sanitized: 'yes' });
+    await expect(loadFixture(p)).rejects.toThrow(/must be boolean/);
+  });
+
+  it('refuses fixtures with sanitized=false', async () => {
+    const p = await writeFixture('unsan.json', { ...VALID, sanitized: false });
+    await expect(loadFixture(p)).rejects.toThrow(/not marked sanitized=true/);
+  });
+
+  it('rejects sanitized:true fixtures that still contain secrets (belt-and-suspenders)', async () => {
+    // Assembled at runtime to avoid tripping the repo's pre-commit secret-scanner.
+    const fakeAwsKey = 'AK' + 'IA' + 'IOSFODNN7EXAMPLE';
+    const dirty = { ...VALID, v1_output: { leaked: fakeAwsKey } };
+    const p = await writeFixture('lying.json', dirty);
+    await expect(loadFixture(p)).rejects.toThrow(/aws_access_key/);
+  });
+});
+
+describe('loadFixturesForScript', () => {
+  it('returns [] when script directory is missing', async () => {
+    const out = await loadFixturesForScript('does-not-exist', tmpDir);
+    expect(out).toEqual([]);
+  });
+
+  it('loads multiple fixtures and skips schema.json', async () => {
+    const dir = path.join(tmpDir, 'demo-script');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'fixture-001.json'), JSON.stringify(VALID));
+    await fs.writeFile(path.join(dir, 'fixture-002.json'), JSON.stringify({ ...VALID, captured_at: '2026-04-25T13:00:00Z' }));
+    await fs.writeFile(path.join(dir, 'schema.json'), JSON.stringify({ ignored: true }));
+    await fs.writeFile(path.join(dir, 'notes.md'), 'should be ignored');
+    const fixtures = await loadFixturesForScript('demo-script', tmpDir);
+    expect(fixtures).toHaveLength(2);
+    expect(fixtures.every(f => f.sanitized === true)).toBe(true);
+  });
+});

--- a/scripts/__tests__/replay/fixture-schema.json
+++ b/scripts/__tests__/replay/fixture-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "scripts/__tests__/replay/fixture-schema.json",
+  "title": "Replay golden fixture",
+  "description": "One real (input, V1 output, downstream-validator result) tuple captured from production for replay testing of V2 prompt rewrites.",
+  "type": "object",
+  "required": ["input", "v1_output", "validator_result", "captured_at", "sanitized"],
+  "properties": {
+    "input": {
+      "description": "The exact input passed to the V1 inline prompt (JSON-serializable)."
+    },
+    "v1_output": {
+      "description": "The V1 prompt's raw output as observed in production."
+    },
+    "validator_result": {
+      "type": "object",
+      "required": ["passed"],
+      "properties": {
+        "passed": { "type": "boolean", "description": "Whether v1_output passed the downstream validator (PRD rubric, JSON schema, etc.)." },
+        "details": { "description": "Optional validator-specific details." }
+      }
+    },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "sanitized": { "type": "boolean", "const": true, "description": "Must be true. Loader refuses fixtures where sanitized !== true." }
+  }
+}

--- a/scripts/__tests__/replay/index.mjs
+++ b/scripts/__tests__/replay/index.mjs
@@ -1,0 +1,4 @@
+export { loadFixture, loadFixturesForScript, FixtureShapeError } from './fixture-loader.mjs';
+export { runValidator, runReplay, ValidatorContractError } from './validator-runner.mjs';
+export { assertParity, summarizeReplayResults, ParityViolation } from './parity-asserter.mjs';
+export { scanForSecrets, assertSanitized, SanitizationViolation } from './sanitization-checker.mjs';

--- a/scripts/__tests__/replay/parity-asserter.mjs
+++ b/scripts/__tests__/replay/parity-asserter.mjs
@@ -1,0 +1,30 @@
+export class ParityViolation extends Error {
+  constructor(message, details) {
+    super(message);
+    this.name = 'ParityViolation';
+    this.details = details;
+  }
+}
+
+export function assertParity({ v1Result, v2Result, fixturePath }) {
+  if (v1Result.passed !== v2Result.passed) {
+    throw new ParityViolation(
+      `Validator parity broken for ${fixturePath}: v1.passed=${v1Result.passed} vs v2.passed=${v2Result.passed}`,
+      { fixturePath, v1Result, v2Result }
+    );
+  }
+  return { ok: true, fixturePath };
+}
+
+export function summarizeReplayResults(results) {
+  const total = results.length;
+  const passed = results.filter(r => r.ok).length;
+  const failed = total - passed;
+  return {
+    total,
+    passed,
+    failed,
+    parity_holds: failed === 0,
+    failures: results.filter(r => !r.ok).map(r => r.fixturePath),
+  };
+}

--- a/scripts/__tests__/replay/parity-asserter.test.js
+++ b/scripts/__tests__/replay/parity-asserter.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { assertParity, summarizeReplayResults, ParityViolation } from './parity-asserter.mjs';
+
+describe('assertParity', () => {
+  it('passes when v1.passed === v2.passed (both true)', () => {
+    const r = assertParity({
+      v1Result: { passed: true },
+      v2Result: { passed: true },
+      fixturePath: 'fix-001.json',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('passes when v1.passed === v2.passed (both false)', () => {
+    const r = assertParity({
+      v1Result: { passed: false },
+      v2Result: { passed: false },
+      fixturePath: 'fix-002.json',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('throws ParityViolation when v1 passed and v2 failed', () => {
+    expect(() => assertParity({
+      v1Result: { passed: true },
+      v2Result: { passed: false },
+      fixturePath: 'fix-003.json',
+    })).toThrow(ParityViolation);
+  });
+
+  it('attaches failure details on the thrown error', () => {
+    try {
+      assertParity({
+        v1Result: { passed: false },
+        v2Result: { passed: true },
+        fixturePath: 'fix-004.json',
+      });
+    } catch (err) {
+      expect(err.details.fixturePath).toBe('fix-004.json');
+      expect(err.details.v1Result.passed).toBe(false);
+      expect(err.details.v2Result.passed).toBe(true);
+    }
+  });
+});
+
+describe('summarizeReplayResults', () => {
+  it('reports parity_holds=true when all results are ok', () => {
+    const s = summarizeReplayResults([
+      { ok: true, fixturePath: 'a' },
+      { ok: true, fixturePath: 'b' },
+    ]);
+    expect(s).toEqual({ total: 2, passed: 2, failed: 0, parity_holds: true, failures: [] });
+  });
+
+  it('lists failing fixture paths when parity is broken', () => {
+    const s = summarizeReplayResults([
+      { ok: true, fixturePath: 'a' },
+      { ok: false, fixturePath: 'b' },
+      { ok: false, fixturePath: 'c' },
+    ]);
+    expect(s.parity_holds).toBe(false);
+    expect(s.failed).toBe(2);
+    expect(s.failures).toEqual(['b', 'c']);
+  });
+});

--- a/scripts/__tests__/replay/sanitization-checker.mjs
+++ b/scripts/__tests__/replay/sanitization-checker.mjs
@@ -1,0 +1,42 @@
+export const SECRET_PATTERNS = Object.freeze([
+  { name: 'anthropic_api_key', pattern: /sk-ant-[A-Za-z0-9_-]{20,}/g },
+  { name: 'openai_api_key', pattern: /sk-(?!ant-)(?:proj-|svcacct-|admin-)?[A-Za-z0-9_-]{20,}/g },
+  { name: 'aws_access_key', pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: 'github_token', pattern: /ghp_[A-Za-z0-9]{36,}/g },
+  { name: 'github_fine_grained_pat', pattern: /github_pat_[A-Za-z0-9_]{82,}/g },
+  { name: 'private_key_block', pattern: /-----BEGIN (RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g },
+  { name: 'jwt_token', pattern: /eyJ[A-Za-z0-9_=-]{8,}\.eyJ[A-Za-z0-9_=-]{8,}\.[A-Za-z0-9_\-+/=]{8,}/g },
+]);
+
+export class SanitizationViolation extends Error {
+  constructor(message, hits) {
+    super(message);
+    this.name = 'SanitizationViolation';
+    this.hits = hits;
+  }
+}
+
+export function scanForSecrets(value) {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  const hits = [];
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    const matches = text.match(pattern);
+    if (matches) hits.push({ kind: name, count: matches.length });
+  }
+  return hits;
+}
+
+export function assertSanitized(fixture, fixturePath) {
+  const all = [
+    ...scanForSecrets(fixture.input),
+    ...scanForSecrets(fixture.v1_output),
+    ...scanForSecrets(fixture.validator_result),
+  ];
+  if (all.length > 0) {
+    throw new SanitizationViolation(
+      `Fixture ${fixturePath} contains apparent secrets: ${all.map(h => `${h.kind}×${h.count}`).join(', ')}`,
+      all
+    );
+  }
+  return { ok: true };
+}

--- a/scripts/__tests__/replay/sanitization-checker.test.js
+++ b/scripts/__tests__/replay/sanitization-checker.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { scanForSecrets, assertSanitized, SanitizationViolation } from './sanitization-checker.mjs';
+
+// Test fixtures are assembled at runtime via concat to avoid tripping the
+// repo's pre-commit secret-scanner on static source text. The assembled
+// strings still match our own regex patterns at runtime — that is the point.
+const SK = 'sk' + '-';
+const PREFIX_ANT = SK + 'ant-';
+const PREFIX_PROJ = SK + 'proj-';
+const PREFIX_SVCACCT = SK + 'svcacct-';
+const PREFIX_AKIA = 'AK' + 'IA';
+const PREFIX_GHP = 'gh' + 'p_';
+const PREFIX_PAT = 'github' + '_pat_';
+const PAYLOAD = 'A'.repeat(24);
+const LONG_PAYLOAD = 'A'.repeat(36);
+const FINE_GRAINED_PAYLOAD = 'A'.repeat(82);
+
+describe('scanForSecrets', () => {
+  it('returns [] for clean text', () => {
+    expect(scanForSecrets('hello world')).toEqual([]);
+  });
+
+  it('detects Anthropic API keys', () => {
+    const hits = scanForSecrets('token: ' + PREFIX_ANT + 'abcdefghijklmnopqrst123');
+    expect(hits.find(h => h.kind === 'anthropic_api_key')).toBeTruthy();
+  });
+
+  it('detects OpenAI keys without confusing them with Anthropic', () => {
+    const hits = scanForSecrets('key=' + SK + 'ABCDEFGHIJKLMNOPQRSTUV12');
+    expect(hits.find(h => h.kind === 'openai_api_key')).toBeTruthy();
+    expect(hits.find(h => h.kind === 'anthropic_api_key')).toBeFalsy();
+  });
+
+  it('detects OpenAI project-scoped keys (sk-proj-)', () => {
+    const hits = scanForSecrets(PREFIX_PROJ + PAYLOAD);
+    expect(hits.find(h => h.kind === 'openai_api_key')).toBeTruthy();
+  });
+
+  it('detects OpenAI service-account keys (sk-svcacct-)', () => {
+    const hits = scanForSecrets(PREFIX_SVCACCT + PAYLOAD);
+    expect(hits.find(h => h.kind === 'openai_api_key')).toBeTruthy();
+  });
+
+  it('detects AWS access keys', () => {
+    const hits = scanForSecrets(PREFIX_AKIA + 'IOSFODNN7EXAMPLE');
+    expect(hits.find(h => h.kind === 'aws_access_key')).toBeTruthy();
+  });
+
+  it('detects classic GitHub PATs (ghp_)', () => {
+    const hits = scanForSecrets(PREFIX_GHP + LONG_PAYLOAD);
+    expect(hits.find(h => h.kind === 'github_token')).toBeTruthy();
+  });
+
+  it('detects GitHub fine-grained PATs (github_pat_)', () => {
+    const hits = scanForSecrets(PREFIX_PAT + FINE_GRAINED_PAYLOAD);
+    expect(hits.find(h => h.kind === 'github_fine_grained_pat')).toBeTruthy();
+  });
+
+  it('detects PEM private-key blocks', () => {
+    const hits = scanForSecrets('-----BEGIN RSA PRIVATE KEY-----');
+    expect(hits.find(h => h.kind === 'private_key_block')).toBeTruthy();
+  });
+
+  it('detects JWT tokens', () => {
+    const hits = scanForSecrets('eyJabcdefgh.eyJijklmnop.signaturepart12');
+    expect(hits.find(h => h.kind === 'jwt_token')).toBeTruthy();
+  });
+
+  it('detects JWT tokens whose middle segment contains hyphens (real base64url)', () => {
+    const hits = scanForSecrets('eyJhbGciOiJI.eyJzdWItcw-AB.signaturepart12');
+    expect(hits.find(h => h.kind === 'jwt_token')).toBeTruthy();
+  });
+
+  it('serializes objects before scanning', () => {
+    const hits = scanForSecrets({ nested: { token: PREFIX_ANT + 'abcdefghijklmnopqrst123' } });
+    expect(hits.find(h => h.kind === 'anthropic_api_key')).toBeTruthy();
+  });
+});
+
+describe('assertSanitized', () => {
+  const CLEAN = {
+    input: { question: 'what is 2+2?' },
+    v1_output: { answer: '4' },
+    validator_result: { passed: true },
+    captured_at: '2026-04-25T12:00:00Z',
+    sanitized: true,
+  };
+
+  it('passes on a clean fixture', () => {
+    expect(assertSanitized(CLEAN, 'fix-001.json').ok).toBe(true);
+  });
+
+  it('throws SanitizationViolation when input contains a key', () => {
+    const dirty = { ...CLEAN, input: { auth: 'Bearer ' + PREFIX_ANT + 'abcdefghijklmnopqrst123' } };
+    expect(() => assertSanitized(dirty, 'fix-002.json')).toThrow(SanitizationViolation);
+  });
+
+  it('throws when v1_output contains a key', () => {
+    const dirty = { ...CLEAN, v1_output: { leaked: PREFIX_AKIA + 'IOSFODNN7EXAMPLE' } };
+    expect(() => assertSanitized(dirty, 'fix-003.json')).toThrow(/aws_access_key/);
+  });
+
+  it('throws when validator_result.details contains a key', () => {
+    const dirty = { ...CLEAN, validator_result: { passed: true, details: 'echoed: ' + PREFIX_GHP + 'B'.repeat(36) } };
+    expect(() => assertSanitized(dirty, 'fix-004.json')).toThrow(/github_token/);
+  });
+});

--- a/scripts/__tests__/replay/validator-runner.mjs
+++ b/scripts/__tests__/replay/validator-runner.mjs
@@ -1,0 +1,26 @@
+export class ValidatorContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ValidatorContractError';
+  }
+}
+
+export async function runValidator(validator, output) {
+  if (typeof validator !== 'function') {
+    throw new ValidatorContractError(`validator must be a function, got ${typeof validator}`);
+  }
+  const result = await validator(output);
+  if (result == null || typeof result !== 'object') {
+    throw new ValidatorContractError(`validator must return an object, got ${typeof result}`);
+  }
+  if (typeof result.passed !== 'boolean') {
+    throw new ValidatorContractError(`validator result must include 'passed: boolean', got ${typeof result.passed}`);
+  }
+  return result;
+}
+
+export async function runReplay({ promptFn, fixture, validator }) {
+  const v2Output = await promptFn(fixture.input);
+  const v2Result = await runValidator(validator, v2Output);
+  return { v2Output, v2Result };
+}

--- a/scripts/__tests__/replay/validator-runner.test.js
+++ b/scripts/__tests__/replay/validator-runner.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { runValidator, runReplay, ValidatorContractError } from './validator-runner.mjs';
+
+const VALID_FIXTURE = {
+  input: { question: 'q' },
+  v1_output: { answer: 'a' },
+  validator_result: { passed: true },
+  captured_at: '2026-04-25T12:00:00Z',
+  sanitized: true,
+};
+
+describe('runValidator', () => {
+  it('returns the validator result on a well-shaped function', async () => {
+    const validator = (out) => ({ passed: out.answer === 'a', details: 'ok' });
+    const r = await runValidator(validator, { answer: 'a' });
+    expect(r.passed).toBe(true);
+    expect(r.details).toBe('ok');
+  });
+
+  it('throws ValidatorContractError when validator is not a function', async () => {
+    await expect(runValidator(null, {})).rejects.toThrow(ValidatorContractError);
+  });
+
+  it('throws when validator returns non-object', async () => {
+    await expect(runValidator(() => 'pass', {})).rejects.toThrow(/must return an object/);
+  });
+
+  it('throws when validator result lacks passed:boolean', async () => {
+    await expect(runValidator(() => ({ ok: true }), {})).rejects.toThrow(/passed: boolean/);
+  });
+});
+
+describe('runReplay', () => {
+  it('invokes promptFn with fixture.input and validates output', async () => {
+    const promptFn = async (input) => ({ answer: input.question.toUpperCase() });
+    const validator = (out) => ({ passed: out.answer === 'Q' });
+    const { v2Output, v2Result } = await runReplay({ promptFn, fixture: VALID_FIXTURE, validator });
+    expect(v2Output).toEqual({ answer: 'Q' });
+    expect(v2Result.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Foundational replay test framework for the inline-prompt rephrase campaign of `SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001`. PRs #2–5 each rewrite one production script's inline Claude prompts from declarative voice ("You are an AI…") to imperative voice; this framework asserts the V2 prompt's output passes the same downstream validator the V1 output passed (FR-3 strict-parity contract).

## Scope correction (in-scope, documented)

The PRD originally listed `scripts/llm-audit.js` as PR #1 target under "safest first." Pre-EXEC code-Read confirmed that file is a 187-line **Grep-based static scanner** for hardcoded model strings — zero inline Claude prompts, not applicable to V1→V2 prompt rephrase work.

Per LEAD validation report `a1674f43-b1f7-4179-b73b-10c31f0c4950` explicit guidance ("if any are already imperative, raise as scope ambiguity to PLAN before coding"), `llm-audit.js` was dropped from scope. PRD amended via `metadata.scope_amendment` (full audit trail in DB; 32/32 verification, 0 drift). 5-PR cadence preserved: 1 framework PR + 4 prompt-rephrase PRs.

## What ships in this PR

**Modules** (`scripts/__tests__/replay/`)
- `fixture-loader.mjs` — loads/shape-validates golden JSON; refuses `sanitized !== true`; invokes `assertSanitized` automatically (belt-and-suspenders enforced even by copy-paste authors)
- `validator-runner.mjs` — runs an injected downstream validator on V2 output with strict result-shape contract
- `parity-asserter.mjs` — strict `v1.passed === v2.passed` contract; treats v1=false→v2=true as a violation (intentional, README documents)
- `sanitization-checker.mjs` — scans `input`, `v1_output`, AND `validator_result` for: Anthropic API keys (incl. admin), OpenAI keys (incl. `sk-proj-` / `sk-svcacct-` / `sk-admin-`), AWS access keys, classic GitHub PATs (`ghp_`), GitHub fine-grained PATs (`github_pat_`), PEM private-key blocks, JWTs (with hyphens in middle segment for real base64url payloads). `SECRET_PATTERNS` is exported and frozen.
- `index.mjs` — barrel export
- `fixture-schema.json` + `README.md` — corpus convention for PRs #2-5

**CI** (`.github/workflows/replay-tests.yml`)
- Runs `npx vitest run scripts/__tests__/replay/` on PRs touching the framework, golden corpus, or any of the 4 target scripts
- Strictly blocking — no `continue-on-error` (FR-3 AC-3). The existing `test-coverage.yml` runs vitest informationally; this workflow is the merge gate.

**Golden-corpus scaffold** (`scripts/__tests__/golden/`)
- `.gitkeep` + `README.md` defining the per-script directory convention

**Tests** (35 vitest cases, ~210ms): shape validation, async edge cases, parity contract, all 7 secret patterns, validator-result scanning, loader's belt-and-suspenders guard. Test fixture strings are runtime-assembled to avoid tripping the repo's pre-commit secret scanner; runtime patterns still match.

## Sub-agent evidence (pre-commit)

| Agent | Verdict | Critical issues found | Status |
|---|---|---|---|
| TESTING | WARNING (intent CONDITIONAL_PASS) | JWT regex hyphen gap; loader didn't invoke scanner | **Fixed inline** |
| SECURITY | WARNING (intent CONDITIONAL_PASS) | OpenAI scoped-key bypass (`sk-proj-` etc.); GitHub fine-grained PAT bypass; `validator_result` unscanned | **Fixed inline** |

Both agents endorsed the strict-parity and `sanitized: true`-mandatory contract decisions. Rows in `sub_agent_execution_results` (ids `9234ff72-...`, `23ab12aa-...`).

## LOC justification

610 insertions across 14 files (202 source / 283 tests / 109 docs+config+yaml). Above the ≤100 target but justified per PR-size guidelines:
- Foundational infrastructure for a 5-PR campaign — splitting framework + tests would ship untested foundation
- Sub-agent reviews surfaced 4 critical defects which were fixed inline (added 6 tests for new patterns)
- Each subsequent PR (#2–5) is expected at ~50–80 LOC (one validator + ~10 fixtures + one replay test using this framework)
- Pre-commit LOC threshold check accepted the size with SD reference

## Follow-up QF (not blocking this PR)

Per security-agent recommendations, before this framework is reused on any script that touches Slack/Stripe/Google/SendGrid: add patterns for `xoxb-` / `xoxp-`, `sk_live_` / `pk_live_`, `AIza…`, `SG.…`, plus PII (email/phone/IP), plus a `golden-corpus-sanitized.test.js` walker that asserts every fixture in `scripts/__tests__/golden/**` is clean (so a fixture-only PR can't slip past the loader). Tracked separately.

## Test plan

- [x] `npx vitest run scripts/__tests__/replay/` → 35/35 pass locally
- [x] Pre-commit secret scanner passes (test fixtures runtime-assembled)
- [x] Pre-commit LOC threshold accepted (SD reference present)
- [ ] CI `Replay Framework Tests` workflow turns green on this PR
- [ ] CI `Test Coverage Enforcement` (informational) does not regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)