### PR TITLE
fix(QF-20260511-205): countLocBySplit 2-dot → 3-dot diff syntax (verifier inflation)

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -20,8 +20,13 @@ import { execSync } from 'child_process';
 const TEST_FILE_PATTERN = /(\.test\.|\.spec\.|\b__tests__\b|\btests\/|\be2e\/|\bplaywright\b)/i;
 
 /**
- * Walk `git diff --numstat <baseRef>..HEAD` and return source/test/total LOC
+ * Walk `git diff --numstat <baseRef>...HEAD` and return source/test/total LOC
  * counts split by path pattern, plus pure-deletion-file LOC for tier classification.
+ *
+ * QF-20260511-205: 3-dot (symmetric difference from common ancestor) is required;
+ * 2-dot inflates counts by including main-side commits when origin/main has
+ * advanced since branch divergence. Sister fix to QF-20260503-820 which migrated
+ * analyzeGitDiff() at line ~370 to the same 3-dot syntax.
  *
  * Used by both autoDetectGitInfo paths (PR-metadata + legacy worktree) so the
  * conflation bug (single actual_loc) can't recur.
@@ -40,7 +45,7 @@ export function countLocBySplit(testDir, baseRef = 'origin/main') {
   const result = { source: 0, test: 0, total: 0, sourceDeletionLoc: 0 };
   let numstat = '';
   try {
-    numstat = execSync(`git diff --numstat ${baseRef}..HEAD`, {
+    numstat = execSync(`git diff --numstat ${baseRef}...HEAD`, {
       cwd: testDir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -59,7 +64,7 @@ export function countLocBySplit(testDir, baseRef = 'origin/main') {
   // as not-counting-against-tier-cap (pure dead-code removal).
   const deletedPaths = new Set();
   try {
-    const nameStatus = execSync(`git diff --name-status --diff-filter=D ${baseRef}..HEAD`, {
+    const nameStatus = execSync(`git diff --name-status --diff-filter=D ${baseRef}...HEAD`, {
       cwd: testDir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -288,8 +293,8 @@ export function autoDetectGitInfo(testDir, options = {}) {
   if (!isInQFWorktree(testDir)) {
     throw new Error(
       `Cannot auto-detect git info: CWD '${testDir}' is not a recognized QF worktree, ` +
-      `and --pr-url was not supplied. Pass --commit-sha / --branch-name / --actual-loc explicitly, ` +
-      `or pass --pr-url <github-pr-url> for post-merge auto-detection.`
+      'and --pr-url was not supplied. Pass --commit-sha / --branch-name / --actual-loc explicitly, ' +
+      'or pass --pr-url <github-pr-url> for post-merge auto-detection.'
     );
   }
 

--- a/tests/unit/scripts/complete-quick-fix-loc-split.test.js
+++ b/tests/unit/scripts/complete-quick-fix-loc-split.test.js
@@ -74,11 +74,19 @@ describe('SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 — countLocBySplit', () =>
     expect(r).toEqual({ source: 0, test: 0, total: 0, sourceDeletionLoc: 0 });
   });
 
-  it('honors custom baseRef', () => {
+  it('honors custom baseRef (QF-20260511-205: 3-dot symmetric diff)', () => {
     execSyncMock.mockReturnValue('5\t1\tlib/x.js');
     countLocBySplit('/fake/repo', 'origin/develop');
+    // QF-20260511-205: must use 3-dot (origin/develop...HEAD), NOT 2-dot.
+    // 2-dot inflates by including main-side commits when origin/main has
+    // advanced since branch divergence (witnessed 9468 LOC across 752 files
+    // on a branch with zero unique commits when 2-dot was in use).
     expect(execSyncMock).toHaveBeenCalledWith(
-      expect.stringContaining('origin/develop..HEAD'),
+      expect.stringContaining('origin/develop...HEAD'),
+      expect.any(Object)
+    );
+    expect(execSyncMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/origin\/develop\.\.HEAD(?!\.)/),
       expect.any(Object)
     );
   });
@@ -163,5 +171,68 @@ describe('SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 — static source-code regr
     expect(src).toContain('actual_loc_reasonable');
     expect(src).toContain('completed_requires_verification');
     expect(src).toContain('force_completed = TRUE');
+  });
+});
+
+describe('QF-20260511-205 — countLocBySplit uses 3-dot diff syntax (static-pin)', () => {
+  let src;
+  beforeEach(() => {
+    src = readFileSync(
+      resolve(REPO_ROOT, 'scripts/modules/complete-quick-fix/git-operations.js'),
+      'utf8'
+    );
+  });
+
+  it('numstat call uses 3-dot ${baseRef}...HEAD (not 2-dot)', () => {
+    expect(src).toContain('git diff --numstat ${baseRef}...HEAD');
+    // Guard against accidental 2-dot regression — the ..HEAD pattern must not
+    // appear with exactly two dots in the numstat command line.
+    expect(src).not.toMatch(/git diff --numstat \$\{baseRef\}\.\.HEAD(?!\.)/);
+  });
+
+  it('name-status (--diff-filter=D) call uses 3-dot ${baseRef}...HEAD', () => {
+    expect(src).toContain('git diff --name-status --diff-filter=D ${baseRef}...HEAD');
+    expect(src).not.toMatch(/git diff --name-status --diff-filter=D \$\{baseRef\}\.\.HEAD(?!\.)/);
+  });
+
+  it('docstring documents 3-dot semantics + cross-references sister QF-20260503-820', () => {
+    // Pin doc-comment changes so future cleanups don't silently drop the
+    // reason 3-dot is required (would invite a regression to the old 2-dot
+    // form that produced 9468-LOC inflation on this branch's repro case).
+    expect(src).toContain('<baseRef>...HEAD');
+    expect(src).toContain('QF-20260511-205');
+    expect(src).toContain('QF-20260503-820');
+  });
+
+  it('countLocBySplit body contains no 2-dot ${baseRef}..HEAD occurrence (anchored)', () => {
+    // Scope to the countLocBySplit function body so other call sites
+    // (e.g. analyzeGitDiff, which already used 3-dot per QF-20260503-820)
+    // aren't matched. The function ends before validateBranchName.
+    const fnStart = src.indexOf('export function countLocBySplit');
+    expect(fnStart).toBeGreaterThan(0);
+    const fnEnd = src.indexOf('function validateBranchName', fnStart);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const body = src.slice(fnStart, fnEnd);
+    expect(body).not.toMatch(/\$\{baseRef\}\.\.HEAD(?!\.)/);
+  });
+});
+
+describe('QF-20260511-205 — countLocBySplit behavior with 3-dot diff', () => {
+  beforeEach(() => execSyncMock.mockReset());
+
+  it('passes the 3-dot ref form to execSync for the default origin/main base', () => {
+    execSyncMock.mockReturnValue('10\t2\tlib/x.js');
+    countLocBySplit('/fake/repo');
+    // First call is the numstat; assert command shape.
+    const firstCall = execSyncMock.mock.calls[0];
+    expect(firstCall[0]).toBe('git diff --numstat origin/main...HEAD');
+  });
+
+  it('name-status call (deletion enumeration) also uses 3-dot', () => {
+    execSyncMock.mockReturnValue('10\t2\tlib/x.js');
+    countLocBySplit('/fake/repo', 'origin/main');
+    // Second call is the --diff-filter=D enumeration.
+    const secondCall = execSyncMock.mock.calls[1];
+    expect(secondCall?.[0]).toBe('git diff --name-status --diff-filter=D origin/main...HEAD');
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/modules/complete-quick-fix/git-operations.js::countLocBySplit` was using 2-dot diff (`\${baseRef}..HEAD`) which over-counts files from `origin/main` commits when main has advanced since branch divergence.
- Sister fix to QF-20260503-820 (migrated `analyzeGitDiff` to 3-dot). `countLocBySplit` was missed in that sweep.
- Local repro on this branch: 2-dot reported **9468 LOC across 752 files** for a branch with zero unique commits. 3-dot reports **0 LOC** (correct).

## Changes (Tier-1: 11 src churn + 75 test churn)
- `numstat` call: `${baseRef}..HEAD` → `${baseRef}...HEAD`
- `name-status --diff-filter=D` call: same 3-dot migration
- Docstring documents 3-dot requirement + cross-refs sister QF
- Updated `'honors custom baseRef'` test to assert 3-dot + negative-regression against 2-dot
- Added 4 static-pin tests anchoring 3-dot in source + scoping no-2-dot guard to `countLocBySplit` body
- Added 2 behavior tests asserting exact command shape to execSync (numstat + name-status)

## Test plan
- [x] 23/23 vitest pass (`npx vitest run tests/unit/scripts/complete-quick-fix-loc-split.test.js`)
- [x] Live repro: `countLocBySplit(repoRoot)` returns 0 LOC instead of 9468 on already-merged downstream branch
- [x] Pre-commit gates: Work accumulation, Scope, LOC threshold, root temp files, blacklisted words all PASS

## Closes
feedback: 9cda54e5 (harness backlog item witnessed across 5+ recent QFs forcing --actual-source-loc / --actual-test-loc manual overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)