### PR TITLE
fix(gate5): default appPath to EHG_Engineer (not EHG) for direct CLI usage

### DIFF
--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -15,7 +15,7 @@
  *
  * Usage:
  *   node scripts/verify-git-commit-status.js SD-XXX /path/to/app
- *   node scripts/verify-git-commit-status.js SD-XXX  # defaults to EHG_ROOT (cross-platform)
+ *   node scripts/verify-git-commit-status.js SD-XXX  # defaults to EHG_Engineer (the repo this script lives in)
  */
 
 import { exec } from 'child_process';
@@ -29,13 +29,19 @@ import { isMainModule } from '../lib/utils/is-main-module.js';
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const _EHG_ENGINEER_ROOT = path.resolve(__dirname, '..');
+const EHG_ENGINEER_ROOT = path.resolve(__dirname, '..');
 const EHG_ROOT = resolveRepoPath('ehg');
 
 const execAsync = promisify(exec);
 
 class GitCommitVerifier {
-  constructor(sdId, appPath = EHG_ROOT, options = {}) {
+  // Default appPath is EHG_Engineer (the repo this script LIVES IN), not EHG.
+  // Backend SDs without explicit target_application were previously misrouted
+  // to EHG_ROOT — gate misfired against the wrong branches and forced bypass.
+  // The handoff executor passes appPath via determineTargetRepository() in
+  // normal flow; this default only matters for direct CLI usage.
+  // Closes feedback row 5424d06e.
+  constructor(sdId, appPath = EHG_ENGINEER_ROOT, options = {}) {
     this.sdId = sdId;
     this.legacyId = options.legacyId || null; // SD-VENTURE-STAGE0-UI-001: Support legacy_id search
     this.appPath = appPath;


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-gate5-default-engineer-root** | Resolves feedback row \`5424d06e\`. Twelfth fix in the harness-cleanup batch.

## Summary
\`scripts/verify-git-commit-status.js\` lives inside EHG_Engineer but defaulted \`appPath\` to \`EHG_ROOT\` (the EHG frontend repo). Backend SDs without explicit \`target_application\` — and any direct CLI invocation — landed in the wrong repo, causing the gate to misfire against EHG branches and forcing per-SD bypass on every PLAN-TO-LEAD handoff.

The corresponding \`_EHG_ENGINEER_ROOT\` constant was already computed at line 32 but underscore-prefixed and unused.

## Fix
| | Before | After |
|---|---|---|
| Line 32 | \`_EHG_ENGINEER_ROOT\` (unused) | \`EHG_ENGINEER_ROOT\` (used) |
| Line 38 (constructor default) | \`appPath = EHG_ROOT\` | \`appPath = EHG_ENGINEER_ROOT\` |
| Line 18 (JSDoc) | "defaults to EHG_ROOT" | "defaults to EHG_Engineer (the repo this script lives in)" |

The handoff executor passes \`appPath\` via \`determineTargetRepository()\` in the normal flow, so this default only matters for direct CLI usage — which is exactly the path operators hit when manually re-running the gate to debug a misfire.

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`1cd1468265\`, 0 commits ahead before commit)
- [x] Confirmed \`_EHG_ENGINEER_ROOT\` was already computed but unused — purely structural cleanup
- [x] Handoff executor's normal flow still passes appPath explicitly via determineTargetRepository
- [ ] Merge cleanly without admin-bypass

## Why this matters
Removes the per-SD bypass loop for backend SDs whose target_application isn't explicit. The default now matches the script's own repo, which is the structurally correct fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)