### PR TITLE
fix(QF-20260513-179): gate stage17.js generateArchetypes on s17_use_gvos_composer flag

### DIFF
--- a/server/routes/stage17.js
+++ b/server/routes/stage17.js
@@ -58,6 +58,29 @@ router.post('/:ventureId/strategy-recommendation', asyncHandler(async (req, res)
   });
 }));
 
+/**
+ * Quick-fix QF-20260513-179: GVOS composer gate (backend half of FR-6).
+ * Mirrors EHG/src/integrations/feature-flags/useFeatureFlag.ts semantics server-side.
+ * When s17_use_gvos_composer flag is ENABLED, skip the legacy archetype generator
+ * (closes the 29th writer-consumer-asymmetry witness — flag was wired in DB + frontend
+ * but backend POST handler never read it, still spawning per-screen Opus calls).
+ * ventureId param accepted for future per-venture targeting (current flag is global).
+ */
+export async function isGvosComposerEnabled(ventureId, supabase) {
+  if (!supabase) return false;
+  try {
+    const { data, error } = await supabase
+      .from('leo_feature_flags')
+      .select('is_enabled')
+      .eq('flag_key', 's17_use_gvos_composer')
+      .maybeSingle();
+    if (error || !data) return false;
+    return data.is_enabled === true;
+  } catch {
+    return false;
+  }
+}
+
 /** Per-venture rate limiter for archetype generation (1 call per 10s per venture). */
 const archetypeRateLimiter = new Map();
 const ARCHETYPE_RATE_LIMIT_TTL_MS = 10_000;
@@ -93,6 +116,13 @@ router.post('/:ventureId/archetypes', asyncHandler(async (req, res) => {
   archetypeRateLimiter.set(ventureId, now);
 
   const supabase = req.app.locals.supabase || req.supabase;
+
+  // Quick-fix QF-20260513-179: skip legacy archetype generator when GVOS composer is active.
+  // SD-LEO-FEAT-GVOS-ACTIVATION-REMEDIATION-001 / FR-6 backend half (closes 29th writer-consumer asymmetry).
+  if (await isGvosComposerEnabled(ventureId, supabase)) {
+    console.info(`[stage17-route] GVOS composer active for ${ventureId.slice(0, 8)} — skipping legacy archetype generator`);
+    return res.status(202).json({ status: 'skipped', reason: 'gvos_composer_active', message: 'Legacy archetype generation skipped — venture is using GVOS composer (s17_use_gvos_composer flag enabled).' });
+  }
 
   const existing = activeArchetypeGenerations.get(ventureId);
   if (existing) {

--- a/tests/integration/stage17-gvos-composer-route-gate.test.js
+++ b/tests/integration/stage17-gvos-composer-route-gate.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const ROUTE = join(REPO_ROOT, 'server', 'routes', 'stage17.js');
+
+describe('stage17.js POST /:ventureId/archetypes — GVOS composer gate (QF-20260513-179)', () => {
+  const src = readFileSync(ROUTE, 'utf8');
+
+  it('exports isGvosComposerEnabled helper', () => {
+    expect(src).toContain('export async function isGvosComposerEnabled');
+    expect(src).toContain("flag_key', 's17_use_gvos_composer'");
+  });
+
+  it('POST handler calls isGvosComposerEnabled BEFORE activeArchetypeGenerations.set', () => {
+    // Locate the POST handler block
+    const handlerStart = src.indexOf("router.post('/:ventureId/archetypes',");
+    expect(handlerStart).toBeGreaterThan(-1);
+
+    const gateCallIdx = src.indexOf('isGvosComposerEnabled(ventureId, supabase)', handlerStart);
+    const ledgerSetIdx = src.indexOf('activeArchetypeGenerations.set(ventureId, ac)', handlerStart);
+
+    expect(gateCallIdx).toBeGreaterThan(handlerStart);
+    expect(ledgerSetIdx).toBeGreaterThan(handlerStart);
+    expect(gateCallIdx).toBeLessThan(ledgerSetIdx);
+  });
+
+  it('returns 202 with status=skipped + reason=gvos_composer_active when flag is on', () => {
+    expect(src).toMatch(/status:\s*'skipped'/);
+    expect(src).toMatch(/reason:\s*'gvos_composer_active'/);
+    expect(src).toMatch(/res\.status\(202\)\.json\(\{\s*status:\s*'skipped'/);
+  });
+
+  it('preserves existing generation path when flag is off (legacy 4-variants flow intact)', () => {
+    expect(src).toContain('activeArchetypeGenerations.set(ventureId, ac)');
+    expect(src).toContain('generateArchetypes(ventureId, supabase');
+    expect(src).toContain("status: 'generating'");
+  });
+
+  it('helper signature accepts ventureId for future per-venture targeting', () => {
+    expect(src).toMatch(/isGvosComposerEnabled\(ventureId,\s*supabase\)/);
+  });
+
+  it('helper queries leo_feature_flags table', () => {
+    expect(src).toContain("from('leo_feature_flags')");
+    expect(src).toContain("select('is_enabled')");
+  });
+});

--- a/tests/unit/stage17-gvos-composer-gate.test.js
+++ b/tests/unit/stage17-gvos-composer-gate.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { isGvosComposerEnabled } from '../../server/routes/stage17.js';
+
+function mockSupabase({ flagEnabled = null, error = null } = {}) {
+  return {
+    from(table) {
+      return {
+        select() {
+          return {
+            eq() { return this; },
+            maybeSingle: async () => {
+              if (error) return { data: null, error: { message: error } };
+              if (flagEnabled === null) return { data: null, error: null };
+              return { data: { is_enabled: flagEnabled }, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('isGvosComposerEnabled (QF-20260513-179)', () => {
+  it('returns true when s17_use_gvos_composer flag is enabled', async () => {
+    const r = await isGvosComposerEnabled('venture-uuid', mockSupabase({ flagEnabled: true }));
+    expect(r).toBe(true);
+  });
+
+  it('returns false when flag is disabled', async () => {
+    const r = await isGvosComposerEnabled('venture-uuid', mockSupabase({ flagEnabled: false }));
+    expect(r).toBe(false);
+  });
+
+  it('returns false when flag row does not exist', async () => {
+    const r = await isGvosComposerEnabled('venture-uuid', mockSupabase({ flagEnabled: null }));
+    expect(r).toBe(false);
+  });
+
+  it('returns false on supabase query error (fail-safe)', async () => {
+    const r = await isGvosComposerEnabled('venture-uuid', mockSupabase({ error: 'connection refused' }));
+    expect(r).toBe(false);
+  });
+
+  it('returns false when supabase client is null/undefined', async () => {
+    expect(await isGvosComposerEnabled('venture-uuid', null)).toBe(false);
+    expect(await isGvosComposerEnabled('venture-uuid', undefined)).toBe(false);
+  });
+
+  it('handles supabase that throws synchronously', async () => {
+    const broken = { from() { throw new Error('boom'); } };
+    expect(await isGvosComposerEnabled('venture-uuid', broken)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes 29th writer-consumer-asymmetry witness (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).

SD-LEO-FEAT-GVOS-ACTIVATION-REMEDIATION-001 / FR-6 declared: *"When ON: S17 UI shows GvosS17Sections panels; archetype generator is skipped."* The frontend half shipped via QF-20260513-655 + QF-20260513-964. The **backend half** was missing — `POST /api/stage17/:ventureId/archetypes` unconditionally created an AbortController + called `generateArchetypes(...)` regardless of flag state, spawning per-screen Opus calls even when `s17_use_gvos_composer` was enabled.

## Changes (28 src LOC, 103 test LOC)

- **`server/routes/stage17.js`**:
  - `isGvosComposerEnabled(ventureId, supabase)` helper — mirrors `useFeatureFlag` semantics server-side; queries `leo_feature_flags.is_enabled` for `s17_use_gvos_composer`; fail-safe (returns false on any error)
  - Gate inserted in POST handler **before** `activeArchetypeGenerations.set` — returns `202 { status: 'skipped', reason: 'gvos_composer_active' }` when flag enabled
  - Legacy path preserved when flag off

## Tests (12/12 passing)

- `tests/unit/stage17-gvos-composer-gate.test.js` — 6 cases (enabled/disabled/missing/error/null-client/throws)
- `tests/integration/stage17-gvos-composer-route-gate.test.js` — 6 shape checks (export, call-order, response shape, legacy preservation, signature, table refs)

## Tier classification

- Src LOC: 28 → **Tier-1** (≤30, auto-approve QF)
- Type: bug, severity: medium → qualifies
- Forbidden keywords: none

## Test plan

- [x] 12 tests passing locally
- [ ] Verify frontend "Continue Generation" button receives 202 status='skipped' (separate UI follow-up if user-visible toast needed; for THIS QF, just return the 202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)