### PR TITLE
fix(QF-20260503-012): Stage18 generate-copy PG 42P10 — use insert+update pattern

### DIFF
--- a/server/routes/stage18.js
+++ b/server/routes/stage18.js
@@ -53,10 +53,10 @@ async function fetchUpstreamAndVenture(supabase, ventureId) {
 }
 
 async function storeMarketingArtifacts(supabase, ventureId, copyResult) {
-  const upserts = [];
+  const inserts = [];
   for (const section of VALID_SECTIONS) {
     if (!copyResult[section]) continue;
-    upserts.push({
+    inserts.push({
       venture_id: ventureId,
       artifact_type: `marketing_${section}`,
       title: titleForSection(section),
@@ -64,10 +64,23 @@ async function storeMarketingArtifacts(supabase, ventureId, copyResult) {
       artifact_data: copyResult[section],
     });
   }
-  if (upserts.length === 0) return { error: null };
-  const { error } = await supabase.from('venture_artifacts')
-    .upsert(upserts, { onConflict: 'venture_id,artifact_type' });
-  if (error) console.error('[stage18-route] artifact upsert error:', error.message);
+  if (inserts.length === 0) return { error: null };
+
+  // venture_artifacts has no unique constraint on (venture_id, artifact_type),
+  // so .upsert(onConflict: ...) fails with PG 42P10. Use the mark-old-as-not-current
+  // + insert pattern that the rest of the codebase relies on (is_current default = true).
+  const artifactTypes = inserts.map(i => i.artifact_type);
+  const { error: markErr } = await supabase.from('venture_artifacts')
+    .update({ is_current: false })
+    .eq('venture_id', ventureId)
+    .in('artifact_type', artifactTypes)
+    .eq('is_current', true);
+  if (markErr) {
+    console.error('[stage18-route] mark-not-current error:', markErr.message);
+    return { error: markErr };
+  }
+  const { error } = await supabase.from('venture_artifacts').insert(inserts);
+  if (error) console.error('[stage18-route] artifact insert error:', error.message);
   return { error };
 }
 
@@ -123,14 +136,29 @@ router.post('/:ventureId/regenerate/:section', asyncHandler(async (req, res) => 
     return res.status(500).json({ error: 'Failed to generate section: ' + section, code: 'GENERATION_FAILED' });
   }
 
-  const { error } = await supabase.from('venture_artifacts')
-    .upsert({
-      venture_id: ventureId,
-      artifact_type: 'marketing_' + section,
-      title: titleForSection(section),
-      lifecycle_stage: 18,
-      artifact_data: sectionData,
-    }, { onConflict: 'venture_id,artifact_type' });
+  // Mark prior current row(s) for this artifact_type as not-current, then insert
+  // the new row. See storeMarketingArtifacts for why this can't use .upsert().
+  const artifactType = 'marketing_' + section;
+  const { error: markErr } = await supabase.from('venture_artifacts')
+    .update({ is_current: false })
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', artifactType)
+    .eq('is_current', true);
+  if (markErr) {
+    console.error('[stage18-route] regenerate mark-not-current error:', markErr.message);
+    return res.status(500).json({
+      error: 'Failed to persist regenerated section: ' + markErr.message,
+      code: 'ARTIFACT_STORAGE_FAILED',
+      data: sectionData,
+    });
+  }
+  const { error } = await supabase.from('venture_artifacts').insert({
+    venture_id: ventureId,
+    artifact_type: artifactType,
+    title: titleForSection(section),
+    lifecycle_stage: 18,
+    artifact_data: sectionData,
+  });
 
   if (error) {
     console.error('[stage18-route] regenerate upsert error:', error.message);


### PR DESCRIPTION
## Summary
- Replaces two `.upsert(onConflict: 'venture_id,artifact_type')` calls in `server/routes/stage18.js` with mark-old-as-not-current + insert pattern.
- Closes the 500 Internal Server Error on `/api/stage18/:ventureId/generate-copy` and `/api/stage18/:ventureId/regenerate/:section`.

## Root Cause
`venture_artifacts` has only a primary key on `id` — no unique constraint on `(venture_id, artifact_type)`. The S18 code assumed such a constraint, so PostgREST returned `42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification` on every call.

The schema design uses `is_current=true` as the canonical-row flag (default `true`), with multiple historical rows preserved via `is_current=false`. Other stages (e.g., S17 archetype generation, queried at `Stage17BlueprintReview.tsx:226`) follow this pattern.

## Fix
Both locations now:
1. `UPDATE venture_artifacts SET is_current=false WHERE venture_id=$1 AND artifact_type IN ($2..) AND is_current=true`
2. `INSERT INTO venture_artifacts (...)` (defaults `is_current=true`)

Net behavioral equivalence to the broken `upsert`: a single row per `(venture_id, artifact_type, is_current=true)` is guaranteed by the new write pattern, without requiring a schema change.

## Surfaced By
PrivacyPatrol AI venture run on 2026-05-03; user clicked Generate Copy on the S18 page; got the 42P10 error inline. Affects ALL ventures hitting S18.

## Test Plan
- [x] Syntax check: `node -c server/routes/stage18.js` passes
- [x] Diff: 42 insertions / 14 deletions, all in `storeMarketingArtifacts` + regenerate route
- [ ] Manual: re-run PrivacyPatrol AI S18 Generate Copy after merge — expect 200 OK + 9 marketing_* artifacts in venture_artifacts (post-merge)
- [ ] Idempotency: regenerate a section twice — expect 1 current row + 1 historical (is_current=false) row

## Follow-up SD
A structural fix worth considering: add a partial unique index `UNIQUE (venture_id, artifact_type) WHERE is_current=true` so the simpler `.upsert(onConflict: ...)` API works without the manual mark-then-insert dance. Captured for later — not required for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)