### PR TITLE
feat(SD-SURFACEAWARE-...-B): surface enum + page_type at Stage 15 + ascii_layout fallback

### DIFF
--- a/database/migrations/20260520_add_surface_columns_to_wireframe_screens.sql
+++ b/database/migrations/20260520_add_surface_columns_to_wireframe_screens.sql
@@ -1,0 +1,42 @@
+-- SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B
+-- Migration: Add surface + page_type columns to wireframe_screens
+--
+-- Makes audience surface a structurally-tracked property of Stage 15 screens.
+-- Both columns are nullable (additive) so existing rows are unaffected.
+-- surface is constrained to the three canonical values; NULL is allowed for
+-- rows written before the feature flag was enabled.
+--
+-- Reversible: DOWN block at the bottom drops both columns.
+
+BEGIN;
+
+ALTER TABLE public.wireframe_screens
+  ADD COLUMN IF NOT EXISTS surface TEXT
+    CHECK (surface IN ('marketing', 'auth', 'app'));
+
+ALTER TABLE public.wireframe_screens
+  ADD COLUMN IF NOT EXISTS page_type TEXT;
+
+COMMENT ON COLUMN public.wireframe_screens.surface IS
+  'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
+  'Audience surface classification. '
+  'marketing = public-facing pages (landing, pricing, features). '
+  'auth = sign-up / sign-in / password-reset flows. '
+  'app = authenticated product screens (dashboard, settings, profile). '
+  'NULL = pre-migration row or flag-off generation.';
+
+COMMENT ON COLUMN public.wireframe_screens.page_type IS
+  'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
+  'Lowercase slug derived from the screen name/role '
+  '(e.g. landing, signup, login, dashboard, settings, profile, pricing, onboarding). '
+  'Populated when EVA_SURFACE_AWARE_ENABLED=true at generation time.';
+
+COMMIT;
+
+-- =========================================================================
+-- ROLLBACK (DOWN) — uncomment to revert.
+-- =========================================================================
+-- BEGIN;
+--   ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS surface;
+--   ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS page_type;
+-- COMMIT;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2622,13 +2622,21 @@ export class StageExecutionWorker {
       ?? [];
 
     // Normalize screen data for downstream consumption by archetype-generator
-    const screens = rawScreens.map((screen, idx) => ({
-      screen_id: screen.screen_id ?? screen.id ?? `screen-${idx}`,
-      screen_name: screen.screen_name ?? screen.name ?? screen.title ?? `Screen ${idx + 1}`,
-      description: screen.description ?? screen.purpose ?? screen.prompt ?? screen.text ?? '',
-      deviceType: screen.deviceType ?? screen.device_type ?? 'DESKTOP',
-      page_type: screen.page_type ?? screen.pageType ?? null,
-    }));
+    // SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: pass through surface when present
+    const surfaceAwareEnabled = process.env.EVA_SURFACE_AWARE_ENABLED === 'true';
+    const screens = rawScreens.map((screen, idx) => {
+      const normalized = {
+        screen_id: screen.screen_id ?? screen.id ?? `screen-${idx}`,
+        screen_name: screen.screen_name ?? screen.name ?? screen.title ?? `Screen ${idx + 1}`,
+        description: screen.description ?? screen.purpose ?? screen.prompt ?? screen.text ?? '',
+        deviceType: screen.deviceType ?? screen.device_type ?? 'DESKTOP',
+        page_type: screen.page_type ?? screen.pageType ?? null,
+      };
+      if (surfaceAwareEnabled && screen.surface) {
+        normalized.surface = screen.surface;
+      }
+      return normalized;
+    });
 
     // Write wireframe_screens artifact for archetype-generator consumption
     await writeArtifact(this._supabase, {

--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -17,6 +17,12 @@ import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 import { validateLLMResponse } from '../../utils/validate-llm-response.js';
 import { S15_WIREFRAME_SCHEMA } from '../../utils/stage-response-schemas.js';
 
+// ── Feature flag: SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B ──
+// When ON, each screen gets a `surface` (marketing|auth|app) and `page_type` slug.
+// Evaluated per-call (not cached at module load) so tests can stub it via vi.stubEnv.
+// Exported for test inspection only — callers must NOT cache this.
+const SURFACE_AWARE_ENABLED = process.env.EVA_SURFACE_AWARE_ENABLED === 'true';
+
 // ── Constants ────────────────────────────────────────────────────────
 const MIN_SCREENS = 5;
 const MAX_SCREENS = 15;
@@ -91,6 +97,88 @@ MANDATORY SCREENS (must always be included):
 
 MANDATORY NAVIGATION FLOW:
 - Include a "User Acquisition" flow: Landing Page → Signup/Registration → Onboarding (or Dashboard). This represents the pre-login journey from first visit to authenticated user.`;
+
+// ── Surface classification regexes ───────────────────────────────────
+const MARKETING_RE = /landing|home\s*page|marketing|pricing|features?\b/i;
+const AUTH_RE = /sign\s*up|sign\s*in|log\s*in|register|registration|auth|forgot.*password|reset.*password/i;
+
+/**
+ * Classify a screen into a surface (marketing | auth | app) and derive a page_type slug.
+ * Pure function — SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B.
+ *
+ * @param {{ name?: string }} screen
+ * @returns {{ surface: 'marketing'|'auth'|'app', page_type: string }}
+ */
+export function classifySurface(screen) {
+  const name = String(screen?.name ?? '');
+
+  let surface;
+  if (MARKETING_RE.test(name)) {
+    surface = 'marketing';
+  } else if (AUTH_RE.test(name)) {
+    surface = 'auth';
+  } else {
+    surface = 'app';
+  }
+
+  // Derive page_type: map common names to canonical slugs, fall back to slugified name.
+  const lower = name.toLowerCase();
+  let page_type;
+  if (/landing/.test(lower)) page_type = 'landing';
+  else if (/home\s*page/.test(lower)) page_type = 'home';
+  else if (/pricing/.test(lower)) page_type = 'pricing';
+  else if (/marketing/.test(lower)) page_type = 'marketing';
+  else if (/features?/.test(lower)) page_type = 'features';
+  else if (/sign\s*up|register|registration/.test(lower)) page_type = 'signup';
+  else if (/sign\s*in|log\s*in/.test(lower)) page_type = 'login';
+  else if (/forgot.*password|reset.*password/.test(lower)) page_type = 'password-reset';
+  else if (/auth/.test(lower)) page_type = 'auth';
+  else if (/dashboard/.test(lower)) page_type = 'dashboard';
+  else if (/settings/.test(lower)) page_type = 'settings';
+  else if (/profile/.test(lower)) page_type = 'profile';
+  else if (/onboard/.test(lower)) page_type = 'onboarding';
+  else {
+    // Slugify: lowercase, replace non-alphanumeric runs with hyphens, trim
+    page_type = lower.replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'screen';
+  }
+
+  return { surface, page_type };
+}
+
+/**
+ * Synthesize a minimal, well-formed ASCII skeleton from key_components.
+ * Used when ascii_layout is absent or empty — never overrides a real layout.
+ * Pure function — SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B.
+ *
+ * @param {{ key_components?: string[], name?: string }} screen
+ * @returns {string[]} Array of ASCII lines (≥5 lines)
+ */
+export function fallbackAsciiLayout(screen) {
+  const components = Array.isArray(screen?.key_components) && screen.key_components.length > 0
+    ? screen.key_components
+    : ['Content area'];
+  const name = String(screen?.name ?? 'Screen').substring(0, 30);
+
+  const lines = [
+    '+' + '-'.repeat(48) + '+',
+    `|  ${name.padEnd(46)}|`,
+    '+' + '='.repeat(48) + '+',
+  ];
+
+  for (const comp of components) {
+    const label = String(comp).substring(0, 42);
+    lines.push(`|  [ ${label.padEnd(42)} ]  |`);
+    lines.push('|' + ' '.repeat(48) + '|');
+  }
+
+  // Ensure ≥5 lines total
+  while (lines.length < 5) {
+    lines.push('|' + ' '.repeat(48) + '|');
+  }
+  lines.push('+' + '-'.repeat(48) + '+');
+
+  return lines;
+}
 
 /**
  * Derive a category from brand genome archetype for service lookups.
@@ -570,29 +658,49 @@ Output ONLY valid JSON.`;
 
   // Normalize each screen — ensure enrichment fields are always populated
   // SD-S15-WIREFRAME-BESTPRACTICE-ORCH-001-B: enforce error_state, empty_state, responsive_notes
-  screens = screens.map((s, i) => ({
-    name: String(s.name || `Screen ${i + 1}`).substring(0, 200),
-    purpose: String(s.purpose || 'General purpose screen').substring(0, 500),
-    persona: String(s.persona || personaNames[0] || 'General User').substring(0, 200),
-    ascii_layout: Array.isArray(s.ascii_layout)
-      ? s.ascii_layout.map(line => String(line).substring(0, 200))
-      : String(s.ascii_layout || '').split('\n').map(line => line.substring(0, 200)),
-    key_components: Array.isArray(s.key_components)
-      ? s.key_components.map(c => String(c).substring(0, 200))
-      : ['Content area'],
-    interaction_notes: String(s.interaction_notes || '').substring(0, 500),
-    error_state: String(s.error_state || 'Display error message with retry option').substring(0, 500),
-    empty_state: String(s.empty_state || 'Show onboarding prompt or placeholder content').substring(0, 500),
-    responsive_notes: String(s.responsive_notes || 'Stack vertically on mobile, 2-col on tablet, full layout on desktop').substring(0, 500),
-    micro_animations: s.micro_animations && typeof s.micro_animations === 'object'
-      ? {
-          entry_transition: String(s.micro_animations.entry_transition || '').substring(0, 200),
-          hover_states: String(s.micro_animations.hover_states || '').substring(0, 200),
-          loading_animation: String(s.micro_animations.loading_animation || '').substring(0, 200),
-          cta_effects: String(s.micro_animations.cta_effects || '').substring(0, 200),
-        }
-      : null,
-  }));
+  // SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: ascii_layout fallback + surface/page_type
+  screens = screens.map((s, i) => {
+    // ── ascii_layout normalization (correctness fix — flag-independent) ──────
+    let resolvedLayout;
+    if (Array.isArray(s.ascii_layout)) {
+      const mapped = s.ascii_layout.map(line => String(line).substring(0, 200));
+      // Empty/whitespace-only — use fallback
+      const hasContent = mapped.some(line => line.trim().length > 0);
+      resolvedLayout = hasContent ? mapped : fallbackAsciiLayout(s);
+    } else {
+      const raw = String(s.ascii_layout || '');
+      const lines = raw.split('\n').map(line => line.substring(0, 200));
+      const hasContent = lines.some(line => line.trim().length > 0);
+      resolvedLayout = hasContent ? lines : fallbackAsciiLayout(s);
+    }
+
+    // ── Surface / page_type tagging (flag-gated) ──────────────────────────────
+    // Re-read env per call so test stubs (vi.stubEnv) take effect.
+    const surfaceFields = process.env.EVA_SURFACE_AWARE_ENABLED === 'true' ? classifySurface(s) : {};
+
+    return {
+      name: String(s.name || `Screen ${i + 1}`).substring(0, 200),
+      purpose: String(s.purpose || 'General purpose screen').substring(0, 500),
+      persona: String(s.persona || personaNames[0] || 'General User').substring(0, 200),
+      ascii_layout: resolvedLayout,
+      key_components: Array.isArray(s.key_components)
+        ? s.key_components.map(c => String(c).substring(0, 200))
+        : ['Content area'],
+      interaction_notes: String(s.interaction_notes || '').substring(0, 500),
+      error_state: String(s.error_state || 'Display error message with retry option').substring(0, 500),
+      empty_state: String(s.empty_state || 'Show onboarding prompt or placeholder content').substring(0, 500),
+      responsive_notes: String(s.responsive_notes || 'Stack vertically on mobile, 2-col on tablet, full layout on desktop').substring(0, 500),
+      micro_animations: s.micro_animations && typeof s.micro_animations === 'object'
+        ? {
+            entry_transition: String(s.micro_animations.entry_transition || '').substring(0, 200),
+            hover_states: String(s.micro_animations.hover_states || '').substring(0, 200),
+            loading_animation: String(s.micro_animations.loading_animation || '').substring(0, 200),
+            cta_effects: String(s.micro_animations.cta_effects || '').substring(0, 200),
+          }
+        : null,
+      ...surfaceFields,
+    };
+  });
 
   // ── Normalize navigation flows ─────────────────────────────────
   let navigationFlows = Array.isArray(parsed.navigation_flows) ? parsed.navigation_flows : [];
@@ -711,4 +819,6 @@ export {
   buildExternalContext,
   buildUserStoryContext,
   buildIASitemapContext,
+  // SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B
+  SURFACE_AWARE_ENABLED,
 };

--- a/tests/unit/stage-15-surface-aware.test.js
+++ b/tests/unit/stage-15-surface-aware.test.js
@@ -1,0 +1,583 @@
+/**
+ * Invariant tests for SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B
+ *
+ * Tests:
+ *   1. classifySurface() — pure helper, no LLM
+ *   2. fallbackAsciiLayout() — pure helper, no LLM
+ *   3. Flag-ON: every screen gets surface + page_type; at least one marketing screen per archetype
+ *   4. Flag-OFF parity: screens must NOT carry surface/page_type
+ *   5. Negative invariant: a screen that should be marketing IS classified marketing
+ *
+ * All tests are deterministic and offline (no LLM calls, no live DB).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock LLM client (no network calls) ──────────────────────────────
+const mockComplete = vi.fn();
+vi.mock('../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({ complete: mockComplete })),
+}));
+
+// ── Mock parse-json utils ────────────────────────────────────────────
+vi.mock('../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: vi.fn((response) => {
+    if (typeof response === 'object' && response !== null && response._parsed) {
+      return response._parsed;
+    }
+    return response;
+  }),
+  extractUsage: vi.fn(() => ({ input_tokens: 10, output_tokens: 20 })),
+}));
+
+// ── Mock sanitize-for-prompt ─────────────────────────────────────────
+vi.mock('../../lib/eva/utils/sanitize-for-prompt.js', () => ({
+  sanitizeForPrompt: vi.fn((text) => text || ''),
+}));
+
+// ── Mock design-reference-library (offline) ─────────────────────────
+vi.mock('../../lib/eva/services/design-reference-library.js', () => ({
+  getDesignReferencesByArchetype: vi.fn().mockResolvedValue([]),
+}));
+
+// ── Import module under test AFTER mocks ────────────────────────────
+import {
+  classifySurface,
+  fallbackAsciiLayout,
+  analyzeStage15WireframeGenerator,
+  MIN_SCREENS,
+} from '../../lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const silentLogger = {
+  log: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+};
+
+/** Minimal valid stage10 data shared across archetype fixtures */
+function makeStage10(overrides = {}) {
+  return {
+    customerPersonas: [
+      { name: 'Founder', goals: ['Launch fast'], painPoints: ['Too much noise'], behaviors: ['Iterates quickly'] },
+    ],
+    brandGenome: {
+      archetype: overrides.archetype ?? 'Creator',
+      values: ['Quality'],
+      tone: 'Direct',
+      audience: overrides.audience ?? 'Startup founders',
+      differentiators: ['Speed'],
+    },
+  };
+}
+
+/**
+ * Build a minimal LLM response for a given archetype's screen list.
+ * All ascii_layout entries are well-formed arrays.
+ */
+function buildLLMResponse(screens) {
+  return {
+    screens,
+    navigation_flows: [
+      { name: 'Main Flow', steps: screens.slice(0, 2).map(s => s.name), persona: 'Founder', description: 'Core path' },
+    ],
+    persona_coverage: {
+      Founder: { primary_screens: [screens[0].name], secondary_screens: [], coverage_score: 80 },
+    },
+    design_rationale: {
+      brand_alignment: 'Clean',
+      tech_feasibility: 'Aligned',
+      ux_patterns_used: [],
+    },
+  };
+}
+
+function makeScreen(name, extra = {}) {
+  return {
+    name,
+    purpose: `Purpose of ${name}`,
+    persona: 'Founder',
+    ascii_layout: [
+      '+--------------------------------+',
+      `| ${name.substring(0, 30).padEnd(30)} |`,
+      '+--------------------------------+',
+      '| [ Primary Action ]             |',
+      '+--------------------------------+',
+    ],
+    key_components: ['Header', 'Content area'],
+    interaction_notes: 'Interact here',
+    error_state: 'Error fallback',
+    empty_state: 'Empty fallback',
+    responsive_notes: 'Stack on mobile',
+    ...extra,
+  };
+}
+
+// ── Three archetype screen fixtures ──────────────────────────────────
+
+/** SaaS archetype: marketing landing + auth + app screens */
+const SAAS_SCREENS = [
+  makeScreen('Landing Page'),
+  makeScreen('Sign Up'),
+  makeScreen('Dashboard'),
+  makeScreen('Settings'),
+  makeScreen('Pricing'),
+];
+
+/** Marketplace archetype: marketing home + auth + app screens */
+const MARKETPLACE_SCREENS = [
+  makeScreen('Home Page'),
+  makeScreen('Register'),
+  makeScreen('Browse Listings'),
+  makeScreen('Seller Dashboard'),
+  makeScreen('Account Profile'),
+];
+
+/** Content archetype: marketing features + auth + app screens */
+const CONTENT_SCREENS = [
+  makeScreen('Marketing Page'),
+  makeScreen('Log In'),
+  makeScreen('Article Feed'),
+  makeScreen('User Profile'),
+  makeScreen('Subscriptions'),
+];
+
+// ════════════════════════════════════════════════════════════════════
+// 1. classifySurface — pure unit tests
+// ════════════════════════════════════════════════════════════════════
+
+describe('classifySurface — pure helper', () => {
+  it('classifies "Landing Page" as marketing', () => {
+    const result = classifySurface({ name: 'Landing Page' });
+    expect(result.surface).toBe('marketing');
+    expect(result.page_type).toBe('landing');
+  });
+
+  it('classifies "Home Page" as marketing', () => {
+    const result = classifySurface({ name: 'Home Page' });
+    expect(result.surface).toBe('marketing');
+    expect(result.page_type).toBe('home');
+  });
+
+  it('classifies "Pricing" as marketing', () => {
+    const result = classifySurface({ name: 'Pricing' });
+    expect(result.surface).toBe('marketing');
+    expect(result.page_type).toBe('pricing');
+  });
+
+  it('classifies "Features" as marketing', () => {
+    const result = classifySurface({ name: 'Features' });
+    expect(result.surface).toBe('marketing');
+    expect(result.page_type).toBe('features');
+  });
+
+  it('classifies "Marketing Page" as marketing', () => {
+    const result = classifySurface({ name: 'Marketing Page' });
+    expect(result.surface).toBe('marketing');
+  });
+
+  it('classifies "Sign Up" as auth', () => {
+    const result = classifySurface({ name: 'Sign Up' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('signup');
+  });
+
+  it('classifies "Sign In" as auth', () => {
+    const result = classifySurface({ name: 'Sign In' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('login');
+  });
+
+  it('classifies "Log In" as auth', () => {
+    const result = classifySurface({ name: 'Log In' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('login');
+  });
+
+  it('classifies "Register" as auth', () => {
+    const result = classifySurface({ name: 'Register' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('signup');
+  });
+
+  it('classifies "Forgot Password" as auth', () => {
+    const result = classifySurface({ name: 'Forgot Password' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('password-reset');
+  });
+
+  it('classifies "Reset Password" as auth', () => {
+    const result = classifySurface({ name: 'Reset Password' });
+    expect(result.surface).toBe('auth');
+    expect(result.page_type).toBe('password-reset');
+  });
+
+  it('classifies "Dashboard" as app', () => {
+    const result = classifySurface({ name: 'Dashboard' });
+    expect(result.surface).toBe('app');
+    expect(result.page_type).toBe('dashboard');
+  });
+
+  it('classifies "Settings" as app', () => {
+    const result = classifySurface({ name: 'Settings' });
+    expect(result.surface).toBe('app');
+    expect(result.page_type).toBe('settings');
+  });
+
+  it('classifies "Profile" as app', () => {
+    const result = classifySurface({ name: 'Profile' });
+    expect(result.surface).toBe('app');
+    expect(result.page_type).toBe('profile');
+  });
+
+  it('classifies "Seller Dashboard" as app', () => {
+    const result = classifySurface({ name: 'Seller Dashboard' });
+    expect(result.surface).toBe('app');
+    expect(result.page_type).toBe('dashboard');
+  });
+
+  it('surface is one of the three canonical values for arbitrary screen names', () => {
+    const names = ['Checkout', 'Order History', 'Support Chat', 'Analytics', 'Notifications'];
+    for (const name of names) {
+      const { surface } = classifySurface({ name });
+      expect(['marketing', 'auth', 'app']).toContain(surface);
+    }
+  });
+
+  it('returns non-empty page_type for any input', () => {
+    const names = ['', undefined, 'Some Weird Screen Name!', 'A'];
+    for (const name of names) {
+      const { page_type } = classifySurface({ name });
+      expect(typeof page_type).toBe('string');
+      expect(page_type.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 2. fallbackAsciiLayout — pure unit tests
+// ════════════════════════════════════════════════════════════════════
+
+describe('fallbackAsciiLayout — pure helper', () => {
+  it('returns an array of strings', () => {
+    const result = fallbackAsciiLayout({ name: 'Dashboard', key_components: ['Chart', 'Button'] });
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.every(line => typeof line === 'string')).toBe(true);
+  });
+
+  it('returns at least 5 lines', () => {
+    const result = fallbackAsciiLayout({ name: 'Test', key_components: ['One'] });
+    expect(result.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('uses screen name in the output', () => {
+    const result = fallbackAsciiLayout({ name: 'My Screen', key_components: ['Widget'] });
+    const joined = result.join('\n');
+    expect(joined).toContain('My Screen');
+  });
+
+  it('includes key_components labels', () => {
+    const result = fallbackAsciiLayout({ name: 'Screen', key_components: ['Nav Bar', 'Hero Image'] });
+    const joined = result.join('\n');
+    expect(joined).toContain('Nav Bar');
+    expect(joined).toContain('Hero Image');
+  });
+
+  it('uses generic placeholder when no key_components', () => {
+    const result = fallbackAsciiLayout({ name: 'Screen' });
+    const joined = result.join('\n');
+    expect(joined).toContain('Content area');
+  });
+
+  it('handles null/undefined gracefully', () => {
+    const result = fallbackAsciiLayout(null);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('uses ASCII box-drawing characters (+, -, |, [ ])', () => {
+    const result = fallbackAsciiLayout({ name: 'X', key_components: ['Y'] });
+    const joined = result.join('');
+    expect(joined).toMatch(/[+\-|]/);
+    expect(joined).toContain('[');
+    expect(joined).toContain(']');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 3. Flag-ON: surface + page_type on every screen, archetype invariants
+// ════════════════════════════════════════════════════════════════════
+
+describe('Flag-ON invariants (EVA_SURFACE_AWARE_ENABLED=true)', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVA_SURFACE_AWARE_ENABLED', 'true');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function runGenerator(screens, stage10Override = {}) {
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(screens) });
+    return analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(stage10Override),
+      logger: silentLogger,
+    });
+  }
+
+  describe('SaaS archetype', () => {
+    it('every screen has surface in {marketing, auth, app}', async () => {
+      const result = await runGenerator(SAAS_SCREENS);
+      for (const screen of result.screens) {
+        expect(['marketing', 'auth', 'app']).toContain(screen.surface);
+      }
+    });
+
+    it('every screen has a non-empty page_type', async () => {
+      const result = await runGenerator(SAAS_SCREENS);
+      for (const screen of result.screens) {
+        expect(typeof screen.page_type).toBe('string');
+        expect(screen.page_type.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('has at least one marketing screen (Landing Page)', async () => {
+      const result = await runGenerator(SAAS_SCREENS);
+      const marketingScreens = result.screens.filter(s => s.surface === 'marketing');
+      expect(marketingScreens.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Landing Page screen is classified as marketing', async () => {
+      const result = await runGenerator(SAAS_SCREENS);
+      const landing = result.screens.find(s => /landing/i.test(s.name));
+      expect(landing).toBeDefined();
+      expect(landing.surface).toBe('marketing');
+      expect(landing.page_type).toBe('landing');
+    });
+
+    it('no screen has an empty/malformed ascii_layout', async () => {
+      const result = await runGenerator(SAAS_SCREENS);
+      for (const screen of result.screens) {
+        expect(Array.isArray(screen.ascii_layout)).toBe(true);
+        const hasContent = screen.ascii_layout.some(line => line.trim().length > 0);
+        expect(hasContent).toBe(true);
+      }
+    });
+  });
+
+  describe('Marketplace archetype', () => {
+    it('every screen has surface in {marketing, auth, app}', async () => {
+      const result = await runGenerator(MARKETPLACE_SCREENS);
+      for (const screen of result.screens) {
+        expect(['marketing', 'auth', 'app']).toContain(screen.surface);
+      }
+    });
+
+    it('has at least one marketing screen (Home Page)', async () => {
+      const result = await runGenerator(MARKETPLACE_SCREENS);
+      const marketingScreens = result.screens.filter(s => s.surface === 'marketing');
+      expect(marketingScreens.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Home Page screen is classified as marketing', async () => {
+      const result = await runGenerator(MARKETPLACE_SCREENS);
+      const home = result.screens.find(s => /home/i.test(s.name));
+      expect(home).toBeDefined();
+      expect(home.surface).toBe('marketing');
+    });
+
+    it('no screen has an empty/malformed ascii_layout', async () => {
+      const result = await runGenerator(MARKETPLACE_SCREENS);
+      for (const screen of result.screens) {
+        expect(Array.isArray(screen.ascii_layout)).toBe(true);
+        const hasContent = screen.ascii_layout.some(line => line.trim().length > 0);
+        expect(hasContent).toBe(true);
+      }
+    });
+  });
+
+  describe('Content archetype', () => {
+    it('every screen has surface in {marketing, auth, app}', async () => {
+      const result = await runGenerator(CONTENT_SCREENS);
+      for (const screen of result.screens) {
+        expect(['marketing', 'auth', 'app']).toContain(screen.surface);
+      }
+    });
+
+    it('has at least one marketing screen (Marketing Page)', async () => {
+      const result = await runGenerator(CONTENT_SCREENS);
+      const marketingScreens = result.screens.filter(s => s.surface === 'marketing');
+      expect(marketingScreens.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('no screen has an empty/malformed ascii_layout', async () => {
+      const result = await runGenerator(CONTENT_SCREENS);
+      for (const screen of result.screens) {
+        expect(Array.isArray(screen.ascii_layout)).toBe(true);
+        const hasContent = screen.ascii_layout.some(line => line.trim().length > 0);
+        expect(hasContent).toBe(true);
+      }
+    });
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 4. Flag-OFF parity: screens must NOT carry surface/page_type
+// ════════════════════════════════════════════════════════════════════
+
+describe('Flag-OFF parity (EVA_SURFACE_AWARE_ENABLED unset or false)', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVA_SURFACE_AWARE_ENABLED', 'false');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('screens do NOT have a surface field when flag is off', async () => {
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(SAAS_SCREENS) });
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+    for (const screen of result.screens) {
+      expect(screen).not.toHaveProperty('surface');
+    }
+  });
+
+  it('screens do NOT have a page_type field when flag is off', async () => {
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(SAAS_SCREENS) });
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+    for (const screen of result.screens) {
+      expect(screen).not.toHaveProperty('page_type');
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 5. ascii_layout fallback — correctness fix (flag-independent)
+// ════════════════════════════════════════════════════════════════════
+
+describe('ascii_layout fallback (correctness fix, flag-independent)', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVA_SURFACE_AWARE_ENABLED', 'false');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('replaces missing ascii_layout with a well-formed fallback', async () => {
+    const screensWithMissingLayout = [
+      { ...makeScreen('Dashboard'), ascii_layout: undefined },
+      ...SAAS_SCREENS.slice(1),
+    ];
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(screensWithMissingLayout) });
+
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+
+    for (const screen of result.screens) {
+      expect(Array.isArray(screen.ascii_layout)).toBe(true);
+      expect(screen.ascii_layout.length).toBeGreaterThanOrEqual(5);
+      const hasContent = screen.ascii_layout.some(line => line.trim().length > 0);
+      expect(hasContent).toBe(true);
+    }
+  });
+
+  it('replaces empty-string ascii_layout with a well-formed fallback', async () => {
+    const screensWithEmptyLayout = [
+      { ...makeScreen('Dashboard'), ascii_layout: '' },
+      ...SAAS_SCREENS.slice(1),
+    ];
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(screensWithEmptyLayout) });
+
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+
+    const dashboard = result.screens.find(s => s.name === 'Dashboard');
+    expect(Array.isArray(dashboard.ascii_layout)).toBe(true);
+    expect(dashboard.ascii_layout.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('replaces whitespace-only array ascii_layout with a well-formed fallback', async () => {
+    const screensWithBlankLayout = [
+      { ...makeScreen('Dashboard'), ascii_layout: ['   ', '  ', ' '] },
+      ...SAAS_SCREENS.slice(1),
+    ];
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(screensWithBlankLayout) });
+
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+
+    const dashboard = result.screens.find(s => s.name === 'Dashboard');
+    expect(Array.isArray(dashboard.ascii_layout)).toBe(true);
+    const hasContent = dashboard.ascii_layout.some(line => line.trim().length > 0);
+    expect(hasContent).toBe(true);
+  });
+
+  it('PRESERVES a real ascii_layout unchanged', async () => {
+    const realLayout = [
+      '+============================+',
+      '|  Real Layout Line 1        |',
+      '|  Real Layout Line 2        |',
+      '|  [ Button ]                |',
+      '+============================+',
+    ];
+    const screensWithRealLayout = [
+      { ...makeScreen('Dashboard'), ascii_layout: realLayout },
+      ...SAAS_SCREENS.slice(1),
+    ];
+    mockComplete.mockResolvedValue({ _parsed: buildLLMResponse(screensWithRealLayout) });
+
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'v-test',
+      stage10Data: makeStage10(),
+      logger: silentLogger,
+    });
+
+    const dashboard = result.screens.find(s => s.name === 'Dashboard');
+    expect(dashboard.ascii_layout).toEqual(realLayout);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 6. Negative invariant: removing tagging WOULD fail the assertion
+// ════════════════════════════════════════════════════════════════════
+
+describe('Negative invariant: surface classification is deterministic', () => {
+  it('classifySurface always returns marketing for Landing Page (cannot be app)', () => {
+    const result = classifySurface({ name: 'Landing Page' });
+    expect(result.surface).not.toBe('app');
+    expect(result.surface).not.toBe('auth');
+    expect(result.surface).toBe('marketing');
+  });
+
+  it('classifySurface always returns auth for Sign Up (cannot be marketing)', () => {
+    const result = classifySurface({ name: 'Sign Up' });
+    expect(result.surface).not.toBe('marketing');
+    expect(result.surface).not.toBe('app');
+    expect(result.surface).toBe('auth');
+  });
+
+  it('classifySurface always returns app for Dashboard (cannot be marketing)', () => {
+    const result = classifySurface({ name: 'Dashboard' });
+    expect(result.surface).not.toBe('marketing');
+    expect(result.surface).not.toBe('auth');
+    expect(result.surface).toBe('app');
+  });
+});


### PR DESCRIPTION
Keystone child of the Surface-Aware Wireframe Generation orchestrator.

## What
- `classifySurface(screen)` → {surface ∈ marketing|auth|app, page_type} + `fallbackAsciiLayout(screen)` in the Stage 15 generator
- Screen normalization attaches surface+page_type when `EVA_SURFACE_AWARE_ENABLED` is on (flag-off byte-parity); ascii_layout fallback synthesizes a skeleton when missing (never overrides a real layout)
- Persist surface alongside page_type (flag-gated)
- Additive + reversible migration: wireframe_screens.surface (CHECK marketing/auth/app) + page_type
- 45 invariant tests across 3 archetype fixtures (SaaS/marketplace/content); 45/45 + 52/52 existing pass

## Why
Replaces the name-only marketing-vs-authenticated distinction with a structural, queryable surface property that Children C/D/E consume.

Migration is additive; feature flag default OFF — apply migration post-merge before flag flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)