### PR TITLE
feat(SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001): suppress corrective-sd-generator drift-loop emissions

### DIFF
--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -21,6 +21,9 @@ import { createSD } from '../leo-create-sd.js';
 import { loadIntelligenceSignals } from '../../lib/eva/intelligence-loader.js';
 import { calculateCorrectivePriority } from '../../lib/eva/corrective-priority-calculator.js';
 import { recordCorrectiveFinding } from '../../lib/eva/corrective-finding-recorder.js';
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA 3: reuse the canonical
+// placeholder regex set rather than redefining it here.
+import { isPlaceholderText } from '../modules/handoff/executors/lead-to-plan/gates/placeholder-content.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 config({ path: join(__dirname, '../../.env') });
@@ -174,6 +177,112 @@ export async function isSourceSDA05Suppressed(sourceSdId, supabase) {
   } catch {
     return { suppress: false, reason: null, sourceSdKey: null };
   }
+}
+
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-1.
+// Skip when source SD status='completed' AND completion_date >= NOW() - 24h AND
+// no FAIL/BLOCKED gate evidence exists for the source SD's most-recent phase.
+// Conservative default: emit on lookup failure or NULL completion_date so legit
+// signals aren't lost (mirrors isSourceSDA05Suppressed shape).
+export async function isSourceCompletedRecently(sourceSdId, supabase) {
+  if (!sourceSdId) return { suppress: false, reason: null, sourceSdKey: null };
+  try {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status, completion_date')
+      .or(`sd_key.eq.${sourceSdId},id.eq.${sourceSdId}`)
+      .limit(1)
+      .maybeSingle();
+    if (!sd || sd.status !== 'completed' || !sd.completion_date) {
+      return { suppress: false, reason: null, sourceSdKey: null };
+    }
+    const hoursSince = (Date.now() - new Date(sd.completion_date).getTime()) / (1000 * 60 * 60);
+    if (hoursSince >= 24) {
+      return { suppress: false, reason: null, sourceSdKey: sd.sd_key || sd.id };
+    }
+    // Verify no FAIL/BLOCKED evidence (UPPERCASE per verdict enum)
+    const { data: failures } = await supabase
+      .from('sub_agent_execution_results')
+      .select('id, verdict')
+      .eq('sd_id', sd.id)
+      .in('verdict', ['FAIL', 'BLOCKED'])
+      .limit(1);
+    if (failures && failures.length > 0) {
+      return { suppress: false, reason: 'has_failing_gate_evidence', sourceSdKey: sd.sd_key || sd.id };
+    }
+    return {
+      suppress: true,
+      reason: 'completed_within_24h_no_failures',
+      sourceSdKey: sd.sd_key || sd.id,
+      hoursSince: Math.round(hoursSince * 10) / 10,
+    };
+  } catch {
+    return { suppress: false, reason: null, sourceSdKey: null };
+  }
+}
+
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-2.
+// Skip when source SD's parent_sd_id resolves to an orchestrator with
+// status='completed' AND completion_date older than 30 days. Orphan-parent class.
+export async function isParentOrchestratorStale(sourceSdId, supabase) {
+  if (!sourceSdId) return { suppress: false, reason: null, parentSdKey: null };
+  try {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, parent_sd_id')
+      .or(`sd_key.eq.${sourceSdId},id.eq.${sourceSdId}`)
+      .limit(1)
+      .maybeSingle();
+    if (!sd || !sd.parent_sd_id) return { suppress: false, reason: null, parentSdKey: null };
+    const { data: parent } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status, completion_date')
+      .eq('id', sd.parent_sd_id)
+      .maybeSingle();
+    if (!parent || parent.status !== 'completed' || !parent.completion_date) {
+      return { suppress: false, reason: null, parentSdKey: parent?.sd_key || sd.parent_sd_id };
+    }
+    const daysSince = (Date.now() - new Date(parent.completion_date).getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSince <= 30) {
+      return { suppress: false, reason: null, parentSdKey: parent.sd_key || parent.id };
+    }
+    return {
+      suppress: true,
+      reason: 'parent_completed_30d_stale',
+      parentSdKey: parent.sd_key || parent.id,
+      daysSince: Math.round(daysSince),
+    };
+  } catch {
+    return { suppress: false, reason: null, parentSdKey: null };
+  }
+}
+
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-3.
+// Refuse emission when source SD's key_changes are entirely placeholder
+// templates (no concrete file/function/test reference). Reuses isPlaceholderText
+// from lead-to-plan/gates/placeholder-content.js as canonical regex set.
+export function isAllKeyChangesPlaceholder(keyChanges) {
+  if (!Array.isArray(keyChanges) || keyChanges.length === 0) return false;
+  return keyChanges.every((kc) => {
+    const text = typeof kc === 'string' ? kc : (kc?.change ?? kc?.title ?? '');
+    return isPlaceholderText(text);
+  });
+}
+
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-4.
+// Strip self-exempting handoff-gate entries from gate_exemptions[] when the
+// source_gate matches. Mapping: eva_vision_score / eva_heal_score both produce
+// findings whose vision-scoring gate IS GATE_VISION_SCORE — exempting that gate
+// is tautological self-exemption. Returns the filtered array.
+const SOURCE_GATE_TO_HANDOFF_GATE = Object.freeze({
+  eva_vision_score: 'GATE_VISION_SCORE',
+  eva_heal_score: 'GATE_VISION_SCORE',
+});
+export function stripSelfExemptingGate(gateExemptions, sourceGate) {
+  if (!Array.isArray(gateExemptions) || gateExemptions.length === 0) return [];
+  const selfExempting = SOURCE_GATE_TO_HANDOFF_GATE[sourceGate];
+  if (!selfExempting) return [...gateExemptions];
+  return gateExemptions.filter((g) => g !== selfExempting);
 }
 
 /**
@@ -478,6 +587,35 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     }
   }
 
+  // 4b. Source-completion + parent-orchestrator suppression
+  // (SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA 1 + 2). Runs BEFORE
+  // multi-dim extraction so the audit trail is clean and no groups are formed
+  // for SDs that should never have generated a finding in the first place.
+  if (score.sd_id) {
+    const completedCheck = await isSourceCompletedRecently(score.sd_id, supabase);
+    if (completedCheck.suppress) {
+      const eventType = 'skipped_completed_source_24h';
+      console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${completedCheck.sourceSdKey} hours_since=${completedCheck.hoursSince}`);
+      await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
+        source_sd_id: completedCheck.sourceSdKey,
+        reason: completedCheck.reason,
+        hours_since_completion: completedCheck.hoursSince,
+      });
+      return { created: false, action: 'skipped', reason: 'completed_source_24h', sdKey: null, sdId: null };
+    }
+    const parentCheck = await isParentOrchestratorStale(score.sd_id, supabase);
+    if (parentCheck.suppress) {
+      const eventType = 'skipped_stale_orchestrator_30d';
+      console.log(`[corrective-sd-generator] eva.corrective.${eventType} parent_sd_key=${parentCheck.parentSdKey} days_stale=${parentCheck.daysSince}`);
+      await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
+        parent_sd_key: parentCheck.parentSdKey,
+        reason: parentCheck.reason,
+        days_stale: parentCheck.daysSince,
+      });
+      return { created: false, action: 'skipped', reason: 'stale_orchestrator_30d', sdKey: null, sdId: null };
+    }
+  }
+
   // 5. Multi-dimension extraction and grouping (SD-MAN-INFRA-VISION-CORRECTIVE-MULTI-DIM-001)
   const tier = TIER_CONFIG[action] ?? TIER_CONFIG.escalation;
   const weakDims = _extractWeakDimensions(score.dimension_scores, 3);
@@ -554,6 +692,33 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     }
   }
 
+  // 5c. Tautology guard (SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-3).
+  // Refuse the entire emission when the source SD's key_changes are all
+  // placeholder templates — generating a corrective finding for an SD whose
+  // own deliverable is template noise is tautological. Conservative default:
+  // emit when key_changes is missing or unreadable.
+  if (score.sd_id) {
+    try {
+      const { data: sourceForTautology } = await supabase
+        .from('strategic_directives_v2')
+        .select('key_changes')
+        .or(`sd_key.eq.${score.sd_id},id.eq.${score.sd_id}`)
+        .limit(1)
+        .maybeSingle();
+      if (sourceForTautology && isAllKeyChangesPlaceholder(sourceForTautology.key_changes)) {
+        const eventType = 'refused_tautology_key_changes';
+        console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${score.sd_id} reason=all_key_changes_placeholder`);
+        await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
+          source_sd_id: score.sd_id,
+          reason: 'all_key_changes_placeholder',
+        });
+        return { created: false, action: 'skipped', reason: 'tautology_key_changes', sdKey: null, sdId: null };
+      }
+    } catch {
+      // Conservative default: emit on lookup failure
+    }
+  }
+
   // 6. Record one feedback finding per group via corrective-finding-recorder
   // (SD-LEO-INFRA-CORRECTIVE-FINDING-REDIRECT-001). Replaces direct createSD()
   // emission; findings now persist in feedback (category='corrective_finding')
@@ -596,7 +761,10 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
           lowest_dim_score: lowestScore,
           vision_id: score.vision_id ?? null,
           action_tier: action,
-          gate_exemptions: ['GATE_VISION_SCORE'],
+          // SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 CAPA-4: strip the
+          // source_gate's corresponding handoff-gate entry so corrective findings
+          // don't self-exempt from the gate that justified their existence.
+          gate_exemptions: stripSelfExemptingGate(['GATE_VISION_SCORE'], sourceGate),
           intelligence_priority: {
             priority: dynamicPriority,
             band: priorityResult?.band ?? null,

--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -678,7 +678,10 @@ async function cmdSDGenerateAll(scoreIds, options = {}) {
 
   for (const scoreId of ids) {
     try {
-      const result = await generateCorrectiveSD(scoreId);
+      // SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 FR-5: forward `options`
+      // so future override flags (e.g., --force at line 436 staleness check)
+      // reach the single-emit path identically to cmdSDGenerate (line 627).
+      const result = await generateCorrectiveSD(scoreId, options);
       if (result.created) {
         results.created.push(result);
         const sdList = result.sds || [{ sdKey: result.sdKey }];

--- a/tests/unit/eva/corrective-sd-generator-suppression-predicates.test.js
+++ b/tests/unit/eva/corrective-sd-generator-suppression-predicates.test.js
@@ -1,0 +1,303 @@
+// SD-FDBK-INFRA-SUPPRESS-CORRECTIVE-GENERATOR-001 — vitest pin for CAPA 1-4 + FR-5.
+// Verdict scope-lock: 13 test scenarios from PRD (TS-1 through TS-13).
+// Mock pattern: plain-object (mirrors corrective-sd-generator-a05-filter.test.js:88-103)
+// per validation-agent finding #6 — vi.fn() is NOT the existing convention.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  isSourceCompletedRecently,
+  isParentOrchestratorStale,
+  isAllKeyChangesPlaceholder,
+  stripSelfExemptingGate,
+} from '../../../scripts/eva/corrective-sd-generator.mjs';
+
+// ── plain-object Supabase mock (matches existing test convention) ──
+function makeSupabaseLookup(rowMap, failureRows = []) {
+  return {
+    from(table) {
+      if (table === 'sub_agent_execution_results') {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: () => ({
+                limit: async () => ({ data: failureRows, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: () => ({
+          or: () => ({
+            limit: () => ({
+              maybeSingle: async () => ({ data: rowMap.byOr ?? null, error: null }),
+            }),
+          }),
+          eq: () => ({
+            maybeSingle: async () => ({ data: rowMap.byEq ?? null, error: null }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+// ── CAPA-1: source-completion suppression ──
+describe('CAPA-1 isSourceCompletedRecently — TS-1 / TS-2 / TS-3 / TS-4 / TS-12', () => {
+  const NOW = Date.now();
+  const HOURS = (h) => new Date(NOW - h * 3600 * 1000).toISOString();
+
+  it('TS-1: skips when source_sd.status=completed AND completion_date 12h ago', async () => {
+    const sb = makeSupabaseLookup({
+      byOr: { id: 'u1', sd_key: 'SD-X', status: 'completed', completion_date: HOURS(12) },
+    });
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(true);
+    expect(r.reason).toBe('completed_within_24h_no_failures');
+    expect(r.sourceSdKey).toBe('SD-X');
+  });
+
+  it('TS-2 boundary: emits at exactly 24h00m (boundary excluded)', async () => {
+    const sb = makeSupabaseLookup({
+      byOr: { id: 'u2', sd_key: 'SD-X', status: 'completed', completion_date: HOURS(24.01) },
+    });
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('TS-2 boundary: skips at 23h59m (boundary included)', async () => {
+    const sb = makeSupabaseLookup({
+      byOr: { id: 'u2b', sd_key: 'SD-X', status: 'completed', completion_date: HOURS(23.5) },
+    });
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(true);
+  });
+
+  it('TS-3: emits when completed-recent BUT a FAIL/BLOCKED gate evidence row exists', async () => {
+    const sb = makeSupabaseLookup(
+      { byOr: { id: 'u3', sd_key: 'SD-X', status: 'completed', completion_date: HOURS(12) } },
+      [{ id: 'ev-fail', verdict: 'FAIL' }]
+    );
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(false);
+    expect(r.reason).toBe('has_failing_gate_evidence');
+  });
+
+  it('TS-4 conservative default: emits when source-SD lookup misses (data null)', async () => {
+    const sb = makeSupabaseLookup({ byOr: null });
+    const r = await isSourceCompletedRecently('SD-MISSING', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('TS-12: emits when source_sd.status=cancelled (predicate is status-specific, not terminal)', async () => {
+    const sb = makeSupabaseLookup({
+      byOr: { id: 'u4', sd_key: 'SD-X', status: 'cancelled', completion_date: HOURS(12) },
+    });
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('emits when completion_date is NULL (incomplete data — conservative default)', async () => {
+    const sb = makeSupabaseLookup({
+      byOr: { id: 'u5', sd_key: 'SD-X', status: 'completed', completion_date: null },
+    });
+    const r = await isSourceCompletedRecently('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('emits when sourceSdId is null (no-op input)', async () => {
+    const r = await isSourceCompletedRecently(null, makeSupabaseLookup({}));
+    expect(r.suppress).toBe(false);
+  });
+});
+
+// ── CAPA-2: parent-orchestrator stale-completion ──
+describe('CAPA-2 isParentOrchestratorStale — TS-5 / TS-6 / TS-7', () => {
+  const NOW = Date.now();
+  const DAYS = (d) => new Date(NOW - d * 24 * 3600 * 1000).toISOString();
+
+  function makeSb(sdRow, parentRow) {
+    let callCount = 0;
+    return {
+      from() {
+        return {
+          select: () => ({
+            or: () => ({
+              limit: () => ({
+                maybeSingle: async () => ({ data: sdRow, error: null }),
+              }),
+            }),
+            eq: () => ({
+              maybeSingle: async () => {
+                callCount++;
+                return { data: parentRow, error: null };
+              },
+            }),
+          }),
+        };
+      },
+    };
+  }
+
+  it('TS-5: skips when parent.status=completed AND completion_date 31d ago', async () => {
+    const sb = makeSb(
+      { id: 'sd1', parent_sd_id: 'parent1' },
+      { id: 'parent1', sd_key: 'SD-PARENT', status: 'completed', completion_date: DAYS(31) }
+    );
+    const r = await isParentOrchestratorStale('SD-X', sb);
+    expect(r.suppress).toBe(true);
+    expect(r.reason).toBe('parent_completed_30d_stale');
+    expect(r.parentSdKey).toBe('SD-PARENT');
+    expect(r.daysSince).toBeGreaterThanOrEqual(31);
+  });
+
+  it('TS-6: emits when parent_sd_id is NULL (no parent — not orphan-stale)', async () => {
+    const sb = makeSb({ id: 'sd2', parent_sd_id: null }, null);
+    const r = await isParentOrchestratorStale('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('TS-7: emits when parent.completion_date is NULL (incomplete data — conservative default)', async () => {
+    const sb = makeSb(
+      { id: 'sd3', parent_sd_id: 'parent3' },
+      { id: 'parent3', sd_key: 'SD-PARENT', status: 'completed', completion_date: null }
+    );
+    const r = await isParentOrchestratorStale('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('emits when parent.status is in_progress (not completed)', async () => {
+    const sb = makeSb(
+      { id: 'sd4', parent_sd_id: 'parent4' },
+      { id: 'parent4', sd_key: 'SD-PARENT', status: 'in_progress', completion_date: DAYS(60) }
+    );
+    const r = await isParentOrchestratorStale('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+
+  it('emits when parent.completion_date is within 30d (not stale)', async () => {
+    const sb = makeSb(
+      { id: 'sd5', parent_sd_id: 'parent5' },
+      { id: 'parent5', sd_key: 'SD-PARENT', status: 'completed', completion_date: DAYS(15) }
+    );
+    const r = await isParentOrchestratorStale('SD-X', sb);
+    expect(r.suppress).toBe(false);
+  });
+});
+
+// ── CAPA-3: tautology guard via isPlaceholderText ──
+describe('CAPA-3 isAllKeyChangesPlaceholder — TS-8 / TS-9', () => {
+  it('TS-8: returns true when key_changes=["Implement core changes for: foo"] (matches isPlaceholderText regex)', () => {
+    expect(isAllKeyChangesPlaceholder(['Implement core changes for: vision-scorer'])).toBe(true);
+  });
+
+  it('TS-8 (object form): returns true when key_changes=[{change: "Implement core changes for: bar"}]', () => {
+    expect(isAllKeyChangesPlaceholder([{ change: 'Implement core changes for: bar' }])).toBe(true);
+  });
+
+  it('TS-9: returns false when at least one entry has concrete file/function reference', () => {
+    expect(
+      isAllKeyChangesPlaceholder([
+        'Implement core changes for: foo',
+        'Edit scripts/eva/corrective-sd-generator.mjs:481 to add suppression check',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false when key_changes is empty array', () => {
+    expect(isAllKeyChangesPlaceholder([])).toBe(false);
+  });
+
+  it('returns false when key_changes is null/undefined', () => {
+    expect(isAllKeyChangesPlaceholder(null)).toBe(false);
+    expect(isAllKeyChangesPlaceholder(undefined)).toBe(false);
+  });
+});
+
+// ── CAPA-4: self-exemption strip ──
+describe('CAPA-4 stripSelfExemptingGate — TS-10 / TS-11', () => {
+  it('TS-10: strips GATE_VISION_SCORE when source_gate=eva_vision_score', () => {
+    const r = stripSelfExemptingGate(['GATE_VISION_SCORE'], 'eva_vision_score');
+    expect(r).toEqual([]);
+  });
+
+  it('TS-10: strips GATE_VISION_SCORE when source_gate=eva_heal_score (heal scores under vision umbrella)', () => {
+    const r = stripSelfExemptingGate(['GATE_VISION_SCORE'], 'eva_heal_score');
+    expect(r).toEqual([]);
+  });
+
+  it('TS-11 additive: strips ONLY the self-exempting entry, preserves other exemptions', () => {
+    const r = stripSelfExemptingGate(
+      ['GATE_VISION_SCORE', 'GATE_TESTING', 'GATE_DESIGN'],
+      'eva_vision_score'
+    );
+    expect(r).toEqual(['GATE_TESTING', 'GATE_DESIGN']);
+  });
+
+  it('preserves array as-is when source_gate is unknown (no mapping)', () => {
+    const r = stripSelfExemptingGate(['GATE_VISION_SCORE'], 'unknown_source');
+    expect(r).toEqual(['GATE_VISION_SCORE']);
+  });
+
+  it('returns empty array when input is null/undefined/empty', () => {
+    expect(stripSelfExemptingGate(null, 'eva_vision_score')).toEqual([]);
+    expect(stripSelfExemptingGate([], 'eva_vision_score')).toEqual([]);
+  });
+});
+
+// ── FR-5: heal-command.mjs:681 forwards options ──
+describe('FR-5 — heal-command.mjs cmdSDGenerateAll forwards options to generateCorrectiveSD (TS-13)', () => {
+  const HEAL = path.resolve(__dirname, '../../../scripts/eva/heal-command.mjs');
+  const src = readFileSync(HEAL, 'utf8');
+
+  it('TS-13: line in cmdSDGenerateAll forwards `options` (was `generateCorrectiveSD(scoreId)` pre-fix)', () => {
+    // Static-pattern assertion: the for-loop in cmdSDGenerateAll must forward options.
+    // Pre-fix called with 1 arg; post-fix calls with 2 args.
+    expect(src).toMatch(/cmdSDGenerateAll[\s\S]*?for\s*\(\s*const\s+scoreId\s+of\s+ids\s*\)\s*\{[\s\S]*?const\s+result\s*=\s*await\s+generateCorrectiveSD\s*\(\s*scoreId\s*,\s*options\s*\)/);
+  });
+
+  it('cmdSDGenerate (single-emit path) forwards options too — sibling parity check', () => {
+    expect(src).toMatch(/async\s+function\s+cmdSDGenerate\s*\([^)]*\)\s*\{[\s\S]*?const\s+result\s*=\s*await\s+generateCorrectiveSD\s*\(\s*scoreId\s*,\s*options\s*\)/);
+  });
+});
+
+// ── AC-2: static-grep for isPlaceholderText reuse ──
+describe('AC-2 — corrective-sd-generator.mjs reuses isPlaceholderText (does not redefine)', () => {
+  const GEN = path.resolve(__dirname, '../../../scripts/eva/corrective-sd-generator.mjs');
+  const src = readFileSync(GEN, 'utf8');
+
+  it('imports isPlaceholderText from canonical location (no redefinition)', () => {
+    expect(src).toMatch(
+      /^import\s+\{[^}]*isPlaceholderText[^}]*\}\s+from\s+['"][^'"]*lead-to-plan\/gates\/placeholder-content[^'"]*['"]/m
+    );
+  });
+
+  it('isPlaceholderText is referenced AT LEAST 2x (1 import + 1 use)', () => {
+    const matches = src.match(/\bisPlaceholderText\b/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── AC-4: distinct event types for each suppression path ──
+describe('AC-4 — each suppression path emits a distinct eva.corrective.* event', () => {
+  const GEN = path.resolve(__dirname, '../../../scripts/eva/corrective-sd-generator.mjs');
+  const src = readFileSync(GEN, 'utf8');
+
+  it('emits skipped_completed_source_24h (CAPA-1)', () => {
+    expect(src).toMatch(/['"]skipped_completed_source_24h['"]/);
+  });
+  it('emits skipped_stale_orchestrator_30d (CAPA-2)', () => {
+    expect(src).toMatch(/['"]skipped_stale_orchestrator_30d['"]/);
+  });
+  it('emits refused_tautology_key_changes (CAPA-3)', () => {
+    expect(src).toMatch(/['"]refused_tautology_key_changes['"]/);
+  });
+
+  it('preserves existing skipped_a05_source_class + skipped_lifecycle_feature_class events', () => {
+    expect(src).toMatch(/['"]skipped_a05_source_class['"]/);
+    expect(src).toMatch(/['"]skipped_lifecycle_feature_class['"]/);
+  });
+});


### PR DESCRIPTION
## Summary
RCA-confirmed root cause: `scripts/eva/corrective-sd-generator.mjs` had source-class + dim suppression but lacked source-completion / parent-stale / tautology / self-exemption guards. Drift-loop emissions hit a 96.9% cancellation rate over 30 days. SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-064 + 047 are textbook tautology — both carry `metadata.gate_exemptions=['GATE_VISION_SCORE']` (self-exempt the gate that justifies their existence).

Ships **CAPA 1-4 + FR-5** (CAPA 5/6/7 deferred to follow-up SDs):

| CAPA | What | Where |
|------|------|-------|
| **1** Source-completion suppression | Skip when source SD `status='completed'` AND `completion_date >= NOW() - 24h` AND no `FAIL`/`BLOCKED` gate evidence | New helper `isSourceCompletedRecently` + invocation BEFORE line 481 |
| **2** Parent-orchestrator stale | Skip when parent orchestrator `status='completed'` AND `completion_date > 30d ago` | New helper `isParentOrchestratorStale` + invocation BEFORE line 481 |
| **3** Tautology guard | Refuse emission when source SD's `key_changes` are entirely placeholder templates | New helper `isAllKeyChangesPlaceholder` (reuses `isPlaceholderText` from `lead-to-plan/gates/placeholder-content.js`) — invoked AT line 583 boundary |
| **4** Self-exemption guard | Strip `GATE_VISION_SCORE` from `metadata.gate_exemptions[]` when source_gate is `eva_vision_score` / `eva_heal_score` | New helper `stripSelfExemptingGate` — replaces hardcoded gate_exemptions write |
| **FR-5** heal-command options propagation | `cmdSDGenerateAll` (batch path) now forwards `options` to `generateCorrectiveSD` (was dropping it; sibling-parity fix vs `cmdSDGenerate` line 627) | `scripts/eva/heal-command.mjs:681` |

## Sub-agent evidence
- testing-agent LEAD-prospective: `437796fe-406b-4e41-8c30-848b82c0e354` (WARNING/88, 6 findings — all addressed in PRD)
- validation-agent PLAN PRD-prospective: `9b5f6604-91a1-44b3-851b-340bcd4c8811` (WARNING/93 — PASS-shippable, 3 EXEC-resolvable precision items)

## Test plan
- [x] **31 new vitest cases** covering CAPA 1-4 + FR-5 + AC-2 (`isPlaceholderText` reuse) + AC-4 (distinct event types)
- [x] **No regression** in existing 12 `corrective-sd-generator-a05-filter.test.js` cases — combined 43/43 pass locally
- [x] Plain-object Supabase mock pattern (matches existing convention per validation-agent finding #6)
- [x] Conservative defaults verified: emit on lookup miss / NULL completion_date / cancelled status

## Deferred (CAPA 5/6/7 — separable, follow-up SDs)
- CAPA-5: cancel SD-064 + SD-047 (needs explicit user auth on shared `strategic_directives_v2` writes)
- CAPA-6: register `issue_patterns` PAT-MAN-INFRA-CORRECTIVE-DRIFT-LOOP-001
- CAPA-7: resolve 5 prior feedback rows as duplicate of this SD

LOC: ~150 src + ~310 test. Tier-3 / full SD scope. Resolves drift-loop class. 6th-witness `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` (sibling generateCorrectiveSD callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)