### PR TITLE
fix(husky): skip smoke tests on docs/reports/test/chore branches

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -342,17 +342,27 @@ echo ""
 # ============================================================================
 # Smoke Tests
 # ============================================================================
-echo "Running smoke tests before commit..."
-npm run test:smoke
+# Exempt docs/, reports/, test/, chore/ branches from smoke tests — these
+# typically contain documentation regeneration, reports, test additions, or
+# housekeeping that don't exercise runtime paths the smoke tests cover.
+# Mirrors the LOC-threshold exemption further down (~line 682).
+# Closes feedback row 36b22247: smoke tests fail offline (DNS ENOTFOUND on
+# test.invalid.local) and force --no-verify on docs-only commits.
+if echo "$BRANCH" | grep -qE '^(docs|reports|test|chore)/'; then
+  echo "📝 Skipping smoke tests — branch type '$(echo "$BRANCH" | cut -d'/' -f1)/' is exempt"
+else
+  echo "Running smoke tests before commit..."
+  npm run test:smoke
 
-# Check exit code
-if [ $? -ne 0 ]; then
-  echo "❌ Smoke tests failed. Commit aborted."
-  echo "Run 'npm run test:smoke' to see details."
-  exit 1
+  # Check exit code
+  if [ $? -ne 0 ]; then
+    echo "❌ Smoke tests failed. Commit aborted."
+    echo "Run 'npm run test:smoke' to see details."
+    exit 1
+  fi
+
+  echo "✅ Smoke tests passed."
 fi
-
-echo "✅ Smoke tests passed."
 
 # ============================================================================
 # PRD Schema Validation


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-husky-smoke-skip-docs** | Resolves feedback row \`36b22247\`. Eleventh fix in the harness-cleanup batch.

## Summary
The husky pre-commit hook ran \`npm run test:smoke\` unconditionally, failing for docs-only branches when network resolution is offline (DNS ENOTFOUND on \`test.invalid.local\` — the intentionally-invalid test target). Operators were forced to \`--no-verify\` on every docs-only commit when offline, which masked any other pre-commit violations.

## Fix
Bring the smoke-test stage into parity with the LOC-threshold exemption (line 682) — exempt the same four branch prefixes:

| Branch prefix | Smoke tests now |
|---|---|
| \`docs/\`    | skipped ✅ |
| \`reports/\` | skipped ✅ |
| \`test/\`    | skipped ✅ |
| \`chore/\`   | skipped ✅ |
| \`feat/\`, \`fix/\`, \`qf/\`, \`quick-fix/\` | run as before |

Documentation regeneration, reports, test-only additions, and chore commits don't exercise the runtime paths the smoke suite covers, so skipping is safe.

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`c9ee9df8e1\`, 0 commits ahead before commit)
- [x] Mirrors the LOC-threshold exemption regex \`^(docs|reports|test|chore)/\` already present at line 682
- [x] feat/fix/qf branches still hit the smoke-test path (the else branch)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Removes the only legitimate reason operators have been forced into \`--no-verify\` for offline docs commits. Now the pre-commit hook can stay strict for code branches while staying out of the way for docs/reports/test/chore work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)