### PR TITLE
feat(SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001): ARM A LLM stream-progress watchdog (PR1 of 5)

### DIFF
--- a/docs/architecture/llm-stream-watchdog.md
+++ b/docs/architecture/llm-stream-watchdog.md
@@ -1,0 +1,123 @@
+# LLM Stream-Progress Watchdog
+
+**SD:** SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 — ARM A
+**Module:** [`lib/llm/stream-watchdog.js`](../../lib/llm/stream-watchdog.js)
+**Error type:** [`LLMStreamStalled`](../../lib/llm/llm-stream-stalled.js)
+
+## Why this exists
+
+Anthropic streaming responses can hit a "connection alive, server idle"
+failure mode where the TCP connection stays open but the server stops
+emitting tokens. A wall-clock timeout cannot catch this until the full
+timeout elapses (Stage 17 uses 300s), during which the worker appears
+busy and downstream archetype generation appears frozen.
+
+The watchdog rejects with a typed `LLMStreamStalled` error after `N` ms
+of silence between tokens (default 90s), independent of any wall-clock
+guard. This converts a silent hang into a fast, recoverable failure
+that ARM B (bounded retry) and ARM E (heartbeat) can act on.
+
+## Default threshold
+
+| Setting | Value | Source |
+|---|---|---|
+| Default | 90,000 ms (90s) | `DEFAULT_STALL_TIMEOUT_MS` in `stream-watchdog.js` |
+| Per-process override | env `LLM_STREAM_STALL_TIMEOUT_MS` (positive integer) | `getDefaultStallTimeout()` |
+| Per-call override | `options.stallTimeout` on `_completeWithStreaming` / `withStreamWatchdog` | `_completeWithStreaming` in `provider-adapters.js` |
+
+Invalid env values (`0`, negative, non-numeric) fall back to the default.
+
+## Caller enumeration
+
+These are the callers known to invoke Anthropic streaming as of the
+PR1 landing date. Append future streaming callers to this list as they
+appear.
+
+### Steady-stream workloads (90s default safe)
+
+| Caller | Path | Workload shape | Notes |
+|---|---|---|---|
+| Stage 17 archetype generation | `lib/eva/stage-17/archetype-generator.js:862` | HTML generation; tokens stream continuously | The motivating S17 caller — routes through `getLLMClient → AnthropicAdapter.complete → _completeWithStreaming`, auto-protected by the watchdog. |
+| Stage 17 design refinement | `lib/eva/stage-17/archetype-generator.js:1055` | Same as above, refinement pass | Same routing, same protection. |
+
+### Direct SDK callers (currently unprotected)
+
+| Caller | Path | Reason | Follow-up |
+|---|---|---|---|
+| EVA chat service | `lib/integrations/eva-chat-service.js:318` | Bypasses the provider adapter — calls `client.messages.stream()` directly to wire `stream.on('text', ...)` for token-streaming UX | Wrap with `withStreamWatchdog(stream, { callerLabel: 'eva-chat' })` in a follow-up QF. Token-streaming UX is bursty, but never legitimately silent for >90s on a sonnet-tier 1024-token reply. |
+
+### Non-streaming callers (out of scope)
+
+The watchdog only affects calls made with `options.stream: true` to
+`AnthropicAdapter.complete()` or direct invocations of
+`AnthropicAdapter._completeWithStreaming()`. The 60+ callers in
+`lib/eva/stage-templates/`, `scripts/eva/`, and elsewhere that use the
+default non-streaming path through `client.messages.create()` are
+unaffected.
+
+## When to override the default
+
+Override `LLM_STREAM_STALL_TIMEOUT_MS` (process-wide) or
+`options.stallTimeout` (per-call) when the workload is **legitimately
+bursty** — i.e. >90s of silence is normal, not a stall.
+
+Concretely:
+
+- **Long reasoning with extended thinking** (`thinkingBudget` > 32k tokens):
+  Anthropic may emit a long thinking block before any text tokens. If
+  that block exceeds 90s, raise `stallTimeout` to ~150s.
+- **Streaming over slow networks** (e.g. a saturated tunnel): a 90s gap
+  may indicate transport not server-side stall. Raise the threshold
+  for that environment, but consider that you are masking real network
+  pathology.
+- **Multi-step tool-use loops** where the SDK pauses mid-stream waiting
+  for tool results: for these, prefer to issue separate streaming calls
+  per step rather than tuning the threshold up — the 90s default
+  protects against per-step stalls.
+
+Do **not** override the default just because a single call timed out.
+Investigate first: an `LLMStreamStalled` event on a non-S17 caller is
+itself a signal worth a backlog entry.
+
+## Error contract
+
+```js
+import { LLMStreamStalled } from '../llm/index.js';
+
+try {
+  const msg = await client.complete(systemPrompt, userPrompt, { stream: true });
+} catch (err) {
+  // Cross-bundle reliable check — prefer this over instanceof
+  if (err.name === 'LLMStreamStalled') {
+    console.error('Stream stalled', {
+      caller: err.callerLabel,
+      threshold: err.threshold,
+      msSinceLastToken: err.msSinceLastToken,
+      lastTokenAt: err.lastTokenAt,
+    });
+    // ARM B (bounded retry) decides whether to retry or write s17_variant_failed
+  } else {
+    throw err;
+  }
+}
+```
+
+## Test coverage
+
+[`lib/llm/stream-watchdog.test.js`](../../lib/llm/stream-watchdog.test.js)
+covers, with vitest fake timers:
+
+- LLMStreamStalled fires within threshold when no tokens stream
+- `err.name === 'LLMStreamStalled'` (cross-bundle reliable)
+- `LLM_STREAM_STALL_TIMEOUT_MS` env override
+- Clean completion does not throw
+- Mid-stream tokens reset the inactivity clock
+- Non-stall SDK errors propagate unchanged
+- Default + env-parsing edge cases for `getDefaultStallTimeout`
+
+## Related
+
+- ARM B (bounded retry) — consumes `LLMStreamStalled` to decide retry vs `s17_variant_failed`. Lands in PR2.
+- ARM E (heartbeat writer) — independent signal; useful when the watchdog has not yet fired but you suspect the worker is hung.
+- ARM F (resume endpoint) — frontend-triggered recovery path that fires when the user-visible 3-min freeze threshold trips, regardless of watchdog state.
+- Sibling `SD-LEO-INFRA-STAGE17-CROSS-REPO-001` (PR #3355) — prevents schema/contract drift across the EHG / EHG_Engineer boundary; this watchdog prevents silent runtime stalls.

--- a/lib/llm/index.js
+++ b/lib/llm/index.js
@@ -74,3 +74,11 @@ export {
   getProviderAdapter,
   getAllAdapters
 } from '../sub-agents/vetting/provider-adapters.js';
+
+// SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A: stream-progress watchdog
+export { LLMStreamStalled } from './llm-stream-stalled.js';
+export {
+  withStreamWatchdog,
+  getDefaultStallTimeout,
+  DEFAULT_STALL_TIMEOUT_MS
+} from './stream-watchdog.js';

--- a/lib/llm/llm-stream-stalled.js
+++ b/lib/llm/llm-stream-stalled.js
@@ -1,0 +1,31 @@
+/**
+ * LLMStreamStalled — typed error for inactive LLM streaming responses.
+ *
+ * Thrown when an Anthropic streaming call has not produced a token within
+ * the configured inter-chunk threshold. Distinct from a clean wall-clock
+ * TIMEOUT: the connection is still alive but the server stopped emitting
+ * tokens (the failure mode that motivated this watchdog —
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A).
+ *
+ * Cross-bundle robustness: prefer `err.name === 'LLMStreamStalled'` over
+ * `instanceof` — monorepo / bundler quirks can produce multiple Error
+ * subclass instances at runtime.
+ */
+export class LLMStreamStalled extends Error {
+  constructor({
+    msSinceLastToken = 0,
+    threshold = 0,
+    callerLabel = 'unknown',
+    lastTokenAt = null,
+  } = {}) {
+    super(
+      `LLM stream stalled: no token for ${msSinceLastToken}ms ` +
+      `(threshold=${threshold}ms, caller=${callerLabel})`
+    );
+    this.name = 'LLMStreamStalled';
+    this.msSinceLastToken = msSinceLastToken;
+    this.threshold = threshold;
+    this.callerLabel = callerLabel;
+    this.lastTokenAt = lastTokenAt;
+  }
+}

--- a/lib/llm/stream-watchdog.js
+++ b/lib/llm/stream-watchdog.js
@@ -1,0 +1,102 @@
+/**
+ * Stream-progress watchdog for Anthropic streaming responses.
+ *
+ * Wraps an Anthropic SDK message stream and rejects with LLMStreamStalled
+ * if no token arrives within `threshold` ms of the previous token (or of
+ * stream start). Distinct from wall-clock timeout: detects the "connection
+ * alive, server idle" failure mode that wall-clock cannot catch until the
+ * full timeout elapses.
+ *
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A
+ *
+ * @module lib/llm/stream-watchdog
+ * @env LLM_STREAM_STALL_TIMEOUT_MS - global default threshold (ms, fallback 90000)
+ */
+
+import { LLMStreamStalled } from './llm-stream-stalled.js';
+
+export const DEFAULT_STALL_TIMEOUT_MS = 90000;
+
+/**
+ * Resolve the active default threshold, honoring LLM_STREAM_STALL_TIMEOUT_MS.
+ * Invalid / non-positive values fall back to DEFAULT_STALL_TIMEOUT_MS.
+ */
+export function getDefaultStallTimeout() {
+  const fromEnv = process.env.LLM_STREAM_STALL_TIMEOUT_MS;
+  if (!fromEnv) return DEFAULT_STALL_TIMEOUT_MS;
+  const n = Number.parseInt(fromEnv, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STALL_TIMEOUT_MS;
+}
+
+/**
+ * Wrap an Anthropic SDK stream with an inter-chunk inactivity watchdog.
+ *
+ * Hooks `stream.on('text', ...)` to track time-since-last-token. If
+ * `threshold` ms elapse without a new token, calls `stream.abort()` and
+ * rejects with LLMStreamStalled.
+ *
+ * @param {object} stream Anthropic stream returned by `client.messages.stream()`
+ * @param {object} [options]
+ * @param {number} [options.threshold]   Max ms between tokens; defaults to env / 90000
+ * @param {string} [options.callerLabel] Identifier surfaced in the error metadata
+ * @returns {Promise<object>} resolves with `stream.finalMessage()` payload on success
+ * @throws  {LLMStreamStalled} when the threshold elapses without a token
+ */
+export function withStreamWatchdog(stream, options = {}) {
+  const threshold = options.threshold ?? getDefaultStallTimeout();
+  const callerLabel = options.callerLabel ?? 'unknown';
+
+  let lastTokenAt = Date.now();
+  let timer = null;
+  let stallReject = null;
+
+  const stallPromise = new Promise((_, reject) => {
+    stallReject = reject;
+  });
+
+  const arm = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      const msSinceLastToken = Date.now() - lastTokenAt;
+      const err = new LLMStreamStalled({
+        msSinceLastToken,
+        threshold,
+        callerLabel,
+        lastTokenAt,
+      });
+      // Order matters: settle the race promise BEFORE abort() so the
+      // typed error wins the Promise.race against finalMessage's
+      // synchronous rejection-on-abort. (Reversed → abort's "Error: aborted"
+      // settles first and the typed error is dropped.)
+      stallReject(err);
+      try { stream.abort(); } catch { /* abort is best-effort */ }
+    }, threshold);
+  };
+
+  const onText = () => {
+    lastTokenAt = Date.now();
+    arm();
+  };
+
+  arm();
+  stream.on('text', onText);
+
+  const cleanup = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (typeof stream.off === 'function') stream.off('text', onText);
+  };
+
+  // Pre-observe finalMessage rejection so that abort()-induced rejections
+  // arriving AFTER the race settles are not flagged as unhandled.
+  const finalPromise = Promise.resolve(stream.finalMessage());
+  finalPromise.catch(() => { /* observed via Promise.race below */ });
+
+  return Promise.race([finalPromise, stallPromise])
+    .then(
+      (msg) => { cleanup(); return msg; },
+      (err) => { cleanup(); throw err; }
+    );
+}

--- a/lib/llm/stream-watchdog.test.js
+++ b/lib/llm/stream-watchdog.test.js
@@ -1,0 +1,168 @@
+/**
+ * Vitest spec for the LLM stream-progress watchdog.
+ *
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A — success_criteria #1
+ * (stalled stream produces LLMStreamStalled within 90–105s).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  withStreamWatchdog,
+  getDefaultStallTimeout,
+  DEFAULT_STALL_TIMEOUT_MS,
+} from './stream-watchdog.js';
+import { LLMStreamStalled } from './llm-stream-stalled.js';
+
+/**
+ * Build an Anthropic-shaped stream double:
+ *   - on/off via EventEmitter
+ *   - finalMessage() resolves/rejects on demand via emit-time control
+ *   - abort() rejects finalMessage() and flips a flag so tests can assert it
+ */
+function makeMockStream() {
+  const ee = new EventEmitter();
+  let resolveFinal;
+  let rejectFinal;
+  const finalPromise = new Promise((res, rej) => {
+    resolveFinal = res;
+    rejectFinal = rej;
+  });
+  const stream = {
+    on: ee.on.bind(ee),
+    off: ee.off.bind(ee),
+    emit: ee.emit.bind(ee),
+    finalMessage: () => finalPromise,
+    aborted: false,
+    abort() {
+      this.aborted = true;
+      rejectFinal(new Error('aborted'));
+    },
+    _resolveFinal: (v) => resolveFinal(v),
+    _rejectFinal: (e) => rejectFinal(e),
+  };
+  return stream;
+}
+
+describe('withStreamWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delete process.env.LLM_STREAM_STALL_TIMEOUT_MS;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with LLMStreamStalled when no tokens arrive within threshold', async () => {
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, {
+      threshold: 90000,
+      callerLabel: 'unit-test',
+    });
+
+    promise.catch(() => { /* swallow for assertion below */ });
+    await vi.advanceTimersByTimeAsync(95000);
+
+    await expect(promise).rejects.toBeInstanceOf(LLMStreamStalled);
+    expect(stream.aborted).toBe(true);
+  });
+
+  it('uses err.name for cross-bundle robustness', async () => {
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, {
+      threshold: 90000,
+      callerLabel: 'cross-bundle',
+    });
+
+    promise.catch(() => {});
+    await vi.advanceTimersByTimeAsync(95000);
+
+    let caught;
+    try { await promise; } catch (e) { caught = e; }
+    expect(caught.name).toBe('LLMStreamStalled');
+    expect(caught.callerLabel).toBe('cross-bundle');
+    expect(caught.threshold).toBe(90000);
+    expect(caught.msSinceLastToken).toBeGreaterThanOrEqual(90000);
+  });
+
+  it('honors LLM_STREAM_STALL_TIMEOUT_MS env override', async () => {
+    process.env.LLM_STREAM_STALL_TIMEOUT_MS = '30000';
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, { callerLabel: 'env-override' });
+    promise.catch(() => { /* silence unhandled-rejection; assertion below */ });
+
+    await vi.advanceTimersByTimeAsync(35000);
+    let caught;
+    try { await promise; } catch (e) { caught = e; }
+    expect(caught).toBeInstanceOf(LLMStreamStalled);
+    expect(caught.threshold).toBe(30000);
+    expect(caught.callerLabel).toBe('env-override');
+  });
+
+  it('does not throw when stream completes cleanly', async () => {
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, { threshold: 90000 });
+
+    stream.emit('text', 'hello');
+    await vi.advanceTimersByTimeAsync(50000);
+    stream._resolveFinal({ content: [{ type: 'text', text: 'hello' }] });
+
+    await expect(promise).resolves.toEqual({ content: [{ type: 'text', text: 'hello' }] });
+    expect(stream.aborted).toBe(false);
+  });
+
+  it('tokens reset the inactivity clock', async () => {
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, { threshold: 90000 });
+
+    // Emit 4 tokens at 60s intervals — total elapsed 240s, but never
+    // 90s of silence, so the watchdog must not fire.
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(60000);
+      stream.emit('text', `chunk-${i}`);
+    }
+    stream._resolveFinal({ ok: true });
+
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(stream.aborted).toBe(false);
+  });
+
+  it('propagates non-stall stream errors unchanged', async () => {
+    const stream = makeMockStream();
+    const promise = withStreamWatchdog(stream, { threshold: 90000 });
+
+    promise.catch(() => {});
+    const sdkErr = new Error('Anthropic 429: rate limited');
+    stream._rejectFinal(sdkErr);
+
+    let caught;
+    try { await promise; } catch (e) { caught = e; }
+    expect(caught).toBe(sdkErr);
+    expect(caught.name).not.toBe('LLMStreamStalled');
+  });
+});
+
+describe('getDefaultStallTimeout', () => {
+  beforeEach(() => {
+    delete process.env.LLM_STREAM_STALL_TIMEOUT_MS;
+  });
+
+  it('defaults to 90000ms when env unset', () => {
+    expect(getDefaultStallTimeout()).toBe(DEFAULT_STALL_TIMEOUT_MS);
+    expect(DEFAULT_STALL_TIMEOUT_MS).toBe(90000);
+  });
+
+  it('parses env override as integer', () => {
+    process.env.LLM_STREAM_STALL_TIMEOUT_MS = '15000';
+    expect(getDefaultStallTimeout()).toBe(15000);
+  });
+
+  it('falls back to default for invalid env values', () => {
+    process.env.LLM_STREAM_STALL_TIMEOUT_MS = 'not-a-number';
+    expect(getDefaultStallTimeout()).toBe(DEFAULT_STALL_TIMEOUT_MS);
+    process.env.LLM_STREAM_STALL_TIMEOUT_MS = '0';
+    expect(getDefaultStallTimeout()).toBe(DEFAULT_STALL_TIMEOUT_MS);
+    process.env.LLM_STREAM_STALL_TIMEOUT_MS = '-100';
+    expect(getDefaultStallTimeout()).toBe(DEFAULT_STALL_TIMEOUT_MS);
+  });
+});

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -8,6 +8,8 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { getOpenAIModel, getClaudeModel, getGoogleModel } from '../../config/model-config.js';
+// SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A: stream-progress watchdog
+import { withStreamWatchdog } from '../../llm/stream-watchdog.js';
 
 // Timeout and retry configuration
 const PROVIDER_TIMEOUT_MS = 30000; // 30 seconds per call (default for short operations)
@@ -236,31 +238,50 @@ export class AnthropicAdapter {
    * Complete a request using streaming mode.
    * Required by Anthropic SDK for operations that may take >10 minutes.
    * Collects streamed chunks and assembles them into a standard response object.
-   * SD-LEO-FIX-REPLACE-EXTERNAL-API-001
+   *
+   * SD-LEO-FIX-REPLACE-EXTERNAL-API-001               (initial streaming integration)
+   * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM A (stream-progress watchdog)
+   *
+   * Two timers guard the call:
+   *   - Inter-chunk watchdog: rejects with LLMStreamStalled if no token
+   *     arrives within options.stallTimeout (or LLM_STREAM_STALL_TIMEOUT_MS,
+   *     default 90s). Distinct from a clean wall-clock timeout.
+   *   - Wall-clock outer guard: rejects with Error('TIMEOUT') after
+   *     options.timeout ms (default PROVIDER_TIMEOUT_MS). Safety net for
+   *     watchdog wedge or pathological streams that emit one token per <90s.
    *
    * @param {Object} requestParams - Anthropic API request parameters
-   * @param {Object} options - Options including timeout
+   * @param {Object} options
+   * @param {number} [options.timeout]      Wall-clock timeout (ms)
+   * @param {number} [options.stallTimeout] Inter-chunk threshold (ms)
+   * @param {string} [options.callerLabel]  Identifier surfaced in stall errors
    * @returns {Promise<Object>} Response object matching non-streaming format
+   * @throws  {LLMStreamStalled} when no token arrives within stallTimeout
+   * @throws  {Error('TIMEOUT')} when the wall-clock timeout elapses
+   *
+   * @env LLM_STREAM_STALL_TIMEOUT_MS - global inter-chunk threshold default
    */
   async _completeWithStreaming(requestParams, options = {}) {
-    const timeout = options.timeout || PROVIDER_TIMEOUT_MS;
+    const wallClockMs = options.timeout || PROVIDER_TIMEOUT_MS;
     const stream = this.client.messages.stream(requestParams);
 
     let timeoutId;
-    const timeoutPromise = new Promise((_, reject) => {
+    const wallClockPromise = new Promise((_, reject) => {
       timeoutId = setTimeout(() => {
-        stream.abort();
+        try { stream.abort(); } catch { /* ignore */ }
         reject(new Error('TIMEOUT'));
-      }, timeout);
+      }, wallClockMs);
+    });
+
+    const watchdog = withStreamWatchdog(stream, {
+      threshold: options.stallTimeout,
+      callerLabel: options.callerLabel || `anthropic:${requestParams.model}`,
     });
 
     try {
-      const finalMessage = await Promise.race([stream.finalMessage(), timeoutPromise]);
+      return await Promise.race([watchdog, wallClockPromise]);
+    } finally {
       clearTimeout(timeoutId);
-      return finalMessage;
-    } catch (err) {
-      clearTimeout(timeoutId);
-      throw err;
     }
   }
 }


### PR DESCRIPTION
## Summary

PR1 of 5 for **SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001** — adds an inter-chunk inactivity watchdog around Anthropic streaming responses to detect the "connection alive, server idle" failure mode that wall-clock timeouts cannot catch until the full timeout elapses (300s in S17). Converts a silent hang into a fast, typed failure that ARMs B/E (PR2) can act on.

- `lib/llm/llm-stream-stalled.js` — typed `LLMStreamStalled` Error subclass; cross-bundle robust via `err.name`
- `lib/llm/stream-watchdog.js` — `withStreamWatchdog(stream, opts)` wrapper, default 90s, env override `LLM_STREAM_STALL_TIMEOUT_MS`
- `lib/sub-agents/vetting/provider-adapters.js` — `AnthropicAdapter._completeWithStreaming` now wraps stream with watchdog (inner) + wall-clock (outer guard). New per-call options: `stallTimeout`, `callerLabel`
- `lib/llm/stream-watchdog.test.js` — 9 vitest cases with fake timers; all pass
- `docs/architecture/llm-stream-watchdog.md` — caller enumeration (closes LEAD `plan_must_address` #1) + override guidance for non-S17 long-runners

## Caller enumeration (from the doc)

| Caller | Auto-protected? |
|---|---|
| `lib/eva/stage-17/archetype-generator.js:862` (S17 critical path) | ✅ via factory |
| `lib/eva/stage-17/archetype-generator.js:1055` (S17 refinement) | ✅ via factory |
| `lib/integrations/eva-chat-service.js:318` (direct `client.messages.stream()`) | ❌ doc'd as follow-up — bypasses adapter |

## Acceptance criteria addressed

- **AC-3** — backend self-healing within 90s of token-less stream — verified by `stream-watchdog.test.js` fake-timer assertion
- **AC-6** — each arm has at least one passing CI test — ARM A row complete

## Test plan

- [x] `npx vitest run lib/llm/stream-watchdog.test.js` — 9/9 passing locally
- [x] `node -e \"import('./lib/llm/index.js')\"` smoke — all new exports present, AnthropicAdapter still importable
- [ ] CI green
- [ ] Merge into `main`, verify next S17 archetype run does not regress

## What's NOT in this PR

PR1 is the framework only. ARMs B (bounded retry consuming `LLMStreamStalled`), C (per-screen failure marker), E (heartbeat) ship in PR2 (`archetype-generator.js`, ~130 LOC). PR3 = ARM F resume endpoint + heartbeat TTL job. PR4 = ARM D frontend banner (EHG repo, behind feature flag, default OFF). PR5 = flag flip ON.

## LOC

- 6 files changed, +464 / -11
- Source-only (excluding tests + docs): +173
- Above the 100-LOC target; documented justification: foundation PR per `feedback_framework_as_pr1_multi_pr_campaign` pattern. PRs 2-5 each target ≤100 LOC.

PRD: `PRD-SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001`
Sibling: SD-LEO-INFRA-STAGE17-CROSS-REPO-001 (PR #3355) — that one prevented schema/contract drift; this one prevents silent runtime stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)