### PR TITLE
feat(SD-LEO-FIX-DROP-LEGACY-ARG-001): adopt p_approval_type:null in venture monitor

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -172,7 +172,10 @@ async function approveDecision(decisionId, stage) {
   const { data, error } = await sb.rpc('approve_chairman_decision', {
     p_decision_id: decisionId,
     p_rationale: `Monitor auto-push: advancing ${VENTURE_NAME} S${stage} [${gateType}]`,
-    p_decided_by: 'venture_monitor'
+    p_decided_by: 'venture_monitor',
+    // SD-LEO-FIX-DROP-LEGACY-ARG-001: system caller, no semantic approval_type.
+    // Pairs with the EHG migration that drops the legacy 3-arg overload.
+    p_approval_type: null
   });
   return { data, error };
 }


### PR DESCRIPTION
## Summary

- Add `p_approval_type: null` to `EHG_Engineer/scripts/monitor-venture-run.cjs:172` `approve_chairman_decision` RPC call.
- Comment now cites SD-LEO-FIX-DROP-LEGACY-ARG-001 and explains *system caller, no semantic approval_type* — the canonical opt-out for system-driven monitor approvals, not a tactical workaround.

## Pairs with

EHG repo PR: same branch name `feat/SD-LEO-FIX-DROP-LEGACY-ARG-001` — drops the legacy 3-arg `approve_chairman_decision` overload via migration. After that PR merges and the migration applies, only the 4-arg variant exists; this monitor commit ensures the system caller passes the new param explicitly.

## Background

During the PrivacyPatrol AI venture monitoring run on 2026-05-03, the first 3-arg `approve_chairman_decision` call after the 4-arg overload landed produced PostgREST `PGRST203 "Could not choose the best candidate function"`. The monitor was tactically patched on a working branch (kept the value, comment said "disambiguate"). This PR formalizes the patch as the canonical pattern post-SD.

RCA dispatch: `a721eb9af4e019c7f`.

## Test plan

- [ ] Re-run `node scripts/monitor-venture-run.cjs` on a fresh venture after the EHG migration applies; expect zero `PGRST203` errors
- [ ] Confirm `STOP_AT_STAGE` env-var honored (no regression vs QF-20260503-096)

## Refs

- RCA: `a721eb9af4e019c7f`
- PRD: `PRD-SD-LEO-FIX-DROP-LEGACY-ARG-001`
- Origin venture: `08d20036-03c9-4a26-bbc5-f37a18dfdf23` (PrivacyPatrol AI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)