### PR TITLE
fix(QF-20260511-469): session-check-concurrency.js libuv-safe exit (process.exitCode pattern)

### DIFF
--- a/scripts/session-check-concurrency.js
+++ b/scripts/session-check-concurrency.js
@@ -96,7 +96,8 @@ async function main() {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) {
     console.error('[session:check-concurrency] missing SUPABASE_URL/SERVICE_ROLE_KEY — cannot query sessions');
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   // SD-LEO-INFRA-CROSS-HOST-CONCURRENT-001 (FR-1 rescoped): widen the contention
@@ -111,7 +112,8 @@ async function main() {
     allSessions = await getActiveSessions();
   } catch (err) {
     console.error('[session:check-concurrency] query failed:', err.message);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   const data = (allSessions || []).filter(s => categorizeSessionForContention(s) !== 'inactive');
@@ -153,7 +155,8 @@ async function main() {
     if (others.length > 0) {
       console.log(`  (${others.length} active session(s) on other branches — no contention)`);
     }
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   }
 
   console.log('');
@@ -180,7 +183,7 @@ async function main() {
   console.log('    3. If the other session is dead but its heartbeat is recent,');
   console.log('       release via the LEO claim CLI before proceeding');
   console.log('');
-  process.exit(1);
+  process.exitCode = 1;
 }
 
 // Entrypoint guard: only run main() when invoked as a CLI, NOT when this
@@ -195,6 +198,6 @@ const isDirectInvoke = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectInvoke) {
   main().catch(e => {
     console.error('[session:check-concurrency] error:', e.message);
-    process.exit(2);
+    process.exitCode = 2;
   });
 }

--- a/tests/session-check-concurrency-libuv-safe-exit.test.js
+++ b/tests/session-check-concurrency-libuv-safe-exit.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, '..', 'scripts', 'session-check-concurrency.js');
+
+function stripCommentsAndStrings(src) {
+  let out = src.replace(/\r\n/g, '\n').replace(/\/\*[\s\S]*?\*\//g, '');
+  out = out
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+  out = out.replace(/(['"`])(?:\\.|(?!\1)[^\\\n])*\1/g, '');
+  return out;
+}
+
+describe('session-check-concurrency.js: Windows libuv-safe exit (QF-20260511-469)', () => {
+  const src = readFileSync(SCRIPT_PATH, 'utf8');
+  const code = stripCommentsAndStrings(src);
+
+  it('has no process.exit(...) call statements in executable code', () => {
+    const matches = code.match(/process\.exit\s*\(/g) || [];
+    expect(matches).toEqual([]);
+  });
+
+  it('uses process.exitCode = 0 for the isolated path', () => {
+    expect(code).toMatch(/process\.exitCode\s*=\s*0/);
+  });
+
+  it('uses process.exitCode = 1 for the contention path', () => {
+    expect(code).toMatch(/process\.exitCode\s*=\s*1/);
+  });
+
+  it('uses process.exitCode = 2 for the error paths (missing creds, query error, catch)', () => {
+    const twos = code.match(/process\.exitCode\s*=\s*2/g) || [];
+    expect(twos.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-469  **Type:** bug **Severity:** medium  ### Issue Description Replace 5 process.exit(N) sites with process.exitCode = N pattern. Same Windows libuv UV_HANDLE_CLOSING fix shipped in de55b88d for scope-gate.js. Closes feedback 4d8785c7.     ### Changes - **Files Changed:** 2   - scripts/session-check-concurrency.js   - tests/session-check-concurrency-libuv-safe-exit.test.js - **LOC:** 54 lines - **Tests:** ✅ Passing - **UAT:** ✅ Verified  ### Verification Pre-existing baseline test failures in tests/unit/helpers/database-helpers.test.js (5 fail) and tests/unit/claim-validity-gate.test.js (1 fail) confirmed unrelated to this fix — they fail identically on origin/main HEAD 056d48e043. New test tests/session-check-concurrency-libuv-safe-exit.test.js (4 tests) PASSES. Manual smoke: \`node scripts/session-check-concurrency.js\` exits cleanly with code 1 (contention path), no libuv assertion.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol