### PR TITLE
feat(SD-S19-...-001-E): retire paste-prompt code; stage19 route serves readiness only

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -626,118 +626,11 @@ function generateTasksDoc(groups) {
   return lines.join('\n');
 }
 
-function generateAgentOptimizedReplitMd(ventureName, stitchManifest, { hasDesigns = true } = {}) {
-  // Pre-existing dead `stitchFileMap` + `stitchBuildStep` removed during cleanup
-  // (defined but never used; the inline `${stitchManifest ? ... : ''}` ternary in
-  // the table below renders the file map directly).
-
-  // SD-LEO-FEAT-VENTURE-GROUNDED-STAGE-001 (Concern C): only reference
-  // docs/designs/ when approved HTML designs were actually written. Autonomous-
-  // worker ventures have no stage_17_approved_desktop artifacts, so docs/designs/
-  // is empty — pointing the builder at it produces dangling references. When no
-  // designs exist, fall back to docs/wireframes.md.
-  const designFileMapRow = hasDesigns
-    ? '| **docs/designs/** | Approved HTML designs for each screen — pixel-perfect reference | **First** — open the relevant screen\'s HTML before building any UI |\n'
-    : '| **docs/wireframes.md** | Screen layouts with ASCII mockups — structural reference | **First** — read the relevant screen\'s layout before building any UI |\n';
-
-  const designBuildStep1 = hasDesigns
-    ? '1. **Open docs/designs/** and find the HTML file for the screen you\'re building — match it closely'
-    : '1. **Read docs/wireframes.md** and find the layout for the screen you\'re building — match its structure';
-
-  const designConsistencySection = hasDesigns
-    ? `## Design Consistency
-The approved HTML designs in docs/designs/ were generated independently per screen.
-There may be inconsistencies between them (e.g., one screen missing a sidebar that all
-others have, different header layouts, inconsistent navigation patterns). When you notice
-inconsistencies:
-- Identify the **majority pattern** across all screens (e.g., 5 of 6 screens have a sidebar)
-- Apply the majority pattern to ALL screens — normalize the shared layout elements
-- Shared elements to keep consistent: navigation/sidebar, header, footer, color usage, typography scale, spacing system
-- Screen-specific elements (hero sections, data tables, forms) should follow the individual design
-`
-    : `## Design Consistency
-No approved HTML designs were generated for this venture — build UI from the wireframe
-layouts in docs/wireframes.md. Keep shared layout elements (navigation/sidebar, header,
-footer, color usage, typography scale, spacing system) consistent across all screens.
-`;
-
-  const designKeyRule = hasDesigns
-    ? '- Do NOT deviate from the approved screen designs in docs/designs/ (except to normalize inconsistencies as described above)'
-    : '- Do NOT deviate from the screen layouts in docs/wireframes.md';
-
-  return `# ${ventureName}
-
-## File Map
-
-Read these files in order when starting a new feature:
-
-| File | Purpose | When to Read |
-|------|---------|-------------|
-${designFileMapRow}| **docs/color-palette.md** | Brand colors as CSS custom properties — copy into global CSS | **First** — import :root block before writing any styles |
-| **docs/spec.md** | Complete specification: problem, users, architecture, screens | Before writing any code |
-| **docs/tasks.md** | Pre-decomposed implementation steps with acceptance criteria | Pick your next task from here |
-| **docs/architecture.md** | Tech stack, data model, API surface | When implementing backend/database work |
-| **docs/branding.md** | Typography, personas, brand voice | When implementing any UI |
-| **docs/product-roadmap.md** | Feature priorities and MVP phasing | When deciding build order |
-
-## Build Workflow
-
-For each feature or task:
-${designBuildStep1}
-2. **Copy the CSS custom properties** from docs/color-palette.md into your global stylesheet (do this once)
-3. **Read docs/tasks.md** and pick the next uncompleted task
-4. **Read docs/spec.md** for the full context on that feature
-5. **Use docs/architecture.md** for data model and API patterns
-6. **Check off** the task's acceptance criteria when done
-
-## Coding Standards
-- TypeScript strict mode
-- Proper error handling on all API calls
-- Responsive design (mobile-first)
-- Semantic HTML with ARIA labels
-- Use environment variables for all secrets
-- Follow existing patterns in the codebase
-
-${designConsistencySection}
-## Key Rules
-- Do NOT invent features not in docs/tasks.md
-- Do NOT change the data model without checking docs/architecture.md
-- Do NOT use colors not in docs/color-palette.md — use the CSS custom properties
-${designKeyRule}
-- Complete one task fully before starting the next
-`;
-}
-
-export function generateInitialPrompt(ventureName, framework = 'Vite', { hasDesigns = true } = {}) {
-  // SD-LEO-FEAT-VENTURE-GROUNDED-STAGE-001 (Concern C): gate docs/designs/
-  // references on whether approved designs were actually written.
-  const designReadLine = hasDesigns
-    ? 'Read docs/designs/ to see the approved HTML designs for each screen.'
-    : 'Read docs/wireframes.md to see the layout for each screen.';
-  const layoutSourceRef = hasDesigns ? 'docs/designs/' : 'docs/wireframes.md';
-
-  return `Create a new ${framework} + TypeScript project called "${ventureName}".
-
-IMPORTANT: This repo already contains a docs/ folder with reference documents.
-Read docs/color-palette.md first and copy the CSS custom properties into your global stylesheet.
-${designReadLine}
-
-Setup:
-- ${framework} with TypeScript (strict mode)
-- Tailwind CSS for styling
-- React Router for navigation
-- A clean folder structure: src/components/, src/pages/, src/lib/
-- Import the brand colors from docs/color-palette.md as CSS custom properties
-
-Do NOT build any features yet. Just:
-1. Initialize the project with the tech stack above
-2. Copy the :root CSS custom properties from docs/color-palette.md into your global CSS
-3. Create a basic App.tsx with a router and navigation layout matching the majority pattern in ${layoutSourceRef}
-4. Add a simple home page that says "${ventureName}" with a subtitle using the brand colors
-5. Ensure the dev server runs without errors
-
-Then proceed to replit.md for the full build workflow.`;
-}
+// SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E: generateAgentOptimizedReplitMd +
+// generateInitialPrompt (the paste-into-Replit-Agent replit.md + scaffold-prompt
+// generators) were removed. Claude Code now builds from the seeded repo
+// (CLAUDE.md + docs/build-tasks.md, emitted in seedRepo()); there are no prompts to
+// paste and no fresh replit.md is seeded (CLAUDE.md supersedes it).
 
 // ── Build-into replit.md marker section (SD-LEO-FEAT-S19-BUILDS-INTO-001) ──
 // In build-into mode the repo IS the venture's design (e.g. a Lovable app) and
@@ -1245,73 +1138,14 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
     } else {
       docsCommitted.push('replit.md (preserved — repo shipped its own)');
     }
-  } else if (docFormat === 'agent-optimized') {
-    const replitMd = generateAgentOptimizedReplitMd(ventureName, stitchManifest, { hasDesigns: hasWrittenDesigns });
-    writeFileSync(replitMdPath, replitMd);
-    docsCommitted.push('replit.md (agent-optimized)');
   } else {
-  // Legacy replit.md
-  const stitchSection = stitchManifest ? `
-## High-Fidelity Design References
-
-Design artifacts generated by Google Stitch are in \`docs/stitch/\`:
-
-- **docs/stitch/DESIGN.md** — Design tokens (colors, typography, spacing, components)
-- **docs/stitch/screens/*.html** — Self-contained HTML screens for each page
-- **docs/stitch/screenshots/*.png** — PNG screenshots for visual acceptance criteria
-
-When building UI features:
-1. Read docs/stitch/DESIGN.md for design tokens (colors, fonts, spacing)
-2. Reference the HTML screen for the page you're building
-3. Match the layout, spacing, and visual hierarchy from the screenshots
-4. Fall back to docs/wireframes.md if a screen has no Stitch export
-` : '';
-
-  // Gate docs/designs references on whether designs were actually written.
-  const designsRefLine = hasWrittenDesigns
-    ? '- **docs/designs/*.html** — Approved HTML designs for each screen (pixel-perfect reference)\n'
-    : '';
-  const designsBuildStep = hasWrittenDesigns
-    ? '2. **Check docs/designs/ first** — these are approved HTML designs for each screen. Match them as closely as possible.\n'
-    : '2. **Check docs/wireframes.md** — these are the screen layouts. Match their structure as closely as possible.\n';
-
-  const replitMd = `# ${ventureName}
-
-This project was scaffolded by Replit and enriched with planning documents from EHG.
-
-## Reference Documents
-
-All planning artifacts are in the \`docs/\` folder:
-
-- **docs/branding.md** — Product name, color palette, typography, personas, brand voice
-- **docs/architecture.md** — Tech stack, data model, API contract, schema
-- **docs/wireframes.md** — All screen layouts with ASCII mockups
-- **docs/context.md** — Problem statement, value proposition, competitive landscape, roadmap
-- **docs/pricing.md** — Pricing model and tiers (if applicable)
-${designsRefLine}- **docs/product-roadmap.md** — Feature priorities and phases
-- **docs/gtm-strategy.md** — Marketing messaging and positioning
-- **docs/color-palette.md** — Brand colors as CSS custom properties
-${stitchSection}
-## Build Instructions
-
-When given a feature prompt, always:
-1. Read the relevant docs/ file referenced in the prompt
-${designsBuildStep}3. Use the CSS custom properties from docs/color-palette.md for all colors
-4. Follow the branding (typography, product name) from docs/branding.md
-5. Use the data model from docs/architecture.md for database operations
-6. Reference docs/product-roadmap.md for feature priority and phasing
-
-## Coding Standards
-- TypeScript strict mode
-- Proper error handling on all API calls
-- Responsive design (mobile-first)
-- Semantic HTML with ARIA labels
-- Use environment variables for all secrets
-`;
-
-  writeFileSync(replitMdPath, replitMd);
-  docsCommitted.push('replit.md');
-  } // end legacy format block
+    // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E: a fresh replit.md is no longer
+    // seeded. CLAUDE.md (committed by the Claude-Code-ready block below) is now the
+    // authoritative build context and supersedes the legacy Agent-oriented replit.md.
+    // An EXISTING replit.md (build-into repos that ship their own) is still preserved
+    // above with the EHG build-context marker appended.
+    docsCommitted.push('replit.md (not seeded — CLAUDE.md supersedes)');
+  }
 
   // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-B: emit the Claude-Code-ready repo
   // artifacts (CLAUDE.md + docs/build-tasks.md + minimal .replit) so a venture
@@ -1472,123 +1306,13 @@ ${designsBuildStep}3. Use the CSS custom properties from docs/color-palette.md f
 // ── Build Prompt Generator (References docs/) ──────
 
 /**
- * Generate build prompts that reference the seeded docs/ files.
- *
- * @param {string} ventureId
- * @returns {Promise<{initial: string, features: Array<{title: string, prompt: string}>}>}
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E: generateBuildPrompts +
+ * getWrittenDesignStems (the CLI-only build-prompt generators) were removed.
+ * Claude Code builds the features from the seeded repo via docs/build-tasks.md
+ * (emitted by seedRepo()), so per-feature paste prompts are no longer generated.
+ * The pure helpers resolveBuildScreens / buildFeaturePrompt / designFileStem
+ * remain (used by repo-readiness.js and the Claude-Code-ready seed block).
  */
-export async function generateBuildPrompts(ventureId) {
-  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-
-  const { data, error } = await supabase.rpc('export_blueprint_review', { p_venture_id: ventureId });
-  if (error) throw new Error(`export_blueprint_review failed: ${error.message}`);
-
-  const groups = data?.groups || [];
-  const { data: venture } = await supabase
-    .from('ventures').select('name').eq('id', ventureId).single();
-  const ventureName = venture?.name || 'Venture';
-
-  // Extract wireframe screens — PREFERRED: blueprint_wireframes (legacy export).
-  const archGroup = findGroup(groups, 'how_to_build_it');
-  const wfArt = archGroup?.artifacts?.find(a => a.artifact_type === 'blueprint_wireframes');
-  const blueprintWireframes = parseContent(wfArt?.content) || {};
-
-  // FALLBACK: S15 wireframe_screens artifact (new-pipeline ventures have no
-  // blueprint_wireframes). Only fetch when the preferred path yields no screens.
-  // SD-LEO-FEAT-VENTURE-GROUNDED-STAGE-001 (Concern C).
-  let wireframeScreensArtifact = null;
-  const hasBlueprintScreens =
-    (blueprintWireframes?.wireframes?.screens?.length || blueprintWireframes?.screens?.length || 0) > 0;
-  if (!hasBlueprintScreens) {
-    const { data: wsArt } = await supabase
-      .from('venture_artifacts')
-      .select('artifact_data')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', 'wireframe_screens')
-      .eq('lifecycle_stage', 15)
-      .eq('is_current', true)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    wireframeScreensArtifact = wsArt?.artifact_data || null;
-  }
-
-  const { screens } = resolveBuildScreens({ blueprintWireframes, wireframeScreensArtifact });
-
-  // Determine which docs/designs/<stem>.html files actually exist for this
-  // venture. They are only written when stage_17_approved_desktop artifacts are
-  // present (mirrors the docs/designs writer in seedRepo). Without this, build
-  // prompts emit dangling "see docs/designs/..." references for autonomous-
-  // worker ventures that never produced approved desktop designs.
-  const writtenDesignStems = await getWrittenDesignStems(supabase, ventureId);
-
-  const features = screens.map((screen, i) =>
-    buildFeaturePrompt({
-      screen,
-      index: i,
-      total: screens.length,
-      prevScreen: i > 0 ? screens[i - 1] : null,
-      writtenDesignStems,
-    })
-  );
-
-  return {
-    initial: generateInitialPrompt(ventureName, 'Vite', { hasDesigns: writtenDesignStems.size > 0 }),
-    features,
-  };
-}
-
-/**
- * Compute the set of docs/designs/<stem>.html filename stems that the seeder
- * WOULD write for a venture. Mirrors the docs/designs writer in seedRepo (~L770):
- * a design file is written for each stage_17_approved_desktop artifact whose
- * artifact_data.html is a string, named from the matching wireframe screen name
- * (or the artifact title / screenId fallback).
- *
- * @param {import('@supabase/supabase-js').SupabaseClient} supabase
- * @param {string} ventureId
- * @returns {Promise<Set<string>>} stems (from designFileStem) of written design files
- */
-async function getWrittenDesignStems(supabase, ventureId) {
-  const stems = new Set();
-  try {
-    const { data: approvedDesigns } = await supabase
-      .from('venture_artifacts')
-      .select('artifact_data, metadata, title')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', 'stage_17_approved_desktop')
-      .eq('is_current', true)
-      .order('created_at');
-
-    if (!approvedDesigns?.length) return stems;
-
-    // Screen-name map (screen id -> name), same source the writer uses.
-    const { data: wfArt } = await supabase
-      .from('venture_artifacts')
-      .select('artifact_data')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', 'wireframe_screens')
-      .eq('is_current', true)
-      .limit(1)
-      .maybeSingle();
-    const screenNames = new Map();
-    for (const s of (wfArt?.artifact_data?.screens || [])) {
-      if (s.id && (s.name || s.screen_name)) screenNames.set(s.id, s.name || s.screen_name);
-    }
-
-    for (const design of approvedDesigns) {
-      const html = design.artifact_data?.html;
-      if (!html || typeof html !== 'string') continue;
-      const screenId = design.metadata?.screenId || 'unknown';
-      const screenName = screenNames.get(screenId) || design.title?.replace(/\s*—.*$/, '') || screenId;
-      stems.add(designFileStem(screenName));
-    }
-  } catch {
-    // On any lookup error, return what we have — better to omit a design
-    // reference than to emit a dangling one.
-  }
-  return stems;
-}
 
 // CLI entry point
 const _isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
@@ -1603,20 +1327,11 @@ if (_isMain) {
 Replit Repo Seeder
 
 Commands:
-  seed <venture-id> <repo-url>     Clone repo, commit docs/, push
-  prompts <venture-id>             Generate build prompts (after seed)
-  initial <venture-name>           Generate initial blank-slate prompt
+  seed <venture-id> <repo-url>     Clone repo, commit docs/ + Claude-Code-ready files, push
 
 Examples:
   node lib/eva/bridge/replit-repo-seeder.js seed <id> https://github.com/user/repo.git
-  node lib/eva/bridge/replit-repo-seeder.js prompts <id>
-  node lib/eva/bridge/replit-repo-seeder.js initial "CronRead"
 `);
-    process.exit(0);
-  }
-
-  if (cmd === 'initial') {
-    console.log(generateInitialPrompt(ventureId || 'MyApp'));
     process.exit(0);
   }
 
@@ -1628,26 +1343,6 @@ Examples:
     seedRepo(ventureId, repoUrl).then(result => {
       console.log(JSON.stringify(result, null, 2));
       process.exit(result.success ? 0 : 1);
-    }).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
-  }
-
-  if (cmd === 'prompts') {
-    if (!ventureId) {
-      console.error('Usage: prompts <venture-id>');
-      process.exit(1);
-    }
-    generateBuildPrompts(ventureId).then(result => {
-      console.log('=== INITIAL PROMPT ===\n');
-      console.log(result.initial);
-      console.log('\n');
-      for (let i = 0; i < result.features.length; i++) {
-        console.log(`=== FEATURE ${i + 1}: ${result.features[i].title} ===\n`);
-        console.log(result.features[i].prompt);
-        console.log('\n');
-      }
     }).catch(err => {
       console.error('Error:', err.message);
       process.exit(1);

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -48,20 +48,18 @@ function validateRegistrationBody(body) {
 /**
  * GET /api/stage19/:ventureId/replit-prompts
  *
- * Returns the Plan Mode prompt and per-feature prompts for a venture, ready
- * to display in Stage 19's Replit workflow UI. Both formats are grounded in
- * the chairman-approved S18 marketing copy via the `Binding contract` block
- * (per the §0 Rule 7 round-trip refinement on 2026-04-28).
+ * Returns the Claude-Code-ready readiness summary for a venture's Stage 19 build.
+ * SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E retired the paste-into-Replit-Agent
+ * prompts payload (planPrompt + per-feature prompts): the ehg S19 UI (Child D) now
+ * consumes `readiness`, and Claude Code builds the features from the seeded repo
+ * (CLAUDE.md + docs/build-tasks.md) rather than from pasted prompts.
  *
  * Response shape:
  * {
  *   ventureName: string,
- *   planPrompt: string,
- *   featurePrompts: [{ title, content, points, priority }],
+ *   mode: string,
  *   warnings?: string[],
  *   generatedAt: string,
- *   // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C: additive Claude-Code-ready readiness
- *   // contract (consumed by the ehg S19 UI from Child D; prompts removed in Child E).
  *   readiness: { repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object },
  * }
  */
@@ -78,21 +76,15 @@ router.get('/:ventureId/replit-prompts', asyncHandler(async (req, res) => {
 
   try {
     const result = await formatReplitOptimized(ventureId, { scope, mode: modeHint });
-    // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C: additive Claude-Code-ready readiness
-    // contract for the cutover. Child D switches the ehg S19 UI to consume this; the
-    // prompts payload below stays until Child E. Best-effort — resolveRepoReadiness
-    // never throws, so a readiness failure can't break the load-bearing prompts response.
+    // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E: the paste-into-Replit-Agent prompts
+    // payload (planPrompt + featurePrompts) has been retired — the ehg S19 UI (Child D)
+    // consumes the readiness contract instead, and Claude Code builds from the seeded
+    // repo. The route now returns venture identity + readiness. resolveRepoReadiness
+    // never throws.
     const readiness = await resolveRepoReadiness(ventureId);
     return res.status(200).json({
       ventureName: result.manifest?.ventureName || 'Venture',
       mode: result.manifest?.mode || 'create-new',
-      planPrompt: result.planModePrompt?.content || '',
-      featurePrompts: (result.featurePrompts || []).map((fp) => ({
-        title: fp.title || fp.filename || 'Feature',
-        content: fp.content || '',
-        points: fp.storyPoints ?? 0,
-        priority: fp.priority || 'medium',
-      })),
       warnings: result.warnings || [],
       generatedAt: result.manifest?.exportedAt || new Date().toISOString(),
       readiness,

--- a/tests/integration/api-routes/stage19-endpoints.test.js
+++ b/tests/integration/api-routes/stage19-endpoints.test.js
@@ -229,9 +229,9 @@ describe('Stage 19 register-deployment endpoint', () => {
   });
 });
 
-// SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C — the GET route now ADDS a Claude-Code-ready
-// readiness summary alongside the (still load-bearing) prompts payload. These assert the
-// backward-compatible contract Child D consumes and Child E later trims.
+// SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E — the GET route now returns ONLY the
+// Claude-Code-ready readiness summary (+ venture identity); the paste-into-Replit-Agent
+// prompts payload (planPrompt/featurePrompts) was retired. These assert the trimmed contract.
 describe('Stage 19 GET /:ventureId/replit-prompts readiness contract', () => {
   const handlers = findRoute('get', '/:ventureId/replit-prompts');
 
@@ -257,26 +257,27 @@ describe('Stage 19 GET /:ventureId/replit-prompts readiness contract', () => {
     resolveRepoReadiness.mockResolvedValue(READINESS);
   });
 
-  it('TS-1: returns the existing prompts payload UNCHANGED plus a top-level readiness summary', async () => {
+  it('TS-1: returns readiness + venture identity, and NO prompts payload', async () => {
     const res = createMockRes();
     await runHandlerChain(handlers, getReq(VALID_UUID), res);
 
     expect(res.statusCode).toBe(200);
-    // Existing prompts contract — every key the live ehg S19 UI relies on today.
+    // Retained: the venture identity the ehg S19 UI reads.
     expect(res.jsonData).toEqual(expect.objectContaining({
       ventureName: 'Canvas AI',
       mode: 'build-into',
-      planPrompt: 'PLAN MODE PROMPT',
-      featurePrompts: [{ title: 'Dashboard', content: 'build dashboard', points: 3, priority: 'high' }],
       warnings: ['heads up'],
       generatedAt: '2026-05-24T00:00:00.000Z',
     }));
-    // Additive readiness contract (Child D consumes this).
+    // Readiness contract (consumed by the ehg S19 UI from Child D).
     expect(res.jsonData.readiness).toEqual(READINESS);
     expect(resolveRepoReadiness).toHaveBeenCalledWith(VALID_UUID);
+    // SD-...-E: the paste-into-Replit-Agent prompts payload is gone.
+    expect(res.jsonData).not.toHaveProperty('planPrompt');
+    expect(res.jsonData).not.toHaveProperty('featurePrompts');
   });
 
-  it('still returns the prompts payload when the repo is not ready (additive — never blocks prompts)', async () => {
+  it('returns readiness even when the repo is not ready (still no prompts payload)', async () => {
     resolveRepoReadiness.mockResolvedValue({
       repoReady: false,
       seededArtifacts: ['CLAUDE.md', 'docs/build-tasks.md', '.replit'],
@@ -285,9 +286,9 @@ describe('Stage 19 GET /:ventureId/replit-prompts readiness contract', () => {
     const res = createMockRes();
     await runHandlerChain(handlers, getReq(VALID_UUID), res);
     expect(res.statusCode).toBe(200);
-    expect(res.jsonData.planPrompt).toBe('PLAN MODE PROMPT'); // prompts still present
-    expect(res.jsonData.featurePrompts).toHaveLength(1);
     expect(res.jsonData.readiness.repoReady).toBe(false);
+    expect(res.jsonData).not.toHaveProperty('planPrompt');
+    expect(res.jsonData).not.toHaveProperty('featurePrompts');
   });
 
   it('rejects an invalid ventureId with 400 before resolving prompts or readiness', async () => {

--- a/tests/unit/eva/replit-repo-seeder.build-prompts.test.js
+++ b/tests/unit/eva/replit-repo-seeder.build-prompts.test.js
@@ -284,28 +284,29 @@ describe('seedRepo() — (d) preserves an existing replit.md', () => {
     expect(result.docsCommitted).toContain('replit.md (preserved — repo shipped its own)');
   });
 
-  it('DOES write a fresh replit.md when none exists', async () => {
+  // SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-E: a fresh replit.md is no longer seeded —
+  // CLAUDE.md (committed by the Claude-Code-ready block) supersedes the legacy Agent template.
+  it('does NOT write a fresh replit.md when none exists (CLAUDE.md supersedes)', async () => {
     replitMdAlreadyExists = false;
     const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
 
     const result = await seedRepo('v-fresh', 'https://github.com/foo/bar.git');
 
     const replitWrites = writeCalls.filter(w => w.path.endsWith('replit.md'));
-    expect(replitWrites).toHaveLength(1); // written once
-    expect(result.docsCommitted).toContain('replit.md (agent-optimized)');
+    expect(replitWrites).toHaveLength(0); // no fresh replit.md is generated
+    expect(result.docsCommitted).toContain('replit.md (not seeded — CLAUDE.md supersedes)');
   });
 
-  it('the fresh agent-optimized replit.md does not reference docs/designs when no designs were written', async () => {
+  it('seeds the Claude-Code-ready docs/build-tasks.md (and no fresh replit.md)', async () => {
     replitMdAlreadyExists = false;
     const { seedRepo } = await import('../../../lib/eva/bridge/replit-repo-seeder.js');
 
-    await seedRepo('v-nodesigns', 'https://github.com/foo/bar.git');
+    const result = await seedRepo('v-ccready', 'https://github.com/foo/bar.git');
 
-    const replitWrite = writeCalls.find(w => w.path.endsWith('replit.md'));
-    expect(replitWrite).toBeDefined();
-    // No stage_17_approved_desktop artifacts in the mock → docs/designs/ empty →
-    // template must fall back to docs/wireframes.md.
-    expect(replitWrite.content).not.toContain('docs/designs/');
-    expect(replitWrite.content).toContain('docs/wireframes.md');
+    // docs/build-tasks.md is always (re)written by the Claude-Code-ready block.
+    expect(writeCalls.filter(w => w.path.endsWith('build-tasks.md')).length).toBeGreaterThanOrEqual(1);
+    expect(result.docsCommitted).toContain('docs/build-tasks.md');
+    // No legacy replit.md was generated.
+    expect(writeCalls.filter(w => w.path.endsWith('replit.md'))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Child E (final) — retire the paste-into-Replit-Agent code

Last child of **SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001**. Children A (writers), B (seedRepo wiring), C (backend readiness contract), and D (ehg UI cutover) are all merged. This removes the now-dead legacy path.

### What changed
- **Route** (`server/routes/stage19.js`): `GET /:ventureId/replit-prompts` no longer returns `planPrompt`/`featurePrompts`. It returns `ventureName`, `mode`, `warnings`, `generatedAt`, and the **`readiness`** summary — which the ehg S19 UI (Child D) consumes. Claude Code builds the features from the seeded repo (`docs/build-tasks.md`), not pasted prompts.
- **Seeder** (`lib/eva/bridge/replit-repo-seeder.js`): deleted `generateAgentOptimizedReplitMd`, `generateInitialPrompt`, `generateBuildPrompts`, `getWrittenDesignStems`; removed the two fresh-`replit.md` write branches (a create-new venture no longer gets a `replit.md` — **CLAUDE.md supersedes it**) while **keeping** the build-into preserve + EHG build-context marker append; dropped the CLI `initial`/`prompts` commands. Kept the tested pure helpers `resolveBuildScreens`/`buildFeaturePrompt`/`designFileStem` (used by `repo-readiness.js` + the Claude-Code-ready seed block). Net seeder **+19 / −324**.

### Tests
- Route-contract: asserts no `planPrompt`/`featurePrompts` + `readiness` present.
- Seeder: asserts no fresh `replit.md` (`docsCommitted` records `'replit.md (not seeded — CLAUDE.md supersedes)'`) + `docs/build-tasks.md` still seeded + the existing-`replit.md` preserve path kept.
- **38/38 green**, `node --check` OK, eslint clean. TESTING sub-agent PASS (92).

### Note
FR-4 (live throwaway-repo run) is covered at the integration layer (mocked git/fs); a live private-GitHub seed run is deferred (needs `delete_repo` scope), per the SD-LEO-FEAT-S19-BUILDS-INTO-001 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
