### PR TITLE
feat(SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001): surface in-flight QFs in fleet roster

### DIFF
--- a/database/migrations/20260426_v_active_sessions_qf_claim_visibility.sql
+++ b/database/migrations/20260426_v_active_sessions_qf_claim_visibility.sql
@@ -1,0 +1,90 @@
+-- Migration: Extend v_active_sessions to surface QF-only session claims
+-- SD: SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001
+--
+-- Problem: Sessions whose only claim is a quick_fix (claiming_session_id set on
+-- the quick_fixes row, status in ['open','in_progress']) currently appear as
+-- 'idle' in v_active_sessions because the prior view only joined quick_fixes
+-- via cs.sd_key = qf.id — a path no claim mechanism actually populates.
+-- create-quick-fix.js writes claiming_session_id on the QF row, NOT cs.sd_key.
+--
+-- Fix: Add a LEFT JOIN on quick_fixes via claiming_session_id (the canonical
+-- relationship), expose qf_id and qf_title, and update computed_status so a
+-- session is 'idle' only when both sd_key AND qf_id are NULL.
+--
+-- Idempotent: DROP VIEW IF EXISTS + CREATE VIEW (transactional). CREATE OR
+-- REPLACE VIEW alone fails on column reorder in Postgres ("cannot change name
+-- of view column"). The new qf_id/qf_title/qf_status columns are inserted at
+-- positions 6-8 (next to sd_title) for readability, which forces a recreate.
+-- Wrapped in a single transaction so concurrent reads either see the old view
+-- or the new view, never an absent view.
+-- Backward-compatible: all pre-existing columns preserved (including the
+-- legacy COALESCE(sd.title, qf.title) sd_title and the cs.sd_key=qf.id JOIN).
+-- Rollback: replay the prior view definition from
+-- 20260406_v_active_sessions_stale_threshold_600s.sql.
+
+BEGIN;
+
+DROP VIEW IF EXISTS v_active_sessions CASCADE;
+
+CREATE VIEW v_active_sessions AS
+SELECT cs.id,
+    cs.session_id,
+    cs.sd_key AS sd_id,
+    cs.sd_key,
+    COALESCE(sd.title, qf.title::character varying) AS sd_title,
+    qf_active.id AS qf_id,
+    qf_active.title AS qf_title,
+    qf_active.status AS qf_status,
+    cs.track,
+    cs.tty,
+    cs.pid,
+    cs.hostname,
+    cs.codebase,
+    cs.current_branch,
+    cs.machine_id,
+    cs.terminal_id,
+    cs.terminal_identity,
+    cs.claimed_at,
+    cs.heartbeat_at,
+    cs.status,
+    cs.released_reason,
+    cs.released_at,
+    cs.stale_reason,
+    cs.stale_at,
+    cs.metadata,
+    cs.created_at,
+    EXTRACT(epoch FROM now() - cs.heartbeat_at) AS heartbeat_age_seconds,
+    EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0 AS heartbeat_age_minutes,
+    GREATEST(0::numeric, 600.0 - EXTRACT(epoch FROM now() - cs.heartbeat_at)) AS seconds_until_stale,
+        CASE
+            WHEN cs.status = 'released'::text THEN 'released'::text
+            WHEN cs.status = 'stale'::text THEN 'stale'::text
+            WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) > 600::numeric THEN 'stale'::text
+            WHEN cs.sd_key IS NULL AND qf_active.id IS NULL THEN 'idle'::text
+            ELSE 'active'::text
+        END AS computed_status,
+        CASE
+            WHEN cs.claimed_at IS NOT NULL THEN EXTRACT(epoch FROM now() - cs.claimed_at) / 60.0
+            ELSE NULL::numeric
+        END AS claim_duration_minutes,
+        CASE
+            WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 60::numeric THEN EXTRACT(epoch FROM now() - cs.heartbeat_at)::integer || 's ago'::text
+            WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 3600::numeric THEN (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0)::integer || 'm ago'::text
+            ELSE (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 3600.0)::integer || 'h ago'::text
+        END AS heartbeat_age_human,
+    cs.is_virtual,
+    cs.parent_session_id
+   FROM claude_sessions cs
+     LEFT JOIN strategic_directives_v2 sd ON cs.sd_key = sd.sd_key
+     LEFT JOIN quick_fixes qf ON cs.sd_key = qf.id
+     LEFT JOIN quick_fixes qf_active ON qf_active.claiming_session_id = cs.session_id
+       AND qf_active.status IN ('open', 'in_progress')
+  WHERE cs.status <> 'released'::text
+  ORDER BY cs.track, cs.claimed_at DESC;
+
+COMMENT ON VIEW v_active_sessions IS 'Active sessions view with 600s stale threshold. Surfaces both SD claims (cs.sd_key) and in-flight QF claims (quick_fixes.claiming_session_id) — sessions are idle only when neither is set.';
+
+COMMIT;
+
+-- Reload PostgREST schema cache so the new columns are immediately visible
+NOTIFY pgrst, 'reload schema';

--- a/scripts/modules/sd-next/display/claim-formatters.js
+++ b/scripts/modules/sd-next/display/claim-formatters.js
@@ -1,0 +1,52 @@
+/**
+ * Claim formatters for fleet roster display
+ * SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001
+ *
+ * Both the ACTIVE SESSIONS table (sd-next) and the Fleet Roster (sd-start.js
+ * claim-conflict path) read v_active_sessions and need to display:
+ * - SD-only claims    → sd_key/sd_title set, qf_id null
+ * - QF-only claims    → qf_id/qf_title set (via quick_fixes.claiming_session_id), sd_key null
+ * - Idle              → both null
+ * - Defensive both    → render both rather than silently de-duplicating
+ *
+ * Two formatters are exposed because the two call sites have different cell
+ * shapes (table column vs. roster line). They share the same dispatch logic.
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Format the "Claimed Work" cell for a tabular ACTIVE SESSIONS row.
+ * Plain string, no colors — caller pads + colors as needed.
+ *
+ * @param {Object} s - Session row from v_active_sessions (sd_id, qf_id, etc.)
+ * @returns {string} Cell content (unpadded, no ANSI escapes).
+ */
+export function formatClaimedWork(s) {
+  if (s.sd_id && s.qf_id) {
+    return `${s.sd_id} +${s.qf_id}`;
+  }
+  if (s.sd_id) return s.sd_id;
+  if (s.qf_id) return `[QF] ${s.qf_id}`;
+  return 'None';
+}
+
+/**
+ * Format the claim segment for a Fleet Roster line (sd-start.js).
+ * Returns a colored string ready for direct console.log.
+ *
+ * @param {Object} s - Session row from v_active_sessions
+ * @returns {string} Display string with colors applied.
+ */
+export function formatRosterClaim(s) {
+  if (s.sd_key && s.qf_id) {
+    return `→ ${s.sd_title || s.sd_key} ${colors.dim}+${colors.reset}${colors.cyan}[QF] ${s.qf_title || s.qf_id}${colors.reset}`;
+  }
+  if (s.sd_key) {
+    return `→ ${s.sd_title || s.sd_key}`;
+  }
+  if (s.qf_id) {
+    return `${colors.cyan}→ [QF] ${s.qf_title || s.qf_id}${colors.reset}`;
+  }
+  return `${colors.dim}(idle)${colors.reset}`;
+}

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -8,6 +8,7 @@ import { isActionableForLead } from '../status-helpers.js';
 import { checkDependenciesResolved, checkMetadataDependency, resolveMetadataBlocker } from '../dependency-resolver.js';
 import { getEstimatedDuration, formatEstimateShort } from '../../../lib/duration-estimator.js';
 import { analyzeClaimRelationship, hasActiveWorkEvidence } from '../claim-analysis.js';
+import { formatClaimedWork } from './claim-formatters.js';
 
 /**
  * Display recommendations section and return structured action data.
@@ -480,14 +481,14 @@ function displayBeginWorkInstructions() {
 export function displayActiveSessions(activeSessions, currentSession) {
   if (activeSessions.length === 0) return;
 
-  const sessionsWithClaims = activeSessions.filter(s => s.sd_id);
-  const idleSessions = activeSessions.filter(s => !s.sd_id);
+  const sessionsWithClaims = activeSessions.filter(s => s.sd_id || s.qf_id);
+  const idleSessions = activeSessions.filter(s => !s.sd_id && !s.qf_id);
 
   if (sessionsWithClaims.length > 0) {
     console.log(`${colors.bold}ACTIVE SESSIONS (${sessionsWithClaims.length}):${colors.reset}\n`);
 
     // Header row
-    console.log(`${colors.dim}   Session           │ Claimed SD                │ Track │ Duration │ Heartbeat${colors.reset}`);
+    console.log(`${colors.dim}   Session           │ Claimed Work              │ Track │ Duration │ Heartbeat${colors.reset}`);
     console.log(`${colors.dim}${'─'.repeat(100)}${colors.reset}`);
 
     for (const s of sessionsWithClaims) {
@@ -508,11 +509,11 @@ export function displayActiveSessions(activeSessions, currentSession) {
         heartbeatColor = colors.yellow;
       }
 
-      const sdDisplay = (s.sd_id || 'None').padEnd(25);
+      const claimDisplay = formatClaimedWork(s).padEnd(25);
       const trackDisplay = (s.track || 'N/A').padEnd(5);
       const durationDisplay = `${ageMin}m`.padEnd(8);
 
-      console.log(`${marker} ${shortId} │ ${colors.bold}${sdDisplay}${colors.reset} │ ${trackDisplay} │ ${durationDisplay} │ ${heartbeatColor}${heartbeatAge}${colors.reset}`);
+      console.log(`${marker} ${shortId} │ ${colors.bold}${claimDisplay}${colors.reset} │ ${trackDisplay} │ ${durationDisplay} │ ${heartbeatColor}${heartbeatAge}${colors.reset}`);
 
       // Show hostname/codebase for non-current sessions (helps identify which terminal)
       if (!isCurrent && (s.hostname || s.codebase)) {
@@ -524,7 +525,7 @@ export function displayActiveSessions(activeSessions, currentSession) {
   }
 
   if (idleSessions.length > 0) {
-    console.log(`${colors.dim}(${idleSessions.length} idle session(s) - no SD claimed)${colors.reset}\n`);
+    console.log(`${colors.dim}(${idleSessions.length} idle session(s) - no SD or QF claimed)${colors.reset}\n`);
   }
 }
 

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -36,6 +36,10 @@ import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
 import { getEstimatedDuration, formatEstimateDetailed } from './lib/duration-estimator.js';
 import { resolve as resolveWorkdir } from './resolve-sd-workdir.js';
+// SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001: shared formatter so the roster
+// also surfaces in-flight QF claims (quick_fixes.claiming_session_id), not just
+// SD claims.
+import { formatRosterClaim } from './modules/sd-next/display/claim-formatters.js';
 // SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001 (FR-008 / D2): consume the extended
 // classification policy so 'outside_repo' / 'false_success' /
 // 'target_changed_after_claim' hints surface with stable codes. The base
@@ -68,7 +72,7 @@ async function displayFleetRoster() {
   try {
     const { data: sessions } = await supabase
       .from('v_active_sessions')
-      .select('session_id, sd_key, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, pid')
+      .select('session_id, sd_key, sd_title, qf_id, qf_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, pid')
       .in('computed_status', ['active', 'idle', 'stale']);
 
     if (!sessions || sessions.length === 0) {
@@ -81,10 +85,8 @@ async function displayFleetRoster() {
       const shortId = s.session_id.substring(0, 12);
       const hbAge = s.heartbeat_age_human || formatHbAge(s.heartbeat_age_seconds);
       const staleTag = (s.heartbeat_age_seconds || 0) > 900 ? ` ${colors.red}STALE${colors.reset}` : '';
-      const sdLabel = s.sd_key
-        ? `→ ${s.sd_title || s.sd_key}`
-        : `${colors.dim}(idle)${colors.reset}`;
-      console.log(`   ${shortId}  ${hbAge}${staleTag}  ${sdLabel}`);
+      const claimLabel = formatRosterClaim(s);
+      console.log(`   ${shortId}  ${hbAge}${staleTag}  ${claimLabel}`);
     }
   } catch {
     // Non-blocking — roster display is informational

--- a/tests/unit/sd-next/claim-formatters.test.js
+++ b/tests/unit/sd-next/claim-formatters.test.js
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001
+ * Covers formatClaimedWork + formatRosterClaim in scripts/modules/sd-next/display/claim-formatters.js
+ *
+ * Scenarios per PRD:
+ *   - SD-only session  (sd_id/sd_key set, qf_id null)
+ *   - QF-only session  (qf_id set via quick_fixes.claiming_session_id, sd_id/sd_key null)
+ *   - Mixed roster     (multiple sessions across SDs and QFs in one render pass)
+ *   - Idle session     (both null → fallback)
+ *   - Dual claim       (defensive: both set → render both, no de-dup)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatClaimedWork,
+  formatRosterClaim,
+} from '../../../scripts/modules/sd-next/display/claim-formatters.js';
+
+// ANSI escape stripper for color-agnostic assertions
+function stripAnsi(s) {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+describe('formatClaimedWork — ACTIVE SESSIONS table cell', () => {
+  it('SD-only session renders the SD id', () => {
+    const s = { sd_id: 'SD-FOO-001', qf_id: null };
+    expect(formatClaimedWork(s)).toBe('SD-FOO-001');
+  });
+
+  it('QF-only session renders [QF] prefix and QF id', () => {
+    const s = { sd_id: null, qf_id: 'QF-20260424-805' };
+    expect(formatClaimedWork(s)).toBe('[QF] QF-20260424-805');
+  });
+
+  it('Idle session (both null) renders "None"', () => {
+    const s = { sd_id: null, qf_id: null };
+    expect(formatClaimedWork(s)).toBe('None');
+  });
+
+  it('Dual-claim defensive case renders both, no de-dup', () => {
+    const s = { sd_id: 'SD-FOO-001', qf_id: 'QF-20260424-805' };
+    const out = formatClaimedWork(s);
+    expect(out).toContain('SD-FOO-001');
+    expect(out).toContain('QF-20260424-805');
+    expect(out).toContain('+');
+  });
+
+  it('Mixed roster: each row formatted independently', () => {
+    const sessions = [
+      { sd_id: 'SD-FOO-001', qf_id: null },
+      { sd_id: null, qf_id: 'QF-20260424-805' },
+      { sd_id: null, qf_id: null },
+    ];
+    const rendered = sessions.map(formatClaimedWork);
+    expect(rendered).toEqual(['SD-FOO-001', '[QF] QF-20260424-805', 'None']);
+  });
+});
+
+describe('formatRosterClaim — Fleet Roster line segment', () => {
+  it('SD-only session renders "→ <sd_title>" preferring title', () => {
+    const s = { sd_key: 'SD-FOO-001', sd_title: 'Foo Feature', qf_id: null };
+    expect(stripAnsi(formatRosterClaim(s))).toBe('→ Foo Feature');
+  });
+
+  it('SD-only session falls back to sd_key when title missing', () => {
+    const s = { sd_key: 'SD-FOO-001', sd_title: null, qf_id: null };
+    expect(stripAnsi(formatRosterClaim(s))).toBe('→ SD-FOO-001');
+  });
+
+  it('QF-only session renders "→ [QF] <qf_title>"', () => {
+    const s = { sd_key: null, qf_id: 'QF-20260424-805', qf_title: 'Fix nav crash' };
+    expect(stripAnsi(formatRosterClaim(s))).toBe('→ [QF] Fix nav crash');
+  });
+
+  it('QF-only session falls back to qf_id when title missing', () => {
+    const s = { sd_key: null, qf_id: 'QF-20260424-805', qf_title: null };
+    expect(stripAnsi(formatRosterClaim(s))).toBe('→ [QF] QF-20260424-805');
+  });
+
+  it('Idle session renders "(idle)" fallback', () => {
+    const s = { sd_key: null, qf_id: null };
+    expect(stripAnsi(formatRosterClaim(s))).toBe('(idle)');
+  });
+
+  it('Dual-claim defensive case renders SD title and [QF] segment, separated by "+"', () => {
+    const s = {
+      sd_key: 'SD-FOO-001',
+      sd_title: 'Foo Feature',
+      qf_id: 'QF-20260424-805',
+      qf_title: 'Fix nav crash',
+    };
+    const plain = stripAnsi(formatRosterClaim(s));
+    expect(plain).toContain('Foo Feature');
+    expect(plain).toContain('[QF] Fix nav crash');
+    expect(plain).toContain('+');
+  });
+
+  it('Color codes applied to QF segment (smoke check)', () => {
+    const s = { sd_key: null, qf_id: 'QF-1', qf_title: 't' };
+    const colored = formatRosterClaim(s);
+    // ANSI present (cyan + reset)
+    expect(colored).not.toBe(stripAnsi(colored));
+  });
+
+  it('Mixed roster: each row dispatches to the correct branch', () => {
+    const sessions = [
+      { sd_key: 'SD-FOO-001', sd_title: 'Foo', qf_id: null },
+      { sd_key: null, qf_id: 'QF-1', qf_title: 'Bar' },
+      { sd_key: null, qf_id: null },
+    ];
+    const plain = sessions.map(formatRosterClaim).map(stripAnsi);
+    expect(plain).toEqual(['→ Foo', '→ [QF] Bar', '(idle)']);
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `v_active_sessions` view to LEFT JOIN `quick_fixes` on `claiming_session_id` (the canonical relationship), exposing `qf_id`, `qf_title`, `qf_status` columns
- Update `displayActiveSessions()` (sd-next) and `displayFleetRoster()` (sd-start.js) to surface QF-only sessions instead of classifying them as idle — closes the coordination blind spot for 3+ parallel Claude Code sessions
- Add 13 vitest cases covering all 5 PRD scenarios (SD-only, QF-only, mixed, idle-only, dual-claim defensive)

## Context
SD: SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001
LEAD-TO-PLAN: 96% | PLAN-TO-EXEC: 95% | sd_type: infrastructure (EXEC-TO-PLAN optional)

The previous view's `cs.sd_key = qf.id` JOIN was dead code — `create-quick-fix.js` writes `claiming_session_id` on the QF row, never `claude_sessions.sd_key`. The new join via `qf_active.claiming_session_id = cs.session_id` is the actual canonical relationship.

Migration uses `BEGIN; DROP VIEW IF EXISTS … CASCADE; CREATE VIEW; COMMIT;` rather than `CREATE OR REPLACE` because Postgres rejects column reorder in OR REPLACE. Atomic transaction; concurrent reads see either old or new view, never absent.

## Test plan
- [x] 13/13 vitest cases pass for `formatClaimedWork` + `formatRosterClaim`
- [x] 44/44 tests/unit/sd-next/ suite passes (no regressions)
- [x] Migration applied to live DB; columns surface (qf_id/qf_title/qf_status visible in `SELECT * FROM v_active_sessions`)
- [x] No SD-only roster regression — same SD-claim sessions still render `→ <sd_title>`
- [ ] Manual: when a session creates a QF via `create-quick-fix.js`, it should appear in `npm run sd:next` ACTIVE SESSIONS table with `[QF] <qf_id>` rather than as idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)