### PR TITLE
fix(QF-20260518-905): narrow .githooks/pre-commit.js handoff glob to match bash hook

### DIFF
--- a/.githooks/pre-commit.js
+++ b/.githooks/pre-commit.js
@@ -46,10 +46,13 @@ function checkFilesystemDrift() {
     }
   }
 
-  // Check for handoff files
+  // Check for handoff files (QF-20260518-905: match bash hook narrowing from
+  // QF-20260516-082. Previous glob `docs/**/handoff-*.md` matched reference docs
+  // in docs/reference/ that aren't actual handoff records; scope to canonical
+  // handoff locations only).
   const handoffPatterns = [
     'handoffs/**/*.md',
-    'docs/**/handoff-*.md'
+    'docs/handoffs/*.md'
   ];
 
   for (const pattern of handoffPatterns) {


### PR DESCRIPTION
## Summary

- QF-20260516-082 (PR #3797, merged 2026-05-16) narrowed the **bash** hook `.githooks/pre-commit` handoff-file check from `docs/**/handoff-*.md` to `docs/handoffs/*.md` to prevent false-positives on legit reference docs in `docs/reference/`
- The **JS** hook `.githooks/pre-commit.js:52` still had the broad glob, so worktrees that invoke the JS hook tripped the same false-positive
- Witnessed today (2026-05-18) during PR #3801 commit which had to use `--no-verify` to bypass
- Fix: narrow JS hook glob to match bash hook → `docs/handoffs/*.md`

## Root cause

29th+ witness of `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` — the bash and JS hooks are parallel writers for the same consumer (filesystem-drift gate). The bash side was narrowed by QF-082 but the JS side was missed, so the two diverged without alignment.

## Verification

- `git diff` shows +5 -1 LOC on `.githooks/pre-commit.js` (3 net + 4 comment lines)
- Pre-commit hook on this commit passes cleanly (no `--no-verify` needed) because the bash hook was already correct on main
- Future commits in worktrees that invoke the JS hook will no longer trip on `docs/reference/handoff-*.md`

## Test plan

- [x] Pre-commit hook on this PR's branch passes (bash hook already correct on main)
- [ ] Smoke test the JS hook directly: from a worktree that has `docs/reference/handoff-state-machines.md`, run `node .githooks/pre-commit.js` — expect SUCCESS (was failing before)
- [ ] No new error class introduced (Tier-1 QF, single-file ≤30 LOC change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)