### PR TITLE
fix(QF-20260504-081): sweep release UPDATE must null worktree_branch (close ck_claude_sessions_worktree_state_consistency violation)

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -807,6 +807,13 @@ async function main() {
         released_reason: releaseReason,
         is_alive: false,
         worktree_path: null,
+        // QF-20260504-081: ck_claude_sessions_worktree_state_consistency requires
+        // sd_key IS NOT NULL OR (worktree_path IS NULL AND worktree_branch IS NULL).
+        // Sweep was missed when worktree_branch was added 2026-05-02 (RPC release
+        // paths got the column, sweep direct UPDATE didn't). Without this null,
+        // every release attempt against a session with non-null worktree_branch
+        // fails the CHECK and emits a dead-letter CLAIM_RELEASED.
+        worktree_branch: null,
         has_uncommitted_changes: false,
         current_branch: null
       })


### PR DESCRIPTION
## Summary

Closes a recurring CHECK constraint violation in `scripts/stale-session-sweep.cjs` release path. Every 5-min sweep cycle since 12:30 UTC 2026-05-04 has been failing to release session 6317ea17 with:
```
new row for relation "claude_sessions" violates check constraint "ck_claude_sessions_worktree_state_consistency"
```
Each failure also emits a dead-letter `CLAIM_RELEASED` row in `session_coordination` targeting an already-silent session, polluting the coord inbox at ~2 messages/cycle (60+ to date).

## Root cause

Migration `20260502_claude_sessions_worktree_invariant.sql` added the CHECK:
```sql
sd_key IS NOT NULL OR (worktree_path IS NULL AND worktree_branch IS NULL)
```

Three release paths exist:
1. `claim_sd` RPC — handles both columns ✓
2. `release_sd` RPC — handles both columns ✓
3. `stale-session-sweep.cjs` main() direct UPDATE — **only cleared `worktree_path`** ✗

When sweep transitions a session from active (`sd_key IS NOT NULL`) to released (`sd_key = NULL` + `worktree_path = NULL`), if `worktree_branch` is non-null the CHECK evaluates FALSE and the UPDATE fails.

## Fix

Add `worktree_branch: null` to the sweep UPDATE shape, mirroring the SQL RPC paths.

## Verification

RCA agent ran the sweep with the fix applied — session `6317ea17-94fb-...` released cleanly. Row state confirmed `status=released` with all `worktree_*` fields null. No further FAILED log lines.

Dead-letter rows already in `session_coordination` are stale but harmless (coordinator dedupes by id).

## Test plan
- [x] Live verification: sweep released stuck session 6317ea17 cleanly post-fix
- [x] Constraint definition reviewed against new UPDATE shape — predicate evaluates TRUE for all 3 release paths
- [x] No new tests added — single-line UPDATE shape correction exercised every sweep cycle in production

## Sizing
- **Tier 1 QF**, 7 LOC (1 functional + 6 explanatory comment)
- No risk keywords (auth/migration/schema/feature)

Feedback row: `d8e2e6f2-7b03-4f95-bfde-23dc72092aa2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)