### PR TITLE
fix(QF-20260511-163): add LEAD_FINAL to model_usage_log_phase_check enum

### DIFF
--- a/database/migrations/20260511_fix_model_usage_log_phase_lead_final_underscore.sql
+++ b/database/migrations/20260511_fix_model_usage_log_phase_lead_final_underscore.sql
@@ -1,0 +1,55 @@
+-- Migration: 20260511_fix_model_usage_log_phase_lead_final_underscore
+-- QF: QF-20260511-163
+-- Closes feedback: 31c14ea3-eac7-4c97-9a3d-c8ad50367ee5
+-- @approved-by: rickfelix@example.com
+--
+-- Issue: model_usage_log_phase_check rejects 'LEAD_FINAL' (underscore form).
+--        The 20260429 migration added 'LEAD-FINAL' (hyphen handoff-type variant)
+--        but missed the underscore internal phase-state name emitted by
+--        scripts/modules/handoff/cli/execution-helpers.js:32 and used as a
+--        state-machine value in scripts/hooks/phase-state-enforcement.js:42-44.
+--
+-- RCA:   Two-name asymmetry. The canonical handoff-type is 'LEAD-FINAL-APPROVAL'
+--        (with dashes), the canonical internal phase-state name is 'LEAD_FINAL'
+--        (with underscore). track-model-usage.js is invoked with the internal
+--        phase-state name, not the handoff-type — so the underscore variant must
+--        be enum-valid.
+--
+-- Fix:   Re-add the enum constraint with 'LEAD_FINAL' included.
+
+ALTER TABLE model_usage_log
+DROP CONSTRAINT IF EXISTS model_usage_log_phase_check;
+
+ALTER TABLE model_usage_log
+ADD CONSTRAINT model_usage_log_phase_check
+CHECK (phase IN (
+  -- Original allowlist
+  'LEAD',
+  'PLAN',
+  'EXEC',
+  'UNKNOWN',
+  -- Completion/standalone (added 2026-04-26 per QF-20260425-002)
+  'STANDALONE',
+  'QF_COMPLETION',
+  'SD_COMPLETION',
+  'HANDOFF',
+  'COMPLETE',
+  -- Underscore sub-phase variants (added 2026-04-26)
+  'LEAD_APPROVAL',
+  'LEAD_FINAL_APPROVAL',
+  'PLAN_DESIGN',
+  'PLAN_VERIFY',
+  'EXEC_IMPLEMENTATION',
+  -- Hyphenated handoff transition strings (added 2026-04-29)
+  'LEAD-TO-PLAN',
+  'PLAN-TO-EXEC',
+  'EXEC-TO-PLAN',
+  'PLAN-TO-LEAD',
+  'LEAD-FINAL',
+  -- Underscore internal phase-state names (added 2026-05-11 per QF-20260511-163)
+  -- Canonical per phase-state-enforcement.js:42-44 + execution-helpers.js:32
+  'LEAD_FINAL'
+));
+
+COMMENT ON CONSTRAINT model_usage_log_phase_check ON model_usage_log IS
+'Valid phase values for model usage tracking. Expanded 2026-05-11 (QF-20260511-163) to add LEAD_FINAL underscore internal phase-state name (sibling to LEAD-FINAL hyphenated handoff-type added 2026-04-29). track-model-usage.js callers pass internal phase-state names from execution-helpers.js / phase-state-enforcement.js, not handoff-type strings.';

--- a/tests/database/model-usage-log-phase-check.test.js
+++ b/tests/database/model-usage-log-phase-check.test.js
@@ -1,0 +1,72 @@
+/**
+ * model_usage_log_phase_check enum regression test
+ * QF-20260511-163 — closes feedback 31c14ea3
+ *
+ * Verifies the migration database/migrations/20260511_fix_model_usage_log_phase_lead_final_underscore.sql:
+ *   - 'LEAD_FINAL' (underscore internal phase-state name) is accepted by the
+ *     check constraint after the 2026-05-11 widen.
+ *
+ * Approach: introspect pg_constraint.conbindef to confirm 'LEAD_FINAL' is in
+ * the CHECK predicate. Avoids touching real model_usage_log rows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+describe('model_usage_log_phase_check enum (QF-20260511-163)', () => {
+  it("includes the 'LEAD_FINAL' underscore internal phase-state name", async () => {
+    let data = null;
+    let error = null;
+    try {
+      const rpcResult = await supabase.rpc('exec_sql_readonly', {
+        sql: `SELECT pg_get_constraintdef(c.oid) AS def
+              FROM pg_constraint c
+              JOIN pg_class t ON t.oid = c.conrelid
+              WHERE t.relname = 'model_usage_log'
+                AND c.conname = 'model_usage_log_phase_check'`
+      });
+      data = rpcResult.data;
+      error = rpcResult.error;
+    } catch (e) {
+      error = e;
+    }
+
+    // Fallback path: many test envs don't have an exec_sql_readonly RPC. Use a
+    // probe INSERT that exercises the CHECK constraint without depending on
+    // optional columns. Cleanup is by session_id to scope the delete.
+    if (!data || error) {
+      const probeSessionId = 'test-LEAD_FINAL-enum-probe-' + Date.now();
+      const probeRow = {
+        session_id: probeSessionId,
+        phase: 'LEAD_FINAL',
+        subagent_type: 'qf-enum-probe',
+        subagent_configured_model: 'claude-opus-4-7',
+        reported_model_name: 'claude-opus-4-7',
+        reported_model_id: 'claude-opus-4-7',
+        config_matches_reported: true,
+        metadata: { probe: 'QF-20260511-163' }
+      };
+      const { error: insertErr } = await supabase
+        .from('model_usage_log')
+        .insert(probeRow);
+      // Cleanup synth probe row regardless of outcome
+      await supabase
+        .from('model_usage_log')
+        .delete()
+        .eq('session_id', probeSessionId);
+      expect(insertErr, `phase='LEAD_FINAL' should not raise 23514: ${insertErr?.message}`)
+        .toBeNull();
+      return;
+    }
+
+    expect(data[0].def, `constraint def should mention LEAD_FINAL: ${data[0].def}`)
+      .toMatch(/LEAD_FINAL/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes feedback `31c14ea3` (filed 2026-05-08): `model_usage_log_phase_check` rejected the `LEAD_FINAL` phase string emitted by `track-model-usage.js` during the LEAD-FINAL handoff path.

The 2026-04-29 migration added the hyphenated handoff-type variant `LEAD-FINAL` but missed the underscore internal phase-state name canonical per:
- `scripts/modules/handoff/cli/execution-helpers.js:32` (`current_phase: 'LEAD_FINAL'`)
- `scripts/hooks/phase-state-enforcement.js:42-44` (state-machine value)

**Two-name asymmetry:** handoff-type is `LEAD-FINAL-APPROVAL` (with dashes); internal phase-state name is `LEAD_FINAL` (with underscore). `track-model-usage` is invoked with the internal phase-state name, not the handoff-type — so the underscore variant must be enum-valid.

Tier-1 1-line enum widen + vitest regression probe.

## Test plan

- [x] Migration applied via `apply-migration.js --prod-deploy` → `MIGRATION_APPLY_PROD_PASS`
- [x] `npx vitest run tests/database/model-usage-log-phase-check.test.js` → 1/1 passed
- [ ] Baseline test failures (brand-variants, eva/stage-execution-worker, venture-ceo-handlers) are pre-existing on origin/main — unrelated to this 5-LOC enum widen

🤖 Generated with [Claude Code](https://claude.com/claude-code)