### PR TITLE
fix(QF-20260511-228): stale-branch detection at session-start hook

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -8,6 +8,6 @@
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-05-11T02:10:51.534Z",
-  "lastUpdatedAt": "2026-05-11T02:10:51.538Z"
+  "clearedAt": "2026-05-11T10:14:15.308Z",
+  "lastUpdatedAt": "2026-05-11T10:14:15.322Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,8 +1,9 @@
 {
-  "sdKey": "QF-20260509-650",
-  "expectedBranch": "qf/QF-20260509-650",
-  "createdAt": "2026-05-11T01:08:44.082Z",
+  "sdKey": "QF-20260511-228",
+  "workType": "QF",
+  "workKey": "QF-20260511-228",
+  "expectedBranch": "qf/QF-20260511-228",
+  "createdAt": "2026-05-11T10:05:31.255Z",
   "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
-  "baseRef": "origin/main"
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/hooks/__tests__/concurrent-session-worktree.test.js
+++ b/scripts/hooks/__tests__/concurrent-session-worktree.test.js
@@ -191,6 +191,49 @@ describe('getActiveDbClaims', () => {
   });
 });
 
+describe('checkBranchFreshness (QF-20260511-228 — closes feedback acd4e5ab)', () => {
+  // Early-return paths don't shell out, so they're safe to exercise behaviorally.
+  // The git-touching path is asserted via static-guard at the bottom of this block.
+  let checkBranchFreshness;
+  beforeEach(() => { ({ checkBranchFreshness } = loadHookExports()); });
+
+  it('returns null when branch is "main"', () => {
+    expect(checkBranchFreshness('main')).toBeNull();
+  });
+  it('returns null when branch is "unknown" (getBranch fallback)', () => {
+    expect(checkBranchFreshness('unknown')).toBeNull();
+  });
+  it('returns null for empty/missing branch', () => {
+    expect(checkBranchFreshness('')).toBeNull();
+    expect(checkBranchFreshness(undefined)).toBeNull();
+    expect(checkBranchFreshness(null)).toBeNull();
+  });
+
+  it('static-guard: hook source contains the expected git rev-list and warning shape', () => {
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    // The function must use rev-list against origin/main (not e.g. main, not @{upstream})
+    expect(src).toMatch(/git rev-list --count HEAD\.\.origin\/main/);
+    // Threshold must be configurable via STALE_BRANCH_WARN_THRESHOLD env, default 10
+    expect(src).toMatch(/STALE_BRANCH_WARN_THRESHOLD\b/);
+    expect(src).toMatch(/\|\|\s*['"]10['"]/);
+    // Loud warning banner must be emitted
+    expect(src).toMatch(/STALE BRANCH WARNING/);
+    // Telemetry event name must match dotted convention used elsewhere
+    expect(src).toMatch(/session\.stale_branch_warning/);
+  });
+
+  it('static-guard: main() wires checkBranchFreshness after getBranch()', () => {
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    // Anchor on `const mySessionId = getCurrentSessionId()` (unique to main())
+    // to skip the unrelated `const branch = getBranch()` inside detectWorkType().
+    const idx = src.indexOf('const mySessionId = getCurrentSessionId()');
+    expect(idx).toBeGreaterThan(0);
+    const slice = src.slice(idx, idx + 600);
+    expect(slice).toMatch(/const branch = getBranch\(\)/);
+    expect(slice).toMatch(/checkBranchFreshness\s*\(\s*branch\s*\)/);
+  });
+});
+
 // ─── Mock supabase client ───────────────────────────────────────────────────
 
 function mockSupabase({ sdRows = [], sdError = null, sessionRows = [] } = {}) {

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -117,6 +117,36 @@ function getBranch() {
 }
 
 /**
+ * QF-20260511-228 (closes feedback acd4e5ab) — Stale-branch detection.
+ * Warns when HEAD is significantly behind origin/main, preventing silent
+ * regression of already-shipped fixes (4× witnessed: QF-442/QF-699/QF-818
+ * + 12-commit-behind session that filed the feedback). Threshold via
+ * STALE_BRANCH_WARN_THRESHOLD env (default 10).
+ */
+function checkBranchFreshness(branch) {
+  if (!branch || branch === 'main' || branch === 'unknown') return null;
+  try {
+    const out = execSync('git rev-list --count HEAD..origin/main', {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']
+    }).trim();
+    const behind = parseInt(out, 10);
+    if (!Number.isFinite(behind)) return null;
+    const threshold = parseInt(process.env.STALE_BRANCH_WARN_THRESHOLD || '10', 10);
+    if (behind > threshold) {
+      console.log('\n========================================');
+      console.log('  STALE BRANCH WARNING');
+      console.log('========================================');
+      console.log(`  Current branch: ${branch}`);
+      console.log(`  Behind origin/main by: ${behind} commit(s) (threshold ${threshold})`);
+      console.log(`  Suggestion: git pull origin main --ff-only  (or fresh worktree from main)`);
+      console.log('========================================\n');
+      logEvent('session.stale_branch_warning', { branch, commits_behind_main: behind, threshold });
+    }
+    return { behind, threshold, warned: behind > threshold };
+  } catch { return null; }
+}
+
+/**
  * Check if we are already inside a worktree
  */
 function isInsideWorktree() {
@@ -639,6 +669,9 @@ async function main() {
   const codebase = getCodebase();
   const branch = getBranch();
 
+  // QF-20260511-228 (closes feedback acd4e5ab): warn when on a stale branch
+  checkBranchFreshness(branch);
+
   // FR-1: Check for concurrent sessions
   const concurrent = await findConcurrentSessions(supabase, mySessionId, codebase, branch);
 
@@ -787,7 +820,7 @@ async function main() {
 // Test exports (used by scripts/hooks/__tests__/concurrent-session-worktree.test.js)
 // Gating `main()` behind `require.main === module` lets tests `require()` this
 // file without triggering the SessionStart side-effects.
-module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees };
+module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees, checkBranchFreshness };
 
 if (require.main === module) {
   // Run with timeout protection (hook has 5s timeout)


### PR DESCRIPTION
## Summary

- Adds `checkBranchFreshness()` to `scripts/hooks/concurrent-session-worktree.cjs` — warns loudly when HEAD is significantly behind `origin/main`, preventing silent regression of already-shipped fixes.
- Wired into `main()` after `getBranch()`. Threshold defaults to 10, override via `STALE_BRANCH_WARN_THRESHOLD` env.
- Closes feedback `acd4e5ab` (4× witnessed: QF-442 stderr leak, QF-699 stderr leak, QF-818 HARNESS BACKLOG DB-canonical reader, plus the 12-commit-behind session-start that filed the feedback). Pattern `PAT-LEO-INFRA-STALE-BRANCH-PHANTOM-REGRESSION-001`.

## Test plan

- [x] 18/18 vitest pass in `scripts/hooks/__tests__/concurrent-session-worktree.test.js` (13 prior + 5 new: early-return for main/unknown/empty branch + static-guard for `git rev-list --count HEAD..origin/main`, threshold env, warning banner, telemetry event, and main() wiring anchored on the unique `const mySessionId = getCurrentSessionId()` line)
- [x] Live smoke: `main` → `null`; QF branch at origin/main HEAD → `{behind:0, threshold:10, warned:false}`
- [x] Pre-existing baseline (rca-learning-ingestion, brand-variants, vision-scoring, virality_analysis) verified unrelated via `git stash` reproduction on clean origin/main

Closes feedback acd4e5ab

🤖 Generated with [Claude Code](https://claude.com/claude-code)