### PR TITLE
fix(QF-20260426-SWEEP-HARDCAP-PIDALIVE): SWEEP_HARD_CAP_20M respects pid_alive

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -425,6 +425,7 @@ async function main() {
       isStale: isStale && !hasPidAlive && !(sourceSide && sourceSide.alive),
       status,
       sourceSideReason: sourceSide?.reason || null,
+      hasPidAlive, // QF-20260426-SWEEP-HARDCAP-PIDALIVE: preserve for hard-cap guard
     };
   });
   if (collisions.length > 0) {
@@ -714,6 +715,17 @@ async function main() {
     let releaseReason = 'SWEEP_PID_DEAD';
     if (FLEET_MC_SWEEP_GATE) {
       if (hbSec >= FLEET_MC_HARD_CAP_SEC) {
+        // QF-20260426-SWEEP-HARDCAP-PIDALIVE: hard cap must respect pid_alive.
+        // Worker phase-boundary scripts (handoff.js validation-agent + Explore
+        // subagents during PLAN_PRD) routinely take 15-25 min. Heartbeat lag
+        // past 20m + live PID = legitimately busy, not stuck.
+        if (s.hasPidAlive) {
+          warnings.push(
+            'WIP_GUARD_HARDCAP_PID_ALIVE: ' + s.session_id +
+            ' hb=' + Math.round(hbSec) + 's >= 20m hard cap BUT pid_alive=true — HOLDING release (SD: ' + s.sd_key + ')'
+          );
+          continue;
+        }
         releaseReason = 'SWEEP_HARD_CAP_20M';
       } else {
         const mc = mcBySession.get(s.session_id);


### PR DESCRIPTION
## Summary

12-LOC defensive guard: `scripts/stale-session-sweep.cjs` SWEEP_HARD_CAP_20M now skips release when the worker's PID is verifiably alive. Phase-boundary scripts (handoff.js validation-agent + Explore subagents during PLAN_PRD) routinely take 15-25 min — heartbeat lag past 20m with live PID is busy, not stuck.

Witnessed 2026-04-26 with Alpha session held through 5+ sweep cycles before hard-capping at 31m despite live process.

## Changes

- Preserve `hasPidAlive` on classified-session objects (line 423-428)
- Hard-cap branch: hold release + emit `WIP_GUARD_HARDCAP_PID_ALIVE` warning when pid_alive=true (line 715-728)

## Test plan

- [x] Defensive change — never releases verifiably-alive workers
- [x] Existing tests (tests/unit/fleet-liveness-sweep-gate.test.js) unaffected — change is additive
- [ ] Manual smoke: run sweep against a 31m+ stale session with live PID; expect WIP_GUARD_HARDCAP_PID_ALIVE warning, no release

## Tier

T1 (≤30 LOC, ≤50 LOC complete-quick-fix.js cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>