### PR TITLE
fix(QF-20260523-727): FR-5: bounded skip-count drift assertion for no-DB unit delta gate

### DIFF
--- a/scripts/compare-to-main-snapshot.mjs
+++ b/scripts/compare-to-main-snapshot.mjs
@@ -8,14 +8,17 @@
  *
  * Modes:
  *   push to main → INSERT a snapshot row into codebase_health_snapshots with
- *                  current failed_tests count and trend_direction relative to
- *                  the prior snapshot.
+ *                  current failed_tests + skipped_tests counts and trend_direction
+ *                  relative to the prior snapshot.
  *   pull_request → SELECT the most recent snapshot for the PR's base branch.
  *                  If current failed_tests > baseline by ≥1, write
  *                  test-failures-pr.json (for the upload-artifact step) and
- *                  exit 1 with three ::error:: annotations on stderr.
+ *                  exit 1 with ::error:: annotations on stderr. Otherwise, if the
+ *                  skipped-test count has drifted outside the baseline's ±10% band
+ *                  (FR-5 vacuous-green guard), exit 1 with a SKIP_DRIFT annotation.
  *
- * Cold start (no prior snapshot for base branch): pass with trend_direction='new'.
+ * Cold start (no prior snapshot for base branch, or a snapshot predating the
+ * skipped_count field): pass — the next push to that branch records the baseline.
  *
  * Env vars required:
  *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
@@ -24,7 +27,8 @@
  *
  * Exit codes:
  *   0 — comparison passed (or push snapshot written)
- *   1 — BASELINE_REGRESSION: PR introduces new failures vs base snapshot
+ *   1 — BASELINE_REGRESSION (new failures vs base) or SKIP_DRIFT (skipped count
+ *       outside the baseline's ±10% band — a likely vacuous-green run)
  *   2 — invocation/parse error (missing env, missing test-results.json, DB error)
  *
  * See docs/reference/test-coverage-baseline-ratchet.md for triage.
@@ -32,7 +36,14 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { argv, env, exit, stderr, stdout } from 'node:process';
+import { createRequire } from 'node:module';
 import { createClient } from '@supabase/supabase-js';
+
+// FR-5 (SD-FDBK-INFRA-VITEST-PROJECT-SPLIT-001): shared skip-drift band detector,
+// authored as CommonJS so the local session hook (compare-test-baseline.cjs) and
+// this ESM ratchet share one implementation. ESM imports it via createRequire.
+const require = createRequire(import.meta.url);
+const { skipDriftStatus } = require('./lib/skip-drift.cjs');
 
 const DIMENSION = 'ci_test_failure_count';
 const TARGET_APP = 'EHG_Engineer';
@@ -71,10 +82,13 @@ function readTestResults(path) {
   try { json = JSON.parse(raw); } catch (e) { die(`failed to parse ${path}: ${e.message}`); }
   const failed = Number(json.numFailedTests ?? 0);
   const total = Number(json.numTotalTests ?? 0);
+  // FR-5: skipped = pending (describeDb/.skip self-skips) + todo. Mirrors the
+  // capture-baseline hook's definition so both delta gates agree.
+  const skipped = Number(json.numPendingTests ?? 0) + Number(json.numTodoTests ?? 0);
   if (!Number.isFinite(failed) || !Number.isFinite(total) || total === 0) {
     die(`unexpected vitest JSON shape: numFailedTests=${json.numFailedTests}, numTotalTests=${json.numTotalTests}`);
   }
-  return { failed, total, raw: json };
+  return { failed, total, skipped: Number.isFinite(skipped) ? skipped : 0, raw: json };
 }
 
 function detectContext() {
@@ -111,26 +125,36 @@ async function fetchPriorSnapshot(supabase, branch) {
   for (const row of data || []) {
     const branchInRow = row.findings?.[0]?.branch;
     if (branchInRow === branch) {
-      return { failed_count: Number(row.findings[0].failed_count), scanned_at: row.scanned_at };
+      // FR-5: skipped_count is absent on snapshots written before this shipped —
+      // leave it null so the skip-drift check cold-starts (passes) until the
+      // next push to this branch records it.
+      const rawSkipped = row.findings[0].skipped_count;
+      return {
+        failed_count: Number(row.findings[0].failed_count),
+        skipped_count: rawSkipped == null ? null : Number(rawSkipped),
+        scanned_at: row.scanned_at,
+      };
     }
   }
   return null;
 }
 
-async function insertSnapshot(supabase, { failed, total, branch, sha, runId, priorFailed }) {
+async function insertSnapshot(supabase, { failed, total, skipped, branch, sha, runId, priorFailed }) {
   const score = total === 0 ? 0 : Number(((total - failed) / total * 100).toFixed(2));
   const trend = trendFor(failed, priorFailed);
   const row = {
     dimension: DIMENSION,
     target_application: TARGET_APP,
     score,
-    findings: [{ failed_count: failed, branch, commit_sha: sha }],
+    // FR-5: skipped_count is recorded alongside failed_count so the next PR's
+    // skip-drift band has a baseline (the ratchet rewrites it on every push).
+    findings: [{ failed_count: failed, skipped_count: skipped, branch, commit_sha: sha }],
     trend_direction: trend,
     metadata: { workflow_run_id: runId },
   };
   const { error } = await supabase.from(TABLE).insert(row);
   if (error) die(`INSERT snapshot failed: ${error.message}`);
-  stdout.write(`Snapshot written: branch=${branch} failed=${failed}/${total} score=${score} trend=${trend}\n`);
+  stdout.write(`Snapshot written: branch=${branch} failed=${failed}/${total} skipped=${skipped} score=${score} trend=${trend}\n`);
 }
 
 function writePrFailuresArtifact(path, raw, failed) {
@@ -155,9 +179,18 @@ function annotateRegression(newFailures) {
   stderr.write(`See docs/reference/test-coverage-baseline-ratchet.md for triage steps.\n`);
 }
 
+function annotateSkipDrift(skip) {
+  stderr.write(
+    `::error::SKIP_DRIFT: ${skip.currentSkipped} skipped this run vs baseline ${skip.baselineSkipped} ` +
+    `(allowed band ${skip.lowerBound}–${skip.upperBound}, drift ${skip.drift >= 0 ? '+' : ''}${skip.drift}).\n`
+  );
+  stderr.write(`A large jump usually means DB-guarded suites all self-skipped (e.g. SUPABASE_URL/SERVICE_ROLE_KEY failed to inject) — a "vacuous green". A large drop means a skip guard was removed.\n`);
+  stderr.write(`Verify the DB secrets are present in CI and that describeDb suites still skip as intended. See docs/reference/test-coverage-baseline-ratchet.md.\n`);
+}
+
 async function main() {
   const args = parseArgs();
-  const { failed, total, raw } = readTestResults(args.resultsPath);
+  const { failed, total, skipped, raw } = readTestResults(args.resultsPath);
   const ctx = detectContext();
 
   const url = env.SUPABASE_URL;
@@ -168,7 +201,7 @@ async function main() {
   if (ctx.mode === 'push') {
     const prior = await fetchPriorSnapshot(supabase, ctx.branch);
     await insertSnapshot(supabase, {
-      failed, total, branch: ctx.branch, sha: ctx.sha, runId: ctx.runId,
+      failed, total, skipped, branch: ctx.branch, sha: ctx.sha, runId: ctx.runId,
       priorFailed: prior?.failed_count,
     });
     return 0;
@@ -186,7 +219,17 @@ async function main() {
     annotateRegression(newFailures);
     return 1;
   }
-  stdout.write(`Snapshot baseline=${prior.failed_count}, current=${failed}, delta=${newFailures} — passing.\n`);
+  // FR-5: failure count is stable — now guard against a vacuous green where the
+  // DB-guarded suites silently all skipped (failed stays flat, skipped spikes).
+  const skip = skipDriftStatus({ baselineSkipped: prior.skipped_count, currentSkipped: skipped });
+  if (skip.status === 'SKIP_DRIFT') {
+    annotateSkipDrift(skip);
+    return 1;
+  }
+  const skipNote = skip.status === 'NEW'
+    ? 'skip baseline not yet recorded (cold start)'
+    : `skipped=${skipped} within band ${skip.lowerBound}–${skip.upperBound}`;
+  stdout.write(`Snapshot baseline=${prior.failed_count}, current=${failed}, delta=${newFailures}; ${skipNote} — passing.\n`);
   return 0;
 }
 

--- a/scripts/hooks/compare-test-baseline.cjs
+++ b/scripts/hooks/compare-test-baseline.cjs
@@ -17,7 +17,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { captureBaseline, captureUnitTestState, captureTypeCheckState } = require('./capture-baseline-test-state');
+// Explicit .cjs extension: these hooks were renamed .js → .cjs (package "type":
+// "module") but this require was left extensionless, which Node's CommonJS
+// loader does NOT resolve to a .cjs file — `npm run hooks:baseline` crashed at
+// load with MODULE_NOT_FOUND. Fixed here alongside the FR-5 skip-drift wiring,
+// since the local gate's skip-awareness can't run until the module loads.
+const { captureBaseline, captureUnitTestState, captureTypeCheckState } = require('./capture-baseline-test-state.cjs');
+const { skipDriftStatus } = require('../lib/skip-drift.cjs');
 
 const SESSION_STATE_FILE = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
 
@@ -70,6 +76,24 @@ function compareTestCounts(baseline, current, label) {
     result.status = 'CLEAN';
   } else {
     result.status = 'STABLE';  // Same failures as baseline
+  }
+
+  // FR-5 (SD-FDBK-INFRA-VITEST-PROJECT-SPLIT-001): skip-count drift. A no-DB
+  // unit run where every DB-guarded suite silently skips keeps `failed` at the
+  // baseline (often 0), so the failure-only checks above would pass it as a
+  // false green. Flag when the skipped count leaves the recorded baseline's
+  // ±10% band (abs floor 10). Cold start (no recorded baseline skip count) is
+  // 'NEW' and is treated as a pass. SKIP_DRIFT never masks a REGRESSION.
+  const skip = skipDriftStatus({
+    baselineSkipped: baseline?.skipped,
+    currentSkipped: current?.skipped,
+  });
+  result.baseline_skipped = skip.baselineSkipped == null ? (baseline?.skipped || 0) : skip.baselineSkipped;
+  result.current_skipped = skip.currentSkipped;
+  result.skip_drift = skip.drift;
+  result.skip_status = skip.status;
+  if (skip.status === 'SKIP_DRIFT' && result.status !== 'REGRESSION') {
+    result.status = 'SKIP_DRIFT';
   }
 
   return result;
@@ -146,13 +170,21 @@ function generateComparisonReport(baseline, current) {
     (report.comparisons.engineer_tests.fixed || 0) +
     (report.comparisons.app_tests.fixed || 0);
 
-  // Determine overall status
+  // FR-5: count comparisons whose skipped count drifted out of band.
+  report.summary.total_skip_drift = Object.values(report.comparisons)
+    .filter(c => c.skip_status === 'SKIP_DRIFT').length;
+
+  // Determine overall status. SKIP_DRIFT is a failing state (ranks below
+  // REGRESSION so a real regression is never masked).
   const hasRegression = Object.values(report.comparisons).some(c => c.status === 'REGRESSION');
+  const hasSkipDrift = Object.values(report.comparisons).some(c => c.status === 'SKIP_DRIFT');
   const hasImprovement = Object.values(report.comparisons).some(c => c.status === 'IMPROVED');
   const allClean = Object.values(report.comparisons).every(c => c.status === 'CLEAN');
 
   if (hasRegression) {
     report.summary.overall_status = 'REGRESSION';
+  } else if (hasSkipDrift) {
+    report.summary.overall_status = 'SKIP_DRIFT';
   } else if (allClean) {
     report.summary.overall_status = 'CLEAN';
   } else if (hasImprovement) {
@@ -177,6 +209,7 @@ function printReport(report) {
 
   for (const [key, comparison] of Object.entries(report.comparisons)) {
     const icon = comparison.status === 'REGRESSION' ? '❌' :
+                 comparison.status === 'SKIP_DRIFT' ? '❌' :
                  comparison.status === 'IMPROVED' ? '✅' :
                  comparison.status === 'CLEAN' ? '✅' : '⚪';
     console.log(`${icon} ${comparison.label}: ${comparison.status}`);
@@ -189,6 +222,10 @@ function printReport(report) {
     }
     if (comparison.fixed > 0) {
       console.log(`   FIXED: ${comparison.fixed}`);
+    }
+    if (comparison.skip_status === 'SKIP_DRIFT') {
+      const sign = comparison.skip_drift >= 0 ? '+' : '';
+      console.log(`   SKIP DRIFT: ${comparison.current_skipped} skipped vs baseline ${comparison.baseline_skipped} (${sign}${comparison.skip_drift}) — possible vacuous green`);
     }
   }
 
@@ -235,8 +272,9 @@ function main() {
 
   printReport(report);
 
-  // Exit with appropriate code
-  if (report.summary.overall_status === 'REGRESSION') {
+  // Exit with appropriate code. SKIP_DRIFT is a failing state alongside
+  // REGRESSION (FR-5: a vacuous-green run must not pass silently).
+  if (report.summary.overall_status === 'REGRESSION' || report.summary.overall_status === 'SKIP_DRIFT') {
     process.exit(1);
   }
 }

--- a/scripts/lib/skip-drift.cjs
+++ b/scripts/lib/skip-drift.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Bounded skip-count drift detector for the no-DB unit delta gates.
+ * SD-FDBK-INFRA-VITEST-PROJECT-SPLIT-001 FR-5 (QF-20260523-727).
+ *
+ * The vitest db/no-db split made the no-DB `unit` baseline a DELTA model:
+ * compare-test-baseline.cjs (local session hook) and compare-to-main-snapshot.mjs
+ * (CI ratchet) flag only NEW *failures* vs a recorded baseline. Neither watched
+ * the SKIPPED count — so a run where every DB-guarded suite silently skips (e.g.
+ * the DB credentials fail to inject and describeDb self-skips the whole suite)
+ * shows failed=0 and passes as a false "green". This detector flags that
+ * vacuous-green: it reports SKIP_DRIFT when the current skipped count falls
+ * outside ±tolerance of the recorded baseline skipped count.
+ *
+ * Delta-model semantics: the recorded baseline IS the expected skip count
+ * (green = stable vs the recorded baseline, NOT zero skips). Cold start (no
+ * baseline skip count recorded yet) returns status 'NEW' so the caller passes
+ * the gate and records `currentSkipped` going forward — identical to how the
+ * failed-count ratchet treats a missing prior snapshot.
+ *
+ * The band uses an absolute floor (default 10) in addition to the percentage so
+ * a small baseline (e.g. CI runs WITH a DB, where only a handful of .skip/.todo
+ * tests are pending) does not trip on benign ±1 churn — only a genuine cliff
+ * (hundreds of suites suddenly self-skipping) breaks the floor.
+ */
+
+const DEFAULT_TOLERANCE = 0.10; // ±10%
+const DEFAULT_ABS_FLOOR = 10; // never flag drift smaller than ±10 tests
+
+function toCount(v) {
+  const n = Math.trunc(Number(v));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * @param {object} params
+ * @param {number|null|undefined} params.baselineSkipped recorded baseline skip count (null/undefined => cold start)
+ * @param {number} params.currentSkipped current run skip count
+ * @param {number} [params.tolerance=0.10] fractional band (0.10 = ±10%)
+ * @param {number} [params.absFloor=10] minimum absolute band half-width
+ * @returns {{status:'OK'|'NEW'|'SKIP_DRIFT', baselineSkipped:number|null, currentSkipped:number, drift:number, lowerBound:number|null, upperBound:number|null, tolerance:number, absFloor:number}}
+ */
+function skipDriftStatus({ baselineSkipped, currentSkipped, tolerance = DEFAULT_TOLERANCE, absFloor = DEFAULT_ABS_FLOOR } = {}) {
+  const cur = toCount(currentSkipped);
+  const tol = Number.isFinite(Number(tolerance)) && Number(tolerance) >= 0 ? Number(tolerance) : DEFAULT_TOLERANCE;
+  const floor = Number.isFinite(Number(absFloor)) && Number(absFloor) >= 0 ? Number(absFloor) : DEFAULT_ABS_FLOOR;
+
+  // Cold start: no baseline recorded yet — pass and let the caller record `cur`.
+  if (baselineSkipped === null || baselineSkipped === undefined || !Number.isFinite(Number(baselineSkipped))) {
+    return { status: 'NEW', baselineSkipped: null, currentSkipped: cur, drift: 0, lowerBound: null, upperBound: null, tolerance: tol, absFloor: floor };
+  }
+
+  const base = toCount(baselineSkipped);
+  const margin = Math.max(base * tol, floor);
+  const lowerBound = Math.max(0, base - margin);
+  const upperBound = base + margin;
+  const drift = cur - base;
+  const status = cur < lowerBound || cur > upperBound ? 'SKIP_DRIFT' : 'OK';
+
+  return { status, baselineSkipped: base, currentSkipped: cur, drift, lowerBound, upperBound, tolerance: tol, absFloor: floor };
+}
+
+module.exports = { skipDriftStatus, DEFAULT_TOLERANCE, DEFAULT_ABS_FLOOR };

--- a/tests/unit/skip-drift.test.js
+++ b/tests/unit/skip-drift.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-FDBK-INFRA-VITEST-PROJECT-SPLIT-001 FR-5 (QF-20260523-727) — unit coverage
+ * for the bounded skip-count drift detector that guards the no-DB unit delta
+ * gates against vacuous green.
+ *
+ * Pure, no-DB: asserts on the band math only (this file belongs to the default
+ * `unit` vitest project and must never touch a connection).
+ */
+import { describe, it, expect } from 'vitest';
+import { skipDriftStatus, DEFAULT_TOLERANCE, DEFAULT_ABS_FLOOR } from '../../scripts/lib/skip-drift.cjs';
+
+describe('skipDriftStatus — cold start', () => {
+  it('returns NEW when baselineSkipped is null (no recorded baseline)', () => {
+    const r = skipDriftStatus({ baselineSkipped: null, currentSkipped: 500 });
+    expect(r.status).toBe('NEW');
+    expect(r.baselineSkipped).toBe(null);
+    expect(r.currentSkipped).toBe(500);
+  });
+
+  it('returns NEW when baselineSkipped is undefined (missing field on old snapshot)', () => {
+    expect(skipDriftStatus({ currentSkipped: 12 }).status).toBe('NEW');
+  });
+
+  it('returns NEW when baselineSkipped is non-finite', () => {
+    expect(skipDriftStatus({ baselineSkipped: NaN, currentSkipped: 12 }).status).toBe('NEW');
+  });
+});
+
+describe('skipDriftStatus — within band (OK)', () => {
+  it('exact match is OK with zero drift', () => {
+    const r = skipDriftStatus({ baselineSkipped: 100, currentSkipped: 100 });
+    expect(r.status).toBe('OK');
+    expect(r.drift).toBe(0);
+    expect(r.lowerBound).toBe(90);
+    expect(r.upperBound).toBe(110);
+  });
+
+  it('is OK at the +10% edge', () => {
+    expect(skipDriftStatus({ baselineSkipped: 100, currentSkipped: 110 }).status).toBe('OK');
+  });
+
+  it('is OK at the -10% edge', () => {
+    expect(skipDriftStatus({ baselineSkipped: 100, currentSkipped: 90 }).status).toBe('OK');
+  });
+});
+
+describe('skipDriftStatus — out of band (SKIP_DRIFT)', () => {
+  it('flags the vacuous-green cliff: all DB suites suddenly skip', () => {
+    const r = skipDriftStatus({ baselineSkipped: 100, currentSkipped: 400 });
+    expect(r.status).toBe('SKIP_DRIFT');
+    expect(r.drift).toBe(300);
+  });
+
+  it('flags a large drop (skip guard removed → DB tests now run/fail elsewhere)', () => {
+    const r = skipDriftStatus({ baselineSkipped: 100, currentSkipped: 50 });
+    expect(r.status).toBe('SKIP_DRIFT');
+    expect(r.drift).toBe(-50);
+  });
+
+  it('coerces a non-finite current count to 0 and flags drift vs a real baseline', () => {
+    const r = skipDriftStatus({ baselineSkipped: 100, currentSkipped: NaN });
+    expect(r.currentSkipped).toBe(0);
+    expect(r.status).toBe('SKIP_DRIFT');
+  });
+});
+
+describe('skipDriftStatus — absolute floor absorbs small-baseline churn', () => {
+  it('does NOT flag ±a-few on a small baseline (band widened by abs floor)', () => {
+    // base=20, %band would be [18,22]; abs floor 10 widens it to [10,30].
+    const r = skipDriftStatus({ baselineSkipped: 20, currentSkipped: 23 });
+    expect(r.status).toBe('OK');
+    expect(r.lowerBound).toBe(10);
+    expect(r.upperBound).toBe(30);
+  });
+
+  it('still flags a genuine cliff on a small baseline', () => {
+    expect(skipDriftStatus({ baselineSkipped: 20, currentSkipped: 400 }).status).toBe('SKIP_DRIFT');
+  });
+
+  it('baseline 0 / current 0 is OK; current beyond the floor is SKIP_DRIFT', () => {
+    expect(skipDriftStatus({ baselineSkipped: 0, currentSkipped: 0 }).status).toBe('OK');
+    expect(skipDriftStatus({ baselineSkipped: 0, currentSkipped: 5 }).status).toBe('OK'); // within floor band [0,10]
+    expect(skipDriftStatus({ baselineSkipped: 0, currentSkipped: 15 }).status).toBe('SKIP_DRIFT');
+  });
+
+  it('clamps the lower bound at 0 (never negative)', () => {
+    const r = skipDriftStatus({ baselineSkipped: 5, currentSkipped: 5 });
+    expect(r.lowerBound).toBe(0); // max(0, 5 - 10)
+  });
+});
+
+describe('skipDriftStatus — configurable tolerance', () => {
+  it('honors a custom tolerance', () => {
+    expect(skipDriftStatus({ baselineSkipped: 100, currentSkipped: 140, tolerance: 0.5 }).status).toBe('OK'); // band [50,150]
+    expect(skipDriftStatus({ baselineSkipped: 100, currentSkipped: 160, tolerance: 0.5 }).status).toBe('SKIP_DRIFT');
+  });
+
+  it('falls back to the default tolerance/floor on garbage input', () => {
+    const r = skipDriftStatus({ baselineSkipped: 100, currentSkipped: 100, tolerance: -1, absFloor: -1 });
+    expect(r.tolerance).toBe(DEFAULT_TOLERANCE);
+    expect(r.absFloor).toBe(DEFAULT_ABS_FLOOR);
+  });
+});
+
+describe('skipDriftStatus — exported constants', () => {
+  it('exposes default tolerance (±10%) and floor (10)', () => {
+    expect(DEFAULT_TOLERANCE).toBe(0.10);
+    expect(DEFAULT_ABS_FLOOR).toBe(10);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260523-727  **Type:** bug **Severity:** medium  ### Issue Description Follow-on to SD-FDBK-INFRA-VITEST-PROJECT-SPLIT-001 closing its one deferred robustness FR. The no-DB unit baseline is a delta model that only tracks failed counts; add a bounded skipped-count drift assertion (shared skip-drift helper) to both delta comparers so an all-skip run cannot masquerade as green.  ### Steps to Reproduce 1. Run the no-DB unit project with db-guarded suites all skipping (e.g. CI secrets fail to inject). 2. Observe failed=0. 3. The delta gate reports green even though hundreds of tests never executed.  ### Expected Behavior The no-DB unit delta gate flags a regression when the skipped test count drifts more than 10 percent from the recorded baseline, so an all-skip run cannot pass green.  ### Actual Behavior Both delta comparers track only the failed count; if every db-guarded unit test silently skips, failed stays 0 and the run passes as a false green.  ### Changes - **Files Changed:** 4   - scripts/compare-to-main-snapshot.mjs   - scripts/hooks/compare-test-baseline.cjs   - scripts/lib/skip-drift.cjs   - tests/unit/skip-drift.test.js - **LOC:** 279 lines - **Tests:** ✅ Passing - **UAT:** ✅ Verified  ### Verification No additional notes  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol