### PR TITLE
fix(QF-20260504-007): restore auto-PostToolUse coordination-inbox hook firing (closes bdc65df3)

### DIFF
--- a/scripts/hooks/__tests__/coordination-inbox.test.js
+++ b/scripts/hooks/__tests__/coordination-inbox.test.js
@@ -82,6 +82,60 @@ describe('HOOK-2: env var takes priority over session-id.json file', () => {
   });
 });
 
+describe('STDIN-1: readSessionIdFromStdin parses {session_id} from stdin (QF-20260504-007)', () => {
+  // Use a child process to control stdin deterministically — vitest cannot easily
+  // mock process.stdin's data-event timing in-process.
+  it('returns session_id when Claude Code passes JSON payload via stdin', async () => {
+    const { spawn } = require('node:child_process');
+    const probe = spawn('node', ['-e', `
+      const hook = require('${HOOK_PATH.replace(/\\/g, '/')}');
+      hook.readSessionIdFromStdin(1000).then(sid => { process.stdout.write(String(sid), () => process.exit(0)); });
+    `], { stdio: ['pipe', 'pipe', 'pipe'] });
+    probe.stdin.end(JSON.stringify({
+      session_id: 'abc-from-stdin-123',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash'
+    }));
+    const out = await new Promise((resolve) => {
+      let buf = '';
+      probe.stdout.on('data', c => { buf += c; });
+      probe.on('close', () => resolve(buf));
+    });
+    expect(out).toBe('abc-from-stdin-123');
+  });
+
+  it('returns null on malformed JSON', async () => {
+    const { spawn } = require('node:child_process');
+    const probe = spawn('node', ['-e', `
+      const hook = require('${HOOK_PATH.replace(/\\/g, '/')}');
+      hook.readSessionIdFromStdin(500).then(sid => { process.stdout.write(String(sid), () => process.exit(0)); });
+    `], { stdio: ['pipe', 'pipe', 'pipe'] });
+    probe.stdin.end('this is not json {{{');
+    const out = await new Promise((resolve) => {
+      let buf = '';
+      probe.stdout.on('data', c => { buf += c; });
+      probe.on('close', () => resolve(buf));
+    });
+    expect(out).toBe('null');
+  });
+
+  it('returns null on timeout (empty stdin, never closes)', async () => {
+    const { spawn } = require('node:child_process');
+    const probe = spawn('node', ['-e', `
+      const hook = require('${HOOK_PATH.replace(/\\/g, '/')}');
+      hook.readSessionIdFromStdin(150).then(sid => { process.stdout.write(String(sid), () => process.exit(0)); });
+    `], { stdio: ['pipe', 'pipe', 'pipe'] });
+    // Deliberately do NOT call probe.stdin.end() — let timeout trigger
+    const out = await new Promise((resolve) => {
+      let buf = '';
+      probe.stdout.on('data', c => { buf += c; });
+      probe.on('close', () => resolve(buf));
+    });
+    probe.stdin.end(); // cleanup
+    expect(out).toBe('null');
+  });
+});
+
 describe('HOOK-3: returns null when env var unset AND file missing AND no PID match', () => {
   const originalEnv = process.env.CLAUDE_SESSION_ID;
   let sessionFileBackup = null;

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -233,6 +233,29 @@ function emitAutoClaimDirective(suggestedSd, availableSds) {
   console.log('');
 }
 
+// QF-20260504-007: Claude Code passes hook payload as JSON on stdin per its
+// PostToolUse protocol. The session_id field is the only reliable identifier of
+// the calling session — env vars (CLAUDE_SESSION_ID) are NOT propagated to hook
+// subprocesses, and per-worktree session-id files don't exist in the parent
+// worktree where the hook actually runs from. Without this read, every auto-fire
+// of this hook returned null at getCurrentSessionId() and exited silently
+// (closes feedback bdc65df3).
+async function readSessionIdFromStdin(timeoutMs = 250) {
+  return new Promise((resolve) => {
+    let buf = '';
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    try {
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', c => { buf += c; });
+      process.stdin.on('end', () => {
+        clearTimeout(timer);
+        try { resolve(JSON.parse(buf)?.session_id || null); } catch { resolve(null); }
+      });
+      process.stdin.on('error', () => { clearTimeout(timer); resolve(null); });
+    } catch { clearTimeout(timer); resolve(null); }
+  });
+}
+
 async function main() {
   let supabase;
   try {
@@ -242,7 +265,9 @@ async function main() {
     return;
   }
 
-  const sessionId = getCurrentSessionId();
+  // QF-20260504-007: stdin is the canonical source for PostToolUse session_id.
+  // Falls back to env/file/PID-scan resolution for non-PostToolUse invocations.
+  const sessionId = (await readSessionIdFromStdin()) || getCurrentSessionId();
   if (!sessionId) return;
 
   // Always update heartbeat (30s throttle) — even when inbox check is skipped
@@ -407,4 +432,4 @@ if (require.main === module) {
   main().catch(() => { /* fail silently */ });
 }
 
-module.exports = { getCurrentSessionId };
+module.exports = { getCurrentSessionId, readSessionIdFromStdin };


### PR DESCRIPTION
## Summary

Closes feedback row `bdc65df3-b306-4571-a7de-1773d3f67e56` (severity high, fleet-wide). Restores auto-PostToolUse coordination-inbox hook firing — workers and the coordinator can now consume inbox messages on their next tool call instead of relying on manual `node` invocations.

## Root cause (diagnosed via canary instrumentation)

Hook fired on every tool call (entry canary at `os.tmpdir()/hook-entry-canary.json` confirmed) but exited silently at `if (!sessionId) return` because `getCurrentSessionId()` returned `null` in the auto-PostToolUse subprocess. All three existing fallbacks failed in production:

| Fallback | Why it fails in PostToolUse subprocess |
|---|---|
| `process.env.CLAUDE_SESSION_ID` | Claude Code does **not** propagate this env var. Verified propagated keys: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `CLAUDE_CODE_SSE_PORT`, `CLAUDE_PROJECT_DIR` — `CLAUDE_SESSION_ID` is not. |
| `.claude/session-id.json` | Doesn't exist in parent worktree where the hook actually runs from (`settings.json` hardcodes parent path; `.claude/session-identity/<sid>.json` per-session files exist but aren't checked). |
| PID scan in `~/.claude-sessions` | Single SSE port shared across all sessions on the host (`port=59316` for every session-identity file), so PID-to-session mapping is ambiguous; `process.ppid` resolves unreliably on Windows. |

## Fix

Read JSON payload from stdin per Claude Code's documented PostToolUse hook protocol. The first chunk of stdin is the canonical `{session_id, transcript_path, cwd, hook_event_name, tool_name, tool_input, tool_response, ...}` payload — empirically verified by inspecting `capture-session-id.cjs` which uses the same mechanism for SessionStart hooks. The new `readSessionIdFromStdin()` uses a 250ms timeout so non-PostToolUse invocations (manual `node` calls) cleanly fall through to existing `getCurrentSessionId()` resolution.

## Out of scope (follow-up)

`scripts/hooks/post-tool-clear-telemetry.cjs` has the same bug class (uses `process.env.CLAUDE_SESSION_ID` which is never set). A separate QF will apply the same stdin pattern there.

## Test plan
- [x] **STDIN-1**: readSessionIdFromStdin parses `{session_id}` from stdin → returns the value
- [x] **STDIN-2**: returns `null` on malformed JSON
- [x] **STDIN-3**: returns `null` on timeout (empty stdin, never closes)
- [x] **HOOK-1/2/3** (existing): getCurrentSessionId fallback chain still works
- [x] **End-to-end**: simulated hook invocation with stdin payload `{"session_id":"6aacba56-..."}` consumed test COACHING row `82364365` and flipped `read_at` at 12:43:41Z within 1 second
- [x] Full file suite: 40/40 tests green (3 STDIN + 13 resolve + 21 signal-router + 3 HOOK)

## Sizing
- **Tier 1 QF**, 27 LOC src + 54 LOC tests
- No risk keywords (auth/migration/schema/feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)