### PR TITLE
test(QF-20260523-562): unit-test FR-5 slug-collision 409 guard (github-repo route)

### DIFF
--- a/server/routes/github-repo.js
+++ b/server/routes/github-repo.js
@@ -20,8 +20,9 @@ const router = Router();
 /**
  * POST /api/github/create-and-seed
  * Creates a new GitHub repo for the venture, then seeds it with docs + designs.
+ * Exported as a named handler so the build-into / slug-collision branches are unit-testable.
  */
-router.post('/create-and-seed', asyncHandler(async (req, res) => {
+export async function createAndSeedHandler(req, res) {
   const { ventureId, ventureName } = req.body || {};
 
   if (!ventureId || !isValidUuid(ventureId)) {
@@ -137,6 +138,8 @@ router.post('/create-and-seed', asyncHandler(async (req, res) => {
       errors: [err.message],
     });
   }
-}));
+}
+
+router.post('/create-and-seed', asyncHandler(createAndSeedHandler));
 
 export default router;

--- a/tests/unit/github-repo-slug-collision.test.js
+++ b/tests/unit/github-repo-slug-collision.test.js
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the create-and-seed route handler (server/routes/github-repo.js).
+ * SD-LEO-FEAT-S19-BUILDS-INTO-001 follow-on (QF-20260523-562): covers the FR-5
+ * slug-collision 409 guard the testing-agent flagged, plus the build-into branch
+ * and the UUID guard. Deps are mocked so no shell/DB/network is touched.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const { execSyncMock, resolveMock, seedRepoMock } = vi.hoisted(() => ({
+  execSyncMock: vi.fn(),
+  resolveMock: vi.fn(),
+  seedRepoMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({ execSync: execSyncMock }));
+vi.mock('../../lib/eva/bridge/resolve-venture-repo.js', () => ({ resolveVentureRepoUrl: resolveMock }));
+vi.mock('../../lib/eva/bridge/replit-repo-seeder.js', () => ({ seedRepo: seedRepoMock }));
+
+import { createAndSeedHandler } from '../../server/routes/github-repo.js';
+
+const VALID_UUID = '4f71b3bd-8a1e-462e-a8b2-76efb8607206';
+
+function mockRes() {
+  const res = { statusCode: null, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+}
+
+// Chainable no-op supabase mock (the route persists venture_resources + advisory_data
+// after a successful build-into seed).
+function mockSupabase() {
+  const chain = {
+    upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    select: () => chain,
+    eq: () => chain,
+    update: vi.fn().mockResolvedValue({ data: null, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  return { from: () => chain };
+}
+
+function mockReq(body) {
+  return { body, app: { locals: { supabase: mockSupabase() } } };
+}
+
+describe('createAndSeedHandler', () => {
+  beforeEach(() => { execSyncMock.mockReset(); resolveMock.mockReset(); seedRepoMock.mockReset(); });
+
+  it('FR-5: returns 409 GITHUB_SLUG_COLLISION when create-new hits a pre-existing repo', async () => {
+    resolveMock.mockResolvedValue(null); // no existing repo -> create-new mode
+    execSyncMock.mockImplementation(() => { throw new Error('GraphQL: Name already exists on this account'); });
+    const res = mockRes();
+    await createAndSeedHandler(mockReq({ ventureId: VALID_UUID, ventureName: 'Test Venture' }), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body.code).toBe('GITHUB_SLUG_COLLISION');
+    expect(seedRepoMock).not.toHaveBeenCalled(); // must NOT seed into an unrelated repo
+  });
+
+  it('build-into: skips gh repo create when a repo resolves, returns mode build-into', async () => {
+    resolveMock.mockResolvedValue('https://github.com/rickfelix/contribution-hub');
+    seedRepoMock.mockResolvedValue({ mode: 'build-into', docsCommitted: ['docs/spec.md'], errors: [] });
+    const res = mockRes();
+    await createAndSeedHandler(mockReq({ ventureId: VALID_UUID, ventureName: 'Canvas AI' }), res);
+    expect(execSyncMock).not.toHaveBeenCalled(); // gh repo create NOT invoked in build-into
+    expect(res.statusCode).toBe(200);
+    expect(res.body.mode).toBe('build-into');
+    expect(seedRepoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 for an invalid ventureId without any shell or resolver call', async () => {
+    const res = mockRes();
+    await createAndSeedHandler(mockReq({ ventureId: 'not-a-uuid' }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('INVALID_VENTURE_ID');
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## QF-20260523-562 — FR-5 slug-collision unit test

Follow-on to **SD-LEO-FEAT-S19-BUILDS-INTO-001** (testing-agent flagged the FR-5 slug-collision guard as untested; non-blocking).

- Exports `createAndSeedHandler` as a named function (testability — per CLAUDE_EXEC).
- 3 vitest cases (deps mocked; no shell/DB/network):
  - **FR-5**: create-new slug collision → `409 GITHUB_SLUG_COLLISION`, `seedRepo` never called.
  - build-into: existing repo resolves → `gh repo create` skipped, `mode:'build-into'`.
  - invalid `ventureId` → `400` before any shell/resolver call.

3/3 pass. Behavior-preserving extract (no functional change to the route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)