### PR TITLE
docs(QF-20260508-403): document NODE_MODULES_LOCK as phantom protocol

### DIFF
--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1430,6 +1430,8 @@ Workers signal mid-execution friction back to the active coordinator via session
 
 **How to send:** `/signal <type> "<body>"` slash command — see /signal --help. Or directly: `node scripts/worker-signal.cjs <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
 
+**NODE_MODULES_LOCK is advisory-only.** Dashboard `INFO` broadcasts with subject `NODE_MODULES_LOCK` are narrative annotations, not an enforced lock — `NODE_MODULES_LOCK` is not in the `coordination_message_type` enum and no producer/consumer gates npm operations on it. The actual `node_modules` blast-radius safety is filesystem-level via `safeRecursiveRm` in `lib/worktree-manager.js` (junction-safe rm; see header comment there). Don't add producer/consumer hooks expecting a real lock — see QF-20260508-403 / RCA `0b0168b7-1d0a-4e84-bb85-19ee25fffa38`.
+
 ## Strategic Governance Hierarchy
 
 The EHG platform operates under a 7-layer strategic governance stack. Each layer has a database table, CLI command, and clear purpose.

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -9,6 +9,22 @@
  * Legacy flat layout (.worktrees/<sdKey>/) is still supported.
  *
  * Legacy session-keyed API is supported via deprecation adapter.
+ *
+ * ─── NODE_MODULES_LOCK is a phantom protocol (QF-20260508-403) ─────────────
+ * Coordinator dashboards may show INFO broadcasts subjected `NODE_MODULES_LOCK`.
+ * These are advisory narrative only. There is NO lock protocol:
+ *   • `NODE_MODULES_LOCK` is not a value in the `coordination_message_type` enum
+ *     (DB rejects `INSERT ... message_type='NODE_MODULES_LOCK'`).
+ *   • Zero producer scripts broadcast a real lock.
+ *   • Zero consumer scripts gate `npm install` / `node_modules` operations on it.
+ * The actual blast-radius safety for concurrent npm install across worktrees is
+ * filesystem-level: junction-safe recursive rm via `safeRecursiveRm` (below) plus
+ * npm's atomic `.staging` swaps which keep concurrent installs on a junction-
+ * symlinked tree safe in practice.
+ * Do NOT add producer/consumer hooks expecting a coordination-channel lock; the
+ * intent was never realized. RCA evidence: `sub_agent_execution_results.id =
+ * 0b0168b7-1d0a-4e84-bb85-19ee25fffa38` (paired with QF-20260508-102).
+ * ────────────────────────────────────────────────────────────────────────────
  */
 
 import { execSync, spawnSync } from 'child_process';


### PR DESCRIPTION
## Summary
- RCA (paired with QF-20260508-102) confirmed `NODE_MODULES_LOCK` referenced in coordinator dashboards has **no implementation**: not in `coordination_message_type` enum, no producer, no consumer.
- Real `node_modules` blast-radius safety lives in `safeRecursiveRm` (junction-safe) at `lib/worktree-manager.js`.
- Adds a header comment block in `lib/worktree-manager.js` killing the phantom + a one-paragraph note in `CLAUDE_CORE.md` after the `/signal` section. Documentation-only.

## Test plan
- [x] No code paths touched — comment block + Markdown
- [x] Cross-references RCA evidence row `0b0168b7-1d0a-4e84-bb85-19ee25fffa38`

Resolves QF-20260508-403. Closes harness-backlog feedback `c5143e50-8180-45a8-885c-6210eb074ec5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)