### PR TITLE
docs(QF-20260514-096): CFO persona uses Claude Code economics, not engineer-hours × blended rate

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -441,7 +441,13 @@ EXPERTISE_GAP: [description of the gap]
 - CTO: "What do we already have? What's the real build cost?"
 - CISO: "What attack surface does this create?"
 - COO: "Can we actually deliver this given current load?"
-- CFO: "What does this cost and what's the return?"
+- CFO: "What are the API-token + user-supervisory-hour costs, and what's the recurring time savings? Reason in Claude Code economics — NOT human-engineer-hours × blended rate."
+
+**CFO seat addendum (QF-20260514-096 — Claude Code economics framing):**
+The CFO MUST reason in **Claude Code economics**, NOT MBA framing:
+- **Cost currency**: (a) API tokens consumed per cycle (Opus/Sonnet/Haiku mix, modest absolute USD); (b) user-supervisory-hours per cycle (the bottleneck — chairman attention, not headcount). Do NOT compute "engineer hours × $80-$200/hr blended rate" — that produces misleading $85K-style figures that do not correspond to real expenditure in a Claude-Code-assisted solo-developer workflow.
+- **Return currency**: recurring user-supervisory-hours saved per month (not "engineer FTE freed"). Payback in user-attention-months, not dollar-months.
+- **Reference**: memory entry `feedback_cfo_persona_claude_code_economics.md` for the full reframing. Chairman flagged the legacy framing during brainstorm a6b92936 Step 8.7 (parent SD-WRITERCONSUMER-ASYMMETRY-...-001 corrected this in scope).
 
 **Quorum check**: After all agents respond, verify at least 4 of 6 (67%) produced substantive positions (>50 characters). If quorum fails, fall back to Step 6D.1b.
 
@@ -1217,7 +1223,7 @@ Build the following markdown content in-memory (do NOT use the Write tool):
 | CTO | What do we already have? What's the real build cost? | [position summary] |
 | CISO | What attack surface does this create? | [position summary] |
 | COO | Can we actually deliver this given current load? | [position summary] |
-| CFO | What does this cost and what's the return? | [position summary] |
+| CFO | API-token + user-supervisory-hour costs, recurring time savings? (Claude Code economics — NOT engineer-hours × blended rate) | [position summary] |
 
 ### Specialist Testimony
 (Included when board flagged expertise gaps — omitted if no gaps detected)

--- a/tests/unit/brainstorm-cfo-claude-code-economics.test.js
+++ b/tests/unit/brainstorm-cfo-claude-code-economics.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const BRAINSTORM = join(REPO_ROOT, '.claude', 'commands', 'brainstorm.md');
+
+describe('brainstorm CFO persona Claude Code economics framing (QF-20260514-096)', () => {
+  const src = readFileSync(BRAINSTORM, 'utf8');
+
+  it('CFO standing question references API-token + user-supervisory-hour currency', () => {
+    expect(src).toContain('API-token + user-supervisory-hour costs');
+    expect(src).toMatch(/CFO:\s*"What are the API-token \+ user-supervisory-hour costs/);
+  });
+
+  it('CFO standing question explicitly rejects blended-rate engineer-hours framing', () => {
+    expect(src).toMatch(/Claude Code economics.*NOT.*engineer-hours.*blended rate/i);
+  });
+
+  it('CFO addendum section present and references QF + memory entry', () => {
+    expect(src).toContain('CFO seat addendum (QF-20260514-096');
+    expect(src).toContain('feedback_cfo_persona_claude_code_economics.md');
+  });
+
+  it('addendum names the misleading $85K-style framing the chairman flagged', () => {
+    expect(src).toContain('$85K');
+    expect(src).toMatch(/chairman flagged/i);
+  });
+
+  it('Round 1 board-positions table CFO row uses Claude Code economics framing', () => {
+    expect(src).toMatch(/\| CFO \| API-token \+ user-supervisory-hour costs/);
+  });
+
+  it('no $80-$200/hr-style blended-rate phrasing remains in CFO addendum', () => {
+    // The addendum CALLS OUT the wrong framing as a "do NOT" — that's the only allowed match
+    const matches = [...src.matchAll(/engineer hours \xD7 \$\d/gi)];
+    expect(matches.length).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary

Reframes the brainstorm-skill CFO standing question + adds explicit addendum so CFO reasoning uses **Claude Code economics** (API tokens + user-supervisory-hours) instead of legacy MBA framing (engineer hours × blended rate). Discovered during brainstorm a6b92936 Step 8.7 chairman review — the legacy framing produced misleading \$85K / 11.3-month payback figures that did not correspond to real expenditure in a Claude-Code-assisted solo-developer workflow.

## Changes (7 src LOC + 35 test LOC)

- `.claude/commands/brainstorm.md`:
  - Line 444: CFO standing question reframed to API-token + user-supervisory-hour costs
  - After line 444: 4-line CFO seat addendum (cost currency, return currency, payback unit, memory-file reference)
  - Line 1226: Round 1 board-positions table CFO row updated to match
- `tests/unit/brainstorm-cfo-claude-code-economics.test.js`: 6 cases verifying addendum + table sync

## Tier classification

- Src LOC: 7 → **Tier-1** (≤30, auto-approve QF)
- Type: documentation, severity: medium → qualifies
- 6/6 tests passing

## Related
- Memory: `feedback_cfo_persona_claude_code_economics.md`
- Parent SD: `SD-WRITERCONSUMER-ASYMMETRY-DETECTION-SCOPECOMPLETION-ORCH-001` (Phase 7 task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)