### PR TITLE
feat(content-parity): DB content parity gate at /leo complete + Phase 2 audit (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,8 @@ scripts/create-*-children.js
 scripts/audit-*.js
 # Phantom-completion audit (SD-MAN-INFRA-RECONCILE-S18-S26-001) — production deliverable
 !scripts/audit-phantom-completions.js
+# DB content parity audit (SD-LEO-INFRA-CODE-CONTENT-PARITY-001) — production deliverable
+!scripts/audit-completed-sd-db-content-parity.js
 
 # One-off story generation scripts (SD-specific, use generate-user-stories.js instead)
 scripts/generate-user-stories-*.js

--- a/lib/db-content-registry-allowlist.js
+++ b/lib/db-content-registry-allowlist.js
@@ -1,0 +1,16 @@
+/**
+ * Central-registry tables eligible for DB content parity assertions.
+ * SD: SD-LEO-INFRA-CODE-CONTENT-PARITY-001 (FR-2)
+ *
+ * Adding a table requires explicit chairman-approved PR. Each addition compounds
+ * gate runtime and false-positive surface area, so the seed is intentionally narrow.
+ */
+
+export const REGISTRY_TABLES = Object.freeze([
+  'stage_config',
+  'chairman_dashboard_config',
+]);
+
+export function isAllowedRegistryTable(name) {
+  return typeof name === 'string' && REGISTRY_TABLES.includes(name);
+}

--- a/scripts/audit-completed-sd-db-content-parity.js
+++ b/scripts/audit-completed-sd-db-content-parity.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * One-time audit walker: surfaces pre-existing code-vs-DB content parity gaps
+ * in already-completed SDs.
+ * SD: SD-LEO-INFRA-CODE-CONTENT-PARITY-001 (FR-4)
+ *
+ * Usage:
+ *   node scripts/audit-completed-sd-db-content-parity.js [--since YYYY-MM-DD] [--sd-id <key>] [--dry-run]
+ *
+ * Reads each completed SD's metadata.db_content_assertions (when present), runs
+ * the same gate logic against live DB rows, and writes a feedback row per drift
+ * detected (category='harness_backlog', source_type='manual_feedback',
+ * metadata.parity_gap_detected=true, metadata.audit_run_id=<UUID>).
+ *
+ * --dry-run skips all feedback writes — prints findings to stdout only.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+import { validateDbContentParity } from '../scripts/modules/handoff/gates/db-content-parity-gate.js';
+
+function parseArgs(argv) {
+  const flags = { since: null, sdId: null, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--since') flags.since = argv[++i];
+    else if (a === '--sd-id') flags.sdId = argv[++i];
+    else if (a === '--dry-run') flags.dryRun = true;
+  }
+  return flags;
+}
+
+export async function runAudit({ supabase, since, sdId, dryRun, auditRunId }) {
+  let query = supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status, updated_at, metadata')
+    .eq('status', 'completed');
+  if (since) query = query.gte('updated_at', since);
+  if (sdId) query = query.eq('sd_key', sdId);
+
+  const { data: sds, error } = await query;
+  if (error) throw new Error(`SD walk failed: ${error.message}`);
+
+  const findings = [];
+  for (const sd of sds || []) {
+    const assertions = Array.isArray(sd.metadata?.db_content_assertions) ? sd.metadata.db_content_assertions : [];
+    if (assertions.length === 0) continue;
+
+    const result = await validateDbContentParity(sd.sd_key, supabase);
+    if (result.pass) continue;
+
+    findings.push({ sd_key: sd.sd_key, mismatches: result.mismatches });
+
+    if (dryRun) continue;
+
+    const summary = result.mismatches
+      .map((m) => `${m.table}/${JSON.stringify(m.row_filter)}: ${m.column} expected=${JSON.stringify(m.expected)} actual=${JSON.stringify(m.actual)}`)
+      .join('; ');
+    const title = `DB content parity gap: ${sd.sd_key}`;
+    await supabase.from('feedback').insert({
+      type: 'enhancement',
+      category: 'harness_backlog',
+      status: 'new',
+      severity: 'medium',
+      source_application: 'EHG_Engineer',
+      source_type: 'manual_feedback',
+      title: title.length > 120 ? title.slice(0, 117) + '...' : title,
+      description: `Audit detected ${result.mismatches.length} content-parity mismatch(es): ${summary}`,
+      metadata: {
+        logged_via: 'audit-completed-sd-db-content-parity.js',
+        deferred_from_sd_key: sd.sd_key,
+        parity_gap_detected: true,
+        audit_run_id: auditRunId,
+        mismatch_count: result.mismatches.length,
+        mismatches: result.mismatches,
+      },
+    });
+  }
+  return findings;
+}
+
+async function main() {
+  const flags = parseArgs(process.argv.slice(2));
+  const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env.');
+    process.exitCode = 1;
+    return;
+  }
+  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const auditRunId = crypto.randomUUID();
+
+  console.log(`[parity-audit] run_id=${auditRunId} dry_run=${flags.dryRun} since=${flags.since || '(all)'} sd=${flags.sdId || '(all)'}`);
+  const findings = await runAudit({ supabase, ...flags, auditRunId });
+
+  if (findings.length === 0) {
+    console.log('[parity-audit] No drift detected. ✅');
+    return;
+  }
+  for (const f of findings) {
+    console.log(`[parity-audit] DRIFT ${f.sd_key} — ${f.mismatches.length} mismatch(es)`);
+    for (const m of f.mismatches) {
+      console.log(`  ${m.table}/${JSON.stringify(m.row_filter)}: ${m.column} expected=${JSON.stringify(m.expected)} actual=${JSON.stringify(m.actual)}`);
+    }
+  }
+  console.log(`[parity-audit] ${findings.length} SD(s) with drift.${flags.dryRun ? ' (dry-run; no feedback rows written)' : ''}`);
+}
+
+const isDirectInvoke = import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` || process.argv[1].endsWith('audit-completed-sd-db-content-parity.js');
+if (isDirectInvoke) {
+  main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -26,6 +26,9 @@ import { createSubagentEvidenceGate } from '../../gates/subagent-evidence-gate.j
 // Scope Completion Verification Gate (SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-002)
 import { createScopeCompletionGate } from '../../gates/scope-completion-gate.js';
 
+// DB Content Parity Gate (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)
+import { createDbContentParityGate } from '../../gates/db-content-parity-gate.js';
+
 // Gate creators
 import {
   createPrerequisiteCheckGate,
@@ -257,6 +260,9 @@ export class PlanToLeadExecutor extends BaseExecutor {
       // SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-002: added to prevent zero-verification bypass
       gates.push(createScopeCompletionGate());
 
+      // DB Content Parity — runs after scope-completion, before /learn (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)
+      gates.push(createDbContentParityGate());
+
       return gates;
     }
 
@@ -328,6 +334,9 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // Semantic Validation Gates (SD-LEO-FEAT-SEMANTIC-VALIDATION-GATES-002)
     gates.push(createScopeAuditGate(this.supabase));
     gates.push(createChildScopeCoverageGate(this.supabase));
+
+    // DB Content Parity — runs before /learn (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)
+    gates.push(createDbContentParityGate());
 
     return gates;
   }

--- a/scripts/modules/handoff/gates/db-content-parity-gate.js
+++ b/scripts/modules/handoff/gates/db-content-parity-gate.js
@@ -1,0 +1,176 @@
+/**
+ * DB Content Parity Verification Gate
+ * SD: SD-LEO-INFRA-CODE-CONTENT-PARITY-001 (FR-1, FR-3)
+ *
+ * Reads `metadata.db_content_assertions` from a Strategic Directive row and
+ * verifies each declared expectation against the live registry-table row.
+ * Fails closed when any assertion mismatches; skips cleanly when no assertions
+ * are declared. Persists one row per run to `sd_verification_results` with
+ * verification_type='DB_CONTENT_PARITY'.
+ *
+ * Assertion shape (operator-declared in PRD-author flow):
+ *   {
+ *     table: <registry-table name from REGISTRY_TABLES>,
+ *     row_filter: { col: value, ... },
+ *     expected_columns: { col: <literal> | { regex: '<pattern>' }, ... }
+ *   }
+ *
+ * Anti-ReDoS guard (TR-6): regex pattern length ≤ 500; warns when patterns
+ * lack start/end anchors when LEO_PARITY_REGEX_REQUIRE_ANCHORS=true.
+ */
+
+import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
+import { isAllowedRegistryTable } from '../../../../lib/db-content-registry-allowlist.js';
+
+const REGEX_MAX_LENGTH = 500;
+const ANCHOR_RX = /^\^.*\$$/;
+
+function shapeError(detail, table = null, row_filter = null) {
+  return { table, row_filter, column: '__shape_error__', expected: null, actual: detail };
+}
+
+function evaluateExpectation(actualValue, expectation) {
+  if (expectation && typeof expectation === 'object' && 'regex' in expectation) {
+    const pattern = expectation.regex;
+    if (typeof pattern !== 'string') {
+      return { ok: false, reason: 'regex must be a string' };
+    }
+    if (pattern.length > REGEX_MAX_LENGTH) {
+      return { ok: false, reason: `regex exceeds ${REGEX_MAX_LENGTH}-char cap` };
+    }
+    if (process.env.LEO_PARITY_REGEX_REQUIRE_ANCHORS === 'true' && !ANCHOR_RX.test(pattern)) {
+      return { ok: false, reason: 'regex must be anchored (^...$)' };
+    }
+    let rx;
+    try {
+      rx = new RegExp(pattern);
+    } catch (e) {
+      return { ok: false, reason: `invalid regex: ${e.message}` };
+    }
+    return { ok: rx.test(String(actualValue ?? '')) };
+  }
+  return { ok: actualValue === expectation };
+}
+
+async function runAssertion(supabase, assertion) {
+  if (!assertion || typeof assertion !== 'object') {
+    return [shapeError('assertion is not an object')];
+  }
+  const { table, row_filter, expected_columns } = assertion;
+  if (!isAllowedRegistryTable(table)) {
+    return [shapeError(`table not in REGISTRY_TABLES: ${String(table)}`, table, row_filter)];
+  }
+  if (!row_filter || typeof row_filter !== 'object') {
+    return [shapeError('row_filter must be an object', table, row_filter)];
+  }
+  if (!expected_columns || typeof expected_columns !== 'object') {
+    return [shapeError('expected_columns must be an object', table, row_filter)];
+  }
+
+  let query = supabase.from(table).select(Object.keys(expected_columns).join(', '));
+  for (const [col, val] of Object.entries(row_filter)) {
+    query = query.eq(col, val);
+  }
+  const { data, error } = await query.maybeSingle();
+  if (error && error.code !== 'PGRST116') {
+    return [shapeError(`query failed: ${error.message}`, table, row_filter)];
+  }
+
+  const mismatches = [];
+  if (!data) {
+    for (const [col, expected] of Object.entries(expected_columns)) {
+      mismatches.push({ table, row_filter, column: col, expected, actual: null });
+    }
+    return mismatches;
+  }
+  for (const [col, expected] of Object.entries(expected_columns)) {
+    const actual = data[col];
+    const verdict = evaluateExpectation(actual, expected);
+    if (!verdict.ok) {
+      mismatches.push({ table, row_filter, column: col, expected, actual: actual ?? null });
+    }
+  }
+  return mismatches;
+}
+
+/**
+ * Validate code-vs-DB content parity for the given SD.
+ * @param {string} sdKey - SD key (e.g., SD-LEO-INFRA-CODE-CONTENT-PARITY-001).
+ * @param {object} [supabaseClient] - injectable Supabase client for tests.
+ * @returns {Promise<{pass: boolean, score: number, mismatches: Array, skipped: boolean, sd_uuid: string|null}>}
+ */
+export async function validateDbContentParity(sdKey, supabaseClient) {
+  const supabase = supabaseClient ?? createSupabaseServiceClient();
+
+  const { data: sd, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, metadata')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+
+  if (error || !sd) {
+    return { pass: false, score: 0, mismatches: [shapeError(`SD lookup failed: ${error?.message || 'not found'}`)], skipped: false, sd_uuid: null };
+  }
+
+  const assertions = Array.isArray(sd.metadata?.db_content_assertions) ? sd.metadata.db_content_assertions : [];
+  if (assertions.length === 0) {
+    await persistResult(supabase, sd.id, { result: 'skip', score: 100, details: { skipped: true, reason: 'no metadata.db_content_assertions' } });
+    return { pass: true, score: 100, mismatches: [], skipped: true, sd_uuid: sd.id };
+  }
+
+  const allMismatches = [];
+  for (const assertion of assertions) {
+    const ms = await runAssertion(supabase, assertion);
+    if (ms.length) allMismatches.push(...ms);
+  }
+
+  const pass = allMismatches.length === 0;
+  const score = pass ? 100 : Math.max(0, Math.round((1 - allMismatches.length / assertions.length) * 100));
+
+  await persistResult(supabase, sd.id, {
+    result: pass ? 'pass' : 'fail',
+    score,
+    details: { mismatches: allMismatches, assertion_count: assertions.length },
+  });
+
+  return { pass, score, mismatches: allMismatches, skipped: false, sd_uuid: sd.id };
+}
+
+async function persistResult(supabase, sdUuid, { result, score, details }) {
+  const { error } = await supabase.from('sd_verification_results').insert({
+    sd_id: sdUuid,
+    verification_type: 'DB_CONTENT_PARITY',
+    result,
+    score,
+    details,
+    verified_by: 'DB_CONTENT_PARITY_GATE',
+  });
+  if (error) {
+    console.warn(`[db-content-parity] sd_verification_results insert failed: ${error.message}`);
+  }
+}
+
+export function createDbContentParityGate() {
+  return {
+    name: 'DB_CONTENT_PARITY',
+    validator: async (ctx) => {
+      const sdKey = ctx.sdKey || ctx.sdId;
+      const result = await validateDbContentParity(sdKey);
+      const mismatchSummaries = result.mismatches.map(
+        (m) => `${m.table || '?'} WHERE ${JSON.stringify(m.row_filter || {})}: column=${m.column} expected=${JSON.stringify(m.expected)} actual=${JSON.stringify(m.actual)}`
+      );
+      return {
+        pass: result.pass,
+        score: result.score,
+        issues: result.pass ? [] : mismatchSummaries,
+        warnings: [],
+        skipped: result.skipped,
+      };
+    },
+    required: true,
+    blocking: true,
+    remediation: 'Migrate the named registry-table row(s) to match the code expectations declared in metadata.db_content_assertions, then re-run /leo complete. Bypass with --bypass-validation --bypass-reason "<ticket>" if migration cannot be applied immediately.',
+  };
+}
+
+export { evaluateExpectation, runAssertion, shapeError };

--- a/tests/unit/audit/db-content-parity-audit.test.js
+++ b/tests/unit/audit/db-content-parity-audit.test.js
@@ -1,0 +1,120 @@
+/**
+ * Vitest cases for scripts/audit-completed-sd-db-content-parity.js (FR-6 audit half).
+ * SD: SD-LEO-INFRA-CODE-CONTENT-PARITY-001
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runAudit } from '../../../scripts/audit-completed-sd-db-content-parity.js';
+
+function makeAuditClient({ sds, rowsByTable = {} }) {
+  const calls = { feedbackInserts: [], verificationInserts: [], registryQueries: [] };
+
+  function from(name) {
+    if (name === 'strategic_directives_v2') {
+      const queryObj = {
+        _filters: {},
+        _gte: null,
+        select: () => queryObj,
+        eq(col, val) {
+          queryObj._filters[col] = val;
+          return queryObj;
+        },
+        gte(col, val) {
+          queryObj._gte = { col, val };
+          return queryObj;
+        },
+        maybeSingle: async () => ({ data: sds.find((s) => s.sd_key === queryObj._filters.sd_key) || null, error: null }),
+        then(onFulfilled) {
+          const filtered = sds
+            .filter((sd) => Object.entries(queryObj._filters).every(([k, v]) => sd[k] === v))
+            .filter((sd) => !queryObj._gte || sd[queryObj._gte.col] >= queryObj._gte.val);
+          return Promise.resolve({ data: filtered, error: null }).then(onFulfilled);
+        },
+      };
+      return queryObj;
+    }
+    if (name === 'feedback') {
+      return {
+        insert: async (row) => {
+          calls.feedbackInserts.push(row);
+          return { error: null };
+        },
+      };
+    }
+    if (name === 'sd_verification_results') {
+      return {
+        insert: async (row) => {
+          calls.verificationInserts.push(row);
+          return { error: null };
+        },
+      };
+    }
+    // registry tables (stage_config etc.)
+    let filters = {};
+    const queryObj = {
+      select: () => queryObj,
+      eq: (col, val) => {
+        filters[col] = val;
+        return queryObj;
+      },
+      maybeSingle: async () => {
+        calls.registryQueries.push({ table: name, filters: { ...filters } });
+        const rows = rowsByTable[name] || [];
+        const match = rows.find((r) => Object.entries(filters).every(([k, v]) => r[k] === v));
+        return { data: match || null, error: null };
+      },
+    };
+    return queryObj;
+  }
+  return { from, _calls: calls };
+}
+
+const SD_WITH_DRIFT = {
+  id: 'uuid-redesign',
+  sd_key: 'SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001',
+  status: 'completed',
+  updated_at: '2026-04-21T00:00:00Z',
+  metadata: {
+    db_content_assertions: [
+      { table: 'stage_config', row_filter: { stage_number: 20 }, expected_columns: { stage_name: 'Code Quality Gate' } },
+    ],
+  },
+};
+const SD_NO_ASSERTIONS = { id: 'uuid-x', sd_key: 'SD-X', status: 'completed', updated_at: '2026-04-22T00:00:00Z', metadata: {} };
+const STAGE_CONFIG_LIVE = [{ stage_number: 20, stage_name: 'User Testing' }];
+
+describe('runAudit walker', () => {
+  it('walks completed SDs and detects pre-existing-gap on SD-REDESIGN-S18S26', async () => {
+    const client = makeAuditClient({ sds: [SD_WITH_DRIFT, SD_NO_ASSERTIONS], rowsByTable: { stage_config: STAGE_CONFIG_LIVE } });
+    const findings = await runAudit({ supabase: client, since: '2026-04-01', dryRun: false, auditRunId: 'audit-uuid-1' });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].sd_key).toBe('SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001');
+    expect(findings[0].mismatches[0]).toMatchObject({ column: 'stage_name', expected: 'Code Quality Gate', actual: 'User Testing' });
+  });
+
+  it('feedback-row writer shape: includes parity_gap_detected, audit_run_id, deferred_from_sd_key', async () => {
+    const client = makeAuditClient({ sds: [SD_WITH_DRIFT], rowsByTable: { stage_config: STAGE_CONFIG_LIVE } });
+    await runAudit({ supabase: client, since: null, dryRun: false, auditRunId: 'audit-uuid-2' });
+    const fb = client._calls.feedbackInserts[0];
+    expect(fb).toBeDefined();
+    expect(fb.category).toBe('harness_backlog');
+    expect(fb.source_type).toBe('manual_feedback');
+    expect(fb.metadata.parity_gap_detected).toBe(true);
+    expect(fb.metadata.audit_run_id).toBe('audit-uuid-2');
+    expect(fb.metadata.deferred_from_sd_key).toBe(SD_WITH_DRIFT.sd_key);
+    expect(fb.metadata.mismatch_count).toBe(1);
+  });
+
+  it('dry-run mode: no feedback inserts', async () => {
+    const client = makeAuditClient({ sds: [SD_WITH_DRIFT], rowsByTable: { stage_config: STAGE_CONFIG_LIVE } });
+    const findings = await runAudit({ supabase: client, since: null, dryRun: true, auditRunId: 'audit-uuid-3' });
+    expect(findings).toHaveLength(1);
+    expect(client._calls.feedbackInserts).toHaveLength(0);
+  });
+
+  it('skips SDs without metadata.db_content_assertions', async () => {
+    const client = makeAuditClient({ sds: [SD_NO_ASSERTIONS], rowsByTable: { stage_config: STAGE_CONFIG_LIVE } });
+    const findings = await runAudit({ supabase: client, since: null, dryRun: true, auditRunId: 'audit-uuid-4' });
+    expect(findings).toHaveLength(0);
+    expect(client._calls.registryQueries).toHaveLength(0);
+  });
+});

--- a/tests/unit/handoff/gates/db-content-parity-gate.test.js
+++ b/tests/unit/handoff/gates/db-content-parity-gate.test.js
@@ -1,0 +1,211 @@
+/**
+ * Vitest cases for db-content-parity-gate.js (FR-6).
+ * SD: SD-LEO-INFRA-CODE-CONTENT-PARITY-001
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateDbContentParity, evaluateExpectation } from '../../../../scripts/modules/handoff/gates/db-content-parity-gate.js';
+import { REGISTRY_TABLES } from '../../../../lib/db-content-registry-allowlist.js';
+
+function makeMockClient({ sd, rowsByTable = {} }) {
+  const calls = { from: [], inserts: [], queries: [] };
+
+  function table(name) {
+    calls.from.push(name);
+    if (name === 'strategic_directives_v2') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: sd, error: null }),
+          }),
+        }),
+      };
+    }
+    if (name === 'sd_verification_results') {
+      return {
+        insert: async (row) => {
+          calls.inserts.push(row);
+          return { error: null };
+        },
+      };
+    }
+    // registry table query: select(...).eq(col, val).eq(...).maybeSingle()
+    let filters = {};
+    const queryObj = {
+      select: () => queryObj,
+      eq: (col, val) => {
+        filters[col] = val;
+        return queryObj;
+      },
+      maybeSingle: async () => {
+        calls.queries.push({ table: name, filters: { ...filters } });
+        const rows = rowsByTable[name] || [];
+        const match = rows.find((r) =>
+          Object.entries(filters).every(([k, v]) => r[k] === v)
+        );
+        return { data: match || null, error: null };
+      },
+    };
+    return queryObj;
+  }
+  return { from: table, _calls: calls };
+}
+
+describe('validateDbContentParity', () => {
+  beforeEach(() => {
+    delete process.env.LEO_PARITY_REGEX_REQUIRE_ANCHORS;
+  });
+
+  it('TS-1 happy path: assertion matches live row', async () => {
+    const sd = {
+      id: 'uuid-1',
+      metadata: {
+        db_content_assertions: [
+          { table: 'stage_config', row_filter: { stage_number: 18 }, expected_columns: { stage_name: 'MVP Development' } },
+        ],
+      },
+    };
+    const client = makeMockClient({
+      sd,
+      rowsByTable: { stage_config: [{ stage_number: 18, stage_name: 'MVP Development' }] },
+    });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(100);
+    expect(r.mismatches).toEqual([]);
+    expect(r.skipped).toBe(false);
+    expect(client._calls.inserts).toHaveLength(1);
+    expect(client._calls.inserts[0].result).toBe('pass');
+  });
+
+  it('TS-2 literal mismatch detected', async () => {
+    const sd = {
+      id: 'uuid-2',
+      metadata: {
+        db_content_assertions: [
+          { table: 'stage_config', row_filter: { stage_number: 20 }, expected_columns: { stage_name: 'Code Quality Gate' } },
+        ],
+      },
+    };
+    const client = makeMockClient({
+      sd,
+      rowsByTable: { stage_config: [{ stage_number: 20, stage_name: 'User Testing' }] },
+    });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(false);
+    expect(r.mismatches).toHaveLength(1);
+    expect(r.mismatches[0]).toMatchObject({ column: 'stage_name', expected: 'Code Quality Gate', actual: 'User Testing' });
+    expect(client._calls.inserts[0].result).toBe('fail');
+  });
+
+  it('TS-3 regex mismatch detected', async () => {
+    const sd = {
+      id: 'uuid-3',
+      metadata: {
+        db_content_assertions: [
+          { table: 'stage_config', row_filter: { stage_number: 21 }, expected_columns: { description: { regex: '^Pre-Launch' } } },
+        ],
+      },
+    };
+    const client = makeMockClient({
+      sd,
+      rowsByTable: { stage_config: [{ stage_number: 21, description: 'Deployment to production' }] },
+    });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(false);
+    expect(r.mismatches[0].expected).toEqual({ regex: '^Pre-Launch' });
+    expect(r.mismatches[0].actual).toBe('Deployment to production');
+  });
+
+  it('TS-4 missing row → actual:null mismatch', async () => {
+    const sd = {
+      id: 'uuid-4',
+      metadata: {
+        db_content_assertions: [
+          { table: 'stage_config', row_filter: { stage_number: 99 }, expected_columns: { stage_name: 'Doesnt Exist' } },
+        ],
+      },
+    };
+    const client = makeMockClient({ sd, rowsByTable: { stage_config: [] } });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(false);
+    expect(r.mismatches[0].actual).toBeNull();
+  });
+
+  it('TS-5 skip path: no assertions → no DB reads on registry tables', async () => {
+    const sd = { id: 'uuid-5', metadata: {} };
+    const client = makeMockClient({ sd });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(true);
+    expect(r.skipped).toBe(true);
+    expect(client._calls.queries).toHaveLength(0);
+    expect(client._calls.inserts[0].result).toBe('skip');
+  });
+
+  it('TS-6 multi-assertion partial fail: 1 pass + 1 fail → pass:false with 1 mismatch', async () => {
+    const sd = {
+      id: 'uuid-6',
+      metadata: {
+        db_content_assertions: [
+          { table: 'stage_config', row_filter: { stage_number: 18 }, expected_columns: { stage_name: 'MVP Development' } },
+          { table: 'stage_config', row_filter: { stage_number: 20 }, expected_columns: { stage_name: 'Code Quality Gate' } },
+        ],
+      },
+    };
+    const client = makeMockClient({
+      sd,
+      rowsByTable: {
+        stage_config: [
+          { stage_number: 18, stage_name: 'MVP Development' },
+          { stage_number: 20, stage_name: 'User Testing' },
+        ],
+      },
+    });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(false);
+    expect(r.mismatches).toHaveLength(1);
+    expect(r.mismatches[0].row_filter).toEqual({ stage_number: 20 });
+  });
+
+  it('shape-error: table not in REGISTRY_TABLES → __shape_error__', async () => {
+    const sd = {
+      id: 'uuid-7',
+      metadata: {
+        db_content_assertions: [
+          { table: 'arbitrary_table', row_filter: { id: 1 }, expected_columns: { name: 'X' } },
+        ],
+      },
+    };
+    const client = makeMockClient({ sd });
+    const r = await validateDbContentParity('SD-X', client);
+    expect(r.pass).toBe(false);
+    expect(r.mismatches[0].column).toBe('__shape_error__');
+  });
+});
+
+describe('evaluateExpectation anti-ReDoS guard (TR-6)', () => {
+  it('rejects regex over 500-char cap', () => {
+    const r = evaluateExpectation('x', { regex: 'a'.repeat(501) });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/cap/);
+  });
+
+  it('LEO_PARITY_REGEX_REQUIRE_ANCHORS=true rejects unanchored', () => {
+    process.env.LEO_PARITY_REGEX_REQUIRE_ANCHORS = 'true';
+    try {
+      const r = evaluateExpectation('x', { regex: 'foo' });
+      expect(r.ok).toBe(false);
+      expect(r.reason).toMatch(/anchor/);
+    } finally {
+      delete process.env.LEO_PARITY_REGEX_REQUIRE_ANCHORS;
+    }
+  });
+});
+
+describe('REGISTRY_TABLES allowlist contract (FR-2)', () => {
+  it('contains the seed tables', () => {
+    expect(REGISTRY_TABLES).toEqual(['stage_config', 'chairman_dashboard_config']);
+  });
+  it('is frozen', () => {
+    expect(Object.isFrozen(REGISTRY_TABLES)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase 1**: New `DB_CONTENT_PARITY` gate at `/leo complete` (PLAN-TO-LEAD) reads operator-declared assertions in `strategic_directives_v2.metadata.db_content_assertions` and verifies them against live registry-table rows (initial allowlist: `stage_config`, `chairman_dashboard_config`). Persists one row per run to `sd_verification_results`.
- **Phase 2**: One-time audit script (`scripts/audit-completed-sd-db-content-parity.js`) walks completed SDs and emits `feedback` rows on drift detection. Live run during EXEC produced feedback row `ccbbfc0a-7e6f-4010-a0fc-a52c08f0f196` confirming the witnessed 9-day SD-REDESIGN-S18S26 stage_config drift (5 mismatches across stages 18–22).
- Closes the precise uncovered dimension in the LEO post-completion verification suite — code-vs-DB content parity — alongside existing PCVP, AUTOHEAL, COMPLETION-SCOPE-VERIFICATION, EHG-REPO-ADD, E2E-MIGRATION-CHECK gates.

## Files (650 LOC: 317 source + 331 tests + 2 .gitignore)
- `lib/db-content-registry-allowlist.js` — REGISTRY_TABLES frozen array
- `scripts/modules/handoff/gates/db-content-parity-gate.js` — `validateDbContentParity` + `createDbContentParityGate` factory
- `scripts/modules/handoff/executors/plan-to-lead/index.js` — gate registered in both reduced and standard gate stacks
- `scripts/audit-completed-sd-db-content-parity.js` — Phase 2 walker (`--since`, `--sd-id`, `--dry-run`)
- `tests/unit/handoff/gates/db-content-parity-gate.test.js` — 11 cases
- `tests/unit/audit/db-content-parity-audit.test.js` — 4 cases
- `.gitignore` — added !exception for the audit script (production deliverable)

## Schema corrections absorbed at PLAN
PLAN database-agent probe-insert surfaced 3 deviations from the PRD draft (recorded in `metadata.scope_amendment` with provenance to `sub_agent_execution_results` row 04cfff5d):
- `sd_verification_results` column is `result`, not `status` (free-text accepted)
- `feedback.source_type` CHECK requires `'manual_feedback'` for harness findings
- Anti-ReDoS guard (TR-6): regex pattern length capped at 500 chars; `LEO_PARITY_REGEX_REQUIRE_ANCHORS=true` rejects unanchored

## Sub-agent evidence trail
- LEAD: VALIDATION (PASS) — no duplicate-implementation hits; sibling SDs reviewed
- PLAN: DATABASE (WARNING — surfaced 3 corrections), STORIES (PASS — 6 stories)
- EXEC: TESTING (PASS — 15/15 vitest)
- PLAN_VERIFICATION: VALIDATION (WARNING — 3 follow-ups all closed before PLAN-TO-LEAD)
- DB_CONTENT_PARITY gate self-tested on this very SD at PLAN-TO-LEAD: 100% (skip path verified)

## Test plan
- [x] `npx vitest run tests/unit/handoff/gates/db-content-parity-gate.test.js tests/unit/audit/db-content-parity-audit.test.js` — 15/15 pass
- [x] Live audit `node scripts/audit-completed-sd-db-content-parity.js --sd-id SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001` — emits feedback row with 5 mismatches as expected
- [x] PLAN-TO-LEAD passed (91%) — DB_CONTENT_PARITY gate active; skip path verified on no-assertion SD
- [x] Schema corrections verified (`result` column, `manual_feedback` source_type, anti-ReDoS guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)