### PR TITLE
fix(QF-20260425-864): extend replay sanitization patterns + corpus walker

### DIFF
--- a/scripts/__tests__/golden/golden-corpus-sanitized.test.js
+++ b/scripts/__tests__/golden/golden-corpus-sanitized.test.js
@@ -1,0 +1,46 @@
+// Walks every fixture under scripts/__tests__/golden/<script>/*.json and
+// asserts assertSanitized passes on it. Closes the threat-model gap where
+// a fixture-only PR could land if the test author skipped the import that
+// triggers the loader's auto-scan. This walker fires regardless of imports.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertSanitized } from '../replay/sanitization-checker.mjs';
+
+const GOLDEN_ROOT = path.dirname(fileURLToPath(import.meta.url));
+
+async function findFixtures(dir) {
+  const out = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await findFixtures(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.json') && entry.name !== 'schema.json') {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('golden corpus sanitization (walker)', async () => {
+  const fixtures = await findFixtures(GOLDEN_ROOT);
+
+  if (fixtures.length === 0) {
+    it('no fixtures yet — vacuously sanitized (PRs #2-5 will populate)', () => {
+      expect(fixtures).toEqual([]);
+    });
+    return;
+  }
+
+  for (const fixturePath of fixtures) {
+    const relative = path.relative(GOLDEN_ROOT, fixturePath);
+    it(`${relative} contains no apparent secrets`, async () => {
+      const raw = await fs.readFile(fixturePath, 'utf8');
+      const fixture = JSON.parse(raw);
+      expect(() => assertSanitized(fixture, relative)).not.toThrow();
+    });
+  }
+});

--- a/scripts/__tests__/replay/README.md
+++ b/scripts/__tests__/replay/README.md
@@ -55,9 +55,34 @@ See `fixture-schema.json`. Every fixture must include:
 
 ## Sanitization
 
-`sanitization-checker.mjs` scans `input`, `v1_output`, and `validator_result` for: Anthropic API keys (incl. admin), OpenAI API keys (incl. `sk-proj-` / `sk-svcacct-` / `sk-admin-` scoped), AWS access keys, GitHub classic PATs (`ghp_`), GitHub fine-grained PATs (`github_pat_`), PEM private-key blocks, and JWTs. The loader (`loadFixture`) invokes `assertSanitized` automatically — refusal-on-suspicion is the policy, since the asymmetric cost (re-redact one fixture vs. leak a Supabase service-role key) favors aggression. Capture pipelines must redact these before writing the fixture.
+`sanitization-checker.mjs` scans `input`, `v1_output`, and `validator_result` for the patterns below. The loader (`loadFixture`) invokes `assertSanitized` automatically, AND `scripts/__tests__/golden/golden-corpus-sanitized.test.js` walks every fixture in CI regardless of which test imports the loader — refusal-on-suspicion is the policy, since the asymmetric cost (re-redact one fixture vs. leak a Supabase service-role key) favors aggression. Capture pipelines must redact these before writing the fixture.
 
-**Known false-positive class**: prose like `"eyJexample0.eyJexample0.signature"` will trip the JWT pattern. Either rephrase the example or redact it; do not add to allowlists. Coverage gaps not in scope for PR #1: Slack tokens, Stripe keys, Google API keys, SendGrid keys, postgres connection strings with embedded passwords, PII (email/phone/IP). Cover in a follow-up QF before reusing this framework for any script that touches those services.
+**Patterns covered** (12, frozen via `Object.freeze(SECRET_PATTERNS)`):
+
+| Pattern | Examples |
+|---|---|
+| `anthropic_api_key` | `sk-ant-...` (incl. admin) |
+| `openai_api_key` | `sk-...`, `sk-proj-...`, `sk-svcacct-...`, `sk-admin-...` |
+| `aws_access_key` | `AKIA...` |
+| `github_token` | `ghp_...` (classic PAT) |
+| `github_fine_grained_pat` | `github_pat_...` |
+| `private_key_block` | PEM blocks (RSA/EC/DSA/OPENSSH/PGP) |
+| `jwt_token` | `eyJ...eyJ...sig` (incl. base64url middles with hyphens) |
+| `slack_token` | `xoxb-` / `xoxp-` / `xoxa-` / `xoxs-` |
+| `stripe_live_key` | `sk_live_` / `pk_live_` / `rk_live_` (NOT `sk_test_`) |
+| `google_api_key` | `AIza...` (39 chars) |
+| `sendgrid_api_key` | `SG.{x}.{y}` |
+| `postgres_conn_with_password` | `postgres://user:password@host` (passwordless URIs ignored) |
+
+**Known false-positive class**: prose like `"eyJexample0.eyJexample0.signature"` will trip the JWT pattern. Either rephrase the example or redact it; do not add to allowlists.
+
+**Explicit non-coverage** (out of scope; do not assume DLP):
+- PII — email addresses, phone numbers, IPv4/IPv6 addresses, postal addresses, names, dates of birth.
+- Stripe test keys (`sk_test_` / `pk_test_`) — placeholder convention, not real credentials.
+- Bearer tokens with no recognizable prefix or structure.
+- Encrypted blobs masquerading as plain text.
+
+If a future target script handles PII or any uncovered credential class, add the pattern in a separate QF before opening the script-rephrase PR.
 
 ## Parity contract
 

--- a/scripts/__tests__/replay/sanitization-checker.mjs
+++ b/scripts/__tests__/replay/sanitization-checker.mjs
@@ -6,6 +6,11 @@ export const SECRET_PATTERNS = Object.freeze([
   { name: 'github_fine_grained_pat', pattern: /github_pat_[A-Za-z0-9_]{82,}/g },
   { name: 'private_key_block', pattern: /-----BEGIN (RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g },
   { name: 'jwt_token', pattern: /eyJ[A-Za-z0-9_=-]{8,}\.eyJ[A-Za-z0-9_=-]{8,}\.[A-Za-z0-9_\-+/=]{8,}/g },
+  { name: 'slack_token', pattern: /xox[abps]-[A-Za-z0-9-]{20,}/g },
+  { name: 'stripe_live_key', pattern: /(?:sk|pk|rk)_live_[A-Za-z0-9]{24,}/g },
+  { name: 'google_api_key', pattern: /AIza[A-Za-z0-9_-]{35}/g },
+  { name: 'sendgrid_api_key', pattern: /SG\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{40,}/g },
+  { name: 'postgres_conn_with_password', pattern: /postgres(?:ql)?:\/\/[^:\s/@]+:[^@\s]+@/g },
 ]);
 
 export class SanitizationViolation extends Error {

--- a/scripts/__tests__/replay/sanitization-checker.test.js
+++ b/scripts/__tests__/replay/sanitization-checker.test.js
@@ -11,9 +11,17 @@ const PREFIX_SVCACCT = SK + 'svcacct-';
 const PREFIX_AKIA = 'AK' + 'IA';
 const PREFIX_GHP = 'gh' + 'p_';
 const PREFIX_PAT = 'github' + '_pat_';
+const PREFIX_XOXB = 'xo' + 'xb-';
+const PREFIX_XOXP = 'xo' + 'xp-';
+const PREFIX_STRIPE_SK = 's' + 'k_live_';
+const PREFIX_STRIPE_PK = 'p' + 'k_live_';
+const PREFIX_GOOG = 'AI' + 'za';
+const PREFIX_SG = 'S' + 'G.';
 const PAYLOAD = 'A'.repeat(24);
 const LONG_PAYLOAD = 'A'.repeat(36);
 const FINE_GRAINED_PAYLOAD = 'A'.repeat(82);
+const GOOG_PAYLOAD = 'A'.repeat(35);
+const SG_PAYLOAD = 'A'.repeat(22) + '.' + 'B'.repeat(43);
 
 describe('scanForSecrets', () => {
   it('returns [] for clean text', () => {
@@ -69,6 +77,56 @@ describe('scanForSecrets', () => {
   it('detects JWT tokens whose middle segment contains hyphens (real base64url)', () => {
     const hits = scanForSecrets('eyJhbGciOiJI.eyJzdWItcw-AB.signaturepart12');
     expect(hits.find(h => h.kind === 'jwt_token')).toBeTruthy();
+  });
+
+  it('detects Slack bot tokens (xoxb-)', () => {
+    const hits = scanForSecrets(PREFIX_XOXB + '12345-67890-' + PAYLOAD);
+    expect(hits.find(h => h.kind === 'slack_token')).toBeTruthy();
+  });
+
+  it('detects Slack user tokens (xoxp-)', () => {
+    const hits = scanForSecrets(PREFIX_XOXP + '12345-67890-' + PAYLOAD);
+    expect(hits.find(h => h.kind === 'slack_token')).toBeTruthy();
+  });
+
+  it('detects Stripe live secret keys (sk_live_)', () => {
+    const hits = scanForSecrets(PREFIX_STRIPE_SK + PAYLOAD);
+    expect(hits.find(h => h.kind === 'stripe_live_key')).toBeTruthy();
+  });
+
+  it('detects Stripe live publishable keys (pk_live_)', () => {
+    const hits = scanForSecrets(PREFIX_STRIPE_PK + PAYLOAD);
+    expect(hits.find(h => h.kind === 'stripe_live_key')).toBeTruthy();
+  });
+
+  it('does not match Stripe test keys (sk_test_/pk_test_)', () => {
+    const hits = scanForSecrets('sk' + '_test_' + PAYLOAD);
+    expect(hits.find(h => h.kind === 'stripe_live_key')).toBeFalsy();
+  });
+
+  it('detects Google API keys (AIza-prefixed, 39 chars total)', () => {
+    const hits = scanForSecrets(PREFIX_GOOG + GOOG_PAYLOAD);
+    expect(hits.find(h => h.kind === 'google_api_key')).toBeTruthy();
+  });
+
+  it('detects SendGrid API keys (SG.{x}.{y})', () => {
+    const hits = scanForSecrets(PREFIX_SG + SG_PAYLOAD);
+    expect(hits.find(h => h.kind === 'sendgrid_api_key')).toBeTruthy();
+  });
+
+  it('detects postgres connection strings with embedded passwords', () => {
+    const hits = scanForSecrets('postgres' + '://user:hunter2@host:5432/db');
+    expect(hits.find(h => h.kind === 'postgres_conn_with_password')).toBeTruthy();
+  });
+
+  it('detects postgresql:// scheme variant with embedded passwords', () => {
+    const hits = scanForSecrets('postgres' + 'ql://admin:s3cret@10.0.0.1:5432/prod');
+    expect(hits.find(h => h.kind === 'postgres_conn_with_password')).toBeTruthy();
+  });
+
+  it('does not match passwordless postgres URIs (no password = no leak)', () => {
+    const hits = scanForSecrets('postgres' + '://localhost:5432/devdb');
+    expect(hits.find(h => h.kind === 'postgres_conn_with_password')).toBeFalsy();
   });
 
   it('serializes objects before scanning', () => {


### PR DESCRIPTION
## Summary

Security follow-up to PR #3344 (`SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001`). The SECURITY sub-agent (row `23ab12aa-...` in `sub_agent_execution_results`) gave verdict WARNING with a deferred-but-bounded recommendation: broaden the framework's pattern coverage and close a real threat-model gap before PRs #2–5 of the campaign build on it.

## Changes

**5 new patterns** added to `SECRET_PATTERNS` (frozen array, now 12 total):

| Pattern | Matches |
|---|---|
| `slack_token` | `xoxb-` / `xoxp-` / `xoxa-` / `xoxs-` |
| `stripe_live_key` | `sk_live_` / `pk_live_` / `rk_live_` (test keys explicitly excluded) |
| `google_api_key` | `AIza...` (39-char total) |
| `sendgrid_api_key` | `SG.{x}.{y}` |
| `postgres_conn_with_password` | `postgres(ql)?://user:pw@...` (passwordless URIs ignored) |

**New walker test** (`scripts/__tests__/golden/golden-corpus-sanitized.test.js`): walks every fixture under `scripts/__tests__/golden/<script>/*.json` and asserts `assertSanitized` passes — regardless of which other test imports the loader. Closes the threat-model gap where a fixture-only PR could land if the test author skips the import that triggers `loadFixture`'s auto-scan.

**README threat-model section** now lists all 12 patterns in a table and explicitly documents non-coverage (PII, Stripe test keys, prefix-less bearer tokens, encrypted blobs).

## Tests

- 46 vitest cases pass in ~240ms (was 35; +10 sanitization + 1 walker).
- Test fixture strings use runtime-string-assembly (`'sk' + '_live_' + ...`) to avoid tripping the repo's pre-commit secret scanner; runtime regex still matches.
- The blocking `Replay Framework Tests` workflow added in PR #3344 covers these paths.

## Scope discipline

This QF is strictly **additive**. The existing `openai_api_key` pattern (and other 6 inherited patterns) are unchanged. Any modifications to existing patterns belong in a separate QF.

## LOC

140 lines (+137 -3) across 4 files. Below the LOC threshold; no SD reference required by pre-commit hook.

## Test plan

- [x] `npx vitest run scripts/__tests__/replay/ scripts/__tests__/golden/` → 46/46 pass locally
- [x] Pre-commit secret scanner passes
- [ ] CI `Replay Framework Tests` workflow turns green
- [ ] Auto-merge with `--squash --delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)