### PR TITLE
fix(tests): correct off-by-one import paths in stage-24/25/26 analysis-step tests

### DIFF
--- a/tests/unit/eva/stage-templates/analysis-steps/stage-24-launch-execution.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-24-launch-execution.test.js
@@ -13,7 +13,7 @@ vi.mock('../../../../../lib/llm/index.js', () => ({
   })),
 }));
 
-import { analyzeStage23, LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES, APP_STORE_STATUSES, DOMAIN_STATUSES, CHANNEL_STATUSES, APP_RANKING_TIERS, COMPETITIVE_POSITIONS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js';
+import { analyzeStage23, LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES, APP_STORE_STATUSES, DOMAIN_STATUSES, CHANNEL_STATUSES, APP_RANKING_TIERS, COMPETITIVE_POSITIONS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-24-launch-execution.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
 
 function createLLMResponse(overrides = {}) {

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-25-metrics-learning.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-25-metrics-learning.test.js
@@ -16,7 +16,7 @@ vi.mock('../../../../../lib/llm/index.js', () => ({
 import {
   analyzeStage24, AARRR_CATEGORIES, TREND_DIRECTIONS, OUTCOME_ASSESSMENTS, IMPACT_LEVELS,
   EXPERIMENT_STATUSES, EXPERIMENT_OUTCOMES, COHORT_PERIODS, ENGAGEMENT_LEVELS,
-} from '../../../../../lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js';
+} from '../../../../../lib/eva/stage-templates/analysis-steps/stage-25-metrics-learning.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
 
 function createLLMResponse(overrides = {}) {

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-26-venture-review.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-26-venture-review.test.js
@@ -13,7 +13,7 @@ vi.mock('../../../../../lib/llm/index.js', () => ({
   })),
 }));
 
-import { analyzeStage25, analyzeExpansionVectors, VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES, EXPANSION_VECTORS, EXPANSION_WEIGHTS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js';
+import { analyzeStage25, analyzeExpansionVectors, VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES, EXPANSION_VECTORS, EXPANSION_WEIGHTS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-26-venture-review.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
 
 function createLLMResponse(overrides = {}) {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
       '**/.worktrees/**',
       '**/.cursor/worktrees/**',
       '**/.claude/worktrees/**',
+      '**/PATH/**',
     ],
     server: {
       deps: {


### PR DESCRIPTION
## Summary

- Fixes `Cannot find module` errors in 3 analysis-step test files caused by the marketing-first stage renumbering (stages 19-26 shifted by +1)
- `stage-24-launch-execution.test.js` now imports from `stage-24-launch-execution.js` (was `stage-23-*`)
- `stage-25-metrics-learning.test.js` now imports from `stage-25-metrics-learning.js` (was `stage-24-*`)
- `stage-26-venture-review.test.js` now imports from `stage-26-venture-review.js` (was `stage-25-*`)
- Excludes `PATH/` (untracked nested git clone at repo root) from vitest test discovery to prevent local test count inflation

## Test plan

- [ ] CI test coverage badge should show fewer failures for the 3 affected test files
- [ ] No regressions — only import path changes and a vitest exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)