### PR TITLE
feat(SD-S19-...-001-C): Claude-Code-ready readiness contract on stage19 route

### DIFF
--- a/lib/eva/bridge/repo-readiness.js
+++ b/lib/eva/bridge/repo-readiness.js
@@ -1,0 +1,129 @@
+/**
+ * repo-readiness
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C (Child C / FR-1, FR-2, FR-3)
+ *
+ * Backward-compatible readiness contract for the Stage-19 cutover. For a venture,
+ * surfaces whether its repo is Claude-Code-ready (a canonical repo resolves + the
+ * artifacts seedRepo() commits) and a summary of the venture-derived build plan —
+ * the data the ehg S19 UI will consume in Child D instead of paste-into-Agent
+ * prompts. This child only ADDS the contract; the prompts payload and the dead
+ * generateBuildPrompts/replit.md path are removed later in Child E.
+ *
+ * `buildReadinessSummary` is PURE (unit-testable, mirrors the Child-A writers).
+ * `resolveRepoReadiness` is the async wrapper that resolves the venture's repo and
+ * screens the SAME way seedRepo() does (resolveVentureRepoUrl + the seeder's
+ * resolveBuildScreens against export_blueprint_review's how_to_build_it group,
+ * with the S15 wireframe_screens fallback) so the summary matches what gets
+ * committed to docs/build-tasks.md. It NEVER throws — a readiness-resolution
+ * failure must never break the (load-bearing) prompts payload (FR-3).
+ */
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { resolveVentureRepoUrl } from './resolve-venture-repo.js';
+import { resolveBuildScreens } from './replit-repo-seeder.js';
+dotenv.config();
+
+// The Claude-Code-ready artifacts seedRepo() commits to a venture repo
+// (lib/eva/bridge/replit-repo-seeder.js — the SD-...-001-B wiring block).
+export const SEEDED_ARTIFACTS = ['CLAUDE.md', 'docs/build-tasks.md', '.replit'];
+
+/** Parse content that may be a JSON string (mirrors the seeder's parseContent). */
+function parseContent(content) {
+  if (!content) return null;
+  if (typeof content === 'object') return content;
+  if (typeof content === 'string') {
+    const trimmed = content.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try { return JSON.parse(trimmed); } catch { return null; }
+    }
+  }
+  return null;
+}
+
+/**
+ * PURE: build the readiness summary from already-resolved inputs.
+ *
+ * buildPlanSummary mirrors build-tasks-writer.js (buildBuildTasks): the
+ * decomposition always has 3 children, and Child 2 holds one grandchild per
+ * screen — or a single minimal-skeleton task when no screens resolve.
+ *
+ * @param {Object} args
+ * @param {boolean} [args.repoReady] - a canonical repo resolves for the venture
+ * @param {string} [args.ventureName]
+ * @param {Array} [args.screens] - normalized screens (from resolveBuildScreens)
+ * @returns {{ repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object }}
+ */
+export function buildReadinessSummary({ repoReady = false, ventureName = 'Venture', screens = [] } = {}) {
+  const name = (ventureName && String(ventureName).trim()) || 'Venture';
+  const screenCount = Array.isArray(screens) ? screens.length : 0;
+  return {
+    repoReady: !!repoReady,
+    seededArtifacts: [...SEEDED_ARTIFACTS],
+    buildPlanSummary: {
+      orchestrator: `${name} build`,
+      childCount: 3,
+      screenCount,
+      featureTaskCount: screenCount > 0 ? screenCount : 1,
+      source: screenCount > 0 ? 'screens' : 'skeleton',
+    },
+  };
+}
+
+/**
+ * ASYNC: resolve a venture's repo-readiness for the Stage-19 route. NEVER throws —
+ * on any failure returns a safe not-ready summary so the prompts payload (which
+ * the live ehg S19 UI depends on today) is unaffected.
+ *
+ * @param {string} ventureId
+ * @param {Object} [opts]
+ * @param {import('@supabase/supabase-js').SupabaseClient} [opts.supabase] - injected for tests; a service-role client is created when omitted
+ * @returns {Promise<{ repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object }>}
+ */
+export async function resolveRepoReadiness(ventureId, { supabase } = {}) {
+  try {
+    const db = supabase || createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+    const repoUrl = await resolveVentureRepoUrl(db, ventureId);
+
+    let ventureName = 'Venture';
+    try {
+      const { data: venture } = await db.from('ventures').select('name').eq('id', ventureId).maybeSingle();
+      if (venture?.name) ventureName = venture.name;
+    } catch { /* keep default */ }
+
+    // Screens — same resolution as seedRepo(): blueprint_wireframes from the
+    // export_blueprint_review how_to_build_it group, else the S15 wireframe_screens
+    // artifact. Wrapped so a missing/failed RPC degrades to zero screens, not a throw.
+    let screens = [];
+    try {
+      const { data } = await db.rpc('export_blueprint_review', { p_venture_id: ventureId });
+      const groups = data?.groups || [];
+      const archGroup = groups.find((g) => g.group_key === 'how_to_build_it');
+      const wfArt = archGroup?.artifacts?.find((a) => a.artifact_type === 'blueprint_wireframes');
+      const blueprintWireframes = parseContent(wfArt?.content) || {};
+      let wireframeScreensArtifact = null;
+      const hasBlueprintScreens =
+        (blueprintWireframes?.wireframes?.screens?.length || blueprintWireframes?.screens?.length || 0) > 0;
+      if (!hasBlueprintScreens) {
+        const { data: wsArt } = await db
+          .from('venture_artifacts')
+          .select('artifact_data')
+          .eq('venture_id', ventureId)
+          .eq('artifact_type', 'wireframe_screens')
+          .eq('lifecycle_stage', 15)
+          .eq('is_current', true)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        wireframeScreensArtifact = wsArt?.artifact_data || null;
+      }
+      screens = resolveBuildScreens({ blueprintWireframes, wireframeScreensArtifact }).screens;
+    } catch { /* degrade to zero screens */ }
+
+    return buildReadinessSummary({ repoReady: !!repoUrl, ventureName, screens });
+  } catch {
+    return buildReadinessSummary({ repoReady: false });
+  }
+}
+
+export default resolveRepoReadiness;

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -22,6 +22,7 @@ import { Router } from 'express';
 import { asyncHandler } from '../../lib/middleware/eva-error-handler.js';
 import { isValidUuid } from '../middleware/validate.js';
 import { formatReplitOptimized } from '../../lib/eva/bridge/replit-prompt-formatter.js';
+import { resolveRepoReadiness } from '../../lib/eva/bridge/repo-readiness.js';
 import { writeArtifact } from '../../lib/eva/artifact-persistence-service.js';
 import { ARTIFACT_TYPES } from '../../lib/eva/artifact-types.js';
 
@@ -59,6 +60,9 @@ function validateRegistrationBody(body) {
  *   featurePrompts: [{ title, content, points, priority }],
  *   warnings?: string[],
  *   generatedAt: string,
+ *   // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C: additive Claude-Code-ready readiness
+ *   // contract (consumed by the ehg S19 UI from Child D; prompts removed in Child E).
+ *   readiness: { repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object },
  * }
  */
 router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
@@ -74,6 +78,11 @@ router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
 
   try {
     const result = await formatReplitOptimized(ventureId, { scope, mode: modeHint });
+    // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C: additive Claude-Code-ready readiness
+    // contract for the cutover. Child D switches the ehg S19 UI to consume this; the
+    // prompts payload below stays until Child E. Best-effort — resolveRepoReadiness
+    // never throws, so a readiness failure can't break the load-bearing prompts response.
+    const readiness = await resolveRepoReadiness(ventureId);
     return res.status(200).json({
       ventureName: result.manifest?.ventureName || 'Venture',
       mode: result.manifest?.mode || 'create-new',
@@ -86,6 +95,7 @@ router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
       })),
       warnings: result.warnings || [],
       generatedAt: result.manifest?.exportedAt || new Date().toISOString(),
+      readiness,
     });
   } catch (err) {
     console.error('[stage19-route] replit-prompts failed', JSON.stringify({

--- a/tests/integration/api-routes/stage19-endpoints.test.js
+++ b/tests/integration/api-routes/stage19-endpoints.test.js
@@ -32,12 +32,18 @@ vi.mock('../../../lib/middleware/eva-error-handler.js', () => ({
   asyncHandler: (fn) => fn,
 }));
 
-// Mock the unrelated GET-side dependency so module-load doesn't try to import its real graph.
+// Mock the GET-side dependencies so module-load doesn't try to import their real
+// graphs (formatter + the readiness resolver, which pulls in the seeder).
 vi.mock('../../../lib/eva/bridge/replit-prompt-formatter.js', () => ({
   formatReplitOptimized: vi.fn(),
 }));
+vi.mock('../../../lib/eva/bridge/repo-readiness.js', () => ({
+  resolveRepoReadiness: vi.fn(),
+}));
 
 const { default: router } = await import('../../../server/routes/stage19.js');
+const { formatReplitOptimized } = await import('../../../lib/eva/bridge/replit-prompt-formatter.js');
+const { resolveRepoReadiness } = await import('../../../lib/eva/bridge/repo-readiness.js');
 
 const VALID_UUID = '11111111-2222-3333-4444-555555555555';
 const VALID_REPO = 'https://github.com/owner/repo';
@@ -220,5 +226,76 @@ describe('Stage 19 register-deployment endpoint', () => {
       expect(res.jsonData.code).toBe('VALIDATION_FAILED');
       expect(res.jsonData.invalid.sort()).toEqual(['deployment_url', 'repo_url']);
     });
+  });
+});
+
+// SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C — the GET route now ADDS a Claude-Code-ready
+// readiness summary alongside the (still load-bearing) prompts payload. These assert the
+// backward-compatible contract Child D consumes and Child E later trims.
+describe('Stage 19 GET /:ventureId/replit-prompts readiness contract', () => {
+  const handlers = findRoute('get', '/:ventureId/replit-prompts');
+
+  // Build a GET request — the handler reads req.params + req.query (no body/app needed
+  // since formatReplitOptimized + resolveRepoReadiness are both mocked here).
+  const getReq = (ventureId, query = {}) => ({ params: { ventureId }, query });
+
+  const PROMPTS_RESULT = {
+    manifest: { ventureName: 'Canvas AI', mode: 'build-into', exportedAt: '2026-05-24T00:00:00.000Z' },
+    planModePrompt: { content: 'PLAN MODE PROMPT' },
+    featurePrompts: [{ title: 'Dashboard', content: 'build dashboard', storyPoints: 3, priority: 'high' }],
+    warnings: ['heads up'],
+  };
+  const READINESS = {
+    repoReady: true,
+    seededArtifacts: ['CLAUDE.md', 'docs/build-tasks.md', '.replit'],
+    buildPlanSummary: { orchestrator: 'Canvas AI build', childCount: 3, screenCount: 1, featureTaskCount: 1, source: 'screens' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    formatReplitOptimized.mockResolvedValue(PROMPTS_RESULT);
+    resolveRepoReadiness.mockResolvedValue(READINESS);
+  });
+
+  it('TS-1: returns the existing prompts payload UNCHANGED plus a top-level readiness summary', async () => {
+    const res = createMockRes();
+    await runHandlerChain(handlers, getReq(VALID_UUID), res);
+
+    expect(res.statusCode).toBe(200);
+    // Existing prompts contract — every key the live ehg S19 UI relies on today.
+    expect(res.jsonData).toEqual(expect.objectContaining({
+      ventureName: 'Canvas AI',
+      mode: 'build-into',
+      planPrompt: 'PLAN MODE PROMPT',
+      featurePrompts: [{ title: 'Dashboard', content: 'build dashboard', points: 3, priority: 'high' }],
+      warnings: ['heads up'],
+      generatedAt: '2026-05-24T00:00:00.000Z',
+    }));
+    // Additive readiness contract (Child D consumes this).
+    expect(res.jsonData.readiness).toEqual(READINESS);
+    expect(resolveRepoReadiness).toHaveBeenCalledWith(VALID_UUID);
+  });
+
+  it('still returns the prompts payload when the repo is not ready (additive — never blocks prompts)', async () => {
+    resolveRepoReadiness.mockResolvedValue({
+      repoReady: false,
+      seededArtifacts: ['CLAUDE.md', 'docs/build-tasks.md', '.replit'],
+      buildPlanSummary: { orchestrator: 'Venture build', childCount: 3, screenCount: 0, featureTaskCount: 1, source: 'skeleton' },
+    });
+    const res = createMockRes();
+    await runHandlerChain(handlers, getReq(VALID_UUID), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonData.planPrompt).toBe('PLAN MODE PROMPT'); // prompts still present
+    expect(res.jsonData.featurePrompts).toHaveLength(1);
+    expect(res.jsonData.readiness.repoReady).toBe(false);
+  });
+
+  it('rejects an invalid ventureId with 400 before resolving prompts or readiness', async () => {
+    const res = createMockRes();
+    await runHandlerChain(handlers, getReq('not-a-uuid'), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonData.code).toBe('INVALID_VENTURE_ID');
+    expect(formatReplitOptimized).not.toHaveBeenCalled();
+    expect(resolveRepoReadiness).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/eva/s19-repo-readiness.test.js
+++ b/tests/unit/eva/s19-repo-readiness.test.js
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the Stage-19 Claude-Code-ready readiness contract.
+ *
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C (Child C)
+ *   TS-2  pure buildReadinessSummary
+ *   TS-3  async resolveRepoReadiness (build-into + create-new) with injected fake client
+ *   TS-4  resilience — resolveRepoReadiness never throws
+ *   TS-5  drift-lock — buildPlanSummary matches buildBuildTasks output
+ *
+ * TEST_REQUIRES_DB: false — every database access goes through injected fakes or
+ * pure functions; no real database connection is opened.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildReadinessSummary,
+  resolveRepoReadiness,
+  SEEDED_ARTIFACTS,
+} from '../../../lib/eva/bridge/repo-readiness.js';
+import { buildBuildTasks } from '../../../lib/eva/bridge/build-tasks-writer.js';
+
+const SAFE_REPO = 'https://github.com/owner/repo';
+
+/**
+ * Minimal chainable fake of the data client surface that resolveRepoReadiness and
+ * resolveVentureRepoUrl touch: ventures (repo_url / name), venture_artifacts
+ * (s17_approved fallback + wireframe_screens S15), and the export_blueprint_review RPC.
+ */
+function makeDb({ repoUrl = null, ventureName = 'Venture', groups = [], s15Screens = null, throws = false } = {}) {
+  const rpc = async (name) => {
+    if (throws) throw new Error('rpc boom');
+    if (name === 'export_blueprint_review') return { data: { groups } };
+    return { data: null };
+  };
+  function builder() {
+    const state = { columns: '', filters: {} };
+    const single = async () => ({ data: resolveSingle(state) });
+    const api = {
+      select(cols) { state.columns = String(cols || ''); return api; },
+      eq(col, val) { state.filters[col] = val; return api; },
+      order() { return api; },
+      limit() { return api; },
+      maybeSingle: single,
+      single,
+      // thenable: resolveVentureRepoUrl's s17_approved fallback awaits the builder directly
+      then: (onFulfilled, onRejected) =>
+        Promise.resolve({ data: resolveList(state) }).then(onFulfilled, onRejected),
+    };
+    return api;
+  }
+  function resolveSingle(state) {
+    if (throws) throw new Error('from boom');
+    if (state.columns.includes('repo_url')) return repoUrl ? { repo_url: repoUrl } : null;
+    if (state.columns.includes('name')) return { name: ventureName };
+    if (state.filters.artifact_type === 'wireframe_screens') {
+      return s15Screens ? { artifact_data: { screens: s15Screens } } : null;
+    }
+    return null;
+  }
+  function resolveList() {
+    return []; // s17_approved fallback → no rows (create-new path)
+  }
+  return { from: () => builder(), rpc };
+}
+
+function blueprintGroups(screens) {
+  return [
+    {
+      group_key: 'how_to_build_it',
+      artifacts: [{ artifact_type: 'blueprint_wireframes', content: { wireframes: { screens } } }],
+    },
+  ];
+}
+
+describe('buildReadinessSummary (pure) — TS-2', () => {
+  it('passes repoReady through and lists the three seeded artifacts', () => {
+    const s = buildReadinessSummary({ repoReady: true, ventureName: 'Canvas AI', screens: [{ name: 'A' }, { name: 'B' }] });
+    expect(s.repoReady).toBe(true);
+    expect(s.seededArtifacts).toEqual(['CLAUDE.md', 'docs/build-tasks.md', '.replit']);
+    expect(s.seededArtifacts).toEqual(SEEDED_ARTIFACTS);
+    expect(s.buildPlanSummary).toEqual({
+      orchestrator: 'Canvas AI build',
+      childCount: 3,
+      screenCount: 2,
+      featureTaskCount: 2,
+      source: 'screens',
+    });
+  });
+
+  it('uses a single skeleton task and source=skeleton when no screens resolve', () => {
+    const s = buildReadinessSummary({ repoReady: false });
+    expect(s.repoReady).toBe(false);
+    expect(s.buildPlanSummary.screenCount).toBe(0);
+    expect(s.buildPlanSummary.featureTaskCount).toBe(1);
+    expect(s.buildPlanSummary.source).toBe('skeleton');
+    expect(s.buildPlanSummary.orchestrator).toBe('Venture build');
+  });
+
+  it('does not mutate the shared SEEDED_ARTIFACTS export', () => {
+    const s = buildReadinessSummary({});
+    s.seededArtifacts.push('mutated');
+    expect(SEEDED_ARTIFACTS).toEqual(['CLAUDE.md', 'docs/build-tasks.md', '.replit']);
+  });
+});
+
+describe('resolveRepoReadiness (async) — TS-3', () => {
+  it('build-into: resolvable repo + blueprint screens → repoReady true with the venture plan', async () => {
+    const db = makeDb({
+      repoUrl: SAFE_REPO,
+      ventureName: 'Canvas AI',
+      groups: blueprintGroups([{ name: 'Dashboard' }, { name: 'Studio' }, { name: 'Shop' }]),
+    });
+    const s = await resolveRepoReadiness('11111111-2222-3333-4444-555555555555', { supabase: db });
+    expect(s.repoReady).toBe(true);
+    expect(s.buildPlanSummary.orchestrator).toBe('Canvas AI build');
+    expect(s.buildPlanSummary.screenCount).toBe(3);
+    expect(s.buildPlanSummary.featureTaskCount).toBe(3);
+    expect(s.seededArtifacts).toEqual(SEEDED_ARTIFACTS);
+  });
+
+  it('falls back to the S15 wireframe_screens artifact when blueprint screens are absent', async () => {
+    const db = makeDb({
+      repoUrl: SAFE_REPO,
+      ventureName: 'Canvas AI',
+      groups: blueprintGroups([]), // no blueprint screens → S15 fallback
+      s15Screens: [{ screen_name: 'Home' }, { screen_name: 'Settings' }],
+    });
+    const s = await resolveRepoReadiness('11111111-2222-3333-4444-555555555555', { supabase: db });
+    expect(s.repoReady).toBe(true);
+    expect(s.buildPlanSummary.screenCount).toBe(2);
+  });
+
+  it('create-new: no repo + no screens → repoReady false, skeleton plan', async () => {
+    const db = makeDb({ repoUrl: null, ventureName: 'Fresh', groups: [] });
+    const s = await resolveRepoReadiness('11111111-2222-3333-4444-555555555555', { supabase: db });
+    expect(s.repoReady).toBe(false);
+    expect(s.buildPlanSummary.screenCount).toBe(0);
+    expect(s.buildPlanSummary.featureTaskCount).toBe(1);
+  });
+});
+
+describe('resolveRepoReadiness resilience — TS-4', () => {
+  it('never throws when the client errors — returns a safe not-ready summary', async () => {
+    const db = makeDb({ throws: true });
+    const s = await resolveRepoReadiness('11111111-2222-3333-4444-555555555555', { supabase: db });
+    expect(s.repoReady).toBe(false);
+    expect(s.seededArtifacts).toEqual(SEEDED_ARTIFACTS);
+    expect(s.buildPlanSummary.source).toBe('skeleton');
+  });
+
+  it('degrades to zero screens (not a throw) when only the RPC fails', async () => {
+    // ventures/repo resolve fine, but export_blueprint_review throws → screens default to 0.
+    const db = makeDb({ repoUrl: SAFE_REPO, ventureName: 'Partial' });
+    db.rpc = async () => { throw new Error('rpc down'); };
+    const s = await resolveRepoReadiness('11111111-2222-3333-4444-555555555555', { supabase: db });
+    expect(s.repoReady).toBe(true); // repo still resolved
+    expect(s.buildPlanSummary.screenCount).toBe(0);
+    expect(s.buildPlanSummary.featureTaskCount).toBe(1);
+  });
+});
+
+describe('buildPlanSummary drift-lock vs buildBuildTasks — TS-5', () => {
+  const cases = [
+    [],
+    [{ name: 'A' }],
+    [{ name: 'A' }, { name: 'B' }, { name: 'C' }, { name: 'D' }],
+  ];
+  it.each(cases)('childCount=3 and featureTaskCount match the generated build-tasks.md (%#)', (screens) => {
+    const md = buildBuildTasks({ name: 'V', screens });
+    const childCount = (md.match(/^### Child /gm) || []).length;
+    const grandchildCount = (md.match(/^- \[ \] \*\*2\./gm) || []).length;
+    const summary = buildReadinessSummary({ repoReady: true, ventureName: 'V', screens }).buildPlanSummary;
+    expect(summary.childCount).toBe(childCount);
+    expect(summary.featureTaskCount).toBe(grandchildCount);
+  });
+});


### PR DESCRIPTION
## Child C — Stage-19 backend readiness contract (backward-compatible cutover)

Part of **SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001** (codify the venture-build process into the Stage-19 seeder). Children A (writers) and B (wire into `seedRepo()`) are merged and live on main; this is the first **cutover** step.

### What changed
- **`GET /api/stage19/:ventureId/replit-prompts`** now returns a top-level `readiness: { repoReady, seededArtifacts, buildPlanSummary }` **alongside** the existing prompts payload. Every existing key (`ventureName, mode, planPrompt, featurePrompts, warnings, generatedAt`) is byte-identical — **purely additive**, so the live ehg S19 UI keeps working with no stale-prompt window. This decouples C/D merge ordering and removes the cross-repo live-break risk.
- **New `lib/eva/bridge/repo-readiness.js`**: a pure `buildReadinessSummary` + an async `resolveRepoReadiness` that resolves the venture repo (`resolveVentureRepoUrl`) and screens (the seeder's `resolveBuildScreens`) **the same way `seedRepo()` does**, so `buildPlanSummary` matches what gets committed to `docs/build-tasks.md`. It **never throws** — a readiness-resolution failure can't break the load-bearing prompts payload (FR-3).

### Not in this child
- No removal of the prompts payload or `generateBuildPrompts`/`generateInitialPrompt`/`replit.md` template — that is **Child E**, after C and D both land.
- The ehg S19 UI switch to consume `readiness` is **Child D** (cross-repo).

### Tests
- `tests/unit/eva/s19-repo-readiness.test.js` (11) — pure / async (build-into + S15 fallback + create-new) / resilience / a **drift-lock** tying `buildPlanSummary` to `buildBuildTasks` output.
- Extends `tests/integration/api-routes/stage19-endpoints.test.js` (+3) — GET route-contract: existing keys unchanged + `readiness` merged + 400 fail-fast.
- **21/21 green**, ESLint clean. TESTING sub-agent: PASS (88/100), evidence `99e587e7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
