### PR TITLE
fix(QF-20260428-RETRO-AGENT-LESSON-TRIAGE): bake lesson-triage step into retro-agent prompt

### DIFF
--- a/.claude/agents/retro-agent.partial
+++ b/.claude/agents/retro-agent.partial
@@ -164,6 +164,73 @@ node scripts/execute-subagent.js --code RETRO --sd-id <SD-ID>
 
 **Evidence**: SD-A11Y-FEATURE-BRANCH-001 - Quality score calculation trigger ensures comprehensive retrospectives
 
+## Lesson Triage — Domain-Specific vs Tooling-Gap (REQUIRED)
+
+> **Why this exists**: Without triage, retros routinely emit "lessons" that are actually symptoms of tooling gaps. The same gap then recurs SD after SD because the lesson was prose nobody queries while the systemic fix was never filed. Memorializing a symptom as a lesson is anti-learning — it normalizes the gap.
+
+**For EACH candidate `key_learning` you are about to write, ask:**
+
+> *"Would tightening tooling X prevent this from ever needing to be re-learned on a future SD? Y/N"*
+
+### If YES (tooling gap)
+This is NOT a true lesson. The lesson is implicit in "this gap exists and is unaddressed." Two-step handling:
+
+1. **File the gap** in the appropriate venue:
+   - Single-line, fast-to-fix → append to `docs/harness-backlog.md` (one-line entry per format in that file)
+   - Tier 1 (≤30 LOC) targeted fix → file `QF-YYYYMMDD-<descriptor>` via `scripts/create-quick-fix.js`
+   - Tier 3 (framework-surface, >75 LOC, or risk keywords) → file `SD-LEO-INFRA-*` via `scripts/leo-create-sd.js --from-plan`
+
+2. **Rewrite the lesson** to name the systemic gap and reference the filed item, NOT to memorialize the symptom:
+   - **BAD** (memorializes the symptom): `"Cross-repo target_application misclassification → manual worktree path fixup"`
+   - **GOOD** (names the gap + tracks the fix): `"Cross-repo SDs require manual worktree fixup until sd-start.js reads the explicit ## Target Application plan header (filed SD-LEO-INFRA-START-WORKTREE-BRANCH-001)"`
+
+The rewritten lesson is durable: when the SD ships, future retros can verify the lesson is now a closed loop. When the SD is still open, future operators see the active gap.
+
+### If NO (true domain-specific lesson)
+Keep the lesson as a concrete, file/line-anchored insight that future SD authors in the same domain would benefit from. Examples that pass triage:
+
+- `"parseRevenuePotential regex with ([KMB])? unanchored at end matched 'm' in 'monthly' → $2000 monthly parsed as $2 billion. Lookahead (?![a-z]) is required when the suffix can be followed by alpha context."` (regex craft, no tooling fix)
+- `"Tie-break tests for weighted composites need intentionally-constructed ties (e.g. weights={automation_feasibility:0,...,strategic_fit:1.0}) — assuming the largest input dominates the composite produces a wrong oracle."` (test design, no tooling fix)
+
+### Required metadata block
+
+In the retrospective's `metadata` jsonb column, populate `lesson_triage` as a sibling key. One entry per `key_learning`. Shape:
+
+```json
+{
+  "lesson_triage": [
+    {
+      "lesson_index": 0,
+      "lesson_text": "<verbatim from key_learnings[0]>",
+      "classification": "domain_specific",
+      "rationale": "regex craft; no tooling can know weight semantics ahead of time"
+    },
+    {
+      "lesson_index": 1,
+      "lesson_text": "<verbatim — already rewritten to name the gap>",
+      "classification": "tooling_gap",
+      "filed_as": { "venue": "harness_backlog | qf | sd", "ref": "<line-N or QF-... or SD-...>" },
+      "rationale": "if sd-start read the plan-content header, this would never recur"
+    }
+  ]
+}
+```
+
+### Self-test before INSERT
+
+Before inserting the retrospective row, scan `key_learnings` for any phrase that looks like a tooling gap:
+- "manual workaround / fixup / patch"
+- "had to bypass / had to override"
+- "X drift between Y and Z"
+- "schema/enum mismatch"
+- "every time we / always have to"
+
+If any match AND the corresponding `lesson_triage[i].classification !== 'tooling_gap'`, you have either misclassified a tooling gap as domain-specific, OR you've left a tooling-gap symptom in the lesson without filing the fix. Re-triage before inserting.
+
+### Why this is a quality gate, not a nice-to-have
+
+A retro that lists 8 lessons but classifies 0 as tooling_gap is suspicious — modern SDs almost always surface ≥1 systemic gap. Conversely, a retro that classifies 8/8 as tooling_gap is also suspicious — domain-specific craft (regex, schema design, test oracles) almost always produces ≥1 true lesson. The triage forces a deliberate classification rather than the lazy "everything is a lesson" default.
+
 ## Database-Driven Validation (SD-A11Y-ONBOARDING-001, SD-VIF-TIER-001)
 
 ### Database Constraints + Trigger Functions


### PR DESCRIPTION
## Summary

Closes the meta-defect surfaced during SD-LEO-ENH-TREND-SCANNER-SCORING-001's closeout: retros emit "lessons" that are actually symptoms of unfixed tooling gaps. Without classification, those gaps recur SD-after-SD because the lesson is buried prose nobody queries while the systemic fix is never filed.

This QF bakes a **Lesson Triage** step into `.claude/agents/retro-agent.partial` so every future retro must classify each `key_learning` as either `domain_specific` (keep as file/line-anchored craft) or `tooling_gap` (file in backlog/QF/SD AND rewrite the lesson to name the gap + reference the filed item).

## Why this matters

The trend-scanner SD that just shipped had 8 candidate lessons. After your conversation surfaced the lesson-vs-tooling-gap distinction, **4 of the 8** were re-classified as systemic gaps:
- Cross-repo target_application misclassification → SD-LEO-INFRA-START-WORKTREE-BRANCH-001 (filed)
- Playwright timeout for backend SDs → QF-20260428-PLAYWRIGHT-BACKEND (just merged in PR #3406)
- Schema drift between memory and live DB → harness-backlog
- node_modules wipe + handoff health check → harness-backlog

That's a 50% triage rate. Without this prompt change, future retros default to "everything is a lesson" and those gaps stay invisible.

## Changes

**`.claude/agents/retro-agent.partial`** (+67 LOC, single hunk between `Quality Score Requirements` and `Database-Driven Validation`):

1. New `Lesson Triage — Domain-Specific vs Tooling-Gap (REQUIRED)` section with:
   - The triage rule (one yes/no question per candidate lesson)
   - Filing-venue routing by size: harness-backlog (1-line) / QF (≤30 LOC) / SD-LEO-INFRA (>75 LOC or framework-surface)
   - Lesson-rewrite examples (BAD vs GOOD)
   - Required `metadata.lesson_triage[]` jsonb array shape with per-lesson classification + rationale + `filed_as.{venue, ref}`
   - Self-test heuristic: scan `key_learnings` for tooling-gap phrase markers before INSERT

2. Self-balancing safeguard: a retro classifying 0/N as tooling_gap is suspicious; classifying N/N as tooling_gap is also suspicious. The triage forces deliberate per-lesson classification rather than the lazy default.

## Test plan

- [x] `node scripts/generate-agent-manifest.js` succeeds — manifest enumerates 17 active + 3 archived agents
- [x] `.partial` is the source of truth (`.md` is gitignored and regenerated on next SessionStart compile)
- [ ] Next SD's PLAN-TO-LEAD retro-agent invocation will populate `metadata.lesson_triage` (verifiable on first downstream SD)
- [ ] Retro-cross-check: re-running the trend-scanner SD's retro under this prompt would produce `lesson_triage` with 4 of 8 entries classified as `tooling_gap`

## Override path

This is a quality requirement, not a flag-gated behavior. There is no `--no-triage` escape hatch by design — if a future operator believes a lesson should bypass the triage, they can manually populate `metadata.lesson_triage[i] = {classification: 'domain_specific', rationale: '<explicit-reason>'}` to satisfy the contract without changing the lesson text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)