### PR TITLE
feat(SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001): quality-checker V1→V2 imperative rephrase (PR #2 of 5)

### DIFF
--- a/scripts/__tests__/golden/quality-checker/fixture-001.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-001.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "layout" },
+  "v1_output": "You are a web layout forensics expert. Compare the reference site DNA with the built output.\nEvaluate structural alignment: grid systems, section ordering, content flow, responsive breakpoints.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 layout prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:00Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-002.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-002.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "visual_composition" },
+  "v1_output": "You are a visual design analyst. Compare the reference and built output.\nEvaluate: color palette adherence, typography hierarchy, whitespace rhythm, visual weight distribution.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 visual_composition prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:01Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-003.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-003.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "design_system" },
+  "v1_output": "You are a design system auditor. Compare reference tokens/components with built output.\nEvaluate: color token consistency, spacing scale adherence, component library match, typography scale.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 design_system prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:02Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-004.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-004.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "interaction" },
+  "v1_output": "You are a UX interaction analyst. Compare interactive patterns between reference and built output.\nEvaluate: hover states, transitions, navigation patterns, form behaviors, micro-interactions.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 interaction prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:03Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-005.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-005.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "technical" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 technical prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:04Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-006.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-006.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "accessibility" },
+  "v1_output": "You are a WCAG accessibility auditor. Evaluate the built output against WCAG 2.1 AA.\nEvaluate: alt text, ARIA labels, keyboard navigation, color contrast, focus management, heading hierarchy.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 accessibility prompt has all required output-spec markers" },
+  "captured_at": "2026-04-28T20:30:05Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-007.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-007.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "unknown_domain" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) for unknown domainKey" },
+  "captured_at": "2026-04-28T20:30:06Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-008.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-008.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) for empty-string domainKey" },
+  "captured_at": "2026-04-28T20:30:07Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-009.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-009.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "Layout" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) — case-sensitive keys; 'Layout' != 'layout'" },
+  "captured_at": "2026-04-28T20:30:08Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-010.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-010.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "visualcomposition" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) — underscore omitted in domain key" },
+  "captured_at": "2026-04-28T20:30:09Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-011.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-011.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "perf" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) — short token not in DOMAIN_RUBRIC" },
+  "captured_at": "2026-04-28T20:30:10Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/golden/quality-checker/fixture-012.json
+++ b/scripts/__tests__/golden/quality-checker/fixture-012.json
@@ -1,0 +1,7 @@
+{
+  "input": { "domainKey": "a11y" },
+  "v1_output": "You are a frontend technical auditor. Evaluate the built output's technical quality.\nEvaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.\n\nReturn ONLY valid JSON:\n{\n  \"score\": <0-100>,\n  \"strengths\": [\"...\"],\n  \"gaps\": [{\"issue\": \"...\", \"severity\": \"critical|high|medium\", \"fix\": \"...\"}]\n}",
+  "validator_result": { "passed": true, "details": "v1 fallback (technical) — abbreviation not present in keymap" },
+  "captured_at": "2026-04-28T20:30:11Z",
+  "sanitized": true
+}

--- a/scripts/__tests__/replay/quality-checker.replay.test.js
+++ b/scripts/__tests__/replay/quality-checker.replay.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadFixturesForScript, runReplay, assertParity } from './index.mjs';
+import { buildDomainPrompt, validateDomainPromptShape } from '../../eva/srip/quality-checker.mjs';
+
+const GOLDEN_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../golden');
+
+const promptFn = async (input) => buildDomainPrompt(input.domainKey);
+const validator = (output) => validateDomainPromptShape(output);
+
+describe('replay: quality-checker (PR #2 of campaign)', async () => {
+  const fixtures = await loadFixturesForScript('quality-checker', GOLDEN_ROOT);
+
+  it('loads at least 10 sanitized fixtures (FR-2 AC-1)', () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const fixture of fixtures) {
+    it(`parity holds for ${fixture.captured_at} (domainKey="${fixture.input.domainKey}")`, async () => {
+      const { v2Result } = await runReplay({ promptFn, fixture, validator });
+      assertParity({
+        v1Result: fixture.validator_result,
+        v2Result,
+        fixturePath: fixture.captured_at,
+      });
+    });
+  }
+
+  it('V2 prompt for known domain "layout" uses imperative voice (Compare/Score/Identify/Return)', () => {
+    const prompt = buildDomainPrompt('layout');
+    expect(prompt).toMatch(/^Compare /);
+    expect(prompt).toMatch(/Score /);
+    expect(prompt).toMatch(/Identify /);
+    expect(prompt).toMatch(/Return /);
+    expect(prompt).not.toMatch(/^You are /);
+  });
+
+  it('V2 prompt falls back to technical for unknown domain key', () => {
+    const fallback = buildDomainPrompt('unknown_zzz');
+    const technical = buildDomainPrompt('technical');
+    expect(fallback).toBe(technical);
+  });
+
+  it('validateDomainPromptShape rejects empty / non-string', () => {
+    expect(validateDomainPromptShape('').passed).toBe(false);
+    expect(validateDomainPromptShape(null).passed).toBe(false);
+    expect(validateDomainPromptShape(undefined).passed).toBe(false);
+    expect(validateDomainPromptShape(42).passed).toBe(false);
+  });
+
+  it('validateDomainPromptShape rejects prompt missing output-spec markers', () => {
+    const r = validateDomainPromptShape('Just words, no JSON spec.');
+    expect(r.passed).toBe(false);
+    expect(r.details).toMatch(/missing markers/);
+  });
+});

--- a/scripts/eva/srip/quality-checker.mjs
+++ b/scripts/eva/srip/quality-checker.mjs
@@ -31,73 +31,65 @@ function getSupabase() {
 }
 
 // ============================================================================
-// LLM Domain Evaluation Prompts
+// LLM Domain Evaluation Prompts (V2 imperative — see PRD-SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001)
 // ============================================================================
 
-function buildDomainPrompt(domainKey) {
-  const prompts = {
-    layout: `You are a web layout forensics expert. Compare the reference site DNA with the built output.
-Evaluate structural alignment: grid systems, section ordering, content flow, responsive breakpoints.
+const DOMAIN_RUBRIC = {
+  layout: {
+    subject: 'layout fidelity',
+    dimensions: ['Grid systems', 'Section ordering', 'Content flow', 'Responsive breakpoints'],
+  },
+  visual_composition: {
+    subject: 'visual composition',
+    dimensions: ['Color palette adherence', 'Typography hierarchy', 'Whitespace rhythm', 'Visual weight distribution'],
+  },
+  design_system: {
+    subject: 'design system consistency',
+    dimensions: ['Color token consistency', 'Spacing scale adherence', 'Component library match', 'Typography scale'],
+  },
+  interaction: {
+    subject: 'interaction patterns',
+    dimensions: ['Hover states', 'Transitions', 'Navigation patterns', 'Form behaviors', 'Micro-interactions'],
+  },
+  technical: {
+    subject: 'technical implementation',
+    dimensions: ['Semantic HTML', 'Performance patterns', 'SEO structure', 'Code organization', 'Framework best practices'],
+  },
+  accessibility: {
+    subject: 'WCAG 2.1 AA accessibility',
+    dimensions: ['Alt text', 'ARIA labels', 'Keyboard navigation', 'Color contrast', 'Focus management', 'Heading hierarchy'],
+  },
+};
 
-Return ONLY valid JSON:
+export function buildDomainPrompt(domainKey) {
+  const rubric = DOMAIN_RUBRIC[domainKey] || DOMAIN_RUBRIC.technical;
+  const dimensionsList = rubric.dimensions.map(d => `- ${d}`).join('\n');
+  return `Compare the reference site DNA against the built output for ${rubric.subject}.
+
+Score the built output (0-100). Inspect each dimension:
+${dimensionsList}
+
+Identify up to 5 concrete strengths supporting the score. List every gap with severity (critical, high, or medium) and propose a specific fix.
+
+Return strictly this JSON, with no surrounding text:
 {
   "score": <0-100>,
   "strengths": ["..."],
   "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
+}`;
+}
 
-    visual_composition: `You are a visual design analyst. Compare the reference and built output.
-Evaluate: color palette adherence, typography hierarchy, whitespace rhythm, visual weight distribution.
-
-Return ONLY valid JSON:
-{
-  "score": <0-100>,
-  "strengths": ["..."],
-  "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
-
-    design_system: `You are a design system auditor. Compare reference tokens/components with built output.
-Evaluate: color token consistency, spacing scale adherence, component library match, typography scale.
-
-Return ONLY valid JSON:
-{
-  "score": <0-100>,
-  "strengths": ["..."],
-  "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
-
-    interaction: `You are a UX interaction analyst. Compare interactive patterns between reference and built output.
-Evaluate: hover states, transitions, navigation patterns, form behaviors, micro-interactions.
-
-Return ONLY valid JSON:
-{
-  "score": <0-100>,
-  "strengths": ["..."],
-  "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
-
-    technical: `You are a frontend technical auditor. Evaluate the built output's technical quality.
-Evaluate: semantic HTML, performance patterns, SEO structure, code organization, framework best practices.
-
-Return ONLY valid JSON:
-{
-  "score": <0-100>,
-  "strengths": ["..."],
-  "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
-
-    accessibility: `You are a WCAG accessibility auditor. Evaluate the built output against WCAG 2.1 AA.
-Evaluate: alt text, ARIA labels, keyboard navigation, color contrast, focus management, heading hierarchy.
-
-Return ONLY valid JSON:
-{
-  "score": <0-100>,
-  "strengths": ["..."],
-  "gaps": [{"issue": "...", "severity": "critical|high|medium", "fix": "..."}]
-}`,
-  };
-
-  return prompts[domainKey] || prompts.technical;
+export function validateDomainPromptShape(prompt) {
+  if (typeof prompt !== 'string' || prompt.length === 0) {
+    return { passed: false, details: 'prompt must be a non-empty string' };
+  }
+  const required = ['score', 'strengths', 'gaps', 'severity', 'critical', 'high', 'medium', 'fix', 'JSON'];
+  const lower = prompt.toLowerCase();
+  const missing = required.filter(m => !lower.includes(m.toLowerCase()));
+  if (missing.length > 0) {
+    return { passed: false, details: `missing markers: ${missing.join(',')}` };
+  }
+  return { passed: true };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

PR #2 of 5 in the **SD-LEO-INFRA-OPUS-HARNESS-PHASE-3-INLINE-SCRIPTS-001** campaign. Replaces V1 declarative inline LLM prompts with V2 imperative voice in `scripts/eva/srip/quality-checker.mjs`. Replace-and-replay (no feature flag); rollback path is `git revert`.

- **Source:** -63 / +55 in `quality-checker.mjs` → net **-8 LOC**, plus 2 added exports (`buildDomainPrompt`, `validateDomainPromptShape`) for replay tests. DOMAIN_RUBRIC drives per-domain dimensions as data, eliminating 6 duplicated string blocks.
- **Tests:** 12 sanitized golden fixtures + 1 replay test (17 cases) + 12 sanitization-walker cases = **74/74 framework tests passing**.
- **Cadence:** PR #1 (#3344) merged 2026-04-25T17:22:25Z. Cadence gate cleared 2026-04-28T17:22:25Z (3.2 h ago at commit time). Earliest workable date for PR #3 (ai-quality-judge): 2026-05-01T17:22:25Z.

## Scope (per PRD FR-4)

```
PR #1 ✅ framework standalone           (#3344 merged 2026-04-25)
PR #2 ⮕ quality-checker.mjs            (this PR)
PR #3 → ai-quality-judge                (2026-05-01+)
PR #4 → eva-intake-pipeline.js          (2026-05-04+)
PR #5 → prd-sd-041c/technical-design.js (2026-05-11+, ≥7-day window)
```

## V2 Prompt Pattern

Each domain prompt now opens with `Compare … against …`, then `Score (0-100)` with bulleted dimensions, `Identify` strengths and gaps, and `Return strictly this JSON …`. Output schema (`score`, `strengths`, `gaps[].{issue,severity,fix}`, severity ∈ {critical, high, medium}) is byte-identical to V1 — downstream parsing in `evaluateDomain` is unchanged.

`buildDomainPrompt('unknown_key')` still falls back to `technical` (covered by fixtures 7–12).

## Parity Contract

`validateDomainPromptShape(prompt)` returns `{ passed, details }`. Passes iff the prompt:
- is a non-empty string
- contains all output-spec markers: `score`, `strengths`, `gaps`, `severity`, `critical`, `high`, `medium`, `fix`, `JSON`

Each fixture's `validator_result.passed === true` (V1 baseline). `runReplay` invokes `buildDomainPrompt(input.domainKey)` and asserts the same predicate holds — `assertParity` fails fast on shape divergence (PRD FR-3 / TS-2).

## Test plan

- [x] `npx vitest run scripts/__tests__/replay/ scripts/__tests__/golden/` → 74/74 pass
- [x] 12 fixtures load + sanitize cleanly (walker)
- [x] V2 prompt is imperative (`/^Compare /`, no `/^You are /`)
- [x] Unknown domainKey falls back to `technical`
- [x] LOC delta within Tier 3 budget (193 insertions across 14 files; net source -8)

## Rollback (per PRD FR-5)

`git revert <merge SHA>` restores V1 prompts cleanly. No feature flag plumbing to clean up. The 12 golden fixtures remain as documentation of V1's prompt shape.

## Sub-agent evidence

Deferred to final EXEC-TO-PLAN handoff per FR-6 AC-3 (single retrospective evidence pass after all 5 PRs merged with stability windows observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)