### PR TITLE
fix(QF-20260524-418): leo-create-sd auto-route: countArchPhases counts prose-string char length as phase count

### DIFF
--- a/scripts/modules/leo-create-sd/auto-route-decider.js
+++ b/scripts/modules/leo-create-sd/auto-route-decider.js
@@ -67,8 +67,14 @@ export const PR_N_PATTERN = /PR-\d+/;
  * @returns {{ structuredPhaseCount: number, contentMatches: string[] }}
  */
 export function countArchPhases(archPlan) {
-  const structuredPhaseCount =
-    archPlan?.sections?.implementation_phases?.length || 0;
+  // 0ee3c3b8: implementation_phases is sometimes stored as a prose STRING, not an
+  // array of phase objects. `?.length` on a string returns its CHARACTER count
+  // (e.g. 1140), which falsely tripped hasMultipleStructured and auto-routed a
+  // single feature SD to the orchestrator creator (→ empty 0-child shell). Only an
+  // array is a real structured phase count; a string falls through to the content-
+  // heading regex / Layer B below.
+  const phases = archPlan?.sections?.implementation_phases;
+  const structuredPhaseCount = Array.isArray(phases) ? phases.length : 0;
   const contentMatches = archPlan?.content
     ? archPlan.content.match(LAYER_B_HEADING_REGEX) || []
     : [];

--- a/tests/unit/auto-route-phase-count.test.js
+++ b/tests/unit/auto-route-phase-count.test.js
@@ -1,0 +1,54 @@
+/**
+ * QF-20260524-418 / feedback 0ee3c3b8: leo-create-sd auto-route must not count a
+ * prose-STRING `implementation_phases` as a structured phase count.
+ *
+ * `countArchPhases` did `implementation_phases?.length`; when that field is prose
+ * text, `.length` returns the CHARACTER count (e.g. 1140), which tripped
+ * hasMultipleStructured and falsely auto-routed a single feature SD to the
+ * orchestrator creator → an empty 0-child orchestrator shell.
+ */
+import { describe, it, expect } from 'vitest';
+import { countArchPhases, shouldAutoRouteToOrchestrator } from '../../scripts/modules/leo-create-sd/auto-route-decider.js';
+
+const route = (archPlan) => shouldAutoRouteToOrchestrator({
+  archPlan, brainstormSession: null, archKey: 'k', visionKey: 'v', title: 't', env: {},
+});
+
+describe('countArchPhases (0ee3c3b8)', () => {
+  it('counts a prose-string implementation_phases as 0 structured phases (not char length)', () => {
+    const archPlan = { sections: { implementation_phases: 'x'.repeat(1140) } };
+    expect(countArchPhases(archPlan).structuredPhaseCount).toBe(0);
+  });
+
+  it('counts array length when implementation_phases is an array', () => {
+    const archPlan = { sections: { implementation_phases: [{}, {}, {}] } };
+    expect(countArchPhases(archPlan).structuredPhaseCount).toBe(3);
+  });
+
+  it('returns 0 when implementation_phases is missing or archPlan is null', () => {
+    expect(countArchPhases({ sections: {} }).structuredPhaseCount).toBe(0);
+    expect(countArchPhases(null).structuredPhaseCount).toBe(0);
+  });
+});
+
+describe('shouldAutoRouteToOrchestrator (0ee3c3b8: no false orchestrator route from a prose string)', () => {
+  it('routes SINGLE when implementation_phases is prose and content has no phase headings', () => {
+    const archPlan = {
+      sections: { implementation_phases: 'x'.repeat(1140) },
+      content: 'A plan written as prose with no structured phase headings.',
+    };
+    const d = route(archPlan);
+    expect(d.telemetry.structured_phase_count).toBe(0);
+    expect(d.route).toBe('single');
+  });
+
+  it('still routes ORCHESTRATOR for a genuine array of >= 2 structured phases', () => {
+    const archPlan = {
+      sections: { implementation_phases: [{ name: 'Phase 1' }, { name: 'Phase 2' }] },
+      content: '',
+    };
+    const d = route(archPlan);
+    expect(d.telemetry.structured_phase_count).toBe(2);
+    expect(d.route).toBe('orchestrator');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260524-418

**Type:** bug
**Severity:** high

### Issue Description
auto-route-decider.js countArchPhases does archPlan.sections.implementation_phases?.length, but implementation_phases can be a PROSE STRING — so .length returns the char count (e.g. 1140), making hasMultipleStructured true and falsely auto-routing a single feature SD to the orchestrator creator, which then parses 0 real phases -> empty orchestrator shell (witnessed: SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001). Fix: Array.isArray guard so a string counts as 0 structured phases (content-regex/Layer-B then decides). Feedback 0ee3c3b8 Bug 1; Bug 2 (--target-repos on orchestrator path) deferred (needs create-orchestrator-from-plan.js flag support).

### Steps to Reproduce
Run leo-create-sd.js --vision-key X --arch-key Y where the arch plan stores implementation_phases as prose text.

### Expected Behavior
structured_phase_count reflects real phase count (0 for prose); single SD stays single unless content has >=2 phase headings.

### Actual Behavior
structured_phase_count=1140 (char length) -> false orchestrator route -> empty shell with 0 children.

### Changes
- **Files Changed:** 2
  - scripts/modules/leo-create-sd/auto-route-decider.js
  - tests/unit/auto-route-phase-count.test.js
- **LOC:** 69 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
auto-route-phase-count test 5/5 pass; revert-integrity proven (prose-string tests fail on revert). tsc clean. 0ee3c3b8 Bug 1 (Array.isArray guard); Bug 2 deferred.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol