### PR TITLE
fix(QF-20260521-275): set DISABLE_SSL_VERIFY on migration-readiness probe

### DIFF
--- a/.github/workflows/pre-merge-migration-readiness.yml
+++ b/.github/workflows/pre-merge-migration-readiness.yml
@@ -47,6 +47,16 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # QF-20260521-275 (PAT-CI-DB-TLS-VERIFY-GAP-001): the GitHub-hosted runner's
+          # trust store does not include the Supabase pooler chain, so getSSLConfig()'s
+          # default rejectUnauthorized:true throws "self-signed certificate in
+          # certificate chain" and the probe hard-fails (INFRA_ERROR, exit 2) on every
+          # migration PR even when the migration is correct (e.g. PR #3815). This is
+          # the same TLS-relaxation the sibling DB workflows rely on. DISABLE_SSL_VERIFY
+          # (not NODE_TLS_REJECT_UNAUTHORIZED=0, which pg's explicit per-socket option
+          # overrides) is the lever getSSLConfig() honors. Read-only pg_proc/pg_trigger
+          # introspection from an ephemeral runner to a known host — residual risk accepted.
+          DISABLE_SSL_VERIFY: 'true'
         run: |
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             node scripts/check-migration-readiness.mjs --pr ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem
The **Pre-merge Migration Readiness** workflow (`check-readiness` job) connects to the Supabase pooler via `getSSLConfig()`, which defaults to `rejectUnauthorized:true`. The GitHub-hosted runner's trust store does not include the pooler certificate chain, so the probe threw `self-signed certificate in certificate chain`, emitted `MIGRATION_READINESS_INFRA_ERROR`, and **exited 2 — hard-failing every migration PR** for an infrastructure reason unrelated to migration readiness.

Observed on PR #3815 (`SD-FDBK-GEN-FIX-TRG-ENFORCE-001`): the gate went red even though the migration was correct and shipped to prod. Structurally recurs on every PR touching `database/migrations/*.sql`.

## Root cause
RCA (pattern **PAT-CI-DB-TLS-VERIFY-GAP-001**): the migration-readiness workflow is the lone DB-connecting CI workflow that omits a TLS-relaxation lever. `getSSLConfig()` only relaxes when `DISABLE_SSL_VERIFY=true` (or `SUPABASE_SSL_CA` points to a committed PEM, which the repo does not have).

## Fix
Set `DISABLE_SSL_VERIFY: 'true'` on the probe step.

- **Why not `NODE_TLS_REJECT_UNAUTHORIZED=0`** (what the sibling workflows set): verified live by rca-agent that it does **not** override pg's explicit per-socket `rejectUnauthorized:true`, so it would not fix this code path. The sibling scripts work only because they hardcode `rejectUnauthorized:false` themselves.
- **Why not CA pinning** (`SUPABASE_SSL_CA`): no committed CA PEM exists; pinning adds a rotation liability that would silently re-break this gate. Security-theater for read-only `pg_proc`/`pg_trigger` introspection from an ephemeral runner to a known host.

## Validation
```
# WITHOUT fix
{"outcome":"MIGRATION_READINESS_INFRA_ERROR","error":"self-signed certificate in certificate chain"}
# WITH fix (DISABLE_SSL_VERIFY=true)
{"outcome":"MIGRATION_READINESS_PASS", ...}
```

## Follow-ups (filed, not in this PR)
- Degrade `MIGRATION_READINESS_INFRA_ERROR` from `exit 2` to neutral/warning so a genuine outage doesn't block unrelated migration PRs (needs github-agent confirmation; has a fail-open trade-off).
- Add a workflow-lint preventive asserting every `getSSLConfig`-connecting CI step sets `DISABLE_SSL_VERIFY`.

QF: QF-20260521-275 (Tier 1) · Pattern: PAT-CI-DB-TLS-VERIFY-GAP-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)