### PR TITLE
QF-20260521-939: heal-before-complete best-tracking + regression-stop convergence guard

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -373,6 +373,20 @@ async function loadToleranceBuffer(supabase) {
  * @param {Object} supabase - Supabase client
  * @returns {Object} Gate configuration
  */
+/**
+ * QF-20260521-939 (RCA 12329ab5): convergence guard for the re-heal loop. scoreSD() re-rolls a
+ * NON-deterministic vision score on UNCHANGED SD content, so the loop must keep the BEST score+row
+ * and stop the moment a re-roll regresses below it — committing the last (often worse) roll forces
+ * spurious EXHAUSTED + a --bypass-validation. Pure + exported for direct unit testing.
+ * @param {{bestScore:number, bestScoreObj:any}} state - best seen so far
+ * @returns {{ bestScore:number, bestScoreObj:any, regression:boolean }}
+ */
+export function trackBestHealScore(state, newScore, newScoreObj) {
+  if (newScore > state.bestScore) return { bestScore: newScore, bestScoreObj: newScoreObj, regression: false };
+  if (newScore < state.bestScore) return { bestScore: state.bestScore, bestScoreObj: state.bestScoreObj, regression: true };
+  return { bestScore: state.bestScore, bestScoreObj: state.bestScoreObj, regression: false };
+}
+
 export function createHealBeforeCompleteGate(supabase) {
   return {
     name: 'HEAL_BEFORE_COMPLETE',
@@ -972,6 +986,14 @@ export function createHealBeforeCompleteGate(supabase) {
 
         let currentScore = sdHealScore;
         let currentScoreObj = latestScore;
+        // QF-20260521-939 (RCA 12329ab5): scoreSD() re-rolls a NON-deterministic vision score on
+        // UNCHANGED SD content, so track the BEST score+row across iterations and stop on a
+        // regression — the loop must not commit the last (often worse) roll (witnessed 80→83→70→58).
+        // No SD content is ever written, so "revert" only changes which already-persisted
+        // eva_vision_scores row the verdict reports; no DB rollback is needed.
+        let bestScore = sdHealScore;
+        let bestScoreObj = latestScore;
+        let regressionStop = false;
         let healIterations = 0;
         const iterationHistory = [];
 
@@ -1012,7 +1034,22 @@ export function createHealBeforeCompleteGate(supabase) {
           currentScoreObj = newScoreObj;
           currentScore = newScoreObj.total_score;
           console.log(`   📈 Iteration ${healIterations} produced score ${currentScore}`);
+
+          // QF-20260521-939: keep the best score+row; stop if a later re-roll regresses below it.
+          const conv = trackBestHealScore({ bestScore, bestScoreObj }, currentScore, newScoreObj);
+          bestScore = conv.bestScore;
+          bestScoreObj = conv.bestScoreObj;
+          if (conv.regression) {
+            regressionStop = true;
+            console.log(`   🛑 Regression detected (${currentScore} < best ${bestScore}); reverting to best score and stopping re-heal.`);
+            break;
+          }
         }
+
+        // QF-20260521-939: evaluate the verdict against the BEST score/row seen, not the last
+        // (possibly-regressed) iteration. bestScore >= currentScore always, so this only helps.
+        currentScore = bestScore;
+        currentScoreObj = bestScoreObj;
 
         // Convergence — PASS
         if (currentScore >= effectiveThreshold) {
@@ -1075,6 +1112,8 @@ export function createHealBeforeCompleteGate(supabase) {
           details: {
             verdict: 'EXHAUSTED',
             reason_code: GATE_REASON_CODES.HEAL_EXHAUSTED,
+            regression_stopped: regressionStop,
+            best_score: bestScore,
             sd_heal_score: currentScore,
             original_score: sdHealScore,
             auto_re_healed: healIterations > 0,

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.test.js
@@ -24,7 +24,7 @@ vi.mock('../../../../../../scripts/eva/vision-scorer.js', () => ({
   }),
 }));
 
-import { createHealBeforeCompleteGate } from './heal-before-complete.js';
+import { createHealBeforeCompleteGate, trackBestHealScore } from './heal-before-complete.js';
 
 /**
  * Build a routed mock supabase tuned for heal-before-complete.
@@ -189,6 +189,37 @@ describe('HEAL_BEFORE_COMPLETE — FR-2 iteration loop', () => {
       expect(result.details.iterations).toBeLessThanOrEqual(MAX_HEAL_ITERATIONS);
     }
     expect(MAX_HEAL_ITERATIONS).toBe(3); // sanity: spec is honored
+  });
+
+  // QF-20260521-939 (RCA 12329ab5): convergence-guard logic — best-tracking + regression-stop.
+  // The non-fast (feature) integration path keeps the score static across iterations, so the
+  // guard logic is unit-tested directly via the exported pure helper the loop uses.
+  it('TS-F: an improving score updates the best and does not stop', () => {
+    expect(trackBestHealScore({ bestScore: 70, bestScoreObj: { id: 'a' } }, 83, { id: 'b' }))
+      .toEqual({ bestScore: 83, bestScoreObj: { id: 'b' }, regression: false });
+  });
+
+  it('TS-G: a regressed score keeps the BEST and signals regression (report best, not the worse roll)', () => {
+    expect(trackBestHealScore({ bestScore: 83, bestScoreObj: { id: 'best' } }, 70, { id: 'worse' }))
+      .toEqual({ bestScore: 83, bestScoreObj: { id: 'best' }, regression: true });
+  });
+
+  it('TS-H: an equal score is neither improvement nor regression', () => {
+    expect(trackBestHealScore({ bestScore: 80, bestScoreObj: { id: 'x' } }, 80, { id: 'y' }))
+      .toEqual({ bestScore: 80, bestScoreObj: { id: 'x' }, regression: false });
+  });
+
+  it('TS-I: the witnessed 80→83→70→58 loop reports best 83 and stops at the first regression', () => {
+    let state = { bestScore: 80, bestScoreObj: { id: 's80' } };
+    let stopped = false;
+    for (const [score, obj] of [[83, { id: 's83' }], [70, { id: 's70' }], [58, { id: 's58' }]]) {
+      const r = trackBestHealScore(state, score, obj);
+      state = { bestScore: r.bestScore, bestScoreObj: r.bestScoreObj };
+      if (r.regression) { stopped = true; break; }
+    }
+    expect(stopped).toBe(true);
+    expect(state.bestScore).toBe(83); // NOT 58 — the witnessed-bug invariant
+    expect(state.bestScoreObj).toEqual({ id: 's83' });
   });
 
   // QF-20260506-295: per-SD vision_addressable_dimensions threshold override


### PR DESCRIPTION
## Summary
RCA of feedback `12329ab5` found the PLAN-TO-LEAD re-heal loop re-rolls a **non-deterministic** vision score on **unchanged** SD content (`scoreSD()` does no content mutation — DB forensics: 80→83→70→**58** for identical content) and committed the **last** iteration's score instead of the **best**, producing spurious `EXHAUSTED` verdicts that force `--bypass-validation`.

**Fix:** a best-tracking + regression-stop convergence guard — track the best score+row across iterations, stop the moment a re-roll regresses below the best, and evaluate the verdict against the **best**, not the last. Extracted as a pure exported `trackBestHealScore()` the loop calls. **No DB rollback** (no SD content is ever written; the "revert" only changes which already-persisted `eva_vision_scores` row the verdict reports). EXHAUSTED details now expose `best_score` + `regression_stopped`.

## Tests
`heal-before-complete.test.js` — **9/9**. TS-F/G/H/I added (the helper is unit-tested deterministically since the non-fast integration path keeps the score static); **TS-I simulates the witnessed 80→83→70→58 and asserts best 83, not 58**. Existing TS-A..E integration tests unchanged and still pass.

39 source LOC. Closes feedback `12329ab5`; a P3 follow-up to pin `temperature:0`/`seed` in `scoreSD()` (deeper determinism root cause) is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
