### PR TITLE
fix(SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001): read JSONB dependencies column

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001",
-  "createdAt": "2026-04-26T15:39:35.067Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer"
+  "sdKey": "SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001",
+  "expectedBranch": "feat/SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001",
+  "createdAt": "2026-05-02T12:07:06.667Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "baseRef": "origin/main"
 }

--- a/lib/utils/dependency-chain-validator.js
+++ b/lib/utils/dependency-chain-validator.js
@@ -10,6 +10,7 @@
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
+import { parseDependencies } from '../../scripts/lib/dependency-graph.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -35,10 +36,10 @@ const supabase = createSupabaseServiceClient();
 export async function validateDependencyChain(sdKey) {
   console.log(`\n🔗 Validating dependency chain for: ${sdKey}`);
 
-  // Fetch the SD
+  // Fetch the SD — include `dependencies` JSONB column (SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001)
   const { data: sd, error: sdError } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, dependency_chain, parent_sd_id, status, progress')
+    .select('id, sd_key, title, dependency_chain, dependencies, parent_sd_id, status, progress')
     .eq('sd_key', sdKey)
     .single();
 
@@ -51,8 +52,13 @@ export async function validateDependencyChain(sdKey) {
     };
   }
 
-  // If no dependency_chain, can proceed
-  if (!sd.dependency_chain || sd.dependency_chain.length === 0) {
+  // Combine deps from BOTH locations: dependencies JSONB column + legacy dependency_chain.
+  // Sister fix to scripts/child-sd-preflight.js::extractDependencyIds.
+  const fromColumn = parseDependencies(sd.dependencies);
+  const fromChain = parseDependencies(sd.dependency_chain);
+  const depKeys = [...new Set([...fromColumn, ...fromChain])];
+
+  if (depKeys.length === 0) {
     console.log('   ✅ No dependencies - can proceed');
     return {
       canProceed: true,
@@ -66,13 +72,13 @@ export async function validateDependencyChain(sdKey) {
   const { data: dependencies, error: depError } = await supabase
     .from('strategic_directives_v2')
     .select('sd_key, title, status, progress')
-    .in('sd_key', sd.dependency_chain);
+    .in('sd_key', depKeys);
 
   if (depError) {
     console.log(`   ⚠️  Error fetching dependencies: ${depError.message}`);
     return {
       canProceed: false,
-      blockedBy: sd.dependency_chain,
+      blockedBy: depKeys,
       message: `Error fetching dependencies: ${depError.message}`,
       dependencyStatus: []
     };
@@ -102,7 +108,7 @@ export async function validateDependencyChain(sdKey) {
 
   // Check for missing dependencies (not found in database)
   const foundKeys = (dependencies || []).map(d => d.sd_key);
-  const missingDeps = sd.dependency_chain.filter(key => !foundKeys.includes(key));
+  const missingDeps = depKeys.filter(key => !foundKeys.includes(key));
   for (const missing of missingDeps) {
     blockedBy.push(missing);
     dependencyStatus.push({
@@ -117,7 +123,7 @@ export async function validateDependencyChain(sdKey) {
 
   const canProceed = blockedBy.length === 0;
   const message = canProceed
-    ? `All ${sd.dependency_chain.length} dependencies satisfied`
+    ? `All ${depKeys.length} dependencies satisfied`
     : `Blocked by ${blockedBy.length} incomplete dependency/dependencies: ${blockedBy.join(', ')}`;
 
   console.log(`   ${canProceed ? '✅' : '❌'} ${message}`);

--- a/lib/utils/dependency-chain-validator.test.js
+++ b/lib/utils/dependency-chain-validator.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Per-test query state used by the in-test supabase mock.
+// Tests set this object to control what the mocked .single() returns.
+let __sdRow = null;
+let __depsResult = { data: [], error: null };
+let __lastInQuery = null;
+
+vi.mock('../supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ single: async () => ({ data: __sdRow, error: __sdRow ? null : new Error('not found') }) }),
+        in: (_col, vals) => { __lastInQuery = vals; return Promise.resolve(__depsResult); },
+      }),
+    }),
+  }),
+}));
+
+const { validateDependencyChain } = await import('./dependency-chain-validator.js');
+
+beforeEach(() => {
+  __sdRow = null;
+  __depsResult = { data: [], error: null };
+  __lastInQuery = null;
+});
+
+describe('validateDependencyChain — SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001 sister fix', () => {
+  // Suppress console.log output noise during tests
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  it('reads sd.dependencies JSONB column (the bug being fixed)', async () => {
+    __sdRow = {
+      id: 'sd-uuid', sd_key: 'SD-EVA-SUPPORT-001-C',
+      dependency_chain: null,
+      dependencies: [{ sd_id: 'SD-EVA-SUPPORT-001-B' }],
+      parent_sd_id: 'parent-uuid', status: 'draft', progress: 0,
+    };
+    __depsResult = {
+      data: [{ sd_key: 'SD-EVA-SUPPORT-001-B', title: 'Phase 2', status: 'draft', progress: 0 }],
+      error: null,
+    };
+    const r = await validateDependencyChain('SD-EVA-SUPPORT-001-C');
+    expect(__lastInQuery).toEqual(['SD-EVA-SUPPORT-001-B']);
+    expect(r.canProceed).toBe(false);
+    expect(r.blockedBy).toEqual(['SD-EVA-SUPPORT-001-B']);
+  });
+
+  it('returns canProceed=true when dependencies populated and dep is complete', async () => {
+    __sdRow = {
+      id: 'u', sd_key: 'SD-X', dependency_chain: null,
+      dependencies: [{ sd_id: 'SD-DONE' }],
+      parent_sd_id: 'p', status: 'draft', progress: 0,
+    };
+    __depsResult = {
+      data: [{ sd_key: 'SD-DONE', title: 'Done', status: 'completed', progress: 100 }],
+      error: null,
+    };
+    const r = await validateDependencyChain('SD-X');
+    expect(r.canProceed).toBe(true);
+    expect(r.blockedBy).toEqual([]);
+  });
+
+  it('returns canProceed=true for placeholder shape (Witness A)', async () => {
+    __sdRow = {
+      id: 'u', sd_key: 'SD-WITNESS-A', dependency_chain: null,
+      dependencies: [{ type: 'internal', status: 'available', dependency: 'none' }],
+      parent_sd_id: 'p', status: 'draft', progress: 0,
+    };
+    const r = await validateDependencyChain('SD-WITNESS-A');
+    expect(r.canProceed).toBe(true);
+    expect(r.message).toContain('No dependencies');
+  });
+
+  it('falls back to legacy dependency_chain when dependencies is null', async () => {
+    __sdRow = {
+      id: 'u', sd_key: 'SD-LEGACY', dependencies: null,
+      dependency_chain: ['SD-LEGACY-DEP'],
+      parent_sd_id: 'p', status: 'draft', progress: 0,
+    };
+    __depsResult = {
+      data: [{ sd_key: 'SD-LEGACY-DEP', title: 'L', status: 'completed', progress: 100 }],
+      error: null,
+    };
+    const r = await validateDependencyChain('SD-LEGACY');
+    expect(__lastInQuery).toEqual(['SD-LEGACY-DEP']);
+    expect(r.canProceed).toBe(true);
+  });
+
+  it('combines dependencies + dependency_chain (deduped)', async () => {
+    __sdRow = {
+      id: 'u', sd_key: 'SD-BOTH',
+      dependencies: [{ sd_id: 'SD-A' }, { sd_id: 'SD-B' }],
+      dependency_chain: ['SD-B', 'SD-C'],
+      parent_sd_id: 'p', status: 'draft', progress: 0,
+    };
+    __depsResult = {
+      data: [
+        { sd_key: 'SD-A', title: 'A', status: 'completed', progress: 100 },
+        { sd_key: 'SD-B', title: 'B', status: 'completed', progress: 100 },
+        { sd_key: 'SD-C', title: 'C', status: 'completed', progress: 100 },
+      ],
+      error: null,
+    };
+    const r = await validateDependencyChain('SD-BOTH');
+    expect(new Set(__lastInQuery)).toEqual(new Set(['SD-A', 'SD-B', 'SD-C']));
+    expect(r.canProceed).toBe(true);
+  });
+
+  it('returns canProceed=true when both dependency sources empty', async () => {
+    __sdRow = {
+      id: 'u', sd_key: 'SD-NONE',
+      dependencies: null, dependency_chain: null,
+      parent_sd_id: 'p', status: 'draft', progress: 0,
+    };
+    const r = await validateDependencyChain('SD-NONE');
+    expect(r.canProceed).toBe(true);
+    expect(r.message).toContain('No dependencies');
+  });
+});

--- a/scripts/__tests__/child-sd-preflight.test.js
+++ b/scripts/__tests__/child-sd-preflight.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the supabase client so importing child-sd-preflight does not hit a real DB.
+// This is required because ChildSDPreflightValidator instantiates a client at module load.
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({ from: () => ({ select: () => ({ eq: () => ({ single: async () => ({ data: null, error: null }) }) }) }) }),
+}));
+
+const { ChildSDPreflightValidator } = await import('../child-sd-preflight.js');
+
+describe('extractDependencyIds — SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001', () => {
+  const v = new ChildSDPreflightValidator();
+
+  // === New: sd.dependencies JSONB column (the bug being fixed) ===
+
+  it('reads sd.dependencies array of {sd_id} objects', () => {
+    const sd = { dependencies: [{ sd_id: 'SD-EVA-SUPPORT-001-B' }] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-EVA-SUPPORT-001-B']);
+  });
+
+  it('reads sd.dependencies with multiple {sd_id} objects', () => {
+    const sd = { dependencies: [{ sd_id: 'SD-X' }, { sd_id: 'SD-Y' }] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-X', 'SD-Y']);
+  });
+
+  it('reads sd.dependencies bare-string shape (38% of population per DATABASE evidence)', () => {
+    const sd = { dependencies: ['SD-A', 'SD-B'] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-A', 'SD-B']);
+  });
+
+  it('returns [] for placeholder shape {type, status, dependency:none} — Witness A canonical case', () => {
+    const sd = { dependencies: [{ type: 'internal', status: 'available', dependency: 'none' }] };
+    expect(v.extractDependencyIds(sd)).toEqual([]);
+  });
+
+  it('returns [] for empty dependencies array', () => {
+    expect(v.extractDependencyIds({ dependencies: [] })).toEqual([]);
+  });
+
+  // === Legacy: sd.dependency_chain (3 historical shapes — regression coverage) ===
+
+  it('legacy Format 1: dependency_chain as array of SD-ID strings', () => {
+    const sd = { dependency_chain: ['SD-LEGACY-1', 'SD-LEGACY-2'] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-LEGACY-1', 'SD-LEGACY-2']);
+  });
+
+  it('legacy Format 2: dependency_chain.children[].depends_on', () => {
+    const sd = {
+      id: 'SD-CHILD-X',
+      dependency_chain: { children: [{ sd_id: 'SD-CHILD-X', depends_on: ['SD-PREREQ'] }] },
+    };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-PREREQ']);
+  });
+
+  it('legacy Format 3: parent.dependency_chain.children[].depends_on (when sd has truthy non-matching chain)', () => {
+    // Format 3 in the original code only triggers when sd.dependency_chain is truthy
+    // but neither an array nor has its own children — a rare shape where the child
+    // just inherits via the parent's chain. Test preserves original behavior.
+    v.parent = { dependency_chain: { children: [{ sd_id: 'SD-CHILD-Y', depends_on: ['SD-PREREQ-2'] }] } };
+    const sd = { id: 'SD-CHILD-Y', dependency_chain: { sentinel: true } };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-PREREQ-2']);
+    v.parent = null;
+  });
+
+  // === Precedence: dependencies wins over dependency_chain when both populated ===
+
+  it('precedence: sd.dependencies takes priority over dependency_chain', () => {
+    const sd = {
+      dependencies: [{ sd_id: 'SD-FROM-COLUMN' }],
+      dependency_chain: ['SD-FROM-CHAIN'],
+    };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-FROM-COLUMN']);
+  });
+
+  it('falls back to dependency_chain when sd.dependencies is null', () => {
+    const sd = { dependencies: null, dependency_chain: ['SD-FALLBACK'] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-FALLBACK']);
+  });
+
+  it('falls back to dependency_chain when sd.dependencies parses to []', () => {
+    const sd = { dependencies: [{ type: 'placeholder' }], dependency_chain: ['SD-FALLBACK-2'] };
+    expect(v.extractDependencyIds(sd)).toEqual(['SD-FALLBACK-2']);
+  });
+
+  // === Edge cases ===
+
+  it('returns [] when neither dependencies nor dependency_chain set', () => {
+    expect(v.extractDependencyIds({})).toEqual([]);
+  });
+});

--- a/scripts/child-sd-preflight.js
+++ b/scripts/child-sd-preflight.js
@@ -22,6 +22,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { getAncestorChain, MAX_HIERARCHY_DEPTH } from './lib/sd-hierarchy-mapper.js';
+import { parseDependencies } from './lib/dependency-graph.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,7 +64,7 @@ const REQUIRED_HANDOFFS_BY_TYPE = {
   default: 3
 };
 
-class ChildSDPreflightValidator {
+export class ChildSDPreflightValidator {
   constructor() {
     this.sd = null;
     this.parent = null;
@@ -163,22 +164,39 @@ class ChildSDPreflightValidator {
   }
 
   /**
-   * Extract dependency IDs from dependency_chain
-   * Supports both old and new formats
+   * Extract dependency IDs from an SD row.
+   *
+   * Reads both modern and legacy locations, in this precedence order:
+   *  1. sd.dependencies (JSONB column on strategic_directives_v2) — array of
+   *     {sd_id} objects, bare SD-ID strings, or placeholder objects like
+   *     {type, status, dependency} (placeholder shape returns []).
+   *     Delegated to parseDependencies for shape normalization.
+   *  2. sd.dependency_chain — three legacy shapes:
+   *     - Array of SD-ID strings
+   *     - Object with children[].depends_on (own chain)
+   *     - Parent's dependency_chain.children[].depends_on
+   *
+   * SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001: previously read only
+   * dependency_chain — false PASS for the 657 child SDs (~42% of pop) that
+   * populate `dependencies` instead. Sister fix in
+   * lib/utils/dependency-chain-validator.js.
    */
   extractDependencyIds(sd) {
+    // Modern location: sd.dependencies JSONB column (array of {sd_id} or strings)
+    const fromColumn = parseDependencies(sd.dependencies);
+    if (fromColumn.length > 0) return fromColumn;
+
     if (!sd.dependency_chain) return [];
 
     const chain = sd.dependency_chain;
 
-    // Format 1: Array of SD IDs directly
+    // Legacy Format 1: Array of SD IDs directly
     if (Array.isArray(chain)) {
       return chain.filter(item => typeof item === 'string' && item.startsWith('SD-'));
     }
 
-    // Format 2: Object with children array containing depends_on
+    // Legacy Format 2: Object with children array containing depends_on
     if (chain.children && Array.isArray(chain.children)) {
-      // Find this SD in the children array and get its depends_on
       const thisChild = chain.children.find(c =>
         c.sd_id === sd.id || c.sd_id === sd.sd_key
       );
@@ -191,8 +209,7 @@ class ChildSDPreflightValidator {
       }
     }
 
-    // Format 3: Parent's dependency_chain with children array
-    // We need to find what this specific SD depends on
+    // Legacy Format 3: Parent's dependency_chain with children array
     if (this.parent?.dependency_chain?.children) {
       const thisChild = this.parent.dependency_chain.children.find(c =>
         c.sd_id === sd.id || c.sd_id === sd.sd_key
@@ -293,6 +310,10 @@ class ChildSDPreflightValidator {
     if (this.dependencies.length === 0) {
       console.log(`${colors.bold}🔗 DEPENDENCY CHECK${colors.reset}`);
       console.log(`${colors.dim}   No dependencies defined for this child SD.${colors.reset}\n`);
+      const unlockGate = this.sd.metadata?.unlock_gate;
+      if (unlockGate?.type) {
+        console.log(`${colors.cyan}   UNLOCK_GATE: ${unlockGate.type}${colors.reset} ${colors.dim}(informational — does not affect verdict)${colors.reset}`);
+      }
       console.log(`${colors.green}✅ RESULT: PASS${colors.reset}`);
       console.log(`${colors.dim}   Ready to work on ${displayId}.${colors.reset}`);
       console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);
@@ -392,6 +413,10 @@ class ChildSDPreflightValidator {
       };
     }
 
+    const unlockGatePass = this.sd.metadata?.unlock_gate;
+    if (unlockGatePass?.type) {
+      console.log(`${colors.cyan}   UNLOCK_GATE: ${unlockGatePass.type}${colors.reset} ${colors.dim}(informational — does not affect verdict)${colors.reset}`);
+    }
     console.log(`${colors.bgGreen}${colors.bold} ✅ RESULT: PROCEED ${colors.reset}`);
     console.log(`${colors.green}   All dependencies satisfied. Ready to work on ${displayId}.${colors.reset}`);
     console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);


### PR DESCRIPTION
## Summary

- `child-sd-preflight.js::extractDependencyIds` and `lib/utils/dependency-chain-validator.js` previously read only `sd.dependency_chain`, missing the `dependencies` JSONB column populated on **657 of 1000 sampled child SDs (~42%)** — a structural false-PASS surface that includes the AUTO-PROCEED entrypoint via the sister validator
- Both call sites now import `parseDependencies` from `scripts/lib/dependency-graph.js` and read `sd.dependencies` before falling through to the legacy `dependency_chain` shapes (3 historical formats preserved as backward-compat fallback)
- Optional `unlock_gate` informational surface added on PASS paths only — does not affect verdict per scope-lock

## Expected Behavior Change

Child SDs that have populated `dependencies` JSONB will now correctly report **BLOCKED** in `child-sd-preflight` and AUTO-PROCEED's dependency check. This is desired but operators should expect `sd:next` badges to flip from **READY → BLOCKED** for affected SDs.

Specific witness SDs that flip:
- `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C` (was PASS, now BLOCKED — dep on `-B` which is draft)
- `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-D`, `-E` (similar pattern, verify pre-merge)

`SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-A` continues to PASS — its `dependencies` is the placeholder shape `[{type:internal, status:available, dependency:none}]` which `parseDependencies` correctly filters to `[]`.

## Test plan

- [x] `vitest run scripts/__tests__/child-sd-preflight.test.js` — 12/12 passing (5 new shapes + 3 legacy + 4 precedence/edge)
- [x] `vitest run lib/utils/dependency-chain-validator.test.js` — 6/6 passing (sister validator regression coverage)
- [x] Acceptance smoke `node scripts/child-sd-preflight.js SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C` → exit 1 (BLOCKED, lists `-B`)
- [x] Acceptance smoke `node scripts/child-sd-preflight.js SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-A` → exit 0 (PASS)
- [ ] CI: existing test suite unchanged — verify no regression in `scripts/__tests__` or `lib/utils/__tests__`

## Evidence trail

- PRD: `PRD-SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001`
- VALIDATION sub-agent: `sub_agent_execution_results.id = 4afb1fd3-c859-4327-8dac-9017df677b1a` (PASS w/ 5 conditions, conf 92)
- DESIGN sub-agent: `5ea422bb-d221-424b-8455-00b4f2552355` (PASS, conf 88 — UNLOCK_GATE placement validated)
- DATABASE sub-agent: `43a55a8a-2d4c-496b-b16e-d3b837cc347f` (PASS, conf 92 — 657-SD population, schema confirmed)
- Vision score: `eva_vision_scores.id = baf29d39-fb06-44e3-bf71-18bbbe027ecd` (85/100; bypassed for narrow-scope bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)