### PR TITLE
feat(SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001): Arm B — worker-smoke.yml CI workflow

### DIFF
--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -1,0 +1,61 @@
+name: Stage Worker Import Smoke Test
+
+# Sub-second pre-merge defense against ESM resolution errors in lib/eva/**.
+# Catches the bug class shipped in PR #3211 (SD-REDESIGN-S18S26-E+F, 2026-04-21):
+# barrel re-exports referencing deleted symbols → Stage Execution Worker
+# crashloop → all ventures globally blocked.
+#
+# Filed under SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001 (Arm B).
+# Fails CLOSED on any ESM static-link error, syntax error, or missing module.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/eva/**'
+      - 'scripts/start-stage-worker.js'
+      - '.github/workflows/worker-smoke.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Skip full npm install — smoke tests below need only the source files.
+      # @supabase/supabase-js is the only runtime dep touched by stage-registry.js;
+      # we install just that one to keep the smoke under 30 seconds total.
+      - name: Install minimal runtime deps
+        run: npm install --no-audit --no-fund --no-save --ignore-scripts @supabase/supabase-js dotenv
+
+      - name: Smoke — barrel ESM static-link
+        # Verifies lib/eva/stage-templates/index.js resolves cleanly.
+        # Pre-fix (PR #3211 era), this would crash with SyntaxError on stage-23.
+        run: |
+          node -e "import('./lib/eva/stage-templates/index.js').then(m => {
+            if (typeof m.STAGE_COUNT !== 'number' || m.STAGE_COUNT < 1) {
+              throw new Error('STAGE_COUNT missing or zero');
+            }
+            if (typeof m.getTemplate !== 'function') {
+              throw new Error('getTemplate missing');
+            }
+            console.log('OK barrel — STAGE_COUNT=' + m.STAGE_COUNT + ' exports=' + Object.keys(m).length);
+          }).catch(e => { console.error('FAIL:', e.message); process.exit(1); });"
+
+      - name: Smoke — worker entrypoint syntax check
+        # node --check parses but does not execute. Catches SyntaxError + import
+        # path errors without booting the supervisor or DB connection.
+        run: node --check scripts/start-stage-worker.js


### PR DESCRIPTION
## Summary
PR #2 of 6 for **SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001**. Adds sub-second pre-merge defense against ESM resolution errors in `lib/eva/**`.

## What changed
NEW `.github/workflows/worker-smoke.yml`:
- Triggers on `pull_request paths: lib/eva/**, scripts/start-stage-worker.js`
- Runs `node -e "import('./lib/eva/stage-templates/index.js')"` + asserts `STAGE_COUNT` and `getTemplate` exist
- Runs `node --check scripts/start-stage-worker.js` (syntax + import path validation, no boot)
- Minimal install (`--no-save --ignore-scripts`) keeps total job under 30 seconds
- Fails CLOSED on any ESM static-link error, syntax error, or missing module

## Why
Pairs with Arm A (PR #3348) — Arm A makes the barrel rot-resistant; Arm B is the CI gate to catch regressions pre-merge.

Without this workflow, `test-coverage.yml` is the only thing that runs vitest on PRs touching the barrel — and per RCA, it (a) excludes `lib/**` from `paths` filter, (b) has `continue-on-error: true`, (c) explicitly tolerates "missing exports" as a known issue. Arm C will fix `test-coverage.yml`; Arm B provides the strict, fast-failing alternative.

## Test plan
- [x] Workflow YAML validates (yamllint via local pre-commit)
- [ ] Future test PR: deliberately-broken-import test PR must cause this workflow to fail red within 30s
- [ ] CI run on this PR self-validates the workflow (it doesn't touch `lib/eva/**` so workflow won't trigger; will trigger on next `lib/eva/**` PR)

## Follow-up PRs (same SD)
- PR #3 — Arm C: harden `test-coverage.yml`
- PR #4 — Arm D (remainder): CODEOWNERS rule
- PR #5 — Arm E: GC zombie analysis-steps
- PR #6 — Arm F: issue_patterns row

🤖 Generated with [Claude Code](https://claude.com/claude-code)