### PR TITLE
fix(QF-20260511-414): scheduled worktree-reaper cadence workflow

### DIFF
--- a/.github/workflows/worktree-reaper-cadence.yml
+++ b/.github/workflows/worktree-reaper-cadence.yml
@@ -1,0 +1,74 @@
+# QF-20260511-414: closes 4th-class witness of PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (reaper script existed, no automation invoked it). Stage 1 only.
+name: Worktree Reaper Cadence
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily 03:00 UTC, low-traffic window.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Plan-only mode (omit --execute)'
+        required: false
+        default: 'false'
+        type: boolean
+permissions:
+  contents: read
+  issues: write
+concurrency:
+  group: worktree-reaper  # Shared with operator-triggered manual runs.
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install minimal deps
+        run: npm ci --ignore-scripts --prefer-offline --no-audit
+      - name: Run reaper (Stage 1)
+        id: reap
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            npm run worktree:reap 2>&1 | tee reaper.log
+          else
+            npm run worktree:reap:execute 2>&1 | tee reaper.log
+          fi
+      - name: Write last_run_at to state file
+        if: always()
+        run: |
+          node -e "const fs=require('fs'),p=require('path');const f=p.join('.claude','worktree-reaper-state.json');const s=fs.existsSync(f)?JSON.parse(fs.readFileSync(f,'utf8')):{schema_version:1,sweep_counter:0,last_result:null};s.last_run_at=new Date().toISOString();s.last_result='${{ job.status }}';s.sweep_counter=(s.sweep_counter||0)+1;fs.mkdirSync(p.dirname(f),{recursive:true});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\n');console.log('last_run_at='+s.last_run_at);"
+          {
+            echo "## Worktree Reaper Cadence"
+            echo "- last_run_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "- result: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload reaper log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: worktree-reaper-log-${{ github.run_id }}
+          path: |
+            reaper.log
+            .claude/worktree-reaper-state.json
+          retention-days: 14
+      - name: Open issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Worktree Reaper Cadence failed (run ${context.runId})`,
+              body: `Scheduled run failed. See logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nClosure: PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (QF-20260511-414).`,
+              labels: ['ci-failure', 'worktree-reaper']
+            });

--- a/tests/unit/workflows/worktree-reaper-cadence.test.js
+++ b/tests/unit/workflows/worktree-reaper-cadence.test.js
@@ -1,0 +1,89 @@
+// QF-20260511-414 — structural test for .github/workflows/worktree-reaper-cadence.yml
+// Asserts cron, concurrency, dispatch input, reaper invocation, state write-back,
+// log artifact, and failure-issue step. Closes 4th-class witness of
+// PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 by guarding the workflow against
+// regression (anyone deleting cron / write-back step trips a test).
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+const WORKFLOW_PATH = path.join(
+  process.cwd(),
+  '.github',
+  'workflows',
+  'worktree-reaper-cadence.yml'
+);
+
+describe('QF-20260511-414: worktree-reaper-cadence.yml', () => {
+  let wf;
+
+  beforeAll(() => {
+    const raw = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    wf = yaml.load(raw);
+  });
+
+  it('exists and is parseable', () => {
+    expect(wf).toBeTruthy();
+    expect(wf.name).toBe('Worktree Reaper Cadence');
+  });
+
+  it('runs on daily cron + workflow_dispatch', () => {
+    // js-yaml parses YAML `on:` key as boolean `true` (the "Norway problem"
+    // sibling); access via bracket notation.
+    const trig = wf.on ?? wf[true];
+    expect(trig).toBeTruthy();
+    expect(trig.schedule).toEqual([{ cron: '0 3 * * *' }]);
+    expect(trig.workflow_dispatch).toBeDefined();
+    expect(trig.workflow_dispatch.inputs.dry_run).toBeDefined();
+  });
+
+  it('uses concurrency group "worktree-reaper" without cancel-in-progress', () => {
+    expect(wf.concurrency.group).toBe('worktree-reaper');
+    expect(wf.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('grants issues:write for failure issue', () => {
+    expect(wf.permissions.issues).toBe('write');
+    expect(wf.permissions.contents).toBe('read');
+  });
+
+  it('invokes worktree:reap:execute by default, plan-only when dry_run', () => {
+    const steps = wf.jobs.reap.steps;
+    const runStep = steps.find((s) => s.id === 'reap');
+    expect(runStep).toBeDefined();
+    expect(runStep.run).toContain('npm run worktree:reap:execute');
+    expect(runStep.run).toContain('npm run worktree:reap');
+    expect(runStep.run).toContain('dry_run');
+  });
+
+  it('writes last_run_at to .claude/worktree-reaper-state.json', () => {
+    const steps = wf.jobs.reap.steps;
+    const writeStep = steps.find((s) => s.name === 'Write last_run_at to state file');
+    expect(writeStep).toBeDefined();
+    expect(writeStep.if).toBe('always()');
+    expect(writeStep.run).toContain('.claude');
+    expect(writeStep.run).toContain('worktree-reaper-state.json');
+    expect(writeStep.run).toContain('last_run_at');
+    expect(writeStep.run).toContain('sweep_counter');
+  });
+
+  it('opens issue only on scheduled failure', () => {
+    const steps = wf.jobs.reap.steps;
+    const issueStep = steps.find((s) => s.name === 'Open issue on failure');
+    expect(issueStep).toBeDefined();
+    expect(issueStep.if).toContain('failure()');
+    expect(issueStep.if).toContain("github.event_name == 'schedule'");
+    expect(issueStep.with.script).toContain('PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001');
+  });
+
+  it('uploads reaper.log + state file as artifact', () => {
+    const steps = wf.jobs.reap.steps;
+    const artStep = steps.find((s) => s.name === 'Upload reaper log');
+    expect(artStep).toBeDefined();
+    expect(artStep.if).toBe('always()');
+    expect(artStep.with.path).toContain('reaper.log');
+    expect(artStep.with.path).toContain('.claude/worktree-reaper-state.json');
+  });
+});


### PR DESCRIPTION
## Summary
- Daily cron @ 03:00 UTC for `scripts/worktree-reaper.mjs` Stage 1
- `workflow_dispatch` with `dry_run` input for ad-hoc plan-only runs
- Concurrency group `worktree-reaper` shared with operator manual runs
- `last_run_at` write-back step (informational on runner + uploaded artifact)
- Failure-issue step (scheduled runs only) for crash visibility

Closes 4th-class witness of **PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001** — reaper script existed but no automation invoked it (6 manual sweeps, 0 scheduled).

## Scope
- Tier 2 QF: **74 src + 89 test LOC** (under 75-src cap)
- Stage 1 only (`--execute`, no `--stage2`); zombie / orphan-SD / idle classes still need operator review per QF description

## Test plan
- [x] `npx vitest run tests/unit/workflows/worktree-reaper-cadence.test.js` — 8/8 PASS
- [ ] CI green
- [ ] First scheduled run produces non-null `last_run_at` in artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)