### PR TITLE
fix(QF-20260509-171): leo-create-sd refuses INSERT when --vision-key/--arch-key resolve to no row (closes 92ff36a1)

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -119,8 +119,15 @@ export function parseTargetReposArg(raw) {
  * @returns {Promise<string|null>} Normalized venture prefix or null
  */
 // Quick-fix QF-20260312-516: Extract SD fields from registered vision/arch documents
-async function enrichFromVisionArch(visionKey, archKey, sb) {
-  if (!visionKey && !archKey) return null;
+// QF-20260509-171 (closes feedback 92ff36a1): return {enriched, missing} so the
+// caller can fail-fast when a supplied --vision-key/--arch-key resolves to no
+// row. Previously the function silently returned null on missing rows and the
+// caller still wrote the unresolved key into sdData.metadata, producing an
+// orphan FK-by-string (e.g. VISION-EVA-SUPPORT-CLI-L2-001 in
+// SD-EVA-SUPPORT-CLI-SKILL-ORCH-001 metadata with no source row).
+export async function enrichFromVisionArch(visionKey, archKey, sb) {
+  const missing = { vision: false, arch: false };
+  if (!visionKey && !archKey) return { enriched: null, missing };
   const result = {};
   try {
     if (visionKey) {
@@ -128,8 +135,10 @@ async function enrichFromVisionArch(visionKey, archKey, sb) {
         .from('eva_vision_documents')
         .select('sections')
         .eq('vision_key', visionKey)
-        .single();
-      if (vision?.sections) {
+        .maybeSingle();
+      if (!vision) {
+        missing.vision = true;
+      } else if (vision.sections) {
         const s = vision.sections;
         if (s.executive_summary) result.description = s.executive_summary;
         if (s.problem_statement) result.rationale = s.problem_statement;
@@ -146,8 +155,10 @@ async function enrichFromVisionArch(visionKey, archKey, sb) {
         .from('eva_architecture_plans')
         .select('sections')
         .eq('plan_key', archKey)
-        .single();
-      if (arch?.sections) {
+        .maybeSingle();
+      if (!arch) {
+        missing.arch = true;
+      } else if (arch.sections) {
         const s = arch.sections;
         if (s.route_component_structure || s.route_and_component_structure) {
           const routes = s.route_component_structure || s.route_and_component_structure;
@@ -166,7 +177,10 @@ async function enrichFromVisionArch(visionKey, archKey, sb) {
   } catch (err) {
     console.warn(`[enrichFromVisionArch] Non-fatal: ${err.message}`);
   }
-  return Object.keys(result).length > 0 ? result : null;
+  return {
+    enriched: Object.keys(result).length > 0 ? result : null,
+    missing
+  };
 }
 
 async function resolveVenturePrefix(cliVenture = null) {
@@ -2321,7 +2335,25 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const sdKey = await generateSDKey({ source, type, title, venturePrefix });
 
       // Quick-fix QF-20260312-516: Enrich SD fields from vision/arch documents
-      const enriched = await enrichFromVisionArch(visionKey, archKey, supabase);
+      // QF-20260509-171 (closes feedback 92ff36a1): refuse INSERT when a supplied
+      // --vision-key/--arch-key resolves to no row in eva_vision_documents /
+      // eva_architecture_plans. The metadata.vision_key/arch_key fields are an
+      // FK-by-string, so an unresolved key would produce an orphan SD whose
+      // strategic provenance LEAD evaluators cannot trace.
+      const enrichResult = await enrichFromVisionArch(visionKey, archKey, supabase);
+      if (enrichResult.missing.vision) {
+        console.error(`\n❌ --vision-key '${visionKey}' not found in eva_vision_documents`);
+        console.error('   Writing it to metadata would create an orphan FK-by-string with no source row.');
+        console.error('   Verify the key, or omit --vision-key.\n');
+        process.exit(1);
+      }
+      if (enrichResult.missing.arch) {
+        console.error(`\n❌ --arch-key '${archKey}' not found in eva_architecture_plans`);
+        console.error('   Writing it to metadata would create an orphan FK-by-string with no source row.');
+        console.error('   Verify the key, or omit --arch-key.\n');
+        process.exit(1);
+      }
+      const enriched = enrichResult.enriched;
       if (enriched) {
         console.log('✓ SD fields enriched from vision/architecture documents');
       }

--- a/tests/unit/leo-create-sd-vision-arch-fail-fast.test.js
+++ b/tests/unit/leo-create-sd-vision-arch-fail-fast.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for QF-20260509-171 (closes feedback 92ff36a1).
+ *
+ * Verifies that scripts/leo-create-sd.js
+ *   1. enrichFromVisionArch returns {enriched, missing} where missing.{vision,arch}
+ *      flags are set true when a supplied key resolves to no row.
+ *   2. The /leo create direct-args caller refuses INSERT (process.exit non-zero
+ *      with diagnostic) when missing.vision or missing.arch is true. Pinned via
+ *      source-text guard since the caller path uses process.exit which is hard
+ *      to assert behaviorally without spawning a child process.
+ *
+ * Background — feedback 92ff36a1 (2026-04-27): leo-create-sd produced
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001 with metadata.vision_key=
+ * VISION-EVA-SUPPORT-CLI-L2-001 and metadata.arch_key=ARCH-EVA-SUPPORT-CLI-001
+ * even though those keys had no row in eva_vision_documents /
+ * eva_architecture_plans. LEAD evaluation could not trace strategic provenance
+ * because the metadata FK-by-string was an orphan.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Mock the supabase client so importing leo-create-sd.js doesn't try to
+// connect at module load (mirrors leo-create-sd-plan-dup-guard.test.js).
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({ from: vi.fn() }),
+}));
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..', '..');
+
+/**
+ * Minimal mock Supabase chain for enrichFromVisionArch.
+ * Allows preconfiguring per-table responses to .maybeSingle().
+ */
+function mkMockSb({ visionRow, archRow }) {
+  return {
+    from(table) {
+      const data =
+        table === 'eva_vision_documents' ? visionRow :
+        table === 'eva_architecture_plans' ? archRow :
+        null;
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => Promise.resolve({ data, error: null }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+describe('enrichFromVisionArch — return shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns {enriched: null, missing: {vision: false, arch: false}} when no keys supplied', async () => {
+    const { enrichFromVisionArch } = await import('../../scripts/leo-create-sd.js');
+    const sb = mkMockSb({});
+    const result = await enrichFromVisionArch(null, null, sb);
+    expect(result).toEqual({ enriched: null, missing: { vision: false, arch: false } });
+  });
+
+  it('flags missing.vision=true when --vision-key resolves to no row', async () => {
+    const { enrichFromVisionArch } = await import('../../scripts/leo-create-sd.js');
+    const sb = mkMockSb({ visionRow: null });
+    const result = await enrichFromVisionArch('VISION-DOES-NOT-EXIST-001', null, sb);
+    expect(result.missing.vision).toBe(true);
+    expect(result.missing.arch).toBe(false);
+    expect(result.enriched).toBeNull();
+  });
+
+  it('flags missing.arch=true when --arch-key resolves to no row', async () => {
+    const { enrichFromVisionArch } = await import('../../scripts/leo-create-sd.js');
+    const sb = mkMockSb({ archRow: null });
+    const result = await enrichFromVisionArch(null, 'ARCH-DOES-NOT-EXIST-001', sb);
+    expect(result.missing.arch).toBe(true);
+    expect(result.missing.vision).toBe(false);
+    expect(result.enriched).toBeNull();
+  });
+
+  it('flags both missing when both keys resolve to no row', async () => {
+    const { enrichFromVisionArch } = await import('../../scripts/leo-create-sd.js');
+    const sb = mkMockSb({ visionRow: null, archRow: null });
+    const result = await enrichFromVisionArch('V-NONE', 'A-NONE', sb);
+    expect(result.missing).toEqual({ vision: true, arch: true });
+    expect(result.enriched).toBeNull();
+  });
+
+  it('returns enriched fields and missing.{vision,arch}=false when keys resolve', async () => {
+    const { enrichFromVisionArch } = await import('../../scripts/leo-create-sd.js');
+    const sb = mkMockSb({
+      visionRow: {
+        sections: {
+          executive_summary: 'A solid summary.',
+          problem_statement: 'A clear problem.',
+          success_criteria: ['Ship it', 'Measure it'],
+        },
+      },
+      archRow: {
+        sections: {
+          implementation_phases: ['Phase 1', 'Phase 2'],
+        },
+      },
+    });
+    const result = await enrichFromVisionArch('VISION-OK', 'ARCH-OK', sb);
+    expect(result.missing).toEqual({ vision: false, arch: false });
+    expect(result.enriched).not.toBeNull();
+    expect(result.enriched.description).toBe('A solid summary.');
+    expect(result.enriched.rationale).toBe('A clear problem.');
+    expect(result.enriched.scope).toContain('Phase 1');
+  });
+});
+
+// Static guard: pin the fail-fast block at the direct-args caller so a future
+// refactor of the async caller doesn't quietly drop the orphan check.
+describe('QF-20260509-171: direct-args caller fail-fast on unresolved key', () => {
+  it('leo-create-sd.js direct-args path refuses INSERT when missing.vision is true', () => {
+    const src = readFileSync(resolve(repoRoot, 'scripts', 'leo-create-sd.js'), 'utf8');
+    expect(src).toMatch(/enrichResult\.missing\.vision/);
+    expect(src).toMatch(/--vision-key.*not found in eva_vision_documents/);
+  });
+
+  it('leo-create-sd.js direct-args path refuses INSERT when missing.arch is true', () => {
+    const src = readFileSync(resolve(repoRoot, 'scripts', 'leo-create-sd.js'), 'utf8');
+    expect(src).toMatch(/enrichResult\.missing\.arch/);
+    expect(src).toMatch(/--arch-key.*not found in eva_architecture_plans/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes feedback `92ff36a1` (witness 2026-04-27): leo-create-sd auto-generated SD metadata referenced `vision_key`/`arch_key` (e.g. `VISION-EVA-SUPPORT-CLI-L2-001` + `ARCH-EVA-SUPPORT-CLI-001` in `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001` metadata) but the corresponding rows did **not** exist in `eva_vision_documents` / `eva_architecture_plans`. LEAD evaluation could not trace strategic provenance because the metadata FK-by-string was an orphan.

## Root cause

- `enrichFromVisionArch` at `scripts/leo-create-sd.js:122` silently swallowed the no-row case (via `.single()` error → caught and warned). It returned `null`, but the caller at line 2251 still wrote the unresolved keys into `sdData.metadata.vision_key` / `metadata.arch_key`.

## Changes (Tier 1, 29 net src LOC)

- `enrichFromVisionArch`: switch `.single()` → `.maybeSingle()` (no row → `data` is `null` instead of throwing) and return `{enriched, missing}` where `missing.{vision,arch}` flag whether a supplied key resolved to no row.
- Direct-args caller (the `/leo create --vision-key X --arch-key Y` path at line 2343): refuse INSERT with descriptive `process.exit(1)` when `missing.vision` or `missing.arch` is true. Operator gets an actionable error naming the unresolved key and the table that would have stored its row.
- Export `enrichFromVisionArch` so it can be exercised by unit tests with a mock supabase client.

## Tests

- 5 new behavioral cases for `enrichFromVisionArch`: no-keys, missing-vision, missing-arch, both-missing, both-resolved-happy-path.
- 2 new static guards pinning the direct-args fail-fast block source-text shape so a future refactor surfaces drift.
- Full leo-create-sd suite regression: 28/28 vitest pass.

## Test plan

- [x] `npx vitest run tests/unit/leo-create-sd-vision-arch-fail-fast.test.js` — 7/7 pass
- [x] `npx vitest run tests/unit/leo-create-sd-*.test.js` (regression) — 28/28 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)