### PR TITLE
fix(QF-20260509-CANCEL-SD-COLDROP): drop non-existent cancelled_at from cancel-sd.js UPDATE

### DIFF
--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -35,7 +35,7 @@ Atomically cancels an SD:
   - cancellation_reason set (required)
   - claiming_session_id cleared
   - is_working_on=false
-  - cancelled_at=NOW
+  - updated_at=NOW (trigger-managed cancellation timestamp)
   - claude_sessions row for the holder released
 
 Required:
@@ -90,13 +90,17 @@ async function cancelSD(sd, reason) {
   }
 
   const claimedSessionId = sd.claiming_session_id;
+  // QF-20260509-CANCEL-SD-COLDROP: strategic_directives_v2 has no dedicated
+  // cancelled_at column — original PR #3625 INSERT shape included it,
+  // causing PGRST204 "Could not find the 'cancelled_at' column" schema-cache
+  // error on first canonical use. updated_at is trigger-managed; cancellation
+  // timestamp is recoverable from updated_at WHERE status='cancelled'.
   const updates = {
     status: 'cancelled',
     current_phase: 'CANCELLED',
     cancellation_reason: reason,
     claiming_session_id: null,
     is_working_on: false,
-    cancelled_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   };
 

--- a/tests/unit/harness/cancel-sd-script.test.js
+++ b/tests/unit/harness/cancel-sd-script.test.js
@@ -70,4 +70,13 @@ describe('QF-20260509-CANCEL-SD: cancel-sd.js canonical script', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
     expect(pkg.scripts['sd:cancel']).toBe('node scripts/cancel-sd.js');
   });
+
+  it('QF-COLDROP regression-pin: updates object does NOT include cancelled_at (column does not exist on strategic_directives_v2)', () => {
+    const src = fs.readFileSync(scriptPath, 'utf-8');
+    const idx = src.indexOf('const updates = {');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 500);
+    expect(block).not.toMatch(/cancelled_at\s*:/);
+    expect(block).toMatch(/updated_at\s*:\s*new Date\(\)\.toISOString\(\)/);
+  });
 });


### PR DESCRIPTION
## Summary
Tier-1, ~3 src + ~12 test LOC, 10/10 vitest pass.

scripts/cancel-sd.js shipped via PR #3625 included \`cancelled_at\` in the UPDATE object, but strategic_directives_v2 has no such column. First canonical use today errored with PGRST204 schema-cache: "Could not find the 'cancelled_at' column".

**Self-validating ship caught its own bug** — attempted to use cancel-sd.js to cancel a misframed SD and hit the schema error.

## Fix
Remove \`cancelled_at\` from updates object. \`updated_at\` is trigger-managed; cancellation timestamp recoverable from \`updated_at WHERE status='cancelled'\`.

## Test plan
- [x] 10/10 tests (9 existing + 1 new regression-pin)
- [x] --help smoke test verified text updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)