### PR TITLE
fix(QF-20260504-032): correct sd-id-resolver import path in 3 handoff gate validators

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js
@@ -69,7 +69,7 @@ export function registerAdditionalValidators(registry) {
 
     // Check if this SD type should skip sub-agent orchestration validation
     // SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001: Use canonical resolver.
-    const { resolveSdInputOrNull } = await import('../../../../lib/sd-id-resolver.js');
+    const { resolveSdInputOrNull } = await import('../../../../../lib/sd-id-resolver.js');
     const { sd: sdData } = await resolveSdInputOrNull(sd_id, supabase);
 
     // SD-LEO-FIX-COMPLETION-WORKFLOW-001: Skip for documentation-only SDs
@@ -207,7 +207,7 @@ export function registerAdditionalValidators(registry) {
     // SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001: Use canonical resolver.
     let sdType = (sd?.sd_type || '').toLowerCase();
     if (!sdType && sd_id) {
-      const { resolveSdInputOrNull } = await import('../../../../lib/sd-id-resolver.js');
+      const { resolveSdInputOrNull } = await import('../../../../../lib/sd-id-resolver.js');
       const { sd: sdData } = await resolveSdInputOrNull(sd_id, supabase);
       sdType = (sdData?.sd_type || '').toLowerCase();
     }

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -265,7 +265,7 @@ export function registerGate2Validators(registry) {
 
     // Check if this SD type should skip code validation
     // SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001: Use canonical resolver.
-    const { resolveSdInputOrNull } = await import('../../../../lib/sd-id-resolver.js');
+    const { resolveSdInputOrNull } = await import('../../../../../lib/sd-id-resolver.js');
     const { sd: sdData } = await resolveSdInputOrNull(sd_id, supabase);
 
     if (sdData && shouldSkipCodeValidation(sdData)) {


### PR DESCRIPTION
## Summary

`gate-2-implementation-fidelity.js:268` and `additional-validators.js:72,210` import from `'../../../../lib/sd-id-resolver.js'` which resolves to `scripts/modules/lib/sd-id-resolver.js` (does not exist). Canonical file is `scripts/lib/sd-id-resolver.js` — needed one more `'../'`.

Blocks EXEC-TO-PLAN handoffs across all SDs; bypass currently required (witnessed on SD-PRIVACYPATROL-...-001-B3 and SD-LEO-FEAT-S20-VERDICT-BLOCK-UI-001).

## Sites fixed
- `scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js:268`
- `scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:72`
- `scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:210`

## Test plan
- [x] Path resolution smoke test: both files now resolve to `scripts/lib/sd-id-resolver.js` which exists.
- [x] Module load smoke test: `await import(...)` of both modules succeeds.
- [ ] Pre-existing `tests/unit/stage-gates-ext.test.js` failures (`logger.warn is not a function` in `lib/agents/modules/venture-state-machine/stage-gates.js:223`) are unrelated to this fix and exist on origin/main — verified by stashing the QF diff and re-running on origin/main copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)