### PR TITLE
feat(SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B): Phase 2 — Decision Log DB + Friday Two-Way Integration

### DIFF
--- a/.claude/commands/eva-support.md
+++ b/.claude/commands/eva-support.md
@@ -56,19 +56,23 @@ If either is unset, exit with a clear one-line error naming the missing variable
 
 ## --task-id Invocation
 
-1. Fetch the subtask via `getTask(taskId)`.
-2. Fetch existing decision-log history via `listComments(taskId)` → `decision-log-formatter.parse()` for each comment, filter non-null, sort by `sequence`.
-3. Classify the subtask via `task-classifier.classify(subtask)`.
-4. Dispatch via `scripts/eva-support/_internal/dispatcher.js` `dispatch(flow, subtask, { history, operatorInput })`. The handler returns `{reply, decision_log_entry}`.
-5. Serialize the entry via `decision-log-formatter.serialize(entry)` and post as a Todoist comment via `todoist-client.postComment(taskId, content)`.
-6. Print to operator:
+> **Phase 2 wiring (SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B)**: decision-log entries are now persisted to `eva_support_decision_log` DB FIRST, then mirrored to Todoist. Friday meeting outcomes from `eva_friday_outcomes` are surfaced in the pushback context at invocation start. Research-flow LLM calls are cached in `eva_support_research_cache` (SHA-256 query hash, 7-day TTL).
+
+1. Surface any unconsumed Friday meeting outcomes via `lib/eva-support/friday-outcome-bridge.js` `surfacePending({ limit: 10 })` (CAS UPDATE consumed_at). Render via `renderPushbackMarkdown(rows)` and prepend to `operatorInput` as additional pushback context (or skip silently if empty). This step is fail-soft — never blocks the invocation.
+2. Fetch the subtask via `getTask(taskId)`.
+3. Fetch existing decision-log history. **Prefer the DB**: `decision-log-store.entriesForTask(taskId)` returns canonical envelopes. If the DB returns empty AND Todoist has comments, fall back to `listComments(taskId)` → `decision-log-formatter.parse()` (Phase 1 path; backfill not yet run).
+4. Classify the subtask via `task-classifier.classify(subtask)`.
+5. Dispatch via `scripts/eva-support/_internal/dispatcher.js` `dispatch(flow, subtask, { history, operatorInput, decisionLogStore: decisionLogStoreModule })`. The handler returns `{reply, decision_log_entry, db_persisted, cache?}`. **Important**: when `decisionLogStore` is injected, the DB write happens BEFORE the function returns — a thrown error here means the Todoist write MUST NOT proceed.
+6. If step 5 succeeded (no throw): serialize the entry via `decision-log-formatter.serialize(entry)` and post as a Todoist comment via `todoist-client.postComment(taskId, content)`. If the Todoist post fails, retry once with 1s backoff; on second failure, surface error to operator but leave the DB row in place — DB is canonical, Todoist is the human-readable mirror.
+7. Print to operator:
    ```
    FLOW: <flow>
    ----
    <reply>
    ----
-   Decision log entry #<sequence> written to Todoist task <taskId>.
+   Decision log entry #<sequence> persisted to DB <db_persisted> and posted to Todoist task <taskId>.
    ```
+   If the research flow returned a cache hit, also print `(cached — no LLM call this turn)`.
 
 ## memory dump Subcommand
 
@@ -88,6 +92,11 @@ If either is unset, exit with a clear one-line error naming the missing variable
 | `dispatch`, `getHandler` | `scripts/eva-support/_internal/dispatcher.js` |
 | `SYSTEM_PROMPT`, `OVERRIDE_TOKEN`, `FLOWS` | `scripts/eva-support/_internal/system-prompt.js` |
 | Per-flow handlers | `scripts/eva-support/{research,decision,draft,action-prep,platform,pure-human}.js` |
+| **Phase 2**: `insertEntry`, `recentEntries`, `entriesForTask` | `lib/eva-support/decision-log-store.js` |
+| **Phase 2**: `get`, `set`, `hashQuery`, `purgeBefore`, `purgeByQueryHash` | `lib/eva-support/research-cache.js` |
+| **Phase 2**: `surfacePending`, `writeOutcome`, `renderPushbackMarkdown` | `lib/eva-support/friday-outcome-bridge.js` |
+| **Phase 2**: schema-pin test | `tests/unit/eva-support/envelope-v1-schema-pin.test.js` |
+| **Phase 2**: backfill (run once) | `scripts/migrations/backfill-eva-decision-log.mjs` |
 
 ## 5-Task Voice Spot-Check (LEAD-FINAL Acceptance Gate)
 

--- a/database/migrations/20260511020000_eva_support_decision_log.sql
+++ b/database/migrations/20260511020000_eva_support_decision_log.sql
@@ -1,0 +1,48 @@
+-- database/migrations/20260511020000_eva_support_decision_log.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-1
+-- Mirrors envelope v1.0 REQUIRED_FIELDS verbatim (see scripts/eva-support/decision-log-formatter.js).
+-- service_role-only RLS posture (writer/reader is a server-side EVA process).
+
+CREATE TABLE IF NOT EXISTS eva_support_decision_log (
+  schema_version  VARCHAR(8)  NOT NULL CHECK (schema_version = '1.0'),
+  task_id         TEXT        NOT NULL,
+  sequence        INTEGER     NOT NULL CHECK (sequence > 0),
+  timestamp       TIMESTAMPTZ NOT NULL,
+  flow            TEXT        NOT NULL,
+  eva_reply_summary       TEXT NOT NULL CHECK (length(eva_reply_summary)       <= 500),
+  operator_input_summary  TEXT NOT NULL CHECK (length(operator_input_summary)  <= 500),
+  override_reason TEXT,
+  model           TEXT        NOT NULL,
+  tokens_in       INTEGER     NOT NULL CHECK (tokens_in  >= 0),
+  tokens_out      INTEGER     NOT NULL CHECK (tokens_out >= 0),
+  "references"    JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (task_id, sequence)
+);
+
+-- Plain b-tree index on (timestamp DESC). NOTE: partial-index variant
+-- "WHERE timestamp > now() - interval '14 days'" was REJECTED because
+-- now() is STABLE, not IMMUTABLE — Postgres rejects non-IMMUTABLE
+-- predicates in CREATE INDEX. The plain index serves the recentEntries
+-- query equivalently via index range scan.
+CREATE INDEX IF NOT EXISTS idx_eva_support_decision_log_ts
+  ON eva_support_decision_log (timestamp DESC);
+
+ALTER TABLE eva_support_decision_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_support_decision_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_support_decision_log IS
+  'EVA Support decision log. Mirrors envelope v1.0 REQUIRED_FIELDS verbatim per scripts/eva-support/decision-log-formatter.js. service_role-only RLS.';
+COMMENT ON COLUMN eva_support_decision_log."references" IS
+  'JSONB array of citation refs. Name matches envelope v1.0 REQUIRED_FIELDS verbatim; quote as "references" in raw SQL to avoid FK-reference keyword ambiguity.';
+COMMENT ON COLUMN eva_support_decision_log.flow IS
+  'Validated app-side against FLOWS list (see decision-log-formatter.js). No DB CHECK to keep value-set evolution in code.';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_support_decision_log;

--- a/database/migrations/20260511020100_eva_support_research_cache.sql
+++ b/database/migrations/20260511020100_eva_support_research_cache.sql
@@ -1,0 +1,37 @@
+-- database/migrations/20260511020100_eva_support_research_cache.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-3
+-- TTL-bounded research result cache keyed by SHA-256 hex of normalized query.
+-- service_role-only RLS posture.
+
+CREATE TABLE IF NOT EXISTS eva_support_research_cache (
+  query_hash    CHAR(64)    PRIMARY KEY,
+  query_text    TEXT        NOT NULL,
+  response_text TEXT        NOT NULL,
+  "references"  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  ttl_until     TIMESTAMPTZ NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  accessed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Plain b-tree index supports eviction-scan: WHERE ttl_until < now()
+CREATE INDEX IF NOT EXISTS idx_eva_support_research_cache_ttl
+  ON eva_support_research_cache (ttl_until);
+
+ALTER TABLE eva_support_research_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_support_research_cache
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_support_research_cache IS
+  'EVA Support research result cache. Keyed by SHA-256 hex of normalize(query)=lowercase+trim+collapse-whitespace. TTL-bounded via ttl_until; eviction by separate cron/script (see scripts/cron/evict-research-cache.mjs if/when added). service_role-only RLS.';
+COMMENT ON COLUMN eva_support_research_cache.query_text IS
+  'May contain PII (e.g. user names in research queries). Protected by service_role-only RLS + TTL eviction via ttl_until. NOT encrypted at column level — relies on Supabase storage-layer encryption-at-rest.';
+COMMENT ON COLUMN eva_support_research_cache."references" IS
+  'JSONB array of citation refs. Quote as "references" in raw SQL to avoid FK-reference keyword ambiguity.';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_support_research_cache;

--- a/database/migrations/20260511020200_eva_friday_outcomes.sql
+++ b/database/migrations/20260511020200_eva_friday_outcomes.sql
@@ -1,0 +1,40 @@
+-- database/migrations/20260511020200_eva_friday_outcomes.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-5
+-- Friday meeting agenda outcome tracking for downstream EVA Support surfacing.
+-- service_role-only RLS posture.
+
+CREATE TABLE IF NOT EXISTS eva_friday_outcomes (
+  outcome_id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  agenda_item_ref   TEXT        NOT NULL,
+  outcome           TEXT        NOT NULL CHECK (outcome IN ('accepted', 'deferred', 'rejected', 'noted')),
+  chairman_feedback TEXT,
+  meeting_date      DATE        NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  consumed_at       TIMESTAMPTZ
+);
+
+-- Partial index on meeting_date DESC WHERE consumed_at IS NULL.
+-- Predicate is IMMUTABLE (NULL test only — no functions), so this is valid.
+-- Supports TR-5 dispatcher query: SELECT ... WHERE consumed_at IS NULL ORDER BY meeting_date DESC LIMIT 10.
+CREATE INDEX IF NOT EXISTS idx_eva_friday_outcomes_unconsumed
+  ON eva_friday_outcomes (meeting_date DESC)
+  WHERE consumed_at IS NULL;
+
+ALTER TABLE eva_friday_outcomes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_friday_outcomes
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_friday_outcomes IS
+  'EVA Friday meeting agenda outcomes. Surfaced by EVA Support dispatcher (TR-5) when consumed_at IS NULL, then marked consumed. service_role-only RLS.';
+COMMENT ON COLUMN eva_friday_outcomes.agenda_item_ref IS
+  'Free-form reference to the originating agenda item (no FK by design — agenda items are markdown-rendered, not persisted as their own table).';
+COMMENT ON COLUMN eva_friday_outcomes.outcome IS
+  'Outcome lifecycle: accepted (acted on) | deferred (revisit later) | rejected (will not pursue) | noted (informational). TEXT+CHECK is used instead of native ENUM to keep value-set evolution transactional (matches project-wide pattern).';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_friday_outcomes;

--- a/database/migrations/COMBINED_eva_001b_phase2_tables.sql
+++ b/database/migrations/COMBINED_eva_001b_phase2_tables.sql
@@ -1,0 +1,125 @@
+-- database/migrations/20260511020000_eva_support_decision_log.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-1
+-- Mirrors envelope v1.0 REQUIRED_FIELDS verbatim (see scripts/eva-support/decision-log-formatter.js).
+-- service_role-only RLS posture (writer/reader is a server-side EVA process).
+
+CREATE TABLE IF NOT EXISTS eva_support_decision_log (
+  schema_version  VARCHAR(8)  NOT NULL CHECK (schema_version = '1.0'),
+  task_id         TEXT        NOT NULL,
+  sequence        INTEGER     NOT NULL CHECK (sequence > 0),
+  timestamp       TIMESTAMPTZ NOT NULL,
+  flow            TEXT        NOT NULL,
+  eva_reply_summary       TEXT NOT NULL CHECK (length(eva_reply_summary)       <= 500),
+  operator_input_summary  TEXT NOT NULL CHECK (length(operator_input_summary)  <= 500),
+  override_reason TEXT,
+  model           TEXT        NOT NULL,
+  tokens_in       INTEGER     NOT NULL CHECK (tokens_in  >= 0),
+  tokens_out      INTEGER     NOT NULL CHECK (tokens_out >= 0),
+  "references"    JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (task_id, sequence)
+);
+
+-- Plain b-tree index on (timestamp DESC). NOTE: partial-index variant
+-- "WHERE timestamp > now() - interval '14 days'" was REJECTED because
+-- now() is STABLE, not IMMUTABLE — Postgres rejects non-IMMUTABLE
+-- predicates in CREATE INDEX. The plain index serves the recentEntries
+-- query equivalently via index range scan.
+CREATE INDEX IF NOT EXISTS idx_eva_support_decision_log_ts
+  ON eva_support_decision_log (timestamp DESC);
+
+ALTER TABLE eva_support_decision_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_support_decision_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_support_decision_log IS
+  'EVA Support decision log. Mirrors envelope v1.0 REQUIRED_FIELDS verbatim per scripts/eva-support/decision-log-formatter.js. service_role-only RLS.';
+COMMENT ON COLUMN eva_support_decision_log."references" IS
+  'JSONB array of citation refs. Name matches envelope v1.0 REQUIRED_FIELDS verbatim; quote as "references" in raw SQL to avoid FK-reference keyword ambiguity.';
+COMMENT ON COLUMN eva_support_decision_log.flow IS
+  'Validated app-side against FLOWS list (see decision-log-formatter.js). No DB CHECK to keep value-set evolution in code.';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_support_decision_log;
+-- database/migrations/20260511020100_eva_support_research_cache.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-3
+-- TTL-bounded research result cache keyed by SHA-256 hex of normalized query.
+-- service_role-only RLS posture.
+
+CREATE TABLE IF NOT EXISTS eva_support_research_cache (
+  query_hash    CHAR(64)    PRIMARY KEY,
+  query_text    TEXT        NOT NULL,
+  response_text TEXT        NOT NULL,
+  "references"  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  ttl_until     TIMESTAMPTZ NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  accessed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Plain b-tree index supports eviction-scan: WHERE ttl_until < now()
+CREATE INDEX IF NOT EXISTS idx_eva_support_research_cache_ttl
+  ON eva_support_research_cache (ttl_until);
+
+ALTER TABLE eva_support_research_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_support_research_cache
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_support_research_cache IS
+  'EVA Support research result cache. Keyed by SHA-256 hex of normalize(query)=lowercase+trim+collapse-whitespace. TTL-bounded via ttl_until; eviction by separate cron/script (see scripts/cron/evict-research-cache.mjs if/when added). service_role-only RLS.';
+COMMENT ON COLUMN eva_support_research_cache.query_text IS
+  'May contain PII (e.g. user names in research queries). Protected by service_role-only RLS + TTL eviction via ttl_until. NOT encrypted at column level — relies on Supabase storage-layer encryption-at-rest.';
+COMMENT ON COLUMN eva_support_research_cache."references" IS
+  'JSONB array of citation refs. Quote as "references" in raw SQL to avoid FK-reference keyword ambiguity.';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_support_research_cache;
+-- database/migrations/20260511020200_eva_friday_outcomes.sql
+--
+-- SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-5
+-- Friday meeting agenda outcome tracking for downstream EVA Support surfacing.
+-- service_role-only RLS posture.
+
+CREATE TABLE IF NOT EXISTS eva_friday_outcomes (
+  outcome_id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  agenda_item_ref   TEXT        NOT NULL,
+  outcome           TEXT        NOT NULL CHECK (outcome IN ('accepted', 'deferred', 'rejected', 'noted')),
+  chairman_feedback TEXT,
+  meeting_date      DATE        NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  consumed_at       TIMESTAMPTZ
+);
+
+-- Partial index on meeting_date DESC WHERE consumed_at IS NULL.
+-- Predicate is IMMUTABLE (NULL test only — no functions), so this is valid.
+-- Supports TR-5 dispatcher query: SELECT ... WHERE consumed_at IS NULL ORDER BY meeting_date DESC LIMIT 10.
+CREATE INDEX IF NOT EXISTS idx_eva_friday_outcomes_unconsumed
+  ON eva_friday_outcomes (meeting_date DESC)
+  WHERE consumed_at IS NULL;
+
+ALTER TABLE eva_friday_outcomes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all
+  ON eva_friday_outcomes
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE  eva_friday_outcomes IS
+  'EVA Friday meeting agenda outcomes. Surfaced by EVA Support dispatcher (TR-5) when consumed_at IS NULL, then marked consumed. service_role-only RLS.';
+COMMENT ON COLUMN eva_friday_outcomes.agenda_item_ref IS
+  'Free-form reference to the originating agenda item (no FK by design — agenda items are markdown-rendered, not persisted as their own table).';
+COMMENT ON COLUMN eva_friday_outcomes.outcome IS
+  'Outcome lifecycle: accepted (acted on) | deferred (revisit later) | rejected (will not pursue) | noted (informational). TEXT+CHECK is used instead of native ENUM to keep value-set evolution transactional (matches project-wide pattern).';
+
+-- ROLLBACK: DROP TABLE IF EXISTS eva_friday_outcomes;

--- a/lib/eva-support/decision-log-store.js
+++ b/lib/eva-support/decision-log-store.js
@@ -1,0 +1,191 @@
+/**
+ * lib/eva-support/decision-log-store.js
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-2, FR-1, FR-4
+ *
+ * Writer + readers for eva_support_decision_log. Columns mirror
+ * scripts/eva-support/decision-log-formatter.js REQUIRED_FIELDS verbatim;
+ * the static regression-pin at tests/unit/eva-support/envelope-v1-schema-pin.test.js
+ * enforces 1:1 column-to-field alignment.
+ *
+ * Read-after-write contract (FR-4): insertEntry SELECTs the inserted row by
+ * (task_id, sequence) and asserts every envelope field landed. Inspired by
+ * lib/db/writeback-verify.mjs (QF-20260509-650) but adapted for INSERT.
+ *
+ * Fail-soft posture (per unlock_gate_override constraint #1): callers may
+ * configure { allowSoftFailures: true } to log instead of throw — but the
+ * default is strict (throw) so DB-FIRST atomic dual-write contract holds.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { REQUIRED_FIELDS } from '../../scripts/eva-support/decision-log-formatter.js';
+
+const TABLE = 'eva_support_decision_log';
+
+function defaultClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('decision-log-store: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  }
+  return createClient(url, key);
+}
+
+export class DecisionLogStoreError extends Error {
+  constructor(message, { cause, code } = {}) {
+    super(message);
+    this.name = 'DecisionLogStoreError';
+    if (cause) this.cause = cause;
+    if (code) this.code = code;
+  }
+}
+
+function isSchemaCacheMiss(error) {
+  if (!error) return false;
+  const code = error.code || '';
+  const msg = error.message || '';
+  return code === 'PGRST205' || code === '42P01' || /schema cache/i.test(msg) || /relation .* does not exist/i.test(msg);
+}
+
+function envelopeToRow(entry) {
+  const row = {};
+  for (const f of REQUIRED_FIELDS) {
+    if (!(f in entry)) {
+      throw new DecisionLogStoreError(`envelope missing required field "${f}"`, { code: 'ENVELOPE_INCOMPLETE' });
+    }
+    row[f] = entry[f];
+  }
+  return row;
+}
+
+/**
+ * INSERT a decision-log envelope. Idempotent on (task_id, sequence).
+ *
+ * Returns { inserted, verified, row }:
+ *   - inserted: true when a new row was created; false when (task_id, sequence) already existed
+ *   - verified: true when read-after-write confirmed every REQUIRED_FIELDS column matches the envelope
+ *   - row: the SELECTed row (may be null on fail-soft path)
+ *
+ * Throws DecisionLogStoreError on schema-cache miss (fail-loud per FR-4 / TEST-2)
+ * or on a verified mismatch. Caller (slash command / sub-flow-base wrapper)
+ * MUST NOT proceed with the Todoist comment write on throw.
+ */
+export async function insertEntry(entry, { client, allowSoftFailures = false } = {}) {
+  if (!entry || typeof entry !== 'object') {
+    throw new DecisionLogStoreError('entry must be an object', { code: 'BAD_INPUT' });
+  }
+  const c = client ?? defaultClient();
+  const row = envelopeToRow(entry);
+
+  // INSERT with ON CONFLICT-equivalent: PostgREST returns a 23505 (unique violation)
+  // when (task_id, sequence) already exists. We treat that as inserted:false rather
+  // than an error so callers can be idempotent.
+  const { data: insertData, error: insertError } = await c
+    .from(TABLE)
+    .insert(row)
+    .select(REQUIRED_FIELDS.join(','))
+    .maybeSingle();
+
+  if (insertError) {
+    if (insertError.code === '23505') {
+      // Unique violation — already exists. Read it back and return inserted:false.
+      const { data: existing, error: readErr } = await c
+        .from(TABLE)
+        .select(REQUIRED_FIELDS.join(','))
+        .eq('task_id', entry.task_id)
+        .eq('sequence', entry.sequence)
+        .maybeSingle();
+      if (readErr) {
+        throw new DecisionLogStoreError(`conflict on (task_id, sequence) but read-after-conflict failed: ${readErr.message}`, { cause: readErr, code: 'READ_AFTER_CONFLICT' });
+      }
+      return { inserted: false, verified: true, row: existing };
+    }
+    if (isSchemaCacheMiss(insertError)) {
+      // Fail loud per FR-4 — the schema-cache miss class is the canonical migration-not-applied signal.
+      throw new DecisionLogStoreError(`eva_support_decision_log not found in schema cache — migration probably not applied: ${insertError.message}`, { cause: insertError, code: 'SCHEMA_CACHE_MISS' });
+    }
+    if (allowSoftFailures) {
+      // Fail-soft: caller chose to swallow non-fatal errors (used for Phase 1 backward compat during the gradual rollout).
+      return { inserted: false, verified: false, row: null, error: insertError };
+    }
+    throw new DecisionLogStoreError(`insert failed: ${insertError.message}`, { cause: insertError, code: insertError.code || 'INSERT_FAILED' });
+  }
+
+  // Read-after-write verification: assert every REQUIRED_FIELDS column matches the envelope.
+  const verified = verifyRowMatchesEntry(insertData, entry);
+  if (!verified.ok) {
+    if (allowSoftFailures) {
+      return { inserted: true, verified: false, row: insertData, mismatch: verified.diffs };
+    }
+    throw new DecisionLogStoreError(`read-after-write mismatch: ${verified.diffs.map((d) => d.field).join(', ')}`, { code: 'WRITEBACK_MISMATCH' });
+  }
+  return { inserted: true, verified: true, row: insertData };
+}
+
+function verifyRowMatchesEntry(row, entry) {
+  if (!row) return { ok: false, diffs: [{ field: '*', reason: 'row missing' }] };
+  const diffs = [];
+  for (const f of REQUIRED_FIELDS) {
+    const r = row[f];
+    const e = entry[f];
+    if (f === 'references') {
+      // Both should be arrays — compare via JSON.stringify (deep-equal for primitive-array contents).
+      if (JSON.stringify(r ?? []) !== JSON.stringify(e ?? [])) diffs.push({ field: f, reason: 'array mismatch' });
+      continue;
+    }
+    if (f === 'timestamp') {
+      // Postgres normalizes timestamptz; compare via Date.getTime for parity.
+      if (new Date(r).getTime() !== new Date(e).getTime()) diffs.push({ field: f, reason: 'timestamp mismatch' });
+      continue;
+    }
+    if (r !== e && !(r == null && e == null)) {
+      diffs.push({ field: f, reason: `expected ${JSON.stringify(e)}, got ${JSON.stringify(r)}` });
+    }
+  }
+  return { ok: diffs.length === 0, diffs };
+}
+
+/**
+ * Fetch recent decision-log entries across all tasks.
+ * @param {object} opts
+ * @param {Date|string} [opts.since] - oldest timestamp to include (default: 7 days ago)
+ * @param {number} [opts.limit] - max rows (default 10)
+ * @param {object} [opts.client] - supabase client (default: env-derived)
+ */
+export async function recentEntries({ since, limit = 10, client } = {}) {
+  const c = client ?? defaultClient();
+  const sinceIso = (since ? new Date(since) : new Date(Date.now() - 7 * 24 * 3600 * 1000)).toISOString();
+  const { data, error } = await c
+    .from(TABLE)
+    .select(REQUIRED_FIELDS.join(','))
+    .gte('timestamp', sinceIso)
+    .order('timestamp', { ascending: false })
+    .limit(limit);
+  if (error) {
+    if (isSchemaCacheMiss(error)) {
+      // Fail-soft for readers — empty list when table not yet present.
+      return [];
+    }
+    throw new DecisionLogStoreError(`recentEntries read failed: ${error.message}`, { cause: error, code: error.code || 'READ_FAILED' });
+  }
+  return data || [];
+}
+
+/**
+ * Fetch all decision-log entries for a specific task_id, ordered by sequence ASC.
+ */
+export async function entriesForTask(taskId, { client } = {}) {
+  if (!taskId) throw new DecisionLogStoreError('taskId required', { code: 'BAD_INPUT' });
+  const c = client ?? defaultClient();
+  const { data, error } = await c
+    .from(TABLE)
+    .select(REQUIRED_FIELDS.join(','))
+    .eq('task_id', taskId)
+    .order('sequence', { ascending: true });
+  if (error) {
+    if (isSchemaCacheMiss(error)) return [];
+    throw new DecisionLogStoreError(`entriesForTask read failed: ${error.message}`, { cause: error, code: error.code || 'READ_FAILED' });
+  }
+  return data || [];
+}
+
+export default { insertEntry, recentEntries, entriesForTask, DecisionLogStoreError };

--- a/lib/eva-support/friday-outcome-bridge.js
+++ b/lib/eva-support/friday-outcome-bridge.js
@@ -1,0 +1,140 @@
+/**
+ * lib/eva-support/friday-outcome-bridge.js
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-3, FR-6, TR-5, US-006
+ *
+ * Bridges Friday meeting outcomes to EVA Support pushback context.
+ *
+ * Two operations:
+ *   - surfacePending(): read unconsumed eva_friday_outcomes (CAS UPDATE consumed_at)
+ *     for the next /eva-support invocation to surface in pushback context.
+ *   - writeOutcome(): record a Friday meeting decision row (consumed_at NULL).
+ *
+ * Fail-soft posture (per unlock_gate_override constraint #1): all errors return
+ * empty / falsy results so Phase 2 wiring never blocks Phase 1 flows.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const TABLE = 'eva_friday_outcomes';
+
+function defaultClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('friday-outcome-bridge: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  }
+  return createClient(url, key);
+}
+
+function isSchemaCacheMiss(error) {
+  if (!error) return false;
+  const code = error.code || '';
+  const msg = error.message || '';
+  return code === 'PGRST205' || code === '42P01' || /schema cache/i.test(msg) || /relation .* does not exist/i.test(msg);
+}
+
+const ALLOWED_OUTCOMES = new Set(['accepted', 'deferred', 'rejected', 'noted']);
+
+/**
+ * Read unconsumed Friday outcomes and CAS-update consumed_at=now() in one atomic step.
+ * Returns the surfaced rows (array). Empty array on no work / fail-soft errors.
+ */
+export async function surfacePending({ client, limit = 10 } = {}) {
+  let c;
+  try {
+    c = client ?? defaultClient();
+  } catch {
+    return [];
+  }
+
+  // Step 1: read unconsumed rows (ORDER BY meeting_date DESC).
+  const { data: rows, error: readErr } = await c
+    .from(TABLE)
+    .select('outcome_id, agenda_item_ref, outcome, chairman_feedback, meeting_date, created_at')
+    .is('consumed_at', null)
+    .order('meeting_date', { ascending: false })
+    .limit(limit);
+
+  if (readErr) {
+    if (isSchemaCacheMiss(readErr)) return [];
+    return [];
+  }
+  if (!rows || rows.length === 0) return [];
+
+  // Step 2: CAS UPDATE consumed_at — only update rows that are STILL NULL (parallel-safe).
+  const ids = rows.map((r) => r.outcome_id);
+  const nowIso = new Date().toISOString();
+  const { data: updated, error: updErr } = await c
+    .from(TABLE)
+    .update({ consumed_at: nowIso })
+    .in('outcome_id', ids)
+    .is('consumed_at', null)
+    .select('outcome_id');
+
+  if (updErr) {
+    // Fail-soft: surfacing without consuming would replay on next invocation; cheap to retry.
+    return [];
+  }
+
+  // Filter: only return rows that the CAS update actually claimed (parallel-safety).
+  const claimedIds = new Set((updated || []).map((u) => u.outcome_id));
+  return rows.filter((r) => claimedIds.has(r.outcome_id));
+}
+
+/**
+ * Render an array of surfaced Friday outcomes as markdown for the EVA Support
+ * pushback context. Empty input returns empty string (silent skip per FR-3).
+ */
+export function renderPushbackMarkdown(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return '';
+  const lines = ['## Friday meeting outcomes (since last /eva-support invocation)', ''];
+  for (const r of rows) {
+    const date = r.meeting_date ? `(${r.meeting_date})` : '';
+    const feedback = r.chairman_feedback ? ` — ${r.chairman_feedback}` : '';
+    lines.push(`- **${r.outcome.toUpperCase()}** ${date}: ${r.agenda_item_ref}${feedback}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Write a new Friday outcome row (consumed_at NULL).
+ *
+ * @param {object} params
+ * @param {string} params.agendaItemRef - free-form agenda item reference
+ * @param {string} params.outcome - one of accepted | deferred | rejected | noted
+ * @param {string} [params.chairmanFeedback] - free-text feedback (nullable)
+ * @param {string} [params.meetingDate] - YYYY-MM-DD; defaults to today (UTC)
+ * @param {object} [params.client] - supabase client
+ * @returns {Promise<{written: boolean, outcome_id?: string, error?: object}>}
+ */
+export async function writeOutcome({ agendaItemRef, outcome, chairmanFeedback = null, meetingDate, client } = {}) {
+  if (!agendaItemRef || typeof agendaItemRef !== 'string') return { written: false, error: { code: 'BAD_INPUT', message: 'agendaItemRef (string) required' } };
+  if (!ALLOWED_OUTCOMES.has(outcome)) return { written: false, error: { code: 'BAD_OUTCOME', message: `outcome must be one of ${[...ALLOWED_OUTCOMES].join(', ')}` } };
+  const date = meetingDate || new Date().toISOString().slice(0, 10);
+
+  let c;
+  try {
+    c = client ?? defaultClient();
+  } catch {
+    return { written: false };
+  }
+
+  const { data, error } = await c
+    .from(TABLE)
+    .insert({
+      agenda_item_ref: agendaItemRef,
+      outcome,
+      chairman_feedback: chairmanFeedback,
+      meeting_date: date,
+    })
+    .select('outcome_id')
+    .maybeSingle();
+
+  if (error) {
+    if (isSchemaCacheMiss(error)) return { written: false, error };
+    return { written: false, error };
+  }
+  return { written: true, outcome_id: data?.outcome_id };
+}
+
+export default { surfacePending, writeOutcome, renderPushbackMarkdown };

--- a/lib/eva-support/research-cache.js
+++ b/lib/eva-support/research-cache.js
@@ -1,0 +1,167 @@
+/**
+ * lib/eva-support/research-cache.js
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-3, FR-2
+ *
+ * Hash-keyed cache for the /eva-support research flow. Hash = SHA-256 hex of
+ * normalize(query)=lowercase + trim + collapse-whitespace. Read-side TTL eviction
+ * (filter ttl_until > now() at SELECT) — no scheduled job.
+ *
+ * Fail-soft posture (per unlock_gate_override constraint #1): all errors return
+ * { hit: false } so cache infrastructure never blocks the research flow.
+ * Production callers can opt in to strict mode via { strict: true }.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'node:crypto';
+
+const TABLE = 'eva_support_research_cache';
+const DEFAULT_TTL_DAYS = 7;
+
+function defaultClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('research-cache: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  }
+  return createClient(url, key);
+}
+
+/**
+ * Normalize a raw query string for hashing: lowercase + trim + collapse whitespace.
+ * Exposed for tests + cache invalidation tooling.
+ */
+export function normalizeQuery(raw) {
+  if (typeof raw !== 'string') return '';
+  return raw.toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * SHA-256 hex of normalized query.
+ */
+export function hashQuery(raw) {
+  return createHash('sha256').update(normalizeQuery(raw)).digest('hex');
+}
+
+function isSchemaCacheMiss(error) {
+  if (!error) return false;
+  const code = error.code || '';
+  const msg = error.message || '';
+  return code === 'PGRST205' || code === '42P01' || /schema cache/i.test(msg) || /relation .* does not exist/i.test(msg);
+}
+
+/**
+ * Fetch a cached response. Returns { hit, response, references, hash }.
+ *
+ * - Returns hit:false when no row exists OR ttl_until <= now() OR any error
+ *   (fail-soft — cache miss is always safe).
+ * - On hit, asynchronously bumps accessed_at via UPDATE (does not block the
+ *   return; the bump is observational telemetry).
+ */
+export async function get(rawQuery, { client, strict = false } = {}) {
+  const hash = hashQuery(rawQuery);
+  const empty = { hit: false, response: null, references: [], hash };
+  let c;
+  try {
+    c = client ?? defaultClient();
+  } catch (e) {
+    if (strict) throw e;
+    return empty;
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data, error } = await c
+    .from(TABLE)
+    .select('query_hash, response_text, "references", ttl_until')
+    .eq('query_hash', hash)
+    .gt('ttl_until', nowIso)
+    .maybeSingle();
+
+  if (error) {
+    if (isSchemaCacheMiss(error)) return empty;
+    if (strict) throw error;
+    return empty;
+  }
+  if (!data) return empty;
+
+  // Fire-and-forget accessed_at bump.
+  void c.from(TABLE).update({ accessed_at: nowIso }).eq('query_hash', hash);
+
+  return {
+    hit: true,
+    response: data.response_text,
+    references: data.references || [],
+    hash,
+  };
+}
+
+/**
+ * Set / overwrite a cached response. Idempotent on query_hash (PRIMARY KEY).
+ * Returns { written: boolean, hash }.
+ */
+export async function set(rawQuery, responseText, { references = [], ttlDays = DEFAULT_TTL_DAYS, client, strict = false } = {}) {
+  if (typeof responseText !== 'string') {
+    if (strict) throw new Error('research-cache.set: responseText must be a string');
+    return { written: false, hash: hashQuery(rawQuery) };
+  }
+  const hash = hashQuery(rawQuery);
+  let c;
+  try {
+    c = client ?? defaultClient();
+  } catch (e) {
+    if (strict) throw e;
+    return { written: false, hash };
+  }
+
+  const ttlUntil = new Date(Date.now() + ttlDays * 24 * 3600 * 1000).toISOString();
+  const row = {
+    query_hash: hash,
+    query_text: normalizeQuery(rawQuery),
+    response_text: responseText,
+    references,
+    ttl_until: ttlUntil,
+  };
+
+  const { error } = await c
+    .from(TABLE)
+    .upsert(row, { onConflict: 'query_hash' });
+
+  if (error) {
+    if (strict && !isSchemaCacheMiss(error)) throw error;
+    return { written: false, hash };
+  }
+  return { written: true, hash };
+}
+
+/**
+ * Purge cached rows older than the given cutoff. Returns { deleted } (count).
+ */
+export async function purgeBefore(cutoffIso, { client } = {}) {
+  const c = client ?? defaultClient();
+  const { count, error } = await c
+    .from(TABLE)
+    .delete({ count: 'exact' })
+    .lt('created_at', cutoffIso);
+  if (error) {
+    if (isSchemaCacheMiss(error)) return { deleted: 0 };
+    throw error;
+  }
+  return { deleted: count ?? 0 };
+}
+
+/**
+ * Purge a single cached row by query_hash. Returns { deleted: 0|1 }.
+ */
+export async function purgeByQueryHash(hash, { client } = {}) {
+  const c = client ?? defaultClient();
+  const { count, error } = await c
+    .from(TABLE)
+    .delete({ count: 'exact' })
+    .eq('query_hash', hash);
+  if (error) {
+    if (isSchemaCacheMiss(error)) return { deleted: 0 };
+    throw error;
+  }
+  return { deleted: count ?? 0 };
+}
+
+export default { get, set, hashQuery, normalizeQuery, purgeBefore, purgeByQueryHash };

--- a/scripts/eva-support/_internal/sub-flow-base.js
+++ b/scripts/eva-support/_internal/sub-flow-base.js
@@ -33,9 +33,14 @@ export function extractOverrideReason(operatorInput) {
  * @param {string} [params.operatorInput] - operator's most recent message (may begin with Override:)
  * @param {object} [params.client] - optional Anthropic client (for tests)
  * @param {string} [params.model]
- * @returns {Promise<{reply: string, decision_log_entry: object}>}
+ * @param {object} [params.decisionLogStore] - SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-4:
+ *   optional Phase 2 store. If provided, the entry is INSERTed via
+ *   decisionLogStore.insertEntry(entry) BEFORE returning. A throw here means
+ *   the caller MUST NOT proceed with the Todoist comment write (atomic DB-FIRST
+ *   contract). If omitted, behavior is identical to Phase 1 (build + return only).
+ * @returns {Promise<{reply: string, decision_log_entry: object, db_persisted?: boolean}>}
  */
-export async function runSubFlow({ flow, flowGuidance, subtask, history = [], operatorInput = '', client, model = DEFAULT_MODEL }) {
+export async function runSubFlow({ flow, flowGuidance, subtask, history = [], operatorInput = '', client, model = DEFAULT_MODEL, decisionLogStore = null }) {
   if (!subtask?.id) throw new Error('subtask.id is required');
 
   const sdkClient = client ?? createAnthropicClient();
@@ -72,7 +77,18 @@ export async function runSubFlow({ flow, flowGuidance, subtask, history = [], op
     references: [],
   });
 
-  return { reply, decision_log_entry };
+  // Phase 2 atomic DB-FIRST dual-write (SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-4):
+  // when a store is injected, persist the envelope to eva_support_decision_log BEFORE
+  // returning. A throw propagates to the dispatcher → slash command, which then
+  // MUST NOT post the Todoist comment. This makes DB the canonical store; Todoist
+  // becomes a human-readable mirror only when the DB write succeeds.
+  let db_persisted = false;
+  if (decisionLogStore && typeof decisionLogStore.insertEntry === 'function') {
+    const result = await decisionLogStore.insertEntry(decision_log_entry);
+    db_persisted = !!(result && (result.verified || result.inserted));
+  }
+
+  return { reply, decision_log_entry, db_persisted };
 }
 
 export default { runSubFlow, extractOverrideReason };

--- a/scripts/eva-support/research.js
+++ b/scripts/eva-support/research.js
@@ -1,9 +1,14 @@
 /**
  * Sub-flow: research.
  * SD: SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-A
+ * Phase 2 extension: SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-2, TR-3, US-004
+ *   research-cache short-circuit before LLM invocation; cache miss falls through
+ *   to runSubFlow and writes back on success.
  */
 
 import { runSubFlow } from './_internal/sub-flow-base.js';
+import * as defaultResearchCache from '../../lib/eva-support/research-cache.js';
+import { buildEntry } from './decision-log-formatter.js';
 
 const FLOW_GUIDANCE = `Mode: investigation. The chairman has an open question that needs prior art, evidence, or context before a decision can be made.
 
@@ -14,8 +19,57 @@ Your reply MUST:
 
 Do not pre-make the decision. Stay in research mode unless the operator overrides.`;
 
-export default async function research(subtask, { history = [], operatorInput = '', client, model } = {}) {
-  return runSubFlow({
+/**
+ * Compose the cache lookup key from subtask + operator input. Keeps the cache
+ * key stable across whitespace/casing variations via research-cache.normalizeQuery.
+ */
+function cacheKeyFor(subtask, operatorInput) {
+  const parts = [subtask?.content ?? '', subtask?.description ?? '', operatorInput ?? ''];
+  return parts.filter(Boolean).join(' :: ');
+}
+
+export default async function research(
+  subtask,
+  { history = [], operatorInput = '', client, model, decisionLogStore = null, researchCache = defaultResearchCache } = {},
+) {
+  // Phase 2 cache lookup (fail-soft per research-cache.js posture — any error returns hit:false).
+  const cacheKey = cacheKeyFor(subtask, operatorInput);
+  if (researchCache && typeof researchCache.get === 'function') {
+    try {
+      const cached = await researchCache.get(cacheKey);
+      if (cached && cached.hit) {
+        const sequence = (history?.length ?? 0) + 1;
+        const decision_log_entry = buildEntry({
+          task_id: subtask.id,
+          sequence,
+          flow: 'research',
+          eva_reply: cached.response,
+          operator_input: operatorInput,
+          override_reason: null,
+          model: 'cache:eva_support_research_cache',
+          tokens_in: 0,
+          tokens_out: 0,
+          references: Array.isArray(cached.references) ? cached.references : [],
+        });
+        // Persist the cache-hit entry to DB if a store is wired (FR-4 dual-write contract).
+        let db_persisted = false;
+        if (decisionLogStore && typeof decisionLogStore.insertEntry === 'function') {
+          const result = await decisionLogStore.insertEntry(decision_log_entry);
+          db_persisted = !!(result && (result.verified || result.inserted));
+        }
+        return {
+          reply: cached.response,
+          decision_log_entry,
+          db_persisted,
+          cache: { hit: true, hash: cached.hash },
+        };
+      }
+    } catch {
+      // Fail-soft: cache infrastructure must never block the research flow.
+    }
+  }
+
+  const result = await runSubFlow({
     flow: 'research',
     flowGuidance: FLOW_GUIDANCE,
     subtask,
@@ -23,5 +77,19 @@ export default async function research(subtask, { history = [], operatorInput = 
     operatorInput,
     client,
     model,
+    decisionLogStore,
   });
+
+  // Write-back: store the LLM response in the cache for future invocations.
+  if (researchCache && typeof researchCache.set === 'function') {
+    try {
+      await researchCache.set(cacheKey, result.reply, {
+        references: result.decision_log_entry?.references ?? [],
+      });
+    } catch {
+      // Fail-soft on write — caller already has the response.
+    }
+  }
+
+  return { ...result, cache: { hit: false } };
 }

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -19,6 +19,12 @@ import { getLLMClient } from '../../lib/llm/client-factory.js';
 import { gatherRdProposals as _gatherRdProposals, renderRdProposals as _renderRdProposals, buildCombinedDecisionPayload as _buildCombinedDecisionPayload, processRdProposalDecision as _processRdProposalDecision } from '../../lib/skunkworks/friday-rd-section.js';
 import { buildInsightsReport, formatInsightsForDisplay } from '../modules/learning/insights.js';
 import { gatherStitchHealth, renderStitchHealth } from '../../lib/eva/bridge/stitch-metrics.js';
+// SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-5, TR-4, US-005: Section 4b reads recent
+// eva_support_decision_log entries via the canonical store; outcome write helper
+// is callable by the /friday slash command after the chairman responds.
+import { recentEntries as _recentDecisionLogEntries } from '../../lib/eva-support/decision-log-store.js';
+import { renderMarkdown as _renderDecisionLogMarkdown } from '../eva-support/decision-log-formatter.js';
+import { writeOutcome as _writeFridayOutcome } from '../../lib/eva-support/friday-outcome-bridge.js';
 import dotenv from 'dotenv';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 
@@ -356,6 +362,44 @@ function renderIntakeReview(data) {
 
   return lines.join('\n');
 }
+
+// ─── Section 4b: Recent EVA Support Decisions (SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-5, US-005)
+//
+// Reads the last 7 days of eva_support_decision_log entries and renders them via
+// the canonical formatter. Silent skip on zero entries (no empty-state UI noise per FR-5 AC).
+// Fail-soft: read errors return empty payload — Section 4b is informational, not critical-path.
+
+async function gatherRecentDecisionLogEntries({ sinceDays = 7, limit = 10 } = {}) {
+  try {
+    const since = new Date(Date.now() - sinceDays * 24 * 3600 * 1000);
+    const entries = await _recentDecisionLogEntries({ since, limit });
+    return { entries: Array.isArray(entries) ? entries : [], sinceDays, limit };
+  } catch {
+    return { entries: [], sinceDays, limit };
+  }
+}
+
+function renderRecentDecisionLogEntries(data) {
+  if (!data || !Array.isArray(data.entries) || data.entries.length === 0) {
+    // Silent skip — per FR-5 AC #4 (no empty-state UI noise).
+    return '';
+  }
+  const lines = [];
+  lines.push('');
+  lines.push('  SECTION 4b: RECENT EVA SUPPORT DECISIONS');
+  lines.push('  ' + '─'.repeat(45));
+  lines.push(`  ${data.entries.length} decision(s) in the last ${data.sinceDays} days:`);
+  lines.push('');
+  // Use the canonical renderer (FR-5 AC #2 — no new rendering code).
+  // Indent each line for visual consistency with sibling sections.
+  const md = _renderDecisionLogMarkdown(data.entries);
+  md.split('\n').forEach(line => lines.push(line ? `  ${line}` : ''));
+  return lines.join('\n');
+}
+
+// Re-export the outcome writer for the /friday slash command to call after the
+// chairman responds to the AskUserQuestion payload (FR-6, US-006).
+export const writeFridayOutcome = _writeFridayOutcome;
 
 // ─── Section 5: R&D Proposals (delegated to lib/skunkworks/friday-rd-section.js)
 
@@ -697,11 +741,12 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log('═'.repeat(55));
 
   // Gather all data in parallel
-  const [perfData, capData, consultData, intakeData, rdData, fleetData, pluginData, insightsData, stitchData] = await Promise.all([
+  const [perfData, capData, consultData, intakeData, decisionLogData, rdData, fleetData, pluginData, insightsData, stitchData] = await Promise.all([
     gatherPerformanceReview(),
     gatherCapabilityReport(),
     gatherConsultantFindings(),
     gatherIntakeReview(),
+    gatherRecentDecisionLogEntries(),
     gatherRdProposals(),
     gatherFleetTelemetry(),
     gatherPluginDiscoveries(),
@@ -714,6 +759,9 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log(renderCapabilityReport(capData));
   logger.log(renderConsultantFindings(consultData));
   logger.log(renderIntakeReview(intakeData));
+  // SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / Section 4b: silent skip when no entries.
+  const section4b = renderRecentDecisionLogEntries(decisionLogData);
+  if (section4b) logger.log(section4b);
   logger.log(renderRdProposals(rdData));
   logger.log(renderFleetTelemetry(fleetData));
   logger.log(renderPluginDiscoveries(pluginData));

--- a/scripts/migrations/backfill-eva-decision-log.mjs
+++ b/scripts/migrations/backfill-eva-decision-log.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * scripts/migrations/backfill-eva-decision-log.mjs
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-7, TR-6, US-007
+ *
+ * Idempotent run-once parser: reads Todoist comments on EVA project tasks,
+ * runs decision-log-formatter.parse() on each, INSERTs the envelopes into
+ * eva_support_decision_log with ON CONFLICT (task_id, sequence) DO NOTHING.
+ *
+ * Resumable: per-batch checkpoint (every 50 entries) written to
+ * scripts/one-off/backfill-eva-decision-log-progress.json so a partial run can
+ * resume from the last completed task. Re-running after a successful complete
+ * run yields inserted=0 (idempotent).
+ *
+ * Usage:
+ *   node scripts/migrations/backfill-eva-decision-log.mjs --dry-run
+ *   node scripts/migrations/backfill-eva-decision-log.mjs
+ *   node scripts/migrations/backfill-eva-decision-log.mjs --reset  (clear checkpoint)
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { TodoistApi } from '@doist/todoist-api-typescript';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { parse as parseEnvelope } from '../eva-support/decision-log-formatter.js';
+
+const CHECKPOINT_PATH = resolve(process.cwd(), 'scripts/one-off/backfill-eva-decision-log-progress.json');
+const TARGET_PROJECT_NAMES = ['EVA', 'EVA Next Steps'];
+const BATCH_SIZE = 50;
+
+const args = new Set(process.argv.slice(2));
+const DRY_RUN = args.has('--dry-run');
+const RESET = args.has('--reset');
+
+function loadCheckpoint() {
+  if (RESET || !existsSync(CHECKPOINT_PATH)) {
+    return { processedTaskIds: [], inserted: 0, skipped: 0, scanned: 0, started_at: new Date().toISOString() };
+  }
+  try {
+    return JSON.parse(readFileSync(CHECKPOINT_PATH, 'utf8'));
+  } catch {
+    return { processedTaskIds: [], inserted: 0, skipped: 0, scanned: 0, started_at: new Date().toISOString() };
+  }
+}
+
+function saveCheckpoint(checkpoint) {
+  mkdirSync(dirname(CHECKPOINT_PATH), { recursive: true });
+  writeFileSync(CHECKPOINT_PATH, JSON.stringify(checkpoint, null, 2));
+}
+
+function normalizeListResponse(response) {
+  if (Array.isArray(response)) return response;
+  if (response && Array.isArray(response.results)) return response.results;
+  return [];
+}
+
+async function main() {
+  const todoistToken = process.env.TODOIST_API_TOKEN;
+  if (!todoistToken) {
+    console.error('Error: TODOIST_API_TOKEN required. Get one from https://todoist.com/app/settings/integrations/developer');
+    process.exit(1);
+  }
+  const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const supaKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supaUrl || !supaKey) {
+    console.error('Error: NEXT_PUBLIC_SUPABASE_URL/SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+
+  const todoist = new TodoistApi(todoistToken);
+  const supabase = createClient(supaUrl, supaKey);
+
+  const checkpoint = loadCheckpoint();
+  const processed = new Set(checkpoint.processedTaskIds || []);
+
+  console.log('=== backfill-eva-decision-log ===');
+  console.log('Mode:', DRY_RUN ? 'DRY-RUN' : 'LIVE');
+  console.log('Checkpoint:', CHECKPOINT_PATH);
+  console.log(`Resuming: ${processed.size} task(s) already processed, ${checkpoint.inserted} inserted, ${checkpoint.skipped} skipped`);
+
+  // 1. Find target projects.
+  const projects = normalizeListResponse(await todoist.getProjects());
+  const targetProjects = projects.filter((p) => TARGET_PROJECT_NAMES.includes(p.name));
+  if (targetProjects.length === 0) {
+    console.log('No target projects found (looking for: ' + TARGET_PROJECT_NAMES.join(', ') + ')');
+    process.exit(0);
+  }
+  console.log(`Found ${targetProjects.length} target project(s): ${targetProjects.map((p) => p.name).join(', ')}`);
+
+  // 2. Collect all tasks across target projects.
+  const tasks = [];
+  for (const p of targetProjects) {
+    const t = normalizeListResponse(await todoist.getTasks({ projectId: p.id }));
+    t.forEach((task) => tasks.push({ ...task, _project: p.name }));
+  }
+  console.log(`Total active tasks: ${tasks.length}`);
+
+  // 3. Iterate tasks → comments → parse → INSERT.
+  let batchCount = 0;
+  for (const task of tasks) {
+    if (processed.has(task.id)) {
+      continue;
+    }
+    const comments = normalizeListResponse(await todoist.getComments({ taskId: task.id }));
+    for (const c of comments) {
+      checkpoint.scanned += 1;
+      const envelope = parseEnvelope(c.content || '');
+      if (!envelope) continue; // Not a decision-log comment.
+
+      if (DRY_RUN) {
+        checkpoint.inserted += 1; // counted as would-insert
+        continue;
+      }
+
+      // Mirror REQUIRED_FIELDS verbatim into the row.
+      const row = {};
+      for (const k of ['schema_version', 'task_id', 'sequence', 'timestamp', 'flow', 'eva_reply_summary', 'operator_input_summary', 'override_reason', 'model', 'tokens_in', 'tokens_out', 'references']) {
+        row[k] = envelope[k];
+      }
+
+      const { error } = await supabase.from('eva_support_decision_log').insert(row);
+      if (error) {
+        if (error.code === '23505') {
+          // Unique violation — already imported. Idempotent skip.
+          checkpoint.skipped += 1;
+        } else if (error.code === 'PGRST205' || error.code === '42P01' || /schema cache/i.test(error.message)) {
+          console.error(`Error: eva_support_decision_log table not found. Apply migrations first.`);
+          saveCheckpoint(checkpoint);
+          process.exit(1);
+        } else {
+          console.error(`Insert failed for task=${envelope.task_id} sequence=${envelope.sequence}: ${error.message}`);
+          checkpoint.skipped += 1;
+        }
+      } else {
+        checkpoint.inserted += 1;
+      }
+    }
+
+    processed.add(task.id);
+    checkpoint.processedTaskIds = [...processed];
+    batchCount += 1;
+
+    if (batchCount % BATCH_SIZE === 0) {
+      saveCheckpoint(checkpoint);
+      console.log(`[checkpoint] ${batchCount} task(s) processed | inserted=${checkpoint.inserted} skipped=${checkpoint.skipped} scanned=${checkpoint.scanned}`);
+    }
+  }
+
+  saveCheckpoint(checkpoint);
+  console.log('\n=== Backfill complete ===');
+  console.log(`Tasks processed: ${processed.size} / ${tasks.length}`);
+  console.log(`Comments scanned: ${checkpoint.scanned}`);
+  console.log(`Envelopes ${DRY_RUN ? 'would-insert' : 'inserted'}: ${checkpoint.inserted}`);
+  console.log(`Skipped (already imported or insert error): ${checkpoint.skipped}`);
+  if (DRY_RUN) console.log('\nThis was a DRY-RUN — no rows were written. Re-run without --dry-run to apply.');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/tests/integration/eva-support/phase2-store-roundtrips.test.js
+++ b/tests/integration/eva-support/phase2-store-roundtrips.test.js
@@ -1,0 +1,205 @@
+/**
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TEST-4, TEST-5, TEST-7, TEST-10, US-003, US-004, US-006
+ *
+ * End-to-end integration test against the real Supabase DB. Exercises every
+ * Phase 2 store helper:
+ *   - decision-log-store.insertEntry / recentEntries / entriesForTask
+ *   - research-cache.set / get / purgeByQueryHash
+ *   - friday-outcome-bridge.writeOutcome / surfacePending CAS
+ *
+ * Tests are idempotent — every test cleans up its inserted rows in afterAll.
+ *
+ * Requires:
+ *   - NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env
+ *   - All 3 migrations applied (eva_support_decision_log, eva_support_research_cache, eva_friday_outcomes)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+import { insertEntry, recentEntries, entriesForTask } from '../../../lib/eva-support/decision-log-store.js';
+import { get, set, hashQuery, purgeByQueryHash } from '../../../lib/eva-support/research-cache.js';
+import { surfacePending, writeOutcome } from '../../../lib/eva-support/friday-outcome-bridge.js';
+
+const TEST_TASK_ID_PREFIX = 'integration-test-' + Date.now() + '-';
+const TEST_QUERY_PREFIX = 'integration-test-query-' + Date.now() + '-';
+const TEST_AGENDA_PREFIX = 'integration-test-agenda-' + Date.now() + '-';
+
+let supabase;
+
+beforeAll(() => {
+  supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+});
+
+afterAll(async () => {
+  // Clean up: remove test rows from all 3 tables.
+  await supabase.from('eva_support_decision_log').delete().like('task_id', `${TEST_TASK_ID_PREFIX}%`);
+  // research_cache: identified by query_text prefix
+  const { data: cacheRows } = await supabase
+    .from('eva_support_research_cache')
+    .select('query_hash')
+    .like('query_text', `${TEST_QUERY_PREFIX.toLowerCase()}%`);
+  for (const r of cacheRows || []) {
+    await supabase.from('eva_support_research_cache').delete().eq('query_hash', r.query_hash);
+  }
+  await supabase.from('eva_friday_outcomes').delete().like('agenda_item_ref', `${TEST_AGENDA_PREFIX}%`);
+});
+
+function envelope(overrides = {}) {
+  // Build base envelope, then apply non-task_id overrides via spread, then set
+  // the prefixed task_id last so a `task_id` override is used as a SUFFIX only.
+  const { task_id: suffix, ...rest } = overrides;
+  return {
+    schema_version: '1.0',
+    task_id: TEST_TASK_ID_PREFIX + (suffix || 't1'),
+    sequence: 1,
+    timestamp: new Date().toISOString(),
+    flow: 'decision',
+    eva_reply_summary: 'pick option A',
+    operator_input_summary: 'A or B?',
+    override_reason: null,
+    model: 'claude-opus-4-7',
+    tokens_in: 50,
+    tokens_out: 25,
+    references: [],
+    ...rest,
+  };
+}
+
+describe('decision-log-store integration (real DB)', () => {
+  it('inserts an entry, reads it back via entriesForTask, recentEntries surfaces it', async () => {
+    const e = envelope({ task_id: 'roundtrip-1' });
+    const insertResult = await insertEntry(e);
+    expect(insertResult.inserted).toBe(true);
+    expect(insertResult.verified).toBe(true);
+
+    const fetched = await entriesForTask(e.task_id);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].eva_reply_summary).toBe('pick option A');
+    expect(fetched[0].schema_version).toBe('1.0');
+
+    const recent = await recentEntries({ since: new Date(Date.now() - 3600000), limit: 50 });
+    expect(recent.some((r) => r.task_id === e.task_id)).toBe(true);
+  });
+
+  it('returns inserted:false on duplicate (task_id, sequence) — idempotent', async () => {
+    const e = envelope({ task_id: 'idempotent-1' });
+    const first = await insertEntry(e);
+    expect(first.inserted).toBe(true);
+
+    const second = await insertEntry(e);
+    expect(second.inserted).toBe(false);
+    expect(second.verified).toBe(true);
+  });
+
+  it('preserves schema_version=1.0 CHECK constraint — rejects other values', async () => {
+    const bad = envelope({ task_id: 'schema-version-check', schema_version: '2.0' });
+    await expect(insertEntry(bad)).rejects.toThrow();
+  });
+});
+
+describe('research-cache integration (real DB)', () => {
+  it('set → get round-trip returns the cached response', async () => {
+    const q = TEST_QUERY_PREFIX + 'roundtrip query';
+    const written = await set(q, 'the response text', { references: ['ref1'] });
+    expect(written.written).toBe(true);
+
+    const got = await get(q);
+    expect(got.hit).toBe(true);
+    expect(got.response).toBe('the response text');
+    expect(got.references).toEqual(['ref1']);
+    expect(got.hash).toBe(hashQuery(q));
+  });
+
+  it('hash normalization makes case + whitespace variants resolve to same cache entry', async () => {
+    const q1 = TEST_QUERY_PREFIX + 'CASE TEST';
+    const q2 = TEST_QUERY_PREFIX + 'case test';
+
+    await set(q1, 'cached body');
+    const got = await get('  ' + TEST_QUERY_PREFIX.toLowerCase() + 'CASE   TEST  ');
+    expect(got.hit).toBe(true);
+    expect(got.response).toBe('cached body');
+  });
+
+  it('purgeByQueryHash removes a specific entry', async () => {
+    const q = TEST_QUERY_PREFIX + 'purge target';
+    await set(q, 'will be deleted');
+    const hash = hashQuery(q);
+
+    const before = await get(q);
+    expect(before.hit).toBe(true);
+
+    const { deleted } = await purgeByQueryHash(hash);
+    expect(deleted).toBe(1);
+
+    const after = await get(q);
+    expect(after.hit).toBe(false);
+  });
+});
+
+describe('friday-outcome-bridge integration (real DB)', () => {
+  it('writeOutcome → surfacePending CAS round-trip', async () => {
+    const ref = TEST_AGENDA_PREFIX + 'cas-1';
+    const written = await writeOutcome({
+      agendaItemRef: ref,
+      outcome: 'accepted',
+      chairmanFeedback: 'go for it',
+      meetingDate: '2026-05-09',
+    });
+    expect(written.written).toBe(true);
+    expect(written.outcome_id).toBeTruthy();
+
+    // Surface should pick it up and CAS-mark consumed.
+    const surfaced = await surfacePending({ limit: 100 });
+    const ours = surfaced.find((r) => r.agenda_item_ref === ref);
+    expect(ours).toBeTruthy();
+    expect(ours.outcome).toBe('accepted');
+
+    // Second surface call: our row should NOT reappear (consumed_at set by CAS).
+    const surfacedAgain = await surfacePending({ limit: 100 });
+    expect(surfacedAgain.some((r) => r.agenda_item_ref === ref)).toBe(false);
+  });
+
+  it('rejects invalid outcome enum', async () => {
+    const result = await writeOutcome({
+      agendaItemRef: TEST_AGENDA_PREFIX + 'bad-enum',
+      outcome: 'invalid',
+      meetingDate: '2026-05-09',
+    });
+    expect(result.written).toBe(false);
+    expect(result.error.code).toBe('BAD_OUTCOME');
+  });
+});
+
+describe('RLS posture (TEST-10 security)', () => {
+  it('anon client cannot SELECT from eva_support_decision_log', async () => {
+    const anon = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    );
+    const { data, error } = await anon.from('eva_support_decision_log').select('task_id').limit(1);
+    // Either: error (denied) OR empty data (RLS filtered out). Both satisfy denial posture.
+    expect(error !== null || (Array.isArray(data) && data.length === 0)).toBe(true);
+  });
+
+  it('anon client cannot SELECT from eva_support_research_cache', async () => {
+    const anon = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    );
+    const { data, error } = await anon.from('eva_support_research_cache').select('query_hash').limit(1);
+    expect(error !== null || (Array.isArray(data) && data.length === 0)).toBe(true);
+  });
+
+  it('anon client cannot SELECT from eva_friday_outcomes', async () => {
+    const anon = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    );
+    const { data, error } = await anon.from('eva_friday_outcomes').select('outcome_id').limit(1);
+    expect(error !== null || (Array.isArray(data) && data.length === 0)).toBe(true);
+  });
+});

--- a/tests/unit/eva-support/decision-log-store.test.js
+++ b/tests/unit/eva-support/decision-log-store.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-2, FR-4, TEST-2, US-003
+ *
+ * Unit tests for lib/eva-support/decision-log-store.js — happy path, conflict
+ * (already-exists), schema-cache miss (fail-loud), and read-after-write mismatch.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { insertEntry, DecisionLogStoreError } from '../../../lib/eva-support/decision-log-store.js';
+
+function envelope(overrides = {}) {
+  return {
+    schema_version: '1.0',
+    task_id: 't-001',
+    sequence: 1,
+    timestamp: '2026-05-11T00:00:00.000Z',
+    flow: 'decision',
+    eva_reply_summary: 'pick A',
+    operator_input_summary: 'A or B?',
+    override_reason: null,
+    model: 'claude-opus-4-7',
+    tokens_in: 50,
+    tokens_out: 25,
+    references: [],
+    ...overrides,
+  };
+}
+
+function fakeClient({ insertResult, insertError, readResult, readError } = {}) {
+  const builder = {
+    from: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(),
+  };
+  // First call goes to INSERT path; ensure maybeSingle returns the insert response.
+  // For conflict path, the second maybeSingle returns the read response.
+  let calls = 0;
+  builder.maybeSingle = vi.fn().mockImplementation(() => {
+    calls += 1;
+    if (calls === 1) return Promise.resolve({ data: insertResult ?? null, error: insertError ?? null });
+    return Promise.resolve({ data: readResult ?? null, error: readError ?? null });
+  });
+  return builder;
+}
+
+describe('decision-log-store.insertEntry', () => {
+  it('returns inserted:true + verified:true on happy path', async () => {
+    const entry = envelope();
+    const client = fakeClient({ insertResult: { ...entry } });
+    const result = await insertEntry(entry, { client });
+    expect(result.inserted).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(client.from).toHaveBeenCalledWith('eva_support_decision_log');
+  });
+
+  it('returns inserted:false + verified:true on unique-key conflict (idempotent)', async () => {
+    const entry = envelope();
+    const client = fakeClient({
+      insertError: { code: '23505', message: 'duplicate key value violates unique constraint' },
+      readResult: { ...entry },
+    });
+    const result = await insertEntry(entry, { client });
+    expect(result.inserted).toBe(false);
+    expect(result.verified).toBe(true);
+  });
+
+  it('throws SCHEMA_CACHE_MISS when table not found (PGRST205)', async () => {
+    const entry = envelope();
+    const client = fakeClient({
+      insertError: { code: 'PGRST205', message: 'Could not find the table' },
+    });
+    await expect(insertEntry(entry, { client })).rejects.toThrow(/migration probably not applied/);
+  });
+
+  it('throws SCHEMA_CACHE_MISS on 42P01 relation does not exist', async () => {
+    const entry = envelope();
+    const client = fakeClient({
+      insertError: { code: '42P01', message: 'relation "eva_support_decision_log" does not exist' },
+    });
+    await expect(insertEntry(entry, { client })).rejects.toThrow(DecisionLogStoreError);
+  });
+
+  it('throws WRITEBACK_MISMATCH when read-after-write row differs from envelope', async () => {
+    const entry = envelope({ eva_reply_summary: 'pick A' });
+    const client = fakeClient({
+      insertResult: { ...entry, eva_reply_summary: 'pick B' }, // DB returned different value
+    });
+    await expect(insertEntry(entry, { client })).rejects.toThrow(/read-after-write mismatch/);
+  });
+
+  it('throws ENVELOPE_INCOMPLETE when a REQUIRED_FIELDS entry is missing', async () => {
+    const incomplete = envelope();
+    delete incomplete.model;
+    const client = fakeClient({});
+    await expect(insertEntry(incomplete, { client })).rejects.toThrow(/envelope missing required field "model"/);
+  });
+
+  it('fail-soft mode returns inserted:false, verified:false on non-conflict insert error', async () => {
+    const entry = envelope();
+    const client = fakeClient({
+      insertError: { code: '23514', message: 'check constraint violated' },
+    });
+    const result = await insertEntry(entry, { client, allowSoftFailures: true });
+    expect(result.inserted).toBe(false);
+    expect(result.verified).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/tests/unit/eva-support/envelope-v1-schema-pin.test.js
+++ b/tests/unit/eva-support/envelope-v1-schema-pin.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / FR-1, AC-2, TEST-1, US-002
+ *
+ * Static regression-pin: asserts envelope v1.0 schema is locked across BOTH sides:
+ *   (a) scripts/eva-support/decision-log-formatter.js literals: ENVELOPE_VERSION,
+ *       FENCE_LANG, REQUIRED_FIELDS (12 named entries)
+ *   (b) eva_support_decision_log table column list (excluding metadata cols
+ *       created_at + PK ordering)
+ *
+ * The pin is read-side: it consumes the formatter source via fs.readFileSync +
+ * regex (not an import — guards against accidental constant rename) and consults
+ * information_schema.columns for the table side. Either drift fails loudly.
+ *
+ * Dual-anchor pattern per SD-FDBK-ENH-CADENCE-VOCAB-DISCRIMINATOR-001 (PR #3685):
+ *   - whole-file regex for module-level constants
+ *   - scoped slice for the REQUIRED_FIELDS array literal
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const FORMATTER_PATH = resolve(
+  process.cwd(),
+  'scripts/eva-support/decision-log-formatter.js',
+);
+
+const EXPECTED_REQUIRED_FIELDS = [
+  'schema_version',
+  'task_id',
+  'sequence',
+  'timestamp',
+  'flow',
+  'eva_reply_summary',
+  'operator_input_summary',
+  'override_reason',
+  'model',
+  'tokens_in',
+  'tokens_out',
+  'references',
+];
+
+const EXPECTED_ENVELOPE_VERSION = '1.0';
+const EXPECTED_FENCE_LANG = 'eva-decision-log';
+
+describe('envelope v1.0 schema pin (formatter + eva_support_decision_log)', () => {
+  let formatterSrc;
+
+  beforeAll(() => {
+    formatterSrc = readFileSync(FORMATTER_PATH, 'utf8');
+  });
+
+  it('formatter file is readable', () => {
+    expect(formatterSrc.length).toBeGreaterThan(100);
+  });
+
+  describe('formatter literals (read via fs.readFileSync + regex)', () => {
+    it('ENVELOPE_VERSION literal is exactly "1.0"', () => {
+      const match = formatterSrc.match(
+        /export\s+const\s+ENVELOPE_VERSION\s*=\s*['"]([^'"]+)['"]/,
+      );
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe(EXPECTED_ENVELOPE_VERSION);
+    });
+
+    it('FENCE_LANG literal is exactly "eva-decision-log"', () => {
+      const match = formatterSrc.match(
+        /export\s+const\s+FENCE_LANG\s*=\s*['"]([^'"]+)['"]/,
+      );
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe(EXPECTED_FENCE_LANG);
+    });
+
+    it('REQUIRED_FIELDS array contains exactly the 12 expected fields in order', () => {
+      // Scoped slice for the REQUIRED_FIELDS array literal — dual-anchor pattern.
+      const startMatch = formatterSrc.match(
+        /export\s+const\s+REQUIRED_FIELDS\s*=\s*\[/,
+      );
+      expect(startMatch).not.toBeNull();
+      const start = startMatch.index + startMatch[0].length;
+      const end = formatterSrc.indexOf('];', start);
+      expect(end).toBeGreaterThan(start);
+
+      const arrayBody = formatterSrc.slice(start, end);
+      // Extract quoted-string entries
+      const entries = [...arrayBody.matchAll(/['"]([a-z_]+)['"]/g)].map(
+        (m) => m[1],
+      );
+
+      expect(entries).toEqual(EXPECTED_REQUIRED_FIELDS);
+    });
+  });
+
+  describe('eva_support_decision_log table columns', () => {
+    let columnNames;
+
+    beforeAll(async () => {
+      const supabase = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+        process.env.SUPABASE_SERVICE_ROLE_KEY,
+      );
+      const { data, error } = await supabase.rpc('exec_sql', {
+        sql_text:
+          "SELECT column_name FROM information_schema.columns WHERE table_name='eva_support_decision_log' AND table_schema='public' ORDER BY ordinal_position",
+      });
+      if (error) throw error;
+      const rows = data?.[0]?.result ?? [];
+      columnNames = rows.map((r) => r.column_name);
+    });
+
+    it('table exists with at least the 12 required columns (plus created_at)', () => {
+      expect(columnNames.length).toBeGreaterThanOrEqual(12);
+    });
+
+    it('table columns include every REQUIRED_FIELDS entry verbatim', () => {
+      for (const field of EXPECTED_REQUIRED_FIELDS) {
+        expect(columnNames).toContain(field);
+      }
+    });
+
+    it('table columns do NOT include extras beyond REQUIRED_FIELDS + created_at', () => {
+      // Allowed extras: created_at (metadata, not envelope)
+      const allowedExtras = new Set(['created_at']);
+      for (const col of columnNames) {
+        const isRequiredField = EXPECTED_REQUIRED_FIELDS.includes(col);
+        const isAllowedExtra = allowedExtras.has(col);
+        expect(
+          isRequiredField || isAllowedExtra,
+          `column "${col}" is neither a REQUIRED_FIELDS entry nor an allowed extra (${[...allowedExtras].join(', ')})`,
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/tests/unit/eva-support/friday-outcome-bridge.test.js
+++ b/tests/unit/eva-support/friday-outcome-bridge.test.js
@@ -1,0 +1,125 @@
+/**
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-5, FR-3, FR-6, TEST-7, US-006
+ *
+ * Unit tests for lib/eva-support/friday-outcome-bridge.js — surfacePending CAS,
+ * writeOutcome happy path / bad input, renderPushbackMarkdown.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { surfacePending, writeOutcome, renderPushbackMarkdown } from '../../../lib/eva-support/friday-outcome-bridge.js';
+
+function fakeClient({ readRows, readError, updateRows, updateError, insertResult, insertError } = {}) {
+  const c = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockImplementation(() => Promise.resolve({ data: readRows ?? null, error: readError ?? null })),
+    update: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: insertResult ?? null, error: insertError ?? null }),
+  };
+  // For update().in().is().select(): provide a separate await target.
+  // Chain ends with .select() which resolves.
+  c._afterUpdate = vi.fn().mockImplementation(() => Promise.resolve({ data: updateRows ?? null, error: updateError ?? null }));
+  c.select = vi.fn().mockImplementation(function (...args) {
+    if (c.update.mock.calls.length > 0 && c.in.mock.calls.length > 0) {
+      // We're in the post-update chain; return the await result.
+      return c._afterUpdate();
+    }
+    return c;
+  });
+  return c;
+}
+
+describe('surfacePending', () => {
+  it('returns surfaced rows that the CAS update successfully claimed', async () => {
+    const rows = [
+      { outcome_id: 'a', agenda_item_ref: 'item-1', outcome: 'accepted', chairman_feedback: null, meeting_date: '2026-05-09', created_at: '2026-05-09T10:00:00Z' },
+      { outcome_id: 'b', agenda_item_ref: 'item-2', outcome: 'deferred', chairman_feedback: 'next week', meeting_date: '2026-05-09', created_at: '2026-05-09T10:01:00Z' },
+    ];
+    const client = fakeClient({ readRows: rows, updateRows: [{ outcome_id: 'a' }, { outcome_id: 'b' }] });
+    const result = await surfacePending({ client });
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.outcome_id)).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array on read error (fail-soft)', async () => {
+    const client = fakeClient({ readError: { code: '42501', message: 'permission denied' } });
+    const result = await surfacePending({ client });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array on schema-cache miss', async () => {
+    const client = fakeClient({ readError: { code: 'PGRST205', message: 'Could not find the table' } });
+    const result = await surfacePending({ client });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when no unconsumed rows exist', async () => {
+    const client = fakeClient({ readRows: [] });
+    const result = await surfacePending({ client });
+    expect(result).toEqual([]);
+  });
+
+  it('filters out rows that lost the CAS race (parallel-safety)', async () => {
+    const rows = [
+      { outcome_id: 'a', agenda_item_ref: 'item-1', outcome: 'accepted', meeting_date: '2026-05-09' },
+      { outcome_id: 'b', agenda_item_ref: 'item-2', outcome: 'deferred', meeting_date: '2026-05-09' },
+    ];
+    // Only 'a' was claimed by this caller; 'b' was claimed by another session.
+    const client = fakeClient({ readRows: rows, updateRows: [{ outcome_id: 'a' }] });
+    const result = await surfacePending({ client });
+    expect(result).toHaveLength(1);
+    expect(result[0].outcome_id).toBe('a');
+  });
+});
+
+describe('writeOutcome', () => {
+  it('writes an outcome row on valid input', async () => {
+    const client = fakeClient({ insertResult: { outcome_id: 'new-uuid-1' } });
+    const result = await writeOutcome({ agendaItemRef: 'recommendation #1', outcome: 'accepted', meetingDate: '2026-05-09', client });
+    expect(result.written).toBe(true);
+    expect(result.outcome_id).toBe('new-uuid-1');
+  });
+
+  it('rejects invalid outcome enum', async () => {
+    const client = fakeClient({});
+    const result = await writeOutcome({ agendaItemRef: 'x', outcome: 'invalid-outcome', client });
+    expect(result.written).toBe(false);
+    expect(result.error.code).toBe('BAD_OUTCOME');
+  });
+
+  it('rejects missing agendaItemRef', async () => {
+    const client = fakeClient({});
+    const result = await writeOutcome({ outcome: 'accepted', client });
+    expect(result.written).toBe(false);
+    expect(result.error.code).toBe('BAD_INPUT');
+  });
+
+  it('fail-soft on schema-cache miss', async () => {
+    const client = fakeClient({ insertError: { code: 'PGRST205', message: 'Could not find the table' } });
+    const result = await writeOutcome({ agendaItemRef: 'x', outcome: 'accepted', client });
+    expect(result.written).toBe(false);
+  });
+});
+
+describe('renderPushbackMarkdown', () => {
+  it('returns empty string for zero rows (silent skip)', () => {
+    expect(renderPushbackMarkdown([])).toBe('');
+    expect(renderPushbackMarkdown(null)).toBe('');
+  });
+
+  it('renders each outcome as a bullet with feedback inlined when present', () => {
+    const md = renderPushbackMarkdown([
+      { outcome: 'accepted', meeting_date: '2026-05-09', agenda_item_ref: 'item-1', chairman_feedback: 'go for it' },
+      { outcome: 'rejected', meeting_date: '2026-05-09', agenda_item_ref: 'item-2', chairman_feedback: null },
+    ]);
+    expect(md).toContain('## Friday meeting outcomes');
+    expect(md).toContain('**ACCEPTED** (2026-05-09): item-1 — go for it');
+    expect(md).toContain('**REJECTED** (2026-05-09): item-2');
+    expect(md).not.toMatch(/item-2 — null/);
+  });
+});

--- a/tests/unit/eva-support/research-cache.test.js
+++ b/tests/unit/eva-support/research-cache.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-B / TR-3, FR-2, TEST-3, US-004
+ *
+ * Unit tests for lib/eva-support/research-cache.js — hash normalization,
+ * get/set happy paths, TTL miss, accessed_at bump, schema-cache-miss fail-soft.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { get, set, hashQuery, normalizeQuery } from '../../../lib/eva-support/research-cache.js';
+
+function fakeClient({ getResult, getError, upsertError } = {}) {
+  const c = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gt: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockImplementation(() => Promise.resolve({ error: upsertError ?? null })),
+    maybeSingle: vi.fn().mockResolvedValue({ data: getResult ?? null, error: getError ?? null }),
+  };
+  return c;
+}
+
+describe('normalizeQuery', () => {
+  it('lowercases + trims + collapses whitespace', () => {
+    expect(normalizeQuery('  Hello   World  ')).toBe('hello world');
+    expect(normalizeQuery('FOO\tBAR\n\nBAZ')).toBe('foo bar baz');
+  });
+
+  it('returns empty string for non-string input', () => {
+    expect(normalizeQuery(null)).toBe('');
+    expect(normalizeQuery(42)).toBe('');
+  });
+});
+
+describe('hashQuery', () => {
+  it('produces stable SHA-256 hex (64 chars) across whitespace/case variants', () => {
+    const a = hashQuery('What is X?');
+    const b = hashQuery('  what is x?  ');
+    const c = hashQuery('WHAT IS X?');
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces different hashes for different normalized queries', () => {
+    expect(hashQuery('foo')).not.toBe(hashQuery('bar'));
+  });
+});
+
+describe('research-cache.get', () => {
+  it('returns hit:true when row exists and ttl_until > now', async () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const client = fakeClient({ getResult: { response_text: 'cached', references: ['ref1'], ttl_until: future } });
+    const result = await get('What is X?', { client });
+    expect(result.hit).toBe(true);
+    expect(result.response).toBe('cached');
+    expect(result.references).toEqual(['ref1']);
+    expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns hit:false when no row matches', async () => {
+    const client = fakeClient({ getResult: null });
+    const result = await get('What is Y?', { client });
+    expect(result.hit).toBe(false);
+    expect(result.response).toBeNull();
+  });
+
+  it('fail-soft: returns hit:false on schema-cache miss', async () => {
+    const client = fakeClient({ getError: { code: 'PGRST205', message: 'Could not find the table' } });
+    const result = await get('What is Z?', { client });
+    expect(result.hit).toBe(false);
+  });
+
+  it('fail-soft: returns hit:false on any other error (default mode)', async () => {
+    const client = fakeClient({ getError: { code: '42501', message: 'permission denied' } });
+    const result = await get('What is Q?', { client });
+    expect(result.hit).toBe(false);
+  });
+});
+
+describe('research-cache.set', () => {
+  it('returns written:true on successful upsert', async () => {
+    const client = fakeClient({});
+    const result = await set('What is X?', 'response text', { client, references: ['r1'] });
+    expect(result.written).toBe(true);
+    expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(client.upsert).toHaveBeenCalled();
+  });
+
+  it('returns written:false when responseText is not a string', async () => {
+    const client = fakeClient({});
+    const result = await set('What is X?', null, { client });
+    expect(result.written).toBe(false);
+  });
+
+  it('fail-soft: returns written:false on upsert error', async () => {
+    const client = fakeClient({ upsertError: { code: '42501', message: 'permission denied' } });
+    const result = await set('What is X?', 'response', { client });
+    expect(result.written).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 2 of EVA Support CLI: adds `eva_support_decision_log` (envelope v1.0 verbatim columns), `eva_support_research_cache` (SHA-256 keyed, 7d TTL), `eva_friday_outcomes` (CAS consumed_at). Plus lib helpers, integration wirings, backfill script.
- Atomic DB-FIRST dual-write in `sub-flow-base.js` (optional `decisionLogStore` param — Phase 1 callers unaffected).
- Friday meeting Section 4b reads recent decision-log entries; outcomes write back via `eva_friday_outcomes` for next /eva-support pushback.
- 117/117 tests pass (12 files: 7 schema-pin + 7+12+10 unit + 11 integration + 70 Phase 1 regression).

## Unlock gate override
- `metadata.unlock_gate.type='usage_signal'` was NOT met (0 fenced eva-decision-log Todoist comments since Phase 1 ship 2026-04-27, empirically verified via Todoist API query).
- **Chairman authorized override 2026-05-11** with rationale: adoption gap is EXOGENOUS — chairman has been working upstream venture-workflow stages, hasn't structurally reached the to-do list phase where /eva-support is relevant. Phase 2 preserves optionality for when workflow clears, instead of forcing context-switch back weeks/months later.
- Override + empirical measurement recorded in SD `metadata.unlock_gate_override`.

## Constraints honored
- ✓ Phase 1 `decision-log-formatter.js` envelope v1.0 frozen (zero diff vs origin/main; static regression-pin via fs.readFileSync + dual-anchor regex)
- ✓ Migrations additive only (`CREATE TABLE IF NOT EXISTS` + rollback `DROP TABLE` comments)
- ✓ Service_role-only RLS on all 3 new tables (anon denial verified)
- ✓ Fail-soft posture on cache + Friday-outcome helpers (Phase 2 wiring never blocks Phase 1)
- ✓ 70/70 Phase 1 regression tests pass

## Test plan
- [x] Schema-pin tests pass (7/7) — formatter literal + table column alignment
- [x] Unit tests pass (29/29) — decision-log-store, research-cache, friday-outcome-bridge
- [x] Integration tests pass (11/11) — end-to-end against real DB, including RLS posture
- [x] Phase 1 regression tests pass (70/70) — no envelope mutation
- [ ] Live smoke (chairman): invoke /eva-support → verify DB row + Todoist comment both written
- [ ] Backfill --dry-run after first /eva-support invocation to verify Todoist→DB import path

## Handoffs
- LEAD-TO-PLAN: PASS @98% (22/22 gates)
- PLAN-TO-EXEC: PASS @96% (18/18 gates)
- EXEC-TO-PLAN: PASS @88% (23/23 gates)
- PLAN-TO-LEAD: PASS @91% (14/14 gates)
- LEAD-FINAL-APPROVAL: pending this PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)