### PR TITLE
fix(QF-20260523-167): complete-quick-fix auto-resolver: preserve PR body newlines (--body-file) + tolerate trailing text after Closes-feedback footer

### DIFF
--- a/lib/governance/resolve-feedback.js
+++ b/lib/governance/resolve-feedback.js
@@ -21,8 +21,12 @@
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SHORT_ID_REGEX = /^[0-9a-f]{8}$/i;
-const FOOTER_REGEX = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f-]{36})[ \t]*$/gim;
-const FOOTER_REGEX_LOOSE = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f][0-9a-f-]{7,35})[ \t]*$/gim;
+// QF-20260523-167 / feedback d66e0850: the id is followed by a negative-lookahead
+// boundary (not anchored to end-of-line) so a footer with trailing text on the same
+// line — e.g. "Closes feedback <uuid>. Shipped via QF-..." — still matches. "Closes"
+// must still be at line start (^ + /m), so this is a footer, not a mid-sentence match.
+const FOOTER_REGEX = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f-]{36})(?![0-9a-f-])/gim;
+const FOOTER_REGEX_LOOSE = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f][0-9a-f-]{7,35})(?![0-9a-f-])/gim;
 
 /**
  * Parse "Closes feedback <uuid>" / "Closes harness backlog <uuid>" footers

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -16,6 +16,7 @@ import {
   generateEvidenceSummary
 } from '../../../lib/utils/quickfix-evidence-capture.js';
 import fs from 'fs';
+import os from 'os';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
@@ -567,17 +568,29 @@ async function createAutoPR(qfId, qf, filesChanged, actualLoc, testsPass, uatVer
     // Check if gh CLI is installed
     execSync('which gh', { stdio: 'pipe' });
 
-    // Generate PR title and body - sanitize for shell usage
+    // Title is still a shell arg, so keep it sanitized.
     const prTitle = sanitizeForShell(`fix(${validatedQfId}): ${qf.title || 'Quick fix'}`);
-    const prBody = sanitizeForShell(generatePRBody(validatedQfId, qf, filesChanged, actualLoc, testsPass, uatVerified, verificationNotes));
+    // QF-20260523-167 / feedback d66e0850: write the body to a temp file and use
+    // --body-file instead of --body "<sanitized>". sanitizeForShell collapsed every
+    // newline to a space, flattening the whole PR body — including any
+    // "Closes feedback <uuid>" footer — onto one line, so the post-merge resolver's
+    // line-anchored FOOTER_REGEX never matched and linked feedback was never closed.
+    // A body file preserves newlines and needs no shell escaping.
+    const prBody = generatePRBody(validatedQfId, qf, filesChanged, actualLoc, testsPass, uatVerified, verificationNotes);
+    const bodyFile = path.join(os.tmpdir(), `qf-pr-body-${validatedQfId}-${Date.now()}.md`);
+    fs.writeFileSync(bodyFile, prBody, 'utf-8');
 
     console.log(`   Creating PR: fix(${validatedQfId}): ${qf.title}\n`);
 
-    // SD-SEC-DATA-VALIDATION-001: Use sanitized inputs
-    const prOutput = execSync(`gh pr create --title "${prTitle}" --body "${prBody}"`, {
-      encoding: 'utf-8',
-      stdio: 'pipe'
-    });
+    let prOutput;
+    try {
+      prOutput = execSync(`gh pr create --title "${prTitle}" --body-file "${bodyFile}"`, {
+        encoding: 'utf-8',
+        stdio: 'pipe'
+      });
+    } finally {
+      try { fs.unlinkSync(bodyFile); } catch { /* best-effort temp cleanup */ }
+    }
 
     // Extract PR URL from output
     const urlMatch = prOutput.match(/https:\/\/github\.com\/[^\s]+/);

--- a/tests/unit/governance/resolve-feedback.test.js
+++ b/tests/unit/governance/resolve-feedback.test.js
@@ -49,6 +49,11 @@ describe('parseFeedbackFooters', () => {
     expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
   });
 
+  it('tolerates trailing text after the uuid on the footer line (QF-20260523-167)', () => {
+    const text = `### Verification\nCloses feedback ${VALID_UUID_1}. Shipped via QF-X. RCA c0c08fd6\n`;
+    expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
+  });
+
   it('parses single "Closes harness backlog <uuid>" footer (alternate verb)', () => {
     const text = `body line\n\nCloses harness backlog ${VALID_UUID_1}\n`;
     expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
@@ -269,8 +274,8 @@ describe('resolve-feedback.js static-pin', () => {
     expect(RESOLVE_FB_SRC).toMatch(/^const SHORT_ID_REGEX = \/\^\[0-9a-f\]\{8\}\$\/i;$/m);
   });
 
-  it('FOOTER_REGEX_LOOSE accepts 8-36 char hex-and-dash payloads', () => {
-    expect(RESOLVE_FB_SRC).toMatch(/^const FOOTER_REGEX_LOOSE = \/\^\[ \\t\]\*Closes\\s\+\(\?:feedback\|harness\\s\+backlog\)\\s\+\(\[0-9a-f\]\[0-9a-f-\]\{7,35\}\)\[ \\t\]\*\$\/gim;$/m);
+  it('FOOTER_REGEX_LOOSE accepts 8-36 char hex-and-dash payloads with a non-hex boundary (QF-20260523-167: tolerates trailing text)', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^const FOOTER_REGEX_LOOSE = \/\^\[ \\t\]\*Closes\\s\+\(\?:feedback\|harness\\s\+backlog\)\\s\+\(\[0-9a-f\]\[0-9a-f-\]\{7,35\}\)\(\?!\[0-9a-f-\]\)\/gim;$/m);
   });
 
   it('UUID range bounds use canonical "0000-0000-0000-000000000000" / "ffff-ffff-ffff-ffffffffffff" tails', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260523-167

**Type:** bug
**Severity:** medium

### Issue Description
createAutoPR in scripts/modules/complete-quick-fix/orchestrator.js builds the PR body then runs it through sanitizeForShell, which replaces every newline with a space. That collapses the whole body (including any 'Closes feedback <uuid>' footer) onto one line, so the post-merge auto-resolver FOOTER_REGEX in lib/governance/resolve-feedback.js (anchored per-line) never matches and feedback rows are never auto-closed. Fix: write the body to a temp file and use gh pr create --body-file (preserves newlines, no shell escaping needed for the body), and relax FOOTER_REGEX to tolerate trailing text after the uuid.


### Expected Behavior
an auto-created QF PR keeps newlines in its body so a Closes-feedback footer stays on its own line and the post-merge resolver closes the linked feedback row

### Actual Behavior
the PR body is flattened to one line; the footer is mid-line; FOOTER_REGEX never matches; linked feedback stays open (had to resolve manually)

### Changes
- **Files Changed:** 3
  - lib/governance/resolve-feedback.js
  - scripts/modules/complete-quick-fix/orchestrator.js
  - tests/unit/governance/resolve-feedback.test.js
- **LOC:** 40 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Fixes the QF auto-resolver: createAutoPR uses gh pr create --body-file (preserves newlines) and FOOTER_REGEX tolerates trailing text. 30/30 resolve-feedback unit tests pass; regex behavior verified (trailing-text matches, own-line matches, mid-sentence rejected); node --check clean. This completion self-validates: it runs the fixed code, so the commit Closes-footer should auto-resolve d66e0850.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol