### PR TITLE
fix(QF-20260426-465): test-coverage workflow uses vitest --reporter=json

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -42,7 +42,8 @@ jobs:
         # canonical defense against that bug class.
         env:
           NODE_OPTIONS: --experimental-vm-modules
-        run: npm run test:coverage -- --json --outputFile=test-results.json
+        # QF-20260426-465: vitest dropped CLI --json in 1.x->3.x; use --reporter=json instead.
+        run: npm run test:coverage -- --reporter=json --outputFile=test-results.json
 
       - name: Check coverage threshold
         run: |


### PR DESCRIPTION
## Summary

vitest 1.x→3.x removed the CLI `--json` option, replacing it with `--reporter=json`. The `test-coverage` workflow at line 45 still uses `--json`, causing every CI run (main + every branch) to fail with `CACError: Unknown option --json`.

Fix: replace `--json` with `--reporter=json`. Same JSON output, current vitest API.

## Inbox items resolved as duplicates

- `f9bad092` Test Coverage Enforcement failed on main
- `84358abf` Test Coverage Enforcement failed on main
- `20b5f04e` Test Coverage Enforcement failed on feat/SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001
- `abc3465b` Test Coverage Enforcement failed on feat/SD-LEO-INFRA-LOOP-STATE-SIGNAL-001

## Test plan

- [x] Verified actual failure log: `CACError: Unknown option --json` (run 24967605353)
- [ ] Post-merge: confirm next test-coverage workflow run on main passes (or fails for a different reason — coverage threshold, not CLI parsing)

## Background

Pre-existing main-CI failure noted in memory `project_sd_stage_archetype_generation_001_4of5_landed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)