### PR TITLE
fix(QF-20260506-295): heal gate per-SD addressable-dim threshold floor parity

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -707,6 +707,47 @@ export function createHealBeforeCompleteGate(supabase) {
       const scoreAge = Math.round((Date.now() - new Date(latestScore.scored_at).getTime()) / (1000 * 60));
       const isSDHeal = latestScore.rubric_snapshot?.mode === 'sd-heal';
 
+      // QF-20260506-295: Apply per-SD vision_addressable_dimensions override.
+      // Mirrors LEAD-TO-PLAN GATE_VISION_SCORE behavior (QF-20260505-102) — when an SD
+      // declares a narrow addressable surface in metadata.vision_addressable_dimensions,
+      // the heal threshold drops proportionally with a 60% floor (MIN_ADJUSTED_THRESHOLD_RATIO).
+      // Without this, narrow-domain SDs (e.g. chairman-UI Reject dialog scoring 75/90 on
+      // the 8 dims it actually addresses) are permanently blocked at heal even when those
+      // addressable dims score well. Skip for corrective SDs (already use GRADE.A).
+      let dynamicAdjustment = null;
+      if (!isCorrective) {
+        try {
+          const { data: scoreDims } = await supabase
+            .from('eva_vision_scores')
+            .select('dimension_scores')
+            .eq('id', latestScore.id)
+            .single();
+          const { data: sdForOverride } = await supabase
+            .from('strategic_directives_v2')
+            .select('metadata')
+            .eq('id', sdUuid)
+            .single();
+          if (scoreDims?.dimension_scores && sdForOverride?.metadata) {
+            const { countAddressableDimensions, calculateDynamicThreshold } = await import(
+              '../../lead-to-plan/gates/vision-score.js'
+            );
+            const { addressable, total } = countAddressableDimensions(
+              sdType,
+              scoreDims.dimension_scores,
+              sdForOverride.metadata
+            );
+            const adjusted = calculateDynamicThreshold(threshold, addressable, total);
+            if (adjusted !== threshold) {
+              dynamicAdjustment = { base: threshold, adjusted, addressable, total };
+              console.log(`   📐 Dynamic threshold (per-SD addressable dims): ${threshold} → ${adjusted} (${addressable}/${total} addressable, MIN_ADJUSTED_THRESHOLD_RATIO floor)`);
+              threshold = adjusted;
+            }
+          }
+        } catch (e) {
+          console.debug('[HealBeforeComplete] dynamic threshold adjustment suppressed:', e?.message || e);
+        }
+      }
+
       console.log(`   SD Heal Score: ${sdHealScore}/100 (threshold: ${threshold})`);
       console.log(`   Score Age: ${scoreAge} min`);
       console.log(`   Score ID: ${latestScore.id}`);

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.test.js
@@ -32,7 +32,7 @@ import { createHealBeforeCompleteGate } from './heal-before-complete.js';
  * @param sdType - SD type (default 'feature' so FAST_HEAL_SD_TYPES path is skipped)
  * @param threshold - leo_config heal threshold (default 80)
  */
-function makeSupabase({ initialScore, sdType = 'feature', threshold = 80, parentSdId = null }) {
+function makeSupabase({ initialScore, sdType = 'feature', threshold = 80, parentSdId = null, metadata = {}, dimensionScores = null }) {
   const auditInserts = [];
   let currentScore = initialScore;
 
@@ -58,7 +58,7 @@ function makeSupabase({ initialScore, sdType = 'feature', threshold = 80, parent
           data: {
             id: 'sd-uuid', sd_key: 'SD-TEST-001', sd_type: sdType,
             parent_sd_id: parentSdId, status: 'in_progress', current_phase: 'PLAN',
-            metadata: {},
+            metadata,
           },
           error: null,
         };
@@ -81,15 +81,15 @@ function makeSupabase({ initialScore, sdType = 'feature', threshold = 80, parent
         limit() { return this; },
         async single() {
           if (this._opts?.head) return { count: 1, error: null };
-          return { data: { id: 'score-' + Math.random(), total_score: currentScore, threshold_action: currentScore >= threshold ? 'accept' : 'gap_closure_sd', rubric_snapshot: { gaps: ['gap1'], mode: 'sd-heal' }, scored_at: new Date().toISOString() }, error: null };
+          return { data: { id: 'score-' + Math.random(), total_score: currentScore, threshold_action: currentScore >= threshold ? 'accept' : 'gap_closure_sd', rubric_snapshot: { gaps: ['gap1'], mode: 'sd-heal' }, scored_at: new Date().toISOString(), dimension_scores: dimensionScores }, error: null };
         },
         then(r) {
           if (this._opts?.head) return Promise.resolve({ count: 1, error: null }).then(r);
-          return Promise.resolve({ data: [{ id: 'score-' + Math.random(), total_score: currentScore, threshold_action: currentScore >= threshold ? 'accept' : 'gap_closure_sd', rubric_snapshot: { gaps: ['gap1'], mode: 'sd-heal' }, scored_at: new Date().toISOString() }], error: null }).then(r);
+          return Promise.resolve({ data: [{ id: 'score-' + Math.random(), total_score: currentScore, threshold_action: currentScore >= threshold ? 'accept' : 'gap_closure_sd', rubric_snapshot: { gaps: ['gap1'], mode: 'sd-heal' }, scored_at: new Date().toISOString(), dimension_scores: dimensionScores }], error: null }).then(r);
         },
         insert(_payload) {
           if (healSequence.length > 0) currentScore = healSequence.shift();
-          return { select: () => Promise.resolve({ data: [{ id: 'inserted-' + Math.random(), total_score: currentScore, threshold_action: 'minor_sd', rubric_snapshot: { mode: 'sd-heal' }, scored_at: new Date().toISOString() }], error: null }) };
+          return { select: () => Promise.resolve({ data: [{ id: 'inserted-' + Math.random(), total_score: currentScore, threshold_action: 'minor_sd', rubric_snapshot: { mode: 'sd-heal' }, scored_at: new Date().toISOString(), dimension_scores: dimensionScores }], error: null }) };
         },
         update() { return { eq: () => Promise.resolve({ data: null, error: null }) }; },
       };
@@ -189,5 +189,52 @@ describe('HEAL_BEFORE_COMPLETE — FR-2 iteration loop', () => {
       expect(result.details.iterations).toBeLessThanOrEqual(MAX_HEAL_ITERATIONS);
     }
     expect(MAX_HEAL_ITERATIONS).toBe(3); // sanity: spec is honored
+  });
+
+  // QF-20260506-295: per-SD vision_addressable_dimensions threshold override
+  it('TS-E: per-SD addressable-dim override floors heal threshold (parity with LEAD-TO-PLAN gate)', async () => {
+    // SD has metadata.vision_addressable_dimensions with 10 patterns. Of the 13
+    // dimensions in the latest score, 7 match the patterns. With baseThreshold 90:
+    //   ratioBased  = 90 * (7/13) ≈ 48
+    //   floor       = 90 * MIN_ADJUSTED_THRESHOLD_RATIO(0.6) = 54
+    //   adjusted    = max(48, 54) = 54
+    //   effective   = 54 - 3 (tolerance) = 51
+    // Score 75 >= 51 → PASS. Without the patch: 75 < 87 → EXHAUSTED.
+    const dimensionScores = {
+      'cli_authoritative_workflow': 88,
+      'decision_filter_engine_escalation': 92,
+      'analysisstep_active_intelligence': 80,
+      'unlimited_compute_posture': 75,
+      'okr_driven_prioritization': 70,
+      'governance_first_chairman': 95,
+      'database_migrations': 90,
+      'event_bus_emission': 87,
+      'lifecycle_stage_orchestration': 91,
+      'stateless_shared_services': 89,
+      'eva_hub_orchestration': 86,
+      'cross_stage_data_contracts': 88,
+      'automation_by_default': 84,
+    };
+    const metadata = {
+      vision_addressable_dimensions: [
+        'chairman', 'governance', 'database', 'event', 'stateless',
+        'eva', 'lifecycle', 'data_contracts', 'automation', 'cross_stage',
+      ],
+    };
+    const supabase = makeSupabase({
+      initialScore: 75,
+      threshold: 90,
+      sdType: 'feature',
+      metadata,
+      dimensionScores,
+    });
+    const gate = createHealBeforeCompleteGate(supabase);
+    const result = await gate.validator(makeCtx({ sd_type: 'feature' }));
+
+    // Primary invariant: a 75 score with the override-floored threshold (54-ish)
+    // must PASS. The exact details path (within-buffer warning vs full pass) is
+    // not asserted because it depends on whether 75 lands above or below the
+    // adjusted base — both are PASS.
+    expect(result.passed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Wires the `MIN_ADJUSTED_THRESHOLD_RATIO=0.6` per-SD threshold floor (added to LEAD-TO-PLAN's `GATE_VISION_SCORE` by QF-20260505-102) into PLAN-TO-LEAD's `HEAL_BEFORE_COMPLETE` gate so both gates apply the same `metadata.vision_addressable_dimensions` adjustment. Closes the writer/consumer asymmetry that blocked SD-LEO-FEAT-STAGE-REJECT-KILL-001 at heal despite passing LEAD-TO-PLAN with the override.
- Same asymmetry class as today's earlier QF-20260506-836 (sentinel writer never read by consumer); 3rd witness today after QF-552 (trigger enum) and QF-836 (read coverage).

## Test plan
- [x] 5/5 `heal-before-complete.test.js` cases pass — 4 existing iteration-loop invariants + new TS-E confirming 75-score feature SD with metadata override → PASS (would EXHAUST without patch).
- [x] 35/35 `vision-score.test.js` cases still pass (helper exports unchanged).
- [ ] Post-merge: re-run PLAN-TO-LEAD on SD-LEO-FEAT-STAGE-REJECT-KILL-001; expect score 75 ≥ adjusted effective threshold ~52 → PASS, then LEAD-FINAL-APPROVAL.

## Notes
- Corrective SDs unaffected (already use GRADE.A=93; `if (!isCorrective)` guards the adjustment).
- SDs without metadata override unaffected (helper falls back to sd_type-level patterns; for `feature` that's `null` → no adjustment).
- Fast-heal SD types (infrastructure/documentation/fix/refactor/enhancement) store non-vision dim_scores; pattern matching yields zero matches → no-op.
- Issue pattern `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` to be registered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)