### PR TITLE
fix(QF-20260511-565): Queue engine: respect metadata.lead_decision.verdict (deferred/paused_pending)

### DIFF
--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -8,6 +8,7 @@ import { checkDependenciesResolved } from '../dependency-resolver.js';
 import { displayTrackSection } from './tracks.js';
 import { rankItems } from '../rank-items.js';
 import { classifyQuickFixes } from './quick-fixes.js';
+import { isLeadDecisionPaused } from '../status-helpers.js';
 
 /**
  * Show fallback queue when no baseline is active.
@@ -132,7 +133,8 @@ export async function showFallbackQueue(supabase, options = {}) {
 
   // Show top ready SD per track.
   for (const [trackKey, trackSDs] of Object.entries(tracks)) {
-    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on);
+    // QF-20260511-565: exclude LEAD-paused/deferred SDs from RECOMMENDED STARTING POINTS
+    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on && !isLeadDecisionPaused(s));
     if (ready) {
       const trackLabel = `Track ${trackKey}`;
       console.log(`${colors.green}  ${trackLabel}:${colors.reset} ${ready.sd_key || ready.id} - ${ready.title.substring(0, 50)}...`);

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -4,7 +4,7 @@
  */
 
 import { colors } from '../colors.js';
-import { isActionableForLead } from '../status-helpers.js';
+import { isActionableForLead, isLeadDecisionPaused } from '../status-helpers.js';
 import { checkDependenciesResolved, checkMetadataDependency, resolveMetadataBlocker } from '../dependency-resolver.js';
 import { getEstimatedDuration, formatEstimateShort } from '../../../lib/duration-estimator.js';
 import { analyzeClaimRelationship, hasActiveWorkEvidence } from '../claim-analysis.js';
@@ -262,6 +262,9 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
     if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
       // SD-LEO-INFRA-CONDITIONAL-QUEUE-GOVERNANCE-001: Skip deferred SDs from recommendations
       if (sd.metadata?.do_not_advance_without_trigger === true) continue;
+
+      // QF-20260511-565: Skip SDs paused at LEAD via metadata.lead_decision.verdict
+      if (isLeadDecisionPaused(sd)) continue;
 
       // SD-LEO-INFRA-CLAIM-GUARD-001: Skip SDs claimed by OTHER sessions (use claiming_session_id)
       if (sd.claiming_session_id && sd.claiming_session_id !== currentSessionId) {

--- a/scripts/modules/sd-next/status-helpers.js
+++ b/scripts/modules/sd-next/status-helpers.js
@@ -104,6 +104,25 @@ export function _resetInconsistentCache() {
   _ghostWarnEmitted = false;
 }
 
+// QF-20260511-565: LEAD strategic pause/defer signal encoded in metadata.lead_decision.verdict.
+// Status enum is narrow (cancelled/completed/draft/in_progress) and cannot express this state,
+// so the queue engine must read it from metadata. Matches the precedent set by
+// project_sd_eva_support_parent_paused_2026_05_11.md and
+// project_sd_eva_support_phase3_lead_deferred.md.
+const PAUSED_VERDICT_RE = /^(deferred|paused_pending)/;
+
+/**
+ * True when an SD has been paused/deferred at LEAD via metadata.lead_decision.verdict.
+ * Tolerates missing metadata, missing lead_decision, or non-string verdict.
+ *
+ * @param {Object} item - SD-like row with optional metadata.lead_decision.verdict
+ * @returns {boolean}
+ */
+export function isLeadDecisionPaused(item) {
+  const verdict = item?.metadata?.lead_decision?.verdict;
+  return typeof verdict === 'string' && PAUSED_VERDICT_RE.test(verdict);
+}
+
 // Phase-to-required-handoff mapping for stuck detection
 const PHASE_REQUIRES_HANDOFF = {
   PLAN_PRD: { from: 'LEAD', to: 'PLAN' },
@@ -149,6 +168,17 @@ export function getPhaseAwareStatus(item) {
   // If handoff chain data is attached, check for stuck state
   if (item._stuck) {
     return `${colors.red}STUCK${colors.reset}`;
+  }
+
+  // QF-20260511-565: LEAD strategic pause via metadata.lead_decision.verdict
+  // outranks phase-based status — an SD paused at LEAD that happens to sit in
+  // PLAN_PRD must not display PLANNING (would mislead operators per CLAUDE.md
+  // badge legend), it must display PAUSED/DEFERRED.
+  if (isLeadDecisionPaused(item)) {
+    const verdict = item.metadata.lead_decision.verdict;
+    return verdict === 'deferred'
+      ? `${colors.dim}DEFERRED${colors.reset}`
+      : `${colors.dim}PAUSED${colors.reset}`;
   }
 
   // Phase-based status takes priority over dependency resolution
@@ -255,6 +285,11 @@ export function isActionableForLead(item) {
 
   // SD-LEO-INFRA-HANDOFF-INTEGRITY-RECOVERY-001: Not actionable if stuck
   if (item._stuck) {
+    return false;
+  }
+
+  // QF-20260511-565: Not actionable if LEAD paused/deferred via metadata.lead_decision
+  if (isLeadDecisionPaused(item)) {
     return false;
   }
 

--- a/tests/unit/sd-next/status-helpers-lead-decision.test.js
+++ b/tests/unit/sd-next/status-helpers-lead-decision.test.js
@@ -1,0 +1,162 @@
+/**
+ * QF-20260511-565: Queue engine respects metadata.lead_decision.verdict
+ *
+ * Closes feedback 89fedaad — SDs paused at LEAD via metadata.lead_decision
+ * (verdict ∈ {deferred, paused_pending_*}) must not surface as READY in
+ * /leo next RECOMMENDED STARTING POINTS.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isLeadDecisionPaused,
+  getPhaseAwareStatus,
+  isActionableForLead,
+} from '../../../scripts/modules/sd-next/status-helpers.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Realistic fixtures mirroring real DB rows on 2026-05-11:
+// - SD-EVA-SUPPORT-CLI-SKILL-ORCH-001     (parent, paused_pending_phase_3_unlock)
+// - SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C   (Phase 3 child, deferred)
+// Captured from project_sd_eva_support_*.md memory entries.
+// ────────────────────────────────────────────────────────────────────────
+const parentOrchestratorPaused = {
+  id: 'sd-eva-support-cli-skill-orch-001',
+  sd_key: 'SD-EVA-SUPPORT-CLI-SKILL-ORCH-001',
+  status: 'in_progress',
+  current_phase: 'PLAN_PRD',
+  progress_percentage: 0,
+  deps_resolved: true,
+  metadata: {
+    is_parent: true,
+    is_orchestrator: true,
+    arch_key: 'EVA-SUPPORT',
+    vision_key: 'EVA',
+    child_count: 3,
+    lead_decision: {
+      verdict: 'paused_pending_phase_3_unlock',
+      decided_at: '2026-05-11T13:57:31Z',
+      decided_by_session: '6c112cf6',
+      reopen_when: '2026-05-25 OR chairman go-ahead',
+    },
+  },
+};
+
+const phase3ChildDeferred = {
+  id: 'sd-eva-support-cli-skill-orch-001-c',
+  sd_key: 'SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C',
+  status: 'draft',
+  current_phase: 'LEAD',
+  progress_percentage: 0,
+  deps_resolved: true,
+  metadata: {
+    parent_sd_id: 'SD-EVA-SUPPORT-CLI-SKILL-ORCH-001',
+    lead_decision: {
+      verdict: 'deferred',
+      decided_at: '2026-05-11T13:36:00Z',
+      reopen_when: '2026-05-25',
+    },
+  },
+};
+
+describe('isLeadDecisionPaused', () => {
+  it('returns true for verdict="deferred"', () => {
+    expect(isLeadDecisionPaused(phase3ChildDeferred)).toBe(true);
+  });
+
+  it('returns true for verdict="paused_pending_phase_3_unlock"', () => {
+    expect(isLeadDecisionPaused(parentOrchestratorPaused)).toBe(true);
+  });
+
+  it('returns true for verdict="paused_pending_unlock" (sibling variant)', () => {
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: 'paused_pending_unlock' } } })).toBe(true);
+  });
+
+  it('returns true for bare verdict="paused_pending"', () => {
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: 'paused_pending' } } })).toBe(true);
+  });
+
+  it('returns false for verdict="in_progress" (not a pause verdict)', () => {
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: 'in_progress' } } })).toBe(false);
+  });
+
+  it('returns false for verdict="approved" or other non-pause string', () => {
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: 'approved' } } })).toBe(false);
+  });
+
+  it('returns false when lead_decision is missing', () => {
+    expect(isLeadDecisionPaused({ metadata: { is_parent: true } })).toBe(false);
+  });
+
+  it('returns false when metadata is missing entirely', () => {
+    expect(isLeadDecisionPaused({ id: 'sd-x', status: 'draft' })).toBe(false);
+  });
+
+  it('returns false when verdict is non-string (defensive)', () => {
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: 123 } } })).toBe(false);
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: null } } })).toBe(false);
+    expect(isLeadDecisionPaused({ metadata: { lead_decision: { verdict: {} } } })).toBe(false);
+  });
+
+  it('returns false for null/undefined item without throwing', () => {
+    expect(isLeadDecisionPaused(null)).toBe(false);
+    expect(isLeadDecisionPaused(undefined)).toBe(false);
+  });
+});
+
+describe('getPhaseAwareStatus: lead_decision.verdict downgrades', () => {
+  it('returns DEFERRED badge for verdict="deferred"', () => {
+    const out = getPhaseAwareStatus(phase3ChildDeferred);
+    expect(out).toMatch(/DEFERRED/);
+    // Must NOT return READY/DRAFT despite deps_resolved+status=draft
+    expect(out).not.toMatch(/READY|DRAFT/);
+  });
+
+  it('returns PAUSED badge for verdict="paused_pending_phase_3_unlock"', () => {
+    const out = getPhaseAwareStatus(parentOrchestratorPaused);
+    expect(out).toMatch(/PAUSED/);
+    // Must NOT return PLANNING despite current_phase=PLAN_PRD
+    expect(out).not.toMatch(/PLANNING|READY/);
+  });
+
+  it('preserves existing DEFERRED branch for do_not_advance_without_trigger', () => {
+    const out = getPhaseAwareStatus({
+      status: 'draft',
+      current_phase: 'LEAD',
+      deps_resolved: true,
+      metadata: { do_not_advance_without_trigger: true },
+    });
+    expect(out).toMatch(/DEFERRED/);
+  });
+
+  it('falls through to existing logic when no lead_decision is present', () => {
+    const out = getPhaseAwareStatus({
+      status: 'draft',
+      current_phase: 'LEAD',
+      deps_resolved: true,
+      metadata: { other_key: 'foo' },
+    });
+    // No verdict → status=draft hits DRAFT branch
+    expect(out).toMatch(/DRAFT/);
+  });
+});
+
+describe('isActionableForLead: lead_decision.verdict suppression', () => {
+  it('returns false when verdict="deferred"', () => {
+    expect(isActionableForLead(phase3ChildDeferred)).toBe(false);
+  });
+
+  it('returns false when verdict="paused_pending_phase_3_unlock"', () => {
+    expect(isActionableForLead(parentOrchestratorPaused)).toBe(false);
+  });
+
+  it('returns true when verdict absent and other conditions OK (LEAD phase, no review)', () => {
+    expect(isActionableForLead({
+      current_phase: 'LEAD',
+      status: 'draft',
+      metadata: {},
+    })).toBe(true);
+  });
+
+  it('returns true with no metadata at all and LEAD phase', () => {
+    expect(isActionableForLead({ current_phase: 'LEAD', status: 'draft' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-565  **Type:** bug **Severity:** medium  ### Issue Description Add lead_decision.verdict awareness to status-helpers (getPhaseAwareStatus, isActionableForLead) and categorizeBaselineSDs in recommendations.js. SDs with metadata.lead_decision.verdict matching /^(deferred|paused_pending)/ should no longer surface as READY in /leo next RECOMMENDED STARTING POINTS. Closes feedback 89fedaad-f46b-4711-a4fb-46f7b26f792f.     ### Changes - **Files Changed:** 4   - scripts/modules/sd-next/display/fallback-queue.js   - scripts/modules/sd-next/display/recommendations.js   - scripts/modules/sd-next/status-helpers.js   - tests/unit/sd-next/status-helpers-lead-decision.test.js - **LOC:** 210 lines - **Tests:** ❌ Failed - **UAT:** ✅ Verified  ### Verification 18/18 new lead-decision tests + 96/96 sibling sd-next suite green. Live /leo next smoke: parent renders PAUSED, child -C renders DEFERRED, neither in RECOMMENDED STARTING POINTS.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol