### PR TITLE
feat(SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001): extend corrective-sd-generator filter to A01-A05 + lifecycle-feature classifier

### DIFF
--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -88,13 +88,28 @@ export const WRITE_KEYWORDS = [
 ];
 export const READONLY_BUGFIX_TYPES = new Set(['bugfix', 'fix', 'documentation']);
 
+// SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001: lifecycle-feature heuristic.
+// Feature-type SDs that touch only session/lifecycle plumbing (e.g. session-id
+// capture, hook installation, identity persistence) legitimately do not address
+// architectural dimensions. They were previously bypassing classification because
+// READONLY_BUGFIX_TYPES omits 'feature'.
+export const LIFECYCLE_FEATURE_KEYWORDS = [
+  'session', 'hook', 'capture', 'sessionstart', 'lifecycle', 'identity',
+];
+
+// SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001: dimension set stripped when a
+// source is suppression-eligible. Previously only A05 was stripped, leaving
+// A01-A04 to emit identical noise correctives (see cancelled SDs 040/041/042).
+export const SUPPRESSED_ARCHITECTURAL_DIMS = new Set(['A01', 'A02', 'A03', 'A04', 'A05']);
+
 /**
- * Lightweight classifier: inspect SD shape and return reason if A05 corrective
- * should be suppressed. Returns null when no suppression match (allow A05).
+ * Lightweight classifier: inspect SD shape and return reason if architectural
+ * correctives should be suppressed. Returns null when no suppression match.
  * Pure / synchronous so it is unit-testable without a Supabase client.
  *
  * @param {Object} sd - { sd_type, scope, key_changes, title, description }
- * @returns {string|null} reason like 'cli_validation' / 'readonly_bugfix' or null
+ * @returns {string|null} reason like 'cli_validation' / 'readonly_bugfix' /
+ *   'documentation' / 'lifecycle_feature' or null
  */
 export function classifySourceSD(sd) {
   if (!sd) return null;
@@ -116,6 +131,20 @@ export function classifySourceSD(sd) {
     return 'readonly_bugfix';
   }
   if (sdType === 'documentation') return 'documentation';
+
+  // Conservative lifecycle-feature path: feature-type SD with at least one
+  // lifecycle keyword AND zero STRICT write verbs. The strict-write count
+  // excludes 'lifecycle' itself (it sits in WRITE_KEYWORDS as a domain noun
+  // that describes lifecycle-themed SDs, not a write action) — otherwise any
+  // SD describing itself as "lifecycle hook" trips the write floor and never
+  // reaches this branch. Real write verbs (persist, emit, publish, insert,
+  // update, migration, schema, broadcast, webhook, event) still bump the count
+  // and disqualify the SD from suppression.
+  if (sdType === 'feature') {
+    const lifecycleMatches = LIFECYCLE_FEATURE_KEYWORDS.filter(k => text.includes(k)).length;
+    const strictWriteMatches = WRITE_KEYWORDS.filter(k => k !== 'lifecycle' && text.includes(k)).length;
+    if (lifecycleMatches >= 1 && strictWriteMatches === 0) return 'lifecycle_feature';
+  }
 
   return null;
 }
@@ -444,25 +473,36 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     });
   }
 
-  // 5b. A05 source-class filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001).
-  // For source SDs that are read-only/CLI/validation-only, A05 (event_bus_integration)
-  // corrective generation is noise — strip A05 from each group's dims and drop the
-  // group entirely if no dims remain. Other dimensions still emit normally.
+  // 5b. Architectural source-class filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001
+  // shipped A05-only; SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001 extends to A01-A05).
+  // For source SDs classified as read-only/CLI/documentation/lifecycle-feature, the
+  // entire architectural row (A01-A05) is noise because the SD does not change
+  // architecture. Strip all A-dims from each group; V-dims pass through. Drop empty
+  // groups. Other dimensions still emit normally for non-suppressed sources.
   if (score.sd_id) {
-    const a05Verdict = await isSourceSDA05Suppressed(score.sd_id, supabase);
-    if (a05Verdict.suppress) {
+    const verdict = await isSourceSDA05Suppressed(score.sd_id, supabase);
+    if (verdict.suppress) {
       let suppressedAny = false;
+      const suppressedDims = new Set();
       for (let i = groups.length - 1; i >= 0; i--) {
         const beforeLen = groups[i].dims.length;
-        groups[i].dims = groups[i].dims.filter(d => d.dimId !== 'A05');
+        for (const d of groups[i].dims) {
+          if (SUPPRESSED_ARCHITECTURAL_DIMS.has(d.dimId)) suppressedDims.add(d.dimId);
+        }
+        groups[i].dims = groups[i].dims.filter(d => !SUPPRESSED_ARCHITECTURAL_DIMS.has(d.dimId));
         if (groups[i].dims.length < beforeLen) suppressedAny = true;
         if (groups[i].dims.length === 0) groups.splice(i, 1);
       }
       if (suppressedAny) {
-        console.log(`[corrective-sd-generator] eva.corrective.skipped_a05 source_sd_id=${a05Verdict.sourceSdKey} reason=${a05Verdict.reason} total_score=${score.total_score ?? '?'}`);
-        await _logAudit(supabase, scoreId, 'skipped_a05_source_class', null, score.vision_id, {
-          source_sd_id: a05Verdict.sourceSdKey,
-          reason: a05Verdict.reason,
+        const eventType = verdict.reason === 'lifecycle_feature'
+          ? 'skipped_lifecycle_feature_class'
+          : 'skipped_a05_source_class';
+        const dimsList = [...suppressedDims].sort().join(',');
+        console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${verdict.sourceSdKey} reason=${verdict.reason} dims=${dimsList} total_score=${score.total_score ?? '?'}`);
+        await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
+          source_sd_id: verdict.sourceSdKey,
+          reason: verdict.reason,
+          suppressed_dims: [...suppressedDims].sort(),
         });
       }
     }

--- a/tests/unit/eva/corrective-sd-generator-lifecycle-feature-filter.test.js
+++ b/tests/unit/eva/corrective-sd-generator-lifecycle-feature-filter.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for lifecycle-feature classifier path + full A01-A05 dimension strip.
+ * SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001
+ *
+ * Follows the mock pattern established by corrective-sd-generator-a05-filter.test.js
+ * (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001).
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+
+let classifySourceSD, isSourceSDA05Suppressed, SUPPRESSED_ARCHITECTURAL_DIMS, LIFECYCLE_FEATURE_KEYWORDS;
+
+beforeAll(async () => {
+  const mod = await import('../../../scripts/eva/corrective-sd-generator.mjs');
+  classifySourceSD = mod.classifySourceSD;
+  isSourceSDA05Suppressed = mod.isSourceSDA05Suppressed;
+  SUPPRESSED_ARCHITECTURAL_DIMS = mod.SUPPRESSED_ARCHITECTURAL_DIMS;
+  LIFECYCLE_FEATURE_KEYWORDS = mod.LIFECYCLE_FEATURE_KEYWORDS;
+});
+
+describe('classifySourceSD: lifecycle-feature path', () => {
+  it('feature SD with session/hook keywords + zero writes returns lifecycle_feature', () => {
+    // Mirrors the source SD that triggered cancelled noise SDs 040/041/042
+    // (SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001).
+    const sd = {
+      sd_type: 'feature',
+      title: 'SessionStart hook capture-session-id.cjs identity record',
+      description: 'capture session identity on SessionStart hook fire',
+      scope: 'session lifecycle plumbing only',
+      key_changes: [{ change: 'add session capture hook', impact: 'identity row exists' }],
+    };
+    expect(classifySourceSD(sd)).toBe('lifecycle_feature');
+  });
+
+  it('feature SD with single lifecycle keyword still triggers (>=1 threshold)', () => {
+    const sd = {
+      sd_type: 'feature',
+      title: 'Add identity badge to header',
+      description: 'show user identity',
+      scope: 'header component',
+      key_changes: [],
+    };
+    expect(classifySourceSD(sd)).toBe('lifecycle_feature');
+  });
+
+  it('feature SD without lifecycle keywords returns null', () => {
+    const sd = {
+      sd_type: 'feature',
+      title: 'Add user dashboard component',
+      description: 'show metrics',
+      scope: 'dashboard ui',
+      key_changes: [{ change: 'render dashboard', impact: 'visible to user' }],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+
+  it('feature SD with lifecycle keyword AND write keyword returns null (write floor)', () => {
+    // The conservative path: a feature that BOTH is lifecycle-themed AND emits/persists
+    // is genuine architectural surface — must not be suppressed.
+    const sd = {
+      sd_type: 'feature',
+      title: 'Persist session identity and emit lifecycle event on capture',
+      description: 'persist + emit on session start',
+      scope: 'session lifecycle backend',
+      key_changes: [],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+
+  it('non-feature type with lifecycle keywords does not trigger lifecycle path', () => {
+    // Documentation SD with "session" word should still classify via documentation
+    // branch, NOT via lifecycle_feature. Fixture avoids strict write verbs (update,
+    // persist, etc.) since those would trigger the writeMatches >= 2 short-circuit.
+    const sd = {
+      sd_type: 'documentation',
+      title: 'Document session capture flow',
+      description: 'docs',
+      scope: 'docs only',
+      key_changes: [],
+    };
+    expect(classifySourceSD(sd)).toBe('documentation');
+  });
+
+  it('feature SD with write keyword count exactly 1 still suppressed (writeMatches===0 is required)', () => {
+    // Edge case: writeMatches must be EXACTLY 0 for the lifecycle-feature path.
+    // A single write keyword fails the >=2 short-circuit but also fails the ===0 floor.
+    const sd = {
+      sd_type: 'feature',
+      title: 'SessionStart hook with persist',
+      description: 'capture session identity',
+      scope: 'capture',
+      key_changes: [{ change: 'capture hook', impact: 'identity captured' }],
+    };
+    // 'persist' (write) appears once → fails writeMatches===0 → returns null
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+});
+
+describe('Existing classifier paths unchanged', () => {
+  it('CLI bugfix still returns cli_validation', () => {
+    const sd = {
+      sd_type: 'bugfix',
+      title: 'Fix CLI parser preflight validation',
+      description: 'parsing fix',
+      scope: 'cli check',
+      key_changes: [],
+    };
+    expect(classifySourceSD(sd)).toBe('cli_validation');
+  });
+
+  it('Documentation SD still returns documentation', () => {
+    expect(classifySourceSD({ sd_type: 'documentation', title: 'docs', description: '', scope: '', key_changes: [] }))
+      .toBe('documentation');
+  });
+
+  it('Write-heavy feature still returns null', () => {
+    const sd = {
+      sd_type: 'feature',
+      title: 'Add user preferences API',
+      description: 'persist preferences and emit lifecycle events on update',
+      scope: 'API insert/update + event publishing',
+      key_changes: [{ change: 'persist prefs', impact: 'emit user.updated event' }],
+    };
+    expect(classifySourceSD(sd)).toBeNull();
+  });
+
+  it('Null/empty source still returns null', () => {
+    expect(classifySourceSD(null)).toBeNull();
+    expect(classifySourceSD(undefined)).toBeNull();
+    expect(classifySourceSD({})).toBeNull();
+  });
+});
+
+describe('SUPPRESSED_ARCHITECTURAL_DIMS contract', () => {
+  it('contains exactly A01-A05', () => {
+    expect([...SUPPRESSED_ARCHITECTURAL_DIMS].sort()).toEqual(['A01', 'A02', 'A03', 'A04', 'A05']);
+  });
+
+  it('does not contain V-dimensions (vision pass-through)', () => {
+    expect(SUPPRESSED_ARCHITECTURAL_DIMS.has('V01')).toBe(false);
+    expect(SUPPRESSED_ARCHITECTURAL_DIMS.has('V07')).toBe(false);
+    expect(SUPPRESSED_ARCHITECTURAL_DIMS.has('V11')).toBe(false);
+  });
+
+  it('does not contain A06+ (out-of-band architectural extensions, if any)', () => {
+    expect(SUPPRESSED_ARCHITECTURAL_DIMS.has('A06')).toBe(false);
+    expect(SUPPRESSED_ARCHITECTURAL_DIMS.has('A07')).toBe(false);
+  });
+});
+
+describe('LIFECYCLE_FEATURE_KEYWORDS contract', () => {
+  it('contains the six core lifecycle terms', () => {
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('session');
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('hook');
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('capture');
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('sessionstart');
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('lifecycle');
+    expect(LIFECYCLE_FEATURE_KEYWORDS).toContain('identity');
+  });
+});
+
+describe('isSourceSDA05Suppressed: lifecycle_feature reason propagation', () => {
+  function makeSupabase(returnRow) {
+    return {
+      from: () => ({
+        select: () => ({
+          or: () => ({
+            limit: () => ({
+              maybeSingle: async () => ({ data: returnRow, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  it('lifecycle-feature source returns suppress=true with reason=lifecycle_feature', async () => {
+    const sb = makeSupabase({
+      id: 'uuid-lf', sd_key: 'SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001', sd_type: 'feature',
+      title: 'SessionStart hook capture-session-id.cjs',
+      description: 'capture session identity',
+      scope: 'session lifecycle hook',
+      key_changes: [],
+    });
+    const r = await isSourceSDA05Suppressed('SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001', sb);
+    expect(r.suppress).toBe(true);
+    expect(r.reason).toBe('lifecycle_feature');
+    expect(r.sourceSdKey).toBe('SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001');
+  });
+
+  it('write-heavy feature source returns suppress=false', async () => {
+    const sb = makeSupabase({
+      id: 'uuid-wh', sd_key: 'SD-FEAT-API-001', sd_type: 'feature',
+      title: 'Persist preferences and emit lifecycle event',
+      description: 'API endpoint that persists and broadcasts',
+      scope: 'persist + emit + broadcast',
+      key_changes: [],
+    });
+    const r = await isSourceSDA05Suppressed('SD-FEAT-API-001', sb);
+    expect(r.suppress).toBe(false);
+    expect(r.reason).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Extends corrective-sd-generator filter (PR #3486 / SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001) from A05-only to full A01-A05 dimension strip
- Adds `lifecycle_feature` classifier path so feature-type SDs that touch only session/hook/capture/sessionstart/identity plumbing become suppression-eligible
- Closes the regression that allowed cancelled SDs 040/041/042 to emit on 2026-05-03 against SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001

## Why
PR #3486 shipped A05-only suppression. Within 24h three identical noise SDs (040/041/042) emitted against the just-completed SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 — same noise pattern, different dimensions (A01/A03/A04). Two compounding gaps: (1) feature-type SDs bypass classification because `READONLY_BUGFIX_TYPES` omits `feature`; (2) step 5b only strips A05 even when classifier matches.

## Changes
- `scripts/eva/corrective-sd-generator.mjs` (~50 LOC delta)
  - Add `LIFECYCLE_FEATURE_KEYWORDS` and `SUPPRESSED_ARCHITECTURAL_DIMS` exports
  - Extend `classifySourceSD` with lifecycle-feature path (uses strict-write count that excludes `lifecycle` itself, since it's a domain noun in WRITE_KEYWORDS)
  - Step 5b strips A01-A05 (was A05 only) and emits `skipped_lifecycle_feature_class` audit event for the new path
- `tests/unit/eva/corrective-sd-generator-lifecycle-feature-filter.test.js` (NEW, 206 LOC, 15 cases)

## Test plan
- [x] 15 new vitest cases pass (lifecycle classification, existing paths unchanged, contracts, mock propagation)
- [x] 13 pre-existing a05-filter cases pass unchanged
- [x] 42 corrective-sd-generator + multidim cases pass (no regression)
- [ ] Post-merge: verify next eva_vision_scores cycle does NOT generate SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-* against feature-type lifecycle source SDs
- [ ] Post-merge: verify audit_log gains `skipped_lifecycle_feature_class` entries on synthetic re-trigger

## Out of scope
Triple-emission dedup (`eva_vision_scores` writes 3 identical scoring rows within seconds for the same source SD). Filed as separate harness backlog if pattern recurs after this fix.

## Related
- Follow-up to: SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001 (PR #3486, completed 2026-05-02)
- Cancelled noise SDs that triggered this work: SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-040/041/042 (cancelled 2026-05-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)