### PR TITLE
feat(SD-FDBK-REFAC-LEO-CREATE-003-001): FR-003 auto-route — consume locked_decisions + disambiguate PR-staged phases

### DIFF
--- a/scripts/__tests__/leo-create-sd-auto-route-decider.test.js
+++ b/scripts/__tests__/leo-create-sd-auto-route-decider.test.js
@@ -1,0 +1,311 @@
+/**
+ * leo-create-sd-auto-route-decider.test.js — SD-FDBK-REFAC-LEO-CREATE-003-001 FR-6
+ *
+ * 9 test cases covering the FR-003 auto-route decision matrix:
+ *   TS-1: SD-GVOS-COMPOSER regression — locked_decisions blocks auto-route
+ *   TS-2: structured phases override locked_decisions (route to orchestrator)
+ *   TS-3: compound-phrase FP guard (validation WARNING-2)
+ *   TS-4: intentional FN — benign phrasing does not match regex
+ *   TS-5: Layer B PR-staged disambiguator fires
+ *   TS-6: mixed Phase+PR-N headings stay orchestrator
+ *   TS-7: 0-row brainstorm reverse-lookup → layer_a_signal=absent
+ *   TS-8: --force-orchestrator override
+ *   TS-9: kill-switch LEO_AUTO_ROUTE_LAYER_A=off
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  shouldAutoRouteToOrchestrator,
+  countArchPhases,
+  hasLockedSingleSdIntent,
+  allHeadingsArePrStaged,
+  SINGLE_SD_INTENT_REGEX,
+  LAYER_B_HEADING_REGEX,
+  PR_N_PATTERN,
+} from '../modules/leo-create-sd/auto-route-decider.js';
+
+// Helpers --------------------------------------------------------------
+
+function makeArchPlan({ structuredPhases = [], content = '' } = {}) {
+  return {
+    sections: structuredPhases.length ? { implementation_phases: structuredPhases } : {},
+    content,
+  };
+}
+
+function makeBrainstormSession(lockedDecisions = []) {
+  return { metadata: { locked_decisions: lockedDecisions } };
+}
+
+const COMMON_TELEMETRY_KEYS = [
+  'route', 'layer_a_signal', 'layer_b_signal', 'override',
+  'structured_phase_count', 'content_phase_count', 'reason',
+  'archKey', 'visionKey', 'title', 'timestamp',
+];
+
+// FR-6 acceptance tests -----------------------------------------------
+
+describe('shouldAutoRouteToOrchestrator — FR-6 9-test acceptance matrix', () => {
+  it('TS-1: GVOS-COMPOSER regression — locked_decisions blocks auto-route', () => {
+    // Empirical: 10 locked_decisions including "One Tier-3 SD-B2 (no split)",
+    // arch plan ARCH-GVOS-COMPOSER-001 has 6 content-only "## Phase N — PR-N" headings,
+    // no structured implementation_phases.
+    const archPlan = makeArchPlan({
+      content: [
+        '## Phase 1 — PR-1 Composer scaffold',
+        '## Phase 2 — PR-2 Identity statement',
+        '## Phase 3 — PR-3 Snapshot registry',
+        '## Phase 4 — PR-4 GVOS profile',
+        '## Phase 5 — PR-5 Adherence logs',
+        '## Phase 6 — PR-6 Token versioning',
+      ].join('\n\n'),
+    });
+    const brainstormSession = makeBrainstormSession([
+      'Pipeline: Lovable replaces Stitch at S17',
+      'One Tier-3 SD-B2 (no split)',
+      'EVA docs updated to v2',
+    ]);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'ARCH-GVOS-COMPOSER-001',
+      visionKey: 'VISION-GVOS-COMPOSER-L2-001',
+      title: 'GVOS Composer',
+      env: {},
+    });
+    expect(d.route).toBe('single');
+    expect(d.layer_a_signal).toBe('locked-decision-veto');
+    expect(d.reason).toMatch(/chairman locked single-SD intent/i);
+    for (const k of COMMON_TELEMETRY_KEYS) expect(d.telemetry).toHaveProperty(k);
+  });
+
+  it('TS-2: structured phases route to orchestrator regardless of locked_decisions', () => {
+    const archPlan = makeArchPlan({
+      structuredPhases: [
+        { number: 1, title: 'Phase 1' },
+        { number: 2, title: 'Phase 2' },
+        { number: 3, title: 'Phase 3' },
+      ],
+    });
+    const brainstormSession = makeBrainstormSession(['One Tier-3 SD-B2 (no split)']);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    expect(d.route).toBe('orchestrator');
+    expect(d.layer_a_signal).toBe('absent'); // Layer A skipped because structuredPhaseCount > 0
+    expect(d.telemetry.structured_phase_count).toBe(3);
+  });
+
+  it('TS-3: compound-phrase FP guard — "Split into 3 PRs but do not split DB layer" + structured', () => {
+    const archPlan = makeArchPlan({
+      structuredPhases: [
+        { number: 1, title: 'Phase 1' },
+        { number: 2, title: 'Phase 2' },
+        { number: 3, title: 'Phase 3' },
+      ],
+    });
+    const brainstormSession = makeBrainstormSession([
+      'Split into 3 PRs but do not split DB layer',
+    ]);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    // Even though the regex would match "do not split", Layer A is skipped
+    // because structuredPhaseCount > 0 — chairman intent for orchestration honored.
+    expect(d.route).toBe('orchestrator');
+    expect(d.layer_a_signal).toBe('absent');
+  });
+
+  it('TS-4: intentional FN — benign phrasing does not match regex', () => {
+    const archPlan = makeArchPlan({
+      content: ['## Phase 1', '## Phase 2', '## Phase 3'].join('\n\n'),
+    });
+    const brainstormSession = makeBrainstormSession([
+      'we should not split this until v2',
+      'consider splitting later',
+    ]);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    // Regex misses both phrasings → defaults to orchestrator (safe direction).
+    expect(d.route).toBe('orchestrator');
+    expect(d.layer_a_signal).toBe('absent');
+    expect(d.layer_b_signal).toBe('absent');
+  });
+
+  it('TS-5: Layer B PR-staged disambiguator fires when all headings are PR-N', () => {
+    const archPlan = makeArchPlan({
+      content: [
+        '## Phase 1 — PR-1',
+        '## Phase 2 — PR-2',
+        '## Phase 3 — PR-3',
+      ].join('\n\n'),
+    });
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession: null,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    expect(d.route).toBe('single');
+    expect(d.layer_b_signal).toBe('pr-staged-phases');
+  });
+
+  it('TS-6: mixed Phase+PR-N headings stay orchestrator (not all PR-N)', () => {
+    const archPlan = makeArchPlan({
+      content: ['## Phase 1', '## Phase 2 — PR-2', '## Phase 3'].join('\n\n'),
+    });
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession: null,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    expect(d.route).toBe('orchestrator');
+    expect(d.layer_b_signal).toBe('absent');
+  });
+
+  it('TS-7: 0-row brainstorm reverse-lookup → layer_a_signal=absent', () => {
+    const archPlan = makeArchPlan({
+      content: ['## Phase 1', '## Phase 2', '## Phase 3'].join('\n\n'),
+    });
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession: null, // caller passes null when 0 or 2+ rows
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    expect(d.route).toBe('orchestrator');
+    expect(d.layer_a_signal).toBe('absent');
+  });
+
+  it('TS-8: --force-orchestrator override beats locked_decisions veto', () => {
+    const archPlan = makeArchPlan({
+      content: ['## Phase 1 — PR-1', '## Phase 2 — PR-2'].join('\n\n'),
+    });
+    const brainstormSession = makeBrainstormSession(['One Tier-3 SD-B2 (no split)']);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      options: { forceOrchestrator: true },
+      env: {},
+    });
+    expect(d.route).toBe('orchestrator');
+    expect(d.override).toBe('force-orchestrator');
+  });
+
+  it('TS-9: kill switch LEO_AUTO_ROUTE_LAYER_A=off bypasses Layer A', () => {
+    const archPlan = makeArchPlan({
+      content: ['## Phase 1', '## Phase 2', '## Phase 3'].join('\n\n'),
+    });
+    const brainstormSession = makeBrainstormSession(['One Tier-3 SD-B2 (no split)']);
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan,
+      brainstormSession,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: { LEO_AUTO_ROUTE_LAYER_A: 'off' },
+    });
+    expect(d.layer_a_signal).toBe('kill-switch');
+    expect(d.route).toBe('orchestrator'); // veto disabled → falls back to default route
+  });
+});
+
+// Pure-helper unit tests -----------------------------------------------
+
+describe('pure helpers', () => {
+  it('countArchPhases counts structured and content phases independently', () => {
+    expect(countArchPhases(null)).toEqual({ structuredPhaseCount: 0, contentMatches: [] });
+    expect(countArchPhases({})).toEqual({ structuredPhaseCount: 0, contentMatches: [] });
+    const p = makeArchPlan({
+      structuredPhases: [{ number: 1 }, { number: 2 }],
+      content: '## Phase 1\n## Phase 2\n### Phase 3 — PR-3',
+    });
+    const r = countArchPhases(p);
+    expect(r.structuredPhaseCount).toBe(2);
+    expect(r.contentMatches.length).toBe(3); // H2/H2/H3 all match the broader regex
+  });
+
+  it('hasLockedSingleSdIntent matches the documented phrasings and rejects benign ones', () => {
+    expect(hasLockedSingleSdIntent(null)).toBe(false);
+    expect(hasLockedSingleSdIntent({ metadata: {} })).toBe(false);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession([]))).toBe(false);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['One Tier-3 SD-B2 (no split)']))).toBe(true);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['Single SD'])))
+      .toBe(true);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['do not split']))).toBe(true);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['keep as one']))).toBe(true);
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['we should not split this until v2'])))
+      .toBe(false); // intentional FN
+    expect(hasLockedSingleSdIntent(makeBrainstormSession(['consider splitting later'])))
+      .toBe(false);
+  });
+
+  it('allHeadingsArePrStaged returns true iff all matches contain PR-N', () => {
+    expect(allHeadingsArePrStaged([])).toBe(false);
+    expect(allHeadingsArePrStaged(['## Phase 1 — PR-1', '## Phase 2 — PR-2'])).toBe(true);
+    expect(allHeadingsArePrStaged(['## Phase 1 — PR-1', '## Phase 2'])).toBe(false);
+    expect(allHeadingsArePrStaged(['## Phase 1', '## Phase 2'])).toBe(false);
+  });
+
+  it('exported regexes match expected patterns', () => {
+    expect(SINGLE_SD_INTENT_REGEX.test('no split')).toBe(true);
+    expect(SINGLE_SD_INTENT_REGEX.test('single SD')).toBe(true);
+    expect(SINGLE_SD_INTENT_REGEX.test('do not split')).toBe(true);
+    expect(LAYER_B_HEADING_REGEX.test('## Phase 1')).toBe(true);
+    LAYER_B_HEADING_REGEX.lastIndex = 0;
+    expect(LAYER_B_HEADING_REGEX.test('### Phase 1')).toBe(true); // broader than line 2302
+    LAYER_B_HEADING_REGEX.lastIndex = 0;
+    expect(PR_N_PATTERN.test('PR-12')).toBe(true);
+    expect(PR_N_PATTERN.test('PR1')).toBe(false);
+  });
+});
+
+// Telemetry contract ---------------------------------------------------
+
+describe('telemetry contract', () => {
+  it('emits all 11 keys on every decision and is JSON-stringifiable', () => {
+    const d = shouldAutoRouteToOrchestrator({
+      archPlan: makeArchPlan(),
+      brainstormSession: null,
+      archKey: 'AK',
+      visionKey: 'VK',
+      title: 'T',
+      env: {},
+    });
+    const t = d.telemetry;
+    const expected = [
+      'route', 'layer_a_signal', 'layer_b_signal', 'override',
+      'structured_phase_count', 'content_phase_count', 'reason',
+      'archKey', 'visionKey', 'title', 'timestamp',
+    ];
+    for (const k of expected) expect(t).toHaveProperty(k);
+    const json = JSON.stringify(t);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -957,7 +957,7 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     if (updateError) {
       console.warn(`   ⚠️  Could not update additional fields: ${updateError.message}`);
     } else {
-      console.log(`   ✅ Updated: risks`);
+      console.log('   ✅ Updated: risks');
     }
   }
 
@@ -2093,7 +2093,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         } catch (err) {
           console.error(`\n❌ Invalid --scope-slice JSON: ${err.message}`);
           console.error(`   Received: ${childScopeSliceRaw}`);
-          console.error(`   Expected shape: {"stages": [18], "deliverable_globs": ["src/stage18/**"]}`);
+          console.error('   Expected shape: {"stages": [18], "deliverable_globs": ["src/stage18/**"]}');
           process.exit(1);
         }
       }
@@ -2288,34 +2288,86 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const targetRepos = targetReposIdx !== -1 ? parseTargetReposArg(args[targetReposIdx + 1]) : null;
 
       // FR-003: Auto-route to orchestrator creator when arch key has phases
+      // SD-FDBK-REFAC-LEO-CREATE-003-001: decision logic extracted to
+      // scripts/modules/leo-create-sd/auto-route-decider.js. Layers A
+      // (locked_decisions intent gate) and B (PR-staged disambiguator) prevent
+      // misclassification of single-SD intent as orchestrator (witnessed on
+      // SD-GVOS-COMPOSER-SNAPSHOTLOCKED-REGISTRY-ORCH-001).
       if (visionKey && archKey) {
+        let archPlan = null;
+        let brainstormSession = null;
         try {
           const sb = createSupabaseServiceClient();
-          const { data: archPlan } = await sb
+          const { data: archPlanData, error: archPlanErr } = await sb
             .from('eva_architecture_plans')
             .select('content, sections')
             .eq('plan_key', archKey)
             .single();
-          const structuredPhaseCount = archPlan?.sections?.implementation_phases?.length || 0;
-          const hasMultipleStructuredPhases = structuredPhaseCount >= 2;
-          const contentPhaseMatches = archPlan?.content
-            ? (archPlan.content.match(/^##?\s*(Phase|Implementation Phase|Step)\s+\d/gim) || [])
-            : [];
-          const hasMultipleContentPhases = contentPhaseMatches.length >= 2;
-          if (hasMultipleStructuredPhases || hasMultipleContentPhases) {
-            console.log(`\n🔄 Auto-routing to orchestrator creator (${structuredPhaseCount || contentPhaseMatches.length} phases detected)...`);
-            const { execSync } = await import('child_process');
-            const cmd = `node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children`;
-            execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
-            process.exit(0);
+          if (archPlanErr) {
+            if (archPlanErr.code === 'PGRST116') {
+              // Not found: likely a typo in --arch-key. Warn, skip FR-003, continue.
+              console.warn(`\n⚠️  archPlan not found for --arch-key='${archKey}', skipping FR-003 auto-route.`);
+              console.warn('   Verify spelling, or omit --arch-key to skip the auto-route check.');
+              archPlan = null;
+            } else {
+              throw archPlanErr;
+            }
+          } else {
+            archPlan = archPlanData;
+          }
+
+          // Reverse-lookup the brainstorm session that authored this plan key.
+          // Uses metadata->>plan_key (no FK exists; JSONB-only linkage). .limit(2)
+          // so we can distinguish 0 / 1 / 2+ rows (conservative bias on ambiguity).
+          if (archPlan) {
+            const { data: bsRows } = await sb
+              .from('brainstorm_sessions')
+              .select('metadata')
+              .eq('metadata->>plan_key', archKey)
+              .limit(2);
+            brainstormSession = Array.isArray(bsRows) && bsRows.length === 1 ? bsRows[0] : null;
           }
         } catch (routeErr) {
           // QF-20260409-561 (P1): Fail loud; silent fallback violated feedback_auto_decompose_sd_hierarchy.
+          // SD-FDBK-REFAC-LEO-CREATE-003-001 FR-5: PGRST116 was already handled above.
           console.error(`\n❌ Orchestrator auto-routing FAILED: ${routeErr.message}`);
           console.error(`   Check orphans: SELECT sd_key FROM strategic_directives_v2 WHERE metadata->>'vision_key'='${visionKey}';`);
           console.error('   Clean via database-agent, then re-run (create-orchestrator-from-plan.js will resume).');
           process.exit(1);
         }
+
+        const { shouldAutoRouteToOrchestrator } = await import('./modules/leo-create-sd/auto-route-decider.js');
+        const decision = shouldAutoRouteToOrchestrator({
+          archPlan,
+          brainstormSession,
+          archKey,
+          visionKey,
+          title,
+          options: { forceOrchestrator: args.includes('--force-orchestrator') },
+        });
+
+        // FR-4: emit a single structured telemetry line on every decision.
+        console.log(`[AUTO-ROUTE-DECISION] ${JSON.stringify(decision.telemetry)}`);
+
+        if (decision.route === 'orchestrator' && (decision.telemetry.structured_phase_count > 0 || decision.telemetry.content_phase_count >= 2)) {
+          console.log(`\n🔄 Auto-routing to orchestrator creator (${decision.telemetry.structured_phase_count || decision.telemetry.content_phase_count} phases detected)...`);
+          try {
+            const { execSync } = await import('child_process');
+            const cmd = `node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children`;
+            execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
+            process.exit(0);
+          } catch (execErr) {
+            console.error(`\n❌ Orchestrator auto-routing FAILED: ${execErr.message}`);
+            console.error(`   Check orphans: SELECT sd_key FROM strategic_directives_v2 WHERE metadata->>'vision_key'='${visionKey}';`);
+            console.error('   Clean via database-agent, then re-run (create-orchestrator-from-plan.js will resume).');
+            process.exit(1);
+          }
+        } else if (decision.route === 'single' && (decision.layer_a_signal !== 'absent' || decision.layer_b_signal !== 'absent')) {
+          // FR-4 UX hint: explain the single-SD route + how to override.
+          console.error('↪ Single-SD route taken. To force orchestrator: re-run with --force-orchestrator,');
+          console.error('  or set LEO_AUTO_ROUTE_LAYER_A=off LEO_AUTO_ROUTE_LAYER_B=off to bypass both gates.');
+        }
+        // else: fall through to normal single-SD creation flow.
 
         // Advisory: warn about uncovered architecture phases (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
         try {

--- a/scripts/modules/leo-create-sd/auto-route-decider.js
+++ b/scripts/modules/leo-create-sd/auto-route-decider.js
@@ -1,0 +1,269 @@
+/**
+ * auto-route-decider.js — pure FR-003 auto-route decision logic
+ *
+ * SD-FDBK-REFAC-LEO-CREATE-003-001
+ *
+ * Extracted from scripts/leo-create-sd.js:2290-2318. Decides whether
+ * `leo-create-sd.js --vision-key X --arch-key Y` should auto-route to the
+ * orchestrator creator (multi-child SD) or fall through to single-SD creation.
+ *
+ * **Pure function** — no I/O, no process.exit, no console.log. Caller fetches
+ * archPlan and brainstormSession via Supabase and passes them in. Returns a
+ * decision object; caller performs the side effects (telemetry, execSync,
+ * exit codes).
+ *
+ * **Two layers** added on top of the original phase-heading heuristic:
+ *
+ *   Layer A — locked_decisions intent gate. If chairman has locked
+ *   "no split" / "single SD" / "one Tier-3 SD" intent in
+ *   `brainstorm_sessions.metadata.locked_decisions` (JSONB array), veto the
+ *   orchestrator route. Only consulted when `structuredPhaseCount === 0`
+ *   (gates against compound-phrase FPs like
+ *   "Split into 3 PRs but do not split DB layer" in plans with structured
+ *   phases — validation-agent WARNING-2).
+ *
+ *   Layer B — PR-staged content-only disambiguator. When the only phase
+ *   signal is the content regex (no structured implementation_phases) AND
+ *   every matched heading contains /PR-\d+/, treat the headings as PR-staged
+ *   implementation phases (not SD-decomposable phases) and skip auto-route.
+ *
+ * **Kill switches** for hotfix recovery (default ON):
+ *   - LEO_AUTO_ROUTE_LAYER_A=off → bypass Layer A
+ *   - LEO_AUTO_ROUTE_LAYER_B=off → bypass Layer B
+ *
+ * @see PRD-SD-FDBK-REFAC-LEO-CREATE-003-001
+ * @see feedback 4c9eb37f-3835-4175-8ba2-c8407dc3aee2
+ */
+
+/**
+ * Regex matching chairman intent to NOT decompose into multiple SDs.
+ * Hits: "no split", "no-split", "single SD", "single-SD", "one Tier-3 SD",
+ *       "do not split", "do-not split", "keep one", "keep as one".
+ * Misses (intentional false-negatives — safer to default to orchestrator):
+ *       "we should not split this until v2"
+ *       "consider splitting later"
+ */
+export const SINGLE_SD_INTENT_REGEX =
+  /(?:no\s+split|no-split|single[\s-]+sd|one\s+tier-?\d+\s+sd|do\s+not\s+split|do-not\s+split|keep\s+(?:as\s+)?one)/i;
+
+/**
+ * Layer B heading regex — broader than the original line-2302 anchor.
+ * Original /^##?\s*(...)/ matched H1/H2 only and stopped at the digit. We
+ * match H2/H3/H4 AND capture the rest of the line so PR_N_PATTERN can be
+ * tested against the full heading (testing-agent narrow-detector finding).
+ */
+export const LAYER_B_HEADING_REGEX =
+  /^#{2,4}\s*(?:Phase|Implementation Phase|Step)\s+\d[^\n\r]*/gim;
+
+/**
+ * PR-N pattern. When EVERY matched heading contains this, Layer B fires.
+ */
+export const PR_N_PATTERN = /PR-\d+/;
+
+/**
+ * Compute structured + content phase counts from an arch plan.
+ *
+ * @param {Object|null} archPlan - Row from eva_architecture_plans
+ * @returns {{ structuredPhaseCount: number, contentMatches: string[] }}
+ */
+export function countArchPhases(archPlan) {
+  const structuredPhaseCount =
+    archPlan?.sections?.implementation_phases?.length || 0;
+  const contentMatches = archPlan?.content
+    ? archPlan.content.match(LAYER_B_HEADING_REGEX) || []
+    : [];
+  return { structuredPhaseCount, contentMatches };
+}
+
+/**
+ * Test whether the locked_decisions JSONB array on a brainstorm session
+ * contains a chairman-locked single-SD intent.
+ *
+ * @param {Object|null} brainstormSession - Row from brainstorm_sessions (or null)
+ * @returns {boolean}
+ */
+export function hasLockedSingleSdIntent(brainstormSession) {
+  if (!brainstormSession) return false;
+  const locked = brainstormSession?.metadata?.locked_decisions;
+  if (!Array.isArray(locked) || locked.length === 0) return false;
+  const joined = locked.filter((s) => typeof s === 'string').join(' ');
+  return SINGLE_SD_INTENT_REGEX.test(joined);
+}
+
+/**
+ * Test whether every content-heading match looks like a PR-staged phase.
+ *
+ * @param {string[]} contentMatches
+ * @returns {boolean} true iff matches.length > 0 AND every match contains /PR-\d+/
+ */
+export function allHeadingsArePrStaged(contentMatches) {
+  if (!Array.isArray(contentMatches) || contentMatches.length === 0) return false;
+  return contentMatches.every((m) => PR_N_PATTERN.test(m));
+}
+
+/**
+ * Decide whether to auto-route to the orchestrator creator.
+ *
+ * @param {Object} args
+ * @param {Object|null} args.archPlan - Row from eva_architecture_plans, or null
+ * @param {Object|null} args.brainstormSession - Row from brainstorm_sessions matching metadata->>plan_key = archKey (or null)
+ * @param {string} args.archKey - The --arch-key flag value (for telemetry)
+ * @param {string} args.visionKey - The --vision-key flag value (for telemetry)
+ * @param {string} args.title - The SD title (for telemetry)
+ * @param {Object} [args.options]
+ * @param {boolean} [args.options.forceOrchestrator] - --force-orchestrator override
+ * @param {Object} [args.env] - Override env var read (for tests); defaults to process.env
+ * @returns {{
+ *   route: 'orchestrator' | 'single',
+ *   layer_a_signal: 'absent' | 'locked-decision-veto' | 'kill-switch',
+ *   layer_b_signal: 'absent' | 'pr-staged-phases' | 'kill-switch',
+ *   override: null | 'force-orchestrator' | 'LEO_AUTO_ROUTE_LAYER_A=off' | 'LEO_AUTO_ROUTE_LAYER_B=off',
+ *   reason: string,
+ *   telemetry: Object
+ * }}
+ */
+export function shouldAutoRouteToOrchestrator({
+  archPlan,
+  brainstormSession,
+  archKey,
+  visionKey,
+  title,
+  options = {},
+  env = process.env,
+} = {}) {
+  const { structuredPhaseCount, contentMatches } = countArchPhases(archPlan);
+  const contentPhaseCount = contentMatches.length;
+  const hasMultipleStructured = structuredPhaseCount >= 2;
+  const hasMultipleContent = contentPhaseCount >= 2;
+
+  // --force-orchestrator override always wins (when there is something to route).
+  if (options.forceOrchestrator) {
+    if (hasMultipleStructured || hasMultipleContent) {
+      return decision({
+        route: 'orchestrator',
+        layer_a_signal: 'absent',
+        layer_b_signal: 'absent',
+        override: 'force-orchestrator',
+        reason: '--force-orchestrator override; routing despite any locked-decision veto',
+        structuredPhaseCount,
+        contentPhaseCount,
+        archKey,
+        visionKey,
+        title,
+      });
+    }
+  }
+
+  // Baseline: if neither structured nor content phases hit threshold, fall through to single.
+  if (!hasMultipleStructured && !hasMultipleContent) {
+    return decision({
+      route: 'single',
+      layer_a_signal: 'absent',
+      layer_b_signal: 'absent',
+      override: null,
+      reason: 'no phase signal detected; single-SD path',
+      structuredPhaseCount,
+      contentPhaseCount,
+      archKey,
+      visionKey,
+      title,
+    });
+  }
+
+  // Layer A: only when no structured phases (avoid compound-FP per WARNING-2).
+  const layerAKillSwitch = String(env.LEO_AUTO_ROUTE_LAYER_A || '').toLowerCase() === 'off';
+  let layer_a_signal = 'absent';
+  let layerAOverride = null;
+  if (layerAKillSwitch) {
+    layer_a_signal = 'kill-switch';
+    layerAOverride = 'LEO_AUTO_ROUTE_LAYER_A=off';
+  } else if (structuredPhaseCount === 0 && hasLockedSingleSdIntent(brainstormSession)) {
+    layer_a_signal = 'locked-decision-veto';
+  }
+
+  if (layer_a_signal === 'locked-decision-veto') {
+    return decision({
+      route: 'single',
+      layer_a_signal,
+      layer_b_signal: 'absent',
+      override: null,
+      reason:
+        'chairman locked single-SD intent in brainstorm_sessions.metadata.locked_decisions; auto-route vetoed',
+      structuredPhaseCount,
+      contentPhaseCount,
+      archKey,
+      visionKey,
+      title,
+    });
+  }
+
+  // Layer B: only fires when no structured phases AND every content heading is PR-staged.
+  const layerBKillSwitch = String(env.LEO_AUTO_ROUTE_LAYER_B || '').toLowerCase() === 'off';
+  let layer_b_signal = 'absent';
+  if (layerBKillSwitch) {
+    layer_b_signal = 'kill-switch';
+  } else if (structuredPhaseCount === 0 && allHeadingsArePrStaged(contentMatches)) {
+    layer_b_signal = 'pr-staged-phases';
+  }
+
+  if (layer_b_signal === 'pr-staged-phases') {
+    return decision({
+      route: 'single',
+      layer_a_signal,
+      layer_b_signal,
+      override: null,
+      reason: 'all phase headings are PR-staged (contain PR-N); treating as PR-staged implementation, not SD-decomposable phases',
+      structuredPhaseCount,
+      contentPhaseCount,
+      archKey,
+      visionKey,
+      title,
+    });
+  }
+
+  // Default: route to orchestrator (preserves pre-refactor behavior).
+  return decision({
+    route: 'orchestrator',
+    layer_a_signal,
+    layer_b_signal,
+    override: layerAOverride,
+    reason: `${structuredPhaseCount || contentPhaseCount} phases detected; auto-routing to orchestrator creator`,
+    structuredPhaseCount,
+    contentPhaseCount,
+    archKey,
+    visionKey,
+    title,
+  });
+}
+
+/**
+ * Build the decision return value, including telemetry payload.
+ * @private
+ */
+function decision({
+  route,
+  layer_a_signal,
+  layer_b_signal,
+  override,
+  reason,
+  structuredPhaseCount,
+  contentPhaseCount,
+  archKey,
+  visionKey,
+  title,
+}) {
+  const telemetry = {
+    route,
+    layer_a_signal,
+    layer_b_signal,
+    override,
+    structured_phase_count: structuredPhaseCount,
+    content_phase_count: contentPhaseCount,
+    reason,
+    archKey: archKey || null,
+    visionKey: visionKey || null,
+    title: title || null,
+    timestamp: new Date().toISOString(),
+  };
+  return { route, layer_a_signal, layer_b_signal, override, reason, telemetry };
+}


### PR DESCRIPTION
## Summary

Closes feedback `4c9eb37f-3835-4175-8ba2-c8407dc3aee2`. 25th+ writer-consumer asymmetry in PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.

**Witnessed misclassification**: SD-GVOS-COMPOSER-SNAPSHOTLOCKED-REGISTRY-ORCH-001 was routed to orchestrator-creator despite Q8 chairman lock "One Tier-3 SD-B2 (no split)" because the arch plan had 6 `## Phase N — PR-N` headings. `leo-create-sd.js` FR-003 auto-route (lines 2290-2318) consumed only the arch-plan phase heuristic, never reading `brainstorm_sessions.metadata.locked_decisions` JSONB array.

## Changes (3 files, +647 / -15)

- **NEW `scripts/modules/leo-create-sd/auto-route-decider.js`** (270 LOC) — pure-function helper `shouldAutoRouteToOrchestrator({archPlan, brainstormSession, ...}) → {route, layer_a_signal, layer_b_signal, override, reason, telemetry}`. Side effects stay at the call site.
- **MODIFIED `scripts/leo-create-sd.js`** (+65 / -13) — FR-003 block refactored. Fetches `brainstorm_sessions` via reverse lookup `metadata->>plan_key`. Emits structured `[AUTO-ROUTE-DECISION]` JSON-line telemetry on every decision. PGRST116 (typo in `--arch-key`) distinguished from real query errors. `--force-orchestrator` flag honored. UX hint emitted when a layer gate fires.
- **NEW tests** (260 LOC, 14 cases) — 9 acceptance matrix (TS-1..TS-9 from PRD FR-6) + 4 pure-helper tests + 1 telemetry contract test. All pass in 5ms.

## Two layers

- **Layer A**: `locked_decisions` regex `(?:no\s+split|single[\s-]+sd|one\s+tier-?\d+\s+sd|do\s+not\s+split|keep\s+(?:as\s+)?one)/i`. Gated by `structuredPhaseCount === 0` (avoids compound-phrase false positives like "Split into 3 PRs but do not split DB layer"). Kill switch: `LEO_AUTO_ROUTE_LAYER_A=off`.
- **Layer B**: PR-staged content-only disambiguator. Fires when no structured phases AND every matched heading contains `/PR-\d+/`. Mixed plans (`## Phase 1` + `## Phase 2 — PR-2`) still route to orchestrator. Kill switch: `LEO_AUTO_ROUTE_LAYER_B=off`.

## Sub-agent verdicts (all PASS)

| Phase | Agent | Verdict | Confidence |
|---|---|---|---|
| LEAD | validation | PASS | 90 |
| LEAD | risk | PASS | 88 |
| LEAD | testing-prospective | reconciled | - |
| PLAN | stories | PASS | 94 |
| PLAN | validation | PASS | 92 |
| EXEC | testing | PASS | 92 |
| EXEC | regression | PASS | 93 |
| PLAN_VERIFICATION | validation | PASS | 94 |

## Handoff scores

LEAD-TO-PLAN @ 94% • PLAN-TO-EXEC @ 92% • EXEC-TO-PLAN @ 94% • PLAN-TO-LEAD @ 94%

## Test plan

- [x] 14 new decider tests pass (5ms)
- [x] 41 existing leo-create-sd test files pass (no regression)
- [x] TypeScript compilation passes
- [x] Layer A regex matches the documented phrasings, misses benign ones
- [x] PGRST116 distinguished from real query errors
- [ ] Post-merge: monitor first 3 `/leo create --vision-key X --arch-key Y` runs for [AUTO-ROUTE-DECISION] telemetry; verify no false-positive single-routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)