### PR TITLE
feat(SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001): S11 name promotion + logo-gen lookup fix (backend FR-1+FR-3)

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -156,9 +156,13 @@ export class StageExecutionWorker {
      * @type {Map<number, (ventureId: string) => Promise<void>>}
      */
     this._postStageHookRegistry = new Map([
-      // SD-LEO-FEAT-GVOS-ACTIVATION-REMEDIATION-001/FR-4: chain both S11 hooks.
+      // SD-LEO-FEAT-GVOS-ACTIVATION-REMEDIATION-001/FR-4: chain S11 hooks.
       // GvosProfile runs AFTER logo so classifier errors do not block logo rendering.
+      // SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001/FR-1: NamePromotion runs first so the
+      // promoted brand name is in place for the logo fallback prompt and downstream
+      // consumers. Each hook is independently non-throwing, so ordering is failure-safe.
       [11, async (ventureId) => {
+        await this._postStageHook_S11_NamePromotion(ventureId);
         await this._postStageHook_S11_LogoGeneration(ventureId);
         await this._postStageHook_S11_GvosProfile(ventureId);
       }],
@@ -2376,19 +2380,38 @@ export class StageExecutionWorker {
       return;
     }
 
-    // Load S11 data to get logoSpec
-    const { data: s11Work } = await this._supabase
-      .from('venture_stage_work')
-      .select('stage_data')
+    // SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001/FR-3: read logoSpec from the canonical
+    // identity_brand_name artifact, not venture_stage_work.stage_data. The S11 analysis
+    // writer (stage-templates/analysis-steps/stage-11-visual-identity.js) persists logoSpec
+    // inside identity_brand_name.artifact_data.logoSpec — it is NOT reliably mirrored into
+    // stage_data, which silently skipped logo generation for ventures that had a valid spec.
+    // The `artifact_data` JSONB column is the writeArtifact mapping (artifact-persistence-service.js).
+    let logoSpec = null;
+    const { data: brandArtifact } = await this._supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
       .eq('venture_id', ventureId)
-      .eq('lifecycle_stage', 11)
+      .eq('artifact_type', 'identity_brand_name')
       .order('updated_at', { ascending: false })
       .limit(1)
-      .single();
+      .maybeSingle();
+    logoSpec = brandArtifact?.artifact_data?.logoSpec || null;
 
-    const logoSpec = s11Work?.stage_data?.logoSpec;
+    // Legacy fallback: older ventures may have logoSpec mirrored into stage_data.
     if (!logoSpec) {
-      logger.log('[S11-Logo] No logoSpec in S11 data — skipping');
+      const { data: s11Work } = await this._supabase
+        .from('venture_stage_work')
+        .select('stage_data')
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', 11)
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      logoSpec = s11Work?.stage_data?.logoSpec || null;
+    }
+
+    if (!logoSpec) {
+      logger.log('[S11-Logo] No logoSpec in identity_brand_name artifact or S11 stage_data — skipping');
       return;
     }
 
@@ -2574,6 +2597,135 @@ export class StageExecutionWorker {
     } catch (err) {
       // Never throw — S11-LogoGeneration must remain the chairman-visible path.
       logger.warn('[S11-GvosProfile] hook errored (non-fatal):', err.message);
+    }
+  }
+
+  /**
+   * S11 post-stage hook: promote the chosen brand name into ventures.name.
+   *
+   * SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001 / FR-1
+   *
+   * Source of truth: identity_brand_name.artifact_data.decision.selectedName.
+   *
+   * PROVENANCE GUARD (no schema change).
+   * LEAD risk evidence: ventures.name has a large blast radius (it threads into
+   * repo names, prompts, docs, marketing copy and chairman-facing surfaces) AND
+   * the system has NO placeholder-name convention — at creation the name is
+   * auto-derived (discovery synthesis) and stored ONLY in ventures.name, with no
+   * separate original-name column, no name_source column, and no name-change audit
+   * row (verified live 2026-05-22). A naive "looks like a placeholder" string check
+   * is therefore unsafe, so this hook self-stamps its own provenance instead:
+   *
+   *   metadata.brand_name_promotion = { promoted_name, prior_name, promoted_at, sd,
+   *                                     source_selected_name }
+   *
+   * Decision table:
+   *   - No marker (first run): the auto-derived creation name has never been promoted.
+   *     Promote selectedName -> ventures.name and stamp the marker (records prior_name
+   *     for audit). This is the single intended promotion window; it runs early and
+   *     automatically in the same pipeline pass that produced the brand, before any
+   *     chairman name-edit surface exists.
+   *   - Marker present AND ventures.name === marker.promoted_name: the current name is
+   *     still exactly the value WE last wrote, so it is safe. Refresh to a changed
+   *     selectedName if needed (no write when already equal -> idempotent).
+   *   - Marker present AND ventures.name !== marker.promoted_name: a human/chairman
+   *     deliberately changed the name after our promotion. STOP permanently and never
+   *     overwrite. This is the chairman-edit detector that satisfies the FR-1 invariant.
+   *
+   * Residual risk (documented): a human edit made BETWEEN creation and the very first
+   * S11 promotion cannot be distinguished from the auto-derived creation name because
+   * no creation-name baseline is persisted anywhere. This is mitigated by promotion
+   * running early/automatically in-pipeline and by the no-op short-circuit when
+   * selectedName already equals the current name. Closing it fully would require a
+   * schema change (a creation-name/name_source column), which is out of scope here.
+   *
+   * Non-throwing / non-blocking: mirrors the GvosProfile hook posture — any error is
+   * logged and swallowed so it never blocks stage advancement.
+   *
+   * @param {string} ventureId
+   */
+  async _postStageHook_S11_NamePromotion(ventureId) {
+    const logger = this._logger;
+    const SD_TAG = 'SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001';
+
+    try {
+      // Read the chosen name from the canonical identity_brand_name artifact.
+      const { data: brandArtifact } = await this._supabase
+        .from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'identity_brand_name')
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      const selectedName = brandArtifact?.artifact_data?.decision?.selectedName;
+      if (!selectedName || typeof selectedName !== 'string' || !selectedName.trim()) {
+        logger.log('[S11-NamePromotion] No decision.selectedName in identity_brand_name artifact — skipping');
+        return;
+      }
+      const chosen = selectedName.trim();
+
+      // Load current venture name + provenance marker.
+      const { data: venture, error: ventureErr } = await this._supabase
+        .from('ventures')
+        .select('id, name, metadata')
+        .eq('id', ventureId)
+        .maybeSingle();
+
+      if (ventureErr || !venture) {
+        logger.warn('[S11-NamePromotion] venture load failed:', ventureErr?.message || 'venture not found');
+        return;
+      }
+
+      const metadata = venture.metadata || {};
+      const marker = metadata.brand_name_promotion || null;
+      const currentName = venture.name || null;
+
+      if (marker) {
+        // Provenance guard: only the value we ourselves last promoted is safe to touch.
+        if (currentName !== marker.promoted_name) {
+          logger.log(
+            '[S11-NamePromotion] Skipping — venture name was changed after promotion ' +
+            `(deliberate/chairman edit detected). current=${JSON.stringify(currentName)} ` +
+            `last_promoted=${JSON.stringify(marker.promoted_name)}`
+          );
+          return;
+        }
+        if (currentName === chosen) {
+          logger.log('[S11-NamePromotion] Skipping — name already promoted to selected value (idempotent)');
+          return;
+        }
+        // Safe refresh: name still equals our last promotion but selectedName changed.
+      }
+
+      // Promote (first run, or safe refresh).
+      const newMarker = {
+        promoted_name: chosen,
+        prior_name: currentName,
+        promoted_at: new Date().toISOString(),
+        sd: SD_TAG,
+        source_selected_name: chosen,
+      };
+
+      const { error: updateErr } = await this._supabase
+        .from('ventures')
+        .update({ name: chosen, metadata: { ...metadata, brand_name_promotion: newMarker } })
+        .eq('id', ventureId);
+
+      if (updateErr) {
+        logger.warn('[S11-NamePromotion] ventures.name promotion update failed:', updateErr.message);
+        return;
+      }
+
+      logger.log('[S11-NamePromotion] Promoted brand name', {
+        ventureId,
+        from: currentName,
+        to: chosen,
+      });
+    } catch (err) {
+      // Never throw — name promotion must never block stage advancement.
+      logger.warn('[S11-NamePromotion] hook errored (non-fatal):', err.message);
     }
   }
 

--- a/tests/unit/eva/stage-execution-worker-s11-brand-grounded.test.js
+++ b/tests/unit/eva/stage-execution-worker-s11-brand-grounded.test.js
@@ -1,0 +1,357 @@
+/**
+ * Tests for S11 brand-grounding post-stage hooks.
+ * SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001
+ *
+ *   FR-1: _postStageHook_S11_NamePromotion — promote identity_brand_name
+ *         decision.selectedName into ventures.name with a provenance guard that
+ *         never overwrites a deliberately-set / chairman-edited name.
+ *   FR-3: _postStageHook_S11_LogoGeneration — read logoSpec from the canonical
+ *         identity_brand_name artifact (artifact_data.logoSpec), falling back to
+ *         venture_stage_work.stage_data.logoSpec for legacy ventures.
+ *
+ * Both hooks use a mocked this._supabase. renderLogo + writeArtifact are mocked
+ * so the logo hook never makes a network/DB call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the renderer + persistence used by the logo hook (dynamic imports).
+vi.mock('../../../lib/eva/bridge/imagen-logo-renderer.js', () => ({
+  renderLogo: vi.fn(),
+}));
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: vi.fn().mockResolvedValue('artifact-id'),
+}));
+
+import { renderLogo } from '../../../lib/eva/bridge/imagen-logo-renderer.js';
+import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/**
+ * Per-table queued-response Supabase mock.
+ *
+ * `responses` maps a table name to an array of results consumed FIFO, one per
+ * terminal call. A terminal call is awaiting the chain itself (e.g. after
+ * `.limit()`), or calling `.maybeSingle()` / `.single()`. Each builder chain is
+ * also a thenable so `await supabase.from(t)....limit(1)` resolves to the next
+ * queued result. `.update(...)` records the payload and resolves to the next
+ * queued result (default { error: null }).
+ */
+function createQueuedSupabase(responses = {}) {
+  const queues = {};
+  for (const [t, arr] of Object.entries(responses)) queues[t] = [...arr];
+  const updateCalls = {}; // table -> array of update payloads
+
+  function nextResult(table) {
+    const q = queues[table];
+    if (q && q.length) return q.shift();
+    return { data: null, error: null };
+  }
+
+  function makeChain(table) {
+    const chain = {};
+    const passthrough = ['select', 'eq', 'neq', 'in', 'gte', 'lte', 'lt', 'gt', 'order', 'limit'];
+    for (const m of passthrough) chain[m] = vi.fn(() => chain);
+    chain.maybeSingle = vi.fn(() => Promise.resolve(nextResult(table)));
+    chain.single = vi.fn(() => Promise.resolve(nextResult(table)));
+    chain.update = vi.fn((payload) => {
+      (updateCalls[table] = updateCalls[table] || []).push(payload);
+      const result = nextResult(table);
+      // .update(...).eq(...) — return a thenable that also has .eq()
+      const upd = {
+        eq: vi.fn(() => Promise.resolve(result)),
+        then: (resolve) => resolve(result),
+      };
+      return upd;
+    });
+    chain.insert = vi.fn(() => ({ then: (resolve) => resolve(nextResult(table)) }));
+    // Make the chain itself awaitable (terminal after .limit() etc.)
+    chain.then = (resolve) => resolve(nextResult(table));
+    return chain;
+  }
+
+  const storage = {
+    from: vi.fn(() => ({
+      upload: vi.fn().mockResolvedValue({ error: null }),
+      getPublicUrl: vi.fn(() => ({ data: { publicUrl: 'https://example/logo.png' } })),
+    })),
+    createBucket: vi.fn().mockResolvedValue({ error: null }),
+  };
+
+  return {
+    from: vi.fn((table) => makeChain(table)),
+    storage,
+    _updateCalls: updateCalls,
+    _queues: queues,
+  };
+}
+
+function makeWorker(supabase, logger) {
+  return new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+}
+
+const VID = 'venture-uuid-abc';
+
+describe('FR-1: _postStageHook_S11_NamePromotion (provenance-guarded name promotion)', () => {
+  let logger;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+  });
+
+  it('promotes selectedName -> ventures.name on first run (no marker) and stamps provenance', async () => {
+    const supabase = createQueuedSupabase({
+      // 1) identity_brand_name artifact lookup
+      venture_artifacts: [
+        { data: { artifact_data: { decision: { selectedName: 'Stratum' } } }, error: null },
+      ],
+      // 2) ventures load (current auto-derived creation name, no marker), 3) update result
+      ventures: [
+        { data: { id: VID, name: 'DesignVerse AI', metadata: { stage_zero: { db_archetype: 'saas' } } }, error: null },
+        { error: null },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_NamePromotion(VID);
+
+    const updates = supabase._updateCalls.ventures || [];
+    expect(updates).toHaveLength(1);
+    expect(updates[0].name).toBe('Stratum');
+    // Provenance marker stamped, preserving prior name + existing metadata
+    expect(updates[0].metadata.brand_name_promotion.promoted_name).toBe('Stratum');
+    expect(updates[0].metadata.brand_name_promotion.prior_name).toBe('DesignVerse AI');
+    expect(updates[0].metadata.brand_name_promotion.sd).toBe('SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001');
+    expect(updates[0].metadata.stage_zero).toEqual({ db_archetype: 'saas' });
+  });
+
+  it('NEVER overwrites a deliberately-edited / chairman-set name on an S11 re-run (mandatory regression)', async () => {
+    // Chairman renamed the venture AFTER our promotion: current name !== marker.promoted_name.
+    const supabase = createQueuedSupabase({
+      venture_artifacts: [
+        { data: { artifact_data: { decision: { selectedName: 'Stratum' } } }, error: null },
+      ],
+      ventures: [
+        {
+          data: {
+            id: VID,
+            name: 'Chairman Chosen Name', // human edit after promotion
+            metadata: { brand_name_promotion: { promoted_name: 'Stratum', prior_name: 'DesignVerse AI' } },
+          },
+          error: null,
+        },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_NamePromotion(VID);
+
+    // No update must occur — the chairman edit is sticky forever.
+    expect(supabase._updateCalls.ventures || []).toHaveLength(0);
+  });
+
+  it('is idempotent: no write when name already promoted to the selected value', async () => {
+    const supabase = createQueuedSupabase({
+      venture_artifacts: [
+        { data: { artifact_data: { decision: { selectedName: 'Stratum' } } }, error: null },
+      ],
+      ventures: [
+        {
+          data: {
+            id: VID,
+            name: 'Stratum', // already equals selectedName + marker
+            metadata: { brand_name_promotion: { promoted_name: 'Stratum', prior_name: 'DesignVerse AI' } },
+          },
+          error: null,
+        },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_NamePromotion(VID);
+
+    expect(supabase._updateCalls.ventures || []).toHaveLength(0);
+  });
+
+  it('safe refresh: updates to a changed selectedName when current name still equals our last promotion', async () => {
+    const supabase = createQueuedSupabase({
+      venture_artifacts: [
+        { data: { artifact_data: { decision: { selectedName: 'StratumV2' } } }, error: null },
+      ],
+      ventures: [
+        {
+          data: {
+            id: VID,
+            name: 'Stratum', // equals marker.promoted_name -> still ours, safe to refresh
+            metadata: { brand_name_promotion: { promoted_name: 'Stratum', prior_name: 'DesignVerse AI' } },
+          },
+          error: null,
+        },
+        { error: null },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_NamePromotion(VID);
+
+    const updates = supabase._updateCalls.ventures || [];
+    expect(updates).toHaveLength(1);
+    expect(updates[0].name).toBe('StratumV2');
+    expect(updates[0].metadata.brand_name_promotion.prior_name).toBe('Stratum');
+  });
+
+  it('skips when artifact has no decision.selectedName', async () => {
+    const supabase = createQueuedSupabase({
+      venture_artifacts: [
+        { data: { artifact_data: { decision: {} } }, error: null },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_NamePromotion(VID);
+
+    expect(supabase._updateCalls.ventures || []).toHaveLength(0);
+    // ventures table should not even be queried for an update
+  });
+
+  it('error path is non-throwing (ventures load error is swallowed)', async () => {
+    const supabase = createQueuedSupabase({
+      venture_artifacts: [
+        { data: { artifact_data: { decision: { selectedName: 'Stratum' } } }, error: null },
+      ],
+      ventures: [
+        { data: null, error: { message: 'connection reset' } },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await expect(worker._postStageHook_S11_NamePromotion(VID)).resolves.toBeUndefined();
+    expect(supabase._updateCalls.ventures || []).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('does not throw when supabase itself throws (outer try/catch)', async () => {
+    const supabase = {
+      from: vi.fn(() => { throw new Error('boom'); }),
+      storage: {},
+    };
+    const worker = makeWorker(supabase, logger);
+    await expect(worker._postStageHook_S11_NamePromotion(VID)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[S11-NamePromotion] hook errored (non-fatal):',
+      'boom'
+    );
+  });
+});
+
+describe('FR-3: _postStageHook_S11_LogoGeneration (logoSpec source)', () => {
+  let logger;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+    renderLogo.mockResolvedValue({ buffer: Buffer.from('png'), mimeType: 'image/png' });
+  });
+
+  it('reads logoSpec from the identity_brand_name artifact (NOT stage_data)', async () => {
+    const logoSpec = { iconConcept: 'mountain', primaryColor: '#2563EB', textTreatment: 'Stratum' };
+    const supabase = createQueuedSupabase({
+      // 1) viability gate (stages >= 7), 2) idempotency (no existing logo)
+      venture_stage_work: [
+        { data: [{ lifecycle_stage: 11 }], error: null }, // viability gate
+      ],
+      venture_artifacts: [
+        { data: [], error: null }, // idempotency: no identity_logo_image
+        { data: { artifact_data: { logoSpec } }, error: null }, // identity_brand_name lookup
+      ],
+      ventures: [
+        { data: { name: 'Stratum' }, error: null }, // venture name fetch
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_LogoGeneration(VID);
+
+    expect(renderLogo).toHaveBeenCalledTimes(1);
+    expect(renderLogo).toHaveBeenCalledWith(logoSpec, expect.objectContaining({ ventureName: 'Stratum' }));
+    expect(writeArtifact).toHaveBeenCalledTimes(1);
+    const wrote = writeArtifact.mock.calls[0][1];
+    expect(wrote.artifactType).toBe('identity_logo_image');
+    expect(wrote.artifactData.logoSpec).toEqual(logoSpec);
+  });
+
+  it('falls back to venture_stage_work.stage_data.logoSpec when no artifact logoSpec', async () => {
+    const legacySpec = { iconConcept: 'legacy-icon', primaryColor: '#000000' };
+    const supabase = createQueuedSupabase({
+      venture_stage_work: [
+        { data: [{ lifecycle_stage: 11 }], error: null }, // viability gate
+        { data: { stage_data: { logoSpec: legacySpec } }, error: null }, // legacy fallback
+      ],
+      venture_artifacts: [
+        { data: [], error: null }, // idempotency
+        { data: { artifact_data: {} }, error: null }, // identity_brand_name has NO logoSpec
+      ],
+      ventures: [
+        { data: { name: 'LegacyCo' }, error: null },
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_LogoGeneration(VID);
+
+    expect(renderLogo).toHaveBeenCalledTimes(1);
+    expect(renderLogo).toHaveBeenCalledWith(legacySpec, expect.objectContaining({ ventureName: 'LegacyCo' }));
+  });
+
+  it('skips (no render) when neither artifact nor stage_data has a logoSpec', async () => {
+    const supabase = createQueuedSupabase({
+      venture_stage_work: [
+        { data: [{ lifecycle_stage: 11 }], error: null }, // viability gate
+        { data: { stage_data: {} }, error: null }, // legacy fallback empty
+      ],
+      venture_artifacts: [
+        { data: [], error: null }, // idempotency
+        { data: { artifact_data: {} }, error: null }, // no logoSpec
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_LogoGeneration(VID);
+
+    expect(renderLogo).not.toHaveBeenCalled();
+    expect(writeArtifact).not.toHaveBeenCalled();
+  });
+
+  it('idempotency: skips when identity_logo_image already exists', async () => {
+    const supabase = createQueuedSupabase({
+      venture_stage_work: [
+        { data: [{ lifecycle_stage: 11 }], error: null }, // viability gate
+      ],
+      venture_artifacts: [
+        { data: [{ id: 'existing-logo' }], error: null }, // idempotency hit
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_LogoGeneration(VID);
+
+    expect(renderLogo).not.toHaveBeenCalled();
+    expect(writeArtifact).not.toHaveBeenCalled();
+  });
+
+  it('viability gate: skips when venture has not passed S7', async () => {
+    const supabase = createQueuedSupabase({
+      venture_stage_work: [
+        { data: [], error: null }, // no stages >= 7
+      ],
+    });
+    const worker = makeWorker(supabase, logger);
+
+    await worker._postStageHook_S11_LogoGeneration(VID);
+
+    expect(renderLogo).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001 — backend (EHG_Engineer)

Backend half of the Venture-Brand-Grounded Stage 17 feature. Frontend (FR-2/4/5/6) ships separately in rickfelix/ehg PR #623.

### FR-3 — Logo generation lookup fix
`_postStageHook_S11_LogoGeneration` read `venture_stage_work.stage_data.logoSpec`, but the S11 writer stores logoSpec in the `identity_brand_name` artifact (`artifact_data.logoSpec`) — so logo generation silently skipped ("No logoSpec in S11 data"). Now reads the canonical artifact (venture_id-scoped, newest first) with a legacy stage_data fallback. All fail-safes preserved (S7 viability gate, idempotency, bucket auto-create, never-throw). `renderLogo` already consumes `iconConcept` (verified, unchanged).

### FR-1 — Provenance-guarded name promotion
New `_postStageHook_S11_NamePromotion` (chained first) promotes `identity_brand_name.decision.selectedName` → `ventures.name`, closing the name split-brain. Guard: a self-stamped `ventures.metadata.brand_name_promotion` marker — promote on first run, idempotent no-op when already promoted, and **never overwrite a name edited after promotion** (chairman-edit protection). Non-throwing.

### Constraints honored
- `_postStageHook_S11_GvosProfile` byte-identical (the recently-fixed onConflict hook — untouched).

### Tests
12 new Vitest unit tests (`tests/unit/eva/stage-execution-worker-s11-brand-grounded.test.js`), incl. the mandatory chairman-edit-never-overwritten regression. All pass. (2 pre-existing failures in `stage-execution-worker.test.js` are red on the origin/main baseline too — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
