### PR TITLE
fix(QF-20260524-746): SUCCESS_METRICS gate: break auto-populate/placeholder catch-22 + parse descriptive actuals + actionable remediation

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
@@ -34,6 +34,14 @@ function parseMetricValue(value) {
   if (pctMatch) return parseFloat(pctMatch[2]);
   const fracMatch = str.match(/^(\d+)\s*\/\s*(\d+)$/);
   if (fracMatch) return (parseFloat(fracMatch[1]) / parseFloat(fracMatch[2])) * 100;
+  // QF-20260524-746: parse descriptive-but-quantified actuals so a genuinely-complete
+  // metric ("6 of 6 FRs", "6/6 FRs implemented") is not misread by the parseFloat fallback
+  // below as the leading integer (6). A partial "5 of 6" → 83.3 still fails a 100% target,
+  // so gate integrity is preserved. (pctMatch above still wins, e.g. "100% — 6 of 6".)
+  const ofMatch = str.match(/\b(\d+)\s+of\s+(\d+)\b/i);
+  if (ofMatch && parseFloat(ofMatch[2]) > 0) return (parseFloat(ofMatch[1]) / parseFloat(ofMatch[2])) * 100;
+  const inlineFracMatch = str.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+  if (inlineFracMatch && parseFloat(inlineFracMatch[2]) > 0) return (parseFloat(inlineFracMatch[1]) / parseFloat(inlineFracMatch[2])) * 100;
   const num = parseFloat(str);
   if (!isNaN(num)) return num;
   return null;
@@ -186,17 +194,23 @@ export function createSuccessMetricsGate(supabase) {
               const targetStr = String(metric.target || '').toLowerCase();
               // Compute a numeric completion percentage from evidence
               const storyPct = totalStories > 0 ? Math.round((completedStories / totalStories) * 100) : (acceptedCount > 0 ? 100 : 0);
-              // Heuristic matching: produce numeric values that parseMetricValue can parse
+              // QF-20260524-746: suffix the auto-populated percentage with its evidence
+              // source so it is NOT the bare "100%" that PLACEHOLDER_ACTUAL_VALUES rejects
+              // (the self-defeating catch-22), while staying parseable (pctMatch wins) and
+              // self-documenting. This makes an evidence-backed completion pass instead of
+              // forcing a manual rewrite. The operator can still overwrite with a real measurement.
+              // Heuristic matching: produce numeric values that parseMetricValue can parse.
+              const autoPct = `${storyPct}% (auto: ${completedStories}/${totalStories} stories complete)`;
               if (name.includes('implementation') || name.includes('completeness') || name.includes('scope')) {
-                metric.actual = `${storyPct}%`;
+                metric.actual = autoPct;
               } else if (name.includes('test') || name.includes('coverage')) {
-                metric.actual = `${storyPct}%`;
+                metric.actual = autoPct;
               } else if (name.includes('regression') || name.includes('zero') || targetStr.includes('0 ')) {
                 metric.actual = '0';
               } else if (name.includes('recurrence') || name.includes('issue')) {
                 metric.actual = '0';
               } else {
-                metric.actual = `${storyPct}%`;
+                metric.actual = autoPct;
               }
               metric._auto_populated = true;
             }
@@ -329,13 +343,18 @@ export function createSuccessMetricsGate(supabase) {
       if (!passed) {
         console.log('\n   REMEDIATION:');
         if (hasEmptyActual) {
-          console.log('   - Record actual values for all success metrics');
+          console.log('   - Record a real actual value for each metric (and set measurement_method).');
         }
         if (achievementScore < ACHIEVEMENT_THRESHOLD) {
-          console.log('   - Work toward meeting defined target values');
+          console.log('   - Work toward meeting the defined target values.');
         }
+        // QF-20260524-746: the achievement check parses `actual` to a NUMBER vs the target.
+        // Spell out the format so operators stop trial-and-error editing (this trap recurred across SDs).
+        console.log('   - FORMAT: for a percentage target, LEAD the actual with the number — target "100%" → actual "100% — 6 of 6 FRs".');
+        console.log('     "6 of 6 FRs" alone parses as 6 and FAILS a 100% target; "N of M" / "N/M" forms are accepted and convert to (N/M)*100.');
+        console.log('     Do NOT leave a bare placeholder ("100%", "TBD") with _auto_populated=true — overwrite it with your real measurement.');
         if (!verificationPassed) {
-          console.log('   - Ensure reported metric values match actual measurements');
+          console.log('   - Ensure reported metric values match actual measurements.');
         }
       }
 
@@ -346,7 +365,7 @@ export function createSuccessMetricsGate(supabase) {
         issues,
         warnings,
         ...(!passed && {
-          remediation: 'Record actual values for all success metrics, ensure targets are met, and verify measurements match reports'
+          remediation: 'For each metric set a real actual + measurement_method. The achievement check parses actual to a number vs the target: for a % target LEAD with the number (e.g. "100% — 6 of 6 FRs"; "6 of 6 FRs" alone parses as 6 and fails 100%; "N of M" / "N/M" convert to (N/M)*100). Do not leave a bare placeholder ("100%"/"TBD") with _auto_populated=true — overwrite it.'
         }),
         details: {
           metrics_count: metrics.length,

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.test.js
@@ -170,3 +170,48 @@ describe('SUCCESS_METRICS gate — FR-1 placeholder distinction', () => {
     expect(result.details.achievement.metric_scores[0].reason_code).toBe(GATE_REASON_CODES.SUCCESS_METRICS_PLACEHOLDER_VALUE);
   });
 });
+
+describe('SUCCESS_METRICS gate — QF-20260524-746 (auto-populate/parse catch-22 fix)', () => {
+  beforeEach(() => { vi.spyOn(console, 'log').mockImplementation(() => {}); });
+
+  it('evidence-suffixed auto-populated percentage passes (catch-22 broken — not a bare-100% placeholder)', async () => {
+    const supabase = makeSupabase({
+      successMetrics: [
+        { metric: 'Implementation completeness', target: '100%', actual: '100% (auto: 6/6 stories complete)', _auto_populated: true },
+      ],
+    });
+    const result = await createSuccessMetricsGate(supabase).validator(makeCtx());
+    expect(result.passed).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('descriptive "N of N" actual meeting target passes (no longer misparsed as the leading integer)', async () => {
+    const supabase = makeSupabase({
+      successMetrics: [
+        { metric: 'Implementation completeness', target: '100%', actual: '6 of 6 FRs implemented' },
+      ],
+    });
+    const result = await createSuccessMetricsGate(supabase).validator(makeCtx());
+    expect(result.passed).toBe(true);
+  });
+
+  it('inline "N/M" actual converts to a percentage and passes a >=80% target', async () => {
+    const supabase = makeSupabase({
+      successMetrics: [
+        { metric: 'Test coverage', target: '>=80%', actual: '6/6 modules covered' },
+      ],
+    });
+    const result = await createSuccessMetricsGate(supabase).validator(makeCtx());
+    expect(result.passed).toBe(true);
+  });
+
+  it('partial "N of M" below target still FAILS (gate integrity preserved — no weakening)', async () => {
+    const supabase = makeSupabase({
+      successMetrics: [
+        { metric: 'Implementation completeness', target: '100%', actual: '5 of 6 FRs implemented' },
+      ],
+    });
+    const result = await createSuccessMetricsGate(supabase).validator(makeCtx());
+    expect(result.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260524-746

**Type:** bug
**Severity:** medium

### Issue Description
The PLAN-TO-LEAD SUCCESS_METRICS gate has a compound catch-22 (RCA 2866d715): (1) it auto-populates a missing metric actual with '100%' then rejects that same value as a placeholder; (2) parseMetricValue's parseFloat fallback misparses a descriptive actual like '6 of 6 FRs' as the number 6, failing a 100% target; (3) the remediation message gives no format guidance. Fix: auto-populate format becomes '<pct>% (auto: N/M stories)' (not in the placeholder blocklist, still parseable); parseMetricValue gains 'N of M' + inline-fraction patterns before parseFloat (a genuinely-complete N-of-N passes, '5 of 6'=83 still fails 100); and the remediation message explains the required actual format. Abuse-safe: the blocklist still catches bare TBD/typed-100%; a metric that does not meet its target still fails.


### Expected Behavior
a fully-completed SD passes SUCCESS_METRICS without 2-3 manual success_metrics edits; descriptive-but-quantified actuals are parsed correctly; remediation tells operators exactly how to format the actual

### Actual Behavior
the gate rejects its own auto-populated 100%, misparses descriptive actuals as small integers, and gives generic remediation — forcing repeated manual edits

### Changes
- **Files Changed:** 2
  - scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
  - scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.test.js
- **LOC:** 79 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Systemic fix (user RCA 2866d715) for the recurring SUCCESS_METRICS catch-22; 3 CAs + 4 regression tests; 9/9 gate tests incl. abuse-safety. Merged origin/main to satisfy resolver-freshness gate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol