### PR TITLE
feat(SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001): wire stage-20 analyzer persistence to venture_quality_findings (FR-B prime)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
@@ -250,12 +250,13 @@ export async function analyzeStage20CodeQuality(params) {
     const hasHigh = allFindings.some(f => f.severity === 'high');
     const verdict = hasCritical ? 'FAIL' : hasHigh ? 'WARN' : 'PASS';
 
-    // FR-A: produce canonical-shape findings alongside the legacy array.
-    // FR-B will plumb `canonical_findings` into the venture_quality_findings
-    // writer; this PR only proves the shape adoption.
+    // FR-A produces canonical-shape findings alongside the legacy array.
+    // FR-B plumbs canonical_findings into the venture_quality_findings writer.
     const adapted = ventureId
       ? adaptLegacyBatch(allFindings, { venture_id: ventureId })
       : { canonical: [], skipped: allFindings, hashes: new Set() };
+
+    const persistResult = await persistAnalyzerFindings(supabase, ventureId, adapted);
 
     return {
       verdict,
@@ -264,6 +265,7 @@ export async function analyzeStage20CodeQuality(params) {
       findings: allFindings,
       canonical_findings: adapted.canonical,
       canonical_skipped_count: adapted.skipped.length,
+      persistence: persistResult,
       summary: {
         total_findings: allFindings.length,
         by_severity: {
@@ -286,6 +288,67 @@ export async function analyzeStage20CodeQuality(params) {
     // Clean up temp directory
     try { await rm(clone.tempRoot, { recursive: true, force: true }); } catch { /* ignore */ }
   }
+}
+
+/**
+ * FR-B: best-effort persistence of canonical findings into venture_quality_findings.
+ *
+ * Failures here must NOT fail the analyzer. The writer relies on UNIQUE(venture_id,
+ * finding_hash) for idempotency, so re-invocation with the same canonical batch is
+ * a no-op at the row-count level. audit_log emission is itself try/catch-wrapped —
+ * observability failure is silent (mirrors capability-gate.js:107-109).
+ *
+ * Exported so unit tests can drive the persistence path without standing up the
+ * full analyzer pipeline (cloneRepo + 4 quality checks).
+ *
+ * @param {Object|null} supabase - service-role client (optional; null skips cleanly)
+ * @param {string|null} ventureId - venture UUID (required for audit_log entity_id)
+ * @param {{canonical: Array, skipped: Array}} adapted - output of adaptLegacyBatch
+ * @returns {Promise<{written:number, errors:Array, skipped_count:number, skipped_reason?:string}>}
+ */
+export async function persistAnalyzerFindings(supabase, ventureId, adapted) {
+  const persistResult = {
+    written: 0,
+    errors: [],
+    skipped_count: 0,
+  };
+
+  if (!supabase) {
+    persistResult.skipped_reason = 'no_supabase_client';
+    return persistResult;
+  }
+
+  if (!adapted || !Array.isArray(adapted.canonical) || adapted.canonical.length === 0) {
+    return persistResult;
+  }
+
+  try {
+    const { writeFindingsBatch } = await import('../../quality-findings/writer.js');
+    const r = await writeFindingsBatch(supabase, adapted.canonical);
+    persistResult.written = r.written;
+    persistResult.errors = r.errors;
+    persistResult.skipped_count = r.errors.length;
+  } catch (err) {
+    persistResult.errors.push({ scope: 'persistence-toplevel', error: err?.message || String(err) });
+  }
+
+  try {
+    await supabase.from('audit_log').insert({
+      event_type: 'venture_quality_findings.persist',
+      entity_type: 'venture',
+      entity_id: ventureId,
+      severity: persistResult.errors.length === 0 ? 'info' : 'warning',
+      created_by: 'stage-20-code-quality-analyzer',
+      metadata: {
+        inserted_count: persistResult.written,
+        skipped_count: persistResult.skipped_count,
+        error_count: persistResult.errors.length,
+        hash_schema_version: 'fnv1a-16',
+      },
+    });
+  } catch { /* observability failure is silent */ }
+
+  return persistResult;
 }
 
 function buildNoRepoReport(ventureName) {

--- a/tests/unit/eva/stage-templates/stage-20-persistence.test.js
+++ b/tests/unit/eva/stage-templates/stage-20-persistence.test.js
@@ -1,0 +1,203 @@
+/**
+ * Vitest coverage for FR-B: stage-20 analyzer persistence path
+ * (SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001).
+ *
+ * Tests target the exported persistAnalyzerFindings helper directly so we do
+ * not need to stand up the full analyzer pipeline (cloneRepo + 4 checks).
+ *
+ * Mock-supabase pattern is the same shape as
+ * tests/unit/eva/quality-findings/writer.test.js:15-55, extended with an
+ * audit_log capture (rows Map keyed on insert id, calls array recording
+ * event_type / metadata) for FR-3 assertions.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { persistAnalyzerFindings } from '../../../../lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js';
+import { computeFindingHash } from '../../../../lib/eva/quality-findings/finding-shape.js';
+
+/**
+ * makeMockSupabase — extended from writer.test.js to also capture audit_log
+ * inserts. Optional `auditThrows` injects a thrower for TS-6 coverage.
+ */
+function makeMockSupabase({ upsertThrows = false, auditThrows = false } = {}) {
+  const rows = new Map();             // venture_quality_findings: venture_id|finding_hash → row
+  const auditRows = [];               // audit_log: ordered insert log
+  const calls = [];                   // every operation
+  let nextId = 1;
+
+  const client = {
+    from(table) {
+      const builder = {
+        upsert(payload, opts) {
+          calls.push({ op: 'upsert', table, payload, opts });
+          if (table === 'venture_quality_findings' && upsertThrows) {
+            return {
+              select: () => ({
+                single: async () => { throw new Error('FK violation'); },
+              }),
+            };
+          }
+          if (table === 'venture_quality_findings') {
+            const key = `${payload.venture_id}|${payload.finding_hash}`;
+            const id = rows.has(key) ? rows.get(key).id : `mock-${nextId++}`;
+            rows.set(key, { ...payload, id });
+            return {
+              select: () => ({
+                single: async () => ({ data: { id }, error: null }),
+              }),
+            };
+          }
+          return { select: () => ({ single: async () => ({ data: {}, error: null }) }) };
+        },
+        insert(payload) {
+          calls.push({ op: 'insert', table, payload });
+          if (table === 'audit_log') {
+            if (auditThrows) {
+              return Promise.reject(new Error('audit_log table does not exist'));
+            }
+            const id = `audit-${auditRows.length + 1}`;
+            auditRows.push({ ...payload, id });
+            return Promise.resolve({ data: { id }, error: null });
+          }
+          return Promise.resolve({ data: {}, error: null });
+        },
+      };
+      return builder;
+    },
+    _rows: rows,
+    _auditRows: auditRows,
+    _calls: calls,
+  };
+  return client;
+}
+
+const VENTURE_ID = 'v-fixture-1';
+
+const makeFinding = (signature, overrides = {}) => ({
+  venture_id: VENTURE_ID,
+  stage_number: 20,
+  finding_category: 'lint',
+  severity: 'medium',
+  finding_hash: computeFindingHash({
+    venture_id: VENTURE_ID,
+    stage_number: 20,
+    finding_category: 'lint',
+    finding_signature: signature,
+  }),
+  evidence_pointer: { signature },
+  ...overrides,
+});
+
+const adapted = (canonical = [], skipped = []) => ({ canonical, skipped, hashes: new Set() });
+
+describe('persistAnalyzerFindings — FR-B', () => {
+  let supabase;
+  beforeEach(() => {
+    supabase = makeMockSupabase();
+  });
+
+  it('TS-1: happy path — writes rows and emits one audit_log info row', async () => {
+    const batch = adapted([
+      makeFinding('no-unused-vars:src/foo.js:1'),
+      makeFinding('no-unused-vars:src/foo.js:2'),
+      makeFinding('npm-audit:left-pad@1.0.0', { finding_category: 'npm_audit', severity: 'high' }),
+    ]);
+    const result = await persistAnalyzerFindings(supabase, VENTURE_ID, batch);
+
+    expect(result.written).toBe(3);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped_count).toBe(0);
+    expect(supabase._rows.size).toBe(3);
+
+    const auditInserts = supabase._calls.filter(c => c.table === 'audit_log');
+    expect(auditInserts).toHaveLength(1);
+    expect(auditInserts[0].payload.severity).toBe('info');
+    expect(auditInserts[0].payload.event_type).toBe('venture_quality_findings.persist');
+    expect(auditInserts[0].payload.entity_type).toBe('venture');
+    expect(auditInserts[0].payload.entity_id).toBe(VENTURE_ID);
+    expect(auditInserts[0].payload.created_by).toBe('stage-20-code-quality-analyzer');
+    expect(auditInserts[0].payload.metadata).toEqual({
+      inserted_count: 3,
+      skipped_count: 0,
+      error_count: 0,
+      hash_schema_version: 'fnv1a-16',
+    });
+  });
+
+  it('TS-2: idempotent re-run — same batch twice yields same row count', async () => {
+    const batch = adapted([
+      makeFinding('lint-rule:src/a.js'),
+      makeFinding('lint-rule:src/b.js'),
+    ]);
+
+    const r1 = await persistAnalyzerFindings(supabase, VENTURE_ID, batch);
+    const r2 = await persistAnalyzerFindings(supabase, VENTURE_ID, batch);
+
+    expect(r1.written).toBe(2);
+    expect(r2.written).toBe(2);
+    expect(supabase._rows.size).toBe(2);
+
+    const auditInserts = supabase._calls.filter(c => c.table === 'audit_log');
+    expect(auditInserts).toHaveLength(2);
+    expect(auditInserts.every(c => c.payload.severity === 'info')).toBe(true);
+  });
+
+  it('TS-3: DB error — analyzer-side return still safe; audit warning emitted', async () => {
+    // writer.writeFindingsBatch catches per-finding (writer.js:79-95), so a
+    // .upsert that throws surfaces as r.errors[].finding/error rather than
+    // tripping the toplevel try/catch. This is the realistic shape users
+    // hit when a single finding fails RLS / FK validation.
+    const throwing = makeMockSupabase({ upsertThrows: true });
+    const batch = adapted([makeFinding('lint:foo')]);
+
+    const result = await persistAnalyzerFindings(throwing, VENTURE_ID, batch);
+
+    expect(result.written).toBe(0);
+    expect(result.errors.length).toBeGreaterThanOrEqual(1);
+    expect(result.errors[0].error).toContain('FK violation');
+    expect(result.errors[0].finding).toBeTruthy();
+    expect(result.skipped_count).toBe(result.errors.length);
+
+    const auditInserts = throwing._calls.filter(c => c.table === 'audit_log');
+    expect(auditInserts).toHaveLength(1);
+    expect(auditInserts[0].payload.severity).toBe('warning');
+    expect(auditInserts[0].payload.metadata.error_count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('TS-4: empty batch — short-circuits with no upsert and no audit_log', async () => {
+    const result = await persistAnalyzerFindings(supabase, VENTURE_ID, adapted([]));
+
+    expect(result.written).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped_count).toBe(0);
+    expect(supabase._calls).toEqual([]);
+  });
+
+  it('TS-5: no supabase client — skips cleanly with skipped_reason', async () => {
+    const batch = adapted([makeFinding('lint:foo')]);
+    const result = await persistAnalyzerFindings(null, VENTURE_ID, batch);
+
+    expect(result).toEqual({
+      written: 0,
+      errors: [],
+      skipped_count: 0,
+      skipped_reason: 'no_supabase_client',
+    });
+  });
+
+  it('TS-6: audit_log insert failure — swallowed; persistence still succeeds', async () => {
+    const throwing = makeMockSupabase({ auditThrows: true });
+    const batch = adapted([makeFinding('lint:foo'), makeFinding('lint:bar')]);
+
+    const result = await persistAnalyzerFindings(throwing, VENTURE_ID, batch);
+
+    expect(result.written).toBe(2);
+    expect(result.errors).toEqual([]);
+    expect(throwing._rows.size).toBe(2);
+
+    // audit_log insert was attempted but threw; no rows captured.
+    expect(throwing._auditRows).toEqual([]);
+    const auditAttempts = throwing._calls.filter(c => c.table === 'audit_log');
+    expect(auditAttempts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Plumbs FR-A's `canonical_findings` emission into the existing `writeFindingsBatch` writer so every stage-20 analyzer run persists its canonical batch to `venture_quality_findings`. Unblocks sibling SDs FR-C (per-finding SD generator) and FR-F (aggregator), both of which depend on the table being non-empty.

**Approach**: extracted `persistAnalyzerFindings(supabase, ventureId, adapted)` as an exported helper for testability. Best-effort: failures NEVER fail the analyzer (analyzer's contract is the verdict + findings array). Idempotency comes from the existing `UNIQUE(venture_id, finding_hash)` constraint and writer's `onConflict` clause — zero application-level dedup.

`audit_log` uses the verified `metadata:` column (NOT `details:`, which is silently dropped — see `capability-gate.js:102` and `bypass-handler.js:66` for existing observability holes worth a follow-up QF).

## Files Changed

- `lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js` (+66/-3) — adds `persistAnalyzerFindings` helper, calls it from analyzer
- `tests/unit/eva/stage-templates/stage-20-persistence.test.js` (+203, new) — 6 vitest cases (TS-1 through TS-6 from PRD)

**Total: 269 LOC** (tier 3, justified by per-PRD 6-case test coverage requirement)

## Test plan

- [x] All 6 new vitest cases pass: \`npx vitest run tests/unit/eva/stage-templates/stage-20-persistence.test.js\`
- [x] Existing \`tests/unit/eva/quality-findings/writer.test.js\` (11 cases) continues to pass — zero regressions
- [x] Combined: 17/17 vitest cases pass
- [ ] **Post-merge manual fixture run** (PRD AC #4): invoke analyzer against a venture with \`repo_url\` set; verify \`SELECT count(*) FROM venture_quality_findings WHERE venture_id = <fixture> > 0\` within 5s; second invocation leaves count unchanged
- [ ] **Post-merge audit_log verification** (PRD AC #5): row appears with \`metadata.hash_schema_version = 'fnv1a-16'\`

## LEO Trace

- **SD**: SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001 (uuid: 34d1336b-579e-45fa-b977-7db078c5527a)
- **Parent SD**: SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-001 (FR-A merged in PR #3441)
- **PRD**: b52dc0b9-865b-4649-973e-5b5093329170
- **Retrospective**: fa0b57f7-0e12-4115-b859-f79d2259a3c2 (quality_score 100)
- **Handoff scores**: LEAD-TO-PLAN 95% / PLAN-TO-EXEC 96% / PLAN-TO-LEAD 92%

## Harness Bugs Filed (out of scope, deferred)

- feedback \`7c68d8e4-8ca2-4b94-89f2-e5f7349b4815\` — sd-start.js creates broken worktree (silent failure)
- feedback \`f651e8eb-d5d6-4989-a2fe-8bb6bd11055e\` — gate6 creates slug-suffixed duplicate branch when canonical already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)