### PR TITLE
fix(worktree): patch .env essentials on early-return path in createWorktree

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -243,6 +243,14 @@ function createWorktree(sdKey, repoRoot) {
   if (fs.existsSync(worktreePath)) {
     if (isValidWorktree(worktreePath)) {
       const existingBranch = getWorktreeBranch(worktreePath);
+      // Patch up essentials (.env, node_modules) for pre-existing worktrees
+      // that DB and scan paths missed. Without this, handoff.js and other
+      // scripts run from the worktree fail with NEXT_PUBLIC_SUPABASE_URL
+      // is required. Closes feedback row c9d07065.
+      const essentials = ensureWorktreeEssentials(worktreePath, repoRoot);
+      if (!essentials.ok) {
+        emitLog({ event: 'worktree.essentials_partial', sdKey, source: 'pre-existing', errors: essentials.errors });
+      }
       return { path: worktreePath, branch: existingBranch || `feat/${sdKey}`, created: false };
     }
     const err = new Error(


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-worktree-essentials-early-return** | Resolves feedback row \`c9d07065\`. Sibling of PR #3463 (claim-state nulling) and PR #3461 (orchestrator cadence parity).

## Summary
\`resolve-sd-workdir.js::createWorktree()\` has three success paths and the early-return at line 246 (worktree directory exists and is a valid registered worktree) was the only one that didn't call \`ensureWorktreeEssentials\`. The DB and scan paths in \`resolve()\` already patch essentials (lines 486, 505), and the main create path does it after registration (line 344) — but a worktree that's valid-on-disk yet missing from the DB AND from the scan output reaches \`createWorktree\`'s early-return without ever getting .env or node_modules patched.

**Symptom**: handoff.js (or any downstream script) run from such a worktree fails with \`NEXT_PUBLIC_SUPABASE_URL is required\`.

## Fix
Add the \`ensureWorktreeEssentials()\` call before the early-return. The helper is **idempotent** — each step has \`!fs.existsSync(dst)\` guards — so the call is safe even when files were already propagated by a prior path. Errors are emitted as \`worktree.essentials_partial\` logs and the return shape is preserved.

## Coverage matrix
| Path | Before | After |
|---|---|---|
| DB hit (line 486) | calls ensureWorktreeEssentials | unchanged |
| Scan hit (line 505) | calls ensureWorktreeEssentials | unchanged |
| createWorktree → fresh worktree (line 344) | calls ensureWorktreeEssentials | unchanged |
| createWorktree → directory exists + valid (early return, line 246) | **skipped** | **calls it** |

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`5e00db9431\`, 0 commits ahead before commit)
- [x] Idempotency confirmed by reading ensureWorktreeEssentials body — every step has dst-exists guard
- [ ] Existing resolve-sd-workdir tests still pass (no signature changes; pure additive defensive code)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Eighth fix in the harness-cleanup batch. Closes a defensive gap in the worktree-resolution pipeline that surfaces as a confusing dotenv error in unrelated downstream scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)