### PR TITLE
fix(QF-20260426-SWEEP-PHANTOM-DETECT): detect + reset phantom in_progress SDs

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -607,6 +607,34 @@ async function main() {
     }
   }
 
+  // QF-20260426-SWEEP-PHANTOM-DETECT: detect phantom in_progress SDs
+  // (status=in_progress + claiming_session_id IS NULL). These are invisible to
+  // sd:next's workable filter and silently park work until manual reset. Reset
+  // to draft/LEAD so the queue surfaces them for the next worker.
+  const { data: phantomInProgress } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, current_phase, progress_percentage')
+    .eq('status', 'in_progress')
+    .is('claiming_session_id', null);
+
+  for (const sd of (phantomInProgress || [])) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({
+        status: 'draft',
+        current_phase: 'LEAD',
+        progress_percentage: 0,
+        is_working_on: false
+      })
+      .eq('sd_key', sd.sd_key)
+      .eq('status', 'in_progress')
+      .is('claiming_session_id', null);
+
+    if (!error) {
+      actions.push('QA: reset phantom ' + sd.sd_key + ' from in_progress/' + sd.current_phase + '/' + sd.progress_percentage + '% → draft/LEAD/0% (no claiming session)');
+    }
+  }
+
   // 3e. QA — detect and auto-enrich bare-shell SDs (FIX #6)
   const { data: pendingSDs } = await supabase
     .from('strategic_directives_v2')


### PR DESCRIPTION
## Summary

28-LOC additive sweep stage: `scripts/stale-session-sweep.cjs` now detects SDs where `status='in_progress' AND claiming_session_id IS NULL` (phantom state) and resets them to `draft/LEAD/0%`. Without this, phantom SDs are invisible to `sd:next` and silently park work.

## Witnessed

2026-04-26 fleet run: SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001 and SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001 both stuck in this state — surfaced only via manual DB query.

## Pattern

Matches sibling QA blocks (section 3d "stuck pending_approval" reset; FIX #2 "clear stale claim on completed"). Defensive UPDATE guards on both `status='in_progress'` AND `claiming_session_id IS NULL` prevent racing a concurrent claim.

## Test plan

- [x] Additive only — no existing logic modified
- [x] Defensive UPDATE filter prevents stomping concurrent claims
- [ ] Manual smoke: insert phantom-state SD, run sweep, verify reset + log entry

## Tier

T1 (28 LOC, ≤30 budget per CLAUDE.md Work Item Routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>