### PR TITLE
fix(QF-20260425-084): stage-template barrel + venture monitor labels — operational hotfix

### DIFF
--- a/lib/eva/stage-templates/index.js
+++ b/lib/eva/stage-templates/index.js
@@ -35,18 +35,22 @@ export { default as stage15 } from './stage-15.js';
 export { default as stage16 } from './stage-16.js';
 export { default as stage17, evaluatePromotionGate as evaluatePhase4PromotionGate } from './stage-17.js';
 
-// Phase 5: THE BUILD LOOP (Stages 18-23)
+// Phase 5: BUILD & MARKET (Stages 18-22, post-redesign)
 export { default as stage18 } from './stage-18.js';
 export { default as stage19 } from './stage-19.js';
 export { default as stage20 } from './stage-20.js';
 export { default as stage21 } from './stage-21.js';
 export { default as stage22 } from './stage-22.js';
-export { default as stage23, evaluatePromotionGate as evaluatePhase5PromotionGate } from './stage-23.js';
 
-// Phase 6: LAUNCH & LEARN (Stages 24-26)
-export { default as stage24, checkReleaseReadiness } from './stage-24.js';
-export { default as stage25, computeReadinessScore } from './stage-25.js';
-export { default as stage26, verifyLaunchAuthorization } from './stage-26.js';
+// Phase 6: LAUNCH & GROW (Stages 23-26, post-redesign — S23 is now a kill gate, not promotion)
+// Named exports below were removed by SD-REDESIGN-S18S26-E+F (PR #3211, 2026-04-21):
+//   stage-23: evaluatePromotionGate (S23 is no longer a promotion gate; promotion lives at S17)
+//   stage-24: checkReleaseReadiness | stage-25: computeReadinessScore | stage-26: verifyLaunchAuthorization
+// Re-exports were dead bindings causing ESM crashloop (RCA 2026-04-25). Restore via auto-discovery — see follow-up SD.
+export { default as stage23 } from './stage-23.js';
+export { default as stage24 } from './stage-24.js';
+export { default as stage25 } from './stage-25.js';
+export { default as stage26 } from './stage-26.js';
 
 import stage01 from './stage-01.js';
 import stage02 from './stage-02.js';

--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -13,22 +13,48 @@ require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-const VENTURE_ID = 'c1b214ad-af1e-4c7a-ba1b-d18fb1f59c06';
-const VENTURE_NAME = 'Blueprint Governance';
+const VENTURE_ID = process.env.VENTURE_ID || '94856fc6-9ba9-4f56-9a5c-85041031a0fc';
+const VENTURE_NAME = process.env.VENTURE_NAME || 'LexiGuard';
 const STOP_AT_STAGE = 17;
 const POLL_MS = 30000;
 
-// Gate classification (from gate-constants.js)
-const KILL_GATES = new Set([3, 5, 13, 24]);
-const PROMOTION_GATES = new Set([10, 17, 18, 19, 23, 25]);
-const BLOCKING_GATES = new Set([3, 5, 10, 13, 17, 18, 19, 20, 23, 24, 25]);
+// Gate classification — sourced from lifecycle_stage_config (DB authoritative as of 2026-04-25)
+// Decision gates require chairman_decision row before advance. PROMOTION = metadata.gate_type='promotion'.
+// S23 is named "Launch Readiness Kill Gate" but stored as decision_gate; flagged here for log clarity.
+const KILL_GATES = new Set([23]);
+const PROMOTION_GATES = new Set([17]);
+const BLOCKING_GATES = new Set([3, 5, 13, 16, 17, 23, 24]);
+// Stages that need an SD/human input (work_type=sd_required) — auto-advance is unsafe
+const SD_REQUIRED_STAGES = new Set([10, 18, 19]);
 
 const STAGE_NAMES = {
-  0:'Stage Zero', 1:'Ideation', 2:'Research', 3:'Validation [KILL]', 4:'Market Analysis',
-  5:'Business Model [KILL]', 6:'Competitor Analysis', 7:'MVP Definition', 8:'Technical Assessment',
-  9:'Financial Modeling', 10:'Brand Identity [PROMO]', 11:'Naming & Visual', 12:'GTM Strategy',
-  13:'Tech Stack [KILL]', 14:'Architecture', 15:'Blueprint & Wireframes',
-  16:'Sprint Planning', 17:'Design Refinement [PROMO]'
+   0:'Stage Zero',
+   1:'Draft Idea',
+   2:'AI Review',
+   3:'Comprehensive Validation [GATE]',
+   4:'Competitive Intelligence',
+   5:'Profitability Forecasting [GATE]',
+   6:'Risk Evaluation',
+   7:'Revenue Architecture',
+   8:'Business Model Canvas',
+   9:'Exit Strategy',
+  10:'Customer & Brand Foundation [SD]',
+  11:'Naming & Visual Identity',
+  12:'GTM & Sales Strategy',
+  13:'Product Roadmap [GATE]',
+  14:'Technical Architecture',
+  15:'Design Studio',
+  16:'Financial Projections [GATE]',
+  17:'Blueprint Review [PROMO GATE]',
+  18:'Marketing Copy Studio [SD]',
+  19:'Build in Replit [SD]',
+  20:'Code Quality Gate',
+  21:'Visual Assets',
+  22:'Distribution Setup',
+  23:'Launch Readiness [KILL GATE]',
+  24:'Go Live & Announce [GATE]',
+  25:'Post-Launch Review',
+  26:'Growth Playbook'
 };
 
 // Post-Stitch-replacement: monitor wireframe_screens instead of stitch artifacts
@@ -47,18 +73,25 @@ const DESIGN_ARTIFACT_TYPES = [
   'stitch_curation', 'stitch_project', 'stitch_design_export',
 ];
 
-// Stage artifact expectations (what we expect at each stage)
+// Stage artifact expectations — sourced from lifecycle_stage_config.required_artifacts (DB authoritative)
 const EXPECTED_ARTIFACTS = {
-  1: ['truth_idea_brief'],
-  2: ['truth_ai_critique'],
-  3: ['truth_validation_decision'],
-  4: ['truth_competitive_analysis'],
-  5: ['truth_financial_model'],
+   1: ['truth_idea_brief'],
+   2: ['truth_ai_critique'],
+   3: ['truth_validation_decision'],
+   4: ['truth_competitive_analysis'],
+   5: ['truth_financial_model'],
+   6: ['engine_risk_matrix'],
+   7: ['engine_pricing_model'],
+   8: ['engine_business_model_canvas'],
+   9: ['engine_exit_strategy'],
   10: ['identity_persona_brand'],
-  11: ['identity_naming_visual', 'identity_brand_name'],
-  14: ['blueprint_technical_architecture'],
-  15: ['blueprint_wireframes', 'blueprint_user_story_pack'],
-  16: ['blueprint_sprint_plan'],
+  11: ['identity_naming_visual'],
+  12: ['identity_brand_guidelines', 'identity_gtm_sales_strategy'],
+  13: ['blueprint_product_roadmap'],
+  14: ['blueprint_technical_architecture', 'blueprint_data_model', 'blueprint_erd_diagram', 'blueprint_api_contract', 'blueprint_schema_spec'],
+  15: ['blueprint_wireframes'],
+  16: ['blueprint_financial_projection'],
+  17: ['system_devils_advocate_review'],
 };
 
 let lastStage = null;
@@ -339,10 +372,12 @@ function validateStageArtifacts(stage, arts) {
 async function main() {
   console.log(`\n${'='.repeat(70)}`);
   console.log(` VENTURE MONITOR — ${VENTURE_NAME} (${VENTURE_ID.slice(0,8)})`);
-  console.log(` Poll every ${POLL_MS/1000}s | Auto-push S3-S16 | HARD STOP at S${STOP_AT_STAGE}`);
-  console.log(` Kill gates: S3, S5, S13 | Promotion gates: S10, S17`);
-  console.log(` Stitch replacement: watching wireframe_screens (S15), s17_archetypes (S17)`);
-  console.log(` Design mastery: s17_design_system, s17_strategy_stats, cross-variant awareness`);
+  console.log(` Poll every ${POLL_MS/1000}s | Auto-push to S${STOP_AT_STAGE - 1} | HARD STOP at S${STOP_AT_STAGE}`);
+  console.log(` Decision gates  : S3, S5, S13, S16, S17 (PROMO), S23 (KILL), S24`);
+  console.log(` Manual / sd_req : S10 Brand, S18 Marketing Copy, S19 Build in Replit`);
+  console.log(` Phases: 1 TRUTH(1-5) | 2 ENGINE(6-9) | 3 IDENTITY(10-12) | 4 BLUEPRINT(13-17) | 5 BUILD&MARKET(18-22) | 6 LAUNCH&GROW(23-26)`);
+  console.log(` Stop point S${STOP_AT_STAGE} = Blueprint Review (promotion gate); next is S18 Marketing Copy (manual)`);
+  console.log(` Watch: wireframe_screens (S15), s17_archetypes / s17_design_system / s17_strategy_stats (S17)`);
   console.log(` Legacy Stitch artifacts should NOT appear for new ventures`);
   console.log(`${'='.repeat(70)}\n`);
 


### PR DESCRIPTION
## Summary
Operational hotfix paired with systemic SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001 (Tier 3, 6 arms).

**1. `lib/eva/stage-templates/index.js`** — remove 4 dead barrel re-exports
SD-REDESIGN-S18S26-E+F (PR #3211, 2026-04-21) deleted these symbols from the stage files:
- `evaluatePromotionGate` from `stage-23.js` (S23 is no longer a promotion gate; promotion lives at S17)
- `checkReleaseReadiness` from `stage-24.js`
- `computeReadinessScore` from `stage-25.js`
- `verifyLaunchAuthorization` from `stage-26.js`

But the barrel kept re-exporting them. ESM static-link failed at line 44, crashed the Stage Execution Worker on every startup, supervisor circuit breaker tripped after 5 attempts. **All ventures globally blocked from advancing through artifact_only/automated_check stages for ~4 days** until manual remediation 2026-04-25 15:19.

**2. `scripts/monitor-venture-run.cjs`** — relabel for post-redesign pipeline
- `STAGE_NAMES` updated to match `lifecycle_stage_config` (DB authoritative): S15 'Blueprint & Wireframes' → 'Design Studio'; S17 'Design Refinement [PROMO]' → 'Blueprint Review [PROMO GATE]'; many others reassigned per redesign
- `KILL_GATES`: `{3,5,13,24}` → `{23}` (S23 is the named kill gate post-redesign)
- `PROMOTION_GATES`: `{10,17,18,19,23,25}` → `{17}` (only S17 has `metadata.gate_type='promotion'`)
- `BLOCKING_GATES`, `SD_REQUIRED_STAGES`, `EXPECTED_ARTIFACTS` all corrected
- VENTURE_ID/NAME read from env with sensible fallback

**Real logic change** ≈12 LOC. Remainder is inline-to-multiline reformatting + DB-sourced data-table expansion + provenance comments. RCA report 2026-04-25 14:50.

**Smoke test verified**: 37 exports load cleanly post-fix; LexiGuard venture advanced from S1 → S17 cleanly after worker restart.

## Test plan
- [x] `node -e "import('./lib/eva/stage-templates/index.js')"` returns 37 exports without error
- [x] LEO stack restart brings Stage Execution Worker up cleanly (no SyntaxError)
- [x] Live venture (LexiGuard, id 94856fc6-9ba9-4f56-9a5c-85041031a0fc) advanced through S1-S16 and stopped at S17 promotion gate as designed
- [x] Monitor logs show correct post-redesign stage names

## Follow-ups
- `SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001` (filed 2026-04-25, Tier 3) addresses the systemic CI gaps that allowed PR #3211 to merge:
  - Auto-discover the barrel (glob-based)
  - Worker-import smoke test in CI
  - Remove `continue-on-error: true` from `test-coverage.yml`
  - Reconcile orphaned `tests/unit/eva/stage-templates/index.test.js`
  - GC zombie `analysis-steps/*` files
  - Pattern row in `issue_patterns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)