### PR TITLE
fix(agentic-review): accept descriptive QF identifiers in linkage regex

### DIFF
--- a/lib/agents/github-review-coordinator.js
+++ b/lib/agents/github-review-coordinator.js
@@ -142,13 +142,16 @@ class GitHubReviewCoordinator {
       const hasPRD = /PRD-[\w-]+/.test(combined);
       const hasBacklog = /BL-\d+/.test(combined);
       // QF-20260409-236: Quick-fix PRs (Tier 1/2) intentionally have no PRD.
-      // Accept QF-YYYYMMDD-NNN identifiers in title or body as valid linkage.
-      const hasQF = /QF-\d{8}-\d{3}/.test(combined);
+      // Accept QF-YYYYMMDD-<suffix> where suffix is either numeric (NNN) or
+      // descriptive (e.g. QF-20260502-relax-linkage-regex,
+      // QF-20260429-LEO-DRIFT-DEDUPE). Both conventions exist in branch names.
+      const QF_PATTERN = /QF-\d{8}-[\w-]{3,}/;
+      const hasQF = QF_PATTERN.test(combined);
 
       // Extract actual IDs for verification
       const sdMatch = combined.match(/SD-[A-Z]+-[\w-]+-\d+[A-Z]?/i);
       const prdMatch = combined.match(/PRD-[\w-]+/);
-      const qfMatch = combined.match(/QF-\d{8}-\d{3}/);
+      const qfMatch = combined.match(QF_PATTERN);
 
       // Check for internal/infrastructure SDs that don't require PRD
       const isInternalSD = sdMatch && /SELF-IMPROVE|INFRA|REFAC|WIN-MIG/i.test(sdMatch[0]);

--- a/tests/unit/agents/github-review-coordinator-qf-regex.test.js
+++ b/tests/unit/agents/github-review-coordinator-qf-regex.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirror of QF_PATTERN at lib/agents/github-review-coordinator.js:checkLinkage().
+// If you change this regex you must change it there too — and vice versa.
+// Kept in-test (rather than imported) because the coordinator file pulls in
+// Octokit at module load, which test environments shouldn't need.
+const QF_PATTERN = /QF-\d{8}-[\w-]{3,}/;
+
+describe('Agentic Review — QF linkage regex', () => {
+  it('accepts numeric QF identifiers (legacy 3-digit suffix)', () => {
+    expect(QF_PATTERN.test('QF-20260409-236')).toBe(true);
+    expect(QF_PATTERN.test('Resolves QF-20260426-770 in body')).toBe(true);
+  });
+
+  it('accepts descriptive lowercase QF identifiers (kebab-case suffix)', () => {
+    expect(QF_PATTERN.test('QF-20260502-relax-linkage-regex')).toBe(true);
+    expect(QF_PATTERN.test('QF-20260502-fetch-depth-main-ref')).toBe(true);
+  });
+
+  it('accepts descriptive uppercase QF identifiers', () => {
+    expect(QF_PATTERN.test('QF-20260429-LEO-DRIFT-DEDUPE')).toBe(true);
+    expect(QF_PATTERN.test('QF-20260428-PLAYWRIGHT-BACKEND')).toBe(true);
+  });
+
+  it('rejects malformed QF strings (too few date digits, missing suffix, short suffix)', () => {
+    expect(QF_PATTERN.test('QF-2026-001')).toBe(false);
+    expect(QF_PATTERN.test('QF-20260502-')).toBe(false);
+    expect(QF_PATTERN.test('QF-20260502-ab')).toBe(false);
+    expect(QF_PATTERN.test('QF-not-a-date-suffix')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Linkage
Resolves feedback row \`16733daa-1e33-4927-93d8-5ea37a7c9bc1\` (filed 2026-04-29 via **SD-LEO-INFRA-CODE-CONTENT-PARITY-001**). Witnessed first-hand on PR #3459 (~30 min ago in the same harness-cleanup batch as PR #3453 and PR #3459).

## Summary
Agentic Review's \`checkLinkage()\` regex \`/QF-\d{8}-\d{3}/\` only accepts QF identifiers with a 3-digit numeric suffix. Half the recent QF branches in this repo use a descriptive suffix instead — those PRs all fail linkage despite being legitimately named QFs. Fix: relax to \`/QF-\d{8}-[\w-]{3,}/\` which accepts both formats.

## What changed
**lib/agents/github-review-coordinator.js**: extract the regex to a \`QF_PATTERN\` const used at both the \`.test()\` and \`.match()\` call sites (so they can't drift). Comment updated. ~7 LOC.

**tests/unit/agents/github-review-coordinator-qf-regex.test.js** (new): 4 vitest cases × 10 regex assertions covering:
| Format | Example | Accepted |
|---|---|---|
| Numeric (legacy) | \`QF-20260409-236\` | ✅ |
| Lowercase descriptive | \`QF-20260502-relax-linkage-regex\` | ✅ |
| Uppercase descriptive | \`QF-20260429-LEO-DRIFT-DEDUPE\` | ✅ |
| Malformed (short suffix, missing date) | \`QF-20260502-ab\`, \`QF-2026-001\` | ❌ |

The regex is mirrored in the test file (with a \"keep in sync\" comment) rather than imported, because the coordinator imports Octokit at module load and we don't want that pulled into the test process.

## Dogfood / smoke test
This PR's own branch name is **\`qf/QF-20260502-relax-linkage-regex\`** — descriptive lowercase. Old regex would reject it; new regex accepts it. **If Agentic Review's linkage check passes on this PR, the fix works.** That's the regression test.

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`b7a7d52604\`, 0 commits ahead before commit)
- [x] Local regex simulation: 10/10 assertions pass
- [ ] Agentic Review's \`SD/PRD/Backlog Linkage\` check passes on this PR (smoke test)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Removes the \"hand-edit-the-PR-body-to-add-an-SD-ref\" friction every descriptive-name QF was hitting. Third Tier-1 fix in the same harness-cleanup batch (PR #3453: test-coverage; PR #3459: db-verify; this PR: agentic-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)