### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001): coordinator-side worker revival contract

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -19,6 +19,8 @@ Parse `$ARGUMENTS` to determine the subcommand:
 - `predictions` or `p` → Predictive signals (capacity, unlock forecast, heartbeat aging)
 - `sweep` or `s` → Run stale session sweep (release dead claims, resolve conflicts, QA fixes)
 - `identity` or `id` → Assign colors and callsigns to active workers
+- `revive [callsign]` → Request revival for a single callsign (e.g., `revive Bravo`)
+- `revive-all` → Request revival for every callsign without an active session
 - `team` or `t` → /execute team banner (active multi-session execution teams, Mockup A)
 - `help` → Show usage help
 
@@ -42,6 +44,8 @@ Map the argument to the appropriate action:
 - `predictions`, `p` → dashboard predictions section
 - `sweep`, `s` → run sweep script
 - `identity`, `id` → assign fleet identities
+- `revive <callsign>` → run coordinator-revive.cjs with the callsign arg
+- `revive-all` → run coordinator-revive.cjs with `all`
 - `team`, `t` → dashboard team section (/execute Mockup A banner — Phase 2)
 - `all`, no args → full dashboard
 - `help` → show help
@@ -180,6 +184,25 @@ Assigns colors and NATO callsigns to all active workers. New workers without an 
 
 Display the assignment table output.
 
+#### For `revive [callsign]` or `revive-all` (SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001):
+
+```bash
+# Single-callsign revival
+node scripts/coordinator-revive.cjs <callsign>      # e.g., 'Bravo'
+
+# Batch revive every callsign without an active session
+node scripts/coordinator-revive.cjs all
+```
+
+INSERTs a row into `worker_spawn_requests` (one pending per callsign — partial unique index enforces idempotency) and emits a `SPAWN_REQUEST` broadcast on `session_coordination`. An external spawn-execution layer (out of scope for this skill — see `docs/protocol/coordinator-worker-revival.md`) consumes the row and starts a fresh CC instance.
+
+Behavior:
+- Single revive of an already-pending callsign reports "already pending" gracefully (no error).
+- `revive-all` queries `v_active_sessions` for callsigns without active sessions, batches inserts, and reports inserted/skipped/failed counts.
+- The `revival` dashboard section (`/coordinator revival` or part of `/coordinator all`) surfaces pending requests with age + expires-in.
+
+Display the script output directly to the user.
+
 #### For `help`:
 
 Display:
@@ -200,6 +223,8 @@ Subcommands:
   /coordinator predict  (p) Predictive signals — capacity, unlock forecast, aging
   /coordinator sweep    (s) Run stale session sweep — release dead, resolve conflicts
   /coordinator identity (id) Assign colors and callsigns to active workers
+  /coordinator revive [callsign] Request revival for a callsign (worker_spawn_requests)
+  /coordinator revive-all   Request revival for every callsign without an active session
   /coordinator help         Show this help
 
 Getting Started:

--- a/database/migrations/20260426_add_spawn_request_enum.sql
+++ b/database/migrations/20260426_add_spawn_request_enum.sql
@@ -1,0 +1,9 @@
+-- Migration: add SPAWN_REQUEST to coordination_message_type enum
+-- SD: SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001 (FR-2)
+-- Purpose: enable /coordinator revive subcommands to broadcast spawn intent on the
+--          existing session_coordination bus without inventing a new transport.
+--
+-- ALTER TYPE ADD VALUE IF NOT EXISTS is the canonical idempotent pattern;
+-- sibling: 20260411_add_stop_requested_save_warning_enum.sql.
+
+ALTER TYPE coordination_message_type ADD VALUE IF NOT EXISTS 'SPAWN_REQUEST';

--- a/database/migrations/20260426_worker_spawn_requests.sql
+++ b/database/migrations/20260426_worker_spawn_requests.sql
@@ -1,0 +1,51 @@
+-- Migration: worker_spawn_requests table for coordinator-driven worker revival
+-- SD: SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001 (FR-1)
+-- Purpose: DB-queryable revival contract — coordinator INSERTs requests, an
+--          external spawn-execution layer (out of scope for this SD) consumes.
+--
+-- Schema notes (DATABASE sub-agent design review row 06fe1ab3-…):
+--   - claude_sessions.session_id is TEXT (not UUID); FKs match.
+--   - ON DELETE SET NULL preserves audit history when sessions rotate.
+--   - Partial unique index on (callsign) WHERE status='pending' enforces idempotency.
+--   - RLS enabled; service_role retains full access (existing operational pattern).
+
+CREATE TABLE IF NOT EXISTS worker_spawn_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  requested_by_session_id TEXT REFERENCES claude_sessions(session_id) ON DELETE SET NULL,
+  requested_callsign TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','fulfilled','expired','cancelled')),
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  fulfilled_by_session_id TEXT REFERENCES claude_sessions(session_id) ON DELETE SET NULL,
+  fulfilled_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT NOW() + INTERVAL '1 hour',
+  payload JSONB DEFAULT '{}'::jsonb
+);
+
+-- Idempotency: at most one pending row per callsign at any time
+CREATE UNIQUE INDEX IF NOT EXISTS idx_wsr_unique_pending_callsign
+  ON worker_spawn_requests (requested_callsign)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_wsr_status_requested_at
+  ON worker_spawn_requests (status, requested_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wsr_requested_by_session_id
+  ON worker_spawn_requests (requested_by_session_id);
+
+-- RLS: enable defense-in-depth; service_role has full access (matches operational pattern).
+ALTER TABLE worker_spawn_requests ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'worker_spawn_requests' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY service_role_all ON worker_spawn_requests
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;

--- a/docs/protocol/coordinator-worker-revival.md
+++ b/docs/protocol/coordinator-worker-revival.md
@@ -1,0 +1,157 @@
+---
+category: protocol
+status: active
+version: 1.0
+author: SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
+last_updated: 2026-04-26
+tags: [fleet, coordinator, worker-revival, session-lifecycle, spawn-execution]
+---
+
+# Coordinator-Side Worker Revival Contract
+
+**SD**: `SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001`
+**Module**: `worker_spawn_requests` table + `coordination_message_type` enum (`SPAWN_REQUEST` value)
+**Enforcement points**: `scripts/coordinator-revive.cjs` (writer), `scripts/fleet-dashboard.cjs` (reader, dashboard surface), external spawn-execution layer (consumer — out of scope)
+
+This contract enables the coordinator to file revival requests for worker callsigns without an active session, replacing the manual restart-of-N-CC-instances toil between SD completions. The contract is **request-only**: this SD ships the writer, the dashboard, the schema, and the bus message. The spawn-execution layer that actually starts new Claude Code instances is **out of scope** — it is documented (see "Spawn-Execution Options" below) but not wired.
+
+## Purpose
+
+When all worker sessions exit (after their first SD or post-completion), the coordinator has no DB-side signal mechanism to spawn fresh workers. `session_coordination` only fires when worker sessions are RUNNING and check their inbox. With 0 active workers, the queue stalls until a human re-invokes Claude Code instances. This contract turns that stall into a one-line operator action: `/coordinator revive-all`.
+
+## Schema
+
+`worker_spawn_requests` — see `database/migrations/20260426_worker_spawn_requests.sql` for the canonical definition.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | gen_random_uuid() default |
+| `requested_by_session_id` | TEXT (FK→claude_sessions, ON DELETE SET NULL) | Coordinator that filed the request; NULL after audit rotation |
+| `requested_callsign` | TEXT NOT NULL | Subset of NATO roster: Alpha, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel |
+| `status` | TEXT (CHECK: pending\|fulfilled\|expired\|cancelled) | Default 'pending' |
+| `requested_at` | TIMESTAMPTZ NOT NULL | Default NOW() |
+| `fulfilled_by_session_id` | TEXT (FK→claude_sessions, ON DELETE SET NULL) | Worker that picked up the request |
+| `fulfilled_at` | TIMESTAMPTZ | Set by the spawn-execution layer when consumed |
+| `expires_at` | TIMESTAMPTZ NOT NULL | Default NOW() + INTERVAL '1 hour' |
+| `payload` | JSONB | Future expansion |
+
+**Indexes**:
+- `idx_wsr_unique_pending_callsign` — partial UNIQUE on `(requested_callsign)` WHERE `status='pending'` (idempotency)
+- `idx_wsr_status_requested_at` — for dashboard reads
+- `idx_wsr_requested_by_session_id` — for audit queries
+
+**RLS**: enabled; `service_role` policy `service_role_all` permits full access. Application paths (this script + fleet-dashboard.cjs) run via service-role.
+
+## Lifecycle
+
+```
+                      ┌────────────┐
+                      │  pending   │ ← INSERT by /coordinator revive
+                      └─────┬──────┘
+            ┌───────────────┼───────────────┐
+            ▼               ▼               ▼
+       ┌─────────┐    ┌──────────┐    ┌────────────┐
+       │fulfilled│    │ expired  │    │ cancelled  │
+       └─────────┘    └──────────┘    └────────────┘
+       ↑              ↑               ↑
+       │              │               │
+       │              expires_at      coordinator
+       │              < NOW()         override
+       │              (consumer       (cancel-revive,
+       │              filters)        future)
+       │
+       spawn-execution layer
+       starts a CC instance,
+       UPDATEs status + fulfilled_*
+```
+
+**No DB-side sweeper** — consumers filter `status='pending' AND expires_at > NOW()`. Expired rows are evidence-of-no-consumer, not garbage.
+
+## Idempotency
+
+The partial unique index enforces: **at most one pending row per callsign at any time**. Repeated `/coordinator revive Bravo` calls within an expiry window are no-ops at the DB layer (unique-violation surfaced as "already pending" by the writer script). This is the canonical mechanism — clients should NOT pre-check `SELECT WHERE callsign='X' AND status='pending'` before insert; rely on the constraint.
+
+## Consumer Responsibilities
+
+A spawn-execution layer that consumes this contract MUST:
+
+1. **Filter** by `status='pending' AND expires_at > NOW()` — never act on expired rows.
+2. **Atomically claim** before spawning: `UPDATE worker_spawn_requests SET status='fulfilled', fulfilled_by_session_id=$1, fulfilled_at=NOW() WHERE id=$2 AND status='pending' RETURNING id`. If the UPDATE returns 0 rows, another consumer claimed it — do not spawn.
+3. **Honor expiry** — if a consumer is slow, the row may have expired. Re-check `expires_at` after claim, before spawn.
+4. **Spawn ONE CC instance per claimed row** — multiple instances per row breaks the idempotency contract.
+5. **Subscribe (optional) to `SPAWN_REQUEST` broadcasts** — if the consumer needs real-time notification rather than polling. Broadcasts are best-effort; the canonical contract is the table.
+
+## Spawn-Execution Options
+
+This SD does not pick a spawn-execution layer. Trade-offs for future implementers:
+
+| Layer | Pros | Cons | When to use |
+|---|---|---|---|
+| **External watchdog daemon** | Simple, pollable, runs anywhere | Need to ship + monitor a separate process; cold-start delay | Dev workstation with a long-running shell; teams that already have a watchdog framework |
+| **Desktop notification** | No infra required; human-in-the-loop preserves judgment | Needs OS-specific integration (macOS/Windows/Linux differ); not unattended | One-operator workflows where step-away is short |
+| **OS-level supervisor** (systemd, launchd, Task Scheduler) | Survives reboots; native to the OS; well-supported | OS-specific config; harder to test; security review needed for invoking CC binary | Production-grade fleet on a dedicated host |
+| **GitHub Actions cron** | No local infra; auditable in CI; integrates with existing GH-Actions toolchain | Spin-up cost (CI minutes); not real-time (5+ min minimum cadence); requires repo write access | Cloud-first teams; already-paying for GHA minutes |
+
+**Default recommendation**: external watchdog for dev, OS-level supervisor for prod. Document the choice in the consumer's own SD when wiring it.
+
+## Operator UX
+
+```
+/coordinator revive Bravo
+  ✓ Revival requested for Bravo
+    row_id: <uuid>
+    expires_at: 2026-04-26T19:25:00Z
+    broadcast: SPAWN_REQUEST emitted on session_coordination
+
+/coordinator revive Bravo  (run again within expiry window)
+  ↺ Bravo: already has a pending revival request.
+    No new row inserted (idempotency rule: one pending per callsign).
+
+/coordinator revive-all
+  ✓ Charlie: revival requested (row <uuid>)
+  ↺ Delta: already pending (idempotency hit, no new row)
+  ✓ Echo: revival requested (row <uuid>)
+
+  revive-all: 2 inserted, 1 skipped (already pending), 0 failed
+```
+
+The `revival_pending` section of `fleet-dashboard.cjs` displays open requests with age + expires-in. It is hidden when zero rows are pending.
+
+## Cross-References
+
+- [Pre-Claim Cadence Gate](./cadence-gate.md) — sibling protocol contract, similar shape
+- [Fleet Coordination Reference](../reference/fleet-coordination.md) — overall fleet model
+- [Worker Registry Guide](../reference/worker-registry-guide.md) — callsign roster + identity assignment
+- [Claude Code Session Continuation](../reference/claude-code-session-continuation.md) — session_id stability rules
+
+## Reference
+
+- Schema migration: `database/migrations/20260426_worker_spawn_requests.sql`
+- Enum migration: `database/migrations/20260426_add_spawn_request_enum.sql`
+- Writer script: `scripts/coordinator-revive.cjs`
+- Slash command: `.claude/commands/coordinator.md` — `/coordinator revive [callsign]` and `/coordinator revive-all`
+- Dashboard reader: `scripts/fleet-dashboard.cjs` — `printRevivalPending(d)` section
+
+## Governance Audit Queries
+
+```sql
+-- All revival requests filed in last 7 days
+SELECT requested_at, requested_callsign, status, fulfilled_at - requested_at AS time_to_fulfill
+FROM worker_spawn_requests
+WHERE requested_at > NOW() - INTERVAL '7 days'
+ORDER BY requested_at DESC;
+
+-- Expired-without-fulfillment rate (signal: consumer wiring broken)
+SELECT
+  COUNT(*) FILTER (WHERE status='expired') AS expired,
+  COUNT(*) FILTER (WHERE status='fulfilled') AS fulfilled,
+  COUNT(*) AS total
+FROM worker_spawn_requests
+WHERE requested_at > NOW() - INTERVAL '30 days';
+
+-- Pending requests right now (operator dashboard equivalent)
+SELECT requested_callsign, NOW() - requested_at AS age, expires_at - NOW() AS expires_in
+FROM worker_spawn_requests
+WHERE status='pending' AND expires_at > NOW()
+ORDER BY requested_at ASC;
+```

--- a/scripts/coordinator-revive.cjs
+++ b/scripts/coordinator-revive.cjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * /coordinator revive [callsign]   — request revival for a single callsign
+ * /coordinator revive-all          — request revival for every callsign without an active session
+ *
+ * SD: SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001 (FR-3, US-002)
+ *
+ * INSERTs into worker_spawn_requests + emits SPAWN_REQUEST broadcast on session_coordination.
+ * Idempotency: at most one pending row per callsign at any time (DB partial unique index).
+ * On duplicate revive, reports "already pending" gracefully — does NOT raise raw SQL error.
+ *
+ * Usage:
+ *   node scripts/coordinator-revive.cjs <callsign>      # e.g. 'Bravo'
+ *   node scripts/coordinator-revive.cjs all
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  return createClient(url, key);
+}
+
+/**
+ * Identify callsigns that currently have NO active session (heartbeat < 5 min).
+ * @returns {Promise<string[]>} Sorted list of idle callsigns (subset of NATO).
+ */
+async function findIdleCallsigns(supabase) {
+  const { data: sessions, error } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, metadata, computed_status, heartbeat_age_seconds');
+  if (error) throw new Error(`v_active_sessions query failed: ${error.message}`);
+
+  const activeCallsigns = new Set();
+  for (const s of sessions || []) {
+    const cs = s.metadata?.fleet_identity?.callsign;
+    if (cs && s.computed_status === 'active') activeCallsigns.add(cs);
+  }
+  return NATO.filter(cs => !activeCallsigns.has(cs));
+}
+
+/**
+ * INSERT a single revival request. Returns { inserted, alreadyPending, error }.
+ */
+async function reviveOne(supabase, callsign, requestedBySessionId) {
+  const { data, error } = await supabase
+    .from('worker_spawn_requests')
+    .insert({
+      requested_by_session_id: requestedBySessionId,
+      requested_callsign: callsign,
+      status: 'pending'
+    })
+    .select('id, requested_at, expires_at')
+    .single();
+
+  if (error) {
+    // Postgres unique-violation error code is 23505. PostgREST surfaces it via .code or message.
+    const isUnique = error.code === '23505' || /unique|duplicate/i.test(error.message || '');
+    if (isUnique) return { inserted: false, alreadyPending: true, error: null };
+    return { inserted: false, alreadyPending: false, error };
+  }
+
+  // Broadcast SPAWN_REQUEST on session_coordination (best-effort — broadcast failure
+  // does NOT undo the row insert; the row is the canonical contract surface).
+  await supabase.from('session_coordination').insert({
+    target_session: 'broadcast',
+    message_type: 'SPAWN_REQUEST',
+    subject: `Spawn request: ${callsign}`,
+    body: `Coordinator requests revival of callsign ${callsign}. Spawn-execution layer (external watchdog/notification/cron) should consume worker_spawn_requests row id=${data.id}.`,
+    payload: { callsign, request_id: data.id, expires_at: data.expires_at }
+  }).then(({ error: bcErr }) => {
+    if (bcErr) console.warn(`  [warn] broadcast emit failed: ${bcErr.message} (row still inserted)`);
+  });
+
+  return { inserted: true, alreadyPending: false, error: null, row: data };
+}
+
+async function main() {
+  const arg = (process.argv[2] || '').trim();
+  if (!arg) {
+    console.error('Usage: coordinator-revive.cjs <callsign|all>');
+    process.exit(1);
+  }
+
+  const supabase = getSupabase();
+  const requestedBySessionId = process.env.CLAUDE_SESSION_ID || null;
+  if (!requestedBySessionId) {
+    console.warn('  [warn] CLAUDE_SESSION_ID not set — requested_by_session_id will be NULL');
+  }
+
+  if (arg.toLowerCase() === 'all') {
+    const idle = await findIdleCallsigns(supabase);
+    if (idle.length === 0) {
+      console.log('All known callsigns have active sessions — nothing to revive.');
+      return;
+    }
+    let inserted = 0, skipped = 0, failed = 0;
+    for (const cs of idle) {
+      const r = await reviveOne(supabase, cs, requestedBySessionId);
+      if (r.inserted) {
+        inserted++;
+        console.log(`  ✓ ${cs}: revival requested (row ${r.row.id})`);
+      } else if (r.alreadyPending) {
+        skipped++;
+        console.log(`  ↺ ${cs}: already pending (idempotency hit, no new row)`);
+      } else {
+        failed++;
+        console.log(`  ✗ ${cs}: ${r.error?.message || 'unknown error'}`);
+      }
+    }
+    console.log(`\nrevive-all: ${inserted} inserted, ${skipped} skipped (already pending), ${failed} failed`);
+    if (failed > 0) process.exit(2);
+    return;
+  }
+
+  // Single-callsign mode
+  const callsign = NATO.find(n => n.toLowerCase() === arg.toLowerCase());
+  if (!callsign) {
+    console.error(`Unknown callsign: "${arg}". Valid: ${NATO.join(', ')}, or 'all'.`);
+    process.exit(1);
+  }
+
+  const r = await reviveOne(supabase, callsign, requestedBySessionId);
+  if (r.inserted) {
+    console.log(`✓ Revival requested for ${callsign}`);
+    console.log(`  row_id: ${r.row.id}`);
+    console.log(`  expires_at: ${r.row.expires_at}`);
+    console.log(`  broadcast: SPAWN_REQUEST emitted on session_coordination`);
+    console.log(`\nA spawn-execution layer (watchdog/notification/cron) should consume the row and start a fresh CC instance.`);
+    console.log(`See docs/protocol/coordinator-worker-revival.md for the contract.`);
+  } else if (r.alreadyPending) {
+    console.log(`↺ ${callsign}: already has a pending revival request.`);
+    console.log(`  No new row inserted (idempotency rule: one pending per callsign).`);
+    console.log(`  Run: SELECT id, requested_at, expires_at FROM worker_spawn_requests WHERE requested_callsign='${callsign}' AND status='pending';`);
+  } else {
+    console.error(`✗ Failed to insert revival request: ${r.error?.message || 'unknown error'}`);
+    process.exit(2);
+  }
+}
+
+// Export internal helpers for unit testing.
+module.exports = { NATO, findIdleCallsigns, reviveOne };
+
+// Only run main() when invoked as CLI (not when require'd by tests).
+if (require.main === module) {
+  main().catch(err => {
+    console.error('REVIVE ERROR:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -146,6 +146,21 @@ async function loadData() {
       .order('agent_slot', { ascending: true })
   ]);
 
+  // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001: pending worker_spawn_requests
+  // Separate query (added after main Promise.all) — graceful degradation if table doesn't exist.
+  let revivalPending = [];
+  try {
+    const { data: rpData } = await supabase
+      .from('worker_spawn_requests')
+      .select('id, requested_callsign, requested_by_session_id, requested_at, expires_at')
+      .eq('status', 'pending')
+      .gt('expires_at', new Date().toISOString())
+      .order('requested_at', { ascending: true });
+    revivalPending = rpData || [];
+  } catch (e) {
+    // Pre-migration clones don't have the table — silently empty.
+  }
+
   const sessions = sessRes.data || [];
   const allSessions = allSessRes.data || [];
   const drainAgents = drainRes.data || [];
@@ -270,7 +285,8 @@ async function loadData() {
     unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells,
     drainAgents,
     mc, mcByWorker,
-    executeTeams
+    executeTeams,
+    revivalPending // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
   };
 }
 
@@ -474,6 +490,34 @@ function printAvailable(d) {
     }
   }
 
+  console.log('');
+}
+
+// ── Section: Revival Pending (SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001) ──
+function printRevivalPending(d) {
+  const rows = d.revivalPending || [];
+  if (rows.length === 0) return; // zero-noise default
+
+  console.log('REVIVAL PENDING (' + rows.length + ')');
+  console.log('─'.repeat(72));
+  console.log('  ' + pad('Callsign', 12) + pad('Requested by', 24) + pad('Age', 12) + 'Expires in');
+  console.log('  ' + '─'.repeat(68));
+
+  const now = Date.now();
+  function fmtAge(ms) {
+    const s = Math.max(0, Math.round(ms / 1000));
+    if (s < 60) return s + 's';
+    const m = Math.round(s / 60);
+    if (m < 60) return m + 'm';
+    return Math.round(m / 60) + 'h';
+  }
+
+  for (const r of rows) {
+    const age = fmtAge(now - Date.parse(r.requested_at));
+    const expIn = fmtAge(Date.parse(r.expires_at) - now);
+    const reqBy = (r.requested_by_session_id || 'unknown').substring(0, 22);
+    console.log('  ' + pad(r.requested_callsign, 12) + pad(reqBy, 24) + pad(age, 12) + expIn);
+  }
   console.log('');
 }
 
@@ -976,6 +1020,7 @@ async function main() {
     workers:       () => printWorkers(d),
     orchestrator:  () => printOrchestrator(d),
     available:     () => printAvailable(d),
+    revival:       () => printRevivalPending(d),
     coordination:  () => printCoordination(d),
     coaching:      async () => await printCoaching(d),
     health:        () => printHealth(d),
@@ -991,6 +1036,7 @@ async function main() {
       printDrainAgents(d);
       printOrchestrator(d);
       printAvailable(d);
+      printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printCoaching(d);
       printHealth(d);

--- a/tests/unit/coordinator-revive.test.js
+++ b/tests/unit/coordinator-revive.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for scripts/coordinator-revive.cjs
+ * SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001 (US-002)
+ *
+ * Covers: NATO roster, findIdleCallsigns, reviveOne (insert / idempotency / unknown errors).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { NATO, findIdleCallsigns, reviveOne } = require('../../scripts/coordinator-revive.cjs');
+
+describe('NATO roster', () => {
+  it('contains the canonical 8 callsigns in order', () => {
+    expect(NATO).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel']);
+  });
+});
+
+function mockSupabase({ activeSessions = [], insertResult = null, insertError = null }) {
+  return {
+    from: (table) => {
+      if (table === 'v_active_sessions') {
+        return {
+          select: () => Promise.resolve({ data: activeSessions, error: null })
+        };
+      }
+      if (table === 'worker_spawn_requests') {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: () => Promise.resolve({ data: insertResult, error: insertError })
+            })
+          })
+        };
+      }
+      if (table === 'session_coordination') {
+        // Best-effort broadcast — return promise-shaped no-op
+        return {
+          insert: () => ({
+            then: (cb) => Promise.resolve({ error: null }).then(cb)
+          })
+        };
+      }
+      return null;
+    }
+  };
+}
+
+describe('findIdleCallsigns()', () => {
+  it('returns the full NATO roster when no sessions exist', async () => {
+    const supabase = mockSupabase({ activeSessions: [] });
+    const idle = await findIdleCallsigns(supabase);
+    expect(idle).toEqual(NATO);
+  });
+
+  it('excludes callsigns of active sessions', async () => {
+    const supabase = mockSupabase({
+      activeSessions: [
+        { session_id: 'a', metadata: { fleet_identity: { callsign: 'Alpha' } }, computed_status: 'active' },
+        { session_id: 'b', metadata: { fleet_identity: { callsign: 'Bravo' } }, computed_status: 'active' }
+      ]
+    });
+    const idle = await findIdleCallsigns(supabase);
+    expect(idle).not.toContain('Alpha');
+    expect(idle).not.toContain('Bravo');
+    expect(idle).toContain('Charlie');
+    expect(idle.length).toBe(NATO.length - 2);
+  });
+
+  it('treats stale/idle sessions (computed_status !== "active") as freeing the callsign', async () => {
+    const supabase = mockSupabase({
+      activeSessions: [
+        { session_id: 'a', metadata: { fleet_identity: { callsign: 'Alpha' } }, computed_status: 'stale' },
+        { session_id: 'c', metadata: { fleet_identity: { callsign: 'Charlie' } }, computed_status: 'idle' }
+      ]
+    });
+    const idle = await findIdleCallsigns(supabase);
+    expect(idle).toContain('Alpha');
+    expect(idle).toContain('Charlie');
+    expect(idle.length).toBe(NATO.length);
+  });
+
+  it('ignores sessions without a fleet_identity.callsign', async () => {
+    const supabase = mockSupabase({
+      activeSessions: [
+        { session_id: 'a', metadata: {}, computed_status: 'active' },
+        { session_id: 'b', metadata: { fleet_identity: {} }, computed_status: 'active' }
+      ]
+    });
+    const idle = await findIdleCallsigns(supabase);
+    expect(idle).toEqual(NATO);
+  });
+});
+
+describe('reviveOne()', () => {
+  it('returns inserted=true on successful insert', async () => {
+    const row = { id: 'abc-123', requested_at: '2026-04-26T18:00:00Z', expires_at: '2026-04-26T19:00:00Z' };
+    const supabase = mockSupabase({ insertResult: row, insertError: null });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.inserted).toBe(true);
+    expect(r.alreadyPending).toBe(false);
+    expect(r.error).toBe(null);
+    expect(r.row).toEqual(row);
+  });
+
+  it('catches Postgres unique violation (code 23505) and reports alreadyPending', async () => {
+    const supabase = mockSupabase({
+      insertResult: null,
+      insertError: { code: '23505', message: 'duplicate key value violates unique constraint' }
+    });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.inserted).toBe(false);
+    expect(r.alreadyPending).toBe(true);
+    expect(r.error).toBe(null);
+  });
+
+  it('catches unique violation by message keyword (no code) and reports alreadyPending', async () => {
+    const supabase = mockSupabase({
+      insertResult: null,
+      insertError: { message: 'duplicate row' }
+    });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.alreadyPending).toBe(true);
+  });
+
+  it('does NOT catch non-unique errors — surfaces them as error', async () => {
+    const supabase = mockSupabase({
+      insertResult: null,
+      insertError: { code: '42501', message: 'permission denied' }
+    });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.inserted).toBe(false);
+    expect(r.alreadyPending).toBe(false);
+    expect(r.error).toEqual({ code: '42501', message: 'permission denied' });
+  });
+
+  it('handles null requestedBySessionId (CLAUDE_SESSION_ID not set)', async () => {
+    const row = { id: 'abc', requested_at: 't', expires_at: 't+1h' };
+    const supabase = mockSupabase({ insertResult: row, insertError: null });
+    const r = await reviveOne(supabase, 'Charlie', null);
+    expect(r.inserted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds DB-queryable revival contract so /coordinator can request worker resumption without manual CC re-launch. Eliminates the 4-restarts-between-SDs toil witnessed at parallel-fleet-run-2026-04-26.

**5 deliverables:**
- `worker_spawn_requests` table (TEXT FKs matching `claude_sessions.session_id`; partial unique index enforces one-pending-per-callsign idempotency; RLS service_role)
- `coordination_message_type` enum gains `SPAWN_REQUEST` (additive, idempotent ALTER TYPE ADD VALUE IF NOT EXISTS)
- `/coordinator revive [callsign]` + `/coordinator revive-all` subcommands via 4-site lockstep edit to `.claude/commands/coordinator.md` (per DOCMON sub-agent guidance)
- `scripts/coordinator-revive.cjs` writer (graceful unique-violation handling as "already pending"; broadcasts SPAWN_REQUEST best-effort)
- `fleet-dashboard.cjs` `revival_pending` section (zero-noise default; shows age + expires-in)
- `docs/protocol/coordinator-worker-revival.md` contract doc (YAML frontmatter + cadence-gate-style prologue + 7 sections + spawn-execution layer trade-off table)

## Scope discipline

LEAD scope amendment dropped 2 of 4 originally proposed key_changes (30% reduction):
- Chose dedicated table over claude_sessions column (validation-agent rationale)
- Deferred fleet-eta-stats revivals-needed metric to follow-up SD

## Out of scope

Spawn-execution layer (external watchdog / desktop notification / OS-supervisor / GitHub Actions cron) — documented in contract; consumer SD ships separately.

## Test plan

- [x] 10 vitest cases pass (`tests/unit/coordinator-revive.test.js`)
- [x] TESTING + REGRESSION sub-agents PASS in `sub_agent_execution_results`
- [x] DATABASE design review PASS with corrections incorporated (TEXT FKs, ALTER TYPE ADD VALUE, ON DELETE SET NULL, RLS)
- [x] DOCMON guidance followed (4-site lockstep, docs/protocol path, frontmatter + prologue dual-pattern)
- [ ] CI green on this branch

## PR size justification

591 LOC total (291 production / 157 docs / 143 tests). At-ceiling per CLAUDE.md tiered guidelines but **atomic-feature** — splitting would deploy table without slash-cmd surface, or slash-cmd without contract doc. Single-PR atomicity preferred over phase-ordered partial deployment.

## LEO metadata

- SD: `SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001`
- Type: infrastructure
- LEAD-TO-PLAN: PASS 96 → PLAN-TO-EXEC: PASS 95 → EXEC-TO-PLAN: PASS 91 → PLAN-TO-LEAD: PASS 97
- Sub-agents: VALIDATION (PASS), DATABASE (CONDITIONAL_PASS → corrections landed), DOCMON (PASS), TESTING (PASS), REGRESSION (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>