### PR TITLE
fix(QF-20260425-288): always strategy-tag S17 archetype variants

### DIFF
--- a/lib/eva/stage-17/archetype-generator.js
+++ b/lib/eva/stage-17/archetype-generator.js
@@ -337,15 +337,6 @@ async function cleanupWipVariants(supabase, ventureId, screenId) {
   if (error) console.warn(`[archetype-generator] WIP cleanup failed for ${screenId}: ${error.message}`);
 }
 
-/** Fallback layouts used when page-type classification fails.
- * SD-MAN-REFAC-S17-SIMPLIFY-PIPELINE-001: Reduced from 6 to 4 variants. */
-const FALLBACK_LAYOUTS = [
-  'hero-centric with full-width header and content below',
-  'card-grid layout with equal-weight content tiles',
-  'sidebar navigation with content-right panel',
-  'single-column minimal with generous whitespace',
-];
-
 /**
  * Named error for missing Stage 15/16 source artifacts.
  */
@@ -759,10 +750,10 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
     // Classify page type
     const classification = classifyPageType(screenTitle, screen.description);
 
-    // SD-S17-DESIGN-MASTERY-PIPELINE-ORCH-001-A: Use strategy-driven layouts when confidence is sufficient
-    let strategyLayouts = classification.confidence >= 0.5
-      ? getStrategyLayouts(classification.pageType)
-      : null;
+    // QF-20260425-288: always strategy-tag the 4 variants; getStrategyLayouts has its own
+    // ?? landing default for low-confidence pageTypes, so every screen now produces
+    // strategy-attributed variants instead of half having strategy_name=null.
+    let strategyLayouts = getStrategyLayouts(classification.pageType);
 
     // SD-S17-STRATEGYFIRST-DESIGN-DIRECTION-ORCH-001-A: filter to chosen strategy or preview top 2
     if (strategy && strategyLayouts) {
@@ -786,9 +777,7 @@ export async function generateArchetypes(ventureId, supabase, options = {}) {
         .filter(Boolean);
     }
 
-    const layouts = strategyLayouts
-      ? strategyLayouts.map(sl => sl.description)
-      : (classification.confidence >= 0.5 ? getArchetypesForPageType(classification.pageType) : FALLBACK_LAYOUTS);
+    const layouts = strategyLayouts.map(sl => sl.description);
     const variantCount = layouts.length;
     console.log(`[archetype-generator] ┌── Screen ${screenIdx + 1}/${totalScreens}: ${screenTitle} (${deviceType})`);
     console.log(`[archetype-generator] │   pageType=${classification.pageType} (confidence=${classification.confidence}), generating ${variantCount} variants${strategyLayouts ? ' [strategy-driven]' : ''}`);

--- a/tests/unit/stage-17/archetype-generator.test.js
+++ b/tests/unit/stage-17/archetype-generator.test.js
@@ -25,6 +25,13 @@ vi.mock('../../../lib/eva/stage-17/page-type-classifier.js', () => ({
     'split-screen layout',
     'dashboard-style layout',
   ]),
+  // QF-20260425-288: archetype-generator now always calls this (no confidence gate)
+  getStrategyLayouts: vi.fn().mockReturnValue([
+    { strategy: 'clarity-first', description: 'clarity-first layout' },
+    { strategy: 'dense', description: 'dense layout' },
+    { strategy: 'narrative', description: 'narrative layout' },
+    { strategy: 'visual-impact', description: 'visual-impact layout' },
+  ]),
 }));
 
 // ── Mock: scoring-engine (fire-and-forget in production) ────────────────────


### PR DESCRIPTION
## Summary
Fixes QF-20260425-288. Stage17's archetype generator gated `strategyLayouts` on `classification.confidence >= 0.5`, so when the chairman picked "Skip - use all strategies" the low-confidence screens (Landing Page, Analyze Document, API & Integrations on LexiGuard) silently fell through to `FALLBACK_LAYOUTS` and got `strategy_name=null` in their variants — while higher-confidence screens (Signup, Dashboard, Analysis Report) got proper strategy attribution. Cosmetic mismatch but no documented contract.

`getStrategyLayouts(pageType)` in `page-type-classifier.js:222-224` already has a `?? STRATEGY_LAYOUTS.landing` defensive default, so the confidence gate is over-protective. Removing it makes every screen produce 4 strategy-attributed variants (clarity-first / dense / narrative / visual-impact). `FALLBACK_LAYOUTS` becomes dead code and is deleted.

## Diff
- `lib/eva/stage-17/archetype-generator.js`: -16 / +5 LOC (drop 2 confidence-gated ternaries, delete FALLBACK_LAYOUTS const + comment)
- `tests/unit/stage-17/archetype-generator.test.js`: +7 LOC (add `getStrategyLayouts` to the existing `vi.mock` of `page-type-classifier.js`, since the file is now always called)

## Pre-existing test state (NOT regressed by this PR)
Confirmed via `git stash + run + pop`: `tests/unit/stage-17/archetype-generator.test.js` has 10/12 tests failing on origin/main with `ArchetypeGenerationError: No wireframe_screens artifact found` — pre-existing unrelated. After my change: identical 10/12 fail. My mock addition keeps the 2 currently-passing tests passing.

## Test plan
- [x] Diff is minimal (single logic file + minimal test mock)
- [x] `getStrategyLayouts`/`getArchetypesForPageType` both have defensive `?? landing` defaults
- [x] Surrounding `if (strategy && strategyLayouts)` / `else if (... && strategyLayouts)` guards remain (defensive — no removal churn)
- [x] FALLBACK_LAYOUTS verified single-use (only line 791); safe to delete
- [x] Pre-existing 10/12 test fails on origin/main confirmed unchanged
- [ ] UAT (manual S17 flow against a venture) — deferred; behavior change is "all variants now have strategy_name set" which is what the QF asked for as option (b)
- [ ] CI green (auto-merge after checks)

## Why option (b) over option (a)
QF described two valid contracts: (a) all `strategy_name=null` with documented page-type-only behavior, or (b) all `strategy_name` populated (fanout). Picked (b) because:
1. The "Skip - use all strategies" button label implies the chairman wants strategy attribution
2. Option (a) requires actively NULLing existing populated values — more surprising
3. Downstream consumers (Stage18+ scoring) likely expect strategy tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)