### PR TITLE
fix(stage-20): correct finding-shape import path

### DIFF
--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -18,7 +18,7 @@
 import { validateString, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage20CodeQuality, VERDICT_OPTIONS } from './analysis-steps/stage-20-code-quality.js';
-import { FINDING_CATEGORIES } from '../../quality-findings/finding-shape.js';
+import { FINDING_CATEGORIES } from '../quality-findings/finding-shape.js';
 
 const TEMPLATE = {
   id: 'stage-20',


### PR DESCRIPTION
## Summary

- Fixes broken import in `lib/eva/stage-templates/stage-20.js` that was resolving to `lib/quality-findings/finding-shape.js` (non-existent) instead of `lib/eva/quality-findings/finding-shape.js`
- The module `finding-shape.js` lives one directory up inside `eva/`, not two levels up
- This was directly causing **Stage Worker Import Smoke Test** failures on main (and any branch importing stage-20)

## Root cause

`stage-20.js` is at `lib/eva/stage-templates/stage-20.js`. Import used `../../quality-findings/...` (two `..` = exits `eva/`), should be `../quality-findings/...` (one `..` = stays inside `eva/`).

## Test plan

- [x] `node -e "import('./lib/eva/stage-templates/stage-20.js')"` resolves without error
- [x] Smoke tests pass (30/30)
- [ ] Stage Worker Import Smoke Test CI passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)