### PR TITLE
fix(QF-20260509-393): 3-fix harness cluster (sd-start STUCK col + verify-* trap doc + WIRE_CHECK glob)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,12 @@ scripts/test-llm-*.js
 scripts/uat-*.js
 scripts/update-*.mjs
 scripts/update-*.js
+# scripts/verify-*.{mjs,js,cjs} silently dropped by these patterns. If you ARE
+# committing a verify-* script (production verifier, hook, etc.) you MUST add an
+# explicit `!scripts/verify-<name>.<ext>` exception below — otherwise `git add`
+# accepts it but `git status` shows nothing tracked. Witnessed: QF-20260509-393
+# (scripts/verify-security-audit-integrity.cjs silently dropped). Same trap class
+# as scripts/check-* (documented 2026-05-05 SD-LEO-INFRA-PRE-COMMIT-GUARD-001).
 scripts/verify-*.mjs
 scripts/verify-*.js
 scripts/verify-*.cjs

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-070",
+  "sdKey": "QF-20260509-393",
   "workType": "QF",
-  "workKey": "QF-20260509-070",
-  "expectedBranch": "qf/QF-20260509-070",
-  "createdAt": "2026-05-09T12:07:43.341Z",
+  "workKey": "QF-20260509-393",
+  "expectedBranch": "qf/QF-20260509-393",
+  "createdAt": "2026-05-09T12:25:19.482Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -123,14 +123,19 @@ function discoverEntryPoints(rootDir) {
 function getScopedJsFiles(rootDir) {
   const normalize = (p) => p.replace(/\\/g, '/');
   try {
+    // QF-20260509-393: 'scripts/**/*.js' git pathspec WITHOUT globstar config
+    // does NOT match flat scripts/*.js (no subdirectory). Was silently excluding
+    // hundreds of flat files (handoff.js, sd-next.js, fleet-dashboard.cjs, etc.).
+    // Fix: list directories recursively, filter by extension in JS.
     const result = execSync(
-      'git ls-files -- "lib/**/*.js" "lib/**/*.mjs" "lib/**/*.cjs" "scripts/**/*.js" "scripts/**/*.mjs" "scripts/**/*.cjs"',
+      'git ls-files -- "lib/" "scripts/"',
       { encoding: 'utf8', cwd: rootDir, timeout: 15000 }
     );
     return result
       .split('\n')
       .map((f) => f.trim())
       .filter(Boolean)
+      .filter((f) => /\.(js|mjs|cjs)$/.test(f))
       .map((f) => normalize(path.resolve(rootDir, f)));
   } catch (_err) {
     return [];

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1197,10 +1197,15 @@ async function main() {
     };
     const req = PHASE_REQUIRES[phase];
     if (req) {
+      // QF-20260509-393: was .eq('sd_key', sd.id) where sd.id is a UUID — wrong
+      // column. sd_phase_handoffs.sd_id is the UUID FK. 9th-witness PAT-LEO-INFRA-
+      // WRITER-CONSUMER-ASYMMETRY-001 (sibling: sd_phase_handoffs has BOTH sd_id
+      // UUID and historical sd_key text values; matching the wrong column produces
+      // false STUCK warnings on every PLAN_PRD-phase resume).
       const { data: handoffs } = await supabase
         .from('sd_phase_handoffs')
         .select('from_phase, to_phase, status')
-        .eq('sd_key', sd.id)
+        .eq('sd_id', sd.id)
         .eq('status', 'accepted');
       const hasRequired = (handoffs || []).some(h => h.from_phase === req.from && h.to_phase === req.to);
       if (!hasRequired) {

--- a/tests/unit/harness/qf-393-cluster.test.js
+++ b/tests/unit/harness/qf-393-cluster.test.js
@@ -1,0 +1,61 @@
+// QF-20260509-393: 3-fix harness cluster (sd-start STUCK + .gitignore + WIRE_CHECK glob).
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+describe('QF-20260509-393 #1: sd-start.js STUCK detector uses sd_id (UUID FK)', () => {
+  it('STUCK detector queries sd_phase_handoffs by sd_id, not sd_key', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf-8');
+    // Locate the STUCK SD WARNING block — anchor on the warning text
+    const warnIdx = src.indexOf('STUCK SD WARNING');
+    expect(warnIdx).toBeGreaterThan(0);
+    // Look back ~600 chars for the handoffs query that drives the warning
+    const block = src.slice(Math.max(0, warnIdx - 600), warnIdx);
+    expect(block).toMatch(/from\(['"]sd_phase_handoffs['"]\)/);
+    expect(block).toMatch(/\.eq\(['"]sd_id['"]/);
+    expect(block).not.toMatch(/\.eq\(['"]sd_key['"],\s*sd\.id\)/);
+  });
+});
+
+describe('QF-20260509-393 #2: .gitignore documents the verify-* trap', () => {
+  it('has explicit comment block above scripts/verify-* patterns', () => {
+    const gi = fs.readFileSync(path.join(repoRoot, '.gitignore'), 'utf-8');
+    const idx = gi.indexOf('scripts/verify-*.mjs');
+    expect(idx).toBeGreaterThan(0);
+    // Comment block must precede the patterns
+    const before = gi.slice(Math.max(0, idx - 600), idx);
+    expect(before).toMatch(/silently dropped/i);
+    expect(before).toMatch(/!scripts\/verify-/);
+  });
+});
+
+describe('QF-20260509-393 #3: WIRE_CHECK getScopedJsFiles includes flat scripts/', () => {
+  it('git ls-files command uses directory pathspec, not glob, and has client-side extension filter', () => {
+    const src = fs.readFileSync(
+      path.join(repoRoot, 'scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js'),
+      'utf-8'
+    );
+    const idx = src.indexOf('function getScopedJsFiles');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 1200);
+
+    // The execSync git-ls-files call: extract the single-quoted string arg.
+    // Use [\s\S] across newlines and a lazy match terminated by `'` immediately
+    // followed by `,` (the next execSync arg).
+    const cmdMatch = block.match(/execSync\(\s*'([\s\S]+?)',/);
+    expect(cmdMatch).not.toBeNull();
+    const command = cmdMatch[1];
+    // Bad pattern (pre-fix): scripts/**/*.js (excludes flat scripts/*.js)
+    expect(command).not.toMatch(/scripts\/\*\*\/\*\./);
+    // Good pattern: directory pathspec
+    expect(command).toMatch(/scripts\//);
+
+    // Must have client-side extension filter (regex tests js|mjs|cjs)
+    expect(block).toMatch(/js\|mjs\|cjs/);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1 cluster, ~10 src + ~60 test LOC, 3 distinct harness fixes:

1. **scripts/sd-start.js:1203** — STUCK SD detector queried `sd_phase_handoffs` by `.eq('sd_key', sd.id)` where `sd.id` is the UUID. Correct column is `sd_id` (UUID FK). False STUCK warnings on every PLAN_PRD-phase resume. **9th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001**.

2. **.gitignore** — added comment block above `scripts/verify-*.{mjs,js,cjs}` documenting silent-drop trap. Same trap class as `scripts/check-*` (2026-05-05 SD-LEO-INFRA-PRE-COMMIT-GUARD-001). Doc-only.

3. **scripts/.../wire-check-gate.js** — `getScopedJsFiles()` `git ls-files` pathspec `scripts/**/*.js` without globstar config does NOT match flat `scripts/*.js` (no subdir). Silently excluded hundreds of flat files (handoff.js, sd-next.js, etc.) from WIRE_CHECK_GATE. Fix: directory pathspec + client-side `/\.(js|mjs|cjs)$/` filter.

## Closes feedback
- 8e525f72-b1c3-46ff-a96c-0bc909a655ea (sd-start STUCK column)
- e340891b-ccfe-4e5e-ba3b-23976bd9b104 (verify-* trap doc)
- 335cb616-54d8-4ae4-a18f-82225742d91c (WIRE_CHECK glob)

## Test plan
- [x] 3/3 vitest pass: `tests/unit/harness/qf-393-cluster.test.js`
- [x] Diff-only inspection: STUCK detector now `eq('sd_id', sd.id)`
- [x] Diff-only inspection: WIRE_CHECK pathspec is `lib/`/`scripts/` (no glob)
- [x] Diff-only inspection: .gitignore comment block precedes patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)