### PR TITLE
fix(QF-20260511-123): complete-quick-fix Test Dir prefers QF-worktree cwd

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260511-772",
+  "sdKey": "QF-20260511-123",
   "workType": "QF",
-  "workKey": "QF-20260511-772",
-  "expectedBranch": "qf/QF-20260511-772",
-  "createdAt": "2026-05-11T19:10:04.324Z",
+  "workKey": "QF-20260511-123",
+  "expectedBranch": "qf/QF-20260511-123",
+  "createdAt": "2026-05-11T19:36:32.264Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -9,6 +9,26 @@
  */
 
 import { execSync, execFileSync } from 'child_process';
+import path from 'path';
+
+// QF-20260511-123 / feedback 0930f169: prefer the QF worktree when cwd is inside
+// .worktrees/qf/<qfId>, so Tier-1 docs-QFs don't fall back to the parent repo's
+// dirty working tree on Windows (Git Bash MSYS cwd doesn't propagate via spawn).
+export function resolveQFWorktreeFromCwd(qfId, cwd = process.cwd()) {
+  if (!qfId || typeof qfId !== 'string') return null;
+  const normalized = cwd.replace(/\\/g, '/');
+  const escaped = qfId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`(.*\\/\\.worktrees\\/(?:qf\\/)?${escaped})(?:\\/|$)`, 'i');
+  const match = normalized.match(pattern);
+  if (!match) return null;
+  const candidate = path.resolve(match[1].replace(/\//g, path.sep));
+  try {
+    execSync('git rev-parse --git-dir', { cwd: candidate, stdio: ['ignore', 'pipe', 'pipe'] });
+    return candidate;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Parse `git status --short` output into a list of file paths.

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -19,7 +19,7 @@ import fs from 'fs';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
-import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain } from './git-operations.js';
+import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd } from './git-operations.js';
 import {
   validateLOC,
   validateTests,
@@ -91,7 +91,13 @@ export async function completeQuickFix(qfId, options = {}) {
 
   // Determine test directory from target_application
   const targetApplication = qf.target_application || 'EHG';
-  const testDir = REPO_PATHS[targetApplication] || EHG_ROOT;
+  let testDir = REPO_PATHS[targetApplication] || EHG_ROOT;
+
+  const cwdWorktree = resolveQFWorktreeFromCwd(qfId);
+  if (cwdWorktree && cwdWorktree !== testDir) {
+    console.log(`📂 Auto-detected QF worktree CWD; overriding Test Dir from ${testDir} → ${cwdWorktree}`);
+    testDir = cwdWorktree;
+  }
 
   console.log(`📋 Quick-Fix: ${qf.title}`);
   console.log(`   Type: ${qf.type}`);

--- a/tests/unit/scripts/resolve-qf-worktree-from-cwd.test.js
+++ b/tests/unit/scripts/resolve-qf-worktree-from-cwd.test.js
@@ -1,0 +1,80 @@
+/**
+ * QF-20260511-123 — resolveQFWorktreeFromCwd
+ *
+ * Validates the CWD→worktree resolver added to complete-quick-fix git-operations.
+ * Closes feedback 0930f169 (Windows shell-cwd vs node process.cwd() asymmetry that
+ * caused Test Dir to fall back to the parent repo, picking up parallel-session
+ * dirty state and tripping the failing-tests gate).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveQFWorktreeFromCwd } from '../../../scripts/modules/complete-quick-fix/git-operations.js';
+
+describe('resolveQFWorktreeFromCwd', () => {
+  let scratchRoot;
+  let worktreeDir;
+
+  beforeAll(() => {
+    scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-cwd-resolver-'));
+    const fakeRepo = path.join(scratchRoot, 'repo');
+    fs.mkdirSync(fakeRepo, { recursive: true });
+    execSync('git init -q', { cwd: fakeRepo });
+    execSync('git config user.email test@example.com', { cwd: fakeRepo });
+    execSync('git config user.name test', { cwd: fakeRepo });
+    fs.writeFileSync(path.join(fakeRepo, 'a.txt'), 'a');
+    execSync('git add a.txt && git commit -q -m seed', { cwd: fakeRepo });
+    worktreeDir = path.join(fakeRepo, '.worktrees', 'qf', 'QF-20260101-001');
+    execSync(`git worktree add -q -b qf/QF-20260101-001 "${worktreeDir}"`, { cwd: fakeRepo });
+  });
+
+  afterAll(() => {
+    try { fs.rmSync(scratchRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('returns the worktree path when cwd is the worktree root', () => {
+    const resolved = resolveQFWorktreeFromCwd('QF-20260101-001', worktreeDir);
+    expect(resolved && path.resolve(resolved)).toBe(path.resolve(worktreeDir));
+  });
+
+  it('returns the worktree path when cwd is a nested subdir inside the worktree', () => {
+    const nested = path.join(worktreeDir, 'src', 'deep');
+    fs.mkdirSync(nested, { recursive: true });
+    const resolved = resolveQFWorktreeFromCwd('QF-20260101-001', nested);
+    expect(resolved && path.resolve(resolved)).toBe(path.resolve(worktreeDir));
+  });
+
+  it('returns null when qfId does not match the worktree path', () => {
+    expect(resolveQFWorktreeFromCwd('QF-20260101-999', worktreeDir)).toBe(null);
+  });
+
+  it('returns null when cwd is outside any worktree', () => {
+    expect(resolveQFWorktreeFromCwd('QF-20260101-001', os.tmpdir())).toBe(null);
+  });
+
+  it('returns null on missing or non-string qfId', () => {
+    expect(resolveQFWorktreeFromCwd(null, worktreeDir)).toBe(null);
+    expect(resolveQFWorktreeFromCwd('', worktreeDir)).toBe(null);
+    expect(resolveQFWorktreeFromCwd(undefined, worktreeDir)).toBe(null);
+  });
+
+  it('handles legacy non-namespaced .worktrees/QF-xxx layout', () => {
+    const legacyRepo = path.join(scratchRoot, 'legacy');
+    fs.mkdirSync(legacyRepo, { recursive: true });
+    execSync('git init -q', { cwd: legacyRepo });
+    execSync('git config user.email t@e.com && git config user.name t', { cwd: legacyRepo });
+    fs.writeFileSync(path.join(legacyRepo, 'a.txt'), 'a');
+    execSync('git add a.txt && git commit -q -m seed', { cwd: legacyRepo });
+    const legacyWt = path.join(legacyRepo, '.worktrees', 'QF-20260101-002');
+    execSync(`git worktree add -q -b QF-20260101-002 "${legacyWt}"`, { cwd: legacyRepo });
+    expect(resolveQFWorktreeFromCwd('QF-20260101-002', legacyWt)).toBe(path.resolve(legacyWt));
+  });
+
+  it('normalizes Windows backslash separators in cwd', () => {
+    const winStyle = worktreeDir.replace(/\//g, '\\');
+    const resolved = resolveQFWorktreeFromCwd('QF-20260101-001', winStyle);
+    expect(resolved && path.resolve(resolved)).toBe(path.resolve(worktreeDir));
+  });
+});


### PR DESCRIPTION
## Summary
- `orchestrator.js` statically resolved `testDir` from `REPO_PATHS[target_application]`, ignoring invocation cwd.
- On Windows, `cd worktree && node script` left process.cwd() reporting the parent repo path → tests ran against parallel-session dirty state → false-positive failing-tests gate → required `--force-complete` bypass on every ship (witnessed during QF-20260511-772 ship).
- New `resolveQFWorktreeFromCwd(qfId, cwd)` in `git-operations.js`: regex-match on `.worktrees/(qf/)?<qfId>`, then verify via `git rev-parse --git-dir`. Orchestrator consults it and overrides `testDir` if matched.

Closes feedback `0930f169-1d7e-45b1-bd87-ae2b3f17d6ca`.

## Test plan
- [x] 7 new unit cases in `tests/unit/scripts/resolve-qf-worktree-from-cwd.test.js` (root cwd, nested subdir, ID mismatch, outside-worktree, null/missing qfId, legacy non-namespaced layout, Windows backslash normalization) — 7/7 pass
- [x] Sibling test `count-loc-by-split-empty-3dot-fallback.test.js` still 5/5
- [x] Orchestrator import sanity: `import('./orchestrator.js')` resolves

Tier 1 (28 src LOC + 87 test LOC). Legacy behavior preserved when cwd is outside any QF worktree (resolver returns null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)