### PR TITLE
feat(QF-20260511-876): FR-C generator fixture-discriminator + nightly sentinel sweep

### DIFF
--- a/lib/eva/quality-findings/sd-generator.js
+++ b/lib/eva/quality-findings/sd-generator.js
@@ -305,6 +305,17 @@ export async function writeAuditLog(supabase, eventType, payload, opts = {}) {
   }
 }
 
+// Test-fixture sentinels (PAT-TEST-FIXTURE-PROMOTION-001 / QF-20260511-876).
+// Tests opt out via FR_C_ALLOW_FIXTURE_FINDINGS=true.
+export const FIXTURE_VENTURE_ID_PREFIX = 'fc000000-';
+export const FIXTURE_SIG_PREFIX = 't-';
+export function isLikelyTestFixture(row) {
+  if (!row) return false;
+  if (typeof row.venture_id === 'string' && row.venture_id.startsWith(FIXTURE_VENTURE_ID_PREFIX)) return true;
+  const sig = row.evidence_pointer && row.evidence_pointer.sig;
+  return typeof sig === 'string' && sig.startsWith(FIXTURE_SIG_PREFIX);
+}
+
 /**
  * Select pending FAIL/WARN-equivalent findings, optionally scoped to one venture.
  *
@@ -322,7 +333,18 @@ export async function selectPendingFindings(supabase, ventureId = null) {
   if (ventureId) query = query.eq('venture_id', ventureId);
   const { data, error } = await query;
   if (error) throw new Error('selectPendingFindings failed: ' + error.message);
-  return data || [];
+  const rows = data || [];
+  if (process.env.FR_C_ALLOW_FIXTURE_FINDINGS === 'true') return rows;
+  const out = [];
+  for (const r of rows) {
+    if (isLikelyTestFixture(r)) {
+      await writeAuditLog(supabase, 'test_fixture_skipped', {
+        finding_id: r.id, venture_id: r.venture_id, sig: r.evidence_pointer?.sig ?? null,
+        finding_category: r.finding_category, severity: r.severity,
+      }, { entityId: r.id, severity: 'warning' });
+    } else out.push(r);
+  }
+  return out;
 }
 
 /**

--- a/scripts/audit-test-fixture-leak.mjs
+++ b/scripts/audit-test-fixture-leak.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Nightly sweep for pending venture_quality_findings matching test-fixture
+// sentinels (PAT-TEST-FIXTURE-PROMOTION-001 / QF-20260511-876).
+// Usage: node scripts/audit-test-fixture-leak.mjs [--execute] [--json]
+
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { isLikelyTestFixture } from '../lib/eva/quality-findings/sd-generator.js';
+
+async function safeExit(code) {
+  try {
+    const d = (await import('undici'))?.getGlobalDispatcher?.();
+    if (d?.destroy) await Promise.race([d.destroy(), new Promise((r) => setTimeout(r, 200))]).catch(() => {});
+  } catch {}
+  process.exit(code);
+}
+
+const args = new Set(process.argv.slice(2));
+const supabase = createSupabaseServiceClient();
+const { data, error } = await supabase
+  .from('venture_quality_findings')
+  .select('id, venture_id, finding_category, severity, evidence_pointer, created_at')
+  .eq('status', 'pending');
+if (error) { console.error('[audit-test-fixture-leak] query failed:', error.message); await safeExit(2); }
+const leaks = (data || []).filter(isLikelyTestFixture);
+
+if (args.has('--json')) {
+  process.stdout.write(JSON.stringify({ count: leaks.length, rows: leaks }, null, 2) + '\n');
+} else {
+  console.log(`[audit-test-fixture-leak] ${leaks.length} pending fixture-shaped rows`);
+  for (const r of leaks.slice(0, 10)) console.log(`  ${r.id} venture=${r.venture_id} sig=${r.evidence_pointer?.sig ?? '-'} (${r.finding_category}/${r.severity})`);
+}
+
+if (args.has('--execute') && leaks.length > 0) {
+  let cancelled = 0;
+  for (const r of leaks) {
+    const { error: uErr } = await supabase.from('venture_quality_findings').update({ status: 'cancelled' }).eq('id', r.id).eq('status', 'pending');
+    if (uErr) console.error(`  failed to cancel ${r.id}: ${uErr.message}`);
+    else cancelled++;
+  }
+  console.log(`[audit-test-fixture-leak] cancelled ${cancelled}/${leaks.length}`);
+}
+
+await safeExit(leaks.length > 0 && !args.has('--execute') ? 1 : 0);

--- a/tests/unit/lib/eva/quality-findings/fr-c-generator.test.js
+++ b/tests/unit/lib/eva/quality-findings/fr-c-generator.test.js
@@ -16,6 +16,9 @@ import {
   generateRemediationSdsForVenture,
   generateRemediationSdsBatch,
   selectPendingFindings,
+  isLikelyTestFixture,
+  FIXTURE_VENTURE_ID_PREFIX,
+  FIXTURE_SIG_PREFIX,
   FR_C_REMEDIATION_SEVERITIES,
   FR_C_OPEN_SD_STATUSES,
 } from '../../../../../lib/eva/quality-findings/sd-generator.js';
@@ -184,6 +187,100 @@ describe('FR-C generator — unit', () => {
 });
 
 // ============================================================================
+// UNIT — fixture discriminator (PAT-TEST-FIXTURE-PROMOTION-001 systemic fix)
+// ============================================================================
+
+describe('FR-C generator — fixture discriminator', () => {
+  let prevEnv;
+  beforeEach(() => {
+    prevEnv = process.env.FR_C_ALLOW_FIXTURE_FINDINGS;
+    delete process.env.FR_C_ALLOW_FIXTURE_FINDINGS;
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.FR_C_ALLOW_FIXTURE_FINDINGS;
+    else process.env.FR_C_ALLOW_FIXTURE_FINDINGS = prevEnv;
+  });
+
+  test('FIXTURE_VENTURE_ID_PREFIX and FIXTURE_SIG_PREFIX exposed as constants', () => {
+    expect(FIXTURE_VENTURE_ID_PREFIX).toBe('fc000000-');
+    expect(FIXTURE_SIG_PREFIX).toBe('t-');
+  });
+
+  test('isLikelyTestFixture identifies fc000000- venture_id', () => {
+    expect(isLikelyTestFixture({ venture_id: 'fc000000-0000-4000-8000-abcdef012345', evidence_pointer: { sig: 's-real' } })).toBe(true);
+  });
+
+  test('isLikelyTestFixture identifies t-* sig', () => {
+    expect(isLikelyTestFixture({ venture_id: '11111111-2222-3333-4444-555555555555', evidence_pointer: { sig: 't-foo' } })).toBe(true);
+  });
+
+  test('isLikelyTestFixture passes through production rows', () => {
+    expect(isLikelyTestFixture({ venture_id: '11111111-2222-3333-4444-555555555555', evidence_pointer: { sig: 's-prod' } })).toBe(false);
+    expect(isLikelyTestFixture({ venture_id: '11111111-2222-3333-4444-555555555555', evidence_pointer: null })).toBe(false);
+    expect(isLikelyTestFixture({ venture_id: '11111111-2222-3333-4444-555555555555' })).toBe(false);
+    expect(isLikelyTestFixture(null)).toBe(false);
+  });
+
+  test('selectPendingFindings filters fixture rows and emits test_fixture_skipped audit_log', async () => {
+    const fixtureRow = { id: 'fix-1', venture_id: 'fc000000-aaaa-bbbb-cccc-dddddddddddd', finding_category: 'lint', severity: 'medium', evidence_pointer: { sig: 'unused' }, stage_number: 20, created_at: '2026-05-11T00:00:00Z' };
+    const sigFixtureRow = { id: 'fix-2', venture_id: '99999999-2222-3333-4444-555555555555', finding_category: 'unit_test', severity: 'high', evidence_pointer: { sig: 't-spike' }, stage_number: 20, created_at: '2026-05-11T00:00:01Z' };
+    const prodRow = { id: 'prod-1', venture_id: '99999999-2222-3333-4444-555555555555', finding_category: 'lint', severity: 'medium', evidence_pointer: { sig: 's-prod' }, stage_number: 20, created_at: '2026-05-11T00:00:02Z' };
+
+    const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    const findingsThenable = {
+      data: [fixtureRow, sigFixtureRow, prodRow], error: null,
+      select: function () { return this; },
+      eq: function () { return this; },
+      in: function () { return this; },
+      order: function () { return this; },
+      then: function (cb) { return cb({ data: this.data, error: this.error }); },
+    };
+
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'venture_quality_findings') return findingsThenable;
+        if (table === 'audit_log') return { insert: auditInsert };
+        throw new Error('unexpected table: ' + table);
+      }),
+    };
+
+    const result = await selectPendingFindings(supabase, null);
+    expect(result).toEqual([prodRow]);
+    expect(auditInsert).toHaveBeenCalledTimes(2);
+    const events = auditInsert.mock.calls.map((c) => c[0]);
+    expect(events.every((e) => e.event_type === 'test_fixture_skipped')).toBe(true);
+    expect(events[0].entity_id).toBe('fix-1');
+    expect(events[0].metadata.venture_id).toBe(fixtureRow.venture_id);
+    expect(events[1].entity_id).toBe('fix-2');
+    expect(events[1].metadata.sig).toBe('t-spike');
+  });
+
+  test('FR_C_ALLOW_FIXTURE_FINDINGS=true bypasses the discriminator (test escape hatch)', async () => {
+    process.env.FR_C_ALLOW_FIXTURE_FINDINGS = 'true';
+    const fixtureRow = { id: 'fix-1', venture_id: 'fc000000-aaaa-bbbb-cccc-dddddddddddd', finding_category: 'lint', severity: 'medium', evidence_pointer: { sig: 't-x' }, stage_number: 20, created_at: '2026-05-11T00:00:00Z' };
+    const auditInsert = vi.fn();
+    const findingsThenable = {
+      data: [fixtureRow], error: null,
+      select: function () { return this; },
+      eq: function () { return this; },
+      in: function () { return this; },
+      order: function () { return this; },
+      then: function (cb) { return cb({ data: this.data, error: this.error }); },
+    };
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'venture_quality_findings') return findingsThenable;
+        if (table === 'audit_log') return { insert: auditInsert };
+        throw new Error('unexpected table: ' + table);
+      }),
+    };
+    const result = await selectPendingFindings(supabase, null);
+    expect(result).toEqual([fixtureRow]);
+    expect(auditInsert).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
 // INTEGRATION — HAS_REAL_DB-gated
 // ============================================================================
 
@@ -192,8 +289,15 @@ describe.skipIf(!HAS_REAL_DB)('FR-C generator — integration (HAS_REAL_DB)', ()
   let testVentureId;
   let createdSdKeys;
   let createdFindingIds;
+  let prevFixtureEnv;
 
   beforeEach(() => {
+    // Integration suite seeds rows that match fixture sentinels (fc000000-
+    // venture_id, t-* sigs). Bypass the discriminator here so generator paths
+    // can exercise dedup/rate-limit on those rows; production cron never sets
+    // this env var (PAT-TEST-FIXTURE-PROMOTION-001).
+    prevFixtureEnv = process.env.FR_C_ALLOW_FIXTURE_FINDINGS;
+    process.env.FR_C_ALLOW_FIXTURE_FINDINGS = 'true';
     supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
     // Stable per-test venture ID so cleanup can target it. Use a sentinel UUID
     // prefix to make rows easy to recognise in case cleanup misses any.
@@ -215,6 +319,8 @@ describe.skipIf(!HAS_REAL_DB)('FR-C generator — integration (HAS_REAL_DB)', ()
         await supabase.from('audit_log').delete().eq('metadata->>venture_id', testVentureId);
       } catch { /* noop */ }
     }
+    if (prevFixtureEnv === undefined) delete process.env.FR_C_ALLOW_FIXTURE_FINDINGS;
+    else process.env.FR_C_ALLOW_FIXTURE_FINDINGS = prevFixtureEnv;
   });
 
   async function seedFinding({ category = 'lint', severity = 'medium', sig = `s-${Date.now()}-${Math.random()}` } = {}) {


### PR DESCRIPTION
## Summary

Closes **PAT-TEST-FIXTURE-PROMOTION-001** (2nd witness 2026-05-11). The FR-C′ remediation-SD generator (lib/eva/quality-findings/sd-generator.js, v1.1.0) had no fixture-discriminator: when the FR-C integration test suite crashed mid-test, its best-effort afterEach cleanup was bypassed and the cron driver promoted the orphan rows (venture_id 'fc000000-' prefix, sigs 't-*') to 5 production SDs. Same incident first witnessed 2026-05-04 (SD-LEO-FIX-REMEDIATION-UNIT-TEST-001).

### Generator-layer guard (defense layer 1)
- `selectPendingFindings` now filters rows where `venture_id` starts with `'fc000000-'` OR `evidence_pointer.sig` starts with `'t-'`. Each skipped row emits an `audit_log` row with `event_type='test_fixture_skipped'` for sentinel-sweep parity.
- Exports `FIXTURE_VENTURE_ID_PREFIX`, `FIXTURE_SIG_PREFIX`, `isLikelyTestFixture(row)` for reuse by the sentinel script.
- Test escape hatch: setting `FR_C_ALLOW_FIXTURE_FINDINGS=true` bypasses the discriminator. The HAS_REAL_DB integration block sets it in `beforeEach` so the legitimate seed-then-process tests continue to exercise dedup / rate-limit on fixture-shaped rows. **Production cron never sets it.**

### Nightly sentinel sweep (defense layer 2)
- `scripts/audit-test-fixture-leak.mjs` reuses `isLikelyTestFixture`.
- Dry-run exits 1 on any pending fixture-shaped rows (alertable from cron).
- `--execute` transitions them `pending` → `cancelled` via the FR-4 status-machine; `cancelled_at` is set atomically by the BEFORE-UPDATE trigger.
- `--json` for machine output. `safeExit` wraps `process.exit` to drain undici (Windows libuv cleanup, QF-20260510-170 pattern).

### Scope deferral
DB-layer CHECK constraint / FK to ventures is deferred to a follow-up SD after burn-in, per QF context. Stage-20 decoupling (intentional, per migration:14) blocks an immediate FK.

### LOC budget
- 24 src (sd-generator.js) + 43 src (sentinel script) = **67 source LOC** (Tier 2 cap = 75).
- 106 test LOC (5 new discriminator unit tests + integration env-management).

### Tests
- 11 unit passed (5 original + 6 new discriminator)
- 4 HAS_REAL_DB integration tests skipped without real DB; will pass in CI when env wired (verified locally earlier in session with env vars present — see commit dd8a555de5).

## Test plan
- [x] `node node_modules/vitest/vitest.mjs run tests/unit/lib/eva/quality-findings/fr-c-generator.test.js` → 11 passed, 4 skipped
- [x] `node scripts/audit-test-fixture-leak.mjs` → exits cleanly, 0 leaks detected currently
- [x] `node scripts/audit-test-fixture-leak.mjs --json` → machine-readable output verified
- [ ] Post-merge: nightly cron picks up the sentinel sweep (operator to wire in cron config / GH actions follow-up)
- [ ] Burn-in 7d before opening DB-layer CHECK/FK follow-up SD

Closes feedback 504a1d06 (test_fixture_promotion harness-bug filed during the 2026-05-11 incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)