### PR TITLE
fix(QF-20260523-802): sanction inline rca-agent expert consult when spawning unavailable

### DIFF
--- a/.claude/agents/rca-agent.partial
+++ b/.claude/agents/rca-agent.partial
@@ -218,6 +218,18 @@ Step 4: CAPA SYNTHESIS         -> Merge your analysis + expert findings
 
 You have Task tool access to invoke domain expert sub-agents. **USE IT ON EVERY RCA.**
 
+### When Task/TeamCreate Are Unavailable (Nested Sub-Agent Context)
+
+This runtime (Claude Code) does **not** allow a sub-agent to spawn another sub-agent. When this agent is itself invoked as a sub-agent, `Task`/`TeamCreate` return *"No such tool available — not available inside subagents."* That is a platform constraint, not a configuration error, and it cannot be worked around from here.
+
+**In that context, satisfy Step 2 INLINE. Inline expert analysis counts as the mandatory consult — it is NOT a protocol violation:**
+
+1. Explicitly adopt the relevant domain expert's lens (see the routing table below). If useful, load that domain's rules from the `leo_sub_agents` table for grounding.
+2. Produce the same *independent, multi-option* analysis the Expert Invocation Template calls for — challenge the surface hypothesis, enumerate ALL options and their tradeoffs, and state what that expert would recommend and why.
+3. Record in the report's "Experts consulted" field that the consult was performed **inline due to sub-agent depth limits**, naming each expert lens applied.
+
+Spawning a real expert sub-agent remains **preferred** whenever `Task` IS available (top-level / orchestrator-invoked RCA). Fall back to inline analysis only when spawning is genuinely unavailable — never use it to skip the rigor.
+
 ### Why This Is Mandatory
 
 - You are the **TRIAGE SPECIALIST**, not the domain expert
@@ -596,7 +608,7 @@ You are a **Forensic Investigator**, not a fixer. Your value is in systematic di
 
 **RCA agent is a FIRST RESPONDER, not a LAST RESORT.**
 
-**Expert consultation is MANDATORY, not optional.** Every RCA you produce must include findings from at least one domain expert sub-agent. If you find yourself writing a CAPA without having invoked any experts, STOP and go back to Step 2.
+**Expert consultation is MANDATORY, not optional.** Every RCA you produce must include findings from at least one domain expert — spawned via `Task` when available, or performed INLINE (adopting the expert's lens) when running as a nested sub-agent where `Task`/`TeamCreate` are unavailable. If you find yourself writing a CAPA without any expert analysis (spawned *or* inline), STOP and go back to Step 2.
 
 **User Feedback** (Evidence):
 > Issues that "keep happening" waste significant time. The pattern is always: quick fix -> recurrence -> another quick fix -> more recurrence -> finally do proper RCA -> permanent fix. Skip to the RCA step immediately.


### PR DESCRIPTION
## Summary
`rca-agent` mandated spawning a domain-expert sub-agent via `Task`/`TeamCreate` on **every** RCA and framed skipping as a "protocol violation." Claude Code does not allow a sub-agent to spawn another sub-agent (`"No such tool available — not available inside subagents"`), so when `rca-agent` runs as a leaf sub-agent the mandate is **provably unsatisfiable**. This surfaced **4×** in the harness backlog (the agent either failed the step or fell back silently while the prompt called it a violation).

## Fix
Added a **"When Task/TeamCreate Are Unavailable (Nested Sub-Agent Context)"** subsection to the agent prompt: in that context, satisfy the mandatory expert consult **inline** — adopt the domain expert's lens, produce the same independent multi-option analysis the template requires, and record the inline consult in the report. Spawning a real expert sub-agent remains **preferred** whenever `Task` IS available (top-level RCA). The closing reinforcement now accepts inline analysis as satisfying the mandate.

## Source/Generated split
The edit is in the tracked source `.claude/agents/rca-agent.partial`. The `.md` is generated (gitignored) via `npm run agents:compile`; verified the fallback text propagates to the compiled `.md`.

## Tracking
- Quick Fix: QF-20260523-802 (Tier 1)
- Closes harness_backlog `14ff574e`, `00cec279`, `d912691d`, `41157f3e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)