### PR TITLE
feat(SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001): keyword detector + atomic INSERT for createSD plan-file path

### DIFF
--- a/scripts/__tests__/leo-create-sd-smoke-detector.test.js
+++ b/scripts/__tests__/leo-create-sd-smoke-detector.test.js
@@ -1,0 +1,122 @@
+// SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001
+//
+// Covers FR-1 (keyword expansion) + FR-2 (three-step fallback chain) + FR-3 (atomic INSERT)
+// + FR-4 (named export) + FR-5 (>=12 vitest cases). 16 subtests + 1 regression guard for "gates".
+//
+// Direct-ESM-import pattern (mirrors sd-creation-roundtrip.test.js, NOT spawn-probe).
+// FR-2 fallback chain is tested by re-implementing the verbatim resolution helper
+// from scripts/leo-create-sd.js:1324 — if production drifts, this helper would also need to
+// drift, so static assertions in TS-17 + FR-3 regression guard catch silent regressions.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { buildDefaultSmokeTestSteps } from '../leo-create-sd.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const SOURCE_PATH = path.resolve(__dirname, '../leo-create-sd.js');
+const SOURCE = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+// Verbatim mirror of the call-site fallback at scripts/leo-create-sd.js:1324
+// `options.scope ?? options.metadata?.scope ?? description`
+function resolveScope(options, description) {
+  return options.scope ?? options.metadata?.scope ?? description;
+}
+
+describe('FR-1: codeKeywords expansion (new keywords fire)', () => {
+  for (const kw of ['flag', 'cli', 'wizard', 'detector', 'parser', 'helper', 'validator', 'hook']) {
+    it(`TS new-keyword: "${kw}" triggers detection on infrastructure SD`, () => {
+      const scope = `Adds a ${kw} to the harness.`;
+      const steps = buildDefaultSmokeTestSteps('infrastructure', 'Untitled', scope);
+      expect(steps).toHaveLength(3);
+      expect(steps[0].instruction).toContain('Run the modified');
+    });
+  }
+});
+
+describe('FR-1: existing keyword regression', () => {
+  it('TS-8: existing keyword ".js" still fires (no regression)', () => {
+    const scope = 'Edits a .js source file.';
+    const steps = buildDefaultSmokeTestSteps('infrastructure', 'Untitled', scope);
+    expect(steps).toHaveLength(3);
+  });
+});
+
+describe('FR-1: negative path (non-code scope returns [])', () => {
+  it('TS-9: empty scope and non-code title returns []', () => {
+    const steps = buildDefaultSmokeTestSteps('infrastructure', 'Update product roadmap copy', undefined);
+    expect(steps).toEqual([]);
+  });
+});
+
+describe('Type-routing regressions (lightweight types unaffected)', () => {
+  it('TS-10: documentation type returns [] even when scope contains code keyword "script"', () => {
+    const steps = buildDefaultSmokeTestSteps('documentation', 'Untitled', 'edits a script');
+    expect(steps).toEqual([]);
+  });
+  it('TS-11: orchestrator type returns [] even when scope contains new keyword "flag"', () => {
+    const steps = buildDefaultSmokeTestSteps('orchestrator', 'Untitled', 'adds a flag');
+    expect(steps).toEqual([]);
+  });
+});
+
+describe('FR-2: three-step fallback chain (options.scope ?? options.metadata?.scope ?? description)', () => {
+  it('TS-13: options.metadata.scope path detected when options.scope undefined', () => {
+    const scope = resolveScope({ metadata: { scope: 'add a wizard' } }, 'fallback description');
+    const steps = buildDefaultSmokeTestSteps('infrastructure', 'Untitled', scope);
+    expect(steps).toHaveLength(3);
+  });
+  it('TS-14: options.scope takes precedence over options.metadata.scope', () => {
+    const scope = resolveScope({ scope: 'script change', metadata: { scope: 'nontriggering text' } }, 'fallback');
+    const steps = buildDefaultSmokeTestSteps('infrastructure', 'Untitled', scope);
+    expect(steps).toHaveLength(3);
+  });
+  it('FR-2 control: neither options.scope nor options.metadata.scope → falls back to description', () => {
+    const scope = resolveScope({}, 'fixes a script bug');
+    const steps = buildDefaultSmokeTestSteps('infrastructure', 'Untitled', scope);
+    expect(steps).toHaveLength(3);
+  });
+});
+
+describe('FR-4: named export shape', () => {
+  it('buildDefaultSmokeTestSteps is exported and callable as a function', () => {
+    expect(typeof buildDefaultSmokeTestSteps).toBe('function');
+    expect(buildDefaultSmokeTestSteps.length).toBe(3); // (type, title, scope)
+  });
+});
+
+describe('FR-3: atomic INSERT — additionalUpdates block carries only risks (static source check)', () => {
+  it('TS-16: source no longer writes scope/key_changes via post-INSERT UPDATE for the plan-file path', () => {
+    // Locate the additionalUpdates block (Step 13 in the plan-file builder)
+    const blockMatch = SOURCE.match(/\/\/ Step 13:[\s\S]*?if \(Object\.keys\(additionalUpdates\)\.length > 0\) \{[\s\S]*?\n  \}/);
+    expect(blockMatch, 'additionalUpdates Step 13 block must exist').toBeTruthy();
+    const block = blockMatch[0];
+    expect(block).not.toMatch(/additionalUpdates\.scope\s*=/);
+    expect(block).not.toMatch(/additionalUpdates\.key_changes\s*=/);
+    expect(block).toMatch(/additionalUpdates\.risks\s*=/);
+  });
+  it('FR-3 control: createOptions in plan-file builder now passes scope and key_changes', () => {
+    // The plan-file createOptions builder must include scope and key_changes
+    expect(SOURCE).toMatch(/scope:\s*scope\s*\|\|\s*null/);
+    expect(SOURCE).toMatch(/key_changes:\s*keyChanges\.length\s*>\s*0\s*\?\s*keyChanges\s*:\s*null/);
+  });
+});
+
+describe('Regression guards (validation-agent findings)', () => {
+  it('TS-17: codeKeywords does NOT contain "gates" (substring-redundant with "gate")', () => {
+    // FR-1 is implemented via an inline array literal inside buildDefaultSmokeTestSteps.
+    // We assert by exercising the live function — if "gates" sneaks back as a literal
+    // entry it would still be caught by `gate` substring-match, but the source-level
+    // assertion below pins the literal away.
+    const codeKeywordsSourceMatch = SOURCE.match(/const codeKeywords = \[([\s\S]*?)\];/);
+    expect(codeKeywordsSourceMatch, 'codeKeywords array literal must exist').toBeTruthy();
+    const arrayBody = codeKeywordsSourceMatch[1];
+    // Match whole-word "gates" (not as part of "gate" or other identifiers)
+    expect(arrayBody).not.toMatch(/['"]gates['"]/);
+    expect(arrayBody).toMatch(/['"]gate['"]/); // existing entry preserved
+  });
+  it('FR-2 source guard: fallback chain at the buildDefault* call site uses three-step resolution', () => {
+    expect(SOURCE).toMatch(/options\.scope\s*\?\?\s*options\.metadata\?\.scope\s*\?\?\s*description/);
+  });
+});

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -820,6 +820,10 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     rationale: 'Created from Claude Code plan file',
     success_criteria: successCriteria,
     strategic_objectives: strategicObjectives.length > 0 ? strategicObjectives : null,
+    // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-3): pass scope and key_changes through createOptions
+    // so createSD INSERTs them atomically — no UPDATE-after-INSERT race, and detector at the buildDefault* call site sees rich content.
+    scope: scope || null,
+    key_changes: keyChanges.length > 0 ? keyChanges : null,
     metadata: {
       source: 'plan',
       plan_content: parsed.fullContent,
@@ -850,10 +854,10 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
   }
   const sd = await createSD(createOptions);
 
-  // Step 13: Update additional fields that aren't in createSD signature
+  // Step 13: Update additional fields that aren't in createSD signature.
+  // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-3): scope and key_changes now flow through createOptions
+  // so they're INSERTed atomically — only `risks` remains for post-INSERT UPDATE.
   const additionalUpdates = {};
-  if (scope) additionalUpdates.scope = scope;
-  if (keyChanges.length > 0) additionalUpdates.key_changes = keyChanges;
   if (risks.length > 0) additionalUpdates.risks = risks;
 
   if (Object.keys(additionalUpdates).length > 0) {
@@ -865,7 +869,7 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     if (updateError) {
       console.warn(`   ⚠️  Could not update additional fields: ${updateError.message}`);
     } else {
-      console.log(`   ✅ Updated: scope, ${keyChanges.length > 0 ? 'key_changes, ' : ''}${risks.length > 0 ? 'risks' : ''}`);
+      console.log(`   ✅ Updated: risks`);
     }
   }
 
@@ -1145,7 +1149,13 @@ function buildDefaultSmokeTestSteps(type, title, scope) {
   // Infrastructure SDs: only generate if scope suggests code changes
   if ((type || '').toLowerCase() === 'infrastructure') {
     const scopeStr = (scope || title || '').toLowerCase();
-    const codeKeywords = ['script', 'fix', 'gate', 'module', 'function', 'class', 'endpoint', 'api', '.js', '.ts'];
+    // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-1): expand to cover CLI / operator-experience / harness vocab.
+    // Kept lowercase only (line above lowercases input). "gates" omitted as substring-redundant with "gate".
+    const codeKeywords = [
+      'script', 'fix', 'gate', 'module', 'function', 'class', 'endpoint', 'api', '.js', '.ts',
+      'flag', 'cli', 'wizard', 'detector', 'parser', 'helper', 'validator', 'hook', 'sub-agent',
+      'refactor', 'sweep', 'audit', 'normalizer',
+    ];
     const hasCodeScope = codeKeywords.some(kw => scopeStr.includes(kw));
     if (!hasCodeScope) return [];
     return [
@@ -1217,6 +1227,9 @@ async function createSD(options) {
     // PAT-SDCREATE-001: Allow passing key_changes and smoke_test_steps
     key_changes = null,
     smoke_test_steps = null,
+    // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-3): accept scope so the plan-file path becomes atomic INSERT.
+    // Default null preserves behavior for callers that omit it (5 internal callers + /leo create path).
+    scope = null,
     // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Allow explicit target_application
     target_application: explicitTargetApp = null,
   } = options;
@@ -1321,7 +1334,9 @@ async function createSD(options) {
     : buildDefaultKeyChanges(type, title);
   const finalSmokeTestSteps = (Array.isArray(smoke_test_steps) && smoke_test_steps.length > 0)
     ? smoke_test_steps
-    : buildDefaultSmokeTestSteps(type, title, options.scope ?? description);
+    // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-2): three-step fallback so detector sees scope from BOTH caller paths
+    // (plan-file passes options.scope after FR-3 atomic-INSERT refactor; /leo create stores it in options.metadata.scope).
+    : buildDefaultSmokeTestSteps(type, title, options.scope ?? options.metadata?.scope ?? description);
 
   // ========================================================================
   // GOVERNANCE GUARDRAILS (SD-MAN-FEAT-CORRECTIVE-VISION-GAP-007)
@@ -1510,7 +1525,7 @@ async function createSD(options) {
     sd_key: sdKey,
     title,
     description,
-    scope: description,  // Required field - defaults to description
+    scope: scope || description,  // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-3): prefer atomic-INSERT scope, fall back to description.
     rationale,
     sd_type: dbType,
     status: 'draft',
@@ -1731,7 +1746,8 @@ export function formatDependencyForDisplay(dep) {
 }
 
 // Export for programmatic use (e.g., corrective-sd-generator)
-export { createSD };
+// SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-4): export buildDefaultSmokeTestSteps for unit-test access.
+export { createSD, buildDefaultSmokeTestSteps };
 
 // ============================================================================
 // CLI Handler


### PR DESCRIPTION
## Summary
- Expand `codeKeywords` in `scripts/leo-create-sd.js` from 10 entries to 23 (add `flag`, `cli`, `wizard`, `detector`, `parser`, `helper`, `validator`, `hook`, `sub-agent`, `refactor`, `sweep`, `audit`, `normalizer`; drop substring-redundant `gates`).
- Three-step fallback chain at the `buildDefaultSmokeTestSteps` call site: `options.scope ?? options.metadata?.scope ?? description` so detector sees scope from BOTH createSD caller paths (plan-file passes `options.scope`; `/leo create` stores in `options.metadata.scope`).
- Atomic INSERT for the plan-file path: `createOptions` now passes scope and key_changes through to `createSD`; `additionalUpdates` block is reduced to risks-only — no UPDATE-after-INSERT race.
- Named export `buildDefaultSmokeTestSteps` for direct vitest access.
- 17-case vitest suite at `scripts/__tests__/leo-create-sd-smoke-detector.test.js` (20 subtests including describe-block keyword loop). 30/30 green; manual `--help` smoke exits 0.

## Why
SMOKE_TEST_SPECIFICATION gate was false-failing at LEAD-TO-PLAN preflight for legitimate code-change infrastructure SDs. Witnessed 2026-05-06 on SD-LEO-INFRA-LEO-CREATE-CROSS-001. 5th witness for PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.

## Test plan
- [x] vitest run scripts/__tests__/leo-create-sd-smoke-detector.test.js → 20/20 PASS
- [x] vitest run scripts/__tests__/leo-create-sd-mapper.test.js (regression) → 10/10 PASS
- [x] node scripts/leo-create-sd.js --help → exit 0
- [x] LEAD-TO-PLAN through PLAN-TO-LEAD all PASS (95/91/90/93%, 0 bypass)
- [x] Eat-our-own-dogfood: this SD passed SMOKE_TEST_SPECIFICATION at LEAD-TO-PLAN at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)