### PR TITLE
fix(QF-20260520-358): resolve appPath in PLAN-TO-EXEC/PLAN-TO-LEAD precheck path

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -116,7 +116,13 @@ export class PlanToExecExecutor extends BaseExecutor {
     await this._loadValidators();
 
     const gates = [];
-    const appPath = options._appPath;
+    // QF-20260520-358: the precheck path (HandoffOrchestrator.precheckHandoff) calls
+    // getRequiredGates() WITHOUT running setup(), which is the only place options._appPath
+    // is set. Without this fallback, precheck passes appPath=undefined to the branch/arch
+    // gates -> GitBranchVerifier defaults to EHG_ROOT (often detached HEAD) -> false
+    // "Could not determine current branch" on every SD precheck. determineTargetRepository
+    // is a pure resolver, so calling it here mirrors execute() with no side effects.
+    const appPath = options._appPath || this.determineTargetRepository(sd);
     const parentOrchestrator = options._isParentOrchestrator;
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -228,7 +228,10 @@ export class PlanToLeadExecutor extends BaseExecutor {
 
   getRequiredGates(sd, options) {
     const gates = [];
-    const appPath = options._appPath;
+    // QF-20260520-358: same precheck/execute divergence as plan-to-exec — precheckHandoff()
+    // calls getRequiredGates() without setup(), so options._appPath is undefined and the git
+    // commit enforcement gate (below) defaults to EHG_ROOT. Fall back to the pure resolver.
+    const appPath = options._appPath || this.determineTargetRepository(sd);
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
     // Ensures CLAUDE_CORE.md AND CLAUDE_LEAD.md (destination phase) are read before handoff

--- a/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
+++ b/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
@@ -1,0 +1,62 @@
+/**
+ * QF-20260520-358 — PLAN-TO-EXEC / PLAN-TO-LEAD precheck _appPath fallback.
+ *
+ * Root cause: HandoffOrchestrator.precheckHandoff() calls executor.getRequiredGates()
+ * WITHOUT first running setup(), but setup() is the only place options._appPath is set.
+ * So in the precheck path appPath was undefined and the branch / git-commit enforcement
+ * gates defaulted to EHG_ROOT (often detached HEAD) -> false "Could not determine current
+ * branch" on every SD precheck regardless of target_application.
+ *
+ * Fix: getRequiredGates falls back to `options._appPath || this.determineTargetRepository(sd)`
+ * in both executors, so precheck resolves the SD's target repo identically to execute().
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PlanToExecExecutor } from '../../../../scripts/modules/handoff/executors/plan-to-exec/index.js';
+import { PlanToLeadExecutor } from '../../../../scripts/modules/handoff/executors/plan-to-lead/index.js';
+
+const fakeSupabase = {
+  from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: () => ({}) }) }) }) }) }),
+};
+
+// Parent orchestrator (plan-to-exec) / orchestrator child (plan-to-lead) take the lighter
+// gate sets — the appPath fallback at the top of getRequiredGates fires for ALL paths, so
+// the lighter set is sufficient to exercise the fix with minimal gate-factory surface.
+const SD_EXEC = {
+  id: 'SD-QF-358-TEST', sd_key: 'SD-QF-358-TEST', sd_type: 'infrastructure',
+  target_application: 'EHG_Engineer', title: 'precheck appPath fallback test', metadata: {},
+};
+const SD_LEAD = { ...SD_EXEC, parent_sd_id: 'SD-PARENT-XYZ', metadata: { parent_orchestrator: 'SD-PARENT-XYZ' } };
+
+describe('QF-20260520-358: precheck _appPath fallback (plan-to-exec)', () => {
+  it('resolves appPath via determineTargetRepository when options._appPath is absent (precheck path)', async () => {
+    const ex = new PlanToExecExecutor({ supabase: fakeSupabase });
+    vi.spyOn(ex, '_loadValidators').mockResolvedValue();
+    const spy = vi.spyOn(ex, 'determineTargetRepository').mockReturnValue('/sentinel/repo');
+    await ex.getRequiredGates(SD_EXEC, { _isParentOrchestrator: true });
+    expect(spy).toHaveBeenCalledWith(SD_EXEC);
+  });
+
+  it('uses the provided options._appPath without calling the resolver (execute path)', async () => {
+    const ex = new PlanToExecExecutor({ supabase: fakeSupabase });
+    vi.spyOn(ex, '_loadValidators').mockResolvedValue();
+    const spy = vi.spyOn(ex, 'determineTargetRepository').mockReturnValue('/sentinel/repo');
+    await ex.getRequiredGates(SD_EXEC, { _appPath: '/already/set', _isParentOrchestrator: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('QF-20260520-358: precheck _appPath fallback (plan-to-lead)', () => {
+  it('resolves appPath via determineTargetRepository when options._appPath is absent', () => {
+    const ex = new PlanToLeadExecutor({ supabase: fakeSupabase });
+    const spy = vi.spyOn(ex, 'determineTargetRepository').mockReturnValue('/sentinel/repo');
+    ex.getRequiredGates(SD_LEAD, {});
+    expect(spy).toHaveBeenCalledWith(SD_LEAD);
+  });
+
+  it('uses the provided options._appPath without calling the resolver', () => {
+    const ex = new PlanToLeadExecutor({ supabase: fakeSupabase });
+    const spy = vi.spyOn(ex, 'determineTargetRepository').mockReturnValue('/sentinel/repo');
+    ex.getRequiredGates(SD_LEAD, { _appPath: '/already/set' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes harness_backlog `bd9f39e8`. `HandoffOrchestrator.precheckHandoff()` calls `executor.getRequiredGates()` **without** running `setup()` first, but `setup()` is the only place `options._appPath` is set. So precheck passed `appPath=undefined` to the branch / git-commit enforcement gates → `GitBranchVerifier` defaulted to `EHG_ROOT` (often detached HEAD) → false **"Could not determine current branch"** on **every SD precheck** regardless of `target_application`. `execute()` worked only because it runs `setup()`.

**Fix:** `getRequiredGates` falls back to `options._appPath || this.determineTargetRepository(sd)` in **both** `PlanToExecExecutor` (`:119`) and `PlanToLeadExecutor` (`:231`) — same defect class. `determineTargetRepository` is a pure resolver (reads `sd.target_application`/category/id, returns a path), so this mirrors `execute()` with no side effects. Purely additive: when `_appPath` is set, `||` short-circuits and behavior is unchanged.

## Test plan
- [x] New `tests/unit/handoff/executors/precheck-apppath-fallback.test.js` (4 cases): fallback fires when `_appPath` absent (precheck) for both executors; provided `_appPath` short-circuits the resolver (execute)
- [x] `npx vitest run tests/unit/handoff/executors/` → **51/51 pass** (no regression)
- [x] Source diff +11/−2 (logic is 2 lines; rest comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)