### PR TITLE
fix(scope-gate): prefer git rev-parse over CLAUDE_PROJECT_DIR for PROJECT_ROOT

### DIFF
--- a/scripts/modules/handoff/gates/scope-completion-gate.js
+++ b/scripts/modules/handoff/gates/scope-completion-gate.js
@@ -14,8 +14,16 @@ import path from 'path';
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 
 import { execSync } from 'child_process';
-const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR ||
-  (() => { try { return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim(); } catch { return 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer'; } })();
+// PROJECT_ROOT prefers `git rev-parse --show-toplevel` (worktree-aware) over
+// the CLAUDE_PROJECT_DIR env var (always points at the MAIN repo, even when
+// running from a worktree). Without this priority, scope-completion-gate
+// looks for SD deliverables at main-repo paths and reports them missing
+// when the SD's branch added them inside the worktree.
+// Closes feedback row e58d53d6.
+const PROJECT_ROOT = (() => {
+  try { return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim(); }
+  catch { return process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer'; }
+})();
 
 /**
  * Extract deliverable items from architecture plan content.


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-scope-gate-worktree-root** | Resolves feedback row \`e58d53d6\`. Sibling fix to PR #3468 in the worktree-state harness-cleanup batch.

## Summary
\`scope-completion-gate.js\` verifies planned SD deliverables exist on disk before \`/leo complete\` signs off. The \`PROJECT_ROOT\` constant was set to \`process.env.CLAUDE_PROJECT_DIR\` when present, falling back to \`git rev-parse --show-toplevel\` only on env-var miss.

Problem: **\`CLAUDE_PROJECT_DIR\` always points at the MAIN repo**, even when commands run from inside a worktree. So the gate looked at main-repo paths and reported \"missing\" for files the SD's branch had created in the worktree.

## Fix
Invert the priority. \`git rev-parse --show-toplevel\` runs against \`process.cwd()\` and correctly returns the **worktree** root when the script runs there. The env var is only used as a fallback when git fails (e.g. CI contexts without a checkout); the hardcoded Windows path remains as last-resort safety net for those cases.

\`\`\`js
// Before
const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR ||
  (() => { try { return execSync(...).trim(); } catch { return 'C:\\...'; } })();

// After
const PROJECT_ROOT = (() => {
  try { return execSync('git rev-parse --show-toplevel', ...).trim(); }
  catch { return process.env.CLAUDE_PROJECT_DIR || 'C:\\...'; }
})();
\`\`\`

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`f4690444eb\`, 0 commits ahead before commit)
- [x] git rev-parse --show-toplevel returns worktree root when run inside one — confirmed via standard git behavior
- [ ] Existing handoff/gates tests still pass (purely additive logic re-ordering)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Ninth fix in the harness-cleanup batch. Removes a false-positive \"missing deliverable\" failure for any SD that was developed in a worktree (which is the standard pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)