### PR TITLE
feat(SD-FDBK-FIX-SUPPRESS-ARCHITECTURE-LAYER-001): suppress api layer for SPA-only target_applications

### DIFF
--- a/lib/eva/config/target-application-capabilities.js
+++ b/lib/eva/config/target-application-capabilities.js
@@ -1,0 +1,61 @@
+/**
+ * Target Application Capabilities — declares which architecture layers each
+ * target_application can actually host. Drives the lifecycle-sd-bridge
+ * grandchild emission filter so we don't generate `api` layer SDs for
+ * frontend-only deployments (Vite SPA, static sites) that have no
+ * serverless runtime to fulfil them.
+ *
+ * Why this exists: auto-pipeline-stage-17-doc-gen mechanically decomposes
+ * every "Implement *" parent into 4 architecture layers (data/api/ui/tests).
+ * For target_application=ehg this produces api SDs that can never ship —
+ * vercel.json rewrites /api/* to /index.html, and vite.config.ts has no
+ * serverless plugin. The class-fix is to pre-filter layers by capability
+ * at emit time.
+ *
+ * Sibling pattern: lib/eva/config/venture-default-capabilities.js.
+ *
+ * Default behaviour: targets not listed here are assumed capable across
+ * all layers (preserves existing emission for unrecognised ventures).
+ * Add an explicit entry to opt out of a layer.
+ *
+ * @module lib/eva/config/target-application-capabilities
+ */
+
+export const TARGET_CAPABILITIES_VERSION = '2026.05';
+
+const RAW_CAPABILITIES = {
+  // EHG customer-facing app — Vite SPA on Vercel, no serverless runtime
+  ehg: {
+    has_serverless_api: false,
+    notes: 'Vite SPA; vercel.json rewrites all non-asset paths to /index.html. No serverless plugin in vite.config.ts.',
+  },
+  // EHG_Engineer — Node service + Supabase Edge Functions; full backend
+  ehg_engineer: {
+    has_serverless_api: true,
+    notes: 'Node service with API routes and supabase/functions/*; backed serverless API supported.',
+  },
+};
+
+const FROZEN_DEFAULTS = Object.freeze({
+  has_serverless_api: true,
+  notes: 'Default — unknown target assumed capable to preserve existing emission.',
+});
+
+export const TARGET_APPLICATION_CAPABILITIES = Object.freeze(
+  Object.fromEntries(
+    Object.entries(RAW_CAPABILITIES).map(([k, v]) => [k, Object.freeze(v)]),
+  ),
+);
+
+/**
+ * Lookup capabilities for a target_application. Match is case-insensitive
+ * and treats `EHG_Engineer`, `ehg_engineer`, `EHG Engineer` as equivalent.
+ *
+ * @param {string|null|undefined} targetApplication
+ * @returns {{has_serverless_api: boolean, notes: string}}
+ */
+export function getTargetApplicationCapabilities(targetApplication) {
+  if (!targetApplication) return FROZEN_DEFAULTS;
+  const key = String(targetApplication).toLowerCase().replace(/[\s-]+/g, '_');
+  return TARGET_APPLICATION_CAPABILITIES[key] || FROZEN_DEFAULTS;
+}

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -37,6 +37,8 @@ import { getCurrentVenture } from '../venture-resolver.js';
 import { loadMapping, resolveArtifactsForSD } from './artifact-mapping-resolver.js';
 import { summarizeArtifacts, enrichSDDescription } from './artifact-enrichment-pipeline.js';
 import { validateIntegrity } from './referential-integrity-rubric.js';
+// QF: target_application capability lookup (suppress api layer for SPA-only targets)
+import { getTargetApplicationCapabilities } from './config/target-application-capabilities.js';
 
 // ── Amplification Caps (US-004) ─────────────────────────────────
 const MAX_CHILDREN_PER_ORCHESTRATOR = 10;
@@ -375,7 +377,11 @@ async function createGrandchildren({
 }) {
   const gcKeys = [];
   // Determine which architecture layers apply based on payload hints
-  const layers = selectApplicableLayers(childPayload);
+  const candidateLayers = selectApplicableLayers(childPayload);
+
+  // Filter by target_application capability — suppress api for SPA-only targets
+  const effectiveTarget = childPayload.target_application || ventureContext?.name || getCurrentVenture();
+  const layers = filterLayersByCapability(candidateLayers, effectiveTarget, { logger, parentChildKey });
 
   // Cap grandchildren per child (US-004)
   const cappedLayers = layers.slice(0, MAX_GRANDCHILDREN_PER_CHILD);
@@ -459,6 +465,36 @@ function selectApplicableLayers(payload) {
   }
   // Default: all layers apply
   return ARCHITECTURE_LAYERS;
+}
+
+/**
+ * Filter layers by target_application capability. Removes layers the target
+ * cannot host (e.g. `api` for a Vite SPA with no serverless runtime). Emits
+ * one audit log line per suppression decision so the choice is auditable.
+ *
+ * @param {Array} layers - Candidate layers from selectApplicableLayers
+ * @param {string|null|undefined} targetApplication - Effective target app
+ * @param {Object} [opts]
+ * @param {Object} [opts.logger=console]
+ * @param {string} [opts.parentChildKey] - Parent SD key for log context
+ * @returns {Array} Filtered layers
+ */
+function filterLayersByCapability(layers, targetApplication, { logger = console, parentChildKey = '' } = {}) {
+  const caps = getTargetApplicationCapabilities(targetApplication);
+  const suppressed = [];
+  const kept = layers.filter(layer => {
+    if (layer.key === 'api' && caps.has_serverless_api === false) {
+      suppressed.push(layer.key);
+      return false;
+    }
+    return true;
+  });
+  if (suppressed.length > 0) {
+    logger.log(
+      `[LifecycleSDBridge] Suppressed architecture_layer(s) [${suppressed.join(',')}] for target_application=${targetApplication} (has_serverless_api=${caps.has_serverless_api})${parentChildKey ? ` parent=${parentChildKey}` : ''}`,
+    );
+  }
+  return kept;
 }
 
 /**
@@ -879,6 +915,7 @@ export const _internal = {
   GENERATION_VERSION,
   buildProvenance,
   selectApplicableLayers,
+  filterLayersByCapability,
   rollbackCreatedRecords,
   createGrandchildren,
   findExistingOrchestrator,

--- a/tests/unit/eva/config/target-application-capabilities.test.js
+++ b/tests/unit/eva/config/target-application-capabilities.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TARGET_APPLICATION_CAPABILITIES,
+  TARGET_CAPABILITIES_VERSION,
+  getTargetApplicationCapabilities,
+} from '../../../../lib/eva/config/target-application-capabilities.js';
+
+describe('target-application-capabilities', () => {
+  it('exports a version', () => {
+    expect(TARGET_CAPABILITIES_VERSION).toMatch(/^\d{4}\.\d{2}$/);
+  });
+
+  it('lists ehg as has_serverless_api=false', () => {
+    expect(TARGET_APPLICATION_CAPABILITIES.ehg.has_serverless_api).toBe(false);
+  });
+
+  it('lists ehg_engineer as has_serverless_api=true', () => {
+    expect(TARGET_APPLICATION_CAPABILITIES.ehg_engineer.has_serverless_api).toBe(true);
+  });
+
+  it('returns false for ehg via lookup', () => {
+    expect(getTargetApplicationCapabilities('ehg').has_serverless_api).toBe(false);
+  });
+
+  it('returns true for EHG_Engineer via lookup (case-insensitive)', () => {
+    expect(getTargetApplicationCapabilities('EHG_Engineer').has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities('ehg_engineer').has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities('EHG Engineer').has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities('ehg-engineer').has_serverless_api).toBe(true);
+  });
+
+  it('defaults unknown targets to permissive (has_serverless_api=true) to preserve existing emission', () => {
+    expect(getTargetApplicationCapabilities('some-new-venture').has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities(null).has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities(undefined).has_serverless_api).toBe(true);
+    expect(getTargetApplicationCapabilities('').has_serverless_api).toBe(true);
+  });
+
+  it('returns frozen objects (defensive against mutation)', () => {
+    const ehg = getTargetApplicationCapabilities('ehg');
+    expect(Object.isFrozen(ehg)).toBe(true);
+    expect(Object.isFrozen(TARGET_APPLICATION_CAPABILITIES)).toBe(true);
+  });
+});

--- a/tests/unit/eva/lifecycle-sd-bridge.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge.test.js
@@ -30,6 +30,7 @@ const {
   MAX_GRANDCHILDREN_PER_CHILD,
   buildProvenance,
   selectApplicableLayers,
+  filterLayersByCapability,
 } = _internal;
 
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -149,6 +150,7 @@ describe('LifecycleSDBridge', () => {
             sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'Desc', scope: 'Scope' }],
           },
           ventureContext: { id: 'v1', name: 'Test' },
+          options: { skipEnrichment: true },
         },
         { supabase: createMockSupabase(), logger: silentLogger },
       );
@@ -167,7 +169,7 @@ describe('LifecycleSDBridge', () => {
             sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'D', scope: 'S' }],
           },
           ventureContext: { id: 'v1', name: 'Test' },
-          options: { generateGrandchildren: false },
+          options: { generateGrandchildren: false, skipEnrichment: true },
         },
         { supabase: createMockSupabase(), logger: silentLogger },
       );
@@ -240,6 +242,188 @@ describe('LifecycleSDBridge', () => {
     it('should ignore unknown layer keys', () => {
       const layers = selectApplicableLayers({ architecture_layers: ['data', 'unknown'] });
       expect(layers.length).toBe(1);
+    });
+  });
+
+  describe('filterLayersByCapability — target_application capability gate', () => {
+    it('should suppress api layer when target_application=ehg (Vite SPA, no serverless API)', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const filtered = filterLayersByCapability(ARCHITECTURE_LAYERS, 'ehg', { logger });
+      const keys = filtered.map(l => l.key);
+      expect(keys).toEqual(['data', 'ui', 'tests']);
+      expect(keys).not.toContain('api');
+    });
+
+    it('should keep all 4 layers when target_application=EHG_Engineer (has serverless API)', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const filtered = filterLayersByCapability(ARCHITECTURE_LAYERS, 'EHG_Engineer', { logger });
+      const keys = filtered.map(l => l.key);
+      expect(keys).toEqual(['data', 'api', 'ui', 'tests']);
+    });
+
+    it('should emit one audit log line when api is suppressed', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      filterLayersByCapability(ARCHITECTURE_LAYERS, 'ehg', { logger, parentChildKey: 'SD-PARENT-001-A' });
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      const msg = logger.log.mock.calls[0][0];
+      expect(msg).toContain('Suppressed architecture_layer(s)');
+      expect(msg).toContain('api');
+      expect(msg).toContain('target_application=ehg');
+      expect(msg).toContain('has_serverless_api=false');
+      expect(msg).toContain('parent=SD-PARENT-001-A');
+    });
+
+    it('should NOT emit audit log when no layers are suppressed', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      filterLayersByCapability(ARCHITECTURE_LAYERS, 'EHG_Engineer', { logger });
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('should default to permissive (all layers) for unknown target_application', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const filtered = filterLayersByCapability(ARCHITECTURE_LAYERS, 'some-new-venture', { logger });
+      expect(filtered.length).toBe(4);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('should be case-insensitive and tolerate spaces/dashes', () => {
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const variants = ['EHG', 'Ehg', 'ehg'];
+      for (const v of variants) {
+        const f = filterLayersByCapability(ARCHITECTURE_LAYERS, v, { logger });
+        expect(f.map(l => l.key)).not.toContain('api');
+      }
+    });
+  });
+
+  describe('createGrandchildren end-to-end — capability suppression', () => {
+    it('should NOT emit api grandchild when ventureContext.name=ehg', async () => {
+      const insertCalls = [];
+      const mockSb = {
+        from: vi.fn((table) => {
+          if (table === 'strategic_directives_v2') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              insert: vi.fn().mockImplementation((data) => {
+                insertCalls.push(data);
+                return Promise.resolve({ data: null, error: null });
+              }),
+              update: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            };
+          }
+          return { select: vi.fn().mockReturnThis(), insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+        }),
+        rpc: vi.fn().mockResolvedValue({ data: { cancelled_sds: 0, cancelled_prds: 0 }, error: null }),
+      };
+
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint EHG',
+            sprint_goal: 'Build SPA feature',
+            sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'D', scope: 'S' }],
+          },
+          ventureContext: { id: 'v1', name: 'ehg' },
+          options: { skipEnrichment: true },
+        },
+        { supabase: mockSb, logger: silentLogger },
+      );
+
+      expect(result.created).toBe(true);
+      // Orchestrator + 1 child + grandchildren. ehg suppresses api → only 3 grandchildren.
+      const grandchildInserts = insertCalls.filter(r => r.metadata?.architecture_layer);
+      expect(grandchildInserts.length).toBe(3);
+      const layers = grandchildInserts.map(r => r.metadata.architecture_layer).sort();
+      expect(layers).toEqual(['data', 'tests', 'ui']);
+    });
+
+    it('should emit all 4 grandchildren when ventureContext.name=EHG_Engineer', async () => {
+      const insertCalls = [];
+      const mockSb = {
+        from: vi.fn((table) => {
+          if (table === 'strategic_directives_v2') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              insert: vi.fn().mockImplementation((data) => {
+                insertCalls.push(data);
+                return Promise.resolve({ data: null, error: null });
+              }),
+              update: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            };
+          }
+          return { select: vi.fn().mockReturnThis(), insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+        }),
+        rpc: vi.fn().mockResolvedValue({ data: { cancelled_sds: 0, cancelled_prds: 0 }, error: null }),
+      };
+
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint Engineer',
+            sprint_goal: 'Build harness feature',
+            sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'D', scope: 'S' }],
+          },
+          ventureContext: { id: 'v1', name: 'EHG_Engineer' },
+          options: { skipEnrichment: true },
+        },
+        { supabase: mockSb, logger: silentLogger },
+      );
+
+      expect(result.created).toBe(true);
+      const grandchildInserts = insertCalls.filter(r => r.metadata?.architecture_layer);
+      expect(grandchildInserts.length).toBe(4);
+      const layers = grandchildInserts.map(r => r.metadata.architecture_layer).sort();
+      expect(layers).toEqual(['api', 'data', 'tests', 'ui']);
+    });
+
+    it('should respect childPayload.target_application override per parent', async () => {
+      const insertCalls = [];
+      const mockSb = {
+        from: vi.fn((table) => {
+          if (table === 'strategic_directives_v2') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              insert: vi.fn().mockImplementation((data) => {
+                insertCalls.push(data);
+                return Promise.resolve({ data: null, error: null });
+              }),
+              update: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            };
+          }
+          return { select: vi.fn().mockReturnThis(), insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+        }),
+        rpc: vi.fn().mockResolvedValue({ data: { cancelled_sds: 0 }, error: null }),
+      };
+
+      // venture is EHG_Engineer but child overrides to ehg → suppress api
+      await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Mixed',
+            sprint_goal: 'Mixed targets',
+            sd_bridge_payloads: [{ title: 'Frontend', type: 'feature', target_application: 'ehg', description: 'D', scope: 'S' }],
+          },
+          ventureContext: { id: 'v1', name: 'EHG_Engineer' },
+          options: { skipEnrichment: true },
+        },
+        { supabase: mockSb, logger: silentLogger },
+      );
+
+      const grandchildInserts = insertCalls.filter(r => r.metadata?.architecture_layer);
+      const layers = grandchildInserts.map(r => r.metadata.architecture_layer).sort();
+      expect(layers).toEqual(['data', 'tests', 'ui']);
     });
   });
 
@@ -351,7 +535,7 @@ describe('LifecycleSDBridge', () => {
           },
           ventureContext: { id: 'v1', name: 'Test' },
           evaKeys: { vision_key: 'VISION-TEST-001', plan_key: 'ARCH-TEST-001' },
-          options: { generateGrandchildren: false },
+          options: { generateGrandchildren: false, skipEnrichment: true },
         },
         { supabase: mockSb, logger: silentLogger },
       );
@@ -398,7 +582,7 @@ describe('LifecycleSDBridge', () => {
           },
           ventureContext: { id: 'v1', name: 'Test' },
           // evaKeys omitted — should default to {}
-          options: { generateGrandchildren: false },
+          options: { generateGrandchildren: false, skipEnrichment: true },
         },
         { supabase: mockSb, logger: silentLogger },
       );


### PR DESCRIPTION
## Summary

- New `lib/eva/config/target-application-capabilities.js` declares per-target_application capability flags (`has_serverless_api`). `ehg`=false (Vite SPA), `ehg_engineer`=true. Unknown targets default permissive.
- New `filterLayersByCapability()` in `lib/eva/lifecycle-sd-bridge.js` chains after `selectApplicableLayers()` and suppresses `architecture_layer=api` for SPA-only targets, with one audit log line per suppression decision.
- 16 new vitest cases (7 config-level + 9 bridge-level). 4 pre-existing test failures fixed as drive-by (added `skipEnrichment: true` to bypass venture_artifacts mock chain that was already broken on `main`).

## Why

`auto-pipeline-stage-17-doc-gen` mechanically emitted `architecture_layer=api` grandchildren for every Stage-19 sprint child, regardless of whether the target_application could host a serverless runtime. For `target_application=ehg` (Vite SPA on Vercel — `vercel.json` rewrites `/api/*` → `/index.html`, no serverless plugin in `vite.config.ts`) those SDs were dead-on-arrival. 6 such SDs were generated and immediately cancelled at LEAD/VALIDATION on 2026-05-03 (sub_agent_execution_results id=`7b8be404`). Class-fix prevents emission rather than catching downstream.

Closes harness backlog `feedback.id=abe207b8-bd71-419e-83e0-989d5b763375`.

## Tracking SD

`SD-FDBK-FIX-SUPPRESS-ARCHITECTURE-LAYER-001` (created via `leo-create-sd.js --from-feedback`, quality 95/100).

## Test plan

- [x] `npx vitest run tests/unit/eva/config/target-application-capabilities.test.js tests/unit/eva/lifecycle-sd-bridge.test.js` — 40 passed, 0 failing
- [x] Capability lookup is case-insensitive and tolerates `EHG_Engineer` / `ehg-engineer` / `EHG Engineer` variants
- [x] Audit log line emitted exactly once per suppression decision; not emitted when nothing is suppressed
- [x] Per-payload `target_application` overrides venture-level target
- [x] Default behaviour preserved for unknown ventures (permissive)

## Risk / blast radius

- Single suppression decision in one well-tested function
- No risk keywords (no auth, schema, migration, feature)
- Permissive default for unknown targets means new ventures retain existing emission until explicitly added
- Drive-by fix to 4 pre-existing test failures only relaxed the assertion path (added `skipEnrichment: true`); none of those tests exercised enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)