### PR TITLE
fix(QF-20260509-711): claim-validity-gate auto-releases orphaned claims when owner is dead

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -243,8 +243,34 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     return { resolved, sd, ownership: 'unclaimed' };
   }
 
-  // Claimed by another active session → HARD STOP
+  // Claimed by another session — check if owner is alive before throwing.
+  // QF-20260509-711: Layer 2 of writer/consumer asymmetry RCA (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
+  // PG-side release functions miss claiming_session_id; if the owner is stale/released/missing, the claim is
+  // an orphan and we auto-release it idempotently (mirrors self-heal pattern at lines 287, 312, 333).
   if (sd.claiming_session_id !== mySessionId) {
+    const { data: owner } = await supabase
+      .from('claude_sessions')
+      .select('status, is_alive')
+      .eq('session_id', sd.claiming_session_id)
+      .maybeSingle();
+
+    const ownerIsDead = !owner || owner.status === 'stale' || owner.status === 'released' || owner.is_alive === false;
+
+    if (ownerIsDead) {
+      // Idempotent canonical claim-release — WHERE-clause restricts to the orphan pair so a fresh claim
+      // acquired between detection and write cannot be overwritten.
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: null, is_working_on: false, active_session_id: null })
+        .eq('sd_key', sdKey)
+        .eq('claiming_session_id', sd.claiming_session_id);
+      console.warn(
+        `[claim-validity-gate] Auto-released orphaned claim on ${sdKey}: owner ${sd.claiming_session_id} ` +
+        `is ${owner?.status ?? 'missing'} (is_alive=${owner?.is_alive ?? 'n/a'}). Proceeding as unclaimed.`
+      );
+      return { resolved, sd: { ...sd, claiming_session_id: null }, ownership: 'unclaimed' };
+    }
+
     throw new ClaimIdentityError({
       reason: 'foreign_claim',
       operation, sdKey,

--- a/tests/unit/claim-validity-gate.test.js
+++ b/tests/unit/claim-validity-gate.test.js
@@ -188,3 +188,83 @@ describe('assertValidClaim — CHECK 3 enhanced', () => {
     }
   });
 });
+
+// QF-20260509-711: Consumer fail-open for orphaned claims when owner session is dead.
+// Layer 2 of writer/consumer asymmetry RCA (11th witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
+describe('assertValidClaim — foreign_claim auto-release on stale owner', () => {
+  // Builds a supabase mock that routes by table. SD lookup returns sdData; claude_sessions
+  // returns ownerData. Captures the auto-release UPDATE in updateCalls for assertions.
+  function buildMock(sdData, ownerData) {
+    const updateCalls = [];
+    const claimingSession = sdData.claiming_session_id;
+    const sb = {
+      from: vi.fn((table) => {
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: ownerData, error: null }) }) }),
+          };
+        }
+        // strategic_directives_v2
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: sdData, error: null }) }) }),
+          update: (payload) => {
+            const eq1 = (col1, val1) => ({
+              eq: (col2, val2) => {
+                updateCalls.push({ payload, where: [[col1, val1], [col2, val2]] });
+                // Simulate idempotency: nothing actually changes locally — gate already returned.
+                return Promise.resolve({ error: null });
+              },
+            });
+            return { eq: eq1 };
+          },
+        };
+      }),
+      _updateCalls: updateCalls,
+    };
+    return sb;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _worktreeCache.clear();
+    realpathSync.mockImplementation((p) => p.replace(/\\/g, '/'));
+    resolveOwnSession.mockResolvedValue({
+      data: { session_id: 'sess-me' },
+      source: 'env_var',
+    });
+  });
+
+  it('auto-releases when owner session is stale, returns ownership=unclaimed', async () => {
+    const sb = buildMock(
+      { sd_key: 'SD-ORPHAN-001', claiming_session_id: 'sess-dead', worktree_path: null, current_phase: 'PLAN_PRD' },
+      { status: 'stale', is_alive: false }
+    );
+    const result = await assertValidClaim(sb, 'SD-ORPHAN-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('unclaimed');
+    expect(result.sd.claiming_session_id).toBeNull();
+    expect(sb._updateCalls).toHaveLength(1);
+    expect(sb._updateCalls[0].payload).toEqual({ claiming_session_id: null, is_working_on: false, active_session_id: null });
+    // WHERE clause MUST pin both sd_key AND claiming_session_id for idempotency
+    expect(sb._updateCalls[0].where).toEqual([['sd_key', 'SD-ORPHAN-001'], ['claiming_session_id', 'sess-dead']]);
+  });
+
+  it('auto-releases when owner session row is missing entirely', async () => {
+    const sb = buildMock(
+      { sd_key: 'SD-MISSING-001', claiming_session_id: 'sess-ghost', worktree_path: null, current_phase: 'EXEC' },
+      null
+    );
+    const result = await assertValidClaim(sb, 'SD-MISSING-001', { operation: 'test_op' });
+    expect(result.ownership).toBe('unclaimed');
+    expect(sb._updateCalls).toHaveLength(1);
+  });
+
+  it('still throws foreign_claim when owner session is active', async () => {
+    const sb = buildMock(
+      { sd_key: 'SD-LIVE-001', claiming_session_id: 'sess-other', worktree_path: null, current_phase: 'EXEC' },
+      { status: 'active', is_alive: true }
+    );
+    await expect(assertValidClaim(sb, 'SD-LIVE-001', { operation: 'test_op' }))
+      .rejects.toMatchObject({ reason: 'foreign_claim', ownerSessionId: 'sess-other' });
+    expect(sb._updateCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Layer 2 of writer/consumer asymmetry RCA (11th witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001). PG-side release functions in `20260201_intelligent_session_lifecycle.sql` clear `active_session_id` but miss `claiming_session_id`, leaving orphaned claims when sessions go stale via `PID_NOT_FOUND`. The JS sweep filters out `status='stale'` rows so it never re-processes them. Result: new sessions hit `foreign_claim` indefinitely.

This QF makes the consumer fail-open: before throwing `foreign_claim`, look up `owner.status` in `claude_sessions`. If `status IN ('stale','released')` OR `is_alive=false` OR row missing, idempotently UPDATE-clear the orphan (WHERE-clause pinned to dead-owner pair) and proceed as `ownership='unclaimed'`.

- **24 src LOC** (Tier-1 ≤30) + 75 test LOC
- **13/13 vitest pass** (10 existing + 3 new in `tests/unit/claim-validity-gate.test.js`)
- Mirrors existing self-heal patterns at `lib/claim-validity-gate.js:287/312/333` (stale worktree, deleted path, wrong cwd)
- Layer 1 (PG-side fix to clear `claiming_session_id` in release functions) deferred to Tier-3 SD — touches `database/migrations/*.sql` (migration risk keyword)

## Witness

2026-05-09 on SD-LEO-FEAT-STAGE-GROWTH-PLAYBOOK-001 — owner `c99d578c` `stale_at=10:23:58Z` `PID_NOT_FOUND` for ~1hr; `sd-start.js` blocked with `foreign_claim`. Same scenario will recur every time a stale session leaves an orphan until Layer 1 ships.

## Test plan

- [x] 3 new vitest cases: stale owner → auto-release; missing owner row → auto-release; active owner → still throws `foreign_claim`
- [x] Idempotency assertion: WHERE clause pins both `sd_key` AND `claiming_session_id` (prevents overwriting fresh claims acquired between detection and write)
- [x] Existing 10 vitest cases for CHECK 3 worktree isolation still pass
- [x] TypeScript check passes
- [ ] Self-validating ship: post-merge, the next time a session encounters a stale-owner orphan, it should auto-release (warning logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)