### PR TITLE
fix(QF-20260509-CROSS-REPO-PLURAL): sub-agent-orchestration cross-repo skip honors target_repos[] plural

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
@@ -62,10 +62,21 @@ export function createSubAgentOrchestrationGate(supabase) {
       }
 
       // Cross-repo SD detection: SDs targeting external repos (e.g. ehg frontend)
-      // cannot have sub-agents invoked inline from this handoff context
-      const targetRepo = ctx.sd?.metadata?.target_repo ||
+      // cannot have sub-agents invoked inline from this handoff context.
+      // QF-20260509-CROSS-REPO-PLURAL (closes 45f3e446): also honor metadata.target_repos
+      // (plural array) which is the convention used by leo-create-sd.js --target-repos
+      // (SD-LEO-INFRA-LEO-CREATE-CROSS-001 PR #3577). Both singular and plural are
+      // in active use → 6th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+      const targetRepoSingular = ctx.sd?.metadata?.target_repo ||
         ctx.sd?.metadata?.implementation_notes?.target_repo;
-      if (targetRepo && targetRepo !== 'EHG_Engineer' && targetRepo !== 'rickfelix/EHG_Engineer') {
+      const targetReposArray = Array.isArray(ctx.sd?.metadata?.target_repos)
+        ? ctx.sd.metadata.target_repos
+        : [];
+      const isExternalRepo = (r) => r && r !== 'EHG_Engineer' && r !== 'rickfelix/EHG_Engineer';
+      const externalSingular = isExternalRepo(targetRepoSingular) ? targetRepoSingular : null;
+      const externalPlural = targetReposArray.find(isExternalRepo) || null;
+      const targetRepo = externalSingular || externalPlural;
+      if (targetRepo) {
         console.log(`   ⚠️  Cross-repo SD detected: target_repo=${targetRepo}`);
         console.log('   → Sub-agent orchestration skipped (agents cannot validate external repo inline)');
         console.log('   → Verify implementation manually or via cached sub-agent results');

--- a/tests/unit/harness/cross-repo-plural-detection.test.js
+++ b/tests/unit/harness/cross-repo-plural-detection.test.js
@@ -1,0 +1,55 @@
+// QF-20260509-CROSS-REPO-PLURAL: sub-agent-orchestration cross-repo skip path
+// must honor BOTH metadata.target_repo (singular) AND metadata.target_repos
+// (plural array). 6th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+// Closes feedback 45f3e446.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const gateFile = path.join(repoRoot, 'scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js');
+
+describe('QF-20260509-CROSS-REPO-PLURAL: sub-agent-orchestration cross-repo plural array support', () => {
+  it('source reads metadata.target_repos plural array', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    expect(src).toMatch(/metadata\?\.target_repos/);
+    expect(src).toMatch(/Array\.isArray\(ctx\.sd\?\.metadata\?\.target_repos\)/);
+  });
+
+  it('source reads metadata.target_repo singular as fallback', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    expect(src).toMatch(/metadata\?\.target_repo[^s]/); // singular, not plural prefix
+  });
+
+  it('source defines isExternalRepo helper that excludes EHG_Engineer + rickfelix/EHG_Engineer', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    expect(src).toMatch(/isExternalRepo/);
+    expect(src).toMatch(/'EHG_Engineer'/);
+    expect(src).toMatch(/'rickfelix\/EHG_Engineer'/);
+  });
+
+  it('source uses .find on plural array to detect first external repo', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    // The plural-array branch must use .find with isExternalRepo
+    expect(src).toMatch(/targetReposArray\.find\(isExternalRepo\)/);
+  });
+
+  it('singular and plural detection both flow into the same skip-path return', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    // After detection, the if-block must check externalSingular || externalPlural via the unified targetRepo var
+    expect(src).toMatch(/const targetRepo\s*=\s*externalSingular\s*\|\|\s*externalPlural/);
+    expect(src).toMatch(/if \(targetRepo\)\s*\{/);
+  });
+
+  it('regression: pre-fix singular-only check is gone', () => {
+    const src = fs.readFileSync(gateFile, 'utf-8');
+    // The OLD pattern was: `if (targetRepo && targetRepo !== 'EHG_Engineer' && targetRepo !== 'rickfelix/EHG_Engineer')`
+    // The NEW pattern is: `if (targetRepo) {` after combining singular+plural via isExternalRepo helper.
+    // We pin: there must be no inline guard on the post-combined check
+    const ifMatch = src.match(/if \(targetRepo &&[^)]*'EHG_Engineer'[^)]*'rickfelix/);
+    expect(ifMatch).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~16 src + ~50 test LOC, 6/6 vitest pass.

`scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js` cross-repo skip path at lines 64-83 only read `metadata.target_repo` (singular). Cross-repo feature SDs created via `leo-create-sd.js --target-repos` (SD-LEO-INFRA-LEO-CREATE-CROSS-001 PR #3577) populate `metadata.target_repos` (plural array). Both conventions in active use. **6th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.**

**Fix:** new `isExternalRepo` helper + `Array.isArray` + `.find` for plural array. Both singular and plural collapse into a unified `targetRepo` value driving a single skip-path.

## Closes
feedback 45f3e446-11c4-48e7-b77e-d99fdce69ecd

## Test plan
- [x] plural-array read via Array.isArray
- [x] singular fallback preserved
- [x] isExternalRepo excludes EHG_Engineer + rickfelix/EHG_Engineer
- [x] .find on plural array
- [x] unified flow into single skip-path return
- [x] regression-pin: pre-fix singular-only inline guard removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)