### PR TITLE
fix(QF-20260509-235): emit WORKTREE_BRUTE_FORCE_FALLBACK_OK telemetry on brute-force rescue path

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -584,6 +584,32 @@ export async function rollbackWorktreeCreation(worktreePath, sessionId, opts = {
     return { ok: false, deferred: true, attempts: fsResult.attempts, lastError: fsResult.lastError };
   }
 
+  // QF-20260509-235: emit telemetry on the brute-force success path so operators
+  // can measure how often `git worktree remove` is refusing to remove (file
+  // locks, dirty files, contention) and the brute-force fallback is rescuing.
+  // Without this, only failures emit (WORKTREE_ROLLBACK_DEFERRED above) — successes
+  // are invisible. Distinct event_type so dashboards separate "rescued" from "deferred".
+  if (fsResult.fellBackToRmSync) {
+    try {
+      const { createSupabaseServiceClient } = await import('../scripts/lib/supabase-connection.js');
+      const supabase = opts.supabase || await createSupabaseServiceClient('engineer');
+      await supabase.from('session_lifecycle_events').insert({
+        event_type: 'WORKTREE_BRUTE_FORCE_FALLBACK_OK',
+        session_id: sessionId || null,
+        reason: 'git_worktree_remove_refused_brute_force_rescued',
+        metadata: {
+          path: worktreePath,
+          original_error: opts.originalError?.message || null,
+          attempts_made: fsResult.attempts,
+          last_error: fsResult.lastError,
+        },
+      });
+    } catch {
+      // Audit emission is best-effort; never let a logging failure mask the
+      // original rollback success to the operator.
+    }
+  }
+
   return { ok: true, deferred: false, attempts: fsResult.attempts, lastError: fsResult.lastError };
 }
 

--- a/tests/unit/lib/worktree-rollback-brute-force-telemetry.test.js
+++ b/tests/unit/lib/worktree-rollback-brute-force-telemetry.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit test: rollbackWorktreeCreation emits WORKTREE_BRUTE_FORCE_FALLBACK_OK
+ * to session_lifecycle_events when the brute-force fallback rescues a worktree
+ * that `git worktree remove --force` refused to delete.
+ *
+ * QF-20260509-235 — closes the observability gap from
+ * SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001 testing-agent finding #7.
+ *
+ * Strategy: inject a mock Supabase + a temp git repo + a locked worktree.
+ * Assert the success path inserts a session_lifecycle_events row with the
+ * expected event_type and metadata.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { rollbackWorktreeCreation } from '../../../lib/worktree-manager.js';
+
+const TMP_BASE = path.join(os.tmpdir(), `wt-brute-tel-${crypto.randomUUID().slice(0, 8)}`);
+
+function safeRm(p) {
+  try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+function buildMockSupabase() {
+  const inserts = [];
+  const supabase = {
+    from: vi.fn().mockImplementation((table) => ({
+      insert: vi.fn().mockImplementation((row) => {
+        inserts.push({ table, row });
+        return { select: vi.fn().mockResolvedValue({ data: [row], error: null }) };
+      }),
+    })),
+  };
+  return { supabase, inserts };
+}
+
+describe('rollbackWorktreeCreation — brute-force success telemetry (QF-20260509-235)', () => {
+  let env;
+
+  beforeAll(() => {
+    fs.mkdirSync(TMP_BASE, { recursive: true });
+    const repoRoot = path.join(TMP_BASE, 'repo');
+    const worktreePath = path.join(TMP_BASE, 'worktree');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    execSync('git init -q', { cwd: repoRoot, stdio: 'pipe' });
+    execSync('git config user.email test@example.com', { cwd: repoRoot, stdio: 'pipe' });
+    execSync('git config user.name Test', { cwd: repoRoot, stdio: 'pipe' });
+    fs.writeFileSync(path.join(repoRoot, 'README.md'), '# test\n');
+    execSync('git add README.md', { cwd: repoRoot, stdio: 'pipe' });
+    execSync('git commit -q -m init', { cwd: repoRoot, stdio: 'pipe' });
+    execSync(`git worktree add -q -b brute-tel-test "${worktreePath}"`, { cwd: repoRoot, stdio: 'pipe' });
+    // Force git worktree remove to fail via .locked file
+    const wtName = path.basename(worktreePath);
+    fs.writeFileSync(
+      path.join(repoRoot, '.git', 'worktrees', wtName, 'locked'),
+      'forcing brute-force fallback for telemetry test\n'
+    );
+    env = { repoRoot, worktreePath };
+  });
+
+  afterAll(() => safeRm(TMP_BASE));
+
+  it('emits WORKTREE_BRUTE_FORCE_FALLBACK_OK with correct shape on brute-force success', async () => {
+    const { supabase, inserts } = buildMockSupabase();
+
+    const result = await rollbackWorktreeCreation(env.worktreePath, 'test-session-001', {
+      repoRoot: env.repoRoot,
+      supabase,
+      delaysMs: [10],
+      originalError: new Error('test rollback context'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.deferred).toBe(false);
+
+    const evRows = inserts.filter((i) => i.table === 'session_lifecycle_events');
+    expect(evRows.length).toBeGreaterThanOrEqual(1);
+
+    const successEvent = evRows.find((i) => i.row.event_type === 'WORKTREE_BRUTE_FORCE_FALLBACK_OK');
+    expect(successEvent, 'no WORKTREE_BRUTE_FORCE_FALLBACK_OK event was emitted').toBeDefined();
+    expect(successEvent.row.session_id).toBe('test-session-001');
+    expect(successEvent.row.reason).toBe('git_worktree_remove_refused_brute_force_rescued');
+    expect(successEvent.row.metadata).toBeDefined();
+    expect(successEvent.row.metadata.path).toBe(env.worktreePath);
+    expect(successEvent.row.metadata.original_error).toBe('test rollback context');
+    expect(successEvent.row.metadata.attempts_made).toBeGreaterThanOrEqual(1);
+    // last_error is the failed-git-worktree-remove message, not null on this path
+    expect(successEvent.row.metadata.last_error).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds session_lifecycle_events emission on the brute-force-success path in rollbackWorktreeCreation. Currently only failures emit (WORKTREE_ROLLBACK_DEFERRED); successful brute-force rescues were invisible.
- New event_type WORKTREE_BRUTE_FORCE_FALLBACK_OK is distinct so dashboards plot rescued-vs-deferred separately.

## Source
Feedback a824b044 (deferred from SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001 testing-agent finding #7).

## Test plan
- [x] tests/unit/lib/worktree-rollback-brute-force-telemetry.test.js — 1/1 pass.
- [ ] CI green.

## Auto-merge
Tier 1 QF (~15 src + 80 test LOC). Auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)