### PR TITLE
feat(SD-FDBK-ENH-SOURCE-LOC-CAP-001): --over-cap-reason granular LOC-cap bypass

### DIFF
--- a/lib/quickfix-self-verifier.js
+++ b/lib/quickfix-self-verifier.js
@@ -192,7 +192,7 @@ import { QF_HARD_LOC_CAP } from '../scripts/modules/complete-quick-fix/verificat
  * matching the policy already used by scripts/modules/complete-quick-fix/verification.js.
  * Falls back to combined actualLoc only when no source/test split is available.
  */
-async function verifyLOCConstraint(qf, context) {
+export async function verifyLOCConstraint(qf, context) {
   const sourceLoc = context.actualSourceLoc ?? qf.actual_source_loc ?? null;
   const testLoc = context.actualTestLoc ?? qf.actual_test_loc ?? null;
   const actualLoc = context.actualLoc || qf.actual_loc;
@@ -207,6 +207,19 @@ async function verifyLOCConstraint(qf, context) {
       message: 'Source LOC not measured',
       issue: 'Cannot verify LOC constraint - source LOC not provided',
       details: 'Run git diff to measure source-only lines changed'
+    };
+  }
+
+  // SD-FDBK-ENH-SOURCE-LOC-CAP-001: --over-cap-reason demotes the over-cap result from
+  // a self-verification BLOCKER to a non-blocking warning. This is the source-LOC cap
+  // ONLY — the scope-creep (Check 2), test-coverage (Check 3), and other checks still
+  // enforce normally. The orchestrator threads context.overCapReason alongside the
+  // validateLOC flag so a single --over-cap-reason clears BOTH enforcement points.
+  if (measured > QF_HARD_LOC_CAP && context.overCapReason) {
+    return {
+      passed: true,
+      message: `${label} (${measured}) exceeds limit (${QF_HARD_LOC_CAP}) — bypassed via --over-cap-reason${suffix}`,
+      details: `Over-cap bypass authorized: "${context.overCapReason}". Source-LOC cap only; tests/compliance/scope-creep gates still enforce.`
     };
   }
 

--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -83,6 +83,8 @@ export function parseArguments(args) {
       'verification-notes': { type: 'string' },
       'force-complete':     { type: 'boolean' },
       'reason':             { type: 'string' },
+      // SD-FDBK-ENH-SOURCE-LOC-CAP-001: bypass ONLY the source-LOC cap (not tests/compliance/self-verify)
+      'over-cap-reason':    { type: 'string' },
       'non-interactive':    { type: 'boolean' },
       'auto-pr':            { type: 'boolean' },
       // QF-20260511-258: bypass resolver-freshness stale-branch guard. Requires reason.
@@ -118,6 +120,16 @@ export function parseArguments(args) {
     );
   }
 
+  // SD-FDBK-ENH-SOURCE-LOC-CAP-001: --over-cap-reason requires a non-empty justification.
+  // It bypasses ONLY the source-LOC cap (validateLOC + self-verifier Check 1), NOT the
+  // failing-tests / compliance / scope-creep gates, and is recorded in verification_notes.
+  if (values['over-cap-reason'] !== undefined && !String(values['over-cap-reason']).trim()) {
+    throw new Error(
+      '[OVER_CAP_REASON_REQUIRED] --over-cap-reason requires a non-empty "<text>" justification. ' +
+      'It bypasses ONLY the source-LOC cap (not tests/compliance/self-verification) and is recorded in verification_notes.'
+    );
+  }
+
   // FR-3: persist --non-interactive so prompt() can fail-fast
   if (values['non-interactive']) {
     _nonInteractiveMode = true;
@@ -137,6 +149,7 @@ export function parseArguments(args) {
     verificationNotes: values['verification-notes'],
     forceComplete:     values['force-complete']   || false,
     reason:            values['reason'],
+    overCapReason:     values['over-cap-reason']   || undefined,
     nonInteractive:    values['non-interactive'] || false,
     // QF-20260509-407: --auto-pr opt-in flag, plus auto-enable under --non-interactive
     // when no --pr-url provided. Eliminates the mid-run prompt-then-throw pattern

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -157,7 +157,8 @@ export async function completeQuickFix(qfId, options = {}) {
   // LOC validation — source-only cap; --force-complete bypasses
   const locValid = await validateLOC(actualSourceLoc, actualTestLoc, qfId, supabase, prompt, {
     forceComplete: options.forceComplete,
-    reason: options.reason
+    reason: options.reason,
+    overCapReason: options.overCapReason
   });
   if (!locValid) {
     process.exit(1);
@@ -294,7 +295,10 @@ export async function completeQuickFix(qfId, options = {}) {
     uatVerified,
     testsVerifiedRecently: true,
     diffAnalysis,
-    testCoverage
+    testCoverage,
+    // SD-FDBK-ENH-SOURCE-LOC-CAP-001: thread the LOC-only bypass to verifyLOCConstraint
+    // (Check 1) so a single --over-cap-reason clears BOTH enforcement points together.
+    overCapReason: options.overCapReason
   };
 
   const verificationResults = await runSelfVerification(qfId, verificationContext);
@@ -359,6 +363,16 @@ export async function completeQuickFix(qfId, options = {}) {
     finalVerificationNotes = JSON.stringify({
       force_completed: true,
       reason: options.reason,
+      operator: process.env.CLAUDE_SESSION_ID || 'unknown',
+      timestamp: new Date().toISOString(),
+      operator_supplied_notes: verificationNotes || null
+    });
+  } else if (options.overCapReason) {
+    // SD-FDBK-ENH-SOURCE-LOC-CAP-001: audit-trail the LOC-only bypass. Distinct from
+    // force_completed — this records ONLY a source-LOC-cap waiver; all other gates ran.
+    finalVerificationNotes = JSON.stringify({
+      over_cap_reason: options.overCapReason,
+      over_cap_source_loc: actualSourceLoc,
       operator: process.env.CLAUDE_SESSION_ID || 'unknown',
       timestamp: new Date().toISOString(),
       operator_supplied_notes: verificationNotes || null

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -36,6 +36,14 @@ export async function validateLOC(sourceLoc, testLoc, qfId, supabase, prompt, fl
     return true;
   }
 
+  // SD-FDBK-ENH-SOURCE-LOC-CAP-001: --over-cap-reason bypasses ONLY the source-LOC cap
+  // (audit trail in verification_notes). Unlike --force-complete it does NOT touch the
+  // failing-tests, compliance, or self-verification (scope-creep) gates.
+  if (flags.overCapReason && sourceLoc > QF_HARD_LOC_CAP) {
+    console.log(`\n⚠️  --over-cap-reason: source-LOC cap bypassed (source=${sourceLoc}, test=${testLoc}, cap=${QF_HARD_LOC_CAP}, reason="${flags.overCapReason}")`);
+    return true;
+  }
+
   if (sourceLoc <= QF_HARD_LOC_CAP) {
     return true;
   }

--- a/tests/unit/complete-quick-fix/over-cap-reason.test.js
+++ b/tests/unit/complete-quick-fix/over-cap-reason.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-FDBK-ENH-SOURCE-LOC-CAP-001 — --over-cap-reason granular LOC-cap bypass.
+ *
+ * Proves the flag bypasses ONLY the source-LOC cap, at BOTH enforcement points
+ * (validateLOC in verification.js AND verifyLOCConstraint Check 1 in the self-verifier),
+ * while the failing-tests, compliance, and scope-creep gates STILL enforce. The
+ * two-enforcement-point coverage matters: session s4 proved a validateLOC-only bypass
+ * was insufficient because verifyLOCConstraint independently re-blocks.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateLOC,
+  validateTests,
+  validateCompliance,
+  QF_HARD_LOC_CAP
+} from '../../../scripts/modules/complete-quick-fix/verification.js';
+import { verifyLOCConstraint, detectScopeCreep } from '../../../lib/quickfix-self-verifier.js';
+import { parseArguments } from '../../../scripts/modules/complete-quick-fix/cli.js';
+
+const noPrompt = async () => 'no';      // declines escalation / proceed prompts
+const OVER = QF_HARD_LOC_CAP + 50;      // safely over the cap
+
+describe('--over-cap-reason — CLI parsing (FR-1)', () => {
+  it('parses a non-empty reason into options.overCapReason', () => {
+    const { options } = parseArguments(['QF-X', '--over-cap-reason', 'docstring-heavy infra fix']);
+    expect(options.overCapReason).toBe('docstring-heavy infra fix');
+  });
+
+  it('throws [OVER_CAP_REASON_REQUIRED] on an empty/whitespace reason', () => {
+    expect(() => parseArguments(['QF-X', '--over-cap-reason', '   '])).toThrow(/OVER_CAP_REASON_REQUIRED/);
+  });
+
+  it('leaves overCapReason undefined when the flag is absent', () => {
+    const { options } = parseArguments(['QF-X', '--actual-source-loc', '10']);
+    expect(options.overCapReason).toBeUndefined();
+  });
+});
+
+describe('--over-cap-reason — validateLOC bypass (FR-2)', () => {
+  it('bypasses the source-LOC cap when overCapReason is set and over cap', async () => {
+    const r = await validateLOC(OVER, 0, 'QF-X', null, noPrompt, { overCapReason: 'justified' });
+    expect(r).toBe(true);
+  });
+
+  it('still follows the escalation path (blocks) when over cap WITHOUT the flag', async () => {
+    const r = await validateLOC(OVER, 0, 'QF-X', null, noPrompt, {});
+    expect(r).toBe(false);
+  });
+
+  it('does not change within-cap behavior', async () => {
+    const r = await validateLOC(10, 0, 'QF-X', null, noPrompt, {});
+    expect(r).toBe(true);
+  });
+});
+
+describe('--over-cap-reason — verifyLOCConstraint demote (FR-3)', () => {
+  it('demotes over-cap from a BLOCKER to a non-blocking warning when overCapReason is set', async () => {
+    const r = await verifyLOCConstraint({ actual_source_loc: OVER }, { actualSourceLoc: OVER, overCapReason: 'justified' });
+    expect(r.passed).toBe(true);
+    expect(r.message).toMatch(/over-cap-reason/i);
+  });
+
+  it('still BLOCKS over-cap WITHOUT the flag (unchanged behavior)', async () => {
+    const r = await verifyLOCConstraint({ actual_source_loc: OVER }, { actualSourceLoc: OVER });
+    expect(r.passed).toBe(false);
+  });
+
+  it('does not affect a within-cap source LOC', async () => {
+    const r = await verifyLOCConstraint({ actual_source_loc: 10 }, { actualSourceLoc: 10, overCapReason: 'irrelevant' });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('--over-cap-reason — bypass is LOC-only, other gates STILL enforce (FR-6)', () => {
+  it('validateTests still blocks failing tests even with overCapReason in flags', () => {
+    const r = validateTests({ passed: false }, { passed: false }, false, { overCapReason: 'justified' });
+    expect(r).toBe(false);
+  });
+
+  it('validateCompliance still blocks a FAIL verdict even with overCapReason in flags', async () => {
+    const r = await validateCompliance(
+      { verdict: 'FAIL', totalScore: 40, confidence: 40, criteriaResults: [] },
+      noPrompt,
+      { overCapReason: 'justified' }
+    );
+    expect(r).toBe(false);
+  });
+
+  it('detectScopeCreep still flags genuine scope creep (overCapReason in context is ignored by it)', async () => {
+    const r = await detectScopeCreep(
+      { title: 'fix login button', description: 'login-handler.js does not bind onClick' },
+      {
+        filesChanged: ['scripts/foo/login-handler.js', 'tests/unit/database/payment-ledger.test.js'],
+        overCapReason: 'justified'
+      }
+    );
+    expect(r.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-SOURCE-LOC-CAP-001 (infrastructure)

### Problem
The QF source-LOC hard cap (75) is enforced at **two** independent points — `validateLOC` (verification.js) and `verifyLOCConstraint` Check 1 (lib/quickfix-self-verifier.js, a self-verification BLOCKER). The cap counts raw `git diff --numstat` added lines, so a docstring-heavy infra QF can exceed it despite low complexity. The only escape today is `--force-complete`, which bypasses **all** gates (tests, compliance, scope-creep, self-verify) and burns a bypass-quota slot.

### Fix
A new `--over-cap-reason "<text>"` flag bypasses **only** the source-LOC cap, at **both** enforcement points, with an audit trail in `quick_fixes.verification_notes`. Every other gate keeps enforcing.

| File | Change |
|------|--------|
| `cli.js` | `--over-cap-reason` flag + non-empty `[OVER_CAP_REASON_REQUIRED]` guard |
| `verification.js` `validateLOC` | LOC-only bypass branch (audit log), only when over cap |
| `lib/quickfix-self-verifier.js` `verifyLOCConstraint` | demote over-cap BLOCKER → non-blocking warning (now exported) |
| `orchestrator.js` | thread `overCapReason` into **both** the validateLOC flags AND the self-verification context; persist audit trail |

### Why both points (s4 lesson)
Session s4 proved a `validateLOC`-only bypass is insufficient — `verifyLOCConstraint` independently re-blocks. A single `--over-cap-reason` now clears both.

### Tests — 12/12 (`tests/unit/complete-quick-fix/over-cap-reason.test.js`)
- FR-1 CLI parse (incl. empty-reason rejection); FR-2 validateLOC bypass (both directions + within-cap); FR-3 verifyLOCConstraint demote (both directions); FR-6 gate-integrity: failing-tests, compliance FAIL, and scope-creep **still block** under the flag.
- Integrity proven by revert+rerun: disabling both branches fails **exactly** the 2 bypass tests; the 10 others (incl. "still blocks without flag") pass.

Closes feedback ae9d4809-414b-4b3b-9508-d78845148a5f

🤖 Generated with [Claude Code](https://claude.com/claude-code)