### PR TITLE
feat(SD-FDBK-ENH-POST-MERGE-AUTO-001): post-merge handoff orchestrator + /ship Step 6.5

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -686,6 +686,37 @@ node scripts/modules/shipping/post-merge-worktree-cleanup.js --sdKey <SD-KEY-OR-
 
 **Note:** The existing LEAD-FINAL-APPROVAL cleanup is kept as a safety net. It is idempotent — if this step already cleaned up, it reports "worktree_not_found" and moves on.
 
+### Step 6.5: Auto-fire Post-Merge LEO Handoff Chain (SD-FDBK-ENH-POST-MERGE-AUTO-001)
+
+**Purpose**: After /ship merges a PR for an SD, automatically fire EXEC-TO-PLAN, PLAN-TO-LEAD, and LEAD-FINAL-APPROVAL handoffs so the SD reaches `status=completed` instead of remaining stuck at `status=draft, current_phase=LEAD`.
+
+**Skip condition**: If `STEP_6_3_RAN_QF_CLOSURE=true` (Quick-Fix flow), skip this step entirely. QFs use complete-quick-fix.js, not the LEO handoff chain.
+
+**Emergency disable**: If a regression emerges, set `LEO_AUTOHANDOFF_ENABLED=false` to skip Step 6.5; the SD will need manual `handoff.js execute` invocations to reach `completed`.
+
+**Run** (after Step 6.3 sets its sentinel; before Step 7's ecosystem prompt):
+```bash
+if [ "${STEP_6_3_RAN_QF_CLOSURE:-false}" = "false" ] && [ "${LEO_AUTOHANDOFF_ENABLED:-true}" = "true" ]; then
+  SD_KEY=$(echo "$BRANCH" | sed -nE 's|^(feat|fix|refactor|docs|test)/(SD-[^-]+(-[^-/]+)*)/?.*|\2|p')
+  if [ -n "$SD_KEY" ]; then
+    node scripts/post-merge-handoff-orchestrator.js --sd-key="$SD_KEY"
+    if [ $? -eq 0 ]; then
+      export STEP_6_5_RAN_AUTOHANDOFF=true
+    fi
+  fi
+fi
+```
+
+**Outcomes**:
+- `exit 0` (action=completed): SD advanced through full chain; status=completed; STEP_6_5_RAN_AUTOHANDOFF=true
+- `exit 0` (action=idempotent_skip): SD already completed; no-op; safe re-run
+- `exit 0` (reason=no_exec_work_to_advance): SD in LEAD/draft state — bug-class case logged for operator review
+- `exit 2-5` (non-zero): orchestrator halted; full step+stderr in `.claude/post-merge-orchestrator.log`. Step 7 ecosystem prompt still runs so operator can intervene.
+
+**Why this exists**: Without this step, `/ship` Step 6 merges the PR but never invokes the downstream LEO phase handoffs — the SD remains stuck at `draft/LEAD/0%` with stale claim ownership, blocking reclaim by parallel sessions. This is the bug-class behind 4035+ aggregate PAT-AUTO-* handoff-fail occurrences and 3 confirmed phantom SDs (SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 PRs #3389+#3437; SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-A).
+
+**Defense-in-depth**: `phantom-completion-sweep.yml` continues to detect any phantoms that emerge despite this fix.
+
 ### Step 7: Post-Merge Command Ecosystem (NEW)
 
 **After a successful merge, present contextual suggestions using AskUserQuestion:**

--- a/scripts/post-merge-handoff-orchestrator.js
+++ b/scripts/post-merge-handoff-orchestrator.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Post-merge handoff orchestrator (SD-FDBK-ENH-POST-MERGE-AUTO-001)
+ *
+ * Wires LEO Protocol phase handoffs (EXEC-TO-PLAN, PLAN-TO-LEAD,
+ * LEAD-FINAL-APPROVAL) into /ship Step 6.5 after PR merge.
+ *
+ * Idempotent: re-running on a completed SD is a no-op.
+ * Honors GATE_SUBAGENT_EVIDENCE by invoking lib/sub-agent-executor.js
+ * for TESTING (before EXEC-TO-PLAN) and RETRO (before PLAN-TO-LEAD).
+ */
+
+import { spawnSync } from 'child_process';
+import { appendFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const LOG_FILE = join(process.cwd(), '.claude', 'post-merge-orchestrator.log');
+const HANDOFF_CHAIN = ['EXEC-TO-PLAN', 'PLAN-TO-LEAD', 'LEAD-FINAL-APPROVAL'];
+const SUBAGENT_FOR = { 'EXEC-TO-PLAN': 'TESTING', 'PLAN-TO-LEAD': 'RETRO' };
+
+function logEvent(event) {
+  const line = JSON.stringify({ timestamp: new Date().toISOString(), ...event }) + '\n';
+  process.stdout.write(line);
+  try {
+    mkdirSync(dirname(LOG_FILE), { recursive: true });
+    appendFileSync(LOG_FILE, line);
+  } catch { /* log file is best-effort */ }
+}
+
+// Classify SD state for routing. Pure function — no side effects.
+export function classifyState({ status, current_phase }) {
+  if (status === 'completed' || current_phase === 'LEAD-FINAL-APPROVAL') {
+    return { action: 'idempotent_skip', reason: 'already_completed_no_op' };
+  }
+  if (current_phase === 'LEAD' && status === 'draft') {
+    return { action: 'warn_skip', reason: 'no_exec_work_to_advance' };
+  }
+  if (['EXEC', 'PLAN_PRD', 'PLAN', 'PLAN_VERIFICATION'].includes(current_phase)) {
+    return { action: 'advance', reason: 'ready_for_handoff_chain' };
+  }
+  return { action: 'warn_skip', reason: `unexpected_phase_${current_phase}_status_${status}` };
+}
+
+function defaultRunner(cmd, args) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env: process.env });
+  return { exitCode: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+// Orchestrator with injectable supabase + runner for tests.
+export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner, env = process.env }) {
+  if (!env.CLAUDE_SESSION_ID) {
+    logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'no_session', exit_code: 2 });
+    return { exitCode: 2, error: 'CLAUDE_SESSION_ID required for handoff claim validity', step: 'preflight' };
+  }
+  logEvent({ event: 'orchestrator_start', sd_key: sdKey });
+  const startTs = Date.now();
+
+  const { data: sd, error: lookupErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('status, current_phase, sd_key')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (lookupErr || !sd) {
+    logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'sd_not_found', exit_code: 3 });
+    return { exitCode: 3, error: `SD ${sdKey} not found`, step: 'preflight' };
+  }
+
+  const decision = classifyState(sd);
+  if (decision.action !== 'advance') {
+    logEvent({ event: 'idempotent_skip', sd_key: sdKey, reason: decision.reason, action: decision.action });
+    return { exitCode: 0, action: decision.action, reason: decision.reason };
+  }
+
+  for (const handoff of HANDOFF_CHAIN) {
+    const subagent = SUBAGENT_FOR[handoff];
+    if (subagent) {
+      const subStart = Date.now();
+      logEvent({ event: 'subagent_start', sd_key: sdKey, subagent, phase: handoff });
+      const sub = runner('node', ['lib/sub-agent-executor.js', subagent, sdKey]);
+      logEvent({ event: 'subagent_end', sd_key: sdKey, subagent, exit_code: sub.exitCode, duration_ms: Date.now() - subStart });
+      if (sub.exitCode !== 0) {
+        logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'subagent_failed', step: handoff, exit_code: 4 });
+        return { exitCode: 4, error: `${subagent} sub-agent failed before ${handoff}`, step: handoff, stderr: sub.stderr };
+      }
+    }
+    const hStart = Date.now();
+    logEvent({ event: 'handoff_start', sd_key: sdKey, handoff });
+    const h = runner('node', ['scripts/handoff.js', 'execute', handoff, sdKey]);
+    logEvent({ event: 'handoff_end', sd_key: sdKey, handoff, exit_code: h.exitCode, duration_ms: Date.now() - hStart });
+    if (h.exitCode !== 0) {
+      logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'handoff_failed', step: handoff, exit_code: 5 });
+      return { exitCode: 5, error: `${handoff} failed`, step: handoff, stderr: h.stderr };
+    }
+  }
+  logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'success', duration_ms: Date.now() - startTs, exit_code: 0 });
+  return { exitCode: 0, action: 'completed' };
+}
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && process.argv[1] === __filename) {
+  const sdKeyArg = process.argv.find(a => a.startsWith('--sd-key='));
+  if (!sdKeyArg) {
+    process.stderr.write('Usage: post-merge-handoff-orchestrator.js --sd-key=<SD-KEY>\n');
+    process.exit(1);
+  }
+  const sdKey = sdKeyArg.split('=')[1];
+  const { createSupabaseServiceClient } = await import('../lib/supabase-connection.js');
+  const supabase = await createSupabaseServiceClient();
+  const result = await runOrchestrator({ sdKey, supabase });
+  process.exit(result.exitCode);
+}

--- a/tests/integration/post-merge-orchestrator.test.js
+++ b/tests/integration/post-merge-orchestrator.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { classifyState, runOrchestrator } from '../../scripts/post-merge-handoff-orchestrator.js';
+
+const SD_KEY = 'SD-FAKE-TEST-001';
+
+function fakeSupabase(sd) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: sd, error: null })
+        })
+      })
+    })
+  };
+}
+
+function recordingRunner() {
+  const calls = [];
+  let plan = [];
+  const run = (cmd, args) => {
+    calls.push({ cmd, args });
+    const result = plan.shift() ?? { exitCode: 0, stdout: '', stderr: '' };
+    return result;
+  };
+  return { run, calls, setPlan: (p) => { plan = p; } };
+}
+
+const ENV_OK = { CLAUDE_SESSION_ID: '6919121d-test' };
+
+describe('classifyState (TS pure-logic guards)', () => {
+  it('treats completed SD as idempotent_skip', () => {
+    expect(classifyState({ status: 'completed', current_phase: 'LEAD-FINAL-APPROVAL' }).action).toBe('idempotent_skip');
+  });
+  it('treats LEAD/draft as warn_skip (TS-003)', () => {
+    expect(classifyState({ status: 'draft', current_phase: 'LEAD' })).toEqual({ action: 'warn_skip', reason: 'no_exec_work_to_advance' });
+  });
+  it('treats EXEC/in_progress as advance (TS-001)', () => {
+    expect(classifyState({ status: 'in_progress', current_phase: 'EXEC' }).action).toBe('advance');
+  });
+  it('treats PLAN_PRD as advance', () => {
+    expect(classifyState({ status: 'in_progress', current_phase: 'PLAN_PRD' }).action).toBe('advance');
+  });
+  it('treats unknown phase as warn_skip', () => {
+    expect(classifyState({ status: 'in_progress', current_phase: 'WEIRD' }).action).toBe('warn_skip');
+  });
+});
+
+describe('runOrchestrator (TS-001..TS-006)', () => {
+  let runner;
+  beforeEach(() => { runner = recordingRunner(); });
+
+  it('TS-006: missing CLAUDE_SESSION_ID returns exit 2 with clear error', async () => {
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'in_progress', current_phase: 'EXEC' }), runner: runner.run, env: {} });
+    expect(result.exitCode).toBe(2);
+    expect(result.error).toMatch(/CLAUDE_SESSION_ID required/);
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it('TS-002: idempotent re-run on completed SD is a no-op', async () => {
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'completed', current_phase: 'LEAD-FINAL-APPROVAL' }), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('idempotent_skip');
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it('TS-003: SD in LEAD/draft (buggy state) exits 0 with no_exec_work_to_advance', async () => {
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'draft', current_phase: 'LEAD' }), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(0);
+    expect(result.reason).toBe('no_exec_work_to_advance');
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it('TS-001: happy path invokes 2 sub-agents + 3 handoffs in correct order', async () => {
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'in_progress', current_phase: 'EXEC' }), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('completed');
+    expect(runner.calls).toEqual([
+      { cmd: 'node', args: ['lib/sub-agent-executor.js', 'TESTING', SD_KEY] },
+      { cmd: 'node', args: ['scripts/handoff.js', 'execute', 'EXEC-TO-PLAN', SD_KEY] },
+      { cmd: 'node', args: ['lib/sub-agent-executor.js', 'RETRO', SD_KEY] },
+      { cmd: 'node', args: ['scripts/handoff.js', 'execute', 'PLAN-TO-LEAD', SD_KEY] },
+      { cmd: 'node', args: ['scripts/handoff.js', 'execute', 'LEAD-FINAL-APPROVAL', SD_KEY] }
+    ]);
+  });
+
+  it('TS-004: sub-agent failure halts before its handoff', async () => {
+    runner.setPlan([{ exitCode: 1, stdout: '', stderr: 'agent boom' }]);
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'in_progress', current_phase: 'EXEC' }), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(4);
+    expect(result.error).toMatch(/TESTING sub-agent failed before EXEC-TO-PLAN/);
+    expect(runner.calls).toHaveLength(1);
+    expect(runner.calls[0].args[0]).toBe('lib/sub-agent-executor.js');
+  });
+
+  it('TS-005: middle handoff failure preserves prior progress', async () => {
+    runner.setPlan([
+      { exitCode: 0 }, // TESTING
+      { exitCode: 0 }, // EXEC-TO-PLAN ok
+      { exitCode: 0 }, // RETRO
+      { exitCode: 1, stderr: 'plan-to-lead boom' } // PLAN-TO-LEAD fails
+    ]);
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase({ status: 'in_progress', current_phase: 'EXEC' }), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(5);
+    expect(result.step).toBe('PLAN-TO-LEAD');
+    expect(runner.calls).toHaveLength(4);
+  });
+
+  it('returns exit 3 when SD does not exist in DB', async () => {
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase(null), runner: runner.run, env: ENV_OK });
+    expect(result.exitCode).toBe(3);
+    expect(result.error).toMatch(/not found/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the bug-class where `/ship` merges a PR but never invokes EXEC-TO-PLAN, PLAN-TO-LEAD, or LEAD-FINAL-APPROVAL handoffs, leaving SDs stuck at `status='draft', current_phase='LEAD', progress=0` with stale claim ownership that blocks reclaim by parallel sessions.

**Bug evidence**: 3 confirmed phantom SDs (SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 PRs #3389+#3437; SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-A) plus 4035+ aggregate auto-recovery occurrences across PAT-AUTO-89a22fe5 (1285), PAT-AUTO-51d8544d (1142), PAT-AUTO-fc4cd518 (1608).

## Implementation

- **`scripts/post-merge-handoff-orchestrator.js`** (112 LOC): Pure `classifyState()` function (testable) + injectable runner + structured JSON logging. Honors GATE_SUBAGENT_EVIDENCE by invoking `lib/sub-agent-executor.js` for TESTING (before EXEC-TO-PLAN) and RETRO (before PLAN-TO-LEAD).
- **`tests/integration/post-merge-orchestrator.test.js`** (114 LOC, 12 tests): TS-001 (happy path order), TS-002 (idempotent re-run), TS-003 (LEAD/draft no-op), TS-004 (sub-agent failure halts), TS-005 (middle handoff failure preserves prior progress), TS-006 (missing CLAUDE_SESSION_ID exits 2) + 5 pure-function classifyState tests + 1 sd_not_found test. **All 12 passing.**
- **`.claude/commands/ship.md`** (+31 LOC): Step 6.5 wire-up between Step 6.3 (QF closure) and Step 7 (ecosystem prompt). Skip for QF flows. Emergency disable via `LEO_AUTOHANDOFF_ENABLED=false`.

**Idempotency**: Re-running on a completed SD is a safe no-op.
**Defense-in-depth**: `phantom-completion-sweep.yml` continues to detect any phantoms that emerge despite this fix.

## PR Size Justification (>200 LOC for infrastructure)

Bundled atomic unit (orchestrator + tests + wire-up + docs) — splitting would create incomplete intermediate states. Source: 112 LOC; tests: 114 LOC; docs: 31 LOC.

## Test plan
- [x] `vitest run tests/integration/post-merge-orchestrator.test.js` — 12/12 passing
- [ ] CI Test Coverage Enforcement workflow green
- [ ] Smoke test on next /ship invocation: orchestrator fires, JSON log lines appear in `.claude/post-merge-orchestrator.log`
- [ ] Backfill test: invoke orchestrator on SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 — reaches `status=completed` within 5 min (FR-005 verification, deferred to follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)