### PR TITLE
fix(sd-start): cadence gate now fires on direct claim + orchestrator leaf routing (QF-20260502-983)

### DIFF
--- a/scripts/__tests__/sd-start-cadence-orchestrator-leaf.test.js
+++ b/scripts/__tests__/sd-start-cadence-orchestrator-leaf.test.js
@@ -1,0 +1,64 @@
+/**
+ * Structural invariants for the orchestrator-leaf cadence gate fix
+ * (QF-CADENCE-ORCH-LEAF). Two latent defects in scripts/sd-start.js:
+ *
+ *   D1: getSDDetails SELECT excluded `governance_metadata` and `metadata`,
+ *       so the cadence gate at sd-start.js read undefined and never fired.
+ *   D2: When orchestrator routing reassigned `sd` to a leaf child, the
+ *       cadence gate had already run on the parent. The leaf's
+ *       governance_metadata.next_workable_after was never re-checked, so a
+ *       cadence-blocked leaf was silently claimed via the parent.
+ *
+ * Pattern: source-text invariant tests (per feedback_sd_next_rendering_pipeline_has_5_sd_selects.md
+ * — guarding bug-fix wiring with grep-style regression checks is preferable
+ * to spawning sd-start.js as a subprocess for every CI run).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SD_START_PATH = path.resolve(__dirname, '..', 'sd-start.js');
+const SOURCE = fs.readFileSync(SD_START_PATH, 'utf8');
+
+describe('sd-start.js cadence gate wiring', () => {
+  it('D1: getSDDetails SELECT must include governance_metadata and metadata', () => {
+    // The cadence helper reads sd.governance_metadata + sd.metadata. If the
+    // SELECT omits them, every gate evaluation runs on undefined and the gate
+    // is dead code regardless of how many call sites we add.
+    // Anchor to the getSDDetails function body; multiple .from('strategic_directives_v2')
+    // calls exist in this file.
+    const fnMatch = SOURCE.match(/async function getSDDetails\([\s\S]*?\n}/);
+    expect(fnMatch, 'getSDDetails function must be present').not.toBeNull();
+    const selectMatch = fnMatch[0].match(/\.select\('([^']+)'\)/);
+    expect(selectMatch, 'getSDDetails .select(...) must be present').not.toBeNull();
+    const cols = selectMatch[1].split(',').map(c => c.trim());
+    expect(cols).toContain('governance_metadata');
+    expect(cols).toContain('metadata');
+  });
+
+  it('D2: enforceCadenceGate must be defined and called at least twice in main()', () => {
+    expect(SOURCE).toMatch(/async function enforceCadenceGate\s*\(/);
+    const callCount = (SOURCE.match(/await enforceCadenceGate\s*\(/g) || []).length;
+    expect(callCount, 'gate must be invoked once on the parent SD and again after orchestrator leaf routing').toBeGreaterThanOrEqual(2);
+  });
+
+  it('D2: post-leaf-routing cadence re-check must follow the leaf reassignment', () => {
+    // The second call site must be positioned AFTER `effectiveId = childId`
+    // (the leaf reassignment) and INSIDE the orchestrator-detection branch.
+    // Otherwise the gate runs on the parent's metadata twice, not the leaf's.
+    const reassignIdx = SOURCE.indexOf('effectiveId = childId');
+    expect(reassignIdx, 'leaf reassignment site not found').toBeGreaterThan(-1);
+    const afterReassign = SOURCE.slice(reassignIdx);
+    expect(afterReassign).toMatch(/await enforceCadenceGate\s*\(\s*sd\s*,\s*effectiveId\s*\)/);
+  });
+
+  it('helper imports the canonical pre-claim-gate module', () => {
+    // Drift guard: helper must read computeGateState from
+    // lib/cadence/pre-claim-gate.mjs, not a local re-implementation.
+    expect(SOURCE).toMatch(/import\(['"]\.\.\/lib\/cadence\/pre-claim-gate\.mjs['"]\)/);
+  });
+});

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -254,7 +254,7 @@ async function getSDDetails(sdId) {
   // Note: legacy_id column was deprecated and removed - using sd_key instead
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id, scope')
+    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id, scope, governance_metadata, metadata')
     .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
@@ -451,6 +451,105 @@ async function getNextHandoff(sd) {
   return handoffMap[phase] || 'LEAD-TO-PLAN';
 }
 
+/**
+ * Enforce SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001 cadence gate.
+ *
+ * Idempotent — safe to call multiple times (e.g., once on the parent SD and
+ * again after orchestrator routing reassigns `sd` to a leaf). Reads
+ * governance_metadata + metadata directly off the passed `sd` object, so
+ * callers must ensure those columns are selected before invoking.
+ *
+ * Refuses (process.exit(1)) when the gate is active and no valid override
+ * is supplied. Override requires --override-cadence-gate "<≥20-char reason>"
+ * plus either --pattern-id or --followup-sd-key, audit-logged fail-closed.
+ */
+async function enforceCadenceGate(sd, effectiveId) {
+  const { computeGateState, formatRefusalMessage } = await import('../lib/cadence/pre-claim-gate.mjs');
+  const gateState = computeGateState({
+    governance_metadata: sd.governance_metadata,
+    metadata: sd.metadata,
+  });
+
+  if (!gateState.active) return;
+
+  const argv = process.argv;
+  const overrideIdx = argv.findIndex(a => a === '--override-cadence-gate');
+  const overrideReason = (overrideIdx !== -1 && argv[overrideIdx + 1]) ? argv[overrideIdx + 1] : null;
+  const patternIdIdx = argv.findIndex(a => a === '--pattern-id');
+  const followupIdx = argv.findIndex(a => a === '--followup-sd-key');
+  const patternId = (patternIdIdx !== -1 && argv[patternIdIdx + 1]) ? argv[patternIdIdx + 1] : null;
+  const followupSdKey = (followupIdx !== -1 && argv[followupIdx + 1]) ? argv[followupIdx + 1] : null;
+
+  if (!overrideReason || overrideReason.length < 20) {
+    console.log(`\n${colors.red}${colors.bold}🚫 ${formatRefusalMessage({ sdKey: effectiveId, gateState })}${colors.reset}`);
+    if (overrideReason && overrideReason.length < 20) {
+      console.log(`${colors.red}   (override reason must be ≥20 chars; got ${overrideReason.length})${colors.reset}`);
+    }
+    try {
+      await supabase.from('audit_log').insert({
+        event_type: 'CADENCE_GATE_REFUSED',
+        entity_type: 'strategic_directive',
+        entity_id: sd.id,
+        metadata: {
+          sd_key: effectiveId,
+          gate_until: gateState.gate_until,
+          days_remaining: gateState.days_remaining,
+          source: gateState.source,
+          override_attempted: overrideReason !== null,
+          override_reason: overrideReason,
+          operator_session_id: process.env.CLAUDE_SESSION_ID || null,
+        },
+        severity: 'info',
+      });
+    } catch (auditErr) {
+      console.warn(`${colors.dim}(audit-log refusal record failed non-blocking: ${auditErr.message})${colors.reset}`);
+    }
+    process.exit(1);
+  }
+
+  const { validateBypassShape } = await import('./modules/handoff/bypass-rubric.js');
+  const shapeResult = await validateBypassShape({
+    patternId,
+    followupSdKey,
+    supabase,
+    bypassReason: overrideReason,
+    sdId: sd.id,
+    handoffType: 'sd_start_cadence_override',
+  });
+  if (!shapeResult.allowed) {
+    console.log(`\n${colors.red}${colors.bold}🚫 Cadence override refused${colors.reset}`);
+    console.log(`   ${shapeResult.message}`);
+    process.exit(1);
+  }
+
+  const { error: auditErr } = await supabase.from('audit_log').insert({
+    event_type: 'CADENCE_GATE_OVERRIDE',
+    entity_type: 'strategic_directive',
+    entity_id: sd.id,
+    metadata: {
+      sd_key: effectiveId,
+      gate_until: gateState.gate_until,
+      days_remaining: gateState.days_remaining,
+      source: gateState.source,
+      override_reason: overrideReason,
+      pattern_id: patternId,
+      followup_sd_key: followupSdKey,
+      operator_session_id: process.env.CLAUDE_SESSION_ID || null,
+    },
+    severity: 'warning',
+  });
+  if (auditErr) {
+    console.log(`\n${colors.red}${colors.bold}🚫 audit-log unavailable; cadence override cannot be safely recorded${colors.reset}`);
+    console.log(`   audit_log error: ${auditErr.message}`);
+    console.log(`   ${colors.dim}fail-closed: claim refused${colors.reset}`);
+    process.exit(1);
+  }
+  console.log(`${colors.yellow}⚠ Cadence gate override accepted${colors.reset}`);
+  console.log(`   Reason:           "${overrideReason}"`);
+  console.log(`   Pattern/Followup: ${patternId || followupSdKey}`);
+  console.log(`   Audit row:        event_type=CADENCE_GATE_OVERRIDE on entity_id=${sd.id}`);
+}
+
 async function main() {
   const sdId = process.argv[2];
 
@@ -471,7 +570,7 @@ async function main() {
   const worktreeGuard = isInsideWorktree();
   if (worktreeGuard.inside) {
     console.log(`\n${colors.red}${colors.bold}Error: sd-start must run from the main repo root${colors.reset}`);
-    console.log(`\n  Current cwd is inside the worktrees subtree:`);
+    console.log('\n  Current cwd is inside the worktrees subtree:');
     console.log(`    ${colors.dim}cwd:       ${process.cwd()}${colors.reset}`);
     console.log(`    ${colors.dim}worktrees: ${worktreeGuard.worktreesDir}${colors.reset}`);
     console.log(`\n  ${colors.cyan}cd ${worktreeGuard.repoRoot}${colors.reset}`);
@@ -518,101 +617,9 @@ async function main() {
   }
 
   // 1.4. SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001: Pre-claim cadence gate.
-  // Refuses claim if SD is in a stability window (governance_metadata.next_workable_after
-  // in future, OR derived from governance_metadata.session_log[last] + metadata.pr_cadence_minimum_days).
-  // Override requires --override-cadence-gate "<reason>" + (--pattern-id PAT-XXX OR --followup-sd-key SD-XXX),
-  // mirroring scripts/modules/handoff/bypass-rubric.js governance anchoring.
-  // Audit-log emission is fail-closed: refusal on INSERT failure during override.
-  {
-    const { computeGateState, formatRefusalMessage } = await import('../lib/cadence/pre-claim-gate.mjs');
-    const gateState = computeGateState({
-      governance_metadata: sd.governance_metadata,
-      metadata: sd.metadata,
-    });
-
-    if (gateState.active) {
-      const argv = process.argv;
-      const overrideIdx = argv.findIndex(a => a === '--override-cadence-gate');
-      const overrideReason = (overrideIdx !== -1 && argv[overrideIdx + 1]) ? argv[overrideIdx + 1] : null;
-      const patternIdIdx = argv.findIndex(a => a === '--pattern-id');
-      const followupIdx = argv.findIndex(a => a === '--followup-sd-key');
-      const patternId = (patternIdIdx !== -1 && argv[patternIdIdx + 1]) ? argv[patternIdIdx + 1] : null;
-      const followupSdKey = (followupIdx !== -1 && argv[followupIdx + 1]) ? argv[followupIdx + 1] : null;
-
-      if (!overrideReason || overrideReason.length < 20) {
-        // No override or reason too short — REFUSE.
-        console.log(`\n${colors.red}${colors.bold}🚫 ${formatRefusalMessage({ sdKey: effectiveId, gateState })}${colors.reset}`);
-        if (overrideReason && overrideReason.length < 20) {
-          console.log(`${colors.red}   (override reason must be ≥20 chars; got ${overrideReason.length})${colors.reset}`);
-        }
-        try {
-          await supabase.from('audit_log').insert({
-            event_type: 'CADENCE_GATE_REFUSED',
-            entity_type: 'strategic_directive',
-            entity_id: sd.id,
-            metadata: {
-              sd_key: effectiveId,
-              gate_until: gateState.gate_until,
-              days_remaining: gateState.days_remaining,
-              source: gateState.source,
-              override_attempted: overrideReason !== null,
-              override_reason: overrideReason,
-              operator_session_id: process.env.CLAUDE_SESSION_ID || null,
-            },
-            severity: 'info',
-          });
-        } catch (auditErr) {
-          // Refusal-side audit failure is non-blocking (the gate is still refusing).
-          console.warn(`${colors.dim}(audit-log refusal record failed non-blocking: ${auditErr.message})${colors.reset}`);
-        }
-        process.exit(1);
-      }
-
-      // Override attempted — validate governance anchoring per bypass-rubric pattern.
-      const { validateBypassShape } = await import('./modules/handoff/bypass-rubric.js');
-      const shapeResult = await validateBypassShape({
-        patternId,
-        followupSdKey,
-        supabase,
-        bypassReason: overrideReason,
-        sdId: sd.id,
-        handoffType: 'sd_start_cadence_override',
-      });
-      if (!shapeResult.allowed) {
-        console.log(`\n${colors.red}${colors.bold}🚫 Cadence override refused${colors.reset}`);
-        console.log(`   ${shapeResult.message}`);
-        process.exit(1);
-      }
-
-      // Override valid — emit audit row BEFORE proceeding. Fail-closed on INSERT error.
-      const { error: auditErr } = await supabase.from('audit_log').insert({
-        event_type: 'CADENCE_GATE_OVERRIDE',
-        entity_type: 'strategic_directive',
-        entity_id: sd.id,
-        metadata: {
-          sd_key: effectiveId,
-          gate_until: gateState.gate_until,
-          days_remaining: gateState.days_remaining,
-          source: gateState.source,
-          override_reason: overrideReason,
-          pattern_id: patternId,
-          followup_sd_key: followupSdKey,
-          operator_session_id: process.env.CLAUDE_SESSION_ID || null,
-        },
-        severity: 'warning',
-      });
-      if (auditErr) {
-        console.log(`\n${colors.red}${colors.bold}🚫 audit-log unavailable; cadence override cannot be safely recorded${colors.reset}`);
-        console.log(`   audit_log error: ${auditErr.message}`);
-        console.log(`   ${colors.dim}fail-closed: claim refused${colors.reset}`);
-        process.exit(1);
-      }
-      console.log(`${colors.yellow}⚠ Cadence gate override accepted${colors.reset}`);
-      console.log(`   Reason:           "${overrideReason}"`);
-      console.log(`   Pattern/Followup: ${patternId || followupSdKey}`);
-      console.log(`   Audit row:        event_type=CADENCE_GATE_OVERRIDE on entity_id=${sd.id}`);
-    }
-  }
+  // Refuses claim if SD is in a stability window. Re-runs after orchestrator
+  // leaf routing so a cadence-blocked leaf is not silently claimed via the parent.
+  await enforceCadenceGate(sd, effectiveId);
 
   // 1.5. Orchestrator detection — route to child instead of claiming parent
   const explicitChild = process.argv.includes('--child') ? process.argv[process.argv.indexOf('--child') + 1] : null;
@@ -697,6 +704,11 @@ async function main() {
       Object.assign(sd, childSd);
       effectiveId = childId;
       console.log(`   ${colors.dim}(Orchestrator ${sdId} not claimed — only leaf ${childId} will be claimed)${colors.reset}`);
+
+      // Re-enforce cadence gate against the leaf's governance_metadata.
+      // Without this re-check, a cadence-blocked leaf is silently claimed via
+      // the parent (the parent has no next_workable_after of its own).
+      await enforceCadenceGate(sd, effectiveId);
     }
   }
 
@@ -857,14 +869,14 @@ async function main() {
         console.log(`  Owner session:  ${claimResult.owner?.session_id || '(none)'}`);
         console.log('');
         console.log(`  ${colors.yellow}Why blocked:${colors.reset} The owning session is released or stale, but`);
-        console.log(`  triangulate() detected evidence the CC conversation is still active`);
-        console.log(`  (sub-agent activity in last 5 min, sibling session on the branch,`);
-        console.log(`  warm worktree, or matching plan-file). Auto-releasing this claim`);
-        console.log(`  would clobber that other session's work.`);
+        console.log('  triangulate() detected evidence the CC conversation is still active');
+        console.log('  (sub-agent activity in last 5 min, sibling session on the branch,');
+        console.log('  warm worktree, or matching plan-file). Auto-releasing this claim');
+        console.log('  would clobber that other session\'s work.');
         console.log('');
         console.log(`  ${colors.cyan}Options:${colors.reset}`);
-        console.log(`    1. Pick a different SD: npm run sd:next`);
-        console.log(`    2. Confirm the other session is truly gone, then retry with:`);
+        console.log('    1. Pick a different SD: npm run sd:next');
+        console.log('    2. Confirm the other session is truly gone, then retry with:');
         console.log(`       node scripts/sd-start.js ${effectiveId} --force-reclaim`);
         console.log(
           `${colors.red}═══════════════════════════════════════════════════════════════════${colors.reset}\n`
@@ -1221,7 +1233,7 @@ async function main() {
           `   Requested SD: ${effectiveId}\n` +
           `   Observed basename: ${observedBasename}\n` +
           `   Resolved path: ${worktreeInfo.cwd}\n` +
-          `\nRemediation:\n` +
+          '\nRemediation:\n' +
           `   1. ${colors.cyan}npm run session:check-concurrency${colors.reset} — confirm no peer sessions are using this worktree\n` +
           `   2. ${colors.cyan}node scripts/release-and-clean.js ${observedBasename}${colors.reset} — release the stale claim and clean the worktree\n` +
           `   3. Re-run /leo start ${effectiveId}\n`


### PR DESCRIPTION
## Summary

Two latent defects in `scripts/sd-start.js` prevented the pre-claim cadence gate (`SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001`) from enforcing as designed.

**D1 — `getSDDetails` SELECT excluded `governance_metadata` and `metadata`.** The cadence helper at line 528 read `sd.governance_metadata`, which was always undefined; `computeGateState` returned `source=none` and the gate was dead code on every direct-claim path.

**D2 — Orchestrator routing reassigned `sd` to a leaf via `Object.assign` AFTER the gate ran on the parent.** The leaf's `next_workable_after` was never re-checked, so a cadence-blocked leaf was silently claimed via the parent. `child-sd-selector.getNextReadyChild` already skips blocked children for one code path (defense-in-depth for me), but `findLeafWorkItem`'s direct `getSDDetails` calls bypass that filter.

**Repro 2026-05-02:** `sd-start SD-EVA-SUPPORT-CLI-SKILL-ORCH-001` silently claimed cadence-blocked child `-B` (`next_workable_after=2026-05-11`, 8.1d future). After fix: parent refuses with "No unclaimed leaf work items available"; direct claim of `-B` refuses with the canonical PR cadence gate message.

**Fix:**
- Add `governance_metadata, metadata` to `getSDDetails` SELECT
- Extract cadence-gate enforcement into idempotent `enforceCadenceGate` helper
- Call helper after parent fetch AND after orchestrator leaf reassignment

## Test plan

- [x] 4 new structural invariant tests in `scripts/__tests__/sd-start-cadence-orchestrator-leaf.test.js` (SELECT columns, helper definition, dual call site, post-leaf positioning)
- [x] 16 existing `scripts/__tests__/cadence-gate.test.js` cases unchanged (helper module untouched)
- [x] Smoke test 1: orchestrator parent (`SD-EVA-SUPPORT-CLI-SKILL-ORCH-001`) → "No unclaimed leaf work items available" with both children skipped via cadence
- [x] Smoke test 2: direct leaf claim (`SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B`) → "🚫 PR cadence gate ... 9 day(s) remaining"

Closes harness backlog row `9eed67d1-ca53-4356-8192-6e92c8c7c070`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)