### PR TITLE
fix(QF-20260502-stories-priority-enum): map MoSCoW → canonical priority before user_stories insert

### DIFF
--- a/scripts/modules/auto-trigger-stories.mjs
+++ b/scripts/modules/auto-trigger-stories.mjs
@@ -617,6 +617,37 @@ function generateDefaultCriteria(sdType, context) {
   return defaults[sdType] || defaults.feature;
 }
 
+// QF-20260502-stories-priority-enum: PRD functional_requirements arrive with
+// MoSCoW priority values (must/should/could/wont) that the user_stories CHECK
+// constraint (critical/high/medium/low/minimal) rejects. Normalize before
+// insert. Also de-case-sensitivize the story_points lookup which previously
+// matched only uppercase {CRITICAL,HIGH,MEDIUM} and silently degraded
+// lowercase canonical inputs to story_points=1.
+const PRIORITY_CANONICAL = new Set(['critical', 'high', 'medium', 'low', 'minimal']);
+const MOSCOW_TO_CANONICAL = {
+  must: 'critical', 'must-have': 'critical', must_have: 'critical',
+  should: 'high', 'should-have': 'high', should_have: 'high',
+  could: 'medium', 'could-have': 'medium', could_have: 'medium',
+  wont: 'low', "won't": 'low', 'wont-have': 'low', wont_have: 'low'
+};
+
+export function normalizePriorityForUserStory(rawPriority) {
+  const lower = String(rawPriority ?? '').trim().toLowerCase();
+  if (!lower) return 'medium';
+  if (PRIORITY_CANONICAL.has(lower)) return lower;
+  if (MOSCOW_TO_CANONICAL[lower]) return MOSCOW_TO_CANONICAL[lower];
+  return 'medium';
+}
+
+export function derivePriorityStoryPoints(canonicalPriority) {
+  switch (canonicalPriority) {
+    case 'critical': return 5;
+    case 'high': return 3;
+    case 'medium': return 2;
+    default: return 1;
+  }
+}
+
 // SD-LEO-INFRA-AUTO-TRIGGER-STORIES-FK-FIX-001: validateSdId split into two
 // functions + lookupSdIdForFk helper. The old single validateSdId was both too
 // strict (rejected UUIDs at input) and too loose (let raw input flow into FK
@@ -843,7 +874,7 @@ export async function autoTriggerStories(supabase, sdId, prdId, options = {}) {
           user_want: story.user_want,
           user_benefit: story.user_benefit,
           story_points: story.story_points || 3,
-          priority: story.priority || 'medium',
+          priority: normalizePriorityForUserStory(story.priority),
           status: 'ready',
           acceptance_criteria: story.acceptance_criteria,
           implementation_context: typeof story.implementation_context === 'object'
@@ -1038,17 +1069,14 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
     const storyNumber = String(i + 1).padStart(3, '0');
     const storyKey = `${sdKey}:US-${storyNumber}`;
 
-    // Determine story points based on priority
-    const storyPoints = fr.priority === 'CRITICAL' ? 5 :
-                        fr.priority === 'HIGH' ? 3 :
-                        fr.priority === 'MEDIUM' ? 2 : 1;
+    // QF-20260502-stories-priority-enum: normalize once (handles MoSCoW + case)
+    // then derive both fields from the canonical value.
+    const priority = normalizePriorityForUserStory(fr.priority);
+    const storyPoints = derivePriorityStoryPoints(priority);
 
     // Determine user role from requirement or default to stakeholder
     // Now uses persona context when available (feature-flagged)
     const userRole = extractUserRole(fr.requirement, prd.category, personaContext);
-
-    // Convert priority to lowercase for user story status
-    const priority = (fr.priority || 'medium').toLowerCase();
 
     // SD-TYPE-AWARE: Transform acceptance criteria based on SD type
     const transformedCriteria = transformAcceptanceCriteria(

--- a/tests/unit/auto-trigger-stories-priority-enum.test.js
+++ b/tests/unit/auto-trigger-stories-priority-enum.test.js
@@ -1,0 +1,95 @@
+/**
+ * QF-20260502-stories-priority-enum
+ *
+ * PRD functional_requirements arrive with MoSCoW priority values
+ * (must/should/could/wont) but user_stories.priority CHECK constraint accepts
+ * only critical/high/medium/low/minimal. Without normalization, story inserts
+ * fail with 23514 and force a manual-author fallback (witnessed during
+ * SD-EHG-AI-GEN-GUARDRAILS-001 — feedback row 13fc76ea).
+ *
+ * Covers:
+ *   - normalizePriorityForUserStory: MoSCoW + canonical (case-insensitive) +
+ *     unknown values
+ *   - derivePriorityStoryPoints: Fibonacci mapping from canonical priority
+ *
+ * Together these guarantee both columns user_stories writes (priority +
+ * story_points) come from the same canonical token.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePriorityForUserStory,
+  derivePriorityStoryPoints
+} from '../../scripts/modules/auto-trigger-stories.mjs';
+
+describe('normalizePriorityForUserStory', () => {
+  it('maps MoSCoW must variants → critical', () => {
+    expect(normalizePriorityForUserStory('must')).toBe('critical');
+    expect(normalizePriorityForUserStory('MUST')).toBe('critical');
+    expect(normalizePriorityForUserStory('must-have')).toBe('critical');
+    expect(normalizePriorityForUserStory('must_have')).toBe('critical');
+  });
+
+  it('maps MoSCoW should variants → high', () => {
+    expect(normalizePriorityForUserStory('should')).toBe('high');
+    expect(normalizePriorityForUserStory('SHOULD')).toBe('high');
+    expect(normalizePriorityForUserStory('should-have')).toBe('high');
+  });
+
+  it('maps MoSCoW could variants → medium', () => {
+    expect(normalizePriorityForUserStory('could')).toBe('medium');
+    expect(normalizePriorityForUserStory('Could_Have')).toBe('medium');
+  });
+
+  it("maps MoSCoW wont/won't variants → low", () => {
+    expect(normalizePriorityForUserStory('wont')).toBe('low');
+    expect(normalizePriorityForUserStory("won't")).toBe('low');
+    expect(normalizePriorityForUserStory('wont-have')).toBe('low');
+  });
+
+  it('passes canonical values through (case-insensitive)', () => {
+    for (const v of ['critical', 'high', 'medium', 'low', 'minimal']) {
+      expect(normalizePriorityForUserStory(v)).toBe(v);
+      expect(normalizePriorityForUserStory(v.toUpperCase())).toBe(v);
+    }
+  });
+
+  it('falls back to medium for unknown / empty / null', () => {
+    expect(normalizePriorityForUserStory(undefined)).toBe('medium');
+    expect(normalizePriorityForUserStory(null)).toBe('medium');
+    expect(normalizePriorityForUserStory('')).toBe('medium');
+    expect(normalizePriorityForUserStory('   ')).toBe('medium');
+    expect(normalizePriorityForUserStory('priority-9000')).toBe('medium');
+  });
+
+  it('output is always one of the DB CHECK constraint values', () => {
+    const allowed = new Set(['critical', 'high', 'medium', 'low', 'minimal']);
+    const samples = ['must', 'SHOULD', 'could_have', 'wont', 'critical',
+                     'HIGH', '', null, 42, 'unknown'];
+    for (const s of samples) {
+      expect(allowed.has(normalizePriorityForUserStory(s))).toBe(true);
+    }
+  });
+});
+
+describe('derivePriorityStoryPoints', () => {
+  it('returns Fibonacci points per canonical priority', () => {
+    expect(derivePriorityStoryPoints('critical')).toBe(5);
+    expect(derivePriorityStoryPoints('high')).toBe(3);
+    expect(derivePriorityStoryPoints('medium')).toBe(2);
+    expect(derivePriorityStoryPoints('low')).toBe(1);
+    expect(derivePriorityStoryPoints('minimal')).toBe(1);
+  });
+
+  it('defaults to 1 for unexpected input (defensive)', () => {
+    expect(derivePriorityStoryPoints('CRITICAL')).toBe(1);
+    expect(derivePriorityStoryPoints(undefined)).toBe(1);
+  });
+
+  it('composes with normalizePriorityForUserStory end-to-end', () => {
+    expect(derivePriorityStoryPoints(normalizePriorityForUserStory('MUST'))).toBe(5);
+    expect(derivePriorityStoryPoints(normalizePriorityForUserStory('should'))).toBe(3);
+    expect(derivePriorityStoryPoints(normalizePriorityForUserStory('could'))).toBe(2);
+    expect(derivePriorityStoryPoints(normalizePriorityForUserStory('wont'))).toBe(1);
+    expect(derivePriorityStoryPoints(normalizePriorityForUserStory('garbage'))).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes feedback row `13fc76ea-dd98-43e0-b5ee-e6bc2c9e1f11` (auto-trigger-stories.mjs priority-enum CHECK mismatch).
- PRD `functional_requirements` arrive with MoSCoW priority values (`must`/`should`/`could`/`wont`) but `user_stories.priority` CHECK constraint accepts only `critical`/`high`/`medium`/`low`/`minimal`. Without normalization, story inserts fail with 23514 and force a manual-author fallback (witnessed during SD-EHG-AI-GEN-GUARDRAILS-001).
- Adjacent latent bug also fixed: `storyPoints` derivation matched only uppercase `{CRITICAL,HIGH,MEDIUM}` so any lowercase canonical input silently degraded to `story_points=1`.

## Approach
Two pure helpers (`normalizePriorityForUserStory` + `derivePriorityStoryPoints`) feed the canonical token to both columns the inserter writes. Applied in both the LLM-generated and template-fallback paths so PRDs that bypass the LLM still produce valid rows.

## Identifier
QF-20260502-stories-priority-enum

## Test plan
- [x] 10 new unit tests cover MoSCoW variants (must/should/could/wont incl. hyphenated and underscore forms), case-insensitive canonical passthrough, the 5 DB-allowed values, end-to-end composition, and defensive defaults for unknown / null input
- [x] Sibling FK-fix test suite (14 unit cases) re-runs green; only failure is a pre-existing live-DB integration `beforeAll` timeout unrelated to this change
- [x] Smoke tests pass via pre-commit hook

## LOC
36 src / 95 tests (Standard QF tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)