### PR TITLE
fix(QF-20260509-409): close 3 pre-existing test failures (validate-loc 4-args + countLocBySplit numstat guard)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-407",
+  "sdKey": "QF-20260509-409",
   "workType": "QF",
-  "workKey": "QF-20260509-407",
-  "expectedBranch": "qf/QF-20260509-407",
-  "createdAt": "2026-05-09T22:32:01.479Z",
+  "workKey": "QF-20260509-409",
+  "expectedBranch": "qf/QF-20260509-409",
+  "createdAt": "2026-05-09T23:04:51.827Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -49,6 +49,11 @@ export function countLocBySplit(testDir, baseRef = 'origin/main') {
   } catch {
     return result;
   }
+  // QF-20260509-409: defensive guard — execSync may return undefined under some
+  // mock setups (e.g. mockReturnValueOnce exhausted in upstream test), in which
+  // case `numstat.split` throws. The catch block above only fires on throw, not
+  // on undefined return. Match the empty-output fail-safe.
+  if (!numstat) return result;
 
   // QF-20260509-407: collect deleted-file paths so we can mark their deletion-LOC
   // as not-counting-against-tier-cap (pure dead-code removal).

--- a/tests/unit/complete-quick-fix/autodetect-git-info.test.js
+++ b/tests/unit/complete-quick-fix/autodetect-git-info.test.js
@@ -61,7 +61,11 @@ describe('autoDetectGitInfo — PR-metadata authoritative path', () => {
     expect(result.commitSha).toBe('a1b2c3d4e5f6789012345678901234567890abcd');
     expect(result.branchName).toBe('qf/QF-EXAMPLE-001');
     expect(result.actualLoc).toBe(85);
-    expect(execSync).toHaveBeenCalledTimes(1);
+    // QF-20260509-409: the count assertion was over-specified — autoDetectGitInfo
+    // also calls countLocBySplit (numstat + name-status) when actualSourceLoc is
+    // undefined. Original assertion passed only because countLocBySplit threw on
+    // undefined numstat (bug, now guarded). First-call shape assertion below is
+    // sufficient to verify gh-first.
     expect(execSync.mock.calls[0][0]).toContain('gh pr view 999');
   });
 

--- a/tests/unit/complete-quick-fix/validate-loc.test.js
+++ b/tests/unit/complete-quick-fix/validate-loc.test.js
@@ -18,17 +18,23 @@ describe('QF-501 LOC-CAP-1: hard cap matches CLAUDE.md routing (Tier 3 = >75)', 
   });
 });
 
+// QF-20260509-409: validateLOC signature was extended by SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 FR-1
+// from (loc, qfId, supabase, prompt) to (sourceLoc, testLoc, qfId, supabase, prompt, flags). These tests
+// were not updated — the testLoc/qfId/supabase positions shifted, so prompt was landing in the wrong
+// position. The ≤75-LOC tests passed silently (no prompt call) but the >75 test crashed at prompt
+// invocation (TypeError: prompt is not a function). All 4 calls now use the canonical 5-arg form.
+
 describe('QF-501 LOC-CAP-2: 31–75 LOC (Tier 2 Standard QF) is accepted', () => {
   it('returns true for 75 LOC (boundary)', async () => {
-    const r = await validateLOC(75, 'QF-X', null, async () => 'no');
+    const r = await validateLOC(75, 0, 'QF-X', null, async () => 'no');
     expect(r).toBe(true);
   });
   it('returns true for 60 LOC (mid-Tier 2)', async () => {
-    const r = await validateLOC(60, 'QF-X', null, async () => 'no');
+    const r = await validateLOC(60, 0, 'QF-X', null, async () => 'no');
     expect(r).toBe(true);
   });
   it('returns true for 51 LOC (was rejected pre-fix)', async () => {
-    const r = await validateLOC(51, 'QF-X', null, async () => 'no');
+    const r = await validateLOC(51, 0, 'QF-X', null, async () => 'no');
     expect(r).toBe(true);
   });
 });
@@ -36,7 +42,7 @@ describe('QF-501 LOC-CAP-2: 31–75 LOC (Tier 2 Standard QF) is accepted', () =>
 describe('QF-501 LOC-CAP-3: >75 LOC (Tier 3) still rejected', () => {
   it('returns false for 76 LOC and prompts for escalation', async () => {
     const prompt = vi.fn(async () => 'no');
-    const r = await validateLOC(76, 'QF-X', null, prompt);
+    const r = await validateLOC(76, 0, 'QF-X', null, prompt);
     expect(r).toBe(false);
     expect(prompt).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## Summary
3 pre-existing test failures uncovered during QF-20260509-407 ship (confirmed pre-existing via \`git stash && vitest run\`). All sit in tests adjacent to the just-modified complete-quick-fix module.

## Failures fixed

### Failure 1 — \`validate-loc.test.js\` QF-501 LOC-CAP-3
\`TypeError: prompt is not a function\` at \`verification.js:50\`. \`validateLOC\` signature was extended by SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 FR-1 from \`(loc, qfId, supabase, prompt)\` to \`(sourceLoc, testLoc, qfId, supabase, prompt, flags)\`. Tests still called the 4-arg form, shifting prompt to the supabase position. The ≤75-LOC tests passed silently (no prompt call) but the >75 test crashed when validateLOC called the missing prompt arg.

**Fix**: all 4 calls aligned to canonical 5-arg form.

### Failures 2+3 — \`autodetect-git-info.test.js\` Path 1 + Open PR
\`TypeError: Cannot read properties of undefined (reading 'split')\` at \`git-operations.js:76\`. Test mocks \`gh-pr-view\` via \`mockReturnValueOnce\`, then \`countLocBySplit\`'s subsequent execSync (numstat) returns undefined, then \`numstat.split\` crashes. The try-catch wraps execSync but not \`numstat.split\`.

**Fix**:
- **Source**: defensive \`if (!numstat) return result;\` in countLocBySplit (matches the empty-output fail-safe; also benefits production for any execSync edge that returns falsy without throwing).
- **Test**: removed an over-specified \`toHaveBeenCalledTimes(1)\` assertion in Path 1 — countLocBySplit legitimately makes additional execSync calls. The first-call-shape assertion (line 65) is sufficient.

## Test plan
- [x] \`npx vitest run tests/unit/complete-quick-fix/ ...\` → **105/105 pass** (was 102/105 with these 3 failures)
- [x] No new regressions

## Tier
**TIER_1** (~10 source LOC + 5 test LOC).

## Closes
- QF-20260509-409
- 3 pre-existing test-baseline failures shrinking the test_failures gate budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)