### PR TITLE
feat(SD-LEO-INFRA-ORPHAN-REAPER-INTEGRATION-001): orphan-qf-reaper integration test + UPDATE shape verification

### DIFF
--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -60,6 +60,11 @@ function fetchPrState(prNumber) {
   }
 }
 
+export function isValidQfId(id) {
+  // FR-5 shell-injection defense for branch-derived path; QF id format set by create-quick-fix.js.
+  return typeof id === 'string' && /^QF-\d{8}-\d{3}$/.test(id);
+}
+
 function fetchMergedPrByBranch(branchName) {
   try {
     const raw = execSync(
@@ -83,7 +88,7 @@ function assertGhAuthenticated() {
   }
 }
 
-async function main() {
+export async function main() {
   assertGhAuthenticated();
 
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -210,6 +215,11 @@ async function main() {
   } else {
     summary.orphan_evaluated = (orphanCandidates || []).length;
     for (const qf of orphanCandidates || []) {
+      if (!isValidQfId(qf.id)) {
+        log('skipped_orphan_invalid_id', { qf_id: qf.id });
+        summary.errored += 1;
+        continue;
+      }
       const branchName = `qf/${qf.id}`;
       const merged = fetchMergedPrByBranch(branchName);
       if (!merged.ok) {
@@ -278,8 +288,10 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error('orphan-qf-reaper: unhandled error:', err.message);
-  console.error(err.stack);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('orphan-qf-reaper: unhandled error:', err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}

--- a/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
@@ -66,4 +66,98 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
   it('still references the SD origin (FR1) in the file header', () => {
     expect(source).toMatch(/SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001.*FR1/);
   });
+
+  // SD-LEO-INFRA-ORPHAN-REAPER-INTEGRATION-001 FR-1: per-path UPDATE column allowlist
+  // and FORBIDDEN-column guard. Closes the writer/consumer asymmetry regression class
+  // that produced QF-911/-492/-182/-847 in 24h.
+  describe('FR-1: per-path UPDATE column allowlist + forbidden columns', () => {
+    const REQUIRED_BOTH_PATHS = [
+      'status', 'completed_at', 'commit_sha',
+      'compliance_verdict', 'compliance_details',
+      'verified_by', 'verification_notes', 'force_completed',
+    ];
+    const REQUIRED_BRANCH_DERIVED_ONLY = ['pr_url'];
+    const FORBIDDEN_COLUMNS = ['metadata', 'merged_via', 'escalation_target', 'audit_log'];
+
+    function blockHasKey(block, key) {
+      // Match `<key>:` at top level of the block (allow whitespace)
+      return new RegExp(`\\b${key}\\s*:`).test(block);
+    }
+
+    it('pr_url path UPDATE block contains all 8 required columns', () => {
+      const blocks = findUpdateBlocks(source);
+      const block = blocks[0]; // first .update({...}) is the pr_url path
+      for (const col of REQUIRED_BOTH_PATHS) {
+        expect(blockHasKey(block, col), `pr_url path missing column: ${col}`).toBe(true);
+      }
+    });
+
+    it('branch-derived path UPDATE block contains all 9 required columns (incl. pr_url)', () => {
+      const blocks = findUpdateBlocks(source);
+      const block = blocks[1]; // second .update({...}) is the branch-derived path
+      const required = [...REQUIRED_BOTH_PATHS, ...REQUIRED_BRANCH_DERIVED_ONLY];
+      for (const col of required) {
+        expect(blockHasKey(block, col), `branch-derived path missing column: ${col}`).toBe(true);
+      }
+    });
+
+    it('neither UPDATE block contains forbidden columns', () => {
+      const blocks = findUpdateBlocks(source);
+      for (const [idx, block] of blocks.entries()) {
+        for (const col of FORBIDDEN_COLUMNS) {
+          expect(blockHasKey(block, col), `block #${idx + 1} contains forbidden column: ${col}`).toBe(false);
+        }
+      }
+    });
+  });
+
+  // FR-2: idempotency .eq('status', qf.status) chain pinned on both UPDATE call sites.
+  describe('FR-2: idempotency guard on both UPDATE blocks', () => {
+    it('source contains exactly two .eq(\'id\', qf.id).eq(\'status\', qf.status) chains', () => {
+      // Match `.eq('id', qf.id)` followed (allowing whitespace/newlines) by `.eq('status', qf.status)`
+      const re = /\.eq\(\s*['"]id['"]\s*,\s*qf\.id\s*\)\s*\.eq\(\s*['"]status['"]\s*,\s*qf\.status\s*\)/g;
+      const matches = source.match(re) || [];
+      expect(matches.length).toBe(2);
+    });
+  });
+
+  // FR-3: SUMMARY counter shape pin (10 keys) — protects GitHub Action observability.
+  describe('FR-3: summary object key shape', () => {
+    const EXPECTED_KEYS = [
+      'evaluated', 'reconciled',
+      'skipped_pr_not_merged', 'skipped_pr_not_found', 'skipped_already_completed',
+      'orphan_evaluated', 'orphan_reconciled',
+      'orphan_skipped_no_merged_pr', 'orphan_skipped_already_completed',
+      'errored',
+    ];
+
+    function extractSummaryBlock(src) {
+      const start = src.indexOf('const summary = {');
+      if (start === -1) return null;
+      let depth = 1;
+      let i = src.indexOf('{', start) + 1;
+      while (i < src.length && depth > 0) {
+        if (src[i] === '{') depth += 1;
+        else if (src[i] === '}') depth -= 1;
+        i += 1;
+      }
+      return src.slice(start, i);
+    }
+
+    it('summary block declares all 10 expected counter keys', () => {
+      const block = extractSummaryBlock(source);
+      expect(block, 'summary block not found').not.toBeNull();
+      for (const key of EXPECTED_KEYS) {
+        expect(new RegExp(`\\b${key}\\s*:`).test(block), `summary missing key: ${key}`).toBe(true);
+      }
+    });
+
+    it('summary block declares ONLY the expected 10 counter keys (no extras)', () => {
+      const block = extractSummaryBlock(source);
+      expect(block).not.toBeNull();
+      // Count `<word>:` occurrences at top level (rough — but valid since summary is a flat object)
+      const keyMatches = block.match(/^\s*[a-z_]+\s*:/gm) || [];
+      expect(keyMatches.length).toBe(EXPECTED_KEYS.length);
+    });
+  });
 });

--- a/tests/unit/scripts/orphan-qf-reaper-integration.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-integration.test.js
@@ -1,0 +1,371 @@
+// SD-LEO-INFRA-ORPHAN-REAPER-INTEGRATION-001
+// FR-4: mocked main() integration test covering both reconciliation paths.
+// FR-5: malformed qf.id rejection (shell-injection defense).
+// FR-6: execSync argv shape regex pin.
+//
+// Both UPDATE call sites are mocked at the @supabase/supabase-js level + child_process
+// at the execSync level so this test runs hermetically with no real DB or gh access.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- Mocks must be hoisted via vi.mock() ----
+const execSyncMock = vi.fn();
+vi.mock('node:child_process', () => ({
+  execSync: (...args) => execSyncMock(...args),
+}));
+
+// supabase chain shape recorder
+function makeSupabaseMock(scenarios) {
+  // scenarios: { firstQuery: rows[], secondQuery: rows[], updateResult: { data, error } }
+  let queryCallCount = 0;
+  const updateCalls = [];
+
+  function chainSelect() {
+    let chain = {};
+    const builder = {};
+    // Generate all chainable methods that just return builder
+    for (const m of ['select', 'in', 'not', 'is', 'lt', 'limit', 'order', 'eq', 'gte']) {
+      builder[m] = vi.fn(() => builder);
+    }
+    // terminal: thenable that resolves to {data,error}
+    builder.then = (resolve) => {
+      queryCallCount += 1;
+      const rows = queryCallCount === 1 ? scenarios.firstQuery : scenarios.secondQuery;
+      resolve({ data: rows, error: null });
+      return Promise.resolve({ data: rows, error: null });
+    };
+    return builder;
+  }
+
+  function chainUpdate(payload) {
+    updateCalls.push({ payload });
+    const builder = {};
+    for (const m of ['eq']) {
+      builder[m] = vi.fn(() => builder);
+    }
+    builder.select = vi.fn(() => ({
+      single: vi.fn(async () => scenarios.updateResult || { data: { id: 'mock', status: 'completed' }, error: null }),
+    }));
+    return builder;
+  }
+
+  const from = vi.fn(() => ({
+    select: chainSelect().select,
+    update: chainUpdate,
+    // back-compat: allow .select(...).in(...).not(...).is(...).lt(...).limit(...)
+    in: chainSelect().in,
+    not: chainSelect().not,
+    is: chainSelect().is,
+    lt: chainSelect().lt,
+    limit: chainSelect().limit,
+  }));
+
+  // The script does: const { data: candidates, error } = await supabase.from('quick_fixes').select(...).in(...).not(...).lt(...).limit(...);
+  // We need each call to .from to return a fresh chainable that, on terminal await, resolves to the right scenario.
+  const fromCalls = [];
+  const fromMock = vi.fn((tableName) => {
+    fromCalls.push(tableName);
+    let chain = {};
+    const builder = {};
+    let isUpdate = false;
+    let updatePayload = null;
+    for (const m of ['select', 'in', 'not', 'is', 'lt', 'limit', 'order', 'gte']) {
+      builder[m] = vi.fn(() => builder);
+    }
+    builder.update = vi.fn((payload) => {
+      isUpdate = true;
+      updatePayload = payload;
+      updateCalls.push({ payload, table: tableName });
+      const upBuilder = {};
+      upBuilder.eq = vi.fn(() => upBuilder);
+      upBuilder.select = vi.fn(() => ({
+        single: vi.fn(async () => scenarios.updateResult || { data: { id: 'mock', status: 'completed' }, error: null }),
+      }));
+      return upBuilder;
+    });
+    builder.then = (resolve) => {
+      if (isUpdate) {
+        return Promise.resolve(scenarios.updateResult).then(resolve);
+      }
+      queryCallCount += 1;
+      const rows = queryCallCount === 1 ? (scenarios.firstQuery || []) : (scenarios.secondQuery || []);
+      const result = { data: rows, error: null };
+      resolve(result);
+      return Promise.resolve(result);
+    };
+    return builder;
+  });
+
+  return {
+    from: fromMock,
+    _calls: { fromCalls, updateCalls, get queryCallCount() { return queryCallCount; } },
+  };
+}
+
+let supabaseInstance;
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => supabaseInstance),
+}));
+
+// dotenv noop in test env
+vi.mock('dotenv/config', () => ({}));
+
+async function importMain() {
+  vi.resetModules();
+  return await import('../../../scripts/orphan-qf-reaper.mjs');
+}
+
+beforeEach(() => {
+  execSyncMock.mockReset();
+  process.env.SUPABASE_URL = 'http://test.supabase';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+  process.env.ORPHAN_QF_REAPER_DRY_RUN = 'false';
+  // gh auth status check + per-row gh calls
+  execSyncMock.mockImplementation((cmd) => {
+    if (cmd === 'gh auth status') return '';
+    return '{}';
+  });
+});
+
+describe('orphan-qf-reaper main() integration (FR-4)', () => {
+  it('TS-1: pr_url path with MERGED PR → UPDATE issued with 8-col shape', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260508-001', status: 'open', pr_url: 'https://github.com/x/y/pull/123', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
+      secondQuery: [],
+      updateResult: { data: { id: 'QF-20260508-001', status: 'completed' }, error: null },
+    });
+
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view 123')) return JSON.stringify({ state: 'MERGED', mergeCommit: { oid: 'abc123' }, mergedAt: '2026-05-08T01:00:00Z' });
+      return '{}';
+    });
+
+    // Stub process.exit so it doesn't actually exit
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const calls = supabaseInstance._calls.updateCalls;
+    expect(calls.length).toBe(1);
+    const payload = calls[0].payload;
+    const requiredCols = ['status', 'completed_at', 'commit_sha', 'compliance_verdict', 'compliance_details', 'verified_by', 'verification_notes', 'force_completed'];
+    for (const c of requiredCols) {
+      expect(payload, `missing ${c}`).toHaveProperty(c);
+    }
+    expect(payload.status).toBe('completed');
+    expect(payload.force_completed).toBe(true);
+    expect(payload.verified_by).toBe('ORPHAN_REAPER');
+    // Forbidden columns must NOT be present
+    expect(payload).not.toHaveProperty('metadata');
+    expect(payload).not.toHaveProperty('merged_via');
+  });
+
+  it('TS-3: branch-derived path with merged PR → UPDATE with 9-col shape including pr_url', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [],
+      secondQuery: [{ id: 'QF-20260508-002', status: 'open', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
+      updateResult: { data: { id: 'QF-20260508-002', status: 'completed' }, error: null },
+    });
+
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr list')) {
+        return JSON.stringify([{ number: 999, url: 'https://github.com/x/y/pull/999', mergeCommit: { oid: 'def456' }, mergedAt: '2026-05-08T02:00:00Z' }]);
+      }
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const calls = supabaseInstance._calls.updateCalls;
+    expect(calls.length).toBe(1);
+    const payload = calls[0].payload;
+    expect(payload).toHaveProperty('pr_url');
+    expect(payload.pr_url).toBe('https://github.com/x/y/pull/999');
+    expect(payload.status).toBe('completed');
+    expect(payload.force_completed).toBe(true);
+    expect(payload).not.toHaveProperty('metadata');
+  });
+
+  it('TS-2: pr_url path with OPEN PR → no UPDATE, skip counter increments', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260508-003', status: 'open', pr_url: 'https://github.com/x/y/pull/124', started_at: '2026-05-08T00:00:00Z' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view 124')) return JSON.stringify({ state: 'OPEN', mergeCommit: null, mergedAt: null });
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(supabaseInstance._calls.updateCalls.length).toBe(0);
+  });
+
+  it('TS-4: branch-derived path with no merged PR → no UPDATE', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [],
+      secondQuery: [{ id: 'QF-20260508-004', status: 'open', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr list')) return '[]';
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(supabaseInstance._calls.updateCalls.length).toBe(0);
+  });
+
+  it('TS-5: DRY_RUN=true → no UPDATEs even when reconciliation would happen', async () => {
+    process.env.ORPHAN_QF_REAPER_DRY_RUN = 'true';
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260508-005', status: 'open', pr_url: 'https://github.com/x/y/pull/125', started_at: '2026-05-08T00:00:00Z' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view 125')) return JSON.stringify({ state: 'MERGED', mergeCommit: { oid: 'xyz' }, mergedAt: '2026-05-08T03:00:00Z' });
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      // DRY_RUN is read at module load — must reimport AFTER setting env
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+      process.env.ORPHAN_QF_REAPER_DRY_RUN = 'false';
+    }
+
+    expect(supabaseInstance._calls.updateCalls.length).toBe(0);
+  });
+});
+
+describe('FR-5: malformed qf.id rejection (shell-injection defense)', () => {
+  it('isValidQfId accepts canonical QF-YYYYMMDD-NNN format', async () => {
+    const { isValidQfId } = await importMain();
+    expect(isValidQfId('QF-20260508-001')).toBe(true);
+    expect(isValidQfId('QF-20991231-999')).toBe(true);
+  });
+
+  it('isValidQfId rejects shell-injection payloads', async () => {
+    const { isValidQfId } = await importMain();
+    expect(isValidQfId('abc"; rm -rf /; echo "')).toBe(false);
+    expect(isValidQfId('QF-20260508-001; ls')).toBe(false);
+    expect(isValidQfId('QF-2026/05/08-001')).toBe(false);
+    expect(isValidQfId('')).toBe(false);
+    expect(isValidQfId(null)).toBe(false);
+    expect(isValidQfId(undefined)).toBe(false);
+    expect(isValidQfId(123)).toBe(false);
+  });
+
+  it('main() skips orphan rows with malformed ids and increments errored', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [],
+      secondQuery: [{ id: 'BAD"; rm -rf /; echo "', status: 'open', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      // If main() reaches gh pr list with the bad id, the test fails:
+      if (cmd.startsWith('gh pr list')) throw new Error('Reached gh with malformed id — FR-5 broken');
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(supabaseInstance._calls.updateCalls.length).toBe(0);
+    // gh pr list should NOT have been invoked for the malformed id
+    const ghListCalls = execSyncMock.mock.calls.filter(c => typeof c[0] === 'string' && c[0].startsWith('gh pr list'));
+    expect(ghListCalls.length).toBe(0);
+  });
+});
+
+describe('FR-6: execSync argv shape regex pin', () => {
+  const PR_VIEW_RE = /^gh pr view \d+ --json state,mergeCommit,mergedAt$/;
+  const PR_LIST_RE = /^gh pr list --head "qf\/QF-\d{8}-\d{3}" --state merged --json number,url,mergeCommit,mergedAt --limit 1$/;
+
+  it('pr_url path invokes gh pr view with exact argv shape', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260508-006', status: 'open', pr_url: 'https://github.com/x/y/pull/777', started_at: '2026-05-08T00:00:00Z' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view')) return JSON.stringify({ state: 'OPEN' });
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghViewCmd = execSyncMock.mock.calls
+      .map(c => c[0])
+      .find(c => typeof c === 'string' && c.startsWith('gh pr view'));
+    expect(ghViewCmd).toBeDefined();
+    expect(ghViewCmd).toMatch(PR_VIEW_RE);
+  });
+
+  it('branch-derived path invokes gh pr list with exact argv shape', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [],
+      secondQuery: [{ id: 'QF-20260508-007', status: 'open', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr list')) return '[]';
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghListCmd = execSyncMock.mock.calls
+      .map(c => c[0])
+      .find(c => typeof c === 'string' && c.startsWith('gh pr list'));
+    expect(ghListCmd).toBeDefined();
+    expect(ghListCmd).toMatch(PR_LIST_RE);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the writer/consumer asymmetry regression class on `scripts/orphan-qf-reaper.mjs` that produced QF-911 / QF-492 / QF-182 / QF-847 within 24 hours. 10th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 — closed at the test boundary.

## Implementation

**Refactor (`scripts/orphan-qf-reaper.mjs`, +18/-6 LOC, AC-8 envelope ≤12 net)**:
- Export `main()` additively
- ESM main-detection guard prevents auto-invoke on `import` from vitest
- `isValidQfId(id)` helper + early-return on branch-derived path (FR-5 shell-injection defense)

**Static guards (`tests/unit/scripts/orphan-qf-reaper-force-completed.test.js`, +94 LOC)**:
- FR-1: per-path UPDATE column allowlist (8 cols pr_url path; 9 cols branch-derived path) + FORBIDDEN list `[metadata, merged_via, escalation_target, audit_log]`
- FR-2: idempotency `.eq('id', qf.id).eq('status', qf.status)` chain pinned (2 matches)
- FR-3: SUMMARY counter shape pin (exactly 10 keys)

**Mocked integration test (`tests/unit/scripts/orphan-qf-reaper-integration.test.js`, 371 LOC NEW)**:
- FR-4: 5 main() scenarios — pr_url MERGED / pr_url OPEN / branch-derived merged / branch-derived no-merged / DRY_RUN
- FR-5: 3 cases — regex accepts canonical, rejects shell-injection, main() skips bad ids without reaching gh
- FR-6: 2 cases — `execSync` argv shape regex on both `gh pr view` and `gh pr list`

## Tests
- 19/19 vitest pass (9 static + 10 integration)
- Smoke: `ORPHAN_QF_REAPER_DRY_RUN=true node scripts/orphan-qf-reaper.mjs` → exit 0

## Sub-agent evidence
- testing-agent prospective LEAD: `3a0d4b97` WARNING/78 → 4 recommendations all incorporated
- validation-agent prospective PLAN PRD: `e49595bf` WARNING/92 → 2 required + 2 optional amendments all applied
- testing-agent retrospective EXEC: `534b69c2` PASS/95
- retrospective: `ca474436` PUBLISHED quality 80

## Test plan
- [x] vitest 19/19 pass locally
- [x] Smoke DRY_RUN exit 0
- [ ] Cron runs without regression after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)