### PR TITLE
QF-20260521-053: retro-gate rejection guidance — correct table name + document gate invariants

### DIFF
--- a/docs/leo/sub-agents/retro-sub-agent-guide.md
+++ b/docs/leo/sub-agents/retro-sub-agent-guide.md
@@ -1004,6 +1004,19 @@ Convert to backlog item or future SD
 
 ---
 
+## Retrospective Gate Invariants (RETROSPECTIVE_EXISTS / RETROSPECTIVE_QUALITY_GATE)
+
+An SD-completion retrospective must satisfy **all four** invariants or the PLAN-TO-LEAD and LEAD-FINAL-APPROVAL gates treat it as missing (enforced in `scripts/modules/handoff/retro-filters.js`):
+
+1. **Existence** — at least one `retrospectives` row for the SD (`sd_id` = the SD **UUID**, not the SD key).
+2. **`retro_type = 'SD_COMPLETION'`** — excludes SPRINT / INCIDENT / AUDIT retros.
+3. **`retrospective_type IS NULL`** — handoff-time retros set this column to the phase (`LEAD_TO_PLAN`, `PLAN_TO_EXEC`, …) and are deliberately excluded by the freshness filter. **Do NOT set `retrospective_type` on a manually-authored SD-completion retro** — setting both `retro_type='SD_COMPLETION'` and `retrospective_type='SD_COMPLETION'` is the most common reason a freshly-written retro "disappears" from the gate.
+4. **Freshness** — `created_at` AFTER the SD's accepted LEAD-TO-PLAN handoff timestamp (defense-in-depth that also catches any handoff-type retros missed by #3).
+
+Quality is scored separately (`quality_score >= 60%`, ≥70 for infrastructure SDs); the `auto_validate_retrospective_quality` trigger computes it from the richness of `what_went_well` / `key_learnings` / `action_items` / `what_needs_improvement`. Note `learning_category` rejects `INFRASTRUCTURE` — use `PROCESS_IMPROVEMENT`.
+
+> The canonical table is **`retrospectives`** (NOT `sd_retrospectives`).
+
 ## Related Documentation
 
 - [Sub-Agent Patterns Guide](../../reference/agent-patterns-guide.md) - Base patterns

--- a/scripts/modules/handoff/rejection-subagent-mapping.js
+++ b/scripts/modules/handoff/rejection-subagent-mapping.js
@@ -566,11 +566,11 @@ const REJECTION_MAP = {
     category: 'workflow',
     promptFn: (ctx) => {
       const brief = fivePointBrief({
-        symptom: `No quality retrospective found for ${ctx.sdId}. LEAD-FINAL-APPROVAL blocked.`,
-        location: `sd_retrospectives table WHERE sd_id='${ctx.sdId}'`,
+        symptom: `No qualifying SD-completion retrospective found for ${ctx.sdId}. LEAD-FINAL-APPROVAL blocked.`,
+        location: `retrospectives table WHERE sd_id='${ctx.sdId}'`,
         frequency: 'Blocking final approval',
-        priorAttempts: 'Retrospective not yet generated',
-        desiredOutcome: `Generate retrospective for ${ctx.sdId} with quality score >= 60%. Include SD-specific learnings, not boilerplate.`
+        priorAttempts: 'Retrospective not yet generated, or written with the wrong structural fields so the gate filter excludes it (see desiredOutcome).',
+        desiredOutcome: `Generate an SD-completion retrospective for ${ctx.sdId} that satisfies the gate filter (scripts/modules/handoff/retro-filters.js): (1) retro_type='SD_COMPLETION'; (2) retrospective_type IS NULL — handoff-time retros tag this column (LEAD_TO_PLAN/etc.) and are excluded, so do NOT set it; (3) created_at AFTER the SD's LEAD-TO-PLAN acceptance; (4) quality_score >= 60% with SD-specific learnings, not boilerplate.`
       });
       return 'Quality retrospective required for final approval.' +
         taskInvocation('retro-agent', brief);

--- a/tests/unit/rejection-subagent-mapping-retro.test.js
+++ b/tests/unit/rejection-subagent-mapping-retro.test.js
@@ -1,0 +1,35 @@
+/**
+ * Regression test for QF-20260521-053 (closes feedback 2b74895e).
+ *
+ * The RETROSPECTIVE_EXISTS rejection brief referenced a non-existent `sd_retrospectives`
+ * table and documented none of the structural invariants the retro gate filters on. This
+ * pins the corrected guidance so it cannot regress.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getRemediation } from '../../scripts/modules/handoff/rejection-subagent-mapping.js';
+
+describe('QF-20260521-053 — retrospective-gate rejection guidance', () => {
+  const ctx = { sdId: 'SD-TEST-RETRO-001' };
+
+  it('RETROSPECTIVE_EXISTS references the real `retrospectives` table, not `sd_retrospectives`', () => {
+    const { message, subagentType } = getRemediation('RETROSPECTIVE_EXISTS', ctx);
+    expect(message).toContain('retrospectives table');
+    expect(message).not.toContain('sd_retrospectives');
+    expect(subagentType).toBe('retro-agent');
+  });
+
+  it('RETROSPECTIVE_EXISTS documents the gate invariants (retro_type, retrospective_type IS NULL, freshness)', () => {
+    const { message } = getRemediation('RETROSPECTIVE_EXISTS', ctx);
+    expect(message).toContain("retro_type='SD_COMPLETION'");
+    expect(message).toMatch(/retrospective_type IS NULL/i);
+    expect(message).toMatch(/LEAD-TO-PLAN acceptance/i);
+    expect(message).toMatch(/quality_score >= 60/i);
+  });
+
+  it('RETROSPECTIVE_QUALITY_GATE guidance also avoids the wrong table name', () => {
+    const { message } = getRemediation('RETROSPECTIVE_QUALITY_GATE', ctx);
+    expect(message).not.toContain('sd_retrospectives');
+    expect(message).toContain('retrospectives table');
+  });
+});


### PR DESCRIPTION
## Summary
The `RETROSPECTIVE_EXISTS` rejection brief pointed at a non-existent `sd_retrospectives` table and documented none of the structural invariants the retro gate filters on, so manual retro authors who set `retrospective_type` silently failed the freshness filter with no guidance (hit firsthand this session).

**Fix (message + docs only):**
- Correct the table name → `retrospectives`.
- Enrich the brief to state all four gate invariants: `retro_type='SD_COMPLETION'`, `retrospective_type IS NULL`, created after LEAD-TO-PLAN acceptance, `quality_score >= 60%`.
- Document the same invariants durably in `docs/leo/sub-agents/retro-sub-agent-guide.md`. (CLAUDE_PLAN.md is DB-generated — a static note there gets overwritten on regen, so the gate guidance + retro guide are the discoverable, durable surfaces.)

## Tests
`tests/unit/rejection-subagent-mapping-retro.test.js` — **3/3 pass** (pure unit, no DB): asserts the corrected table name and the documented invariants, and guards `RETROSPECTIVE_QUALITY_GATE` against the wrong name too.

Source change: 8 LOC in `rejection-subagent-mapping.js`. Closes feedback `2b74895e` (P1.5-E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
