### PR TITLE
fix(agent-md): preserve .partial frontmatter when DB lookup misses

### DIFF
--- a/scripts/generate-agent-md-from-db.js
+++ b/scripts/generate-agent-md-from-db.js
@@ -304,14 +304,23 @@ function compileAgentFromPartial(partialPath, agentName, agentCode, data, config
   const rawContent = fs.readFileSync(partialPath, 'utf8');
   const agent = data.agentByCode[agentCode];
 
-  // Strip old frontmatter — we generate it from DB now
-  const body = stripYamlFrontmatter(rawContent);
+  // 27edb2c0: when the DB has no row for this agentCode (agent authored as a
+  // .partial but not in leo_sub_agents — or fetch returned an unexpectedly
+  // empty agentByCode) preserve the .partial's frontmatter rather than
+  // stripping it and writing a frontmatter-less .md. Without this fallback,
+  // Claude Code couldn't recognize the file as an agent and the subagent_type
+  // was effectively unregistered (witnessed for stories-agent and risk-agent).
+  const body = agent ? stripYamlFrontmatter(rawContent) : rawContent;
 
   // Remove any existing "Institutional Memory (Generated)" section
   const cleanedBody = body.replace(/## Institutional Memory \(Generated\)[\s\S]*?(?=\n## [^I]|\n---\n|$)/, '');
 
-  // Generate new frontmatter from DB
+  // Generate new frontmatter from DB; falls back to '' when no DB row, in
+  // which case cleanedBody still carries the .partial's frontmatter.
   const frontmatter = agent ? generateFrontmatter(agentName, agent) : '';
+  if (!agent) {
+    console.warn(`  ⚠️  No DB row for ${agentCode} (${agentName}) — preserving .partial frontmatter as fallback`);
+  }
 
   // Compose knowledge block
   const knowledgeBlock = composeKnowledgeBlock(agentCode, data, configCategoryMappings);


### PR DESCRIPTION
## Linkage
**QF: QF-20260502-agent-md-frontmatter-fallback** | Resolves feedback row \`27edb2c0\`. Fifteenth fix in the harness-cleanup batch.

## Summary
\`generate-agent-md-from-db.js::compileAgentFromPartial\` unconditionally stripped the .partial's YAML frontmatter and replaced it with a DB-generated one. When the DB lookup failed (agentCode not found in \`agentByCode\` — row missing or fetch transient-erred), the replacement frontmatter became \`''\` and the resulting .md had **no frontmatter at all**. Claude Code requires the YAML block to recognize a file as a sub-agent definition, so the file was effectively unregistered even though it lived on disk.

**Witnessed**: \`stories-agent.md\` and \`risk-agent.md\` regenerated 2026-05-02 18:18 with bodies starting at \`## Institutional Memory (Generated)\` instead of \`---\nname: ...\n---\`. Their \`subagent_type\` was absent from the Task tool allowlist despite \`CLAUDE_LEAD.md\` and \`CLAUDE_PLAN.md\` referencing them.

## Fix
| Condition | Old behavior | New behavior |
|---|---|---|
| DB has agent row | Strip .partial frontmatter, use DB-generated | Same (unchanged) |
| DB lookup misses | Strip .partial frontmatter, set replacement = '' → **no frontmatter** | **Preserve .partial's frontmatter as-is** + stderr warning |

\`\`\`js
// Before
const body = stripYamlFrontmatter(rawContent);
const frontmatter = agent ? generateFrontmatter(agentName, agent) : '';

// After
const body = agent ? stripYamlFrontmatter(rawContent) : rawContent;
const frontmatter = agent ? generateFrontmatter(agentName, agent) : '';
if (!agent) console.warn(\`⚠️  No DB row for \${agentCode} (\${agentName}) — preserving .partial frontmatter as fallback\`);
\`\`\`

## Test plan
- [x] Worktree branched directly off origin/main (HEAD \`0ab2151a94\`, 0 commits ahead before commit)
- [x] DB-row-present path is unchanged (common case; the existing flow)
- [x] DB-row-missing path now emits a recognizable agent file plus a clear stderr warning
- [ ] Next agent compilation cycle regenerates stories-agent.md and risk-agent.md correctly (the structural smoke test)
- [ ] Merge cleanly without admin-bypass

## Why this matters
Defensive fix for the silent-broken-agent failure mode. Even when DB rows exist (the common case today), this guard ensures a transient DB error during the SessionStart compile never produces an unrecognizable .md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)