### PR TITLE
fix(QF-20260505-canonical-hook): hook delegation from worktrees to parent

### DIFF
--- a/lib/hooks/__tests__/canonical-parent.test.js
+++ b/lib/hooks/__tests__/canonical-parent.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { isInWorktree, findCanonicalParent } = require_('../canonical-parent.cjs');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Resolve the canonical (main) repo top-level — the parent worktree.
+function gitRevParse(arg, cwd) {
+  return execFileSync('git', ['rev-parse', arg], { cwd, encoding: 'utf8' }).trim();
+}
+const PARENT_TOPLEVEL = (() => {
+  const commonDir = path.resolve(__dirname, gitRevParse('--git-common-dir', __dirname));
+  return path.dirname(commonDir);
+})();
+
+describe('canonical-parent.cjs', () => {
+  it('isInWorktree() returns false for the parent worktree', () => {
+    expect(isInWorktree(PARENT_TOPLEVEL)).toBe(false);
+  });
+
+  it('findCanonicalParent() returns null for the parent worktree', () => {
+    expect(findCanonicalParent(PARENT_TOPLEVEL)).toBeNull();
+  });
+
+  // Pick the first real worktree under .worktrees/* (one with a .git file).
+  // Skipped if no real worktrees exist (CI checkout, fresh clone).
+  function findFirstRealWorktree() {
+    const fs = require_('fs');
+    const wtRoot = path.join(PARENT_TOPLEVEL, '.worktrees');
+    if (!fs.existsSync(wtRoot)) return null;
+    const entries = fs.readdirSync(wtRoot).filter(e => {
+      const p = path.join(wtRoot, e);
+      return fs.statSync(p).isDirectory() && fs.existsSync(path.join(p, '.git'));
+    });
+    return entries.length > 0 ? path.join(wtRoot, entries[0]) : null;
+  }
+
+  it('isInWorktree() returns true for a .worktrees/* path', () => {
+    const wtPath = findFirstRealWorktree();
+    if (!wtPath) return; // graceful: no worktrees in CI checkout
+    expect(isInWorktree(wtPath)).toBe(true);
+  });
+
+  it('findCanonicalParent() returns the parent path from inside a worktree', () => {
+    const wtPath = findFirstRealWorktree();
+    if (!wtPath) return;
+    const result = findCanonicalParent(wtPath);
+    expect(result).not.toBeNull();
+    expect(path.resolve(result)).toBe(path.resolve(PARENT_TOPLEVEL));
+  });
+
+  it('isInWorktree() returns false for a non-git directory', () => {
+    expect(isInWorktree(require_('os').tmpdir())).toBe(false);
+  });
+
+  it('findCanonicalParent() returns null for a non-git directory', () => {
+    expect(findCanonicalParent(require_('os').tmpdir())).toBeNull();
+  });
+});

--- a/lib/hooks/canonical-parent.cjs
+++ b/lib/hooks/canonical-parent.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+// QF-20260505-canonical-hook — resolve the canonical (parent) worktree for hook delegation.
+//
+// Problem: settings.json hook commands use ${CLAUDE_PROJECT_DIR}, which expands
+// to each session's project root. For sessions started in a git worktree
+// (.worktrees/<sd-key>/), this resolves to the worktree's *own* copy of the
+// hook script — frozen at the time the worktree was created. Hook fixes
+// merged to main do NOT propagate to existing worktrees, so a new hook
+// implementation can sit shipped-but-non-functional on every active worktree.
+//
+// Witnessed 2026-05-04: PR #3546 (DELIVERED layer) shipped to main, but every
+// active worker worktree was created before the merge and ran the pre-fix
+// hook. Result: 0 DELIVERED rows ever inserted in production, despite the
+// helper code being correct and the unit tests passing.
+//
+// Solution: each worktree-aware hook checks `isInWorktree(__dirname)` at
+// startup. If true, find the canonical (parent) worktree via
+// `git rev-parse --git-common-dir` and delegate to that path's hook
+// implementation. Parent worktree's check returns null and falls through to
+// the local implementation — no recursion.
+
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function gitRevParse(arg, cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', arg], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isInWorktree(cwd) {
+  const gitDir = gitRevParse('--git-dir', cwd);
+  const gitCommonDir = gitRevParse('--git-common-dir', cwd);
+  if (!gitDir || !gitCommonDir) return false;
+  return path.resolve(cwd, gitDir) !== path.resolve(cwd, gitCommonDir);
+}
+
+function findCanonicalParent(cwd) {
+  if (!isInWorktree(cwd)) return null;
+  const gitCommonDir = gitRevParse('--git-common-dir', cwd);
+  if (!gitCommonDir) return null;
+  const absCommon = path.resolve(cwd, gitCommonDir);
+  return path.dirname(absCommon);
+}
+
+module.exports = { isInWorktree, findCanonicalParent };

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -410,7 +410,7 @@ async function main() {
   // Read unread coordination messages for this session
   const { data: messages, error: tableErr } = await supabase
     .from('session_coordination')
-    .select('id, message_type, subject, body, payload, sender_type, created_at')
+    .select('id, message_type, subject, body, payload, sender_type, sender_session, created_at')
     .eq('target_session', sessionId)
     .is('read_at', null)
     .order('created_at', { ascending: true })

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -17,6 +17,27 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+// QF-20260505-canonical-hook — when invoked from a worktree, delegate to the
+// parent worktree's hook implementation. Hook fixes shipped to main don't
+// otherwise reach existing worktrees because settings.json paths resolve via
+// ${CLAUDE_PROJECT_DIR}, which is per-session. Witnessed 2026-05-04 with
+// PR #3546 DELIVERED layer (0 production firings despite correct code).
+if (require.main === module) {
+  try {
+    const { findCanonicalParent } = require(path.resolve(__dirname, '../../lib/hooks/canonical-parent.cjs'));
+    const canonical = findCanonicalParent(__dirname);
+    const myParent = path.resolve(__dirname, '../..');
+    if (canonical && canonical !== myParent) {
+      const parentHook = path.join(canonical, 'scripts/hooks/coordination-inbox.cjs');
+      if (fs.existsSync(parentHook)) {
+        const { spawnSync } = require('child_process');
+        const r = spawnSync(process.execPath, [parentHook], { stdio: 'inherit', windowsHide: true });
+        process.exit(typeof r.status === 'number' ? r.status : 0);
+      }
+    }
+  } catch { /* fall through to local impl on any error */ }
+}
+
 // QF-20260504-912: per-session throttle/heartbeat paths. Pre-fix these were
 // host-shared, causing 5/6 sessions to be starved for up to 60s after any one
 // session marked the throttle. Mirror the friction-counters pattern (validated


### PR DESCRIPTION
## Summary

Two complementary fixes that together restore PR #3546's DELIVERED layer to working order in production:

1. **Parent-canonical hook delegation** — `lib/hooks/canonical-parent.cjs` + shim block in `scripts/hooks/coordination-inbox.cjs`. When invoked from a worktree, spawns the parent worktree's hook with `stdio:'inherit'` so Claude Code's hook payload reaches the parent's latest implementation unchanged.

2. **SELECT statement fix** — added `sender_session` to the SELECT at `scripts/hooks/coordination-inbox.cjs:392`. Without this, the post-PR-3546 `insertDeliveredRowIfRequested` helper checks `!msg.sender_session` and silently returns `'skipped'` for every message, because the column is never fetched.

Both bugs together explain why **0 DELIVERED rows had ever been inserted in production** despite PR #3546 shipping ~24 hours ago.

## Why two fixes?

- The shim alone delegates correctly but the parent's hook still returns 'skipped' due to the SELECT bug
- The SELECT fix alone works in the parent worktree, but existing worktrees still run pre-fix code without the shim

Both must land together for the DELIVERED layer to function end-to-end.

## End-to-end validation

Tested against real Supabase with both fixes applied:

```
PROBE_ID: 54fa9487-dd51-4066-be51-308e8bf8f400
Hook exit: 0
DELIVERED rows: 1
  ✅ [DELIVERED 54fa9487] | sender=3b312d3f-495 → target=44444444-val
  payload: {"kind":"transport_ack","sender":"3b312d3f-4954-...","delivered_for":"54fa9487-dd51-..."}
```

## Tier

Tier 2 (~73 source LOC + ~70 test LOC). No risk keywords.

## Test plan
- [x] `npx vitest run lib/hooks/__tests__/canonical-parent.test.js` — 6/6 pass
- [x] `npx vitest run scripts/hooks/__tests__/coordination-inbox.test.js scripts/hooks/__tests__/coordination-inbox-delivered.test.js` — 27/27 pass (no regression)
- [x] **End-to-end against real Supabase**: probe → shim delegates → parent's hook → SELECT now includes sender_session → helper INSERTS DELIVERED row → row appears in coord inbox with correct payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)