### PR TITLE
fix(QF-20260523-481): correct check-git-state.js import path in precheck CLI

### DIFF
--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -443,7 +443,7 @@ export async function handlePrecheckCommand(precheckType, precheckSdId) {
   console.log('STEP 1: GIT STATE CHECK');
   console.log('─'.repeat(50));
   try {
-    const { checkGitState } = await import('../../check-git-state.js');
+    const { checkGitState } = await import('../../../check-git-state.js');
     const gitResult = await checkGitState();
     if (!gitResult.passed) {
       console.log('');


### PR DESCRIPTION
## Summary
Handoff precheck **STEP 1 (git-state check)** was silently skipped on every run. `scripts/modules/handoff/cli/cli-main.js` imported `'../../check-git-state.js'`, which resolves to the nonexistent `scripts/modules/check-git-state.js`. The import threw and was swallowed by the surrounding `try/catch`, so `checkGitState()` never ran — git-state validation (uncommitted/unpushed/branch checks) was effectively disabled at every precheck.

The real module is `scripts/check-git-state.js` (three levels up). The failure hint already printed at line 451 (`Run: node scripts/check-git-state.js for details`) pointed at the correct location.

## Fix
One-line import path correction: `'../../check-git-state.js'` → `'../../../check-git-state.js'`.

## Verification
`path.resolve` from the importer directory:
- OLD `../../check-git-state.js` → `scripts/modules/check-git-state.js` — **does not exist**
- NEW `../../../check-git-state.js` → `scripts/check-git-state.js` — **exists**, exports `checkGitState` returning `{ passed, ... }` matching the call site.

## Tracking
- Quick Fix: QF-20260523-481 (Tier 1, ≤30 LOC)
- Closes harness_backlog `885f1493`

🤖 Generated with [Claude Code](https://claude.com/claude-code)