### PR TITLE
fix(eva): logo renderer uses live Imagen 4 :predict (Imagen 3 retired)

### DIFF
--- a/lib/eva/bridge/imagen-logo-renderer.js
+++ b/lib/eva/bridge/imagen-logo-renderer.js
@@ -2,12 +2,15 @@
  * Imagen Logo Renderer
  * SD: SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
  *
- * Renders logo images from S11 logoSpec using Google Imagen 3 via Gemini API.
- * Returns a PNG buffer or null on failure (never throws).
+ * Renders logo images from S11 logoSpec using Google Imagen 4 via the Gemini API
+ * (generativelanguage v1beta :predict). Returns a PNG buffer or null on failure (never throws).
  */
 
-const IMAGEN_MODEL = 'imagen-3.0-generate-002';
-const FALLBACK_MODEL = 'imagen-3.0-generate-001';
+// Imagen 3 was retired from generativelanguage.googleapis.com/v1beta (model 404s).
+// Live models are Imagen 4 and use the :predict verb (not :generateImages).
+// Externalized to env so a future model retirement is a config change, not a code edit.
+const IMAGEN_MODEL = process.env.IMAGEN_LOGO_MODEL || 'imagen-4.0-fast-generate-001';
+const FALLBACK_MODEL = process.env.IMAGEN_LOGO_FALLBACK_MODEL || 'imagen-4.0-generate-001';
 
 /**
  * Render a logo image from a logoSpec using Google Imagen 3.
@@ -96,7 +99,7 @@ function sanitizePrompt(prompt) {
  * Call Google Imagen 3 API to generate an image.
  */
 async function callImagenAPI(apiKey, prompt, logger) {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${IMAGEN_MODEL}:generateImages?key=${apiKey}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${IMAGEN_MODEL}:predict?key=${apiKey}`;
 
   const body = {
     instances: [{ prompt }],
@@ -148,7 +151,7 @@ async function callImagenAPI(apiKey, prompt, logger) {
  * Fallback to older Imagen model if primary returns 404.
  */
 async function callImagenFallback(apiKey, prompt, logger) {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${FALLBACK_MODEL}:generateImages?key=${apiKey}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${FALLBACK_MODEL}:predict?key=${apiKey}`;
   logger.log('[ImagenLogo] Trying fallback model', { model: FALLBACK_MODEL });
 
   const response = await fetch(url, {
@@ -161,7 +164,13 @@ async function callImagenFallback(apiKey, prompt, logger) {
     signal: AbortSignal.timeout(60000),
   });
 
-  if (!response.ok) return null;
+  if (!response.ok) {
+    // Loud logging: a silent `return null` here masked the Imagen 3 retirement
+    // (404s swallowed) for an unknown period, surfacing only as "no logo".
+    const errText = await response.text().catch(() => 'unknown');
+    logger.warn(`[ImagenLogo] Fallback model ${FALLBACK_MODEL} :predict failed: ${response.status} ${errText.substring(0, 200)}`);
+    return null;
+  }
 
   const data = await response.json();
   const predictions = data.predictions || data.generatedImages || [];

--- a/tests/unit/eva/imagen-logo-renderer.test.js
+++ b/tests/unit/eva/imagen-logo-renderer.test.js
@@ -3,8 +3,8 @@
  * SD: SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001
  */
 
-import { describe, it, expect } from 'vitest';
-import { buildPromptVariants, sanitizePrompt } from '../../../lib/eva/bridge/imagen-logo-renderer.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildPromptVariants, sanitizePrompt, renderLogo } from '../../../lib/eva/bridge/imagen-logo-renderer.js';
 
 describe('imagen-logo-renderer', () => {
   describe('buildPromptVariants', () => {
@@ -60,6 +60,55 @@ describe('imagen-logo-renderer', () => {
     it('should handle non-string input', () => {
       expect(sanitizePrompt(123)).toBe('123');
       expect(sanitizePrompt(null)).toBe('null');
+    });
+  });
+
+  // QF regression (Google retired Imagen 3 from v1beta): lock in the live
+  // Imagen 4 model + :predict verb, and the no-longer-silent fallback failure.
+  describe('renderLogo — Imagen 4 :predict contract', () => {
+    const realFetch = global.fetch;
+    const realKey = process.env.GEMINI_API_KEY;
+    const realGoogle = process.env.GOOGLE_AI_API_KEY;
+    const quietLogger = { log() {}, warn() {} };
+
+    beforeEach(() => { process.env.GEMINI_API_KEY = 'test-key'; });
+    afterEach(() => {
+      global.fetch = realFetch;
+      if (realKey === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = realKey;
+      if (realGoogle === undefined) delete process.env.GOOGLE_AI_API_KEY; else process.env.GOOGLE_AI_API_KEY = realGoogle;
+      vi.restoreAllMocks();
+    });
+
+    it('calls an Imagen 4 model via :predict (not retired Imagen 3 / :generateImages)', async () => {
+      const urls = [];
+      global.fetch = vi.fn(async (url) => {
+        urls.push(url);
+        return { ok: true, status: 200, json: async () => ({ predictions: [{ bytesBase64Encoded: 'aGVsbG8=', mimeType: 'image/png' }] }), text: async () => '' };
+      });
+      const result = await renderLogo({ svgPrompt: 'a logo' }, { ventureName: 'Test', logger: quietLogger });
+      expect(result).not.toBeNull();
+      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(result.mimeType).toBe('image/png');
+      expect(urls[0]).toContain(':predict');
+      expect(urls[0]).not.toContain(':generateImages');
+      expect(urls[0]).toContain('imagen-4.0');
+      expect(urls[0]).not.toContain('imagen-3.0');
+    });
+
+    it('returns null (no throw) when no API key is present', async () => {
+      delete process.env.GEMINI_API_KEY;
+      delete process.env.GOOGLE_AI_API_KEY;
+      const result = await renderLogo({ svgPrompt: 'a logo' }, { logger: quietLogger });
+      expect(result).toBeNull();
+    });
+
+    it('logs loudly (not silently) when the fallback model also fails', async () => {
+      const warnings = [];
+      const logger = { log() {}, warn: (m) => warnings.push(String(m)) };
+      global.fetch = vi.fn(async () => ({ ok: false, status: 404, text: async () => 'NOT_FOUND' }));
+      const result = await renderLogo({ svgPrompt: 'a logo' }, { ventureName: 'T', maxRetries: 0, logger });
+      expect(result).toBeNull();
+      expect(warnings.some((w) => w.includes('Fallback model') && w.includes('failed'))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Google retired **Imagen 3** from the `generativelanguage.googleapis.com/v1beta` endpoint. `lib/eva/bridge/imagen-logo-renderer.js` called dead model IDs (`imagen-3.0-generate-002` / `-001`) **and** a non-existent verb (`:generateImages`), so every S11 logo generation 404'd. The fallback's `if (!response.ok) return null;` **silently swallowed** the 404 → surfaced only as "no logo."

Discovered during live validation of **SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001** (FR-3/FR-6): venture "Canvas AI" had a valid `logoSpec` but zero `identity_logo_image` artifacts. Root cause is a pre-existing defect in **SD-EVA-FEAT-LOGO-IMAGEN-PIPELINE-001**'s renderer, not the brand-grounding SD (whose lookup-path fix is confirmed working).

## Changes
- `IMAGEN_MODEL` → `imagen-4.0-fast-generate-001`, `FALLBACK_MODEL` → `imagen-4.0-generate-001` — both **env-overridable** (`IMAGEN_LOGO_MODEL` / `IMAGEN_LOGO_FALLBACK_MODEL`) so a future model retirement is a config change, not a code edit.
- Verb `:generateImages` → `:predict` (both call sites). The existing request body and `predictions[0].bytesBase64Encoded` parsing already match the predict contract — **no body/response changes needed**.
- Fallback now **logs status + body** before returning null (kills the silent-swallow that hid this).
- 3 regression tests lock in: Imagen 4 model + `:predict` verb (fails on revert to Imagen 3 / `:generateImages`), null-without-throw on missing key, and loud fallback logging.

## Test plan
- **Live contract probe**: both Imagen 4 models return HTTP 200 + `image/png` via `:predict` with the renderer's exact request body.
- **End-to-end re-run** for Canvas AI: fixed `renderLogo` → "Logo generated successfully { model: 'imagen-4.0-fast-generate-001' }" → 329KB PNG → uploaded to `venture-logos` → `identity_logo_image` artifact written (FR-3/FR-6 now satisfied).
- **Unit**: `npx vitest run tests/unit/eva/imagen-logo-renderer.test.js` → 11/11 pass (8 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
