### PR TITLE
feat(SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001): SHIP_REVIEW_FINDINGS_PROOF gate + LEO protocol hardening

### DIFF
--- a/.github/workflows/phantom-completion-sweep.yml
+++ b/.github/workflows/phantom-completion-sweep.yml
@@ -1,0 +1,62 @@
+name: Phantom Completion Sweep
+
+on:
+  schedule:
+    # Daily at 09:00 UTC (after typical EU/US ship windows close)
+    - cron: '0 9 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  sweep:
+    name: Detect status=completed SDs lacking ship_review_findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Run phantom sweep
+        id: sweep
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -e
+          # Find completed code-shipping SDs missing ship_review_findings rows.
+          # Uses the same audit script SD-2 created (script gated by --apply, so
+          # this dry-run mode is safe to invoke nightly).
+          OUTPUT=$(node scripts/audit-phantom-completions.js --include-shipped 2>&1 || true)
+          echo "$OUTPUT"
+
+          # Detect any UNKNOWN/PHANTOM bucket entries that emerged since the
+          # 2026-04-28 baseline (SD-MAN-INFRA-RECONCILE-S18-S26-001 cleaned the
+          # original 12+ phantoms). Any new emergence indicates a gate bypass.
+          if echo "$OUTPUT" | grep -qE '^(PHANTOM_NO_FORWARDING|PHANTOM_WITH_FORWARDING|UNKNOWN) \([1-9]'; then
+            echo "phantom_detected=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Phantom Completion Detected"
+              echo ""
+              echo '```'
+              echo "$OUTPUT"
+              echo '```'
+            } > /tmp/issue-body.md
+          else
+            echo "phantom_detected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue on phantom detection
+        if: steps.sweep.outputs.phantom_detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Phantom completion suspected: $(date -u +%Y-%m-%d)" \
+            --label phantom-completion-suspected \
+            --body-file /tmp/issue-body.md

--- a/database/migrations/20260428_ship_review_findings_fk_and_merge_meta.sql
+++ b/database/migrations/20260428_ship_review_findings_fk_and_merge_meta.sql
@@ -1,0 +1,40 @@
+-- Migration: ship_review_findings FK + merge metadata columns
+-- SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001 (FR-6 / US-006)
+-- Date: 2026-04-28
+--
+-- Hardens ship_review_findings:
+--   1. Adds merged_at + merge_commit_sha columns for authoritative backfill metadata
+--      (sibling of synthesized_at from SD-MAN-INFRA-RECONCILE-S18-S26-001).
+--   2. Adds NOT VALID FK from sd_key → strategic_directives_v2(sd_key).
+--      NOT VALID preserves existing rows; future inserts/updates are validated.
+--      sd_key remains nullable since legacy rows may not have it set.
+--
+-- Idempotent: uses IF NOT EXISTS + checks for existing constraint name.
+
+ALTER TABLE ship_review_findings
+  ADD COLUMN IF NOT EXISTS merged_at TIMESTAMPTZ NULL;
+
+ALTER TABLE ship_review_findings
+  ADD COLUMN IF NOT EXISTS merge_commit_sha TEXT NULL;
+
+COMMENT ON COLUMN ship_review_findings.merged_at IS
+  'Timestamp of PR merge (from gh pr view --json mergedAt). Authoritative for backfill rows; may be NULL on real-time-logged rows from /ship Step 5.5.';
+
+COMMENT ON COLUMN ship_review_findings.merge_commit_sha IS
+  'SHA of the merge commit (from gh pr view --json mergeCommit.oid). Used by SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001 nightly cron to verify PRs are still merged on main.';
+
+-- Add FK as NOT VALID so existing rows are not retroactively checked.
+-- The constraint applies to new inserts and updates from this point forward.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ship_review_findings_sd_key_fkey'
+  ) THEN
+    ALTER TABLE ship_review_findings
+      ADD CONSTRAINT ship_review_findings_sd_key_fkey
+      FOREIGN KEY (sd_key) REFERENCES strategic_directives_v2(sd_key)
+      DEFERRABLE INITIALLY DEFERRED
+      NOT VALID;
+  END IF;
+END $$;

--- a/database/migrations/20260428_validation_gate_registry_lock.sql
+++ b/database/migrations/20260428_validation_gate_registry_lock.sql
@@ -1,0 +1,49 @@
+-- Migration: Lock validation_gate_registry against silent disables of protected gates
+-- SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001 (FR-3 / US-003)
+-- Date: 2026-04-28
+--
+-- Background: Without this trigger, any UPDATE on validation_gate_registry can
+-- set enabled=false on critical gates (PR_MERGE_VERIFICATION, the new
+-- SHIP_REVIEW_FINDINGS_PROOF), silently bypassing the entire phantom-completion
+-- protection. This trigger requires a documented disable_reason citing either
+-- a --pattern-id (issue_patterns row) OR --followup-sd-key (strategic_directives_v2
+-- row) — mirrors validateBypassShape's dual-key requirement.
+--
+-- Idempotent: uses CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS.
+
+CREATE OR REPLACE FUNCTION validation_gate_registry_lock_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+  protected_gates TEXT[] := ARRAY['PR_MERGE_VERIFICATION', 'SHIP_REVIEW_FINDINGS_PROOF'];
+  reason_text TEXT;
+  has_pattern_id BOOLEAN := FALSE;
+  has_followup_sd BOOLEAN := FALSE;
+BEGIN
+  -- Only fire when disabling a protected gate
+  IF NEW.gate_name = ANY(protected_gates) AND OLD.enabled = TRUE AND NEW.enabled = FALSE THEN
+    reason_text := COALESCE(NEW.metadata->>'disable_reason', '');
+
+    -- Require either --pattern-id <PAT-XXX> OR --followup-sd-key <SD-XXX> in the reason
+    has_pattern_id := reason_text ~ '--pattern-id\s+PAT-[A-Z0-9-]+';
+    has_followup_sd := reason_text ~ '--followup-sd-key\s+SD-[A-Z0-9-]+';
+
+    IF NOT (has_pattern_id OR has_followup_sd) THEN
+      RAISE EXCEPTION 'Cannot disable protected gate "%": metadata.disable_reason must include --pattern-id <PAT-XXX> or --followup-sd-key <SD-XXX>. Got: "%"',
+        NEW.gate_name, reason_text
+      USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_validation_gate_registry_lock ON validation_gate_registry;
+
+CREATE TRIGGER trigger_validation_gate_registry_lock
+  BEFORE UPDATE ON validation_gate_registry
+  FOR EACH ROW
+  EXECUTE FUNCTION validation_gate_registry_lock_trigger();
+
+COMMENT ON FUNCTION validation_gate_registry_lock_trigger() IS
+  'SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001: Rejects silent disables of PR_MERGE_VERIFICATION and SHIP_REVIEW_FINDINGS_PROOF without documented bypass justification.';

--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -125,43 +125,19 @@ export async function checkAndCompleteParentSD(sd, supabase, { shippingResults }
           await recordFailedCompletion(parentSD, 'Manual intervention required', report, supabase);
         }
       } catch (guardianError) {
-        console.log(`   ⚠️  Guardian unavailable: ${guardianError.message}`);
-        console.log('   📝 Attempting legacy completion (may fail if artifacts missing)...');
-
-        const { error } = await supabase
-          .from('strategic_directives_v2')
-          .update({
-            status: 'completed',
-            progress_percentage: 100,
-            current_phase: 'COMPLETED',
-            updated_at: new Date().toISOString()
-          })
-          .eq('id', parentSD.id);
-
-        if (error) {
-          console.log(`   ❌ Legacy completion FAILED: ${error.message}`);
-          console.log(`   💡 Run: node scripts/modules/orchestrator-completion-guardian.js ${parentSD.id} --auto-fix --complete`);
-          await recordFailedCompletion(parentSD, error.message, null, supabase);
-        } else {
-          console.log(`   ✅ Parent SD "${parentSD.title}" auto-completed (legacy path)`);
-
-          // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
-          // SD-LEO-ENH-AUTO-PROCEED-001-05: Returns chaining info if enabled
-          const hookResult = await executeOrchestratorCompletionHook(
-            parentSD.id,
-            parentSD.title,
-            siblings.length,
-            { supabase, shippingResults }
-          );
-
-          return {
-            orchestratorCompleted: true,
-            chainContinue: hookResult?.chainContinue || false,
-            nextOrchestrator: hookResult?.nextOrchestrator || null,
-            nextOrchestratorSdKey: hookResult?.nextOrchestratorSdKey || null
-          };
-        }
+        // SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001 (FR-2 / US-002): closed legacy
+        // direct-DB write path. Previously this catch silently UPDATEd status='completed'
+        // without running gates — the smoking gun that allowed SD-MAN-INFRA-S18-S26-DATA-001
+        // and other phantoms to ship. Guardian unavailability is a P0 — not permission
+        // to skip the gate chain.
+        console.log(`   ❌ Guardian unavailable: ${guardianError.message}`);
+        console.log(`   ❌ LEGACY DIRECT-DB COMPLETION PATH IS CLOSED (SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001).`);
+        console.log(`   💡 Required action: invoke RCA on Guardian failure, OR explicitly bypass via:`);
+        console.log(`      node scripts/modules/orchestrator-completion-guardian.js ${parentSD.id} --auto-fix --complete`);
+        await recordFailedCompletion(parentSD, `Guardian unavailable: ${guardianError.message}. Legacy fallback closed by SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001.`, null, supabase);
+        throw new Error(`PHANTOM_PROOF_LEGACY_PATH_CLOSED: Guardian failed for parent ${parentSD.id} (${parentSD.sd_key || 'no sd_key'}). Direct-DB status=completed write refused. Original error: ${guardianError.message}`);
       }
+
     }
   } catch (error) {
     console.log(`   ⚠️  Parent check error: ${error.message}`);

--- a/scripts/modules/handoff/gates/ship-review-findings-proof.js
+++ b/scripts/modules/handoff/gates/ship-review-findings-proof.js
@@ -1,0 +1,97 @@
+/**
+ * SHIP_REVIEW_FINDINGS_PROOF Gate
+ *
+ * Closes the structural defect that allowed 12+ S17-S26 phantom completions:
+ * SDs reaching status='completed' without verifiable merge evidence in
+ * ship_review_findings.
+ *
+ * Required for code-shipping SDs at LEAD-FINAL-APPROVAL. A PR merged with
+ * no ship_review_findings row is itself suspicious — /ship Step 5.5 is
+ * supposed to log every reviewed merge.
+ *
+ * SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001
+ * @module scripts/modules/handoff/gates/ship-review-findings-proof
+ */
+
+const CODE_SD_TYPES = new Set(['feature', 'bugfix', 'infrastructure']);
+
+/**
+ * Decide if this SD requires ship_review_findings proof.
+ * Code SDs: yes. Documentation/refactor/security overrides: per metadata.work_type.
+ */
+export function requiresShipReviewProof(sd) {
+  if (sd?.metadata?.no_pr_required === true) return false;
+  if (sd?.metadata?.work_type === 'code') return true;
+  if (CODE_SD_TYPES.has(sd?.sd_type)) return true;
+  return false;
+}
+
+/**
+ * Run the SHIP_REVIEW_FINDINGS_PROOF gate.
+ *
+ * @param {object} params
+ * @param {object} params.sd - Strategic Directive row (sd_key, sd_type, metadata)
+ * @param {object} params.supabase - Supabase client
+ * @returns {Promise<{passed: boolean, score: number, reason: string, evidence?: object[]}>}
+ */
+export async function runShipReviewFindingsProofGate({ sd, supabase }) {
+  if (!requiresShipReviewProof(sd)) {
+    return {
+      passed: true,
+      score: 100,
+      reason: 'SHIP_REVIEW_FINDINGS_PROOF: not applicable (no_pr_required or non-code SD type)',
+    };
+  }
+
+  const { data: rows, error } = await supabase
+    .from('ship_review_findings')
+    .select('id, pr_number, verdict, branch, synthesized_at, reviewed_at')
+    .eq('sd_key', sd.sd_key);
+
+  if (error) {
+    return {
+      passed: false,
+      score: 0,
+      reason: `SHIP_REVIEW_FINDINGS_PROOF: query failed (${error.message}) — fail-closed for safety`,
+    };
+  }
+
+  const passing = (rows || []).filter((r) => r.verdict === 'pass');
+
+  if (passing.length === 0) {
+    const total = rows?.length || 0;
+    return {
+      passed: false,
+      score: 0,
+      reason:
+        total === 0
+          ? `SHIP_REVIEW_FINDINGS_PROOF: no ship_review_findings row for sd_key=${sd.sd_key}. Was /ship invoked? Check Step 5.5 logged the merge review.`
+          : `SHIP_REVIEW_FINDINGS_PROOF: ${total} ship_review_findings row(s) exist for sd_key=${sd.sd_key} but none have verdict='pass'`,
+      evidence: rows,
+    };
+  }
+
+  return {
+    passed: true,
+    score: 100,
+    reason: `SHIP_REVIEW_FINDINGS_PROOF: ${passing.length} passing review(s) found for sd_key=${sd.sd_key}`,
+    evidence: passing.map((r) => ({
+      id: r.id,
+      pr_number: r.pr_number,
+      verdict: r.verdict,
+      synthesized: !!r.synthesized_at,
+    })),
+  };
+}
+
+export const SHIP_REVIEW_FINDINGS_PROOF_GATE = {
+  name: 'SHIP_REVIEW_FINDINGS_PROOF',
+  description:
+    'Verifies ship_review_findings row with verdict=pass exists for code-shipping SDs. ' +
+    'Required at LEAD-FINAL-APPROVAL. Companion to PR_MERGE_VERIFICATION — a merged PR ' +
+    'with no findings row is itself suspicious (Step 5.5 of /ship should log every review).',
+  required: true,
+  bypass_allowed: 'dual-key-only',
+  threshold: 70,
+  run: runShipReviewFindingsProofGate,
+};

--- a/tests/integration/ship-review-findings-proof-gate.test.js
+++ b/tests/integration/ship-review-findings-proof-gate.test.js
@@ -1,0 +1,118 @@
+/**
+ * tests/integration/ship-review-findings-proof-gate.test.js
+ *
+ * Regression test for SD-LEO-INFRA-PHANTOM-COMPLETION-PROOF-001.
+ *
+ * Asserts the new SHIP_REVIEW_FINDINGS_PROOF gate:
+ *   1. Fails closed for code-shipping SDs without ship_review_findings rows
+ *   2. Passes for SDs with verdict='pass' findings
+ *   3. Skips non-code SDs (no_pr_required + non-code sd_type)
+ *   4. Fails on query errors (fail-closed for safety)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runShipReviewFindingsProofGate,
+  requiresShipReviewProof,
+  SHIP_REVIEW_FINDINGS_PROOF_GATE,
+} from '../../scripts/modules/handoff/gates/ship-review-findings-proof.js';
+
+function fakeSupabase(rows, error = null) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => Promise.resolve({ data: rows, error }),
+      }),
+    }),
+  };
+}
+
+describe('SHIP_REVIEW_FINDINGS_PROOF gate', () => {
+  it('fails closed when no ship_review_findings row exists for code SD', async () => {
+    const sd = { sd_key: 'SD-TEST-001', sd_type: 'bugfix', metadata: { work_type: 'code' } };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase([]),
+    });
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toMatch(/no ship_review_findings row/);
+  });
+
+  it('passes when verdict=pass row exists', async () => {
+    const sd = { sd_key: 'SD-TEST-002', sd_type: 'feature', metadata: { work_type: 'code' } };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase([{ id: 'r1', pr_number: 100, verdict: 'pass' }]),
+    });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.evidence).toHaveLength(1);
+  });
+
+  it('fails when row exists but verdict=block', async () => {
+    const sd = { sd_key: 'SD-TEST-003', sd_type: 'bugfix', metadata: { work_type: 'code' } };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase([{ id: 'r1', pr_number: 100, verdict: 'block' }]),
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/none have verdict='pass'/);
+  });
+
+  it('skips when no_pr_required=true', async () => {
+    const sd = {
+      sd_key: 'SD-TEST-004',
+      sd_type: 'documentation',
+      metadata: { no_pr_required: true },
+    };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase([]),
+    });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.reason).toMatch(/not applicable/);
+  });
+
+  it('skips for non-code sd_type without work_type override', async () => {
+    const sd = { sd_key: 'SD-TEST-005', sd_type: 'documentation', metadata: {} };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase([]),
+    });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('fails closed on Supabase query error', async () => {
+    const sd = { sd_key: 'SD-TEST-006', sd_type: 'bugfix', metadata: { work_type: 'code' } };
+    const result = await runShipReviewFindingsProofGate({
+      sd,
+      supabase: fakeSupabase(null, { message: 'Connection timeout' }),
+    });
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toMatch(/query failed.*fail-closed/);
+  });
+
+  it('exports a gate descriptor with required metadata', () => {
+    expect(SHIP_REVIEW_FINDINGS_PROOF_GATE.name).toBe('SHIP_REVIEW_FINDINGS_PROOF');
+    expect(SHIP_REVIEW_FINDINGS_PROOF_GATE.required).toBe(true);
+    expect(SHIP_REVIEW_FINDINGS_PROOF_GATE.bypass_allowed).toBe('dual-key-only');
+  });
+
+  it('requiresShipReviewProof: code work_type', () => {
+    expect(requiresShipReviewProof({ sd_type: 'documentation', metadata: { work_type: 'code' } })).toBe(true);
+  });
+
+  it('requiresShipReviewProof: feature/bugfix/infrastructure types', () => {
+    expect(requiresShipReviewProof({ sd_type: 'feature', metadata: {} })).toBe(true);
+    expect(requiresShipReviewProof({ sd_type: 'bugfix', metadata: {} })).toBe(true);
+    expect(requiresShipReviewProof({ sd_type: 'infrastructure', metadata: {} })).toBe(true);
+  });
+
+  it('requiresShipReviewProof: explicit no_pr_required override', () => {
+    expect(requiresShipReviewProof({ sd_type: 'feature', metadata: { no_pr_required: true } })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `scripts/modules/handoff/gates/ship-review-findings-proof.js` — fail-closed gate for code SDs without ship_review_findings evidence
- Closed legacy direct-DB completion path at `helpers.js:131-139` (smoking gun for S18-S26 phantom completions)
- New trigger migration locking `validation_gate_registry` against silent disables of protected gates
- New schema migration adding FK + `merged_at` + `merge_commit_sha` to `ship_review_findings`
- New nightly cron `.github/workflows/phantom-completion-sweep.yml` reusing audit-phantom-completions.js (from SD-2)
- 10/10 vitest covering happy path, fail-closed, skip, query-error, gate descriptor

## Context
Final piece of the 3-SD phantom-completion campaign:
1. SD-1 (`SD-MAN-FIX-STAGE-MARKETING-COPY-001` — merged) fixed user-visible Stage 18 fallback
2. SD-2 (`SD-MAN-INFRA-RECONCILE-S18-S26-001` — merged) cleaned the data baseline (3 cancellations + 9 backfills)
3. **SD-3 (this PR)** — adds the structural gate so the issue cannot recur

The 7-day observation-only mode for `SHIP_REVIEW_FINDINGS_PROOF` (`required=true` in validation_gate_registry deferred to a follow-up cadence-aware ship) ensures the gate detects issues without blocking during baseline transition. SD-2 already cleaned the historical baseline so the gate would only fire on new emergence.

## Test plan
- [x] vitest: 10/10 passing on tests/integration/ship-review-findings-proof-gate.test.js
- [x] Migrations are idempotent (CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS + ALTER TABLE ADD COLUMN IF NOT EXISTS)
- [ ] Apply migrations to live DB (deferred to ship)
- [ ] Register SHIP_REVIEW_FINDINGS_PROOF in validation_gate_registry as required=false initially (7-day observation)
- [ ] Wire into getRequiredGates() at gates.js:1072-1122 (deferred to follow-up cadence-aware ship)

## Risks & rollback
- **Legacy path closure**: if the OrchestratorCompletionGuardian is unavailable, parent SDs now block instead of silently completing. Rollback: revert helpers.js section.
- **Trigger lock**: rolling back is `DROP TRIGGER trigger_validation_gate_registry_lock` — instantly reversible.
- **FK NOT VALID**: existing rows preserved; if FK becomes problematic, drop with `ALTER TABLE DROP CONSTRAINT ship_review_findings_sd_key_fkey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)