### PR TITLE
fix(QF-20260524-488): quickfix self-verifier: treat a test file paired with a changed/mentioned production file as in-scope, not scope creep

### DIFF
--- a/lib/quickfix-self-verifier.js
+++ b/lib/quickfix-self-verifier.js
@@ -237,7 +237,16 @@ async function verifyLOCConstraint(qf, context) {
 /**
  * Check 2: Detect scope creep (did we fix more than we said?)
  */
-async function detectScopeCreep(qf, context) {
+// QF-20260524-488 / feedback e0cf303f: a test file co-located with the production
+// file it covers is in-scope, not scope creep. Match common test paths and reduce a
+// path to the production base name it covers (strip a .test/.spec marker + extension).
+const TEST_PATH_RE = /(\.test\.|\.spec\.|(^|\/)__tests__\/|(^|\/)tests?\/)/i;
+function coveredBaseName(file) {
+  const leaf = (file || '').split('/').pop() || '';
+  return leaf.replace(/\.(test|spec)\.[^.]+$/i, '').replace(/\.[^.]+$/, '');
+}
+
+export async function detectScopeCreep(qf, context) {
   const filesChanged = context.filesChanged || [];
 
   // Check if we changed more files than expected
@@ -254,9 +263,22 @@ async function detectScopeCreep(qf, context) {
   const issueDescription = `${qf.title} ${qf.description}`.toLowerCase();
   const mentionedFiles = issueDescription.match(/[a-zA-Z0-9_-]+\.(tsx?|jsx?|js|css|sql)/g) || [];
 
-  const unrelatedFiles = filesChanged.filter(file =>
-    !mentionedFiles.some(mentioned => file.includes(mentioned))
+  // QF-20260524-488 / feedback e0cf303f: a changed test file is in-scope when the
+  // production base name it covers matches a changed non-test file or a mentioned
+  // file — a cohesive prod+test pair is not scope creep. Genuinely unrelated files
+  // (including a test for an unrelated module) are still flagged.
+  const changedProdBases = new Set(
+    filesChanged.filter(f => !TEST_PATH_RE.test(f)).map(coveredBaseName)
   );
+  const mentionedBases = new Set(mentionedFiles.map(coveredBaseName));
+  const unrelatedFiles = filesChanged.filter(file => {
+    if (mentionedFiles.some(mentioned => file.includes(mentioned))) return false;
+    if (TEST_PATH_RE.test(file)) {
+      const base = coveredBaseName(file);
+      if (changedProdBases.has(base) || mentionedBases.has(base)) return false;
+    }
+    return true;
+  });
 
   if (unrelatedFiles.length > 0 && mentionedFiles.length > 0) {
     return {

--- a/tests/quickfix-self-verifier-scope-creep.test.js
+++ b/tests/quickfix-self-verifier-scope-creep.test.js
@@ -1,0 +1,49 @@
+/**
+ * Regression tests for QF-20260524-488 / feedback e0cf303f.
+ *
+ * detectScopeCreep() used to flag a cohesive production+test quick-fix as scope
+ * creep, because a test file ("foo.test.js") does not contain the substring of the
+ * mentioned production file ("foo.js"). The fix treats a changed test file as
+ * in-scope when the production base name it covers matches a changed non-test file
+ * or a file mentioned in the issue text — while still flagging genuinely unrelated
+ * files (including a test for an unrelated module).
+ */
+import { describe, it, expect } from 'vitest';
+import { detectScopeCreep } from '../lib/quickfix-self-verifier.js';
+
+const qf = (title, description) => ({ title, description });
+
+describe('detectScopeCreep — prod+test pairing (e0cf303f)', () => {
+  it('passes a cohesive production + co-located test change', async () => {
+    const r = await detectScopeCreep(
+      qf('Fix fleet-lock-hash race', 'patch lib/fleet-lock-hash.js'),
+      { filesChanged: ['lib/fleet-lock-hash.js', 'lib/fleet-lock-hash.test.js'] }
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('passes a test-only change for a module mentioned in the issue', async () => {
+    const r = await detectScopeCreep(
+      qf('Add coverage for foo', 'add tests for foo.js'),
+      { filesChanged: ['tests/unit/foo.test.js'] }
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('still FLAGS a test for an unrelated module (real scope creep preserved)', async () => {
+    const r = await detectScopeCreep(
+      qf('Fix foo', 'patch foo.js'),
+      { filesChanged: ['lib/foo.js', 'lib/bar.test.js'] }
+    );
+    expect(r.passed).toBe(false);
+    expect(r.issue).toMatch(/scope creep/i);
+  });
+
+  it('still FLAGS an unrelated non-test production file (real scope creep preserved)', async () => {
+    const r = await detectScopeCreep(
+      qf('Fix foo', 'patch foo.js'),
+      { filesChanged: ['lib/foo.js', 'lib/baz.js'] }
+    );
+    expect(r.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260524-488

**Type:** bug
**Severity:** medium

### Issue Description
lib/quickfix-self-verifier.js detectScopeCreep() flags a changed file as 'Possible scope creep - changed unrelated files' (drops confidence to 70) when the issue text does not mention it. A cohesive production+test quick-fix trips this: the issue mentions foo.js, the QF changes foo.js + foo.test.js, but 'foo.test.js'.includes('foo.js') is false, so the test file is judged unrelated. Under --non-interactive the only way past the 70%-confidence prompt is --force-complete, which over-broadly bypasses the LOC cap + compliance + self-verify together. Fix: in detectScopeCreep, a changed test file (.test./.spec./__tests__/ /tests/) is in-scope when the production base name it covers matches either another changed non-test file or a file mentioned in the issue text. Genuinely unrelated files (incl. tests for an unrelated module) are still flagged, preserving real scope-creep detection. Adds regression tests for the prod+test pair (in-scope) and an unrelated-module test (still flagged).


### Expected Behavior
a QF that changes a production file plus its co-located test passes self-verification scope check (confidence stays high)

### Actual Behavior
the paired test file is judged 'unrelated', confidence drops to 70%, and only --force-complete (all-gate bypass) clears it

### Changes
- **Files Changed:** 2
  - lib/quickfix-self-verifier.js
  - tests/quickfix-self-verifier-scope-creep.test.js
- **LOC:** 81 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
detectScopeCreep treats a test file as in-scope when its covered base name matches a changed non-test file or a mentioned file; unrelated files (test or prod) still flag. detectScopeCreep exported for unit test. 4/4 pass incl. 2 real-scope-creep-preserved cases.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol