### PR TITLE
fix(QF-20260513-725): tighten activation-invariant trigger regex (FP 58% -> 7.3%)

### DIFF
--- a/scripts/modules/activation-invariant/trigger-evaluator.js
+++ b/scripts/modules/activation-invariant/trigger-evaluator.js
@@ -21,12 +21,19 @@ const SCHEMA_TYPES = new Set(['schema', 'database', 'migration']);
 const SURFACE_TYPES = new Set(['feature', 'ui', 'component', 'route']);
 const WORKER_TYPES = new Set(['worker', 'consumer', 'api', 'service', 'job']);
 
-// Lane 2: free-text anchors. Carefully chosen — both schema-evidence AND
-// consumer-evidence must match for the SD to trigger. Anchors are word-
-// boundary regexes so "schema" matches but not "schematic".
-const SCHEMA_TEXT_REGEX = /\b(schema|migration|column|table|side[- ]table|seed|catalog|registry)\b/i;
-const SURFACE_TEXT_REGEX = /\b(ui|component|route|page|panel|render|view|menu|navigation|admin)\b/i;
-const WORKER_TEXT_REGEX = /\b(worker|consumer|api|service|job|orchestrat\w*|pipeline|trigger|hook)\b/i;
+// Lane 2: free-text anchors. Carefully tuned (QF-20260513-725) — wide single
+// words (column/table alone, view/panel/admin/render, pipeline/trigger/hook/
+// orchestrator) are dropped because LEO-infra SDs casually mention them
+// without shipping a real chain (58% FP rate on May-2026 cohort before tuning).
+// Replaced with stronger phrase anchors: action-bound schema terms, paired UI
+// patterns, role-bound worker/consumer mentions.
+//
+// Tuning regression check: GVOS-S17-PROMPT-QUALITY, GVOS-S17-E2E-PLAYWRIGHT,
+// and the synthetic motivating fixture must still trigger this lane. See
+// trigger-evaluator.test.js for the production-SD coverage tests.
+const SCHEMA_TEXT_REGEX = /\b(schema (migration|change|update|adds)|migration (adds|creates|introduces)|new[ -]table|side[- ]table|seed migration|catalog table|registry table|new (catalog|registry)|gvos_[a-z_]+|adds [a-z_]+_(table|rubric))\b/i;
+const SURFACE_TEXT_REGEX = /\b(ui[ -]?component|react[- ]component|new[- ]component|chairman[^.]*view|dashboard|user[- ]facing|panel[^.]*renders|page[^.]*renders|component[^.]*renders)\b/i;
+const WORKER_TEXT_REGEX = /\b(s\d+ worker|stage[ -]\d+ worker|worker[^.]*(populates|writes|consumes|reads|hook)|consumer[^.]*(reads|consumes|populates)|new[- ](consumer|worker|api))\b/i;
 
 /**
  * Pull all free-text fields from a single key_changes entry. Tolerant of

--- a/scripts/modules/activation-invariant/trigger-evaluator.test.js
+++ b/scripts/modules/activation-invariant/trigger-evaluator.test.js
@@ -76,9 +76,12 @@ describe('evaluateTrigger — free-text (Lane 2) handles heterogeneous shapes', 
   });
 
   it('does NOT trigger when text mentions schema-only (no consumer surface or worker)', () => {
+    // Tightened regex (QF-20260513-725) requires action-bound schema phrases.
+    // Use one that matches so this test exercises the lane-pair logic
+    // (schema yes, consumer no -> trigger false), not just regex selectivity.
     const sd = {
       key_changes: [
-        { title: 'Migration', detail: 'Add new column to product_requirements_v2' },
+        { title: 'Migration adds new catalog table', detail: 'Backfill rows for product_requirements_v2' },
       ],
     };
     const result = evaluateTrigger(sd);
@@ -112,6 +115,34 @@ describe('evaluateTrigger — both-lane match', () => {
     expect(result.lane1.passed).toBe(true);
     expect(result.lane2.passed).toBe(true);
     expect(result.reason).toBe('both_lanes_match');
+  });
+});
+
+describe('evaluateTrigger — tightened regex regression (QF-20260513-725)', () => {
+  it('does NOT trigger on bare word "schema" or "migration" mentions', () => {
+    // Pre-tuning, these single words alone triggered Lane 2 schemaMatch.
+    // Post-tuning, action-bound phrases required.
+    const sd = { key_changes: [{ title: 'Refactor', detail: 'Adjust schema considerations in the worker code path' }] };
+    expect(evaluateTrigger(sd).lane2.schemaMatch).toBe(false);
+  });
+
+  it('does NOT trigger on bare "view" / "panel" / "admin" mentions', () => {
+    // Pre-tuning, these single words alone triggered Lane 2 surfaceMatch.
+    const sd = { key_changes: [{ title: 'Schema migration', detail: 'Review admin queue; view changes; panel for audit log' }] };
+    // schema phrase matches schema regex, but no consumer phrase matches.
+    const result = evaluateTrigger(sd);
+    expect(result.lane2.schemaMatch).toBe(true);
+    expect(result.lane2.consumerMatch).toBe(false);
+    expect(result.triggered).toBe(false);
+  });
+
+  it('does NOT trigger on bare "trigger" / "hook" / "pipeline" mentions', () => {
+    // Pre-tuning, these LEO-infra-common words triggered Lane 2 workerMatch.
+    const sd = { key_changes: [{ title: 'Migration adds new catalog table', detail: 'Use DB trigger and pipeline hook to dedupe' }] };
+    const result = evaluateTrigger(sd);
+    expect(result.lane2.schemaMatch).toBe(true);
+    expect(result.lane2.consumerMatch).toBe(false);
+    expect(result.triggered).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to SD-LEO-INFRA-REQUIRE-END-END-001 (PR #3759) retro `fcd2c768` action item 1: tunes the DUAL-SCAN trigger evaluator's free-text regex anchors to meet the <10% false-positive PRD target (FR-4 risk R1).

## Measurement

| Cohort | Before | After |
|---|---:|---:|
| May-2026 completed SDs (110 rows) | **63 / 109 (58%)** | **8 / 110 (7.3%)** |

True-positives verified preserved:
- `SD-GVOS-COMPOSER-SNAPSHOTLOCKED-REGISTRY-ORCH-001` — still triggers
- `SD-GVOS-S17-PROMPT-QUALITY-ORCH-001` — still triggers

## What changed

Dropped over-permissive single-word matches that LEO-infra SDs casually mention:
- `column`, `table` (alone) from SCHEMA
- `view`, `panel`, `admin`, `render` (alone) from SURFACE
- `pipeline`, `trigger`, `hook`, `orchestrator` from WORKER

Replaced with action-bound phrases — see commit message for full list.

## Test plan
- [x] `npx vitest run scripts/modules/activation-invariant/trigger-evaluator.test.js` (14/14, includes 3 new regression cases)
- [x] `node scripts/one-off/scan-completed-sds-for-activation-gap.mjs --since 2026-05-01` reports 8/110

🤖 Generated with [Claude Code](https://claude.com/claude-code)