### PR TITLE
fix(QF-20260523-697): worktree teardown: pre-unlink node_modules before git worktree remove --force at all 3 unguarded sites (prevent shared-store wipe)

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -481,6 +481,11 @@ export function rollbackWorktreeFilesystemSync(worktreePath, repoRoot, opts = {}
   const maxAttempts = delaysMs.length;
   let lastError = null;
 
+  // QF-20260523-697: unlink the node_modules junction BEFORE git removes the
+  // worktree, so `git worktree remove --force` can't follow it and wipe the
+  // shared main-repo node_modules (idempotent — safe to run before the retry loop).
+  preUnlinkWorktreeNodeModules(worktreePath);
+
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       execSync(`git worktree remove --force "${worktreePath}"`, {
@@ -1362,17 +1367,32 @@ export function safeRecursiveCp(srcPath, destPath, options = {}) {
 export function removeWorktreeViaGit(wtPath, repoRoot, options = {}) {
   const { allowFail = false } = options;
   try {
-    const nmPath = `${wtPath}/node_modules`;
-    try {
-      const lst = fs.lstatSync(nmPath);
-      if (lst.isSymbolicLink()) _unlinkSymOrJunction(nmPath);
-    } catch { /* no node_modules or already gone */ }
+    preUnlinkWorktreeNodeModules(wtPath);
     execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoRoot, stdio: 'pipe' });
     return { ok: true, error: null };
   } catch (err) {
     if (allowFail) return { ok: false, error: err?.message || String(err) };
     throw err;
   }
+}
+
+/**
+ * QF-20260523-697: unlink a worktree's node_modules symlink/junction BEFORE any
+ * `git worktree remove --force`, so git cannot follow the link and delete the
+ * shared main-repo node_modules. Idempotent + best-effort (no link / already gone
+ * is a no-op). Extracted from removeWorktreeViaGit (QF-20260511-446) so the three
+ * remaining direct-execSync sites — rollbackWorktreeFilesystemSync, the primary
+ * removal path, and cleanupOrphans — pre-unlink too, instead of relying on their
+ * safeRecursiveRm fallback which only runs AFTER git already followed the link
+ * (recurrence of feedback 95022758 / 9d091303 after the original guards shipped).
+ * @param {string} wtPath - worktree directory path
+ */
+function preUnlinkWorktreeNodeModules(wtPath) {
+  try {
+    const nmPath = `${wtPath}/node_modules`;
+    const lst = fs.lstatSync(nmPath);
+    if (lst.isSymbolicLink()) _unlinkSymOrJunction(nmPath);
+  } catch { /* no node_modules, not a link, or already gone — nothing to unlink */ }
 }
 
 function _unlinkSymOrJunction(p) {
@@ -1501,6 +1521,9 @@ export function removeWorktree(sdKey) {
   }
 
   try {
+    // QF-20260523-697: unlink node_modules first so git can't follow the
+    // junction and wipe the shared main-repo node_modules.
+    preUnlinkWorktreeNodeModules(worktreePath);
     execSync(`git worktree remove --force "${worktreePath}"`, {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -1957,6 +1980,9 @@ export async function cleanupStaleWorktrees({ dryRun = false, maxAgeMs, supabase
 
       // Remove worktree
       try {
+        // QF-20260523-697: unlink node_modules first so git can't follow the
+        // junction and wipe the shared main-repo node_modules.
+        preUnlinkWorktreeNodeModules(item.path);
         execSync(`git worktree remove --force "${item.path}"`, {
           cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
         });

--- a/lib/worktree-preunlink-before-remove.test.js
+++ b/lib/worktree-preunlink-before-remove.test.js
@@ -1,0 +1,53 @@
+/**
+ * QF-20260523-697 regression: worktree teardown must unlink the node_modules
+ * symlink/junction BEFORE `git worktree remove --force` runs, so git cannot
+ * follow the link and delete the shared main-repo node_modules (recurrence of
+ * feedback 95022758 / 9d091303). Exercises the rollbackWorktreeFilesystemSync
+ * site, which shares the preUnlinkWorktreeNodeModules helper with the primary
+ * removal path and cleanupOrphans.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const order = [];
+const execSyncMock = vi.fn((cmd) => { order.push(`git:${cmd}`); return ''; });
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, execSync: (...a) => execSyncMock(...a) };
+});
+
+// Make a worktree node_modules look like a symlink so the pre-unlink path fires,
+// and record unlink vs git-remove ordering.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal();
+  const base = actual.default || actual;
+  const mocked = {
+    ...base,
+    lstatSync: (p) => String(p).replace(/\\/g, '/').endsWith('/node_modules')
+      ? { isSymbolicLink: () => true }
+      : base.lstatSync(p),
+    unlinkSync: (p) => { order.push(`unlink:${p}`); },
+    existsSync: () => true,
+    rmSync: () => {},
+  };
+  return { ...mocked, default: mocked };
+});
+
+const { rollbackWorktreeFilesystemSync } = await import('./worktree-manager.js');
+
+describe('QF-20260523-697: pre-unlink node_modules before git worktree remove', () => {
+  beforeEach(() => { order.length = 0; execSyncMock.mockClear(); });
+
+  it('unlinks the node_modules junction BEFORE git worktree remove (no shared-store wipe)', () => {
+    const result = rollbackWorktreeFilesystemSync('/p/wt', '/p', { delaysMs: [0, 0, 0] });
+    expect(result.ok).toBe(true);
+
+    const unlinkIdx = order.findIndex(e => e.startsWith('unlink:') && e.includes('node_modules'));
+    const gitIdx = order.findIndex(e => e.startsWith('git:') && e.includes('git worktree remove'));
+
+    expect(unlinkIdx).toBeGreaterThanOrEqual(0); // node_modules link was unlinked
+    expect(gitIdx).toBeGreaterThanOrEqual(0);     // git worktree remove ran
+    expect(unlinkIdx).toBeLessThan(gitIdx);       // unlink happened FIRST, so git can't follow it
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260523-697

**Type:** bug
**Severity:** high

### Issue Description
Three 'git worktree remove --force' call sites in lib/worktree-manager.js — rollbackWorktreeFilesystemSync (L486), the main removal path (L1504), and cleanupOrphans (L1960) — run git directly without first unlinking the worktree node_modules symlink/junction. On Windows git follows the link and deletes the shared main-repo node_modules; the safeRecursiveRm fallback at each site only runs AFTER git already did the damage. removeWorktreeViaGit (QF-20260511-446) added the correct pre-unlink pattern but only in its own function. Fix: extract the pre-unlink step into a shared helper and call it before all three execSync calls (and refactor removeWorktreeViaGit to use it), so teardown never follows the node_modules link regardless of isolation strategy.


### Expected Behavior
tearing down a worktree whose node_modules is a junction/symlink never deletes the shared main-repo node_modules — the link is unlinked before git worktree remove runs

### Actual Behavior
rollbackWorktreeFilesystemSync / main removal / cleanupOrphans call git worktree remove --force directly; git follows the node_modules junction and rm-rf's the shared store (recurrence of feedback 95022758 after its guards shipped)

### Changes
- **Files Changed:** 2
  - lib/worktree-manager.js
  - lib/worktree-preunlink-before-remove.test.js
- **LOC:** 91 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Pre-unlinks node_modules at all 3 unguarded git-worktree-remove sites via a shared helper. node --check clean; new regression test passes (unlink before git); existing worktree-manager unit suite zero-delta (2 pre-existing worktree-rollback baseline failures unchanged, confirmed via stash-and-rerun, tracked BL-TST-002).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol