### PR TITLE
fix(QF-20260509-COMPLIANCE-LOOP): refinement-prompt at compliance-loop.js:77 honors --force-complete

### DIFF
--- a/scripts/modules/complete-quick-fix/compliance-loop.js
+++ b/scripts/modules/complete-quick-fix/compliance-loop.js
@@ -13,9 +13,12 @@ import { MAX_REFINEMENT_ATTEMPTS } from './constants.js';
  * @param {object} qf - Quick-fix record
  * @param {object} context - Context for compliance check
  * @param {Function} prompt - Prompt function for user input
+ * @param {object} [flags] - Force-complete / non-interactive flags (QF-20260509-COMPLIANCE-LOOP)
+ * @param {boolean} [flags.forceComplete] - When true, refinement-prompt auto-skips
+ * @param {string} [flags.reason] - Reason for force-complete (logged)
  * @returns {Promise<object>} Final compliance results and refinement history
  */
-export async function runComplianceWithRefinement(qfId, qf, context, prompt) {
+export async function runComplianceWithRefinement(qfId, qf, context, prompt, flags = {}) {
   console.log('\n🔄 Compliance Rubric with Auto-Refinement (max 3 attempts)\n');
 
   let complianceResults = null;
@@ -79,7 +82,16 @@ export async function runComplianceWithRefinement(qfId, qf, context, prompt) {
         console.log(`      Suggestion: ${getRefinementSuggestion(c.id)}\n`);
       });
 
-      const refineChoice = await prompt('\n   Attempt auto-refinement? (yes/no/skip): ');
+      // QF-20260509-COMPLIANCE-LOOP (closes 0974d18b): under --force-complete
+      // (or any non-interactive caller), don't wedge waiting for stdin. Treat
+      // it as 'skip' — break out of refinement and let validateCompliance
+      // (already flag-aware via QF-20260508-407) decide WARN-verdict path.
+      // 9th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (sibling miss
+      // in QF-20260509-552 which patched validateTests + git-operations.js
+      // prompts but not this one).
+      const refineChoice = flags.forceComplete
+        ? (console.log('\n   --force-complete set — auto-skipping refinement.\n'), 'skip')
+        : await prompt('\n   Attempt auto-refinement? (yes/no/skip): ');
 
       if (refineChoice.toLowerCase() === 'skip') {
         console.log('\n   Skipping remaining refinement attempts...\n');

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -264,7 +264,14 @@ export async function completeQuickFix(qfId, options = {}) {
     testsPass
   };
 
-  const { complianceResults } = await runComplianceWithRefinement(qfId, qf, complianceContext, prompt);
+  // QF-20260509-COMPLIANCE-LOOP (closes 0974d18b): forward {forceComplete,reason}
+  // so the refinement-prompt at compliance-loop.js:77 auto-skips under
+  // --force-complete instead of wedging on stdin (9th-witness writer/consumer
+  // asymmetry; sibling miss in QF-20260509-552).
+  const { complianceResults } = await runComplianceWithRefinement(qfId, qf, complianceContext, prompt, {
+    forceComplete: options.forceComplete,
+    reason: options.reason
+  });
   // QF-20260508-407: forward {forceComplete, reason} so validateCompliance can
   // short-circuit the WARN-verdict prompt under --non-interactive (sibling parity
   // with validateLOC and validateSelfVerification).

--- a/tests/unit/harness/compliance-loop-force-complete.test.js
+++ b/tests/unit/harness/compliance-loop-force-complete.test.js
@@ -1,0 +1,118 @@
+// QF-20260509-COMPLIANCE-LOOP: refinement-prompt at compliance-loop.js:77
+// must auto-skip under flags.forceComplete instead of wedging on stdin.
+// Closes feedback 0974d18b. 9th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001
+// (sibling miss in QF-20260509-552 which patched validateTests + mergeToMain
+// + commit/push prompts but not the compliance-loop refinement prompt).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the rubric so we can control verdict
+const runComplianceRubricMock = vi.fn();
+vi.mock('../../../lib/quickfix-compliance-rubric.js', () => ({
+  runComplianceRubric: (...args) => runComplianceRubricMock(...args)
+}));
+
+// Mock execSync so applyAutoRefinement's npm-lint path doesn't run
+vi.mock('child_process', async () => ({
+  execSync: vi.fn(() => '')
+}));
+
+import { runComplianceWithRefinement } from '../../../scripts/modules/complete-quick-fix/compliance-loop.js';
+
+const failingResult = {
+  totalScore: 40,
+  verdict: 'FAIL',
+  criteriaResults: [
+    { id: 'targeted_fix', name: 'Targeted Fix', passed: false, score: 0, maxScore: 10, evidence: 'too many files' },
+    { id: 'unit_tests_pass', name: 'Unit Tests', passed: true, score: 10, maxScore: 10, evidence: '' },
+  ],
+};
+const passingResult = { ...failingResult, totalScore: 90, verdict: 'PASS', criteriaResults: failingResult.criteriaResults.map(c => ({ ...c, passed: true })) };
+
+describe('QF-20260509-COMPLIANCE-LOOP: runComplianceWithRefinement honors flags.forceComplete', () => {
+  beforeEach(() => {
+    runComplianceRubricMock.mockReset();
+  });
+
+  it('with FAIL verdict and forceComplete=true, auto-skips refinement-prompt (no prompt() call)', async () => {
+    runComplianceRubricMock.mockResolvedValue(failingResult);
+    const promptSpy = vi.fn();  // assert NOT called
+
+    const { refinementHistory } = await runComplianceWithRefinement(
+      'QF-TEST',
+      { description: 'test fix', actual_behavior: 'broken', estimated_loc: 20 },
+      { errorsBeforeFix: [], errorsAfterFix: [], actualLoc: 20, filesChanged: [], testsPass: true },
+      promptSpy,
+      { forceComplete: true, reason: 'autonomous-sweep' }
+    );
+
+    expect(promptSpy).not.toHaveBeenCalled();
+    // Still records the FAIL attempt before breaking
+    expect(refinementHistory).toHaveLength(1);
+    expect(refinementHistory[0].verdict).toBe('FAIL');
+  });
+
+  it('with FAIL verdict and forceComplete absent (default), DOES call prompt()', async () => {
+    runComplianceRubricMock.mockResolvedValue(failingResult);
+    const promptSpy = vi.fn().mockResolvedValue('skip');  // user types 'skip'
+
+    await runComplianceWithRefinement(
+      'QF-TEST',
+      { description: 'test fix', actual_behavior: 'broken', estimated_loc: 20 },
+      { errorsBeforeFix: [], errorsAfterFix: [], actualLoc: 20, filesChanged: [], testsPass: true },
+      promptSpy
+    );
+
+    // The original interactive behavior is preserved when no flag passed
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+    expect(promptSpy.mock.calls[0][0]).toMatch(/Attempt auto-refinement/);
+  });
+
+  it('with PASS verdict on first attempt, prompt() never called regardless of flags', async () => {
+    runComplianceRubricMock.mockResolvedValue(passingResult);
+    const promptSpy = vi.fn();
+
+    const { refinementHistory } = await runComplianceWithRefinement(
+      'QF-TEST',
+      { description: 'test fix', actual_behavior: 'ok', estimated_loc: 10 },
+      { errorsBeforeFix: [], errorsAfterFix: [], actualLoc: 10, filesChanged: [], testsPass: true },
+      promptSpy,
+      { forceComplete: false }
+    );
+
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(refinementHistory[0].verdict).toBe('PASS');
+  });
+
+  it('flags param defaults to {} when omitted (backward-compat)', async () => {
+    runComplianceRubricMock.mockResolvedValue(passingResult);
+    const promptSpy = vi.fn();
+
+    // 4 args (no flags) — must not throw on flags.forceComplete read
+    await expect(
+      runComplianceWithRefinement(
+        'QF-TEST',
+        { description: 'x', actual_behavior: 'y', estimated_loc: 5 },
+        { errorsBeforeFix: [], errorsAfterFix: [], actualLoc: 5, filesChanged: [], testsPass: true },
+        promptSpy
+      )
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('QF-20260509-COMPLIANCE-LOOP: source-level guard verifies the auto-skip branch is wired', () => {
+  it('compliance-loop.js source contains the forceComplete-aware refineChoice ternary', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../scripts/modules/complete-quick-fix/compliance-loop.js'),
+      'utf-8'
+    );
+    // Must contain the flag-gated ternary (auto-skip path)
+    expect(src).toMatch(/flags\.forceComplete[\s\S]+?'skip'/);
+    // Must still preserve the original prompt for interactive use
+    expect(src).toMatch(/Attempt auto-refinement/);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~14 src + ~95 test LOC, 5/5 vitest pass.

`runComplianceWithRefinement()` gains `flags = {}` parameter. Under `flags.forceComplete=true` the `'Attempt auto-refinement? (yes/no/skip):'` prompt at compliance-loop.js:77 auto-skips with a console message instead of wedging on stdin.

Caller in `orchestrator.js:267` now forwards `options.forceComplete` + `options.reason` (previously dropped on the floor).

**9th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.** Sibling miss in QF-20260509-552 (which patched validateTests + git-operations prompts but missed compliance-loop because the lesson was filed mid-flight as feedback 0974d18b).

## Test plan
- [x] `tests/unit/harness/compliance-loop-force-complete.test.js` 5/5
  - forceComplete=true → prompt NOT called
  - forceComplete absent → prompt CALLED (interactive preserved)
  - PASS verdict → prompt never called
  - backward-compat: 4-arg signature
  - source-level guard pin

## Closes
feedback 0974d18b-06fc-4348-9910-8b003b2a9045

## Out of scope
7 other prompts in complete-quick-fix module (verification.js:50,292,348 + orchestrator.js:119,182,195,208) remain --force-complete-naive. Will surface as separate witnesses if hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)