### PR TITLE
fix(QF-20260508-997): extend stale-sweep claim cleanup to cancelled SDs

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -602,14 +602,17 @@ async function main() {
     }
   }
 
-  // FIX #2: Proactively clear stale claiming_session_id on completed SDs to prevent churn
-  const { data: completedWithClaims } = await supabase
+  // FIX #2: Proactively clear stale claiming_session_id on completed/cancelled SDs to prevent churn.
+  // QF-20260508-997: cancelled SDs share the same orphan-claim profile as completed ones — the
+  // owning session has long since exited but the row still carries claiming_session_id, blocking
+  // re-pickup and inflating active-claims counts. Same fix applies; status filter widened.
+  const { data: terminalWithClaims } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, claiming_session_id, is_working_on')
-    .eq('status', 'completed')
+    .select('sd_key, status, claiming_session_id, is_working_on')
+    .in('status', ['completed', 'cancelled'])
     .not('claiming_session_id', 'is', null);
 
-  for (const sd of (completedWithClaims || [])) {
+  for (const sd of (terminalWithClaims || [])) {
     const { error } = await supabase
       .from('strategic_directives_v2')
       .update({ claiming_session_id: null, is_working_on: false })
@@ -617,7 +620,7 @@ async function main() {
       .select();
 
     if (!error) {
-      actions.push('QA: cleared stale claiming_session_id on completed ' + sd.sd_key);
+      actions.push('QA: cleared stale claiming_session_id on ' + sd.status + ' ' + sd.sd_key);
     }
   }
 
@@ -1197,14 +1200,14 @@ async function main() {
   // QA summary
   const stuckCompleted = stuckApproval.filter(sd => sd.progress_percentage >= 100 && sd.completion_date);
   const stuckReset = stuckApproval.filter(sd => !(sd.progress_percentage >= 100 && sd.completion_date));
-  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (completedWithClaims || []).length;
+  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (terminalWithClaims || []).length;
   if (qaIssues > 0) {
     console.log('QA FIXES (' + qaIssues + '):');
     if (workingOnCompleted.length > 0) console.log('  Released ' + workingOnCompleted.length + ' session(s) working on completed SDs');
     if (orphanedClaims.length > 0) console.log('  Released ' + orphanedClaims.length + ' session(s) with orphaned claims');
     if (stuckCompleted.length > 0) console.log('  Completed ' + stuckCompleted.length + ' SD(s) stuck at 100%/pending_approval');
     if (stuckReset.length > 0) console.log('  Reset ' + stuckReset.length + ' SD(s) from pending_approval → draft (no session working on them)');
-    if ((completedWithClaims || []).length > 0) console.log('  Cleared ' + (completedWithClaims || []).length + ' stale claiming_session_id on completed SDs');
+    if ((terminalWithClaims || []).length > 0) console.log('  Cleared ' + (terminalWithClaims || []).length + ' stale claiming_session_id on completed/cancelled SDs');
     if (claimIntegrityIssues.length > 0) console.log('  Nudged ' + claimIntegrityIssues.length + ' idle session(s) with CLAIM_REMINDER');
     console.log('');
   }

--- a/tests/unit/stale-sweep-cancelled-claims.test.js
+++ b/tests/unit/stale-sweep-cancelled-claims.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs');
+
+describe('QF-20260508-997: stale-sweep clears cancelled-SD claims', () => {
+  const src = readFileSync(SCRIPT, 'utf8');
+
+  it('FIX #2 status filter includes cancelled, not just completed', () => {
+    expect(src).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]completed['"]\s*,\s*['"]cancelled['"]\s*\]/);
+  });
+
+  it('FIX #2 query selects status alongside sd_key for accurate logging', () => {
+    expect(src).toMatch(/select\(\s*['"][^'"]*\bstatus\b[^'"]*['"]\s*\)\s*\.in\(\s*['"]status['"]/);
+  });
+
+  it('action message reports actual status (completed or cancelled), not hardcoded "completed"', () => {
+    expect(src).toMatch(/QA: cleared stale claiming_session_id on '\s*\+\s*sd\.status/);
+  });
+
+  it('summary output mentions both completed and cancelled', () => {
+    expect(src).toMatch(/Cleared.*stale claiming_session_id on completed\/cancelled/);
+  });
+
+  it('legacy variable name completedWithClaims is fully replaced (no orphan references)', () => {
+    expect(src.includes('completedWithClaims')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- FIX #2 in `scripts/stale-session-sweep.cjs` previously cleared orphan `claiming_session_id` only on `status='completed'` SDs. Cancelled SDs are structurally identical for this purpose but were excluded — leading to multi-day zombie claims (witnessed 2026-05-08 on 2 PrivacyPatrol child SDs, 3 days stale).
- Status filter widened to `.in('status', ['completed','cancelled'])`; SELECT now includes `status` so the action log differentiates each row; summary line and variable renamed accordingly.
- Static-pattern vitest pins all 5 invariants (filter, select, log message, summary, legacy-name absence).

## Test plan
- [x] `npx vitest run tests/unit/stale-sweep-cancelled-claims.test.js` → 5/5 pass
- [x] Orthogonal to #3592 (QF-20260508-230 release payload) — same file, different function
- [ ] Post-merge: next sweep cycle clears `SD-PRIVACYPATROL-AI-LEO-ORCH-SPRINT-SPRINT-2026-001-C` and `-001-E3` zombies

Resolves QF-20260508-997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)