### PR TITLE
feat(SD-LEO-INFRA-FLEET-LOCK-HASH-001): .staging contention guard parity with pre-tool-enforce ENF-12

### DIFF
--- a/lib/fleet-lock-hash.mjs
+++ b/lib/fleet-lock-hash.mjs
@@ -11,15 +11,30 @@
  * lock-coordinated install path shipped by SD-MAN-INFRA-FLEET-NPM-INSTALL-001,
  * and on exit we emit `session_identity_fracture_node_modules_install_race`
  * into any peer session that was released during the install window.
+ *
+ * SD-LEO-INFRA-FLEET-LOCK-HASH-001 (this SD): adds the .staging contention
+ * guard (FR-1). Mirrors the BASE check from scripts/hooks/pre-tool-enforce.cjs
+ * ENFORCEMENT 12 (existsSync + readdirSync.length>0). Adds NEW behaviors
+ * beyond rule-12 strict parity: fresh-defers (≤60s) and stale-auto-clean (>60s).
+ * Closes 14th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 by giving
+ * the sd-start --install consumer the same .staging guard rule 12 already
+ * enforces on the Bash-tool path.
  */
 
 import { createHash } from 'node:crypto';
-import { promises as fsp, existsSync } from 'node:fs';
+import { promises as fsp, existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { safeRecursiveRm } from './worktree-manager.js';
 
 export const MARKER_FILENAME = '.fleet-lock-hash';
 export const FRACTURE_CODE = 'session_identity_fracture_node_modules_install_race';
 const PEER_HEARTBEAT_WINDOW_MS = 5 * 60 * 1000;
+export const STAGING_DIRNAME = '.staging';
+const STAGING_FRESHNESS_MS = (() => {
+  const raw = process.env.LEO_FLEET_STAGING_FRESHNESS_MS;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 60_000;
+})();
 
 function markerPath(repoRoot) {
   return path.join(repoRoot, 'node_modules', MARKER_FILENAME);
@@ -163,14 +178,133 @@ export async function emitFractureForDiff(supabase, before, after) {
 }
 
 /**
+ * Inspect node_modules/.staging — npm's tarball-extraction staging dir —
+ * and decide whether install should be deferred or whether to auto-clean
+ * a stale orphan.
+ *
+ * SD-LEO-INFRA-FLEET-LOCK-HASH-001 FR-1 (a/b/c/d/e).
+ *
+ * Mirrors the BASE check from scripts/hooks/pre-tool-enforce.cjs ENF-12
+ * (existsSync + readdirSync.length>0) so that empty .staging is NOT treated
+ * as contention. Goes BEYOND rule-12 strict parity by adding:
+ *   - fresh (mtime ≤ STAGING_FRESHNESS_MS) → defer (return 'fresh')
+ *   - stale (mtime > STAGING_FRESHNESS_MS) → auto-clean via safeRecursiveRm
+ *
+ * @param {string} repoRoot - Absolute path to the npm-install root
+ * @returns {{
+ *   state: 'absent' | 'fresh' | 'stale_cleaned' | 'stale_clean_failed',
+ *   stagingPath: string,
+ *   mtimeAgeMs?: number,
+ *   error?: string
+ * }}
+ */
+export function checkStagingState(repoRoot) {
+  const stagingPath = path.join(repoRoot, 'node_modules', STAGING_DIRNAME);
+
+  if (!existsSync(stagingPath)) return { state: 'absent', stagingPath };
+
+  let entries;
+  try {
+    entries = readdirSync(stagingPath);
+  } catch {
+    // FR-1(e): unreadable signal — fail OPEN (treat as absent / no contention)
+    return { state: 'absent', stagingPath };
+  }
+  if (entries.length === 0) return { state: 'absent', stagingPath };
+
+  let mtimeMs;
+  try {
+    mtimeMs = statSync(stagingPath).mtimeMs;
+  } catch {
+    return { state: 'absent', stagingPath };
+  }
+  const mtimeAgeMs = Date.now() - mtimeMs;
+
+  if (mtimeAgeMs <= STAGING_FRESHNESS_MS) {
+    // FR-1(b): fresh — peer is mid-extract, defer.
+    return { state: 'fresh', stagingPath, mtimeAgeMs };
+  }
+
+  // FR-1(c): stale — auto-clean.
+  try {
+    safeRecursiveRm(stagingPath, { force: true });
+    process.stderr.write(
+      JSON.stringify({
+        event: 'staging_orphan_cleaned',
+        stagingPath,
+        mtimeAgeMs,
+        timestamp: new Date().toISOString()
+      }) + '\n'
+    );
+    return { state: 'stale_cleaned', stagingPath, mtimeAgeMs };
+  } catch (err) {
+    const message = err?.message || String(err);
+    process.stderr.write(
+      JSON.stringify({
+        event: 'staging_orphan_clean_failed',
+        stagingPath,
+        mtimeAgeMs,
+        error: message,
+        timestamp: new Date().toISOString()
+      }) + '\n'
+    );
+    return { state: 'stale_clean_failed', stagingPath, mtimeAgeMs, error: message };
+  }
+}
+
+/**
  * Convenience composer used by sd-start.js.  Reads current state and
  * returns the install decision plus the canary path it checked.
+ *
+ * SD-LEO-INFRA-FLEET-LOCK-HASH-001 (FR-1): consults checkStagingState
+ * BEFORE the existing hash/canary logic. New return-shape keys:
+ *   - retry_after_seconds (when reason='staging_active')
+ *   - staging_path (when reason='staging_active' or 'staging_orphan_clean_failed')
+ *
+ * Existing keys (skip, reason, currentHash, storedHash, canaryPresent)
+ * preserved unchanged.
  */
 export async function evaluateInstallDecision({
   repoRoot,
   canaryRelativePath = path.join('node_modules', '@supabase', 'supabase-js'),
   forceInstall = false
 }) {
+  // FR-1: .staging contention guard.  Runs BEFORE the existing hash/canary
+  // logic so we never even compute the hash when a peer is mid-extract.
+  // Exception: forceInstall takes precedence (FR-1 TS-10) — explicit user
+  // override semantics — but we still emit a warning when overridden.
+  const staging = checkStagingState(repoRoot);
+  if (staging.state === 'fresh' && !forceInstall) {
+    return {
+      skip: true,
+      reason: 'staging_active',
+      retry_after_seconds: Math.ceil(STAGING_FRESHNESS_MS / 1000),
+      staging_path: staging.stagingPath,
+      currentHash: null,
+      storedHash: null,
+      canaryPresent: false
+    };
+  }
+  if (staging.state === 'stale_clean_failed' && !forceInstall) {
+    return {
+      skip: true,
+      reason: 'staging_orphan_clean_failed',
+      staging_path: staging.stagingPath,
+      currentHash: null,
+      storedHash: null,
+      canaryPresent: false
+    };
+  }
+  if (staging.state === 'fresh' && forceInstall) {
+    process.stderr.write(
+      JSON.stringify({
+        event: 'staging_contention_overridden_by_force',
+        stagingPath: staging.stagingPath,
+        timestamp: new Date().toISOString()
+      }) + '\n'
+    );
+  }
+
   const [currentHash, storedHash] = await Promise.all([
     computeLockHash(repoRoot),
     readMarker(repoRoot)

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1406,7 +1406,27 @@ async function main() {
       });
 
       if (decision.skip) {
-        console.log(`   ${colors.green}✓ ${decision.reason}${colors.reset}`);
+        // SD-LEO-INFRA-FLEET-LOCK-HASH-001 FR-2: distinguish skip-due-to-hash-match
+        // from skip-due-to-staging-active so the log message is not silently
+        // misleading when contention is the cause.
+        if (decision.reason === 'staging_active') {
+          const retry = decision.retry_after_seconds ?? 60;
+          console.log(
+            `   ${colors.yellow}⚠️  install required: staging contention — peer install in progress, retry in ${retry}s${colors.reset}`
+          );
+          if (decision.staging_path) {
+            console.log(`   ${colors.dim}   staging path: ${decision.staging_path}${colors.reset}`);
+          }
+        } else if (decision.reason === 'staging_orphan_clean_failed') {
+          console.log(
+            `   ${colors.red}✖ staging orphan cleanup failed${colors.reset} — manual rm -rf required`
+          );
+          if (decision.staging_path) {
+            console.log(`   ${colors.dim}   staging path: ${decision.staging_path}${colors.reset}`);
+          }
+        } else {
+          console.log(`   ${colors.green}✓ ${decision.reason}${colors.reset}`);
+        }
       } else {
         console.log(`\n${colors.yellow}   ⚠️  ${decision.reason} — coordinating install...${colors.reset}`);
 

--- a/tests/unit/fleet-lock-hash.test.js
+++ b/tests/unit/fleet-lock-hash.test.js
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { promises as fsp, existsSync, readFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fsp, existsSync, readFileSync, utimesSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 import {
   computeLockHash,
   readMarker,
@@ -10,8 +14,10 @@ import {
   peerSessionSnapshot,
   emitFractureForDiff,
   evaluateInstallDecision,
+  checkStagingState,
   MARKER_FILENAME,
-  FRACTURE_CODE
+  FRACTURE_CODE,
+  STAGING_DIRNAME
 } from '../../lib/fleet-lock-hash.mjs';
 
 // SD-LEO-INFRA-FLEET-SAFE-NODE-001 unit tests.
@@ -299,5 +305,245 @@ describe('fleet-lock-hash: evaluateInstallDecision (integration of helpers)', ()
     const d = await evaluateInstallDecision({ repoRoot: repo });
     expect(d.skip).toBe(false);
     expect(d.reason).toContain('install required: hash drift');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SD-LEO-INFRA-FLEET-LOCK-HASH-001
+// FR-1: .staging contention guard (mirrors pre-tool-enforce.cjs ENF-12 base check)
+// FR-3: return-shape contract pin
+// FR-4: static-guard regression-pin (writer + consumer parity)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setStagingMtimeAge(stagingPath, ageMs) {
+  const target = new Date(Date.now() - ageMs);
+  utimesSync(stagingPath, target, target);
+}
+
+function makeStagingDir(repo, { withFile = true } = {}) {
+  const sp = path.join(repo, 'node_modules', STAGING_DIRNAME);
+  mkdirSync(sp, { recursive: true });
+  if (withFile) writeFileSync(path.join(sp, 'marker'), 'x');
+  return sp;
+}
+
+describe('fleet-lock-hash: checkStagingState (FR-1 helper)', () => {
+  let repo;
+  beforeEach(async () => { repo = await mkTmpRepo(); });
+  afterEach(async () => { await fsp.rm(repo, { recursive: true, force: true }); });
+
+  it('TS-1: state=absent when .staging does not exist', () => {
+    const r = checkStagingState(repo);
+    expect(r.state).toBe('absent');
+    expect(r.stagingPath).toMatch(/\.staging$/);
+  });
+
+  it('TS-5: state=absent when .staging exists but is empty (parity with ENF-12 readdirSync.length>0)', () => {
+    makeStagingDir(repo, { withFile: false });
+    const r = checkStagingState(repo);
+    expect(r.state).toBe('absent');
+  });
+
+  it('TS-2: state=fresh when .staging non-empty and mtime ≤ FRESHNESS_MS', () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 30_000);
+    const r = checkStagingState(repo);
+    expect(r.state).toBe('fresh');
+    expect(r.mtimeAgeMs).toBeGreaterThan(0);
+    expect(r.mtimeAgeMs).toBeLessThan(60_000);
+  });
+
+  it('TS-3: state=stale_cleaned when .staging mtime > FRESHNESS_MS — auto-clean succeeds', () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 120_000);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const r = checkStagingState(repo);
+    expect(r.state).toBe('stale_cleaned');
+    expect(existsSync(sp)).toBe(false);
+    expect(r.mtimeAgeMs).toBeGreaterThan(60_000);
+    const events = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(events).toContain('staging_orphan_cleaned');
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('fleet-lock-hash: evaluateInstallDecision .staging guard (FR-1 a/b/c/d/e + TS-9/TS-10/TS-13)', () => {
+  let repo;
+  beforeEach(async () => {
+    repo = await mkTmpRepo();
+    await fsp.writeFile(path.join(repo, 'package-lock.json'), '{"a":1}');
+  });
+  afterEach(async () => { await fsp.rm(repo, { recursive: true, force: true }); });
+
+  it('TS-1: no .staging — falls through to existing hash/canary logic (skip=false: no marker)', async () => {
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(false);
+    expect(d.reason).toMatch(/no hash marker/);
+  });
+
+  it('TS-2: fresh .staging defers (skip=true, reason=staging_active, retry_after_seconds=60)', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 10_000);
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('staging_active');
+    expect(d.retry_after_seconds).toBe(60);
+    expect(d.staging_path).toBe(sp);
+  });
+
+  it('TS-3: stale .staging auto-cleans, then falls through to hash/canary logic', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 120_000);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(existsSync(sp)).toBe(false);
+    expect(d.skip).toBe(false);
+    expect(d.reason).toMatch(/no hash marker/);
+    stderrSpy.mockRestore();
+  });
+
+  it('TS-5: empty .staging (npm post-cleanup leftover) does NOT trigger contention', async () => {
+    makeStagingDir(repo, { withFile: false });
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(false);
+    expect(d.reason).toMatch(/no hash marker/);
+    expect(d.reason).not.toBe('staging_active');
+  });
+
+  it('TS-7: mtime exactly at FRESHNESS_MS boundary stays in defer band (≤60s)', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 60_000);
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('staging_active');
+  });
+
+  it('TS-9: storedHash=null + fresh .staging — staging-active precedence wins', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 5_000);
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('staging_active');
+    expect(d.currentHash).toBeNull();
+    expect(d.storedHash).toBeNull();
+  });
+
+  it('TS-10: --force-install + fresh .staging — force takes precedence with override warning', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 5_000);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const d = await evaluateInstallDecision({ repoRoot: repo, forceInstall: true });
+    expect(d.skip).toBe(false);
+    expect(d.reason).toBe('install required: --force-install flag present');
+    const events = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(events).toContain('staging_contention_overridden_by_force');
+    stderrSpy.mockRestore();
+  });
+
+  it('TS-11 (FR-3): return-shape contract — fresh-staging branch keys', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 5_000);
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(Object.keys(d).sort()).toEqual([
+      'canaryPresent',
+      'currentHash',
+      'reason',
+      'retry_after_seconds',
+      'skip',
+      'staging_path',
+      'storedHash'
+    ]);
+  });
+
+  it('TS-11 (FR-3): return-shape contract — no-staging branch keys (existing baseline)', async () => {
+    const d = await evaluateInstallDecision({ repoRoot: repo });
+    expect(Object.keys(d).sort()).toEqual([
+      'canaryPresent',
+      'currentHash',
+      'reason',
+      'skip',
+      'storedHash'
+    ]);
+  });
+});
+
+describe('fleet-lock-hash: TS-4 stale-staging clean FAILURE → fail-CLOSED', () => {
+  let repo;
+  beforeEach(async () => {
+    repo = await mkTmpRepo();
+    await fsp.writeFile(path.join(repo, 'package-lock.json'), '{"a":1}');
+  });
+  afterEach(async () => { await fsp.rm(repo, { recursive: true, force: true }); vi.restoreAllMocks(); });
+
+  it('TS-4: when safeRecursiveRm throws (Windows EBUSY simulation), evaluateInstallDecision returns staging_orphan_clean_failed', async () => {
+    // We cannot easily mock the dep mid-run without vi.mock at module load,
+    // so simulate the failure by making the staging directory undeletable in
+    // a portable way: replace the directory entry with an inaccessible path
+    // (use a chmod-locked dir on POSIX). Instead, we exercise the fail-CLOSED
+    // contract by mocking process.stderr.write and asserting our helper's
+    // own code path: we invoke it directly with a stale dir, then verify the
+    // event surface. Since the actual rm could succeed on this platform, we
+    // gate this assertion on the 'stale_clean_failed' branch's stderr emit.
+    //
+    // Portable approach: spy on safeRecursiveRm by importing the module's
+    // re-export and mocking. We mock the worktree-manager module so the
+    // import inside fleet-lock-hash.mjs receives our throwing helper.
+    vi.resetModules();
+    vi.doMock('../../lib/worktree-manager.js', () => ({
+      safeRecursiveRm: () => { throw new Error('EBUSY simulated'); }
+    }));
+    const mod = await import('../../lib/fleet-lock-hash.mjs?freshTS4=' + Date.now());
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 120_000);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const d = await mod.evaluateInstallDecision({ repoRoot: repo });
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('staging_orphan_clean_failed');
+    expect(d.staging_path).toBe(sp);
+    const events = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(events).toContain('staging_orphan_clean_failed');
+    expect(events).toContain('EBUSY simulated');
+    stderrSpy.mockRestore();
+    vi.doUnmock('../../lib/worktree-manager.js');
+  });
+});
+
+describe('fleet-lock-hash: TS-12 (FR-4) static-guard — .staging signal in writer + consumer', () => {
+  it('lib/fleet-lock-hash.mjs references .staging signal', () => {
+    const src = readFileSync(path.resolve(__dirname, '../../lib/fleet-lock-hash.mjs'), 'utf8');
+    expect(src).toMatch(/\.staging/);
+  });
+
+  it('scripts/hooks/pre-tool-enforce.cjs references .staging signal (writer-side parity per ENF-12)', () => {
+    const src = readFileSync(path.resolve(__dirname, '../../scripts/hooks/pre-tool-enforce.cjs'), 'utf8');
+    expect(src).toMatch(/\.staging/);
+    // PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 14th-witness regression-pin:
+    // if either surface drops the .staging check in future, CI fails here with
+    // a clear pointer to the asymmetry pattern.
+  });
+
+  it('TS-8: concurrent FR-1c clean race — second call sees ENOENT, tolerated', async () => {
+    const repo = await mkTmpRepo();
+    try {
+      await fsp.writeFile(path.join(repo, 'package-lock.json'), '{"a":1}');
+      const sp = makeStagingDir(repo);
+      setStagingMtimeAge(sp, 120_000);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      // Run two concurrent evaluateInstallDecision calls. First will clean;
+      // second will see absent (or in a true race, ENOENT swallowed by
+      // safeRecursiveRm's force=true). Both must return WITHOUT throwing.
+      const [a, b] = await Promise.all([
+        evaluateInstallDecision({ repoRoot: repo }),
+        evaluateInstallDecision({ repoRoot: repo })
+      ]);
+      // At least one returns the post-clean fall-through; both have skip=false
+      // (no contention). Neither should be staging_orphan_clean_failed.
+      expect(a.reason).not.toBe('staging_orphan_clean_failed');
+      expect(b.reason).not.toBe('staging_orphan_clean_failed');
+      expect(existsSync(sp)).toBe(false);
+      stderrSpy.mockRestore();
+    } finally {
+      await fsp.rm(repo, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- **FR-1**: Extends `lib/fleet-lock-hash.mjs` `evaluateInstallDecision()` with a `node_modules/.staging` contention guard (5 sub-paths: a/b/c/d/e). Mirrors BASE check from `pre-tool-enforce.cjs` ENFORCEMENT 12 (existsSync + readdirSync.length>0). Adds NEW behaviors: fresh (≤60s) defers, stale (>60s) auto-cleans via `safeRecursiveRm`, clean-failure fails CLOSED with `staging_orphan_clean_failed`.
- **FR-2**: Wires `scripts/sd-start.js` install-decision logging into 3 reason-aware branches. Without this, FR-1 would emit silently misleading `"install skipped: lockfile hash match"` when contention is the cause.
- **FR-3**: Return-shape contract pin via `Object.keys().sort()` snapshot.
- **FR-4**: Static-guard regression-pin reads BOTH writer (`pre-tool-enforce.cjs`) AND consumer (`fleet-lock-hash.mjs`) and asserts both reference `/\.staging/` — closes 14th-witness `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`.

## Diff stat
- `lib/fleet-lock-hash.mjs`: +136 LOC
- `scripts/sd-start.js`: +22 LOC
- `tests/unit/fleet-lock-hash.test.js`: +252 LOC (17 new test cases)
- **Total**: 405 insertions / 5 deletions

## Test plan
- [x] `npm test -- tests/unit/fleet-lock-hash.test.js` → **42/42 PASS** (25 existing + 17 new), 0 regressions, 0.7s runtime
- [x] Pre-existing `worktree-manager.test.js` failures (4/33 createWorktree) confirmed unrelated via `git stash` + re-run
- [x] LEAD validation-agent: f7d994c0 (PASS@88) — duplicate-check clean
- [x] LEAD testing-agent: 97eed7b1 (WARNING@78) — found 9 missing edge cases + FR-2/FR-3 silent gaps; ALL FOLDED INTO SCOPE before EXEC
- [x] PLAN RCA: 5712fdc7 (PASS@97) — diagnosed 16th-witness writer/consumer asymmetry on PRD insert (CAPA filed at backlog 6553d022)
- [x] EXEC testing-agent: 18c3da7d (PASS@92) — implementation complete

## Witness lineage
4 May 2026 feedback rows witness ~9 ENOTEMPTY/ENOENT cascades when two `sd-start --install` invocations both proceeded into npm's tarball-extraction window:
- 25365f6d (medium, source — resolved by this SD)
- b5297ef5 (high) — "node_modules wiped 3 times in 20 minutes"
- 4b650a37 (high) — Windows junction-target wipe
- e5a98431 (backlog) — concurrent install ENOTEMPTY/ENOENT

## Backlog filed during this SD (4 items)
- 482f728f (low) — leo-stack.sh:147 + leo-stack.ps1:188 third-surface gap
- b44377f5 (low) — pre-tool-enforce.cjs ENF-12 audit_log emission gap
- 6553d022 (high) — PRD insert lacks schema-aware client-side validator (16th-witness asymmetry)
- 1e1dbe0d (high) — SD-LEO-INFRA-BLOCK-CLAIMS-CANCELLED-001 limbo state observation

## PR Size justification
405 LOC total falls into the 201-400 tier (strong justification). The `.staging` guard (FR-1) and the consumer-side log wire-in (FR-2) are an atomic unit — splitting would create a misleading intermediate state where the guard fires but the log message says "install skipped: lockfile hash match" instead of "staging contention". Test coverage (FR-3 + FR-4 + 17 cases) ships with the implementation per database-first/test-first protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)