### PR TITLE
fix(QF-20260509-AGENT-MD): findInjectionPoint must skip past frontmatter before H1 search

### DIFF
--- a/scripts/generate-agent-md-from-db.js
+++ b/scripts/generate-agent-md-from-db.js
@@ -289,15 +289,23 @@ function stripYamlFrontmatter(content) {
 // ─── Agent File Compilation ──────────────────────────────────────────────────
 
 function findInjectionPoint(content) {
-  // Inject after the first H1 heading's paragraph
-  const h1Match = content.match(/\n(# [^\n]+)\n/);
+  // QF-20260509-AGENT-MD: skip past YAML frontmatter so both the H1 search
+  // AND the no-H1 fallback land inside the body. Without this, agents whose
+  // body has no H1 (stories-agent, risk-agent, uat-agent, redis-specialist)
+  // had the knowledge block prepended at offset 0 — BEFORE frontmatter —
+  // breaking Claude Code's agent registration (Task tool reported the
+  // subagent_type as not-found).
+  const fmMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  const baseOffset = fmMatch ? fmMatch[0].length : 0;
+  const body = content.substring(baseOffset);
+  const h1Match = body.match(/\n(# [^\n]+)\n/);
   if (h1Match) {
-    const h1End = h1Match.index + h1Match[0].length;
+    const h1End = baseOffset + h1Match.index + h1Match[0].length;
     const nextBlank = content.indexOf('\n\n', h1End);
     if (nextBlank !== -1) return nextBlank + 2;
     return h1End;
   }
-  return 0;
+  return baseOffset;
 }
 
 function compileAgentFromPartial(partialPath, agentName, agentCode, data, configCategoryMappings, allSkills) {
@@ -637,4 +645,4 @@ if (import.meta.url === `file:///${normalizedArgv}`) {
   });
 }
 
-export { main, composeKnowledgeBlock, composeSkillBlock, compileAgentFromPartial, compileAgentFromDB, fetchLiveData, AGENT_CODE_MAP, generateFrontmatter };
+export { main, composeKnowledgeBlock, composeSkillBlock, compileAgentFromPartial, compileAgentFromDB, fetchLiveData, AGENT_CODE_MAP, generateFrontmatter, findInjectionPoint };

--- a/tests/unit/harness/generate-agent-md-injection-point.test.js
+++ b/tests/unit/harness/generate-agent-md-injection-point.test.js
@@ -1,0 +1,82 @@
+// QF-20260509-AGENT-MD: findInjectionPoint must skip past YAML frontmatter
+// before the H1 search and the no-H1 fallback. Without this, agents whose
+// body has no H1 (stories-agent, risk-agent, uat-agent, redis-specialist)
+// got the knowledge block prepended at offset 0 — BEFORE frontmatter —
+// breaking Claude Code's agent registration.
+
+import { describe, it, expect } from 'vitest';
+import { findInjectionPoint } from '../../../scripts/generate-agent-md-from-db.js';
+
+const FRONTMATTER = '---\nname: test-agent\ndescription: "x"\ntools: Bash\nmodel: sonnet\n---\n';
+
+describe('QF-20260509-AGENT-MD: findInjectionPoint frontmatter awareness', () => {
+  it('frontmatter + H1: injects after H1 paragraph', () => {
+    const body = '\n# Title\nFirst para line\n\nSecond paragraph.\n';
+    const content = FRONTMATTER + body;
+    const idx = findInjectionPoint(content);
+    // Must land AFTER the frontmatter (not at 0)
+    expect(idx).toBeGreaterThanOrEqual(FRONTMATTER.length);
+    // Must land at-or-after the blank line that ends the H1 paragraph
+    const beforeIdx = content.substring(0, idx);
+    expect(beforeIdx).toContain('# Title');
+    expect(beforeIdx).toContain('First para line');
+  });
+
+  it('frontmatter + NO H1: injects RIGHT AFTER frontmatter (regression case)', () => {
+    // This is the bug case from feedback d06b191d: stories-agent.partial,
+    // risk-agent.partial, uat-agent.partial all start with `## Heading` not `# Heading`
+    const body = '\n## Model Usage Tracking (Auto-Log)\n\nlog stuff\n';
+    const content = FRONTMATTER + body;
+    const idx = findInjectionPoint(content);
+    // Must NOT be 0 (which would prepend BEFORE frontmatter — the original bug)
+    expect(idx).not.toBe(0);
+    // Must land exactly at the end of the frontmatter
+    expect(idx).toBe(FRONTMATTER.length);
+    // Verify everything before idx is the frontmatter
+    expect(content.substring(0, idx)).toBe(FRONTMATTER);
+  });
+
+  it('no frontmatter + H1: existing behavior preserved (injects after H1 paragraph)', () => {
+    const content = '\n# Title\nFirst line\n\nbody.\n';
+    const idx = findInjectionPoint(content);
+    expect(idx).toBeGreaterThan(0);
+    expect(content.substring(0, idx)).toContain('# Title');
+  });
+
+  it('no frontmatter + no H1: injects at 0 (existing fallback)', () => {
+    const content = '\n## Only H2\n\nno H1 here.\n';
+    const idx = findInjectionPoint(content);
+    expect(idx).toBe(0);
+  });
+
+  it('windows line endings (CRLF) frontmatter handled', () => {
+    const fmCRLF = '---\r\nname: x\r\ndescription: "y"\r\ntools: Bash\r\nmodel: sonnet\r\n---\r\n';
+    const body = '\n## H2 only\n\nbody.\n';
+    const content = fmCRLF + body;
+    const idx = findInjectionPoint(content);
+    expect(idx).toBe(fmCRLF.length);
+  });
+
+  it('real fixture: stories-agent.partial-shaped content lands inside body', () => {
+    // Simulates the exact pattern from .claude/agents/stories-agent.partial
+    const partialContent = `---
+name: stories-agent
+description: "MUST BE USED PROACTIVELY for all user story context engineering sub-agent tasks. Trigger on keywords: user story, story, acceptance criteria, user journey."
+tools: Bash, Read, Write
+model: sonnet
+---
+
+<!-- reasoning_effort: medium -->
+
+## Model Usage Tracking (Auto-Log)
+
+**FIRST STEP**: Before doing any other work, log your model identity by running:
+`;
+    const idx = findInjectionPoint(partialContent);
+    // Frontmatter ends at the first '---\n' followed by content; verify idx is AFTER it
+    const fmEnd = partialContent.indexOf('---\n', 4) + 4;
+    expect(idx).toBeGreaterThanOrEqual(fmEnd);
+    // The character at idx must NOT be inside the frontmatter
+    expect(partialContent.substring(0, idx)).toMatch(/^---[\s\S]+?---\r?\n?$/);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~14 src + ~76 test LOC.

**Bug:** `scripts/generate-agent-md-from-db.js:291` searched for the first H1 across the entire assembled content (frontmatter + body) and returned **0** when no H1 was found. For agents whose body has no H1 (stories-agent.partial, risk-agent.partial, uat-agent.partial all open with `## Heading`, plus DB-only redis-specialist-agent), this prepended the knowledge block at offset 0 — **before** the YAML frontmatter.

**Symptom:** Generated `.md` files had `## Institutional Memory (Generated)` as line 1 instead of `---`, so Claude Code's Task tool reported `subagent_type 'stories-agent' not found` for all 4 affected agents.

**Fix:** Detect frontmatter (`^---\n...\n---\n`, both LF and CRLF) up front, then search for H1 only in the body slice. When H1 is absent, return the position right after frontmatter — never offset 0.

## Test plan
- [x] 6/6 vitest pass: `tests/unit/harness/generate-agent-md-injection-point.test.js`
  - frontmatter + H1 (existing path)
  - frontmatter + NO H1 (regression case — was returning 0)
  - no-frontmatter + H1
  - no-frontmatter + no-H1
  - CRLF frontmatter
  - real stories-agent.partial-shaped fixture
- [x] Local `node scripts/generate-agent-md-from-db.js` — all 4 previously corrupted agents now start with `---` at line 1.

## Closes feedback
- d06b191d-4c7c-47d9-9e78-411bff786df4 (rca agent aee480dd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)