### PR TITLE
fix(SD-LEO-INFRA-VISION-FIDELITY-GATE-001): wire VISION_FIDELITY_GATE into PLAN-TO-LEAD executor

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -44,7 +44,9 @@ import {
   createFailureChainOrderingGate,
   // Semantic Validation Gates (SD-LEO-FEAT-SEMANTIC-VALIDATION-GATES-002)
   createScopeAuditGate,
-  createChildScopeCoverageGate
+  createChildScopeCoverageGate,
+  // Vision Fidelity Gate (SD-LEO-INFRA-VISION-FIDELITY-GATE-001 FR-2)
+  createVisionFidelityGate
 } from './gates/index.js';
 // Note: requiresTraceabilityGates is re-exported via 'export * from ./gates/index.js'
 
@@ -299,6 +301,14 @@ export class PlanToLeadExecutor extends BaseExecutor {
 
     // Architecture plan validation (advisory — checks dimension coverage)
     gates.push(createArchitecturePlanValidationGate(this.supabase));
+
+    // Vision Fidelity Gate (SD-LEO-INFRA-VISION-FIDELITY-GATE-001 FR-2)
+    // LLM-driven element-level wireframe vs implementation comparison.
+    // Severity-tier policy per sd_type — see lib/sub-agents/vision-fidelity/severity-policy.js.
+    // Skips for documentation/refactor; warn-only for infrastructure; blocks feature/bugfix
+    // when critical_missing > 2 (or mixed: critical>1 AND non_critical>5).
+    // Fail-soft: missing vision_key, sub-agent throw, or LLM timeout → advisory pass.
+    gates.push(createVisionFidelityGate(this.supabase));
 
     // Smoke Test Evidence gate (blocking for pipeline SDs)
     // Prevents architecture plans from missing runtime observation of the actual failure.


### PR DESCRIPTION
## Summary

**PR-4 follow-up** for **SD-LEO-INFRA-VISION-FIDELITY-GATE-001**. Closes the AC-2 gap that PR-3 #3393 left.

## What was missing

PR-3 shipped:
- The gate factory (\`scripts/modules/handoff/executors/plan-to-lead/gates/vision-fidelity.js\`)
- The gate's test suite (9 vitest cases passing)
- The barrel-export from \`gates/index.js\` (\`export { createVisionFidelityGate }\`)
- The operator guide + trend query

But missed: the actual \`gates.push(createVisionFidelityGate(this.supabase))\` call inside \`PlanToLeadExecutor\` at \`scripts/modules/handoff/executors/plan-to-lead/index.js\`. Without that, the gate is *reachable* as an import but never *runs* in the precheck/execute pipeline.

AC-2 reads: \"VISION_FIDELITY_GATE is registered in scripts/modules/handoff/executors/plan-to-lead/gates/index.js **and runs** as part of \`node scripts/handoff.js precheck PLAN-TO-LEAD <SD-ID>\` output.\" Export-only satisfies the first half; this PR satisfies the second.

## How surfaced

VALIDATION sub-agent (\`sub_agent_execution_results\` row \`cd2e1290-6326-4518-9130-92d127311cc8\`, verdict=\`PASS\` confidence=95) flagged it during PLAN_VERIFICATION as an \"ordering observation\":

> createVisionFidelityGate is exported via gates/index.js:36 but **not yet registered** in the plan-to-lead executor's gate array — separate wiring follow-up, not an overlap concern.

## Patch

| Change | Location | LOC |
|---|---|---|
| Import \`createVisionFidelityGate\` | \`plan-to-lead/index.js:47\` | +3 |
| \`gates.push(createVisionFidelityGate(this.supabase))\` w/ inline comment | \`plan-to-lead/index.js:~304\` | +8 |
| **Total** | | **+11/-1** |

Inline comment explains the severity-tier policy (block / warn / skip per \`sd_type\`) and fail-soft branches (missing \`vision_key\`, sub-agent throw, LLM timeout → advisory pass) so future maintainers see the gate's behavior at the registration site.

## Test Plan

- [x] Module load smoke test: \`import('scripts/modules/handoff/executors/plan-to-lead/index.js')\` resolves without error
- [x] ESLint clean on the diff (pre-existing \`sdId\` unused-arg warning at line 103 is unrelated to this patch — same on \`main\`)
- [x] Diff is +11/-1, single-file, zero new dependencies
- [ ] Live precheck against any feature SD will exercise the gate at runtime — deferred to operator workflow (this SD itself has no \`vision_key\` so the meta-recursive PLAN-TO-LEAD precheck will hit the \`PENDING\` skip path per TS-7, by design)

## Why a follow-up PR vs amending PR-3

PR-3 was already merged when VALIDATION surfaced the gap. Amending a merged PR would force-push and is generally prohibited per CLAUDE.md. A small follow-up PR is the safer pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)