### PR TITLE
fix(QF-20260511-556): accept 8-char short-UUID prefixes in 'Closes feedback' footer parser

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260511-228",
+  "sdKey": "QF-20260511-556",
   "workType": "QF",
-  "workKey": "QF-20260511-228",
-  "expectedBranch": "qf/QF-20260511-228",
-  "createdAt": "2026-05-11T10:05:31.255Z",
+  "workKey": "QF-20260511-556",
+  "expectedBranch": "qf/QF-20260511-556",
+  "createdAt": "2026-05-11T10:31:13.393Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/governance/resolve-feedback.js
+++ b/lib/governance/resolve-feedback.js
@@ -12,11 +12,17 @@
  *   call sites; consolidating prevents future drift between QF-completion and
  *   SD-completion paths.
  *
+ * QF-20260511-556 extends the parser to accept 8-char short-UUID prefixes
+ * (the form `/leo inbox` actually displays); short IDs are expanded via DB
+ * lookup with ambiguity guard. Closes harness backlog 769b4aa7.
+ *
  * @module lib/governance/resolve-feedback
  */
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SHORT_ID_REGEX = /^[0-9a-f]{8}$/i;
 const FOOTER_REGEX = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f-]{36})[ \t]*$/gim;
+const FOOTER_REGEX_LOOSE = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f][0-9a-f-]{7,35})[ \t]*$/gim;
 
 /**
  * Parse "Closes feedback <uuid>" / "Closes harness backlog <uuid>" footers
@@ -24,6 +30,10 @@ const FOOTER_REGEX = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f-
  *
  * Strict UUID v1-5 shape required; malformed UUIDs are silently dropped.
  * Returns deduplicated array of lowercased UUID strings preserving discovery order.
+ *
+ * Preserved for backward compatibility. Prefer `parseAndExpandFeedbackFooters`
+ * for new call sites — it also handles 8-char short IDs (as displayed in
+ * `/leo inbox`).
  *
  * @param {string} text
  * @returns {string[]}
@@ -40,6 +50,86 @@ export function parseFeedbackFooters(text) {
     out.push(uuid);
   }
   return out;
+}
+
+/**
+ * Parse footers (lenient) and expand 8-char short UUID prefixes via DB lookup.
+ *
+ * Accepts both full 36-char UUIDs and 8-char hex prefixes — the latter being
+ * the form actually displayed by `/leo inbox`, which previously caused silent
+ * misses (harness backlog 769b4aa7). Short prefixes are expanded by querying
+ * the `feedback` table over a UUID range; only exact-1 matches are accepted.
+ * Zero matches and ambiguous (>1) prefixes are warn-skipped.
+ *
+ * Fail-soft: DB errors on a single prefix produce a warning, not an exception;
+ * other footers in the same corpus still process.
+ *
+ * @param {Object} args
+ * @param {string} args.text
+ * @param {Object} args.supabase
+ * @returns {Promise<{ uuids: string[], warnings: string[] }>}
+ */
+export async function parseAndExpandFeedbackFooters({ text, supabase } = {}) {
+  if (!text || typeof text !== 'string') return { uuids: [], warnings: [] };
+  const seenUuids = new Set();
+  const seenShort = new Set();
+  const fullUuids = [];
+  const shortIds = [];
+  const warnings = [];
+
+  for (const match of text.matchAll(FOOTER_REGEX_LOOSE)) {
+    const token = (match[1] || '').toLowerCase();
+    if (UUID_REGEX.test(token)) {
+      if (!seenUuids.has(token)) {
+        seenUuids.add(token);
+        fullUuids.push(token);
+      }
+    } else if (SHORT_ID_REGEX.test(token)) {
+      if (!seenShort.has(token)) {
+        seenShort.add(token);
+        shortIds.push(token);
+      }
+    }
+  }
+
+  if (shortIds.length > 0 && !supabase) {
+    warnings.push(`Short UUID prefixes in footer but no supabase client: skipped ${shortIds.join(', ')}`);
+    return { uuids: fullUuids, warnings };
+  }
+
+  for (const prefix of shortIds) {
+    const lo = `${prefix}-0000-0000-0000-000000000000`;
+    const hi = `${prefix}-ffff-ffff-ffff-ffffffffffff`;
+    try {
+      const { data, error } = await supabase
+        .from('feedback')
+        .select('id')
+        .gte('id', lo)
+        .lte('id', hi)
+        .limit(2);
+      if (error) {
+        warnings.push(`feedback ${prefix}: lookup error: ${error.message}`);
+        continue;
+      }
+      if (!data || data.length === 0) {
+        warnings.push(`feedback ${prefix}: no match (use full 36-char UUID)`);
+        continue;
+      }
+      if (data.length > 1) {
+        warnings.push(`feedback ${prefix}: ambiguous (>=2 matches; use full 36-char UUID)`);
+        continue;
+      }
+      const fullId = String(data[0].id).toLowerCase();
+      if (!seenUuids.has(fullId)) {
+        seenUuids.add(fullId);
+        fullUuids.push(fullId);
+      }
+    } catch (err) {
+      warnings.push(`feedback ${prefix}: lookup threw: ${err?.message || String(err)}`);
+    }
+  }
+
+  return { uuids: fullUuids, warnings };
 }
 
 /**
@@ -96,4 +186,4 @@ export async function resolveFeedback({ supabase, feedbackId, quickFixId, sdId, 
   }
 }
 
-export default { parseFeedbackFooters, resolveFeedback };
+export default { parseFeedbackFooters, parseAndExpandFeedbackFooters, resolveFeedback };

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -32,7 +32,7 @@ import {
 } from './verification.js';
 import { runComplianceWithRefinement } from './compliance-loop.js';
 import { prompt, displayCompletionSummary } from './cli.js';
-import { resolveFeedback, parseFeedbackFooters } from '../../../lib/governance/resolve-feedback.js';
+import { resolveFeedback, parseAndExpandFeedbackFooters } from '../../../lib/governance/resolve-feedback.js';
 import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -387,7 +387,8 @@ export async function completeQuickFix(qfId, options = {}) {
  *
  * Collects text from (a) PR body via `gh pr view --json body,commits` and
  * (b) the local commit message via `git log -1 --format=%B <sha>`, runs
- * parseFeedbackFooters, and calls resolveFeedback per UUID. All steps are
+ * parseAndExpandFeedbackFooters (which also expands 8-char short IDs via DB
+ * lookup, QF-20260511-556), and calls resolveFeedback per UUID. All steps are
  * defensive — any failure logs a warning and continues without blocking QF
  * completion (post-merge is informational, not gating).
  *
@@ -438,7 +439,13 @@ async function resolveLinkedFeedbackRows(supabase, qf, qfId, prUrl, commitSha, t
   // Source 3: QF description (may carry the link from issue creation)
   if (qf?.description) corpus.push(qf.description);
 
-  const uuids = parseFeedbackFooters(corpus.join('\n'));
+  const { uuids, warnings } = await parseAndExpandFeedbackFooters({
+    text: corpus.join('\n'),
+    supabase,
+  });
+  for (const w of warnings) {
+    console.log(`   ⚠️  ${w}`);
+  }
   if (uuids.length === 0) {
     return;
   }

--- a/tests/unit/governance/resolve-feedback.test.js
+++ b/tests/unit/governance/resolve-feedback.test.js
@@ -1,6 +1,17 @@
 // SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-1 unit tests for lib/governance/resolve-feedback.js
+// QF-20260511-556: parseAndExpandFeedbackFooters short-UUID acceptance.
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { resolveFeedback, parseFeedbackFooters } from '../../../lib/governance/resolve-feedback.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveFeedback, parseFeedbackFooters, parseAndExpandFeedbackFooters } from '../../../lib/governance/resolve-feedback.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const RESOLVE_FB_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../../../lib/governance/resolve-feedback.js'),
+  'utf-8'
+);
 
 const VALID_UUID_1 = '6639e063-b269-4dd0-bfef-fabd8ef0fc09';
 const VALID_UUID_2 = '8ccd01b1-5e60-4c79-8280-20967e515580';
@@ -133,5 +144,149 @@ describe('resolveFeedback', () => {
     expect(sb._captured.update.resolution_notes).toBeUndefined();
     expect(sb._captured.update.status).toBe('resolved');
     expect(sb._captured.update.resolved_at).toBeDefined();
+  });
+});
+
+// QF-20260511-556: short-UUID prefix expansion via DB lookup
+function makeLookupSupabase({ rowsByRange = {}, error = null } = {}) {
+  const calls = [];
+  const builder = (rows) => {
+    const chain = {
+      _table: null,
+      _gte: null,
+      _lte: null,
+      from(t) { chain._table = t; return chain; },
+      select() { return chain; },
+      gte(c, v) { chain._gte = { c, v }; return chain; },
+      lte(c, v) { chain._lte = { c, v }; return chain; },
+      limit() { return Promise.resolve({ data: rows, error }); },
+    };
+    return chain;
+  };
+  return {
+    from(table) {
+      const c = builder(null);
+      c.from(table);
+      const origGte = c.gte.bind(c);
+      c.gte = (col, val) => {
+        origGte(col, val);
+        calls.push({ table, gte: val });
+        // Pull rows by gte-prefix key (8-char head)
+        const head = val.slice(0, 8);
+        const rows = rowsByRange[head] || [];
+        const r = builder(rows);
+        r._table = table;
+        return r;
+      };
+      return c;
+    },
+    _calls: calls,
+  };
+}
+
+describe('parseAndExpandFeedbackFooters', () => {
+  it('passes through full 36-char UUIDs without DB lookup', async () => {
+    const sb = makeLookupSupabase({});
+    const text = `Closes feedback ${VALID_UUID_1}\nCloses harness backlog ${VALID_UUID_2}\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual([VALID_UUID_1, VALID_UUID_2]);
+    expect(result.warnings).toEqual([]);
+    expect(sb._calls.length).toBe(0);
+  });
+
+  it('expands an 8-char short ID with a unique DB match', async () => {
+    const sb = makeLookupSupabase({ rowsByRange: { 'acd4e5ab': [{ id: 'acd4e5ab-1111-2222-3333-444444444444' }] } });
+    const text = `body\n\nCloses feedback acd4e5ab\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual(['acd4e5ab-1111-2222-3333-444444444444']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warn-skips ambiguous (>=2 matches) short ID', async () => {
+    const sb = makeLookupSupabase({
+      rowsByRange: { '12345678': [
+        { id: '12345678-aaaa-aaaa-aaaa-aaaaaaaaaaaa' },
+        { id: '12345678-bbbb-bbbb-bbbb-bbbbbbbbbbbb' },
+      ] },
+    });
+    const text = `Closes feedback 12345678\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toMatch(/12345678/);
+    expect(result.warnings[0]).toMatch(/ambiguous/i);
+  });
+
+  it('warn-skips short ID with no match', async () => {
+    const sb = makeLookupSupabase({});
+    const text = `Closes feedback deadbeef\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toMatch(/deadbeef/);
+    expect(result.warnings[0]).toMatch(/no match/i);
+  });
+
+  it('merges full + short, deduping when short expands to a full already present', async () => {
+    const headOfFull = VALID_UUID_1.slice(0, 8);
+    const sb = makeLookupSupabase({ rowsByRange: { [headOfFull]: [{ id: VALID_UUID_1 }] } });
+    const text = `Closes feedback ${VALID_UUID_1}\nCloses harness backlog ${headOfFull}\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual([VALID_UUID_1]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('silently drops non-hex / wrong-length tokens (e.g. 7-char, 12-char no-dashes)', async () => {
+    const sb = makeLookupSupabase({});
+    const text = `Closes feedback abcdef0\nCloses feedback abcdef0123ab\nCloses feedback zzzzzzzz\n`;
+    const result = await parseAndExpandFeedbackFooters({ text, supabase: sb });
+    expect(result.uuids).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('returns warning if short IDs are present but no supabase is supplied', async () => {
+    const text = `Closes feedback acd4e5ab\n`;
+    const result = await parseAndExpandFeedbackFooters({ text });
+    expect(result.uuids).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toMatch(/no supabase/i);
+  });
+
+  it('returns empty + no warnings for empty/null input', async () => {
+    expect(await parseAndExpandFeedbackFooters({ text: '', supabase: null })).toEqual({ uuids: [], warnings: [] });
+    expect(await parseAndExpandFeedbackFooters({ text: null, supabase: null })).toEqual({ uuids: [], warnings: [] });
+    expect(await parseAndExpandFeedbackFooters({})).toEqual({ uuids: [], warnings: [] });
+  });
+});
+
+// Static-pin regression: lock in the contracts so future drift is caught.
+describe('resolve-feedback.js static-pin', () => {
+  it('UUID_REGEX matches canonical UUID v1-5 shape (36 chars, dashed)', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^const UUID_REGEX = \/\^\[0-9a-f\]\{8\}-\[0-9a-f\]\{4\}-\[0-9a-f\]\{4\}-\[0-9a-f\]\{4\}-\[0-9a-f\]\{12\}\$\/i;$/m);
+  });
+
+  it('SHORT_ID_REGEX matches exactly 8 hex chars (matches /leo inbox display format)', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^const SHORT_ID_REGEX = \/\^\[0-9a-f\]\{8\}\$\/i;$/m);
+  });
+
+  it('FOOTER_REGEX_LOOSE accepts 8-36 char hex-and-dash payloads', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^const FOOTER_REGEX_LOOSE = \/\^\[ \\t\]\*Closes\\s\+\(\?:feedback\|harness\\s\+backlog\)\\s\+\(\[0-9a-f\]\[0-9a-f-\]\{7,35\}\)\[ \\t\]\*\$\/gim;$/m);
+  });
+
+  it('UUID range bounds use canonical "0000-0000-0000-000000000000" / "ffff-ffff-ffff-ffffffffffff" tails', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/`\$\{prefix\}-0000-0000-0000-000000000000`/);
+    expect(RESOLVE_FB_SRC).toMatch(/`\$\{prefix\}-ffff-ffff-ffff-ffffffffffff`/);
+  });
+
+  it('expand path uses .gte() / .lte() / .limit(2) on the feedback table (NOT LIKE — uuid columns reject LIKE)', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/\.from\(['"]feedback['"]\)[\s\S]*?\.gte\(['"]id['"], lo\)[\s\S]*?\.lte\(['"]id['"], hi\)[\s\S]*?\.limit\(2\)/);
+    expect(RESOLVE_FB_SRC).not.toMatch(/\.like\(['"]id['"]/);
+    expect(RESOLVE_FB_SRC).not.toMatch(/\.ilike\(['"]id['"]/);
+  });
+
+  it('parseAndExpandFeedbackFooters is exported alongside backward-compat parseFeedbackFooters', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^export async function parseAndExpandFeedbackFooters/m);
+    expect(RESOLVE_FB_SRC).toMatch(/^export function parseFeedbackFooters/m);
+    expect(RESOLVE_FB_SRC).toMatch(/parseFeedbackFooters,\s*parseAndExpandFeedbackFooters,\s*resolveFeedback/);
   });
 });


### PR DESCRIPTION
## Summary
- Extend `lib/governance/resolve-feedback.js` with `parseAndExpandFeedbackFooters` that accepts both 36-char full UUIDs and 8-char hex prefixes (the form `/leo inbox` actually displays)
- Short prefixes expand via UUID range query (`gte`/`lte`) with strict ambiguity guard — exactly-1 match required; 0 or >1 warn-skip
- `parseFeedbackFooters` preserved for backward compat; one caller (`complete-quick-fix/orchestrator.js`) migrated to the new function
- **Self-validating ship**: this PR's footer is `Closes feedback 769b4aa7` (8-char short ID — the very form this QF teaches the parser to accept). Post-merge auto-resolver exercises the new path on its own ship.

## Why
`/leo inbox` only displays 8-char UUID prefixes, naturally tempting short-ID footers in PR/commit messages. Old `FOOTER_REGEX` required full 36-char — silent miss, no log, zero parses. Witnessed in PR #3695 (QF-228) where `Closes feedback acd4e5ab` was silently dropped; manual `resolveFeedback()` call needed afterward.

## Test plan
- [x] 29/29 unit tests pass (15 prior + 7 new behavior + 7 new static-pin regression)
- [x] Live DB smoke: short prefix `769b4aa7` resolves to full UUID `769b4aa7-7ba5-458b-add1-990a42a90a02`, warnings empty
- [x] Pre-existing baseline failures (manifesto-mode/hard-halt-protocol/chairman-escalation/guardrail-intelligence-analyzer) verified unrelated via stash bisect
- [x] No `LIKE`/`ILIKE` on uuid column (PostgREST rejects); pinned in static-guard
- [ ] Post-merge auto-resolver fires on `Closes feedback 769b4aa7` footer (8-char) — self-validating

Closes feedback 769b4aa7

🤖 Generated with [Claude Code](https://claude.com/claude-code)