### PR TITLE
feat(SD-LEO-INFRA-SINGLE-FILE-MODE-001): single-file mode for wrap script

### DIFF
--- a/scripts/hooks/check-retro-migrations-wrapped.cjs
+++ b/scripts/hooks/check-retro-migrations-wrapped.cjs
@@ -88,9 +88,11 @@ if (violations.length > 0) {
     console.error('   Missing: ' + missing.join(', '));
     console.error('');
   }
-  console.error('   Fix:');
-  console.error('     node scripts/one-off/_wrap-retro-migrations.cjs');
-  console.error('     (or add BEGIN; near top + COMMIT; at EOF manually)');
+  console.error('   Fix (per-file mode wraps just your offending file(s)):');
+  for (const { file } of violations) {
+    console.error('     node scripts/one-off/_wrap-retro-migrations.cjs ' + file);
+  }
+  console.error('   (or add BEGIN; near top + COMMIT; at EOF manually)');
   console.error('');
   console.error('   Emergency bypass (logged): git commit --no-verify');
   console.error('');

--- a/scripts/one-off/_wrap-retro-migrations.cjs
+++ b/scripts/one-off/_wrap-retro-migrations.cjs
@@ -1,18 +1,30 @@
 #!/usr/bin/env node
 /**
- * Bulk-wrap 17 retrospective migration files in BEGIN;/COMMIT; for SD-LEO-INFRA-BULK-ADD-BEGIN-001.
+ * Wrap retrospective migration files in BEGIN;/COMMIT; for the Layer 4.3 CI grep contract.
  *
- * Why: The Layer 4.3 retrospective-quality-gates CI workflow greps every
- * `database/migrations/*retrospective*.sql` for `BEGIN;` and `COMMIT;`. 17 files
- * lack the wrappers, causing chronic CI red on every retrospective-touching PR.
+ * Original bulk-edit script: SD-LEO-INFRA-BULK-ADD-BEGIN-001 (PR #3562).
+ * Single-file mode added: SD-LEO-INFRA-SINGLE-FILE-MODE-001 (this SD), so the
+ * pre-commit guard from SD-LEO-INFRA-PRE-COMMIT-GUARD-001 (PR #3564) can point
+ * developers at an actionable per-file command.
  *
- * What: Idempotently inserts `BEGIN;` after each file's leading comment header
- * and appends `COMMIT;` at the bottom, plus a one-line audit comment citing this SD.
+ * Modes:
+ *   node _wrap-retro-migrations.cjs                    → bulk mode: hard-coded list of 17 files
+ *   node _wrap-retro-migrations.cjs <path>             → single-file mode (pass any number of paths)
+ *   node _wrap-retro-migrations.cjs --help             → print usage and exit 0
  *
- * Pre-flight guard: skips files containing `CREATE INDEX CONCURRENTLY` (cannot run
+ * Per-file paths must:
+ *   - end in .sql
+ *   - resolve under database/migrations/
+ *
+ * Why:  Layer 4.3 retrospective-quality-gates CI workflow greps every
+ *       database/migrations/*retrospective*.sql for line-leading BEGIN; / COMMIT;.
+ * What: Idempotently inserts BEGIN; after each file's leading comment header
+ *       and appends COMMIT; at the bottom, plus a one-line audit comment.
+ *
+ * Pre-flight guard: skips files containing CREATE INDEX CONCURRENTLY (cannot run
  * inside a transaction). Logs the exclusion with reason.
  *
- * Idempotency: re-run is a no-op once each file has `^BEGIN;` and `^COMMIT;`.
+ * Idempotency: re-run is a no-op once each file has ^BEGIN; and ^COMMIT;.
  */
 
 const fs = require('fs');
@@ -21,7 +33,7 @@ const path = require('path');
 const ROOT = path.resolve(__dirname, '..', '..');
 const MIG_DIR = path.join(ROOT, 'database', 'migrations');
 
-const FILES = [
+const BULK_FILES = [
   '20251015_add_retrospective_quality_score_constraint.sql',
   '20251015_add_retrospective_quality_score_constraint_fixed.sql',
   '20251015_add_retrospective_quality_score_constraint_part2.sql',
@@ -43,37 +55,43 @@ const FILES = [
 
 const AUDIT_COMMENT = `-- 2026-05-05 (SD-LEO-INFRA-BULK-ADD-BEGIN-001): added BEGIN;/COMMIT; for Layer 4.3 CI grep contract. Migration was already applied to production; transaction wrapping affects file-structure validation only, not runtime.`;
 
-const stats = { modified: 0, skipped: 0, excluded: 0, errors: 0 };
+function printUsage() {
+  console.log('Usage:');
+  console.log('  node scripts/one-off/_wrap-retro-migrations.cjs                  # bulk mode (17 historical files)');
+  console.log('  node scripts/one-off/_wrap-retro-migrations.cjs <path> [<path>]  # single-file mode (one or more paths)');
+  console.log('  node scripts/one-off/_wrap-retro-migrations.cjs --help           # show this message');
+  console.log('');
+  console.log('Per-file paths must end in .sql and resolve under database/migrations/.');
+}
 
-for (const file of FILES) {
-  const fullPath = path.join(MIG_DIR, file);
+/**
+ * Wrap a single migration file in place.
+ * Returns one of: 'modified', 'skipped', 'excluded', 'error'.
+ */
+function processFile(displayName, fullPath) {
   try {
     if (!fs.existsSync(fullPath)) {
-      console.error(`[ERROR] missing: ${file}`);
-      stats.errors++;
-      continue;
+      console.error(`[ERROR] missing: ${displayName}`);
+      return 'error';
     }
 
     const original = fs.readFileSync(fullPath, 'utf8');
 
-    // CONCURRENTLY pre-flight (FR-5)
+    // CONCURRENTLY pre-flight
     if (/CREATE\s+INDEX\s+CONCURRENTLY/i.test(original)) {
-      console.log(`[EXCLUDED] ${file} — contains CREATE INDEX CONCURRENTLY (cannot run inside transaction)`);
-      stats.excluded++;
-      continue;
+      console.log(`[EXCLUDED] ${displayName} — contains CREATE INDEX CONCURRENTLY (cannot run inside transaction)`);
+      return 'excluded';
     }
 
     // Idempotency: skip if BOTH BEGIN; and COMMIT; are already present at line-start
     const hasBegin = /^BEGIN;\s*$/m.test(original);
     const hasCommit = /^COMMIT;\s*$/m.test(original);
     if (hasBegin && hasCommit) {
-      console.log(`[SKIP] ${file} — already wrapped`);
-      stats.skipped++;
-      continue;
+      console.log(`[SKIP] ${displayName} — already wrapped`);
+      return 'skipped';
     }
 
     // Find insertion point for BEGIN;: after leading comment block (lines starting with --)
-    // Walk lines until we find the first non-comment, non-blank line.
     const lines = original.split(/\r?\n/);
     let insertIdx = 0;
     for (let i = 0; i < lines.length; i++) {
@@ -85,11 +103,10 @@ for (const file of FILES) {
       }
     }
 
-    // Build new content with BEGIN; + audit comment + COMMIT; at EOF
     const headerLines = lines.slice(0, insertIdx);
     const bodyLines = lines.slice(insertIdx);
 
-    // Trim trailing blank lines from body to ensure COMMIT; is the final non-blank line
+    // Trim trailing blank lines from body
     while (bodyLines.length && bodyLines[bodyLines.length - 1].trim() === '') {
       bodyLines.pop();
     }
@@ -106,19 +123,74 @@ for (const file of FILES) {
     ].join('\n');
 
     fs.writeFileSync(fullPath, wrapped, 'utf8');
-    console.log(`[MODIFIED] ${file}`);
-    stats.modified++;
+    console.log(`[MODIFIED] ${displayName}`);
+    return 'modified';
   } catch (err) {
-    console.error(`[ERROR] ${file}: ${err.message}`);
-    stats.errors++;
+    console.error(`[ERROR] ${displayName}: ${err.message}`);
+    return 'error';
   }
 }
 
-console.log('');
-console.log('=== Summary ===');
-console.log(`Modified: ${stats.modified}`);
-console.log(`Skipped (already wrapped): ${stats.skipped}`);
-console.log(`Excluded (CONCURRENTLY): ${stats.excluded}`);
-console.log(`Errors: ${stats.errors}`);
+/**
+ * Validate a path arg: must end in .sql AND resolve under database/migrations/.
+ * Returns { ok, fullPath, displayName } or { ok: false, error }.
+ */
+function validatePathArg(arg) {
+  if (!arg.toLowerCase().endsWith('.sql')) {
+    return { ok: false, error: `${arg}: not a .sql file` };
+  }
+  const fullPath = path.isAbsolute(arg) ? path.resolve(arg) : path.resolve(process.cwd(), arg);
+  const relFromMigDir = path.relative(MIG_DIR, fullPath);
+  if (relFromMigDir.startsWith('..') || path.isAbsolute(relFromMigDir)) {
+    return { ok: false, error: `${arg}: not under database/migrations/` };
+  }
+  const displayName = path.relative(process.cwd(), fullPath).replace(/\\/g, '/');
+  return { ok: true, fullPath, displayName };
+}
 
-process.exit(stats.errors > 0 ? 1 : 0);
+function main() {
+  const args = process.argv.slice(2);
+
+  // --help / -h
+  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const stats = { modified: 0, skipped: 0, excluded: 0, errors: 0 };
+  let mode;
+
+  if (args.length === 0) {
+    // Bulk mode: process the hard-coded list
+    mode = 'bulk';
+    for (const file of BULK_FILES) {
+      const fullPath = path.join(MIG_DIR, file);
+      const result = processFile(file, fullPath);
+      stats[result === 'error' ? 'errors' : result]++;
+    }
+  } else {
+    // Single-file (or multi-file) mode: process each provided path
+    mode = 'per-file';
+    for (const arg of args) {
+      const v = validatePathArg(arg);
+      if (!v.ok) {
+        console.error(`[ERROR] ${v.error}`);
+        stats.errors++;
+        continue;
+      }
+      const result = processFile(v.displayName, v.fullPath);
+      stats[result === 'error' ? 'errors' : result]++;
+    }
+  }
+
+  console.log('');
+  console.log(`=== Summary (${mode} mode) ===`);
+  console.log(`Modified: ${stats.modified}`);
+  console.log(`Skipped (already wrapped): ${stats.skipped}`);
+  console.log(`Excluded (CONCURRENTLY): ${stats.excluded}`);
+  console.log(`Errors: ${stats.errors}`);
+
+  process.exit(stats.errors > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds single-file mode to `scripts/one-off/_wrap-retro-migrations.cjs` so the pre-commit guard from PR #3564 can point developers at an actionable per-file command. Updates remediation message to interpolate the offending path.

**Closes the half-open loop**: pre-commit guard now prints copy-paste-ready commands that wrap just the offending files.

## What ships

- `scripts/one-off/_wrap-retro-migrations.cjs`: argv handling, validatePathArg, processFile helper. ~80 LOC change (refactor + new mode).
- `scripts/hooks/check-retro-migrations-wrapped.cjs`: remediation message references per-file syntax with interpolated path.

## Modes

```
node scripts/one-off/_wrap-retro-migrations.cjs                   # bulk (17 historical)
node scripts/one-off/_wrap-retro-migrations.cjs <path>            # single-file
node scripts/one-off/_wrap-retro-migrations.cjs --help            # usage
```

## Smoke tests
- ✅ TS-1 bulk mode: 17 files report SKIP (idempotent)
- ✅ TS-2 per-file mode: broken file gets BEGIN restored
- ✅ TS-3 --help: prints usage, exits 0
- ✅ TS-4 invalid path: clean error message, exit 1

Backward-compatible. The retrospective-migrations CI-hygiene chain (cleanup → fix → prevent → remediation actionable) is now closed end-to-end.

## Test plan
- [ ] CI green (Layer 4.3 still passing)