### PR TITLE
QF-20260512-300: sd-next filter metadata.is_test=true from queue+recommendations

### DIFF
--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -134,7 +134,8 @@ export async function showFallbackQueue(supabase, options = {}) {
   // Show top ready SD per track.
   for (const [trackKey, trackSDs] of Object.entries(tracks)) {
     // QF-20260511-565: exclude LEAD-paused/deferred SDs from RECOMMENDED STARTING POINTS
-    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on && !isLeadDecisionPaused(s));
+    // QF-20260512-300: exclude test-harness SDs (metadata.is_test=true) from recommendations
+    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on && !isLeadDecisionPaused(s) && s.metadata?.is_test !== true);
     if (ready) {
       const trackLabel = `Track ${trackKey}`;
       console.log(`${colors.green}  ${trackLabel}:${colors.reset} ${ready.sd_key || ready.id} - ${ready.title.substring(0, 50)}...`);

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -260,6 +260,9 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
       .single();
 
     if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      // QF-20260512-300: Skip test-harness SDs (metadata.is_test=true) from recommendations
+      if (sd.metadata?.is_test === true) continue;
+
       // SD-LEO-INFRA-CONDITIONAL-QUEUE-GOVERNANCE-001: Skip deferred SDs from recommendations
       if (sd.metadata?.do_not_advance_without_trigger === true) continue;
 

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -19,6 +19,10 @@ import { renderQFRow } from './quick-fixes.js';
  * @param {Object} sessionContext - Session context {claimedSDs, currentSession, activeSessions, supabase}
  */
 export async function displayTrackSection(trackKey, trackName, items, sessionContext = {}) {
+  // QF-20260512-300: drop test-harness SDs (metadata.is_test=true) before display
+  // so fixtures like SD-TEST-MP1GU8PO-* don't leak into the workable queue.
+  // QFs and SDs without metadata pass through (optional chaining returns undefined).
+  items = items.filter(item => item.metadata?.is_test !== true);
   if (items.length === 0) return;
 
   // SD-FDBK-INFRA-ATOMIC-REVERT-HELPER-001: prefetch ghost-completed SD ids


### PR DESCRIPTION
## Summary
\`npm run sd:next\` was leaking 4 test-harness SDs into the workable queue + recommendations:
- SD-TEST-MP1GU8PO-ORCH-001 (Test Orchestrator)
- SD-TEST-MP1GU8PO-CHILD-001/002/003

All flagged with \`metadata.is_test=true\` but no codepath honored the flag. They appeared as \`[9999]\` (P3, sequence_rank null) and were the recommended Track B \"START\" target on a fresh queue.

## Fix sites (3 files, +9 -1 LOC)
1. \`display/tracks.js\` — filter \`items\` at \`displayTrackSection\` entry. Covers all tracks (A/B/C/STANDALONE) in both baseline and fallback rendering paths. QFs pass through (no \`metadata.is_test\`).
2. \`display/recommendations.js\` — skip in \`categorizeBaselineSDs\` loop, alongside existing skips for \`do_not_advance_without_trigger\` and \`isLeadDecisionPaused\`.
3. \`display/fallback-queue.js\` — extend the per-track \"ready\" picker predicate.

## Empirical validation (run in this worktree)
Before:
\`\`\`
[34m[1mTRACK B: Feature/Stages
[9999] SD-TEST-MP1GU8PO-ORCH-001 - Test Orchestrator [P3]... DRAFT
...
Track B: SD-TEST-MP1GU8PO-ORCH-001 - Test Orchestrator...
\`\`\`

After:
\`\`\`
[34m[1mTRACK B: Feature/Stages
[9999] SD-EVA-SUPPORT-CLI-SKILL-ORCH-001 ... PAUSED
[9999] SD-LEO-REFAC-GATE-DECISION-CREATION-001 ... DRAFT
[9999] SD-LEO-REFAC-GATE-POST-APPROVAL-001 ... DRAFT
[CLAIMED] SD-GVOS-COMPOSER-SNAPSHOTLOCKED-REGISTRY-ORCH-001 ...
...
Track B: SD-LEO-REFAC-GATE-DECISION-CREATION-001 ...
\`\`\`

Closes harness_backlog feedback \`df294dcd-92ba-4f42-ae5d-a09073993acac\`.

## Test plan
- [x] Empirical: \`npm run sd:next\` run in worktree shows test SDs filtered
- [ ] CI checks pass
- [ ] Post-merge: re-run \`npm run sd:next\` on main — confirm no SD-TEST-* leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)