### PR TITLE
QF-20260512-220: can-auto-advance-tests.yml — preflight job (secrets-in-if fix)

### DIFF
--- a/.github/workflows/can-auto-advance-tests.yml
+++ b/.github/workflows/can-auto-advance-tests.yml
@@ -19,6 +19,27 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: Check integration credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      has_creds: ${{ steps.check.outputs.has_creds }}
+    steps:
+      - id: check
+        # secrets.* is allowed in step-level env, NOT in job-level if. Convert
+        # presence-of-secret to a string output so `integration` can gate via
+        # `needs.preflight.outputs.has_creds`.
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [[ -n "$SUPABASE_URL" && -n "$SUPABASE_KEY" ]]; then
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          fi
+
   unit:
     name: Unit tests (worker mock)
     runs-on: ubuntu-latest
@@ -37,7 +58,8 @@ jobs:
     name: Integration tests (live RPC equivalence)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL != '' && secrets.SUPABASE_SERVICE_ROLE_KEY != '' }}
+    needs: preflight
+    if: needs.preflight.outputs.has_creds == 'true'
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
## Summary
- Workflow `.github/workflows/can-auto-advance-tests.yml` was REJECTED at parse time on every push to main since SD-LEO-REFAC-GATE-AUTO-ADVANCE-001 introduced it, because the `integration` job used `secrets.*` in a job-level `if:` (not a supported context). Empty `jobs[]` in run metadata + "workflow file issue" error confirms.
- Move secret-presence detection to a tiny `preflight` job that reads secrets via step-level `env:` (allowed), emits `has_creds=true|false` as a job output, and have `integration` gate on `needs.preflight.outputs.has_creds == 'true'` (which IS allowed in job-level `if:`).
- Unit job was silently skipped on main since merge; it now runs.

## Evidence
| Run | Branch | Trigger | Result |
|---|---|---|---|
| [25756579330](https://github.com/rickfelix/EHG_Engineer/actions/runs/25756579330) | main | post-merge PR #3748 | failure / workflow file issue |
| [25760615662](https://github.com/rickfelix/EHG_Engineer/actions/runs/25760615662) | main | post-merge PR #3750 | failure / workflow file issue |

Closes `feedback` rows: `9264341b-baf2-45b1-b954-b06af500e02b`, `ede149b2-19c5-40a7-b218-3689623ab6f1`, `5530e81a-1963-4a83-9e72-1049c9870000` (category=ci_failure on this workflow).

## Test plan
- [x] YAML parses (`js-yaml.load` succeeds)
- [x] `integration.needs: preflight` and `integration.if: needs.preflight.outputs.has_creds == 'true'` (no `secrets.*` in job-level if)
- [ ] CI run on this PR: `preflight` runs always; `unit` runs always; `integration` runs only if Supabase secrets present
- [ ] Post-merge `push: branches: [main]` run shows all jobs scheduled (no "workflow file issue")

🤖 Generated with [Claude Code](https://claude.com/claude-code)