### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-134): bimodal id/sd_key lookup in handoff prerequisite-preflight

### DIFF
--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -15,6 +15,7 @@
 
 import { SD_TYPE_THRESHOLDS, DEFAULT_THRESHOLD, JSONB_FIELDS } from '../../sd-quality-scoring.js';
 import { shouldBypassUserStories } from '../../../../lib/protocol-policies/orchestrator-bypass.js';
+import { lookupSdIdForFk } from '../../auto-trigger-stories.mjs';
 
 /**
  * Determines whether an SD requires user stories at PLAN-TO-EXEC time.
@@ -64,11 +65,28 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
   const issues = [];
 
   try {
-    // Load SD record
+    // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-134: bimodal id/sd_key resolution.
+    // strategic_directives_v2.id is varchar(50) PK and may hold UUID-shaped
+    // strings on newer SDs or sd_key strings on legacy rows. Resolve via the
+    // PR #3367 helper, then full-row select keyed on the canonical id.
+    let resolved;
+    try {
+      resolved = await lookupSdIdForFk(supabase, sdId);
+    } catch {
+      return {
+        passed: false,
+        issues: [{
+          code: 'SD_NOT_FOUND',
+          message: `Strategic Directive ${sdId} not found in database`,
+          remediation: 'Identifier did not match either id or sd_key. Verify the value (UUID or SD-XXX format) and re-check via: SELECT id, sd_key FROM strategic_directives_v2 WHERE id = $1 OR sd_key = $1.'
+        }]
+      };
+    }
+
     const { data: sd, error: sdError } = await supabase
       .from('strategic_directives_v2')
       .select('*')
-      .eq('sd_key', sdId)
+      .eq('id', resolved.id)
       .single();
 
     if (sdError || !sd) {
@@ -77,7 +95,7 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
         issues: [{
           code: 'SD_NOT_FOUND',
           message: `Strategic Directive ${sdId} not found in database`,
-          remediation: 'Verify the SD key is correct. Run: node -e "..." to check.'
+          remediation: 'Identifier resolved but full row could not be loaded. Check DB connectivity and row visibility.'
         }]
       };
     }

--- a/tests/unit/handoff/prerequisite-preflight-bimodal-lookup.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-bimodal-lookup.test.js
@@ -1,0 +1,241 @@
+/**
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-134
+ *
+ * Tests the bimodal id/sd_key resolver wired into runPrerequisitePreflight
+ * via the PR #3367 lookupSdIdForFk helper. Covers PRD test_scenarios TS-1
+ * through TS-5: sd_key resolution, UUID-id resolution (the regression case),
+ * miss path, dispatch through PLAN-TO-EXEC, and autoFix UPDATE writeback
+ * after id-keyed load.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runPrerequisitePreflight } from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+// Lightweight Supabase stub: shapes responses per .from(table).select().eq().single()
+// and per the .or().single() shape used by lookupSdIdForFk. Records every .eq()
+// and .or() filter so tests can assert dispatch ordering.
+function makeSupabase({ resolveRow, fullRow, prdRow, plan2leadRow, retroRow, updateError = null, captureUpdate = null }) {
+  const calls = { eqs: [], ors: [], updates: [], inFilters: [] };
+  const make = (overrides = {}) => ({
+    select() { return this; },
+    eq(col, val) {
+      calls.eqs.push({ col, val });
+      return this;
+    },
+    or(filter) {
+      calls.ors.push(filter);
+      return this;
+    },
+    in(col, vals) {
+      calls.inFilters.push({ col, vals });
+      return this;
+    },
+    limit() { return this; },
+    update(payload) {
+      calls.updates.push({ payload, eq: null });
+      return {
+        eq(col, val) {
+          calls.updates[calls.updates.length - 1].eq = { col, val };
+          if (captureUpdate) captureUpdate({ payload, eq: { col, val } });
+          return Promise.resolve({ error: updateError });
+        }
+      };
+    },
+    async single() {
+      return overrides.payload || { data: null, error: null };
+    }
+  });
+
+  return {
+    _calls: calls,
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        // Two roles: lookupSdIdForFk uses .or().single() returning resolveRow;
+        // preflight's full-row load uses .eq('id', X).single() returning fullRow;
+        // autoFix writeback uses .update(...).eq('sd_key', X).
+        let lastWasOr = false;
+        return {
+          select() { return this; },
+          or(filter) {
+            calls.ors.push(filter);
+            lastWasOr = true;
+            return this;
+          },
+          eq(col, val) {
+            calls.eqs.push({ col, val });
+            lastWasOr = false;
+            return this;
+          },
+          update(payload) {
+            calls.updates.push({ payload, eq: null });
+            return {
+              eq(col, val) {
+                calls.updates[calls.updates.length - 1].eq = { col, val };
+                if (captureUpdate) captureUpdate({ payload, eq: { col, val } });
+                return Promise.resolve({ error: updateError });
+              }
+            };
+          },
+          async single() {
+            if (lastWasOr) {
+              return resolveRow || { data: null, error: { message: 'no row' } };
+            }
+            return fullRow || { data: null, error: null };
+          }
+        };
+      }
+      if (table === 'product_requirements_v2') {
+        return {
+          ...make({ payload: prdRow || { data: null, error: null } }),
+          eq(col, val) { calls.eqs.push({ col, val }); return this; }
+        };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select() { return this; },
+          eq(col, val) { calls.eqs.push({ col, val }); return this; },
+          in(col, vals) { calls.inFilters.push({ col, vals }); return this; },
+          limit() { return Promise.resolve(plan2leadRow || { data: [], error: null }); }
+        };
+      }
+      if (table === 'retrospectives') {
+        return {
+          select() { return this; },
+          eq(col, val) { calls.eqs.push({ col, val }); return this; },
+          limit() { return Promise.resolve(retroRow || { data: [], error: null }); }
+        };
+      }
+      if (table === 'user_stories') {
+        return {
+          select() { return this; },
+          eq(col, val) {
+            calls.eqs.push({ col, val });
+            return Promise.resolve({ data: [], error: null });
+          }
+        };
+      }
+      return make();
+    }
+  };
+}
+
+// A "complete" SD that satisfies all autoFix preconditions so we can assert on
+// the resolution path without preflight tripping on autoFix details.
+const COMPLETE_SD = {
+  id: 'SD-FOO-001',
+  sd_key: 'SD-FOO-001',
+  sd_type: 'infrastructure',
+  description: 'A '.repeat(120) + 'thorough description that exceeds the infrastructure minimum word count threshold so that DESCRIPTION_TOO_SHORT does not fire during these resolution tests.',
+  risks: [{ risk: 'r', mitigation: 'm' }],
+  key_principles: ['p1', 'p2'],
+  implementation_guidelines: ['g1'],
+  dependencies: [],
+  smoke_test_steps: [{ instruction: 'i', expected_outcome: 'e' }]
+};
+
+// =============================================================================
+// TS-1: sd_key resolves (legacy SDs where id == sd_key)
+// =============================================================================
+describe('TS-1: sd_key resolution still works', () => {
+  it('resolves sd_key input and proceeds to LEAD-TO-PLAN checks', async () => {
+    const supabase = makeSupabase({
+      resolveRow: { data: { id: 'SD-FOO-001', sd_key: 'SD-FOO-001' }, error: null },
+      fullRow: { data: COMPLETE_SD, error: null }
+    });
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', 'SD-FOO-001');
+    expect(result.issues.find(i => i.code === 'SD_NOT_FOUND')).toBeUndefined();
+    // lookupSdIdForFk used the OR filter
+    expect(supabase._calls.ors[0]).toContain('id.eq.SD-FOO-001');
+    expect(supabase._calls.ors[0]).toContain('sd_key.eq.SD-FOO-001');
+    // Then full-row select keyed on resolved id
+    expect(supabase._calls.eqs.some(e => e.col === 'id' && e.val === 'SD-FOO-001')).toBe(true);
+  });
+});
+
+// =============================================================================
+// TS-2: UUID id resolution (the regression case)
+// =============================================================================
+describe('TS-2: UUID-id resolution (the bug fix)', () => {
+  it('resolves a UUID-shaped legacy id and does not emit SD_NOT_FOUND', async () => {
+    const uuidId = 'db86fb73-b572-4a19-98d7-a1193c1299ed';
+    const sdRow = { ...COMPLETE_SD, id: uuidId, sd_key: 'SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001' };
+    const supabase = makeSupabase({
+      resolveRow: { data: { id: uuidId, sd_key: 'SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001' }, error: null },
+      fullRow: { data: sdRow, error: null }
+    });
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', uuidId);
+    expect(result.issues.find(i => i.code === 'SD_NOT_FOUND')).toBeUndefined();
+    expect(supabase._calls.ors[0]).toContain(`id.eq.${uuidId}`);
+    expect(supabase._calls.eqs.some(e => e.col === 'id' && e.val === uuidId)).toBe(true);
+  });
+});
+
+// =============================================================================
+// TS-3: both id and sd_key miss → SD_NOT_FOUND with refreshed remediation
+// =============================================================================
+describe('TS-3: true-miss error path', () => {
+  it('returns SD_NOT_FOUND when neither id nor sd_key matches', async () => {
+    const supabase = makeSupabase({
+      resolveRow: { data: null, error: { message: 'no row' } }
+    });
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', 'NOT-A-REAL-SD-9999');
+    expect(result.passed).toBe(false);
+    const miss = result.issues.find(i => i.code === 'SD_NOT_FOUND');
+    expect(miss).toBeDefined();
+    expect(miss.message).toContain('NOT-A-REAL-SD-9999');
+    expect(miss.remediation).toMatch(/id or sd_key/);
+  });
+});
+
+// =============================================================================
+// TS-4: PLAN-TO-EXEC dispatch via UUID id
+// =============================================================================
+describe('TS-4: PLAN-TO-EXEC reaches PRD/stories checks via UUID id', () => {
+  it('dispatches to checkPlanToExecPrereqs after id-keyed load', async () => {
+    const uuidId = 'fc41919c-3610-4a26-a143-caf06c9d0a80';
+    const sdRow = { ...COMPLETE_SD, id: uuidId, sd_key: 'SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001' };
+    const supabase = makeSupabase({
+      resolveRow: { data: { id: uuidId, sd_key: 'SD-LEO-INFRA-HANDOFF-MERGE-MAIN-001' }, error: null },
+      fullRow: { data: sdRow, error: null },
+      prdRow: { data: null, error: null }
+    });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-EXEC', uuidId);
+    expect(result.issues.find(i => i.code === 'SD_NOT_FOUND')).toBeUndefined();
+    // PLAN-TO-EXEC dispatch must reach the PRD check
+    expect(result.issues.some(i => i.code === 'PRD_MISSING')).toBe(true);
+  });
+});
+
+// =============================================================================
+// TS-5: autoFix UPDATE writeback after id-keyed load uses canonical sd_key
+// =============================================================================
+describe('TS-5: autoFix UPDATE keys on canonical sd_key, not the input identifier', () => {
+  it('writeback after UUID-id load targets the canonical sd_key', async () => {
+    const uuidId = 'db86fb73-b572-4a19-98d7-a1193c1299ed';
+    const canonicalKey = 'SD-LEO-INFRA-STAGE-ARCHETYPE-GENERATION-001';
+    // Incomplete SD: missing risks → autoFix triggers
+    const incomplete = {
+      id: uuidId,
+      sd_key: canonicalKey,
+      sd_type: 'infrastructure',
+      description: 'short',
+      risks: [],
+      key_principles: [],
+      implementation_guidelines: [],
+      dependencies: []
+    };
+    const captured = [];
+    const supabase = makeSupabase({
+      resolveRow: { data: { id: uuidId, sd_key: canonicalKey }, error: null },
+      fullRow: { data: incomplete, error: null },
+      captureUpdate: (e) => captured.push(e)
+    });
+    await runPrerequisitePreflight(supabase, 'LEAD-TO-PLAN', uuidId);
+    expect(captured.length).toBeGreaterThan(0);
+    // Every UPDATE must key on the canonical sd_key — not the UUID-id input
+    for (const c of captured) {
+      expect(c.eq.col).toBe('sd_key');
+      expect(c.eq.val).toBe(canonicalKey);
+      expect(c.eq.val).not.toBe(uuidId);
+    }
+  });
+});

--- a/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
@@ -72,6 +72,7 @@ describe('checkPlanToExecPrereqs USER_STORIES bypass behavior', () => {
         const builder = {
           select: () => builder,
           eq: () => builder,
+          or: () => builder,
           single: async () => {
             if (table === 'strategic_directives_v2') return { data: sdRow, error: null };
             if (table === 'product_requirements_v2') return { data: prdRow || null, error: null };
@@ -211,6 +212,7 @@ describe('QF-20260423-666: passed filters info-severity entries', () => {
         const builder = {
           select: () => builder,
           eq: () => builder,
+          or: () => builder,
           single: async () => {
             if (table === 'strategic_directives_v2') return { data: sdRow, error: null };
             if (table === 'product_requirements_v2') return { data: prdRow || null, error: null };


### PR DESCRIPTION
## Summary
- Replace sd_key-only SELECT in `prerequisite-preflight.js` with the PR #3367 `lookupSdIdForFk` helper, then full-row select keyed on the canonical id. Eliminates spurious `SD_NOT_FOUND` failures whenever callers pass a UUID-shaped legacy `id` instead of an `sd_key`.
- Closes 5/7 occurrences across PAT-RETRO-LEADTOPLAN-db86fb73 (4 occ) and PAT-HF-LEADTOPLAN-fc41919c (3 occ — the SD_NOT_FOUND subset). Remaining 2 (SMOKE_TEST_MISSING, DESCRIPTION_TOO_SHORT) are author-side gaps already covered by LEARN-108 — explicitly out of scope here per validation-agent reframe.
- 24 LOC source + 243 LOC tests. 5 new vitest cases (TS-1..TS-5) + 43/43 regression preserved across sibling suites.

## Why a structural fix, not a fingerprint fix
Validation-agent (sub_agent_execution_results 4fcd81d3-...) flagged that this SD's first authoring was a near-twin of cancelled SD-LEARN-FIX-ADDRESS-PAT-RETRO-004 (closed as ghost SD for the same db86fb73 fingerprint). LEAD reframed scope from "address two patterns" to "fix bimodal lookup defect in prerequisite-preflight", anchored to PR #3367 as precedent. The fingerprints were symptom; the structural defect (sd_key-only lookup that misses UUID-id rows) was the cause.

## Live smoke (already verified)
| Input | Form | Result |
|---|---|---|
| `db86fb73-b572-4a19-98d7-a1193c1299ed` | UUID id (legacy varchar) | passed=true, no SD_NOT_FOUND |
| `SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-134` | sd_key | passed=true, backward-compat preserved |
| `NOT-A-REAL-SD-9999` | true miss | passed=false, codes=[SD_NOT_FOUND] with refreshed remediation |

## Test plan
- [x] `prerequisite-preflight-bimodal-lookup.test.js`: 5/5 (sd_key resolves, UUID-id resolves, miss path, PLAN-TO-EXEC dispatch via UUID, autoFix UPDATE keys on canonical sd_key)
- [x] `prerequisite-preflight-prd-status.test.js`: 5/5 (regression)
- [x] `prerequisite-preflight-stories-exemption.test.js`: 21/21 (regression — sibling mock extended with `or` chain)
- [x] `auto-trigger-stories-fk-fix.test.js`: 17/17 (PR #3367 contract preserved)
- [x] Live smoke against UUID id, sd_key, and a true-miss identifier

## Handoff scores
- LEAD-TO-PLAN: 95
- PLAN-TO-EXEC: 97
- EXEC-TO-PLAN: 90
- PLAN-TO-LEAD: 92

## Sub-agent evidence
- VALIDATION (LEAD): WARNING — reframe required (4fcd81d3-...)
- DESIGN (PLAN): WARNING — DX text refinement folded in (4df2b926-...)
- DATABASE (PLAN): PASS conf=95 (b204a967-...)
- TESTING (EXEC): PASS conf=92 (c67a7ff6-...)
- RETRO (PLAN): PASS (99a9aaf9-...) → retrospective 8fe400bc-...

## Follow-up tracked in retrospective
- Audit other `.eq('sd_key', sdId)` sites for the same hazard class
- Extract `lookupSdIdForFk` from `auto-trigger-stories.mjs` to a shared `scripts/lib/sd-id-resolver.js` (recommended by validation-agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)