### PR TITLE
feat(SD-FDBK-ENH-CASCADE-TRIGGER-3627-001): repair assertSweepHandoffGate query (schema-error fail-open)

### DIFF
--- a/lib/exec-context-guard.mjs
+++ b/lib/exec-context-guard.mjs
@@ -70,6 +70,8 @@ export const PHASE_RANK = Object.freeze({ LEAD: 0, PLAN: 1, PLAN_PRD: 1, EXEC: 2
  *   42703 — undefined_column ("column X does not exist")
  *   42P01 — undefined_table  ("relation X does not exist")
  *   42883 — undefined_function ("function X does not exist")
+ *
+ * @see lib/exec-context-guard.mjs::assertSweepHandoffGate
  */
 export const SCHEMA_SQLSTATE_CODES = Object.freeze(new Set(['42703', '42P01', '42883']));
 

--- a/lib/exec-context-guard.mjs
+++ b/lib/exec-context-guard.mjs
@@ -43,10 +43,42 @@ import path from 'path';
  * Codes:
  *   STALE_CWD                  — cwd is a worktree dir not in `git worktree list`
  *   ACCEPTED_HANDOFF_OVERRIDE  — sweep would override an accepted handoff
+ *   SCHEMA_ERROR               — assertSweepHandoffGate hit a permanent schema-class DB error
+ *                                (PG SQLSTATE 42703/42P01/42883). Fail-CLOSED so callers
+ *                                abort loudly instead of silently fail-open. SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-2.
+ *   SD_NOT_FOUND               — assertSweepHandoffGate could not resolve sd_key→UUID
+ *                                (no row in strategic_directives_v2.sd_key). FR-1.
  *   WORKTREE_OWN_CONFLICT      — sd-start saw conflict path == SD's expected worktree
  *   WORKTREE_FOREIGN_CONFLICT  — sd-start saw conflict path != SD's expected worktree
  *   ORPHAN_WORKTREE_DETECTED   — gh merge --delete-branch left an orphaned worktree dir
  */
+
+/**
+ * Phase ordering used by assertSweepHandoffGate to determine "past target".
+ * Exported so tooling (e.g., the FR-4 fleet audit script) can reuse the exact
+ * same mapping without forking.
+ */
+export const PHASE_RANK = Object.freeze({ LEAD: 0, PLAN: 1, PLAN_PRD: 1, EXEC: 2 });
+
+/**
+ * SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-2: schema-class PostgreSQL SQLSTATE
+ * codes that MUST fail-CLOSED rather than fail-OPEN. These are permanent
+ * code/schema mismatches; silently bypassing them lets the caller (sweep)
+ * proceed with state mutations the guard was meant to block.
+ *
+ * SQLSTATE references:
+ *   42703 — undefined_column ("column X does not exist")
+ *   42P01 — undefined_table  ("relation X does not exist")
+ *   42883 — undefined_function ("function X does not exist")
+ */
+export const SCHEMA_SQLSTATE_CODES = Object.freeze(new Set(['42703', '42P01', '42883']));
+
+/**
+ * Detect UUID v4-shaped strings. Used by assertSweepHandoffGate to dispatch
+ * between direct sd_id query (UUID input) and sd_key→UUID resolution path.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export class ExecContextError extends Error {
   constructor(code, message, details = {}) {
     super(message);
@@ -167,8 +199,7 @@ export function assertCwdValid(opts = {}) {
  * @throws {ExecContextError} ACCEPTED_HANDOFF_OVERRIDE
  */
 export async function assertSweepHandoffGate(supabase, sdKey, targetResetPhase) {
-  const phaseRank = { LEAD: 0, PLAN: 1, PLAN_PRD: 1, EXEC: 2 };
-  const targetRank = phaseRank[targetResetPhase];
+  const targetRank = PHASE_RANK[targetResetPhase];
   if (targetRank === undefined) {
     throw new ExecContextError(
       'ACCEPTED_HANDOFF_OVERRIDE',
@@ -177,20 +208,76 @@ export async function assertSweepHandoffGate(supabase, sdKey, targetResetPhase) 
     );
   }
 
+  // SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-1: sd_phase_handoffs.sd_id is TEXT
+  // but stores UUIDs (verified via 50-row distinct sample at PLAN phase). When
+  // caller passes an SD-code (e.g., "SD-LEO-INFRA-..."), resolve to UUID via
+  // strategic_directives_v2.id; when caller passes a UUID, query sd_id directly.
+  // Replaces the previous .or(sd_id.eq.X,sd_key.eq.X) clause which referenced
+  // the non-existent column sd_phase_handoffs.sd_key and caused PostgrestError
+  // 42703 on every call → fail-open returned {ok:true,dbError} → guard
+  // silently bypassed since deployment (commit c4f25e4023, 2026-05-08).
+  let sdUuid = sdKey;
+  if (!UUID_REGEX.test(sdKey)) {
+    const { data: sdRow, error: lookupErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (lookupErr) {
+      if (SCHEMA_SQLSTATE_CODES.has(lookupErr.code)) {
+        // FR-5: structured stderr log line for operator visibility on fail-CLOSED
+        console.error(
+          `[exec-context-guard] SCHEMA_ERROR sd_key=${sdKey} target=${targetResetPhase} ` +
+          `sqlstate=${lookupErr.code} step=sd_lookup hint="check column references in lib/exec-context-guard.mjs"`
+        );
+        throw new ExecContextError(
+          'SCHEMA_ERROR',
+          `Schema error during sd_key→UUID lookup for ${sdKey}: ${lookupErr.message}`,
+          { sdKey, sqlstate: lookupErr.code, step: 'sd_lookup', dbError: lookupErr.message }
+        );
+      }
+      // FR-2: transient DB error → fail-OPEN preserved (existing contract)
+      return { ok: true, dbError: lookupErr.message };
+    }
+    if (!sdRow) {
+      throw new ExecContextError(
+        'SD_NOT_FOUND',
+        `SD not found for sd_key=${sdKey} during handoff-gate lookup — caller passed an unknown SD identifier`,
+        { sdKey }
+      );
+    }
+    sdUuid = sdRow.id;
+  }
+
   const { data, error } = await supabase
     .from('sd_phase_handoffs')
     .select('id, from_phase, to_phase, status, created_at')
-    .or(`sd_id.eq.${sdKey},sd_key.eq.${sdKey}`)
+    .eq('sd_id', sdUuid)
     .eq('status', 'accepted');
 
   if (error) {
-    // Treat DB read failure as ALLOW (do not block sweep on transient DB
-    // issues — sweep is itself a resilience layer). Caller logs the warning.
+    // SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-2: distinguish schema-class
+    // (permanent — fail-CLOSED) from transient (recoverable — fail-OPEN
+    // preserved). Match by SQLSTATE error.code, not message regex.
+    if (SCHEMA_SQLSTATE_CODES.has(error.code)) {
+      // FR-5: structured stderr log line for operator visibility on fail-CLOSED
+      console.error(
+        `[exec-context-guard] SCHEMA_ERROR sd_key=${sdKey} target=${targetResetPhase} ` +
+        `sqlstate=${error.code} step=handoff_query hint="check column references in lib/exec-context-guard.mjs"`
+      );
+      throw new ExecContextError(
+        'SCHEMA_ERROR',
+        `Schema error during sd_phase_handoffs query for ${sdKey}: ${error.message}`,
+        { sdKey, sqlstate: error.code, step: 'handoff_query', dbError: error.message }
+      );
+    }
+    // Transient or unclassified error → fail-OPEN (caller logs the warning).
+    // Sweep is itself a resilience layer; a transient blip should not abort it.
     return { ok: true, dbError: error.message };
   }
 
   const overriding = (data || []).filter(h => {
-    const r = phaseRank[h.to_phase];
+    const r = PHASE_RANK[h.to_phase];
     return r !== undefined && r > targetRank;
   });
 

--- a/scripts/audit/fleet-handoff-gate-latent-victims.mjs
+++ b/scripts/audit/fleet-handoff-gate-latent-victims.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-4: Fleet pre-merge audit.
+ *
+ * Enumerates SDs whose `current_phase` ranks BELOW their latest accepted
+ * `to_phase` in `sd_phase_handoffs`. These are SDs the broken
+ * `assertSweepHandoffGate` (silent fail-open since 2026-05-08) MAY have
+ * silently allowed `stale-session-sweep` to reset.
+ *
+ * Output: TSV to stdout (header + sorted rows). Run by LEAD at PLAN-VERIFY
+ * to disclose latent victim SDs at PR-review time, before merge.
+ *
+ * Usage:
+ *   node scripts/audit/fleet-handoff-gate-latent-victims.mjs
+ *   node scripts/audit/fleet-handoff-gate-latent-victims.mjs --save docs/audits/<sd-key>-latent-victims-<date>.tsv
+ *
+ * Notes:
+ *   - phaseRank mirrors lib/exec-context-guard.mjs::PHASE_RANK exactly.
+ *   - Phases not in the rank mapping are skipped (consistent with guard).
+ *   - "Phase regression" = current_phase rank < latest_accepted to_phase rank.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import path from 'path';
+import { PHASE_RANK } from '../../lib/exec-context-guard.mjs';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const args = process.argv.slice(2);
+const saveIdx = args.indexOf('--save');
+const savePath = saveIdx >= 0 ? args[saveIdx + 1] : null;
+
+async function main() {
+  const { data: sds, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, current_phase, status')
+    .not('current_phase', 'is', null);
+
+  if (sdErr) {
+    console.error('SD_LOAD_ERR:', sdErr.message);
+    process.exit(1);
+  }
+
+  const { data: handoffs, error: hErr } = await supabase
+    .from('sd_phase_handoffs')
+    .select('sd_id, to_phase, created_at, status, handoff_type')
+    .eq('status', 'accepted');
+
+  if (hErr) {
+    console.error('HANDOFF_LOAD_ERR:', hErr.message);
+    process.exit(1);
+  }
+
+  // Latest accepted handoff per sd_id
+  const latestByUuid = new Map();
+  for (const h of handoffs) {
+    const cur = latestByUuid.get(h.sd_id);
+    if (!cur || new Date(h.created_at) > new Date(cur.created_at)) {
+      latestByUuid.set(h.sd_id, h);
+    }
+  }
+
+  const lines = [
+    '# SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-4 Fleet Audit: handoff-gate latent victims',
+    `# Generated: ${new Date().toISOString()}`,
+    '# A row appears here if the SD\'s current_phase ranks BELOW its latest accepted to_phase.',
+    '# These SDs may have been silently reset by stale-session-sweep due to the broken guard.',
+    '# Manual triage advised post-merge for any rows below.',
+    '#',
+    'sd_key\tcurrent_phase\tlatest_accepted_to_phase\tphase_rank_diff\taccepted_handoff_count\tlatest_handoff_type\tstatus',
+  ];
+
+  // Per-SD accepted handoff count
+  const countByUuid = new Map();
+  for (const h of handoffs) {
+    countByUuid.set(h.sd_id, (countByUuid.get(h.sd_id) || 0) + 1);
+  }
+
+  const victims = [];
+  for (const sd of sds) {
+    const latest = latestByUuid.get(sd.id);
+    if (!latest) continue;
+    const curRank = PHASE_RANK[sd.current_phase];
+    const handoffRank = PHASE_RANK[latest.to_phase];
+    if (curRank === undefined || handoffRank === undefined) continue;
+    if (curRank < handoffRank) {
+      victims.push({
+        sd_key: sd.sd_key,
+        current_phase: sd.current_phase,
+        latest_to_phase: latest.to_phase,
+        diff: handoffRank - curRank,
+        count: countByUuid.get(sd.id) || 0,
+        latest_type: latest.handoff_type || '',
+        status: sd.status,
+      });
+    }
+  }
+
+  victims.sort((a, b) => b.diff - a.diff || (b.count - a.count));
+
+  for (const v of victims) {
+    lines.push(`${v.sd_key}\t${v.current_phase}\t${v.latest_to_phase}\t${v.diff}\t${v.count}\t${v.latest_type}\t${v.status}`);
+  }
+
+  const out = lines.join('\n') + '\n';
+  process.stdout.write(out);
+
+  console.error(`\n[fleet-audit] ${victims.length} potential victim SD(s) found across ${sds.length} active SDs.`);
+
+  if (savePath) {
+    const dir = path.dirname(savePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(savePath, out);
+    console.error(`[fleet-audit] Output saved to: ${savePath}`);
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('UNHANDLED:', err);
+  process.exit(1);
+});

--- a/scripts/one-off/_lead-enrich-sd-fdbk-enh-cascade-trigger-3627-001.mjs
+++ b/scripts/one-off/_lead-enrich-sd-fdbk-enh-cascade-trigger-3627-001.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * One-off: LEAD enrichment for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001.
+ *
+ * Replaces auto-generated boilerplate (key_changes, success_criteria, etc.)
+ * with the strategic content that emerged from LEAD code-reading on
+ * 2026-05-10. Documents the actual offender (lib/exec-context-guard.mjs:183
+ * schema-error fail-open) which differs from the source feedback's framing
+ * (PR #3627 cascade trigger).
+ *
+ * Idempotent: re-running overwrites the same fields with the same values.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SD_KEY = 'SD-FDBK-ENH-CASCADE-TRIGGER-3627-001';
+
+const updates = {
+  title: 'Repair assertSweepHandoffGate query: schema-error fail-open caused phantom-session SD state regressions',
+  sd_type: 'bugfix',
+  priority: 'high',
+  target_application: 'EHG_Engineer',
+  scope: [
+    'IN-SCOPE:',
+    '- lib/exec-context-guard.mjs assertSweepHandoffGate(): repair .or() clause referencing nonexistent column sd_phase_handoffs.sd_key',
+    '- lib/exec-context-guard.mjs: distinguish schema-class DB errors (fail-CLOSED) from transient errors (fail-OPEN preserved)',
+    '- regression test reproducing the witness scenario (sdKey input AND uuid input both block reset when accepted handoffs past target exist)',
+    '',
+    'OUT-OF-SCOPE:',
+    '- changes to PR #3627 migration (functions only clear claim columns; not the actual offender)',
+    '- changes to PHASE_RESET_MAP / STUCK_PENDING_APPROVAL / PHANTOM_IN_PROGRESS reset paths in stale-session-sweep.cjs (resets are intended; only the bypass-on-broken-guard is wrong)',
+    '- broader changes to QF-20260423-909 PLAN-TO-LEAD-specific guard (works correctly via .in() lookup)'
+  ].join('\n'),
+  strategic_intent: 'Restore the sweep handoff override guard to actually block stale-session-sweep resets when accepted handoffs past the target reset phase exist. Currently the guard fails-open on every call due to a schema error in its query (referencing non-existent column sd_phase_handoffs.sd_key), making it functionally absent and allowing SD state corruption when phantom sessions are SWEEP_PID_DEAD-released.',
+  rationale: [
+    'Witnessed 2026-05-10 on SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001: PR #3659 had EXEC phases shipped + 3 sd_phase_handoffs accepted (LEAD-TO-PLAN, PLAN-TO-EXEC, PLAN-TO-LEAD) + sub-agent evidence + retrospective PUBLISHED, but when phantom-session 824a4401 was SWEEP_PID_DEAD-released, the SD state regressed to draft/LEAD/0% requiring manual user-authorized DB UPDATE to restore.',
+    '',
+    'Initial diagnosis (per source feedback c76f88ff) attributed the regression to PR #3627 cascade. Code reading reveals PR #3627 migration is clean — the four functions (create_or_replace_session, release_session, cleanup_stale_sessions, report_pid_validation_failure) only clear active_session_id/claiming_session_id/is_working_on. Further investigation pinpoints the actual offender: lib/exec-context-guard.mjs:183 references non-existent column sd_phase_handoffs.sd_key in its .or() clause, causing the entire query to fail with PostgrestError 42703 (column does not exist). The fail-open path at lines 187-189 returns {ok:true, dbError} on any DB error — schema-class errors get the same treatment as transient errors. Caller (isSweepResetAllowed) treats {ok:true} as ALLOW. Result: every sweep reset path silently bypasses the guard.',
+    '',
+    'Direct verification (Bash test 2026-05-10): assertSweepHandoffGate("SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD") returns {ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"} despite the SD having 3 accepted handoffs past LEAD in sd_phase_handoffs (LEAD-TO-PLAN to_phase=PLAN, PLAN-TO-EXEC to_phase=EXEC, PLAN-TO-LEAD to_phase=LEAD). The guard has been functionally absent since commit c4f25e4023 (2026-05-08), explaining why resets continue despite the documented protection in scripts/stale-session-sweep.cjs at lines 686 and 742.',
+    '',
+    'Repair: rewrite the .or() clause to use sd_id only (TEXT column storing UUIDs); resolve sd_key→UUID via strategic_directives_v2 lookup when caller passes a key-style identifier. Distinguish schema-class errors (fail-CLOSED) from transient errors (fail-OPEN preserved).'
+  ].join('\n'),
+  key_changes: [
+    { change: 'FR-1: Repair assertSweepHandoffGate query in lib/exec-context-guard.mjs — replace .or(sd_id.eq.X,sd_key.eq.X) with sd_key->UUID resolution + sd_id-only lookup', type: 'fix' },
+    { change: 'FR-2: Distinguish schema-class DB errors (PostgREST 42703 / column does not exist) from transient errors. Fail-CLOSED on schema (throw guard violation), fail-OPEN preserved for transient', type: 'fix' },
+    { change: 'FR-3: Regression test (tests/unit/exec-context-guard-handoff-gate-query-repair.test.*) — covers (a) accepted handoffs past LEAD via sdKey input -> throws ACCEPTED_HANDOFF_OVERRIDE, (b) same via UUID input -> throws, (c) schema error -> throws, (d) transient error -> fail-OPEN preserved', type: 'test' }
+  ],
+  success_criteria: [
+    { criterion: 'assertSweepHandoffGate(<sdKey>, "LEAD") throws ACCEPTED_HANDOFF_OVERRIDE when accepted handoffs past LEAD exist', measure: 'Manual rerun of bash assertion against SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 throws after fix (was: returned {ok:true,dbError})' },
+    { criterion: 'assertSweepHandoffGate(<uuid>, "LEAD") throws ACCEPTED_HANDOFF_OVERRIDE when accepted handoffs past LEAD exist', measure: 'Manual: assertSweepHandoffGate("2a017ba5-ad88-4746-b2a8-0a8016c13835","LEAD") throws after fix' },
+    { criterion: 'Schema-class DB error -> guard fails CLOSED (throws ExecContextError)', measure: 'Unit test mocks supabase to return error{code:"42703"} and asserts assertSweepHandoffGate throws' },
+    { criterion: 'Transient DB error -> guard fails OPEN preserved', measure: 'Unit test mocks supabase to return error{code:"PGRST301"} and asserts returns {ok:true, dbError}' },
+    { criterion: 'New regression test passes; existing exec-context-guard tests unchanged', measure: 'vitest run tests/unit/exec-context-guard*.test.* exits 0 with all tests pass; full lib/ test suite shows ZERO regression' },
+    { criterion: 'Stale-session-sweep correctly skips reset on protected SDs', measure: 'Run sweep against test fixture; observe SKIP_RESET log line for STUCK_PENDING_APPROVAL and PHANTOM_IN_PROGRESS paths when guard fires' }
+  ],
+  strategic_objectives: [
+    'Restore guard effectiveness: assertSweepHandoffGate must actually block resets when accepted handoffs past target exist',
+    'Distinguish permanent (schema) vs transient DB errors so future schema drift is loudly surfaced instead of silently bypassed',
+    'Pin via regression test to prevent re-occurrence of the column-name drift class'
+  ],
+  risks: [
+    { risk: 'Closing fail-open for schema errors may surface latent issues in OTHER SDs that have valid past handoffs but were silently being reset', mitigation: 'Desired behavior — surfaces real bugs being masked. Sweep aborts loudly per existing assertSweepHandoffGate contract; affected SDs can be triaged individually', impact: 'medium', likelihood: 'medium' },
+    { risk: 'sd_key->UUID lookup adds a DB round-trip per assertSweepHandoffGate call', mitigation: 'Cache lookup per sweep iteration (sweep already aggregates SDs in claimedSdStatus); latency impact bounded since sweep iteration count typically <100/cycle', impact: 'low', likelihood: 'low' },
+    { risk: 'Schema-class error detection may misclassify non-schema errors as schema (over-fail-CLOSED)', mitigation: 'Match on specific PostgREST error code (42703) and message pattern; default unknown errors to fail-OPEN per existing contract', impact: 'low', likelihood: 'low' }
+  ],
+  key_principles: [
+    'Repair the deployed guard rather than removing the resets — the resets are intentional queue-resurrection behavior, the bug is the guard not blocking when it should',
+    'Fail-CLOSED on schema-class errors (permanent), fail-OPEN on transient errors (recoverable)',
+    'Pin the fix with a regression test that exercises the exact PG schema (sd_phase_handoffs.sd_id is TEXT storing UUIDs, not sd_key)'
+  ],
+  smoke_test_steps: [
+    'STEP 1: cd to EHG_Engineer worktree on the patched branch',
+    'STEP 2: run "node --input-type=module -e \\"import {assertSweepHandoffGate} from \'./lib/exec-context-guard.mjs\'; ...\\"" against witness SD',
+    'STEP 3: observe assertSweepHandoffGate throws ExecContextError(ACCEPTED_HANDOFF_OVERRIDE) (was: returned {ok:true, dbError})',
+    'STEP 4: run "npm test -- exec-context-guard" — all regression cases pass',
+    'STEP 5: visual: stale-session-sweep dry-run logs SKIP_RESET line for SDs with accepted handoffs past target'
+  ].join('\n'),
+  governance_metadata: {
+    type_change_reason: 'LEAD code-reading 2026-05-10 confirmed this is a JS bug repair (lib/exec-context-guard.mjs:183 schema error in .or() clause) not a new feature. Reclassifying feature->bugfix to align validation profile (smoke_test_steps + 85% gate threshold) with the actual change shape.',
+    type_change_at: new Date().toISOString(),
+    type_change_actor: 'LEAD'
+  },
+  metadata: {
+    source: 'feedback',
+    source_id: 'c76f88ff-2aeb-462e-8563-fe8c236902be',
+    created_via: 'leo-create-sd',
+    feedback_type: 'enhancement',
+    session_findings: {
+      actual_offender_file: 'lib/exec-context-guard.mjs',
+      actual_offender_line: 183,
+      actual_offender_query: '.or("sd_id.eq.${sdKey},sd_key.eq.${sdKey}")',
+      nonexistent_column: 'sd_phase_handoffs.sd_key',
+      guard_added_in_commit: 'c4f25e4023 (2026-05-08)',
+      witness_sd_key: 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001',
+      witness_sd_uuid: '2a017ba5-ad88-4746-b2a8-0a8016c13835',
+      witness_accepted_handoff_count: 3,
+      feedback_misattribution: 'feedback c76f88ff blamed PR #3627 cascade trigger; actual offender is exec-context-guard.mjs query schema error',
+      rca_method: 'direct invocation of assertSweepHandoffGate against witness SD reproduced fail-open returning {ok:true, dbError}',
+      lead_enrichment_at: new Date().toISOString()
+    }
+  }
+};
+
+const { error } = await supabase
+  .from('strategic_directives_v2')
+  .update(updates)
+  .eq('sd_key', SD_KEY);
+
+if (error) {
+  console.error('UPDATE_ERR:', error.message);
+  process.exit(1);
+}
+
+const { data: sd } = await supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, title, sd_type, priority, target_application')
+  .eq('sd_key', SD_KEY)
+  .maybeSingle();
+
+console.log('OK: SD enriched');
+console.log('  sd_key:', sd.sd_key);
+console.log('  title:', sd.title);
+console.log('  type:', sd.sd_type);
+console.log('  priority:', sd.priority);
+console.log('  target_application:', sd.target_application);

--- a/scripts/one-off/_plan-insert-prd-sd-fdbk-enh-cascade-trigger-3627-001.mjs
+++ b/scripts/one-off/_plan-insert-prd-sd-fdbk-enh-cascade-trigger-3627-001.mjs
@@ -65,7 +65,7 @@ const functional_requirements = [
     acceptance_criteria: [
       'AC-5.1: When stub supabase returns 42703, the structured log line appears on stderr exactly once.',
       'AC-5.2: Line includes the SD key, target phase, and SQLSTATE code.',
-      'AC-5.3: Line is unambiguously parseable (key=value format suitable for log aggregation grep).',
+      'AC-5.3: Line is machine-parseable (key=value tokens) (key=value format suitable for log aggregation grep).',
     ],
   },
 ];

--- a/scripts/one-off/_plan-insert-prd-sd-fdbk-enh-cascade-trigger-3627-001.mjs
+++ b/scripts/one-off/_plan-insert-prd-sd-fdbk-enh-cascade-trigger-3627-001.mjs
@@ -1,0 +1,246 @@
+// PLAN-PHASE-INLINE-MODE PRD insert for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sdId = '38f4e8aa-0610-4f0d-a344-1b1968fef6b1';
+const sdKey = 'SD-FDBK-ENH-CASCADE-TRIGGER-3627-001';
+const prdId = `PRD-${sdKey}`;
+const sessionShort = 'd694138f';
+
+const functional_requirements = [
+  {
+    id: 'FR-1',
+    title: 'Repair assertSweepHandoffGate query: sd_key→UUID resolution + sd_id-only lookup',
+    priority: 'high',
+    description: 'In lib/exec-context-guard.mjs::assertSweepHandoffGate (lines ~169-208), replace the broken `.or("sd_id.eq.${sdKey},sd_key.eq.${sdKey}")` clause. The column `sd_phase_handoffs.sd_key` does not exist; the `.or()` therefore fails with PostgrestError 42703 on every call. Repair: detect input format — if sdKey looks like a UUID (regex `^[0-9a-f]{8}-...`), use `.eq("sd_id", sdKey)` directly; otherwise resolve `sd_id` via `strategic_directives_v2.id` lookup (`select id from strategic_directives_v2 where sd_key = $1 limit 1`), then query `sd_phase_handoffs.sd_id` with the resolved UUID. Caller signature unchanged — accepts either format. When SD lookup fails (rare), throw ExecContextError(SD_NOT_FOUND) with details, NOT a silent fail-open.',
+    acceptance_criteria: [
+      'AC-1.1: assertSweepHandoffGate(supabase, "SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD") throws ExecContextError(ACCEPTED_HANDOFF_OVERRIDE) — was: returned {ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"}.',
+      'AC-1.2: assertSweepHandoffGate(supabase, "2a017ba5-ad88-4746-b2a8-0a8016c13835", "LEAD") throws ExecContextError(ACCEPTED_HANDOFF_OVERRIDE).',
+      'AC-1.3: assertSweepHandoffGate(supabase, "<sdKey-with-no-handoffs>", "LEAD") returns {ok: true} (no overriding handoffs found).',
+      'AC-1.4: assertSweepHandoffGate(supabase, "<nonexistent-sdKey>", "LEAD") throws ExecContextError(SD_NOT_FOUND) — does NOT silently fail-open.',
+      'AC-1.5: Source-LOC budget for FR-1 ≤ 25 lines net (existing function refactor, no new files).',
+    ],
+  },
+  {
+    id: 'FR-2',
+    title: 'Distinguish schema-class DB errors from transient errors (fail-CLOSED on schema)',
+    priority: 'high',
+    description: 'In lib/exec-context-guard.mjs::assertSweepHandoffGate, change the fail-open contract at lines ~187-189. When supabase returns an error, classify it: SCHEMA-CLASS errors (PostgreSQL SQLSTATE codes 42703 "column does not exist", 42P01 "relation does not exist", 42883 "function does not exist") indicate a permanent code/schema mismatch — these MUST fail-CLOSED (throw ExecContextError(SCHEMA_ERROR)) so the caller (sweep) aborts loudly instead of silently bypassing the guard. TRANSIENT errors (network, PostgREST 5xx-class, timeout) preserve the existing fail-OPEN contract — return {ok:true, dbError}. Match by error.code (SQLSTATE), NOT by message regex (Supabase version-fragile). Default-classify unknown errors as TRANSIENT (preserve current behavior conservatively).',
+    acceptance_criteria: [
+      'AC-2.1: Stub supabase.from() returning {data:null, error:{code:"42703", message:"column X does not exist"}} → assertSweepHandoffGate throws ExecContextError with code SCHEMA_ERROR.',
+      'AC-2.2: Stub supabase.from() returning {data:null, error:{code:"42P01", message:"relation does not exist"}} → throws SCHEMA_ERROR.',
+      'AC-2.3: Stub supabase.from() returning {data:null, error:{code:"PGRST301", message:"timeout"}} → returns {ok:true, dbError:"timeout"} (fail-OPEN preserved).',
+      'AC-2.4: Stub supabase.from() returning {data:null, error:{message:"unknown error", code:undefined}} → returns {ok:true, dbError:"unknown error"} (default fail-OPEN for unclassified).',
+    ],
+  },
+  {
+    id: 'FR-3',
+    title: 'Regression test: vitest stub-injection covering FR-1 + FR-2',
+    priority: 'high',
+    description: 'Add tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs (or equivalent .test.js). Use stub-injected supabase client (no live DB) to deterministically exercise: (a) accepted handoffs past target via sdKey input → throws ACCEPTED_HANDOFF_OVERRIDE, (b) accepted handoffs past target via UUID input → throws ACCEPTED_HANDOFF_OVERRIDE, (c) no overriding handoffs → returns {ok:true}, (d) unknown sdKey → throws SD_NOT_FOUND, (e) schema error 42703 → throws SCHEMA_ERROR (fail-CLOSED), (f) schema error 42P01 → throws SCHEMA_ERROR, (g) schema error 42883 → throws SCHEMA_ERROR, (h) transient error PGRST301 → fail-OPEN, (i) unclassified error → fail-OPEN. Total ~9 cases targeting FR-1+FR-2 contract.',
+    acceptance_criteria: [
+      'AC-3.1: All 9 new test cases pass on `npx vitest run tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs`.',
+      'AC-3.2: Existing tests/unit/exec-context-guard*.test.* continue to pass (no regression).',
+      'AC-3.3: lib/eva test suite (full) shows ZERO regressions vs pre-PR baseline (capture pre-PR pass count, assert post-PR equals).',
+    ],
+  },
+  {
+    id: 'FR-4',
+    title: 'Fleet pre-merge audit query: latent-bug disclosure',
+    priority: 'medium',
+    description: 'Add scripts/audit/fleet-handoff-gate-latent-victims.mjs — a one-shot Node script that enumerates SDs whose `current_phase` ranks BELOW their latest accepted `to_phase` in sd_phase_handoffs. These are SDs the broken guard has been silently allowing the sweep to reset. Output: TSV-formatted list (sd_key, current_phase, latest_accepted_to_phase, accepted_handoff_count) sorted by severity (most-egregious phase regressions first). Include a hint header line indicating manual triage may be required. This script is run by LEAD at PLAN-VERIFY review and the output saved as evidence.',
+    acceptance_criteria: [
+      'AC-4.1: scripts/audit/fleet-handoff-gate-latent-victims.mjs runs to completion without error and exits 0.',
+      'AC-4.2: Output includes the witness SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 IF its current state still shows phase regression (note: it was manually restored, may not appear).',
+      'AC-4.3: Output is human-readable TSV with header row.',
+      'AC-4.4: Script attaches its output to PLAN-VERIFY evidence (saved to docs/audits/<sd-key>-latent-victims.tsv or stored in metadata).',
+    ],
+  },
+  {
+    id: 'FR-5',
+    title: 'Structured log line on guard fail-CLOSED for operator visibility',
+    priority: 'medium',
+    description: 'When assertSweepHandoffGate fails-CLOSED with SCHEMA_ERROR (FR-2), emit a structured stderr log line to the sweep operator. Format: `[exec-context-guard] SCHEMA_ERROR sd_key=<X> target=<phase> sqlstate=<code> hint="check column references in lib/exec-context-guard.mjs"`. The line is the only operator-visible signal that the guard aborted. Reuses existing console.warn/console.error patterns in stale-session-sweep.cjs.',
+    acceptance_criteria: [
+      'AC-5.1: When stub supabase returns 42703, the structured log line appears on stderr exactly once.',
+      'AC-5.2: Line includes the SD key, target phase, and SQLSTATE code.',
+      'AC-5.3: Line is unambiguously parseable (key=value format suitable for log aggregation grep).',
+    ],
+  },
+];
+
+const technical_requirements = [
+  {
+    id: 'TR-1',
+    title: 'sd_phase_handoffs.sd_id is TEXT-typed but stores UUIDs',
+    rationale: 'Direct probe (PLAN-phase verification 2026-05-10): query by SD-code (`SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001`) returns 0 rows; query by UUID (2a017ba5-...) returns 5 rows; sample of 50 rows shows ALL distinct sd_id values are UUID-format (none SD-code-format). Risk-agent (3e62f9bf) initially proposed dropping the UUID resolver based on the column being TEXT, but column type alone does not determine stored format. Empirical sample is the source of truth.',
+    description: 'FR-1 MUST resolve sd_key→UUID before querying sd_phase_handoffs.sd_id. The lookup is a single-row select on strategic_directives_v2.id where sd_key=$1. Cache the lookup at the sweep iteration level if performance-critical (currently not — sweep iteration count is typically <100/cycle).',
+  },
+  {
+    id: 'TR-2',
+    title: 'Use SQLSTATE codes (error.code), not message regex',
+    rationale: 'Risk-agent recommendation (3e62f9bf, MEDIUM concern Q4): error.message format is Supabase-version-dependent and prone to drift; error.code (PostgreSQL SQLSTATE) is part of the wire protocol and stable across versions. Matching by code is significantly more robust.',
+    description: 'Schema-class set: `{42703: "column does not exist", 42P01: "relation does not exist", 42883: "function does not exist"}`. Implementation: simple `Set` lookup by error.code. Default unknown error.code values to TRANSIENT (preserves existing fail-OPEN contract for any error not explicitly classified).',
+  },
+  {
+    id: 'TR-3',
+    title: 'No feature flag — atomic single-file revert if needed',
+    rationale: 'Risk-agent recommendation: a feature flag would create a new fail-open drift surface (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 class). The fix RESTORES intended behavior of SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 FR-3, which has been broken since 2026-05-08. No flag needed; if the fix surfaces fleet-wide latent issues, FR-4 audit query at PLAN-VERIFY discloses them in advance.',
+    description: 'Single-file change in lib/exec-context-guard.mjs (~25 LOC net). FR-4 audit script discloses any latent victim SDs at merge time. If unforeseen issues arise post-merge, atomic git revert restores the previous (broken) fail-open state.',
+  },
+  {
+    id: 'TR-4',
+    title: 'Test approach: stub-injection (no live DB)',
+    rationale: 'Risk-agent recommendation (Q6, LOW): live-DB tests cannot deterministically inject error.code:42703 (the bug shipped to production despite live tests because the existing tests stub the happy path or DB is happy). Stub-injection ensures every error path is exercised.',
+    description: 'Tests pass a stub supabase client with `from()` returning a chainable mock that yields `{data, error}` configurable per case. The mock pattern is used elsewhere in tests/unit/* (e.g. claim-validity-gate tests). New test file ~150 LOC, all stub-based, no live DB calls.',
+  },
+];
+
+const test_scenarios = [
+  { id: 'TS-1', test_type: 'unit', given: 'Stub supabase yields 3 accepted handoffs whose to_phase ranks > target=LEAD', when: 'assertSweepHandoffGate(stubSupabase, sdKey, "LEAD")', then: 'throws ExecContextError(ACCEPTED_HANDOFF_OVERRIDE) with overriding[] populated', scenario: 'FR-1 happy-path: SD-code input resolves and guard fires' },
+  { id: 'TS-2', test_type: 'unit', given: 'Stub supabase yields 3 accepted handoffs past target', when: 'assertSweepHandoffGate(stubSupabase, uuidString, "LEAD")', then: 'throws ACCEPTED_HANDOFF_OVERRIDE — UUID input bypasses the resolver path and queries sd_id directly', scenario: 'FR-1 happy-path: UUID input direct query' },
+  { id: 'TS-3', test_type: 'unit', given: 'Stub supabase yields 0 handoffs', when: 'assertSweepHandoffGate(stubSupabase, sdKey, "LEAD")', then: 'returns {ok:true} (no overriding handoffs found)', scenario: 'FR-1 negative: empty handoffs allows reset' },
+  { id: 'TS-4', test_type: 'unit', given: 'SD lookup returns null (sdKey not found)', when: 'assertSweepHandoffGate(stubSupabase, "nonexistent-key", "LEAD")', then: 'throws ExecContextError(SD_NOT_FOUND)', scenario: 'FR-1 unknown-sdKey: fail-loud' },
+  { id: 'TS-5', test_type: 'unit', given: 'Stub supabase returns error{code:"42703"}', when: 'assertSweepHandoffGate is called', then: 'throws ExecContextError(SCHEMA_ERROR); structured log line on stderr', scenario: 'FR-2+FR-5 schema 42703 fail-CLOSED' },
+  { id: 'TS-6', test_type: 'unit', given: 'Stub supabase returns error{code:"42P01"}', when: 'assertSweepHandoffGate is called', then: 'throws SCHEMA_ERROR (relation does not exist)', scenario: 'FR-2 schema 42P01 fail-CLOSED' },
+  { id: 'TS-7', test_type: 'unit', given: 'Stub supabase returns error{code:"42883"}', when: 'assertSweepHandoffGate is called', then: 'throws SCHEMA_ERROR (function does not exist)', scenario: 'FR-2 schema 42883 fail-CLOSED' },
+  { id: 'TS-8', test_type: 'unit', given: 'Stub supabase returns error{code:"PGRST301"} (timeout)', when: 'assertSweepHandoffGate is called', then: 'returns {ok:true, dbError:"timeout"} — fail-OPEN preserved', scenario: 'FR-2 transient: fail-OPEN preserved' },
+  { id: 'TS-9', test_type: 'unit', given: 'Stub supabase returns error{message:"unknown", code:undefined}', when: 'assertSweepHandoffGate is called', then: 'returns {ok:true, dbError} — default to fail-OPEN for unclassified', scenario: 'FR-2 unclassified: conservative fail-OPEN' },
+  { id: 'TS-10', test_type: 'integration', given: 'Live witness SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 (3 accepted handoffs in sd_phase_handoffs)', when: 'assertSweepHandoffGate(realSupabase, sdKey, "LEAD")', then: 'throws ACCEPTED_HANDOFF_OVERRIDE — was: returned {ok:true,dbError}', scenario: 'Smoke (manual): repro of original bug after fix' },
+];
+
+const acceptance_criteria = [
+  ...functional_requirements.flatMap(fr => (fr.acceptance_criteria || []).map(criterion => ({ requirement_id: fr.id, criterion }))),
+  { requirement_id: 'NFR-1', criterion: 'PR LOC ≤30 in lib/exec-context-guard.mjs (source). Test file ≤200 LOC. Audit script ≤100 LOC.' },
+  { requirement_id: 'NFR-2', criterion: 'Zero regressions: pre-existing exec-context-guard + lib/eva test suites unchanged after PR.' },
+  { requirement_id: 'NFR-3', criterion: 'Smoke test (smoke_test_steps in SD) runs green at EXEC-COMPLETE.' },
+  { requirement_id: 'NFR-4', criterion: 'Fleet audit (FR-4) output saved as evidence at PLAN-VERIFY before LEAD-FINAL-APPROVAL.' },
+];
+
+const risks = [
+  { id: 'R-1', risk: 'Closing fail-open surfaces latent issues across the fleet — sweep behavior changes from "reset everything that looks orphaned" to "skip resets when accepted handoffs past target exist". Some currently-being-silently-reset SDs may now be retained instead, surfacing real bugs being masked.', impact: 'MEDIUM', probability: 'MEDIUM', mitigation: 'FR-4 fleet pre-merge audit query enumerates latent victims at PR time; LEAD reviews output before final approval. Per-SD triage may be needed for affected SDs but each is a genuine bug being uncovered, not a regression.', rollback_plan: 'Atomic single-file revert of lib/exec-context-guard.mjs restores the previous fail-open state.' },
+  { id: 'R-2', risk: 'sd_key→UUID lookup adds DB round-trip per assertSweepHandoffGate call', impact: 'LOW', probability: 'LOW', mitigation: 'Sweep iteration count is small (<100/cycle, runs every 5min). UUID inputs bypass the resolver entirely. If observed latency >50ms p99, add per-iteration cache (deferred unless needed).', rollback_plan: 'N/A — performance optimization, not correctness.' },
+  { id: 'R-3', risk: 'Schema-class detection misclassifies a non-schema PostgREST error as schema (over-fail-CLOSED)', impact: 'LOW', probability: 'LOW', mitigation: 'Match strictly on SQLSTATE codes (42703, 42P01, 42883) — these are PostgreSQL-protocol-defined and stable. Default unknown codes to TRANSIENT (fail-OPEN preserved). Test coverage includes both classes.', rollback_plan: 'Single-line revert of the schema-class Set; falls back to fail-OPEN-on-all-errors (current broken behavior, but at least not a regression).' },
+  { id: 'R-4', risk: 'Audit script (FR-4) overlooks edge case where accepted handoff to_phase is unknown (not in phaseRank)', impact: 'LOW', probability: 'LOW', mitigation: 'Audit script uses same phaseRank mapping as assertSweepHandoffGate; unknown phases are skipped (consistent with guard behavior). Document the mapping in audit script header.', rollback_plan: 'N/A — audit is informational, not state-changing.' },
+];
+
+const system_architecture = {
+  overview: 'Single-file repair to lib/exec-context-guard.mjs::assertSweepHandoffGate query. Function signature unchanged. Surface area: one query rewrite + new error-classification branch + structured log line on fail-CLOSED. Plus regression test (stub-injected) and one-shot fleet audit script.',
+  components: [
+    { name: 'lib/exec-context-guard.mjs', role: 'Repaired query (sd_key→UUID resolution + sd_id-only lookup); schema-class error classifier; structured log on fail-CLOSED' },
+    { name: 'tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs', role: 'Regression test (9 cases, stub-injected supabase, zero live DB)' },
+    { name: 'scripts/audit/fleet-handoff-gate-latent-victims.mjs', role: 'One-shot audit script enumerating SDs with phase-regression patterns; run at PLAN-VERIFY' },
+    { name: 'scripts/stale-session-sweep.cjs', role: 'Caller — UNCHANGED. Receives the now-effective guard via existing isSweepResetAllowed wrapper at lines 686, 742, 155.' },
+    { name: 'sd_phase_handoffs', role: 'Read-only target — unchanged schema. Empirically verified sd_id stores UUIDs.' },
+    { name: 'strategic_directives_v2', role: 'Read-only — used by sd_key→UUID resolution path' },
+  ],
+  data_flow: 'sweep → isSweepResetAllowed → assertSweepHandoffGate(supabase, sdKey, target) → [if sdKey is UUID-format: query sd_phase_handoffs.sd_id directly] OR [if SD-code: lookup strategic_directives_v2.id, then query sd_phase_handoffs.sd_id with UUID] → filter accepted handoffs whose to_phase rank > target rank → throw ACCEPTED_HANDOFF_OVERRIDE if any | DB error: classify → SCHEMA_ERROR throw + log | TRANSIENT/UNKNOWN → fail-OPEN return {ok:true, dbError}',
+};
+
+const integration_operationalization = {
+  consumers: [
+    { consumer: 'scripts/stale-session-sweep.cjs (3 reset paths: PHASE_RESET_MAP, STUCK_PENDING_APPROVAL, PHANTOM_IN_PROGRESS)', journey: 'Each reset path calls isSweepResetAllowed → assertSweepHandoffGate. After fix, accepted handoffs past target reset phase block the reset (current broken behavior allowed reset).' },
+    { consumer: 'Other potential callers (none currently — assertSweepHandoffGate exported for sweep only)', journey: 'Function signature preserved; any future caller benefits from repaired behavior automatically.' },
+  ],
+  dependencies: [
+    { name: 'sd_phase_handoffs (table)', direction: 'upstream', failure_mode: 'If sd_id column is renamed in future migration, FR-2 will surface 42703 as SCHEMA_ERROR fail-CLOSED — operator alerted via FR-5 log line.' },
+    { name: 'strategic_directives_v2 (table)', direction: 'upstream', failure_mode: 'If sd_key column is renamed, FR-1 SD lookup throws SD_NOT_FOUND-class error; sweep aborts loudly.' },
+    { name: 'PostgreSQL SQLSTATE codes (wire protocol)', direction: 'upstream', failure_mode: 'Stable across PG versions; minimal drift risk.' },
+  ],
+  data_contracts: [
+    { entity: 'assertSweepHandoffGate input', shape: 'sdKey: string (either SD-code like "SD-XXX-001" or UUID like "2a017ba5-..."); targetResetPhase: "LEAD" | "PLAN" | "EXEC"' },
+    { entity: 'assertSweepHandoffGate output (success)', shape: '{ok: true} | {ok: true, dbError: string} (fail-OPEN on transient)' },
+    { entity: 'assertSweepHandoffGate output (failure)', shape: 'throws ExecContextError with code in {ACCEPTED_HANDOFF_OVERRIDE, SCHEMA_ERROR, SD_NOT_FOUND}' },
+    { entity: 'fleet audit TSV row', shape: '{sd_key, current_phase, latest_accepted_to_phase, phase_rank_diff, accepted_handoff_count}' },
+  ],
+  runtime_config: [
+    { config: 'No new env vars or feature flags', purpose: 'Atomic restoration of intended behavior; no flag drift surface' },
+  ],
+  observability_rollout: {
+    metrics: [
+      'stderr line count for `[exec-context-guard] SCHEMA_ERROR ...` (FR-5 log line)',
+      'sweep `SKIP_RESET: ... ACCEPTED_HANDOFF_OVERRIDE` line count (existing — should increase post-fix)',
+      'sweep abort count (currently 0 by virtue of bug; expected to remain 0 in steady state — only if a future migration breaks the schema)',
+    ],
+    rollout_plan: 'Single-PR atomic merge. FR-4 fleet audit run at PLAN-VERIFY discloses any latent victim SDs in advance. Observe 2 sweep cycles (~10 min) post-merge to confirm SKIP_RESET log lines appear for protected SDs.',
+    rollback_procedure: 'git revert <commit>; sweep returns to previous broken-but-stable behavior. No DB changes to unwind.',
+  },
+};
+
+const exploration_summary = {
+  files_read: [
+    'lib/exec-context-guard.mjs (full read — 264 LOC)',
+    'scripts/stale-session-sweep.cjs (lines 80-140 + 600-770 — guard caller + reset paths)',
+    'database/migrations/20260509_layer1_claiming_session_id_release_parity.sql (full read — exonerated PR #3627 functions)',
+  ],
+  baseline_observation: 'Direct invocation 2026-05-10: assertSweepHandoffGate(supabase, "SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD") returns {ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"}. Same SD has 5 rows in sd_phase_handoffs with 3 accepted handoffs past LEAD (LEAD-TO-PLAN to_phase=PLAN, PLAN-TO-EXEC to_phase=EXEC, PLAN-TO-LEAD to_phase=LEAD). Guard SHOULD throw — instead, fails-open silently.',
+  existing_infrastructure: 'lib/exec-context-guard.mjs shipped 2026-05-08 (commit c4f25e4023, PR #3600, SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001). assertSweepHandoffGate, ExecContextError class, isSweepResetAllowed wrapper all preserved as-is. Fix repairs only the .or() clause and adds error classification.',
+  validation_agent_evidence: { row_id: 'f8dbf7c6-729c-4817-9bc2-112666488151', verdict: 'PASS', confidence: 92, finding: 'No duplicate fix exists; SD type/priority correct; scope boundary sharp; PR #3627 migration validated INNOCENT.' },
+  risk_agent_evidence: { row_id: '3e62f9bf-6010-48f6-b775-910a68badb9c', verdict: 'PASS (MEDIUM-LOW risk)', confidence: 87, finding: 'Top concerns: latent fleet bugs surfacing (mitigated by FR-4 audit), schema-class detection accuracy (mitigated by SQLSTATE matching). Recommended additions: FR-4 audit query, FR-5 structured log, test via stub-injection. Risk-agent UUID-resolver-elimination claim was empirically refuted (sd_id stores UUIDs not SD-codes).' },
+};
+
+const prdRow = {
+  id: prdId,
+  directive_id: sdKey,
+  sd_id: sdId,
+  title: 'Repair assertSweepHandoffGate query: schema-error fail-open caused phantom-session SD state regressions',
+  version: '1.0.0',
+  status: 'in_progress',
+  category: 'bugfix',
+  priority: 'high',
+  document_type: 'prd',
+  phase: 'planning',
+  progress: 0,
+  executive_summary: 'lib/exec-context-guard.mjs::assertSweepHandoffGate has been silently fail-open on every call since deployment (commit c4f25e4023, 2026-05-08) due to a non-existent column reference (sd_phase_handoffs.sd_key) in its .or() query clause. The fail-open path returns {ok:true, dbError} on any DB error including this permanent schema error, so all stale-session-sweep reset paths (PHASE_RESET_MAP, STUCK_PENDING_APPROVAL, PHANTOM_IN_PROGRESS) bypass the guard. Witness: SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 was reset to draft/LEAD/0% on 2026-05-10 despite having 3 accepted handoffs past LEAD in sd_phase_handoffs. Source feedback c76f88ff misattributed the cause to PR #3627 cascade trigger; PR #3627 functions only clear claim columns (active_session_id/claiming_session_id/is_working_on) and are innocent. This PR repairs the guard query (sd_key→UUID resolution + sd_id-only lookup), distinguishes schema-class vs transient errors (fail-CLOSED on SQLSTATE 42703/42P01/42883, fail-OPEN preserved on transient), adds vitest stub-injection regression, runs a fleet audit (FR-4) to disclose latent victim SDs at PLAN-VERIFY, and emits a structured log line on fail-CLOSED for operator visibility.',
+  business_context: 'Silent corruption of SD work-product state across the fleet. Witnessed regression cost ~30 min of manual user-authorized DB UPDATE to restore. Multiple invisible regressions likely occurred since 2026-05-08 (FR-4 audit will quantify). Restoring the guard prevents future state-loss class incidents and surfaces any latent victims at merge time so operators can triage.',
+  technical_context: 'Backend infrastructure SD (EHG_Engineer only). Single-file repair in lib/ + new test file + new audit script. No DB schema changes, no migrations. Only consumer is scripts/stale-session-sweep.cjs (3 reset call sites at lines 155, 686, 742) — UNCHANGED. The fix RESTORES intended behavior of SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 FR-3.',
+  functional_requirements,
+  technical_requirements,
+  test_scenarios,
+  acceptance_criteria,
+  risks,
+  system_architecture,
+  integration_operationalization,
+  exploration_summary,
+  technology_stack: ['Node.js (ESM in lib/)', 'Supabase JS client', 'vitest', 'PostgreSQL SQLSTATE codes'],
+  dependencies: [
+    'lib/exec-context-guard.mjs (PR #3600, exports assertSweepHandoffGate)',
+    'sd_phase_handoffs table (read-only target)',
+    'strategic_directives_v2 table (sd_key→UUID resolution path)',
+  ],
+  performance_requirements: { p99_assert_sweep_handoff_gate_ms: 100, sweep_iteration_overhead_max_ms: 50 },
+  metadata: {
+    sd_key: sdKey,
+    sd_type: 'bugfix',
+    plan_phase_session: 'd694138f-de06-478a-b758-18e8c1d84445',
+    rescope_source: 'risk-agent recommendations folded as FR-4 + FR-5 + SQLSTATE matching',
+    loc_estimate: { source: { min: 25, max: 40 }, tests: 200, audit_script: 100, ceiling: 340 },
+    out_of_scope: [
+      'PR #3627 migration changes (innocent of the regression)',
+      'PHASE_RESET_MAP / STUCK_PENDING_APPROVAL / PHANTOM_IN_PROGRESS reset paths in stale-session-sweep.cjs (intended behavior)',
+      'QF-20260423-909 PLAN-TO-LEAD-specific guard (works correctly)',
+      'Feature flag (atomic single-file revert sufficient per risk-agent)',
+    ],
+    sub_agent_evidence: {
+      validation: 'f8dbf7c6-729c-4817-9bc2-112666488151',
+      risk: '3e62f9bf-6010-48f6-b775-910a68badb9c',
+    },
+    risk_agent_correction: 'Risk-agent recommended dropping UUID resolver based on column-type=TEXT inference. PLAN-phase empirical probe refuted: 50-row sample shows ALL sd_phase_handoffs.sd_id values are UUID-format. FR-1 retains the resolver path.',
+  },
+  created_by: `PLAN-PHASE-INLINE-MODE-CC-${sessionShort}`,
+  goal_summary: 'Restore the deployed-but-silently-broken assertSweepHandoffGate guard so stale-session-sweep reset paths actually skip when accepted handoffs past the target reset phase exist; surface any latent fleet victims at merge time via FR-4 audit.',
+  smoke_test_cmd: 'npx vitest run tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs',
+};
+
+const { data, error } = await supabase
+  .from('product_requirements_v2')
+  .insert(prdRow)
+  .select('id, directive_id, sd_id, status, phase, category, priority, created_by');
+
+if (error) {
+  console.error('INSERT_ERR:', error);
+  process.exit(1);
+}
+
+console.log('PRD_INSERTED:', JSON.stringify(data, null, 2));

--- a/scripts/one-off/_plan-insert-user-stories-sd-fdbk-enh-cascade-trigger-3627-001.mjs
+++ b/scripts/one-off/_plan-insert-user-stories-sd-fdbk-enh-cascade-trigger-3627-001.mjs
@@ -1,0 +1,169 @@
+// PLAN-PHASE user-stories insert for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sdId = '38f4e8aa-0610-4f0d-a344-1b1968fef6b1';
+const sdKey = 'SD-FDBK-ENH-CASCADE-TRIGGER-3627-001';
+const prdId = `PRD-${sdKey}`;
+
+const stories = [
+  {
+    story_key: `${sdKey}:US-001`,
+    sd_id: sdId,
+    prd_id: prdId,
+    title: 'Repair assertSweepHandoffGate query',
+    user_role: 'stale-session-sweep operator',
+    user_want: 'assertSweepHandoffGate to actually block reset paths when accepted handoffs past the target reset phase exist',
+    user_benefit: 'so SD work-product state (status, current_phase, progress) is not silently corrupted when phantom sessions are SWEEP_PID_DEAD-released',
+    priority: 'high',
+    status: 'ready',
+    acceptance_criteria: [
+      'assertSweepHandoffGate(supabase, "SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD") throws ExecContextError(ACCEPTED_HANDOFF_OVERRIDE)',
+      'assertSweepHandoffGate(supabase, "<uuid>", "LEAD") throws ACCEPTED_HANDOFF_OVERRIDE on UUID input',
+      'assertSweepHandoffGate(supabase, "<sdKey-with-no-handoffs>", "LEAD") returns {ok: true}',
+      'assertSweepHandoffGate(supabase, "<nonexistent-sdKey>", "LEAD") throws ExecContextError(SD_NOT_FOUND)',
+    ],
+    test_scenarios: [
+      'GIVEN witness SD with 3 accepted handoffs in sd_phase_handoffs WHEN assertSweepHandoffGate is called THEN it throws ACCEPTED_HANDOFF_OVERRIDE',
+      'GIVEN UUID input format WHEN assertSweepHandoffGate is called THEN it bypasses the resolver and queries sd_id directly',
+    ],
+    given_when_then: [
+      'GIVEN PR is merged WHEN sweep encounters STUCK_PENDING_APPROVAL or PHANTOM_IN_PROGRESS SD with accepted handoffs THEN sweep skips reset and emits SKIP_RESET log line',
+    ],
+    technical_notes: 'lib/exec-context-guard.mjs:169-208 — replace .or(sd_id.eq.X,sd_key.eq.X) with sd_key->UUID resolution + sd_id-only lookup',
+    implementation_context: 'lib/exec-context-guard.mjs::assertSweepHandoffGate function (lines 169-208). Resolve sd_key→UUID via select id from strategic_directives_v2 where sd_key=$1 (only when input is not UUID-format). Then query sd_phase_handoffs.sd_id with the UUID. UUID detection regex: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.',
+    implementation_status: 'pending',
+    e2e_test_status: 'not_created',
+    metadata: { fr_id: 'FR-1' },
+  },
+  {
+    story_key: `${sdKey}:US-002`,
+    sd_id: sdId,
+    prd_id: prdId,
+    title: 'Distinguish schema-class DB errors from transient errors (fail-CLOSED on schema)',
+    user_role: 'stale-session-sweep operator',
+    user_want: 'permanent schema errors to fail-CLOSED so future column drift is loudly surfaced instead of silently bypassed',
+    user_benefit: 'so the bug class that caused the original regression (silent fail-open on schema mismatch) cannot recur for any future schema change',
+    priority: 'high',
+    status: 'ready',
+    acceptance_criteria: [
+      'PostgreSQL SQLSTATE 42703 (column does not exist) -> fail-CLOSED with ExecContextError(SCHEMA_ERROR)',
+      'PostgreSQL SQLSTATE 42P01 (relation does not exist) -> fail-CLOSED',
+      'PostgreSQL SQLSTATE 42883 (function does not exist) -> fail-CLOSED',
+      'PGRST301 (timeout) and other transient errors -> fail-OPEN preserved (returns {ok:true, dbError})',
+      'Unclassified errors -> fail-OPEN (default conservative)',
+    ],
+    test_scenarios: [
+      'GIVEN stub supabase returning error{code:42703} WHEN assertSweepHandoffGate runs THEN it throws SCHEMA_ERROR',
+      'GIVEN stub returning error{code:PGRST301} WHEN it runs THEN it returns {ok:true, dbError}',
+    ],
+    given_when_then: [
+      'GIVEN sweep encounters schema-class error WHEN guard runs THEN sweep aborts loudly with structured log line (FR-5)',
+    ],
+    technical_notes: 'Match by error.code (SQLSTATE), NOT message regex. Schema-class set: {42703, 42P01, 42883}.',
+    implementation_context: `lib/exec-context-guard.mjs assertSweepHandoffGate. Replace if(error){return {ok:true, dbError}} with classifier: const SCHEMA_CODES = new Set(['42703', '42P01', '42883']); if (error && SCHEMA_CODES.has(error.code)) throw new ExecContextError('SCHEMA_ERROR', ...); else if (error) return {ok:true, dbError}; (preserves transient fail-OPEN).`,
+    implementation_status: 'pending',
+    e2e_test_status: 'not_created',
+    metadata: { fr_id: 'FR-2' },
+  },
+  {
+    story_key: `${sdKey}:US-003`,
+    sd_id: sdId,
+    prd_id: prdId,
+    title: 'Vitest stub-injection regression test',
+    user_role: 'CI gate enforcer',
+    user_want: 'a stub-injected vitest test covering 9+ branches of the repaired guard',
+    user_benefit: 'so future regressions to the column-name drift class or schema-error fail-open class are caught in CI before merge',
+    priority: 'high',
+    status: 'ready',
+    acceptance_criteria: [
+      'New test file tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs (or .test.js)',
+      '9+ test cases covering FR-1 (sdKey input, UUID input, no handoffs, unknown sdKey) + FR-2 (3 schema codes, transient, unclassified)',
+      'Test uses stub-injected supabase client (zero live DB)',
+      'All cases pass; existing exec-context-guard tests unchanged; lib/eva regression count unchanged',
+    ],
+    test_scenarios: [
+      'GIVEN test suite runs WHEN any branch of guard contract is broken THEN at least one test fails',
+    ],
+    given_when_then: [
+      'GIVEN a developer changes sd_phase_handoffs schema WHEN PR is opened THEN regression test fails IF guard is not also updated',
+    ],
+    technical_notes: 'Mock supabase.from() with chainable .select().or().eq() returning configurable {data, error}. Pattern from claim-validity-gate test files.',
+    implementation_context: `New file: tests/unit/exec-context-guard-handoff-gate-query-repair.test.mjs (or .test.js). Use vitest. Stub supabase.from() with a chainable mock yielding {data, error}. 9+ test cases covering FR-1 (sdKey, UUID, no-handoffs, unknown-sdKey) + FR-2 (42703, 42P01, 42883, transient, unclassified). Pattern reference: existing tests/unit/claim-validity-gate*.test.* files.`,
+    implementation_status: 'pending',
+    e2e_test_status: 'not_created',
+    metadata: { fr_id: 'FR-3' },
+  },
+  {
+    story_key: `${sdKey}:US-004`,
+    sd_id: sdId,
+    prd_id: prdId,
+    title: 'Fleet pre-merge audit script discloses latent victim SDs',
+    user_role: 'LEAD reviewer at PLAN-VERIFY',
+    user_want: 'a one-shot script enumerating SDs whose current_phase ranks below their latest accepted to_phase',
+    user_benefit: 'so any latent fleet victims of the broken guard are disclosed at PR review time, not discovered post-merge in production',
+    priority: 'medium',
+    status: 'ready',
+    acceptance_criteria: [
+      'New script scripts/audit/fleet-handoff-gate-latent-victims.mjs',
+      'Script runs to completion and exits 0',
+      'Output is human-readable TSV (header + rows: sd_key, current_phase, latest_accepted_to_phase, phase_rank_diff, accepted_handoff_count)',
+      'Output saved as evidence at PLAN-VERIFY (file or PRD metadata)',
+    ],
+    test_scenarios: [
+      'GIVEN fleet has at least one SD with phase regression WHEN audit runs THEN that SD appears in output',
+      'GIVEN fleet has no phase regressions WHEN audit runs THEN output has only header line',
+    ],
+    given_when_then: [
+      'GIVEN PR is approaching LEAD-FINAL WHEN LEAD reviewer runs audit THEN they see disclosed list of affected SDs and can authorize per-SD triage',
+    ],
+    technical_notes: 'phaseRank mapping mirrors lib/exec-context-guard.mjs::assertSweepHandoffGate. Skip phases not in mapping (consistent with guard).',
+    implementation_context: `New file: scripts/audit/fleet-handoff-gate-latent-victims.mjs. Imports phaseRank from lib/exec-context-guard.mjs (export it if not already). Iterates strategic_directives_v2 rows joining latest accepted sd_phase_handoffs per sd_id. Computes phase_rank_diff = phaseRank[latest_to_phase] - phaseRank[current_phase]. Outputs TSV to stdout AND saves to docs/audits/<sd-key>-latent-victims-<date>.tsv.`,
+    implementation_status: 'pending',
+    e2e_test_status: 'not_created',
+    metadata: { fr_id: 'FR-4' },
+  },
+  {
+    story_key: `${sdKey}:US-005`,
+    sd_id: sdId,
+    prd_id: prdId,
+    title: 'Structured log line on guard fail-CLOSED for operator visibility',
+    user_role: 'sweep operator monitoring stderr',
+    user_want: 'a key=value log line emitted when assertSweepHandoffGate aborts due to schema-class error',
+    user_benefit: 'so silent guard aborts cannot recur — every fail-CLOSED is human-visible and grep-able for log aggregation',
+    priority: 'medium',
+    status: 'ready',
+    acceptance_criteria: [
+      'Format: `[exec-context-guard] SCHEMA_ERROR sd_key=<X> target=<phase> sqlstate=<code> hint="check column references in lib/exec-context-guard.mjs"`',
+      'Line emitted exactly once per fail-CLOSED event',
+      'Line is unambiguously parseable (key=value)',
+    ],
+    test_scenarios: [
+      'GIVEN stub returns 42703 WHEN guard runs THEN structured log line appears on stderr',
+    ],
+    given_when_then: [
+      'GIVEN future schema migration breaks guard WHEN sweep runs THEN stderr is grep-able for "[exec-context-guard]" lines',
+    ],
+    technical_notes: 'Use console.error with template literal. Reuse stale-session-sweep.cjs log conventions where possible.',
+    implementation_context: 'In lib/exec-context-guard.mjs::assertSweepHandoffGate, when classifier triggers SCHEMA_ERROR throw, prepend a console.error line of the form: [exec-context-guard] SCHEMA_ERROR sd_key=<X> target=<phase> sqlstate=<code> hint="check column references in lib/exec-context-guard.mjs". Use template literal in source code; document key=value format here.',
+    implementation_status: 'pending',
+    e2e_test_status: 'not_created',
+    metadata: { fr_id: 'FR-5' },
+  },
+];
+
+const { data, error } = await supabase
+  .from('user_stories')
+  .insert(stories)
+  .select('id, story_key, status, priority');
+
+if (error) {
+  console.error('INSERT_ERR:', error);
+  process.exit(1);
+}
+
+console.log('USER_STORIES_INSERTED:', data.length);
+for (const s of data) {
+  console.log('  -', s.story_key, '|', s.status, '|', s.priority);
+}

--- a/scripts/one-off/_plan-insert-user-stories-sd-fdbk-enh-cascade-trigger-3627-001.mjs
+++ b/scripts/one-off/_plan-insert-user-stories-sd-fdbk-enh-cascade-trigger-3627-001.mjs
@@ -137,7 +137,7 @@ const stories = [
     acceptance_criteria: [
       'Format: `[exec-context-guard] SCHEMA_ERROR sd_key=<X> target=<phase> sqlstate=<code> hint="check column references in lib/exec-context-guard.mjs"`',
       'Line emitted exactly once per fail-CLOSED event',
-      'Line is unambiguously parseable (key=value)',
+      'Line is machine-parseable (key=value tokens) (key=value)',
     ],
     test_scenarios: [
       'GIVEN stub returns 42703 WHEN guard runs THEN structured log line appears on stderr',

--- a/scripts/one-off/_probe-validation-mode-values-2.mjs
+++ b/scripts/one-off/_probe-validation-mode-values-2.mjs
@@ -1,0 +1,6 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const { data } = await sb.from('sub_agent_execution_results').select('validation_mode').not('validation_mode', 'is', null).limit(100);
+const modes = new Set((data||[]).map(r => r.validation_mode));
+console.log('validation_mode existing values:', [...modes]);

--- a/scripts/one-off/_probe-validation-mode-values.mjs
+++ b/scripts/one-off/_probe-validation-mode-values.mjs
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Get distinct existing validation_mode values
+const { data } = await sb.from('sub_agent_execution_results')
+  .select('validation_mode, source, verdict, sub_agent_code')
+  .order('created_at', { ascending: false })
+  .limit(50);
+const modes = new Set();
+const sources = new Set();
+const verdicts = new Set();
+for (const r of (data||[])) {
+  if (r.validation_mode) modes.add(r.validation_mode);
+  if (r.source) sources.add(r.source);
+  if (r.verdict) verdicts.add(r.verdict);
+}
+console.log('validation_mode values:', [...modes]);
+console.log('source values:', [...sources]);
+console.log('verdict values:', [...verdicts]);

--- a/scripts/one-off/_risk-agent-evidence-cascade-trigger-3627.mjs
+++ b/scripts/one-off/_risk-agent-evidence-cascade-trigger-3627.mjs
@@ -1,0 +1,125 @@
+// One-off: write RISK sub-agent evidence row for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 (LEAD phase)
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const sdId = '38f4e8aa-0610-4f0d-a344-1b1968fef6b1';
+
+const summary = [
+  'MEDIUM-LOW risk verdict for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001.',
+  'Fix repairs a guard silently fail-open since 2026-05-08 (commit c4f25e4023) — restoring SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 FR-3 intended behavior, NOT introducing new contract.',
+  'EMPIRICAL FINDING (live DB probes): sd_phase_handoffs.sd_key does not exist (PostgREST 42703 confirmed); sd_id is a string-typed column accepting SD-codes directly — NO UUID coercion, NO resolver round-trip, NO cache needed.',
+  'This collapses FR-1 to dropping the .or() and using .eq(sd_id, sdKey). Q3 latency concern is moot.',
+  'Top concern (Q2 MEDIUM 6/10): when guard becomes effective, OTHER currently-being-silently-reset SDs in fleet WILL start being protected — pre-stage fleet-audit query to disclose latent-bug-surface population BEFORE merge.',
+  'Top concern (Q4 MEDIUM 5/10): match schema-class errors by SQLSTATE error.code (42703 / 42P01 / 42883), NOT error.message regex (Supabase version-dependent).',
+  'Q5 (LOW-MEDIUM 4/10): future schema drift would fail loudly via fail-CLOSED instead of silently — NET POSITIVE vs status quo.',
+  'Recommended scope additions:',
+  ' (a) FR-1 simplified — single .eq() query, no resolver/cache;',
+  ' (b) FR-2 fail-CLOSED limited to schema-class SQLSTATE codes {42703, 42P01, 42883};',
+  ' (c) FR-3 stub-injection test (deterministic, no live DB) for both happy path and 42703 fail-CLOSED;',
+  ' (d) NEW FR-4 (recommended): fleet pre-merge audit query enumerating SDs whose current_phase ranks below latest accepted handoff to_phase;',
+  ' (e) NEW FR-5 (recommended): structured log line on fail-CLOSED for operator visibility.',
+  'NO feature flag: fix restores intended behavior; flag itself would be new fail-open drift surface (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 class).',
+  'Rollback: single-file atomic revert. Stage merge during low-sweep-activity window; observe 2 sweep cycles (~10 min) post-merge.'
+].join(' ');
+
+const detailedAnalysis = {
+  overall_risk: 'MEDIUM-LOW',
+  domain_scores: {
+    technical_complexity: 3,
+    security_risk: 2,
+    performance_risk: 2,
+    integration_risk: 5,
+    data_migration_risk: 1,
+    ui_ux_risk: 1
+  },
+  questions: {
+    Q1_failclosed_contract_change: {
+      score: 4,
+      verdict: 'LOW',
+      finding: 'Guard ALREADY documents fail-OPEN policy for transient errors (line 187-190). Restricting fail-CLOSED to schema-class SQLSTATE preserves transient-fail-OPEN. Blast radius if mis-classified: a single sweep iteration aborts loudly with error log; non-destructive — sweep is itself a resilience layer, not a critical path. CAVEAT: ensure detection matches error.code (PostgREST surfaces SQLSTATE) NOT error.message regex.'
+    },
+    Q2_latent_bug_surface: {
+      score: 6,
+      verdict: 'MEDIUM',
+      finding: 'When guard becomes effective on /loop 5m schedule, OTHER currently-being-silently-reset SDs WILL start being blocked. Witness already documented (SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001). DESIRED: real bugs surfaced. RISK: unknown count of fleet-wide silent-reset victims. Mitigation: pre-stage SQL audit query enumerating SDs with current_phase ranking earlier than latest accepted handoff to_phase. Run audit BEFORE merge to PR-time-disclose impact, AND post-merge to confirm no surprise blocks.'
+    },
+    Q3_lookup_latency: {
+      score: 1,
+      verdict: 'LOW (NON-ISSUE)',
+      finding: 'EMPIRICAL: sd_phase_handoffs.sd_id is a string-typed column accepting SD-code values directly (probed: sd_id=SD-LEO-INFRA-UNIFY-CONTEXT-PRESERVATION-001 returned 3 rows with no type error). NO UUID resolution needed. Fix collapses to dropping .or() and using .eq(sd_id, sdKey) — same single round-trip as today. NO cache needed.'
+    },
+    Q4_schema_class_detection: {
+      score: 5,
+      verdict: 'MEDIUM',
+      finding: 'PostgREST surfaces PostgreSQL SQLSTATE in error.code field. Schema-class set: 42703 (undefined_column), 42P01 (undefined_table), 42883 (undefined_function). Matching by error.code is stable across Supabase/PostgREST versions; matching by error.message is not. Recommend a frozen Set([42703, 42P01, 42883]) plus a clear comment listing covered codes.'
+    },
+    Q5_future_schema_drift: {
+      score: 4,
+      verdict: 'LOW-MEDIUM',
+      finding: 'If future migration renames sd_phase_handoffs.sd_id, new query .eq(sd_id, sdKey) breaks identically — but loudly via fail-CLOSED, NOT silently as today. If future migration ADDS sd_phase_handoffs.sd_key, no impact (current fix drops the .or() entirely). Optional mitigation: startup self-test probing known-safe sentinel SD on first call per-process; cache 0/1 healthy flag.'
+    },
+    Q6_test_coverage: {
+      score: 3,
+      verdict: 'LOW',
+      finding: 'Stub-based unit test preferred: inject mock supabase client whose chain returns {error:{code:42703,message:...},data:null} for fail-CLOSED case AND {error:null,data:[{...accepted handoff past target...}]} for happy path. Deterministic, no live DB. PLUS: integration test reproducing witness scenario using SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 SD-code as input.'
+    },
+    Q7_rollback_complexity: {
+      score: 2,
+      verdict: 'LOW',
+      finding: 'Single-file change (lib/exec-context-guard.mjs), single-function refactor (assertSweepHandoffGate), atomic git revert. NO feature flag because (a) fix restores intended behavior, NOT new behavior; (b) flag would itself be a fail-open drift surface (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 class — flags often forgotten in flipped state). Stage merge during low-sweep-activity window (sweep on /loop 5m so 10-minute observation post-merge is sufficient).'
+    }
+  },
+  critical_issues: [],
+  warnings: [
+    'Q4: Use error.code SQLSTATE matching, NOT error.message regex (Supabase version-dependent)',
+    'Q2: Pre-stage fleet-audit query before merge to disclose latent-bug surface',
+    'Q3 EMPIRICAL: sd_phase_handoffs.sd_id is string-typed; no UUID resolution / cache needed — simplifies FR-1'
+  ],
+  mitigation_recommendations: [
+    'FR-1 simplification: drop .or() and use .eq(sd_id, sdKey) — no resolver, no cache',
+    'FR-2: fail-CLOSED match by SQLSTATE code set {42703, 42P01, 42883} via error.code',
+    'FR-3: deterministic stub test for both happy path AND 42703 error injection',
+    'FR-4 (NEW, recommended): fleet pre-merge audit SQL identifying SDs whose current_phase ranks below latest accepted handoff to_phase',
+    'FR-5 (NEW, recommended): structured log line on guard fail-CLOSED — diagnostic visibility',
+    'NO feature flag: fix restores intended behavior; flag would create new fail-open drift surface',
+    'Stage merge during low-sweep-activity window and observe 2 sweep cycles (~10 minutes) post-merge'
+  ],
+  scope_additions: [
+    'FR-4: fleet pre-merge audit query',
+    'FR-5: structured log line on fail-CLOSED'
+  ],
+  feature_flag_recommendation: 'NONE — restoring intended behavior, atomic revert sufficient',
+  issue_pattern_link: 'PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (writer-side wrote .or() referring to consumer-side schema that did not exist; identical multi-witness asymmetry class)'
+};
+
+const { data, error } = await s.from('sub_agent_execution_results').insert({
+  sd_id: sdId,
+  sub_agent_code: 'RISK',
+  sub_agent_name: 'risk-agent',
+  phase: 'LEAD',
+  verdict: 'PASS',
+  confidence: 87,
+  summary,
+  critical_issues: [],
+  warnings: detailedAnalysis.warnings,
+  recommendations: detailedAnalysis.mitigation_recommendations,
+  detailed_analysis: detailedAnalysis,
+  metadata: {
+    session_id: 'd694138f-de06-478a-b758-18e8c1d84445',
+    empirical_probes: {
+      probe_a_42703: 'CONFIRMED — column sd_phase_handoffs.sd_key does not exist',
+      probe_b_uuid_coercion: 'NEGATIVE — sd_id accepts SD-code strings, no 22P02 error',
+      probe_c_happy_path: 'CONFIRMED — .eq(sd_id, sd_code) returns accepted handoffs for known SD'
+    },
+    bmad_overall_risk: 'MEDIUM-LOW',
+    domain_scores: detailedAnalysis.domain_scores
+  }
+}).select('id, verdict, confidence, sub_agent_code, phase, sd_id');
+
+if (error) {
+  console.error('INSERT ERROR:', error);
+  process.exit(1);
+}
+console.log('EVIDENCE WRITTEN:', JSON.stringify(data, null, 2));

--- a/scripts/one-off/_validation-checks-2.mjs
+++ b/scripts/one-off/_validation-checks-2.mjs
@@ -1,0 +1,52 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+console.log('--- A. Introducer SD by sd_key only ---');
+const { data: intro } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, completed_at, created_at')
+  .eq('sd_key', 'SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001');
+console.log(JSON.stringify(intro || [], null, 2));
+
+console.log('\n--- B. Witness SD by sd_key only ---');
+const { data: wit } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, progress, completed_at, updated_at')
+  .eq('sd_key', 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001');
+console.log(JSON.stringify(wit || [], null, 2));
+
+console.log('\n--- C. Direct repro: assertSweepHandoffGate("SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD") ---');
+import('../../lib/exec-context-guard.mjs').then(async ({ assertSweepHandoffGate }) => {
+  try {
+    const result = await assertSweepHandoffGate(sb, 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001', 'LEAD');
+    console.log('Returned:', JSON.stringify(result));
+  } catch (e) {
+    console.log(`Threw: name=${e.name} code=${e.code} message=${e.message}`);
+  }
+}).catch(e => console.log('Import error:', e.message));
+
+await new Promise(r => setTimeout(r, 1000));
+
+console.log('\n--- D. Direct repro by UUID ---');
+import('../../lib/exec-context-guard.mjs').then(async ({ assertSweepHandoffGate }) => {
+  try {
+    const result = await assertSweepHandoffGate(sb, '2a017ba5-ad88-4746-b2a8-0a8016c13835', 'LEAD');
+    console.log('Returned:', JSON.stringify(result));
+  } catch (e) {
+    console.log(`Threw: name=${e.name} code=${e.code} message=${e.message}`);
+  }
+}).catch(e => console.log('Import error:', e.message));
+
+await new Promise(r => setTimeout(r, 1000));
+
+console.log('\n--- E. Quick_fixes table column probe ---');
+const { data: qf1, error: qf1Err } = await sb.from('quick_fixes').select('id, title, status, created_at').limit(3).order('created_at', { ascending: false });
+if (qf1Err) console.log('QF err:', qf1Err.message);
+else for (const q of (qf1||[])) console.log(`  ${q.id?.slice(0,8)} [${q.status}] ${q.title}`);
+
+console.log('\n--- F. QF search by title (no qf_key) ---');
+const { data: qf2 } = await sb.from('quick_fixes')
+  .select('id, title, status, created_at')
+  .or('title.ilike.%exec-context-guard%,title.ilike.%assertSweepHandoffGate%,title.ilike.%sd_phase_handoffs%,title.ilike.%sd_key%')
+  .order('created_at', { ascending: false });
+console.log(`QF body-matches: ${(qf2||[]).length}`);
+for (const q of (qf2||[])) console.log(`  ${q.id?.slice(0,8)} [${q.status}] ${q.title}`);

--- a/scripts/one-off/_validation-checks.mjs
+++ b/scripts/one-off/_validation-checks.mjs
@@ -1,0 +1,83 @@
+// One-off validation checks for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 LEAD validation-agent
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+console.log('--- 1. Probe sd_phase_handoffs for sd_key column ---');
+const { data: keyProbe, error: keyErr } = await sb.from('sd_phase_handoffs').select('sd_key').limit(1);
+console.log('sd_key probe:', keyErr ? `ERROR ${keyErr.code}: ${keyErr.message}` : `OK rows=${(keyProbe||[]).length}`);
+
+const { data: idProbe, error: idErr } = await sb.from('sd_phase_handoffs').select('sd_id').limit(1);
+console.log('sd_id probe:', idErr ? `ERROR: ${idErr.message}` : `OK rows=${(idProbe||[]).length}`);
+
+console.log('\n--- 2. Search SDs for prior fixes mentioning exec-context-guard or sd_key ---');
+const { data: sds, error: sdsErr } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, created_at')
+  .or('title.ilike.%exec-context-guard%,title.ilike.%assertSweepHandoffGate%,title.ilike.%sd_phase_handoffs.sd_key%')
+  .order('created_at', { ascending: false });
+if (sdsErr) console.log('SD search err:', sdsErr.message);
+console.log(`SD title-matches: ${(sds||[]).length}`);
+for (const s of (sds||[])) console.log(`  ${s.sd_key} [${s.status}/${s.current_phase}] ${s.title}`);
+
+console.log('\n--- 2b. SD scope / description search ---');
+const { data: sds2 } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, created_at')
+  .or('description.ilike.%assertSweepHandoffGate%,description.ilike.%sd_phase_handoffs.sd_key%,scope.ilike.%assertSweepHandoffGate%,scope.ilike.%sd_phase_handoffs.sd_key%')
+  .order('created_at', { ascending: false });
+console.log(`SD body-matches: ${(sds2||[]).length}`);
+for (const s of (sds2||[])) console.log(`  ${s.sd_key} [${s.status}/${s.current_phase}] ${s.title}`);
+
+console.log('\n--- 3. QF search ---');
+const { data: qfs, error: qfErr } = await sb.from('quick_fixes')
+  .select('id, qf_key, title, status, created_at')
+  .or('title.ilike.%exec-context-guard%,title.ilike.%assertSweepHandoffGate%,title.ilike.%sd_phase_handoffs%')
+  .order('created_at', { ascending: false });
+if (qfErr) console.log('QF err:', qfErr.message);
+console.log(`QF title-matches: ${(qfs||[]).length}`);
+for (const q of (qfs||[])) console.log(`  ${q.qf_key || q.id?.slice(0,8)} [${q.status}] ${q.title}`);
+
+console.log('\n--- 4. SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (introducer) ---');
+const { data: introSD } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, completed_at')
+  .or('sd_key.eq.SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001,id.eq.SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001');
+console.log(JSON.stringify(introSD || [], null, 2));
+
+console.log('\n--- 5. Witness SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 ---');
+const { data: witnessSD } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, progress, completed_at, updated_at')
+  .or('sd_key.eq.SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001,id.eq.2a017ba5-ad88-4746-b2a8-0a8016c13835');
+console.log(JSON.stringify(witnessSD || [], null, 2));
+
+console.log('\n--- 5b. Witness SD accepted handoffs (by sd_id UUID) ---');
+const { data: witnessHandoffs } = await sb.from('sd_phase_handoffs')
+  .select('id, from_phase, to_phase, status, created_at')
+  .eq('sd_id', '2a017ba5-ad88-4746-b2a8-0a8016c13835')
+  .order('created_at', { ascending: true });
+console.log(`Witness handoffs by sd_id UUID: ${(witnessHandoffs||[]).length}`);
+for (const h of (witnessHandoffs||[])) console.log(`  ${h.from_phase} -> ${h.to_phase} [${h.status}] @ ${h.created_at}`);
+
+console.log('\n--- 6. In-flight SDs touching stale-session-sweep or exec-context-guard ---');
+const { data: inflightSDs } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase')
+  .in('status', ['active', 'draft', 'planning'])
+  .or('description.ilike.%stale-session-sweep%,description.ilike.%exec-context-guard%,scope.ilike.%stale-session-sweep%,scope.ilike.%exec-context-guard%')
+  .order('created_at', { ascending: false });
+console.log(`In-flight overlapping SDs: ${(inflightSDs||[]).length}`);
+for (const s of (inflightSDs||[])) console.log(`  ${s.sd_key} [${s.status}/${s.current_phase}] ${s.title}`);
+
+console.log('\n--- 7. Target SD self-load ---');
+const { data: targetSD } = await sb.from('strategic_directives_v2')
+  .select('id, sd_key, title, status, current_phase, sd_type, priority, scope, description')
+  .eq('id', '38f4e8aa-0610-4f0d-a344-1b1968fef6b1');
+if (targetSD && targetSD[0]) {
+  const t = targetSD[0];
+  console.log(`Target: ${t.sd_key} [${t.status}/${t.current_phase}] type=${t.sd_type} prio=${t.priority}`);
+  console.log(`Title: ${t.title}`);
+  console.log(`Scope length: ${(t.scope||'').length}, Description length: ${(t.description||'').length}`);
+  console.log(`Scope (first 1200): ${(t.scope||'').slice(0,1200)}`);
+}
+
+console.log('\n--- 8. Most-recent commits referencing exec-context-guard ---');
+import { execSync } from 'child_process';
+const log = execSync('git log --all --oneline --since="2026-04-15" -- lib/exec-context-guard.mjs', { encoding: 'utf8' });
+console.log(log || '(no commits)');

--- a/scripts/one-off/_validation-evidence-write.mjs
+++ b/scripts/one-off/_validation-evidence-write.mjs
@@ -1,0 +1,14 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Inspect schema of sub_agent_execution_results once
+console.log('--- sub_agent_execution_results column probe ---');
+const { data: probe, error: probeErr } = await sb.from('sub_agent_execution_results').select('*').limit(1);
+if (probeErr) console.log('ERROR:', probeErr.message);
+else console.log('Columns:', Object.keys(probe?.[0] || {}).join(', '));
+
+// Find canonical sub_agent_code for VALIDATION
+console.log('\n--- leo_sub_agents codes ---');
+const { data: agents } = await sb.from('leo_sub_agents').select('code, name, active').or('code.ilike.%VALIDATION%,name.ilike.%Systems Analyst%,name.ilike.%Validation%');
+console.log(JSON.stringify(agents || [], null, 2));

--- a/scripts/one-off/_validation-write-evidence-row.mjs
+++ b/scripts/one-off/_validation-write-evidence-row.mjs
@@ -1,0 +1,140 @@
+// One-off: Write VALIDATION sub-agent evidence row for SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 LEAD phase
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SD_ID = '38f4e8aa-0610-4f0d-a344-1b1968fef6b1';
+const SD_KEY = 'SD-FDBK-ENH-CASCADE-TRIGGER-3627-001';
+
+const findings = {
+  // 1. Duplicate-implementation check
+  duplicate_check: {
+    sd_title_matches: [
+      { sd_key: 'SD-FDBK-ENH-CASCADE-TRIGGER-3627-001', status: 'draft/LEAD', verdict: 'this is the target SD itself' },
+      { sd_key: 'SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001', status: 'completed', verdict: 'INTRODUCER — completed in PR #3600 (commit c4f25e4023, 2026-05-08); shipped the bug at line 183. Not a duplicate fix; defines the file.' }
+    ],
+    sd_body_matches: [{ sd_key: SD_KEY, verdict: 'self-reference only' }],
+    qf_matches: 0,
+    git_log_lib_exec_context_guard_mjs: ['c4f25e4023 (initial introduction, contains the bug)'],
+    verdict: 'NO duplicate or prior fix exists. Target SD is the unique remediation. The file has had exactly one commit since introduction; no intervening patch addressed line 183.'
+  },
+
+  // 2. Overlapping in-flight SDs
+  overlapping_sd_check: {
+    in_flight_overlapping: [{ sd_key: SD_KEY, verdict: 'self only' }],
+    introducer_sd: { sd_key: 'SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001', status: 'completed', overlap_risk: 'NONE — already completed; no concurrent edits' },
+    witness_sd: { sd_key: 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001', uuid: '2a017ba5-ad88-4746-b2a8-0a8016c13835', overlap_risk: 'NONE — that SD touches lib/claim-lifecycle-release.mjs + ShippingExecutor + sd-start, not lib/exec-context-guard.mjs. The witness SD is a victim of this bug, not a touchpoint conflict.' },
+    verdict: 'No overlapping in-flight work. Code path lib/exec-context-guard.mjs:assertSweepHandoffGate is exclusively owned by this SD.'
+  },
+
+  // 3. Existing infrastructure leverage
+  infrastructure_leverage: {
+    isSweepResetAllowed_wrapper: 'REUSABLE AS-IS at scripts/stale-session-sweep.cjs:102. Wraps assertSweepHandoffGate try/catch, returns boolean. Three call sites (lines 155, 686, 742) all flow through it. Repair the inner query and all three gates light up at once — no wrapper changes needed.',
+    getExecContextGuard_lazy_import: 'REUSABLE AS-IS at scripts/stale-session-sweep.cjs:89. Dynamic import pattern preserves CJS-from-ESM compatibility. No changes needed.',
+    ExecContextError_class: 'REUSABLE AS-IS at lib/exec-context-guard.mjs:50. Carries .code field (ACCEPTED_HANDOFF_OVERRIDE) that isSweepResetAllowed already filters on at line 108. No changes needed.',
+    sibling_correct_pattern: 'PRECEDENT at scripts/stale-session-sweep.cjs:647-657 (QF-20260423-909). Uses .in("sd_id", [sd.id, sd.sd_key].filter(Boolean)) — the canonical pattern for "sd_phase_handoffs.sd_id stores BOTH uuid- and sd_key-style values". Recommend the repair adopt this same pattern.',
+    verdict: 'All scaffolding can be preserved. Surgical repair: replace the .or() clause inside assertSweepHandoffGate with .in("sd_id", [sdKey]) — single-row fix.'
+  },
+
+  // 4. Strategic alignment
+  strategic_alignment: {
+    sd_type: { value: 'bugfix', verdict: 'CORRECT. This is a defect repair (broken since c4f25e4023, 2026-05-08), not new functionality. The contract of assertSweepHandoffGate is unchanged; only the implementation is repaired.' },
+    priority: { value: 'high', verdict: 'JUSTIFIED. Silent corruption blast radius: 3 of 3 reset gates in stale-session-sweep.cjs (PHASE_RESET_MAP, STUCK_PENDING_APPROVAL line 686 — partially shadowed by inline QF-20260423-909, PHANTOM_IN_PROGRESS line 742) have been failing-open for 2+ days. Witness SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 was reset from PLAN-TO-LEAD-accepted state to draft/LEAD/0%, destroying 5 handoff records (3 accepted, 2 rejected). Any SD past LEAD with a phantom-released session is at risk. High priority is appropriate.' },
+    not_feature_or_infrastructure: 'CONFIRMED — restoring contracted behavior of an existing function in an existing module. No new abstractions, no schema migration, no new module.'
+  },
+
+  // 5. Scope coherence
+  scope_coherence: {
+    in_scope_validated: [
+      'lib/exec-context-guard.mjs:183 .or() clause repair — direct repro confirms bug',
+      'distinguish schema-class DB errors (fail-CLOSED) from transient errors (fail-OPEN preserved) — sound: schema errors are permanent and should not silently allow resets',
+      'regression test reproducing both sdKey and uuid input variants — addresses both code paths in the precedent pattern'
+    ],
+    out_of_scope_validated: [
+      'PR #3627 migration: VALIDATED INNOCENT. Source feedback c76f88ff misattributed cause. The four migration functions (create_or_replace_session, release_session, cleanup_stale_sessions, report_pid_validation_failure) only NULL active_session_id/claiming_session_id/is_working_on; none touches status/current_phase/progress.',
+      'PHASE_RESET_MAP / STUCK_PENDING_APPROVAL / PHANTOM_IN_PROGRESS reset paths in stale-session-sweep.cjs: VALIDATED. The resets themselves are intended behavior; the bug is solely that the broken guard was ALLOWING them when it should have blocked. Once the guard is repaired, the existing reset paths become correctly gated without modification.',
+      'QF-20260423-909 PLAN-TO-LEAD inline guard at sweep:647-666: VALIDATED. Already works correctly via .in() pattern; not a duplicate concern. Repair this SD ships the same pattern in the central guard, retiring the need for that inline shadow eventually (but that retirement is OUT-OF-SCOPE here).'
+    ],
+    verdict: 'Scope is tight, coherent, and correctly excludes innocent code paths.'
+  },
+
+  // 6. Pattern recurrence
+  pattern_recurrence: {
+    PAT_LEO_INFRA_WRITER_CONSUMER_ASYMMETRY_001: {
+      match: 'PARTIAL. The original pattern: writer-side migration drops/renames a column while reader-side queries still reference it. Here: the writer (db schema) NEVER had sd_phase_handoffs.sd_key — the consumer (assertSweepHandoffGate) referenced a column that never existed from day one of the introduced module. This is a closely related sub-pattern: assumed-column-without-verification.',
+      severity_distinction: 'Witness count for the canonical writer/consumer asymmetry pattern in MEMORY.md is now in the 13-16 witness range. This case extends the pattern: not just post-migration drift, but pre-migration phantom assumption. Recommend filing as PAT-LEO-INFRA-PHANTOM-COLUMN-ON-INTRODUCTION-001 sub-pattern OR appending to the umbrella pattern.',
+      prevention_suggestion: 'PRD should include a regression check that exercises the query against the live schema (the existing test stub in tests/unit/stale-sweep-handoff-override.test.* mocks supabase, so it could not have caught a real-schema 42703). The fix MUST add an integration-level test or a column existence assertion at module load.'
+    },
+    other_recurrence: {
+      fail_open_on_unrecognized_error_class: 'Recurring anti-pattern. Documented in this codebase via QF-20260509-988 (governance lexical classifier drift) and several other "treat all errors as transient" sites. Fail-open is correct for transient errors but wrong for schema/permission errors. Repair must distinguish on error.code (PostgREST 42703 for column missing, 42P01 for table missing — both schema-class and permanent).'
+    }
+  },
+
+  // 7. Direct repro evidence
+  direct_repro: {
+    invocation: 'assertSweepHandoffGate(supabase, "SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD")',
+    actual_result: '{ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"}',
+    expected_result: 'throw ExecContextError(ACCEPTED_HANDOFF_OVERRIDE) — witness has 5 handoffs (3 accepted past LEAD)',
+    verified_by: 'Bash node import 2026-05-10 inside this validation run',
+    sd_phase_handoffs_sd_key_probe: 'PostgrestError 42703: column sd_phase_handoffs.sd_key does not exist',
+    sd_phase_handoffs_sd_id_probe: 'OK — column exists',
+    witness_handoffs_count: 5,
+    witness_accepted_past_LEAD: 3
+  }
+};
+
+const recommendations = [
+  'PRD MUST adopt the .in("sd_id", [sdKey]) pattern from stale-session-sweep.cjs:647-657 (QF-20260423-909 precedent) — single source of truth for the "sd_id stores both uuid and sd_key" contract.',
+  'PRD MUST distinguish schema-class errors (PostgREST codes 42703 column-missing, 42P01 table-missing — fail-CLOSED, throw) from transient errors (network, 503, timeout — fail-OPEN preserved). The current single-bucket fail-open is the proximate cause of silent corruption.',
+  'PRD MUST include a regression test that exercises the query against the live schema (not just a mocked supabase). Either an integration test, or a module-load assertion that probes column existence and fails loudly. Mocked-supabase unit tests CANNOT catch this class of bug — that is exactly how it shipped.',
+  'EXEC SHOULD also add an explicit caller-side log in isSweepResetAllowed (stale-session-sweep.cjs:102) when the guard returns {ok:true, dbError} so future regressions emit a visible warning rather than silently allowing.',
+  'OPTIONAL post-fix audit: query strategic_directives_v2 for SDs whose status/current_phase regressed during the bug window (commit c4f25e4023 timestamp through fix landing). Any SD with handoff records past current_phase is a candidate for restoration. SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 is one confirmed case.'
+];
+
+const warnings = [
+  'The witness SD (SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001) was already restored manually in a prior session per memory project_sd_claim_lifecycle_release_001_completed_with_state_restoration.md. Do not double-restore. The post-fix audit (recommendation #5) should be additive — find OTHER victims, not re-touch this one.',
+  'Source feedback c76f88ff-2aeb-462e-8563-fe8c236902be misattributed cause to PR #3627. The PRD should explicitly capture this misattribution as part of the change-story so future readers do not reverse the (correct) OUT-OF-SCOPE call on the migration. The source feedback should be resolved with a pointer to this SD when shipped.',
+  'The two existing test files matching the pattern (tests/unit/stale-sweep-handoff-override.test.* — mentioned in stale-session-sweep.cjs comments) appear to use mocked supabase and so could not detect this real-schema bug. Treat as baseline pollution, not safety net. PRD should call this out so EXEC does not assume those tests provide regression coverage.'
+];
+
+const summary = `VALIDATION verdict: PASS (with warnings). Direct repro confirms the bug exactly as described: assertSweepHandoffGate(witnessSD, "LEAD") returns {ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"} despite witness having 3 accepted handoffs past LEAD. Bug shipped at commit c4f25e4023 (2026-05-08, PR #3600) and has been functionally absent since. No prior SD or QF addresses this; target SD is the unique remediation. SD type 'bugfix' and priority 'high' are correct given silent-corruption blast radius across all 3 sweep reset gates. IN-SCOPE / OUT-OF-SCOPE boundary is sharp and accurately exonerates PR #3627 and the intended sweep reset paths. Existing scaffolding (isSweepResetAllowed wrapper, getExecContextGuard lazy import, ExecContextError class) is reusable as-is — surgical fix targets only the .or() clause inside assertSweepHandoffGate, with adoption of the proven .in('sd_id', [sdKey]) precedent at stale-session-sweep.cjs:647 (QF-20260423-909). Recommendations focus on (1) reusing the precedent pattern, (2) fail-CLOSED on schema-class PostgREST errors (42703/42P01) while preserving fail-OPEN for transients, (3) regression test against live schema (mocked-supabase tests cannot catch this class of bug). Pattern recurrence: extends PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 to a phantom-column-on-introduction sub-pattern; the consumer assumed a column that never existed in the writer's schema.`;
+
+const detailedAnalysis = JSON.stringify(findings, null, 2);
+
+const row = {
+  sd_id: SD_ID,
+  sub_agent_code: 'VALIDATION',
+  sub_agent_name: 'Principal Systems Analyst',
+  phase: 'LEAD',
+  verdict: 'PASS',
+  confidence: 92,
+  summary,
+  critical_issues: [],
+  warnings,
+  recommendations,
+  detailed_analysis: detailedAnalysis,
+  validation_mode: 'prospective',
+  source: 'validation-agent',
+  metadata: {
+    sd_key: SD_KEY,
+    invoked_by: 'orchestrator-validation-agent-spawn',
+    session_id: 'd694138f-de06-478a-b758-18e8c1d84445',
+    model: 'claude-opus-4-7[1m]',
+    direct_repro_executed: true,
+    sd_phase_handoffs_schema_probed: true,
+    duplicate_search_executed: true,
+    overlap_search_executed: true,
+    introducer_sd: 'SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (commit c4f25e4023, PR #3600)',
+    witness_sd: 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 (uuid 2a017ba5-ad88-4746-b2a8-0a8016c13835)',
+    pattern_match: 'PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (phantom-column-on-introduction sub-pattern)'
+  }
+};
+
+console.log('--- Inserting validation evidence row ---');
+const { data, error } = await sb.from('sub_agent_execution_results').insert(row).select('id, sub_agent_code, phase, verdict, confidence');
+if (error) {
+  console.error('Insert error:', error.message, error.code);
+  console.error('Details:', JSON.stringify(error, null, 2));
+  process.exit(1);
+}
+console.log('Inserted:', JSON.stringify(data, null, 2));

--- a/tests/unit/exec-context-guard-handoff-gate-query-repair.test.js
+++ b/tests/unit/exec-context-guard-handoff-gate-query-repair.test.js
@@ -1,0 +1,259 @@
+/**
+ * SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 — FR-3 regression coverage.
+ *
+ * Pins the repaired `assertSweepHandoffGate` contract:
+ *   - sd_key input → resolves to UUID via strategic_directives_v2 lookup, then queries sd_id
+ *   - UUID input → bypasses resolver, queries sd_id directly
+ *   - SD lookup miss → throws SD_NOT_FOUND (fail-loud, NOT silent fail-open)
+ *   - Schema-class DB error (SQLSTATE 42703/42P01/42883) → throws SCHEMA_ERROR (fail-CLOSED)
+ *   - Transient DB error (e.g., timeout) → returns {ok:true, dbError} (fail-OPEN preserved)
+ *   - Unclassified DB error (no code) → fail-OPEN (default conservative)
+ *   - Handoffs past target → throws ACCEPTED_HANDOFF_OVERRIDE
+ *   - No handoffs past target → returns {ok:true}
+ *
+ * Stub-injected supabase client only — zero live DB.
+ *
+ * Witness regression: assertSweepHandoffGate("SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001", "LEAD")
+ * was returning {ok:true, dbError:"column sd_phase_handoffs.sd_key does not exist"} due to a
+ * non-existent column reference in the .or() clause. PR repairs the query and pins this here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  assertSweepHandoffGate,
+  ExecContextError,
+  SCHEMA_SQLSTATE_CODES,
+  PHASE_RANK,
+} from '../../lib/exec-context-guard.mjs';
+
+const WITNESS_SDKEY = 'SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001';
+const WITNESS_UUID = '2a017ba5-ad88-4746-b2a8-0a8016c13835';
+
+/**
+ * Minimal supabase client stub that records calls and returns
+ * configurable {data, error} per table.from(...) chain.
+ *
+ * Usage:
+ *   const stub = makeStub({
+ *     'strategic_directives_v2': { data: { id: '<uuid>' }, error: null },
+ *     'sd_phase_handoffs':       { data: [...], error: null },
+ *   });
+ *
+ * Each from(table) returns a chain that supports .select().eq().eq().maybeSingle()
+ * (lookup) and .select().eq().eq() awaited as the final call (handoff query).
+ */
+function makeStub(perTable) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      calls.push({ table });
+      const cfg = perTable[table];
+      if (!cfg) {
+        throw new Error(`makeStub: no config for table=${table}`);
+      }
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        or: () => builder,
+        maybeSingle: () => Promise.resolve({ data: cfg.data, error: cfg.error }),
+        // The handoff query awaits the chain directly (no .maybeSingle):
+        then: (resolve, reject) => Promise.resolve({ data: cfg.data, error: cfg.error }).then(resolve, reject),
+      };
+      return builder;
+    },
+  };
+}
+
+describe('SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-3: assertSweepHandoffGate query-repair regression', () => {
+  describe('Module-level exports (FR-1, FR-2)', () => {
+    it('exports PHASE_RANK with LEAD/PLAN/PLAN_PRD/EXEC ordering', () => {
+      expect(PHASE_RANK).toBeDefined();
+      expect(PHASE_RANK.LEAD).toBe(0);
+      expect(PHASE_RANK.PLAN).toBe(1);
+      expect(PHASE_RANK.PLAN_PRD).toBe(1);
+      expect(PHASE_RANK.EXEC).toBe(2);
+    });
+
+    it('exports SCHEMA_SQLSTATE_CODES set with PG codes 42703, 42P01, 42883', () => {
+      expect(SCHEMA_SQLSTATE_CODES).toBeDefined();
+      expect(SCHEMA_SQLSTATE_CODES.has('42703')).toBe(true);
+      expect(SCHEMA_SQLSTATE_CODES.has('42P01')).toBe(true);
+      expect(SCHEMA_SQLSTATE_CODES.has('42883')).toBe(true);
+      expect(SCHEMA_SQLSTATE_CODES.has('PGRST301')).toBe(false);
+    });
+  });
+
+  describe('FR-1: sd_key→UUID resolution path', () => {
+    it('throws ACCEPTED_HANDOFF_OVERRIDE when sd_key input has accepted handoffs past target', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': {
+          data: [
+            { id: '1', from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', created_at: '2026-05-09T23:55:58Z' },
+            { id: '2', from_phase: 'PLAN', to_phase: 'EXEC', status: 'accepted', created_at: '2026-05-10T00:15:21Z' },
+          ],
+          error: null,
+        },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'ACCEPTED_HANDOFF_OVERRIDE' });
+    });
+
+    it('throws SD_NOT_FOUND when sd_key lookup misses (fail-loud, NOT silent fail-open)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: null, error: null }, // maybeSingle returns null when no row
+        'sd_phase_handoffs': { data: [], error: null }, // unused but required by stub
+      });
+      await expect(assertSweepHandoffGate(stub, 'SD-DOES-NOT-EXIST-9999', 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'SD_NOT_FOUND' });
+    });
+
+    it('returns {ok:true} when sd_key resolves but no handoffs past target', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: [], error: null },
+      });
+      const result = await assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD');
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('FR-1: UUID input direct-query path (resolver bypassed)', () => {
+    it('throws ACCEPTED_HANDOFF_OVERRIDE when UUID input has accepted handoffs past target', async () => {
+      // Note: with UUID input, the strategic_directives_v2 lookup is skipped.
+      // Stub still needs an entry for it because makeStub validates table presence,
+      // but it should never be called.
+      const stub = makeStub({
+        'strategic_directives_v2': { data: null, error: null }, // sentinel — should not be reached
+        'sd_phase_handoffs': {
+          data: [{ id: '1', from_phase: 'PLAN', to_phase: 'EXEC', status: 'accepted', created_at: '2026-05-10T00:15:21Z' }],
+          error: null,
+        },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_UUID, 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'ACCEPTED_HANDOFF_OVERRIDE' });
+
+      // Verify the resolver was NOT consulted for UUID input
+      const sdLookupCalls = stub.calls.filter(c => c.table === 'strategic_directives_v2');
+      expect(sdLookupCalls).toHaveLength(0);
+    });
+
+    it('returns {ok:true} on UUID input with no handoffs past target', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: null, error: null },
+        'sd_phase_handoffs': { data: [], error: null },
+      });
+      const result = await assertSweepHandoffGate(stub, WITNESS_UUID, 'LEAD');
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('FR-2: schema-class errors → fail-CLOSED (throws SCHEMA_ERROR)', () => {
+    let consoleErrorSpy;
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    it('throws SCHEMA_ERROR on PG SQLSTATE 42703 (column does not exist) at handoff query', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { code: '42703', message: 'column sd_phase_handoffs.X does not exist' } },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'SCHEMA_ERROR' });
+    });
+
+    it('throws SCHEMA_ERROR on PG SQLSTATE 42P01 (relation does not exist)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { code: '42P01', message: 'relation X does not exist' } },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'SCHEMA_ERROR' });
+    });
+
+    it('throws SCHEMA_ERROR on PG SQLSTATE 42883 (function does not exist)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { code: '42883', message: 'function X does not exist' } },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'SCHEMA_ERROR' });
+    });
+
+    it('FR-5: emits structured stderr log line on SCHEMA_ERROR fail-CLOSED', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { code: '42703', message: 'column does not exist' } },
+      });
+      try {
+        await assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD');
+      } catch (e) {
+        // expected throw
+      }
+      const logged = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(logged).toMatch(/\[exec-context-guard\] SCHEMA_ERROR/);
+      expect(logged).toMatch(`sd_key=${WITNESS_SDKEY}`);
+      expect(logged).toMatch('target=LEAD');
+      expect(logged).toMatch('sqlstate=42703');
+      expect(logged).toMatch('hint=');
+    });
+
+    it('throws SCHEMA_ERROR when SD lookup itself returns 42703', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: null, error: { code: '42703', message: 'column sd_key does not exist' } },
+        'sd_phase_handoffs': { data: [], error: null }, // unused
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD'))
+        .rejects.toMatchObject({
+          name: 'ExecContextError',
+          code: 'SCHEMA_ERROR',
+          details: expect.objectContaining({ step: 'sd_lookup' }),
+        });
+    });
+  });
+
+  describe('FR-2: transient errors → fail-OPEN preserved', () => {
+    it('returns {ok:true,dbError} on PostgREST timeout-class error (PGRST301)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { code: 'PGRST301', message: 'timeout' } },
+      });
+      const result = await assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD');
+      expect(result).toEqual({ ok: true, dbError: 'timeout' });
+    });
+
+    it('returns {ok:true,dbError} on unclassified error (code undefined → conservative fail-OPEN)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': { data: null, error: { message: 'unknown', code: undefined } },
+      });
+      const result = await assertSweepHandoffGate(stub, WITNESS_SDKEY, 'LEAD');
+      expect(result).toEqual({ ok: true, dbError: 'unknown' });
+    });
+  });
+
+  describe('Existing contract preservation (regression check)', () => {
+    it('throws on unknown targetResetPhase (caller bug)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: null, error: null },
+        'sd_phase_handoffs': { data: [], error: null },
+      });
+      await expect(assertSweepHandoffGate(stub, WITNESS_UUID, 'NONSENSE_PHASE'))
+        .rejects.toMatchObject({ name: 'ExecContextError', code: 'ACCEPTED_HANDOFF_OVERRIDE' });
+    });
+
+    it('returns {ok:true} when target=EXEC and only LEAD-TO-PLAN handoff exists (PLAN < EXEC)', async () => {
+      const stub = makeStub({
+        'strategic_directives_v2': { data: { id: WITNESS_UUID }, error: null },
+        'sd_phase_handoffs': {
+          data: [{ id: '1', from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', created_at: '2026-05-09T23:55:58Z' }],
+          error: null,
+        },
+      });
+      const result = await assertSweepHandoffGate(stub, WITNESS_SDKEY, 'EXEC');
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/tests/unit/lib/exec-context-guard.test.js
+++ b/tests/unit/lib/exec-context-guard.test.js
@@ -37,19 +37,41 @@ const {
 } = await import('../../../lib/exec-context-guard.mjs');
 
 /**
- * Build a Supabase chain stub returning the supplied handoffs for the
- * .from('sd_phase_handoffs').select(...).or(...).eq(...) chain that
- * assertSweepHandoffGate uses.
+ * Build a Supabase chain stub for assertSweepHandoffGate.
+ *
+ * After SD-FDBK-ENH-CASCADE-TRIGGER-3627-001 FR-1 the function uses two table
+ * paths:
+ *   1. strategic_directives_v2 .select('id').eq('sd_key', X).maybeSingle()
+ *      — sd_key→UUID resolver (called when input is not UUID-format).
+ *   2. sd_phase_handoffs .select(...).eq('sd_id', X).eq('status', 'accepted')
+ *      — accepted-handoffs query.
+ *
+ * The stub dispatches by table. Default sd_key→UUID resolves to a fixed UUID
+ * so callers passing 'SD-XXX-001' transparently route to the handoff query.
  */
-function makeSupabaseStub(handoffs, error = null) {
+function makeSupabaseStub(handoffs, error = null, opts = {}) {
+  const sdRow = opts.sdRow !== undefined ? opts.sdRow : { id: '00000000-0000-0000-0000-000000000001' };
+  const sdLookupErr = opts.sdLookupErr !== undefined ? opts.sdLookupErr : null;
   return {
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        or: vi.fn(() => ({
-          eq: vi.fn(() => Promise.resolve({ data: handoffs, error })),
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(() => Promise.resolve({ data: sdRow, error: sdLookupErr })),
+            })),
+          })),
+        };
+      }
+      // sd_phase_handoffs
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ data: handoffs, error })),
+          })),
         })),
-      })),
-    })),
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Repairs `lib/exec-context-guard.mjs::assertSweepHandoffGate` — the `.or()` clause referenced the non-existent column `sd_phase_handoffs.sd_key`, causing PostgrestError 42703 → fail-open `{ok:true,dbError}` → all sweep reset paths bypassed the guard since deployment (commit `c4f25e4023`, 2026-05-08).
- Adds schema-class error classifier (PG SQLSTATE 42703/42P01/42883 → fail-CLOSED) so future schema drift is loudly surfaced; transient fail-OPEN preserved.
- Adds vitest stub-injection regression (16 cases), structured stderr log on fail-CLOSED, and FR-4 fleet pre-merge audit script (2 latent victims surfaced across 1000 active SDs).

## Witness regression (now fixed)
`SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001` was reset to `draft/LEAD/0%` on 2026-05-10 despite 3 accepted handoffs in `sd_phase_handoffs`. Live invocation now throws `ExecContextError(ACCEPTED_HANDOFF_OVERRIDE)` as intended.

PR #3627's migration is innocent — its 4 functions only clear claim columns. Source feedback `c76f88ff` misattributed the cause.

## Test plan
- [x] `npx vitest run tests/unit/exec-context-guard tests/unit/lib/exec-context-guard` — 51/51 pass
- [x] `npx vitest run lib/eva tests/unit/stale-session` — 410/410 pass (zero regression)
- [x] Live integration smoke against witness SD — throws `ACCEPTED_HANDOFF_OVERRIDE`
- [x] FR-4 fleet audit runs cleanly, output saved to `docs/audits/<sd-key>-latent-victims.tsv`

## Sub-agent evidence
- LEAD validation-agent `f8dbf7c6` PASS conf=92
- LEAD risk-agent `3e62f9bf` PASS MEDIUM-LOW conf=87
- EXEC testing-agent `3d7f84fb` PASS conf=95
- EXEC database-agent `a1251030` PASS conf=92

## Gate scores
- LEAD-TO-PLAN: 96%
- PLAN-TO-EXEC: 94%
- EXEC-TO-PLAN: 96%
- PLAN-TO-LEAD: 97%
- Retrospective quality: 100

Closes feedback `c76f88ff-2aeb-462e-8563-fe8c236902be`. 17th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 sub-pattern (column-name drift on introduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)