### PR TITLE
fix(QF-20260511-741): countLocBySplit empty 3-dot fallback to headRef^...headRef

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -92,8 +92,9 @@ const TEST_FILE_PATTERN = /(\.test\.|\.spec\.|\b__tests__\b|\btests\/|\be2e\/|\b
 export function countLocBySplit(testDir, baseRef = 'origin/main', headRef = 'HEAD') {
   const result = { source: 0, test: 0, total: 0, sourceDeletionLoc: 0 };
   let numstat = '';
+  let effectiveRange = `${baseRef}...${headRef}`;
   try {
-    numstat = execSync(`git diff --numstat ${baseRef}...${headRef}`, {
+    numstat = execSync(`git diff --numstat ${effectiveRange}`, {
       cwd: testDir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -101,6 +102,29 @@ export function countLocBySplit(testDir, baseRef = 'origin/main', headRef = 'HEA
     });
   } catch {
     return result;
+  }
+  // QF-20260511-741: empty 3-dot diff fallback. When baseRef has been
+  // fast-forwarded to or IS headRef (post-fetch fast-forward case, or
+  // true-merge-commit case where mergeCommit.oid IS origin/main tip),
+  // 3-dot returns empty and the caller would otherwise fall back to GitHub-
+  // API total as 100% source LOC. Retry against headRef's first parent so
+  // the actual file changes are counted. Only fires for explicit commit
+  // SHAs (headRef !== 'HEAD'); the legacy in-worktree HEAD path has no
+  // equivalent fallback because HEAD^...HEAD would compare against the
+  // previous commit, not the PR base. Closes feedback 2b792e59 + 661285bc.
+  if (!numstat && headRef !== 'HEAD') {
+    try {
+      effectiveRange = `${headRef}^...${headRef}`;
+      numstat = execSync(`git diff --numstat ${effectiveRange}`, {
+        cwd: testDir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 10000
+      });
+    } catch {
+      // First parent unreachable (shallow clone, root commit). Fall through
+      // with empty numstat — fail-safe matches original empty-result behavior.
+    }
   }
   // QF-20260509-409: defensive guard — execSync may return undefined under some
   // mock setups (e.g. mockReturnValueOnce exhausted in upstream test), in which
@@ -112,7 +136,7 @@ export function countLocBySplit(testDir, baseRef = 'origin/main', headRef = 'HEA
   // as not-counting-against-tier-cap (pure dead-code removal).
   const deletedPaths = new Set();
   try {
-    const nameStatus = execSync(`git diff --name-status --diff-filter=D ${baseRef}...${headRef}`, {
+    const nameStatus = execSync(`git diff --name-status --diff-filter=D ${effectiveRange}`, {
       cwd: testDir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/unit/scripts/complete-quick-fix-loc-split.test.js
+++ b/tests/unit/scripts/complete-quick-fix-loc-split.test.js
@@ -268,17 +268,25 @@ describe('QF-20260511-205 — countLocBySplit uses 3-dot diff syntax (static-pin
     );
   });
 
-  it('numstat call uses 3-dot ${baseRef}...${headRef} (not 2-dot)', () => {
+  it('numstat call uses 3-dot baseRef...headRef (not 2-dot)', () => {
     // QF-20260511-129: headRef is now parameterized (was hardcoded 'HEAD').
-    // 3-dot semantics preserved — the second segment is now ${headRef} (default 'HEAD').
-    expect(src).toContain('git diff --numstat ${baseRef}...${headRef}');
+    // QF-20260511-741: the 3-dot range is now hoisted into an `effectiveRange`
+    // variable so an empty 3-dot result can be retried against headRef^.
+    // The literal `${baseRef}...${headRef}` template lives at the variable
+    // init site; execSync references the variable.
+    expect(src).toContain('`${baseRef}...${headRef}`');
+    expect(src).toMatch(/git diff --numstat \$\{effectiveRange\}/);
     // Guard against accidental 2-dot regression on either ref form.
     expect(src).not.toMatch(/git diff --numstat \$\{baseRef\}\.\.\$\{headRef\}(?!\.)/);
     expect(src).not.toMatch(/git diff --numstat \$\{baseRef\}\.\.HEAD(?!\.)/);
   });
 
-  it('name-status (--diff-filter=D) call uses 3-dot ${baseRef}...${headRef}', () => {
-    expect(src).toContain('git diff --name-status --diff-filter=D ${baseRef}...${headRef}');
+  it('name-status (--diff-filter=D) call shares the same range as numstat', () => {
+    // QF-20260511-741: both numstat and diff-filter route through
+    // ${effectiveRange} so the fallback (headRef^...headRef) is applied
+    // symmetrically — diff-filter against original 3-dot when numstat
+    // fell back would mis-count deletions.
+    expect(src).toMatch(/git diff --name-status --diff-filter=D \$\{effectiveRange\}/);
     expect(src).not.toMatch(/git diff --name-status --diff-filter=D \$\{baseRef\}\.\.\$\{headRef\}(?!\.)/);
     expect(src).not.toMatch(/git diff --name-status --diff-filter=D \$\{baseRef\}\.\.HEAD(?!\.)/);
   });

--- a/tests/unit/scripts/count-loc-by-split-empty-3dot-fallback.test.js
+++ b/tests/unit/scripts/count-loc-by-split-empty-3dot-fallback.test.js
@@ -1,0 +1,87 @@
+/**
+ * QF-20260511-741: countLocBySplit empty 3-dot diff fallback.
+ *
+ * Closes feedback 2b792e59 (merge-commit PR: pr.mergeCommit.oid IS origin/main
+ * → empty 3-dot diff → split={0,0,0} → caller falls back to GitHub-API total
+ * as 100% source) and 661285bc (post-fetch fast-forward: origin/main has been
+ * fast-forwarded to mergeCommit.oid before complete-quick-fix runs → same
+ * empty 3-dot symptom).
+ *
+ * Fix: when `git diff --numstat baseRef...headRef` returns empty AND
+ * headRef !== 'HEAD' (explicit commit SHA), retry with headRef^...headRef.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', () => ({ execSync: execSyncMock }));
+
+const { countLocBySplit } = await import('../../../scripts/modules/complete-quick-fix/git-operations.js');
+
+describe('QF-20260511-741 — countLocBySplit empty 3-dot fallback', () => {
+  beforeEach(() => execSyncMock.mockReset());
+
+  it('falls back to headRef^...headRef when 3-dot returns empty AND headRef is an explicit SHA', () => {
+    // First call (3-dot): empty diff
+    execSyncMock.mockReturnValueOnce('');
+    // Second call (parent-diff fallback): real numstat
+    execSyncMock.mockReturnValueOnce('27\t0\tlib/foo.js\n94\t0\ttests/foo.test.js');
+    // Third call (--name-status --diff-filter=D on effectiveRange): empty
+    execSyncMock.mockReturnValueOnce('');
+
+    const r = countLocBySplit('/fake/repo', 'origin/main', 'abc123def');
+
+    expect(r.source).toBe(27);
+    expect(r.test).toBe(94);
+    expect(r.total).toBe(121);
+
+    // Verify the fallback range was used
+    const calls = execSyncMock.mock.calls.map(c => c[0]);
+    expect(calls[0]).toBe('git diff --numstat origin/main...abc123def');
+    expect(calls[1]).toBe('git diff --numstat abc123def^...abc123def');
+  });
+
+  it('does NOT fall back when headRef is HEAD (legacy in-worktree path)', () => {
+    execSyncMock.mockReturnValueOnce(''); // empty 3-dot
+    // No second call expected — fallback should be skipped for HEAD.
+
+    const r = countLocBySplit('/fake/repo', 'origin/main', 'HEAD');
+
+    expect(r).toEqual({ source: 0, test: 0, total: 0, sourceDeletionLoc: 0 });
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes effectiveRange (fallback range) to --diff-filter=D call', () => {
+    execSyncMock.mockReturnValueOnce(''); // empty 3-dot
+    execSyncMock.mockReturnValueOnce('5\t10\tlib/deleted.js'); // fallback numstat
+    execSyncMock.mockReturnValueOnce('D\tlib/deleted.js'); // diff-filter D
+
+    const r = countLocBySplit('/fake/repo', 'origin/main', 'sha999');
+
+    expect(r.sourceDeletionLoc).toBe(15);
+    const calls = execSyncMock.mock.calls.map(c => c[0]);
+    expect(calls[2]).toBe('git diff --name-status --diff-filter=D sha999^...sha999');
+  });
+
+  it('tolerates parent-diff failing (e.g. root/shallow commit) and returns empty result', () => {
+    execSyncMock.mockReturnValueOnce(''); // empty 3-dot
+    execSyncMock.mockImplementationOnce(() => { throw new Error('fatal: ambiguous argument'); }); // parent unreachable
+
+    const r = countLocBySplit('/fake/repo', 'origin/main', 'sha000');
+
+    expect(r).toEqual({ source: 0, test: 0, total: 0, sourceDeletionLoc: 0 });
+  });
+
+  it('uses 3-dot range when it returns non-empty (regression: no unnecessary fallback)', () => {
+    execSyncMock.mockReturnValueOnce('20\t0\tlib/a.js'); // 3-dot has real data
+    execSyncMock.mockReturnValueOnce(''); // diff-filter D — empty
+
+    const r = countLocBySplit('/fake/repo', 'origin/main', 'sha-with-data');
+
+    expect(r.source).toBe(20);
+    const calls = execSyncMock.mock.calls.map(c => c[0]);
+    expect(calls[0]).toBe('git diff --numstat origin/main...sha-with-data');
+    // The 2nd call should be the diff-filter, NOT the parent-fallback diff
+    expect(calls[1]).toBe('git diff --name-status --diff-filter=D origin/main...sha-with-data');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-741

**Type:** bug · **Severity:** medium · **Tier:** 1 — actual src ~10 LOC

### Issue
\`countLocBySplit\` returns \`split={0,0,0}\` when \`git diff --numstat origin/main...mergeCommit.oid\` produces an empty diff. This happens in two scenarios:

1. **True-merge-commit PRs** (feedback \`2b792e59\`): after \`git fetch\`, \`pr.mergeCommit.oid\` IS \`origin/main\` → 3-dot is empty.
2. **Post-fetch fast-forward** (feedback \`661285bc\`): \`origin/main\` has already been fast-forwarded to \`mergeCommit.oid\` by the time \`complete-quick-fix\` runs → 3-dot is empty.

In both cases the caller silently falls back to GitHub-API total as 100% source LOC. Witnessed:
- **QF-20260511-129** self-validation: total 133 reported as 133 src / 0 test (actual 27 / 94)
- **QF-20260511-414** PR #3717: 163 additions reported as 163 src / 0 test → force-completed

### Fix
When 3-dot returns empty AND \`headRef !== 'HEAD'\` (explicit commit SHA), retry with \`headRef^...headRef\` (diff against the merge-commit's first parent — i.e. the pre-merge base). Skipped for the legacy in-worktree HEAD path because \`HEAD^...HEAD\` compares against the previous commit, not the PR base.

The \`--name-status --diff-filter=D\` call now routes through the same \`effectiveRange\` variable so deletion counting stays symmetric with the numstat range.

### Closes
- feedback \`2b792e59\`
- feedback \`661285bc\`

### Changes
- \`scripts/modules/complete-quick-fix/git-operations.js\`: +25 -3 (fallback block + variable extraction)
- \`tests/unit/scripts/count-loc-by-split-empty-3dot-fallback.test.js\`: +85 (5 new cases)
- \`tests/unit/scripts/complete-quick-fix-loc-split.test.js\`: updated 2 static-source guards (literal-template → variable form); 2-dot regression checks preserved

**Source LOC:** ~10 (Tier-1 cap 30) · **Test LOC:** ~85 + 2 guard updates

### Verification
- \`npx vitest run tests/unit/complete-quick-fix tests/unit/scripts/count-loc tests/unit/scripts/complete-quick-fix\` → 149/149 passing (5 new + 144 existing)
- Tests cover: fallback fires on empty 3-dot + explicit SHA, fallback skipped for HEAD, diff-filter uses fallback range, parent unreachable tolerated, no unnecessary fallback when 3-dot has data

🤖 Generated with [Claude Code](https://claude.com/claude-code)