### PR TITLE
fix(QF-20260509-PRMERGE-EXACT): PR_MERGE_VERIFICATION + PR_PRECHECK exact-match regex on branch names

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -449,6 +449,12 @@ export function createPRPrecheckGate() {
 
       const sdId = ctx.sd.sd_key || ctx.sd.id;
       const branchPatterns = [`feat/${sdId}`, `fix/${sdId}`, `docs/${sdId}`, `test/${sdId}`];
+      // QF-20260509-PRMERGE-EXACT (closes 9d55499d): exact-match regex anchored
+      // at start AND end. Pre-fix `.includes(pattern)` matched extended-suffix
+      // sibling branches (e.g. `feat/SD-X-001-stage-25-foo` matched query for
+      // SD-X-001 because headRefName.includes("feat/SD-X-001") returned true).
+      const sdIdEscaped = sdId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const exactBranchRegex = new RegExp(`^(feat|fix|docs|test)/${sdIdEscaped}$`, 'i');
 
       try {
         const { execSync } = await import('child_process');
@@ -461,9 +467,7 @@ export function createPRPrecheckGate() {
               { encoding: 'utf8', timeout: 15000 }
             );
             const prs = JSON.parse(result || '[]');
-            const matching = prs.filter(pr =>
-              branchPatterns.some(p => pr.headRefName.toLowerCase().includes(p.toLowerCase()))
-            );
+            const matching = prs.filter(pr => exactBranchRegex.test(pr.headRefName));
 
             if (matching.length > 0) {
               console.log(`   ❌ Open PR(s) found in ${repo} — run /ship first`);
@@ -515,13 +519,22 @@ export function createPRMergeVerificationGate() {
 
       const sdId = ctx.sd.sd_key || ctx.sd.id;
 
-      // Build expected branch name pattern for this SD
+      // Build expected branch name pattern for this SD (kept for logging downstream).
       const branchPatterns = [
         `feat/${sdId}`,
         `fix/${sdId}`,
         `docs/${sdId}`,
         `test/${sdId}`
       ];
+
+      // QF-20260509-PRMERGE-EXACT (closes 9d55499d): exact-match regex anchored
+      // at start AND end of branch name. Pre-fix `.includes(pattern)` matched
+      // sibling branches with extended-suffix names. Witnessed 2026-05-07
+      // SD-LEO-FEAT-STAGE-POST-LAUNCH-002 LEAD-FINAL-APPROVAL: orphan branch
+      // in non-target repo with different SD's commits caused false-positive
+      // block requiring explicit DELETE to unwedge.
+      const sdIdEscaped = sdId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const exactBranchRegex = new RegExp(`^(feat|fix|docs|test)/${sdIdEscaped}$`, 'i');
 
       try {
         const { execSync } = await import('child_process');
@@ -540,11 +553,9 @@ export function createPRMergeVerificationGate() {
 
             const prs = JSON.parse(result || '[]');
 
-            const matchingPRs = prs.filter(pr =>
-              branchPatterns.some(pattern =>
-                pr.headRefName.toLowerCase().includes(pattern.toLowerCase())
-              )
-            );
+            // QF-20260509-PRMERGE-EXACT: anchored regex (not includes) rejects
+            // extended-suffix sibling branches.
+            const matchingPRs = prs.filter(pr => exactBranchRegex.test(pr.headRefName));
 
             if (matchingPRs.length > 0) {
               openPRs.push(...matchingPRs.map(pr => ({
@@ -605,10 +616,17 @@ export function createPRMergeVerificationGate() {
 
             const branchList = execSync('git branch -r', { encoding: 'utf8', cwd: repoPath, timeout: 10000 });
 
-            for (const pattern of branchPatterns) {
+            // QF-20260509-PRMERGE-EXACT: per-branch exact-match instead of
+            // per-pattern .includes() (collapses 4 pattern iterations into 1
+            // regex test per branch).
+            {
               const matchingBranches = branchList.split('\n')
                 .map(b => b.trim())
-                .filter(b => b.toLowerCase().includes(pattern.toLowerCase()) && !b.includes('HEAD'));
+                .filter(b => {
+                  if (!b || b.includes('HEAD')) return false;
+                  const branchName = b.replace(/^origin\//, '');
+                  return exactBranchRegex.test(branchName);
+                });
 
               for (const branch of matchingBranches) {
                 const cleanBranch = branch.replace('origin/', '');

--- a/tests/unit/harness/prmerge-exact-match.test.js
+++ b/tests/unit/harness/prmerge-exact-match.test.js
@@ -1,0 +1,64 @@
+// QF-20260509-PRMERGE-EXACT: PR_MERGE_VERIFICATION + PR_PRECHECK gates must
+// use exact-match regex (anchored at ^ and $) instead of .includes(pattern)
+// for branch-name matching. Closes feedback 9d55499d.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const gatesFile = path.join(repoRoot, 'scripts/modules/handoff/executors/lead-final-approval/gates.js');
+
+describe('QF-20260509-PRMERGE-EXACT: branch-name matching anchors prefix and SD-key', () => {
+  let src;
+  beforeAll(() => {
+    src = fs.readFileSync(gatesFile, 'utf-8');
+  });
+
+  it('builds exactBranchRegex with ^ and $ anchors (anchored)', () => {
+    expect(src).toMatch(/exactBranchRegex\s*=\s*new RegExp\(`\^\(feat\|fix\|docs\|test\)\/\$\{sdIdEscaped\}\$`/);
+  });
+
+  it('escapes regex metacharacters in sdId before building the regex', () => {
+    expect(src).toMatch(/sdIdEscaped\s*=\s*sdId\.replace/);
+  });
+
+  it('PR_MERGE_VERIFICATION gate filters PRs via exactBranchRegex.test (not includes)', () => {
+    const idx = src.indexOf("name: 'PR_MERGE_VERIFICATION'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 4000);
+    expect(block).toMatch(/prs\.filter\(pr => exactBranchRegex\.test\(pr\.headRefName\)\)/);
+  });
+
+  it('PR_PRECHECK gate filters PRs via exactBranchRegex.test (not includes)', () => {
+    const idx = src.indexOf("name: 'PR_PRECHECK'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 2500);
+    expect(block).toMatch(/prs\.filter\(pr => exactBranchRegex\.test\(pr\.headRefName\)\)/);
+  });
+
+  it('unmerged-branch-list scan strips origin/ prefix before regex test', () => {
+    const idx = src.indexOf("git branch -r");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 1500);
+    expect(block).toMatch(/branchName\s*=\s*b\.replace/);
+    expect(block).toMatch(/exactBranchRegex\.test\(branchName\)/);
+  });
+
+  it('regression-pin: pre-fix bare `branchPatterns.some(p => ...includes(p)` removed from PR-filtering paths', () => {
+    expect(src).not.toMatch(/prs\.filter\(pr =>\s*branchPatterns\.some\(/);
+  });
+
+  it('exactBranchRegex distinguishes exact vs extended-suffix names (behavioral simulation)', () => {
+    const sdId = 'SD-LEO-FEAT-STAGE-POST-LAUNCH-002';
+    const sdIdEscaped = sdId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`^(feat|fix|docs|test)/${sdIdEscaped}$`, 'i');
+    expect(re.test('feat/SD-LEO-FEAT-STAGE-POST-LAUNCH-002')).toBe(true);
+    expect(re.test('fix/SD-LEO-FEAT-STAGE-POST-LAUNCH-002')).toBe(true);
+    expect(re.test('feat/SD-LEO-FEAT-STAGE-POST-LAUNCH-002-stage-25-post-launch-review-ehg-frontend')).toBe(false);
+    expect(re.test('feat/SD-LEO-FEAT-STAGE-POST-LAUNCH-003')).toBe(false);
+    expect(re.test('chore/SD-LEO-FEAT-STAGE-POST-LAUNCH-002')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Tier-1, ~25 src + ~70 test LOC, 7/7 vitest pass.

\`scripts/modules/handoff/executors/lead-final-approval/gates.js\` — both PR_MERGE_VERIFICATION + PR_PRECHECK gates used \`.includes(pattern)\` for branch-name matching. False-positive matched sibling branches with extended-suffix names. Witnessed 2026-05-07 SD-LEO-FEAT-STAGE-POST-LAUNCH-002 — orphan branch in non-target repo with different SD's commits caused false-positive block requiring explicit DELETE.

**Fix:** anchored regex \`^(feat|fix|docs|test)/<sd-key>$\` at start AND end. SD-key metacharacters escaped before regex construction. Applied to all 3 sites (precheck, main gate, unmerged-branch scan).

## Closes
feedback 9d55499d-8c2f-43a8-8edc-10e6f479f96e

## Test plan
- [x] anchored regex pin
- [x] sdId metacharacter escaping
- [x] PR_MERGE_VERIFICATION exactBranchRegex.test
- [x] PR_PRECHECK exactBranchRegex.test
- [x] unmerged-branch scan strips origin/ prefix
- [x] regression-pin: branchPatterns.some(...includes()) gone
- [x] behavioral simulation: exact vs extended-suffix vs different SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)