### PR TITLE
feat(SD-S19-...-001-A): Claude-Code-ready repo artifact writers (Child A)

### DIFF
--- a/lib/eva/bridge/build-tasks-writer.js
+++ b/lib/eva/bridge/build-tasks-writer.js
@@ -1,0 +1,90 @@
+/**
+ * build-tasks-writer
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-A (Child A / FR-2)
+ *
+ * Pure builder: returns the contents of the venture repo's `docs/build-tasks.md`
+ * — a FULLY VENTURE-DERIVED orchestrator → children → grandchildren build
+ * decomposition (chairman decision: derive from the venture's own artifacts, not
+ * a fixed template). The per-feature grandchildren come from the venture's
+ * screens; the lead task is always "discover current state" (do not assume the
+ * repo is unbuilt — the conduit/Agent may have built much already).
+ *
+ * Minimal-skeleton fallback: when the venture has no screens, emit a still-valid,
+ * non-empty decomposition (never an empty build-tasks.md).
+ *
+ * Pure (no DB / git / fs); the venture-data fetch happens in Child B inside
+ * seedRepo(), which passes the resolved screens here.
+ */
+
+/** Normalize a screen entry (string or {name|screen_name}) to a trimmed name. */
+function screenName(screen, i) {
+  if (typeof screen === 'string') return screen.trim() || `Screen ${i + 1}`;
+  if (screen && typeof screen === 'object') {
+    return String(screen.name || screen.screen_name || `Screen ${i + 1}`).trim();
+  }
+  return `Screen ${i + 1}`;
+}
+
+/**
+ * @param {Object} ctx
+ * @param {string} [ctx.name] - venture name
+ * @param {Array<string|{name?:string,screen_name?:string,purpose?:string}>} [ctx.screens]
+ * @returns {string} docs/build-tasks.md markdown (always non-empty)
+ */
+export function buildBuildTasks(ctx = {}) {
+  const name = (ctx.name && String(ctx.name).trim()) || 'Venture';
+  const screens = Array.isArray(ctx.screens) ? ctx.screens : [];
+
+  const header = `# Build Tasks — ${name}
+
+> Orchestrator → children → grandchildren. Work top-down, one grandchild at a
+> time; commit after each. **Lead task is always "discover current state"** —
+> inspect the existing repo (schema, server fns, routes, data layer) before
+> building; the design conduit or Replit Agent may have built much already, so
+> build ON it, do not duplicate.
+
+## Orchestrator: ${name} build
+
+### Child 1 — Discover current state & Replit-native backend
+- [ ] **1.1 Discover** — inventory existing routes, schema, server functions, and data layer. Note what is already built. Do NOT assume a blank repo.
+- [ ] **1.2 Replit-native data** — Replit Postgres via \`DATABASE_URL\` (Drizzle or \`pg\`); remove any Supabase coupling. Schema in code.
+- [ ] **1.3 Object Storage** — Replit Object Storage (default bucket, key-prefix namespacing); sign URLs via the Replit sidecar, never the GCS local signer.
+- [ ] **1.4 Auth (Clerk)** — \`@clerk/tanstack-react-start\`; \`VITE_CLERK_PUBLISHABLE_KEY\` (prefixed + passed explicitly) + \`CLERK_SECRET_KEY\`; upsert a local \`users\` row keyed by \`clerk_user_id\`; app-level ownership scoping.`;
+
+  let child2;
+  if (screens.length === 0) {
+    // Minimal-skeleton fallback — never emit an empty build-tasks.md.
+    child2 = `
+
+### Child 2 — Core features
+- [ ] **2.1 Core feature** — implement the venture's primary user flow end-to-end, scoped to the signed-in user. (No wireframe screens were available at seed time — refine this into per-screen grandchildren from \`docs/\` once the design is in the repo.)`;
+  } else {
+    const grandchildren = screens
+      .map((screen, i) => {
+        const sn = screenName(screen, i);
+        const purpose =
+          screen && typeof screen === 'object' && screen.purpose
+            ? ` — ${String(screen.purpose).trim()}`
+            : '';
+        return `- [ ] **2.${i + 1} ${sn}**${purpose} — build the screen + its data wiring, scoped to the signed-in user.`;
+      })
+      .join('\n');
+    child2 = `
+
+### Child 2 — Core features (one grandchild per screen)
+${grandchildren}`;
+  }
+
+  const child3 = `
+
+### Child 3 — Monitoring, polish & deploy
+- [ ] **3.1 Sentry** verified on client + server (no-ops gracefully when DSN absent).
+- [ ] **3.2 AI images (if applicable)** — Google Gemini image editing via \`GEMINI_API_KEY\`; honest fallback when unconfigured.
+- [ ] **3.3 Polish** — responsive/mobile-first, a11y (semantic HTML + ARIA).
+- [ ] **3.4 Deploy** — Replit hosting (autoscale); confirm the run command + port in \`.replit\`.
+`;
+
+  return header + child2 + child3;
+}
+
+export default buildBuildTasks;

--- a/lib/eva/bridge/claude-md-writer.js
+++ b/lib/eva/bridge/claude-md-writer.js
@@ -1,0 +1,69 @@
+/**
+ * claude-md-writer
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-A (Child A / FR-1)
+ *
+ * Pure builder: returns the contents of the venture repo's root `CLAUDE.md` —
+ * the persistent, authoritative build context Claude Code auto-reads every
+ * session. This is the ONLY reliable enforcement of the backend rules (a pasted
+ * prompt gets ignored; a committed CLAUDE.md persists).
+ *
+ * Lifts the proven contribution-hub / Canvas AI CLAUDE.md structure and pins the
+ * hard-won rules: Replit-native (never Supabase), Claude-Code-builds /
+ * Replit-hosts / no-Agent, the Clerk VITE_CLERK_PUBLISHABLE_KEY gotcha,
+ * object-storage signing via the Replit sidecar (never the GCS local signer),
+ * and Gemini as the image provider.
+ *
+ * Pure (no DB / git / fs) so it is unit-testable in isolation — mirrors the
+ * existing seeder helpers (resolveBuildScreens, buildFeaturePrompt). The
+ * venture-data fetch + file write happen in Child B inside seedRepo().
+ */
+
+const DEFAULT_STACK =
+  'TanStack Start + React 19 + Vite + TypeScript (strict) + Tailwind. Package manager: bun.';
+const DEFAULT_RUN = 'bun run dev';
+
+/**
+ * @param {Object} ctx
+ * @param {string} [ctx.name] - venture name (e.g. "Canvas AI")
+ * @param {string} [ctx.stack] - one-line stack description
+ * @param {string} [ctx.runCommand] - dev run command (default `bun run dev`)
+ * @returns {string} CLAUDE.md markdown
+ */
+export function buildClaudeMd(ctx = {}) {
+  const name = (ctx.name && String(ctx.name).trim()) || 'this venture';
+  const stack = (ctx.stack && String(ctx.stack).trim()) || DEFAULT_STACK;
+  const runCommand = (ctx.runCommand && String(ctx.runCommand).trim()) || DEFAULT_RUN;
+
+  return `# CLAUDE.md — ${name}
+
+> Build instructions for **Claude Code**. This file is read automatically every session and is the **authoritative** build context for this repo. If anything here conflicts with \`replit.md\` (which the Replit Agent may have written and is stale on the backend), **this file wins**.
+
+## Build model (READ THIS)
+- **You (Claude Code) build the features here, in this repo**, and commit/push to GitHub. **Replit hosts** the result (it pulls from GitHub). Do **not** rely on the Replit AI Agent — it is metered, undoes Claude Code's work, and has removed load-bearing packages it deemed "orphaned." Keep it OFF this repo.
+- Work through **\`docs/build-tasks.md\`** in order (orchestrator → children → grandchildren); do one grandchild task at a time, commit, move on. Lead task is always "discover current state" — do not assume the repo is unbuilt.
+- Keep changes **additive and scoped**; match the existing design system and conventions.
+
+## Backend: Replit-native ONLY — never Supabase
+This venture runs on **Replit's native stack**. If the Replit Agent ever wired Supabase, that is technical debt to remove, not a pattern to extend.
+- **Data** → **Replit Postgres** (Neon-backed, scale-to-zero). Connect via \`DATABASE_URL\` (Replit injects it once you provision Postgres in the Replit **Database** panel). Use a typed client (Drizzle or \`pg\`). Note: the dev Postgres is Repl-scoped — not reachable from a laptop, so typecheck locally and run/test in Replit.
+- **File storage** → **Replit Object Storage** (provisioned via the Object Storage UI panel — one auto-ID'd bucket in \`DEFAULT_OBJECT_STORAGE_BUCKET_ID\`; namespace by key **prefix**, you cannot name buckets). **Sign object URLs via the Replit sidecar** (\`POST http://127.0.0.1:1106/object-storage/signed-object-url\`), **never** the \`@google-cloud/storage\` client's local \`getSignedUrl()\` — the sidecar credentials have no \`client_email\`, so local signing throws *"Cannot sign data without client_email"*. (This applies to BOTH uploads and downloads.)
+- **Auth** → **Clerk** via \`@clerk/tanstack-react-start\` (clerk.com hosted — NOT a Replit integration; do NOT use "Replit Auth", which is Agent-only and signs users in with Replit accounts). **#1 gotcha:** Clerk's Vite SDK resolves the **publishable** key via \`import.meta.env\` (VITE_-prefixed ONLY). Name the secret **\`VITE_CLERK_PUBLISHABLE_KEY\`** AND pass it explicitly: \`clerkMiddleware({ publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY })\` + \`<ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>\`. Keep \`CLERK_SECRET_KEY\` server-only (do NOT pass \`secretKey\` to clerkMiddleware). On first sign-in, upsert a local \`users\` row keyed by \`clerk_user_id\`; ownership checks are app-level \`where user_id = <clerkUserId>\`.
+- **AI images** → **Google Gemini** image editing (\`gemini-2.5-flash-image\` via the Gemini API, raw \`fetch\`, no SDK dep), reads \`GEMINI_API_KEY\` (or \`GOOGLE_API_KEY\`); model id overridable via \`GEMINI_IMAGE_MODEL\`. Chairman-chosen provider — do **NOT** switch to OpenAI/Replicate/etc. without asking. Gemini image output generally needs billing enabled on the Google AI project.
+- **Errors** → **Sentry**, no-ops gracefully when its DSN is absent.
+- **NEVER** add \`@supabase/supabase-js\`, Supabase URLs/keys, RLS-as-business-logic, or Supabase Edge Functions. Read all backend config from **env vars** — never hardcode secrets.
+
+## Stack & commands
+- ${stack}
+- Dev: \`${runCommand}\`. After pulling new code/deps OR changing a Secret, **restart** the Repl (a running dev server won't pick up a new package or a changed Secret).
+
+## Hosting (Replit, no Agent)
+Replit imports this GitHub repo and runs the dev/start command (see \`.replit\`). To go live: provision Postgres + Object Storage + Clerk in Replit's UI panels (one-click each — **not** the Agent), then publish. Your commits to GitHub flow into Replit.
+
+## Conventions
+- TypeScript strict; proper error handling on all async/IO; responsive (mobile-first); semantic HTML + ARIA.
+- Secrets via env vars only. Don't commit keys.
+- After each grandchild task: a quick build/typecheck, then commit with a clear message.
+`;
+}
+
+export default buildClaudeMd;

--- a/lib/eva/bridge/replit-config-writer.js
+++ b/lib/eva/bridge/replit-config-writer.js
@@ -1,0 +1,43 @@
+/**
+ * replit-config-writer
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-A (Child A / FR-3)
+ *
+ * Pure builder: returns the contents of the venture repo's `.replit` — the
+ * minimal Replit HOSTING run-config (how Replit RUNS the app), NOT Agent build
+ * context. Matches the proven contribution-hub config: `bun run dev` on port
+ * 5000, autoscale deployment.
+ *
+ * Pure (no DB / git / fs); the file write happens in Child B inside seedRepo().
+ * NOTE: seedRepo must PRESERVE an existing `.replit`/`replit.md` if present
+ * (build-into mode) — that preserve logic lives in the seeder, not here.
+ */
+
+const DEFAULT_RUN = 'bun run dev';
+const DEFAULT_PORT = 5000;
+
+/**
+ * @param {Object} ctx
+ * @param {string} [ctx.runCommand] - dev run command (default `bun run dev`)
+ * @param {number} [ctx.port] - local app port (default 5000)
+ * @param {number} [ctx.externalPort] - external port (default 80)
+ * @returns {string} `.replit` file contents
+ */
+export function buildReplitConfig(ctx = {}) {
+  const runCommand = (ctx.runCommand && String(ctx.runCommand).trim()) || DEFAULT_RUN;
+  const port = Number.isInteger(ctx.port) && ctx.port > 0 ? ctx.port : DEFAULT_PORT;
+  const externalPort =
+    Number.isInteger(ctx.externalPort) && ctx.externalPort > 0 ? ctx.externalPort : 80;
+
+  return `run = "${runCommand}"
+
+[deployment]
+run = ["sh", "-c", "${runCommand}"]
+deploymentTarget = "autoscale"
+
+[[ports]]
+localPort = ${port}
+externalPort = ${externalPort}
+`;
+}
+
+export default buildReplitConfig;

--- a/tests/unit/eva/s19-claude-code-ready-writers.test.js
+++ b/tests/unit/eva/s19-claude-code-ready-writers.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-A — unit tests for the three
+ * Claude-Code-ready repo artifact writers (pure builders, no DB/git/fs).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildClaudeMd } from '../../../lib/eva/bridge/claude-md-writer.js';
+import { buildBuildTasks } from '../../../lib/eva/bridge/build-tasks-writer.js';
+import { buildReplitConfig } from '../../../lib/eva/bridge/replit-config-writer.js';
+
+describe('buildClaudeMd', () => {
+  const md = buildClaudeMd({ name: 'Canvas AI' });
+
+  it('includes the venture name in the title', () => {
+    expect(md).toContain('# CLAUDE.md — Canvas AI');
+  });
+
+  it('pins every load-bearing backend rule', () => {
+    expect(md).toMatch(/never\s+Supabase/i);
+    expect(md).toContain('VITE_CLERK_PUBLISHABLE_KEY');
+    expect(md).toContain('127.0.0.1:1106'); // sidecar signing endpoint
+    expect(md).toMatch(/sidecar/i);
+    expect(md).toMatch(/Gemini/);
+    expect(md).toMatch(/Replit hosts|Replit-hosts|Replit \*\*hosts\*\*|\*\*Replit hosts\*\*/i);
+    expect(md).toMatch(/keep it off|Agent off|do \*\*not\*\* rely on the Replit AI Agent/i);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(buildClaudeMd({ name: 'Canvas AI' })).toBe(md);
+  });
+
+  it('falls back gracefully with no context', () => {
+    const out = buildClaudeMd();
+    expect(out).toContain('# CLAUDE.md — this venture');
+    expect(out.length).toBeGreaterThan(200);
+  });
+});
+
+describe('buildBuildTasks', () => {
+  it('derives one grandchild per screen when screens are present', () => {
+    const md = buildBuildTasks({
+      name: 'Canvas AI',
+      screens: [{ name: 'Dashboard' }, { name: 'New Project' }, 'Studio'],
+    });
+    expect(md).toContain('# Build Tasks — Canvas AI');
+    expect(md).toContain('2.1 Dashboard');
+    expect(md).toContain('2.2 New Project');
+    expect(md).toContain('2.3 Studio');
+    // lead task is always discover-current-state
+    expect(md).toMatch(/discover current state/i);
+  });
+
+  it('emits a non-empty minimal skeleton when there are no screens', () => {
+    const md = buildBuildTasks({ name: 'EmptyVenture', screens: [] });
+    expect(md.trim().length).toBeGreaterThan(100);
+    expect(md).toContain('Child 2 — Core features');
+    expect(md).toMatch(/discover current state/i);
+  });
+
+  it('never emits an empty document even with no context', () => {
+    const md = buildBuildTasks();
+    expect(md.trim().length).toBeGreaterThan(100);
+    expect(md).toContain('# Build Tasks — Venture');
+  });
+
+  it('is deterministic for the same input', () => {
+    const args = { name: 'Canvas AI', screens: [{ name: 'Dashboard' }] };
+    expect(buildBuildTasks(args)).toBe(buildBuildTasks(args));
+  });
+});
+
+describe('buildReplitConfig', () => {
+  it('produces a valid minimal .replit with run command and port', () => {
+    const cfg = buildReplitConfig();
+    expect(cfg).toContain('run = "bun run dev"');
+    expect(cfg).toContain('deploymentTarget = "autoscale"');
+    expect(cfg).toContain('localPort = 5000');
+    expect(cfg).toContain('[[ports]]');
+  });
+
+  it('honors overrides', () => {
+    const cfg = buildReplitConfig({ runCommand: 'npm run dev', port: 3000 });
+    expect(cfg).toContain('run = "npm run dev"');
+    expect(cfg).toContain('localPort = 3000');
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(buildReplitConfig()).toBe(buildReplitConfig());
+  });
+});


### PR DESCRIPTION
## Child A — Claude-Code-ready repo artifact writers

Child A of orchestrator **SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001** (codify the proven venture-build process into the Stage-19 seeder).

Three **pure-builder** modules under `lib/eva/bridge` that produce the seeded venture repo's Claude-Code-ready artifacts from injected venture context. **No `seedRepo` wiring yet** — that's Child B (clean phase boundary).

- **`claude-md-writer.js`** — `buildClaudeMd(ctx)` → `CLAUDE.md` pinning the proven backend rules: Replit-native / never Supabase, Claude-Code-builds + Replit-hosts + no-Agent, the Clerk `VITE_CLERK_PUBLISHABLE_KEY` gotcha, object-storage signing via the Replit sidecar (never the GCS local signer), and Gemini as the image provider. Lifts the contribution-hub reference.
- **`build-tasks-writer.js`** — `buildBuildTasks(ctx)` → fully venture-derived `docs/build-tasks.md` (orchestrator → children → grandchildren, one grandchild per screen), with a **minimal-skeleton fallback** so it is never empty.
- **`replit-config-writer.js`** — `buildReplitConfig(ctx)` → minimal `.replit` (`bun run dev` on port 5000, autoscale).

All pure (no DB/git/fs), mirroring the existing `resolveBuildScreens` / `buildFeaturePrompt` helpers so they unit-test in isolation.

## Tests
`tests/unit/eva/s19-claude-code-ready-writers.test.js` — **11/11 pass**. Covers: every pinned rule present in CLAUDE.md, per-screen grandchildren + never-empty fallback for build-tasks, valid `.replit`, and determinism for all three.

## Scope
+291 LOC, additive only. No changes to `seedRepo` or any live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)