### PR TITLE
fix(QF-20260521-729): normalize non-array proven_solutions in issue-knowledge-base

### DIFF
--- a/lib/learning/issue-knowledge-base.js
+++ b/lib/learning/issue-knowledge-base.js
@@ -14,6 +14,35 @@ dotenv.config();
 // module-load doesn't crash vitest collection in CI without secrets.
 const supabase = lazyServiceClient();
 
+/**
+ * Normalize a pattern's proven_solutions JSONB into an array.
+ *
+ * QF-20260521-729 (feedback ca443489): the column is sometimes stored as a
+ * non-array — a JSON-encoded string (double-encoded array) or a foreign-shaped
+ * object like {steps:[...]}. The `!x || x.length === 0` guard does NOT catch
+ * these: an object's `.length` is undefined (=== 0 is false) and a string's
+ * `.length` is its char count (nonzero), so both slip through to `.reduce` /
+ * `.sort` / `.find` and throw "X is not a function". Normalize once: arrays
+ * pass through, JSON-string arrays are parsed back, everything else (objects,
+ * plain strings, null/undefined) becomes []. Observed live: 15 string + 5
+ * object rows of 1208 in issue_patterns crashed search-prior-issues.js.
+ *
+ * @param {*} value - raw proven_solutions value from a pattern row
+ * @returns {Array} always an array (possibly empty)
+ */
+export function toSolutionArray(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
 export class IssueKnowledgeBase {
   constructor() {
     this.minSimilarity = 0.15; // 15% minimum for search results (Jaccard similarity is strict)
@@ -120,14 +149,14 @@ export class IssueKnowledgeBase {
    */
   async getSolution(patternId) {
     const pattern = await this.getPattern(patternId);
+    const solutions = toSolutionArray(pattern?.proven_solutions);
 
-    if (!pattern || !pattern.proven_solutions || pattern.proven_solutions.length === 0) {
+    if (!pattern || solutions.length === 0) {
       return null;
     }
 
     // Return highest success rate solution
-    const solutions = pattern.proven_solutions;
-    solutions.sort((a, b) => (b.success_rate || 0) - (a.success_rate || 0));
+    solutions.sort((a, b) => ((b && b.success_rate) || 0) - ((a && a.success_rate) || 0));
 
     return {
       pattern_id: pattern.pattern_id,
@@ -165,8 +194,9 @@ export class IssueKnowledgeBase {
     const newCount = pattern.occurrence_count + 1;
 
     // Update proven solutions
-    let solutions = pattern.proven_solutions || [];
+    let solutions = toSolutionArray(pattern.proven_solutions);
     const existingSolution = solutions.find(s =>
+      s && typeof s.solution === 'string' &&
       s.solution.toLowerCase() === solution_applied.toLowerCase()
     );
 
@@ -441,14 +471,15 @@ export class IssueKnowledgeBase {
   }
 
   calculateSuccessRate(pattern) {
-    if (!pattern.proven_solutions || pattern.proven_solutions.length === 0) {
+    const solutions = toSolutionArray(pattern?.proven_solutions);
+    if (solutions.length === 0) {
       return 0;
     }
 
-    const totalApplied = pattern.proven_solutions.reduce((sum, s) =>
-      sum + (s.times_applied || 0), 0);
-    const totalSuccessful = pattern.proven_solutions.reduce((sum, s) =>
-      sum + (s.times_successful || 0), 0);
+    const totalApplied = solutions.reduce((sum, s) =>
+      sum + ((s && s.times_applied) || 0), 0);
+    const totalSuccessful = solutions.reduce((sum, s) =>
+      sum + ((s && s.times_successful) || 0), 0);
 
     return totalApplied > 0 ? totalSuccessful / totalApplied : 0;
   }

--- a/tests/unit/issue-knowledge-base-proven-solutions-normalize.test.js
+++ b/tests/unit/issue-knowledge-base-proven-solutions-normalize.test.js
@@ -1,0 +1,116 @@
+/**
+ * QF-20260521-729 (feedback ca443489): issue-knowledge-base.js consumers
+ * (getSolution .sort, recordOccurrence .find, calculateSuccessRate .reduce)
+ * crashed when proven_solutions JSONB was a non-array — a JSON-encoded string
+ * (double-encoded array) or a foreign-shaped object. The `!x || x.length===0`
+ * guard let both through (object .length undefined; string .length nonzero).
+ *
+ * These tests pin the normalizer (toSolutionArray) and assert calculateSuccessRate
+ * no longer throws on the live non-array shapes, plus a static guard that the
+ * three consumer sites route through the normalizer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { toSolutionArray, IssueKnowledgeBase } from '../../lib/learning/issue-knowledge-base.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../');
+
+describe('toSolutionArray — proven_solutions normalization', () => {
+  it('passes a real array through unchanged (identity)', () => {
+    const arr = [{ solution: 'x', times_applied: 2, times_successful: 1 }];
+    expect(toSolutionArray(arr)).toBe(arr);
+  });
+
+  it('parses a double-encoded JSON-string array (15 live string rows)', () => {
+    const raw = JSON.stringify([{ solution: 'do the thing', times_applied: 50, times_successful: 40 }]);
+    const out = toSolutionArray(raw);
+    expect(Array.isArray(out)).toBe(true);
+    expect(out).toHaveLength(1);
+    expect(out[0].times_applied).toBe(50);
+  });
+
+  it('parses a double-encoded JSON array-of-strings', () => {
+    const raw = JSON.stringify(['Add auto-generation step', 'Update gate messages']);
+    expect(toSolutionArray(raw)).toEqual(['Add auto-generation step', 'Update gate messages']);
+  });
+
+  it('returns [] for a foreign-shaped object (5 live object rows, e.g. {steps:[...]})', () => {
+    expect(toSolutionArray({ steps: ['a', 'b'] })).toEqual([]);
+    expect(toSolutionArray({ solutions: ['x'] })).toEqual([]);
+  });
+
+  it('returns [] for a non-JSON plain string, null, undefined, and number', () => {
+    expect(toSolutionArray('needs investigation')).toEqual([]);
+    expect(toSolutionArray(null)).toEqual([]);
+    expect(toSolutionArray(undefined)).toEqual([]);
+    expect(toSolutionArray(42)).toEqual([]);
+  });
+
+  it('returns [] for a JSON-string that decodes to a non-array', () => {
+    expect(toSolutionArray('{"a":1}')).toEqual([]);
+    expect(toSolutionArray('"just a string"')).toEqual([]);
+  });
+});
+
+describe('calculateSuccessRate — no crash on non-array proven_solutions (the reported bug)', () => {
+  const kb = new IssueKnowledgeBase();
+
+  it('object proven_solutions returns 0 instead of throwing "reduce is not a function"', () => {
+    expect(() => kb.calculateSuccessRate({ proven_solutions: { steps: ['a'] } })).not.toThrow();
+    expect(kb.calculateSuccessRate({ proven_solutions: { steps: ['a'] } })).toBe(0);
+  });
+
+  it('plain-string proven_solutions returns 0 instead of throwing', () => {
+    expect(() => kb.calculateSuccessRate({ proven_solutions: 'investigate' })).not.toThrow();
+    expect(kb.calculateSuccessRate({ proven_solutions: 'investigate' })).toBe(0);
+  });
+
+  it('null / undefined / missing proven_solutions returns 0', () => {
+    expect(kb.calculateSuccessRate({ proven_solutions: null })).toBe(0);
+    expect(kb.calculateSuccessRate({})).toBe(0);
+  });
+
+  it('double-encoded JSON-string array is parsed and rate computed', () => {
+    const raw = JSON.stringify([
+      { solution: 'a', times_applied: 4, times_successful: 3 },
+      { solution: 'b', times_applied: 6, times_successful: 3 }
+    ]);
+    // (3+3) successful / (4+6) applied = 0.6
+    expect(kb.calculateSuccessRate({ proven_solutions: raw })).toBeCloseTo(0.6, 5);
+  });
+
+  it('real array still computes correctly (no regression)', () => {
+    const arr = [{ solution: 'a', times_applied: 10, times_successful: 5 }];
+    expect(kb.calculateSuccessRate({ proven_solutions: arr })).toBeCloseTo(0.5, 5);
+  });
+
+  it('array-of-strings (recovered) does not crash and yields 0 applied', () => {
+    expect(() => kb.calculateSuccessRate({ proven_solutions: ['x', 'y'] })).not.toThrow();
+    expect(kb.calculateSuccessRate({ proven_solutions: ['x', 'y'] })).toBe(0);
+  });
+});
+
+describe('static guard — the three consumer sites route through toSolutionArray', () => {
+  const src = readFileSync(
+    resolve(REPO_ROOT, 'lib/learning/issue-knowledge-base.js'),
+    'utf-8'
+  );
+
+  it('exports the toSolutionArray normalizer', () => {
+    expect(src).toMatch(/export function toSolutionArray\(/);
+  });
+
+  it('getSolution, recordOccurrence and calculateSuccessRate all call toSolutionArray', () => {
+    const calls = src.match(/toSolutionArray\(/g) || [];
+    // 1 definition + 3 consumer call sites = 4 occurrences minimum
+    expect(calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('no consumer still calls .reduce/.sort/.find directly on pattern.proven_solutions', () => {
+    expect(src).not.toMatch(/pattern\.proven_solutions\.(reduce|sort|find)\(/);
+  });
+});


### PR DESCRIPTION
## Problem
`search-prior-issues.js` crashes with **`pattern.proven_solutions.reduce is not a function`** (issue-knowledge-base.js:448), plus sibling crashes in `getSolution` (`.sort`) and `recordOccurrence` (`.find`).

The guard `!x || x.length === 0` does not catch a **non-array** `proven_solutions` JSONB value:
- an **object**'s `.length` is `undefined` (`=== 0` is false), and
- a **string**'s `.length` is its char count (nonzero),

so both slip past the guard straight into array methods and throw.

**Live data:** 15 `string` + 5 `object` rows of 1208 in `issue_patterns`. The string rows are double-encoded JSON arrays; the object rows have foreign shapes (`{steps:[...]}`, `{solutions:[...]}`).

## Fix
A single exported `toSolutionArray()` normalizer, applied at all three consumer sites:
- arrays pass through unchanged,
- JSON-string arrays are `JSON.parse`d back (**recovers the 15 string rows' real stats**),
- everything else (objects, plain strings, null/undefined) becomes `[]`.

Consumer predicates hardened against null / non-object entries (e.g. recovered array-of-strings).

## Validation
- **15/15** new unit tests pass (`toSolutionArray` + `calculateSuccessRate` resilience + static guard).
- Existing module consumer test (`tests/regression/empty-fixture-coverage.test.js`) still green.
- **End-to-end on live data:** `getSolution` + `calculateSuccessRate` on all 4 sample non-array `pattern_id`s return without crashing (4/4); `PAT-INTENTIONAL-001`'s true 100% success rate is recovered from its double-encoded string.

Closes feedback `ca443489`. QF-20260521-729 (Tier 1/2; ~40 source LOC, 116 test LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)