### PR TITLE
fix(QF-20260509-LEO-CREATE-FLAGS): leo-create-sd.js review-flag sibling parity

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -326,6 +326,12 @@ async function createFromLearn(patternId) {
  * Create SD from /inbox feedback item
  */
 async function createFromFeedback(feedbackId, options = {}) {
+  // QF-20260509-LEO-CREATE-FLAGS (closes 8a640d32 sibling-parity gap):
+  // honor --migration-reviewed / --security-reviewed in --from-feedback path
+  // (mirrors --from-plan / --child handling). Without this, the GR-MIGRATION-REVIEW
+  // / GR-SECURITY-BASELINE guardrails block SD creation from feedback rows whose
+  // description mentions migration or schema even with the flags set.
+  const { migrationReviewed = false, securityReviewed = false } = options;
   console.log(`\n📋 Creating SD from feedback: ${feedbackId}`);
 
   // Fetch feedback item (support full or partial UUID)
@@ -410,7 +416,10 @@ async function createFromFeedback(feedbackId, options = {}) {
       source: 'feedback',
       source_id: feedback.id,
       feedback_type: feedback.type,
-      feedback_priority: feedback.priority
+      feedback_priority: feedback.priority,
+      // QF-20260509-LEO-CREATE-FLAGS: propagate guardrail review flags
+      ...(migrationReviewed ? { migration_reviewed: true } : {}),
+      ...(securityReviewed ? { security_reviewed: true } : {})
     }
   });
 
@@ -1854,13 +1863,17 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         [fbTypeIdx !== -1 ? fbTypeIdx + 1 : -1,
          fbTitleIdx !== -1 ? fbTitleIdx + 1 : -1].filter(i => i > 0)
       );
-      const fbKnownFlags = new Set(['--from-feedback', '--type', '--title']);
+      // QF-20260509-LEO-CREATE-FLAGS: include review flags so they're not
+      // mistaken for the feedback ID positional. Closes 8a640d32 sibling parity.
+      const fbKnownFlags = new Set(['--from-feedback', '--type', '--title', '--migration-reviewed', '--security-reviewed']);
       const feedbackId = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !fbFlagValuePositions.has(i) && !fbKnownFlags.has(arg)
       ) || args[1];
       await createFromFeedback(feedbackId, {
         typeOverride: fbTypeIdx !== -1 ? args[fbTypeIdx + 1] : null,
         titleOverride: fbTitleIdx !== -1 ? args[fbTitleIdx + 1] : null,
+        migrationReviewed: args.includes('--migration-reviewed'),
+        securityReviewed: args.includes('--security-reviewed'),
       });
     } else if (args[0] === '--from-qf') {
       await createFromQF(args[1]);
@@ -2006,7 +2019,12 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
     } else {
       // Direct creation: <source> <type> "<title>"
       // Detect unknown flags to prevent silent corruption (SD-LEO-FIX-CREATE-ARGS-001)
-      const knownDirectFlags = new Set(['--venture', '--vision-key', '--arch-key', '--target-repos']);
+      // QF-20260509-LEO-CREATE-FLAGS: --migration-reviewed / --security-reviewed / --yes / -y
+      // are now valid in direct-args mode (closes 8a640d32 sibling-parity gap with --from-plan).
+      const knownDirectFlags = new Set([
+        '--venture', '--vision-key', '--arch-key', '--target-repos',
+        '--migration-reviewed', '--security-reviewed', '--yes', '-y'
+      ]);
       const unknownFlags = args.filter(a => a.startsWith('-') && !knownDirectFlags.has(a));
       if (unknownFlags.length > 0) {
         console.error('\n❌ Unknown flag(s): ' + unknownFlags.join(', '));
@@ -2239,6 +2257,11 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const ventureConfig = cliVenture ? getVentureConfig(cliVenture) : null;
       const targetApp = ventureConfig?.name || cliVenture || null;
 
+      // QF-20260509-LEO-CREATE-FLAGS: honor --migration-reviewed / --security-reviewed
+      // in direct-args mode (closes 8a640d32 sibling parity with --from-plan / --from-feedback).
+      const directMigrationReviewed = args.includes('--migration-reviewed');
+      const directSecurityReviewed = args.includes('--security-reviewed');
+
       await createSD({
         sdKey,
         title,
@@ -2254,7 +2277,9 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           ...(visionKey && { vision_key: visionKey }),
           ...(archKey && { arch_key: archKey }),
           ...(enriched?.scope && { scope: enriched.scope }),
-          ...(targetRepos && { target_repos: targetRepos })
+          ...(targetRepos && { target_repos: targetRepos }),
+          ...(directMigrationReviewed ? { migration_reviewed: true } : {}),
+          ...(directSecurityReviewed ? { security_reviewed: true } : {})
         }
       });
     }

--- a/tests/unit/harness/leo-create-flags-parity.test.js
+++ b/tests/unit/harness/leo-create-flags-parity.test.js
@@ -1,0 +1,85 @@
+// QF-20260509-LEO-CREATE-FLAGS: --migration-reviewed / --security-reviewed
+// must work in BOTH --from-feedback path AND direct-args mode (closes 8a640d32
+// sibling-parity gap with --from-plan path).
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.resolve(__dirname, '../../../scripts/leo-create-sd.js');
+
+describe('QF-20260509-LEO-CREATE-FLAGS: review flags sibling parity across creation paths', () => {
+  let src;
+  beforeAll(() => {
+    src = fs.readFileSync(scriptPath, 'utf-8');
+  });
+
+  describe('--from-feedback path', () => {
+    it('createFromFeedback destructures migrationReviewed + securityReviewed from options', () => {
+      // Locate the function and inspect its body
+      const idx = src.indexOf('async function createFromFeedback');
+      expect(idx).toBeGreaterThan(0);
+      const body = src.slice(idx, idx + 3500);
+      expect(body).toMatch(/migrationReviewed\s*=\s*false/);
+      expect(body).toMatch(/securityReviewed\s*=\s*false/);
+    });
+
+    it('createFromFeedback metadata propagates migration_reviewed=true when flag is set', () => {
+      const idx = src.indexOf('async function createFromFeedback');
+      const body = src.slice(idx, idx + 5000);
+      // Spread only when truthy
+      expect(body).toMatch(/migrationReviewed\s*\?\s*\{\s*migration_reviewed:\s*true\s*\}/);
+      expect(body).toMatch(/securityReviewed\s*\?\s*\{\s*security_reviewed:\s*true\s*\}/);
+    });
+
+    it('CLI args parser includes --migration-reviewed / --security-reviewed in fbKnownFlags', () => {
+      const idx = src.indexOf("const fbKnownFlags = new Set");
+      expect(idx).toBeGreaterThan(0);
+      const block = src.slice(idx, idx + 200);
+      expect(block).toMatch(/--migration-reviewed/);
+      expect(block).toMatch(/--security-reviewed/);
+    });
+
+    it('CLI passes args.includes(--migration-reviewed) / --security-reviewed to createFromFeedback', () => {
+      const idx = src.indexOf('await createFromFeedback(feedbackId,');
+      expect(idx).toBeGreaterThan(0);
+      const block = src.slice(idx, idx + 400);
+      expect(block).toMatch(/migrationReviewed:\s*args\.includes\(['"]--migration-reviewed['"]\)/);
+      expect(block).toMatch(/securityReviewed:\s*args\.includes\(['"]--security-reviewed['"]\)/);
+    });
+  });
+
+  describe('direct-args mode', () => {
+    it('knownDirectFlags Set includes --migration-reviewed / --security-reviewed / --yes / -y', () => {
+      const idx = src.indexOf('const knownDirectFlags = new Set');
+      expect(idx).toBeGreaterThan(0);
+      const block = src.slice(idx, idx + 300);
+      expect(block).toMatch(/--migration-reviewed/);
+      expect(block).toMatch(/--security-reviewed/);
+      expect(block).toMatch(/--yes/);
+      expect(block).toMatch(/'-y'/);
+    });
+
+    it('direct-args createSD metadata propagates migration_reviewed when flag is set', () => {
+      // The wiring lives in the direct creation block AFTER any vision-readiness
+      // routing — search the whole file since the line distance is ~250 lines.
+      expect(src).toMatch(/directMigrationReviewed\s*=\s*args\.includes\(['"]--migration-reviewed['"]\)/);
+      expect(src).toMatch(/directSecurityReviewed\s*=\s*args\.includes\(['"]--security-reviewed['"]\)/);
+      expect(src).toMatch(/directMigrationReviewed\s*\?\s*\{\s*migration_reviewed:\s*true\s*\}/);
+      expect(src).toMatch(/directSecurityReviewed\s*\?\s*\{\s*security_reviewed:\s*true\s*\}/);
+    });
+  });
+
+  describe('regression: direct-args mode no longer rejects review flags as unknown', () => {
+    it('the unknownFlags filter excludes review flags', () => {
+      const idx = src.indexOf('const unknownFlags = args.filter');
+      expect(idx).toBeGreaterThan(0);
+      // The filter relies on knownDirectFlags Set — verified above
+      // Pin: there is no separate exclusion list that would re-reject these
+      const block = src.slice(idx, idx + 300);
+      expect(block).toMatch(/!knownDirectFlags\.has\(a\)/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~22 src + ~85 test LOC, 7/7 vitest pass.

\`scripts/leo-create-sd.js\` — propagate \`--migration-reviewed\` / \`--security-reviewed\` through 2 additional creation paths (sibling parity with \`--from-plan\`):

**(a) --from-feedback path:**
- \`createFromFeedback()\` destructures \`migrationReviewed\` / \`securityReviewed\` from options
- Spreads \`{ migration_reviewed: true }\` / \`{ security_reviewed: true }\` into metadata when flags set
- CLI parser includes flags in \`fbKnownFlags\` Set
- \`args.includes()\` values forwarded to \`createFromFeedback()\`

**(b) Direct-args mode:**
- \`knownDirectFlags\` Set extended: \`--migration-reviewed\`, \`--security-reviewed\`, \`--yes\`, \`-y\` (previously rejected as 'unknown flag')
- \`createSD()\` metadata propagates flags

## Closes
feedback 8a640d32-369e-4176-9840-2ce0e31d1a03 (sibling-parity gap; discovered when promoting 64e40594 hit GR-MIGRATION-REVIEW guardrail through \`--from-feedback\`)

## Test plan
- [x] createFromFeedback destructures flags
- [x] metadata spread conditional on truthy
- [x] fbKnownFlags Set includes both review flags
- [x] CLI passes args.includes() to createFromFeedback
- [x] knownDirectFlags Set includes flags + --yes/-y
- [x] direct-args metadata propagates flags
- [x] regression-pin on unknownFlags filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)