### PR TITLE
fix(QF-20260504-830): exempt /coordinator scripts from pre-tool-enforce dedup

### DIFF
--- a/scripts/hooks/__tests__/retry-state-manager.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager.test.js
@@ -1,0 +1,105 @@
+// QF-20260504-830 — exempt /coordinator monitoring scripts from RCA-TIERED dedup.
+// Closes feedback id=57c7873e-09ff-4259-8761-7b6ebbf5d74b.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const MODULE_PATH = path.resolve(__dirname, '../retry-state-manager.cjs');
+
+function loadFresh() {
+  // CJS require cache lets us re-import after mutating env in tests.
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+describe('QF-830 isExempt: known-idempotent /coordinator monitoring scripts', () => {
+  const { isExempt } = loadFresh();
+
+  it('exempts stale-session-sweep.cjs', () => {
+    expect(isExempt('node scripts/stale-session-sweep.cjs')).toBe(true);
+  });
+
+  it('exempts fleet-dashboard.cjs with args', () => {
+    expect(isExempt('node scripts/fleet-dashboard.cjs all')).toBe(true);
+  });
+
+  it('exempts assign-fleet-identities.cjs', () => {
+    expect(isExempt('node scripts/assign-fleet-identities.cjs')).toBe(true);
+  });
+
+  it('exempts .claude/tmp/coord-*.cjs', () => {
+    expect(isExempt('node .claude/tmp/coord-resume-bulletin.cjs')).toBe(true);
+  });
+
+  it('exempts .claude/tmp/coord-*.mjs', () => {
+    expect(isExempt('node .claude/tmp/coord-foo.mjs')).toBe(true);
+  });
+
+  it('does NOT exempt non-monitoring scripts (preserves throttle)', () => {
+    expect(isExempt('node scripts/leo-create-sd.js')).toBe(false);
+  });
+
+  it('tolerates ./ path prefix', () => {
+    expect(isExempt('node ./scripts/stale-session-sweep.cjs')).toBe(true);
+  });
+
+  it('returns false for non-string / empty input', () => {
+    expect(isExempt(null)).toBe(false);
+    expect(isExempt(undefined)).toBe(false);
+    expect(isExempt('')).toBe(false);
+    expect(isExempt(42)).toBe(false);
+  });
+});
+
+describe('QF-830 recordAndCount: exempt commands skip record AND count', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf830-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns count=0 across 4 successive exempt invocations and writes nothing', async () => {
+    const { recordAndCount } = loadFresh();
+    const sessionId = 'qf830-exempt';
+    const sdKey = 'SD-FAKE';
+    const input = { command: 'node scripts/stale-session-sweep.cjs' };
+    const opts = { rcaCheck: async () => null };
+
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount(sessionId, sdKey, 'Bash', input, opts);
+      expect(r.attempts).toBe(0);
+      expect(r.rcaResetApplied).toBe(false);
+      expect(r.signature).toMatch(/^Bash:/);
+    }
+
+    // No state file should have been written for the exempt signature.
+    const stateFile = path.join(tmpDir, `retry-state-${sessionId}.json`);
+    if (fs.existsSync(stateFile)) {
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+      expect(state.invocations || {}).toEqual({});
+    }
+  });
+
+  it('returns counts 1,2,3,4 for non-exempt signature (existing behavior preserved)', async () => {
+    const { recordAndCount } = loadFresh();
+    const sessionId = 'qf830-throttled';
+    const sdKey = 'SD-FAKE';
+    const input = { command: 'node scripts/leo-create-sd.js --foo' };
+    const opts = { rcaCheck: async () => null };
+
+    const counts = [];
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount(sessionId, sdKey, 'Bash', input, opts);
+      counts.push(r.attempts);
+    }
+    expect(counts).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -25,6 +25,28 @@ const crypto = require('crypto');
 
 const RETRY_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 
+// QF-20260504-830 — known-idempotent monitoring commands are exempt from
+// signature dedup. RCA-TIERED ENFORCEMENT was tripping the 4th invocation of
+// /coordinator periodic probes (all exit 0) the same way it gates retry loops.
+// Patterns are matched against the raw Bash command string.
+const EXEMPT_PATTERNS = [
+  /\bscripts[/\\]stale-session-sweep\.cjs\b/,
+  /\bscripts[/\\]fleet-dashboard\.cjs\b/,
+  /\bscripts[/\\]assign-fleet-identities\.cjs\b/,
+  /[/\\]?\.claude[/\\]tmp[/\\]coord-[\w-]+\.(?:cjs|mjs)\b/,
+];
+
+/**
+ * Whether a Bash command should bypass invocation tracking entirely.
+ * Returns false for any non-string input.
+ * @param {string} commandStr
+ * @returns {boolean}
+ */
+function isExempt(commandStr) {
+  if (typeof commandStr !== 'string' || !commandStr) return false;
+  return EXEMPT_PATTERNS.some(rx => rx.test(commandStr));
+}
+
 /**
  * Resolve the on-disk state path for a session.
  * @param {string} sessionId
@@ -172,6 +194,10 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
     return { attempts: 0, signature: null, rcaResetApplied: false };
   }
 
+  if (toolName === 'Bash' && isExempt(toolInput && toolInput.command)) {
+    return { attempts: 0, signature, rcaResetApplied: false };
+  }
+
   const now = typeof opts.now === 'number' ? opts.now : Date.now();
   const rcaCheck = opts.rcaCheck || fetchRcaInvocationSince;
 
@@ -207,5 +233,6 @@ module.exports = {
   fetchRcaInvocationSince,
   pruneStale,
   stateFilePath,
+  isExempt,
   RETRY_WINDOW_MS
 };


### PR DESCRIPTION
## Summary
- Add `isExempt()` helper to `scripts/hooks/retry-state-manager.cjs` and wire it into `recordAndCount()` so known-idempotent /coordinator monitoring scripts skip RCA-TIERED dedup tracking entirely.
- Patterns covered: `scripts/stale-session-sweep.cjs`, `scripts/fleet-dashboard.cjs`, `scripts/assign-fleet-identities.cjs`, `.claude/tmp/coord-*.{cjs,mjs}`.
- Closes feedback id=`57c7873e-09ff-4259-8761-7b6ebbf5d74b` (CAPA Option A from the RCA finding).

## Why
ENFORCEMENT 11 (RCA-TIERED, `SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129`) was hard-blocking the 4th invocation of idempotent successful /coordinator monitoring scripts within a 10-minute rolling window. All four prior invocations exited 0 — the rule conflated benign periodic probes with the retry loops it was designed to gate. Coordinator/campaign sessions also can't trigger the DB-backed reset path (no SD claim → no `sd_key` → `fetchRcaInvocationSince` short-circuits).

## Scope (Tier 1 QF, 132 LOC)
- `scripts/hooks/retry-state-manager.cjs` (+27): `EXEMPT_PATTERNS` + `isExempt()` helper + early-return in `recordAndCount()` for Bash commands matching the allowlist; export added.
- `scripts/hooks/__tests__/retry-state-manager.test.js` (+105 new): 10 vitest cases covering pattern match, `./` path-prefix tolerance, non-string input, non-exempt throttle preservation, and 4-invocation integration for both exempt (count=0 each) and non-exempt (counts 1,2,3,4) signatures.

## Out of scope (deferred)
- CAPA Option B (post-tool `exit_code` wiring) and Option C (manual reset CLI).
- feedback id=`0e33f03c` — separate `ENF-SD-CREATE-SKILL` issue, same hook file but different rule.
- feedback id=`267e0631` — env-var-vs-stdin per-rule audit. RCA-TIERED branch is verifiably stdin-driven (it fired correctly on the 4th invocation), so 267e0631 needs narrowing rather than fixing here.

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/retry-state-manager.test.js` — 10/10 green
- [x] `npx vitest run scripts/hooks/__tests__/` — 79/80 green (1 todo, no regressions)
- [x] Pre-commit smoke tests pass (15/15)
- [ ] Post-merge verification: fresh /coordinator session runs each canonical script 4+ times within 10min — no T3.G blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)