### PR TITLE
fix(QF-20260508-648): assign-fleet-identities excludes coordinator sessions

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -15,6 +15,13 @@
 const COLORS = ['blue', 'green', 'purple', 'orange', 'cyan', 'pink', 'yellow', 'red'];
 const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
 
+// QF-20260508-648: writer/consumer asymmetry — lib/coordinator/resolve.cjs
+// setActiveCoordinator() writes metadata.is_coordinator=true; this consumer
+// must filter it out so coordinator sessions aren't assigned worker callsigns.
+function filterOutCoordinators(rows) {
+  return (rows || []).filter(w => w && w.metadata?.is_coordinator !== true);
+}
+
 const ANSI = {
   red: '\x1b[31m', blue: '\x1b[34m', green: '\x1b[32m', yellow: '\x1b[33m',
   purple: '\x1b[35m', orange: '\x1b[38;5;208m', pink: '\x1b[38;5;213m', cyan: '\x1b[36m',
@@ -59,12 +66,14 @@ async function main() {
     query = query.neq('session_id', excludeSession);
   }
 
-  const { data: workers, error } = await query.order('heartbeat_at', { ascending: false });
+  const { data: rawWorkers, error } = await query.order('heartbeat_at', { ascending: false });
 
   if (error) {
     console.error('Error querying workers:', error.message);
     process.exit(1);
   }
+
+  const workers = filterOutCoordinators(rawWorkers);
 
   if (!workers || workers.length === 0) {
     console.log('No active workers found.');
@@ -250,7 +259,11 @@ async function main() {
   console.log('');
 }
 
-main().catch(err => {
-  console.error('Fleet identity assignment failed:', err.message);
-  process.exit(1);
-});
+module.exports = { filterOutCoordinators };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fleet identity assignment failed:', err.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -1,0 +1,63 @@
+// QF-20260508-648: writer/consumer asymmetry — assign-fleet-identities.cjs must
+// filter out coordinator sessions (metadata.is_coordinator=true) so the coordinator
+// is not assigned a worker callsign (Alpha-as-worker confusion).
+//
+// Sibling pattern: lib/coordinator/resolve.cjs setActiveCoordinator() is the writer.
+// 10th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { filterOutCoordinators } = require('../../scripts/assign-fleet-identities.cjs');
+
+describe('filterOutCoordinators (QF-20260508-648)', () => {
+  it('excludes a coordinator row (metadata.is_coordinator=true)', () => {
+    const rows = [
+      { session_id: 'coord-1', metadata: { is_coordinator: true } },
+      { session_id: 'worker-1', metadata: { fleet_identity: { callsign: 'Bravo' } } }
+    ];
+    const out = filterOutCoordinators(rows);
+    expect(out.map(r => r.session_id)).toEqual(['worker-1']);
+  });
+
+  it('retains workers whose metadata is missing entirely', () => {
+    const rows = [
+      { session_id: 'worker-1' },
+      { session_id: 'worker-2', metadata: null },
+      { session_id: 'worker-3', metadata: {} }
+    ];
+    const out = filterOutCoordinators(rows);
+    expect(out.map(r => r.session_id)).toEqual(['worker-1', 'worker-2', 'worker-3']);
+  });
+
+  it('retains workers with is_coordinator=false (idle workers explicitly cleared)', () => {
+    const rows = [
+      { session_id: 'worker-1', metadata: { is_coordinator: false } }
+    ];
+    expect(filterOutCoordinators(rows).map(r => r.session_id)).toEqual(['worker-1']);
+  });
+
+  it('handles null/undefined input without throwing', () => {
+    expect(filterOutCoordinators(null)).toEqual([]);
+    expect(filterOutCoordinators(undefined)).toEqual([]);
+    expect(filterOutCoordinators([])).toEqual([]);
+  });
+
+  it('filters mixed roster correctly (coordinator + multiple workers)', () => {
+    const rows = [
+      { session_id: 'worker-a' },
+      { session_id: 'coord-x', metadata: { is_coordinator: true, fleet_identity: { callsign: 'Alpha' } } },
+      { session_id: 'worker-b', metadata: { is_coordinator: false } },
+      { session_id: 'coord-y', metadata: { is_coordinator: true } },
+      { session_id: 'worker-c', metadata: { fleet_identity: { callsign: 'Charlie' } } }
+    ];
+    const out = filterOutCoordinators(rows);
+    expect(out.map(r => r.session_id)).toEqual(['worker-a', 'worker-b', 'worker-c']);
+  });
+
+  it('safely handles rows with null entries (does not throw on optional chain)', () => {
+    const rows = [null, undefined, { session_id: 'worker-1' }];
+    expect(filterOutCoordinators(rows).map(r => r.session_id)).toEqual(['worker-1']);
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/assign-fleet-identities.cjs` now filters out coordinator sessions (metadata.is_coordinator=true) post-query, so the coordinator no longer gets assigned a worker callsign (Alpha-as-worker confusion).
- Writer/consumer asymmetry fix: `lib/coordinator/resolve.cjs` writes `is_coordinator=true`; this sibling consumer now reads it. 10th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.

## Implementation
- Pure helper `filterOutCoordinators(rows)` — drops null rows and any row with `metadata.is_coordinator === true`.
- Applied immediately after the active-worker query, before dedup/assignment.
- Helper exported for testability; CLI behavior gated on `require.main === module`.

## Tests
- `tests/unit/assign-fleet-identities-coordinator-filter.test.js` — 6 vitest cases, all pass.

## Test plan
- [x] vitest passes (6/6)
- [ ] Manual smoke: run `node scripts/assign-fleet-identities.cjs` while a coordinator is active; coordinator should NOT receive a callsign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)