### PR TITLE
fix(QF-20260508-853): design-agent diff-based early-return for backend-only SDs

### DIFF
--- a/lib/sub-agents/design/index.js
+++ b/lib/sub-agents/design/index.js
@@ -25,6 +25,7 @@
 
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 import dotenv from 'dotenv';
 import { createSupabaseServiceClient } from '../../../scripts/lib/supabase-connection.js';
 
@@ -76,6 +77,15 @@ export async function execute(sdId, subAgent, options = {}) {
   // SDs, causing 40% pass rate since infra SDs have no UI components to validate.
   const skipResult = await checkForNonUISdType(sdId, options);
   if (skipResult) return skipResult;
+
+  // QF-20260508-853: Diff-based early-return for backend-only feature/fix SDs.
+  // The sd_type-based check above catches sd_type=infrastructure/api/etc., but feature/fix
+  // SDs that are entirely backend (no .tsx/.jsx/.css in diff) still ran the full DESIGN
+  // pipeline and returned BLOCKED via accessibility/risk-context scoring against
+  // unchanged UI files. 3rd witness pattern (POST-LAUNCH-002, LAUNCH-READINESS-001,
+  // LIVE-ANNOUNCE-001) — each consumed 1/3 bypass quota at EXEC-TO-PLAN.
+  const diffResult = checkForNonUIDiff(options);
+  if (diffResult) return diffResult;
 
   const results = {
     verdict: 'PASS',
@@ -478,6 +488,65 @@ async function checkForNonUISdType(sdId, options) {
   } catch (error) {
     console.warn(`   ⚠️  SD type detection failed: ${error.message}, continuing with full DESIGN validation`);
     return null; // On error, fall through to full validation
+  }
+}
+
+/**
+ * QF-20260508-853: Check the diff vs origin/main for any UI extensions; if zero,
+ * the SD is backend-only regardless of sd_type and DESIGN should return PASS.
+ *
+ * @param {Object} options - Execution options (may include repo_path; default cwd)
+ * @returns {Object|null} Skip result if zero UI extensions in diff, null otherwise
+ */
+const UI_EXTENSION_PATTERN = /\.(tsx|jsx|css|scss|sass|less|html?|vue|svelte)$/i;
+
+export function checkForNonUIDiff(options = {}) {
+  try {
+    const repoPath = options.repo_path || process.cwd();
+    const baseRef = options.diff_base_ref || 'origin/main';
+    const diff = execSync(`git diff --name-only ${baseRef}..HEAD`, {
+      cwd: repoPath,
+      timeout: 5000,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const files = diff.split('\n').map(f => f.trim()).filter(Boolean);
+    if (files.length === 0) return null; // empty diff: let the existing flow run
+    const uiFiles = files.filter(f => UI_EXTENSION_PATTERN.test(f));
+    if (uiFiles.length > 0) return null; // has UI changes: run full validation
+
+    console.log(`\n🏗️  Diff Analysis: ${files.length} file(s) changed, 0 UI extensions detected`);
+    console.log('   💡 Backend-only SD — no UI components to validate');
+
+    return {
+      verdict: 'PASS',
+      confidence: 90,
+      critical_issues: [],
+      warnings: [],
+      recommendations: [{
+        severity: 'INFO',
+        issue: 'Backend-only SD - design checks skipped',
+        recommendation: 'No UI components in diff (zero .tsx/.jsx/.css/.scss/.html files vs origin/main)'
+      }],
+      detailed_analysis: {
+        skip_reason: 'backend_only_diff',
+        files_changed: files.length,
+        ui_files_changed: 0,
+        diff_base_ref: baseRef,
+        validation_approach: 'Diff-based detection — DESIGN not applicable when zero UI extensions in diff'
+      },
+      findings: {
+        design_system_check: { skipped: true, reason: 'backend-only diff' },
+        component_analysis: { skipped: true, reason: 'backend-only diff' },
+        accessibility_check: { skipped: true, reason: 'backend-only diff' },
+        responsive_check: { skipped: true, reason: 'backend-only diff' },
+        consistency_check: { skipped: true, reason: 'backend-only diff' }
+      },
+      options
+    };
+  } catch (error) {
+    console.warn(`   ⚠️  Diff detection failed: ${error.message}, continuing with full DESIGN validation`);
+    return null;
   }
 }
 

--- a/tests/unit/sub-agents/design-backend-only-diff.test.js
+++ b/tests/unit/sub-agents/design-backend-only-diff.test.js
@@ -1,0 +1,146 @@
+/**
+ * QF-20260508-853: design-agent diff-based early-return for backend-only SDs.
+ *
+ * Pattern: 3rd witness (POST-LAUNCH-002, LAUNCH-READINESS-001, LIVE-ANNOUNCE-001) of
+ * design-agent BLOCKED at EXEC-TO-PLAN for backend-only feature SDs that the existing
+ * sd_type-based check did not catch (sd_type='feature', not 'infrastructure'). Each
+ * witness consumed 1/3 bypass quota.
+ *
+ * Fix: a separate diff-based check (checkForNonUIDiff) that early-returns PASS when
+ * `git diff --name-only origin/main..HEAD` contains zero UI extensions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Stub execSync at module load
+const execSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', () => ({ execSync: execSyncMock }));
+
+// Stub the supabase client + dotenv to avoid network/env requirements at import time
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({})),
+}));
+
+// Stub the heavy DESIGN modules so import succeeds without their transitive deps
+vi.mock('../../../lib/sub-agents/design/utils.js', () => ({
+  enhanceWithRiskContext: vi.fn(),
+  validateUxContractCompliance: vi.fn(),
+  parseBaselineWorkflow: vi.fn(),
+}));
+vi.mock('../../../lib/sub-agents/design/checks.js', () => ({
+  checkDesignSystem: vi.fn(),
+  analyzeComponents: vi.fn(),
+  checkAccessibility: vi.fn(),
+  checkResponsiveDesign: vi.fn(),
+  checkDesignConsistency: vi.fn(),
+  generateRecommendations: vi.fn(),
+}));
+vi.mock('../../../lib/sub-agents/design/workflow-analyzer.js', () => ({
+  workflowReviewCapability: vi.fn(),
+}));
+vi.mock('../../../lib/repo-paths.js', () => ({
+  resolveRepoPath: vi.fn(() => '/fake/repo'),
+}));
+
+const { checkForNonUIDiff } = await import('../../../lib/sub-agents/design/index.js');
+
+describe('QF-20260508-853 — design-agent diff-based early-return for backend-only SDs', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it('returns PASS when diff contains only backend files (.js/.sql/.cjs)', () => {
+    execSyncMock.mockReturnValue([
+      'lib/eva/artifact-types.js',
+      'lib/eva/lifecycle/exit-gate-verifiers.js',
+      'database/migrations/20260507_add_launch_metrics.sql',
+      'tests/unit/eva/stage-templates/stage-24-routing.test.js',
+    ].join('\n'));
+
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+
+    expect(result).not.toBeNull();
+    expect(result.verdict).toBe('PASS');
+    expect(result.confidence).toBe(90);
+    expect(result.detailed_analysis.skip_reason).toBe('backend_only_diff');
+    expect(result.detailed_analysis.files_changed).toBe(4);
+    expect(result.detailed_analysis.ui_files_changed).toBe(0);
+  });
+
+  it('returns null (full validation) when diff contains a .tsx file', () => {
+    execSyncMock.mockReturnValue([
+      'src/components/MyComponent.tsx',
+      'lib/utils.js',
+    ].join('\n'));
+
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null (full validation) when diff contains a .jsx file', () => {
+    execSyncMock.mockReturnValue([
+      'src/components/Old.jsx',
+    ].join('\n'));
+
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null (full validation) when diff contains a .css/.scss/.html file', () => {
+    for (const filename of ['styles/main.css', 'styles/_vars.scss', 'public/index.html']) {
+      execSyncMock.mockReset();
+      execSyncMock.mockReturnValueOnce(filename);
+      const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+      expect(result).toBeNull();
+    }
+  });
+
+  it('returns null (full validation) when diff is empty (no commits past origin/main)', () => {
+    execSyncMock.mockReturnValue('');
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null (graceful fallback) when git diff command throws', () => {
+    execSyncMock.mockImplementation(() => { throw new Error('not a git repo'); });
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result).toBeNull();
+  });
+
+  it('honors options.diff_base_ref override (custom base branch)', () => {
+    execSyncMock.mockReturnValue('lib/foo.js');
+    checkForNonUIDiff({ repo_path: '/fake/repo', diff_base_ref: 'origin/develop' });
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('origin/develop..HEAD'),
+      expect.any(Object),
+    );
+  });
+
+  it('case-insensitive UI-extension match (.TSX / .HTM)', () => {
+    execSyncMock.mockReturnValue('src/Old.TSX');
+    expect(checkForNonUIDiff({ repo_path: '/fake/repo' })).toBeNull();
+
+    execSyncMock.mockReset();
+    execSyncMock.mockReturnValue('public/page.HTM');
+    expect(checkForNonUIDiff({ repo_path: '/fake/repo' })).toBeNull();
+  });
+
+  it('strips trailing whitespace and ignores empty lines in diff output', () => {
+    execSyncMock.mockReturnValue('lib/foo.js  \n\n  lib/bar.js  \n  \n');
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result).not.toBeNull();
+    expect(result.detailed_analysis.files_changed).toBe(2);
+  });
+
+  it('return shape matches existing checkForNonUISdType findings contract', () => {
+    execSyncMock.mockReturnValue('lib/foo.js');
+    const result = checkForNonUIDiff({ repo_path: '/fake/repo' });
+    expect(result.findings).toEqual(expect.objectContaining({
+      design_system_check: expect.objectContaining({ skipped: true }),
+      component_analysis: expect.objectContaining({ skipped: true }),
+      accessibility_check: expect.objectContaining({ skipped: true }),
+      responsive_check: expect.objectContaining({ skipped: true }),
+      consistency_check: expect.objectContaining({ skipped: true }),
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `checkForNonUIDiff()` helper to lib/sub-agents/design/index.js that runs after the existing `checkForNonUISdType()` check
- Uses `git diff --name-only origin/main..HEAD` to detect UI extensions (.tsx/.jsx/.css/.scss/.sass/.less/.html?/.vue/.svelte)
- Zero UI matches → early-return PASS confidence=90 with reason='backend_only_diff'
- Closes the 3rd-witness pattern: design-agent BLOCKED on backend feature SDs (POST-LAUNCH-002, LAUNCH-READINESS-001, LIVE-ANNOUNCE-001)

## Why
The existing `checkForNonUISdType` (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-010) catches `sd_type='infrastructure'` but NOT backend `sd_type='feature'/'fix'` SDs. Each of the 3 witnesses consumed 1/3 bypass quota at EXEC-TO-PLAN; this fix reduces that to 2/3.

## Test plan
- [x] `npx vitest run tests/unit/sub-agents/design-backend-only-diff.test.js` — 10/10 pass
- [x] `tsc --noEmit` clean
- [x] Backend-only SD now returns PASS confidence=90 with reason='backend_only_diff'
- [x] UI files in diff → falls through to full validation (preserves existing behavior)
- [x] Empty diff → null (lets existing flow run)
- [x] Diff command failure → null (graceful fallback)

Closes feedback `cc916c5c-2887-4ea7-8850-14c72fe39f8e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)