### PR TITLE
fix(QF-20260511-960): wire-check-gate exclude scripts/one-off/ from reachability scope

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -32,9 +32,16 @@ const GATE_NAME = 'WIRE_CHECK_GATE';
  * and nested `tests/` paths (e.g. `scripts/archive/one-time/tests/`), since
  * the previous `^tests/` anchor missed those entirely.
  *
- * Patterns are canonical only (*.test.ext, *.spec.ext, __tests__/, test/, tests/);
- * intentionally NOT matching *.test-* or similar variants to avoid
- * over-matching production files (mitigation for TS-7 negative control).
+ * QF-20260511-960 / feedback 39219c66: scripts/one-off/ is a session-private
+ * holding area for ad-hoc investigation / amendment / check scripts (convention:
+ * `_` prefix, every file in the directory). They have no permanent entry point
+ * by design and routinely cross-session-leak when LEAD-FINAL-APPROVAL runs from
+ * main-repo cwd on a sibling branch tip — producing false-positive WIRE_CHECK
+ * failures for files this SD/PR never touched. Exclude the directory.
+ *
+ * Patterns are canonical only (*.test.ext, *.spec.ext, __tests__/, test/, tests/,
+ * scripts/one-off/); intentionally NOT matching *.test-* or similar variants to
+ * avoid over-matching production files (mitigation for TS-7 negative control).
  * The `(^|\/)tests?\/` form requires a directory-boundary, so `lib/testing/`
  * and `scripts/test-helpers.js` do NOT match.
  */
@@ -42,7 +49,8 @@ export const EXCLUSION_PATTERNS = [
   /\.test\.(js|mjs|cjs|jsx|tsx)$/,
   /\.spec\.(js|mjs|cjs|jsx|tsx)$/,
   /(^|\/)__tests__\//,
-  /(^|\/)tests?\//
+  /(^|\/)tests?\//,
+  /(^|\/)scripts\/one-off\//
 ];
 
 /**

--- a/tests/unit/handoff/wire-check-gate.test.js
+++ b/tests/unit/handoff/wire-check-gate.test.js
@@ -71,6 +71,28 @@ describe('EXCLUSION_PATTERNS (FR-1)', () => {
       expect(pattern).toBeInstanceOf(RegExp);
     }
   });
+
+  // QF-20260511-960 / feedback 39219c66: cross-session false-positives on
+  // scripts/one-off/ files committed locally by sibling sessions. By convention
+  // every file in scripts/one-off/ has an underscore prefix and no permanent
+  // entry point, so the directory is exempt from wire-check reachability.
+  describe('scripts/one-off/ exclusion (QF-20260511-960)', () => {
+    it('matches typical underscore-prefixed one-off scripts', () => {
+      expect(isExcludedFromWireCheck('scripts/one-off/_check-205-foo.mjs')).toBe(true);
+      expect(isExcludedFromWireCheck('scripts/one-off/_verify-qf-205-bar.cjs')).toBe(true);
+      expect(isExcludedFromWireCheck('scripts/one-off/_apply-migration.mjs')).toBe(true);
+      expect(isExcludedFromWireCheck('scripts/one-off/_amend-prd-sd-leo-feat.mjs')).toBe(true);
+    });
+
+    it('does NOT match other scripts/ paths', () => {
+      expect(isExcludedFromWireCheck('scripts/handoff.js')).toBe(false);
+      expect(isExcludedFromWireCheck('scripts/sd-next.js')).toBe(false);
+      expect(isExcludedFromWireCheck('scripts/modules/foo.js')).toBe(false);
+      // Lookalike directories that share the "one-off" substring must NOT match.
+      expect(isExcludedFromWireCheck('scripts/one-offsite/foo.js')).toBe(false);
+      expect(isExcludedFromWireCheck('lib/one-off/foo.js')).toBe(false);
+    });
+  });
 });
 
 describe('call-graph-builder barrel re-export resolution (FR-2 AC-1)', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260511-960  **Type:** bug **Severity:** medium  ### Issue Description WIRE_CHECK_GATE produces cross-session false-positives for files committed locally to scripts/one-off/ from sibling sessions — when LEAD-FINAL-APPROVAL runs from main repo cwd on a leaked branch tip, origin/main...HEAD picks up sibling-session one-off scripts that have no permanent entry point by design (convention: scripts/one-off/_*). Witnessed SD-LEO-INFRA-PRE-MERGE-MIGRATION-001 LEAD-FINAL-APPROVAL 2026-05-11T15:42Z (5 false-positive files all under scripts/one-off/). Add (^|/)scripts/one-off/ pattern to EXCLUSION_PATTERNS. Closes feedback 39219c66.     ### Changes - **Files Changed:** 2   - scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js   - tests/unit/handoff/wire-check-gate.test.js - **LOC:** 34 lines - **Tests:** ❌ Failed - **UAT:** ✅ Verified  ### Verification Tier-1 12 src LOC + 22 test LOC. EXCLUSION_PATTERNS gains scripts/one-off/ entry; 14/14 wire-check-gate.test.js cases pass. Branch up-to-date with origin/main (merged PRs #3738 + #3740).  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol