### PR TITLE
feat(SD-LEO-INFRA-AUDIT-SHARED-TABLES-001): add npm scripts for audit + PAT persistence (wire-check follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "audit:retro": "node scripts/audit-retro.mjs",
     "audit:stage17": "node scripts/audit-stage17-urls.mjs",
     "audit:orphan-prs": "node scripts/audit-orphan-prs.mjs",
+    "audit:shared-tables": "node scripts/audit-shared-tables-residue.cjs",
+    "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",
     "quality:aggregate": "node scripts/aggregate-quality-findings.js",
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",


### PR DESCRIPTION
## Summary
Follow-up to PR #3586 — adds 2 npm script entries so `WIRE_CHECK_GATE` (LEAD-FINAL-APPROVAL) finds reachable entry points for the 3 files shipped in #3586 (commit db0097e7b).

- `npm run audit:shared-tables` → `scripts/audit-shared-tables-residue.cjs`
- `npm run pattern:port-isol-persist` → `scripts/insert-pat-port-isol-001.mjs`
- `scripts/lib/killed-initiatives.cjs` is reachable transitively via the audit script's `require()` statement.

Unblocks the parent SD's LEAD-FINAL-APPROVAL handoff. 2-line change.

## Test plan
- [x] `npm run audit:shared-tables --silent` → exits 0; emits artifact (verified live)
- [x] `npm run pattern:port-isol-persist --silent` → upserts row, asserts checklist length=9 (verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)