### PR TITLE
fix(QF-20260509-149): assist-engine excludes harness_backlog from Phase 2 enhancements

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-552",
+  "sdKey": "QF-20260509-149",
   "workType": "QF",
-  "workKey": "QF-20260509-552",
-  "expectedBranch": "qf/QF-20260509-552",
-  "createdAt": "2026-05-09T11:12:33.830Z",
+  "workKey": "QF-20260509-149",
+  "expectedBranch": "qf/QF-20260509-149",
+  "createdAt": "2026-05-09T12:09:33.789Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/quality/assist-engine.js
+++ b/lib/quality/assist-engine.js
@@ -78,6 +78,24 @@ function filterStaleUntriaged(rows) {
 }
 
 /**
+ * QF-20260509-149: Exclude category='harness_backlog' rows from the enhancements stream.
+ *
+ * Harness-backlog rows are deferred-class per CLAUDE.md MODE rule and surface in the
+ * `npm run sd:next` HARNESS BACKLOG section. They are not schedulable enhancements and
+ * must be excluded from /leo assist Phase 2 to prevent operator noise on every product-
+ * default fall-through. Campaign-mode operators query the backlog directly.
+ *
+ * @param {Array<object>} enriched - Sensemaking-enriched feedback rows
+ * @returns {{enhancements: Array<object>, skippedHarnessBacklog: number}}
+ */
+function splitEnhancementsExcludingHarnessBacklog(enriched) {
+  const all = (enriched || []).filter(i => i.type === 'enhancement');
+  const enhancements = all.filter(i => i.category !== 'harness_backlog');
+  const skippedHarnessBacklog = all.length - enhancements.length;
+  return { enhancements, skippedHarnessBacklog };
+}
+
+/**
  * AssistEngine - Main class for /leo assist processing
  */
 class AssistEngine {
@@ -178,9 +196,12 @@ class AssistEngine {
     // FR-002: Enrich with sensemaking dispositions (filter discards, annotate keeps)
     const { enriched, discardedCount } = enrichWithSensemaking(triaged);
 
-    // Separate issues from enhancements
+    // Separate issues from enhancements; harness_backlog filtered out per QF-20260509-149.
     const issues = enriched.filter(i => i.type === 'issue');
-    const enhancements = enriched.filter(i => i.type === 'enhancement');
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog(enriched);
+    if (skippedHarnessBacklog > 0) {
+      console.log(`[assist-engine] Excluded ${skippedHarnessBacklog} harness_backlog row(s) from enhancements stream (campaign-mode workflow)`);
+    }
 
     return { issues, enhancements, total: enriched.length, discardedCount };
   }
@@ -751,7 +772,8 @@ export {
   AssistEngine,
   RESULT_TYPES,
   filterStaleUntriaged,
-  STALE_UNTRIAGED_GRACE_MS
+  STALE_UNTRIAGED_GRACE_MS,
+  splitEnhancementsExcludingHarnessBacklog
 };
 
 // Default export

--- a/tests/unit/assist-engine-harness-backlog-filter.test.js
+++ b/tests/unit/assist-engine-harness-backlog-filter.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for QF-20260509-149: harness_backlog exclusion from /leo assist Phase 2.
+ *
+ * Backlog row 413d2b19. Witnessed 2026-05-09: 117/118 enhancements surfaced were
+ * already-deferred harness_backlog rows that operator had to batch-defer manually.
+ * Fix excludes them at the source (lib/quality/assist-engine.js).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { splitEnhancementsExcludingHarnessBacklog } from '../../lib/quality/assist-engine.js';
+
+function row({ id, type = 'enhancement', category = null }) {
+  return { id, type, category };
+}
+
+describe('QF-20260509-149: splitEnhancementsExcludingHarnessBacklog', () => {
+  it('excludes type=enhancement rows with category=harness_backlog', () => {
+    const enriched = [
+      row({ id: 'a', category: 'harness_backlog' }),
+      row({ id: 'b', category: 'enhancement' }),
+      row({ id: 'c', category: 'harness_backlog' }),
+      row({ id: 'd', category: null }),
+    ];
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog(enriched);
+    expect(enhancements.map(e => e.id)).toEqual(['b', 'd']);
+    expect(skippedHarnessBacklog).toBe(2);
+  });
+
+  it('does not affect type=issue rows', () => {
+    const enriched = [
+      row({ id: 'i1', type: 'issue', category: 'harness_backlog' }),
+      row({ id: 'e1', type: 'enhancement', category: 'harness_backlog' }),
+    ];
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog(enriched);
+    expect(enhancements).toEqual([]);
+    expect(skippedHarnessBacklog).toBe(1);
+  });
+
+  it('returns empty + zero on empty input', () => {
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog([]);
+    expect(enhancements).toEqual([]);
+    expect(skippedHarnessBacklog).toBe(0);
+  });
+
+  it('returns empty + zero on null/undefined', () => {
+    expect(splitEnhancementsExcludingHarnessBacklog(null)).toEqual({ enhancements: [], skippedHarnessBacklog: 0 });
+    expect(splitEnhancementsExcludingHarnessBacklog(undefined)).toEqual({ enhancements: [], skippedHarnessBacklog: 0 });
+  });
+
+  it('passes through enhancements when none are harness_backlog', () => {
+    const enriched = [
+      row({ id: 'e1', category: 'enhancement' }),
+      row({ id: 'e2', category: 'feature_request' }),
+    ];
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog(enriched);
+    expect(enhancements.map(e => e.id)).toEqual(['e1', 'e2']);
+    expect(skippedHarnessBacklog).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Backlog row 413d2b19. Witnessed in this session: /leo assist Phase 1 returned 0 issues, Phase 2 surfaced 117/118 already-deferred `category='harness_backlog'` rows requiring manual batch-defer to clear the inbox view. These rows are deferred-class per CLAUDE.md MODE rule and already appear in \`npm run sd:next\` HARNESS BACKLOG section — double-surfacing as schedulable enhancements is operator noise.

Extracted \`splitEnhancementsExcludingHarnessBacklog()\` helper and exported for unit testing. Called from \`loadInboxItems()\` at line 183. Skip count logged to stdout when non-zero.

- **25 src LOC** + 59 test LOC (Tier-1 ≤30)
- **11/11 vitest pass** (5 new + 6 existing CAPA-5 stale-untriaged)
- Campaign-mode operators query backlog directly (\`category='harness_backlog' AND status IN ('new','backlog')\`) — unaffected

## Test plan

- [x] 5 new vitest cases: filters harness_backlog enhancements, leaves issues alone, handles empty/null/undefined, passes through enhancements when no harness_backlog
- [x] 6 existing CAPA-5 tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)