### PR TITLE
feat(SD-LEO-INFRA-POST-MERGE-AUTO-001): post-merge orchestrator coverage for non-/ship merge surfaces + DB session derive fallback

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -699,7 +699,11 @@ node scripts/modules/shipping/post-merge-worktree-cleanup.js --sdKey <SD-KEY-OR-
 if [ "${STEP_6_3_RAN_QF_CLOSURE:-false}" = "false" ] && [ "${LEO_AUTOHANDOFF_ENABLED:-true}" = "true" ]; then
   SD_KEY=$(echo "$BRANCH" | sed -nE 's|^(feat|fix|refactor|docs|test)/(SD-[^-]+(-[^-/]+)*)/?.*|\2|p')
   if [ -n "$SD_KEY" ]; then
-    node scripts/post-merge-handoff-orchestrator.js --sd-key="$SD_KEY"
+    # SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-1: pass --merged-branch so the orchestrator
+    # can derive an active session_id from claude_sessions when CLAUDE_SESSION_ID env
+    # is missing. $BRANCH is the original branch name (string), preserved even after
+    # `gh pr merge --delete-branch` removed the local ref.
+    node scripts/post-merge-handoff-orchestrator.js --sd-key="$SD_KEY" --merged-branch="$BRANCH"
     if [ $? -eq 0 ]; then
       export STEP_6_5_RAN_AUTOHANDOFF=true
     fi

--- a/scripts/gh-merge-safe.mjs
+++ b/scripts/gh-merge-safe.mjs
@@ -15,11 +15,57 @@
  * Defaults: --squash, no branch deletion.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 
 function sh(cmd) {
   return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+/**
+ * SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-3: invoke the post-merge handoff orchestrator
+ * after a successful gh-api-PUT merge so SDs merged via this fallback path receive
+ * the same auto-pipeline (status flip → retro generation → claim release → learning
+ * capture) as the /ship Step 6 path. Skipped for QF branches (handled by
+ * complete-quick-fix.js elsewhere).
+ *
+ * Honors LEO_AUTOHANDOFF_ENABLED for emergency disable parity with ship.md Step 6.5.
+ *
+ * Failure here is logged but does NOT propagate as an exit-1 — the merge itself
+ * already succeeded and the post-merge layer is reconcilable by orphan-qf-reaper /
+ * future post-merge sweep. Operators can re-run the orchestrator manually if needed.
+ */
+function invokePostMergeOrchestrator(headRefName) {
+  if (process.env.LEO_AUTOHANDOFF_ENABLED === 'false') {
+    console.log('ℹ️  LEO_AUTOHANDOFF_ENABLED=false — skipping post-merge orchestrator');
+    return;
+  }
+  // QF skip parity with ship.md Step 6.3 → Step 6.5 (second-block) flow.
+  if (/^(qf|quick-fix)\//.test(headRefName)) {
+    return;
+  }
+  // Derive SD_KEY from branch name with the same regex shape as ship.md Step 6.5
+  // (sed -nE 's|^(feat|fix|refactor|docs|test)/(SD-[^-]+(-[^-/]+)*)/?.*|\2|p').
+  const sdKeyMatch = headRefName.match(/^(?:feat|fix|refactor|docs|test)\/(SD-[^-]+(?:-[^-/]+)*)\/?/);
+  if (!sdKeyMatch) {
+    return;
+  }
+  const sdKey = sdKeyMatch[1];
+  console.log(`🔁 Post-merge orchestrator: ${sdKey} (merged_branch=${headRefName})`);
+  const r = spawnSync(
+    'node',
+    [
+      'scripts/post-merge-handoff-orchestrator.js',
+      `--sd-key=${sdKey}`,
+      `--merged-branch=${headRefName}`,
+    ],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env: process.env },
+  );
+  if (r.status !== 0) {
+    console.error(
+      `⚠️  Post-merge orchestrator exited ${r.status} (non-blocking): ${(r.stderr || '').trim().slice(0, 500)}`,
+    );
+  }
 }
 
 function main() {
@@ -68,6 +114,11 @@ function main() {
     console.error(`Merge failed for PR #${prNumber}: ${e.stderr || e.message}`);
     process.exit(1);
   }
+
+  // SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-3: invoke post-merge orchestrator BEFORE
+  // optional branch deletion so we still have a live local ref if the orchestrator
+  // needs it for any future enrichment. Branch-name string is preserved either way.
+  invokePostMergeOrchestrator(preview.headRefName);
 
   if (values['delete-branch']) {
     try {

--- a/scripts/post-merge-handoff-orchestrator.js
+++ b/scripts/post-merge-handoff-orchestrator.js
@@ -42,18 +42,85 @@ export function classifyState({ status, current_phase }) {
   return { action: 'warn_skip', reason: `unexpected_phase_${current_phase}_status_${status}` };
 }
 
-function defaultRunner(cmd, args) {
-  const r = spawnSync(cmd, args, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env: process.env });
+function defaultRunner(cmd, args, opts = {}) {
+  const env = opts.env || process.env;
+  const r = spawnSync(cmd, args, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env });
   return { exitCode: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
 }
 
-// Orchestrator with injectable supabase + runner for tests.
-export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner, env = process.env }) {
-  if (!env.CLAUDE_SESSION_ID) {
-    logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'no_session', exit_code: 2 });
-    return { exitCode: 2, error: 'CLAUDE_SESSION_ID required for handoff claim validity', step: 'preflight' };
+/**
+ * Derive an active session_id from a merged-branch name when CLAUDE_SESSION_ID is missing.
+ *
+ * SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-2: replaces the lines 52-54 hard-fail with a
+ * unique-active-session lookup, falling back to fail-loud-when-ambiguous.
+ *
+ * Resolution rules (LEAD decision D4):
+ *   - count == 1                                      → return session_id
+ *   - count == 0                                      → exit 2 (no_active_session_for_branch)
+ *   - count >= 2, top.heartbeat_at - next > 2 seconds → return top.session_id (warn)
+ *   - count >= 2, within ±2s                          → exit 2 (ambiguous_concurrent_sessions)
+ *
+ * Status filter (status='active') and 60s heartbeat freshness window prevent SIGKILLed
+ * sessions from impersonating dead workers (risk-agent NEW-RISK-1+2 mitigation).
+ */
+export async function deriveSessionFromBranch(supabase, mergedBranch) {
+  const STALE_HEARTBEAT_SEC = 60;
+  const TIE_BREAK_MS = 2000;
+  const cutoff = new Date(Date.now() - STALE_HEARTBEAT_SEC * 1000).toISOString();
+
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, heartbeat_at')
+    .eq('current_branch', mergedBranch)
+    .is('released_at', null)
+    .eq('status', 'active')
+    .gt('heartbeat_at', cutoff)
+    .order('heartbeat_at', { ascending: false })
+    .limit(2);
+
+  if (error) {
+    return { ok: false, reason: 'db_query_failed', detail: error.message };
   }
-  logEvent({ event: 'orchestrator_start', sd_key: sdKey });
+
+  const rows = data || [];
+  if (rows.length === 0) {
+    return { ok: false, reason: 'no_active_session_for_branch', merged_branch: mergedBranch };
+  }
+  if (rows.length === 1) {
+    return { ok: true, session_id: rows[0].session_id, source: 'unique_match' };
+  }
+  const topMs = new Date(rows[0].heartbeat_at).getTime();
+  const nextMs = new Date(rows[1].heartbeat_at).getTime();
+  if (topMs - nextMs > TIE_BREAK_MS) {
+    return { ok: true, session_id: rows[0].session_id, source: 'most_recent_heartbeat_warn', heartbeat_delta_ms: topMs - nextMs };
+  }
+  return { ok: false, reason: 'ambiguous_concurrent_sessions', heartbeat_delta_ms: topMs - nextMs };
+}
+
+// Orchestrator with injectable supabase + runner for tests.
+export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner, env = process.env, mergedBranch = null }) {
+  // SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-2: env CLAUDE_SESSION_ID still wins;
+  // --merged-branch DB-derive is the unique-match fallback.
+  let resolvedSession = env.CLAUDE_SESSION_ID;
+  let sessionSource = resolvedSession ? 'env' : null;
+  if (!resolvedSession && mergedBranch) {
+    const derived = await deriveSessionFromBranch(supabase, mergedBranch);
+    if (derived.ok) {
+      resolvedSession = derived.session_id;
+      sessionSource = derived.source;
+      logEvent({ event: 'session_derived', sd_key: sdKey, merged_branch: mergedBranch, source: derived.source, session_id: resolvedSession });
+    } else {
+      logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'session_derive_failed', reason: derived.reason, merged_branch: mergedBranch, exit_code: 2 });
+      return { exitCode: 2, error: `deriveSessionFromBranch: ${derived.reason}`, step: 'preflight', detail: derived };
+    }
+  }
+  if (!resolvedSession) {
+    logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'no_session', exit_code: 2 });
+    return { exitCode: 2, error: 'CLAUDE_SESSION_ID required for handoff claim validity (no env, no --merged-branch)', step: 'preflight' };
+  }
+  // Propagate the resolved session into the env for downstream subprocesses.
+  env = { ...env, CLAUDE_SESSION_ID: resolvedSession };
+  logEvent({ event: 'orchestrator_start', sd_key: sdKey, session_source: sessionSource });
   const startTs = Date.now();
 
   const { data: sd, error: lookupErr } = await supabase
@@ -77,7 +144,7 @@ export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner,
     if (subagent) {
       const subStart = Date.now();
       logEvent({ event: 'subagent_start', sd_key: sdKey, subagent, phase: handoff });
-      const sub = runner('node', ['lib/sub-agent-executor.js', subagent, sdKey]);
+      const sub = runner('node', ['lib/sub-agent-executor.js', subagent, sdKey], { env });
       logEvent({ event: 'subagent_end', sd_key: sdKey, subagent, exit_code: sub.exitCode, duration_ms: Date.now() - subStart });
       if (sub.exitCode !== 0) {
         logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'subagent_failed', step: handoff, exit_code: 4 });
@@ -86,7 +153,7 @@ export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner,
     }
     const hStart = Date.now();
     logEvent({ event: 'handoff_start', sd_key: sdKey, handoff });
-    const h = runner('node', ['scripts/handoff.js', 'execute', handoff, sdKey]);
+    const h = runner('node', ['scripts/handoff.js', 'execute', handoff, sdKey], { env });
     logEvent({ event: 'handoff_end', sd_key: sdKey, handoff, exit_code: h.exitCode, duration_ms: Date.now() - hStart });
     if (h.exitCode !== 0) {
       logEvent({ event: 'orchestrator_end', sd_key: sdKey, status: 'handoff_failed', step: handoff, exit_code: 5 });
@@ -100,13 +167,15 @@ export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner,
 const __filename = fileURLToPath(import.meta.url);
 if (process.argv[1] && process.argv[1] === __filename) {
   const sdKeyArg = process.argv.find(a => a.startsWith('--sd-key='));
+  const mergedBranchArg = process.argv.find(a => a.startsWith('--merged-branch='));
   if (!sdKeyArg) {
-    process.stderr.write('Usage: post-merge-handoff-orchestrator.js --sd-key=<SD-KEY>\n');
+    process.stderr.write('Usage: post-merge-handoff-orchestrator.js --sd-key=<SD-KEY> [--merged-branch=<branch>]\n');
     process.exit(1);
   }
   const sdKey = sdKeyArg.split('=')[1];
+  const mergedBranch = mergedBranchArg ? mergedBranchArg.split('=')[1] : null;
   const { createSupabaseServiceClient } = await import('../lib/supabase-connection.js');
   const supabase = await createSupabaseServiceClient();
-  const result = await runOrchestrator({ sdKey, supabase });
+  const result = await runOrchestrator({ sdKey, supabase, mergedBranch });
   process.exit(result.exitCode);
 }

--- a/tests/integration/post-merge-orchestrator.test.js
+++ b/tests/integration/post-merge-orchestrator.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { classifyState, runOrchestrator } from '../../scripts/post-merge-handoff-orchestrator.js';
+import { classifyState, runOrchestrator, deriveSessionFromBranch } from '../../scripts/post-merge-handoff-orchestrator.js';
 
 const SD_KEY = 'SD-FAKE-TEST-001';
 
@@ -110,5 +110,148 @@ describe('runOrchestrator (TS-001..TS-006)', () => {
     const result = await runOrchestrator({ sdKey: SD_KEY, supabase: fakeSupabase(null), runner: runner.run, env: ENV_OK });
     expect(result.exitCode).toBe(3);
     expect(result.error).toMatch(/not found/);
+  });
+});
+
+// SD-LEO-INFRA-POST-MERGE-AUTO-001 FR-2 deriveSessionFromBranch coverage (T7-T10).
+// Stub claude_sessions PostgREST chain: select → eq → is → eq → gt → order → limit.
+function fakeClaudeSessions(rows, error = null) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    is: () => chain,
+    gt: () => chain,
+    order: () => chain,
+    limit: async () => ({ data: rows, error }),
+  };
+  return { from: () => chain };
+}
+
+describe('deriveSessionFromBranch (FR-2 — SD-LEO-INFRA-POST-MERGE-AUTO-001)', () => {
+  it('T7: count==1 returns session_id with source=unique_match', async () => {
+    const supabase = fakeClaudeSessions([
+      { session_id: 'sess-uuid-A', heartbeat_at: new Date().toISOString() },
+    ]);
+    const r = await deriveSessionFromBranch(supabase, 'feat/SD-FAKE-001');
+    expect(r.ok).toBe(true);
+    expect(r.session_id).toBe('sess-uuid-A');
+    expect(r.source).toBe('unique_match');
+  });
+
+  it('T8: count==0 returns ok=false with reason=no_active_session_for_branch', async () => {
+    const supabase = fakeClaudeSessions([]);
+    const r = await deriveSessionFromBranch(supabase, 'feat/SD-FAKE-001');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('no_active_session_for_branch');
+    expect(r.merged_branch).toBe('feat/SD-FAKE-001');
+  });
+
+  it('T9: count==2 with most-recent heartbeat 5s newer returns most-recent (warn-but-proceed)', async () => {
+    const now = Date.now();
+    const supabase = fakeClaudeSessions([
+      { session_id: 'sess-newer', heartbeat_at: new Date(now).toISOString() },
+      { session_id: 'sess-older', heartbeat_at: new Date(now - 5000).toISOString() },
+    ]);
+    const r = await deriveSessionFromBranch(supabase, 'feat/SD-FAKE-001');
+    expect(r.ok).toBe(true);
+    expect(r.session_id).toBe('sess-newer');
+    expect(r.source).toBe('most_recent_heartbeat_warn');
+    expect(r.heartbeat_delta_ms).toBeGreaterThan(2000);
+  });
+
+  it('T10: count==2 within ±2s returns ok=false with reason=ambiguous_concurrent_sessions', async () => {
+    const now = Date.now();
+    const supabase = fakeClaudeSessions([
+      { session_id: 'sess-A', heartbeat_at: new Date(now).toISOString() },
+      { session_id: 'sess-B', heartbeat_at: new Date(now - 1500).toISOString() },
+    ]);
+    const r = await deriveSessionFromBranch(supabase, 'feat/SD-FAKE-001');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('ambiguous_concurrent_sessions');
+    expect(r.heartbeat_delta_ms).toBeLessThanOrEqual(2000);
+  });
+
+  it('propagates DB query error as ok=false reason=db_query_failed', async () => {
+    const supabase = fakeClaudeSessions(null, { message: 'PostgREST exploded' });
+    const r = await deriveSessionFromBranch(supabase, 'feat/SD-FAKE-001');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('db_query_failed');
+    expect(r.detail).toMatch(/PostgREST/);
+  });
+});
+
+describe('runOrchestrator FR-2 integration (env-vs-derive precedence)', () => {
+  let runner;
+  beforeEach(() => { runner = recordingRunner(); });
+
+  it('FR-2a: --merged-branch + missing env + 1 active session → derives session_id and continues', async () => {
+    // Composite supabase: claude_sessions returns 1 row, strategic_directives_v2 returns the SD.
+    const sd = { status: 'in_progress', current_phase: 'EXEC' };
+    const supabase = {
+      from: (table) => {
+        if (table === 'claude_sessions') {
+          const chain = {
+            select: () => chain, eq: () => chain, is: () => chain, gt: () => chain, order: () => chain,
+            limit: async () => ({ data: [{ session_id: 'derived-sess', heartbeat_at: new Date().toISOString() }], error: null }),
+          };
+          return chain;
+        }
+        // strategic_directives_v2
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: sd, error: null }) }) }),
+        };
+      },
+    };
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase, runner: runner.run, env: {}, mergedBranch: 'feat/SD-FAKE-TEST-001' });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('completed');
+    // Derived session_id should propagate to spawned subprocesses via opts.env.
+    const lastCall = runner.calls[runner.calls.length - 1];
+    expect(lastCall.cmd).toBe('node');
+  });
+
+  it('FR-2b: --merged-branch + missing env + 0 active sessions → exit 2 reason=no_active_session_for_branch', async () => {
+    const supabase = {
+      from: (table) => {
+        if (table === 'claude_sessions') {
+          const chain = {
+            select: () => chain, eq: () => chain, is: () => chain, gt: () => chain, order: () => chain,
+            limit: async () => ({ data: [], error: null }),
+          };
+          return chain;
+        }
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { status: 'in_progress', current_phase: 'EXEC' }, error: null }) }) }) };
+      },
+    };
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase, runner: runner.run, env: {}, mergedBranch: 'feat/SD-FAKE-TEST-001' });
+    expect(result.exitCode).toBe(2);
+    expect(result.error).toMatch(/no_active_session_for_branch/);
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it('FR-2c: env CLAUDE_SESSION_ID wins even when --merged-branch is also provided', async () => {
+    // claude_sessions stub should NOT be queried if env is set; test uses a stub that throws if invoked.
+    let claudeSessionsQueried = false;
+    const supabase = {
+      from: (table) => {
+        if (table === 'claude_sessions') {
+          claudeSessionsQueried = true;
+          throw new Error('claude_sessions should not be queried when env is set');
+        }
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { status: 'in_progress', current_phase: 'EXEC' }, error: null }) }) }) };
+      },
+    };
+    const result = await runOrchestrator({ sdKey: SD_KEY, supabase, runner: runner.run, env: ENV_OK, mergedBranch: 'feat/SD-FAKE-TEST-001' });
+    expect(result.exitCode).toBe(0);
+    expect(claudeSessionsQueried).toBe(false);
+  });
+});
+
+// T6 idempotency regression: orchestrator re-fire on completed SD is a no-op
+// (covered by existing TS-002, but explicitly tagged here for SD-LEO-INFRA-POST-MERGE-AUTO-001 traceability).
+describe('FR-5 idempotency regression-pin (T6)', () => {
+  it('T6: re-fire on status=completed via classifyState returns idempotent_skip', () => {
+    expect(classifyState({ status: 'completed', current_phase: 'EXEC' }).action).toBe('idempotent_skip');
+    expect(classifyState({ status: 'in_progress', current_phase: 'LEAD-FINAL-APPROVAL' }).action).toBe('idempotent_skip');
   });
 });


### PR DESCRIPTION
## Summary

Closes the post-merge silent-no-op class for SD/QF rows merged via routes other than the /ship Step 6.5 second-block path. Three FRs implemented per LEAD decisions D1-D6.

- **FR-1** — Pass `--merged-branch=$BRANCH` from `.claude/commands/ship.md` Step 6.5 (second-block, line 702) so the orchestrator can derive an active `session_id` when `CLAUDE_SESSION_ID` env is missing. Single-arg addition; preserves the `STEP_6_3_RAN_QF_CLOSURE`/`LEO_AUTOHANDOFF_ENABLED` skip parity.
- **FR-2** — `deriveSessionFromBranch` helper in `scripts/post-merge-handoff-orchestrator.js`. Query `claude_sessions` filtered by `current_branch + released_at IS NULL + status='active' + heartbeat_at > NOW()-60s`, ORDER BY heartbeat DESC LIMIT 2. Resolution: count==1 use; count==0 exit-2 (`no_active_session_for_branch`); count==2 with delta>2s use most-recent (warn-but-proceed); count==2 within ±2s exit-2 (`ambiguous_concurrent_sessions`). 60s freshness window + status='active' filter prevent SIGKILLed-process impersonation (risk-agent NEW-RISK-1+2). ±2s tie-break preserves `SD-LEO-INFRA-CROSS-HOST-CONCURRENT-001` contracts (NEW-RISK-2). env CLAUDE_SESSION_ID still wins when set; --merged-branch is fallback only.
- **FR-3** — Orchestrator wire-in for `scripts/gh-merge-safe.mjs` gh-api-PUT success path (3rd PR-merge surface). SD-key derivation via the same regex shape as ship.md Step 6.5; QF-skip parity (`qf/*` and `quick-fix/*` prefixes); `LEO_AUTOHANDOFF_ENABLED` honored; non-blocking (orchestrator failure logged but doesn't propagate as exit-1).
- **FR-5** — `classifyState()` lines 32-43 idempotency contract preserved; T6 regression-pin asserts re-fire on `status=completed` is no-op.
- **FR-6** — Deferred FR-3 (GH webhook reconciler) trigger metric documented in `SD.metadata.deferred_fr3_trigger` — re-evaluate if any audit_log incident references merged-but-status-open SD/QF in 7-day window post-ship.

### Mid-EXEC reframe

testing-agent FIND-1 (LEAD prospective) discovered `attemptAutoMerge` has NO production caller outside `ship.md` Step 6 (which already invokes orchestrator via Step 6.5 second-block). The original FR-1 premise (wire orchestrator into `lib/ship/auto-merge.mjs`) was incorrect; the fix is a 1-arg addition at the existing call-site. FR-4 wrapper-side propagation contract was reframed to apply to `scripts/gh-merge-safe.mjs` (where we now invoke orchestrator), not `lib/ship/auto-merge.mjs` (which already hard-fails on its own merge errors per QF-20260504-195).

## Test plan
- [x] vitest 54/54 PASS (45 existing + 9 new T7-T10 + FR-2a/b/c + db_query_failed + T6 regression-pin)
- [x] LEAD-TO-PLAN PASS @94% (19/19 gates)
- [x] PLAN-TO-EXEC PASS @95% (19/19 gates)
- [x] PLAN-TO-LEAD PASS @92% (20/20 gates after success_metrics actuals + retrospective insertion)
- [x] LEAD-FINAL-APPROVAL PASS @97% (24/24 gates)
- [x] SD status=completed, retrospective row 654720fb quality=100

## Sub-agent evidence (LEAD prospective)
- testing-agent: c1cd5ac2-115f-4f15-9591-0231a1fc7943 PASS@78
- validation-agent: fffe51d2-05b4-4b4b-ac89-af1bb140c007 PASS@95
- risk-agent: 4baf88ee-50cc-48b9-9c84-5cadffc9c493 PASS@88

## LOC
- Source: ~130 across 4 files
- Tests: ~145 (9 new test cases)

Closes feedback `89e55bf4-9d8c-4c54-9788-0958c62d192f` (RCA agent `a0bc2946b4c61fe70`).

Replaces #3670 (which was wrongly tied to feat/SD-LEO-INFRA-CROSS-HOST-CONCURRENT-001 due to mid-session worktree cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)