### PR TITLE
fix(QF-20260509-699): PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001 sibling-sites batch — context-monitor + unified-state-manager

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -8,6 +8,6 @@
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-05-10T00:57:06.943Z",
-  "lastUpdatedAt": "2026-05-10T00:57:06.946Z"
+  "clearedAt": "2026-05-10T01:10:23.583Z",
+  "lastUpdatedAt": "2026-05-10T01:10:23.585Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260509-442",
+  "sdKey": "QF-20260509-699",
   "workType": "QF",
-  "workKey": "QF-20260509-442",
-  "expectedBranch": "qf/QF-20260509-442",
-  "createdAt": "2026-05-10T00:45:16.900Z",
+  "workKey": "QF-20260509-699",
+  "expectedBranch": "qf/QF-20260509-699",
+  "createdAt": "2026-05-10T01:06:34.806Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/agents/context-monitor.js
+++ b/lib/agents/context-monitor.js
@@ -401,19 +401,25 @@ class ContextMonitor {
         uncommitted_changes: false
       };
       
+      // QF-20260509-699: stdio:'pipe' on all 3 sites prevents child stderr from
+      // leaking when cwd isn't a repo or HEAD~5 doesn't exist
+      // (PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001).
+
       // Get current branch
       try {
-        context.current_branch = execSync('git branch --show-current', { 
-          cwd: this.projectRoot, 
-          encoding: 'utf8' 
+        context.current_branch = execSync('git branch --show-current', {
+          cwd: this.projectRoot,
+          encoding: 'utf8',
+          stdio: 'pipe'
         }).trim();
       } catch {}
 
       // Get recent commits
       try {
-        const commits = execSync('git log --oneline -5', { 
-          cwd: this.projectRoot, 
-          encoding: 'utf8' 
+        const commits = execSync('git log --oneline -5', {
+          cwd: this.projectRoot,
+          encoding: 'utf8',
+          stdio: 'pipe'
         }).trim().split('\n');
         context.recent_commits = commits.map(line => {
           const [hash, ...message] = line.split(' ');
@@ -423,9 +429,10 @@ class ContextMonitor {
 
       // Get recent file changes
       try {
-        const changes = execSync('git diff --name-only HEAD~5..HEAD', { 
-          cwd: this.projectRoot, 
-          encoding: 'utf8' 
+        const changes = execSync('git diff --name-only HEAD~5..HEAD', {
+          cwd: this.projectRoot,
+          encoding: 'utf8',
+          stdio: 'pipe'
         }).trim().split('\n').filter(f => f);
         context.recent_changes = changes.map(file => ({ file, type: 'modified' }));
       } catch {}

--- a/lib/context/unified-state-manager.js
+++ b/lib/context/unified-state-manager.js
@@ -343,29 +343,36 @@ class UnifiedStateManager {
    * Get git state safely
    */
   getGitState() {
+    // QF-20260509-699: stdio:'pipe' on all 5 sites prevents child stderr from
+    // leaking when cwd isn't a repo or HEAD~5 doesn't exist
+    // (PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001).
     try {
       const branch = execSync('git branch --show-current', {
         cwd: this.projectDir,
         encoding: 'utf8',
-        timeout: 5000
+        timeout: 5000,
+        stdio: 'pipe'
       }).trim();
 
       const status = execSync('git status --porcelain', {
         cwd: this.projectDir,
         encoding: 'utf8',
-        timeout: 5000
+        timeout: 5000,
+        stdio: 'pipe'
       }).trim();
 
       const recentCommits = execSync('git log -5 --oneline', {
         cwd: this.projectDir,
         encoding: 'utf8',
-        timeout: 5000
+        timeout: 5000,
+        stdio: 'pipe'
       }).trim().split('\n').filter(Boolean);
 
       const stagedChanges = execSync('git diff --cached --stat', {
         cwd: this.projectDir,
         encoding: 'utf8',
-        timeout: 5000
+        timeout: 5000,
+        stdio: 'pipe'
       }).trim();
 
       let modifiedFiles = [];
@@ -373,7 +380,8 @@ class UnifiedStateManager {
         modifiedFiles = execSync('git diff --name-only HEAD~5', {
           cwd: this.projectDir,
           encoding: 'utf8',
-          timeout: 5000
+          timeout: 5000,
+          stdio: 'pipe'
         }).trim().split('\n').filter(Boolean).slice(0, 20);
       } catch {
         // If HEAD~5 doesn't exist, use status

--- a/lib/multi-repo/index.js
+++ b/lib/multi-repo/index.js
@@ -146,12 +146,14 @@ export function discoverRepos() {
           const known = KNOWN_REPOS[entry] || KNOWN_REPOS[entry.toLowerCase()];
 
           // Try to get GitHub remote
+          // QF-20260509-699: stdio:'pipe' (PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001).
           let github = known?.github || `rickfelix/${entry}`;
           try {
             const remoteUrl = execSync('git remote get-url origin', {
               encoding: 'utf8',
               cwd: fullPath,
-              timeout: 5000
+              timeout: 5000,
+              stdio: 'pipe'
             }).trim();
 
             const match = remoteUrl.match(/github\.com[:/](.+?)(?:\.git)?$/);

--- a/tests/unit/stderr-leak-static-guard.test.js
+++ b/tests/unit/stderr-leak-static-guard.test.js
@@ -1,0 +1,71 @@
+/**
+ * Static guard test for PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001.
+ * QF-20260509-699 — sibling-sites batch follow-up to QF-20260509-442 (PR #3656).
+ *
+ * Scans the 3 files known to call execSync('git ...') inside silent try/catch
+ * blocks and asserts every execSync invocation passes stdio:'pipe' (or array
+ * form with stderr piped/ignored). Without this guard, a future edit can
+ * silently re-introduce the stderr leak — the JS catch keeps the pipeline
+ * green but the user sees `fatal:` on stderr.
+ *
+ * Pinned files (must keep stdio:'pipe' on every execSync call):
+ *   - lib/multi-repo/index.js
+ *   - lib/agents/context-monitor.js
+ *   - lib/context/unified-state-manager.js
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+
+const PINNED_FILES = [
+  'lib/multi-repo/index.js',
+  'lib/agents/context-monitor.js',
+  'lib/context/unified-state-manager.js',
+];
+
+// Match an execSync call and capture its full argument-object literal.
+// Greedy enough to span multi-line option blocks; relies on balanced braces
+// being uncommon inside the options object (no nested object literals exist
+// in the pinned files).
+const EXEC_SYNC_CALL_RE = /execSync\s*\([^)]*?\{([^{}]*?)\}\s*\)/gms;
+
+function findExecSyncCalls(source) {
+  const matches = [];
+  let m;
+  EXEC_SYNC_CALL_RE.lastIndex = 0;
+  while ((m = EXEC_SYNC_CALL_RE.exec(source)) !== null) {
+    matches.push({
+      full: m[0],
+      optionsBody: m[1],
+      lineNumber: source.slice(0, m.index).split('\n').length,
+    });
+  }
+  return matches;
+}
+
+function hasStdioPipe(optionsBody) {
+  // Accepts: stdio: 'pipe' | "pipe" | [..., 'pipe'|'ignore', ...]
+  return /stdio\s*:\s*(['"]pipe['"]|\[[^\]]*\])/.test(optionsBody);
+}
+
+describe('PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001 — static guard', () => {
+  for (const relPath of PINNED_FILES) {
+    it(`every execSync in ${relPath} sets stdio:'pipe'`, () => {
+      const source = readFileSync(join(repoRoot, relPath), 'utf8');
+      const calls = findExecSyncCalls(source);
+      expect(calls.length, `expected at least one execSync call in ${relPath}`).toBeGreaterThan(0);
+
+      const offenders = calls.filter((c) => !hasStdioPipe(c.optionsBody));
+      const offenderLines = offenders.map((c) => `  line ${c.lineNumber}: ${c.full.slice(0, 120).replace(/\s+/g, ' ')}…`).join('\n');
+      expect(
+        offenders.length,
+        `${offenders.length} execSync call(s) in ${relPath} missing stdio:'pipe' — see PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001:\n${offenderLines}`,
+      ).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260509-699  **Type:** bug **Severity:** medium  ### Issue Description Follow-up to QF-20260509-442 (PR #3656) closing the remaining 8 stderr-leak sibling sites in lib/agents/context-monitor.js (3 sites: lines 406/414/426) + lib/context/unified-state-manager.js (5 sites: lines 347/353/359/365/373). Same pattern PAT-EXEC-SYNC-STDERR-LEAK-IN-CATCH-001: each is execSync('git ...') inside an empty try/catch without stdio:'pipe' — Node default ['pipe','pipe','inherit'] leaks child stderr to parent terminal even though JS exception is swallowed. Fix: add stdio:'pipe' to each call (8 LOC source). Plus: static-guard vitest case scanning lib/ for the anti-pattern (try-catch wrapping execSync without stdio:'pipe') as regression-pin against future drift.     ### Changes - **Files Changed:** 4   - lib/agents/context-monitor.js   - lib/context/unified-state-manager.js   - lib/multi-repo/index.js   - tests/unit/stderr-leak-static-guard.test.js - **LOC:** 107 lines - **Tests:** ❌ Failed - **UAT:** ✅ Verified  ### Verification Static guard caught 9th site in multi-repo/index.js:151 that rca-agent missed — guard works. Closes pattern class across all 3 pinned files.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol