### PR TITLE
fix(QF-20260523-640): GATE4 fetch missing gate1/gate2 when only gate3 provided

### DIFF
--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -124,7 +124,22 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     const acceptedHandoffs = { gate1: false, gate2: false, gate3: false };
     // SD-LEARN-FIX-ADDRESS-PAT-AUTO-002: Track data sources for audit trail
     const gateDataSources = { gate1: 'none', gate2: 'none', gate3: 'none' };
-    if (!gateResults.gate1 && !gateResults.gate2 && !gateResults.gate3) {
+    // Mark any DIRECTLY-provided gate results as accepted/direct up front. A caller may
+    // legitimately supply only a SUBSET — e.g. the PLAN-TO-LEAD wrapper passes the
+    // freshly-computed gate3 from ctx but not gate1/gate2. Provided values are never
+    // clobbered by the canonical fetch below (the `if (!gateResults.gateN)` guards).
+    if (gateResults.gate1) { acceptedHandoffs.gate1 = true; gateDataSources.gate1 = 'direct'; }
+    if (gateResults.gate2) { acceptedHandoffs.gate2 = true; gateDataSources.gate2 = 'direct'; }
+    if (gateResults.gate3) { acceptedHandoffs.gate3 = true; gateDataSources.gate3 = 'direct'; }
+
+    // Fetch ANY gate not provided directly. BUGFIX (harness_backlog 5986136e): the guard
+    // was `!gate1 && !gate2 && !gate3` (fetch only when ALL THREE absent). A partial caller
+    // — the PLAN-TO-LEAD wrapper supplying gate3-from-ctx — made that guard false and
+    // suppressed the canonical fetch for gate1/gate2, leaving them null -> spurious
+    // "only 1/3 gates cleared" at PLAN-TO-LEAD on every code SD. (gate1_validation legacy key
+    // is no longer written; gate1 lives only under gate_results.GATE1_PRD_QUALITY.) Now we
+    // fetch whenever ANY gate is missing and credit accepted handoffs independently.
+    if (!gateResults.gate1 || !gateResults.gate2 || !gateResults.gate3) {
       // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff data when available
       const handoffs = options.prefetched?.handoffHistory || (await supabase
         .from('sd_phase_handoffs')
@@ -135,26 +150,31 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
       if (handoffs) {
         for (const handoff of handoffs) {
           // PLAN-TO-EXEC: Gate 1 (PRD Quality)
-          // Read canonical gate_results first, fall back to legacy key
+          // Read canonical gate_results first, fall back to legacy key. Acceptance is
+          // credited regardless of whether the gate value is already present.
           if (handoff.handoff_type === 'PLAN-TO-EXEC') {
             if (handoff.status === 'accepted') acceptedHandoffs.gate1 = true;
-            if (handoff.metadata?.gate_results?.GATE1_PRD_QUALITY) {
-              gateResults.gate1 = handoff.metadata.gate_results.GATE1_PRD_QUALITY;
-              gateDataSources.gate1 = 'canonical';
-            } else if (handoff.metadata?.gate1_validation) {
-              gateResults.gate1 = handoff.metadata.gate1_validation;
-              gateDataSources.gate1 = 'legacy';
+            if (!gateResults.gate1) {
+              if (handoff.metadata?.gate_results?.GATE1_PRD_QUALITY) {
+                gateResults.gate1 = handoff.metadata.gate_results.GATE1_PRD_QUALITY;
+                gateDataSources.gate1 = 'canonical';
+              } else if (handoff.metadata?.gate1_validation) {
+                gateResults.gate1 = handoff.metadata.gate1_validation;
+                gateDataSources.gate1 = 'legacy';
+              }
             }
           }
           // EXEC-TO-PLAN: Gate 2 (Implementation Fidelity)
           if (handoff.handoff_type === 'EXEC-TO-PLAN') {
             if (handoff.status === 'accepted') acceptedHandoffs.gate2 = true;
-            if (handoff.metadata?.gate_results?.GATE2_IMPLEMENTATION_FIDELITY) {
-              gateResults.gate2 = handoff.metadata.gate_results.GATE2_IMPLEMENTATION_FIDELITY;
-              gateDataSources.gate2 = 'canonical';
-            } else if (handoff.metadata?.gate2_validation) {
-              gateResults.gate2 = handoff.metadata.gate2_validation;
-              gateDataSources.gate2 = 'legacy';
+            if (!gateResults.gate2) {
+              if (handoff.metadata?.gate_results?.GATE2_IMPLEMENTATION_FIDELITY) {
+                gateResults.gate2 = handoff.metadata.gate_results.GATE2_IMPLEMENTATION_FIDELITY;
+                gateDataSources.gate2 = 'canonical';
+              } else if (handoff.metadata?.gate2_validation) {
+                gateResults.gate2 = handoff.metadata.gate2_validation;
+                gateDataSources.gate2 = 'legacy';
+              }
             }
           }
           // PLAN-TO-LEAD: Gate 3 (Traceability)
@@ -162,21 +182,18 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
           // then nested gate_results.GATE3_TRACEABILITY
           if (handoff.handoff_type === 'PLAN-TO-LEAD') {
             if (handoff.status === 'accepted') acceptedHandoffs.gate3 = true;
-            if (handoff.metadata?.gate_results?.GATE3_TRACEABILITY) {
-              gateResults.gate3 = handoff.metadata.gate_results.GATE3_TRACEABILITY;
-              gateDataSources.gate3 = 'canonical';
-            } else if (handoff.metadata?.gate3_validation) {
-              gateResults.gate3 = handoff.metadata.gate3_validation;
-              gateDataSources.gate3 = 'legacy';
+            if (!gateResults.gate3) {
+              if (handoff.metadata?.gate_results?.GATE3_TRACEABILITY) {
+                gateResults.gate3 = handoff.metadata.gate_results.GATE3_TRACEABILITY;
+                gateDataSources.gate3 = 'canonical';
+              } else if (handoff.metadata?.gate3_validation) {
+                gateResults.gate3 = handoff.metadata.gate3_validation;
+                gateDataSources.gate3 = 'legacy';
+              }
             }
           }
         }
       }
-    } else {
-      // Gate results provided directly - assume all accepted
-      if (allGateResults.gate1) { acceptedHandoffs.gate1 = true; gateDataSources.gate1 = 'direct'; }
-      if (allGateResults.gate2) { acceptedHandoffs.gate2 = true; gateDataSources.gate2 = 'direct'; }
-      if (allGateResults.gate3) { acceptedHandoffs.gate3 = true; gateDataSources.gate3 = 'direct'; }
     }
     // Store for Section D access and audit trail
     validation._acceptedHandoffs = acceptedHandoffs;

--- a/tests/unit/gate4-bypass-acceptance.test.js
+++ b/tests/unit/gate4-bypass-acceptance.test.js
@@ -26,7 +26,7 @@ vi.mock('../../scripts/modules/pattern-tracking.js', () => ({
   getPatternStats: vi.fn().mockResolvedValue({ total: 0, resolved: 0 })
 }));
 
-function createMockSupabase({ prdData = null, handoffs = [], retroData = null } = {}) {
+function createMockSupabase({ prdData = null, handoffs = [], retroData = null, sdData = { id: 'sd-uuid', sd_key: 'test-sd', sd_type: 'feature' } } = {}) {
   const mockSingle = (data) => ({
     data,
     error: data ? null : { message: 'Not found', code: 'PGRST116' }
@@ -34,6 +34,23 @@ function createMockSupabase({ prdData = null, handoffs = [], retroData = null } 
 
   return {
     from: vi.fn((table) => {
+      // validateGate4LeadFinal resolves sd_key/UUID via strategic_directives_v2.select().or().single()
+      // before any other query (SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001). Without this branch the
+      // default mock has no .or() and the lookup throws -> function returns early/partial.
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: vi.fn().mockReturnValue({
+            // primary lookup: .or().single()
+            or: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue(mockSingle(sdData))
+            }),
+            // D2 retro-UUID resolution: .eq('sd_key').single()
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue(mockSingle(sdData))
+            })
+          })
+        };
+      }
       if (table === 'product_requirements_v2') {
         return {
           select: vi.fn().mockReturnValue({
@@ -61,6 +78,13 @@ function createMockSupabase({ prdData = null, handoffs = [], retroData = null } 
         return {
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
+              // validateExecutiveApproval D2 query: .eq().order().limit().single()
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue(mockSingle(retroData))
+                })
+              }),
+              // legacy callers: .eq().single()
               single: vi.fn().mockResolvedValue(mockSingle(retroData))
             })
           })
@@ -152,5 +176,44 @@ describe('PAT-GATE4-BYPASS-001: Gate 4 Bypass Acceptance', () => {
     // Should auto-pass (Gate 4 is only for design/database pattern)
     expect(result.passed).toBe(true);
     expect(result.score).toBe(100);
+  });
+
+  it('fetches gate1/gate2 from canonical handoff metadata when only gate3 is provided (harness_backlog 5986136e)', async () => {
+    // Repro: the PLAN-TO-LEAD wrapper supplies ONLY gate3 (the fresh ctx result). gate1 now
+    // lives ONLY under canonical gate_results.GATE1_PRD_QUALITY (legacy gate1_validation is no
+    // longer written). Before the fix, the all-null guard (!g1 && !g2 && !g3) was false because
+    // gate3 was set, so the canonical fetch was suppressed and gate1/gate2 stayed undefined ->
+    // gates_passed=1 ("only 1/3 gates cleared"). After the fix the validator fetches any missing
+    // gate, so all three are credited.
+    const gateResults = { gate3: { passed: true, score: 85 } };
+
+    const handoffs = [
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_PRD_QUALITY: { passed: true, score: 92 } } }, created_at: '2026-01-01' },
+      { handoff_type: 'EXEC-TO-PLAN', status: 'accepted', metadata: { gate_results: { GATE2_IMPLEMENTATION_FIDELITY: { passed: true, score: 88 } } }, created_at: '2026-01-02' }
+    ];
+
+    const supabase = createMockSupabase({
+      prdData: {
+        metadata: { design_analysis: { exists: true } },
+        directive_id: 'test-sd',
+        title: 'Test',
+        created_at: new Date().toISOString()
+      },
+      handoffs,
+      retroData: { id: 'retro-1', quality_score: 80 }
+    });
+
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    // gate3 came directly from the caller; gate1/gate2 must be FETCHED from canonical
+    // handoff metadata even though gate3 was already present. Before the fix both stayed
+    // 'none' (canonical fetch suppressed by the all-null guard). _gateDataSources is set
+    // before the Section A-D scoring, so this assertion is robust to unrelated baseline
+    // breakage in those later sections (harness_backlog 75bdb4da).
+    expect(result._gateDataSources.gate3).toBe('direct');
+    expect(result._gateDataSources.gate1).toBe('canonical');
+    expect(result._gateDataSources.gate2).toBe('canonical');
+    // All three handoffs were accepted, so bypass-credit tracking sees all three.
+    expect(result._acceptedHandoffs).toEqual({ gate1: true, gate2: true, gate3: true });
   });
 });


### PR DESCRIPTION
## Summary
`GATE4_WORKFLOW_ROI` false-fails **"only 1/3 gates cleared"** at PLAN-TO-LEAD for every code SD.

`validateGate4LeadFinal` only ran its canonical gate-fetch when **all three** gate results were absent (`!gate1 && !gate2 && !gate3`). The PLAN-TO-LEAD wrapper (`traceability-gates.js`) supplies the freshly-computed `gate3` from `ctx`, so the all-null guard was false → canonical fetch suppressed → `gate1`/`gate2` left null. Since `gate1` now lives **only** under `gate_results.GATE1_PRD_QUALITY` (the legacy `gate1_validation` key is no longer written), gate1 stayed null → "1/3 cleared".

### Reproduction (verified against live DB)
Every non-rejected PLAN-TO-EXEC handoff: `has_legacy_gate1=false`, `has_canonical_gate_results=true`. gate1 is canonical-only, so the wrapper's legacy-only read returns null on every code SD.

## Fix (validator-side — safe for all 6 callers)
- Mark directly-provided gates as `accepted`/`direct` up front.
- Fetch **any** gate still missing (`||` guard instead of `&&`), guarding each assignment with `if (!gateResults.gateN)` so provided values are never clobbered.
- Credit accepted handoffs independently of whether a gate value was provided.

Callers passing `{}` or all-three are unchanged; only the partial-input path is corrected.

## Tests
- New regression: gate3-only input still fetches gate1/gate2 as `canonical` and credits all accepted handoffs (asserts `_gateDataSources`/`_acceptedHandoffs`, set before the scoring sections).
- Repaired two stale mocks in the shared helper (`strategic_directives_v2` `.or()`/`.eq()` lookup; `retrospectives` `.order().limit().single()` chain) — this also greens the 3 pre-existing baseline-broken tests in this file (partial toward harness_backlog `75bdb4da`).
- **4/4 pass.**

## Tracking
- Quick Fix: QF-20260523-640
- Closes harness_backlog `5986136e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)