### PR TITLE
fix(QF-20260502-pg-stmt-splitter): respect comments + string literals when splitting PostgreSQL statements

### DIFF
--- a/scripts/lib/supabase-connection.js
+++ b/scripts/lib/supabase-connection.js
@@ -325,27 +325,95 @@ export async function createSupabaseAnonClient(projectKey = 'engineer', options 
 }
 
 /**
- * PostgreSQL statement splitter that respects $$ delimiters
+ * PostgreSQL statement splitter that respects $$ delimiters, single-line `--`
+ * comments, block comments, and single-quoted string literals.
+ *
+ * QF-20260502-pg-stmt-splitter: prior version only tracked $$ delimiters, so
+ * any `;` inside a `--` comment or a `'...;...'` literal incorrectly terminated
+ * the current statement and broke migrations applied via this helper. The
+ * workaround was to send the full file as one client.query() call, which
+ * defeated the purpose of the splitter.
+ *
  * @param {string} sql - SQL content
  * @returns {string[]} Array of statements
  */
 export function splitPostgreSQLStatements(sql) {
   let inDollarQuote = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let inSingleQuote = false;
   let current = '';
   const statements = [];
 
   for (let i = 0; i < sql.length; i++) {
-    // Check for $$ delimiter (used in function bodies)
-    if (sql[i] === '$' && sql[i+1] === '$') {
-      inDollarQuote = !inDollarQuote;
-      current += '$$';
-      i++; // Skip next $
+    const ch = sql[i];
+    const next = sql[i + 1];
+
+    if (inLineComment) {
+      current += ch;
+      if (ch === '\n') inLineComment = false;
+      continue;
     }
-    // Semicolon only terminates if not in dollar quote
-    else if (sql[i] === ';' && !inDollarQuote) {
+    if (inBlockComment) {
+      current += ch;
+      if (ch === '*' && next === '/') {
+        current += '/';
+        i++;
+        inBlockComment = false;
+      }
+      continue;
+    }
+    if (inSingleQuote) {
+      current += ch;
+      if (ch === "'") {
+        // SQL escapes a single quote by doubling it: 'it''s ok'.
+        if (next === "'") {
+          current += "'";
+          i++;
+        } else {
+          inSingleQuote = false;
+        }
+      }
+      continue;
+    }
+    if (inDollarQuote) {
+      if (ch === '$' && next === '$') {
+        inDollarQuote = false;
+        current += '$$';
+        i++;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '-' && next === '-') {
+      inLineComment = true;
+      current += '--';
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      current += '/*';
+      i++;
+      continue;
+    }
+    if (ch === "'") {
+      inSingleQuote = true;
+      current += ch;
+      continue;
+    }
+    if (ch === '$' && next === '$') {
+      inDollarQuote = true;
+      current += '$$';
+      i++;
+      continue;
+    }
+    if (ch === ';') {
       const trimmed = current.trim();
       if (trimmed.length > 0) {
-        // Remove comment-only lines
+        // Strip comment-only lines so the executor doesn't get a no-op statement.
         const lines = trimmed.split('\n').filter(line => {
           const l = line.trim();
           return l.length > 0 && !l.startsWith('--');
@@ -355,13 +423,11 @@ export function splitPostgreSQLStatements(sql) {
         }
       }
       current = '';
+      continue;
     }
-    else {
-      current += sql[i];
-    }
+    current += ch;
   }
 
-  // Add final statement if exists
   if (current.trim().length > 0) {
     statements.push(current.trim());
   }

--- a/tests/unit/split-postgresql-statements.test.js
+++ b/tests/unit/split-postgresql-statements.test.js
@@ -1,0 +1,107 @@
+/**
+ * QF-20260502-pg-stmt-splitter
+ *
+ * splitPostgreSQLStatements (scripts/lib/supabase-connection.js) used to track
+ * only $$ delimiters, so a `;` inside a `--` line comment or a `'...;...'`
+ * literal terminated the statement and broke migration apply (rejected as
+ * 42601 syntax error). Workaround was to drop the splitter and ship the whole
+ * file as one client.query(), which defeated its purpose.
+ *
+ * Behaviour now under test:
+ *   - basic semicolon split
+ *   - `--` line comments (inline at end of statement, on their own line, with embedded `;`)
+ *   - `/* * /` block comments (multi-line, with embedded `;`)
+ *   - single-quoted string literals (with embedded `;`, with `''` escape)
+ *   - dollar-quoted function bodies (existing behaviour preserved)
+ *   - leading / trailing whitespace, comment-only segments
+ */
+import { describe, it, expect } from 'vitest';
+import { splitPostgreSQLStatements } from '../../scripts/lib/supabase-connection.js';
+
+describe('splitPostgreSQLStatements', () => {
+  it('splits two simple statements on a top-level semicolon', () => {
+    const stmts = splitPostgreSQLStatements(
+      'CREATE TABLE a (id int);\nCREATE TABLE b (id int);'
+    );
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain('CREATE TABLE a');
+    expect(stmts[1]).toContain('CREATE TABLE b');
+  });
+
+  it('does NOT split on `;` inside a single-line `--` comment', () => {
+    // The original bug: the inline comment's `;` terminated the SELECT prematurely.
+    const sql = 'SELECT 1 -- pretend ; ends here\n  AS one;\nSELECT 2;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain('SELECT 1');
+    expect(stmts[0]).toContain('AS one');
+    expect(stmts[1]).toContain('SELECT 2');
+  });
+
+  it('does NOT split on `;` inside a /* block */ comment that spans lines', () => {
+    const sql = 'SELECT 1\n/* block ; with semicolon\n  spanning lines ; here */\n  AS one;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).toContain('SELECT 1');
+    expect(stmts[0]).toContain('AS one');
+  });
+
+  it('does NOT split on `;` inside single-quoted string literals', () => {
+    const sql = 'INSERT INTO t (msg) VALUES (\'hello;world\');\nSELECT 1;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("'hello;world'");
+    expect(stmts[1]).toContain('SELECT 1');
+  });
+
+  it("handles SQL '' escape inside a single-quoted literal without re-entering quote", () => {
+    // 'it''s ok; really' is a single literal — the inner ;` must NOT split.
+    const sql = 'INSERT INTO t (msg) VALUES (\'it\'\'s ok; really\');\nSELECT 2;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("'it''s ok; really'");
+    expect(stmts[1]).toContain('SELECT 2');
+  });
+
+  it('preserves prior $$ behaviour: function body with internal `;` is one statement', () => {
+    const sql = `CREATE OR REPLACE FUNCTION f() RETURNS void AS $$
+BEGIN
+  PERFORM 1;
+  PERFORM 2;
+END;
+$$ LANGUAGE plpgsql;
+SELECT 99;`;
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain('CREATE OR REPLACE FUNCTION');
+    expect(stmts[0]).toContain('END;');
+    expect(stmts[1]).toContain('SELECT 99');
+  });
+
+  it('drops comment-only segments (no SQL after stripping `--` lines)', () => {
+    const sql = '-- header comment\n-- another comment\n;\nSELECT 1;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).toContain('SELECT 1');
+  });
+
+  it('handles real-world COMMENT ON ... IS literal with embedded semicolon', () => {
+    // PostgreSQL COMMENT statements often embed semicolons in the literal body.
+    const sql = 'COMMENT ON COLUMN t.col IS \'See: trigger fires; row updated\';\nALTER TABLE t ADD COLUMN c2 int;';
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("'See: trigger fires; row updated'");
+    expect(stmts[1]).toContain('ALTER TABLE t');
+  });
+
+  it('returns empty array for empty / whitespace input', () => {
+    expect(splitPostgreSQLStatements('')).toEqual([]);
+    expect(splitPostgreSQLStatements('   \n  \n')).toEqual([]);
+  });
+
+  it('handles a final statement without trailing `;`', () => {
+    const stmts = splitPostgreSQLStatements('SELECT 1;\nSELECT 2');
+    expect(stmts).toHaveLength(2);
+    expect(stmts[1]).toContain('SELECT 2');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes feedback row `08270302-2dc5-444f-8c45-b76a2f93d953` (splitPostgreSQLStatements splits on semicolons inside `--` comments).
- Prior version only tracked `$$` delimiters, so any `;` inside a single-line `--` comment, a `/* ... */` block, or a `'...;...'` literal prematurely terminated the current statement and broke migrations applied via this helper (rejected as 42601 syntax error). The documented workaround was to ship the whole file via one `client.query()` call — defeating the splitter's purpose.

## Approach
State machine now tracks four contexts (line comment, block comment, single-quoted string with `''` escape, dollar quote) and suppresses semicolon termination inside any of them. Outside-context behaviour (semicolon split, comment-only-segment drop, trailing no-semicolon statement) is unchanged.

## Identifier
QF-20260502-pg-stmt-splitter

## Test plan
- [x] 10 new unit cases for the splitter directly: basic split, inline `--` with `;`, multi-line `/* */` with `;`, single-quote literal with `;`, `''` escape inside literal, `$$` function-body preservation, comment-only segments, real-world `COMMENT ON ... IS '...;...'` pattern, empty / whitespace input, missing trailing `;`
- [x] Existing `tests/database/migration-tester.test.js` suite (29 cases) re-runs green — no regression in the migration validator that consumes this splitter
- [x] Smoke tests pass via pre-commit hook

## LOC
78 src / 107 tests (197 total — under 400 hard cap; comprehensive test coverage justifies the parser rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)