### PR TITLE
fix(QF-20260514-grill-validator): GATE_GRILL_CONVERGENCE validator interface

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/grill-convergence.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/grill-convergence.js
@@ -23,7 +23,14 @@ export function createGrillConvergenceGate(supabase) {
     name: 'GATE_GRILL_CONVERGENCE',
     description: 'SDs with open_questions_for_plan_phase must have a fresh /grill convergence artifact before LEAD-TO-PLAN (phase-1 warn, phase-2 hard-fail)',
     threshold: 70,
-    async execute(sd) {
+    required: false,
+    remediation: 'Run `node scripts/pocock/grill-runner.mjs --sd-id <SD-ID>` against open questions OR set metadata.grill_bypass=true with grill_bypass_reason (≥10 chars). Bypass quota: 3 per SD, 10 per day globally.',
+    validator: async (ctx) => executeGrillConvergence(ctx.sd, supabase),
+  };
+}
+
+async function executeGrillConvergence(sd, supabase) {
+  {
       const openQuestions = sd?.metadata?.open_questions_for_plan_phase || [];
       const sdKey = sd?.sd_key || sd?.id;
 
@@ -204,8 +211,7 @@ export function createGrillConvergenceGate(supabase) {
           artifact_count: (artifacts || []).length,
         },
       };
-    },
-  };
+  }
 }
 
 export default createGrillConvergenceGate;


### PR DESCRIPTION
## Summary

Hotfix follow-up to #3775. The `GATE_GRILL_CONVERGENCE` gate shipped with `async execute(sd)` but the LEAD-TO-PLAN gate framework calls `gate.validator(ctx)` where `ctx.sd` is the SD. Result: every LEAD-TO-PLAN precheck since #3775 merged returns `validator is not a function`, blocking all feature SDs.

Caught by Child D (Pocock Phase 2) precheck. Peer gates in the same registry (`sd-quality-gate.js`, `lead-evaluation-check.js`) use `{ name, validator, required, remediation }`.

Change: rename `async execute(sd)` → standalone `async function executeGrillConvergence(sd, supabase)` invoked from `validator(ctx)`. Add `required: false` and `remediation` string.

## Test plan

- [x] Post-fix precheck on Child D shows `GATE_GRILL_CONVERGENCE: 100%` PASS and overall 96%.
- [x] Gate skips when `metadata.open_questions_for_plan_phase` is empty (no-op path).
- [x] Gate emits feedback row + phase-1 warn when open questions exist with no fresh artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)