### PR TITLE
fix(QF-20260503-440): GATE_SUBAGENT_EVIDENCE parse naive DB timestamps as UTC

### DIFF
--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -27,6 +27,21 @@ export const REQUIRED_SUBAGENTS = {
 };
 
 /**
+ * Parse a DB timestamp string treating naive (no-TZ) values as UTC.
+ * strategic_directives_v2.created_at and sd_phase_handoffs.accepted_at are
+ * stored as timestamp-without-time-zone in some environments; PostgREST returns
+ * them as naive strings, and `new Date(...)` parses naive strings as LOCAL —
+ * inflating freshness anchors by the local UTC offset and rejecting valid
+ * evidence rows. Append 'Z' when no TZ marker is present so JS treats it as UTC.
+ */
+function parseAsUTC(ts) {
+  if (!ts) return null;
+  if (ts instanceof Date) return ts;
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(ts);
+  return new Date(hasTZ ? ts : ts + 'Z');
+}
+
+/**
  * Resolve the current-phase start timestamp for freshness comparison.
  * Order:
  *   1) sd_phase_handoffs.accepted_at for most recent accepted handoff INTO current phase
@@ -41,7 +56,7 @@ export const REQUIRED_SUBAGENTS = {
 async function resolveCurrentPhaseStartedAt(ctx, supabase) {
   if (ctx._phaseStartedAt instanceof Date) return ctx._phaseStartedAt;
   if (typeof ctx._phaseStartedAt === 'string') {
-    ctx._phaseStartedAt = new Date(ctx._phaseStartedAt);
+    ctx._phaseStartedAt = parseAsUTC(ctx._phaseStartedAt);
     return ctx._phaseStartedAt;
   }
 
@@ -79,7 +94,7 @@ async function resolveCurrentPhaseStartedAt(ctx, supabase) {
       .limit(1);
 
     if (data && data.length > 0 && data[0].accepted_at) {
-      ctx._phaseStartedAt = new Date(data[0].accepted_at);
+      ctx._phaseStartedAt = parseAsUTC(data[0].accepted_at);
       return ctx._phaseStartedAt;
     }
   } catch (_) {
@@ -94,7 +109,7 @@ async function resolveCurrentPhaseStartedAt(ctx, supabase) {
       .eq('id', sdUuid)
       .single();
     if (data?.created_at) {
-      ctx._phaseStartedAt = new Date(data.created_at);
+      ctx._phaseStartedAt = parseAsUTC(data.created_at);
       return ctx._phaseStartedAt;
     }
   } catch (_) { /* noop */ }


### PR DESCRIPTION
## Summary
Closes a high-severity gate-rejection caused by naive-timestamp parsing in the SUBAGENT_EVIDENCE freshness check.

## Root Cause
`subagent-evidence-gate.js` calls `new Date(row.accepted_at)` and `new Date(row.created_at)` on strings returned from `sd_phase_handoffs.accepted_at` and `strategic_directives_v2.created_at`. When those columns are stored as `timestamp-without-time-zone`, PostgREST returns naive strings (no TZ suffix), and `new Date()` parses them as **local time**. On EDT this inflates `phase_started_at` by 4 hours, so any evidence row inserted within the first 4 hours of phase entry is incorrectly filtered out by the freshness check.

## Witness
2026-05-03 SD-LEO-FIX-REORDER-RELEASECLAIM-CLEAR-001:
- Evidence row `43a92c17` inserted at `2026-05-03T01:19:10Z`
- Gate computed `phase_started_at=2026-05-03T05:11:06Z` (SD `created_at=01:11:06` parsed as local-EDT)
- Valid row filtered out → `SUBAGENT_EVIDENCE_MISSING` blocked the handoff

## Fix
Adds `parseAsUTC(ts)` helper that appends `'Z'` when no TZ marker is present. Replaces 3 callsites (line 44 string-branch + lines 82/97 DB-result branches).

```js
function parseAsUTC(ts) {
  if (!ts) return null;
  if (ts instanceof Date) return ts;
  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(ts);
  return new Date(hasTZ ? ts : ts + 'Z');
}
```

Tactical fix per harness-backlog feedback row `7015eb1b` option (2). Structural follow-up (ALTER COLUMN ... TYPE timestamptz) can be tracked separately if needed.

## Test Plan
- [x] Inline UTC-parse tests passing (naive, TZ-aware, Z-suffix, fractional, null/empty/undefined)
- [x] Syntax check (node -c)
- [x] LOC: 18 insertions / 3 deletions (Tier 1 auto-approve)
- [ ] Manual: re-run a handoff for a fresh SD whose evidence rows were inserted within 4h of SD creation; expect gate PASS (post-merge)

## Related
- Harness-backlog feedback row: `7015eb1b-17de-4a34-822e-84ad85223ef5`
- Same TZ pattern may apply to other naive-timestamp readers — flagged for audit if more incidents surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)