### PR TITLE
feat(SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001): ARM F resume endpoint + heartbeat TTL prune (PR3 of 5)

### DIFF
--- a/docs/architecture/stage17-contracts.md
+++ b/docs/architecture/stage17-contracts.md
@@ -18,6 +18,7 @@ All endpoints are mounted under `/api/stage17` (`server/index.js:168`) and requi
 | `POST` | `/api/stage17/:ventureId/strategy-recommendation` | Returns ranked design strategies | `server/routes/stage17.js:45` |
 | `POST` | `/api/stage17/:ventureId/archetypes` | Generates 4 HTML archetypes per screen | `server/routes/stage17.js:80` |
 | `POST` | `/api/stage17/:ventureId/archetypes/cancel` | Cancels in-flight archetype generation | `server/routes/stage17.js:129` |
+| `POST` | `/api/stage17/:ventureId/archetypes/resume` | Resumes interrupted generation; idempotent via `s17_session_state.metadata.resume_lock` (10-min TTL) — see §5.3 | `server/routes/stage17.js` (ARM F) |
 | `POST` | `/api/stage17/:ventureId/select` | Pass 1 selection (2 archetypes → 4 refined) | `server/routes/stage17.js:149` |
 | `POST` | `/api/stage17/:ventureId/refine` | Pass 2 selection (approve final variant) | `server/routes/stage17.js:179` |
 | `POST` | `/api/stage17/:ventureId/approve` | Auto-advance chairman gate when all screens approved | `server/routes/stage17.js:243` |
@@ -161,9 +162,29 @@ Two distinct artifact-shapes carry "this thing didn't fully complete" semantics.
 
 ### 5.2 `s17_heartbeat` TTL + pruning policy
 
-Heartbeats are written every 30s during active generation. The `writeArtifact` dedup logic UPDATEs the same row each tick (one row per active venture), so steady-state row count is bounded. A maintenance job (PR3, TR-2) prunes rows whose `metadata.ttlExpiresAt` is in the past — TTL defaults to 7 days, configurable via the `ttlDays` option to `startHeartbeatWriter()`.
+Heartbeats are written every 30s during active generation. The `writeArtifact` dedup logic UPDATEs the same row each tick (one row per active venture), so steady-state row count is bounded. A maintenance job (`scripts/maintenance/prune-s17-heartbeats.mjs`, ARM F TR-2) prunes rows whose `metadata.ttlExpiresAt` is in the past — TTL defaults to 7 days, configurable via the `ttlDays` option to `startHeartbeatWriter()`.
 
-The TTL exists for the failure mode where a venture's generation crashed without `stop()` running (e.g. process kill -9): the row is left behind with no path to deletion via the normal `cleanupWipVariants` flow. After 7 days it is unconditionally garbage-collected by the maintenance job.
+The TTL exists for the failure mode where a venture's generation crashed without `stop()` running (e.g. process kill -9): the row is left behind with no path to deletion via the normal `cleanupWipVariants` flow. After 7 days it is unconditionally garbage-collected by the maintenance job. Run manually as `node scripts/maintenance/prune-s17-heartbeats.mjs` (or `--dry-run` to inspect first).
+
+### 5.3 Resume endpoint idempotency (`s17_session_state.metadata.resume_lock`)
+
+`POST /api/stage17/:ventureId/archetypes/resume` (ARM F) claims a 10-minute lock on the venture's existing `s17_session_state` artifact before spawning the generator:
+
+```json
+"metadata": {
+  "resume_lock": {
+    "token": "<uuid>",
+    "expires_at": "<ISO 8601 — now + 10 min>",
+    "acquired_at": "<ISO 8601>"
+  }
+}
+```
+
+A second concurrent call within the TTL receives HTTP 409 `{code: 'RESUME_LOCKED', existingExpiresAt}`. After the generator's `.finally()` runs, the lock is released. Crashed jobs (no release) recover automatically once the TTL elapses — the next caller's `acquireResumeLock` overwrites the expired lock.
+
+This pattern was chosen over a `job_id` UNIQUE constraint to avoid a schema migration: the `s17_session_state` row already exists per-venture (`writeArtifact` dedup ensures one row), and lock semantics are exactly what double-fire prevention needs.
+
+Helpers: `lib/eva/stage-17/resume-lock.js` — `acquireResumeLock(supabase, ventureId, opts)` → `{acquired, token, expiresAt}` or `{acquired:false, reason:'LOCKED', existingExpiresAt}`; `releaseResumeLock(supabase, ventureId, token)` → `{released}` (token-mismatch is a no-op, defensive against late `.finally()`).
 
 ## 6. Historical drift cases (training set for Arm D fingerprint)
 

--- a/lib/eva/stage-17/resume-lock.js
+++ b/lib/eva/stage-17/resume-lock.js
@@ -1,0 +1,123 @@
+/**
+ * Stage 17 resume-endpoint idempotency lock.
+ *
+ * The `POST /api/stage17/:ventureId/archetypes/resume` endpoint must reject
+ * concurrent or accidentally-double-fired calls so that two servers do not
+ * race to regenerate the same screens. We store a per-venture lock_token on
+ * the existing `s17_session_state` artifact's metadata — zero schema
+ * migration, dedup-safe (the row already exists per-venture), 10-minute TTL
+ * to recover from crashed jobs.
+ *
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM F
+ *
+ * @module lib/eva/stage-17/resume-lock
+ */
+
+import { randomUUID } from 'node:crypto';
+
+export const RESUME_LOCK_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Attempt to claim the resume lock for `ventureId`.
+ *
+ * Returns `{acquired:true, token, expiresAt}` on success, or
+ * `{acquired:false, reason:'LOCKED'|'DB_ERROR', existingExpiresAt?, error?}`
+ * on failure. Expired locks are reclaimable — the helper checks the live
+ * timestamp before refusing.
+ *
+ * @param {object} supabase Supabase client
+ * @param {string} ventureId UUID
+ * @param {object} [options]
+ * @param {number} [options.ttlMs=RESUME_LOCK_TTL_MS] Lock validity window
+ * @param {() => number} [options.now=Date.now] Injection seam for tests
+ */
+export async function acquireResumeLock(supabase, ventureId, options = {}) {
+  const ttlMs = options.ttlMs ?? RESUME_LOCK_TTL_MS;
+  const now = (options.now ?? Date.now)();
+
+  const { data: existing, error: readErr } = await supabase
+    .from('venture_artifacts')
+    .select('id, metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 's17_session_state')
+    .eq('is_current', true)
+    .maybeSingle();
+  if (readErr) return { acquired: false, reason: 'DB_ERROR', error: readErr.message };
+
+  const existingLock = existing?.metadata?.resume_lock;
+  if (existingLock?.expires_at) {
+    const expiresAtMs = new Date(existingLock.expires_at).getTime();
+    if (Number.isFinite(expiresAtMs) && expiresAtMs > now) {
+      return { acquired: false, reason: 'LOCKED', existingExpiresAt: existingLock.expires_at };
+    }
+    // expired → fall through and overwrite
+  }
+
+  const token = randomUUID();
+  const expiresAt = new Date(now + ttlMs).toISOString();
+  const acquiredAt = new Date(now).toISOString();
+  const newMetadata = {
+    ...(existing?.metadata || {}),
+    resume_lock: { token, expires_at: expiresAt, acquired_at: acquiredAt },
+  };
+
+  if (existing?.id) {
+    const { error: updErr } = await supabase
+      .from('venture_artifacts')
+      .update({ metadata: newMetadata })
+      .eq('id', existing.id);
+    if (updErr) return { acquired: false, reason: 'DB_ERROR', error: updErr.message };
+  } else {
+    // Bootstrap a session_state row if none exists yet (first resume on a
+    // venture whose generation never started).
+    const { writeArtifact } = await import('../artifact-persistence-service.js');
+    await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 17,
+      artifactType: 's17_session_state',
+      title: 'Generation Progress',
+      content: JSON.stringify({ log: [], updatedAt: acquiredAt }),
+      artifactData: { log: [] },
+      qualityScore: null,
+      validationStatus: null,
+      source: 'stage17-resume-endpoint',
+      metadata: { ...newMetadata, progressUpdate: true },
+    });
+  }
+
+  return { acquired: true, token, expiresAt };
+}
+
+/**
+ * Release the resume lock if `token` matches the stored token. Mismatched
+ * tokens are no-ops (returns `{released:false, reason:'TOKEN_MISMATCH'}`)
+ * — defensive against late `.finally()` callbacks running after the lock
+ * has already expired and been re-acquired by another caller.
+ */
+export async function releaseResumeLock(supabase, ventureId, token) {
+  if (!token) return { released: false, reason: 'NO_TOKEN' };
+
+  const { data: existing, error: readErr } = await supabase
+    .from('venture_artifacts')
+    .select('id, metadata')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 's17_session_state')
+    .eq('is_current', true)
+    .maybeSingle();
+  if (readErr) return { released: false, reason: 'DB_ERROR', error: readErr.message };
+  if (!existing?.metadata?.resume_lock) return { released: false, reason: 'NO_LOCK' };
+  if (existing.metadata.resume_lock.token !== token) {
+    return { released: false, reason: 'TOKEN_MISMATCH' };
+  }
+
+  const newMetadata = { ...existing.metadata };
+  delete newMetadata.resume_lock;
+
+  const { error: updErr } = await supabase
+    .from('venture_artifacts')
+    .update({ metadata: newMetadata })
+    .eq('id', existing.id);
+  if (updErr) return { released: false, reason: 'DB_ERROR', error: updErr.message };
+
+  return { released: true };
+}

--- a/lib/eva/stage-17/resume-lock.test.js
+++ b/lib/eva/stage-17/resume-lock.test.js
@@ -1,0 +1,192 @@
+/**
+ * Vitest spec for the Stage 17 resume-endpoint idempotency lock.
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM F
+ *
+ * The lock helpers operate over a small slice of the Supabase API
+ * (.from(...).select().eq().eq().eq().maybeSingle() and .update().eq()).
+ * We hand-roll a minimal in-memory mock that supports just that surface
+ * — pulling in the real Supabase JS client for unit tests would add
+ * weight without raising signal.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { acquireResumeLock, releaseResumeLock, RESUME_LOCK_TTL_MS } from './resume-lock.js';
+
+function makeSupabaseMock(initialRows = []) {
+  // Tiny query-chain matcher tailored to acquireResumeLock / releaseResumeLock.
+  let rows = initialRows.map((r) => ({ ...r }));
+  const calls = [];
+
+  return {
+    from(_table) {
+      const filters = {};
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { filters[col] = val; return builder; },
+        async maybeSingle() {
+          calls.push({ op: 'select', filters: { ...filters } });
+          const match = rows.find((r) =>
+            Object.entries(filters).every(([k, v]) => r[k] === v)
+          );
+          return { data: match || null, error: null };
+        },
+        update(patch) {
+          return {
+            async eq(col, val) {
+              calls.push({ op: 'update', match: { [col]: val }, patch });
+              const idx = rows.findIndex((r) => r[col] === val);
+              if (idx === -1) return { error: { message: 'not found' } };
+              rows[idx] = { ...rows[idx], ...patch };
+              return { error: null };
+            },
+          };
+        },
+        async insert(payload) {
+          calls.push({ op: 'insert', payload });
+          rows.push({ id: `row-${rows.length + 1}`, ...payload });
+          return { data: payload, error: null };
+        },
+      };
+      return builder;
+    },
+    _rows: () => rows,
+    _calls: () => calls,
+  };
+}
+
+describe('acquireResumeLock', () => {
+  const ventureId = '00000000-0000-0000-0000-000000000001';
+
+  it('acquires fresh lock when no session_state row exists (bootstrap path skipped in unit; assert no-row→writeArtifact would be called)', async () => {
+    // For the no-existing-row path, the helper imports artifact-persistence-service.
+    // We test that path indirectly — here we assert the reader returns null cleanly.
+    const sb = makeSupabaseMock([]);
+    // Spy on writeArtifact import so the bootstrap path doesn't actually hit Supabase
+    vi.doMock('../artifact-persistence-service.js', () => ({
+      writeArtifact: vi.fn(async () => 'bootstrap-id'),
+    }));
+    // Re-import after mock (vitest hoists)
+    const mod = await import('./resume-lock.js');
+    const result = await mod.acquireResumeLock(sb, ventureId);
+    expect(result.acquired).toBe(true);
+    expect(typeof result.token).toBe('string');
+    expect(typeof result.expiresAt).toBe('string');
+    vi.doUnmock('../artifact-persistence-service.js');
+  });
+
+  it('acquires fresh lock when row exists but has no resume_lock', async () => {
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: { progressUpdate: true },
+    }]);
+    const result = await acquireResumeLock(sb, ventureId);
+    expect(result.acquired).toBe(true);
+    expect(result.token).toBeTypeOf('string');
+
+    const stored = sb._rows()[0].metadata.resume_lock;
+    expect(stored.token).toBe(result.token);
+    expect(stored.expires_at).toBe(result.expiresAt);
+    // Pre-existing metadata is preserved
+    expect(sb._rows()[0].metadata.progressUpdate).toBe(true);
+  });
+
+  it('refuses to acquire when an unexpired lock already exists', async () => {
+    const futureExpires = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: { resume_lock: { token: 'pre-existing', expires_at: futureExpires, acquired_at: '2026-04-26T00:00:00.000Z' } },
+    }]);
+    const result = await acquireResumeLock(sb, ventureId);
+    expect(result.acquired).toBe(false);
+    expect(result.reason).toBe('LOCKED');
+    expect(result.existingExpiresAt).toBe(futureExpires);
+  });
+
+  it('reclaims the lock when the existing one has expired', async () => {
+    const pastExpires = new Date(Date.now() - 60_000).toISOString();
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: { resume_lock: { token: 'old', expires_at: pastExpires, acquired_at: '2026-04-25T00:00:00.000Z' } },
+    }]);
+    const result = await acquireResumeLock(sb, ventureId);
+    expect(result.acquired).toBe(true);
+    expect(result.token).not.toBe('old');
+    expect(sb._rows()[0].metadata.resume_lock.token).toBe(result.token);
+  });
+
+  it('honors options.ttlMs', async () => {
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: {},
+    }]);
+    const fixedNow = 1_700_000_000_000;
+    const result = await acquireResumeLock(sb, ventureId, { ttlMs: 60_000, now: () => fixedNow });
+    expect(new Date(result.expiresAt).getTime()).toBe(fixedNow + 60_000);
+    expect(RESUME_LOCK_TTL_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+describe('releaseResumeLock', () => {
+  const ventureId = '00000000-0000-0000-0000-000000000001';
+
+  it('releases when token matches', async () => {
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: { resume_lock: { token: 'tok-1', expires_at: 'x', acquired_at: 'y' }, otherKey: 'preserved' },
+    }]);
+    const result = await releaseResumeLock(sb, ventureId, 'tok-1');
+    expect(result.released).toBe(true);
+    expect(sb._rows()[0].metadata.resume_lock).toBeUndefined();
+    expect(sb._rows()[0].metadata.otherKey).toBe('preserved');
+  });
+
+  it('rejects when token does not match', async () => {
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: { resume_lock: { token: 'right', expires_at: 'x', acquired_at: 'y' } },
+    }]);
+    const result = await releaseResumeLock(sb, ventureId, 'wrong');
+    expect(result.released).toBe(false);
+    expect(result.reason).toBe('TOKEN_MISMATCH');
+    // Lock is preserved on mismatch
+    expect(sb._rows()[0].metadata.resume_lock.token).toBe('right');
+  });
+
+  it('returns NO_LOCK when no lock exists', async () => {
+    const sb = makeSupabaseMock([{
+      id: 'row-1',
+      venture_id: ventureId,
+      artifact_type: 's17_session_state',
+      is_current: true,
+      metadata: {},
+    }]);
+    const result = await releaseResumeLock(sb, ventureId, 'any-token');
+    expect(result.released).toBe(false);
+    expect(result.reason).toBe('NO_LOCK');
+  });
+
+  it('returns NO_TOKEN when called without a token', async () => {
+    const sb = makeSupabaseMock([]);
+    const result = await releaseResumeLock(sb, ventureId, '');
+    expect(result.released).toBe(false);
+    expect(result.reason).toBe('NO_TOKEN');
+  });
+});

--- a/scripts/maintenance/prune-s17-heartbeats.mjs
+++ b/scripts/maintenance/prune-s17-heartbeats.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Prune expired Stage 17 heartbeats.
+ *
+ * Deletes `s17_heartbeat` venture_artifacts whose `metadata.ttlExpiresAt`
+ * is in the past. The heartbeat-writer (ARM E) embeds the TTL on every
+ * write, so this cron-style script is the only counterparty needed —
+ * no DB-side trigger, no pg_cron job, no schema migration.
+ *
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM F (TR-2)
+ *
+ * Usage:
+ *   node scripts/maintenance/prune-s17-heartbeats.mjs           # prune
+ *   node scripts/maintenance/prune-s17-heartbeats.mjs --dry-run # report only
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+/**
+ * Delete expired s17_heartbeat rows.
+ *
+ * @param {object} supabase Supabase client
+ * @param {object} [options]
+ * @param {boolean} [options.dryRun=false] If true, count without deleting
+ * @param {() => Date} [options.now=() => new Date()] Injection seam for tests
+ * @returns {Promise<{pruned:number, ids:string[]}>}
+ */
+export async function pruneExpiredHeartbeats(supabase, options = {}) {
+  const dryRun = options.dryRun ?? false;
+  const now = (options.now ?? (() => new Date()))().toISOString();
+
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, metadata')
+    .eq('artifact_type', 's17_heartbeat')
+    .lt('metadata->>ttlExpiresAt', now);
+
+  if (error) throw error;
+  if (!data || data.length === 0) return { pruned: 0, ids: [] };
+
+  const ids = data.map((r) => r.id);
+
+  if (dryRun) return { pruned: 0, ids, dryRun: true };
+
+  const { error: delError } = await supabase
+    .from('venture_artifacts')
+    .delete()
+    .in('id', ids);
+  if (delError) throw delError;
+
+  return { pruned: ids.length, ids };
+}
+
+// CLI entry — only when invoked directly, not when imported by tests.
+const isDirectInvocation =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('prune-s17-heartbeats.mjs');
+
+if (isDirectInvocation) {
+  const dryRun = process.argv.includes('--dry-run');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[prune-s17-heartbeats] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(2);
+  }
+  const supabase = createClient(url, key);
+  pruneExpiredHeartbeats(supabase, { dryRun })
+    .then((r) => {
+      const verb = r.dryRun ? 'would prune' : 'pruned';
+      console.log(`[prune-s17-heartbeats] ${verb} ${r.dryRun ? r.ids.length : r.pruned} expired heartbeat(s)`);
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('[prune-s17-heartbeats]', err.message);
+      process.exit(1);
+    });
+}

--- a/scripts/maintenance/prune-s17-heartbeats.test.js
+++ b/scripts/maintenance/prune-s17-heartbeats.test.js
@@ -1,0 +1,100 @@
+/**
+ * Vitest spec for the s17_heartbeat prune script.
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM F (TR-2)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pruneExpiredHeartbeats } from './prune-s17-heartbeats.mjs';
+
+function makeSupabaseMock(rows = []) {
+  const calls = [];
+  return {
+    from(_table) {
+      const filters = {};
+      const ltFilters = {};
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { filters[col] = val; return builder; },
+        lt(col, val) { ltFilters[col] = val; return builder; },
+        async then(resolve) {
+          // Allow `await sb.from(...).select().eq().lt()` to resolve.
+          calls.push({ op: 'select', filters: { ...filters }, ltFilters: { ...ltFilters } });
+          const matches = rows.filter((r) => {
+            for (const [k, v] of Object.entries(filters)) {
+              if (r[k] !== v) return false;
+            }
+            for (const [k, v] of Object.entries(ltFilters)) {
+              const path = k.split('->>');
+              if (path.length === 2) {
+                const fieldVal = r[path[0]]?.[path[1]];
+                if (!(fieldVal < v)) return false;
+              }
+            }
+            return true;
+          });
+          resolve({ data: matches, error: null });
+        },
+        delete() {
+          return {
+            async in(col, ids) {
+              calls.push({ op: 'delete', col, ids });
+              for (const id of ids) {
+                const idx = rows.findIndex((r) => r.id === id);
+                if (idx !== -1) rows.splice(idx, 1);
+              }
+              return { error: null };
+            },
+          };
+        },
+      };
+      return builder;
+    },
+    _rows: () => rows,
+    _calls: () => calls,
+  };
+}
+
+describe('pruneExpiredHeartbeats', () => {
+  const fixedNow = () => new Date('2026-04-26T12:00:00.000Z');
+
+  it('returns {pruned:0} when no rows match', async () => {
+    const sb = makeSupabaseMock([]);
+    const result = await pruneExpiredHeartbeats(sb, { now: fixedNow });
+    expect(result).toEqual({ pruned: 0, ids: [] });
+  });
+
+  it('deletes rows whose ttlExpiresAt is in the past', async () => {
+    const sb = makeSupabaseMock([
+      { id: 'h1', artifact_type: 's17_heartbeat', metadata: { ttlExpiresAt: '2026-04-20T00:00:00.000Z' } },
+      { id: 'h2', artifact_type: 's17_heartbeat', metadata: { ttlExpiresAt: '2026-04-25T00:00:00.000Z' } },
+      { id: 'h3', artifact_type: 's17_heartbeat', metadata: { ttlExpiresAt: '2026-05-01T00:00:00.000Z' } }, // future
+    ]);
+    const result = await pruneExpiredHeartbeats(sb, { now: fixedNow });
+    expect(result.pruned).toBe(2);
+    expect(result.ids).toEqual(['h1', 'h2']);
+    // Only the future row remains
+    expect(sb._rows().map((r) => r.id)).toEqual(['h3']);
+  });
+
+  it('honors dryRun: reports without deleting', async () => {
+    const sb = makeSupabaseMock([
+      { id: 'h1', artifact_type: 's17_heartbeat', metadata: { ttlExpiresAt: '2026-04-20T00:00:00.000Z' } },
+    ]);
+    const result = await pruneExpiredHeartbeats(sb, { now: fixedNow, dryRun: true });
+    expect(result.dryRun).toBe(true);
+    expect(result.ids).toEqual(['h1']);
+    expect(result.pruned).toBe(0);
+    // Row preserved
+    expect(sb._rows().length).toBe(1);
+  });
+
+  it('does not touch non-heartbeat rows', async () => {
+    const sb = makeSupabaseMock([
+      { id: 'h1', artifact_type: 's17_heartbeat', metadata: { ttlExpiresAt: '2026-04-20T00:00:00.000Z' } },
+      { id: 'a1', artifact_type: 's17_archetypes', metadata: { ttlExpiresAt: '2026-04-20T00:00:00.000Z' } },
+    ]);
+    const result = await pruneExpiredHeartbeats(sb, { now: fixedNow });
+    expect(result.pruned).toBe(1);
+    expect(sb._rows().map((r) => r.id).sort()).toEqual(['a1']);
+  });
+});

--- a/server/routes/stage17.js
+++ b/server/routes/stage17.js
@@ -124,6 +124,71 @@ router.post('/:ventureId/archetypes', asyncHandler(async (req, res) => {
 }));
 
 /**
+ * POST /api/stage17/:ventureId/archetypes/resume
+ *
+ * Resume archetype generation for a venture whose prior run was interrupted
+ * (worker crash, watchdog stall, network drop). Idempotency guard: claims a
+ * 10-min lock_token on the venture's s17_session_state row before spawning
+ * the generator. A second concurrent call within the TTL gets 409.
+ *
+ * SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 ARM F
+ */
+router.post('/:ventureId/archetypes/resume', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+
+  const supabase = req.app.locals.supabase || req.supabase;
+  const { acquireResumeLock, releaseResumeLock } = await import('../../lib/eva/stage-17/resume-lock.js');
+
+  const lock = await acquireResumeLock(supabase, ventureId);
+  if (!lock.acquired) {
+    if (lock.reason === 'LOCKED') {
+      return res.status(409).json({
+        error: 'Resume already in progress for this venture',
+        code: 'RESUME_LOCKED',
+        existingExpiresAt: lock.existingExpiresAt,
+      });
+    }
+    return res.status(500).json({ error: sanitizeErrorMessage(lock.error), code: 'RESUME_LOCK_ERROR' });
+  }
+
+  // Defensively cancel any in-process foreground generation for this venture
+  // before resuming — the resume request is the new authoritative driver.
+  const inFlight = activeArchetypeGenerations.get(ventureId);
+  if (inFlight) {
+    inFlight.abort();
+    activeArchetypeGenerations.delete(ventureId);
+  }
+
+  const ac = new AbortController();
+  activeArchetypeGenerations.set(ventureId, ac);
+
+  res.status(202).json({
+    status: 'resuming',
+    lockToken: lock.token,
+    expiresAt: lock.expiresAt,
+    message: 'Resume started. Monitor progress via s17_heartbeat artifact.',
+  });
+
+  generateArchetypes(ventureId, supabase, { signal: ac.signal })
+    .then((result) => {
+      const label = result?.cancelled ? 'cancelled' : 'complete';
+      console.log(`[stage17-route] stage17/archetypes/resume ${label}: ${result?.artifactIds?.length ?? 0} screens for ${ventureId.slice(0, 8)}`);
+    })
+    .catch((err) => {
+      console.error('[stage17-route] stage17/archetypes/resume background failed:', err.message ?? err);
+    })
+    .finally(async () => {
+      activeArchetypeGenerations.delete(ventureId);
+      try { await releaseResumeLock(supabase, ventureId, lock.token); }
+      catch (err) { console.warn('[stage17-route] resume-lock release failed:', err.message ?? err); }
+    });
+  return;
+}));
+
+/**
  * POST /api/stage17/:ventureId/archetypes/cancel
  */
 router.post('/:ventureId/archetypes/cancel', asyncHandler(async (req, res) => {


### PR DESCRIPTION
## Summary

PR3 of 5 — ARM F backend completion. Must ship before ARM D (PR4) so the frontend banner has a reliable backend to call.

> **Stacked PR.** Base = `feat/SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001-pr2` (PR #3360). Auto-rebases when #3360 merges.

### Resume endpoint
- `POST /api/stage17/:ventureId/archetypes/resume` (mirrors `/archetypes` 202 fire-and-forget)
- Acquires 10-min lock_token before spawning generator; releases in `.finally()`
- Concurrent calls within TTL → HTTP 409 `RESUME_LOCKED` with `existingExpiresAt`
- Defensively cancels any in-process foreground generation for the same venture

### Idempotency (closes LEAD `plan_must_address` #3)
- `lib/eva/stage-17/resume-lock.js` — `acquireResumeLock` / `releaseResumeLock`
- Lock stored at `s17_session_state.metadata.resume_lock = {token, expires_at, acquired_at}` — zero schema migration
- Expired locks reclaimable; mismatched-token release is a no-op (defensive against late `.finally()`)
- Bootstrap path handles first-resume on ventures whose generation never started

### Heartbeat TTL maintenance (closes LEAD `plan_must_address` #2)
- `scripts/maintenance/prune-s17-heartbeats.mjs` — `pruneExpiredHeartbeats(supabase, opts)` + CLI
- Selects via `metadata->>ttlExpiresAt < now()` JSONB accessor (server-side filter)
- `--dry-run` flag for inspection; no schema, no pg_cron, no triggers

### Tests (13 new + 23 prior = 36/36 green)
- `resume-lock.test.js` — 9 cases: bootstrap, fresh-acquire, refuse-on-unexpired, reclaim-expired, ttlMs override, release-matching, release-mismatch, NO_LOCK, NO_TOKEN
- `prune-s17-heartbeats.test.js` — 4 cases: empty match, deletes-expired, dry-run reports, leaves non-heartbeat rows alone

### Contracts
- §1 — `/archetypes/resume` added to endpoint catalog
- §5.2 — links prune script + manual run instructions
- §5.3 (new) — full `resume_lock` metadata shape, 409 response contract, rationale (chose `metadata.resume_lock` over `job_id` UNIQUE: zero migration, dedup-safe, lock semantics fit double-fire prevention)

## Acceptance criteria
- **AC-2** — single stalled screen no longer requires user to discard all in-flight work — ARM F's resume regenerates only missing screens (generateArchetypes' existing dedup skips completed)
- **AC-5** — zero schema migrations for ARM F — held: lock lives on existing `s17_session_state.metadata`; only PR2's CHECK extension was needed
- **AC-6** — ARM F row complete

## LOC

- 6 files changed, +583 / -2
- Source-only (no tests): ~190
- Above PRD's ~50 LOC target — the lock helpers (123 LOC, mostly JSDoc + bootstrap path) and the route's defensive cancel-and-release lifecycle came in heavier than the original estimate. Lessons-learned for SD retro: per-call `gh pr view` cost analysis for the prune helper showed it was easier to keep the lock helpers monolithic than split into acquire/release sub-modules.

PRD: `PRD-SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001`
Stacked on: PR #3360 (ARMs B+C+E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)