### PR TITLE
fix(session-register): wire into SessionStart + read current session-identity marker scheme

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,6 +59,11 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/capture-session-id.cjs",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/session-register.cjs",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -38,6 +38,36 @@ function detectCurrentRepo() {
 }
 
 function getCurrentSessionId() {
+  // Resolution order (5f02d3c2):
+  //   1. CLAUDE_SESSION_ID env var (set by capture-session-id.cjs which runs
+  //      earlier in the SessionStart chain — most reliable when present)
+  //   2. .claude/session-identity/<uuid>.json — current marker scheme;
+  //      pick the most-recently-modified file. capture-session-id.cjs:383
+  //      writes one file per session here.
+  //   3. .claude/session-id.json — legacy single-file marker (predates the
+  //      session-identity dir, kept for backward compat)
+  //   4. ~/.claude-sessions/*.json — even-older fallback
+  if (process.env.CLAUDE_SESSION_ID) {
+    return process.env.CLAUDE_SESSION_ID;
+  }
+
+  try {
+    const markerDir = path.resolve(__dirname, '../../.claude/session-identity');
+    if (fs.existsSync(markerDir)) {
+      const markers = fs.readdirSync(markerDir)
+        .filter(f => f.endsWith('.json'))
+        .map(f => {
+          const full = path.join(markerDir, f);
+          return { name: f, mtime: fs.statSync(full).mtimeMs };
+        })
+        .sort((a, b) => b.mtime - a.mtime);
+      if (markers.length > 0) {
+        const latest = JSON.parse(fs.readFileSync(path.join(markerDir, markers[0].name), 'utf8'));
+        if (latest.session_id) return latest.session_id;
+      }
+    }
+  } catch { /* fall through to legacy lookups */ }
+
   try {
     const sessionFile = path.resolve(__dirname, '../../.claude/session-id.json');
     if (fs.existsSync(sessionFile)) {


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-session-register-wire** | Resolves feedback row \`5f02d3c2\`. Thirteenth fix in the harness-cleanup batch.

## Summary
\`scripts/hooks/session-register.cjs\` has lived in the repo without ever being wired into \`.claude/settings.json\` SessionStart hooks. Even if it WERE wired, it would no-op: it reads only the legacy \`.claude/session-id.json\` (singular) which doesn't exist in current sessions — \`capture-session-id.cjs\` switched to writing one file per session into \`.claude/session-identity/\` long ago.

**Net effect**: post-restart sessions show only the marker file (via \`capture-session-id.cjs\`) and no \`claude_sessions\` row. \`handoff.js\` then blocks at \`GATE_CLAIM_VALIDITY=no_deterministic_identity\` because Strategy 1 (env_var → session_id/terminal_id row lookup) finds nothing. Operators have been working around this by running \`sd:start\` before any handoff post-restart.

## Fix
**Part 1** — \`session-register.cjs::getCurrentSessionId\` resolution chain (in order):
1. \`process.env.CLAUDE_SESSION_ID\` (most reliable; set by \`capture-session-id.cjs\` earlier in the chain)
2. \`.claude/session-identity/<uuid>.json\` (current scheme; pick latest by mtime)
3. \`.claude/session-id.json\` (legacy single-file marker, kept for compat)
4. \`~/.claude-sessions/*.json\` (oldest fallback)

**Part 2** — \`.claude/settings.json\` — added \`session-register.cjs\` to the second SessionStart hook group, right after \`capture-session-id.cjs\`, with a 5-second timeout. Order matters: \`capture-session-id\` writes the marker file and env var; \`session-register\` reads them and upserts the \`claude_sessions\` row.

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`02eaf56dbd\`, 0 commits ahead before commit)
- [x] Verified marker scheme path matches \`capture-session-id.cjs:383\`
- [x] Hook order set so capture writes before register reads
- [ ] Post-merge: next session restart upserts a claude_sessions row immediately (the fix's smoke test)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Idle workers visible in the fleet dashboard immediately after restart. \`handoff.js\` no longer requires an upstream \`sd:start\` to make \`GATE_CLAIM_VALIDITY\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)