### PR TITLE
feat(SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001): junction-safe brute-force fallback closes 3rd unsafe Windows-junction site

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -113,8 +113,8 @@ export class WorktreeBaseFetchFailedError extends Error {
   constructor({ baseRef, gitOutput, exitCode }) {
     super(
       `Failed to fetch worktree base ref '${baseRef}'. ` +
-      `Worktree creation refused (fail-closed). ` +
-      `Verify network access to origin or set LEO_WORKTREE_BASE_REF.`
+      'Worktree creation refused (fail-closed). ' +
+      'Verify network access to origin or set LEO_WORKTREE_BASE_REF.'
     );
     this.name = 'WorktreeBaseFetchFailedError';
     this.code = 'WORKTREE_BASE_FETCH_FAILED';
@@ -144,12 +144,12 @@ export class WorktreeForkDriftError extends Error {
     super(
       `${reasonLine} ` +
       `Reusing it would silently undo merged work.${sample}\n` +
-      `\n  Remediation (pick one):\n` +
+      '\n  Remediation (pick one):\n' +
       `    1. Rebase: git checkout ${branch} && git fetch origin && git rebase ${baseRef}\n` +
       `    2. Cherry-pick: list your commits via 'git log ${baseRef}..${branch}', then cherry-pick each onto a fresh branch off ${baseRef}\n` +
       `    3. Abandon-and-reset: git branch -D ${branch} && rerun sd-start (recreates from ${baseRef})\n` +
-      `\n  Override (NOT recommended for normal flow):\n` +
-      `    LEO_FORK_DRIFT_THRESHOLD_COMMITS=<higher> LEO_FORK_DRIFT_THRESHOLD_HOURS=<higher> rerun the operation.`
+      '\n  Override (NOT recommended for normal flow):\n' +
+      '    LEO_FORK_DRIFT_THRESHOLD_COMMITS=<higher> LEO_FORK_DRIFT_THRESHOLD_HOURS=<higher> rerun the operation.'
     );
     this.name = 'WorktreeForkDriftError';
     this.code = 'WORKTREE_FORK_DRIFT';
@@ -188,7 +188,7 @@ export function fetchBaseRef(repoRoot, baseRef) {
   if (slashIdx < 0) {
     throw new WorktreeBaseFetchFailedError({
       baseRef,
-      gitOutput: `baseRef must be of the form '<remote>/<branch>'`,
+      gitOutput: 'baseRef must be of the form \'<remote>/<branch>\'',
       exitCode: -1
     });
   }
@@ -500,8 +500,12 @@ export function rollbackWorktreeFilesystemSync(worktreePath, repoRoot, opts = {}
   }
 
   // Step 2: brute-force directory removal if git worktree remove never succeeded.
+  // SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001: routes through safeRecursiveRm
+  // (line 1052) instead of raw fs.rmSync — closes the 3rd unsafe Windows-junction site.
+  // Prior fixes (PR #3471 introducing the helper, PR #3590 patching reaper + hook)
+  // missed this brute-force fallback path.
   try {
-    fs.rmSync(worktreePath, { recursive: true, force: true });
+    safeRecursiveRm(worktreePath, { force: true });
     try {
       execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
     } catch {

--- a/tests/unit/lib/worktree-manager-internal-rmsync-guard.test.js
+++ b/tests/unit/lib/worktree-manager-internal-rmsync-guard.test.js
@@ -1,0 +1,222 @@
+/**
+ * AST-based static guard for lib/worktree-manager.js (internal scope).
+ *
+ * Complements tests/unit/lib/worktree-rmsync-junction-safety.test.js which
+ * scans scripts/ for raw fs.rmSync({recursive:true}) without junction safety.
+ * That guard is scoped to scripts/ only — this one targets the lib/ file
+ * itself with AST precision (catches multi-line, extracted-opts, and
+ * destructured-rmSync evasion patterns the regex-based scripts/ guard
+ * doesn't address).
+ *
+ * SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001 FR-2.
+ *
+ * Anchored on the safeRecursiveRm function declaration's source position
+ * (NOT hardcoded line numbers) — a future code shuffle that moves the
+ * helper still works.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from '@babel/parser';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TARGET_FILE = path.resolve(__dirname, '../../../lib/worktree-manager.js');
+
+function walkAst(node, visit) {
+  if (!node || typeof node !== 'object') return;
+  visit(node);
+  for (const key of Object.keys(node)) {
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const c of child) walkAst(c, visit);
+    } else if (child && typeof child === 'object' && child.type) {
+      walkAst(child, visit);
+    }
+  }
+}
+
+function resolveCalleeName(callee) {
+  if (!callee) return null;
+  if (callee.type === 'MemberExpression') {
+    const obj = callee.object?.name;
+    const prop = callee.property?.name ?? callee.property?.value;
+    if (obj && prop) return `${obj}.${prop}`;
+  }
+  if (callee.type === 'Identifier') return callee.name;
+  return null;
+}
+
+function objectHasRecursiveTrue(objectExpr) {
+  if (objectExpr?.type !== 'ObjectExpression') return false;
+  for (const prop of objectExpr.properties || []) {
+    if (prop.type !== 'ObjectProperty' && prop.type !== 'Property') continue;
+    const keyName = prop.key?.name ?? prop.key?.value;
+    const v = prop.value;
+    const isTrue =
+      (v?.type === 'BooleanLiteral' && v.value === true) ||
+      (v?.type === 'Literal' && v.value === true);
+    if (keyName === 'recursive' && isTrue) return true;
+  }
+  return false;
+}
+
+function findVariableInit(name, ast) {
+  let result = null;
+  walkAst(ast, (node) => {
+    if (node.type === 'VariableDeclarator' && node.id?.name === name && node.init) {
+      result = node.init;
+    }
+  });
+  return result;
+}
+
+function findRecursiveRmSyncCalls(ast) {
+  const matches = [];
+  walkAst(ast, (node) => {
+    if (node.type !== 'CallExpression') return;
+    const calleeName = resolveCalleeName(node.callee);
+    if (!['fs.rmSync', 'rmSync'].includes(calleeName)) return;
+    const args = node.arguments || [];
+    if (args.length < 2) return;
+    const opts = args[1];
+    let recursive = false;
+    if (opts.type === 'ObjectExpression') {
+      recursive = objectHasRecursiveTrue(opts);
+    } else if (opts.type === 'Identifier') {
+      const init = findVariableInit(opts.name, ast);
+      if (init && init.type === 'ObjectExpression') {
+        recursive = objectHasRecursiveTrue(init);
+      }
+    }
+    if (recursive) matches.push(node);
+  });
+  return matches;
+}
+
+function findSafeRecursiveRmRange(ast) {
+  let range = null;
+  walkAst(ast, (node) => {
+    const fn =
+      node.type === 'FunctionDeclaration' && node.id?.name === 'safeRecursiveRm'
+        ? node
+        : node.type === 'ExportNamedDeclaration' &&
+          node.declaration?.type === 'FunctionDeclaration' &&
+          node.declaration.id?.name === 'safeRecursiveRm'
+        ? node.declaration
+        : null;
+    if (fn) range = { start: fn.start, end: fn.end };
+  });
+  return range;
+}
+
+describe('lib/worktree-manager.js internal fs.rmSync({recursive:true}) AST guard', () => {
+  it('every recursive fs.rmSync sits within safeRecursiveRm body', () => {
+    const src = fs.readFileSync(TARGET_FILE, 'utf8');
+    const ast = parse(src, { sourceType: 'module', errorRecovery: false });
+
+    const safeRange = findSafeRecursiveRmRange(ast);
+    expect(safeRange, 'safeRecursiveRm export not found').not.toBeNull();
+
+    const calls = findRecursiveRmSyncCalls(ast);
+    const violations = [];
+    for (const node of calls) {
+      const inSafeHelper = node.start >= safeRange.start && node.end <= safeRange.end;
+      if (inSafeHelper) continue;
+      const before = src.slice(0, node.start).split('\n');
+      const line = before.length;
+      const col = before[before.length - 1].length + 1;
+      violations.push({
+        line,
+        col,
+        snippet: src.slice(node.start, Math.min(node.end, node.start + 120)).replace(/\s+/g, ' '),
+      });
+    }
+
+    if (violations.length > 0) {
+      const formatted = violations
+        .map((v) => `  ${TARGET_FILE}:${v.line}:${v.col} — ${v.snippet}`)
+        .join('\n');
+      throw new Error(
+        `[WORKTREE_RAW_RM_OUTSIDE_SAFE_HELPER] ${violations.length} raw fs.rmSync({recursive:true}) call(s) in lib/worktree-manager.js OUTSIDE the safeRecursiveRm function body:\n${formatted}\n\nUse safeRecursiveRm(path, { force: true }) instead.`
+      );
+    }
+  });
+
+  function runGuardOnSource(source) {
+    const ast = parse(source, { sourceType: 'module', errorRecovery: false });
+    const safeRange = findSafeRecursiveRmRange(ast);
+    const calls = findRecursiveRmSyncCalls(ast);
+    let outside = 0;
+    for (const node of calls) {
+      if (!safeRange || node.start < safeRange.start || node.end > safeRange.end) {
+        outside++;
+      }
+    }
+    return outside;
+  }
+
+  it('catches multi-line {recursive:true} call', () => {
+    expect(
+      runGuardOnSource(`
+        import fs from 'node:fs';
+        function bad() {
+          fs.rmSync(
+            '/some/path',
+            {
+              recursive: true,
+              force: true,
+            }
+          );
+        }
+      `)
+    ).toBe(1);
+  });
+
+  it('catches extracted opts variable', () => {
+    expect(
+      runGuardOnSource(`
+        import fs from 'node:fs';
+        function bad() {
+          const opts = { recursive: true, force: true };
+          fs.rmSync('/some/path', opts);
+        }
+      `)
+    ).toBe(1);
+  });
+
+  it('catches destructured rmSync from fs', () => {
+    expect(
+      runGuardOnSource(`
+        import { rmSync } from 'node:fs';
+        function bad() {
+          rmSync('/some/path', { recursive: true, force: true });
+        }
+      `)
+    ).toBe(1);
+  });
+
+  it('does NOT flag non-recursive fs.rmSync calls', () => {
+    expect(
+      runGuardOnSource(`
+        import fs from 'node:fs';
+        function ok() {
+          fs.rmSync('/some/path', { force: true });
+          fs.rmSync('/file.txt');
+        }
+      `)
+    ).toBe(0);
+  });
+
+  it('does NOT flag calls inside safeRecursiveRm helper definition', () => {
+    expect(
+      runGuardOnSource(`
+        import fs from 'node:fs';
+        export function safeRecursiveRm(targetPath, options = {}) {
+          fs.rmSync(targetPath, { recursive: true, force: true });
+        }
+      `)
+    ).toBe(0);
+  });
+});

--- a/tests/unit/lib/worktree-removeWorktreeDir-junction.test.js
+++ b/tests/unit/lib/worktree-removeWorktreeDir-junction.test.js
@@ -1,0 +1,172 @@
+/**
+ * Integration test for rollbackWorktreeFilesystemSync brute-force fallback path.
+ * SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001 FR-3.
+ *
+ * Strategy:
+ *  - Outer describe runs on ALL platforms: creates a temp git repo + worktree,
+ *    locks the worktree (via .git/worktrees/<name>/locked file — git-native),
+ *    calls rollbackWorktreeFilesystemSync, asserts result.fellBackToRmSync===true.
+ *  - Inner describe runs only when junction creation succeeds (Windows with
+ *    appropriate privileges). Creates a node_modules junction inside the
+ *    worktree pointing to a sibling tempdir holding marker files; after
+ *    rollback runs, asserts the SIBLING tempdir + markers survive (i.e.,
+ *    safeRecursiveRm correctly unlinked the junction without recursing into it).
+ *
+ * Soft-skip pattern follows tests/unit/worktree-manager.test.js:386-393:
+ *  try fs.symlinkSync(...,'junction'); catch -> early return with notice.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { rollbackWorktreeFilesystemSync } from '../../../lib/worktree-manager.js';
+
+const TMP_BASE = path.join(os.tmpdir(), `worktree-junction-test-${crypto.randomUUID().slice(0, 8)}`);
+
+function safeRm(p) {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function setupTestRepo() {
+  fs.mkdirSync(TMP_BASE, { recursive: true });
+  const repoRoot = path.join(TMP_BASE, 'repo');
+  const worktreePath = path.join(TMP_BASE, 'worktree');
+  fs.mkdirSync(repoRoot, { recursive: true });
+
+  execSync('git init -q', { cwd: repoRoot, stdio: 'pipe' });
+  execSync('git config user.email test@example.com', { cwd: repoRoot, stdio: 'pipe' });
+  execSync('git config user.name Test', { cwd: repoRoot, stdio: 'pipe' });
+
+  // Initial commit so HEAD exists
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), '# test\n');
+  execSync('git add README.md', { cwd: repoRoot, stdio: 'pipe' });
+  execSync('git commit -q -m init', { cwd: repoRoot, stdio: 'pipe' });
+
+  execSync(`git worktree add -q -b junction-test "${worktreePath}"`, {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  });
+
+  return { repoRoot, worktreePath };
+}
+
+function lockWorktreeViaFile(repoRoot, worktreePath) {
+  // .git/worktrees/<name>/locked — git's native worktree-lock file.
+  // Causes `git worktree remove --force` to error with "is locked".
+  const wtName = path.basename(worktreePath);
+  const lockedPath = path.join(repoRoot, '.git', 'worktrees', wtName, 'locked');
+  fs.writeFileSync(lockedPath, 'integration test — forcing brute-force fallback\n');
+  return lockedPath;
+}
+
+describe('rollbackWorktreeFilesystemSync — brute-force fallback (cross-platform)', () => {
+  let env;
+
+  beforeAll(() => {
+    env = setupTestRepo();
+  });
+
+  afterAll(() => {
+    safeRm(TMP_BASE);
+  });
+
+  it('falls back to safeRecursiveRm when git worktree remove fails (locked worktree)', () => {
+    lockWorktreeViaFile(env.repoRoot, env.worktreePath);
+
+    // Sanity: worktree dir exists before rollback
+    expect(fs.existsSync(env.worktreePath)).toBe(true);
+
+    const result = rollbackWorktreeFilesystemSync(env.worktreePath, env.repoRoot, {
+      maxAttempts: 2,
+      delaysMs: [10],
+    });
+
+    // Brute-force path executed
+    expect(result.fellBackToRmSync).toBe(true);
+    // Worktree dir is gone
+    expect(fs.existsSync(env.worktreePath)).toBe(false);
+  });
+});
+
+describe('rollbackWorktreeFilesystemSync — junction TARGET preservation (Windows-only)', () => {
+  // Soft-skip pattern: try junction creation; if it fails (non-Windows OR
+  // Windows-without-admin), early-return with notice. Mirrors existing
+  // tests/unit/worktree-manager.test.js:386-393.
+
+  it('junction TARGET tempdir + marker files survive after rollback', () => {
+    const baseDir = path.join(os.tmpdir(), `wt-junction-survival-${crypto.randomUUID().slice(0, 8)}`);
+    const repoRoot = path.join(baseDir, 'repo');
+    const worktreePath = path.join(baseDir, 'worktree');
+    const targetTempdir = path.join(baseDir, 'junction-target');
+
+    try {
+      // Setup git repo + worktree.
+      fs.mkdirSync(repoRoot, { recursive: true });
+      execSync('git init -q', { cwd: repoRoot, stdio: 'pipe' });
+      execSync('git config user.email test@example.com', { cwd: repoRoot, stdio: 'pipe' });
+      execSync('git config user.name Test', { cwd: repoRoot, stdio: 'pipe' });
+      fs.writeFileSync(path.join(repoRoot, 'README.md'), '# test\n');
+      execSync('git add README.md', { cwd: repoRoot, stdio: 'pipe' });
+      execSync('git commit -q -m init', { cwd: repoRoot, stdio: 'pipe' });
+      execSync(`git worktree add -q -b junction-survival-test "${worktreePath}"`, {
+        cwd: repoRoot,
+        stdio: 'pipe',
+      });
+
+      // Create a sibling tempdir to be the junction TARGET.
+      fs.mkdirSync(targetTempdir, { recursive: true });
+      const markerPath = path.join(targetTempdir, 'survives.txt');
+      fs.writeFileSync(markerPath, 'this file must still exist after rollback');
+
+      // Try to create the junction. If this throws (non-Windows or no admin),
+      // soft-skip with a notice (mirrors tests/unit/worktree-manager.test.js:386-393).
+      const junctionPath = path.join(worktreePath, 'node_modules');
+      try {
+        fs.symlinkSync(targetTempdir, junctionPath, 'junction');
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[soft-skip] junction creation unavailable on this platform/privileges: ${err.message}. ` +
+            'Skipping Windows-only junction-target survival assertion.'
+        );
+        safeRm(baseDir);
+        return;
+      }
+
+      // Force git remove failure via .locked file.
+      const wtName = path.basename(worktreePath);
+      fs.writeFileSync(
+        path.join(repoRoot, '.git', 'worktrees', wtName, 'locked'),
+        'forcing brute-force fallback\n'
+      );
+
+      // Sanity checks.
+      expect(fs.existsSync(worktreePath)).toBe(true);
+      expect(fs.existsSync(junctionPath)).toBe(true);
+      expect(fs.existsSync(markerPath)).toBe(true);
+
+      // Run rollback — must hit brute-force path.
+      const result = rollbackWorktreeFilesystemSync(worktreePath, repoRoot, {
+        maxAttempts: 2,
+        delaysMs: [10],
+      });
+
+      expect(result.fellBackToRmSync).toBe(true);
+      expect(fs.existsSync(worktreePath)).toBe(false);
+      // KEY ASSERTION: the junction TARGET tempdir + marker file must survive.
+      expect(fs.existsSync(targetTempdir)).toBe(true);
+      expect(fs.existsSync(markerPath)).toBe(true);
+      const markerContents = fs.readFileSync(markerPath, 'utf8');
+      expect(markerContents).toBe('this file must still exist after rollback');
+    } finally {
+      safeRm(baseDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces raw `fs.rmSync(path, { recursive: true, force: true })` at `lib/worktree-manager.js:504` with `safeRecursiveRm(path, { force: true })` (helper exists in same file at line 1052).
- Closes the 3rd and final unsafe Windows-junction-following site in the worktree-cleanup family. PRs #3471 + #3590 closed 2 of 3 sites; this one was the brute-force fallback in `rollbackWorktreeFilesystemSync` after `git worktree remove` retries fail.
- Adds AST-based static guard (catches multi-line/extracted-opts/destructured evasion patterns the existing regex-based `scripts/` guard doesn't cover) + cross-platform integration test using git-native `.git/worktrees/<name>/locked` lock + Windows-only junction-target survival assertion.
- Persists `PAT-WINDOWS-JUNCTION-FOLLOW-RECURSIVE-RM-001` row in `issue_patterns` (occurrence_count=3, status=active) capturing the 3-witness arc.

## Source incident
Feedback `3ac6ad55` — node_modules wiped 2× in 93m during session `c9e09624` (2026-05-09). Coordinator sessions reportedly hit it 3× in 20m prior. On Windows, `fs.rmSync({recursive:true,force:true})` follows junction reparse points and recursively deletes the junction TARGET; worktrees use junctions to share `node_modules` with the main checkout, so the wipe brick'd every parallel session until `npm install` recovered (799 packages, ~17-45s).

## Test plan
- [x] `npx vitest run tests/unit/lib/worktree-manager-internal-rmsync-guard.test.js` — 6/6 pass (AST guard + 4 evasion-pattern fixtures + 1 negative + 1 helper-allowlist).
- [x] `npx vitest run tests/unit/lib/worktree-removeWorktreeDir-junction.test.js` — 2/2 pass (cross-platform fall-through + Windows-only junction TARGET survival).
- [x] No regression in lib/ test suites (4 pre-existing failures in `tests/unit/worktree-manager.test.js` for createWorktree post-condition checking on Windows paths are unrelated — confirmed by stash'd-baseline run).
- [ ] CI vitest unit + integration green.

## Sub-agent evidence
- `02fec8cf` (testing-agent at LEAD prospective on the prior cancelled SD — diagnostic)
- `14f17c16` (testing-agent at LEAD prospective on this SD — 8 findings, 4 absorbed inline)
- `292884a5` (validation-agent at PLAN PRD prospective — caught `issue_patterns` schema mismatch as BLOCKING; corrected before EXEC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)