### PR TITLE
feat(SD-LEO-INFRA-PRE-COMMIT-GUARD-001): pre-commit guard for retro SQL BEGIN/COMMIT

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -191,6 +191,38 @@ fi
 echo "✅ Script reference protection passed"
 
 # ============================================================================
+# STAGE 0.7: Retrospective Migration BEGIN/COMMIT Guard (BLOCKING)
+# ============================================================================
+# SD-LEO-INFRA-PRE-COMMIT-GUARD-001: Catch new database/migrations/*retrospective*.sql
+# files that lack line-leading BEGIN; / COMMIT;. The Layer 4.3 retrospective-quality-gates
+# CI workflow greps for those keywords and fails the entire PR otherwise. SD-LEO-INFRA-
+# BULK-ADD-BEGIN-001 closed the chronic red on 17 historical files; this stage prevents
+# regressions from new files at commit time.
+# ============================================================================
+
+STAGED_RETRO=$(git diff --cached --name-only --diff-filter=AM | grep -E "^database/migrations/.*retrospective.*\.sql$" || true)
+
+if [ -n "$STAGED_RETRO" ]; then
+  echo ""
+  echo "🧪 Running retrospective-migration BEGIN/COMMIT guard..."
+
+  # Helper script lives in scripts/. If absent (e.g., partial checkout), warn rather than block.
+  HELPER="scripts/hooks/check-retro-migrations-wrapped.cjs"
+  if [ ! -f "$HELPER" ]; then
+    echo "  ⚠️  $HELPER not found — guard skipped (commit proceeds)."
+  else
+    # Pass each path as a separate arg.
+    if ! echo "$STAGED_RETRO" | xargs -I {} echo "{}" | xargs node "$HELPER"; then
+      echo ""
+      echo "  Pre-commit blocked by Stage 0.7. Resolve the violations above and re-stage."
+      echo ""
+      exit 1
+    fi
+    echo "✅ Retrospective-migration guard passed"
+  fi
+fi
+
+# ============================================================================
 # STAGE 1: Secret Detection (BLOCKING)
 # ============================================================================
 # SD-SEC-CREDENTIAL-ROTATION-001: Prevent accidental commit of secrets

--- a/scripts/hooks/check-retro-migrations-wrapped.cjs
+++ b/scripts/hooks/check-retro-migrations-wrapped.cjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit helper for SD-LEO-INFRA-PRE-COMMIT-GUARD-001.
+ *
+ * Validates that staged `database/migrations/*retrospective*.sql` files contain
+ * line-leading `BEGIN;` and `COMMIT;` keywords (the contract enforced by the
+ * Layer 4.3 retrospective-quality-gates CI workflow). Catches regressions at
+ * commit time so the chronic CI red closed by SD-LEO-INFRA-BULK-ADD-BEGIN-001
+ * cannot quietly return.
+ *
+ * Usage (from .husky/pre-commit STAGE 0.7):
+ *   node scripts/check-retro-migrations-wrapped.cjs <file1> <file2> ...
+ *
+ * Exit codes:
+ *   0 — all paths pass (or zero matching files; or all matching files use
+ *       CREATE INDEX CONCURRENTLY which is incompatible with explicit transactions)
+ *   1 — one or more files lack ^BEGIN; or ^COMMIT; → commit is blocked
+ *
+ * The workflow's grep contract is line-leading (`grep -L "^BEGIN;"`); same regex
+ * is used here so local guard and CI gate agree exactly.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const files = args.filter((a) => /database\/migrations\/.*retrospective.*\.sql$/i.test(a));
+
+if (files.length === 0) {
+  // Empty-set fast path — no retrospective SQL files in this commit.
+  process.exit(0);
+}
+
+const violations = [];
+const concurrentlyExcluded = [];
+
+for (const file of files) {
+  const fullPath = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(fullPath)) {
+    // File deleted in this commit — nothing to validate.
+    continue;
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(fullPath, 'utf8');
+  } catch (err) {
+    violations.push({ file, missing: ['<read-error: ' + err.message + '>'] });
+    continue;
+  }
+
+  if (/CREATE\s+INDEX\s+CONCURRENTLY/i.test(content)) {
+    // CONCURRENTLY incompatible with explicit transaction — exclude with advisory.
+    concurrentlyExcluded.push(file);
+    continue;
+  }
+
+  const missing = [];
+  if (!/^BEGIN;\s*$/m.test(content)) missing.push('BEGIN;');
+  if (!/^COMMIT;\s*$/m.test(content)) missing.push('COMMIT;');
+
+  if (missing.length > 0) {
+    violations.push({ file, missing });
+  }
+}
+
+if (concurrentlyExcluded.length > 0) {
+  console.log('');
+  console.log('  ⚠️  Retrospective SQL files containing CREATE INDEX CONCURRENTLY (excluded from BEGIN/COMMIT check):');
+  for (const file of concurrentlyExcluded) {
+    console.log('      - ' + file);
+  }
+  console.log('     CONCURRENTLY is incompatible with explicit transaction wrapping.');
+  console.log('     Flag these files for separate handling; Layer 4.3 CI will still fail until resolved.');
+  console.log('');
+}
+
+if (violations.length > 0) {
+  console.error('');
+  console.error('❌ BLOCKED: Staged retrospective SQL file(s) missing BEGIN/COMMIT transaction wrapping');
+  console.error('');
+  console.error('   The Layer 4.3 retrospective-quality-gates CI workflow grep contract requires');
+  console.error('   line-leading ^BEGIN; and ^COMMIT; in every database/migrations/*retrospective*.sql file.');
+  console.error('   See: .github/workflows/retrospective-quality-gates.yml lines 232,237');
+  console.error('');
+  for (const { file, missing } of violations) {
+    console.error('   File: ' + file);
+    console.error('   Missing: ' + missing.join(', '));
+    console.error('');
+  }
+  console.error('   Fix:');
+  console.error('     node scripts/one-off/_wrap-retro-migrations.cjs');
+  console.error('     (or add BEGIN; near top + COMMIT; at EOF manually)');
+  console.error('');
+  console.error('   Emergency bypass (logged): git commit --no-verify');
+  console.error('');
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds STAGE 0.7 to `.husky/pre-commit` + helper at `scripts/hooks/check-retro-migrations-wrapped.cjs` that blocks commits when staged `database/migrations/*retrospective*.sql` files lack line-leading `BEGIN;`/`COMMIT;`. Catches regressions of the Layer 4.3 chronic CI red that SD-LEO-INFRA-BULK-ADD-BEGIN-001 just closed (PR #3562).

## What ships

- `scripts/hooks/check-retro-migrations-wrapped.cjs` — Node helper (filtering, BEGIN/COMMIT check, CONCURRENTLY pre-flight, diagnostic output)
- `.husky/pre-commit` STAGE 0.7 — bash glue (filters staged paths, empty-set fast path, invokes helper)

~130 LOC total.

## Smoke tests
- ✅ Positive: deliberately-broken file blocks commit with diagnostic
- ✅ Negative: all 23 existing wrapped retro files pass (helper exits 0 cleanly)
- ✅ Empty-set: zero retro files staged → stage silent, no slowdown

## Why now

Action item from SD-LEO-INFRA-BULK-ADD-BEGIN-001 retrospective: *"Add a pre-commit hook (or expand the wrap script into a periodic audit) that catches new retrospective migrations missing BEGIN;/COMMIT; before they merge."* This is the prevention layer.

## Test plan
- [ ] CI green
- [ ] Layer 4.3 still green (no regression)