### PR TITLE
fix(QF-20260524-272): scope-creep recognizes topic-named test files as in-scope

### DIFF
--- a/lib/quickfix-self-verifier.js
+++ b/lib/quickfix-self-verifier.js
@@ -246,6 +246,31 @@ function coveredBaseName(file) {
   return leaf.replace(/\.(test|spec)\.[^.]+$/i, '').replace(/\.[^.]+$/, '');
 }
 
+// QF-20260524-272 / feedback f5577d22: a test is frequently named after the BUG
+// TOPIC (e.g. `auto-route-phase-count.test.js`) rather than the production file it
+// exercises (`auto-route-decider.js`), so the exact base-name match (above) misses
+// it and the cohesive prod+test pair false-flags as scope creep. Relate a test to
+// in-scope work by a shared TOPIC token or directory segment too. Generic structural
+// tokens are excluded so a genuinely unrelated test still flags (CONTROL tests).
+const GENERIC_PATH_TOKENS = new Set([
+  'test', 'tests', 'spec', 'specs', 'unit', 'e2e', 'src', 'lib', 'libs',
+  'scripts', 'script', 'modules', 'module', 'components', 'component',
+  'index', 'utils', 'util', 'main', 'json', 'tsx', 'jsx'
+]);
+function topicTokens(nameOrPath) {
+  return (nameOrPath || '')
+    .toLowerCase()
+    .split(/[/\\\-_.]+/)
+    .filter(t => t.length >= 4 && !GENERIC_PATH_TOKENS.has(t));
+}
+function dirSegments(file) {
+  const parts = (file || '').split(/[/\\]/);
+  parts.pop(); // drop the leaf file name
+  return parts
+    .map(seg => seg.toLowerCase())
+    .filter(seg => seg.length >= 4 && !GENERIC_PATH_TOKENS.has(seg));
+}
+
 export async function detectScopeCreep(qf, context) {
   const filesChanged = context.filesChanged || [];
 
@@ -263,20 +288,35 @@ export async function detectScopeCreep(qf, context) {
   const issueDescription = `${qf.title} ${qf.description}`.toLowerCase();
   const mentionedFiles = issueDescription.match(/[a-zA-Z0-9_-]+\.(tsx?|jsx?|js|css|sql)/g) || [];
 
-  // QF-20260524-488 / feedback e0cf303f: a changed test file is in-scope when the
-  // production base name it covers matches a changed non-test file or a mentioned
-  // file — a cohesive prod+test pair is not scope creep. Genuinely unrelated files
-  // (including a test for an unrelated module) are still flagged.
-  const changedProdBases = new Set(
-    filesChanged.filter(f => !TEST_PATH_RE.test(f)).map(coveredBaseName)
-  );
+  // QF-20260524-488 / feedback e0cf303f + QF-20260524-272 / feedback f5577d22: a
+  // changed test file is in-scope when (a) the production base name it covers matches
+  // a changed non-test file or a mentioned file, OR (b) it shares a topic token or
+  // directory segment with the changed-production / mentioned set. A cohesive
+  // prod+test pair is not scope creep; genuinely unrelated files (including a test for
+  // an unrelated module) are still flagged. Production-file detection stays strict.
+  const prodFiles = filesChanged.filter(f => !TEST_PATH_RE.test(f));
+  const changedProdBases = new Set(prodFiles.map(coveredBaseName));
   const mentionedBases = new Set(mentionedFiles.map(coveredBaseName));
+  // Topic pool: tokens from in-scope production + explicitly-mentioned file names.
+  const topicPool = new Set();
+  for (const base of [...changedProdBases, ...mentionedBases]) {
+    for (const t of topicTokens(base)) topicPool.add(t);
+  }
+  // Directory pool: meaningful directory segments of changed production files.
+  const dirPool = new Set();
+  for (const f of prodFiles) {
+    for (const seg of dirSegments(f)) dirPool.add(seg);
+  }
+  const testIsInScope = (file) => {
+    const base = coveredBaseName(file);
+    if (changedProdBases.has(base) || mentionedBases.has(base)) return true; // sibling base name
+    if (topicTokens(base).some(t => topicPool.has(t))) return true;          // shared topic token
+    if (dirSegments(file).some(seg => dirPool.has(seg))) return true;        // shared topic directory
+    return false;
+  };
   const unrelatedFiles = filesChanged.filter(file => {
     if (mentionedFiles.some(mentioned => file.includes(mentioned))) return false;
-    if (TEST_PATH_RE.test(file)) {
-      const base = coveredBaseName(file);
-      if (changedProdBases.has(base) || mentionedBases.has(base)) return false;
-    }
+    if (TEST_PATH_RE.test(file) && testIsInScope(file)) return false;
     return true;
   });
 

--- a/tests/quickfix-self-verifier-scope-creep.test.js
+++ b/tests/quickfix-self-verifier-scope-creep.test.js
@@ -47,3 +47,85 @@ describe('detectScopeCreep — prod+test pairing (e0cf303f)', () => {
     expect(r.passed).toBe(false);
   });
 });
+
+/**
+ * Regression tests for QF-20260524-272 / feedback f5577d22.
+ *
+ * The e0cf303f fix only matched EXACT sibling base names, so a test named after the
+ * bug TOPIC (e.g. `auto-route-phase-count.test.js`) rather than the production file it
+ * covers (`auto-route-decider.js`) still false-flagged the cohesive pair as scope
+ * creep. detectScopeCreep now also relates a test by a shared topic token or directory
+ * segment — while a genuinely unrelated test (CONTROL) still flags, and production
+ * files keep strict detection.
+ */
+describe('detectScopeCreep — topic / directory relatedness (f5577d22)', () => {
+  it('passes a topic-named test that shares a token with the changed prod file (QF-418)', async () => {
+    const r = await detectScopeCreep(
+      qf('auto-route counts prose-string char length', 'Array.isArray guard in auto-route-decider.js'),
+      {
+        filesChanged: [
+          'scripts/modules/leo-create-sd/auto-route-decider.js',
+          'tests/unit/auto-route-phase-count.test.js'
+        ]
+      }
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('passes a test in a directory mirroring the changed prod module (QF-057-style)', async () => {
+    const r = await detectScopeCreep(
+      qf('complete-quick-fix LOC misreport', 'split LOC in git-operations.js'),
+      {
+        filesChanged: [
+          'scripts/modules/complete-quick-fix/git-operations.js',
+          'tests/unit/complete-quick-fix/loc-cap-accuracy.test.js'
+        ]
+      }
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('recognizes the topic-test as in-scope even when prod files legitimately flag (QF-337)', async () => {
+    // The description names precompact-unified.js (dead code per RCA); the fix touched
+    // different prod files, so THOSE still flag — but the topic-named test must not.
+    const r = await detectScopeCreep(
+      qf('PreCompact hook wipes protocol-read tracking', 'precompact-unified.js is dead; fix the wired precompact-snapshot hook'),
+      {
+        filesChanged: [
+          'lib/context/unified-state-manager.js',
+          'scripts/hooks/precompact-snapshot.ps1',
+          'tests/unit/precompact-protocol-read-preservation.test.js'
+        ]
+      }
+    );
+    expect(r.passed).toBe(false); // prod files (description-named-wrong-file) still flag
+    expect(r.details || '').not.toContain('precompact-protocol-read-preservation.test.js');
+  });
+
+  it('still FLAGS a genuinely unrelated test — no shared token or directory (CONTROL)', async () => {
+    const r = await detectScopeCreep(
+      qf('fix login button onClick', 'login-handler.js does not bind onClick'),
+      {
+        filesChanged: [
+          'scripts/foo/login-handler.js',
+          'tests/unit/database/payment-ledger.test.js'
+        ]
+      }
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details || '').toContain('payment-ledger.test.js');
+  });
+
+  it('does NOT relate two unrelated files via the shared generic tests/unit directory (CONTROL)', async () => {
+    const r = await detectScopeCreep(
+      qf('fix alpha-service', 'patch alpha-service.js'),
+      {
+        filesChanged: [
+          'src/svc/alpha-service.js',
+          'tests/unit/beta-widget.test.js'
+        ]
+      }
+    );
+    expect(r.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260524-272

**Type:** bug · **Severity:** medium · **Tier:** 2 · **Target:** EHG_Engineer

### Problem
`lib/quickfix-self-verifier.js` `detectScopeCreep` flagged a cohesive prod+test quick-fix as scope creep ("Possible scope creep - changed unrelated files", confidence→70%) when the test file was named after the bug **topic** (e.g. `auto-route-phase-count.test.js`) rather than the production basename (`auto-route-decider.js`). Witnessed repeatedly in session s4 (QF-418, QF-337). The QF-488/e0cf303f fix only matched **exact sibling base names**, so topic-named tests still false-flagged → forced `--force-complete` (over-bypass of all gates).

### Fix
Extend test-file relatedness so a changed test is in-scope when it shares a **topic token** OR a **directory segment** with a changed production file / mentioned file — not only the exact sibling base name. Generic structural tokens (`test`, `unit`, `lib`, `scripts`, `modules`, …) are excluded so genuinely unrelated tests still flag. **Production-file detection is left strict** (the gate's primary value) to avoid false-negatives.

### Tests (`tests/quickfix-self-verifier-scope-creep.test.js`, 9/9 pass)
- Cohesive: topic-token (QF-418), directory-mirror (QF-057-style), and topic-test-in-scope-while-prod-flags (QF-337).
- CONTROL (false-negative guards): genuinely unrelated test still flags; shared generic `tests/unit/` dir does not rescue.
- Integrity proven by revert+rerun: with the new relatedness disabled, exactly the 3 cohesive cases regress to failing.

Closes feedback f5577d22-0797-41d5-9c13-9ed7f6b2a45c

🤖 Generated with [Claude Code](https://claude.com/claude-code)