### PR TITLE
fix(QF-20260503-515): Gate 4 ROI validation crashes on sd_key — query by handoffLookupId

### DIFF
--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -319,10 +319,13 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     if (gateResults.gate3?.score) priorGateScores.push(gateResults.gate3.score);
 
     // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD for pattern tracking
+    // QF-20260503-515: query by handoffLookupId (UUID-resolved at line 69) instead of raw sd_id —
+    // sd_id may be the sd_key string when invoked via canonical CLI form, and .eq('id', sd_key)
+    // returns null, causing calculateAdaptiveThreshold to dereference null.risk_level.
     const sdData = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('*')
-      .eq('id', sd_id)
+      .eq('id', handoffLookupId)
       .single()).data;
 
     // Fetch pattern statistics for maturity bonus


### PR DESCRIPTION
## Summary
HIGH severity. Gate 4 (workflow ROI validation) crashes on every LEAD-FINAL-APPROVAL handoff invoked with sd_key form (the canonical CLI form). 1-line fix: use already-resolved `handoffLookupId` (UUID) instead of raw `sd_id` (may be sd_key string).

## Root Cause
`scripts/modules/workflow-roi-validation.js:325` fetches SD via `.eq('id', sd_id)`. When the caller passes `sd_id=sd_key` (the canonical CLI form), `.eq('id', sd_key)` returns null because the `id` column is UUID. Downstream at lines 333-335 the `thresholdSd` ternary produces an object missing `risk_level`, then `calculateAdaptiveThreshold` dereferences `null.risk_level` → throws.

The crash silently rewrites a real Gate 4 score (witness: 72) to 0% in the handoff rejection record, blocking LEAD-FINAL-APPROVAL regardless of actual implementation quality.

## Fix
Use `handoffLookupId` (line 69) which is guaranteed UUID after the line 62-66 OR-resolution. The variable is already used at lines 92, 96, 132 for related queries — this aligns line 325 with the file's existing pattern.

```diff
-      .eq('id', sd_id)
+      .eq('id', handoffLookupId)
```

## Test Plan
- [x] Syntax check (node -c)
- [x] `handoffLookupId` confirmed in scope at edit site (declared line 60, resolved line 69)
- [x] Pattern matches existing handoffLookupId usages (lines 92, 96, 132)
- [ ] Manual: invoke `node scripts/handoff.js execute LEAD-FINAL-APPROVAL SD-XXX-001` for any feature SD post-merge; expect Gate 4 returns real score, not 0%

## Related
- Harness-backlog feedback row: `442d8457`
- Affects ALL LEAD-FINAL-APPROVAL handoffs invoked with sd_key — high blast radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)