### PR TITLE
fix(QF-20260524-043): guard husky prepare script for CI lean installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "agent:metrics": "node lib/agents/metrics-dashboard.cjs",
     "agent:metrics:agent": "node lib/agents/metrics-dashboard.cjs agent",
     "agent:metrics:top": "node lib/agents/metrics-dashboard.cjs top",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "postinstall": "node scripts/generate-agent-md-from-db.js || echo 'Agent compilation skipped (missing DB credentials)'",
     "agents:compile": "node scripts/generate-agent-md-from-db.js",
     "hooks:install": "node scripts/hooks/install-hooks.js",


### PR DESCRIPTION
## Quick-Fix QF-20260524-043

**Resolves recurring CI failure** (feedback `b215c67c`, run [26281537445](https://github.com/rickfelix/EHG_Engineer/actions/runs/26281537445)).

### Root cause
`package.json` `"prepare": "husky"` runs during the npm install lifecycle. Workflows that install with `npm ci --omit=dev` omit husky (a devDependency), so npm's `prepare` step fails:

```
sh: 1: husky: not found
npm error code 127
```

`npm ci` then exits non-zero **before the workflow's real script runs**. Affected workflows: `pocock-weekly-deepening`, `youtube-subscription-digest`. (The earlier "Insufficient unconsumed findings" disposition was a *different* failure mode — the cron's own gate; this instance is the husky exit-127 install break.)

### Fix
```diff
- "prepare": "husky",
+ "prepare": "husky || true",
```
Husky's documented CI guard: no-op when husky is unavailable (lean/production installs), still installs git hooks on normal dev installs. One line; fixes both affected workflows at the root.

### Validation
- ✅ `package.json` valid JSON
- ✅ Shell guard proven: `sh -c "husky-nonexistent || true"` → **exit 0** (the exact CI scenario)
- ✅ `npx tsc --noEmit` → exit 0
- ✅ CI on this PR exercises the real install path

🤖 Generated with [Claude Code](https://claude.com/claude-code)