### PR TITLE
fix(QF-20260504-501): align complete-quick-fix LOC hard cap with CLAUDE.md routing

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -162,7 +162,8 @@ export function autoDetectGitInfo(testDir, options = {}) {
 
     if (!result.actualLoc) {
       // gh additions+deletions overcounts vs git --shortstat for renames, but feeds the
-      // 50-LOC hard-cap fail-safely (stricter, never under-rejects).
+      // QF hard-cap (see QF_HARD_LOC_CAP in verification.js) fail-safely (stricter,
+      // never under-rejects).
       const additions = typeof pr.additions === 'number' ? pr.additions : 0;
       const deletions = typeof pr.deletions === 'number' ? pr.deletions : 0;
       result.actualLoc = additions + deletions;

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -7,7 +7,13 @@ import path from 'path';
 import { execSync } from 'child_process';
 
 /**
- * Validate LOC constraint (hard cap at 50)
+ * Hard cap on QF size. Aligned with CLAUDE.md routing: Tier 1 ≤30,
+ * Tier 2 31–75 (Standard QF), Tier 3 >75 (full SD). QF-20260504-501.
+ */
+export const QF_HARD_LOC_CAP = 75;
+
+/**
+ * Validate LOC constraint against the QF hard cap (CLAUDE.md routing).
  * @param {number} actualLoc - Actual lines of code
  * @param {string} qfId - Quick-fix ID
  * @param {object} supabase - Supabase client
@@ -15,13 +21,13 @@ import { execSync } from 'child_process';
  * @returns {Promise<boolean>} True if validation passed, false if should exit
  */
 export async function validateLOC(actualLoc, qfId, supabase, prompt) {
-  if (actualLoc <= 50) {
+  if (actualLoc <= QF_HARD_LOC_CAP) {
     return true;
   }
 
   console.log('\n❌ CANNOT COMPLETE - LOC EXCEEDS LIMIT\n');
   console.log(`   Actual LOC: ${actualLoc}`);
-  console.log('   Limit:      50\n');
+  console.log(`   Limit:      ${QF_HARD_LOC_CAP}\n`);
   console.log('⚠️  This issue must be escalated to a full Strategic Directive.\n');
 
   const escalate = await prompt('Auto-escalate to SD? (yes/no): ');
@@ -31,7 +37,7 @@ export async function validateLOC(actualLoc, qfId, supabase, prompt) {
       .from('quick_fixes')
       .update({
         status: 'escalated',
-        escalation_reason: `Actual LOC (${actualLoc}) exceeds 50 line hard cap`,
+        escalation_reason: `Actual LOC (${actualLoc}) exceeds ${QF_HARD_LOC_CAP} line hard cap`,
         actual_loc: actualLoc
       })
       .eq('id', qfId);
@@ -46,7 +52,7 @@ export async function validateLOC(actualLoc, qfId, supabase, prompt) {
     return false;
   }
 
-  console.log('\n⚠️  Quick-fix not completed. Reduce LOC to ≤50 or escalate.\n');
+  console.log(`\n⚠️  Quick-fix not completed. Reduce LOC to ≤${QF_HARD_LOC_CAP} or escalate.\n`);
   return false;
 }
 

--- a/tests/unit/complete-quick-fix/validate-loc.test.js
+++ b/tests/unit/complete-quick-fix/validate-loc.test.js
@@ -1,0 +1,43 @@
+// Tests for QF-20260504-501 — validateLOC hard cap aligned with CLAUDE.md routing.
+// Pre-fix: cap was 50, but CLAUDE.md says Tier 2 Standard QF spans 31–75 LOC and
+// Tier 3 (>75) is full SD. Post-fix: cap is 75. QFs at 31–75 LOC must validate.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { validateLOC, QF_HARD_LOC_CAP } = await import(
+  '../../../scripts/modules/complete-quick-fix/verification.js'
+);
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+describe('QF-501 LOC-CAP-1: hard cap matches CLAUDE.md routing (Tier 3 = >75)', () => {
+  it('exports QF_HARD_LOC_CAP === 75', () => {
+    expect(QF_HARD_LOC_CAP).toBe(75);
+  });
+});
+
+describe('QF-501 LOC-CAP-2: 31–75 LOC (Tier 2 Standard QF) is accepted', () => {
+  it('returns true for 75 LOC (boundary)', async () => {
+    const r = await validateLOC(75, 'QF-X', null, async () => 'no');
+    expect(r).toBe(true);
+  });
+  it('returns true for 60 LOC (mid-Tier 2)', async () => {
+    const r = await validateLOC(60, 'QF-X', null, async () => 'no');
+    expect(r).toBe(true);
+  });
+  it('returns true for 51 LOC (was rejected pre-fix)', async () => {
+    const r = await validateLOC(51, 'QF-X', null, async () => 'no');
+    expect(r).toBe(true);
+  });
+});
+
+describe('QF-501 LOC-CAP-3: >75 LOC (Tier 3) still rejected', () => {
+  it('returns false for 76 LOC and prompts for escalation', async () => {
+    const prompt = vi.fn(async () => 'no');
+    const r = await validateLOC(76, 'QF-X', null, prompt);
+    expect(r).toBe(false);
+    expect(prompt).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- validateLOC hard cap was 50, but CLAUDE.md routing says Tier 2 Standard QF spans 31–75 LOC and Tier 3 starts at >75. The mismatch auto-escalated mechanically simple QFs that included test files (witnessed on QF-251 today, source feedback 6ac7c1b5).
- Extract QF_HARD_LOC_CAP=75 constant from verification.js; gate logic, escalation_reason, and reduce-LOC-or-escalate copy reference the constant.
- Update inline 50-LOC comment in git-operations.js to point at the constant.

## Test plan
- [x] `npx vitest run tests/unit/complete-quick-fix/validate-loc.test.js` — 5/5 pass.
- [x] Boundary cases: 51, 60, 75 LOC accepted (rejected pre-fix); 76 LOC still rejected and prompts for escalation.
- [x] No behavior change at the 75 boundary: matches CLAUDE.md \"Tier 3 = full SD\" routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)