### PR TITLE
fix(QF-20260508-230): worktree_branch:null in all 4 stale-sweep release sites

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -477,6 +477,11 @@ async function main() {
     // Using 'idle' silently fails when another session on the same terminal exists.
     const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
     // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
+    // QF-20260508-230: ck_claude_sessions_worktree_state_consistency requires sd_key IS NOT NULL
+    // OR (worktree_path IS NULL AND worktree_branch IS NULL). Without worktree_branch:null here,
+    // partial-null UPDATE silently rolls back via PostgREST and the sweep churns 5-min loops.
+    // 5th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 — sibling at line ~801 was patched
+    // by QF-20260504-081 but this one was missed.
     const { error } = await supabase
       .from('claude_sessions')
       .update({
@@ -485,6 +490,7 @@ async function main() {
         released_at: now.toISOString(),
         released_reason: 'SWEEP_SD_ALREADY_COMPLETED',
         worktree_path: null,
+        worktree_branch: null,
         has_uncommitted_changes: false,
         current_branch: null
       })
@@ -506,6 +512,10 @@ async function main() {
   for (const s of orphanedClaims) {
     const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
     // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
+    // QF-20260508-230: ck_claude_sessions_worktree_state_consistency requires sd_key IS NOT NULL
+    // OR (worktree_path IS NULL AND worktree_branch IS NULL). Vitest static guard at
+    // tests/unit/scripts/stale-session-sweep-release-payload.test.js pins this invariant
+    // for ALL release sites — adding a new release path? Add worktree_branch:null too.
     const { error } = await supabase
       .from('claude_sessions')
       .update({
@@ -514,6 +524,7 @@ async function main() {
         released_at: now.toISOString(),
         released_reason: 'SWEEP_ORPHANED_CLAIM',
         worktree_path: null,
+        worktree_branch: null,
         has_uncommitted_changes: false,
         current_branch: null
       })
@@ -868,6 +879,9 @@ async function main() {
 
       const targetStatus = evict.status === 'ACTIVE' ? 'idle' : 'released';
       // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
+      // QF-20260508-230: ck_claude_sessions_worktree_state_consistency requires sd_key IS NOT NULL
+      // OR (worktree_path IS NULL AND worktree_branch IS NULL). worktree_branch:null required;
+      // sibling release at workingOnCompleted branch (line ~480) had the same bug.
       const { error } = await supabase
         .from('claude_sessions')
         .update({
@@ -876,6 +890,7 @@ async function main() {
           released_at: now.toISOString(),
           released_reason: 'SWEEP_CONFLICT_RESOLUTION',
           worktree_path: null,
+          worktree_branch: null,
           has_uncommitted_changes: false,
           current_branch: null
         })

--- a/tests/unit/scripts/stale-session-sweep-release-payload.test.js
+++ b/tests/unit/scripts/stale-session-sweep-release-payload.test.js
@@ -1,0 +1,63 @@
+/**
+ * QF-20260508-230: stale-session-sweep release UPDATE must include worktree_branch:null
+ * at ALL THREE release sites (5th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
+ *
+ * The CHECK constraint `ck_claude_sessions_worktree_state_consistency` (added 2026-05-02)
+ * requires `sd_key IS NOT NULL OR (worktree_path IS NULL AND worktree_branch IS NULL)`.
+ * Sweep release UPDATEs that null sd_key + worktree_path but leave worktree_branch populated
+ * silently fail via PostgREST partial-rollback, causing 5-min churn loops.
+ *
+ * QF-20260504-081 fixed ONE site (the dead-session release path); QF-20260508-230 fixes
+ * the two sibling sites (workingOnCompleted + conflict-eviction). This test pins all three.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SOURCE = readFileSync(resolve(REPO_ROOT, 'scripts/stale-session-sweep.cjs'), 'utf8');
+
+describe('QF-20260508-230 — stale-session-sweep release payload invariant', () => {
+  it('release payload includes worktree_branch:null at every claude_sessions UPDATE site', () => {
+    // Find every occurrence of `.from('claude_sessions')` followed within ~250 chars by
+    // an `.update({` block. Each such block MUST contain `worktree_branch: null`.
+    const fromMatches = [...SOURCE.matchAll(/\.from\(\s*['"]claude_sessions['"]\s*\)/g)];
+    expect(fromMatches.length).toBeGreaterThanOrEqual(3);
+
+    for (const m of fromMatches) {
+      const start = m.index;
+      // Look ahead up to 1000 chars for an `.update({...})` block
+      const window = SOURCE.slice(start, start + 1000);
+      const updateMatch = window.match(/\.update\s*\(\s*\{([\s\S]*?)\}\s*\)/);
+      if (!updateMatch) continue; // not all from() are UPDATEs (some are SELECT)
+      const updatePayload = updateMatch[1];
+
+      // Skip payloads that don't null sd_key (those are NOT release UPDATEs)
+      if (!/sd_key\s*:\s*null/.test(updatePayload)) continue;
+
+      // The release-shaped UPDATE must also null worktree_branch (CHECK invariant)
+      const offsetInFile = start + updateMatch.index;
+      const lineNumber = SOURCE.slice(0, offsetInFile).split('\n').length;
+      expect(updatePayload, `Release UPDATE at line ~${lineNumber} missing worktree_branch:null`)
+        .toMatch(/worktree_branch\s*:\s*null/);
+    }
+  });
+
+  it('all 3 known release sites are still wired (regression guard against accidental removal)', () => {
+    // Pin the 3 release reasons we know about. If any of these strings disappears,
+    // either the site was removed (intentional refactor — update this test) or accidentally
+    // dropped (regression — fix the source).
+    expect(SOURCE).toContain('SWEEP_SD_ALREADY_COMPLETED');
+    expect(SOURCE).toContain('SWEEP_CONFLICT_RESOLUTION');
+    expect(SOURCE).toMatch(/releaseReason/); // dynamic reason for dead-session path
+  });
+
+  it('CHECK constraint name appears in code comment for documentation traceability', () => {
+    // Pattern from Memory: documenting the CHECK in the source so the next developer
+    // sees WHY worktree_branch:null is mandatory.
+    expect(SOURCE).toMatch(/ck_claude_sessions_worktree_state_consistency/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the 5th-witness writer/consumer asymmetry pattern (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001) where the 2026-05-02 CHECK constraint addition (worktree_branch column) was only honored at 1 of 4 release sites in stale-session-sweep.cjs. QF-20260504-081 patched the dead-session release path; this QF fixes the 3 remaining siblings.

## Changes
- **scripts/stale-session-sweep.cjs**: add `worktree_branch: null` at 3 release UPDATE sites:
  - line ~482: SWEEP_SD_ALREADY_COMPLETED (workingOnCompleted release)
  - line ~518: SWEEP_ORPHANED_CLAIM (orphaned-claim release — discovered by the static guard)
  - line ~879: SWEEP_CONFLICT_RESOLUTION (conflict-eviction release)
- **tests/unit/scripts/stale-session-sweep-release-payload.test.js**: 3 vitest cases, static guard pins the invariant for ALL release-shaped UPDATEs (any UPDATE that nulls sd_key MUST also null worktree_branch).

## Why
PostgreSQL CHECK constraint `ck_claude_sessions_worktree_state_consistency` requires `sd_key IS NOT NULL OR (worktree_path IS NULL AND worktree_branch IS NULL)`. Release UPDATEs that null sd_key + worktree_path but leave worktree_branch populated fail the CHECK; PostgREST silently rolls back the constraint-affected columns, leaving claim partially-cleared. Worker re-asserts on next tool call → 5-min churn loop. RCA evidence: sub_agent_execution_results `0b0168b7`.

## Test plan
- [x] 3/3 vitest pass (release-payload static guard found a 3rd site I missed initially)
- [x] tsc clean (no type changes)
- [x] Source LOC: ~6 (3 added lines + 3 comment refs); test LOC: ~50

🤖 Generated with [Claude Code](https://claude.com/claude-code)