### PR TITLE
fix(SD-LEO-INFRA-SMOKE-TEST-SCHEMA-RECONCILE-001): dual-shape canonicalizer for smoke_test_steps preflight

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -37,6 +37,26 @@ export function shouldRequireUserStories(sdType) {
 }
 
 /**
+ * Canonicalize a smoke_test_steps entry to {instruction, expected_outcome}.
+ *
+ * SD-LEO-INFRA-SMOKE-TEST-SCHEMA-RECONCILE-001 — eliminates the asymmetry
+ * between PRECHECK gate (smoke-test-specification.js — accepts dual shape)
+ * and execute preflight (this file — historically strict).
+ *
+ * Accepts: {instruction, expected_outcome} | {instruction_template, expected_outcome_template} | {step, expected}
+ * Returns: { instruction, expected_outcome } — undefined for both keys when neither pair is fully present.
+ *
+ * @param {Object|null|undefined} step
+ * @returns {{instruction: string|undefined, expected_outcome: string|undefined}}
+ */
+export function canonicalizeSmokeStep(step) {
+  if (!step || typeof step !== 'object') return { instruction: undefined, expected_outcome: undefined };
+  const instruction = step.instruction || step.instruction_template || step.step;
+  const expected_outcome = step.expected_outcome || step.expected_outcome_template || step.expected;
+  return { instruction, expected_outcome };
+}
+
+/**
  * Run prerequisite preflight checks for a given handoff type.
  * Returns { passed, issues[] } where each issue has { code, message, remediation }.
  */
@@ -241,6 +261,9 @@ function checkLeadToPlanPrereqs(sd) {
   }
 
   // Check smoke_test_steps
+  // SD-LEO-INFRA-SMOKE-TEST-SCHEMA-RECONCILE-001: canonicalize each step
+  // before validity check — accepts legacy {step, expected} shape in addition
+  // to canonical {instruction, expected_outcome}.
   const smokeSteps = sd.smoke_test_steps;
   if (!smokeSteps || !Array.isArray(smokeSteps) || smokeSteps.length === 0) {
     issues.push({
@@ -249,9 +272,10 @@ function checkLeadToPlanPrereqs(sd) {
       remediation: 'Add smoke_test_steps: [{instruction: "...", expected_outcome: "..."}]'
     });
   } else {
-    const validSteps = smokeSteps.filter(s => s.instruction && s.expected_outcome);
+    const canonicalized = smokeSteps.map(canonicalizeSmokeStep);
+    const validSteps = canonicalized.filter(s => s.instruction && s.expected_outcome);
     if (validSteps.length === 0) {
-      const invalidStep = smokeSteps[0];
+      const invalidStep = canonicalized[0];
       const missingFields = [];
       if (!invalidStep?.instruction) missingFields.push('instruction');
       if (!invalidStep?.expected_outcome) missingFields.push('expected_outcome');
@@ -259,11 +283,12 @@ function checkLeadToPlanPrereqs(sd) {
         code: 'SMOKE_TEST_INVALID',
         message: `smoke_test_steps[0] is missing required field(s): ${missingFields.join(', ')}`,
         remediation: [
-          'Each step must have both fields. Example:',
+          'Each step must have both fields. Canonical (preferred):',
           '  smoke_test_steps: [',
           '    { instruction: "Run: node scripts/handoff.js execute LEAD-TO-PLAN SD-EXAMPLE-001",',
           '      expected_outcome: "HANDOFF_RESULT=PASS printed to stdout" }',
-          '  ]'
+          '  ]',
+          'Legacy {step, expected} shape is also accepted (auto-canonicalized).'
         ].join('\n')
       });
     }

--- a/tests/unit/handoff/prerequisite-preflight-smoke-canonicalize.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-smoke-canonicalize.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for canonicalizeSmokeStep helper + dual-shape backward-compat
+ * in checkLeadToPlanPrereqs smoke_test_steps validation.
+ *
+ * SD-LEO-INFRA-SMOKE-TEST-SCHEMA-RECONCILE-001
+ *
+ * Verifies:
+ * - canonicalizeSmokeStep returns {instruction, expected_outcome} for both shapes
+ * - Legacy {step, expected} smoke_test_steps pass LEAD-TO-PLAN preflight
+ * - Canonical {instruction, expected_outcome} continue passing (no regression)
+ * - Mixed array (legacy + canonical) passes
+ * - Genuinely malformed steps still emit SMOKE_TEST_INVALID
+ * - Empty array still emits SMOKE_TEST_MISSING (distinct from INVALID)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalizeSmokeStep,
+  runPrerequisitePreflight
+} from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+describe('canonicalizeSmokeStep() helper', () => {
+  it('returns canonical shape unchanged for {instruction, expected_outcome}', () => {
+    const out = canonicalizeSmokeStep({ instruction: 'do x', expected_outcome: 'y happens' });
+    expect(out).toEqual({ instruction: 'do x', expected_outcome: 'y happens' });
+  });
+
+  it('canonicalizes legacy {step, expected} to {instruction, expected_outcome}', () => {
+    const out = canonicalizeSmokeStep({ step: 'do x', expected: 'y happens' });
+    expect(out).toEqual({ instruction: 'do x', expected_outcome: 'y happens' });
+  });
+
+  it('accepts {instruction_template, expected_outcome_template} (PRECHECK gate parity)', () => {
+    const out = canonicalizeSmokeStep({
+      instruction_template: 'tmpl x',
+      expected_outcome_template: 'tmpl y'
+    });
+    expect(out).toEqual({ instruction: 'tmpl x', expected_outcome: 'tmpl y' });
+  });
+
+  it('returns both keys undefined for empty object', () => {
+    const out = canonicalizeSmokeStep({});
+    expect(out).toEqual({ instruction: undefined, expected_outcome: undefined });
+  });
+
+  it('returns both keys undefined for null/undefined input', () => {
+    expect(canonicalizeSmokeStep(null)).toEqual({ instruction: undefined, expected_outcome: undefined });
+    expect(canonicalizeSmokeStep(undefined)).toEqual({ instruction: undefined, expected_outcome: undefined });
+  });
+
+  it('returns both keys undefined for non-object input (string/number/array)', () => {
+    expect(canonicalizeSmokeStep('string')).toEqual({ instruction: undefined, expected_outcome: undefined });
+    expect(canonicalizeSmokeStep(42)).toEqual({ instruction: undefined, expected_outcome: undefined });
+  });
+
+  it('prefers canonical keys when both shapes present (canonical wins)', () => {
+    const out = canonicalizeSmokeStep({
+      instruction: 'canonical',
+      expected_outcome: 'canonical_out',
+      step: 'legacy',
+      expected: 'legacy_out'
+    });
+    expect(out).toEqual({ instruction: 'canonical', expected_outcome: 'canonical_out' });
+  });
+
+  it('preserves step_number untouched (caller-managed)', () => {
+    // canonicalize only normalizes instruction/expected_outcome — step_number
+    // is not part of the canonical shape it produces. Caller can read
+    // step.step_number off the original object if needed.
+    const out = canonicalizeSmokeStep({ step_number: 1, step: 'a', expected: 'b' });
+    expect(out.instruction).toBe('a');
+    expect(out.expected_outcome).toBe('b');
+  });
+});
+
+describe('checkLeadToPlanPrereqs smoke_test_steps via canonicalizer', () => {
+  function makeMockSupabase({ sdRow }) {
+    return {
+      from: () => {
+        const builder = {
+          select: () => builder,
+          eq: () => builder,
+          single: async () => ({ data: sdRow, error: null })
+        };
+        return builder;
+      }
+    };
+  }
+
+  function baseSdFixture(overrides = {}) {
+    return {
+      id: 'SD-TEST-CANON-001',
+      sd_key: 'SD-TEST-CANON-001',
+      sd_type: 'bugfix',
+      description: 'a '.repeat(60),
+      success_criteria: [{ criterion: 'x', measure: 'y' }],
+      strategic_objectives: ['Objective 1'],
+      key_changes: [{ change: 'c', type: 'fix' }],
+      key_principles: ['p1'],
+      risks: [{ risk: 'r', mitigation: 'm' }],
+      implementation_guidelines: ['g1'],
+      dependencies: [],
+      ...overrides
+    };
+  }
+
+  it('legacy {step, expected} array passes preflight', async () => {
+    const sd = baseSdFixture({
+      smoke_test_steps: [{ step: 'do x', expected: 'y happens' }]
+    });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).not.toContain('SMOKE_TEST_INVALID');
+    expect(codes).not.toContain('SMOKE_TEST_MISSING');
+  });
+
+  it('canonical {instruction, expected_outcome} array passes preflight (no regression)', async () => {
+    const sd = baseSdFixture({
+      smoke_test_steps: [{ instruction: 'do x', expected_outcome: 'y happens' }]
+    });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).not.toContain('SMOKE_TEST_INVALID');
+    expect(codes).not.toContain('SMOKE_TEST_MISSING');
+  });
+
+  it('mixed array (legacy + canonical) passes preflight', async () => {
+    const sd = baseSdFixture({
+      smoke_test_steps: [
+        { step: 'a', expected: 'b' },
+        { instruction: 'c', expected_outcome: 'd' }
+      ]
+    });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).not.toContain('SMOKE_TEST_INVALID');
+    expect(codes).not.toContain('SMOKE_TEST_MISSING');
+  });
+
+  it('malformed step (missing both pairs) still emits SMOKE_TEST_INVALID', async () => {
+    const sd = baseSdFixture({
+      smoke_test_steps: [{}]
+    });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('SMOKE_TEST_INVALID');
+  });
+
+  it('partial step (only step, no expected) emits SMOKE_TEST_INVALID', async () => {
+    const sd = baseSdFixture({
+      smoke_test_steps: [{ step: 'do x' }]
+    });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('SMOKE_TEST_INVALID');
+    const invalid = result.issues.find((i) => i.code === 'SMOKE_TEST_INVALID');
+    expect(invalid.message).toContain('expected_outcome');
+  });
+
+  it('empty array emits SMOKE_TEST_MISSING (preserved, distinct from INVALID)', async () => {
+    const sd = baseSdFixture({ smoke_test_steps: [] });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('SMOKE_TEST_MISSING');
+    expect(codes).not.toContain('SMOKE_TEST_INVALID');
+  });
+
+  it('SMOKE_TEST_INVALID remediation mentions both shapes accepted', async () => {
+    const sd = baseSdFixture({ smoke_test_steps: [{}] });
+    const supabase = makeMockSupabase({ sdRow: sd });
+
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', sd.sd_key);
+    const invalid = result.issues.find((i) => i.code === 'SMOKE_TEST_INVALID');
+    expect(invalid).toBeDefined();
+    // Canonical shape example must remain visible
+    expect(invalid.remediation).toContain('instruction');
+    expect(invalid.remediation).toContain('expected_outcome');
+    // Legacy support note must be present
+    expect(invalid.remediation).toContain('Legacy');
+    expect(invalid.remediation).toContain('auto-canonicalized');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `canonicalizeSmokeStep()` pure helper to `prerequisite-preflight.js` accepting both legacy `{step, expected}` and canonical `{instruction, expected_outcome}` shapes (plus template variants)
- Wire it into `checkLeadToPlanPrereqs()` so the handoff.js execute preflight no longer rejects legacy-shape inputs with `SMOKE_TEST_INVALID`
- Eliminates the asymmetry with the PRECHECK gate (`smoke-test-specification.js`) that already accepted dual shape — both gates now operationally symmetric
- Update `SMOKE_TEST_INVALID` remediation message to mention dual-shape support
- Defensive against one-off scripts (e.g., `scripts/one-off/sd-man-fix-restore-s17-update.mjs`) that bypass canonical authoring helpers — the trigger of mid-LEAD database-agent reconcile toil at `SD-MAN-FIX-RESTORE-S17-SINGLE-001`

## Scope discipline

LEAD scope amendment dropped 2 of 4 originally proposed key_changes (50% scope_reduction):
- ❌ "Update SD authoring helpers" — verified 6/6 already canonical (LEARN-085, leo-create-sd, create-sd, sd-from-feedback, sd-builders, child-sd-llm-service)
- ❌ "Migration of existing rows" — verified 30/30 sampled SDs already canonical
- ✅ Defensive backward-compat reader (this PR)
- ✅ 4+ vitest cases (15 in this PR)

## Test plan

- [x] 15 vitest cases pass (`tests/unit/handoff/prerequisite-preflight-smoke-canonicalize.test.js`)
- [x] Sibling tests unaffected (26/26 in `prerequisite-preflight-{stories-exemption,prd-status}.test.js`)
- [x] TESTING + REGRESSION sub-agents PASS verdicts in `sub_agent_execution_results`
- [ ] CI green on this branch

## LEO metadata

- SD: `SD-LEO-INFRA-SMOKE-TEST-SCHEMA-RECONCILE-001`
- Type: bugfix
- LEAD-TO-PLAN: PASS 96 → PLAN-TO-EXEC: PASS 94 → EXEC-TO-PLAN: PASS 96 → PLAN-TO-LEAD: PASS 97
- LOC: +33 -4 production (29 net) + 193 test = 222 insertions
- PR ceiling: well under 400 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>