### PR TITLE
fix(QF-20260503-028): Stage18 LLM 180s timeout — gemini-2.5-pro thinking

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js
@@ -249,7 +249,8 @@ export async function analyzeStage18MarketingCopy(params) {
 
   try {
     const client = getLLMClient();
-    const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+    // 180s timeout — gemini-2.5-pro thinking on multi-artifact prompts blows past the 30s default.
+    const response = await client.complete(SYSTEM_PROMPT, userPrompt, { timeout: 180000 });
     const parsed = parseJSON(response);
     usage = extractUsage(response) || {};
 


### PR DESCRIPTION
## Summary
1-line fix: pass `{ timeout: 180000 }` (3min) as the third arg to `client.complete()` in `lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js:252`.

## Root Cause
Adapter default is `PROVIDER_TIMEOUT_MS = 30000` (30s). gemini-2.5-pro with medium-effort thinking on a 12-artifact prompt reliably exceeds that budget. Result: 3-attempt TIMEOUT → silent fallback content for every Generate Copy / Regenerate attempt.

`PROVIDER_TIMEOUT_LONG_MS = 180000` already exists in `provider-adapters.js:16` but no caller wires it in.

## Witness
PrivacyPatrol AI venture run 2026-05-03 — server log showed identical 3-attempt TIMEOUT on initial Generate Copy and on per-section Regenerate. DB rows for `marketing_blog_draft` had 2 versions, both fallback content.

## Test Plan
- [x] Syntax check
- [x] Diff: 1-line addition
- [ ] Manual: re-run Generate Copy on PrivacyPatrol AI; expect real LLM-generated copy with `persona_target` populated, no `[Fallback ...]` markers (post-merge + server restart)

## Structural Follow-up
`SD-LEO-FIX-GOOGLEADAPTER-TIMEOUT-DOESN-001` — auto-select timeout by model tier so future callers don't have to remember to opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)