### PR TITLE
fix(QF-20260509-NESTED-JUNCTION): safeRecursiveRm/Cp recursive walk for nested junctions

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1062,6 +1062,7 @@ function logWorktreeEvent(event, fields = {}) {
 /**
  * Junction-safe recursive removal.
  * SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001
+ * QF-20260509-NESTED-JUNCTION: recursive walk for nested junctions
  *
  * On Windows, fs.rmSync({recursive:true,force:true}) can follow Windows junctions
  * (created via fs.symlinkSync(target, link, 'junction')) and delete the JUNCTION
@@ -1070,8 +1071,12 @@ function logWorktreeEvent(event, fields = {}) {
  *
  * Strategy:
  *  - If the path itself is a symlink/junction, fs.unlinkSync it (don't recurse).
- *  - If it's a directory, walk top-level entries and unlink any symlink/junction
- *    children FIRST, then fs.rmSync the remainder recursively.
+ *  - If it's a directory, walk the FULL TREE and unlink every symlink/junction
+ *    descendant FIRST, then fs.rmSync the remainder recursively. The recursive
+ *    walk is required because junctions can be nested (e.g. wt/<sub>/node_modules);
+ *    a single-level pre-pass (the original implementation) would miss them and
+ *    rmSync would follow them. Witnessed 2026-05-09: reaper wiped repo-root
+ *    node_modules via SD-LEO-INFRA-MAKE-SESSIONSTART-WORKTREE-001 archive.
  *
  * On Unix, Node already does not follow symlinks during recursive rm; the lstat
  * check is harmless. Cross-platform identical behavior for the symlink case.
@@ -1097,39 +1102,64 @@ export function safeRecursiveRm(targetPath, options = {}) {
     return;
   }
   if (stat.isDirectory()) {
-    const entries = fs.readdirSync(targetPath, { withFileTypes: true });
-    for (const entry of entries) {
-      const childPath = path.join(targetPath, entry.name);
-      let childStat;
-      try {
-        childStat = fs.lstatSync(childPath);
-      } catch {
-        continue;
-      }
-      if (childStat.isSymbolicLink()) {
-        try {
-          _unlinkSymOrJunction(childPath);
-        } catch (err) {
-          if (!force) throw err;
-        }
-      }
-    }
+    _unlinkLinksRecursive(targetPath, force);
   }
   fs.rmSync(targetPath, { recursive: true, force });
 }
 
 /**
+ * Walk a directory tree and unlink every symlink/junction descendant.
+ * Does not delete regular files or directories — caller is expected to
+ * follow up with fs.rmSync({recursive:true}). Once all junctions/symlinks
+ * are unlinked, that final rmSync cannot follow a junction target.
+ *
+ * @param {string} dir - Directory to walk
+ * @param {boolean} force - Suppress per-entry errors when true
+ */
+function _unlinkLinksRecursive(dir, force) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const childPath = path.join(dir, entry.name);
+    let childStat;
+    try {
+      childStat = fs.lstatSync(childPath);
+    } catch {
+      continue;
+    }
+    if (childStat.isSymbolicLink()) {
+      try {
+        _unlinkSymOrJunction(childPath);
+      } catch (err) {
+        if (!force) throw err;
+      }
+      continue;
+    }
+    if (childStat.isDirectory()) {
+      _unlinkLinksRecursive(childPath, force);
+    }
+  }
+}
+
+/**
  * Junction-safe recursive copy. Symmetric to safeRecursiveRm.
  * SD-FDBK-ENH-SESSION-WORKTREE-CLEANUP-001
+ * QF-20260509-NESTED-JUNCTION: recursive walk for nested junctions
  *
  * fs.cpSync({recursive:true}) on Windows can follow junctions and copy the
  * JUNCTION TARGET's multi-GB contents into the destination. For _archive of
  * worktrees, that means duplicating the main repo's node_modules into
  * .worktrees/_archive/<sd>-<ts> — wasted disk and slow archival.
  *
- * Strategy: walk entries; for each symlink/junction, try to recreate as a link
- * at the destination (preserving the link itself, not the target). Fall through
- * to fs.cpSync for regular directories/files.
+ * Strategy: walk entries recursively; for each symlink/junction at any depth,
+ * recreate as a link at the destination (preserving the link itself, not the
+ * target). Recursive descent is required to handle nested junctions —
+ * delegating to fs.cpSync for any subdirectory (the original behavior) would
+ * follow nested junctions on Windows.
  *
  * @param {string} srcPath
  * @param {string} destPath
@@ -1163,7 +1193,11 @@ export function safeRecursiveCp(srcPath, destPath, options = {}) {
       _recreateLinkAtDest(srcChild, destChild);
       continue;
     }
-    fs.cpSync(srcChild, destChild, { recursive: true, ...options });
+    if (childStat.isDirectory()) {
+      safeRecursiveCp(srcChild, destChild, options);
+    } else {
+      fs.copyFileSync(srcChild, destChild);
+    }
   }
 }
 

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -57,7 +57,7 @@ import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 
 import { listActiveWorktrees } from '../lib/worktree-quota.js';
-import { safeRecursiveRm } from '../lib/worktree-manager.js';
+import { safeRecursiveRm, safeRecursiveCp } from '../lib/worktree-manager.js';
 import {
   isZombieOnMain,
   isNested,
@@ -441,9 +441,22 @@ function preserveUntrackedFiles({ wtPath, preserveRoot, untracked, repoRoot, log
     const tgt = path.join(dest, rel);
     try {
       fs.mkdirSync(path.dirname(tgt), { recursive: true });
-      const st = fs.statSync(src);
+      // QF-20260509-NESTED-JUNCTION: lstat (not stat) to detect symlinks/junctions
+      // without following them. safeRecursiveCp recreates links at destination
+      // instead of duplicating junction-target contents.
+      const st = fs.lstatSync(src);
       if (st.isDirectory()) {
-        fs.cpSync(src, tgt, { recursive: true });
+        safeRecursiveCp(src, tgt);
+      } else if (st.isSymbolicLink()) {
+        try {
+          const target = fs.readlinkSync(src);
+          const linkType = process.platform === 'win32' ? 'junction' : 'file';
+          fs.symlinkSync(target, tgt, linkType);
+        } catch (e) {
+          logger?.(`preserve: symlink-recreate failed for ${rel} (${e?.message || e})`);
+          skipped.push(rel);
+          continue;
+        }
       } else {
         fs.copyFileSync(src, tgt);
       }

--- a/tests/unit/lib/safeRecursive-nested-junction.test.js
+++ b/tests/unit/lib/safeRecursive-nested-junction.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { safeRecursiveRm, safeRecursiveCp } from '../../../lib/worktree-manager.js';
+
+/**
+ * QF-20260509-NESTED-JUNCTION — runtime regression pin
+ *
+ * Witness 2026-05-09T23:27Z: scripts/worktree-reaper.mjs called safeRecursiveRm
+ * on .worktrees/SD-LEO-INFRA-MAKE-SESSIONSTART-WORKTREE-001 which contained a
+ * NESTED junction (one level deep below the top-level worktree path). The
+ * pre-fix safeRecursiveRm only unlinked top-level junctions; the nested
+ * junction was followed by the final fs.rmSync({recursive:true}), wiping
+ * repo-root node_modules and bricking 5 parallel Claude Code sessions.
+ *
+ * This test pins the recursive-walk fix: a junction at depth >= 2 must be
+ * unlinked (NOT followed) so the final rmSync cannot delete the link target.
+ *
+ * Cross-platform: junction is a Windows reparse-point construct
+ * (fs.symlinkSync(target, link, 'junction')). On non-Windows we use a regular
+ * directory symlink which Node's recursive rm already handles safely; the
+ * test still asserts the recursive-walk shape on non-Windows too.
+ */
+
+const isWindows = process.platform === 'win32';
+
+describe('safeRecursiveRm — nested junction regression pin (QF-20260509-NESTED-JUNCTION)', () => {
+  let tmpRoot;
+  let externalTarget;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-nested-junction-rm-'));
+    externalTarget = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-junction-target-'));
+    fs.writeFileSync(path.join(externalTarget, 'sentinel.txt'), 'preserve-me');
+  });
+
+  afterEach(() => {
+    // best-effort cleanup; we use the helper-under-test for tmpRoot to avoid
+    // re-introducing the bug from the cleanup path itself.
+    try { safeRecursiveRm(tmpRoot); } catch {}
+    try { safeRecursiveRm(externalTarget); } catch {}
+  });
+
+  it('NESTED junction at depth=2 does not cause target wipe', () => {
+    const wt = path.join(tmpRoot, 'wt');
+    const sub = path.join(wt, 'sub');
+    fs.mkdirSync(sub, { recursive: true });
+
+    const linkPath = path.join(sub, 'node_modules');
+    if (isWindows) {
+      fs.symlinkSync(externalTarget, linkPath, 'junction');
+    } else {
+      fs.symlinkSync(externalTarget, linkPath, 'dir');
+    }
+
+    safeRecursiveRm(wt);
+
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(externalTarget)).toBe(true);
+    expect(fs.existsSync(path.join(externalTarget, 'sentinel.txt'))).toBe(true);
+  });
+
+  it('NESTED junction at depth=3 also survives', () => {
+    const wt = path.join(tmpRoot, 'wt');
+    const deep = path.join(wt, 'a', 'b');
+    fs.mkdirSync(deep, { recursive: true });
+
+    const linkPath = path.join(deep, 'linked');
+    if (isWindows) {
+      fs.symlinkSync(externalTarget, linkPath, 'junction');
+    } else {
+      fs.symlinkSync(externalTarget, linkPath, 'dir');
+    }
+
+    safeRecursiveRm(wt);
+
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(path.join(externalTarget, 'sentinel.txt'))).toBe(true);
+  });
+
+  it('TOP-LEVEL junction (the original case) still survives', () => {
+    const wt = path.join(tmpRoot, 'wt');
+    fs.mkdirSync(wt, { recursive: true });
+
+    const linkPath = path.join(wt, 'node_modules');
+    if (isWindows) {
+      fs.symlinkSync(externalTarget, linkPath, 'junction');
+    } else {
+      fs.symlinkSync(externalTarget, linkPath, 'dir');
+    }
+
+    safeRecursiveRm(wt);
+
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(path.join(externalTarget, 'sentinel.txt'))).toBe(true);
+  });
+});
+
+describe('safeRecursiveCp — nested junction regression pin (QF-20260509-NESTED-JUNCTION)', () => {
+  let tmpRoot;
+  let externalTarget;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-nested-junction-cp-'));
+    externalTarget = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-cp-target-'));
+    fs.writeFileSync(path.join(externalTarget, 'big-content.txt'), 'a'.repeat(1024));
+  });
+
+  afterEach(() => {
+    try { safeRecursiveRm(tmpRoot); } catch {}
+    try { safeRecursiveRm(externalTarget); } catch {}
+  });
+
+  it('NESTED junction is recreated as link, not copied', () => {
+    const src = path.join(tmpRoot, 'src');
+    const sub = path.join(src, 'sub');
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(src, 'real-file.txt'), 'real');
+
+    const linkPath = path.join(sub, 'linked');
+    if (isWindows) {
+      fs.symlinkSync(externalTarget, linkPath, 'junction');
+    } else {
+      fs.symlinkSync(externalTarget, linkPath, 'dir');
+    }
+
+    const dest = path.join(tmpRoot, 'dest');
+    safeRecursiveCp(src, dest);
+
+    expect(fs.existsSync(path.join(dest, 'real-file.txt'))).toBe(true);
+    const destLinkPath = path.join(dest, 'sub', 'linked');
+    expect(fs.existsSync(destLinkPath)).toBe(true);
+    const destLinkStat = fs.lstatSync(destLinkPath);
+    expect(destLinkStat.isSymbolicLink()).toBe(true);
+    // Junction target's contents must NOT be duplicated under dest/sub/linked
+    // (i.e. lstat reports a symlink, the helper preserved the link).
+  });
+});

--- a/tests/unit/lib/worktree-rmsync-junction-safety.test.js
+++ b/tests/unit/lib/worktree-rmsync-junction-safety.test.js
@@ -71,11 +71,20 @@ function walkScripts(dir, accum = []) {
 // formatting variants (newlines, varying spacing).
 const RAW_RMSYNC_RECURSIVE = /\bfs\.rmSync\s*\([^)]*\brecursive\s*:\s*true/s;
 
+// QF-20260509-NESTED-JUNCTION: fs.cpSync({recursive:true}) follows Windows
+// junctions just like fs.rmSync({recursive:true}). Worktree-related files that
+// COPY recursively must use safeRecursiveCp to avoid junction-target duplication
+// (or wipe in the rare case the target is symlinked elsewhere).
+const RAW_CPSYNC_RECURSIVE = /\bfs\.cpSync\s*\([^)]*\brecursive\s*:\s*true/s;
+
 // Confirms file uses junction-safe rm. Two accepted patterns:
 //   1. References safeRecursiveRm (ESM ./lib/worktree-manager.js consumers)
 //   2. Inlines junction-aware logic (CJS callers): lstatSync + isSymbolicLink + unlinkSync
 //      indicate the file checks-and-unlinks junctions BEFORE rmSync.
 const SAFE_IMPORT = /\bsafeRecursiveRm\b|isSymbolicLink\(\)[\s\S]{0,200}\bunlinkSync\b/;
+
+// Confirms file uses junction-safe cp.
+const SAFE_CP_IMPORT = /\bsafeRecursiveCp\b/;
 
 // Worktree-related code paths — files that operate on `.worktrees/*` paths.
 // The static guard only fires on these; non-worktree rmSync (e.g., cleaning
@@ -87,7 +96,7 @@ const WORKTREE_PATH_REFERENCE = /\.worktrees|worktree-(?:reaper|manager)|wtPath|
 describe('worktree-rmsync junction safety — static guard over scripts/', () => {
   const allFiles = walkScripts(SCRIPTS_DIR);
 
-  it(`finds at least 100 source files under scripts/ (sanity)`, () => {
+  it('finds at least 100 source files under scripts/ (sanity)', () => {
     expect(allFiles.length).toBeGreaterThan(100);
   });
 
@@ -116,13 +125,43 @@ describe('worktree-rmsync junction safety — static guard over scripts/', () =>
     if (offenders.length > 0) {
       const message =
         `Found ${offenders.length} WORKTREE-RELATED file(s) using raw fs.rmSync({recursive:true}) ` +
-        `without junction-safe handling:\n` +
+        'without junction-safe handling:\n' +
         offenders.map((f) => `  - ${f}`).join('\n') +
-        `\n\nFix options:\n` +
-        `  1. ESM callers: import { safeRecursiveRm } from '../lib/worktree-manager.js' and replace the rmSync call.\n` +
-        `  2. CJS callers (cannot import ESM directly): inline the unlink-junction-first pattern. See ` +
-        `scripts/hooks/concurrent-session-worktree.cjs (QF-20260508-102) for the canonical CJS template.\n` +
-        `  3. Or scripts/worktree-reaper.mjs (QF-20260508-102) for the canonical ESM pattern.`;
+        '\n\nFix options:\n' +
+        '  1. ESM callers: import { safeRecursiveRm } from \'../lib/worktree-manager.js\' and replace the rmSync call.\n' +
+        '  2. CJS callers (cannot import ESM directly): inline the unlink-junction-first pattern. See ' +
+        'scripts/hooks/concurrent-session-worktree.cjs (QF-20260508-102) for the canonical CJS template.\n' +
+        '  3. Or scripts/worktree-reaper.mjs (QF-20260508-102) for the canonical ESM pattern.';
+      throw new Error(message);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every WORKTREE-RELATED script that uses fs.cpSync({recursive:true}) MUST use safeRecursiveCp', () => {
+    // QF-20260509-NESTED-JUNCTION: closes 4th witness of WINDOWS-JUNCTION-FOLLOW-RECURSIVE-RM-001 chain.
+    // Reaper's preserve-untracked path used raw fs.cpSync({recursive:true}) which on Windows
+    // would copy junction-target contents (e.g. node_modules) into scratch/preserved-from-*.
+    const offenders = [];
+    for (const file of allFiles) {
+      let src;
+      try {
+        src = readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      const stripped = stripComments(src);
+      if (!RAW_CPSYNC_RECURSIVE.test(stripped)) continue;
+      if (!WORKTREE_PATH_REFERENCE.test(stripped)) continue;
+      if (!SAFE_CP_IMPORT.test(stripped)) {
+        offenders.push(file.replace(/\\/g, '/'));
+      }
+    }
+    if (offenders.length > 0) {
+      const message =
+        `Found ${offenders.length} WORKTREE-RELATED file(s) using raw fs.cpSync({recursive:true}) ` +
+        'without junction-safe handling:\n' +
+        offenders.map((f) => `  - ${f}`).join('\n') +
+        '\n\nFix: import { safeRecursiveCp } from \'../lib/worktree-manager.js\' and replace the cpSync call.';
       throw new Error(message);
     }
     expect(offenders).toEqual([]);
@@ -138,6 +177,29 @@ fs.rmSync(wtPath, { recursive: true, force: true });
     expect(stripped).toMatch(RAW_RMSYNC_RECURSIVE);
     expect(stripped).toMatch(WORKTREE_PATH_REFERENCE);
     expect(stripped).not.toMatch(SAFE_IMPORT);
+  });
+
+  it('cpSync regex correctly detects synthetic worktree-related violation', () => {
+    const violation = `
+import fs from 'node:fs';
+const wtPath = '/some/.worktrees/SD-X-001';
+fs.cpSync(src, wtPath, { recursive: true });
+    `;
+    const stripped = stripComments(violation);
+    expect(stripped).toMatch(RAW_CPSYNC_RECURSIVE);
+    expect(stripped).toMatch(WORKTREE_PATH_REFERENCE);
+    expect(stripped).not.toMatch(SAFE_CP_IMPORT);
+  });
+
+  it('cpSync regex accepts ESM caller with safeRecursiveCp import', () => {
+    const guarded = `
+import { safeRecursiveCp } from '../lib/worktree-manager.js';
+import fs from 'node:fs';
+const wtPath = '/some/.worktrees/SD-X-001';
+safeRecursiveCp(src, wtPath);
+    `;
+    const stripped = stripComments(guarded);
+    expect(stripped).toMatch(SAFE_CP_IMPORT);
   });
 
   it('regex accepts ESM caller with safeRecursiveRm import', () => {


### PR DESCRIPTION
## Summary
- 4th witness of WINDOWS-JUNCTION-FOLLOW-RECURSIVE-RM-001 chain. Witnessed 2026-05-09T23:27Z when `npm run worktree:reap:execute` reaped `.worktrees/SD-LEO-INFRA-MAKE-SESSIONSTART-WORKTREE-001` and the brute-force fallback's `safeRecursiveRm` followed a **nested** junction, wiping repo-root `node_modules/` and bricking 5 parallel Claude Code sessions.
- Helper-internal fix: `safeRecursiveRm` and `safeRecursiveCp` now do a **full-tree** recursive walk to unlink every symlink/junction descendant before delegating to junction-following node APIs.
- Reaper's `preserveUntrackedFiles` (line 446) now uses `safeRecursiveCp` and `lstatSync` so symlinks are preserved as links instead of having their targets copied.
- Static guard extended to also flag `fs.cpSync({recursive:true})` for worktree-related files (4 new positive/negative regex tests).
- Runtime regression pin (4 tests): nested junction at depth=2 / depth=3 / top-level / cpSync nested — asserts external link target survives.

## Root cause (RCA)
Diagnosed via `rca-agent` (run `aa80838b839e01fb0`). 5-Whys converged on: `safeRecursiveRm` did a **single-depth** pre-pass before calling `fs.rmSync({recursive:true})`. Junctions nested below the top level (e.g. `wt/<sub>/node_modules`) slipped through, then the final rmSync followed them on Windows. The PR #3630 AST static guard verified callers IMPORT `safeRecursiveRm`, not that the helper is correct — so the bug-inside-the-helper passed.

## Test plan
- [x] `npx vitest run tests/unit/lib/safeRecursive-nested-junction.test.js tests/unit/lib/worktree-rmsync-junction-safety.test.js` → 14/14 pass (4 new + 10 extended)
- [x] `npx vitest run tests/unit/lib/` → 177/177 actual tests pass (2 pre-existing custom-runner files report process.exit-as-failure; unrelated baseline)
- [x] Pattern: PAT-WINDOWS-JUNCTION-SHALLOW-WALK-001 (filed; 4th witness of WINDOWS-JUNCTION-FOLLOW-RECURSIVE-RM-001)
- [x] Files changed: `lib/worktree-manager.js`, `scripts/worktree-reaper.mjs`, `tests/unit/lib/worktree-rmsync-junction-safety.test.js`, `tests/unit/lib/safeRecursive-nested-junction.test.js`
- [ ] Smoke test post-merge: re-run `worktree:reap:execute` against any nested-junction-containing worktree (none currently in fleet, but the regression test pins it)

## Tier
Tier-2 QF (~30 src LOC + ~210 test LOC). Junction-walk fix is contained, no schema/migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)