### PR TITLE
fix(QF-20260523-824): fleet-lock-hash TS-7: deterministic clock for the FRESHNESS_MS boundary test

### DIFF
--- a/lib/fleet-lock-hash.mjs
+++ b/lib/fleet-lock-hash.mjs
@@ -198,7 +198,7 @@ export async function emitFractureForDiff(supabase, before, after) {
  *   error?: string
  * }}
  */
-export function checkStagingState(repoRoot) {
+export function checkStagingState(repoRoot, now = Date.now()) {
   const stagingPath = path.join(repoRoot, 'node_modules', STAGING_DIRNAME);
 
   if (!existsSync(stagingPath)) return { state: 'absent', stagingPath };
@@ -218,7 +218,10 @@ export function checkStagingState(repoRoot) {
   } catch {
     return { state: 'absent', stagingPath };
   }
-  const mtimeAgeMs = Date.now() - mtimeMs;
+  // QF-20260523-824 (closes feedback 414fdace): `now` is injectable (default
+  // Date.now()) so the FRESHNESS_MS boundary test is deterministic instead of
+  // racing on wall-clock time elapsed between setting mtime and this read.
+  const mtimeAgeMs = now - mtimeMs;
 
   if (mtimeAgeMs <= STAGING_FRESHNESS_MS) {
     // FR-1(b): fresh — peer is mid-extract, defer.
@@ -267,13 +270,14 @@ export function checkStagingState(repoRoot) {
 export async function evaluateInstallDecision({
   repoRoot,
   canaryRelativePath = path.join('node_modules', '@supabase', 'supabase-js'),
-  forceInstall = false
+  forceInstall = false,
+  now = Date.now()
 }) {
   // FR-1: .staging contention guard.  Runs BEFORE the existing hash/canary
   // logic so we never even compute the hash when a peer is mid-extract.
   // Exception: forceInstall takes precedence (FR-1 TS-10) — explicit user
   // override semantics — but we still emit a warning when overridden.
-  const staging = checkStagingState(repoRoot);
+  const staging = checkStagingState(repoRoot, now);
   if (staging.state === 'fresh' && !forceInstall) {
     return {
       skip: true,

--- a/tests/unit/fleet-lock-hash.test.js
+++ b/tests/unit/fleet-lock-hash.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { promises as fsp, existsSync, readFileSync, utimesSync, mkdirSync, writeFileSync } from 'node:fs';
+import { promises as fsp, existsSync, readFileSync, utimesSync, mkdirSync, writeFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -413,9 +413,26 @@ describe('fleet-lock-hash: evaluateInstallDecision .staging guard (FR-1 a/b/c/d/
   it('TS-7: mtime exactly at FRESHNESS_MS boundary stays in defer band (≤60s)', async () => {
     const sp = makeStagingDir(repo);
     setStagingMtimeAge(sp, 60_000);
-    const d = await evaluateInstallDecision({ repoRoot: repo });
+    // QF-20260523-824 (closes feedback 414fdace): inject a deterministic clock so
+    // mtimeAgeMs == 60_000 EXACTLY. The original test let wall-clock time elapse
+    // between setting mtime and the freshness read, so age drifted to >60_000
+    // ~1-in-3 runs and flipped fresh→stale. now = mtime + 60_000 removes the race
+    // and pins the inclusive (≤) boundary.
+    const mtimeMs = statSync(sp).mtimeMs;
+    const d = await evaluateInstallDecision({ repoRoot: repo, now: mtimeMs + 60_000 });
     expect(d.skip).toBe(true);
     expect(d.reason).toBe('staging_active');
+  });
+
+  it('TS-7b: mtime 1ms PAST FRESHNESS_MS is stale (boundary is inclusive ≤, not <)', async () => {
+    const sp = makeStagingDir(repo);
+    setStagingMtimeAge(sp, 60_000);
+    const mtimeMs = statSync(sp).mtimeMs;
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const d = await evaluateInstallDecision({ repoRoot: repo, now: mtimeMs + 60_001 });
+    expect(d.skip).toBe(false); // stale → auto-cleaned → falls through to hash/canary logic
+    expect(existsSync(sp)).toBe(false);
+    stderrSpy.mockRestore();
   });
 
   it('TS-9: storedHash=null + fresh .staging — staging-active precedence wins', async () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260523-824  **Type:** bug **Severity:** low  ### Issue Description Closes feedback 414fdace. tests/unit/fleet-lock-hash.test.js TS-7 ('mtime exactly at FRESHNESS_MS boundary') fails ~1-in-3 due to a wall-clock race: setStagingMtimeAge sets mtime=now-60000, but checkStagingState computes Date.now()-mtimeMs a few ms later (>60000) flipping fresh→stale. Add an optional injectable now param (default Date.now()) to checkStagingState + evaluateInstallDecision so the boundary test pins the clock and asserts the inclusive ≤ boundary deterministically.  ### Steps to Reproduce 1. Run vitest tests/unit/fleet-lock-hash.test.js repeatedly. 2. TS-7 fails intermittently (~1-in-3).  ### Expected Behavior TS-7 deterministically asserts mtime age == FRESHNESS_MS defers (inclusive boundary).  ### Actual Behavior TS-7 races on wall-clock elapsed time between setting mtime and the freshness check.  ### Changes - **Files Changed:** 2   - lib/fleet-lock-hash.mjs   - tests/unit/fleet-lock-hash.test.js - **LOC:** 34 lines - **Tests:** ✅ Passing - **UAT:** ✅ Verified  ### Verification Clock-injection fix: optional now param (default Date.now()) threaded checkStagingState + evaluateInstallDecision. TS-7 now pins age==60000 exactly; +TS-7b (60001→stale). 43/43 green on 3 consecutive runs (was flaky ~1-in-3). Closes feedback 414fdace.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol