### PR TITLE
feat(SD-LEO-INFRA-CROSS-REPO-MERGE-001): scope PR_MERGE_VERIFICATION repo scan to target_application + metadata.target_repos

### DIFF
--- a/database/migrations/20260506160000_backfill_target_repos_cross_repo_sds.sql
+++ b/database/migrations/20260506160000_backfill_target_repos_cross_repo_sds.sql
@@ -1,0 +1,65 @@
+-- ============================================================================
+-- Migration: 20260506160000_backfill_target_repos_cross_repo_sds.sql
+-- SD: SD-LEO-INFRA-CROSS-REPO-MERGE-001
+-- Date: 2026-05-06
+--
+-- Purpose:
+--   Backfill `metadata.target_repos = ['EHG', 'EHG_Engineer']` on three known
+--   cross-repo SDs so the new PR_MERGE_VERIFICATION repo-scope helper
+--   (computeReposForSD in lead-final-approval/gates.js) preserves their
+--   intended both-repo scan behavior post-deploy.
+--
+--   Without this backfill, those SDs would fall through to the Tier-2 branch
+--   of computeReposForSD (which derives a SINGLE repo from target_application)
+--   and stop scanning the OTHER repo — losing coverage on cross-repo work
+--   that has already shipped.
+--
+-- Rows targeted (3, all completed):
+--   - SD-LEO-FEAT-STAGE-REJECT-KILL-001     (target_application=EHG; cross-repo)
+--   - SD-LEO-FEAT-STAGE-POST-LAUNCH-001     (target_application=EHG; cross-repo)
+--   - SD-LEO-FIX-REVERT-CROSS-VENTURE-001   (target_application=EHG_Engineer; cross-repo cleanup)
+--
+-- Idempotency:
+--   * jsonb_set with create_missing=true preserves all other metadata keys.
+--   * WHERE clause guards against double-application (NOT (metadata ? 'target_repos')).
+--   * Re-running matches 0 rows after first apply.
+--
+-- ROLLBACK:
+--   UPDATE strategic_directives_v2
+--   SET metadata = metadata - 'target_repos'
+--   WHERE sd_key IN (
+--     'SD-LEO-FEAT-STAGE-REJECT-KILL-001',
+--     'SD-LEO-FEAT-STAGE-POST-LAUNCH-001',
+--     'SD-LEO-FIX-REVERT-CROSS-VENTURE-001'
+--   );
+-- ============================================================================
+
+BEGIN;
+
+DO $backfill$
+DECLARE
+  v_rows_affected INTEGER;
+BEGIN
+  WITH backfilled AS (
+    UPDATE strategic_directives_v2
+    SET metadata = jsonb_set(
+      coalesce(metadata, '{}'::jsonb),
+      '{target_repos}',
+      '["EHG", "EHG_Engineer"]'::jsonb,
+      true
+    )
+    WHERE sd_key IN (
+      'SD-LEO-FEAT-STAGE-REJECT-KILL-001',
+      'SD-LEO-FEAT-STAGE-POST-LAUNCH-001',
+      'SD-LEO-FIX-REVERT-CROSS-VENTURE-001'
+    )
+      AND (NOT (metadata ? 'target_repos') OR metadata->'target_repos' = 'null')
+    RETURNING sd_key
+  )
+  SELECT COUNT(*) INTO v_rows_affected FROM backfilled;
+
+  RAISE NOTICE '[SD-LEO-INFRA-CROSS-REPO-MERGE-001] Backfilled metadata.target_repos on % cross-repo SDs.', v_rows_affected;
+END;
+$backfill$;
+
+COMMIT;

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -53,6 +53,62 @@ function getRepoPath(repoName) {
 }
 
 /**
+ * Compute the list of repos to scan for a given SD's PR_MERGE_VERIFICATION.
+ *
+ * SD-LEO-INFRA-CROSS-REPO-MERGE-001: Closes the gate-side phantom-branch class
+ * where single-repo SDs were blocked by stale branches in the OTHER repo.
+ *
+ * Precedence:
+ *   1. sd.metadata.target_repos[] — explicit allowlist (canonical for cross-repo SDs)
+ *   2. sd.target_application — single-repo derivation (case-insensitive)
+ *   3. fallback to both repos with WARN log (legacy SDs without metadata)
+ *
+ * @param {Object} sd - Strategic Directive record
+ * @returns {Array<{githubRepo: string, localPath: string}>}
+ */
+export function computeReposForSD(sd) {
+  const sdId = sd?.sd_key || sd?.id || 'unknown';
+  const all = [
+    { githubRepo: 'rickfelix/ehg', localPath: getRepoPath('EHG') },
+    { githubRepo: 'rickfelix/EHG_Engineer', localPath: getRepoPath('EHG_Engineer') }
+  ];
+
+  // Tier 1: explicit metadata.target_repos[] allowlist
+  const targetRepos = sd?.metadata?.target_repos;
+  if (Array.isArray(targetRepos) && targetRepos.length > 0) {
+    const allowed = targetRepos.map(r => String(r).toLowerCase().trim());
+    const result = all.filter(r => {
+      const shortName = r.githubRepo.split('/')[1].toLowerCase();
+      return allowed.includes(shortName) || allowed.includes(r.githubRepo.toLowerCase());
+    });
+    if (result.length > 0) {
+      console.log(`[GATE_PR_MERGE_REPO_SCOPE] sd=${sdId} target_application=${sd?.target_application || 'NULL'} target_repos=${JSON.stringify(targetRepos)} scanning=${JSON.stringify(result.map(r => r.githubRepo))}`);
+      return result;
+    }
+  }
+
+  // Tier 2: derived from target_application (case-insensitive)
+  const ta = (typeof sd?.target_application === 'string') ? sd.target_application.toLowerCase().trim() : '';
+  if (ta) {
+    if (ta.includes('engineer')) {
+      const result = [all[1]]; // EHG_Engineer only
+      console.log(`[GATE_PR_MERGE_REPO_SCOPE] sd=${sdId} target_application=${sd.target_application} target_repos=NULL scanning=${JSON.stringify(result.map(r => r.githubRepo))}`);
+      return result;
+    }
+    if (ta === 'ehg' || ta === 'app' || ta === 'application') {
+      const result = [all[0]]; // EHG only
+      console.log(`[GATE_PR_MERGE_REPO_SCOPE] sd=${sdId} target_application=${sd.target_application} target_repos=NULL scanning=${JSON.stringify(result.map(r => r.githubRepo))}`);
+      return result;
+    }
+    // Venture-name or unknown — fall through to Tier 3
+  }
+
+  // Tier 3: legacy fallback — scan both repos with WARN
+  console.warn(`[GATE_PR_MERGE_REPO_SCOPE] sd=${sdId} no target_application or target_repos — scanning both repos (legacy behavior)`);
+  return all;
+}
+
+/**
  * Create Gate 1: PLAN-TO-LEAD handoff verification
  * @param {Object} supabase - Supabase client
  * @returns {Object} Gate definition
@@ -470,10 +526,12 @@ export function createPRMergeVerificationGate() {
       try {
         const { execSync } = await import('child_process');
 
-        const repos = ['rickfelix/ehg', 'rickfelix/EHG_Engineer'];
+        // SD-LEO-INFRA-CROSS-REPO-MERGE-001: scope repo scan to SD's target_application
+        // and metadata.target_repos[] instead of hardcoding both repos.
+        const reposWithPaths = computeReposForSD(ctx.sd);
         const openPRs = [];
 
-        for (const repo of repos) {
+        for (const { githubRepo: repo } of reposWithPaths) {
           try {
             const result = execSync(
               `gh pr list --repo ${repo} --state open --json number,title,headRefName,url --limit 100`,
@@ -529,10 +587,12 @@ export function createPRMergeVerificationGate() {
         console.log(`   Checked patterns: ${branchPatterns.join(', ')}`);
 
         // Check for unmerged branches with commits
+        // SD-LEO-INFRA-CROSS-REPO-MERGE-001: reuse the same scoped repo list (computeReposForSD)
+        // for the unmerged-branch scan to keep both loops consuming a single source of truth
+        // (writer/consumer asymmetry class — PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
         const unmergedBranches = [];
-        for (const repo of repos) {
+        for (const { githubRepo: repo, localPath: repoPath } of reposWithPaths) {
           try {
-            const repoPath = repo === 'rickfelix/ehg' ? getRepoPath('EHG') : getRepoPath('EHG_Engineer');
 
             // SD-LLM-CONTRACT-PIPELINE-TEST-ORCH-001-B RCA: prune stale remote-tracking refs
             // before checking branches. Without this, squash-merged branches whose remote was

--- a/scripts/verify-git-branch-status.js
+++ b/scripts/verify-git-branch-status.js
@@ -84,6 +84,17 @@ class GitBranchVerifier {
     this.worktreeMode = options.worktreeMode || false;
     this.expectedBranchName = this.generateBranchName(sdId, sdTitle);
 
+    // SD-LEO-INFRA-CROSS-REPO-MERGE-001 (FR-2): defensive scope assertion.
+    // When caller passes options.targetApplication, warn loudly if appPath
+    // doesn't match — defense against future regressions in
+    // BaseExecutor.determineTargetRepository. Warn-only, non-blocking.
+    if (options.targetApplication) {
+      const expectedPath = resolveRepoPath(options.targetApplication);
+      if (expectedPath && path.resolve(expectedPath) !== path.resolve(appPath)) {
+        console.warn(`[CROSS_REPO_SCOPE_WARN] verify-git-branch-status running on ${appPath} but SD targets ${options.targetApplication} (expected path: ${expectedPath})`);
+      }
+    }
+
     this.results = {
       branchExists: false,
       onCorrectBranch: false,

--- a/tests/unit/lead-final-pr-merge-verification-cross-repo.test.js
+++ b/tests/unit/lead-final-pr-merge-verification-cross-repo.test.js
@@ -1,0 +1,98 @@
+/**
+ * computeReposForSD unit tests
+ * SD-LEO-INFRA-CROSS-REPO-MERGE-001 (FR-4)
+ *
+ * Verifies the precedence rules and case-handling of the repo-scope helper
+ * used by PR_MERGE_VERIFICATION at LEAD-FINAL-APPROVAL.
+ *
+ *   Tier 1: metadata.target_repos[]    → explicit allowlist
+ *   Tier 2: target_application         → single-repo derivation (case-insensitive)
+ *   Tier 3: fallback both with WARN    → legacy SDs without metadata
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { computeReposForSD } from '../../scripts/modules/handoff/executors/lead-final-approval/gates.js';
+
+describe('computeReposForSD (SD-LEO-INFRA-CROSS-REPO-MERGE-001)', () => {
+  let warnSpy, logSpy;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('FR-4a: target_application=EHG_Engineer → only scans EHG_Engineer', () => {
+    const sd = { sd_key: 'SD-DEMO-CR-001', target_application: 'EHG_Engineer', metadata: null };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(1);
+    expect(result[0].githubRepo).toBe('rickfelix/EHG_Engineer');
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+    const allLogMessages = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allLogMessages).toContain('[GATE_PR_MERGE_REPO_SCOPE]');
+    expect(allLogMessages).toContain('rickfelix/EHG_Engineer');
+  });
+
+  it('FR-4b: target_application=EHG → only scans EHG', () => {
+    const sd = { sd_key: 'SD-DEMO-CR-002', target_application: 'EHG', metadata: null };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(1);
+    expect(result[0].githubRepo).toBe('rickfelix/ehg');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('FR-4c: metadata.target_repos[] wins over target_application', () => {
+    const sd = {
+      sd_key: 'SD-DEMO-CR-003',
+      target_application: 'EHG_Engineer',
+      metadata: { target_repos: ['EHG', 'EHG_Engineer'] }
+    };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(2);
+    const repos = result.map(r => r.githubRepo);
+    expect(repos).toContain('rickfelix/ehg');
+    expect(repos).toContain('rickfelix/EHG_Engineer');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('FR-4d: NULL target_application + NULL metadata → fallback both with WARN', () => {
+    const sd = { sd_key: 'SD-DEMO-CR-004', target_application: null, metadata: null };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(2);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnMsg = warnSpy.mock.calls[0][0];
+    expect(warnMsg).toContain('[GATE_PR_MERGE_REPO_SCOPE]');
+    expect(warnMsg).toContain('legacy behavior');
+  });
+
+  it('FR-4e: venture-name target_application falls back to both with WARN', () => {
+    const sd = { sd_key: 'SD-DEMO-CR-005', target_application: 'PrivacyPatrol AI', metadata: null };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(2);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('FR-4f: target_application case-insensitive (lowercase ehg_engineer)', () => {
+    const sd = { sd_key: 'SD-DEMO-CR-006', target_application: 'ehg_engineer', metadata: null };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(1);
+    expect(result[0].githubRepo).toBe('rickfelix/EHG_Engineer');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('FR-4g: empty target_repos[] falls through to target_application', () => {
+    const sd = {
+      sd_key: 'SD-DEMO-CR-007',
+      target_application: 'EHG_Engineer',
+      metadata: { target_repos: [] }
+    };
+    const result = computeReposForSD(sd);
+    expect(result).toHaveLength(1);
+    expect(result[0].githubRepo).toBe('rickfelix/EHG_Engineer');
+  });
+});


### PR DESCRIPTION
## Summary
- PR_MERGE_VERIFICATION at LEAD-FINAL hardcoded `const repos = ['rickfelix/ehg', 'rickfelix/EHG_Engineer'];` and iterated both repos unconditionally, blocking single-repo SDs whenever a stale branch with their name pattern existed in the OTHER repo.
- New `computeReposForSD(sd)` helper with 3-tier precedence: `metadata.target_repos[]` → `target_application` (case-insensitive) → fallback both with WARN.
- Both consumers (open-PR scan + unmerged-branch scan) consume the helper — closes writer/consumer asymmetry for this gate.
- Backfilled `metadata.target_repos=["EHG","EHG_Engineer"]` on 3 known cross-repo SDs (REJECT-KILL, POST-LAUNCH, REVERT-CROSS-VENTURE) so they keep both-repo scan post-deploy.

## Why this scope
Replaces harness backlog `a3d30c4a-03ab-4477-9362-4515e08684c5` filed yesterday during SD-LEO-INFRA-CLAIM-DUAL-COLUMN-001 LEAD-FINAL block. Validation-agent PLAN verdict PASS@88 with 6 refinements (all incorporated): lowercase compare, both loops consume helper, empty-array edge case test, idempotency guard on backfill.

## Test plan
- [x] `npx vitest run tests/unit/lead-final-pr-merge-verification-cross-repo.test.js` — 7/7 pass (376ms)
- [x] `npx supabase db query --linked --file <migration>` — backfill applied; 3 cross-repo SDs now have `target_repos=["EHG","EHG_Engineer"]`
- [x] Existing slug-truncation regression test still green (8/8)
- [x] `node --check` clean on both edited files

## LOC
238 insertions / 4 deletions. Test file (98 LOC) and migration (65 LOC, mostly comments + rollback) are required by FR-3 + FR-4. Net semantic change ~85 LOC.

## Pattern
Third witness for `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` applied to gate scopes (not column-clearing). The precheck-side reads target_application correctly via `BaseExecutor.determineTargetRepository`; the gate-side now mirrors that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)