### PR TITLE
feat(SD-LEO-INFRA-VISION-FIDELITY-GATE-001): PR-2 vision-fidelity sub-agent + S18 case-study (FR-1/FR-5/FR-7)

### DIFF
--- a/lib/sub-agents/vision-fidelity/__tests__/agent.test.js
+++ b/lib/sub-agents/vision-fidelity/__tests__/agent.test.js
@@ -1,0 +1,160 @@
+/**
+ * vision-fidelity sub-agent tests — TS-1, TS-3, TS-4, TS-6, TS-7, TS-8 (FR-1).
+ * Severity policy (FR-3) + bypass-rubric (FR-4) live in policy.test.js.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { executeVisionFidelity } from '../index.js';
+
+function makeSD({ sdType = 'feature', visionKey = 'VISION-FIXTURE-001', archKey = null } = {}) {
+  return {
+    id: 'sd-uuid-fixture',
+    sd_key: 'SD-FIXTURE-001',
+    sd_type: sdType,
+    status: 'in_progress',
+    current_phase: 'PLAN_VERIFICATION',
+    metadata: visionKey
+      ? { vision_key: visionKey, arch_key: archKey, branch_name: 'feat/SD-FIXTURE-001' }
+      : { branch_name: 'feat/SD-FIXTURE-001' }
+  };
+}
+
+const VISION_DOC_FIXTURE = {
+  key: 'VISION-FIXTURE-001', title: 'Fixture vision', version: 1,
+  content: 'wireframe stub', extracted_dimensions: { dimensions: [] }, status: 'active'
+};
+const PRD_FIXTURE = {
+  id: 'prd-uuid', title: 'PRD Fixture',
+  acceptance_criteria: ['AC-1'], functional_requirements: [{ id: 'FR-1' }], test_scenarios: []
+};
+
+function makeSupabase({ sd, prd = null, visionDoc = null, archPlan = null, capture }) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return { select: () => ({ or: () => ({ maybeSingle: async () => ({ data: sd }) }) }) };
+      }
+      if (table === 'eva_vision_documents') {
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: visionDoc }) }) }) };
+      }
+      if (table === 'eva_architecture_plans') {
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: archPlan }) }) }) };
+      }
+      if (table === 'product_requirements_v2') {
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: prd }) }) }) };
+      }
+      if (table === 'sub_agent_execution_results') {
+        return { insert: async (row) => { capture.rows.push(row); return { data: null, error: null }; } };
+      }
+      return {};
+    }
+  };
+}
+
+const makeLlm = (response) => ({ complete: async () => ({ content: JSON.stringify(response) }) });
+const noopGit = () => '+ stub diff';
+
+describe('vision-fidelity sub-agent (FR-1)', () => {
+  it('TS-1 happy path: feature SD with all 9 delivered → PASS, vision_coverage_pct=1.0', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD();
+    const supabase = makeSupabase({ sd, prd: PRD_FIXTURE, visionDoc: VISION_DOC_FIXTURE, capture });
+    const llm = makeLlm({
+      delivered_elements: Array.from({ length: 9 }, (_, i) => ({ element: `el-${i}`, severity: 'critical', source_section: 's', evidence: 'shipped' })),
+      partial_elements: [], missing_elements: [], scope_creep_elements: []
+    });
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, llmClient: llm, gitDiffFn: noopGit });
+
+    expect(r.verdict).toBe('PASS');
+    expect(r.passed).toBe(true);
+    expect(r.details.vision_coverage_pct).toBe(1);
+    expect(r.details.delivered_count).toBe(9);
+    expect(capture.rows).toHaveLength(1);
+    expect(capture.rows[0].verdict).toBe('PASS');
+    expect(capture.rows[0].sub_agent_code).toBe('VISION_FIDELITY');
+  });
+
+  it('TS-3 infrastructure SD with 8 missing → WARNING, passed=true (warn-only never blocks)', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD({ sdType: 'infrastructure' });
+    const supabase = makeSupabase({ sd, prd: PRD_FIXTURE, visionDoc: VISION_DOC_FIXTURE, capture });
+    const missing = Array.from({ length: 8 }, (_, i) => ({
+      element: `m-${i}`, severity: i < 5 ? 'critical' : 'normal', source_section: 'wireframe section'
+    }));
+    const llm = makeLlm({ delivered_elements: [], partial_elements: [], missing_elements: missing, scope_creep_elements: [] });
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, llmClient: llm, gitDiffFn: noopGit });
+
+    expect(r.passed).toBe(true);
+    expect(r.verdict).toBe('WARNING');
+    expect(r.warnings.filter(w => /vision missing/i.test(w))).toHaveLength(8);
+    expect(r.issues).toHaveLength(0);
+    expect(capture.rows[0].verdict).toBe('WARNING');
+  });
+
+  it('TS-4 documentation SD → skipped, no LLM call, no DB row', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD({ sdType: 'documentation' });
+    const supabase = makeSupabase({ sd, capture });
+    const llmCalled = vi.fn(async () => ({ content: '{}' }));
+    const llm = { complete: llmCalled };
+
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, llmClient: llm, gitDiffFn: noopGit });
+
+    expect(r.passed).toBe(true);
+    expect(r.details.skipped).toBe(true);
+    expect(r.details.reason).toMatch(/sd-type does not produce UI/);
+    expect(llmCalled).not.toHaveBeenCalled();
+    expect(capture.rows).toHaveLength(0);
+  });
+
+  it('TS-6 LLM timeout → fail-soft to PENDING with details.timeout=true', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD();
+    const supabase = makeSupabase({ sd, prd: PRD_FIXTURE, visionDoc: VISION_DOC_FIXTURE, capture });
+    const llm = { complete: () => new Promise(() => {}) }; // never resolves
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, llmClient: llm, gitDiffFn: noopGit, timeoutMs: 25 });
+
+    expect(r.passed).toBe(true);
+    expect(r.verdict).toBe('PENDING');
+    expect(r.details.timeout).toBe(true);
+    expect(r.warnings.some(w => /timed out/i.test(w))).toBe(true);
+    expect(capture.rows[0].verdict).toBe('PENDING');
+  });
+
+  it('TS-7 no vision_key → PENDING with skipped_reason=no_vision_key (DB row written)', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD({ visionKey: null });
+    const supabase = makeSupabase({ sd, capture });
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, gitDiffFn: noopGit });
+
+    expect(r.passed).toBe(true);
+    expect(r.verdict).toBe('PENDING');
+    expect(r.details.skipped_reason).toBe('no_vision_key');
+    expect(r.warnings.some(w => /no vision_key in sd metadata/i.test(w))).toBe(true);
+    expect(capture.rows).toHaveLength(1);
+    expect(capture.rows[0].verdict).toBe('PENDING');
+  });
+
+  it('TS-8 scope creep alone bumps PASS → WARNING and surfaces in warnings', async () => {
+    const capture = { rows: [] };
+    const sd = makeSD();
+    const supabase = makeSupabase({ sd, prd: PRD_FIXTURE, visionDoc: VISION_DOC_FIXTURE, capture });
+    const llm = makeLlm({
+      delivered_elements: Array.from({ length: 9 }, (_, i) => ({ element: `el-${i}`, severity: 'critical', source_section: 's' })),
+      partial_elements: [], missing_elements: [],
+      scope_creep_elements: [
+        { element: 'extra-feature-1', source_section: null, evidence: 'in PR but not vision' },
+        { element: 'extra-feature-2', source_section: null, evidence: 'in PR but not vision' },
+        { element: 'extra-feature-3', source_section: null, evidence: 'in PR but not vision' }
+      ]
+    });
+    const r = await executeVisionFidelity({ sdId: 'SD-FIXTURE-001', supabase, llmClient: llm, gitDiffFn: noopGit });
+
+    expect(r.verdict).toBe('WARNING');
+    expect(r.passed).toBe(true);
+    expect(r.warnings.filter(w => /scope-creep/.test(w))).toHaveLength(3);
+    expect(r.details.scope_creep_count).toBe(3);
+    expect(r.details.scope_creep_elements).toHaveLength(3);
+    expect(capture.rows[0].verdict).toBe('WARNING');
+  });
+});
+

--- a/lib/sub-agents/vision-fidelity/__tests__/s18-case-study.test.js
+++ b/lib/sub-agents/vision-fidelity/__tests__/s18-case-study.test.js
@@ -1,0 +1,90 @@
+/**
+ * vision-fidelity TS-2 — S18 case-study fixture (FR-7).
+ *
+ * Anchor: chairman_feedback 2026-04-27 "looks very generic" against
+ * SD-ACTIVATE-S18-MARKETING-COPY-ORCH-001 post-merge state. Hand-curated
+ * 8 missing elements (5 critical, 3 non-critical) per the database-agent
+ * grounding note in SD metadata.case_study_grounding_note. NO retro mining.
+ */
+import { describe, it, expect } from 'vitest';
+import { executeVisionFidelity } from '../index.js';
+
+// 8 chairman-identified items: 5 critical (UX-breaking), 3 non-critical (polish).
+const S18_CHAIRMAN_FIXTURE = {
+  delivered_elements: [],
+  partial_elements: [],
+  missing_elements: [
+    { element: 'Default progress counter showing 0/9 sections',                    severity: 'critical', source_section: 'wireframe header progress bar',   expected: 'Counter renders 0/9, not 0/0' },
+    { element: 'Upstream artifacts list (S15 brand, S16 archetype, S17 design)',  severity: 'critical', source_section: 'wireframe upstream-context panel',  expected: 'List shows 12 artifacts, not magic 0/12' },
+    { element: 'Per-section briefs and examples for each of the 9 sections',      severity: 'critical', source_section: 'wireframe section-card layout',     expected: 'Each card shows brief + example slots' },
+    { element: 'Section card layout rendering 9 distinct sections',               severity: 'critical', source_section: 'wireframe main canvas',             expected: 'Nine cards with copy editor surfaces' },
+    { element: 'Sticky-footer Approve button at bottom of stage',                 severity: 'critical', source_section: 'wireframe footer specification',    expected: 'Approve sticky-bottom, not inline' },
+    { element: 'Persona context block under header',                              severity: 'normal',   source_section: 'wireframe persona panel',           expected: 'Persona name + role, not bare dash' },
+    { element: 'Persona badges visible in empty state',                           severity: 'normal',   source_section: 'wireframe empty-state spec',        expected: 'Empty state surfaces persona context' },
+    { element: 'Generate Copy cost-estimate tooltip',                             severity: 'normal',   source_section: 'wireframe Generate button',         expected: 'Tooltip shows estimated tokens / $' }
+  ],
+  scope_creep_elements: []
+};
+
+function makeS18Supabase({ capture }) {
+  const sd = {
+    id: 's18-uuid', sd_key: 'SD-ACTIVATE-S18-FIXTURE', sd_type: 'feature',
+    status: 'in_progress', current_phase: 'PLAN_VERIFICATION',
+    metadata: { vision_key: 'VISION-S18-001', branch_name: 'feat/SD-ACTIVATE-S18-FIXTURE' }
+  };
+  const visionDoc = {
+    key: 'VISION-S18-001', title: 'S18 marketing-copy', version: 1,
+    content: 'wireframe text excerpt', extracted_dimensions: {}
+  };
+  const prd = {
+    id: 'prd-s18', title: 'PRD: S18 marketing-copy',
+    acceptance_criteria: ['AC-1', 'AC-2'], functional_requirements: [{ id: 'FR-1' }], test_scenarios: []
+  };
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') return { select: () => ({ or: () => ({ maybeSingle: async () => ({ data: sd }) }) }) };
+      if (table === 'eva_vision_documents')    return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: visionDoc }) }) }) };
+      if (table === 'eva_architecture_plans')  return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+      if (table === 'product_requirements_v2') return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: prd }) }) }) };
+      if (table === 'sub_agent_execution_results') {
+        return { insert: async (row) => { capture.rows.push(row); return { data: null, error: null }; } };
+      }
+      return {};
+    }
+  };
+}
+
+describe('TS-2 S18 case-study (FR-7)', () => {
+  it('feature SD with 8 chairman-identified missing elements → FAIL with split issues/warnings', async () => {
+    const capture = { rows: [] };
+    const supabase = makeS18Supabase({ capture });
+    const llm = { complete: async () => ({ content: JSON.stringify(S18_CHAIRMAN_FIXTURE) }) };
+
+    const startMs = Date.now();
+    const r = await executeVisionFidelity({
+      sdId: 'SD-ACTIVATE-S18-FIXTURE',
+      supabase, llmClient: llm,
+      gitDiffFn: () => '+ partial impl'
+    });
+    expect(Date.now() - startMs).toBeLessThan(2000);
+
+    expect(r.passed).toBe(false);
+    expect(r.verdict).toBe('FAIL');
+    expect(r.missing_elements).toHaveLength(8);
+    expect(r.issues.length).toBe(5);
+    expect(r.warnings.length).toBe(3);
+    expect(r.details.critical_missing).toBe(5);
+    expect(r.details.non_critical_missing).toBe(3);
+    expect(r.details.missing_count).toBe(8);
+
+    expect(capture.rows).toHaveLength(1);
+    expect(capture.rows[0].verdict).toBe('FAIL');
+    expect(capture.rows[0].sub_agent_code).toBe('VISION_FIDELITY');
+
+    // Each missing element must trace to a wireframe source_section (PRD AC-1 traceability).
+    for (const el of r.missing_elements) {
+      expect(typeof el.source_section).toBe('string');
+      expect(el.source_section.length).toBeGreaterThan(5);
+    }
+  });
+});

--- a/lib/sub-agents/vision-fidelity/index.js
+++ b/lib/sub-agents/vision-fidelity/index.js
@@ -1,0 +1,378 @@
+/**
+ * Vision-fidelity sub-agent.
+ * SD-LEO-INFRA-VISION-FIDELITY-GATE-001 FR-1.
+ *
+ * Compares an SD's source vision wireframe (eva_vision_documents +
+ * eva_architecture_plans extracted_dimensions) against the actual implementation
+ * (PRD acceptance_criteria + functional_requirements + git diff) using the
+ * validation LLM tier. Produces delivered/partial/missing/scope_creep tabulation.
+ *
+ * Consumed by:
+ *   - PLAN-TO-LEAD gate (PR-2: scripts/modules/handoff/executors/plan-to-lead/gates/vision-fidelity.js)
+ *   - Direct invocation for ad-hoc audits
+ */
+
+import { execFileSync } from 'child_process';
+import { getValidationClient } from '../../llm/client-factory.js';
+import { classifyOutcome, computeCoveragePct } from './severity-policy.js';
+
+export const SUB_AGENT_CODE = 'VISION_FIDELITY';
+export const SUB_AGENT_NAME = 'Vision Fidelity Sub-Agent';
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+const DIFF_MAX_BYTES = 200_000;
+
+/**
+ * @param {Object} args
+ * @param {string} args.sdId - SD UUID or sd_key
+ * @param {Object} args.supabase - service-role client
+ * @param {boolean} [args.dryRun] - skip DB insert
+ * @param {Object} [args.llmClient] - injectable for tests; defaults to getValidationClient()
+ * @param {Function} [args.gitDiffFn] - injectable for tests; defaults to readGitDiff
+ * @param {number} [args.timeoutMs] - LLM call timeout, default 90000
+ */
+export async function executeVisionFidelity(args = {}) {
+  const {
+    sdId,
+    supabase,
+    dryRun = false,
+    llmClient = null,
+    gitDiffFn = readGitDiff,
+    timeoutMs = DEFAULT_TIMEOUT_MS
+  } = args;
+
+  if (!sdId || !supabase) {
+    throw new Error('executeVisionFidelity requires {sdId, supabase}');
+  }
+
+  const sd = await loadSD(supabase, sdId);
+  if (!sd) {
+    return makeSkippedResult({ reason: `SD not found: ${sdId}`, dryRun });
+  }
+
+  const sdType = sd.sd_type;
+  const visionKey = sd.metadata?.vision_key || null;
+  const archKey = sd.metadata?.arch_key || null;
+  const branchName = sd.metadata?.branch_name || sd.metadata?.git_branch || null;
+
+  // sd_type policy=skip → no LLM call, no DB row written
+  const skipPolicy = classifyOutcome({ sdType, criticalMissing: 0, nonCriticalMissing: 0 });
+  if (skipPolicy.skipped) {
+    return finalizeResult({
+      supabase, sd,
+      verdict: 'PASS',
+      passed: true,
+      delivered: [], partial: [], missing: [], scopeCreep: [],
+      details: { skipped: true, reason: skipPolicy.reason, vision_key: visionKey, arch_key: archKey, sd_type: sdType },
+      warnings: [`Vision-fidelity skipped: ${skipPolicy.reason}`],
+      issues: [],
+      dryRun,
+      skipDbInsert: true
+    });
+  }
+
+  if (!visionKey) {
+    return finalizeResult({
+      supabase, sd,
+      verdict: 'PENDING',
+      passed: true,
+      delivered: [], partial: [], missing: [], scopeCreep: [],
+      details: { skipped: true, skipped_reason: 'no_vision_key', vision_key: null, arch_key: archKey, sd_type: sdType },
+      warnings: ['No vision_key in SD metadata — vision-fidelity comparison skipped'],
+      issues: [],
+      dryRun
+    });
+  }
+
+  const [visionDoc, archPlan, prd] = await Promise.all([
+    loadVisionDocument(supabase, visionKey),
+    archKey ? loadArchPlan(supabase, archKey) : Promise.resolve(null),
+    loadPRD(supabase, sd.id)
+  ]);
+
+  if (!visionDoc) {
+    return finalizeResult({
+      supabase, sd,
+      verdict: 'PENDING',
+      passed: true,
+      delivered: [], partial: [], missing: [], scopeCreep: [],
+      details: { vision_key: visionKey, arch_key: archKey, sd_type: sdType, missing_artifact: 'eva_vision_documents' },
+      warnings: [`vision_key ${visionKey} not found in eva_vision_documents — advisory pass`],
+      issues: [],
+      dryRun
+    });
+  }
+
+  let diffText = '';
+  try {
+    diffText = await Promise.resolve(gitDiffFn({ branchName, baseBranch: 'origin/main' }));
+  } catch (err) {
+    diffText = `[diff unavailable: ${err.message}]`;
+  }
+
+  const { systemPrompt, userPrompt } = buildPrompts({ sd, visionDoc, archPlan, prd, diffText });
+
+  const client = llmClient || getValidationClient();
+  let parsed;
+  try {
+    const raw = await callWithTimeout(client.complete(systemPrompt, userPrompt), timeoutMs);
+    parsed = parseAgentResponse(raw);
+  } catch (err) {
+    return finalizeResult({
+      supabase, sd,
+      verdict: 'PENDING',
+      passed: true,
+      delivered: [], partial: [], missing: [], scopeCreep: [],
+      details: { vision_key: visionKey, arch_key: archKey, sd_type: sdType, timeout: /timed out/i.test(err.message), error: err.message },
+      warnings: [`vision-fidelity agent ${/timed out/i.test(err.message) ? 'timed out' : 'failed'}: ${err.message} — advisory only`],
+      issues: [],
+      dryRun
+    });
+  }
+
+  const { delivered_elements, partial_elements, missing_elements, scope_creep_elements } = parsed;
+
+  const criticalMissing = missing_elements.filter(el => el.severity === 'critical' || el.critical === true).length;
+  const nonCriticalMissing = missing_elements.length - criticalMissing;
+
+  const outcome = classifyOutcome({ sdType, criticalMissing, nonCriticalMissing });
+
+  const totalElements = delivered_elements.length + partial_elements.length + missing_elements.length;
+  const visionCoveragePct = computeCoveragePct(delivered_elements.length, totalElements);
+
+  const issues = [];
+  const warnings = [];
+  if (outcome.mode === 'block' && !outcome.passed) {
+    for (const el of missing_elements) {
+      const target = (el.severity === 'critical' || el.critical) ? issues : warnings;
+      target.push(formatElementMessage(el, 'missing'));
+    }
+  } else if (outcome.mode === 'warn') {
+    for (const el of missing_elements) warnings.push(formatElementMessage(el, 'missing'));
+  } else if (outcome.mode === 'block' && outcome.verdict === 'CONDITIONAL_PASS') {
+    for (const el of missing_elements) warnings.push(formatElementMessage(el, 'missing'));
+  }
+  for (const el of partial_elements) warnings.push(formatElementMessage(el, 'partial'));
+
+  // Scope creep is informational unless it's the only signal — then bump PASS → WARNING.
+  for (const el of scope_creep_elements) {
+    warnings.push(`vision scope-creep: ${el.element}${el.source_section ? ` (not in ${el.source_section})` : ''}`);
+  }
+  let finalVerdict = outcome.verdict;
+  if (scope_creep_elements.length > 0 && finalVerdict === 'PASS') {
+    finalVerdict = 'WARNING';
+  }
+
+  return finalizeResult({
+    supabase, sd,
+    verdict: finalVerdict,
+    passed: outcome.passed,
+    delivered: delivered_elements,
+    partial: partial_elements,
+    missing: missing_elements,
+    scopeCreep: scope_creep_elements,
+    details: {
+      vision_key: visionKey,
+      arch_key: archKey,
+      sd_type: sdType,
+      delivered_count: delivered_elements.length,
+      partial_count: partial_elements.length,
+      missing_count: missing_elements.length,
+      critical_missing: criticalMissing,
+      non_critical_missing: nonCriticalMissing,
+      scope_creep_count: scope_creep_elements.length,
+      scope_creep_elements: scope_creep_elements,
+      total_elements: totalElements,
+      vision_coverage_pct: visionCoveragePct,
+      severity_mode: outcome.mode
+    },
+    warnings,
+    issues,
+    dryRun
+  });
+}
+
+async function loadSD(supabase, sdId) {
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, sd_type, status, current_phase, metadata')
+    .or(`id.eq.${sdId},sd_key.eq.${sdId}`)
+    .maybeSingle();
+  return data;
+}
+
+async function loadVisionDocument(supabase, visionKey) {
+  const { data } = await supabase
+    .from('eva_vision_documents')
+    .select('key, title, version, content, extracted_dimensions, status')
+    .eq('key', visionKey)
+    .maybeSingle();
+  return data;
+}
+
+async function loadArchPlan(supabase, archKey) {
+  const { data } = await supabase
+    .from('eva_architecture_plans')
+    .select('key, title, content, extracted_dimensions, vision_key')
+    .eq('key', archKey)
+    .maybeSingle();
+  return data;
+}
+
+async function loadPRD(supabase, sdId) {
+  const { data } = await supabase
+    .from('product_requirements_v2')
+    .select('id, title, functional_requirements, acceptance_criteria, test_scenarios')
+    .eq('sd_id', sdId)
+    .maybeSingle();
+  return data;
+}
+
+export function readGitDiff({ branchName, baseBranch = 'origin/main' }) {
+  if (!branchName) return '[no branch_name in SD metadata]';
+  try {
+    const out = execFileSync('git', ['diff', `${baseBranch}...${branchName}`, '--unified=0'], {
+      encoding: 'utf8',
+      maxBuffer: DIFF_MAX_BYTES * 4
+    });
+    return out.length > DIFF_MAX_BYTES ? out.slice(0, DIFF_MAX_BYTES) + '\n[truncated]' : out;
+  } catch (err) {
+    return `[git diff failed: ${err.message}]`;
+  }
+}
+
+export function buildPrompts({ sd, visionDoc, archPlan, prd, diffText }) {
+  const systemPrompt = [
+    'You are the Vision-Fidelity sub-agent for the LEO Protocol.',
+    'You compare an SD\'s wireframe/architecture intent against the implemented PR.',
+    'Your output is strict JSON, no prose, no markdown fences.',
+    '',
+    'Schema:',
+    '{',
+    '  "delivered_elements": [{"element": string, "severity": "critical"|"normal", "source_section": string, "evidence": string}],',
+    '  "partial_elements":   [{"element": string, "severity": "critical"|"normal", "source_section": string, "gap": string}],',
+    '  "missing_elements":   [{"element": string, "severity": "critical"|"normal", "source_section": string, "expected": string}],',
+    '  "scope_creep_elements": [{"element": string, "source_section": string|null, "evidence": string}]',
+    '}',
+    '',
+    'Rules:',
+    '- An "element" is a discrete user-facing or contract-defining unit from the wireframe (button, count, list, card, badge, persona, banner, footer).',
+    '- "critical" = element is named or quantified in the wireframe and absence breaks the chairman-promised UX or audit-trail intent.',
+    '- "normal" = cosmetic, copy-only, or polish — absence is undesired but tolerable.',
+    '- "scope_creep" = present in implementation but NOT named in vision/arch/PRD.',
+    '- Do NOT invent elements. Cite source_section verbatim from the wireframe text when possible.',
+    '- If diff is truncated, base the comparison on PRD acceptance_criteria as evidence of delivery.'
+  ].join('\n');
+
+  const userPrompt = [
+    `SD: ${sd.sd_key} (sd_type=${sd.sd_type})`,
+    `Vision: ${visionDoc.key} v${visionDoc.version || '?'} — ${visionDoc.title || ''}`,
+    archPlan ? `Architecture: ${archPlan.key}` : 'Architecture: (none)',
+    '',
+    '=== VISION extracted_dimensions ===',
+    JSON.stringify(visionDoc.extracted_dimensions || {}, null, 2),
+    '',
+    '=== VISION content (truncated) ===',
+    truncate(visionDoc.content || '', 6000),
+    '',
+    archPlan ? '=== ARCH extracted_dimensions ===\n' + JSON.stringify(archPlan.extracted_dimensions || {}, null, 2) : '',
+    '',
+    '=== PRD acceptance_criteria ===',
+    JSON.stringify(prd?.acceptance_criteria || [], null, 2),
+    '',
+    '=== PRD functional_requirements ===',
+    JSON.stringify(prd?.functional_requirements || [], null, 2),
+    '',
+    '=== GIT DIFF (truncated) ===',
+    truncate(diffText || '', 8000),
+    '',
+    'Return the JSON object. No prose.'
+  ].filter(Boolean).join('\n');
+
+  return { systemPrompt, userPrompt };
+}
+
+export function parseAgentResponse(raw) {
+  let text = typeof raw === 'string' ? raw : (raw?.content ?? raw?.text ?? '');
+  if (typeof text !== 'string') text = JSON.stringify(text);
+  text = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  const parsed = JSON.parse(text);
+  return {
+    delivered_elements:   asArray(parsed.delivered_elements),
+    partial_elements:     asArray(parsed.partial_elements),
+    missing_elements:     asArray(parsed.missing_elements),
+    scope_creep_elements: asArray(parsed.scope_creep_elements)
+  };
+}
+
+function asArray(x) { return Array.isArray(x) ? x : []; }
+
+function truncate(s, n) {
+  if (typeof s !== 'string') return '';
+  return s.length > n ? s.slice(0, n) + '\n[truncated]' : s;
+}
+
+function formatElementMessage(el, kind) {
+  const sev = el.severity === 'critical' || el.critical ? '[critical] ' : '';
+  const where = el.source_section ? ` (${el.source_section})` : '';
+  return `${sev}vision ${kind}: ${el.element}${where}`;
+}
+
+function callWithTimeout(promise, ms) {
+  return Promise.race([
+    Promise.resolve(promise),
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`vision-fidelity LLM call timed out after ${ms}ms`)), ms))
+  ]);
+}
+
+async function finalizeResult({ supabase, sd, verdict, passed, delivered, partial, missing, scopeCreep, details, warnings, issues, dryRun, skipDbInsert = false }) {
+  const result = {
+    verdict,
+    passed,
+    sd_id: sd.id,
+    sd_key: sd.sd_key,
+    delivered_elements: delivered,
+    partial_elements: partial,
+    missing_elements: missing,
+    scope_creep_elements: scopeCreep,
+    issues,
+    warnings,
+    details
+  };
+
+  if (dryRun || skipDbInsert) return result;
+
+  const insertRow = {
+    sd_id: sd.id,
+    sub_agent_code: SUB_AGENT_CODE,
+    sub_agent_name: SUB_AGENT_NAME,
+    verdict,
+    confidence: 100,
+    critical_issues: issues,
+    warnings,
+    recommendations: [],
+    detailed_analysis: { delivered, partial, missing, scope_creep: scopeCreep },
+    metadata: details,
+    phase: 'PLAN_VERIFICATION',
+    source: 'vision-fidelity-sub-agent'
+  };
+
+  try {
+    await supabase.from('sub_agent_execution_results').insert(insertRow);
+  } catch (err) {
+    result.warnings = [...warnings, `failed to persist sub_agent_execution_results: ${err.message}`];
+  }
+
+  return result;
+}
+
+function makeSkippedResult({ reason }) {
+  return {
+    verdict: 'PASS',
+    passed: true,
+    delivered_elements: [], partial_elements: [], missing_elements: [], scope_creep_elements: [],
+    issues: [], warnings: [reason], details: { skipped: true, reason }
+  };
+}
+
+export default { executeVisionFidelity, SUB_AGENT_CODE, SUB_AGENT_NAME };


### PR DESCRIPTION
## Summary

PR-2 of 3 for **SD-LEO-INFRA-VISION-FIDELITY-GATE-001** (Vision-Fidelity Gate at PLAN-TO-LEAD).

Builds on **PR-1 #3391** (severity-tier policy + bypass-rubric mod, merged) by shipping the **vision-fidelity sub-agent module** + its **comprehensive test suite** + the **canonical S18 case-study fixture**.

## What's in this PR

### \`lib/sub-agents/vision-fidelity/index.js\` (FR-1 + FR-5)

Exports \`executeVisionFidelity({sdId, supabase, dryRun, llmClient, gitDiffFn, timeoutMs})\`. The function:

1. Loads SD metadata (\`vision_key\`, \`arch_key\`, \`branch_name\`) and short-circuits per the FR-3 severity policy (PR-1's \`severity-policy.js\`):
   - \`sd_type=documentation\`/\`refactor\` → skip entirely (no LLM call, no DB row)
   - \`vision_key\` missing → \`PENDING\` with \`details.skipped_reason='no_vision_key'\` (DB row written for traceability)
2. Loads \`eva_vision_documents\` (by \`vision_key\`), \`eva_architecture_plans\` (by \`arch_key\`), the PRD (\`acceptance_criteria\` + \`functional_requirements\`), and the SD branch \`git diff\`
3. Builds a strict-JSON-output prompt for \`getValidationClient().complete()\`
4. Parses the LLM response into \`{delivered_elements, partial_elements, missing_elements, scope_creep_elements}\`
5. Applies the FR-3 severity policy (passing element counts through \`classifyOutcome\`)
6. Bumps \`PASS → WARNING\` when scope-creep is the only signal
7. **Persists to \`sub_agent_execution_results\`** with \`sub_agent_code='VISION_FIDELITY'\`, valid verdict from the documented enum (per memory \`reference_sub_agent_execution_results_valid_verdicts\` — never \`PASS_WITH_NOTES\`), \`metadata\` populated with \`{delivered_count, partial_count, missing_count, scope_creep_count, scope_creep_elements, total_elements, vision_coverage_pct, severity_mode, vision_key, arch_key, sd_type}\` (FR-5)
8. Fail-soft on LLM timeout (default 90s) → returns \`verdict='PENDING'\` with \`details.timeout=true\`

Injectable seams (\`llmClient\`, \`gitDiffFn\`, \`timeoutMs\`) keep the test suite hermetic — no real-network LLM calls in CI.

### \`lib/sub-agents/vision-fidelity/__tests__/agent.test.js\` (FR-1)

6 vitest scenarios — one per acceptance scenario in the PRD:

| Scenario | Given | Then |
|---|---|---|
| **TS-1** | feature SD, all 9 wireframe sections delivered | \`PASS\`, \`vision_coverage_pct=1.0\`, DB row written |
| **TS-3** | infrastructure SD with 8 missing | \`WARNING\` (warn-only never blocks), DB row \`verdict=WARNING\` |
| **TS-4** | documentation SD | skipped, no LLM call, no DB row |
| **TS-6** | LLM never resolves (timeout @ 25ms in test) | \`PENDING\`, \`details.timeout=true\`, advisory pass |
| **TS-7** | feature SD, no \`vision_key\` in metadata | \`PENDING\`, \`details.skipped_reason='no_vision_key'\`, DB row written |
| **TS-8** | scope_creep=3 only (no missing) | \`WARNING\`, scope-creep elements surfaced in warnings + metadata |

### \`lib/sub-agents/vision-fidelity/__tests__/s18-case-study.test.js\` (FR-7)

TS-2 — the canonical case-study test. Synthetic SD mimicking \`SD-ACTIVATE-S18-MARKETING-COPY-ORCH-001\` post-merge state. Mock LLM returns the **8 chairman-identified missing elements** (5 critical, 3 non-critical) hand-curated from the database-agent grounding note in this SD's metadata (chairman_feedback 2026-04-27 \"looks very generic\" — NOT retro mining per FR-7 spec).

Asserts: \`passed=false\`, \`verdict=FAIL\`, \`missing_elements.length===8\`, \`issues.length===5\` (critical), \`warnings.length===3\` (non-critical), each missing element has a non-empty \`source_section\` traceable to wireframe text. Test runs in <2 seconds (assertion guards against future regression).

## Test Plan

- [x] \`npx vitest run lib/sub-agents/vision-fidelity/__tests__/\` → **7/7 passing in 327ms**
- [x] ESLint clean
- [x] No new dependencies added (uses \`child_process.execFileSync\` for git diff vs adding \`simple-git\`)
- [x] PR-1's severity-policy.js consumed correctly (severity classification cross-validated by PR-1's policy.test.js + this PR's behavioral tests)
- [x] No real-network LLM calls in CI (LLM client is injectable; default \`getValidationClient()\` only used in production path)

## PR-2 Size Justification (over 400 LOC cap)

**628 LOC total** (378 impl + 250 tests). Per CLAUDE_CORE.md \"Over 400 lines: Generally prohibited\":

1. **Cohesion** — Sub-agent module + its test suite are a single proof-of-correctness unit per FR-1/FR-7 acceptance. Splitting tests from impl creates an unverified intermediate state where the new module ships without behavioral verification.
2. **Test surface is structurally large** — FR-7 requires the immutable S18 chairman-feedback fixture (~70 LOC of structured element data, hand-curated from chairman_feedback 2026-04-27 per database-agent grounding note). FR-1 requires 6 distinct scenarios (TS-1, 3, 4, 6, 7, 8) each with its own supabase + LLM mock setup.
3. **Memory \`feedback_loc_estimate_undershoots_tier_threshold\`** — the PRD's original 570 LOC estimate for this bundle was already a known undershoot pattern. Realized 628 LOC is consistent with the predicted 2-2.5× drift.
4. **No further safe split** — extracting prompts/git-diff helpers to separate files would only spread LOC across more files in the same PR (no actual reduction). Splitting tests-only into a follow-up PR (\"PR-2b\") creates a window where main has untested code.

This is the smallest PR that delivers verified FR-1 + FR-5 + FR-7.

## Next: PR-3

PR-3 will ship: \`scripts/modules/handoff/executors/plan-to-lead/gates/vision-fidelity.js\` (gate factory) + gate test + \`gates/index.js\` wire-up + \`scripts/queries/vision-coverage-trend.sql\` (FR-6) + \`docs/reference/vision-fidelity-gate.md\` operator guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)