### PR TITLE
feat(SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001): redirect corrective findings to feedback table + triage CLI

### DIFF
--- a/database/migrations/20260504_feedback_corrective_columns.sql
+++ b/database/migrations/20260504_feedback_corrective_columns.sql
@@ -1,0 +1,46 @@
+-- SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 — PR1 of 5
+-- Adds 6 nullable columns to feedback table to support corrective-finding redirect.
+-- Findings from corrective-sd-generator and quality-findings/sd-generator now record
+-- here (category='corrective_finding') instead of inserting draft SDs into
+-- strategic_directives_v2. The triage CLI promotes selected findings to SDs.
+--
+-- Validated by DATABASE sub-agent run b2db4da3-dc33-4f85-b7eb-fcd1e0d088d2:
+--   - feedback table verified: 57 cols, 843 rows, NOT NULL{id, type, source_application,
+--     source_type, title, feedback_type}
+--   - All 6 proposed names confirmed not present (no collision)
+--   - ADD COLUMN nullable is non-blocking on PG 11+ (no table rewrite)
+--   - promoted_to_sd_id MUST be varchar(50) — feedback.sd_id/strategic_directive_id/
+--     resolution_sd_id all store sd_key strings, not UUIDs
+--
+-- Apply: supabase db query --linked --file database/migrations/20260504_feedback_corrective_columns.sql
+-- Rollback: ALTER TABLE feedback DROP COLUMN IF EXISTS x6 (see rollback block at end, commented)
+
+ALTER TABLE feedback
+  ADD COLUMN IF NOT EXISTS corrective_class    text,
+  ADD COLUMN IF NOT EXISTS source_gate         text,
+  ADD COLUMN IF NOT EXISTS gate_run_id         uuid,
+  ADD COLUMN IF NOT EXISTS promoted_to_sd_id   varchar(50),
+  ADD COLUMN IF NOT EXISTS promoted_at         timestamptz,
+  ADD COLUMN IF NOT EXISTS promoted_by         text;
+
+COMMENT ON COLUMN feedback.corrective_class IS
+  'Classification of corrective finding (vision_gap, arch_gap, lifecycle_feature, cli_validation, etc.). Set when category=corrective_finding. NULL for non-corrective rows.';
+COMMENT ON COLUMN feedback.source_gate IS
+  'Which gate detected the finding (eva_vision_score, eva_heal_score, s20_code_quality_gate). NULL for non-corrective rows.';
+COMMENT ON COLUMN feedback.gate_run_id IS
+  'Backref to the source gate run record (e.g., eva_vision_scores.id). NULL when source has no run-id concept. No FK constraint due to multi-source.';
+COMMENT ON COLUMN feedback.promoted_to_sd_id IS
+  'sd_key string of the SD created when triage CLI promoted this finding. NULL until promotion. varchar(50) matches feedback.sd_id semantics.';
+COMMENT ON COLUMN feedback.promoted_at IS
+  'Timestamp when triage CLI promoted this finding to an SD. Set together with promoted_to_sd_id.';
+COMMENT ON COLUMN feedback.promoted_by IS
+  'session_id of the operator who ran corrective-triage promote. Audit trail.';
+
+-- ROLLBACK (uncomment if needed):
+-- ALTER TABLE feedback
+--   DROP COLUMN IF EXISTS corrective_class,
+--   DROP COLUMN IF EXISTS source_gate,
+--   DROP COLUMN IF EXISTS gate_run_id,
+--   DROP COLUMN IF EXISTS promoted_to_sd_id,
+--   DROP COLUMN IF EXISTS promoted_at,
+--   DROP COLUMN IF EXISTS promoted_by;

--- a/database/migrations/20260504_feedback_corrective_index.sql
+++ b/database/migrations/20260504_feedback_corrective_index.sql
@@ -1,0 +1,22 @@
+-- SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 — PR1 of 5 (index, separate file)
+-- Adds partial index on (category, status) for triage CLI list queries.
+--
+-- MUST be a separate file because CREATE INDEX CONCURRENTLY cannot run inside
+-- a transaction (PostgreSQL constraint). The previous migration applies all
+-- ALTER TABLE statements transactionally; this one runs outside that boundary.
+--
+-- Validated by DATABASE sub-agent run b2db4da3:
+--   - Partial filter scopes to ~17% of feedback rows (excludes 671/843 ci_failure rows)
+--   - Column ordering (category, status) matches the triage CLI predicate
+--     category='corrective_finding' AND status='new'
+--   - CONCURRENTLY required for prod safety (no exclusive lock)
+--
+-- Apply: supabase db query --linked --file database/migrations/20260504_feedback_corrective_index.sql
+-- Rollback: DROP INDEX IF EXISTS idx_feedback_category_status;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_feedback_category_status
+  ON feedback (category, status)
+  WHERE category IN ('corrective_finding', 'harness_backlog');
+
+COMMENT ON INDEX idx_feedback_category_status IS
+  'Triage-list optimization. Partial filter excludes high-volume ci_failure / auto_capture rows. Used by corrective-triage CLI list and harness-backlog queries.';

--- a/lib/eva/corrective-finding-recorder.js
+++ b/lib/eva/corrective-finding-recorder.js
@@ -1,0 +1,121 @@
+/**
+ * corrective-finding-recorder.js
+ *
+ * Single-write entry point for corrective findings detected by EVA gates.
+ * Replaces the prior pattern of inserting draft SDs directly into
+ * strategic_directives_v2. Findings now persist in the feedback table
+ * (category='corrective_finding') and are promoted to SDs deliberately
+ * via scripts/corrective-triage.mjs.
+ *
+ * Part of: SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 (PR2 of 5)
+ * Pairs with: PR1 schema migration (20260504_feedback_corrective_*.sql)
+ */
+import { createHash } from 'crypto';
+
+/**
+ * Compute the natural-key dedup hash for a finding.
+ * Stable across re-invocations of the same gate run targeting the same source SD.
+ *
+ * @param {string|null} sourceSdId
+ * @param {string[]} dimensions
+ * @param {string|null} gateRunId
+ * @returns {string} 64-char hex sha256
+ */
+export function computeDedupHash(sourceSdId, dimensions, gateRunId) {
+  const dims = Array.isArray(dimensions) ? [...dimensions].sort().join(',') : '';
+  const payload = `${sourceSdId ?? 'null'}::${dims}::${gateRunId ?? 'null'}`;
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+/**
+ * Idempotently record a corrective finding to the feedback table.
+ *
+ * @param {Object} supabase - Supabase client (service role for INSERT)
+ * @param {Object} finding
+ * @param {string|null} finding.source_sd_id - sd_key of the source SD that scored low
+ * @param {string} finding.source_gate - 'eva_vision_score' | 'eva_heal_score' | 's20_code_quality_gate'
+ * @param {string|null} finding.gate_run_id - UUID of the run record (e.g., eva_vision_scores.id)
+ * @param {string} finding.corrective_class - 'vision_gap' | 'arch_gap' | 'lifecycle_feature' | 'cli_validation' | 'code_quality'
+ * @param {string[]} finding.dimensions - dimension codes (e.g., ['V03', 'A02'])
+ * @param {string} finding.tier - 'minor' | 'gap-closure' | 'escalation'
+ * @param {number|null} finding.score - numeric score 0-100
+ * @param {string} finding.title - human-readable summary
+ * @param {string} finding.description - detail text
+ * @param {Object} [finding.metadata] - extra payload merged into feedback.metadata
+ * @returns {Promise<{recorded: boolean, feedbackId: string, dedupHash: string}>}
+ */
+export async function recordCorrectiveFinding(supabase, finding) {
+  if (!finding || typeof finding !== 'object') {
+    throw new Error('recordCorrectiveFinding: finding object is required');
+  }
+  const {
+    source_sd_id = null,
+    source_gate,
+    gate_run_id = null,
+    corrective_class,
+    dimensions = [],
+    tier,
+    score = null,
+    title,
+    description = '',
+    metadata: extraMetadata = {},
+  } = finding;
+
+  if (!source_gate) throw new Error('recordCorrectiveFinding: source_gate is required');
+  if (!corrective_class) throw new Error('recordCorrectiveFinding: corrective_class is required');
+  if (!tier) throw new Error('recordCorrectiveFinding: tier is required');
+  if (!title || typeof title !== 'string') throw new Error('recordCorrectiveFinding: title is required');
+
+  const dedupHash = computeDedupHash(source_sd_id, dimensions, gate_run_id);
+
+  const { data: existing, error: lookupErr } = await supabase
+    .from('feedback')
+    .select('id')
+    .eq('metadata->>dedup_hash', dedupHash)
+    .eq('category', 'corrective_finding')
+    .limit(1)
+    .maybeSingle();
+
+  if (lookupErr) {
+    throw new Error(`recordCorrectiveFinding: dedup lookup failed: ${lookupErr.message}`);
+  }
+  if (existing) {
+    return { recorded: false, feedbackId: existing.id, dedupHash };
+  }
+
+  const severity = tier === 'escalation' ? 'high' : tier === 'gap-closure' ? 'medium' : 'low';
+  const row = {
+    type: 'issue',
+    source_application: 'EHG_Engineer',
+    source_type: 'auto_capture',
+    feedback_type: 'corrective_finding',
+    title: title.slice(0, 500),
+    description: description.slice(0, 5000),
+    category: 'corrective_finding',
+    status: 'new',
+    severity,
+    corrective_class,
+    source_gate,
+    gate_run_id,
+    metadata: {
+      ...extraMetadata,
+      dedup_hash: dedupHash,
+      source_sd_id,
+      dimensions: [...dimensions].sort(),
+      tier,
+      score,
+      logged_via: 'corrective-finding-recorder',
+    },
+  };
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from('feedback')
+    .insert(row)
+    .select('id')
+    .single();
+
+  if (insertErr) {
+    throw new Error(`recordCorrectiveFinding: insert failed: ${insertErr.message}`);
+  }
+  return { recorded: true, feedbackId: inserted.id, dedupHash };
+}

--- a/lib/eva/event-bus/vision-events.js
+++ b/lib/eva/event-bus/vision-events.js
@@ -37,6 +37,18 @@ export const VISION_EVENTS = {
   GAP_DETECTED: 'vision.gap_detected',
   /** Emitted when scoreSD() generates a corrective SD — payload: {originSdKey, correctedSdKey, supabase} */
   CORRECTIVE_SD_CREATED: 'vision.corrective_sd_created',
+  /**
+   * Emitted when corrective-sd-generator records a finding to feedback (replaces direct SD-emission).
+   * Payload: {originSdKey, feedbackId, recorded, scoreId, action, dimensions, label, correctiveClass, sourceGate}
+   * SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001
+   */
+  CORRECTIVE_FINDING_RECORDED: 'vision.corrective_finding_recorded',
+  /**
+   * Emitted when corrective-triage CLI promotes a feedback finding to an SD.
+   * Payload: {originSdKey, feedbackId, correctiveSdKey, promotedBy}
+   * SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001
+   */
+  CORRECTIVE_PROMOTED_TO_SD: 'vision.corrective_promoted_to_sd',
   /** Emitted when process-gap-reporter detects a process gap — payload: {gapType, description, supabase} */
   PROCESS_GAP_DETECTED: 'vision.process_gap_detected',
   /**

--- a/scripts/corrective-triage.mjs
+++ b/scripts/corrective-triage.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * corrective-triage.mjs
+ *
+ * Operator-facing CLI for triaging corrective findings recorded by
+ * corrective-sd-generator. Subcommands:
+ *   list                       List open corrective findings
+ *   promote <feedback-id>      Promote a finding to a real SD
+ *   dismiss <feedback-id>      Mark a finding as wont_fix
+ *   bulk-dismiss --class <c>   Mark all matching findings wont_fix
+ *
+ * Replaces the prior pattern where corrective-sd-generator emitted draft SDs
+ * directly. SD creation now happens deliberately via this CLI.
+ *
+ * Part of: SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 (PR4 of 5)
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { publishVisionEvent, VISION_EVENTS } from '../lib/eva/event-bus/vision-events.js';
+import { createSD } from './leo-create-sd.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../.env') });
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, key);
+}
+
+function parseFlags(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) {
+      const key = argv[i].slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) { flags[key] = next; i++; }
+      else { flags[key] = true; }
+    }
+  }
+  return flags;
+}
+
+export async function listFindings(supabase, { class: cls, status = 'new', ageGt = null } = {}) {
+  let q = supabase.from('feedback')
+    .select('id, title, status, severity, corrective_class, source_gate, gate_run_id, promoted_to_sd_id, created_at, metadata')
+    .eq('category', 'corrective_finding')
+    .eq('status', status)
+    .order('created_at', { ascending: false });
+  if (cls) q = q.eq('corrective_class', cls);
+  if (ageGt) {
+    const cutoff = new Date(Date.now() - Number(ageGt) * 86400000).toISOString();
+    q = q.lt('created_at', cutoff);
+  }
+  const { data, error } = await q;
+  if (error) throw new Error(`list failed: ${error.message}`);
+  return data || [];
+}
+
+export async function promoteFinding(supabase, feedbackId, { promotedBy = 'corrective-triage-cli' } = {}) {
+  const { data: row, error } = await supabase.from('feedback')
+    .select('id, title, description, status, promoted_to_sd_id, corrective_class, source_gate, gate_run_id, metadata')
+    .eq('id', feedbackId)
+    .single();
+  if (error || !row) throw new Error(`feedback ${feedbackId} not found: ${error?.message}`);
+  if (row.promoted_to_sd_id) {
+    return { promoted: false, reason: 'already_promoted', sdKey: row.promoted_to_sd_id, feedbackId };
+  }
+  if (row.status === 'wont_fix' || row.status === 'resolved') {
+    return { promoted: false, reason: `feedback status=${row.status}; cannot promote`, feedbackId };
+  }
+
+  const payload = row.metadata?.promote_payload;
+  if (!payload) throw new Error(`feedback ${feedbackId} has no metadata.promote_payload — generated before redirect; cannot promote`);
+
+  const sourceSdId = row.metadata?.source_sd_id ?? null;
+  const dims = row.metadata?.dimensions ?? [];
+
+  const newSD = await createSD({
+    title: row.title,
+    description: row.description,
+    type: payload.sdType,
+    priority: payload.priority,
+    category: payload.category,
+    parentId: payload.parentId,
+    rationale: payload.rationale,
+    strategic_objectives: payload.strategic_objectives,
+    success_criteria: payload.success_criteria,
+    success_metrics: payload.success_metrics,
+    key_principles: payload.key_principles,
+    metadata: {
+      source: 'corrective_triage_promotion',
+      promoted_from_feedback_id: feedbackId,
+      source_sd_id: sourceSdId,
+      gate_run_id: row.gate_run_id,
+      action_tier: row.metadata?.tier ?? null,
+      dimensions: dims,
+      gate_exemptions: ['GATE_VISION_SCORE'],
+      intelligence_priority: row.metadata?.intelligence_priority ?? null,
+    },
+  });
+
+  if (row.gate_run_id) {
+    await supabase.from('eva_vision_scores')
+      .update({ generated_sd_ids: [newSD.id] })
+      .eq('id', row.gate_run_id);
+  }
+
+  await supabase.from('feedback')
+    .update({
+      status: 'in_progress',
+      promoted_to_sd_id: newSD.sd_key,
+      promoted_at: new Date().toISOString(),
+      promoted_by: promotedBy,
+    })
+    .eq('id', feedbackId);
+
+  publishVisionEvent(VISION_EVENTS.CORRECTIVE_PROMOTED_TO_SD, {
+    originSdKey: sourceSdId,
+    feedbackId,
+    correctiveSdKey: newSD.sd_key,
+    promotedBy,
+  });
+
+  return { promoted: true, sdKey: newSD.sd_key, sdId: newSD.id, feedbackId };
+}
+
+export async function dismissFinding(supabase, feedbackId, { reason = 'dismissed via corrective-triage CLI' } = {}) {
+  const { data: row } = await supabase.from('feedback').select('id, status').eq('id', feedbackId).single();
+  if (!row) throw new Error(`feedback ${feedbackId} not found`);
+  if (row.status === 'wont_fix' || row.status === 'resolved') {
+    return { dismissed: false, reason: `feedback already in terminal status=${row.status}`, feedbackId };
+  }
+  const { error } = await supabase.from('feedback')
+    .update({
+      status: 'wont_fix',
+      resolution_type: 'wont_fix',
+      resolution_notes: reason,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq('id', feedbackId);
+  if (error) throw new Error(`dismiss failed: ${error.message}`);
+  return { dismissed: true, feedbackId, reason };
+}
+
+export async function bulkDismiss(supabase, { class: cls, ageGt = null, reason = 'bulk-dismissed via corrective-triage CLI' } = {}) {
+  if (!cls) throw new Error('bulkDismiss requires --class filter');
+  const findings = await listFindings(supabase, { class: cls, ageGt });
+  const dismissed = [];
+  for (const f of findings) {
+    try {
+      const r = await dismissFinding(supabase, f.id, { reason });
+      if (r.dismissed) dismissed.push(f.id);
+    } catch (e) {
+      console.warn(`[bulk-dismiss] ${f.id}: ${e.message}`);
+    }
+  }
+  return { dismissed: dismissed.length, ids: dismissed };
+}
+
+function formatRow(r) {
+  const ageMin = Math.round((Date.now() - new Date(r.created_at).getTime()) / 60000);
+  const dims = (r.metadata?.dimensions || []).join(',');
+  const tier = r.metadata?.tier || '?';
+  const score = r.metadata?.score ?? '?';
+  return `  ${r.id}  ${(r.corrective_class || '?').padEnd(16)} ${r.source_gate?.padEnd(22) || '?'} t=${tier.padEnd(11)} score=${String(score).padEnd(5)} dims=${dims.padEnd(20)} age=${ageMin}m  ${r.title.slice(0, 60)}`;
+}
+
+const argv1 = process.argv[1];
+const isMain = argv1 && (
+  import.meta.url === `file://${argv1}` ||
+  import.meta.url === `file:///${argv1.replace(/\\/g, '/')}`
+);
+
+if (isMain) {
+  const [, , cmd, ...rest] = process.argv;
+  const flags = parseFlags(rest);
+  const positional = rest.filter(a => !a.startsWith('--') && rest[rest.indexOf(a) - 1]?.slice(0, 2) !== '--' || rest[rest.indexOf(a) - 1]?.startsWith('--') === false);
+  const sb = getSupabase();
+
+  try {
+    if (cmd === 'list') {
+      const findings = await listFindings(sb, { class: flags.class, status: flags.status, ageGt: flags['age-gt'] });
+      console.log(`\n${findings.length} finding(s) [class=${flags.class || 'any'}, status=${flags.status || 'new'}]:\n`);
+      findings.forEach(r => console.log(formatRow(r)));
+      console.log('');
+    } else if (cmd === 'promote') {
+      const id = process.argv[3];
+      if (!id) { console.error('Usage: corrective-triage promote <feedback-id>'); process.exit(1); }
+      const r = await promoteFinding(sb, id, { promotedBy: process.env.CLAUDE_SESSION_ID || 'manual' });
+      console.log(JSON.stringify(r, null, 2));
+    } else if (cmd === 'dismiss') {
+      const id = process.argv[3];
+      if (!id) { console.error('Usage: corrective-triage dismiss <feedback-id> [--reason "<text>"]'); process.exit(1); }
+      const r = await dismissFinding(sb, id, { reason: flags.reason });
+      console.log(JSON.stringify(r, null, 2));
+    } else if (cmd === 'bulk-dismiss') {
+      const r = await bulkDismiss(sb, { class: flags.class, ageGt: flags['age-gt'], reason: flags.reason });
+      console.log(JSON.stringify(r, null, 2));
+    } else {
+      console.log(`Usage:
+  corrective-triage list [--class <c>] [--status <s>] [--age-gt <days>]
+  corrective-triage promote <feedback-id>
+  corrective-triage dismiss <feedback-id> [--reason "<text>"]
+  corrective-triage bulk-dismiss --class <c> [--age-gt <days>] [--reason "<text>"]
+
+Classes: vision_gap, arch_gap, lifecycle_feature, cli_validation, code_quality, other_gap
+Statuses: new, in_progress, backlog, resolved, wont_fix`);
+      process.exit(cmd ? 1 : 0);
+    }
+    process.exit(0);
+  } catch (e) {
+    console.error('Error:', e.message);
+    process.exit(1);
+  }
+}

--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -20,6 +20,7 @@ import { generateSDKey } from '../modules/sd-key-generator.js';
 import { createSD } from '../leo-create-sd.js';
 import { loadIntelligenceSignals } from '../../lib/eva/intelligence-loader.js';
 import { calculateCorrectivePriority } from '../../lib/eva/corrective-priority-calculator.js';
+import { recordCorrectiveFinding } from '../../lib/eva/corrective-finding-recorder.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 config({ path: join(__dirname, '../../.env') });
@@ -553,12 +554,14 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     }
   }
 
-  // 6. Create one SD per group via createSD (standard LEO creation pipeline)
-  const createdSDs = [];
-  const allGeneratedIds = [...existingIds];
+  // 6. Record one feedback finding per group via corrective-finding-recorder
+  // (SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001). Replaces direct createSD()
+  // emission; findings now persist in feedback (category='corrective_finding')
+  // and are promoted to SDs deliberately via scripts/corrective-triage.mjs.
+  const recordedFindings = [];
 
   for (const group of groups) {
-    const { dims, sdType, category, label } = group;
+    const { dims, label } = group;
     const dimSummary = dims.map(d => `${d.dimensionName} (${d.dimId})`).join(', ');
     const lowestScore = dims[0]?.score ?? score.total_score;
     const title = `Corrective: ${label} Gap — ${dimSummary} (score ${score.total_score ?? '?'}/100)`;
@@ -567,46 +570,32 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
       score.rubric_snapshot, score.total_score, action
     );
 
-    // QF-20260503-858: dedup — skip if a draft corrective already targets the
-    // same source-SD + dimension set. Prevents the duplicate-emission noise
-    // observed 2026-05-03 (15/24 post-filter SDs were duplicates).
     const dimensionIds = dims.map(d => d.dimId);
-    const dupSdKey = await findDuplicateCorrective(supabase, score.sd_id, dimensionIds);
-    if (dupSdKey) {
-      console.log(`[corrective-sd-generator] eva.corrective.skipped_duplicate source_sd_id=${score.sd_id} dims=${[...dimensionIds].sort().join(',')} existing=${dupSdKey}`);
-      await _logAudit(supabase, scoreId, 'skipped_duplicate', dupSdKey, score.vision_id, {
-        source_sd_id: score.sd_id,
-        dimensions: dimensionIds,
-        existing_sd_key: dupSdKey,
-      });
-      continue;
-    }
-
-    // Generate SD key through standard pipeline
-    const sdKey = await generateSDKey({ source: 'CORR', type: sdType, title });
+    const correctiveClass = label === 'Vision' ? 'vision_gap'
+      : label === 'Architecture' ? 'arch_gap'
+      : 'other_gap';
+    const sourceGate = score.rubric_snapshot?.mode === 'sd-heal'
+      ? 'eva_heal_score'
+      : 'eva_vision_score';
+    const dynamicPriority = priorityResult?.priority ?? tier.priority;
 
     try {
-      const dynamicPriority = priorityResult?.priority ?? tier.priority;
-      const newSD = await createSD({
-        sdKey,
+      const result = await recordCorrectiveFinding(supabase, {
+        source_sd_id: score.sd_id ?? null,
+        source_gate: sourceGate,
+        gate_run_id: scoreId,
+        corrective_class: correctiveClass,
+        dimensions: dimensionIds,
+        tier: action,
+        score: score.total_score ?? null,
         title,
         description,
-        type: sdType,
-        priority: dynamicPriority,
-        category,
-        parentId: ORCHESTRATOR_ID,
-        rationale: `Vision score of ${score.total_score ?? '?'}/100 is below the ${action} threshold. Corrective action required for ${label} dimensions: ${dimSummary}.`,
-        strategic_objectives: dims.map(d => ({ objective: `Improve ${d.dimensionName} above ${THRESHOLDS.ACCEPT}`, metric: `EVA ${d.dimId} >= ${THRESHOLDS.ACCEPT}` })),
-        success_criteria: dims.map(d => ({ criterion: `${d.dimensionName} gap addressed`, measure: `EVA re-score shows ${d.dimId} >= ${THRESHOLDS.ACCEPT}` })),
-        success_metrics: [{ metric: 'EVA dimension score', target: String(THRESHOLDS.ACCEPT), actual: String(lowestScore) }],
-        key_principles: [{ principle: 'Vision alignment', description: `Address ${label} gap(s) to improve EVA vision score` }],
         metadata: {
           source: 'corrective_sd_generator',
-          source_sd_id: score.sd_id ?? null,
-          score_id: scoreId,
-          vision_origin_score_id: scoreId,
+          dim_summary: dimSummary,
+          lowest_dim_score: lowestScore,
+          vision_id: score.vision_id ?? null,
           action_tier: action,
-          dimensions: dims.map(d => d.dimId),
           gate_exemptions: ['GATE_VISION_SCORE'],
           intelligence_priority: {
             priority: dynamicPriority,
@@ -615,47 +604,67 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
             reason_codes: priorityResult?.reason_codes ?? [],
             source: priorityResult?.source ?? 'static',
           },
+          // Stored for triage CLI promote — payload identical to pre-redesign
+          // createSD args, so promotion produces the same SD as before.
+          promote_payload: {
+            sdType: group.sdType,
+            category: group.category,
+            parentId: ORCHESTRATOR_ID,
+            priority: dynamicPriority,
+            rationale: `Vision score of ${score.total_score ?? '?'}/100 is below the ${action} threshold. Corrective action required for ${label} dimensions: ${dimSummary}.`,
+            strategic_objectives: dims.map(d => ({ objective: `Improve ${d.dimensionName} above ${THRESHOLDS.ACCEPT}`, metric: `EVA ${d.dimId} >= ${THRESHOLDS.ACCEPT}` })),
+            success_criteria: dims.map(d => ({ criterion: `${d.dimensionName} gap addressed`, measure: `EVA re-score shows ${d.dimId} >= ${THRESHOLDS.ACCEPT}` })),
+            success_metrics: [{ metric: 'EVA dimension score', target: String(THRESHOLDS.ACCEPT), actual: String(lowestScore) }],
+            key_principles: [{ principle: 'Vision alignment', description: `Address ${label} gap(s) to improve EVA vision score` }],
+          },
         },
       });
 
-      // Set vision_origin_score_id (not handled by createSD)
-      await supabase
-        .from('strategic_directives_v2')
-        .update({ vision_origin_score_id: scoreId })
-        .eq('sd_key', newSD.sd_key);
+      recordedFindings.push({ feedbackId: result.feedbackId, recorded: result.recorded, dims, label });
+      await _logAudit(supabase, scoreId, action, null, score.vision_id, {
+        feedback_id: result.feedbackId,
+        recorded: result.recorded,
+        dedup_hash: result.dedupHash,
+        corrective_class: correctiveClass,
+        source_gate: sourceGate,
+      });
 
-      createdSDs.push({ sdKey: newSD.sd_key, sdId: newSD.id, dims, label });
-      allGeneratedIds.push(newSD.id);
-      await _logAudit(supabase, scoreId, action, newSD.sd_key, score.vision_id);
-
-      // Publish corrective SD created event
-      publishVisionEvent(VISION_EVENTS.CORRECTIVE_SD_CREATED, {
+      // Replaces CORRECTIVE_SD_CREATED — no SD created at this stage.
+      publishVisionEvent(VISION_EVENTS.CORRECTIVE_FINDING_RECORDED ?? 'eva.corrective.finding_recorded', {
         originSdKey: score.sd_id || null,
-        correctiveSdKey: newSD.sd_key,
+        feedbackId: result.feedbackId,
+        recorded: result.recorded,
         scoreId,
         action,
-        dimensions: dims.map(d => d.dimId),
+        dimensions: dimensionIds,
         label,
+        correctiveClass,
+        sourceGate,
       });
-    } catch (sdErr) {
-      console.warn(`[corrective-sd-generator] Failed to create ${label} SD: ${sdErr?.message}`);
+    } catch (recErr) {
+      console.warn(`[corrective-sd-generator] Failed to record ${label} finding: ${recErr?.message}`);
       continue;
     }
   }
 
-  if (createdSDs.length === 0) {
-    throw new Error('Failed to create any corrective SDs');
+  if (recordedFindings.length === 0) {
+    throw new Error('Failed to record any corrective findings');
   }
 
-  // 7. Update generated_sd_ids with all created SD IDs
-  await supabase
-    .from('eva_vision_scores')
-    .update({ generated_sd_ids: allGeneratedIds })
-    .eq('id', scoreId);
-
-  // Backward-compatible return: primary SD = first created; sds = full list
-  const primary = createdSDs[0];
-  return { created: true, action, sdKey: primary.sdKey, sdId: primary.sdId, sds: createdSDs };
+  // 7. Backward-compatible return shim: existing callers may destructure
+  //    {created, action, sdKey, sdId, sds}. We preserve those keys (as null/[]
+  //    since no SDs are created at this stage) and add feedbackIds as additive
+  //    new field. eva_vision_scores.generated_sd_ids no longer updated here —
+  //    triage CLI promote will update it when an SD is actually created.
+  return {
+    created: false,
+    action,
+    sdKey: null,
+    sdId: null,
+    sds: [],
+    feedbackIds: recordedFindings.map(f => f.feedbackId),
+    findings: recordedFindings,
+  };
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/unit/eva/corrective-finding-recorder.test.js
+++ b/tests/unit/eva/corrective-finding-recorder.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 — PR2 of 5
+ * Unit tests for lib/eva/corrective-finding-recorder.js
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+
+let recordCorrectiveFinding;
+let computeDedupHash;
+
+beforeAll(async () => {
+  const mod = await import('../../../lib/eva/corrective-finding-recorder.js');
+  recordCorrectiveFinding = mod.recordCorrectiveFinding;
+  computeDedupHash = mod.computeDedupHash;
+});
+
+function mockSupabase({ existing = null, lookupErr = null, insertErr = null, insertedId = 'fb-uuid-1' } = {}) {
+  let inserted = null;
+  return {
+    inserted: () => inserted,
+    from(table) {
+      if (table !== 'feedback') throw new Error(`unexpected table ${table}`);
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              limit: () => ({
+                maybeSingle: () => Promise.resolve({ data: existing, error: lookupErr }),
+              }),
+            }),
+          }),
+        }),
+        insert(row) {
+          inserted = row;
+          return {
+            select: () => ({
+              single: () => Promise.resolve({
+                data: insertErr ? null : { id: insertedId },
+                error: insertErr,
+              }),
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('computeDedupHash', () => {
+  it('produces stable hash for identical input', () => {
+    const a = computeDedupHash('SD-X', ['V01', 'V02'], 'run-1');
+    const b = computeDedupHash('SD-X', ['V01', 'V02'], 'run-1');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is order-independent for dimensions', () => {
+    const a = computeDedupHash('SD-X', ['V02', 'V01'], 'run-1');
+    const b = computeDedupHash('SD-X', ['V01', 'V02'], 'run-1');
+    expect(a).toBe(b);
+  });
+
+  it('differs when source_sd_id differs', () => {
+    const a = computeDedupHash('SD-X', ['V01'], 'run-1');
+    const b = computeDedupHash('SD-Y', ['V01'], 'run-1');
+    expect(a).not.toBe(b);
+  });
+
+  it('handles null source_sd_id and gate_run_id', () => {
+    const h = computeDedupHash(null, ['V01'], null);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('recordCorrectiveFinding', () => {
+  const baseFinding = {
+    source_sd_id: 'SD-SOURCE-001',
+    source_gate: 'eva_vision_score',
+    gate_run_id: '11111111-1111-1111-1111-111111111111',
+    corrective_class: 'vision_gap',
+    dimensions: ['V03', 'V07'],
+    tier: 'gap-closure',
+    score: 72,
+    title: 'Vision gap V03/V07 below threshold',
+    description: 'Score 72 < 83 threshold for SD-SOURCE-001',
+    metadata: { rubric_run: 'rb-1' },
+  };
+
+  it('inserts a new feedback row when no duplicate exists', async () => {
+    const sb = mockSupabase({ existing: null, insertedId: 'fb-1' });
+    const result = await recordCorrectiveFinding(sb, baseFinding);
+    expect(result.recorded).toBe(true);
+    expect(result.feedbackId).toBe('fb-1');
+    expect(result.dedupHash).toMatch(/^[0-9a-f]{64}$/);
+
+    const row = sb.inserted();
+    expect(row).not.toBeNull();
+    expect(row.category).toBe('corrective_finding');
+    expect(row.status).toBe('new');
+    expect(row.type).toBe('issue');
+    expect(row.source_application).toBe('EHG_Engineer');
+    expect(row.source_type).toBe('auto_capture');
+    expect(row.feedback_type).toBe('corrective_finding');
+    expect(row.corrective_class).toBe('vision_gap');
+    expect(row.source_gate).toBe('eva_vision_score');
+    expect(row.gate_run_id).toBe('11111111-1111-1111-1111-111111111111');
+    expect(row.severity).toBe('medium');
+    expect(row.metadata.dedup_hash).toBe(result.dedupHash);
+    expect(row.metadata.dimensions).toEqual(['V03', 'V07']);
+    expect(row.metadata.rubric_run).toBe('rb-1');
+    expect(row.metadata.tier).toBe('gap-closure');
+    expect(row.metadata.score).toBe(72);
+  });
+
+  it('returns existing feedbackId without inserting on dedup hit', async () => {
+    const sb = mockSupabase({ existing: { id: 'fb-existing' } });
+    const result = await recordCorrectiveFinding(sb, baseFinding);
+    expect(result.recorded).toBe(false);
+    expect(result.feedbackId).toBe('fb-existing');
+    expect(sb.inserted()).toBeNull();
+  });
+
+  it('maps tier=escalation to severity=high', async () => {
+    const sb = mockSupabase({ existing: null });
+    await recordCorrectiveFinding(sb, { ...baseFinding, tier: 'escalation' });
+    expect(sb.inserted().severity).toBe('high');
+  });
+
+  it('maps tier=minor to severity=low', async () => {
+    const sb = mockSupabase({ existing: null });
+    await recordCorrectiveFinding(sb, { ...baseFinding, tier: 'minor' });
+    expect(sb.inserted().severity).toBe('low');
+  });
+
+  it('rejects when source_gate is missing', async () => {
+    const sb = mockSupabase({ existing: null });
+    await expect(recordCorrectiveFinding(sb, { ...baseFinding, source_gate: undefined }))
+      .rejects.toThrow(/source_gate is required/);
+  });
+
+  it('rejects when corrective_class is missing', async () => {
+    const sb = mockSupabase({ existing: null });
+    await expect(recordCorrectiveFinding(sb, { ...baseFinding, corrective_class: undefined }))
+      .rejects.toThrow(/corrective_class is required/);
+  });
+
+  it('rejects when title is missing', async () => {
+    const sb = mockSupabase({ existing: null });
+    await expect(recordCorrectiveFinding(sb, { ...baseFinding, title: undefined }))
+      .rejects.toThrow(/title is required/);
+  });
+
+  it('rejects when tier is missing', async () => {
+    const sb = mockSupabase({ existing: null });
+    await expect(recordCorrectiveFinding(sb, { ...baseFinding, tier: undefined }))
+      .rejects.toThrow(/tier is required/);
+  });
+
+  it('propagates insert errors', async () => {
+    const sb = mockSupabase({ existing: null, insertErr: { message: 'CHECK violation' } });
+    await expect(recordCorrectiveFinding(sb, baseFinding))
+      .rejects.toThrow(/insert failed: CHECK violation/);
+  });
+
+  it('propagates lookup errors', async () => {
+    const sb = mockSupabase({ lookupErr: { message: 'connection lost' } });
+    await expect(recordCorrectiveFinding(sb, baseFinding))
+      .rejects.toThrow(/dedup lookup failed: connection lost/);
+  });
+});

--- a/tests/unit/eva/corrective-sd-generator-redirect.test.js
+++ b/tests/unit/eva/corrective-sd-generator-redirect.test.js
@@ -1,0 +1,153 @@
+/**
+ * SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 — PR5 of 5
+ * Contract tests for the redirect refactor:
+ *   - corrective-sd-generator imports recorder (not just createSD)
+ *   - VISION_EVENTS includes the new event types
+ *   - corrective-finding-recorder exports computeDedupHash + recordCorrectiveFinding
+ *   - The generator's source code reflects the refactor (no SD INSERT)
+ *
+ * Behavior-level tests live in:
+ *   - corrective-finding-recorder.test.js (recorder unit tests, 14 cases)
+ *   - corrective-sd-generator.test.js (filter behavior, options binding)
+ *   - corrective-sd-generator-{a05,lifecycle,dedup}.test.js (filter cases)
+ *   - corrective-triage.test.js (CLI subcommand cases, 11)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../..');
+
+describe('redirect contract — recorder module', () => {
+  it('exports recordCorrectiveFinding and computeDedupHash', async () => {
+    const mod = await import('../../../lib/eva/corrective-finding-recorder.js');
+    expect(typeof mod.recordCorrectiveFinding).toBe('function');
+    expect(typeof mod.computeDedupHash).toBe('function');
+  });
+
+  it('computeDedupHash is deterministic and order-independent', async () => {
+    const { computeDedupHash } = await import('../../../lib/eva/corrective-finding-recorder.js');
+    const a = computeDedupHash('SD-X', ['V01', 'V02'], 'run');
+    const b = computeDedupHash('SD-X', ['V02', 'V01'], 'run');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('redirect contract — VISION_EVENTS', () => {
+  it('includes CORRECTIVE_FINDING_RECORDED', async () => {
+    const { VISION_EVENTS } = await import('../../../lib/eva/event-bus/vision-events.js');
+    expect(VISION_EVENTS.CORRECTIVE_FINDING_RECORDED).toBe('vision.corrective_finding_recorded');
+  });
+
+  it('includes CORRECTIVE_PROMOTED_TO_SD', async () => {
+    const { VISION_EVENTS } = await import('../../../lib/eva/event-bus/vision-events.js');
+    expect(VISION_EVENTS.CORRECTIVE_PROMOTED_TO_SD).toBe('vision.corrective_promoted_to_sd');
+  });
+
+  it('preserves CORRECTIVE_SD_CREATED for backward compat', async () => {
+    const { VISION_EVENTS } = await import('../../../lib/eva/event-bus/vision-events.js');
+    expect(VISION_EVENTS.CORRECTIVE_SD_CREATED).toBe('vision.corrective_sd_created');
+  });
+});
+
+describe('redirect contract — corrective-sd-generator source', () => {
+  const generatorSrc = readFileSync(
+    join(repoRoot, 'scripts/eva/corrective-sd-generator.mjs'),
+    'utf8'
+  );
+
+  it('imports recordCorrectiveFinding from the recorder module', () => {
+    expect(generatorSrc).toContain("import { recordCorrectiveFinding } from '../../lib/eva/corrective-finding-recorder.js'");
+  });
+
+  it('calls recordCorrectiveFinding inside generateCorrectiveSD', () => {
+    expect(generatorSrc).toContain('await recordCorrectiveFinding(supabase, {');
+  });
+
+  it('does NOT call createSD inside the per-group loop after the redirect', () => {
+    // After the refactor, createSD is still imported (used elsewhere — leo-create-sd
+    // helpers) but not invoked in the per-group emit loop. Approximate this by
+    // ensuring the OLD `await createSD({` pattern is absent.
+    expect(generatorSrc).not.toContain('newSD = await createSD({');
+  });
+
+  it('return shim preserves OLD shape with feedbackIds additive', () => {
+    expect(generatorSrc).toContain('created: false');
+    expect(generatorSrc).toContain('sdKey: null');
+    expect(generatorSrc).toContain('sds: []');
+    expect(generatorSrc).toContain('feedbackIds:');
+    expect(generatorSrc).toContain('findings:');
+  });
+
+  it('publishes CORRECTIVE_FINDING_RECORDED event (replaces CORRECTIVE_SD_CREATED in the emit path)', () => {
+    expect(generatorSrc).toContain('CORRECTIVE_FINDING_RECORDED');
+  });
+});
+
+describe('redirect contract — corrective-triage CLI source', () => {
+  const triageSrc = readFileSync(
+    join(repoRoot, 'scripts/corrective-triage.mjs'),
+    'utf8'
+  );
+
+  it('exports the four subcommand functions', () => {
+    expect(triageSrc).toMatch(/export async function listFindings/);
+    expect(triageSrc).toMatch(/export async function promoteFinding/);
+    expect(triageSrc).toMatch(/export async function dismissFinding/);
+    expect(triageSrc).toMatch(/export async function bulkDismiss/);
+  });
+
+  it('promote uses metadata.promote_payload to call createSD', () => {
+    expect(triageSrc).toContain('promote_payload');
+    expect(triageSrc).toContain('createSD({');
+  });
+
+  it('promote sets feedback.promoted_to_sd_id + status=in_progress + promoted_at', () => {
+    expect(triageSrc).toContain("status: 'in_progress'");
+    expect(triageSrc).toContain('promoted_to_sd_id');
+    expect(triageSrc).toContain('promoted_at');
+    expect(triageSrc).toContain('promoted_by');
+  });
+
+  it('publishes CORRECTIVE_PROMOTED_TO_SD on successful promote', () => {
+    expect(triageSrc).toContain('CORRECTIVE_PROMOTED_TO_SD');
+  });
+
+  it('dismiss sets resolution_type=wont_fix per feedback table contract', () => {
+    expect(triageSrc).toContain("status: 'wont_fix'");
+    expect(triageSrc).toContain("resolution_type: 'wont_fix'");
+  });
+});
+
+describe('redirect contract — schema migration files', () => {
+  const migCols = readFileSync(
+    join(repoRoot, 'database/migrations/20260504_feedback_corrective_columns.sql'),
+    'utf8'
+  );
+  const migIdx = readFileSync(
+    join(repoRoot, 'database/migrations/20260504_feedback_corrective_index.sql'),
+    'utf8'
+  );
+
+  it('column migration adds all 6 columns with IF NOT EXISTS', () => {
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS corrective_class');
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS source_gate');
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS gate_run_id');
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS promoted_to_sd_id');
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS promoted_at');
+    expect(migCols).toContain('ADD COLUMN IF NOT EXISTS promoted_by');
+  });
+
+  it('promoted_to_sd_id is varchar(50) per database-agent finding (sd_key string, not UUID)', () => {
+    expect(migCols).toMatch(/promoted_to_sd_id\s+varchar\(50\)/);
+  });
+
+  it('index migration uses CONCURRENTLY and partial filter', () => {
+    expect(migIdx).toContain('CREATE INDEX CONCURRENTLY');
+    expect(migIdx).toContain('idx_feedback_category_status');
+    expect(migIdx).toContain("category IN ('corrective_finding', 'harness_backlog')");
+  });
+});

--- a/tests/unit/scripts/corrective-triage.test.js
+++ b/tests/unit/scripts/corrective-triage.test.js
@@ -1,0 +1,167 @@
+/**
+ * SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001 — PR4 of 5
+ * Unit tests for scripts/corrective-triage.mjs
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+vi.mock('../../../scripts/leo-create-sd.js', () => ({
+  createSD: vi.fn(async () => ({ id: 'sd-uuid-1', sd_key: 'SD-PROMOTED-001' })),
+}));
+vi.mock('../../../lib/eva/event-bus/vision-events.js', () => ({
+  publishVisionEvent: vi.fn(),
+  VISION_EVENTS: { CORRECTIVE_PROMOTED_TO_SD: 'vision.corrective_promoted_to_sd' },
+}));
+
+let listFindings, promoteFinding, dismissFinding, bulkDismiss;
+
+beforeAll(async () => {
+  const mod = await import('../../../scripts/corrective-triage.mjs');
+  listFindings = mod.listFindings;
+  promoteFinding = mod.promoteFinding;
+  dismissFinding = mod.dismissFinding;
+  bulkDismiss = mod.bulkDismiss;
+});
+
+// Builder that supports BOTH terminal modes:
+//   - .single() / .maybeSingle() resolve to {data, error}
+//   - implicit await (then) resolves to {data: rows, error}
+// All chainable methods return the same builder so order doesn't matter.
+function makeBuilder({ single, rows = [], error = null }) {
+  const result = single !== undefined
+    ? { data: single, error }
+    : { data: rows, error };
+  const chain = {
+    select() { return chain; },
+    eq() { return chain; },
+    lt() { return chain; },
+    order() { return chain; },
+    limit() { return chain; },
+    single() { return Promise.resolve(result); },
+    maybeSingle() { return Promise.resolve(result); },
+    then(resolve, reject) { return Promise.resolve(result).then(resolve, reject); },
+  };
+  return chain;
+}
+
+function mockSupabase({ rows = [], single, lookupErr = null, updateOk = true } = {}) {
+  return {
+    from(table) {
+      return {
+        select: () => makeBuilder({ single, rows, error: lookupErr }),
+        update() {
+          return {
+            eq: () => Promise.resolve({ data: null, error: updateOk ? null : { message: 'fail' } }),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('listFindings', () => {
+  it('queries feedback table with correct filter chain', async () => {
+    const rows = [
+      { id: 'f1', title: 't1', status: 'new', corrective_class: 'vision_gap', source_gate: 'eva_vision_score', metadata: { dimensions: ['V01'], tier: 'gap-closure' }, created_at: new Date().toISOString() },
+    ];
+    const sb = mockSupabase({ rows });
+    const out = await listFindings(sb);
+    expect(out).toEqual(rows);
+  });
+
+  it('returns empty array when nothing matches', async () => {
+    const sb = mockSupabase({ rows: [] });
+    expect(await listFindings(sb, { class: 'arch_gap' })).toEqual([]);
+  });
+});
+
+describe('promoteFinding', () => {
+  const baseRow = {
+    id: 'fb-1',
+    title: 'Vision V03 gap',
+    description: 'desc',
+    status: 'new',
+    promoted_to_sd_id: null,
+    corrective_class: 'vision_gap',
+    source_gate: 'eva_vision_score',
+    gate_run_id: '11111111-1111-1111-1111-111111111111',
+    metadata: {
+      source_sd_id: 'SD-SRC-001',
+      dimensions: ['V03'],
+      tier: 'gap-closure',
+      promote_payload: {
+        sdType: 'corrective',
+        category: 'corrective',
+        parentId: 'orch-1',
+        priority: 'high',
+        rationale: 'rationale text',
+        strategic_objectives: [{ objective: 'o1', metric: 'm1' }],
+        success_criteria: [{ criterion: 'c1', measure: 'meas1' }],
+        success_metrics: [{ metric: 'em', target: '93', actual: '70' }],
+        key_principles: [{ principle: 'p1', description: 'd1' }],
+      },
+    },
+  };
+
+  it('creates an SD and updates feedback row when row is promotable', async () => {
+    const sb = mockSupabase({ single: baseRow });
+    const r = await promoteFinding(sb, 'fb-1', { promotedBy: 'tester' });
+    expect(r.promoted).toBe(true);
+    expect(r.sdKey).toBe('SD-PROMOTED-001');
+    expect(r.feedbackId).toBe('fb-1');
+  });
+
+  it('returns already_promoted when feedback.promoted_to_sd_id is set', async () => {
+    const sb = mockSupabase({ single: { ...baseRow, promoted_to_sd_id: 'SD-EXISTING-001' } });
+    const r = await promoteFinding(sb, 'fb-1');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('already_promoted');
+    expect(r.sdKey).toBe('SD-EXISTING-001');
+  });
+
+  it('refuses to promote a wont_fix finding', async () => {
+    const sb = mockSupabase({ single: { ...baseRow, status: 'wont_fix' } });
+    const r = await promoteFinding(sb, 'fb-1');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toMatch(/wont_fix/);
+  });
+
+  it('throws when promote_payload is absent', async () => {
+    const sb = mockSupabase({ single: { ...baseRow, metadata: { source_sd_id: 'X' } } });
+    await expect(promoteFinding(sb, 'fb-1')).rejects.toThrow(/no metadata.promote_payload/);
+  });
+});
+
+describe('dismissFinding', () => {
+  it('marks status=wont_fix when row exists', async () => {
+    const sb = mockSupabase({ single: { id: 'fb-1', status: 'new' } });
+    const r = await dismissFinding(sb, 'fb-1', { reason: 'duplicate of SD-X' });
+    expect(r.dismissed).toBe(true);
+    expect(r.feedbackId).toBe('fb-1');
+  });
+
+  it('returns dismissed=false when already wont_fix', async () => {
+    const sb = mockSupabase({ single: { id: 'fb-1', status: 'wont_fix' } });
+    const r = await dismissFinding(sb, 'fb-1');
+    expect(r.dismissed).toBe(false);
+  });
+
+  it('throws when feedback row missing', async () => {
+    const sb = mockSupabase({ single: null });
+    await expect(dismissFinding(sb, 'fb-missing')).rejects.toThrow(/not found/);
+  });
+});
+
+describe('bulkDismiss', () => {
+  it('rejects when class flag missing', async () => {
+    const sb = mockSupabase({});
+    await expect(bulkDismiss(sb, {})).rejects.toThrow(/requires --class/);
+  });
+
+  it('returns 0 dismissed for empty result set', async () => {
+    const sb = mockSupabase({ rows: [] });
+    const r = await bulkDismiss(sb, { class: 'arch_gap' });
+    expect(r.dismissed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Inverts the corrective-sd-generator architecture from opt-out filtering (which kept growing) to opt-in promotion. Findings now persist to the `feedback` table and are deliberately promoted to SDs via a new triage CLI.

**Closes the recurring batch-cancel-then-add-filter pattern** observed over the past weeks (29 SDs cancelled in a 24h window, 9 on 2026-05-02, 4 vision-gap variants on 2026-05-03; PR #3486 was the third filter shipped in 7 days).

## Test plan

- [x] Schema migration applied + verified to dedlbzhpgkmetvhbkyzq (database-agent run 32247604, all 6 columns + 1 partial index confirmed)
- [x] 104/104 corrective-related tests green across 7 files (TESTING agent run 92b634d7)
- [x] All 4 pre-existing filter test files pass unmodified (filter contracts preserved)
- [x] LEAD-TO-PLAN handoff passed (96%, 27 gates)
- [x] PLAN-TO-EXEC handoff passed (94%, 27 gates)
- [x] PLAN-TO-LEAD handoff passed (94%, 27 gates)
- [ ] LEAD-FINAL-APPROVAL pending merge
- [ ] Post-deploy: monitor `strategic_directives_v2 WHERE metadata.source=corrective_sd_generator AND status=draft` for 7d (expect 0 new rows)

## Scope

**5-commit branch**:
1. `2f8e297f98` PR1 — schema migration (6 columns + partial index, +68 LOC)
2. `9b475c7ead` PR2 — recorder module + 14 unit tests (+293 LOC)
3. `fa037d8111` PR3 — generator refactor (replaces createSD with recorder, +83 / −62 LOC)
4. `e82318338a` PR4 — corrective-triage CLI + 11 unit tests (+386 LOC)
5. `68be6113cd` PR5 — 18 redirect-contract tests (+153 LOC)

**Total**: ~390 LOC additions + 62 deletions across 7 files.

## PR size justification (>200 LOC tier)

This SD bundles foundational schema + recorder + 1-of-2-pipelines refactor + triage CLI + tests. Splitting into 5 separate PRs would have created broken intermediate states (recorder requires schema; triage CLI requires recorder; tests require all of the above). Multi-commit history within a single PR provides per-step reviewability without losing atomicity.

## Out of scope (deferred)

- `lib/eva/quality-findings/sd-generator.js` path B (S20 Code Quality Gate) — `transitionFindingToSdFiled()` expects an `sd_key`, requires its own state-machine refactor. Filed as follow-up SD scope.
- Auto-promote on escalation tier (deferred per Q8 scope-reduction)
- SLA alarm for stale triage backlog (deferred per Q8)
- Backfill of 448 historical brainstorm_sessions audit rows (deferred)

## Sub-agent evidence rows

- VALIDATION (LEAD): `7225ac9c-2c25-432a-b296-eacabeca0752` CONDITIONAL_PASS — surfaced quality-findings second pipeline scope finding
- DATABASE (LEAD prospective): `b2db4da3-dc33-4f85-b7eb-fcd1e0d088d2` PASS 95%
- DATABASE (EXEC execution): `32247604-25d7-4d52-86c4-fe62bbceef47` PASS — both migrations applied + verified
- TESTING (PLAN): `92b634d7-5974-4ec9-afee-0bcedfe62371` PASS 95% — 104/104 tests verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)