### PR TITLE
fix(QF-20260504-840): UserPromptSubmit stdin ports for autonomous-checkpoint + session-cleanup (closes 26559fbb + d9b70e54)

### DIFF
--- a/scripts/hooks/__tests__/autonomous-checkpoint.test.js
+++ b/scripts/hooks/__tests__/autonomous-checkpoint.test.js
@@ -1,0 +1,59 @@
+// Tests for QF-20260504-840 — autonomous-checkpoint.js stdin port
+// Pre-fix: read process.env.CLAUDE_SESSION_ID (never propagated by Claude Code
+// to UserPromptSubmit subprocesses) → all peers collided on session-default.json.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+const HOOK_PATH = path.resolve(__dirname, '../autonomous-checkpoint.js').replace(/\\/g, '/');
+
+function spawnHook(stdinPayload, extraEnv = {}) {
+  const { spawn } = require('node:child_process');
+  const probe = spawn('node', [HOOK_PATH], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, TEST_DUMP_RESOLVED: '1', ...extraEnv }
+  });
+  if (stdinPayload === null) probe.stdin.end();
+  else probe.stdin.end(stdinPayload);
+  return new Promise((resolve) => {
+    let stdout = ''; let stderr = '';
+    probe.stdout.on('data', c => { stdout += c; });
+    probe.stderr.on('data', c => { stderr += c; });
+    probe.on('close', code => resolve({ stdout, stderr, code }));
+  });
+}
+
+describe('QF-840 CKPT-STDIN-1: session_id from stdin populates SESSION_ID', () => {
+  it('reads session_id from UserPromptSubmit stdin payload', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'ckpt-stdin-1-abc',
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'test'
+    }), { CLAUDE_SESSION_ID: '' });
+    expect(JSON.parse(r.stdout).session_id).toBe('ckpt-stdin-1-abc');
+  });
+});
+
+describe('QF-840 CKPT-STDIN-2: empty stdin → env fallback', () => {
+  it('falls back to CLAUDE_SESSION_ID env when stdin empty', async () => {
+    const r = await spawnHook(null, { CLAUDE_SESSION_ID: 'env-ckpt-002' });
+    expect(JSON.parse(r.stdout).session_id).toBe('env-ckpt-002');
+  });
+});
+
+describe('QF-840 CKPT-STDIN-3: malformed stdin → env fallback, no throw', () => {
+  it('does not crash on malformed stdin', async () => {
+    const r = await spawnHook('not json {{{', { CLAUDE_SESSION_ID: 'malformed-ckpt-003' });
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout).session_id).toBe('malformed-ckpt-003');
+  });
+});
+
+describe('QF-840 CKPT-STDIN-4: stdin precedence over env', () => {
+  it('stdin session_id wins when both present', async () => {
+    const r = await spawnHook(JSON.stringify({ session_id: 'stdin-wins-ckpt' }), {
+      CLAUDE_SESSION_ID: 'env-loses-ckpt'
+    });
+    expect(JSON.parse(r.stdout).session_id).toBe('stdin-wins-ckpt');
+  });
+});

--- a/scripts/hooks/__tests__/session-cleanup.test.js
+++ b/scripts/hooks/__tests__/session-cleanup.test.js
@@ -1,0 +1,50 @@
+// Tests for QF-20260504-840 — session-cleanup.js stdin port
+// Pre-fix: same env-var bug → SESSION_ID collided to 'default' across peers,
+// risking deletion of peer session marker files during cleanup walk.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+const HOOK_PATH = path.resolve(__dirname, '../session-cleanup.js').replace(/\\/g, '/');
+
+function spawnHook(stdinPayload, extraEnv = {}) {
+  const { spawn } = require('node:child_process');
+  const probe = spawn('node', [HOOK_PATH], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, TEST_DUMP_RESOLVED: '1', ...extraEnv }
+  });
+  if (stdinPayload === null) probe.stdin.end();
+  else probe.stdin.end(stdinPayload);
+  return new Promise((resolve) => {
+    let stdout = ''; let stderr = '';
+    probe.stdout.on('data', c => { stdout += c; });
+    probe.stderr.on('data', c => { stderr += c; });
+    probe.on('close', code => resolve({ stdout, stderr, code }));
+  });
+}
+
+describe('QF-840 CLEANUP-STDIN-1: session_id from stdin populates SESSION_ID', () => {
+  it('reads session_id from UserPromptSubmit stdin', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'cleanup-stdin-1-abc',
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'test'
+    }), { CLAUDE_SESSION_ID: '' });
+    expect(JSON.parse(r.stdout).session_id).toBe('cleanup-stdin-1-abc');
+  });
+});
+
+describe('QF-840 CLEANUP-STDIN-2: empty stdin → env fallback', () => {
+  it('falls back to env when stdin empty', async () => {
+    const r = await spawnHook(null, { CLAUDE_SESSION_ID: 'env-cleanup-002' });
+    expect(JSON.parse(r.stdout).session_id).toBe('env-cleanup-002');
+  });
+});
+
+describe('QF-840 CLEANUP-STDIN-3: malformed stdin → env fallback, no throw', () => {
+  it('does not crash on malformed stdin', async () => {
+    const r = await spawnHook('not json {{{', { CLAUDE_SESSION_ID: 'malformed-cleanup-003' });
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout).session_id).toBe('malformed-cleanup-003');
+  });
+});

--- a/scripts/hooks/autonomous-checkpoint.js
+++ b/scripts/hooks/autonomous-checkpoint.js
@@ -28,10 +28,31 @@ import { execSync } from 'child_process';
 const THRESHOLD = parseInt(process.env.LEO_CHECKPOINT_THRESHOLD || '20');
 const ENABLED = process.env.LEO_CHECKPOINT_ENABLED !== 'false';
 
+// QF-20260504-840: Read UserPromptSubmit stdin payload synchronously at module
+// load. Per RCA #2 (2026-05-04), Claude Code does NOT propagate
+// CLAUDE_SESSION_ID env var to UserPromptSubmit hook subprocesses — the
+// canonical source is the JSON {session_id, ...} payload via stdin.
+// Pre-fix, all peer sessions collided on session-default.json counter file.
+// fs.readFileSync(0) reads stdin sync to EOF; Claude Code closes stdin before
+// hook runs so this won't hang. Failure falls through to env then 'default'.
+const _stdinPayload = (() => {
+  try {
+    const raw = fs.readFileSync(0, 'utf8');
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+})();
+
 // Counter file location - session-specific
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || 'default';
+const SESSION_ID = _stdinPayload.session_id || process.env.CLAUDE_SESSION_ID || 'default';
 const COUNTER_DIR = path.join(os.tmpdir(), 'leo-checkpoints');
 const COUNTER_FILE = path.join(COUNTER_DIR, `session-${SESSION_ID}.json`);
+
+// QF-20260504-840: test-only mode — print resolved SESSION_ID and exit before
+// any side-effects. Tests use this to verify stdin resolution.
+if (process.env.TEST_DUMP_RESOLVED === '1') {
+  console.log(JSON.stringify({ session_id: SESSION_ID }));
+  process.exit(0);
+}
 
 // ============================================================================
 // HELPER FUNCTIONS

--- a/scripts/hooks/session-cleanup.js
+++ b/scripts/hooks/session-cleanup.js
@@ -22,7 +22,24 @@ import os from 'os';
 // CONFIGURATION
 // ============================================================================
 
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || 'default';
+// QF-20260504-840: Read UserPromptSubmit stdin payload at module load (see
+// autonomous-checkpoint.js for full rationale). Pre-fix, peer sessions all
+// resolved to SESSION_ID='default' and could delete each other's marker files
+// during the cleanup walk at lines 57-78.
+const _stdinPayload = (() => {
+  try {
+    const raw = fs.readFileSync(0, 'utf8');
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+})();
+
+const SESSION_ID = _stdinPayload.session_id || process.env.CLAUDE_SESSION_ID || 'default';
+
+// QF-20260504-840: test-only mode for stdin-resolution verification.
+if (process.env.TEST_DUMP_RESOLVED === '1') {
+  console.log(JSON.stringify({ session_id: SESSION_ID }));
+  process.exit(0);
+}
 const MAX_AGE_MS = 6 * 60 * 60 * 1000; // 6 hours - files older than this are stale
 
 // Locations to clean


### PR DESCRIPTION
Bundle two MEDIUM-severity stdin ports following the same pattern as QF-765/932. Closes feedback rows 26559fbb + d9b70e54. Eliminates peer-session collision on shared SESSION_ID='default' counter file + cleanup-walker peer-state deletion risk. 7/7 new tests + zero regressions. Tier 1 QF, ~36 LOC src + 96 LOC tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)