### PR TITLE
feat(SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001): Auto-detect target_application from key_changes paths

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-INFRA-RESTART-SKILL-LEO-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-RESTART-SKILL-LEO-001",
-  "createdAt": "2026-04-25T17:39:18.267Z",
+  "sdKey": "SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001",
+  "createdAt": "2026-04-26T15:39:35.067Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer"
 }

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -50,6 +50,8 @@ import { scoreSD } from './eva/vision-scorer.js';
 import { trackWriteSource } from '../lib/eva/cli-write-gate.js';
 import { validateSDFields } from './modules/validate-sd-fields.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+// SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: path-based target detector
+import { detectFromKeyChanges } from './modules/handoff/executors/lead-to-plan/gates/target-application.js';
 
 const supabase = createSupabaseServiceClient();
 
@@ -1426,9 +1428,12 @@ async function createSD(options) {
   }
 
   // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Resolve target_application from venture context
-  // Precedence: explicit param > VENTURE env var > getCurrentVenture() > 'EHG_Engineer'
+  // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: insert key_changes path detector
+  //   between VENTURE env var and getCurrentVenture() fallback (line 1446 below).
+  // Precedence: explicit param > VENTURE env var > path detect from key_changes > getCurrentVenture() > 'EHG_Engineer'
   const resolvedTargetApplication = explicitTargetApp
     || (process.env.VENTURE && (getVentureConfig(process.env.VENTURE)?.name || process.env.VENTURE))
+    || detectFromKeyChanges(finalKeyChanges)
     || null;
 
   const sdData = {

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
@@ -4,7 +4,75 @@
  *
  * SD-LEO-GEMINI-001: Validate target_application at LEAD-TO-PLAN to prevent
  * late-stage failures when commits are searched in wrong repository
+ *
+ * SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: Path-based detector
+ * `detectFromKeyChanges` complements the prose detector below; consumed by
+ * leo-create-sd.js BEFORE the venture-resolver fallback so all-frontend SDs
+ * route to EHG without manual --venture intervention.
  */
+
+// Path-prefix substrings that vote toward each application. Matches are
+// case-sensitive substring checks against `key_changes[].change` strings.
+// Update review date in the comment block below when patterns change.
+// Last reviewed: 2026-04-26 (SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001)
+export const PATH_PATTERN_DICTIONARY = {
+  EHG: [
+    '/ehg/',
+    'src/components/',
+    'src/pages/',
+    'src/stages/',
+    'src/ventures/',
+    'src/hooks/',
+    'src/lib/',
+  ],
+  EHG_Engineer: [
+    'scripts/',
+    'lib/eva/',
+    'lib/sub-agents/',
+    'lib/llm/',
+    'lib/genesis/',
+    'lib/utils/',
+    'lib/telemetry/',
+    'lib/team/',
+    '.claude/',
+    'CLAUDE.md',
+    'CLAUDE_CORE.md',
+    'CLAUDE_LEAD.md',
+    'CLAUDE_PLAN.md',
+    'CLAUDE_EXEC.md',
+    'handoff.js',
+  ],
+};
+
+/**
+ * Path-based target_application detector for SD authoring.
+ *
+ * Scans `key_changes[].change` strings against PATH_PATTERN_DICTIONARY,
+ * tallies matches per application, and returns the majority winner.
+ * Returns null on tie, empty input, non-array input, or zero matches —
+ * the caller's existing fallback chain (getCurrentVenture / explicitTargetApp /
+ * 'EHG_Engineer') handles those cases.
+ *
+ * @param {Array<{type?: string, change?: string}>|*} keyChanges
+ * @returns {'EHG'|'EHG_Engineer'|null}
+ */
+export function detectFromKeyChanges(keyChanges) {
+  if (!Array.isArray(keyChanges) || keyChanges.length === 0) return null;
+
+  let ehgVotes = 0;
+  let engineerVotes = 0;
+
+  for (const entry of keyChanges) {
+    const change = (entry && typeof entry === 'object' && typeof entry.change === 'string') ? entry.change : '';
+    if (!change) continue;
+    if (PATH_PATTERN_DICTIONARY.EHG.some(p => change.includes(p))) ehgVotes += 1;
+    if (PATH_PATTERN_DICTIONARY.EHG_Engineer.some(p => change.includes(p))) engineerVotes += 1;
+  }
+
+  if (ehgVotes === 0 && engineerVotes === 0) return null;
+  if (ehgVotes === engineerVotes) return null;
+  return ehgVotes > engineerVotes ? 'EHG' : 'EHG_Engineer';
+}
 
 /**
  * Validate and potentially auto-correct target_application

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.test.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.test.js
@@ -9,7 +9,7 @@ vi.mock('../../../../../../lib/venture-resolver.js', () => ({
   getCurrentVenture: vi.fn(() => 'EHG_Engineer'),
 }));
 
-import { validateTargetApplication, createTargetApplicationGate } from './target-application.js';
+import { validateTargetApplication, createTargetApplicationGate, detectFromKeyChanges, PATH_PATTERN_DICTIONARY } from './target-application.js';
 import { createMockSD, createMockSupabase, assertValidatorResult } from '../../../../../../tests/factories/validator-context-factory.js';
 
 describe('validateTargetApplication', () => {
@@ -122,6 +122,71 @@ describe('validateTargetApplication', () => {
 
     expect(result.pass).toBe(true);
     expect(result.score).toBe(100);
+  });
+});
+
+// SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001
+describe('detectFromKeyChanges', () => {
+  it('returns "EHG" for all-frontend paths', () => {
+    const result = detectFromKeyChanges([
+      { type: 'feature', change: 'Modify /ehg/src/components/stage17/Stage17ReviewPanel.tsx' },
+      { type: 'test', change: 'Add tests under src/pages/admin/' },
+    ]);
+    expect(result).toBe('EHG');
+  });
+
+  it('returns "EHG_Engineer" for all-backend paths', () => {
+    const result = detectFromKeyChanges([
+      { type: 'feature', change: 'Add scripts/modules/handoff/foo.js' },
+      { type: 'test', change: 'Update lib/eva/bar.js' },
+    ]);
+    expect(result).toBe('EHG_Engineer');
+  });
+
+  it('returns null for empty array', () => {
+    expect(detectFromKeyChanges([])).toBeNull();
+  });
+
+  it('returns null for non-array input without throwing', () => {
+    expect(detectFromKeyChanges(undefined)).toBeNull();
+    expect(detectFromKeyChanges(null)).toBeNull();
+    expect(detectFromKeyChanges('not-an-array')).toBeNull();
+    expect(detectFromKeyChanges({ change: '/ehg/' })).toBeNull();
+  });
+
+  it('returns null on tied EHG vs EHG_Engineer counts', () => {
+    const result = detectFromKeyChanges([
+      { type: 'feature', change: '/ehg/src/foo.tsx' },
+      { type: 'feature', change: 'scripts/bar.js' },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no path patterns match', () => {
+    const result = detectFromKeyChanges([
+      { type: 'feature', change: 'docs/some-prose-only-change.md' },
+      { type: 'fix', change: 'unrelated text with no path prefix' },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('skips entries with missing or non-string change field without throwing', () => {
+    const result = detectFromKeyChanges([
+      { type: 'feature', change: '/ehg/src/foo.tsx' },
+      { type: 'feature' },
+      { type: 'test', change: null },
+      'not-an-object',
+      null,
+      { type: 'feature', change: 'src/pages/bar.tsx' },
+    ]);
+    expect(result).toBe('EHG');
+  });
+
+  it('exports PATH_PATTERN_DICTIONARY with both application keys populated', () => {
+    expect(Array.isArray(PATH_PATTERN_DICTIONARY.EHG)).toBe(true);
+    expect(Array.isArray(PATH_PATTERN_DICTIONARY.EHG_Engineer)).toBe(true);
+    expect(PATH_PATTERN_DICTIONARY.EHG.length).toBeGreaterThan(0);
+    expect(PATH_PATTERN_DICTIONARY.EHG_Engineer.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `detectFromKeyChanges(key_changes)` helper to existing `target-application.js` gate module — sibling to prose-based `validateTargetApplication`.
- Wires path-based detector into `leo-create-sd.js:1432` precedence chain: `explicitTargetApp > VENTURE env > detectFromKeyChanges > getCurrentVenture > 'EHG_Engineer'`.
- Prevents wrong-codebase routing at SD authoring time (e.g., the SD-MAN-FIX-RESTORE-S17-SINGLE-001 incident that motivated this SD).

## Architecture
**Option A** per validation-agent verdict `f8313a5f` (PASS @ 92%): extend the existing target-application.js gate file rather than create a new module. Single source for target-app reasoning; co-located vitest fixtures.

## LEAD Q8 deletion audit (14% scope reduction)
- ❌ Dropped `--target-application` CLI override flag — redundant with existing `--venture` flag and `explicitTargetApp` parameter.
- ❌ Trimmed vitest target from 5+ to 3 essential cases (8 ultimately added for defensive coverage).

## Diff stats
- 4 files changed, 143 insertions, 5 deletions (Tier 2: acceptable per CLAUDE.md PR Size Guidelines)

## Test plan
- [x] Unit tests: 17/17 vitest cases pass (9 pre-existing + 8 new for `detectFromKeyChanges` + dictionary export shape)
- [x] TESTING sub-agent: PASS @ 96% confidence (`sub_agent_execution_results` row `14ca74b1`)
- [x] Smoke test deferred to post-merge: run `node scripts/leo-create-sd.js --interactive` with key_changes targeting `/ehg/src/components/` → expect `target_application='EHG'`

## Phase scores
- LEAD-TO-PLAN: 96/100
- PLAN-TO-EXEC: 94/100
- EXEC-TO-PLAN: 93/100 (with documented bypass for GATE_TEST_COVERAGE_QUALITY playwright timeout — backend-only SD)
- PLAN-TO-LEAD: 95/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)