### PR TITLE
fix(QF-20260523-132): monitor analysis-step source-match + plan-mode intensity var

### DIFF
--- a/scripts/modules/plan-mode/intelligent-plan-templates.js
+++ b/scripts/modules/plan-mode/intelligent-plan-templates.js
@@ -255,7 +255,7 @@ npm run sd:status         # Check SD status
  */
 export function generatePlanPlan(sdContext) {
   const { id, title, type, typeProfile, _complexity, scope, keyChanges } = sdContext;
-  const _intensity = getWorkflowIntensity(sdContext);
+  const intensity = getWorkflowIntensity(sdContext);
 
   const sections = [];
 
@@ -403,7 +403,7 @@ node scripts/handoff.js plan-to-exec  # Transition to EXEC
  */
 export function generateExecPlan(sdContext) {
   const { id, title, type, typeProfile, _complexity, keyChanges } = sdContext;
-  const _intensity = getWorkflowIntensity(sdContext);
+  const intensity = getWorkflowIntensity(sdContext);
 
   const sections = [];
 

--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -94,13 +94,20 @@ function isWorkerSourceForStage(source, stage) {
   if (!source) return false;
   if (ADVISORY_SOURCES.has(source)) return false;
   if (ADVISORY_SUFFIXES.some((suf) => source.endsWith(suf))) return false;
+  // Canonical EVA worker sources are emitted as 'analysis-step:stage-NN' (and
+  // 'analysis-step:stage-NN-<suffix>' for projections, e.g. S14/S26 typed arrays).
+  // Strip the 'analysis-step:' prefix so they match the stage-NN forms below; otherwise
+  // typed-array stages report false 'missing_artifact'. harness_backlog 87a65161.
+  const normalized = source.startsWith('analysis-step:')
+    ? source.slice('analysis-step:'.length)
+    : source;
   const padded = `stage-${String(stage).padStart(2, '0')}`;
   const unpadded = `stage-${stage}`;
   return (
-    source === padded ||
-    source === unpadded ||
-    source.startsWith(`${padded}-`) ||
-    source.startsWith(`${unpadded}-`)
+    normalized === padded ||
+    normalized === unpadded ||
+    normalized.startsWith(`${padded}-`) ||
+    normalized.startsWith(`${unpadded}-`)
   );
 }
 

--- a/tests/unit/monitor-venture-run-validate.test.js
+++ b/tests/unit/monitor-venture-run-validate.test.js
@@ -36,6 +36,15 @@ describe('isWorkerSourceForStage — source-aware filter', () => {
       expect(isWorkerSourceForStage('stage-17-strategy-stats', 17)).toBe(true);
     });
 
+    it('matches canonical EVA analysis-step:stage-NN sources (typed-array stages S14/S26) — harness_backlog 87a65161', () => {
+      expect(isWorkerSourceForStage('analysis-step:stage-14', 14)).toBe(true);
+      expect(isWorkerSourceForStage('analysis-step:stage-14-projection', 14)).toBe(true);
+      expect(isWorkerSourceForStage('analysis-step:stage-26', 26)).toBe(true);
+      expect(isWorkerSourceForStage('analysis-step:stage-26-projection', 26)).toBe(true);
+      // wrong stage still rejected
+      expect(isWorkerSourceForStage('analysis-step:stage-99', 14)).toBe(false);
+    });
+
     it('matches both padded and unpadded forms regardless of which is used', () => {
       // If production data ever uses stage-1 instead of stage-01, the filter
       // still matches — defensive against the empirical convention shifting.


### PR DESCRIPTION
Two independent mechanical harness bugfixes (batched per low-risk + tiny):

**1. `monitor-venture-run.cjs` `isWorkerSourceForStage` (harness_backlog 87a65161)** — didn't recognize the canonical EVA source `analysis-step:stage-NN` (+ `-<suffix>` projections), so typed-array stages (S14/S26) reported false `missing_artifact`. Now strips the `analysis-step:` prefix before matching. +1 regression test (19/19 pass).

**2. `intelligent-plan-templates.js` (harness_backlog 9c552f33)** — `generatePlanPlan`/`generateExecPlan` declared `const _intensity` but used `intensity` → `ReferenceError: intensity is not defined` at LEAD-TO-PLAN plan-mode entry for non-refactor SDs (plan file not written). Renamed to `intensity`.

- QF-20260523-132 (Tier 1)
- Closes harness_backlog `87a65161`, `9c552f33`

🤖 Generated with [Claude Code](https://claude.com/claude-code)