### PR TITLE
feat(QF-20260511-026): SessionStart [ROLE] orientation hook for /signal priming

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-register.cjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-role-orient.cjs",
+            "timeout": 3
           }
         ]
       }

--- a/scripts/hooks/__tests__/session-role-orient.test.js
+++ b/scripts/hooks/__tests__/session-role-orient.test.js
@@ -1,0 +1,231 @@
+/**
+ * Tests for session-role-orient.cjs (QF-20260511-026).
+ *
+ * Pure-function tests for decide() + readCoordFile() + fetchMeta(), plus a
+ * static-pin regression check that the three [ROLE] block constants remain
+ * verbatim (workers, coordinators, and solo sessions read these at boot).
+ *
+ * Hook is .cjs and module.exports its pure helpers — we test via require()
+ * with cache bust, mirroring concurrent-session-worktree.test.js.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const HOOK_PATH = path.resolve(__dirname, '../session-role-orient.cjs');
+
+function loadHook() {
+  delete require.cache[require.resolve(HOOK_PATH)];
+  return require(HOOK_PATH);
+}
+
+// ─── decide() — pure routing ────────────────────────────────────────────────
+
+describe('decide()', () => {
+  let decide, SOLO, COORDINATOR;
+
+  beforeEach(() => {
+    ({ decide, SOLO, COORDINATOR } = loadHook());
+  });
+
+  it('returns COORDINATOR when meta.is_coordinator is true', () => {
+    expect(decide('me', { is_coordinator: true }, null)).toBe(COORDINATOR);
+  });
+
+  it('returns COORDINATOR when coord file points to my own session (DB row absent)', () => {
+    // File-only fallback: meta unavailable but the pointer file says I am the coord.
+    const out = decide('abc123', null, { session_id: 'abc123' });
+    expect(out).toBe(COORDINATOR);
+  });
+
+  it('returns workerLines when coord file points to a different session', () => {
+    const out = decide('worker-uuid', { callsign: 'Bravo' }, { session_id: 'coord-uuid-12345678' });
+    expect(out[0]).toMatch(/WORKER \(callsign: Bravo\) under coordinator session=coord-uu\./);
+    expect(out[1]).toMatch(/\/signal <type>/);
+    expect(out[2]).toMatch(/Types: stuck \| need-sweep/);
+  });
+
+  it('workerLines degrades to "no callsign" when metadata is missing', () => {
+    const out = decide('worker-uuid', null, { session_id: 'coord-uuid-12345678' });
+    expect(out[0]).toMatch(/WORKER \(no callsign\)/);
+  });
+
+  it('returns SOLO when there is no coord file and no metadata', () => {
+    expect(decide('me', null, null)).toBe(SOLO);
+  });
+
+  it('returns SOLO when there is no coord file even with metadata present', () => {
+    expect(decide('me', { callsign: 'Bravo' }, null)).toBe(SOLO);
+  });
+});
+
+// ─── readCoordFile() — filesystem I/O ───────────────────────────────────────
+
+describe('readCoordFile()', () => {
+  let readCoordFile;
+  let savedCoord;
+  const COORD_PATH = path.resolve(__dirname, '../../../.claude/active-coordinator.json');
+
+  beforeEach(() => {
+    ({ readCoordFile } = loadHook());
+    try { savedCoord = fs.existsSync(COORD_PATH) ? fs.readFileSync(COORD_PATH, 'utf8') : null; } catch { savedCoord = null; }
+  });
+
+  afterEach(() => {
+    try {
+      if (savedCoord === null && fs.existsSync(COORD_PATH)) fs.unlinkSync(COORD_PATH);
+      else if (savedCoord !== null) fs.writeFileSync(COORD_PATH, savedCoord);
+    } catch { /* ignore */ }
+  });
+
+  it('returns null when the file does not exist', () => {
+    if (fs.existsSync(COORD_PATH)) fs.unlinkSync(COORD_PATH);
+    expect(readCoordFile()).toBeNull();
+  });
+
+  it('returns parsed JSON when the file exists', () => {
+    fs.mkdirSync(path.dirname(COORD_PATH), { recursive: true });
+    fs.writeFileSync(COORD_PATH, JSON.stringify({ session_id: 'abc', started_at: 'now', host: 'h' }));
+    expect(readCoordFile()).toEqual({ session_id: 'abc', started_at: 'now', host: 'h' });
+  });
+
+  it('returns null on malformed JSON (no throw)', () => {
+    fs.mkdirSync(path.dirname(COORD_PATH), { recursive: true });
+    fs.writeFileSync(COORD_PATH, '{not json');
+    expect(readCoordFile()).toBeNull();
+  });
+});
+
+// ─── fetchMeta() — Supabase wrapper ─────────────────────────────────────────
+
+describe('fetchMeta()', () => {
+  let fetchMeta;
+  let envSnapshot;
+
+  beforeEach(() => {
+    ({ fetchMeta } = loadHook());
+    envSnapshot = { url: process.env.SUPABASE_URL, key: process.env.SUPABASE_SERVICE_ROLE_KEY };
+  });
+
+  afterEach(() => {
+    process.env.SUPABASE_URL = envSnapshot.url;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = envSnapshot.key;
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when SUPABASE_URL is missing (fail-soft)', async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+    expect(await fetchMeta('any')).toBeNull();
+  });
+
+  it('returns metadata object on 200 OK with row present', async () => {
+    process.env.SUPABASE_URL = 'http://x.local';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ metadata: { is_coordinator: true, callsign: 'Alpha' } }]
+    }));
+    expect(await fetchMeta('s1')).toEqual({ is_coordinator: true, callsign: 'Alpha' });
+  });
+
+  it('returns null on non-2xx response (fail-soft, no throw)', async () => {
+    process.env.SUPABASE_URL = 'http://x.local';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    expect(await fetchMeta('s1')).toBeNull();
+  });
+
+  it('returns null when fetch throws (network error)', async () => {
+    process.env.SUPABASE_URL = 'http://x.local';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    expect(await fetchMeta('s1')).toBeNull();
+  });
+
+  it('returns null when the response is an empty array (no row for this session)', async () => {
+    process.env.SUPABASE_URL = 'http://x.local';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
+    expect(await fetchMeta('s1')).toBeNull();
+  });
+});
+
+// ─── findActiveCoord() — DB fallback for worktree workers ──────────────────
+
+describe('findActiveCoord()', () => {
+  let findActiveCoord;
+
+  beforeEach(() => {
+    ({ findActiveCoord } = loadHook());
+    process.env.SUPABASE_URL = 'http://x.local';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('returns the coordinator session_id when DB returns a row', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ session_id: 'coord-xyz' }]
+    }));
+    expect(await findActiveCoord()).toBe('coord-xyz');
+  });
+
+  it('returns null when no coordinator session is fresh', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
+    expect(await findActiveCoord()).toBeNull();
+  });
+
+  it('issues a PostgREST query with the is_coordinator filter and heartbeat cutoff', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchSpy);
+    await findActiveCoord();
+    const calledUrl = fetchSpy.mock.calls[0][0];
+    expect(calledUrl).toMatch(/metadata->>is_coordinator=eq\.true/);
+    expect(calledUrl).toMatch(/heartbeat_at=gte\./);
+    expect(calledUrl).toMatch(/order=heartbeat_at\.desc/);
+    expect(calledUrl).toMatch(/limit=1/);
+  });
+});
+
+// ─── Static-pin: verbatim [ROLE] block content ──────────────────────────────
+// Workers read these blocks at boot to learn the /signal channel — wording is
+// part of the user-visible behavior, not an implementation detail. Pin so an
+// accidental edit (e.g. dropping the threshold list) fails the test.
+
+describe('static-pin: [ROLE] block content', () => {
+  let SOLO, COORDINATOR, workerLines;
+
+  beforeEach(() => {
+    ({ SOLO, COORDINATOR, workerLines } = loadHook());
+  });
+
+  it('SOLO block names the canonical pause points + /leo assist fallback', () => {
+    const joined = SOLO.join('\n');
+    expect(joined).toMatch(/SOLO/);
+    expect(joined).toMatch(/Canonical pause points/);
+    expect(joined).toMatch(/\/leo assist Phase 1/);
+  });
+
+  it('COORDINATOR block names /coordinator inbox + 60min aggregation rule', () => {
+    const joined = COORDINATOR.join('\n');
+    expect(joined).toMatch(/COORDINATOR/);
+    expect(joined).toMatch(/\/coordinator inbox/);
+    expect(joined).toMatch(/60min/);
+    expect(joined).toMatch(/harness_backlog/);
+  });
+
+  it('WORKER block names /signal trigger thresholds + 7 type vocabulary', () => {
+    const lines = workerLines('Bravo', 'abc12345').join('\n');
+    expect(lines).toMatch(/WORKER/);
+    expect(lines).toMatch(/gate 2×/);
+    expect(lines).toMatch(/RCA 2×/);
+    expect(lines).toMatch(/tool 3×/);
+    expect(lines).toMatch(/stuck \| need-sweep \| prd-ambiguous \| gate-bug \| spec-conflict \| harness-bug \| feedback \| other/);
+    expect(lines).toMatch(/--low\|medium\|high\|critical/);
+  });
+});

--- a/scripts/hooks/session-role-orient.cjs
+++ b/scripts/hooks/session-role-orient.cjs
@@ -1,0 +1,75 @@
+/* session-role-orient.cjs — SessionStart hook (QF-20260511-026).
+ * Emits 3-line [ROLE] block (SOLO | WORKER | COORDINATOR). */
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+
+const COORD_FILE = path.resolve(__dirname, '../../.claude/active-coordinator.json');
+const BUDGET_MS = 1500;
+const STALE_MIN = 10;
+const SOLO = [
+  '[ROLE] SOLO — no active coordinator detected.',
+  '[ROLE] Canonical pause points apply (CLAUDE.md 5-point list). Log harness bugs: node scripts/log-harness-bug.js "<symptom>".',
+  '[ROLE] If /leo next returns no workable SD AND AUTO-PROCEED=ON → fall through to /leo assist Phase 1 (continuation, NOT pause).'
+];
+const COORDINATOR = [
+  '[ROLE] COORDINATOR — you manage the fleet.',
+  '[ROLE] Drain worker signals via /coordinator inbox (filtered by payload->signal_type IS NOT NULL).',
+  '[ROLE] 3+ matching signals within 60min auto-promote to feedback (category=harness_backlog) → SD pipeline.'
+];
+const workerLines = (callsign, coordShort) => [
+  `[ROLE] WORKER (${callsign ? `callsign: ${callsign}` : 'no callsign'}) under coordinator session=${coordShort}.`,
+  '[ROLE] /signal <type> "<body>" when ANY: recurrence (gate 2×, RCA 2×, tool 3×) | about to bypass | spec/PRD friction | harness-bug recognized | memory-trend match.',
+  '[ROLE] Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Severity --low|medium|high|critical (critical bypasses 3× threshold).'
+];
+
+function readCoordFile() {
+  try { return fs.existsSync(COORD_FILE) ? JSON.parse(fs.readFileSync(COORD_FILE, 'utf8')) : null; } catch { return null; }
+}
+async function pgGet(qs) {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), BUDGET_MS);
+  try {
+    const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/${qs}`,
+      { headers: { apikey: key, Authorization: `Bearer ${key}` }, signal: ctl.signal });
+    return res.ok ? await res.json() : null;
+  } catch { return null; } finally { clearTimeout(timer); }
+}
+async function fetchMeta(sid) {
+  return (await pgGet(`claude_sessions?session_id=eq.${sid}&select=metadata`))?.[0]?.metadata || null;
+}
+async function findActiveCoord() {
+  const cutoff = new Date(Date.now() - STALE_MIN * 60_000).toISOString();
+  return (await pgGet(`claude_sessions?heartbeat_at=gte.${cutoff}&metadata->>is_coordinator=eq.true&order=heartbeat_at.desc&limit=1&select=session_id`))?.[0]?.session_id || null;
+}
+function decide(sessionId, meta, coordFile) {
+  if (meta?.is_coordinator) return COORDINATOR;
+  if (coordFile?.session_id === sessionId) return COORDINATOR;
+  if (coordFile?.session_id) return workerLines(meta?.callsign, coordFile.session_id.slice(0, 8));
+  return SOLO;
+}
+function main() {
+  return new Promise(resolve => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', c => { input += c; });
+    process.stdin.on('end', async () => {
+      const sessionId = (() => { try { return JSON.parse(input)?.session_id; } catch { return null; } })();
+      let coordFile = readCoordFile();
+      if (!coordFile && sessionId) {
+        const dbCoord = await findActiveCoord();
+        if (dbCoord) coordFile = { session_id: dbCoord };
+      }
+      const meta = sessionId ? await fetchMeta(sessionId) : null;
+      decide(sessionId, meta, coordFile).forEach(l => console.log(l));
+      resolve();
+    });
+    process.stdin.on('error', () => resolve());
+    setTimeout(resolve, BUDGET_MS + 300);
+  });
+}
+if (require.main === module) main().then(() => process.exit(0)).catch(() => process.exit(0));
+module.exports = { readCoordFile, fetchMeta, findActiveCoord, decide, SOLO, COORDINATOR, workerLines };

--- a/templates/session-prologue.md
+++ b/templates/session-prologue.md
@@ -1,6 +1,15 @@
-# Session Prologue - LEO Protocol v4.3.3 - UI Parity Governance 4.3.3
+# Session Prologue - LEO Protocol v4.4.1
 *Copy-paste this at session start to align Claude with EHG_Engineer practices*
 *Generated: 2025-12-03T23:21:50.817Z*
+
+## Operating Mode
+
+At SessionStart, `scripts/hooks/session-role-orient.cjs` emits a `[ROLE]` block naming your role and channel:
+- **SOLO** — no active coordinator. Canonical pause points apply. Fall through to `/leo assist` Phase 1 when `/leo next` returns no workable SD under AUTO-PROCEED=ON.
+- **WORKER** — under coordinator. `/signal <type> "<body>"` when recurrence (gate 2×, RCA 2×, tool 3×) | bypass intent | spec/PRD friction | harness-bug recognized | memory-trend match.
+- **COORDINATOR** — drain worker signals via `/coordinator inbox`. 3+ matching signals within 60min auto-promote to feedback (category=harness_backlog).
+
+If you don't see a `[ROLE]` line at session start, the hook is unregistered or failed silently — check `.claude/settings.json` and run `echo '{"session_id":"<uuid>"}' | node scripts/hooks/session-role-orient.cjs` to probe.
 
 ## Core Directives
 


### PR DESCRIPTION
## Summary

- Adds new SessionStart hook `scripts/hooks/session-role-orient.cjs` (75 src LOC, Tier-2) that emits a 3-line `[ROLE]` block at boot — SOLO / WORKER / COORDINATOR — so workers see `/signal` threshold rules at boot instead of buried in CLAUDE_CORE.md
- Includes DB fallback (`findActiveCoord`) so workers running inside `.worktrees/*` can detect the active coordinator even though the local `.claude/active-coordinator.json` file is only visible from the main repo
- 20 vitest cases covering routing, filesystem I/O, Supabase wrapper, DB fallback, and static-pin of `[ROLE]` block content

## Why

CLAUDE.md item 10's own "Why" diagnoses the gap:
> *"The /signal channel is documented only in CLAUDE_CORE.md, so workers loaded into a phase file (LEAD/PLAN/EXEC) without core never see when to send."*

MEMORY.md is full of incidents that recurred 3, 4, even 5+ times before being addressed — patterns that should have been signaled at threshold but weren't, because each session hit them fresh without knowing the channel existed at the moment of friction.

This hook closes that discoverability gap by surfacing the trigger heuristic at the very first thing every session sees, before any phase file is loaded.

## Detection order

1. `claude_sessions.metadata.is_coordinator === true` → **COORDINATOR**
2. `.claude/active-coordinator.json` points at me → **COORDINATOR** (file fallback)
3. Local coord file present, points at a different session → **WORKER** + callsign + coord short-id
4. No local coord file, but DB scan finds an active coordinator → **WORKER** (this is the worktree path)
5. None of the above → **SOLO**

## Fail-soft contract

Every error path returns null without throwing — missing SUPABASE creds, fetch errors, 1.5s abort timeout, malformed JSON, non-2xx responses. Hook never blocks SessionStart. Registered with 3s timeout in `.claude/settings.json` (1.5s budget + headroom).

## Test plan

- [x] `npx vitest run scripts/hooks/__tests__/session-role-orient.test.js` — 20/20 pass
- [x] Manual SOLO probe (no coord file) → hits DB fallback, correctly emits WORKER block with real coordinator session=6c112cf6 (validated in worktree)
- [x] Manual WORKER probe (fake coord file pointing elsewhere) → WORKER block with that coordinator's short-id
- [x] Manual COORDINATOR-SELF probe (coord file points at my session_id) → COORDINATOR block
- [x] settings.json parses; hook appears in SessionStart chain at position 3 (after capture-session-id and session-register)
- [ ] Fresh CC session restart needed to verify `[ROLE]` block appears in SessionStart context (deferred to post-merge — requires session restart, not testable in current session)

Closes feedback-style discoverability gap; closes CLAUDE.md item 10 "Why" diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)