### PR TITLE
fix(QF-20260508-847): orphan-qf-reaper UPDATE includes force_completed:true

### DIFF
--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -169,6 +169,7 @@ async function main() {
           pr_number: prNumber,
           merge_commit_sha: mergeCommitSha,
         }),
+        force_completed: true,
       })
       .eq('id', qf.id)
       .eq('status', qf.status)
@@ -249,6 +250,7 @@ async function main() {
             branch: branchName,
             merge_commit_sha: mergeCommitSha,
           }),
+          force_completed: true,
         })
         .eq('id', qf.id)
         .eq('status', qf.status)

--- a/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
@@ -1,0 +1,69 @@
+// QF-20260508-847: orphan-qf-reaper UPDATE must include force_completed:true
+// to satisfy quick_fixes CHECK constraint completed_requires_verification:
+//   (tests_passing AND uat_verified) OR force_completed
+//
+// Both UPDATE call-sites in scripts/orphan-qf-reaper.mjs are reaper-driven
+// retroactive completions — neither path can vouch for tests_passing or
+// uat_verified at row-level. force_completed:true is the canonical override
+// (mirrors the database-agent canonical UPDATE pattern used for QF-20260508-515
+// retro-reconcile and the complete-quick-fix.js --force-complete flag).
+//
+// Prior witness: QF-20260508-182 added verified_by + verification_notes but
+// missed force_completed; reaper still hit the CHECK on every cron run since
+// 2026-05-08T23:32Z, leaving QF-911/-492/-182/-648 stuck as orphans.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REAPER_PATH = join(__dirname, '..', '..', '..', 'scripts', 'orphan-qf-reaper.mjs');
+
+describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard)', () => {
+  const source = readFileSync(REAPER_PATH, 'utf8');
+
+  // Robust to formatting: count `.update({` blocks targeting quick_fixes that
+  // also contain `force_completed: true` somewhere in the same block (until
+  // the matching `})`). Both sites must qualify.
+  function findUpdateBlocks(src) {
+    const blocks = [];
+    let cursor = 0;
+    while (true) {
+      const start = src.indexOf('.update({', cursor);
+      if (start === -1) break;
+      // Find matching closing `})` by tracking braces, naive but sufficient
+      let depth = 1;
+      let i = src.indexOf('{', start) + 1;
+      while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth += 1;
+        else if (ch === '}') depth -= 1;
+        i += 1;
+      }
+      blocks.push(src.slice(start, i));
+      cursor = i;
+    }
+    return blocks;
+  }
+
+  it('contains exactly two .update({...}) blocks (pr_url + branch-derived paths)', () => {
+    const blocks = findUpdateBlocks(source);
+    expect(blocks.length).toBe(2);
+  });
+
+  it('every UPDATE block sets status:completed AND force_completed:true', () => {
+    const blocks = findUpdateBlocks(source);
+    for (const [idx, block] of blocks.entries()) {
+      expect(block, `block #${idx + 1} missing status:'completed'`).toMatch(/status:\s*'completed'/);
+      expect(block, `block #${idx + 1} missing force_completed:true`).toMatch(/force_completed:\s*true/);
+      expect(block, `block #${idx + 1} missing verified_by:'ORPHAN_REAPER'`).toMatch(/verified_by:\s*'ORPHAN_REAPER'/);
+      expect(block, `block #${idx + 1} missing verification_notes`).toMatch(/verification_notes:/);
+    }
+  });
+
+  it('still references the SD origin (FR1) in the file header', () => {
+    expect(source).toMatch(/SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001.*FR1/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `force_completed: true` to both UPDATE branches in `scripts/orphan-qf-reaper.mjs` (L159 pr_url path + L237 branch-derived path).
- Resolves the silent CHECK-constraint failure that has caused **every reaper cron run since 2026-05-08T23:32Z** to error out reaping orphan QFs.
- 4 orphan QFs were stuck in `status='open'` because of this — three of them (QF-20260508-911 / -492 / -182) are the reaper's own follow-up fixes that never got reaped, breaking the FR1 promise of [SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001](https://github.com/rickfelix/EHG_Engineer/pull/3291). 5th was QF-20260508-515 (manually reconciled this session via database-agent canonical UPDATE before the reaper bug was diagnosed).
- Why force_completed and not tests_passing/uat_verified? The CHECK is `(tests_passing AND uat_verified) OR force_completed`. The reaper is reconciling already-merged PRs retroactively — it has no row-level signal for tests/UAT. force_completed:true is the canonical "explicit override, audited via verified_by + verification_notes" path. Mirrors the QF-20260508-515 manual canonical UPDATE pattern that the database-agent applied earlier in this session.

## Test plan
- [x] Static guard at `tests/unit/scripts/orphan-qf-reaper-force-completed.test.js` (3 cases) pins both UPDATE blocks. Asserts each carries `status:'completed'` + `force_completed:true` + `verified_by:'ORPHAN_REAPER'` + `verification_notes` — prevents silent omission of any required field on future edits.
- [x] Live dry-run before fix: orphan_evaluated=3, orphan_reconciled=0, errored=3 (`completed_requires_verification` violations on all 3).
- [x] Live dry-run after fix: orphan_evaluated=3, orphan_reconciled=3, errored=0.
- [ ] Post-merge: cron run will reap the 3 stuck orphans automatically — confirm via `quick_fixes` table after next 15-min tick.

## LOC
Source: 2 LOC (one `force_completed: true,` per UPDATE branch). Test: 67 LOC. Tier-1.

## RCA-context (this session)
1. Picked up QF-20260508-515 from `/leo next` queue.
2. Discovered `41efef0e61` already merged via PR #3587 → DB/code mismatch (pause point #5).
3. Invoked rca-agent (`2f77cb4a-4a4f-41e1-afc5-124c3d1a0ba5`): two-writer asymmetry (UAT_AGENT row vs developer commit), 5th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
4. database-agent applied canonical UPDATE on QF-515 (audit_log `43561317-2669-45f5-ba84-0f86b853aa26`).
5. Discovered `complete-quick-fix.js --non-interactive` still prompts on WARN compliance (sibling feedback `5d62eb87-5640-4f61-8f3d-49a2a8311004`, sibling of existing `f10d778a` 7th-witness).
6. **This PR**: Discovered orphan-qf-reaper failing on every cron run → diagnosed missing `force_completed` flag on its own UPDATEs → 2-LOC fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)