### PR TITLE
fix(QF-20260511-446): removeWorktreeViaGit pre-unlinks node_modules symlink before 'git worktree remove --force'

### DIFF
--- a/lib/eva/proving/fix-agent.js
+++ b/lib/eva/proving/fix-agent.js
@@ -15,7 +15,7 @@ import path from 'path';
 // helpers. Proving-flow worktrees are ephemeral but still need a clean base —
 // inheriting from the operator's current HEAD pollutes pattern-fix attempts
 // with unrelated commits and skews proving outcomes.
-import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError } from '../../worktree-manager.js';
+import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError, removeWorktreeViaGit } from '../../worktree-manager.js';
 
 const DEFAULT_REPO_ROOT = process.cwd();
 const WORKTREE_PREFIX = '.worktrees/proving-fix';
@@ -62,7 +62,9 @@ export function createFixWorktree(repoRoot, fixId) {
   const worktreePath = path.join(repoRoot, WORKTREE_PREFIX, fixId);
 
   if (fs.existsSync(worktreePath)) {
-    execSync(`git worktree remove "${worktreePath}" --force`, { cwd: repoRoot, stdio: 'pipe' });
+    // QF-20260511-446: route through removeWorktreeViaGit to unlink the
+    // node_modules symlink before git removes the worktree (Windows MSYS-symlink wipe vector).
+    removeWorktreeViaGit(worktreePath, repoRoot);
   }
 
   // SD-LEO-INFRA-START-WORKTREE-BRANCH-001: fork explicitly from baseRef.

--- a/lib/eva/proving/fix-agent.js
+++ b/lib/eva/proving/fix-agent.js
@@ -89,9 +89,10 @@ export function createFixWorktree(repoRoot, fixId) {
  * @param {string} branch - Branch to delete
  */
 export function removeFixWorktree(repoRoot, worktreePath, branch) {
-  try {
-    execSync(`git worktree remove "${worktreePath}" --force`, { cwd: repoRoot, stdio: 'pipe' });
-  } catch { /* already removed */ }
+  // QF-20260511-446: route through removeWorktreeViaGit so the node_modules
+  // symlink is unlinked first — bare `git worktree remove --force` follows
+  // MSYS bash symlinks on Windows and wipes the main repo's node_modules.
+  removeWorktreeViaGit(worktreePath, repoRoot, { allowFail: true });
   try {
     execSync(`git branch -D "${branch}"`, { cwd: repoRoot, stdio: 'pipe' });
   } catch { /* branch may not exist */ }

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1340,6 +1340,37 @@ export function safeRecursiveCp(srcPath, destPath, options = {}) {
   }
 }
 
+/**
+ * QF-20260511-446: Remove a worktree via `git worktree remove --force`, but
+ * first unlink any `node_modules` symlink inside it so git does not follow
+ * the link and wipe the main repo's node_modules.
+ *
+ * On Windows, worktree node_modules are sometimes MSYS bash symlinks rather
+ * than Windows junctions; `git worktree remove --force` follows them and
+ * deletes the target contents. Mirrors the pre-unlink pattern that
+ * safeRecursiveRm uses for fs.rmSync sites (PR #3590 / #3654).
+ *
+ * @param {string} wtPath - Worktree directory path
+ * @param {string} repoRoot - Main repo path (cwd for git)
+ * @param {{ allowFail?: boolean }} [options] - allowFail returns {ok:false,error} instead of throwing
+ * @returns {{ ok: boolean, error: string|null }}
+ */
+export function removeWorktreeViaGit(wtPath, repoRoot, options = {}) {
+  const { allowFail = false } = options;
+  try {
+    const nmPath = `${wtPath}/node_modules`;
+    try {
+      const lst = fs.lstatSync(nmPath);
+      if (lst.isSymbolicLink()) _unlinkSymOrJunction(nmPath);
+    } catch { /* no node_modules or already gone */ }
+    execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoRoot, stdio: 'pipe' });
+    return { ok: true, error: null };
+  } catch (err) {
+    if (allowFail) return { ok: false, error: err?.message || String(err) };
+    throw err;
+  }
+}
+
 function _unlinkSymOrJunction(p) {
   try {
     fs.unlinkSync(p);

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { createClient } from '@supabase/supabase-js';
-import { safeRecursiveRm, safeRecursiveCp } from '../../../lib/worktree-manager.js';
+import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../../../lib/worktree-manager.js';
 
 // Quick-fix QF-20260211-111: Post-merge worktree cleanup for /ship
 // FR-5: Added --sdKey support for external callers (SD-LEO-INFRA-UNIFIED-WORKTREE-LIFECYCLE-001)
@@ -306,13 +306,12 @@ async function cleanupWorktreeByPath(wtPath, options = {}) {
     return { cleaned: false, reason: 'unpushed_commits', commits, ...archive, mainRepoPath, workKey: sdKey };
   }
 
-  try {
-    execSync(`git worktree remove --force "${wtPath}"`, { cwd: mainRepoPath, encoding: 'utf8', stdio: 'pipe' });
-  } catch {
-    if (fs.existsSync(wtPath)) {
-      safeRecursiveRm(wtPath);
-      execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
-    }
+  // QF-20260511-446: pre-unlink node_modules symlink so git doesn't follow it
+  // and wipe main repo's node_modules (MSYS-symlink-on-Windows wipe vector).
+  const gitRemove = removeWorktreeViaGit(wtPath, mainRepoPath, { allowFail: true });
+  if (!gitRemove.ok && fs.existsSync(wtPath)) {
+    safeRecursiveRm(wtPath);
+    execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
   }
   return { cleaned: true, mainRepoPath, workKey: sdKey };
 }

--- a/scripts/modules/shipping/worktree-merge.js
+++ b/scripts/modules/shipping/worktree-merge.js
@@ -13,6 +13,7 @@
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
+import { removeWorktreeViaGit } from '../../../lib/worktree-manager.js';
 
 function run(cmd, opts = {}) {
   try {
@@ -68,9 +69,12 @@ function main() {
     console.log('   🧹 Pruning worktree references...');
     run('git worktree prune', { cwd: mainRepoPath });
 
-    // Try to remove the worktree directory if it still exists
+    // Try to remove the worktree directory if it still exists.
+    // QF-20260511-446: route through removeWorktreeViaGit so the node_modules
+    // symlink is unlinked first — bare `git worktree remove --force` follows
+    // MSYS bash symlinks on Windows and wipes the main repo's node_modules.
     if (existsSync(worktreePath)) {
-      run(`git worktree remove "${worktreeRelative}" --force`, { cwd: mainRepoPath, allowFail: true });
+      removeWorktreeViaGit(worktreePath, mainRepoPath, { allowFail: true });
     }
 
     // Delete local branch reference

--- a/tests/worktree-manager-remove-via-git.test.js
+++ b/tests/worktree-manager-remove-via-git.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for lib/worktree-manager.js removeWorktreeViaGit().
+ *
+ * QF-20260511-446 — closes feedback 68a6f715 (mid-session node_modules wipe)
+ * + a8d2b446 (mid-LEAD-phase worktree wipe). Root cause: three call sites
+ * invoked `git worktree remove --force <wtPath>` without first unlinking the
+ * worktree's `node_modules` symlink. On Windows with MSYS bash symlinks
+ * (not Windows junctions), git follows the link and deletes the target's
+ * contents — i.e. wipes main repo's node_modules.
+ *
+ * These tests assert the helper:
+ *   1. Calls fs.lstatSync on <wtPath>/node_modules
+ *   2. If the entry is a symlink, calls fs.unlinkSync BEFORE execSync
+ *   3. Then calls execSync with the exact git command + cwd=repoRoot
+ *   4. Returns {ok:true,error:null} on success
+ *   5. Returns {ok:false,error:<msg>} when allowFail and git fails
+ *   6. Re-throws when allowFail is false
+ *   7. Tolerates missing node_modules (lstat throws — swallowed)
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const calls = [];
+function recordCall(name, args) { calls.push({ name, args }); }
+
+vi.mock('fs', () => ({
+  default: {
+    lstatSync: vi.fn((p) => {
+      recordCall('lstatSync', [p]);
+      if (lstatBehavior.throws) throw lstatBehavior.error;
+      return { isSymbolicLink: () => lstatBehavior.isSymlink };
+    }),
+    unlinkSync: vi.fn((p) => { recordCall('unlinkSync', [p]); }),
+    rmdirSync: vi.fn((p) => { recordCall('rmdirSync', [p]); }),
+    existsSync: vi.fn(() => true),
+    readlinkSync: vi.fn(() => ''),
+    rmSync: vi.fn(),
+    cpSync: vi.fn(),
+    symlinkSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => ''),
+  },
+  lstatSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn((cmd, opts) => {
+    recordCall('execSync', [cmd, opts?.cwd]);
+    if (execBehavior.throws) throw execBehavior.error;
+    return '';
+  }),
+  spawnSync: vi.fn(),
+}));
+
+let lstatBehavior;
+let execBehavior;
+
+import { removeWorktreeViaGit } from '../lib/worktree-manager.js';
+
+describe('removeWorktreeViaGit (QF-20260511-446)', () => {
+  beforeEach(() => {
+    calls.length = 0;
+    lstatBehavior = { isSymlink: true, throws: false, error: null };
+    execBehavior = { throws: false, error: null };
+  });
+
+  it('unlinks node_modules symlink BEFORE running git worktree remove', () => {
+    const result = removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo');
+    const unlinkIdx = calls.findIndex(c => c.name === 'unlinkSync');
+    const execIdx = calls.findIndex(c => c.name === 'execSync');
+    expect(unlinkIdx).toBeGreaterThanOrEqual(0);
+    expect(execIdx).toBeGreaterThan(unlinkIdx);
+    expect(result).toEqual({ ok: true, error: null });
+  });
+
+  it('passes correct git command and cwd=repoRoot', () => {
+    removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo');
+    const exec = calls.find(c => c.name === 'execSync');
+    expect(exec.args[0]).toBe('git worktree remove --force "/repo/.worktrees/SD-1"');
+    expect(exec.args[1]).toBe('/repo');
+  });
+
+  it('skips unlink when node_modules is NOT a symlink', () => {
+    lstatBehavior.isSymlink = false;
+    removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo');
+    expect(calls.find(c => c.name === 'unlinkSync')).toBeUndefined();
+    expect(calls.find(c => c.name === 'execSync')).toBeDefined();
+  });
+
+  it('tolerates missing node_modules (lstat throws → swallowed)', () => {
+    lstatBehavior.throws = true;
+    lstatBehavior.error = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    const result = removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo');
+    expect(result.ok).toBe(true);
+    expect(calls.find(c => c.name === 'unlinkSync')).toBeUndefined();
+    expect(calls.find(c => c.name === 'execSync')).toBeDefined();
+  });
+
+  it('returns {ok:false,error} when allowFail and git fails', () => {
+    execBehavior.throws = true;
+    execBehavior.error = new Error('fatal: worktree busy');
+    const result = removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo', { allowFail: true });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/worktree busy/);
+  });
+
+  it('re-throws when allowFail is false and git fails', () => {
+    execBehavior.throws = true;
+    execBehavior.error = new Error('fatal: worktree busy');
+    expect(() => removeWorktreeViaGit('/repo/.worktrees/SD-1', '/repo')).toThrow(/worktree busy/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-446

**Type:** bug · **Severity:** high · **Tier:** 1 (routed) — actual src 22 LOC

### Issue
Three call sites invoke \`git worktree remove --force <wtPath>\` without first unlinking the worktree's \`node_modules\` symlink. On Windows with MSYS bash symlinks (not Windows junctions), git follows the link and deletes the target's contents — i.e. wipes main repo's \`node_modules\`, bricking every parallel session.

### RCA (rca-agent, confidence 0.88)
Witness pattern matches \`/ship\` and post-merge cleanup timing:
- feedback \`68a6f715\` (2026-05-11): live mid-this-session wipe during sibling PR #3721 merge
- feedback \`a8d2b446\` (2026-05-10): "Worktree silently wiped mid-LEAD-phase"

Prior fixes (PR #3590 / #3654 / #3471 / SD-FDBK-INFRA-CONCURRENT-NPM-RECONCILIATION-001) all wrapped \`fs.rmSync\` call sites with junction-aware helpers (\`safeRecursiveRm\`/\`safeRecursiveCp\`). The \`git worktree remove\` shell-out sites were never wrapped — git itself does the symlink-following deletion when MSYS symlinks are present.

### Fix
Add \`lib/worktree-manager.js#removeWorktreeViaGit(wtPath, repoRoot, {allowFail})\` — lstat \`node_modules\`, \`unlinkSync\` if symlink, then \`execSync\` the git command. Mirrors the pre-unlink pattern already used at every \`fs.rmSync\` site.

Rewire three call sites:
- \`scripts/modules/shipping/worktree-merge.js:73\` (/ship flow)
- \`scripts/modules/shipping/post-merge-worktree-cleanup.js:310\` (post-merge cleanup)
- \`lib/eva/proving/fix-agent.js:65\` (EVA fix-agent disposal)

### Closes
- feedback \`68a6f715\` (live witness)
- feedback \`a8d2b446\`

### Changes
- \`lib/worktree-manager.js\`: +31 LOC (helper + JSDoc)
- \`scripts/modules/shipping/worktree-merge.js\`: +6 -2
- \`scripts/modules/shipping/post-merge-worktree-cleanup.js\`: +6 -7
- \`lib/eva/proving/fix-agent.js\`: +4 -2
- \`tests/worktree-manager-remove-via-git.test.js\`: +108 (6 cases)

**Source LOC:** 22 (well under Tier-1 cap 30) · **Test LOC:** 108

### Verification
- \`npx vitest run tests/worktree-manager-remove-via-git.test.js\` → 6/6 passing
- Tests assert: unlink-before-exec ordering, correct git command + cwd, skip-when-not-symlink, tolerate-missing-node_modules, allowFail returns {ok:false}, no-allowFail re-throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)