### PR TITLE
fix(QF-20260524-587): granular --accept-compliance-warn for complete-quick-fix

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -89,6 +89,8 @@ export function parseArguments(args) {
       'auto-pr':            { type: 'boolean' },
       // QF-20260511-258: bypass resolver-freshness stale-branch guard. Requires reason.
       'allow-stale-branch': { type: 'boolean' },
+      // QF-20260524-587: granular WARN-verdict compliance bypass. Requires reason.
+      'accept-compliance-warn': { type: 'boolean' },
       'help':               { type: 'boolean', short: 'h' }
     },
     allowPositionals: true,
@@ -130,6 +132,16 @@ export function parseArguments(args) {
     );
   }
 
+  // QF-20260524-587: --accept-compliance-warn REQUIRES --reason. It clears ONLY the
+  // WARN-verdict compliance prompt (so completion works under --non-interactive) and does
+  // NOT bypass FAIL-verdict, the LOC cap, or self-verification — unlike --force-complete.
+  if (values['accept-compliance-warn'] && !values['reason']) {
+    throw new Error(
+      '[ACCEPT_COMPLIANCE_WARN_NO_REASON] --accept-compliance-warn requires --reason "<text>". ' +
+      'It clears ONLY the WARN-verdict compliance prompt (not FAIL/LOC/self-verification) and is recorded in verification_notes.'
+    );
+  }
+
   // FR-3: persist --non-interactive so prompt() can fail-fast
   if (values['non-interactive']) {
     _nonInteractiveMode = true;
@@ -150,6 +162,7 @@ export function parseArguments(args) {
     forceComplete:     values['force-complete']   || false,
     reason:            values['reason'],
     overCapReason:     values['over-cap-reason']   || undefined,
+    acceptComplianceWarn: values['accept-compliance-warn'] || false,
     nonInteractive:    values['non-interactive'] || false,
     // QF-20260509-407: --auto-pr opt-in flag, plus auto-enable under --non-interactive
     // when no --pr-url provided. Eliminates the mid-run prompt-then-throw pattern
@@ -200,6 +213,10 @@ Options:
                         Use only when shipping is the right call despite worker being
                         forked before a resolver-relevant fix landed in main. The
                         auto-resolver will likely no-op for this completion.
+  --accept-compliance-warn  Clear ONLY the WARN-verdict compliance prompt (so completion
+                        works under --non-interactive). REQUIRES --reason. Does NOT bypass
+                        FAIL-verdict, the LOC cap, or self-verification — narrower and safer
+                        than --force-complete. Recorded in verification_notes.
   --help, -h            Show this help
 
 Programmatic Verification:

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -353,6 +353,7 @@ export async function completeQuickFix(qfId, options = {}) {
   // with validateLOC and validateSelfVerification).
   const complianceValid = await validateCompliance(complianceResults, prompt, {
     forceComplete: options.forceComplete,
+    acceptComplianceWarn: options.acceptComplianceWarn,
     reason: options.reason
   });
   if (!complianceValid) {

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -363,6 +363,14 @@ export async function validateCompliance(complianceResults, prompt, flags = {}) 
       return true;
     }
 
+    // QF-20260524-587: --accept-compliance-warn clears ONLY this WARN-verdict prompt
+    // (so completion works under --non-interactive) WITHOUT the over-broad --force-complete
+    // (which also clears FAIL/LOC/self-verification). Audit trail in verification_notes.
+    if (flags.acceptComplianceWarn) {
+      console.log(`   ⚠️  --accept-compliance-warn: WARN-verdict prompt cleared (reason="${flags.reason}"). FAIL/LOC/self-verification gates still enforced.\n`);
+      return true;
+    }
+
     const proceedCompliance = await prompt('   Proceed with completion? (yes/no): ');
     if (!proceedCompliance.toLowerCase().startsWith('y')) {
       console.log('\n   Completion cancelled. Improve compliance score and try again.\n');


### PR DESCRIPTION
## Summary
complete-quick-fix's WARN-verdict compliance branch (`verification.js`) calls `prompt()`, which throws under `--non-interactive`. Previously the **only** escape was `--force-complete` — but that also bypasses FAIL-verdict, the LOC cap, and self-verification (over-broad).

This adds a narrow, audited **`--accept-compliance-warn`** flag (requires `--reason`, mirrors `--over-cap-reason` / `--allow-stale-branch`) that clears **only** the WARN-verdict prompt. FAIL-verdict, the source-LOC cap, and self-verification stay enforced.

## Changes (~18 LOC, 3 files)
- `cli.js` — parse `--accept-compliance-warn`, require `--reason`, map to `options.acceptComplianceWarn`, help text.
- `orchestrator.js` — thread the flag into `validateCompliance`.
- `verification.js` — WARN branch: granular clear when the flag is set.

## Verification
- `--accept-compliance-warn` without `--reason` → throws `ACCEPT_COMPLIANCE_WARN_NO_REASON`.
- WARN verdict + flag → returns true (no prompt).
- **FAIL verdict + flag → still returns false** (not bypassed — proves granularity vs `--force-complete`).
- `node --check` passes on all 3 files.

Resolves harness_backlog `5fa4b871`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)