### PR TITLE
feat(SD-LEO-ENH-TREND-SCANNER-SCORING-001): Trend Scanner v2 — scoring fidelity, prompt versioning, silent-failure hardening

### DIFF
--- a/database/migrations/20260428_stage_zero_prompt_version.sql
+++ b/database/migrations/20260428_stage_zero_prompt_version.sql
@@ -1,0 +1,44 @@
+-- Migration: Add prompt_version column to stage_zero_requests + discovery_strategies
+-- SD: SD-LEO-ENH-TREND-SCANNER-SCORING-001 (FR-5, AC-8)
+-- Purpose: Enable Trend Scanner v2 prompt-version stamping per FR-4. Nullable design
+--          preserves backfill compat — pre-migration rows surface via COALESCE in the
+--          replacement RPC migration as 'v1-pre-versioning'.
+--
+-- ─── DEPLOY ORDER (TR-3, BLOCKING) ─────────────────────────────────────────────
+-- Two-stage deploy mandatory:
+--   1. MERGE THIS MIGRATION FIRST.
+--   2. Wait >=30s for the queue processor schema cache to refresh.
+--   3. Merge the RPC migration (20260428_stage_zero_prompt_version_rpc.sql).
+--   4. Merge the application code that writes prompt_version.
+-- Rationale: bundling migration + code change risks deploy-ordering races. Single-instance
+-- queue processor design accepts the brief column-present-but-unused window with no data loss.
+-- ────────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE stage_zero_requests
+  ADD COLUMN IF NOT EXISTS prompt_version TEXT NULL;
+
+ALTER TABLE discovery_strategies
+  ADD COLUMN IF NOT EXISTS prompt_version_active TEXT NULL;
+
+-- Partial index: only over rows that carry a prompt_version (most legacy rows are NULL).
+-- Keeps the index small and effective for closed-loop RPC GROUP BY behavior.
+CREATE INDEX IF NOT EXISTS idx_stage_zero_requests_prompt_version
+  ON stage_zero_requests (prompt_version)
+  WHERE prompt_version IS NOT NULL;
+
+COMMENT ON COLUMN stage_zero_requests.prompt_version IS
+  'Prompt version stamped by Stage Zero strategy runner (e.g. ''2026-04-28-v2''). NULL for pre-versioning runs; surfaced via COALESCE in get_discovery_strategy_scores as ''v1-pre-versioning''. Bumps deliberately when a strategy''s LLM prompt template changes meaningfully — never a content hash (TR-2). Set by SD-LEO-ENH-TREND-SCANNER-SCORING-001.';
+
+COMMENT ON COLUMN discovery_strategies.prompt_version_active IS
+  'Optional override for the strategy''s active prompt version. When NULL, the runtime falls back to the code-default constant (TREND_SCANNER_PROMPT_VERSION etc). Set by SD-LEO-ENH-TREND-SCANNER-SCORING-001.';
+
+-- ─── DOWN ──────────────────────────────────────────────────────────────────────
+-- To revert (reverse order of creation):
+--   DROP INDEX IF EXISTS idx_stage_zero_requests_prompt_version;
+--   ALTER TABLE discovery_strategies DROP COLUMN IF EXISTS prompt_version_active;
+--   ALTER TABLE stage_zero_requests  DROP COLUMN IF EXISTS prompt_version;
+--
+-- Roll back code change first (queue processor reverts to v1 path); wait for active requests to
+-- drain (~30s); then run the DOWN block above. ehg/ hook continues to work — StrategyScore
+-- interface extension is additive (extra field ignored by older callers).
+-- ────────────────────────────────────────────────────────────────────────────────

--- a/database/migrations/20260428_stage_zero_prompt_version_rpc.sql
+++ b/database/migrations/20260428_stage_zero_prompt_version_rpc.sql
@@ -1,0 +1,86 @@
+-- Migration: get_discovery_strategy_scores RPC — version-aware grouping
+-- SD: SD-LEO-ENH-TREND-SCANNER-SCORING-001 (FR-6, AC-4, TR-5, PA-003 BLOCKING)
+-- Purpose: Replace the v1 RPC with a version-aware variant that groups by
+--          (strategy, COALESCE(prompt_version, 'v1-pre-versioning')) and returns
+--          prompt_version as a NEW TABLE column.
+--
+-- ─── PA-003 BLOCKING CONSTRAINT (TR-5) ─────────────────────────────────────────
+-- prompt_version MUST be added as a NEW TABLE column with COALESCE default,
+-- NOT as a raw second GROUP BY column inserted into the existing SELECT shape.
+-- useDiscoveryStrategyScores.ts is typed as flat StrategyScore[]; raw shape change
+-- would break consumers. The COALESCE-with-new-column form preserves wide-row
+-- compatibility — older callers ignore the extra field; new callers read it.
+-- ────────────────────────────────────────────────────────────────────────────────
+--
+-- ─── DEPLOY ORDER (TR-3, BLOCKING) ─────────────────────────────────────────────
+-- This migration MUST run AFTER 20260428_stage_zero_prompt_version.sql so the
+-- ventures.metadata.stage_zero.origin_metadata.prompt_version JSONB key exists in
+-- the read-side schema (the migration above adds the typed columns; the RPC reads
+-- the JSONB key which is additive and requires no schema change on ventures).
+-- ────────────────────────────────────────────────────────────────────────────────
+
+-- DO NOT EDIT the prior 20260313_discovery_strategy_scores.sql migration. We use
+-- CREATE OR REPLACE on the function to preserve the existing function signature
+-- across upgrade paths; the RETURNS TABLE contract gains one new column.
+
+CREATE OR REPLACE FUNCTION get_discovery_strategy_scores()
+RETURNS TABLE (
+  strategy TEXT,
+  prompt_version TEXT,         -- NEW column (FR-6 / TR-5 / PA-003)
+  venture_count BIGINT,
+  total_outcomes BIGINT,
+  pass_count BIGINT,
+  pass_rate NUMERIC,
+  avg_score NUMERIC,
+  composite_score NUMERIC
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    v.metadata->'stage_zero'->'origin_metadata'->>'discovery_strategy' AS strategy,
+    -- COALESCE legacy NULLs to a single sentinel so they aggregate together rather
+    -- than appearing as a NULL row in the result. Sentinel matches LEGACY_PROMPT_VERSION_SENTINEL
+    -- in lib/eva/stage-zero/paths/discovery-mode-versions.js.
+    COALESCE(
+      v.metadata->'stage_zero'->'origin_metadata'->>'prompt_version',
+      'v1-pre-versioning'
+    ) AS prompt_version,
+    COUNT(DISTINCT v.id) AS venture_count,
+    COUNT(epo.id) AS total_outcomes,
+    COUNT(CASE WHEN epo.signal_type = 'pass' THEN 1 END) AS pass_count,
+    ROUND(
+      COUNT(CASE WHEN epo.signal_type = 'pass' THEN 1 END)::NUMERIC
+      / NULLIF(COUNT(epo.id), 0), 3
+    ) AS pass_rate,
+    ROUND(AVG((epo.outcome->>'score')::NUMERIC), 2) AS avg_score,
+    ROUND(
+      0.7 * (COUNT(CASE WHEN epo.signal_type = 'pass' THEN 1 END)::NUMERIC
+             / NULLIF(COUNT(epo.id), 0))
+      + 0.3 * (AVG((epo.outcome->>'score')::NUMERIC) / 10.0),
+    3) AS composite_score
+  FROM ventures v
+  JOIN evaluation_profile_outcomes epo ON epo.venture_id = v.id
+  WHERE v.metadata->'stage_zero'->'origin_metadata'->>'discovery_strategy' IS NOT NULL
+    AND v.status NOT IN ('cancelled', 'archived')
+    AND (epo.outcome->>'simulated')::BOOLEAN IS DISTINCT FROM TRUE
+  GROUP BY
+    v.metadata->'stage_zero'->'origin_metadata'->>'discovery_strategy',
+    COALESCE(
+      v.metadata->'stage_zero'->'origin_metadata'->>'prompt_version',
+      'v1-pre-versioning'
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+GRANT EXECUTE ON FUNCTION get_discovery_strategy_scores() TO authenticated;
+
+COMMENT ON FUNCTION get_discovery_strategy_scores() IS
+  'Aggregates discovery strategy performance from evaluation gate outcomes, grouped by (strategy, prompt_version). Legacy NULL prompt_version rows surface as ''v1-pre-versioning''. Used by DiscoveryModeDialog star ratings (latest version wins for a given strategy until UI surfacing SD lands). Set by SD-LEO-ENH-TREND-SCANNER-SCORING-001.';
+
+-- ─── DOWN ──────────────────────────────────────────────────────────────────────
+-- To revert this RPC change while keeping the typed columns intact:
+--   CREATE OR REPLACE FUNCTION get_discovery_strategy_scores()
+--   RETURNS TABLE (... prior 7-column shape ...) AS $$ ... $$ LANGUAGE plpgsql ...;
+-- Re-run the prior migration body from 20260313_discovery_strategy_scores.sql.
+-- ehg/ consumers continue to work — the StrategyScore extension was additive.
+-- ────────────────────────────────────────────────────────────────────────────────

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -143,6 +143,10 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
               competitor_urls: brief.competitor_ref,
               blueprint_id: brief.blueprint_id,
               discovery_strategy: brief.discovery_strategy,
+              // FR-4c (SD-LEO-ENH-TREND-SCANNER-SCORING-001): stamp prompt_version
+              // when the brief carries one. Null/undefined for legacy ventures —
+              // surfaced as 'v1-pre-versioning' via COALESCE in the closed-loop RPC.
+              prompt_version: brief.prompt_version ?? brief.metadata?.prompt_version ?? null,
             },
           },
         },

--- a/lib/eva/stage-zero/paths/discovery-mode-versions.js
+++ b/lib/eva/stage-zero/paths/discovery-mode-versions.js
@@ -1,0 +1,22 @@
+/**
+ * Single-source-of-truth prompt-version constants for Stage Zero discovery-mode strategies.
+ *
+ * Bumped deliberately when a strategy's LLM prompt changes meaningfully.
+ * Used by:
+ *  - runTrendScanner (stamps metadata.prompt_version on candidate output)
+ *  - chairman-review.persistVentureBrief (writes metadata.stage_zero.origin_metadata.prompt_version)
+ *  - useStageZeroQueue (adds metadata.prompt_version_hint to queue inserts)
+ *  - stage-zero-queue-processor (surfaces in result payload)
+ *  - get_discovery_strategy_scores RPC (groups by COALESCE(prompt_version, 'v1-pre-versioning'))
+ *
+ * Version format: 'YYYY-MM-DD-vN'. Hashes are NOT used — they change on whitespace edits
+ * and are unreadable in score history. A human-curated string bumps deliberately.
+ */
+
+export const TREND_SCANNER_PROMPT_VERSION = '2026-04-28-v2';
+
+/**
+ * Sentinel surfaced by the get_discovery_strategy_scores RPC's COALESCE default
+ * for legacy ventures that pre-date prompt versioning (prompt_version IS NULL).
+ */
+export const LEGACY_PROMPT_VERSION_SENTINEL = 'v1-pre-versioning';

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -136,6 +136,12 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
       candidates_generated: ranked.length,
       top_score: top.score,
       constraints_applied: Object.keys(constraints),
+      // FR-4 (SD-LEO-ENH-TREND-SCANNER-SCORING-001): surface prompt_version in
+      // PathOutput so the orchestrator → chairman-review pipeline can stamp
+      // origin_metadata.prompt_version on the venture row. Null for legacy
+      // strategies that have not adopted versioning yet.
+      prompt_version: top.prompt_version ?? null,
+      score_attribution: top.score_attribution ?? null,
     },
   });
 }

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -20,6 +20,47 @@ import { getValidationClient } from '../../../llm/client-factory.js';
 import { getCapabilityContextBlock } from '../../../capabilities/scanner-context.js';
 import { getMentalModelContextBlock } from '../../mental-models/index.js';
 import { loadActiveStrategies, FALLBACK_STRATEGIES } from '../strategy-loader.js';
+import { TREND_SCANNER_PROMPT_VERSION } from './discovery-mode-versions.js';
+import { parseRevenuePotential } from '../utils/parse-revenue.js';
+import { computeStrategicFit } from '../utils/strategic-fit.js';
+
+// ── Typed errors for silent-failure hardening (FR-7) ─────────────────────────
+// Surfaced by callLLMForCandidates / runTrendScanner; mapped to error_details.error_type
+// in scripts/stage-zero-queue-processor.js catch block.
+
+export class LLMEmptyResponseError extends Error {
+  constructor({ strategyName, promptVersion, responseLength }) {
+    super(`${strategyName}_empty_response: got ${responseLength} chars from LLM`);
+    this.name = 'LLMEmptyResponseError';
+    this.strategyName = strategyName;
+    this.promptVersion = promptVersion;
+    this.responseLength = responseLength;
+    this.errorType = 'empty_response';
+  }
+}
+
+export class LLMParseError extends Error {
+  constructor({ strategyName, promptVersion, responseLength, reason = 'no JSON array found' }) {
+    super(`${strategyName}_parse_failed: ${reason}`);
+    this.name = 'LLMParseError';
+    this.strategyName = strategyName;
+    this.promptVersion = promptVersion;
+    this.responseLength = responseLength;
+    this.errorType = 'parse_failure';
+  }
+}
+
+export class LLMUndercountError extends Error {
+  constructor({ strategyName, promptVersion, expected, actual }) {
+    super(`${strategyName}_undercount: got ${actual} of ${expected} expected`);
+    this.name = 'LLMUndercountError';
+    this.strategyName = strategyName;
+    this.promptVersion = promptVersion;
+    this.expected = expected;
+    this.actual = actual;
+    this.errorType = 'undercount';
+  }
+}
 
 /**
  * Execute the discovery mode path.
@@ -199,7 +240,26 @@ For each candidate, provide:
 Return a JSON array:
 [{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "monthly_revenue_potential": "string", "competition_level": "string", "automation_feasibility": 8 }]`;
 
-  return callLLMForCandidates(client, prompt, { logger, strategyName: 'Trend Scanner' });
+  const candidates = await callLLMForCandidates(client, prompt, {
+    logger,
+    strategyName: 'trend_scanner',
+    promptVersion: TREND_SCANNER_PROMPT_VERSION,
+    strictMode: true,
+  });
+
+  // FR-7 post-condition: surface impoverished-signal runs (1 of 5 etc.) as failed,
+  // not as ranked-but-thin output that masquerades as success.
+  const minExpected = Math.ceil((candidateCount || 5) / 2);
+  if (candidates.length < minExpected) {
+    throw new LLMUndercountError({
+      strategyName: 'trend_scanner',
+      promptVersion: TREND_SCANNER_PROMPT_VERSION,
+      expected: candidateCount || 5,
+      actual: candidates.length,
+    });
+  }
+
+  return candidates.map(c => ({ ...c, prompt_version: TREND_SCANNER_PROMPT_VERSION }));
 }
 
 /**
@@ -466,8 +526,19 @@ If no ventures are worth reviving, return an empty array: []`;
       }));
     }
     logger.warn(`   Warning: Could not parse nursery re-evaluation response (${content.length} chars)`);
+    // FR-7 conservative gate: only fire when there was input to re-evaluate AND nothing came back.
+    // 0-input → graceful empty (TS-11); ≥1-input + 0-output → undercount (real failure).
+    if (nurseryItems.length >= 1) {
+      throw new LLMUndercountError({
+        strategyName: 'nursery_reeval',
+        promptVersion: null,
+        expected: nurseryItems.length,
+        actual: 0,
+      });
+    }
     return [];
   } catch (err) {
+    if (err instanceof LLMUndercountError) throw err;
     logger.warn(`   Warning: Nursery re-evaluation failed: ${err.message}`);
     return [];
   }
@@ -475,48 +546,182 @@ If no ventures are worth reviving, return an empty array: []`;
 
 /**
  * Common LLM call handler for candidate generation strategies.
+ *
+ * Throws typed errors on failure modes that previously silently returned []:
+ *   - LLMEmptyResponseError  : LLM returned <10 chars
+ *   - LLMParseError          : no JSON array found OR JSON.parse failed
+ * Other thrown errors (network, timeout) propagate unchanged with message preserved.
+ *
+ * Trend Scanner is the only strategy currently strict-mode (FR-7); other strategies
+ * pass `strictMode:false` to preserve historical [] return on parse-fail until
+ * sibling SDs widen the contract.
  */
-async function callLLMForCandidates(client, prompt, { logger = console, strategyName = 'unknown' } = {}) {
+async function callLLMForCandidates(client, prompt, { logger = console, strategyName = 'unknown', promptVersion = null, strictMode = false } = {}) {
+  // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+  const raw = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
+  const text = typeof raw === 'string' ? raw : (raw?.content || raw?.choices?.[0]?.message?.content || '');
+  const responseLength = text ? text.length : 0;
+
+  if (!text || responseLength < 10) {
+    const usage = raw?.usage || {};
+    if (strictMode) {
+      throw new LLMEmptyResponseError({ strategyName, promptVersion, responseLength });
+    }
+    logger.warn(`   Warning: ${strategyName} returned empty/truncated response (${responseLength} chars). Usage: ${JSON.stringify(usage)}`);
+    return [];
+  }
+
+  const jsonMatch = text.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) {
+    if (strictMode) {
+      throw new LLMParseError({ strategyName, promptVersion, responseLength, reason: 'no JSON array found' });
+    }
+    logger.warn(`   Warning: Could not parse ${strategyName} response (${responseLength} chars, no JSON array found)`);
+    return [];
+  }
+
+  let parsed;
   try {
-    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
-    const raw = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
-    const text = typeof raw === 'string' ? raw : (raw?.content || raw?.choices?.[0]?.message?.content || '');
-
-    if (!text || text.length < 10) {
-      const usage = raw?.usage || {};
-      logger.warn(`   Warning: ${strategyName} returned empty/truncated response (${text.length} chars). Usage: ${JSON.stringify(usage)}`);
-      return [];
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch (parseErr) {
+    if (strictMode) {
+      throw new LLMParseError({ strategyName, promptVersion, responseLength, reason: `JSON.parse failed: ${parseErr.message}` });
     }
+    logger.warn(`   Warning: ${strategyName} JSON.parse failed: ${parseErr.message}`);
+    return [];
+  }
 
-    const jsonMatch = text.match(/\[[\s\S]*\]/);
-    if (jsonMatch) {
-      const parsed = JSON.parse(jsonMatch[0]);
-      return parsed.map(c => ({ ...c, source: strategyName }));
+  if (!Array.isArray(parsed)) {
+    if (strictMode) {
+      throw new LLMParseError({ strategyName, promptVersion, responseLength, reason: 'parsed value is not an array' });
     }
-    logger.warn(`   Warning: Could not parse ${strategyName} response (${text.length} chars, no JSON array found)`);
     return [];
-  } catch (err) {
-    logger.warn(`   Warning: ${strategyName} analysis failed: ${err.message}`);
-    return [];
+  }
+
+  return parsed.map(c => ({ ...c, source: strategyName }));
+}
+
+// FR-1: Default weights for the 5-field weighted composite. MUST sum to 1.0.
+// Asserted at module load — drift here corrupts longitudinal composite_score history.
+export const DEFAULT_RANK_WEIGHTS = Object.freeze({
+  automation_feasibility: 0.30,
+  monthly_revenue_potential: 0.25,
+  target_market_specificity: 0.20,
+  strategic_fit: 0.15,
+  competition_level: 0.10,
+});
+{
+  const sum = Object.values(DEFAULT_RANK_WEIGHTS).reduce((a, b) => a + b, 0);
+  if (Math.abs(sum - 1.0) > 1e-9) {
+    throw new Error(`DEFAULT_RANK_WEIGHTS must sum to 1.0; got ${sum}`);
   }
 }
 
 /**
  * Rank candidates by composite score.
- * Score = automation_feasibility * 10 + bonus factors.
  *
- * @param {Object[]} candidates - Raw candidates from strategy
- * @returns {Object[]} Sorted candidates with scores
+ * v2 (default): deterministic 5-field weighted composite over LLM-emitted fields,
+ * plus a score_attribution array listing which inputs contributed.
+ *
+ * v1 (legacy branch): for candidates with `prompt_version` IS NULL (historical
+ * rows pre-versioning), uses the original 2-field formula. Prevents silent
+ * re-scoring of legacy candidates under v2 weights they were not generated for.
+ *
+ * Tie-break order: composite_score DESC → parsed_revenue_high DESC → automation_feasibility DESC → name (stable).
+ *
+ * @param {Object[]} candidates
+ * @param {Object} [opts]
+ * @param {Object} [opts.weights]                  Override DEFAULT_RANK_WEIGHTS (must sum to 1.0).
+ * @param {Object|null} [opts.strategicContext]    Passed to computeStrategicFit.
+ * @returns {Object[]} sorted candidates carrying composite_score + score_attribution + score (compat alias).
  */
-export function rankCandidates(candidates) {
-  return candidates
-    .map(c => {
+export function rankCandidates(candidates, opts = {}) {
+  const { weights, strategicContext = null } = opts;
+  const w = weights ? validateWeights(weights) : DEFAULT_RANK_WEIGHTS;
+
+  const enriched = candidates.map(c => {
+    const isLegacy = c.prompt_version == null;
+    if (isLegacy) {
       const feasibility = Number(c.automation_feasibility) || 5;
       const competitionBonus = c.competition_level === 'low' ? 10 : c.competition_level === 'medium' ? 5 : 0;
       const score = feasibility * 10 + competitionBonus;
-      return { ...c, score };
-    })
-    .sort((a, b) => b.score - a.score);
+      return {
+        ...c,
+        composite_score: score,
+        score, // compat alias preserves callers reading top.score
+        parsed_revenue_high: 0,
+        score_attribution: ['legacy_v1_formula', 'automation_feasibility', 'competition_level'],
+      };
+    }
+
+    const automationFeasibility01 = clamp01(Number(c.automation_feasibility) / 10 || 0);
+    const revenue = parseRevenuePotential(c.monthly_revenue_potential);
+    const revenueHighRaw = revenue ? revenue.high : 0;
+    const revenue01 = revenueHighRaw > 0 ? clamp01(Math.log10(revenueHighRaw + 1) / 6) : 0; // log10($1M) ≈ 6
+    const targetSpec01 = clamp01(scoreTargetMarketSpecificity(c.target_market) / 100);
+    const strategicFit01 = clamp01(computeStrategicFit(c, strategicContext) / 100);
+    const competition01 = c.competition_level === 'low' ? 1 : c.competition_level === 'medium' ? 0.5 : c.competition_level === 'high' ? 0 : 0.5;
+
+    const composite =
+      w.automation_feasibility * automationFeasibility01 +
+      w.monthly_revenue_potential * revenue01 +
+      w.target_market_specificity * targetSpec01 +
+      w.strategic_fit * strategicFit01 +
+      w.competition_level * competition01;
+
+    const composite_score = Math.round(composite * 100); // 0-100 scale
+
+    const attribution = [];
+    if (Number.isFinite(Number(c.automation_feasibility))) attribution.push('automation_feasibility');
+    if (revenue != null) attribution.push('monthly_revenue_potential');
+    if (c.target_market) attribution.push('target_market_specificity');
+    if (strategicContext != null) attribution.push('strategic_fit');
+    if (c.competition_level) attribution.push('competition_level');
+
+    return {
+      ...c,
+      composite_score,
+      score: composite_score, // compat alias
+      parsed_revenue_high: revenueHighRaw,
+      score_attribution: attribution,
+    };
+  });
+
+  return enriched.sort((a, b) => {
+    if (b.composite_score !== a.composite_score) return b.composite_score - a.composite_score;
+    if (b.parsed_revenue_high !== a.parsed_revenue_high) return b.parsed_revenue_high - a.parsed_revenue_high;
+    const aFeas = Number(a.automation_feasibility) || 0;
+    const bFeas = Number(b.automation_feasibility) || 0;
+    if (bFeas !== aFeas) return bFeas - aFeas;
+    return String(a.name || '').localeCompare(String(b.name || ''));
+  });
+}
+
+function clamp01(n) {
+  if (!Number.isFinite(n)) return 0;
+  return n < 0 ? 0 : n > 1 ? 1 : n;
+}
+
+function validateWeights(w) {
+  const sum = Object.values(w).reduce((a, b) => a + (Number(b) || 0), 0);
+  if (Math.abs(sum - 1.0) > 1e-9) {
+    throw new Error(`rankCandidates weights must sum to 1.0; got ${sum}`);
+  }
+  return w;
+}
+
+// Heuristic: a target_market string with proper-noun anchors and a quantifier (e.g., "B2B SaaS startups
+// with 50-200 employees") is more specific than "everyone" or "consumers". Returns 0-100.
+function scoreTargetMarketSpecificity(text) {
+  if (!text || typeof text !== 'string') return 0;
+  const s = text.trim();
+  if (!s) return 0;
+  let score = 30; // baseline non-empty
+  if (/\b\d/.test(s)) score += 25;                                           // numeric qualifier (size, age band)
+  if (/\b(B2B|B2C|SaaS|enterprise|SMB|startup|professional|industry|niche)\b/i.test(s)) score += 20;
+  if (s.split(/\s+/).length >= 6) score += 15;                               // sentence-shaped, not one word
+  if (/[A-Z][a-z]+/.test(s)) score += 10;                                    // proper-noun-ish anchor
+  return Math.min(100, score);
 }
 
 /**

--- a/lib/eva/stage-zero/utils/parse-revenue.js
+++ b/lib/eva/stage-zero/utils/parse-revenue.js
@@ -28,8 +28,11 @@ export function parseRevenuePotential(input) {
   if (!s) return null;
 
   // Numeric extraction: capture any "$<number><suffix>" tokens. Suffix in {K,M,B} (case-insensitive).
+  // The suffix must NOT be followed by another letter — otherwise "$2000 monthly" would parse the
+  // "m" in "monthly" as the million suffix. Drop the optional whitespace between number and suffix
+  // (shorthand suffixes are always glued, e.g. "$5K" not "$5 K") and add a non-letter lookahead.
   // Matches: $5K, $5,000, $5.5K, $5M, $5,000,000, $500
-  const tokenRe = /\$\s*([\d,]+(?:\.\d+)?)\s*([KMB])?/gi;
+  const tokenRe = /\$\s*([\d,]+(?:\.\d+)?)([KMB](?![a-z]))?/gi;
   const tokens = [];
   let m;
   while ((m = tokenRe.exec(s)) !== null) {

--- a/lib/eva/stage-zero/utils/parse-revenue.js
+++ b/lib/eva/stage-zero/utils/parse-revenue.js
@@ -1,0 +1,68 @@
+/**
+ * Parse free-form LLM revenue strings into a normalized {low, high, currency} object.
+ *
+ * The LLM emits monthly_revenue_potential as a freeform string in many shapes; this
+ * helper normalizes them so rankCandidates can compute a numeric revenue contribution.
+ * Yearly inputs are normalized to monthly (divided by 12).
+ *
+ * Returns null for unparseable input — never throws. Callers fall back to a neutral
+ * revenue contribution when null.
+ *
+ * Supported input forms (>=8, per AC-6):
+ *   '$5K/month'              → { low: 5000,  high: 5000,  currency: 'USD' }
+ *   '$5,000-$50,000/mo'      → { low: 5000,  high: 50000, currency: 'USD' }
+ *   '$1K+/month'             → { low: 1000,  high: 1000,  currency: 'USD' }
+ *   '$500-$2000 monthly'     → { low: 500,   high: 2000,  currency: 'USD' }
+ *   '~$10K MRR'              → { low: 10000, high: 10000, currency: 'USD' }
+ *   '$2K+'                   → { low: 2000,  high: 2000,  currency: 'USD' }
+ *   '$60K/year'              → { low: 5000,  high: 5000,  currency: 'USD' }   // /12
+ *   '$10M/year'              → { low: 833333, high: 833333, currency: 'USD' } // /12
+ *   'unknown' or ''          → null
+ *
+ * @param {string|null|undefined} input
+ * @returns {{low: number, high: number, currency: 'USD'} | null}
+ */
+export function parseRevenuePotential(input) {
+  if (input == null || typeof input !== 'string') return null;
+  const s = input.trim();
+  if (!s) return null;
+
+  // Numeric extraction: capture any "$<number><suffix>" tokens. Suffix in {K,M,B} (case-insensitive).
+  // Matches: $5K, $5,000, $5.5K, $5M, $5,000,000, $500
+  const tokenRe = /\$\s*([\d,]+(?:\.\d+)?)\s*([KMB])?/gi;
+  const tokens = [];
+  let m;
+  while ((m = tokenRe.exec(s)) !== null) {
+    const num = Number(m[1].replace(/,/g, ''));
+    if (!Number.isFinite(num)) continue;
+    const suffix = (m[2] || '').toUpperCase();
+    const mult = suffix === 'K' ? 1_000 : suffix === 'M' ? 1_000_000 : suffix === 'B' ? 1_000_000_000 : 1;
+    tokens.push(Math.round(num * mult));
+  }
+
+  if (tokens.length === 0) return null;
+
+  // Detect yearly vs monthly. Default is monthly when ambiguous (matches current LLM prompt asks).
+  const lower = s.toLowerCase();
+  const isYearly = /\b(year|yearly|annual|annually|\/yr|\/year|per\s+year|p\.?a\.?)\b/.test(lower);
+
+  // Range detection — two tokens with an explicit hyphen or 'to'/'-' between them.
+  const isRange = tokens.length >= 2 && /(\d.*[\-–]\s*\$|\bto\b)/i.test(s);
+
+  let low;
+  let high;
+  if (isRange) {
+    low = Math.min(tokens[0], tokens[1]);
+    high = Math.max(tokens[0], tokens[1]);
+  } else {
+    low = tokens[0];
+    high = tokens[0];
+  }
+
+  if (isYearly) {
+    low = Math.round(low / 12);
+    high = Math.round(high / 12);
+  }
+
+  return { low, high, currency: 'USD' };
+}

--- a/lib/eva/stage-zero/utils/strategic-fit.js
+++ b/lib/eva/stage-zero/utils/strategic-fit.js
@@ -1,0 +1,90 @@
+/**
+ * Compute a 0-100 strategic-fit score for a discovery candidate by measuring
+ * keyword overlap between the candidate's narrative fields and the strategic
+ * context themes loaded by `loadStrategicContext`.
+ *
+ * Used as the 0.15-weighted input in rankCandidates' v2 composite score.
+ *
+ * Falls back to 50 (neutral) when context is null/malformed — the worst case is
+ * a neutral contribution, never a thrown error.
+ *
+ * @param {Object} candidate - LLM-emitted candidate ({target_market, solution, revenue_model, ...})
+ * @param {Object|null|undefined} strategicContext - Loaded by lib/eva/stage-zero/strategic-context-loader.js
+ *   Either {themes: string[]} or {formattedPromptBlock: string} or {strategic_objectives, vision_statement, ...}
+ * @param {{logger?: Console}} [opts]
+ * @returns {number} integer in [0, 100]
+ */
+export function computeStrategicFit(candidate, strategicContext, opts = {}) {
+  const { logger = console } = opts;
+
+  if (!candidate || typeof candidate !== 'object') return 50;
+
+  const themes = extractThemes(strategicContext);
+  if (themes.length === 0) {
+    if (strategicContext != null) {
+      try { logger.warn?.('   computeStrategicFit: strategicContext provided but no themes extracted; returning neutral 50'); } catch { /* ignore logger errors */ }
+    }
+    return 50;
+  }
+
+  const candidateText = [
+    candidate.target_market,
+    candidate.solution,
+    candidate.revenue_model,
+    candidate.problem_statement,
+    candidate.automation_approach,
+  ].filter(Boolean).join(' ').toLowerCase();
+
+  if (!candidateText) return 50;
+
+  const candidateTokens = new Set(tokenize(candidateText));
+  let overlap = 0;
+  for (const theme of themes) {
+    for (const tok of tokenize(theme)) {
+      if (candidateTokens.has(tok)) {
+        overlap += 1;
+        break;
+      }
+    }
+  }
+
+  const fraction = themes.length > 0 ? overlap / themes.length : 0;
+  return Math.min(100, Math.max(0, Math.round(fraction * 100)));
+}
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'of', 'in', 'on', 'at', 'to', 'for',
+  'is', 'are', 'was', 'were', 'be', 'been', 'being', 'with', 'as', 'by',
+  'this', 'that', 'these', 'those', 'it', 'its', 'has', 'have', 'had',
+  'we', 'us', 'our', 'you', 'your', 'they', 'their',
+]);
+
+function tokenize(text) {
+  if (!text || typeof text !== 'string') return [];
+  return text.toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+function extractThemes(strategicContext) {
+  if (!strategicContext || typeof strategicContext !== 'object') return [];
+
+  if (Array.isArray(strategicContext.themes)) {
+    return strategicContext.themes.filter(t => typeof t === 'string' && t.length > 0);
+  }
+  if (typeof strategicContext.formattedPromptBlock === 'string' && strategicContext.formattedPromptBlock.length > 0) {
+    return [strategicContext.formattedPromptBlock];
+  }
+  const fallback = [];
+  if (Array.isArray(strategicContext.strategic_objectives)) {
+    for (const o of strategicContext.strategic_objectives) {
+      if (typeof o === 'string' && o.length > 0) fallback.push(o);
+      else if (o && typeof o === 'object' && typeof o.objective === 'string') fallback.push(o.objective);
+    }
+  }
+  if (typeof strategicContext.vision_statement === 'string' && strategicContext.vision_statement.length > 0) {
+    fallback.push(strategicContext.vision_statement);
+  }
+  return fallback;
+}

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -250,15 +250,33 @@ async function processRequest(supabase, request) {
     log.info(`Completed request ${request.id} | decision=${result.decision} | duration=${result.duration_ms}ms`);
     return true;
   } catch (err) {
-    // Store failure
+    // Store failure — map thrown typed errors to error_details.error_type so
+    // dashboards can distinguish parse_failure / empty_response / undercount / timeout / other.
+    // Error class carries .errorType (set by LLMEmptyResponseError, LLMParseError, LLMUndercountError).
+    let errorType = err && typeof err.errorType === 'string' ? err.errorType : null;
+    if (!errorType) {
+      const name = err?.name || '';
+      const msg = err?.message || '';
+      if (name === 'TimeoutError' || /timed?\s*out|timeout/i.test(msg)) errorType = 'timeout';
+      else errorType = 'other';
+    }
+
     await updateStatus(supabase, request.id, {
       status: 'failed',
       error_message: err.message,
-      error_details: { stack: err.stack, name: err.name },
+      error_details: {
+        stack: err.stack,
+        name: err.name,
+        error_type: errorType,
+        ...(err?.strategyName ? { strategy_name: err.strategyName } : {}),
+        ...(err?.promptVersion ? { prompt_version: err.promptVersion } : {}),
+        ...(err?.expected != null ? { expected: err.expected } : {}),
+        ...(err?.actual != null ? { actual: err.actual } : {}),
+      },
       completed_at: new Date().toISOString(),
     });
 
-    log.error(`Failed request ${request.id}:`, err.message);
+    log.error(`Failed request ${request.id} [error_type=${errorType}]:`, err.message);
     return false;
   }
 }

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -240,10 +240,18 @@ async function processRequest(supabase, request) {
       EXECUTION_TIMEOUT_MS
     );
 
+    // FR-4e (SD-LEO-ENH-TREND-SCANNER-SCORING-001): surface prompt_version in the
+    // top-level result payload so dashboard consumers and the closed-loop RPC
+    // can read it without nested metadata traversal. Null for non-versioned strategies.
+    const promptVersion = result?.brief?.metadata?.prompt_version
+      ?? result?.brief?.prompt_version
+      ?? null;
+
     // Store success
     await updateStatus(supabase, request.id, {
       status: 'completed',
-      result,
+      result: { ...result, prompt_version: promptVersion },
+      prompt_version: promptVersion,
       completed_at: new Date().toISOString(),
     });
 

--- a/tests/unit/database/migrations/stage-zero-prompt-version.test.js
+++ b/tests/unit/database/migrations/stage-zero-prompt-version.test.js
@@ -1,0 +1,102 @@
+/**
+ * Static-content tests for the SD-LEO-ENH-TREND-SCANNER-SCORING-001 migrations.
+ *
+ * Covers AC-8 (TS-8 reversibility) as a static surrogate — full end-to-end DB
+ * reversibility requires a test Supabase instance and is documented in the
+ * migration headers. These assertions ensure the DOWN block + deploy-order
+ * documentation is present before the migration is merged.
+ *
+ * Also covers AC-9 (TS-9): no DiscoveryModeDialog UI changes — verified by
+ * static repo inspection in a sibling test below.
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001 Checkpoint 3.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// here = tests/unit/database/migrations → 4 levels up → repo root
+const repoRoot = path.resolve(here, '..', '..', '..', '..');
+
+const COLUMN_MIGRATION = path.join(repoRoot, 'database', 'migrations', '20260428_stage_zero_prompt_version.sql');
+const RPC_MIGRATION = path.join(repoRoot, 'database', 'migrations', '20260428_stage_zero_prompt_version_rpc.sql');
+
+describe('20260428_stage_zero_prompt_version.sql — column-add migration', () => {
+  test('migration file exists at the documented path', () => {
+    expect(existsSync(COLUMN_MIGRATION)).toBe(true);
+  });
+
+  const sql = existsSync(COLUMN_MIGRATION) ? readFileSync(COLUMN_MIGRATION, 'utf-8') : '';
+
+  test('adds prompt_version column to stage_zero_requests as TEXT NULL', () => {
+    expect(sql).toMatch(/ALTER TABLE stage_zero_requests[\s\S]*ADD COLUMN[\s\S]*prompt_version[\s\S]*TEXT[\s\S]*NULL/i);
+  });
+
+  test('adds prompt_version_active column to discovery_strategies as TEXT NULL', () => {
+    expect(sql).toMatch(/ALTER TABLE discovery_strategies[\s\S]*ADD COLUMN[\s\S]*prompt_version_active[\s\S]*TEXT[\s\S]*NULL/i);
+  });
+
+  test('creates partial index on non-null prompt_version', () => {
+    expect(sql).toMatch(/CREATE INDEX[\s\S]*idx_stage_zero_requests_prompt_version[\s\S]*WHERE prompt_version IS NOT NULL/i);
+  });
+
+  test('documents reversible DOWN block (AC-8)', () => {
+    // DOWN may appear in a banner like "-- ─── DOWN ───"; just check for the keyword
+    // alongside the actual reversal SQL.
+    expect(sql).toMatch(/DOWN/);
+    expect(sql).toMatch(/DROP INDEX[\s\S]*DROP COLUMN/i);
+  });
+
+  test('documents two-stage deploy order (TR-3)', () => {
+    expect(sql.toLowerCase()).toContain('deploy order');
+    expect(sql).toMatch(/30s|>=30/i);
+  });
+});
+
+describe('20260428_stage_zero_prompt_version_rpc.sql — RPC migration', () => {
+  test('migration file exists', () => {
+    expect(existsSync(RPC_MIGRATION)).toBe(true);
+  });
+
+  const sql = existsSync(RPC_MIGRATION) ? readFileSync(RPC_MIGRATION, 'utf-8') : '';
+
+  test('uses CREATE OR REPLACE FUNCTION (not DROP+CREATE)', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION get_discovery_strategy_scores/i);
+  });
+
+  test('returns prompt_version as a NEW TABLE column (TR-5 / PA-003 BLOCKING)', () => {
+    expect(sql).toMatch(/RETURNS TABLE[\s\S]*prompt_version\s+TEXT/i);
+  });
+
+  test('uses COALESCE with v1-pre-versioning sentinel for legacy null rows', () => {
+    expect(sql).toMatch(/COALESCE[\s\S]*prompt_version[\s\S]*v1-pre-versioning/i);
+  });
+
+  test('GROUP BY includes COALESCE(prompt_version) — not raw column', () => {
+    // Must be the COALESCE expression in GROUP BY, not a bare prompt_version reference
+    // (which would force consumers to handle null rows).
+    expect(sql).toMatch(/GROUP BY[\s\S]*COALESCE[\s\S]*prompt_version[\s\S]*v1-pre-versioning/i);
+  });
+
+  test('explicitly references PA-003 BLOCKING constraint in the comment block', () => {
+    expect(sql).toContain('PA-003');
+    expect(sql.toLowerCase()).toContain('blocking');
+  });
+});
+
+describe('AC-9 — no DiscoveryModeDialog UI changes', () => {
+  test('SD source diff does not modify DiscoveryModeDialog.tsx', () => {
+    // We assert via a guarded check: the SD's primary diff lives in EHG_Engineer; the
+    // ehg/ side touches only useStageZeroQueue.ts + useDiscoveryStrategyScores.ts. Verify
+    // the dialog file path was NOT modified in this worktree (the file lives in a sibling
+    // ehg/ repo and is intentionally out of scope per FR-6 and AC-9). This test is a
+    // static guard — it confirms the directory layout assumption.
+    const dialogInThisRepo = path.join(repoRoot, 'src', 'components', 'chairman-v3', 'opportunities', 'DiscoveryModeDialog.tsx');
+    // The dialog should NOT exist inside EHG_Engineer (it lives in ehg/). If a future
+    // refactor moves it here, this guard alerts the author that AC-9 needs revisiting.
+    expect(existsSync(dialogInThisRepo)).toBe(false);
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-failure.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-failure.test.js
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for FR-7 silent-failure hardening: typed error throws + post-condition gate.
+ * Covers TS-2, TS-3, TS-10, TS-11 (US-002 + US-003 from Checkpoint 1).
+ *
+ * Asserts that callLLMForCandidates and runTrendScanner surface previously-silent
+ * failures as LLMEmptyResponseError / LLMParseError / LLMUndercountError. Also covers
+ * the queue-processor catch-block error_type mapping.
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001.
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../lib/llm/client-factory.js', () => ({
+  getValidationClient: vi.fn(() => ({ complete: vi.fn() })),
+}));
+
+vi.mock('../../../../../lib/capabilities/scanner-context.js', () => ({
+  getCapabilityContextBlock: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../../../mental-models/index.js', () => ({
+  getMentalModelContextBlock: vi.fn().mockResolvedValue(''),
+}), { virtual: true });
+
+import {
+  executeDiscoveryMode,
+  LLMEmptyResponseError,
+  LLMParseError,
+  LLMUndercountError,
+} from '../../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+import { TREND_SCANNER_PROMPT_VERSION } from '../../../../../lib/eva/stage-zero/paths/discovery-mode-versions.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function createSupabase(strategy = { strategy_key: 'trend_scanner', name: 'Trend Scanner', description: 'Find trends', is_active: true }) {
+  // Each .from() call returns a fresh chainable; supports .select().eq().eq().single() and ranking-data .gte().order().limit()
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+      single: vi.fn().mockResolvedValue({ data: strategy, error: null }),
+    })),
+  };
+}
+
+function llmReturning(content) {
+  return { complete: vi.fn().mockResolvedValue(content) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('callLLMForCandidates strict mode (FR-7)', () => {
+  test('empty response throws LLMEmptyResponseError with diagnostic context (TS-10)', async () => {
+    const llmClient = llmReturning('');
+    await expect(
+      executeDiscoveryMode(
+        { strategy: 'trend_scanner', candidateCount: 5 },
+        { supabase: createSupabase(), logger: silentLogger, llmClient }
+      )
+    ).rejects.toBeInstanceOf(LLMEmptyResponseError);
+  });
+
+  test('LLMEmptyResponseError carries strategyName + promptVersion + responseLength', async () => {
+    const llmClient = llmReturning('');
+    try {
+      await executeDiscoveryMode(
+        { strategy: 'trend_scanner', candidateCount: 5 },
+        { supabase: createSupabase(), logger: silentLogger, llmClient }
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LLMEmptyResponseError);
+      expect(err.strategyName).toBe('trend_scanner');
+      expect(err.promptVersion).toBe(TREND_SCANNER_PROMPT_VERSION);
+      expect(err.responseLength).toBe(0);
+      expect(err.errorType).toBe('empty_response');
+    }
+  });
+
+  test('malformed JSON (no array) throws LLMParseError (TS-2)', async () => {
+    const llmClient = llmReturning('the model says: nothing useful here, no JSON');
+    try {
+      await executeDiscoveryMode(
+        { strategy: 'trend_scanner', candidateCount: 5 },
+        { supabase: createSupabase(), logger: silentLogger, llmClient }
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LLMParseError);
+      expect(err.errorType).toBe('parse_failure');
+      expect(err.message).toMatch(/parse_failed.*no JSON array found/);
+    }
+  });
+
+  test('truncated JSON (broken array) throws LLMParseError', async () => {
+    const llmClient = llmReturning('[ { "name": "X", broken syntax');
+    await expect(
+      executeDiscoveryMode(
+        { strategy: 'trend_scanner', candidateCount: 5 },
+        { supabase: createSupabase(), logger: silentLogger, llmClient }
+      )
+    ).rejects.toBeInstanceOf(LLMParseError);
+  });
+});
+
+describe('runTrendScanner post-condition gate (FR-7, TS-3)', () => {
+  test('1-of-5 undercount throws LLMUndercountError', async () => {
+    const llmClient = llmReturning(JSON.stringify([
+      { name: 'OnlyOne', automation_feasibility: 8, competition_level: 'low' },
+    ]));
+    try {
+      await executeDiscoveryMode(
+        { strategy: 'trend_scanner', candidateCount: 5 },
+        { supabase: createSupabase(), logger: silentLogger, llmClient }
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LLMUndercountError);
+      expect(err.errorType).toBe('undercount');
+      expect(err.expected).toBe(5);
+      expect(err.actual).toBe(1);
+      expect(err.message).toMatch(/got 1 of 5/);
+    }
+  });
+
+  test('exactly half — does NOT throw (boundary: ceil(5/2)=3 candidates is the floor)', async () => {
+    const llmClient = llmReturning(JSON.stringify([
+      { name: 'A', automation_feasibility: 8, competition_level: 'low' },
+      { name: 'B', automation_feasibility: 7, competition_level: 'medium' },
+      { name: 'C', automation_feasibility: 6, competition_level: 'low' },
+    ]));
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner', candidateCount: 5 },
+      { supabase: createSupabase(), logger: silentLogger, llmClient }
+    );
+    expect(result).not.toBeNull();
+    expect(result.raw_material.candidates.length).toBe(3);
+  });
+
+  test('full count — emits prompt_version on every candidate', async () => {
+    const llmClient = llmReturning(JSON.stringify([
+      { name: 'A', automation_feasibility: 8, competition_level: 'low' },
+      { name: 'B', automation_feasibility: 7, competition_level: 'medium' },
+      { name: 'C', automation_feasibility: 6, competition_level: 'high' },
+      { name: 'D', automation_feasibility: 5, competition_level: 'low' },
+      { name: 'E', automation_feasibility: 9, competition_level: 'low' },
+    ]));
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner', candidateCount: 5 },
+      { supabase: createSupabase(), logger: silentLogger, llmClient }
+    );
+    expect(result.raw_material.candidates.length).toBe(5);
+    for (const c of result.raw_material.candidates) {
+      expect(c.prompt_version).toBe(TREND_SCANNER_PROMPT_VERSION);
+    }
+  });
+});
+
+describe('error_type queue-processor mapping shape (FR-7)', () => {
+  // The queue processor catch block reads err.errorType to populate
+  // error_details.error_type. This test verifies the contract surface.
+  test('LLMEmptyResponseError exposes errorType=empty_response', () => {
+    const e = new LLMEmptyResponseError({ strategyName: 'trend_scanner', promptVersion: 'v', responseLength: 0 });
+    expect(e.errorType).toBe('empty_response');
+    expect(e.name).toBe('LLMEmptyResponseError');
+  });
+
+  test('LLMParseError exposes errorType=parse_failure', () => {
+    const e = new LLMParseError({ strategyName: 'trend_scanner', promptVersion: 'v', responseLength: 100 });
+    expect(e.errorType).toBe('parse_failure');
+    expect(e.name).toBe('LLMParseError');
+  });
+
+  test('LLMUndercountError exposes errorType=undercount', () => {
+    const e = new LLMUndercountError({ strategyName: 'trend_scanner', promptVersion: 'v', expected: 5, actual: 1 });
+    expect(e.errorType).toBe('undercount');
+    expect(e.name).toBe('LLMUndercountError');
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit test for FR-7 conservative nursery gate (TS-11, US-009 boundary case).
+ * Confirms 0-input → graceful empty output (NOT undercount error).
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001 Checkpoint 3.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('../../../../../lib/llm/client-factory.js', () => ({
+  getValidationClient: vi.fn(() => ({ complete: vi.fn() })),
+}));
+
+vi.mock('../../../../../lib/capabilities/scanner-context.js', () => ({
+  getCapabilityContextBlock: vi.fn().mockResolvedValue(''),
+}));
+
+import {
+  executeDiscoveryMode,
+  LLMUndercountError,
+} from '../../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function nurserySupabase(items) {
+  // discovery_strategies.single() needs to return the strategy config; venture_nursery query uses
+  // .from('venture_nursery').select(...).eq('status','parked').order(...).limit(...)
+  const calls = [];
+  return {
+    from: vi.fn((table) => {
+      calls.push(table);
+      if (table === 'discovery_strategies') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { strategy_key: 'nursery_reeval', name: 'Nursery Re-eval', description: 'reeval', is_active: true },
+            error: null,
+          }),
+        };
+      }
+      // venture_nursery
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: items, error: null }),
+      };
+    }),
+  };
+}
+
+describe('runNurseryReeval — conservative gate (TS-11)', () => {
+  test('0 nursery items → returns null (graceful empty), no LLMUndercountError', async () => {
+    const result = await executeDiscoveryMode(
+      { strategy: 'nursery_reeval', candidateCount: 5 },
+      { supabase: nurserySupabase([]), logger: silentLogger, llmClient: { complete: vi.fn() } }
+    );
+    // executeDiscoveryMode returns null when no candidates returned from runner
+    // (existing behavior preserved for the 0-input boundary case).
+    expect(result).toBeNull();
+  });
+
+  test('LLMUndercountError class instantiation surface (constructor contract)', () => {
+    // Defends against accidental constructor signature drift; the queue processor
+    // catch block reads err.errorType + err.expected + err.actual.
+    const e = new LLMUndercountError({
+      strategyName: 'nursery_reeval',
+      promptVersion: null,
+      expected: 3,
+      actual: 0,
+    });
+    expect(e.errorType).toBe('undercount');
+    expect(e.expected).toBe(3);
+    expect(e.actual).toBe(0);
+    expect(e.strategyName).toBe('nursery_reeval');
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-rank.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-rank.test.js
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for FR-1 rankCandidates v2 5-field weighted composite + score_attribution + legacy v1 branch.
+ * Covers: TS-1 (default-weights ranking emits score_attribution >=3), TS-5 (legacy v1 branch), TS-7 (coverage).
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001 Checkpoint 1 / US-001.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { rankCandidates, DEFAULT_RANK_WEIGHTS } from '../../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+import { TREND_SCANNER_PROMPT_VERSION } from '../../../../../lib/eva/stage-zero/paths/discovery-mode-versions.js';
+
+const v2 = TREND_SCANNER_PROMPT_VERSION;
+
+function v2Candidate(overrides = {}) {
+  return {
+    name: 'Acme',
+    problem_statement: 'Customers struggle with X',
+    solution: 'AI agent does X',
+    target_market: 'B2B SaaS startups with 50-200 employees in fintech',
+    revenue_model: 'subscription',
+    automation_approach: 'fully autonomous',
+    monthly_revenue_potential: '$10K-$50K/month',
+    competition_level: 'low',
+    automation_feasibility: 8,
+    prompt_version: v2,
+    ...overrides,
+  };
+}
+
+const strategicCtx = { themes: ['fintech automation', 'B2B SaaS', 'subscription revenue'] };
+
+describe('rankCandidates - default weights (FR-1)', () => {
+  test('DEFAULT_RANK_WEIGHTS sums to 1.0', () => {
+    const sum = Object.values(DEFAULT_RANK_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(Math.abs(sum - 1)).toBeLessThan(1e-9);
+  });
+
+  test('top candidate cites >=3 LLM-emitted fields in score_attribution (TS-1, AC-1)', () => {
+    const candidates = [
+      v2Candidate({ name: 'Alpha', automation_feasibility: 9, monthly_revenue_potential: '$20K-$50K/month', competition_level: 'low' }),
+      v2Candidate({ name: 'Beta', automation_feasibility: 7, monthly_revenue_potential: '$5K-$10K/month', competition_level: 'medium' }),
+      v2Candidate({ name: 'Gamma', automation_feasibility: 5, monthly_revenue_potential: '$1K/month', competition_level: 'high' }),
+      v2Candidate({ name: 'Delta', automation_feasibility: 6, monthly_revenue_potential: '$3K/month', competition_level: 'medium' }),
+      v2Candidate({ name: 'Epsilon', automation_feasibility: 8, monthly_revenue_potential: '$15K/month', competition_level: 'low' }),
+    ];
+    const ranked = rankCandidates(candidates, { strategicContext: strategicCtx });
+    expect(ranked[0].score_attribution.length).toBeGreaterThanOrEqual(3);
+    // Must include >=3 of the 5 documented inputs (FR-1 names them automation_feasibility,
+    // monthly_revenue_potential, target_market_specificity, strategic_fit, competition_level).
+    const known = ['automation_feasibility', 'monthly_revenue_potential', 'target_market_specificity', 'strategic_fit', 'competition_level'];
+    const cited = ranked[0].score_attribution.filter(a => known.includes(a));
+    expect(cited.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('emits composite_score in 0-100 range with score alias for backward compat', () => {
+    const ranked = rankCandidates([v2Candidate()], { strategicContext: strategicCtx });
+    expect(ranked[0].composite_score).toBeGreaterThanOrEqual(0);
+    expect(ranked[0].composite_score).toBeLessThanOrEqual(100);
+    expect(ranked[0].score).toBe(ranked[0].composite_score);
+  });
+
+  test('higher automation_feasibility + low competition outranks lower with high competition', () => {
+    const ranked = rankCandidates(
+      [
+        v2Candidate({ name: 'Weak', automation_feasibility: 4, competition_level: 'high', monthly_revenue_potential: '$1K' }),
+        v2Candidate({ name: 'Strong', automation_feasibility: 9, competition_level: 'low', monthly_revenue_potential: '$20K' }),
+      ],
+      { strategicContext: strategicCtx }
+    );
+    expect(ranked[0].name).toBe('Strong');
+  });
+
+  test('handles missing fields without throwing — defaults to neutral contributions', () => {
+    const ranked = rankCandidates([v2Candidate({ monthly_revenue_potential: undefined, target_market: '', competition_level: undefined })], { strategicContext: strategicCtx });
+    expect(ranked[0]).toBeDefined();
+    expect(ranked[0].score_attribution.length).toBeGreaterThan(0);
+  });
+});
+
+describe('rankCandidates - tie-break order', () => {
+  test('genuine composite ties broken by name ASC (A before B with identical inputs)', () => {
+    const cands = [
+      v2Candidate({ name: 'B', automation_feasibility: 5, monthly_revenue_potential: '$5K' }),
+      v2Candidate({ name: 'A', automation_feasibility: 5, monthly_revenue_potential: '$5K' }),
+    ];
+    const ranked = rankCandidates(cands);
+    expect(ranked[0].name).toBe('A');
+    expect(ranked[1].name).toBe('B');
+  });
+
+  test('parsed_revenue_high DESC fires when composite ties (constructed via custom weights)', () => {
+    // Force a tie on composite by zeroing the feasibility weight: same competition + market + fit + revenue weights
+    // means revenue is the only differentiator — but identical candidates with different revenue
+    // produce different composites. To genuinely tie composites, we hand-pick log10 of revenues
+    // such that revenue contributions match: $5K and $4999 → log10 produces near-identical * 0.25.
+    // Easier: use custom weights with strategic_fit=1.0 and identical contexts.
+    const w = {
+      automation_feasibility: 0.0,
+      monthly_revenue_potential: 0.0,
+      target_market_specificity: 0.0,
+      strategic_fit: 1.0,
+      competition_level: 0.0,
+    };
+    // Without strategicContext, fit=50 (neutral) for both; composites will tie.
+    // Tie-break should then look at parsed_revenue_high.
+    const cands = [
+      v2Candidate({ name: 'LowRev', monthly_revenue_potential: '$1K', automation_feasibility: 8 }),
+      v2Candidate({ name: 'HighRev', monthly_revenue_potential: '$50K', automation_feasibility: 4 }),
+    ];
+    const ranked = rankCandidates(cands, { weights: w });
+    expect(ranked[0].composite_score).toBe(ranked[1].composite_score); // confirm tie
+    expect(ranked[0].name).toBe('HighRev');
+  });
+
+  test('automation_feasibility DESC fires when composite + revenue both tie', () => {
+    const w = {
+      automation_feasibility: 0.0,
+      monthly_revenue_potential: 0.0,
+      target_market_specificity: 0.0,
+      strategic_fit: 1.0,
+      competition_level: 0.0,
+    };
+    const cands = [
+      v2Candidate({ name: 'LowFeas', automation_feasibility: 4, monthly_revenue_potential: '$5K' }),
+      v2Candidate({ name: 'HighFeas', automation_feasibility: 9, monthly_revenue_potential: '$5K' }),
+    ];
+    const ranked = rankCandidates(cands, { weights: w });
+    expect(ranked[0].composite_score).toBe(ranked[1].composite_score);
+    expect(ranked[0].parsed_revenue_high).toBe(ranked[1].parsed_revenue_high);
+    expect(ranked[0].name).toBe('HighFeas');
+  });
+});
+
+describe('rankCandidates - legacy v1 branch (TR-4, AC-5, TS-5)', () => {
+  test('candidate without prompt_version uses 2-field v1 formula', () => {
+    const legacyCandidate = {
+      name: 'Old',
+      automation_feasibility: 8,
+      competition_level: 'low',
+      // no prompt_version → legacy branch
+    };
+    const ranked = rankCandidates([legacyCandidate]);
+    expect(ranked[0].score_attribution).toContain('legacy_v1_formula');
+    // v1 formula: feasibility*10 + competition_bonus(low=10) = 90
+    expect(ranked[0].score).toBe(90);
+    expect(ranked[0].composite_score).toBe(90);
+  });
+
+  test('mixed v1+v2: each candidate scored under its own formula, no silent re-scoring', () => {
+    const mixed = [
+      { name: 'Legacy', automation_feasibility: 9, competition_level: 'low' }, // v1 → 100
+      v2Candidate({ name: 'Modern', automation_feasibility: 9, monthly_revenue_potential: '$50K', competition_level: 'low' }),
+    ];
+    const ranked = rankCandidates(mixed, { strategicContext: strategicCtx });
+    const legacy = ranked.find(r => r.name === 'Legacy');
+    const modern = ranked.find(r => r.name === 'Modern');
+    expect(legacy.score_attribution).toContain('legacy_v1_formula');
+    expect(modern.score_attribution).not.toContain('legacy_v1_formula');
+    // Legacy keeps its v1 score; modern is computed under v2.
+    expect(legacy.composite_score).toBe(100);
+  });
+});
+
+describe('rankCandidates - custom weights validation', () => {
+  test('throws when custom weights do not sum to 1.0', () => {
+    expect(() => rankCandidates([v2Candidate()], { weights: { automation_feasibility: 0.5 } })).toThrow(/sum to 1\.0/);
+  });
+
+  test('accepts custom weights that sum to 1.0', () => {
+    const w = {
+      automation_feasibility: 0.5,
+      monthly_revenue_potential: 0.2,
+      target_market_specificity: 0.1,
+      strategic_fit: 0.1,
+      competition_level: 0.1,
+    };
+    expect(() => rankCandidates([v2Candidate()], { weights: w, strategicContext: strategicCtx })).not.toThrow();
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
@@ -39,14 +39,14 @@ function createMockSupabase(strategyData = null, nurseryItems = []) {
   return { from: vi.fn(() => chain), _chain: chain };
 }
 
+// SD-LEO-ENH-TREND-SCANNER-SCORING-001 (Checkpoint 2): mock now matches the
+// actual `client.complete(systemPrompt, prompt, opts)` API used by
+// callLLMForCandidates. Prior `messages.create` shape was a pre-existing test bug
+// masked by the silent [] return path that has since been hardened (FR-7).
 function createMockLlm(candidates) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify(candidates) }],
-      }),
-    },
+    complete: vi.fn().mockResolvedValue(JSON.stringify(candidates)),
   };
 }
 
@@ -59,9 +59,13 @@ const defaultStrategy = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 5 candidates — meets the default-candidateCount post-condition floor of ceil(5/2)=3 (FR-7).
   mockLlmClient = createMockLlm([
-    { name: 'Venture A', problem_statement: 'Problem A', solution: 'Solution A', target_market: 'Market A', automation_feasibility: 8, competition_level: 'low' },
-    { name: 'Venture B', problem_statement: 'Problem B', solution: 'Solution B', target_market: 'Market B', automation_feasibility: 6, competition_level: 'high' },
+    { name: 'Venture A', problem_statement: 'Problem A', solution: 'Solution A', target_market: 'Market A', automation_feasibility: 8, competition_level: 'low',    monthly_revenue_potential: '$10K/month' },
+    { name: 'Venture B', problem_statement: 'Problem B', solution: 'Solution B', target_market: 'Market B', automation_feasibility: 6, competition_level: 'high',   monthly_revenue_potential: '$5K/month' },
+    { name: 'Venture C', problem_statement: 'Problem C', solution: 'Solution C', target_market: 'Market C', automation_feasibility: 7, competition_level: 'medium', monthly_revenue_potential: '$3K/month' },
+    { name: 'Venture D', problem_statement: 'Problem D', solution: 'Solution D', target_market: 'Market D', automation_feasibility: 5, competition_level: 'low',    monthly_revenue_potential: '$2K/month' },
+    { name: 'Venture E', problem_statement: 'Problem E', solution: 'Solution E', target_market: 'Market E', automation_feasibility: 9, competition_level: 'low',    monthly_revenue_potential: '$20K/month' },
   ]);
   mockSupabase = createMockSupabase(defaultStrategy);
 });
@@ -94,7 +98,7 @@ describe('executeDiscoveryMode', () => {
     );
 
     expect(mockSupabase.from).toHaveBeenCalledWith('discovery_strategies');
-    expect(mockLlmClient.messages.create).toHaveBeenCalled();
+    expect(mockLlmClient.complete).toHaveBeenCalled();
     expect(result).not.toBeNull();
     expect(result.origin_type).toBe('discovery');
     expect(result.discovery_strategy).toBe('trend_scanner');
@@ -107,7 +111,8 @@ describe('executeDiscoveryMode', () => {
       { supabase: mockSupabase, logger: silentLogger, llmClient: mockLlmClient }
     );
 
-    const prompt = mockLlmClient.messages.create.mock.calls[0][0].messages[0].content;
+    // client.complete(systemPrompt, prompt, opts) — assert on prompt arg.
+    const prompt = mockLlmClient.complete.mock.calls[0][1];
     expect(prompt).toContain('3');
   });
 
@@ -117,17 +122,19 @@ describe('executeDiscoveryMode', () => {
       { supabase: mockSupabase, logger: silentLogger, llmClient: mockLlmClient }
     );
 
-    const prompt = mockLlmClient.messages.create.mock.calls[0][0].messages[0].content;
+    const prompt = mockLlmClient.complete.mock.calls[0][1];
     expect(prompt).toContain('budget_range');
   });
 
-  test('returns null when LLM returns no candidates', async () => {
+  test('throws LLMUndercountError when LLM returns no candidates (post-FR-7 hardening)', async () => {
     const emptyLlm = createMockLlm([]);
-    const result = await executeDiscoveryMode(
-      { strategy: 'trend_scanner' },
-      { supabase: mockSupabase, logger: silentLogger, llmClient: emptyLlm }
-    );
-    expect(result).toBeNull();
+    // Prior behavior was silent null return (masking the failure); FR-7 surfaces this as an error.
+    await expect(
+      executeDiscoveryMode(
+        { strategy: 'trend_scanner' },
+        { supabase: mockSupabase, logger: silentLogger, llmClient: emptyLlm }
+      )
+    ).rejects.toThrow(/undercount|empty_response/);
   });
 
   test('returns PathOutput with metadata including strategy info', async () => {

--- a/tests/unit/eva/stage-zero/utils/parse-revenue.test.js
+++ b/tests/unit/eva/stage-zero/utils/parse-revenue.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for parseRevenuePotential helper (FR-2, AC-6, TS-6).
+ * Asserts the helper handles >=8 documented LLM revenue input forms.
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001 Checkpoint 2 / US-006.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { parseRevenuePotential } from '../../../../../lib/eva/stage-zero/utils/parse-revenue.js';
+
+describe('parseRevenuePotential — documented input forms (AC-6)', () => {
+  const cases = [
+    { input: '$5K/month',          expected: { low: 5000,    high: 5000,    currency: 'USD' } },
+    { input: '$5,000-$50,000/mo',  expected: { low: 5000,    high: 50000,   currency: 'USD' } },
+    { input: '$1K+/month',         expected: { low: 1000,    high: 1000,    currency: 'USD' } },
+    { input: '$500-$2000 monthly', expected: { low: 500,     high: 2000,    currency: 'USD' } },
+    { input: '~$10K MRR',          expected: { low: 10000,   high: 10000,   currency: 'USD' } },
+    { input: '$2K+',               expected: { low: 2000,    high: 2000,    currency: 'USD' } },
+    { input: '$60K/year',          expected: { low: 5000,    high: 5000,    currency: 'USD' } },
+    { input: '$10M/year',          expected: { low: 833333,  high: 833333,  currency: 'USD' } },
+  ];
+
+  test.each(cases)('parses "$input" → low/high', ({ input, expected }) => {
+    const result = parseRevenuePotential(input);
+    expect(result).toEqual(expected);
+  });
+
+  test('covers at least 8 documented input forms', () => {
+    expect(cases.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe('parseRevenuePotential — null fallback (no throws)', () => {
+  test.each([
+    'unknown',
+    '',
+    '   ',
+    'TBD',
+    'see attached',
+    null,
+    undefined,
+    42, // non-string
+    {},
+    [],
+  ])('returns null for unparseable input %p', (input) => {
+    expect(parseRevenuePotential(input)).toBeNull();
+  });
+
+  test('does not throw on weird unicode', () => {
+    expect(() => parseRevenuePotential('💰 $5K')).not.toThrow();
+    // The regex still extracts $5K → 5000
+    expect(parseRevenuePotential('💰 $5K')).toEqual({ low: 5000, high: 5000, currency: 'USD' });
+  });
+});
+
+describe('parseRevenuePotential — yearly normalization', () => {
+  test('yearly is divided by 12', () => {
+    expect(parseRevenuePotential('$120K/year')).toEqual({ low: 10000, high: 10000, currency: 'USD' });
+  });
+
+  test('annual is divided by 12', () => {
+    expect(parseRevenuePotential('$60K annually')).toEqual({ low: 5000, high: 5000, currency: 'USD' });
+  });
+
+  test('p.a. is treated as yearly', () => {
+    expect(parseRevenuePotential('$24K p.a.')).toEqual({ low: 2000, high: 2000, currency: 'USD' });
+  });
+
+  test('default is monthly when ambiguous', () => {
+    expect(parseRevenuePotential('$10K')).toEqual({ low: 10000, high: 10000, currency: 'USD' });
+  });
+});
+
+describe('parseRevenuePotential — range detection', () => {
+  test('hyphen-separated range', () => {
+    expect(parseRevenuePotential('$1K-$5K')).toEqual({ low: 1000, high: 5000, currency: 'USD' });
+  });
+
+  test('"to" separated range', () => {
+    expect(parseRevenuePotential('$1,000 to $5,000')).toEqual({ low: 1000, high: 5000, currency: 'USD' });
+  });
+
+  test('comma-numeric ranges parsed correctly', () => {
+    expect(parseRevenuePotential('$5,000-$50,000/mo')).toEqual({ low: 5000, high: 50000, currency: 'USD' });
+  });
+
+  test('decimal shorthand: $5.5K', () => {
+    expect(parseRevenuePotential('$5.5K/month')).toEqual({ low: 5500, high: 5500, currency: 'USD' });
+  });
+
+  test('billion shorthand: $2B/year', () => {
+    expect(parseRevenuePotential('$2B/year')).toEqual({ low: 166666667, high: 166666667, currency: 'USD' });
+  });
+});

--- a/tests/unit/eva/stage-zero/utils/strategic-fit.test.js
+++ b/tests/unit/eva/stage-zero/utils/strategic-fit.test.js
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for computeStrategicFit (FR-3).
+ *
+ * Covers >=6 cases per AC-7: null context, empty themes, full overlap, no overlap,
+ * partial overlap, malformed context.
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import { computeStrategicFit } from '../../../../../lib/eva/stage-zero/utils/strategic-fit.js';
+
+const silentLogger = { warn: vi.fn() };
+
+const baseCandidate = {
+  target_market: 'B2B SaaS startups in fintech',
+  solution: 'AI-driven automation for invoice reconciliation',
+  revenue_model: 'subscription',
+  problem_statement: 'manual reconciliation is slow',
+  automation_approach: 'fully autonomous agents',
+};
+
+describe('computeStrategicFit — null/malformed context fallback (50)', () => {
+  test('null context returns 50', () => {
+    expect(computeStrategicFit(baseCandidate, null, { logger: silentLogger })).toBe(50);
+  });
+
+  test('undefined context returns 50', () => {
+    expect(computeStrategicFit(baseCandidate, undefined)).toBe(50);
+  });
+
+  test('non-object context returns 50', () => {
+    expect(computeStrategicFit(baseCandidate, 'not-an-object', { logger: silentLogger })).toBe(50);
+  });
+
+  test('context with no themes returns 50 (empty extraction)', () => {
+    expect(computeStrategicFit(baseCandidate, {}, { logger: silentLogger })).toBe(50);
+  });
+
+  test('logs WARN when context provided but themes empty', () => {
+    const logger = { warn: vi.fn() };
+    computeStrategicFit(baseCandidate, { not_themes: 'something' }, { logger });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});
+
+describe('computeStrategicFit — overlap scoring', () => {
+  test('full overlap with all themes returns 100', () => {
+    const ctx = { themes: ['fintech', 'automation', 'subscription'] };
+    expect(computeStrategicFit(baseCandidate, ctx)).toBe(100);
+  });
+
+  test('no overlap returns 0', () => {
+    const ctx = { themes: ['gaming', 'mobile-first', 'consumer-social'] };
+    const candidate = { ...baseCandidate, target_market: 'enterprise law firms', solution: 'document review automation', revenue_model: 'per-seat licensing' };
+    expect(computeStrategicFit(candidate, ctx)).toBe(0);
+  });
+
+  test('partial overlap (1 of 3 themes) returns 33', () => {
+    const ctx = { themes: ['fintech', 'gaming', 'consumer-social'] };
+    expect(computeStrategicFit(baseCandidate, ctx)).toBe(33);
+  });
+
+  test('partial overlap (2 of 4 themes) returns 50', () => {
+    const ctx = { themes: ['fintech', 'automation', 'gaming', 'consumer-social'] };
+    expect(computeStrategicFit(baseCandidate, ctx)).toBe(50);
+  });
+});
+
+describe('computeStrategicFit — context source variants', () => {
+  test('formattedPromptBlock string is used as a single theme', () => {
+    const ctx = { formattedPromptBlock: 'Strategic priority: fintech automation for SaaS startups' };
+    const score = computeStrategicFit(baseCandidate, ctx);
+    expect(score).toBe(100); // single theme, the candidate text overlaps it
+  });
+
+  test('strategic_objectives array is used as fallback themes', () => {
+    const ctx = {
+      strategic_objectives: [
+        { objective: 'expand into fintech vertical' },
+        { objective: 'capture enterprise SaaS market' },
+      ],
+    };
+    const score = computeStrategicFit(baseCandidate, ctx);
+    expect(score).toBeGreaterThanOrEqual(50);
+  });
+
+  test('vision_statement string is used as fallback theme', () => {
+    const ctx = { vision_statement: 'AI-first fintech automation for the next decade' };
+    const score = computeStrategicFit(baseCandidate, ctx);
+    expect(score).toBe(100);
+  });
+});
+
+describe('computeStrategicFit — guards', () => {
+  test('non-object candidate returns 50', () => {
+    expect(computeStrategicFit(null, { themes: ['x'] })).toBe(50);
+    expect(computeStrategicFit(undefined, { themes: ['x'] })).toBe(50);
+    expect(computeStrategicFit('a string', { themes: ['x'] })).toBe(50);
+  });
+
+  test('candidate with all empty fields returns 50 (no token to compare)', () => {
+    const empty = { target_market: '', solution: '', revenue_model: '', problem_statement: '', automation_approach: '' };
+    expect(computeStrategicFit(empty, { themes: ['fintech'] })).toBe(50);
+  });
+
+  test('returns integer in [0, 100]', () => {
+    const ctx = { themes: ['fintech', 'automation', 'subscription', 'B2B', 'SaaS'] };
+    const score = computeStrategicFit(baseCandidate, ctx);
+    expect(Number.isInteger(score)).toBe(true);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});

--- a/tests/unit/scripts/stage-zero-queue-processor.test.js
+++ b/tests/unit/scripts/stage-zero-queue-processor.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit test for FR-7 / FR-4e queue processor extensions:
+ *  - catch block maps thrown error class → error_details.error_type
+ *  - success path surfaces prompt_version in result + typed column
+ *
+ * Part of SD-LEO-ENH-TREND-SCANNER-SCORING-001 Checkpoint 3.
+ *
+ * Tests the specific contract surface — error_type values that downstream
+ * dashboards distinguish (parse_failure | empty_response | undercount | timeout | other).
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Module references the actual error classes via duck-typing (err.errorType).
+import {
+  LLMEmptyResponseError,
+  LLMParseError,
+  LLMUndercountError,
+} from '../../../lib/eva/stage-zero/paths/discovery-mode.js';
+
+vi.mock('../../../lib/eva/stage-zero/stage-zero-orchestrator.js', () => ({
+  executeStageZero: vi.fn(),
+}));
+
+import { executeStageZero } from '../../../lib/eva/stage-zero/stage-zero-orchestrator.js';
+import { processRequest } from '../../../scripts/stage-zero-queue-processor.js';
+
+let updateCalls;
+let supabase;
+
+function makeSupabase() {
+  updateCalls = [];
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      gt: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      update: vi.fn((payload) => {
+        updateCalls.push(payload);
+        return { eq: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    })),
+  };
+}
+
+const baseRequest = {
+  id: 'req-1',
+  metadata: { path: 'discovery_mode', strategy: 'trend_scanner' },
+  priority: 1,
+  prompt: 'test',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabase = makeSupabase();
+});
+
+describe('processRequest — error_type mapping (FR-7)', () => {
+  test('LLMParseError → error_details.error_type=parse_failure', async () => {
+    executeStageZero.mockRejectedValue(new LLMParseError({
+      strategyName: 'trend_scanner', promptVersion: 'v', responseLength: 50,
+    }));
+    await processRequest(supabase, baseRequest);
+
+    const failedUpdate = updateCalls.find(u => u.status === 'failed');
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate.error_details.error_type).toBe('parse_failure');
+    expect(failedUpdate.error_details.strategy_name).toBe('trend_scanner');
+    expect(failedUpdate.error_details.prompt_version).toBe('v');
+  });
+
+  test('LLMEmptyResponseError → error_details.error_type=empty_response', async () => {
+    executeStageZero.mockRejectedValue(new LLMEmptyResponseError({
+      strategyName: 'trend_scanner', promptVersion: 'v', responseLength: 0,
+    }));
+    await processRequest(supabase, baseRequest);
+
+    const failedUpdate = updateCalls.find(u => u.status === 'failed');
+    expect(failedUpdate.error_details.error_type).toBe('empty_response');
+  });
+
+  test('LLMUndercountError → error_details.error_type=undercount + expected/actual', async () => {
+    executeStageZero.mockRejectedValue(new LLMUndercountError({
+      strategyName: 'trend_scanner', promptVersion: 'v', expected: 5, actual: 1,
+    }));
+    await processRequest(supabase, baseRequest);
+
+    const failedUpdate = updateCalls.find(u => u.status === 'failed');
+    expect(failedUpdate.error_details.error_type).toBe('undercount');
+    expect(failedUpdate.error_details.expected).toBe(5);
+    expect(failedUpdate.error_details.actual).toBe(1);
+  });
+
+  test('TimeoutError-shaped error → error_type=timeout', async () => {
+    const err = new Error('Operation timed out after 60s');
+    err.name = 'TimeoutError';
+    executeStageZero.mockRejectedValue(err);
+    await processRequest(supabase, baseRequest);
+
+    const failedUpdate = updateCalls.find(u => u.status === 'failed');
+    expect(failedUpdate.error_details.error_type).toBe('timeout');
+  });
+
+  test('Unknown / generic error → error_type=other', async () => {
+    executeStageZero.mockRejectedValue(new Error('something else broke'));
+    await processRequest(supabase, baseRequest);
+
+    const failedUpdate = updateCalls.find(u => u.status === 'failed');
+    expect(failedUpdate.error_details.error_type).toBe('other');
+  });
+});
+
+describe('processRequest — success path (FR-4e)', () => {
+  test('surfaces prompt_version on top-level result + writes typed column', async () => {
+    executeStageZero.mockResolvedValue({
+      decision: 'ready',
+      duration_ms: 1234,
+      brief: { metadata: { prompt_version: '2026-04-28-v2' } },
+    });
+    await processRequest(supabase, baseRequest);
+
+    const successUpdate = updateCalls.find(u => u.status === 'completed');
+    expect(successUpdate).toBeDefined();
+    expect(successUpdate.prompt_version).toBe('2026-04-28-v2');
+    expect(successUpdate.result.prompt_version).toBe('2026-04-28-v2');
+  });
+
+  test('null prompt_version when brief lacks one (legacy strategies)', async () => {
+    executeStageZero.mockResolvedValue({
+      decision: 'ready',
+      duration_ms: 1234,
+      brief: { metadata: {} },
+    });
+    await processRequest(supabase, baseRequest);
+
+    const successUpdate = updateCalls.find(u => u.status === 'completed');
+    expect(successUpdate.prompt_version).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Trend Scanner scorer was reading only 2 of 9 LLM-emitted fields, had no prompt versioning, and silently completed on JSON parse failures. This SD widens the scorer to a 5-field weighted composite, stamps a prompt_version through 5 touchpoints, and converts silent failures into typed errors with informative `status='failed'` rows.

## Scope

- **FR-1 (rankCandidates)**: 2-field formula → 5-field weighted composite (automation_feasibility 0.30, monthly_revenue_potential 0.25, target_market_specificity 0.20, strategic_fit 0.15, competition_level 0.10) with score_attribution emission. Weights sum-to-1.0 asserted at module load (TR-1).
- **FR-2 (parseRevenuePotential)**: new helper at `lib/eva/stage-zero/utils/parse-revenue.js` handles 8+ LLM revenue forms ($5K/month, $5K-$50K/mo, $1K+/month, $60K/year → /12, etc.), yearly→monthly normalization, range detection, decimal/billion shorthand. Returns null for unparseable; never throws.
- **FR-3 (computeStrategicFit)**: new helper at `lib/eva/stage-zero/utils/strategic-fit.js`, keyword-overlap heuristic with graceful 50-neutral fallback on null/malformed context.
- **FR-4 (prompt versioning)**: new constant `TREND_SCANNER_PROMPT_VERSION='2026-04-28-v2'` at `lib/eva/stage-zero/paths/discovery-mode-versions.js`, stamped through 5 touchpoints: (a) runTrendScanner candidate output; (b) executeDiscoveryMode PathOutput.metadata; (c) chairman-review.persistVentureBrief origin_metadata; (d) ehg/src/hooks/useStageZeroQueue.ts insert payload (sibling [PR](https://github.com/rickfelix/ehg/pull/new/feat/SD-LEO-ENH-TREND-SCANNER-SCORING-001)); (e) queue-processor result/typed-column.
- **FR-5 (column migration)**: `database/migrations/20260428_stage_zero_prompt_version.sql` adds nullable `prompt_version` columns to `stage_zero_requests` + `discovery_strategies` with partial index, reversible DOWN block, two-stage deploy doc (TR-3, ≥30s wait between column-add and code-change merges).
- **FR-6 (RPC update)**: `database/migrations/20260428_stage_zero_prompt_version_rpc.sql` adds `prompt_version` to `get_discovery_strategy_scores` as a NEW TABLE column with `COALESCE(prompt_version, 'v1-pre-versioning')` default — **PA-003 BLOCKING** preserved (NOT raw GROUP BY shape change; flat-shape consumers unaffected; TR-5).
- **FR-7 (silent-failure hardening)**: typed errors `LLMEmptyResponseError`, `LLMParseError`, `LLMUndercountError` replace silent `[]` returns in `callLLMForCandidates`. `runTrendScanner` post-condition gate at `ceil(candidateCount/2)`. Conservative `runNurseryReeval` gate (≥1 input AND 0 output). Queue-processor catch maps `err.errorType` → `error_details.error_type` (`parse_failure | empty_response | undercount | timeout | other`), reusing existing failure path (TR-6).
- **FR-8 (test coverage)**: 97 vitest cases across 8 files (5 new + 3 extended).

## Test plan

- [x] `npx vitest run tests/unit/eva/stage-zero/paths/discovery-mode-rank.test.js tests/unit/eva/stage-zero/paths/discovery-mode-failure.test.js tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js tests/unit/eva/stage-zero/paths/discovery-mode.test.js tests/unit/eva/stage-zero/utils/parse-revenue.test.js tests/unit/eva/stage-zero/utils/strategic-fit.test.js tests/unit/scripts/stage-zero-queue-processor.test.js tests/unit/database/migrations/stage-zero-prompt-version.test.js` → **97/97 pass**
- [x] Coverage on new code: `parse-revenue.js` 100% lines / 95.83% branches; `strategic-fit.js` 100% / 89.79%; `discovery-mode-versions.js` 100%
- [x] Pre-existing baseline: 46 stage-zero failures unrelated to this SD (was 52 before — net reduction of 6 by fixing the `discovery-mode.test.js` mock-vs-API drift that FR-7 hardening surfaced)
- [ ] **Two-stage deploy required (TR-3)**: merge column migration → wait ≥30s for queue processor schema cache refresh → merge RPC migration → merge code change. See migration headers for the canonical order. CI cannot enforce this; operator must respect it manually.
- [ ] Post-merge integration smoke: trigger one trend_scanner discovery_mode request; verify `stage_zero_requests.prompt_version='2026-04-28-v2'`, `metadata.stage_zero.origin_metadata.prompt_version` populated on the venture row, and `get_discovery_strategy_scores()` returns rows for `prompt_version='2026-04-28-v2'` AND `prompt_version='v1-pre-versioning'` for legacy ventures.
- [ ] Manual chairman smoke: open DiscoveryModeDialog and confirm zero UI delta vs v1 (AC-9).

## Sibling PR (cross-repo)

This SD spans two repos. The ehg/ side carries hook-only changes (no UI) and is shipped via:
- ehg branch: `feat/SD-LEO-ENH-TREND-SCANNER-SCORING-001`
- ehg PR: opening alongside this one
- ehg files: `src/hooks/useStageZeroQueue.ts` (insert payload `prompt_version_hint`) + `src/hooks/useDiscoveryStrategyScores.ts` (additive `prompt_version?: string` field on `StrategyScore`)

## Process notes (harness defects deferred to backlog)

- SD's `target_application='EHG'` is misclassified — primary code lives in EHG_Engineer. `sd-start.js` worktree creation routed to wrong repo; manual fixup on `strategic_directives_v2.worktree_path` + `claude_sessions.worktree_path` was required. Captured in `harness-backlog.md` 2026-04-28; root-cause SD filed as `SD-LEO-INFRA-START-WORKTREE-BRANCH-001` (worktree created off main repo HEAD instead of `origin/main`, causing this PR to need cherry-picking onto a clean base).
- `GATE_TEST_COVERAGE_QUALITY` Playwright timeout (60s) at EXEC-TO-PLAN — backend SD with no UI tests, this gate is a known harness defect; bypassed with full reason citing the SD-ID. Documented in `feedback_playwright_coverage_gate_timeout_backend_sds.md`.
- 5 additional schema-drift / harness defects captured in `harness-backlog.md` for a future campaign-mode session.

## LEO Protocol gates

- LEAD-TO-PLAN: 94
- PLAN-TO-EXEC: 93
- EXEC-TO-PLAN: 96 (1 documented bypass)
- PLAN-TO-LEAD: 96
- testing-agent verdict: PASS confidence 95 (sub_agent_execution_results id `93404246-03a9-470b-a95c-541383524b37`)
- retro-agent: SD-completion retrospective `0d0bb434-8e60-442c-a7ce-83ec66b74c9e` (quality_score=80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)