### PR TITLE
fix(QF-20260509-CANCEL-SD): canonical scripts/cancel-sd.js for atomic SD cancellation

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "doc:audit": "node scripts/eva/doc-health-audit.mjs",
     "story:template": "node scripts/story-requirements-template.js",
     "sd:next": "node scripts/sd-next.js",
+    "sd:cancel": "node scripts/cancel-sd.js",
     "signal": "node scripts/worker-signal.cjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Canonical SD Cancellation Script (QF-20260509-CANCEL-SD)
+ *
+ * Atomically cancels a Strategic Directive: sets status='cancelled',
+ * current_phase='CANCELLED', cancellation_reason, clears claiming_session_id +
+ * is_working_on, and releases the corresponding claude_sessions row.
+ *
+ * Closes feedback 5b5b959e (no canonical cancel-sd.js exists; direct UPDATE
+ * leaves claiming_session_id populated → ck_claude_sessions_worktree_state_consistency
+ * violations on stale releaseClaim path).
+ *
+ * Usage:
+ *   node scripts/cancel-sd.js <SD-KEY-or-UUID> --reason "<reason>"
+ *
+ * Examples:
+ *   node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "Superseded by SD-BAR"
+ *   node scripts/cancel-sd.js f55da615-... --reason "Duplicate of SD-X"
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createSupabaseServiceClient();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage: node scripts/cancel-sd.js <SD-KEY-or-UUID> --reason "<reason>"
+
+Atomically cancels an SD:
+  - status='cancelled', current_phase='CANCELLED'
+  - cancellation_reason set (required)
+  - claiming_session_id cleared
+  - is_working_on=false
+  - cancelled_at=NOW
+  - claude_sessions row for the holder released
+
+Required:
+  --reason "<text>"   Cancellation reason (cannot be empty)
+
+Examples:
+  node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "Superseded by SD-BAR-001"
+  node scripts/cancel-sd.js --help
+`);
+    process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
+  }
+
+  const reasonIdx = args.indexOf('--reason');
+  const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : null;
+  const sdInput = args.find(a => !a.startsWith('-') && (reasonIdx === -1 || args.indexOf(a) !== reasonIdx + 1));
+
+  if (!sdInput) {
+    console.error('❌ Missing SD identifier (sd_key or UUID)');
+    process.exit(1);
+  }
+  if (!reason || reason.trim() === '') {
+    console.error('❌ Missing or empty --reason "<text>" (required)');
+    process.exit(1);
+  }
+
+  return { sdInput, reason: reason.trim() };
+}
+
+async function resolveSD(input) {
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(input);
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, current_phase, claiming_session_id, is_working_on')
+    .or(isUuid ? `id.eq.${input}` : `sd_key.eq.${input}`)
+    .limit(1)
+    .single();
+  if (error || !data) {
+    console.error(`❌ SD not found: ${input}`);
+    process.exit(1);
+  }
+  return data;
+}
+
+async function cancelSD(sd, reason) {
+  if (sd.status === 'cancelled') {
+    console.log(`ℹ️  SD ${sd.sd_key} already cancelled (status='cancelled'). No-op.`);
+    return false;
+  }
+  if (sd.status === 'completed') {
+    console.error(`❌ Cannot cancel completed SD ${sd.sd_key} (status='completed'). Use a different remediation path.`);
+    process.exit(1);
+  }
+
+  const claimedSessionId = sd.claiming_session_id;
+  const updates = {
+    status: 'cancelled',
+    current_phase: 'CANCELLED',
+    cancellation_reason: reason,
+    claiming_session_id: null,
+    is_working_on: false,
+    cancelled_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .update(updates)
+    .eq('id', sd.id);
+  if (sdErr) {
+    console.error(`❌ Failed to update SD ${sd.sd_key}:`, sdErr.message);
+    process.exit(1);
+  }
+  console.log(`✓ SD ${sd.sd_key} cancelled (status=cancelled, current_phase=CANCELLED)`);
+
+  // Release the holder's claude_sessions row, if any
+  if (claimedSessionId) {
+    const { error: csErr } = await supabase
+      .from('claude_sessions')
+      .update({
+        status: 'released',
+        sd_key: null,
+        worktree_path: null,
+        worktree_branch: null,
+        released_at: new Date().toISOString(),
+      })
+      .eq('session_id', claimedSessionId)
+      .eq('sd_key', sd.sd_key);  // only release if THIS SD was the active claim
+    if (csErr) {
+      console.warn(`⚠️  claude_sessions release for ${claimedSessionId.slice(0, 8)} failed (non-fatal):`, csErr.message);
+    } else {
+      console.log(`✓ Released claude_sessions row for holder ${claimedSessionId.slice(0, 8)}`);
+    }
+  }
+
+  return true;
+}
+
+(async () => {
+  const { sdInput, reason } = parseArgs();
+  const sd = await resolveSD(sdInput);
+
+  console.log(`SD: ${sd.sd_key} — ${sd.title?.slice(0, 80)}`);
+  console.log(`  Current status: ${sd.status} / phase: ${sd.current_phase}`);
+  console.log(`  Claim: ${sd.claiming_session_id ? sd.claiming_session_id.slice(0, 8) : '(none)'}`);
+  console.log(`  Reason: ${reason}`);
+  console.log('');
+
+  const changed = await cancelSD(sd, reason);
+  if (changed) {
+    console.log('\n✅ Cancellation complete.');
+  }
+})().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/tests/unit/harness/cancel-sd-script.test.js
+++ b/tests/unit/harness/cancel-sd-script.test.js
@@ -1,0 +1,73 @@
+// QF-20260509-CANCEL-SD: source-level guards for the canonical cancel-sd.js
+// script. Closes feedback 5b5b959e (no canonical cancel-sd.js exists; direct
+// UPDATE leaves claiming_session_id populated).
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const scriptPath = path.join(repoRoot, 'scripts/cancel-sd.js');
+
+describe('QF-20260509-CANCEL-SD: cancel-sd.js canonical script', () => {
+  it('script exists at scripts/cancel-sd.js', () => {
+    expect(fs.existsSync(scriptPath)).toBe(true);
+  });
+
+  it('script enforces required --reason flag (rejects empty)', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    expect(src).toMatch(/Missing or empty --reason/);
+    expect(src).toMatch(/required\)/);
+  });
+
+  it('script accepts both sd_key and UUID identifiers', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    // UUID detection regex
+    expect(src).toMatch(/\^\[0-9a-f\]\{8\}-/);
+    // resolveSD must .or both sd_key and id
+    expect(src).toMatch(/sd_key\.eq\.\${input}/);
+    expect(src).toMatch(/id\.eq\.\${input}/);
+  });
+
+  it('atomic UPDATE clears claiming_session_id + is_working_on=false', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    expect(src).toMatch(/claiming_session_id:\s*null/);
+    expect(src).toMatch(/is_working_on:\s*false/);
+    expect(src).toMatch(/status:\s*'cancelled'/);
+    expect(src).toMatch(/current_phase:\s*'CANCELLED'/);
+  });
+
+  it('cancellation_reason is required (not optional)', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    // The reason field must be present in the updates object
+    expect(src).toMatch(/cancellation_reason:\s*reason/);
+  });
+
+  it('releases claude_sessions row scoped to the SD-being-cancelled', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    expect(src).toMatch(/from\(['"]claude_sessions['"]\)/);
+    expect(src).toMatch(/status:\s*'released'/);
+    // Must filter by both session_id AND sd_key (not blind release)
+    expect(src).toMatch(/\.eq\(['"]session_id['"],\s*claimedSessionId\)/);
+    expect(src).toMatch(/\.eq\(['"]sd_key['"],\s*sd\.sd_key\)/);
+  });
+
+  it('refuses to cancel completed SDs', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    expect(src).toMatch(/Cannot cancel completed SD/);
+    expect(src).toMatch(/sd\.status === ['"]completed['"]/);
+  });
+
+  it('idempotent on already-cancelled SDs (no-op + early return)', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    expect(src).toMatch(/already cancelled/);
+    expect(src).toMatch(/sd\.status === ['"]cancelled['"]/);
+  });
+
+  it('npm run sd:cancel script entry exists in package.json', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+    expect(pkg.scripts['sd:cancel']).toBe('node scripts/cancel-sd.js');
+  });
+});


### PR DESCRIPTION
## Summary
Tier-2, ~135 src + ~75 test LOC, 9/9 vitest pass.

New canonical \`scripts/cancel-sd.js\` script. Atomically cancels an SD:
- \`status='cancelled'\`, \`current_phase='CANCELLED'\`
- \`cancellation_reason\` set (required, non-empty)
- \`claiming_session_id\` cleared
- \`is_working_on=false\`
- \`cancelled_at=NOW\`
- Releases the holder's \`claude_sessions\` row (scoped to \`session_id + sd_key\` to avoid blind release of unrelated peer claims)

\`package.json\` gains \`npm run sd:cancel\` entry (WIRE_CHECK_GATE satisfaction + discoverability).

## Closes
feedback 5b5b959e-0634-43bf-b13f-09ea7400c133 (no canonical cancel-sd.js exists; direct UPDATE leaves \`claiming_session_id\` populated → \`ck_claude_sessions_worktree_state_consistency\` violations on stale releaseClaim path)

## Behavior
- Refuses to cancel \`completed\` SDs (use different remediation path)
- Idempotent on already-cancelled SDs (no-op + early return)
- Logs the holder session that was released

## Test plan
- [x] script exists at canonical path
- [x] enforces non-empty \`--reason\` flag
- [x] accepts both sd_key and UUID identifiers
- [x] atomic UPDATE clears \`claiming_session_id\` + \`is_working_on\`
- [x] \`cancellation_reason\` is required
- [x] \`claude_sessions\` release scoped to \`(session_id, sd_key)\` — not blind
- [x] refuses to cancel completed SDs
- [x] idempotent on already-cancelled SDs
- [x] \`npm run sd:cancel\` entry exists in package.json
- [x] \`--help\` smoke-tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)