### PR TITLE
feat(SD-LEO-FIX-REORDER-RELEASECLAIM-CLEAR-001): migrate releaseClaim to atomic release_sd RPC

### DIFF
--- a/scripts/modules/handoff/claim-swapper.js
+++ b/scripts/modules/handoff/claim-swapper.js
@@ -88,27 +88,43 @@ export async function swapClaim(supabase, { sessionId, oldSdKey, newSdKey }) {
  */
 export async function releaseClaim(supabase, sessionId, sdKey) {
   try {
-    const { data, error } = await supabase
+    // Pre-check holds caller-side safety: confirm session actually holds sdKey.
+    // The atomic RPC below is session-scoped (releases whatever the session
+    // holds) so this guards against caller-side bugs where the wrong sdKey is
+    // passed.
+    const { data: session, error: selectError } = await supabase
       .from('claude_sessions')
-      .update({
-        sd_key: null,
-        released_at: new Date().toISOString()
-      })
+      .select('sd_key')
       .eq('session_id', sessionId)
-      .eq('sd_key', sdKey)
-      .select('session_id');
+      .maybeSingle();
+
+    if (selectError) {
+      return { success: false, reason: `DB error: ${selectError.message}` };
+    }
+    if (!session) {
+      return { success: false, reason: `Session ${sessionId} not found` };
+    }
+    if (session.sd_key !== sdKey) {
+      return { success: false, reason: `Session does not hold claim on ${sdKey}` };
+    }
+
+    // Atomic release via release_sd RPC (migration 20260502_release_clear_worktree_state.sql):
+    // single UPDATE NULLs sd_key, worktree_path, worktree_branch together so the
+    // ck_claude_sessions_worktree_state_consistency invariant holds at every
+    // observable row state. Also clears claiming_session_id / active_session_id
+    // on the SD row, fixing the partial-cleanup class where releaseClaim only
+    // touched claude_sessions.
+    const { data, error } = await supabase.rpc('release_sd', {
+      p_session_id: sessionId,
+      p_reason: 'release_claim'
+    });
 
     if (error) {
       return { success: false, reason: `DB error: ${error.message}` };
     }
-
-    if (!data || data.length === 0) {
-      return { success: false, reason: `Session does not hold claim on ${sdKey}` };
+    if (data && data.success === false) {
+      return { success: false, reason: data.error || data.message || 'release_sd RPC reported failure' };
     }
-
-    // FR-2: clear worktree state through the single-owner writer so the
-    // (sd_key, worktree_*) invariant holds. Audit log line emitted by writer.
-    await clearWorktreeState(sessionId, { supabase, reason: 'release_claim' });
 
     return { success: true, reason: `Released ${sdKey}` };
   } catch (err) {

--- a/scripts/modules/handoff/claim-swapper.test.js
+++ b/scripts/modules/handoff/claim-swapper.test.js
@@ -77,40 +77,78 @@ describe('swapClaim — FR-2 wiring', () => {
   });
 });
 
-describe('releaseClaim — FR-2 wiring', () => {
-  it('UPDATE payload does NOT contain worktree_path or worktree_branch', async () => {
-    const supabase = makeSupabase([{ session_id: 'S1' }]);
-    await releaseClaim(supabase, 'S1', 'SD-OLD');
-
-    const updateArg = supabase._spies.update.mock.calls[0][0];
-    expect(updateArg).not.toHaveProperty('worktree_path');
-    expect(updateArg).not.toHaveProperty('worktree_branch');
+function makeReleaseSupabase({ noSession = false, heldSdKey = 'SD-OLD', selectError = null, rpcError = null, rpcResult = { success: true } } = {}) {
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: noSession ? null : { sd_key: heldSdKey },
+    error: selectError
   });
+  const eqSession = vi.fn().mockReturnValue({ maybeSingle });
+  const select = vi.fn().mockReturnValue({ eq: eqSession });
+  const from = vi.fn().mockReturnValue({ select });
+  const rpc = vi.fn().mockResolvedValue({ data: rpcResult, error: rpcError });
+  return { from, rpc, _spies: { from, select, eqSession, maybeSingle, rpc } };
+}
 
-  it('invokes clearWorktreeState after a successful release', async () => {
-    const supabase = makeSupabase([{ session_id: 'S1' }]);
-    await releaseClaim(supabase, 'S1', 'SD-OLD');
-
-    expect(clearWorktreeStateMock).toHaveBeenCalledTimes(1);
-    expect(clearWorktreeStateMock).toHaveBeenCalledWith('S1', expect.objectContaining({
-      supabase,
-      reason: 'release_claim'
-    }));
-  });
-
-  it('does NOT invoke clearWorktreeState when no row matched (session does not hold claim)', async () => {
-    const supabase = makeSupabase([]);
+describe('releaseClaim — atomic release_sd RPC', () => {
+  it('invokes release_sd RPC with session_id + reason after pre-check passes', async () => {
+    const supabase = makeReleaseSupabase({ heldSdKey: 'SD-OLD' });
     const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(supabase._spies.rpc).toHaveBeenCalledTimes(1);
+    expect(supabase._spies.rpc).toHaveBeenCalledWith('release_sd', {
+      p_session_id: 'S1',
+      p_reason: 'release_claim'
+    });
+  });
+
+  it('does NOT invoke clearWorktreeState directly (RPC handles worktree clear server-side)', async () => {
+    const supabase = makeReleaseSupabase({ heldSdKey: 'SD-OLD' });
+    await releaseClaim(supabase, 'S1', 'SD-OLD');
+
     expect(clearWorktreeStateMock).not.toHaveBeenCalled();
   });
 
-  it('does NOT invoke clearWorktreeState when the release UPDATE returned a DB error', async () => {
-    const supabase = makeSupabase(null, { message: 'connection lost' });
+  it('returns failure when session row not found, without invoking RPC', async () => {
+    const supabase = makeReleaseSupabase({ noSession: true });
     const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
 
     expect(result.success).toBe(false);
-    expect(clearWorktreeStateMock).not.toHaveBeenCalled();
+    expect(result.reason).toMatch(/not found/);
+    expect(supabase._spies.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when session holds a different sdKey, without invoking RPC', async () => {
+    const supabase = makeReleaseSupabase({ heldSdKey: 'SD-OTHER' });
+    const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toMatch(/does not hold claim/);
+    expect(supabase._spies.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when pre-check SELECT errors, without invoking RPC', async () => {
+    const supabase = makeReleaseSupabase({ selectError: { message: 'connection lost' } });
+    const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toMatch(/connection lost/);
+    expect(supabase._spies.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when release_sd RPC returns a DB error', async () => {
+    const supabase = makeReleaseSupabase({ heldSdKey: 'SD-OLD', rpcError: { message: 'permission denied' } });
+    const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toMatch(/permission denied/);
+  });
+
+  it('returns failure when release_sd RPC reports success=false in payload', async () => {
+    const supabase = makeReleaseSupabase({ heldSdKey: 'SD-OLD', rpcResult: { success: false, error: 'session_not_found' } });
+    const result = await releaseClaim(supabase, 'S1', 'SD-OLD');
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toMatch(/session_not_found/);
   });
 });


### PR DESCRIPTION
## Summary
- Replaces manual 2-step (UPDATE sd_key=null + clearWorktreeState) in `claim-swapper.releaseClaim()` with a single `supabase.rpc('release_sd', ...)` call
- The 2-step violates `ck_claude_sessions_worktree_state_consistency` CHECK constraint when worktree_* columns are populated; the atomic RPC nulls sd_key + worktree_path + worktree_branch + claiming_session_id in one UPDATE
- Adds pre-check SELECT to verify session holds the requested sdKey before invoking the RPC
- Aligns the test-only function with the established production pattern — 12 production callers (claim-command.js, claim-guard.mjs, session-manager.mjs, etc.) already use `release_sd` RPC directly

## Closes
- Inbox `da91527d-679c-47b2-8627-3780b7a4575f` (CHECK constraint violation, severity=high)
- Inbox `5b5b959e-0634-43bf-b13f-09ea7400c133` partially (orphaned `claiming_session_id` — full closure needs separate canonical `scripts/cancel-sd.js`)

## Escalation chain
- Started as QF-20260502-737 (Tier 1, "reorder 2 calls", 20 LOC)
- Scope grew to 88 LOC after discovering the atomic RPC was the right answer
- Escalated to SD via `--from-qf` flag
- Linked: `quick_fixes.QF-20260502-737.escalated_to_sd_id` → this SD

## Test plan
- [x] 12/12 unit tests in `scripts/modules/handoff/claim-swapper.test.js` pass
- [x] 7 new tests cover RPC invocation params, pre-check pass/fail/error, RPC error propagation
- [x] Zero regressions (15 broader test failures in `scripts/modules/handoff/` confirmed pre-existing on main via stash+checkout reproduction)
- [ ] Post-merge: integration test `tests/integration/worktree-state-atomicity.test.js` TS-1 with `RUN_DB_INTEGRATION_WORKTREE_STATE=1`
- [ ] Post-merge: spot-check `releaseClaim` is invoked correctly by any future production caller

## Sub-agent evidence
- VALIDATION: `43a92c17-9589-470f-ab3a-5b5e8b7de6e1` (PASS, 92)
- EXPLORE: `b3df9b7d-2791-40e1-830a-6365b9439d4c` (PASS, 92)
- TESTING: `7facfdee-5b2b-4f07-93e1-05a28ba20ee9` (PASS, 95)
- SECURITY: `460a0806-c973-4333-a382-ba3ec988e940` (PASS, 92)

## LEO handoffs (all PASS)
- LEAD-TO-PLAN: 93
- PLAN-TO-EXEC: 92
- EXEC-TO-PLAN: 92
- PLAN-TO-LEAD: 98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>