### PR TITLE
feat(SD-FDBK-ENH-SESSION-STATE-SCOPING-001): one canonical session-state resolver

### DIFF
--- a/lib/context/unified-state-manager.js
+++ b/lib/context/unified-state-manager.js
@@ -25,35 +25,17 @@ import os from 'os';
 import { execSync } from 'child_process';
 import dotenv from 'dotenv';
 dotenv.config();
+// SD-FDBK-ENH-SESSION-STATE-SCOPING-001: single canonical resolver (extracted from the
+// previously-private copies below) so the hooks/gates/generator converge on the same file.
+import { getSessionScopedStateFileName, getSessionIdForSync } from '../../scripts/hooks/lib/session-state-resolver.cjs';
 
 const STATE_FILE_NAME = 'unified-session-state.json';
 const STATE_DIR = '.claude';
 const MAX_AGE_MINUTES = 30; // Consider state "recent" if less than this
 
-/**
- * Get session-scoped state filename (SD-LEO-INFRA-CLAIM-GUARD-001: US-004).
- * Prevents cross-session state contamination on shared machines.
- * Falls back to legacy shared filename if session ID unavailable.
- * @returns {string} Session-scoped or legacy filename
- */
-function getSessionScopedStateFileName() {
-  try {
-    const sessionDir = path.join(os.homedir(), '.claude-sessions');
-    if (fs.existsSync(sessionDir)) {
-      const pid = process.ppid || process.pid;
-      const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
-      for (const file of files) {
-        try {
-          const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
-          if (data.pid === pid && data.session_id) {
-            return `unified-session-state.${data.session_id}.json`;
-          }
-        } catch { /* skip */ }
-      }
-    }
-  } catch { /* fallback to legacy */ }
-  return STATE_FILE_NAME; // Legacy fallback
-}
+// getSessionScopedStateFileName + getSessionIdForSync are now imported from the canonical
+// scripts/hooks/lib/session-state-resolver.cjs (SD-FDBK-ENH-SESSION-STATE-SCOPING-001).
+// The mechanism (~/.claude-sessions PID match → session_id, legacy fallback) is byte-identical.
 
 // Database client (lazy init) for PAT-STATE-SYNC-001 dual-write
 let _supabase = null;
@@ -62,26 +44,6 @@ function getSupabase() {
     _supabase = createSupabaseServiceClient();
   }
   return _supabase;
-}
-
-/**
- * Get session ID for DB sync (reuses the same logic as getSessionScopedStateFileName)
- * @returns {string|null}
- */
-function getSessionIdForSync() {
-  try {
-    const sessionDir = path.join(os.homedir(), '.claude-sessions');
-    if (!fs.existsSync(sessionDir)) return null;
-    const pid = process.ppid || process.pid;
-    const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
-    for (const file of files) {
-      try {
-        const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
-        if (data.pid === pid && data.session_id) return data.session_id;
-      } catch { /* skip */ }
-    }
-  } catch { /* fallback */ }
-  return null;
 }
 
 /**

--- a/scripts/hooks/lib/session-state-resolver.cjs
+++ b/scripts/hooks/lib/session-state-resolver.cjs
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Canonical session-state path resolver — SD-FDBK-ENH-SESSION-STATE-SCOPING-001.
+ *
+ * Single source of truth for the unified-session-state file path, so that
+ * lib/context/unified-state-manager.js and the three former hardcoders
+ * (scripts/hooks/protocol-file-tracker.cjs, scripts/modules/sd-key-generator.js,
+ * scripts/modules/handoff/gates/protocol-file-read-gate.js) all resolve the SAME
+ * file and stop the cross-session split-brain.
+ *
+ * Mechanism is extracted VERBATIM from unified-state-manager.js's original
+ * getSessionScopedStateFileName / getSessionIdForSync (~/.claude-sessions registry,
+ * process.ppid||pid match → data.session_id, legacy fallback) so unified-state-manager
+ * stays byte-identical. Adopting the more-robust lib/hooks/session-id.cjs::resolveSessionId
+ * cascade (stdin/env/marker) is a deliberate FOLLOW-ON — it keys a different registry and
+ * would change the resolved filename for every session, so it is intentionally out of scope
+ * here (per LEAD decision 2026-05-24).
+ *
+ * Static module.exports literal so ESM consumers can use named imports
+ * (proven pattern: lib/coordinator/signal-router.cjs, scripts/worker-signal.cjs).
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const LEGACY_STATE_FILE_NAME = 'unified-session-state.json';
+const STATE_DIR = '.claude';
+
+// CLAUDE_SESSIONS_DIR_OVERRIDE: hermetic-test override so tests never touch the
+// real ~/.claude-sessions. Unset in production → identical to the original logic.
+function getSessionsDir() {
+  return process.env.CLAUDE_SESSIONS_DIR_OVERRIDE || path.join(os.homedir(), '.claude-sessions');
+}
+
+function getProjectDir(projectDir) {
+  return projectDir || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+/**
+ * Resolve the current session id from the ~/.claude-sessions registry by PID match.
+ * Verbatim from unified-state-manager.js::getSessionIdForSync (consolidated).
+ * @returns {string|null}
+ */
+function getSessionIdForSync() {
+  try {
+    const sessionDir = getSessionsDir();
+    if (!fs.existsSync(sessionDir)) return null;
+    const pid = process.ppid || process.pid;
+    const files = fs.readdirSync(sessionDir).filter((f) => f.endsWith('.json'));
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
+        if (data.pid === pid && data.session_id) return data.session_id;
+      } catch { /* skip unreadable */ }
+    }
+  } catch { /* fall back to legacy */ }
+  return null;
+}
+
+/**
+ * Session-scoped state filename, or the legacy shared filename when no session resolves.
+ * @returns {string}
+ */
+function getSessionScopedStateFileName() {
+  const sid = getSessionIdForSync();
+  return sid ? `unified-session-state.${sid}.json` : LEGACY_STATE_FILE_NAME;
+}
+
+/** Absolute path to the (scoped-or-legacy) state file. */
+function getSessionStateFilePath(projectDir) {
+  return path.join(getProjectDir(projectDir), STATE_DIR, getSessionScopedStateFileName());
+}
+
+/** Absolute path to the legacy shared state file. */
+function getLegacyStateFilePath(projectDir) {
+  return path.join(getProjectDir(projectDir), STATE_DIR, LEGACY_STATE_FILE_NAME);
+}
+
+/**
+ * Read-fallback path: the scoped file when it exists on disk, else the legacy file.
+ * Keeps readers non-regressive for a fresh session whose scoped file isn't written yet.
+ * @returns {string}
+ */
+function resolveStateReadPath(projectDir) {
+  const scoped = getSessionStateFilePath(projectDir);
+  try {
+    if (scoped !== getLegacyStateFilePath(projectDir) && fs.existsSync(scoped)) return scoped;
+  } catch { /* fall through to legacy */ }
+  return getLegacyStateFilePath(projectDir);
+}
+
+module.exports = {
+  LEGACY_STATE_FILE_NAME,
+  STATE_DIR,
+  getSessionIdForSync,
+  getSessionScopedStateFileName,
+  getSessionStateFilePath,
+  getLegacyStateFilePath,
+  resolveStateReadPath,
+};

--- a/scripts/hooks/protocol-file-tracker.cjs
+++ b/scripts/hooks/protocol-file-tracker.cjs
@@ -16,9 +16,12 @@ const fs = require('fs');
 const path = require('path');
 const { detectProjectDir } = require('./lib/detect-context.cjs');
 
-// Session state file path
+// Session state file path — SD-FDBK-ENH-SESSION-STATE-SCOPING-001: resolve via the canonical
+// resolver (same ~/.claude-sessions mechanism as unified-state-manager) instead of hardcoding
+// the legacy shared file, so writes land in the per-session file and converge with the writer.
+const { getSessionStateFilePath, resolveStateReadPath } = require('./lib/session-state-resolver.cjs');
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || detectProjectDir();
-const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
+const SESSION_STATE_FILE = getSessionStateFilePath(PROJECT_DIR); // scoped write/metadata path
 // Sync marker file for race condition prevention (PAT-ASYNC-RACE-001)
 const SYNC_MARKER_FILE = path.join(PROJECT_DIR, '.claude', '.protocol-sync');
 
@@ -65,8 +68,10 @@ const PROTOCOL_FILE_EQUIVALENTS = {
  */
 function readSessionState() {
   try {
-    if (fs.existsSync(SESSION_STATE_FILE)) {
-      const content = fs.readFileSync(SESSION_STATE_FILE, 'utf8');
+    // Read-fallback: scoped file if it exists, else legacy (no fresh-session regression).
+    const readPath = resolveStateReadPath(PROJECT_DIR);
+    if (fs.existsSync(readPath)) {
+      const content = fs.readFileSync(readPath, 'utf8');
       // Handle BOM if present
       const cleanContent = content.replace(/^\uFEFF/, '');
       return JSON.parse(cleanContent);

--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -24,10 +24,13 @@
 
 import fs from 'fs';
 import path from 'path';
+// SD-FDBK-ENH-SESSION-STATE-SCOPING-001: resolve via the canonical resolver (scoped write,
+// read-fallback to legacy) instead of hardcoding the shared file.
+import { getSessionStateFilePath, resolveStateReadPath } from '../../../hooks/lib/session-state-resolver.cjs';
 
 // Session state file path
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer';
-const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
+const SESSION_STATE_FILE = getSessionStateFilePath(PROJECT_DIR); // scoped write path
 
 /**
  * Get the protocol mode from environment
@@ -78,8 +81,10 @@ const HANDOFF_FILE_REQUIREMENTS = HANDOFF_FILE_REQUIREMENTS_FULL;
  */
 function readSessionState() {
   try {
-    if (fs.existsSync(SESSION_STATE_FILE)) {
-      const content = fs.readFileSync(SESSION_STATE_FILE, 'utf8');
+    // Read-fallback: scoped file if it exists, else legacy (no fresh-session regression).
+    const readPath = resolveStateReadPath(PROJECT_DIR);
+    if (fs.existsSync(readPath)) {
+      const content = fs.readFileSync(readPath, 'utf8');
       // Handle BOM if present
       const cleanContent = content.replace(/^\uFEFF/, '');
       return JSON.parse(cleanContent);

--- a/scripts/modules/sd-key-generator.js
+++ b/scripts/modules/sd-key-generator.js
@@ -19,6 +19,9 @@ import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
+// SD-FDBK-ENH-SESSION-STATE-SCOPING-001: resolve the state path via the canonical resolver
+// (read-fallback to legacy) instead of hardcoding the shared file.
+import { resolveStateReadPath } from '../hooks/lib/session-state-resolver.cjs';
 
 dotenv.config();
 
@@ -27,7 +30,6 @@ dotenv.config();
 // ============================================================================
 
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer';
-const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
 
 /**
  * Read the unified session state to check protocol file read status
@@ -35,8 +37,10 @@ const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-st
  */
 function readSessionState() {
   try {
-    if (fs.existsSync(SESSION_STATE_FILE)) {
-      const content = fs.readFileSync(SESSION_STATE_FILE, 'utf8');
+    // Read-fallback: scoped file if it exists, else legacy (no fresh-session regression).
+    const readPath = resolveStateReadPath(PROJECT_DIR);
+    if (fs.existsSync(readPath)) {
+      const content = fs.readFileSync(readPath, 'utf8');
       const cleanContent = content.replace(/^\uFEFF/, ''); // Handle BOM
       return JSON.parse(cleanContent);
     }

--- a/tests/unit/session-state-resolver.test.js
+++ b/tests/unit/session-state-resolver.test.js
@@ -1,0 +1,90 @@
+/**
+ * SD-FDBK-ENH-SESSION-STATE-SCOPING-001 — canonical session-state resolver.
+ *
+ * Validates the extracted ~/.claude-sessions mechanism (per-session filename when a
+ * registry entry matches process.ppid||pid; legacy fallback otherwise) and the
+ * existsSync read-fallback. The ESM named import from the .cjs resolver below also
+ * exercises the ESM↔CJS interop the SD relies on (R1).
+ *
+ * Hermetic: uses CLAUDE_SESSIONS_DIR_OVERRIDE + a tmp project dir; never touches the
+ * real ~/.claude-sessions or repo .claude.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  getSessionIdForSync,
+  getSessionScopedStateFileName,
+  getSessionStateFilePath,
+  getLegacyStateFilePath,
+  resolveStateReadPath,
+  LEGACY_STATE_FILE_NAME
+} from '../../scripts/hooks/lib/session-state-resolver.cjs';
+
+const MATCH_PID = process.ppid || process.pid; // what getSessionIdForSync matches on
+
+let sessionsDir;
+let projectDir;
+let savedSessionsOverride;
+let savedProjectDir;
+
+function writeSession(file, obj) {
+  fs.writeFileSync(path.join(sessionsDir, file), JSON.stringify(obj));
+}
+
+beforeEach(() => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'sss-test-'));
+  sessionsDir = path.join(base, 'claude-sessions');
+  projectDir = path.join(base, 'project');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+  savedSessionsOverride = process.env.CLAUDE_SESSIONS_DIR_OVERRIDE;
+  savedProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_SESSIONS_DIR_OVERRIDE = sessionsDir;
+  process.env.CLAUDE_PROJECT_DIR = projectDir;
+});
+
+afterEach(() => {
+  if (savedSessionsOverride === undefined) delete process.env.CLAUDE_SESSIONS_DIR_OVERRIDE;
+  else process.env.CLAUDE_SESSIONS_DIR_OVERRIDE = savedSessionsOverride;
+  if (savedProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = savedProjectDir;
+});
+
+describe('session-state-resolver (SD-FDBK-ENH-SESSION-STATE-SCOPING-001)', () => {
+  it('TS-1: per-session filename when a registry entry matches the PID', () => {
+    writeSession('s.json', { pid: MATCH_PID, session_id: 'sess-AAA' });
+    expect(getSessionIdForSync()).toBe('sess-AAA');
+    expect(getSessionScopedStateFileName()).toBe('unified-session-state.sess-AAA.json');
+  });
+
+  it('TS-2: legacy filename when no registry entry matches the PID (byte-identical)', () => {
+    writeSession('other.json', { pid: 999999, session_id: 'sess-OTHER' });
+    expect(getSessionIdForSync()).toBeNull();
+    expect(getSessionScopedStateFileName()).toBe(LEGACY_STATE_FILE_NAME);
+  });
+
+  it('TS-3: legacy filename when the sessions registry dir does not exist', () => {
+    process.env.CLAUDE_SESSIONS_DIR_OVERRIDE = path.join(projectDir, 'no-such-sessions-dir');
+    expect(getSessionScopedStateFileName()).toBe(LEGACY_STATE_FILE_NAME);
+  });
+
+  it('TS-4: getSessionStateFilePath builds the scoped absolute path under <project>/.claude', () => {
+    writeSession('s.json', { pid: MATCH_PID, session_id: 'sess-BBB' });
+    expect(getSessionStateFilePath()).toBe(path.join(projectDir, '.claude', 'unified-session-state.sess-BBB.json'));
+  });
+
+  it('TS-5: read-fallback returns the scoped file when it exists on disk', () => {
+    writeSession('s.json', { pid: MATCH_PID, session_id: 'sess-CCC' });
+    const scoped = path.join(projectDir, '.claude', 'unified-session-state.sess-CCC.json');
+    fs.writeFileSync(scoped, '{}');
+    expect(resolveStateReadPath()).toBe(scoped);
+  });
+
+  it('TS-6: read-fallback returns the legacy file when the scoped file is absent (fresh session)', () => {
+    writeSession('s.json', { pid: MATCH_PID, session_id: 'sess-DDD' });
+    // scoped filename resolves, but the scoped file was never written
+    expect(resolveStateReadPath()).toBe(getLegacyStateFilePath());
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-SESSION-STATE-SCOPING-001 — resolves harness_backlog `b7980512`

Fixes the session-state **split-brain**: `unified-state-manager.js` resolved a per-session file (`~/.claude-sessions` PID match) while three consumers **hardcoded** the legacy shared `.claude/unified-session-state.json` — latent cross-session contamination (QF-20260524-337 RCA preventive #1).

### Fix
New **`scripts/hooks/lib/session-state-resolver.cjs`** (static-export CJS) extracts unified-state-manager's **exact `~/.claude-sessions` mechanism**; `unified-state-manager.js` + the 3 consumers (`protocol-file-tracker.cjs`, `sd-key-generator.js`, `protocol-file-read-gate.js`) all import it. Readers use `resolveStateReadPath` (scoped-if-exists **else legacy** → fresh-session non-regressive); writers use the scoped path, converging with the manager.

### Chairman design decision
The prospective testing-agent recommended reusing the richer `lib/hooks/session-id.cjs::resolveSessionId` cascade — but that keys a **different registry** and would change unified-state-manager's resolved filename for every session (risking orphaned state). Since this is live protocol-gating machinery, I escalated the fork; **conservative extract chosen** (keep `~/.claude-sessions` byte-identical). Adopting the richer cascade is a tracked **follow-on**.

### Regression-proven
`protocol-file-read-gate.test.js` is red on `main` already — I `git stash`-ed my edits and re-ran: the failing set is **identical** with/without my change (diff empty → pre-existing/stale, not my regression). `session-state-resolver.test.js` **6/6**, `protocol-file-tracker` **12/12**, and the **session-id-propagation canary** stay green. EXEC-TO-PLAN 93, GATE2 fidelity 100%. Full LEAD→PLAN→EXEC→PLAN-TO-LEAD one session (94/96/93/96), prospective testing-agent at PLAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)