### PR TITLE
feat(SD-LEO-INFRA-RESTART-SKILL-LEO-001): harden /restart skill + leo-stack PS

### DIFF
--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -16,73 +16,30 @@ This uses the appropriate script for the current platform:
 - **Windows**: Uses `leo-stack.ps1` (PowerShell)
 - **Linux/macOS/WSL**: Uses `leo-stack.sh` (Bash)
 
-This restarts all three servers:
+This restarts both managed servers:
 - EHG_Engineer (port 3000)
 - EHG App (port 8080)
-- Agent Platform (port 8000)
 
-After running, confirm the status shows all servers running.
+> Historical note: an "Agent Platform" service formerly managed by leo-stack was retired on 2026-04-25 (commit `f8e252ee28`, CrewAI elimination). leo-stack scripts no longer manage it; references to it in older docs are dead.
+
+After running, confirm the status shows both servers running.
+
+## Post-Restart Routing (Deterministic)
+
+After restart, route automatically based on the current SD's `sd_type` (read from `strategic_directives_v2`). Do **not** present `AskUserQuestion` menus at this boundary — the routing is deterministic per CLAUDE.md AUTO-PROCEED canonical pause-points.
+
+| `sd_type` | Next action |
+|-----------|-------------|
+| `feature`, `bugfix`, `security`, `refactor`, `enhancement` | Invoke `/uat` (UAT required before ship) |
+| `infrastructure`, `database`, `documentation` | Invoke `/ship` (no UAT required for these types) |
+| `orchestrator`, no SD claimed, or `sd_type` unknown | Log "Restart complete; awaiting operator direction" and return |
+
+The operator can verbally override at any time (e.g., "skip /uat", "done for now"). The deterministic rule replaces three prior `AskUserQuestion` menus that violated AUTO-PROCEED — see SD-LEO-INFRA-RESTART-SKILL-LEO-001.
 
 ## Command Ecosystem Integration
 
-### Cross-Reference
-
 This command is part of the **Command Ecosystem**. For full workflow context, see:
-- **[Command Ecosystem Reference](../../docs/reference/command-ecosystem.md)** - Complete inter-command flow diagram and relationships
-
----
-
-The `/restart` command connects to other commands in the workflow:
-
-### Post-Restart Suggestions
-
-**If SD requires UAT (feature, bugfix, security, refactor, enhancement) - Use AskUserQuestion:**
-
-```javascript
-{
-  "question": "Servers restarted. Ready for User Acceptance Testing?",
-  "header": "Post-Restart",
-  "multiSelect": false,
-  "options": [
-    {"label": "/uat (Recommended)", "description": "Run human acceptance testing before shipping"},
-    {"label": "Skip UAT, /ship", "description": "Ship without formal UAT (not recommended for features)"},
-    {"label": "/leo next", "description": "Check SD queue first"},
-    {"label": "Done for now", "description": "End session"}
-  ]
-}
-```
-
-**If SD is infrastructure/database/docs (UAT exempt) - Use AskUserQuestion:**
-
-```javascript
-{
-  "question": "Servers restarted. Ready for visual review?",
-  "header": "Post-Restart",
-  "multiSelect": false,
-  "options": [
-    {"label": "Visual review done, /ship", "description": "Proceed to shipping workflow"},
-    {"label": "/leo next", "description": "Check SD queue first"},
-    {"label": "Done for now", "description": "End session"}
-  ]
-}
-```
-
-**If starting fresh work - Use AskUserQuestion:**
-
-```javascript
-{
-  "question": "Servers restarted. What would you like to do?",
-  "header": "Next Step",
-  "multiSelect": false,
-  "options": [
-    {"label": "/leo next", "description": "See SD queue and pick next work"},
-    {"label": "/leo status", "description": "Check current SD progress"},
-    {"label": "Done for now", "description": "End session"}
-  ]
-}
-```
-
-**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
+- **[Command Ecosystem Reference](../../docs/reference/command-ecosystem.md)** — Complete inter-command flow diagram and relationships
 
 ### When to Use /restart
 
@@ -94,11 +51,11 @@ The `/restart` command connects to other commands in the workflow:
 | Long session (>2 hours) | Yes | Prevents stale server state |
 | After major implementation | Yes | Ensure changes are reflected |
 | Quick-fix or small changes | Optional | Usually not needed |
+| Backend-only SDs (no UI) | Skip | Restart is pure ceremony with no UI to refresh |
 
 ### Typical Flow After /restart
 
 ```
-/restart → /uat → /ship → /document → /learn
+/restart → /uat → /ship → /document → /learn   (UAT-required sd_types)
+/restart → /ship → /document → /learn          (UAT-exempt sd_types)
 ```
-
-For UAT-requiring SDs (feature, bugfix, security, refactor, enhancement), always suggest /uat before /ship.

--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -30,9 +30,11 @@ After restart, route automatically based on the current SD's `sd_type` (read fro
 
 | `sd_type` | Next action |
 |-----------|-------------|
-| `feature`, `bugfix`, `security`, `refactor`, `enhancement` | Invoke `/uat` (UAT required before ship) |
-| `infrastructure`, `database`, `documentation` | Invoke `/ship` (no UAT required for these types) |
-| `orchestrator`, no SD claimed, or `sd_type` unknown | Log "Restart complete; awaiting operator direction" and return |
+| `feature`, `bugfix`, `security`, `refactor`, `enhancement`, `performance`, `ux_debt` | Invoke `/uat` (UAT required before ship — user-observable surface) |
+| `infrastructure`, `database`, `documentation`, `docs`, `uat` | Invoke `/ship` (no UAT required — `uat` campaigns ARE the test scenarios) |
+| `orchestrator`, `discovery_spike`, `implementation`, no SD claimed, or `sd_type` unknown | Log "Restart complete; awaiting operator direction" and return |
+
+> The 15 valid `sd_type` values are defined in `database/migrations/20260206_register_uat_sd_type.sql`. If a new type is introduced, update this table and the corresponding test invariant.
 
 The operator can verbally override at any time (e.g., "skip /uat", "done for now"). The deterministic rule replaces three prior `AskUserQuestion` menus that violated AUTO-PROCEED — see SD-LEO-INFRA-RESTART-SKILL-LEO-001.
 

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,6 @@
 {
-  "sdKey": "SD-EHG-MARKETING-DISTRIBUTION-PRODUCER-BINDING-001",
-  "expectedBranch": "feat/SD-EHG-MARKETING-DISTRIBUTION-PRODUCER-BINDING-001",
-  "createdAt": "2026-04-24T20:05:55.630Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
+  "sdKey": "SD-LEO-INFRA-RESTART-SKILL-LEO-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-RESTART-SKILL-LEO-001",
+  "createdAt": "2026-04-25T17:39:18.267Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer"
 }

--- a/docs/guides/leo-stack-management.md
+++ b/docs/guides/leo-stack-management.md
@@ -1,9 +1,9 @@
 ---
 category: guide
 status: draft
-version: 1.0.0
+version: 2.1.0
 author: auto-fixer
-last_updated: 2026-02-28
+last_updated: 2026-04-25
 tags: [guide, auto-generated]
 ---
 # LEO Stack Management - Cross-Platform Version
@@ -14,21 +14,16 @@ tags: [guide, auto-generated]
 - [Metadata](#metadata)
 - [Overview](#overview)
 - [Platform Support](#platform-support)
-- [Overview](#overview)
 - [Quick Start](#quick-start)
   - [Using the Cross-Platform Runner (Recommended)](#using-the-cross-platform-runner-recommended)
   - [Using the /leo and /restart Slash Commands](#using-the-leo-and-restart-slash-commands)
   - [Start Individual Servers](#start-individual-servers)
 - [Windows-Specific Notes](#windows-specific-notes)
   - [PowerShell Direct Usage](#powershell-direct-usage)
-  - [Virtual Environment for Agent Platform](#virtual-environment-for-agent-platform)
 - [Prerequisites](#prerequisites)
-  - [For All Servers](#for-all-servers)
-  - [For Agent Platform (Port 8000)](#for-agent-platform-port-8000)
 - [Server URLs](#server-urls)
 - [Troubleshooting](#troubleshooting)
   - [Port Already in Use](#port-already-in-use)
-  - [Agent Platform Not Starting](#agent-platform-not-starting)
   - [Viewing Logs](#viewing-logs)
 - [Development Workflow](#development-workflow)
   - [Standard Development Session](#standard-development-session)
@@ -43,16 +38,19 @@ tags: [guide, auto-generated]
 ## Metadata
 - **Category**: Guide
 - **Status**: Approved
-- **Version**: 2.0.0
-- **Author**: Claude Code (Windows Migration)
-- **Last Updated**: 2026-01-19
+- **Version**: 2.1.0
+- **Last Updated**: 2026-04-25
 - **Tags**: leo-stack, deployment, cross-platform, windows, operations
 
 ## Overview
 
-Management guide for the LEO Stack - the three-server ecosystem powering the LEO Protocol.
+Management guide for the LEO Stack — the two-server ecosystem powering the LEO Protocol.
 
 **Quick Command:** `node scripts/cross-platform-run.js leo-stack [start|stop|restart|status]`
+
+> Agent Platform was removed from leo-stack management on 2026-04-25 (commit `f8e252ee28`, CrewAI elimination). AI workflows that previously ran under leo-stack management have been retired; references in older docs and archived scripts are dead.
+
+> Operators are responsible for `git pull` in `EHG_Engineer/` and `ehg/` before `/restart` if they want latest. The Windows path no longer auto-pulls (matches POSIX behavior; prevents peer-worktree clobber).
 
 ## Platform Support
 
@@ -65,17 +63,12 @@ The cross-platform runner automatically selects the right script for your OS.
 
 ---
 
-## Overview
-
-The **LEO Stack** consists of three servers that power your LEO Protocol ecosystem:
+## Servers Managed
 
 | Server | Port | Purpose | Technology | Startup Time |
 |--------|------|---------|------------|--------------|
 | **EHG_Engineer** | 3000 | LEO Protocol Framework & Backend API | Node.js/Express | ~1 second |
 | **EHG App** | 8080 | Frontend UI & User Interface | Vite/React | ~3 seconds |
-| **Agent Platform** | 8000 | AI Research Backend (for Venture Creation) | FastAPI/Python | **10-15 seconds** |
-
-**Note:** The Agent Platform (port 8000) takes 10-15 seconds to fully start because it loads AI components.
 
 ## Quick Start
 
@@ -113,7 +106,6 @@ In Claude Code sessions:
 ```bash
 node scripts/cross-platform-run.js leo-stack start-engineer
 node scripts/cross-platform-run.js leo-stack start-app
-node scripts/cross-platform-run.js leo-stack start-agent
 ```
 
 ## Windows-Specific Notes
@@ -129,30 +121,10 @@ You can also run the PowerShell script directly:
 .\scripts\leo-stack.ps1 restart -Fast
 ```
 
-### Virtual Environment for Agent Platform
-
-On Windows, the Python venv is at `venv_win`:
-```powershell
-cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
-.\venv_win\Scripts\Activate.ps1
-```
-
 ## Prerequisites
 
-### For All Servers
 - Node.js and npm installed
-- Git for Windows (includes Git Bash)
-
-### For Agent Platform (Port 8000)
-- Python 3.10+
-- Virtual environment set up (`venv_win` on Windows)
-
-**First-time setup for Agent Platform:**
-
-```powershell
-cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
-.\INSTALL.ps1
-```
+- Git for Windows (includes Git Bash) on Windows; standard `git` elsewhere
 
 ## Server URLs
 
@@ -160,8 +132,6 @@ cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
 |--------|-----|-------------|
 | EHG_Engineer | http://localhost:3000 | Immediately |
 | EHG App | http://localhost:8080 | ~3 seconds |
-| Agent Platform | http://localhost:8000 | 10-15 seconds |
-| API Docs | http://localhost:8000/api/docs | 10-15 seconds |
 
 ## Troubleshooting
 
@@ -180,46 +150,6 @@ Stop-Process -Id <PID> -Force
 node scripts/cross-platform-run.js leo-stack clean
 ```
 
-### Agent Platform Not Starting
-
-**Check virtual environment:**
-```powershell
-Test-Path C:\Users\rickf\Projects\_EHG\ehg\agent-platform\venv_win
-```
-
-If not found, run setup:
-```powershell
-cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
-.\INSTALL.ps1
-```
-
-**Check for missing dependencies:**
-If you see `ModuleNotFoundError` in logs, install the missing package:
-```powershell
-cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
-.\venv_win\Scripts\pip.exe install <missing-package>
-```
-
-**Common dependency issues and resolutions:**
-
-| Error | Missing Package(s) | Solution |
-|-------|-------------------|----------|
-| `No module named 'langchain_openai'` | `langchain_openai` | `pip install langchain_openai` |
-| `No module named 'anthropic'` | `anthropic` | `pip install anthropic` |
-| `Client.__init__() got an unexpected keyword argument 'proxy'` | Outdated `supabase` stack | `pip install --upgrade supabase gotrue` |
-| `No module named 'websockets.asyncio'` | Outdated `websockets` | `pip install "websockets>=13,<16"` |
-
-**Full dependency reinstall (if multiple issues):**
-```powershell
-cd C:\Users\rickf\Projects\_EHG\ehg\agent-platform
-.\venv_win\Scripts\pip.exe install -r requirements.txt --upgrade
-```
-
-**Note:** After installing dependencies, restart the Agent Platform:
-```bash
-node scripts/cross-platform-run.js leo-stack restart
-```
-
 ### Viewing Logs
 
 Logs are stored in `.logs/`:
@@ -230,7 +160,6 @@ Get-ChildItem .logs -File | Sort-Object LastWriteTime -Descending | Select-Objec
 # View specific log
 Get-Content .logs\engineer-*.log -Tail 50
 Get-Content .logs\app-*.log -Tail 50
-Get-Content .logs\agent-*.log -Tail 50
 ```
 
 ## Development Workflow
@@ -241,9 +170,8 @@ Get-Content .logs\agent-*.log -Tail 50
    ```bash
    node scripts/cross-platform-run.js leo-stack start
    ```
-   Wait 15 seconds for Agent Platform to fully load.
 
-2. **Verify all servers:**
+2. **Verify both servers:**
    ```bash
    node scripts/cross-platform-run.js leo-stack status
    ```
@@ -284,7 +212,6 @@ Use `-Fast` flag for reduced delays during development.
 PID files are stored in `.pids/`:
 - `engineer.pid` - EHG_Engineer process
 - `app.pid` - EHG App process
-- `agent.pid` - Agent Platform process
 
 ### Log Files
 
@@ -292,7 +219,6 @@ Log files are stored in `.logs/`:
 - `leo-stack-YYYYMMDD-HHMMSS.log` - Script operations
 - `engineer-*.log` - EHG_Engineer output
 - `app-*.log` - Vite output
-- `agent-*.log` - FastAPI output
 
 ## Commands Reference
 
@@ -305,17 +231,12 @@ Log files are stored in `.logs/`:
 | `clean` | Clean up processes on all ports |
 | `start-engineer` | Start only EHG_Engineer (3000) |
 | `start-app` | Start only EHG App (8080) |
-| `start-agent` | Start only Agent Platform (8000) |
-| `emergency` | Force kill all node/python processes |
+| `start-worker` | Start workers from `config/workers.json` |
+| `emergency` | Force kill all node processes (Windows only; prompts for confirmation) |
 
 ## Support
 
 For issues:
-- Check this README
+- Check this guide
 - Review logs in `.logs/`
 - Verify prerequisites are installed
-- Wait 15 seconds after starting for Agent Platform
-
----
-
-*Updated: January 2026 - Windows native environment (no WSL)*

--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -178,18 +178,7 @@ function Start-App {
         }
     }
 
-    # Auto-pull latest from remote before starting (SD-MAN-REFAC-S17-SIMPLIFY-FRONTEND-001)
-    Push-Location $AppDir
-    $gitPull = & git pull origin main 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        $changes = ($gitPull | Select-String "files changed|Already up to date" | Out-String).Trim()
-        if ($changes -and -not ($changes -match "Already up to date")) {
-            Write-Log "INFO" "[UI] Pulled latest: $changes" "Cyan"
-        }
-    } else {
-        Write-Log "WARN" "[UI] git pull failed (non-blocking): $gitPull" "Yellow"
-    }
-    Pop-Location
+    # No auto git-pull here — keeps parity with leo-stack.sh and avoids clobbering peer-worktree state.
 
     # Auto-install if node_modules missing (fleet ops can clobber them)
     $viteBin = Join-Path $AppDir "node_modules\.bin\vite.cmd"

--- a/tests/restart-skill-content.test.js
+++ b/tests/restart-skill-content.test.js
@@ -1,0 +1,109 @@
+/**
+ * Content invariants for the /restart skill and leo-stack scripts.
+ *
+ * These assertions lock the cleanup shipped by SD-LEO-INFRA-RESTART-SKILL-LEO-001
+ * so future drift is caught at CI rather than at /restart-time.
+ *
+ * Each failure message names the specific drift and points to the SD —
+ * if you intentionally need to restore one of these patterns (e.g., bringing
+ * back an Agent Platform service), file a new SD that updates this test.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+
+const restartSkillPath = resolve(repoRoot, '.claude/commands/restart.md');
+const leoStackPs1Path = resolve(repoRoot, 'scripts/leo-stack.ps1');
+const guidePath = resolve(repoRoot, 'docs/guides/leo-stack-management.md');
+
+let restartSkill;
+let leoStackPs1;
+let guide;
+
+beforeAll(() => {
+  restartSkill = readFileSync(restartSkillPath, 'utf8');
+  leoStackPs1 = readFileSync(leoStackPs1Path, 'utf8');
+  guide = readFileSync(guidePath, 'utf8');
+});
+
+describe('restart skill — Agent Platform / port 8000 doc-truth', () => {
+  it('restart.md does not reference Agent Platform', () => {
+    const matches = restartSkill.match(/agent platform/gi) || [];
+    expect(
+      matches.length,
+      'restart.md must not reference Agent Platform — the service was retired in commit f8e252ee28 and leo-stack scripts no longer manage it. The "Historical note" line about retirement is the only allowed mention and lives in restart.md only when phrased as a historical note. To restore Agent Platform, file a new SD.'
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it('restart.md does not list port 8000 as a managed server', () => {
+    const matches = restartSkill.match(/port\s*8000|:8000/gi) || [];
+    expect(
+      matches.length,
+      'restart.md must not list :8000 as a managed server — leo-stack.ps1 and leo-stack.sh manage only :3000 and :8080.'
+    ).toBe(0);
+  });
+});
+
+describe('restart skill — AUTO-PROCEED routing (no AskUserQuestion)', () => {
+  it('restart.md contains zero AskUserQuestion menu invocations', () => {
+    // Match menu-shaped invocations (JSON `"question":` field or `AskUserQuestion(` call).
+    // Prose references explaining why menus were removed are intentionally allowed.
+    const matches = restartSkill.match(/(?:"question"\s*:\s*"|AskUserQuestion\s*\()/g) || [];
+    expect(
+      matches.length,
+      'restart.md must not embed AskUserQuestion menu invocations — three prior menus violated AUTO-PROCEED canonical pause-points (CLAUDE.md). Routing is now deterministic on sd_type.'
+    ).toBe(0);
+  });
+
+  it('restart.md contains a deterministic sd_type-based routing rule', () => {
+    expect(
+      restartSkill,
+      'restart.md must reference sd_type so the post-restart routing is deterministic.'
+    ).toMatch(/sd_type/);
+    expect(
+      restartSkill,
+      'restart.md must reference at least one downstream skill (/uat or /ship) in its routing rule.'
+    ).toMatch(/\/uat|\/ship/);
+  });
+});
+
+describe('leo-stack.ps1 — no auto git-pull (parity with leo-stack.sh)', () => {
+  it('leo-stack.ps1 does not invoke git pull', () => {
+    const matches = leoStackPs1.match(/git\s+pull/g) || [];
+    expect(
+      matches.length,
+      'leo-stack.ps1 must not auto-pull — the bash sibling does not auto-pull, and Windows-only auto-pull can clobber peer-worktree state during parallel sessions. Operators run `git pull` explicitly.'
+    ).toBe(0);
+  });
+
+  it('leo-stack.ps1 still recovers missing node_modules in EHG App', () => {
+    expect(
+      leoStackPs1,
+      'leo-stack.ps1 Start-App must keep the node_modules-recovery block — fleet ops can clobber node_modules and the script needs to self-heal.'
+    ).toMatch(/node_modules missing in EHG App/);
+  });
+});
+
+describe('leo-stack-management.md — guide reflects current servers only', () => {
+  it('guide contains at most one Agent Platform reference (the deprecation note)', () => {
+    const matches = guide.match(/agent platform/gi) || [];
+    expect(
+      matches.length,
+      'leo-stack-management.md must mention Agent Platform at most once (the single deprecation note pointing operators at the f8e252ee28 retirement). All other references are dead docs.'
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it('guide does not list port 8000 as a managed server', () => {
+    const matches = guide.match(/port\s*8000|:8000/gi) || [];
+    expect(
+      matches.length,
+      'leo-stack-management.md must not list :8000 — Agent Platform is retired.'
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent operator-facing drift bugs in the `/restart` subsystem:

- **Doc-truth restoration**: `restart.md` claimed it managed an "Agent Platform" service on `:8000`, but that service was retired Feb 2026 (commit `f8e252ee28`, CrewAI elimination). Operators saw false "all servers running" confirmations while AI workflows on `:8000` were dead. Stripped from `restart.md` + `docs/guides/leo-stack-management.md` (~17 dead refs); 1-line deprecation note replaces the section.
- **AUTO-PROCEED routing**: Replaced 3 sequential `AskUserQuestion` menus in `restart.md` with deterministic `sd_type`-keyed routing. Menus violated CLAUDE.md canonical pause-points and contradicted three documented memories (`feedback_auto_proceed_decide_dont_ask`, `feedback_infer_mode_dont_ask`, `user_auto_proceed_intent`).
- **PowerShell parity**: Removed Windows-only auto `git pull origin main` from `leo-stack.ps1` Start-App. The bash sibling never auto-pulled; the asymmetry could clobber peer-worktree state during parallel sessions.

`tests/restart-skill-content.test.js` locks 8 invariants (4 product + 4 negative) so future drift is caught at CI.

**Net diff**: -134 LOC (mostly dead-doc removal). **Defers** to follow-up SDs: HTTP health probes, `$EngineerDir` hardcoding, PS Read-Host emergency hang, broader bash/PS asymmetry cleanup.

## Test plan

- [x] `npx vitest run tests/restart-skill-content.test.js` → 8/8 passing
- [x] Visual review of `restart.md` confirms deterministic routing rule + historical note
- [x] `leo-stack.ps1` Start-App still has `node_modules`-recovery block intact
- [ ] Manual verification on next `/restart` invocation: no AskUserQuestion deferred-tool prompts, sd_type-based auto-route fires
- [ ] Manual verification on Windows: `node scripts/cross-platform-run.js leo-stack restart` produces no `[UI] Pulled latest:` log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)