### PR TITLE
fix(QF-20260523-692): make formatWireframePrompts build-into-aware

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -899,7 +899,7 @@ function extractWireframeScreens(groups) {
  * @param {object} summary - RPC summary
  * @returns {Array<{filename: string, content: string, charCount: number}>}
  */
-export function formatWireframePrompts(groups, venture, summary) {
+export function formatWireframePrompts(groups, venture, summary, { mode = 'create-new' } = {}) {
   const screens = extractWireframeScreens(groups);
   if (screens.length === 0) return [];
 
@@ -939,6 +939,11 @@ export function formatWireframePrompts(groups, venture, summary) {
     }
 
     lines.push('**Instructions:**');
+    if (mode === 'build-into') {
+      // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001 follow-on (QF-20260523-692): the repo
+      // already contains the venture's app — extend it, don't scaffold/recreate.
+      lines.push('- This app already exists in the repo — EXTEND it: reuse existing components/routes and match their patterns; do NOT scaffold a new app or recreate existing files');
+    }
     lines.push('- Refer to replit.md for branding (colors, typography, product name)');
     lines.push('- Refer to `docs/wireframes.md` for full wireframe specifications and screen flow');
     lines.push('- If available, refer to `docs/stitch/DESIGN.md` for design tokens and component specs');

--- a/tests/unit/bridge/replit-wireframe-mode.test.js
+++ b/tests/unit/bridge/replit-wireframe-mode.test.js
@@ -1,0 +1,30 @@
+/**
+ * QF-20260523-692: formatWireframePrompts must honor build-into mode (follow-on to
+ * SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001 — it previously ignored the threaded {mode}).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatWireframePrompts } from '../../../lib/eva/bridge/replit-format-strategies.js';
+
+const groups = [
+  {
+    group_key: 'how_to_build_it',
+    artifacts: [{ artifact_type: 'blueprint_wireframes', content: JSON.stringify({ screens: [{ name: 'Dashboard', purpose: 'Main view' }] }) }],
+  },
+];
+const venture = { name: 'TestVenture', description: 'A test app', targetPlatform: 'web' };
+const summary = {};
+
+describe('formatWireframePrompts — mode-aware', () => {
+  it('build-into: instructs extending the existing app', () => {
+    const fps = formatWireframePrompts(groups, venture, summary, { mode: 'build-into' });
+    expect(fps.length).toBeGreaterThan(0);
+    expect(fps[0].content).toMatch(/EXTEND|already exists/);
+  });
+
+  it('create-new: byte-identical to default, no extend instruction', () => {
+    const createNew = formatWireframePrompts(groups, venture, summary, { mode: 'create-new' });
+    const dflt = formatWireframePrompts(groups, venture, summary);
+    expect(JSON.stringify(createNew)).toBe(JSON.stringify(dflt));
+    expect(createNew[0].content).not.toContain('EXTEND');
+  });
+});


### PR DESCRIPTION
Follow-on to SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001. `formatWireframePrompts` ignored the threaded `{mode}` arg, so wireframe-scope prompts stayed create-new-style in build-into. Adds the mode param + a build-into 'extend the existing app' instruction (mirrors formatFeaturePrompts); create-new byte-identical. +2 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)