### PR TITLE
feat(SD-FDBK-ENH-PRD-AUTHORING-QUERY-001): inject live table metadata into PRD generation

### DIFF
--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -484,6 +484,9 @@ async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, 
       };
     } else {
       llmPrdContent = await generatePRDContentWithLLM(sdData, {
+        // SD-FDBK-ENH-PRD-AUTHORING-QUERY-001: thread supabase so the generator can
+        // inject live table metadata (row counts + columns) for production grounding.
+        supabase,
         ...analyses,
         personas: analyses.stakeholderPersonas,
         existingStories

--- a/scripts/prd/llm-generator.js
+++ b/scripts/prd/llm-generator.js
@@ -22,6 +22,8 @@ import {
 // Imports are static (not dynamic) so the module graph loads cleanly at test time;
 // behavior change still gated by PRD_REWRITE_LOOP env var (default OFF).
 import { applyRewriteLoop } from '../modules/prd/rewrite-loop.js';
+// SD-FDBK-ENH-PRD-AUTHORING-QUERY-001: live table metadata grounding (fail-soft).
+import { buildLiveTableMetadataSection } from './table-metadata-query.js';
 
 /**
  * Check if inline PRD generation mode is enabled.
@@ -200,6 +202,14 @@ export async function generatePRDContentWithLLM(sd, context = {}) {
     return null;
   }
 
+  // SD-FDBK-ENH-PRD-AUTHORING-QUERY-001: ground the prompt in production reality by
+  // injecting live row counts + columns for tables this SD references. Computed once
+  // here (the only async seam) so both the inline and external-API paths get it via
+  // context; fully fail-soft (returns '' when no DB/creds/tables).
+  if (context.supabase && context.liveTableMetadataSection === undefined) {
+    context.liveTableMetadataSection = await buildLiveTableMetadataSection(context.supabase, sd, context);
+  }
+
   if (isInlineModeEnabled()) {
     return generatePRDInline(sd, context);
   }
@@ -376,6 +386,12 @@ export function buildPRDGenerationContext(sd, context = {}) {
   const constraints = getImplementationContextConstraints(implCtx);
   if (constraints) {
     sections.push(`## CONTEXT CONSTRAINTS (${implCtx.toUpperCase()})\n${constraints}`);
+  }
+
+  // 9.5 Live table metadata (SD-FDBK-ENH-PRD-AUTHORING-QUERY-001) — production reality
+  // check injected just before the task so the LLM sees real counts/columns last.
+  if (context.liveTableMetadataSection) {
+    sections.push(context.liveTableMetadataSection);
   }
 
   // 10. Generation Instructions — concise

--- a/scripts/prd/table-metadata-query.js
+++ b/scripts/prd/table-metadata-query.js
@@ -1,0 +1,147 @@
+/**
+ * Live table metadata for PRD grounding — SD-FDBK-ENH-PRD-AUTHORING-QUERY-001.
+ *
+ * Extracts the table names an SD references, looks up LIVE row counts + actual
+ * column names, and formats a markdown section injected into the PRD LLM context
+ * (by buildPRDGenerationContext) so generated FRs match production reality instead
+ * of assuming wrong row counts or non-existent columns.
+ *
+ * VERIFY-FIRST NOTE: PostgREST does NOT expose information_schema (querying
+ * `information_schema.columns`/`.tables` via supabase-js fails with PGRST205). So
+ * validation + introspection use PostgREST-native probes instead:
+ *   - existence + columns: `select('*').limit(1)` — PGRST205 ⇒ table does not exist
+ *     (skip); otherwise the sample row's keys are the real columns.
+ *   - row count: head `select('*', { count: 'exact', head: true })`.
+ * Behaviour matches the PRD success criteria (real count, real columns, hallucinated
+ * names filtered); only the mechanism differs from the PRD's information_schema wording.
+ *
+ * Fully FAIL-SOFT: every path swallows errors and returns '' (no section) so PRD
+ * generation is never broken by missing credentials, an empty table, or a query error.
+ */
+
+const SECTION_HEADER = '## LIVE TABLE METADATA (PRODUCTION REALITY CHECK)';
+const MAX_TABLES = 50;
+const MAX_COLUMNS_SHOWN = 60;
+
+// snake_case identifiers (>=2 segments) that plausibly name a table. Correctness does
+// not depend on this being precise — every candidate is validated against the live DB,
+// so false positives are simply skipped. The stopword set just avoids wasted probes.
+const TABLE_TOKEN_RE = /\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g;
+const STOPWORDS = new Set([
+  'target_application', 'sub_agent', 'sub_agents', 'key_changes', 'success_criteria',
+  'success_metrics', 'acceptance_criteria', 'functional_requirements', 'technical_requirements',
+  'test_scenarios', 'service_role', 'service_role_key', 'pull_request', 'feature_flag',
+  'fail_soft', 'row_count', 'row_counts', 'production_reality'
+]);
+
+/**
+ * Extract candidate table names from the SD + the DATABASE sub-agent analysis.
+ * @returns {string[]} de-duplicated candidate names (capped)
+ */
+export function extractTableNamesFromSD(sd = {}, context = {}) {
+  const names = new Set();
+
+  // 1. DATABASE sub-agent output (highest confidence) — affected_tables / new_tables / tables.
+  const dbAnalysis = context.databaseAnalysis;
+  if (dbAnalysis) {
+    const text = typeof dbAnalysis === 'string' ? dbAnalysis : JSON.stringify(dbAnalysis);
+    for (const key of ['affected_tables', 'new_tables', 'tables']) {
+      const m = new RegExp(`"${key}"\\s*:\\s*\\[([^\\]]*)\\]`).exec(text);
+      if (m) {
+        for (const raw of m[1].split(',')) {
+          const v = raw.replace(/["'\s]/g, '');
+          if (v && /^[a-z][a-z0-9_]*$/.test(v)) names.add(v);
+        }
+      }
+    }
+  }
+
+  // 2. snake_case identifiers in the SD scope / description / key_changes text.
+  const parts = [sd.scope, sd.description];
+  if (Array.isArray(sd.key_changes)) {
+    parts.push(sd.key_changes.map((k) => (typeof k === 'string' ? k : k && k.change) || '').join(' '));
+  }
+  const blob = parts.filter(Boolean).join(' ').toLowerCase();
+  let mm;
+  while ((mm = TABLE_TOKEN_RE.exec(blob)) !== null) {
+    if (!STOPWORDS.has(mm[0])) names.add(mm[0]);
+  }
+
+  return [...names].slice(0, MAX_TABLES);
+}
+
+/**
+ * For each candidate, validate existence and read live row count + columns.
+ * Invalid (non-existent) tables are filtered out. FAIL-SOFT per table.
+ * @returns {Promise<Array<{table:string,rowCount:number|null,columns:string[]}>>}
+ */
+export async function queryLiveTableMetadata(supabase, names) {
+  if (!supabase || !Array.isArray(names) || names.length === 0) return [];
+  const results = [];
+  for (const table of names) {
+    try {
+      // Probe: validates existence (PGRST205 ⇒ skip) and yields real columns.
+      const probe = await supabase.from(table).select('*').limit(1);
+      if (probe.error) continue; // non-existent / not exposed — skip silently
+      const columns = probe.data && probe.data[0] ? Object.keys(probe.data[0]) : [];
+
+      let rowCount = null;
+      try {
+        const cnt = await supabase.from(table).select('*', { count: 'exact', head: true });
+        if (!cnt.error && typeof cnt.count === 'number') rowCount = cnt.count;
+      } catch (_) { /* count is best-effort */ }
+
+      results.push({ table, rowCount, columns });
+    } catch (_) {
+      // fail-soft per table
+    }
+  }
+  return results;
+}
+
+/**
+ * Format the validated metadata into the markdown section.
+ * @returns {string} markdown section, or '' when there is nothing to show
+ */
+export function formatTableMetadataSection(results) {
+  if (!Array.isArray(results) || results.length === 0) return '';
+  const lines = [
+    SECTION_HEADER,
+    '',
+    'Live values for tables referenced by this SD. **Generated FRs MUST match these** —',
+    'do not assume row counts or column names that contradict this section.',
+    ''
+  ];
+  for (const r of results) {
+    const count = r.rowCount === null ? 'unknown' : String(r.rowCount);
+    lines.push(`### \`${r.table}\` — ${count} row(s)`);
+    if (r.columns.length) {
+      const shown = r.columns.slice(0, MAX_COLUMNS_SHOWN);
+      const extra = r.columns.length > MAX_COLUMNS_SHOWN ? ` (+${r.columns.length - MAX_COLUMNS_SHOWN} more)` : '';
+      lines.push(`Columns: ${shown.map((c) => `\`${c}\``).join(', ')}${extra}`);
+    } else {
+      lines.push('Columns: (empty table — no sample row available; only row count is authoritative)');
+    }
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Orchestrator: extract → query → format. Returns '' on any miss. Never throws.
+ * @returns {Promise<string>}
+ */
+export async function buildLiveTableMetadataSection(supabase, sd, context = {}) {
+  if (!supabase) return '';
+  try {
+    const names = extractTableNamesFromSD(sd, context);
+    if (names.length === 0) return '';
+    const results = await queryLiveTableMetadata(supabase, names);
+    const section = formatTableMetadataSection(results);
+    if (section) console.log(`   📋 Injected live table metadata for ${results.length} table(s): ${results.map((r) => r.table).join(', ')}`);
+    return section;
+  } catch (e) {
+    console.log(`   ℹ️  Live table metadata skipped: ${e.message}`);
+    return '';
+  }
+}

--- a/tests/unit/prd/table-metadata-query.test.js
+++ b/tests/unit/prd/table-metadata-query.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-FDBK-ENH-PRD-AUTHORING-QUERY-001 — live table metadata grounding for PRD generation.
+ *
+ * Verifies extraction (DATABASE sub-agent output + multi-segment scope regex), live
+ * lookup with PostgREST-native probes (existence + columns + count), hallucinated-name
+ * filtering, fail-soft behavior, and markdown formatting — all with a mocked supabase.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractTableNamesFromSD,
+  queryLiveTableMetadata,
+  formatTableMetadataSection,
+  buildLiveTableMetadataSection
+} from '../../../scripts/prd/table-metadata-query.js';
+
+// Mock supabase mirroring live PostgREST behavior:
+//  - select('*').limit(1)            → { data:[row] | [], error } ; PGRST205 for unknown table
+//  - select('*',{count,head:true})   → { count, error }
+// `tables` maps existing table name → { count, columns }. Absent name ⇒ does not exist.
+function makeSupabase(tables) {
+  return {
+    from(table) {
+      const t = tables[table];
+      return {
+        select(_cols, opts) {
+          if (opts && opts.head) {
+            return Promise.resolve(t ? { count: t.count, error: null } : { count: null, error: null });
+          }
+          const result = t
+            ? { data: t.columns && t.columns.length ? [Object.fromEntries(t.columns.map((c) => [c, null]))] : [], error: null }
+            : { data: null, error: { code: 'PGRST205', message: `Could not find the table 'public.${table}' in the schema cache` } };
+          return { limit: () => Promise.resolve(result) };
+        }
+      };
+    }
+  };
+}
+
+describe('table-metadata-query (SD-FDBK-ENH-PRD-AUTHORING-QUERY-001)', () => {
+  it('TS-5: extracts tables from DATABASE sub-agent output + multi-segment scope regex', () => {
+    const sd = { scope: 'Touches venture_briefs and stage_zero_requests during intake.' };
+    const ctx = { databaseAnalysis: '{"affected_tables":["ventures","accounts"],"new_tables":[]}' };
+    const names = extractTableNamesFromSD(sd, ctx);
+    expect(names).toContain('ventures');          // single-word via sub-agent output
+    expect(names).toContain('accounts');           // single-word via sub-agent output
+    expect(names).toContain('venture_briefs');     // multi-segment via scope regex
+    expect(names).toContain('stage_zero_requests');
+  });
+
+  it('TS-1: real table → section with live row count + actual columns', async () => {
+    const supa = makeSupabase({ ventures: { count: 4, columns: ['id', 'name', 'industry', 'vertical_category', 'tags'] } });
+    const section = await buildLiveTableMetadataSection(supa, { scope: 'venture work' }, { databaseAnalysis: '{"affected_tables":["ventures"]}' });
+    expect(section).toContain('LIVE TABLE METADATA');
+    expect(section).toContain('`ventures` — 4 row(s)');
+    expect(section).toContain('`industry`');
+    expect(section).toContain('`vertical_category`');
+    // grounds against the assumed-but-nonexistent columns from the origin defect:
+    expect(section).not.toContain('industry_tags');
+  });
+
+  it('TS-2: fail-soft when supabase is absent', async () => {
+    const section = await buildLiveTableMetadataSection(null, { scope: 'uses ventures' }, { databaseAnalysis: '{"affected_tables":["ventures"]}' });
+    expect(section).toBe('');
+  });
+
+  it('TS-3: fail-soft when no tables are referenced', async () => {
+    const supa = makeSupabase({ ventures: { count: 4, columns: ['id'] } });
+    const section = await buildLiveTableMetadataSection(supa, { scope: 'A purely textual change with no table references at all.' }, {});
+    expect(section).toBe('');
+  });
+
+  it('TS-4: hallucinated / non-existent table is filtered out', async () => {
+    const supa = makeSupabase({ venture_briefs: { count: 2, columns: ['id', 'title'] } }); // bogus_fake_table absent
+    const results = await queryLiveTableMetadata(supa, ['venture_briefs', 'bogus_fake_table']);
+    expect(results.map((r) => r.table)).toEqual(['venture_briefs']); // bogus filtered out (PGRST205)
+    const section = formatTableMetadataSection(results);
+    expect(section).toContain('venture_briefs');
+    expect(section).not.toContain('bogus_fake_table');
+  });
+
+  it('empty table → row count shown, columns noted unavailable (fail-soft)', async () => {
+    const supa = makeSupabase({ audit_log: { count: 0, columns: [] } });
+    const results = await queryLiveTableMetadata(supa, ['audit_log']);
+    expect(results[0]).toMatchObject({ table: 'audit_log', rowCount: 0, columns: [] });
+    expect(formatTableMetadataSection(results)).toContain('`audit_log` — 0 row(s)');
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-PRD-AUTHORING-QUERY-001 — resolves harness_backlog `564531d9`

Grounds PRD generation in **production reality**: a new fail-soft module injects a `LIVE TABLE METADATA` section (real row counts + actual columns) into the LLM context for tables an SD references — so generated FRs stop assuming wrong counts / non-existent columns (origin defect: a PRD claimed *4 ventures@S11* vs live *1*, and assumed `ventures.industry_tags`/`audience_tags` columns that don't exist).

### How
- **New `scripts/prd/table-metadata-query.js`**: `extractTableNamesFromSD` (DATABASE sub-agent `affected_tables`/`new_tables` + multi-segment `snake_case` scope regex) → `queryLiveTableMetadata` (validate + count + columns) → `formatTableMetadataSection`.
- **`scripts/prd/llm-generator.js`**: compute the section once in the async `generatePRDContentWithLLM`, inject in `buildPRDGenerationContext` before the `## TASK` block (covers both inline + API paths). Only the **wired** generator is touched.
- **`scripts/prd/index.js`**: thread `supabase` into the generator context (+3 LOC).

### Verify-first correction
PostgREST does **not** expose `information_schema` (PGRST205). Switched to native probes: `select('*').limit(1)` validates existence (PGRST205 ⇒ skip) **and** yields real columns from a sample row; head `count(*)` gives the row count. Behaviour matches the PRD success criteria.

### Fail-soft
No supabase / no tables / query error ⇒ no section, no throw, PRD generation unchanged. Hallucinated/typo table names are filtered (probe PGRST205).

### Tests
`tests/unit/prd/table-metadata-query.test.js` — extraction (sub-agent + regex), real-table section, fail-soft (no supabase / no tables), hallucinated-filter, empty-table — **6/6**. EXEC-TO-PLAN GATE2_IMPLEMENTATION_FIDELITY 100%. Full LEAD→PLAN→EXEC→PLAN-TO-LEAD one session (94/94/92/96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)