### PR TITLE
feat(SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001-C): Per-Finding SD Generator (Tier-aware, idempotent)

### DIFF
--- a/lib/eva/quality-findings/sd-generator.js
+++ b/lib/eva/quality-findings/sd-generator.js
@@ -1,0 +1,221 @@
+/**
+ * Per-finding SD generator: converts each unresolved finding from
+ * venture_quality_findings into a Tier-aware remediation SD.
+ *
+ * SD: SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001-C
+ *
+ * Idempotency: deduped by metadata.parent_finding_hash on
+ * strategic_directives_v2. Re-running scan against same venture state
+ * yields zero new SDs.
+ *
+ * Delegation: invokes scripts/leo-create-sd.js as a child_process so
+ * canonical validation runs (vision/arch checks, gates, etc). Direct
+ * strategic_directives_v2 INSERTs would bypass that pipeline.
+ *
+ * @module lib/eva/quality-findings/sd-generator
+ */
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { validateFindingShape } from './finding-shape.js';
+
+/**
+ * Tier mapping table per CLAUDE.md Work Item Routing.
+ *
+ * Format: { [finding_category]: { [severity]: tier } }
+ *
+ * Tier 1: ≤30 LOC auto-approve QF
+ * Tier 2: 31-75 LOC standard QF
+ * Tier 3: >75 LOC full SD (also forced by risk keywords: auth, migration, schema, feature)
+ *
+ * Defaults to Tier 2 for any (category, severity) not in the table.
+ */
+export const TIER_MAP = Object.freeze({
+  // Code Review
+  npm_audit:    { critical: 3, high: 3, medium: 2, low: 1 },
+  secrets:      { critical: 3, high: 3, medium: 3, low: 2 },  // always at least Tier 2 — security keyword
+  lint:         { critical: 2, high: 2, medium: 1, low: 1 },
+  test_suite:   { critical: 3, high: 2, medium: 2, low: 1 },
+  capability:   { critical: 3, high: 3, medium: 2, low: 1 },
+  // QA
+  unit_test:    { critical: 3, high: 2, medium: 1, low: 1 },
+  e2e_test:     { critical: 3, high: 2, medium: 2, low: 1 },
+  // UAT
+  uat_test:     { critical: 3, high: 3, medium: 2, low: 1 },
+  bug_report:   { critical: 3, high: 3, medium: 2, low: 1 },
+  uat_signoff:  { critical: 3, high: 3, medium: 3, low: 2 },  // chairman-facing — minimum Tier 2
+});
+
+/**
+ * Resolve Tier for a finding's severity + category.
+ *
+ * @param {string} category - one of FINDING_CATEGORIES
+ * @param {string} severity - one of SEVERITY_LEVELS
+ * @returns {number} 1, 2, or 3
+ */
+export function resolveTier(category, severity) {
+  const row = TIER_MAP[category];
+  if (!row) return 2; // default for unknown categories
+  return row[severity] ?? 2;
+}
+
+/**
+ * Map Tier number to leo-create-sd type flag.
+ * Tier 1 = QF (handled separately, not by this generator).
+ * Tier 2 = QF or fix.
+ * Tier 3 = full SD (default to 'fix' or 'feature' depending on category).
+ */
+export function tierToSdType(tier, category) {
+  if (tier === 1) return 'fix';
+  if (tier === 2) return 'fix';
+  // Tier 3
+  if (category === 'capability' || category === 'secrets') return 'security';
+  if (category.endsWith('_test') || category === 'bug_report') return 'bugfix';
+  return 'fix';
+}
+
+/**
+ * Check whether a remediation SD already exists for this finding_hash.
+ * Uses metadata.parent_finding_hash for idempotency (per US-2).
+ *
+ * @param {Object} supabase
+ * @param {string} finding_hash
+ * @returns {Promise<{exists: boolean, sd_key?: string}>}
+ */
+export async function findExistingRemediation(supabase, finding_hash) {
+  if (!supabase || !finding_hash) {
+    throw new Error('supabase + finding_hash required');
+  }
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key')
+    .filter('metadata->>parent_finding_hash', 'eq', finding_hash)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error('findExistingRemediation failed: ' + error.message);
+  }
+
+  return data ? { exists: true, sd_key: data.sd_key } : { exists: false };
+}
+
+/**
+ * Build a leo-create-sd.js argument list for a finding.
+ * Returns the args array (caller spawns the process).
+ *
+ * @param {Object} finding - canonical FindingShape
+ * @returns {{type: string, tier: number, args: Array<string>, metadata: Object}}
+ */
+export function buildCreateSdArgs(finding) {
+  const v = validateFindingShape(finding);
+  if (!v.valid) {
+    throw new Error('Invalid finding: ' + v.errors.join('; '));
+  }
+
+  const tier = resolveTier(finding.finding_category, finding.severity);
+  const sdType = tierToSdType(tier, finding.finding_category);
+
+  // Title is short and descriptive
+  const evidenceSummary = JSON.stringify(finding.evidence_pointer || {}).slice(0, 80);
+  const title = `Remediation: ${finding.finding_category} (${finding.severity}) — ${evidenceSummary}`.slice(0, 200);
+
+  const metadata = {
+    parent_finding_hash: finding.finding_hash,
+    parent_orchestrator: 'SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001',
+    source_stage_number: finding.stage_number,
+    source_finding_category: finding.finding_category,
+    source_severity: finding.severity,
+    venture_id: finding.venture_id,
+    generator: 'sd-generator.js',
+    generator_version: '1.0.0',
+  };
+
+  // leo-create-sd.js positional args: <source> <type> "<title>"
+  const args = [
+    'LEO',
+    sdType,
+    title,
+    '--metadata', JSON.stringify(metadata),
+  ];
+
+  return { type: sdType, tier, args, metadata };
+}
+
+/**
+ * Generate a remediation SD for a finding.
+ *
+ * Idempotent: if metadata.parent_finding_hash already exists on any SD,
+ * returns the existing sd_key without spawning leo-create-sd.js.
+ *
+ * @param {Object} params
+ * @param {Object} params.supabase
+ * @param {Object} params.finding - canonical FindingShape
+ * @param {boolean} [params.dryRun=false] - skip leo-create-sd.js spawn
+ * @returns {Promise<{sd_key?: string, created: boolean, skipped: boolean, reason?: string}>}
+ */
+export async function generateRemediationSD({ supabase, finding, dryRun = false }) {
+  // Idempotency check
+  const existing = await findExistingRemediation(supabase, finding.finding_hash);
+  if (existing.exists) {
+    return { sd_key: existing.sd_key, created: false, skipped: true, reason: 'duplicate_finding_hash' };
+  }
+
+  const { type, tier, args, metadata } = buildCreateSdArgs(finding);
+
+  if (dryRun) {
+    return { created: false, skipped: true, reason: 'dry_run', tier, type, metadata };
+  }
+
+  // Delegate to leo-create-sd.js (canonical SD creation path)
+  const scriptPath = path.resolve(process.cwd(), 'scripts/leo-create-sd.js');
+  return await new Promise((resolve, reject) => {
+    const proc = spawn('node', [scriptPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => { stdout += d.toString(); });
+    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.on('close', (exitCode) => {
+      if (exitCode !== 0) {
+        reject(new Error(`leo-create-sd.js exited ${exitCode}: ${stderr.slice(-500)}`));
+        return;
+      }
+      // Parse SD key from stdout (line like "SD Key:   SD-LEO-FIX-XXX-001")
+      const m = stdout.match(/SD Key:\s+(SD-[A-Z0-9-]+)/);
+      const sd_key = m ? m[1] : null;
+      resolve({ sd_key, created: true, skipped: false, tier, type, metadata });
+    });
+    proc.on('error', reject);
+  });
+}
+
+/**
+ * Batch-generate remediation SDs for an array of unresolved findings.
+ * Continues on per-finding errors; returns counts + errors.
+ *
+ * @param {Object} params
+ * @param {Object} params.supabase
+ * @param {Array<Object>} params.findings - array of FindingShape
+ * @param {boolean} [params.dryRun=false]
+ * @returns {Promise<{created: Array, skipped: Array, errors: Array}>}
+ */
+export async function generateBatch({ supabase, findings, dryRun = false }) {
+  const created = [];
+  const skipped = [];
+  const errors = [];
+
+  for (const f of findings || []) {
+    try {
+      const r = await generateRemediationSD({ supabase, finding: f, dryRun });
+      if (r.created) created.push({ finding_hash: f.finding_hash, sd_key: r.sd_key });
+      else skipped.push({ finding_hash: f.finding_hash, reason: r.reason });
+    } catch (err) {
+      errors.push({ finding_hash: f.finding_hash, error: err.message });
+    }
+  }
+
+  return { created, skipped, errors };
+}

--- a/tests/unit/eva/quality-findings/sd-generator.test.js
+++ b/tests/unit/eva/quality-findings/sd-generator.test.js
@@ -1,0 +1,196 @@
+/**
+ * Vitest coverage for per-finding SD generator (SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001-C).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TIER_MAP,
+  resolveTier,
+  tierToSdType,
+  findExistingRemediation,
+  buildCreateSdArgs,
+  generateRemediationSD,
+  generateBatch,
+} from '../../../../lib/eva/quality-findings/sd-generator.js';
+import { computeFindingHash, FINDING_CATEGORIES } from '../../../../lib/eva/quality-findings/finding-shape.js';
+
+const validFinding = (overrides = {}) => ({
+  venture_id: 'v-test-001',
+  stage_number: 20,
+  finding_category: 'lint',
+  severity: 'medium',
+  finding_hash: computeFindingHash({
+    venture_id: 'v-test-001',
+    stage_number: 20,
+    finding_category: 'lint',
+    finding_signature: 'no-unused-vars:src/foo.js:42',
+  }),
+  evidence_pointer: { file: 'src/foo.js' },
+  ...overrides,
+});
+
+function makeMockSupabase(existingFindings = new Set()) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            filter(_col, _op, val) {
+              return {
+                limit() {
+                  return {
+                    maybeSingle: async () => ({
+                      data: existingFindings.has(val) ? { sd_key: 'SD-EXISTING-001' } : null,
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('TIER_MAP', () => {
+  it('covers all 10 finding categories', () => {
+    for (const cat of FINDING_CATEGORIES) {
+      expect(TIER_MAP[cat]).toBeDefined();
+    }
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(TIER_MAP)).toBe(true);
+  });
+});
+
+describe('resolveTier', () => {
+  it('critical+secrets → Tier 3 (security keyword forces high tier)', () => {
+    expect(resolveTier('secrets', 'critical')).toBe(3);
+  });
+
+  it('medium+lint → Tier 1 (auto-approve QF)', () => {
+    expect(resolveTier('lint', 'medium')).toBe(1);
+  });
+
+  it('low+npm_audit → Tier 1', () => {
+    expect(resolveTier('npm_audit', 'low')).toBe(1);
+  });
+
+  it('uat_signoff always ≥ Tier 2 (chairman-facing)', () => {
+    expect(resolveTier('uat_signoff', 'low')).toBe(2);
+    expect(resolveTier('uat_signoff', 'medium')).toBe(3);
+  });
+
+  it('unknown category defaults to Tier 2', () => {
+    expect(resolveTier('invented_category', 'medium')).toBe(2);
+  });
+});
+
+describe('tierToSdType', () => {
+  it('Tier 3 + security categories → security type', () => {
+    expect(tierToSdType(3, 'secrets')).toBe('security');
+    expect(tierToSdType(3, 'capability')).toBe('security');
+  });
+
+  it('Tier 3 + test categories → bugfix', () => {
+    expect(tierToSdType(3, 'unit_test')).toBe('bugfix');
+    expect(tierToSdType(3, 'e2e_test')).toBe('bugfix');
+    expect(tierToSdType(3, 'bug_report')).toBe('bugfix');
+  });
+
+  it('Tier 1/2 → fix', () => {
+    expect(tierToSdType(1, 'lint')).toBe('fix');
+    expect(tierToSdType(2, 'lint')).toBe('fix');
+  });
+});
+
+describe('findExistingRemediation (idempotency check)', () => {
+  it('returns exists=true when finding_hash already linked to an SD', async () => {
+    const supabase = makeMockSupabase(new Set(['hash-existing']));
+    const r = await findExistingRemediation(supabase, 'hash-existing');
+    expect(r.exists).toBe(true);
+    expect(r.sd_key).toBe('SD-EXISTING-001');
+  });
+
+  it('returns exists=false when finding_hash is novel', async () => {
+    const supabase = makeMockSupabase(new Set());
+    const r = await findExistingRemediation(supabase, 'hash-novel');
+    expect(r.exists).toBe(false);
+  });
+
+  it('rejects missing args', async () => {
+    const supabase = makeMockSupabase();
+    await expect(findExistingRemediation(null, 'h')).rejects.toThrow();
+    await expect(findExistingRemediation(supabase, null)).rejects.toThrow();
+  });
+});
+
+describe('buildCreateSdArgs', () => {
+  it('builds args + metadata for a valid finding', () => {
+    const r = buildCreateSdArgs(validFinding());
+    expect(r.tier).toBe(1);
+    expect(r.type).toBe('fix');
+    expect(r.args[0]).toBe('LEO');
+    expect(r.args[1]).toBe('fix');
+    expect(r.args[2]).toMatch(/Remediation: lint/);
+    expect(r.metadata.parent_finding_hash).toBe(validFinding().finding_hash);
+    expect(r.metadata.parent_orchestrator).toBe('SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001');
+    expect(r.metadata.source_stage_number).toBe(20);
+  });
+
+  it('routes critical+secrets to Tier 3 + security type', () => {
+    const r = buildCreateSdArgs(validFinding({ finding_category: 'secrets', severity: 'critical' }));
+    expect(r.tier).toBe(3);
+    expect(r.type).toBe('security');
+  });
+
+  it('rejects invalid finding shape', () => {
+    expect(() => buildCreateSdArgs(validFinding({ finding_category: 'invalid' }))).toThrow();
+  });
+});
+
+describe('generateRemediationSD (dryRun)', () => {
+  it('skips creation if existing remediation found (idempotency)', async () => {
+    const f = validFinding();
+    const supabase = makeMockSupabase(new Set([f.finding_hash]));
+    const r = await generateRemediationSD({ supabase, finding: f });
+    expect(r.created).toBe(false);
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe('duplicate_finding_hash');
+    expect(r.sd_key).toBe('SD-EXISTING-001');
+  });
+
+  it('returns dry-run result without spawning leo-create-sd.js', async () => {
+    const supabase = makeMockSupabase();
+    const r = await generateRemediationSD({ supabase, finding: validFinding(), dryRun: true });
+    expect(r.created).toBe(false);
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe('dry_run');
+    expect(r.tier).toBe(1);
+    expect(r.type).toBe('fix');
+  });
+});
+
+describe('generateBatch', () => {
+  it('aggregates created + skipped + errors per finding', async () => {
+    const f1 = validFinding({ finding_category: 'lint' });
+    const f2 = validFinding({ finding_category: 'secrets', severity: 'critical' });
+    const f3 = validFinding({ finding_category: 'invalid_category' });
+    const supabase = makeMockSupabase();
+    const r = await generateBatch({ supabase, findings: [f1, f2, f3], dryRun: true });
+    expect(r.skipped.length).toBe(2);
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0].error).toMatch(/Invalid finding/);
+  });
+
+  it('handles empty findings array', async () => {
+    const supabase = makeMockSupabase();
+    const r = await generateBatch({ supabase, findings: [], dryRun: true });
+    expect(r.created).toEqual([]);
+    expect(r.skipped).toEqual([]);
+    expect(r.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Component C of SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001. Converts unresolved findings into Tier-aware remediation SDs via leo-create-sd.js delegation.

## Deliverables (417 LOC)
- `lib/eva/quality-findings/sd-generator.js` — TIER_MAP, resolveTier, tierToSdType, findExistingRemediation, buildCreateSdArgs, generateRemediationSD, generateBatch
- 20 vitest cases (TIER_MAP coverage, idempotency, dry-run, batch aggregation)

## Idempotency
metadata.parent_finding_hash on strategic_directives_v2 ensures re-runs produce zero duplicate SDs.

## Tier mapping
secrets/uat_signoff floor at Tier 2 (security/chairman-facing); _test/bug_report → bugfix at Tier 3; default Tier 2.

## Test plan
- [x] Vitest 20/20 pass
- [x] Idempotency verified (existing finding_hash skips creation)
- [x] Dry-run mode prevents leo-create-sd.js spawn during tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)