### PR TITLE
fix(QF-20260523-820): sd-start.js: process.exit(0) on success so the claim CLI cannot hang on the heartbeat interval (SIGTERM exit 143)

### DIFF
--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -114,6 +114,13 @@ async function releaseSessionWithRetry(reason = 'graceful_exit') {
  * SD-LEO-INFRA-ISL-001 (US-002): Enhanced with graceful exit handlers
  * SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001 (FR-007): Supports ownership modes
  *
+ * ⚠️ This arms a ref'd 30s setInterval that keeps the Node event loop alive.
+ * It is intended for LONG-RUNNING workers (handoff.js, BaseExecutor.js,
+ * add-prd-to-database.js). If you call it from a short-lived claim-and-exit CLI,
+ * you MUST call stopHeartbeat() (or process.exit()) before the script returns —
+ * otherwise the process hangs until an external watchdog SIGTERMs it (exit 143).
+ * See QF-20260424-805 (add-prd-to-database.js) and QF-20260523-820 (sd-start.js).
+ *
  * @param {string} sessionId - Session ID to send heartbeats for
  * @param {object} [options]
  * @param {'exclusive'|'cooperative'} [options.ownershipMode='exclusive']

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -35,7 +35,7 @@ import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
 // under a rotated session_id (the 2026-04-24 incident class).
 import { checkPreClaimEvidence } from './modules/claim-health/triangulate.js';
 import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
-import { isProcessRunning, startHeartbeat } from '../lib/heartbeat-manager.mjs';
+import { isProcessRunning, startHeartbeat, stopHeartbeat } from '../lib/heartbeat-manager.mjs';
 import { getEstimatedDuration, formatEstimateDetailed } from './lib/duration-estimator.js';
 import { resolve as resolveWorkdir } from './resolve-sd-workdir.js';
 // SD-LEO-INFRA-FLEET-DASHBOARD-VISIBILITY-001: shared formatter so the roster
@@ -1758,7 +1758,24 @@ async function main() {
   console.log('═'.repeat(50));
 }
 
-main().catch(error => {
-  console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // QF-20260523-820: sd-start is a claim-and-exit CLI. startHeartbeat() (called
+    // mid-flow per FR-3 of SD-FDBK-INFRA-CASCADE-TRIGGER-OVERREACH-001) arms a ref'd
+    // 30s setInterval that holds Node's event loop open. Without an explicit exit the
+    // success path never returns — the process hangs until an external watchdog
+    // SIGTERMs it (exit 143). The orchestrator path masked this because its
+    // all-complete / no-child branches exit before the heartbeat is armed; the
+    // "found a workable child" branch falls through to here and hangs (true blast
+    // radius: every non-error-terminating run). Stop the heartbeat and exit, mirroring
+    // the QF-20260424-805 fix in add-prd-to-database.js. stopHeartbeat() clears the
+    // interval but does NOT release the claim (cooperative ownership) — the claim
+    // persists for the agent's subsequent work. RCA: sub_agent_execution_results
+    // c0c08fd6-c722-44a7-95d4-5c4126c2dd40.
+    stopHeartbeat();
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Quick-Fix: QF-20260523-820  **Type:** bug **Severity:** medium  ### Issue Description sd-start CLI never returns to the shell after a successful claim. startHeartbeat() arms a refd 30s setInterval that keeps the Node event loop alive; main() success path returns without process.exit(0), so the process hangs until an external watchdog SIGTERMs it (exit 143). Fix: exit(0) on the main() success path; mirrors the prior fix in add-prd-to-database.js.   ### Expected Behavior sd-start returns to the shell within ~1-2s after claiming and printing next steps  ### Actual Behavior process hangs indefinitely after the claim write; killed by SIGTERM (exit 143). Reported on orchestrator SDs but root cause is general.  ### Changes - **Files Changed:** 2   - lib/heartbeat-manager.mjs   - scripts/sd-start.js - **LOC:** 36 lines - **Tests:** ✅ Passing - **UAT:** ✅ Verified  ### Verification Closes feedback 2a94bc85-8008-4f55-a5e3-ae1ddb6efac5. RCA c0c08fd6 (0.97): startHeartbeat ref-d 30s setInterval held the event loop open; main() success path lacked process.exit(0); fixed via stopHeartbeat()+exit(0) mirroring QF-20260424-805. Verified: 92 relevant unit tests pass (sd-start + heartbeat-manager suites), node --check clean on both edited files. Live sd-start run intentionally not performed (forbidden on shared main; mutates claims/worktrees). Full unit suite skipped (pre-existing baseline failures; CI compare-to-main delta gate is authority). JS-only change so tsc skipped.  --- 🤖 Generated with [Claude Code](https://claude.com/claude-code) Quick-Fix Workflow - LEO Protocol