### PR TITLE
fix(SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001): cadence-vocab discriminator for unlock_gate advisory states

### DIFF
--- a/lib/cadence/pre-claim-gate.mjs
+++ b/lib/cadence/pre-claim-gate.mjs
@@ -8,10 +8,31 @@
  * SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001
  *
  * SOURCE PRECEDENCE
+ *   0. metadata.unlock_gate (typed event-based gate; SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001)
+ *      When metadata.unlock_gate is a non-null object with string .type, and
+ *      .type is NOT in CADENCE_REFUSAL_TYPES (the explicit allowlist of
+ *      time-based refusal-eligible types), the gate short-circuits and
+ *      returns source='unlock_gate_advisory' with active=false. The
+ *      governance_metadata.next_workable_after timestamp is preserved on
+ *      gate_until as advisory metadata, NOT as a refusal anchor. Closes 19th-
+ *      candidate witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 where
+ *      writers used next_workable_after for two semantics (PR-cadence stability
+ *      window vs unlock_gate advisory milestone) and consumers treated them
+ *      identically.
  *   1. governance_metadata.next_workable_after  (explicit ISO timestamp; wins)
  *   2. metadata.pr_cadence_minimum_days + last session_log entry
  *      (derived: lastActivity + minimumDays)
  *   3. Neither set → {active: false, source: 'none'} — opt-in by metadata presence
+ *
+ * UNLOCK_GATE VOCABULARY
+ *   metadata.unlock_gate.type values observed in production (as of 2026-05-10):
+ *     - 'usage_signal'   — chairman/operator usage-frequency trigger (advisory)
+ *     - 'value_proof'    — phase-N-ships-and-proves-value trigger (advisory)
+ *     - 'pr_cadence'     — explicit time-based PR cadence (refusal-eligible)
+ *     - 'time_window'    — explicit time-window stability (refusal-eligible)
+ *   When .type is one of the advisory values (or any value NOT in
+ *   CADENCE_REFUSAL_TYPES), the cadence gate yields. Refusal-eligible types
+ *   continue to fall through to Source 1/2 logic.
  *
  * SESSION_LOG NOTE
  *   session_log is the JSONB array at
@@ -25,12 +46,25 @@
 const MS_PER_DAY = 86400000;
 
 /**
+ * Allowlist of metadata.unlock_gate.type values that are refusal-eligible
+ * (i.e., when one of these types is present, the cadence gate falls through to
+ * the time-based refusal logic instead of yielding via the advisory path).
+ *
+ * Frozen Set for O(1) membership lookup and to prevent runtime mutation.
+ * Pattern mirrors lib/sd-type-enum.js CANONICAL_SD_TYPES (precedent from
+ * SD-FDBK-INFRA-TYPE-SOURCE-TRUTH-001).
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const CADENCE_REFUSAL_TYPES = Object.freeze(new Set(['pr_cadence', 'time_window']));
+
+/**
  * @typedef {Object} GateState
  * @property {boolean} active                Gate is currently in effect (claim should be refused)
  * @property {string|null} gate_until        ISO timestamp when gate expires (null when source='none')
  * @property {number|null} days_remaining    Whole days remaining (ceil); null when not active
  * @property {string} reason                 Operator-readable reason text
- * @property {'next_workable_after'|'derived_from_session_log'|'none'} source
+ * @property {'unlock_gate_advisory'|'next_workable_after'|'derived_from_session_log'|'none'} source
  */
 
 /**
@@ -47,6 +81,24 @@ export function computeGateState({ governance_metadata, metadata, session_log, n
   const nowMs = typeof now === 'number' ? now : Date.now();
   const gm = governance_metadata || {};
   const md = metadata || {};
+
+  // Source 0: metadata.unlock_gate vocabulary discriminator
+  // When unlock_gate.type is present and NOT in the refusal-eligible allowlist,
+  // the gate yields with source='unlock_gate_advisory'. The next_workable_after
+  // timestamp (if any) is preserved on gate_until as advisory metadata.
+  // SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001
+  const unlockGate = md.unlock_gate;
+  if (unlockGate && typeof unlockGate === 'object' && typeof unlockGate.type === 'string') {
+    if (!CADENCE_REFUSAL_TYPES.has(unlockGate.type)) {
+      return {
+        active: false,
+        gate_until: typeof gm.next_workable_after === 'string' ? gm.next_workable_after : null,
+        days_remaining: null,
+        reason: `unlock_gate.type='${unlockGate.type}' is event-based (advisory). Cadence gate yields; surface as informational, not blocking.`,
+        source: 'unlock_gate_advisory',
+      };
+    }
+  }
 
   // Source 1: explicit next_workable_after ISO timestamp
   if (gm.next_workable_after) {

--- a/scripts/modules/handoff/child-sd-selector.js
+++ b/scripts/modules/handoff/child-sd-selector.js
@@ -78,11 +78,20 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
     // past the same window that direct sd-start would refuse.
     // (Closes feedback row f52246de — orchestrator preflight router bypassed
     // the cadence gate from PR #3353 / SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001.)
+    //
+    // SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001: branch on state.source so
+    // unlock_gate_advisory (event-based gate types like 'usage_signal' /
+    // 'value_proof') is surfaced informationally rather than filtered out.
     const cadenceCleared = unblocked.filter(child => {
       const state = computeGateState({
         governance_metadata: child.governance_metadata,
         metadata: child.metadata,
       });
+      if (state.source === 'unlock_gate_advisory') {
+        const gateTypeStr = child.metadata?.unlock_gate?.type || 'unknown';
+        console.log(`   [child-sd-selector] ${child.sd_key || child.id} unlock_gate=${gateTypeStr} (informational — does not affect verdict)`);
+        return true;
+      }
       if (state.active) {
         console.log(`   [child-sd-selector] Skipping ${child.sd_key || child.id} - cadence gate active (${state.days_remaining}d until ${state.gate_until})`);
         return false;

--- a/scripts/modules/sd-next/status-helpers.js
+++ b/scripts/modules/sd-next/status-helpers.js
@@ -107,6 +107,11 @@ export function getPhaseAwareStatus(item) {
  * Returns empty string when no gate is active (no badge rendered).
  * SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001
  *
+ * SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001: source='unlock_gate_advisory'
+ * returns empty string (no blocking badge rendered). Advisory states are
+ * surfaced via separate informational helpers, not as a CADENCE-WAIT badge,
+ * since they do not block claim acquisition.
+ *
  * @param {Object} item - SD item with governance_metadata + metadata
  * @returns {string} Colored badge string (with leading space) or empty string
  */
@@ -115,6 +120,7 @@ export function getCadenceBadge(item) {
     governance_metadata: item?.governance_metadata,
     metadata: item?.metadata,
   });
+  if (gateState.source === 'unlock_gate_advisory') return '';
   if (!gateState.active) return '';
   const dayWord = gateState.days_remaining === 1 ? 'day' : 'days';
   return ` ${colors.magenta}[CADENCE-WAIT ${gateState.days_remaining} ${dayWord}]${colors.reset}`;
@@ -123,6 +129,11 @@ export function getCadenceBadge(item) {
 /**
  * Get cadence-wait reason text for inline display under an SD entry.
  * Returns empty string when no gate active.
+ *
+ * SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001: returns empty for
+ * source='unlock_gate_advisory' — the advisory reason is informational and
+ * surfaced via different rendering paths, not via this hard-block helper.
+ *
  * @param {Object} item
  * @returns {string}
  */
@@ -131,6 +142,7 @@ export function getCadenceReason(item) {
     governance_metadata: item?.governance_metadata,
     metadata: item?.metadata,
   });
+  if (gateState.source === 'unlock_gate_advisory') return '';
   if (!gateState.active) return '';
   return gateState.reason;
 }

--- a/scripts/one-off/_prd-content-cadence-vocab-discriminator-001.json
+++ b/scripts/one-off/_prd-content-cadence-vocab-discriminator-001.json
@@ -1,0 +1,239 @@
+{
+  "title": "PRD: Cadence-vocab discriminator for lib/cadence/pre-claim-gate.mjs",
+  "executive_summary": "lib/cadence/pre-claim-gate.mjs:46-80 currently treats governance_metadata.next_workable_after as a hard PR-cadence refusal whenever the timestamp is in the future. This misclassifies SDs that populate next_workable_after as advisory milestones alongside metadata.unlock_gate.type='usage_signal' or 'value_proof' (event-based unlock semantics). Two child SDs (SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B and -C) are stuck in DRAFT/LEAD because the cadence gate, child-sd-selector, status-helpers, and sd-start refuse claims. This PRD adds an explicit allowlist of refusal-eligible unlock_gate.type values (pr_cadence, time_window) and routes all other event-based types through a non-blocking source='unlock_gate_advisory' path. Consumers branch on state.source to log informationally rather than skip. Backward compatibility preserved for the no-unlock_gate path (existing PR-cadence semantics unchanged). Closes 19th-candidate witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (cadence-vocab variant).",
+
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "lib/cadence/pre-claim-gate.mjs computeGateState must inspect metadata.unlock_gate before falling through to next_workable_after / pr_cadence_minimum_days. When metadata.unlock_gate is a non-null object with a string .type field NOT present in the exported CADENCE_REFUSAL_TYPES allowlist (default ['pr_cadence', 'time_window']), the function must early-return GateState shape { active: false, gate_until: governance_metadata.next_workable_after || null, days_remaining: null, reason: <descriptive>, source: 'unlock_gate_advisory' } regardless of the next_workable_after timestamp.",
+      "acceptance_criteria": [
+        "Vitest case: computeGateState with metadata.unlock_gate.type='usage_signal' and governance_metadata.next_workable_after set 5 years in the future returns active=false, source='unlock_gate_advisory'",
+        "Vitest case: computeGateState with metadata.unlock_gate.type='value_proof' returns active=false, source='unlock_gate_advisory'",
+        "Vitest case: computeGateState with metadata.unlock_gate.type='pr_cadence' AND next_workable_after in future falls through to existing logic and returns active=true, source='next_workable_after'",
+        "Vitest case: computeGateState with no metadata.unlock_gate AND next_workable_after in future preserves existing behavior (active=true, source='next_workable_after')"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "CADENCE_REFUSAL_TYPES must be an exported, Object.frozen Set literal in lib/cadence/pre-claim-gate.mjs. Default membership: ['pr_cadence', 'time_window']. Mirrors the freeze pattern used in lib/sd-type-enum.js CANONICAL_SD_TYPES. The Set is consulted by both producers (e.g. future writers wanting to assert refusal-eligibility) and consumers via computeGateState.",
+      "acceptance_criteria": [
+        "import { CADENCE_REFUSAL_TYPES } from 'lib/cadence/pre-claim-gate.mjs' succeeds",
+        "CADENCE_REFUSAL_TYPES instanceof Set === true and CADENCE_REFUSAL_TYPES.size === 2",
+        "CADENCE_REFUSAL_TYPES.add('foo') throws TypeError (Object.frozen Set)",
+        "Static-pin regex test asserts the literal new Set(['pr_cadence', 'time_window']) string appears in the source within the computeGateState helper region"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "scripts/modules/handoff/child-sd-selector.js lines 81-91 cadenceCleared filter must branch on state.source. When source==='unlock_gate_advisory' the child must NOT be filtered out — the function logs an informational message including '(informational — does not affect verdict)' (canonical phrase from child-sd-preflight.js) and returns true to retain the child in the candidate set. When state.active is true and source !== 'unlock_gate_advisory', existing skip behavior is preserved.",
+      "acceptance_criteria": [
+        "Vitest case asserting a child with metadata.unlock_gate.type='usage_signal' is NOT filtered out by cadenceCleared",
+        "Vitest case asserting a child with metadata.unlock_gate absent but next_workable_after in future IS filtered out (existing behavior preserved)",
+        "Console output for advisory case contains the literal substring '(informational — does not affect verdict)'"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "requirement": "scripts/modules/sd-next/status-helpers.js getCadenceBadge and getCadenceReason must return empty string (no badge / no reason text) when computeGateState returns source='unlock_gate_advisory'. The existing CADENCE-WAIT magenta badge MUST NOT render for advisory states. Function signatures and return types unchanged for the non-advisory paths.",
+      "acceptance_criteria": [
+        "Vitest case: getCadenceBadge with metadata.unlock_gate.type='value_proof' returns '' (empty string)",
+        "Vitest case: getCadenceReason with metadata.unlock_gate.type='usage_signal' returns '' (empty string)",
+        "Vitest case: existing CADENCE-WAIT badge still renders when no unlock_gate present"
+      ]
+    },
+    {
+      "id": "FR-5",
+      "requirement": "scripts/sd-start.js cadence refusal point (current location ~line 470, invokes computeGateState + formatRefusalMessage) must mirror the new source-aware behavior. When state.active is false (including the new advisory path), no refusal is emitted. When state.active is true and state.source !== 'unlock_gate_advisory', the existing refusal flow is preserved including CADENCE_GATE_REFUSED audit-log row. No audit-log row is written for the advisory path (avoids misleading telemetry per validation-agent warning #4).",
+      "acceptance_criteria": [
+        "Static-pin regex test asserts scripts/sd-start.js cadence-refusal block reads state.source",
+        "No CADENCE_GATE_REFUSED audit-log row is inserted when source='unlock_gate_advisory'",
+        "Existing CADENCE_GATE_REFUSED audit-log behavior preserved for true cadence refusals"
+      ]
+    },
+    {
+      "id": "FR-6",
+      "requirement": "formatRefusalMessage in lib/cadence/pre-claim-gate.mjs must include the source value in the formatted output so operators can distinguish unlock_gate_advisory from PR-cadence refusals. Existing 'source:' line must surface the new value verbatim.",
+      "acceptance_criteria": [
+        "Vitest case: formatRefusalMessage with gateState.source='unlock_gate_advisory' produces output containing the substring 'source:     unlock_gate_advisory'",
+        "Existing tests for source='next_workable_after' and source='derived_from_session_log' continue to pass"
+      ]
+    }
+  ],
+
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "requirement": "Implementation must be backward-compatible: all callers passing only governance_metadata or only metadata.pr_cadence_minimum_days continue to receive identical GateState shape (no new required fields). New source value 'unlock_gate_advisory' is additive to the GateState.source enum.",
+      "verification": "Run scripts/modules/handoff/__tests__/ + tests/unit/cadence/ + tests/unit/sd-next/ — full regression must pass without breakage."
+    },
+    {
+      "id": "TR-2",
+      "requirement": "CADENCE_REFUSAL_TYPES must be a frozen Set (not array) for O(1) membership lookup. Use Object.freeze(new Set([...])) idiom matching lib/sd-type-enum.js CANONICAL_SD_TYPES export pattern (precedent from SD-FDBK-INFRA-TYPE-SOURCE-TRUTH-001).",
+      "verification": "Direct mutation attempt (CADENCE_REFUSAL_TYPES.add) throws TypeError; type-check via typeof CADENCE_REFUSAL_TYPES === 'object' && CADENCE_REFUSAL_TYPES instanceof Set."
+    },
+    {
+      "id": "TR-3",
+      "requirement": "Static-pin regression-guard test pattern: tests use fs.readFileSync + regex on a scoped helper region (NOT full file content) to avoid false-matches with JSDoc comments or unrelated code. Scope via const helperRegion = src.slice(src.indexOf('export function computeGateState'), src.indexOf('function buildGateState')) per SD-FDBK-INFRA-ORCHESTRATOR-ROUTING-PHASE-001 lesson learned (avoids `grandchildren.length > 0` false-matches).",
+      "verification": "Code review of pin test files confirms scoped slice extraction; tests pass when correct literal is present; tests fail when literal is mutated."
+    },
+    {
+      "id": "TR-4",
+      "requirement": "Module load assertion at test-import time validates: (a) CADENCE_REFUSAL_TYPES is exported, frozen, Set; (b) computeGateState function exists; (c) formatRefusalMessage function exists. Throws fail-loud with descriptive error if any assertion fails. Pattern: precedent from SD-LEO-INFRA-WORKTREE-CLEANUP-WINDOWS-001.",
+      "verification": "Test file's top-level import block contains assertion calls; intentional removal of exports triggers test-time fail-loud."
+    },
+    {
+      "id": "TR-5",
+      "requirement": "Pre-merge DB audit query must be run during EXEC phase to enumerate existing metadata.unlock_gate.type values. Query: SELECT DISTINCT metadata->'unlock_gate'->>'type' AS t, COUNT(*) FROM strategic_directives_v2 WHERE metadata ? 'unlock_gate' GROUP BY 1. Results documented in EXEC commit message + sub_agent_execution_results metadata. Expected at PRD-time: 2 distinct values (value_proof, usage_signal). If new unknown values surface mid-EXEC, evaluate whether to extend CADENCE_REFUSAL_TYPES OR document as additional advisory types.",
+      "verification": "EXEC commit includes audit query output. If audit surfaces unknown type values, sub_agent_execution_results for testing-exec contains explicit acknowledgment of disposition."
+    }
+  ],
+
+  "acceptance_criteria": [
+    "AC-1: All 4 modified source files (lib/cadence/pre-claim-gate.mjs, scripts/modules/handoff/child-sd-selector.js, scripts/modules/sd-next/status-helpers.js, scripts/sd-start.js) pass linting + their module-load assertions at test-import time",
+    "AC-2: Vitest run on tests/unit/cadence/ + new pin tests achieves 100% pass with at minimum 8 NEW test cases (4 computeGateState scenarios + 2 consumer scenarios + 2 formatRefusalMessage scenarios) and 0 regressions in pre-existing handoff/sd-next test suites",
+    "AC-3: Live smoke validation post-merge — npm run sd:next no longer shows CADENCE-WAIT N day(s) badge for SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B and -C. node scripts/sd-start.js --child SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B is no longer refused with cadence-gate message.",
+    "AC-4: PR opened against rickfelix/EHG_Engineer with title 'fix(SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001): cadence-vocab discriminator for unlock_gate advisory states' and body containing 'Closes feedback 41f703dc-8196-4278-95f1-4b1dab36cf28' + 'Closes (witness) PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 19th candidate (cadence-vocab variant)'",
+    "AC-5: Retrospective generated post-merge with quality_score >=70, learning_category not in ['APPLICATION_ISSUE' without affected_components], retrospective_type IS NULL (gate filter invariant)"
+  ],
+
+  "system_architecture": {
+    "overview": "Single-helper-and-consumers fix in EHG_Engineer harness internals. The architecture is unchanged at the macro level: producers continue to author governance_metadata.next_workable_after and metadata.unlock_gate, consumers (child-sd-selector, status-helpers, sd-start) continue to call computeGateState({governance_metadata, metadata}). The new logic is internal to computeGateState: an early-return branch that fires when metadata.unlock_gate is present and unlock_gate.type is not in the CADENCE_REFUSAL_TYPES allowlist. All consumers are updated to recognize the new state.source value ('unlock_gate_advisory') and surface it informationally rather than block.",
+    "components": [
+      "lib/cadence/pre-claim-gate.mjs — single source-of-truth for cadence gate state. Adds: CADENCE_REFUSAL_TYPES (frozen Set), updated computeGateState with unlock_gate discriminator branch, updated formatRefusalMessage to surface source value",
+      "scripts/modules/handoff/child-sd-selector.js — orchestrator preflight router. Updates lines 81-91 cadenceCleared filter to branch on state.source",
+      "scripts/modules/sd-next/status-helpers.js — sd:next dashboard renderer. Updates getCadenceBadge + getCadenceReason to suppress badge for advisory states",
+      "scripts/sd-start.js — SD claim entry point. Updates cadence-refusal block ~line 470 to skip refusal when source='unlock_gate_advisory'",
+      "tests/unit/cadence/pre-claim-gate-discriminator.test.mjs — NEW vitest file with 4 computeGateState scenarios + 2 formatRefusalMessage scenarios",
+      "tests/unit/handoff/child-sd-selector-unlock-gate.test.mjs — NEW vitest file with 2 consumer scenarios",
+      "tests/unit/cadence/pre-claim-gate-static-guard.test.mjs — NEW static-pin regression test (fs.readFileSync + scoped regex)"
+    ],
+    "data_flow": "1) SD-author writes metadata.unlock_gate = {type, trigger, measured_via} alongside (optional) governance_metadata.next_workable_after milestone. 2) Caller invokes computeGateState({governance_metadata, metadata}). 3) computeGateState inspects metadata.unlock_gate FIRST — if present with type NOT in CADENCE_REFUSAL_TYPES, early-returns {active:false, source:'unlock_gate_advisory', gate_until:next_workable_after||null, days_remaining:null}. 4) If unlock_gate absent OR type in allowlist, falls through to existing next_workable_after + pr_cadence_minimum_days logic. 5) Consumers (child-sd-selector, status-helpers, sd-start) inspect both state.active AND state.source to decide whether to skip, render badge, or refuse claim.",
+    "integration_points": [
+      "Producers: leo-create-sd.js / one-off SD authors writing metadata.unlock_gate.type",
+      "Consumers: scripts/modules/handoff/child-sd-selector.js (cadenceCleared filter), scripts/modules/sd-next/status-helpers.js (getCadenceBadge, getCadenceReason), scripts/sd-start.js (cadence refusal point ~line 470), and any future caller of computeGateState",
+      "Audit logging: scripts/sd-start.js CADENCE_GATE_REFUSED audit-log row insertion (suppressed for advisory states per FR-5)",
+      "DB schema: strategic_directives_v2.metadata.unlock_gate JSONB structure (unchanged); strategic_directives_v2.governance_metadata.next_workable_after (unchanged); no migrations"
+    ]
+  },
+
+  "implementation_approach": {
+    "phases": [
+      "Phase 1 (~10 min): Pre-merge DB audit. Run SELECT DISTINCT metadata->'unlock_gate'->>'type' query. Document result in EXEC commit body.",
+      "Phase 2 (~30 min): lib/cadence/pre-claim-gate.mjs — add CADENCE_REFUSAL_TYPES export + unlock_gate discriminator branch in computeGateState + update formatRefusalMessage. Write JSDoc explaining the vocabulary semantics.",
+      "Phase 3 (~20 min): Update 3 consumers (child-sd-selector lines 81-91, status-helpers getCadenceBadge+getCadenceReason, sd-start cadence-refusal block). Each consumer branches on state.source.",
+      "Phase 4 (~30 min): Write 3 vitest test files (computeGateState scenarios, consumer scenarios, static-pin guard). Use fs.readFileSync + scoped slice pattern.",
+      "Phase 5 (~10 min): Run npx vitest, fix any regressions. Commit with structured message."
+    ],
+    "tools": "vitest (existing test runner); supabase-js (DB audit query); git worktree (feat/SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001); pgrep/process-aware sd-start.js",
+    "branch_strategy": "Single feature branch feat/SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001 created by scripts/sd-start.js. All edits within one worktree. Single PR to origin/main."
+  },
+
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "computeGateState with metadata.unlock_gate.type='usage_signal' and governance_metadata.next_workable_after='2030-01-01T00:00:00Z' returns {active:false, source:'unlock_gate_advisory', gate_until:'2030-01-01T00:00:00Z', days_remaining:null}",
+      "test_type": "unit",
+      "expected_result": "Returned GateState object matches the assertion. days_remaining MUST be null (NOT a positive integer)."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "computeGateState with metadata.unlock_gate.type='value_proof' returns identical advisory shape as TS-1 — both event-based types follow the same advisory path",
+      "test_type": "unit",
+      "expected_result": "active=false, source='unlock_gate_advisory'"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Backward-compat: computeGateState with NO metadata.unlock_gate + future next_workable_after returns existing shape (active:true, source:'next_workable_after', positive days_remaining)",
+      "test_type": "regression",
+      "expected_result": "Existing behavior preserved exactly — no source field drift, no days_remaining computation change."
+    },
+    {
+      "id": "TS-4",
+      "scenario": "Refusal-eligible: computeGateState with metadata.unlock_gate.type='pr_cadence' falls through to next_workable_after logic and returns active:true when timestamp is future-dated",
+      "test_type": "unit",
+      "expected_result": "active=true, source='next_workable_after' — unlock_gate is present but allowlist match preserves refusal"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "Consumer: child-sd-selector.js cadenceCleared filter retains child with metadata.unlock_gate.type='usage_signal' (does NOT filter out)",
+      "test_type": "integration",
+      "expected_result": "filter result includes the child; console output contains '(informational — does not affect verdict)'"
+    },
+    {
+      "id": "TS-6",
+      "scenario": "Consumer: getCadenceBadge returns empty string for advisory-source GateState (no magenta CADENCE-WAIT badge rendered)",
+      "test_type": "unit",
+      "expected_result": "Empty string return value; existing badge rendering for non-advisory source preserved"
+    },
+    {
+      "id": "TS-7",
+      "scenario": "Static-pin guard: file content of lib/cadence/pre-claim-gate.mjs contains the literal CADENCE_REFUSAL_TYPES = new Set(['pr_cadence', 'time_window']) within the helper region between 'export function computeGateState' and 'function buildGateState'",
+      "test_type": "static_guard",
+      "expected_result": "fs.readFileSync + regex match succeeds within scoped slice; full-file regex (without slicing) would be too permissive and risk JSDoc false-matches"
+    },
+    {
+      "id": "TS-8",
+      "scenario": "Module-load assertion: importing lib/cadence/pre-claim-gate.mjs and asserting CADENCE_REFUSAL_TYPES instanceof Set + Object.isFrozen(CADENCE_REFUSAL_TYPES) returns true",
+      "test_type": "unit",
+      "expected_result": "Both assertions pass; intentional removal of Object.freeze in mutated source triggers test failure"
+    },
+    {
+      "id": "TS-9",
+      "scenario": "Smoke: post-merge npm run sd:next no longer renders [CADENCE-WAIT 1 day] or [CADENCE-WAIT 114 days] badges for SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / -C respectively",
+      "test_type": "smoke",
+      "expected_result": "Track B display shows the children without blocking cadence badges; SDs appear claimable per /leo next ranking"
+    }
+  ],
+
+  "risks": [
+    {
+      "id": "R-1",
+      "risk": "Backward incompatibility: existing SDs may have authored metadata.unlock_gate.type values not enumerated in CADENCE_REFUSAL_TYPES. Switching the default to non-blocking could allow claims that prior versions would have refused.",
+      "mitigation": "Pre-merge DB audit (TR-5) enumerates current values. At PRD-time only 2 types observed: value_proof, usage_signal — both intentionally non-blocking. The allowlist (pr_cadence, time_window) is explicit and narrow. JSDoc on computeGateState documents the contract.",
+      "rollback_plan": "Revert PR. The change is additive only (new exported Set, new branch in one function); no schema changes, no DB writes. Reverting restores pre-change behavior identically.",
+      "severity": "medium",
+      "likelihood": "low"
+    },
+    {
+      "id": "R-2",
+      "risk": "Consumer test breakage: existing tests in tests/unit/handoff/ or tests/unit/sd-next/ may assert active=true on next_workable_after presence with mock metadata that accidentally includes a non-allowlist unlock_gate type.",
+      "mitigation": "TR-3 scoped static-pin pattern + R-TEST-1 mitigation from risk-agent: gate the new early-return on metadata.unlock_gate PRESENCE (typeof object check). Tests not setting metadata.unlock_gate are unaffected. Run full lib/eva regression to catch any breakage.",
+      "rollback_plan": "If regression tests reveal breakage, expand CADENCE_REFUSAL_TYPES to include the surprising type values OR refine the early-return predicate to require a stricter unlock_gate shape (.type must be string, must be in known-types Set).",
+      "severity": "medium",
+      "likelihood": "low"
+    },
+    {
+      "id": "R-3",
+      "risk": "Phantom-compliance: static-pin guard regex could match JSDoc comment text containing the literal 'CADENCE_REFUSAL_TYPES = new Set' rather than the actual implementation, causing false-pass on a mutated source file.",
+      "mitigation": "TR-3 + R-PHANTOM-1 mitigation from risk-agent: scope regex to slice between explicit function anchors (between /export function computeGateState/ and next /^function buildGateState/ or /^export/). Document the slicing in the test file. Mutation-test: intentionally remove the literal from source and confirm test fails.",
+      "rollback_plan": "If false-pass discovered, expand slice anchors to include both the Set literal AND the early-return branch using state.source assignment. Pin tests are cheap to refine.",
+      "severity": "low",
+      "likelihood": "low"
+    },
+    {
+      "id": "R-4",
+      "risk": "Audit-log telemetry pollution: scripts/sd-start.js CADENCE_GATE_REFUSED row could be inserted for advisory-path encounters, misclassifying advisory states as refusals in downstream analytics.",
+      "mitigation": "FR-5 + validation-agent warning #4: gate audit-log insertion on source !== 'unlock_gate_advisory'. Add explicit check + comment at the audit-log call site. Vitest can mock the audit-log insert and assert 0 calls for advisory states.",
+      "rollback_plan": "If audit-log pollution detected post-merge, run DELETE FROM audit_log WHERE category='CADENCE_GATE_REFUSED' AND created_at>=<PR-merge-time> AND sd_key IN (advisory SDs). Patch the audit-log call site with the missing guard.",
+      "severity": "low",
+      "likelihood": "low"
+    }
+  ],
+
+  "out_of_scope": [
+    "P2 ghost-completion partial-revert (atomic-revert helper + DB invariant) — separate feedback 0a06a05a-3c52-41ba-9c5e-d62582d5395a",
+    "P3 orchestrator-routing parent-phase awareness — already shipped in SD-FDBK-INFRA-ORCHESTRATOR-ROUTING-PHASE-001 (PR #3684)",
+    "P4 parent.metadata.child_count auto-maintenance — separate feedback 1a9d108a-2cde-479f-9704-6c1f0f07d500",
+    "Schema migrations to metadata.unlock_gate structure — out of scope; the field is already authored",
+    "EVA vision-document linkage / arch_key wiring — unrelated to cadence-gate vocabulary",
+    "Changes to producers that author metadata.unlock_gate (writers stay as-is)"
+  ],
+
+  "success_metrics": [
+    { "metric": "Vitest pass rate for tests/unit/cadence/ + new pin tests", "target": "100%", "actual": "TBD post-EXEC" },
+    { "metric": "Lib/eva regression test baseline change", "target": "0 new failures", "actual": "TBD post-EXEC" },
+    { "metric": "PR merged status", "target": "merged into origin/main", "actual": "TBD post-LEAD-FINAL" },
+    { "metric": "SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B/-C cadence-wait badge removed in /leo next", "target": "0 CADENCE-WAIT badges for these 2 SDs", "actual": "TBD post-merge smoke test" },
+    { "metric": "Retrospective quality_score", "target": ">=70", "actual": "TBD post-merge" }
+  ]
+}

--- a/scripts/one-off/_testing-prospective-sd-fdbk-cadence-vocab-discriminator-001.mjs
+++ b/scripts/one-off/_testing-prospective-sd-fdbk-cadence-vocab-discriminator-001.mjs
@@ -1,0 +1,176 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'node:crypto';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SD_ID = '258ee3b1-bcef-4500-9090-7401762dac3b';
+const SD_KEY = 'SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001';
+const SUB = 'TESTING';
+const PHASE = 'PLAN';
+const NONCE = new Date().toISOString();
+
+const uniqueKey = `${SD_ID}|${SUB}|${PHASE}|prospective|${NONCE}`;
+const invocation_id = createHash('sha256').update(uniqueKey).digest('hex');
+
+const critical_issues = [];
+
+const warnings = [
+  {
+    code: 'W-1',
+    summary: 'Missing edge: metadata.unlock_gate present but .type missing/non-string',
+    detail: 'FR-1 specifies allowlist match on .type, but TS suite has no case for unlock_gate={} or {type:123}. EXEC should add a unit subcase asserting fall-through to legacy logic (treat malformed unlock_gate as if absent). Without this, a malformed writer could silently bypass refusal.'
+  },
+  {
+    code: 'W-2',
+    summary: 'Missing edge: allowlist match (pr_cadence/time_window) but no next_workable_after',
+    detail: 'TS-4 covers pr_cadence WITH future next_workable_after. Need a case where unlock_gate.type=pr_cadence but no timestamp AND no pr_cadence_minimum_days/session_log fall-through. Expected: source=none/active=false. Confirms refusal-eligible types do not inadvertently short-circuit to advisory when no real refusal data exists.'
+  },
+  {
+    code: 'W-3',
+    summary: 'days_remaining=null contract change (TS-1) may break downstream consumers',
+    detail: 'TS-1 mandates days_remaining=null for advisory; TS-3 verifies positive integer for next_workable_after. JSDoc typedef must be updated to document that null is now valid for active=false advisory states (currently spec says null only when not active). Any downstream that does state.days_remaining > 0 rather than checking state.active could regress.'
+  },
+  {
+    code: 'W-4',
+    summary: 'formatRefusalMessage advisory rendering (FR-6) tension with FR-5 no-emit',
+    detail: 'FR-5 says no refusal flow for advisory source; FR-6 asks formatRefusalMessage to handle source=unlock_gate_advisory. If FR-5 is correct, formatRefusalMessage will never see advisory state in production. Recommend EXEC keep FR-6 test (defense-in-depth) but document divergence in JSDoc.'
+  },
+  {
+    code: 'W-5',
+    summary: 'R-2 consumer-test breakage risk: existing child-sd-selector test does not stub computeGateState',
+    detail: 'tests/unit/handoff/child-sd-selector.test.js mocks urgency-scorer + dependency-dag but NOT pre-claim-gate. New advisory branch executes against real computeGateState. New tests must either (a) mock computeGateState, or (b) construct child fixtures with full metadata flowing through real computeGateState. Option (b) preferred (mirrors orchestrator-routing-phase static-pin pattern from PR #3684).'
+  },
+  {
+    code: 'W-6',
+    summary: 'Static-pin scope anchor verification',
+    detail: 'Proposed slice between "export function computeGateState" and "function buildGateState" is correct for current file shape (lines 46-101). However, CADENCE_REFUSAL_TYPES (FR-2) is module-level. If EXEC places the Set BELOW computeGateState, scoped slice would miss it. Recommend TWO anchors: (1) whole-file regex for the Set declaration, (2) scoped slice for the .has() usage inside computeGateState.'
+  },
+  {
+    code: 'W-7',
+    summary: 'TS-9 smoke test is environmental, not automated',
+    detail: 'TS-9 asserts sd:next output for specific SD keys (-B/-C). This is a manual post-merge smoke; explicitly call out it is NOT a vitest case and runs once after PR merge. Document in test file header so PLAN-TO-LEAD does not look for an automated case.'
+  },
+  {
+    code: 'W-8',
+    summary: 'Missing edge: source-precedence (advisory wins over elapsed next_workable_after)',
+    detail: 'Add unit case: governance_metadata.next_workable_after in PAST + metadata.unlock_gate.type=usage_signal should STILL return source=unlock_gate_advisory (not source=none with elapsed window). Confirms precedence is checked before timestamp evaluation.'
+  },
+  {
+    code: 'W-9',
+    summary: 'FR-5 acceptance criteria 2-3 (CADENCE_GATE_REFUSED audit-log behavior) lacks a TS row',
+    detail: 'FR-5 has 3 acceptance criteria; only the static-pin regex (AC-1) is covered by TS-7. AC-2 (no audit-log row for advisory) and AC-3 (audit-log preserved for true refusals) need explicit integration tests against scripts/sd-start.js or a dependency injection seam.'
+  }
+];
+
+const recommendations = [
+  {
+    code: 'R-1',
+    summary: 'Add 4-5 supplementary unit cases for W-1/W-2/W-3/W-8 edge cases',
+    detail: 'Expand TS suite from 9 to ~13 cases: malformed unlock_gate (W-1), allowlist-type-no-timestamp (W-2), elapsed-window-advisory precedence (W-8), days_remaining-null-not-positive (W-3), formatRefusalMessage source line (FR-6 AC-1). Brings distinct test-type count to 5 (well above PRD requirement of 2).'
+  },
+  {
+    code: 'R-2',
+    summary: 'Static-pin pattern: whole-file regex for Set declaration + scoped slice for usage',
+    detail: 'fs.readFileSync once. (a) Run regex for CADENCE_REFUSAL_TYPES declaration on full source. (b) Slice from "export function computeGateState" to "function buildGateState" and regex for the .has() call within that slice. Combines orchestrator-routing-phase scoping (memory PR #3684) with sd-type-enum.js freeze-pattern verification.'
+  },
+  {
+    code: 'R-3',
+    summary: 'child-sd-selector test: use real computeGateState with full fixture metadata (option b)',
+    detail: 'Construct child fixtures: (i) metadata.unlock_gate.type=usage_signal + future next_workable_after → expect retained; (ii) governance_metadata.next_workable_after only → expect filtered. Both flow through REAL computeGateState. Mirrors PR #3684 static-pin pattern. Avoid vi.mock("lib/cadence/pre-claim-gate.mjs") — that bypasses the unit under test.'
+  },
+  {
+    code: 'R-4',
+    summary: 'Update JSDoc GateState typedef',
+    detail: 'Change days_remaining doc from "null when not active" to "null when not active OR when source=unlock_gate_advisory". Source union adds "unlock_gate_advisory". This is a contract change consumers may import via JSDoc reference.'
+  },
+  {
+    code: 'R-5',
+    summary: 'Vitest config check for .test.mjs extension support',
+    detail: 'Verify vitest.config.* glob includes .mjs (default vitest includes mjs/js/ts/cjs/etc). If repo uses a restrictive include array, EXEC must update config or use .test.js extension. Quick check: search for vitest.config files and review test glob.'
+  },
+  {
+    code: 'R-6',
+    summary: 'TS-5 console-substring assertion: use console.log spy + em-dash UTF-8 verification',
+    detail: 'vi.spyOn(console, "log") + assert spy.mock.calls.some(c => String(c[0] || "").includes(LITERAL)). The em-dash character (U+2014) must be encoded UTF-8 in test file (verify no BOM, no ASCII fallback).'
+  },
+  {
+    code: 'R-7',
+    summary: 'Add integration test for FR-5 audit-log AC-2/AC-3',
+    detail: 'Integration test against scripts/sd-start.js cadence-refusal block (or a refactored seam) asserting CADENCE_GATE_REFUSED row is NOT inserted for advisory and IS inserted for true refusals. May require a small SD-start refactor to expose the audit-log decision point as a unit-testable function.'
+  }
+];
+
+const findings = {
+  scenarios_assessed: 9,
+  scenarios_recommended: 13,
+  test_type_distribution_proposed: { unit: 5, integration: 1, regression: 1, static_guard: 1, smoke: 1 },
+  distinct_test_types: 5,
+  prd_requirement_distinct_types: 2,
+  meets_distinct_type_requirement: true,
+  static_pin_pattern_viable: true,
+  static_pin_recommendation: 'Whole-file regex for Set declaration + scoped slice (between computeGateState export and buildGateState) for the .has() usage',
+  consumer_test_breakage_risk_assessed: true,
+  consumer_test_breakage_mitigation: 'Use real computeGateState with full fixture metadata (R-3), avoid mocking pre-claim-gate module',
+  surface_area_coverage: {
+    'computeGateState advisory path (FR-1)': 'TS-1, TS-2 — adequate',
+    'computeGateState refusal-eligible allowlist (FR-1)': 'TS-4 — adequate',
+    'computeGateState baseline regression (FR-1)': 'TS-3 — adequate',
+    'CADENCE_REFUSAL_TYPES frozen Set (FR-2)': 'TS-7, TS-8 — adequate (with R-2 robustness)',
+    'child-sd-selector cadenceCleared advisory (FR-3)': 'TS-5 — adequate (with R-3 mitigation)',
+    'getCadenceBadge advisory empty string (FR-4)': 'TS-6 — adequate',
+    'sd-start.js cadence-refusal short-circuit (FR-5)': 'PARTIAL — only AC-1 covered by TS-7; AC-2/AC-3 audit-log behavior uncovered (W-9, R-7)',
+    'formatRefusalMessage source surface (FR-6)': 'NOT COVERED — recommend TS-10 unit case (W-4, R-1)'
+  },
+  edge_cases_missing: [
+    'malformed unlock_gate (W-1)',
+    'allowlist-type but no timestamp (W-2)',
+    'elapsed next_workable_after + advisory unlock_gate (W-8)',
+    'formatRefusalMessage source=advisory (W-4)',
+    'scripts/sd-start.js audit-log advisory short-circuit (W-9)'
+  ],
+  validation_mode_rationale: 'prospective: PRD review pre-EXEC; no test execution performed; assessment is structural/coverage-based only.',
+  verdict_rationale: 'PASS with warnings. 9 scenarios cover the core advisory/refusal discriminator path with adequate distinct test types (5, vs PRD requirement of 2). Static-pin pattern is viable with R-2 robustness refinement. Consumer-test breakage risk is real but mitigable via R-3. Edge-case gaps (W-1/W-2/W-8) and FR-5/FR-6 coverage holes (W-4/W-9) are MEDIUM severity — they will not block the core fix but should be addressed pre-EXEC-TO-PLAN.'
+};
+
+const row = {
+  sd_id: SD_ID,
+  sub_agent_code: SUB,
+  sub_agent_name: 'testing-agent',
+  phase: PHASE,
+  validation_mode: 'prospective',
+  verdict: 'PASS',
+  confidence: 86,
+  critical_issues,
+  recommendations,
+  warnings,
+  detailed_analysis: findings,
+  invocation_id,
+  metadata: {
+    sd_key: SD_KEY,
+    prd_id: 'PRD-SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001',
+    test_scenarios_assessed: 9,
+    test_scenarios_recommended_total: 13,
+    distinct_test_types: 5,
+    prospective: true,
+    nonce: NONCE,
+    invoked_by: 'orchestrator (PLAN prospective TESTING review)'
+  }
+};
+
+const { data, error } = await supabase
+  .from('sub_agent_execution_results')
+  .insert(row)
+  .select('id, verdict, confidence, validation_mode, phase')
+  .maybeSingle();
+
+if (error) {
+  console.error('INSERT ERROR:', JSON.stringify(error, null, 2));
+  process.exit(1);
+}
+
+console.log('INSERTED:', JSON.stringify(data, null, 2));
+console.log('invocation_id:', invocation_id);

--- a/tests/unit/cadence/pre-claim-gate-discriminator.test.js
+++ b/tests/unit/cadence/pre-claim-gate-discriminator.test.js
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for lib/cadence/pre-claim-gate.mjs computeGateState +
+ * formatRefusalMessage unlock_gate vocabulary discriminator.
+ *
+ * SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001
+ *
+ * Closes 19th-candidate witness of PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001
+ * (cadence-vocab variant). Covers PRD test scenarios TS-1..TS-4, TS-8, and
+ * supplementary edge cases W-1, W-2, W-8 surfaced by PLAN-phase testing-agent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeGateState,
+  formatRefusalMessage,
+  CADENCE_REFUSAL_TYPES,
+} from '../../../lib/cadence/pre-claim-gate.mjs';
+
+// Fixed "now" for deterministic time-window math (2026-05-10T00:00:00Z = 1778390400000 ms)
+const FIXED_NOW = Date.UTC(2026, 4, 10);
+
+// Future-dated next_workable_after used by multiple cases
+const FUTURE_ISO = '2030-01-01T00:00:00Z';
+// Past-dated for elapsed-window case
+const PAST_ISO = '2020-01-01T00:00:00Z';
+
+describe('CADENCE_REFUSAL_TYPES (export contract)', () => {
+  it('is a Set instance', () => {
+    expect(CADENCE_REFUSAL_TYPES).toBeInstanceOf(Set);
+  });
+
+  it('has exactly 2 entries (pr_cadence + time_window)', () => {
+    expect(CADENCE_REFUSAL_TYPES.size).toBe(2);
+    expect(CADENCE_REFUSAL_TYPES.has('pr_cadence')).toBe(true);
+    expect(CADENCE_REFUSAL_TYPES.has('time_window')).toBe(true);
+  });
+
+  it('does NOT contain advisory types', () => {
+    expect(CADENCE_REFUSAL_TYPES.has('usage_signal')).toBe(false);
+    expect(CADENCE_REFUSAL_TYPES.has('value_proof')).toBe(false);
+  });
+
+  it('is frozen (TS-8 — module-load assertion)', () => {
+    expect(Object.isFrozen(CADENCE_REFUSAL_TYPES)).toBe(true);
+  });
+});
+
+describe('computeGateState — unlock_gate advisory discriminator', () => {
+  it('TS-1: unlock_gate.type=usage_signal with future next_workable_after returns advisory', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'usage_signal', trigger: 'chairman invokes /eva-support 3x/week' } },
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('unlock_gate_advisory');
+    expect(state.gate_until).toBe(FUTURE_ISO);
+    expect(state.days_remaining).toBeNull();
+    expect(state.reason).toContain("usage_signal");
+    expect(state.reason).toContain('advisory');
+  });
+
+  it('TS-2: unlock_gate.type=value_proof returns advisory (event-based)', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'value_proof', trigger: 'Phase 2 ships AND chairman uses queries' } },
+      governance_metadata: { next_workable_after: '2026-09-01T00:00:00Z' },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('unlock_gate_advisory');
+    expect(state.gate_until).toBe('2026-09-01T00:00:00Z');
+  });
+
+  it('advisory path with NO next_workable_after preserves gate_until=null', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'usage_signal' } },
+      governance_metadata: {},
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('unlock_gate_advisory');
+    expect(state.gate_until).toBeNull();
+  });
+});
+
+describe('computeGateState — refusal-eligible types fall through', () => {
+  it('TS-4: unlock_gate.type=pr_cadence with future next_workable_after STILL refuses', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'pr_cadence' } },
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(true);
+    expect(state.source).toBe('next_workable_after');
+    expect(state.gate_until).toBe(FUTURE_ISO);
+    expect(state.days_remaining).toBeGreaterThan(0);
+  });
+
+  it('unlock_gate.type=time_window with future next_workable_after STILL refuses', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'time_window' } },
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(true);
+    expect(state.source).toBe('next_workable_after');
+  });
+});
+
+describe('computeGateState — backward compatibility (no unlock_gate)', () => {
+  it('TS-3: no metadata.unlock_gate + future next_workable_after returns existing active=true', () => {
+    const state = computeGateState({
+      metadata: {},
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(true);
+    expect(state.source).toBe('next_workable_after');
+  });
+
+  it('no metadata + elapsed next_workable_after returns active=false (existing behavior)', () => {
+    const state = computeGateState({
+      governance_metadata: { next_workable_after: PAST_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(false);
+    expect(state.days_remaining).toBe(0);
+  });
+
+  it('no metadata at all returns source=none (existing behavior)', () => {
+    const state = computeGateState({});
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('none');
+  });
+});
+
+describe('computeGateState — edge cases (PLAN testing-agent recommendations)', () => {
+  it('W-1: malformed unlock_gate (empty object) falls through (no advisory)', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: {} },
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    // unlock_gate.type is missing — advisory branch requires typeof type === 'string'
+    expect(state.source).toBe('next_workable_after');
+    expect(state.active).toBe(true);
+  });
+
+  it('W-1: malformed unlock_gate.type (non-string number) falls through', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 123 } },
+      governance_metadata: { next_workable_after: FUTURE_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.source).toBe('next_workable_after');
+    expect(state.active).toBe(true);
+  });
+
+  it('W-2: unlock_gate.type=pr_cadence with NO next_workable_after AND no pr_cadence_minimum_days falls through to source=none', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'pr_cadence' } },
+      governance_metadata: {},
+      now: FIXED_NOW,
+    });
+    // type is refusal-eligible (allowlist hit) — advisory branch skipped — falls through to
+    // Source 1 (no next_workable_after) → Source 2 (no pr_cadence_minimum_days) → source=none
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('none');
+  });
+
+  it('W-8: PAST next_workable_after + advisory unlock_gate returns advisory (precedence — advisory wins before timestamp eval)', () => {
+    const state = computeGateState({
+      metadata: { unlock_gate: { type: 'usage_signal' } },
+      governance_metadata: { next_workable_after: PAST_ISO },
+      now: FIXED_NOW,
+    });
+    expect(state.active).toBe(false);
+    expect(state.source).toBe('unlock_gate_advisory');
+    expect(state.gate_until).toBe(PAST_ISO);
+  });
+
+  it('null metadata + unlock_gate fixture does not crash', () => {
+    const state = computeGateState({
+      metadata: null,
+      governance_metadata: null,
+      now: FIXED_NOW,
+    });
+    expect(state.source).toBe('none');
+  });
+});
+
+describe('formatRefusalMessage — source surfacing (FR-6)', () => {
+  it('source value appears in formatted output for next_workable_after', () => {
+    const msg = formatRefusalMessage({
+      sdKey: 'SD-EX-001',
+      gateState: {
+        active: true,
+        gate_until: FUTURE_ISO,
+        days_remaining: 1366,
+        reason: 'PR cadence: 1366 day(s) remaining',
+        source: 'next_workable_after',
+      },
+    });
+    expect(msg).toContain('source:     next_workable_after');
+  });
+
+  it('source value appears for advisory state (FR-6 AC-1)', () => {
+    const msg = formatRefusalMessage({
+      sdKey: 'SD-EX-001',
+      gateState: {
+        active: false,
+        gate_until: FUTURE_ISO,
+        days_remaining: null,
+        reason: "unlock_gate.type='usage_signal' is event-based (advisory).",
+        source: 'unlock_gate_advisory',
+      },
+    });
+    expect(msg).toContain('source:     unlock_gate_advisory');
+  });
+});

--- a/tests/unit/cadence/pre-claim-gate-static-guard.test.js
+++ b/tests/unit/cadence/pre-claim-gate-static-guard.test.js
@@ -1,0 +1,131 @@
+/**
+ * Static-pin regression guard for lib/cadence/pre-claim-gate.mjs and its
+ * consumers. Verifies that the unlock_gate vocabulary discriminator is wired
+ * via the literal CADENCE_REFUSAL_TYPES Set and that consumers branch on
+ * state.source rather than only state.active.
+ *
+ * SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001 TS-7
+ *
+ * Pattern: fs.readFileSync + scoped slice between explicit function anchors
+ * (NOT whole-file regex) to avoid false-matches against JSDoc or unrelated
+ * code. Mirrors the lesson learned in SD-FDBK-INFRA-ORCHESTRATOR-ROUTING-PHASE-001
+ * where static-pin tests required scoping to a helperRegion slice.
+ *
+ * Dual-anchor strategy (testing-agent R-2):
+ *  (a) whole-file regex for top-level CADENCE_REFUSAL_TYPES Object.freeze
+ *      declaration (a module-level export, not inside a function)
+ *  (b) scoped slice for the unlock_gate.type usage inside computeGateState
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+const GATE_PATH = path.join(PROJECT_ROOT, 'lib', 'cadence', 'pre-claim-gate.mjs');
+const SELECTOR_PATH = path.join(PROJECT_ROOT, 'scripts', 'modules', 'handoff', 'child-sd-selector.js');
+const STATUS_HELPERS_PATH = path.join(PROJECT_ROOT, 'scripts', 'modules', 'sd-next', 'status-helpers.js');
+
+function readSource(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function sliceBetweenAnchors(src, startAnchor, endAnchor) {
+  const startIdx = src.indexOf(startAnchor);
+  if (startIdx === -1) {
+    throw new Error(`Start anchor not found: ${startAnchor}`);
+  }
+  const endIdx = src.indexOf(endAnchor, startIdx + startAnchor.length);
+  if (endIdx === -1) {
+    throw new Error(`End anchor not found: ${endAnchor} (after ${startAnchor})`);
+  }
+  return src.slice(startIdx, endIdx);
+}
+
+describe('static-pin: lib/cadence/pre-claim-gate.mjs', () => {
+  const src = readSource(GATE_PATH);
+
+  it('exports CADENCE_REFUSAL_TYPES as Object.freeze(new Set([...])) at module level (anchor a)', () => {
+    expect(src).toMatch(/export const CADENCE_REFUSAL_TYPES = Object\.freeze\(new Set\(\[/);
+  });
+
+  it('CADENCE_REFUSAL_TYPES contains pr_cadence and time_window string literals', () => {
+    // Whole-file search OK here — Set membership is a single, unique location
+    expect(src).toMatch(/['"]pr_cadence['"]/);
+    expect(src).toMatch(/['"]time_window['"]/);
+  });
+
+  it('computeGateState helper region uses CADENCE_REFUSAL_TYPES.has(unlock_gate.type) (anchor b — scoped)', () => {
+    // Scoped slice: from 'export function computeGateState' to next 'function buildGateState'
+    const helperRegion = sliceBetweenAnchors(
+      src,
+      'export function computeGateState',
+      'function buildGateState'
+    );
+    expect(helperRegion).toMatch(/CADENCE_REFUSAL_TYPES\.has\(/);
+    expect(helperRegion).toMatch(/unlock_gate_advisory/);
+  });
+
+  it('helper region returns source:\'unlock_gate_advisory\' string literal in advisory branch', () => {
+    const helperRegion = sliceBetweenAnchors(
+      src,
+      'export function computeGateState',
+      'function buildGateState'
+    );
+    expect(helperRegion).toMatch(/source:\s*['"]unlock_gate_advisory['"]/);
+  });
+
+  it('GateState JSDoc typedef enumerates unlock_gate_advisory as valid source value', () => {
+    expect(src).toMatch(/unlock_gate_advisory.*next_workable_after.*derived_from_session_log.*none/s);
+  });
+});
+
+describe('static-pin: scripts/modules/handoff/child-sd-selector.js cadence filter (FR-3)', () => {
+  const src = readSource(SELECTOR_PATH);
+
+  it('cadenceCleared filter region branches on state.source === unlock_gate_advisory', () => {
+    // Scope to the cadenceCleared filter (between its declaration and next blank stanza)
+    const filterRegion = sliceBetweenAnchors(
+      src,
+      'const cadenceCleared = unblocked.filter',
+      'const withUrgency'
+    );
+    expect(filterRegion).toMatch(/state\.source\s*===\s*['"]unlock_gate_advisory['"]/);
+  });
+
+  it('cadenceCleared advisory branch logs the canonical phrase from child-sd-preflight.js', () => {
+    const filterRegion = sliceBetweenAnchors(
+      src,
+      'const cadenceCleared = unblocked.filter',
+      'const withUrgency'
+    );
+    // em-dash (—) literal — the canonical informational marker from child-sd-preflight.js:315
+    expect(filterRegion).toMatch(/\(informational\s+—\s+does not affect verdict\)/);
+  });
+});
+
+describe('static-pin: scripts/modules/sd-next/status-helpers.js (FR-4)', () => {
+  const src = readSource(STATUS_HELPERS_PATH);
+
+  it('getCadenceBadge region suppresses badge for advisory source', () => {
+    const helperRegion = sliceBetweenAnchors(
+      src,
+      'export function getCadenceBadge',
+      'export function getCadenceReason'
+    );
+    expect(helperRegion).toMatch(/source\s*===\s*['"]unlock_gate_advisory['"]/);
+    expect(helperRegion).toMatch(/return\s+['"]['"]\s*;?\s*\n/);
+  });
+
+  it('getCadenceReason region suppresses reason text for advisory source', () => {
+    const startIdx = src.indexOf('export function getCadenceReason');
+    expect(startIdx).toBeGreaterThan(-1);
+    // Scope to ~end of file (whichever comes first): another export or end-of-file
+    const nextExportIdx = src.indexOf('\nexport function', startIdx + 'export function getCadenceReason'.length);
+    const slice = src.slice(startIdx, nextExportIdx === -1 ? undefined : nextExportIdx);
+    expect(slice).toMatch(/source\s*===\s*['"]unlock_gate_advisory['"]/);
+  });
+});

--- a/tests/unit/handoff/child-sd-selector-unlock-gate.test.js
+++ b/tests/unit/handoff/child-sd-selector-unlock-gate.test.js
@@ -1,0 +1,149 @@
+/**
+ * Integration test for scripts/modules/handoff/child-sd-selector.js
+ * unlock_gate advisory branch.
+ *
+ * SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001 TS-5
+ *
+ * Strategy: use the REAL computeGateState (not vi.mock) — the unit-under-test
+ * is the consumer's discriminator branching, not the gate itself. Tests assert
+ * the advisory child is RETAINED in cadenceCleared output and that the
+ * canonical informational log substring is emitted.
+ *
+ * Per testing-agent R-3: real fn + full fixture metadata (vi.mock the gate
+ * would bypass the real branching we want to verify).
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// Mock side-effect modules NOT under test (urgency, DAG) so the test doesn't
+// pull in their own DB / external surface
+vi.mock('../../../scripts/modules/handoff/auto-proceed/urgency-scorer.js', () => ({
+  sortByUrgency: vi.fn((items) => items),
+  scoreToBand: vi.fn(() => 'normal'),
+}));
+
+vi.mock('../../../lib/orchestrator/dependency-dag.js', () => ({
+  buildDependencyDAG: vi.fn(),
+  detectCycles: vi.fn(),
+  computeRunnableSet: vi.fn(),
+}));
+
+import { getNextReadyChild } from '../../../scripts/modules/handoff/child-sd-selector.js';
+
+function makeSupabase(children) {
+  // Mirror the production query chain shape: from -> select -> eq -> in [-> neq]
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          in: () => ({
+            // both with-neq and without-neq paths return same fixture
+            neq: () => Promise.resolve({ data: children, error: null }),
+            then: (resolve) => resolve({ data: children, error: null }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('child-sd-selector cadenceCleared advisory branch (FR-3)', () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('TS-5: child with metadata.unlock_gate.type=usage_signal is RETAINED (not filtered)', async () => {
+    const advisoryChild = {
+      id: 'child-advisory',
+      sd_key: 'SD-EX-001-B',
+      title: 'Advisory child',
+      status: 'draft',
+      priority: 50,
+      sequence_rank: 2,
+      created_at: '2026-04-01T00:00:00Z',
+      metadata: { unlock_gate: { type: 'usage_signal', trigger: 'foo' } },
+      governance_metadata: { next_workable_after: '2030-01-01T00:00:00Z' },
+    };
+
+    const supabase = makeSupabase([advisoryChild]);
+    const result = await getNextReadyChild(supabase, 'parent-1', null);
+
+    expect(result.sd).not.toBeNull();
+    expect(result.sd.sd_key).toBe('SD-EX-001-B');
+  });
+
+  it('TS-5: advisory log contains canonical informational phrase', async () => {
+    const advisoryChild = {
+      id: 'child-advisory-2',
+      sd_key: 'SD-EX-001-C',
+      status: 'draft',
+      created_at: '2026-04-01T00:00:00Z',
+      metadata: { unlock_gate: { type: 'value_proof' } },
+      governance_metadata: { next_workable_after: '2026-09-01T00:00:00Z' },
+    };
+
+    const supabase = makeSupabase([advisoryChild]);
+    await getNextReadyChild(supabase, 'parent-1', null);
+
+    const allLogs = consoleLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allLogs).toMatch(/SD-EX-001-C/);
+    expect(allLogs).toMatch(/unlock_gate=value_proof/);
+    expect(allLogs).toMatch(/\(informational\s+—\s+does not affect verdict\)/);
+  });
+
+  it('backward-compat: child WITHOUT unlock_gate + future next_workable_after IS filtered out (existing behavior)', async () => {
+    const blockedChild = {
+      id: 'child-blocked',
+      sd_key: 'SD-EX-002',
+      status: 'draft',
+      created_at: '2026-04-01T00:00:00Z',
+      metadata: {},
+      governance_metadata: { next_workable_after: '2030-01-01T00:00:00Z' },
+    };
+
+    const supabase = makeSupabase([blockedChild]);
+    const result = await getNextReadyChild(supabase, 'parent-1', null);
+
+    expect(result.sd).toBeNull();
+
+    const allLogs = consoleLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allLogs).toMatch(/Skipping SD-EX-002/);
+    expect(allLogs).toMatch(/cadence gate active/);
+  });
+
+  it('mixed: advisory child retained + blocked child filtered out in same batch', async () => {
+    const advisoryChild = {
+      id: 'child-adv',
+      sd_key: 'SD-EX-003-A',
+      status: 'draft',
+      created_at: '2026-04-01T00:00:00Z',
+      metadata: { unlock_gate: { type: 'usage_signal' } },
+      governance_metadata: { next_workable_after: '2030-01-01T00:00:00Z' },
+    };
+    const blockedChild = {
+      id: 'child-blk',
+      sd_key: 'SD-EX-003-B',
+      status: 'draft',
+      created_at: '2026-04-02T00:00:00Z',
+      metadata: {},
+      governance_metadata: { next_workable_after: '2030-01-01T00:00:00Z' },
+    };
+
+    const supabase = makeSupabase([advisoryChild, blockedChild]);
+    const result = await getNextReadyChild(supabase, 'parent-1', null);
+
+    // Either advisory child is selected (since blocked is filtered)
+    expect(result.sd).not.toBeNull();
+    expect(result.sd.sd_key).toBe('SD-EX-003-A');
+
+    const allLogs = consoleLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allLogs).toMatch(/SD-EX-003-A unlock_gate=usage_signal \(informational/);
+    expect(allLogs).toMatch(/Skipping SD-EX-003-B/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes 19th-candidate witness of `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` (cadence-vocab variant) and feedback `41f703dc-8196-4278-95f1-4b1dab36cf28`.

`lib/cadence/pre-claim-gate.mjs` `computeGateState` treated `governance_metadata.next_workable_after` as a hard time-based PR-cadence refusal whenever the timestamp was in the future. Two SDs (`SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B` / `-C`) populate `next_workable_after` as an advisory milestone alongside `metadata.unlock_gate.type='usage_signal'|'value_proof'` — event-based unlock semantics that should not block claims. The gate had no discriminator, so `child-sd-selector.js:81-91` and `sd-next/status-helpers.js` filtered them out with `"cadence gate active (1d until …)"` / `"(114d until …)"` messages.

19th-candidate witness of `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`: writer side (SD authors) overloaded `next_workable_after` for two semantics; consumer (`computeGateState`) treated both identically.

## Changes

- **`lib/cadence/pre-claim-gate.mjs`**: Added exported `CADENCE_REFUSAL_TYPES` `Object.frozen` `Set` (`['pr_cadence', 'time_window']`) — explicit allowlist of refusal-eligible `unlock_gate.type` values. Added Source 0 branch at top of `computeGateState`: when `metadata.unlock_gate` is non-null object with string `.type` AND `.type` is NOT in `CADENCE_REFUSAL_TYPES`, short-circuit and return `{ active: false, source: 'unlock_gate_advisory', gate_until: <preserved>, days_remaining: null }`. JSDoc `UNLOCK_GATE VOCABULARY` documents the contract.
- **`scripts/modules/handoff/child-sd-selector.js`**: `cadenceCleared` filter branches on `state.source` — advisory entries are RETAINED with informational log using the canonical `"(informational — does not affect verdict)"` phrase (matches `child-sd-preflight.js:315`).
- **`scripts/modules/sd-next/status-helpers.js`**: `getCadenceBadge` + `getCadenceReason` short-circuit empty string for `source==='unlock_gate_advisory'` — no blocking `CADENCE-WAIT` badge rendered.
- **`scripts/sd-start.js`**: NOT touched — advisory states return `active=false`, so existing `if (!gateState.active) return` early-return handles them naturally. No `CADENCE_GATE_REFUSED` audit-log row for advisory path (the insert lives inside the refusal block).

## Tests (32 new vitest cases + zero regression)

- `tests/unit/cadence/pre-claim-gate-discriminator.test.js` (16 cases): `CADENCE_REFUSAL_TYPES` export contract, advisory scenarios, refusal-eligible fall-through, backward-compat, edge cases W-1/W-2/W-8, `formatRefusalMessage` source surfacing.
- `tests/unit/cadence/pre-claim-gate-static-guard.test.js` (8 cases): dual-anchor static-pin (whole-file `Set` decl + scoped slice for `computeGateState` helper region + child-sd-selector `cadenceCleared` region + `getCadenceBadge`/`getCadenceReason` regions).
- `tests/unit/handoff/child-sd-selector-unlock-gate.test.js` (4 cases): real-`computeGateState` integration with mocked supabase — advisory retained + canonical log + backward-compat baseline + mixed advisory+blocked batch.
- Regression: **82 existing tests pass** across child-sd-selector + sd-next suites; **406 lib/eva tests pass**. Zero new failures.

## DB Audit (TR-5, pre-merge)

Only 2 SDs in production have `metadata.unlock_gate`:
- `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B`: `type='usage_signal'`
- `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C`: `type='value_proof'`

Neither is in `CADENCE_REFUSAL_TYPES`. Zero rows would be unintentionally unblocked — both will route through the new advisory path exactly as intended.

## Sub-agent evidence

- LEAD validation `d64850e9-b4f0-424e-9402-4e7d7975f79f` PASS@93
- LEAD risk `4bac9052-db8e-440c-bc1a-863a2fbd1c05` LOW@88
- PLAN testing-prospective `a2f15289-d8b7-487b-9dc8-496f90e2a214` PASS@86
- EXEC testing-retrospective `87229ec2-58c6-457b-a916-0f05fd51127f` PASS@95

## Out of scope (separate feedback rows per RCA P2-P4)

- P2 ghost-completion partial-revert → feedback `0a06a05a-3c52-41ba-9c5e-d62582d5395a`
- P3 orchestrator-routing parent-phase → already shipped `SD-FDBK-INFRA-ORCHESTRATOR-ROUTING-PHASE-001` (PR #3684)
- P4 `parent.metadata.child_count` maintenance → feedback `1a9d108a-2cde-479f-9704-6c1f0f07d500`

## Test plan

- [x] `npx vitest run tests/unit/cadence/ tests/unit/handoff/child-sd-selector*.test.js tests/unit/sd-next/` → 114/114 PASS
- [x] Inline smoke: `computeGateState({metadata:{unlock_gate:{type:'usage_signal'}},governance_metadata:{next_workable_after:'2030-01-01T00:00:00Z'}})` returns `{active:false, source:'unlock_gate_advisory', ...}`
- [x] `CADENCE_REFUSAL_TYPES.size === 2`, `Object.isFrozen(CADENCE_REFUSAL_TYPES) === true`
- [x] Pre-merge DB audit: zero affected rows in production with unlock_gate.type in allowlist
- [ ] Post-merge live smoke: `npm run sd:next` no longer shows `[CADENCE-WAIT N day(s)]` badge for `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B/-C`

Closes feedback `41f703dc-8196-4278-95f1-4b1dab36cf28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)