### PR TITLE
feat(SD-FDBK-INFRA-LAYER-SIDE-CLAIMING-001): Layer 1 PG-side claiming_session_id release parity

### DIFF
--- a/database/migrations/20260509_layer1_claiming_session_id_release_parity.sql
+++ b/database/migrations/20260509_layer1_claiming_session_id_release_parity.sql
@@ -1,0 +1,340 @@
+BEGIN;
+
+-- SD-FDBK-INFRA-LAYER-SIDE-CLAIMING-001 (Layer 1 / writer-side parity)
+-- Closes feedback 64e40594. Pairs with QF-20260509-711 (Layer 2 / consumer
+-- fail-open in lib/claim-validity-gate.js:247-280).
+--
+-- 11th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001:
+-- 4 PG functions in 20260201_intelligent_session_lifecycle.sql + 1 sibling-file
+-- UPDATE in 20260201_fix_cleanup_stale_sessions.sql historically cleared
+-- strategic_directives_v2.active_session_id but left claiming_session_id
+-- populated → claim-validity-gate then saw a foreign claim until Layer 2
+-- auto-released it. This migration closes the writer side.
+--
+-- Method: CREATE OR REPLACE FUNCTION (NOT DROP+CREATE) preserves grants/ACLs
+-- and is atomic from in-flight callers' perspective. BEGIN/COMMIT wrap so all
+-- 4 replacements land atomically per retro-migrations convention
+-- (SD-LEO-INFRA-PRE-COMMIT-GUARD-001 STAGE 0.7).
+
+-- ============================================================================
+-- FR-2: create_or_replace_session — clear claiming_session_id alongside active_session_id
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION create_or_replace_session(
+  p_session_id TEXT,
+  p_machine_id TEXT,
+  p_terminal_id TEXT,
+  p_tty TEXT,
+  p_pid INTEGER,
+  p_hostname TEXT,
+  p_codebase TEXT,
+  p_metadata JSONB DEFAULT '{}'::JSONB
+) RETURNS JSONB AS $$
+DECLARE
+  v_terminal_identity TEXT;
+  v_previous_session RECORD;
+  v_auto_released BOOLEAN := false;
+  v_previous_session_id TEXT := NULL;
+BEGIN
+  v_terminal_identity := COALESCE(p_machine_id, '') || ':' || COALESCE(p_terminal_id, p_tty, '');
+
+  SELECT session_id, sd_key, status INTO v_previous_session
+  FROM claude_sessions
+  WHERE terminal_identity = v_terminal_identity
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1;
+
+  IF v_previous_session IS NOT NULL THEN
+    UPDATE claude_sessions
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'AUTO_REPLACED',
+        updated_at = NOW()
+    WHERE session_id = v_previous_session.session_id;
+
+    IF v_previous_session.sd_key IS NOT NULL THEN
+      -- LAYER-SIDE-CLAIMING-001 FR-2: clear claiming_session_id alongside active_session_id.
+      -- (sd_claims table reference removed — table does not exist in current schema.)
+      UPDATE strategic_directives_v2
+      SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+      WHERE active_session_id = v_previous_session.session_id
+         OR claiming_session_id = v_previous_session.session_id;
+    END IF;
+
+    v_auto_released := true;
+    v_previous_session_id := v_previous_session.session_id;
+
+    RAISE NOTICE 'Auto-released previous session % for terminal %',
+      v_previous_session.session_id, v_terminal_identity;
+  END IF;
+
+  INSERT INTO claude_sessions (
+    session_id, machine_id, terminal_id, tty, pid, hostname, codebase,
+    status, heartbeat_at, metadata, created_at, updated_at
+  ) VALUES (
+    p_session_id, p_machine_id, p_terminal_id, p_tty, p_pid, p_hostname, p_codebase,
+    'idle', NOW(), p_metadata, NOW(), NOW()
+  )
+  ON CONFLICT (session_id) DO UPDATE SET
+    machine_id = EXCLUDED.machine_id,
+    terminal_id = EXCLUDED.terminal_id,
+    tty = EXCLUDED.tty,
+    pid = EXCLUDED.pid,
+    hostname = EXCLUDED.hostname,
+    heartbeat_at = NOW(),
+    metadata = EXCLUDED.metadata,
+    status = CASE
+      WHEN claude_sessions.status = 'released' THEN 'idle'
+      ELSE claude_sessions.status
+    END,
+    updated_at = NOW();
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'terminal_identity', v_terminal_identity,
+    'auto_released', v_auto_released,
+    'previous_session_id', v_previous_session_id,
+    'created_at', NOW()
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'terminal_conflict',
+      'message', format('Terminal identity %s already claimed by another session', v_terminal_identity)
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION create_or_replace_session IS
+  'Atomically creates a session, auto-releasing any previous session for the same terminal identity. Layer 1 parity (LAYER-SIDE-CLAIMING-001): clears claiming_session_id alongside active_session_id. Part of FR-1.';
+
+-- ============================================================================
+-- FR-3: release_session — clear claiming_session_id alongside active_session_id
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION release_session(
+  p_session_id TEXT,
+  p_reason TEXT DEFAULT 'graceful_exit'
+) RETURNS JSONB AS $$
+DECLARE
+  v_session RECORD;
+BEGIN
+  SELECT session_id, status, sd_key, released_at INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_session IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'session_not_found',
+      'message', format('Session %s not found', p_session_id)
+    );
+  END IF;
+
+  IF v_session.status = 'released' THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'already_released', true,
+      'session_id', p_session_id,
+      'released_at', v_session.released_at
+    );
+  END IF;
+
+  IF v_session.sd_key IS NOT NULL THEN
+    -- LAYER-SIDE-CLAIMING-001 FR-3: clear claiming_session_id alongside active_session_id.
+    -- (sd_claims table reference removed — table does not exist in current schema.)
+    UPDATE strategic_directives_v2
+    SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+    WHERE active_session_id = p_session_id
+       OR claiming_session_id = p_session_id;
+  END IF;
+
+  UPDATE claude_sessions
+  SET status = 'released',
+      released_at = NOW(),
+      released_reason = p_reason,
+      sd_key = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'released_at', NOW(),
+    'reason', p_reason,
+    'had_sd_claim', v_session.sd_key IS NOT NULL
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION release_session IS
+  'Releases a session with reason tracking. Idempotent. Layer 1 parity (LAYER-SIDE-CLAIMING-001): clears claiming_session_id alongside active_session_id. Part of FR-3.';
+
+-- ============================================================================
+-- FR-4: cleanup_stale_sessions — clear claiming_session_id in batch release
+-- (canonical version supersedes both 20260201_intelligent_session_lifecycle.sql:290
+--  and 20260201_fix_cleanup_stale_sessions.sql — single source of truth)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION cleanup_stale_sessions(
+  p_stale_threshold_seconds INTEGER DEFAULT 120,
+  p_batch_size INTEGER DEFAULT 100
+) RETURNS JSONB AS $$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+BEGIN
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE claude_sessions cs
+    SET status = 'stale',
+        stale_at = NOW(),
+        stale_reason = 'HEARTBEAT_TIMEOUT',
+        updated_at = NOW()
+    FROM stale_sessions ss
+    WHERE cs.session_id = ss.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_stale_count FROM updated;
+
+  WITH release_sessions AS (
+    SELECT session_id, sd_key
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  released AS (
+    UPDATE claude_sessions cs
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'STALE_CLEANUP',
+        sd_key = NULL,
+        track = NULL,
+        claimed_at = NULL,
+        updated_at = NOW()
+    FROM release_sessions rs
+    WHERE cs.session_id = rs.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_released_count FROM released;
+
+  -- LAYER-SIDE-CLAIMING-001 FR-4: clear claiming_session_id alongside active_session_id.
+  -- (sd_claims table reference removed — table does not exist in current schema.)
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+  WHERE active_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  )
+  OR claiming_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'executed_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_stale_sessions IS
+  'Batch cleanup of stale sessions: marks stale after threshold, releases after 30s stale. Layer 1 parity (LAYER-SIDE-CLAIMING-001): clears claiming_session_id alongside active_session_id. Part of FR-4.';
+
+-- ============================================================================
+-- FR-5: report_pid_validation_failure — add NEW SD-claim-release UPDATE
+-- (function previously only set claude_sessions.status='stale'; now also
+--  releases the failed session's SD claim atomically with the stale flag)
+-- Order: claude_sessions UPDATE first (existing semantics), strategic_directives_v2
+-- UPDATE second (new) — partial-failure shape leaves session stale + claim
+-- retained, which is the safe state (Layer 2 fail-open auto-releases on next gate).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION report_pid_validation_failure(
+  p_session_id TEXT,
+  p_machine_id TEXT
+) RETURNS JSONB AS $$
+DECLARE
+  v_session RECORD;
+BEGIN
+  SELECT session_id, machine_id, status, sd_key INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_session IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'session_not_found',
+      'message', format('Session %s not found', p_session_id)
+    );
+  END IF;
+
+  IF v_session.machine_id != p_machine_id THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'machine_mismatch',
+      'message', 'PID validation must be reported from same machine'
+    );
+  END IF;
+
+  IF v_session.status NOT IN ('active', 'idle') THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'already_processed', true,
+      'current_status', v_session.status
+    );
+  END IF;
+
+  -- (1/2) Mark session as stale due to PID not found (existing behavior)
+  UPDATE claude_sessions
+  SET status = 'stale',
+      stale_at = NOW(),
+      stale_reason = 'PID_NOT_FOUND',
+      pid_validated_at = NOW(),
+      updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  -- (2/2) LAYER-SIDE-CLAIMING-001 FR-5: release the failed session's SD claim.
+  -- Conditional WHERE narrows to only SDs linked to the failed session via either
+  -- column (per validation-agent recommendation — never blanket clobber).
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+  WHERE active_session_id = p_session_id
+     OR claiming_session_id = p_session_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'new_status', 'stale',
+    'stale_reason', 'PID_NOT_FOUND',
+    'stale_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION report_pid_validation_failure IS
+  'Marks a session as stale when PID validation fails. Includes machine_id check for safety. Layer 1 parity (LAYER-SIDE-CLAIMING-001): also releases the failed session SD claim by clearing both active_session_id and claiming_session_id. Part of FR-2.';
+
+COMMIT;

--- a/tests/integration/migrations/layer1-claiming-session-roundtrip.test.js
+++ b/tests/integration/migrations/layer1-claiming-session-roundtrip.test.js
@@ -1,0 +1,204 @@
+// SD-FDBK-INFRA-LAYER-SIDE-CLAIMING-001 FR-8: integration round-trip test.
+// Self-validating ship — calls the live PG functions and asserts SD claim is
+// auto-released without QF-711 fallback firing.
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const supabase = createSupabaseServiceClient();
+
+describe.skipIf(!HAS_REAL_DB)('SD-LAYER-SIDE-CLAIMING-001 FR-8: integration round-trip', () => {
+  // Test fixtures use timestamped IDs so beforeAll self-heal in
+  // blocked-state-detector.test.js (QF-FIXTURE-LEAK) won't sweep them mid-run.
+  const fixtureIds = [];
+
+  afterEach(async () => {
+    if (fixtureIds.length > 0) {
+      await supabase.from('strategic_directives_v2').delete().in('id', fixtureIds);
+      fixtureIds.length = 0;
+    }
+  });
+
+  it('report_pid_validation_failure releases claim on the failed session\'s SD', async () => {
+    const ts = Date.now();
+    const sessionId = `TEST-LAYER-CLAIMING-SESSION-${ts}`;
+    const sdId = `TEST-LAYER-CLAIMING-SD-${ts}`;
+
+    // Seed a claude_sessions row in 'active' state
+    const { error: csErr } = await supabase
+      .from('claude_sessions')
+      .insert({
+        session_id: sessionId,
+        machine_id: 'test-machine',
+        terminal_id: `test-term-${ts}`,
+        pid: 99999,
+        hostname: 'test-host',
+        codebase: 'EHG_Engineer',
+        status: 'active',
+        heartbeat_at: new Date().toISOString(),
+      });
+    expect(csErr).toBeNull();
+
+    // Seed an SD with the session as its claim holder (both column linkages)
+    const { error: sdErr } = await supabase
+      .from('strategic_directives_v2')
+      .insert({
+        id: sdId,
+        sd_key: sdId,
+        title: 'Test SD for Layer 1 round-trip',
+        category: 'test',
+        status: 'draft',
+        priority: 'low',
+        category: 'test',
+        description: 'Test fixture for Layer 1 claim-release parity round-trip',
+        rationale: 'Integration test fixture',
+        scope: 'Test scope',
+        sequence_rank: 0,
+        sd_code_user_facing: sdId,
+        active_session_id: sessionId,
+        claiming_session_id: sessionId,
+        is_working_on: true,
+      });
+    expect(sdErr).toBeNull();
+    fixtureIds.push(sdId);
+
+    // Call report_pid_validation_failure
+    const { data: rpcData, error: rpcErr } = await supabase
+      .rpc('report_pid_validation_failure', {
+        p_session_id: sessionId,
+        p_machine_id: 'test-machine',
+      });
+    expect(rpcErr).toBeNull();
+    expect(rpcData?.success).toBe(true);
+    expect(rpcData?.new_status).toBe('stale');
+
+    // ASSERT: SD claim released — BOTH columns NULL after Layer 1 fires
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('active_session_id, claiming_session_id, is_working_on')
+      .eq('id', sdId)
+      .single();
+    expect(sd.active_session_id).toBeNull();
+    expect(sd.claiming_session_id).toBeNull();
+    expect(sd.is_working_on).toBe(false);
+
+    // Cleanup claude_sessions row
+    await supabase.from('claude_sessions').delete().eq('session_id', sessionId);
+  });
+
+  it('FR-5 idempotency: double-call returns already_processed=true (no error, no double-clear)', async () => {
+    const ts = Date.now();
+    const sessionId = `TEST-LAYER-CLAIMING-IDEMPOTENT-${ts}`;
+    const sdId = `TEST-LAYER-CLAIMING-IDEMPOTENT-SD-${ts}`;
+
+    await supabase.from('claude_sessions').insert({
+      session_id: sessionId,
+      machine_id: 'test-machine',
+      terminal_id: `test-term-${ts}`,
+      pid: 99998,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+      status: 'active',
+      heartbeat_at: new Date().toISOString(),
+    });
+    await supabase.from('strategic_directives_v2').insert({
+      id: sdId,
+      sd_key: sdId,
+      title: 'Test SD idempotency',
+      status: 'draft',
+      priority: 'low',
+      category: 'test',
+      description: 'Idempotency test fixture',
+      rationale: 'Idempotency test',
+      scope: 'Test',
+      sequence_rank: 0,
+      sd_code_user_facing: sdId,
+      active_session_id: sessionId,
+      claiming_session_id: sessionId,
+      is_working_on: true,
+    });
+    fixtureIds.push(sdId);
+
+    // First call
+    const { data: r1, error: e1 } = await supabase.rpc('report_pid_validation_failure', {
+      p_session_id: sessionId,
+      p_machine_id: 'test-machine',
+    });
+    expect(e1).toBeNull();
+    expect(r1?.success).toBe(true);
+    expect(r1?.new_status).toBe('stale');
+
+    // Second call — already_processed
+    const { data: r2 } = await supabase.rpc('report_pid_validation_failure', {
+      p_session_id: sessionId,
+      p_machine_id: 'test-machine',
+    });
+    expect(r2?.success).toBe(true);
+    expect(r2?.already_processed).toBe(true);
+
+    await supabase.from('claude_sessions').delete().eq('session_id', sessionId);
+  });
+
+  // FR-4 negative case removed from integration suite: cleanup_stale_sessions
+  // operates on shared claude_sessions state; test fixtures cannot reliably
+  // isolate from other in-flight test sessions without machine_id partitioning.
+  // Static-guard test (parity-static.test.js) pins the SQL pattern instead.
+  it.skip('FR-4 negative case: orphan-claim shape (active_session_id NULL, claiming_session_id set) is reached by cleanup_stale_sessions', async () => {
+    const ts = Date.now();
+    const sessionId = `TEST-LAYER-CLAIMING-ORPHAN-${ts}`;
+    const sdId = `TEST-LAYER-CLAIMING-ORPHAN-SD-${ts}`;
+
+    // Seed a session that's been stale for >30s already
+    const staleAt = new Date(Date.now() - 35000).toISOString(); // 35s ago
+    const heartbeat = new Date(Date.now() - 200000).toISOString(); // 200s ago — past 120s threshold
+    await supabase.from('claude_sessions').insert({
+      session_id: sessionId,
+      machine_id: 'test-machine',
+      terminal_id: `test-term-${ts}`,
+      pid: 99997,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+      status: 'stale',
+      stale_at: staleAt,
+      stale_reason: 'TEST_PRESEEDED',
+      heartbeat_at: heartbeat,
+    });
+    // Orphan-claim shape: active_session_id NULL, claiming_session_id set
+    await supabase.from('strategic_directives_v2').insert({
+      id: sdId,
+      sd_key: sdId,
+      title: 'Test SD orphan claim',
+      category: 'test',
+      status: 'draft',
+      active_session_id: null,
+      claiming_session_id: sessionId,
+      is_working_on: true,
+    });
+    fixtureIds.push(sdId);
+
+    // Call cleanup_stale_sessions
+    const { data, error } = await supabase.rpc('cleanup_stale_sessions', {
+      p_stale_threshold_seconds: 120,
+      p_batch_size: 100,
+    });
+    expect(error).toBeNull();
+    expect(data?.success).toBe(true);
+
+    // ASSERT: orphan claim cleared — claiming_session_id NULL even though
+    // active_session_id was already NULL
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('claiming_session_id, is_working_on')
+      .eq('id', sdId)
+      .single();
+    expect(sd.claiming_session_id).toBeNull();
+    expect(sd.is_working_on).toBe(false);
+
+    await supabase.from('claude_sessions').delete().eq('session_id', sessionId);
+  });
+});

--- a/tests/unit/migrations/layer1-claiming-session-parity-static.test.js
+++ b/tests/unit/migrations/layer1-claiming-session-parity-static.test.js
@@ -1,0 +1,103 @@
+// SD-FDBK-INFRA-LAYER-SIDE-CLAIMING-001 FR-7: SQL static-guard for Layer 1
+// claiming_session_id release parity. Pins ALL release sites in the new
+// migration to clear BOTH active_session_id AND claiming_session_id.
+//
+// Closes feedback 64e40594. 11th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const migrationFile = path.join(repoRoot, 'database/migrations/20260509_layer1_claiming_session_id_release_parity.sql');
+
+describe('SD-LAYER-SIDE-CLAIMING-001 FR-7: SQL static-guard for claim-release parity', () => {
+  let sql;
+  beforeAll(() => {
+    sql = fs.readFileSync(migrationFile, 'utf-8');
+  });
+
+  it('migration file starts with BEGIN; (line-leading)', () => {
+    // First non-comment line should be BEGIN; — pre-commit hook STAGE 0.7 enforces this
+    const firstNonCommentLine = sql.split('\n').find(line => {
+      const trimmed = line.trim();
+      return trimmed && !trimmed.startsWith('--');
+    });
+    expect(firstNonCommentLine).toMatch(/^BEGIN;/);
+  });
+
+  it('migration file ends with COMMIT; (line-leading)', () => {
+    // Last non-empty non-comment line should be COMMIT;
+    const lines = sql.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('--'));
+    const last = lines[lines.length - 1];
+    expect(last).toMatch(/^COMMIT;/);
+  });
+
+  it('uses CREATE OR REPLACE FUNCTION (not DROP+CREATE) for atomicity + grant preservation', () => {
+    // 4 actual function definitions (one per `CREATE OR REPLACE FUNCTION <name>(`)
+    const definitions = (sql.match(/CREATE OR REPLACE FUNCTION \w+\(/g) || []).length;
+    expect(definitions).toBe(4);
+    // Negative-pin: no DROP FUNCTION should appear (would forfeit GRANTs)
+    expect(sql).not.toMatch(/DROP FUNCTION/i);
+  });
+
+  it('all 4 expected functions are replaced', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION create_or_replace_session/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION release_session/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION cleanup_stale_sessions/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION report_pid_validation_failure/);
+  });
+
+  it('every UPDATE strategic_directives_v2 SET … includes claiming_session_id = NULL (parity)', () => {
+    // Find every UPDATE strategic_directives_v2 block
+    const updateBlocks = sql.match(/UPDATE strategic_directives_v2[\s\S]+?(?=;|WHERE)/g) || [];
+    expect(updateBlocks.length).toBeGreaterThanOrEqual(4);
+    for (const block of updateBlocks) {
+      expect(block).toMatch(/active_session_id\s*=\s*NULL/);
+      expect(block).toMatch(/claiming_session_id\s*=\s*NULL/);
+      expect(block).toMatch(/is_working_on\s*=\s*false/);
+    }
+  });
+
+  it('every WHERE clause for SD release matches BOTH columns (active_session_id OR claiming_session_id)', () => {
+    // The WHERE clauses that follow strategic_directives_v2 UPDATEs should accept either link
+    // Find each "WHERE" block immediately following an UPDATE strategic_directives_v2
+    const fullUpdates = sql.match(/UPDATE strategic_directives_v2[\s\S]+?;/g) || [];
+    expect(fullUpdates.length).toBeGreaterThanOrEqual(4);
+    // At least 4 of them must scan both columns — covers FR-2/3/4/5
+    const dualColumnUpdates = fullUpdates.filter(stmt =>
+      /active_session_id\s*(?:=|IN)/.test(stmt) && /claiming_session_id\s*(?:=|IN)/.test(stmt)
+    );
+    expect(dualColumnUpdates.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('FR-5: report_pid_validation_failure has TWO UPDATEs in proper order (claude_sessions first, strategic_directives_v2 second)', () => {
+    // Locate the function body
+    const fnIdx = sql.indexOf('CREATE OR REPLACE FUNCTION report_pid_validation_failure');
+    expect(fnIdx).toBeGreaterThan(0);
+    // Body ends at the next $$ LANGUAGE
+    const bodyEnd = sql.indexOf('$$ LANGUAGE plpgsql;', fnIdx);
+    const body = sql.slice(fnIdx, bodyEnd);
+    const claudeSessionsUpdateIdx = body.indexOf('UPDATE claude_sessions');
+    const sdUpdateIdx = body.indexOf('UPDATE strategic_directives_v2');
+    expect(claudeSessionsUpdateIdx).toBeGreaterThan(0);
+    expect(sdUpdateIdx).toBeGreaterThan(claudeSessionsUpdateIdx); // SD second
+  });
+
+  it('FR-2: create_or_replace_session UPDATE filters by both columns via OR (not AND)', () => {
+    const fnIdx = sql.indexOf('CREATE OR REPLACE FUNCTION create_or_replace_session');
+    const bodyEnd = sql.indexOf('$$ LANGUAGE plpgsql;', fnIdx);
+    const body = sql.slice(fnIdx, bodyEnd);
+    // SD UPDATE must use OR (so a session linked via either column releases)
+    const sdUpdate = body.match(/UPDATE strategic_directives_v2[\s\S]+?;/);
+    expect(sdUpdate).not.toBeNull();
+    expect(sdUpdate[0]).toMatch(/\bOR\b/);
+  });
+
+  it('LANGUAGE plpgsql preserved (no SECURITY clause regression)', () => {
+    const lang = (sql.match(/\$\$ LANGUAGE plpgsql/g) || []).length;
+    expect(lang).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-3 SD, ~218 src + ~280 test LOC, 11/12 tests pass + 1 skipped (deferred via feedback d17b9b9f).

**11th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.** Pairs with QF-20260509-711 (Layer 2 consumer fail-open in lib/claim-validity-gate.js shipped via PR #3613).

### The bug
4 PG functions in 20260201_intelligent_session_lifecycle.sql historically cleared strategic_directives_v2.active_session_id but left claiming_session_id populated. claim-validity-gate then saw a foreign claim until Layer 2 auto-released it. report_pid_validation_failure didn't release the SD claim at all.

### The fix
New migration with BEGIN/COMMIT wrap and CREATE OR REPLACE FUNCTION (atomic, preserves grants):

- `create_or_replace_session`: clears BOTH columns when releasing previous session
- `release_session`: clears BOTH columns
- `cleanup_stale_sessions` (canonical, supersedes both prior definitions): clears BOTH columns in batch release
- `report_pid_validation_failure`: NEW conditional UPDATE clearing both columns scoped to `(active_session_id = p_session_id OR claiming_session_id = p_session_id)` — never blanket clobber

### Closes feedback
- 64e40594-4359-497c-a5e2-0bf795d6f1fa

### LEO Protocol
- testing-agent (LEAD prospective): APPROVE with 4 PRD decisions captured
- validation-agent (PLAN PRD): PASS with 2 minor concerns addressed
- testing-agent (EXEC retrospective): CONCERNS → cleared after AC-9 verification + AC-8 deferred-with-traceability
- LEAD-TO-PLAN: 93% PASS / 27 gates
- PLAN-TO-EXEC: 94% PASS / 24 gates
- EXEC-TO-PLAN: 93% PASS / 28 gates

### Test plan
- [x] 9/9 SQL static-guard tests
- [x] 2/2 integration round-trip + idempotency
- [x] 13/13 lib/claim-validity-gate.test.js regression (AC-9)
- [x] Migration applied cleanly to live DB
- [x] 1 test skipped (FR-4 orphan-claim e2e) — deferred via feedback d17b9b9f for shared-state isolation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)