### PR TITLE
feat(SD-FDBK-INFRA-ADD-PRD-DATABASE-001): close add-prd-to-database INLINE-mode Catch-22

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -46,9 +46,77 @@ export {
 } from './prd/prd-creator.js';
 
 // CLI entry point - delegate to modular index
+import fs from 'node:fs';
 import { addPRDToDatabase } from './prd/index.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 import { startHeartbeat, stopHeartbeat } from '../lib/heartbeat-manager.mjs';
+
+// SD-FDBK-INFRA-ADD-PRD-DATABASE-001: --content flag closes the INLINE-mode Catch-22.
+// 2MB cap prevents parse-bomb / memory-exhaustion on file or stdin input (R4 mitigation).
+const CONTENT_PAYLOAD_MAX_BYTES = 2 * 1024 * 1024;
+
+function readStdinSync() {
+  return fs.readFileSync(0, { encoding: 'utf8' });
+}
+
+export function loadContentPayload(rawValue) {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    throw new Error('--content requires a value (file path with @ prefix, "-" for stdin, or literal JSON)');
+  }
+  let raw;
+  if (rawValue === '-') {
+    raw = readStdinSync();
+  } else if (rawValue.startsWith('@')) {
+    const filePath = rawValue.slice(1);
+    if (!filePath) throw new Error('--content @<path>: empty file path');
+    if (!fs.existsSync(filePath)) {
+      const err = new Error(`--content @${filePath}: file not found`);
+      err.code = 'CONTENT_FILE_NOT_FOUND';
+      throw err;
+    }
+    const stat = fs.statSync(filePath);
+    if (stat.size > CONTENT_PAYLOAD_MAX_BYTES) {
+      throw new Error(`--content @${filePath}: PAYLOAD_TOO_LARGE (${stat.size} bytes > ${CONTENT_PAYLOAD_MAX_BYTES} cap)`);
+    }
+    raw = fs.readFileSync(filePath, 'utf8');
+  } else {
+    raw = rawValue;
+  }
+  if (Buffer.byteLength(raw, 'utf8') > CONTENT_PAYLOAD_MAX_BYTES) {
+    throw new Error(`--content: PAYLOAD_TOO_LARGE (${Buffer.byteLength(raw, 'utf8')} bytes > ${CONTENT_PAYLOAD_MAX_BYTES} cap)`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const err = new Error(`--content: INVALID_JSON (${e.message})`);
+    err.code = 'CONTENT_INVALID_JSON';
+    throw err;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('--content: payload must be a JSON object (got ' + (Array.isArray(parsed) ? 'array' : typeof parsed) + ')');
+  }
+  return parsed;
+}
+
+export function extractContentArg(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--content') {
+      const value = args[i + 1];
+      const remaining = [...args.slice(0, i), ...args.slice(i + 2)];
+      return { value, remaining };
+    }
+    if (a.startsWith('--content=')) {
+      const value = a.slice('--content='.length);
+      const remaining = [...args.slice(0, i), ...args.slice(i + 1)];
+      return { value, remaining };
+    }
+  }
+  return { value: undefined, remaining: args };
+}
+
+export { CONTENT_PAYLOAD_MAX_BYTES };
 
 if (isMainModule(import.meta.url)) {
   // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
@@ -61,11 +129,29 @@ if (isMainModule(import.meta.url)) {
     startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
   }
 
-  const args = process.argv.slice(2);
-  if (args.length < 1) {
-    console.log('Usage: node scripts/add-prd-to-database.js <SD-ID> [PRD-Title]');
+  const argv = process.argv.slice(2);
+  if (argv.length < 1) {
+    console.log('Usage: node scripts/add-prd-to-database.js <SD-ID> [PRD-Title] [--content @path | --content - | --content \'<json>\']');
     console.log('Example: node scripts/add-prd-to-database.js SD-DASHBOARD-AUDIT-2025-08-31-A "Dashboard Audit PRD"');
+    console.log('Example: node scripts/add-prd-to-database.js SD-XXX-001 --content @./my-prd.json');
+    console.log('Example: cat prd.json | node scripts/add-prd-to-database.js SD-XXX-001 --content -');
     process.exit(1);
+  }
+
+  // SD-FDBK-INFRA-ADD-PRD-DATABASE-001: parse --content BEFORE addPRDToDatabase()
+  // so the INLINE-branch process.exit(0) at scripts/prd/index.js:540 is never reached
+  // (IR2 critical: gate-route at CLI argv-parse).
+  const { value: contentValue, remaining: args } = extractContentArg(argv);
+
+  let contentOverride = null;
+  if (contentValue !== undefined) {
+    try {
+      contentOverride = loadContentPayload(contentValue);
+    } catch (e) {
+      console.error(`\n❌ ${e.message}`);
+      if (heartbeatActive) stopHeartbeat();
+      process.exit(1);
+    }
   }
 
   const sdId = args[0];
@@ -76,7 +162,7 @@ if (isMainModule(import.meta.url)) {
   // (exit 143) — even though the PRD + user-story rows already landed in the DB.
   // Cooperative mode means stopHeartbeat does NOT release the parent session's
   // claim; only the in-process timer is cleared.
-  addPRDToDatabase(sdId, prdTitle).finally(() => {
+  addPRDToDatabase(sdId, prdTitle, contentOverride).finally(() => {
     if (heartbeatActive) stopHeartbeat();
   });
 }

--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -68,8 +68,12 @@ dotenv.config();
  * Main PRD creation function
  * @param {string} sdId - Strategic Directive ID
  * @param {string} prdTitle - Optional PRD title
+ * @param {Object|null} contentOverride - Optional pre-generated PRD JSON content (SD-FDBK-INFRA-ADD-PRD-DATABASE-001).
+ *                                        When provided, LLM generation is SKIPPED but grounding + quality
+ *                                        validation gates still run, and metadata.created_via='content_arg'
+ *                                        is injected for audit-trail provenance.
  */
-export async function addPRDToDatabase(sdId, prdTitle) {
+export async function addPRDToDatabase(sdId, prdTitle, contentOverride = null) {
   console.log(`Adding PRD for ${sdId} to database...\n`);
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -154,13 +158,15 @@ export async function addPRDToDatabase(sdId, prdTitle) {
 
     // Generate and validate LLM content BEFORE creating PRD
     // SD-LEO-INFRA-CONTEXT-AWARE-LLM-001C: "Generate first, then insert" pattern
+    // SD-FDBK-INFRA-ADD-PRD-DATABASE-001: contentOverride bypasses LLM generation
+    // but still runs validatePRDGrounding + validatePRDQuality (R6 governance).
     const llmContent = await generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, {
       designAnalysis,
       databaseAnalysis,
       securityAnalysis,
       riskAnalysis,
       stakeholderPersonas
-    });
+    }, contentOverride);
 
     // Attach integration contract to LLM content metadata (FR-1)
     if (integrationContract) {
@@ -453,7 +459,7 @@ async function handlePersonaIngestion(sdData, sdId) {
  *
  * @returns {Object} Validated LLM content ready for PRD insertion
  */
-async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, analyses) {
+async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, analyses, contentOverride = null) {
   console.log('\n='.repeat(55));
   console.log('PHASE 3: LLM-BASED PRD CONTENT GENERATION');
   console.log('='.repeat(55));
@@ -465,11 +471,24 @@ async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, 
       console.log(`   Found ${existingStories.length} existing user stories for consistency`);
     }
 
-    const llmPrdContent = await generatePRDContentWithLLM(sdData, {
-      ...analyses,
-      personas: analyses.stakeholderPersonas,
-      existingStories
-    });
+    // SD-FDBK-INFRA-ADD-PRD-DATABASE-001: --content path skips LLM call, but
+    // still runs validatePRDGrounding + validatePRDQuality (R6) and tags
+    // metadata.created_via='content_arg' (R3 audit-trail integrity).
+    let llmPrdContent;
+    if (contentOverride) {
+      console.log('\n   📥 CONTENT OVERRIDE: using pre-generated PRD JSON (LLM skipped)');
+      llmPrdContent = contentOverride;
+      llmPrdContent.metadata = {
+        ...(llmPrdContent.metadata || {}),
+        created_via: 'content_arg'
+      };
+    } else {
+      llmPrdContent = await generatePRDContentWithLLM(sdData, {
+        ...analyses,
+        personas: analyses.stakeholderPersonas,
+        existingStories
+      });
+    }
 
     if (!llmPrdContent) {
       // Check if inline mode is active — null return is expected
@@ -564,6 +583,40 @@ async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, 
     }
 
     console.log(`   ✅ Grounding validation passed (${(groundingResults.average_confidence * 100).toFixed(0)}% average confidence)`);
+
+    // SD-FDBK-INFRA-ADD-PRD-DATABASE-001: --content path runs validatePRDQuality
+    // explicitly (R6 governance). LLM-generated content already passes through
+    // the per-story Russian-judge quality scorer downstream, but hand-authored
+    // JSON skips that path — so we run the rubric validator here on the whole
+    // payload to surface quality scores before insertion.
+    if (contentOverride) {
+      console.log('\n   🔍 Running PRD quality validation (--content path)...');
+      const qualityResult = validatePRDQuality(llmPrdContent);
+      const qualityMode = resolveEnforcementMode();
+      console.log(`   [prd-quality] score=${qualityResult.score} threshold=${qualityResult.threshold} passed=${qualityResult.passed} mode=${qualityMode}`);
+      if (!qualityResult.passed && qualityMode === 'block') {
+        console.error(`\n   ❌ PRD QUALITY GATE FAILED: score=${qualityResult.score} threshold=${qualityResult.threshold}`);
+        for (const dim of qualityResult.breakdown || []) {
+          if (dim.reasons?.length) {
+            console.error(`      - ${dim.dimension} (${dim.score}/10): ${dim.reasons.join('; ')}`);
+          }
+        }
+        process.exit(1);
+      } else if (!qualityResult.passed) {
+        console.warn(`   ⚠️  PRD quality warning (warn-only): score=${qualityResult.score} threshold=${qualityResult.threshold}`);
+      } else {
+        console.log(`   ✅ Quality validation passed`);
+      }
+      llmPrdContent.metadata = {
+        ...(llmPrdContent.metadata || {}),
+        content_quality: {
+          score: qualityResult.score,
+          threshold: qualityResult.threshold,
+          passed: qualityResult.passed,
+          mode: qualityMode
+        }
+      };
+    }
 
     // Attach grounding validation results to metadata for the PRD record
     llmPrdContent.metadata = {

--- a/tests/integration/add-prd-content-arg-cli.test.js
+++ b/tests/integration/add-prd-content-arg-cli.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-FDBK-INFRA-ADD-PRD-DATABASE-001
+ * CLI subprocess smoke tests for add-prd-to-database.js --content flag.
+ *
+ * Runs the actual binary via spawnSync. Tests cover surface that is
+ * isolated from the database (help, validation errors). Full happy-path
+ * AC coverage lives in the unit tests; the static guard pins the wire-in
+ * to scripts/prd/index.js.
+ *
+ * NOTE: For tests that need a real subprocess but no DB, we test only the
+ * pre-DB validation path (file-not-found, oversized, bad JSON). The script
+ * exits before any Supabase call.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'add-prd-to-database.js');
+
+function runCli(args, opts = {}) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 30000,
+    cwd: REPO_ROOT,
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    ...opts
+  });
+}
+
+describe('add-prd-to-database.js --content CLI', () => {
+  it('AC-2: help message includes --content usage when no args given', () => {
+    const r = runCli([]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/--content/);
+    expect(r.stdout).toMatch(/@path/);
+    expect(r.stdout).toMatch(/cat prd\.json/);
+  });
+
+  it('AC-4: --content @<missing-path> exits non-zero with file-not-found', () => {
+    const missing = path.join(os.tmpdir(), `nonexistent-prd-${Date.now()}.json`);
+    const r = runCli(['SD-FAKE-FOR-CLI-TEST', '--content', '@' + missing]);
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/file not found/);
+  });
+
+  it('AC-7: --content with malformed JSON exits non-zero with INVALID_JSON', () => {
+    const r = runCli(['SD-FAKE-FOR-CLI-TEST', '--content', '{not: valid}']);
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/INVALID_JSON/);
+  });
+
+  it('AC-7: --content with array (non-object) exits non-zero', () => {
+    const r = runCli(['SD-FAKE-FOR-CLI-TEST', '--content', '[1,2,3]']);
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/must be a JSON object/);
+  });
+
+  it('AC-4: --content @<oversized-file> exits non-zero with PAYLOAD_TOO_LARGE', () => {
+    const big = path.join(os.tmpdir(), `big-prd-${Date.now()}.json`);
+    fs.writeFileSync(big, JSON.stringify({ blob: 'x'.repeat(2 * 1024 * 1024 + 100) }), 'utf8');
+    try {
+      const r = runCli(['SD-FAKE-FOR-CLI-TEST', '--content', '@' + big]);
+      expect(r.status).toBe(1);
+      expect(r.stderr + r.stdout).toMatch(/PAYLOAD_TOO_LARGE/);
+    } finally {
+      try { fs.unlinkSync(big); } catch { /* ignore */ }
+    }
+  });
+
+  it('--content with empty value (--content=) exits non-zero', () => {
+    const r = runCli(['SD-FAKE-FOR-CLI-TEST', '--content=']);
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/--content requires a value/);
+  });
+});

--- a/tests/unit/add-prd-content-arg-parser.test.js
+++ b/tests/unit/add-prd-content-arg-parser.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-FDBK-INFRA-ADD-PRD-DATABASE-001
+ * Unit tests for the --content argument parser + payload loader.
+ *
+ * No subprocess spawn, no DB calls — purely testing the helper functions
+ * exported by scripts/add-prd-to-database.js. Covers AC-1 (flag recognition),
+ * AC-3 (file path mode), AC-4 (missing file error), AC-5 (stdin via mocked
+ * fs.readFileSync(0)), AC-6/AC-7 (validation errors), and the 2MB payload cap.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  extractContentArg,
+  loadContentPayload,
+  CONTENT_PAYLOAD_MAX_BYTES
+} from '../../scripts/add-prd-to-database.js';
+
+describe('extractContentArg', () => {
+  it('returns undefined value when --content is absent (AC-8 backward compat)', () => {
+    const r = extractContentArg(['SD-XXX-001', 'My Title']);
+    expect(r.value).toBeUndefined();
+    expect(r.remaining).toEqual(['SD-XXX-001', 'My Title']);
+  });
+
+  it('extracts --content <value> form (AC-1)', () => {
+    const r = extractContentArg(['SD-XXX-001', '--content', '@./prd.json']);
+    expect(r.value).toBe('@./prd.json');
+    expect(r.remaining).toEqual(['SD-XXX-001']);
+  });
+
+  it('extracts --content=<value> form', () => {
+    const r = extractContentArg(['SD-XXX-001', '--content=-']);
+    expect(r.value).toBe('-');
+    expect(r.remaining).toEqual(['SD-XXX-001']);
+  });
+
+  it('preserves positional args around --content', () => {
+    const r = extractContentArg(['SD-XXX-001', 'Title', '--content', '@x.json', '--other']);
+    expect(r.value).toBe('@x.json');
+    expect(r.remaining).toEqual(['SD-XXX-001', 'Title', '--other']);
+  });
+});
+
+describe('loadContentPayload', () => {
+  let tmpFile;
+
+  afterEach(() => {
+    if (tmpFile && fs.existsSync(tmpFile)) {
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    }
+    tmpFile = null;
+    vi.restoreAllMocks();
+  });
+
+  it('parses literal JSON object (AC-1)', () => {
+    const payload = JSON.stringify({ executive_summary: 'x'.repeat(60), functional_requirements: [{ title: 'FR-1' }] });
+    const out = loadContentPayload(payload);
+    expect(out.executive_summary.length).toBe(60);
+    expect(out.functional_requirements).toHaveLength(1);
+  });
+
+  it('reads file via @<path> (AC-3)', () => {
+    tmpFile = path.join(os.tmpdir(), `prd-test-${Date.now()}.json`);
+    const obj = { executive_summary: 'y'.repeat(60), functional_requirements: [{ title: 'A' }] };
+    fs.writeFileSync(tmpFile, JSON.stringify(obj), 'utf8');
+    const out = loadContentPayload('@' + tmpFile);
+    expect(out.executive_summary).toBe(obj.executive_summary);
+  });
+
+  it('throws CONTENT_FILE_NOT_FOUND for missing path (AC-4)', () => {
+    expect(() => loadContentPayload('@/nonexistent/path-' + Date.now() + '.json'))
+      .toThrow(/file not found/);
+  });
+
+  it('throws CONTENT_INVALID_JSON for malformed JSON (AC-7)', () => {
+    expect(() => loadContentPayload('{not: json}'))
+      .toThrow(/INVALID_JSON/);
+  });
+
+  it('rejects non-object JSON (array / scalar) (AC-7)', () => {
+    expect(() => loadContentPayload('[1,2,3]')).toThrow(/must be a JSON object/);
+    expect(() => loadContentPayload('42')).toThrow(/must be a JSON object/);
+  });
+
+  it('rejects empty value', () => {
+    expect(() => loadContentPayload('')).toThrow(/--content requires a value/);
+    expect(() => loadContentPayload(undefined)).toThrow(/--content requires a value/);
+  });
+
+  it('reads stdin via "-" (AC-5)', () => {
+    const obj = { executive_summary: 's'.repeat(60), functional_requirements: [{ title: 'B' }] };
+    const original = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation((target, opts) => {
+      if (target === 0) return JSON.stringify(obj);
+      return original.call(fs, target, opts);
+    });
+    const out = loadContentPayload('-');
+    expect(out.executive_summary).toBe(obj.executive_summary);
+  });
+
+  it('rejects oversized literal payload (PAYLOAD_TOO_LARGE)', () => {
+    const big = JSON.stringify({ blob: 'x'.repeat(CONTENT_PAYLOAD_MAX_BYTES + 100) });
+    expect(() => loadContentPayload(big)).toThrow(/PAYLOAD_TOO_LARGE/);
+  });
+
+  it('rejects oversized file payload (PAYLOAD_TOO_LARGE)', () => {
+    tmpFile = path.join(os.tmpdir(), `prd-big-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ blob: 'x'.repeat(CONTENT_PAYLOAD_MAX_BYTES + 100) }), 'utf8');
+    expect(() => loadContentPayload('@' + tmpFile)).toThrow(/PAYLOAD_TOO_LARGE/);
+  });
+
+  it('rejects empty file path (@)', () => {
+    expect(() => loadContentPayload('@')).toThrow(/empty file path/);
+  });
+});

--- a/tests/unit/add-prd-content-arg-static-guard.test.js
+++ b/tests/unit/add-prd-content-arg-static-guard.test.js
@@ -1,0 +1,103 @@
+/**
+ * SD-FDBK-INFRA-ADD-PRD-DATABASE-001
+ * Static guard regression-pin for the --content flag wiring.
+ *
+ * fs.readFileSync + regex on source files (mocking-independent). Asserts that
+ * the canonical PRD generation pipeline retains the safety wires that close
+ * the original INLINE-mode Catch-22:
+ *   - --content flag is parsed in the CLI entry
+ *   - createPRDWithValidatedContent is the insertion helper
+ *   - validatePRDGrounding + validatePRDQuality run on the --content path
+ *   - metadata.created_via='content_arg' literal is set for audit-trail provenance
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function readSource(rel) {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+}
+
+describe('SD-FDBK-INFRA-ADD-PRD-DATABASE-001: --content flag static guard', () => {
+  describe('scripts/add-prd-to-database.js', () => {
+    const src = readSource('scripts/add-prd-to-database.js');
+
+    it('exports extractContentArg parser', () => {
+      expect(src).toMatch(/export\s+(?:function\s+)?extractContentArg/);
+    });
+
+    it('exports loadContentPayload helper', () => {
+      expect(src).toMatch(/export\s+(?:function\s+)?loadContentPayload/);
+    });
+
+    it('declares 2MB payload cap', () => {
+      expect(src).toMatch(/CONTENT_PAYLOAD_MAX_BYTES\s*=\s*2\s*\*\s*1024\s*\*\s*1024/);
+    });
+
+    it('rejects oversized payloads (PAYLOAD_TOO_LARGE)', () => {
+      expect(src).toMatch(/PAYLOAD_TOO_LARGE/);
+    });
+
+    it('handles file path mode (@<path>)', () => {
+      expect(src).toMatch(/rawValue\.startsWith\(['"]@['"]\)/);
+    });
+
+    it('handles stdin mode (-)', () => {
+      expect(src).toMatch(/rawValue\s*===\s*['"]-['"]/);
+    });
+
+    it('passes contentOverride to addPRDToDatabase', () => {
+      expect(src).toMatch(/addPRDToDatabase\s*\(\s*sdId\s*,\s*prdTitle\s*,\s*contentOverride\s*\)/);
+    });
+
+    it('parses --content BEFORE addPRDToDatabase invocation (gate-route at argv parse)', () => {
+      const extractIdx = src.search(/extractContentArg\s*\(\s*argv\s*\)/);
+      const callIdx = src.search(/addPRDToDatabase\s*\(\s*sdId\s*,/);
+      expect(extractIdx).toBeGreaterThan(0);
+      expect(callIdx).toBeGreaterThan(0);
+      expect(extractIdx).toBeLessThan(callIdx);
+    });
+  });
+
+  describe('scripts/prd/index.js', () => {
+    const src = readSource('scripts/prd/index.js');
+
+    it('addPRDToDatabase signature accepts contentOverride param', () => {
+      expect(src).toMatch(/export\s+async\s+function\s+addPRDToDatabase\s*\([^)]*contentOverride[^)]*\)/);
+    });
+
+    it('threads contentOverride into generateAndValidatePRDContent', () => {
+      // Looser regex tolerates whitespace/newlines and line breaks between args.
+      expect(src).toMatch(/generateAndValidatePRDContent\s*\(/);
+      expect(src).toMatch(/\}\s*,\s*contentOverride\s*\)/);
+    });
+
+    it('invokes validatePRDGrounding (always, on every path)', () => {
+      expect(src).toMatch(/\bvalidatePRDGrounding\s*\(/);
+    });
+
+    it('invokes validatePRDQuality on --content path', () => {
+      expect(src).toMatch(/\bvalidatePRDQuality\s*\(/);
+    });
+
+    it('sets metadata.created_via=content_arg on --content path', () => {
+      expect(src).toMatch(/created_via\s*:\s*['"]content_arg['"]/);
+    });
+
+    it('skips LLM call when contentOverride is provided', () => {
+      // The override branch must short-circuit before generatePRDContentWithLLM.
+      const overrideMarker = src.indexOf('CONTENT OVERRIDE');
+      expect(overrideMarker).toBeGreaterThan(-1);
+      // The if-branch must reference contentOverride and assign llmPrdContent without await on the LLM.
+      expect(src).toMatch(/if\s*\(\s*contentOverride\s*\)\s*\{[^}]*llmPrdContent\s*=\s*contentOverride/);
+    });
+
+    it('insertion still routes through createPRDWithValidatedContent', () => {
+      expect(src).toMatch(/\bcreatePRDWithValidatedContent\s*\(/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--content @file.json | - | <literal>` flag to `scripts/add-prd-to-database.js`, closing the INLINE-mode Catch-22 that produced **15+ `prd_creation_source_missing` audit events in the prior 30 days** (latest 2026-05-10T17:43Z, just hours before this PR). When `--content` is set, LLM generation is SKIPPED but `validatePRDGrounding` + `validatePRDQuality` still run, and `metadata.created_via='content_arg'` is injected for audit-trail provenance.

The Catch-22: `scripts/prd/index.js:474-540` instructs Claude Code to insert PRD manually; the only canonical helper (`createPRDWithValidatedContent`) was sandbox-blocked from one-off scripts. The `--content` flag sidesteps the hook entirely without needing a hook whitelist or `LLM_PRD_INLINE=false` default change.

## Implementation

- **`scripts/add-prd-to-database.js`** (+82 src LOC): `extractContentArg()` + `loadContentPayload()` exported; supports `@path`, `-` (stdin), and literal JSON; 2MB payload cap (R4); error codes (`CONTENT_FILE_NOT_FOUND`, `CONTENT_INVALID_JSON`, `PAYLOAD_TOO_LARGE`); routes BEFORE `addPRDToDatabase()` to avoid the `process.exit(0)` trap at index.js:540 (IR2).
- **`scripts/prd/index.js`** (+57 src LOC): `addPRDToDatabase(sdId, prdTitle, contentOverride=null)` signature; `generateAndValidatePRDContent` skips LLM when `contentOverride` set, runs `validatePRDQuality` (R6), injects `metadata.created_via='content_arg'` (R3).
- **3 new test files** (+301 test LOC, 35 tests, 100% PASS):
  - `tests/unit/add-prd-content-arg-static-guard.test.js` (14 tests, fs.readFileSync + regex, mocking-independent)
  - `tests/unit/add-prd-content-arg-parser.test.js` (14 unit tests)
  - `tests/integration/add-prd-content-arg-cli.test.js` (6 subprocess CLI tests)

## Q8 deletions held

- ❌ Hook whitelist for one-off scripts (option b) — `--content` sidesteps the hook
- ❌ `LLM_PRD_INLINE=false` default change (option c) — additive flag is backward-compatible

## Sub-agent evidence (8 rows)

| Phase | Agent | Verdict | Confidence |
|---|---|---|---|
| LEAD | validation | PASS | 92 |
| LEAD | risk | PASS | 86 |
| PLAN | validation | PASS | 84 |
| PLAN | risk | PASS | 88 |
| PLAN | testing | PASS | 88 |
| EXEC | testing | CONDITIONAL_PASS | 92 |
| EXEC | validation | PASS | 92 |
| EXEC | risk | PASS | 89 |

## Handoff scores

LEAD-TO-PLAN 93% → PLAN-TO-EXEC 97% → EXEC-TO-PLAN 92% → PLAN-TO-LEAD 97%. Zero `--bypass-validation` used.

## Tests

- 35/35 new tests PASS
- 51/51 directly-related PRD tests PASS (no regressions)
- Pre-existing baseline failures (virality.test.js, prd-enrichment.test.js) confirmed UNCHANGED via stash-bisect

## Test plan

- [x] `npx vitest run tests/unit/add-prd-content-arg-*.test.js tests/integration/add-prd-content-arg-cli.test.js` — 35 PASS
- [x] `npx vitest run tests/unit/prd-creator-prevalidation.test.js tests/unit/prd-quality-validator.test.js` — 16 PASS
- [x] Stash bisect to confirm baseline failures pre-existing
- [x] LLM-driven PRD creation works first try (this SD's own PRD created via `LLM_PRD_INLINE=false` + Google Gemini 2.5-pro)
- [ ] Post-deploy: 30-day audit_log query tracking `metadata.created_via=content_arg` vs `MISSING` ratio (success criterion: prd_creation_source_missing drops from 15+/30d to ~0)

## Follow-up

1 non-blocking SD recommended (per risk-agent EXEC retrospective 2e799bdf): skip `designAnalysis`/`databaseAnalysis`/`securityAnalysis`/`riskAnalysis` sub-agent runs when `contentOverride` is provided (IR3 cost optimization, ~20-40 LOC, Tier 2).

Closes feedback cb21bb9a-881c-4983-858d-191e140f7cc8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)