### PR TITLE
fix(QF-20260521-389): guard destructive npm ci from wiping the shared node_modules store (harness 95022758)

### DIFF
--- a/lib/__tests__/npm-ci-junction-guard.test.js
+++ b/lib/__tests__/npm-ci-junction-guard.test.js
@@ -1,0 +1,80 @@
+// harness 95022758 / QF-20260521-389: guard that refuses `npm ci` when it would
+// rm -rf the SHARED node_modules store and brick parallel sessions.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { npmCiWouldWipeSharedStore, NPM_CI_RE } = require('../npm-ci-junction-guard.cjs');
+
+// Build an injectable fake fs from a {relPath: kind} spec. kind ∈
+// 'symlink' | 'file' | 'dir'. Absent paths throw ENOENT (like real fs).
+function fakeFs(spec) {
+  const norm = p => p.replace(/\\/g, '/');
+  const get = p => {
+    const key = Object.keys(spec).find(k => norm(p).endsWith(k));
+    return key ? spec[key] : null;
+  };
+  return {
+    lstatSync(p) {
+      const kind = get(p);
+      if (!kind) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+      return {
+        isSymbolicLink: () => kind === 'symlink',
+        isFile: () => kind === 'file',
+        isDirectory: () => kind === 'dir',
+      };
+    },
+    existsSync(p) { return get(p) != null; },
+    readdirSync(p) { return get(p) === 'dir' ? ['qf'] : []; },
+  };
+}
+
+describe('NPM_CI_RE', () => {
+  it('matches real npm ci invocations', () => {
+    expect(NPM_CI_RE.test('npm ci')).toBe(true);
+    expect(NPM_CI_RE.test('npm ci --no-audit')).toBe(true);
+    expect(NPM_CI_RE.test('cd /tmp && npm ci')).toBe(true);
+  });
+  it('does NOT match npm install / npm i / lookalikes', () => {
+    expect(NPM_CI_RE.test('npm install')).toBe(false);
+    expect(NPM_CI_RE.test('npm i')).toBe(false);
+    expect(NPM_CI_RE.test('npm cite something')).toBe(false);
+    expect(NPM_CI_RE.test('npmci')).toBe(false);
+  });
+});
+
+describe('npmCiWouldWipeSharedStore', () => {
+  it('BLOCKS npm ci when node_modules is a junction (rm -rf follows it)', () => {
+    const fs = fakeFs({ '/wt/node_modules': 'symlink' });
+    const r = npmCiWouldWipeSharedStore({ command: 'npm ci', cwd: '/wt', fs });
+    expect(r.wipes).toBe(true);
+    expect(r.reason).toBe('node_modules_is_junction');
+  });
+
+  it('ALLOWS npm ci in an isolated worktree (real node_modules, .git is a file)', () => {
+    const fs = fakeFs({ '/wt/node_modules': 'dir', '/wt/.git': 'file' });
+    const r = npmCiWouldWipeSharedStore({ command: 'npm ci', cwd: '/wt', fs });
+    expect(r.wipes).toBe(false);
+    expect(r.reason).toBe('isolated_worktree');
+  });
+
+  it('BLOCKS npm ci in the main repo root when worktrees are active', () => {
+    const fs = fakeFs({ '/repo/node_modules': 'dir', '/repo/.git': 'dir', '/repo/.worktrees': 'dir' });
+    const r = npmCiWouldWipeSharedStore({ command: 'npm ci', cwd: '/repo', fs });
+    expect(r.wipes).toBe(true);
+    expect(r.reason).toBe('main_root_with_active_worktrees');
+  });
+
+  it('ALLOWS npm ci in the main repo root with no worktrees', () => {
+    const fs = fakeFs({ '/repo/node_modules': 'dir', '/repo/.git': 'dir' });
+    const r = npmCiWouldWipeSharedStore({ command: 'npm ci', cwd: '/repo', fs });
+    expect(r.wipes).toBe(false);
+    expect(r.reason).toBe('no_shared_sharers');
+  });
+
+  it('IGNORES npm install (additive — never wipes)', () => {
+    const fs = fakeFs({ '/wt/node_modules': 'symlink' });
+    const r = npmCiWouldWipeSharedStore({ command: 'npm install --ignore-scripts', cwd: '/wt', fs });
+    expect(r.wipes).toBe(false);
+    expect(r.reason).toBe('not_npm_ci');
+  });
+});

--- a/lib/npm-ci-junction-guard.cjs
+++ b/lib/npm-ci-junction-guard.cjs
@@ -1,0 +1,72 @@
+'use strict';
+/**
+ * npm ci shared-store wipe guard — harness 95022758 / QF-20260521-389.
+ *
+ * `npm ci` runs `rm -rf node_modules` BEFORE installing. In this fleet every
+ * worktree's node_modules is a junction to the single shared store in the main
+ * repo. So `npm ci`:
+ *   - through a junction  → the rm -rf follows the link and wipes the SHARED store
+ *   - in the main repo root while worktrees junction to it → wipes the store
+ *     those worktrees depend on, mid-flight
+ * Either way it bricks every parallel session (the recurring wipe). Root cause
+ * verified 2026-05-21: it is NOT worktree-removal (Node-created junctions report
+ * isSymbolicLink()=true, so the removal unlink-guards fire). The culprit is
+ * ad-hoc destructive `npm ci`; the fleet-safe path uses ADDITIVE `npm install`
+ * under lib/npm-install-lock.cjs.
+ *
+ * This module is pure + fs-injectable so it can be unit-tested without touching
+ * the real filesystem, and so the PreToolUse hook change stays tiny.
+ */
+const path = require('path');
+
+// Matches a real `npm ci` invocation (mirrors ENFORCEMENT 12's NPM_INSTALL_RE
+// boundary style). Does NOT match `npm install`, `npm i`, or `npm cite`.
+const NPM_CI_RE = /(?:^|[\s;&|(])npm\s+ci(?:\s|$)/;
+
+/**
+ * @param {object}   args
+ * @param {string}   args.command          - the Bash command line
+ * @param {string}   [args.cwd]            - working directory the command runs in
+ * @param {object}   [args.fs]             - injectable fs (lstatSync/existsSync/readdirSync)
+ * @returns {{ wipes: boolean, reason: string }}
+ */
+function npmCiWouldWipeSharedStore({ command, cwd, fs: fsMod = require('fs') } = {}) {
+  if (typeof command !== 'string' || !NPM_CI_RE.test(command) || /--help/.test(command)) {
+    return { wipes: false, reason: 'not_npm_ci' };
+  }
+  const base = cwd || process.cwd();
+
+  // Case 1: node_modules is a junction/symlink → rm -rf follows it into the
+  // shared store. Always a wipe.
+  let nmStat = null;
+  try { nmStat = fsMod.lstatSync(path.join(base, 'node_modules')); } catch { /* absent */ }
+  if (nmStat && nmStat.isSymbolicLink()) {
+    return { wipes: true, reason: 'node_modules_is_junction' };
+  }
+
+  // Distinguish the main repo root (`.git` is a DIRECTORY) from a worktree
+  // (`.git` is a FILE pointing at the gitdir).
+  let gitStat = null;
+  try { gitStat = fsMod.lstatSync(path.join(base, '.git')); } catch { /* not a repo root */ }
+
+  // Case 2a: isolated worktree with a REAL node_modules → npm ci only affects
+  // this tree. Safe.
+  if (gitStat && gitStat.isFile()) {
+    return { wipes: false, reason: 'isolated_worktree' };
+  }
+
+  // Case 2b: main repo root with active worktrees junctioning to THIS store →
+  // npm ci here wipes them mid-flight.
+  if (gitStat && gitStat.isDirectory()) {
+    const wtDir = path.join(base, '.worktrees');
+    try {
+      if (fsMod.existsSync(wtDir) && fsMod.readdirSync(wtDir).length > 0) {
+        return { wipes: true, reason: 'main_root_with_active_worktrees' };
+      }
+    } catch { /* unreadable → fall through to safe */ }
+  }
+
+  return { wipes: false, reason: 'no_shared_sharers' };
+}
+
+module.exports = { npmCiWouldWipeSharedStore, NPM_CI_RE };

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -405,7 +405,7 @@ async function createQuickFix(options = {}) {
           symlinkNodeModules(result.path);
         } catch (symlinkErr) {
           console.log(`   ⚠️  node_modules symlink failed: ${symlinkErr.message}`);
-          console.log('   Run npm ci in the worktree if needed.\n');
+          console.log('   Run `npm install --ignore-scripts --no-audit --no-fund` in the worktree if needed (NOT `npm ci` — its rm -rf wipes the shared store; harness 95022758).\n');
         }
 
         const action = result.created ? 'Created' : 'Reusing existing';

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -466,6 +466,33 @@ async function main() {
     }
   }
 
+  // --- ENFORCEMENT 12c: Destructive `npm ci` shared-store wipe guard (harness 95022758) ---
+  // `npm ci` does `rm -rf node_modules` first. Through a worktree junction, or in
+  // the main repo root while worktrees junction to it, that rm -rf wipes the
+  // SHARED store and bricks every parallel session (root cause verified
+  // 2026-05-21: NOT worktree-removal). Redirect to the additive `npm install`.
+  // Same LEO_NPM_INSTALL_GUARD=off escape as ENFORCEMENT 12. Fail-open.
+  if (TOOL_NAME === 'Bash' && process.env.LEO_NPM_INSTALL_GUARD !== 'off') {
+    try {
+      const { npmCiWouldWipeSharedStore } = require('../../lib/npm-ci-junction-guard.cjs');
+      const verdict = npmCiWouldWipeSharedStore({ command: input.command || '', cwd: input.cwd || process.cwd() });
+      if (verdict.wipes) {
+        const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'NPM-CI-SHARED-WIPE', `npm ci would wipe shared node_modules (${verdict.reason})`, 'block', { reason: verdict.reason });
+        process.stderr.write(
+          `NPM CI SHARED-STORE WIPE GUARD (harness 95022758): refusing \`npm ci\`.\n` +
+          `  Reason: ${verdict.reason} — npm ci's \`rm -rf node_modules\` would wipe the SHARED store and brick every parallel session.\n` +
+          `  Use the additive install instead:  npm install --ignore-scripts --no-audit --no-fund\n` +
+          `  Override (single-session only):    LEO_NPM_INSTALL_GUARD=off\n`
+        );
+        await Promise.race([
+          Promise.resolve(auditPromise),
+          new Promise(resolve => setTimeout(resolve, 1000))
+        ]).catch(() => { /* audit never blocks enforcement */ });
+        process.exit(2);
+      }
+    } catch { /* fail-open on any internal error */ }
+  }
+
   // --- ENFORCEMENT 13: Worktree Hygiene Guard (SD-LEO-INFRA-PRE-TOOL-WORKTREE-GUARD-001) ---
   // PreToolUse check on Edit/Write — catches the most common parallel-session
   // failure mode at the moment of first damage:

--- a/scripts/session-worktree.js
+++ b/scripts/session-worktree.js
@@ -214,7 +214,7 @@ async function main() {
         console.log('node_modules linked successfully.');
       } catch (err) {
         console.error(`Warning: Could not link node_modules: ${err.message}`);
-        console.error('You may need to run npm ci inside the worktree.');
+        console.error('You may need to run `npm install --ignore-scripts --no-audit --no-fund` inside the worktree (NOT `npm ci` — its rm -rf wipes the shared store; harness 95022758).');
       }
     }
 


### PR DESCRIPTION
## Problem (harness 95022758, sev=high)
The shared main-repo `node_modules` gets emptied **mid-session**, bricking every parallel Claude Code session. It recurred **twice in one session** today.

## Root cause — verified 2026-05-21 (and it's NOT what everyone assumed)
The long-assumed theory — *"worktree removal follows the node_modules junction and `rm -rf`s main"* — is **disproven**: Node-created junctions report `lstatSync().isSymbolicLink() === true` (verified live), so the existing unlink-first guards (QF-20260512-347 / -446 / -508-102) **do** fire. Worktree removal is exonerated.

The real culprit is a **destructive `npm ci`**, which runs `rm -rf node_modules` *before* installing:
- through a worktree **junction** → the `rm -rf` follows the link into the **shared** store;
- in the **main repo root** while worktrees junction to it → wipes the store they depend on, mid-flight.

A second session "recovering" with `npm ci` then creates a **livelock**. The fleet-safe path (`sd-start.js` + `lib/npm-install-lock.cjs`) correctly uses **additive `npm install`**; ad-hoc `npm ci` is the footgun.

## Fix
- **`lib/npm-ci-junction-guard.cjs`** — pure, fs-injectable `npmCiWouldWipeSharedStore`. Blocks `npm ci` when `node_modules` is a junction, or `cwd` is the main repo root (`.git` is a dir) with active worktrees; **allows** it in an isolated worktree (`.git` is a file + real `node_modules`). Zero false-positives.
- **`pre-tool-enforce.cjs` ENFORCEMENT 12c** — thin, **fail-open** hook block; refuses such `npm ci` (exit 2) and redirects to additive `npm install`. Same `LEO_NPM_INSTALL_GUARD=off` escape as ENFORCEMENT 12.
- **`create-quick-fix.js` / `session-worktree.js`** — fallback hints no longer recommend `npm ci`.

## Verification
- **7/7 unit tests** (`lib/__tests__/npm-ci-junction-guard.test.js`): junction, isolated-worktree, main-with-worktrees, main-without, npm-install, regex boundaries.
- Hook **parses** (`node --check`).
- **E2E**: `npm ci` in main → exit 2 (would've caught this session's own footgun); `npm install` → allowed; guard-off escape → allowed.

## Follow-up (filed)
Durable per-worktree isolation + the corrected root-cause analysis are captured in harness_backlog 95022758. RCA-disproven theory documented to prevent re-investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)