### PR TITLE
fix(QF-20260511-056): quickfix-self-verifier verifyLOCConstraint use source-only LOC + align cap to 75

### DIFF
--- a/lib/quickfix-self-verifier.js
+++ b/lib/quickfix-self-verifier.js
@@ -183,42 +183,54 @@ export async function runSelfVerification(qfId, context = {}) {
   return verificationResults;
 }
 
+import { QF_HARD_LOC_CAP } from '../scripts/modules/complete-quick-fix/verification.js';
+
 /**
- * Check 1: Verify LOC constraint (actual ≤ 50)
+ * Check 1: Verify LOC constraint against the QF source-LOC cap.
+ *
+ * QF-20260511-056: applies the cap to source-only LOC (test LOC excluded),
+ * matching the policy already used by scripts/modules/complete-quick-fix/verification.js.
+ * Falls back to combined actualLoc only when no source/test split is available.
  */
 async function verifyLOCConstraint(qf, context) {
+  const sourceLoc = context.actualSourceLoc ?? qf.actual_source_loc ?? null;
+  const testLoc = context.actualTestLoc ?? qf.actual_test_loc ?? null;
   const actualLoc = context.actualLoc || qf.actual_loc;
+  const measured = sourceLoc ?? actualLoc;
+  const splitAvailable = sourceLoc !== null;
+  const label = splitAvailable ? 'Source LOC' : 'Actual LOC';
+  const suffix = splitAvailable && testLoc !== null ? ` (test: ${testLoc}, excluded)` : '';
 
-  if (!actualLoc) {
+  if (measured === null || measured === undefined) {
     return {
       passed: false,
-      message: 'Actual LOC not measured',
-      issue: 'Cannot verify LOC constraint - actual LOC not provided',
-      details: 'Run git diff to measure actual lines changed'
+      message: 'Source LOC not measured',
+      issue: 'Cannot verify LOC constraint - source LOC not provided',
+      details: 'Run git diff to measure source-only lines changed'
     };
   }
 
-  if (actualLoc > 50) {
+  if (measured > QF_HARD_LOC_CAP) {
     return {
       passed: false,
-      message: `Actual LOC (${actualLoc}) exceeds limit (50)`,
+      message: `${label} (${measured}) exceeds limit (${QF_HARD_LOC_CAP})${suffix}`,
       issue: 'LOC constraint violated - requires escalation to full SD',
       details: 'This change is too large for quick-fix workflow. Escalate to Strategic Directive.'
     };
   }
 
-  if (actualLoc > 40) {
+  if (measured > QF_HARD_LOC_CAP * 0.8) {
     return {
       passed: true,
-      message: `Actual LOC (${actualLoc}) within limit but approaching threshold`,
+      message: `${label} (${measured}) within limit but approaching threshold${suffix}`,
       details: `Consider: Is this really a "quick" fix? Estimated was ${qf.estimated_loc || 'N/A'}.`
     };
   }
 
   return {
     passed: true,
-    message: `Actual LOC (${actualLoc}) well within limit (50)`,
-    details: `Estimated: ${qf.estimated_loc || 'N/A'}, Actual: ${actualLoc} - good estimation!`
+    message: `${label} (${measured}) well within limit (${QF_HARD_LOC_CAP})${suffix}`,
+    details: `Estimated: ${qf.estimated_loc || 'N/A'}, ${label}: ${measured} - good estimation!`
   };
 }
 

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -261,8 +261,12 @@ export async function completeQuickFix(qfId, options = {}) {
   let finalPrUrl = prUrl;
 
   // Self-Verification (Combat Overconfidence)
+  // QF-20260511-056: forward source/test split so verifyLOCConstraint can apply
+  // the cap to source-only LOC (matches compliance-rubric context below).
   const verificationContext = {
     actualLoc,
+    actualSourceLoc,
+    actualTestLoc,
     filesChanged,
     testsPass,
     uatVerified,

--- a/tests/quickfix-self-verifier-loc-cap.test.js
+++ b/tests/quickfix-self-verifier-loc-cap.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { runSelfVerification } from '../lib/quickfix-self-verifier.js';
+import { QF_HARD_LOC_CAP } from '../scripts/modules/complete-quick-fix/verification.js';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+async function findExistingQfId() {
+  const { data } = await supabase
+    .from('quick_fixes')
+    .select('id')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  return data?.[0]?.id ?? null;
+}
+
+describe('quickfix-self-verifier verifyLOCConstraint (QF-20260511-056)', () => {
+  it('uses source-only LOC when actualSourceLoc is provided (large test LOC does NOT trip cap)', async () => {
+    const qfId = await findExistingQfId();
+    if (!qfId) return;
+
+    const result = await runSelfVerification(qfId, {
+      actualLoc: 300,
+      actualSourceLoc: 20,
+      actualTestLoc: 280,
+      filesChanged: [],
+      testsPass: true,
+      uatVerified: true,
+      testsVerifiedRecently: true
+    });
+
+    const locCheck = result.checks[0];
+    expect(locCheck.passed).toBe(true);
+    expect(locCheck.message).toMatch(/Source LOC \(20\)/);
+    expect(locCheck.message).toMatch(/test: 280, excluded/);
+  });
+
+  it('blocks when actualSourceLoc exceeds QF_HARD_LOC_CAP', async () => {
+    const qfId = await findExistingQfId();
+    if (!qfId) return;
+
+    const overCap = QF_HARD_LOC_CAP + 10;
+    const result = await runSelfVerification(qfId, {
+      actualLoc: overCap + 50,
+      actualSourceLoc: overCap,
+      actualTestLoc: 50,
+      filesChanged: [],
+      testsPass: true,
+      uatVerified: true,
+      testsVerifiedRecently: true
+    });
+
+    const locCheck = result.checks[0];
+    expect(locCheck.passed).toBe(false);
+    expect(locCheck.message).toMatch(new RegExp(`Source LOC \\(${overCap}\\) exceeds limit \\(${QF_HARD_LOC_CAP}\\)`));
+  });
+
+  it('falls back to combined actualLoc when no split is provided', async () => {
+    const qfId = await findExistingQfId();
+    if (!qfId) return;
+
+    const result = await runSelfVerification(qfId, {
+      actualLoc: 25,
+      filesChanged: [],
+      testsPass: true,
+      uatVerified: true,
+      testsVerifiedRecently: true
+    });
+
+    const locCheck = result.checks[0];
+    expect(locCheck.passed).toBe(true);
+    expect(locCheck.message).toMatch(/Actual LOC \(25\)/);
+    expect(locCheck.message).not.toMatch(/excluded/);
+  });
+
+  it('cap aligns with QF_HARD_LOC_CAP (75), not stale value 50', () => {
+    expect(QF_HARD_LOC_CAP).toBe(75);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-056  **Type:** bug **Severity:** low  ### Issue Description Check 1 (LOC Constraint Validation) in lib/quickfix-self-verifier.js uses combined actualLoc against a stale 50-line cap. The newer scripts/modules/complete-quick-fix/verification.js already uses sourceLoc against QF_HARD_LOC_CAP=75 (matching CLAUDE.md routing). Fix: pass actualSourceLoc/actualTestLoc into verificationContext; teach verifyLOCConstraint to prefer source-only LOC and align cap to QF_HARD_LOC_CAP. Closes feedback 85bd3fc8 (11+ witness recurring friction).     ### Changes - **Files Changed:** 3   - lib/quickfix-self-verifier.js   - scripts/modules/complete-quick-fix/orchestrator.js   - tests/quickfix-self-verifier-loc-cap.test.js - **LOC:** 113 lines - **Tests:** ✅ Passing - **UAT:** ✅ Verified  ### Verification Manual smoke: 4 new vitest cases pass (source-only cap, over-cap reject, fallback, cap value pin = 75). Self-validating: this very QF's verifier would have blocked at the old 50-line cap with combined LOC=98 (16 src + 82 test); under the fixed verifier with source-only cap=75, source LOC=16 passes cleanly.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol