### PR TITLE
feat(SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001): Arm C + D-remainder — harden test-coverage.yml + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,3 +48,12 @@ CONTRIBUTING.md @rickfelix
 **/auth* @rickfelix
 **/security* @rickfelix
 **/credentials* @rickfelix
+
+# Stage templates barrel — protected per SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001
+# Any change to a stage-NN.js file should also touch the contract test below
+# (tests/unit/eva/stage-templates/index.test.js). The auto-discovery barrel
+# (lib/eva/stage-templates/index.js, post-2026-04-25) makes deletions safe at
+# runtime, but the contract test guards against semantic regressions.
+/lib/eva/stage-templates/stage-*.js @rickfelix
+/lib/eva/stage-templates/index.js @rickfelix
+/tests/unit/eva/stage-templates/index.test.js @rickfelix

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/**'
       - 'scripts/**'
+      - 'lib/**'
       - 'server.js'
   push:
     branches: [main, develop]
@@ -33,16 +34,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq bc
 
       - name: Run tests with coverage
+        # Fails closed on test errors (SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001 Arm C).
+        # Prior versions tolerated "missing exports / ESM conflicts" via
+        # `continue-on-error: true` and a `|| exit 0` soft-pass — this is
+        # exactly the policy gap that allowed PR #3211 (SD-REDESIGN-S18S26-E+F)
+        # to merge with a barrel-rot regression. The strict mode here is the
+        # canonical defense against that bug class.
         env:
           NODE_OPTIONS: --experimental-vm-modules
-        run: |
-          npm run test:coverage -- --json --outputFile=test-results.json || {
-            echo "⚠️ Test coverage encountered errors"
-            echo "This is informational - workflow will continue"
-            echo "Known issues: Jest environment teardown, missing exports, ESM conflicts"
-            exit 0
-          }
-        continue-on-error: true  # Informational only during test infrastructure fixes
+        run: npm run test:coverage -- --json --outputFile=test-results.json
 
       - name: Check coverage threshold
         run: |


### PR DESCRIPTION
## Summary
PR #3 of 6 for **SD-LEO-INFRA-STAGE-TEMPLATE-BARREL-001**. Two arms in one focused PR (each is small):

**Arm C** — Stop swallowing missing-export errors in `.github/workflows/test-coverage.yml`:
- Add `lib/**` to `pull_request.paths` filter (was: `src/**`, `scripts/**`, `server.js`)
- Remove `continue-on-error: true`
- Remove the `|| { echo "⚠️"; exit 0 }` soft-pass block that explicitly tolerated "missing exports / ESM conflicts" — the exact bug class that allowed PR #3211 to merge

**Arm D-remainder** — CODEOWNERS rule for stage templates:
- Explicit ownership for `/lib/eva/stage-templates/stage-*.js`, `index.js`, and the contract test
- The auto-discovery barrel (Arm A, PR #3348) handles runtime safety; CODEOWNERS formalizes review for semantic changes

## Test plan
- [x] Workflow YAML lints
- [x] CODEOWNERS syntax is well-formed
- [ ] Replay test: a sandbox PR cherry-picking PR #3211 must fail red in test-coverage.yml (canonical Arm C smoke)
- [ ] Future PRs touching `lib/eva/stage-templates/stage-*.js` should get @rickfelix as required reviewer

## Deferred
- **Arm E** (GC zombie analysis-step files) — needs careful cascade analysis. 1 of 4 candidate-zombies (`stage-16-financial-projections.js`) is actively imported by `stage-16.js`; 3 have associated test files. Will ship as separate PR with proper verification.
- **Arm F** (issue_patterns row INSERT) — DB-only change, will be applied via database-agent, not a code PR.

## Follow-up PRs (same SD)
- PR #x — Arm E: GC zombie analysis-steps + their tests (with cascade verification)
- DB INSERT — Arm F: issue_patterns row + fingerprint
- Final EXEC-TO-PLAN handoff once all arms land

🤖 Generated with [Claude Code](https://claude.com/claude-code)