### PR TITLE
feat(SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002): make GATE2 fidelity scan cross-repo/worktree-aware

### DIFF
--- a/scripts/modules/implementation-fidelity/utils/repo-detection.js
+++ b/scripts/modules/implementation-fidelity/utils/repo-detection.js
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import { readFile } from 'fs/promises';
 import { getSDSearchTerms } from './git-helpers.js';
 import { resolveRepoPath, ENGINEER_ROOT } from '../../../../lib/repo-paths.js';
+import { resolveWorktreeCwd } from '../../../../lib/resolve-worktree-cwd.js';
 
 const execAsync = promisify(exec);
 
@@ -110,9 +111,11 @@ export async function detectImplementationRepos(sd_id, supabase) {
   const cwd = process.cwd();
   const cwdNorm = cwd.replace(/\\/g, '/');
   const foundRepos = [];
+  // SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002: the SD-KEY (not the UUID) drives worktree
+  // resolution — resolveWorktreeCwd's extractSdId regex matches the SD-key form, not a UUID.
+  const sdKey = searchTerms.find(t => t.startsWith('SD-'));
 
   if (cwdNorm.includes('.worktrees/')) {
-    const sdKey = searchTerms.find(t => t.startsWith('SD-'));
     if (sdKey && cwdNorm.includes(sdKey)) {
       console.log(`   📋 Worktree detected for ${sdKey}, using cwd: ${cwd}`);
       foundRepos.push(cwd);
@@ -155,7 +158,30 @@ export async function detectImplementationRepos(sd_id, supabase) {
     foundRepos.push(cwd);
   }
 
-  return foundRepos;
+  // SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002: redirect each resolved repo to the SD's
+  // worktree when one exists. The git `--all` commit scan above is worktree-agnostic (worktrees
+  // share the repo's .git object DB), so foundRepos holds repo ROOTS — but the downstream
+  // section validators also run non-`--all` FILESYSTEM scans (migration dirs, test dirs,
+  // readFile) that read the on-disk checkout. For an EHG-targeted SD whose code lives in an
+  // ehg worktree on a non-default branch, scanning the root (parked on another branch) misses
+  // the files → false-RED ~68 → forced --bypass-validation. Mirrors the GATE5/GATE6 fix
+  // (SD-LEO-INFRA-BRANCH-AWARE-PLAN-001 via resolveWorktreeCwd). Null-fallback keeps
+  // EHG_Engineer self-target + non-worktree runs byte-identical; normalize + de-dup preserves
+  // primaryMigrationRepo ordering (target repo stays first).
+  const resolved = [];
+  const seen = new Set();
+  for (const repo of foundRepos) {
+    const redirected = (sdKey ? resolveWorktreeCwd(repo, { sdId: sdKey }) : null) || repo;
+    const norm = path.resolve(redirected).replace(/\\/g, '/');
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    resolved.push(redirected);
+    if (redirected !== repo) {
+      console.log(`   🌲 Worktree resolved for fidelity scan: ${redirected} (was ${repo})`);
+    }
+  }
+
+  return resolved;
 }
 
 /**

--- a/tests/unit/implementation-fidelity/cross-repo-worktree-resolution.test.js
+++ b/tests/unit/implementation-fidelity/cross-repo-worktree-resolution.test.js
@@ -1,0 +1,137 @@
+/**
+ * SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002 — GATE2_IMPLEMENTATION_FIDELITY
+ * cross-repo worktree resolution.
+ *
+ * detectImplementationRepos() runs a worktree-agnostic `git --all` commit scan (worktrees
+ * share the repo .git object DB), so it collects repo ROOTS. The downstream section
+ * validators then run non-`--all` FILESYSTEM scans (migration dirs, test dirs, readFile)
+ * that read the on-disk checkout. For an EHG-targeted SD whose code is in an ehg worktree
+ * on a non-default branch, scanning the root (parked on another branch) misses the files
+ * → false-RED ~68 → forced --bypass-validation.
+ *
+ * The fix redirects each resolved repo to its SD worktree via resolveWorktreeCwd
+ * (mirroring SD-LEO-INFRA-BRANCH-AWARE-PLAN-001's GATE5/GATE6 fix), passing the SD-KEY
+ * (not a UUID), with null-fallback (byte-identical) and normalize+dedup.
+ *
+ * CASE-A EHG worktree redirect (the fix) | CASE-B EHG_Engineer self-target byte-identical
+ * CASE-C SD-KEY (not UUID) passed to resolver | CASE-D dedup | CASE-E EHG_Engineer-in-worktree
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted, mutable fixture the vi.mock factories read.
+const h = vi.hoisted(() => ({
+  worktreeReturn: null, // value (or fn(appPath,opts)) resolveWorktreeCwd returns
+  resolveCalls: [],     // recorded { appPath, opts }
+  foundSet: new Set(),  // repos whose `git --all --grep` "finds" a commit
+}));
+
+// Hermetic search terms: the SD-KEY is the first SD- term (drives worktree resolution).
+vi.mock('../../../scripts/modules/implementation-fidelity/utils/git-helpers.js', () => ({
+  getSDSearchTerms: async () => ['SD-TEST-EHG-001', 'feature work'],
+  gitLogForSD: async () => '',
+}));
+
+// Controllable worktree resolver — records every call so we can assert the SD-KEY is passed.
+vi.mock('../../../lib/resolve-worktree-cwd.js', () => ({
+  resolveWorktreeCwd: (appPath, opts) => {
+    h.resolveCalls.push({ appPath, opts });
+    return typeof h.worktreeReturn === 'function' ? h.worktreeReturn(appPath, opts) : h.worktreeReturn;
+  },
+  listActiveWorktrees: () => [],
+}));
+
+// `git --all --grep` stub: report a commit for repos in h.foundSet.
+vi.mock('child_process', () => ({
+  exec: (cmd, optsOrCb, maybeCb) => {
+    const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+    const m = /-C "([^"]+)"/.exec(cmd);
+    const repo = m ? m[1] : '';
+    const norm = repo.replace(/\\/g, '/');
+    const found = [...h.foundSet].some((r) => r.replace(/\\/g, '/') === norm);
+    cb(null, { stdout: found ? 'abc1234\n' : '', stderr: '' });
+  },
+}));
+
+// Force the registry-miss fallback so candidateRepos === [EHG_ROOT, EHG_ENGINEER_ROOT].
+vi.mock('fs/promises', () => ({
+  readFile: async () => { throw new Error('no registry (test fixture)'); },
+}));
+
+const { detectImplementationRepos, EHG_ROOT, EHG_ENGINEER_ROOT } = await import(
+  '../../../scripts/modules/implementation-fidelity/utils/repo-detection.js'
+);
+
+// Minimal chainable supabase stub: target_application query resolves to null
+// (→ registry path → readFile throws → [EHG_ROOT, EHG_ENGINEER_ROOT] fallback).
+function makeSupabase() {
+  const chain = {
+    from: () => chain,
+    select: () => chain,
+    or: () => chain,
+    eq: () => chain,
+    limit: () => chain,
+    single: () => Promise.resolve({ data: null, error: null }),
+  };
+  return chain;
+}
+
+describe('GATE2 cross-repo worktree resolution (SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002)', () => {
+  beforeEach(() => {
+    h.worktreeReturn = null;
+    h.resolveCalls = [];
+    h.foundSet = new Set();
+  });
+
+  it('CASE-A: redirects a found repo to its SD worktree', async () => {
+    h.foundSet = new Set([EHG_ROOT]);
+    h.worktreeReturn = '/wt/ehg-SD-TEST-EHG-001';
+
+    // sd_id is a UUID — the worktree resolution must still use the SD-KEY from search terms.
+    const result = await detectImplementationRepos('11111111-2222-3333-4444-555555555555', makeSupabase());
+
+    expect(result).toEqual(['/wt/ehg-SD-TEST-EHG-001']);
+    const callForEhg = h.resolveCalls.find((c) => c.appPath === EHG_ROOT);
+    expect(callForEhg).toBeTruthy();
+    expect(callForEhg.opts.sdId).toBe('SD-TEST-EHG-001');
+  });
+
+  it('CASE-B: byte-identical when no worktree matches (resolver returns null)', async () => {
+    h.foundSet = new Set([EHG_ROOT]);
+    h.worktreeReturn = null; // no worktree → fall back to the repo root unchanged
+
+    const result = await detectImplementationRepos('SD-TEST-EHG-001', makeSupabase());
+
+    expect(result).toEqual([EHG_ROOT]);
+  });
+
+  it('CASE-C: passes the SD-KEY (not the UUID) to resolveWorktreeCwd', async () => {
+    h.foundSet = new Set([EHG_ROOT]);
+    h.worktreeReturn = '/wt/ehg';
+
+    await detectImplementationRepos('11111111-2222-3333-4444-555555555555', makeSupabase());
+
+    expect(h.resolveCalls.length).toBeGreaterThan(0);
+    for (const c of h.resolveCalls) {
+      expect(c.opts.sdId).toBe('SD-TEST-EHG-001'); // SD-KEY form, matches extractSdId
+      expect(c.opts.sdId).not.toMatch(/^[0-9a-f]{8}-/i); // never a UUID
+    }
+  });
+
+  it('CASE-D: de-duplicates when multiple repos resolve to the same worktree', async () => {
+    h.foundSet = new Set([EHG_ROOT, EHG_ENGINEER_ROOT]);
+    h.worktreeReturn = () => '/wt/shared'; // both repos collapse to one path
+
+    const result = await detectImplementationRepos('SD-TEST-EHG-001', makeSupabase());
+
+    expect(result).toEqual(['/wt/shared']); // single, de-duplicated entry
+  });
+
+  it('CASE-E: redirects an EHG_Engineer-resident SD to its EHG_Engineer worktree', async () => {
+    h.foundSet = new Set([EHG_ENGINEER_ROOT]);
+    h.worktreeReturn = (appPath) => (appPath === EHG_ENGINEER_ROOT ? '/wt/engineer-SD-TEST-EHG-001' : null);
+
+    const result = await detectImplementationRepos('SD-TEST-EHG-001', makeSupabase());
+
+    expect(result).toEqual(['/wt/engineer-SD-TEST-EHG-001']);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002 — resolves harness_backlog `c0910085`

Makes the EXEC-TO-PLAN gate **GATE2_IMPLEMENTATION_FIDELITY** resolve an EHG-targeted SD's actual worktree, so SDs whose code lives in an `ehg` worktree on a non-default branch stop false-REDing (~68 → forced `--bypass-validation`). Mirrors `SD-LEO-INFRA-BRANCH-AWARE-PLAN-001` (GATE5/GATE6).

### Root cause (reframed by prospective testing-agent, RISK-1)
`git -C <root> log --all` is **worktree-agnostic** (worktrees share the `.git` object DB), so `detectImplementationRepos` collected repo **roots**. The section validators' non-`--all` **filesystem scans** (migration dirs, test dirs, `readFile`) then read a root parked on another branch → missed the SD's files.

### Fix (centralized, ~25 LOC, zero section-file edits — RISK-6)
In `scripts/modules/implementation-fidelity/utils/repo-detection.js`, `detectImplementationRepos` redirects each resolved repo to its SD worktree via `resolveWorktreeCwd(repo,{sdId})`:
- Passes the **SD-KEY** (not a UUID) so `extractSdId` matches (RISK-3 — else silent no-op).
- **Null-fallback** → EHG_Engineer self-target + non-worktree runs are **byte-identical**.
- **Normalize + dedup** preserves `primaryMigrationRepo` ordering (RISK-4).

### Tests
`tests/unit/implementation-fidelity/cross-repo-worktree-resolution.test.js` — CASE-A redirect, CASE-B byte-identical, CASE-C SD-KEY-not-UUID, CASE-D dedup, CASE-E EHG_Engineer-in-worktree (**5/5**); full implementation-fidelity suite **37/37** green. The EXEC-TO-PLAN run scored this SD's own `GATE2_IMPLEMENTATION_FIDELITY` at **100%** (live self-validation).

Full LEAD→PLAN→EXEC→PLAN-TO-LEAD this session (94/96/93/96), prospective testing-agent at PLAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)