### PR TITLE
fix(QF-20260520-436): don't auto-close deferred harness_backlog feedback on SD completion

### DIFF
--- a/scripts/log-harness-bug.js
+++ b/scripts/log-harness-bug.js
@@ -66,6 +66,12 @@ async function main() {
         logged_via: 'log-harness-bug.js',
         source_location: file,
         deferred_from_sd_key: sd,
+        // QF-20260520-436: harness-backlog items are DEFERRED for a future
+        // campaign — the surfacing SD did NOT address them. defer_only=true tells
+        // lead-final-approval autoCloseFeedback NOT to resolve them when that SD
+        // completes (deferred_from_sd_key alone is overloaded: emit-feedback uses
+        // it for bundled-CAPA that the SD *does* resolve).
+        defer_only: true,
       },
     });
 

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -810,12 +810,19 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     //    emit-feedback (SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-2) writes this when a
     //    CAPA item is deferred from a parent SD; without this reader, bundled-CAPA
     //    rows remain status='new' forever after the bundling SD merges.
+    //
+    //    QF-20260520-436: EXCLUDE metadata.defer_only=true. deferred_from_sd_key is
+    //    overloaded — log-harness-bug.js sets it on items merely DEFERRED to a future
+    //    campaign (the surfacing SD did NOT address them), marking them defer_only.
+    //    Auto-closing those silently drops backlog work. Bundled-CAPA rows (emit-feedback
+    //    without defer_only) still auto-close as intended.
     let linkedByDeferredFrom = [];
     if (sdKey) {
       const { data: deferredFeedback, error: deferredError } = await this.supabase
         .from('feedback')
         .select('id')
         .filter('metadata->>deferred_from_sd_key', 'eq', sdKey)
+        .not('metadata->>defer_only', 'eq', 'true')
         .not('status', 'in', terminalStatuses);
 
       if (!deferredError && deferredFeedback) {

--- a/tests/unit/handoff/lead-final-approval-defer-only-exclusion.test.js
+++ b/tests/unit/handoff/lead-final-approval-defer-only-exclusion.test.js
@@ -1,0 +1,51 @@
+/**
+ * Static-pin regression test for QF-20260520-436.
+ *
+ * autoCloseFeedback resolves feedback by metadata.deferred_from_sd_key, but that
+ * key is OVERLOADED: emit-feedback sets it on bundled-CAPA the SD addresses
+ * (auto-close correct), while log-harness-bug.js sets it on items merely DEFERRED
+ * to a future campaign (auto-close WRONG — silently drops backlog work). The fix
+ * marks deferred items metadata.defer_only=true and excludes them from the sweep.
+ *
+ * Pins (matching the QF-20260510-925 dual-anchor convention):
+ *   - the reader (autoCloseFeedback) excludes defer_only=true from the deferred_from query
+ *   - the writer (log-harness-bug.js) stamps defer_only=true
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXECUTOR_PATH = resolve(__dirname, '../../../scripts/modules/handoff/executors/lead-final-approval/index.js');
+const WRITER_PATH = resolve(__dirname, '../../../scripts/log-harness-bug.js');
+
+describe('QF-20260520-436: deferred harness_backlog items are not auto-closed on SD completion', () => {
+  const executorSrc = readFileSync(EXECUTOR_PATH, 'utf8');
+  const writerSrc = readFileSync(WRITER_PATH, 'utf8');
+
+  it('reader: autoCloseFeedback excludes metadata.defer_only=true from the deferred_from sweep', () => {
+    // Scope to the QF-20260510-925 deferred_from block so the exclusion is on the
+    // right query (not a coincidental match elsewhere).
+    const startIdx = executorSrc.indexOf('// 3. QF-20260510-925');
+    expect(startIdx).toBeGreaterThan(-1);
+    const slice = executorSrc.slice(startIdx, startIdx + 1100);
+    // The deferred_from query must carry BOTH the deferred_from filter and the new exclusion.
+    expect(slice).toMatch(/'metadata->>deferred_from_sd_key',\s*'eq',\s*sdKey/);
+    expect(slice).toMatch(/\.not\('metadata->>defer_only',\s*'eq',\s*'true'\)/);
+  });
+
+  it('reader: terminalStatuses exclusion is still preserved (no regression)', () => {
+    const startIdx = executorSrc.indexOf('// 3. QF-20260510-925');
+    const slice = executorSrc.slice(startIdx, startIdx + 1600);
+    expect(slice).toMatch(/\.not\('status',\s*'in',\s*terminalStatuses\)/);
+  });
+
+  it('writer: log-harness-bug.js stamps defer_only=true in feedback metadata', () => {
+    // defer_only rides alongside deferred_from_sd_key in the emitFeedback metadata.
+    const mdIdx = writerSrc.indexOf('deferred_from_sd_key: sd');
+    expect(mdIdx).toBeGreaterThan(-1);
+    const slice = writerSrc.slice(mdIdx, mdIdx + 600);
+    expect(slice).toMatch(/defer_only:\s*true/);
+  });
+});

--- a/tests/unit/handoff/lead-final-approval-deferred-from-feedback.test.js
+++ b/tests/unit/handoff/lead-final-approval-deferred-from-feedback.test.js
@@ -52,13 +52,13 @@ describe('QF-20260510-925: autoCloseFeedback metadata.deferred_from_sd_key chann
     const startIdx = src.indexOf('// 3. QF-20260510-925');
     expect(startIdx).toBeGreaterThan(-1);
     // Match a slice that captures the if-gate immediately following the comment.
-    const slice = src.slice(startIdx, startIdx + 600);
+    const slice = src.slice(startIdx, startIdx + 1000); // widened for QF-20260520-436 defer_only comment+filter
     expect(slice).toMatch(/let\s+linkedByDeferredFrom\s*=\s*\[\];\s*if\s*\(sdKey\)/);
   });
 
   it('terminalStatuses exclusion is preserved on the new query', () => {
     const startIdx = src.indexOf('// 3. QF-20260510-925');
-    const slice = src.slice(startIdx, startIdx + 900);
+    const slice = src.slice(startIdx, startIdx + 1400); // widened for QF-20260520-436 defer_only comment+filter
     expect(slice).toMatch(/\.not\('status',\s*'in',\s*terminalStatuses\)/);
   });
 });


### PR DESCRIPTION
## Summary
`autoCloseFeedback` (lead-final-approval) resolves feedback by `metadata.deferred_from_sd_key` — but that key is **overloaded**: `emit-feedback` sets it on bundled-CAPA the SD *addresses* (auto-close correct), while `log-harness-bug.js` sets it on items merely **deferred** to a future campaign. So deferred harness-backlog items were **silently resolved** when the surfacing SD completed (witnessed this session: SD-ACTIVATE dropped 5 deferred items → feedback `dc2c2928`).

## Fix (Tier-1, +2 source lines)
- `log-harness-bug.js`: stamp `metadata.defer_only=true` on deferred items.
- `lead-final-approval/index.js`: exclude `metadata.defer_only=true` from the `deferred_from_sd_key` sweep (bundled-CAPA without the flag still auto-closes).
- tests: new static-pin for the exclusion + writer flag; widened the QF-20260510-925 pin windows. **8/8 pass** (the broader local suite has ~409 pre-existing failures across 130 files — DB-less dev worktree + stale tests — unrelated to this 2-file change; CI judges in a proper env).
- backfill: `defer_only=true` set on 50 existing open `log-harness-bug` items (protects the current backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)