### PR TITLE
QF-20260503-858: dedup corrective-sd-generator emissions

### DIFF
--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -175,6 +175,51 @@ export async function isSourceSDA05Suppressed(sourceSdId, supabase) {
   }
 }
 
+/**
+ * QF-20260503-858 dedup: return the sd_key of an existing draft corrective SD
+ * that targets the same source SD + dimensions, or null if no duplicate.
+ *
+ * Match key is (source_sd_id, sorted dimensions). Resolves candidate source SDs
+ * via metadata.source_sd_id (preferred) or falls back to the eva_vision_scores
+ * row referenced by metadata.score_id (legacy SDs predating this field).
+ *
+ * @param {Object} supabase
+ * @param {string|null} sourceSdId
+ * @param {string[]} dimensionIds
+ * @returns {Promise<string|null>} duplicate sd_key, or null
+ */
+export async function findDuplicateCorrective(supabase, sourceSdId, dimensionIds) {
+  if (!sourceSdId || !Array.isArray(dimensionIds) || dimensionIds.length === 0) return null;
+  const dimsKey = [...dimensionIds].sort().join(',');
+  try {
+    const { data: drafts } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, metadata')
+      .eq('status', 'draft')
+      .filter('metadata->>source', 'eq', 'corrective_sd_generator');
+    const matches = (drafts || []).filter(
+      d => (d.metadata?.dimensions || []).slice().sort().join(',') === dimsKey
+    );
+    if (!matches.length) return null;
+    const idsNeedingLookup = matches
+      .filter(m => !m.metadata?.source_sd_id)
+      .map(m => m.metadata?.score_id || m.metadata?.vision_origin_score_id)
+      .filter(Boolean);
+    const scoreSdMap = {};
+    if (idsNeedingLookup.length) {
+      const { data: scores } = await supabase
+        .from('eva_vision_scores').select('id, sd_id').in('id', idsNeedingLookup);
+      for (const sc of (scores || [])) scoreSdMap[sc.id] = sc.sd_id;
+    }
+    for (const m of matches) {
+      const candSrc = m.metadata?.source_sd_id
+        || scoreSdMap[m.metadata?.score_id || m.metadata?.vision_origin_score_id];
+      if (candSrc === sourceSdId) return m.sd_key;
+    }
+    return null;
+  } catch { return null; }
+}
+
 // ─── Supabase Client ──────────────────────────────────────────────────────────
 
 function getSupabase() {
@@ -522,6 +567,21 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
       score.rubric_snapshot, score.total_score, action
     );
 
+    // QF-20260503-858: dedup — skip if a draft corrective already targets the
+    // same source-SD + dimension set. Prevents the duplicate-emission noise
+    // observed 2026-05-03 (15/24 post-filter SDs were duplicates).
+    const dimensionIds = dims.map(d => d.dimId);
+    const dupSdKey = await findDuplicateCorrective(supabase, score.sd_id, dimensionIds);
+    if (dupSdKey) {
+      console.log(`[corrective-sd-generator] eva.corrective.skipped_duplicate source_sd_id=${score.sd_id} dims=${[...dimensionIds].sort().join(',')} existing=${dupSdKey}`);
+      await _logAudit(supabase, scoreId, 'skipped_duplicate', dupSdKey, score.vision_id, {
+        source_sd_id: score.sd_id,
+        dimensions: dimensionIds,
+        existing_sd_key: dupSdKey,
+      });
+      continue;
+    }
+
     // Generate SD key through standard pipeline
     const sdKey = await generateSDKey({ source: 'CORR', type: sdType, title });
 
@@ -542,6 +602,7 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
         key_principles: [{ principle: 'Vision alignment', description: `Address ${label} gap(s) to improve EVA vision score` }],
         metadata: {
           source: 'corrective_sd_generator',
+          source_sd_id: score.sd_id ?? null,
           score_id: scoreId,
           vision_origin_score_id: scoreId,
           action_tier: action,

--- a/tests/unit/eva/corrective-sd-generator-dedup.test.js
+++ b/tests/unit/eva/corrective-sd-generator-dedup.test.js
@@ -1,0 +1,101 @@
+/**
+ * QF-20260503-858: dedup pre-insert check on corrective-sd-generator.
+ *
+ * Validates findDuplicateCorrective() catches drafts with the same source SD
+ * and dimension set. Includes legacy-SD fallback (lookup via eva_vision_scores)
+ * and new-format match (metadata.source_sd_id).
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+
+let findDuplicateCorrective;
+
+beforeAll(async () => {
+  const mod = await import('../../../scripts/eva/corrective-sd-generator.mjs');
+  findDuplicateCorrective = mod.findDuplicateCorrective;
+});
+
+function mockSupabase({ drafts = [], scores = [] } = {}) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: () => ({
+              filter: () => Promise.resolve({ data: drafts, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'eva_vision_scores') {
+        return {
+          select: () => ({
+            in: () => Promise.resolve({ data: scores, error: null }),
+          }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+describe('findDuplicateCorrective', () => {
+  it('returns null when no drafts exist', async () => {
+    const sb = mockSupabase({ drafts: [] });
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBeNull();
+  });
+
+  it('returns null when no draft matches dim set', async () => {
+    const sb = mockSupabase({ drafts: [
+      { sd_key: 'GAP-001', metadata: { source_sd_id: 'src-1', dimensions: ['V08'] } },
+    ]});
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBeNull();
+  });
+
+  it('matches by metadata.source_sd_id (new-format SD)', async () => {
+    const sb = mockSupabase({ drafts: [
+      { sd_key: 'GAP-045', metadata: { source_sd_id: 'src-1', dimensions: ['A05'] } },
+    ]});
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBe('GAP-045');
+  });
+
+  it('matches via eva_vision_scores fallback (legacy SD without source_sd_id)', async () => {
+    const sb = mockSupabase({
+      drafts: [
+        { sd_key: 'GAP-049', metadata: { score_id: 'sc-1', dimensions: ['A05'] } },
+      ],
+      scores: [{ id: 'sc-1', sd_id: 'src-1' }],
+    });
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBe('GAP-049');
+  });
+
+  it('matches dim sets order-insensitive (A04,A05 == A05,A04)', async () => {
+    const sb = mockSupabase({ drafts: [
+      { sd_key: 'GAP-050', metadata: { source_sd_id: 'src-1', dimensions: ['A04', 'A05'] } },
+    ]});
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05', 'A04'])).toBe('GAP-050');
+  });
+
+  it('returns null when source SD differs even with matching dims', async () => {
+    const sb = mockSupabase({ drafts: [
+      { sd_key: 'GAP-100', metadata: { source_sd_id: 'src-2', dimensions: ['A05'] } },
+    ]});
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBeNull();
+  });
+
+  it('returns null on null/empty inputs', async () => {
+    const sb = mockSupabase();
+    expect(await findDuplicateCorrective(sb, null, ['A05'])).toBeNull();
+    expect(await findDuplicateCorrective(sb, 'src-1', [])).toBeNull();
+    expect(await findDuplicateCorrective(sb, 'src-1', null)).toBeNull();
+  });
+
+  it('returns null on supabase error (fail-open — never silently lose legit emissions)', async () => {
+    const sb = {
+      from: () => { throw new Error('connection lost'); },
+    };
+    expect(await findDuplicateCorrective(sb, 'src-1', ['A05'])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds pre-insert dedup check to `corrective-sd-generator.mjs` — closes the gap that allowed 15 duplicate SDs in 30 minutes on 2026-05-03
- Persists `source_sd_id` in new corrective-SD metadata so future dedup runs don't need score-row lookups
- Filter PR #3492 was correct; this is the orthogonal "did we already emit this?" check

## What changed
- `scripts/eva/corrective-sd-generator.mjs` (+61): new `findDuplicateCorrective()` exported function + Step 5c dedup check at the createSD call site + `metadata.source_sd_id` persistence
- `tests/unit/eva/corrective-sd-generator-dedup.test.js` (+101 new): 8 vitest cases covering new-format match, legacy `eva_vision_scores` fallback, order-insensitive dim sets, fail-open on errors

## Evidence
2026-05-03 post-filter audit found 24 GAP SDs against 9 unique source-SD + dim groups:
- SD-LEO-FEAT-STAGE-CODE-QUALITY-001 + A05 → 4 dup SDs (GAP-045/047/048/049)
- SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001 + V08 → 5 dup SDs (GAP-033..037)
- SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001 + A04+A05 → 5 dup SDs (GAP-050..054)
- SD-LEO-FEAT-STAGE-CODE-QUALITY-001 + V06+V08 → 2 dup SDs (GAP-026/028)
- SD-LEO-FEAT-STAGE-CODE-QUALITY-001 + V06+V08 → 3 dup SDs (GAP-030/031/032)

## Routing
- 61 src LOC (Tier 2 QF, no risk keywords)
- 162 total LOC (src + tests)
- Documented exception per CLAUDE.md "≤100 LOC target. Exceed only with documented justification" — tests not counted toward routing tier

## Test plan
- [x] 8 new dedup vitest cases pass
- [x] 70 sibling tests (a05-filter, lifecycle-feature-filter, multidim, generator) still pass
- [ ] CI green

## Out-of-scope
- Existing 24 draft duplicates NOT cancelled by this PR — mass-cancellation requires explicit user authorization (scope creep beyond QF). Recommend manual triage by Chairman.
- Filed under quick_fixes table as `QF-20260503-858`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)