### PR TITLE
feat(SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001): Stage 21 canonical artifact emission + entry-precondition + tests

### DIFF
--- a/database/migrations/20260504_backfill_privacypatrol_s21_visual_artifacts.sql
+++ b/database/migrations/20260504_backfill_privacypatrol_s21_visual_artifacts.sql
@@ -1,0 +1,165 @@
+-- =============================================================================
+-- Migration: Backfill PrivacyPatrol AI S21 visual artifacts
+-- SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001 (FR-6)
+-- Date: 2026-05-04
+--
+-- Purpose:
+--   Derive visual_device_screenshots + visual_social_graphics from the existing
+--   bundled launch_test_plan row for venture 08d20036-03c9-4a26-bbc5-f37a18dfdf23
+--   (PrivacyPatrol AI). Mark legacy row is_current=false with deprecated_by tag.
+--
+--   PrivacyPatrol AI's S21 launch_test_plan row was emitted on 2026-05-03 with
+--   wrong artifact_type and incomplete data. This backfill maps:
+--     launch_test_plan.device_screenshots[] → visual_device_screenshots
+--     launch_test_plan.social_graphics[]    → visual_social_graphics
+--     launch_test_plan.video_storyboard[]   → visual_social_graphics.video_storyboard
+--                                              (storyboard not yet a separate canonical type)
+--
+-- Idempotent:
+--   (a) Legacy row marked is_current=false after first run; WHERE clauses no-match on rerun
+--   (b) NOT EXISTS guards on the new INSERTs catch any partial-replay
+--
+-- Rollback (manual):
+--   UPDATE venture_artifacts SET is_current=false
+--   WHERE venture_id='08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+--     AND lifecycle_stage=21
+--     AND artifact_type IN ('visual_device_screenshots','visual_social_graphics')
+--     AND artifact_data->>'derived_from_artifact_id' IS NOT NULL;
+--   UPDATE venture_artifacts SET is_current=true,
+--     artifact_data = artifact_data - 'deprecated_by'
+--   WHERE venture_id='08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+--     AND lifecycle_stage=21
+--     AND artifact_type='launch_test_plan';
+-- =============================================================================
+
+BEGIN;
+
+-- 0. Lock legacy row to prevent concurrent worker writes during derivation.
+SELECT id, artifact_data
+FROM venture_artifacts
+WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+  AND lifecycle_stage = 21
+  AND artifact_type = 'launch_test_plan'
+  AND is_current = true
+FOR UPDATE;
+
+-- 1. Insert visual_device_screenshots — derived from launch_test_plan.device_screenshots[]
+INSERT INTO venture_artifacts (
+  venture_id, lifecycle_stage, artifact_type, is_current, source, artifact_data, created_at, updated_at
+)
+SELECT
+  va.venture_id,
+  21,
+  'visual_device_screenshots',
+  true,
+  'backfill_sd_leo_feat_stage_visual_assets_001',
+  jsonb_build_object(
+    'device_screenshots', COALESCE(va.artifact_data->'device_screenshots', '[]'::jsonb),
+    'total_screenshots', jsonb_array_length(COALESCE(va.artifact_data->'device_screenshots', '[]'::jsonb)),
+    'devices_covered', (
+      SELECT jsonb_agg(DISTINCT s->>'device')
+      FROM jsonb_array_elements(COALESCE(va.artifact_data->'device_screenshots', '[]'::jsonb)) s
+      WHERE s->>'device' IS NOT NULL
+    ),
+    'file_urls', '[]'::jsonb,  -- FR-2 will populate after Playwright integration
+    'rendering_status', 'specs_only',
+    'derived_from_artifact_id', va.id,
+    'derived_at', to_jsonb(NOW())
+  ),
+  NOW(), NOW()
+FROM venture_artifacts va
+WHERE va.venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+  AND va.lifecycle_stage = 21
+  AND va.artifact_type = 'launch_test_plan'
+  AND va.is_current = true
+  AND NOT EXISTS (
+    SELECT 1 FROM venture_artifacts va2
+    WHERE va2.venture_id = va.venture_id
+      AND va2.lifecycle_stage = 21
+      AND va2.artifact_type = 'visual_device_screenshots'
+      AND va2.is_current = true
+  );
+
+-- 2. Insert visual_social_graphics — derived from launch_test_plan.social_graphics[]
+--    + video_storyboard nested under metadata (no separate canonical type yet)
+INSERT INTO venture_artifacts (
+  venture_id, lifecycle_stage, artifact_type, is_current, source, artifact_data, created_at, updated_at
+)
+SELECT
+  va.venture_id,
+  21,
+  'visual_social_graphics',
+  true,
+  'backfill_sd_leo_feat_stage_visual_assets_001',
+  jsonb_build_object(
+    'social_graphics', COALESCE(va.artifact_data->'social_graphics', '[]'::jsonb),
+    'total_socials', jsonb_array_length(COALESCE(va.artifact_data->'social_graphics', '[]'::jsonb)),
+    'platforms_covered', (
+      SELECT jsonb_agg(DISTINCT s->>'platform')
+      FROM jsonb_array_elements(COALESCE(va.artifact_data->'social_graphics', '[]'::jsonb)) s
+      WHERE s->>'platform' IS NOT NULL
+    ),
+    'file_urls', '[]'::jsonb,  -- FR-2 will populate
+    'rendering_status', 'specs_only',
+    'video_storyboard', COALESCE(va.artifact_data->'video_storyboard', '[]'::jsonb),
+    'derived_from_artifact_id', va.id,
+    'derived_at', to_jsonb(NOW())
+  ),
+  NOW(), NOW()
+FROM venture_artifacts va
+WHERE va.venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+  AND va.lifecycle_stage = 21
+  AND va.artifact_type = 'launch_test_plan'
+  AND va.is_current = true
+  AND NOT EXISTS (
+    SELECT 1 FROM venture_artifacts va2
+    WHERE va2.venture_id = va.venture_id
+      AND va2.lifecycle_stage = 21
+      AND va2.artifact_type = 'visual_social_graphics'
+      AND va2.is_current = true
+  );
+
+-- 3. Mark legacy bundled launch_test_plan row as not-current; preserve for audit/rollback.
+UPDATE venture_artifacts
+SET is_current = false,
+    updated_at = NOW(),
+    artifact_data = jsonb_set(
+      COALESCE(artifact_data, '{}'::jsonb),
+      '{deprecated_by}',
+      to_jsonb('SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001'::text)
+    )
+WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+  AND lifecycle_stage = 21
+  AND artifact_type = 'launch_test_plan'
+  AND is_current = true;
+
+-- 4. Verification: fail the migration if backfill produces wrong counts.
+DO $$
+DECLARE
+  v_canonical_count int;
+  v_legacy_current_count int;
+BEGIN
+  SELECT count(*) INTO v_canonical_count FROM venture_artifacts
+  WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+    AND lifecycle_stage = 21
+    AND artifact_type IN ('visual_device_screenshots','visual_social_graphics')
+    AND is_current = true;
+
+  SELECT count(*) INTO v_legacy_current_count FROM venture_artifacts
+  WHERE venture_id = '08d20036-03c9-4a26-bbc5-f37a18dfdf23'
+    AND lifecycle_stage = 21
+    AND artifact_type = 'launch_test_plan'
+    AND is_current = true;
+
+  IF v_canonical_count <> 2 THEN
+    RAISE EXCEPTION 'S21 BACKFILL FAIL: expected 2 canonical rows for venture 08d20036-..., got %', v_canonical_count;
+  END IF;
+
+  IF v_legacy_current_count <> 0 THEN
+    RAISE EXCEPTION 'S21 BACKFILL FAIL: expected 0 legacy launch_test_plan rows with is_current=true, got %', v_legacy_current_count;
+  END IF;
+
+  RAISE NOTICE 'S21 BACKFILL VERIFIED: 2 canonical rows is_current=true, 0 legacy rows is_current=true.';
+END $$;
+
+COMMIT;

--- a/database/migrations/20260504_ensure_s21_lifecycle_stage_config.sql
+++ b/database/migrations/20260504_ensure_s21_lifecycle_stage_config.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- Migration: Ensure lifecycle_stage_config row for stage 21 has canonical
+--            required_artifacts populated and work_type='artifact_only'
+-- SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001 (FR-3 thin wiring)
+-- Date: 2026-05-04
+--
+-- Purpose:
+--   The fn_advance_venture_stage function shipped by S22 reads
+--   lifecycle_stage_config.required_artifacts to decide whether S21→S22 advance
+--   is permitted. This migration is DEFENSIVE — it ensures stage 21's config row
+--   has the correct canonical required_artifacts list and work_type. Per PLAN-DATABASE
+--   verification, this row may already be correct; the UPSERT is idempotent and safe
+--   to re-run.
+--
+-- Idempotent: INSERT ... ON CONFLICT (stage_number) DO UPDATE.
+--
+-- Rollback (manual):
+--   Restore prior required_artifacts list from
+--   `database/migrations/20260421_redesign_s18_s26_lifecycle_stage_config.sql`.
+-- =============================================================================
+
+BEGIN;
+
+INSERT INTO lifecycle_stage_config (
+  stage_number,
+  stage_name,
+  work_type,
+  required_artifacts
+) VALUES (
+  21,
+  'Visual Assets',
+  'artifact_only',
+  '["visual_device_screenshots", "visual_social_graphics"]'::jsonb
+)
+ON CONFLICT (stage_number) DO UPDATE SET
+  work_type = 'artifact_only',
+  required_artifacts =
+    CASE
+      WHEN lifecycle_stage_config.required_artifacts @> '["visual_device_screenshots"]'::jsonb
+        AND lifecycle_stage_config.required_artifacts @> '["visual_social_graphics"]'::jsonb
+      THEN lifecycle_stage_config.required_artifacts
+      ELSE '["visual_device_screenshots", "visual_social_graphics"]'::jsonb
+    END,
+  updated_at = NOW();
+
+-- Verification.
+DO $$
+DECLARE
+  v_required jsonb;
+  v_work_type text;
+BEGIN
+  SELECT required_artifacts, work_type INTO v_required, v_work_type
+  FROM lifecycle_stage_config WHERE stage_number = 21;
+
+  IF v_required IS NULL THEN
+    RAISE EXCEPTION 'S21 LIFECYCLE CONFIG FAIL: no row for stage_number=21 after upsert';
+  END IF;
+
+  IF v_work_type IS DISTINCT FROM 'artifact_only' THEN
+    RAISE EXCEPTION 'S21 LIFECYCLE CONFIG FAIL: work_type=% (expected artifact_only)', v_work_type;
+  END IF;
+
+  IF NOT (v_required @> '["visual_device_screenshots"]'::jsonb) THEN
+    RAISE EXCEPTION 'S21 LIFECYCLE CONFIG FAIL: required_artifacts missing visual_device_screenshots. Got: %', v_required::text;
+  END IF;
+
+  IF NOT (v_required @> '["visual_social_graphics"]'::jsonb) THEN
+    RAISE EXCEPTION 'S21 LIFECYCLE CONFIG FAIL: required_artifacts missing visual_social_graphics. Got: %', v_required::text;
+  END IF;
+
+  RAISE NOTICE 'S21 LIFECYCLE CONFIG OK: work_type=artifact_only, required_artifacts=%', v_required::text;
+END $$;
+
+COMMIT;

--- a/database/migrations/20260504_extend_venture_artifacts_visual_skipped.sql
+++ b/database/migrations/20260504_extend_venture_artifacts_visual_skipped.sql
@@ -1,0 +1,125 @@
+-- =============================================================================
+-- Migration: Extend venture_artifacts.artifact_type CHECK to accept
+--            visual_assets_skipped (FR-4 SKIP marker)
+-- SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001
+-- Date: 2026-05-04
+--
+-- Purpose:
+--   PLAN-DATABASE evaluation (row e2a33b6c-dfb1-496f-a04d-41a8406db63b) confirmed
+--   via INSERT-probe that 'visual_device_screenshots' and 'visual_social_graphics'
+--   are already accepted by the CHECK constraint (added by 20260421 migration), but
+--   'visual_assets_skipped' is REJECTED. The S21 worker FR-4 path emits this type
+--   when entry preconditions are missing; without this migration the worker would
+--   fail at runtime when it should be communicating a SKIP state.
+--
+-- PostgreSQL CHECK constraints cannot be ALTER-extended; must DROP+RECREATE with
+-- the FULL list verbatim from the most recent prior migration.
+-- Source: 20260421_expand_venture_artifacts_marketing_types.sql (lines 22-81).
+--
+-- Idempotent: DROP IF EXISTS + ADD CONSTRAINT. Re-run safe.
+--
+-- Rollback:
+--   Restore prior list from 20260421_expand_venture_artifacts_marketing_types.sql.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE venture_artifacts DROP CONSTRAINT IF EXISTS venture_artifacts_artifact_type_check;
+
+ALTER TABLE venture_artifacts ADD CONSTRAINT venture_artifacts_artifact_type_check
+CHECK (((artifact_type)::text = ANY (ARRAY[
+  -- Intake (Stage 0)
+  'intake_venture_analysis',
+  -- Truth (Stages 1-5)
+  'truth_idea_brief', 'truth_ai_critique', 'truth_validation_decision',
+  'truth_competitive_analysis', 'truth_financial_model',
+  'truth_problem_statement', 'truth_target_market_analysis', 'truth_value_proposition',
+  -- Engine (Stages 6-9)
+  'engine_risk_matrix', 'engine_pricing_model', 'engine_business_model_canvas',
+  'engine_exit_strategy', 'engine_risk_assessment', 'engine_revenue_model',
+  -- Identity (Stages 10-12)
+  'identity_persona_brand', 'identity_brand_guidelines', 'identity_naming_visual',
+  'identity_brand_name', 'identity_gtm_sales_strategy',
+  -- Blueprint (Stages 13-17)
+  'blueprint_product_roadmap', 'blueprint_technical_architecture', 'blueprint_data_model',
+  'blueprint_erd_diagram', 'blueprint_api_contract', 'blueprint_schema_spec',
+  'blueprint_risk_register', 'blueprint_user_story_pack', 'blueprint_wireframes',
+  'blueprint_financial_projection', 'blueprint_launch_readiness', 'blueprint_sprint_plan',
+  'blueprint_promotion_gate', 'blueprint_project_plan', 'blueprint_review_summary',
+  -- Build (Stages 18-22) — existing
+  'build_system_prompt', 'build_cicd_config', 'build_security_audit', 'build_mvp_build',
+  'build_test_coverage_report',
+  -- Marketing Copy Studio (Stage 18)
+  'marketing_tagline', 'marketing_app_store_desc', 'marketing_landing_hero',
+  'marketing_email_welcome', 'marketing_email_onboarding', 'marketing_email_reengagement',
+  'marketing_social_posts', 'marketing_seo_meta', 'marketing_blog_draft',
+  -- Code Quality Gate (Stage 20)
+  'code_quality_report',
+  -- Visual Assets (Stage 21)
+  'visual_device_screenshots', 'visual_social_graphics',
+  -- NEW for SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001 FR-4 SKIP marker
+  'visual_assets_skipped',
+  -- Distribution Setup (Stage 22)
+  'distribution_channel_config', 'distribution_ad_copy',
+  -- Launch (Stages 23-26) — existing + new
+  'launch_test_plan', 'launch_uat_report', 'launch_deployment_runbook',
+  'launch_marketing_checklist', 'launch_analytics_dashboard', 'launch_health_scoring',
+  'launch_churn_triggers', 'launch_retention_playbook', 'launch_optimization_roadmap',
+  'launch_assumptions_vs_reality', 'launch_launch_metrics', 'launch_user_feedback_summary',
+  'launch_production_app',
+  'launch_readiness_checklist',
+  -- Growth Playbook (Stage 26)
+  'growth_playbook',
+  -- Cross-cutting / System
+  'system_devils_advocate_review',
+  -- Gate & Analysis artifacts
+  'value_multiplier_assessment',
+  'economic_lens',
+  'lifecycle_sd_bridge',
+  'post_lifecycle_decision',
+  -- Stitch integration (legacy, preserved)
+  'stitch_project', 'stitch_curation', 'stitch_budget',
+  -- S17 Design stage legacy artifacts (in use in production data)
+  's17_archetypes', 's17_session_state', 's17_strategy_recommendation', 's17_variant_wip',
+  'stage_17_approved_desktop', 'wireframe_screens',
+  -- Dynamic stage analysis artifacts
+  'stage_0_analysis', 'stage_1_analysis', 'stage_2_analysis', 'stage_3_analysis',
+  'stage_4_analysis', 'stage_5_analysis', 'stage_6_analysis', 'stage_7_analysis',
+  'stage_8_analysis', 'stage_9_analysis', 'stage_10_analysis', 'stage_11_analysis',
+  'stage_12_analysis', 'stage_13_analysis', 'stage_14_analysis', 'stage_15_analysis',
+  'stage_16_analysis', 'stage_17_analysis', 'stage_18_analysis', 'stage_19_analysis',
+  'stage_20_analysis', 'stage_21_analysis', 'stage_22_analysis', 'stage_23_analysis',
+  'stage_24_analysis', 'stage_25_analysis', 'stage_26_analysis'
+]::text[])));
+
+-- Verification.
+DO $$
+DECLARE
+  v_check_def text;
+BEGIN
+  SELECT pg_get_constraintdef(oid) INTO v_check_def
+  FROM pg_constraint
+  WHERE conrelid = 'venture_artifacts'::regclass
+    AND conname = 'venture_artifacts_artifact_type_check';
+
+  IF v_check_def IS NULL THEN
+    RAISE EXCEPTION 'CHECK CONSTRAINT FAIL: venture_artifacts_artifact_type_check missing after recreate';
+  END IF;
+
+  IF v_check_def NOT LIKE '%visual_assets_skipped%' THEN
+    RAISE EXCEPTION 'CHECK CONSTRAINT FAIL: visual_assets_skipped not present in recreated CHECK. Got: %', v_check_def;
+  END IF;
+
+  -- Sanity: ensure pre-existing types still present (no regression).
+  IF v_check_def NOT LIKE '%visual_device_screenshots%' THEN
+    RAISE EXCEPTION 'CHECK CONSTRAINT REGRESSION: visual_device_screenshots removed during recreate';
+  END IF;
+
+  IF v_check_def NOT LIKE '%distribution_channel_config%' THEN
+    RAISE EXCEPTION 'CHECK CONSTRAINT REGRESSION: distribution_channel_config (S22) removed during recreate';
+  END IF;
+
+  RAISE NOTICE 'CHECK CONSTRAINT OK: visual_assets_skipped added; pre-existing types preserved';
+END $$;
+
+COMMIT;

--- a/database/migrations/20260504_seed_leo_s21_required_artifacts_gate_flag.sql
+++ b/database/migrations/20260504_seed_leo_s21_required_artifacts_gate_flag.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- Migration: Seed LEO_S21_REQUIRED_ARTIFACTS_GATE feature flag (default OFF)
+-- SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001 (FR-3 thin wiring)
+-- Date: 2026-05-04
+--
+-- Purpose:
+--   When OFF (default): worker dual-emits (canonical pair + legacy launch_test_plan).
+--                       fn_advance_venture_stage uses dual-read with legacy fallback.
+--   When ON:           worker emits ONLY canonical pair (visual_device_screenshots
+--                      + visual_social_graphics). fn_advance_venture_stage requires
+--                      canonical artifacts before S21→S22 advance.
+--
+-- This is THIN WIRING per PLAN-VALIDATION C1 — the gate logic itself is shipped
+-- by SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001's fn_advance_venture_stage migration
+-- (database/migrations/20260504_fn_advance_venture_stage_canonical_artifact_source.sql).
+-- That function reads lifecycle_stage_config.required_artifacts directly when canonical
+-- entries are populated. S21 just needs to seed the opt-in flag and confirm the config.
+--
+-- The flag is FLIPPED MANUALLY by the EXEC owner ≥1 day after worker code (FR-1) is
+-- deployed and dual-emit has produced canonical rows for at least 1 production venture.
+-- Per PLAN-VALIDATION C4 cutoff.
+--
+-- Idempotent: ON CONFLICT (flag_key) DO UPDATE re-applies on re-run.
+--
+-- Rollback:
+--   UPDATE leo_feature_flags
+--   SET is_enabled = false, lifecycle_state = 'disabled'
+--   WHERE flag_key = 'LEO_S21_REQUIRED_ARTIFACTS_GATE';
+-- =============================================================================
+
+BEGIN;
+
+INSERT INTO leo_feature_flags (
+  flag_key,
+  display_name,
+  description,
+  is_enabled,
+  risk_tier,
+  lifecycle_state,
+  is_temporary,
+  expiry_at,
+  owner_type,
+  owner_id
+) VALUES (
+  'LEO_S21_REQUIRED_ARTIFACTS_GATE',
+  'S21 Visual Assets Required-Artifacts Gate',
+  'When ON: fn_advance_venture_stage requires canonical visual_device_screenshots + visual_social_graphics artifacts before S21→S22 advance. Worker emits ONLY canonical pair. When OFF: dual-read with legacy launch_test_plan fallback; worker dual-emits both canonical + legacy. Thin per-stage wiring leveraging the shared advance-gate mechanism shipped by SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001 (PR #3510). SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001.',
+  false,
+  'high',
+  'enabled',
+  true,
+  NOW() + INTERVAL '90 days',
+  'sd',
+  'SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001'
+)
+ON CONFLICT (flag_key) DO UPDATE SET
+  description = EXCLUDED.description,
+  risk_tier = EXCLUDED.risk_tier,
+  owner_type = EXCLUDED.owner_type,
+  owner_id = EXCLUDED.owner_id,
+  updated_at = NOW();
+
+-- Verification.
+DO $$
+DECLARE
+  v_exists boolean;
+  v_default_off boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM leo_feature_flags WHERE flag_key = 'LEO_S21_REQUIRED_ARTIFACTS_GATE'
+  ) INTO v_exists;
+
+  IF NOT v_exists THEN
+    RAISE EXCEPTION 'FEATURE FLAG SEED FAIL: LEO_S21_REQUIRED_ARTIFACTS_GATE row not present after INSERT';
+  END IF;
+
+  -- Default must be OFF — accidental ON would block all in-flight ventures at S21.
+  SELECT (is_enabled = false) INTO v_default_off
+  FROM leo_feature_flags WHERE flag_key = 'LEO_S21_REQUIRED_ARTIFACTS_GATE';
+
+  IF NOT v_default_off THEN
+    RAISE WARNING 'LEO_S21_REQUIRED_ARTIFACTS_GATE is_enabled=true on first seed. This MUST be OFF until worker deploy + 1d soak. Re-run will not reset is_enabled (ON CONFLICT preserves existing value).';
+  END IF;
+
+  RAISE NOTICE 'FEATURE FLAG SEEDED: LEO_S21_REQUIRED_ARTIFACTS_GATE present, default-off=%', v_default_off;
+END $$;
+
+COMMIT;

--- a/lib/eva/stage-templates/analysis-steps/stage-21-acquirability.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-acquirability.js
@@ -1,4 +1,16 @@
 /**
+ * DISPOSITION (FR-5, SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001):
+ *   This file's filename (stage-21-acquirability.js) sits in the stage-21 dispatch slot
+ *   per index.js line 85, but its @module path, header text, and export name
+ *   (analyzeStage20Acquirability) describe Stage-20 acquirability evaluation. This is
+ *   the codebase's intentional pattern: file_name = dispatch_stage_N, function_name =
+ *   analyzed_data_stage_N-1. The index.js re-export aliases analyzeStage20Acquirability
+ *   AS analyzeStage21Acquirability (line 64). Renaming the file or function is deferred
+ *   to a follow-up SD because consumers wire to current paths and a coordinated rename
+ *   has cross-file blast radius (parallel pattern in stage-22-acquirability.js, which
+ *   was kept by SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001 with an identical disposition
+ *   comment). KEEP — documentation-only addition; no behavioural change.
+ *
  * Stage 20 Acquirability Delta - Quality Assurance
  * Phase: THE BUILD LOOP (Stages 17-22)
  * Part of SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-C

--- a/lib/eva/stage-templates/analysis-steps/stage-21-quality-assurance.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-quality-assurance.js
@@ -1,4 +1,13 @@
 /**
+ * DISPOSITION (FR-5, SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001):
+ *   This file's filename (stage-21-quality-assurance.js) sits in the stage-21 dispatch
+ *   slot per index.js line 122, but its @module path and header describe Stage-20 QA
+ *   analysis. The exported function `analyzeStage21` is consumed directly by stage-21.js
+ *   (which imports it without the index.js re-export aliasing layer). KEEP — same
+ *   intentional file_name=dispatch_N / analyzed_data=N-1 pattern as stage-21-acquirability.js
+ *   and stage-22-acquirability.js. Documentation-only addition; no behavioural change.
+ *   Function/file rename deferred to follow-up SD per cross-file blast radius.
+ *
  * Stage 20 Analysis Step - Quality Assurance
  * Phase: THE BUILD LOOP (Stages 17-22)
  * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -1,11 +1,22 @@
 /**
  * Stage 21 Analysis Step — Visual Assets
  * Phase: BUILD & MARKET (Stages 18-22)
- * SD: SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-D
+ * SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001 (refactor of SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-D)
  *
  * Generates visual marketing asset specifications from S17 approved designs
  * and S11 brand identity. Produces device-framed screenshot specs and
  * social media graphic specifications per platform.
+ *
+ * FR-1: emits two canonical venture_artifacts rows (visual_device_screenshots
+ *       + visual_social_graphics) instead of one bundled launch_test_plan.
+ *       Dual-emits the legacy launch_test_plan row while
+ *       LEO_S21_REQUIRED_ARTIFACTS_GATE=false (backward compat).
+ * FR-2: Real PNG/SVG file rendering via Playwright deferred to follow-up phase.
+ *       Current emission contains structured specs (descriptions, dimensions,
+ *       headlines) usable by downstream stages even before real files land.
+ * FR-4: refuses to run when S11 visual-identity, S17 archetypes, or S19
+ *       deployment_url upstream preconditions absent; emits visual_assets_skipped
+ *       artifact noting which precondition is missing.
  *
  * @module lib/eva/stage-templates/analysis-steps/stage-21-visual-assets
  */
@@ -14,15 +25,25 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 
 const DEVICE_FRAMES = ['iphone_15', 'macbook_pro', 'ipad', 'android_phone'];
+
+// PLAN-DESIGN cond #4: 4 mandatory + 1 optional platform.
 const SOCIAL_SIZES = [
-  { platform: 'instagram', format: 'square', width: 1080, height: 1080 },
-  { platform: 'twitter', format: 'banner', width: 1500, height: 500 },
-  { platform: 'facebook', format: 'cover', width: 1200, height: 630 },
-  { platform: 'linkedin', format: 'post', width: 1200, height: 627 },
+  { platform: 'instagram', format: 'square',   width: 1080, height: 1080, required: true },
+  { platform: 'instagram', format: 'portrait', width: 1080, height: 1350, required: true, platform_label: 'Instagram (4:5)' },
+  { platform: 'twitter',   format: 'banner',   width: 1500, height: 500,  required: true, platform_label: 'X' },
+  { platform: 'facebook',  format: 'cover',    width: 820,  height: 312,  required: true },
+  { platform: 'opengraph', format: 'card',     width: 1200, height: 630,  required: false },
 ];
 
-// 2026-04-22: LLM generates asset specifications (descriptions, alt text, recommended scenes)
-// Actual image generation deferred to Playwright/CDP integration follow-up SD
+const REQUIRED_UPSTREAM = [
+  { artifact_type: 'visual_color_palette', source_stage: 11, param_key: 'stage11ColorData' },
+  { artifact_type: 'visual_typography',    source_stage: 11, param_key: 'stage11TypographyData' },
+  { artifact_type: 'visual_logo_spec',     source_stage: 11, param_key: 'stage11LogoData' },
+  { artifact_type: 's17_archetypes',       source_stage: 17, param_key: 'stage17Data' },
+];
+
+const FEATURE_FLAG_KEY = 'LEO_S21_REQUIRED_ARTIFACTS_GATE';
+
 const SYSTEM_PROMPT = `You are EVA's Visual Asset Planner. Generate specifications for marketing visual assets based on the venture's approved designs and brand identity.
 
 Output valid JSON:
@@ -37,8 +58,8 @@ Output valid JSON:
   ],
   "social_graphics": [
     {
-      "platform": "instagram|twitter|facebook|linkedin",
-      "format": "square|banner|cover|post",
+      "platform": "instagram|twitter|facebook|opengraph",
+      "format": "square|portrait|banner|cover|card",
       "width": 1080,
       "height": 1080,
       "headline": "Text overlay for the graphic",
@@ -57,22 +78,237 @@ Output valid JSON:
 }
 
 Rules:
-- Generate at least 3 device screenshots across different devices
-- Generate at least 4 social graphics (one per platform)
+- Generate at least 2 device screenshots (iphone_15 + macbook_pro minimum)
+- Generate at least 4 mandatory social graphics: Instagram square, Instagram portrait, Twitter/X banner, Facebook cover; OpenGraph 1200x630 is recommended
 - Generate 3-5 video storyboard scenes
-- Use brand colors and naming from identity data
-- Screenshots should show the most compelling features
+- Use brand colors and typography from S11 visual-identity context
+- Screenshots should show the most compelling features rendered against actual deployed app (FR-2 follow-up phase will use Playwright)
 - Social graphics should be platform-appropriate in tone`;
 
+/**
+ * Pure helper. Returns {ok, missing[]} where missing names which upstream
+ * artifact_type or venture_resource is absent. Does not call the database.
+ *
+ * Checks 5 things: 3 S11 visual-identity artifacts, S17 archetypes, and
+ * venture_resources.deployment_url (FR-4 spec).
+ */
+export function validateEntryPreconditions(params) {
+  const missing = [];
+  for (const req of REQUIRED_UPSTREAM) {
+    const data = params[req.param_key];
+    const present = data && typeof data === 'object' && Object.keys(data).length > 0;
+    if (!present) missing.push({ artifact_type: req.artifact_type, source_stage: req.source_stage });
+  }
+  // Special-case: deployment_url comes from venture_resources, not venture_artifacts.
+  // Caller passes it as deploymentUrl. Per FR-4 spec, it's required.
+  if (!params.deploymentUrl || typeof params.deploymentUrl !== 'string' || params.deploymentUrl.trim().length === 0) {
+    missing.push({ artifact_type: 'venture_resources.deployment_url', source_stage: 19 });
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Pure helper. Validates that LLM output covers required platforms and devices.
+ * Throws a descriptive error on failure (caller catches and converts to fallback).
+ */
+export function validatePlatformCoverage(result) {
+  if (!result || typeof result !== 'object') {
+    throw new Error('validatePlatformCoverage: result is not an object');
+  }
+  const screenshots = Array.isArray(result.device_screenshots) ? result.device_screenshots : [];
+  if (screenshots.length < 2) {
+    throw new Error(`validatePlatformCoverage: device_screenshots count ${screenshots.length} below minimum 2`);
+  }
+  const socials = Array.isArray(result.social_graphics) ? result.social_graphics : [];
+  const requiredKeys = SOCIAL_SIZES.filter(s => s.required).map(s => `${s.platform}:${s.format}`);
+  const seenKeys = new Set(socials.map(s => `${s.platform}:${s.format}`));
+  for (const key of requiredKeys) {
+    if (!seenKeys.has(key)) {
+      throw new Error(`validatePlatformCoverage: missing required social platform "${key}"`);
+    }
+  }
+  return true;
+}
+
+/**
+ * Pure helper. Splits the LLM result object into the two canonical-pair payloads
+ * (visual_device_screenshots + visual_social_graphics). Video storyboard data
+ * (if any) attaches to social_graphics under metadata.video_storyboard since the
+ * spec doesn't yet declare visual_video_storyboards as a separate canonical type
+ * (PLAN out-of-scope decision; deferred to follow-up SD).
+ */
+export function splitArtifacts(result) {
+  const screenshotData = {
+    device_screenshots: Array.isArray(result.device_screenshots) ? result.device_screenshots : [],
+    total_screenshots: (result.device_screenshots || []).length,
+    devices_covered: [...new Set((result.device_screenshots || []).map(s => s.device).filter(Boolean))],
+    file_urls: [], // FR-2 will populate this with Playwright-generated PNGs
+    rendering_status: 'specs_only',
+  };
+  const socialData = {
+    social_graphics: Array.isArray(result.social_graphics) ? result.social_graphics : [],
+    total_socials: (result.social_graphics || []).length,
+    platforms_covered: [...new Set((result.social_graphics || []).map(s => s.platform).filter(Boolean))],
+    file_urls: [], // FR-2 will populate
+    rendering_status: 'specs_only',
+    video_storyboard: result.video_storyboard || [],
+  };
+  return { screenshotData, socialData };
+}
+
+async function readFeatureFlag(supabase, logger) {
+  if (!supabase) return false;
+  try {
+    const { data, error } = await supabase
+      .from('leo_feature_flags')
+      .select('is_enabled')
+      .eq('flag_key', FEATURE_FLAG_KEY)
+      .maybeSingle();
+    if (error) {
+      logger?.warn?.(`[S21-VisualAssets] feature flag read error, defaulting OFF: ${error.message}`);
+      return false;
+    }
+    return Boolean(data?.is_enabled);
+  } catch (err) {
+    logger?.warn?.(`[S21-VisualAssets] feature flag read threw, defaulting OFF: ${err.message}`);
+    return false;
+  }
+}
+
+async function persistCanonicalPair(supabase, ventureId, screenshotData, socialData, fullResult, options) {
+  if (!supabase || !ventureId) {
+    options.logger?.warn?.('[S21-VisualAssets] persistCanonicalPair skipped: no supabase or ventureId');
+    return { persisted: false, reason: 'no_supabase_or_ventureId' };
+  }
+
+  const writes = [
+    { artifact_type: 'visual_device_screenshots', artifact_data: screenshotData },
+    { artifact_type: 'visual_social_graphics',    artifact_data: socialData },
+  ];
+
+  // Dual-emit during rollout while flag OFF (backward-compat for any consumer
+  // still reading launch_test_plan from S21). Single-emit canonical only when ON.
+  if (options.dualEmit) {
+    writes.push({
+      artifact_type: 'launch_test_plan',
+      artifact_data: fullResult,
+    });
+  }
+
+  const persisted = [];
+  for (const w of writes) {
+    const { error: e1 } = await supabase
+      .from('venture_artifacts')
+      .update({ is_current: false, updated_at: new Date().toISOString() })
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 21)
+      .eq('artifact_type', w.artifact_type)
+      .eq('is_current', true);
+    if (e1) {
+      options.logger?.warn?.(`[S21-VisualAssets] mark-stale error on ${w.artifact_type}: ${e1.message}`);
+    }
+
+    const { error: e2 } = await supabase
+      .from('venture_artifacts')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: 21,
+        artifact_type: w.artifact_type,
+        is_current: true,
+        source: 'worker_sd_leo_feat_stage_visual_assets_001',
+        artifact_data: w.artifact_data,
+      });
+    if (e2) {
+      options.logger?.warn?.(`[S21-VisualAssets] insert error on ${w.artifact_type}: ${e2.message}`);
+    } else {
+      persisted.push(w.artifact_type);
+    }
+  }
+  return { persisted: persisted.length > 0, types: persisted };
+}
+
+async function persistSkipMarker(supabase, ventureId, missing, logger) {
+  if (!supabase || !ventureId) return { persisted: false };
+  // Map missing artifact_type to a canonical skip_reason enum.
+  // Per PRD AC-4: NO_DEPLOYMENT_URL | NO_S11_VISUAL_IDENTITY | NO_S17_APPROVED_DESIGNS
+  let skipReason = 'NO_PRECONDITIONS';
+  if (missing.some(m => m.artifact_type === 'venture_resources.deployment_url')) {
+    skipReason = 'NO_DEPLOYMENT_URL';
+  } else if (missing.some(m => m.source_stage === 17)) {
+    skipReason = 'NO_S17_APPROVED_DESIGNS';
+  } else if (missing.some(m => m.source_stage === 11)) {
+    skipReason = 'NO_S11_VISUAL_IDENTITY';
+  }
+
+  try {
+    const { error } = await supabase
+      .from('venture_artifacts')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: 21,
+        artifact_type: 'visual_assets_skipped',
+        is_current: true,
+        source: 'worker_sd_leo_feat_stage_visual_assets_001',
+        artifact_data: {
+          skip_reason: skipReason,
+          missing_preconditions: missing.map(m => m.artifact_type),
+          attempted_at: new Date().toISOString(),
+          required_upstream: REQUIRED_UPSTREAM,
+        },
+      });
+    if (error) {
+      logger?.warn?.(`[S21-VisualAssets] SKIP marker persist error: ${error.message}`);
+      return { persisted: false, error: error.message };
+    }
+    return { persisted: true, skip_reason: skipReason };
+  } catch (err) {
+    logger?.warn?.(`[S21-VisualAssets] SKIP marker persist threw: ${err.message}`);
+    return { persisted: false, error: err.message };
+  }
+}
+
 export async function analyzeStage21VisualAssets(params) {
-  const { stage17Data, stage11Data, stage10Data, ventureName, logger = console } = params;
+  const {
+    stage17Data, stage11Data, stage10Data,
+    stage11ColorData, stage11TypographyData, stage11LogoData,
+    deploymentUrl,
+    ventureName, ventureId, supabase,
+    logger = console,
+  } = params;
 
   logger.info?.(`[S21-VisualAssets] Generating visual asset specs for ${ventureName || 'unknown'}`);
 
+  // FR-4: entry-precondition check. Refuse to fabricate visual assets without source material.
+  const preflight = validateEntryPreconditions(params);
+  if (!preflight.ok) {
+    const skipResult = await persistSkipMarker(supabase, ventureId, preflight.missing, logger);
+    logger.warn?.(
+      `[S21-VisualAssets] SKIP — missing preconditions (skip_reason=${skipResult.skip_reason || 'unknown'}): ${preflight.missing.map(m => m.artifact_type).join(', ')}`
+    );
+    return {
+      _skip: true,
+      skip_reason: skipResult.skip_reason || 'NO_PRECONDITIONS',
+      precondition_missing: preflight.missing,
+      device_screenshots: [],
+      social_graphics: [],
+      video_storyboard: [],
+      total_assets: 0,
+      screenshot_count: 0,
+      social_count: 0,
+      storyboard_count: 0,
+      usage: {},
+    };
+  }
+
+  const flagEnabled = await readFeatureFlag(supabase, logger);
+
   const context = {
     designs: stage17Data || {},
-    brand: stage11Data || {},
+    brand_palette: stage11ColorData || {},
+    brand_typography: stage11TypographyData || {},
+    brand_logo: stage11LogoData || {},
     persona: stage10Data || {},
+    deployment_url: deploymentUrl,
     venture_name: ventureName,
   };
 
@@ -86,9 +322,29 @@ export async function analyzeStage21VisualAssets(params) {
     usage = extractUsage(response) || {};
     result = parsed?.device_screenshots ? parsed : buildFallback(ventureName);
   } catch (err) {
-    logger.warn('[S21-VisualAssets] LLM error, using fallback:', err.message);
+    logger.warn?.('[S21-VisualAssets] LLM error, using fallback:', err.message);
     result = buildFallback(ventureName);
   }
+
+  // Validate platform coverage; if it fails, fall back to deterministic specs.
+  try {
+    validatePlatformCoverage(result);
+  } catch (err) {
+    logger.warn?.(`[S21-VisualAssets] LLM output failed platform coverage (${err.message}); using fallback`);
+    result = buildFallback(ventureName);
+  }
+
+  const { screenshotData, socialData } = splitArtifacts(result);
+
+  // Dual-emit when flag OFF (rollout). Single-emit when flag ON (post-rollout).
+  await persistCanonicalPair(
+    supabase,
+    ventureId,
+    screenshotData,
+    socialData,
+    result,
+    { dualEmit: !flagEnabled, logger }
+  );
 
   return {
     ...result,
@@ -99,17 +355,30 @@ export async function analyzeStage21VisualAssets(params) {
     screenshot_count: result.device_screenshots?.length || 0,
     social_count: result.social_graphics?.length || 0,
     storyboard_count: result.video_storyboard?.length || 0,
+    canonical_emission: {
+      flag_enabled: flagEnabled,
+      dual_emit: !flagEnabled,
+      types_emitted: flagEnabled
+        ? ['visual_device_screenshots', 'visual_social_graphics']
+        : ['visual_device_screenshots', 'visual_social_graphics', 'launch_test_plan'],
+    },
     usage,
   };
 }
 
 function buildFallback(ventureName) {
   return {
-    device_screenshots: DEVICE_FRAMES.slice(0, 3).map(device => ({
+    device_screenshots: DEVICE_FRAMES.slice(0, 2).map(device => ({
       device, scene: `${ventureName} main dashboard view`, alt_text: `${ventureName} on ${device}`, key_features_visible: ['main feature'],
     })),
-    social_graphics: SOCIAL_SIZES.map(s => ({
-      ...s, headline: `Introducing ${ventureName}`, description: `Launch graphic for ${s.platform}`, brand_colors_used: true,
+    social_graphics: SOCIAL_SIZES.filter(s => s.required).map(s => ({
+      platform: s.platform,
+      format: s.format,
+      width: s.width,
+      height: s.height,
+      headline: `Introducing ${ventureName}`,
+      description: `Launch graphic for ${s.platform} ${s.format}`,
+      brand_colors_used: true,
     })),
     video_storyboard: [
       { scene_number: 1, duration_seconds: 5, description: 'Problem statement hook', shot_type: 'wide' },
@@ -119,4 +388,4 @@ function buildFallback(ventureName) {
   };
 }
 
-export { DEVICE_FRAMES, SOCIAL_SIZES };
+export { DEVICE_FRAMES, SOCIAL_SIZES, REQUIRED_UPSTREAM, FEATURE_FLAG_KEY };

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-21-visual-assets.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-21-visual-assets.test.js
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for Stage 21 Analysis Step — Visual Assets
+ * SD: SD-LEO-FEAT-STAGE-VISUAL-ASSETS-001
+ *
+ * Covers:
+ *   FR-1 split + dual-emit (flag OFF emits 3 incl. legacy launch_test_plan,
+ *        flag ON emits 2 canonical only)
+ *   FR-4 entry-precondition refusal + skip marker artifact (3 skip_reasons via it.each)
+ *   Platform coverage validation (validatePlatformCoverage)
+ *   Import canary — guards against vi.mock-masks-broken-import per
+ *     reference_vi_mock_masks_broken_import memory
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-21-visual-assets.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LLM client BEFORE importing the module under test.
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import {
+  analyzeStage21VisualAssets,
+  validateEntryPreconditions,
+  validatePlatformCoverage,
+  splitArtifacts,
+  DEVICE_FRAMES,
+  SOCIAL_SIZES,
+  REQUIRED_UPSTREAM,
+  FEATURE_FLAG_KEY,
+} from '../../../../../lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+// Helper — full happy-path LLM response (canonical 2 device + 4 social).
+function makeLLMResponse(overrides = {}) {
+  const device_screenshots = overrides.device_screenshots || [
+    { device: 'iphone_15', scene: 'home', alt_text: 'app on iphone', key_features_visible: ['nav'] },
+    { device: 'macbook_pro', scene: 'dashboard', alt_text: 'app on mac', key_features_visible: ['chart'] },
+  ];
+  const social_graphics = overrides.social_graphics || [
+    { platform: 'instagram', format: 'square', width: 1080, height: 1080, headline: 'h', description: 'd', brand_colors_used: true },
+    { platform: 'instagram', format: 'portrait', width: 1080, height: 1350, headline: 'h', description: 'd', brand_colors_used: true },
+    { platform: 'twitter', format: 'banner', width: 1500, height: 500, headline: 'h', description: 'd', brand_colors_used: true },
+    { platform: 'facebook', format: 'cover', width: 820, height: 312, headline: 'h', description: 'd', brand_colors_used: true },
+  ];
+  const video_storyboard = overrides.video_storyboard || [
+    { scene_number: 1, duration_seconds: 5, description: 'hook', shot_type: 'wide' },
+  ];
+  return JSON.stringify({ device_screenshots, social_graphics, video_storyboard });
+}
+
+function setupMockLLM(response) {
+  const mockComplete = vi.fn().mockResolvedValue(response);
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+// Factory — fake supabase that records all writes.
+function makeFakeSupabase({ flagEnabled = false } = {}) {
+  const inserted = [];
+  const updated = [];
+  const sb = {
+    from(table) {
+      const ctx = { table, filters: {} };
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { ctx.filters[col] = val; return builder; },
+        maybeSingle() {
+          if (table === 'leo_feature_flags' && ctx.filters.flag_key === FEATURE_FLAG_KEY) {
+            return Promise.resolve({ data: { is_enabled: flagEnabled }, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(payload) {
+          inserted.push({ table, payload });
+          return Promise.resolve({ data: payload, error: null });
+        },
+      };
+      builder.update = (payload) => {
+        const rec = { op: 'update', table, payload, filters: {} };
+        updated.push(rec);
+        const eqChain = {
+          eq(col, val) { rec.filters[col] = val; return eqChain; },
+          then(resolve) { resolve({ data: null, error: null }); return Promise.resolve({ data: null, error: null }); },
+        };
+        return eqChain;
+      };
+      return builder;
+    },
+  };
+  return { sb, inserted, updated };
+}
+
+const VALID_UPSTREAM = {
+  stage11ColorData: { palette: ['#fff', '#000'] },
+  stage11TypographyData: { heading: 'Inter', body: 'Inter' },
+  stage11LogoData: { primaryColor: '#0a0a0a', svgPrompt: 'lock' },
+  stage17Data: { archetypes: ['hero', 'feature_grid'] },
+  deploymentUrl: 'https://example.app/',
+};
+
+describe('stage-21-visual-assets — pure helpers (FR-1/FR-4)', () => {
+  describe('validateEntryPreconditions (FR-4)', () => {
+    it('passes when all 4 upstream artifacts + deployment_url present', () => {
+      const result = validateEntryPreconditions(VALID_UPSTREAM);
+      expect(result.ok).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it.each(REQUIRED_UPSTREAM)('fails when $artifact_type missing', (req) => {
+      const params = { ...VALID_UPSTREAM, [req.param_key]: null };
+      const result = validateEntryPreconditions(params);
+      expect(result.ok).toBe(false);
+      expect(result.missing).toContainEqual({ artifact_type: req.artifact_type, source_stage: req.source_stage });
+    });
+
+    it('fails when deploymentUrl missing — emits venture_resources.deployment_url in missing list', () => {
+      const params = { ...VALID_UPSTREAM, deploymentUrl: null };
+      const result = validateEntryPreconditions(params);
+      expect(result.ok).toBe(false);
+      expect(result.missing).toContainEqual({ artifact_type: 'venture_resources.deployment_url', source_stage: 19 });
+    });
+
+    it('treats empty-object data as missing', () => {
+      const result = validateEntryPreconditions({ ...VALID_UPSTREAM, stage11ColorData: {} });
+      expect(result.ok).toBe(false);
+      expect(result.missing[0].artifact_type).toBe('visual_color_palette');
+    });
+
+    it('treats empty-string deploymentUrl as missing', () => {
+      const result = validateEntryPreconditions({ ...VALID_UPSTREAM, deploymentUrl: '   ' });
+      expect(result.ok).toBe(false);
+      expect(result.missing.some(m => m.artifact_type === 'venture_resources.deployment_url')).toBe(true);
+    });
+  });
+
+  describe('validatePlatformCoverage', () => {
+    it('passes happy path (4 required socials + 2 devices)', () => {
+      const result = JSON.parse(makeLLMResponse());
+      expect(() => validatePlatformCoverage(result)).not.toThrow();
+    });
+
+    it('throws on fewer than 2 device screenshots', () => {
+      const result = JSON.parse(makeLLMResponse({ device_screenshots: [{ device: 'iphone_15', scene: 's', alt_text: 'a', key_features_visible: [] }] }));
+      expect(() => validatePlatformCoverage(result)).toThrow(/device_screenshots count 1 below minimum 2/);
+    });
+
+    it('throws when any required social platform missing', () => {
+      const result = JSON.parse(makeLLMResponse({
+        social_graphics: [
+          { platform: 'instagram', format: 'square', width: 1080, height: 1080 },
+          { platform: 'instagram', format: 'portrait', width: 1080, height: 1350 },
+          { platform: 'twitter', format: 'banner', width: 1500, height: 500 },
+          // Missing facebook:cover
+        ],
+      }));
+      expect(() => validatePlatformCoverage(result)).toThrow(/missing required social platform "facebook:cover"/);
+    });
+  });
+
+  describe('splitArtifacts', () => {
+    it('splits LLM result into screenshotData + socialData with file_urls=[] (FR-2 deferred)', () => {
+      const result = JSON.parse(makeLLMResponse());
+      const { screenshotData, socialData } = splitArtifacts(result);
+      expect(screenshotData.device_screenshots.length).toBe(2);
+      expect(screenshotData.total_screenshots).toBe(2);
+      expect(screenshotData.devices_covered).toEqual(expect.arrayContaining(['iphone_15', 'macbook_pro']));
+      expect(screenshotData.file_urls).toEqual([]);
+      expect(screenshotData.rendering_status).toBe('specs_only');
+      expect(socialData.social_graphics.length).toBe(4);
+      expect(socialData.platforms_covered).toEqual(expect.arrayContaining(['instagram', 'twitter', 'facebook']));
+      expect(socialData.video_storyboard.length).toBe(1);
+    });
+
+    it('handles missing arrays gracefully', () => {
+      const { screenshotData, socialData } = splitArtifacts({});
+      expect(screenshotData.device_screenshots).toEqual([]);
+      expect(screenshotData.total_screenshots).toBe(0);
+      expect(socialData.social_graphics).toEqual([]);
+      expect(socialData.video_storyboard).toEqual([]);
+    });
+  });
+});
+
+describe('stage-21-visual-assets — orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['NO_DEPLOYMENT_URL',         { deploymentUrl: null },         'venture_resources.deployment_url'],
+    ['NO_S11_VISUAL_IDENTITY',    { stage11ColorData: {} },        'visual_color_palette'],
+    ['NO_S17_APPROVED_DESIGNS',   { stage17Data: null },           's17_archetypes'],
+  ])('FR-4 — emits visual_assets_skipped with skip_reason=%s when %j', async (expectedReason, override, expectedMissingType) => {
+    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
+    const params = {
+      ...VALID_UPSTREAM,
+      ...override,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-skip',
+      supabase: sb,
+      logger: { info: () => {}, warn: () => {} },
+    };
+
+    const out = await analyzeStage21VisualAssets(params);
+
+    expect(out._skip).toBe(true);
+    expect(out.skip_reason).toBe(expectedReason);
+    expect(out.precondition_missing.some(m => m.artifact_type === expectedMissingType)).toBe(true);
+
+    const skipInsert = inserted.find(i => i.payload.artifact_type === 'visual_assets_skipped');
+    expect(skipInsert).toBeDefined();
+    expect(skipInsert.payload.artifact_data.skip_reason).toBe(expectedReason);
+    expect(skipInsert.payload.artifact_data.missing_preconditions).toContain(expectedMissingType);
+    expect(skipInsert.payload.lifecycle_stage).toBe(21);
+    expect(skipInsert.payload.is_current).toBe(true);
+
+    // No canonical artifacts emitted on skip path.
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_device_screenshots')).toBeUndefined();
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_social_graphics')).toBeUndefined();
+  });
+
+  it('FR-1 — dual-emit (canonical pair + legacy launch_test_plan) when flag OFF', async () => {
+    setupMockLLM(makeLLMResponse());
+    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
+    const params = {
+      ...VALID_UPSTREAM,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-1',
+      supabase: sb,
+      logger: { info: () => {}, warn: () => {} },
+    };
+    const out = await analyzeStage21VisualAssets(params);
+
+    expect(out.canonical_emission.flag_enabled).toBe(false);
+    expect(out.canonical_emission.dual_emit).toBe(true);
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_device_screenshots')).toBeDefined();
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_social_graphics')).toBeDefined();
+    expect(inserted.find(i => i.payload.artifact_type === 'launch_test_plan')).toBeDefined();
+  });
+
+  it('FR-1 — single-emit canonical pair only when flag ON', async () => {
+    setupMockLLM(makeLLMResponse());
+    const { sb, inserted } = makeFakeSupabase({ flagEnabled: true });
+    const params = {
+      ...VALID_UPSTREAM,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-2',
+      supabase: sb,
+      logger: { info: () => {}, warn: () => {} },
+    };
+    const out = await analyzeStage21VisualAssets(params);
+
+    expect(out.canonical_emission.flag_enabled).toBe(true);
+    expect(out.canonical_emission.dual_emit).toBe(false);
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_device_screenshots')).toBeDefined();
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_social_graphics')).toBeDefined();
+    expect(inserted.find(i => i.payload.artifact_type === 'launch_test_plan')).toBeUndefined();
+  });
+
+  it('FR-1 — idempotent: marks prior is_current=true rows as is_current=false before insert', async () => {
+    setupMockLLM(makeLLMResponse());
+    const { sb, updated } = makeFakeSupabase({ flagEnabled: false });
+    const params = {
+      ...VALID_UPSTREAM,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-3',
+      supabase: sb,
+      logger: { info: () => {}, warn: () => {} },
+    };
+    await analyzeStage21VisualAssets(params);
+    const screenshotUpdates = updated.filter(u => u.filters.artifact_type === 'visual_device_screenshots');
+    const socialUpdates = updated.filter(u => u.filters.artifact_type === 'visual_social_graphics');
+    const legacyUpdates = updated.filter(u => u.filters.artifact_type === 'launch_test_plan');
+    expect(screenshotUpdates.length).toBe(1);
+    expect(socialUpdates.length).toBe(1);
+    expect(legacyUpdates.length).toBe(1);
+    expect(screenshotUpdates[0].payload.is_current).toBe(false);
+  });
+
+  it('falls back to deterministic specs when LLM output fails platform coverage', async () => {
+    // LLM returns malformed (only 1 device, only 2 socials)
+    setupMockLLM(JSON.stringify({
+      device_screenshots: [{ device: 'iphone_15', scene: 's', alt_text: 'a', key_features_visible: [] }],
+      social_graphics: [
+        { platform: 'instagram', format: 'square', width: 1080, height: 1080 },
+      ],
+      video_storyboard: [],
+    }));
+    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
+    const params = {
+      ...VALID_UPSTREAM,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-4',
+      supabase: sb,
+      logger: { info: () => {}, warn: () => {} },
+    };
+    const out = await analyzeStage21VisualAssets(params);
+    // After fallback, all 4 required platforms should be present.
+    expect(out.social_count).toBeGreaterThanOrEqual(4);
+    expect(out.screenshot_count).toBeGreaterThanOrEqual(2);
+    // Canonical pair still emitted.
+    expect(inserted.find(i => i.payload.artifact_type === 'visual_device_screenshots')).toBeDefined();
+  });
+
+  it('returns gracefully when supabase absent (no persistence happens)', async () => {
+    setupMockLLM(makeLLMResponse());
+    const params = {
+      ...VALID_UPSTREAM,
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-5',
+      supabase: null,
+      logger: { info: () => {}, warn: () => {} },
+    };
+    const out = await analyzeStage21VisualAssets(params);
+    expect(out.canonical_emission.flag_enabled).toBe(false);
+    expect(out.device_screenshots.length).toBeGreaterThan(0);
+  });
+});
+
+describe('stage-21-visual-assets — import canary (vi.mock guard)', () => {
+  // Per memory reference_vi_mock_masks_broken_import: vi.mock can fabricate exports
+  // that don't actually exist, masking broken imports. This test asserts each named
+  // export is a function (non-undefined), which would fail if vi.mock is hiding a
+  // missing real export.
+  it('all named exports are defined functions or values', () => {
+    expect(typeof analyzeStage21VisualAssets).toBe('function');
+    expect(typeof validateEntryPreconditions).toBe('function');
+    expect(typeof validatePlatformCoverage).toBe('function');
+    expect(typeof splitArtifacts).toBe('function');
+    expect(Array.isArray(DEVICE_FRAMES)).toBe(true);
+    expect(Array.isArray(SOCIAL_SIZES)).toBe(true);
+    expect(Array.isArray(REQUIRED_UPSTREAM)).toBe(true);
+    expect(typeof FEATURE_FLAG_KEY).toBe('string');
+    expect(FEATURE_FLAG_KEY).toBe('LEO_S21_REQUIRED_ARTIFACTS_GATE');
+  });
+
+  it('REQUIRED_UPSTREAM lists exactly 4 entries (3 S11 + 1 S17)', () => {
+    expect(REQUIRED_UPSTREAM.length).toBe(4);
+    const sources = new Set(REQUIRED_UPSTREAM.map(r => r.source_stage));
+    expect(sources).toEqual(new Set([11, 17]));
+  });
+
+  it('SOCIAL_SIZES lists 5 entries with 4 marked required', () => {
+    expect(SOCIAL_SIZES.length).toBe(5);
+    expect(SOCIAL_SIZES.filter(s => s.required).length).toBe(4);
+    expect(SOCIAL_SIZES.find(s => !s.required).platform).toBe('opengraph');
+  });
+});


### PR DESCRIPTION
## Summary

Closes 7 RCA-identified gaps in Stage 21 (Visual Assets) — last unshipped node in the four-stage S19/S20/S21/S22 campaign.

- **FR-1**: stage-21-visual-assets.js worker emits canonical pair (visual_device_screenshots + visual_social_graphics); dual-emits legacy launch_test_plan while LEO_S21_REQUIRED_ARTIFACTS_GATE=false
- **FR-3**: thin per-stage wiring leveraging fn_advance_venture_stage shipped by S22 PR #3510 — NOT a new gate
- **FR-4**: validateEntryPreconditions checks 3 S11 + 1 S17 artifacts + venture_resources.deployment_url; emits visual_assets_skipped on miss
- **FR-5**: DISPOSITION JSDoc comments on stage-21-acquirability.js + stage-21-quality-assurance.js (KEEP-only, mirrors S22 pattern)
- **FR-6**: backfill migration for PrivacyPatrol AI venture
- **FR-7**: 24/24 vitest unit tests pass

## Test plan
- [x] `npx vitest run tests/unit/eva/stage-templates/analysis-steps/stage-21-visual-assets.test.js` — 24/24 pass
- [ ] Apply migrations in order to live Supabase (deferred to operator)
- [ ] Phase 5: flip LEO_S21_REQUIRED_ARTIFACTS_GATE=true after ≥1d soak (deferred to LEAD)

## Sub-agent evidence
- VALIDATION (LEAD): row 56b93530 PASS@88
- DESIGN (LEAD/PLAN/EXEC): rows 1a085bf4 / 49f868c3 / 713531f4 PASS
- DATABASE (PLAN): row e2a33b6c PASS@91
- TESTING (EXEC): row a1315da9 PASS@90

🤖 Generated with [Claude Code](https://claude.com/claude-code)