### PR TITLE
fix(QF-20260510-925): autoCloseFeedback reads metadata.deferred_from_sd_key (18th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001)

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -8,6 +8,6 @@
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-05-11T01:20:30.956Z",
-  "lastUpdatedAt": "2026-05-11T01:20:30.960Z"
+  "clearedAt": "2026-05-11T02:10:51.534Z",
+  "lastUpdatedAt": "2026-05-11T02:10:51.538Z"
 }

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -699,6 +699,12 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
    * Auto-close feedback items linked to this SD (US-002)
    * Queries feedback table for items with matching strategic_directive_id
    * or resolution_sd_id, and transitions them to 'resolved'.
+   *
+   * QF-20260510-925: also reads metadata.deferred_from_sd_key (set by
+   * emit-feedback per SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-2). Closes
+   * 18th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 — the writer
+   * channel was wired without a matching reader, leaving bundled-CAPA
+   * feedback rows stuck at status='new' after their bundling SD merged.
    */
   async autoCloseFeedback(sd) {
     const sdId = sd.id;
@@ -732,10 +738,28 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       }
     }
 
+    // 3. QF-20260510-925: Find feedback items linked via metadata.deferred_from_sd_key.
+    //    emit-feedback (SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-2) writes this when a
+    //    CAPA item is deferred from a parent SD; without this reader, bundled-CAPA
+    //    rows remain status='new' forever after the bundling SD merges.
+    let linkedByDeferredFrom = [];
+    if (sdKey) {
+      const { data: deferredFeedback, error: deferredError } = await this.supabase
+        .from('feedback')
+        .select('id')
+        .filter('metadata->>deferred_from_sd_key', 'eq', sdKey)
+        .not('status', 'in', terminalStatuses);
+
+      if (!deferredError && deferredFeedback) {
+        linkedByDeferredFrom = deferredFeedback;
+      }
+    }
+
     // Deduplicate IDs
     const allIds = [...new Set([
       ...(linkedById || []).map(f => f.id),
-      ...linkedByBranch.map(f => f.id)
+      ...linkedByBranch.map(f => f.id),
+      ...linkedByDeferredFrom.map(f => f.id)
     ])];
 
     if (allIds.length === 0) {

--- a/tests/unit/handoff/lead-final-approval-deferred-from-feedback.test.js
+++ b/tests/unit/handoff/lead-final-approval-deferred-from-feedback.test.js
@@ -1,0 +1,64 @@
+/**
+ * Static-pin regression test for QF-20260510-925.
+ *
+ * Pins the metadata.deferred_from_sd_key channel in
+ * LeadFinalApprovalExecutor.autoCloseFeedback so future refactors cannot
+ * silently re-introduce the 18th-witness writer-consumer asymmetry
+ * (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001). The dual-anchor pattern
+ * matches established practice (SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001
+ * project memory): scoped-slice regex on the autoCloseFeedback method body
+ * + whole-file regex on the JSONB filter literal.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SOURCE_PATH = resolve(
+  __dirname,
+  '../../../scripts/modules/handoff/executors/lead-final-approval/index.js'
+);
+
+describe('QF-20260510-925: autoCloseFeedback metadata.deferred_from_sd_key channel', () => {
+  const src = readFileSync(SOURCE_PATH, 'utf8');
+
+  it('source file imports and method exists (sanity)', () => {
+    expect(src).toMatch(/async autoCloseFeedback\(sd\)/);
+  });
+
+  it('file contains the canonical JSONB filter literal', () => {
+    // PostgREST JSONB ->> operator with exact key name; case-sensitive.
+    expect(src).toMatch(/'metadata->>deferred_from_sd_key',\s*'eq',\s*sdKey/);
+  });
+
+  it('linkedByDeferredFrom variable is declared and included in dedup', () => {
+    // Scope to autoCloseFeedback body so unrelated future code can not
+    // accidentally satisfy the pin.
+    const startIdx = src.indexOf('async autoCloseFeedback(sd)');
+    expect(startIdx).toBeGreaterThan(-1);
+    // closing brace of the method (next line beginning with `  }`)
+    const endIdx = src.indexOf('\n  }', startIdx);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    const body = src.slice(startIdx, endIdx);
+
+    expect(body).toMatch(/let\s+linkedByDeferredFrom\s*=\s*\[\]/);
+    expect(body).toMatch(/\.\.\.linkedByDeferredFrom\.map\(f\s*=>\s*f\.id\)/);
+  });
+
+  it('new query is gated on sdKey (same defensive shape as linkedByBranch)', () => {
+    const startIdx = src.indexOf('// 3. QF-20260510-925');
+    expect(startIdx).toBeGreaterThan(-1);
+    // Match a slice that captures the if-gate immediately following the comment.
+    const slice = src.slice(startIdx, startIdx + 600);
+    expect(slice).toMatch(/let\s+linkedByDeferredFrom\s*=\s*\[\];\s*if\s*\(sdKey\)/);
+  });
+
+  it('terminalStatuses exclusion is preserved on the new query', () => {
+    const startIdx = src.indexOf('// 3. QF-20260510-925');
+    const slice = src.slice(startIdx, startIdx + 900);
+    expect(slice).toMatch(/\.not\('status',\s*'in',\s*terminalStatuses\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `LeadFinalApprovalExecutor.autoCloseFeedback` with a 3rd query branch that filters feedback rows by `metadata->>deferred_from_sd_key`. The writer side (`emit-feedback` FR-2 from `SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001`, PR #3676) has been populating this key since 2026-05-10; the reader was missing, leaving bundled-CAPA rows stuck at `status='new'` after their bundling SD merged.

18th-witness `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`.

## Witness audit (this PR backfills)

When this PR merges, the existing QF auto-resolver (per `SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001`) parses the `Closes feedback <uuid>` footers below and resolves them. Going forward, the new code path also closes deferred-from-SD bundled CAPAs at the SD-merge boundary.

- `f383d272-b9d2-44f0-832a-396297b0425c` — meta-SD recommendation (addressed by completed SD-LEO-INFRA-LEAD-EMPIRICAL-PRECHECK-001)
- `f269bed0-d990-44b3-be80-50f638283e6f` — heterogeneous PK shape (C2; addressed by `verifyJoinShape`)
- `79dc2f05-0e24-4ffe-9ed0-3642b1e09236` — LEAD pre-enrichment stale branch (C1; addressed by `verifyOriginMainPremise`)
- `1e1dbe0d-6060-4d34-959f-d9cbd22e0b6d` — BLOCK-CLAIMS-CANCELLED limbo state

## Changes

- **scripts/modules/handoff/executors/lead-final-approval/index.js** (+25 LOC)
  - New `linkedByDeferredFrom` query: `.filter('metadata->>deferred_from_sd_key', 'eq', sdKey)` with same `.not('status', 'in', terminalStatuses)` and same defensive `if (sdKey)` gate as `linkedByBranch`.
  - Dedup line extended to include the new channel.
  - Docblock updated with QF reference + writer-consumer asymmetry rationale.

- **tests/unit/handoff/lead-final-approval-deferred-from-feedback.test.js** (+64 LOC, new)
  - Dual-anchor static-pin: whole-file regex on the JSONB filter literal + scoped-slice regex on the `autoCloseFeedback` body (per `SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001` precedent).
  - Mock-independent — defends against silent refactor regression.

## Test plan

- [x] 5/5 new static-pin tests pass
- [x] 38/38 US-002 baseline tests (`tests/unit/quality/feedback-learning.test.js`) unchanged
- [x] 67/67 combined feedback-suite (handoff + governance/emit-feedback + regression-pins/wire-feedback-table)
- [x] Pre-existing baseline failures (handoff-orchestrator, prerequisite-preflight-smoke, database-helpers, claim-validity-gate) verified unrelated via `git stash` bisect — same failures at `origin/main` HEAD `d8787b39ca`
- [x] TypeScript: `npx tsc --noEmit` PASS

## RCA / context

- RCA result: `sub_agent_execution_results.id = ddac7e9a-5299-4d3e-acb7-2c46bb62c5c6`
- Predecessors: SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 (PR #3676, v1 footer parser for QF only), SD-LEO-INFRA-LEAD-EMPIRICAL-PRECHECK-001 (PR #3681, bundled the 3 CAPAs but PR body lacked Closes footers)
- C2 (footer parser wiring to LEAD-FINAL) deferred — would require PR-body fetch in `autoCloseFeedback`, which runs BEFORE the ship-review-findings-populator step. Tracked as follow-up.

## Closes

Closes feedback f383d272-b9d2-44f0-832a-396297b0425c
Closes feedback f269bed0-d990-44b3-be80-50f638283e6f
Closes feedback 79dc2f05-0e24-4ffe-9ed0-3642b1e09236
Closes feedback 1e1dbe0d-6060-4d34-959f-d9cbd22e0b6d

🤖 Generated with [Claude Code](https://claude.com/claude-code)