### PR TITLE
fix(ci): fetch-depth: 0 in test-coverage so branch-resolver tests can resolve 'main'

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On PR runs the merge ref is checked out and 'main' exists only as
+      # 'origin/main'. The branch-resolver tests use the literal 'main' ref
+      # via `git show main:...` / `git ls-tree main`, so create a local
+      # branch pointing at origin/main for them.
+      - name: Ensure local 'main' ref for branch-resolver tests
+        if: github.event_name == 'pull_request'
+        run: git update-ref refs/heads/main refs/remotes/origin/main
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -8,6 +8,8 @@ on:
       - 'lib/**'
       - 'server.js'
       - 'vitest.config.js'
+      # Re-run on workflow changes so edits to this file self-validate.
+      - '.github/workflows/test-coverage.yml'
   push:
     branches: [main, develop]
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -20,7 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth: 0 — branch-resolver tests reference the literal 'main' ref
+      # (e.g. readFileFromBranch(repoPath, 'main', ...)). Default depth=1 omits it
+      # on PR runs and the tests fail BASELINE_REGRESSION against the ratchet.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Two-commit YAML fix to `.github/workflows/test-coverage.yml`. Closes the BASELINE_REGRESSION false-positive that has forced admin-bypass on every PR since the SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 baseline ratchet landed.

## Root cause (corrected after iteration)
Two distinct missing pieces, both in the workflow's checkout setup:

1. **`fetch-depth: 0`** — `actions/checkout@v4` defaults to depth=1 and only fetches `refs/pull/<n>/merge` on PR runs. Main's history isn't local, so `git show main:package.json` fails.
2. **Local `main` ref** — even with full history fetched, on PR runs HEAD is the merge ref and the only pointer at main's tip is `origin/main` (a remote-tracking ref). The branch-resolver tests use the literal `main` ref via `git show main:...` / `git ls-tree main`, which still fails until a local `refs/heads/main` exists. `git update-ref refs/heads/main refs/remotes/origin/main` (PR-only, guarded by `if: github.event_name == 'pull_request'`) creates it without touching HEAD or the working tree.

The first commit (fetch-depth: 0) alone left the 3 `Branch Resolver - File Operations Domain Logic` tests still failing. The second commit (update-ref) closed the gap; coverage gate now greens.

## Bonus structural fix
Added `.github/workflows/test-coverage.yml` to its own `paths:` filter so workflow edits self-validate on the same PR. Without this, edits to the workflow alone don't trigger the workflow — chicken-and-egg when fixing the workflow itself.

## Test plan
- [x] Worktree branched directly off origin/main (HEAD `05d6a8a6d3`, 0 commits ahead before commit 1)
- [x] Test Coverage Enforcement gate goes green on this PR — `coverage` job: 10m48s, 0 new failures vs main baseline (Compare to main snapshot: success; Upload PR test-failures: skipped)
- [x] All 11 checks pass; mergeable state CLEAN
- [ ] Merge cleanly without admin-bypass
- [ ] Next PR after this lands also greens Test Coverage without bypass (regression test)

## Recent admin-bypassed PRs that needed this fix
- PR #3451 (SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-C-001)
- PR #3450 (FR-D)
- Earlier branches: `feat/SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001`, `feat/SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001`

## Source
feedback row `5f4a3998-28f6-4024-af8c-8cef74e52c5c` (category=harness_backlog, severity=high).

## Out of scope (file separately if desired)
DB Verify gate fails on every PR with "Forbidden direct eng_* usage detected" in `apps/ingest/vh_governance_ingest.ts:6, :30`. Not touched by this PR — DB Verify's paths filter excludes workflow YAML, so it doesn't even appear on this PR's check list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)