### PR TITLE
QF-20260521-259: monitor counts -post-hook/-analysis required artifacts as delivered

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -149,6 +149,7 @@ async function assertSdRequiredStagesMatchCanonical(sbClient = sb) {
 // Module export for testability (vitest reaches in via require)
 module.exports = module.exports || {};
 module.exports.isWorkerSourceForStage = isWorkerSourceForStage;
+module.exports.computeMissingArtifacts = computeMissingArtifacts;
 module.exports.loadExpectedArtifactsByStage = loadExpectedArtifactsByStage;
 module.exports.ADVISORY_SOURCES = ADVISORY_SOURCES;
 module.exports.ADVISORY_SUFFIXES = ADVISORY_SUFFIXES;
@@ -444,17 +445,29 @@ async function poll() {
   return true;
 }
 
+// QF-20260521-259 (closes feedback 02431bca + edb8fc43): a required deliverable counts as
+// "delivered" if a row of that artifact_type exists from a worker-source row OR an advisory-SUFFIX
+// row (-post-hook / -analysis). Several required deliverables are legitimately emitted that way
+// (wireframe_screens via stage-15-post-hook; identity_brand_guidelines via stage-10-analysis stored
+// at lifecycle_stage=12), and were previously reported as false missing_artifact positives because
+// SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001 filtered to worker rows only. Pure ADVISORY_SOURCES
+// (devils-advocate, manual-upload, lifecycle-sd-bridge) remain commentary and do not satisfy a
+// required artifact_type. Pure function for testability (vitest reaches in via require).
+function computeMissingArtifacts(stage, arts, expected) {
+  const deliveredTypes = new Set(
+    (arts || [])
+      .filter((a) => isWorkerSourceForStage(a.source, stage)
+        || (a.source && ADVISORY_SUFFIXES.some((suf) => a.source.endsWith(suf))))
+      .map((a) => a.artifact_type)
+  );
+  return (expected || []).filter((e) => !deliveredTypes.has(e));
+}
+
 function validateStageArtifacts(stage, arts) {
   const expected = expectedArtifactsByStage.get(stage);
   if (!expected || expected.length === 0) return;
 
-  // SD-LEO-REFAC-REFACTOR-MONITOR-EXPECTED-001: filter to worker rows only.
-  // Advisory rows (stage-gates, devils-advocate, *-analysis, etc.) are observability metadata,
-  // not required deliverables — including them inflated the missing-set with false positives.
-  const workerArts = arts.filter((a) => isWorkerSourceForStage(a.source, stage));
-  const types = new Set(workerArts.map((a) => a.artifact_type));
-
-  const missing = expected.filter((e) => !types.has(e));
+  const missing = computeMissingArtifacts(stage, arts, expected);
   if (missing.length > 0) {
     const msg = `S${stage} missing expected: ${missing.join(', ')}`;
     issues.push({ stage, type: 'missing_artifact', msg, ts: ts() });

--- a/tests/unit/monitor-compute-missing-artifacts.test.js
+++ b/tests/unit/monitor-compute-missing-artifacts.test.js
@@ -1,0 +1,47 @@
+/**
+ * Regression test for QF-20260521-259 (closes feedback 02431bca + edb8fc43).
+ *
+ * computeMissingArtifacts counts a required artifact_type as delivered when it appears in a
+ * worker-source row OR an advisory-SUFFIX (-post-hook / -analysis) row — several required
+ * deliverables are legitimately emitted that way (wireframe_screens via stage-15-post-hook;
+ * identity_brand_guidelines via stage-10-analysis at lifecycle_stage=12), and were previously
+ * reported as false missing_artifact positives. Pure ADVISORY_SOURCES (devils-advocate, etc.)
+ * still do not satisfy a required type. No DB dependency — pure logic over in-memory data.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { computeMissingArtifacts } = require('../../scripts/monitor-venture-run.cjs');
+
+describe('computeMissingArtifacts — required-deliverable presence', () => {
+  it('a -post-hook-sourced required deliverable counts as present (edb8fc43: wireframe_screens)', () => {
+    const arts = [{ artifact_type: 'wireframe_screens', source: 'stage-15-post-hook' }];
+    expect(computeMissingArtifacts(15, arts, ['wireframe_screens'])).toEqual([]);
+  });
+
+  it('a -analysis-sourced required deliverable counts as present (02431bca: identity_brand_guidelines at S12)', () => {
+    const arts = [{ artifact_type: 'identity_brand_guidelines', source: 'stage-10-analysis' }];
+    expect(computeMissingArtifacts(12, arts, ['identity_brand_guidelines'])).toEqual([]);
+  });
+
+  it('a normal worker-source required deliverable still counts as present', () => {
+    const arts = [{ artifact_type: 'financial_projections', source: 'stage-16' }];
+    expect(computeMissingArtifacts(16, arts, ['financial_projections'])).toEqual([]);
+  });
+
+  it('a genuinely absent required deliverable is still reported missing', () => {
+    const arts = [{ artifact_type: 'something_else', source: 'stage-16' }];
+    expect(computeMissingArtifacts(16, arts, ['financial_projections'])).toEqual(['financial_projections']);
+  });
+
+  it('a pure ADVISORY_SOURCE (devils-advocate) does NOT satisfy a required type', () => {
+    const arts = [{ artifact_type: 'financial_projections', source: 'devils-advocate' }];
+    expect(computeMissingArtifacts(16, arts, ['financial_projections'])).toEqual(['financial_projections']);
+  });
+
+  it('no artifacts → all expected reported missing; empty expected → nothing missing', () => {
+    expect(computeMissingArtifacts(16, [], ['financial_projections'])).toEqual(['financial_projections']);
+    expect(computeMissingArtifacts(16, [{ artifact_type: 'x', source: 'stage-16' }], [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
`validateStageArtifacts` filtered to worker-source rows only, so REQUIRED deliverables legitimately emitted via `-post-hook`/`-analysis` sources were reported as **false `missing_artifact`** positives while `checkDesignArtifacts` confirmed them present:
- `wireframe_screens` via `stage-15-post-hook` (the Google-Stitch replacement) — feedback `edb8fc43`
- `identity_brand_guidelines` via `stage-10-analysis` stored at `lifecycle_stage=12` — feedback `02431bca`

**Fix:** extracted a pure `computeMissingArtifacts(stage, arts, expected)` helper — a required `artifact_type` counts as delivered when present in a worker-source row **or** an advisory-suffix (`-post-hook`/`-analysis`) row. Pure `ADVISORY_SOURCES` (devils-advocate, manual-upload, lifecycle-sd-bridge) remain commentary and do not satisfy a required type. `isWorkerSourceForStage` is unchanged. Observability-only; pipeline unaffected.

## Tests
`tests/unit/monitor-compute-missing-artifacts.test.js` — **6/6** (pure, no DB): post-hook + analysis cases satisfied, worker case satisfied, genuine-miss reported, pure-advisory does NOT satisfy. Full monitor unit suite **24/24** (existing `isWorkerSourceForStage` tests intact).

Net ~13 source LOC. Closes feedback `02431bca` + `edb8fc43`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
