### PR TITLE
feat(SD-LEO-FEAT-STAGE-CODE-QUALITY-001): wire canonical S20 analyzer + sync FR-C SD generation

### DIFF
--- a/lib/eva/quality-findings/sd-generator.js
+++ b/lib/eva/quality-findings/sd-generator.js
@@ -491,6 +491,47 @@ function buildRemediationSdContent({ ventureId, findingCategory, severity, sampl
  * @param {Object} args.sampleFinding - for title/description content
  * @returns {Promise<{id: string, sd_key: string}>}
  */
+/**
+ * SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-8 (2026-05-03): derive target_application
+ * from venture context. Previously hardcoded to 'EHG_Engineer', which routed
+ * remediation SDs for venture-codebase findings to the wrong application.
+ *
+ * Derivation order (first non-null wins):
+ *  1. sampleFinding.target_application (if writer caller passes it explicitly)
+ *  2. venture.metadata.stage_zero.target_platform (mapped to EHG/EHG_Engineer)
+ *  3. 'EHG' default (ventures live in EHG; remediation work on venture code
+ *     belongs to the EHG platform, NOT to the EHG_Engineer engine code).
+ *
+ * @param {Object} supabase
+ * @param {string} ventureId
+ * @param {Object} sampleFinding
+ * @returns {Promise<'EHG' | 'EHG_Engineer'>}
+ */
+export async function deriveTargetApplication(supabase, ventureId, sampleFinding = {}) {
+  if (sampleFinding && typeof sampleFinding.target_application === 'string') {
+    const v = sampleFinding.target_application;
+    if (v === 'EHG' || v === 'EHG_Engineer') return v;
+  }
+
+  if (supabase && ventureId) {
+    try {
+      const { data } = await supabase
+        .from('ventures')
+        .select('metadata')
+        .eq('id', ventureId)
+        .maybeSingle();
+      const platform = data?.metadata?.stage_zero?.target_platform;
+      if (typeof platform === 'string') {
+        const norm = platform.toLowerCase();
+        if (norm === 'ehg_engineer' || norm === 'engineer') return 'EHG_Engineer';
+        if (norm === 'ehg' || norm === 'platform' || norm === 'web') return 'EHG';
+      }
+    } catch { /* best-effort lookup; fall through to default */ }
+  }
+
+  return 'EHG';
+}
+
 export async function insertDraftRemediationSd(supabase, { ventureId, findingCategory, severity, findingIds, sampleFinding }) {
   if (!ventureId || !findingCategory || !severity || !Array.isArray(findingIds) || findingIds.length === 0) {
     throw new Error('insertDraftRemediationSd requires ventureId, findingCategory, severity, findingIds[]');
@@ -505,15 +546,20 @@ export async function insertDraftRemediationSd(supabase, { ventureId, findingCat
     skipLeadValidation: true,
   });
 
+  const targetApplication = await deriveTargetApplication(supabase, ventureId, sampleFinding);
+
   const metadata = {
     generated_by: GENERATED_BY_TAG,
-    generator_version: '1.0.0',
+    generator_version: '1.1.0',
     parent_orchestrator: 'SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-001',
     venture_id: ventureId,
     finding_category: findingCategory,
     severity,
     source_finding_ids: findingIds,
     sample_evidence_pointer: sampleFinding.evidence_pointer || {},
+    target_application_source: sampleFinding?.target_application
+      ? 'finding_explicit'
+      : (targetApplication === 'EHG' ? 'venture_default' : 'venture_metadata'),
   };
 
   const { data, error } = await supabase
@@ -531,7 +577,7 @@ export async function insertDraftRemediationSd(supabase, { ventureId, findingCat
       category: 'infrastructure',
       priority: 'medium',
       sd_type: 'bugfix',
-      target_application: 'EHG_Engineer',
+      target_application: targetApplication,
       created_by: 'fr-c-generator',
       progress: 0,
       phase_progress: 0,

--- a/lib/eva/quality-findings/writer.js
+++ b/lib/eva/quality-findings/writer.js
@@ -2,6 +2,7 @@
  * Writer module for venture_quality_findings.
  *
  * SD: SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001-B
+ * Updated: SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-2 (sync sd-generator path).
  *
  * Idempotent UPSERT keyed on (venture_id, finding_hash). Re-running the writer
  * with the same finding_hash inputs is a no-op (or updates evidence_pointer +
@@ -15,12 +16,111 @@
 import { validateFindingShape, computeFindingHash, FINDING_CATEGORIES } from './finding-shape.js';
 
 /**
+ * SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-2 (severity floor): only high/critical
+ * findings produce remediation SDs synchronously. Medium/low/info findings are
+ * stored without auto-SD creation to prevent queue-spam.
+ *
+ * Severity floor matches SEVERITIES_REQUIRING_SYNC_SD_GENERATION below; the
+ * cron (FR_C_REMEDIATION_SEVERITIES in sd-generator.js) historically also
+ * included 'medium' for batch backfill. Sync path is intentionally narrower.
+ */
+const SEVERITIES_REQUIRING_SYNC_SD_GENERATION = new Set(['critical', 'high']);
+
+/**
+ * Kill switch for the sync sd-generator path. Set
+ * LEO_FR_C_SYNC_GENERATION_ENABLED=off (case-insensitive) to fall back to
+ * cron-only SD generation. Default ON.
+ */
+function isSyncSdGenerationEnabled() {
+  const raw = process.env.LEO_FR_C_SYNC_GENERATION_ENABLED;
+  if (typeof raw !== 'string') return true;
+  const v = raw.trim().toLowerCase();
+  return v !== 'off' && v !== 'false' && v !== '0' && v !== 'no';
+}
+
+/**
+ * Maybe invoke the FR-C remediation-SD generator inline for a freshly-written
+ * finding. Failures here MUST NOT throw — sd-generator failure is observable
+ * in audit_log but should never block finding persistence.
+ *
+ * @param {Object} supabase
+ * @param {Object} finding - canonical finding (already persisted)
+ * @param {string} findingId - id returned by writeFinding upsert
+ * @returns {Promise<{generated: boolean, sd_key?: string, skipped_reason?: string}>}
+ */
+async function maybeGenerateSdForFinding(supabase, finding, findingId) {
+  if (!isSyncSdGenerationEnabled()) {
+    return { generated: false, skipped_reason: 'kill_switch_off' };
+  }
+  if (!SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has(finding.severity)) {
+    return { generated: false, skipped_reason: 'severity_floor' };
+  }
+  if (!finding.venture_id || !finding.finding_category) {
+    return { generated: false, skipped_reason: 'missing_required_fields' };
+  }
+
+  try {
+    const { findOpenSdForCompositeKey, insertDraftRemediationSd, appendFindingToSdMetadata, transitionFindingToSdFiled } =
+      await import('./sd-generator.js');
+
+    // Composite-key dedupe: open SD already covering (venture_id, category, severity)?
+    const existing = await findOpenSdForCompositeKey(
+      supabase,
+      finding.venture_id,
+      finding.finding_category,
+      finding.severity
+    );
+
+    if (existing?.id) {
+      // Append this finding id to the existing SD's metadata, mark finding as filed
+      await appendFindingToSdMetadata(supabase, existing.id, findingId).catch(() => {});
+      await transitionFindingToSdFiled(supabase, findingId, existing.sd_key).catch(() => {});
+      return { generated: false, sd_key: existing.sd_key, skipped_reason: 'dedupe_hit' };
+    }
+
+    // No open SD — create a fresh draft remediation SD.
+    const newSd = await insertDraftRemediationSd(supabase, {
+      ventureId: finding.venture_id,
+      findingCategory: finding.finding_category,
+      severity: finding.severity,
+      findingIds: [findingId],
+      sampleFinding: finding,
+    });
+    await transitionFindingToSdFiled(supabase, findingId, newSd.sd_key).catch(() => {});
+    return { generated: true, sd_key: newSd.sd_key };
+  } catch (err) {
+    // Best-effort observability: record but never re-throw.
+    try {
+      await supabase.from('audit_log').insert({
+        event_type: 'fr_c_sync_generator.error',
+        entity_type: 'venture_quality_finding',
+        entity_id: findingId,
+        severity: 'warning',
+        created_by: 'fr-c-sync-generator',
+        metadata: {
+          venture_id: finding.venture_id,
+          finding_category: finding.finding_category,
+          finding_severity: finding.severity,
+          error: err?.message || String(err),
+        },
+      });
+    } catch { /* observability failure is silent */ }
+    return { generated: false, skipped_reason: 'sd_generator_threw' };
+  }
+}
+
+/**
  * Write one canonical finding to venture_quality_findings.
  * Returns the upserted row id.
  *
+ * If the finding's severity is high or critical AND the sync sd-generator
+ * kill-switch is on (default), invoke sd-generator.insertDraftRemediationSd
+ * inline before returning. Sync invocation result is exposed on the response
+ * for caller-side telemetry.
+ *
  * @param {Object} supabase    - service-role Supabase client
  * @param {Object} finding     - canonical FindingShape (must pass validateFindingShape)
- * @returns {Promise<{id: string, inserted: boolean}>}
+ * @returns {Promise<{id: string, inserted: boolean, sd_generation?: Object}>}
  */
 export async function writeFinding(supabase, finding) {
   if (!supabase) throw new Error('supabase client required');
@@ -55,7 +155,10 @@ export async function writeFinding(supabase, finding) {
     throw new Error('writeFinding failed: ' + error.message);
   }
 
-  return { id: data.id, inserted: true };
+  // FR-2: sync FR-C SD generation for high/critical findings.
+  const sdGeneration = await maybeGenerateSdForFinding(supabase, finding, data.id);
+
+  return { id: data.id, inserted: true, sd_generation: sdGeneration };
 }
 
 /**
@@ -66,7 +169,7 @@ export async function writeFinding(supabase, finding) {
  *
  * @param {Object} supabase
  * @param {Array<Object>} findings
- * @returns {Promise<{written: number, errors: Array<{finding, error}>}>}
+ * @returns {Promise<{written: number, errors: Array<{finding, error}>, sd_generated: number, sd_dedupe_hit: number}>}
  */
 export async function writeFindingsBatch(supabase, findings) {
   if (!Array.isArray(findings)) {
@@ -74,6 +177,8 @@ export async function writeFindingsBatch(supabase, findings) {
   }
 
   let written = 0;
+  let sd_generated = 0;
+  let sd_dedupe_hit = 0;
   const errors = [];
 
   for (const f of findings) {
@@ -87,15 +192,24 @@ export async function writeFindingsBatch(supabase, findings) {
           finding_signature: f.finding_signature,
         });
       }
-      await writeFinding(supabase, f);
+      const r = await writeFinding(supabase, f);
       written += 1;
+      if (r.sd_generation?.generated) sd_generated += 1;
+      else if (r.sd_generation?.skipped_reason === 'dedupe_hit') sd_dedupe_hit += 1;
     } catch (err) {
       errors.push({ finding: f, error: err.message });
     }
   }
 
-  return { written, errors };
+  return { written, errors, sd_generated, sd_dedupe_hit };
 }
+
+// FR-2 hooks exported for tests + observability tooling.
+export const __fr2 = {
+  SEVERITIES_REQUIRING_SYNC_SD_GENERATION,
+  isSyncSdGenerationEnabled,
+  maybeGenerateSdForFinding,
+};
 
 /**
  * Mark a finding as resolved (sets resolved_at to now).

--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -39,14 +39,14 @@ export { analyzeStage17 } from './stage-17-blueprint-review.js';
 // SD-LEO-INFRA-BUILD-LOOP-DATA-001: function names now match stage numbers (no aliasing)
 export { analyzeStage18 } from './stage-18-build-readiness.js';
 export { analyzeStage19 } from './stage-19-sprint-planning.js';
-// DEPRECATED (SD-LEO-ORCH-QUALITY-LIFECYCLE-LOOP-001-A): the canonical S20-S22 templates
-// post-marketing-first redesign live in `lib/eva/stage-templates/stage-2X.js`. The legacy
-// build-loop names below (analyzeStage20=Build Execution, analyzeStage21=QA, analyzeStage22=Build Review)
-// are retained for backwards compatibility with callers that import them, but new code
-// should consume the canonical templates directly. Stage 20 is the unified Quality Gate
-// (Code Review + QA + UAT, 10 finding categories per `lib/eva/quality-findings/finding-shape.js`).
-// Stage 21 is Visual Assets. Stage 22 is Distribution Setup.
-export { analyzeStage20 } from './stage-20-build-execution.js';
+// SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-1 (path-a replace, 2026-05-03): stage 20 now
+// dispatches to the canonical Code Quality Gate analyzer (stage-20-code-quality.js)
+// — the FR-B/D/E analyzer that writes venture_quality_findings + code_quality_report.
+// Previously stage 20 dispatched to stage-20-build-execution.js, which never produced
+// venture_quality_findings rows (zero rows globally as of 2026-05-03 per PrivacyPatrol AI
+// run). Stage 21 is Visual Assets. Stage 22 is Distribution Setup.
+export { analyzeStage20CodeQuality as analyzeStage20 } from './stage-20-code-quality.js';
+export { analyzeStage20 as analyzeStage20BuildExecution } from './stage-20-build-execution.js';
 export { analyzeStage21 } from './stage-21-quality-assurance.js';
 export { analyzeStage22 } from './stage-22-build-review.js';
 export { analyzeStage22 as analyzeStage23 } from './stage-23-release-readiness.js';
@@ -117,7 +117,8 @@ export async function getAnalysisStep(stageNumber) {
     17: () => import('./stage-17-blueprint-review.js').then(m => m.analyzeStage17),
     18: () => import('./stage-18-build-readiness.js').then(m => m.analyzeStage18),
     19: () => import('./stage-19-sprint-planning.js').then(m => m.analyzeStage19),
-    20: () => import('./stage-20-build-execution.js').then(m => m.analyzeStage20),
+    // SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-1: dispatch the canonical analyzer
+    20: () => import('./stage-20-code-quality.js').then(m => m.analyzeStage20CodeQuality),
     21: () => import('./stage-21-quality-assurance.js').then(m => m.analyzeStage21),
     22: () => import('./stage-22-build-review.js').then(m => m.analyzeStage22),
     23: () => import('./stage-23-release-readiness.js').then(m => m.analyzeStage22),

--- a/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
@@ -469,11 +469,16 @@ export async function persistAnalyzerFindings(supabase, ventureId, adapted) {
 }
 
 function buildNoRepoReport(ventureName) {
+  // SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-4 (2026-05-03): missing-precondition
+  // returns verdict=BLOCKED, distinct from FAIL so the advance-writer's
+  // verdict-block can route operators back to S19 (no override path) instead
+  // of treating it as a real critical finding (which would offer override).
   return {
-    verdict: 'FAIL',
+    verdict: 'BLOCKED',
     repo_url: null,
     venture_name: ventureName,
-    findings: [{ check: 'repo_access', title: 'No GitHub repo URL found in venture_resources', severity: 'critical', detail: 'S19 must complete and store github_repo before S20 can validate' }],
+    blocked_reason: 'missing_github_repo_precondition',
+    findings: [{ check: 'precondition', title: 'No GitHub repo URL registered for this venture', severity: 'critical', detail: 'S19 must complete and register github_repo in venture_resources before S20 can validate. Operator: return to Stage 19 (no override available for missing precondition).' }],
     summary: { total_findings: 1, by_severity: { critical: 1, high: 0, medium: 0, low: 0, info: 0 }, by_check: {} },
     checks_run: 0,
   };

--- a/tests/integration/eva/analysis-steps.test.js
+++ b/tests/integration/eva/analysis-steps.test.js
@@ -1099,16 +1099,25 @@ describe('Stage 19: analyzeStage19', () => {
 describe('Stage 20: analyzeStage20', () => {
   beforeEach(() => { mockComplete.mockReset(); });
 
-  // analyzeStage20 = stage-20-build-execution.js. LLM synthesis is permanently
-  // disabled — requires real SD completion data from venture_stage_work.
+  // SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-1 (2026-05-03): analyzeStage20 now
+  // dispatches to the canonical Code Quality Gate analyzer (stage-20-code-quality.js)
+  // — NOT the legacy stage-20-build-execution.js. The legacy export is still
+  // reachable via analyzeStage20BuildExecution for backwards-compat callers.
   it.skip('produces valid QA assessment with quality decision', async () => {
-    // Skipped: analyzeStage20 is REFUSED — requires real build data from SD completion pipeline.
-    // LLM fabrication is permanently disabled to prevent poisoned downstream stages.
+    // Skipped: superseded — canonical analyzer needs a github_repo + clone path.
+    // Covered by tests/unit/eva/stage-code-quality-fr-1-2-4-8.test.js.
   });
 
-  it('throws when stage19Data is missing', async () => {
-    await expect(analyzeStage20({ logger: silentLogger }))
-      .rejects.toThrow('Stage 20 build execution requires Stage 19 (sprint planning) data');
+  it('returns BLOCKED verdict when no github_repo (canonical analyzer)', async () => {
+    const result = await analyzeStage20({
+      stage19Data: null,
+      ventureName: 'IntegrationTestVenture',
+      ventureId: null,
+      supabase: null,
+      logger: silentLogger,
+    });
+    expect(result.verdict).toBe('BLOCKED');
+    expect(result.findings[0].check).toBe('precondition');
   });
 });
 

--- a/tests/unit/eva/stage-code-quality-fr-1-2-4-8.test.js
+++ b/tests/unit/eva/stage-code-quality-fr-1-2-4-8.test.js
@@ -1,0 +1,331 @@
+/**
+ * Vitest coverage for SD-LEO-FEAT-STAGE-CODE-QUALITY-001 FR-1, FR-2, FR-4, FR-8.
+ * FR-7 mandates these tests cover dispatch wiring, sync sd-generator, BLOCKED
+ * verdict on missing precondition, and target_application derivation.
+ *
+ * @module tests/unit/eva/stage-code-quality-fr-1-2-4-8
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// FR-1: dispatch + canonical analyzer wiring
+import { getAnalysisStep } from '../../../lib/eva/stage-templates/analysis-steps/index.js';
+import { analyzeStage20CodeQuality } from '../../../lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js';
+
+// FR-2: writer sync sd-generator path
+import { writeFinding, writeFindingsBatch, __fr2 } from '../../../lib/eva/quality-findings/writer.js';
+import { computeFindingHash } from '../../../lib/eva/quality-findings/finding-shape.js';
+
+// FR-8: target_application derivation
+import { deriveTargetApplication } from '../../../lib/eva/quality-findings/sd-generator.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FR-1: dispatch table maps stage 20 to canonical Code Quality Gate analyzer
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FR-1 — analysis-steps dispatcher routes stage 20 to canonical analyzer', () => {
+  it('getAnalysisStep(20) returns the canonical analyzeStage20CodeQuality function', async () => {
+    const fn = await getAnalysisStep(20);
+    expect(typeof fn).toBe('function');
+    expect(fn).toBe(analyzeStage20CodeQuality);
+  });
+
+  it('getAnalysisStep(20) does NOT return the legacy build-execution analyzer', async () => {
+    const fn = await getAnalysisStep(20);
+    // Legacy module exports `analyzeStage20`; canonical exports `analyzeStage20CodeQuality`.
+    // We assert the function name is the canonical one, defensively.
+    expect(fn.name).toBe('analyzeStage20CodeQuality');
+  });
+
+  it('canonical analyzer is callable with no-supabase / no-venture (returns BLOCKED report)', async () => {
+    // No supabase + no stage19Data → no repo URL → buildNoRepoReport() path.
+    const result = await analyzeStage20CodeQuality({
+      stage19Data: null,
+      ventureName: 'TestVenture',
+      ventureId: null,
+      supabase: null,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    expect(result.verdict).toBe('BLOCKED');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].check).toBe('precondition');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FR-4: missing-github-repo emits verdict=BLOCKED (not FAIL)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FR-4 — missing precondition emits verdict=BLOCKED', () => {
+  it('verdict is BLOCKED, not FAIL, when no github_repo registered', async () => {
+    const result = await analyzeStage20CodeQuality({
+      stage19Data: null,
+      ventureName: 'NoRepoVenture',
+      ventureId: 'abc-123',
+      supabase: null, // signals "cannot look up venture_resources"
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    expect(result.verdict).toBe('BLOCKED');
+    expect(result.verdict).not.toBe('FAIL');
+    expect(result.blocked_reason).toBe('missing_github_repo_precondition');
+  });
+
+  it('BLOCKED report carries finding_category=precondition (NOT repo_access)', async () => {
+    const result = await analyzeStage20CodeQuality({
+      stage19Data: null,
+      ventureName: 'NoRepoVenture2',
+      ventureId: null,
+      supabase: null,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    expect(result.findings[0].check).toBe('precondition');
+    // BLOCKED finding still surfaces severity=critical so operators see it,
+    // but advance-writer must distinguish via verdict (BLOCKED vs FAIL).
+    expect(result.findings[0].severity).toBe('critical');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FR-2: writer.js synchronously invokes sd-generator for high/critical findings
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeMockSupabaseRecording() {
+  const rows = new Map(); // venture_id|finding_hash → row
+  const calls = [];
+
+  const noopFilterChain = () => ({
+    eq() { return this; },
+    in() { return this; },
+    is() { return Promise.resolve({ error: null, count: 0 }); },
+    select() { return this; },
+    order() { return this; },
+    limit() { return this; },
+    single() { return Promise.resolve({ data: null, error: null }); },
+    maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+  });
+
+  const builderFor = (table) => ({
+    upsert(payload, opts) {
+      calls.push({ op: 'upsert', table, payload, opts });
+      const key = `${payload.venture_id}|${payload.finding_hash}`;
+      const id = rows.has(key) ? rows.get(key).id : `mock-${rows.size + 1}`;
+      rows.set(key, { ...payload, id });
+      return { select: () => ({ single: async () => ({ data: { id }, error: null }) }) };
+    },
+    insert(payload) {
+      calls.push({ op: 'insert', table, payload });
+      // sd-generator inserts → strategic_directives_v2 / audit_log;
+      // simulate an SD-row return so insertDraftRemediationSd can resolve.
+      const id = `mock-sd-${calls.length}`;
+      const sd_key = payload?.sd_key || `MOCK-SD-${calls.length}`;
+      return { select: () => ({ single: async () => ({ data: { id, sd_key }, error: null }) }) };
+    },
+    update(payload) {
+      calls.push({ op: 'update', table, payload });
+      return noopFilterChain();
+    },
+    select() { return noopFilterChain(); },
+    eq() { return noopFilterChain(); },
+    in() { return noopFilterChain(); },
+  });
+
+  return {
+    from(table) { return builderFor(table); },
+    _rows: rows,
+    _calls: calls,
+  };
+}
+
+const validFinding = (overrides = {}) => ({
+  venture_id: 'venture-x',
+  stage_number: 20,
+  finding_category: 'lint',
+  severity: 'medium',
+  finding_hash: computeFindingHash({
+    venture_id: 'venture-x',
+    stage_number: 20,
+    finding_category: 'lint',
+    finding_signature: 'no-unused-vars:src/foo.js:42',
+  }),
+  evidence_pointer: { file: 'src/foo.js' },
+  ...overrides,
+});
+
+describe('FR-2 — sync sd-generator path', () => {
+  let supabase;
+  beforeEach(() => {
+    supabase = makeMockSupabaseRecording();
+    // Force kill switch ON regardless of host env.
+    delete process.env.LEO_FR_C_SYNC_GENERATION_ENABLED;
+  });
+
+  it('severity=medium does NOT invoke sd-generator (severity floor)', async () => {
+    const r = await writeFinding(supabase, validFinding({ severity: 'medium' }));
+    expect(r.sd_generation?.skipped_reason).toBe('severity_floor');
+    expect(r.sd_generation?.generated).toBe(false);
+  });
+
+  it('severity=critical invokes sd-generator (severity floor passes)', async () => {
+    const r = await writeFinding(supabase, validFinding({
+      severity: 'critical',
+      finding_hash: computeFindingHash({
+        venture_id: 'venture-x',
+        stage_number: 20,
+        finding_category: 'secrets',
+        finding_signature: 'aws-key:src/config.js',
+      }),
+      finding_category: 'secrets',
+    }));
+    // Path either generates a fresh SD or falls into dedupe/threw branch — but the floor must NOT skip.
+    expect(r.sd_generation?.skipped_reason).not.toBe('severity_floor');
+  });
+
+  it('severity=low does NOT invoke sd-generator', async () => {
+    const r = await writeFinding(supabase, validFinding({ severity: 'low' }));
+    expect(r.sd_generation?.skipped_reason).toBe('severity_floor');
+  });
+
+  it('LEO_FR_C_SYNC_GENERATION_ENABLED=off disables sync path even for critical', async () => {
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = 'off';
+    try {
+      const r = await writeFinding(supabase, validFinding({ severity: 'critical', finding_category: 'secrets' }));
+      expect(r.sd_generation?.skipped_reason).toBe('kill_switch_off');
+    } finally {
+      delete process.env.LEO_FR_C_SYNC_GENERATION_ENABLED;
+    }
+  });
+
+  it('LEO_FR_C_SYNC_GENERATION_ENABLED accepts on/off variants case-insensitively', () => {
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = 'OFF';
+    expect(__fr2.isSyncSdGenerationEnabled()).toBe(false);
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = 'False';
+    expect(__fr2.isSyncSdGenerationEnabled()).toBe(false);
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = '0';
+    expect(__fr2.isSyncSdGenerationEnabled()).toBe(false);
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = 'on';
+    expect(__fr2.isSyncSdGenerationEnabled()).toBe(true);
+    delete process.env.LEO_FR_C_SYNC_GENERATION_ENABLED;
+    expect(__fr2.isSyncSdGenerationEnabled()).toBe(true); // default ON
+  });
+
+  it('SEVERITIES_REQUIRING_SYNC_SD_GENERATION includes critical and high only', () => {
+    expect(__fr2.SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has('critical')).toBe(true);
+    expect(__fr2.SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has('high')).toBe(true);
+    expect(__fr2.SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has('medium')).toBe(false);
+    expect(__fr2.SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has('low')).toBe(false);
+    expect(__fr2.SEVERITIES_REQUIRING_SYNC_SD_GENERATION.has('info')).toBe(false);
+  });
+
+  it('writeFindingsBatch returns sd_generated and sd_dedupe_hit counters', async () => {
+    const r = await writeFindingsBatch(supabase, [
+      validFinding({ severity: 'medium' }),
+      validFinding({
+        severity: 'critical',
+        finding_category: 'secrets',
+        finding_hash: computeFindingHash({
+          venture_id: 'venture-x',
+          stage_number: 20,
+          finding_category: 'secrets',
+          finding_signature: 'aws-key:src/y.js',
+        }),
+      }),
+    ]);
+    expect(r).toHaveProperty('sd_generated');
+    expect(r).toHaveProperty('sd_dedupe_hit');
+    expect(typeof r.sd_generated).toBe('number');
+    expect(r.written).toBeGreaterThanOrEqual(1);
+  });
+
+  it('finding without venture_id or finding_category skips sync path with reason', async () => {
+    const r = await __fr2.maybeGenerateSdForFinding(supabase, { severity: 'critical' }, 'mock-id');
+    expect(r.skipped_reason).toBe('missing_required_fields');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FR-8: target_application derivation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FR-8 — sd-generator derives target_application from venture context', () => {
+  it('explicit sampleFinding.target_application=EHG is honored', async () => {
+    const t = await deriveTargetApplication(null, 'venture-1', { target_application: 'EHG' });
+    expect(t).toBe('EHG');
+  });
+
+  it('explicit sampleFinding.target_application=EHG_Engineer is honored', async () => {
+    const t = await deriveTargetApplication(null, 'venture-1', { target_application: 'EHG_Engineer' });
+    expect(t).toBe('EHG_Engineer');
+  });
+
+  it('invalid explicit target_application falls through to default', async () => {
+    const t = await deriveTargetApplication(null, 'venture-1', { target_application: 'Mars' });
+    expect(t).toBe('EHG');
+  });
+
+  it('venture metadata.stage_zero.target_platform=ehg_engineer maps to EHG_Engineer', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: { metadata: { stage_zero: { target_platform: 'ehg_engineer' } } },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+    const t = await deriveTargetApplication(supabase, 'venture-1', {});
+    expect(t).toBe('EHG_Engineer');
+  });
+
+  it('venture metadata.stage_zero.target_platform=platform maps to EHG', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: { metadata: { stage_zero: { target_platform: 'platform' } } },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+    const t = await deriveTargetApplication(supabase, 'venture-1', {});
+    expect(t).toBe('EHG');
+  });
+
+  it('no venture metadata → default EHG (NOT EHG_Engineer hardcode)', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      }),
+    };
+    const t = await deriveTargetApplication(supabase, 'venture-1', {});
+    expect(t).toBe('EHG');
+  });
+
+  it('null supabase + no explicit override → default EHG', async () => {
+    const t = await deriveTargetApplication(null, 'venture-1', {});
+    expect(t).toBe('EHG');
+  });
+
+  it('lookup error swallowed; falls through to default EHG', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => { throw new Error('connection lost'); },
+          }),
+        }),
+      }),
+    };
+    const t = await deriveTargetApplication(supabase, 'venture-1', {});
+    expect(t).toBe('EHG');
+  });
+});


### PR DESCRIPTION
## Summary

Closes 5 of 8 FRs in SD-LEO-FEAT-STAGE-CODE-QUALITY-001. Backend wiring for the Stage 20 Code Quality Gate. UI verdict-block (FR-3) deferred to follow-up SD-LEO-FEAT-S20-VERDICT-BLOCK-UI-001.

**FRs delivered**:
- **FR-1** (CRITICAL): `lib/eva/stage-templates/analysis-steps/index.js` — stage 20 dispatch path-a replace (legacy `stage-20-build-execution.js` → canonical `stage-20-code-quality.js`). Legacy export preserved as `analyzeStage20BuildExecution` for back-compat (no current importers).
- **FR-2** (HIGH): `lib/eva/quality-findings/writer.js` — synchronous FR-C SD generation on high/critical findings via `maybeGenerateSdForFinding`. Severity floor blocks medium/low/info. Composite-key dedupe. `LEO_FR_C_SYNC_GENERATION_ENABLED=off` kill switch reverts to cron-only.
- **FR-4** (CRITICAL): `lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js` — `buildNoRepoReport` emits `verdict='BLOCKED'` with `finding_category='precondition'` (was FAIL with `repo_access`). Distinct from FAIL so advance-writer routes operators to S19 (no override) vs FAIL (override available).
- **FR-7**: `tests/unit/eva/stage-code-quality-fr-1-2-4-8.test.js` (NEW, 21 vitest cases). All 128 quality-findings unit tests + 42 analysis-steps integration tests green.
- **FR-8** (MEDIUM): `lib/eva/quality-findings/sd-generator.js` — `deriveTargetApplication()` honors explicit > venture metadata > `'EHG'` default. Was hardcoded `'EHG_Engineer'` which routed venture-codebase remediation SDs to wrong app.

**Deferred** (per `PRD.metadata.scope_amendment`):
- FR-3 (UI verdict-block): EHG-side. Follow-up SD-LEO-FEAT-S20-VERDICT-BLOCK-UI-001 filed (DRAFT).
- FR-5 (artifact_type alignment): upstream stage worker concern, separate.
- FR-6 (PrivacyPatrol AI backfill): hard-blocked on SD-LEO-FEAT-STAGE-BUILD-REPLIT-001 (S19 deploy).

**Stats**: 6 files changed, +531/-25 LOC (4 source + 2 tests).

**Sub-agent evidence chain** (all rows in `sub_agent_execution_results` PLAN_VERIFICATION phase):
- TESTING (PASS conf 95) — `cd10a1ea`
- SECURITY (PASS conf 94) — `2e047dfe`
- GITHUB (PASS conf 92) — `fbe4c3da`
- DESIGN (PASS conf 95) — `d59e6b29`
- VALIDATION (PASS conf 95) — `d59e00b3`
- UAT (WARNING conf 88, deferred UI noted) — `aaeccf68`
- PERFORMANCE (PASS conf 88, +200-300ms p95 for sync sd-gen on critical findings, kill switch wired) — `3a809792`

Bypass quota: 2/3 used (EXEC-TO-PLAN + PLAN-TO-LEAD), both anchored on follow-up SD-LEO-FEAT-S20-VERDICT-BLOCK-UI-001 to address documented harness false-positives (DESIGN runs unconditionally for feature SDs at PLAN_VERIFY despite backend-only PR + cwd-vs-worktree gate harness bug per `feedback_gate5_git_commit_reads_main_repo_branch.md`).

## Test plan

- [x] Run new FR test suite: `npx vitest run tests/unit/eva/stage-code-quality-fr-1-2-4-8.test.js` — 21/21 PASS
- [x] Run full quality-findings suite: `npx vitest run tests/unit/eva/quality-findings/` — 128/128 PASS
- [x] Run analysis-steps integration: `npx vitest run tests/integration/eva/analysis-steps.test.js` — 42 PASS, 9 skipped
- [ ] Post-merge: monitor `audit_log` for `event_type='fr_c_sync_generator.error'` rows (FR-2 sync sd-gen failures should be observable, not silent)
- [ ] Post-merge: query `SELECT count(*) FROM venture_quality_findings` daily — baseline 0 rows globally as of 2026-05-03; expect non-zero within 24h of any venture passing through S20
- [ ] Post-merge: when SD-LEO-FEAT-S20-VERDICT-BLOCK-UI-001 ships, do canary venture run with flag ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)