### PR TITLE
chore(ci): dedupe leo-drift-check workflow — drop feat/* from push trigger (QF-20260429)

### DIFF
--- a/.github/workflows/leo-drift-check.yml
+++ b/.github/workflows/leo-drift-check.yml
@@ -2,7 +2,13 @@ name: LEO Protocol Drift Check
 
 on:
   push:
-    branches: [main, develop, 'feat/*']
+    # Push triggers scope to protected branches only — feature branches are
+    # covered by the pull_request trigger below. Including 'feat/*' here used
+    # to fire a duplicate workflow run on every push to a feature branch with
+    # an open PR (concurrency.group keys on github.ref which differs between
+    # push and pull_request events, so it does not dedupe across event types).
+    # See QF-20260429-LEO-DRIFT-DEDUPE rationale.
+    branches: [main, develop]
     paths:
       - 'tools/gates/**'
       - 'scripts/**'


### PR DESCRIPTION
## Summary
- One-line YAML fix: drop `'feat/*'` from `.github/workflows/leo-drift-check.yml` push trigger.
- Eliminates duplicate workflow runs on every push to a `feat/*` branch with an open PR.
- Net diff: 7 lines (1 changed list + 6 lines of explanatory comment).

**Tracking**: QF-20260429-001 (canonical short ID; descriptive long ID `QF-20260429-LEO-DRIFT-DEDUPE` lives in `quick_fixes` table)

## Why
On PR #3420 (just merged) the LEO Protocol Drift Check workflow fired **twice**:
- 15:49:49 — `push` event (matched `feat/*`)
- 15:50:32 — `pull_request` event (matched `main`)

Both produced full job sets, so 7 of the 35 PR checks were redundant. The existing `concurrency.group: \${{ github.workflow }}-\${{ github.ref }}` doesn't dedupe across event types because `github.ref` differs (push uses head ref, pull_request uses merge ref).

This was the only workflow with the dual-trigger anti-pattern — the rest correctly scope push triggers to `[main, develop]`.

## Test plan
- [x] No semantic change for protected-branch validation (push to `main`/`develop` still triggers the workflow).
- [x] PR validation still covered by the `pull_request` trigger (unchanged).
- [ ] Next push to a `feat/*` branch with an open PR fires only the `pull_request` workflow run (verifiable on the next SD's PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)