### PR TITLE
QF-20260512-519: complete-quick-fix post-hoc PR-state check before local-merge fallback

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -731,6 +731,19 @@ export async function mergeToMain(testDir, qf, prUrl, prompt, flags = {}) {
             return;
           }
         } catch (ghMergeErr) {
+          // QF-20260512-519: `gh pr merge --merge --delete-branch` may exit non-zero
+          // when the server-side merge succeeded but the local --delete-branch step
+          // failed (e.g., an orphan worktree holds the branch). Re-query PR state
+          // before falling through to local-merge — the local-merge fallback also
+          // breaks when an orphan worktree holds [main] (harness backlog d40eb680).
+          try {
+            const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
+            const stateOut = execSync(`gh pr view ${prNumber} --json state`, { encoding: 'utf-8', cwd: testDir }).trim();
+            if (stateOut.includes('"MERGED"')) {
+              console.log(`   ✅ PR merged via GitHub (post-merge cleanup may have failed; non-critical)\n`);
+              return;
+            }
+          } catch { /* unable to verify — fall through */ }
           console.log(`   ⚠️  GitHub merge failed: ${ghMergeErr.message}`);
           console.log('   Attempting local merge...\n');
         }


### PR DESCRIPTION
## Summary
\`gh pr merge <pr> --merge --delete-branch\` can exit non-zero when the **server-side merge SUCCEEDED** but the local \`--delete-branch\` step failed (orphan worktree holding the branch). The previous catch block treated all non-zero exits as full merge failure and fell through to local-merge, which then ALSO breaks if an orphan worktree holds [main] (the d40eb680 wart). User gets a confusing double-failure trail despite their PR being merged just fine.

## Fix
In the catch block at \`scripts/modules/complete-quick-fix/git-operations.js:733\`, re-query PR state via \`gh pr view <pr> --json state\` BEFORE falling through to local-merge. If \`state=\"MERGED\"\`, treat it as success and return early.

## Empirical witness (this session)
- Shipped QF-20260512-300, ran \`complete-quick-fix.js --force-complete\`
- Server-side merge succeeded: PR #3753 → commit \`40d7a75740\` on main at 2026-05-13T02:21:26Z
- Local cleanup failed: \`gh pr merge 3753\` returned non-zero (orphan worktree at \`.worktrees/qf/QF-20260512-220\` held [main])
- Local-merge fallback also failed: \`fatal: 'main' is already used by worktree at '.worktrees/qf/QF-20260512-220'\`
- Net: confusing double-error to user despite a perfectly successful merge

## Test plan
- [x] +13 LOC, single file (\`git-operations.js\`)
- [x] Catch block now post-queries PR state via \`gh pr view --json state\`
- [ ] CI checks pass
- [ ] Functional test (this PR itself): \`complete-quick-fix.js\` should detect merge success and not fall through, even if --delete-branch fails

Closes harness_backlog feedback \`d40eb680-9a2a-4beb-a4df-51bbd609affe\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)