### PR TITLE
fix(QF-20260524-337): PreCompact hook wipes protocol-read tracking, re-blocking /sd-create after compaction

### DIFF
--- a/lib/context/unified-state-manager.js
+++ b/lib/context/unified-state-manager.js
@@ -724,6 +724,21 @@ class UnifiedStateManager {
       ...additionalData.extra
     };
 
+    // QF-20260524-337: Preserve protocol-file-read tracking across state rebuilds.
+    // Compaction snapshot writers reconstruct state from scratch; without this,
+    // protocolFilesRead/protocolFileReadStatus are dropped and /sd-create re-blocks
+    // post-compaction with "CLAUDE_CORE.md has not been read" (feedback 6bbe551f).
+    // (The currently-wired hook is precompact-snapshot.ps1; this hardens the JS path.)
+    for (const key of [
+      'protocolFilesRead', 'protocolFilesReadAt', 'protocolFileReadStatus',
+      'protocolGate', 'protocolFilesPartiallyRead', 'protocolReadConfirmations',
+      'protocolFileEscalations'
+    ]) {
+      if (existingState[key] !== undefined && state[key] === undefined) {
+        state[key] = existingState[key];
+      }
+    }
+
     // Calculate and add token metrics
     const estimatedTokens = this.estimateStateTokens(state);
     state.tokenMetrics = {

--- a/scripts/hooks/precompact-snapshot.ps1
+++ b/scripts/hooks/precompact-snapshot.ps1
@@ -37,6 +37,34 @@ if (Test-Path $sessionState) {
     }
 }
 
+# QF-20260524-337: Preserve protocol-file-read tracking across compaction.
+# This hook previously scratch-built $state and overwrote the file, dropping
+# protocolFilesRead/protocolFileReadStatus/etc. Post-compaction /sd-create then
+# re-blocked with "CLAUDE_CORE.md has not been read" (sd-key-generator.js Case 1,
+# feedback 6bbe551f). Read the existing state and carry these keys forward so a
+# session that already read the protocol files stays unblocked after compaction.
+$preservedKeys = @(
+    'protocolFilesRead', 'protocolFilesReadAt', 'protocolFileReadStatus',
+    'protocolGate', 'protocolFilesPartiallyRead', 'protocolReadConfirmations',
+    'protocolFileEscalations'
+)
+$preserved = @{}
+if (Test-Path $UnifiedStateFile) {
+    try {
+        $existingRaw = Get-Content $UnifiedStateFile -Raw -ErrorAction Stop
+        if ($existingRaw) {
+            $existingState = ($existingRaw.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop)
+            foreach ($key in $preservedKeys) {
+                if (($existingState.PSObject.Properties.Name -contains $key) -and ($null -ne $existingState.$key)) {
+                    $preserved[$key] = $existingState.$key
+                }
+            }
+        }
+    } catch {
+        # Corrupt/unreadable existing state - proceed without preservation (fail-open)
+    }
+}
+
 # Build unified state JSON
 $timestamp = Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
 $state = @{
@@ -66,6 +94,11 @@ $state = @{
         keyDecisions = @()
         pendingActions = @("Restore context after session start")
     }
+}
+
+# QF-20260524-337: Merge preserved protocol-read tracking back into the new state.
+foreach ($key in $preserved.Keys) {
+    $state[$key] = $preserved[$key]
 }
 
 # Write unified state (atomic write via temp file)

--- a/tests/unit/precompact-protocol-read-preservation.test.js
+++ b/tests/unit/precompact-protocol-read-preservation.test.js
@@ -1,0 +1,120 @@
+/**
+ * QF-20260524-337: protocol-read tracking must survive context compaction.
+ *
+ * Root cause (feedback 6bbe551f): the wired PreCompact hook
+ * scripts/hooks/precompact-snapshot.ps1 rebuilt .claude/unified-session-state.json
+ * from scratch on every auto-compaction, dropping protocolFilesRead /
+ * protocolFileReadStatus and 5 sibling keys. Post-compaction, /sd-create
+ * (sd-key-generator.js validateCoreFileRead Case 1) then re-blocked with
+ * "CLAUDE_CORE.md has not been read in this session".
+ *
+ * These tests assert the preservation contract in BOTH state writers:
+ *   1. UnifiedStateManager.buildState (portable JS — runs on CI), and
+ *   2. precompact-snapshot.ps1 — the actually-wired hook (Windows-gated, since
+ *      it is a PowerShell file that only executes on the win32 hook host).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// The seven non-SD context keys the compaction snapshot must NOT discard.
+const PROTOCOL_KEYS = [
+  'protocolFilesRead',
+  'protocolFilesReadAt',
+  'protocolFileReadStatus',
+  'protocolGate',
+  'protocolFilesPartiallyRead',
+  'protocolReadConfirmations',
+  'protocolFileEscalations',
+];
+
+function seedState() {
+  const now = new Date().toISOString();
+  return {
+    version: '2.0.0',
+    timestamp: now,
+    trigger: 'manual',
+    protocolFilesRead: ['CLAUDE_CORE.md', 'CLAUDE_CORE_DIGEST.md', 'CLAUDE_LEAD.md'],
+    protocolFilesReadAt: { 'CLAUDE_CORE.md': now },
+    protocolFileReadStatus: {
+      'CLAUDE_CORE.md': {
+        readCount: 2,
+        lastReadWasPartial: true,
+        lastPartialRead: { limit: 700, offset: 0 },
+        ranges: [{ offset: 1, limit: 800 }, { offset: 801, limit: 843 }],
+      },
+    },
+    protocolGate: { compactionCount: 1, fileReads: {} },
+  };
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf337-'));
+  fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+});
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+// ---------- Portable: buildState (lib/context/unified-state-manager.js) ----------
+describe('UnifiedStateManager.buildState preserves protocol-read tracking', () => {
+  it('carries forward existing protocol keys through a precompact rebuild', async () => {
+    const stateFile = path.join(tmpDir, '.claude', 'unified-session-state.json');
+    fs.writeFileSync(stateFile, JSON.stringify(seedState(), null, 2), 'utf8');
+
+    const { default: UnifiedStateManager } = await import('../../lib/context/unified-state-manager.js');
+    const built = await new UnifiedStateManager(tmpDir).buildState('precompact');
+
+    expect(built.protocolFilesRead).toContain('CLAUDE_CORE.md');
+    expect(built.protocolFileReadStatus['CLAUDE_CORE.md'].readCount).toBe(2);
+    expect(built.protocolFileReadStatus['CLAUDE_CORE.md'].ranges).toHaveLength(2);
+    expect(built.protocolGate.compactionCount).toBe(1);
+  });
+
+  it('does not fabricate protocol keys when prior state has none', async () => {
+    const stateFile = path.join(tmpDir, '.claude', 'unified-session-state.json');
+    fs.writeFileSync(stateFile, JSON.stringify(
+      { version: '2.0.0', timestamp: new Date().toISOString(), trigger: 'manual' }, null, 2), 'utf8');
+
+    const { default: UnifiedStateManager } = await import('../../lib/context/unified-state-manager.js');
+    const built = await new UnifiedStateManager(tmpDir).buildState('precompact');
+
+    for (const key of PROTOCOL_KEYS) expect(built[key]).toBeUndefined();
+  });
+});
+
+// ---------- Windows-gated: the actually-wired precompact-snapshot.ps1 ----------
+describe.skipIf(process.platform !== 'win32')(
+  'precompact-snapshot.ps1 (wired PreCompact hook) preserves protocol-read tracking',
+  () => {
+    it('keeps protocolFilesRead/Status after a real snapshot rewrite', () => {
+      const stateFile = path.join(tmpDir, '.claude', 'unified-session-state.json');
+      fs.writeFileSync(stateFile, JSON.stringify(seedState(), null, 2), 'utf8');
+
+      const ps1 = path.join(REPO_ROOT, 'scripts', 'hooks', 'precompact-snapshot.ps1');
+      execSync(`powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${ps1}"`, {
+        // Point both CLAUDE_PROJECT_DIR and USERPROFILE at the temp dir so the hook
+        // never touches the real shared session state or ~/.claude/flags.
+        env: { ...process.env, CLAUDE_PROJECT_DIR: tmpDir, USERPROFILE: tmpDir },
+        stdio: 'pipe',
+        timeout: 30000,
+      });
+
+      let raw = fs.readFileSync(stateFile, 'utf8');
+      if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1); // PS Out-File -Encoding UTF8 adds a BOM
+      const after = JSON.parse(raw);
+
+      // trigger flips to 'precompact' only if the hook actually ran and rewrote the file.
+      expect(after.trigger).toBe('precompact');
+      expect(after.protocolFilesRead).toContain('CLAUDE_CORE.md');
+      expect(after.protocolFileReadStatus['CLAUDE_CORE.md'].readCount).toBe(2);
+      expect(after.protocolFileReadStatus['CLAUDE_CORE.md'].ranges).toHaveLength(2);
+    });
+  },
+);


### PR DESCRIPTION
## Quick-Fix: QF-20260524-337

**Type:** bug
**Severity:** medium

### Issue Description
precompact-snapshot.ps1 scratch-writes unified-session-state.json each auto-compaction, dropping protocolFilesRead/protocolFileReadStatus and 5 sibling keys. Post-compaction /sd-create (sd-key-generator validateCoreFileRead Case 1) re-blocks: 'CLAUDE_CORE.md has not been read'. Root cause for feedback 6bbe551f (RCA: precompact-unified.js/buildState is dead code; wired PS1 is the culprit). Fix: read-merge to preserve the 7 tracker keys; harden buildState defensively.

### Steps to Reproduce
1. Read CLAUDE_CORE.md. 2. Let session auto-compact. 3. Run /sd-create.

### Expected Behavior
SD key generation proceeds; the CLAUDE_CORE.md read is remembered across compaction.

### Actual Behavior
Blocked with 'CLAUDE_CORE.md has not been read in this session' (Case 1).

### Changes
- **Files Changed:** 3
  - lib/context/unified-state-manager.js
  - scripts/hooks/precompact-snapshot.ps1
  - tests/unit/precompact-protocol-read-preservation.test.js
- **LOC:** 175 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Targeted regression test 3/3 pass (portable buildState + Windows-gated PS1 exec). Integrity verified by revert: fix reverted => both preservation assertions fail (protocolFilesRead undefined). tsc PASSED. Full unit suite not run via gate (377s>2min timeout; ~23 pre-existing no-DB fails tracked BL-TST-002, unrelated). Fix location differs from QF description because RCA corrected diagnosis: wired hook is precompact-snapshot.ps1 (not precompact-unified.js/buildState, which is dead code). Root cause feedback 6bbe551f.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol