### PR TITLE
feat(SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001): persist metadata.is_fallback on Stage 18 artifacts

### DIFF
--- a/scripts/one-off/amend-prd-scope-stage18-fallback.mjs
+++ b/scripts/one-off/amend-prd-scope-stage18-fallback.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const PRD_ID = 'PRD-SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001';
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const scope_amendment = {
+  recorded_at: new Date().toISOString(),
+  source: 'PLAN-phase sub-agent evidence (DESIGN e5773b9c-b74d-48b5-a164-ce1f63cb6159, DATABASE c77d3635-e873-4f25-878f-b8ca1ea7dd0c)',
+  amendments: [
+    {
+      fr: 'FR-1',
+      action: 'simplify',
+      from: 'analyzer exposes per-section _isFallback marker on each of 9 sections',
+      to: 'analyzer continues using existing batch-level result.metadata.llmFallbackCount; no per-section marker needed',
+      reason: 'DATABASE C1: llmFallbackCount is batch-scoped (0|1 for all 9 sections). Current analyzer is all-or-nothing — buildFallbackCopy returns ALL 9 sections as fallback in the catch/invalid-JSON branch; LLM success returns ALL 9 from real LLM. There is no partial-fallback case. Per-section marker is over-engineering for a non-existent state. Keep batch flag.',
+      impact: 'Reduces backend code change to 1-3 LOC in stage-18-marketing-copy.js (no buildFallbackCopy modification needed)'
+    },
+    {
+      fr: 'FR-3',
+      action: 'reframe',
+      from: 'Frontend reads metadata.is_fallback from each venture_artifacts row',
+      to: 'Frontend reads advisory.metadata.llmFallbackCount from the existing /api/stage18/:ventureId/generate-copy response; renders amber Fallback Badge on ALL 9 sections when llmFallbackCount > 0',
+      reason: 'DATABASE C2: Stage18MarketingCopy.tsx does NOT query venture_artifacts directly. It receives advisory data from the API response (which already includes result.metadata.llmFallbackCount). No new query path required.',
+      impact: 'Smaller frontend change. No need to extend Supabase query types. Read existing advisory.metadata.llmFallbackCount.'
+    },
+    {
+      fr: 'FR-4',
+      action: 'drop_and_replace',
+      from: 'Disable venture-level Promote control when any section is_fallback=true; tooltip explains',
+      to: 'Render warning Alert above the section grid (matching existing isLlmUnavailable Alert pattern at lines 421-450) when advisory.metadata.llmFallbackCount > 0. Alert text reuses the amber-token pattern. No control disabled because no Promote button exists in current UI.',
+      reason: 'DESIGN finding #3 CONCERN: grep confirmed no Promote button in Stage18 or any sibling stage. Only surfaces are informational GateBanner (decision-driven label only), Generate Copy, and per-section Regenerate. FR-4 cannot disable a button that does not exist. Visual warning Alert achieves the same silent-failure prevention without requiring a new Promote button (out of scope) or backend gate-decision change (out of scope).',
+      impact: 'Reduces scope. Adds ~10 LOC for warning Alert. Removes complexity around tooltip/disabled state on a non-existent control.'
+    },
+    {
+      fr: 'FR-5',
+      action: 'clarify',
+      from: 'Backfill migration in scripts/migrations/',
+      to: 'Backfill at scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs',
+      reason: 'DATABASE C3: data-only fix on a single test-fixture venture; will not exist in fresh deployments; matches PRD Node-for-re-runnability guidance.',
+      impact: 'Path correction; no scope change'
+    },
+    {
+      fr: 'FR-6',
+      action: 'keep',
+      reason: 'Still valid: runtime detection uses canonical metadata.is_fallback (from FR-2 backend write), NOT text-substring at render time. Backfill (FR-5) is the only place text-substring matching is used (one-time cleanup of pre-fix rows).'
+    }
+  ],
+  net_scope_change: '~30% reduction in EXEC scope. Removes per-section analyzer changes, removes Promote-button gating UX, simplifies frontend to read existing advisory.metadata field.',
+  followup_sds_to_consider: [
+    'Add explicit Promote button surface to Stage 18 with fallback-gating (currently no such button exists; informational GateBanner only). Tier 2 enhancement.',
+    'Per-section partial fallback support if buildFallbackCopy ever evolves to mix real-LLM and fallback sections. Currently all-or-nothing.'
+  ],
+  audit_log_insert_template: {
+    event_type: 'stage18_marketing_fallback_backfill',
+    entity_type: 'venture_artifact_batch',
+    entity_id: '08d20036-03c9-4a26-bbc5-f37a18dfdf23',
+    new_value: { row_count: 9, is_fallback_set_to: true },
+    metadata: {
+      sd_key: 'SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001',
+      prd_id: 'PRD-SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001',
+      fr: 'FR-5',
+      ac: 'AC-3',
+      venture_id: '08d20036-03c9-4a26-bbc5-f37a18dfdf23',
+      artifact_type_filter: 'marketing_%',
+      is_current_filter: true,
+      executed_via: 'scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs'
+    },
+    severity: 'info',
+    created_by: 'database-agent:SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001'
+  }
+};
+
+const sel = await supabase.from('product_requirements_v2').select('metadata').eq('id', PRD_ID).single();
+const merged = { ...(sel.data?.metadata || {}), scope_amendment };
+const upd = await supabase.from('product_requirements_v2').update({ metadata: merged }).eq('id', PRD_ID).select('id').single();
+if (upd.error) {
+  console.error('amend failed:', upd.error.message);
+  process.exit(1);
+}
+console.log('PRD', upd.data.id, 'scope_amendment recorded with', scope_amendment.amendments.length, 'amendments');
+console.log('Net scope change:', scope_amendment.net_scope_change);

--- a/scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs
+++ b/scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * One-off backfill: set metadata.is_fallback=true on the 9 PrivacyPatrol AI
+ * Stage 18 marketing artifacts that pre-date the SD-LEO-FIX-STAGE18-SILENT-
+ * FALLBACK-001 fix.
+ *
+ * Scope: venture_id=08d20036-03c9-4a26-bbc5-f37a18dfdf23 only (NOT a blanket
+ * UPDATE — per VALIDATION evidence 9437fdb4-... and DATABASE evidence
+ * c77d3635-...). Idempotent (jsonb || merge overwrites is_fallback to true on
+ * re-run). Writes a single audit_log row with row_count=9.
+ *
+ * Why text-pattern detection is acceptable here (and only here): runtime
+ * write paths in server/routes/stage18.js write metadata.is_fallback
+ * directly. This script is the one-time cleanup of 9 rows that pre-date
+ * that write path. Substring "[Fallback —" is the visible marker
+ * buildFallbackCopy emits at lib/eva/stage-templates/analysis-steps/
+ * stage-18-marketing-copy.js:354-361.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const VENTURE_ID = '08d20036-03c9-4a26-bbc5-f37a18dfdf23';
+const SD_KEY = 'SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001';
+const PRD_ID = 'PRD-' + SD_KEY;
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const { data: rows, error: selErr } = await supabase
+  .from('venture_artifacts')
+  .select('id, artifact_type, metadata, artifact_data')
+  .eq('venture_id', VENTURE_ID)
+  .like('artifact_type', 'marketing_%')
+  .eq('is_current', true);
+
+if (selErr) {
+  console.error('select failed:', selErr.message);
+  process.exit(1);
+}
+
+if (!rows || rows.length === 0) {
+  console.log('no candidate rows for venture', VENTURE_ID, '— nothing to backfill');
+  process.exit(0);
+}
+
+const matches = rows.filter((r) => {
+  const txt = JSON.stringify(r.artifact_data || {});
+  return txt.includes('[Fallback');
+});
+
+console.log(`scope: ${rows.length} marketing_* rows; fallback-matched by substring: ${matches.length}`);
+
+let updated = 0;
+for (const r of matches) {
+  const merged = { ...(r.metadata || {}), is_fallback: true };
+  const { error: updErr } = await supabase
+    .from('venture_artifacts')
+    .update({ metadata: merged })
+    .eq('id', r.id);
+  if (updErr) {
+    console.error('update failed for', r.id, ':', updErr.message);
+    process.exit(1);
+  }
+  updated++;
+}
+
+const { error: auditErr } = await supabase.from('audit_log').insert({
+  event_type: 'stage18_marketing_fallback_backfill',
+  entity_type: 'venture_artifact_batch',
+  entity_id: VENTURE_ID,
+  new_value: { row_count: updated, is_fallback_set_to: true },
+  metadata: {
+    sd_key: SD_KEY,
+    prd_id: PRD_ID,
+    fr: 'FR-5',
+    ac: 'AC-3',
+    venture_id: VENTURE_ID,
+    artifact_type_filter: 'marketing_%',
+    is_current_filter: true,
+    executed_via: 'scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs'
+  },
+  severity: 'info',
+  created_by: `backfill:${SD_KEY}`
+});
+
+if (auditErr) {
+  console.warn('audit_log insert failed (non-fatal):', auditErr.message);
+}
+
+console.log(`backfilled ${updated} of ${matches.length} fallback-matched rows; audit_log written: ${!auditErr}`);

--- a/scripts/one-off/insert-prd-sd-leo-fix-stage18-fallback.mjs
+++ b/scripts/one-off/insert-prd-sd-leo-fix-stage18-fallback.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * One-off: insert PRD for SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001
+ *
+ * Background: add-prd-to-database.js ran in INLINE mode and emitted the
+ * generation prompt without inserting a row. This script materializes the
+ * PRD informed by the validation-agent + risk-agent evidence rows and the
+ * exploration_summary written at LEAD.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_UUID = '42c60c0c-4156-428f-ab19-9f8bad01d271';
+const SD_KEY = 'SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001';
+const PRD_ID = 'PRD-' + SD_KEY;
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const functional_requirements = [
+  {
+    id: 'FR-1',
+    priority: 'CRITICAL',
+    description: 'analyzeStage18MarketingCopy currently returns top-level llmFallbackCount (0|1) only. To support per-row fallback flagging, the analyzer must mark each section in copyOutput when it came from buildFallbackCopy(). Without per-section marking, storeMarketingArtifacts cannot tag individual venture_artifacts rows correctly when partial fallback is added later.',
+    requirement: 'analyzer exposes per-section fallback marker',
+    acceptance_criteria: [
+      'AC-1: When LLM throws or returns invalid structure, every section in copyOutput carries an explicit fallback indicator (e.g., section._isFallback=true on each of the 9 COPY_SECTIONS)',
+      'AC-2: When LLM succeeds, sections do NOT carry the marker (or carry it as false)',
+      'AC-3: result.metadata still contains the existing llmFallbackCount=0|1 batch-level signal — no breaking change',
+      'AC-4: Vitest covers both branches — buildFallbackCopy adds markers; valid LLM JSON does not'
+    ]
+  },
+  {
+    id: 'FR-2',
+    priority: 'CRITICAL',
+    description: 'storeMarketingArtifacts in server/routes/stage18.js writes 9 venture_artifacts rows from copyResult but never propagates fallback origin. The /:ventureId/regenerate/:section path also drops the signal. Both write paths must set venture_artifacts.metadata.is_fallback so downstream consumers can detect fallback origin without text-pattern parsing.',
+    requirement: 'persistence writes metadata.is_fallback on both /generate-copy and /regenerate/:section paths',
+    acceptance_criteria: [
+      'AC-1: storeMarketingArtifacts insert payload includes metadata: { is_fallback: <per-section flag from FR-1> } for each row',
+      'AC-2: /:ventureId/regenerate/:section insert payload includes metadata.is_fallback for the regenerated section',
+      'AC-3: When a section is real-LLM, metadata.is_fallback is false (explicit, not omitted) so frontend can rely on the field existing',
+      'AC-4: Vitest unit covers both routes — fallback path writes is_fallback=true; success path writes is_fallback=false'
+    ]
+  },
+  {
+    id: 'FR-3',
+    priority: 'CRITICAL',
+    description: 'Stage18MarketingCopy.tsx currently renders <Badge>{hasContent ? "Generated" : "Pending"}</Badge> at lines 527-529 — a binary badge with no fallback signal. Replace with three-state rendering using the existing amber-token alert pattern (lines 422-426) for the fallback case. NOTE: SD plan mentioned a per-section "Approve" button — no such control exists in current UI; only the Regenerate button (lines 539-547). PRD scope corrects to the actual UI surface.',
+    requirement: 'frontend reads metadata.is_fallback per section and renders amber Fallback pill plus inline section warning',
+    acceptance_criteria: [
+      'AC-1: Frontend query loads metadata.is_fallback alongside artifact_data for each marketing_* row of the current venture',
+      'AC-2: When section.metadata.is_fallback === true, badge renders with amber tokens (border-amber-500/50 bg-amber-500/10 text-amber-700) and label "Fallback" — reuse existing tokens from lines 422-426, do not introduce a new component',
+      'AC-3: When metadata.is_fallback is false or null, badge renders the existing default "Generated" variant (no regression)',
+      'AC-4: Section card surfaces a one-line inline warning beneath the title: "LLM was unavailable — click Regenerate to retry."',
+      'AC-5: data-testid="stage18-fallback-badge-{section}" added so smoke tests can assert presence/absence'
+    ]
+  },
+  {
+    id: 'FR-4',
+    priority: 'HIGH',
+    description: 'The venture-level PROMOTION GATE at lines 410-417 (rendered via GateOverlay) currently allows promotion regardless of section provenance. Operator could promote a venture whose marketing copy is entirely fallback. PROMOTION GATE button must be disabled (or its decision normalized to a non-approving state) when ANY current marketing_* row has metadata.is_fallback=true. Tooltip explains the gating reason.',
+    requirement: 'venture-level Promote disables when any current section has metadata.is_fallback=true; tooltip explains',
+    acceptance_criteria: [
+      'AC-1: Boolean derived: anyFallback = sections.some(s => s.metadata?.is_fallback === true)',
+      'AC-2: When anyFallback is true, the Promote button surface is disabled or the gate decision UI shows a blocking state',
+      'AC-3: Tooltip on the disabled control reads: "Regenerate fallback sections before promoting." (matches risk-agent recommendation a629fd46-...)',
+      'AC-4: After regenerating all 9 sections successfully, anyFallback flips to false and Promote re-enables — verified by Vitest unit'
+    ]
+  },
+  {
+    id: 'FR-5',
+    priority: 'HIGH',
+    description: 'PrivacyPatrol AI venture (venture_id=08d20036-03c9-4a26-bbc5-f37a18dfdf23) has 9 existing marketing_* rows, all is_current=true, all containing the literal "[Fallback —" substring in artifact_data and persona_target="our target user". These predate this fix. Backfill MUST be scoped to that single venture (per VALIDATION warning W2 — NOT a blanket UPDATE) so the fix is observable on the originating venture without touching unrelated marketing rows that may legitimately mention the word "fallback" elsewhere.',
+    requirement: 'one-off backfill migration sets metadata.is_fallback=true on the 9 existing PrivacyPatrol AI rows in a single transaction with audit log',
+    acceptance_criteria: [
+      'AC-1: Migration is a Node script (not a SQL migration) so it can run via the database-agent and be re-runnable safely (idempotent)',
+      "AC-2: Migration is scoped: WHERE venture_id = 08d20036-03c9-4a26-bbc5-f37a18dfdf23 AND artifact_type LIKE 'marketing_%' AND is_current = true",
+      'AC-3: Migration writes a single audit_log row with row_count=9 and execution context (script name, sd_key, timestamp)',
+      'AC-4: After migration, frontend renders amber Fallback pill on all 9 sections of the PrivacyPatrol AI venture without any code being deployed (validates FR-3 against existing data)'
+    ]
+  },
+  {
+    id: 'FR-6',
+    priority: 'MEDIUM',
+    description: 'The check used by PROMOTION GATE for fallback presence (FR-4 AC-1) MUST rely on canonical metadata.is_fallback rather than text-substring detection of "[Fallback —" in artifact_data. Text-substring is a defense-in-depth ONLY for the backfill script (FR-5), not for runtime. This addresses risk-agent concern about false positives on legitimate copy that may use the word "fallback".',
+    requirement: 'runtime fallback detection uses metadata.is_fallback exclusively, not text matching',
+    acceptance_criteria: [
+      'AC-1: Codebase grep confirms no /\\[Fallback —/ regex or substring check at runtime in Stage18MarketingCopy.tsx',
+      'AC-2: Backfill script (FR-5) is the only place text-pattern matching is permitted; comment in script explains why (one-time cleanup of pre-fix rows)',
+      'AC-3: After fix is deployed, all NEW rows rely solely on metadata.is_fallback for downstream gating'
+    ]
+  }
+];
+
+const technical_requirements = [
+  {
+    id: 'TR-1',
+    requirement: 'Backend writes use additive jsonb merge — never overwrite existing metadata keys',
+    rationale: 'venture_artifacts.metadata may carry other keys in future. Use { ...existingMetadata, is_fallback } pattern in inserts (insert is fresh, but the principle applies if any update path exists).'
+  },
+  {
+    id: 'TR-2',
+    requirement: 'Frontend type definition for marketing artifact row extends to include metadata.is_fallback?: boolean',
+    rationale: 'Stage18MarketingCopy.tsx uses CopySectionData type. Either extend that type or add a sibling type for the persisted row shape so TypeScript prevents missed-read regressions.'
+  },
+  {
+    id: 'TR-3',
+    requirement: 'Backend-first deploy ordering — ship server/routes/stage18.js + analyzer changes before the EHG frontend Stage18MarketingCopy.tsx changes',
+    rationale: 'Forward-compat: backend writes is_fallback into rows that pre-update UI ignores; frontend update later picks them up. Reverse ordering causes UI to expect a field that does not yet exist (still safe — falsy default — but suboptimal). Per risk-agent a629fd46 recommendation.'
+  },
+  {
+    id: 'TR-4',
+    requirement: 'Per-section marker in analyzer must NOT include the literal "_isFallback" string in any persisted artifact_data field — keep it in section.metadata or strip before persistence',
+    rationale: 'artifact_data is rendered to humans (operator). A leaking "_isFallback":true would be visible noise. Recommend: storeMarketingArtifacts reads the marker from a shape like copyResult.__sectionFlags[section] = { is_fallback }, NOT inlined into copyResult[section].'
+  }
+];
+
+const test_scenarios = [
+  {
+    id: 'TS-1',
+    scenario: 'Analyzer emits per-section fallback flag when LLM throws',
+    given: 'analyzeStage18MarketingCopy called with stub LLM client that throws',
+    when: 'Function returns',
+    then: 'Returned object contains per-section fallback indicator on all 9 COPY_SECTIONS; result.metadata.llmFallbackCount === 1',
+    test_type: 'unit'
+  },
+  {
+    id: 'TS-2',
+    scenario: 'Analyzer does NOT emit fallback flag when LLM succeeds',
+    given: 'Stub LLM client returns valid JSON with all 9 sections',
+    when: 'Function returns',
+    then: 'No section carries the fallback marker; result.metadata.llmFallbackCount === 0',
+    test_type: 'unit'
+  },
+  {
+    id: 'TS-3',
+    scenario: 'storeMarketingArtifacts writes is_fallback=true for fallback rows',
+    given: 'Mock supabase, copyResult with per-section fallback markers from buildFallbackCopy',
+    when: 'storeMarketingArtifacts runs',
+    then: 'Each of 9 inserted rows includes metadata.is_fallback=true; mark-old-as-not-current pattern preserved',
+    test_type: 'unit'
+  },
+  {
+    id: 'TS-4',
+    scenario: 'storeMarketingArtifacts writes is_fallback=false for real-LLM rows',
+    given: 'Mock supabase, copyResult from valid LLM response',
+    when: 'storeMarketingArtifacts runs',
+    then: 'Each of 9 inserted rows includes metadata.is_fallback=false (explicit, not undefined)',
+    test_type: 'unit'
+  },
+  {
+    id: 'TS-5',
+    scenario: 'Regenerate route also writes metadata.is_fallback',
+    given: 'POST /:ventureId/regenerate/:section with stub LLM that throws',
+    when: 'Handler responds',
+    then: 'Inserted row has metadata.is_fallback=true; existing mark-not-current pattern preserved',
+    test_type: 'integration'
+  },
+  {
+    id: 'TS-6',
+    scenario: 'Frontend renders amber Fallback badge for is_fallback=true sections',
+    given: 'Stage18MarketingCopy mounted with mocked artifacts where one section has metadata.is_fallback=true',
+    when: 'Component renders',
+    then: 'data-testid="stage18-fallback-badge-tagline" present with class containing "border-amber-500/50"; default "Generated" badge absent for that section',
+    test_type: 'component'
+  },
+  {
+    id: 'TS-7',
+    scenario: 'Frontend renders default Generated badge for is_fallback=false sections',
+    given: 'Stage18MarketingCopy mounted with all artifacts metadata.is_fallback=false',
+    when: 'Component renders',
+    then: 'No fallback badge present; existing "Generated" badge rendered (regression guard)',
+    test_type: 'component'
+  },
+  {
+    id: 'TS-8',
+    scenario: 'Promote button disabled when any section is fallback',
+    given: '8 sections is_fallback=false, 1 section is_fallback=true',
+    when: 'Promote control rendered',
+    then: 'Promote disabled state asserted; tooltip text contains "Regenerate fallback sections"',
+    test_type: 'component'
+  },
+  {
+    id: 'TS-9',
+    scenario: 'Backfill migration is idempotent and scoped',
+    given: 'PrivacyPatrol AI venture has 9 marketing_* rows with metadata IS NULL',
+    when: 'Backfill script runs twice',
+    then: 'Both runs succeed; row count 9 each time; no other ventures touched (SELECT count from venture_artifacts WHERE artifact_type LIKE marketing_% AND venture_id != 08d20036 returns same value before and after)',
+    test_type: 'integration'
+  },
+  {
+    id: 'TS-10',
+    scenario: '30-second smoke (manual UAT)',
+    given: 'Pre-existing PrivacyPatrol AI venture (08d20036) loaded after backfill+frontend deploy',
+    when: 'Operator opens Stage 18',
+    then: 'All 9 section cards display amber Fallback pill; Promote button disabled with tooltip; click Regenerate on one section, on success that pill clears; after regenerating all 9 Promote enables',
+    test_type: 'smoke'
+  }
+];
+
+const acceptance_criteria = [
+  'Analyzer exposes per-section fallback marker on fallback path; not present on success path (FR-1)',
+  'Both /generate-copy and /regenerate/:section persistence paths write metadata.is_fallback (FR-2)',
+  'Stage18MarketingCopy renders amber Fallback pill (with existing amber tokens) when metadata.is_fallback=true; no regression of default Generated pill (FR-3)',
+  'Venture-level Promote disables when any current section is fallback; tooltip explains (FR-4)',
+  'Backfill migration scoped to venture_id=08d20036 only; idempotent; audit log row written (FR-5)',
+  'Runtime detection uses metadata.is_fallback exclusively — no text-substring matching at render time (FR-6)',
+  'PrivacyPatrol AI venture demos correctly post-deploy: amber pills on all 9 sections, Promote disabled, regenerate clears pill (Q9 demo)',
+  'All Vitest unit + component tests pass (TS-1 through TS-9); zero regressions on existing Stage18 tests',
+  'Branch ≤100 LOC src target (likely 80-100 src + 100-150 tests + 30-50 backfill); cross-repo PRs (EHG_Engineer + EHG)'
+];
+
+const risks = [
+  {
+    risk: 'False-positive fallback detection in backfill — text "[Fallback —" could legitimately appear in real LLM copy (rare but possible if a venture themed around fallback systems)',
+    impact: 'LOW',
+    mitigation: 'Backfill is scoped to ONE venture_id (08d20036). Risk applies only if that venture happens to use the word fallback in real copy — manually inspected, it does not. Future runs of backfill on other ventures are explicitly out of scope.',
+    probability: 'LOW',
+    rollback_plan: "UPDATE venture_artifacts SET metadata = metadata - 'is_fallback' WHERE venture_id = 08d20036 AND artifact_type LIKE marketing_%. Single revert query."
+  },
+  {
+    risk: 'Cross-repo deploy ordering desync — frontend ships first, reads is_fallback before backend writes it',
+    impact: 'LOW',
+    mitigation: 'Frontend default-renders Generated pill when is_fallback is undefined or false (FR-3 AC-3). Old behavior preserved during desync window. Per TR-3, deploy backend first as defense in depth.',
+    probability: 'MEDIUM',
+    rollback_plan: 'Frontend revert is single-PR; backend revert is single-PR. Both safe.'
+  },
+  {
+    risk: 'Operator surprise — Promote suddenly disabled on a venture they expected to ship',
+    impact: 'MEDIUM',
+    mitigation: 'Tooltip explicitly states the reason and remediation ("Regenerate fallback sections before promoting"). Per FR-4 AC-3. Q9 smoke covers the regenerate-and-unblock flow end-to-end.',
+    probability: 'MEDIUM',
+    rollback_plan: 'Feature flag is_fallback gating behind a frontend flag if needed; revert removes the gate while preserving the badge for awareness.'
+  }
+];
+
+const system_architecture = {
+  components: [
+    'EHG_Engineer/lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js — analyzer, adds per-section fallback marker on fallback branches',
+    'EHG_Engineer/server/routes/stage18.js — storeMarketingArtifacts + regenerate handler write metadata.is_fallback on insert',
+    'ehg/src/components/stages/Stage18MarketingCopy.tsx — reads metadata.is_fallback per section; renders amber Fallback pill; gates Promote',
+    'EHG_Engineer/scripts/migrations/<date>-backfill-stage18-fallback-metadata.mjs — one-off, scoped, idempotent backfill for PrivacyPatrol AI venture'
+  ],
+  data_flow: 'LLM call (or fallback) → analyzer marks per-section flag → storeMarketingArtifacts persists with metadata.is_fallback → Stage18MarketingCopy renders badge + gates Promote → operator clicks Regenerate → POST /regenerate/:section runs analyzer again → if success, new row metadata.is_fallback=false → UI re-fetches → pill clears',
+  observability: 'audit_log row from backfill provides one-time count. Per-row metadata.is_fallback queryable via Supabase for ongoing monitoring. Existing console.error logs in analyzer (lines 264, 290) flag LLM errors at run time.'
+};
+
+const ui_ux_requirements = {
+  badge: 'Amber Fallback pill replaces default Generated pill when section.metadata.is_fallback=true. Reuse existing tokens from lines 422-426 of Stage18MarketingCopy.tsx. Do NOT introduce a new shadcn/ui Badge variant.',
+  inline_warning: 'One-line text beneath section card title when fallback: "LLM was unavailable — click Regenerate to retry." (no exclamation, no emoji)',
+  promote_gate: 'Existing Promote control disabled when any section.metadata.is_fallback=true. Tooltip on disabled state: "Regenerate fallback sections before promoting." Use existing Tooltip primitive (already imported in Stage18MarketingCopy.tsx).',
+  accessibility: 'aria-label="Fallback content from LLM unavailability" on the amber pill. Disabled Promote retains aria-disabled="true". Color is NOT the only signal — text label "Fallback" + tooltip explanation provide non-color affordance.'
+};
+
+const implementation_approach = `1. Backend (EHG_Engineer worktree):
+   - stage-18-marketing-copy.js: add per-section fallback flag in buildFallbackCopy output (e.g., wrap each section with { ...sectionData, _isFallback: true } OR keep parallel __sectionFlags map). Prefer the parallel map per TR-4 to avoid leaking _isFallback into operator-visible artifact_data.
+   - server/routes/stage18.js: storeMarketingArtifacts reads the parallel map and writes metadata: { is_fallback: <bool> } per insert; regenerate handler does same for the single section.
+   - Vitest unit covering both branches (LLM success + LLM throw) for both routes.
+
+2. Frontend (EHG repo):
+   - Stage18MarketingCopy.tsx: extend type for marketing artifact row to include metadata.is_fallback?. In the section-card render block (lines 506-557), conditionally render amber Fallback pill OR default Generated pill. Add inline warning beneath title when fallback. Compute anyFallback boolean at top of component and feed into Promote gate.
+   - Vitest component tests via @testing-library/react.
+
+3. Backfill (EHG_Engineer worktree):
+   - scripts/migrations/<YYYYMMDD>-backfill-stage18-fallback-metadata.mjs.
+   - Idempotent SELECT-then-UPDATE scoped to venture_id=08d20036. Writes one audit_log row.
+   - Documented as one-time; not added to migration runner.
+
+4. Order of PRs (per TR-3 backend-first):
+   - PR 1: Backend (analyzer + stage18.js + tests) — EHG_Engineer
+   - PR 2: Backfill migration — EHG_Engineer (run once after PR 1 ships)
+   - PR 3: Frontend — EHG repo
+
+   Each PR ≤100 LOC src target, max 200 LOC inc tests.`;
+
+const prd_row = {
+  id: PRD_ID,
+  directive_id: SD_KEY, // varchar reference per memory
+  sd_id: SD_UUID,
+  title: 'Stage18 silent fallback persistence — surface fallback state to UI',
+  version: '1.0.0',
+  status: 'approved',
+  category: 'bugfix',
+  priority: 'medium',
+  executive_summary: 'Fix a silent failure mode where Gemini-timeout fallback marketing copy persists to venture_artifacts indistinguishable from real LLM output. Add metadata.is_fallback at write time (analyzer + 2 backend write paths), surface as amber pill in Stage18MarketingCopy.tsx, gate venture-level Promote when any section is fallback, and backfill the 9 existing PrivacyPatrol AI rows. Cross-repo (EHG_Engineer + EHG), backend-first deploy.',
+  business_context: 'Operator running PrivacyPatrol AI venture on 2026-05-03 was shown 9 marketing artifacts marked "Generated" with no signal that all 9 came from the fallback path after a Gemini 3-attempt TIMEOUT. Without this fix, ANY LLM unavailability produces shippable-looking-but-placeholder marketing copy — the venture promotion path could push fallback text to production.',
+  technical_context: 'Backend already tracks llmFallbackCount at the analyzer batch level (stage-18-marketing-copy.js:248-267) but storeMarketingArtifacts (server/routes/stage18.js:55-85) does not propagate it. Frontend renders <Badge>{hasContent ? "Generated" : "Pending"}</Badge> at lines 527-529 — no fallback awareness. Per LEAD exploration, the SD plan referenced a per-section "Approve" button that does not exist; PRD scope corrects to actual UI surface (per-section Regenerate already exists; Promote is venture-level).',
+  functional_requirements,
+  technical_requirements,
+  system_architecture,
+  ui_ux_requirements,
+  implementation_approach,
+  test_scenarios,
+  acceptance_criteria,
+  risks,
+  exploration_summary: 'See SD.exploration_summary for the 6-file deep dive. Validation evidence: 9437fdb4-... (sub_agent_execution_results, PASS-with-CONCERNS). Risk evidence: a629fd46-... (CONCERNS, two warnings encoded into FR-4 and FR-6). Scope correction logged in exploration: SD plan FR-3/FR-4 had per-section Approve which does not exist; PRD aligns to the venture-level Promote gate that does exist.',
+  metadata: {
+    sd_uuid: SD_UUID,
+    sd_key: SD_KEY,
+    plan_phase_evidence: ['9437fdb4-dfc2-4693-a7cc-7449802e7c88', 'a629fd46-d306-4c23-8e05-384e71f7d466'],
+    cross_repo: ['EHG_Engineer', 'ehg'],
+    deploy_order: 'backend-first',
+    estimated_loc: { src: '80-100', tests: '100-150', backfill: '30-50' },
+    pr_plan: 3,
+    venture_id_in_scope_for_backfill: '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+  }
+};
+
+async function main() {
+  const { data, error } = await supabase
+    .from('product_requirements_v2')
+    .insert(prd_row)
+    .select('id, sd_id, status, version')
+    .single();
+
+  if (error) {
+    console.error('PRD insert failed:', error.message);
+    console.error('details:', error);
+    process.exit(1);
+  }
+  return data;
+}
+
+const data = await main();
+
+console.log('PRD inserted:', JSON.stringify(data, null, 2));
+console.log('FR count:', functional_requirements.length);
+console.log('TR count:', technical_requirements.length);
+console.log('TS count:', test_scenarios.length);
+console.log('AC count:', acceptance_criteria.length);
+console.log('Risk count:', risks.length);

--- a/scripts/one-off/insert-user-stories-stage18-fallback.mjs
+++ b/scripts/one-off/insert-user-stories-stage18-fallback.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_UUID = '42c60c0c-4156-428f-ab19-9f8bad01d271';
+const SD_KEY = 'SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001';
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const stories = [
+  {
+    story_key: `${SD_KEY}:US-001`,
+    sd_id: SD_UUID,
+    title: 'Surface LLM fallback origin in Stage 18 marketing copy badges',
+    user_role: 'Solo entrepreneur (chairman) reviewing Stage 18 marketing copy',
+    user_want: 'each section card to clearly indicate when its content came from the LLM-fallback path versus a successful LLM generation',
+    user_benefit: 'I can immediately spot placeholder copy and avoid promoting a venture with fake marketing content to production',
+    acceptance_criteria: [
+      'When advisory.metadata.llmFallbackCount > 0 (LLM was unavailable), every section card shows an amber Fallback badge instead of the default Generated badge',
+      'When advisory.metadata.llmFallbackCount === 0 (real LLM succeeded), section cards show the existing default Generated badge unchanged (regression guard)',
+      'Pending sections continue to render the existing outline Pending badge regardless of fallback state',
+      'The amber Fallback badge has aria-label="Fallback content from LLM unavailability" and uses the existing amber-token pattern (border-amber-500/50 bg-amber-500/10 text-amber-700) so color is not the only signal',
+      'data-testid="stage18-fallback-badge-{section}" is present on each fallback badge so smoke tests can assert presence/absence'
+    ],
+    implementation_context: 'Edit ehg/src/components/stages/Stage18MarketingCopy.tsx lines 527-529 to render a three-state Badge: amber Fallback when advisory.metadata.llmFallbackCount > 0, default Generated when llmFallbackCount === 0 and hasContent, outline Pending otherwise. Reuse the className tuple from the isLlmUnavailable Alert at lines 423-426. Do NOT introduce a new shadcn Badge variant. Tier 2 frontend change, ~15-25 src LOC + 30-50 test LOC.',
+    status: 'ready'
+  },
+  {
+    story_key: `${SD_KEY}:US-002`,
+    sd_id: SD_UUID,
+    title: 'Show warning Alert above section grid when fallback content present',
+    user_role: 'Solo entrepreneur reviewing Stage 18 after a Generate Copy run that hit LLM unavailability',
+    user_want: 'a single, prominent warning at the top of the section grid stating that the marketing copy is from the fallback path',
+    user_benefit: 'I do not need to scan all 9 sections to detect the silent failure mode — the warning surfaces at the top of the screen and recommends regenerating before promoting',
+    acceptance_criteria: [
+      'When advisory.metadata.llmFallbackCount > 0, an Alert renders above the section card grid (after the summary metrics, before the section grid)',
+      'Alert reuses the existing isLlmUnavailable amber styling pattern (lines 421-450 of Stage18MarketingCopy.tsx)',
+      'Alert text reads: "Marketing copy generated from LLM-fallback path. Regenerate sections before promoting this venture." (concise, no exclamation)',
+      'Alert is dismissible-or-not consistent with the existing isLlmUnavailable Alert pattern; uses AlertTriangle icon',
+      'data-testid="stage18-fallback-warning-alert" is present',
+      'When llmFallbackCount === 0, no Alert renders (no false positives, no regression of normal flow)'
+    ],
+    implementation_context: 'Add a second Alert block in Stage18MarketingCopy.tsx, reusing the conditional pattern at lines 420-451. Place after the summary metrics div (line 488) and before the section card grid (line 499). Reuse Alert, AlertTitle, AlertDescription, AlertTriangle imports already in the file. Replaces the original FR-4 of disabling a Promote button — that button does not exist, so a visual warning Alert is the correct surface for the silent-failure prevention. Tier 2 frontend change, ~10-15 src LOC.',
+    status: 'ready'
+  },
+  {
+    story_key: `${SD_KEY}:US-003`,
+    sd_id: SD_UUID,
+    title: 'Persist fallback origin to venture_artifacts so backfill and audit can reconstruct it',
+    user_role: 'Database administrator or future operator reviewing historical marketing artifacts',
+    user_want: 'each marketing_* row in venture_artifacts to carry metadata.is_fallback so the fallback origin can be queried directly without parsing artifact text',
+    user_benefit: 'I can run SQL queries to count fallback artifacts across ventures, audit the silent-failure incident, and the existing 9 PrivacyPatrol AI rows can be backfilled correctly',
+    acceptance_criteria: [
+      'storeMarketingArtifacts in server/routes/stage18.js writes metadata: { is_fallback: boolean } on every inserted row, derived from result.metadata.llmFallbackCount > 0',
+      'POST /:ventureId/regenerate/:section also writes metadata.is_fallback on the regenerated row',
+      'For real-LLM rows, metadata.is_fallback is explicitly false (not omitted) so consumers can rely on the field existing',
+      'Vitest unit covers both routes: success path writes is_fallback=false; fallback path writes is_fallback=true; mark-old-as-not-current pattern preserved',
+      'A scoped backfill at scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs sets metadata.is_fallback=true on the 9 existing PrivacyPatrol AI rows (venture_id=08d20036-03c9-4a26-bbc5-f37a18dfdf23, artifact_type LIKE marketing_%, is_current=true) — idempotent, single transaction, with audit_log row of count 9'
+    ],
+    implementation_context: 'Backend: extend the inserts at server/routes/stage18.js lines 59-66 (storeMarketingArtifacts) and lines 155-161 (regenerate) to include metadata: { is_fallback: copyResult.metadata?.llmFallbackCount > 0 }. Backfill: COALESCE(metadata, {}) || {is_fallback:true} jsonb merge for the 9 PrivacyPatrol AI rows; audit_log INSERT shape is documented in PRD metadata.scope_amendment.audit_log_insert_template. Tier 2 backend change, ~5-10 src LOC + 50-80 test LOC + 30-50 backfill LOC.',
+    status: 'ready'
+  }
+];
+
+const { data, error } = await supabase
+  .from('user_stories')
+  .insert(stories)
+  .select('story_key, status');
+
+if (error) {
+  console.error('insert failed:', error.message);
+  console.error('details:', error);
+  process.exit(1);
+}
+
+console.log('inserted', data.length, 'user stories:');
+for (const s of data) console.log(' -', s.story_key, '(' + s.status + ')');

--- a/server/routes/stage18.js
+++ b/server/routes/stage18.js
@@ -53,6 +53,7 @@ async function fetchUpstreamAndVenture(supabase, ventureId) {
 }
 
 async function storeMarketingArtifacts(supabase, ventureId, copyResult) {
+  const isFallback = (copyResult?.metadata?.llmFallbackCount ?? 0) > 0;
   const inserts = [];
   for (const section of VALID_SECTIONS) {
     if (!copyResult[section]) continue;
@@ -62,6 +63,7 @@ async function storeMarketingArtifacts(supabase, ventureId, copyResult) {
       title: titleForSection(section),
       lifecycle_stage: 18,
       artifact_data: copyResult[section],
+      metadata: { is_fallback: isFallback },
     });
   }
   if (inserts.length === 0) return { error: null };
@@ -152,12 +154,14 @@ router.post('/:ventureId/regenerate/:section', asyncHandler(async (req, res) => 
       data: sectionData,
     });
   }
+  const isFallback = (result?.metadata?.llmFallbackCount ?? 0) > 0;
   const { error } = await supabase.from('venture_artifacts').insert({
     venture_id: ventureId,
     artifact_type: artifactType,
     title: titleForSection(section),
     lifecycle_stage: 18,
     artifact_data: sectionData,
+    metadata: { is_fallback: isFallback },
   });
 
   if (error) {

--- a/tests/unit/stage18-fallback-metadata.test.js
+++ b/tests/unit/stage18-fallback-metadata.test.js
@@ -1,0 +1,187 @@
+/**
+ * Stage 18 fallback metadata persistence — unit tests
+ *
+ * SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001 / FR-2 / TS-3, TS-4, TS-5
+ *
+ * Validates that storeMarketingArtifacts and the regenerate handler write
+ * `metadata.is_fallback` derived from `result.metadata.llmFallbackCount`
+ * to every persisted venture_artifacts row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAnalyze = vi.fn();
+vi.mock('../../lib/eva/stage-templates/analysis-steps/stage-18-marketing-copy.js', () => ({
+  analyzeStage18MarketingCopy: (...args) => mockAnalyze(...args),
+}));
+
+vi.mock('../../server/middleware/validate.js', () => ({
+  isValidUuid: (v) => typeof v === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v),
+}));
+
+vi.mock('../../lib/middleware/eva-error-handler.js', () => ({
+  asyncHandler: (fn) => fn,
+}));
+
+const { default: router } = await import('../../server/routes/stage18.js');
+
+const VALID_UUID = '11111111-2222-3333-4444-555555555555';
+
+const COPY_SECTIONS = [
+  'tagline', 'app_store_desc', 'landing_hero',
+  'email_welcome', 'email_onboarding', 'email_reengagement',
+  'social_posts', 'seo_meta', 'blog_draft',
+];
+
+function buildResult(llmFallbackCount) {
+  const result = { metadata: { llmFallbackCount } };
+  for (const s of COPY_SECTIONS) result[s] = { text: `${s} content`, persona_target: 'Tester' };
+  return result;
+}
+
+function buildSupabase() {
+  const insertSpy = vi.fn().mockResolvedValue({ error: null });
+  const updateChain = {
+    update: vi.fn(() => updateChain),
+    eq: vi.fn(() => updateChain),
+    in: vi.fn(() => updateChain),
+    then: undefined,
+  };
+  // mark-not-current update returns { error: null } when awaited at the end of the chain
+  // We make the chain thenable on the final .eq() call by returning a resolved promise.
+  // Simpler: route mark-not-current through a function that returns { error: null }.
+  const fromSpy = vi.fn((table) => {
+    if (table === 'ventures') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({ data: { name: 'Test Venture' }, error: null }),
+          })),
+        })),
+      };
+    }
+    if (table === 'venture_artifacts') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            })),
+            eq: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            })),
+          })),
+        })),
+        insert: insertSpy,
+      };
+    }
+    return {};
+  });
+  return { from: fromSpy, _insertSpy: insertSpy };
+}
+
+function createMockReq(params = {}, supabase = buildSupabase()) {
+  return { params, app: { locals: { supabase } } };
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200, jsonData: null,
+    status(c) { this.statusCode = c; return this; },
+    json(d) { this.jsonData = d; return this; },
+  };
+}
+
+function findRoute(method, path) {
+  for (const layer of router.stack) {
+    if (layer.route && Object.keys(layer.route.methods)[0] === method && layer.route.path === path) {
+      return layer.route.stack.map((s) => s.handle);
+    }
+  }
+  throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+}
+
+async function runHandlerChain(handlers, req, res) {
+  let idx = 0;
+  const next = async (err) => {
+    if (err) throw err;
+    if (idx < handlers.length) await handlers[idx++](req, res, next);
+  };
+  await next();
+}
+
+describe('Stage 18 fallback metadata persistence', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('POST /:ventureId/generate-copy', () => {
+    const handlers = findRoute('post', '/:ventureId/generate-copy');
+
+    it('TS-3: writes metadata.is_fallback=true on every row when llmFallbackCount=1', async () => {
+      mockAnalyze.mockResolvedValueOnce(buildResult(1));
+      const supabase = buildSupabase();
+      await runHandlerChain(handlers, createMockReq({ ventureId: VALID_UUID }, supabase), createMockRes());
+
+      expect(supabase._insertSpy).toHaveBeenCalledTimes(1);
+      const [rows] = supabase._insertSpy.mock.calls[0];
+      expect(rows).toHaveLength(9);
+      for (const r of rows) {
+        expect(r.metadata).toEqual({ is_fallback: true });
+        expect(r.artifact_type.startsWith('marketing_')).toBe(true);
+        expect(r.lifecycle_stage).toBe(18);
+      }
+    });
+
+    it('TS-4: writes metadata.is_fallback=false on every row when llmFallbackCount=0', async () => {
+      mockAnalyze.mockResolvedValueOnce(buildResult(0));
+      const supabase = buildSupabase();
+      await runHandlerChain(handlers, createMockReq({ ventureId: VALID_UUID }, supabase), createMockRes());
+
+      expect(supabase._insertSpy).toHaveBeenCalledTimes(1);
+      const [rows] = supabase._insertSpy.mock.calls[0];
+      for (const r of rows) {
+        expect(r.metadata).toEqual({ is_fallback: false });
+      }
+    });
+
+    it('handles missing metadata.llmFallbackCount as is_fallback=false (graceful degradation)', async () => {
+      mockAnalyze.mockResolvedValueOnce({ ...buildResult(0), metadata: undefined });
+      const supabase = buildSupabase();
+      await runHandlerChain(handlers, createMockReq({ ventureId: VALID_UUID }, supabase), createMockRes());
+
+      const [rows] = supabase._insertSpy.mock.calls[0];
+      for (const r of rows) {
+        expect(r.metadata).toEqual({ is_fallback: false });
+      }
+    });
+  });
+
+  describe('POST /:ventureId/regenerate/:section', () => {
+    const handlers = findRoute('post', '/:ventureId/regenerate/:section');
+
+    it('TS-5: writes metadata.is_fallback=true on regenerated row when llmFallbackCount>0', async () => {
+      mockAnalyze.mockResolvedValueOnce(buildResult(1));
+      const supabase = buildSupabase();
+      await runHandlerChain(handlers, createMockReq({ ventureId: VALID_UUID, section: 'tagline' }, supabase), createMockRes());
+
+      expect(supabase._insertSpy).toHaveBeenCalledTimes(1);
+      const [row] = supabase._insertSpy.mock.calls[0];
+      expect(row.artifact_type).toBe('marketing_tagline');
+      expect(row.metadata).toEqual({ is_fallback: true });
+    });
+
+    it('writes metadata.is_fallback=false on regenerated row when llmFallbackCount=0', async () => {
+      mockAnalyze.mockResolvedValueOnce(buildResult(0));
+      const supabase = buildSupabase();
+      await runHandlerChain(handlers, createMockReq({ ventureId: VALID_UUID, section: 'blog_draft' }, supabase), createMockRes());
+
+      const [row] = supabase._insertSpy.mock.calls[0];
+      expect(row.artifact_type).toBe('marketing_blog_draft');
+      expect(row.metadata).toEqual({ is_fallback: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `server/routes/stage18.js` — both `/generate-copy` and `/regenerate/:section` write paths now persist `metadata.is_fallback` to `venture_artifacts`, derived from `result.metadata.llmFallbackCount > 0`.
- 5 vitest unit tests at `tests/unit/stage18-fallback-metadata.test.js` covering both routes, all green (237ms).
- Backfill script at `scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs` — scoped to PrivacyPatrol AI venture (08d20036), idempotent, audit_log entry. Runs post-merge.

## Why
Operator running PrivacyPatrol AI on 2026-05-03 saw 9 marketing artifacts mislabeled "Generated" after a Gemini timeout — silent failure mode. Backend already tracked `llmFallbackCount` at the analyzer batch level but never propagated it to persisted rows. This PR fixes that propagation. Frontend rendering follows in https://github.com/rickfelix/ehg/pull/new/feat/SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001 (backend-first deploy ordering per PRD TR-3).

## Test plan
- [x] Vitest unit (5 tests): both paths write `metadata.is_fallback` correctly for fallback + success branches
- [x] Vitest covers graceful-default for missing `metadata.llmFallbackCount`
- [ ] Post-merge: execute `node scripts/one-off/backfill-stage18-marketing-fallback-flag.mjs` to flag the 9 PrivacyPatrol AI rows; verify `audit_log` row.

PRD: PRD-SD-LEO-FIX-STAGE18-SILENT-FALLBACK-001
LEAD evidence: 9437fdb4 (VALIDATION) + a629fd46 (RISK)
PLAN evidence: e5773b9c (DESIGN) + c77d3635 (DATABASE)
EXEC evidence: TESTING PASS (95% confidence)
Retrospective: d9dc51d9-4cf7-473b-9be1-0c29801b9290 (quality 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)