### PR TITLE
fix(QF-20260511-365): complete-quick-fix orchestrator skips test-run for docs-only QFs

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -532,6 +532,24 @@ export function analyzeGitDiff(testDir, qfDescription = '') {
   return { filesChanged, diffAnalysis };
 }
 
+// QF-20260511-365 / feedback 869f7cf3: classify a path as docs-only so the
+// orchestrator can skip the unit+e2e test run for docs-only QFs (the gate
+// otherwise re-surfaces pre-existing baseline failures unrelated to the QF,
+// burning a bypass-quota slot per ship). Patterns deliberately strict — anything
+// outside this list (including config files, package.json, .yml) opts back in.
+export function isDocsOnlyPath(file) {
+  if (!file || typeof file !== 'string') return false;
+  const f = file.replace(/\\/g, '/');
+  if (/^docs\//i.test(f)) return true;
+  if (/(^|\/)(README|LICENSE|LICENCE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT|NOTICE|AUTHORS)(\.|$)/i.test(f)) return true;
+  return /\.(md|markdown|rst|adoc|txt)$/i.test(f);
+}
+
+export function isDocsOnlyDiff(filesChanged) {
+  if (!Array.isArray(filesChanged) || filesChanged.length === 0) return false;
+  return filesChanged.every(isDocsOnlyPath);
+}
+
 /**
  * Commit and push changes
  * @param {string} testDir - Directory to run git commands in

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -19,7 +19,7 @@ import fs from 'fs';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
-import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd } from './git-operations.js';
+import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff } from './git-operations.js';
 import {
   validateLOC,
   validateTests,
@@ -162,9 +162,17 @@ export async function completeQuickFix(qfId, options = {}) {
     process.exit(1);
   }
 
+  // QF-20260511-365 / feedback 869f7cf3: hoist analyzeGitDiff above the test-run
+  // block so docs-only QFs can skip the unit+e2e suite (otherwise the gate
+  // re-surfaces pre-existing baseline failures unrelated to the QF on every ship,
+  // burning a bypass-quota slot per ship). Original hoist site (closer to
+  // createAutoPR) is preserved as a no-op reference; filesChanged/diffAnalysis
+  // are now computed once here and reused later in the PR-acquisition block.
+  const { filesChanged, diffAnalysis } = analyzeGitDiff(testDir, qf.description);
+  const docsOnlyDiff = isDocsOnlyDiff(filesChanged);
+
   // Test verification - PROGRAMMATIC (not self-reported)
   console.log('\n🧪 PROGRAMMATIC TEST VERIFICATION\n');
-  console.log('   Running tests to verify fix quality (not self-reported)...\n');
 
   let unitTestResult = null;
   let e2eTestResult = null;
@@ -176,7 +184,16 @@ export async function completeQuickFix(qfId, options = {}) {
   if (options.skipTestRun) {
     testsPass = options.testsPass !== undefined ? options.testsPass : true;
     console.log(`   ⚠️  Skipping test run (--skip-tests); testsPass=${testsPass}\n`);
+  } else if (docsOnlyDiff) {
+    // QF-20260511-365 / feedback 869f7cf3: docs-only diff bypasses the test-run
+    // gate. The diff contains zero source files (docs/, *.md, *.rst, README/
+    // LICENSE/CHANGELOG, etc.), so the unit+e2e suite would only re-validate
+    // unrelated pre-existing baseline failures. testsPass=true is sound here
+    // because there is no source to validate; docmon + bypass-guard still run.
+    testsPass = true;
+    console.log(`   📚 Docs-only diff detected (${filesChanged.length} file(s)); skipping unit+e2e tests.\n`);
   } else {
+    console.log('   Running tests to verify fix quality (not self-reported)...\n');
     // Run unit tests in target application directory
     console.log('━━━ Unit Tests ━━━\n');
     unitTestResult = runTests('unit', { testDir });
@@ -215,13 +232,11 @@ export async function completeQuickFix(qfId, options = {}) {
     process.exit(1);
   }
 
-  // QF-20260509-779 (closes bd600229; completes QF-20260509-407 Bug C):
-  // analyzeGitDiff runs BEFORE the PR-acquisition block so createAutoPR has
-  // filesChanged available, and so the autoPr branch can fire BEFORE the
-  // PR-URL prompt. Without this hoist, the prompt at line 195 ran first and
-  // rejected under --non-interactive (correct fail-fast) but left the autoPr
-  // branch unreachable. 13th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
-  const { filesChanged, diffAnalysis } = analyzeGitDiff(testDir, qf.description);
+  // QF-20260509-779 / QF-20260511-365: analyzeGitDiff was hoisted above the
+  // test-run block so docs-only QFs can short-circuit the test gate. filesChanged
+  // and diffAnalysis are reused here. (Original hoist motivation: ensure
+  // createAutoPR has filesChanged available and the autoPr branch fires BEFORE
+  // the PR-URL prompt. 13th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.)
 
   // Test Coverage Verification (uses filesChanged from above)
   const testCoverage = verifyTestCoverage(filesChanged);

--- a/tests/unit/complete-quick-fix/docs-only-test-skip.test.js
+++ b/tests/unit/complete-quick-fix/docs-only-test-skip.test.js
@@ -1,0 +1,95 @@
+/**
+ * QF-20260511-365 — docs-only test-skip helpers
+ *
+ * Closes feedback 869f7cf3-ce8d-4218-a2e4-9c56d5a8067c: complete-quick-fix
+ * orchestrator was running the full unit+e2e suite for docs-only QFs, surfacing
+ * pre-existing baseline failures unrelated to the QF and burning a bypass-quota
+ * slot per ship.
+ *
+ * These tests pin the pure-helper contract that the orchestrator uses to decide
+ * whether the test-run block can be safely skipped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isDocsOnlyPath,
+  isDocsOnlyDiff,
+} from '../../../scripts/modules/complete-quick-fix/git-operations.js';
+
+describe('isDocsOnlyPath', () => {
+  it('classifies markdown variants as docs', () => {
+    expect(isDocsOnlyPath('CLAUDE.md')).toBe(true);
+    expect(isDocsOnlyPath('notes.markdown')).toBe(true);
+    expect(isDocsOnlyPath('docs/getting-started.md')).toBe(true);
+  });
+
+  it('classifies common doc filenames without extension', () => {
+    expect(isDocsOnlyPath('README')).toBe(true);
+    expect(isDocsOnlyPath('LICENSE')).toBe(true);
+    expect(isDocsOnlyPath('LICENCE')).toBe(true);
+    expect(isDocsOnlyPath('CHANGELOG')).toBe(true);
+    expect(isDocsOnlyPath('CONTRIBUTING')).toBe(true);
+    expect(isDocsOnlyPath('NOTICE')).toBe(true);
+    expect(isDocsOnlyPath('subdir/README.md')).toBe(true);
+  });
+
+  it('classifies anything under docs/ as docs (case-insensitive)', () => {
+    expect(isDocsOnlyPath('docs/anything/at/all.json')).toBe(true);
+    expect(isDocsOnlyPath('Docs/Mixed.YAML')).toBe(true);
+  });
+
+  it('classifies rst/adoc/txt as docs', () => {
+    expect(isDocsOnlyPath('NOTES.rst')).toBe(true);
+    expect(isDocsOnlyPath('manual.adoc')).toBe(true);
+    expect(isDocsOnlyPath('release-notes.txt')).toBe(true);
+  });
+
+  it('rejects source files', () => {
+    expect(isDocsOnlyPath('src/index.js')).toBe(false);
+    expect(isDocsOnlyPath('scripts/foo.mjs')).toBe(false);
+    expect(isDocsOnlyPath('lib/x.cjs')).toBe(false);
+    expect(isDocsOnlyPath('a.ts')).toBe(false);
+    expect(isDocsOnlyPath('component.tsx')).toBe(false);
+  });
+
+  it('rejects configuration and metadata files at repo root', () => {
+    expect(isDocsOnlyPath('package.json')).toBe(false);
+    expect(isDocsOnlyPath('.github/workflows/ci.yml')).toBe(false);
+    expect(isDocsOnlyPath('tsconfig.json')).toBe(false);
+    expect(isDocsOnlyPath('vitest.config.ts')).toBe(false);
+  });
+
+  it('normalizes Windows-style separators', () => {
+    expect(isDocsOnlyPath('docs\\guide\\setup.md')).toBe(true);
+    expect(isDocsOnlyPath('src\\index.js')).toBe(false);
+  });
+
+  it('returns false for empty or non-string input', () => {
+    expect(isDocsOnlyPath('')).toBe(false);
+    expect(isDocsOnlyPath(null)).toBe(false);
+    expect(isDocsOnlyPath(undefined)).toBe(false);
+    expect(isDocsOnlyPath(42)).toBe(false);
+  });
+});
+
+describe('isDocsOnlyDiff', () => {
+  it('returns true when every file is a docs path', () => {
+    expect(isDocsOnlyDiff(['README.md', 'docs/x.md', 'CHANGELOG'])).toBe(true);
+  });
+
+  it('returns false when ANY file is source', () => {
+    expect(isDocsOnlyDiff(['README.md', 'src/index.js'])).toBe(false);
+    expect(isDocsOnlyDiff(['docs/x.md', 'package.json'])).toBe(false);
+  });
+
+  it('returns false for empty / non-array input (no diff → cannot prove docs-only)', () => {
+    expect(isDocsOnlyDiff([])).toBe(false);
+    expect(isDocsOnlyDiff(null)).toBe(false);
+    expect(isDocsOnlyDiff(undefined)).toBe(false);
+    expect(isDocsOnlyDiff('docs/x.md')).toBe(false);
+  });
+
+  it('handles single docs file', () => {
+    expect(isDocsOnlyDiff(['CLAUDE.md'])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260511-365  **Type:** polish **Severity:** medium  ### Issue Description complete-quick-fix orchestrator runs full unit+e2e suite even for docs-only QFs (no .js/.ts/.mjs/.cjs source changes), burning bypass quota on pre-existing baseline failures unrelated to the QF (witnessed: QF-20260511-772 docs-only 5 src LOC). Add isDocsOnlyDiff helper to git-operations.js + early-skip in orchestrator.js when diff is docs-only. Closes feedback 869f7cf3-ce8d-4218-a2e4-9c56d5a8067c.     ### Changes - **Files Changed:** 3   - scripts/modules/complete-quick-fix/git-operations.js   - scripts/modules/complete-quick-fix/orchestrator.js   - tests/unit/complete-quick-fix/docs-only-test-skip.test.js - **LOC:** 50 lines - **Tests:** ❌ Failed - **UAT:** ✅ Verified  ### Verification Tier-2 docs-only test-skip in complete-quick-fix orchestrator. 12 new vitest cases, all 110 tests in tests/unit/complete-quick-fix/ pass. Self-validating: this QF contains source files (the helper), so it correctly runs the unit+e2e gate, not the docs-skip path.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol