### PR TITLE
fix(QF-20260508-988): defer FR-3a worker signals to /coordinator inbox renderer

### DIFF
--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -418,9 +418,28 @@ async function main() {
 
   let emittedDirective = false;
 
+  // QF-20260508-988: when this session is the active coordinator, FR-3a worker
+  // signals (message_type=INFO + payload.signal_type) must be deferred to the
+  // /coordinator inbox renderer (scripts/fleet-dashboard.cjs:1042) instead of
+  // being drained here. Otherwise the dashboard's `read_at IS NULL` filter
+  // never matches because this hook marks them read first.
+  // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+  let amCoordinator = false;
+  if (!tableErr && messages && messages.length > 0) {
+    try {
+      const { getActiveCoordinatorId } = require(path.resolve(__dirname, '../../lib/coordinator/resolve.cjs'));
+      const coordinatorId = await getActiveCoordinatorId(supabase);
+      amCoordinator = coordinatorId && coordinatorId === sessionId;
+    } catch { /* fail-open: process messages normally if resolve.cjs missing */ }
+  }
+
   if (!tableErr && messages && messages.length > 0) {
     // Output each message
     for (const msg of messages) {
+      // QF-20260508-988: defer worker FR-3a signals to /coordinator inbox.
+      if (amCoordinator && msg.message_type === 'INFO' && msg.payload && msg.payload.signal_type) {
+        continue;
+      }
       const typeLabel = {
         'CLAIM_RELEASED': 'CLAIM RELEASED',
         'WORK_ASSIGNMENT': 'WORK ASSIGNMENT',

--- a/tests/unit/coordination-inbox-fr3a-defer.test.js
+++ b/tests/unit/coordination-inbox-fr3a-defer.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const HOOK = path.resolve(__dirname, '../../scripts/hooks/coordination-inbox.cjs');
+
+describe('QF-20260508-988: coordination-inbox FR-3a deferral guard', () => {
+  const src = readFileSync(HOOK, 'utf8');
+
+  it('imports getActiveCoordinatorId from lib/coordinator/resolve.cjs', () => {
+    expect(src).toMatch(/getActiveCoordinatorId\b/);
+    expect(src).toMatch(/lib\/coordinator\/resolve\.cjs/);
+  });
+
+  it('resolves amCoordinator before iterating messages', () => {
+    const guardIdx = src.indexOf('let amCoordinator = false');
+    const loopIdx = src.indexOf('for (const msg of messages)');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(loopIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(loopIdx);
+  });
+
+  it('skips FR-3a signals (INFO + payload.signal_type) when this session IS the coordinator', () => {
+    expect(src).toMatch(
+      /amCoordinator\s*&&\s*msg\.message_type\s*===\s*'INFO'\s*&&\s*msg\.payload\s*&&\s*msg\.payload\.signal_type/
+    );
+  });
+
+  it('fail-open: catch swallows resolve.cjs require errors so worker sessions still drain', () => {
+    expect(src).toMatch(/catch\s*\{\s*\/\*\s*fail-open[^*]*\*\/\s*\}/);
+  });
+
+  it('only marks coordinator-self comparison (not all coordinators)', () => {
+    expect(src).toMatch(/coordinatorId\s*===\s*sessionId/);
+  });
+});


### PR DESCRIPTION
## Summary
- Coordinator's own PostToolUse hook (`scripts/hooks/coordination-inbox.cjs`) was draining FR-3a worker signals before `/coordinator inbox` could render them — root-cause of "(no unread worker signals)" on a live coordinator.
- Guard now resolves `getActiveCoordinatorId()` once and skips rows where `message_type==='INFO' && payload.signal_type` if this session IS the active coordinator. Workers and non-coordinator sessions retain current behavior.
- Static-pattern vitest pins guard structure (5 assertions) so future edits don't silently weaken it.

## Test plan
- [x] `npx vitest run tests/unit/coordination-inbox-fr3a-defer.test.js` → 5/5 pass
- [x] End-to-end probe verified by previous session against live coordinator (signal surfaces in `/coordinator inbox` after fix)
- [x] Fail-open: try/catch around `require('lib/coordinator/resolve.cjs')` so workers still drain if helper goes missing

Resolves QF-20260508-988. Restores SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 FR-3a inbound path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)