### PR TITLE
fix(QF-20260523-339): auto-resolve-recovered: add 0%-success/no-runs workflow_unhealthy sweep (resolve immortal ci_failure rows + one aggregated alert)

### DIFF
--- a/scripts/modules/inbox/auto-resolve-recovered.js
+++ b/scripts/modules/inbox/auto-resolve-recovered.js
@@ -61,6 +61,21 @@ export function shouldAutoResolve(runs, rowCreatedAt, k) {
   return new Date(newest.createdAt) > new Date(rowCreatedAt);
 }
 
+// QF-20260523-339: a workflow producing ZERO successes over its recent runs (or
+// no runs at all in the window) is unhealthy — Path 1 (K consecutive successes)
+// can never clear its ci_failure rows. `runs` is fetchRecentRuns output (most-
+// recent first, up to k):
+//   null                       -> false (transient gh error / unknown; do not resolve)
+//   []                         -> true  (no runs in window: workflow deleted/renamed/inactive)
+//   >= minRuns and none success -> true  (0% success)
+//   else                       -> false (a recent run succeeded, or too few runs to judge)
+export function isWorkflowUnhealthy(runs, minRuns) {
+  if (!Array.isArray(runs)) return false;
+  if (runs.length === 0) return true;
+  if (runs.length < minRuns) return false;
+  return runs.every(r => !r || r.conclusion !== 'success');
+}
+
 // status=new rows are eligible immediately (post-merge race; K-consecutive-success
 // already enforces correctness). status=in_progress still requires the stale-hours
 // min-age so we don't churn rows the triage pipeline is actively working.
@@ -120,14 +135,19 @@ async function run() {
   if (!items?.length) { console.log('[auto-resolve-recovered] No stuck rows.'); return; }
 
   let resolved = 0, skipped = 0;
+  // QF-20260523-339: emit ONE aggregated unhealthy-workflow alert per workflow,
+  // not one per immortal row.
+  const alertedWorkflows = new Set();
   for (const item of items) {
     if (!isEligibleForResolve(item, flags.staleHours)) { skipped++; continue; }
     const { workflow_name, repo, branch } = item.metadata || {};
     if (!repo) { skipped++; continue; }
 
     // Path 1 (CAPA-7): the cited workflow self-healed (K consecutive successes).
+    // runs is hoisted so Path 3 (workflow_unhealthy) can reuse the same fetch.
+    let runs = null;
     if (workflow_name) {
-      const runs = fetchRecentRuns(repo, workflow_name, flags.k);
+      runs = fetchRecentRuns(repo, workflow_name, flags.k);
       if (shouldAutoResolve(runs, item.created_at, flags.k)) {
         const oldest = runs[runs.length - 1].createdAt, newest = runs[0].createdAt;
         const notes = `Auto-resolved (CAPA-7): workflow "${workflow_name}" had ${flags.k}/${flags.k} consecutive successful runs (oldest ${oldest}, newest ${newest}); newest > row.created_at ${item.created_at}.`;
@@ -145,6 +165,21 @@ async function run() {
         if (await resolveItem(supabase, item, 'pr_merged_moot', notes, flags.dryRun)) resolved++; else skipped++;
         continue;
       }
+    }
+
+    // Path 3 (QF-20260523-339): the workflow is unhealthy — 0% success over the recent runs
+    // (or no runs at all). Path 1 can never clear these rows. Resolve as workflow_unhealthy and
+    // emit ONE aggregated alert per workflow instead of leaving one immortal row per failed run.
+    if (workflow_name && isWorkflowUnhealthy(runs, flags.k)) {
+      const wfKey = `${repo}|${workflow_name}`;
+      if (!alertedWorkflows.has(wfKey)) {
+        console.warn(`[auto-resolve-recovered] ⚠️  WORKFLOW_UNHEALTHY: "${workflow_name}" (${repo}) — 0 successful runs in the last ${flags.k} (or no runs). Resolving its stuck ci_failure rows as workflow_unhealthy; investigate or retire the workflow itself.`);
+        alertedWorkflows.add(wfKey);
+      }
+      const detail = runs.length === 0 ? 'no runs found in window' : `0/${runs.length} recent runs succeeded`;
+      const notes = `Auto-resolved (QF-20260523-339 workflow_unhealthy): workflow "${workflow_name}" is unhealthy (${detail}); Path-1 K-consecutive-success can never clear this row. One aggregated alert emitted per workflow — investigate/repair or retire the workflow.`;
+      if (await resolveItem(supabase, item, 'workflow_unhealthy', notes, flags.dryRun)) resolved++; else skipped++;
+      continue;
     }
 
     skipped++;

--- a/tests/unit/inbox/auto-resolve-recovered.test.js
+++ b/tests/unit/inbox/auto-resolve-recovered.test.js
@@ -20,7 +20,7 @@ vi.mock('../../../lib/utils/is-main-module.js', () => ({ isMainModule: () => fal
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://test.local';
 process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
 
-const { shouldAutoResolve, parseArgs, fetchRecentRuns, isEligibleForResolve } = await import(
+const { shouldAutoResolve, parseArgs, fetchRecentRuns, isEligibleForResolve, isWorkflowUnhealthy } = await import(
   '../../../scripts/modules/inbox/auto-resolve-recovered.js'
 );
 
@@ -202,5 +202,41 @@ describe('fetchRecentRuns', () => {
     const mockExec = vi.fn(() => 'not-json-at-all');
     const result = fetchRecentRuns('owner/repo', 'Workflow', 5, mockExec);
     expect(result).toBe(null);
+  });
+});
+
+describe('isWorkflowUnhealthy (QF-20260523-339: 0%-success / no-runs sweep)', () => {
+  const fail = (c = 'failure') => ({ conclusion: c, createdAt: '2026-05-10T10:00:00Z' });
+  const success = () => ({ conclusion: 'success', createdAt: '2026-05-10T10:00:00Z' });
+
+  it('returns false for null (transient gh error / unknown — never resolve on uncertainty)', () => {
+    expect(isWorkflowUnhealthy(null, 5)).toBe(false);
+    expect(isWorkflowUnhealthy(undefined, 5)).toBe(false);
+  });
+
+  it('returns true for empty array (no runs in window: workflow deleted/renamed/inactive)', () => {
+    expect(isWorkflowUnhealthy([], 5)).toBe(true);
+  });
+
+  it('returns true when >= minRuns and none succeeded (0% success)', () => {
+    expect(isWorkflowUnhealthy([fail(), fail(), fail(), fail(), fail()], 5)).toBe(true);
+  });
+
+  it('returns false when fewer than minRuns (insufficient evidence)', () => {
+    expect(isWorkflowUnhealthy([fail(), fail()], 5)).toBe(false);
+  });
+
+  it('returns false when at least one recent run succeeded', () => {
+    expect(isWorkflowUnhealthy([fail(), fail(), success(), fail(), fail()], 5)).toBe(false);
+  });
+
+  it('treats cancelled/null/neutral conclusions as non-success', () => {
+    expect(isWorkflowUnhealthy([fail('cancelled'), fail('neutral'), fail(null), fail(), fail()], 5)).toBe(true);
+  });
+
+  it('honors variable minRuns (3 failures: unhealthy at minRuns=3, not at minRuns=5)', () => {
+    const threeFails = [fail(), fail(), fail()];
+    expect(isWorkflowUnhealthy(threeFails, 3)).toBe(true);
+    expect(isWorkflowUnhealthy(threeFails, 5)).toBe(false);
   });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260523-339

**Type:** bug
**Severity:** medium

### Issue Description
auto-resolve-recovered.js Path 1 needs K consecutive successes and Path 2 needs a merged/closed PR. A workflow that NEVER succeeds (0% success) and whose rows have no merged PR produces immortal ci_failure rows that neither path can resolve. Add Path 3: when a workflow has zero successes over its recent runs (or no runs at all), resolve its ci_failure rows as resolution_type=workflow_unhealthy and emit ONE aggregated alert per workflow instead of leaving one immortal row per failed run.


### Expected Behavior
ci_failure rows for a never-succeeding workflow are resolved as workflow_unhealthy with a single aggregated alert per workflow

### Actual Behavior
0%-success workflows accumulate immortal ci_failure rows that Path 1 (needs K successes) can never clear

### Changes
- **Files Changed:** 2
  - scripts/modules/inbox/auto-resolve-recovered.js
  - tests/unit/inbox/auto-resolve-recovered.test.js
- **LOC:** 80 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Added Path 3 (workflow_unhealthy) + isWorkflowUnhealthy pure fn + aggregated per-workflow alert. node --check clean; 31/31 unit tests pass (7 new). Resolution type workflow_unhealthy is free-text (matches existing auto_resolved/pr_merged_moot). Conservative: requires >=k all-non-success or empty runs; null (transient) never resolves.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol