### PR TITLE
fix(QF-20260524-089): npm-ci wipe guard: scope NPM_CI_RE to a real command boundary so mid-arg text no longer false-positive-blocks

### DIFF
--- a/lib/__tests__/npm-ci-junction-guard.test.js
+++ b/lib/__tests__/npm-ci-junction-guard.test.js
@@ -78,3 +78,29 @@ describe('npmCiWouldWipeSharedStore', () => {
     expect(r.reason).toBe('not_npm_ci');
   });
 });
+
+describe('NPM_CI_RE — QF-20260524-089: scope to a command boundary, not mid-arg text', () => {
+  it('does NOT match the token mid-arg / inside a quoted string (the false-positive)', () => {
+    // These commands merely MENTION npm ci; they do not run it. Before the fix
+    // the bare-whitespace boundary matched the embedded ' npm ci ' and blocked them.
+    expect(NPM_CI_RE.test('git commit -m "fixes the npm ci wipe guard"')).toBe(false);
+    expect(NPM_CI_RE.test('node x.js "do not run npm ci here"')).toBe(false);
+    expect(NPM_CI_RE.test('echo "use npm install, never npm ci"')).toBe(false);
+  });
+
+  it('STILL matches npm ci at a real command-start position', () => {
+    expect(NPM_CI_RE.test('npm ci')).toBe(true);          // start of line
+    expect(NPM_CI_RE.test('cd x && npm ci')).toBe(true);  // after &&
+    expect(NPM_CI_RE.test('echo done; npm ci')).toBe(true); // after ;
+    expect(NPM_CI_RE.test('false || npm ci')).toBe(true); // after ||
+  });
+});
+
+describe('npmCiWouldWipeSharedStore — QF-20260524-089 false-positive end-to-end', () => {
+  it('does NOT block a benign command that only mentions npm ci, even on a junctioned tree', () => {
+    const fs = fakeFs({ '/wt/node_modules': 'symlink' });
+    const r = npmCiWouldWipeSharedStore({ command: 'git commit -m "see: npm ci wipes node_modules"', cwd: '/wt', fs });
+    expect(r.wipes).toBe(false);
+    expect(r.reason).toBe('not_npm_ci');
+  });
+});

--- a/lib/npm-ci-junction-guard.cjs
+++ b/lib/npm-ci-junction-guard.cjs
@@ -19,9 +19,15 @@
  */
 const path = require('path');
 
-// Matches a real `npm ci` invocation (mirrors ENFORCEMENT 12's NPM_INSTALL_RE
-// boundary style). Does NOT match `npm install`, `npm i`, or `npm cite`.
-const NPM_CI_RE = /(?:^|[\s;&|(])npm\s+ci(?:\s|$)/;
+// Matches a real `npm ci` invocation: the token must sit at a command-START
+// position — beginning of the line, or immediately after a shell command
+// separator (`;` `&` `|` `(` or newline), allowing intervening whitespace so
+// `cd x && npm ci` still matches. A bare-whitespace boundary is deliberately
+// NOT treated as a command start: that is what made the token false-positive
+// when it merely appears mid-arg / inside a quoted string — a commit message,
+// a log line, or `node x.js "... npm ci ..."` — none of which RUN npm ci
+// (QF-20260524-089). Still does NOT match `npm install`, `npm i`, or `npm cite`.
+const NPM_CI_RE = /(?:^|[;&|(\n])\s*npm\s+ci(?:\s|$)/;
 
 /**
  * @param {object}   args


### PR DESCRIPTION
## Quick-Fix: QF-20260524-089

**Type:** bug
**Severity:** medium

### Issue Description
ENFORCEMENT 12c's npm-ci shared-store wipe guard delegates to npmCiWouldWipeSharedStore in lib/npm-ci-junction-guard.cjs, whose NPM_CI_RE = /(?:^|[\s;&|(])npm\s+ci(?:\s|$)/ treats ANY whitespace as a command boundary. So a benign Bash command whose ARGS merely mention the token (git commit -m "...npm ci...", node x.js "do not run npm ci") false-positive-matches and is hard-blocked. Fix: require a real shell command separator (start-of-string or one of ; & | ( newline) followed by optional whitespace, dropping the bare-whitespace boundary, so the token is only matched when it is the actual command, not mid-arg text. Real invocations (npm ci, cd x && npm ci, echo a; npm ci) still match; npm cite / npm install still do not.


### Expected Behavior
a benign command that merely mentions 'npm ci' inside a quoted arg or commit message is NOT blocked; a real 'npm ci' invocation (incl. after && / ; ) is still blocked

### Actual Behavior
any command containing the substring ' npm ci ' anywhere (incl. inside quoted args / commit messages) is hard-blocked by the wipe guard

### Changes
- **Files Changed:** 2
  - lib/__tests__/npm-ci-junction-guard.test.js
  - lib/npm-ci-junction-guard.cjs
- **LOC:** 42 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Scopes NPM_CI_RE to a real command boundary; PreToolUse hook control flow untouched (delegates to this pure fn). 10/10 unit tests: existing BLOCK cases still block, 4 new cover the mid-arg false-positives + command-start true-positives + e2e benign-mention. node --check clean. Closes feedback c43e5de0 (B part; D shipped as item 2b).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol