### PR TITLE
fix(QF-20260506-552): defang create_postmortem_on_venture_failure trigger via ::text cast

### DIFF
--- a/database/migrations/20260506053601_defang_postmortem_trigger_enum_cast.sql
+++ b/database/migrations/20260506053601_defang_postmortem_trigger_enum_cast.sql
@@ -1,0 +1,24 @@
+-- QF-20260506-552 — Defang create_postmortem_on_venture_failure via ::text cast
+-- Origin: RCA-AGENT report on SD-LEO-FEAT-STAGE-REJECT-KILL-001 EXEC blocker
+--
+-- Trigger compared NEW.status (venture_status_enum) against literal 'failed',
+-- which the enum doesn't contain — Postgres raised 22P02 on every UPDATE OF
+-- ventures.status. Defensive ::text cast preserves trigger semantics (branch
+-- never fires while 'failed' is absent) without crashing. See
+-- issue_pattern PAT-DB-TRIG-ENUM-001 for the prevention checklist.
+
+CREATE OR REPLACE FUNCTION public.create_postmortem_on_venture_failure()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status::text = 'failed'
+     AND (OLD.status IS NULL OR OLD.status::text != 'failed') THEN
+    INSERT INTO public.venture_postmortems (
+      venture_id, venture_name, venture_start_date,
+      failure_date, status, created_by
+    ) VALUES (
+      NEW.id, NEW.name, NEW.created_at, NOW(), 'draft', 'TRIGGER'
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- 12-LOC defensive `::text` cast in `create_postmortem_on_venture_failure()` trigger to eliminate latent 22P02 enum-cast crash on `UPDATE OF ventures.status`
- Trigger has been a non-functional landmine since 2026-01-02 (`database/migrations/20260102_postmortems.sql`) — comparing `NEW.status` (typed `venture_status_enum`: `active|paused|completed|cancelled|archived`) against literal `'failed'` which is NOT a label in the enum
- Defect surfaced during `SD-LEO-FEAT-STAGE-REJECT-KILL-001` EXEC migration apply (`kill_venture` RPC + `reject_chairman_decision` A-4 + PrivacyPatrol AI backfill all UPDATE `ventures.status`)
- Origin: RCA-AGENT report on REJECT-KILL EXEC blocker, CAPA-1 (defensive cast preserves trigger semantics — branch never fires while `'failed'` is absent — without crashing)
- Live DB DDL applied via `npx supabase db query --linked --file ...` before commit (database-agent canonical Windows path)

## Risk
- **Behavior change**: zero. Trigger has never auto-created a postmortem because no UPDATE has ever set `ventures.status` to `'failed'` (impossible — the enum rejects it). Defensive cast preserves that observable behavior.
- **Future redesign**: a follow-up SD will re-target the trigger to `workflow_status='failed'` (the correct discriminator now that `workflow_status_enum` includes `'failed'`).

## Test plan
- [x] Live DB CREATE OR REPLACE FUNCTION applied (Supabase `db query --linked`)
- [ ] Smoke-tested transitively via re-applying SD-LEO-FEAT-STAGE-REJECT-KILL-001 migration 2 (kill-venture UPDATE on PrivacyPatrol AI venture)
- Unit/E2E test suites: skipped (pre-existing failures unrelated to trigger function — see memory `project_sd_man_infra_triage_377_completed.md`); fix is pure SQL DDL with no JS code paths

## Vision rubric
7/20 — Quick Fix path. Tier 1 routing (12 LOC).

## Pattern + harness backlog
- Issue pattern `PAT-DB-TRIG-ENUM-001` to be registered: "Trigger function compares NEW.&lt;col&gt; against literal not in col's enum"
- Harness backlog: PLAN database-agent inventory should dry-run trigger bodies against planned UPDATE payloads (caught here at 22P02 + earlier 42P13 parameter-default drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)