### PR TITLE
fix(QF-20260504-195): auto-merge.mjs verifies mergedAt after exit 0

### DIFF
--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -69,6 +69,24 @@ export function buildMergeArgs(prNumber, { admin } = {}) {
 }
 
 /**
+ * Verify a PR is actually merged by re-fetching mergedAt.
+ *
+ * QF-20260504-195: `gh pr merge` can exit 0 in queued / auto-merge-label
+ * states without the merge actually completing. The exit code alone is not
+ * load-bearing — we must confirm `mergedAt` is non-null before declaring
+ * success. Returns true / false (false on lookup failure — safer fallback,
+ * forces fall-through to race-recovery).
+ */
+export function verifyMerged(prNumber, runner = defaultRunner) {
+  const r = runner(['pr', 'view', String(prNumber), '--json', 'mergedAt', '--jq', '.mergedAt']);
+  if (r.code !== 0) return false;
+  const trimmed = r.stdout.trim();
+  if (!trimmed) return false;
+  if (trimmed === 'null') return false;
+  return true;
+}
+
+/**
  * Top-level orchestrator. Returns:
  *   { ok: true, action: 'merged' | 'already-merged', adminUsed: boolean }
  *   { ok: false, reason: string, exitCode: number }
@@ -106,11 +124,19 @@ export async function attemptAutoMerge({
   const merge = runner(mergeArgs);
 
   if (merge.code === 0) {
-    logger.info(`✅ PR #${prNumber} merged and branch deleted`);
-    return { ok: true, action: 'merged', adminUsed: enforceAdmins };
+    if (verifyMerged(prNumber, runner)) {
+      logger.info(`✅ PR #${prNumber} merged and branch deleted`);
+      return { ok: true, action: 'merged', adminUsed: enforceAdmins };
+    }
+    // QF-20260504-195: gh pr merge exited 0 but mergedAt is null — the
+    // merge was queued / auto-merge-labeled / silently rejected. Fall
+    // through to state-check + hard-fail instead of trusting the exit code.
+    logger.warn(
+      `⚠️  gh pr merge exited 0 but mergedAt is null — verifying PR state before declaring success`,
+    );
   }
 
-  // 4. Non-zero exit — race recovery.
+  // 4. Non-zero exit OR exit-0-but-not-merged — race recovery.
   const stateRes = runner(['pr', 'view', String(prNumber), '--json', 'state', '--jq', '.state']);
   const state = stateRes.code === 0 ? stateRes.stdout.trim() : null;
 
@@ -121,15 +147,21 @@ export async function attemptAutoMerge({
     return { ok: true, action: 'already-merged', adminUsed: enforceAdmins };
   }
 
+  const silentSuccess = merge.code === 0;
+  const reason = silentSuccess
+    ? `silent-success: gh pr merge exit 0 but mergedAt null, state=${state ?? 'unknown'}`
+    : (merge.stderr.trim() || `merge exit ${merge.code}, state=${state ?? 'unknown'}`);
   logger.error(
-    `❌ gh pr merge failed (exit ${merge.code}, PR state=${state ?? 'unknown'}) — /ship HARD-FAIL`,
+    silentSuccess
+      ? `❌ gh pr merge silent-success regression (exit 0, mergedAt null, state=${state ?? 'unknown'}) — /ship HARD-FAIL`
+      : `❌ gh pr merge failed (exit ${merge.code}, PR state=${state ?? 'unknown'}) — /ship HARD-FAIL`,
   );
   logger.error(
     `   Manual recovery: gh pr ready ${prNumber} && gh pr merge ${prNumber} --merge --delete-branch --admin`,
   );
   return {
     ok: false,
-    reason: merge.stderr.trim() || `merge exit ${merge.code}, state=${state ?? 'unknown'}`,
-    exitCode: merge.code,
+    reason,
+    exitCode: silentSuccess ? 1 : merge.code,
   };
 }

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -12,6 +12,7 @@ import {
   detectDraftState,
   detectEnforceAdmins,
   buildMergeArgs,
+  verifyMerged,
 } from '../../../lib/ship/auto-merge.mjs';
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
@@ -35,6 +36,8 @@ function makeRunner(responses) {
 const argvMatchers = {
   prViewIsDraft: (args) =>
     args[0] === 'pr' && args[1] === 'view' && args.includes('isDraft'),
+  prViewMergedAt: (args) =>
+    args[0] === 'pr' && args[1] === 'view' && args.includes('mergedAt'),
   prViewState: (args) =>
     args[0] === 'pr' && args[1] === 'view' && args.includes('state'),
   prReady: (args) => args[0] === 'pr' && args[1] === 'ready',
@@ -115,6 +118,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.prReady, result: { stdout: '' } },
       { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -131,6 +135,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       ['pr', 'ready'],
       ['api', 'repos/rickfelix/EHG_Engineer/branches/main/protection'],
       ['pr', 'merge'],
+      ['pr', 'view'],
     ]);
     const mergeCall = calls.find(argvMatchers.prMerge);
     expect(mergeCall).toContain('--admin');
@@ -141,6 +146,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
       { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -160,6 +166,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
       { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -173,6 +180,79 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
     expect(r).toEqual({ ok: true, action: 'merged', adminUsed: false });
     const mergeCall = calls.find(argvMatchers.prMerge);
     expect(mergeCall).not.toContain('--admin');
+  });
+});
+
+describe('verifyMerged (QF-20260504-195)', () => {
+  it('returns true when mergedAt is a populated ISO timestamp', () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+    ]);
+    expect(verifyMerged(568, runner)).toBe(true);
+  });
+
+  it('returns false when gh emits the literal string "null" (PR not merged)', () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewMergedAt, result: { stdout: 'null\n' } },
+    ]);
+    expect(verifyMerged(568, runner)).toBe(false);
+  });
+
+  it('returns false on lookup failure (safer fallback)', () => {
+    const runner = () => ({ code: 1, stdout: '', stderr: 'auth required' });
+    expect(verifyMerged(568, runner)).toBe(false);
+  });
+
+  it('returns false on empty stdout', () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '' } },
+    ]);
+    expect(verifyMerged(568, runner)).toBe(false);
+  });
+});
+
+describe('attemptAutoMerge — silent-success regression (QF-20260504-195)', () => {
+  it('hard-fails when gh pr merge exits 0 but mergedAt is null and PR state is OPEN', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
+      { match: argvMatchers.prMerge, result: { code: 0, stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: 'null\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'OPEN\n' } },
+    ]);
+
+    const r = await attemptAutoMerge({
+      prNumber: 568,
+      repoOwner: 'rickfelix',
+      repoName: 'ehg',
+      runner,
+      logger: silentLogger,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(1);
+    expect(r.reason).toMatch(/silent-success/);
+    expect(r.reason).toMatch(/state=OPEN/);
+  });
+
+  it('recovers as already-merged when exit-0-mergedAt-null but state is MERGED (race)', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
+      { match: argvMatchers.prMerge, result: { code: 0, stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: 'null\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+    ]);
+
+    const r = await attemptAutoMerge({
+      prNumber: 568,
+      repoOwner: 'rickfelix',
+      repoName: 'ehg',
+      runner,
+      logger: silentLogger,
+    });
+
+    expect(r).toEqual({ ok: true, action: 'already-merged', adminUsed: true });
   });
 });
 
@@ -211,6 +291,8 @@ describe('attemptAutoMerge — race recovery (FR-4, TS-5)', () => {
         match: argvMatchers.prMerge,
         result: { code: 1, stderr: 'pull request not found in mergeable state' },
       },
+      // Non-zero exit short-circuits past verifyMerged into the race-recovery
+      // state check; no prViewMergedAt entry needed in this path.
       { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
     ]);
 


### PR DESCRIPTION
## Summary

- Closes silent-success regression class — same bug SD-LEO-INFRA-SHIP-AUTO-MERGE-001 (PR #3414) was supposed to close
- Witnessed 3x in 3 days (PRs #554, #564, #568): `gh pr merge` exits 0 in queued / auto-merge-label / mergeStateStatus=UNSTABLE states without actually merging
- After exit 0, now verifies `mergedAt` via `gh pr view`; when null but state=MERGED falls through to existing race-recovery (legitimate concurrent-merge); when null + state≠MERGED hard-fails with descriptive reason

## Scope

Tier 2 QF — 38 src LOC, 82 test LOC. 2 files touched:
- `lib/ship/auto-merge.mjs` — new `verifyMerged()` helper + post-exit-0 verification branch
- `tests/unit/ship/auto-merge.test.js` — 5 new cases (4 verifyMerged unit + 2 e2e silent-success), 3 happy-path tests updated to mock the new view call

## Test plan

- [x] 20/20 vitest pass (`tests/unit/ship/auto-merge.test.js`)
- [x] verifyMerged returns true on populated ISO timestamp
- [x] verifyMerged returns false on `null` literal / lookup failure / empty stdout
- [x] attemptAutoMerge hard-fails when exit 0 + mergedAt=null + state=OPEN
- [x] attemptAutoMerge recovers as already-merged when exit 0 + mergedAt=null + state=MERGED
- [ ] CI green (Vercel preflight + GitHub Actions)

## Notes

Branch suffixed `-v2` because the original `qf/QF-20260504-195` branch was first pushed from a stale base (parent commit predated 14 merged QFs); this branch was rebased onto current `origin/main` to avoid reverting QF-716 / QF-921 / QF-749 / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)