### PR TITLE
feat(SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001): A05 source-class filter for corrective-sd-generator

### DIFF
--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -72,6 +72,80 @@ export const MIN_OCCURRENCES = 2;
 // created_by values that identify test/smoke-test score records to skip.
 const TEST_CREATED_BY_PATTERNS = ['test-', 'test-sync', 'vision-scorer-test'];
 
+// ─── A05 Source-Class Filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001) ───
+// Heuristic keyword sets used by classifySourceSD() to decide whether the source
+// SD is a class for which A05 (event_bus_integration) corrective SDs are noise.
+// Read-only/CLI/validation-only sources legitimately do not emit lifecycle events.
+
+export const READONLY_KEYWORDS = [
+  'cli', 'validation', 'parser', 'parsing', 'validator', 'preflight',
+  'check', 'verify', 'classifier', 'lookup', 'query', 'audit',
+  'helper', 'logger', 'reporter', 'inspector', 'scanner',
+];
+export const WRITE_KEYWORDS = [
+  'emit', 'publish', 'event', 'persist', 'insert', 'update', 'migration',
+  'schema', 'lifecycle', 'webhook', 'broadcast',
+];
+export const READONLY_BUGFIX_TYPES = new Set(['bugfix', 'fix', 'documentation']);
+
+/**
+ * Lightweight classifier: inspect SD shape and return reason if A05 corrective
+ * should be suppressed. Returns null when no suppression match (allow A05).
+ * Pure / synchronous so it is unit-testable without a Supabase client.
+ *
+ * @param {Object} sd - { sd_type, scope, key_changes, title, description }
+ * @returns {string|null} reason like 'cli_validation' / 'readonly_bugfix' or null
+ */
+export function classifySourceSD(sd) {
+  if (!sd) return null;
+  const text = [
+    sd.title, sd.description, sd.scope,
+    Array.isArray(sd.key_changes)
+      ? sd.key_changes.map(k => (typeof k === 'object' ? `${k.change || ''} ${k.impact || ''}` : String(k))).join(' ')
+      : '',
+  ].join(' ').toLowerCase();
+
+  const writeMatches = WRITE_KEYWORDS.filter(k => text.includes(k)).length;
+  if (writeMatches >= 2) return null;
+
+  const readonlyMatches = READONLY_KEYWORDS.filter(k => text.includes(k)).length;
+  if (readonlyMatches >= 2) return 'cli_validation';
+
+  const sdType = String(sd.sd_type || '').toLowerCase();
+  if (READONLY_BUGFIX_TYPES.has(sdType) && writeMatches === 0 && readonlyMatches >= 1) {
+    return 'readonly_bugfix';
+  }
+  if (sdType === 'documentation') return 'documentation';
+
+  return null;
+}
+
+/**
+ * Database-backed companion: load source SD by sd_key OR id and run classifier.
+ * Conservative default: returns suppress=false on any lookup failure or null SD,
+ * so legit A05 emissions are never silently lost.
+ *
+ * @param {string|null} sourceSdId
+ * @param {Object} supabase
+ * @returns {Promise<{ suppress: boolean, reason: string|null, sourceSdKey: string|null }>}
+ */
+export async function isSourceSDA05Suppressed(sourceSdId, supabase) {
+  if (!sourceSdId) return { suppress: false, reason: null, sourceSdKey: null };
+  try {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, sd_type, title, description, scope, key_changes')
+      .or(`sd_key.eq.${sourceSdId},id.eq.${sourceSdId}`)
+      .limit(1)
+      .maybeSingle();
+    if (error || !data) return { suppress: false, reason: null, sourceSdKey: null };
+    const reason = classifySourceSD(data);
+    return { suppress: !!reason, reason, sourceSdKey: data.sd_key || data.id };
+  } catch {
+    return { suppress: false, reason: null, sourceSdKey: null };
+  }
+}
+
 // ─── Supabase Client ──────────────────────────────────────────────────────────
 
 function getSupabase() {
@@ -370,6 +444,30 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     });
   }
 
+  // 5b. A05 source-class filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001).
+  // For source SDs that are read-only/CLI/validation-only, A05 (event_bus_integration)
+  // corrective generation is noise — strip A05 from each group's dims and drop the
+  // group entirely if no dims remain. Other dimensions still emit normally.
+  if (score.sd_id) {
+    const a05Verdict = await isSourceSDA05Suppressed(score.sd_id, supabase);
+    if (a05Verdict.suppress) {
+      let suppressedAny = false;
+      for (let i = groups.length - 1; i >= 0; i--) {
+        const beforeLen = groups[i].dims.length;
+        groups[i].dims = groups[i].dims.filter(d => d.dimId !== 'A05');
+        if (groups[i].dims.length < beforeLen) suppressedAny = true;
+        if (groups[i].dims.length === 0) groups.splice(i, 1);
+      }
+      if (suppressedAny) {
+        console.log(`[corrective-sd-generator] eva.corrective.skipped_a05 source_sd_id=${a05Verdict.sourceSdKey} reason=${a05Verdict.reason} total_score=${score.total_score ?? '?'}`);
+        await _logAudit(supabase, scoreId, 'skipped_a05_source_class', null, score.vision_id, {
+          source_sd_id: a05Verdict.sourceSdKey,
+          reason: a05Verdict.reason,
+        });
+      }
+    }
+  }
+
   // 6. Create one SD per group via createSD (standard LEO creation pipeline)
   const createdSDs = [];
   const allGeneratedIds = [...existingIds];
@@ -528,11 +626,11 @@ function _extractDimensionName(dimensionScores, totalScore) {
   return _extractLowestDimension(dimensionScores, totalScore).dimensionName;
 }
 
-async function _logAudit(supabase, scoreId, action, sdKey, visionId) {
+async function _logAudit(supabase, scoreId, action, sdKey, visionId, extra = null) {
   try {
     await supabase.from('brainstorm_sessions').insert({
       domain: 'protocol',
-      topic: `EVA Corrective SD: ${sdKey ?? 'accept (no SD)'}`,
+      topic: `EVA Corrective SD: ${sdKey ?? action}`,
       mode: 'structured',
       capabilities_status: 'not_checked',
       retrospective_status: 'pending',
@@ -542,6 +640,7 @@ async function _logAudit(supabase, scoreId, action, sdKey, visionId) {
         vision_id: visionId,
         action_taken: action,
         sd_key_created: sdKey ?? null,
+        ...(extra || {}),
       },
     });
   } catch {

--- a/tests/unit/eva/corrective-sd-generator-a05-filter.test.js
+++ b/tests/unit/eva/corrective-sd-generator-a05-filter.test.js
@@ -1,0 +1,146 @@
+/**
+ * Tests for A05 source-class filter
+ * SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+
+let classifySourceSD, isSourceSDA05Suppressed;
+
+beforeAll(async () => {
+  const mod = await import('../../../scripts/eva/corrective-sd-generator.mjs');
+  classifySourceSD = mod.classifySourceSD;
+  isSourceSDA05Suppressed = mod.isSourceSDA05Suppressed;
+});
+
+describe('classifySourceSD', () => {
+  it('CLI bugfix: returns cli_validation', () => {
+    const sd = {
+      sd_type: 'bugfix',
+      title: 'Fix CLI parser dependency lookup',
+      description: 'preflight validation parser fix',
+      scope: 'child-sd-preflight.js validation logic',
+      key_changes: [{ change: 'fix parser lookup', impact: 'preflight returns correct verdict' }],
+    };
+    expect(classifySourceSD(sd)).toBe('cli_validation');
+  });
+
+  it('Bugfix with single readonly keyword: returns readonly_bugfix', () => {
+    const sd = {
+      sd_type: 'bugfix',
+      title: 'Fix off-by-one in array slice',
+      description: 'array slice off-by-one fix',
+      scope: 'helper indexing',
+      key_changes: [{ change: 'index off-by-one', impact: 'corrected slice' }],
+    };
+    expect(classifySourceSD(sd)).toBe('readonly_bugfix');
+  });
+
+  it('Documentation SD: returns documentation', () => {
+    expect(classifySourceSD({ sd_type: 'documentation', title: 'docs', description: '', scope: '', key_changes: [] }))
+      .toBe('documentation');
+  });
+
+  it('Feature SD with backend writes: returns null (allow A05)', () => {
+    const sd = {
+      sd_type: 'feature',
+      title: 'Add user preferences API',
+      description: 'persist preferences and emit lifecycle events on update',
+      scope: 'API insert/update + event publishing',
+      key_changes: [{ change: 'persist prefs', impact: 'emit user.updated event' }],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+
+  it('Database migration SD: returns null (allow A05)', () => {
+    const sd = {
+      sd_type: 'database',
+      title: 'Add columns for new feature',
+      description: 'schema migration for ventures',
+      scope: 'migration: add new columns; insert seed data',
+      key_changes: [{ change: 'migration up', impact: 'schema evolution' }],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+
+  it('Null/empty source: returns null', () => {
+    expect(classifySourceSD(null)).toBeNull();
+    expect(classifySourceSD(undefined)).toBeNull();
+    expect(classifySourceSD({})).toBeNull();
+  });
+
+  it('Bugfix with write keywords (e.g. emit fix): returns null - not suppressed', () => {
+    const sd = {
+      sd_type: 'bugfix',
+      title: 'Fix event emission on stage completion',
+      description: 'publish event after persist; broadcast lifecycle update',
+      scope: 'webhook + emit fix',
+      key_changes: [],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+});
+
+describe('isSourceSDA05Suppressed', () => {
+  function makeSupabase(returnRow, throwError = false) {
+    return {
+      from: () => ({
+        select: () => ({
+          or: () => ({
+            limit: () => ({
+              maybeSingle: async () => {
+                if (throwError) throw new Error('db down');
+                return returnRow ? { data: returnRow, error: null } : { data: null, error: null };
+              },
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  it('Returns suppress=true for CLI bugfix source SD', async () => {
+    const sb = makeSupabase({
+      id: 'uuid-1', sd_key: 'SD-X', sd_type: 'bugfix',
+      title: 'CLI parser preflight fix', description: 'validation', scope: 'check',
+      key_changes: [{ change: 'parser fix' }],
+    });
+    const r = await isSourceSDA05Suppressed('SD-X', sb);
+    expect(r.suppress).toBe(true);
+    expect(r.reason).toBe('cli_validation');
+    expect(r.sourceSdKey).toBe('SD-X');
+  });
+
+  it('Returns suppress=false for feature SD with writes', async () => {
+    const sb = makeSupabase({
+      id: 'uuid-2', sd_key: 'SD-Y', sd_type: 'feature',
+      title: 'Add API endpoint', description: 'persist data and emit lifecycle event',
+      scope: 'insert/update + publish',
+      key_changes: [{ change: 'persist' }, { change: 'emit' }],
+    });
+    const r = await isSourceSDA05Suppressed('SD-Y', sb);
+    expect(r.suppress).toBe(false);
+    expect(r.reason).toBeNull();
+  });
+
+  it('Returns suppress=false on null sourceSdId (conservative default)', async () => {
+    const sb = makeSupabase(null);
+    const r = await isSourceSDA05Suppressed(null, sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('Returns suppress=false when source SD lookup fails (conservative default)', async () => {
+    const sb = makeSupabase(null, true);
+    const r = await isSourceSDA05Suppressed('SD-MISSING', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('Returns suppress=false when source SD not found in DB', async () => {
+    const sb = makeSupabase(null);
+    const r = await isSourceSDA05Suppressed('SD-NOTFOUND', sb);
+    expect(r.suppress).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `isSourceSDA05Suppressed` + `classifySourceSD` helpers in `scripts/eva/corrective-sd-generator.mjs` to skip A05 (event_bus_integration) corrective-SD generation when the source SD targets read-only CLI utilities or validation-only bugfixes
- Wires filter between groups computation (line ~360) and createSD loop (~377) — strips A05 from each group dims and drops empty groups, preserving non-A05 emissions in multi-dim groups
- Reduces observed 49% sibling cancellation rate (70/143 children of `SD-MAN-ORCH-EVA-VISION-GOVERNANCE-001`) by filtering false-positives at the generator instead of LEAD-side cancellation

## Test plan
- [x] All 12 new vitest cases pass in `tests/unit/eva/corrective-sd-generator-a05-filter.test.js`
- [x] Existing 42 tests in `corrective-sd-generator.test.js` and `corrective-sd-generator-multidim.test.js` remain green (no regressions)
- [ ] Runtime smoke test: replay score `d51f4062-0348-4c9e-abe5-ea52e455d24c` (SD-031 source) — expect zero A05 corrective SDs + audit log
- [ ] Negative smoke test: replay against a feature-SD source — expect A05 corrective still emitted

## PR Size Justification
247 LOC (103 source + 146 tests). Tier 3 acceptable: filter logic + comprehensive test coverage as atomic unit; tests are mandatory acceptance criteria per PRD FR-5.

## Out of scope (filed separately)
- Harness backlog id `84f83d1e`: `corrective-sd-generator.mjs:286` references undefined `options?.force` — ReferenceError on any score with `git_sha`. Distinct from this filter; will be a separate QF.

## Conservative defaults
- Source SD lookup failure → `suppress=false` (allow A05 emission). False-negatives are cheaper than false-positives.
- No schema changes. No new tables. Reuses existing `_logAudit` helper.

## Closes
- Reproducer SD: `SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-031` (cancelled 2026-05-02 against `SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001` CLI bugfix)
- Validation evidence: `sub_agent_execution_results.id=f8f20935-443f-4f4e-b63b-fa4095e032dd` (CONDITIONAL_PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)