### PR TITLE
feat(SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-A): deleteVentureFully helper

### DIFF
--- a/lib/deleteVentureFully.js
+++ b/lib/deleteVentureFully.js
@@ -1,0 +1,228 @@
+/**
+ * deleteVentureFully — full single-venture teardown helper
+ *
+ * SD: SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-A (Phase 1)
+ *
+ * Lifts the master-reset teardown (server/routes/ventures.js POST /master-reset,
+ * phases 1–6) and scopes it to a SINGLE venture. Unlike master-reset — which
+ * calls the portfolio-wide `master_reset_portfolio` RPC — this helper calls the
+ * single-venture `delete_venture(p_venture_id)` RPC.
+ *
+ * This module is the shared teardown engine that sibling child B will wire into
+ * the `full-delete` / `bulk-full-delete` endpoints and the refactored
+ * master-reset loop. It has no HTTP surface of its own.
+ *
+ * Phase order (credentials BEFORE DB delete, mirroring master-reset):
+ *   1. Look up venture repo + name from venture_provisioning_state
+ *   2. runTeardown(ventureId)            — external resources (Vercel/FS/Docker)
+ *   3. markResourcesCleaned(ventureId)   — venture_resources status
+ *   4. cleanupCredentials([ventureId])   — revoke credentials at providers
+ *   5. delete_venture(p_venture_id) RPC  — DB cascade (BLOCKING)
+ *   6. gh repo delete                    — guarded + injection-safe slug regex
+ *   7. applications/registry.json edit   — remove the one venture's app entry
+ *
+ * Every phase except the DB delete is non-blocking: failures are captured in the
+ * returned per-phase result rather than thrown.
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { createSupabaseServiceClient } from './supabase-client.js';
+import { runTeardown } from './cleanup/index.js';
+import { markResourcesCleaned } from './venture-resources.js';
+import { cleanup as cleanupCredentials } from './cleanup/credentials.js';
+
+/**
+ * Core repos that must NEVER be deleted. Canonical home for the guard set;
+ * sibling child B refactors server/routes/ventures.js to import from here so the
+ * list does not drift between the single-venture and portfolio paths.
+ */
+export const PROTECTED_REPOS = new Set([
+  'rickfelix/ehg',
+  'rickfelix/EHG_Engineer',
+  'rickfelix/ehg_engineer',
+]);
+
+// Injection-safe slug: owner/repo of only safe path characters. Anything with
+// shell metacharacters, spaces, or extra path segments is rejected before any
+// shell invocation. (Hardening over master-reset, which only counted segments.)
+const SAFE_SLUG_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/**
+ * Extract and validate the owner/repo slug from a venture repo URL.
+ * @param {string} url
+ * @returns {{ slug: string|null, valid: boolean }}
+ */
+export function parseRepoSlug(url) {
+  if (!url || typeof url !== 'string') return { slug: null, valid: false };
+  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
+  const slug = (match ? match[1] : url).replace(/\.git$/, '').trim();
+  return { slug, valid: SAFE_SLUG_RE.test(slug) };
+}
+
+/** @param {string} slug */
+export function isProtectedRepo(slug) {
+  return PROTECTED_REPOS.has(slug) || PROTECTED_REPOS.has(slug.toLowerCase());
+}
+
+/**
+ * Full teardown for a single venture.
+ *
+ * @param {string} ventureId - UUID of the venture to delete
+ * @param {Object} [options]
+ * @param {boolean} [options.dryRun=false] - Threaded through to runTeardown/credentials
+ * @param {import('@supabase/supabase-js').SupabaseClient} [options.supabase] - Injectable client (tests)
+ * @returns {Promise<{
+ *   success: boolean,
+ *   venture: { id: string, name: string|null },
+ *   phases: Object
+ * }>}
+ */
+export async function deleteVentureFully(ventureId, options = {}) {
+  const { dryRun = false } = options;
+  const supabase = options.supabase || createSupabaseServiceClient();
+
+  const phases = {
+    teardown: null,
+    resources_marked: 0,
+    credentials: { revoked: [], failed: [], skipped: [] },
+    db: { success: false, count: 0 },
+    github_repo: { slug: null, status: 'none' },
+    registry: { cleaned: false },
+  };
+
+  if (!ventureId) {
+    return { success: false, venture: { id: ventureId, name: null }, phases, error: 'ventureId is required' };
+  }
+
+  // Phase 1: collect repo + name BEFORE deletion
+  let repoUrl = null;
+  let ventureName = null;
+  try {
+    const { data: prov } = await supabase
+      .from('venture_provisioning_state')
+      .select('venture_id, venture_name, github_repo_url')
+      .eq('venture_id', ventureId)
+      .maybeSingle();
+    repoUrl = prov?.github_repo_url || null;
+    ventureName = prov?.venture_name || null;
+  } catch (err) {
+    phases.provisioning_error = err.message;
+  }
+
+  // Phase 2: external resource teardown (non-blocking)
+  try {
+    phases.teardown = await runTeardown(ventureId, { dryRun });
+  } catch (err) {
+    phases.teardown = { success: false, error: err.message };
+  }
+
+  // Phase 3: mark venture_resources cleaned (non-blocking)
+  try {
+    phases.resources_marked = await markResourcesCleaned(ventureId);
+  } catch (err) {
+    phases.resources_marked = 0;
+    phases.resources_error = err.message;
+  }
+
+  // Phase 4: revoke credentials BEFORE DB deletion (non-blocking)
+  try {
+    phases.credentials = await cleanupCredentials([ventureId], { dryRun });
+  } catch (err) {
+    phases.credentials = { revoked: [], failed: [{ error: err.message }], skipped: [] };
+  }
+
+  // Phase 5: DB delete via SINGLE-venture RPC (BLOCKING)
+  if (dryRun) {
+    phases.db = { success: true, count: 0, dryRun: true };
+  } else {
+    try {
+      const { data: rpcResult, error: rpcErr } = await supabase.rpc('delete_venture', { p_venture_id: ventureId });
+      if (rpcErr || (rpcResult && rpcResult.success === false)) {
+        phases.db = { success: false, count: 0, error: rpcErr?.message || rpcResult?.error || 'delete_venture failed' };
+        return { success: false, venture: { id: ventureId, name: ventureName }, phases };
+      }
+      phases.db = { success: true, count: 1, deleted_counts: rpcResult?.deleted_counts };
+      if (rpcResult?.venture_name) ventureName = ventureName || rpcResult.venture_name;
+    } catch (err) {
+      phases.db = { success: false, count: 0, error: err.message };
+      return { success: false, venture: { id: ventureId, name: ventureName }, phases };
+    }
+  }
+
+  // Phase 6: delete the GitHub repo (guarded, non-blocking)
+  phases.github_repo = deleteGithubRepo(repoUrl, { dryRun });
+
+  // Phase 7: clean applications/registry.json for this one venture (non-blocking)
+  phases.registry = cleanRegistryEntry(ventureName, { dryRun });
+
+  return { success: true, venture: { id: ventureId, name: ventureName }, phases };
+}
+
+/**
+ * Delete a single GitHub repo behind the PROTECTED_REPOS guard + injection-safe slug.
+ * @returns {{ slug: string|null, status: 'deleted'|'skipped'|'failed'|'none', reason?: string }}
+ */
+function deleteGithubRepo(repoUrl, { dryRun = false } = {}) {
+  if (!repoUrl) return { slug: null, status: 'none' };
+
+  const { slug, valid } = parseRepoSlug(repoUrl);
+  if (!slug || !valid) {
+    return { slug, status: 'failed', reason: 'invalid or unsafe repo slug' };
+  }
+  if (isProtectedRepo(slug)) {
+    return { slug, status: 'skipped', reason: 'PROTECTED — core repo, never deleted' };
+  }
+  if (dryRun) {
+    return { slug, status: 'skipped', reason: 'dryRun' };
+  }
+
+  try {
+    execSync(`gh repo delete ${slug} --yes`, { timeout: 15000, stdio: 'pipe' });
+    return { slug, status: 'deleted' };
+  } catch (err) {
+    const msg = err.stderr?.toString() || err.message || '';
+    if (msg.includes('not found') || msg.includes('404')) {
+      return { slug, status: 'deleted', reason: 'already gone' };
+    }
+    return { slug, status: 'failed', reason: msg.substring(0, 200) };
+  }
+}
+
+/**
+ * Remove a single venture's app entry from applications/registry.json.
+ * Core apps (ehg, ehg_engineer, test-leo-project) are never removed.
+ * @returns {{ cleaned: boolean, error?: string }}
+ */
+function cleanRegistryEntry(ventureName, { dryRun = false } = {}) {
+  if (!ventureName) return { cleaned: false };
+  try {
+    const registryPath = resolve(process.cwd(), 'applications/registry.json');
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+    const apps = registry.applications || {};
+    const coreApps = new Set(['ehg', 'ehg_engineer', 'test-leo-project']);
+    const target = ventureName.toLowerCase();
+
+    let removed = 0;
+    for (const [key, app] of Object.entries(apps)) {
+      const name = (app.name || '').toLowerCase();
+      if (name === target && !coreApps.has(name)) {
+        if (!dryRun) delete apps[key];
+        removed++;
+      }
+    }
+
+    if (removed > 0 && !dryRun) {
+      registry.metadata.total_apps = Object.keys(apps).length;
+      registry.metadata.active_apps = Object.values(apps).filter(a => a.status === 'active').length;
+      registry.metadata.last_updated = new Date().toISOString();
+      writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+    }
+    return { cleaned: removed > 0 };
+  } catch (err) {
+    return { cleaned: false, error: err.message };
+  }
+}
+
+export default deleteVentureFully;

--- a/tests/unit/cleanup/delete-venture-fully.test.js
+++ b/tests/unit/cleanup/delete-venture-fully.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for lib/deleteVentureFully.js
+ *
+ * SD: SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-A (Phase 1)
+ *
+ * Covers: happy path, PROTECTED_REPOS short-circuit, injection-safe slug
+ * rejection, non-blocking phase failure, and blocking DB-delete failure.
+ * All shell/DB/fs side effects are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mock the lifted dependencies (each creates its own client internally) ---
+vi.mock('../../../lib/cleanup/index.js', () => ({
+  runTeardown: vi.fn(() => Promise.resolve({ success: true, providers: {} })),
+}));
+vi.mock('../../../lib/venture-resources.js', () => ({
+  markResourcesCleaned: vi.fn(() => Promise.resolve(1)),
+}));
+vi.mock('../../../lib/cleanup/credentials.js', () => ({
+  cleanup: vi.fn(() => Promise.resolve({ revoked: [{ id: 'c1' }], failed: [], skipped: [] })),
+}));
+// Client factory is unused when we inject options.supabase, but mock it so the
+// import never reaches real env/network.
+vi.mock('../../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: vi.fn(() => makeSupabase({})),
+}));
+
+// --- Mock shell + filesystem ---
+const execSyncMock = vi.fn(() => Buffer.from(''));
+vi.mock('child_process', () => ({ execSync: (...a) => execSyncMock(...a) }));
+
+const writeFileSyncMock = vi.fn();
+let registryJson;
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(() => JSON.stringify(registryJson)),
+  writeFileSync: (...a) => writeFileSyncMock(...a),
+}));
+
+/**
+ * Build a configurable supabase mock.
+ * @param {Object} cfg
+ * @param {Object} [cfg.prov] - venture_provisioning_state row
+ * @param {Object} [cfg.rpc]  - { data, error } returned by .rpc('delete_venture')
+ */
+function makeSupabase({ prov = null, rpc = { data: { success: true, venture_name: 'TestVenture' }, error: null } }) {
+  const rpcMock = vi.fn(() => Promise.resolve(rpc));
+  const client = {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: prov, error: null })),
+        })),
+      })),
+    })),
+    rpc: rpcMock,
+  };
+  client.__rpc = rpcMock;
+  return client;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  execSyncMock.mockReturnValue(Buffer.from(''));
+  registryJson = {
+    applications: {
+      APP001: { id: 'APP001', name: 'ehg', status: 'active' },
+      APP050: { id: 'APP050', name: 'TestVenture', status: 'active' },
+    },
+    metadata: { total_apps: 2, active_apps: 2, last_updated: '2026-01-01' },
+  };
+});
+
+describe('deleteVentureFully', () => {
+  it('TS-1: happy path runs all phases and uses the single-venture RPC', async () => {
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const supabase = makeSupabase({
+      prov: { venture_id: 'v1', venture_name: 'TestVenture', github_repo_url: 'https://github.com/rickfelix/test-venture.git' },
+    });
+
+    const result = await deleteVentureFully('v1', { supabase });
+
+    expect(result.success).toBe(true);
+    // Single-venture RPC, never the portfolio RPC
+    expect(supabase.__rpc).toHaveBeenCalledWith('delete_venture', { p_venture_id: 'v1' });
+    expect(supabase.__rpc).not.toHaveBeenCalledWith('master_reset_portfolio', expect.anything());
+    // Repo deleted via gh
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    expect(execSyncMock.mock.calls[0][0]).toContain('gh repo delete rickfelix/test-venture --yes');
+    expect(result.phases.github_repo.status).toBe('deleted');
+    // Registry cleaned + written
+    expect(result.phases.registry.cleaned).toBe(true);
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    // Per-phase breakdown present
+    expect(result.phases.db.success).toBe(true);
+    expect(result.phases.credentials.revoked.length).toBe(1);
+  });
+
+  it('TS-2: PROTECTED_REPOS slug is never shelled out', async () => {
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const supabase = makeSupabase({
+      prov: { venture_id: 'v1', venture_name: 'Core', github_repo_url: 'https://github.com/rickfelix/ehg.git' },
+    });
+
+    const result = await deleteVentureFully('v1', { supabase });
+
+    expect(result.phases.github_repo.status).toBe('skipped');
+    expect(result.phases.github_repo.reason).toContain('PROTECTED');
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('TS-3: malformed/injection slug is rejected before any shell call', async () => {
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const supabase = makeSupabase({
+      prov: { venture_id: 'v1', venture_name: 'Evil', github_repo_url: 'https://github.com/rickfelix/test;rm -rf ~' },
+    });
+
+    const result = await deleteVentureFully('v1', { supabase });
+
+    expect(result.phases.github_repo.status).toBe('failed');
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: a non-blocking credential failure does not abort teardown', async () => {
+    const credentials = await import('../../../lib/cleanup/credentials.js');
+    credentials.cleanup.mockRejectedValueOnce(new Error('provider down'));
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const supabase = makeSupabase({
+      prov: { venture_id: 'v1', venture_name: 'TestVenture', github_repo_url: 'https://github.com/rickfelix/test-venture.git' },
+    });
+
+    const result = await deleteVentureFully('v1', { supabase });
+
+    expect(result.success).toBe(true);
+    expect(result.phases.credentials.failed.length).toBeGreaterThan(0);
+    expect(supabase.__rpc).toHaveBeenCalledWith('delete_venture', { p_venture_id: 'v1' });
+  });
+
+  it('TS-5: a DB-delete failure is blocking and skips repo/registry', async () => {
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const supabase = makeSupabase({
+      prov: { venture_id: 'v1', venture_name: 'TestVenture', github_repo_url: 'https://github.com/rickfelix/test-venture.git' },
+      rpc: { data: { success: false, error: 'cascade blocked' }, error: null },
+    });
+
+    const result = await deleteVentureFully('v1', { supabase });
+
+    expect(result.success).toBe(false);
+    expect(result.phases.db.success).toBe(false);
+    expect(result.phases.github_repo.status).toBe('none');
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a ventureId', async () => {
+    const { deleteVentureFully } = await import('../../../lib/deleteVentureFully.js');
+    const result = await deleteVentureFully(undefined, { supabase: makeSupabase({}) });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/ventureId/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001 (single-venture + bulk delete full teardown parity).

Adds `lib/deleteVentureFully.js` — a reusable single-venture teardown helper that lifts master-reset phases 1-6 (`server/routes/ventures.js`) but scopes them to one venture via the `delete_venture(p_venture_id)` RPC instead of the portfolio-wide `master_reset_portfolio`.

## Changes
- Reuses `runTeardown`, `markResourcesCleaned`, `cleanupCredentials`, the `PROTECTED_REPOS` guard, and the registry edit (no teardown logic duplicated).
- Adds an **injection-safe slug regex** (`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`) — hardening over master-reset, which only counted path segments.
- Returns a **structured per-phase result**; only the DB delete is blocking, all other phases capture failures.
- `PROTECTED_REPOS` now lives in the helper as the canonical source (sibling B refactors the route to import it).

## Tests
6 unit tests (`tests/unit/cleanup/delete-venture-fully.test.js`) mocking `execSync`/supabase/`fs`: happy path, PROTECTED_REPOS skip, injection-safe slug rejection, non-blocking credential failure, blocking DB failure, missing ventureId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)