### PR TITLE
fix(QF-20260504-628): use ${CLAUDE_PROJECT_DIR} in settings.json hook paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/statusline.cjs"
+    "command": "node ${CLAUDE_PROJECT_DIR}/.claude/statusline.cjs"
   },
   "hooks": {
     "PreCompact": [
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/precompact-snapshot.ps1",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/scripts/hooks/precompact-snapshot.ps1",
             "timeout": 10
           }
         ]
@@ -23,32 +23,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/session-state-sync.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-state-sync.cjs",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/cleanup-orphaned-tasks.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/cleanup-orphaned-tasks.cjs",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/session-start-loader.ps1",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-start-loader.ps1",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/telemetry-auto-trigger.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/telemetry-auto-trigger.cjs",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/agent-compiler-hook.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/agent-compiler-hook.cjs",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/concurrent-session-worktree.cjs",
             "timeout": 10
           }
         ]
@@ -57,12 +57,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/capture-session-id.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/capture-session-id.cjs",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/session-register.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-register.cjs",
             "timeout": 5
           }
         ]
@@ -73,17 +73,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/context-compact-nudge.js --time-only --interval 10",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/context-compact-nudge.js --time-only --interval 10",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/coordination-inbox.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/coordination-inbox.cjs",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/post-tool-clear-telemetry.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-tool-clear-telemetry.cjs",
             "timeout": 3
           }
         ]
@@ -98,12 +98,12 @@
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/auto-learning-capture.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/auto-learning-capture.cjs",
             "timeout": 20
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/post-ship-enforcement.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-ship-enforcement.cjs",
             "timeout": 3
           }
         ]
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/migration-execution-reminder.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/migration-execution-reminder.cjs",
             "timeout": 5
           },
           {
@@ -140,7 +140,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/protocol-file-tracker.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/protocol-file-tracker.cjs",
             "timeout": 3
           }
         ]
@@ -150,7 +150,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/task-subagent-recorder.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/task-subagent-recorder.cjs",
             "timeout": 10
           }
         ]
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/post-tool-loop-state.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-tool-loop-state.cjs",
             "timeout": 5
           }
         ]
@@ -171,17 +171,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/set-activity-state.ps1 -State idle",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/.claude/set-activity-state.ps1 -State idle",
             "timeout": 2
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/stop-subagent-enforcement.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/stop-subagent-enforcement.js",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/auto-proceed-pause-lint.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/auto-proceed-pause-lint.cjs",
             "timeout": 5
           }
         ]
@@ -192,27 +192,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/session-cleanup.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-cleanup.js",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/set-activity-state.ps1 -State running",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/.claude/set-activity-state.ps1 -State running",
             "timeout": 2
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/autonomous-checkpoint.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/autonomous-checkpoint.js",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/auto-proceed-resume.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/auto-proceed-resume.js",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/context-compact-nudge.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/context-compact-nudge.js",
             "timeout": 3
           }
         ]
@@ -223,7 +223,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/set-activity-state.ps1 -State running",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/.claude/set-activity-state.ps1 -State running",
             "timeout": 2
           }
         ]
@@ -243,7 +243,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/pre-tool-enforce.cjs",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/pre-tool-enforce.cjs",
             "timeout": 3
           }
         ]
@@ -253,7 +253,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/task-recorder.js",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/task-recorder.js",
             "timeout": 5
           }
         ]

--- a/tests/unit/settings-claude-project-dir.test.js
+++ b/tests/unit/settings-claude-project-dir.test.js
@@ -1,0 +1,42 @@
+// QF-20260504-628 — guard against re-introduction of hardcoded absolute
+// paths in .claude/settings.json hook commands. Per Claude Code hooks
+// reference, ${CLAUDE_PROJECT_DIR} resolves per-worktree at exec time,
+// which is what we want for multi-worktree fleets. Hardcoded paths point
+// child worktrees at the parent's stale code (closes feedback 7c11211b).
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SETTINGS_PATH = path.resolve(__dirname, '../../.claude/settings.json');
+
+function allHookCommands() {
+  const j = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  return Object.values(j.hooks).flatMap(arr => arr.flatMap(g => g.hooks || [])).map(h => h.command);
+}
+
+describe('QF-628 SETTINGS-1: no hook command hardcodes the parent worktree path', () => {
+  it('rejects any /Users/.../EHG_Engineer/ or C:/Users/.../EHG_Engineer/ literal in commands', () => {
+    const offenders = allHookCommands().filter(c =>
+      /[A-Za-z]:[\\/]Users[\\/][^\s"']+[\\/]EHG_Engineer[\\/]/.test(c) ||
+      /\/Users\/[^\s"']+\/EHG_Engineer\//.test(c)
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('QF-628 SETTINGS-2: hook commands invoking project files use ${CLAUDE_PROJECT_DIR}', () => {
+  it('every hook command referencing scripts/ or lib/ goes through the variable', () => {
+    const offenders = allHookCommands().filter(c =>
+      /\b(scripts|lib)\//.test(c) && !/\$\{?CLAUDE_PROJECT_DIR\}?/.test(c)
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('QF-628 SETTINGS-3: statusLine command also uses ${CLAUDE_PROJECT_DIR}', () => {
+  it('statusLine.command is variable-relative', () => {
+    const j = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+    expect(j.statusLine.command).toMatch(/\$\{?CLAUDE_PROJECT_DIR\}?/);
+  });
+});


### PR DESCRIPTION
## Summary
- `.claude/settings.json` hardcoded the parent worktree's absolute path in 30 hook command strings + the statusLine command. In a multi-worktree fleet, child worktrees fire hooks but Claude Code executes the parent's stale code from those absolute paths — so post-merge fixes don't take effect for child sessions until the parent rebases.
- Replace `C:/Users/rickf/Projects/_EHG/EHG_Engineer/` with `${CLAUDE_PROJECT_DIR}/` (resolved per-worktree at exec time per the [Claude Code hooks reference](https://code.claude.com/docs/en/hooks.md)).
- Closes feedback 7c11211b.

## Test plan
- [x] `npx vitest run tests/unit/settings-claude-project-dir.test.js` — 3/3 pass.
- [x] No hook command references a literal Users/.../EHG_Engineer/ path.
- [x] Every hook referencing `scripts/` or `lib/` goes through the variable.
- [x] `statusLine.command` also variable-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)