### PR TITLE
fix(QF-20260523-253): S19 build-into prompts treat the existing app as source of truth

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -646,9 +646,15 @@ export function formatPlanModePrompt(groups, venture, summary, { mode = 'create-
   // One-sentence project description
   const desc = venture.description || `${venture.name || 'Venture'} application`;
   // SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001: build-into continues the existing app; create-new scaffolds (unchanged).
+  // QF-20260523-253 (source-of-truth hardening): in build-into mode the EXISTING APP is authoritative.
+  // Do NOT assert a detected framework or treat the planning-era description as the build target — both can
+  // conflict with what was actually built (the Vercel/Supabase-vs-actual-stack mismatch Replit flagged on the
+  // first build-into venture). State an explicit precedence so docs never drag the build off the live app.
   if (mode === 'build-into') {
-    lines.push(`Continue building the existing ${framework} app already in this repo: ${summarizeContent(desc, 150)}`);
-    lines.push('This repo already contains the venture\'s Stage-17 app. Build ON it — inspect package.json plus the existing routes and components and match their conventions. Do NOT scaffold a new app or recreate existing files.');
+    lines.push('Continue building the existing app already in this repo. Inspect package.json, the routes, and the components FIRST to confirm the actual stack — do NOT assume a framework. Build ON the app; do NOT scaffold a new app or recreate existing files.');
+    lines.push(`Intended purpose (planning-era context — may differ from the current build): ${summarizeContent(desc, 150)}`);
+    lines.push('');
+    lines.push('Source of truth when these disagree: (1) the existing app in this repo — current reality, authoritative for stack, database, auth, hosting, routes, and design system; (2) the docs/ files below — chairman-approved intent; (3) this prompt — planning-era summary. Where any doc or this prompt conflicts with the running app, FOLLOW THE APP. Do not switch the database/auth provider or re-platform to match a doc.');
   } else {
     lines.push(`Build a ${framework} application: ${summarizeContent(desc, 150)}`);
   }
@@ -664,11 +670,13 @@ export function formatPlanModePrompt(groups, venture, summary, { mode = 'create-
   lines.push('- docs/spec.md — integrated product specification (problem, users, architecture, screens). Single-file reference if you need cross-section context.');
   lines.push('- docs/marketing-copy.md — approved positioning, taglines, landing CTA, email subjects. Build features that deliver these promises.');
   lines.push(mode === 'build-into'
-    ? '- The existing app in this repo (+ the EHG-BUILD-CONTEXT section in replit.md) — match its current design system, layout, and navigation. The app itself is the design reference; build additively on top of it.'
+    ? '- The existing app in this repo (+ the EHG-BUILD-CONTEXT section in replit.md) — match its current design system, layout, and navigation. The app itself is the design reference; build additively on top of it. If older design mockups exist anywhere in the repo, treat them as superseded — the app already embodies the chosen direction.'
     : '- docs/designs/ — approved HTML designs. Match the layout and the majority navigation pattern.');
   lines.push('- docs/color-palette.md — brand CSS custom properties. Use only these colors.');
   lines.push('- docs/branding.md — typography and persona voice.');
-  lines.push('- docs/architecture.md — tech stack, data model, API surface, schema. Use these decisions; do not re-derive.');
+  lines.push(mode === 'build-into'
+    ? '- docs/architecture.md — approved data model, API surface & domain decisions. Use it for WHAT to build (entities, endpoints, domain rules), NOT to re-platform: the existing app is authoritative for the actual stack/database/auth. If architecture.md names a different stack than the repo, follow the repo.'
+    : '- docs/architecture.md — tech stack, data model, API surface, schema. Use these decisions; do not re-derive.');
   lines.push('- docs/monitoring.md — Sentry + central feedback table integration. Wire this on day one.');
   lines.push('- docs/tasks.md — pre-decomposed implementation steps with acceptance criteria. Canonical task list once Plan Mode is approved.');
   lines.push('- docs/gtm-strategy.md — go-to-market positioning context.');
@@ -726,8 +734,11 @@ export function formatPlanModePrompt(groups, venture, summary, { mode = 'create-
   if (prompt.length > PLAN_MODE_BUDGET) {
     const shortLines = [];
     shortLines.push(mode === 'build-into'
-      ? `Continue the existing ${framework} app in this repo (build on it; do not scaffold): ${venture.name || 'Venture'}`
+      ? `Continue the existing app in this repo (inspect package.json for its stack; build on it, do not scaffold): ${venture.name || 'Venture'}`
       : `Build a ${framework} app: ${venture.name || 'Venture'}`);
+    if (mode === 'build-into') {
+      shortLines.push('Source of truth: the existing app wins over any doc — do not switch the database/auth provider or re-platform to match a doc.');
+    }
     shortLines.push('');
     shortLines.push('Binding contract — read first:');
     shortLines.push('- docs/spec.md (integrated specification — cross-section context)');
@@ -736,7 +747,9 @@ export function formatPlanModePrompt(groups, venture, summary, { mode = 'create-
       ? '- The existing app + replit.md EHG-BUILD-CONTEXT (match its design system; build additively)'
       : '- docs/designs/ (approved HTML — match the majority nav pattern)');
     shortLines.push('- docs/color-palette.md (brand CSS variables — use only these)');
-    shortLines.push('- docs/architecture.md (tech stack + data model + schema — use these decisions)');
+    shortLines.push(mode === 'build-into'
+      ? '- docs/architecture.md (data model + domain only — NOT to re-platform; the app is authoritative for the stack)'
+      : '- docs/architecture.md (tech stack + data model + schema — use these decisions)');
     shortLines.push('- docs/monitoring.md (Sentry + central feedback table — wire on day one)');
     shortLines.push('- docs/tasks.md (pre-decomposed task list)');
     shortLines.push('');

--- a/tests/unit/bridge/replit-prompt-sot-hardening.test.js
+++ b/tests/unit/bridge/replit-prompt-sot-hardening.test.js
@@ -1,0 +1,72 @@
+/**
+ * QF-20260523-253: source-of-truth hardening for build-into Plan Mode prompts
+ * (follow-on to SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001).
+ *
+ * Replit's review of the first build-into venture flagged that the prompt asserted
+ * a *guessed* framework and treated planning-era docs as authoritative, so a stale
+ * docs/architecture.md (Vercel + Supabase) could drag the build off the actual app.
+ * These assertions lock in: build-into makes the EXISTING APP authoritative; create-new
+ * is byte-identical to before (no regression on the scaffold path).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatPlanModePrompt } from '../../../lib/eva/bridge/replit-format-strategies.js';
+
+// Minimal groups: no how_to_build_it group => detectStack defaults framework to 'Vite' (web).
+const groups = [
+  {
+    group_key: 'sprint_plan',
+    group_name: 'Sprint Plan',
+    artifacts: [{ content: JSON.stringify({ items: [{ name: 'Login', story_points: 1, priority: 'high' }] }) }],
+  },
+];
+const venture = { name: 'TestVenture', description: 'A test venture app', targetPlatform: 'web' };
+const summary = {};
+
+const buildInto = formatPlanModePrompt(groups, venture, summary, { mode: 'build-into' });
+const createNew = formatPlanModePrompt(groups, venture, summary, { mode: 'create-new' });
+
+describe('formatPlanModePrompt — build-into source-of-truth hardening', () => {
+  it('does NOT assert a guessed framework in the build-into opening (P2)', () => {
+    expect(buildInto).not.toContain('existing Vite app');
+    expect(buildInto).toContain('do NOT assume a framework');
+    expect(buildInto).toContain('package.json');
+  });
+
+  it('states an explicit source-of-truth precedence with the app authoritative (P1)', () => {
+    expect(buildInto).toContain('Source of truth');
+    expect(buildInto).toContain('FOLLOW THE APP');
+    expect(buildInto.toLowerCase()).toContain('switch the database/auth provider');
+  });
+
+  it('reframes the planning description as intent, not the build target (P2)', () => {
+    expect(buildInto).toContain('Intended purpose');
+  });
+
+  it('makes the architecture doc defensive — domain not re-platform (P3)', () => {
+    expect(buildInto.toLowerCase()).toContain('not to re-platform');
+    expect(buildInto).toContain('follow the repo');
+  });
+
+  it('tells Replit older design mockups are superseded by the app (P4)', () => {
+    expect(buildInto).toContain('treat them as superseded');
+    expect(buildInto).not.toContain('docs/designs/'); // build-into never points at docs/designs/ (shared invariant)
+  });
+});
+
+describe('formatPlanModePrompt — create-new path is unchanged (regression guard)', () => {
+  it('still opens with the framework-asserted scaffold line', () => {
+    expect(createNew).toContain('Build a Vite application: A test venture app');
+  });
+
+  it('keeps the original architecture + designs doc-list lines', () => {
+    expect(createNew).toContain('- docs/architecture.md — tech stack, data model, API surface, schema. Use these decisions; do not re-derive.');
+    expect(createNew).toContain('Match the layout and the majority navigation pattern.');
+  });
+
+  it('does NOT leak any build-into-only source-of-truth language', () => {
+    expect(createNew).not.toContain('Source of truth');
+    expect(createNew).not.toContain('FOLLOW THE APP');
+    expect(createNew).not.toContain('Intended purpose');
+    expect(createNew).not.toContain('treat them as superseded');
+  });
+});


### PR DESCRIPTION
## What
Source-of-truth hardening for the S19 **build-into** Replit Plan Mode prompt (follow-on to SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001).

Replit's review of the first build-into venture (Canvas AI → contribution-hub) flagged that the prompt asserted a *guessed* framework and treated planning-era docs as authoritative, so a stale `docs/architecture.md` (Vercel + Supabase) could pull the build off the actual app.

## Changes (`formatPlanModePrompt`, build-into mode only)
- **P1** Explicit precedence: existing app (current reality, authoritative for stack/db/auth/hosting/routes/design) > `docs/` (chairman intent) > this prompt. Conflicts ⇒ **follow the app**; never switch db/auth provider or re-platform to match a doc.
- **P2** Drop the detected-framework assertion + reframe `venture.description` as "intended purpose" (may differ from the build). Tell Replit to inspect `package.json` first.
- **P3** `docs/architecture.md` reframed as data-model/domain intent, **not** a re-platform directive.
- **P4** Older repo design mockups marked superseded by the app.
- Same precedence carried (terse) into the truncated-budget fallback.

**create-new path is byte-identical** (all changes inside `build-into` branches).

## Tests
- New `tests/unit/bridge/replit-prompt-sot-hardening.test.js` (8 assertions: build-into language + create-new regression guard).
- Full bridge suite: **79/79 green**.

~13 net source LOC (Tier 1 QF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)