### PR TITLE
fix(SD-FDBK-GEN-FIX-TRG-ENFORCE-001): guard enforce_parent_orchestrator_type against corrected parents

### DIFF
--- a/database/migrations/20260520_fix_enforce_parent_orchestrator_type_corrected_parent_guard.sql
+++ b/database/migrations/20260520_fix_enforce_parent_orchestrator_type_corrected_parent_guard.sql
@@ -1,0 +1,86 @@
+-- Migration: guard enforce_parent_orchestrator_type() against deliberately-corrected parents
+-- SD-FDBK-GEN-FIX-TRG-ENFORCE-001 (closes harness_backlog 954df6ff)
+--
+-- PROBLEM
+--   trg_enforce_parent_orchestrator_type fires AFTER UPDATE OF parent_sd_id on a CHILD and
+--   issues a nested UPDATE forcing the PARENT to sd_type='orchestrator'. When the parent was
+--   deliberately corrected away from 'orchestrator' (recorded in
+--   governance_metadata.type_change_history), that nested UPDATE re-enters the parent's
+--   BEFORE-UPDATE governance chain and is hard-blocked by detect_type_change_gaming()
+--   (feature->orchestrator is an 85->70 threshold drop and the stored correction reason often
+--   contains 'avoid'). Net effect: setting parent_sd_id on a child fails. RCA empirically
+--   reproduced (rollback-only); 3 live SDs affected.
+--
+-- FIX (additive, Option B)
+--   Add a guard so the cascade does NOT re-promote a parent that carries a type_change_history
+--   entry with from='orchestrator'. This fixes the semantic defect at root (don't silently
+--   re-promote a corrected parent on child attach) and leaves the five anti-gaming governance
+--   triggers entirely untouched. The predicate only SUBTRACTS the parent UPDATE for corrected
+--   parents; for every other parent the UPDATE proceeds exactly as before, so recursion is
+--   strictly reduced and the 3 currently-blocked SDs auto-unblock with zero row mutation.
+--
+-- DATA CONTRACT
+--   governance_metadata.type_change_history is a top-level JSONB ARRAY of
+--   {from, to, reason, changed_at} (written by enforce_sd_type_change_explanation). The
+--   jsonb_typeof(...) = 'array' guard defends against a future object-shaped writer so
+--   jsonb_array_elements never raises SQLSTATE 22023.
+--
+-- SAFETY: CREATE OR REPLACE only — no DROP, idempotent, re-runnable. Rollback block below.
+
+CREATE OR REPLACE FUNCTION public.enforce_parent_orchestrator_type()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF NEW.parent_sd_id IS NOT NULL THEN
+    UPDATE strategic_directives_v2 AS p
+    SET
+      sd_type = 'orchestrator',
+      updated_at = NOW()
+    WHERE p.id = NEW.parent_sd_id
+      AND p.sd_type != 'orchestrator'
+      -- 4e2b5fa2: skip auto-promotion when the parent has already terminated.
+      -- Avoids the enforce_type_change_timing block on completed parents and
+      -- unblocks follow-up SD filing (CAPAs, regression children, etc.).
+      AND p.status NOT IN ('completed', 'archived', 'cancelled')
+      -- SD-FDBK-GEN-FIX-TRG-ENFORCE-001 (954df6ff): do NOT re-promote a parent that was
+      -- deliberately corrected away from 'orchestrator'. Re-promoting would silently undo a
+      -- governance decision and re-enter the parent's gaming-detection chain, hard-blocking
+      -- the child's parent_sd_id write. type_change_history is a JSONB array; the jsonb_typeof
+      -- guard keeps jsonb_array_elements from raising 22023 on a non-array value.
+      AND NOT EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(
+          CASE
+            WHEN jsonb_typeof(p.governance_metadata -> 'type_change_history') = 'array'
+              THEN p.governance_metadata -> 'type_change_history'
+            ELSE '[]'::jsonb
+          END
+        ) AS h
+        WHERE h ->> 'from' = 'orchestrator'
+      );
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================================
+-- ROLLBACK (re-apply the prior function body verbatim; no DROP needed)
+-- ============================================================================
+-- CREATE OR REPLACE FUNCTION public.enforce_parent_orchestrator_type()
+--  RETURNS trigger
+--  LANGUAGE plpgsql
+-- AS $function$
+-- BEGIN
+--   IF NEW.parent_sd_id IS NOT NULL THEN
+--     UPDATE strategic_directives_v2
+--     SET
+--       sd_type = 'orchestrator',
+--       updated_at = NOW()
+--     WHERE id = NEW.parent_sd_id
+--       AND sd_type != 'orchestrator'
+--       AND status NOT IN ('completed', 'archived', 'cancelled');
+--   END IF;
+--   RETURN NEW;
+-- END;
+-- $function$;

--- a/tests/integration/enforce-parent-orchestrator-corrected-guard.test.js
+++ b/tests/integration/enforce-parent-orchestrator-corrected-guard.test.js
@@ -1,0 +1,79 @@
+/**
+ * Regression test for SD-FDBK-GEN-FIX-TRG-ENFORCE-001 (closes harness_backlog 954df6ff).
+ *
+ * Locks in the corrected-parent guard added to enforce_parent_orchestrator_type(). The
+ * AFTER-UPDATE-OF-parent_sd_id trigger force-promotes a child's parent to sd_type='orchestrator';
+ * when the parent was deliberately corrected away from 'orchestrator' (recorded in
+ * governance_metadata.type_change_history), that re-promotion re-enters the parent's
+ * BEFORE-UPDATE governance chain and is hard-blocked by detect_type_change_gaming(). The fix
+ * adds a NOT EXISTS guard so a corrected parent is skipped.
+ *
+ * This test validates the EXACT guard predicate (the migration's WHERE clause) against
+ * representative governance_metadata values via read-only SELECTs, plus that
+ * detect_type_change_gaming() is unchanged. The full trigger before/after was independently
+ * reproduced (rollback-only) by the database-agent at LEAD (sub_agent_execution_results 502c4491)
+ * and is re-verified at apply-time.
+ *
+ * Runs against the live linked DB (read-only); skips when no service-role key is available
+ * (e.g. CI without secrets). On Windows the project's .env injection handles DISABLE_SSL_VERIFY.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { createDatabaseClient } from '../../lib/supabase-connection.js';
+
+const HAS_DB = Boolean(
+  (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL) && process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const skipIfNoDb = HAS_DB ? test : test.skip;
+
+// Mirrors the migration guard exactly. $1 = full governance_metadata jsonb (or null).
+// is_exempt=true means "a from='orchestrator' entry exists" => the parent UPDATE is suppressed
+// (parent NOT re-promoted). is_exempt=false means the parent auto-promotes as before.
+const GUARD_SQL = `SELECT EXISTS (
+  SELECT 1 FROM jsonb_array_elements(
+    CASE WHEN jsonb_typeof(COALESCE($1::jsonb, '{}'::jsonb) -> 'type_change_history') = 'array'
+         THEN COALESCE($1::jsonb, '{}'::jsonb) -> 'type_change_history' ELSE '[]'::jsonb END
+  ) AS h WHERE h ->> 'from' = 'orchestrator'
+) AS is_exempt`;
+
+let client;
+beforeAll(async () => {
+  if (HAS_DB) client = await createDatabaseClient('engineer', { verify: false });
+});
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+async function isExempt(gm) {
+  const arg = gm === null ? null : JSON.stringify(gm);
+  const r = await client.query(GUARD_SQL, [arg]);
+  return r.rows[0].is_exempt;
+}
+
+describe('enforce_parent_orchestrator_type corrected-parent guard (954df6ff)', () => {
+  skipIfNoDb('class a: corrected parent (single from=orchestrator) is exempt from re-promotion', async () => {
+    expect(await isExempt({ type_change_history: [{ from: 'orchestrator', to: 'feature' }] })).toBe(true);
+  });
+
+  skipIfNoDb("class a': from='orchestrator' anywhere in a multi-element history matches", async () => {
+    expect(await isExempt({ type_change_history: [{ from: 'feature', to: 'feature' }, { from: 'orchestrator', to: 'feature' }] })).toBe(true);
+  });
+
+  skipIfNoDb('class b: uncorrected parent (feature->orchestrator only) is NOT exempt (still auto-promotes)', async () => {
+    expect(await isExempt({ type_change_history: [{ from: 'feature', to: 'orchestrator' }] })).toBe(false);
+  });
+
+  skipIfNoDb('class d: empty / absent / null history is treated as uncorrected', async () => {
+    expect(await isExempt({ type_change_history: [] })).toBe(false);
+    expect(await isExempt({})).toBe(false);
+    expect(await isExempt(null)).toBe(false);
+  });
+
+  skipIfNoDb('class d: a non-array type_change_history is handled without error (no SQLSTATE 22023)', async () => {
+    expect(await isExempt({ type_change_history: { from: 'orchestrator' } })).toBe(false);
+  });
+
+  skipIfNoDb('class c: detect_type_change_gaming() verdict is unchanged for a genuine gaming reason', async () => {
+    const r = await client.query("SELECT detect_type_change_gaming('feature'::text,'infrastructure'::text,'reduce threshold to bypass the gate') AS g");
+    expect(r.rows[0].g).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes harness_backlog `954df6ff`. `trg_enforce_parent_orchestrator_type` (AFTER UPDATE OF `parent_sd_id`) force-promotes a child's parent to `sd_type='orchestrator'`. When the parent was **deliberately corrected away** from orchestrator (recorded in `governance_metadata.type_change_history`), that nested UPDATE re-enters the parent's BEFORE-UPDATE governance chain and is hard-blocked by `detect_type_change_gaming()` (feature→orchestrator = 85→70 threshold drop). Setting `parent_sd_id` on a child then fails — **3 live SDs affected**; interim workaround was the `dependencies` field.

**Fix (additive, Option B):** the nested UPDATE skips parents carrying a `type_change_history` entry `from='orchestrator'`. Fixes the semantic defect at root (don't silently re-promote a corrected parent) and leaves the five anti-gaming governance triggers **untouched**. `jsonb_typeof` guard defends the array contract (no SQLSTATE 22023). `CREATE OR REPLACE`, no DROP, idempotent, embeds a verbatim rollback block.

RCA + design by database-agent (sub_agent_execution_results `502c4491`); Option A (weaken gaming gate) and C (5-trigger session flag) rejected for larger blast radius.

## Test plan
- [x] `tests/integration/enforce-parent-orchestrator-corrected-guard.test.js` (skipIfNoDb; 6 cases: single/multi-element corrected, uncorrected, empty/absent/null, non-array contract defense, `detect_type_change_gaming` unchanged) → **6/6 pass** on live DB
- [x] Full trigger before/after reproduced (rollback-only) by database-agent at LEAD
- [x] Migration is additive / idempotent / no-DROP with a verbatim rollback block

## ⚠️ Apply note
The migration **is not auto-applied by merge**. It must be applied to the prod DB (function replace) as a gated post-merge step, then re-verified (the 3 affected SDs accept `parent_sd_id`; gaming detection unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)