### PR TITLE
fix(QF-20260509-407): complete-quick-fix.js friction cluster (deletion-LOC + --force-complete FAIL bypass + --auto-pr)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-849",
+  "sdKey": "QF-20260509-407",
   "workType": "QF",
-  "workKey": "QF-20260509-849",
-  "expectedBranch": "qf/QF-20260509-849",
-  "createdAt": "2026-05-09T22:18:45.004Z",
+  "workKey": "QF-20260509-407",
+  "expectedBranch": "qf/QF-20260509-407",
+  "createdAt": "2026-05-09T22:32:01.479Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/quickfix-compliance-rubric.js
+++ b/lib/quickfix-compliance-rubric.js
@@ -87,17 +87,25 @@ export const QUICKFIX_RUBRIC = {
         // cap to 75 (QF_HARD_LOC_CAP at scripts/modules/complete-quick-fix/verification.js:13,
         // set by QF-20260504-501). actualLoc is total = source + test which double-counts
         // legitimate test LOC against the source-only QF tier policy.
+        // QF-20260509-407: subtract `sourceDeletionLoc` (LOC from pure-deletion source
+        // files) — dead-code removal is not new source surface and should not consume
+        // the 75-cap budget. Reported number is net source = source - sourceDeletionLoc.
+        // Evidence prefix kept as "Source LOC:" for backward-compat with QF-20260509-070
+        // tests; deletion-only suffix appears only when applicable.
         name: 'LOC Constraint Met (≤75 source)',
         points: 10,
         check: async (context) => {
           const sourceLoc = context.actualSourceLoc ?? context.actualLoc ?? 0;
+          const deletionLoc = context.sourceDeletionLoc ?? 0;
+          const netSourceLoc = Math.max(0, sourceLoc - deletionLoc);
           const testLoc = context.actualTestLoc ?? 0;
-          const withinLimit = sourceLoc <= 75;
+          const withinLimit = netSourceLoc <= 75;
 
+          const deletionNote = deletionLoc > 0 ? `, deletion-only LOC: ${deletionLoc} (excluded from cap)` : '';
           return {
             score: withinLimit ? 10 : 0,
             passed: withinLimit,
-            evidence: `Source LOC: ${sourceLoc} (limit: 75)${testLoc ? `, test LOC: ${testLoc} (excluded)` : ''}`
+            evidence: `Source LOC: ${netSourceLoc} (limit: 75)${deletionNote}${testLoc ? `, test LOC: ${testLoc} (excluded)` : ''}`
           };
         }
       },
@@ -372,8 +380,13 @@ export const QUICKFIX_RUBRIC = {
           const escalationTriggers = [];
 
           // QF-20260509-070: source-only LOC against the canonical 75-cap.
+          // QF-20260509-407: subtract sourceDeletionLoc (pure dead-code removal does
+          // not warrant escalation to a full SD). Trigger label kept as "source LOC >75"
+          // for backward-compat with existing test fixtures; the number is net.
           const sourceLoc = context.actualSourceLoc ?? context.actualLoc ?? 0;
-          if (sourceLoc > 75) escalationTriggers.push('source LOC >75');
+          const deletionLoc = context.sourceDeletionLoc ?? 0;
+          const netSourceLoc = Math.max(0, sourceLoc - deletionLoc);
+          if (netSourceLoc > 75) escalationTriggers.push('source LOC >75');
 
           const filesChanged = context.filesChanged || [];
           if (filesChanged.some(f => f.includes('migration') || f.includes('.sql'))) {

--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -84,6 +84,7 @@ export function parseArguments(args) {
       'force-complete':     { type: 'boolean' },
       'reason':             { type: 'string' },
       'non-interactive':    { type: 'boolean' },
+      'auto-pr':            { type: 'boolean' },
       'help':               { type: 'boolean', short: 'h' }
     },
     allowPositionals: true,
@@ -123,7 +124,12 @@ export function parseArguments(args) {
     verificationNotes: values['verification-notes'],
     forceComplete:     values['force-complete']   || false,
     reason:            values['reason'],
-    nonInteractive:    values['non-interactive'] || false
+    nonInteractive:    values['non-interactive'] || false,
+    // QF-20260509-407: --auto-pr opt-in flag, plus auto-enable under --non-interactive
+    // when no --pr-url provided. Eliminates the mid-run prompt-then-throw pattern
+    // (the prompt() wrapper rejects under non-interactive but only AFTER several
+    // setup steps have already run).
+    autoPr:            values['auto-pr'] || (values['non-interactive'] && !values['pr-url']) || false
   };
 
   return { qfId, options };
@@ -156,6 +162,9 @@ Options:
                         REQUIRES --reason "<text>". Used for already-merged PRs or audit-trailed exceptions.
   --reason              Required with --force-complete. Recorded in verification_notes JSON audit trail.
   --non-interactive     Fail-fast on any prompt (instead of hanging under piped stdin). Use in CI / scripts.
+                        When set without --pr-url, --auto-pr is auto-enabled to avoid mid-run prompt failure.
+  --auto-pr             Auto-create the PR via 'gh pr create' if --pr-url is not provided.
+                        Implicit under --non-interactive when no --pr-url.
   --help, -h            Show this help
 
 Programmatic Verification:

--- a/scripts/modules/complete-quick-fix/compliance-loop.js
+++ b/scripts/modules/complete-quick-fix/compliance-loop.js
@@ -40,6 +40,9 @@ export async function runComplianceWithRefinement(qfId, qf, context, prompt, fla
       // test LOC with source against a stale 50-cap.
       actualSourceLoc: context.actualSourceLoc,
       actualTestLoc: context.actualTestLoc,
+      // QF-20260509-407: forward pure-deletion LOC so the rubric can subtract
+      // dead-code removal from tier-classification (loc_constraint + proper_classification).
+      sourceDeletionLoc: context.sourceDeletionLoc,
       filesChanged: context.filesChanged,
       issueDescription: qf.description,
       complexity: qf.estimated_loc > 30 ? 'medium' : 'low',

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -20,18 +20,24 @@ import { execSync } from 'child_process';
 const TEST_FILE_PATTERN = /(\.test\.|\.spec\.|\b__tests__\b|\btests\/|\be2e\/|\bplaywright\b)/i;
 
 /**
- * Walk `git diff --numstat <baseRef>..HEAD` and return { source, test, total }
- * insertion+deletion counts split by path pattern.
+ * Walk `git diff --numstat <baseRef>..HEAD` and return source/test/total LOC
+ * counts split by path pattern, plus pure-deletion-file LOC for tier classification.
  *
  * Used by both autoDetectGitInfo paths (PR-metadata + legacy worktree) so the
  * conflation bug (single actual_loc) can't recur.
  *
+ * QF-20260509-407: also returns `sourceDeletionLoc` — LOC from source files
+ * that are pure deletions (file no longer exists in HEAD). The compliance
+ * rubric subtracts this from `source` for tier-classification (≤75-source-LOC
+ * cap) checks because dead-code removal is not new source surface and should
+ * not falsely trigger "should escalate to SD".
+ *
  * @param {string} testDir - Directory to run git commands in
  * @param {string} baseRef - Base branch ref (default 'origin/main')
- * @returns {{source: number, test: number, total: number}} Split LOC counts
+ * @returns {{source: number, test: number, total: number, sourceDeletionLoc: number}} Split LOC counts
  */
 export function countLocBySplit(testDir, baseRef = 'origin/main') {
-  const result = { source: 0, test: 0, total: 0 };
+  const result = { source: 0, test: 0, total: 0, sourceDeletionLoc: 0 };
   let numstat = '';
   try {
     numstat = execSync(`git diff --numstat ${baseRef}..HEAD`, {
@@ -44,6 +50,29 @@ export function countLocBySplit(testDir, baseRef = 'origin/main') {
     return result;
   }
 
+  // QF-20260509-407: collect deleted-file paths so we can mark their deletion-LOC
+  // as not-counting-against-tier-cap (pure dead-code removal).
+  const deletedPaths = new Set();
+  try {
+    const nameStatus = execSync(`git diff --name-status --diff-filter=D ${baseRef}..HEAD`, {
+      cwd: testDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000
+    });
+    for (const line of nameStatus.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split('\t');
+      if (parts.length >= 2 && parts[0].startsWith('D')) {
+        deletedPaths.add(parts.slice(1).join('\t').trim());
+      }
+    }
+  } catch {
+    // diff-filter may fail in a fresh worktree; fall through with empty set
+    // (sourceDeletionLoc stays 0 — fail-safe, matches old behavior).
+  }
+
   for (const line of numstat.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -54,10 +83,15 @@ export function countLocBySplit(testDir, baseRef = 'origin/main') {
     const deleted = parts[1] === '-' ? 0 : parseInt(parts[1], 10) || 0;
     const filepath = parts.slice(2).join('\t').trim();
     const loc = added + deleted;
-    if (TEST_FILE_PATTERN.test(filepath)) {
+    const isTest = TEST_FILE_PATTERN.test(filepath);
+    if (isTest) {
       result.test += loc;
     } else {
       result.source += loc;
+      if (deletedPaths.has(filepath)) {
+        // Pure-deletion source file → all `loc` here is `deleted` (added=0).
+        result.sourceDeletionLoc += loc;
+      }
     }
     result.total += loc;
   }
@@ -237,6 +271,8 @@ export function autoDetectGitInfo(testDir, options = {}) {
       if (split.total > 0) {
         result.actualSourceLoc = split.source;
         result.actualTestLoc = split.test;
+        // QF-20260509-407: forward deletion-only source LOC for tier classification.
+        result.sourceDeletionLoc = split.sourceDeletionLoc;
         console.log(`🔍 PR #${prNumber} → source LOC: ${split.source}, test LOC: ${split.test} (split via git numstat)`);
       }
     }
@@ -283,6 +319,8 @@ export function autoDetectGitInfo(testDir, options = {}) {
       if (split.total > 0) {
         result.actualSourceLoc = split.source;
         result.actualTestLoc = split.test;
+        // QF-20260509-407: forward deletion-only source LOC for tier classification.
+        result.sourceDeletionLoc = split.sourceDeletionLoc;
         console.log(`🔍 Auto-detected source LOC: ${split.source}, test LOC: ${split.test} (split via git numstat)`);
       }
     }

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -102,7 +102,7 @@ export async function completeQuickFix(qfId, options = {}) {
     console.error(`\n❌ ${e.message}\n`);
     process.exit(1);
   }
-  let { commitSha, branchName, actualLoc, actualSourceLoc, actualTestLoc } = gitInfo;
+  let { commitSha, branchName, actualLoc, actualSourceLoc, actualTestLoc, sourceDeletionLoc } = gitInfo;
 
   // SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001:
   //   - Operator can override source/test split via --actual-source-loc / --actual-test-loc
@@ -254,12 +254,15 @@ export async function completeQuickFix(qfId, options = {}) {
 
   // Compliance Rubric with Auto-Refinement
   // QF-20260509-070: include source/test split so rubric uses source-only LOC.
+  // QF-20260509-407: forward sourceDeletionLoc so the rubric can subtract pure
+  // dead-code deletion from tier classification (loc_constraint + proper_classification).
   const complianceContext = {
     errorsBeforeFix: evidenceData.errorsBeforeFix,
     errorsAfterFix: evidenceData.errorsAfterFix,
     actualLoc,
     actualSourceLoc,
     actualTestLoc,
+    sourceDeletionLoc,
     filesChanged,
     testsPass
   };

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -320,6 +320,16 @@ export async function validateCompliance(complianceResults, prompt, flags = {}) 
       console.log(`   ${i + 1}. ${c.name} (${c.score}/${c.maxScore} points)`);
       console.log(`      ${c.evidence}\n`);
     });
+    // QF-20260509-407: --force-complete bypasses FAIL-verdict (parity with WARN
+    // branch below). The flag docs say "Bypass self-verification + LOC-cap blocks"
+    // — without this branch, FAIL still hard-blocks even after the refinement-loop
+    // skip from QF-20260509-COMPLIANCE-LOOP. Audit trail lives in verification_notes
+    // JSON via SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 FR-2.
+    if (flags.forceComplete) {
+      console.log(`   ⚠️  --force-complete: FAIL-verdict gate bypassed (reason="${flags.reason}")`);
+      console.log('       quick_fixes.force_completed=true; failed criteria recorded in audit trail.\n');
+      return true;
+    }
     console.log('   Options:');
     console.log('   1. Manually fix issues and re-run completion script');
     console.log('   2. Escalate to full Strategic Directive\n');

--- a/tests/unit/complete-quick-fix/qf-407-friction-cluster.test.js
+++ b/tests/unit/complete-quick-fix/qf-407-friction-cluster.test.js
@@ -1,0 +1,230 @@
+// QF-20260509-407: complete-quick-fix.js friction cluster.
+//
+// Three behaviors fixed (witnessed twice this session via QF-20260509-796 + QF-20260509-849):
+//   A. Deletion-LOC accounting — compliance rubric subtracts pure-deletion-file LOC
+//      from net-source-LOC for tier classification (loc_constraint + proper_classification).
+//   B. --force-complete bypasses FAIL-verdict gate (parity with WARN branch).
+//   C. --auto-pr CLI flag wired + auto-enabled under --non-interactive when no --pr-url.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { QUICKFIX_RUBRIC } = await import('../../../lib/quickfix-compliance-rubric.js');
+const { validateCompliance } = await import(
+  '../../../scripts/modules/complete-quick-fix/verification.js'
+);
+
+function findRule(id) {
+  for (const cat of Object.values(QUICKFIX_RUBRIC)) {
+    const found = cat.criteria?.find(c => c.id === id);
+    if (found) return found;
+  }
+  throw new Error(`Rule not found: ${id}`);
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+// ── Bug A: deletion-LOC accounting ──────────────────────────────────────
+
+describe('QF-20260509-407 Bug A: loc_constraint subtracts sourceDeletionLoc', () => {
+  const rule = findRule('loc_constraint');
+
+  it('passes when net source (source - deletion) is under 75, even if raw source is well over', async () => {
+    // Witnessed shape: QF-20260509-796 deleted a 712-LOC dead duplicate file +
+    // ~19 LOC of edits = source=731, deletionLoc=712, net=19.
+    const r = await rule.check({
+      actualSourceLoc: 731,
+      actualTestLoc: 0,
+      sourceDeletionLoc: 712
+    });
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(10);
+    expect(r.evidence).toMatch(/Source LOC:\s*19/);
+    expect(r.evidence).toMatch(/deletion-only LOC:\s*712.*excluded/);
+  });
+
+  it('fails when net source > 75 even when deletion subtraction applies', async () => {
+    const r = await rule.check({
+      actualSourceLoc: 200,
+      sourceDeletionLoc: 50
+    });
+    expect(r.passed).toBe(false);
+    expect(r.evidence).toMatch(/Source LOC:\s*150/);
+  });
+
+  it('omits deletion-only suffix when sourceDeletionLoc is 0 or undefined (backward compat)', async () => {
+    const r1 = await rule.check({ actualSourceLoc: 25, actualTestLoc: 110 });
+    expect(r1.evidence).not.toMatch(/deletion-only/);
+    expect(r1.evidence).toMatch(/Source LOC:\s*25/);
+
+    const r2 = await rule.check({ actualSourceLoc: 25, sourceDeletionLoc: 0 });
+    expect(r2.evidence).not.toMatch(/deletion-only/);
+  });
+
+  it('clamps net source LOC at 0 when deletion exceeds source (defense, not a real shape)', async () => {
+    const r = await rule.check({ actualSourceLoc: 50, sourceDeletionLoc: 100 });
+    expect(r.passed).toBe(true);
+    expect(r.evidence).toMatch(/Source LOC:\s*0/);
+  });
+});
+
+describe('QF-20260509-407 Bug A: proper_classification subtracts sourceDeletionLoc', () => {
+  const rule = findRule('proper_classification');
+
+  it('does NOT flag escalation when net source <= 75 even when raw source is well over', async () => {
+    const r = await rule.check({
+      actualSourceLoc: 731,
+      sourceDeletionLoc: 712,
+      filesChanged: ['scripts/foo.js']
+    });
+    expect(r.passed).toBe(true);
+    expect(r.evidence).not.toMatch(/source LOC >75/);
+  });
+
+  it('flags escalation when net source > 75', async () => {
+    const r = await rule.check({
+      actualSourceLoc: 200,
+      sourceDeletionLoc: 50,
+      filesChanged: ['scripts/foo.js']
+    });
+    expect(r.passed).toBe(false);
+    expect(r.evidence).toMatch(/source LOC >75/);
+  });
+});
+
+// ── Bug B: --force-complete bypasses FAIL-verdict ──────────────────────────
+
+describe('QF-20260509-407 Bug B: validateCompliance honors {forceComplete} on FAIL verdict', () => {
+  const failResults = {
+    verdict: 'FAIL',
+    totalScore: 51,
+    confidence: 51,
+    criteriaResults: [
+      { name: 'LOC Constraint Met (≤75 source)', score: 0, maxScore: 10, passed: false, evidence: 'Source LOC: 724 (limit: 75)' },
+      { name: 'Properly Classified', score: 0, maxScore: 5, passed: false, evidence: 'Should escalate: source LOC >75' }
+    ]
+  };
+
+  it('FAIL verdict WITHOUT forceComplete returns false (baseline regression check)', async () => {
+    const prompt = vi.fn(() => { throw new Error('prompt should not be called on FAIL'); });
+    const r = await validateCompliance(failResults, prompt);
+    expect(r).toBe(false);
+  });
+
+  it('FAIL verdict WITH forceComplete:true short-circuits and returns true (the fix)', async () => {
+    const prompt = vi.fn(() => { throw new Error('prompt MUST NOT be called when forceComplete:true'); });
+    const r = await validateCompliance(failResults, prompt, {
+      forceComplete: true,
+      reason: 'Tier-1 deletion-only — pre-existing failures unrelated'
+    });
+    expect(r).toBe(true);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('FAIL verdict WITH forceComplete:true logs the bypass reason for audit', async () => {
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((m) => logs.push(String(m)));
+    const prompt = vi.fn(() => { throw new Error('prompt should not be called'); });
+    await validateCompliance(failResults, prompt, {
+      forceComplete: true,
+      reason: 'audited FAIL bypass'
+    });
+    const audit = logs.find(l => l.includes('--force-complete') && l.includes('FAIL-verdict') && l.includes('audited FAIL bypass'));
+    expect(audit).toBeTruthy();
+  });
+
+  it('FAIL verdict WITH forceComplete:false still hard-blocks (does not bypass)', async () => {
+    const prompt = vi.fn(() => { throw new Error('prompt should not be called'); });
+    const r = await validateCompliance(failResults, prompt, { forceComplete: false });
+    expect(r).toBe(false);
+  });
+
+  it('FAIL verdict still logs the failed criteria before bypass (audit completeness)', async () => {
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((m) => logs.push(String(m)));
+    const prompt = vi.fn();
+    await validateCompliance(failResults, prompt, { forceComplete: true, reason: 'r' });
+    const sawCriteria = logs.find(l => l.includes('LOC Constraint Met'));
+    expect(sawCriteria).toBeTruthy();
+  });
+});
+
+// ── Bug C: --auto-pr CLI flag + auto-enable under --non-interactive ────────
+
+describe('QF-20260509-407 Bug C: --auto-pr flag wired in cli.js', () => {
+  const cliPath = resolve(__dirname, '../../../scripts/modules/complete-quick-fix/cli.js');
+
+  it('cli.js declares --auto-pr in the parseArgs options', () => {
+    const src = readFileSync(cliPath, 'utf8');
+    expect(src).toMatch(/'auto-pr':\s*\{\s*type:\s*'boolean'\s*\}/);
+  });
+
+  it('cli.js exports autoPr in the options object', () => {
+    const src = readFileSync(cliPath, 'utf8');
+    expect(src).toMatch(/autoPr:\s*values\['auto-pr'\]/);
+  });
+
+  it('autoPr auto-enables under --non-interactive when no --pr-url provided', () => {
+    const src = readFileSync(cliPath, 'utf8');
+    // pattern: autoPr: values['auto-pr'] || (values['non-interactive'] && !values['pr-url']) || false
+    expect(src).toMatch(/autoPr:[^,\n]*non-interactive[^,\n]*pr-url/);
+  });
+
+  it('--auto-pr appears in the displayHelp output (discoverability)', () => {
+    const src = readFileSync(cliPath, 'utf8');
+    expect(src).toMatch(/--auto-pr\s+Auto-create the PR/);
+  });
+});
+
+// ── countLocBySplit returns sourceDeletionLoc field ────────────────────────
+
+describe('QF-20260509-407 Bug A: countLocBySplit signature includes sourceDeletionLoc', () => {
+  const gitOpsPath = resolve(__dirname, '../../../scripts/modules/complete-quick-fix/git-operations.js');
+
+  it('countLocBySplit initializes sourceDeletionLoc in the result object', () => {
+    const src = readFileSync(gitOpsPath, 'utf8');
+    expect(src).toMatch(/result\s*=\s*\{[^}]*sourceDeletionLoc:\s*0/);
+  });
+
+  it('countLocBySplit reads git diff --name-status --diff-filter=D for deleted-file detection', () => {
+    const src = readFileSync(gitOpsPath, 'utf8');
+    expect(src).toMatch(/git diff --name-status --diff-filter=D/);
+  });
+
+  it('countLocBySplit accumulates sourceDeletionLoc when file is in deletedPaths set', () => {
+    const src = readFileSync(gitOpsPath, 'utf8');
+    expect(src).toMatch(/result\.sourceDeletionLoc\s*\+=/);
+  });
+
+  it('autoDetectGitInfo forwards sourceDeletionLoc on both PR-metadata and legacy paths', () => {
+    const src = readFileSync(gitOpsPath, 'utf8');
+    const matches = src.match(/result\.sourceDeletionLoc\s*=\s*split\.sourceDeletionLoc/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2); // PR + legacy paths
+  });
+
+  it('orchestrator.js destructures sourceDeletionLoc from gitInfo and forwards to compliance', () => {
+    const orchPath = resolve(__dirname, '../../../scripts/modules/complete-quick-fix/orchestrator.js');
+    const src = readFileSync(orchPath, 'utf8');
+    expect(src).toMatch(/let\s*\{[^}]*sourceDeletionLoc[^}]*\}\s*=\s*gitInfo/);
+    expect(src).toMatch(/sourceDeletionLoc[,\s]/); // also forwarded into complianceContext
+  });
+});
+
+// ── File existence guard (regression-pin) ──────────────────────────────────
+
+describe('QF-20260509-407: source files unchanged location', () => {
+  it('cli.js, verification.js, compliance-loop.js, git-operations.js, orchestrator.js all exist at canonical paths', () => {
+    const base = resolve(__dirname, '../../../scripts/modules/complete-quick-fix');
+    for (const f of ['cli.js', 'verification.js', 'compliance-loop.js', 'git-operations.js', 'orchestrator.js']) {
+      expect(existsSync(resolve(base, f)), `${f} should exist`).toBe(true);
+    }
+    expect(existsSync(resolve(__dirname, '../../../lib/quickfix-compliance-rubric.js'))).toBe(true);
+  });
+});

--- a/tests/unit/scripts/complete-quick-fix-loc-split.test.js
+++ b/tests/unit/scripts/complete-quick-fix-loc-split.test.js
@@ -70,7 +70,8 @@ describe('SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 — countLocBySplit', () =>
   it('returns zeros on empty git output (e.g. no commits past base)', () => {
     execSyncMock.mockReturnValue('');
     const r = countLocBySplit('/fake/repo');
-    expect(r).toEqual({ source: 0, test: 0, total: 0 });
+    // QF-20260509-407: signature extended with sourceDeletionLoc.
+    expect(r).toEqual({ source: 0, test: 0, total: 0, sourceDeletionLoc: 0 });
   });
 
   it('honors custom baseRef', () => {


### PR DESCRIPTION
## Summary
Three behaviors in \`scripts/complete-quick-fix.js\` hit twice this session (QF-20260509-796 + QF-20260509-849) and worked around with \`--actual-source-loc\` overrides + manual \`gh pr create\`. This PR systemically fixes all three.

## Changes

### Bug A — Deletion-LOC accounting
- \`countLocBySplit\` now also returns \`sourceDeletionLoc\` (LOC from pure-deletion source files; detected via \`git diff --name-status --diff-filter=D\`)
- Compliance rubric (\`loc_constraint\` + \`proper_classification\`) subtracts \`sourceDeletionLoc\` from \`sourceLoc\` for tier-classification (≤75-cap) checks
- Net source LOC = \`source - sourceDeletionLoc\` — dead-code removal no longer falsely triggers "should escalate to SD" on QFs that delete drifted code

### Bug B — --force-complete bypasses FAIL verdict
- \`validateCompliance\` FAIL branch now honors \`{forceComplete}\` flag (parity with WARN branch from QF-20260508-407)
- Audit trail logs "FAIL-verdict gate bypassed" with reason before returning true; failed criteria still logged before bypass
- 12th-witness \`PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001\` — sibling that QF-20260508-407 missed

### Bug C — --auto-pr CLI flag + auto-enable under --non-interactive
- New \`--auto-pr\` boolean flag wires the existing \`createAutoPR()\` path
- Auto-enabled when \`--non-interactive\` is set without \`--pr-url\` (eliminates mid-run prompt-then-throw)
- Help text updated for discoverability

## Test plan
- [x] 21 new tests in \`tests/unit/complete-quick-fix/qf-407-friction-cluster.test.js\` (8 Bug A, 5 Bug B, 4 Bug C, 4 static-guard wiring) — **21/21 pass**
- [x] 1 existing test updated (\`complete-quick-fix-loc-split.test.js\` line 73 \`toEqual\` shape now includes \`sourceDeletionLoc: 0\`)
- [x] 3 pre-existing failures (\`validate-loc 76-LOC\` + 2 \`autodetect-git-info\` numstat-mock cases) confirmed pre-existing via \`git stash && vitest run\` — not caused by this PR

## Tier
**TIER_2** (~70 source LOC + ~190 test LOC).

## Closes
- QF-20260509-407
- Harness backlog feedback \`79fbcd5d\` (filed this session during QF-796 ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)