### PR TITLE
fix(SD-FDBK-ENH-WIRE-CHECK-GATE-001): WIRE_CHECK_GATE traces server-route-only lib modules

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -87,10 +87,13 @@ export function isExcludedFromWireCheck(file) {
 /**
  * Discover entry point files from package.json scripts and known pipeline scripts.
  *
+ * Exported (SD-FDBK-ENH-WIRE-CHECK-GATE-001) so unit tests can assert the
+ * discovered entry set directly without invoking the whole gate.
+ *
  * @param {string} rootDir - Project root
  * @returns {string[]} Absolute paths (forward slashes)
  */
-function discoverEntryPoints(rootDir) {
+export function discoverEntryPoints(rootDir) {
   const entries = new Set();
   const normalize = (p) => p.replace(/\\/g, '/');
 
@@ -130,12 +133,21 @@ function discoverEntryPoints(rootDir) {
   }
 
   // 2. Known pipeline entry points
+  //
+  // SD-FDBK-ENH-WIRE-CHECK-GATE-001: server/index.js is the Express HTTP entry
+  // point. It is NOT referenced by any package.json script and was not among
+  // the pipeline entries, so lib/ modules reachable ONLY through a server route
+  // (server/index.js -> server/routes/*.js -> lib/...) had no traversal root and
+  // false-positived as "unreachable" (e.g. lib/eva/stage-17/refinement.js via the
+  // /api/stage17 route). Seeding it pairs with the server/ scope addition in
+  // getScopedJsFiles below — both are required for the chain to resolve.
   const knownEntries = [
     'scripts/leo-orchestrator-enforced.js',
     'scripts/handoff.js',
     'scripts/sd-next.js',
     'scripts/eva/eva-pipeline.js',
     'scripts/generate-claude-md-from-db.js',
+    'server/index.js',
   ];
 
   for (const entry of knownEntries) {
@@ -146,20 +158,29 @@ function discoverEntryPoints(rootDir) {
 }
 
 /**
- * Get all JS files in the project scope (lib + scripts directories).
+ * Get all JS files in the project scope (lib + scripts + server directories).
+ *
+ * Exported (SD-FDBK-ENH-WIRE-CHECK-GATE-001) so unit tests can assert the
+ * scoped file set directly without invoking the whole gate.
  *
  * @param {string} rootDir - Project root
  * @returns {string[]} Absolute paths (forward slashes)
  */
-function getScopedJsFiles(rootDir) {
+export function getScopedJsFiles(rootDir) {
   const normalize = (p) => p.replace(/\\/g, '/');
   try {
     // QF-20260509-393: 'scripts/**/*.js' git pathspec WITHOUT globstar config
     // does NOT match flat scripts/*.js (no subdirectory). Was silently excluding
     // hundreds of flat files (handoff.js, sd-next.js, fleet-dashboard.cjs, etc.).
     // Fix: list directories recursively, filter by extension in JS.
+    //
+    // SD-FDBK-ENH-WIRE-CHECK-GATE-001: include server/ so Express route modules
+    // become nodes in the call graph. Without them, a lib/ module reachable only
+    // via server/index.js -> server/routes/*.js -> lib/... is unreachable in the
+    // graph and false-positives. Pairs with the server/index.js entry point seed
+    // in discoverEntryPoints above.
     const result = execSync(
-      'git ls-files -- "lib/" "scripts/"',
+      'git ls-files -- "lib/" "scripts/" "server/"',
       { encoding: 'utf8', cwd: rootDir, timeout: 15000 }
     );
     return result

--- a/tests/unit/gates/wire-check-gate.test.js
+++ b/tests/unit/gates/wire-check-gate.test.js
@@ -336,3 +336,119 @@ describe('wire-check-gate exports SD-LEO-INFRA-WIRE-CHECK-GATE-001 fix surface',
     expect(catchBlock).not.toMatch(/passed:\s*true/);
   });
 });
+
+// ─── SD-FDBK-ENH-WIRE-CHECK-GATE-001: server/ scope + server entry point ──
+// A lib/ module reachable ONLY through an Express route
+// (server/index.js -> server/routes/*.js -> lib/...) was flagged unreachable
+// because getScopedJsFiles scanned only lib/+scripts/ and discoverEntryPoints
+// never seeded server/index.js. These tests pin both scope surfaces and prove
+// the reachability semantics (positive) while preserving orphan detection
+// (negative control), per the prospective testing-agent truth table.
+describe('wire-check-gate server-route scope (SD-FDBK-ENH-WIRE-CHECK-GATE-001)', () => {
+  let getScopedJsFiles;
+  let discoverEntryPoints;
+  let buildCallGraph;
+  let checkReachability;
+  let REPO_ROOT;
+
+  beforeEach(async () => {
+    const url = await import('url');
+    const __filename2 = url.fileURLToPath(import.meta.url);
+    const __dirname2 = path.dirname(__filename2);
+    REPO_ROOT = path.resolve(__dirname2, '../../../');
+
+    const gateMod = await import(
+      '../../../scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js'
+    );
+    getScopedJsFiles = gateMod.getScopedJsFiles;
+    discoverEntryPoints = gateMod.discoverEntryPoints;
+
+    const cgMod = await import('../../../lib/static-analysis/call-graph-builder.js');
+    buildCallGraph = cgMod.buildCallGraph;
+    const rcMod = await import('../../../lib/static-analysis/reachability-checker.js');
+    checkReachability = rcMod.checkReachability;
+  });
+
+  // FR-001 (live repo): server/ files are now in the call-graph scope
+  it('getScopedJsFiles includes server route modules and server/index.js', () => {
+    const files = getScopedJsFiles(REPO_ROOT);
+    expect(Array.isArray(files)).toBe(true);
+    expect(files.some((f) => f.endsWith('/server/index.js'))).toBe(true);
+    expect(files.some((f) => f.endsWith('/server/routes/stage17.js'))).toBe(true);
+  });
+
+  // FR-002 (live repo): server/index.js is a discovered entry point
+  it('discoverEntryPoints seeds server/index.js as an entry point', () => {
+    const entries = discoverEntryPoints(REPO_ROOT);
+    const expected = path.resolve(REPO_ROOT, 'server/index.js').replace(/\\/g, '/');
+    expect(entries).toContain(expected);
+  });
+
+  // FR-003 (positive fixture): a lib leaf reachable only via entry->route->lib
+  // is classified reachable — mirrors the gate's own scope+entry pipeline.
+  it('classifies a server-route-only lib module as reachable', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wire-srv-pos-'));
+    try {
+      fs.mkdirSync(path.join(tmpDir, 'server', 'routes'), { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, 'lib'), { recursive: true });
+      const leaf = path.join(tmpDir, 'lib', 'leaf.js');
+      const route = path.join(tmpDir, 'server', 'routes', 'r.js');
+      const index = path.join(tmpDir, 'server', 'index.js');
+      fs.writeFileSync(leaf, 'export const leaf = 1;');
+      fs.writeFileSync(route, "import { leaf } from '../../lib/leaf.js';\nexport default leaf;");
+      fs.writeFileSync(index, "import r from './routes/r.js';\nconsole.log(r);");
+
+      const allFiles = [index, route, leaf].map((f) => f.replace(/\\/g, '/'));
+      const entryPoints = [index.replace(/\\/g, '/')]; // as discoverEntryPoints would seed
+      const leafNorm = leaf.replace(/\\/g, '/');
+
+      const { graph } = buildCallGraph(allFiles, tmpDir);
+      const { reachable, unreachable } = checkReachability(graph, entryPoints, [leafNorm]);
+
+      expect(reachable.has(leafNorm)).toBe(true);
+      expect(unreachable.size).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // FR-004 (negative control): a genuinely orphaned lib file stays unreachable
+  // even with server/ in scope + the server entry seeded — no over-broadening.
+  it('still flags a genuinely orphaned lib module as unreachable', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wire-srv-neg-'));
+    try {
+      fs.mkdirSync(path.join(tmpDir, 'server'), { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, 'lib'), { recursive: true });
+      const orphan = path.join(tmpDir, 'lib', 'orphan.js');
+      const index = path.join(tmpDir, 'server', 'index.js');
+      fs.writeFileSync(orphan, 'export const o = 1;'); // imported by nobody
+      fs.writeFileSync(index, "console.log('no imports here');");
+
+      const allFiles = [index, orphan].map((f) => f.replace(/\\/g, '/'));
+      const entryPoints = [index.replace(/\\/g, '/')];
+      const orphanNorm = orphan.replace(/\\/g, '/');
+
+      const { graph } = buildCallGraph(allFiles, tmpDir);
+      const { reachable, unreachable } = checkReachability(graph, entryPoints, [orphanNorm]);
+
+      expect(unreachable.has(orphanNorm)).toBe(true);
+      expect(reachable.size).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // FR-005 (source pins): guard the two scope surfaces against regression.
+  it('source pins the server/ pathspec and the server/index.js entry', async () => {
+    const url = await import('url');
+    const __filename2 = url.fileURLToPath(import.meta.url);
+    const __dirname2 = path.dirname(__filename2);
+    const gateFile = path.resolve(__dirname2, '../../../scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js');
+    const source = fs.readFileSync(gateFile, 'utf8');
+    expect(source).toMatch(/git ls-files[^\n]*"server\/"/);
+    expect(source).toMatch(/['"`]server\/index\.js['"`]/);
+    // Both functions must be exported for the assertions above to import them.
+    expect(source).toMatch(/export function getScopedJsFiles/);
+    expect(source).toMatch(/export function discoverEntryPoints/);
+  });
+});


### PR DESCRIPTION
## Summary
`WIRE_CHECK_GATE` (the LEAD-FINAL-APPROVAL static-analysis reachability gate) false-positived on `lib/` modules reachable **only** through an Express route. Its `getScopedJsFiles()` scanned only `lib/`+`scripts/` and `discoverEntryPoints()` seeded entry points from `package.json` scripts + 5 pipeline scripts — never `server/`. So the static chain `server/index.js → server/routes/stage17.js → lib/eva/stage-17/selection-flow.js → refinement.js` was never traced and the leaf was flagged unreachable (originally hit on SD-LEO-REFAC-EXTRACT-S17-ARCHETYPE-001, which had to bypass the gate).

## Changes (`scripts/modules/handoff/.../gates/wire-check-gate.js`)
1. `getScopedJsFiles` git pathspec: `lib/ scripts/` → `lib/ scripts/ server/` (server route modules become call-graph nodes).
2. `discoverEntryPoints` `knownEntries` += `server/index.js` (the real HTTP entry-point seed).
3. `export` both functions for direct unit testing.

Both changes are **jointly required** — a prospective testing-agent run built the real acorn call graph and proved it via truth table: neither change alone resolves the chain; both together do.

## Tests (`tests/unit/gates/wire-check-gate.test.js`, +5)
- FR-001/002 live-repo pins: `server/routes/stage17.js` + `server/index.js` in scope; `server/index.js` discovered as entry.
- FR-003 positive: server-route-only lib leaf classified reachable.
- FR-004 **negative control**: a genuinely orphaned `lib/` file stays unreachable (no over-broadening — only 14.6% of scope reachable).
- FR-005 source pins for the pathspec, entry literal, and both exports.

**47/47 wire-check tests pass.** 0 new acorn parse warnings (30 server files). This SD dogfoods its own gate at LEAD-FINAL-APPROVAL.

sd_type: infrastructure | LEAD-TO-PLAN 95 · PLAN-TO-EXEC 97 · PLAN-TO-LEAD 93

🤖 Generated with [Claude Code](https://claude.com/claude-code)