### PR TITLE
docs(QF-20260508-810): persist /signal awareness pointers in section-file mappings

### DIFF
--- a/scripts/section-file-mapping-digest.json
+++ b/scripts/section-file-mapping-digest.json
@@ -17,6 +17,7 @@
   "CLAUDE_CORE_DIGEST.md": {
     "description": "Essential enforcement rules (~10k chars) - non-negotiable constraints only",
     "sections": [
+      "signaling_friction_pointer_digest",
       "rca_issue_resolution_mandate",
       "mandatory_phase_transitions",
       "negative_constraints_global",
@@ -29,6 +30,7 @@
   "CLAUDE_LEAD_DIGEST.md": {
     "description": "LEAD phase essentials (~3-4k chars) - approval gates and validation requirements",
     "sections": [
+      "signaling_friction_pointer_digest",
       "simplicity_first_enforcement",
       "lead_pre_approval_simplicity_gate",
       "sd_evaluation",
@@ -39,6 +41,7 @@
   "CLAUDE_PLAN_DIGEST.md": {
     "description": "PLAN phase essentials (~4k chars) - PRD requirements and constraints",
     "sections": [
+      "signaling_friction_pointer_digest",
       "prd_creation_anti_pattern",
       "plan_pre_exec_checklist",
       "negative_constraints_plan"
@@ -48,6 +51,7 @@
   "CLAUDE_EXEC_DIGEST.md": {
     "description": "EXEC phase essentials (~8k chars) - implementation requirements and constraints",
     "sections": [
+      "signaling_friction_pointer_digest",
       "exec_implementation_requirements",
       "exec_dual_test_requirement",
       "branch_hygiene_gate",

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -60,6 +60,7 @@
   "CLAUDE_LEAD.md": {
     "description": "LEAD phase operations (~15-20k chars). Lean LEAD (2026-02-16).",
     "sections": [
+      "signaling_friction_pointer_phase",
       "sd_creation_process",
       "sd_creation_anti_pattern",
       "sd_creation_errors",
@@ -89,6 +90,7 @@
   "CLAUDE_PLAN.md": {
     "description": "PLAN phase operations (~20-25k chars). Lean PLAN (2026-02-16).",
     "sections": [
+      "signaling_friction_pointer_phase",
       "workflow",
       "PHASE_2_PLANNING",
       "prd_creation_anti_pattern",
@@ -127,6 +129,7 @@
   "CLAUDE_EXEC.md": {
     "description": "EXEC phase operations (~15-20k chars). Lean EXEC (2026-02-16).",
     "sections": [
+      "signaling_friction_pointer_phase",
       "workflow",
       "exec_implementation_requirements",
       "exec_retrospective_anti_patterns",


### PR DESCRIPTION
## Summary
- Follow-up to QF-20260508-517 ([#3601](https://github.com/rickfelix/EHG_Engineer/pull/3601)) which shipped `/signal` awareness pointers as direct markdown edits. Without DB backing, `.github/workflows/leo-kb-refresh.yml` would silently overwrite them at the next 6 AM UTC regen.
- DB rows persisted via database-agent (audit trail in `sub_agent_execution_results`):
  - `id=596` `signaling_friction_pointer_phase` (3-paragraph phase-file content)
  - `id=597` `signaling_friction_pointer_digest` (1-paragraph DIGEST condensed content)
  - `id=209` `session_prologue` updated to append item #10 (Friction signaling) for CLAUDE.md router
- This PR adds the section types to both mapping JSONs (7 lines total) so the regenerator routes them to the right files.

## Why no MD changes in this PR
A push to `main` that touches `scripts/section-file-mapping.json` triggers `leo-kb-refresh.yml`. That workflow regenerates and auto-commits. Local regen verified the new pointers render correctly in all 8 target files; isolating this PR to the 7-line mapping change keeps review clean and lets the unrelated DB drift accumulated since the last regen land in a separate auto-commit.

## Test plan
- [x] database-agent verified all 3 row writes (id=596 / 597 / 209) with content integrity (471 chars / 281 chars / 4650 chars)
- [x] Local regen run produced expected friction-signaling content in all 8 target files
- [x] No constraint violations (no unique constraint on `section_type`, no row-level mtime tracked — safe upsert pattern used)

Closes harness-backlog feedback row `6cb46626` (5-witness pattern). Same DB-first persistence pattern as SD-LEO-INFRA-CODIFY-PROTOCOL-RULES-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)