### PR TITLE
feat(SD-LEO-FEAT-STAGE-BUILD-REPLIT-001): Stage 19 dual artifact emit + exit-gate enforcer + register-deployment endpoint

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-04-15T13:27:08.232Z"
+  "last_scan": "2026-05-03T19:01:38.741Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,8 @@
 {
-  "sdKey": "SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001",
-  "expectedBranch": "feat/SD-FDBK-ENH-CHILD-PREFLIGHT-RETURNS-001",
-  "createdAt": "2026-05-02T12:07:06.667Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "sdKey": "SD-LEO-FEAT-STAGE-BUILD-REPLIT-001",
+  "expectedBranch": "feat/SD-LEO-FEAT-STAGE-BUILD-REPLIT-001",
+  "createdAt": "2026-05-03T18:41:15.610Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260503_venture_resources_add_replit_urls.sql
+++ b/database/migrations/20260503_venture_resources_add_replit_urls.sql
@@ -1,0 +1,21 @@
+-- Add repo_url + deployment_url columns to venture_resources for Stage 19 Replit registration.
+-- SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-4 / TR-4
+--
+-- Why first-class columns (not metadata JSONB):
+--   The Stage 19 exit-gate enforcer (FR-2) reduces the existence check to two NOT NULL
+--   predicates on indexed columns. Storing inside metadata JSONB would force jsonb_path_exists
+--   on every advance — slower, harder to index, and less queryable from chairman_dashboard.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE UNIQUE INDEX IF NOT EXISTS.
+-- No NOT NULL constraint (some venture types skip Replit). No default. Existing rows leave new
+-- columns NULL — verified by AC-FR4-3.
+
+ALTER TABLE venture_resources ADD COLUMN IF NOT EXISTS repo_url text;
+ALTER TABLE venture_resources ADD COLUMN IF NOT EXISTS deployment_url text;
+
+-- Partial unique index: prevent the same deployment_url being registered twice for one venture.
+-- Partial (WHERE deployment_url IS NOT NULL) so existing/future rows without the column populated
+-- are unaffected; verified by AC-FR4-4.
+CREATE UNIQUE INDEX IF NOT EXISTS venture_resources_venture_deployment_url_uniq
+  ON venture_resources (venture_id, deployment_url)
+  WHERE deployment_url IS NOT NULL;

--- a/docs/reference/schema/engineer/tables/venture_resources.md
+++ b/docs/reference/schema/engineer/tables/venture_resources.md
@@ -14,7 +14,7 @@
 
 ---
 
-## Columns (9 total)
+## Columns (11 total)
 
 | Column | Type | Nullable | Default | Description |
 |--------|------|----------|---------|-------------|
@@ -27,6 +27,8 @@
 | metadata | `jsonb` | YES | `'{}'::jsonb` | - |
 | created_at | `timestamp with time zone` | **NO** | `now()` | - |
 | updated_at | `timestamp with time zone` | **NO** | `now()` | - |
+| repo_url | `text` | YES | - | GitHub repository URL captured at Stage 19 Replit-deployment registration. Populated by `POST /api/stage19/:ventureId/register-deployment` (SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-3). Read by exit-gate-enforcer for the `gates.exit` "GitHub repo URL stored in venture_resources" verifier. NULL for ventures that skip Replit. |
+| deployment_url | `text` | YES | - | Replit / hosting deployment URL captured at Stage 19 registration alongside `repo_url`. Same SD/FR. Indexed by partial unique index `venture_resources_venture_deployment_url_uniq` to prevent duplicate registrations per venture. NULL for non-Replit ventures. |
 
 ## Constraints
 
@@ -61,6 +63,13 @@
   ```sql
   CREATE UNIQUE INDEX venture_resources_venture_id_resource_type_resource_identif_key ON public.venture_resources USING btree (venture_id, resource_type, resource_identifier)
   ```
+- `venture_resources_venture_deployment_url_uniq` (partial)
+  ```sql
+  CREATE UNIQUE INDEX venture_resources_venture_deployment_url_uniq
+    ON public.venture_resources (venture_id, deployment_url)
+    WHERE deployment_url IS NOT NULL
+  ```
+  Added by migration `20260503_venture_resources_add_replit_urls.sql` to prevent duplicate Replit deployment registrations on the same venture. Partial-on-NOT-NULL so existing rows without `deployment_url` are unaffected.
 
 ## RLS Policies
 

--- a/lib/eva/__tests__/stage-19-binding-contract.test.js
+++ b/lib/eva/__tests__/stage-19-binding-contract.test.js
@@ -25,6 +25,9 @@ import {
   ARTIFACT_TYPES,
   ARTIFACT_TYPE_BY_STAGE,
 } from '../artifact-types.js';
+// SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 — additional named import for the
+// dual-emit invariant suite at the bottom of this file.
+import { getStageForArtifactType } from '../artifact-types.js';
 
 describe('Stage 19 Binding Contract', () => {
   describe('Contract refusal: missing Stage 18 data', () => {
@@ -170,6 +173,45 @@ describe('Stage 19 Binding Contract', () => {
     test('analyzer source surfaces persona target when present', () => {
       const source = analyzeStage19.toString();
       expect(source).toMatch(/persona_target/);
+    });
+  });
+
+  describe('Dual artifact emission at Stage 19 (SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-1, AC-FR1-1, AC-FR1-3)', () => {
+    test('BUILD_MVP_BUILD constant exists with the expected canonical value', () => {
+      expect(ARTIFACT_TYPES.BUILD_MVP_BUILD).toBe('build_mvp_build');
+    });
+
+    test('Stage 19 entry contains BOTH BLUEPRINT_SPRINT_PLAN and BUILD_MVP_BUILD', () => {
+      // DUAL spec-authority direction (locked at LEAD): the planning artifact
+      // (blueprint_sprint_plan) is preserved alongside the build-completion
+      // artifact (build_mvp_build) emitted by the POST register-deployment
+      // endpoint. Both must appear in ARTIFACT_TYPE_BY_STAGE[19].
+      expect(ARTIFACT_TYPE_BY_STAGE[19]).toContain(
+        ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN
+      );
+      expect(ARTIFACT_TYPE_BY_STAGE[19]).toContain(
+        ARTIFACT_TYPES.BUILD_MVP_BUILD
+      );
+    });
+
+    test('Stage 19 entry is exactly the dual pair (no extra entries)', () => {
+      // Defensive shape check: catches accidental drift if someone appends a
+      // third artifact without updating the LEAD scope decision.
+      expect(ARTIFACT_TYPE_BY_STAGE[19]).toHaveLength(2);
+    });
+
+    test('getStageForArtifactType resolves build_mvp_build to stage 19 deterministically', () => {
+      // Reverse-lookup invariant: BUILD_MVP_BUILD must be unique to S19 so the
+      // _STAGE_BY_ARTIFACT_TYPE reduce maps it to 19. If a future change adds
+      // BUILD_MVP_BUILD to another stage, this guard fires.
+      expect(getStageForArtifactType('build_mvp_build')).toBe(19);
+    });
+
+    test('No other stage entry references BUILD_MVP_BUILD', () => {
+      const stagesWithBuildMvp = Object.entries(ARTIFACT_TYPE_BY_STAGE)
+        .filter(([, types]) => types.includes(ARTIFACT_TYPES.BUILD_MVP_BUILD))
+        .map(([stage]) => Number(stage));
+      expect(stagesWithBuildMvp).toEqual([19]);
     });
   });
 });

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -256,7 +256,14 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
   // reverse-lookup _STAGE_BY_ARTIFACT_TYPE will map blueprint_sprint_plan
   // to 19 (last write wins) since S19 is the unambiguous Sprint Planning
   // stage by name.
-  19: [ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN],
+  // SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 — DUAL emission added at S19:
+  // BUILD_MVP_BUILD is the build-completion output (emitted by POST
+  // /api/stage19/:ventureId/register-deployment when the operator returns
+  // post-Replit-build with repo + deployment URLs). Coexists with the
+  // planning blueprint_sprint_plan emit. BUILD_MVP_BUILD is unique to S19
+  // (no other stage entry references it), so reverse-lookup
+  // _STAGE_BY_ARTIFACT_TYPE resolves 'build_mvp_build' to 19 deterministically.
+  19: [ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN, ARTIFACT_TYPES.BUILD_MVP_BUILD],
   20: [ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
   21: [ARTIFACT_TYPES.LAUNCH_TEST_PLAN, ARTIFACT_TYPES.LAUNCH_UAT_REPORT],
   22: [ARTIFACT_TYPES.LAUNCH_DEPLOYMENT_RUNBOOK],

--- a/lib/eva/lifecycle/exit-gate-enforcer.js
+++ b/lib/eva/lifecycle/exit-gate-enforcer.js
@@ -1,0 +1,143 @@
+/**
+ * Exit-gate enforcer for venture stage advance.
+ *
+ * SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-2 / TR-2 / TR-3
+ *
+ * Reads `lifecycle_stage_config.metadata.gates.exit` for the from_stage,
+ * dispatches each declared gate string to a verifier from
+ * exit-gate-verifiers.GATE_VERIFIERS, and returns a structured payload the
+ * caller renders as a user-actionable error or uses to authorize the
+ * advance_venture_stage RPC call.
+ *
+ * Why Node-side instead of a SQL trigger:
+ *   gates.exit entries are author-specified prose (e.g. "Application deployed",
+ *   "GitHub repo URL stored in venture_resources"). A SQL trigger cannot
+ *   interpret prose; this Node-side dispatcher with a verifier-map can grow
+ *   as new stages declare new gates without touching the RPC. database-agent
+ *   confirmed the existing `fn_advance_venture_stage` RPC has its own
+ *   `artifact_gate` (20260406_add_artifact_gate_to_fn_advance_venture_stage.sql)
+ *   that checks `stage_artifact_requirements`. This enforcer COMPOSES with
+ *   that — it adds metadata.gates.exit checks beyond the existing required-
+ *   artifact gate.
+ *
+ * Feature flag: LEO_S19_EXIT_GATE_ENFORCER
+ *   ON  (default) — enforce gates, refuse advance when not all satisfied.
+ *   OFF           — log a structured WARN and pass-through (legacy behavior).
+ *   Read once at module-load via process.env. Process restart required to
+ *   change state (TR-3).
+ *
+ * @module lib/eva/lifecycle/exit-gate-enforcer
+ */
+
+import { resolveVerifier } from './exit-gate-verifiers.js';
+
+const FLAG_NAME = 'LEO_S19_EXIT_GATE_ENFORCER';
+const FLAG_VALUE = (() => {
+  const raw = process.env[FLAG_NAME];
+  if (raw === undefined || raw === '') return 'on'; // default ON for new ventures
+  return String(raw).toLowerCase();
+})();
+
+/**
+ * @typedef {Object} EnforcerResult
+ * @property {boolean} allowed — true when the advance is authorized.
+ * @property {string[]} blocked_by — reasons each unsatisfied gate failed; empty when allowed.
+ * @property {string[]} gates_checked — the prose strings actually dispatched.
+ * @property {number} stage_number — the from_stage we evaluated.
+ * @property {boolean} flag_enforced — whether enforcement was active for this call.
+ */
+
+/**
+ * Evaluate whether a venture is allowed to advance from `fromStage`. Caller is
+ * responsible for invoking the actual advance RPC when allowed===true.
+ *
+ * Empty / missing gates.exit → allowed (no gates to check).
+ * Unknown gate strings (no verifier registered) → logged and skipped (allow),
+ * matching the staged-rollout philosophy of TR-3.
+ *
+ * @param {Object} args
+ * @param {import('@supabase/supabase-js').SupabaseClient} args.supabase
+ * @param {string} args.ventureId
+ * @param {number} args.fromStage
+ * @returns {Promise<EnforcerResult>}
+ */
+export async function checkExitGates({ supabase, ventureId, fromStage }) {
+  const flagEnforced = FLAG_VALUE !== 'off' && FLAG_VALUE !== '0' && FLAG_VALUE !== 'false';
+
+  if (!flagEnforced) {
+    console.warn(`[exit-gate-enforcer] ${FLAG_NAME}=${FLAG_VALUE} — enforcement skipped for venture=${ventureId} from_stage=${fromStage}`);
+    return {
+      allowed: true,
+      blocked_by: [],
+      gates_checked: [],
+      stage_number: fromStage,
+      flag_enforced: false,
+    };
+  }
+
+  // Read the gates.exit declaration for this stage.
+  const { data: stageConfig, error: cfgError } = await supabase
+    .from('lifecycle_stage_config')
+    .select('metadata')
+    .eq('stage_number', fromStage)
+    .maybeSingle();
+
+  if (cfgError) {
+    // Treat config read failure as a hard block — surface the error to the caller.
+    return {
+      allowed: false,
+      blocked_by: [`lifecycle_stage_config read failed: ${cfgError.message}`],
+      gates_checked: [],
+      stage_number: fromStage,
+      flag_enforced: true,
+    };
+  }
+
+  const gatesExit = stageConfig?.metadata?.gates?.exit;
+  if (!Array.isArray(gatesExit) || gatesExit.length === 0) {
+    // No gates declared → allow.
+    return {
+      allowed: true,
+      blocked_by: [],
+      gates_checked: [],
+      stage_number: fromStage,
+      flag_enforced: true,
+    };
+  }
+
+  const blocked_by = [];
+  const gates_checked = [];
+
+  for (const gateString of gatesExit) {
+    gates_checked.push(gateString);
+    const verifier = resolveVerifier(gateString);
+    if (!verifier) {
+      console.warn(`[exit-gate-enforcer] No verifier registered for gate "${gateString}" at stage ${fromStage} — skipping (allow).`);
+      continue;
+    }
+    const { satisfied, reason } = await verifier({ supabase, ventureId, fromStage });
+    if (!satisfied) {
+      blocked_by.push(`${gateString}: ${reason}`);
+    }
+  }
+
+  return {
+    allowed: blocked_by.length === 0,
+    blocked_by,
+    gates_checked,
+    stage_number: fromStage,
+    flag_enforced: true,
+  };
+}
+
+/**
+ * Read-only flag inspector for tests and diagnostics.
+ * @returns {{ name: string, value: string, enforced: boolean }}
+ */
+export function getEnforcementFlag() {
+  return {
+    name: FLAG_NAME,
+    value: FLAG_VALUE,
+    enforced: FLAG_VALUE !== 'off' && FLAG_VALUE !== '0' && FLAG_VALUE !== 'false',
+  };
+}

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -1,0 +1,105 @@
+/**
+ * Exit-gate verifier map for the Stage 19→20 enforcer.
+ *
+ * SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-2 / TR-2
+ *
+ * Each verifier resolves a free-text gate string declared in
+ * lifecycle_stage_config.metadata.gates.exit (author-specified prose) into a
+ * structured "satisfied yes/no" check against runtime DB state.
+ *
+ * v1 ships with the two S19 verifiers required for the Replit registration
+ * flow. New stages register additional verifiers by appending to GATE_VERIFIERS
+ * and providing a substring-matched key.
+ *
+ * @module lib/eva/lifecycle/exit-gate-verifiers
+ */
+
+/**
+ * @typedef {Object} VerifierResult
+ * @property {boolean} satisfied
+ * @property {string} reason — human-readable explanation if !satisfied
+ */
+
+/**
+ * @typedef {Object} VerifierContext
+ * @property {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @property {string} ventureId
+ * @property {number} fromStage
+ */
+
+/**
+ * Verifier: build_mvp_build artifact present AND is_current=true.
+ * Backs the gate string "Application deployed".
+ *
+ * @param {VerifierContext} ctx
+ * @returns {Promise<VerifierResult>}
+ */
+async function verifyBuildMvpBuildPresent({ supabase, ventureId }) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'build_mvp_build')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    return { satisfied: false, reason: `venture_artifacts query failed: ${error.message}` };
+  }
+  return data
+    ? { satisfied: true, reason: '' }
+    : { satisfied: false, reason: 'build_mvp_build artifact missing or not is_current' };
+}
+
+/**
+ * Verifier: venture_resources.repo_url AND venture_resources.deployment_url populated.
+ * Backs the gate string "GitHub repo URL stored in venture_resources".
+ *
+ * @param {VerifierContext} ctx
+ * @returns {Promise<VerifierResult>}
+ */
+async function verifyVentureResourceUrlsPopulated({ supabase, ventureId }) {
+  const { data, error } = await supabase
+    .from('venture_resources')
+    .select('repo_url, deployment_url')
+    .eq('venture_id', ventureId)
+    .not('repo_url', 'is', null)
+    .not('deployment_url', 'is', null)
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    return { satisfied: false, reason: `venture_resources query failed: ${error.message}` };
+  }
+  return data
+    ? { satisfied: true, reason: '' }
+    : { satisfied: false, reason: 'venture_resources.repo_url and/or deployment_url not populated' };
+}
+
+/**
+ * Verifier registry: gate-string-substring → verifier function.
+ * Lookup is case-insensitive substring match (gate strings are author-prose so
+ * exact-string equality is too brittle).
+ *
+ * Order matters when multiple keys match the same gate string — the first
+ * match wins. Keep the most-specific keys first.
+ */
+export const GATE_VERIFIERS = Object.freeze([
+  { match: 'application deployed', verifier: verifyBuildMvpBuildPresent },
+  { match: 'github repo url', verifier: verifyVentureResourceUrlsPopulated },
+]);
+
+/**
+ * Resolve a free-text gate string to a verifier function, or null if no
+ * verifier is registered. Caller treats null as "unknown gate, allow with WARN".
+ *
+ * @param {string} gateString
+ * @returns {((ctx: VerifierContext) => Promise<VerifierResult>) | null}
+ */
+export function resolveVerifier(gateString) {
+  if (typeof gateString !== 'string') return null;
+  const lc = gateString.toLowerCase();
+  for (const { match, verifier } of GATE_VERIFIERS) {
+    if (lc.includes(match)) return verifier;
+  }
+  return null;
+}

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -22,8 +22,27 @@ import { Router } from 'express';
 import { asyncHandler } from '../../lib/middleware/eva-error-handler.js';
 import { isValidUuid } from '../middleware/validate.js';
 import { formatReplitOptimized } from '../../lib/eva/bridge/replit-prompt-formatter.js';
+import { writeArtifact } from '../../lib/eva/artifact-persistence-service.js';
+import { ARTIFACT_TYPES } from '../../lib/eva/artifact-types.js';
 
 const router = Router();
+
+// SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-3 — URL shape validators
+const HTTPS_URL_RE = /^https:\/\/[^\s/$.?#].[^\s]*$/i;
+const GITHUB_REPO_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/?$/i;
+
+function validateRegistrationBody(body) {
+  const errors = {};
+  const repo_url = typeof body?.repo_url === 'string' ? body.repo_url.trim() : '';
+  const deployment_url = typeof body?.deployment_url === 'string' ? body.deployment_url.trim() : '';
+  if (!repo_url || !GITHUB_REPO_RE.test(repo_url)) {
+    errors.repo_url = 'must be https://github.com/<owner>/<repo>';
+  }
+  if (!deployment_url || !HTTPS_URL_RE.test(deployment_url)) {
+    errors.deployment_url = 'must be a valid https:// URL';
+  }
+  return { repo_url, deployment_url, errors };
+}
 
 /**
  * GET /api/stage19/:ventureId/replit-prompts
@@ -77,6 +96,114 @@ router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
       code: 'PROMPT_BUILD_FAILED',
     });
   }
+}));
+
+/**
+ * POST /api/stage19/:ventureId/register-deployment
+ *
+ * SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-3
+ *
+ * Registers Replit deployment + GitHub repo URLs for a venture and emits the
+ * canonical `build_mvp_build` artifact (the "build is done" signal that the
+ * Stage 19→20 exit-gate enforcer reads).
+ *
+ * Request body: { repo_url: string, deployment_url: string }
+ *   repo_url       — must match https://github.com/<owner>/<repo>
+ *   deployment_url — must be a valid https:// URL
+ *
+ * Behavior:
+ *   1. Validate UUID + URL shapes (400 INVALID_VENTURE_ID / VALIDATION_FAILED).
+ *   2. Upsert venture_resources columns repo_url + deployment_url
+ *      (resource_type='replit_deployment', resource_identifier=deployment_url
+ *      so the existing (venture_id, resource_type, resource_identifier) unique
+ *      constraint provides idempotency on the deployment URL).
+ *   3. Emit `build_mvp_build` artifact via artifact-persistence-service.writeArtifact;
+ *      writeArtifact's is_current dedup makes the emit idempotent.
+ *   4. Return 200 with the resource id, artifact id, and canonical URLs.
+ */
+router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+  const { repo_url, deployment_url, errors } = validateRegistrationBody(req.body);
+  if (Object.keys(errors).length > 0) {
+    return res.status(400).json({
+      error: 'URL validation failed',
+      code: 'VALIDATION_FAILED',
+      invalid: Object.keys(errors),
+      reason: errors,
+    });
+  }
+
+  const supabase = req.app.locals.supabase;
+  if (!supabase) {
+    return res.status(500).json({ error: 'Supabase client unavailable', code: 'NO_SUPABASE' });
+  }
+
+  // Upsert venture_resources row using the existing unique key
+  // (venture_id, resource_type, resource_identifier) for idempotency.
+  const { data: resourceRow, error: upsertErr } = await supabase
+    .from('venture_resources')
+    .upsert({
+      venture_id: ventureId,
+      resource_type: 'replit_deployment',
+      resource_identifier: deployment_url,
+      provider: 'replit',
+      status: 'active',
+      repo_url,
+      deployment_url,
+    }, { onConflict: 'venture_id,resource_type,resource_identifier' })
+    .select('id')
+    .single();
+
+  if (upsertErr) {
+    console.error('[stage19-route] register-deployment upsert failed', upsertErr.message);
+    return res.status(500).json({
+      error: 'Failed to persist venture_resources',
+      code: 'RESOURCE_UPSERT_FAILED',
+      detail: upsertErr.message,
+    });
+  }
+
+  // Emit build_mvp_build artifact (writeArtifact handles dedup via is_current).
+  let artifactId;
+  try {
+    artifactId = await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 19,
+      artifactType: ARTIFACT_TYPES.BUILD_MVP_BUILD,
+      title: 'Replit deployment registered',
+      artifactData: {
+        repo_url,
+        deployment_url,
+        registered_at: new Date().toISOString(),
+      },
+      metadata: {
+        registered_via: 'POST /api/stage19/:ventureId/register-deployment',
+        repo_url,
+        deployment_url,
+      },
+      source: 'stage19-register-deployment',
+    });
+  } catch (err) {
+    console.error('[stage19-route] build_mvp_build emit failed', err.message);
+    return res.status(500).json({
+      error: 'venture_resources persisted but artifact emit failed',
+      code: 'ARTIFACT_EMIT_FAILED',
+      detail: err.message,
+      resource_id: resourceRow?.id,
+    });
+  }
+
+  return res.status(200).json({
+    ventureId,
+    repo_url,
+    deployment_url,
+    resource_id: resourceRow?.id,
+    artifact_id: artifactId,
+    artifact_type: ARTIFACT_TYPES.BUILD_MVP_BUILD,
+  });
 }));
 
 export default router;

--- a/tests/integration/api-routes/stage19-endpoints.test.js
+++ b/tests/integration/api-routes/stage19-endpoints.test.js
@@ -1,0 +1,224 @@
+/**
+ * Integration tests for Stage 19 Replit Workflow API Endpoints.
+ *
+ * SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-3 / FR-5
+ *
+ * Covers:
+ *   TS-A: POST register-deployment happy path returns 200, upserts venture_resources,
+ *         emits build_mvp_build artifact
+ *   TS-B: URL validation rejects malformed inputs (400 VALIDATION_FAILED)
+ *   TS-C: Idempotent — re-submitting same payload returns 200, no duplicate artifact
+ *   TS-D: Invalid ventureId UUID rejected (400 INVALID_VENTURE_ID)
+ *
+ * Mock pattern adapted from tests/integration/api-routes/stage18-endpoints.test.js
+ * (buildSupabaseMock + createMockReq/Res + findRoute + runHandlerChain).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock writeArtifact so we can assert on its call args without touching a real DB.
+const mockWriteArtifact = vi.fn();
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: (...args) => mockWriteArtifact(...args),
+}));
+
+// Mock validateUuid so we control validation independently of the regex impl.
+vi.mock('../../../server/middleware/validate.js', () => ({
+  isValidUuid: (v) => typeof v === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v),
+}));
+
+// Mock asyncHandler to a passthrough so we can run handlers directly.
+vi.mock('../../../lib/middleware/eva-error-handler.js', () => ({
+  asyncHandler: (fn) => fn,
+}));
+
+// Mock the unrelated GET-side dependency so module-load doesn't try to import its real graph.
+vi.mock('../../../lib/eva/bridge/replit-prompt-formatter.js', () => ({
+  formatReplitOptimized: vi.fn(),
+}));
+
+const { default: router } = await import('../../../server/routes/stage19.js');
+
+const VALID_UUID = '11111111-2222-3333-4444-555555555555';
+const VALID_REPO = 'https://github.com/owner/repo';
+const VALID_DEPLOYMENT = 'https://my-app.example.replit.app';
+
+function buildSupabaseMock({ upsertResult = null, upsertError = null } = {}) {
+  const upsertSpy = vi.fn().mockReturnValue({
+    select: vi.fn(() => ({
+      single: vi.fn().mockResolvedValue({
+        data: upsertResult ?? { id: 'res-1' },
+        error: upsertError,
+      }),
+    })),
+  });
+  return {
+    from: vi.fn((table) => {
+      if (table === 'venture_resources') {
+        return { upsert: upsertSpy };
+      }
+      return { upsert: vi.fn() };
+    }),
+    _upsertSpy: upsertSpy,
+  };
+}
+
+function createMockReq(params = {}, body = {}, supabase = buildSupabaseMock()) {
+  return { params, body, app: { locals: { supabase } } };
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200, jsonData: null,
+    status(c) { this.statusCode = c; return this; },
+    json(d) { this.jsonData = d; return this; },
+  };
+}
+
+function findRoute(method, path) {
+  for (const layer of router.stack) {
+    if (layer.route && Object.keys(layer.route.methods)[0] === method && layer.route.path === path) {
+      return layer.route.stack.map((s) => s.handle);
+    }
+  }
+  throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+}
+
+async function runHandlerChain(handlers, req, res) {
+  let idx = 0;
+  const next = async (err) => {
+    if (err) throw err;
+    if (idx < handlers.length) await handlers[idx++](req, res, next);
+  };
+  await next();
+}
+
+describe('Stage 19 register-deployment endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteArtifact.mockResolvedValue('artifact-1');
+  });
+
+  describe('POST /:ventureId/register-deployment', () => {
+    const handlers = findRoute('post', '/:ventureId/register-deployment');
+
+    it('TS-A: happy path → 200, upserts venture_resources, emits build_mvp_build artifact (AC-FR3-3)', async () => {
+      const supabase = buildSupabaseMock();
+      const req = createMockReq(
+        { ventureId: VALID_UUID },
+        { repo_url: VALID_REPO, deployment_url: VALID_DEPLOYMENT },
+        supabase,
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonData).toEqual(expect.objectContaining({
+        ventureId: VALID_UUID,
+        repo_url: VALID_REPO,
+        deployment_url: VALID_DEPLOYMENT,
+        resource_id: 'res-1',
+        artifact_id: 'artifact-1',
+        artifact_type: 'build_mvp_build',
+      }));
+      // Confirm venture_resources upsert payload includes both URL columns
+      // and the resource_type discriminator that gives us idempotency.
+      expect(supabase._upsertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          venture_id: VALID_UUID,
+          resource_type: 'replit_deployment',
+          resource_identifier: VALID_DEPLOYMENT,
+          repo_url: VALID_REPO,
+          deployment_url: VALID_DEPLOYMENT,
+        }),
+        expect.objectContaining({ onConflict: expect.any(String) }),
+      );
+      // Confirm artifact emit: lifecycle_stage=19, type=build_mvp_build, is_current dedup default
+      expect(mockWriteArtifact).toHaveBeenCalledTimes(1);
+      const [, opts] = mockWriteArtifact.mock.calls[0];
+      expect(opts.ventureId).toBe(VALID_UUID);
+      expect(opts.lifecycleStage).toBe(19);
+      expect(opts.artifactType).toBe('build_mvp_build');
+      expect(opts.artifactData).toEqual(expect.objectContaining({
+        repo_url: VALID_REPO,
+        deployment_url: VALID_DEPLOYMENT,
+        registered_at: expect.any(String),
+      }));
+    });
+
+    it('TS-B-1: rejects malformed repo_url with 400 VALIDATION_FAILED (AC-FR3-2)', async () => {
+      const req = createMockReq(
+        { ventureId: VALID_UUID },
+        { repo_url: 'not-a-url', deployment_url: VALID_DEPLOYMENT },
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('VALIDATION_FAILED');
+      expect(res.jsonData.invalid).toContain('repo_url');
+      expect(mockWriteArtifact).not.toHaveBeenCalled();
+    });
+
+    it('TS-B-2: rejects http:// (insecure) deployment_url with 400 VALIDATION_FAILED', async () => {
+      const req = createMockReq(
+        { ventureId: VALID_UUID },
+        { repo_url: VALID_REPO, deployment_url: 'http://insecure.example' },
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('VALIDATION_FAILED');
+      expect(res.jsonData.invalid).toContain('deployment_url');
+    });
+
+    it('TS-B-3: rejects non-github.com repo URLs with 400 VALIDATION_FAILED', async () => {
+      const req = createMockReq(
+        { ventureId: VALID_UUID },
+        { repo_url: 'https://gitlab.com/owner/repo', deployment_url: VALID_DEPLOYMENT },
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.invalid).toContain('repo_url');
+    });
+
+    it('TS-C: idempotent — re-submitting same payload still returns 200; writeArtifact dedup handles it (AC-FR3-5)', async () => {
+      // Both calls use the same supabase mock; upsert returns the same row id;
+      // writeArtifact returns the same artifact id (its is_current dedup is unit-tested
+      // separately in artifact-persistence-service tests). Endpoint contract is: both
+      // calls 200 with same payload.
+      const supabase = buildSupabaseMock({ upsertResult: { id: 'res-1' } });
+      const body = { repo_url: VALID_REPO, deployment_url: VALID_DEPLOYMENT };
+      const req1 = createMockReq({ ventureId: VALID_UUID }, body, supabase);
+      const res1 = createMockRes();
+      await runHandlerChain(handlers, req1, res1);
+      const req2 = createMockReq({ ventureId: VALID_UUID }, body, supabase);
+      const res2 = createMockRes();
+      await runHandlerChain(handlers, req2, res2);
+      expect(res1.statusCode).toBe(200);
+      expect(res2.statusCode).toBe(200);
+      expect(res1.jsonData.artifact_id).toBe(res2.jsonData.artifact_id);
+      expect(res1.jsonData.resource_id).toBe(res2.jsonData.resource_id);
+    });
+
+    it('TS-D: rejects invalid UUID with 400 INVALID_VENTURE_ID', async () => {
+      const req = createMockReq(
+        { ventureId: 'not-a-uuid' },
+        { repo_url: VALID_REPO, deployment_url: VALID_DEPLOYMENT },
+      );
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('INVALID_VENTURE_ID');
+      expect(mockWriteArtifact).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty body fields with 400', async () => {
+      const req = createMockReq({ ventureId: VALID_UUID }, {});
+      const res = createMockRes();
+      await runHandlerChain(handlers, req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonData.code).toBe('VALIDATION_FAILED');
+      expect(res.jsonData.invalid.sort()).toEqual(['deployment_url', 'repo_url']);
+    });
+  });
+});

--- a/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
+++ b/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for lib/eva/lifecycle/exit-gate-enforcer.
+ *
+ * SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 / FR-2 / FR-5
+ *
+ * Covers:
+ *   - allow when both gates satisfied
+ *   - block when build_mvp_build artifact missing
+ *   - block when venture_resources.repo_url is null
+ *   - block when venture_resources.deployment_url is null
+ *   - flag OFF skips enforcement (legacy behavior)
+ *   - empty gates.exit array → allow
+ *   - missing verifier for prose gate string → skip with WARN, allow
+ *   - lifecycle_stage_config read failure → block with structured reason
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We need to control process.env.LEO_S19_EXIT_GATE_ENFORCER per test, but the
+// enforcer reads it at module-load. Use vi.resetModules + dynamic import.
+const VENTURE_ID = '11111111-2222-3333-4444-555555555555';
+
+function buildSupabaseMock({
+  stageConfig = { exit: ['Application deployed', 'GitHub repo URL stored in venture_resources'] },
+  buildArtifactPresent = true,
+  resourceRow = { repo_url: 'https://github.com/foo/bar', deployment_url: 'https://app.example.replit.app' },
+  configError = null,
+} = {}) {
+  const buildEqChain = (finalResult) => {
+    const chain = {
+      eq: vi.fn(() => chain),
+      not: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      maybeSingle: vi.fn().mockResolvedValue(finalResult),
+    };
+    return chain;
+  };
+
+  return {
+    from: vi.fn((table) => {
+      if (table === 'lifecycle_stage_config') {
+        return {
+          select: vi.fn(() => buildEqChain({
+            data: configError ? null : { metadata: { gates: stageConfig } },
+            error: configError,
+          })),
+        };
+      }
+      if (table === 'venture_artifacts') {
+        return {
+          select: vi.fn(() => buildEqChain({
+            data: buildArtifactPresent ? { id: 'art-1' } : null,
+            error: null,
+          })),
+        };
+      }
+      if (table === 'venture_resources') {
+        return {
+          select: vi.fn(() => buildEqChain({
+            data: resourceRow,
+            error: null,
+          })),
+        };
+      }
+      return { select: vi.fn() };
+    }),
+  };
+}
+
+async function importEnforcerWithFlag(value) {
+  vi.resetModules();
+  if (value === undefined) {
+    delete process.env.LEO_S19_EXIT_GATE_ENFORCER;
+  } else {
+    process.env.LEO_S19_EXIT_GATE_ENFORCER = value;
+  }
+  return await import('../../../../lib/eva/lifecycle/exit-gate-enforcer.js');
+}
+
+describe('exit-gate-enforcer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('flag enforcement (TR-3)', () => {
+    it('default flag (unset) is treated as ON / enforced', async () => {
+      const { getEnforcementFlag } = await importEnforcerWithFlag(undefined);
+      const flag = getEnforcementFlag();
+      expect(flag.enforced).toBe(true);
+      expect(flag.value).toBe('on');
+    });
+
+    it('flag=off short-circuits enforcement and returns allowed=true with flag_enforced=false', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('off');
+      const supabase = buildSupabaseMock();
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(true);
+      expect(result.flag_enforced).toBe(false);
+      expect(result.gates_checked).toEqual([]);
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('flag=on enforces and reports flag_enforced=true', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock();
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.flag_enforced).toBe(true);
+    });
+  });
+
+  describe('S19 happy path (AC-FR2-1: both gates passed)', () => {
+    it('allows advance when build_mvp_build present AND venture_resources URLs populated', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock();
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(true);
+      expect(result.blocked_by).toEqual([]);
+      expect(result.gates_checked).toEqual([
+        'Application deployed',
+        'GitHub repo URL stored in venture_resources',
+      ]);
+      expect(result.stage_number).toBe(19);
+    });
+  });
+
+  describe('S19 blocking cases (AC-FR2-1)', () => {
+    it('blocks when build_mvp_build artifact missing', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({ buildArtifactPresent: false });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by).toHaveLength(1);
+      expect(result.blocked_by[0]).toMatch(/Application deployed/);
+      expect(result.blocked_by[0]).toMatch(/build_mvp_build/);
+    });
+
+    it('blocks when venture_resources row absent (repo_url + deployment_url unpopulated)', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      // Simulate the .not().not() filter returning no row when either column is null.
+      const supabase = buildSupabaseMock({ resourceRow: null });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by).toHaveLength(1);
+      expect(result.blocked_by[0]).toMatch(/GitHub repo URL stored/);
+      expect(result.blocked_by[0]).toMatch(/repo_url and\/or deployment_url not populated/);
+    });
+
+    it('blocks with multiple reasons when both gates fail', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({
+        buildArtifactPresent: false,
+        resourceRow: null,
+      });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by).toHaveLength(2);
+    });
+  });
+
+  describe('config / verifier edge cases', () => {
+    it('returns allowed=true when gates.exit array is empty', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({ stageConfig: { exit: [] } });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(true);
+      expect(result.gates_checked).toEqual([]);
+    });
+
+    it('returns allowed=true when gates.exit is missing (no metadata.gates key)', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({ stageConfig: undefined });
+      // Override the from() to return metadata without gates.exit key.
+      supabase.from = vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+          })),
+        })),
+      }));
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('skips unknown gate strings (no verifier registered) with a WARN, still allows', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({
+        stageConfig: { exit: ['Frobnicate the widget cache'] },
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(true);
+      expect(result.gates_checked).toEqual(['Frobnicate the widget cache']);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('blocks with structured reason when lifecycle_stage_config read fails', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({ configError: { message: 'simulated PG error' } });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by[0]).toMatch(/lifecycle_stage_config read failed/);
+      expect(result.blocked_by[0]).toMatch(/simulated PG error/);
+    });
+  });
+
+  describe('AC-FR2-4: structured payload shape', () => {
+    it('returns {allowed, blocked_by[], gates_checked[], stage_number, flag_enforced}', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock();
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result).toEqual(expect.objectContaining({
+        allowed: expect.any(Boolean),
+        blocked_by: expect.any(Array),
+        gates_checked: expect.any(Array),
+        stage_number: 19,
+        flag_enforced: expect.any(Boolean),
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes spec/code drift in Stage 19 lifecycle that allowed venture transitions to fire with `approved_by=null` cascading 3 stages in 30s on PrivacyPatrol AI 2026-05-03. Adds the operator-facing Replit deployment registration surface plus the data-driven exit-gate enforcer the lifecycle_stage_config.metadata.gates.exit declarations have been waiting for.

**Phase 1 — Schema + Registry (~30 LOC):**
- `database/migrations/20260503_venture_resources_add_replit_urls.sql` — idempotent ADD COLUMN IF NOT EXISTS for `repo_url` + `deployment_url` plus partial unique index on `(venture_id, deployment_url) WHERE deployment_url IS NOT NULL`
- `lib/eva/artifact-types.js` — `ARTIFACT_TYPE_BY_STAGE[19]` is now `[BLUEPRINT_SPRINT_PLAN, BUILD_MVP_BUILD]` (DUAL spec-authority direction locked at LEAD; old comment preserved + new comment block above)
- `lib/eva/__tests__/stage-19-binding-contract.test.js` — 5 new test cases in a new describe block; existing 19 cases unchanged (24/24 pass)
- `docs/reference/schema/engineer/tables/venture_resources.md` — documented new columns + partial unique index

**Phase 2 — Enforcer + Endpoint (~250 LOC, behind `LEO_S19_EXIT_GATE_ENFORCER` flag default ON):**
- `lib/eva/lifecycle/exit-gate-enforcer.js` (NEW) — wraps `advance_venture_stage` RPC. Reads `lifecycle_stage_config.metadata.gates.exit`. Returns `{allowed, blocked_by[], gates_checked[], stage_number, flag_enforced}`.
- `lib/eva/lifecycle/exit-gate-verifiers.js` (NEW) — substring-matched gate-string -> verifier dispatcher. v1 ships 2 verifiers (build_mvp_build present + venture_resources URLs populated).
- `server/routes/stage19.js` — added `POST /:ventureId/register-deployment`. Validates URL shapes, upserts venture_resources, emits `build_mvp_build` artifact via `writeArtifact` (is_current dedup keeps it idempotent).
- 12 unit cases for enforcer + 7 integration cases for endpoint = 19/19 pass.

**Companion EHG repo PR:** [EHG#XXX](https://github.com/rickfelix/ehg) — Phase 3 UI (DeploymentRegistrationForm + useRegisterReplitDeployment hook + BuildMethodSelector wiring).

**LEAD scope-lock:** FR-1 + FR-2 + FR-3 + FR-4 + FR-5. Deferred to follow-up SDs: FR-4 broader S10/S18/S19 enforcement, FR-5 S15-S22 audit, FR-6 PrivacyPatrol backfill. Enforcer is NOT yet wired into the live `advance_venture_stage` call site — that wiring is itself a deferred follow-up SD per scope-lock so this PR ships a self-contained primitive.

**Sub-agent evidence (EXEC phase):**
- TESTING: PASS 92/100 (id 9c5ad7f5)
- REGRESSION: PASS 92/100 (id 853d668f)
- DESIGN: PASS 96/100 (id 85382eda)

**Cross-SD:** synergistic with SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001 (approved_by=null cascade RCA) and SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001 (overlaps deferred FR-5 audit).

## Test plan

- [x] `npx vitest run lib/eva/__tests__/stage-19-binding-contract.test.js` — 24/24 pass (existing 19 untouched + 5 new dual-emit cases)
- [x] `npx vitest run tests/unit/eva/lifecycle/exit-gate-enforcer.test.js` — 12/12 pass (flag-on/off, S19 happy path, missing-build/missing-URL/both-fail, empty/missing gates.exit, unknown gate WARN, config read failure, payload shape)
- [x] `npx vitest run tests/integration/api-routes/stage19-endpoints.test.js` — 7/7 pass (happy path + 3 URL validation rejections + idempotency + invalid UUID + empty body)
- [x] Total: 43/43 vitest cases pass in EHG_Engineer
- [ ] Migration is idempotent — re-running `database/migrations/20260503_venture_resources_add_replit_urls.sql` is a no-op (verified by IF NOT EXISTS construction)
- [ ] Manual S19 chairman smoke test on a fresh venture once both this PR and the EHG companion PR ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)