### PR TITLE
fix(QF-20260511-728): create-quick-fix.js error on unknown flags

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -482,6 +482,10 @@ Tiered Routing:
   - Risk keywords (security, auth, schema): Force Tier 3
     `);
     process.exit(0);
+  } else {
+    console.error(`❌ Unknown argument: ${arg}`);
+    console.error(`   Run with --help for usage information.`);
+    process.exit(1);
   }
 }
 

--- a/tests/create-quick-fix-unknown-flag.test.js
+++ b/tests/create-quick-fix-unknown-flag.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'create-quick-fix.js');
+
+function runCli(args) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 15000,
+    env: { ...process.env, SUPABASE_URL: 'http://test.invalid.local', SUPABASE_SERVICE_ROLE_KEY: 'test' }
+  });
+}
+
+describe('create-quick-fix.js unknown-flag handling (QF-20260511-728)', () => {
+  it('exits non-zero on --id (previously silently ignored)', () => {
+    const r = runCli(['--id', 'QF-FOO', '--title', 'x']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/Unknown argument/);
+    expect(r.stderr).toMatch(/--id/);
+  });
+
+  it('exits non-zero on any other unknown flag', () => {
+    const r = runCli(['--bogus-flag', 'value']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/Unknown argument: --bogus-flag/);
+  });
+
+  it('--help still succeeds (exits 0)', () => {
+    const r = runCli(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an else-branch to scripts/create-quick-fix.js CLI parser to error and exit 1 on any unknown flag (previously silently ignored).
- Witnessed: --id flag was claimed in past sessions but never honored — silently auto-generated instead.
- 4 src LOC + 36 test LOC. Closes feedback 734e7380.

## Test plan
- [x] tests/create-quick-fix-unknown-flag.test.js — 3/3 PASS (vitest)
- [x] --id flag errors with non-zero exit + clear message
- [x] --help still exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)