### PR TITLE
fix(QF-20260509-ASSIST-PEER-LEAK): assist-engine context-analyzer scopes is_working_on by current session

### DIFF
--- a/lib/quality/context-analyzer.js
+++ b/lib/quality/context-analyzer.js
@@ -52,10 +52,23 @@ async function getRecentSDContext(options = {}) {
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - daysBack);
 
+  // QF-20260509-ASSIST-PEER-LEAK (closes 1462a0a2): scope is_working_on=true
+  // matches to the CURRENT session's claim. Without this, /leo assist saw
+  // peer-session is_working_on rows and prioritized fixes "related to current
+  // SD work" using a peer's SD, biasing autonomous fix order. Source of truth
+  // for "currently working on this session" is claiming_session_id matching
+  // process.env.CLAUDE_SESSION_ID. When CLAUDE_SESSION_ID is unset, we fall
+  // back to the original query (no session scoping) — this keeps non-claim
+  // contexts (e.g. CLI inspectors) functional.
+  const currentSessionId = process.env.CLAUDE_SESSION_ID || null;
+  const isWorkingOnFilter = currentSessionId
+    ? `and(is_working_on.eq.true,claiming_session_id.eq.${currentSessionId})`
+    : 'is_working_on.eq.true';
+
   const { data: recentSDs, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, description, sd_type, current_phase, updated_at, is_working_on')
-    .or(`is_working_on.eq.true,updated_at.gte.${cutoffDate.toISOString()}`)
+    .select('id, sd_key, title, description, sd_type, current_phase, updated_at, is_working_on, claiming_session_id')
+    .or(`${isWorkingOnFilter},updated_at.gte.${cutoffDate.toISOString()}`)
     .not('status', 'in', '(completed,cancelled)')
     .order('updated_at', { ascending: false })
     .limit(limit);

--- a/tests/unit/harness/assist-peer-leak.test.js
+++ b/tests/unit/harness/assist-peer-leak.test.js
@@ -1,0 +1,53 @@
+// QF-20260509-ASSIST-PEER-LEAK: assist-engine context summary must NOT
+// surface peer's is_working_on=true rows. Filter by CLAUDE_SESSION_ID.
+// Closes feedback 1462a0a2.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const srcFile = path.join(repoRoot, 'lib/quality/context-analyzer.js');
+
+describe('QF-20260509-ASSIST-PEER-LEAK: getRecentSDContext session scoping', () => {
+  let src;
+  beforeAll(() => {
+    src = fs.readFileSync(srcFile, 'utf-8');
+  });
+
+  it('reads CLAUDE_SESSION_ID from env to scope is_working_on filter', () => {
+    expect(src).toMatch(/process\.env\.CLAUDE_SESSION_ID/);
+  });
+
+  it('builds isWorkingOnFilter with claiming_session_id match when session present', () => {
+    expect(src).toMatch(/claiming_session_id\.eq\.\$\{currentSessionId\}/);
+    // Uses postgrest "and()" composition to AND the two conditions
+    expect(src).toMatch(/and\(is_working_on\.eq\.true,claiming_session_id\.eq/);
+  });
+
+  it('falls back to plain is_working_on.eq.true when session not set (no regression for CLI inspectors)', () => {
+    // Locate the function and check the fallback branch
+    const idx = src.indexOf('async function getRecentSDContext');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 1500);
+    expect(block).toMatch(/currentSessionId\s*\?[\s\S]+?:\s*['"]is_working_on\.eq\.true['"]/);
+  });
+
+  it('SELECT now includes claiming_session_id (consumers can re-verify scoping)', () => {
+    const idx = src.indexOf('async function getRecentSDContext');
+    const block = src.slice(idx, idx + 1500);
+    expect(block).toMatch(/\.select\([^)]*claiming_session_id/);
+  });
+
+  it('regression-pin: plain unbounded `is_working_on.eq.true` is gone from the query path', () => {
+    const idx = src.indexOf('async function getRecentSDContext');
+    const block = src.slice(idx, idx + 1500);
+    // The pre-fix pattern was `.or(\`is_working_on.eq.true,updated_at...\`)`
+    // The post-fix pattern uses `${isWorkingOnFilter}` template var
+    expect(block).toMatch(/\$\{isWorkingOnFilter\}/);
+    // Must NOT have the pre-fix bare leading is_working_on.eq.true followed by comma
+    expect(block).not.toMatch(/\.or\(`is_working_on\.eq\.true,updated_at/);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~12 src + ~50 test LOC, 5/5 vitest pass.

\`lib/quality/context-analyzer.js getRecentSDContext()\` matched \`is_working_on=true\` rows across all sessions. /leo assist surfaced peer sessions' active SDs as "currently working on", biasing autonomous fix order.

**Fix:** scope \`is_working_on=true\` matches to current session via \`claiming_session_id = process.env.CLAUDE_SESSION_ID\` (when set). Falls back to plain \`is_working_on.eq.true\` when env unset (CLI inspectors).

## Closes
feedback 1462a0a2-cb77-4465-a41b-1b7b3d3df55d

## Test plan
- [x] CLAUDE_SESSION_ID read from env
- [x] PostgREST and() composition with claiming_session_id
- [x] fallback when env unset
- [x] SELECT includes claiming_session_id
- [x] regression-pin against unbounded query

🤖 Generated with [Claude Code](https://claude.com/claude-code)