### PR TITLE
fix(QF-20260508-182): orphan-qf-reaper sets verified_by + verification_notes to satisfy completed_requires_verification CHECK

### DIFF
--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -162,6 +162,13 @@ async function main() {
         commit_sha: mergeCommitSha,
         compliance_verdict: 'PASS',
         compliance_details: 'Auto-reconciled by orphan-qf-reaper — PR merged on GitHub without complete-quick-fix.js flipping DB status.',
+        verified_by: 'ORPHAN_REAPER',
+        verification_notes: JSON.stringify({
+          reconciled_at: new Date().toISOString(),
+          closed_by: 'orphan_reaper',
+          pr_number: prNumber,
+          merge_commit_sha: mergeCommitSha,
+        }),
       })
       .eq('id', qf.id)
       .eq('status', qf.status)
@@ -234,6 +241,14 @@ async function main() {
           pr_url: prUrl,
           compliance_verdict: 'PASS',
           compliance_details: 'Auto-reconciled by orphan-qf-reaper (branch-derived path) — PR merged on GitHub without pr_url ever populated.',
+          verified_by: 'ORPHAN_REAPER',
+          verification_notes: JSON.stringify({
+            reconciled_at: new Date().toISOString(),
+            closed_by: 'orphan_reaper_branch_derived',
+            pr_number: prNumber,
+            branch: branchName,
+            merge_commit_sha: mergeCommitSha,
+          }),
         })
         .eq('id', qf.id)
         .eq('status', qf.status)


### PR DESCRIPTION
## Summary
- Sets `verified_by='ORPHAN_REAPER'` and `verification_notes` (canonical JSON shape) in both UPDATE blocks of `scripts/orphan-qf-reaper.mjs`. Required to satisfy the `completed_requires_verification` CHECK constraint that fires when `status` flips to `completed`.
- Continuation of QF-20260508-911 (PR #3605, branch-derived path) + QF-20260508-492 (PR #3606, metadata column drop). With those landed, the next reaper run hit the CHECK constraint as expected per memory.

## Why
3rd compounding bug witnessed in the reaper script over a single session, all in the same writer/consumer asymmetry pattern class as PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001. The reaper has likely never successfully reconciled any row since SD-LEO-INFRA-LIFECYCLE-RECONCILIATION shipped — explains the indefinite orphan accumulation.

## Test plan
- [ ] Post-merge: re-run `node scripts/orphan-qf-reaper.mjs` with `ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES=0`. Expect `summary.orphan_reconciled = 5` (QF-515 + QF-810 + QF-911 + QF-492 + this QF-182).
- [ ] All 5 rows have `status='completed'`, `verified_by='ORPHAN_REAPER'`, `verification_notes` populated, `pr_url`/`commit_sha`/`completed_at` set.
- [ ] Idempotency: a second live run yields `orphan_skipped_already_completed = 5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)