### PR TITLE
feat(SD-EHG-AI-GEN-GUARDRAILS-001): Sub-PR #4c — Seam B postGenerationHook for Stage 18

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
@@ -2,6 +2,8 @@
  * Stage 18 Analysis Step — Marketing Copy Studio
  * Phase: BUILD & MARKET (Stages 18-22)
  * SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-B
+ *      + SD-EHG-AI-GEN-GUARDRAILS-001 (Seam B / Sub-PR #4c — adds
+ *        postGenerationHook for downstream guardrails wiring)
  *
  * Reads 12 upstream venture artifacts and generates persona-targeted
  * marketing copy across 9 sections via LLM.
@@ -11,6 +13,35 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+
+/**
+ * Default no-op hook. The EHG repo's lib/ai-guardrails/ orchestrator
+ * (SD-EHG-AI-GEN-GUARDRAILS-001) is wired in via params.postGenerationHook
+ * by the EVA stage runner once feature flag AI_GUARDRAILS_ENABLED is on.
+ *
+ * Hook contract: receives { content, ventureName, ventureId, sourceCandidates? }
+ * and returns { content, violations: [], blockedBy?: string }. Default
+ * passes content through unchanged with zero violations — preserves
+ * pre-guardrails behavior exactly.
+ *
+ * Stage 22/26 marketing surfaces inherit this seam by referencing the
+ * same hook injection pattern.
+ *
+ * @typedef {Object} PostGenerationHookInput
+ * @property {Object}   content           — generated copy output (COPY_SECTIONS keys)
+ * @property {string=}  ventureName
+ * @property {string=}  ventureId
+ * @property {Array=}   sourceCandidates  — for citation builder grounding
+ *
+ * @typedef {Object} PostGenerationHookResult
+ * @property {Object}   content           — possibly redacted/transformed content
+ * @property {Array}    violations        — guardrail Violation[] (see EHG repo)
+ * @property {string=}  blockedBy         — guardrail layer name if blocked
+ */
+export const noopPostGenerationHook = async (input) => ({
+  content: input.content,
+  violations: [],
+});
 
 const COPY_SECTIONS = [
   'tagline', 'app_store_desc', 'landing_hero',
@@ -195,7 +226,9 @@ export async function analyzeStage18MarketingCopy(params) {
     stage10Data, stage11Data, stage12Data, stage13Data,
     stage15Data, stage16Data,
     ventureName,
+    ventureId,
     logger = console,
+    postGenerationHook = noopPostGenerationHook, // Seam B (SD-EHG-AI-GEN-GUARDRAILS-001)
   } = params;
 
   logger.info?.('[S18-MarketingCopy] Starting copy generation for', ventureName || 'unknown venture');
@@ -245,6 +278,32 @@ export async function analyzeStage18MarketingCopy(params) {
     copyOutput = buildFallbackCopy(ventureName, upstreamByType);
   }
 
+  // Seam B (SD-EHG-AI-GEN-GUARDRAILS-001 / Sub-PR #4c) — invoke guardrails
+  // hook BEFORE persona-coverage validation so violations + redactions are
+  // reflected in downstream metrics. Default hook is no-op.
+  let guardrailViolations = [];
+  let guardrailBlockedBy;
+  try {
+    const hookResult = await postGenerationHook({
+      content: copyOutput,
+      ventureName,
+      ventureId,
+      sourceCandidates: undefined, // wired in Sub-PR #8 audit-trail integration
+    });
+    if (hookResult && hookResult.content) {
+      copyOutput = hookResult.content;
+    }
+    if (hookResult && Array.isArray(hookResult.violations)) {
+      guardrailViolations = hookResult.violations;
+    }
+    if (hookResult && hookResult.blockedBy) {
+      guardrailBlockedBy = hookResult.blockedBy;
+    }
+  } catch (hookErr) {
+    // Partial-audit semantics — hook failure must not abort copy generation.
+    logger.warn?.('[S18-MarketingCopy] postGenerationHook threw:', hookErr?.message || hookErr);
+  }
+
   // Validate persona coverage
   const personaName = extractPersonaName(upstreamByType);
   const personaCoverage = personaName ? checkPersonaCoverage(copyOutput, personaName) : { covered: 0, total: COPY_SECTIONS.length, pct: 0 };
@@ -259,11 +318,14 @@ export async function analyzeStage18MarketingCopy(params) {
       persona_name: personaName,
       persona_coverage: personaCoverage,
       venture_name: ventureName,
+      guardrail_violations: guardrailViolations,
+      guardrail_blocked_by: guardrailBlockedBy,
     },
     totalSections: COPY_SECTIONS.length,
     completedSections: COPY_SECTIONS.filter(s => copyOutput[s]).length,
     personaCoveragePct: personaCoverage.pct,
     llmFallbackCount,
+    guardrailViolationCount: guardrailViolations.length,
     usage,
   };
 
@@ -313,3 +375,7 @@ function buildFallbackCopy(ventureName, upstreamByType) {
 }
 
 export { COPY_SECTIONS, UPSTREAM_ARTIFACT_TYPES };
+
+// Re-export so downstream stages (Stage22/Stage26 marketing surfaces) can
+// import the same default when wiring their seams later.
+export { noopPostGenerationHook as defaultPostGenerationHook };

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-18-marketing-copy-seam.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-18-marketing-copy-seam.test.js
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for Stage 18 Marketing Copy — Seam B (postGenerationHook).
+ * SD-EHG-AI-GEN-GUARDRAILS-001 / Sub-PR #4c
+ *
+ * Verifies the integration seam through which the EHG repo's
+ * lib/ai-guardrails/ orchestrator is invoked. The seam itself does NOT
+ * import EHG code — that's the EVA stage runner's job to inject.
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-18-marketing-copy-seam.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const validCopy = {
+  tagline: { text: 'Original tagline', persona_target: 'Builder' },
+  app_store_desc: { text: 'desc', persona_target: 'Builder' },
+  landing_hero: { headline: 'Original headline', subheadline: 'sub', cta_text: 'Go', persona_target: 'Builder' },
+  email_welcome: { subject: 's', body: 'b', persona_target: 'Builder' },
+  email_onboarding: { subject: 's', body: 'b', persona_target: 'Builder' },
+  email_reengagement: { subject: 's', body: 'b', persona_target: 'Builder' },
+  social_posts: { twitter: 't', linkedin: 'l', instagram: 'i', facebook: 'f', product_hunt: 'p', persona_target: 'Builder' },
+  seo_meta: { title: 't', description: 'd', keywords: ['k'], persona_target: 'Builder' },
+  blog_draft: { title: 't', intro: 'i', sections: ['a'], conclusion: 'c', persona_target: 'Builder' },
+};
+
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(async () => JSON.stringify(validCopy)),
+  })),
+}));
+
+vi.mock('../../../../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: vi.fn((x) => (typeof x === 'string' ? JSON.parse(x) : x)),
+  extractUsage: vi.fn(() => ({ tokens: 100 })),
+}));
+
+import {
+  analyzeStage18MarketingCopy,
+  noopPostGenerationHook,
+  defaultPostGenerationHook,
+} from '../../../../../lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js';
+
+const baseParams = () => ({
+  ventureName: 'Acme',
+  ventureId: 'ven-001',
+  stage10Data: { primary_persona: { name: 'Builder' } },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+});
+
+describe('stage-18 Seam B / noopPostGenerationHook', () => {
+  it('passes content through unchanged with zero violations', async () => {
+    const r = await noopPostGenerationHook({ content: validCopy });
+    expect(r.content).toBe(validCopy);
+    expect(r.violations).toEqual([]);
+  });
+
+  it('is exported as defaultPostGenerationHook alias', () => {
+    expect(defaultPostGenerationHook).toBe(noopPostGenerationHook);
+  });
+});
+
+describe('stage-18 Seam B / analyzeStage18MarketingCopy hook integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('default behavior (no hook) emits zero guardrail violations', async () => {
+    const result = await analyzeStage18MarketingCopy(baseParams());
+    expect(result.metadata.guardrail_violations).toEqual([]);
+    expect(result.metadata.guardrail_blocked_by).toBeUndefined();
+    expect(result.guardrailViolationCount).toBe(0);
+  });
+
+  it('invokes injected postGenerationHook with content + ventureName + ventureId', async () => {
+    const hook = vi.fn(async (input) => ({ content: input.content, violations: [] }));
+    await analyzeStage18MarketingCopy({ ...baseParams(), postGenerationHook: hook });
+    expect(hook).toHaveBeenCalledTimes(1);
+    const callArg = hook.mock.calls[0][0];
+    expect(callArg.ventureName).toBe('Acme');
+    expect(callArg.ventureId).toBe('ven-001');
+    expect(callArg.content).toBeDefined();
+    expect(callArg.content.tagline).toBeDefined();
+  });
+
+  it('propagates violations from hook into result.metadata', async () => {
+    const hook = async (input) => ({
+      content: input.content,
+      violations: [
+        { layer: 'pii', severity: 'warning', metadata: { token_type: 'email' } },
+        { layer: 'claim', severity: 'error', metadata: { category: 'medical' } },
+      ],
+    });
+    const result = await analyzeStage18MarketingCopy({ ...baseParams(), postGenerationHook: hook });
+    expect(result.metadata.guardrail_violations).toHaveLength(2);
+    expect(result.guardrailViolationCount).toBe(2);
+  });
+
+  it('propagates blockedBy when hook flags a layer', async () => {
+    const hook = async (input) => ({
+      content: input.content,
+      violations: [{ layer: 'claim', severity: 'error', metadata: {} }],
+      blockedBy: 'claim',
+    });
+    const result = await analyzeStage18MarketingCopy({ ...baseParams(), postGenerationHook: hook });
+    expect(result.metadata.guardrail_blocked_by).toBe('claim');
+  });
+
+  it('replaces copyOutput when hook returns transformed content (PII redaction case)', async () => {
+    const redacted = { ...validCopy, tagline: { text: '[REDACTED:EMAIL] tagline', persona_target: 'Builder' } };
+    const hook = async () => ({ content: redacted, violations: [] });
+    const result = await analyzeStage18MarketingCopy({ ...baseParams(), postGenerationHook: hook });
+    expect(result.tagline.text).toContain('[REDACTED:EMAIL]');
+  });
+
+  it('partial-audit semantics: hook exception does NOT abort generation', async () => {
+    const params = baseParams();
+    const hook = async () => {
+      throw new Error('orchestrator unreachable');
+    };
+    const result = await analyzeStage18MarketingCopy({ ...params, postGenerationHook: hook });
+    expect(result).toBeDefined();
+    expect(result.tagline).toBeDefined();
+    expect(result.metadata.guardrail_violations).toEqual([]);
+    expect(params.logger.warn).toHaveBeenCalled();
+  });
+
+  it('hook returning null does not corrupt result', async () => {
+    const hook = async () => null;
+    const result = await analyzeStage18MarketingCopy({ ...baseParams(), postGenerationHook: hook });
+    expect(result.tagline).toBeDefined();
+    expect(result.metadata.guardrail_violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Cross-repo follow-up to **rickfelix/ehg#543** (the main 5-commit guardrails stack). Adds the integration seam in `lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js` that the EHG repo's `lib/ai-guardrails/` orchestrator plugs into when feature flag `AI_GUARDRAILS_ENABLED` is on.

Per LEAD scope amendment A4: the EHG-side `Stage18MarketingCopy.tsx` already had a hook point (existing `checkCompliance()`); this EHG_Engineer-side template did NOT. This adds the missing seam without coupling EHG_Engineer to EHG code — injection happens at the EVA stage runner level.

## Linkage

- **SD**: SD-EHG-AI-GEN-GUARDRAILS-001
- **PRD**: PRD-SD-EHG-AI-GEN-GUARDRAILS-001 (`product_requirements_v2.id=4a71255f-1b63-4250-8033-dd38be27bde7` v1.1.1, FR-4c + scope amendment A4)

## Behavior change with default no-op hook

**Zero.** The default `noopPostGenerationHook` returns content unchanged with empty violations. Production behavior is bit-for-bit identical until a runner injects a real hook.

## Changes

- **`lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js`** (+66 LOC)
  - Export `noopPostGenerationHook` and `defaultPostGenerationHook` alias
  - Accept `params.postGenerationHook` (default no-op) + `params.ventureId`
  - Invoke hook AFTER LLM copy generation, BEFORE persona-coverage validation
  - Surface `guardrail_violations`, `guardrail_blocked_by` in `result.metadata`
  - Surface `guardrailViolationCount` at top level of result
  - Partial-audit semantics: hook exceptions caught + logged, generation continues (FR-6)

- **`tests/unit/eva/stage-templates/analysis-steps/stage-18-marketing-copy-seam.test.js`** (NEW, 124 LOC, 9 tests passing)
  - noop pass-through
  - hook invocation arg shape (content/ventureName/ventureId)
  - violation propagation
  - blockedBy propagation
  - content replacement (PII redaction case)
  - partial-audit on hook exception
  - null hook return tolerance

## Hook contract (JSDoc typedef inline)

```
Input  : { content, ventureName?, ventureId?, sourceCandidates? }
Output : { content, violations: [], blockedBy?: string }
```

## Test plan

- [x] `npx vitest run tests/unit/eva/stage-templates/analysis-steps/stage-18-marketing-copy-seam.test.js` — 9/9 passing
- [ ] Reviewer verifies the seam is at the right point in the function (after LLM, before persona-coverage)
- [ ] Reviewer confirms 66 LOC is in the ≤100 sweet spot

## Stage 22 / Stage 26 reuse

Re-exported as `defaultPostGenerationHook` so future Stage 22/Stage 26 marketing surfaces import the same default when wiring their own seams. Same shape; one runner injection step covers all three stages.

## Refs

- Companion PR: **rickfelix/ehg#543** (the 5-commit stack: DB migrations + 4 guardrail middleware layers + types regen + first GitHub Actions workflow)
- DB sub-agent evidence: `sub_agent_execution_results.id=b23d7632-aabf-4566-a8e6-0b9f135a201d`
- DESIGN sub-agent evidence: `sub_agent_execution_results.id=505810b4-e279-4b63-a7e3-591427895f79`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
