### PR TITLE
fix(QF-20260513-258): supabase-connection skip password check when connectionString provided

### DIFF
--- a/.github/workflows/pre-merge-migration-readiness.yml
+++ b/.github/workflows/pre-merge-migration-readiness.yml
@@ -40,6 +40,11 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+          # QF-20260513-258: DATABASE_URL is a fallback used by
+          # check-migration-readiness.mjs when SUPABASE_POOLER_URL is unset.
+          # Either env var is sufficient — supabase-connection.js skips the
+          # password requirement once connectionString is provided.
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |

--- a/scripts/check-migration-readiness.mjs
+++ b/scripts/check-migration-readiness.mjs
@@ -227,7 +227,15 @@ async function main() {
 
   let client;
   try {
-    client = await createDatabaseClient('engineer', { verify: true });
+    // QF-20260513-258: In CI (pre-merge-migration-readiness.yml) the
+    // pooler/admin password isn't a configured secret — only DATABASE_URL /
+    // SUPABASE_POOLER_URL are exposed. Pass connectionString explicitly so
+    // supabase-connection.js skips the SUPABASE_DB_PASSWORD requirement.
+    const connectionString =
+      process.env.SUPABASE_POOLER_URL ||
+      process.env.DATABASE_URL ||
+      undefined;
+    client = await createDatabaseClient('engineer', { verify: true, connectionString });
   } catch (err) {
     console.error(`[${OUTCOME.INFRA_ERROR}] could not connect to live DB: ${err.message}`);
     console.log(JSON.stringify({ outcome: OUTCOME.INFRA_ERROR, error: err.message }));

--- a/scripts/lib/supabase-connection.js
+++ b/scripts/lib/supabase-connection.js
@@ -127,9 +127,14 @@ export async function createDatabaseClient(projectKey = 'ehg', options = {}) {
                    process.env.SUPABASE_DB_PASSWORD ||
                    process.env.EHG_DB_PASSWORD;
 
-  if (!password) {
+  // QF-20260513-258: password is only required when we need to BUILD a
+  // connection string from parts. If the caller passed a complete
+  // connectionString (e.g. SUPABASE_POOLER_URL in CI), credentials are
+  // already encoded in the URL — don't force a separate password env var.
+  if (!password && !options.connectionString) {
     throw new Error(
-      'Database password not found. Set SUPABASE_DB_PASSWORD or EHG_DB_PASSWORD in .env file. ' +
+      'Database password not found. Set SUPABASE_DB_PASSWORD or EHG_DB_PASSWORD in .env file, ' +
+      'or pass options.connectionString. ' +
       'SECURITY: Hardcoded password fallbacks are not allowed.'
     );
   }

--- a/tests/lib/supabase-connection-connstr-skip-password.test.js
+++ b/tests/lib/supabase-connection-connstr-skip-password.test.js
@@ -1,0 +1,69 @@
+/**
+ * QF-20260513-258 — closes feedback a583d097
+ *
+ * Verifies createDatabaseClient() skips the SUPABASE_DB_PASSWORD requirement
+ * when the caller passes options.connectionString. This is the CI codepath
+ * for the Pre-merge Migration Readiness workflow: SUPABASE_POOLER_URL is the
+ * only exposed credential, the discrete DB password env vars are not set.
+ *
+ * Before this fix, supabase-connection.js threw "Database password not found"
+ * unconditionally even when a connection string was supplied — blocking all
+ * migration-readiness probes on PRs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+const SAVED_ENV = {};
+const ENV_KEYS = ['SUPABASE_DB_PASSWORD', 'EHG_DB_PASSWORD'];
+
+function snapshotEnv() {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+function restoreEnv() {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+describe('createDatabaseClient — connectionString skips password requirement (QF-20260513-258)', () => {
+  beforeEach(() => {
+    snapshotEnv();
+    delete process.env.SUPABASE_DB_PASSWORD;
+    delete process.env.EHG_DB_PASSWORD;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('throws when neither password nor connectionString is provided', async () => {
+    await expect(
+      createDatabaseClient('engineer', { verify: true })
+    ).rejects.toThrow(/Database password not found/);
+  });
+
+  it('does NOT throw the password error when connectionString is provided (even without env passwords)', async () => {
+    // We pass a syntactically-valid pg URL with bogus credentials so the
+    // password check is bypassed. The connection itself will fail later
+    // (refused/timeout), but the error must NOT be "Database password not found".
+    const bogusUrl = 'postgres://anonymous:anonymous@127.0.0.1:1/postgres';
+    try {
+      const client = await createDatabaseClient('engineer', {
+        connectionString: bogusUrl,
+        timeout: 100, // fast-fail the actual connect
+      });
+      // If somehow connected (it won't), clean up
+      await client.end().catch(() => {});
+    } catch (err) {
+      expect(err.message).not.toMatch(/Database password not found/);
+    }
+  });
+
+  it('mentions options.connectionString in the password-missing error remediation', async () => {
+    await expect(
+      createDatabaseClient('engineer', {})
+    ).rejects.toThrow(/options\.connectionString/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix QF-20260513-258

Closes feedback `a583d097-7f1b-48a0-8003-472e6039d793`. Pre-merge Migration Readiness workflow blocks all migration PRs: `scripts/lib/supabase-connection.js:130-135` throws `Database password not found` unconditionally, even when the caller supplies `options.connectionString`. Witnessed 3× on already-merged branches 2026-05-12 (runs 25756384841 / 25748033410 / 25748476756).

23rd+ writer-consumer asymmetry — workflow writer assumes `SUPABASE_POOLER_URL` secret exists; library consumer requires `SUPABASE_DB_PASSWORD` regardless of `options.connectionString`.

## Changes (3 src files, 87 LOC including tests)

- **`scripts/lib/supabase-connection.js`** — gate the password-required throw on `!options.connectionString`. When a complete URL is supplied, credentials are already encoded.
- **`scripts/check-migration-readiness.mjs`** — pass `connectionString` from `SUPABASE_POOLER_URL` (preferred) or `DATABASE_URL` (fallback).
- **`.github/workflows/pre-merge-migration-readiness.yml`** — expose `DATABASE_URL` as a step env for the fallback path.

## Test plan

- [x] New unit tests pass: `tests/lib/supabase-connection-connstr-skip-password.test.js` — 3/3 in 5ms
- [x] Regression: `tests/lib/supabase-connection-ssl-ca.test.js` — 6/6
- [x] TypeScript compilation passed (`npx tsc --noEmit`)
- [ ] Post-merge: verify next migration PR's `pre-merge-migration-readiness` workflow runs to completion

Skipping the full test suite — pre-existing baseline failures in `claim-default.test.js`, `semantic-validation-gates.test.js`, `session-writer/no-bypass.test.js`, and e2e/* are unrelated to this 3-file conditional-password fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)