### PR TITLE
fix(SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001): junction-safe rm/cp prevents Windows node_modules wipe

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -758,6 +758,138 @@ function logWorktreeEvent(event, fields = {}) {
 }
 
 /**
+ * Junction-safe recursive removal.
+ * SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001
+ *
+ * On Windows, fs.rmSync({recursive:true,force:true}) can follow Windows junctions
+ * (created via fs.symlinkSync(target, link, 'junction')) and delete the JUNCTION
+ * TARGET's contents. For our worktrees, that target is the main repo's
+ * node_modules — bricking every parallel session.
+ *
+ * Strategy:
+ *  - If the path itself is a symlink/junction, fs.unlinkSync it (don't recurse).
+ *  - If it's a directory, walk top-level entries and unlink any symlink/junction
+ *    children FIRST, then fs.rmSync the remainder recursively.
+ *
+ * On Unix, Node already does not follow symlinks during recursive rm; the lstat
+ * check is harmless. Cross-platform identical behavior for the symlink case.
+ *
+ * @param {string} targetPath - Path to remove
+ * @param {{force?: boolean}} [options] - force=true (default) ignores ENOENT
+ */
+export function safeRecursiveRm(targetPath, options = {}) {
+  const { force = true } = options;
+  if (!fs.existsSync(targetPath)) {
+    if (force) return;
+    throw new Error(`safeRecursiveRm: path does not exist: ${targetPath}`);
+  }
+  let stat;
+  try {
+    stat = fs.lstatSync(targetPath);
+  } catch (err) {
+    if (force) return;
+    throw err;
+  }
+  if (stat.isSymbolicLink()) {
+    _unlinkSymOrJunction(targetPath);
+    return;
+  }
+  if (stat.isDirectory()) {
+    const entries = fs.readdirSync(targetPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const childPath = path.join(targetPath, entry.name);
+      let childStat;
+      try {
+        childStat = fs.lstatSync(childPath);
+      } catch {
+        continue;
+      }
+      if (childStat.isSymbolicLink()) {
+        try {
+          _unlinkSymOrJunction(childPath);
+        } catch (err) {
+          if (!force) throw err;
+        }
+      }
+    }
+  }
+  fs.rmSync(targetPath, { recursive: true, force });
+}
+
+/**
+ * Junction-safe recursive copy. Symmetric to safeRecursiveRm.
+ * SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001
+ *
+ * fs.cpSync({recursive:true}) on Windows can follow junctions and copy the
+ * JUNCTION TARGET's multi-GB contents into the destination. For _archive of
+ * worktrees, that means duplicating the main repo's node_modules into
+ * .worktrees/_archive/<sd>-<ts> — wasted disk and slow archival.
+ *
+ * Strategy: walk entries; for each symlink/junction, try to recreate as a link
+ * at the destination (preserving the link itself, not the target). Fall through
+ * to fs.cpSync for regular directories/files.
+ *
+ * @param {string} srcPath
+ * @param {string} destPath
+ * @param {{recursive?: boolean, errorOnExist?: boolean}} [options]
+ */
+export function safeRecursiveCp(srcPath, destPath, options = {}) {
+  if (!fs.existsSync(srcPath)) {
+    throw new Error(`safeRecursiveCp: source does not exist: ${srcPath}`);
+  }
+  const stat = fs.lstatSync(srcPath);
+  if (stat.isSymbolicLink()) {
+    _recreateLinkAtDest(srcPath, destPath);
+    return;
+  }
+  if (!stat.isDirectory()) {
+    fs.cpSync(srcPath, destPath, { recursive: false, ...options });
+    return;
+  }
+  fs.mkdirSync(destPath, { recursive: true });
+  const entries = fs.readdirSync(srcPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcChild = path.join(srcPath, entry.name);
+    const destChild = path.join(destPath, entry.name);
+    let childStat;
+    try {
+      childStat = fs.lstatSync(srcChild);
+    } catch {
+      continue;
+    }
+    if (childStat.isSymbolicLink()) {
+      _recreateLinkAtDest(srcChild, destChild);
+      continue;
+    }
+    fs.cpSync(srcChild, destChild, { recursive: true, ...options });
+  }
+}
+
+function _unlinkSymOrJunction(p) {
+  try {
+    fs.unlinkSync(p);
+  } catch (err) {
+    // Windows: junctions to directories sometimes need rmdirSync to remove the
+    // reparse point itself (without following).
+    if (process.platform === 'win32' && (err.code === 'EPERM' || err.code === 'EISDIR')) {
+      fs.rmdirSync(p);
+      return;
+    }
+    throw err;
+  }
+}
+
+function _recreateLinkAtDest(srcLink, destPath) {
+  try {
+    const target = fs.readlinkSync(srcLink);
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+    fs.symlinkSync(target, destPath, linkType);
+  } catch {
+    // Best effort — caller wanted an archive, not a perfect mirror. Skip on failure.
+  }
+}
+
+/**
  * Symlink or junction node_modules into a worktree
  *
  * @param {string} worktreePath - Path to the worktree
@@ -787,7 +919,7 @@ export function symlinkNodeModules(worktreePath, repoRoot) {
     } catch {
       // If we can't read the link, remove and recreate
     }
-    fs.rmSync(targetModules, { recursive: true, force: true });
+    safeRecursiveRm(targetModules);
   }
 
   // On Windows, use junction (doesn't require elevation)
@@ -856,7 +988,7 @@ export function removeWorktree(sdKey) {
     });
   } catch {
     // If git worktree remove fails, clean up manually
-    fs.rmSync(worktreePath, { recursive: true, force: true });
+    safeRecursiveRm(worktreePath);
     try {
       execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
     } catch {
@@ -879,8 +1011,8 @@ function _archiveWorktreeDir(wtPath, sdKey, repoRoot) {
   try {
     fs.renameSync(wtPath, archivePath);
   } catch {
-    fs.cpSync(wtPath, archivePath, { recursive: true });
-    fs.rmSync(wtPath, { recursive: true, force: true });
+    safeRecursiveCp(wtPath, archivePath, { recursive: true });
+    safeRecursiveRm(wtPath);
   }
   try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch { /* best effort */ }
   console.warn(JSON.stringify({ event: 'worktree.archived', sdKey, archivePath, timestamp: new Date().toISOString() }));
@@ -1249,7 +1381,7 @@ export async function cleanupStaleWorktrees({ dryRun = false, maxAgeMs, supabase
       } catch {
         // If git worktree remove fails, clean up manually
         if (fs.existsSync(item.path)) {
-          fs.rmSync(item.path, { recursive: true, force: true });
+          safeRecursiveRm(item.path);
         }
       }
       result.cleaned.push(`${item.key} (${item.reason})`);

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -1,10 +1,12 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { safeRecursiveRm, safeRecursiveCp } from '../../../lib/worktree-manager.js';
 
 // Quick-fix QF-20260211-111: Post-merge worktree cleanup for /ship
 // FR-5: Added --sdKey support for external callers (SD-LEO-INFRA-UNIFIED-WORKTREE-LIFECYCLE-001)
 // SD-MAN-INFRA-WORKTREE-CODE-LOSS-001: Pre-cleanup commit check + archive-on-conflict
+// SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001: junction-safe rm/cp prevents node_modules wipe on Windows
 const gitExec = (cmd, opts = {}) =>
   execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], ...opts }).trim();
 
@@ -85,9 +87,9 @@ function archiveWorktree(wtPath, sdKey) {
   try {
     fs.renameSync(wtPath, archivePath);
   } catch {
-    // Cross-device move on Windows — copy then delete
-    fs.cpSync(wtPath, archivePath, { recursive: true });
-    fs.rmSync(wtPath, { recursive: true, force: true });
+    // Cross-device move on Windows — copy then delete (junction-safe to avoid wiping shared node_modules)
+    safeRecursiveCp(wtPath, archivePath, { recursive: true });
+    safeRecursiveRm(wtPath);
   }
 
   // Prune git worktree references for the moved path
@@ -160,7 +162,7 @@ function cleanupWorktreeByPath(wtPath) {
     execSync(`git worktree remove --force "${wtPath}"`, { cwd: mainRepoPath, encoding: 'utf8', stdio: 'pipe' });
   } catch {
     if (fs.existsSync(wtPath)) {
-      fs.rmSync(wtPath, { recursive: true, force: true });
+      safeRecursiveRm(wtPath);
       execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
     }
   }

--- a/tests/unit/worktree-manager.test.js
+++ b/tests/unit/worktree-manager.test.js
@@ -23,6 +23,8 @@ const {
   listWorktrees,
   resolveExpectedBranch,
   validateSdKey,
+  safeRecursiveRm,
+  safeRecursiveCp,
   _resetDeprecationWarning
 } = await import('../../lib/worktree-manager.js');
 
@@ -354,6 +356,131 @@ describe('Worktree Manager', () => {
       execSync.mockReturnValue('/nonexistent/path\n');
       const result = listWorktrees();
       expect(result).toEqual([]);
+    });
+  });
+
+  // SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001
+  describe('safeRecursiveRm', () => {
+    it('returns silently when path does not exist (force=true default)', () => {
+      const missing = path.join(os.tmpdir(), `srm-${Date.now()}-missing`);
+      expect(() => safeRecursiveRm(missing)).not.toThrow();
+    });
+
+    it('removes a regular directory tree like fs.rmSync', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-'));
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'a');
+      fs.mkdirSync(path.join(dir, 'sub'));
+      fs.writeFileSync(path.join(dir, 'sub', 'b.txt'), 'b');
+      safeRecursiveRm(dir);
+      expect(fs.existsSync(dir)).toBe(false);
+    });
+
+    it('unlinks a top-level junction child WITHOUT touching the junction target', () => {
+      const target = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-target-'));
+      const sentinel = path.join(target, 'sentinel.txt');
+      fs.writeFileSync(sentinel, 'PRESERVE_ME');
+
+      const wt = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-wt-'));
+      fs.writeFileSync(path.join(wt, 'src.txt'), 'worktree-content');
+      const linkPath = path.join(wt, 'node_modules');
+      try {
+        fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+      } catch (err) {
+        // Windows without admin / developer-mode can't create symlinks; skip
+        fs.rmSync(target, { recursive: true, force: true });
+        fs.rmSync(wt, { recursive: true, force: true });
+        return;
+      }
+
+      safeRecursiveRm(wt);
+
+      expect(fs.existsSync(wt)).toBe(false);
+      expect(fs.existsSync(target)).toBe(true);
+      expect(fs.existsSync(sentinel)).toBe(true);
+      expect(fs.readFileSync(sentinel, 'utf8')).toBe('PRESERVE_ME');
+      fs.rmSync(target, { recursive: true, force: true });
+    });
+
+    it('unlinks the path itself when it is a symlink/junction (no recursion)', () => {
+      const target = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-target2-'));
+      fs.writeFileSync(path.join(target, 'keep.txt'), 'KEEP');
+      const link = path.join(os.tmpdir(), `srm-link-${Date.now()}`);
+      try {
+        fs.symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir');
+      } catch {
+        fs.rmSync(target, { recursive: true, force: true });
+        return;
+      }
+
+      safeRecursiveRm(link);
+
+      expect(fs.existsSync(link)).toBe(false);
+      expect(fs.existsSync(target)).toBe(true);
+      expect(fs.existsSync(path.join(target, 'keep.txt'))).toBe(true);
+      fs.rmSync(target, { recursive: true, force: true });
+    });
+  });
+
+  describe('safeRecursiveCp', () => {
+    it('throws when source does not exist', () => {
+      const missing = path.join(os.tmpdir(), `scp-${Date.now()}-missing`);
+      const dest = path.join(os.tmpdir(), `scp-dest-${Date.now()}`);
+      expect(() => safeRecursiveCp(missing, dest)).toThrow(/source does not exist/);
+    });
+
+    it('copies a regular directory tree faithfully', () => {
+      const src = fs.mkdtempSync(path.join(os.tmpdir(), 'scp-src-'));
+      fs.writeFileSync(path.join(src, 'a.txt'), 'A');
+      fs.mkdirSync(path.join(src, 'sub'));
+      fs.writeFileSync(path.join(src, 'sub', 'b.txt'), 'B');
+
+      const dest = path.join(os.tmpdir(), `scp-dest-${Date.now()}`);
+      safeRecursiveCp(src, dest, { recursive: true });
+
+      expect(fs.readFileSync(path.join(dest, 'a.txt'), 'utf8')).toBe('A');
+      expect(fs.readFileSync(path.join(dest, 'sub', 'b.txt'), 'utf8')).toBe('B');
+      fs.rmSync(src, { recursive: true, force: true });
+      fs.rmSync(dest, { recursive: true, force: true });
+    });
+
+    it('does NOT copy junction TARGET contents into destination', () => {
+      const target = fs.mkdtempSync(path.join(os.tmpdir(), 'scp-target-'));
+      // Sentinel that proves target was NOT copied into dest
+      fs.writeFileSync(path.join(target, 'BIG_SENTINEL.txt'), 'x'.repeat(1024));
+
+      const src = fs.mkdtempSync(path.join(os.tmpdir(), 'scp-src-'));
+      fs.writeFileSync(path.join(src, 'real.txt'), 'real-content');
+      try {
+        fs.symlinkSync(target, path.join(src, 'node_modules'),
+          process.platform === 'win32' ? 'junction' : 'dir');
+      } catch {
+        fs.rmSync(target, { recursive: true, force: true });
+        fs.rmSync(src, { recursive: true, force: true });
+        return;
+      }
+
+      const dest = path.join(os.tmpdir(), `scp-dest-${Date.now()}`);
+      safeRecursiveCp(src, dest, { recursive: true });
+
+      expect(fs.readFileSync(path.join(dest, 'real.txt'), 'utf8')).toBe('real-content');
+      // Critical assertion: target file MUST NOT have been copied through the junction
+      const destNodeModules = path.join(dest, 'node_modules');
+      const bigSentinelInDest = path.join(destNodeModules, 'BIG_SENTINEL.txt');
+      // Either the link was recreated (so reading the sentinel via the link is OK,
+      // but the file at destNodeModules itself is a SYMLINK, not a regular file
+      // containing the copied content) OR the link was skipped entirely.
+      if (fs.existsSync(destNodeModules)) {
+        const destStat = fs.lstatSync(destNodeModules);
+        expect(destStat.isSymbolicLink()).toBe(true);
+      }
+      // Even if we read through the link, the SOURCE target's sentinel still exists
+      // because we never wrote a copy. Assert source target unchanged.
+      expect(fs.existsSync(path.join(target, 'BIG_SENTINEL.txt'))).toBe(true);
+
+      fs.rmSync(target, { recursive: true, force: true });
+      fs.rmSync(src, { recursive: true, force: true });
+      // Use safeRecursiveRm for dest in case junction was recreated
+      safeRecursiveRm(dest);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `safeRecursiveRm` and `safeRecursiveCp` helpers to `lib/worktree-manager.js` that walk top-level entries via `fs.lstatSync` and unlink junction/symlink children before recursing — preventing Windows `fs.rmSync({recursive:true,force:true})` from following node_modules junctions and deleting the JUNCTION TARGET (the main repo's node_modules).
- Wires both helpers into `lib/shipping/post-merge-worktree-cleanup.js`. Drop-in replacements; preserves `SD-MAN-INFRA-WORKTREE-CODE-LOSS-001` archival semantics (`removeWorktree` still blocks on unpushed commits and routes through `_archiveWorktreeDir`).
- Adds 7 vitest cases (4 for `safeRecursiveRm`, 3 for `safeRecursiveCp`). All 7 pass on Windows; Linux/macOS-only paths self-skip when symlink creation fails (no admin/developer-mode).

## Background — bug witnessed twice 2026-05-01
`session:worktree --cleanup --force` followed the node_modules junction (created via `fs.symlinkSync(..., 'junction')`) and deleted the JUNCTION TARGET, bricking all parallel sessions and forcing fleet-lock npm install recovery. Root cause: `fs.rmSync` and `fs.cpSync` on Windows can recurse into junction reparse points instead of treating them as opaque links.

## Salvage provenance
- Original commit `6e7e4eba15` was authored on `feat/SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001` on 2026-05-01 23:09 EDT but never pushed; branch base (`f348b04623`) was 52 commits behind current main and the worktree was orphaned.
- This PR is a fresh cherry-pick of `6e7e4eba15` onto current `origin/main` — auto-merge handled `lib/worktree-manager.js` cleanly. New commit SHA: `d46bcccd0e`. Stats identical to original (270 insertions / 9 deletions / 3 files).
- Original branch `feat/SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001` (and its worktree at `.worktrees/SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001`) preserved on disk for audit; can be removed after this merges.

## Test plan
- [x] `npx vitest run tests/unit/worktree-manager.test.js -t safeRecursive` → 7 pass
- [x] Full file: 29 pass, 4 fail. The 4 failures are pre-existing `createWorktree` mock setup issues on `origin/main` (`verifyWorktreeRegisteredSync` mock), explicitly noted in the original commit message as "inherited from origin/main" — not introduced by this PR
- [ ] CI on Windows runner if available
- [ ] One real `session:worktree --cleanup --force` cycle on Windows post-merge as smoke test

## Sizing
142 LOC helpers + 127 LOC tests + 10 LOC wiring = 270 LOC across 3 files. Above 100 LOC small-PR target, well within 400 LOC max. Tier 3 (>75 LOC) per CLAUDE.md routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)