### PR TITLE
feat(SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001): migrate 3 emit-feedback bypass writers to canonical helper

### DIFF
--- a/lib/governance/emit-feedback.js
+++ b/lib/governance/emit-feedback.js
@@ -71,6 +71,62 @@ async function _autoFillDeferredFromSdKey(supabase) {
 }
 
 /**
+ * SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 / TR-4: priority enum allowlist mirrors
+ * the feedback.priority CHECK constraint. App-level validation gives clear fail-loud
+ * diagnostics ('INVALID_PRIORITY:<value>') instead of opaque PostgrestError 22023.
+ */
+export const ALLOWED_PRIORITIES = Object.freeze(new Set(['critical', 'high', 'medium', 'low']));
+
+/**
+ * SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 / TR-2 (dedup_hash composition guard):
+ * source_id, priority, priority_reasoning are pass-through only and MUST NOT join
+ * the dedup_hash composition. Hash stays sha256(today::description::dedup_key).
+ *
+ * @private
+ */
+function _validatePriority(priority) {
+  if (priority === undefined || priority === null) return;
+  if (!ALLOWED_PRIORITIES.has(priority)) {
+    throw new Error(`emitFeedback: INVALID_PRIORITY:${priority} (allowed: ${[...ALLOWED_PRIORITIES].join(',')})`);
+  }
+}
+
+/**
+ * Build the row object for INSERT. Extracted so emitFeedback (singleton) and
+ * emitFeedbackBatch (bulk) share identical column-shaping logic — preventing
+ * divergence between singleton and batch INSERT shapes.
+ *
+ * @private
+ */
+function _buildRowObject(args, enrichedMetadata, dedupHash) {
+  const { type, category, severity, source_application, source_type, sd_id,
+    title, description, source_id, priority, priority_reasoning } = args;
+  const cappedTitle = title.length > 120 ? `${title.slice(0, 117)}...` : title;
+  const row = {
+    type,
+    category,
+    status: 'new',
+    severity,
+    source_application,
+    source_type,
+    title: cappedTitle,
+    description,
+    sd_id, // canonical column name per database-agent C-DB-2 (NOT related_sd_id)
+    metadata: {
+      ...enrichedMetadata,
+      dedup_hash: dedupHash,
+      emitted_at: new Date().toISOString(),
+    },
+  };
+  // SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: optional pass-through columns.
+  // Only set when caller provided them — preserves additive backward-compat.
+  if (source_id !== undefined && source_id !== null) row.source_id = source_id;
+  if (priority !== undefined && priority !== null) row.priority = priority;
+  if (priority_reasoning !== undefined && priority_reasoning !== null) row.priority_reasoning = priority_reasoning;
+  return row;
+}
+
+/**
  * Insert a structured feedback row — idempotent via SHA-256 dedup_hash.
  *
  * STRUCTURED COLUMNS ONLY — never interpolate user-supplied SD title or
@@ -87,6 +143,9 @@ async function _autoFillDeferredFromSdKey(supabase) {
  * @param {string} [args.source_application='EHG_Engineer']
  * @param {string} [args.source_type='manual_feedback']
  * @param {string|null} [args.sd_id] - feedback.sd_id (UUID, NOT related_sd_id per C-DB-2)
+ * @param {string|null} [args.source_id] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: source-tracking id (UAT scenario id, retro id, etc). Pass-through only — does NOT join dedup_hash.
+ * @param {string|null} [args.priority] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: 'critical' | 'high' | 'medium' | 'low'. Validated app-level (TR-4). Pass-through only.
+ * @param {string|null} [args.priority_reasoning] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: human-readable rationale for priority. Pass-through only.
  * @param {Object} [args.metadata={}] - Caller-supplied structured metadata
  * @param {string|null} [args.dedup_key] - Dedup component (file path, layer name, etc.)
  * @returns {Promise<{ id: string|null, deduped: boolean }>} insert id, or deduped=true if existing row found
@@ -101,12 +160,16 @@ export async function emitFeedback({
   source_application = 'EHG_Engineer',
   source_type = 'manual_feedback',
   sd_id = null,
+  source_id = null,
+  priority = null,
+  priority_reasoning = null,
   metadata = {},
   dedup_key = null,
 } = {}) {
   if (!supabase) throw new Error('emitFeedback: supabase client is required');
   if (!title) throw new Error('emitFeedback: title is required');
   if (!description) throw new Error('emitFeedback: description is required');
+  _validatePriority(priority);
 
   // SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-2: best-effort auto-fill
   // metadata.deferred_from_sd_key from active claim when caller did not set it.
@@ -118,6 +181,9 @@ export async function emitFeedback({
   }
 
   const today = new Date().toISOString().slice(0, 10);
+  // SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 TR-2: dedup_hash composition is a
+  // SECURITY-CRITICAL CONTRACT — source_id, priority, priority_reasoning are
+  // pass-through and MUST NOT join the hash. Test TS-2 pins this invariant.
   const dedupHash = crypto
     .createHash('sha256')
     .update(`${today}::${description}::${dedup_key || ''}`)
@@ -135,26 +201,16 @@ export async function emitFeedback({
     return { id: existing.id, deduped: true };
   }
 
-  const cappedTitle = title.length > 120 ? `${title.slice(0, 117)}...` : title;
+  const row = _buildRowObject(
+    { type, category, severity, source_application, source_type, sd_id,
+      title, description, source_id, priority, priority_reasoning },
+    enrichedMetadata,
+    dedupHash,
+  );
 
   const { data, error } = await supabase
     .from('feedback')
-    .insert({
-      type,
-      category,
-      status: 'new',
-      severity,
-      source_application,
-      source_type,
-      title: cappedTitle,
-      description,
-      sd_id, // canonical column name per database-agent C-DB-2 (NOT related_sd_id)
-      metadata: {
-        ...enrichedMetadata,
-        dedup_hash: dedupHash,
-        emitted_at: new Date().toISOString(),
-      },
-    })
+    .insert(row)
     .select('id')
     .single();
 
@@ -162,33 +218,153 @@ export async function emitFeedback({
     throw new Error(`emitFeedback: INSERT failed: ${error.message}`);
   }
 
-  // SD-LEO-INFRA-DEDICATED-SECURITY-AUDIT-001 PA-5 dual-write: when feature flag
-  // enabled and this is a capability-suppression event, ALSO write to
-  // security_audit_events. Failures here do NOT block the feedback write
-  // (already returned id); they're logged via stderr for the integrity auditor.
-  const dualWriteEnabled = process.env.SECURITY_AUDIT_DUAL_WRITE_PA5 === 'true';
-  const isCapSuppression = metadata?.event_type === 'capability_suppression' || dedup_key?.startsWith('capability-suppression');
-  if (dualWriteEnabled && isCapSuppression) {
-    try {
-      await writeAuditEvent({
-        supabase,
-        event_type: 'capability_suppression',
-        severity: severity === 'critical' ? 'critical' : 'warning',
-        source_agent: 'lib/governance/emit-feedback',
-        source_module_path: 'lib/governance/emit-feedback.js',
-        sd_id,
-        event_payload: {
-          feedback_id: data.id,
-          dedup_key,
-          suppressed_layers: metadata?.suppressed_layers || [],
-          suppression_reason: metadata?.suppression_reason || description?.slice(0, 200) || 'unspecified',
-        },
-        pat_pattern_id: metadata?.pat_pattern_id || null,
-      });
-    } catch (auditErr) {
-      console.error(`[emit-feedback] PA-5 dual-write to security_audit_events failed (non-blocking): ${auditErr.message}`);
-    }
-  }
+  await _maybePa5DualWrite({
+    supabase, metadata, dedup_key, severity, sd_id, description, feedbackId: data.id,
+  });
 
   return { id: data.id, deduped: false };
+}
+
+/**
+ * SD-LEO-INFRA-DEDICATED-SECURITY-AUDIT-001 PA-5 dual-write: when feature flag
+ * enabled and this is a capability-suppression event, ALSO write to
+ * security_audit_events. Failures here do NOT block the feedback write
+ * (already returned id); they're logged via stderr for the integrity auditor.
+ *
+ * Extracted from emitFeedback (SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-2)
+ * so emitFeedbackBatch can reuse identical PA-5 semantics per-item.
+ *
+ * @private
+ */
+async function _maybePa5DualWrite({ supabase, metadata, dedup_key, severity, sd_id, description, feedbackId }) {
+  const dualWriteEnabled = process.env.SECURITY_AUDIT_DUAL_WRITE_PA5 === 'true';
+  const isCapSuppression = metadata?.event_type === 'capability_suppression' || dedup_key?.startsWith('capability-suppression');
+  if (!dualWriteEnabled || !isCapSuppression) return;
+  try {
+    await writeAuditEvent({
+      supabase,
+      event_type: 'capability_suppression',
+      severity: severity === 'critical' ? 'critical' : 'warning',
+      source_agent: 'lib/governance/emit-feedback',
+      source_module_path: 'lib/governance/emit-feedback.js',
+      sd_id,
+      event_payload: {
+        feedback_id: feedbackId,
+        dedup_key,
+        suppressed_layers: metadata?.suppressed_layers || [],
+        suppression_reason: metadata?.suppression_reason || description?.slice(0, 200) || 'unspecified',
+      },
+      pat_pattern_id: metadata?.pat_pattern_id || null,
+    });
+  } catch (auditErr) {
+    console.error(`[emit-feedback] PA-5 dual-write to security_audit_events failed (non-blocking): ${auditErr.message}`);
+  }
+}
+
+/**
+ * SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-2: bulk INSERT variant.
+ *
+ * Per-item dedup pre-check + single .insert(records) DB call (TR-3 perf).
+ * PA-5 dual-write fires per qualifying item AFTER the batch returns; failure
+ * of one PA-5 dual-write does NOT abort remaining items (matches singleton).
+ *
+ * Items array may be empty (returns clean shape without an INSERT call).
+ * Each item validated by emitFeedback contract: title + description required;
+ * priority validated against allowlist when present.
+ *
+ * @param {Object} args
+ * @param {Object} args.supabase - Supabase client
+ * @param {Array<Object>} args.items - Per-item args (same shape as emitFeedback args, minus supabase)
+ * @param {Object} [args.shared={}] - Defaults applied to each item; per-item field wins on conflict
+ * @returns {Promise<{ inserted: Array<string>, skipped: number, deduped: Array<string> }>}
+ *   inserted = newly created row ids; skipped = invalid/excluded items count;
+ *   deduped = existing row ids matched by dedup_hash
+ */
+export async function emitFeedbackBatch({ supabase, items = [], shared = {} } = {}) {
+  if (!supabase) throw new Error('emitFeedbackBatch: supabase client is required');
+  if (!Array.isArray(items)) throw new Error('emitFeedbackBatch: items must be an array');
+  if (items.length === 0) return { inserted: [], skipped: 0, deduped: [] };
+
+  // Resolve auto-fill once (per batch, not per item) — cheap + matches singleton semantics.
+  const sharedAutoSdKey = (!shared?.metadata?.deferred_from_sd_key && items.some(i => !i?.metadata?.deferred_from_sd_key))
+    ? await _autoFillDeferredFromSdKey(supabase)
+    : null;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const toInsert = [];
+  const dualWriteContexts = []; // captured per-item for PA-5 loop after batch
+  const deduped = [];
+  let skipped = 0;
+
+  for (let idx = 0; idx < items.length; idx++) {
+    const raw = items[idx] ?? {};
+    // shared fields merge under per-item (per-item wins on conflict per TR-3 spec)
+    const item = { ...shared, ...raw, metadata: { ...(shared.metadata || {}), ...(raw.metadata || {}) } };
+
+    if (!item.title || !item.description) {
+      throw new Error(`emitFeedbackBatch: BATCH_ITEM_INVALID:${idx} (title and description required)`);
+    }
+    _validatePriority(item.priority);
+
+    const enrichedMetadata = { ...item.metadata };
+    if (!enrichedMetadata.deferred_from_sd_key && sharedAutoSdKey) {
+      enrichedMetadata.deferred_from_sd_key = sharedAutoSdKey;
+    }
+
+    const dedupHash = crypto
+      .createHash('sha256')
+      .update(`${today}::${item.description}::${item.dedup_key || ''}`)
+      .digest('hex');
+
+    const category = item.category ?? 'harness_backlog';
+    const { data: existing } = await supabase
+      .from('feedback')
+      .select('id')
+      .eq('category', category)
+      .eq('metadata->>dedup_hash', dedupHash)
+      .maybeSingle();
+    if (existing) {
+      deduped.push(existing.id);
+      continue;
+    }
+
+    const args = {
+      type: item.type ?? 'enhancement',
+      category,
+      severity: item.severity ?? 'medium',
+      source_application: item.source_application ?? 'EHG_Engineer',
+      source_type: item.source_type ?? 'manual_feedback',
+      sd_id: item.sd_id ?? null,
+      title: item.title,
+      description: item.description,
+      source_id: item.source_id ?? null,
+      priority: item.priority ?? null,
+      priority_reasoning: item.priority_reasoning ?? null,
+    };
+    toInsert.push(_buildRowObject(args, enrichedMetadata, dedupHash));
+    dualWriteContexts.push({
+      metadata: item.metadata, dedup_key: item.dedup_key, severity: args.severity,
+      sd_id: args.sd_id, description: item.description,
+    });
+  }
+
+  if (toInsert.length === 0) {
+    return { inserted: [], skipped, deduped };
+  }
+
+  const { data, error } = await supabase
+    .from('feedback')
+    .insert(toInsert)
+    .select('id');
+  if (error) throw new Error(`emitFeedbackBatch: INSERT failed: ${error.message}`);
+
+  const insertedIds = (data || []).map(r => r.id);
+
+  // PA-5 dual-write per qualifying item; per-item failure logged but does NOT abort
+  for (let i = 0; i < dualWriteContexts.length; i++) {
+    const ctx = dualWriteContexts[i];
+    await _maybePa5DualWrite({ supabase, ...ctx, feedbackId: insertedIds[i] });
+  }
+
+  return { inserted: insertedIds, skipped, deduped };
 }

--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -3,6 +3,9 @@
  * Extracted from retro.js for modularity
  */
 
+// SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-4: route bulk INSERT through canonical helper
+import { emitFeedbackBatch } from '../../governance/emit-feedback.js';
+
 /**
  * Check if a VALID completion retrospective already exists for this SD
  *
@@ -396,39 +399,45 @@ export async function insertFeedbackForFutureEnhancements(supabase, enhancements
     return { inserted: 0, skipped };
   }
 
-  const records = newEnhancements.map(e => ({
+  // SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-4: route through canonical helper.
+  // dedup_key is per-item (`retro:${retroId}:${idx}`) so the helper's hash-based
+  // dedup complements (does not replace) the title-set dedup above.
+  const items = newEnhancements.map((e, idx) => ({
     type: 'enhancement',
     source_application: 'engineer',
     source_type: 'retrospective',
     source_id: retroId,
     title: e.enhancement?.substring(0, 200) || 'Future enhancement opportunity',
     description: JSON.stringify({ ...e, captured_from_retro: retroId }),
-    status: 'new',
     priority: e.effort === 'low' ? 'high' : 'medium',
-    sd_id: sdId
+    sd_id: sdId,
+    dedup_key: `retro:${retroId}:${idx}`,
   }));
 
-  const { data: inserted, error } = await supabase.from('feedback').insert(records).select('id');
-  if (error) {
-    console.log(`   ⚠️ Failed to insert feedback: ${error.message}`);
-    return { inserted: 0, skipped: existingTitles.size, error: error.message };
+  let result;
+  try {
+    result = await emitFeedbackBatch({ supabase, items });
+  } catch (err) {
+    console.log(`   ⚠️ Failed to insert feedback: ${err.message}`);
+    return { inserted: 0, skipped: existingTitles.size, error: err.message };
   }
 
-  const skipped = enhancements.length - newEnhancements.length;
-  console.log(`   ✅ Inserted ${records.length} future enhancement(s) into feedback inbox`);
+  const titleSetSkipped = enhancements.length - newEnhancements.length;
+  const skipped = titleSetSkipped + result.deduped.length;
+  console.log(`   ✅ Inserted ${result.inserted.length} future enhancement(s) into feedback inbox`);
   if (skipped > 0) {
     console.log(`   ℹ️  Skipped ${skipped} duplicate(s)`);
   }
 
-  // Fire-and-forget: quality processing and AI triage for inserted items
-  const insertedIds = (inserted || []).map(r => r.id);
-  if (insertedIds.length > 0) {
-    triggerQualityAndTriagePipeline(supabase, insertedIds).catch(err => {
+  // Fire-and-forget: quality processing and AI triage for ONLY newly inserted items
+  // (NOT for hash-deduped or title-set-deduped). Preserves AC-15 contract.
+  if (result.inserted.length > 0) {
+    triggerQualityAndTriagePipeline(supabase, result.inserted).catch(err => {
       console.log(`   ⚠️ Non-blocking: quality/triage pipeline error: ${err.message}`);
     });
   }
 
-  return { inserted: records.length, skipped };
+  return { inserted: result.inserted.length, skipped };
 }
 
 /**

--- a/lib/uat/result-recorder.js
+++ b/lib/uat/result-recorder.js
@@ -26,6 +26,8 @@ import {
 import { GRADE } from '../standards/grade-scale.js';
 // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven source_application
 import { getCurrentVenture } from '../venture-resolver.js';
+// SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-3: route through canonical helper
+import { emitFeedback } from '../governance/emit-feedback.js';
 
 let supabase = null;
 
@@ -293,25 +295,27 @@ async function recordDefect(testRunId, scenario, details) {
   };
   const priorityResult = calculatePriority(preliminaryRecord);
 
-  // SD-QUALITY-INT-001: Write to unified feedback table
+  // SD-QUALITY-INT-001 + SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-3: write via canonical helper
+  // dedup_key disambiguates concurrent runs of same scenario across testRunIds (PRD AC-12).
   try {
-    await db.from('feedback').insert({
+    await emitFeedback({
+      supabase: db,
       type: 'issue',
       title: `UAT Failure: ${scenario.title}`,
       description: `${errorMessage}\n\n**Scenario Details:**\n- Given: ${scenario.given || 'N/A'}\n- When: ${scenario.when || 'N/A'}\n- Then: ${scenario.then || 'N/A'}`,
-      severity: severity,
+      severity,
       priority: priorityResult.priority,
       priority_reasoning: priorityResult.reasoning,
-      status: 'new',  // Valid status per schema
       source_type: 'uat_failure',
       source_application: getCurrentVenture(),
+      source_id: scenario.sourceId,
+      dedup_key: `uat-failure:${scenario.id || ''}:${testRunId || ''}`,
       metadata: {
         test_run_id: testRunId,
         scenario_id: scenario.id,
         scenario_title: scenario.title,
         failure_type: failureType,
         estimated_loc: estimatedLOC,
-        source_id: scenario.sourceId,
         source: scenario.source,
         // SD-LEO-ENH-UAT-DOM-CAPTURE-001: DOM capture metadata
         dom_capture_offered: domCaptureOffered,
@@ -330,8 +334,6 @@ async function recordDefect(testRunId, scenario, details) {
         } : null,
         route_context: scenario.routeContext || null
       },
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
     });
     console.log('   Recorded UAT failure to feedback table');
 

--- a/scripts/audit-completed-sd-db-content-parity.js
+++ b/scripts/audit-completed-sd-db-content-parity.js
@@ -18,6 +18,8 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { validateDbContentParity } from '../scripts/modules/handoff/gates/db-content-parity-gate.js';
+// SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-5: route through canonical helper
+import { emitFeedback } from '../lib/governance/emit-feedback.js';
 
 function parseArgs(argv) {
   const flags = { since: null, sdId: null, dryRun: false };
@@ -57,15 +59,15 @@ export async function runAudit({ supabase, since, sdId, dryRun, auditRunId }) {
       .map((m) => `${m.table}/${JSON.stringify(m.row_filter)}: ${m.column} expected=${JSON.stringify(m.expected)} actual=${JSON.stringify(m.actual)}`)
       .join('; ');
     const title = `DB content parity gap: ${sd.sd_key}`;
-    await supabase.from('feedback').insert({
+    // SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-5: canonical helper invocation.
+    // dedup_key includes auditRunId so cross-audit-run dedup is intentional (re-runs DO insert).
+    await emitFeedback({
+      supabase,
       type: 'enhancement',
-      category: 'harness_backlog',
-      status: 'new',
       severity: 'medium',
-      source_application: 'EHG_Engineer',
-      source_type: 'manual_feedback',
-      title: title.length > 120 ? title.slice(0, 117) + '...' : title,
+      title,
       description: `Audit detected ${result.mismatches.length} content-parity mismatch(es): ${summary}`,
+      dedup_key: `audit-content-parity:${sd.sd_key}:${auditRunId}`,
       metadata: {
         logged_via: 'audit-completed-sd-db-content-parity.js',
         deferred_from_sd_key: sd.sd_key,

--- a/tests/unit/audit/db-content-parity-audit.test.js
+++ b/tests/unit/audit/db-content-parity-audit.test.js
@@ -33,11 +33,35 @@ function makeAuditClient({ sds, rowsByTable = {} }) {
       return queryObj;
     }
     if (name === 'feedback') {
+      // SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-5: emitFeedback dedup-check
+      // chain support — `.select('id').eq('category', x).eq('metadata->>dedup_hash', h).maybeSingle()`.
+      // Returns {data: null} so the INSERT branch proceeds.
+      const insertChain = (row) => {
+        const single = async () => ({ data: { id: `fb-${calls.feedbackInserts.length + 1}` }, error: null });
+        return { select: () => ({ single }), then: (cb) => cb({ data: { id: 'inserted' }, error: null }) };
+      };
       return {
-        insert: async (row) => {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({ maybeSingle: async () => ({ data: null }) }),
+          }),
+        }),
+        insert: (row) => {
           calls.feedbackInserts.push(row);
-          return { error: null };
+          return insertChain(row);
         },
+      };
+    }
+    if (name === 'v_active_sessions') {
+      // emitFeedback FR-2 auto-fill lookup; return empty so it no-ops in tests.
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              not: async () => ({ data: [], error: null }),
+            }),
+          }),
+        }),
       };
     }
     if (name === 'sd_verification_results') {

--- a/tests/unit/emit-feedback-bypass-static-guard.test.js
+++ b/tests/unit/emit-feedback-bypass-static-guard.test.js
@@ -1,0 +1,93 @@
+/**
+ * SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-6
+ *
+ * Static-guard regression test: enforce that lib/governance/emit-feedback.js
+ * remains the canonical INSERT writer for the feedback table.
+ *
+ * Pattern: runs verifyHelperCoverage on lib/+scripts/ and asserts the bypass
+ * sites set EXACTLY EQUALS the documented OOS allowlist (5 entries).
+ *
+ * If a NEW bypass appears (or an OOS line drifts), this test fails — forcing
+ * either the new caller to migrate to emitFeedback OR an explicit allowlist
+ * update via PR review (TR-5: line-tuple matching is intentional).
+ *
+ * Allowlist update procedure:
+ *   1. If a file moved or a line shifted, update the OOS_ALLOWLIST entry.
+ *   2. If a NEW bypass site is intentionally OOS (template string, one-off
+ *      script, UPDATE-axis), document the rationale in a code comment AND
+ *      add to OOS_ALLOWLIST.
+ *   3. If a NEW bypass site is in scope, migrate the caller to emitFeedback
+ *      / emitFeedbackBatch instead of adding to allowlist.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { verifyHelperCoverage } from '../../scripts/lib/lead-precheck-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+
+/**
+ * Documented OOS bypass sites as (path, line) tuples. Match by path AND line.
+ * Path uses forward slashes (cross-platform; verifyHelperCoverage normalizes).
+ *
+ * Each entry MUST have a `reason` explaining why it is NOT in scope for
+ * canonical-helper migration. Reason is non-functional — included for the
+ * human reviewing a future allowlist change.
+ */
+const OOS_ALLOWLIST = [
+  { path: 'lib/eva/bridge/replit-format-strategies.js', line: 570, reason: 'lines.push of source-template literal — emits sample code into Replit prompt; not a real DB call.' },
+  { path: 'lib/eva/bridge/replit-prompt-formatter.js',  line: 179, reason: 'inside markdown template string emitted to Replit setup instructions; not a real DB call.' },
+  { path: 'lib/quality/assist-engine.js',               line: 444, reason: 'UPDATE not INSERT; emitFeedback is INSERT-only canonical surface. UPDATE bypass requires separate canonical pattern (deferred — see SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 follow-up scope).' },
+  { path: 'scripts/one-off/migrate-harness-backlog-to-feedback.mjs', line: 205, reason: 'one-off legacy data-migration script (archived after run).' },
+  { path: 'scripts/one-off/_plan-insert-prd-sd-leo-infra-lead-empirical-precheck-001.mjs', line: 315, reason: 'PRD body markdown text (not executable code).' },
+];
+
+function tupleKey(s) { return `${s.path}:${s.line}`; }
+
+describe('FR-6: emit-feedback canonical-helper bypass guard', () => {
+  it('bypass_sites set EQUALS the documented OOS allowlist (path+line tuple match)', async () => {
+    const result = await verifyHelperCoverage({
+      helperFile: 'lib/governance/emit-feedback.js',
+      table: 'feedback',
+      repoRoot: REPO_ROOT,
+      includeDirs: ['lib', 'scripts'],
+    });
+
+    const actual = (result.evidence?.bypass_sites || []).map(s => ({ path: s.path, line: s.line }));
+    const actualKeys = new Set(actual.map(tupleKey));
+    const expectedKeys = new Set(OOS_ALLOWLIST.map(tupleKey));
+
+    const unexpected = [...actualKeys].filter(k => !expectedKeys.has(k));
+    const missing = [...expectedKeys].filter(k => !actualKeys.has(k));
+
+    if (unexpected.length || missing.length) {
+      // Enrich diagnostics with snippets for unexpected entries
+      const snippetMap = new Map((result.evidence?.bypass_sites || []).map(s => [tupleKey(s), s.snippet]));
+      const unexpectedDetail = unexpected.map(k => `  + UNEXPECTED ${k}\n      snippet: ${snippetMap.get(k) || '(n/a)'}`).join('\n');
+      const missingDetail   = missing.map(k => `  - MISSING    ${k} (allowlist entry no longer found — was the file renamed or the line shifted?)`).join('\n');
+      const msg = [
+        'emit-feedback bypass-site set does not match OOS allowlist.',
+        '',
+        unexpectedDetail || '',
+        missingDetail || '',
+        '',
+        'See FR-6 docstring in this file for allowlist update procedure.',
+      ].filter(Boolean).join('\n');
+      throw new Error(msg);
+    }
+    expect(actualKeys.size).toBe(expectedKeys.size);
+  });
+
+  it('canonical helper has at least 2 known importers (lifecycle-sd-bridge + log-harness-bug)', async () => {
+    const result = await verifyHelperCoverage({
+      helperFile: 'lib/governance/emit-feedback.js',
+      table: 'feedback',
+      repoRoot: REPO_ROOT,
+      includeDirs: ['lib', 'scripts'],
+    });
+    expect((result.evidence?.canonical_imports || []).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/emit-feedback-extensions.test.js
+++ b/tests/unit/emit-feedback-extensions.test.js
@@ -1,0 +1,226 @@
+/**
+ * SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-7
+ *
+ * Pin extended emitFeedback API contract:
+ *   - FR-1: priority / priority_reasoning / source_id pass-through
+ *   - TR-2: dedup_hash composition guard (source_id MUST NOT join hash)
+ *   - TR-4: priority enum validation throws INVALID_PRIORITY:<value>
+ *   - FR-2: emitFeedbackBatch happy path / dedup / empty / invalid / PA-5 dual-write
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the audit-events-emitter BEFORE importing emit-feedback.js
+const writeAuditEventMock = vi.fn();
+vi.mock('../../lib/security/audit-events-emitter.js', () => ({
+  writeAuditEvent: (...args) => writeAuditEventMock(...args),
+}));
+
+const { emitFeedback, emitFeedbackBatch, ALLOWED_PRIORITIES } = await import('../../lib/governance/emit-feedback.js');
+
+// --- mock supabase client factory ---
+function makeMockSupabase({ existingDedupHash = null, insertReturn = null, insertError = null } = {}) {
+  const inserts = [];
+  const insertCalls = []; // record full payloads
+  const dedupLookups = [];
+
+  const client = {
+    from(_table) {
+      return {
+        select(_cols) {
+          return {
+            eq: (col, val) => ({
+              eq: (col2, val2) => ({
+                maybeSingle: async () => {
+                  dedupLookups.push({ col, val, col2, val2 });
+                  if (existingDedupHash && val2 === existingDedupHash) {
+                    return { data: { id: 'existing-row-id' } };
+                  }
+                  return { data: null };
+                },
+              }),
+              not: () => ({ then: async () => ({ data: [], error: null }) }),
+            }),
+          };
+        },
+        insert(payload) {
+          insertCalls.push(payload);
+          if (Array.isArray(payload)) {
+            inserts.push(...payload);
+            return {
+              select: () => ({
+                then: (cb) => cb({ data: insertReturn ?? payload.map((_, i) => ({ id: `new-id-${i}` })), error: insertError }),
+              }),
+            };
+          }
+          inserts.push(payload);
+          return {
+            select: () => ({
+              single: async () => ({ data: insertReturn ?? { id: 'new-row-id' }, error: insertError }),
+            }),
+          };
+        },
+      };
+    },
+    inserts,
+    insertCalls,
+    dedupLookups,
+  };
+  return client;
+}
+
+beforeEach(() => {
+  writeAuditEventMock.mockReset();
+  delete process.env.SECURITY_AUDIT_DUAL_WRITE_PA5;
+  process.env.AUTO_FILL_DEFERRED_FROM_SD_KEY = '0'; // disable auto-fill in tests
+});
+
+describe('FR-1: emitFeedback pass-through fields', () => {
+  it('passes priority + priority_reasoning + source_id to INSERT row', async () => {
+    const sb = makeMockSupabase();
+    await emitFeedback({
+      supabase: sb,
+      title: 't', description: 'd',
+      priority: 'high',
+      priority_reasoning: 'UAT failure',
+      source_id: 'scenario-42',
+      dedup_key: 'k1',
+    });
+    const row = sb.inserts[0];
+    expect(row.priority).toBe('high');
+    expect(row.priority_reasoning).toBe('UAT failure');
+    expect(row.source_id).toBe('scenario-42');
+  });
+
+  it('omits optional fields from INSERT when not provided (additive backward-compat)', async () => {
+    const sb = makeMockSupabase();
+    await emitFeedback({ supabase: sb, title: 't', description: 'd' });
+    const row = sb.inserts[0];
+    expect(row).not.toHaveProperty('priority');
+    expect(row).not.toHaveProperty('priority_reasoning');
+    expect(row).not.toHaveProperty('source_id');
+  });
+});
+
+describe('TR-4: priority enum validation', () => {
+  it('throws INVALID_PRIORITY:HIGH on uppercase', async () => {
+    const sb = makeMockSupabase();
+    await expect(
+      emitFeedback({ supabase: sb, title: 't', description: 'd', priority: 'HIGH' }),
+    ).rejects.toThrow(/INVALID_PRIORITY:HIGH/);
+  });
+
+  it('accepts all 4 allowed values', async () => {
+    for (const p of ['critical', 'high', 'medium', 'low']) {
+      const sb = makeMockSupabase();
+      await emitFeedback({ supabase: sb, title: 't', description: 'd', priority: p, dedup_key: `k-${p}` });
+      expect(sb.inserts[0].priority).toBe(p);
+    }
+  });
+
+  it('exposes ALLOWED_PRIORITIES as a frozen Set', () => {
+    expect(ALLOWED_PRIORITIES instanceof Set).toBe(true);
+    expect(Object.isFrozen(ALLOWED_PRIORITIES)).toBe(true);
+    expect(ALLOWED_PRIORITIES.size).toBe(4);
+  });
+});
+
+describe('TR-2: dedup_hash composition guard (source_id MUST NOT join hash)', () => {
+  it('produces identical dedup_hash when only source_id varies', async () => {
+    const sb1 = makeMockSupabase();
+    const sb2 = makeMockSupabase();
+    await emitFeedback({ supabase: sb1, title: 't', description: 'd', dedup_key: 'k', source_id: 'A' });
+    await emitFeedback({ supabase: sb2, title: 't', description: 'd', dedup_key: 'k', source_id: 'B' });
+    const hash1 = sb1.inserts[0].metadata.dedup_hash;
+    const hash2 = sb2.inserts[0].metadata.dedup_hash;
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces identical dedup_hash when only priority varies', async () => {
+    const sb1 = makeMockSupabase();
+    const sb2 = makeMockSupabase();
+    await emitFeedback({ supabase: sb1, title: 't', description: 'd', dedup_key: 'k', priority: 'high' });
+    await emitFeedback({ supabase: sb2, title: 't', description: 'd', dedup_key: 'k', priority: 'low' });
+    expect(sb1.inserts[0].metadata.dedup_hash).toBe(sb2.inserts[0].metadata.dedup_hash);
+  });
+});
+
+describe('FR-2: emitFeedbackBatch', () => {
+  it('happy path inserts N items in single .insert() call', async () => {
+    const sb = makeMockSupabase();
+    const items = [
+      { title: 't1', description: 'd1', dedup_key: 'k1' },
+      { title: 't2', description: 'd2', dedup_key: 'k2' },
+      { title: 't3', description: 'd3', dedup_key: 'k3' },
+    ];
+    const result = await emitFeedbackBatch({ supabase: sb, items });
+    expect(result.inserted).toHaveLength(3);
+    expect(result.skipped).toBe(0);
+    expect(result.deduped).toEqual([]);
+    // Single .insert() call with array payload
+    const arrayCalls = sb.insertCalls.filter(p => Array.isArray(p));
+    expect(arrayCalls).toHaveLength(1);
+    expect(arrayCalls[0]).toHaveLength(3);
+  });
+
+  it('returns clean shape without INSERT call when items=[]', async () => {
+    const sb = makeMockSupabase();
+    const result = await emitFeedbackBatch({ supabase: sb, items: [] });
+    expect(result).toEqual({ inserted: [], skipped: 0, deduped: [] });
+    expect(sb.insertCalls).toEqual([]);
+  });
+
+  it('throws BATCH_ITEM_INVALID:<idx> for missing title or description', async () => {
+    const sb = makeMockSupabase();
+    await expect(
+      emitFeedbackBatch({ supabase: sb, items: [{ title: 't', description: 'd' }, { title: '' }] }),
+    ).rejects.toThrow(/BATCH_ITEM_INVALID:1/);
+  });
+
+  it('throws when supabase missing', async () => {
+    await expect(emitFeedbackBatch({ items: [] })).rejects.toThrow(/supabase client is required/);
+  });
+
+  it('throws when items is not an array', async () => {
+    const sb = makeMockSupabase();
+    await expect(emitFeedbackBatch({ supabase: sb, items: 'not-an-array' })).rejects.toThrow(/items must be an array/);
+  });
+
+  it('shared fields apply to each item with per-item override', async () => {
+    const sb = makeMockSupabase();
+    const items = [
+      { title: 't1', description: 'd1', dedup_key: 'k1' },
+      { title: 't2', description: 'd2', dedup_key: 'k2', severity: 'high' },
+    ];
+    await emitFeedbackBatch({ supabase: sb, items, shared: { severity: 'medium', source_application: 'engineer' } });
+    expect(sb.inserts[0].severity).toBe('medium');
+    expect(sb.inserts[0].source_application).toBe('engineer');
+    expect(sb.inserts[1].severity).toBe('high'); // per-item wins
+    expect(sb.inserts[1].source_application).toBe('engineer');
+  });
+
+  it('PA-5 dual-write fires per qualifying item in batch when env flag set', async () => {
+    process.env.SECURITY_AUDIT_DUAL_WRITE_PA5 = 'true';
+    const sb = makeMockSupabase({ insertReturn: [{ id: 'id-0' }, { id: 'id-1' }, { id: 'id-2' }] });
+    const items = [
+      { title: 't1', description: 'd1', dedup_key: 'k1', metadata: { event_type: 'capability_suppression' } },
+      { title: 't2', description: 'd2', dedup_key: 'k2' }, // not qualifying
+      { title: 't3', description: 'd3', dedup_key: 'k3', metadata: { event_type: 'capability_suppression' } },
+    ];
+    await emitFeedbackBatch({ supabase: sb, items });
+    expect(writeAuditEventMock).toHaveBeenCalledTimes(2);
+    // Confirm feedback_id arg matches batch insert id ordering
+    expect(writeAuditEventMock.mock.calls[0][0].event_payload.feedback_id).toBe('id-0');
+    expect(writeAuditEventMock.mock.calls[1][0].event_payload.feedback_id).toBe('id-2');
+  });
+
+  it('PA-5 dual-write does NOT fire when env flag not set', async () => {
+    delete process.env.SECURITY_AUDIT_DUAL_WRITE_PA5;
+    const sb = makeMockSupabase();
+    const items = [
+      { title: 't1', description: 'd1', dedup_key: 'k1', metadata: { event_type: 'capability_suppression' } },
+    ];
+    await emitFeedbackBatch({ supabase: sb, items });
+    expect(writeAuditEventMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Migrate 3 production INSERT writers (`uat/result-recorder.js:298`, `sub-agents/retro/db-operations.js:411`, `audit-completed-sd-db-content-parity.js:60`) to the canonical `lib/governance/emit-feedback.js` helper. Closes the 17th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
- Extend `emitFeedback` with optional `priority` / `priority_reasoning` / `source_id` pass-through fields plus `ALLOWED_PRIORITIES` Set + app-level `_validatePriority` (TR-4). Extract `_buildRowObject` + `_maybePa5DualWrite` helpers shared with new bulk path.
- Add new `emitFeedbackBatch({supabase, items, shared})` for bulk INSERT — per-item dedup pre-check, single `.insert(records)` DB call, per-item PA-5 dual-write loop, returns `{inserted, skipped, deduped}`.
- Add `tests/unit/emit-feedback-extensions.test.js` (15 cases) + `tests/unit/emit-feedback-bypass-static-guard.test.js` (2 cases). Static-guard pins bypass_sites set EQUALS the documented OOS allowlist (5 entries) by `(path, line)` tuple via `verifyHelperCoverage`.
- Bypass-site count: **8 → 5** (matches OOS allowlist exactly). Canonical importer count: **2 → 5** (+3 new importers verifying migration completeness).

## Critical invariant (TR-2)
`dedup_hash` composition stays `sha256(today::description::dedup_key)`. `source_id`, `priority`, `priority_reasoning` are pass-through ONLY and MUST NOT join the hash. Pinned by TS-2 unit test (asserts hash equality across 2 calls differing only in source_id).

## Test plan
- [x] 17 new vitest cases PASS
- [x] 17 existing emit-feedback tests PASS (zero regression)
- [x] 4 migrated audit-test cases PASS after mock-shape extension
- [x] `lib/eva/*` baseline: 123 failed (matches documented baseline; ZERO new failures)
- [x] Full corpus stash bisect: -16 net failure improvement vs origin/main
- [x] Static-guard test enforces 5-entry OOS allowlist with line-tuple matching (TR-5)
- [ ] Post-merge: resolve-feedback hook auto-resolves feedback `4d3b3680` and harness backlog `18c57c39`

## Sub-agent evidence
- LEAD validation `6f5824b8` PASS@93%
- LEAD risk `3b8ec360` MEDIUM proceed (R-5 security primary; addressed via TR-2)
- PLAN database `41d589fd`, risk `298dbec8`, stories `b0ac824c` PASS
- PLAN testing-plan `cd7e217b` PASS@90%
- EXEC testing-exec `d27c11ad` PASS@95%
- PLAN validation (post-EXEC) `e3834fae` PASS@91%
- Retrospective `14cf8c48` PUBLISHED qs=100

Closes feedback `4d3b3680-c2ab-4f08-80a1-2cb12d66982f`
Closes harness backlog `18c57c39-a7cf-4752-a7e0-3b3dc74c3d71`

🤖 Generated with [Claude Code](https://claude.com/claude-code)