### PR TITLE
fix(QF-20260524-057): complete-quick-fix counts test-only QFs as source LOC (1becd80a)

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -201,6 +201,31 @@ export function countLocBySplit(testDir, baseRef = 'origin/main', headRef = 'HEA
 }
 
 /**
+ * Split LOC into source/test from a PR's per-file additions/deletions
+ * (`gh pr view --json files`). Fallback for when the local numstat split is
+ * unavailable — e.g. the PR commit isn't present locally (--merge non-squash, or
+ * completing from an unrelated CWD). Without this, a test-only QF was misreported
+ * as 100% source LOC and falsely escalated to Tier-3 (feedback 1becd80a;
+ * QF-20260523-562: 84 add ≈ 5 src + 79 test, but reported 86/0). Classification
+ * mirrors countLocBySplit's TEST_FILE_PATTERN so the two paths agree.
+ *
+ * @param {Array<{path?:string,additions?:number,deletions?:number}>} files
+ * @returns {{source:number, test:number, total:number}}
+ */
+export function countLocByPrFiles(files) {
+  const result = { source: 0, test: 0, total: 0 };
+  for (const f of files || []) {
+    const filepath = f?.path || '';
+    if (!filepath) continue;
+    const loc = (Number(f.additions) || 0) + (Number(f.deletions) || 0);
+    if (TEST_FILE_PATTERN.test(filepath)) result.test += loc;
+    else result.source += loc;
+    result.total += loc;
+  }
+  return result;
+}
+
+/**
  * Sanitize branch name for safe shell usage
  * SD-SEC-DATA-VALIDATION-001: Validate git branch names
  * @param {string} branchName - Branch name to validate
@@ -277,7 +302,9 @@ export function isInQFWorktree(testDir) {
  * @returns {object} Parsed JSON: { state, headRefName, mergeCommit, additions, deletions, url }
  */
 export function fetchPRMetadata(prNumber, testDir) {
-  const fields = 'state,headRefName,mergeCommit,additions,deletions,url';
+  // 1becd80a: include `files` (per-file additions/deletions) so the source/test
+  // split can fall back to the PR file list when the merge commit isn't local.
+  const fields = 'state,headRefName,mergeCommit,additions,deletions,url,files';
   let raw;
   try {
     raw = execSync(`gh pr view ${prNumber} --json ${fields}`, {
@@ -375,22 +402,38 @@ export function autoDetectGitInfo(testDir, options = {}) {
     // (QF-20260511-876: 1624 src / 181 test reported for actual 67 / 106 LOC).
     if (result.actualSourceLoc === undefined) {
       let splitHeadRef = 'HEAD';
+      let localSplitAvailable = true;
       if (result.commitSha) {
         try {
           execSync(`git cat-file -e ${result.commitSha}`, { cwd: testDir, stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 });
           splitHeadRef = result.commitSha;
         } catch {
-          console.log(`⚠️  PR commit ${result.commitSha.substring(0, 7)} not present locally — skipping source/test split (would over-report from CWD HEAD)`);
-          return result;
+          // 1becd80a: PR commit not present locally (--merge non-squash, or running
+          // from an unrelated CWD). The local numstat split would over-report from
+          // CWD HEAD, so fall back to the PR file list below instead of skipping —
+          // skipping defaulted test-only QFs to source=total/test=0 (false Tier-3).
+          console.log(`⚠️  PR commit ${result.commitSha.substring(0, 7)} not present locally — using gh PR file list for source/test split`);
+          localSplitAvailable = false;
         }
       }
-      const split = countLocBySplit(testDir, 'origin/main', splitHeadRef);
-      if (split.total > 0) {
+      if (localSplitAvailable) {
+        const split = countLocBySplit(testDir, 'origin/main', splitHeadRef);
+        if (split.total > 0) {
+          result.actualSourceLoc = split.source;
+          result.actualTestLoc = split.test;
+          // QF-20260509-407: forward deletion-only source LOC for tier classification.
+          result.sourceDeletionLoc = split.sourceDeletionLoc;
+          console.log(`🔍 PR #${prNumber} → source LOC: ${split.source}, test LOC: ${split.test} (split via git numstat @ ${splitHeadRef.substring(0, 7)})`);
+        }
+      }
+      // 1becd80a fallback: PR-file-list split when the local numstat split was
+      // unavailable (commit not local) or returned empty. pr.files is populated
+      // by fetchPRMetadata's `files` field.
+      if (result.actualSourceLoc === undefined && Array.isArray(pr.files) && pr.files.length > 0) {
+        const split = countLocByPrFiles(pr.files);
         result.actualSourceLoc = split.source;
         result.actualTestLoc = split.test;
-        // QF-20260509-407: forward deletion-only source LOC for tier classification.
-        result.sourceDeletionLoc = split.sourceDeletionLoc;
-        console.log(`🔍 PR #${prNumber} → source LOC: ${split.source}, test LOC: ${split.test} (split via git numstat @ ${splitHeadRef.substring(0, 7)})`);
+        console.log(`🔍 PR #${prNumber} → source LOC: ${split.source}, test LOC: ${split.test} (split via gh PR file list)`);
       }
     }
     return result;

--- a/tests/unit/complete-quick-fix/qf-057-loc-cap-accuracy-and-bypass.test.js
+++ b/tests/unit/complete-quick-fix/qf-057-loc-cap-accuracy-and-bypass.test.js
@@ -1,0 +1,43 @@
+/**
+ * QF-20260524-057: complete-quick-fix LOC-cap accuracy (feedback 1becd80a).
+ *
+ * countLocByPrFiles: when the merged PR commit isn't local (--merge non-squash,
+ * or completing from an unrelated CWD), the source/test split must come from the
+ * PR file list — otherwise the splitter is skipped and the orchestrator defaults
+ * actualSourceLoc=total / test=0, falsely escalating test-only QFs to Tier-3
+ * (QF-20260523-562: 84 add ≈ 5 src + 79 test, but reported 86/0).
+ */
+import { describe, it, expect } from 'vitest';
+import { countLocByPrFiles } from '../../../scripts/modules/complete-quick-fix/git-operations.js';
+
+describe('countLocByPrFiles (1becd80a: PR-file-list source/test split)', () => {
+  it('classifies tests/unit/*.test.js as test, not source (the QF-562 case)', () => {
+    const files = [
+      { path: 'tests/unit/foo.test.js', additions: 79, deletions: 0 },
+      { path: 'scripts/foo.js', additions: 5, deletions: 0 },
+    ];
+    const r = countLocByPrFiles(files);
+    expect(r.source).toBe(5);   // was misreported as 84 (100% source) before the fix
+    expect(r.test).toBe(79);
+    expect(r.total).toBe(84);
+  });
+
+  it('counts additions + deletions and recognizes spec/__tests__/e2e patterns', () => {
+    const files = [
+      { path: 'src/a.spec.ts', additions: 10, deletions: 2 },      // test
+      { path: 'src/__tests__/b.js', additions: 4, deletions: 1 },  // test
+      { path: 'e2e/c.js', additions: 3, deletions: 0 },            // test
+      { path: 'lib/d.js', additions: 6, deletions: 4 },            // source
+    ];
+    const r = countLocByPrFiles(files);
+    expect(r.test).toBe(20);
+    expect(r.source).toBe(10);
+    expect(r.total).toBe(30);
+  });
+
+  it('is robust to empty / undefined / missing fields', () => {
+    expect(countLocByPrFiles([])).toEqual({ source: 0, test: 0, total: 0 });
+    expect(countLocByPrFiles(undefined)).toEqual({ source: 0, test: 0, total: 0 });
+    expect(countLocByPrFiles([{ path: '' }, { additions: 5 }])).toEqual({ source: 0, test: 0, total: 0 });
+  });
+});

--- a/tests/unit/scripts/complete-quick-fix-loc-split.test.js
+++ b/tests/unit/scripts/complete-quick-fix-loc-split.test.js
@@ -178,10 +178,11 @@ describe('QF-20260511-129 — PR-metadata path pins countLocBySplit to mergeComm
   it('PR-metadata branch guards with git cat-file -e before pinning to commitSha', () => {
     const prBranchStart = src.indexOf('PR-metadata authoritative path');
     const prBranchSnippet = src.slice(prBranchStart, prBranchStart + 4000);
-    // The guard skips the split (rather than inflating from CWD HEAD) when the
-    // commit isn't fetched locally.
+    // When the commit isn't fetched locally, the guard avoids inflating from CWD
+    // HEAD by falling back to the PR file list (1becd80a) instead of skipping the
+    // split (skipping defaulted test-only QFs to 100% source LOC → false Tier-3).
     expect(prBranchSnippet).toMatch(/git cat-file -e \$\{result\.commitSha\}/);
-    expect(prBranchSnippet).toMatch(/skipping source\/test split/);
+    expect(prBranchSnippet).toMatch(/using gh PR file list/);
   });
 
   it('legacy in-worktree branch passes "HEAD" explicitly (clarity, no behavior change)', () => {


### PR DESCRIPTION
## QF-20260524-057 — feedback 1becd80a

When a merged PR's commit isn't present locally (`--merge` non-squash, or completing from an unrelated CWD), `countLocBySplit` was skipped and the orchestrator defaulted `actualSourceLoc=total / test=0` — so a test-only QF was misreported as 100% source LOC and **falsely escalated to Tier-3** (QF-20260523-562: 84 additions ≈ 5 src + 79 test, reported as 86/0).

### Fix
- `fetchPRMetadata` now requests the `files` field.
- `autoDetectGitInfo` falls back to a new `countLocByPrFiles(pr.files)` split (mirrors `countLocBySplit`'s TEST_FILE_PATTERN) when the local numstat split is unavailable.
- Updates the QF-129 source-string guard for the new fall-back behavior.

### Tests
- New `countLocByPrFiles` unit tests (3); full complete-quick-fix suite 148/148; revert-integrity proven.

> `--over-cap-reason` (ae9d4809) was deferred — it is multi-gate (validateLOC + self-verifier Check 1 + the low-confidence prompt), tracked separately.