### PR TITLE
feat(SD-FDBK-ENH-GATE2-FIDELITY-AWARE-001): N/A-aware GATE2 Database fidelity for zero-DB SDs

### DIFF
--- a/scripts/modules/implementation-fidelity/sections/database-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/database-fidelity.js
@@ -60,6 +60,30 @@ export async function validateDatabaseFidelity(sd_id, databaseAnalysis, validati
     return;
   }
 
+  // SD-FDBK-ENH-GATE2-FIDELITY-AWARE-001: N/A-aware Section B. When the SD has a
+  // genuinely zero database footprint — no migration files AND no database queries
+  // (no supabase .from()/.rpc(), no SQL DDL/DML) anywhere in its diff — the
+  // migration-centric Database Implementation Fidelity checks are Not Applicable.
+  // Award full credit (mirrors the SKIP/exempt/ADVISORY idiom above) instead of the
+  // ~18-19/35 partial that dragged frontend-only feature SDs to a RED verdict
+  // (regressed SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-C: 77% despite Design 20/25
+  // + E2E 20/20 + TESTING PASS). Target-agnostic: keys on real DB signal, NOT
+  // sd_type/target, so a sd_type=feature targeting the EHG frontend qualifies — the
+  // existing sd_type==='frontend' frontend_mode did not catch it. Conservative: ANY
+  // DB signal (or a detection error) falls through to normal Section B scoring.
+  const dbScope = await detectDatabaseScope(sd_id, supabase);
+  if (!dbScope.hasMigrations && !dbScope.hasQueries) {
+    validation.score += 35;
+    validation.gate_scores.database_fidelity = 35;
+    validation.details.database_fidelity = {
+      applicable: false,
+      reason: 'Not applicable — SD has zero database footprint (no migration files, no database queries detected)',
+      db_scope: dbScope,
+    };
+    console.log('   ✅ Section B N/A — zero database footprint (no migrations, no DB queries) — full credit (35/35)');
+    return;
+  }
+
   let sectionScore = 0;
   const sectionDetails = {};
   sectionDetails.exemptions = { B1: isB1Exempt, B2: isB2Exempt, B3: isB3Exempt };
@@ -204,6 +228,65 @@ export async function validateDatabaseFidelity(sd_id, databaseAnalysis, validati
   validation.gate_scores.database_fidelity = sectionScore;
   validation.details.database_fidelity = sectionDetails;
   console.log(`\n   Section B Score: ${sectionScore}/35`);
+}
+
+/**
+ * SD-FDBK-ENH-GATE2-FIDELITY-AWARE-001: Detect whether an SD has any database
+ * footprint, used to decide if Section B (Database Implementation Fidelity) is
+ * Not Applicable. Two independent signals:
+ *   - hasMigrations: an SD-matched migration file exists on disk (filesystem scan,
+ *     same dirs/match as B1).
+ *   - hasQueries: the SD's diff contains a database query signal — a supabase
+ *     client call (.from( / .rpc() or SQL DDL/DML (CREATE/ALTER TABLE, INSERT,
+ *     UPDATE ... SET, DELETE FROM, CREATE POLICY).
+ * Conservative on failure: returns hasMigrations/hasQueries = true (detection_error)
+ * so a scan failure falls through to normal scoring rather than granting a free N/A.
+ *
+ * @param {string} sd_id
+ * @param {Object} supabase
+ * @returns {Promise<{hasMigrations: boolean, hasQueries: boolean, detection_error?: boolean}>}
+ */
+async function detectDatabaseScope(sd_id, supabase) {
+  try {
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    const searchTerms = await getSDSearchTerms(sd_id, supabase);
+    const searchLower = searchTerms.map(t => t.replace('SD-', '').toLowerCase());
+
+    // Signal 1: SD-matched migration files on disk (mirrors B1 detection).
+    let hasMigrations = false;
+    const migrationDirs = ['database/migrations', 'supabase/migrations', 'migrations'];
+    for (const repo of implementationRepos) {
+      for (const dir of migrationDirs) {
+        const fullPath = path.join(repo, dir);
+        if (existsSync(fullPath)) {
+          const files = await readdir(fullPath);
+          if (files.some(f => searchLower.some(term => f.toLowerCase().includes(term)))) {
+            hasMigrations = true;
+          }
+        }
+      }
+    }
+
+    // Signal 2: database query signals in the SD's diff.
+    let gitDiff = '';
+    for (const repo of implementationRepos) {
+      try {
+        gitDiff += await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
+          searchTerms,
+          { timeout: 15000 }
+        );
+      } catch (_) { /* skip repos without matching commits */ }
+    }
+    const dbSignal = /\.from\(|\.rpc\(|create\s+table|alter\s+table|insert\s+into|update\s+\w+\s+set|delete\s+from|create\s+policy|alter\s+policy/i;
+    const hasQueries = dbSignal.test(gitDiff);
+
+    return { hasMigrations, hasQueries };
+  } catch (error) {
+    // Conservative: on detection failure, do NOT grant the N/A pass — fall through
+    // to normal Section B scoring.
+    return { hasMigrations: true, hasQueries: true, detection_error: true };
+  }
 }
 
 /**

--- a/tests/unit/implementation-fidelity/database-fidelity-na-aware.test.js
+++ b/tests/unit/implementation-fidelity/database-fidelity-na-aware.test.js
@@ -1,0 +1,106 @@
+/**
+ * SD-FDBK-ENH-GATE2-FIDELITY-AWARE-001 — N/A-aware Section B (Database
+ * Implementation Fidelity).
+ *
+ * When an SD has a genuinely zero database footprint (no SD-matched migration
+ * files AND no database query signals in its diff), Section B is Not Applicable
+ * and earns full credit (35/35) — instead of the ~18-19/35 partial that dragged
+ * frontend-only feature SDs to a RED GATE2 verdict (regressed
+ * SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-C). Any DB signal falls through to
+ * normal scoring (conservative).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted holder so the vi.mock factory can read per-test git-diff content.
+const h = vi.hoisted(() => ({ repos: [], gitDiff: '', throwRepos: false }));
+
+vi.mock('../../../scripts/modules/implementation-fidelity/utils/index.js', () => ({
+  getSDSearchTerms: async () => ['SD-TEST-001'],
+  detectImplementationRepos: async () => {
+    if (h.throwRepos) throw new Error('repo detection boom');
+    return h.repos;
+  },
+  gitLogForSD: async () => h.gitDiff,
+}));
+
+const { validateDatabaseFidelity } = await import(
+  '../../../scripts/modules/implementation-fidelity/sections/database-fidelity.js'
+);
+
+function makeValidation({ sd_type = 'feature', target_application = 'EHG' } = {}) {
+  return {
+    passed: true,
+    score: 0,
+    issues: [],
+    warnings: [],
+    details: { sd_type, target_application },
+    gate_scores: {},
+  };
+}
+
+// Section B never reaches a live DB in the zero-DB / no-migration paths, but the
+// signature requires a supabase arg. Provide a minimal chainable stub.
+function makeSupabase() {
+  const chain = {
+    from: () => chain,
+    select: () => Promise.resolve({ data: [], error: null }),
+    eq: () => chain,
+  };
+  return chain;
+}
+
+const DB_ANALYSIS = { tables: ['noop'] }; // truthy → passes the !databaseAnalysis early-return
+
+describe('GATE2 Section B — N/A-aware database fidelity (SD-...-FIDELITY-AWARE-001)', () => {
+  // A fake repo path (no migration dirs on disk → hasMigrations=false) so the diff
+  // scan actually runs and detection keys purely on the git-diff signal.
+  beforeEach(() => { h.repos = ['/fake/repo']; h.gitDiff = ''; h.throwRepos = false; });
+
+  it('zero DB footprint (no migrations, no queries) → Section B N/A, full credit 35/35', async () => {
+    h.gitDiff = 'diff --git a/src/components/Foo.tsx b/src/components/Foo.tsx\n+ const x = 1;';
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', DB_ANALYSIS, v, makeSupabase());
+
+    expect(v.gate_scores.database_fidelity).toBe(35);
+    expect(v.details.database_fidelity.applicable).toBe(false);
+    expect(v.details.database_fidelity.reason).toMatch(/Not applicable.*zero database footprint/i);
+  });
+
+  it('diff with supabase .from() → NOT N/A, falls through to normal scoring', async () => {
+    h.gitDiff = 'diff --git a/x.js b/x.js\n+ const { data } = await supabase.from("ventures").select("*");';
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', DB_ANALYSIS, v, makeSupabase());
+
+    // The N/A early-return must NOT have fired.
+    expect(v.details.database_fidelity.applicable).not.toBe(false);
+  });
+
+  it('diff with supabase .rpc() → NOT N/A (client DB call counts as a query)', async () => {
+    h.gitDiff = '+ await supabase.rpc("delete_venture", { p_venture_id: id });';
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', DB_ANALYSIS, v, makeSupabase());
+    expect(v.details.database_fidelity.applicable).not.toBe(false);
+  });
+
+  it('diff with SQL DDL (CREATE TABLE) → NOT N/A', async () => {
+    h.gitDiff = '+ CREATE TABLE public.things (id uuid primary key);';
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', DB_ANALYSIS, v, makeSupabase());
+    expect(v.details.database_fidelity.applicable).not.toBe(false);
+  });
+
+  it('conservative: a scope-detection error does NOT grant the N/A pass', async () => {
+    h.throwRepos = true; // detectDatabaseScope catch → {hasMigrations:true, hasQueries:true}
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', DB_ANALYSIS, v, makeSupabase());
+    expect(v.details.database_fidelity.applicable).not.toBe(false);
+  });
+
+  it('preserves the existing 18/35 partial when no DATABASE analysis is present (unchanged path)', async () => {
+    const v = makeValidation();
+    await validateDatabaseFidelity('SD-TEST-001', null, v, makeSupabase());
+    expect(v.gate_scores.database_fidelity).toBe(18);
+    // The !databaseAnalysis path returns before the N/A block — no applicable marker.
+    expect(v.details.database_fidelity).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
GATE2_IMPLEMENTATION_FIDELITY (EXEC-TO-PLAN) Section B (Database Implementation Fidelity, 35pts) is migration-centric. A legitimately zero-DB SD scored ~18-19/35 ("No migration files", "No database queries"), dragging **frontend-only feature SDs** to a RED verdict — regressed `SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-C` (77% despite Design 20/25 + E2E 20/20 + TESTING PASS). The existing `frontend_mode` only keys on `sd_type==='frontend'`, so a `sd_type=feature` SD targeting the EHG frontend had no escape.

## Fix
Conservative, **target-agnostic** N/A early-return in `validateDatabaseFidelity` (`scripts/modules/implementation-fidelity/sections/database-fidelity.js`): when an SD has zero database footprint — no SD-matched migration files on disk AND no DB query signal in its diff (supabase `.from(`/`.rpc(` or SQL DDL/DML) — Section B is **Not Applicable → full credit (35/35)**, mirroring the existing SKIP/exempt/ADVISORY idiom. New `detectDatabaseScope()` helper. Keys on real DB signal (not `sd_type`/target). **Any DB signal — or a detection error — falls through to normal scoring** (conservative; can't mask a real missing migration in a DB-touching SD).

## Test (6 unit tests; 42/42 implementation-fidelity, no regression)
- zero-DB diff → Section B N/A, 35/35
- supabase `.from()` / `.rpc()` / SQL `CREATE TABLE` → NOT N/A (falls through)
- `!databaseAnalysis` 18/35 path unchanged
- **scope-detection error → does NOT grant the N/A pass** (conservative invariant locked)

Backed by TESTING sub-agent review (PASS, evidence `fc4302a4`).

Resolves harness_backlog `fa2666aa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)