### PR TITLE
fix(eva): don't open a chairman gate behind a FAILED stage

### DIFF
--- a/lib/eva/__tests__/should-open-chairman-gate.test.js
+++ b/lib/eva/__tests__/should-open-chairman-gate.test.js
@@ -1,0 +1,31 @@
+/**
+ * Regression for the "Canvas AI" Stage-19 content-less phantom gate (2026-05-23):
+ * the worker opened a chairman gate behind a FAILED stage, creating a pending
+ * decision with no artifact/advisory → the venture parked at a content-less gate
+ * and the panel spun "Loading…" forever. shouldOpenChairmanGate must refuse to
+ * open a gate behind a failed/empty stage, while preserving the build-loop
+ * governance-override path and the normal (successful-stage) review flow.
+ */
+import { describe, test, expect } from 'vitest';
+import { shouldOpenChairmanGate } from '../should-open-chairman-gate.js';
+
+describe('shouldOpenChairmanGate — no content-less gate behind a FAILED stage', () => {
+  test('non-gate stage never opens a gate', () => {
+    expect(shouldOpenChairmanGate({ isHardGate: false, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(false);
+    expect(shouldOpenChairmanGate({ isHardGate: false, stageFailed: true, canGovernanceOverrideFailed: false })).toBe(false);
+  });
+
+  test('hard gate + successful stage opens the gate (normal review flow)', () => {
+    expect(shouldOpenChairmanGate({ isHardGate: true, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(true);
+  });
+
+  test('REGRESSION: hard gate + FAILED + not governance-overridable does NOT open a gate', () => {
+    // The exact Canvas AI S19 case: a failed stage must surface as FAILED, never as
+    // a content-less "awaiting decision" gate.
+    expect(shouldOpenChairmanGate({ isHardGate: true, stageFailed: true, canGovernanceOverrideFailed: false })).toBe(false);
+  });
+
+  test('hard gate + FAILED + build-loop governance override still opens the gate (unchanged)', () => {
+    expect(shouldOpenChairmanGate({ isHardGate: true, stageFailed: true, canGovernanceOverrideFailed: true })).toBe(true);
+  });
+});

--- a/lib/eva/should-open-chairman-gate.js
+++ b/lib/eva/should-open-chairman-gate.js
@@ -1,0 +1,29 @@
+/**
+ * Pure policy — should the worker open a post-execution chairman gate for a stage?
+ *
+ * Returns false when the stage produced no usable result (FAILED or missing) UNLESS
+ * the build-loop governance-override path applies.
+ *
+ * Why this exists (RCA: Canvas AI Stage 19, 2026-05-23): the worker's post-execution
+ * hard-gate check ran unconditionally — even when processStage returned FAILED with
+ * zero artifacts. That opened a pending "stage_gate" chairman_decision with no
+ * artifact/advisory behind it, so the venture parked at a CONTENT-LESS gate and the
+ * Stage panel spun "Loading…" forever. A failed stage must instead surface via the
+ * worker's FAILED handler (orchestrator_state='failed' — a clean terminal state),
+ * not as a misleading "awaiting decision" gate.
+ *
+ * The build-loop governance-override path (a FAILED stage 17-22 that governance
+ * auto-advances) keeps opening its gate so existing auto-advance behaviour is
+ * unchanged.
+ *
+ * @param {object} args
+ * @param {boolean} args.isHardGate - stage is a hardcoded or dynamic hard gate
+ * @param {boolean} args.stageFailed - processStage returned FAILED or produced no result
+ * @param {boolean} args.canGovernanceOverrideFailed - build-loop (17-22) FAILED stage that governance auto-advances
+ * @returns {boolean} true if a chairman gate should be opened for this stage
+ */
+export function shouldOpenChairmanGate({ isHardGate, stageFailed, canGovernanceOverrideFailed }) {
+  if (!isHardGate) return false;
+  if (stageFailed && !canGovernanceOverrideFailed) return false;
+  return true;
+}

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -37,6 +37,7 @@ import { hostname } from 'os';
 import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
+import { shouldOpenChairmanGate } from './should-open-chairman-gate.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -1025,7 +1026,24 @@ export class StageExecutionWorker {
         // Also check hard_gate_stages from DB config (dynamic gates beyond the hardcoded set).
         const isHardcodedGate = govPost.isBlocking(currentStage);
         const isDynamicHardGate = !isHardcodedGate && await this._isInHardGateStages(currentStage);
-        if (isHardcodedGate || isDynamicHardGate) {
+
+        // Compute failure state BEFORE opening any chairman gate. A FAILED (or
+        // missing) stage result must NOT open a hard-gate chairman decision: doing
+        // so creates a pending "awaiting decision" gate with no artifact/advisory
+        // behind it, so the venture parks at a content-less gate and the stage
+        // panel spins "Loading…" forever (RCA: Canvas AI S19, 2026-05-23). A failed
+        // stage instead surfaces via the FAILED handler below (orchestrator_state
+        // ='failed' — a clean terminal state). The build-loop governance-override
+        // path (canGovernanceOverrideFailed) keeps its existing gate handling so
+        // auto-advance behaviour is byte-identical. _canAutoAdvance is only called
+        // for FAILED build-loop stages (&&-short-circuit) — no extra RPC on success.
+        const resultStatus = (result?.status || '').toUpperCase();
+        const stageFailed = !result || resultStatus === 'FAILED';
+        const canGovernanceOverrideFailed = resultStatus === 'FAILED'
+          && currentStage >= 17 && currentStage <= 22
+          && await this._canAutoAdvance(currentStage);
+
+        if (shouldOpenChairmanGate({ isHardGate: isHardcodedGate || isDynamicHardGate, stageFailed, canGovernanceOverrideFailed })) {
           const gateResult = await this._handleChairmanGate(ventureId, currentStage);
           if (gateResult.blocked) {
             // Only revert current_lifecycle_stage when actually blocked for
@@ -1057,15 +1075,13 @@ export class StageExecutionWorker {
           // (line ~630), not here — hard-gated stages never reach this block on re-entry.
         }
 
-        const resultStatus = (result?.status || '').toUpperCase();
-        if (!result || resultStatus === 'FAILED') {
+        // resultStatus / stageFailed / canGovernanceOverrideFailed were computed
+        // above (before the gate block) so a FAILED stage never opens a gate.
+        if (stageFailed) {
           // For build-loop stages with auto-approve, treat FAILED as BLOCKED so
           // governance can override. Analysis steps throw REFUSED for LLM-disabled
           // stages, which becomes FAILED — but governance should still advance.
           // RCA: PAT-ORCH-STATE-001 (FAILED vs BLOCKED in build-loop)
-          const canGovernanceOverrideFailed = resultStatus === 'FAILED'
-            && currentStage >= 17 && currentStage <= 22
-            && await this._canAutoAdvance(currentStage);
           if (!canGovernanceOverrideFailed) {
             this._logger.error(`[Worker] Stage ${currentStage} failed for ${ventureId} after retries`);
             this._logStageTransition(ventureId, currentStage, 'failed', stageDurationMs, result).catch(() => {});


### PR DESCRIPTION
## Problem (the bug class behind the Canvas AI S19 stall)
The worker's post-execution hard-gate check (`stage-execution-worker.js`) ran **unconditionally** — even when `processStage` returned `FAILED` with zero artifacts. It opened a pending `stage_gate` `chairman_decision` with **no artifact/advisory behind it**, so the venture parked at a content-less gate and the stage panel spun **"Loading…" forever** (and clearing it manually re-triggers a duplicate-artifact loop).

This is the *mechanism* behind the Canvas AI S19 stall (2026-05-23): a registry-miss throw made the analysis `FAILED`, yet the gate still opened. **PR #3843** fixed that one *trigger*; this PR closes the **class** — any failure at any of the 10 hard-gate stages (3/5/10/13/17/18/19/23/24/25) would otherwise reproduce the exact spinning content-less gate.

## Fix
Extract the gate-open decision into a pure, unit-tested **`shouldOpenChairmanGate()`** and guard the post-exec gate block with it:
- Open a gate only for a hard gate whose stage did **not** fail.
- **Exception preserved:** the build-loop governance-override path (a `FAILED` stage 17-22 that governance auto-advances) keeps opening its gate — **byte-identical** behaviour.
- A `FAILED`/missing-result stage now falls through to the existing FAILED handler → `orchestrator_state='failed'` (a clean **terminal** state), instead of a misleading gate.
- A `BLOCKED`-result stage is **not** treated as failed, so it still opens its gate (legit gate state with content).

`resultStatus` / `stageFailed` / `canGovernanceOverrideFailed` are hoisted above the gate block and reused by the FAILED handler (`_canAutoAdvance` still `&&`-short-circuits, so **no extra RPC on a successful stage**).

```js
export function shouldOpenChairmanGate({ isHardGate, stageFailed, canGovernanceOverrideFailed }) {
  if (!isHardGate) return false;
  if (stageFailed && !canGovernanceOverrideFailed) return false;
  return true;
}
```

## Why no re-run loop
A FAILED venture is **excluded from re-selection** — the worker only picks `orchestrator_state='idle'` (`stage-execution-worker.js:466`), and `releaseState=FAILED` writes `orchestrator_state='failed'`. So this yields a clean terminal FAILED, not a re-run loop.

## Tests / verification
- `node --check` clean on both files.
- New `lib/eva/__tests__/should-open-chairman-gate.test.js` — 4 cases (non-gate; success→open; **FAILED non-overridable→no gate** (the regression); FAILED build-loop override→still open).
- S19 suites green.
- **Behaviour-neutral on the worker suite:** `tests/unit/eva/stage-execution-worker.test.js` shows the same `2 failed | 16 passed | 2 skipped` with and without this change (verified via stash baseline — the 2 failures are pre-existing/environmental, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
