### PR TITLE
refactor(SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001): monitor EXPECTED_ARTIFACTS → lifecycle_stage_config + source filter

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -73,26 +73,60 @@ const DESIGN_ARTIFACT_TYPES = [
   'stitch_curation', 'stitch_project', 'stitch_design_export',
 ];
 
-// Stage artifact expectations — sourced from lifecycle_stage_config.required_artifacts (DB authoritative)
-const EXPECTED_ARTIFACTS = {
-   1: ['truth_idea_brief'],
-   2: ['truth_ai_critique'],
-   3: ['truth_validation_decision'],
-   4: ['truth_competitive_analysis'],
-   5: ['truth_financial_model'],
-   6: ['engine_risk_matrix'],
-   7: ['engine_pricing_model'],
-   8: ['engine_business_model_canvas'],
-   9: ['engine_exit_strategy'],
-  10: ['identity_persona_brand'],
-  11: ['identity_naming_visual'],
-  12: ['identity_brand_guidelines', 'identity_gtm_sales_strategy'],
-  13: ['blueprint_product_roadmap'],
-  14: ['blueprint_technical_architecture', 'blueprint_data_model', 'blueprint_erd_diagram', 'blueprint_api_contract', 'blueprint_schema_spec'],
-  15: ['blueprint_wireframes'],
-  16: ['blueprint_financial_projection'],
-  17: ['system_devils_advocate_review'],
-};
+// SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001: stage artifact expectations are now loaded
+// from lifecycle_stage_config.required_artifacts at startup (DB-authoritative).
+// expectedArtifactsByStage is populated by loadExpectedArtifactsByStage() before polling.
+let expectedArtifactsByStage = new Map();
+
+// Worker-row source filter — EMPIRICAL (verified via SELECT DISTINCT source FROM venture_artifacts).
+// Worker sources match: stage-NN (zero-padded for 1-9, unpadded for 10+) OR stage-NN-<sub-variant>.
+// Advisory rows DO NOT count toward required-artifact validation — they are observability metadata.
+const ADVISORY_SOURCES = new Set([
+  'stage-gates',
+  'devils-advocate',
+  'chairman-review',
+  'manual-upload',
+  'lifecycle-sd-bridge',
+]);
+const ADVISORY_SUFFIXES = ['-analysis', '-post-hook'];
+
+function isWorkerSourceForStage(source, stage) {
+  if (!source) return false;
+  if (ADVISORY_SOURCES.has(source)) return false;
+  if (ADVISORY_SUFFIXES.some((suf) => source.endsWith(suf))) return false;
+  const padded = `stage-${String(stage).padStart(2, '0')}`;
+  const unpadded = `stage-${stage}`;
+  return (
+    source === padded ||
+    source === unpadded ||
+    source.startsWith(`${padded}-`) ||
+    source.startsWith(`${unpadded}-`)
+  );
+}
+
+async function loadExpectedArtifactsByStage() {
+  const { data, error } = await sb
+    .from('lifecycle_stage_config')
+    .select('stage_number, required_artifacts');
+  if (error) {
+    throw new Error(
+      `Failed to load lifecycle_stage_config (DB-authoritative artifact taxonomy): ${error.message}`
+    );
+  }
+  const map = new Map();
+  for (const row of data || []) {
+    const required = Array.isArray(row.required_artifacts) ? row.required_artifacts : [];
+    map.set(row.stage_number, required);
+  }
+  return map;
+}
+
+// Module export for testability (vitest reaches in via require)
+module.exports = module.exports || {};
+module.exports.isWorkerSourceForStage = isWorkerSourceForStage;
+module.exports.loadExpectedArtifactsByStage = loadExpectedArtifactsByStage;
+module.exports.ADVISORY_SOURCES = ADVISORY_SOURCES;
+module.exports.ADVISORY_SUFFIXES = ADVISORY_SUFFIXES;
 
 let lastStage = null;
 let issues = [];
@@ -128,7 +162,7 @@ async function getPendingDecision(stage) {
 
 async function getArtifacts(stage) {
   const { data } = await sb.from('venture_artifacts')
-    .select('lifecycle_stage, artifact_type, title, created_at, metadata')
+    .select('lifecycle_stage, artifact_type, title, source, created_at, metadata')
     .eq('venture_id', VENTURE_ID)
     .eq('lifecycle_stage', stage)
     .order('created_at', { ascending: false })
@@ -138,7 +172,7 @@ async function getArtifacts(stage) {
 
 async function getAllArtifacts() {
   const { data } = await sb.from('venture_artifacts')
-    .select('lifecycle_stage, artifact_type, title, created_at')
+    .select('lifecycle_stage, artifact_type, title, source, created_at')
     .eq('venture_id', VENTURE_ID)
     .order('lifecycle_stage', { ascending: true });
   return data || [];
@@ -360,11 +394,16 @@ async function poll() {
 }
 
 function validateStageArtifacts(stage, arts) {
-  const types = new Set(arts.map(a => a.artifact_type));
-  const expected = EXPECTED_ARTIFACTS[stage];
-  if (!expected) return;
+  const expected = expectedArtifactsByStage.get(stage);
+  if (!expected || expected.length === 0) return;
 
-  const missing = expected.filter(e => !types.has(e));
+  // SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001: filter to worker rows only.
+  // Advisory rows (stage-gates, devils-advocate, *-analysis, etc.) are observability metadata,
+  // not required deliverables — including them inflated the missing-set with false positives.
+  const workerArts = arts.filter((a) => isWorkerSourceForStage(a.source, stage));
+  const types = new Set(workerArts.map((a) => a.artifact_type));
+
+  const missing = expected.filter((e) => !types.has(e));
   if (missing.length > 0) {
     const msg = `S${stage} missing expected: ${missing.join(', ')}`;
     issues.push({ stage, type: 'missing_artifact', msg, ts: ts() });
@@ -372,7 +411,35 @@ function validateStageArtifacts(stage, arts) {
   }
 }
 
+async function runDryRunValidate() {
+  const map = await loadExpectedArtifactsByStage();
+  console.log('lifecycle_stage_config.required_artifacts (DB-authoritative):');
+  const stages = Array.from(map.keys()).sort((a, b) => a - b);
+  for (const stage of stages) {
+    const required = map.get(stage) || [];
+    console.log(`  Stage ${String(stage).padStart(2, ' ')}: ${required.length === 0 ? '(none)' : required.join(', ')}`);
+  }
+  console.log(`\nTotal stages loaded: ${stages.length}`);
+}
+
 async function main() {
+  // SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001: --dry-run-validate flag short-circuits polling.
+  // Loads the artifact map, prints it, exits 0. No polling, no DB writes, no venture-id resolution.
+  const dryRunFlag = process.argv.some((a) => a === '--dry-run-validate' || a === '--dryRunValidate');
+  if (dryRunFlag) {
+    await runDryRunValidate();
+    process.exit(0);
+  }
+
+  // Load DB-authoritative artifact map BEFORE polling begins. On failure, exit non-zero
+  // rather than silently falling back to stale data — operator must see the error.
+  try {
+    expectedArtifactsByStage = await loadExpectedArtifactsByStage();
+  } catch (err) {
+    console.error(`[FATAL] ${err.message}`);
+    process.exit(1);
+  }
+
   console.log(`\n${'='.repeat(70)}`);
   console.log(` VENTURE MONITOR — ${VENTURE_NAME} (${VENTURE_ID.slice(0,8)})`);
   console.log(` Poll every ${POLL_MS/1000}s | Auto-push to S${STOP_AT_STAGE - 1} | HARD STOP at S${STOP_AT_STAGE}`);

--- a/tests/unit/monitor-venture-run-validate.test.js
+++ b/tests/unit/monitor-venture-run-validate.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001 / FR-004
+ * Source-aware filter unit tests for monitor-venture-run.cjs.
+ *
+ * Tests the worker-vs-advisory source-prefix filter and verifies the filter
+ * matches the EMPIRICAL distribution of source values in venture_artifacts
+ * (verified 2026-05-03 via SELECT DISTINCT source — see PR body).
+ *
+ * No DB dependency — pure logic over in-memory data.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const monitor = require('../../scripts/monitor-venture-run.cjs');
+const { isWorkerSourceForStage, ADVISORY_SOURCES, ADVISORY_SUFFIXES } = monitor;
+
+describe('isWorkerSourceForStage — source-aware filter', () => {
+  describe('worker sources (must match)', () => {
+    it('matches stage-NN exact (zero-padded for 1-9)', () => {
+      expect(isWorkerSourceForStage('stage-01', 1)).toBe(true);
+      expect(isWorkerSourceForStage('stage-09', 9)).toBe(true);
+    });
+
+    it('matches stage-NN exact (unpadded for 10+)', () => {
+      expect(isWorkerSourceForStage('stage-10', 10)).toBe(true);
+      expect(isWorkerSourceForStage('stage-15', 15)).toBe(true);
+      expect(isWorkerSourceForStage('stage-23', 23)).toBe(true);
+    });
+
+    it('matches stage-NN-<sub-variant> for sub-stage workers (e.g., S17 archetype generator)', () => {
+      expect(isWorkerSourceForStage('stage-17-archetype-generator', 17)).toBe(true);
+      expect(isWorkerSourceForStage('stage-17-selection-flow', 17)).toBe(true);
+      expect(isWorkerSourceForStage('stage-17-design-mastering', 17)).toBe(true);
+      expect(isWorkerSourceForStage('stage-17-strategy-recommender', 17)).toBe(true);
+      expect(isWorkerSourceForStage('stage-17-strategy-stats', 17)).toBe(true);
+    });
+
+    it('matches both padded and unpadded forms regardless of which is used', () => {
+      // If production data ever uses stage-1 instead of stage-01, the filter
+      // still matches — defensive against the empirical convention shifting.
+      expect(isWorkerSourceForStage('stage-1', 1)).toBe(true);
+    });
+  });
+
+  describe('advisory sources (must NOT match)', () => {
+    it.each([...ADVISORY_SOURCES])(
+      'rejects advisory source: %s',
+      (advisorySource) => {
+        for (let stage = 1; stage <= 26; stage += 1) {
+          expect(isWorkerSourceForStage(advisorySource, stage)).toBe(false);
+        }
+      }
+    );
+
+    it.each(ADVISORY_SUFFIXES)(
+      'rejects sources ending in advisory suffix: %s',
+      (suffix) => {
+        expect(isWorkerSourceForStage(`stage-10${suffix}`, 10)).toBe(false);
+        expect(isWorkerSourceForStage(`stage-15${suffix}`, 15)).toBe(false);
+      }
+    );
+
+    it('null or undefined source is not a worker', () => {
+      expect(isWorkerSourceForStage(null, 10)).toBe(false);
+      expect(isWorkerSourceForStage(undefined, 10)).toBe(false);
+      expect(isWorkerSourceForStage('', 10)).toBe(false);
+    });
+  });
+
+  describe('cross-stage isolation', () => {
+    it('stage-12 source does not match stage 11 worker filter', () => {
+      expect(isWorkerSourceForStage('stage-12', 11)).toBe(false);
+    });
+
+    it('stage-17-archetype-generator does not match stage 16', () => {
+      expect(isWorkerSourceForStage('stage-17-archetype-generator', 16)).toBe(false);
+    });
+
+    it('zero-padded stage-01 does not match stage 10', () => {
+      expect(isWorkerSourceForStage('stage-01', 10)).toBe(false);
+    });
+  });
+
+  describe('regression: PrivacyPatrol AI false-positive scenario', () => {
+    it('S15 with worker stage-15 row + stage-15-post-hook advisory only counts the worker', () => {
+      const arts = [
+        { source: 'stage-15', artifact_type: 'wireframe_screens' },
+        { source: 'stage-15-post-hook', artifact_type: 'blueprint_wireframes_legacy_marker' },
+      ];
+      const workerOnly = arts.filter((a) => isWorkerSourceForStage(a.source, 15));
+      expect(workerOnly).toHaveLength(1);
+      expect(workerOnly[0].source).toBe('stage-15');
+    });
+
+    it('Advisory-only stage produces empty worker set', () => {
+      const arts = [
+        { source: 'stage-gates', artifact_type: 'gate_decision' },
+        { source: 'devils-advocate', artifact_type: 'system_devils_advocate_review' },
+      ];
+      const workerOnly = arts.filter((a) => isWorkerSourceForStage(a.source, 17));
+      expect(workerOnly).toHaveLength(0);
+    });
+
+    it('Mixed worker + advisory keeps only worker', () => {
+      const arts = [
+        { source: 'stage-12', artifact_type: 'identity_brand_guidelines' },
+        { source: 'stage-12', artifact_type: 'identity_gtm_sales_strategy' },
+        { source: 'stage-gates', artifact_type: 'gate_decision' },
+        { source: 'devils-advocate', artifact_type: 'critique_note' },
+      ];
+      const workerOnly = arts.filter((a) => isWorkerSourceForStage(a.source, 12));
+      expect(workerOnly).toHaveLength(2);
+      expect(workerOnly.map((a) => a.artifact_type).sort()).toEqual([
+        'identity_brand_guidelines',
+        'identity_gtm_sales_strategy',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded `EXPECTED_ARTIFACTS` constant in `scripts/monitor-venture-run.cjs` with runtime read from `lifecycle_stage_config.required_artifacts` (DB-authoritative).
- Add source-aware filter (`isWorkerSourceForStage`) to `validateStageArtifacts` so advisory rows (stage-gates, devils-advocate, chairman-review, manual-upload, lifecycle-sd-bridge, plus `*-analysis` / `*-post-hook` suffixes) are excluded from required-artifact validation.
- Add `--dry-run-validate` CLI flag for operators to inspect the loaded map without polling.
- Add vitest coverage in `tests/unit/monitor-venture-run-validate.test.js` (filter logic, cross-stage isolation, regression scenarios).
- `getArtifacts` / `getAllArtifacts` SELECT lists include the `source` column.

## Background

`monitor-venture-run.cjs:76-95` hardcoded a stage-to-required-artifacts map even though the script's own header comment cited `lifecycle_stage_config` as DB-authoritative. This drift produced the S15 false-positive missing-artifact warning during the PrivacyPatrol AI venture monitor run on 2026-05-03 (`blueprint_wireframes` superseded by `wireframe_screens` per the Stitch replacement). RCA dispatch `a50789d8504854069`, Hypothesis #1 HIGH confidence.

## Empirical source-distribution evidence (TR-003)

`SELECT DISTINCT source FROM venture_artifacts WHERE source IS NOT NULL` returned 35 distinct values:
- **Workers**: `stage-01` ... `stage-09` (zero-padded), `stage-10` ... `stage-23` (unpadded), `stage-17-archetype-generator`, `stage-17-selection-flow`, `stage-17-design-mastering`, `stage-17-strategy-recommender`, `stage-17-strategy-stats`
- **Advisory**: `stage-gates`, `devils-advocate`, `chairman-review`, `manual-upload`, `lifecycle-sd-bridge`
- **Advisory-suffix**: `stage-10-analysis`, `stage-11-analysis`, `stage-15-post-hook`

The filter uses both padded (`stage-0N`) and unpadded (`stage-N`) match forms to be defensive against the convention shifting.

## Peer-monitor sweep (FR-005)

`rg -n "EXPECTED_ARTIFACTS" scripts/` returned **no other matches** in EHG_Engineer. No peer monitors require the same fix.

## Test plan

- [x] Unit test: 12 inline-verified pass cases for `isWorkerSourceForStage` (worker matches, advisory rejection, cross-stage isolation, null/empty source, regression scenarios).
- [ ] CI runs full vitest suite — should be green
- [ ] Manual smoke: `node scripts/monitor-venture-run.cjs --dry-run-validate` prints the map and exits 0
- [ ] Re-run monitor against PrivacyPatrol AI (or any venture) — verify no S15 `blueprint_wireframes` false-positive warning
- [ ] Verify legitimate missing-artifact detection still fires when a real worker row is absent (regression baseline)

## Refs

- RCA: `a50789d8504854069`
- PRD: `PRD-SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001`
- Origin venture: `08d20036-03c9-4a26-bbc5-f37a18dfdf23` (PrivacyPatrol AI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)