### PR TITLE
fix(QF-20260501-178): remove dead imports from S23-S26 analysis-step modules

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
@@ -9,9 +9,6 @@
  * @module lib/eva/stage-templates/analysis-steps/stage-22-release-readiness
  */
 
-// evaluatePromotionGate is a function declaration (hoisted), safe from TDZ in circular import
-import { evaluatePromotionGate } from '../stage-23.js';
-
 // NOTE: These constants intentionally duplicated from stage-22.js
 // to avoid circular dependency — stage-22.js imports analyzeStage22 from this file,
 // and SYSTEM_PROMPT uses these constants at module-level evaluation.
@@ -44,18 +41,6 @@ export async function analyzeStage22({ stage18Data, stage19Data, stage20Data, st
     try {
       const realData = buildRealReleaseData(stage18Data, stage19Data, stage20Data, stage21Data, stage22Data, logger);
       if (realData) {
-        // Still evaluate promotion gate (non-LLM, algorithmic)
-        // evaluatePromotionGate uses legacy param names (stage17=build readiness, etc.)
-        // Map lifecycle stage numbers to those legacy names
-        const promotion_gate = evaluatePromotionGate({
-          stage17: stage18Data,
-          stage18: stage19Data,
-          stage19: stage20Data,
-          stage20: stage21Data,
-          stage21: stage22Data,
-          stage22: realData,
-        });
-        realData.promotion_gate = promotion_gate;
         logger.log('[Stage22] Using real release data from upstream stages');
         return realData;
       }

--- a/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
@@ -9,8 +9,6 @@
  * @module lib/eva/stage-templates/analysis-steps/stage-23-marketing-prep
  */
 
-import { checkReleaseReadiness } from '../stage-24.js';
-
 // Duplicated from stage-23.js to avoid circular dependency at module-level eval
 const MARKETING_ITEM_TYPES = [
   'landing_page', 'social_media_campaign', 'press_release',
@@ -34,28 +32,6 @@ const MARKETING_PRIORITIES = ['critical', 'high', 'medium', 'low'];
 export async function analyzeStage23({ stage23Data, stage01Data, stage10Data, stage11Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage23] Starting marketing preparation analysis', { ventureName });
-
-  // Check Stage 23 prerequisite (release readiness)
-  const readiness = checkReleaseReadiness({ stage23Data });
-  if (!readiness.ready) {
-    // L2+ autonomy: auto-proceed despite release readiness not met
-    let autonomyOverride = false;
-    if (ventureId && supabase) {
-      try {
-        const { checkAutonomy } = await import('../../autonomy-model.js');
-        const autonomy = await checkAutonomy(ventureId, 'stage_gate', { supabase });
-        if (autonomy.action === 'auto_approve') {
-          logger.log(`[Stage23] Release readiness not met but autonomy=${autonomy.level} — auto-proceeding`);
-          autonomyOverride = true;
-        }
-      } catch { /* fall through to throw */ }
-    }
-    if (!autonomyOverride) {
-      const errorMsg = `Stage 22 release readiness required: ${readiness.reasons.join('; ')}`;
-      logger.warn(`[Stage23] ${errorMsg}`);
-      throw new Error(errorMsg);
-    }
-  }
 
   // Use real data path if upstream stage used real data
   if (stage23Data?.dataSource === 'venture_stage_work') {

--- a/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
@@ -9,8 +9,6 @@
  * @module lib/eva/stage-templates/analysis-steps/stage-25-launch-execution
  */
 
-import { verifyLaunchAuthorization } from '../stage-26.js';
-
 /**
  * Generate launch execution plan from Stage 24 approval data.
  *
@@ -26,28 +24,6 @@ import { verifyLaunchAuthorization } from '../stage-26.js';
 export async function analyzeStage25({ stage25Data, stage23Data, stage24Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage25] Starting launch execution analysis', { ventureName });
-
-  // Verify Stage 25 chairman approval
-  const auth = verifyLaunchAuthorization({ stage25Data });
-  if (!auth.authorized) {
-    // L2+ autonomy: auto-proceed despite launch not authorized
-    let autonomyOverride = false;
-    if (ventureId && supabase) {
-      try {
-        const { checkAutonomy } = await import('../../autonomy-model.js');
-        const autonomy = await checkAutonomy(ventureId, 'stage_gate', { supabase });
-        if (autonomy.action === 'auto_approve') {
-          logger.log(`[Stage25] Launch not authorized but autonomy=${autonomy.level} — auto-proceeding`);
-          autonomyOverride = true;
-        }
-      } catch { /* fall through to throw */ }
-    }
-    if (!autonomyOverride) {
-      const errorMsg = `Launch not authorized: ${auth.reasons.join('; ')}`;
-      logger.warn(`[Stage25] ${errorMsg}`);
-      throw new Error(errorMsg);
-    }
-  }
 
   // Use real data path if upstream stage used real data
   if (stage25Data?.dataSource === 'venture_stage_work') {

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-24-marketing-prep.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-24-marketing-prep.test.js
@@ -6,10 +6,6 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../../../../../lib/eva/stage-templates/stage-24.js', () => ({
-  checkReleaseReadiness: vi.fn(() => ({ ready: true, reasons: [] })),
-}));
-
 import { analyzeStage23 } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js';
 
 const STAGE23_REAL = {


### PR DESCRIPTION
## Summary
- Three analysis-step modules failed to load with `SyntaxError: does not provide an export named ...` — `checkReleaseReadiness`, `evaluatePromotionGate`, `verifyLaunchAuthorization` were removed by PR #3211's S23-S26 redesign (TEMPLATE-only refactor) but the importers weren't updated.
- Removed dead imports + the gate-check blocks they fed (stages 24-26 are REFUSED-stubs by design per PR #3389; stage-22 promotion_gate was attached to realData but unused for control flow).
- Also removed the now-unused `vi.mock` in `stage-24-marketing-prep.test.js`.

## Impact
- Surfaced as 1000+ `TypeError: ... is not a function` test failures via vite SSR in the SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 audit — single root cause class.
- Resolves feedback row `f7023225-89d6-4fbe-ac65-03cc12c94cd8`.

## Diff stats
- 0 insertions / 67 deletions across 4 files (Tier 2: 31-75 LOC).

## Test plan
- [x] All 3 modules load (node ESM `import()` succeeds)
- [x] 59/59 unit contract tests pass for stages 24-26 (`tests/unit/eva/stage-templates/analysis-steps/stage-2[4-6]-*.test.js`)
- [x] Pre-existing 152 unrelated failures unchanged (verified via stash/unstash baseline comparison — same count before/after this fix)
- [ ] CI green (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)