### PR TITLE
fix(db): enforce_parent_orchestrator_type skips terminal-status parents

### DIFF
--- a/database/migrations/20260502_enforce_orchestrator_skip_terminal_parents.sql
+++ b/database/migrations/20260502_enforce_orchestrator_skip_terminal_parents.sql
@@ -1,0 +1,59 @@
+-- 20260502_enforce_orchestrator_skip_terminal_parents.sql
+--
+-- Closes feedback row 4e2b5fa2 (filed 2026-05-02 by session ed6fcc61):
+-- trg_enforce_parent_orchestrator_type fires AFTER INSERT on any child SD with
+-- a non-NULL parent_sd_id. The trigger UPDATEs the parent
+-- SET sd_type='orchestrator', which fires four BEFORE-UPDATE triggers on the
+-- parent including enforce_type_change_timing — that one BLOCKS once
+-- has_handoffs AND current_phase NOT IN (LEAD, DRAFT). Net effect: cannot
+-- file ANY follow-up SD (CAPA, regression-recovery child, post-mortem-driven
+-- enhancement) with parent_sd_id FK against a parent that has already
+-- completed.
+--
+-- Witnessed parent SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-001 (status=completed,
+-- current_phase=COMPLETED, sd_type=infrastructure — never auto-promoted to
+-- orchestrator while it was still in active phases) — filing FR-D-prime
+-- against it raised SD_TYPE_CHANGE_TIMING_BLOCKED.
+--
+-- Forward-only fix: extend the existing idempotency guard so the auto-promotion
+-- also skips when the parent is already in a terminal status. There is no
+-- value in promoting a finished parent to 'orchestrator' for a new follow-up
+-- SD — its classification is historical, and enforce_type_change_timing is
+-- correctly preventing post-completion sd_type drift.
+--
+-- All other behavior (the IF NEW.parent_sd_id IS NOT NULL guard, the existing
+-- sd_type != 'orchestrator' guard, the SET / RETURN shape) is preserved
+-- verbatim from the live function definition.
+
+CREATE OR REPLACE FUNCTION public.enforce_parent_orchestrator_type()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF NEW.parent_sd_id IS NOT NULL THEN
+    UPDATE strategic_directives_v2
+    SET
+      sd_type = 'orchestrator',
+      updated_at = NOW()
+    WHERE id = NEW.parent_sd_id
+      AND sd_type != 'orchestrator'
+      -- 4e2b5fa2: skip auto-promotion when the parent has already terminated.
+      -- Avoids the enforce_type_change_timing block on completed parents and
+      -- unblocks follow-up SD filing (CAPAs, regression children, etc.).
+      AND status NOT IN ('completed', 'archived', 'cancelled');
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.enforce_parent_orchestrator_type() IS
+'LEO Protocol Governance: Automatically sets sd_type=orchestrator for any SD
+that becomes a parent (when another SD references it via parent_sd_id),
+EXCEPT when the parent is already in a terminal status (completed/archived/
+cancelled). Terminal-status parents have their sd_type frozen by
+enforce_type_change_timing, and there is no operational reason to promote a
+finished parent for a new follow-up child.
+
+Updated 2026-05-02 (feedback row 4e2b5fa2) to skip terminal parents.
+Original purpose preserved for active parents — see
+20251227_enforce_orchestrator_type_for_parent_sds.sql.';


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-enforce-orchestrator-skip-terminal** | Resolves feedback row \`4e2b5fa2\`. Sibling of PR #3463 (claim-state nulling) in the harness-cleanup batch.

## Summary
\`trg_enforce_parent_orchestrator_type\` fires AFTER INSERT on any child SD with a non-NULL \`parent_sd_id\`. The trigger UPDATEs the parent \`SET sd_type='orchestrator'\`, which fires the BEFORE-UPDATE chain — \`enforce_type_change_timing\` then **BLOCKS** once handoffs exist AND \`current_phase NOT IN (LEAD, DRAFT)\`.

**Net effect**: cannot file any follow-up SD (CAPA, regression-recovery child, post-mortem-driven enhancement) against a parent that has already completed.

**Witnessed 2026-05-02**: filing FR-D-prime against parent \`SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-001\` (status=completed, current_phase=COMPLETED, sd_type=infrastructure — never auto-promoted to orchestrator while active) raised \`SD_TYPE_CHANGE_TIMING_BLOCKED\`.

## Fix
Forward-only migration that extends the existing idempotency guard (\`AND sd_type != 'orchestrator'\`) so the auto-promotion **also** skips when the parent is in a terminal status:

\`\`\`sql
WHERE id = NEW.parent_sd_id
  AND sd_type != 'orchestrator'
  AND status NOT IN ('completed', 'archived', 'cancelled');  -- new
\`\`\`

Promoting a finished parent has no operational value — its classification is historical, and \`enforce_type_change_timing\` is **correctly** preventing post-completion sd_type drift. The fix unblocks the legitimate follow-up case while preserving the gate for active parents.

## Behavior matrix
| Parent state | Old behavior | New behavior |
|---|---|---|
| sd_type='orchestrator' (already), any status | UPDATE matches 0 rows (no-op) | UPDATE matches 0 rows (unchanged) |
| sd_type non-orchestrator, status active/in_progress | UPDATE → parent promoted | UPDATE → parent promoted (unchanged) |
| sd_type non-orchestrator, status='completed' | UPDATE → enforce_type_change_timing **BLOCKS the child INSERT** | UPDATE matches 0 rows → child INSERT **succeeds** |

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`6717d38492\`, 0 commits ahead before commit)
- [x] Live function read via \`pg_get_functiondef\` to ensure migration matches deployed shape
- [x] enforce_type_change_timing logic verified — guard against type-drift after handoffs is preserved
- [ ] Migration applied to EHG_Engineer DB (project dedlbzhpgkmetvhbkyzq) — staging path
- [ ] Post-apply: confirm \`pg_get_functiondef('enforce_parent_orchestrator_type'::regproc)\` shows the new \`AND status NOT IN ...\` clause
- [ ] Smoke test: insert a child SD with parent_sd_id pointing to a completed non-orchestrator parent succeeds
- [ ] Merge cleanly without admin-bypass

## Why this matters
Seventh fix in the harness-cleanup batch — closes a real CAPA-filing block. Without this fix, every post-completion follow-up SD requires a manual workaround (e.g., bypass metadata or temporarily reverting parent.status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)