### PR TITLE
feat(QF-20260504-663): add --repo flag to worktree-reaper.mjs

### DIFF
--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -82,6 +82,7 @@ function parseArgs(argv) {
     help: args.includes('--help') || args.includes('-h'),
     days: DEFAULT_IDLE_DAYS,
     preserveRoot: null,
+    repo: null,
   };
   const daysIdx = args.findIndex((a) => a === '--days');
   if (daysIdx !== -1 && args[daysIdx + 1]) {
@@ -91,6 +92,10 @@ function parseArgs(argv) {
   const prIdx = args.findIndex((a) => a === '--preserve-root');
   if (prIdx !== -1 && args[prIdx + 1]) {
     opts.preserveRoot = args[prIdx + 1];
+  }
+  const repoIdx = args.findIndex((a) => a === '--repo');
+  if (repoIdx !== -1 && args[repoIdx + 1]) {
+    opts.repo = args[repoIdx + 1];
   }
   return opts;
 }
@@ -107,6 +112,8 @@ Options:
   --yes                 Skip interactive confirmation for Stage 2
   --days <n>            Idle threshold in days (default: ${DEFAULT_IDLE_DAYS})
   --preserve-root <p>   Override preserve destination root (default: scratch/preserved-from-*)
+  --repo <path>         Run against a different repo (chdir before scanning); useful when
+                        the target repo's quota is full but you can't easily cd into it
   --phantom-only        Legacy mode: only report phantoms (missing dirs / prunable)
   --verbose, -v         Include per-worktree detector trace in the table
   --help, -h            Show this help
@@ -543,6 +550,16 @@ export async function main(argv = process.argv) {
   if (opts.help) {
     console.log(HELP);
     return 0;
+  }
+
+  if (opts.repo) {
+    const target = path.resolve(opts.repo);
+    if (!fs.existsSync(target)) {
+      console.error(`❌ --repo path does not exist: ${target}`);
+      return 2;
+    }
+    try { process.chdir(target); }
+    catch (e) { console.error(`❌ Cannot chdir to --repo ${target}: ${e.message}`); return 2; }
   }
 
   loadDotenv();


### PR DESCRIPTION
## Summary

Adds \`--repo <path>\` to \`worktree-reaper.mjs\`. Reaper used to derive \`repoRoot\` exclusively from \`process.cwd()\`, so scanning a non-current repo required cd-ing in. With Bash tool resetting cwd between calls, this was effectively unreachable.

## Why

Witnessed earlier today: \`SD-PRIVACYPATROL-...-001-E\` failed sd-start with EHG quota 21/20. Reaper invocation reported only EHG_Engineer worktrees because cwd was EHG_Engineer. No clean way to invoke it against EHG.

## Change (17 LOC, parseArgs + HELP + chdir)

- \`parseArgs\`: read \`--repo <path>\` into \`opts.repo\`
- \`HELP\`: document the flag
- \`main()\`: validate path exists + \`process.chdir(target)\` before \`assertCwdIsMainRepoRoot()\`

## Smoke test

\`\`\`
$ node scripts/worktree-reaper.mjs --repo /c/Users/rickf/Projects/_EHG/ehg
   Repo root: C:/Users/rickf/Projects/_EHG/ehg
   Worktrees scanned: 20
   Stage 1 (auto-safe):       12
   Stage 2 (analyzed):        7
   Kept (including active):   1
\`\`\`

Closes harness-backlog \`ef6db861\`.

## Test plan
- [x] Smoke test against EHG repo passes
- [x] Smoke test against EHG_Engineer (no flag) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)