### PR TITLE
fix(QF-20260521-494): pre-merge migration-readiness INFRA_ERROR is advisory, not a hard PR failure

### DIFF
--- a/.github/workflows/pre-merge-migration-readiness.yml
+++ b/.github/workflows/pre-merge-migration-readiness.yml
@@ -45,11 +45,35 @@ jobs:
           # Either env var is sufficient — supabase-connection.js skips the
           # password requirement once connectionString is provided.
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # QF-20260521-494 / PAT-CI-DB-TLS-VERIFY-GAP-001 (witness 3): the
+          # pg-direct probe connects to the Supabase pooler, whose CA is not in
+          # the GitHub runner trust store, so strict verification throws
+          # SELF_SIGNED_CERT_IN_CHAIN (INFRA_ERROR) on every PR — the gate has
+          # never once succeeded. This is a READ-ONLY introspection
+          # (pg_proc / pg_trigger) to a known host on an ephemeral runner, so
+          # relaxing verification here is acceptable. Follow-up (Option B):
+          # bundle the Supabase CA + default SUPABASE_SSL_CA in
+          # supabase-connection.js to restore strict verification everywhere.
+          DISABLE_SSL_VERIFY: 'true'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          # QF-20260521-494: INFRA_ERROR (exit 2) means the probe could not run
+          # (DB unreachable / secret missing) — that is environmental, NOT a
+          # readiness verdict. Surface it as a non-blocking warning so it
+          # neither red-Xes the PR (this gate is advisory defense-in-depth) nor
+          # spawns immortal ci_failure feedback rows (auto-resolve-recovered
+          # needs K successful re-runs, which a never-succeeding gate can never
+          # produce). A real divergence/conflict (exit 1) STILL fails the gate.
+          set +e
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             node scripts/check-migration-readiness.mjs --pr ${{ github.event.pull_request.number }}
           else
             node scripts/check-migration-readiness.mjs
           fi
+          code=$?
+          if [ "$code" = "2" ]; then
+            echo "::warning::Pre-merge migration-readiness probe could not run (INFRA_ERROR, exit 2); advisory check skipped — not blocking. See log above."
+            exit 0
+          fi
+          exit "$code"


### PR DESCRIPTION
## Problem
The **Pre-merge Migration Readiness** gate failed on **100% of recent PRs** (8/8, 2026-05-16→05-20) with:
```
[MIGRATION_READINESS_INFRA_ERROR] could not connect to live DB: self-signed certificate in certificate chain
```
The pg-direct probe can't verify the Supabase pooler chain in CI (no CA in the runner trust store). This is `PAT-CI-DB-TLS-VERIFY-GAP-001` (witness 3; same class as QF-20260511-917 on Windows).

`INFRA_ERROR` (exit 2) is **environmental, not a readiness verdict**, yet it:
1. red-X'd every migration PR (the gate is advisory defense-in-depth, but a hard step failure blocks), and
2. spawned `ci_failure` feedback rows that `auto-resolve-recovered.js` can **never** clear — it requires K consecutive *successful* re-runs, and this gate never succeeded once → immortal inbox rows (15 of 28 had to be closed by hand).

## Fix (workflow-only, additive — +24/-0)
- **`DISABLE_SSL_VERIFY: 'true'`** on the read-only probe step so the gate can actually connect and run (introspection of `pg_proc`/`pg_trigger` to a known host on an ephemeral runner).
- **Exit-code translation**: `exit 2` (INFRA_ERROR) → non-blocking `::warning::`; **`exit 1` (real DRIFT/CONFLICT) still fails the gate**. This stops the noise at the source — a non-failing job creates no `ci_failure` row — and is robust to *any* future transient DB issue, not just TLS.

Verified by simulation: `exit 0 → pass`, `exit 1 → fail`, `exit 2 → warn+pass`.

## Follow-up (filed separately)
- **Option B**: bundle the Supabase CA + default `SUPABASE_SSL_CA` in `supabase-connection.js` to restore strict verification everywhere (CI + Windows), removing the need for `DISABLE_SSL_VERIFY`.
- Feedback-pipeline preventives: PR-merged-aware resolution + 0%-success-workflow sweep in `auto-resolve-recovered.js`.

RCA: full 5-whys (connection + pipeline layers) attached to QF-20260521-494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)