### PR TITLE
fix(QF-20260524-350): cap auto-child SD title at varchar(500)

### DIFF
--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -397,10 +397,14 @@ async function main() {
         traceability: archKey ? 'arch_dimension' : 'vision_dimension'
       }));
 
+      // QF-20260524-350: the title column is varchar(500); a long Implementation
+      // Phase title/prose overflowed it (22001). Cap it like description/scope/rationale.
+      const rawChildTitle = `Phase ${phase.number}: ${phase.title}`;
+      const childTitle = rawChildTitle.length > 500 ? `${rawChildTitle.slice(0, 497)}...` : rawChildTitle;
       const childSD = {
         id: childId,
         sd_key: childKey,
-        title: `Phase ${phase.number}: ${phase.title}`,
+        title: childTitle,
         description: phase.description || phase.content?.trim().slice(0, 2000) || `Phase ${phase.number}: ${phase.title}`,
         sd_type: childType,
         category: orchestratorSD.category,


### PR DESCRIPTION
## Summary
`create-orchestrator-from-plan.js --auto-children` wrote `Phase N: <phase.title>` directly into the child SD `title` column (`varchar(500)`) with no cap. A long Implementation Phase title/prose therefore threw `22001 value too long for type character varying(500)` and aborted orchestrator decomposition. Sibling fields (`description`/`scope` sliced to 2000, `rationale` to 500) were already bounded — the title was the lone gap.

## Fix
Cap the child title at 500 chars (497 + `...`) before the insert. ~4 LOC.

## Test
- `node --check` passes.
- Logic verified: 800-char title → 500 chars ending `...`; short title unchanged.

Resolves harness_backlog `70632ea0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)