### PR TITLE
feat(SD-LEO-INFRA-SMART-PER-WORKTREE-001): smart per-worktree node_modules isolation

### DIFF
--- a/lib/__tests__/worktree-provision.test.js
+++ b/lib/__tests__/worktree-provision.test.js
@@ -1,0 +1,113 @@
+// SD-LEO-INFRA-SMART-PER-WORKTREE-001 — smart per-worktree node_modules provisioning.
+import { describe, it, expect, vi } from 'vitest';
+import {
+  decideWorktreeProvisionMode,
+  provisionWorktreeNodeModules,
+  defaultRunInstall,
+  getIsolationMode,
+} from '../worktree-provision.js';
+
+const GB = 1024 * 1024 * 1024;
+
+describe('decideWorktreeProvisionMode (pure decision)', () => {
+  it('auto + solo (1) -> junction', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 1 })).toEqual({ strategy: 'junction', reason: 'auto_solo' });
+  });
+  it('auto + zero (0) -> junction', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 0 })).toEqual({ strategy: 'junction', reason: 'auto_solo' });
+  });
+  it('auto + concurrent (2) -> isolate', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 2 })).toEqual({ strategy: 'isolate', reason: 'auto_concurrent' });
+  });
+  it('auto + many (3) -> isolate', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 3 }).strategy).toBe('isolate');
+  });
+  it('exactly-1 boundary -> junction (pins the >=2 threshold)', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 1 }).strategy).toBe('junction');
+  });
+  it('always + solo -> isolate', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'always', activeSessionCount: 1 })).toEqual({ strategy: 'isolate', reason: 'mode_always' });
+  });
+  it('never + concurrent -> junction', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'never', activeSessionCount: 5 })).toEqual({ strategy: 'junction', reason: 'mode_never' });
+  });
+  it('auto + uncertain count (null) -> isolate (conservative)', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: null })).toEqual({ strategy: 'isolate', reason: 'auto_uncertain_count' });
+  });
+  it('unknown mode -> isolate (fail-safe)', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'garbage', activeSessionCount: 1 })).toEqual({ strategy: 'isolate', reason: 'mode_unknown_failsafe' });
+  });
+  it('disk floor forces junction even under always/concurrent', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'always', activeSessionCount: 5, freeDiskBytes: 2 * GB })).toEqual({ strategy: 'junction', reason: 'disk_floor' });
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 5, freeDiskBytes: 2 * GB }).reason).toBe('disk_floor');
+  });
+  it('sufficient disk does not trigger the floor', () => {
+    expect(decideWorktreeProvisionMode({ mode: 'auto', activeSessionCount: 2, freeDiskBytes: 50 * GB }).strategy).toBe('isolate');
+  });
+});
+
+describe('getIsolationMode', () => {
+  it('defaults to auto and normalizes unknown to auto', () => {
+    expect(getIsolationMode({})).toBe('auto');
+    expect(getIsolationMode({ WORKTREE_ISOLATION_MODE: 'ALWAYS' })).toBe('always');
+    expect(getIsolationMode({ WORKTREE_ISOLATION_MODE: 'bogus' })).toBe('auto');
+  });
+});
+
+function spies() {
+  return {
+    decide: vi.fn(),
+    symlink: vi.fn(),
+    runInstall: vi.fn(),
+    writeMarker: vi.fn(),
+    rm: vi.fn(),
+    log: vi.fn(),
+  };
+}
+
+describe('provisionWorktreeNodeModules (execution)', () => {
+  it('ISOLATE: runs install, writes isolated marker, does NOT junction', () => {
+    const d = spies();
+    d.decide.mockReturnValue({ strategy: 'isolate', reason: 'auto_concurrent' });
+    const r = provisionWorktreeNodeModules('/wt', { repoRoot: '/repo', activeSessionCount: 2, deps: d });
+    expect(r).toEqual({ strategy: 'isolate', reason: 'auto_concurrent' });
+    expect(d.runInstall).toHaveBeenCalledWith('/wt');
+    expect(d.symlink).not.toHaveBeenCalled();
+    expect(d.writeMarker).toHaveBeenCalledWith('/wt', 'isolated');
+  });
+
+  it('JUNCTION: symlinks (worktree, repoRoot), writes junction marker, does NOT install', () => {
+    const d = spies();
+    d.decide.mockReturnValue({ strategy: 'junction', reason: 'auto_solo' });
+    const r = provisionWorktreeNodeModules('/wt', { repoRoot: '/repo', activeSessionCount: 1, deps: d });
+    expect(r).toEqual({ strategy: 'junction', reason: 'auto_solo' });
+    expect(d.symlink).toHaveBeenCalledWith('/wt', '/repo');
+    expect(d.runInstall).not.toHaveBeenCalled();
+    expect(d.writeMarker).toHaveBeenCalledWith('/wt', 'junction');
+  });
+
+  it('FALLBACK: isolate install failure -> clean partial -> junction (worktree always usable)', () => {
+    const d = spies();
+    d.decide.mockReturnValue({ strategy: 'isolate', reason: 'auto_concurrent' });
+    d.runInstall.mockImplementation(() => { throw new Error('npm boom'); });
+    const r = provisionWorktreeNodeModules('/wt', { repoRoot: '/repo', deps: d });
+    expect(r.strategy).toBe('junction');
+    expect(r.reason).toBe('isolate_failed_fallback');
+    expect(r.fallbackReason).toMatch(/npm boom/);
+    expect(d.symlink).toHaveBeenCalledWith('/wt', '/repo'); // fell back to junction
+    expect(d.writeMarker).toHaveBeenLastCalledWith('/wt', 'junction');
+  });
+});
+
+describe('defaultRunInstall (command + cwd contract)', () => {
+  it('runs additive `npm install --ignore-scripts` with cwd === worktreePath (never repoRoot)', () => {
+    const exec = vi.fn();
+    defaultRunInstall('/wt', { execSyncImpl: exec });
+    expect(exec).toHaveBeenCalledTimes(1);
+    const [cmd, opts] = exec.mock.calls[0];
+    expect(cmd).toMatch(/^npm install\b/);
+    expect(cmd).toMatch(/--ignore-scripts/);
+    expect(cmd).not.toMatch(/\bnpm ci\b/); // never the destructive command
+    expect(opts.cwd).toBe('/wt');
+  });
+});

--- a/lib/worktree-provision.js
+++ b/lib/worktree-provision.js
@@ -1,0 +1,163 @@
+/**
+ * Smart per-worktree node_modules provisioning — SD-LEO-INFRA-SMART-PER-WORKTREE-001.
+ *
+ * Retires UNCONDITIONAL junctioning. New worktrees get either:
+ *   - a REAL isolated node_modules (additive `npm install`, immune to shared-store wipes), or
+ *   - the cheap junction (symlinkNodeModules) — the legacy behavior.
+ * decided by a pure policy from { mode, activeSessionCount, freeDiskBytes }.
+ *
+ * Root context: all worktrees junction to ONE shared main store, which keeps getting
+ * wiped mid-session (harness 95022758) despite many op-hardening fixes + the npm-ci
+ * guard (QF-20260521-389). Isolation removes the shared dependency for actively-worked
+ * worktrees. Bounded: isolate only under concurrency (auto) so solo sessions stay cheap.
+ *
+ * Design constraints (LEAD triangulation — RISK/VALIDATION/TESTING):
+ *  - ADDITIVE only: never touches sd-start's fleet-safe MAIN install (evaluateInstallDecision /
+ *    fleet-lock-hash / global NODE_MODULES lock). (R4)
+ *  - No global lock for per-worktree installs — they target distinct dirs and are already
+ *    concurrency-safe via npm's atomic .staging + shared cache. (R5/R10)
+ *  - Never leave a broken worktree: on isolated-install failure, clean the partial and fall
+ *    back to a junction so the worktree is ALWAYS usable. (R7)
+ *  - Heartbeat-fresh session counting; isolate on uncertainty; disk floor. (R1/R6)
+ *  - Pure decision + injectable deps for unit testing without a real install. (TESTING)
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { symlinkNodeModules, safeRecursiveRmWithRetry, getRepoRoot } from './worktree-manager.js';
+
+export const ISOLATION_MODES = ['auto', 'always', 'never'];
+const CONCURRENCY_THRESHOLD = 2;          // >=2 active sessions => concurrency risk
+const DISK_FLOOR_BYTES = 3 * 1024 * 1024 * 1024; // ~3GB — below this, force junction
+const HEARTBEAT_FRESH_MS = 5 * 60 * 1000; // sessions stale >5min are treated inactive
+const MARKER_FILE = '.worktree-nm-mode';  // dual-mode teardown hint: 'isolated' | 'junction'
+
+/** Resolve the configured isolation mode (env-driven, default auto). */
+export function getIsolationMode(env = process.env) {
+  const m = String(env.WORKTREE_ISOLATION_MODE || 'auto').toLowerCase();
+  return ISOLATION_MODES.includes(m) ? m : 'auto';
+}
+
+/**
+ * PURE decision: should a new worktree isolate its node_modules or junction to the shared store?
+ * @returns {{ strategy: 'isolate'|'junction', reason: string }}
+ */
+export function decideWorktreeProvisionMode({ mode = 'auto', activeSessionCount, freeDiskBytes } = {}) {
+  const m = String(mode).toLowerCase();
+  if (m === 'never') return { strategy: 'junction', reason: 'mode_never' };
+  // Disk floor is a hard safety stop — applies even to 'always'.
+  if (typeof freeDiskBytes === 'number' && freeDiskBytes < DISK_FLOOR_BYTES) {
+    return { strategy: 'junction', reason: 'disk_floor' };
+  }
+  if (m === 'always') return { strategy: 'isolate', reason: 'mode_always' };
+  if (m !== 'auto') return { strategy: 'isolate', reason: 'mode_unknown_failsafe' };
+  // auto: isolate under concurrency or when the count is unknown (conservative).
+  const n = Number(activeSessionCount);
+  if (activeSessionCount == null || Number.isNaN(n)) return { strategy: 'isolate', reason: 'auto_uncertain_count' };
+  if (n >= CONCURRENCY_THRESHOLD) return { strategy: 'isolate', reason: 'auto_concurrent' };
+  return { strategy: 'junction', reason: 'auto_solo' };
+}
+
+export function defaultRunInstall(worktreePath, { execSyncImpl = execSync } = {}) {
+  // Install directly in the worktree (full repo context: .npmrc/workspaces honored).
+  // npm builds in node_modules/.staging then moves atomically; additive (NOT `npm ci`),
+  // and cwd === worktreePath so it NEVER touches the shared main store.
+  execSyncImpl('npm install --ignore-scripts --no-audit --no-fund', {
+    cwd: worktreePath, stdio: 'pipe', timeout: 180000,
+  });
+}
+
+function defaultWriteMarker(worktreePath, modeStr) {
+  try { fs.writeFileSync(path.join(worktreePath, MARKER_FILE), modeStr + '\n'); } catch { /* best-effort */ }
+}
+
+/** Read the isolation-mode marker for teardown decisions. Returns 'isolated' | 'junction' | null. */
+export function readWorktreeNmMode(worktreePath, fsImpl = fs) {
+  try { return fsImpl.readFileSync(path.join(worktreePath, MARKER_FILE), 'utf8').trim() || null; }
+  catch { return null; }
+}
+
+/**
+ * Execute the provisioning decision. Sync + injectable for tests.
+ * Never leaves a broken worktree: isolate failure → clean partial → junction fallback.
+ * @returns {{ strategy: 'isolate'|'junction', reason: string, fallbackReason?: string }}
+ */
+export function provisionWorktreeNodeModules(worktreePath, options = {}) {
+  const { repoRoot, mode = getIsolationMode(), activeSessionCount, freeDiskBytes, deps = {} } = options;
+  const {
+    decide = decideWorktreeProvisionMode,
+    symlink = symlinkNodeModules,
+    runInstall = defaultRunInstall,
+    writeMarker = defaultWriteMarker,
+    rm = safeRecursiveRmWithRetry,
+    log = (msg) => console.log(msg),
+  } = deps;
+
+  const decision = decide({ mode, activeSessionCount, freeDiskBytes });
+
+  if (decision.strategy === 'junction') {
+    symlink(worktreePath, repoRoot);
+    writeMarker(worktreePath, 'junction');
+    log(`[worktree-provision] junction (${decision.reason}): ${worktreePath}`);
+    return { strategy: 'junction', reason: decision.reason };
+  }
+
+  // isolate
+  try {
+    runInstall(worktreePath);
+    writeMarker(worktreePath, 'isolated');
+    log(`[worktree-provision] isolated (${decision.reason}): ${worktreePath}`);
+    return { strategy: 'isolate', reason: decision.reason };
+  } catch (err) {
+    // Clean any partial install so the junction fallback is clean, then fall back.
+    try { const nm = path.join(worktreePath, 'node_modules'); if (fs.existsSync(nm)) rm(nm); } catch { /* best-effort */ }
+    try {
+      symlink(worktreePath, repoRoot);
+      writeMarker(worktreePath, 'junction');
+      log(`[worktree-provision] isolate FAILED (${err.message}); fell back to junction: ${worktreePath}`);
+      return { strategy: 'junction', reason: 'isolate_failed_fallback', fallbackReason: err.message };
+    } catch (err2) {
+      log(`[worktree-provision] isolate AND junction failed: ${err2.message}`);
+      throw err2;
+    }
+  }
+}
+
+/** Count heartbeat-FRESH active sessions (stale >5min treated inactive). Returns null on any error (→ isolate). */
+export async function countActiveFreshSessions({ supabase, nowMs = Date.now(), freshMs = HEARTBEAT_FRESH_MS } = {}) {
+  try {
+    if (!supabase) {
+      const { createClient } = await import('@supabase/supabase-js');
+      const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+      if (!url || !key) return null;
+      supabase = createClient(url, key);
+    }
+    const cutoff = new Date(nowMs - freshMs).toISOString();
+    const { count, error } = await supabase.from('claude_sessions')
+      .select('session_id', { count: 'exact', head: true })
+      .eq('status', 'active').gte('heartbeat_at', cutoff);
+    if (error) return null;
+    return typeof count === 'number' ? count : null;
+  } catch { return null; }
+}
+
+/** Free bytes on the filesystem holding dirPath; undefined if unavailable. */
+export function getFreeDiskBytes(dirPath, fsImpl = fs) {
+  try { const s = fsImpl.statfsSync(dirPath); return Number(s.bavail) * Number(s.bsize); }
+  catch { return undefined; }
+}
+
+/**
+ * Async convenience used by worktree-creation call sites: gathers mode + heartbeat-fresh
+ * session count + free disk, then provisions. Keeps call sites a one-liner.
+ */
+export async function provisionWorktreeNodeModulesAuto(worktreePath, { repoRoot, supabase, mode } = {}) {
+  const resolvedRoot = repoRoot || getRepoRoot();
+  const resolvedMode = mode || getIsolationMode();
+  const activeSessionCount = resolvedMode === 'auto' ? await countActiveFreshSessions({ supabase }) : undefined;
+  const freeDiskBytes = getFreeDiskBytes(worktreePath);
+  return provisionWorktreeNodeModules(worktreePath, { repoRoot: resolvedRoot, mode: resolvedMode, activeSessionCount, freeDiskBytes });
+}
+
+export default { decideWorktreeProvisionMode, provisionWorktreeNodeModules, provisionWorktreeNodeModulesAuto, getIsolationMode, readWorktreeNmMode, countActiveFreshSessions, getFreeDiskBytes, ISOLATION_MODES };

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -400,11 +400,14 @@ async function createQuickFix(options = {}) {
       });
 
       if (result.mode === 'worktree') {
-        // Symlink node_modules into worktree
+        // SD-LEO-INFRA-SMART-PER-WORKTREE-001: smart provisioning — isolate
+        // node_modules under concurrency (immune to shared-store wipes), else junction.
         try {
-          symlinkNodeModules(result.path);
-        } catch (symlinkErr) {
-          console.log(`   ⚠️  node_modules symlink failed: ${symlinkErr.message}`);
+          const { provisionWorktreeNodeModulesAuto } = await import('../lib/worktree-provision.js');
+          const prov = await provisionWorktreeNodeModulesAuto(result.path, { repoRoot: ENGINEER_ROOT });
+          console.log(`   📦 node_modules: ${prov.strategy} (${prov.reason})`);
+        } catch (provErr) {
+          console.log(`   ⚠️  node_modules provisioning failed: ${provErr.message}`);
           console.log('   Run `npm install --ignore-scripts --no-audit --no-fund` in the worktree if needed (NOT `npm ci` — its rm -rf wipes the shared store; harness 95022758).\n');
         }
 

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -29,6 +29,7 @@ import { enforceWorktreeQuota, MAX_WORKTREE_COUNT, WORKTREE_QUOTA_HELPERS } from
 // SD-LEO-INFRA-LEO-INFRA-WORKTREE-001: SUBSTRATE_ITEMS + validateWorktreeSubstrate
 // for the post-creation completeness gate.
 import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError, SUBSTRATE_ITEMS, validateWorktreeSubstrate } from '../lib/worktree-manager.js';
+import { provisionWorktreeNodeModules, getIsolationMode, getFreeDiskBytes, countActiveFreshSessions } from '../lib/worktree-provision.js';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -231,7 +232,7 @@ function verifyWorktreeRegistered(worktreePath, repoRoot) {
 /**
  * Create a new worktree for the SD
  */
-function createWorktree(sdKey, repoRoot) {
+function createWorktree(sdKey, repoRoot, opts = {}) {
   const worktreesDir = path.join(repoRoot, WORKTREES_DIR);
   const worktreePath = path.join(worktreesDir, sdKey);
 
@@ -249,7 +250,7 @@ function createWorktree(sdKey, repoRoot) {
       // that DB and scan paths missed. Without this, handoff.js and other
       // scripts run from the worktree fail with NEXT_PUBLIC_SUPABASE_URL
       // is required. Closes feedback row c9d07065.
-      const essentials = ensureWorktreeEssentials(worktreePath, repoRoot);
+      const essentials = ensureWorktreeEssentials(worktreePath, repoRoot, { activeSessionCount: opts.activeSessionCount });
       if (!essentials.ok) {
         emitLog({ event: 'worktree.essentials_partial', sdKey, source: 'pre-existing', errors: essentials.errors });
       }
@@ -351,7 +352,7 @@ function createWorktree(sdKey, repoRoot) {
     baseRef
   }, null, 2));
 
-  const essentials = ensureWorktreeEssentials(worktreePath, repoRoot);
+  const essentials = ensureWorktreeEssentials(worktreePath, repoRoot, { activeSessionCount: opts.activeSessionCount });
   if (!essentials.ok) {
     emitLog({ event: 'worktree.essentials_partial', sdKey, errors: essentials.errors });
   }
@@ -405,7 +406,7 @@ function createWorktree(sdKey, repoRoot) {
  * SUBSTRATE_ITEMS membership; .env.local is opportunistic (not in the
  * substrate contract but copied if present).
  */
-function ensureWorktreeEssentials(worktreePath, repoRoot) {
+function ensureWorktreeEssentials(worktreePath, repoRoot, opts = {}) {
   // SD-LEO-FIX-WORKTREE-CREATION-ATOMICITY-001 US-004: Structured error return
   // instead of swallowed catches. Best-effort semantics preserved (no throw) but
   // failures are surfaced so callers can log and operators can diagnose.
@@ -420,13 +421,19 @@ function ensureWorktreeEssentials(worktreePath, repoRoot) {
     const targetModules = path.join(worktreePath, 'node_modules');
     if (fs.existsSync(sourceModules) && !fs.existsSync(targetModules)) {
       try {
-        if (process.platform === 'win32') {
-          fs.symlinkSync(sourceModules, targetModules, 'junction');
-        } else {
-          fs.symlinkSync(sourceModules, targetModules, 'dir');
-        }
+        // SD-LEO-INFRA-SMART-PER-WORKTREE-001: isolate node_modules under concurrency
+        // (immune to shared-store wipes), else junction. provision handles the
+        // junction fallback internally. ADDITIVE — does NOT touch sd-start's
+        // fleet-safe MAIN install path.
+        provisionWorktreeNodeModules(worktreePath, {
+          repoRoot,
+          mode: getIsolationMode(),
+          activeSessionCount: opts.activeSessionCount,
+          freeDiskBytes: getFreeDiskBytes(worktreePath),
+          deps: { log: () => {} },
+        });
       } catch (err) {
-        errors.push({ step: 'symlink_node_modules', message: err.message });
+        errors.push({ step: 'provision_node_modules', message: err.message });
       }
     }
   }
@@ -491,6 +498,10 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     };
   }
 
+  // SD-LEO-INFRA-SMART-PER-WORKTREE-001: fetch heartbeat-fresh active-session count once
+  // (auto mode only) to drive the isolate-vs-junction decision in ensureWorktreeEssentials.
+  const _activeSessionCount = getIsolationMode() === 'auto' ? await countActiveFreshSessions({}) : undefined;
+
   // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Resolve repo root from SD's target_application
   // When an SD targets a venture repo, create worktrees in that repo instead of EHG_Engineer
   if (!targetApp) {
@@ -537,7 +548,7 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     } else {
       const branch = getWorktreeBranch(dbResult.path);
       emitLog({ event: 'worktree.resolved', sdKey, source: 'db', resolvedCwd: dbResult.path, outcome: 'success' });
-      const dbEssentials = ensureWorktreeEssentials(dbResult.path, repoRoot);
+      const dbEssentials = ensureWorktreeEssentials(dbResult.path, repoRoot, { activeSessionCount: _activeSessionCount });
       if (!dbEssentials.ok) emitLog({ event: 'worktree.essentials_partial', sdKey, source: 'db', errors: dbEssentials.errors });
       return {
         sdKey, cwd: dbResult.path, source: 'db', success: true,
@@ -556,7 +567,7 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     // Persist to DB for future lookups
     await persistWorktreePath(sdKey, scanResult.path, branch);
 
-    const scanEssentials = ensureWorktreeEssentials(scanResult.path, repoRoot);
+    const scanEssentials = ensureWorktreeEssentials(scanResult.path, repoRoot, { activeSessionCount: _activeSessionCount });
     if (!scanEssentials.ok) emitLog({ event: 'worktree.essentials_partial', sdKey, source: 'scan', errors: scanEssentials.errors });
     return {
       sdKey, cwd: scanResult.path, source: 'scan', success: true,
@@ -568,7 +579,7 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
   if (mode === 'claim') {
     // Create one
     try {
-      const created = createWorktree(sdKey, repoRoot);
+      const created = createWorktree(sdKey, repoRoot, { activeSessionCount: _activeSessionCount });
       emitLog({ event: 'worktree.resolved', sdKey, source: 'created', resolvedCwd: created.path, outcome: 'success' });
 
       // Persist to DB

--- a/scripts/session-worktree.js
+++ b/scripts/session-worktree.js
@@ -21,6 +21,7 @@ import {
   listWorktrees,
   getRepoRoot
 } from '../lib/worktree-manager.js';
+import { provisionWorktreeNodeModulesAuto } from '../lib/worktree-provision.js';
 
 function parseArgs(argv) {
   const args = {};
@@ -207,13 +208,14 @@ async function main() {
       process.exit(0);
     }
 
-    // Symlink node_modules
+    // SD-LEO-INFRA-SMART-PER-WORKTREE-001: smart provisioning (isolate under
+    // concurrency, else junction). Falls back to junction on isolate failure.
     if (!args.noSymlink) {
       try {
-        symlinkNodeModules(result.path, getRepoRoot());
-        console.log('node_modules linked successfully.');
+        const prov = await provisionWorktreeNodeModulesAuto(result.path, { repoRoot: getRepoRoot() });
+        console.log(`node_modules: ${prov.strategy} (${prov.reason}).`);
       } catch (err) {
-        console.error(`Warning: Could not link node_modules: ${err.message}`);
+        console.error(`Warning: Could not provision node_modules: ${err.message}`);
         console.error('You may need to run `npm install --ignore-scripts --no-audit --no-fund` inside the worktree (NOT `npm ci` — its rm -rf wipes the shared store; harness 95022758).');
       }
     }


### PR DESCRIPTION
## Problem
All worktrees junction `node_modules` to ONE shared main store, which keeps getting **wiped mid-session** (harness 95022758), bricking parallel sessions — despite multiple prior op-hardening SDs (FLEET-SAFE-NODE, CONCURRENT-NPM-RECONCILIATION, CLEANUP-WINDOWS) and the just-shipped npm-ci guard (QF-20260521-389). Any destructive op on the shared store propagates to every junction-sharer.

## Fix — smart/bounded per-worktree isolation
Retire **unconditional** junctioning. New worktrees now get:
- a **real isolated `node_modules`** under concurrency (≥2 heartbeat-fresh sessions, or `WORKTREE_ISOLATION_MODE=always`) — immune to shared-store wipes; or
- the **cheap junction** when solo (auto) — no disk/latency cost.

`lib/worktree-provision.js` (new):
- `decideWorktreeProvisionMode({mode,activeSessionCount,freeDiskBytes})` — pure: auto isolates on concurrency/uncertainty, junctions solo; **disk floor (<~3GB) forces junction**; `always`/`never` override.
- `provisionWorktreeNodeModules(...)` — additive `npm install --ignore-scripts` with **cwd=worktree** (never the shared store) + **junction fallback on any failure** (worktree always usable) + `.worktree-nm-mode` marker. **No global lock** (per-worktree dirs are already concurrency-safe).
- `countActiveFreshSessions` / `getFreeDiskBytes` / `provisionWorktreeNodeModulesAuto`.

Wiring (additive — sd-start's fleet-safe MAIN install is **untouched**): `create-quick-fix.js`, `session-worktree.js`, `resolve-sd-workdir.js` (sd-start path; `activeSessionCount` threaded from async `resolve()`).

**Scope: NEW worktrees only** — existing junctioned worktrees stay guard-protected.

## Verification
- **16/16 unit tests** (`lib/__tests__/worktree-provision.test.js`): decision matrix (solo/concurrent/uncertain/boundary/disk-floor + always/never), install cmd/cwd contract, junction, install-failure→junction-fallback.
- **Regression**: `fleet-lock-hash` 42/42 (sd-start fleet-safe path unregressed); the isolation path acquires no global lock (verified).
- **Live**: count=3 → `isolate`; solo → `junction`.

## Relationship to the npm-ci guard (QF-20260521-389)
The guard blocks the destructive *trigger*; this SD removes the shared *dependency* for active worktrees. Together they close harness 95022758 for actively-worked worktrees.

## Follow-ups (non-blocking)
- TS-5 reaper integration test (real `node_modules` removal — reaper unchanged by this SD).
- Stabilize the pre-existing `fleet-lock-hash` TS-7 wall-clock flake.

LEAD 94 · PLAN-TO-EXEC 95 · EXEC-TO-PLAN 92 · PLAN-TO-LEAD 96. Triangulation: VALIDATION (not a duplicate), RISK (corrected the global-lock assumption), TESTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)