### PR TITLE
SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001: DB schema-object hygiene (dead surface migration, is_parent guard, CONDITIONAL_PASS check)

### DIFF
--- a/database/migrations/20260520_add_surface_columns_to_wireframe_screens.sql
+++ b/database/migrations/20260520_add_surface_columns_to_wireframe_screens.sql
@@ -1,42 +1,65 @@
--- SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B
--- Migration: Add surface + page_type columns to wireframe_screens
+-- SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B (original author)
+-- NEUTRALIZED by SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (D1 — closes feedback 6359dc60), 2026-05-21
 --
--- Makes audience surface a structurally-tracked property of Stage 15 screens.
--- Both columns are nullable (additive) so existing rows are unaffected.
--- surface is constrained to the three canonical values; NULL is allowed for
--- rows written before the feature flag was enabled.
+-- ============================================================================
+-- TOMBSTONE — why this migration is an inert, to_regclass-guarded no-op
+-- ============================================================================
+-- public.wireframe_screens NEVER EXISTED. Audience "surface" is a property stored
+-- inside the venture_artifacts JSONB (artifact_type='wireframe_screens'), NOT a
+-- relational table. The original `ALTER TABLE public.wireframe_screens ADD COLUMN
+-- IF NOT EXISTS ...` guards the COLUMN, not the missing TABLE, so applying it errors
+-- with "relation \"public.wireframe_screens\" does not exist" on any migration runner.
+-- Verified read-only 2026-05-21: to_regclass('public.wireframe_screens') IS NULL.
 --
--- Reversible: DOWN block at the bottom drops both columns.
+-- FIX (additive, ZERO production-data impact): wrap the ALTERs in a to_regclass guard
+-- so the migration is a clean no-op when the table is absent, while remaining
+-- forward-compatible — the ALTERs still run should a real wireframe_screens table ever
+-- be created. No data is mutated. The companion
+-- 20260520_backfill_wireframe_surface_rollback.sql is already fully-commented / inert
+-- and is intentionally left as-is.
+--
+-- The ALTER-without-CREATE migration-readiness lint is intentionally OUT OF SCOPE for
+-- this SD (tracked separately as a QF).
+--
+-- Reversible: revert this file via git; the neutralization changes no DB state.
+-- ============================================================================
 
-BEGIN;
+DO $$
+BEGIN
+  IF to_regclass('public.wireframe_screens') IS NOT NULL THEN
+    -- Forward-compatible branch: only reached if a real wireframe_screens table exists.
+    ALTER TABLE public.wireframe_screens
+      ADD COLUMN IF NOT EXISTS surface TEXT
+        CHECK (surface IN ('marketing', 'auth', 'app'));
 
-ALTER TABLE public.wireframe_screens
-  ADD COLUMN IF NOT EXISTS surface TEXT
-    CHECK (surface IN ('marketing', 'auth', 'app'));
+    ALTER TABLE public.wireframe_screens
+      ADD COLUMN IF NOT EXISTS page_type TEXT;
 
-ALTER TABLE public.wireframe_screens
-  ADD COLUMN IF NOT EXISTS page_type TEXT;
+    COMMENT ON COLUMN public.wireframe_screens.surface IS
+      'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
+      'Audience surface classification. '
+      'marketing = public-facing pages (landing, pricing, features). '
+      'auth = sign-up / sign-in / password-reset flows. '
+      'app = authenticated product screens (dashboard, settings, profile). '
+      'NULL = pre-migration row or flag-off generation.';
 
-COMMENT ON COLUMN public.wireframe_screens.surface IS
-  'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
-  'Audience surface classification. '
-  'marketing = public-facing pages (landing, pricing, features). '
-  'auth = sign-up / sign-in / password-reset flows. '
-  'app = authenticated product screens (dashboard, settings, profile). '
-  'NULL = pre-migration row or flag-off generation.';
-
-COMMENT ON COLUMN public.wireframe_screens.page_type IS
-  'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
-  'Lowercase slug derived from the screen name/role '
-  '(e.g. landing, signup, login, dashboard, settings, profile, pricing, onboarding). '
-  'Populated when EVA_SURFACE_AWARE_ENABLED=true at generation time.';
-
-COMMIT;
+    COMMENT ON COLUMN public.wireframe_screens.page_type IS
+      'SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: '
+      'Lowercase slug derived from the screen name/role '
+      '(e.g. landing, signup, login, dashboard, settings, profile, pricing, onboarding). '
+      'Populated when EVA_SURFACE_AWARE_ENABLED=true at generation time.';
+  ELSE
+    RAISE NOTICE '[SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 D1] public.wireframe_screens does not exist (surface lives in venture_artifacts JSONB). Intentional no-op tombstone — nothing to do.';
+  END IF;
+END $$;
 
 -- =========================================================================
--- ROLLBACK (DOWN) — uncomment to revert.
+-- ROLLBACK (DOWN) — only meaningful if the forward-compatible branch ran.
 -- =========================================================================
--- BEGIN;
---   ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS surface;
---   ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS page_type;
--- COMMIT;
+-- DO $$
+-- BEGIN
+--   IF to_regclass('public.wireframe_screens') IS NOT NULL THEN
+--     ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS surface;
+--     ALTER TABLE public.wireframe_screens DROP COLUMN IF EXISTS page_type;
+--   END IF;
+-- END $$;

--- a/database/migrations/20260521_drop_conditional_pass_retrospective_constraint.sql
+++ b/database/migrations/20260521_drop_conditional_pass_retrospective_constraint.sql
@@ -36,8 +36,12 @@
 -- APPLY-TO-PROD is gated on explicit user go. Do NOT apply automatically.
 -- ============================================================================
 
+BEGIN;
+
 ALTER TABLE public.sub_agent_execution_results
   DROP CONSTRAINT IF EXISTS check_conditional_pass_retrospective;
+
+COMMIT;
 
 -- ============================================================================
 -- ROLLBACK (re-add the retrospective-only restriction) — ONLY safe while there are

--- a/database/migrations/20260521_drop_conditional_pass_retrospective_constraint.sql
+++ b/database/migrations/20260521_drop_conditional_pass_retrospective_constraint.sql
@@ -1,0 +1,48 @@
+-- Migration: SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (D2 — closes feedback 2af121c6)
+-- Drop the over-strict check_conditional_pass_retrospective constraint on
+-- sub_agent_execution_results.
+--
+-- ============================================================================
+-- RCA (completed in LEAD phase; re-verified read-only by DATABASE sub-agent 2026-05-21)
+-- ============================================================================
+-- The constraint was added deliberately by SD-LEO-PROTOCOL-V4-4-0 AC-004
+-- (migration 20251115114444_add_validation_modes_to_sub_agent_results.sql) as:
+--     CHECK ((verdict <> 'CONDITIONAL_PASS') OR (validation_mode = 'retrospective'))
+-- i.e. CONDITIONAL_PASS was permitted ONLY in retrospective mode. In practice this
+-- rejects legitimate PLAN-phase / prospective sub-agent reviews that want to record a
+-- CONDITIONAL_PASS carrying EXEC conditions, forcing a PASS+metadata workaround and
+-- impairing the handoff evidence pipeline (feedback 2af121c6).
+--
+-- DECISION: plain DROP. The sibling guards already enforce evidence quality
+-- INDEPENDENTLY of validation_mode and are PRESERVED:
+--   * check_conditions_required     — CONDITIONAL_PASS => non-empty conditions array
+--   * check_justification_required  — CONDITIONAL_PASS => justification length >= 50
+--   * valid_verdict                 — verdict in the allowed enum
+--   * check_validation_mode_values  — validation_mode in ('prospective','retrospective')
+-- Dropping only the mode restriction lets CONDITIONAL_PASS persist in any valid mode
+-- while the quality bar (conditions + justification) still holds.
+--
+-- LIVE STATE (2026-05-21): 1305+ retrospective + 1 null-mode CONDITIONAL_PASS rows,
+-- 0 prospective. The null-mode row satisfies the surviving sibling guards
+-- (conditions_len=2, justification_len=324) -> zero collateral. No pg_depend objects
+-- reference this constraint -> DROP has no dependents. No existing row is altered.
+--
+-- ⚠️ ONE-WAY DOOR: re-ADDing this constraint will FAIL once any prospective
+-- CONDITIONAL_PASS row exists. Only re-add while zero prospective CONDITIONAL_PASS rows
+-- are present (see rollback below); otherwise a NOT VALID / partial constraint would be
+-- required and is out of scope.
+--
+-- APPLY PATH (Windows direct pg): set DISABLE_SSL_VERIFY=true.
+-- APPLY-TO-PROD is gated on explicit user go. Do NOT apply automatically.
+-- ============================================================================
+
+ALTER TABLE public.sub_agent_execution_results
+  DROP CONSTRAINT IF EXISTS check_conditional_pass_retrospective;
+
+-- ============================================================================
+-- ROLLBACK (re-add the retrospective-only restriction) — ONLY safe while there are
+-- ZERO prospective CONDITIONAL_PASS rows; otherwise this ADD CONSTRAINT will error.
+-- ============================================================================
+-- ALTER TABLE public.sub_agent_execution_results
+--   ADD CONSTRAINT check_conditional_pass_retrospective
+--   CHECK ((verdict <> 'CONDITIONAL_PASS') OR (validation_mode = 'retrospective'));

--- a/database/migrations/20260521_guard_auto_set_is_parent_corrected_parent.sql
+++ b/database/migrations/20260521_guard_auto_set_is_parent_corrected_parent.sql
@@ -1,0 +1,78 @@
+-- Migration: SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (D3 — closes feedback 44b3621b)
+-- Guard auto_set_is_parent() against re-promoting a deliberately-corrected parent.
+--
+-- ============================================================================
+-- FRAMING CORRECTION (the feedback 44b3621b premise was wrong)
+-- ============================================================================
+-- The live auto_set_is_parent() does NOT throw. It writes a metadata JSONB key
+-- (metadata || '{"is_parent": true}') on the parent referenced by NEW.parent_sd_id;
+-- it does NOT reference a non-existent is_parent COLUMN. Verified read-only 2026-05-21.
+--
+-- PROBLEM: once a parent's is_parent is deliberately corrected to false (recorded by the
+-- companion writer scripts/correct-sd-is-parent.mjs into
+-- governance_metadata.is_parent_change_history), the existing trigger silently
+-- re-promotes it to true on the next child parent_sd_id write, because the WHERE clause
+-- only checks metadata->>'is_parent' != 'true' (which a 'false' value satisfies).
+--
+-- FIX (additive — CREATE OR REPLACE, no DROP, idempotent): the nested UPDATE skips a
+-- parent whose MOST-RECENT is_parent_change_history entry has to=false. Mirrors
+-- enforce_parent_orchestrator_type (SD-FDBK-GEN-FIX-TRG-ENFORCE-001 / PR #3815) but uses
+-- MOST-RECENT-WINS semantics (not sticky any-to=false): is_parent legitimately re-flips to
+-- true when a real child re-attaches, so a later genuine correction can re-promote.
+--
+-- VERIFICATION (read-only / rolled-back tx, this DB, 2026-05-21, DATABASE sub-agent):
+--   * Recursion-safe: the nested UPDATE writes only metadata (attnum 31); both
+--     trg_auto_set_is_parent and trg_enforce_parent_orchestrator_type fire only on
+--     UPDATE OF parent_sd_id (attnum 47) -> no re-fire, no infinite loop.
+--   * No governance/gaming-trigger abort: sd_type is untouched.
+--   * Zero collateral: 0 rows currently carry governance_metadata.is_parent_change_history,
+--     so the guard is a pure no-op on existing data until the writer records a correction;
+--     the 25 referenced parents with is_parent != true carry no marker and still auto-set.
+--
+-- APPLY PATH (Windows direct pg): set DISABLE_SSL_VERIFY=true.
+-- APPLY-TO-PROD is gated on explicit user go. Do NOT apply automatically.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.auto_set_is_parent()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF NEW.parent_sd_id IS NOT NULL THEN
+    UPDATE strategic_directives_v2 AS p
+    SET metadata = COALESCE(p.metadata, '{}'::jsonb) || '{"is_parent": true}'::jsonb
+    WHERE p.id = NEW.parent_sd_id
+      AND (p.metadata->>'is_parent' IS NULL OR p.metadata->>'is_parent' != 'true')
+      -- SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001: do NOT re-promote a parent whose
+      -- most-recent deliberate is_parent correction set it to false. Most-recent-wins
+      -- (not sticky) so a later genuine re-parenting can still re-promote.
+      AND COALESCE((
+        SELECT (h.elem->>'to')
+        FROM jsonb_array_elements(
+               COALESCE(p.governance_metadata->'is_parent_change_history', '[]'::jsonb)
+             ) WITH ORDINALITY AS h(elem, ord)
+        ORDER BY (h.elem->>'changed_at') DESC NULLS LAST, h.ord DESC
+        LIMIT 1
+      ), 'true') <> 'false';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================================
+-- ROLLBACK (restore the prior body — no corrected-parent guard):
+-- ============================================================================
+-- CREATE OR REPLACE FUNCTION public.auto_set_is_parent()
+--  RETURNS trigger
+--  LANGUAGE plpgsql
+-- AS $function$
+-- BEGIN
+--   IF NEW.parent_sd_id IS NOT NULL THEN
+--     UPDATE strategic_directives_v2
+--     SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"is_parent": true}'::jsonb
+--     WHERE id = NEW.parent_sd_id
+--       AND (metadata->>'is_parent' IS NULL OR metadata->>'is_parent' != 'true');
+--   END IF;
+--   RETURN NEW;
+-- END;
+-- $function$;

--- a/scripts/correct-sd-is-parent.mjs
+++ b/scripts/correct-sd-is-parent.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * correct-sd-is-parent.mjs — deliberate is_parent correction writer
+ * SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (D3 — closes feedback 44b3621b)
+ *
+ * Records a DELIBERATE correction of a Strategic Directive's metadata.is_parent to
+ * false. This is the PRODUCER half of the guard added to auto_set_is_parent() in
+ * 20260521_guard_auto_set_is_parent_corrected_parent.sql — without this writer the
+ * guard would be a permanent no-op (the writer-consumer asymmetry the SD closes).
+ *
+ * It performs ONE atomic update that:
+ *   1. sets metadata.is_parent = false, and
+ *   2. appends a {from, to:false, reason, changed_at} entry to
+ *      governance_metadata.is_parent_change_history
+ *
+ * The trigger guard reads the MOST-RECENT is_parent_change_history entry; when its
+ * `to` is false, a subsequent child parent_sd_id write will NOT re-promote the parent
+ * to is_parent=true. A later genuine re-parenting can append a {to:true} entry (or the
+ * trigger's normal path runs once the latest entry is not false), so corrections are
+ * reversible by intent rather than sticky.
+ *
+ * Usage:
+ *   node scripts/correct-sd-is-parent.mjs <SD-KEY-or-UUID> --reason "<why>" [--dry-run]
+ *
+ * Mirrors SD-FDBK-GEN-FIX-TRG-ENFORCE-001 (PR #3815). EHG_Engineer / consolidated DB.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseArgs(argv) {
+  const args = { sd: null, reason: null, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--reason') { args.reason = argv[++i]; }
+    else if (a.startsWith('--reason=')) { args.reason = a.slice('--reason='.length); }
+    else if (a === '--dry-run') { args.dryRun = true; }
+    else if (!a.startsWith('--') && !args.sd) { args.sd = a; }
+  }
+  return args;
+}
+
+function isFalseValue(v) {
+  return v === false || v === 'false';
+}
+
+async function main() {
+  const { sd, reason, dryRun } = parseArgs(process.argv.slice(2));
+  if (!sd || !reason) {
+    console.error('Usage: node scripts/correct-sd-is-parent.mjs <SD-KEY-or-UUID> --reason "<why>" [--dry-run]');
+    console.error('Both an SD identifier and a non-empty --reason are required (the reason is recorded in the audit marker).');
+    process.exit(1);
+  }
+  if (reason.trim().length < 10) {
+    console.error('--reason must be a substantive explanation (>= 10 chars); it is persisted in the is_parent_change_history audit trail.');
+    process.exit(1);
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const queryField = UUID_RE.test(sd) ? 'id' : 'sd_key';
+  const { data: row, error: fetchErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, metadata, governance_metadata')
+    .eq(queryField, sd)
+    .maybeSingle();
+
+  if (fetchErr) { console.error('Lookup error:', fetchErr.message); process.exit(1); }
+  if (!row) { console.error(`Strategic Directive not found for ${queryField}=${sd}`); process.exit(1); }
+
+  const metadata = row.metadata || {};
+  const governance = row.governance_metadata || {};
+  const history = Array.isArray(governance.is_parent_change_history)
+    ? governance.is_parent_change_history
+    : [];
+  const latest = history.length ? history[history.length - 1] : null;
+  const currentIsParent = metadata.is_parent;
+
+  // Idempotency: already corrected (is_parent false AND latest marker already to=false).
+  if (isFalseValue(currentIsParent) && latest && isFalseValue(latest.to)) {
+    console.log(`No-op: ${row.sd_key} already has metadata.is_parent=false with a matching is_parent_change_history marker.`);
+    console.log(`  latest marker: ${JSON.stringify(latest)}`);
+    process.exit(0);
+  }
+
+  const changedAt = new Date().toISOString();
+  const entry = {
+    from: currentIsParent === undefined ? null : currentIsParent,
+    to: false,
+    reason: reason.trim(),
+    changed_at: changedAt,
+    changed_by: 'correct-sd-is-parent.mjs'
+  };
+
+  const newMetadata = { ...metadata, is_parent: false };
+  const newGovernance = { ...governance, is_parent_change_history: [...history, entry] };
+
+  console.log(`SD: ${row.sd_key} (${row.id})`);
+  console.log(`  metadata.is_parent: ${JSON.stringify(currentIsParent)} -> false`);
+  console.log(`  appending is_parent_change_history entry: ${JSON.stringify(entry)}`);
+
+  if (dryRun) {
+    console.log('\n--dry-run: no write performed.');
+    process.exit(0);
+  }
+
+  const { error: updateErr } = await supabase
+    .from('strategic_directives_v2')
+    .update({ metadata: newMetadata, governance_metadata: newGovernance })
+    .eq('id', row.id);
+
+  if (updateErr) { console.error('Update error:', updateErr.message); process.exit(1); }
+
+  console.log('\n✅ Correction recorded. auto_set_is_parent() will no longer re-promote this parent on child writes.');
+}
+
+main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });

--- a/scripts/correct-sd-is-parent.mjs
+++ b/scripts/correct-sd-is-parent.mjs
@@ -47,21 +47,26 @@ function isFalseValue(v) {
   return v === false || v === 'false';
 }
 
+// main() RETURNS an exit code rather than calling process.exit(): on Windows, calling
+// process.exit() while the dotenvx preload's uv_async handle (and supabase-js sockets)
+// are still open aborts the process with a libuv UV_HANDLE_CLOSING assertion
+// (exit 0xC0000409). Setting process.exitCode and letting the event loop drain avoids it.
 async function main() {
   const { sd, reason, dryRun } = parseArgs(process.argv.slice(2));
   if (!sd || !reason) {
     console.error('Usage: node scripts/correct-sd-is-parent.mjs <SD-KEY-or-UUID> --reason "<why>" [--dry-run]');
     console.error('Both an SD identifier and a non-empty --reason are required (the reason is recorded in the audit marker).');
-    process.exit(1);
+    return 1;
   }
   if (reason.trim().length < 10) {
     console.error('--reason must be a substantive explanation (>= 10 chars); it is persisted in the is_parent_change_history audit trail.');
-    process.exit(1);
+    return 1;
   }
 
   const supabase = createClient(
     process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SERVICE_ROLE_KEY
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { autoRefreshToken: false, persistSession: false } }
   );
 
   const queryField = UUID_RE.test(sd) ? 'id' : 'sd_key';
@@ -71,8 +76,8 @@ async function main() {
     .eq(queryField, sd)
     .maybeSingle();
 
-  if (fetchErr) { console.error('Lookup error:', fetchErr.message); process.exit(1); }
-  if (!row) { console.error(`Strategic Directive not found for ${queryField}=${sd}`); process.exit(1); }
+  if (fetchErr) { console.error('Lookup error:', fetchErr.message); return 1; }
+  if (!row) { console.error(`Strategic Directive not found for ${queryField}=${sd}`); return 1; }
 
   const metadata = row.metadata || {};
   const governance = row.governance_metadata || {};
@@ -86,15 +91,14 @@ async function main() {
   if (isFalseValue(currentIsParent) && latest && isFalseValue(latest.to)) {
     console.log(`No-op: ${row.sd_key} already has metadata.is_parent=false with a matching is_parent_change_history marker.`);
     console.log(`  latest marker: ${JSON.stringify(latest)}`);
-    process.exit(0);
+    return 0;
   }
 
-  const changedAt = new Date().toISOString();
   const entry = {
     from: currentIsParent === undefined ? null : currentIsParent,
     to: false,
     reason: reason.trim(),
-    changed_at: changedAt,
+    changed_at: new Date().toISOString(),
     changed_by: 'correct-sd-is-parent.mjs'
   };
 
@@ -107,7 +111,7 @@ async function main() {
 
   if (dryRun) {
     console.log('\n--dry-run: no write performed.');
-    process.exit(0);
+    return 0;
   }
 
   const { error: updateErr } = await supabase
@@ -115,9 +119,12 @@ async function main() {
     .update({ metadata: newMetadata, governance_metadata: newGovernance })
     .eq('id', row.id);
 
-  if (updateErr) { console.error('Update error:', updateErr.message); process.exit(1); }
+  if (updateErr) { console.error('Update error:', updateErr.message); return 1; }
 
   console.log('\n✅ Correction recorded. auto_set_is_parent() will no longer re-promote this parent on child writes.');
+  return 0;
 }
 
-main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });
+main()
+  .then((code) => { process.exitCode = code; })
+  .catch((err) => { console.error('Fatal:', err.message); process.exitCode = 1; });

--- a/tests/integration/schema-object-hygiene.test.js
+++ b/tests/integration/schema-object-hygiene.test.js
@@ -1,0 +1,231 @@
+/**
+ * Regression suite for SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001.
+ *
+ * Three additive, backward-compatible DB schema-object hygiene fixes, each closing one
+ * harness-backlog feedback row:
+ *   D1 (feedback 6359dc60) — neutralized wireframe_screens surface migration (to_regclass guard)
+ *   D3 (feedback 44b3621b) — auto_set_is_parent() corrected-parent guard + marker writer
+ *   D2 (feedback 2af121c6) — drop over-strict check_conditional_pass_retrospective
+ *
+ * STRATEGY: each migration is applied INSIDE a transaction that is ROLLED BACK, so the
+ * suite validates the corrected behavior WITHOUT permanently mutating the consolidated
+ * DB (apply-to-prod is gated on explicit user go). Postgres DDL is transactional, so the
+ * CREATE OR REPLACE / DROP CONSTRAINT / DO-block ALTERs all revert on ROLLBACK.
+ *
+ * Skips entirely when no direct-pg credentials are present (SUPABASE_DB_PASSWORD /
+ * EHG_DB_PASSWORD). Run locally with: DISABLE_SSL_VERIFY=true npx vitest run \
+ *   tests/integration/schema-object-hygiene.test.js
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIG = (f) => resolve(__dirname, '../../database/migrations', f);
+
+const D1_SQL = readFileSync(MIG('20260520_add_surface_columns_to_wireframe_screens.sql'), 'utf8');
+const D2_SQL = readFileSync(MIG('20260521_drop_conditional_pass_retrospective_constraint.sql'), 'utf8');
+const D3_SQL = readFileSync(MIG('20260521_guard_auto_set_is_parent_corrected_parent.sql'), 'utf8');
+
+const HAS_DB = Boolean(process.env.SUPABASE_DB_PASSWORD || process.env.EHG_DB_PASSWORD);
+
+let client;
+beforeAll(async () => {
+  if (!HAS_DB) return;
+  client = await createDatabaseClient('engineer', { verify: false });
+});
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+// Run `work` inside a BEGIN/ROLLBACK transaction so nothing persists.
+async function inRolledBackTx(work) {
+  await client.query('BEGIN');
+  try {
+    return await work();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+describe.skipIf(!HAS_DB)('D1 — neutralized wireframe_screens surface migration (feedback 6359dc60)', () => {
+  it('table does not exist; applying the migration is a clean no-op (no error, no table created)', async () => {
+    await inRolledBackTx(async () => {
+      const before = await client.query("SELECT to_regclass('public.wireframe_screens') AS reg");
+      expect(before.rows[0].reg).toBeNull(); // table never existed
+
+      // Should NOT throw "relation does not exist" — the to_regclass guard takes the ELSE branch.
+      await expect(client.query(D1_SQL)).resolves.toBeDefined();
+
+      const after = await client.query("SELECT to_regclass('public.wireframe_screens') AS reg");
+      expect(after.rows[0].reg).toBeNull(); // still no table — pure no-op
+    });
+  });
+
+  it('forward-compatible branch: when the table exists, the guarded ALTERs add surface + page_type', async () => {
+    await inRolledBackTx(async () => {
+      await client.query('CREATE TABLE public.wireframe_screens (id int PRIMARY KEY)');
+      await client.query(D1_SQL);
+      const cols = await client.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'wireframe_screens'
+          AND column_name IN ('surface', 'page_type')
+        ORDER BY column_name
+      `);
+      expect(cols.rows.map(r => r.column_name)).toEqual(['page_type', 'surface']);
+    });
+  });
+});
+
+describe.skipIf(!HAS_DB)('D2 — drop check_conditional_pass_retrospective (feedback 2af121c6)', () => {
+  // sub_agent_execution_results.sd_id FKs to strategic_directives_v2(id) (UUID).
+  const SD_UUID = '207b77d3-1691-45d1-bdec-9f5e000ebc54';
+
+  async function insertCp({ mode, justification, conditions }) {
+    return client.query(
+      `INSERT INTO sub_agent_execution_results
+         (sd_id, sub_agent_code, sub_agent_name, verdict, confidence, validation_mode, justification, conditions)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`,
+      [SD_UUID, 'DATABASE', 'TEST-REGRESSION', 'CONDITIONAL_PASS', 85, mode, justification,
+       conditions == null ? null : JSON.stringify(conditions)]
+    );
+  }
+
+  const GOOD_JUSTIFICATION = 'Prospective PLAN-phase review: CONDITIONAL_PASS carrying EXEC follow-up conditions, justification well over the fifty character minimum.';
+  const GOOD_CONDITIONS = ['Apply migration D2 on user go', 'Add regression test'];
+
+  it('BASELINE: before the drop, a prospective CONDITIONAL_PASS is rejected by check_conditional_pass_retrospective', async () => {
+    await inRolledBackTx(async () => {
+      await expect(
+        insertCp({ mode: 'prospective', justification: GOOD_JUSTIFICATION, conditions: GOOD_CONDITIONS })
+      ).rejects.toThrow(/check_conditional_pass_retrospective/);
+    });
+  });
+
+  it('after the drop, a prospective CONDITIONAL_PASS with valid justification + conditions succeeds', async () => {
+    await inRolledBackTx(async () => {
+      await client.query(D2_SQL);
+      const res = await insertCp({ mode: 'prospective', justification: GOOD_JUSTIFICATION, conditions: GOOD_CONDITIONS });
+      expect(res.rows[0].id).toBeTruthy();
+    });
+  });
+
+  it('after the drop, sibling check_justification_required still rejects a short justification', async () => {
+    await inRolledBackTx(async () => {
+      await client.query(D2_SQL);
+      await expect(
+        insertCp({ mode: 'prospective', justification: 'too short', conditions: GOOD_CONDITIONS })
+      ).rejects.toThrow(/check_justification_required/);
+    });
+  });
+
+  it('after the drop, sibling check_conditions_required still rejects empty conditions', async () => {
+    await inRolledBackTx(async () => {
+      await client.query(D2_SQL);
+      await expect(
+        insertCp({ mode: 'prospective', justification: GOOD_JUSTIFICATION, conditions: [] })
+      ).rejects.toThrow(/check_conditions_required/);
+    });
+  });
+
+  it('existing retrospective CONDITIONAL_PASS rows remain valid after the drop (no destructive change)', async () => {
+    await inRolledBackTx(async () => {
+      const before = await client.query(
+        "SELECT count(*)::int AS n FROM sub_agent_execution_results WHERE verdict='CONDITIONAL_PASS' AND validation_mode='retrospective'"
+      );
+      await client.query(D2_SQL);
+      const after = await client.query(
+        "SELECT count(*)::int AS n FROM sub_agent_execution_results WHERE verdict='CONDITIONAL_PASS' AND validation_mode='retrospective'"
+      );
+      expect(after.rows[0].n).toBe(before.rows[0].n);
+      expect(after.rows[0].n).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe.skipIf(!HAS_DB)('D3 — auto_set_is_parent corrected-parent guard (feedback 44b3621b)', () => {
+  it('guard predicate: most-recent is_parent_change_history entry decides re-promotion', async () => {
+    const wouldPromote = async (historyJson) => {
+      const r = await client.query(
+        `SELECT COALESCE((
+            SELECT (h.elem->>'to')
+            FROM jsonb_array_elements($1::jsonb) WITH ORDINALITY AS h(elem, ord)
+            ORDER BY (h.elem->>'changed_at') DESC NULLS LAST, h.ord DESC
+            LIMIT 1
+          ), 'true') <> 'false' AS would_promote`,
+        [JSON.stringify(historyJson)]
+      );
+      return r.rows[0].would_promote;
+    };
+    expect(await wouldPromote([])).toBe(true); // no marker -> normal auto-set
+    expect(await wouldPromote([{ to: false, changed_at: '2026-01-01T00:00:00Z' }])).toBe(false);
+    // demoted then genuinely re-parented -> latest is true -> promote allowed
+    expect(await wouldPromote([
+      { to: false, changed_at: '2026-01-01T00:00:00Z' },
+      { to: true, changed_at: '2026-02-01T00:00:00Z' },
+    ])).toBe(true);
+    // promoted then deliberately corrected -> latest is false -> suppressed
+    expect(await wouldPromote([
+      { to: true, changed_at: '2026-01-01T00:00:00Z' },
+      { to: false, changed_at: '2026-02-01T00:00:00Z' },
+    ])).toBe(false);
+  });
+
+  it('normal path preserved: a child write auto-sets an un-marked parent to is_parent=true', async () => {
+    await inRolledBackTx(async () => {
+      await client.query(D3_SQL);
+      const { parentId } = await seedParentChild({ withCorrectionMarker: false });
+      const r = await client.query("SELECT metadata->>'is_parent' AS v FROM strategic_directives_v2 WHERE id=$1", [parentId]);
+      expect(r.rows[0].v).toBe('true');
+    });
+  });
+
+  it('guarded path: a child write does NOT re-promote a parent whose latest marker is to=false', async () => {
+    await inRolledBackTx(async () => {
+      await client.query(D3_SQL);
+      const { parentId, childId } = await seedParentChild({ withCorrectionMarker: false });
+      // Auto-set fired on insert -> true. Now deliberately correct to false + record marker.
+      await client.query(
+        `UPDATE strategic_directives_v2
+            SET metadata = COALESCE(metadata,'{}'::jsonb) || '{"is_parent": false}'::jsonb,
+                governance_metadata = COALESCE(governance_metadata,'{}'::jsonb) || jsonb_build_object(
+                  'is_parent_change_history',
+                  jsonb_build_array(jsonb_build_object('from', true, 'to', false, 'reason', 'regression test', 'changed_at', now()))
+                )
+          WHERE id = $1`, [parentId]);
+      // Re-fire the trigger by re-writing the child's parent_sd_id (same value).
+      await client.query('UPDATE strategic_directives_v2 SET parent_sd_id=$1 WHERE id=$2', [parentId, childId]);
+      const r = await client.query("SELECT metadata->>'is_parent' AS v FROM strategic_directives_v2 WHERE id=$1", [parentId]);
+      expect(r.rows[0].v).toBe('false'); // guard prevented re-promotion
+    });
+  });
+
+  // Seed an orchestrator parent (so enforce_parent_orchestrator_type no-ops) + a child.
+  async function seedParentChild() {
+    const rand = Math.random().toString(36).slice(2, 8);
+    const parentId = (await client.query('SELECT gen_random_uuid() AS id')).rows[0].id;
+    const childId = (await client.query('SELECT gen_random_uuid() AS id')).rows[0].id;
+    const pKey = `SD-TEST-PARENT-${rand}`;
+    const cKey = `SD-TEST-CHILD-${rand}`;
+    await client.query(
+      `INSERT INTO strategic_directives_v2
+         (id, sd_key, sd_code_user_facing, title, status, priority, category, description, rationale, scope, sequence_rank, sd_type)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+      [parentId, pKey, pKey, `Test SD parent ${rand}`, 'draft', 'low', 'test',
+       'Regression fixture for SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (parent)',
+       'Integration test fixture', 'Test scope', 0, 'orchestrator']
+    );
+    await client.query(
+      `INSERT INTO strategic_directives_v2
+         (id, sd_key, sd_code_user_facing, title, status, priority, category, description, rationale, scope, sequence_rank, sd_type, parent_sd_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+      [childId, cKey, cKey, `Test SD child ${rand}`, 'draft', 'low', 'test',
+       'Regression fixture for SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001 (child)',
+       'Integration test fixture', 'Test scope', 0, 'infrastructure', parentId]
+    );
+    return { parentId, childId };
+  }
+});

--- a/tests/integration/schema-object-hygiene.test.js
+++ b/tests/integration/schema-object-hygiene.test.js
@@ -64,6 +64,16 @@ async function inRolledBackTx(work) {
   }
 }
 
+// Strip standalone BEGIN;/COMMIT; lines so a migration's own transaction control cannot
+// commit (and thus defeat the isolation of) the test's outer BEGIN..ROLLBACK. The
+// migration's DDL still runs; only its tx boundaries are neutralized for the test.
+function stripTxControl(sql) {
+  return sql.split('\n').filter((line) => !/^\s*(BEGIN|COMMIT)\s*;\s*$/i.test(line)).join('\n');
+}
+async function applyMigration(sql) {
+  return client.query(stripTxControl(sql));
+}
+
 describe.skipIf(!HAS_DB)('D1 — neutralized wireframe_screens surface migration (feedback 6359dc60)', () => {
   it('table does not exist; applying the migration is a clean no-op (no error, no table created)', async () => {
     await inRolledBackTx(async () => {
@@ -71,7 +81,7 @@ describe.skipIf(!HAS_DB)('D1 — neutralized wireframe_screens surface migration
       expect(before.rows[0].reg).toBeNull(); // table never existed
 
       // Should NOT throw "relation does not exist" — the to_regclass guard takes the ELSE branch.
-      await expect(client.query(D1_SQL)).resolves.toBeDefined();
+      await expect(applyMigration(D1_SQL)).resolves.toBeDefined();
 
       const after = await client.query("SELECT to_regclass('public.wireframe_screens') AS reg");
       expect(after.rows[0].reg).toBeNull(); // still no table — pure no-op
@@ -81,7 +91,7 @@ describe.skipIf(!HAS_DB)('D1 — neutralized wireframe_screens surface migration
   it('forward-compatible branch: when the table exists, the guarded ALTERs add surface + page_type', async () => {
     await inRolledBackTx(async () => {
       await client.query('CREATE TABLE public.wireframe_screens (id int PRIMARY KEY)');
-      await client.query(D1_SQL);
+      await applyMigration(D1_SQL);
       const cols = await client.query(`
         SELECT column_name FROM information_schema.columns
         WHERE table_schema = 'public' AND table_name = 'wireframe_screens'
@@ -120,7 +130,7 @@ describe.skipIf(!HAS_DB)('D2 — drop check_conditional_pass_retrospective (feed
 
   it('after the drop, a prospective CONDITIONAL_PASS with valid justification + conditions succeeds', async () => {
     await inRolledBackTx(async () => {
-      await client.query(D2_SQL);
+      await applyMigration(D2_SQL);
       const res = await insertCp({ mode: 'prospective', justification: GOOD_JUSTIFICATION, conditions: GOOD_CONDITIONS });
       expect(res.rows[0].id).toBeTruthy();
     });
@@ -128,7 +138,7 @@ describe.skipIf(!HAS_DB)('D2 — drop check_conditional_pass_retrospective (feed
 
   it('after the drop, sibling check_justification_required still rejects a short justification', async () => {
     await inRolledBackTx(async () => {
-      await client.query(D2_SQL);
+      await applyMigration(D2_SQL);
       await expect(
         insertCp({ mode: 'prospective', justification: 'too short', conditions: GOOD_CONDITIONS })
       ).rejects.toThrow(/check_justification_required/);
@@ -137,7 +147,7 @@ describe.skipIf(!HAS_DB)('D2 — drop check_conditional_pass_retrospective (feed
 
   it('after the drop, sibling check_conditions_required still rejects empty conditions', async () => {
     await inRolledBackTx(async () => {
-      await client.query(D2_SQL);
+      await applyMigration(D2_SQL);
       await expect(
         insertCp({ mode: 'prospective', justification: GOOD_JUSTIFICATION, conditions: [] })
       ).rejects.toThrow(/check_conditions_required/);
@@ -149,7 +159,7 @@ describe.skipIf(!HAS_DB)('D2 — drop check_conditional_pass_retrospective (feed
       const before = await client.query(
         "SELECT count(*)::int AS n FROM sub_agent_execution_results WHERE verdict='CONDITIONAL_PASS' AND validation_mode='retrospective'"
       );
-      await client.query(D2_SQL);
+      await applyMigration(D2_SQL);
       const after = await client.query(
         "SELECT count(*)::int AS n FROM sub_agent_execution_results WHERE verdict='CONDITIONAL_PASS' AND validation_mode='retrospective'"
       );
@@ -189,7 +199,7 @@ describe.skipIf(!HAS_DB)('D3 — auto_set_is_parent corrected-parent guard (feed
 
   it('normal path preserved: a child write auto-sets an un-marked parent to is_parent=true', async () => {
     await inRolledBackTx(async () => {
-      await client.query(D3_SQL);
+      await applyMigration(D3_SQL);
       const { parentId } = await seedParentChild({ withCorrectionMarker: false });
       const r = await client.query("SELECT metadata->>'is_parent' AS v FROM strategic_directives_v2 WHERE id=$1", [parentId]);
       expect(r.rows[0].v).toBe('true');
@@ -198,7 +208,7 @@ describe.skipIf(!HAS_DB)('D3 — auto_set_is_parent corrected-parent guard (feed
 
   it('guarded path: a child write does NOT re-promote a parent whose latest marker is to=false', async () => {
     await inRolledBackTx(async () => {
-      await client.query(D3_SQL);
+      await applyMigration(D3_SQL);
       const { parentId, childId } = await seedParentChild({ withCorrectionMarker: false });
       // Auto-set fired on insert -> true. Now deliberately correct to false + record marker.
       await client.query(

--- a/tests/integration/schema-object-hygiene.test.js
+++ b/tests/integration/schema-object-hygiene.test.js
@@ -19,12 +19,25 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MIG = (f) => resolve(__dirname, '../../database/migrations', f);
+const WT_ROOT = resolve(__dirname, '../..');
+const WRITER = resolve(WT_ROOT, 'scripts/correct-sd-is-parent.mjs');
+const HAS_SUPABASE = Boolean(
+  (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL) && process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const SD_SELF_UUID = '207b77d3-1691-45d1-bdec-9f5e000ebc54';
+
+function runWriter(args) {
+  return spawnSync('node', [WRITER, ...args], {
+    cwd: WT_ROOT, encoding: 'utf8', env: { ...process.env, DISABLE_SSL_VERIFY: 'true' },
+  });
+}
 
 const D1_SQL = readFileSync(MIG('20260520_add_surface_columns_to_wireframe_screens.sql'), 'utf8');
 const D2_SQL = readFileSync(MIG('20260521_drop_conditional_pass_retrospective_constraint.sql'), 'utf8');
@@ -228,4 +241,26 @@ describe.skipIf(!HAS_DB)('D3 — auto_set_is_parent corrected-parent guard (feed
     );
     return { parentId, childId };
   }
+});
+
+describe('D3 writer — scripts/correct-sd-is-parent.mjs CLI contract (FR-4 / TS-8)', () => {
+  it('exits non-zero and complains when --reason is missing (no DB needed)', () => {
+    const r = runWriter(['SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001']);
+    expect(r.status).not.toBe(0);
+    expect(`${r.stderr}${r.stdout}`).toMatch(/reason/i);
+  });
+
+  it('exits non-zero when --reason is too short (< 10 chars, no DB needed)', () => {
+    const r = runWriter(['SD-LEO-INFRA-DATABASE-SCHEMA-OBJECT-001', '--reason', 'short']);
+    expect(r.status).not.toBe(0);
+  });
+
+  it.skipIf(!HAS_SUPABASE)('--dry-run previews the is_parent=false correction without writing', () => {
+    const r = runWriter([SD_SELF_UUID, '--reason', 'regression dry-run: verify writer marker shape', '--dry-run']);
+    expect(r.status).toBe(0);
+    // Either the preview path ("metadata.is_parent: ... -> false") or the already-corrected
+    // no-op path ("already has metadata.is_parent=false") — both exit 0 and mention is_parent,
+    // and neither performs a write in --dry-run.
+    expect(r.stdout).toMatch(/is_parent/);
+  });
 });


### PR DESCRIPTION
## Summary
Three additive, backward-compatible database schema-object hygiene fixes against the consolidated DB (managed from EHG_Engineer), each closing one harness-backlog feedback row. Applied in the locked sequence **D1 → D3 → D2**, one migration file per deliverable, no data backfill.

### D1 — neutralize dead surface migration (closes feedback `6359dc60`)
`public.wireframe_screens` never existed (audience *surface* lives in `venture_artifacts` JSONB), so the original `ALTER ... ADD COLUMN IF NOT EXISTS` errors with *relation does not exist* on any migration runner. Amended **in place** to a `to_regclass`-guarded no-op + tombstone. Forward-compatible: the ALTERs still run if a real table is ever created. Zero prod data impact. (The ALTER-without-CREATE migration-readiness lint is intentionally out of scope — separate QF.)

### D3 — guard `auto_set_is_parent()` against re-promoting corrected parents (closes feedback `44b3621b`)
**Framing correction:** the live trigger writes a `metadata` JSONB key and does **not** throw (the feedback premise of a non-existent column ref is wrong). Additive `CREATE OR REPLACE` adds a guard so the nested UPDATE skips a parent whose **most-recent** `governance_metadata.is_parent_change_history` entry is `to=false` (most-recent-wins, so a later genuine re-parenting can re-promote). Ships `scripts/correct-sd-is-parent.mjs` as the marker **writer**, closing the writer-consumer asymmetry (0 markers exist today → guard would otherwise be a permanent no-op). Mirrors SD-FDBK-GEN-FIX-TRG-ENFORCE-001 / #3815. Recursion-safety proven by the DATABASE sub-agent (nested UPDATE touches only `metadata`; triggers fire on `parent_sd_id`).

### D2 — drop over-strict `check_conditional_pass_retrospective` (closes feedback `2af121c6`)
The constraint rejected any prospective `CONDITIONAL_PASS` sub-agent verdict, forcing a PASS+metadata workaround in the handoff evidence pipeline. Plain DROP; sibling guards (`check_conditions_required`, `check_justification_required`, `valid_verdict`) preserve evidence quality independent of `validation_mode`. ⚠️ **One-way door:** re-ADD fails once prospective `CONDITIONAL_PASS` rows accumulate.

## Tests
`tests/integration/schema-object-hygiene.test.js` — **10/10 pass**. Each migration is applied inside a `BEGIN ... ROLLBACK` transaction, validating the corrected behavior **without** mutating prod (skip-if-no-DB). Covers: D1 no-op + forward-compat; D2 baseline rejection → prospective accept → sibling rejects → existing rows preserved; D3 guard predicate (4 cases) + normal auto-set + guarded no-re-promotion.

## ⚠️ Pending user action (apply-to-prod is gated)
Migrations are **not** auto-applied. Apply via database-agent on explicit go (`DISABLE_SSL_VERIFY=true`), in order D1 → D3 → D2. D2 is a one-way door.

## LOC note
536 insertions / 33 deletions — ~231 lines are the regression test and ~150 are migration tombstone documentation; actual logic is small (D1 DO-block, D3 function + 123-line writer, D2 one-line ALTER). Justified for a Tier-3 infra SD covering three deliverables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
