### PR TITLE
feat(SD-LEO-FIX-S14-WORKER-OMITS-001): persistArtifact typed-array detection + backfill

### DIFF
--- a/database/migrations/20260503_003_lifecycle_stage_config_s14_blueprints.sql
+++ b/database/migrations/20260503_003_lifecycle_stage_config_s14_blueprints.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- SD-LEO-FIX-S14-WORKER-OMITS-001 FR-006 — lifecycle_stage_config[14] ensures
+-- all 5 required blueprint artifacts are declared.
+--
+-- Origin: 2026-05-03 PrivacyPatrol AI venture monitoring revealed S14 missing
+-- 4 of 5 blueprint artifacts (data_model, erd_diagram, api_contract,
+-- schema_spec). Root cause was in the persistence layer (FR-001), not the
+-- config — but this migration ships as the DDL contract so a fresh deploy or
+-- DB rebuild has the correct expected_artifacts list.
+--
+-- Per database-agent finding 04f646d8: required_artifacts ALREADY contains
+-- all 5 target types in the live DB; this migration is a no-op against
+-- current state. Keeping the migration for:
+--   1. Fresh-deploy correctness
+--   2. Migration-history audit trail
+--   3. Rollback safety: if some future migration removes a type, this one
+--      restores it
+--
+-- The column is `stage_number` (NOT `lifecycle_stage`) per database-agent
+-- finding. Array cast must be ::text[] (NOT ::varchar[]) per dry-run.
+--
+-- Idempotency: WHERE clause uses IS DISTINCT FROM with ::text[] cast. Re-run
+-- updates 0 rows when the array already matches.
+-- ============================================================================
+
+BEGIN;
+
+UPDATE lifecycle_stage_config
+   SET required_artifacts = ARRAY[
+         'blueprint_technical_architecture',
+         'blueprint_data_model',
+         'blueprint_erd_diagram',
+         'blueprint_api_contract',
+         'blueprint_schema_spec'
+       ]::text[]
+ WHERE stage_number = 14
+   AND required_artifacts IS DISTINCT FROM ARRAY[
+         'blueprint_technical_architecture',
+         'blueprint_data_model',
+         'blueprint_erd_diagram',
+         'blueprint_api_contract',
+         'blueprint_schema_spec'
+       ]::text[];
+
+-- Down-migration recipe (emergency rollback):
+-- This migration is idempotent + a no-op against current state. Rolling back
+-- would require knowing the prior value of required_artifacts. If rollback is
+-- truly needed, query the migration_history (or git log of this file) to
+-- reconstruct the prior state. Default rollback is a no-op.
+
+COMMIT;

--- a/database/migrations/20260503_004_backfill_s14_legacy_incomplete.sql
+++ b/database/migrations/20260503_004_backfill_s14_legacy_incomplete.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- SD-LEO-FIX-S14-WORKER-OMITS-001 FR-003 — backfill venture_artifacts to flag
+-- ventures that ran through the broken persistArtifact path with metadata.
+-- legacy_incomplete=true. This is the default backfill strategy (option b);
+-- regeneration (option a) is reserved for PrivacyPatrol AI specifically and
+-- is a separate operation post-deploy.
+--
+-- Origin: 2026-05-03 PrivacyPatrol AI revealed only blueprint_technical_
+-- architecture persisted at lifecycle_stage=14 (1 of 5 expected). This
+-- migration tags affected ventures' existing row with metadata.
+-- legacy_incomplete=true so downstream consumers can filter or alert on the
+-- inconsistency without losing the existing data.
+--
+-- Affected venture detection: any venture with lifecycle_stage=14 rows whose
+-- DISTINCT artifact_type list count < 5 — those are the partial-emit ventures.
+--
+-- Idempotency: jsonb_set with create_if_missing=true is idempotent on
+-- repeated runs (overwrites the same key with the same value). The WHERE
+-- filter additionally excludes already-tagged rows for clarity.
+--
+-- Per database-agent finding 04f646d8: 1 venture affected today
+-- (08d20036-03c9-4a26-bbc5-f37a18dfdf23 = PrivacyPatrol AI).
+-- ============================================================================
+
+BEGIN;
+
+-- Tag affected ventures' existing blueprint_technical_architecture row with
+-- metadata.legacy_incomplete=true. Detection: ventures with fewer than 5
+-- distinct artifact_types at lifecycle_stage=14.
+WITH affected_ventures AS (
+  SELECT venture_id
+    FROM venture_artifacts
+   WHERE lifecycle_stage = 14
+   GROUP BY venture_id
+  HAVING COUNT(DISTINCT artifact_type) < 5
+)
+UPDATE venture_artifacts va
+   SET metadata = jsonb_set(
+         COALESCE(va.metadata, '{}'::jsonb),
+         '{legacy_incomplete}',
+         'true'::jsonb,
+         true -- create_if_missing
+       ),
+       updated_at = NOW()
+  FROM affected_ventures av
+ WHERE va.venture_id = av.venture_id
+   AND va.lifecycle_stage = 14
+   AND va.artifact_type = 'blueprint_technical_architecture'
+   AND (va.metadata->>'legacy_incomplete') IS DISTINCT FROM 'true';
+
+-- Down-migration recipe (emergency rollback):
+--   BEGIN;
+--     UPDATE venture_artifacts
+--        SET metadata = metadata - 'legacy_incomplete'
+--      WHERE lifecycle_stage = 14
+--        AND artifact_type = 'blueprint_technical_architecture'
+--        AND (metadata->>'legacy_incomplete') = 'true';
+--   COMMIT;
+
+COMMIT;

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -7,7 +7,7 @@
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
-import { writeArtifact } from './artifact-persistence-service.js';
+import { writeArtifact, writeArtifactBatch } from './artifact-persistence-service.js';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -245,6 +245,66 @@ export function validateOutput(output, template) {
 export async function persistArtifact(supabase, ventureId, stageNumber, artifactData, evaKeys = {}) {
   // SD-EVA-FIX-STAGE-TEMPLATE-BYPASS-001: Migrated to unified persistence service
   // SD-LEO-INFRA-STREAM-VENTURE-EVA-002-C: Pass EVA keys for eager synthesis
+  //
+  // SD-LEO-FIX-S14-WORKER-OMITS-001 FR-001: Detect typed-array contract from
+  // stage workers that return {artifacts: [...]}. eva-orchestrator.js:424
+  // already handles this; stage-execution-engine.js (this code path) was
+  // dropping the array and writing only one artifact. PrivacyPatrol AI's S14
+  // missing 4 of 5 blueprint sub-artifacts is the empirical signal. When the
+  // array is present, route to writeArtifactBatch (already exported by
+  // artifact-persistence-service.js:275). When absent or empty, legacy
+  // single-artifact path runs unchanged for backward compat.
+
+  // FR-001 typed-array branch: detect Array.isArray(artifactData?.artifacts) && length > 0
+  if (artifactData && Array.isArray(artifactData.artifacts) && artifactData.artifacts.length > 0) {
+    // Map each typed entry to the writeArtifactBatch signature. Uses the same
+    // shape as eva-orchestrator.js:425-432 to ensure consistency between the
+    // two orchestrator paths.
+    const batchEntries = artifactData.artifacts.map((a) => ({
+      artifactType: a.artifactType,
+      title: a.title || `${a.artifactType} (Stage ${stageNumber})`,
+      payload: a.payload ?? null,
+      content: typeof a.payload === 'string' ? a.payload : null,
+      artifactData: typeof a.payload === 'object' ? a.payload : null,
+      source: a.source || 'stage-execution-engine',
+      metadata: a.metadata || null,
+    }));
+
+    const ids = await writeArtifactBatch(
+      supabase,
+      ventureId,
+      stageNumber,
+      batchEntries,
+      null, // idempotencyKey
+      { visionKey: evaKeys.visionKey || null, planKey: evaKeys.planKey || null }
+    );
+
+    // FR-002: emit one batch event (not N events). Mirrors single-path event
+    // shape but with stage_analysis_completed_batch event_type for analytics.
+    try {
+      await supabase.from('eva_orchestration_events').insert({
+        event_type: 'stage_analysis_completed_batch',
+        event_source: 'stage_execution_engine',
+        venture_id: ventureId,
+        event_data: {
+          stage_number: stageNumber,
+          artifact_count: ids.length,
+          artifact_ids: ids,
+          artifact_types: batchEntries.map((e) => e.artifactType),
+          sd_origin: 'SD-LEO-FIX-S14-WORKER-OMITS-001',
+        },
+        chairman_flagged: false,
+      });
+    } catch (_eventErr) {
+      // Non-blocking: artifacts already persisted
+    }
+
+    // Return first ID for caller backward-compat (callers store it for logging only).
+    return ids[0];
+  }
+
+  // Legacy single-artifact path — preserved unchanged for stages that don't
+  // emit a typed-array contract.
   const artifactId = await writeArtifact(supabase, {
     ventureId,
     lifecycleStage: stageNumber,

--- a/tests/unit/eva/stage-execution-engine-persist-artifact.test.js
+++ b/tests/unit/eva/stage-execution-engine-persist-artifact.test.js
@@ -1,0 +1,220 @@
+/**
+ * SD-LEO-FIX-S14-WORKER-OMITS-001 FR-004 — persistArtifact typed-array
+ * detection branch.
+ *
+ * Verifies that stage-execution-engine.js:persistArtifact correctly handles:
+ *   - Typed-array path: artifactData.artifacts = [N entries] → writeArtifactBatch
+ *   - Legacy path: artifactData lacks .artifacts → writeArtifact (single)
+ *   - Empty-array edge: artifactData.artifacts = [] → legacy fall-through
+ *
+ * Pre-fix: persistArtifact always called writeArtifact with hardcoded
+ * artifactType=stage_${stageNumber}_analysis, dropping output.artifacts on
+ * the floor. PrivacyPatrol AI's S14 missing 4 of 5 blueprint sub-artifacts
+ * was the empirical signal.
+ *
+ * @module tests/unit/eva/stage-execution-engine-persist-artifact.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock artifact-persistence-service so we can spy on both writeArtifact (legacy)
+// and writeArtifactBatch (typed). vi.spyOn on a real export is preferred per
+// reference_vi_mock_masks_broken_import.md, but vi.mock on the whole module is
+// acceptable here because both names are real exports (verified — see
+// lib/eva/artifact-persistence-service.js:248 and :275).
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: vi.fn(),
+  writeArtifactBatch: vi.fn(),
+}));
+
+import { persistArtifact } from '../../../lib/eva/stage-execution-engine.js';
+import {
+  writeArtifact,
+  writeArtifactBatch,
+} from '../../../lib/eva/artifact-persistence-service.js';
+
+function createMockSupabase() {
+  const insertedEvents = [];
+  const chain = {
+    insert: vi.fn(async (row) => {
+      insertedEvents.push(row);
+      return { error: null };
+    }),
+  };
+  return {
+    from: vi.fn(() => chain),
+    _insertedEvents: insertedEvents,
+  };
+}
+
+describe('FR-001/FR-004: persistArtifact typed-array detection branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('typed-array path: 5 entries → writeArtifactBatch called once with 5; writeArtifact NOT called', async () => {
+    writeArtifactBatch.mockResolvedValue([
+      'id-blueprint',
+      'id-data-model',
+      'id-erd',
+      'id-api',
+      'id-schema',
+    ]);
+
+    const supabase = createMockSupabase();
+    const s14Output = {
+      // S14 returns { ...legacyPayload, artifactType, artifacts: [5] }
+      artifactType: 'blueprint_technical_architecture',
+      layers: [],
+      artifacts: [
+        { artifactType: 'blueprint_technical_architecture', payload: { layers: [] }, source: 'analysis-step:stage-14' },
+        { artifactType: 'blueprint_data_model', payload: { entities: [] }, source: 'analysis-step:stage-14-projection' },
+        { artifactType: 'blueprint_erd_diagram', payload: { mermaid: '' }, source: 'analysis-step:stage-14-projection' },
+        { artifactType: 'blueprint_api_contract', payload: { endpoints: [] }, source: 'analysis-step:stage-14-projection' },
+        { artifactType: 'blueprint_schema_spec', payload: { tables: [] }, source: 'analysis-step:stage-14-projection' },
+      ],
+    };
+
+    const id = await persistArtifact(supabase, 'venture-uuid', 14, s14Output, {
+      visionKey: 'vk-1',
+      planKey: 'pk-1',
+    });
+
+    expect(writeArtifactBatch).toHaveBeenCalledTimes(1);
+    expect(writeArtifact).not.toHaveBeenCalled();
+
+    const [, ventureArg, stageArg, batchEntries, idempotencyKey, opts] =
+      writeArtifactBatch.mock.calls[0];
+    expect(ventureArg).toBe('venture-uuid');
+    expect(stageArg).toBe(14);
+    expect(batchEntries).toHaveLength(5);
+    expect(batchEntries.map((e) => e.artifactType)).toEqual([
+      'blueprint_technical_architecture',
+      'blueprint_data_model',
+      'blueprint_erd_diagram',
+      'blueprint_api_contract',
+      'blueprint_schema_spec',
+    ]);
+    expect(idempotencyKey).toBeNull();
+    expect(opts).toEqual({ visionKey: 'vk-1', planKey: 'pk-1' });
+
+    // Returns first ID for caller backward-compat
+    expect(id).toBe('id-blueprint');
+
+    // Batch event emitted (one row, not five)
+    const batchEvents = supabase._insertedEvents.filter(
+      (e) => e.event_type === 'stage_analysis_completed_batch'
+    );
+    expect(batchEvents).toHaveLength(1);
+    expect(batchEvents[0].event_data.artifact_count).toBe(5);
+    expect(batchEvents[0].event_data.artifact_ids).toHaveLength(5);
+    expect(batchEvents[0].event_data.sd_origin).toBe('SD-LEO-FIX-S14-WORKER-OMITS-001');
+  });
+
+  it('legacy path: artifactData lacks .artifacts → writeArtifact (single) called', async () => {
+    writeArtifact.mockResolvedValue('legacy-artifact-id');
+
+    const supabase = createMockSupabase();
+    const stageOutput = { someField: 'value', otherField: 42 }; // no .artifacts
+
+    const id = await persistArtifact(supabase, 'venture-uuid', 7, stageOutput, {});
+
+    expect(writeArtifact).toHaveBeenCalledTimes(1);
+    expect(writeArtifactBatch).not.toHaveBeenCalled();
+
+    const [, opts] = writeArtifact.mock.calls[0];
+    expect(opts.lifecycleStage).toBe(7);
+    expect(opts.artifactType).toBe('stage_7_analysis');
+    expect(opts.title).toBe('Stage 7 Analysis');
+
+    expect(id).toBe('legacy-artifact-id');
+
+    // Legacy single event emitted
+    const legacyEvents = supabase._insertedEvents.filter(
+      (e) => e.event_type === 'stage_analysis_completed'
+    );
+    expect(legacyEvents).toHaveLength(1);
+  });
+
+  it('empty-array edge: artifactData.artifacts = [] → legacy fall-through', async () => {
+    writeArtifact.mockResolvedValue('legacy-from-empty');
+
+    const supabase = createMockSupabase();
+    const emptyArrOutput = { artifacts: [], summary: 'nothing produced' };
+
+    const id = await persistArtifact(supabase, 'venture-uuid', 8, emptyArrOutput, {});
+
+    // Empty array does NOT trigger batch path — falls through to legacy
+    expect(writeArtifactBatch).not.toHaveBeenCalled();
+    expect(writeArtifact).toHaveBeenCalledTimes(1);
+    expect(id).toBe('legacy-from-empty');
+  });
+
+  it('non-array .artifacts (e.g., string) → legacy fall-through', async () => {
+    writeArtifact.mockResolvedValue('legacy-from-non-array');
+
+    const supabase = createMockSupabase();
+    const malformedOutput = { artifacts: 'not an array', stage: 9 };
+
+    const id = await persistArtifact(supabase, 'venture-uuid', 9, malformedOutput, {});
+
+    expect(writeArtifactBatch).not.toHaveBeenCalled();
+    expect(writeArtifact).toHaveBeenCalledTimes(1);
+    expect(id).toBe('legacy-from-non-array');
+  });
+
+  it('return shape consistency: both paths return a string ID', async () => {
+    writeArtifactBatch.mockResolvedValue(['batch-id-1', 'batch-id-2']);
+    writeArtifact.mockResolvedValue('legacy-id');
+
+    const supabase = createMockSupabase();
+
+    const typedId = await persistArtifact(
+      supabase,
+      'venture-uuid',
+      14,
+      { artifacts: [{ artifactType: 't1', payload: {} }, { artifactType: 't2', payload: {} }] },
+      {}
+    );
+    expect(typedId).toBe('batch-id-1');
+    expect(typeof typedId).toBe('string');
+
+    vi.clearAllMocks();
+    writeArtifact.mockResolvedValue('legacy-id-2');
+    const legacyId = await persistArtifact(supabase, 'venture-uuid', 5, { foo: 'bar' }, {});
+    expect(legacyId).toBe('legacy-id-2');
+    expect(typeof legacyId).toBe('string');
+  });
+
+  it('FR-002: typed-array path event uses event_type=stage_analysis_completed_batch', async () => {
+    writeArtifactBatch.mockResolvedValue(['id1', 'id2']);
+
+    const supabase = createMockSupabase();
+    await persistArtifact(
+      supabase,
+      'v1',
+      14,
+      { artifacts: [{ artifactType: 'a', payload: {} }, { artifactType: 'b', payload: {} }] },
+      {}
+    );
+
+    const events = supabase._insertedEvents;
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('stage_analysis_completed_batch');
+    expect(events[0].event_data.artifact_count).toBe(2);
+    expect(events[0].event_data.artifact_types).toEqual(['a', 'b']);
+  });
+
+  it('FR-002: legacy path event uses event_type=stage_analysis_completed (unchanged)', async () => {
+    writeArtifact.mockResolvedValue('legacy-id');
+
+    const supabase = createMockSupabase();
+    await persistArtifact(supabase, 'v1', 5, { x: 1 }, {});
+
+    const events = supabase._insertedEvents;
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('stage_analysis_completed');
+    expect(events[0].event_data.stage_number).toBe(5);
+    expect(events[0].event_data.artifact_type).toBe('stage_5_analysis');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the path-dependent defect where `stage-execution-engine.js:persistArtifact` was dropping S14's `output.artifacts` typed-array on the floor. PrivacyPatrol AI (2026-05-03) ran through this broken path and persisted only 1 of 5 expected blueprint artifacts.

- **FR-001 detection branch**: `persistArtifact` now detects `Array.isArray(artifactData?.artifacts) && length > 0` and routes to `writeArtifactBatch` — verbatim parallel to `eva-orchestrator.js:424` to prevent future divergence.
- **FR-002 batch event**: typed-array path emits ONE `stage_analysis_completed_batch` event (not N); legacy path's single event unchanged.
- **FR-003 backfill**: tags affected ventures' existing row with `metadata.legacy_incomplete=true` (default); PrivacyPatrol AI eligible for option-a regeneration in a follow-up post-deploy operation.
- **FR-006 DDL contract**: ships `lifecycle_stage_config[stage_number=14]` migration even though it's a no-op against current state (per database-agent finding) — keeps DDL contract correct for fresh deploys.
- **7 vitest cases** covering both persistArtifact paths + edges.

## Sub-agent evidence

- TESTING `6a04eb53-8a0f-4e5d-8893-25a769a827e0` — PASS 92
- DATABASE `04f646d8-4542-4d18-a476-d86ee7d21a7f` — PASS 96

## Test plan

- [x] vitest suite: 7 passed locally
- [ ] FR-005 integration test (drive S14 end-to-end through stage-execution-engine path) deferred to follow-up SD
- [ ] Apply migrations on staging; verify lifecycle_stage_config no-op + PrivacyPatrol AI tagged with metadata.legacy_incomplete=true; re-run produces 0 changes
- [ ] PrivacyPatrol AI regeneration (option a) post-deploy: re-run S14 worker, verify all 5 artifacts persisted

## Companion SD

Related: `SD-LEO-FIX-FIX-S10-WORKER-001` (different defect class in same EHG_Engineer/lib/eva/ worker layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)