### PR TITLE
fix(QF-20260511-080): scope `git add` to QF-touched files in complete-quick-fix

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -12,16 +12,10 @@ import { execSync, execFileSync } from 'child_process';
 
 /**
  * Parse `git status --short` output into a list of file paths.
- *
- * QF-20260511-080 (closes harness 62327062): used by commitAndPushChanges to
- * scope `git add` to QF-touched files. Previously a blind `git add .` swept
- * unrelated dirty state (.claude/* session-state, scripts/one-off/_*.mjs) into
- * the QF commit when complete-quick-fix ran from the main repo CWD instead of
- * the QF worktree.
- *
- * Handles short porcelain format (XY + space + path), untracked (`??`),
- * renames (`R  old -> new` → returns new path), and quoted paths.
- *
+ * QF-20260511-080 (closes harness 62327062): blind `git add .` previously
+ * swept unrelated dirty state into QF commits. Handles short porcelain
+ * (XY + path), untracked (`??`), renames (`R old -> new` → new path),
+ * and quoted paths.
  * @param {string} statusOutput - Raw output of `git status --short`
  * @returns {string[]} Unique file paths
  */

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -8,7 +8,57 @@
  *   actualSourceLoc + actualTestLoc separately.
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
+
+/**
+ * Parse `git status --short` output into a list of file paths.
+ *
+ * QF-20260511-080 (closes harness 62327062): used by commitAndPushChanges to
+ * scope `git add` to QF-touched files. Previously a blind `git add .` swept
+ * unrelated dirty state (.claude/* session-state, scripts/one-off/_*.mjs) into
+ * the QF commit when complete-quick-fix ran from the main repo CWD instead of
+ * the QF worktree.
+ *
+ * Handles short porcelain format (XY + space + path), untracked (`??`),
+ * renames (`R  old -> new` → returns new path), and quoted paths.
+ *
+ * @param {string} statusOutput - Raw output of `git status --short`
+ * @returns {string[]} Unique file paths
+ */
+export function parseGitStatusFiles(statusOutput) {
+  if (!statusOutput) return [];
+  const files = new Set();
+  for (const line of statusOutput.split('\n')) {
+    if (!line || line.length < 4) continue;
+    let rest = line.slice(3);
+    const arrowIdx = rest.indexOf(' -> ');
+    if (arrowIdx >= 0) rest = rest.slice(arrowIdx + 4);
+    if (rest.length >= 2 && rest.startsWith('"') && rest.endsWith('"')) {
+      rest = rest.slice(1, -1);
+    }
+    if (rest) files.add(rest);
+  }
+  return [...files];
+}
+
+/**
+ * Partition dirty files into QF-scoped vs unrelated by intersection with the
+ * branch's `git diff origin/main...HEAD --name-only` set (filesChanged).
+ *
+ * @param {string[]} dirtyFiles - Files reported by `git status --short`
+ * @param {string[]} scopedFiles - QF-touched files (from analyzeGitDiff)
+ * @returns {{scopedDirty: string[], unrelatedDirty: string[]}}
+ */
+export function partitionDirtyByScope(dirtyFiles, scopedFiles) {
+  const scopeSet = new Set(scopedFiles || []);
+  const scopedDirty = [];
+  const unrelatedDirty = [];
+  for (const f of dirtyFiles || []) {
+    if (scopeSet.has(f)) scopedDirty.push(f);
+    else unrelatedDirty.push(f);
+  }
+  return { scopedDirty, unrelatedDirty };
+}
 
 /**
  * Test-file path heuristic. Matches:
@@ -471,9 +521,27 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
     const gitStatus = execSync('git status --short', { encoding: 'utf-8', cwd: testDir }).trim();
 
     if (gitStatus) {
+      const dirtyFiles = parseGitStatusFiles(gitStatus);
+      const { scopedDirty, unrelatedDirty } = partitionDirtyByScope(dirtyFiles, filesChanged);
+
+      if (scopedDirty.length === 0) {
+        console.log(`   Current Branch: ${currentBranch}`);
+        console.log('   ℹ️  No QF-scoped uncommitted changes detected.');
+        if (unrelatedDirty.length > 0) {
+          console.log(`   ⚠️  Ignoring ${unrelatedDirty.length} unrelated dirty file(s) to prevent branch pollution (harness 62327062):`);
+          unrelatedDirty.slice(0, 10).forEach(f => console.log(`        - ${f}`));
+          if (unrelatedDirty.length > 10) console.log(`        ... and ${unrelatedDirty.length - 10} more`);
+        }
+        console.log(`   Current commit: ${commitSha?.substring(0, 7) || 'Unknown'}\n`);
+        return commitSha;
+      }
+
       console.log(`   Current Branch: ${currentBranch}`);
-      console.log('   Uncommitted Changes:\n');
-      console.log(gitStatus.split('\n').map(line => `      ${line}`).join('\n'));
+      if (unrelatedDirty.length > 0) {
+        console.log(`   ℹ️  Ignoring ${unrelatedDirty.length} unrelated dirty file(s) not in QF scope`);
+      }
+      console.log('   Uncommitted Changes (QF-scoped):\n');
+      scopedDirty.forEach(f => console.log(`      ${f}`));
       console.log();
 
       const commitMessage = generateCommitMessage(qf, actualLoc, filesChanged, prUrl, testsPass);
@@ -493,7 +561,7 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
 
       if (shouldCommit.toLowerCase().startsWith('y')) {
         console.log('\n   📦 Staging changes...');
-        execSync('git add .', { stdio: 'inherit', cwd: testDir });
+        execFileSync('git', ['add', '--', ...scopedDirty], { stdio: 'inherit', cwd: testDir });
 
         console.log('   📝 Creating commit...');
         // SD-SEC-DATA-VALIDATION-001: Sanitize commit message

--- a/tests/unit/complete-quick-fix/scoped-staging.test.js
+++ b/tests/unit/complete-quick-fix/scoped-staging.test.js
@@ -1,0 +1,162 @@
+/**
+ * QF-20260511-080 — scoped staging helpers
+ *
+ * Closes harness 62327062: `complete-quick-fix.js` previously did `git add .`
+ * which swept unrelated dirty state (.claude/* session-state files,
+ * scripts/one-off/_*.mjs) into the QF commit when run from main repo CWD.
+ *
+ * These tests pin the contract for the two pure helpers that scope staging
+ * to QF-touched files only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseGitStatusFiles,
+  partitionDirtyByScope,
+} from '../../../scripts/modules/complete-quick-fix/git-operations.js';
+
+describe('parseGitStatusFiles', () => {
+  it('parses modified, staged, and untracked entries', () => {
+    const out = [
+      ' M src/a.js',
+      'M  src/b.js',
+      '?? src/c.js',
+      'AM src/d.js',
+    ].join('\n');
+    expect(parseGitStatusFiles(out)).toEqual([
+      'src/a.js', 'src/b.js', 'src/c.js', 'src/d.js',
+    ]);
+  });
+
+  it('extracts the new path on rename entries (R  old -> new)', () => {
+    const out = 'R  old/path.js -> new/path.js';
+    expect(parseGitStatusFiles(out)).toEqual(['new/path.js']);
+  });
+
+  it('handles multiple lines with mixed status codes including rename', () => {
+    const out = [
+      ' M src/a.js',
+      'R  old.js -> new.js',
+      '?? new-untracked.js',
+    ].join('\n');
+    expect(parseGitStatusFiles(out)).toEqual([
+      'src/a.js', 'new.js', 'new-untracked.js',
+    ]);
+  });
+
+  it('returns empty array for empty/null/undefined input', () => {
+    expect(parseGitStatusFiles('')).toEqual([]);
+    expect(parseGitStatusFiles(null)).toEqual([]);
+    expect(parseGitStatusFiles(undefined)).toEqual([]);
+  });
+
+  it('strips git quoting on paths with spaces', () => {
+    const out = ' M "path with spaces.js"';
+    expect(parseGitStatusFiles(out)).toEqual(['path with spaces.js']);
+  });
+
+  it('deduplicates duplicate paths (same path on multiple lines)', () => {
+    const out = ' M a.js\n M a.js\nMM a.js';
+    expect(parseGitStatusFiles(out)).toEqual(['a.js']);
+  });
+
+  it('skips lines too short to contain a path', () => {
+    const out = '\n M\n??\n M actual.js';
+    expect(parseGitStatusFiles(out)).toEqual(['actual.js']);
+  });
+});
+
+describe('partitionDirtyByScope', () => {
+  it('separates scoped from unrelated by intersection', () => {
+    const result = partitionDirtyByScope(
+      ['src/a.js', 'src/b.js', 'src/c.js'],
+      ['src/a.js', 'src/c.js'],
+    );
+    expect(result).toEqual({
+      scopedDirty: ['src/a.js', 'src/c.js'],
+      unrelatedDirty: ['src/b.js'],
+    });
+  });
+
+  it('returns all-unrelated when scope is empty array (bug repro path)', () => {
+    expect(partitionDirtyByScope(
+      ['.claude/state.json', 'scripts/one-off/_x.mjs'],
+      [],
+    )).toEqual({
+      scopedDirty: [],
+      unrelatedDirty: ['.claude/state.json', 'scripts/one-off/_x.mjs'],
+    });
+  });
+
+  it('returns all-scoped when dirty is a subset of scope', () => {
+    expect(partitionDirtyByScope(
+      ['src/a.js'],
+      ['src/a.js', 'src/b.js', 'src/c.js'],
+    )).toEqual({
+      scopedDirty: ['src/a.js'],
+      unrelatedDirty: [],
+    });
+  });
+
+  it('handles null/undefined scopedFiles as empty (defensive)', () => {
+    expect(partitionDirtyByScope(['a.js'], null)).toEqual({
+      scopedDirty: [],
+      unrelatedDirty: ['a.js'],
+    });
+    expect(partitionDirtyByScope(['a.js'], undefined)).toEqual({
+      scopedDirty: [],
+      unrelatedDirty: ['a.js'],
+    });
+  });
+
+  it('handles null/undefined dirtyFiles as empty (defensive)', () => {
+    expect(partitionDirtyByScope(null, ['a.js'])).toEqual({
+      scopedDirty: [],
+      unrelatedDirty: [],
+    });
+    expect(partitionDirtyByScope(undefined, ['a.js'])).toEqual({
+      scopedDirty: [],
+      unrelatedDirty: [],
+    });
+  });
+
+  it('preserves dirty-file order in each partition', () => {
+    const result = partitionDirtyByScope(
+      ['z.js', 'a.js', 'm.js', 'b.js'],
+      ['a.js', 'b.js'],
+    );
+    expect(result.scopedDirty).toEqual(['a.js', 'b.js']);
+    expect(result.unrelatedDirty).toEqual(['z.js', 'm.js']);
+  });
+});
+
+describe('parse + partition integration (regression for harness 62327062)', () => {
+  it('classic bug repro: dirty session-state + zero scope → all unrelated', () => {
+    const gitStatus = [
+      ' M .claude/.protocol-sync',
+      ' M .claude/fleet-dashboard-state.json',
+      '?? .claude/tmp/friction-counters-abc.json',
+      '?? scripts/one-off/_test.mjs',
+    ].join('\n');
+    const dirtyFiles = parseGitStatusFiles(gitStatus);
+    const { scopedDirty, unrelatedDirty } = partitionDirtyByScope(dirtyFiles, []);
+    expect(scopedDirty).toEqual([]);
+    expect(unrelatedDirty).toHaveLength(4);
+    expect(unrelatedDirty).toContain('.claude/.protocol-sync');
+    expect(unrelatedDirty).toContain('scripts/one-off/_test.mjs');
+  });
+
+  it('mixed case: 1 scoped + 3 unrelated → only scoped staged', () => {
+    const gitStatus = [
+      ' M scripts/modules/complete-quick-fix/git-operations.js',
+      ' M .claude/.protocol-sync',
+      '?? .claude/tmp/friction-counters-xyz.json',
+      '?? scripts/one-off/_debug.mjs',
+    ].join('\n');
+    const filesChanged = ['scripts/modules/complete-quick-fix/git-operations.js'];
+    const dirtyFiles = parseGitStatusFiles(gitStatus);
+    const { scopedDirty, unrelatedDirty } = partitionDirtyByScope(dirtyFiles, filesChanged);
+    expect(scopedDirty).toEqual(['scripts/modules/complete-quick-fix/git-operations.js']);
+    expect(unrelatedDirty).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes harness 62327062 (high severity) — `complete-quick-fix.js` previously did `git add .` blindly, sweeping unrelated dirty state (`.claude/*` session-state + `scripts/one-off/_*.mjs`) into QF commits when run from main repo CWD.
- Scope staging to `filesChanged ∩ dirtyFiles` via 2 new pure helpers (`parseGitStatusFiles`, `partitionDirtyByScope`) + `execFileSync('git', ['add', '--', ...scopedDirty])`.
- New guard branch: if no scoped dirty files exist but unrelated do, refuse to commit + warn instead of staging arbitrary state.
- Self-validating ship class — the fix exercises itself when this QF's own complete-quick-fix runs.

## Test plan
- [x] 15 new vitest cases (`tests/unit/complete-quick-fix/scoped-staging.test.js`) covering both helpers + classic bug repro (zero-scope + dirty session-state → all unrelated)
- [x] 98/98 complete-quick-fix tests pass (no regression in `autodetect-git-info`, `compliance-rubric-source-loc`, `qf-407-friction-cluster`, `qf-779-autopr-branch-order`, `sibling-parity-force-complete`, `validate-compliance-force-bypass`, `validate-loc`)
- [x] LOC: 72 src additions / 75 Tier 2 cap (fits with 3-line headroom), 162 new test LOC
- [ ] Self-validation: run `node scripts/complete-quick-fix.js QF-20260511-080` from this worktree — patched code path executes on its own ship; any unrelated dirty `.worktree.json` should be warned-and-ignored, not bundled

Closes feedback 62327062-c9dd-4396-aebf-293bf30fcb76

🤖 Generated with [Claude Code](https://claude.com/claude-code)