### PR TITLE
fix(QF-20260523-019): main-guard check-git-state.js so import has no side effects

### DIFF
--- a/scripts/check-git-state.js
+++ b/scripts/check-git-state.js
@@ -14,6 +14,7 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { pathToFileURL } from 'url';
 
 const execAsync = promisify(exec);
 
@@ -185,18 +186,24 @@ async function checkGitState() {
   return result;
 }
 
-// CLI execution
-const args = process.argv.slice(2);
-const jsonOutput = args.includes('--json');
-
-checkGitState().then(result => {
-  if (jsonOutput) {
-    console.log(JSON.stringify(result, null, 2));
-  }
-  process.exit(result.passed ? 0 : 1);
-}).catch(err => {
-  console.error('Error:', err.message);
-  process.exit(1);
-});
-
 export { checkGitState };
+
+// CLI execution — only when run directly (node scripts/check-git-state.js), NOT when
+// imported. Without this guard, importing the module (e.g. from the handoff precheck CLI
+// at scripts/modules/handoff/cli/cli-main.js) runs checkGitState() + process.exit() in the
+// HOST process, halting it on dirty git. Regression exposed by QF-20260523-481 (which fixed
+// the precheck's import path); guarded here so import is side-effect-free.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  const args = process.argv.slice(2);
+  const jsonOutput = args.includes('--json');
+
+  checkGitState().then(result => {
+    if (jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    process.exit(result.passed ? 0 : 1);
+  }).catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
`scripts/check-git-state.js` ran its CLI block (`checkGitState()` + `process.exit`) at module top-level with **no main-guard**. QF-20260523-481 fixed the handoff precheck's import path (`cli-main.js`), which then made *importing* this module execute that block — running `checkGitState()` and calling `process.exit(1)` on dirty git **inside the host process** (the precheck), halting it at STEP 1 before the gates. (Regression I introduced with #3846; caught while dogfooding the precheck.)

## Fix
Wrap the CLI block in `if (import.meta.url === pathToFileURL(process.argv[1] || '').href)` so it only runs when the module is the entry point.

## Verification
- **Import**: `import('./scripts/check-git-state.js')` → exits 0, exports `checkGitState`, **no** CLI output / no `process.exit`.
- **Direct**: `node scripts/check-git-state.js` → still runs the check (exit 1 on dirty git).

## Tracking
- Quick Fix: QF-20260523-019 (Tier 1, high — restores precheck behavior for all sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)