### PR TITLE
fix(SD-LEO-INFRA-BULK-ADD-BEGIN-001): wrap 17 retro migrations in BEGIN/COMMIT

### DIFF
--- a/database/migrations/20251015_add_retrospective_quality_score_constraint.sql
+++ b/database/migrations/20251015_add_retrospective_quality_score_constraint.sql
@@ -8,6 +8,9 @@
 -- ============================================================================
 
 -- Find and report records with problematic quality scores
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 DO $$
 DECLARE
   zero_count INTEGER;
@@ -354,3 +357,5 @@ BEGIN
   RAISE NOTICE '';
 END;
 $$;
+
+COMMIT;

--- a/database/migrations/20251015_add_retrospective_quality_score_constraint_fixed.sql
+++ b/database/migrations/20251015_add_retrospective_quality_score_constraint_fixed.sql
@@ -9,6 +9,9 @@
 -- ============================================================================
 
 -- Find and report records with problematic quality scores
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 DO $$
 DECLARE
   zero_count INTEGER;
@@ -64,3 +67,5 @@ BEGIN
   END IF;
 END;
 $$;
+
+COMMIT;

--- a/database/migrations/20251015_add_retrospective_quality_score_constraint_part2.sql
+++ b/database/migrations/20251015_add_retrospective_quality_score_constraint_part2.sql
@@ -8,6 +8,9 @@
 -- Step 1: Add NOT NULL constraint
 -- ============================================================================
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ALTER COLUMN quality_score SET NOT NULL;
 
@@ -248,3 +251,5 @@ BEGIN
   RAISE NOTICE '';
 END;
 $$;
+
+COMMIT;

--- a/database/migrations/20251204_add_protocol_improvements_to_retrospectives.sql
+++ b/database/migrations/20251204_add_protocol_improvements_to_retrospectives.sql
@@ -9,6 +9,9 @@
 -- This field will store structured protocol improvement suggestions
 -- Format: Array of objects with category, improvement, evidence, and impact
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS protocol_improvements JSONB DEFAULT '[]'::jsonb;
 
@@ -145,3 +148,5 @@ GRANT EXECUTE ON FUNCTION get_all_protocol_improvements TO service_role;
 -- DROP FUNCTION IF EXISTS validate_protocol_improvements_for_process_category;
 -- ALTER TABLE retrospectives DROP CONSTRAINT IF EXISTS check_protocol_improvements_is_array;
 -- ALTER TABLE retrospectives DROP COLUMN IF EXISTS protocol_improvements;
+
+COMMIT;

--- a/database/migrations/20251210_retrospective_self_improvement_system.sql
+++ b/database/migrations/20251210_retrospective_self_improvement_system.sql
@@ -21,6 +21,9 @@
 -- =====================================================================================
 
 -- Add retrospective_type column with default
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS retrospective_type TEXT DEFAULT 'SD_COMPLETION';
 
@@ -575,3 +578,5 @@ GRANT SELECT ON v_improvement_effectiveness TO authenticated;
 -- 2. Test with sample retrospective
 -- 3. Review pending improvements: SELECT * FROM v_pending_improvements;
 -- 4. Integrate with handoff scripts to show warnings
+
+COMMIT;

--- a/database/migrations/20251228_audit_retrospective_schema.sql
+++ b/database/migrations/20251228_audit_retrospective_schema.sql
@@ -7,6 +7,9 @@
 -- 1. Runtime audits table (first-class audit entities)
 -- ============================================================================
 -- Track audits as first-class entities for metrics and retrospectives
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 CREATE TABLE IF NOT EXISTS runtime_audits (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
@@ -362,3 +365,5 @@ COMMENT ON VIEW audit_retrospective_quality IS
   'Quality metrics view for audit retrospectives.
    Used to enforce quality gates and track improvement over time.
    Target: 100% coverage, ≥3 verbatim citations, divergence insights present.';
+
+COMMIT;

--- a/database/migrations/20260101_standardize_retrospective_arrays.sql
+++ b/database/migrations/20260101_standardize_retrospective_arrays.sql
@@ -7,6 +7,9 @@
 -- STEP 1: Create helper function to convert array items
 -- ============================================================
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 CREATE OR REPLACE FUNCTION convert_array_strings_to_objects(
   arr jsonb,
   text_key text DEFAULT 'learning'
@@ -113,3 +116,5 @@ BEGIN
     RAISE NOTICE 'Migration complete: All key_learnings items are now objects';
   END IF;
 END $$;
+
+COMMIT;

--- a/database/migrations/20260119_add_coverage_metrics_to_retrospectives.sql
+++ b/database/migrations/20260119_add_coverage_metrics_to_retrospectives.sql
@@ -7,6 +7,9 @@
 -- ============================================================================
 
 -- Check if columns exist before adding (idempotent)
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 DO $$
 BEGIN
   -- coverage_tool: What tool measured coverage (jest, istanbul, c8, etc.)
@@ -187,3 +190,5 @@ BEGIN
   RAISE NOTICE '  - Warning (not error) if coverage_tool missing';
   RAISE NOTICE '============================================================';
 END $$;
+
+COMMIT;

--- a/database/migrations/20260123_retrospective_auto_archive_trigger.sql
+++ b/database/migrations/20260123_retrospective_auto_archive_trigger.sql
@@ -18,6 +18,9 @@
 -- PART 1: Add archive tracking columns if not exist
 -- ============================================================================
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ DEFAULT NULL;
 
@@ -207,3 +210,5 @@ BEGIN
   RAISE NOTICE 'To run manual cleanup: SELECT run_retrospective_maintenance();';
   RAISE NOTICE '=========================================================';
 END $$;
+
+COMMIT;

--- a/database/migrations/20260130_add_metadata_to_retrospectives.sql
+++ b/database/migrations/20260130_add_metadata_to_retrospectives.sql
@@ -5,6 +5,9 @@
 -- Solution: Add metadata column for consistency and flexibility
 
 -- Step 1: Add metadata column if not exists
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb;
 
@@ -20,3 +23,5 @@ COMMENT ON COLUMN retrospectives.metadata IS
 -- SELECT column_name, data_type, column_default
 -- FROM information_schema.columns
 -- WHERE table_name = 'retrospectives' AND column_name = 'metadata';
+
+COMMIT;

--- a/database/migrations/20260131_retrospective_idempotency.sql
+++ b/database/migrations/20260131_retrospective_idempotency.sql
@@ -3,6 +3,9 @@
 -- Purpose: Prevent duplicate pattern extraction from retrospectives
 
 -- Add idempotency tracking to retrospectives
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS learning_extracted_at TIMESTAMPTZ;
 
@@ -12,3 +15,5 @@ WHERE learning_extracted_at IS NULL AND quality_score >= 60;
 
 COMMENT ON COLUMN retrospectives.learning_extracted_at IS
   'Timestamp when patterns were extracted. NULL = not yet processed.';
+
+COMMIT;

--- a/database/migrations/20260201_add_future_enhancements_to_retrospectives.sql
+++ b/database/migrations/20260201_add_future_enhancements_to_retrospectives.sql
@@ -4,6 +4,9 @@
 -- Fix: Add future_enhancements JSONB field to store improvement opportunities
 
 -- Add future_enhancements column to retrospectives table
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 ADD COLUMN IF NOT EXISTS future_enhancements JSONB DEFAULT '[]'::jsonb;
 
@@ -23,3 +26,5 @@ Each entry: {
 -- Create index for searching enhancements
 CREATE INDEX IF NOT EXISTS idx_retrospectives_future_enhancements 
 ON retrospectives USING gin (future_enhancements);
+
+COMMIT;

--- a/database/migrations/20260211_fix_retrospective_optional_complete.sql
+++ b/database/migrations/20260211_fix_retrospective_optional_complete.sql
@@ -32,6 +32,9 @@
 -- PART 2: Update calculate_sd_progress to delegate to get_progress_breakdown
 -- ============================================================================
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 CREATE OR REPLACE FUNCTION calculate_sd_progress(sd_id_param text)
 RETURNS INT
 LANGUAGE plpgsql
@@ -83,3 +86,5 @@ BEGIN
     RAISE WARNING '  - RETROSPECTIVE complete: %', breakdown->'phase_breakdown'->'RETROSPECTIVE'->>'complete';
   END IF;
 END $$;
+
+COMMIT;

--- a/database/migrations/20260211_fix_template_retrospective_optional.sql
+++ b/database/migrations/20260211_fix_template_retrospective_optional.sql
@@ -16,6 +16,9 @@
 -- Update the template evaluation logic for 'artifact:retrospective' to check
 -- requires_retrospective flag. If false, auto-complete the step.
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 CREATE OR REPLACE FUNCTION get_progress_breakdown(sd_id_param text)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -398,3 +401,5 @@ END $$;
 COMMENT ON FUNCTION get_progress_breakdown IS
 'Calculates SD progress breakdown using templates when available, with fallback to hardcoded logic.
 FIXED: Respects requires_retrospective flag from sd_type_validation_profiles - auto-completes retrospective step for SD types that do not require it (e.g., bugfix with requires_retrospective=false).';
+
+COMMIT;

--- a/database/migrations/fix-retrospectives-constraint.sql
+++ b/database/migrations/fix-retrospectives-constraint.sql
@@ -11,6 +11,9 @@
 -- Execute this in Supabase SQL Editor with elevated privileges
 
 -- Step 1: Drop the existing restrictive constraint
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
 DROP CONSTRAINT IF EXISTS retrospectives_retro_type_check;
 
@@ -42,3 +45,5 @@ CHECK (retro_type IN (
 SELECT constraint_name, check_clause
 FROM information_schema.check_constraints
 WHERE constraint_name = 'retrospectives_retro_type_check';
+
+COMMIT;

--- a/database/migrations/fix_retrospectives_retro_type_constraint.sql
+++ b/database/migrations/fix_retrospectives_retro_type_constraint.sql
@@ -3,6 +3,9 @@
 -- but the constraint only allowed: ARCHITECTURE_DECISION, INCIDENT, SD_COMPLETION
 
 -- Drop the existing constraint
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives DROP CONSTRAINT IF EXISTS retrospectives_retro_type_check;
 
 -- Add new constraint with all valid handoff types
@@ -25,3 +28,5 @@ CHECK (retro_type IN (
 -- SELECT conname, pg_get_constraintdef(oid)
 -- FROM pg_constraint
 -- WHERE conrelid = 'retrospectives'::regclass;
+
+COMMIT;

--- a/database/migrations/leo_protocol_enforcement_002_retrospective_quality.sql
+++ b/database/migrations/leo_protocol_enforcement_002_retrospective_quality.sql
@@ -8,6 +8,9 @@
 -- SCHEMA CHANGES: Add quality tracking to retrospectives table
 -- ============================================================================
 
+-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.
+BEGIN;
+
 ALTER TABLE retrospectives
   ADD COLUMN IF NOT EXISTS quality_score INTEGER CHECK (quality_score >= 0 AND quality_score <= 100),
   ADD COLUMN IF NOT EXISTS quality_issues JSONB DEFAULT '[]'::jsonb,
@@ -281,3 +284,5 @@ BEGIN
   RAISE NOTICE 'Trigger created: auto_validate_retrospective_quality';
   RAISE NOTICE 'Quality threshold: 70/100 required for LEAD approval';
 END $$;
+
+COMMIT;

--- a/scripts/one-off/_wrap-retro-migrations.cjs
+++ b/scripts/one-off/_wrap-retro-migrations.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Bulk-wrap 17 retrospective migration files in BEGIN;/COMMIT; for SD-LEO-INFRA-BULK-ADD-BEGIN-001.
+ *
+ * Why: The Layer 4.3 retrospective-quality-gates CI workflow greps every
+ * `database/migrations/*retrospective*.sql` for `BEGIN;` and `COMMIT;`. 17 files
+ * lack the wrappers, causing chronic CI red on every retrospective-touching PR.
+ *
+ * What: Idempotently inserts `BEGIN;` after each file's leading comment header
+ * and appends `COMMIT;` at the bottom, plus a one-line audit comment citing this SD.
+ *
+ * Pre-flight guard: skips files containing `CREATE INDEX CONCURRENTLY` (cannot run
+ * inside a transaction). Logs the exclusion with reason.
+ *
+ * Idempotency: re-run is a no-op once each file has `^BEGIN;` and `^COMMIT;`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const MIG_DIR = path.join(ROOT, 'database', 'migrations');
+
+const FILES = [
+  '20251015_add_retrospective_quality_score_constraint.sql',
+  '20251015_add_retrospective_quality_score_constraint_fixed.sql',
+  '20251015_add_retrospective_quality_score_constraint_part2.sql',
+  '20251204_add_protocol_improvements_to_retrospectives.sql',
+  '20251210_retrospective_self_improvement_system.sql',
+  '20251228_audit_retrospective_schema.sql',
+  '20260101_standardize_retrospective_arrays.sql',
+  '20260119_add_coverage_metrics_to_retrospectives.sql',
+  '20260123_retrospective_auto_archive_trigger.sql',
+  '20260130_add_metadata_to_retrospectives.sql',
+  '20260131_retrospective_idempotency.sql',
+  '20260201_add_future_enhancements_to_retrospectives.sql',
+  '20260211_fix_retrospective_optional_complete.sql',
+  '20260211_fix_template_retrospective_optional.sql',
+  'fix_retrospectives_retro_type_constraint.sql',
+  'fix-retrospectives-constraint.sql',
+  'leo_protocol_enforcement_002_retrospective_quality.sql',
+];
+
+const AUDIT_COMMENT = `-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.`;
+
+const stats = { modified: 0, skipped: 0, excluded: 0, errors: 0 };
+
+for (const file of FILES) {
+  const fullPath = path.join(MIG_DIR, file);
+  try {
+    if (!fs.existsSync(fullPath)) {
+      console.error(`[ERROR] missing: ${file}`);
+      stats.errors++;
+      continue;
+    }
+
+    const original = fs.readFileSync(fullPath, 'utf8');
+
+    // CONCURRENTLY pre-flight (FR-5)
+    if (/CREATE\s+INDEX\s+CONCURRENTLY/i.test(original)) {
+      console.log(`[EXCLUDED] ${file} — contains CREATE INDEX CONCURRENTLY (cannot run inside transaction)`);
+      stats.excluded++;
+      continue;
+    }
+
+    // Idempotency: skip if BOTH BEGIN; and COMMIT; are already present at line-start
+    const hasBegin = /^BEGIN;\s*$/m.test(original);
+    const hasCommit = /^COMMIT;\s*$/m.test(original);
+    if (hasBegin && hasCommit) {
+      console.log(`[SKIP] ${file} — already wrapped`);
+      stats.skipped++;
+      continue;
+    }
+
+    // Find insertion point for BEGIN;: after leading comment block (lines starting with --)
+    // Walk lines until we find the first non-comment, non-blank line.
+    const lines = original.split(/\r?\n/);
+    let insertIdx = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed === '' || trimmed.startsWith('--')) {
+        insertIdx = i + 1;
+      } else {
+        break;
+      }
+    }
+
+    // Build new content with BEGIN; + audit comment + COMMIT; at EOF
+    const headerLines = lines.slice(0, insertIdx);
+    const bodyLines = lines.slice(insertIdx);
+
+    // Trim trailing blank lines from body to ensure COMMIT; is the final non-blank line
+    while (bodyLines.length && bodyLines[bodyLines.length - 1].trim() === '') {
+      bodyLines.pop();
+    }
+
+    const wrapped = [
+      ...headerLines,
+      AUDIT_COMMENT,
+      'BEGIN;',
+      '',
+      ...bodyLines,
+      '',
+      'COMMIT;',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(fullPath, wrapped, 'utf8');
+    console.log(`[MODIFIED] ${file}`);
+    stats.modified++;
+  } catch (err) {
+    console.error(`[ERROR] ${file}: ${err.message}`);
+    stats.errors++;
+  }
+}
+
+console.log('');
+console.log('=== Summary ===');
+console.log(`Modified: ${stats.modified}`);
+console.log(`Skipped (already wrapped): ${stats.skipped}`);
+console.log(`Excluded (CONCURRENTLY): ${stats.excluded}`);
+console.log(`Errors: ${stats.errors}`);
+
+process.exit(stats.errors > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Bulk-adds `BEGIN;`/`COMMIT;` transaction wrappers to 17 retrospective migration files that lacked them, satisfying the Layer 4.3 retrospective-quality-gates CI grep contract.

**Why**: The Layer 4.3 workflow finds every `database/migrations/*retrospective*.sql` and greps for explicit `BEGIN;`/`COMMIT;`. 17 files lacked the wrappers, causing chronic CI red on every retrospective-touching PR. Most recently witnessed firsthand on PR #3560 (SD-LEO-FIX-FIX-AUTO-POPULATE-001).

## What ships

- **Wrap script**: `scripts/one-off/_wrap-retro-migrations.cjs` — auditable bulk-edit with hard-coded file list, idempotent re-runs, and `CREATE INDEX CONCURRENTLY` pre-flight guard.
- **17 modified migration files**: each gets a one-line audit comment + `BEGIN;` + `COMMIT;`.

## Why this is safe

- Migrations have already been applied to production. The wrapping affects file-structure CI validation only — runtime is unaffected.
- `CREATE OR REPLACE` / `IF NOT EXISTS` guards in each migration body keep them idempotent regardless.
- No business-logic changes to any migration body. Diff is purely structural (BEGIN/COMMIT keywords + audit comments).

## Verification

```
$ find database/migrations -name '*retrospective*.sql' | xargs grep -L '^BEGIN;'   → 0 files
$ find database/migrations -name '*retrospective*.sql' | xargs grep -L '^COMMIT;'  → 0 files
$ node scripts/one-off/_wrap-retro-migrations.cjs   (re-run)                       → 17 skips, 0 modifications
```

CONCURRENTLY exclusions: 0.

**Note on diff size**: line-count appears large (~971+/-762) because Windows LF→CRLF normalization touched every line. Semantic change is ~3 lines per file × 17 files = ~50 LOC.

## Test plan
- [ ] Layer 4.3 Migration File Validation passes (was chronic-red)
- [ ] Layer 4: Quality Gates Summary passes (depends on 4.3)
- [ ] CI typecheck still green