### PR TITLE
fix(QF-20260520-600): register 'database' sd_type in GATE_VISION_SCORE maps

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -44,6 +44,11 @@ export const SD_TYPE_THRESHOLDS = {
   // Tier 2 — standard bar
   infrastructure: 80,
   enhancement:    80,
+  // QF-20260520-600: database (schema/migration) SDs are infra-class. Without this entry
+  // they fell to _default 80 with no dimension narrowing (database absent from
+  // SD_TYPE_ADDRESSABLE_DIMENSIONS too), hard-blocking LEAD-TO-PLAN and forcing a manual
+  // metadata.vision_addressable_dimensions workaround (witnessed SD-FDBK-GEN-FIX-TRG-ENFORCE-001).
+  database:       80,
   // Tier 3 — lower bar
   maintenance:    70,
   protocol:       70,
@@ -83,6 +88,10 @@ export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
   // so EHG_Engineer CLI-first infra SDs score on real dim coverage instead of
   // silently floor-rule-passing. PAT-HF-LEADTOPLAN-1cbfab60 was the standing evidence.
   infrastructure: ['architecture', 'reliability', 'scalability', 'performance', 'security', 'maintainability', 'automation', 'observability', 'cli', 'workflow', 'protocol', 'governance'],
+  // QF-20260520-600: database/migration SDs address schema/data/architecture dimensions, not
+  // the full product vision — narrow like infrastructure so the adjusted threshold reflects
+  // real dim coverage instead of demanding a full-vision score from a migration.
+  database:       ['architecture', 'reliability', 'scalability', 'performance', 'security', 'maintainability', 'data', 'governance', 'compliance', 'observability'],
   enhancement:    null,
   maintenance:    ['reliability', 'maintainability', 'performance', 'security', 'architecture'],
   protocol:       ['process', 'governance', 'compliance', 'documentation', 'automation', 'quality'],

--- a/tests/unit/eva/vision-score-gate.test.js
+++ b/tests/unit/eva/vision-score-gate.test.js
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateVisionScore, SD_TYPE_THRESHOLDS, DIMENSION_WARNING_THRESHOLD } from '../../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
+import { validateVisionScore, SD_TYPE_THRESHOLDS, SD_TYPE_ADDRESSABLE_DIMENSIONS, DIMENSION_WARNING_THRESHOLD } from '../../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
 
 describe('vision-score-gate: validateVisionScore', () => {
   describe('Path 1: no score available', () => {
@@ -117,6 +117,34 @@ describe('vision-score-gate: validateVisionScore', () => {
       expect(result.passed).toBe(true);
       expect(result.score).toBe(100);
       expect(result.warnings).toEqual([]);
+    });
+  });
+
+  // QF-20260520-600: database sd_type must be infra-class, not _default with no narrowing.
+  describe('database sd_type (QF-20260520-600)', () => {
+    it('is registered as a tier-2 (80) threshold with a database-relevant addressable-dims list', () => {
+      expect(SD_TYPE_THRESHOLDS.database).toBe(80);
+      expect(Array.isArray(SD_TYPE_ADDRESSABLE_DIMENSIONS.database)).toBe(true);
+      expect(SD_TYPE_ADDRESSABLE_DIMENSIONS.database.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('passes at the base threshold boundary (score=80) and fails just below (79) when no dimension data', async () => {
+      const at = await validateVisionScore({ sd_key: 'SD-DB', sd_type: 'database', vision_score: 80, vision_score_action: 'minor_sd' }, null);
+      expect(at.passed).toBe(true);
+      const below = await validateVisionScore({ sd_key: 'SD-DB', sd_type: 'database', vision_score: 79, vision_score_action: 'gap_closure_sd' }, null);
+      expect(below.passed).toBe(false);
+    });
+
+    it('narrows the threshold via addressable dims so a partial-coverage database SD is not held to the full bar', async () => {
+      // 3 of 6 dims match the database addressable set -> adjusted threshold = max(80*3/6, 80*0.6) = 48.
+      // Without the database entry in SD_TYPE_ADDRESSABLE_DIMENSIONS, patterns=null -> no narrowing -> bar stays 80 and 50 would fail.
+      const dimension_scores = {
+        architecture_alignment: 70, reliability_posture: 70, security_controls: 70,
+        unrelated_dim_one: 40, unrelated_dim_two: 40, unrelated_dim_three: 40,
+      };
+      const sd = { sd_key: 'SD-DB', sd_type: 'database', vision_score: 50, vision_score_action: 'gap_closure_sd', dimension_scores };
+      const result = await validateVisionScore(sd, null);
+      expect(result.passed).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
`vision-score.js` (the LEAD-TO-PLAN `GATE_VISION_SCORE`) had **no `database` entry** in `SD_TYPE_THRESHOLDS` or `SD_TYPE_ADDRESSABLE_DIMENSIONS`. So database-type SDs fell to `_default 80` with `patterns=null` (all dims addressable → **no narrowing**) and hard-blocked LEAD-TO-PLAN — forcing a manual `metadata.vision_addressable_dimensions` workaround (witnessed on SD-FDBK-GEN-FIX-TRG-ENFORCE-001 this session).

**Fix:** database SDs are infra-class — add `database: 80` (tier-2, like `infrastructure`) and a database-relevant addressable-dims list (architecture/reliability/scalability/performance/security/maintainability/data/governance/compliance/observability), so they auto-narrow to real dimension coverage instead of being held to a full-vision bar.

## Test plan
- [x] `tests/unit/eva/vision-score-gate.test.js` +3 cases (map registration; base-threshold boundary 80/79; **narrowing** case that fails under the old no-narrowing `_default` path and passes with the fix) → **19/19 pass**
- [x] `tests/sd-type-threshold-canonical.test.js` → **2/2 pass** (no regression)
- [x] Source diff +9 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)