### PR TITLE
fix(QF-20260509-LEO-CREATE-PLAN-DUP-GUARD): refuse --from-plan dup within 24h — closes feedback 082b421c

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -15,7 +15,7 @@
  * Part of SD-LEO-SDKEY-001: Centralize SD Creation Through /leo
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import {
   generateSDKey,
@@ -647,6 +647,46 @@ async function createChild(parentKey, index = 0, overrides = {}) {
 }
 
 /**
+ * Compute a deterministic SHA256 hash of plan content for duplicate detection.
+ * Normalizes line endings (CRLF→LF) and trims trailing whitespace per line so
+ * that benign editor save-formatting changes don't bypass the guard.
+ *
+ * @param {string} content
+ * @returns {string} 64-char hex digest
+ */
+export function computePlanContentHash(content) {
+  if (!content) return createHash('sha256').update('').digest('hex');
+  const normalized = String(content).replace(/\r\n/g, '\n').split('\n').map(l => l.replace(/\s+$/, '')).join('\n').trimEnd();
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Look up a non-cancelled SD created within the last 24h whose metadata
+ * carries the same plan_content_hash. Used to refuse duplicate INSERTs from
+ * back-to-back --from-plan runs.
+ *
+ * @param {string} hash - SHA256 hex digest from computePlanContentHash()
+ * @returns {Promise<{sd_key:string,title:string,status:string,id:string}|null>}
+ */
+export async function findRecentSDByPlanHash(hash) {
+  if (!hash) return null;
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, created_at')
+    .eq('metadata->>plan_content_hash', hash)
+    .gte('created_at', cutoff)
+    .not('status', 'in', '(cancelled,archived)')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) {
+    console.warn(`   ⚠️  duplicate-guard query failed: ${error.message} — proceeding without guard`);
+    return null;
+  }
+  return (data && data.length > 0) ? data[0] : null;
+}
+
+/**
  * Create SD from Claude Code plan file
  *
  * When called without a path, auto-detects the most recent plan and shows
@@ -818,6 +858,15 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     mitigation: r.mitigation || 'Address during implementation'
   }));
 
+  // QF-20260509-LEO-CREATE-PLAN-DUP-GUARD (closes feedback 082b421c).
+  // Compute SHA256 of the (whitespace-normalized) plan content. We use the
+  // hash for both (i) provenance metadata and (ii) the duplicate-detection
+  // query a few lines down — same plan run twice within 24h ⇒ refuse, unless
+  // --force-create overrides. Catches the LEO-FEAT-* / LEO-FIX-* duplicate
+  // pair that landed when the auto-classifier picked different sd_types on
+  // back-to-back runs of the same plan file.
+  const planContentHash = computePlanContentHash(parsed.fullContent);
+
   // Step 12: Create SD with all extracted fields.
   // Pass priority through so plan authored `## Priority` and --priority CLI overrides reach the DB.
   // When parsed.priority is null (no header, no override), omit the field so createSD's default ('medium') applies.
@@ -836,6 +885,7 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     metadata: {
       source: 'plan',
       plan_content: parsed.fullContent,
+      plan_content_hash: planContentHash,
       plan_file_path: archiveResult.archivedPath || null,
       original_plan_path: originalPath,
       files_to_modify: parsed.files,
@@ -861,6 +911,20 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
   if (parsed.targetApplication) {
     createOptions.target_application = parsed.targetApplication;
   }
+
+  // Pre-INSERT duplicate guard (QF-20260509-LEO-CREATE-PLAN-DUP-GUARD).
+  // Same plan content within last 24h ⇒ refuse unless --force-create.
+  if (!overrides.forceCreate) {
+    const dup = await findRecentSDByPlanHash(planContentHash);
+    if (dup) {
+      console.error(`\n❌ Duplicate plan detected: SD ${dup.sd_key} (${dup.status}) was created from the same plan content within the last 24h.`);
+      console.error(`   Title: ${dup.title}`);
+      console.error('   To create another SD anyway, re-run with --force-create.');
+      console.error('   Otherwise, edit the existing SD or cancel it first (npm run sd:cancel).');
+      process.exit(1);
+    }
+  }
+
   const sd = await createSD(createOptions);
 
   // Step 13: Update additional fields that aren't in createSD signature.
@@ -1906,6 +1970,8 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // Parse boolean review flags (satisfy GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE)
       const migrationReviewed = args.includes('--migration-reviewed');
       const securityReviewed = args.includes('--security-reviewed');
+      // QF-20260509-LEO-CREATE-PLAN-DUP-GUARD: override the same-plan-within-24h refusal
+      const forceCreate = args.includes('--force-create');
       // SD-LEO-INFRA-LEO-CREATE-CROSS-001: --target-repos for cross-repo SDs
       const targetReposIdxPlan = args.indexOf('--target-repos');
       const targetReposPlan = targetReposIdxPlan !== -1 ? parseTargetReposArg(args[targetReposIdxPlan + 1]) : null;
@@ -1923,7 +1989,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const knownPlanFlags = new Set([
         '--yes', '-y', '--type', '--title', '--priority', '--from-plan',
         '--vision-key', '--arch-key', '--migration-reviewed', '--security-reviewed',
-        '--target-repos'
+        '--target-repos', '--force-create'
       ]);
       const planPath = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !flagValuePositions.has(i) && !knownPlanFlags.has(arg)
@@ -1937,6 +2003,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         migrationReviewed,
         securityReviewed,
         targetRepos: targetReposPlan,
+        forceCreate,
       });
     } else if (args[0] === '--child') {
       // Parse --type and --title overrides for child creation

--- a/tests/unit/leo-create-sd-plan-dup-guard.test.js
+++ b/tests/unit/leo-create-sd-plan-dup-guard.test.js
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for QF-20260509-LEO-CREATE-PLAN-DUP-GUARD
+ *
+ * Verifies that scripts/leo-create-sd.js exposes a deterministic
+ * computePlanContentHash() helper and a findRecentSDByPlanHash() query that
+ * the --from-plan duplicate guard relies on.
+ *
+ * Background — feedback 082b421c (2026-05-03): leo-create-sd --from-plan ran
+ * twice on the same plan within 5 minutes and produced two separate SDs
+ * (LEO-FEAT-* and LEO-FIX-*) because the auto-classifier picked different
+ * sd_type values across runs (likely due to a small mid-run edit). The fix
+ * is to refuse the second INSERT when the same plan content (whitespace-
+ * normalized SHA256) was already used to create a non-cancelled SD in the
+ * past 24h, with --force-create as the documented override.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We need to mock the supabase client BEFORE importing leo-create-sd because
+// it instantiates one at module load (line 56: createSupabaseServiceClient()).
+const supabaseFromCalls = [];
+const queryState = {
+  rows: [],
+  error: null,
+};
+const queryBuilder = {
+  select() { return queryBuilder; },
+  eq() { return queryBuilder; },
+  gte() { return queryBuilder; },
+  not() { return queryBuilder; },
+  order() { return queryBuilder; },
+  limit() {
+    return Promise.resolve({ data: queryState.rows, error: queryState.error });
+  },
+};
+
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({
+    from: vi.fn((table) => {
+      supabaseFromCalls.push(table);
+      return queryBuilder;
+    }),
+  }),
+}));
+
+beforeEach(() => {
+  supabaseFromCalls.length = 0;
+  queryState.rows = [];
+  queryState.error = null;
+});
+
+describe('computePlanContentHash', () => {
+  it('returns a stable 64-char hex digest for identical input', async () => {
+    const { computePlanContentHash } = await import('../../scripts/leo-create-sd.js');
+    const a = computePlanContentHash('# Plan A\n\nbody');
+    const b = computePlanContentHash('# Plan A\n\nbody');
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+    expect(a).toBe(b);
+  });
+
+  it('normalizes CRLF→LF so editor save-formatting changes do not bypass the guard', async () => {
+    const { computePlanContentHash } = await import('../../scripts/leo-create-sd.js');
+    expect(computePlanContentHash('foo\r\nbar')).toBe(computePlanContentHash('foo\nbar'));
+  });
+
+  it('strips trailing whitespace per line', async () => {
+    const { computePlanContentHash } = await import('../../scripts/leo-create-sd.js');
+    expect(computePlanContentHash('foo   \nbar  ')).toBe(computePlanContentHash('foo\nbar'));
+  });
+
+  it('produces different hashes for genuinely different content', async () => {
+    const { computePlanContentHash } = await import('../../scripts/leo-create-sd.js');
+    expect(computePlanContentHash('plan one')).not.toBe(computePlanContentHash('plan two'));
+  });
+
+  it('handles empty/null input without throwing', async () => {
+    const { computePlanContentHash } = await import('../../scripts/leo-create-sd.js');
+    expect(computePlanContentHash('')).toMatch(/^[a-f0-9]{64}$/);
+    expect(computePlanContentHash(null)).toMatch(/^[a-f0-9]{64}$/);
+    expect(computePlanContentHash(undefined)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('findRecentSDByPlanHash', () => {
+  it('returns the row when supabase finds a matching SD', async () => {
+    queryState.rows = [{
+      id: 'uuid-1',
+      sd_key: 'SD-LEO-FEAT-X-001',
+      title: 'Existing',
+      status: 'active',
+      created_at: new Date().toISOString(),
+    }];
+    const { findRecentSDByPlanHash } = await import('../../scripts/leo-create-sd.js');
+    const dup = await findRecentSDByPlanHash('a'.repeat(64));
+    expect(dup).toMatchObject({ sd_key: 'SD-LEO-FEAT-X-001', status: 'active' });
+    expect(supabaseFromCalls).toContain('strategic_directives_v2');
+  });
+
+  it('returns null when no rows match (clean run)', async () => {
+    queryState.rows = [];
+    const { findRecentSDByPlanHash } = await import('../../scripts/leo-create-sd.js');
+    expect(await findRecentSDByPlanHash('b'.repeat(64))).toBeNull();
+  });
+
+  it('returns null when hash is missing (defensive guard)', async () => {
+    const { findRecentSDByPlanHash } = await import('../../scripts/leo-create-sd.js');
+    expect(await findRecentSDByPlanHash('')).toBeNull();
+    expect(await findRecentSDByPlanHash(null)).toBeNull();
+    // No DB call when input is empty — the guard short-circuits.
+    expect(supabaseFromCalls).toEqual([]);
+  });
+
+  it('falls back to null (does not throw) when supabase returns an error', async () => {
+    queryState.error = { message: 'connection lost' };
+    const { findRecentSDByPlanHash } = await import('../../scripts/leo-create-sd.js');
+    expect(await findRecentSDByPlanHash('c'.repeat(64))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/leo-create-sd.js --from-plan` was running twice on the same plan file in close succession and producing two separate SDs (LEO-FEAT-* and LEO-FIX-*) because the plan-text auto-classifier picked different `sd_type` values across runs — likely caused by a small mid-run edit shifting the keyword match. Symptom recorded in feedback `082b421c` (2026-05-03, plan `sd-009-stage20-code-quality-gate-alignment.md`, 17:45:21 → 17:50:27).

## Fix

Add a content-hash-based collision guard inside `createFromPlan`:

1. **`computePlanContentHash(content)`** (new exported helper) — SHA256 over `parsed.fullContent` after CRLF→LF normalization and trailing-whitespace strip per line. Deterministic; benign editor save-formatting changes don't bypass the guard.
2. **Store hash in `metadata.plan_content_hash`** alongside the existing provenance fields.
3. **`findRecentSDByPlanHash(hash)`** (new exported helper) — query `strategic_directives_v2` filtered to `metadata->>plan_content_hash = hash`, `created_at >= NOW() - 24h`, `status NOT IN (cancelled, archived)`. Failures degrade to `null` (warn + proceed) so a transient DB hiccup doesn't block creation.
4. **Pre-INSERT check** in `createFromPlan`: if `findRecentSDByPlanHash` returns a hit, refuse with an actionable error naming the existing SD's `sd_key`, `title`, and `status`, and pointing to the override flag.
5. **`--force-create` flag** — explicit operator override of the 24h refusal. Wired into `knownPlanFlags` Set + passed through `createFromPlan` overrides.

The original symptom was caused by mid-run plan edits flipping the classifier output; making the classifier itself "more deterministic" wouldn't have helped because the input text genuinely changed. The collision guard catches this regardless of what classifier output the second run produces.

## LOC

| | Count | Tier |
|---|---|---|
| Source | 69 (incl. JSDoc + helper functions) | Tier-2 (31-75) |
| Test   | 118 | — |

## Test plan

- [x] 9 new vitest cases in `tests/unit/leo-create-sd-plan-dup-guard.test.js`:
  - `computePlanContentHash`: stable digest, CRLF→LF normalization, trailing-whitespace strip, distinct-content distinct hash, null/empty input safe
  - `findRecentSDByPlanHash`: returns row when match, returns null when none, returns null on missing hash (no DB call), returns null on supabase error
- [x] 24/24 adjacent tests (`leo-create-flags-parity`, `target-repos`, `vision-prescreen`) pass — no regressions
- [x] Idempotent: second run within 24h refuses; outside 24h or after `--force-create` proceeds normally
- [x] Cancelled/archived SDs are explicitly excluded from the guard so prior triage decisions don't block legitimate retries
- [x] Fail-soft on DB errors — never blocks INSERT on a transient query failure

Closes feedback `082b421c-e890-4092-bb2b-dcfd5191c1f8` (harness backlog, original 2026-05-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)