### PR TITLE
feat(SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001): FR-1..FR-5 — finish SessionStart hook + tick fixes

### DIFF
--- a/scripts/hooks/__tests__/fr1-fr5-structural.test.js
+++ b/scripts/hooks/__tests__/fr1-fr5-structural.test.js
@@ -1,0 +1,122 @@
+/**
+ * FR-1, FR-2, FR-3, FR-4, FR-5 structural invariants
+ *
+ * SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001
+ *
+ * These cases pin the structural shape of the FRs that ship as follow-ups to
+ * FR-7 (which has its own test file: fr7-dotenv-self-load.test.js). They are
+ * source-grep assertions so a future commit cannot accidentally revert any FR
+ * without a vitest failure.
+ *
+ * Maps PRD test scenarios:
+ *   TS-002: FR-2 — per-attempt status logs remain debug-gated
+ *   TS-003: FR-2 — exhaustion stderr is always-on (no debug gate)
+ *   TS-004: FR-3 — /current pointer write is unconditional (not gated on sotOrdering)
+ *   TS-005: FR-1+FR-4 — session-tick first-tick POST + 409 idempotency
+ *   TS-007: FR-5 — self-kill timer value pinned to (12000, 13500]
+ *   TS-008: anti-foot-gun — vi.mock NOT used to simulate clean process.env
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const HOOK_PATH = resolve(REPO_ROOT, 'scripts/hooks/capture-session-id.cjs');
+const TICK_PATH = resolve(REPO_ROOT, 'scripts/session-tick.cjs');
+const FR7_TEST_PATH = resolve(__dirname, 'fr7-dotenv-self-load.test.js');
+const THIS_TEST_PATH = resolve(__dirname, 'fr1-fr5-structural.test.js');
+
+describe('FR-2: telemetry observability', () => {
+  it('TS-002: per-attempt status stderr remains debug-gated', () => {
+    const src = readFileSync(HOOK_PATH, 'utf8');
+    // The per-attempt status log MUST stay behind `if (debug)` so happy-path
+    // retries do not flood stderr.
+    expect(src).toMatch(/if \(debug\) \{\s*\n\s*console\.error\(`SessionStart:capture-session-id: upsert status=/);
+    expect(src).toMatch(/if \(debug\) \{\s*\n\s*console\.error\(`SessionStart:capture-session-id: upsert failed attempt=/);
+  });
+
+  it('TS-003: exhaustion stderr is always-on (no debug gate)', () => {
+    const src = readFileSync(HOOK_PATH, 'utf8');
+    const exhaustIdx = src.indexOf('upsert exhausted ${MAX_ATTEMPTS} attempts');
+    expect(exhaustIdx).toBeGreaterThan(0);
+    // Look at the 600 chars BEFORE the exhaustion log — that window covers the
+    // multi-line FR-2 marker comment block.
+    const preceding = src.slice(Math.max(0, exhaustIdx - 600), exhaustIdx);
+    // Must contain the FR-2 marker comment so future readers see why unconditional
+    expect(preceding).toMatch(/FR-2/);
+    expect(preceding).toMatch(/always-on/i);
+    // The console.error call must not be wrapped in `if (debug) {` immediately above.
+    // Last 80 chars before the call site must NOT contain the gate opening.
+    const last80 = src.slice(Math.max(0, exhaustIdx - 80), exhaustIdx);
+    expect(last80).not.toMatch(/if \(debug\)/);
+  });
+});
+
+describe('FR-3: unconditional /current pointer write', () => {
+  it('TS-004: /current write block is OUTSIDE if (sotOrdering)', () => {
+    const src = readFileSync(HOOK_PATH, 'utf8');
+    // The currentPointer declaration must be at outer scope (not inside if-sotOrdering).
+    // Verify by checking the block shape: const currentPointer = ... ; if (sotOrdering) { ... } else { fs.writeFileSync ... }
+    expect(src).toMatch(/const currentPointer = path\.join\(markerDir, 'current'\);\s*\n\s*if \(sotOrdering\) \{\s*\n\s*sotAtomicWrite\(currentPointer, sessionId\);\s*\n\s*\} else \{\s*\n\s*fs\.writeFileSync\(currentPointer, sessionId\);\s*\n\s*\}/);
+    // FR-3 marker comment must be present
+    expect(src).toMatch(/FR-3.*unconditional pointer write/i);
+  });
+});
+
+describe('FR-1+FR-4: session-tick first-tick INSERT-if-not-exists with race idempotency', () => {
+  it('TS-005a: tick has isFirstTick state', () => {
+    const src = readFileSync(TICK_PATH, 'utf8');
+    expect(src).toMatch(/let\s+isFirstTick\s*=\s*true/);
+  });
+
+  it('TS-005b: first-tick branch issues POST with merge-duplicates Prefer header', () => {
+    const src = readFileSync(TICK_PATH, 'utf8');
+    expect(src).toMatch(/method:\s*'POST'/);
+    expect(src).toMatch(/Prefer:\s*'resolution=merge-duplicates,return=minimal'/);
+  });
+
+  it('TS-005c: 409 response treated as success (race-on-race idempotency)', () => {
+    const src = readFileSync(TICK_PATH, 'utf8');
+    // Must check both res.ok AND res.status === 409 for first-tick success path
+    expect(src).toMatch(/res\.ok\s*\|\|\s*res\.status\s*===\s*409/);
+    // After success/409, isFirstTick must flip to false so subsequent ticks PATCH
+    expect(src).toMatch(/isFirstTick\s*=\s*false/);
+  });
+
+  it('TS-005d: subsequent ticks (isFirstTick=false) revert to PATCH', () => {
+    const src = readFileSync(TICK_PATH, 'utf8');
+    // The else branch (steady state) must use PATCH, not POST
+    expect(src).toMatch(/\}\s*else\s*\{[\s\S]{0,500}method:\s*'PATCH'/);
+  });
+});
+
+describe('FR-5: self-kill timer invariant', () => {
+  it('TS-007: timer value is in (12000, 13500]', () => {
+    const src = readFileSync(HOOK_PATH, 'utf8');
+    // Find the top-level setTimeout(resolve, N); inside main()'s Promise wrapper.
+    const match = src.match(/setTimeout\(\s*resolve\s*,\s*(\d+)\s*\)/);
+    expect(match).not.toBeNull();
+    const ms = Number(match[1]);
+    expect(ms).toBeGreaterThan(12000);
+    expect(ms).toBeLessThanOrEqual(13500);
+  });
+});
+
+describe('TS-008: anti-foot-gun lint — tests use child_process.spawn, NOT mocking for env', () => {
+  // Per VALIDATION risk #3 / reference_vi_mock_masks_broken_import.md,
+  // simulating a clean process env via test-framework mocking can mask the very
+  // bug FR-7 fixes. Lint scans the FR-7 test (the integration test) and rejects
+  // mock-of-process patterns. The structural test file (this one) is exempt
+  // because its assertions are pure source-grep with no env simulation at all.
+  it('FR-7 integration test does not mock process or process.env', () => {
+    const src = readFileSync(FR7_TEST_PATH, 'utf8');
+    // Strip line-comments before scanning so descriptive text in comments
+    // does not trigger a false-positive against the lint pattern.
+    const codeOnly = src.split('\n').map(line => line.replace(/\/\/.*$/, '')).join('\n');
+    expect(codeOnly).not.toMatch(/vi\.mock\s*\(\s*['"](node:)?process['"]\s*\)/);
+    expect(codeOnly).not.toMatch(/vi\.spyOn\s*\(\s*process\.env\b/);
+    // Positive assertion: FR-7 integration test must use spawnWithCleanEnv helper
+    expect(codeOnly).toMatch(/spawnWithCleanEnv\s*\(/);
+  });
+});

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -570,9 +570,16 @@ function main() {
     });
 
     // Timeout must exceed the internal PowerShell budget (tree_walk + scan = 9s).
-    // Registered hook timeout in .claude/settings.json is 15s; 12s leaves 3s margin
-    // for marker write + cleanup before Claude Code kills the process.
-    setTimeout(resolve, 12000);
+    // Registered hook timeout in .claude/settings.json is 15s.
+    //
+    // SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 (FR-5): bumped 12000ms → 13500ms.
+    // Belt-and-suspenders after FR-1+FR-4+FR-7 land — gives the upsert + tick spawn
+    // path more headroom on slow Windows tree-walks (TREE_WALK_TIMEOUT_MS=6000 +
+    // SCAN_TIMEOUT_MS=3000 + 3-attempt upsert ~11s could exceed the 12s budget).
+    // Per DESIGN consolidation #2 in metadata.design_plan_recommendations: shipped
+    // as separately revertible commit so it can be reverted independently if the
+    // structural fixes prove sufficient without the timer extension.
+    setTimeout(resolve, 13500);
   });
 }
 

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -355,9 +355,11 @@ async function upsertSessionRow(sessionId, ccPid, source) {
     }
   }
 
-  if (debug) {
-    console.error(`SessionStart:capture-session-id: upsert exhausted ${MAX_ATTEMPTS} attempts (last_status=${lastStatus}, last_error=${lastError?.message || 'n/a'})`);
-  }
+  // SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 (FR-2): exhaustion stderr is always-on.
+  // Per-attempt logs (lines 334/340/350) remain debug-gated to keep happy-path noise low,
+  // but exhaustion (3 retries failed) is never silent — operator-trust violation tracked
+  // across 5 prior reproductions of failure mode F.
+  console.error(`SessionStart:capture-session-id: upsert exhausted ${MAX_ATTEMPTS} attempts (last_status=${lastStatus}, last_error=${lastError?.message || 'n/a'})`);
 }
 
 function main() {
@@ -457,9 +459,18 @@ function main() {
           // When SOT is enabled, atomically update the /current pointer to match.
           // This is the third identity source — once it's written, claim-validity-gate
           // sees all three in agreement.
+          //
+          // SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 (FR-3): unconditional pointer write.
+          // Previously gated on sotOrdering — left /current 8.5+ days stale under SOT-off
+          // (the default), pointing at unrelated sessions. claim-validity-gate observers
+          // need /current to be a deterministic third source regardless of SOT flag state.
+          // Atomic semantics preserved: sotAtomicWrite under SOT-on, plain writeFileSync
+          // under SOT-off (writeFileSync is atomic for small payloads on Windows).
+          const currentPointer = path.join(markerDir, 'current');
           if (sotOrdering) {
-            const currentPointer = path.join(markerDir, 'current');
             sotAtomicWrite(currentPointer, sessionId);
+          } else {
+            fs.writeFileSync(currentPointer, sessionId);
           }
 
           // Cleanup old markers — preserve markers for alive PIDs, only delete dead ones

--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -98,38 +98,79 @@ function parentAlive() {
 
 // ── Telemetry write ──────────────────────────────────────────────────────────
 
+// SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 (FR-1+FR-4): first-tick recovery path.
+// Originally tickOnce always PATCHed — when no row existed (because
+// capture-session-id.cjs upsert silent-failed at SessionStart), every tick was
+// a 0-row no-op. Now the first tick after spawn does a POST with
+// resolution=merge-duplicates so the row is created if missing. UNIQUE(session_id)
+// + onConflict=session_id provides idempotency at the DB level. Subsequent ticks
+// revert to PATCH so steady-state cost is unchanged.
+let isFirstTick = true;
+
 async function tickOnce() {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !supabaseKey) return;
 
-  const url =
-    `${supabaseUrl.replace(/\/$/, '')}/rest/v1/claude_sessions` +
-    `?session_id=eq.${encodeURIComponent(sessionId)}`;
-
+  const baseUrl = `${supabaseUrl.replace(/\/$/, '')}/rest/v1/claude_sessions`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+  const debug = process.env.LEO_TELEMETRY_DEBUG === '1';
 
   try {
-    // SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4: update BOTH columns.
-    // claim-guard.mjs keys claim TTL on heartbeat_at (300s stale threshold).
-    // Updating only process_alive_at leaves the claim vulnerable to stale-claim
-    // cleanup during long Edit/Write/Read bursts that don't invoke any CLI script.
     const now = new Date().toISOString();
-    await fetch(url, {
-      method: 'PATCH',
-      headers: {
-        apikey: supabaseKey,
-        Authorization: `Bearer ${supabaseKey}`,
-        'Content-Type': 'application/json',
-        Prefer: 'return=minimal',
-      },
-      body: JSON.stringify({
-        process_alive_at: now,
-        heartbeat_at: now,
-      }),
-      signal: controller.signal,
-    });
+    if (isFirstTick) {
+      // FR-1+FR-4: insert-if-not-exists (POST + merge-duplicates) so a missing row
+      // self-heals within ~30s. UNIQUE(session_id) + 409 path treated as success
+      // gives race-on-race idempotency with capture-session-id.cjs upsertSessionRow.
+      const res = await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+          'Content-Type': 'application/json',
+          Prefer: 'resolution=merge-duplicates,return=minimal',
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+          status: 'active',
+          heartbeat_at: now,
+          process_alive_at: now,
+          pid: process.pid,
+          hostname: require('os').hostname(),
+          metadata: { cc_parent_pid: parentPid, source: 'session-tick-first' },
+        }),
+        signal: controller.signal,
+      });
+      // 2xx OR 409/conflict → row exists, ticks can revert to PATCH.
+      if (res.ok || res.status === 409) {
+        isFirstTick = false;
+        if (debug && res.status === 409) {
+          console.error(`session-tick: first-tick POST 409 (row already existed) — race resolved, switching to PATCH`);
+        }
+      } else {
+        // Non-success: leave isFirstTick=true so the next tick retries the POST.
+        if (debug) console.error(`session-tick: first-tick POST status=${res.status} — will retry on next tick`);
+      }
+    } else {
+      // Steady state — SD-LEO-INFRA-PROTOCOL-ENFORCEMENT-001 FR-4: update BOTH columns.
+      // claim-guard.mjs keys claim TTL on heartbeat_at (300s stale threshold).
+      const url = `${baseUrl}?session_id=eq.${encodeURIComponent(sessionId)}`;
+      await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        },
+        body: JSON.stringify({
+          process_alive_at: now,
+          heartbeat_at: now,
+        }),
+        signal: controller.signal,
+      });
+    }
   } catch {
     // swallow — next tick will retry. Never crash the tick loop.
   } finally {


### PR DESCRIPTION
## Summary

Follow-up to **PR #3489** (FR-7 dotenv self-load, already merged). Completes the remaining FRs from `PRD-SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001`.

- **FR-1 + FR-4** (`session-tick.cjs`): first-tick after spawn now POSTs `claude_sessions` with `Prefer: resolution=merge-duplicates`. UNIQUE(session_id) + treating HTTP 409 as success delivers race-on-race idempotency with `capture-session-id.cjs`'s own upsert. Subsequent ticks revert to PATCH so steady-state cost is unchanged.
- **FR-2** (`capture-session-id.cjs:343-345`): drop the `LEO_TELEMETRY_DEBUG=1` gate on the exhaustion stderr line. Per-attempt status logs stay debug-gated.
- **FR-3** (`capture-session-id.cjs:445-448`): unconditional `/current` pointer write (previously gated on `sotOrdering`, leaving the pointer 8.5+ days stale under SOT-off — the default).
- **FR-5** (`capture-session-id.cjs:549`, separate revertible commit per DESIGN #2): self-kill timer 12000ms → 13500ms.
- **Test coverage**: 9 new vitest cases in `scripts/hooks/__tests__/fr1-fr5-structural.test.js` covering TS-002, TS-003, TS-004, TS-005a-d, TS-007, TS-008.

## Why split from PR #3489

PR #3489 shipped FR-7 (the root-cause fix for failure mode F) in isolation so the meta-recursive blocker — the bug that prevented LEAD-TO-PLAN handoff for this very SD — could close cleanly. With the GATE_CLAIM_VALIDITY pipeline now functional, this PR finishes the SD scope per PRD.

## Commit layout (separately revertible per DESIGN #2)

1. `0140e36a89` FR-2 + FR-3 (capture-session-id.cjs telemetry surface + pointer write)
2. `e31f8f5402` FR-1 + FR-4 (session-tick first-tick INSERT-if-not-exists)
3. `ba627e43da` FR-5 (self-kill timer bump — independently revertible)
4. `01f0afc2c1` Vitest structural invariants for all four FRs

## Test plan

- [x] `npx vitest run scripts/hooks/__tests__/fr1-fr5-structural.test.js scripts/hooks/__tests__/fr7-dotenv-self-load.test.js` → 13/13 green
- [ ] Manual smoke 1: launch a fresh CC session from a clean PowerShell. Verify `claude_sessions` row appears within ~5s (FR-7 fast path) and that subsequent heartbeats land via PATCH.
- [ ] Manual smoke 2: artificially break the SessionStart hook upsert (e.g., temporarily revert FR-7) and verify FR-1+FR-4 in `session-tick.cjs` recovers the row within ~30s of the first tick.
- [ ] Manual smoke 3: verify `.claude/session-identity/current` mtime updates on every fresh CC session start (FR-3).
- [ ] After merge: remove `LEO_TELEMETRY_DEBUG=1` from `.claude/settings.json` line 4 (was diagnostic only).

## DESIGN consolidations honored

- **#1** Collapse FR-1 into FR-4 — single mechanism (insert-if-not-exists in tick) ✓
- **#2** FR-5 timer bump shipped in own commit `ba627e43da` ✓
- **#3** Test coverage 5+ scenarios — TS-002/003/004/005a-d/007/008 + FR-7's TS-001/006 = 13 cases ✓
- **#4** FR-3 (unconditional `/current` write) shipped in own commit ✓ (sequenced with FR-2 in `0140e36a89` since both are line-level changes in the same file region)

## Closes

This PR + PR #3489 together deliver the full PRD scope for SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 — closes the 5-reproduction silent-fail history of `claude_sessions` row missing post-SessionStart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)