### PR TITLE
fix(QF-20260524-711): pocock-weekly-deepening insufficient findings is a no-op

### DIFF
--- a/scripts/pocock/weekly-deepening-report.mjs
+++ b/scripts/pocock/weekly-deepening-report.mjs
@@ -165,13 +165,22 @@ async function main() {
     process.exit(1);
   }
   if (!findings || findings.length < opts.minCandidates) {
-    const msg = `Insufficient unconsumed findings (${(findings || []).length} < ${opts.minCandidates})`;
-    if (opts.dryRun) {
-      process.stdout.write(JSON.stringify({ dry_run: true, candidates_available: (findings || []).length, message: msg }) + '\n');
-      process.exit(0);
-    }
-    await emitFailureFeedback(msg);
-    process.exit(1);
+    // QF-20260524-711: "no unconsumed findings to deepen this week" is a normal
+    // quiet-week NO-OP, not a failure. Previously the emit path called
+    // emitFailureFeedback() + exit 1, turning the Friday cron red on main and
+    // spamming the inbox with pocock_weekly_deepening_failure rows (e.g. "0 < 3").
+    // Treat insufficient INPUT as a graceful no-op in BOTH dry-run and emit modes.
+    // (The post-emission shortfall path below — findings existed but emission fell
+    // short — remains a real failure, since that signals a scoring/emit defect.)
+    const msg = `Insufficient unconsumed findings (${(findings || []).length} < ${opts.minCandidates}) — no-op`;
+    process.stdout.write(JSON.stringify({
+      no_op: true,
+      dry_run: !!opts.dryRun,
+      candidates_available: (findings || []).length,
+      min_candidates: opts.minCandidates,
+      message: msg,
+    }) + '\n');
+    process.exit(0);
   }
 
   if (opts.dryRun) {

--- a/tests/unit/pocock/weekly-deepening-noop.test.js
+++ b/tests/unit/pocock/weekly-deepening-noop.test.js
@@ -1,0 +1,51 @@
+/**
+ * QF-20260524-711 — pocock-weekly-deepening insufficient-findings is a no-op
+ *
+ * Regression guard: "no unconsumed findings to deepen this week" must be a
+ * graceful no-op (exit 0), NOT a CI failure (emitFailureFeedback + exit 1).
+ * The post-emission shortfall path (findings existed but emission fell short)
+ * must REMAIN a real failure. Source-level pins (no DB / network required).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(
+  __dirname,
+  '../../../scripts/pocock/weekly-deepening-report.mjs'
+);
+
+const source = fs.readFileSync(SCRIPT, 'utf8');
+
+describe('pocock weekly-deepening: insufficient findings is a no-op (QF-20260524-711)', () => {
+  // Isolate the insufficient-INPUT branch precisely: from its message up to the
+  // next structural delimiter (`if (opts.dryRun)` — the emit-path early return
+  // that immediately follows the branch). This window is exactly the branch body.
+  const branch = (() => {
+    const start = source.indexOf('Insufficient unconsumed findings');
+    expect(start).toBeGreaterThan(-1);
+    const after = source.indexOf('if (opts.dryRun)', start);
+    expect(after).toBeGreaterThan(start);
+    return source.slice(start, after);
+  })();
+
+  it('exits 0 (no-op) on insufficient input — both modes', () => {
+    expect(branch).toMatch(/no_op:\s*true/);
+    expect(branch).toMatch(/process\.exit\(0\)/);
+  });
+
+  it('does NOT emit failure feedback or exit 1 on insufficient input', () => {
+    expect(branch).not.toMatch(/emitFailureFeedback/);
+    expect(branch).not.toMatch(/process\.exit\(1\)/);
+  });
+
+  it('PRESERVES the post-emission shortfall path as a real failure', () => {
+    // "Emitted N < min" path (findings existed but emission fell short) must
+    // still surface as a failure — guards against over-broadening the fix.
+    const block = source.slice(source.indexOf('`Emitted '), source.indexOf('`Emitted ') + 400);
+    expect(block).toMatch(/emitFailureFeedback/);
+    expect(block).toMatch(/process\.exit\(1\)/);
+  });
+});


### PR DESCRIPTION
## Problem
`scripts/pocock/weekly-deepening-report.mjs --emit-sds` (the Friday cron) called `emitFailureFeedback()` + `process.exit(1)` whenever unconsumed `architectural_prevention_findings` were below `--min-candidates` (e.g. `0 < 3`). A quiet week with no new findings to deepen is a **normal no-op**, not a failure — but it turned the cron red on `main` and spammed `pocock_weekly_deepening_failure` inbox rows (resolves feedback `babd1b61` / `fca9cd85`).

## Fix (~10 source LOC)
The insufficient-**input** branch now exits 0 with an informational `{no_op:true, candidates_available, min_candidates}` payload in **both** dry-run and emit modes (mirroring the existing dry-run behavior). The post-emission shortfall path (line ~201 — findings existed but emission fell short) **stays a real failure**, since that signals a scoring/emit defect.

## Tests
+3 source-pin regression tests (`tests/unit/pocock/weekly-deepening-noop.test.js`, no DB/network needed): insufficient input exits 0 / emits no failure feedback / does not exit 1; and the shortfall path is preserved as a real failure (guards against over-broadening).

Tier 1 quick-fix. 🤖 Generated with [Claude Code](https://claude.com/claude-code)