### PR TITLE
fix(QF-20260509-849): align 9 capability-score tests with phantom-table-stubbed source

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-796",
+  "sdKey": "QF-20260509-849",
   "workType": "QF",
-  "workKey": "QF-20260509-796",
-  "expectedBranch": "qf/QF-20260509-796",
-  "createdAt": "2026-05-09T21:59:19.946Z",
+  "workKey": "QF-20260509-849",
+  "expectedBranch": "qf/QF-20260509-849",
+  "createdAt": "2026-05-09T22:18:45.004Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/capability-score/__tests__/capability-score.test.js
+++ b/lib/eva/capability-score/__tests__/capability-score.test.js
@@ -175,7 +175,12 @@ describe('computeCapabilityScore', () => {
     expect(result.scores.market_validation.score).toBeNull();
   });
 
-  test('persists scores via UPSERT when supabase provided', async () => {
+  // QF-20260509-849: source persistScores is a no-op since commit 238aaaa7a9
+  // (phantom-table cleanup of venture_capability_scores). Test now asserts the
+  // documented stub behavior — no supabase.from() call + warn logged. Restore
+  // the original UPSERT assertion only if the table is restored (would need
+  // SD-EVA-CCS-TABLE-RESTORE-001 or equivalent).
+  test('skips persist (phantom-table stub) when supabase provided', async () => {
     const supabase = mockSupabase();
     const result = await computeCapabilityScore(1, { data: 'test' }, {
       ventureId: 'v-001',
@@ -186,7 +191,10 @@ describe('computeCapabilityScore', () => {
     });
 
     expect(result).not.toBeNull();
-    expect(supabase.from).toHaveBeenCalledWith('venture_capability_scores');
+    expect(supabase.from).not.toHaveBeenCalled();
+    expect(silentLogger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/Skipping persist .*phantom table/)
+    );
   });
 
   test('returns null when LLM throws (non-blocking)', async () => {
@@ -287,98 +295,57 @@ describe('getCumulativeProfile', () => {
     expect(result.gaps).toEqual([]);
   });
 
-  test('computes weighted cumulative from scored data', async () => {
+  // QF-20260509-849: source returns empty profile regardless of mocked data
+  // since commit 238aaaa7a9 stubbed the supabase query (data = []). These tests
+  // now assert the documented stub-shape contract. Restore behavior-bearing
+  // assertions only when venture_capability_scores table is restored.
+  test('returns empty profile (phantom-table stub) regardless of mock data', async () => {
     const data = [
       { stage_number: 1, dimension: 'technical_depth', score: 70, rationale: 'ok', scored_at: '2026-01-01' },
       { stage_number: 1, dimension: 'market_validation', score: 80, rationale: 'ok', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'financial_rigor', score: 40, rationale: 'ok', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'operational_readiness', score: 50, rationale: 'ok', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'strategic_alignment', score: 90, rationale: 'ok', scored_at: '2026-01-01' },
     ];
-
-    const orderMock = vi.fn().mockResolvedValue({ data, error: null });
-    const supabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            order: orderMock,
-          }),
-        }),
-      }),
-    };
+    const supabase = mockSupabaseQuery(data);
 
     const result = await getCumulativeProfile('v-001', { supabase });
 
     expect(result.ventureId).toBe('v-001');
-    expect(result.stagesScored).toBe(1);
-    expect(result.overall).not.toBeNull();
-    expect(result.overall).toBeGreaterThan(0);
-    // financial_rigor at 40 should be a gap (< 40 threshold)
-    // Actually 40 is not < 40, it's equal, so no gap
-    expect(result.dimensions.technical_depth.cumulative).toBe(70);
-    expect(result.dimensions.market_validation.cumulative).toBe(80);
+    expect(result.overall).toBeNull();
+    expect(result.stagesScored).toBe(0);
+    expect(result.dimensions).toEqual({});
+    expect(result.gaps).toEqual([]);
   });
 
-  test('detects capability gaps below 40', async () => {
+  test('returns empty gaps array (phantom-table stub) even when mock data has low scores', async () => {
     const data = [
-      { stage_number: 1, dimension: 'technical_depth', score: 30, rationale: 'weak', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'market_validation', score: 80, rationale: 'ok', scored_at: '2026-01-01' },
       { stage_number: 1, dimension: 'financial_rigor', score: 20, rationale: 'missing', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'operational_readiness', score: 60, rationale: 'ok', scored_at: '2026-01-01' },
-      { stage_number: 1, dimension: 'strategic_alignment', score: 75, rationale: 'ok', scored_at: '2026-01-01' },
     ];
-
-    const supabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            order: vi.fn().mockResolvedValue({ data, error: null }),
-          }),
-        }),
-      }),
-    };
+    const supabase = mockSupabaseQuery(data);
 
     const result = await getCumulativeProfile('v-001', { supabase });
 
-    expect(result.gaps).toHaveLength(2);
-    expect(result.gaps.map(g => g.dimension)).toContain('technical_depth');
-    expect(result.gaps.map(g => g.dimension)).toContain('financial_rigor');
+    expect(result.gaps).toEqual([]);
   });
 
-  test('computes trend from 2+ scores in same dimension', async () => {
+  test('returns empty trend (phantom-table stub) even when mock data has dimension history', async () => {
     const data = [
       { stage_number: 1, dimension: 'technical_depth', score: 50, rationale: 'ok', scored_at: '2026-01-01' },
       { stage_number: 2, dimension: 'technical_depth', score: 70, rationale: 'better', scored_at: '2026-01-02' },
     ];
-
-    const supabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            order: vi.fn().mockResolvedValue({ data, error: null }),
-          }),
-        }),
-      }),
-    };
+    const supabase = mockSupabaseQuery(data);
 
     const result = await getCumulativeProfile('v-001', { supabase });
 
-    expect(result.dimensions.technical_depth.trend).toBe('improving');
+    expect(result.dimensions).toEqual({});
+    expect(result.trend).toEqual({});
   });
 
-  test('throws on query error', async () => {
-    const supabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
-          }),
-        }),
-      }),
-    };
+  test('does not throw on mocked query error (phantom-table stub never queries)', async () => {
+    const supabase = mockSupabaseQuery(null, { message: 'DB error' });
 
-    await expect(getCumulativeProfile('v-001', { supabase }))
-      .rejects.toThrow('Failed to fetch capability scores');
+    const result = await getCumulativeProfile('v-001', { supabase });
+
+    expect(result.ventureId).toBe('v-001');
+    expect(result.overall).toBeNull();
   });
 });
 
@@ -402,20 +369,14 @@ describe('compareVentures', () => {
     expect(result.sortBy).toBe('overall');
   });
 
-  test('ranks ventures by overall score descending', async () => {
+  // QF-20260509-849: source returns empty ventures regardless of mocked data
+  // since commit 238aaaa7a9 stubbed the supabase query (data = []). These tests
+  // now assert the documented stub-shape contract. Stage-range filter test was
+  // deleted because the .gte chain is unreachable in the stubbed implementation.
+  test('returns empty ventures (phantom-table stub) regardless of mock data', async () => {
     const data = [
       { venture_id: 'v-1', stage_number: 1, dimension: 'technical_depth', score: 90 },
-      { venture_id: 'v-1', stage_number: 1, dimension: 'market_validation', score: 85 },
-      { venture_id: 'v-1', stage_number: 1, dimension: 'financial_rigor', score: 80 },
-      { venture_id: 'v-1', stage_number: 1, dimension: 'operational_readiness', score: 75 },
-      { venture_id: 'v-1', stage_number: 1, dimension: 'strategic_alignment', score: 70 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'technical_depth', score: 40 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'market_validation', score: 35 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'financial_rigor', score: 30 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'operational_readiness', score: 25 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'strategic_alignment', score: 20 },
     ];
-
     const supabase = {
       from: vi.fn().mockReturnValue({
         select: vi.fn().mockResolvedValue({ data, error: null }),
@@ -424,22 +385,14 @@ describe('compareVentures', () => {
 
     const result = await compareVentures({ supabase });
 
-    expect(result.ventures).toHaveLength(2);
-    expect(result.ventures[0].ventureId).toBe('v-1');
-    expect(result.ventures[1].ventureId).toBe('v-2');
-    expect(result.ventures[0].rank).toBe(1);
-    expect(result.ventures[1].rank).toBe(2);
-    expect(result.ventures[0].overall).toBeGreaterThan(result.ventures[1].overall);
+    expect(result.ventures).toEqual([]);
+    expect(result.sortBy).toBe('overall');
   });
 
-  test('sorts by specific dimension', async () => {
+  test('returns empty ventures (phantom-table stub) when sortBy is a valid dimension', async () => {
     const data = [
-      { venture_id: 'v-1', stage_number: 1, dimension: 'technical_depth', score: 40 },
-      { venture_id: 'v-1', stage_number: 1, dimension: 'market_validation', score: 90 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'technical_depth', score: 80 },
-      { venture_id: 'v-2', stage_number: 1, dimension: 'market_validation', score: 50 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'technical_depth', score: 80 },
     ];
-
     const supabase = {
       from: vi.fn().mockReturnValue({
         select: vi.fn().mockResolvedValue({ data, error: null }),
@@ -448,7 +401,7 @@ describe('compareVentures', () => {
 
     const result = await compareVentures({ supabase, sortBy: 'technical_depth' });
 
-    expect(result.ventures[0].ventureId).toBe('v-2'); // TD=80 > TD=40
+    expect(result.ventures).toEqual([]);
     expect(result.sortBy).toBe('technical_depth');
   });
 
@@ -458,58 +411,16 @@ describe('compareVentures', () => {
       .rejects.toThrow('Invalid sortBy');
   });
 
-  test('applies limit', async () => {
-    const data = [];
-    for (let i = 0; i < 10; i++) {
-      for (const dim of DIMENSIONS) {
-        data.push({ venture_id: `v-${i}`, stage_number: 1, dimension: dim, score: 50 + i });
-      }
-    }
-
+  test('returns empty ventures (phantom-table stub) when limit is provided', async () => {
     const supabase = {
       from: vi.fn().mockReturnValue({
-        select: vi.fn().mockResolvedValue({ data, error: null }),
+        select: vi.fn().mockResolvedValue({ data: [], error: null }),
       }),
     };
 
     const result = await compareVentures({ supabase, limit: 3 });
 
-    expect(result.ventures).toHaveLength(3);
-    expect(result.totalVentures).toBe(10);
-  });
-
-  test('applies stage range filters', async () => {
-    const data = [
-      { venture_id: 'v-1', stage_number: 3, dimension: 'technical_depth', score: 70 },
-    ];
-
-    const gteMock = vi.fn().mockReturnThis();
-    const lteMock = vi.fn().mockResolvedValue({ data, error: null });
-
-    const supabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          gte: gteMock,
-          lte: lteMock,
-        }),
-      }),
-    };
-
-    // When stageMin is provided, gte is called
-    const selectReturnValue = {
-      gte: vi.fn().mockReturnValue({
-        lte: vi.fn().mockResolvedValue({ data, error: null }),
-      }),
-    };
-    const supabase2 = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue(selectReturnValue),
-      }),
-    };
-
-    const result = await compareVentures({ supabase: supabase2, stageMin: 2, stageMax: 5 });
-
-    expect(selectReturnValue.gte).toHaveBeenCalledWith('stage_number', 2);
+    expect(result.ventures).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- 9 of 30 tests in \`lib/eva/capability-score/__tests__/capability-score.test.js\` had been failing consistently in baseline counts across multiple recent SDs
- RCA (rca-agent) found a single root cause: commit \`238aaaa7a9\` (2026-04-03) stubbed source code (replaced \`supabase.from('venture_capability_scores')\` with \`const data = []\` + \`persistScores\` no-op) when the phantom table was removed
- Tests authored 2026-03-22 (12 days earlier) still asserted the pre-stub DB-backed contract
- This is the **12th-witness** of \`PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001\` — writer (phantom cleanup) shipped without consumer (test) follow-through

## Changes
- score-stage.js test 1 → assert NO \`supabase.from()\` call + \`warn\` matched (instead of "persists via UPSERT")
- cumulative-profile.js tests 2-5 → assert empty-profile shape regardless of mock data
- compare-ventures.js tests 6-8 → assert empty-ventures shape
- compare-ventures.js test 9 (stage-range filters) → **DELETED** (.gte chain is unreachable in stubbed source — RCA-recommended)

Each \`describe\` block has a header comment citing QF-20260509-849 + commit 238aaaa7a9 + the restoration condition (if/when \`venture_capability_scores\` table returns).

Net: 1 file changed, **50 insertions, 139 deletions** (test-only, no source change).

## Test plan
- [x] \`npx vitest run lib/eva/capability-score/__tests__/capability-score.test.js\` → **29/29 pass** (was 21/30 fail)
- [x] \`npx vitest run lib/eva/\` → **406/406 pass** across 31 files (up from 397/406, zero regression)
- [x] \`npx tsc --noEmit\` (run in complete-quick-fix.js) → expected PASS

## Tier
**TIER_2** (~50 LOC, test-only).

## Closes
- QF-20260509-849
- Test-baseline pollution that consumed \`test_failures\` gate budget for unrelated SDs across recent campaigns
- SD-LEO-INFRA-BACKEND-WRITE-SAFETY-001 retro \`dbae95ee\` action_item #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)