### PR TITLE
feat(SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001): observability hardening + audit + backfill

### DIFF
--- a/database/migrations/20260503_001_backfill_missing_stage_transitions.sql
+++ b/database/migrations/20260503_001_backfill_missing_stage_transitions.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001 FR-004
+-- Backfill missing venture_stage_transitions rows for PrivacyPatrol AI venture
+--
+-- Origin: PrivacyPatrol AI venture monitoring (2026-05-03) revealed 3 missing
+-- audit-trail rows: S12->S13, S15->S16, S16->S17. The advance happened
+-- (ventures.current_lifecycle_stage and venture_stage_work both consistent),
+-- but the transition write silently failed at stage-execution-worker.js:2211
+-- before the FR-002 observability fix landed.
+--
+-- Idempotency: deterministic v5 UUID idempotency_key + ON CONFLICT DO NOTHING
+-- against the partial unique index idx_venture_stage_transitions_idempotency
+-- ON (venture_id, idempotency_key) WHERE idempotency_key IS NOT NULL.
+-- Re-running this migration produces zero additional rows.
+--
+-- transition_type='normal' is used because the CHECK constraint allows only
+-- ('normal','skip','rollback','pivot'); 'backfilled' would fail. Provenance
+-- is preserved in the deterministic idempotency_key suffix and this header.
+--
+-- Down-migration recipe (emergency rollback):
+--   DELETE FROM venture_stage_transitions
+--   WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+--     AND idempotency_key IN (
+--       uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:12->13:backfill-sd-leo-fix-vst-001'),
+--       uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:15->16:backfill-sd-leo-fix-vst-001'),
+--       uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:16->17:backfill-sd-leo-fix-vst-001')
+--     );
+-- ============================================================================
+
+BEGIN;
+
+-- Ensure uuid-ossp extension is available for uuid_generate_v5
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Insert the 3 missing PrivacyPatrol AI transitions with deterministic
+-- idempotency keys derived from venture_id + transition shape + SD provenance.
+-- The OID namespace UUID '6ba7b812-9dad-11d1-80b4-00c04fd430c8' is the standard
+-- DNS-namespace UUID; we use it as a stable namespace constant for v5 keys.
+INSERT INTO venture_stage_transitions (
+  venture_id,
+  from_stage,
+  to_stage,
+  transition_type,
+  idempotency_key
+) VALUES
+  (
+    '08d20036-03c9-4a26-bbc5-f37a18dfdf23',
+    12,
+    13,
+    'normal',
+    uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:12->13:backfill-sd-leo-fix-vst-001')
+  ),
+  (
+    '08d20036-03c9-4a26-bbc5-f37a18dfdf23',
+    15,
+    16,
+    'normal',
+    uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:15->16:backfill-sd-leo-fix-vst-001')
+  ),
+  (
+    '08d20036-03c9-4a26-bbc5-f37a18dfdf23',
+    16,
+    17,
+    'normal',
+    uuid_generate_v5('6ba7b812-9dad-11d1-80b4-00c04fd430c8'::uuid, '08d20036-03c9-4a26-bbc5-f37a18dfdf23:16->17:backfill-sd-leo-fix-vst-001')
+  )
+ON CONFLICT (venture_id, idempotency_key) DO NOTHING;
+
+-- Post-flight check: confirm exactly 3 rows now exist for the affected venture
+-- at these stage boundaries. Comment out for production apply if you want to
+-- avoid raising on partial state; uncomment for staging validation.
+--
+-- DO $$
+-- DECLARE
+--   v_count INT;
+-- BEGIN
+--   SELECT COUNT(*) INTO v_count
+--   FROM venture_stage_transitions
+--   WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+--     AND ((from_stage = 12 AND to_stage = 13) OR
+--          (from_stage = 15 AND to_stage = 16) OR
+--          (from_stage = 16 AND to_stage = 17));
+--   IF v_count <> 3 THEN
+--     RAISE EXCEPTION 'Backfill verification failed: expected 3 rows, found %', v_count;
+--   END IF;
+-- END $$;
+
+COMMIT;

--- a/docs/audits/sd-leo-fix-venture-stage-transitions-001-advance-paths.md
+++ b/docs/audits/sd-leo-fix-venture-stage-transitions-001-advance-paths.md
@@ -1,0 +1,84 @@
+# Audit: venture_stage_transitions writer paths
+
+**SD**: SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001
+**Date**: 2026-05-03
+**Origin**: PrivacyPatrol AI venture monitoring (venture `08d20036-03c9-4a26-bbc5-f37a18dfdf23`) revealed 3 missing transition rows: S12→S13, S15→S16, S16→S17.
+
+## FR-001 Goal
+
+Enumerate every code path that mutates `ventures.current_lifecycle_stage` in EHG_Engineer. For each, classify whether it writes a `venture_stage_transitions` audit row.
+
+## Findings
+
+### Canonical writers (write transition rows)
+
+| # | Path | File:Line | Trigger | Writes transitions |
+|---|------|-----------|---------|---------------------|
+| 1 | `_advanceStage` (worker fast-path) | `lib/eva/stage-execution-worker.js:2107-2216` | Worker normal advance, governance override | YES (lines 2186-2213) — has dedup guard + try/catch |
+| 2 | `advanceStage` (RPC gateway) | `lib/eva/artifact-persistence-service.js:377-420` | Calls `fn_advance_venture_stage` RPC | YES (RPC writes transition row inside SECURITY DEFINER body); throws on RPC error |
+| 3 | `bootstrap_venture_workflow` (DB RPC) | `ehg/supabase/migrations/20260320_001_*.sql:197-299` | Initial bootstrap (from_stage=0) | YES (lines 278-285), idempotent via uuid_v5 |
+
+### Direct mutators (call sites)
+
+`grep -nE "\.update\\(.*current_lifecycle_stage|\\.from\\('ventures'\\).*current_lifecycle_stage" lib/` returns only one direct site:
+
+| Path | File:Line | Calls _advanceStage downstream? |
+|------|-----------|---------------------------------|
+| `_advanceStage` body | `lib/eva/stage-execution-worker.js:2111-2114` | n/a (this IS the writer) |
+
+All other usages are reads (SELECT) or test fixtures.
+
+### Non-canonical advance paths
+
+**None located in EHG_Engineer/lib/eva.** Both `eva-orchestrator.js` (line 424 detects `stepResult.artifacts`) and the worker's normal cycle (`processStage` → `_advanceStage`) flow through path #1. The early-exit paths at `stage-execution-worker.js:792, 887` (referenced by RCA Explore) also call `_advanceStage` per the same trampoline.
+
+### Why PrivacyPatrol AI's 3 transitions are missing
+
+Most likely failure mode (database-agent evidence row `7b47a137`): the SELECT or INSERT inside the existing try/catch at `stage-execution-worker.js:2190-2213` failed silently. The catch only logs `warn`, never emits a structured event. Supabase v2 returns `{data, error}` — does NOT throw. The current code does not check `error` on the SELECT, so a quiet RLS denial or connectivity flap can produce `data: null, error: <something>`, the code interprets `data:null` as "no row exists", proceeds with INSERT, INSERT fails for the same reason, catch records a warning, and the venture continues advancing.
+
+There may also have been a transient connectivity issue on the day of the run; this audit cannot prove the exact cause without observability that did not exist.
+
+## FR-003 Centralization Verdict
+
+**No-op.** Audit reveals zero non-canonical advance paths. FR-003 resolves to "no refactor needed; existing centralization at `_advanceStage` and `advanceStage` is sufficient." FR-002 (observability hardening) does the heavy lifting — once silent fails surface, the system is self-correcting for future occurrences.
+
+## FR-002 Observability Plan
+
+`stage-execution-worker.js:2186-2213` rewritten:
+
+1. SELECT block separated from INSERT block, each with its own try/catch.
+2. SELECT block also checks `error` field of Supabase response (current code does not).
+3. On failure of either block, emit `eva_orchestration_events` row with `event_type='escalation'` (per database-agent: `transition_record_failed` is not in the `chk_event_type` allowed list) and `event_data.subtype='transition_record_failed'` plus `failure_phase` = `dedup_guard_select` | `insert`.
+4. Logger level escalated from `warn` → `error`.
+5. Non-fatal preserved (advance completes even if audit fails).
+
+## FR-004 Backfill Plan
+
+Idempotent migration inserts the 3 missing PrivacyPatrol AI rows using deterministic v5 UUID idempotency keys:
+
+```sql
+INSERT INTO venture_stage_transitions (venture_id, from_stage, to_stage, transition_type, idempotency_key)
+VALUES
+  ('08d20036-...', 12, 13, 'normal', uuid_generate_v5(uuid_ns_oid(), '08d20036-...:12->13:backfill')),
+  ('08d20036-...', 15, 16, 'normal', uuid_generate_v5(uuid_ns_oid(), '08d20036-...:15->16:backfill')),
+  ('08d20036-...', 16, 17, 'normal', uuid_generate_v5(uuid_ns_oid(), '08d20036-...:16->17:backfill'))
+ON CONFLICT (venture_id, idempotency_key) DO NOTHING;
+```
+
+The partial unique index `idx_venture_stage_transitions_idempotency ON (venture_id, idempotency_key) WHERE idempotency_key IS NOT NULL` (per database-agent finding) makes ON CONFLICT safe.
+
+`transition_type='normal'` is used because the `transition_type` CHECK constraint allows only `('normal', 'skip', 'rollback', 'pivot')` — `'backfilled'` would fail. Provenance is preserved in a comment + the deterministic idempotency key suffix.
+
+## FR-005 Test Coverage Plan
+
+- **Unit (this SD)**: vitest forces SELECT throw + INSERT throw, asserts `eva_orchestration_events` row emitted with correct shape, assertion advance completes (non-fatal preserved).
+- **Integration (FR-005)**: deferred to follow-up if the unit-level coverage is insufficient. Existing test scaffolding at `tests/integration/pipeline-s0-s17.test.js` is the seed for a future regression.
+
+## Conclusion
+
+Audit confirms no architectural drift; the defect is observability gap, not design. Fix is observability hardening (FR-002) + backfill (FR-004) + tests. FR-003 is a no-op. FR-005 ships unit coverage; full integration regression deferred.
+
+## Sub-agent Evidence
+
+- `db24af6f-5a6e-40cf-a948-3de4d58f7800` — TESTING agent (PASS, 85)
+- `7b47a137-733c-4f01-84b5-b61aea8179ad` — DATABASE agent (PASS, 92)

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2187,9 +2187,16 @@ export class StageExecutionWorker {
     // SD-LEO-FIX-EVA-STAGE-WORKER-001: Previously only the RPC path (via
     // artifact-persistence-service.js) wrote transitions. This fast-path
     // was missing them, causing gaps at gate-override boundaries.
+    //
+    // SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001 FR-002: Split SELECT/INSERT
+    // into separate try blocks, check Supabase {data, error} response shape
+    // (Supabase v2 does NOT throw on row errors), and emit a structured
+    // eva_orchestration_events row when audit writes fail. Logger escalated
+    // warn→error. Non-fatal preserved — advance completes even if audit drops.
+    let dedupOk = true;
+    let existingTransition = null;
     try {
-      // Dedup guard: prevent duplicate transition records from chairman re-clicks
-      const { data: existingTransition } = await this._supabase
+      const { data, error } = await this._supabase
         .from('venture_stage_transitions')
         .select('id')
         .eq('venture_id', ventureId)
@@ -2197,9 +2204,26 @@ export class StageExecutionWorker {
         .eq('to_stage', toStage)
         .limit(1)
         .maybeSingle();
+      if (error) throw error;
+      existingTransition = data;
+    } catch (selectErr) {
+      dedupOk = false;
+      await this._emitTransitionFailureEvent({
+        venture_id: ventureId,
+        from_stage: fromStage,
+        to_stage: toStage,
+        advancement_type: advancementType,
+        failure_phase: 'dedup_guard_select',
+        error_message: selectErr?.message || String(selectErr),
+      });
+      this._logger.error(`[SAE] Transition dedup guard SELECT failed (non-fatal): ${selectErr?.message || selectErr}`);
+    }
 
-      if (!existingTransition) {
-        await this._supabase
+    // Skip INSERT if dedup-guard failed — we cannot tell if a row already exists,
+    // and a duplicate write is worse than a missed audit (which is already surfaced).
+    if (dedupOk && !existingTransition) {
+      try {
+        const { error: insertErr } = await this._supabase
           .from('venture_stage_transitions')
           .insert({
             venture_id: ventureId,
@@ -2207,12 +2231,75 @@ export class StageExecutionWorker {
             to_stage: toStage,
             transition_type: advancementType === 'governance_override' ? 'governance_override' : 'normal',
           });
+        if (insertErr) throw insertErr;
+      } catch (insertErr) {
+        await this._emitTransitionFailureEvent({
+          venture_id: ventureId,
+          from_stage: fromStage,
+          to_stage: toStage,
+          advancement_type: advancementType,
+          failure_phase: 'insert',
+          error_message: insertErr?.message || String(insertErr),
+        });
+        this._logger.error(`[SAE] Transition INSERT failed (non-fatal): ${insertErr?.message || insertErr}`);
       }
-    } catch (transErr) {
-      this._logger.warn(`[SAE] Transition record failed (non-fatal): ${transErr.message}`);
     }
 
     this._logger.log(`[SAE] Advanced S${fromStage} → S${toStage} (type=${advancementType}, venture=${ventureId.slice(0, 8)})`);
+  }
+
+  /**
+   * Emit a structured observability event when a venture_stage_transitions
+   * audit-trail write fails. Used by _advanceStage's dedup-guard SELECT and
+   * INSERT failure paths so silent fails surface in eva_orchestration_events
+   * for analytics + alerting.
+   *
+   * SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001 FR-002.
+   *
+   * The eva_orchestration_events.chk_event_type CHECK constraint allows only
+   * a fixed enum: stage_completed, stage_started, decision_requested,
+   * decision_resolved, escalation, dfe_triggered, agent_communication,
+   * health_score_changed, venture_created, venture_status_changed,
+   * chairman_override, gate_passed, gate_failed, custom. We use 'escalation'
+   * with metadata.subtype='transition_record_failed' so analytics can split
+   * on subtype while staying schema-compatible.
+   *
+   * Non-fatal: if event emission itself fails, log and move on — this is the
+   * last-resort surfacing layer.
+   *
+   * @param {Object} payload
+   * @param {string} payload.venture_id
+   * @param {number} payload.from_stage
+   * @param {number} payload.to_stage
+   * @param {string} payload.advancement_type
+   * @param {string} payload.failure_phase - 'dedup_guard_select' | 'insert'
+   * @param {string} payload.error_message
+   */
+  async _emitTransitionFailureEvent(payload) {
+    try {
+      const { error } = await this._supabase
+        .from('eva_orchestration_events')
+        .insert({
+          event_type: 'escalation',
+          event_source: 'stage_execution_worker',
+          venture_id: payload.venture_id,
+          event_data: {
+            subtype: 'transition_record_failed',
+            from_stage: payload.from_stage,
+            to_stage: payload.to_stage,
+            advancement_type: payload.advancement_type,
+            failure_phase: payload.failure_phase,
+            error_message: payload.error_message,
+            sd_origin: 'SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001',
+          },
+          chairman_flagged: false,
+        });
+      if (error) {
+        this._logger.error(`[SAE] Failed to emit transition_record_failed event (last-resort): ${error.message}`);
+      }
+    } catch (eventErr) {
+      this._logger.error(`[SAE] Failed to emit transition_record_failed event (last-resort): ${eventErr?.message || eventErr}`);
+    }
   }
 
   /**

--- a/tests/unit/eva/stage-execution-worker-transition-observability.test.js
+++ b/tests/unit/eva/stage-execution-worker-transition-observability.test.js
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001 FR-002 — observability hardening
+ * for the venture_stage_transitions audit-trail writer in
+ * lib/eva/stage-execution-worker.js:_advanceStage and _emitTransitionFailureEvent.
+ *
+ * The existing stage-execution-worker-advancement.test.js reconstructs
+ * _advanceStage's side-effect chain in-test (the module has too many file-level
+ * side-effects to import directly). We follow the same pattern, scoped to
+ * Side-effect 6 (transitions write) + the new helper.
+ */
+
+function createMockSupabase(overrides = {}) {
+  // Per-table response queue lets a test set the result for each call.
+  const responses = {
+    venture_stage_transitions_select: { data: null, error: null },
+    venture_stage_transitions_insert: { error: null },
+    eva_orchestration_events_insert: { error: null },
+    ...overrides,
+  };
+
+  const insertedRows = [];
+
+  const chainBuilder = (tableName) => {
+    const chain = {
+      _table: tableName,
+      _select: false,
+      _insert: false,
+      select: vi.fn(function () { this._select = true; return this; }),
+      eq: vi.fn(function () { return this; }),
+      limit: vi.fn(function () { return this; }),
+      maybeSingle: vi.fn(async function () {
+        if (this._table === 'venture_stage_transitions' && this._select) {
+          return responses.venture_stage_transitions_select;
+        }
+        return { data: null, error: null };
+      }),
+      insert: vi.fn(async function (row) {
+        insertedRows.push({ table: this._table, row });
+        if (this._table === 'venture_stage_transitions') {
+          return responses.venture_stage_transitions_insert;
+        }
+        if (this._table === 'eva_orchestration_events') {
+          return responses.eva_orchestration_events_insert;
+        }
+        return { error: null };
+      }),
+    };
+    return chain;
+  };
+
+  return {
+    from: vi.fn((table) => chainBuilder(table)),
+    _insertedRows: insertedRows,
+  };
+}
+
+// Reconstruct just Side-effect 6 + helper as it appears in the worker.
+function makeTransitionWriter(supabase, logger) {
+  const worker = { _supabase: supabase, _logger: logger };
+
+  worker._emitTransitionFailureEvent = async function (payload) {
+    try {
+      const { error } = await this._supabase
+        .from('eva_orchestration_events')
+        .insert({
+          event_type: 'escalation',
+          event_source: 'stage_execution_worker',
+          venture_id: payload.venture_id,
+          event_data: {
+            subtype: 'transition_record_failed',
+            from_stage: payload.from_stage,
+            to_stage: payload.to_stage,
+            advancement_type: payload.advancement_type,
+            failure_phase: payload.failure_phase,
+            error_message: payload.error_message,
+            sd_origin: 'SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001',
+          },
+          chairman_flagged: false,
+        });
+      if (error) {
+        this._logger.error(`[SAE] Failed to emit transition_record_failed event (last-resort): ${error.message}`);
+      }
+    } catch (eventErr) {
+      this._logger.error(`[SAE] Failed to emit transition_record_failed event (last-resort): ${eventErr?.message || eventErr}`);
+    }
+  };
+
+  // Side-effect 6 only (the new split SELECT/INSERT block)
+  worker._writeTransition = async function (ventureId, fromStage, toStage, advancementType) {
+    let dedupOk = true;
+    let existingTransition = null;
+    try {
+      const { data, error } = await this._supabase
+        .from('venture_stage_transitions')
+        .select('id')
+        .eq('venture_id', ventureId)
+        .eq('from_stage', fromStage)
+        .eq('to_stage', toStage)
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      existingTransition = data;
+    } catch (selectErr) {
+      dedupOk = false;
+      await this._emitTransitionFailureEvent({
+        venture_id: ventureId,
+        from_stage: fromStage,
+        to_stage: toStage,
+        advancement_type: advancementType,
+        failure_phase: 'dedup_guard_select',
+        error_message: selectErr?.message || String(selectErr),
+      });
+      this._logger.error(`[SAE] Transition dedup guard SELECT failed (non-fatal): ${selectErr?.message || selectErr}`);
+    }
+
+    if (dedupOk && !existingTransition) {
+      try {
+        const { error: insertErr } = await this._supabase
+          .from('venture_stage_transitions')
+          .insert({
+            venture_id: ventureId,
+            from_stage: fromStage,
+            to_stage: toStage,
+            transition_type: advancementType === 'governance_override' ? 'governance_override' : 'normal',
+          });
+        if (insertErr) throw insertErr;
+      } catch (insertErr) {
+        await this._emitTransitionFailureEvent({
+          venture_id: ventureId,
+          from_stage: fromStage,
+          to_stage: toStage,
+          advancement_type: advancementType,
+          failure_phase: 'insert',
+          error_message: insertErr?.message || String(insertErr),
+        });
+        this._logger.error(`[SAE] Transition INSERT failed (non-fatal): ${insertErr?.message || insertErr}`);
+      }
+    }
+  };
+
+  return worker;
+}
+
+describe('FR-002: transition_record_failed observability', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  });
+
+  it('happy path: SELECT returns no row, INSERT succeeds, no event emitted', async () => {
+    const supabase = createMockSupabase();
+    const worker = makeTransitionWriter(supabase, logger);
+
+    await worker._writeTransition('11111111-1111-1111-1111-111111111111', 12, 13, 'normal');
+
+    const insertedTables = supabase._insertedRows.map(r => r.table);
+    expect(insertedTables).toEqual(['venture_stage_transitions']);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('SELECT failure emits eva_orchestration_events row + logger.error; INSERT skipped', async () => {
+    const supabase = createMockSupabase({
+      venture_stage_transitions_select: { data: null, error: { message: 'simulated RLS denial' } },
+    });
+    const worker = makeTransitionWriter(supabase, logger);
+
+    await worker._writeTransition('22222222-2222-2222-2222-222222222222', 15, 16, 'normal');
+
+    const eventRows = supabase._insertedRows.filter(r => r.table === 'eva_orchestration_events');
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0].row.event_type).toBe('escalation');
+    expect(eventRows[0].row.event_data.subtype).toBe('transition_record_failed');
+    expect(eventRows[0].row.event_data.failure_phase).toBe('dedup_guard_select');
+    expect(eventRows[0].row.event_data.from_stage).toBe(15);
+    expect(eventRows[0].row.event_data.to_stage).toBe(16);
+    expect(eventRows[0].row.event_data.error_message).toMatch(/RLS denial/);
+
+    // Critical: INSERT must be skipped when dedup guard fails (avoid duplicate writes)
+    const transitionInserts = supabase._insertedRows.filter(r => r.table === 'venture_stage_transitions');
+    expect(transitionInserts).toHaveLength(0);
+
+    expect(logger.error).toHaveBeenCalled();
+    const errorMsgs = logger.error.mock.calls.map(c => String(c[0]));
+    expect(errorMsgs.some(m => m.includes('dedup guard SELECT failed'))).toBe(true);
+  });
+
+  it('INSERT failure emits eva_orchestration_events row + logger.error; advance still completes', async () => {
+    const supabase = createMockSupabase({
+      venture_stage_transitions_select: { data: null, error: null },
+      venture_stage_transitions_insert: { error: { message: 'simulated INSERT conflict' } },
+    });
+    const worker = makeTransitionWriter(supabase, logger);
+
+    let threw = false;
+    try {
+      await worker._writeTransition('33333333-3333-3333-3333-333333333333', 16, 17, 'normal');
+    } catch (e) {
+      threw = true;
+    }
+    // Non-fatal preserved — function does NOT throw out
+    expect(threw).toBe(false);
+
+    const eventRows = supabase._insertedRows.filter(r => r.table === 'eva_orchestration_events');
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0].row.event_data.failure_phase).toBe('insert');
+    expect(eventRows[0].row.event_data.error_message).toMatch(/INSERT conflict/);
+    expect(eventRows[0].row.event_data.sd_origin).toBe('SD-LEO-FIX-VENTURE-STAGE-TRANSITIONS-001');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('event-emit failure is also logged (last-resort observability)', async () => {
+    const supabase = createMockSupabase({
+      venture_stage_transitions_insert: { error: { message: 'primary INSERT failed' } },
+      eva_orchestration_events_insert: { error: { message: 'event-emit also failed' } },
+    });
+    const worker = makeTransitionWriter(supabase, logger);
+
+    await worker._writeTransition('44444444-4444-4444-4444-444444444444', 12, 13, 'normal');
+
+    // Two error logs: original failure + last-resort emit failure
+    const errorMsgs = logger.error.mock.calls.map(c => String(c[0]));
+    expect(errorMsgs.some(m => m.includes('Transition INSERT failed'))).toBe(true);
+    expect(errorMsgs.some(m => m.includes('Failed to emit transition_record_failed event'))).toBe(true);
+  });
+
+  it('existing transition: dedup guard returns row, no INSERT attempted', async () => {
+    const supabase = createMockSupabase({
+      venture_stage_transitions_select: { data: { id: 'existing-uuid' }, error: null },
+    });
+    const worker = makeTransitionWriter(supabase, logger);
+
+    await worker._writeTransition('55555555-5555-5555-5555-555555555555', 12, 13, 'normal');
+
+    const transitionInserts = supabase._insertedRows.filter(r => r.table === 'venture_stage_transitions');
+    expect(transitionInserts).toHaveLength(0);
+
+    const eventRows = supabase._insertedRows.filter(r => r.table === 'eva_orchestration_events');
+    expect(eventRows).toHaveLength(0);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('governance_override transition_type passes through correctly', async () => {
+    const supabase = createMockSupabase();
+    const worker = makeTransitionWriter(supabase, logger);
+
+    await worker._writeTransition('66666666-6666-6666-6666-666666666666', 10, 11, 'governance_override');
+
+    const transitionInserts = supabase._insertedRows.filter(r => r.table === 'venture_stage_transitions');
+    expect(transitionInserts).toHaveLength(1);
+    expect(transitionInserts[0].row.transition_type).toBe('governance_override');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the silent-fail mode in `stage-execution-worker.js:_advanceStage` that hid PrivacyPatrol AI's 3 missing `venture_stage_transitions` rows (S12→S13, S15→S16, S16→S17), discovered during 2026-05-03 venture monitoring run.

- **FR-001 audit**: enumerates every advance path in `EHG_Engineer/lib/eva` — zero non-canonical paths; defect is observability gap, not architectural drift. FR-003 resolves no-op.
- **FR-002 fix**: split SELECT/INSERT in `_advanceStage`'s transition write into separate try blocks; both check Supabase `{data, error}` (Supabase v2 does NOT throw on row errors); on failure emit `eva_orchestration_events` with `event_type='escalation'` + `event_data.subtype='transition_record_failed'`; logger warn → error; non-fatal preserved.
- **FR-004 backfill**: idempotent migration inserts the 3 missing PrivacyPatrol AI transition rows using deterministic v5 UUID idempotency keys + ON CONFLICT DO NOTHING.
- **FR-005 unit tests**: 6 vitest cases (happy / SELECT-fail / INSERT-fail / event-emit-also-fails / existing-row-dedup / governance_override).

## Sub-agent evidence

- TESTING `db24af6f-5a6e-40cf-a948-3de4d58f7800` — PASS 85
- DATABASE `7b47a137-733c-4f01-84b5-b61aea8179ad` — PASS 92

## Why >100 LOC

4 PRD-required deliverables in one atomic SD scope. Audit doc (84 LOC markdown) determined FR-003 no-op; splitting loses that linkage. Migration ships with the fix to avoid a prod window where new code coexists with old gap data. 255 LOC tests is a 2.5:1 ratio for new observability surface.

## Test plan

- [x] vitest `stage-execution-worker-transition-observability.test.js` — 6 passed locally
- [ ] Apply migration on staging; verify 3 new rows for venture `08d20036` with deterministic idempotency keys; re-run produces 0 changes
- [ ] Re-run venture monitor on PrivacyPatrol AI — gap report shows 0 missing transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)