### PR TITLE
docs(QF-20260508-406): warn QF authors about DB-generated markdown overwrite trap

### DIFF
--- a/scripts/read-quick-fix.js
+++ b/scripts/read-quick-fix.js
@@ -60,6 +60,35 @@ async function readQuickFix(qfId, options = {}) {
   console.log('📝 DESCRIPTION\n');
   console.log(`   ${qf.description}\n`);
 
+  // QF-20260508-406: DB-backed file warning. CLAUDE_*.md, *_DIGEST.md, and
+  // leo-protocol-v*.md are auto-regenerated daily at 06:00 UTC by
+  // .github/workflows/leo-kb-refresh.yml. Manual markdown edits to these
+  // files are silently overwritten unless backed by leo_protocol_sections
+  // rows + scripts/section-file-mapping*.json entries. Surfaced here so
+  // QF authors see the trap at the moment they read the spec.
+  // RCA-recommended preventive fix from QF-810 follow-up loop.
+  const dbBackedFilePattern = /(CLAUDE_[A-Z_]+\.md|CLAUDE\.md|[A-Z_]+_DIGEST\.md|leo-protocol-v[\d.]+\.md)/g;
+  const haystack = [qf.description, qf.steps_to_reproduce, qf.expected_behavior, qf.actual_behavior].filter(Boolean).join(' ');
+  const matches = [...new Set([...(haystack.matchAll(dbBackedFilePattern) || [])].map(m => m[1]))];
+  if (matches.length > 0) {
+    console.log('⚠️  DB-BACKED FILE WARNING\n');
+    console.log('   This QF references DB-generated markdown file(s):');
+    matches.forEach(m => console.log(`     - ${m}`));
+    console.log('');
+    console.log('   These files are regenerated daily at 06:00 UTC by');
+    console.log('   .github/workflows/leo-kb-refresh.yml. Direct markdown edits will be');
+    console.log('   silently overwritten on the next regen.');
+    console.log('');
+    console.log('   To make changes durable, update the source-of-truth in DB:');
+    console.log('     1. Modify or insert the relevant leo_protocol_sections row');
+    console.log('     2. Update scripts/section-file-mapping.json (full files)');
+    console.log('        or scripts/section-file-mapping-digest.json (DIGESTs)');
+    console.log('     3. Run: node scripts/generate-claude-md-from-db.js');
+    console.log('     4. Commit the regenerated markdown alongside the mapping change');
+    console.log('');
+    console.log('   See QF-20260508-810 for an example of the DB-first persistence pattern.\n');
+  }
+
   // Reproduction steps
   if (qf.steps_to_reproduce) {
     console.log('🔄 STEPS TO REPRODUCE\n');

--- a/tests/unit/read-quick-fix-db-backed-warning.test.js
+++ b/tests/unit/read-quick-fix-db-backed-warning.test.js
@@ -1,0 +1,76 @@
+// QF-20260508-406: read-quick-fix.js DB-backed file warning.
+// Static-pattern + behavior tests pinning the warning detector + remediation block.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/read-quick-fix.js');
+
+describe('QF-20260508-406: read-quick-fix.js DB-backed file warning', () => {
+  const src = readFileSync(SCRIPT, 'utf8');
+
+  it('exports a regex that matches CLAUDE_<phase>.md files', () => {
+    const match = src.match(/dbBackedFilePattern\s*=\s*\/([^/]+)\/g/);
+    expect(match).toBeTruthy();
+    const re = new RegExp(match[1], 'g');
+    const samples = ['CLAUDE_LEAD.md', 'CLAUDE_PLAN.md', 'CLAUDE_EXEC.md', 'CLAUDE_CORE.md'];
+    samples.forEach(s => expect(s).toMatch(re));
+  });
+
+  it('regex matches DIGEST variants', () => {
+    const match = src.match(/dbBackedFilePattern\s*=\s*\/([^/]+)\/g/);
+    const re = new RegExp(match[1], 'g');
+    const samples = ['CLAUDE_LEAD_DIGEST.md', 'CLAUDE_PLAN_DIGEST.md', 'CLAUDE_EXEC_DIGEST.md', 'CLAUDE_CORE_DIGEST.md', 'CLAUDE_DIGEST.md'];
+    samples.forEach(s => expect(s).toMatch(re));
+  });
+
+  it('regex matches CLAUDE.md (router) and leo-protocol-v*.md', () => {
+    const match = src.match(/dbBackedFilePattern\s*=\s*\/([^/]+)\/g/);
+    const re = new RegExp(match[1], 'g');
+    expect('CLAUDE.md').toMatch(re);
+    expect('leo-protocol-v4.4.1.md').toMatch(re);
+    expect('leo-protocol-v5.0.md').toMatch(re);
+  });
+
+  it('regex does NOT match unrelated markdown', () => {
+    const match = src.match(/dbBackedFilePattern\s*=\s*\/([^/]+)\/g/);
+    const re = new RegExp(match[1], 'g');
+    const negatives = ['README.md', 'docs/api/foo.md', 'CHANGELOG.md', 'src/lib/foo.ts', 'package.json'];
+    negatives.forEach(n => {
+      const reFresh = new RegExp(match[1], 'g');
+      expect(reFresh.test(n)).toBe(false);
+    });
+  });
+
+  it('warning block mentions leo-kb-refresh.yml workflow as the overwrite trigger', () => {
+    expect(src).toMatch(/leo-kb-refresh\.yml/);
+    expect(src).toMatch(/06:00 UTC/);
+  });
+
+  it('warning block lists the 4-step durable-update remediation', () => {
+    expect(src).toMatch(/leo_protocol_sections/);
+    expect(src).toMatch(/section-file-mapping\.json/);
+    expect(src).toMatch(/section-file-mapping-digest\.json/);
+    expect(src).toMatch(/generate-claude-md-from-db\.js/);
+  });
+
+  it('warning is gated on regex match (only fires when haystack matches)', () => {
+    expect(src).toMatch(/if\s*\(\s*matches\.length\s*>\s*0\s*\)/);
+  });
+
+  it('haystack includes description + steps + behavior fields (full QF content scanned)', () => {
+    expect(src).toMatch(/qf\.description/);
+    expect(src).toMatch(/qf\.steps_to_reproduce/);
+    expect(src).toMatch(/qf\.expected_behavior/);
+    expect(src).toMatch(/qf\.actual_behavior/);
+  });
+
+  it('warning references QF-20260508-810 as DB-first pattern example', () => {
+    expect(src).toMatch(/QF-20260508-810/);
+  });
+
+  it('regex deduplicates matches (no duplicate warnings for repeated mentions)', () => {
+    expect(src).toMatch(/new Set/);
+  });
+});


### PR DESCRIPTION
## Summary
RCA-recommended preventive fix from QF-810 follow-up loop (rca-agent 2026-05-09): the QF lifecycle gives no signal that markdown edits to `CLAUDE_*.md`, `*_DIGEST.md`, or `leo-protocol-v*.md` are auto-regenerated daily at 06:00 UTC by `.github/workflows/leo-kb-refresh.yml`. QF-517 fell into this trap; QF-810 was the cleanup. This fix surfaces the warning at the moment QF authors read the spec.

## Detector
- Regex: `/(CLAUDE_[A-Z_]+\.md|CLAUDE\.md|[A-Z_]+_DIGEST\.md|leo-protocol-v[\d.]+\.md)/g`
- Scans description + steps_to_reproduce + expected_behavior + actual_behavior (all 4 user-authored text fields)
- Dedup via `new Set()` so repeated mentions produce one warning, not many

## Warning block
- States the overwrite mechanism (workflow name + UTC time)
- Lists the 4-step durable-update remediation: leo_protocol_sections row → mapping JSONs → regen script → commit alongside
- Cross-references QF-20260508-810 as the canonical DB-first persistence example

## Test plan
- [x] 10 vitest cases pin regex inclusions / exclusions / haystack coverage / warning content / dedup → 10/10 pass locally

29 LOC src + 78 LOC test = Tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)