### PR TITLE
feat(SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001): outcome-digest signature + UUID resolution + PostToolUse capture

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -164,6 +164,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-tool-rca-outcome.cjs",
+            "timeout": 2
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-AUDIT-SHARED-TABLES-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-AUDIT-SHARED-TABLES-001",
-  "createdAt": "2026-05-08T22:33:19.082Z",
+  "sdKey": "SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001",
+  "createdAt": "2026-05-09T00:31:36.381Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "audit:orphan-prs": "node scripts/audit-orphan-prs.mjs",
     "audit:shared-tables": "node scripts/audit-shared-tables-residue.cjs",
     "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
+    "hook:rca-outcome": "node scripts/hooks/post-tool-rca-outcome.cjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",
     "quality:aggregate": "node scripts/aggregate-quality-findings.js",
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",

--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -1,0 +1,179 @@
+/**
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001 — L4 PostToolUse outcome capture tests.
+ *
+ * Tests that scripts/hooks/post-tool-rca-outcome.cjs:
+ *   TS-17: writes .claude/last-outcome-<session>.json with proper schema
+ *   TS-18: fail-open on malformed/empty stdin (exits 0, no crash)
+ *   plus: regex assertion that hook reads stdin (not env) for tool_response.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const HOOK_PATH = path.resolve(__dirname, '../post-tool-rca-outcome.cjs');
+
+describe('L4 — post-tool-rca-outcome.cjs', () => {
+  let tmpDir;
+  const SESSION_ID = 'test-session-' + Math.random().toString(36).slice(2);
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-outcome-test-'));
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it('TS-17: writes outcome file with {tool_name, exit_code, stderr_sha, captured_at}', () => {
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_response: {
+        exit_code: 1,
+        stderr: 'ReferenceError: foo is not defined\n  at line 5',
+      },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: {
+        ...process.env,
+        CLAUDE_TOOL_NAME: 'Bash',
+        CLAUDE_SESSION_ID: SESSION_ID,
+        LEO_RETRY_STATE_DIR: tmpDir,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.tool_name).toBe('Bash');
+    expect(written.exit_code).toBe(1);
+    expect(written.stderr_sha).toMatch(/^[0-9a-f]{16}$/);
+    expect(typeof written.captured_at).toBe('string');
+    // stderr_sha should be a digest of the FIRST LINE only
+    const crypto = require('crypto');
+    const expectedSha = crypto
+      .createHash('sha256')
+      .update('ReferenceError: foo is not defined')
+      .digest('hex')
+      .slice(0, 16);
+    expect(written.stderr_sha).toBe(expectedSha);
+  });
+
+  it('TS-18: malformed stdin → exit 0, no crash, no file written', () => {
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: 'not-json-at-all',
+      env: {
+        ...process.env,
+        CLAUDE_TOOL_NAME: 'Bash',
+        CLAUDE_SESSION_ID: SESSION_ID,
+        LEO_RETRY_STATE_DIR: tmpDir,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  it('empty stdin → exit 0, no file written', () => {
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: '',
+      env: {
+        ...process.env,
+        CLAUDE_TOOL_NAME: 'Bash',
+        CLAUDE_SESSION_ID: SESSION_ID,
+        LEO_RETRY_STATE_DIR: tmpDir,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  it('feature-flag LEO_RCA_OUTCOME_CAPTURE=off short-circuits', () => {
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_response: { exit_code: 1, stderr: 'x' },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: {
+        ...process.env,
+        CLAUDE_TOOL_NAME: 'Bash',
+        CLAUDE_SESSION_ID: SESSION_ID,
+        LEO_RETRY_STATE_DIR: tmpDir,
+        LEO_RCA_OUTCOME_CAPTURE: 'off',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  it('non-Bash tool → no file written (signatures are file_path-keyed)', () => {
+    const payload = JSON.stringify({
+      tool_name: 'Edit',
+      tool_response: { exit_code: 0 },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: {
+        ...process.env,
+        CLAUDE_TOOL_NAME: 'Edit',
+        CLAUDE_SESSION_ID: SESSION_ID,
+        LEO_RETRY_STATE_DIR: tmpDir,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+});
+
+describe('Static-source guard — hook contract integrity', () => {
+  it('post-tool-rca-outcome.cjs reads tool_response from STDIN, not env', () => {
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    // Must reference process.stdin (canonical contract)
+    expect(src).toMatch(/process\.stdin/);
+    // Must NOT read tool_response from env (the bug class)
+    expect(src).not.toMatch(/process\.env\.CLAUDE_TOOL_RESPONSE/);
+    expect(src).not.toMatch(/process\.env\.TOOL_RESPONSE/);
+  });
+
+  it('retry-state-manager signatureFor body references last_outcome AND createHash', () => {
+    const mgrSrc = fs.readFileSync(
+      path.resolve(__dirname, '../retry-state-manager.cjs'),
+      'utf8'
+    );
+    expect(mgrSrc).toMatch(/lastOutcome/);
+    expect(mgrSrc).toMatch(/createHash/);
+  });
+
+  it('retry-state-manager fetchRcaInvocationSince uses UUID resolution before query', () => {
+    const mgrSrc = fs.readFileSync(
+      path.resolve(__dirname, '../retry-state-manager.cjs'),
+      'utf8'
+    );
+    expect(mgrSrc).toMatch(/resolveSdKeyToUuid/);
+    expect(mgrSrc).toMatch(/UUID_REGEX/);
+  });
+
+  it('pre-tool-enforce.cjs prefers st.sd?.id over st.sd?.sd_key', () => {
+    const enforceSrc = fs.readFileSync(
+      path.resolve(__dirname, '../pre-tool-enforce.cjs'),
+      'utf8'
+    );
+    // The order matters: st.sd?.id should come BEFORE st.sd?.sd_key in the OR fallback
+    const claimedSdKeyMatch = enforceSrc.match(
+      /claimedSdKey\s*=\s*st\.sd\?\.id\s*\|\|\s*st\.sd\?\.sd_key/
+    );
+    expect(claimedSdKeyMatch).toBeTruthy();
+  });
+});

--- a/scripts/hooks/__tests__/retry-state-manager-outcome-mix.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-outcome-mix.test.js
@@ -1,0 +1,265 @@
+/**
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001 — Outcome-mix + UUID-resolution tests.
+ *
+ * 16 cases across 3 layers:
+ *   L1 (6): signatureFor outcome admixture
+ *   L2 (6): fetchRcaInvocationSince UUID resolution
+ *   L3 (4): recordAndCount integration (TDD-iteration unblock + stuck-loop guard)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const MODULE_PATH = path.resolve(__dirname, '../retry-state-manager.cjs');
+
+function loadFresh() {
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+describe('L1 — signatureFor outcome admixture', () => {
+  const { signatureFor } = loadFresh();
+
+  it('TS-1: back-compat — no last_outcome arg returns "Bash:<hash>"', () => {
+    const sig = signatureFor('Bash', { command: 'echo hi' });
+    expect(sig).toMatch(/^Bash:[0-9a-f]{16}$/);
+    // Same input → same signature (deterministic)
+    expect(signatureFor('Bash', { command: 'echo hi' })).toBe(sig);
+  });
+
+  it('TS-2: with last_outcome returns "Bash:<hash>:<digest>"', () => {
+    const sig = signatureFor('Bash', { command: 'echo hi' }, { exit_code: 1, stderr_sha: 'abc' });
+    expect(sig).toMatch(/^Bash:[0-9a-f]{16}:[0-9a-f]{8}$/);
+  });
+
+  it('TS-3: different exit codes produce different signatures', () => {
+    const a = signatureFor('Bash', { command: 'x' }, { exit_code: 0, stderr_sha: 'sha' });
+    const b = signatureFor('Bash', { command: 'x' }, { exit_code: 1, stderr_sha: 'sha' });
+    expect(a).not.toBe(b);
+  });
+
+  it('TS-4: same outcome produces same digest (stuck-loop preserved)', () => {
+    const a = signatureFor('Bash', { command: 'x' }, { exit_code: 1, stderr_sha: 'abc' });
+    const b = signatureFor('Bash', { command: 'x' }, { exit_code: 1, stderr_sha: 'abc' });
+    expect(a).toBe(b);
+  });
+
+  it('TS-5: Edit/Write/MultiEdit signatures unaffected by last_outcome', () => {
+    const editSig = signatureFor('Edit', { file_path: '/x.js' }, { exit_code: 1, stderr_sha: 'abc' });
+    expect(editSig).toBe('Edit:/x.js');
+    const writeSig = signatureFor('Write', { file_path: '/x.js' }, { exit_code: 1, stderr_sha: 'abc' });
+    expect(writeSig).toBe('Write:/x.js');
+  });
+
+  it('TS-6: malformed last_outcome falls back to command-only without throwing', () => {
+    const a = signatureFor('Bash', { command: 'x' }, null);
+    const b = signatureFor('Bash', { command: 'x' }, undefined);
+    const c = signatureFor('Bash', { command: 'x' }, {}); // empty object — no exit/stderr fields
+    const baseline = signatureFor('Bash', { command: 'x' });
+    expect(a).toBe(baseline);
+    expect(b).toBe(baseline);
+    expect(c).toBe(baseline);
+    // String-as-outcome should also fall through (object check)
+    expect(signatureFor('Bash', { command: 'x' }, 'not-an-object')).toBe(baseline);
+  });
+});
+
+describe('L2 — fetchRcaInvocationSince UUID resolution', () => {
+  const PP_UUID = '08d20036-03c9-4a26-bbc5-f37a18dfdf23';
+  const SD_KEY = 'SD-FAKE-001';
+  const RESOLVED_UUID = 'aaaa1111-2222-3333-4444-555566667777';
+
+  beforeEach(() => {
+    delete require.cache[require.resolve(MODULE_PATH)];
+  });
+
+  it('TS-7: UUID input passed directly — no resolution round-trip', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      json: async () => [{ created_at: '2026-05-09T00:00:00Z' }],
+    }));
+    global.fetch = fetchSpy;
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    const result = await mod.fetchRcaInvocationSince(PP_UUID, null);
+    expect(result).toBe('2026-05-09T00:00:00Z');
+    // Only the sub_agent_execution_results query — NO strategic_directives_v2 lookup.
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][0]).toMatch(/sub_agent_execution_results/);
+  });
+
+  it('TS-8: sd_key string resolves to UUID first, then queries with UUID', async () => {
+    const fetchSpy = vi.fn(async (url) => {
+      if (url.includes('strategic_directives_v2')) {
+        return { ok: true, json: async () => [{ id: RESOLVED_UUID }] };
+      }
+      return { ok: true, json: async () => [{ created_at: '2026-05-09T01:00:00Z' }] };
+    });
+    global.fetch = fetchSpy;
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    const result = await mod.fetchRcaInvocationSince(SD_KEY, null);
+    expect(result).toBe('2026-05-09T01:00:00Z');
+    // Two calls: 1) resolve sd_key→UUID, 2) query sub_agent_execution_results with UUID
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0][0]).toMatch(/strategic_directives_v2/);
+    expect(fetchSpy.mock.calls[1][0]).toContain(`eq.${RESOLVED_UUID}`);
+  });
+
+  it('TS-9: malformed sd_id returns null without throwing', async () => {
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    expect(await mod.fetchRcaInvocationSince(null, null)).toBeNull();
+    expect(await mod.fetchRcaInvocationSince(undefined, null)).toBeNull();
+    expect(await mod.fetchRcaInvocationSince('', null)).toBeNull();
+  });
+
+  it('TS-10: lastResetAt sets gt filter on PostgREST query', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => [] }));
+    global.fetch = fetchSpy;
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    await mod.fetchRcaInvocationSince(PP_UUID, '2026-05-08T00:00:00Z');
+    const url = fetchSpy.mock.calls[0][0];
+    expect(url).toContain('created_at=gt.2026-05-08');
+  });
+
+  it('TS-11: 1.2s timeout aborts gracefully → null', async () => {
+    global.fetch = vi.fn(
+      () => new Promise((resolve, reject) => {
+        setTimeout(() => resolve({ ok: false, json: async () => ({}) }), 5000);
+      })
+    );
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    // Don't actually wait 5s — assert the fetch is wrapped with AbortController and returns null on abort.
+    // For unit speed, just assert the function does not throw.
+    const promise = mod.fetchRcaInvocationSince(PP_UUID, null);
+    // Race against 2s test budget
+    const result = await Promise.race([
+      promise,
+      new Promise((r) => setTimeout(() => r('TIMEOUT'), 2000)),
+    ]);
+    // Either timed out internally (null) or our race ticker fires (TIMEOUT). Either way no throw.
+    expect(['TIMEOUT', null]).toContain(result);
+  });
+
+  it('TS-12: non-UUID input that is not in strategic_directives_v2 returns null', async () => {
+    const fetchSpy = vi.fn(async (url) => {
+      if (url.includes('strategic_directives_v2')) {
+        return { ok: true, json: async () => [] };
+      }
+      return { ok: true, json: async () => [{ created_at: 'should-not-reach' }] };
+    });
+    global.fetch = fetchSpy;
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    const mod = require(MODULE_PATH);
+    mod._resetSdKeyCache();
+    const result = await mod.fetchRcaInvocationSince('SD-DOES-NOT-EXIST', null);
+    expect(result).toBeNull();
+    // Only resolution call — no sub_agent_execution_results query
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('L3 — recordAndCount integration', () => {
+  let tmpDir;
+  const SESSION_ID = 'test-session-' + Math.random().toString(36).slice(2);
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-state-test-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+    delete require.cache[require.resolve(MODULE_PATH)];
+  });
+
+  it('TS-13: TDD pattern — 3 different-outcome retries → attempts stays 1', async () => {
+    const mod = require(MODULE_PATH);
+    const noopRca = vi.fn(async () => null);
+    const a = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'npx vitest run x' }, {
+      rcaCheck: noopRca,
+      lastOutcome: { exit_code: 1, stderr_sha: 'first-failure-sha' },
+    });
+    expect(a.attempts).toBe(1);
+    const b = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'npx vitest run x' }, {
+      rcaCheck: noopRca,
+      lastOutcome: { exit_code: 1, stderr_sha: 'second-failure-sha' },
+    });
+    expect(b.attempts).toBe(1);
+    const c = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'npx vitest run x' }, {
+      rcaCheck: noopRca,
+      lastOutcome: { exit_code: 0, stderr_sha: '' },
+    });
+    expect(c.attempts).toBe(1);
+    // Each had a distinct signature
+    expect(a.signature).not.toBe(b.signature);
+    expect(b.signature).not.toBe(c.signature);
+  });
+
+  it('TS-14: STUCK-LOOP regression guard — 3 IDENTICAL-outcome retries → attempts increments to 3', async () => {
+    const mod = require(MODULE_PATH);
+    const noopRca = vi.fn(async () => null);
+    const sameOutcome = { exit_code: 1, stderr_sha: 'same-failure-sha' };
+    const a = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'failing-cmd' }, {
+      rcaCheck: noopRca,
+      lastOutcome: sameOutcome,
+    });
+    expect(a.attempts).toBe(1);
+    const b = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'failing-cmd' }, {
+      rcaCheck: noopRca,
+      lastOutcome: sameOutcome,
+    });
+    expect(b.attempts).toBe(2);
+    const c = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'failing-cmd' }, {
+      rcaCheck: noopRca,
+      lastOutcome: sameOutcome,
+    });
+    expect(c.attempts).toBe(3);
+    // All same signature (stuck loop)
+    expect(a.signature).toBe(b.signature);
+    expect(b.signature).toBe(c.signature);
+  });
+
+  it('TS-15: RCA reset clears state.invocations on next call', async () => {
+    const mod = require(MODULE_PATH);
+    let rcaSeen = false;
+    const rcaCheck = vi.fn(async () => {
+      // Return null first time, then a fresh ISO once "RCA persisted"
+      const ret = rcaSeen ? '2026-05-09T02:00:00Z' : null;
+      rcaSeen = true;
+      return ret;
+    });
+    // Build up 2 attempts
+    await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'cmd1' }, {
+      rcaCheck,
+      lastOutcome: { exit_code: 1, stderr_sha: 'a' },
+    });
+    const second = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'cmd1' }, {
+      rcaCheck,
+      lastOutcome: { exit_code: 1, stderr_sha: 'a' },
+    });
+    // RCA fires — counter resets to 1
+    expect(second.rcaResetApplied).toBe(true);
+    expect(second.attempts).toBe(1);
+  });
+
+  it('TS-16: back-compat — recordAndCount without lastOutcome opt still works', async () => {
+    const mod = require(MODULE_PATH);
+    const noopRca = vi.fn(async () => null);
+    const a = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: 'echo hi' }, { rcaCheck: noopRca });
+    expect(a.attempts).toBe(1);
+    expect(a.signature).toMatch(/^Bash:[0-9a-f]{16}$/);
+    // No outcome digest segment when lastOutcome is missing
+    expect(a.signature.split(':').length).toBe(2);
+  });
+});

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * post-tool-rca-outcome.cjs — capture tool outcome for next PreToolUse signature mix.
+ *
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001
+ *
+ * Reads tool_response from STDIN payload (per verified 2026-05-04 hook
+ * stdin/env contract — env contains only 6 CLAUDE_* vars, NOT tool_response).
+ * Writes .claude/last-outcome-<session>.json with {tool_name, exit_code,
+ * stderr_sha, captured_at}. PreToolUse reads this file on next call and threads
+ * the digest into signatureFor() so iterative TDD (different stderr each retry)
+ * naturally tracks attempts=1 instead of tripping the 3-strikes counter.
+ *
+ * Hook contract:
+ *   - Always exits 0 (fail-open). Bookkeeping must NOT block tool execution.
+ *   - matcher: "Bash" in .claude/settings.json restricts firing.
+ *   - Feature-flag: LEO_RCA_OUTCOME_CAPTURE=off short-circuits the write.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
+const STDIN_TIMEOUT_MS = 1000;
+
+function getStdinJson(timeoutMs) {
+  return new Promise((resolve) => {
+    let chunks = [];
+    let resolved = false;
+    const timer = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        resolve(null);
+      }
+    }, timeoutMs);
+
+    process.stdin.on('data', (chunk) => chunks.push(chunk));
+    process.stdin.on('end', () => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8').trim();
+        if (!raw) return resolve(null);
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(null);
+      }
+    });
+    process.stdin.on('error', () => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timer);
+        resolve(null);
+      }
+    });
+  });
+}
+
+function stateFilePath(sessionId) {
+  const override = process.env.LEO_RETRY_STATE_DIR;
+  const dir = override
+    ? path.resolve(override)
+    : path.resolve(__dirname, '../../.claude');
+  return path.join(dir, `last-outcome-${sessionId}.json`);
+}
+
+function digestStderr(stderr) {
+  if (typeof stderr !== 'string' || !stderr) return '';
+  // First-line canonicalization — captures the failure shape without tying
+  // the digest to volatile fields like file paths or timestamps in subsequent lines.
+  const firstLine = stderr.split(/\r?\n/, 1)[0] || '';
+  return crypto.createHash('sha256').update(firstLine).digest('hex').slice(0, 16);
+}
+
+(async () => {
+  try {
+    // Feature-flag gate.
+    const flag = (process.env.LEO_RCA_OUTCOME_CAPTURE || 'on').toLowerCase();
+    if (flag === 'off' || flag === '0' || flag === 'false') return;
+
+    // Resolve session id (env first per existing hook precedent).
+    const sessionId =
+      process.env.CLAUDE_SESSION_ID ||
+      process.env.SESSION_ID ||
+      '';
+    if (!sessionId) return;
+
+    const payload = await getStdinJson(STDIN_TIMEOUT_MS);
+    if (!payload || typeof payload !== 'object') return;
+
+    // Claude Code hook payload: tool_response is the structured outcome.
+    // Accept multiple shapes for robustness across hook protocol versions.
+    const resp = payload.tool_response || payload.response || payload || {};
+    const toolName = TOOL_NAME || payload.tool_name || resp.tool_name || '';
+    if (!toolName) return;
+
+    // Only Bash carries exit code semantics relevant to this signature mix.
+    // For other tools, outcome capture is unnecessary (signatures are file_path-keyed).
+    if (toolName !== 'Bash') return;
+
+    const exitCode =
+      typeof resp.exit_code === 'number'
+        ? resp.exit_code
+        : typeof resp.code === 'number'
+          ? resp.code
+          : typeof resp.status === 'number'
+            ? resp.status
+            : null;
+    const stderr =
+      typeof resp.stderr === 'string'
+        ? resp.stderr
+        : typeof resp.error === 'string'
+          ? resp.error
+          : '';
+    const stderrSha = digestStderr(stderr);
+
+    // Skip writes that would yield no signal (no exit code AND no stderr).
+    if (exitCode === null && !stderrSha) return;
+
+    const outcome = {
+      tool_name: toolName,
+      exit_code: exitCode,
+      stderr_sha: stderrSha,
+      captured_at: new Date().toISOString(),
+    };
+
+    const fp = stateFilePath(sessionId);
+    fs.mkdirSync(path.dirname(fp), { recursive: true });
+    const tmp = `${fp}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(outcome), 'utf8');
+    fs.renameSync(tmp, fp);
+  } catch (err) {
+    // Fail-open: log to stderr but never throw.
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      process.stderr.write(`[post-tool-rca-outcome] ${err.message}\n`);
+    }
+  } finally {
+    process.exit(0);
+  }
+})();

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -796,6 +796,9 @@ async function main() {
       const stateMgr = require('./retry-state-manager.cjs');
 
       // Resolve the claimed SD key (used for RCA reset lookup).
+      // SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: prefer st.sd?.id (UUID) over
+      // st.sd?.sd_key (string). sub_agent_execution_results.sd_id is UUID-typed;
+      // stateMgr.fetchRcaInvocationSince now also UUID-resolves as a safety net.
       let claimedSdKey = null;
       try {
         const fs2 = require('fs');
@@ -803,14 +806,35 @@ async function main() {
         const stateFile = path2.resolve(__dirname, '../../.claude/unified-session-state.json');
         if (fs2.existsSync(stateFile)) {
           const st = JSON.parse(fs2.readFileSync(stateFile, 'utf8'));
-          claimedSdKey = st.sd?.sd_key || st.sd?.id || null;
+          claimedSdKey = st.sd?.id || st.sd?.sd_key || null;
         }
       } catch {
         // Missing state file is not fatal — reset lookup simply no-ops.
       }
 
+      // SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: read prior tool's outcome (captured
+      // by post-tool-rca-outcome.cjs PostToolUse hook) and thread into recordAndCount
+      // so signatureFor can mix the outcome digest. Different exit_code or stderr_sha
+      // → different signature → iterative TDD does not trip the 3-strikes counter.
+      let lastOutcome = null;
+      try {
+        const fs2 = require('fs');
+        const path2 = require('path');
+        const outcomeFile = path2.resolve(
+          __dirname,
+          `../../.claude/last-outcome-${_SESSION_ID}.json`
+        );
+        if (fs2.existsSync(outcomeFile)) {
+          const raw = fs2.readFileSync(outcomeFile, 'utf8');
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object') lastOutcome = parsed;
+        }
+      } catch {
+        // Missing/malformed outcome file → fall through to command-only signature (back-compat).
+      }
+
       const { attempts, signature, rcaResetApplied } = await stateMgr.recordAndCount(
-        _SESSION_ID, claimedSdKey, TOOL_NAME, input
+        _SESSION_ID, claimedSdKey, TOOL_NAME, input, { lastOutcome }
       );
 
       if (signature && attempts >= 2) {

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -25,6 +25,16 @@ const crypto = require('crypto');
 
 const RETRY_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 
+// SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001 — UUID-shape regex.
+// fetchRcaInvocationSince queries sub_agent_execution_results.sd_id which is
+// UUID-typed. Callers may pass either UUID or sd_key string; non-UUID inputs
+// must be resolved before the PostgREST filter (silent miss otherwise).
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Module-scope 60s TTL cache for sd_key→UUID resolutions.
+const _sdKeyToUuidCache = new Map(); // key -> { uuid: string|null, expires_at: number }
+const SD_KEY_CACHE_TTL_MS = 60 * 1000;
+
 // QF-20260504-830 — known-idempotent monitoring commands are exempt from
 // signature dedup. RCA-TIERED ENFORCEMENT was tripping the 4th invocation of
 // /coordinator periodic probes (all exit 0) the same way it gates retry loops.
@@ -62,16 +72,38 @@ function stateFilePath(sessionId) {
 
 /**
  * Build a stable signature for a tool invocation.
+ *
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: optional `lastOutcome` param mixes a
+ * digest of {exit_code, stderr_sha} into the Bash signature so iterative TDD
+ * (different failure each retry) does NOT collapse into the stuck-loop signature.
+ * Same outcome → same digest → stuck-loop detection preserved.
+ *
+ * Edit/Write/MultiEdit signatures are unchanged — file_path is the natural key.
+ *
  * @param {string} toolName
  * @param {Object} input
+ * @param {{exit_code?: number|string, stderr_sha?: string}} [lastOutcome] - optional outcome
+ *        from the prior tool call (captured by post-tool-rca-outcome.cjs).
+ *        Without it, returns the legacy command-only signature (back-compat).
  * @returns {string|null}
  */
-function signatureFor(toolName, input) {
+function signatureFor(toolName, input, lastOutcome) {
   if (!toolName || !input) return null;
   if (toolName === 'Bash') {
     const cmd = typeof input.command === 'string' ? input.command : '';
     if (!cmd) return null;
     const hash = crypto.createHash('sha256').update(cmd).digest('hex').slice(0, 16);
+    // Outcome admixture (back-compat: missing/malformed lastOutcome → command-only signature).
+    if (
+      lastOutcome &&
+      typeof lastOutcome === 'object' &&
+      (lastOutcome.exit_code !== undefined || lastOutcome.stderr_sha !== undefined)
+    ) {
+      const ec = lastOutcome.exit_code === undefined ? '' : String(lastOutcome.exit_code);
+      const ss = typeof lastOutcome.stderr_sha === 'string' ? lastOutcome.stderr_sha : '';
+      const outcomeDigest = crypto.createHash('sha256').update(`${ec}|${ss}`).digest('hex').slice(0, 8);
+      return `Bash:${hash}:${outcomeDigest}`;
+    }
     return `Bash:${hash}`;
   }
   if (toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit') {
@@ -80,6 +112,66 @@ function signatureFor(toolName, input) {
     return `${toolName}:${fp}`;
   }
   return null;
+}
+
+/**
+ * Resolve sd_key string → UUID for sub_agent_execution_results.sd_id queries.
+ * Returns null when input is null/undefined/unknown.
+ *
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: closes silent UUID-vs-sd_key mismatch
+ * (6th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
+ *
+ * @param {string|null|undefined} sdKeyOrUuid
+ * @returns {Promise<string|null>}
+ */
+async function resolveSdKeyToUuid(sdKeyOrUuid) {
+  if (typeof sdKeyOrUuid !== 'string' || !sdKeyOrUuid) return null;
+  // Already a UUID — pass through.
+  if (UUID_REGEX.test(sdKeyOrUuid)) return sdKeyOrUuid;
+
+  // Cache hit?
+  const now = Date.now();
+  const cached = _sdKeyToUuidCache.get(sdKeyOrUuid);
+  if (cached && cached.expires_at > now) {
+    return cached.uuid;
+  }
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+
+  // OR-query against strategic_directives_v2 (sd_key.eq.X OR id.eq.X).
+  // Note: id column is UUID but PostgREST tolerates string equality in or() filter.
+  const params = new URLSearchParams();
+  params.set('select', 'id');
+  params.set('or', `(sd_key.eq.${sdKeyOrUuid},id.eq.${sdKeyOrUuid})`);
+  params.set('limit', '1');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1200);
+  let resolved = null;
+  try {
+    const resp = await fetch(`${url}/rest/v1/strategic_directives_v2?${params.toString()}`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (resp.ok) {
+      const rows = await resp.json();
+      if (Array.isArray(rows) && rows.length > 0 && typeof rows[0].id === 'string') {
+        resolved = rows[0].id;
+      }
+    }
+  } catch {
+    clearTimeout(timer);
+    // Fail-open
+  }
+
+  _sdKeyToUuidCache.set(sdKeyOrUuid, { uuid: resolved, expires_at: now + SD_KEY_CACHE_TTL_MS });
+  if (!resolved && process.env.LEO_TELEMETRY_DEBUG === '1') {
+    process.stderr.write(`[retry-state-manager] sd_key resolution failed: ${sdKeyOrUuid}\n`);
+  }
+  return resolved;
 }
 
 /**
@@ -147,10 +239,16 @@ async function fetchRcaInvocationSince(sdKey, lastResetAt) {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key || !sdKey) return null;
 
+  // SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: resolve sd_key→UUID before the
+  // PostgREST filter. sub_agent_execution_results.sd_id is UUID-typed; passing
+  // a sd_key string silently mismatches and the reset never fires.
+  const sdUuid = await resolveSdKeyToUuid(sdKey);
+  if (!sdUuid) return null;
+
   const params = new URLSearchParams();
   params.set('select', 'created_at');
   params.set('sub_agent_code', 'eq.RCA');
-  params.set('sd_id', `eq.${sdKey}`);
+  params.set('sd_id', `eq.${sdUuid}`);
   params.set('order', 'created_at.desc');
   params.set('limit', '1');
   if (lastResetAt) params.set('created_at', `gt.${lastResetAt}`);
@@ -179,6 +277,10 @@ async function fetchRcaInvocationSince(sdKey, lastResetAt) {
  * Record a tool invocation and return the current attempt count.
  * Also performs RCA-reset lookup and state pruning. Fail-open on all errors.
  *
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: optional `lastOutcome` param threads
+ * the prior tool's outcome digest into the signature, allowing iterative TDD
+ * to track at attempts=1 while preserving stuck-loop detection.
+ *
  * @param {string} sessionId
  * @param {string} sdKey
  * @param {string} toolName
@@ -186,10 +288,11 @@ async function fetchRcaInvocationSince(sdKey, lastResetAt) {
  * @param {Object} [opts]
  * @param {Function} [opts.rcaCheck] - injectable async (sdKey, lastResetAt) => ISO|null
  * @param {number}   [opts.now]      - injectable current time in ms (for tests)
+ * @param {Object}   [opts.lastOutcome] - {exit_code, stderr_sha} from prior tool call
  * @returns {Promise<{ attempts: number, signature: string|null, rcaResetApplied: boolean }>}
  */
 async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) {
-  const signature = signatureFor(toolName, toolInput);
+  const signature = signatureFor(toolName, toolInput, opts.lastOutcome);
   if (!sessionId || !signature) {
     return { attempts: 0, signature: null, rcaResetApplied: false };
   }
@@ -231,8 +334,12 @@ module.exports = {
   readState,
   writeState,
   fetchRcaInvocationSince,
+  resolveSdKeyToUuid,
   pruneStale,
   stateFilePath,
   isExempt,
-  RETRY_WINDOW_MS
+  RETRY_WINDOW_MS,
+  UUID_REGEX,
+  // Test-only export for cache reset between test cases
+  _resetSdKeyCache: () => { _sdKeyToUuidCache.clear(); },
 };


### PR DESCRIPTION
## Summary
Two root-cause fixes that unblock iterative TDD without weakening stuck-loop detection. Discovered through user-directed RCA on hook over-aggressiveness witnessed twice in the source session (SD-LEO-INFRA-AUDIT-SHARED-TABLES-001 EXEC + QF-20260508-102 EXEC).

### Fix 1 — signatureFor() outcome admixture (back-compat)
Bash signature becomes `Bash:<cmdHash>:<outcomeDigest>` when prior tool's `last_outcome` (`exit_code`, `stderr_sha`) is provided. **Iterative TDD with different failures naturally tracks at attempts=1; identical-outcome retries still trip the 3-strikes counter (TS-14 regression guard).**

### Fix 2 — fetchRcaInvocationSince UUID resolution (silent-bug fix)
6th-witness `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`. The documented "automatic RCA reset" was silently broken for ALL SDs identified by sd_key — `sub_agent_execution_results.sd_id` is UUID-typed; the PostgREST filter passed the sd_key string directly. Now resolves sd_key→UUID inline (UUID-shape regex + OR-query, 60s TTL cache).

### Plus PostToolUse infrastructure
New `scripts/hooks/post-tool-rca-outcome.cjs` reads `tool_response` from stdin (per verified 2026-05-04 contract — NOT env), computes `stderr_sha`, writes `.claude/last-outcome-<session>.json`. PreToolUse threads it into `recordAndCount`.

## Test Results
**35/35 vitest pass** across 3 test files:
- `retry-state-manager-outcome-mix.test.js` (16 cases L1+L2+L3)
- `post-tool-rca-outcome.test.js` (5 functional + 4 static-source guards)
- `retry-state-manager.test.js` (10 existing — back-compat verified)

Mandatory tests included:
- **TS-1** byte-equal back-compat (no last_outcome → identical to prior impl)
- **TS-14** STUCK-LOOP regression guard (3 identical-outcome → attempts=3)
- **TS-13** TDD-iteration unblock (3 different-outcome → attempts=1)
- **TS-8** sd_key→UUID resolution (the bug fix)
- 4 static-source-code guards on hook contract integrity

## Sub-Agent Evidence
| Phase | Agent | Verdict | Conf | Evidence ID |
|-------|-------|---------|------|-------------|
| RCA (source) | RCA | PASS | 95 | `464448bb-20ab-42d5-b44d-4642a1b7b2a7` |
| LEAD | VALIDATION | PASS | 92 | `9bccd260-3e87-42ab-af7a-c06a2567ab3c` |
| LEAD | TESTING (prospective) | PASS | 96 | `89289dda-8d3f-466b-881d-ae29d1b0e660` |

Handoff scores: LEAD-TO-PLAN 95% | PLAN-TO-EXEC 94%.

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/{retry-state-manager,retry-state-manager-outcome-mix,post-tool-rca-outcome}.test.js` → 35/35
- [x] Manual: `signatureFor("Bash", {command:"x"})` returns `Bash:<hash>` (back-compat)
- [x] Manual: `signatureFor("Bash", {command:"x"}, {exit_code:1, stderr_sha:"abc"})` returns `Bash:<hash>:<digest>`
- [x] PR_MERGE_VERIFICATION single-repo (EHG_Engineer-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)