### PR TITLE
fix(QF-20260511-699): worktree-manager self-heal empty unregistered stale dirs

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -672,6 +672,8 @@ export function createWorktree({ sdKey, session, branch, force = false, repoRoot
     fs.mkdirSync(worktreesDir, { recursive: true });
   }
 
+  selfHealEmptyStaleWorktreeDir(worktreePath, repoRoot);
+
   // Check if worktree already exists
   if (fs.existsSync(worktreePath)) {
     const existingBranch = getWorktreeBranch(worktreePath);
@@ -840,6 +842,8 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
     if (!fs.existsSync(worktreeDir)) {
       fs.mkdirSync(worktreeDir, { recursive: true });
     }
+
+    selfHealEmptyStaleWorktreeDir(worktreePath, repoRoot);
 
     // Check if worktree already exists
     if (fs.existsSync(worktreePath)) {
@@ -1768,6 +1772,27 @@ function getWorktreeBranch(worktreePath) {
     encoding: 'utf8',
     stdio: 'pipe'
   }).trim();
+}
+
+// Closes feedback f03f0f73 (QF-20260511-699): empty unregistered .worktrees/<key>/
+// dirs blocked re-creation because getWorktreeBranch threw on the missing .git
+// pointer, and the pre-tool hook denied the recommended `rm -rf` recovery step.
+function selfHealEmptyStaleWorktreeDir(worktreePath, repoRoot) {
+  try {
+    if (!fs.existsSync(worktreePath)) return false;
+    if (fs.readdirSync(worktreePath).length > 0) return false;
+    const listed = execSync('git worktree list --porcelain', { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' });
+    const expected = path.resolve(worktreePath).replace(/\\/g, '/');
+    const registered = listed.split('\n')
+      .filter((l) => l.startsWith('worktree '))
+      .map((l) => path.resolve(l.replace('worktree ', '').trim()).replace(/\\/g, '/'));
+    if (registered.includes(expected)) return false;
+    fs.rmdirSync(worktreePath);
+    try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch { /* non-fatal */ }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function branchExistsLocally(branch) {

--- a/tests/worktree-self-heal-empty-stale-dir.test.js
+++ b/tests/worktree-self-heal-empty-stale-dir.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function git(cwd, ...args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+describe('worktree-manager selfHealEmptyStaleWorktreeDir (QF-20260511-699)', () => {
+  let tmpRepo;
+  let worktreePath;
+
+  beforeEach(() => {
+    tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-selfheal-'));
+    git(tmpRepo, 'init', '-q', '-b', 'main');
+    git(tmpRepo, 'config', 'user.email', 'test@example.com');
+    git(tmpRepo, 'config', 'user.name', 'test');
+    fs.writeFileSync(path.join(tmpRepo, 'seed.txt'), 'seed');
+    git(tmpRepo, 'add', '.');
+    git(tmpRepo, 'commit', '-q', '-m', 'seed');
+    worktreePath = path.join(tmpRepo, '.worktrees', 'QF-TEST-EMPTY');
+    fs.mkdirSync(worktreePath, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpRepo, { recursive: true, force: true }); } catch {}
+  });
+
+  it('removes empty unregistered worktree dir even when downstream fetchBaseRef fails (proves self-heal ran)', async () => {
+    const mod = await import('../lib/worktree-manager.js?selfheal-empty-' + Date.now());
+    expect(fs.existsSync(worktreePath)).toBe(true);
+    expect(fs.readdirSync(worktreePath).length).toBe(0);
+
+    // tmpRepo has no `origin` remote, so createWorktree will throw at fetchBaseRef.
+    // The self-heal step runs BEFORE that; observable side effect: the empty dir
+    // gets removed, proving the helper executed.
+    try {
+      mod.createWorktree({
+        sdKey: 'QF-TEST-EMPTY',
+        branch: 'qf/QF-TEST-EMPTY',
+        repoRoot: tmpRepo,
+      });
+    } catch {
+      // expected: WorktreeBaseFetchFailedError (no origin remote)
+    }
+
+    // Self-heal removed the empty stale dir before the existence check tripped.
+    expect(fs.existsSync(worktreePath)).toBe(false);
+  });
+
+  it('does NOT remove worktreePath when it has files (self-heal skips non-empty dirs)', async () => {
+    const mod = await import('../lib/worktree-manager.js?selfheal-nonempty-' + Date.now());
+    fs.writeFileSync(path.join(worktreePath, 'leftover.txt'), 'do not delete');
+    try {
+      mod.createWorktree({
+        sdKey: 'QF-TEST-EMPTY',
+        branch: 'qf/QF-TEST-EMPTY',
+        repoRoot: tmpRepo,
+      });
+    } catch {
+      // expected: getWorktreeBranch throws on non-git dir
+    }
+    // File survives — self-heal must skip non-empty dirs.
+    expect(fs.existsSync(path.join(worktreePath, 'leftover.txt'))).toBe(true);
+  });
+
+  it('does NOT remove worktreePath when it is registered in git worktree list', async () => {
+    const mod = await import('../lib/worktree-manager.js?selfheal-registered-' + Date.now());
+    // Create a legitimate worktree at worktreePath.
+    fs.rmdirSync(worktreePath); // remove the fixture-empty one
+    git(tmpRepo, 'worktree', 'add', worktreePath, '-b', 'real-branch');
+    expect(fs.existsSync(path.join(worktreePath, '.git'))).toBe(true);
+    const sentinel = path.join(worktreePath, 'sentinel.txt');
+    fs.writeFileSync(sentinel, 'real worktree content');
+
+    try {
+      mod.createWorktree({
+        sdKey: 'QF-TEST-EMPTY',
+        branch: 'qf/QF-TEST-EMPTY',
+        repoRoot: tmpRepo,
+      });
+    } catch {
+      // expected: 'already exists' or similar
+    }
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds selfHealEmptyStaleWorktreeDir() helper to lib/worktree-manager.js
- Called from both createWorktree (SD path) and createWorkTypeWorktree (QF path) before the existence check
- Detects: (exists + readdir empty + not in `git worktree list --porcelain`) and rmdir + prune

## Why
Empty unregistered .worktrees/<key>/ directories block re-creation because getWorktreeBranch() throws on the missing .git pointer. The recommended `rm -rf` remediation is denied by the pre-tool hook. Closes feedback f03f0f73.

## Test plan
- [x] tests/worktree-self-heal-empty-stale-dir.test.js — 3/3 PASS (vitest)
  - removes empty unregistered dir as observable side effect
  - skips non-empty dirs (sentinel file survives)
  - skips registered worktrees (real worktree content preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)