### PR TITLE
fix(worktrees): copy .env.local + git-root fallback in scope-completion-gate

### DIFF
--- a/scripts/modules/handoff/gates/scope-completion-gate.js
+++ b/scripts/modules/handoff/gates/scope-completion-gate.js
@@ -13,7 +13,9 @@ import fs from 'fs';
 import path from 'path';
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 
-const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer';
+import { execSync } from 'child_process';
+const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR ||
+  (() => { try { return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim(); } catch { return 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer'; } })();
 
 /**
  * Extract deliverable items from architecture plan content.
@@ -288,7 +290,7 @@ export async function validateScopeCompletion(sdKey) {
       score: 70,
       issues: [],
       warnings: [
-        `SD inherits scope from parent orchestrator (metadata.inherited_from_parent set) but has no scope_slice declared. Gate returns soft-pass (score=70). Declare scope_slice on the child to score only the claimed subset of parent deliverables.`
+        'SD inherits scope from parent orchestrator (metadata.inherited_from_parent set) but has no scope_slice declared. Gate returns soft-pass (score=70). Declare scope_slice on the child to score only the claimed subset of parent deliverables.'
       ],
       checklist: [],
       details: {

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -381,14 +381,16 @@ function ensureWorktreeEssentials(worktreePath, repoRoot) {
     }
   }
 
-  // Copy .env (gitignored, so never present in worktrees)
-  const sourceEnv = path.join(repoRoot, '.env');
-  const targetEnv = path.join(worktreePath, '.env');
-  if (fs.existsSync(sourceEnv) && !fs.existsSync(targetEnv)) {
-    try {
-      fs.copyFileSync(sourceEnv, targetEnv);
-    } catch (err) {
-      errors.push({ step: 'copy_env', message: err.message });
+  // Copy .env and .env.local (gitignored, so never present in worktrees)
+  for (const envFile of ['.env', '.env.local']) {
+    const src = path.join(repoRoot, envFile);
+    const dst = path.join(worktreePath, envFile);
+    if (fs.existsSync(src) && !fs.existsSync(dst)) {
+      try {
+        fs.copyFileSync(src, dst);
+      } catch (err) {
+        errors.push({ step: `copy_${envFile}`, message: err.message });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **`resolve-sd-workdir.js`**: `ensureWorktreeEssentials` now copies both `.env` and `.env.local` to new worktrees. Previously only `.env` was copied, leaving `NEXT_PUBLIC_SUPABASE_URL` and other `.env.local`-only vars absent when `handoff.js` ran from a new worktree.

- **`scope-completion-gate.js`**: `PROJECT_ROOT` now uses `git rev-parse --show-toplevel` as the fallback instead of a hardcoded Windows path. This ensures file-existence checks resolve against the actual worktree directory, not the main repo.

## Test plan

- [x] Smoke tests pass (30/30)
- [ ] Handoff.js in a fresh worktree no longer fails with `NEXT_PUBLIC_SUPABASE_URL is required`
- [ ] Scope-completion-gate correctly finds files created in worktree during handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)