### PR TITLE
QF-20260521-815: auto-resolve-recovered PR-merged-moot path (immortal ci_failure rows)

### DIFF
--- a/scripts/modules/inbox/auto-resolve-recovered.js
+++ b/scripts/modules/inbox/auto-resolve-recovered.js
@@ -74,6 +74,39 @@ export function isEligibleForResolve(item, staleHours, now = Date.now()) {
   return false;
 }
 
+// 0187ad17: query the most-recent PR for a branch. Injectable exec for testability.
+export function fetchBranchPr(repo, branch, exec = execSync) {
+  const b = String(branch).replace(/"/g, '');
+  try {
+    const raw = exec(`gh pr list --repo ${repo} --head "${b}" --state all --json number,state,mergedAt --limit 1`, { encoding: 'utf8', timeout: 15000 });
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// 0187ad17: a ci_failure on a branch whose PR is MERGED or CLOSED is moot regardless of workflow
+// health — this closes the immortal-row gap where a 100%-failing workflow never produces the
+// K consecutive successes shouldAutoResolve() requires. `prList` is `gh pr list --json` output
+// (most-recent first).
+export function isPrMoot(prList) {
+  if (!Array.isArray(prList) || prList.length === 0) return { moot: false };
+  const pr = prList[0];
+  const state = String(pr.state || '').toUpperCase();
+  return { moot: state === 'MERGED' || state === 'CLOSED', number: pr.number, state };
+}
+
+async function resolveItem(supabase, item, resolutionType, notes, dryRun) {
+  if (dryRun) { console.log(`  [DRY-RUN] ${item.id.slice(0, 8)} → ${resolutionType}`); return true; }
+  const { error: upErr } = await supabase.from('feedback').update({
+    status: 'resolved', resolution_type: resolutionType, resolution_notes: notes,
+    resolved_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+  }).eq('id', item.id);
+  if (upErr) { console.error(`  [ERROR] ${item.id.slice(0, 8)}: ${upErr.message}`); return false; }
+  console.log(`  [OK] ${item.id.slice(0, 8)} → resolved (${resolutionType})`);
+  return true;
+}
+
 async function run() {
   const flags = parseArgs();
   const supabase = getSupabase();
@@ -89,16 +122,32 @@ async function run() {
   let resolved = 0, skipped = 0;
   for (const item of items) {
     if (!isEligibleForResolve(item, flags.staleHours)) { skipped++; continue; }
-    const { workflow_name, repo } = item.metadata || {};
-    if (!workflow_name || !repo) { skipped++; continue; }
-    const runs = fetchRecentRuns(repo, workflow_name, flags.k);
-    if (!shouldAutoResolve(runs, item.created_at, flags.k)) { skipped++; continue; }
-    const oldest = runs[runs.length - 1].createdAt;
-    const newest = runs[0].createdAt;
-    const notes = `Auto-resolved by clockwork-auto-resolve (CAPA-7): workflow "${workflow_name}" had ${flags.k}/${flags.k} consecutive successful runs (oldest ${oldest}, newest ${newest}); newest > row.created_at ${item.created_at}.`;
-    if (flags.dryRun) { console.log(`  [DRY-RUN] ${item.id.slice(0, 8)} → ${workflow_name}`); resolved++; continue; }
-    const { error: upErr } = await supabase.from('feedback').update({ status: 'resolved', resolution_type: 'auto_resolved', resolution_notes: notes, resolved_at: new Date().toISOString(), updated_at: new Date().toISOString() }).eq('id', item.id);
-    if (upErr) { console.error(`  [ERROR] ${item.id.slice(0, 8)}: ${upErr.message}`); skipped++; } else { console.log(`  [OK] ${item.id.slice(0, 8)} → resolved (${workflow_name})`); resolved++; }
+    const { workflow_name, repo, branch } = item.metadata || {};
+    if (!repo) { skipped++; continue; }
+
+    // Path 1 (CAPA-7): the cited workflow self-healed (K consecutive successes).
+    if (workflow_name) {
+      const runs = fetchRecentRuns(repo, workflow_name, flags.k);
+      if (shouldAutoResolve(runs, item.created_at, flags.k)) {
+        const oldest = runs[runs.length - 1].createdAt, newest = runs[0].createdAt;
+        const notes = `Auto-resolved (CAPA-7): workflow "${workflow_name}" had ${flags.k}/${flags.k} consecutive successful runs (oldest ${oldest}, newest ${newest}); newest > row.created_at ${item.created_at}.`;
+        if (await resolveItem(supabase, item, 'auto_resolved', notes, flags.dryRun)) resolved++; else skipped++;
+        continue;
+      }
+    }
+
+    // Path 2 (0187ad17): the row's branch PR is MERGED/CLOSED → the ci_failure is moot regardless
+    // of workflow health (closes the immortal-row gap for never-succeeding workflows).
+    if (branch) {
+      const pr = isPrMoot(fetchBranchPr(repo, branch) || []);
+      if (pr.moot) {
+        const notes = `Auto-resolved (0187ad17 PR-merged-moot): branch "${branch}" PR #${pr.number} is ${pr.state}; the cited ci_failure is moot regardless of workflow health.`;
+        if (await resolveItem(supabase, item, 'pr_merged_moot', notes, flags.dryRun)) resolved++; else skipped++;
+        continue;
+      }
+    }
+
+    skipped++;
   }
   console.log(`\n[auto-resolve-recovered] Resolved=${resolved} Skipped=${skipped} Total=${items.length} Mode=${flags.dryRun ? 'dry-run' : 'live'}`);
 }

--- a/tests/unit/auto-resolve-pr-moot.test.js
+++ b/tests/unit/auto-resolve-pr-moot.test.js
@@ -1,0 +1,51 @@
+/**
+ * Regression test for QF-20260521-815 (closes feedback 0187ad17).
+ *
+ * auto-resolve-recovered.js can never clear a ci_failure row for a workflow that fails 100% of
+ * the time (shouldAutoResolve requires K consecutive successes). The PR-merged-moot path resolves
+ * a row whose branch PR is MERGED/CLOSED regardless of workflow health. Pure logic, no DB/gh.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isPrMoot, fetchBranchPr } from '../../scripts/modules/inbox/auto-resolve-recovered.js';
+
+describe('isPrMoot — branch PR resolution state', () => {
+  it('MERGED PR is moot', () => {
+    expect(isPrMoot([{ number: 1, state: 'MERGED' }])).toEqual({ moot: true, number: 1, state: 'MERGED' });
+  });
+  it('CLOSED PR is moot', () => {
+    expect(isPrMoot([{ number: 2, state: 'CLOSED' }])).toEqual({ moot: true, number: 2, state: 'CLOSED' });
+  });
+  it('OPEN PR is NOT moot', () => {
+    expect(isPrMoot([{ number: 3, state: 'OPEN' }]).moot).toBe(false);
+  });
+  it('lowercase state is normalized', () => {
+    expect(isPrMoot([{ number: 4, state: 'merged' }]).moot).toBe(true);
+  });
+  it('no PR / empty / non-array → not moot', () => {
+    expect(isPrMoot([]).moot).toBe(false);
+    expect(isPrMoot(null).moot).toBe(false);
+    expect(isPrMoot(undefined).moot).toBe(false);
+  });
+});
+
+describe('fetchBranchPr — gh query (injectable exec)', () => {
+  it('parses gh JSON and targets the right repo + branch', () => {
+    const calls = [];
+    const fakeExec = (cmd) => { calls.push(cmd); return '[{"number":7,"state":"MERGED","mergedAt":"2026-05-21T00:00:00Z"}]'; };
+    const result = fetchBranchPr('rickfelix/EHG_Engineer', 'qf/QF-20260521-815', fakeExec);
+    expect(result).toEqual([{ number: 7, state: 'MERGED', mergedAt: '2026-05-21T00:00:00Z' }]);
+    expect(calls[0]).toContain('--repo rickfelix/EHG_Engineer');
+    expect(calls[0]).toContain('--head "qf/QF-20260521-815"');
+    expect(calls[0]).toContain('--state all');
+  });
+  it('returns null when gh errors (no PR / gh unavailable)', () => {
+    const throwingExec = () => { throw new Error('gh: no PRs'); };
+    expect(fetchBranchPr('r', 'b', throwingExec)).toBeNull();
+  });
+
+  it('end-to-end: a merged PR for the branch is detected as moot', () => {
+    const fakeExec = () => '[{"number":3829,"state":"MERGED"}]';
+    expect(isPrMoot(fetchBranchPr('rickfelix/EHG_Engineer', 'qf/x', fakeExec) || []).moot).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
`auto-resolve-recovered.js` can never clear a `ci_failure` row for a workflow that fails 100% of the time — `shouldAutoResolve` requires K consecutive **successful** runs. A never-succeeding gate produced 28 immortal rows (15 closed by hand).

**Fix:** a CA-independent **PR-merged-moot** path — when a `ci_failure` row's `metadata.branch` maps to a **MERGED or CLOSED** PR, the row is moot regardless of workflow health and is resolved as `resolution_type=pr_merged_moot`. New pure `isPrMoot` + injectable `fetchBranchPr` + a shared `resolveItem` helper. `run()` now also handles rows with a `branch` but no `workflow_name`.

## Tests
`tests/unit/auto-resolve-pr-moot.test.js` — **8/8** (pure, no DB/gh). ~49 source LOC. Closes the **P2** of feedback `0187ad17`; the **P3** 0%-success sweep is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
