### PR TITLE
fix(QF-20260511-917): supabase-connection getSSLConfig honors SUPABASE_SSL_CA env (Windows pg-direct CA trust)

### DIFF
--- a/scripts/lib/supabase-connection.js
+++ b/scripts/lib/supabase-connection.js
@@ -13,6 +13,7 @@
  */
 
 import pg from 'pg';
+import fs from 'fs';
 import dotenv from 'dotenv';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -30,9 +31,20 @@ const { Client } = pg;
  * Get SSL configuration based on environment
  * SD-SEC-CONFIG-SECURITY-001: Environment-aware SSL verification
  */
-function getSSLConfig() {
+export function getSSLConfig() {
   const isProduction = process.env.NODE_ENV === 'production';
   const disableSSLVerify = process.env.DISABLE_SSL_VERIFY === 'true';
+
+  // SUPABASE_SSL_CA: path to a PEM bundle that signs the Supabase pooler chain.
+  // On Windows, the system trust store does not include the Supabase root, so
+  // pg-direct connections fail with SELF_SIGNED_CERT_IN_CHAIN. Pointing this at
+  // the Supabase-signed CA (e.g. supabase-root-2021-ca.pem) keeps verification
+  // strict instead of falling back to DISABLE_SSL_VERIFY=true. QF-20260511-917
+  // closes feedback e97a791f.
+  const caPath = process.env.SUPABASE_SSL_CA;
+  if (caPath && fs.existsSync(caPath)) {
+    return { rejectUnauthorized: true, ca: fs.readFileSync(caPath, 'utf8') };
+  }
 
   if (isProduction) {
     return { rejectUnauthorized: true };

--- a/tests/lib/supabase-connection-ssl-ca.test.js
+++ b/tests/lib/supabase-connection-ssl-ca.test.js
@@ -1,0 +1,90 @@
+/**
+ * QF-20260511-917 — closes feedback e97a791f
+ *
+ * Verifies getSSLConfig() honors SUPABASE_SSL_CA env var so Windows pg-direct
+ * connections to the Supabase pooler can use the Supabase-signed CA bundle
+ * (e.g. supabase-root-2021-ca.pem) instead of falling back to
+ * DISABLE_SSL_VERIFY=true.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getSSLConfig } from '../../scripts/lib/supabase-connection.js';
+
+const SAVED_ENV = {};
+const ENV_KEYS = ['SUPABASE_SSL_CA', 'DISABLE_SSL_VERIFY', 'NODE_ENV'];
+
+function snapshotEnv() {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+function restoreEnv() {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+describe('getSSLConfig — SUPABASE_SSL_CA env (QF-20260511-917)', () => {
+  let tmpDir;
+  let caPath;
+
+  beforeEach(() => {
+    snapshotEnv();
+    tmpDir = mkdtempSync(join(tmpdir(), 'qf917-'));
+    caPath = join(tmpDir, 'fake-ca.pem');
+    writeFileSync(caPath, '-----BEGIN CERTIFICATE-----\nFAKE-FOR-TEST\n-----END CERTIFICATE-----\n');
+    delete process.env.SUPABASE_SSL_CA;
+    delete process.env.DISABLE_SSL_VERIFY;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads CA bundle when SUPABASE_SSL_CA points at a readable PEM file', () => {
+    process.env.SUPABASE_SSL_CA = caPath;
+    const cfg = getSSLConfig();
+    expect(cfg.rejectUnauthorized).toBe(true);
+    expect(typeof cfg.ca).toBe('string');
+    expect(cfg.ca).toContain('FAKE-FOR-TEST');
+  });
+
+  it('falls through to default-strict when SUPABASE_SSL_CA is unset', () => {
+    const cfg = getSSLConfig();
+    expect(cfg).toEqual({ rejectUnauthorized: true });
+    expect(cfg.ca).toBeUndefined();
+  });
+
+  it('falls through when SUPABASE_SSL_CA points at a missing file', () => {
+    process.env.SUPABASE_SSL_CA = join(tmpDir, 'does-not-exist.pem');
+    const cfg = getSSLConfig();
+    expect(cfg).toEqual({ rejectUnauthorized: true });
+    expect(cfg.ca).toBeUndefined();
+  });
+
+  it('SUPABASE_SSL_CA takes precedence over DISABLE_SSL_VERIFY=true', () => {
+    process.env.SUPABASE_SSL_CA = caPath;
+    process.env.DISABLE_SSL_VERIFY = 'true';
+    const cfg = getSSLConfig();
+    expect(cfg.rejectUnauthorized).toBe(true);
+    expect(cfg.ca).toContain('FAKE-FOR-TEST');
+  });
+
+  it('SUPABASE_SSL_CA takes precedence over NODE_ENV=production', () => {
+    process.env.SUPABASE_SSL_CA = caPath;
+    process.env.NODE_ENV = 'production';
+    const cfg = getSSLConfig();
+    expect(cfg.rejectUnauthorized).toBe(true);
+    expect(cfg.ca).toContain('FAKE-FOR-TEST');
+  });
+
+  it('preserves DISABLE_SSL_VERIFY=true escape hatch when SUPABASE_SSL_CA unset', () => {
+    process.env.DISABLE_SSL_VERIFY = 'true';
+    const cfg = getSSLConfig();
+    expect(cfg).toEqual({ rejectUnauthorized: false });
+  });
+});


### PR DESCRIPTION
## Summary

- `scripts/lib/supabase-connection.js`: `getSSLConfig()` gets a 4th branch — when `SUPABASE_SSL_CA` points at a readable PEM file, load it as `ca` and keep `rejectUnauthorized: true`. Takes precedence over `NODE_ENV=production` and `DISABLE_SSL_VERIFY=true`.
- New vitest at `tests/lib/supabase-connection-ssl-ca.test.js` (6 cases): bundle loaded when env set + file readable; falls through when unset / missing file; precedence over the two existing branches; existing `DISABLE_SSL_VERIFY=true` escape hatch still works when no CA env.

## Why

Closes feedback `e97a791f` — Windows pg-direct connections to `aws-1-us-east-1.pooler.supabase.com:5432` fail with `SELF_SIGNED_CERT_IN_CHAIN` because the system trust store does not include the Supabase pooler-signed CA chain. Existing workaround was setting `DISABLE_SSL_VERIFY=true`, which silently disables verification across all connections. With this change, callers can point at the canonical Supabase-signed CA bundle (e.g., `supabase-root-2021-ca.pem`) and keep verification strict.

## Tier

Tier-1: 14 LOC source + 6 vitest cases. Routing decision: `TIER_1` from create-quick-fix.js.

## Test plan

- [x] `npx vitest run tests/lib/supabase-connection-ssl-ca.test.js` → 6/6 pass
- [x] No regression to existing 3 branches: `DISABLE_SSL_VERIFY=true` still returns `{ rejectUnauthorized: false }`; production / default still strict
- [x] CA precedence ordering verified (over both production and DISABLE_SSL_VERIFY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)