### PR TITLE
feat(SD-LEO-INFRA-LOOP-STATE-SIGNAL-001): surface /loop chaining state in claude_sessions

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -100,6 +100,7 @@ The dashboard may show additional columns from the heartbeat intelligence system
 - **Fails** (handoff failure count): Flag WORKER_STRUGGLING when fails > 3. Suggest /rca at fails > 5.
 - **WIP** (uncommitted changes): If a stale session has WIP=yes, **do NOT recommend release** — flag as "stale with uncommitted work, needs SAVE_WARNING"
 - **Branch**: Cross-check for worktree conflicts. Two workers on the same branch = WORKTREE_CONFLICT. Exception: QF-type SDs on main branch are expected.
+- **LoopState** (`claude_sessions.loop_state`): `awaiting_tick` means the worker is in a /loop parked on ScheduleWakeup — do not dispatch new work; it will resume autonomously. `active` = mid-iteration; `exited` = loop ended (safe to dispatch); `--` = no /loop state recorded.
 
 When these columns show `-` (not yet populated), fall back to heartbeat-age-only assessment.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,6 +149,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "ScheduleWakeup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/post-tool-loop-state.cjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [

--- a/database/migrations/20260426_add_claude_sessions_loop_state.sql
+++ b/database/migrations/20260426_add_claude_sessions_loop_state.sql
@@ -1,0 +1,60 @@
+-- SD-LEO-INFRA-LOOP-STATE-SIGNAL-001
+-- Add claude_sessions.loop_state column for coordinator observability of /loop chaining state.
+-- Whitelist: active | awaiting_tick | exited | unknown.
+-- DATABASE sub-agent evidence row: 9cea72f9-33f0-499b-a0cc-f83a36ff704c flagged that
+-- v_active_sessions live definition has drifted from the source file (45 cols vs 14),
+-- so this migration uses pg_get_viewdef() to capture the LIVE view definition rather
+-- than editing the stale file.
+
+BEGIN;
+
+-- Step 1: Add the column with default 'unknown' so existing rows are coherent.
+-- Idempotent: ADD COLUMN IF NOT EXISTS guards re-application.
+-- CHECK enforces the 4-value whitelist (NULL is permitted because IN(...) against NULL
+-- evaluates to UNKNOWN which the CHECK accepts; explicit IS NULL is redundant).
+ALTER TABLE claude_sessions
+  ADD COLUMN IF NOT EXISTS loop_state TEXT DEFAULT 'unknown';
+
+-- Add the CHECK constraint separately so we can guard against duplicate creation.
+-- The IF NOT EXISTS pattern on constraints requires DO block + catalog probe.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'claude_sessions_loop_state_check'
+      AND conrelid = 'claude_sessions'::regclass
+  ) THEN
+    ALTER TABLE claude_sessions
+      ADD CONSTRAINT claude_sessions_loop_state_check
+      CHECK (loop_state IN ('active', 'awaiting_tick', 'exited', 'unknown'));
+  END IF;
+END$$;
+
+-- Step 2: Refresh v_active_sessions to expose the new column.
+-- Capture the LIVE view definition (pg_get_viewdef returns the SELECT body), wrap it
+-- in a CREATE OR REPLACE VIEW, and append loop_state to the projection. This avoids
+-- re-typing 45 columns from a file that has drifted from production.
+DO $$
+DECLARE
+  view_body TEXT;
+BEGIN
+  SELECT pg_get_viewdef('v_active_sessions'::regclass, true) INTO view_body;
+
+  -- Only refresh if loop_state is not already in the view body
+  IF view_body NOT LIKE '%loop_state%' THEN
+    -- Strip trailing semicolon from pg_get_viewdef output
+    view_body := regexp_replace(view_body, ';\s*$', '');
+    -- The view body is "SELECT col1, col2, ... FROM ..."
+    -- We append `, claude_sessions.loop_state` to the SELECT projection. The simplest
+    -- way is to re-CREATE OR REPLACE with the body wrapped in a subquery + the new col.
+    EXECUTE format(
+      'CREATE OR REPLACE VIEW v_active_sessions AS SELECT _v.*, _cs.loop_state FROM (%s) _v LEFT JOIN claude_sessions _cs ON _cs.session_id = _v.session_id',
+      view_body
+    );
+  END IF;
+END$$;
+
+COMMIT;
+
+-- Step 3: Refresh PostgREST schema cache so clients see the new column without restart.
+NOTIFY pgrst, 'reload schema';

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -107,7 +107,7 @@ async function loadData() {
   const [sessRes, allSessRes, childRes, workRes, coordRes, rawSessRes, drainRes] = await Promise.all([
     supabase
       .from('v_active_sessions')
-      .select('session_id, sd_key, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track, terminal_id')
+      .select('session_id, sd_key, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track, terminal_id, loop_state')
       .not('sd_key', 'is', null)
       .order('heartbeat_age_seconds', { ascending: true }),
     supabase
@@ -356,8 +356,9 @@ function printWorkers(d) {
   } else {
     const csidHeader = hasCollision ? pad('CSID', 12) : '';
     const mcHeader = mcOk ? pad('P(alive)', 16) : '';
-    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
-    console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 136 : 120) : (mcOk ? 124 : 108)));
+    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('LoopState', 14) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
+    // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: LoopState column (14 chars) added between WIP and Activity → 14-char wider separator.
+    console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 150 : 134) : (mcOk ? 138 : 122)));
     for (const s of d.activeSessions) {
       const child = d.children.find(c => c.sd_key === s.sd_key);
       const pct = child ? child.progress_percentage : 0;
@@ -373,7 +374,10 @@ function printWorkers(d) {
       const mcCell = mcOk
         ? pad((mcRow ? pBar(mcRow.p_alive, 10) + ' ' + mcRow.p_alive.toFixed(2) : pad('-', 15)), 16)
         : '';
-      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
+      // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: render loop_state; NULL or `unknown` collapses to `--`.
+      const loopRaw = s.loop_state;
+      const loopCell = (!loopRaw || loopRaw === 'unknown') ? '--' : String(loopRaw);
+      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(loopCell, 14) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
     }
   }
 

--- a/scripts/hooks/post-tool-loop-state.cjs
+++ b/scripts/hooks/post-tool-loop-state.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — write claude_sessions.loop_state=awaiting_tick after
+ * a successful ScheduleWakeup tool call.
+ *
+ * SD: SD-LEO-INFRA-LOOP-STATE-SIGNAL-001
+ *
+ * Hook contract:
+ *   - matcher: "ScheduleWakeup" (set in .claude/settings.json) restricts firing
+ *     to the right tool. We still verify CLAUDE_TOOL_NAME defensively in case
+ *     the matcher is missing or the hook is invoked from a different settings
+ *     entry.
+ *   - Always exit 0 — observability writes MUST NOT block the tool call. Any
+ *     failure is logged to stderr by the tracker module.
+ *   - Feature-flag gate: setting LEO_LOOP_STATE_SIGNAL=off short-circuits the
+ *     write entirely (no tracker import, no DB call) so an operator can
+ *     disable the writer per-session without redeploying.
+ */
+
+const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
+
+(async () => {
+  try {
+    if (TOOL_NAME !== 'ScheduleWakeup') return;
+
+    const flag = (process.env.LEO_LOOP_STATE_SIGNAL || 'on').toLowerCase();
+    if (flag === 'off' || flag === '0' || flag === 'false') return;
+
+    const sessionId =
+      process.env.CLAUDE_SESSION_ID ||
+      process.env.SESSION_ID ||
+      '';
+    if (!sessionId) return;
+
+    const {
+      setLoopState,
+      LOOP_STATE_AWAITING_TICK
+    } = require('../lib/sessions/loop-state-tracker.cjs');
+
+    await setLoopState(sessionId, LOOP_STATE_AWAITING_TICK);
+  } catch (e) {
+    process.stderr.write(`[post-tool-loop-state] ${e.message}\n`);
+  } finally {
+    process.exit(0);
+  }
+})();

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -115,6 +115,22 @@ async function main() {
   if (!error) {
     console.log(`session-register: registered ${sessionId.slice(0, 12)}...`);
   }
+
+  // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: if the session was previously parked
+  // in `awaiting_tick` (set by post-tool-loop-state.cjs after a ScheduleWakeup),
+  // SessionStart now means the wakeup fired — flip to `active`. Conditional WHERE
+  // means fresh sessions (no prior loop_state) are not touched.
+  try {
+    const {
+      LOOP_STATE_ACTIVE,
+      LOOP_STATE_AWAITING_TICK
+    } = require('../lib/sessions/loop-state-tracker.cjs');
+    await supabase
+      .from('claude_sessions')
+      .update({ loop_state: LOOP_STATE_ACTIVE })
+      .eq('session_id', sessionId)
+      .eq('loop_state', LOOP_STATE_AWAITING_TICK);
+  } catch { /* best-effort observability; never block SessionStart */ }
 }
 
 main().catch(() => { /* fail silently */ });

--- a/scripts/lib/sessions/loop-state-tracker.cjs
+++ b/scripts/lib/sessions/loop-state-tracker.cjs
@@ -1,0 +1,112 @@
+/**
+ * Loop State Tracker — single source of truth for claude_sessions.loop_state writes.
+ *
+ * SD: SD-LEO-INFRA-LOOP-STATE-SIGNAL-001
+ *
+ * Why this module exists:
+ *   Coordinators need DB-queryable visibility into worker /loop chaining state.
+ *   Three writer paths (PostToolUse hook on ScheduleWakeup, SessionStart wakeup
+ *   detection in session-register.cjs, stale-session-sweep extension) must all
+ *   route through ONE place so the constants and validation rules cannot drift.
+ *
+ * Writes are best-effort observability — they MUST NOT throw. A failed write
+ * logs to stderr and returns; the calling hook continues.
+ *
+ * Constants are exported as named strings (not inline literals at call sites)
+ * so a `grep -r LOOP_STATE_AWAITING_TICK` from repo root finds every reference.
+ */
+
+const LOOP_STATE_ACTIVE = 'active';
+const LOOP_STATE_AWAITING_TICK = 'awaiting_tick';
+const LOOP_STATE_EXITED = 'exited';
+const LOOP_STATE_UNKNOWN = 'unknown';
+
+const VALID_STATES = Object.freeze([
+  LOOP_STATE_ACTIVE,
+  LOOP_STATE_AWAITING_TICK,
+  LOOP_STATE_EXITED,
+  LOOP_STATE_UNKNOWN
+]);
+
+function isValidState(state) {
+  return VALID_STATES.includes(state);
+}
+
+/**
+ * Set loop_state on a claude_sessions row. Best-effort, non-throwing.
+ *
+ * @param {string} sessionId - claude_sessions.session_id
+ * @param {string} state - one of VALID_STATES
+ * @param {object} [options]
+ * @param {object} [options.supabase] - injectable client; if omitted, lazily created
+ * @param {string} [options.reason] - free-form note logged on failure
+ * @returns {Promise<{ ok: boolean, skipped?: string, error?: string }>}
+ */
+async function setLoopState(sessionId, state, options = {}) {
+  if (!sessionId) {
+    return { ok: false, skipped: 'no_session_id' };
+  }
+  if (!isValidState(state)) {
+    // Validation failure is the one case we surface — invalid state is a bug,
+    // not a runtime condition. Throw so tests catch it; production callers
+    // already pass constants from this module so this is a developer-error path.
+    throw new Error(
+      `loop-state-tracker: invalid state '${state}'; expected one of ${VALID_STATES.join(', ')}`
+    );
+  }
+
+  let supabase = options.supabase;
+  if (!supabase) {
+    try {
+      const { createSupabaseServiceClient } = require('../../../lib/supabase-client.cjs');
+      supabase = createSupabaseServiceClient();
+    } catch (e) {
+      // Supabase unavailable — degrade silently; this is best-effort observability.
+      process.stderr.write(
+        `[loop-state-tracker] supabase client unavailable for session ${sessionId.slice(0, 12)} state=${state}: ${e.message}\n`
+      );
+      return { ok: false, error: 'supabase_unavailable' };
+    }
+  }
+
+  try {
+    const { error, count } = await supabase
+      .from('claude_sessions')
+      .update({ loop_state: state })
+      .eq('session_id', sessionId)
+      .select('session_id', { count: 'exact', head: true });
+
+    if (error) {
+      process.stderr.write(
+        `[loop-state-tracker] update failed for session ${sessionId.slice(0, 12)} state=${state}: ${error.message}\n`
+      );
+      return { ok: false, error: error.message };
+    }
+
+    if (count === 0) {
+      // Session row does not exist yet (cold-start race) or was just released.
+      // Non-fatal: surface to stderr so operators can audit, but do not throw.
+      process.stderr.write(
+        `[loop-state-tracker] no session row found for ${sessionId.slice(0, 12)} state=${state}; skipped\n`
+      );
+      return { ok: false, skipped: 'session_not_found' };
+    }
+
+    return { ok: true };
+  } catch (e) {
+    process.stderr.write(
+      `[loop-state-tracker] unexpected failure for session ${sessionId.slice(0, 12)} state=${state}: ${e.message}\n`
+    );
+    return { ok: false, error: e.message };
+  }
+}
+
+module.exports = {
+  LOOP_STATE_ACTIVE,
+  LOOP_STATE_AWAITING_TICK,
+  LOOP_STATE_EXITED,
+  LOOP_STATE_UNKNOWN,
+  VALID_STATES,
+  isValidState,
+  setLoopState
+};

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1259,6 +1259,27 @@ async function main() {
     console.log('');
   }
 
+  // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001 — flip loop_state to `exited` on
+  // sessions that just got released by this sweep cycle. Best-effort: failure
+  // does not roll back the release. Single bulk UPDATE rather than threading
+  // the field through every release path above (4+ sites in 3a/3b/3c/3d).
+  try {
+    // `now` was captured at the start of main() and is used for every release_at
+    // write in this sweep, so released_at >= now identifies sessions released
+    // during this cycle.
+    const sweepStartIso = now && now.toISOString ? now.toISOString() : null;
+    if (sweepStartIso) {
+      const { LOOP_STATE_EXITED } = require('./lib/sessions/loop-state-tracker.cjs');
+      await supabase
+        .from('claude_sessions')
+        .update({ loop_state: LOOP_STATE_EXITED })
+        .gte('released_at', sweepStartIso)
+        .in('loop_state', ['active', 'awaiting_tick']);
+    }
+  } catch (loopExitErr) {
+    console.log('LOOP_STATE EXIT: ' + (loopExitErr && loopExitErr.message ? loopExitErr.message : 'unknown'));
+  }
+
   console.log('=== SWEEP COMPLETE ===');
 }
 

--- a/tests/unit/loop-state-tracker.test.js
+++ b/tests/unit/loop-state-tracker.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const tracker = require('../../scripts/lib/sessions/loop-state-tracker.cjs');
+
+// SD-LEO-INFRA-LOOP-STATE-SIGNAL-001 unit tests.
+// Covers: constants match DB whitelist, validation, missing-session graceful
+// handling, success path, and the supabase-unavailable fallback.
+
+describe('loop-state-tracker: constants', () => {
+  it('exports all four LOOP_STATE_* constants matching DB whitelist exactly', () => {
+    // The DB CHECK constraint on claude_sessions.loop_state allows exactly:
+    // ('active','awaiting_tick','exited','unknown'). The exported constants
+    // MUST stay in lockstep with that whitelist or callsites silently corrupt
+    // observability data.
+    const sortedExports = [
+      tracker.LOOP_STATE_ACTIVE,
+      tracker.LOOP_STATE_AWAITING_TICK,
+      tracker.LOOP_STATE_EXITED,
+      tracker.LOOP_STATE_UNKNOWN
+    ].sort();
+    expect(sortedExports).toEqual(['active', 'awaiting_tick', 'exited', 'unknown']);
+  });
+
+  it('VALID_STATES contains the same four values as the named constants', () => {
+    expect([...tracker.VALID_STATES].sort()).toEqual(
+      ['active', 'awaiting_tick', 'exited', 'unknown']
+    );
+  });
+
+  it('VALID_STATES is frozen', () => {
+    expect(Object.isFrozen(tracker.VALID_STATES)).toBe(true);
+  });
+
+  it('isValidState accepts whitelist values and rejects others', () => {
+    expect(tracker.isValidState('active')).toBe(true);
+    expect(tracker.isValidState('awaiting_tick')).toBe(true);
+    expect(tracker.isValidState('exited')).toBe(true);
+    expect(tracker.isValidState('unknown')).toBe(true);
+    expect(tracker.isValidState('garbage')).toBe(false);
+    expect(tracker.isValidState('')).toBe(false);
+    expect(tracker.isValidState(null)).toBe(false);
+    expect(tracker.isValidState(undefined)).toBe(false);
+  });
+});
+
+describe('loop-state-tracker: setLoopState', () => {
+  let stderrMessages;
+  let originalWrite;
+
+  beforeEach(() => {
+    stderrMessages = [];
+    originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg) => {
+      stderrMessages.push(String(msg));
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  function makeMockSupabase({ updateError = null, count = 1 } = {}) {
+    return {
+      from: vi.fn(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(async () => ({ error: updateError, count }))
+          }))
+        }))
+      }))
+    };
+  }
+
+  it('throws on invalid state — that is a programmer error, not runtime', async () => {
+    await expect(
+      tracker.setLoopState('sess-12345678', 'garbage', { supabase: makeMockSupabase() })
+    ).rejects.toThrow(/invalid state.*garbage/);
+  });
+
+  it('skips silently when sessionId is empty', async () => {
+    const result = await tracker.setLoopState('', tracker.LOOP_STATE_ACTIVE, {
+      supabase: makeMockSupabase()
+    });
+    expect(result).toEqual({ ok: false, skipped: 'no_session_id' });
+  });
+
+  it('returns ok when update affects one row', async () => {
+    const supa = makeMockSupabase({ count: 1 });
+    const result = await tracker.setLoopState('sess-12345678', tracker.LOOP_STATE_AWAITING_TICK, {
+      supabase: supa
+    });
+    expect(result).toEqual({ ok: true });
+    expect(supa.from).toHaveBeenCalledWith('claude_sessions');
+  });
+
+  it('returns skipped + warns to stderr when session row not found (count=0)', async () => {
+    const result = await tracker.setLoopState('sess-missing', tracker.LOOP_STATE_EXITED, {
+      supabase: makeMockSupabase({ count: 0 })
+    });
+    expect(result).toEqual({ ok: false, skipped: 'session_not_found' });
+    const combined = stderrMessages.join('');
+    expect(combined).toContain('no session row found');
+    expect(combined).toContain('sess-missing');
+  });
+
+  it('returns error + warns to stderr when supabase update fails — never throws', async () => {
+    const supa = makeMockSupabase({ updateError: { message: 'boom' } });
+    const result = await tracker.setLoopState('sess-12345678', tracker.LOOP_STATE_ACTIVE, {
+      supabase: supa
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('boom');
+    expect(stderrMessages.join('')).toContain('boom');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `claude_sessions.loop_state` enum column (active|awaiting_tick|exited|unknown) and three writer paths so coordinators can DB-query worker /loop chaining state. Resolves the 2026-04-26 fleet-run gap where 4 idle workers parked indefinitely after first SDs shipped — coordinators couldn't distinguish "in /loop awaiting tick" from "exited" from "stuck mid-handoff".

**Architecture pivot at PLAN**: SD originally referenced "/loop skill or ScheduleWakeup wrapper" — Explore found neither exists (loop is native Claude Code, ScheduleWakeup is SDK-level). Pivoted to Claude Code hooks routing through `scripts/lib/sessions/loop-state-tracker.cjs`.

**Out of scope (LEAD scope-lock)**: no /loop chaining behavior changes, no auto-revival logic (sibling SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001 owns that), no UI changes outside fleet-dashboard.cjs.

## Test plan

- [x] Migration applied to consolidated DB; 11,950 rows backfilled to `unknown`
- [x] CHECK constraint rejects out-of-whitelist values
- [x] `v_active_sessions` view exposes `loop_state` (live-capture pattern via `pg_get_viewdef()` to avoid 45-vs-14 source-file drift)
- [x] 9/9 vitest cases pass (`tests/unit/loop-state-tracker.test.js`)
- [ ] Smoke test post-merge: register a /loop session, observe `awaiting_tick → active → awaiting_tick → exited` lifecycle
- [ ] Verify fleet-dashboard.cjs renders LoopState column without alignment regression

## Handoff scores

- LEAD-TO-PLAN: 95/100 (27 gates)
- PLAN-TO-EXEC: 96/100
- PLAN-TO-LEAD: 91/100

## Sub-agent evidence

- DOCMON LEAD: row `260965cd-21b9-453b-880d-52dd6dc41003` (PASS — recommended dedicated enum column over metadata.loop_state JSON path)
- DATABASE PLAN: row `9cea72f9-33f0-499b-a0cc-f83a36ff704c` (WARNING — flagged view drift; pivoted to live-capture pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)