### PR TITLE
fix(QF-20260426-042): status line counts only depth-1 worktrees

### DIFF
--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -140,17 +140,19 @@ try {
   }
 } catch (_) { /* intentionally silent: git may not be available */ }
 
-// Worktree SD detection
+// Worktree SD detection — source of truth is `git worktree list --porcelain`
+// (matches scripts/worktree-reaper.mjs). Previously this scanned `.worktrees/*`
+// at depth 1 with a `.worktree.json` marker requirement, which missed nested
+// `qf/QF-*` worktrees and any worktree without a marker file.
 let activeWorktreeSd = '';
 try {
-  const worktreesDir = path.join(cwd, '.worktrees');
-  if (fs.existsSync(worktreesDir)) {
-    const dirs = fs.readdirSync(worktreesDir, { withFileTypes: true })
-      .filter(d => d.isDirectory() && fs.existsSync(path.join(worktreesDir, d.name, '.worktree.json')))
-      .map(d => d.name);
-    if (dirs.length === 1) activeWorktreeSd = dirs[0];
-    else if (dirs.length > 1) activeWorktreeSd = `${dirs.length}wt`;
-  }
+  const out = execSync('git worktree list --porcelain', { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  const paths = out.split('\n')
+    .filter(l => l.startsWith('worktree '))
+    .map(l => l.slice('worktree '.length).trim())
+    .filter(p => path.resolve(p) !== path.resolve(cwd)); // exclude main repo
+  if (paths.length === 1) activeWorktreeSd = path.basename(paths[0]);
+  else if (paths.length > 1) activeWorktreeSd = `${paths.length}wt`;
 } catch (_) { /* intentionally silent: worktree detection is optional */ }
 
 // Activity state


### PR DESCRIPTION
## Summary
- `.claude/statusline.cjs` scanned `.worktrees/*` at depth-1 with a `.worktree.json` marker filter, missing nested `qf/QF-*` worktrees and any worktree without a marker.
- Switch to `git worktree list --porcelain` as the source of truth (matches `scripts/worktree-reaper.mjs`). Single source means the badge and the reaper can never disagree again.
- Smoke-tested locally: badge correctly shows `[8wt]` matching `git worktree list` output.

## Test plan
- [x] Manual smoke: `echo '{...}' | node .claude/statusline.cjs` prints accurate `[Nwt]` count
- [x] Cross-checked against `git worktree list` output (matches)
- [ ] CI green
- [ ] Status line refreshes correctly on next session start

## Notes
- Tier-1 auto-approve QF (~20 LOC, no risk keywords)
- Pre-existing `eva-master-scheduler.test.js` and other backend test failures are unrelated to this change — `--skip-tests` used at completion with rationale; CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)