### PR TITLE
feat(SD-LEO-INFRA-RESTORE-FEEDBACK-PIPELINE-001): FR-C cron lock refactor + auto-triage source enum compliance

### DIFF
--- a/.github/workflows/fr-c-generator-cron.yml
+++ b/.github/workflows/fr-c-generator-cron.yml
@@ -4,8 +4,9 @@ name: "FR-C Remediation SD Generator (cron)"
 #
 # Hourly sweep of venture_quality_findings (status='pending', severity in
 # critical/high/medium) → DRAFT remediation SDs in strategic_directives_v2.
-# Idempotent via pg_advisory_lock(hashtext('fr_c_generator')); the script
-# no-ops gracefully if a previous tick is still running.
+# Idempotent via cron_run_locks table + try_claim_cron_lock RPC; the script
+# no-ops gracefully if a previous tick is still running. The TTL on the row
+# lock self-heals after 2x the cron interval, so a crashed tick can't jam it.
 
 on:
   schedule:
@@ -27,7 +28,7 @@ permissions:
   contents: read
 
 concurrency:
-  # Cancel any in-flight run to avoid stacking — the advisory lock would no-op
+  # Cancel any in-flight run to avoid stacking — the cron lock would no-op
   # the second one anyway, but cancelling avoids burning Actions minutes.
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -41,7 +42,6 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-      SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
       FR_C_RATE_LIMIT_PER_VENTURE_PER_DAY: ${{ github.event.inputs.rate_limit_override || '' }}
 
     steps:

--- a/database/migrations/20260503_cron_run_locks.sql
+++ b/database/migrations/20260503_cron_run_locks.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- cron_run_locks: TTL-based claim-by-row lock primitive for cron entrypoints
+-- ============================================================================
+--
+-- Purpose: replace pg_advisory_lock for the FR-C generator (and future cron
+-- jobs) so the lock survives the Supabase RPC connection model. Postgres
+-- session-scoped advisory locks are released as soon as the pooled connection
+-- returns, which defeats their cross-tick guarantee when called over PostgREST.
+--
+-- A claim row carries an owner UUID (minted by the caller) and an expires_at
+-- timestamp. try_claim_cron_lock() succeeds when no row exists OR the existing
+-- row is expired; release_cron_lock() deletes only when the owner UUID matches
+-- (so a late release from a prior tick can't drop the current owner's claim).
+--
+-- Replaces SUPABASE_POOLER_URL dependency in scripts/cron/fr-c-generator.mjs.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.cron_run_locks (
+  name        text PRIMARY KEY,
+  owner       uuid NOT NULL,
+  locked_at   timestamptz NOT NULL DEFAULT now(),
+  expires_at  timestamptz NOT NULL
+);
+
+COMMENT ON TABLE public.cron_run_locks IS
+  'TTL-based row locks for cron entrypoints invoked over Supabase RPC. See try_claim_cron_lock()/release_cron_lock().';
+
+-- ----------------------------------------------------------------------------
+-- try_claim_cron_lock(p_name, p_owner, p_ttl_seconds) → boolean
+--
+-- Returns true if the caller now owns the lock; false if a non-expired claim
+-- by another owner is already in place. Uses INSERT ... ON CONFLICT DO UPDATE
+-- with a WHERE that only overwrites expired rows, so the read-and-claim is
+-- atomic.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.try_claim_cron_lock(
+  p_name        text,
+  p_owner       uuid,
+  p_ttl_seconds integer DEFAULT 600
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_winner uuid;
+BEGIN
+  IF p_name IS NULL OR length(p_name) = 0 THEN
+    RAISE EXCEPTION 'try_claim_cron_lock: p_name required';
+  END IF;
+  IF p_owner IS NULL THEN
+    RAISE EXCEPTION 'try_claim_cron_lock: p_owner required';
+  END IF;
+  IF p_ttl_seconds IS NULL OR p_ttl_seconds < 1 THEN
+    RAISE EXCEPTION 'try_claim_cron_lock: p_ttl_seconds must be >= 1';
+  END IF;
+
+  INSERT INTO public.cron_run_locks (name, owner, locked_at, expires_at)
+  VALUES (p_name, p_owner, now(), now() + make_interval(secs => p_ttl_seconds))
+  ON CONFLICT (name) DO UPDATE
+    SET owner = EXCLUDED.owner,
+        locked_at = EXCLUDED.locked_at,
+        expires_at = EXCLUDED.expires_at
+    WHERE public.cron_run_locks.expires_at <= now()
+  RETURNING owner INTO v_winner;
+
+  RETURN v_winner = p_owner;
+END;
+$$;
+
+COMMENT ON FUNCTION public.try_claim_cron_lock(text, uuid, integer) IS
+  'Atomic claim-or-noop. Returns true if caller now owns the lock; false if held by another non-expired owner.';
+
+-- ----------------------------------------------------------------------------
+-- release_cron_lock(p_name, p_owner) → boolean
+--
+-- Owner-scoped delete. Returns true if a row was actually removed (i.e. the
+-- caller still owned the lock at release time). Returns false if the row was
+-- already taken over by a later tick after expiry.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.release_cron_lock(
+  p_name  text,
+  p_owner uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted integer;
+BEGIN
+  DELETE FROM public.cron_run_locks
+   WHERE name = p_name AND owner = p_owner;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.release_cron_lock(text, uuid) IS
+  'Owner-scoped release. Returns true if the row was deleted; false if a later tick already took ownership after expiry.';
+
+-- ----------------------------------------------------------------------------
+-- Grants — service_role calls these from cron jobs; revoke from anon.
+-- ----------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.try_claim_cron_lock(text, uuid, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.release_cron_lock(text, uuid)            FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.try_claim_cron_lock(text, uuid, integer) TO service_role, authenticated;
+GRANT EXECUTE ON FUNCTION public.release_cron_lock(text, uuid)            TO service_role, authenticated;
+
+-- Lock down direct table writes; service_role uses the RPC functions.
+ALTER TABLE public.cron_run_locks ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS cron_run_locks_service_all ON public.cron_run_locks;
+CREATE POLICY cron_run_locks_service_all ON public.cron_run_locks
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Rollback (manual):
+--   DROP POLICY IF EXISTS cron_run_locks_service_all ON public.cron_run_locks;
+--   DROP FUNCTION IF EXISTS public.release_cron_lock(text, uuid);
+--   DROP FUNCTION IF EXISTS public.try_claim_cron_lock(text, uuid, integer);
+--   DROP TABLE IF EXISTS public.cron_run_locks;

--- a/scripts/cron/fr-c-generator.mjs
+++ b/scripts/cron/fr-c-generator.mjs
@@ -4,10 +4,16 @@
  *
  * SD: SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-FR-C-001 (FR-2)
  *
- * Idempotency: acquires pg_advisory_lock(hashtext('fr_c_generator')) before
- * any read of venture_quality_findings; releases in finally. A second concurrent
- * tick observes the lock as held, writes audit_log event='lock_held', and
- * exits 0 (not an error — graceful no-op).
+ * Idempotency: claims a TTL row in cron_run_locks via the
+ * try_claim_cron_lock(name, owner, ttl_seconds) RPC before any read of
+ * venture_quality_findings; releases via release_cron_lock(name, owner) in
+ * finally. A second concurrent tick observes the row as held by another owner,
+ * writes audit_log event='lock_held', and exits 0 (graceful no-op).
+ *
+ * The RPC primitive replaced session-scoped pg_advisory_lock — Supabase RPC
+ * pools connections, so an advisory lock taken inside one call is released
+ * when the connection returns to the pool, defeating the cross-tick guard.
+ * See database/migrations/20260503_cron_run_locks.sql.
  *
  * Failure isolation: any generator exception is caught at the entrypoint
  * boundary; the lock is released; failure surfaces via audit_log
@@ -21,19 +27,21 @@
  *
  * Env:
  *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY      — required
- *   SUPABASE_POOLER_URL                          — required (pg advisory lock)
  *   FR_C_POLL_INTERVAL_SEC                       — default 3600; <60 rejected
  *   FR_C_RATE_LIMIT_PER_VENTURE_PER_DAY          — default 20
  */
 import 'dotenv/config';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
-import pg from 'pg';
 import { generateRemediationSdsBatch, writeAuditLog } from '../../lib/eva/quality-findings/sd-generator.js';
 
-const LOCK_KEY_NAME = 'fr_c_generator';
+const LOCK_NAME = 'fr_c_generator';
 const DEFAULT_INTERVAL_SEC = 3600;
 const MIN_INTERVAL_SEC = 60;
+// TTL covers two cron periods so a crashed tick (e.g. SIGKILL after timeout)
+// self-heals before the next scheduled run instead of jamming the lock.
+const LOCK_TTL_FLOOR_SEC = 600;
 
 function parseArgs(argv) {
   const args = { daemon: false, dryRun: false };
@@ -65,38 +73,41 @@ function buildSupabase() {
   return createClient(url, key);
 }
 
-function buildPgClient() {
-  const conn = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.POSTGRES_URL;
-  if (!conn) throw new Error('SUPABASE_POOLER_URL (or DATABASE_URL) required for pg_advisory_lock');
-  return new pg.Client({ connectionString: conn });
+function computeLockTtlSec(intervalSec) {
+  // 2x interval gives the next tick a clean slate even if the current one
+  // wedges; floor at LOCK_TTL_FLOOR_SEC for short FR_C_POLL_INTERVAL_SEC values.
+  return Math.max(LOCK_TTL_FLOOR_SEC, intervalSec * 2);
 }
 
 /**
- * Compute the bigint advisory-lock key from a string.
- * Postgres hashtext returns int4; pg_advisory_lock(int) overload is sufficient
- * for our uniqueness needs. Computed server-side via SELECT hashtext($1)::int.
+ * Atomically claim the cron lock row. Returns true if this caller owns it.
  *
- * @param {pg.Client} client
- * @returns {Promise<number>}
+ * @param {Object} supabase
+ * @param {string} owner - UUID minted at process start
+ * @param {number} ttlSec
+ * @returns {Promise<boolean>}
  */
-async function resolveLockKey(client) {
-  const r = await client.query('SELECT hashtext($1)::int AS k', [LOCK_KEY_NAME]);
-  return r.rows[0].k;
+async function tryClaimLock(supabase, owner, ttlSec) {
+  const { data, error } = await supabase.rpc('try_claim_cron_lock', {
+    p_name: LOCK_NAME,
+    p_owner: owner,
+    p_ttl_seconds: ttlSec,
+  });
+  if (error) throw new Error(`try_claim_cron_lock RPC failed: ${error.message}`);
+  return data === true;
 }
 
-/**
- * Try to acquire the advisory lock without blocking. Returns true if acquired.
- */
-async function tryAcquireLock(client, key) {
-  const r = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [key]);
-  return r.rows[0].acquired === true;
-}
-
-async function releaseLock(client, key) {
+async function releaseLock(supabase, owner) {
   try {
-    await client.query('SELECT pg_advisory_unlock($1)', [key]);
+    const { error } = await supabase.rpc('release_cron_lock', {
+      p_name: LOCK_NAME,
+      p_owner: owner,
+    });
+    if (error) {
+      process.stderr.write(`[fr-c-generator] release_cron_lock failed: ${error.message}\n`);
+    }
   } catch (err) {
-    process.stderr.write(`[fr-c-generator] pg_advisory_unlock failed: ${err.message}\n`);
+    process.stderr.write(`[fr-c-generator] release_cron_lock threw: ${err.message}\n`);
   }
 }
 
@@ -108,14 +119,14 @@ async function runOneBatch({ supabase, dryRun }) {
   return await generateRemediationSdsBatch({ supabase });
 }
 
-async function runOnce({ args, supabase, pgClient, lockKey }) {
-  const acquired = await tryAcquireLock(pgClient, lockKey);
+async function runOnce({ args, supabase, owner, ttlSec }) {
+  const acquired = await tryClaimLock(supabase, owner, ttlSec);
   if (!acquired) {
-    process.stdout.write('[fr-c-generator] advisory lock held by another invocation; no-op exit\n');
+    process.stdout.write('[fr-c-generator] cron lock held by another tick; no-op exit\n');
     await writeAuditLog(supabase, 'lock_held', {
-      lock_name: LOCK_KEY_NAME,
-      lock_key: lockKey,
-    }, { entityType: 'fr_c_generator_run', entityId: LOCK_KEY_NAME, severity: 'info' });
+      lock_name: LOCK_NAME,
+      owner,
+    }, { entityType: 'fr_c_generator_run', entityId: LOCK_NAME, severity: 'info' });
     return { exitCode: 0, summary: { lockHeld: true } };
   }
 
@@ -130,10 +141,10 @@ async function runOnce({ args, supabase, pgClient, lockKey }) {
     await writeAuditLog(supabase, 'generator_failed', {
       error: err.message,
       stack: (err.stack || '').slice(0, 1000),
-    }, { entityType: 'fr_c_generator_run', entityId: LOCK_KEY_NAME, severity: 'error' });
+    }, { entityType: 'fr_c_generator_run', entityId: LOCK_NAME, severity: 'error' });
     return { exitCode: 1, summary: { error: err.message } };
   } finally {
-    await releaseLock(pgClient, lockKey);
+    await releaseLock(supabase, owner);
   }
 }
 
@@ -150,33 +161,31 @@ Flags:
 
 Env:
   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY        required
-  SUPABASE_POOLER_URL                            required for pg_advisory_lock
   FR_C_POLL_INTERVAL_SEC                         default 3600 (>=60 enforced)
   FR_C_RATE_LIMIT_PER_VENTURE_PER_DAY            default 20
+
+Lock:
+  Uses cron_run_locks table + try_claim_cron_lock RPC. TTL self-heals after
+  max(600s, 2*interval) so a crashed tick can't jam the lock.
 `);
     return 0;
   }
 
-  // Validate env up front (rejects invalid intervals before opening DB conn).
+  // Validate env up front (rejects invalid intervals before opening conn).
   const intervalSec = readPollIntervalFromEnv();
   const supabase = buildSupabase();
-  const pgClient = buildPgClient();
-  await pgClient.connect();
-  const lockKey = await resolveLockKey(pgClient);
+  const owner = randomUUID();
+  const ttlSec = computeLockTtlSec(intervalSec);
 
-  try {
-    if (!args.daemon) {
-      const { exitCode } = await runOnce({ args, supabase, pgClient, lockKey });
-      return exitCode;
-    }
-    process.stdout.write(`[fr-c-generator] daemon mode interval=${intervalSec}s\n`);
-    /* eslint-disable no-constant-condition */
-    while (true) {
-      await runOnce({ args, supabase, pgClient, lockKey });
-      await new Promise((r) => setTimeout(r, intervalSec * 1000));
-    }
-  } finally {
-    try { await pgClient.end(); } catch { /* noop */ }
+  if (!args.daemon) {
+    const { exitCode } = await runOnce({ args, supabase, owner, ttlSec });
+    return exitCode;
+  }
+  process.stdout.write(`[fr-c-generator] daemon mode interval=${intervalSec}s ttl=${ttlSec}s owner=${owner}\n`);
+  /* eslint-disable no-constant-condition */
+  while (true) {
+    await runOnce({ args, supabase, owner, ttlSec });
+    await new Promise((r) => setTimeout(r, intervalSec * 1000));
   }
 }
 
@@ -196,4 +205,4 @@ if (isDirectInvocation) {
     });
 }
 
-export { main, parseArgs, readPollIntervalFromEnv, resolveLockKey, tryAcquireLock, releaseLock };
+export { main, parseArgs, readPollIntervalFromEnv, computeLockTtlSec, tryClaimLock, releaseLock, runOnce, LOCK_NAME };

--- a/scripts/modules/inbox/assist-runner.js
+++ b/scripts/modules/inbox/assist-runner.js
@@ -3,8 +3,13 @@
 /**
  * LEO Assist Runner — Periodic feedback inbox processor
  *
- * Queries untriaged feedback items and classifies them via LLM.
+ * Queries untriaged feedback items and classifies them via heuristics.
  * Designed to run from GitHub Actions on a cron schedule.
+ *
+ * Writes ai_triage_source='rules' (heuristic only). LLM-based classification
+ * is handled by auto-triage.js (Child -D), which writes 'llm'. Both values
+ * are constrained by chk_ai_triage_source_valid on the feedback table — see
+ * database/migrations/20260207_feedback_llm_triage_columns.sql.
  *
  * Usage:
  *   node scripts/modules/inbox/assist-runner.js [--max-items N] [--dry-run]
@@ -14,9 +19,13 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
 import 'dotenv/config';
 
 const CLASSIFICATION_CATEGORIES = ['bug', 'enhancement', 'question', 'noise'];
+// Must match chk_ai_triage_source_valid CHECK constraint on feedback table.
+// assist-runner only does heuristic classification, so always 'rules'.
+const TRIAGE_SOURCE = 'rules';
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -67,7 +76,7 @@ async function classifyItem(item) {
     confidence = 0.65;
   }
 
-  return { classification, confidence };
+  return { classification, confidence, source: TRIAGE_SOURCE };
 }
 
 async function run() {
@@ -104,11 +113,11 @@ async function run() {
   let errors = 0;
 
   for (const item of items) {
-    const { classification, confidence } = await classifyItem(item);
+    const { classification, confidence, source } = await classifyItem(item);
     const truncTitle = (item.title || '').substring(0, 60);
 
     if (flags.dryRun) {
-      console.log(`  [DRY-RUN] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%)`);
+      console.log(`  [DRY-RUN] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%) [${source}]`);
       processed++;
       continue;
     }
@@ -118,7 +127,7 @@ async function run() {
       .update({
         ai_triage_classification: classification,
         ai_triage_confidence: Math.round(confidence * 100),
-        ai_triage_source: 'assist-runner',
+        ai_triage_source: source,
         updated_at: new Date().toISOString()
       })
       .eq('id', item.id);
@@ -127,7 +136,7 @@ async function run() {
       console.error(`  [ERROR] ${truncTitle}: ${updateError.message}`);
       errors++;
     } else {
-      console.log(`  [OK] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%)`);
+      console.log(`  [OK] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%) [${source}]`);
       processed++;
     }
   }
@@ -138,7 +147,12 @@ async function run() {
   console.log(`  Mode: ${flags.dryRun ? 'dry-run (no writes)' : 'live'}`);
 }
 
-run().catch(err => {
-  console.error('[assist-runner] Fatal:', err.message);
-  process.exit(1);
-});
+// Exported for unit tests.
+export { classifyItem, TRIAGE_SOURCE };
+
+if (isMainModule(import.meta.url)) {
+  run().catch(err => {
+    console.error('[assist-runner] Fatal:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/modules/inbox/auto-triage.js
+++ b/scripts/modules/inbox/auto-triage.js
@@ -7,6 +7,10 @@
  * on feedback table rows with status='new' and no existing classification.
  *
  * Categories: bug, enhancement, question, noise
+ * Sources: 'llm' (LLM-derived classification) or 'rules' (heuristic fallback).
+ *   These are the only values permitted by the chk_ai_triage_source_valid
+ *   CHECK constraint on the feedback table — see migration
+ *   database/migrations/20260207_feedback_llm_triage_columns.sql.
  * Idempotent: skips already-classified items.
  *
  * Usage:
@@ -18,9 +22,12 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getLLMClient } from '../../../lib/llm/client-factory.js';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
 import 'dotenv/config';
 
 const VALID_CATEGORIES = ['bug', 'enhancement', 'question', 'noise'];
+// Must match chk_ai_triage_source_valid CHECK constraint on feedback table.
+const VALID_SOURCES = ['llm', 'rules'];
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 500;
 
@@ -75,7 +82,9 @@ async function classifyWithLLM(item) {
 
     const text = typeof result === 'string' ? result : result?.content || result?.text || '';
     const match = text.match(/\{[^}]+\}/);
-    if (!match) return { classification: 'question', confidence: 0.40 };
+    // No parseable JSON in LLM output: fall back to a hardcoded default
+    // and report 'rules' as the source (the value is not LLM-derived).
+    if (!match) return { classification: 'question', confidence: 0.40, source: 'rules' };
 
     const parsed = JSON.parse(match[0]);
     const classification = VALID_CATEGORIES.includes(parsed.classification)
@@ -83,7 +92,7 @@ async function classifyWithLLM(item) {
       : 'question';
     const confidence = Math.max(0, Math.min(1, parseFloat(parsed.confidence) || 0.50));
 
-    return { classification, confidence };
+    return { classification, confidence, source: 'llm' };
   } catch (err) {
     console.warn(`  [WARN] LLM classification failed: ${err.message}`);
     return heuristicClassify(item);
@@ -95,15 +104,15 @@ function heuristicClassify(item) {
   const category = (item.category || '').toLowerCase();
 
   if (category.includes('error') || category.includes('failure') || category.includes('ci_failure')) {
-    return { classification: 'bug', confidence: 0.75 };
+    return { classification: 'bug', confidence: 0.75, source: 'rules' };
   }
   if (title.includes('fail') || title.includes('error') || title.includes('crash')) {
-    return { classification: 'bug', confidence: 0.70 };
+    return { classification: 'bug', confidence: 0.70, source: 'rules' };
   }
   if (title.includes('add') || title.includes('improve') || title.includes('enhance')) {
-    return { classification: 'enhancement', confidence: 0.65 };
+    return { classification: 'enhancement', confidence: 0.65, source: 'rules' };
   }
-  return { classification: 'question', confidence: 0.50 };
+  return { classification: 'question', confidence: 0.50, source: 'rules' };
 }
 
 function sleep(ms) {
@@ -144,12 +153,15 @@ async function run() {
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    const { classification, confidence } = await classifyWithLLM(item);
+    const { classification, confidence, source } = await classifyWithLLM(item);
     const truncTitle = (item.title || '').substring(0, 55);
     totalConfidence += confidence;
+    // Defense-in-depth: never write a value that would violate
+    // chk_ai_triage_source_valid; treat unknown sources as 'rules'.
+    const safeSource = VALID_SOURCES.includes(source) ? source : 'rules';
 
     if (flags.dryRun) {
-      console.log(`  [DRY-RUN] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%)`);
+      console.log(`  [DRY-RUN] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%) [${safeSource}]`);
       processed++;
     } else {
       const { error: updateError } = await supabase
@@ -157,7 +169,7 @@ async function run() {
         .update({
           ai_triage_classification: classification,
           ai_triage_confidence: Math.round(confidence * 100),
-          ai_triage_source: 'auto-triage-llm',
+          ai_triage_source: safeSource,
           updated_at: new Date().toISOString()
         })
         .eq('id', item.id);
@@ -166,7 +178,7 @@ async function run() {
         console.error(`  [ERROR] ${truncTitle}: ${updateError.message}`);
         errors++;
       } else {
-        console.log(`  [OK] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%)`);
+        console.log(`  [OK] ${truncTitle} → ${classification} (${(confidence * 100).toFixed(0)}%) [${safeSource}]`);
         processed++;
       }
     }
@@ -191,7 +203,12 @@ async function run() {
   }
 }
 
-run().catch(err => {
-  console.error('[auto-triage] Fatal:', err.message);
-  process.exit(1);
-});
+// Exported for unit tests.
+export { classifyWithLLM, heuristicClassify, VALID_SOURCES };
+
+if (isMainModule(import.meta.url)) {
+  run().catch(err => {
+    console.error('[auto-triage] Fatal:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/modules/inbox/auto-triage.test.js
+++ b/scripts/modules/inbox/auto-triage.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for auto-triage and assist-runner ai_triage_source values.
+ *
+ * Regression: chk_ai_triage_source_valid CHECK constraint on the feedback
+ * table only allows 'llm' or 'rules' (or NULL). Previous writers used
+ * 'auto-triage-llm' and 'assist-runner', which silently violated the
+ * constraint and stranded ~194 untriaged rows. See CAPA-5.
+ *
+ * @module scripts/modules/inbox/auto-triage.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks must be declared before any import of the modules under test
+// (vi.mock calls are hoisted). LLM client + supabase + dotenv are stubbed
+// so importing the script does not exit() or open network sockets.
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: () => ({ update: () => ({ eq: () => ({}) }) }) })),
+}));
+
+vi.mock('dotenv/config', () => ({}));
+
+const llmCompleteMock = vi.fn();
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  getLLMClient: () => ({ complete: llmCompleteMock }),
+}));
+
+// Force isMainModule to return false so the script doesn't auto-invoke run()
+vi.mock('../../../lib/utils/is-main-module.js', () => ({
+  isMainModule: () => false,
+}));
+
+// Provide minimal env so getSupabase()/getSupabaseClient() don't process.exit().
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://test.local';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
+
+const { classifyWithLLM, heuristicClassify, VALID_SOURCES } = await import('./auto-triage.js');
+const { classifyItem, TRIAGE_SOURCE } = await import('./assist-runner.js');
+
+describe('chk_ai_triage_source_valid compatibility', () => {
+  it('VALID_SOURCES exports the constraint-allowed set', () => {
+    expect(VALID_SOURCES).toEqual(['llm', 'rules']);
+  });
+
+  describe('auto-triage heuristicClassify', () => {
+    it("returns source='rules' for category=ci_failure", () => {
+      const r = heuristicClassify({ title: 'x', category: 'ci_failure' });
+      expect(r.source).toBe('rules');
+      expect(VALID_SOURCES).toContain(r.source);
+    });
+
+    it("returns source='rules' for title containing 'fail'", () => {
+      const r = heuristicClassify({ title: 'build fail on main', category: '' });
+      expect(r.source).toBe('rules');
+    });
+
+    it("returns source='rules' for default 'question' classification", () => {
+      const r = heuristicClassify({ title: 'how does X work?', category: '' });
+      expect(r.classification).toBe('question');
+      expect(r.source).toBe('rules');
+    });
+  });
+
+  describe('auto-triage classifyWithLLM', () => {
+    beforeEach(() => llmCompleteMock.mockReset());
+
+    it("returns source='llm' on parseable LLM output", async () => {
+      llmCompleteMock.mockResolvedValueOnce('{"classification":"bug","confidence":0.9}');
+      const r = await classifyWithLLM({ title: 't', description: 'd' });
+      expect(r.classification).toBe('bug');
+      expect(r.source).toBe('llm');
+      expect(VALID_SOURCES).toContain(r.source);
+    });
+
+    it("returns source='rules' when LLM output has no JSON", async () => {
+      llmCompleteMock.mockResolvedValueOnce('I refuse to classify');
+      const r = await classifyWithLLM({ title: 't', description: 'd' });
+      expect(r.classification).toBe('question');
+      expect(r.source).toBe('rules');
+    });
+
+    it("returns source='rules' when LLM throws (heuristic fallback)", async () => {
+      llmCompleteMock.mockRejectedValueOnce(new Error('API key not valid'));
+      const r = await classifyWithLLM({ title: 'crash on save', category: '' });
+      expect(r.classification).toBe('bug');
+      expect(r.source).toBe('rules');
+      expect(VALID_SOURCES).toContain(r.source);
+    });
+  });
+
+  describe('assist-runner classifyItem', () => {
+    it("always returns source='rules' (heuristic only)", async () => {
+      expect(TRIAGE_SOURCE).toBe('rules');
+      const r1 = await classifyItem({ title: 'broken thing', category: '' });
+      const r2 = await classifyItem({ title: 'add new feature', category: '' });
+      const r3 = await classifyItem({ title: '?', category: 'ci_failure' });
+      for (const r of [r1, r2, r3]) {
+        expect(r.source).toBe('rules');
+        expect(VALID_SOURCES).toContain(r.source);
+      }
+    });
+  });
+
+  it('rejects the legacy invalid source values', () => {
+    expect(VALID_SOURCES).not.toContain('auto-triage-llm');
+    expect(VALID_SOURCES).not.toContain('assist-runner');
+  });
+});

--- a/tests/unit/scripts/cron/fr-c-generator.test.js
+++ b/tests/unit/scripts/cron/fr-c-generator.test.js
@@ -1,0 +1,167 @@
+/**
+ * FR-C generator cron entrypoint tests.
+ *
+ * SD: SD-LEO-INFRA-FIX-FR-C-CRON-DROP-POOLER-001
+ *
+ * Covers the post-SUPABASE_POOLER_URL refactor: the script now claims a TTL
+ * row in cron_run_locks via the try_claim_cron_lock RPC instead of taking a
+ * session-scoped pg_advisory_lock. These tests verify the lock-contention
+ * branch (no-op + audit) and the lock-acquired branch (generator invoked,
+ * release_cron_lock called with the same owner).
+ *
+ * Pure unit: mocks the sd-generator and supabase client at the import boundary,
+ * no DB or network needed.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Mock the sd-generator BEFORE importing the cron entrypoint so the cron's
+// `import { generateRemediationSdsBatch, writeAuditLog } from '...sd-generator.js'`
+// resolves to these spies.
+const generateRemediationSdsBatchSpy = vi.fn();
+const writeAuditLogSpy = vi.fn();
+vi.mock('../../../../lib/eva/quality-findings/sd-generator.js', () => ({
+  generateRemediationSdsBatch: (...args) => generateRemediationSdsBatchSpy(...args),
+  writeAuditLog: (...args) => writeAuditLogSpy(...args),
+}));
+
+// Stub the supabase-js client so buildSupabase() doesn't need real env wiring.
+// We construct the supabase shape inline per test and pass it through runOnce.
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({})),
+}));
+
+const cronModule = await import('../../../../scripts/cron/fr-c-generator.mjs');
+const { runOnce, computeLockTtlSec, LOCK_NAME, tryClaimLock, releaseLock } = cronModule;
+
+function makeSupabaseMock(rpcResponses) {
+  // rpcResponses: Map<rpcName, () => { data, error }>
+  const rpc = vi.fn((name, _params) => {
+    const responder = rpcResponses.get(name);
+    if (!responder) throw new Error(`unmocked rpc: ${name}`);
+    return Promise.resolve(responder());
+  });
+  return { rpc, _rpc: rpc };
+}
+
+describe('fr-c-generator cron — lock primitive', () => {
+  beforeEach(() => {
+    generateRemediationSdsBatchSpy.mockReset();
+    writeAuditLogSpy.mockReset();
+  });
+
+  test('computeLockTtlSec floors at 600s and otherwise returns 2x interval', () => {
+    expect(computeLockTtlSec(60)).toBe(600);     // floor wins
+    expect(computeLockTtlSec(300)).toBe(600);    // floor wins
+    expect(computeLockTtlSec(3600)).toBe(7200);  // 2x interval wins
+    expect(computeLockTtlSec(86400)).toBe(172800);
+  });
+
+  test('tryClaimLock surfaces the boolean from try_claim_cron_lock RPC', async () => {
+    const supabase = makeSupabaseMock(new Map([
+      ['try_claim_cron_lock', () => ({ data: true, error: null })],
+    ]));
+    await expect(tryClaimLock(supabase, 'owner-uuid-1', 600)).resolves.toBe(true);
+    expect(supabase._rpc).toHaveBeenCalledWith('try_claim_cron_lock', {
+      p_name: LOCK_NAME,
+      p_owner: 'owner-uuid-1',
+      p_ttl_seconds: 600,
+    });
+  });
+
+  test('tryClaimLock throws when RPC returns an error', async () => {
+    const supabase = makeSupabaseMock(new Map([
+      ['try_claim_cron_lock', () => ({ data: null, error: { message: 'boom' } })],
+    ]));
+    await expect(tryClaimLock(supabase, 'owner-uuid-1', 600)).rejects.toThrow(/try_claim_cron_lock RPC failed: boom/);
+  });
+
+  test('runOnce no-ops when lock is held by another tick', async () => {
+    const supabase = makeSupabaseMock(new Map([
+      ['try_claim_cron_lock', () => ({ data: false, error: null })],
+    ]));
+
+    const result = await runOnce({
+      args: { dryRun: false, daemon: false },
+      supabase,
+      owner: 'owner-uuid-other-tick',
+      ttlSec: 7200,
+    });
+
+    expect(result).toEqual({ exitCode: 0, summary: { lockHeld: true } });
+    // Generator must NOT be invoked when contention is detected.
+    expect(generateRemediationSdsBatchSpy).not.toHaveBeenCalled();
+    // Audit must be written with event=lock_held and the correct payload.
+    expect(writeAuditLogSpy).toHaveBeenCalledWith(
+      supabase,
+      'lock_held',
+      expect.objectContaining({ lock_name: LOCK_NAME, owner: 'owner-uuid-other-tick' }),
+      expect.objectContaining({ entityType: 'fr_c_generator_run', entityId: LOCK_NAME, severity: 'info' }),
+    );
+    // We did NOT acquire the lock, so we must NOT call release_cron_lock.
+    const rpcCalls = supabase._rpc.mock.calls.map((c) => c[0]);
+    expect(rpcCalls).toEqual(['try_claim_cron_lock']);
+  });
+
+  test('runOnce invokes generator and releases lock on the success path', async () => {
+    generateRemediationSdsBatchSpy.mockResolvedValue({
+      ventures: ['v1'], totalCreated: 1, totalAppended: 0, totalSkippedRateLimited: 0, totalErrors: 0, perVenture: { v1: { created: 1 } },
+    });
+    const supabase = makeSupabaseMock(new Map([
+      ['try_claim_cron_lock', () => ({ data: true, error: null })],
+      ['release_cron_lock', () => ({ data: true, error: null })],
+    ]));
+
+    const result = await runOnce({
+      args: { dryRun: false, daemon: false },
+      supabase,
+      owner: 'owner-uuid-this-tick',
+      ttlSec: 7200,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary.totalCreated).toBe(1);
+    expect(generateRemediationSdsBatchSpy).toHaveBeenCalledTimes(1);
+    expect(writeAuditLogSpy).not.toHaveBeenCalled(); // success path doesn't audit on its own
+    // Both RPCs must be called: claim then release with the same owner.
+    const rpcCalls = supabase._rpc.mock.calls;
+    expect(rpcCalls[0]).toEqual(['try_claim_cron_lock', { p_name: LOCK_NAME, p_owner: 'owner-uuid-this-tick', p_ttl_seconds: 7200 }]);
+    expect(rpcCalls[1]).toEqual(['release_cron_lock',  { p_name: LOCK_NAME, p_owner: 'owner-uuid-this-tick' }]);
+  });
+
+  test('runOnce releases lock and audits when generator throws', async () => {
+    generateRemediationSdsBatchSpy.mockRejectedValue(new Error('generator boom'));
+    const supabase = makeSupabaseMock(new Map([
+      ['try_claim_cron_lock', () => ({ data: true, error: null })],
+      ['release_cron_lock', () => ({ data: true, error: null })],
+    ]));
+
+    const result = await runOnce({
+      args: { dryRun: false, daemon: false },
+      supabase,
+      owner: 'owner-uuid-this-tick',
+      ttlSec: 7200,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.summary.error).toBe('generator boom');
+    // Audit captures generator_failed.
+    expect(writeAuditLogSpy).toHaveBeenCalledWith(
+      supabase,
+      'generator_failed',
+      expect.objectContaining({ error: 'generator boom' }),
+      expect.objectContaining({ entityType: 'fr_c_generator_run', entityId: LOCK_NAME, severity: 'error' }),
+    );
+    // Release MUST still be called via finally{}.
+    const rpcNames = supabase._rpc.mock.calls.map((c) => c[0]);
+    expect(rpcNames).toContain('release_cron_lock');
+  });
+
+  test('releaseLock swallows RPC errors so finally{} cannot mask the original failure', async () => {
+    const supabase = makeSupabaseMock(new Map([
+      ['release_cron_lock', () => ({ data: null, error: { message: 'release exploded' } })],
+    ]));
+    // Should not throw despite the RPC error response.
+    await expect(releaseLock(supabase, 'owner-uuid-1')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Restores the feedback pipeline by closing two silent infrastructure failures discovered during `/leo assist` (2026-05-03):

- **FR-1 (Critical)**: FR-C Remediation cron has had **27 consecutive failures** since PR #3451 because GitHub secret `SUPABASE_POOLER_URL` was never configured. Refactored to row-based TTL lock via Supabase RPC, eliminating the secret dependency.
- **FR-2 (High)**: Clockwork Auto-Triage was silently failing (`success` conclusion, 0 processed / 20 errors per run) due to writers using `ai_triage_source` values that violated `chk_ai_triage_source_valid`. Result: 154+ stranded stale-untriaged feedback rows. Writers now send canonical `'llm'` / `'rules'` values.

## Changes

**FR-1 — Cron lock refactor** (eliminates `SUPABASE_POOLER_URL`):
- `database/migrations/20260503_cron_run_locks.sql` (new, 122 LOC) — `cron_run_locks` table + `try_claim_cron_lock` + `release_cron_lock` RPCs. SECURITY DEFINER, RLS service-role-only. **Already applied to live DB.**
- `scripts/cron/fr-c-generator.mjs` (refactored, +123/-85 net) — removed `pg.Client` + `buildPgClient` + `resolveLockKey`; added `randomUUID()` owner mint + `tryClaimLock`/`releaseLock` via `supabase.rpc`; `computeLockTtlSec` floor `max(600s, 2*interval)` for crash self-heal.
- `.github/workflows/fr-c-generator-cron.yml` — removed `SUPABASE_POOLER_URL` env reference.
- `tests/unit/scripts/cron/fr-c-generator.test.js` (new, 167 LOC, 7 vitest cases).

**FR-2 — Triage source enum compliance** (no migration; constraint was correct):
- `scripts/modules/inbox/auto-triage.js` — `classifyWithLLM` returns `source='llm'` on parseable LLM output, `source='rules'` on heuristic fallback. `VALID_SOURCES = ['llm', 'rules']` defense-in-depth.
- `scripts/modules/inbox/assist-runner.js` — replaced literal `'assist-runner'` with `TRIAGE_SOURCE = 'rules'`.
- `scripts/modules/inbox/auto-triage.test.js` (new, 108 LOC, 9 vitest cases incl. sentinel test).

## Supersedes

- **PR #3483** (`qf/QF-20260502-fr-c-pooler-url`) — 1-line stop-gap that remapped `SUPABASE_POOLER_URL` to `secrets.DATABASE_URL`. Will close as superseded after this lands; this PR eliminates the secret entirely.

## Sub-agent evidence

- **DATABASE (af6a88c5)**: FR-1 architectural design — pg_advisory_lock semantics analysis, lock primitive selection.
- **DATABASE (a464807c)**: FR-2 constraint audit — `pg_get_constraintdef` + writer audit (3 sites, 2 broken, 1 correct), live INSERT/UPDATE round-trip with `'llm'` and `'rules'`.
- **DATABASE (a7ad9693)**: live migration apply on consolidated DB (`dedlbzhpgkmetvhbkyzq`), verification queries, claim/release round-trip passed.

## Test plan

- [x] `npx vitest run tests/unit/scripts/cron/fr-c-generator.test.js` — 7/7 green
- [x] `npx vitest run scripts/modules/inbox/auto-triage.test.js` — 9/9 green
- [x] Migration applied to live DB; round-trip claim/release verified
- [ ] Post-merge: `gh workflow run "FR-C Remediation SD Generator (cron)" -f dry_run=true` to confirm RPC path works
- [ ] Post-merge: confirm next organic hourly cron tick succeeds (first since PR #3451)
- [ ] Post-merge: rotate Gemini API key for full auto-triage restoration (separate admin task; constraint fix means it won't crash on writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)