### PR TITLE
fix(SD-FDBK-INFRA-GATE-VISION-SCORE-001): narrow/focused-feature carve-out for GATE_VISION_SCORE

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -73,6 +73,17 @@ export const FLOOR_MINIMUM_SCORE = 60;
 export const MIN_ADJUSTED_THRESHOLD_RATIO = 0.6;
 
 /**
+ * SD-FDBK-INFRA-GATE-VISION-SCORE-001: a dimension scored at/above this floor is
+ * "meaningfully addressed" by a focused null-pattern-type SD
+ * (feature/governance/enhancement). Used to AUTO-DETECT addressable dimensions for
+ * those types so a focused feature no longer needs manual
+ * metadata.vision_addressable_dimensions tuning. Calibrated to the dimension
+ * midpoint; paired with the FLOOR_MINIMUM_SCORE (60) addressable-average floor and
+ * the MIN_ADJUSTED_THRESHOLD_RATIO (0.6) threshold floor for abuse-resistance.
+ */
+export const NARROW_FEATURE_DIM_FLOOR = 50;
+
+/**
  * Dimension addressability by SD type.
  * Maps SD type to a Set of dimension name patterns that the type CAN address.
  * Dimensions not in this set are considered non-addressable for that SD type.
@@ -119,28 +130,62 @@ export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
  * @param {Object|null} sdMetadata - SD's metadata column (may carry per-SD override)
  * @returns {{ addressable: number, total: number }}
  */
+/**
+ * Resolve the array of addressable dimension NAMES for an SD. Single source of
+ * truth for both countAddressableDimensions and the addressable-average floor.
+ * Precedence:
+ *   1. Manual override: a non-empty sdMetadata.vision_addressable_dimensions pattern
+ *      list (QF-20260505-102) — wins over everything.
+ *   2. null-pattern types (SD_TYPE_ADDRESSABLE_DIMENSIONS[type] === null:
+ *      feature/governance/enhancement/orchestrator) with NO manual override —
+ *      SD-FDBK-INFRA-GATE-VISION-SCORE-001 carve-out: AUTO-DETECT addressable dims as
+ *      those scored >= NARROW_FEATURE_DIM_FLOOR. A focused feature only "addresses"
+ *      the dims it scored meaningfully on, so it no longer needs manual
+ *      vision_addressable_dimensions tuning. A broad feature whose dims all clear the
+ *      floor yields all-addressable → no narrowing → the full bar is preserved.
+ *   3. Other types: case-insensitive substring match against the type's pattern list.
+ *
+ * @param {string} sdType
+ * @param {Object|null} dimensionScores - JSONB { dimName: score, ... }
+ * @param {Object|null} sdMetadata - SD's metadata column (may carry per-SD override)
+ * @returns {string[]} addressable dimension names
+ */
+export function getAddressableDimNames(sdType, dimensionScores, sdMetadata) {
+  if (!dimensionScores || typeof dimensionScores !== 'object') return [];
+  const dimNames = Object.keys(dimensionScores);
+
+  const sdLevelPatterns = sdMetadata?.vision_addressable_dimensions;
+  if (Array.isArray(sdLevelPatterns) && sdLevelPatterns.length > 0) {
+    return dimNames.filter(name =>
+      sdLevelPatterns.some(p => name.toLowerCase().includes(String(p).toLowerCase())));
+  }
+
+  const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
+  if (patterns === null || patterns === undefined) {
+    // Carve-out: auto-detect addressable dims from scores for null-pattern types.
+    return dimNames.filter(name =>
+      typeof dimensionScores[name] === 'number' && dimensionScores[name] >= NARROW_FEATURE_DIM_FLOOR);
+  }
+
+  return dimNames.filter(name =>
+    patterns.some(p => name.toLowerCase().includes(p.toLowerCase())));
+}
+
+/**
+ * Count addressable dimensions for an SD type. Delegates to getAddressableDimNames.
+ * Returns { addressable, total } counts.
+ *
+ * @param {string} sdType
+ * @param {Object|null} dimensionScores - JSONB { dimName: score, ... }
+ * @param {Object|null} sdMetadata - SD's metadata column (may carry per-SD override)
+ * @returns {{ addressable: number, total: number }}
+ */
 export function countAddressableDimensions(sdType, dimensionScores, sdMetadata) {
   if (!dimensionScores || typeof dimensionScores !== 'object') {
     return { addressable: 0, total: 0 };
   }
-
-  const dimNames = Object.keys(dimensionScores);
-  const total = dimNames.length;
-
-  const sdLevelPatterns = sdMetadata?.vision_addressable_dimensions;
-  const patterns = (Array.isArray(sdLevelPatterns) && sdLevelPatterns.length > 0)
-    ? sdLevelPatterns
-    : SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
-
-  if (patterns === null || patterns === undefined) {
-    return { addressable: total, total }; // all addressable
-  }
-
-  const addressable = dimNames.filter(name => {
-    const lower = name.toLowerCase();
-    return patterns.some(p => lower.includes(p.toLowerCase()));
-  }).length;
-
+  const total = Object.keys(dimensionScores).length;
+  const addressable = getAddressableDimNames(sdType, dimensionScores, sdMetadata).length;
   return { addressable, total };
 }
 
@@ -449,33 +494,46 @@ export async function validateVisionScore(sd, supabase) {
   }
 
   // ── Floor rule: minimum average score for addressable dims ────────────────
+  // SD-FDBK-INFRA-GATE-VISION-SCORE-001: applies to the type-pattern path AND the
+  // null-type auto-detect carve-out path (so a focused feature must score WELL on the
+  // dims it addresses, not merely narrow the set). The manual-override path is
+  // intentionally excluded to preserve its prior behavior (backward-compat).
   if (total > 0 && addressable > 0 && addressable < total && dimensionScores) {
-    const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
-    if (patterns) {
-      const addressableDimScores = Object.entries(dimensionScores)
-        .filter(([name]) => patterns.some(p => name.toLowerCase().includes(p.toLowerCase())))
+    const hasManualOverride = Array.isArray(sd.metadata?.vision_addressable_dimensions)
+      && sd.metadata.vision_addressable_dimensions.length > 0;
+    const typePatterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
+    let addressableDimScores = null;
+    if (typePatterns) {
+      // Type-pattern path (unchanged behavior).
+      addressableDimScores = Object.entries(dimensionScores)
+        .filter(([name]) => typePatterns.some(p => name.toLowerCase().includes(p.toLowerCase())))
         .map(([, score]) => score)
         .filter(s => typeof s === 'number');
+    } else if (!hasManualOverride) {
+      // null-type auto-detect carve-out path: score the auto-detected addressable dims.
+      addressableDimScores = getAddressableDimNames(sdType, dimensionScores, sd.metadata)
+        .map(name => dimensionScores[name])
+        .filter(s => typeof s === 'number');
+    }
 
-      if (addressableDimScores.length > 0) {
-        const avgScore = addressableDimScores.reduce((a, b) => a + b, 0) / addressableDimScores.length;
-        if (avgScore < FLOOR_MINIMUM_SCORE) {
-          console.log(`   ❌ Floor rule: addressable dim avg ${Math.round(avgScore)}/100 < ${FLOOR_MINIMUM_SCORE} minimum`);
-          await logGateEvaluation(supabase, {
-            sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
-            baseThreshold, adjustedThreshold: threshold, score: visionScore,
-            verdict: 'blocked_floor_score', floorRuleTriggered: true,
-            context: `Addressable dim avg ${Math.round(avgScore)} below floor minimum ${FLOOR_MINIMUM_SCORE}`,
-          });
-          return {
-            passed: false,
-            score: 0,
-            maxScore: 100,
-            details: `Floor rule: addressable dim avg ${Math.round(avgScore)}/100 below minimum ${FLOOR_MINIMUM_SCORE}`,
-            remediation: `Improve addressable dimension scores to avg >= ${FLOOR_MINIMUM_SCORE}`,
-            warnings: [],
-          };
-        }
+    if (addressableDimScores && addressableDimScores.length > 0) {
+      const avgScore = addressableDimScores.reduce((a, b) => a + b, 0) / addressableDimScores.length;
+      if (avgScore < FLOOR_MINIMUM_SCORE) {
+        console.log(`   ❌ Floor rule: addressable dim avg ${Math.round(avgScore)}/100 < ${FLOOR_MINIMUM_SCORE} minimum`);
+        await logGateEvaluation(supabase, {
+          sdId: sdKey, sdType, totalDims: total, addressableCount: addressable,
+          baseThreshold, adjustedThreshold: threshold, score: visionScore,
+          verdict: 'blocked_floor_score', floorRuleTriggered: true,
+          context: `Addressable dim avg ${Math.round(avgScore)} below floor minimum ${FLOOR_MINIMUM_SCORE}`,
+        });
+        return {
+          passed: false,
+          score: 0,
+          maxScore: 100,
+          details: `Floor rule: addressable dim avg ${Math.round(avgScore)}/100 below minimum ${FLOOR_MINIMUM_SCORE}`,
+          remediation: `Improve addressable dimension scores to avg >= ${FLOOR_MINIMUM_SCORE}`,
+          warnings: [],
+        };
       }
     }
   }

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.test.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.test.js
@@ -18,9 +18,12 @@ import {
   SD_TYPE_ADDRESSABLE_DIMENSIONS,
   MIN_ADDRESSABLE_DIMENSIONS,
   MIN_ADJUSTED_THRESHOLD_RATIO,
+  NARROW_FEATURE_DIM_FLOOR,
   countAddressableDimensions,
+  getAddressableDimNames,
   calculateDynamicThreshold,
   buildTierRemediationHint,
+  validateVisionScore,
 } from './vision-score.js';
 
 // Convert dim names to the JSONB shape the real gate consumes
@@ -172,6 +175,68 @@ describe('calculateDynamicThreshold — sanity (unchanged behavior)', () => {
 
   it('returns base when total is 0 (no dimension data)', () => {
     expect(calculateDynamicThreshold(80, 0, 0)).toBe(80);
+  });
+});
+
+describe('SD-FDBK-INFRA-GATE-VISION-SCORE-001 — narrow/focused-feature carve-out', () => {
+  it('NARROW_FEATURE_DIM_FLOOR is pinned at 50 (calibration)', () => {
+    expect(NARROW_FEATURE_DIM_FLOOR).toBe(50);
+  });
+
+  it('getAddressableDimNames auto-detects a focused feature from scores (>= floor)', () => {
+    const dims = { a: 90, b: 85, c: 80, d: 30, e: 20, f: 10 };
+    expect(getAddressableDimNames('feature', dims).sort()).toEqual(['a', 'b', 'c']);
+    expect(countAddressableDimensions('feature', dims)).toEqual({ addressable: 3, total: 6 });
+  });
+
+  it('broad feature (all dims >= floor) stays all-addressable (no narrowing → full bar)', () => {
+    const dims = { a: 88, b: 77, c: 66, d: 55 };
+    expect(countAddressableDimensions('feature', dims)).toEqual({ addressable: 4, total: 4 });
+  });
+
+  it('manual vision_addressable_dimensions override still wins over score-based auto-detect', () => {
+    const dims = { security_posture: 90, performance_x: 90, cli_y: 90 };
+    const meta = { vision_addressable_dimensions: ['security'] };
+    expect(getAddressableDimNames('feature', dims, meta)).toEqual(['security_posture']);
+  });
+
+  it('non-null pattern types stay pattern-based (not score-based) — no leakage from the carve-out', () => {
+    const dims = { user_delight: 90, architecture_clarity: 90 };
+    // refactor pattern set has 'architecture' but not 'user'/'delight'
+    expect(getAddressableDimNames('refactor', dims).sort()).toEqual(['architecture_clarity']);
+  });
+
+  it('gate: focused-good feature passes at the narrowed threshold without manual tuning', async () => {
+    const sd = {
+      sd_key: 'TEST-FOCUSED-GOOD', sd_type: 'feature',
+      vision_score: 60, vision_score_action: 'gap_closure_sd',
+      dimension_scores: { a: 90, b: 85, c: 80, d: 20, e: 15, f: 10 }, metadata: {},
+    };
+    // addressable 3/6 → threshold max(90*3/6=45, 54)=54; addressable avg 85 >= 60; score 60 >= 54 → pass
+    const r = await validateVisionScore(sd, null);
+    expect(r.passed).toBe(true);
+  });
+
+  it('gate: broad-but-mediocre feature still faces the full 90 bar (cannot game the carve-out)', async () => {
+    const sd = {
+      sd_key: 'TEST-BROAD-MEDIOCRE', sd_type: 'feature',
+      vision_score: 55, vision_score_action: 'gap_closure_sd',
+      dimension_scores: { a: 55, b: 56, c: 54, d: 55, e: 53, f: 57 }, metadata: {},
+    };
+    // all dims >= 50 → addressable == total → no narrowing → bar 90; 55 < 90 → block
+    const r = await validateVisionScore(sd, null);
+    expect(r.passed).toBe(false);
+  });
+
+  it('gate: focused-but-weak feature is blocked by the addressable-average floor', async () => {
+    const sd = {
+      sd_key: 'TEST-FOCUSED-WEAK', sd_type: 'feature',
+      vision_score: 58, vision_score_action: 'gap_closure_sd',
+      dimension_scores: { a: 55, b: 52, c: 51, d: 10, e: 10, f: 10 }, metadata: {},
+    };
+    // addressable [55,52,51] avg 52.7 < 60 → avg-floor hard-blocks before the threshold check
+    const r = await validateVisionScore(sd, null);
+    expect(r.passed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## SD-FDBK-INFRA-GATE-VISION-SCORE-001 — GATE_VISION_SCORE narrow/focused-feature carve-out

Feature-type SDs defaulted to all-dimensions-addressable + a 90/100 bar, forcing focused features to manually enumerate `metadata.vision_addressable_dimensions`. This auto-detects addressable dims for null-pattern types (feature/governance/enhancement) from the dimension scores (>= `NARROW_FEATURE_DIM_FLOOR`=50), feeding the existing dynamic threshold, and extends the addressable-average>=60 floor to that path so a broad-but-mediocre feature still faces the full bar.

- `getAddressableDimNames()` single source of truth (manual override > null-type auto-detect > type-pattern).
- Manual-override + non-null pattern-type paths unchanged (backward-compat); all floors preserved (MIN_ADDRESSABLE=3, MIN_ADJUSTED_THRESHOLD_RATIO=0.6).
- Tests: 43/43 (8 new carve-out cases). REGRESSION sub-agent PASS (97/100). Backward-compat confirmed zero-delta by reverting the gate and re-running.

Closes feedback 7884c1fd-...

🤖 Generated with [Claude Code](https://claude.com/claude-code)