### PR TITLE
fix(eva): Stage 19 tolerates brand-grounded/unregistered ventures

### DIFF
--- a/lib/eva/__tests__/stage-19-unregistered-venture.test.js
+++ b/lib/eva/__tests__/stage-19-unregistered-venture.test.js
@@ -1,0 +1,55 @@
+/**
+ * Stage 19 — brand-grounded / unregistered venture tolerance.
+ *
+ * Regression for the "Canvas AI" Stage-19 stall (2026-05-23): a venture renamed
+ * off its registered registry key by SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001 made
+ * the sprint-plan analyzer throw VentureNotRegisteredError at routing resolution.
+ * The throw left 0 artifacts + empty advisory_data, yet the post-execution hard
+ * gate still opened a pending chairman decision — so the venture parked at a
+ * content-less gate and the Stage-19 panel spun "Loading Sprint Planning…"
+ * indefinitely.
+ *
+ * resolveStage19Routing must degrade gracefully for a NAMED-but-unregistered
+ * venture (no throw), while NEVER silently routing to the 'ehg' default and
+ * still failing closed for the null-venture security case (C-SEC-8B).
+ */
+import { describe, test, expect } from 'vitest';
+import { resolveStage19Routing } from '../stage-templates/analysis-steps/stage-19-sprint-planning.js';
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+describe('Stage 19 routing — unregistered/brand-grounded venture tolerance', () => {
+  test('registered venture ("ehg") resolves normally (no fallback)', () => {
+    const routing = resolveStage19Routing('ehg', silentLogger);
+    expect(routing.targetApp).toBe('ehg');
+    expect(routing.fallback).toBe(false);
+  });
+
+  test('unregistered venture ("Canvas AI") degrades gracefully instead of throwing', () => {
+    let routing;
+    expect(() => {
+      routing = resolveStage19Routing('Canvas AI', silentLogger);
+    }).not.toThrow();
+    // target_application is stamped with the venture's own name — NEVER the
+    // silent 'ehg' default the fail-closed rule guards against.
+    expect(routing.targetApp).toBe('Canvas AI');
+    expect(routing.targetApp).not.toBe('ehg');
+    expect(routing.fallback).toBe(true);
+    expect(routing.unregistered).toBe(true);
+  });
+
+  test('graceful fallback warns loudly (not silent)', () => {
+    const warnings = [];
+    const logger = { log() {}, warn: (...a) => warnings.push(a), error() {} };
+    resolveStage19Routing('Some Unregistered Venture XYZ', logger);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(String(warnings[0][0])).toMatch(/not in registry/i);
+  });
+
+  test('null venture name still fails closed (no silent EHG via omitted name)', () => {
+    // sd_type 'feature' is NOT a legitimate no-venture type, so a null name must
+    // still throw. resolveStage19Routing only softens the registry-miss case for
+    // a NAMED venture — it does not reopen the C-SEC-8B null-venture hole.
+    expect(() => resolveStage19Routing(null, silentLogger)).toThrow();
+  });
+});

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -57,6 +57,60 @@ function resolveAppType(stage15Data) {
   return sorted.length > 0 ? sorted[0][0] : 'agnostic';
 }
 
+/**
+ * Resolve target_application routing for the Stage 19 sprint plan.
+ *
+ * Stage 19 is sprint-plan GENERATION (preview content for chairman review), not
+ * SD CREATION. resolveTargetApplication is fail-closed and throws
+ * VentureNotRegisteredError on a registry miss
+ * (SD-LEO-INFRA-FAIL-CLOSED-VENTURE-001-B) so an unregistered venture never
+ * silently routes a build to EHG. But throwing HERE aborts the whole stage: no
+ * artifact + empty advisory_data are persisted, yet the post-execution hard gate
+ * still opens a pending decision — so the venture parks at a content-less gate
+ * and the Stage-19 panel spins "Loading Sprint Planning…" forever. This bit
+ * "Canvas AI" live (2026-05-23): the venture was renamed off its registered key
+ * by SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001, so every brand-grounded venture
+ * would hit the same wall at Stage 19.
+ *
+ * Degrade gracefully on a registry miss for a NAMED venture: stamp
+ * target_application with the venture's own name — never the silent 'ehg'
+ * default the fail-closed rule guards against — and let the sprint plan
+ * generate. routing.targetApp is only preview metadata on the sprint items /
+ * sd_bridge_payloads (it is not displayed), and the real fail-closed enforcement
+ * still runs at the SD-CREATION boundary (lifecycle-sd-bridge re-resolves
+ * routing and blocks a still-unregistered venture there).
+ *
+ * The null/empty-name case is NOT softened — that is the C-SEC-8B security hole
+ * (any caller routing to EHG by omitting venture_name) and stays fail-closed.
+ * Any non-registry error is also rethrown unchanged.
+ *
+ * @param {string|null|undefined} ventureName
+ * @param {Object} [logger=console]
+ * @returns {{ targetApp: string, githubRepo: string|null, localPath: string|null, supabaseSchema: string|null, fallback: boolean, unregistered?: boolean }}
+ */
+export function resolveStage19Routing(ventureName, logger = console) {
+  try {
+    return resolveTargetApplication(ventureName, { sd_type: 'feature', logger });
+  } catch (err) {
+    if (err?.name === 'VentureNotRegisteredError' && ventureName) {
+      logger.warn(
+        '[Stage19] Venture not in registry — generating sprint plan with unresolved routing; ' +
+          'build-SD creation will re-validate target_application at gate approval',
+        { ventureName, error: err.message }
+      );
+      return {
+        targetApp: ventureName,
+        githubRepo: null,
+        localPath: null,
+        supabaseSchema: null,
+        fallback: true,
+        unregistered: true,
+      };
+    }
+    throw err;
+  }
+}
+
 // Render EHG_VENTURE_DEFAULT_CAPABILITIES as inline prompt text. Imported
 // from config so updates flow from one source. SD-LEO-ENH-CONSTRAIN-STAGE-EMIT-001.
 const MANDATORY_CAPABILITIES_BLOCK = EHG_VENTURE_DEFAULT_CAPABILITIES
@@ -374,15 +428,12 @@ Output ONLY valid JSON.`;
     logger.warn('[Stage19] LLM fallback fields detected', { llmFallbackCount });
   }
 
-  // Resolve venture routing from registry (replaces hardcoded 'ehg').
-  // SD-LEO-INFRA-FAIL-CLOSED-VENTURE-001-B (PA-1): resolveTargetApplication now
-  // throws VentureNotRegisteredError on registry-miss instead of falling back
-  // to EHG silently. Stage 19 SDs are 'feature'-typed (or 'feature' with valid
-  // venture context); the null-venture branch with sd_type 'feature' will
-  // throw, which is the intended fail-closed behavior. Caller (worker dispatch)
-  // catches VentureNotRegisteredError and aborts the SD-creation transaction.
-  // Sync variant retained — async migration tracked separately.
-  const routing = resolveTargetApplication(ventureName, { sd_type: 'feature', logger });
+  // Resolve venture routing. resolveTargetApplication is fail-closed (throws on a
+  // registry miss) which is correct for SD CREATION, but Stage 19 is sprint-plan
+  // GENERATION — resolveStage19Routing() degrades gracefully on a miss for a
+  // named (e.g. brand-grounded) venture so the plan still renders, while keeping
+  // fail-closed for the null-venture case and at the SD-creation boundary.
+  const routing = resolveStage19Routing(ventureName, logger);
 
   // appType resolved earlier (before platformContext, see comment there).
   if (appType !== 'agnostic') {


### PR DESCRIPTION
## Problem
Stage 19 (Sprint Planning) parks ventures at a **content-less chairman gate** with an endlessly-spinning "Loading Sprint Planning…" panel when the venture isn't in `applications/registry.json`.

The S19 analyzer calls `resolveTargetApplication(ventureName)`, which is **fail-closed** — it throws `VentureNotRegisteredError` on a registry miss (SD-LEO-INFRA-FAIL-CLOSED-VENTURE-001-B) so an unregistered venture never silently routes a build to EHG. That's correct for **SD creation**, but S19 is **sprint-plan generation**: the throw aborts the stage *before* any artifact / `advisory_data` is persisted — yet the post-execution hard-gate check still opens a pending chairman decision. Result: 0 artifacts + empty advisory behind a pending gate → the panel spins forever.

**Live trigger:** `SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001` renames ventures to their real brand name (e.g. `DesignVerse AI → Canvas AI`), moving them off their registered registry key — so **every brand-grounded venture hits this wall at S19.** Root-caused on venture "Canvas AI" 2026-05-23 (3 failed S19 attempts in `stage_executions`, all `VentureNotRegisteredError`).

## Fix
Extract `resolveStage19Routing()` and call it at the S19 resolve site. On a registry miss for a **named** venture it degrades gracefully — stamping `target_application` with the venture's **own name** (never the silent `'ehg'` default the fail-closed rule guards against) — so the sprint plan generates and renders.

- `routing.targetApp` is only **preview metadata** on sprint items / `sd_bridge_payloads` (not displayed by `Stage19SprintPlanning.tsx`), so the fallback is invisible and safe.
- **Security preserved:** the null-venture case (C-SEC-8B) stays fail-closed (rethrows), and the real enforcement still runs at the **SD-creation boundary** (`lifecycle-sd-bridge` re-resolves routing and blocks a still-unregistered venture there). `sd-router.js` is untouched.

## Tests
- New `lib/eva/__tests__/stage-19-unregistered-venture.test.js` (4 cases): registered venture resolves; unregistered degrades (no throw, own name stamped, not 'ehg'); fallback warns loudly; null venture still fails closed.
- Existing S19 suites green (32 passed total); smoke tests pass.

## Deploy / scope notes
- The worker must be **restarted** to load this change (the `analysis-steps/` dir is not file-watched).
- This prevents the stall for **future** S19 entries. A venture **already** parked at a content-less gate (e.g. Canvas AI) additionally needs its stale pending decision cleared to re-run — a separate, opt-in step (no venture state is mutated by this PR).
- Follow-up (not in this PR): the worker opening a chairman gate behind a `FAILED` stage (the general "phantom gate" mechanism) is worth a separate, carefully-reviewed fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
