### PR TITLE
feat(SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001): surface harness-backlog.md staleness in sd:next

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -56,7 +56,8 @@ import {
   loadOpenQuickFixes,
   triageQuickFixes,
   loadUnscheduledRoadmapItems,
-  loadFeedbackItems
+  loadFeedbackItems,
+  loadHarnessBacklog
 } from './data-loaders.js';
 import {
   displayOKRScorecard,
@@ -128,6 +129,8 @@ export class SDNextSelector {
     this.qfTriageResults = new Map();
     this.unscheduledRoadmapItems = [];
     this.feedbackItems = [];
+    // SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001
+    this.harnessBacklog = null;
   }
 
   /**
@@ -186,6 +189,8 @@ export class SDNextSelector {
     }
     this.unscheduledRoadmapItems = await loadUnscheduledRoadmapItems(this.supabase);
     this.feedbackItems = await loadFeedbackItems(this.supabase);
+    // SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001: load harness backlog file
+    this.harnessBacklog = await loadHarnessBacklog();
     this.loadMultiRepoStatus();
 
     // SD-LEO-INFRA-SESSION-COMPACTION-CLAIM-001: Detect local signals
@@ -221,6 +226,7 @@ export class SDNextSelector {
         qfTriageResults: this.qfTriageResults,
       });
       this.displayFeedbackItems();
+      this.displayHarnessBacklog();
       if (qfSummaryNoBaseline.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
       }
@@ -239,6 +245,7 @@ export class SDNextSelector {
         qfTriageResults: this.qfTriageResults,
       });
       this.displayFeedbackItems();
+      this.displayHarnessBacklog();
       if (qfSummaryExhausted.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
       }
@@ -250,6 +257,9 @@ export class SDNextSelector {
 
     // Display actionable feedback items (SD-LEO-INFRA-FEEDBACK-PIPELINE-ACTIVATION-001-C)
     this.displayFeedbackItems();
+
+    // Display harness backlog staleness (SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001)
+    this.displayHarnessBacklog();
 
     // Display recommendations and get structured action data
     const recommendation = await displayRecommendations(this.supabase, this.baselineItems, this.conflicts, this.getSessionContext(), qfSummary);
@@ -605,6 +615,66 @@ export class SDNextSelector {
       console.log(`  ${badge} ${cat}${title}${age > 7 ? ` ${c.red}(${age}d)${c.reset}` : ` ${c.dim}(${age}d)${c.reset}`}`);
     }
     console.log(`${c.dim}  Run /inbox to triage${c.reset}`);
+  }
+
+  /**
+   * Display harness backlog count + oldest-entry age + top 5 items.
+   * SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001
+   *
+   * Section ALWAYS renders so operators learn the surface exists. Color
+   * escalates green (<7d) → yellow (7-13d) → magenta (>=14d) on count badge.
+   */
+  displayHarnessBacklog() {
+    const c = colors;
+    const data = this.harnessBacklog;
+
+    if (!data) {
+      console.log(`\n${c.bold}${c.yellow}HARNESS BACKLOG${c.reset} ${c.dim}(not loaded)${c.reset}`);
+      return;
+    }
+
+    if (data.fileMissing) {
+      console.log(`\n${c.bold}${c.yellow}HARNESS BACKLOG${c.reset} ${c.dim}(file missing — check docs/harness-backlog.md)${c.reset}`);
+      return;
+    }
+
+    if (data.error) {
+      console.log(`\n${c.bold}${c.yellow}HARNESS BACKLOG${c.reset} ${c.red}(parse error — see stderr)${c.reset}`);
+      process.stderr.write(`[harness-backlog] ${data.error}\n`);
+      return;
+    }
+
+    const ageColor = data.oldestAgeDays >= 14
+      ? c.magenta
+      : data.oldestAgeDays >= 7
+        ? c.yellow
+        : c.green;
+    const countDisplay = data.count === 0
+      ? `${c.dim}0 items${c.reset}`
+      : `${ageColor}${data.count} item${data.count === 1 ? '' : 's'}, oldest ${data.oldestAgeDays}d${c.reset}`;
+
+    console.log(`\n${c.bold}${c.yellow}HARNESS BACKLOG${c.reset} (${countDisplay})`);
+
+    if (data.count === 0) {
+      console.log(`${c.dim}  No deferred items — keep filing one-liners during product work${c.reset}`);
+      return;
+    }
+
+    const sorted = [...data.items].sort((a, b) => b.ageDays - a.ageDays);
+    const top = sorted.slice(0, 5);
+    for (const item of top) {
+      const ageBadge = item.ageDays >= 14
+        ? `${c.magenta}${item.ageDays}d${c.reset}`
+        : item.ageDays >= 7
+          ? `${c.yellow}${item.ageDays}d${c.reset}`
+          : `${c.dim}${item.ageDays}d${c.reset}`;
+      const symptom = (item.symptom || '(no symptom)').slice(0, 80);
+      console.log(`  ${ageBadge} ${symptom}`);
+    }
+    if (data.count > 5) {
+      console.log(`${c.dim}  +${data.count - 5} more — see docs/harness-backlog.md${c.reset}`);
+    }
+    console.log(`${c.dim}  Process via [MODE: campaign] session or /leo audit${c.reset}`);
   }
 
   async displayTracks() {

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -4,6 +4,9 @@
  */
 
 import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { parseHarnessBacklog } from './harness-backlog-parser.js';
 
 /**
  * Log a query failure with structured context for diagnostics.
@@ -597,4 +600,62 @@ export async function loadFeedbackItems(supabase) {
     // Table may not exist in all environments
     return [];
   }
+}
+
+/**
+ * Harness-backlog loader cache (SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001).
+ * Keyed by absolute filePath; entry shape:
+ *   { mtimeMs: number, expiresAt: number, result: HarnessBacklogParseResult }
+ * 60s TTL upper bound; mtime-mismatch invalidates earlier.
+ */
+const HARNESS_BACKLOG_TTL_MS = 60_000;
+const _harnessBacklogCache = new Map();
+
+/**
+ * Load + parse docs/harness-backlog.md for the sd:next HARNESS BACKLOG section.
+ * Read-only filesystem access. mtime-keyed in-memory cache (60s TTL) prevents
+ * repeated reads on rapid sd:next invocations.
+ *
+ * @param {string} [filePath]  Absolute path to harness-backlog.md.
+ *                             Defaults to <repo-root>/docs/harness-backlog.md
+ *                             (repo root resolved relative to this module).
+ * @returns {Promise<{ count:number, oldestAgeDays:number, items:Array, fileMissing:boolean, error:string|null }>}
+ */
+export async function loadHarnessBacklog(filePath) {
+  const resolvedPath = filePath
+    ?? process.env.HARNESS_BACKLOG_PATH
+    ?? path.resolve(process.cwd(), 'docs', 'harness-backlog.md');
+
+  try {
+    const stat = await fs.stat(resolvedPath).catch(() => null);
+    if (!stat) {
+      return { count: 0, oldestAgeDays: 0, items: [], fileMissing: true, error: null };
+    }
+    const cached = _harnessBacklogCache.get(resolvedPath);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.expiresAt > Date.now()) {
+      return cached.result;
+    }
+    const content = await fs.readFile(resolvedPath, 'utf8');
+    const parsed = parseHarnessBacklog(content);
+    const result = { ...parsed, fileMissing: false, error: null };
+    _harnessBacklogCache.set(resolvedPath, {
+      mtimeMs: stat.mtimeMs,
+      expiresAt: Date.now() + HARNESS_BACKLOG_TTL_MS,
+      result,
+    });
+    return result;
+  } catch (err) {
+    return {
+      count: 0,
+      oldestAgeDays: 0,
+      items: [],
+      fileMissing: false,
+      error: err?.message || String(err),
+    };
+  }
+}
+
+/** Test-only: clear the harness-backlog loader cache. */
+export function _clearHarnessBacklogCache() {
+  _harnessBacklogCache.clear();
 }

--- a/scripts/modules/sd-next/harness-backlog-parser.js
+++ b/scripts/modules/sd-next/harness-backlog-parser.js
@@ -1,0 +1,88 @@
+/**
+ * Harness Backlog Parser — SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001
+ *
+ * Pure function: parses docs/harness-backlog.md content into a structured
+ * shape consumed by the sd:next HARNESS BACKLOG section renderer.
+ *
+ * Format expected (one item per line):
+ *   YYYY-MM-DD | <symptom> | <file or command> | deferred from SD-...
+ *
+ * Lenient: any line starting with YYYY-MM-DD is captured as an item even
+ * if pipe-split returns fewer than 4 fields. Unrecognised lines are skipped
+ * (header text, code blocks, comments).
+ */
+
+const DATE_PREFIX_RE = /^(\d{4}-\d{2}-\d{2})\b/;
+
+/**
+ * @typedef {Object} HarnessBacklogItem
+ * @property {string} date         YYYY-MM-DD as captured
+ * @property {string} symptom      Human-readable description
+ * @property {string|null} source  File or command where it surfaced (null if missing)
+ * @property {number} ageDays      Days from item date to nowMs (rounded down)
+ */
+
+/**
+ * @typedef {Object} HarnessBacklogParseResult
+ * @property {number} count                Number of valid items
+ * @property {number} oldestAgeDays        Max ageDays across items (0 when count===0)
+ * @property {HarnessBacklogItem[]} items  Items in original file order
+ */
+
+/**
+ * Parse a harness-backlog.md markdown body.
+ *
+ * @param {string} content  Raw file contents
+ * @param {Object} [opts]
+ * @param {number} [opts.nowMs=Date.now()]  Override "now" for testing
+ * @returns {HarnessBacklogParseResult}
+ */
+export function parseHarnessBacklog(content, opts = {}) {
+  const nowMs = opts.nowMs ?? Date.now();
+  if (!content || typeof content !== 'string') {
+    return { count: 0, oldestAgeDays: 0, items: [] };
+  }
+
+  const lines = content.split(/\r?\n/);
+  const items = [];
+  let inCodeBlock = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    if (!line) continue;
+    if (line.startsWith('<!--') || line.startsWith('-->')) continue;
+    if (line.startsWith('#')) continue;
+
+    const dateMatch = line.match(DATE_PREFIX_RE);
+    if (!dateMatch) continue;
+
+    const date = dateMatch[1];
+    const remainder = line.slice(date.length).replace(/^\s*\|?\s*/, '');
+    const fields = remainder.split(' | ').map((f) => f.trim());
+    const symptom = fields[0] || '';
+    let source = null;
+    if (fields.length >= 2) {
+      source = fields[1] || null;
+    }
+    if (!symptom) {
+      process.stderr.write(
+        `[harness-backlog-parser] WARN: line starting with ${date} has no symptom field — captured with empty symptom\n`,
+      );
+    }
+
+    const itemMs = Date.parse(`${date}T00:00:00Z`);
+    const ageDays = Number.isFinite(itemMs)
+      ? Math.max(0, Math.floor((nowMs - itemMs) / 86400000))
+      : 0;
+
+    items.push({ date, symptom, source, ageDays });
+  }
+
+  const oldestAgeDays = items.reduce((max, item) => Math.max(max, item.ageDays), 0);
+  return { count: items.length, oldestAgeDays, items };
+}

--- a/tests/unit/sd-next/harness-backlog-parser.test.js
+++ b/tests/unit/sd-next/harness-backlog-parser.test.js
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for SD-LEO-INFRA-SURFACE-HARNESS-BACKLOG-001 (FR-1, FR-5).
+ * Covers parseHarnessBacklog + loadHarnessBacklog cache behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  parseHarnessBacklog,
+} from '../../../scripts/modules/sd-next/harness-backlog-parser.js';
+import {
+  loadHarnessBacklog,
+  _clearHarnessBacklogCache,
+} from '../../../scripts/modules/sd-next/data-loaders.js';
+
+// Pin "now" so ageDays calculations are deterministic.
+const NOW_MS = Date.parse('2026-04-30T12:00:00Z');
+
+const GOLDEN_FIXTURE = `# Harness Backlog
+
+Some intro paragraph that should be ignored.
+
+\`\`\`
+2026-04-01 | should-be-ignored-inside-fence | scripts/foo.js | deferred from SD-EXAMPLE
+\`\`\`
+
+## Items
+
+<!-- comment block ignored -->
+2026-04-30 | Latest issue surfaced today | scripts/sd-next.js:200 | deferred from SD-X-001
+2026-04-23 | Week-old issue | lib/foo.js | deferred from SD-Y-002
+2026-04-01 | Month-old recurrence flag | scripts/handoff.js | deferred from SD-Z-003
+`;
+
+const EMPTY_FIXTURE = `# Harness Backlog
+
+## Items
+
+<!-- Append below. -->
+`;
+
+const MALFORMED_FIXTURE = `# Harness Backlog
+
+## Items
+
+2026-04-26 | only one symptom field, no source pipe
+2026-04-25 | well-formed | path/to/file.js | deferred from SD-OK-001
+`;
+
+describe('parseHarnessBacklog — FR-1', () => {
+  it('parses 3 well-formed entries with correct shape and ageDays', () => {
+    const result = parseHarnessBacklog(GOLDEN_FIXTURE, { nowMs: NOW_MS });
+    expect(result.count).toBe(3);
+    expect(result.oldestAgeDays).toBe(29); // 2026-04-30 - 2026-04-01
+    expect(result.items).toEqual([
+      {
+        date: '2026-04-30',
+        symptom: 'Latest issue surfaced today',
+        source: 'scripts/sd-next.js:200',
+        ageDays: 0,
+      },
+      {
+        date: '2026-04-23',
+        symptom: 'Week-old issue',
+        source: 'lib/foo.js',
+        ageDays: 7,
+      },
+      {
+        date: '2026-04-01',
+        symptom: 'Month-old recurrence flag',
+        source: 'scripts/handoff.js',
+        ageDays: 29,
+      },
+    ]);
+  });
+
+  it('skips lines inside fenced code blocks', () => {
+    const result = parseHarnessBacklog(GOLDEN_FIXTURE, { nowMs: NOW_MS });
+    const symptoms = result.items.map((i) => i.symptom);
+    expect(symptoms).not.toContain('should-be-ignored-inside-fence');
+  });
+
+  it('returns count=0/oldestAgeDays=0/items=[] for empty content', () => {
+    const result = parseHarnessBacklog(EMPTY_FIXTURE, { nowMs: NOW_MS });
+    expect(result).toEqual({ count: 0, oldestAgeDays: 0, items: [] });
+  });
+
+  it('returns empty result for null/undefined/non-string input', () => {
+    expect(parseHarnessBacklog(null).count).toBe(0);
+    expect(parseHarnessBacklog(undefined).count).toBe(0);
+    expect(parseHarnessBacklog(42).count).toBe(0);
+  });
+
+  it('lenient parse: malformed line still captured with source=null', () => {
+    const result = parseHarnessBacklog(MALFORMED_FIXTURE, { nowMs: NOW_MS });
+    expect(result.count).toBe(2);
+    expect(result.items[0]).toMatchObject({
+      date: '2026-04-26',
+      symptom: 'only one symptom field, no source pipe',
+      source: null,
+    });
+    expect(result.items[1].source).toBe('path/to/file.js');
+  });
+});
+
+describe('loadHarnessBacklog — FR-2 (cache + fileMissing)', () => {
+  let tmpDir;
+  let tmpPath;
+
+  beforeEach(async () => {
+    _clearHarnessBacklogCache();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'harness-backlog-test-'));
+    tmpPath = path.join(tmpDir, 'harness-backlog.md');
+  });
+  afterEach(async () => {
+    _clearHarnessBacklogCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fileMissing branch returns shape with fileMissing=true', async () => {
+    const missing = path.join(tmpDir, 'does-not-exist.md');
+    const result = await loadHarnessBacklog(missing);
+    expect(result).toEqual({
+      count: 0,
+      oldestAgeDays: 0,
+      items: [],
+      fileMissing: true,
+      error: null,
+    });
+  });
+
+  it('cache hit returns same object reference on repeated call', async () => {
+    await fs.writeFile(tmpPath, GOLDEN_FIXTURE);
+    const a = await loadHarnessBacklog(tmpPath);
+    const b = await loadHarnessBacklog(tmpPath);
+    expect(b).toBe(a);
+    expect(a.count).toBeGreaterThan(0);
+    expect(a.fileMissing).toBe(false);
+  });
+
+  it('mtime change invalidates cache', async () => {
+    await fs.writeFile(tmpPath, GOLDEN_FIXTURE);
+    const first = await loadHarnessBacklog(tmpPath);
+    expect(first.count).toBe(3);
+
+    // Force mtime advance (some filesystems have second-resolution mtime).
+    await new Promise((r) => setTimeout(r, 1100));
+    await fs.writeFile(tmpPath, EMPTY_FIXTURE);
+    const second = await loadHarnessBacklog(tmpPath);
+    expect(second).not.toBe(first);
+    expect(second.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a HARNESS BACKLOG section to `npm run sd:next` output (after FEEDBACK INBOX) that parses `docs/harness-backlog.md`, counts open entries, computes oldest-entry age in days, and renders a colored badge that escalates green (<7d) → yellow (7-13d) → magenta (≥14d). Read-only display, no triage actions.

Closes the visibility gap demonstrated by SD-LEO-INFRA-S17-PLAYWRIGHT-COVERAGE-001 (PR #532, merged earlier today) where the GATE5 cross-repo bug was bypassed for the second time despite being captured in the backlog from a prior session — the file was passive and no surface drew operator attention.

**Coverage**: 374 LOC across 4 files
- `scripts/modules/sd-next/harness-backlog-parser.js` (88 LOC) — pure function, lenient line parser
- `scripts/modules/sd-next/data-loaders.js` (+61 LOC) — `loadHarnessBacklog()` with mtime-keyed 60s cache + `fileMissing` branch
- `scripts/modules/sd-next/SDNextSelector.js` (+72 LOC) — `displayHarnessBacklog()` mirror of `displayFeedbackItems`, wired into all 3 call sites (no-baseline early return, exhausted-baseline early return, normal flow) per `feedback_sd_next_rendering_pipeline_has_5_sd_selects.md`
- `tests/unit/sd-next/harness-backlog-parser.test.js` (154 LOC) — 8 tests across parser shape, code-block skip, empty/null inputs, malformed-line lenient capture, loader fileMissing, cache hit (same object reference), mtime invalidation

## Test plan

- [x] `npx vitest run tests/unit/sd-next/harness-backlog-parser.test.js` → 8/8 passing in 1.4s
- [x] `npm run sd:next` smoke test: section renders correctly with current 9-entry main backlog ("9 items, oldest 0d", green badge, top 5 + "+4 more" overflow line, dim hint footer)
- [ ] Operator: pull `main` into any sibling worktrees that branched before this commit so their `sd:next` shows current backlog state
- [ ] Operator: run `NO_COLOR=1 npm run sd:next` to verify ANSI suppression (relies on existing `colors.js` helper convention)

## LEO Protocol

- LEAD-TO-PLAN: PASS 94/100 (`GATE_VISION_SCORE` bypassed — L1/L2 tier mismatch on harness-tooling SD; established pattern from PR #3365)
- PLAN-TO-EXEC: PASS 94/100 (all 22 gates clean)
- EXEC-TO-PLAN: PASS 93/100 (`GATE_TEST_COVERAGE_QUALITY` bypassed — Playwright executor irrelevant for CLI-text-rendering SD; documented pattern)
- PLAN-TO-LEAD: PASS 92/100 (all gates clean — `HEAL_BEFORE_COMPLETE` 90%, `GATE5` 100%, `SUCCESS_METRICS` 74%, `RETROSPECTIVE_QUALITY` 90%)

## Sub-agent evidence

- VALIDATION `301b7721` (PASS, located injection at `SDNextSelector.js:608`)
- STORIES `7303dc62` (5 stories US-001..US-005 with 100% implementation_context)
- TESTING `f3d082cc` (PASS confidence 92, retrospective review)
- Retrospective `56587527` (quality 90, 6 SD-specific learnings, 4 action items)

## Self-aware closure

This SD itself appears in `npm run sd:next` HARNESS BACKLOG section once merged — the same fix that adds visibility automatically benefits from that visibility. Filed in this session's prior turn (SD created from harness-backlog discussion); shipped this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)