### PR TITLE
fix(QF-20260502-176): GATE_TEST_COVERAGE_QUALITY short-circuit on zero-UI diff regardless of sd_type

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.js
@@ -340,16 +340,19 @@ export function createTestCoverageQualityGate(supabase) {
         };
       }
 
-      // QF-20260428-PLAYWRIGHT-BACKEND: short-circuit for backend-only SDs with no UI surface in the diff.
-      // Spawning Playwright in this case is guaranteed to time out at 60s and force a documented bypass
-      // at every backend EXEC-TO-PLAN. The skip is fail-open (passed=true, score=100) but explicitly
-      // logged + tagged in details.skip_reason so audits can distinguish from a real PASS.
-      // Override via `LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT=off` (e.g., a backend SD that legitimately added e2e tests).
+      // QF-20260502-176 (extends QF-20260428-PLAYWRIGHT-BACKEND): short-circuit fires whenever
+      // the diff has zero UI surface, regardless of sd_type. Original gate keyed only on
+      // BACKEND_ONLY_SD_TYPES, which excluded sd_type=feature even when the feature's diff
+      // was 100% backend (witnessed: SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001 — Windows fs
+      // junction fix, lib/worktree-manager.js + tests, sd_type=feature, zero UI files).
+      // Spawning Playwright with no UI surface to test is guaranteed to time out at 60s.
+      // Skip is fail-open (passed=true, score=100), tagged in details.skip_reason for audit.
+      // Override via `LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT=off` if e2e tests were added.
       const shortCircuitEnabled = process.env.LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT !== 'off';
       const isBackendOnly = BACKEND_ONLY_SD_TYPES.has(sdType);
       const diffTouchesUI = hasUIFiles(codeChanges.codeFiles);
-      if (shortCircuitEnabled && isBackendOnly && !diffTouchesUI) {
-        console.log(`   ⏭️  Backend-only SD (sd_type=${sdType}) with no UI files in diff — skipping Playwright spawn`);
+      if (shortCircuitEnabled && !diffTouchesUI) {
+        console.log(`   ⏭️  No UI files in diff (sd_type=${sdType}, backend_only_label=${isBackendOnly}) — skipping Playwright spawn`);
         console.log('   💡 Override with LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT=off if e2e tests added');
         return {
           passed: true,
@@ -357,7 +360,7 @@ export function createTestCoverageQualityGate(supabase) {
           max_score: 100,
           issues: [],
           warnings: [
-            `Backend-only SD (${sdType}) with zero UI files in diff — Playwright spawn skipped`,
+            `No UI files in diff (sd_type=${sdType}) — Playwright spawn skipped`,
             'If this SD legitimately includes e2e tests, set LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT=off and re-run'
           ],
           details: {
@@ -365,11 +368,12 @@ export function createTestCoverageQualityGate(supabase) {
             blocking: false,
             threshold_used: threshold,
             sd_type: sdType,
-            mode: 'short_circuit_backend_only',
-            skip_reason: 'backend_only_sd_no_ui_files',
+            mode: 'short_circuit_no_ui_diff',
+            skip_reason: 'no_ui_files_in_diff',
+            backend_only_label: isBackendOnly,
             changed_files_count: codeChanges.codeFileCount,
             ui_files_count: 0,
-            summary: 'Backend-only SD with no UI surface in diff'
+            summary: 'No UI surface in diff — Playwright skipped'
           }
         };
       }


### PR DESCRIPTION
## Summary
Relax the Playwright short-circuit in `scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.js` to fire whenever the diff has zero UI files, regardless of `sd_type`. Previously gated on `BACKEND_ONLY_SD_TYPES` (bugfix/infrastructure/documentation/database/refactor) AND zero UI — which excluded `sd_type=feature` SDs whose diff happened to be 100% backend.

## Witness
SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001 (PR #3471, merged 2026-05-02): Windows fs junction fix, 270 LOC across `lib/worktree-manager.js` + `lib/shipping/post-merge-worktree-cleanup.js` + `tests/unit/worktree-manager.test.js`. `sd_type=feature`, zero UI files in diff. Playwright spawned with nothing to test and timed out at 60s → forced a 2/3 bypass-quota burning `--bypass-validation` with `TOOLING_BUG`-matched reason.

## Fix
- Predicate changed from `isBackendOnly && !diffTouchesUI` → `!diffTouchesUI`
- `details.mode`: `short_circuit_backend_only` → `short_circuit_no_ui_diff`
- `details.skip_reason`: `backend_only_sd_no_ui_files` → `no_ui_files_in_diff`
- New `details.backend_only_label` preserves original sd_type-based classification for observability

## Behavior matrix
| sd_type | hasUIFiles | Before | After |
|---------|:---:|--------|--------|
| bugfix/infra/docs/db/refactor | no | skip ✅ | skip ✅ |
| bugfix/infra/docs/db/refactor | yes | spawn Playwright | spawn Playwright |
| feature | no | **spawn → 60s timeout → bypass needed** ❌ | skip ✅ |
| feature | yes | spawn Playwright | spawn Playwright |

## False-positive risk
Feature SD with new e2e tests but zero UI files in diff. The `hasUIFiles` regex covers `.tsx/.jsx/components|src/components|src/pages|pages|app/|src/app/` — any meaningful UI work triggers Playwright. Concrete false-positive requires shipping e2e infrastructure with no UI files; `LEO_PLAYWRIGHT_BACKEND_SHORTCIRCUIT=off` remains the documented escape hatch.

## Test plan
- [x] Existing 10 tests pass (`tests/unit/handoff/gates/test-coverage-threshold-profile.test.js`)
- [ ] Next backend-typed `feature` SD that goes through EXEC-TO-PLAN should pass without bypass (the natural integration test — the harness will exercise this on the next zero-UI feature SD)

## Sizing
15 insertions / 11 deletions in 1 file (Tier 1 QF, ≤30 LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)