### PR TITLE
fix(SD-LEO-INFRA-BRANCH-AWARE-PLAN-001): branch-aware git gates resolve the SD worktree (cross-repo)

### DIFF
--- a/lib/resolve-worktree-cwd.js
+++ b/lib/resolve-worktree-cwd.js
@@ -1,0 +1,106 @@
+/**
+ * resolve-worktree-cwd.js — Resolve the git worktree that holds an SD's branch.
+ *
+ * SD-LEO-INFRA-BRANCH-AWARE-PLAN-001
+ *
+ * Why: the PLAN-TO-LEAD git verifier GATE5 (scripts/verify-git-commit-status.js)
+ * and its sibling GATE6 (scripts/verify-git-branch-status.js) historically ran
+ * EVERY git command in the target repo ROOT (appPath, from resolveRepoPath()).
+ * For a cross-repo EHG SD whose branch lives in an `ehg/.worktrees/<SD>/`
+ * worktree while ehg main is occupied by ANOTHER branch (the normal
+ * multi-session case), the root reports the wrong current branch and main's
+ * uncommitted files — producing false "Branch SD-ID does not match target
+ * SD-ID" and "N uncommitted source files" blockers and forcing a
+ * --bypass-validation. Resolving the SD's worktree makes the checks read where
+ * the work actually lives; returning null preserves the no-worktree behavior
+ * byte-for-byte.
+ *
+ * Mechanism: enumerate `git worktree list --porcelain` in the TARGET repo
+ * (reusing listActiveWorktrees from worktree-quota.js — the single porcelain
+ * parser in this codebase) and match the worktree whose branch belongs to the
+ * SD. We do NOT read strategic_directives_v2.worktree_path: that column points
+ * at the EHG_Engineer worktree, which is the wrong repo for an EHG-targeted SD.
+ */
+
+import path from 'node:path';
+import { listActiveWorktrees } from './worktree-quota.js';
+
+/**
+ * Extract the canonical SD-ID from a branch name.
+ * SD-ID segments are UPPERCASE alphanumeric (with optional dots for versions);
+ * the slug suffix is lowercase, so the match naturally stops at the slug.
+ * Mirrors the extraction used by the verifiers' checkBranchMatchesSD.
+ *
+ * @param {string} branchName
+ * @returns {string|null}
+ */
+export function extractSdId(branchName) {
+  if (!branchName) return null;
+  const m = String(branchName).match(/SD-[A-Z0-9.]+(-[A-Z0-9.]+)*/);
+  return m ? m[0] : null;
+}
+
+/**
+ * Strip a leading `refs/heads/` from a branch ref. `git worktree list
+ * --porcelain` emits the `branch` field as `refs/heads/<name>`.
+ *
+ * @param {string} branch
+ * @returns {string}
+ */
+export function stripRefsHeads(branch) {
+  if (!branch) return '';
+  return String(branch).replace(/^refs\/heads\//, '');
+}
+
+/**
+ * Resolve the absolute path of the worktree currently checked out on the SD's
+ * branch within `appPath`'s repository, or null when none matches.
+ *
+ * Matching strategy (first hit wins):
+ *   1. Exact branch-name equality with `expectedBranch` (refs/heads/ stripped).
+ *   2. SD-ID equality: the worktree's branch extracts to the SAME SD-ID as the
+ *      target (handles slug vs no-slug canonical branch forms, e.g.
+ *      feat/SD-X vs feat/SD-X-some-slug). Exact SD-ID equality guards against
+ *      prefix collisions (SD-X must not match SD-X-CHILD or SD-X1).
+ *
+ * Safe by construction: any git failure inside listActiveWorktrees yields an
+ * empty list -> this returns null -> caller falls back to appPath.
+ *
+ * @param {string} appPath - Absolute path to the target repo ROOT.
+ * @param {object} [opts]
+ * @param {string} [opts.expectedBranch] - The SD's expected branch name.
+ * @param {string} [opts.sdId] - The SD key/ID (e.g. SD-LEO-INFRA-...).
+ * @returns {string|null} Absolute, normalized worktree path, or null.
+ */
+export function resolveWorktreeCwd(appPath, opts = {}) {
+  if (!appPath) return null;
+  const { expectedBranch, sdId } = opts;
+
+  let worktrees;
+  try {
+    worktrees = listActiveWorktrees(appPath);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(worktrees) || worktrees.length === 0) return null;
+
+  // 1. Exact branch-name match (preferred — unambiguous).
+  const expectedShort = stripRefsHeads(expectedBranch);
+  if (expectedShort) {
+    const exact = worktrees.find((wt) => stripRefsHeads(wt.branch) === expectedShort);
+    if (exact && exact.path) return path.resolve(exact.path);
+  }
+
+  // 2. SD-ID extraction fallback (slug vs no-slug canonical branch forms).
+  const targetSdId = sdId || extractSdId(expectedShort);
+  if (targetSdId) {
+    const byId = worktrees.find(
+      (wt) => extractSdId(stripRefsHeads(wt.branch)) === targetSdId
+    );
+    if (byId && byId.path) return path.resolve(byId.path);
+  }
+
+  return null;
+}
+
+export default resolveWorktreeCwd;

--- a/scripts/verify-git-branch-status.js
+++ b/scripts/verify-git-branch-status.js
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 
 import { resolveRepoPath } from '../lib/repo-paths.js';
+import { resolveWorktreeCwd } from '../lib/resolve-worktree-cwd.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
@@ -82,6 +83,12 @@ class GitBranchVerifier {
     this.sdTitle = sdTitle || '';
     this.appPath = appPath;
     this.worktreeMode = options.worktreeMode || false;
+    // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: directory git commands run in. Resolved
+    // to the SD's worktree in verify() ONLY in standard (non-worktree) mode.
+    // In worktreeMode the verifier intentionally reads the MAIN repo's branch to
+    // decide whether main must switch away so the worktree can hold the branch,
+    // so worktreeMode keeps appPath (byte-identical to prior behavior).
+    this.effectiveCwd = appPath;
     this.expectedBranchName = this.generateBranchName(sdId, sdTitle);
 
     // SD-LEO-INFRA-CROSS-REPO-MERGE-001 (FR-2): defensive scope assertion.
@@ -163,7 +170,7 @@ class GitBranchVerifier {
    */
   async gitCommand(command) {
     try {
-      const { stdout, stderr } = await execAsync(command, { cwd: this.appPath });
+      const { stdout, stderr } = await execAsync(command, { cwd: this.effectiveCwd });
       return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
     } catch (error) {
       return {
@@ -606,6 +613,24 @@ class GitBranchVerifier {
       this.results.blockers.push('Not a git repository');
       this.results.verdict = 'FAIL';
       return this.results;
+    }
+
+    // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: in STANDARD (non-worktree) mode, if the
+    // SD's branch is checked out in a worktree of this repo, run the read checks
+    // there so we don't false-fail against the repo root's current branch. In
+    // worktreeMode we deliberately keep appPath (the verifier reads the MAIN
+    // repo's branch to decide whether main must switch away for worktree
+    // checkout) — see the constructor note. Symmetric with GATE5's GitCommitVerifier.
+    if (!this.worktreeMode) {
+      const resolvedCwd = resolveWorktreeCwd(this.appPath, {
+        expectedBranch: this.expectedBranchName,
+        sdId: this.sdId,
+      });
+      if (resolvedCwd && resolvedCwd !== this.appPath) {
+        this.effectiveCwd = resolvedCwd;
+        console.log(`🌲 Worktree resolved: ${resolvedCwd}`);
+        console.log('   (branch checks run in the SD worktree, not the repo root)');
+      }
     }
 
     // f651e8eb: prefer existing canonical (no-slug) branch over creating a

--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -144,10 +144,18 @@ class GitCommitVerifier {
       return true;
     }
 
-    // Parse uncommitted files
+    // Parse uncommitted files.
+    // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: porcelain format is "XY <path>", but
+    // gitCommand() trims the whole stdout, which strips the leading status space
+    // of the FIRST line when X is blank (e.g. " M .worktree.json" -> "M .worktree
+    // .json"). A naive substring(3) then drops the path's first char
+    // (".worktree.json" -> "worktree.json"), defeating root-level artifact
+    // exclusions in isRootTempFile. Parse the path after the status+separator so
+    // it is correct whether or not the leading space was trimmed.
     this.results.uncommittedFiles = uncommittedLines.map(line => {
-      const status = line.substring(0, 2);
-      const file = line.substring(3);
+      const m = line.match(/^(.{1,2})\s+(.+)$/);
+      const status = m ? m[1] : line.substring(0, 2);
+      const file = m ? m[2] : line.substring(3);
       return { status, file };
     });
 

--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -108,7 +108,14 @@ class GitCommitVerifier {
       /-quality-report\.md$/,
       /-stories-summary\.json$/,
       /^credential-scan-results\.json$/,
-      /^SD-.*-README\.md$/
+      /^SD-.*-README\.md$/,
+      // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: worktree-runtime artifacts. Now that
+      // GATE5 resolves and reads the SD's worktree (not the repo root), these
+      // tooling-maintained files (.worktree.json heartbeat/session metadata,
+      // .worktree-nm-mode node_modules marker) are routinely dirty in a worktree
+      // and must NOT block the handoff — they are not source changes.
+      /^\.worktree\.json$/,
+      /^\.worktree-nm-mode$/
     ];
 
     return tempPatterns.some(p => p.test(filePath));

--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 
 import { resolveRepoPath } from '../lib/repo-paths.js';
+import { resolveWorktreeCwd } from '../lib/resolve-worktree-cwd.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +46,10 @@ class GitCommitVerifier {
     this.sdId = sdId;
     this.legacyId = options.legacyId || null; // SD-VENTURE-STAGE0-UI-001: Support legacy_id search
     this.appPath = appPath;
+    // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: the directory git commands actually run in.
+    // Resolved in verify() to the SD's worktree when its branch lives in one (the
+    // cross-repo / multi-session case); falls back to appPath (repo root) otherwise.
+    this.effectiveCwd = appPath;
     this.results = {
       cleanWorkingDirectory: false,
       commitsExist: false,
@@ -78,7 +83,7 @@ class GitCommitVerifier {
    */
   async gitCommand(command) {
     try {
-      const { stdout, stderr } = await execAsync(command, { cwd: this.appPath });
+      const { stdout, stderr } = await execAsync(command, { cwd: this.effectiveCwd });
       return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
     } catch (error) {
       return {
@@ -398,6 +403,19 @@ class GitCommitVerifier {
       this.results.blockers.push('Not a git repository');
       this.results.verdict = 'FAIL';
       return this.results;
+    }
+
+    // SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: when the SD's branch is checked out in
+    // a worktree of this repo (the cross-repo / multi-session case — e.g. an
+    // EHG SD whose branch lives in ehg/.worktrees/<SD>/ while ehg main is on
+    // another branch), run the branch + dirty-file checks THERE, not in the
+    // repo root. Falls back to appPath when no worktree matches, so single-
+    // session and EHG_Engineer self-target behavior is byte-identical.
+    const resolvedCwd = resolveWorktreeCwd(this.appPath, { sdId: this.sdId });
+    if (resolvedCwd && resolvedCwd !== this.appPath) {
+      this.effectiveCwd = resolvedCwd;
+      console.log(`Worktree resolved: ${resolvedCwd}`);
+      console.log('   (branch + dirty-file checks run in the SD worktree, not the repo root)');
     }
 
     // Run all checks

--- a/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
+++ b/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
@@ -177,4 +177,25 @@ describe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: GATE5 ignores worktree-runtime art
     expect(v.isRootTempFile('config.json')).toBe(false);
     expect(v.isRootTempFile('scripts/foo.js')).toBe(false);
   });
+
+  it('checkCleanWorkingDirectory: a leading .worktree.json (status space trimmed by stdout.trim) is excluded -> clean', async () => {
+    const v = new GitCommitVerifier('SD-X', '/repo');
+    // gitCommand trims the whole stdout, so the first porcelain line arrives as
+    // "M .worktree.json" (leading status space stripped). The robust parse must
+    // still recover ".worktree.json" so isRootTempFile excludes it.
+    vi.spyOn(v, 'gitCommand').mockResolvedValue({ stdout: 'M .worktree.json', stderr: '', success: true });
+    const ok = await v.checkCleanWorkingDirectory();
+    expect(ok).toBe(true);
+    expect(v.results.cleanWorkingDirectory).toBe(true);
+    expect(v.results.uncommittedFiles[0].file).toBe('.worktree.json');
+  });
+
+  it('checkCleanWorkingDirectory: a leading real source file (status space trimmed) is parsed correctly and still blocks', async () => {
+    const v = new GitCommitVerifier('SD-X', '/repo');
+    vi.spyOn(v, 'gitCommand').mockResolvedValue({ stdout: 'M src/foo.js', stderr: '', success: true });
+    const ok = await v.checkCleanWorkingDirectory();
+    expect(ok).toBe(false); // genuine source change still blocks
+    // path must be "src/foo.js", NOT the pre-fix corrupted "rc/foo.js"
+    expect(v.results.uncommittedFiles[0].file).toBe('src/foo.js');
+  });
 });

--- a/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
+++ b/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
@@ -24,6 +24,7 @@ vi.mock('../../../../lib/worktree-quota.js', async (importOriginal) => {
 });
 import { resolveWorktreeCwd, extractSdId, stripRefsHeads } from '../../../../lib/resolve-worktree-cwd.js';
 import { listActiveWorktrees } from '../../../../lib/worktree-quota.js';
+import GitCommitVerifier from '../../../../scripts/verify-git-commit-status.js';
 
 const fakeSupabase = {
   from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: () => ({}) }) }) }) }) }),
@@ -162,5 +163,18 @@ describe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: resolveWorktreeCwd', () => {
       { path: '/repo/.worktrees/detached', head: 'abc123' }, // no branch field
     ]);
     expect(resolveWorktreeCwd('/repo', { sdId: 'SD-X-001' })).toBeNull();
+  });
+});
+
+describe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: GATE5 ignores worktree-runtime artifacts', () => {
+  it('isRootTempFile excludes .worktree.json and .worktree-nm-mode (routinely dirty in every worktree)', () => {
+    const v = new GitCommitVerifier('SD-X', '/repo');
+    // Now that GATE5 reads the SD worktree, these tooling-maintained files would
+    // otherwise block every worktree-based handoff.
+    expect(v.isRootTempFile('.worktree.json')).toBe(true);
+    expect(v.isRootTempFile('.worktree-nm-mode')).toBe(true);
+    // Sanity: genuine source changes are still NOT treated as temp artifacts.
+    expect(v.isRootTempFile('config.json')).toBe(false);
+    expect(v.isRootTempFile('scripts/foo.js')).toBe(false);
   });
 });

--- a/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
+++ b/tests/unit/handoff/executors/precheck-apppath-fallback.test.js
@@ -10,9 +10,20 @@
  * Fix: getRequiredGates falls back to `options._appPath || this.determineTargetRepository(sd)`
  * in both executors, so precheck resolves the SD's target repo identically to execute().
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
 import { PlanToExecExecutor } from '../../../../scripts/modules/handoff/executors/plan-to-exec/index.js';
 import { PlanToLeadExecutor } from '../../../../scripts/modules/handoff/executors/plan-to-lead/index.js';
+
+// SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: the git verifiers (GATE5 commit / GATE6
+// branch) now resolve the SD's worktree before their branch + dirty-file checks.
+// Mock listActiveWorktrees so resolveWorktreeCwd can be exercised deterministically.
+vi.mock('../../../../lib/worktree-quota.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, listActiveWorktrees: vi.fn() };
+});
+import { resolveWorktreeCwd, extractSdId, stripRefsHeads } from '../../../../lib/resolve-worktree-cwd.js';
+import { listActiveWorktrees } from '../../../../lib/worktree-quota.js';
 
 const fakeSupabase = {
   from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: () => ({}) }) }) }) }) }),
@@ -58,5 +69,98 @@ describe('QF-20260520-358: precheck _appPath fallback (plan-to-lead)', () => {
     const spy = vi.spyOn(ex, 'determineTargetRepository').mockReturnValue('/sentinel/repo');
     ex.getRequiredGates(SD_LEAD, { _appPath: '/already/set' });
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: worktree resolution for GATE5/GATE6
+// ──────────────────────────────────────────────────────────────────────────
+describe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001: resolveWorktreeCwd', () => {
+  beforeEach(() => {
+    vi.mocked(listActiveWorktrees).mockReset();
+  });
+
+  it('helper: stripRefsHeads removes the refs/heads/ prefix', () => {
+    expect(stripRefsHeads('refs/heads/feat/SD-X-001-slug')).toBe('feat/SD-X-001-slug');
+    expect(stripRefsHeads('feat/SD-X-001')).toBe('feat/SD-X-001');
+    expect(stripRefsHeads(undefined)).toBe('');
+  });
+
+  it('helper: extractSdId pulls the canonical SD-ID and stops at the lowercase slug', () => {
+    expect(extractSdId('feat/SD-LEO-INFRA-BRANCH-AWARE-PLAN-001-some-slug')).toBe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001');
+    expect(extractSdId('feat/SD-LEO-INFRA-BRANCH-AWARE-PLAN-001')).toBe('SD-LEO-INFRA-BRANCH-AWARE-PLAN-001');
+    expect(extractSdId('main')).toBeNull();
+  });
+
+  it('case (a): EHG_Engineer SD with a worktree resolves to that worktree (exact branch match, refs/heads/ stripped)', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: '/repo/.worktrees/SD-X-001', branch: 'refs/heads/feat/SD-X-001' },
+    ]);
+    const out = resolveWorktreeCwd('/repo', { expectedBranch: 'feat/SD-X-001', sdId: 'SD-X-001' });
+    expect(out).toBe(path.resolve('/repo/.worktrees/SD-X-001'));
+  });
+
+  it('case (b): EHG cross-repo SD — ehg main is on ANOTHER branch, SD branch lives in a worktree -> resolves the worktree (SD-ID fallback)', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      // ehg main is checked out on a different SD's branch (not returned by
+      // listActiveWorktrees since it filters the main worktree); the SD's branch
+      // is in a worktree. Match by SD-ID even though expectedBranch is unknown (GATE5 path).
+      { path: '/ehg/.worktrees/SD-FDBK-001', branch: 'refs/heads/feat/SD-FDBK-001-restrict-approve' },
+      { path: '/ehg/.worktrees/SD-OTHER-999', branch: 'refs/heads/feat/SD-OTHER-999' },
+    ]);
+    const out = resolveWorktreeCwd('/ehg', { sdId: 'SD-FDBK-001' });
+    expect(out).toBe(path.resolve('/ehg/.worktrees/SD-FDBK-001'));
+  });
+
+  it('case (c): no worktree matches -> returns null so the caller falls back to appPath (byte-identical legacy behavior)', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: '/repo/.worktrees/SD-OTHER-001', branch: 'refs/heads/feat/SD-OTHER-001' },
+    ]);
+    expect(resolveWorktreeCwd('/repo', { expectedBranch: 'feat/SD-X-001', sdId: 'SD-X-001' })).toBeNull();
+  });
+
+  it('matches slug vs no-slug canonical branch forms via SD-ID extraction', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: '/repo/.worktrees/SD-X-001', branch: 'refs/heads/feat/SD-X-001' }, // no-slug canonical
+    ]);
+    // expected branch is the slugged form; should still match the no-slug worktree
+    const out = resolveWorktreeCwd('/repo', { expectedBranch: 'feat/SD-X-001-some-slug', sdId: 'SD-X-001' });
+    expect(out).toBe(path.resolve('/repo/.worktrees/SD-X-001'));
+  });
+
+  it('guards against SD-ID prefix collisions (SD-X-001 must not match SD-X-001-B)', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: '/repo/.worktrees/SD-X-001-B', branch: 'refs/heads/feat/SD-X-001-B' },
+    ]);
+    // Only a child SD's worktree is present; the parent SD-X-001 must NOT match it.
+    expect(resolveWorktreeCwd('/repo', { sdId: 'SD-X-001' })).toBeNull();
+  });
+
+  it('normalizes the returned worktree path (Windows backslashes -> path.resolve)', () => {
+    const winPath = 'C:\\\\repo\\\\.worktrees\\\\SD-X-001';
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: winPath, branch: 'refs/heads/feat/SD-X-001' },
+    ]);
+    const out = resolveWorktreeCwd('C:\\\\repo', { expectedBranch: 'feat/SD-X-001', sdId: 'SD-X-001' });
+    // The function returns path.resolve(wt.path) — assert it equals the normalized form,
+    // proving normalization happens rather than passing the raw mixed-separator string.
+    expect(out).toBe(path.resolve(winPath));
+  });
+
+  it('returns null when listActiveWorktrees yields [] (git failure -> graceful fallback)', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([]);
+    expect(resolveWorktreeCwd('/repo', { sdId: 'SD-X-001' })).toBeNull();
+  });
+
+  it('returns null when appPath is falsy', () => {
+    expect(resolveWorktreeCwd('', { sdId: 'SD-X-001' })).toBeNull();
+    expect(resolveWorktreeCwd(undefined, { sdId: 'SD-X-001' })).toBeNull();
+  });
+
+  it('ignores detached / branch-less worktrees', () => {
+    vi.mocked(listActiveWorktrees).mockReturnValue([
+      { path: '/repo/.worktrees/detached', head: 'abc123' }, // no branch field
+    ]);
+    expect(resolveWorktreeCwd('/repo', { sdId: 'SD-X-001' })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
PLAN-TO-LEAD GATE5 (`verify-git-commit-status.js`) and PLAN-TO-EXEC GATE6 (`verify-git-branch-status.js`) ran every git command in the target repo ROOT. For a cross-repo EHG SD whose branch lives in `ehg/.worktrees/<SD>/` while ehg main is on another branch (normal multi-session case), they read the wrong branch + main's dirty files → false "Branch SD-ID does not match" + "N uncommitted source files" blockers → forced `--bypass-validation`.

- **NEW `lib/resolve-worktree-cwd.js`** — resolves the SD's worktree via `git worktree list` (reuses `listActiveWorktrees`, no new parser), matched by exact branch then SD-ID, with `refs/heads/` stripping + prefix-collision guard; returns null → fallback to appPath.
- **GATE5** runs its branch + dirty-file checks in the resolved worktree.
- **GATE6** uses the same resolver, applied **only in standard mode** — `worktreeMode` (its real invocation) intentionally reads main's branch to manage worktree checkout, so it stays byte-identical.
- Excluded worktree-runtime artifacts (`.worktree.json`, `.worktree-nm-mode`) from the dirty-file filter, and fixed a latent porcelain-parse bug (global `stdout.trim()` dropped the first line's status space → corrupted path) — both surfaced by the live smoke test.

Rejected `strategic_directives_v2.worktree_path` (points at the EHG_Engineer worktree — wrong repo for EHG-targeted SDs). Complements PR #3839 (getRepoPath path-existence).

## Test plan
- [x] 18/18 unit tests (`tests/unit/handoff/executors/precheck-apppath-fallback.test.js`)
- [x] E2E smoke: fixed GATE5, given the shared EHG_Engineer root (on a different branch), resolves this SD's own worktree → verdict PASS
- [x] PLAN-TO-LEAD precheck 93% (GATE5 passes in the real gate)

SD: SD-LEO-INFRA-BRANCH-AWARE-PLAN-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)