### PR TITLE
fix(QF-20260504-749): mtime fallback + null-resolution canary in session-id.cjs

### DIFF
--- a/lib/hooks/__tests__/session-id-mtime-fallback.test.js
+++ b/lib/hooks/__tests__/session-id-mtime-fallback.test.js
@@ -1,0 +1,81 @@
+// Tests for QF-20260504-749 — readLatestMarkerByMtime fallback +
+// logNullResolution diagnostic canary in lib/hooks/session-id.cjs.
+// Closes deferred bundle from feedback 7f49b45f.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const helper = require(path.resolve(__dirname, '../session-id.cjs'));
+const { readLatestMarkerByMtime, logNullResolution } = helper;
+
+let tmpRoot;
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qf749-'));
+});
+afterEach(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe('QF-749 MTIME-1: returns null when markerDir does not exist', () => {
+  it('does not throw, returns null', () => {
+    expect(readLatestMarkerByMtime(path.join(tmpRoot, 'missing'))).toBeNull();
+  });
+});
+
+describe('QF-749 MTIME-2: picks newest marker by mtime', () => {
+  it('returns session_id from the most-recently-modified marker', () => {
+    const mk = (name, sid, mtime) => {
+      const p = path.join(tmpRoot, name);
+      fs.writeFileSync(p, JSON.stringify({ session_id: sid }));
+      fs.utimesSync(p, mtime / 1000, mtime / 1000);
+    };
+    mk('pid-100.json', 'older-session-aaaa', Date.now() - 60_000);
+    mk('pid-200.json', 'newer-session-bbbb', Date.now());
+    mk('pid-150.json', 'middle-session-cccc', Date.now() - 30_000);
+    expect(readLatestMarkerByMtime(tmpRoot)).toBe('newer-session-bbbb');
+  });
+});
+
+describe('QF-749 MTIME-3: skips invalid marker, falls through to next', () => {
+  it('ignores marker with invalid session_id and returns the next valid one', () => {
+    const newest = path.join(tmpRoot, 'pid-300.json');
+    fs.writeFileSync(newest, JSON.stringify({ session_id: 'INVALID@SID!' }));
+    fs.utimesSync(newest, Date.now() / 1000, Date.now() / 1000);
+    const older = path.join(tmpRoot, 'pid-100.json');
+    fs.writeFileSync(older, JSON.stringify({ session_id: 'valid-session-xyz' }));
+    fs.utimesSync(older, (Date.now() - 60_000) / 1000, (Date.now() - 60_000) / 1000);
+    expect(readLatestMarkerByMtime(tmpRoot)).toBe('valid-session-xyz');
+  });
+});
+
+describe('QF-749 MTIME-4: ignores non-marker files', () => {
+  it('only considers pid-*.json files', () => {
+    fs.writeFileSync(path.join(tmpRoot, 'random.json'), JSON.stringify({ session_id: 'should-be-ignored' }));
+    fs.writeFileSync(path.join(tmpRoot, 'pid-99.json'), JSON.stringify({ session_id: 'pid-marker-wins' }));
+    expect(readLatestMarkerByMtime(tmpRoot)).toBe('pid-marker-wins');
+  });
+});
+
+describe('QF-749 LOG-1: logNullResolution writes a JSON canary file', () => {
+  it('creates os.tmpdir/claude-hook-resolve-null/pid-<pid>-<ts>.json', () => {
+    const dir = path.join(os.tmpdir(), 'claude-hook-resolve-null');
+    const before = fs.existsSync(dir) ? fs.readdirSync(dir).length : 0;
+    logNullResolution({ stdin: false, env: false, marker: false, mtime: false });
+    const after = fs.readdirSync(dir).length;
+    expect(after).toBeGreaterThan(before);
+    const newest = fs.readdirSync(dir)
+      .map(f => ({ f, m: fs.statSync(path.join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.m - a.m)[0].f;
+    const data = JSON.parse(fs.readFileSync(path.join(dir, newest), 'utf8'));
+    expect(data.pid).toBe(process.pid);
+    expect(data.steps).toEqual({ stdin: false, env: false, marker: false, mtime: false });
+  });
+});
+
+describe('QF-749 LOG-2: logNullResolution swallows errors silently', () => {
+  it('does not throw even when fs.mkdirSync would fail', () => {
+    expect(() => logNullResolution({ steps: 'whatever' })).not.toThrow();
+  });
+});

--- a/lib/hooks/session-id.cjs
+++ b/lib/hooks/session-id.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execSync } = require('child_process');
 
@@ -131,6 +132,47 @@ function readSessionIdFromIdentityMarker(opts = {}) {
   } catch { return null; }
 }
 
+// QF-20260504-749 — Windows fallback when findClaudeCodeCcPid PowerShell scan
+// fails (process gone, slow CIM call, etc). Reads the most-recently-modified
+// pid-*.json marker in markerDir, on the assumption the active CC session
+// updated theirs most recently. Strictly weaker than ccPid lookup — only used
+// after that path returns null.
+function readLatestMarkerByMtime(markerDirArg) {
+  try {
+    const markerDir = markerDirArg || path.resolve(__dirname, '../../.claude/session-identity');
+    if (!fs.existsSync(markerDir)) return null;
+    const candidates = fs.readdirSync(markerDir)
+      .filter(f => f.startsWith('pid-') && f.endsWith('.json'))
+      .map(f => {
+        try { return { f, mtime: fs.statSync(path.join(markerDir, f)).mtimeMs }; }
+        catch { return null; }
+      })
+      .filter(Boolean)
+      .sort((a, b) => b.mtime - a.mtime);
+    for (const { f } of candidates) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(markerDir, f), 'utf8'));
+        if (isValidSessionId(data?.session_id)) return data.session_id;
+      } catch { /* keep trying */ }
+    }
+    return null;
+  } catch { return null; }
+}
+
+// QF-20260504-749 — diagnostic write-canary for null-resolution paths.
+// Writes a one-shot JSON file to os.tmpdir()/claude-hook-resolve-null/ with
+// {pid, ppid, ts, steps:{stdin,env,marker,mtime}} so future RCAs can tell why
+// a hook fired but resolveSessionId returned null. Best-effort, never throws.
+function logNullResolution(steps) {
+  try {
+    const dir = path.join(os.tmpdir(), 'claude-hook-resolve-null');
+    fs.mkdirSync(dir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    fs.writeFileSync(path.join(dir, `pid-${process.pid}-${ts}.json`),
+      JSON.stringify({ pid: process.pid, ppid: process.ppid, ts: new Date().toISOString(), steps }));
+  } catch { /* best-effort */ }
+}
+
 async function resolveSessionId(timeoutMs = 250) {
   const fromStdin = await readSessionIdFromStdin(timeoutMs);
   if (isValidSessionId(fromStdin)) return fromStdin;
@@ -139,11 +181,19 @@ async function resolveSessionId(timeoutMs = 250) {
   // QF-20260504-297: 3rd fallback — canonical marker dir. Test overrides via
   // QF297_MARKER_DIR_OVERRIDE / QF297_CCPID_OVERRIDE so spawned children can
   // exercise the fallback against a tmp dir without touching real markers.
+  const markerDirOverride = process.env.QF297_MARKER_DIR_OVERRIDE || undefined;
   const fromMarker = readSessionIdFromIdentityMarker({
-    markerDir: process.env.QF297_MARKER_DIR_OVERRIDE || undefined,
+    markerDir: markerDirOverride,
     ccPid: process.env.QF297_CCPID_OVERRIDE || undefined
   });
   if (isValidSessionId(fromMarker)) return fromMarker;
+  // QF-20260504-749: 4th fallback — latest marker by mtime when ccPid lookup
+  // failed (PowerShell scan gone awry on Windows). Strictly weaker than #3.
+  const fromMtime = readLatestMarkerByMtime(markerDirOverride);
+  if (isValidSessionId(fromMtime)) return fromMtime;
+  if (process.env.QF749_DISABLE_NULL_LOG !== '1') {
+    logNullResolution({ stdin: false, env: false, marker: false, mtime: false });
+  }
   return null;
 }
 
@@ -153,5 +203,8 @@ module.exports = {
   isValidSessionId,
   // QF-20260504-297 — exposed for tests + direct use by coordination-inbox.cjs
   readSessionIdFromIdentityMarker,
-  findClaudeCodeCcPid
+  findClaudeCodeCcPid,
+  // QF-20260504-749 — exposed for tests
+  readLatestMarkerByMtime,
+  logNullResolution
 };


### PR DESCRIPTION
## Summary
- resolveSessionId already walks stdin → env → ccPid marker (QF-007 + QF-297). Two diagnostic gaps remained from feedback 7f49b45f:
  - PowerShell ccPid scan can fail mid-flight; add a 4th fallback `readLatestMarkerByMtime()` that picks the most-recently-modified pid-*.json marker. Strictly weaker than ccPid lookup; only kicks in after #3 returns null.
  - When all four steps miss, no on-disk evidence existed — diagnosing \"session_id null, hook silently no-ops\" was guesswork. Add `logNullResolution()` best-effort write-canary at `os.tmpdir/claude-hook-resolve-null/pid-<pid>-<ts>.json`. Silenced via `QF749_DISABLE_NULL_LOG=1`.

## Test plan
- [x] `npx vitest run lib/hooks/__tests__/session-id-mtime-fallback.test.js` — 6/6 pass.
- [x] `npx vitest run lib/hooks/__tests__/session-id.test.js` — 14/14 existing pass.
- [x] LOG-2 verifies the canary writer never throws (best-effort contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)