### PR TITLE
fix(ci): pass Supabase secrets to test-coverage step + bound teardown silence

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -43,6 +43,16 @@ jobs:
         # canonical defense against that bug class.
         env:
           NODE_OPTIONS: --experimental-vm-modules
+          # SD-LEO-INFRA-VITEST-EXITS-61S-001: tests/setup.js falls back to
+          # https://test.invalid.local when SUPABASE_URL is unset. Smoke tests
+          # then issue real .from('table').select() calls that hang in supabase-js
+          # fetch retry against the unresolvable host until vitest's testTimeout
+          # (60s) force-kills the worker — which exits 1 with no test failure.
+          # Pass the secrets so DB-touching tests have a real endpoint.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         # QF-20260426-465: vitest dropped CLI --json in 1.x->3.x; use --reporter=json instead.
         run: npm run test:coverage -- --reporter=json --outputFile=test-results.json
 

--- a/tests/canary/workflow-exit-code.canary.test.js
+++ b/tests/canary/workflow-exit-code.canary.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Canary regression test for SD-LEO-INFRA-VITEST-EXITS-61S-001 FR-3.
+ *
+ * Default: skipped. Activate by setting CANARY_TEST=1 in the env.
+ *
+ * When activated, the test deliberately fails. The contract being verified
+ * is that .github/workflows/test-coverage.yml exits 1 AND that the JSON
+ * reporter records `# fail 1` — proving the workflow correctly distinguishes
+ * real test failures from the silent teardown class this SD addresses.
+ *
+ * NEVER commit a workflow change that sets CANARY_TEST=1 on a merge path.
+ */
+const CANARY_ON = process.env.CANARY_TEST === '1';
+
+describe('canary: workflow exit code on real failure', () => {
+  it.skipIf(!CANARY_ON)('deliberately fails when CANARY_TEST=1 to prove CI exits 1', () => {
+    expect(true).toBe(false);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -26,6 +26,8 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 60000,
+    teardownTimeout: 10000,
+    pool: 'forks',
     setupFiles: ['./tests/setup.js'],
     include: [
       '**/__tests__/**/*.test.js',


### PR DESCRIPTION
## Summary

Closes SD-LEO-INFRA-VITEST-EXITS-61S-001.

**Root cause**: `.github/workflows/test-coverage.yml` "Run tests with coverage" step had no `env:` block. Tests ran without Supabase credentials, so `tests/setup.js` `||=` fell through to the synthetic `https://test.invalid.local` sentinel. Smoke tests then issued real `.from('table').select()` calls that hung in supabase-js fetch retry against the unresolvable host until vitest's `testTimeout` (60000ms) force-killed the worker — exit 1 with TAP `# fail 0`. 16 false failures since 2026-04-30.

**Fix** (3 files, +33 LOC):

- `.github/workflows/test-coverage.yml` — pass `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` to the test step. Secrets already exist in repo (referenced by the downstream "Capture test results" step at lines 77-78) — they were just never passed to the step that needed them.
- `vitest.config.js` — add `teardownTimeout: 10000` + `pool: 'forks'`. Defense-in-depth: bounds any future open-handle leak to 10s instead of 60s.
- `tests/canary/workflow-exit-code.canary.test.js` — PRD FR-3 negative regression test, gated on `CANARY_TEST=1`. Default skip; activates a deliberate failure to verify workflow correctly exits 1 with `# fail 1` on real failure.

**Sibling**: SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 addresses orthogonal `# fail N` test-side scope. Whichever PR lands second rebases on main.

**Diagnosis path**: LEAD VALIDATION (row 13bf3fbb) → PLAN TESTING (row 6ab251e1, surfaced the SUPABASE_URL=*.invalid + DNS hang hypothesis) → EXEC implementation → PLAN_VERIFICATION (row d0156379, PASS@88%).

## Test plan

- [x] Local: `npx vitest run tests/smoke.test.js --coverage` completes (was hanging >75s before fix)
- [x] Canary OFF: 1 skipped, exit 0
- [x] Canary ON (`CANARY_TEST=1`): 1 failed, exit non-zero
- [ ] CI: this workflow run on the PR exits 0 in <90s with TAP `# fail 0`
- [ ] CI: 7-day green-rate on main reaches ≥95% (post-merge metric)

## Risks (per PLAN_VERIFICATION sub-agent)

1. CI is the only unverified surface for M-1..M-4. `teardownTimeout: 10000` caps any new silence at 10s.
2. `NEXT_PUBLIC_SUPABASE_ANON_KEY` is newly referenced. The other 3 are precedent-confirmed. If absent, anon-key paths regress silently — first PR CI run is the discovery step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>