### PR TITLE
fix(orchestrator): apply pre-claim cadence gate inside child-sd-selector

### DIFF
--- a/scripts/modules/handoff/child-sd-selector.js
+++ b/scripts/modules/handoff/child-sd-selector.js
@@ -13,6 +13,7 @@
 import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
 import { sortByUrgency, scoreToBand } from '../auto-proceed/urgency-scorer.js';
 import { buildDependencyDAG, detectCycles, computeRunnableSet } from '../../../lib/orchestrator/dependency-dag.js';
+import { computeGateState } from '../../../lib/cadence/pre-claim-gate.mjs';
 
 /**
  * Check if an SD is a child (has a parent)
@@ -44,7 +45,7 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
     // FIX: 2026-02-05 - Added sd_type for SD-type-aware workflow continuation
     let query = supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, status, priority, current_phase, sequence_rank, created_at, metadata, dependencies, updated_at, progress_percentage, sd_type, claiming_session_id')
+      .select('id, sd_key, title, status, priority, current_phase, sequence_rank, created_at, metadata, governance_metadata, dependencies, updated_at, progress_percentage, sd_type, claiming_session_id')
       .eq('parent_sd_id', parentSdId)
       .in('status', ['draft', 'active']);
 
@@ -72,9 +73,26 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
       return true;
     }) : [];
 
+    // Skip children with active pre-claim cadence gate. Mirrors the refusal
+    // logic in scripts/sd-start.js so orchestrator-routed claims can't slip
+    // past the same window that direct sd-start would refuse.
+    // (Closes feedback row f52246de — orchestrator preflight router bypassed
+    // the cadence gate from PR #3353 / SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001.)
+    const cadenceCleared = unblocked.filter(child => {
+      const state = computeGateState({
+        governance_metadata: child.governance_metadata,
+        metadata: child.metadata,
+      });
+      if (state.active) {
+        console.log(`   [child-sd-selector] Skipping ${child.sd_key || child.id} - cadence gate active (${state.days_remaining}d until ${state.gate_until})`);
+        return false;
+      }
+      return true;
+    });
+
     // SD-LEO-ENH-AUTO-PROCEED-001-11: Sort by urgency (band > score > enqueue_time)
     // Map candidates to include urgency data for sorting
-    const withUrgency = unblocked.map(child => ({
+    const withUrgency = cadenceCleared.map(child => ({
       ...child,
       urgency_score: child.metadata?.urgency_score ?? 0.5,
       urgency_band: child.metadata?.urgency_band ?? scoreToBand(child.metadata?.urgency_score ?? 0.5),
@@ -194,7 +212,7 @@ export async function getReadyChildren(supabase, parentSdId, options = {}) {
     // Fetch ALL children (not just active/draft) for DAG construction
     const { data: allChildren, error: allError } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, status, priority, current_phase, sequence_rank, created_at, metadata, dependencies, updated_at, progress_percentage, sd_type')
+      .select('id, sd_key, title, status, priority, current_phase, sequence_rank, created_at, metadata, governance_metadata, dependencies, updated_at, progress_percentage, sd_type')
       .eq('parent_sd_id', parentSdId);
 
     if (allError) {
@@ -245,8 +263,22 @@ export async function getReadyChildren(supabase, parentSdId, options = {}) {
       .map(id => allChildren.find(c => c.id === id))
       .filter(c => c && workableStatuses.includes(c.status));
 
+    // Skip children with active pre-claim cadence gate (same rule as
+    // getNextReadyChild — orchestrator-parallel mode must not bypass it).
+    const cadenceCleared = readyCandidates.filter(child => {
+      const state = computeGateState({
+        governance_metadata: child.governance_metadata,
+        metadata: child.metadata,
+      });
+      if (state.active) {
+        console.log(`   [child-sd-selector] Skipping ${child.sd_key || child.id} - cadence gate active (${state.days_remaining}d until ${state.gate_until})`);
+        return false;
+      }
+      return true;
+    });
+
     // Apply urgency sorting (same as getNextReadyChild)
-    const withUrgency = readyCandidates.map(child => ({
+    const withUrgency = cadenceCleared.map(child => ({
       ...child,
       urgency_score: child.metadata?.urgency_score ?? 0.5,
       urgency_band: child.metadata?.urgency_band ?? scoreToBand(child.metadata?.urgency_score ?? 0.5),

--- a/tests/unit/handoff/child-sd-selector.test.js
+++ b/tests/unit/handoff/child-sd-selector.test.js
@@ -170,6 +170,85 @@ describe('Child SD Selector', () => {
       expect(result.reason).toContain('blocked');
     });
 
+    it('skips children with active cadence gate and returns the next unguarded one', async () => {
+      // f52246de — orchestrator preflight router was bypassing the cadence gate
+      // applied at sd-start. The gate must apply identically here.
+      const futureIso = new Date(Date.now() + 5 * 86400000).toISOString();
+      const gatedChild = {
+        id: 'child-gated',
+        sd_key: 'SD-GATED',
+        title: 'Gated Child',
+        status: 'draft',
+        priority: 50,
+        sequence_rank: 1,
+        governance_metadata: { next_workable_after: futureIso },
+      };
+      const openChild = {
+        id: 'child-open',
+        sd_key: 'SD-OPEN',
+        title: 'Open Child',
+        status: 'draft',
+        priority: 50,
+        sequence_rank: 2,
+      };
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              in: () => Promise.resolve({ data: [gatedChild, openChild], error: null })
+            })
+          })
+        })
+      };
+
+      const result = await getNextReadyChild(mockSupabase, 'parent-1');
+
+      expect(result.sd).toBeTruthy();
+      expect(result.sd.id).toBe('child-open');
+      expect(result.allComplete).toBe(false);
+    });
+
+    it('returns null when every candidate is gated by an active cadence window', async () => {
+      const futureIso = new Date(Date.now() + 3 * 86400000).toISOString();
+      const gatedChildren = [
+        {
+          id: 'c1', sd_key: 'SD-C1', status: 'draft',
+          governance_metadata: { next_workable_after: futureIso },
+        },
+        {
+          id: 'c2', sd_key: 'SD-C2', status: 'draft',
+          governance_metadata: { next_workable_after: futureIso },
+        },
+      ];
+      let queryCount = 0;
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => {
+              queryCount++;
+              if (queryCount === 1) {
+                return { in: () => Promise.resolve({ data: gatedChildren, error: null }) };
+              }
+              return Promise.resolve({
+                data: [
+                  { id: 'c1', status: 'draft' },
+                  { id: 'c2', status: 'draft' }
+                ],
+                error: null
+              });
+            }
+          })
+        })
+      };
+
+      const result = await getNextReadyChild(mockSupabase, 'parent-1');
+
+      expect(result.sd).toBe(null);
+      expect(result.allComplete).toBe(false);
+      // 2 candidates were gated, 0 completed → no ready children, none blocked
+      expect(result.reason).toContain('No ready children');
+    });
+
     it('should handle query errors gracefully', async () => {
       // Production code: the first query uses .eq().in() and awaits directly
       const mockSupabase = {


### PR DESCRIPTION
## Linkage
Resolves feedback row \`f52246de\` (filed 2026-05-01). Closes the orchestrator-preflight loophole left open by **SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001** (PR #3353).

## Summary
PR #3353 added a pre-claim cadence gate that refuses direct \`/leo start <SD>\` when the SD is in a stability window. But the orchestrator's child selector (\`scripts/modules/handoff/child-sd-selector.js\`) didn't apply that same gate when routing to the next child — so an orchestrator could pick a child whose direct sd-start would have been refused.

**Witnessed 2026-05-01**: \`/leo start SD-EVA-SUPPORT-CLI-SKILL-ORCH-001\` routed via \`getNextReadyChild()\` to child B (\`governance_metadata.next_workable_after=2026-05-11\`, [CADENCE-WAIT 10 days] badge visible in sd:next), instead of child C which had no gate. Direct sd-start of child B WAS refused as expected; only the orchestrator path bypassed the gate.

## Fix
Import \`computeGateState\` from \`lib/cadence/pre-claim-gate.mjs\` and apply it inside both child-selector entry points:

- **\`getNextReadyChild()\`** — sequential path used by AUTO-PROCEED.
- **\`getReadyChildren()\`** — parallel-coordinator path (ORCH_PARALLEL_CHILDREN_ENABLED=true).

Both queries now also select \`governance_metadata\` so the gate has the data it needs. Filter runs **after** the blocked_by filter and **before** urgency sort, mirroring the cleared→sort→select pipeline already established for blockers.

## Tests
2 new vitest cases against the existing \`tests/unit/handoff/child-sd-selector.test.js\`:
- Skip a gated child, return the next unguarded sibling.
- All children gated → return null with reason \"No ready children\".

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`67d8a9304f\`, 0 commits ahead before commit)
- [x] Existing test conventions followed (chained mock supabase, vi.mock for siblings)
- [ ] CI passes: \`Run Tests & Verify Stories\` + \`coverage\` baseline-ratchet still green
- [ ] Merge cleanly without admin-bypass

## Why this matters
Closes the most-cited cadence-bypass since PR #3353 shipped. Fourth Tier-1 fix in the same harness-cleanup batch (PR #3453: test-coverage; PR #3459: db-verify; PR #3460: agentic-review linkage; this PR: orchestrator cadence parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)