### PR TITLE
feat(SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001): mode-aware S19 Replit prompts (backend)

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -333,7 +333,7 @@ function extractSprintItems(groups) {
  * @param {object} summary - RPC summary
  * @returns {string} Markdown content for replit.md
  */
-export function formatReplitMd(groups, venture, summary) {
+export function formatReplitMd(groups, venture, summary, { mode = 'create-new' } = {}) {
   const { techStack, framework } = detectStack(groups, { targetPlatform: venture.targetPlatform || 'web' });
   const lines = [];
 
@@ -342,6 +342,14 @@ export function formatReplitMd(groups, venture, summary) {
   lines.push('');
   if (venture.description) {
     lines.push(`> ${venture.description}`);
+    lines.push('');
+  }
+
+  // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: in build-into mode the repo already
+  // contains the venture's Stage-17 app — instruct continuation, not scaffolding.
+  if (mode === 'build-into') {
+    lines.push('## Build Context');
+    lines.push('This repository **already contains the working app** for this venture (your approved Stage-17 design). **Build on it — do not scaffold a new app, recreate it, or remove existing files.** Inspect the existing stack, routes, and components (start from `package.json` and the `EHG-BUILD-CONTEXT` section if present) and match their conventions. The sections below are the spec to converge toward, not a from-scratch blueprint.');
     lines.push('');
   }
 
@@ -467,7 +475,9 @@ export function formatReplitMd(groups, venture, summary) {
       const screens = wfData.wireframes?.screens || wfData.screens || [];
       if (screens.length > 0) {
         lines.push('## Application Screens');
-        lines.push(`This app has ${screens.length} screens. Build ALL of them:`);
+        lines.push(mode === 'build-into'
+          ? `This app should have these ${screens.length} screens. Some may already exist in the repo — build any that are missing and refine the rest to match the spec. Do NOT recreate the app from scratch:`
+          : `This app has ${screens.length} screens. Build ALL of them:`);
         lines.push('');
         for (const screen of screens) {
           lines.push(`### ${screen.name || 'Screen'}`);
@@ -628,14 +638,20 @@ function rankSprintItems(items) {
  * @param {object} summary - RPC summary
  * @returns {string} Concise plan mode prompt (<2000 chars)
  */
-export function formatPlanModePrompt(groups, venture, summary) {
+export function formatPlanModePrompt(groups, venture, summary, { mode = 'create-new' } = {}) {
   const items = extractSprintItems(groups);
   const { framework } = detectStack(groups, { targetPlatform: venture.targetPlatform || 'web' });
   const lines = [];
 
   // One-sentence project description
   const desc = venture.description || `${venture.name || 'Venture'} application`;
-  lines.push(`Build a ${framework} application: ${summarizeContent(desc, 150)}`);
+  // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: build-into continues the existing app; create-new scaffolds (unchanged).
+  if (mode === 'build-into') {
+    lines.push(`Continue building the existing ${framework} app already in this repo: ${summarizeContent(desc, 150)}`);
+    lines.push('This repo already contains the venture\'s Stage-17 app. Build ON it — inspect package.json plus the existing routes and components and match their conventions. Do NOT scaffold a new app or recreate existing files.');
+  } else {
+    lines.push(`Build a ${framework} application: ${summarizeContent(desc, 150)}`);
+  }
   lines.push('');
 
   // Binding-contract references — Replit Agent's auto-generated replit.md
@@ -647,7 +663,9 @@ export function formatPlanModePrompt(groups, venture, summary) {
   lines.push('Binding contract — read first (these are the chairman-approved inputs the build must fulfill):');
   lines.push('- docs/spec.md — integrated product specification (problem, users, architecture, screens). Single-file reference if you need cross-section context.');
   lines.push('- docs/marketing-copy.md — approved positioning, taglines, landing CTA, email subjects. Build features that deliver these promises.');
-  lines.push('- docs/designs/ — approved HTML designs. Match the layout and the majority navigation pattern.');
+  lines.push(mode === 'build-into'
+    ? '- The existing app in this repo (+ the EHG-BUILD-CONTEXT section in replit.md) — match its current design system, layout, and navigation. The app itself is the design reference; build additively on top of it.'
+    : '- docs/designs/ — approved HTML designs. Match the layout and the majority navigation pattern.');
   lines.push('- docs/color-palette.md — brand CSS custom properties. Use only these colors.');
   lines.push('- docs/branding.md — typography and persona voice.');
   lines.push('- docs/architecture.md — tech stack, data model, API surface, schema. Use these decisions; do not re-derive.');
@@ -707,12 +725,16 @@ export function formatPlanModePrompt(groups, venture, summary) {
   // MUST know which docs/ files carry the chairman-approved context.
   if (prompt.length > PLAN_MODE_BUDGET) {
     const shortLines = [];
-    shortLines.push(`Build a ${framework} app: ${venture.name || 'Venture'}`);
+    shortLines.push(mode === 'build-into'
+      ? `Continue the existing ${framework} app in this repo (build on it; do not scaffold): ${venture.name || 'Venture'}`
+      : `Build a ${framework} app: ${venture.name || 'Venture'}`);
     shortLines.push('');
     shortLines.push('Binding contract — read first:');
     shortLines.push('- docs/spec.md (integrated specification — cross-section context)');
     shortLines.push('- docs/marketing-copy.md (approved positioning + CTA the build must deliver)');
-    shortLines.push('- docs/designs/ (approved HTML — match the majority nav pattern)');
+    shortLines.push(mode === 'build-into'
+      ? '- The existing app + replit.md EHG-BUILD-CONTEXT (match its design system; build additively)'
+      : '- docs/designs/ (approved HTML — match the majority nav pattern)');
     shortLines.push('- docs/color-palette.md (brand CSS variables — use only these)');
     shortLines.push('- docs/architecture.md (tech stack + data model + schema — use these decisions)');
     shortLines.push('- docs/monitoring.md (Sentry + central feedback table — wire on day one)');
@@ -745,7 +767,7 @@ export function formatPlanModePrompt(groups, venture, summary) {
  * @param {object} summary - RPC summary
  * @returns {Array<{filename: string, content: string, charCount: number}>}
  */
-export function formatFeaturePrompts(groups, venture, summary) {
+export function formatFeaturePrompts(groups, venture, summary, { mode = 'create-new' } = {}) {
   const items = extractSprintItems(groups);
   if (items.length === 0) return [];
 
@@ -819,13 +841,20 @@ export function formatFeaturePrompts(groups, venture, summary) {
     lines.push('');
     lines.push('**Read first (binding contract for this feature):**');
     lines.push('- docs/marketing-copy.md — chairman-approved positioning. This feature must deliver the promises relevant to it (landing-hero CTA, app-store description claims, email value-prop).');
-    lines.push('- docs/designs/ — approved HTML mockups. Match the layout and the majority navigation pattern.');
+    lines.push(mode === 'build-into'
+      ? '- The existing app in this repo (+ replit.md EHG-BUILD-CONTEXT) — match its current design system, layout, and components. Reuse existing components; the app itself is the design reference.'
+      : '- docs/designs/ — approved HTML mockups. Match the layout and the majority navigation pattern.');
     lines.push('- docs/color-palette.md — brand CSS custom properties. Use only these colors.');
     lines.push('- docs/branding.md — typography and persona voice (target persona named in marketing-copy.md).');
     lines.push('');
     lines.push('**Instructions:**');
+    if (mode === 'build-into') {
+      lines.push('- This app already exists in the repo — EXTEND it: reuse existing components/routes and match their patterns; do NOT scaffold a new app or recreate existing files');
+    }
     lines.push('- Implement this feature completely before moving to the next');
-    lines.push('- Match docs/designs/ visually; use docs/color-palette.md tokens only');
+    lines.push(mode === 'build-into'
+      ? '- Match the existing app\'s design system visually; use docs/color-palette.md tokens only'
+      : '- Match docs/designs/ visually; use docs/color-palette.md tokens only');
     lines.push('- Test the feature works end-to-end before proceeding');
     lines.push('- Checkpoint after completion');
 

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -461,11 +461,25 @@ export async function formatReplitPrompt(ventureId, options = {}) {
  * @returns {Promise<{replitMd, planModePrompt, featurePrompts, warnings, manifest}>}
  */
 export async function formatReplitOptimized(ventureId, options = {}) {
-  const { scope = 'sprint' } = options; // 'sprint' (MVP) or 'wireframes' (full scope)
+  const { scope = 'sprint', mode: modeHint = 'create-new' } = options; // scope 'sprint'|'wireframes' (SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001)
   const { formatReplitMd, formatPlanModePrompt, formatFeaturePrompts, formatWireframePrompts } =
     await import('./replit-format-strategies.js');
 
   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: resolve build-into vs create-new from the
+  // ventures.repo_url SSOT (authoritative). A resolvable repo => build-into prompts
+  // (continue the existing app); otherwise create-new (scaffold, unchanged). The
+  // caller's `mode` is an advisory hint, used only if the SSOT lookup fails.
+  // Read-only — no repo cloning here.
+  let mode = 'create-new';
+  try {
+    const { resolveVentureRepoUrl } = await import('./resolve-venture-repo.js');
+    const existingRepo = await resolveVentureRepoUrl(supabase, ventureId);
+    mode = existingRepo ? 'build-into' : 'create-new';
+  } catch {
+    mode = modeHint === 'build-into' ? 'build-into' : 'create-new';
+  }
 
   const { data, error } = await supabase.rpc('export_blueprint_review', { p_venture_id: ventureId });
   if (error) throw new Error(`export_blueprint_review failed: ${error.message}`);
@@ -477,19 +491,19 @@ export async function formatReplitOptimized(ventureId, options = {}) {
   const summary = data.summary || {};
   const warnings = [];
 
-  const replitMdContent = formatReplitMd(data.groups, ventureMeta, summary);
-  const planContent = formatPlanModePrompt(data.groups, ventureMeta, summary);
+  const replitMdContent = formatReplitMd(data.groups, ventureMeta, summary, { mode });
+  const planContent = formatPlanModePrompt(data.groups, ventureMeta, summary, { mode });
 
   // Feature prompts: sprint-scoped (MVP) or wireframe-scoped (full app)
   let features;
   if (scope === 'wireframes') {
-    features = formatWireframePrompts(data.groups, ventureMeta, summary);
+    features = formatWireframePrompts(data.groups, ventureMeta, summary, { mode });
     if (features.length === 0) {
       warnings.push('No wireframe screens found — falling back to sprint items');
-      features = formatFeaturePrompts(data.groups, ventureMeta, summary);
+      features = formatFeaturePrompts(data.groups, ventureMeta, summary, { mode });
     }
   } else {
-    features = formatFeaturePrompts(data.groups, ventureMeta, summary);
+    features = formatFeaturePrompts(data.groups, ventureMeta, summary, { mode });
   }
 
   if (replitMdContent.length > 15000) {
@@ -510,6 +524,7 @@ export async function formatReplitOptimized(ventureId, options = {}) {
     manifest: {
       ventureId,
       ventureName: ventureMeta.name,
+      mode,
       exportedAt: new Date().toISOString(),
       totalCharCount: totalChars,
       featureCount: features.length,

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -68,11 +68,15 @@ router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
   }
 
   const scope = req.query.scope === 'wireframes' ? 'wireframes' : 'sprint';
+  // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: ?mode=build-into is an advisory hint; the
+  // formatter resolves the authoritative mode from the ventures.repo_url SSOT.
+  const modeHint = req.query.mode === 'build-into' ? 'build-into' : undefined;
 
   try {
-    const result = await formatReplitOptimized(ventureId, { scope });
+    const result = await formatReplitOptimized(ventureId, { scope, mode: modeHint });
     return res.status(200).json({
       ventureName: result.manifest?.ventureName || 'Venture',
+      mode: result.manifest?.mode || 'create-new',
       planPrompt: result.planModePrompt?.content || '',
       featurePrompts: (result.featurePrompts || []).map((fp) => ({
         title: fp.title || fp.filename || 'Feature',

--- a/tests/unit/bridge/replit-prompt-mode.test.js
+++ b/tests/unit/bridge/replit-prompt-mode.test.js
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for mode-aware Stage-19 Replit prompt generation.
+ * SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: build-into prompts continue the existing
+ * app (no "scaffold a new app", no docs/designs/ reference); create-new is
+ * byte-identical to the prior behavior (FR-5). Pure functions — no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatReplitMd,
+  formatPlanModePrompt,
+  formatFeaturePrompts,
+} from '../../../lib/eva/bridge/replit-format-strategies.js';
+
+const groups = [
+  { group_key: 'what_to_build', artifacts: [{ content: 'A test app for users', artifact_type: 'overview' }] },
+  { group_key: 'how_to_build_it', artifacts: [] },
+  {
+    group_key: 'sprint_plan',
+    artifacts: [{
+      content: JSON.stringify({
+        items: [{ name: 'User Login', description: 'Login feature', story_points: 3, priority: 'high', success_criteria: 'User can log in' }],
+      }),
+    }],
+  },
+];
+const venture = { name: 'TestVenture', description: 'A test venture app', targetPlatform: 'web' };
+const summary = {};
+
+describe('formatPlanModePrompt — mode-aware (FR-2/FR-3)', () => {
+  it('create-new: scaffolds a new app + references docs/designs/', () => {
+    const p = formatPlanModePrompt(groups, venture, summary); // default create-new
+    expect(p).toMatch(/Build a .* application/);
+    expect(p).toContain('docs/designs/');
+    expect(p).not.toContain('Continue building the existing');
+  });
+
+  it('build-into: continues the existing app, drops docs/designs/', () => {
+    const p = formatPlanModePrompt(groups, venture, summary, { mode: 'build-into' });
+    expect(p).toContain('Continue building the existing');
+    expect(p).not.toContain('docs/designs/');
+    expect(p).toMatch(/existing app|EHG-BUILD-CONTEXT/);
+  });
+});
+
+describe('formatFeaturePrompts — mode-aware (FR-2/FR-3)', () => {
+  it('create-new: feature prompt references docs/designs/', () => {
+    const fps = formatFeaturePrompts(groups, venture, summary);
+    expect(fps.length).toBeGreaterThan(0);
+    expect(fps[0].content).toContain('docs/designs/');
+  });
+
+  it('build-into: feature prompt extends the existing app, no docs/designs/', () => {
+    const fps = formatFeaturePrompts(groups, venture, summary, { mode: 'build-into' });
+    expect(fps.length).toBeGreaterThan(0);
+    expect(fps[0].content).not.toContain('docs/designs/');
+    expect(fps[0].content).toMatch(/EXTEND|existing app/);
+  });
+});
+
+describe('formatReplitMd — mode-aware (FR-2)', () => {
+  it('build-into adds a Build Context (build on the existing app); create-new does not', () => {
+    const buildInto = formatReplitMd(groups, venture, summary, { mode: 'build-into' });
+    const createNew = formatReplitMd(groups, venture, summary);
+    expect(buildInto).toContain('## Build Context');
+    expect(buildInto).toMatch(/already contains the working app|build on the existing app/i);
+    expect(createNew).not.toContain('## Build Context');
+  });
+});
+
+describe('FR-5: create-new byte-identical to prior behavior', () => {
+  it('formatPlanModePrompt create-new === default (no mode)', () => {
+    expect(formatPlanModePrompt(groups, venture, summary, { mode: 'create-new' }))
+      .toBe(formatPlanModePrompt(groups, venture, summary));
+  });
+  it('formatReplitMd create-new === default (no mode)', () => {
+    expect(formatReplitMd(groups, venture, summary, { mode: 'create-new' }))
+      .toBe(formatReplitMd(groups, venture, summary));
+  });
+  it('formatFeaturePrompts create-new === default (no mode)', () => {
+    expect(JSON.stringify(formatFeaturePrompts(groups, venture, summary, { mode: 'create-new' })))
+      .toBe(JSON.stringify(formatFeaturePrompts(groups, venture, summary)));
+  });
+});


### PR DESCRIPTION
## SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001 — backend (phase 2 of build-into)

S19's Replit prompts assumed a **blank repo** even after S19 now builds INTO the venture's existing S17 design repo. This makes them **build-into-aware**.

- **stage19.js** — accept `?mode` hint + expose the resolved `mode` in the response.
- **replit-prompt-formatter.js** — `formatReplitOptimized` resolves build-into vs create-new from the **`ventures.repo_url` SSOT** (authoritative; `?mode` is advisory; read-only) and threads `mode` to the strategies + manifest.
- **replit-format-strategies.js** — `formatReplitMd` / `formatPlanModePrompt` / `formatFeaturePrompts` emit build-into language (*continue the existing app; inspect+match its stack/routes/design system; build additively*) and **drop the empty `docs/designs/` reference**; create-new is **byte-identical** (FR-5).
- 8 unit tests (mode-branching + create-new byte-identity). `tsc` clean.

Pairs with the ehg Step-2 build-into prompt PR. Prompt generation is read-only (no live-repo writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)