### PR TITLE
fix(QF-20260524-309): load QF self-verifier from the worktree, not the invoking tree

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -8,7 +8,7 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { restartLeoStack } from '../../../lib/server-manager.js';
 import { runSelfVerification } from '../../../lib/quickfix-self-verifier.js';
 import {
@@ -301,7 +301,18 @@ export async function completeQuickFix(qfId, options = {}) {
     overCapReason: options.overCapReason
   };
 
-  const verificationResults = await runSelfVerification(qfId, verificationContext);
+  // QF-20260524-309 (a38f6b06): prefer the testDir (QF worktree) copy of the self-verifier
+  // over this orchestrator's bundled import, so running the main repo's complete-quick-fix.js
+  // from a worktree cannot run a stale verifier when the main tree predates a merged fix.
+  let runSV = runSelfVerification;
+  try {
+    const localVerifier = path.join(testDir, 'lib', 'quickfix-self-verifier.js');
+    if (testDir && fs.existsSync(localVerifier)) {
+      const mod = await import(pathToFileURL(localVerifier).href);
+      if (typeof mod.runSelfVerification === 'function') runSV = mod.runSelfVerification;
+    }
+  } catch { /* fall back to the bundled verifier */ }
+  const verificationResults = await runSV(qfId, verificationContext);
   // SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 FR-2: --force-complete bypasses self-verification prompts
   const selfVerificationValid = await validateSelfVerification(verificationResults, prompt, {
     forceComplete: options.forceComplete,


### PR DESCRIPTION
## Quick-Fix QF-20260524-309 — resolves harness_backlog `a38f6b06`

### Root cause
`scripts/modules/complete-quick-fix/orchestrator.js` statically imported `runSelfVerification` from its own location (`../../../lib/quickfix-self-verifier.js`). So running the **main repo's** `complete-quick-fix.js` from a QF **worktree** ran the *main tree's* verifier. When the main tree sat on an older branch predating a merged verifier fix, the **stale** verifier produced false-positives (witnessed: `QF-20260524-566` hit the `QF-272` scope-creep false-positive even though its worktree already had the fix; running the worktree's own script used the correct verifier).

### Fix (~12 LOC)
At the call site, prefer the `testDir` (worktree) copy of the verifier via dynamic `import()`, with a **try/catch fallback to the bundled import**:
- Normal run (`testDir` == repo root) → loads the same module → **identical behavior**.
- Worktree run via main-repo script → loads the worktree's verifier → **bug fixed**.
- Missing file / import error → falls back to bundled → **no breakage**.

### Verification
- `node --check` parses the file.
- Isolation test: `pathToFileURL(testDir/lib/quickfix-self-verifier.js)` imports and exposes `runSelfVerification`.
- This PR's own completion **dogfoods** the new path.

Same class as the `a38f6b06`/`QF-272` self-verifier robustness work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)