### PR TITLE
feat(SD-S19-...-001-B): wire Claude-Code-ready writers into seedRepo()

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -24,6 +24,9 @@ import {
   normalizeGroupKey,
 } from './replit-format-strategies.js';
 import { registerVentureResource } from '../../venture-resources.js';
+import { buildClaudeMd } from './claude-md-writer.js';
+import { buildBuildTasks } from './build-tasks-writer.js';
+import { buildReplitConfig } from './replit-config-writer.js';
 
 /**
  * Parse content that may be a JSON string.
@@ -1310,12 +1313,67 @@ ${designsBuildStep}3. Use the CSS custom properties from docs/color-palette.md f
   docsCommitted.push('replit.md');
   } // end legacy format block
 
+  // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-B: emit the Claude-Code-ready repo
+  // artifacts (CLAUDE.md + docs/build-tasks.md + minimal .replit) so a venture
+  // reaching S19 is buildable by Claude Code, not just paste-into-Agent prompts.
+  // Resolve the venture's screens the same way generateBuildPrompts does, then
+  // feed the pure Child-A writers. CLAUDE.md/.replit are PRESERVED if the repo
+  // already ships its own (same rule as replit.md); docs/build-tasks.md is
+  // regenerated like the other docs.
+  try {
+    const archGroup = findGroup(groups, 'how_to_build_it');
+    const wfArt = archGroup?.artifacts?.find(a => a.artifact_type === 'blueprint_wireframes');
+    const blueprintWireframes = parseContent(wfArt?.content) || {};
+    let wireframeScreensArtifact = null;
+    const hasBlueprintScreens =
+      (blueprintWireframes?.wireframes?.screens?.length || blueprintWireframes?.screens?.length || 0) > 0;
+    if (!hasBlueprintScreens) {
+      const { data: wsArt } = await supabase
+        .from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'wireframe_screens')
+        .eq('lifecycle_stage', 15)
+        .eq('is_current', true)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      wireframeScreensArtifact = wsArt?.artifact_data || null;
+    }
+    const { screens } = resolveBuildScreens({ blueprintWireframes, wireframeScreensArtifact });
+    const ventureContext = { name: ventureName, screens };
+
+    // docs/build-tasks.md — venture-derived; regenerated like the other docs.
+    writeFileSync(join(docsDir, 'build-tasks.md'), buildBuildTasks(ventureContext));
+    docsCommitted.push('docs/build-tasks.md');
+
+    // CLAUDE.md (root) — preserve a repo's own hand-tuned file; only seed when absent.
+    const claudeMdPath = join(repoDir, 'CLAUDE.md');
+    if (!existsSync(claudeMdPath)) {
+      writeFileSync(claudeMdPath, buildClaudeMd(ventureContext));
+      docsCommitted.push('CLAUDE.md');
+    } else {
+      docsCommitted.push('CLAUDE.md (preserved — repo shipped its own)');
+    }
+
+    // .replit (root) — preserve the repo's own hosting config; only seed when absent.
+    const replitConfigPath = join(repoDir, '.replit');
+    if (!existsSync(replitConfigPath)) {
+      writeFileSync(replitConfigPath, buildReplitConfig(ventureContext));
+      docsCommitted.push('.replit');
+    } else {
+      docsCommitted.push('.replit (preserved — repo shipped its own)');
+    }
+  } catch (err) {
+    errors.push(`claude-code-ready artifacts: ${err.message}`);
+  }
+
   // Git add, commit, push — idempotent: no-op when re-run on an
   // already-up-to-date repo (was reporting misleading "git push failed:
   // Command failed: git commit" on a benign re-click of Step 1; verified
   // empirically against rickfelix/lexiguard on 2026-04-28).
   try {
-    execSync('git add docs/ replit.md', { cwd: repoDir, encoding: 'utf-8' });
+    execSync('git add docs/ replit.md CLAUDE.md .replit', { cwd: repoDir, encoding: 'utf-8' });
 
     // `git diff --cached --quiet` exits 0 when nothing is staged, 1 when
     // there are staged changes. Wrap in try because execSync throws on

--- a/tests/unit/eva/replit-repo-seeder.claude-code-ready.test.js
+++ b/tests/unit/eva/replit-repo-seeder.claude-code-ready.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-B — integration tests for the
+ * Claude-Code-ready artifact wiring in seedRepo(). Verifies the three Child-A
+ * writers are invoked on the live seed path so a seeded venture repo actually
+ * receives CLAUDE.md, docs/build-tasks.md, and a minimal .replit — and that an
+ * existing CLAUDE.md/.replit is PRESERVED (same rule as replit.md).
+ *
+ * Mocks seedRepo's IO (supabase, git, fs) — mirrors replit-repo-seeder.persist-url.test.js.
+ *
+ * TEST_REQUIRES_DB: false — @supabase/supabase-js is vi.mock'd below, so this is
+ * a pure no-DB unit test (safe in the no-DB `unit` vitest project). This explicit
+ * declaration satisfies the audit-db-test-guards signal: the supabase import here
+ * is a mock target, not a live-DB dependency. (The guard's static check matches
+ * the literal "@supabase/supabase-js" string in the vi.mock call and cannot infer
+ * the mock on its own — auto-detecting vi.mock'd DB clients is a logged guard
+ * enhancement, not a blocker for this mocked suite.)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const writeCalls = [];
+let lastFromTable = null;
+
+vi.mock('../../../lib/venture-resources.js', () => ({
+  registerVentureResource: vi.fn(() => Promise.resolve({ id: 'res-1', status: 'active' })),
+}));
+
+vi.mock('child_process', () => ({ execSync: vi.fn(() => '') }));
+
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn((p, content) => writeCalls.push({ path: String(p), content: String(content) })),
+  readFileSync: vi.fn(() => ''),
+  // Default: artifact files absent (so they get written); dirs present (skip clone).
+  existsSync: vi.fn((p) => !/(?:CLAUDE\.md|\.replit|replit\.md)$/.test(String(p).replace(/\\/g, '/'))),
+}));
+
+function buildSupabaseMock(screens) {
+  const chain = {
+    select() { return chain; }, eq() { return chain; }, in() { return chain; },
+    order() { return chain; }, limit() { return chain; },
+    single() {
+      if (lastFromTable === 'ventures') {
+        return Promise.resolve({ data: { name: 'CanvasAI', target_platform: 'web', metadata: { doc_format: 'agent-optimized' } }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+    then(resolve) { return Promise.resolve({ data: [], error: null }).then(resolve); },
+    update() { return chain; }, upsert() { return chain; },
+  };
+  return {
+    from: vi.fn((table) => { lastFromTable = table; return chain; }),
+    rpc: vi.fn(() => Promise.resolve({
+      data: { groups: [
+        { group_key: 'how_to_build_it', artifacts: [
+          { artifact_type: 'blueprint_wireframes', content: JSON.stringify({ wireframes: { screens } }) },
+        ] },
+      ] },
+      error: null,
+    })),
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => buildSupabaseMock([{ name: 'Dashboard' }, { name: 'Studio' }])),
+}));
+
+const seedPaths = () => writeCalls.map(c => c.path.replace(/\\/g, '/'));
+
+beforeEach(async () => {
+  writeCalls.length = 0;
+  lastFromTable = null;
+  const fs = await import('fs');
+  fs.existsSync.mockImplementation((p) => !/(?:CLAUDE\.md|\.replit|replit\.md)$/.test(String(p).replace(/\\/g, '/')));
+});
+
+describe('seedRepo() — Claude-Code-ready artifacts (Child B wiring)', () => {
+  it('writes CLAUDE.md, docs/build-tasks.md, and .replit into the seeded repo', async () => {
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+    await seedRepo('v-1', 'https://github.com/foo/bar.git');
+    const paths = seedPaths();
+    expect(paths.some(p => /\/CLAUDE\.md$/.test(p))).toBe(true);
+    expect(paths.some(p => /\/docs\/build-tasks\.md$/.test(p))).toBe(true);
+    expect(paths.some(p => /\/\.replit$/.test(p))).toBe(true);
+  });
+
+  it('pins the backend rules in CLAUDE.md and derives build-tasks from the venture screens', async () => {
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+    await seedRepo('v-1', 'https://github.com/foo/bar.git');
+    const claude = writeCalls.find(c => /\/CLAUDE\.md$/.test(c.path.replace(/\\/g, '/')));
+    expect(claude).toBeDefined();
+    expect(claude.content).toMatch(/never\s+Supabase/i);
+    expect(claude.content).toContain('VITE_CLERK_PUBLISHABLE_KEY');
+    const tasks = writeCalls.find(c => /build-tasks\.md$/.test(c.path));
+    expect(tasks).toBeDefined();
+    expect(tasks.content).toContain('Dashboard');
+    expect(tasks.content).toContain('Studio');
+  });
+
+  it('preserves an existing CLAUDE.md / .replit (never overwrites the repo\'s own)', async () => {
+    const fs = await import('fs');
+    fs.existsSync.mockImplementation(() => true); // everything present → preserve path
+    const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
+    await seedRepo('v-1', 'https://github.com/foo/bar.git');
+    const paths = seedPaths();
+    expect(paths.some(p => /\/CLAUDE\.md$/.test(p))).toBe(false); // preserved, not rewritten
+    expect(paths.some(p => /\/\.replit$/.test(p))).toBe(false);   // preserved, not rewritten
+    expect(paths.some(p => /build-tasks\.md$/.test(p))).toBe(true); // docs always regenerated
+  });
+});


### PR DESCRIPTION
## Child B — wire the Claude-Code-ready writers into seedRepo()

Child B of orchestrator **SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001**. Integration step: invokes the three Child-A pure builders on the live `seedRepo()` path so a venture reaching Stage 19 gets the artifacts **committed to its repo**, not just paste-into-Agent prompts.

- `docs/build-tasks.md` — venture-derived (screens resolved as `generateBuildPrompts` does).
- `CLAUDE.md` + `.replit` at repo root — written only when absent; **preserved** if the repo ships its own (same rule as `replit.md`).
- `git add` extended to stage them.

No cutover of the paste-prompt path yet (Child C/D). Integration test asserts the three artifacts are written, CLAUDE.md pins the backend rules, build-tasks reflects screens, and existing files are preserved. **21/21 seeder tests pass** (incl. existing persist-url + build-prompts — no build-into regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)