### PR TITLE
fix(eva): S11 GVOS-profile writer onConflict target (unblanks Stage 17)

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2521,6 +2521,7 @@ export class StageExecutionWorker {
       // Pass through the classifier's method verbatim — no normalization needed.
       const profileRow = {
         venture_id: ventureId,
+        version: 1,
         archetype_id: result.archetypeId || null,
         archetype_selection_method: result.method,
         archetype_selection_confidence: result.confidence,
@@ -2528,12 +2529,18 @@ export class StageExecutionWorker {
         business_model_class: venture.business_model_class || null,
       };
 
+      // onConflict MUST match the table's actual unique constraint (venture_id, version).
+      // Using 'venture_id' alone threw Postgres 42P10 and wrote 0 rows, which — combined
+      // with the swallowed error below — left every new venture without a GVOS profile and
+      // blanked Stage 17 (RCA 2026-05-22).
       const { error: upsertErr } = await this._supabase
         .from('venture_gvos_profile')
-        .upsert(profileRow, { onConflict: 'venture_id' });
+        .upsert(profileRow, { onConflict: 'venture_id,version' });
 
       if (upsertErr) {
-        logger.warn('[S11-GvosProfile] upsert failed:', upsertErr.message);
+        // Surface loudly: a silently-swallowed write here previously hid a 100%-reproducible
+        // failure that blanked Stage 17 for all new ventures.
+        logger.error('[S11-GvosProfile] profile upsert FAILED:', upsertErr.message);
         return;
       }
 


### PR DESCRIPTION
## Problem
Stage 17 (Blueprint Review) renders **blank** for every venture created after 2026-05-18. Reproduced live on venture ImpactPortfolio (RCA 2026-05-22).

## Root cause
`_postStageHook_S11_GvosProfile` (the S11 post-stage writer that creates `venture_gvos_profile`, shipped by **SD-LEO-FEAT-GVOS-ACTIVATION-REMEDIATION-001 / FR-4**) upserts with `onConflict: 'venture_id'`, but the table's unique constraint is `(venture_id, version)`. The mismatch throws Postgres **42P10**, writes **0 rows**, and the error was **silently swallowed** (`logger.warn(...); return`). So no GVOS profile was ever written via this path. The S17 GVOS surface (`GvosS17Sections` → `useVentureArchetype`) hard-gates on the profile row and returns `null` (blank) without it; with `s17_use_gvos_composer` ON (default), the legacy fallback gallery is flag-suppressed → guaranteed blank. The 2026-05-21 one-shot backfill migration only masked this for pre-existing ventures.

## Fix
- `onConflict: 'venture_id,version'` (matches the real unique constraint) + explicit `version: 1` in `profileRow`.
- Upgrade the upsert-failure log from `warn` → `error` so a future broken writer surfaces instead of failing dark.

## Validation
- Reproduced live: original upsert → 42P10 / 0 rows; corrected upsert writes the row.
- Backfilled the affected venture (ImpactPortfolio) with the corrected logic → **S17 now renders** (archetype "Calm Minimal" + composer preview + S15 wireframe screens; 0 console errors).
- `node --check` clean; pre-commit gates passed (11 LOC).

## Follow-ups (not in this PR)
- Backfill any other post-2026-05-18 ventures lacking a profile.
- Route post-stage-hook write failures to an audit / `eva_orchestration_events` row (defense-in-depth).
- Add a test asserting `venture_gvos_profile` upserts target a real unique constraint (PAT-WRITER-INVALID-ONCONFLICT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)