### PR TITLE
feat(SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001): close fail-open paths in PR_MERGE_VERIFICATION gate

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -585,9 +585,21 @@ export function createPRMergeVerificationGate() {
                       });
                     }
                   }
-                } catch (_e) {
-                  // Intentionally suppressed: branch comparison failed, skip
-                  console.debug('[LeadFinalApproval] branch comparison suppressed:', _e?.message || _e);
+                } catch (e) {
+                  // SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001: do NOT silently skip.
+                  // A branch we cannot compare against main is unverified — treat as
+                  // unmerged unless we have positive evidence otherwise. This was the
+                  // dual failure mode in SD-MAN-ORCH-S18-S26-PIPELINE-001-A: branch
+                  // existed on origin but rev-list/gh-pr-list either errored or was
+                  // skipped on the LEAD host, leaving the branch unverified yet allowed.
+                  console.log(`   ⚠️  Could not verify ${cleanBranch}: ${e?.message || e}`);
+                  unmergedBranches.push({
+                    branch: cleanBranch,
+                    repo: repo,
+                    commits: null,
+                    unverified: true,
+                    reason: e?.message || String(e)
+                  });
                 }
               }
             }
@@ -598,9 +610,15 @@ export function createPRMergeVerificationGate() {
         }
 
         if (unmergedBranches.length > 0) {
-          console.log(`   ❌ Found ${unmergedBranches.length} unmerged branch(es) with commits:`);
-          unmergedBranches.forEach(b => {
+          const verified = unmergedBranches.filter(b => !b.unverified);
+          const unverified = unmergedBranches.filter(b => b.unverified);
+          console.log(`   ❌ Found ${unmergedBranches.length} branch(es) blocking completion (${verified.length} unmerged + ${unverified.length} unverified):`);
+          verified.forEach(b => {
             console.log(`      - ${b.branch} (${b.commits} commits ahead of main)`);
+            console.log(`        Repo: ${b.repo}`);
+          });
+          unverified.forEach(b => {
+            console.log(`      - ${b.branch} (UNVERIFIED — could not compare against main: ${b.reason})`);
             console.log(`        Repo: ${b.repo}`);
           });
 
@@ -609,18 +627,21 @@ export function createPRMergeVerificationGate() {
             score: 0,
             max_score: 100,
             issues: [
-              `${unmergedBranches.length} unmerged branch(es) with commits - create PRs and merge before completion`,
-              ...unmergedBranches.map(b => `  → ${b.branch} (${b.commits} commits) in ${b.repo}`),
+              `${unmergedBranches.length} branch(es) block completion (${verified.length} unmerged, ${unverified.length} unverified) - resolve before completion`,
+              ...verified.map(b => `  → ${b.branch} (${b.commits} commits) in ${b.repo}`),
+              ...unverified.map(b => `  → ${b.branch} (UNVERIFIED: ${b.reason}) in ${b.repo}`),
               '',
               'REMEDIATION: Run /ship to create PRs and merge branches before running LEAD-FINAL-APPROVAL.',
               'Required order: EXEC → /ship (merge PR) → LEAD-FINAL-APPROVAL',
-              ...unmergedBranches.map(b => `  → cd to ${b.repo} repo, then: git push -u origin ${b.branch} && gh pr create && gh pr merge --merge --delete-branch`)
+              ...verified.map(b => `  → cd to ${b.repo} repo, then: git push -u origin ${b.branch} && gh pr create && gh pr merge --merge --delete-branch`),
+              ...(unverified.length > 0 ? ['', 'For UNVERIFIED branches: resolve the comparison error (gh auth, network, repo path) and re-run, OR --bypass-validation with documented reason if the branch is known-merged.'] : [])
             ],
             warnings: [],
             details: {
               checkedPatterns: branchPatterns,
               openPRs: 0,
-              unmergedBranches: unmergedBranches
+              unmergedBranches: unmergedBranches,
+              unverifiedCount: unverified.length
             }
           };
         }
@@ -637,14 +658,30 @@ export function createPRMergeVerificationGate() {
         };
 
       } catch (error) {
-        console.log(`   ⚠️  PR verification skipped: ${error.message}`);
+        // SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001: fail-closed when verification cannot run.
+        // Previously returned passed=true score=80 here, which silently allowed completion
+        // when gh CLI was unavailable or git operations threw. Witnessed live in
+        // SD-MAN-ORCH-S18-S26-PIPELINE-001-A: branch never merged, gate accepted at 88,
+        // 24 warnings, no bypass. The fail-open path is the bug — verification failure
+        // is not equivalent to verification success.
+        console.log(`   ❌ PR verification failed: ${error.message}`);
         return {
-          passed: true,
-          score: 80,
+          passed: false,
+          score: 0,
           max_score: 100,
-          issues: [],
-          warnings: [`PR verification could not run: ${error.message}. Verify manually that all PRs are merged.`],
-          details: { skipped: true, reason: error.message }
+          issues: [
+            `PR verification could not run: ${error.message}`,
+            '',
+            'REMEDIATION: Resolve the underlying verification error before retrying:',
+            '  - gh CLI unauthenticated → run: gh auth login',
+            '  - gh CLI not installed → install from https://cli.github.com/',
+            '  - Repo path missing → verify EHG/EHG_Engineer paths in repo-paths.js',
+            '  - Network/timeout → retry; if persistent, document and use --bypass-validation with reason',
+            '',
+            'Bypass available for documented emergencies: --bypass-validation --bypass-reason "<reason>"'
+          ],
+          warnings: [],
+          details: { failed: true, reason: error.message, fail_closed: true }
         };
       }
     },

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/pr-merge-verification.test.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/pr-merge-verification.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001:
+ *
+ * Tests cover the two fail-open holes in createPRMergeVerificationGate that
+ * allowed SD-MAN-ORCH-S18-S26-PIPELINE-001-A to complete with branch
+ * `feat/...-s18-marketing-copy-regenerate-api-fronte` (commit 2a63dac3) on
+ * origin and never merged to main:
+ *
+ *   1. Outer-try error path returned passed=true, score=80 (fail-open). Now
+ *      returns passed=false, score=0 (fail-closed).
+ *   2. Per-branch comparison errors silently `console.debug`'d and skipped.
+ *      Now classified as `unverified` and treated as completion blockers.
+ */
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+vi.mock('../../../../sd-type-checker.js', () => ({ getTierForSD: vi.fn(() => 3) }));
+vi.mock('../../../retro-filters.js', () => ({ getFilteredRetrospective: vi.fn() }));
+vi.mock('../../../../../lib/repo-paths.js', () => ({
+  resolveRepoPath: vi.fn((name) => `/fake/${name}`),
+  ENGINEER_ROOT: '/fake/EHG_Engineer',
+}));
+
+import { execSync } from 'child_process';
+import { createPRMergeVerificationGate } from '../gates.js';
+
+const makeCtx = (sdKey = 'SD-MAN-ORCH-TEST-001') => ({
+  sd: { id: 'test-uuid', sd_key: sdKey, sd_type: 'infrastructure' },
+  sdId: 'test-uuid',
+});
+
+describe('createPRMergeVerificationGate fail-closed behaviour (SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  it.skip('outer-try error fails closed (defense-in-depth — outer catch is unreachable in normal operation)', async () => {
+    // The outer try wraps `await import('child_process')` plus orchestration. Every
+    // call site inside the loops is wrapped in an inner try, so the outer catch only
+    // fires if the dynamic import itself fails — which doesn't happen in vitest. The
+    // outer-catch fail-closed change at gates.js line 639 is defense-in-depth: it
+    // ensures that any future code added between the dynamic import and the inner
+    // try-wrapped loops also fails closed, not open.
+    //
+    // The actual failure mode that allowed SD-MAN-ORCH-S18-S26-PIPELINE-001-A through
+    // was the inner branch-comparison catch (line 588) silently swallowing errors —
+    // that path IS exercised by the next test ("inner branch-comparison error marks
+    // branch unverified and blocks completion").
+  });
+
+  it('inner branch-comparison error marks branch unverified and blocks completion', async () => {
+    let callIndex = 0;
+    execSync.mockImplementation((cmd) => {
+      callIndex++;
+      if (cmd.startsWith('gh pr list') && cmd.includes('--state open')) return '[]';
+      if (cmd.startsWith('git fetch')) return '';
+      if (cmd === 'git branch -r') return '  origin/feat/SD-MAN-ORCH-TEST-001-thing\n  origin/main';
+      if (cmd.includes('rev-list --count')) {
+        throw new Error('fatal: bad revision');
+      }
+      if (cmd.includes('gh pr list --head')) return '[]';
+      return '';
+    });
+    const gate = createPRMergeVerificationGate();
+    const result = await gate.validator(makeCtx());
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.details?.unverifiedCount).toBeGreaterThanOrEqual(1);
+    expect(result.issues.join('\n')).toMatch(/UNVERIFIED/);
+  });
+
+  it('happy path: no open PRs and no unmerged branches still passes', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.startsWith('gh pr list') && cmd.includes('--state open')) return '[]';
+      if (cmd.startsWith('git fetch')) return '';
+      if (cmd === 'git branch -r') return '  origin/main\n  origin/HEAD -> origin/main';
+      return '';
+    });
+    const gate = createPRMergeVerificationGate();
+    const result = await gate.validator(makeCtx());
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('detects unmerged branches with commits ahead of main', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.startsWith('gh pr list') && cmd.includes('--state open')) return '[]';
+      if (cmd.startsWith('git fetch')) return '';
+      if (cmd === 'git branch -r') return '  origin/feat/SD-MAN-ORCH-TEST-001-thing\n  origin/main';
+      if (cmd.includes('rev-list --count')) return '5';
+      if (cmd.includes('gh pr list --head')) return '[]';
+      return '';
+    });
+    const gate = createPRMergeVerificationGate();
+    const result = await gate.validator(makeCtx());
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.issues.join('\n')).toMatch(/5 commits/);
+  });
+
+  it('squash-merge artifact (branch+merged-PR) passes — does not regress legitimate completions', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.startsWith('gh pr list') && cmd.includes('--state open')) return '[]';
+      if (cmd.startsWith('git fetch')) return '';
+      if (cmd === 'git branch -r') return '  origin/feat/SD-MAN-ORCH-TEST-001-thing\n  origin/main';
+      if (cmd.includes('rev-list --count')) return '3';
+      if (cmd.includes('gh pr list --head')) return JSON.stringify([{ number: 42 }]);
+      return '';
+    });
+    const gate = createPRMergeVerificationGate();
+    const result = await gate.validator(makeCtx());
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Closes two fail-open paths in `createPRMergeVerificationGate` that allowed `SD-MAN-ORCH-S18-S26-PIPELINE-001-A` to complete with branch on origin but never merged to main (CAPA from S18 dead-gate UX defect campaign).

## Changes

1. **Outer-try error path** returned `passed=true score=80`. Now returns `passed=false score=0` with actionable remediation. Defense-in-depth; only triggers if dynamic import fails.
2. **Per-branch git rev-list comparison errors** silently `console.debug`'d and skipped. Now classified as `unverified` and treated as completion blockers. **Load-bearing fix** — RCA confirmed SD-MAN-ORCH-001-A's LEAD-FINAL accepted at score 88 with no bypass and `metadata.pr_url` undefined; the inner-catch suppression masked the unmerged-branch reality.

## Test plan

- [x] 5 vitest cases (1 documented-skip for unreachable outer-catch path)
- [x] Verified against real failure mode signature (SD-MAN-ORCH-001-A commit 2a63dac3)
- [ ] Gate fails closed in CI if branch not merged

## Strategic Directive

CAPA 1 from `project_s18_dead_gate_capa_campaign_2026_04_26.md` — paired with SD-MAN-FIX-WIRE-S18-S22-001 (re-land branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)