### PR TITLE
feat(SD-LEO-INFRA-LEO-CREATE-CROSS-001): --target-repos flag for cross-repo SD metadata at creation time

### DIFF
--- a/.claude/commands/sd-create.md
+++ b/.claude/commands/sd-create.md
@@ -23,7 +23,36 @@ SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-learn <pattern-id>
 SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-feedback <id>
 SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-plan [path]
 node scripts/modules/sd-key-generator.js --child <parent-key> <index>
+
+# Cross-repo SDs — set metadata.target_repos[] at creation time
+# (SD-LEO-INFRA-LEO-CREATE-CROSS-001 — pairs with PR_MERGE_VERIFICATION at LEAD-FINAL)
+SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js LEO <type> "<title>" --target-repos EHG,EHG_Engineer
 ```
+
+## Cross-Repo SDs (--target-repos)
+
+When the user describes work that spans BOTH `rickfelix/ehg` (frontend) AND
+`rickfelix/EHG_Engineer` (backend) — for example, an EHG UI dialog backed by
+an EHG_Engineer migration + RPC — set `metadata.target_repos[]` at creation
+time via the `--target-repos` flag.
+
+**Why**: PR_MERGE_VERIFICATION at LEAD-FINAL uses `computeReposForSD(sd)` to
+scope its scan. Without `metadata.target_repos[]`, single-repo SDs may
+trip on phantom branches in the OTHER repo, and cross-repo SDs may stop
+scanning the second repo.
+
+**Valid values** (case-insensitive, normalized): `EHG`, `EHG_Engineer`.
+
+**Examples**:
+```bash
+# Single-repo EHG_Engineer SD (most LEO-INFRA SDs) — flag NOT needed
+SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js LEO infrastructure "Backend-only fix"
+
+# Cross-repo SD (REJECT-KILL pattern: EHG UI + EHG_Engineer migration)
+SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js LEO feature "Reject venture dialog" --target-repos EHG,EHG_Engineer
+```
+
+Invalid input fails loud with `[INVALID_TARGET_REPOS]` bracket-tokenized error.
 
 ## Step 0: Vision Readiness Rubric
 

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -56,6 +56,58 @@ import { detectFromKeyChanges } from './modules/handoff/executors/lead-to-plan/g
 const supabase = createSupabaseServiceClient();
 
 // ============================================================================
+// Cross-Repo Target Repos Parsing (SD-LEO-INFRA-LEO-CREATE-CROSS-001)
+// ============================================================================
+
+/**
+ * Allowed platform repo names for the --target-repos flag.
+ * Writer/consumer parity with computeReposForSD() in
+ * scripts/modules/handoff/executors/lead-final-approval/gates.js (SD-LEO-INFRA-CROSS-REPO-MERGE-001).
+ * Canonical casing: 'EHG' and 'EHG_Engineer'.
+ */
+export const ALLOWED_REPOS = new Set(['EHG', 'EHG_Engineer']);
+
+/**
+ * Parse the --target-repos comma-separated list, validate against ALLOWED_REPOS,
+ * normalize case (ehg → EHG, ehg_engineer → EHG_Engineer), dedup, return array.
+ *
+ * @param {string|null|undefined} raw - Comma-separated repo list (e.g., "EHG,EHG_Engineer")
+ * @returns {string[]|null} Normalized array; null if raw is empty/missing
+ *
+ * On invalid repo: console.error with `[INVALID_TARGET_REPOS]` bracket-tokenized
+ * message and process.exit(1). Pure function otherwise (no side effects).
+ */
+export function parseTargetReposArg(raw) {
+  if (raw == null || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+
+  const parts = trimmed.split(',').map(s => s.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const normalized = [];
+  const seen = new Set();
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    let canonical = null;
+    if (lower === 'ehg_engineer') canonical = 'EHG_Engineer';
+    else if (lower === 'ehg') canonical = 'EHG';
+
+    if (canonical === null || !ALLOWED_REPOS.has(canonical)) {
+      console.error(`\n❌ [INVALID_TARGET_REPOS] Invalid --target-repos value: "${part}". Valid: ${[...ALLOWED_REPOS].join(', ')}.`);
+      process.exit(1);
+    }
+
+    if (!seen.has(canonical)) {
+      seen.add(canonical);
+      normalized.push(canonical);
+    }
+  }
+
+  return normalized;
+}
+
+// ============================================================================
 // Venture Context Resolution (SD-LEO-INFRA-SD-NAMESPACING-001)
 // ============================================================================
 
@@ -533,6 +585,7 @@ async function createChild(parentKey, index = 0, overrides = {}) {
       ...(overrides.securityReviewed ? { security_reviewed: true } : {}),
       ...(overrides.visionKey ? { vision_key: overrides.visionKey } : {}),
       ...(overrides.archKey ? { arch_key: overrides.archKey } : {}),
+      ...(overrides.targetRepos ? { target_repos: overrides.targetRepos } : {}),
     }
   });
 
@@ -783,6 +836,7 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
       ...(overrides.archKey ? { arch_key: overrides.archKey } : {}),
       ...(overrides.migrationReviewed ? { migration_reviewed: true } : {}),
       ...(overrides.securityReviewed ? { security_reviewed: true } : {}),
+      ...(overrides.targetRepos ? { target_repos: overrides.targetRepos } : {}),
     }
   };
   if (parsed.priority) createOptions.priority = parsed.priority;
@@ -1720,6 +1774,14 @@ Flags:
   --scope-slice <JSON>  (--child only) Declare the slice of parent orchestrator scope this
                         child claims. JSON shape: {stages?: number[], deliverable_globs?: string[]}.
                         Example: --scope-slice='{"stages":[18]}'
+  --target-repos <list> Set metadata.target_repos[] for cross-repo SDs (comma-separated).
+                        Valid values: EHG, EHG_Engineer (case-insensitive; normalized).
+                        When set, PR_MERGE_VERIFICATION at LEAD-FINAL scopes its scan
+                        to ONLY these repos. Required for SDs spanning both platform repos.
+                        Example: --target-repos EHG,EHG_Engineer
+                        Pairs with computeReposForSD() at lead-final-approval/gates.js
+                        (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in all 3 modes:
+                        direct LEO, --from-plan, --child.
   --help             Show this help message
 
 Dependency Field Guide:
@@ -1815,6 +1877,9 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // Parse boolean review flags (satisfy GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE)
       const migrationReviewed = args.includes('--migration-reviewed');
       const securityReviewed = args.includes('--security-reviewed');
+      // SD-LEO-INFRA-LEO-CREATE-CROSS-001: --target-repos for cross-repo SDs
+      const targetReposIdxPlan = args.indexOf('--target-repos');
+      const targetReposPlan = targetReposIdxPlan !== -1 ? parseTargetReposArg(args[targetReposIdxPlan + 1]) : null;
       // Path is any arg that isn't a flag or a flag's value
       const flagValuePositions = new Set(
         [
@@ -1823,11 +1888,13 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           priorityIdx !== -1 ? priorityIdx + 1 : -1,
           visionKeyIdx !== -1 ? visionKeyIdx + 1 : -1,
           archKeyIdx !== -1 ? archKeyIdx + 1 : -1,
+          targetReposIdxPlan !== -1 ? targetReposIdxPlan + 1 : -1,
         ].filter(i => i > 0)
       );
       const knownPlanFlags = new Set([
         '--yes', '-y', '--type', '--title', '--priority', '--from-plan',
-        '--vision-key', '--arch-key', '--migration-reviewed', '--security-reviewed'
+        '--vision-key', '--arch-key', '--migration-reviewed', '--security-reviewed',
+        '--target-repos'
       ]);
       const planPath = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !flagValuePositions.has(i) && !knownPlanFlags.has(arg)
@@ -1840,6 +1907,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         archKey,
         migrationReviewed,
         securityReviewed,
+        targetRepos: targetReposPlan,
       });
     } else if (args[0] === '--child') {
       // Parse --type and --title overrides for child creation
@@ -1855,6 +1923,11 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // Parse review flags for child creation (GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE)
       if (args.includes('--migration-reviewed')) childOverrides.migrationReviewed = true;
       if (args.includes('--security-reviewed')) childOverrides.securityReviewed = true;
+      // SD-LEO-INFRA-LEO-CREATE-CROSS-001: --target-repos for cross-repo child SDs
+      const childTargetReposIdx = args.indexOf('--target-repos');
+      if (childTargetReposIdx !== -1 && args[childTargetReposIdx + 1]) {
+        childOverrides.targetRepos = parseTargetReposArg(args[childTargetReposIdx + 1]);
+      }
       // Parse --vision-key / --arch-key for child creation
       const childVisionKeyIdx = args.indexOf('--vision-key');
       if (childVisionKeyIdx !== -1 && args[childVisionKeyIdx + 1]) {
@@ -1903,7 +1976,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // args[1] = parent key, args[2] = index (skip flag positions)
       const childParentKey = args[1];
       const flagValuePositionsChild = new Set(
-        [childTypeIdx, childTitleIdx, childVisionKeyIdx, childArchKeyIdx]
+        [childTypeIdx, childTitleIdx, childVisionKeyIdx, childArchKeyIdx, childTargetReposIdx]
           .filter(i => i !== -1).map(i => i + 1)
       );
       // --scope-slice value (next arg) is also a flag value to skip when finding the index arg
@@ -1917,7 +1990,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
     } else {
       // Direct creation: <source> <type> "<title>"
       // Detect unknown flags to prevent silent corruption (SD-LEO-FIX-CREATE-ARGS-001)
-      const knownDirectFlags = new Set(['--venture', '--vision-key', '--arch-key']);
+      const knownDirectFlags = new Set(['--venture', '--vision-key', '--arch-key', '--target-repos']);
       const unknownFlags = args.filter(a => a.startsWith('-') && !knownDirectFlags.has(a));
       if (unknownFlags.length > 0) {
         console.error('\n❌ Unknown flag(s): ' + unknownFlags.join(', '));
@@ -1934,7 +2007,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const [source, type, ...titleParts] = args;
       // Strip flags and their values from the title (SD-DISTILLTOBRAINSTORM quality fix)
       // Without this, --vision-key VALUE --arch-key VALUE leak into the title text
-      const flagsWithValues = new Set(['--venture', '--vision-key', '--arch-key']);
+      const flagsWithValues = new Set(['--venture', '--vision-key', '--arch-key', '--target-repos']);
       const cleanedTitleParts = [];
       for (let i = 0; i < titleParts.length; i++) {
         if (flagsWithValues.has(titleParts[i])) {
@@ -2081,6 +2154,9 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const visionKey = visionKeyIdx !== -1 ? args[visionKeyIdx + 1] : null;
       const archKeyIdx = args.indexOf('--arch-key');
       const archKey = archKeyIdx !== -1 ? args[archKeyIdx + 1] : null;
+      // SD-LEO-INFRA-LEO-CREATE-CROSS-001: --target-repos for cross-repo SDs
+      const targetReposIdx = args.indexOf('--target-repos');
+      const targetRepos = targetReposIdx !== -1 ? parseTargetReposArg(args[targetReposIdx + 1]) : null;
 
       // FR-003: Auto-route to orchestrator creator when arch key has phases
       if (visionKey && archKey) {
@@ -2161,7 +2237,8 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           ...phase0Metadata,
           ...(visionKey && { vision_key: visionKey }),
           ...(archKey && { arch_key: archKey }),
-          ...(enriched?.scope && { scope: enriched.scope })
+          ...(enriched?.scope && { scope: enriched.scope }),
+          ...(targetRepos && { target_repos: targetRepos })
         }
       });
     }

--- a/tests/unit/leo-create-sd-target-repos.test.js
+++ b/tests/unit/leo-create-sd-target-repos.test.js
@@ -1,0 +1,94 @@
+/**
+ * parseTargetReposArg unit tests
+ * SD-LEO-INFRA-LEO-CREATE-CROSS-001 (FR-5)
+ *
+ * Verifies the --target-repos flag parser exported from scripts/leo-create-sd.js.
+ * Pure function: validates against ALLOWED_REPOS, normalizes case, dedups.
+ * Invalid input → console.error([INVALID_TARGET_REPOS] ...) + process.exit(1).
+ *
+ * Writer/consumer parity: ALLOWED_REPOS = {EHG, EHG_Engineer} matches the
+ * canonical names accepted by computeReposForSD() in
+ * scripts/modules/handoff/executors/lead-final-approval/gates.js
+ * (SD-LEO-INFRA-CROSS-REPO-MERGE-001).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parseTargetReposArg, ALLOWED_REPOS } from '../../scripts/leo-create-sd.js';
+
+describe('parseTargetReposArg (SD-LEO-INFRA-LEO-CREATE-CROSS-001)', () => {
+  let exitSpy, errorSpy;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('FR-5a: single repo → array with one canonical entry', () => {
+    expect(parseTargetReposArg('EHG')).toEqual(['EHG']);
+    expect(parseTargetReposArg('EHG_Engineer')).toEqual(['EHG_Engineer']);
+  });
+
+  it('FR-5b: both repos comma-separated → preserves order', () => {
+    expect(parseTargetReposArg('EHG,EHG_Engineer')).toEqual(['EHG', 'EHG_Engineer']);
+    expect(parseTargetReposArg('EHG_Engineer,EHG')).toEqual(['EHG_Engineer', 'EHG']);
+  });
+
+  it('FR-5c: lowercase normalization → canonical case', () => {
+    expect(parseTargetReposArg('ehg,ehg_engineer')).toEqual(['EHG', 'EHG_Engineer']);
+    expect(parseTargetReposArg('EHG,ehg_ENGINEER')).toEqual(['EHG', 'EHG_Engineer']);
+  });
+
+  it('FR-5d: dedup duplicates → single entry preserved', () => {
+    expect(parseTargetReposArg('EHG,EHG')).toEqual(['EHG']);
+    expect(parseTargetReposArg('EHG,EHG_Engineer,EHG,EHG_Engineer')).toEqual(['EHG', 'EHG_Engineer']);
+    expect(parseTargetReposArg('ehg,EHG,Ehg')).toEqual(['EHG']); // case-insensitive dedup
+  });
+
+  it('FR-5e: whitespace tolerance → trimmed before validation', () => {
+    expect(parseTargetReposArg(' EHG , EHG_Engineer ')).toEqual(['EHG', 'EHG_Engineer']);
+    expect(parseTargetReposArg('  EHG_Engineer  ')).toEqual(['EHG_Engineer']);
+  });
+
+  it('FR-5f: empty/null/undefined input → null (no metadata key set)', () => {
+    expect(parseTargetReposArg('')).toBeNull();
+    expect(parseTargetReposArg('   ')).toBeNull();
+    expect(parseTargetReposArg(null)).toBeNull();
+    expect(parseTargetReposArg(undefined)).toBeNull();
+  });
+
+  it('FR-5g: invalid repo → bracket-tokenized error + process.exit(1)', () => {
+    expect(() => parseTargetReposArg('EHG,FooBar')).toThrow('process.exit(1)');
+    expect(errorSpy).toHaveBeenCalled();
+    const errMsg = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(errMsg).toContain('[INVALID_TARGET_REPOS]');
+    expect(errMsg).toContain('FooBar');
+    expect(errMsg).toContain('EHG, EHG_Engineer'); // valid values listed
+  });
+
+  it('FR-5h: empty entries between commas → silently dropped', () => {
+    expect(parseTargetReposArg('EHG,,EHG_Engineer')).toEqual(['EHG', 'EHG_Engineer']);
+    expect(parseTargetReposArg(',EHG,')).toEqual(['EHG']);
+  });
+
+  it('FR-5i: ALLOWED_REPOS export matches consumer expectations', () => {
+    // Writer/consumer parity check (validation-agent's #5 refinement)
+    expect(ALLOWED_REPOS).toBeInstanceOf(Set);
+    expect(ALLOWED_REPOS.has('EHG')).toBe(true);
+    expect(ALLOWED_REPOS.has('EHG_Engineer')).toBe(true);
+    expect(ALLOWED_REPOS.has('ehg')).toBe(false); // canonical case only
+    expect(ALLOWED_REPOS.size).toBe(2);
+  });
+
+  it('FR-5j: non-string input → null (defensive)', () => {
+    expect(parseTargetReposArg(123)).toBeNull();
+    expect(parseTargetReposArg(['EHG'])).toBeNull();
+    expect(parseTargetReposArg({ repo: 'EHG' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes operator-experience gap from SD-LEO-INFRA-CROSS-REPO-MERGE-001 (PR #3575).
- New \`--target-repos <list>\` flag on \`leo-create-sd.js\` sets \`metadata.target_repos[]\` at creation time.
- Pure helper \`parseTargetReposArg\` validates against \`ALLOWED_REPOS = {EHG, EHG_Engineer}\`, normalizes case, dedups; invalid → \`[INVALID_TARGET_REPOS]\` bracket error + exit 1.
- Wired into all 3 creation paths: direct LEO, \`--from-plan\`, \`--child\`.

## Why
PR_MERGE_VERIFICATION at LEAD-FINAL uses \`computeReposForSD(sd)\` with 3-tier precedence: \`metadata.target_repos[]\` (canonical) → \`target_application\` (single-repo) → fallback both. Previously, future cross-repo SDs (REJECT-KILL pattern) had no canonical way to set Tier 1 — defaulting to Tier 2 lost coverage on the OTHER repo, OR falling to Tier 3 hit the WARN fallback.

## Validation
Validation-agent PLAN verdict CONCERNS@82 → all 5 refinements incorporated:
1. Metadata sites = 3 per --vision-key precedent (not 8-central thread)
2. Help text in leo-create-sd.js is canonical (sd-create.md is add-on, not primary)
3. Skip-list = 5 locations including \`flagValuePositionsChild\` line 1905 (validation-agent caught the missed location)
4. ≥8 subtests delivered (10 actual)
5. \`ALLOWED_REPOS\` Set writer/consumer parity with paired SD (case-normalize-first, exact-match)

## Test plan
- [x] 10/10 vitest subtests pass (\`npx vitest run tests/unit/leo-create-sd-target-repos.test.js\`, 540ms)
- [x] Smoke: \`node scripts/leo-create-sd.js --help\` shows flag with description
- [x] Smoke: \`parseTargetReposArg('EHG,ehg_engineer')\` returns \`['EHG','EHG_Engineer']\`
- [x] \`node --check\` clean

## LOC
205 insertions / 5 deletions. Test file (94 LOC) + skill prompt update (29 LOC) are required by FR-5 + FR-3. Net core change ~80 LOC across helper + 3 parse blocks + 3 metadata spreads + 5 skip-list updates + help text.

## Process learning
SD creation tripped SMOKE_TEST_MISSING preflight because \`buildDefaultSmokeTestSteps\` keyword detector missed 'leo-create-sd' in title. Filed as harness backlog (root cause: keyword list too narrow + scope not re-evaluated post-update). Workaround applied; fix deferred to follow-up SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)