### PR TITLE
fix(QF-20260516-082): verifyMerged cross-checks state==MERGED + hook handoff false-positive

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,8 +28,10 @@ if ls prds/*.md 2>/dev/null | grep -q .; then
     exit 1
 fi
 
-# Check for handoff files
-if ls handoffs/*.md docs/**/handoff-*.md 2>/dev/null | grep -q .; then
+# Check for handoff files (QF-20260516-082: closes harness 9655eef2 — the
+# previous glob `docs/**/handoff-*.md` matched reference docs in docs/reference/
+# that aren't actual handoff records; scope to canonical handoff locations only).
+if ls handoffs/*.md docs/handoffs/*.md 2>/dev/null | grep -q .; then
     echo -e "${RED}❌${NC}"
     echo -e "${RED}ERROR: Handoff files detected!${NC}"
     echo "Handoffs must be stored in database only"

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -69,21 +69,31 @@ export function buildMergeArgs(prNumber, { admin } = {}) {
 }
 
 /**
- * Verify a PR is actually merged by re-fetching mergedAt.
+ * Verify a PR is actually merged by re-fetching mergedAt + cross-checking state.
  *
  * QF-20260504-195: `gh pr merge` can exit 0 in queued / auto-merge-label
  * states without the merge actually completing. The exit code alone is not
  * load-bearing — we must confirm `mergedAt` is non-null before declaring
- * success. Returns true / false (false on lookup failure — safer fallback,
- * forces fall-through to race-recovery).
+ * success.
+ *
+ * QF-20260516-082 (closes harness 72a3a5f1): mergedAt alone is not enough.
+ * Empirical witness 2026-05-13 PR rickfelix/ehg#600: gh returned a populated
+ * mergedAt timestamp while the PR was still queued behind an unstable
+ * mergeable_state (Vercel check pending). The gh REST view can briefly
+ * surface a stale mergedAt during the queue→merge window. Cross-check
+ * state==='MERGED' (authoritative) before declaring success.
+ *
+ * Returns true / false (false on lookup failure — safer fallback, forces
+ * fall-through to race-recovery).
  */
 export function verifyMerged(prNumber, runner = defaultRunner) {
-  const r = runner(['pr', 'view', String(prNumber), '--json', 'mergedAt', '--jq', '.mergedAt']);
-  if (r.code !== 0) return false;
-  const trimmed = r.stdout.trim();
-  if (!trimmed) return false;
-  if (trimmed === 'null') return false;
-  return true;
+  const mergedAtRes = runner(['pr', 'view', String(prNumber), '--json', 'mergedAt', '--jq', '.mergedAt']);
+  if (mergedAtRes.code !== 0) return false;
+  const trimmed = mergedAtRes.stdout.trim();
+  if (!trimmed || trimmed === 'null') return false;
+  const stateRes = runner(['pr', 'view', String(prNumber), '--json', 'state', '--jq', '.state']);
+  if (stateRes.code !== 0) return false;
+  return stateRes.stdout.trim() === 'MERGED';
 }
 
 /**

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -124,6 +124,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -141,11 +142,14 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
     // unmatched-call default returns code=1 → verifyBranchDeleted returns
     // null → "branch deletion not verified" advisory is logged. No
     // additional gh api call is made when the headRefName lookup fails.
+    // QF-20260516-082: verifyMerged cross-checks state==='MERGED' after
+    // mergedAt, adding one more pr-view call to the happy path.
     expect(calls.map((c) => c.slice(0, 2))).toEqual([
       ['pr', 'view'],
       ['pr', 'ready'],
       ['api', 'repos/rickfelix/EHG_Engineer/branches/main/protection'],
       ['pr', 'merge'],
+      ['pr', 'view'],
       ['pr', 'view'],
       ['pr', 'view'],
     ]);
@@ -159,6 +163,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -179,6 +184,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
     ]);
 
     const r = await attemptAutoMerge({
@@ -195,10 +201,11 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
   });
 });
 
-describe('verifyMerged (QF-20260504-195)', () => {
-  it('returns true when mergedAt is a populated ISO timestamp', () => {
+describe('verifyMerged (QF-20260504-195, QF-20260516-082)', () => {
+  it('returns true when mergedAt is populated AND state===MERGED', () => {
     const { runner } = makeRunner([
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
     ]);
     expect(verifyMerged(568, runner)).toBe(true);
   });
@@ -218,6 +225,25 @@ describe('verifyMerged (QF-20260504-195)', () => {
   it('returns false on empty stdout', () => {
     const { runner } = makeRunner([
       { match: argvMatchers.prViewMergedAt, result: { stdout: '' } },
+    ]);
+    expect(verifyMerged(568, runner)).toBe(false);
+  });
+
+  it('QF-20260516-082 (closes harness 72a3a5f1): returns false when mergedAt populated but state===OPEN (queued-but-not-merged race)', () => {
+    // Empirical witness: PR rickfelix/ehg#600 returned mergedAt timestamp via
+    // gh while pulls REST endpoint showed merged=false, mergeable_state=unstable.
+    // state==='OPEN' is the authoritative tie-breaker that catches this race.
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-13T23:25:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'OPEN\n' } },
+    ]);
+    expect(verifyMerged(600, runner)).toBe(false);
+  });
+
+  it('QF-20260516-082: returns false when state lookup itself fails', () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-04T22:23:28Z\n' } },
+      // No prViewState matcher → runner returns code=1 → verifyMerged false.
     ]);
     expect(verifyMerged(568, runner)).toBe(false);
   });
@@ -405,6 +431,7 @@ describe('attemptAutoMerge — branch-deletion verification (QF-20260509-VERIFY-
       { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-06T10:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
       { match: argvMatchers.prViewHeadRef, result: { stdout: 'qf/QF-foo\n' } },
       { match: argvMatchers.apiRefHead, result: { code: 0, stdout: '{"ref":"refs/heads/qf/QF-foo"}' } },
     ]);
@@ -439,6 +466,7 @@ describe('attemptAutoMerge — branch-deletion verification (QF-20260509-VERIFY-
       { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-06T10:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
       { match: argvMatchers.prViewHeadRef, result: { stdout: 'qf/QF-bar\n' } },
       { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'gh: Not Found (HTTP 404)' } },
     ]);
@@ -467,6 +495,7 @@ describe('attemptAutoMerge — branch-deletion verification (QF-20260509-VERIFY-
       { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
       { match: argvMatchers.prMerge, result: { stdout: '' } },
       { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-06T10:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
       // headRefName lookup fails → verifyBranchDeleted returns null →
       // attemptAutoMerge logs the "not verified" advisory.
     ]);


### PR DESCRIPTION
## Summary
Closes two harness false-positives in one targeted fix.

**Harness 72a3a5f1** — `lib/ship/auto-merge.mjs verifyMerged()`:
Empirical witness 2026-05-13 PR rickfelix/ehg#600 (QF-20260513-786): `attemptAutoMerge` returned `{ok:true, action:"merged"}` but `gh api .../pulls/600` immediately after showed `merged=false, mergeable_state=unstable`. The gh CLI surfaced a stale `mergedAt` timestamp while the merge was queued behind a pending Vercel check.

`verifyMerged()` now cross-checks `state==='MERGED'` (authoritative) after `mergedAt`. When state is OPEN despite mergedAt being populated, verifyMerged returns false → fall-through to existing race-recovery path → recover via state-check or hard-fail with silent-success regression.

27th+ PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 witness.

**Harness 9655eef2** — `.githooks/pre-commit` handoff-file check:
Previous glob `docs/**/handoff-*.md` false-positived on two pre-existing reference docs (`docs/reference/handoff-resolution-lifecycle-pattern.md`, `docs/reference/handoff-state-machines.md`, added 2026-04-24 in PR #3276) that aren't actual handoff records. Scoped to canonical locations only (`handoffs/` + `docs/handoffs/`). Unblocks future commits.

## LOC
- Source: +12/-5 in `lib/ship/auto-merge.mjs`, +3/-1 in `.githooks/pre-commit`
- Tests: +33/-2 in `tests/unit/ship/auto-merge.test.js`
- **Total**: 50/9 = 41 net LOC, under tier-2 cap.

## Test Plan
- [x] `vitest run tests/unit/ship/auto-merge.test.js` → 32 passed (was 30 — 2 new regression cases for harness 72a3a5f1)
- [x] Local `.githooks/pre-commit` now exits 0 (was exit 1 due to false-positive on `docs/reference/handoff-*.md`)
- [x] verifyMerged returns false when `mergedAt` populated + `state===OPEN` (new test case)
- [x] verifyMerged returns false when state lookup itself fails (new test case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)