### PR TITLE
fix(QF-20260523-634): replit-reentry-adapter.test.js: mock the artifact-persistence path (writeArtifact) instead of the stale @supabase createClient

### DIFF
--- a/tests/unit/eva/replit-reentry-adapter.test.js
+++ b/tests/unit/eva/replit-reentry-adapter.test.js
@@ -22,6 +22,16 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
+// QF-20260523-634 / e99b1f8a: importReplitBuild also persists Stage 20 via
+// writeArtifact (artifact-persistence-service), not only the mocked supabase
+// client. Unmocked, the real writeArtifact throws against the mock client and
+// pushes a "Stage 20 artifact failed" error, so result.success is false even
+// though the stage upserts succeed. Mock it to a resolved no-op so success
+// reflects the upsert path these tests assert on.
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
+  writeArtifact: vi.fn().mockResolvedValue({ id: 'mock-artifact', success: true }),
+}));
+
 const { importReplitBuild } = await import('../../../lib/eva/bridge/replit-reentry-adapter.js');
 
 describe('Replit Re-entry Adapter', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260523-634

**Type:** bug
**Severity:** low

### Issue Description
replit-reentry-adapter.test.js 'writes records for stages 20,21,22' fails on main (SD-independent baseline failure, part of 75bdb4da). The test mocks @supabase/supabase-js createClient, but importReplitBuild now persists via writeArtifact / artifact-persistence-service rather than the mocked createClient, so its assertions never observe the writes. Fix: update the test to mock/spy the artifact-persistence path the adapter actually uses.


### Expected Behavior
the stages 20,21,22 test asserts against the artifact-persistence path the adapter uses and passes

### Actual Behavior
the test mocks the wrong layer (createClient) and fails on main

### Changes
- **Files Changed:** 1
  - tests/unit/eva/replit-reentry-adapter.test.js
- **LOC:** 17 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Test-only: added vi.mock for artifact-persistence-service so the real writeArtifact no longer throws against the mock client. Target test now 6/6 pass (was 5/6). Removes one baseline failure.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol