### PR TITLE
fix(ci): db-verify policy regex stops flagging eng_* in comments and view names

### DIFF
--- a/.github/workflows/db-verify.yml
+++ b/.github/workflows/db-verify.yml
@@ -10,6 +10,9 @@ on:
       - 'db/**'
       - 'ops/**'
       - 'database/migrations/**'
+      - 'apps/ingest/**'
+      # Re-run on workflow changes so edits to this file self-validate.
+      - '.github/workflows/db-verify.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -51,7 +54,13 @@ jobs:
             echo 'Forbidden pattern detected (GRANT ALL)';
             exit 1;
           fi
-          if grep -R "eng_" apps/ingest -n | grep -v "v_eng_"; then
+          # Match bare eng_* identifiers (eng_ followed by a letter), then
+          # exclude legitimate references:
+          #   - v_eng_*: view naming convention
+          #   - views.eng_*: schema-qualified view access (still through a view)
+          # The bare-identifier regex sidesteps doc-comment text like `eng_*`
+          # (no letter after underscore) which the prior literal-substring grep flagged.
+          if grep -REn '\beng_[a-zA-Z]' apps/ingest | grep -v 'v_eng_' | grep -v 'views\.eng_'; then
             echo 'Forbidden direct eng_* usage detected in app code';
             exit 1;
           fi


### PR DESCRIPTION
## Linkage
Sibling of `qf/QF-20260502-fetch-depth-main-ref` (PR #3453). Both close gates that have been forcing admin-bypass since the baseline ratchet from **SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001** went live — that SD made deterministic CI failures count toward the delta budget, surfacing two long-standing harness defects (test-coverage on PR #3453, db-verify on this PR).

## Summary
Tightens the Policy regression scan in `.github/workflows/db-verify.yml` so it stops flagging two false positives in `apps/ingest/vh_governance_ingest.ts`:

- **Line 6** — JSDoc comment describing the policy: `* This service reads governance data from engineering (eng_*) tables`
- **Line 30** — string literal naming a schema-qualified view: `'1. Reading governance data from views.eng_governance_summary'`

## Fix
Two changes to the grep:

1. Match bare `eng_*` identifiers via `\beng_[a-zA-Z]` instead of literal substring `eng_`. The word boundary + required letter excludes family-pattern references like `eng_*` (no letter after `_`).
2. Add `views\.eng_` to the negative filter — schema-qualified view access is by definition through a view, hence policy-compliant.

## Locally simulated
| Input | Old scanner | New scanner |
|---|---|---|
| `* ... (eng_*) tables` (JSDoc, line 6) | FLAGGED | clean |
| `'... views.eng_governance_summary'` (line 30) | FLAGGED | clean |
| `SELECT * FROM eng_strategic_directives` (real violation) | FLAGGED | FLAGGED |
| `SELECT * FROM v_eng_strategic` (compliant view) | clean | clean |

## Bonus
- `apps/ingest/**` added to the workflow's paths filter — the policy scan covers ingest code, so ingest changes should trigger DB Verify.
- `.github/workflows/db-verify.yml` added too, so workflow edits self-validate (same chicken-and-egg fix as PR #3453).

## Test plan
- [x] Worktree branched directly off origin/main (HEAD `fde28df4c2`, 0 commits ahead before commit)
- [x] Local simulation shows both false positives cleared and genuine violation still caught
- [x] DB Verify gate green on this PR — `verify` job: 6s, policy regression scan exit 0
- [ ] Merge cleanly without admin-bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)