### PR TITLE
docs(QF-20260508-517): surface /signal awareness in phase files, DIGESTs, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Invoke the RCA Sub-Agent (`subagent_type="rca-agent"`). Your prompt MUST contain
 9. **Chunked reads allowed** — `Read` has a 25k-token per-call cap (hard-coded Claude Code limit, NOT context exhaustion). Paginate with `offset`/`limit` or invoke `/read-full <path>`; use `*_DIGEST.md` for phase docs. Never `cat` via Bash (tighter ~30k char cap).
 > Why: The 25k cap is per Read call (Claude Code issues #40357/#14888/#15687), independent of the 1M context window. Misinterpreting it as "context too small" causes silent partial-reads of protocol files — the leading cause of LEO compliance drift in long sessions.
 
+10. **Friction signaling** — when you hit recurrence (gate 2× / RCA 2× / tool 3×), are about to bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), see protocol-spec friction, recognize a harness bug, or match a memory trend, `/signal <type> "<body>"` to the active coordinator. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. See CLAUDE_CORE.md "Signaling friction to the coordinator". SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+> Why: The /signal channel is documented only in CLAUDE_CORE.md, so workers loaded into a phase file (LEAD/PLAN/EXEC) without core never see when to send. Surfacing the trigger heuristic at every entry point makes the channel discoverable at the moment friction occurs, not 3+ workers and several recurrences later.
 
 ## AUTO-PROCEED Mode
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -12,6 +12,9 @@
 
 ---
 
+## Friction signaling
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+
 ## RCA Issue Resolution Mandate
 
 ## ⚠️ CRITICAL: Issue Resolution Protocol

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -10,6 +10,9 @@
 
 ---
 
+## Friction signaling
+**Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
 ## Autonomous Continuation Directives
 
 **CRITICAL**: These directives guide autonomous agent behavior during EXEC phase execution.

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -12,6 +12,9 @@
 
 ---
 
+## Friction signaling
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+
 ## 🚨 EXEC Agent Implementation Requirements
 
 ### MANDATORY Pre-Implementation Verification

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -10,6 +10,9 @@
 
 ---
 
+## Friction signaling
+**Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
 ## Autonomous Continuation Directives
 
 **CRITICAL**: These directives guide autonomous agent behavior during LEAD phase execution.

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -12,6 +12,9 @@
 
 ---
 
+## Friction signaling
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+
 ## 6-Step SD Evaluation Checklist
 
 **6-Step SD Evaluation Checklist (MANDATORY for LEAD & PLAN)**:

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -11,6 +11,9 @@
 
 ---
 
+## Friction signaling
+**Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
 ## Autonomous Continuation Directives
 
 **CRITICAL**: These directives guide autonomous agent behavior during PLAN phase execution.

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -12,6 +12,9 @@
 
 ---
 
+## Friction signaling
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints


### PR DESCRIPTION
## Summary
- The `/signal` worker→coordinator channel + 5-trigger heuristic lived only in `CLAUDE_CORE.md`. Workers loaded into phase files (LEAD/PLAN/EXEC) per CLAUDE.md Context Loading directive never saw it. DIGEST variants under context pressure also missed it.
- Witnessed 2026-05-08: 4 worker callsigns × 3-hour `/coordinator` window × multiple objectively `/signal`-worthy conditions → **zero invocations**.
- Adds a brief "Friction signaling" subsection to LEAD/PLAN/EXEC + 4 DIGEST files + Session Prologue item #10 in CLAUDE.md. Source-of-truth stays `CLAUDE_CORE.md`.

## Test plan
- [x] Source-of-truth unchanged (CLAUDE_CORE.md `Signaling friction` section preserved)
- [x] All 8 docs link back to canonical section + SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 anchor
- [x] 23 LOC, well under Tier 1 ceiling

## Known follow-up
- `CLAUDE_*.md` files are auto-regenerated daily by `.github/workflows/leo-kb-refresh.yml`. These manual edits will be overwritten within ~24h unless backed by `leo_protocol_sections` rows + `scripts/section-file-mapping.json` entries.
- Harness-backlog filed (feedback row `6cb46626-5c36-4ef8-bd40-5ded2228de04`) for DB-first follow-up: insert `signaling_friction_pointer_phase` + `signaling_friction_pointer_digest` sections + update mapping.

Resolves QF-20260508-517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)