### PR TITLE
fix(QF-20260503-096): make STOP_AT_STAGE configurable via env var

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -15,7 +15,7 @@ const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_R
 
 const VENTURE_ID = process.env.VENTURE_ID || '94856fc6-9ba9-4f56-9a5c-85041031a0fc';
 const VENTURE_NAME = process.env.VENTURE_NAME || 'LexiGuard';
-const STOP_AT_STAGE = 17;
+const STOP_AT_STAGE = parseInt(process.env.STOP_AT_STAGE || '17', 10);
 const POLL_MS = 30000;
 
 // Gate classification — sourced from lifecycle_stage_config (DB authoritative as of 2026-04-25)


### PR DESCRIPTION
## Summary
- 1-LOC change: `scripts/monitor-venture-run.cjs:18` reads `STOP_AT_STAGE` from env var, defaults to `17`.
- Unblocks observation runs for stages beyond S16 (S17 design pipeline, S20 quality analyzer) without script edits.

## Origin
Surfaced during PrivacyPatrol AI venture monitoring run on 2026-05-03 — reusable monitoring prompt template parameterizes `STOP_AT_STAGE` but the script ignored env input.

## Verification
- `node -c scripts/monitor-venture-run.cjs` — syntax OK
- `STOP_AT_STAGE=22 node -e "..."` — env var override resolves to 22 ✓
- Unset → defaults to 17 ✓

## Test Plan
- [x] Syntax check
- [x] Env var override path
- [x] Default path (env unset)
- [ ] Manual smoke run with `STOP_AT_STAGE=22` against a fresh venture (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)