### PR TITLE
fix(QF-20260426-SWEEP-MSG-NUKE): stop deleting unexpired broadcasts + COACHING to stale sessions

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -970,24 +970,28 @@ async function main() {
 
   // FIX #3: Clean up coordination messages targeting dead/stale sessions
   // These accumulate because target sessions exit without reading them
+  // QF-20260426-SWEEP-MSG-NUKE: previously also deleted unexpired broadcasts
+  // (target_session='broadcast' is never in classified-set) and COACHING messages
+  // to STALE-but-claim-holding sessions (workers read on next sd-start chained run).
+  // Now: only delete unread messages where (a) target is a real session_id (UUID-shaped),
+  // (b) target is DEAD (claim released), and (c) message is past its expires_at if set.
   const allSessionIds = new Set(classified.map(s => s.session_id));
+  const deadIds = new Set(classified.filter(s => s.status === 'DEAD').map(s => s.session_id));
+  const nowMs = Date.now();
+  const isUuidLike = (s) => typeof s === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(s);
+  const isExpired = (m) => !m.expires_at || new Date(m.expires_at).getTime() <= nowMs;
+
   const { data: unreadMsgs } = await supabase
     .from('session_coordination')
-    .select('id, target_session')
+    .select('id, target_session, message_type, expires_at')
     .is('acknowledged_at', null)
     .is('read_at', null);
 
-  const deadMsgIds = (unreadMsgs || [])
-    .filter(m => !allSessionIds.has(m.target_session))
+  const allDeadMsgIds = (unreadMsgs || [])
+    .filter(m => isUuidLike(m.target_session))
+    .filter(m => !allSessionIds.has(m.target_session) || deadIds.has(m.target_session))
+    .filter(isExpired)
     .map(m => m.id);
-
-  // Also include messages targeting sessions classified as DEAD or stale
-  const deadOrStaleIds = new Set(classified.filter(s => s.status !== 'ACTIVE').map(s => s.session_id));
-  const staleMsgIds = (unreadMsgs || [])
-    .filter(m => deadOrStaleIds.has(m.target_session))
-    .map(m => m.id);
-
-  const allDeadMsgIds = [...new Set([...deadMsgIds, ...staleMsgIds])];
   if (allDeadMsgIds.length > 0) {
     // Delete in batches of 50
     for (let i = 0; i < allDeadMsgIds.length; i += 50) {


### PR DESCRIPTION
## Summary
Fixes high-severity QF-20260426-SWEEP-MSG-NUKE. `stale-session-sweep.cjs` lines 980-997 deleted any unread `session_coordination` row whose `target_session` wasn't in the live classified-set OR was classified non-ACTIVE. Two collateral kills:

1. **Broadcasts** (`target_session='broadcast'` literal, never a session_id) were swept regardless of `expires_at`.
2. **COACHING / WORK_ASSIGNMENT to STALE sessions** — STALE sessions still hold their claim and read inbox on the next `sd-start` (chained mode). Sweeping these silently broke the parallel-fleet learning collector (`PAT-PARALLEL-FLEET-LEARNING-COLLECTOR-001`).

## Fix
Narrow the deletion predicate to AND-of:
- `target_session` is UUID-shaped (`/^[0-9a-f]{8}-[0-9a-f]{4}-/i`) — skips `'broadcast'` and any future literals
- target session is `DEAD` (claim released), not just STALE
- message is past its `expires_at` (or has none)

`SELECT` now also fetches `message_type` + `expires_at` columns needed for the predicate.

## Diff
- `scripts/stale-session-sweep.cjs`: +15 / -11 = net +4 LOC, single file

## Test plan
- [x] Diff isolated to one cleanup block; surrounding sweep logic untouched
- [x] Broadcast preservation: 5 sample rows in DB confirm `target_session='broadcast'` shape; new `isUuidLike()` excludes them
- [x] STALE preservation: only `s.status === 'DEAD'` (claim already released) qualifies for cleanup
- [x] TTL respected: `expires_at` clause prevents pre-expiry deletion
- [ ] UAT (live sweep cycle) — deferred; behavior change is strictly less destructive (smaller delete-set), no possibility of new false-deletes
- [ ] CI green (auto-merge after checks)

## Why this matters now
**6 parallel sessions** are currently running on this fleet (per operator). The buggy sweep is actively destroying the broadcasts/COACHING they exchange every ~5 min. Shipping this PR directly closes the parallel-fleet coordination gap referenced in the QF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)