### PR TITLE
fix(QF-20260511-361): task-hydrator loadSD migrates to canonical resolveSdInput

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260511-122",
+  "sdKey": "QF-20260511-361",
   "workType": "QF",
-  "workKey": "QF-20260511-122",
-  "expectedBranch": "qf/QF-20260511-122",
-  "createdAt": "2026-05-11T11:01:07.898Z",
+  "workKey": "QF-20260511-361",
+  "expectedBranch": "qf/QF-20260511-361",
+  "createdAt": "2026-05-11T11:26:59.280Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/tasks/task-hydrator.js
+++ b/lib/tasks/task-hydrator.js
@@ -15,6 +15,7 @@ import { readFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { selectTrack, TRACK_CONFIG } from './track-selector.js';
+import { resolveSdInput } from '../../scripts/lib/sd-id-resolver.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, 'templates', 'tracks');
@@ -30,33 +31,20 @@ export class TaskHydrator {
 
   /**
    * Load an SD from the database
-   * @param {string} sdId - SD identifier (id or uuid_id)
+   * @param {string} sdId - SD identifier (UUID or sd_key form)
    * @returns {Object} SD data
    */
   async loadSD(sdId) {
-    // Try by id first, then by uuid_id
-    let { data: sd, error } = await this.supabase
-      .from('strategic_directives_v2')
-      .select('*')
-      .eq('id', sdId)
-      .single();
-
-    if (error || !sd) {
-      const result = await this.supabase
-        .from('strategic_directives_v2')
-        .select('*')
-        .eq('uuid_id', sdId)
-        .single();
-
-      sd = result.data;
-      error = result.error;
+    // Use the canonical resolveSdInput helper so sd_key inputs (the CLI shape
+    // passed by handoff.js execution-helpers) do not crash with PostgREST 22P02
+    // against the uuid `id` column. Preserve the legacy "Failed to load SD"
+    // error envelope so existing callers continue to read the same shape.
+    try {
+      const { sd } = await resolveSdInput(sdId, this.supabase);
+      return sd;
+    } catch (err) {
+      throw new Error(`Failed to load SD ${sdId}: ${err.message}`);
     }
-
-    if (error) {
-      throw new Error(`Failed to load SD ${sdId}: ${error.message}`);
-    }
-
-    return sd;
   }
 
   /**

--- a/tests/unit/regression-pins/task-hydrator-load-sd-pins.test.js
+++ b/tests/unit/regression-pins/task-hydrator-load-sd-pins.test.js
@@ -1,0 +1,67 @@
+// QF-20260511-361 — static-guard regression pins.
+//
+// Pins lib/tasks/task-hydrator.js loadSD() to the canonical resolveSdInput
+// helper. Before this fix, loadSD did .eq('id', sdId) then .eq('uuid_id', sdId);
+// both crashed with PostgREST 22P02 ("invalid input syntax for type uuid")
+// when sdId was in sd_key form (the CLI shape passed by handoff.js
+// execution-helpers). Witness: feedback 7d1f66f2 — 3 hits in one session on
+// SD-FDBK-INFRA-TYPE-SOURCE-TRUTH-001.
+//
+// Same class as the SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001 11-callsite
+// sweep but this callsite was missed.
+//
+// These pins read the source file as a string (no module load) and assert
+// that the migration stays in place.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../..');
+
+function read(rel) {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+describe('QF-20260511-361 task-hydrator loadSD canonical resolver pins', () => {
+  it('lib/tasks/task-hydrator.js imports resolveSdInput from scripts/lib/sd-id-resolver', () => {
+    const src = read('lib/tasks/task-hydrator.js');
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveSdInput\b[^}]*\}\s*from\s*['"][^'"]*scripts\/lib\/sd-id-resolver(?:\.js)?['"]/
+    );
+  });
+
+  it('loadSD method calls resolveSdInput', () => {
+    const src = read('lib/tasks/task-hydrator.js');
+    const start = src.indexOf('async loadSD(');
+    expect(start).toBeGreaterThan(-1);
+    // Bound the slice to the loadSD method body (next ~1500 chars covers the body).
+    const body = src.slice(start, start + 1500);
+    expect(body).toMatch(/\bresolveSdInput\s*\(\s*sdId\s*,\s*this\.supabase\s*\)/);
+  });
+
+  it('loadSD body does NOT contain the legacy .eq(\'id\', sdId) / .eq(\'uuid_id\', sdId) chain', () => {
+    const src = read('lib/tasks/task-hydrator.js');
+    const start = src.indexOf('async loadSD(');
+    const body = src.slice(start, start + 1500);
+    // Both legacy patterns must be gone from the loadSD body.
+    expect(body).not.toMatch(/\.eq\(\s*['"]id['"]\s*,\s*sdId/);
+    expect(body).not.toMatch(/\.eq\(\s*['"]uuid_id['"]\s*,\s*sdId/);
+  });
+
+  it('loadSD preserves the legacy "Failed to load SD" error envelope for caller compat', () => {
+    const src = read('lib/tasks/task-hydrator.js');
+    const start = src.indexOf('async loadSD(');
+    const body = src.slice(start, start + 1500);
+    // Existing callers (and possibly tests) parse the prefix of this error message.
+    expect(body).toMatch(/Failed to load SD\s*\$\{sdId\}:/);
+  });
+
+  it('loadSD wraps resolveSdInput in try/catch to translate errors', () => {
+    const src = read('lib/tasks/task-hydrator.js');
+    const start = src.indexOf('async loadSD(');
+    const body = src.slice(start, start + 1500);
+    // resolveSdInput throws on input-validation and on not-found; the wrapper
+    // must catch so we keep the legacy Error envelope.
+    expect(body).toMatch(/try\s*\{[\s\S]*resolveSdInput[\s\S]*\}\s*catch\s*\(/);
+  });
+});


### PR DESCRIPTION
## Summary

- `lib/tasks/task-hydrator.js` `loadSD()` previously did `.eq('id', sdId)` then `.eq('uuid_id', sdId)` — both crashed with PostgREST 22P02 ("invalid input syntax for type uuid") when `sdId` was in `sd_key` form, which is the canonical CLI shape passed by handoff.js execution-helpers `hydrateAndOutputTasks`.
- Migrated to canonical `resolveSdInput` from `scripts/lib/sd-id-resolver.js` (single OR query, fail-fast contract).
- Preserved the legacy `Failed to load SD ${sdId}: ${msg}` error envelope so existing callers see the same Error shape.
- 5-case static-pin regression test in `tests/unit/regression-pins/task-hydrator-load-sd-pins.test.js`.

## Root cause class

Same as the SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001 11-callsite sweep (commit `17749fdfce`), but this callsite was missed. Closes the writer/consumer asymmetry for the task-hydration consumer of handoff.js's `sdId` arg.

## Witness

Feedback `7d1f66f2-d398-49da-bee2-9c2834959670` — Task hydration skipped at every handoff with `Failed to load SD <SD-KEY>: invalid input syntax for type uuid: "<SD-KEY>"`. Witnessed 3 times in single session 2026-05-10 (LEAD-TO-PLAN, PLAN-TO-EXEC, PLAN-TO-LEAD on SD-FDBK-INFRA-TYPE-SOURCE-TRUTH-001).

## Test plan

- [x] `npx vitest run tests/unit/regression-pins/task-hydrator-load-sd-pins.test.js` — 5/5 PASS
- [x] Source LOC: 11 additions / 19 deletions / net -8 (Tier-1, well within ≤30 source cap)
- [x] Test LOC: 67 new (static-pin pattern)
- [ ] Self-validating: next handoff.js invocation on any SD passed by `sd_key` will exercise the new path.

Closes feedback 7d1f66f2-d398-49da-bee2-9c2834959670

🤖 Generated with [Claude Code](https://claude.com/claude-code)