### PR TITLE
fix(QF-20260504-912): per-session throttle + heartbeat in coordination-inbox.cjs

### DIFF
--- a/scripts/hooks/__tests__/coordination-inbox.test.js
+++ b/scripts/hooks/__tests__/coordination-inbox.test.js
@@ -20,6 +20,138 @@ function loadHook() {
   return require(HOOK_PATH);
 }
 
+// =============================================================================
+// QF-20260504-912: Per-session throttle + heartbeat (closes peer-starvation bug)
+// =============================================================================
+// Pre-fix: THROTTLE_FILE and HEARTBEAT_FILE were host-shared paths. With 6
+// active sessions, the first hook fire marks the throttle and the next 5
+// sessions skip their inbox check for up to 60s — message starvation.
+// Post-fix: per-session paths mirror the friction-counters pattern at lines
+// ~96-125 of coordination-inbox.cjs.
+
+describe('QF-912 THROTTLE-1: shouldCheck(sessionId) is per-session, not global', () => {
+  it('returns true for session A even when session B just marked its throttle', () => {
+    const hook = loadHook();
+    const sidA = 'sessionA-throttle1';
+    const sidB = 'sessionB-throttle1';
+    // Wipe both sessions' throttle files first
+    try { fs.unlinkSync(hook.getThrottleFile(sidA)); } catch {}
+    try { fs.unlinkSync(hook.getThrottleFile(sidB)); } catch {}
+    // B marks throttle (recent)
+    hook.markChecked(sidB);
+    // A's check must still return true — A has no own throttle file
+    expect(hook.shouldCheck(sidA)).toBe(true);
+    // Cleanup
+    try { fs.unlinkSync(hook.getThrottleFile(sidA)); } catch {}
+    try { fs.unlinkSync(hook.getThrottleFile(sidB)); } catch {}
+  });
+});
+
+describe('QF-912 THROTTLE-2: shouldCheck(sessionId) returns false only when same session is fresh', () => {
+  it('returns false for session A when A itself just marked', () => {
+    const hook = loadHook();
+    const sid = 'sessionA-throttle2';
+    try { fs.unlinkSync(hook.getThrottleFile(sid)); } catch {}
+    hook.markChecked(sid);
+    expect(hook.shouldCheck(sid)).toBe(false);
+    try { fs.unlinkSync(hook.getThrottleFile(sid)); } catch {}
+  });
+});
+
+describe('QF-912 THROTTLE-3: markChecked(sessionId) writes a per-session file', () => {
+  it('writes to a path containing the sessionId and not to the global path', () => {
+    const hook = loadHook();
+    const sid = 'sessionA-throttle3';
+    const expected = hook.getThrottleFile(sid);
+    expect(expected).toContain(sid);
+    expect(expected).not.toBe(path.join(require('os').tmpdir(), 'claude-coordination-inbox-last-check.json'));
+    try { fs.unlinkSync(expected); } catch {}
+    hook.markChecked(sid);
+    expect(fs.existsSync(expected)).toBe(true);
+    try { fs.unlinkSync(expected); } catch {}
+  });
+});
+
+describe('QF-912 THROTTLE-4: invalid sessionId is rejected gracefully (security M4)', () => {
+  it('does not write a file and shouldCheck returns true (fail-open) for malformed sessionId', () => {
+    const hook = loadHook();
+    const bad = '../../etc/passwd';
+    // markChecked must not throw and must not write
+    expect(() => hook.markChecked(bad)).not.toThrow();
+    // shouldCheck should not throw
+    expect(() => hook.shouldCheck(bad)).not.toThrow();
+    // Returns true (fail-open) because invalid sessionId means no per-session state can exist
+    expect(hook.shouldCheck(bad)).toBe(true);
+  });
+});
+
+describe('QF-912 HEARTBEAT-1: shouldHeartbeat(sessionId) is per-session', () => {
+  it('returns true for A even when B just heartbeated', () => {
+    const hook = loadHook();
+    const sidA = 'sessionA-hb1';
+    const sidB = 'sessionB-hb1';
+    try { fs.unlinkSync(hook.getHeartbeatFile(sidA)); } catch {}
+    try { fs.unlinkSync(hook.getHeartbeatFile(sidB)); } catch {}
+    hook.markHeartbeat(sidB);
+    expect(hook.shouldHeartbeat(sidA)).toBe(true);
+    try { fs.unlinkSync(hook.getHeartbeatFile(sidA)); } catch {}
+    try { fs.unlinkSync(hook.getHeartbeatFile(sidB)); } catch {}
+  });
+});
+
+describe('QF-912 HEARTBEAT-2: shouldHeartbeat(sessionId) returns false only when same session is fresh', () => {
+  it('returns false for A when A itself just heartbeated', () => {
+    const hook = loadHook();
+    const sid = 'sessionA-hb2';
+    try { fs.unlinkSync(hook.getHeartbeatFile(sid)); } catch {}
+    hook.markHeartbeat(sid);
+    expect(hook.shouldHeartbeat(sid)).toBe(false);
+    try { fs.unlinkSync(hook.getHeartbeatFile(sid)); } catch {}
+  });
+});
+
+describe('QF-912 HEARTBEAT-3: markHeartbeat(sessionId) writes a per-session file', () => {
+  it('writes to a path containing the sessionId', () => {
+    const hook = loadHook();
+    const sid = 'sessionA-hb3';
+    const expected = hook.getHeartbeatFile(sid);
+    expect(expected).toContain(sid);
+    expect(expected).not.toBe(path.join(require('os').tmpdir(), 'claude-heartbeat-last-update.json'));
+    try { fs.unlinkSync(expected); } catch {}
+    hook.markHeartbeat(sid);
+    expect(fs.existsSync(expected)).toBe(true);
+    try { fs.unlinkSync(expected); } catch {}
+  });
+});
+
+describe('QF-912 HEARTBEAT-4: invalid sessionId is rejected gracefully', () => {
+  it('does not write a file and shouldHeartbeat returns true (fail-open)', () => {
+    const hook = loadHook();
+    const bad = 'has spaces and !!!';
+    expect(() => hook.markHeartbeat(bad)).not.toThrow();
+    expect(() => hook.shouldHeartbeat(bad)).not.toThrow();
+    expect(hook.shouldHeartbeat(bad)).toBe(true);
+  });
+});
+
+describe('QF-912 CROSS-SESSION-1: 6 sessions can all check independently within same window', () => {
+  it('after 6 distinct markChecked calls, all 6 throttle files exist at distinct paths', () => {
+    const hook = loadHook();
+    const sids = ['sess1', 'sess2', 'sess3', 'sess4', 'sess5', 'sess6'].map(s => 'qf912-' + s);
+    sids.forEach(sid => { try { fs.unlinkSync(hook.getThrottleFile(sid)); } catch {} });
+    sids.forEach(sid => hook.markChecked(sid));
+    const paths = sids.map(sid => hook.getThrottleFile(sid));
+    // All paths distinct
+    expect(new Set(paths).size).toBe(6);
+    // All files exist
+    paths.forEach(p => expect(fs.existsSync(p)).toBe(true));
+    // None is the legacy shared path
+    paths.forEach(p => expect(p).not.toBe(path.join(require('os').tmpdir(), 'claude-coordination-inbox-last-check.json')));
+    // Cleanup
+    paths.forEach(p => { try { fs.unlinkSync(p); } catch {} });
+  });
+});
+
 describe('HOOK-1: getCurrentSessionId returns process.env.CLAUDE_SESSION_ID when set', () => {
   const originalEnv = process.env.CLAUDE_SESSION_ID;
   let sessionFileBackup = null;

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -17,8 +17,18 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const THROTTLE_FILE = path.join(os.tmpdir(), 'claude-coordination-inbox-last-check.json');
-const HEARTBEAT_FILE = path.join(os.tmpdir(), 'claude-heartbeat-last-update.json');
+// QF-20260504-912: per-session throttle/heartbeat paths. Pre-fix these were
+// host-shared, causing 5/6 sessions to be starved for up to 60s after any one
+// session marked the throttle. Mirror the friction-counters pattern (validated
+// regex + per-session filename) at lines ~96-125 below.
+function getThrottleFile(sessionId) {
+  if (!isValidSessionId(sessionId)) return null;
+  return path.join(os.tmpdir(), `claude-coordination-inbox-throttle-${sessionId}.json`);
+}
+function getHeartbeatFile(sessionId) {
+  if (!isValidSessionId(sessionId)) return null;
+  return path.join(os.tmpdir(), `claude-coordination-inbox-heartbeat-${sessionId}.json`);
+}
 
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-5c — friction-detection counter file.
 // Per-session counter of recurring failures; emits proactive /signal nudge when
@@ -40,39 +50,50 @@ function getIdentityFile(resolvedSessionId) {
 // SD-LEO-INFRA-FLEET-COORDINATION-RESILIENCE-001 (FR-003):
 // Reduced from 300s to 60s for faster coordination message delivery.
 // Configurable via env var for tuning under high DB load.
-const CHECK_INTERVAL_MS = parseInt(process.env.COORDINATION_CHECK_INTERVAL_MS, 10) || 60_000;
+// QF-20260504-912: default reduced 60_000 → 15_000 — safe now that throttle is
+// per-session (no peer interference). Per-session DB load: 4 queries/min × 6
+// sessions = 24/min, well below capacity.
+const CHECK_INTERVAL_MS = parseInt(process.env.COORDINATION_CHECK_INTERVAL_MS, 10) || 15_000;
 const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 
-function shouldCheck() {
+function shouldCheck(sessionId) {
+  const file = getThrottleFile(sessionId);
+  if (!file) return true;
   try {
-    if (!fs.existsSync(THROTTLE_FILE)) return true;
-    const data = JSON.parse(fs.readFileSync(THROTTLE_FILE, 'utf8'));
+    if (!fs.existsSync(file)) return true;
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
     return (Date.now() - data.lastCheck) > CHECK_INTERVAL_MS;
   } catch {
     return true;
   }
 }
 
-function markChecked() {
+function markChecked(sessionId) {
+  const file = getThrottleFile(sessionId);
+  if (!file) return;
   try {
-    fs.writeFileSync(THROTTLE_FILE, JSON.stringify({ lastCheck: Date.now() }));
+    fs.writeFileSync(file, JSON.stringify({ lastCheck: Date.now() }));
   } catch { /* ignore */ }
 }
 
-function shouldHeartbeat() {
+function shouldHeartbeat(sessionId) {
+  const file = getHeartbeatFile(sessionId);
+  if (!file) return true;
   try {
-    if (!fs.existsSync(HEARTBEAT_FILE)) return true;
-    const data = JSON.parse(fs.readFileSync(HEARTBEAT_FILE, 'utf8'));
+    if (!fs.existsSync(file)) return true;
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
     return (Date.now() - data.lastHeartbeat) > HEARTBEAT_INTERVAL_MS;
   } catch {
     return true;
   }
 }
 
-function markHeartbeat() {
+function markHeartbeat(sessionId) {
+  const file = getHeartbeatFile(sessionId);
+  if (!file) return;
   try {
-    fs.writeFileSync(HEARTBEAT_FILE, JSON.stringify({ lastHeartbeat: Date.now() }));
+    fs.writeFileSync(file, JSON.stringify({ lastHeartbeat: Date.now() }));
   } catch { /* ignore */ }
 }
 
@@ -80,8 +101,8 @@ function markHeartbeat() {
  * Update heartbeat_at on claude_sessions — runs every 30s regardless of inbox check
  */
 async function updateHeartbeat(supabase, sessionId) {
-  if (!shouldHeartbeat()) return;
-  markHeartbeat();
+  if (!shouldHeartbeat(sessionId)) return;
+  markHeartbeat(sessionId);
   try {
     // stampBranch keeps current_branch fresh on inbox-hook heartbeats — see
     // lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
@@ -273,8 +294,8 @@ async function main() {
   // Always update heartbeat (30s throttle) — even when inbox check is skipped
   await updateHeartbeat(supabase, sessionId);
 
-  if (!shouldCheck()) return;
-  markChecked();
+  if (!shouldCheck(sessionId)) return;
+  markChecked(sessionId);
 
   // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-5c — check friction counters and
   // reset if SD changed. Counters are populated by external hooks (gate failures,
@@ -432,4 +453,14 @@ if (require.main === module) {
   main().catch(() => { /* fail silently */ });
 }
 
-module.exports = { getCurrentSessionId, readSessionIdFromStdin };
+module.exports = {
+  getCurrentSessionId,
+  readSessionIdFromStdin,
+  // QF-20260504-912 — exposed for per-session throttle/heartbeat tests
+  shouldCheck,
+  markChecked,
+  shouldHeartbeat,
+  markHeartbeat,
+  getThrottleFile,
+  getHeartbeatFile
+};


### PR DESCRIPTION
## Summary

Closes the multi-session **message starvation** bug surfaced during QF-20260504-007 verification. With ~6 active Claude Code sessions on one host, the prior host-shared throttle file at `os.tmpdir()/claude-coordination-inbox-last-check.json` caused 5/6 sessions to skip their inbox check for up to 60s after any one session marked the throttle. Same pattern for `claude-heartbeat-last-update.json`.

This is the multi-session blocker called out in the planning phase. After this lands, message delivery latency drops from up-to-60s (worst case under 6-session load) to up-to-15s.

## Root cause

`THROTTLE_FILE` / `HEARTBEAT_FILE` were module-level constants pointing at single per-host paths. `shouldCheck`/`markChecked` and `shouldHeartbeat`/`markHeartbeat` read/wrote those without any session scoping. Single-session-per-host: fine. Six concurrent sessions: peer starvation.

## Fix

Mirror the existing friction-counters per-session pattern (lines ~96-125 of the same file):

- New `getThrottleFile(sessionId)` and `getHeartbeatFile(sessionId)` construct paths with the `session_id` embedded in the filename (`claude-coordination-inbox-throttle-${sessionId}.json` etc.)
- `isValidSessionId()` regex from the same file is reused for security M4 — rejects shell-injection patterns before `path.join`
- `shouldCheck(sessionId)` / `markChecked(sessionId)` take the resolver-derived `session_id` as a parameter; `main()` passes it through after `getCurrentSessionId()` resolves
- Same for `shouldHeartbeat(sessionId)` / `markHeartbeat(sessionId)`; `updateHeartbeat()` forwards its existing `sessionId` arg

Default `COORDINATION_CHECK_INTERVAL_MS` dropped `60_000 → 15_000`. Safe now that throttle is per-session (no peer interference). Per-session DB load: 4 queries/min × 6 sessions = 24/min, well below capacity. Net delivery latency drops from up-to-60s to up-to-15s on the slow path.

## Test plan (test-first, all 9 new cases failed before fix, pass after)

- [x] **QF-912 THROTTLE-1**: peer's throttle does not block own `shouldCheck`
- [x] **QF-912 THROTTLE-2**: own throttle DOES block own check within window
- [x] **QF-912 THROTTLE-3**: `markChecked` writes a per-session file at the expected path
- [x] **QF-912 THROTTLE-4**: invalid sessionId fails open (security M4 alignment)
- [x] **QF-912 HEARTBEAT-1/2/3/4**: same shape for heartbeat
- [x] **QF-912 CROSS-SESSION-1**: 6 distinct `markChecked(sid)` calls produce 6 distinct files at 6 distinct paths
- [x] Existing tests preserved: HOOK-1/2/3 (env-var fallback), STDIN-1/2/3 (stdin session_id from QF-007)
- [x] **15/15** in this file pass; **49/49** across coordination-inbox + resolve + signal-router

## Sizing
- **Tier 1 QF**, ~22 LOC src behavior delta + 132 LOC tests
- No risk keywords (auth/migration/schema/feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)