### PR TITLE
fix(QF-20260509-REPLIT-SEEDER-PERSIST-URL): seedRepo persists repo URL — closes feedback 9af99a84

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -23,6 +23,7 @@ import {
   formatArtifactContent,
   normalizeGroupKey,
 } from './replit-format-strategies.js';
+import { registerVentureResource } from '../../venture-resources.js';
 
 /**
  * Parse content that may be a JSON string.
@@ -1064,6 +1065,21 @@ When given a feature prompt, always:
     }
   } catch (err) {
     errors.push(`git push failed: ${err.message}`);
+  }
+
+  // Persist repo URL provenance (idempotent under venture_resources UNIQUE
+  // constraint). Pre-2026-05-09 the seeder used the URL to clone/commit/push
+  // but never recorded it, so Stage 19/20 lookups failed for ventures seeded
+  // via the CLI / programmatic path — see feedback 9af99a84 (LexiGuard).
+  try {
+    await registerVentureResource(ventureId, 'github_repo', repoUrl, 'github', {
+      seeded_by: 'replit-repo-seeder',
+      seeded_at: new Date().toISOString(),
+      docs_committed_count: docsCommitted.length,
+    });
+    await supabase.from('ventures').update({ repo_url: repoUrl }).eq('id', ventureId);
+  } catch (err) {
+    errors.push(`venture_resources persistence failed: ${err.message}`);
   }
 
   return { success: errors.length === 0, docsCommitted, errors, repoDir, ventureName };

--- a/tests/unit/eva/replit-repo-seeder.persist-url.test.js
+++ b/tests/unit/eva/replit-repo-seeder.persist-url.test.js
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for QF-20260509-REPLIT-SEEDER-PERSIST-URL
+ *
+ * Verifies that lib/eva/bridge/replit-repo-seeder.js::seedRepo() persists the
+ * GitHub repo URL after a successful (or attempted) push, by:
+ *   1. Calling registerVentureResource(ventureId, 'github_repo', repoUrl, 'github', {...})
+ *   2. UPDATEing ventures.repo_url
+ *
+ * Background — feedback 9af99a84 (LexiGuard, 2026-04-29): seedRepo accepted
+ * the GitHub URL as a parameter, used it to clone/commit/push, but never
+ * recorded it back to either venture_resources or ventures.repo_url. As a
+ * result, every venture seeded via the CLI / programmatic path lost provenance
+ * of its repo URL — Stage 19/20 lookups failed and required manual backfill.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module-level mock state — wired into vi.mock factories below.
+const registerCalls = [];
+const venturesUpdateCalls = [];
+
+// Track which `.from(table)` chain is being walked at any moment.
+let lastFromTable = null;
+
+vi.mock('../../../lib/venture-resources.js', () => ({
+  registerVentureResource: vi.fn((...args) => {
+    registerCalls.push(args);
+    return Promise.resolve({ id: 'res-1', status: 'active' });
+  }),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(() => ''),
+}));
+
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => true), // skip clone — pretend repo dir already there
+}));
+
+function buildSupabaseMock() {
+  // Minimal fluent chain that supports:
+  //   from(t).select(c).eq(k,v).single()                             — returns ventureRow / artifactRow
+  //   from(t).select(c).eq(k,v).eq(k2,v2).maybeSingle()              — returns artifactRow
+  //   from(t).select(c).eq(k,v).eq(k2,v2).limit(N).maybeSingle()     — returns artifactRow
+  //   from(t).select(c).eq(k,v).eq(k2,v2).order(k3,opt).limit(N).maybeSingle() — returns artifactRow
+  //   from(t).select(c).eq(k,v).eq(k2,v2).eq(k3,v3).order(k4,opt)    — returns array
+  //   from(t).update(payload).eq(k,v)                                 — captures venturesUpdateCalls
+  //   from(t).in(c, list)                                             — returns array
+  //   rpc(name, params)                                               — returns {data:{groups:[...]}}
+
+  const chain = {
+    select() { return chain; },
+    eq() { return chain; },
+    in() { return chain; },
+    order() { return chain; },
+    limit() { return chain; },
+    single() {
+      // Used by ventures lookup (line ~595): { name, target_platform } and metadata
+      if (lastFromTable === 'ventures') {
+        return Promise.resolve({
+          data: { name: 'TestVenture', target_platform: 'web', metadata: { doc_format: 'agent-optimized' } },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    maybeSingle() {
+      return Promise.resolve({ data: null, error: null });
+    },
+    then(resolve) {
+      // For chains that resolve directly (e.g. update().eq() awaited).
+      return Promise.resolve({ data: [], error: null }).then(resolve);
+    },
+    update(payload) {
+      if (lastFromTable === 'ventures') {
+        venturesUpdateCalls.push(payload);
+      }
+      return chain;
+    },
+    upsert() { return chain; },
+  };
+
+  return {
+    from: vi.fn((table) => {
+      lastFromTable = table;
+      return chain;
+    }),
+    rpc: vi.fn(() => Promise.resolve({
+      data: { groups: [{ group_key: 'what_to_build', artifacts: [] }] },
+      error: null,
+    })),
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => buildSupabaseMock()),
+}));
+
+beforeEach(() => {
+  registerCalls.length = 0;
+  venturesUpdateCalls.length = 0;
+  lastFromTable = null;
+});
+
+describe('seedRepo() — venture_resources URL persistence', () => {
+  it('calls registerVentureResource with (ventureId, "github_repo", repoUrl, "github", metadata)', async () => {
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+
+    const result = await seedRepo('v-abc', 'https://github.com/foo/bar.git');
+
+    expect(registerCalls.length).toBe(1);
+    const [vid, type, ident, provider, meta] = registerCalls[0];
+    expect(vid).toBe('v-abc');
+    expect(type).toBe('github_repo');
+    expect(ident).toBe('https://github.com/foo/bar.git');
+    expect(provider).toBe('github');
+    expect(meta).toMatchObject({
+      seeded_by: 'replit-repo-seeder',
+      docs_committed_count: expect.any(Number),
+    });
+    expect(meta.seeded_at).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO date
+    expect(result).toBeDefined();
+  });
+
+  it('UPDATEs ventures.repo_url after successful push', async () => {
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+
+    await seedRepo('v-xyz', 'https://github.com/owner/myrepo.git');
+
+    expect(venturesUpdateCalls).toContainEqual({ repo_url: 'https://github.com/owner/myrepo.git' });
+  });
+
+  it('does not throw when registerVentureResource rejects — captures error in result.errors', async () => {
+    const venturesMod = await import('../../../lib/venture-resources.js');
+    venturesMod.registerVentureResource.mockRejectedValueOnce(new Error('FK violation'));
+
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+
+    const result = await seedRepo('v-bad', 'https://github.com/foo/bar.git');
+
+    // Persistence error captured but seedRepo returned normally
+    expect(result).toBeDefined();
+    expect(result.errors.some(e => e.includes('venture_resources persistence failed'))).toBe(true);
+  });
+
+  it('passes the same repoUrl to both registerVentureResource and ventures.update — preserves exact identity', async () => {
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+
+    const url = 'https://github.com/rickfelix/lexiguard.git';
+    await seedRepo('lexiguard-v1', url);
+
+    expect(registerCalls[0][2]).toBe(url);
+    expect(venturesUpdateCalls.find(p => p.repo_url === url)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`lib/eva/bridge/replit-repo-seeder.js::seedRepo(ventureId, repoUrl)` accepted the GitHub URL as a parameter and used it to clone/commit/push the venture docs, but never persisted it back to either `venture_resources` or `ventures.repo_url`. Direct callers (the module's own CLI at `seedRepo` lines ~1167-1180, and any programmatic caller that didn't also write the row itself like `server/routes/github-repo.js` does at lines 66-89) lost provenance — Stage 19/20 lookups failed and required manual backfill. LexiGuard hit this 2026-04-29.

## Fix

Inside `seedRepo`, immediately after the git push attempt block:

1. Call `registerVentureResource(ventureId, 'github_repo', repoUrl, 'github', {...})` (idempotent under the existing UNIQUE `(venture_id, resource_type, resource_identifier)` constraint).
2. UPDATE `ventures.repo_url = repoUrl` (idempotent row update).
3. Wrap both in a try/catch that pushes failures to `result.errors` rather than throwing — the seed itself already succeeded by this point so partial DB persistence shouldn't poison the return value.

The HTTP route `server/routes/github-repo.js` continues to also write `venture_resources` (its narrower `onConflict: 'venture_id,resource_type'` upsert will simply update the row this fix writes — convergent).

## LOC

| | Count | Tier |
|---|---|---|
| Source | 16 | Tier-1 (≤30) |
| Test   | 157 | — |

## Test plan

- [x] 4 new vitest cases in `tests/unit/eva/replit-repo-seeder.persist-url.test.js`:
  - registerVentureResource called with correct args
  - ventures.repo_url updated
  - persistence error captured in result.errors (does not throw)
  - exact-URL identity between both writes
- [x] 53/53 adjacent tests (`venture-resources.test.js` + `replit-format-strategies.test.js`) pass — no regressions
- [x] Tier-1 LOC budget honored
- [x] Idempotent — UNIQUE constraint on venture_resources + idempotent UPDATE on ventures
- [x] Fail-soft — persistence failure captured but doesn't throw

Closes feedback `9af99a84-9a68-4113-85ae-8740f05536cc` (harness backlog, original 2026-04-29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)