### PR TITLE
fix(gate6): prefer existing no-slug canonical branch over creating slugged duplicate

### DIFF
--- a/scripts/verify-git-branch-status.js
+++ b/scripts/verify-git-branch-status.js
@@ -538,6 +538,38 @@ class GitBranchVerifier {
   }
 
   /**
+   * Pre-check: if a no-slug canonical branch <branchType>/<sdId> already
+   * exists locally or on remote, override expectedBranchName to use it.
+   * Closes naming-convention drift between sd-start.js (creates no-slug
+   * canonical) and generateBranchName() (slug-suffixed).
+   * Closes feedback row f651e8eb.
+   */
+  async preferExistingCanonicalBranch() {
+    // Don't override if expectedBranchName already has no slug.
+    const branchType = this.expectedBranchName.split('/')[0] || 'feat';
+    const noSlugCanonical = `${branchType}/${this.sdId}`;
+    if (this.expectedBranchName === noSlugCanonical) return;
+
+    // Local check
+    const localResult = await this.gitCommand('git branch --list');
+    const localBranches = localResult.stdout.split('\n').map(b => b.trim().replace(/^\* /, ''));
+    if (localBranches.includes(noSlugCanonical)) {
+      console.log(`   ↪ Found existing canonical branch ${noSlugCanonical} — using it instead of generated ${this.expectedBranchName}`);
+      this.expectedBranchName = noSlugCanonical;
+      this.results.expectedBranch = noSlugCanonical;
+      return;
+    }
+
+    // Remote check
+    const remoteResult = await this.gitCommand(`git ls-remote --heads origin ${noSlugCanonical}`);
+    if (remoteResult.success && remoteResult.stdout.length > 0) {
+      console.log(`   ↪ Found canonical branch ${noSlugCanonical} on remote — using it instead of generated ${this.expectedBranchName}`);
+      this.expectedBranchName = noSlugCanonical;
+      this.results.expectedBranch = noSlugCanonical;
+    }
+  }
+
+  /**
    * Run all checks and execute actions as needed
    */
   async verify() {
@@ -564,6 +596,13 @@ class GitBranchVerifier {
       this.results.verdict = 'FAIL';
       return this.results;
     }
+
+    // f651e8eb: prefer existing canonical (no-slug) branch over creating a
+    // slugged duplicate. sd-start.js creates feat/<sdId> (no slug) at claim
+    // time; without this pre-check, this verifier would not find the slugged
+    // expectedBranchName and would CREATE a second branch, leaving the
+    // worktree on one branch and EXEC committing to another.
+    await this.preferExistingCanonicalBranch();
 
     // Run all checks
     const _check1 = await this.checkBranchExists();


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-gate6-prefer-existing-branch** | Resolves feedback row \`f651e8eb\`. Tenth fix in the harness-cleanup batch.

## Summary
\`GATE6_BRANCH_ENFORCEMENT\` generates \`expectedBranchName\` via \`generateBranchName()\`, which appends a 40-char title slug (e.g. \`feat/SD-XXX-001-wire-stage-20-...\`). But \`scripts/sd-start.js\` creates the canonical \`feat/<sdId>\` (no slug) at claim time. Two divergent conventions:

- **sd-start created**: \`feat/SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001\`
- **Gate6 expected** (and created): \`feat/SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-B-001-wire-stage-20-analyzer-to-persist\`

The worktree is on the first; EXEC is now expected to commit to the second. **Split-brain**, witnessed 2026-05-02.

## Fix
Add \`preferExistingCanonicalBranch()\` pre-check at the start of \`verify()\`. If \`<branchType>/<sdId>\` (no slug) already exists locally or on remote, override \`expectedBranchName\` to use it. The slugged \`generateBranchName()\` result remains the default for fresh SDs that have no existing branch.

\`\`\`js
// New method on GitBranchVerifier:
async preferExistingCanonicalBranch() {
  const noSlugCanonical = \`\${branchType}/\${this.sdId}\`;
  // Local then remote check; if found, override this.expectedBranchName.
}
\`\`\`

## Behavior matrix
| State | Old verifier | New verifier |
|---|---|---|
| Fresh SD, no existing branch | Creates \`feat/<sdId>-<slug>\` | Same (preserves slug as default) |
| sd-start already created \`feat/<sdId>\` (no slug) | Creates duplicate \`feat/<sdId>-<slug>\` | **Reuses \`feat/<sdId>\`** |
| Existing slugged branch (legacy) | Reuses it | Reuses it (no-slug check fails first, falls through) |

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`292dc46114\`, 0 commits ahead before commit)
- [x] Pre-check is additive — doesn't modify existing \`checkBranchExists\` flow when no canonical branch found
- [ ] Existing branch-enforcement tests still pass
- [ ] Merge cleanly without admin-bypass

## Why this matters
Closes a split-brain scenario where worktree branch and EXEC commit branch diverge. Without this fix, every SD started via sd-start.js triggers a duplicate slugged branch at PLAN-TO-EXEC, and operators must manually reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)