### PR TITLE
fix(QF-20260509-G2FID-SECTIONS): no-DESIGN-no-DATABASE short-circuit populates validation.sections

### DIFF
--- a/scripts/modules/implementation-fidelity/index.js
+++ b/scripts/modules/implementation-fidelity/index.js
@@ -204,6 +204,20 @@ export async function validateGate2ExecToPlan(sd_id, supabase, options = {}) {
       validation.warnings.push('No DESIGN or DATABASE analysis found - skipping Gate 2');
       validation.score = 100;
       validation.passed = true;
+      // QF-20260509-G2FID-SECTIONS (closes 7e2bd2a7): mirror docu-skip pattern
+      // (lines 88-99) so downstream sub-validators (2A:uiComponentsImplemented /
+      // userWorkflowsImplemented / userActionsSupported) read populated
+      // sections.A/B/C/D instead of undefined → 0/100. Without this, top-level
+      // GATE2 passes 100/100 but EXEC-TO-PLAN fails on sub-validator 0/100 —
+      // witnessed 11x retry pattern on SD-PRIVACYPATROL-...-D3.
+      const bypassSection = {
+        score: 100,
+        passed: true,
+        issues: [],
+        warnings: ['No DESIGN/DATABASE analysis - sub-validator section bypassed']
+      };
+      validation.sections = { A: bypassSection, B: bypassSection, C: bypassSection, D: bypassSection };
+      validation.sectionScores = { A: bypassSection, B: bypassSection, C: bypassSection, D: bypassSection };
       return validation;
     }
 

--- a/tests/unit/harness/g2fid-sections-shortcircuit.test.js
+++ b/tests/unit/harness/g2fid-sections-shortcircuit.test.js
@@ -1,0 +1,63 @@
+// QF-20260509-G2FID-SECTIONS: implementation-fidelity short-circuit branch
+// (no DESIGN/DATABASE analysis) must populate validation.sections.A/B/C/D
+// with bypassSection — otherwise downstream sub-validators read undefined
+// → 0/100 while top-level GATE2 reports 100/100 (11x retry witnessed
+// 2026-05-04 SD-PRIVACYPATROL-...-D3 EXEC-TO-PLAN). Closes feedback 7e2bd2a7.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+describe('QF-20260509-G2FID-SECTIONS: short-circuit branch source-level guard', () => {
+  it('no-DESIGN-no-DATABASE branch sets validation.sections + sectionScores', () => {
+    const src = fs.readFileSync(
+      path.join(repoRoot, 'scripts/modules/implementation-fidelity/index.js'),
+      'utf-8'
+    );
+    // Locate the short-circuit branch
+    const idx = src.indexOf('No DESIGN or DATABASE analysis found');
+    expect(idx).toBeGreaterThan(0);
+    // Look forward ~1000 chars for the bypassSection wiring
+    const block = src.slice(idx, idx + 1500);
+    expect(block).toMatch(/bypassSection/);
+    expect(block).toMatch(/validation\.sections\s*=/);
+    expect(block).toMatch(/A:\s*bypassSection/);
+    expect(block).toMatch(/B:\s*bypassSection/);
+    expect(block).toMatch(/C:\s*bypassSection/);
+    expect(block).toMatch(/D:\s*bypassSection/);
+    expect(block).toMatch(/validation\.sectionScores\s*=/);
+  });
+
+  it('bypassSection shape matches docu-skip pattern at lines 82-99', () => {
+    const src = fs.readFileSync(
+      path.join(repoRoot, 'scripts/modules/implementation-fidelity/index.js'),
+      'utf-8'
+    );
+    // Both blocks should declare bypassSection with score:100 + passed:true + issues + warnings
+    const matches = src.match(/const bypassSection\s*=\s*{[\s\S]+?};/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);  // docu-skip + no-analysis
+    matches.forEach(m => {
+      expect(m).toMatch(/score:\s*100/);
+      expect(m).toMatch(/passed:\s*true/);
+      expect(m).toMatch(/issues:\s*\[\s*\]/);
+      expect(m).toMatch(/warnings:/);
+    });
+  });
+
+  it('short-circuit branch returns AFTER populating sections (not before)', () => {
+    const src = fs.readFileSync(
+      path.join(repoRoot, 'scripts/modules/implementation-fidelity/index.js'),
+      'utf-8'
+    );
+    const startIdx = src.indexOf('No DESIGN or DATABASE analysis found');
+    const block = src.slice(startIdx, startIdx + 1500);
+    const sectionsIdx = block.indexOf('validation.sections =');
+    const returnIdx = block.indexOf('return validation;');
+    expect(sectionsIdx).toBeGreaterThan(0);
+    expect(returnIdx).toBeGreaterThan(sectionsIdx);  // return AFTER sections set
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~16 src + ~50 test LOC, 3/3 vitest pass.

`implementation-fidelity/index.js:203-208` short-circuit (no DESIGN AND no DATABASE analysis) returned with `validation.score=100` + `validation.passed=true` but NEVER populated `validation.sections.A/B/C/D`. Downstream sub-validators (`2A:uiComponentsImplemented` / `userWorkflowsImplemented` / `userActionsSupported`) read `result.sections.A` → `undefined` → 0/100. Top-level GATE2 passes 100/100 but EXEC-TO-PLAN fails on sub-validator divergence. **11x retry pattern witnessed 2026-05-04 SD-PRIVACYPATROL-...-D3.**

**Fix:** Mirror the docu-skip pattern at lines 88-99 — populate `sections` + `sectionScores` with `bypassSection {score:100, passed:true, issues:[], warnings:[]}` for all four sections before returning.

## Closes
feedback 7e2bd2a7-8168-4409-b508-69b17a773a8a

## Test plan
- [x] no-DESIGN-no-DATABASE branch sets sections + sectionScores
- [x] bypassSection shape matches docu-skip pattern (score:100/passed:true)
- [x] return statement AFTER sections populated (regression-pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)