### PR TITLE
fix(QF-20260503-283): sd-key-generator detect chunked-read protocol files

### DIFF
--- a/scripts/modules/sd-key-generator.js
+++ b/scripts/modules/sd-key-generator.js
@@ -52,7 +52,13 @@ function readSessionState() {
  */
 function isLeadFileRead() {
   const state = readSessionState();
-  return state.protocolFilesRead?.includes('CLAUDE_LEAD.md') || state.protocolFilesRead?.includes('CLAUDE_LEAD.md') || false;
+  // QF-20260503-283: also accept readCount > 0 in protocolFileReadStatus —
+  // chunked reads update that schema but never append to protocolFilesRead,
+  // so without this fallback Case 1 in validateLeadFileRead short-circuits
+  // before Case 2's cumulative-coverage check can run.
+  return state.protocolFilesRead?.includes('CLAUDE_LEAD.md')
+    || (state.protocolFileReadStatus?.['CLAUDE_LEAD.md']?.readCount > 0)
+    || false;
 }
 
 /**
@@ -61,7 +67,11 @@ function isLeadFileRead() {
  */
 function isCoreFileRead() {
   const state = readSessionState();
-  return state.protocolFilesRead?.includes('CLAUDE_CORE.md') || state.protocolFilesRead?.includes('CLAUDE_CORE.md') || false;
+  // QF-20260503-283: also accept readCount > 0 in protocolFileReadStatus —
+  // chunked reads update that schema but never append to protocolFilesRead.
+  return state.protocolFilesRead?.includes('CLAUDE_CORE.md')
+    || (state.protocolFileReadStatus?.['CLAUDE_CORE.md']?.readCount > 0)
+    || false;
 }
 
 /**


### PR DESCRIPTION
## Summary
HIGH severity. SD creation was blocked for any session that read CLAUDE_CORE.md or CLAUDE_LEAD.md via chunked offset/limit reads (the only viable path given the 25k-token Read cap).

## Root Cause
`scripts/modules/sd-key-generator.js` `isCoreFileRead` (L62-65) and `isLeadFileRead` (L53-56) only checked `state.protocolFilesRead.includes(filename)`. When the read-tracking hook updates `state.protocolFileReadStatus[filename].readCount` (the new schema for chunked-read tracking) without appending to the `protocolFilesRead` array, these helpers returned false.

`validateCoreFileRead`/`validateLeadFileRead` then hit Case 1 (`if (!isRead)`) and short-circuited with "has not been read in this session" — preventing Case 2 (cumulative-range coverage 95% check) from running.

Bonus: both helpers had a duplicate `||` clause (same expression twice — copy-paste typo).

## Fix
Add `protocolFileReadStatus[filename].readCount > 0` as a fallback check in both helpers; remove the duplicate `||` clauses.

```diff
-  return state.protocolFilesRead?.includes('CLAUDE_CORE.md')
-      || state.protocolFilesRead?.includes('CLAUDE_CORE.md') || false;
+  return state.protocolFilesRead?.includes('CLAUDE_CORE.md')
+      || (state.protocolFileReadStatus?.['CLAUDE_CORE.md']?.readCount > 0)
+      || false;
```

Case 2's coverage check then correctly evaluates whether chunked reads collectively reached 95%.

## Test Plan
- [x] Syntax check (node -c) + module-load check
- [x] Both helpers updated with parallel fix
- [ ] Manual: run leo-create-sd.js after a chunked-read session of CLAUDE_CORE.md; expect SD creation succeeds when cumulative coverage ≥95% (post-merge)

## Related
- Harness-backlog feedback row: `fd6da2fe`
- Affects ALL SD creation paths via leo-create-sd.js for sessions using chunked reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)