### PR TITLE
fix(QF-20260524-566): forward + handle --target-repos on the orchestrator auto-route path

### DIFF
--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -21,12 +21,22 @@ import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import { inheritStrategicFields, inferSDType } from './modules/child-sd-template.js';
 import { generateTraceableMetrics, mapDimensionsToPhases } from './modules/vision-arch-traceability.js';
-import { scoreSDAtConception } from './leo-create-sd.js';
+import { scoreSDAtConception, parseTargetReposArg } from './leo-create-sd.js';
 
 dotenv.config();
 
 // QF-20260409-561 (P0): DB-authoritative sd_type list (mirrors sd_type_check constraint).
 const DB_VALID_SD_TYPES = ['feature','implementation','infrastructure','bugfix','refactor','documentation','orchestrator','database','security','performance','enhancement','docs','discovery_spike','ux_debt','uat'];
+
+// QF-20260524-566 / feedback 0ee3c3b8 Bug 2: persist metadata.target_repos[] onto the
+// orchestrator SD and its auto-created children for cross-repo orchestrators, so
+// PR_MERGE_VERIFICATION (computeReposForSD) scopes correctly at LEAD-FINAL. No-op when
+// targetRepos is null/empty (single-repo orchestrators are unchanged). Pure + exported.
+export function withTargetRepos(metadata, targetRepos) {
+  return Array.isArray(targetRepos) && targetRepos.length > 0
+    ? { ...metadata, target_repos: targetRepos }
+    : metadata;
+}
 
 /**
  * C1 (SD-LEO-INFRA-LEO-UPSTREAM-DECISION-001): VERTICAL-SLICE CHECK
@@ -163,6 +173,8 @@ async function main() {
   const title = getArg('--title');
   const autoChildren = args.includes('--auto-children');
   const dryRun = args.includes('--dry-run');
+  // QF-20260524-566 / feedback 0ee3c3b8 Bug 2: forwarded from leo-create-sd.js auto-route.
+  const targetRepos = parseTargetReposArg(getArg('--target-repos'));
 
   if (!visionKey && !archKey) {
     console.error('Error: At least one of --vision-key or --arch-key is required');
@@ -293,13 +305,13 @@ async function main() {
     dependencies: [],
     risks: [],
     stakeholders: [],
-    metadata: {
+    metadata: withTargetRepos({
       is_orchestrator: true,
       vision_key: visionKey,
       arch_key: archKey,
       auto_generated: true,
       child_count: phases.length
-    },
+    }, targetRepos),
     key_changes: phases.map(p => `Phase ${p.number}: ${p.title}`),
     target_application: 'EHG_Engineer',
     created_at: new Date().toISOString(),
@@ -411,7 +423,7 @@ async function main() {
         target_application: 'EHG_Engineer',
         non_vertical: sliceCheck.non_vertical,
         non_vertical_justification: sliceCheck.justification,
-        metadata: {
+        metadata: withTargetRepos({
           vision_key: visionKey,
           arch_key: archKey,
           phase_number: phase.number,
@@ -423,7 +435,7 @@ async function main() {
             justification: sliceCheck.justification,
             detector_version: 'C1-v1-heuristic'
           }
-        },
+        }, targetRepos),
         key_changes: [phase.title],
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -108,6 +108,20 @@ export function parseTargetReposArg(raw) {
   return normalized;
 }
 
+/**
+ * Build the create-orchestrator-from-plan.js exec command for the auto-route path,
+ * forwarding --target-repos for cross-repo orchestrator SDs (QF-20260524-566 /
+ * feedback 0ee3c3b8 Bug 2). Pure + exported for unit testing. `targetRepos` is the
+ * normalized array from parseTargetReposArg (or null for single-repo SDs).
+ */
+export function buildOrchestratorCmd({ visionKey, archKey, title, targetRepos } = {}) {
+  let cmd = `node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children`;
+  if (Array.isArray(targetRepos) && targetRepos.length > 0) {
+    cmd += ` --target-repos ${targetRepos.join(',')}`;
+  }
+  return cmd;
+}
+
 // ============================================================================
 // Venture Context Resolution (SD-LEO-INFRA-SD-NAMESPACING-001)
 // ============================================================================
@@ -2353,7 +2367,9 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           console.log(`\n🔄 Auto-routing to orchestrator creator (${decision.telemetry.structured_phase_count || decision.telemetry.content_phase_count} phases detected)...`);
           try {
             const { execSync } = await import('child_process');
-            const cmd = `node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children`;
+            // QF-20260524-566 / feedback 0ee3c3b8 Bug 2: forward --target-repos so the
+            // orchestrator + auto-created children inherit metadata.target_repos.
+            const cmd = buildOrchestratorCmd({ visionKey, archKey, title, targetRepos });
             execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
             process.exit(0);
           } catch (execErr) {

--- a/tests/unit/orchestrator-target-repos.test.js
+++ b/tests/unit/orchestrator-target-repos.test.js
@@ -1,0 +1,59 @@
+/**
+ * QF-20260524-566 / feedback 0ee3c3b8 Bug 2.
+ *
+ * leo-create-sd.js auto-routes to create-orchestrator-from-plan.js but dropped
+ * --target-repos, and that script had no handling — so cross-repo orchestrator SDs
+ * (and their auto-created children) never got metadata.target_repos, breaking
+ * PR_MERGE_VERIFICATION repo-scoping at LEAD-FINAL.
+ *
+ * - buildOrchestratorCmd (leo-create-sd.js) forwards --target-repos into the exec.
+ * - withTargetRepos (create-orchestrator-from-plan.js) persists target_repos onto the
+ *   orchestrator + child SD metadata. Both are no-ops when targetRepos is null/empty,
+ *   so single-repo orchestrators are byte-for-byte unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildOrchestratorCmd } from '../../scripts/leo-create-sd.js';
+import { withTargetRepos } from '../../scripts/create-orchestrator-from-plan.js';
+
+describe('buildOrchestratorCmd — forwards --target-repos (leo-create-sd auto-route)', () => {
+  const base = { visionKey: 'VISION-X', archKey: 'ARCH-X', title: 'My Orchestrator' };
+
+  it('appends --target-repos when a cross-repo list is provided', () => {
+    const cmd = buildOrchestratorCmd({ ...base, targetRepos: ['EHG', 'EHG_Engineer'] });
+    expect(cmd).toContain('--target-repos EHG,EHG_Engineer');
+    expect(cmd).toContain('--vision-key VISION-X');
+    expect(cmd).toContain('--auto-children');
+  });
+
+  it('omits --target-repos when targetRepos is null (single-repo, unchanged)', () => {
+    const cmd = buildOrchestratorCmd({ ...base, targetRepos: null });
+    expect(cmd).not.toContain('--target-repos');
+  });
+
+  it('omits --target-repos for an empty array', () => {
+    const cmd = buildOrchestratorCmd({ ...base, targetRepos: [] });
+    expect(cmd).not.toContain('--target-repos');
+  });
+});
+
+describe('withTargetRepos — persists target_repos onto SD metadata', () => {
+  it('adds target_repos when a list is provided, preserving existing keys', () => {
+    const out = withTargetRepos({ is_orchestrator: true, vision_key: 'V' }, ['EHG', 'EHG_Engineer']);
+    expect(out.target_repos).toEqual(['EHG', 'EHG_Engineer']);
+    expect(out.is_orchestrator).toBe(true);
+    expect(out.vision_key).toBe('V');
+  });
+
+  it('is a no-op when targetRepos is null (no target_repos key added)', () => {
+    const meta = { is_orchestrator: true };
+    const out = withTargetRepos(meta, null);
+    expect(out).toBe(meta);
+    expect('target_repos' in out).toBe(false);
+  });
+
+  it('is a no-op for an empty array', () => {
+    const out = withTargetRepos({ phase_number: 2 }, []);
+    expect('target_repos' in out).toBe(false);
+    expect(out.phase_number).toBe(2);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260524-566 (feedback 0ee3c3b8 Bug 2)

### Problem
`leo-create-sd.js` auto-routes to `create-orchestrator-from-plan.js` (L2356 `execSync`) but **dropped `--target-repos`**, and that script had **zero** `--target-repos` handling. So a cross-repo orchestrator SD and its auto-created children never received `metadata.target_repos[]` → `PR_MERGE_VERIFICATION` (`computeReposForSD`) mis-scopes the repo scan at LEAD-FINAL. (Bug 1 of this feedback — phase-miscount over-route — shipped #3889.)

### Fix
- **leo-create-sd.js**: extracted exported `buildOrchestratorCmd()` that forwards `--target-repos` (from the already-parsed `targetRepos`) into the orchestrator exec command.
- **create-orchestrator-from-plan.js**: parse `--target-repos` (reusing the canonical `parseTargetReposArg`) and persist `target_repos` onto **both** the orchestrator and child SD metadata via a new exported `withTargetRepos()` helper. No-op when absent → single-repo orchestrators byte-for-byte unchanged.

### Tests — 6/6 (`tests/unit/orchestrator-target-repos.test.js`)
- `buildOrchestratorCmd`: appends `--target-repos` for a cross-repo list; omits it for null / empty.
- `withTargetRepos`: adds `target_repos` (preserving existing keys); no-op for null / empty.
- Integrity proven by revert+rerun: disabling both branches fails exactly the 2 positive tests.

Closes feedback 0ee3c3b8-4b80-411d-865a-d1ae16d9c0c8

🤖 Generated with [Claude Code](https://claude.com/claude-code)