### PR TITLE
fix(QF-20260503-697): fleet-dashboard markerIds.substring crash — read claude_session_id property

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -367,7 +367,9 @@ function printWorkers(d) {
       const fails = s.handoff_fail_count != null ? String(s.handoff_fail_count) : '-';
       const wip = s.has_uncommitted_changes === true ? 'Y' : s.has_uncommitted_changes === false ? 'N' : '-';
       const struggleTag = (s.handoff_fail_count || 0) > 3 ? ' [STRUGGLING]' : '';
-      const csid = hasCollision ? pad((markerIds[s.session_id] || '').substring(0, 10), 12) : '';
+      // markerIds[id] is { claude_session_id, pid, alive } per getMarkerSessionIds(); read property before substring
+      const markerEntry = markerIds[s.session_id];
+      const csid = hasCollision ? pad((markerEntry?.claude_session_id || '').substring(0, 10), 12) : '';
       const activity = formatActivity(s);
       const silent = formatSilentUntil(s);
       const mcRow = d.mcByWorker && d.mcByWorker[s.session_id];


### PR DESCRIPTION
## Summary
1-line semantic fix: extract `entry?.claude_session_id` before calling `.substring()`.

## Root Cause
`scripts/fleet-dashboard.cjs:370` called `(markerIds[s.session_id] || '').substring(0, 10)`. `getMarkerSessionIds()` (line 25-37) returns objects keyed by session_id:
```js
{ claude_session_id, pid, alive }
```
…not strings. Calling `.substring` on an object throws `markerIds[s.session_id].substring is not a function`, crashing the dashboard's `all` and `workers` sections.

## Fix
```js
const markerEntry = markerIds[s.session_id];
const csid = hasCollision ? pad((markerEntry?.claude_session_id || '').substring(0, 10), 12) : '';
```

Plus a comment documenting the entry shape so future readers don't hit the same trap.

## Test Plan
- [x] Syntax check (node -c)
- [x] Single callsite (verified via grep `markerIds\[`)
- [ ] Manual: run `node scripts/fleet-dashboard.cjs all` post-merge with multiple active sessions; expect no TypeError, csid column shows truncated claude_session_id when collisions detected

## Related
- Harness-backlog feedback row: `eb727637-99dd-458c-9a55-c23cf9deb65e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)