### PR TITLE
fix(QF-20260504-design-sub-agent-cwd): replace shell cd-and-pipe with cwd option

### DIFF
--- a/lib/sub-agents/design/checks.js
+++ b/lib/sub-agents/design/checks.js
@@ -24,12 +24,14 @@ export async function checkDesignSystem(repoPath, _sdId) {
   try {
     // Check for inline styles (violation)
     const { stdout: inlineStyles } = await execAsync(
-      `cd "${repoPath}" && grep -r "style={{" src/components 2>/dev/null | wc -l`
+      `grep -r "style={{" src/components 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     // Check for non-Tailwind custom CSS
     const { stdout: customCSS } = await execAsync(
-      `cd "${repoPath}" && find src/components -name "*.css" 2>/dev/null | wc -l`
+      `find src/components -name "*.css" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     const violations = parseInt(inlineStyles.trim()) + parseInt(customCSS.trim());
@@ -60,7 +62,8 @@ export async function analyzeComponents(repoPath, _sdId) {
   try {
     // Find all component files
     const { stdout: componentFiles } = await execAsync(
-      `cd "${repoPath}" && find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null`
+      `find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null`,
+    { cwd: repoPath }
     );
 
     const files = componentFiles.trim().split('\n').filter(f => f);
@@ -70,7 +73,8 @@ export async function analyzeComponents(repoPath, _sdId) {
     for (const file of files.slice(0, 20)) { // Limit to 20 files for performance
       try {
         const { stdout: lineCount } = await execAsync(
-          `cd "${repoPath}" && wc -l "${file}" 2>/dev/null | awk '{print $1}'`
+          `wc -l "${file}" 2>/dev/null | awk '{print $1}'`,
+        { cwd: repoPath }
         );
         const lines = parseInt(lineCount.trim());
         if (lines > 600) {
@@ -119,7 +123,8 @@ export async function checkAccessibility(repoPath, sdId, supabase) {
     // Call design-sub-agent.js with --git-diff-only flag
     const designAgentPath = path.resolve(__dirname, '../../agents/design-sub-agent.js');
     const { stdout, stderr: _stderr } = await execAsync(
-      `cd "${repoPath}" && node "${designAgentPath}" src/components --git-diff-only 2>&1`
+      `node "${designAgentPath}" src/components --git-diff-only 2>&1`,
+    { cwd: repoPath }
     );
 
     // Parse design-sub-agent output
@@ -154,11 +159,13 @@ export async function checkAccessibility(repoPath, sdId, supabase) {
     // Fall back to simple grep checks
     try {
       const { stdout: missingAltFiles } = await execAsync(
-        `cd "${repoPath}" && grep -rl "<img" src/components 2>/dev/null | grep -v "alt="`
+        `grep -rl "<img" src/components 2>/dev/null | grep -v "alt="`,
+      { cwd: repoPath }
       );
 
       const { stdout: missingAriaFiles } = await execAsync(
-        `cd "${repoPath}" && grep -rl "<button" src/components 2>/dev/null | grep -v "aria-label"`
+        `grep -rl "<button" src/components 2>/dev/null | grep -v "aria-label"`,
+      { cwd: repoPath }
       );
 
       const affectedFiles = [
@@ -195,12 +202,14 @@ export async function checkResponsiveDesign(repoPath, _sdId) {
   try {
     // Check for responsive breakpoints usage
     const { stdout: responsiveClasses } = await execAsync(
-      `cd "${repoPath}" && grep -r "sm:\\|md:\\|lg:\\|xl:" src/components 2>/dev/null | wc -l`
+      `grep -r "sm:\\|md:\\|lg:\\|xl:" src/components 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     // Count total components
     const { stdout: totalComponents } = await execAsync(
-      `cd "${repoPath}" && find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null | wc -l`
+      `find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     const hasResponsive = parseInt(responsiveClasses.trim()) > 0;
@@ -229,12 +238,14 @@ export async function checkDesignConsistency(repoPath, _sdId) {
   try {
     // Check for consistent spacing (Tailwind scale)
     const { stdout: customSpacing } = await execAsync(
-      `cd "${repoPath}" && grep -r "margin:\\|padding:" src/components 2>/dev/null | wc -l`
+      `grep -r "margin:\\|padding:" src/components 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     // Check for hex colors (should use Tailwind palette)
     const { stdout: hexColors } = await execAsync(
-      `cd "${repoPath}" && grep -r "#[0-9a-fA-F]\\{6\\}" src/components 2>/dev/null | wc -l`
+      `grep -r "#[0-9a-fA-F]\\{6\\}" src/components 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
 
     const inconsistencies = parseInt(customSpacing.trim()) + parseInt(hexColors.trim());

--- a/lib/sub-agents/design/patterns.js
+++ b/lib/sub-agents/design/patterns.js
@@ -34,14 +34,16 @@ export async function analyzeCodebasePatterns(repoPath) {
   try {
     // 1. Scan for error boundary patterns
     const { stdout: errorBoundaries } = await execAsync(
-      `cd "${repoPath}" && grep -r "ErrorBoundary\\|useErrorHandler\\|try.*catch\\|\.catch(" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`
+      `grep -r "ErrorBoundary\\|useErrorHandler\\|try.*catch\\|\.catch(" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
     const errorCount = parseInt(errorBoundaries.trim()) || 0;
 
     if (errorCount > 0) {
       // Find actual implementations
       const { stdout: errorExamples } = await execAsync(
-        `cd "${repoPath}" && grep -r "ErrorBoundary\\|try.*catch" src/ --include="*.jsx" --include="*.tsx" -A 3 2>/dev/null | head -20`
+        `grep -r "ErrorBoundary\\|try.*catch" src/ --include="*.jsx" --include="*.tsx" -A 3 2>/dev/null | head -20`,
+      { cwd: repoPath }
       );
       patterns.error_recovery.push({
         pattern: 'ErrorBoundary / try-catch',
@@ -53,7 +55,8 @@ export async function analyzeCodebasePatterns(repoPath) {
 
     // 2. Scan for confirmation modal patterns
     const { stdout: confirmations } = await execAsync(
-      `cd "${repoPath}" && grep -ri "confirm\\|AlertDialog\\|ConfirmDialog\\|Modal.*destructive" src/ --include="*.jsx" --include="*.tsx" 2>/dev/null | wc -l`
+      `grep -ri "confirm\\|AlertDialog\\|ConfirmDialog\\|Modal.*destructive" src/ --include="*.jsx" --include="*.tsx" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
     const confirmCount = parseInt(confirmations.trim()) || 0;
 
@@ -67,17 +70,20 @@ export async function analyzeCodebasePatterns(repoPath) {
 
     // 3. Scan for form validation patterns
     const { stdout: formValidation } = await execAsync(
-      `cd "${repoPath}" && grep -ri "yup\\|zod\\|validation.*schema\\|useForm\\|FormProvider" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`
+      `grep -ri "yup\\|zod\\|validation.*schema\\|useForm\\|FormProvider" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
     const formCount = parseInt(formValidation.trim()) || 0;
 
     if (formCount > 0) {
       // Detect validation library
       const { stdout: hasYup } = await execAsync(
-        `cd "${repoPath}" && grep -r "yup" src/ 2>/dev/null | wc -l`
+        `grep -r "yup" src/ 2>/dev/null | wc -l`,
+      { cwd: repoPath }
       );
       const { stdout: hasZod } = await execAsync(
-        `cd "${repoPath}" && grep -r "zod" src/ 2>/dev/null | wc -l`
+        `grep -r "zod" src/ 2>/dev/null | wc -l`,
+      { cwd: repoPath }
       );
 
       const yupCount = parseInt(hasYup.trim()) || 0;
@@ -95,7 +101,8 @@ export async function analyzeCodebasePatterns(repoPath) {
 
     // 4. Scan for loading state patterns
     const { stdout: loadingStates } = await execAsync(
-      `cd "${repoPath}" && grep -ri "isLoading\\|loading\\|Skeleton\\|Spinner" src/ --include="*.jsx" --include="*.tsx" 2>/dev/null | wc -l`
+      `grep -ri "isLoading\\|loading\\|Skeleton\\|Spinner" src/ --include="*.jsx" --include="*.tsx" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
     const loadingCount = parseInt(loadingStates.trim()) || 0;
 
@@ -109,7 +116,8 @@ export async function analyzeCodebasePatterns(repoPath) {
 
     // 5. Scan for navigation patterns (React Router, Next.js)
     const { stdout: navigationPatterns } = await execAsync(
-      `cd "${repoPath}" && grep -ri "useNavigate\\|useRouter\\|router\\.push\\|navigate(" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`
+      `grep -ri "useNavigate\\|useRouter\\|router\\.push\\|navigate(" src/ --include="*.jsx" --include="*.tsx" --include="*.js" --include="*.ts" 2>/dev/null | wc -l`,
+    { cwd: repoPath }
     );
     const navCount = parseInt(navigationPatterns.trim()) || 0;
 

--- a/lib/sub-agents/design/utils.js
+++ b/lib/sub-agents/design/utils.js
@@ -125,7 +125,8 @@ export async function enhanceWithRiskContext(affectedFiles, patternType, repoPat
 export async function getGitDiffFiles(repoPath) {
   try {
     const { stdout } = await execAsync(
-      `cd "${repoPath}" && git diff --name-only HEAD 2>/dev/null`
+      `git diff --name-only HEAD 2>/dev/null`,
+    { cwd: repoPath }
     );
 
     const files = stdout.trim().split('\n').filter(f => f && f.endsWith('.tsx') || f.endsWith('.jsx'));


### PR DESCRIPTION
## Summary

design-sub-agent.js orchestrator at PLAN_VERIFY runs from a worktree CWD that doesn't match the target ehg repo path. The shell construct \`cd \"\${repoPath}\" && CMD\` fails on Windows with "system cannot find the path specified" — all internal grep/find/wc commands silently error out and design_score falls through to 0/100, producing false-positive BLOCKED verdicts. Witnessed across 4 stage SDs in the S19/S20/S21/S22 campaign.

## Fix
Replace shell cd-and-pipe with \`{ cwd: repoPath }\` execAsync option. 20 substitutions across 3 files:
- lib/sub-agents/design/checks.js (11)
- lib/sub-agents/design/patterns.js (8)
- lib/sub-agents/design/utils.js (1)

The cwd-option pattern was already in correct use elsewhere (lib/agents/design-sub-agent/file-helpers.js).

## Harness backlog reference
feedback row 3ea3ae86-1d41-4d45-b1f3-d5dceae1f0aa

## Test plan
- [x] Local apply against S21 SD enabled EXEC-TO-PLAN gate to pass at score 85 (otherwise blocked at design_score=0)
- [ ] Re-run any pending DESIGN sub-agent orchestration to confirm CWD now resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)