### PR TITLE
fix(QF-20260524-430): WIRE_CHECK_GATE: allowlist the dynamically-imported lib/eva/stage-templates tree so new files are not false-flagged unreachable

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -54,11 +54,34 @@ export const EXCLUSION_PATTERNS = [
 ];
 
 /**
+ * Known dynamic-load trees: directories whose modules are loaded EXCLUSIVELY via
+ * runtime dynamic import() / readdirSync glob — never via a static import statement
+ * reachable from an entry point. Static call-graph analysis cannot trace them, so a
+ * NEW file in such a tree is a guaranteed false-positive "unreachable" finding. This
+ * is a DIFFERENT reason than EXCLUSION_PATTERNS (files with no runtime entry by
+ * design — tests, one-off scripts), kept separate so each intent stays explicit.
+ *
+ * lib/eva/stage-templates/ — the EVA stage-execution worker loads every stage
+ * template and analysis-step via `await import('./stage-templates/...')`, and the
+ * barrel (index.js) auto-discovers stage-NN.js via readdirSync, NOT static
+ * re-exports. Verified 2026-05-24: no static import chain reaches the tree from any
+ * in-scope WIRE_CHECK entry point. Flagged stage-16-positioning-brief.js on
+ * SD-LEO-FEAT-VENTURE-GROUNDED-STAGE-001. feedback 9e61167f (GREENLIT 2026-05-23).
+ * The trailing `/` keeps this boundary-safe (does NOT match `stage-templates-foo/`).
+ */
+export const KNOWN_DYNAMIC_PATTERNS = [
+  /(^|\/)lib\/eva\/stage-templates\//
+];
+
+/**
  * @param {string} file - Forward-slash relative path from repo root
- * @returns {boolean} true when the path matches any EXCLUSION_PATTERN
+ * @returns {boolean} true when the path is excluded from the reachability check —
+ *   either a test/spec/one-off path (EXCLUSION_PATTERNS) or a known dynamic-load
+ *   tree static analysis cannot trace (KNOWN_DYNAMIC_PATTERNS).
  */
 export function isExcludedFromWireCheck(file) {
-  return EXCLUSION_PATTERNS.some((re) => re.test(file));
+  return EXCLUSION_PATTERNS.some((re) => re.test(file)) ||
+    KNOWN_DYNAMIC_PATTERNS.some((re) => re.test(file));
 }
 
 /**

--- a/tests/unit/handoff/wire-check-gate.test.js
+++ b/tests/unit/handoff/wire-check-gate.test.js
@@ -21,6 +21,7 @@ import { buildCallGraph } from '../../../lib/static-analysis/call-graph-builder.
 import { checkReachability } from '../../../lib/static-analysis/reachability-checker.js';
 import {
   EXCLUSION_PATTERNS,
+  KNOWN_DYNAMIC_PATTERNS,
   isExcludedFromWireCheck
 } from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js';
 
@@ -91,6 +92,33 @@ describe('EXCLUSION_PATTERNS (FR-1)', () => {
       // Lookalike directories that share the "one-off" substring must NOT match.
       expect(isExcludedFromWireCheck('scripts/one-offsite/foo.js')).toBe(false);
       expect(isExcludedFromWireCheck('lib/one-off/foo.js')).toBe(false);
+    });
+  });
+
+  // QF-20260524-430 / feedback 9e61167f: the EVA stage-template tree is loaded only
+  // via runtime dynamic import() + readdirSync, so static reachability cannot trace it.
+  describe('KNOWN_DYNAMIC_PATTERNS — lib/eva/stage-templates dynamic-load tree (9e61167f)', () => {
+    it('excludes stage templates and analysis-steps under lib/eva/stage-templates/', () => {
+      expect(isExcludedFromWireCheck('lib/eva/stage-templates/stage-16.js')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/eva/stage-templates/analysis-steps/stage-16-positioning-brief.js')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/eva/stage-templates/index.js')).toBe(true);
+    });
+
+    it('does NOT over-match lookalike paths or other lib/eva files (boundary-safe)', () => {
+      expect(isExcludedFromWireCheck('lib/eva/stage-templates-foo/x.js')).toBe(false);
+      expect(isExcludedFromWireCheck('lib/eva/stage-registry.js')).toBe(false);
+      expect(isExcludedFromWireCheck('lib/eva/stage-execution-worker.js')).toBe(false);
+    });
+
+    it('still checks ordinary new lib/ and scripts/ files (no loss of real coverage)', () => {
+      expect(isExcludedFromWireCheck('lib/governance/resolve-feedback.js')).toBe(false);
+      expect(isExcludedFromWireCheck('scripts/handoff.js')).toBe(false);
+    });
+
+    it('exports KNOWN_DYNAMIC_PATTERNS as a non-empty regex list', () => {
+      expect(Array.isArray(KNOWN_DYNAMIC_PATTERNS)).toBe(true);
+      expect(KNOWN_DYNAMIC_PATTERNS.length).toBeGreaterThan(0);
+      for (const p of KNOWN_DYNAMIC_PATTERNS) expect(p).toBeInstanceOf(RegExp);
     });
   });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260524-430

**Type:** bug
**Severity:** medium

### Issue Description
The LEAD-FINAL-APPROVAL WIRE_CHECK_GATE flags any new JS file under lib/ or scripts/ that its acorn static call-graph cannot reach from an entry point. The entire lib/eva/stage-templates/ tree is loaded EXCLUSIVELY at runtime: the stage-execution worker uses await import('./stage-templates/...'), and the barrel index.js auto-discovers stage-NN.js via readdirSync (not static re-exports). Verified there is no static import chain into the tree from any in-scope entry point. So a NEW stage template or analysis-step file is a guaranteed false-positive unreachable finding (hit stage-16-positioning-brief.js on a prior SD, forcing a documented gate bypass). Fix: add a KNOWN_DYNAMIC_PATTERNS allowlist (separate from the test/spec EXCLUSION_PATTERNS) matching the stage-templates tree, and have isExcludedFromWireCheck honor it, so these files are skipped from the reachability requirement. Boundary-safe regex (does not match stage-templates-foo). Adds regression tests for the new pattern and a guard that lookalike paths still get checked.


### Expected Behavior
a new file under lib/eva/stage-templates/ (incl. analysis-steps/) is skipped from the WIRE_CHECK reachability requirement; ordinary new lib/scripts files are still checked

### Actual Behavior
a new stage-template / analysis-step file is reported unreachable and blocks LEAD-FINAL-APPROVAL, requiring a manual gate bypass

### Changes
- **Files Changed:** 2
  - scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
  - tests/unit/handoff/wire-check-gate.test.js
- **LOC:** 60 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Adds KNOWN_DYNAMIC_PATTERNS allowlist for the runtime-only lib/eva/stage-templates tree (worker uses await import + readdirSync barrel; verified no static entry-point chain). Boundary-safe; ordinary files still checked. 42/42 wire-check unit tests pass. Closes feedback 9e61167f.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol