### PR TITLE
fix(QF-20260502-fr-c-pooler-url): remap fr-c cron to secrets.DATABASE_URL

### DIFF
--- a/.github/workflows/fr-c-generator-cron.yml
+++ b/.github/workflows/fr-c-generator-cron.yml
@@ -41,7 +41,9 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-      SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+      # secrets.DATABASE_URL is the canonical pooler connection string in this
+      # repo (see schema-docs-update.yml). secrets.SUPABASE_POOLER_URL is unset.
+      SUPABASE_POOLER_URL: ${{ secrets.DATABASE_URL }}
       FR_C_RATE_LIMIT_PER_VENTURE_PER_DAY: ${{ github.event.inputs.rate_limit_override || '' }}
 
     steps:


### PR DESCRIPTION
## Summary

The hourly `FR-C Remediation SD Generator (cron)` workflow on main has been failing since 2026-05-01 with:

```
[fr-c-generator] unhandled: Error: SUPABASE_POOLER_URL (or DATABASE_URL) required for pg_advisory_lock
    at buildPgClient (scripts/cron/fr-c-generator.mjs:70:20)
```

Root cause: the workflow env wires `SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}` but that repo secret is unset. The script accepts `DATABASE_URL` as a fallback, but the workflow never passes it.

## Fix

Remap to `secrets.DATABASE_URL` — the canonical pooler connection in this repo (already used the same way in `schema-docs-update.yml:62`).

```diff
-      SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+      # secrets.DATABASE_URL is the canonical pooler connection string in this
+      # repo (see schema-docs-update.yml). secrets.SUPABASE_POOLER_URL is unset.
+      SUPABASE_POOLER_URL: ${{ secrets.DATABASE_URL }}
```

## Test plan

- [ ] Workflow passes on next scheduled tick (hourly cron) or via `workflow_dispatch` with `dry_run=true`
- [ ] No regression in other consumers of `secrets.DATABASE_URL` (read-only mapping)

## Context

- Closes feedback row `1c0cda25-ce69-4395-8d31-cb4527d2ed18` (ci_failure inbox)
- Same root-cause class as `marketing-schema-verify.yml:46` which currently warns and skips — separate sweep if desired
- Discovered during `/leo assist` inbox sweep (mode: campaign)
- Filed concurrently as harness backlog: dangling `metadata.deferred_to_sd_uuid` write-time validation gap (feedback c60fa140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)