### PR TITLE
feat(sd-next): conditional worktree-isolation reminder when peer sessions are live

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -68,6 +68,7 @@ import {
   displayRecommendations,
   displayActiveSessions,
   displaySessionContext,
+  displayWorktreeIsolationReminder,
   displayParallelOpportunities,
   showFallbackQueue,
   showExhaustedBaselineMessage,
@@ -227,6 +228,7 @@ export class SDNextSelector {
       });
       this.displayFeedbackItems();
       this.displayHarnessBacklog();
+      displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
       if (qfSummaryNoBaseline.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
       }
@@ -246,6 +248,7 @@ export class SDNextSelector {
       });
       this.displayFeedbackItems();
       this.displayHarnessBacklog();
+      displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
       if (qfSummaryExhausted.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
       }
@@ -284,6 +287,8 @@ export class SDNextSelector {
 
     // Display brainstorm pipeline health advisory
     await this.displayBrainstormPipelineHealth();
+
+    displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
 
     console.log(`\n${colors.cyan}═══════════════════════════════════════════════════════════════════${colors.reset}\n`);
 

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -12,7 +12,9 @@ export {
 export {
   displayRecommendations,
   displayActiveSessions,
-  displaySessionContext
+  displaySessionContext,
+  displayWorktreeIsolationReminder,
+  countPeerSessions
 } from './recommendations.js';
 export { displayParallelOpportunities } from './parallel.js';
 export {

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -542,6 +542,37 @@ function formatHeartbeatAgeDisplay(seconds) {
 }
 
 /**
+ * Count peer Claude Code sessions live alongside the current one.
+ * Pure function, exported for unit tests. Uses session_id equality only —
+ * staleness is already filtered upstream by v_active_sessions
+ * (heartbeat_age_seconds <= 600).
+ *
+ * @param {Array} activeSessions - Rows from v_active_sessions
+ * @param {Object|null} currentSession - { session_id } or null
+ * @returns {number} - Count of peer sessions (0 if none or current unknown)
+ */
+export function countPeerSessions(activeSessions, currentSession) {
+  if (!Array.isArray(activeSessions) || activeSessions.length === 0) return 0;
+  if (!currentSession || !currentSession.session_id) return 0;
+  return activeSessions.filter(s => s && s.session_id !== currentSession.session_id).length;
+}
+
+/**
+ * Conditional advisory for parallel-session workflows: print one yellow line
+ * if peer Claude Code sessions are live, plus a dim follow-up pointing to the
+ * concurrency commands. No output if peer count is 0 or current session unknown.
+ *
+ * @param {Array} activeSessions - Rows from v_active_sessions
+ * @param {Object|null} currentSession - { session_id } or null
+ */
+export function displayWorktreeIsolationReminder(activeSessions, currentSession) {
+  const peerCount = countPeerSessions(activeSessions, currentSession);
+  if (peerCount === 0) return;
+  console.log(`\n${colors.yellow}⚠ ${peerCount} other Claude Code session(s) active.${colors.reset}`);
+  console.log(`${colors.dim}  Before Write/Edit work: run \`npm run session:check-concurrency\`, or \`npm run session:worktree\` to isolate.${colors.reset}`);
+}
+
+/**
  * Display session context (recent activity)
  *
  * @param {Array} recentActivity - Recent activity data

--- a/tests/unit/sd-next/worktree-isolation-reminder.test.js
+++ b/tests/unit/sd-next/worktree-isolation-reminder.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the worktree-isolation reminder rendered by sd:next.
+ * Covers countPeerSessions (pure) and displayWorktreeIsolationReminder (renderer)
+ * in scripts/modules/sd-next/display/recommendations.js.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  countPeerSessions,
+  displayWorktreeIsolationReminder,
+} from '../../../scripts/modules/sd-next/display/recommendations.js';
+
+const SESSION_CURRENT = '00000000-0000-0000-0000-000000000001';
+const SESSION_PEER_A  = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const SESSION_PEER_B  = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+describe('countPeerSessions', () => {
+  it('returns 0 for an empty active-sessions array', () => {
+    expect(countPeerSessions([], { session_id: SESSION_CURRENT })).toBe(0);
+  });
+
+  it('returns 0 when currentSession is null (cannot identify self)', () => {
+    expect(countPeerSessions([{ session_id: SESSION_PEER_A }], null)).toBe(0);
+  });
+
+  it('returns 0 when only the current session is present', () => {
+    expect(
+      countPeerSessions(
+        [{ session_id: SESSION_CURRENT }],
+        { session_id: SESSION_CURRENT }
+      )
+    ).toBe(0);
+  });
+
+  it('returns the count of peers when multiple peer sessions are active', () => {
+    expect(
+      countPeerSessions(
+        [
+          { session_id: SESSION_CURRENT },
+          { session_id: SESSION_PEER_A },
+          { session_id: SESSION_PEER_B },
+        ],
+        { session_id: SESSION_CURRENT }
+      )
+    ).toBe(2);
+  });
+
+  it('tolerates malformed entries (null/undefined) without crashing', () => {
+    expect(
+      countPeerSessions(
+        [null, undefined, { session_id: SESSION_PEER_A }],
+        { session_id: SESSION_CURRENT }
+      )
+    ).toBe(1);
+  });
+
+  it('returns 0 when activeSessions is not an array', () => {
+    expect(countPeerSessions(undefined, { session_id: SESSION_CURRENT })).toBe(0);
+    expect(countPeerSessions(null, { session_id: SESSION_CURRENT })).toBe(0);
+  });
+});
+
+describe('displayWorktreeIsolationReminder', () => {
+  let logSpy;
+
+  // Filter spy calls to those produced by our reminder, ignoring unrelated
+  // console.log noise (e.g. dotenv injection banners that fire during lazy
+  // module resolution inside vitest).
+  const reminderCalls = () =>
+    logSpy.mock.calls.filter(
+      call => typeof call[0] === 'string' && call[0].includes('Claude Code session')
+    );
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('prints nothing when there are no peer sessions', () => {
+    displayWorktreeIsolationReminder([], { session_id: SESSION_CURRENT });
+    expect(reminderCalls()).toHaveLength(0);
+  });
+
+  it('prints nothing when only the current session is active', () => {
+    displayWorktreeIsolationReminder(
+      [{ session_id: SESSION_CURRENT }],
+      { session_id: SESSION_CURRENT }
+    );
+    expect(reminderCalls()).toHaveLength(0);
+  });
+
+  it('prints nothing when currentSession is unknown', () => {
+    displayWorktreeIsolationReminder(
+      [{ session_id: SESSION_PEER_A }],
+      null
+    );
+    expect(reminderCalls()).toHaveLength(0);
+  });
+
+  it('prints two lines when one peer is active, including the peer count and both commands', () => {
+    displayWorktreeIsolationReminder(
+      [{ session_id: SESSION_CURRENT }, { session_id: SESSION_PEER_A }],
+      { session_id: SESSION_CURRENT }
+    );
+    const calls = reminderCalls();
+    expect(calls).toHaveLength(1);
+    const combined = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(combined).toMatch(/1 other Claude Code session/);
+    expect(combined).toContain('npm run session:check-concurrency');
+    expect(combined).toContain('npm run session:worktree');
+  });
+
+  it('reports the correct peer count when multiple peers are active', () => {
+    displayWorktreeIsolationReminder(
+      [
+        { session_id: SESSION_CURRENT },
+        { session_id: SESSION_PEER_A },
+        { session_id: SESSION_PEER_B },
+      ],
+      { session_id: SESSION_CURRENT }
+    );
+    const calls = reminderCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toMatch(/2 other Claude Code session\(s\)/);
+  });
+});


### PR DESCRIPTION
## Summary

- Print a one-line yellow advisory at the bottom of `npm run sd:next` output when other Claude Code sessions are detected, pointing to `npm run session:check-concurrency` and `npm run session:worktree`.
- Conditional rendering — silent when no peer sessions are active, so the line surfaces exactly at the decision point where it matters and doesn't accumulate as banner noise.
- Wired at all three branch exits in `SDNextSelector.run()` (no-baseline, exhausted, active-baseline) for uniform coverage regardless of state.
- Pure helper `countPeerSessions()` filters `this.activeSessions` (already loaded upstream from `v_active_sessions`, with 600s heartbeat staleness applied at the view layer) by `session_id !== currentSession.session_id` — **zero new DB cost**.

## Why

Parallel Claude Code sessions are routine in this workflow, and CLAUDE.md item 8 documents the failure mode: peer sessions sharing one working tree cause one session's `git checkout` to mutate files mid-PostToolUse-hook in another, surfacing as opaque "internal error" tool results. The mitigations exist (`session:check-concurrency`, `session:worktree`, the SessionStart auto-worktree hook), but the rule lives in CLAUDE.md — which isn't re-read each turn — so it's easy to miss. Surfacing the reminder at the natural decision point (`sd:next`, right before picking up work and editing) catches the case CLAUDE.md alone can't.

## Test plan

- [x] 11 vitest cases pass — `tests/unit/sd-next/worktree-isolation-reminder.test.js` covers no-peer, current-only, multi-peer, null-input, malformed-entry, and output-content assertions.
- [x] Full `tests/unit/sd-next/` suite still green (63/63 tests, no regressions).
- [x] `SDNextSelector.js` import resolution verified.
- [ ] Manual verification: run `sd:next` with a peer session live, confirm yellow advisory renders before the closing banner.
- [ ] Manual verification: run `sd:next` with no peers, confirm no advisory output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)