### PR TITLE
fix(QF-20260524-250): make Gate 0 SD-key regex digit-domain-aware

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -621,7 +621,7 @@ fi
 if echo "$BRANCH" | grep -qE '^(feat|fix)/'; then
   # Check for SD identifier pattern: SD-XXX-NNN, SD-XXX-CATEGORY-NNN, or SD-XXX-MULTI-SEGMENT-NNN
   # Updated to support variable-length SD identifiers like SD-LEO-SELF-IMPROVE-AIJUDGE-001
-  if ! echo "$BRANCH" | grep -qiE 'SD-[A-Z]+(-[A-Z0-9]+)*-[0-9]+'; then
+  if ! echo "$BRANCH" | grep -qiE 'SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+'; then
     # Also accept quick-fix pattern for fix/ branches: QF-YYYYMMDD-NNN
     if echo "$BRANCH" | grep -qE '^fix/' && echo "$BRANCH" | grep -qE 'QF-[0-9]{8}-[0-9]+'; then
       echo "   ℹ️  Quick-fix pattern detected (QF-YYYYMMDD-NNN)"
@@ -672,7 +672,7 @@ fi
 # Extract SD identifier pattern from commit message or branch name
 # Matches: SD-LEO-GATE0-001, SD-FEATURE-001, SD-LEO-REFACTOR-LARGE-FILES-002
 # Also matches multi-segment: SD-LEO-SELF-IMPROVE-AIJUDGE-001
-SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z]+(-[A-Z0-9]+)*-[0-9]+' | head -1)
+SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+' | head -1)
 
 if [ ! -z "$SD_ID" ]; then
   echo "   Found SD reference: $SD_ID"


### PR DESCRIPTION
## Quick-Fix QF-20260524-250 — resolves harness_backlog `e65d2214`

### Root cause
The pre-commit hook (`.husky/pre-commit`) SD-key regex `SD-[A-Z]+(-[A-Z0-9]+)*-[0-9]+` has a **first segment** (`[A-Z]+`) that can't match a digit-bearing domain such as the **S19** child family:
- **STAGE 7 / Gate 0** (line 675): empty `SD_ID` → silently **skips** SD-status validation (`"No SD reference found"`) for the whole digit-domain family — an enforcement gap.
- **STAGE 6** (line 624): emits a false `"missing SD identifier"` warning.

### Fix (2 lines)
First segment `[A-Z]+` → `[A-Z0-9]+` in both occurrences.

### Verification (empirical)
| Input | Before | After |
|---|---|---|
| `feat/SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001-C` | no match (silent skip) | extracts `SD-S19-SEEDS-A-CLAUDECODEREADY-ORCH-001` ✓ |
| `SD-LEO-REFAC-RETIRE-LEGACY-STAGE-001` | matches | matches ✓ (no regression) |
| `fix/QF-20260524-250` | no match | no match ✓ (QF routing unaffected) |

Same regex-fragility class as `PAT-CI-REGEX-LINKAGE-FRAGILITY-001`.

### Related follow-on (not in scope)
`.github/workflows/sd-validation.yml:45` uses a separate, structurally-different regex (`SD-[A-Z]+-[A-Z0-9]+-[0-9]+|SD-[A-Z]+-[0-9]+`) with broader fragility (no multi-segment support) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)