### PR TITLE
fix(QF-20260504-932): pre-tool-enforce.cjs PreToolUse stdin port — restore 13 enforcement rules (closes 267e0631)

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce.test.js
@@ -1,0 +1,121 @@
+// Tests for QF-20260504-932 — pre-tool-enforce.cjs stdin port
+// Pre-fix: hook read process.env.CLAUDE_TOOL_NAME / CLAUDE_TOOL_INPUT /
+// CLAUDE_SESSION_ID — Claude Code propagates none of these to PreToolUse
+// subprocesses (verified by RCA #2 canaries). All 13 enforcement rules
+// silently no-op fleet-wide. Post-fix: hook reads {tool_name, tool_input,
+// session_id} JSON payload from stdin per documented PreToolUse contract.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+const HOOK_PATH = path.resolve(__dirname, '../pre-tool-enforce.cjs').replace(/\\/g, '/');
+
+function spawnHook(stdinPayload, extraEnv = {}) {
+  const { spawn } = require('node:child_process');
+  // The hook supports a TEST_DUMP_RESOLVED=1 mode that prints the resolved
+  // {tool_name, tool_input_raw, session_id} as JSON and exits before any
+  // enforcement runs. This lets tests verify the resolution path without
+  // triggering side-effects (audit writes, exit-2 blocks, etc).
+  const probe = spawn('node', [HOOK_PATH], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, TEST_DUMP_RESOLVED: '1', ...extraEnv }
+  });
+  if (stdinPayload === null) {
+    probe.stdin.end();
+  } else {
+    probe.stdin.end(stdinPayload);
+  }
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    probe.stdout.on('data', c => { stdout += c; });
+    probe.stderr.on('data', c => { stderr += c; });
+    probe.on('close', code => resolve({ stdout, stderr, code }));
+  });
+}
+
+describe('QF-932 ENF-STDIN-1: tool_name from stdin populates TOOL_NAME', () => {
+  it('reads tool_name from stdin payload', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'enf-stdin-1-abc',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi' },
+      hook_event_name: 'PreToolUse'
+    }), { CLAUDE_TOOL_NAME: '' });
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.tool_name).toBe('Bash');
+  });
+});
+
+describe('QF-932 ENF-STDIN-2: tool_input from stdin (object) becomes TOOL_INPUT_RAW (JSON string)', () => {
+  it('serializes object tool_input back to JSON string', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'enf-stdin-2-abc',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls -la', description: 'list' },
+      hook_event_name: 'PreToolUse'
+    }), { CLAUDE_TOOL_INPUT: '' });
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.tool_input_raw).toBe(JSON.stringify({ command: 'ls -la', description: 'list' }));
+  });
+});
+
+describe('QF-932 ENF-STDIN-3: session_id from stdin populates _SESSION_ID', () => {
+  it('reads session_id from stdin payload', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'enf-stdin-3-xyz-789',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/x' },
+      hook_event_name: 'PreToolUse'
+    }), { CLAUDE_SESSION_ID: '', SESSION_ID: '' });
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.session_id).toBe('enf-stdin-3-xyz-789');
+  });
+});
+
+describe('QF-932 ENF-STDIN-4: empty stdin → env fallback works', () => {
+  it('falls back to env vars when stdin is empty', async () => {
+    const r = await spawnHook(null, {
+      CLAUDE_TOOL_NAME: 'Glob',
+      CLAUDE_TOOL_INPUT: '{"pattern":"**/*.js"}',
+      CLAUDE_SESSION_ID: 'env-fallback-session-001'
+    });
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.tool_name).toBe('Glob');
+    expect(parsed.tool_input_raw).toBe('{"pattern":"**/*.js"}');
+    expect(parsed.session_id).toBe('env-fallback-session-001');
+  });
+});
+
+describe('QF-932 ENF-STDIN-5: malformed stdin JSON → graceful env fallback, no throw', () => {
+  it('does not crash on malformed stdin', async () => {
+    const r = await spawnHook('this is not json {{{', {
+      CLAUDE_TOOL_NAME: 'Edit',
+      CLAUDE_TOOL_INPUT: '{"file_path":"/tmp/y"}',
+      CLAUDE_SESSION_ID: 'malformed-fallback-002'
+    });
+    expect(r.code).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.tool_name).toBe('Edit');
+    expect(parsed.session_id).toBe('malformed-fallback-002');
+  });
+});
+
+describe('QF-932 ENF-STDIN-6: stdin precedence over env', () => {
+  it('stdin tool_name + session_id win over env when both present', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'stdin-wins-789',
+      tool_name: 'Write',
+      tool_input: { file_path: '/tmp/z', content: 'data' },
+      hook_event_name: 'PreToolUse'
+    }), {
+      CLAUDE_TOOL_NAME: 'Glob',
+      CLAUDE_TOOL_INPUT: '{"pattern":"x"}',
+      CLAUDE_SESSION_ID: 'env-loses-001'
+    });
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.tool_name).toBe('Write');
+    expect(parsed.session_id).toBe('stdin-wins-789');
+    expect(parsed.tool_input_raw).toBe(JSON.stringify({ file_path: '/tmp/z', content: 'data' }));
+  });
+});

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -24,8 +24,30 @@
  *           stdout = advisory feedback shown to model
  */
 
-const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
-const TOOL_INPUT_RAW = process.env.CLAUDE_TOOL_INPUT || '';
+// QF-20260504-932: Read PreToolUse stdin payload synchronously at module load.
+// Per RCA #2 (2026-05-04), Claude Code does NOT propagate CLAUDE_TOOL_NAME,
+// CLAUDE_TOOL_INPUT, or CLAUDE_SESSION_ID env vars to PreToolUse hook
+// subprocesses — the canonical source is the JSON {session_id, tool_name,
+// tool_input, hook_event_name, ...} payload passed via stdin (verified contract
+// in lib/hooks/session-id.cjs JSDoc). Pre-fix, all 13 enforcement rules in
+// this file silently no-op'd because TOOL_NAME/TOOL_INPUT_RAW resolved to ''.
+//
+// fs.readFileSync(0) reads stdin sync to EOF. Claude Code closes stdin before
+// the hook process gets control, so this won't hang. Wrapped in try/catch:
+// any failure (no stdin, malformed JSON, etc) falls through to env vars.
+const _stdinPayload = (() => {
+  try {
+    const raw = require('fs').readFileSync(0, 'utf8');
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+})();
+
+const TOOL_NAME = _stdinPayload.tool_name || process.env.CLAUDE_TOOL_NAME || '';
+const TOOL_INPUT_RAW = _stdinPayload.tool_input != null
+  ? (typeof _stdinPayload.tool_input === 'string'
+      ? _stdinPayload.tool_input
+      : JSON.stringify(_stdinPayload.tool_input))
+  : (process.env.CLAUDE_TOOL_INPUT || '');
 
 // --- ENFORCEMENT 8: Permission Audit Trail (SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C) ---
 // Fire-and-forget async write to permission_audit_log table.
@@ -96,11 +118,27 @@ function auditPermissionDecision(sessionId, toolName, ruleCode, ruleDesc, outcom
   }
 }
 
-// Derive session ID once at module load time
-const _SESSION_ID = process.env.SESSION_ID ||
+// Derive session ID once at module load time. QF-20260504-932: stdin payload
+// (Claude Code's PreToolUse contract) takes precedence over env vars, which
+// are not propagated to PreToolUse subprocesses.
+const _SESSION_ID = _stdinPayload.session_id ||
+  process.env.SESSION_ID ||
   process.env.CLAUDE_SESSION_ID ||
   process.env.LEO_SESSION_ID ||
   'unknown';
+
+// QF-20260504-932: test-only mode — print resolved variables and exit before
+// any enforcement runs. Tests use this to verify stdin/env resolution without
+// triggering side-effects (audit writes, exit-2 blocks). Production hooks
+// never set TEST_DUMP_RESOLVED.
+if (process.env.TEST_DUMP_RESOLVED === '1') {
+  console.log(JSON.stringify({
+    tool_name: TOOL_NAME,
+    tool_input_raw: TOOL_INPUT_RAW,
+    session_id: _SESSION_ID
+  }));
+  process.exit(0);
+}
 
 // --- WORKTREE CLAIM GUARD (PAT-CLMMULTI-001) ---
 // Regex to detect paths inside .worktrees/<SD-KEY>/


### PR DESCRIPTION
## Summary

Restores all 13 LEO Protocol enforcement rules to fleet-wide operation. Pre-fix, the PreToolUse hook silently no-op'd because it read `process.env.CLAUDE_TOOL_NAME`, `CLAUDE_TOOL_INPUT`, and `CLAUDE_SESSION_ID` — **none of which Claude Code propagates to PreToolUse subprocesses** (verified by RCA #2 canary instrumentation 2026-05-04).

## Affected enforcement rules (all silently dead pre-fix)

1. NC-006 background execution ban
2. Tool policy profile validation
3. Sub-agent routing advisory
4. Worktree claim guard (PAT-CLMMULTI-001)
5. DB-only strategic artifacts
6. MCP write operation block
7. Schema pre-flight validation
8. Permission audit trail
9. SD creation skill enforcement (ENF-SD-CREATE-SKILL)
10. D1 Bugfix TDD Prove-It Gate
11. RCA Tiered Enforcement
12. npm install Concurrency Guard
13. Worktree Hygiene Guard (main/master block + dirty-tree warn)

All 13 rules silently allowed every tool call through with `TOOL_NAME=''`, so Bash/Edit/Write/Task gates never matched.

## Fix

Read PreToolUse stdin payload **synchronously** at module load via `fs.readFileSync(0, 'utf8')` + `JSON.parse`. The verified PreToolUse contract (per `lib/hooks/session-id.cjs` JSDoc, RCA #2) is:
```
{ session_id, transcript_path, cwd, permission_mode, agent_id, agent_type,
  hook_event_name, tool_name, tool_input, tool_use_id }
```

Module-level constants `TOOL_NAME` / `TOOL_INPUT_RAW` / `_SESSION_ID` now resolve **stdin-first with env-var fallback** for non-stdin invocations (manual node calls, tests). `tool_input` from stdin is an object — `JSON.stringify` back into `TOOL_INPUT_RAW` so existing `JSON.parse(TOOL_INPUT_RAW)` at line 295 still works without downstream changes.

Test-only `TEST_DUMP_RESOLVED=1` mode prints resolved `{tool_name, tool_input_raw, session_id}` and exits 0 before enforcement runs. Production invocations never set this env var.

## Test plan (test-first, all 6 cases failed before fix, pass after)

- [x] **ENF-STDIN-1**: `tool_name` from stdin populates `TOOL_NAME`
- [x] **ENF-STDIN-2**: `tool_input` object → `TOOL_INPUT_RAW` JSON string
- [x] **ENF-STDIN-3**: `session_id` from stdin populates `_SESSION_ID`
- [x] **ENF-STDIN-4**: empty stdin → env fallback works
- [x] **ENF-STDIN-5**: malformed stdin JSON → graceful env fallback, no throw, exit 0
- [x] **ENF-STDIN-6**: stdin precedence (stdin wins when both set)
- [x] **110/111 across 11 test files** — zero regressions in coordination-inbox, signal-router, resolve, post-tool-*, session-id

## Sizing
- **Tier 1 QF**, ~22 LOC src + 119 LOC tests
- No risk keywords (auth/migration/schema/feature)

Closes feedback row `267e0631` (HIGH severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)