### PR TITLE
fix(QF-20260503-820): scope complete-quick-fix diff to merge-base (three-dot syntax)

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -224,7 +224,12 @@ export function analyzeGitDiff(testDir, qfDescription = '') {
   let diffAnalysis = {};
 
   try {
-    const files = execSync('git diff origin/main --name-only', { encoding: 'utf-8', cwd: testDir })
+    // QF-20260503-820: use three-dot syntax (origin/main...HEAD) so the diff is
+    // scoped to "what THIS branch changed since divergence" — independent of how
+    // far origin/main has advanced during the QF lifecycle. Two-dot syntax
+    // (origin/main..HEAD) was producing false-positive scope-creep warnings
+    // when parallel sessions merged unrelated work to main mid-flight.
+    const files = execSync('git diff origin/main...HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
       .trim()
       .split('\n')
       .filter(f => f);
@@ -233,7 +238,7 @@ export function analyzeGitDiff(testDir, qfDescription = '') {
     console.log(`   Files Changed: ${filesChanged.length}`);
     filesChanged.forEach(file => console.log(`      - ${file}`));
 
-    const diffStat = execSync('git diff origin/main --stat', { encoding: 'utf-8', cwd: testDir });
+    const diffStat = execSync('git diff origin/main...HEAD --stat', { encoding: 'utf-8', cwd: testDir });
     const insertions = diffStat.match(/(\d+) insertion/);
     const deletions = diffStat.match(/(\d+) deletion/);
 


### PR DESCRIPTION
## Summary
2-line semantic fix: `git diff origin/main` → `git diff origin/main...HEAD` (three-dot) at two callsites in `scripts/modules/complete-quick-fix/git-operations.js`. Eliminates false-positive scope-creep warnings when parallel sessions advance origin/main during a QF lifecycle.

## Root Cause
`analyzeGitDiff` at line 227 + 236 ran:
```js
git diff origin/main --name-only
git diff origin/main --stat
```
Two-dot (or omitted) syntax compares working-tree HEAD against the **current** state of origin/main. When parallel sessions merge unrelated work to main between worktree creation and completion, those new files show up in `filesChanged` as differences — even though I never touched them. The verifier in `lib/quickfix-self-verifier.js:228-256` then flags them as scope creep.

Three-dot `origin/main...HEAD` diffs from the **merge-base** of (origin/main, HEAD) to HEAD — only the changes THIS branch introduced since divergence. Unaffected by how far origin/main has advanced.

## Witnessed
2026-05-03 across 4 QFs (440, 697, 515, 283). Each required `git rebase origin/main` mid-flow to clear false-positives before completion would proceed.

## Fix
```diff
-    const files = execSync('git diff origin/main --name-only', ...)
+    const files = execSync('git diff origin/main...HEAD --name-only', ...)

-    const diffStat = execSync('git diff origin/main --stat', ...)
+    const diffStat = execSync('git diff origin/main...HEAD --stat', ...)
```

Plus a comment block documenting why three-dot matters here.

## Test Plan
- [x] Syntax check (node -c)
- [x] Sanity test on this very QF: three-dot returns 1 file (my fix); confirmed
- [x] Behavior unchanged for QFs whose origin/main hasn't moved (which is most QFs in non-parallel-session days)
- [ ] Manual: ship a future QF while a parallel SD merge lands during the window; confirm verifier doesn't flag the SD's files (post-merge)

## Related
- Self-discovered during this session's auto-mode QF sweep (QFs 440/697/515/283)
- Lessons learned doc preserved in session memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)