### PR TITLE
fix(QF-20260510-WT-CLAIM-PROTECT-001): worktree-reaper loadClaimMap fail-loud + schema-correct query

### DIFF
--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -219,32 +219,63 @@ function getSupabaseClient() {
   } catch { return null; }
 }
 
-async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 1000 } = {}) {
+// QF-20260510-WT-CLAIM-PROTECT-001: v_active_sessions does NOT expose a
+// worktree_path column; the prior query referenced it and silently swallowed
+// the PostgrestError, leaving the claim map empty so every active session was
+// classified claim_status=absent and eligible for stage1_remove. Anyone
+// running --execute would have destroyed actively-claimed worktrees with
+// dirty files. Now we (a) select only schema-correct columns, (b) FAIL-LOUD
+// on supabase errors so silent corruption is impossible, and (c) derive the
+// worktree path from the .worktrees/<sd_key> | .worktrees/qf/<qf_id>
+// convention plus a current_branch fallback (handles stale-claim rows where
+// the session moved branches without releasing). Pattern witness:
+// PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (17th).
+async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 1000, repoRoot = process.cwd() } = {}) {
   const map = new Map();
   if (!supabase) return map;
-  try {
-    const { data, error } = await supabase
-      .from('v_active_sessions')
-      .select('session_id, sd_key, worktree_path, last_heartbeat_at, computed_status')
-      .not('worktree_path', 'is', null);
-    if (error || !data) return map;
-    const now = Date.now();
-    for (const row of data) {
-      if (row.computed_status && row.computed_status !== 'active') continue;
-      if (row.last_heartbeat_at) {
-        const hb = new Date(row.last_heartbeat_at).getTime();
-        if (Number.isFinite(hb) && now - hb > heartbeatThresholdMs) continue;
-      }
-      const normalized = normalizePath(row.worktree_path);
-      if (normalized) {
-        map.set(normalized, {
-          sd_key: row.sd_key,
-          session_id: row.session_id,
-          heartbeat_at: row.last_heartbeat_at,
-        });
-      }
+  const { data, error } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_key, qf_id, current_branch, heartbeat_at, computed_status')
+    .eq('computed_status', 'active');
+  if (error) {
+    throw new Error(
+      `[reaper] loadClaimMap query failed: ${error.message}` +
+      (error.code ? ` (code=${error.code})` : '') +
+      ' — refusing to proceed; silent failure here causes active-claim destruction.'
+    );
+  }
+  if (!data) return map;
+  const worktreesDir = path.join(repoRoot, '.worktrees');
+  const now = Date.now();
+  function addCandidate(wtPath, info) {
+    const normalized = normalizePath(wtPath);
+    if (normalized) map.set(normalized, info);
+  }
+  function branchToBasename(branch) {
+    if (!branch) return null;
+    const m = String(branch).match(/^(?:refs\/heads\/)?(?:feat|qf|fix|chore|hotfix)\/(.+)$/);
+    return m ? m[1] : null;
+  }
+  for (const row of data) {
+    if (row.computed_status && row.computed_status !== 'active') continue;
+    if (row.heartbeat_at) {
+      const hb = new Date(row.heartbeat_at).getTime();
+      if (Number.isFinite(hb) && now - hb > heartbeatThresholdMs) continue;
     }
-  } catch { /* fall through with empty map */ }
+    const info = {
+      sd_key: row.sd_key,
+      qf_id: row.qf_id,
+      session_id: row.session_id,
+      heartbeat_at: row.heartbeat_at,
+    };
+    if (row.sd_key) addCandidate(path.join(worktreesDir, row.sd_key), info);
+    if (row.qf_id) addCandidate(path.join(worktreesDir, 'qf', row.qf_id), info);
+    const branchBase = branchToBasename(row.current_branch);
+    if (branchBase) {
+      if (/^QF-/.test(branchBase)) addCandidate(path.join(worktreesDir, 'qf', branchBase), info);
+      else addCandidate(path.join(worktreesDir, branchBase), info);
+    }
+  }
   return map;
 }
 

--- a/tests/integration/worktree-reaper.test.js
+++ b/tests/integration/worktree-reaper.test.js
@@ -19,6 +19,7 @@ import {
   buildRecord,
   preserveUntrackedFiles,
   runPhantomOnlyMode,
+  loadClaimMap,
 } from '../../scripts/worktree-reaper.mjs';
 
 // ── parseArgs ──────────────────────────────────────────────────────────
@@ -240,5 +241,102 @@ describe('runPhantomOnlyMode (legacy compatibility)', () => {
       expect(logs.join('\n')).toMatch(/directory missing/);
       expect(logs.join('\n')).toMatch(/marked prunable/);
     } finally { console.log = origLog; }
+  });
+});
+
+// ── loadClaimMap ───────────────────────────────────────────────────────
+// QF-20260510-WT-CLAIM-PROTECT-001 regression pins.
+// Prior bug: query referenced v_active_sessions.worktree_path which does not
+// exist on the view; PostgrestError was silently swallowed → empty claim map
+// → all active sessions classified claim_status=absent → eligible for
+// stage1_remove. Anyone running --execute would have destroyed active work.
+
+function makeSupabaseStub({ rows = null, error = null } = {}) {
+  // Minimal stub that mimics PostgREST chain: from().select().eq() and
+  // from().select().not(). Both return a thenable resolving to {data,error}.
+  function chain() {
+    const result = Promise.resolve({ data: rows, error });
+    return {
+      eq: () => result,
+      not: () => result,
+      then: result.then.bind(result),
+    };
+  }
+  return { from: () => ({ select: () => chain() }) };
+}
+
+describe('loadClaimMap (QF-20260510-WT-CLAIM-PROTECT-001)', () => {
+  it('throws fail-loud on supabase error rather than returning empty map', async () => {
+    const supabase = makeSupabaseStub({
+      error: { message: 'column v_active_sessions.worktree_path does not exist', code: '42703' },
+    });
+    await expect(loadClaimMap(supabase)).rejects.toThrow(/loadClaimMap query failed/);
+    await expect(loadClaimMap(supabase)).rejects.toThrow(/refusing to proceed/);
+  });
+
+  it('derives worktree path from sd_key via .worktrees/<sd_key> convention', async () => {
+    const repoRoot = '/repo';
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's1', sd_key: 'SD-FOO-001', qf_id: null, current_branch: null, heartbeat_at: new Date().toISOString(), computed_status: 'active' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const expected = path.join(repoRoot, '.worktrees', 'SD-FOO-001').replace(/\\/g, '/').toLowerCase();
+    expect(map.get(path.resolve(expected).replace(/\\/g, '/').toLowerCase())).toMatchObject({ sd_key: 'SD-FOO-001', session_id: 's1' });
+  });
+
+  it('derives worktree path from qf_id via .worktrees/qf/<qf_id> convention', async () => {
+    const repoRoot = '/repo';
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's2', sd_key: null, qf_id: 'QF-20260510-001', current_branch: null, heartbeat_at: new Date().toISOString(), computed_status: 'active' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const expected = path.resolve(path.join(repoRoot, '.worktrees', 'qf', 'QF-20260510-001')).replace(/\\/g, '/').toLowerCase();
+    expect(map.get(expected)).toMatchObject({ qf_id: 'QF-20260510-001', session_id: 's2' });
+  });
+
+  it('falls back to current_branch basename when sd_key is stale and session moved branches', async () => {
+    const repoRoot = '/repo';
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's3', sd_key: 'SD-OLD-001', qf_id: null, current_branch: 'feat/SD-NEW-001', heartbeat_at: new Date().toISOString(), computed_status: 'active' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const oldKey = path.resolve(path.join(repoRoot, '.worktrees', 'SD-OLD-001')).replace(/\\/g, '/').toLowerCase();
+    const newKey = path.resolve(path.join(repoRoot, '.worktrees', 'SD-NEW-001')).replace(/\\/g, '/').toLowerCase();
+    expect(map.has(oldKey)).toBe(true);
+    expect(map.has(newKey)).toBe(true);
+  });
+
+  it('parses qf/<id> branches into the qf/ subdirectory', async () => {
+    const repoRoot = '/repo';
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's4', sd_key: null, qf_id: null, current_branch: 'qf/QF-20260510-XYZ', heartbeat_at: new Date().toISOString(), computed_status: 'active' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const key = path.resolve(path.join(repoRoot, '.worktrees', 'qf', 'QF-20260510-XYZ')).replace(/\\/g, '/').toLowerCase();
+    expect(map.has(key)).toBe(true);
+  });
+
+  it('skips rows whose heartbeat is older than the threshold', async () => {
+    const repoRoot = '/repo';
+    const old = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(); // 3hr ago, threshold is 2hr
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's5', sd_key: 'SD-STALE-001', qf_id: null, current_branch: null, heartbeat_at: old, computed_status: 'active' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    expect(map.size).toBe(0);
+  });
+
+  it('skips rows whose computed_status is not active', async () => {
+    const repoRoot = '/repo';
+    const supabase = makeSupabaseStub({ rows: [
+      { session_id: 's6', sd_key: 'SD-RELEASED-001', qf_id: null, current_branch: null, heartbeat_at: new Date().toISOString(), computed_status: 'released' },
+    ]});
+    const map = await loadClaimMap(supabase, { repoRoot });
+    expect(map.size).toBe(0);
+  });
+
+  it('returns empty map (no throw) when supabase client is absent', async () => {
+    const map = await loadClaimMap(null);
+    expect(map.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- **P0 data-loss class fix**: `loadClaimMap` previously queried `v_active_sessions.worktree_path` (does not exist) and `last_heartbeat_at` (real column is `heartbeat_at`); the PostgrestError was silently swallowed by a try/catch that returned an empty map → every active session classified `claim_status=absent` → eligible for `stage1_remove`. Anyone running `--execute` would have destroyed actively-claimed worktrees with dirty files.
- **Fix**: schema-correct column projection, fail-loud throw on supabase error (refuses to proceed on silent failure), and worktree-path derivation from `.worktrees/<sd_key>` | `.worktrees/qf/<qf_id>` convention plus `current_branch` fallback for stale-claim rows.
- **Pattern**: PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 17th-witness.

## Test plan
- [x] 8 new vitest regression pins covering each failure mode + path-derivation branch (25/25 pass)
- [x] Live smoke: `loadClaimMap` against current DB returns 4 active sessions (was 0 with bug); QF's own session present in protected list (self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)