### PR TITLE
feat(SD-FDBK-ENH-COMPLETE-QUICK-FIX-001): granular --accept-low-confidence bypass + worktree restart note

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -91,6 +91,8 @@ export function parseArguments(args) {
       'allow-stale-branch': { type: 'boolean' },
       // QF-20260524-587: granular WARN-verdict compliance bypass. Requires reason.
       'accept-compliance-warn': { type: 'boolean' },
+      // SD-FDBK-ENH-COMPLETE-QUICK-FIX-001: granular low-confidence self-verify bypass. Requires reason.
+      'accept-low-confidence': { type: 'boolean' },
       'help':               { type: 'boolean', short: 'h' }
     },
     allowPositionals: true,
@@ -142,6 +144,16 @@ export function parseArguments(args) {
     );
   }
 
+  // SD-FDBK-ENH-COMPLETE-QUICK-FIX-001: --accept-low-confidence REQUIRES --reason. It clears ONLY the
+  // self-verification LOW-CONFIDENCE proceed-anyway prompt (so completion works under --non-interactive)
+  // and does NOT bypass verification blockers, the LOC cap, or compliance — unlike --force-complete.
+  if (values['accept-low-confidence'] && !values['reason']) {
+    throw new Error(
+      '[ACCEPT_LOW_CONFIDENCE_NO_REASON] --accept-low-confidence requires --reason "<text>". ' +
+      'It clears ONLY the low-confidence self-verification prompt (not blockers/LOC/compliance) and is recorded in verification_notes.'
+    );
+  }
+
   // FR-3: persist --non-interactive so prompt() can fail-fast
   if (values['non-interactive']) {
     _nonInteractiveMode = true;
@@ -163,6 +175,7 @@ export function parseArguments(args) {
     reason:            values['reason'],
     overCapReason:     values['over-cap-reason']   || undefined,
     acceptComplianceWarn: values['accept-compliance-warn'] || false,
+    acceptLowConfidence: values['accept-low-confidence'] || false,
     nonInteractive:    values['non-interactive'] || false,
     // QF-20260509-407: --auto-pr opt-in flag, plus auto-enable under --non-interactive
     // when no --pr-url provided. Eliminates the mid-run prompt-then-throw pattern
@@ -216,6 +229,10 @@ Options:
   --accept-compliance-warn  Clear ONLY the WARN-verdict compliance prompt (so completion
                         works under --non-interactive). REQUIRES --reason. Does NOT bypass
                         FAIL-verdict, the LOC cap, or self-verification — narrower and safer
+                        than --force-complete. Recorded in verification_notes.
+  --accept-low-confidence   Clear ONLY the self-verification LOW-CONFIDENCE proceed-anyway prompt
+                        (so completion works under --non-interactive). REQUIRES --reason. Does NOT
+                        bypass verification blockers, the LOC cap, or compliance — narrower and safer
                         than --force-complete. Recorded in verification_notes.
   --help, -h            Show this help
 

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -273,10 +273,21 @@ export async function completeQuickFix(qfId, options = {}) {
 
   // LEO Stack Restart
   console.log('🔄 LEO Stack Restart\n');
-  const restartResult = await restartLeoStack({ verbose: true });
-  if (!restartResult.success) {
-    console.log(`   ⚠️  LEO stack restart failed: ${restartResult.message}`);
-    console.log('   You may need to restart manually: bash scripts/leo-stack.sh restart\n');
+  // SD-FDBK-ENH-COMPLETE-QUICK-FIX-001 (Part B): inside a QF worktree, `leo-stack.sh restart`
+  // always fails (the stack runs from the main repo, not the worktree) and is irrelevant to
+  // completing the QF. The old red "restart failed" warning was routinely mistaken for a
+  // verification problem and nudged operators toward the over-broad --force-complete. In a
+  // worktree, skip the attempt and emit a calm informational note instead. (This warning never
+  // fed self-verification confidence — that comes from the self-verifier's own checks.)
+  const inWorktree = typeof testDir === 'string' && /[\\/]\.worktrees[\\/]/.test(testDir);
+  if (inWorktree) {
+    console.log('   ℹ️  LEO stack restart skipped in worktree (expected; the stack runs from the main repo). Does not affect verification.\n');
+  } else {
+    const restartResult = await restartLeoStack({ verbose: true });
+    if (!restartResult.success) {
+      console.log(`   ⚠️  LEO stack restart failed: ${restartResult.message}`);
+      console.log('   You may need to restart manually: bash scripts/leo-stack.sh restart\n');
+    }
   }
 
   // QF-20260509-779: --auto-pr is now handled in the PR-acquisition block above.
@@ -316,6 +327,9 @@ export async function completeQuickFix(qfId, options = {}) {
   // SD-FDBK-INFRA-FIX-COMPLETION-LIFECYCLE-001 FR-2: --force-complete bypasses self-verification prompts
   const selfVerificationValid = await validateSelfVerification(verificationResults, prompt, {
     forceComplete: options.forceComplete,
+    // SD-FDBK-ENH-COMPLETE-QUICK-FIX-001: granular bypass for the low-confidence proceed-anyway
+    // prompt only (mirrors how validateCompliance receives acceptComplianceWarn).
+    acceptLowConfidence: options.acceptLowConfidence,
     reason: options.reason
   });
   if (!selfVerificationValid) {

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -297,6 +297,16 @@ export async function validateSelfVerification(verificationResults, prompt, flag
       console.log(`   ${i + 1}. ${warning}`);
     });
 
+    // SD-FDBK-ENH-COMPLETE-QUICK-FIX-001: --accept-low-confidence clears ONLY this low-confidence
+    // proceed-anyway prompt (so completion works under --non-interactive) WITHOUT the over-broad
+    // --force-complete (which also clears blockers/LOC/compliance). Audit trail in verification_notes.
+    // The earlier !verificationResults.passed blocker branch is unaffected — only --force-complete
+    // bypasses blockers.
+    if (flags.acceptLowConfidence) {
+      console.log(`\n   ⚠️  --accept-low-confidence: low-confidence (${verificationResults.confidence}%) prompt cleared (reason="${flags.reason}"). Blockers/LOC/compliance/scope gates still enforced.\n`);
+      return true;
+    }
+
     const proceed = await prompt('\n   Proceed anyway? (yes/no): ');
     if (!proceed.toLowerCase().startsWith('y')) {
       console.log('\n   Completion cancelled. Review warnings and try again.\n');

--- a/tests/unit/complete-quick-fix/accept-low-confidence.test.js
+++ b/tests/unit/complete-quick-fix/accept-low-confidence.test.js
@@ -1,0 +1,67 @@
+/**
+ * SD-FDBK-ENH-COMPLETE-QUICK-FIX-001 — --accept-low-confidence granular bypass.
+ *
+ * Proves the flag clears ONLY the self-verification LOW-CONFIDENCE "Proceed anyway?" prompt
+ * (validateSelfVerification, confidence<80 branch) while verification BLOCKERS still gate.
+ * Mirrors the --over-cap-reason / --accept-compliance-warn granular-bypass pattern: narrow by
+ * construction, unlike --force-complete (which also clears blockers/LOC/compliance).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { validateSelfVerification } from '../../../scripts/modules/complete-quick-fix/verification.js';
+import { parseArguments } from '../../../scripts/modules/complete-quick-fix/cli.js';
+
+const lowConfidence = () => ({ passed: true, confidence: 70, warnings: ['scope creep detected'], blockers: [] });
+const withBlocker  = () => ({ passed: false, confidence: 50, warnings: [], blockers: ['Other tests now failing'] });
+
+describe('--accept-low-confidence — CLI parsing (FR-1 / AC-4)', () => {
+  it('maps the flag + reason into options.acceptLowConfidence and options.reason', () => {
+    const { options } = parseArguments(['QF-X', '--accept-low-confidence', '--reason', 'CI run; warning is scope-only']);
+    expect(options.acceptLowConfidence).toBe(true);
+    expect(options.reason).toBe('CI run; warning is scope-only');
+  });
+
+  it('throws [ACCEPT_LOW_CONFIDENCE_NO_REASON] when the flag is set without --reason', () => {
+    expect(() => parseArguments(['QF-X', '--accept-low-confidence'])).toThrow(/ACCEPT_LOW_CONFIDENCE_NO_REASON/);
+  });
+
+  it('leaves acceptLowConfidence false when the flag is absent', () => {
+    const { options } = parseArguments(['QF-X', '--pr-url', 'https://example/pull/1']);
+    expect(options.acceptLowConfidence).toBe(false);
+  });
+});
+
+describe('--accept-low-confidence — clears ONLY the low-confidence prompt (FR-3 / AC-1, AC-2)', () => {
+  it('returns true WITHOUT prompting when confidence<80 and the flag+reason are set', async () => {
+    const prompt = vi.fn(async () => 'no'); // would decline if ever called
+    const result = await validateSelfVerification(lowConfidence(), prompt, { acceptLowConfidence: true, reason: 'ci' });
+    expect(result).toBe(true);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('still gates (prompts) when confidence<80 and the flag is absent — default behavior preserved', async () => {
+    const prompt = vi.fn(async () => 'no');
+    const result = await validateSelfVerification(lowConfidence(), prompt, {});
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+
+  it('proceeds when the operator answers yes at the default prompt', async () => {
+    const prompt = vi.fn(async () => 'yes');
+    const result = await validateSelfVerification(lowConfidence(), prompt, {});
+    expect(result).toBe(true);
+  });
+});
+
+describe('--accept-low-confidence — narrowness guarantee: blockers STILL gate (FR-5 / AC-3)', () => {
+  it('does NOT bypass a verification blocker (passed=false) — returns false even with the flag', async () => {
+    const prompt = vi.fn(async () => 'yes');
+    const result = await validateSelfVerification(withBlocker(), prompt, { acceptLowConfidence: true, reason: 'ci' });
+    expect(result).toBe(false);
+  });
+
+  it('only --force-complete bypasses a blocker (sanity check that the blocker path is force-only)', async () => {
+    const prompt = vi.fn(async () => 'no');
+    const result = await validateSelfVerification(withBlocker(), prompt, { forceComplete: true, reason: 'merged PR' });
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a granular `--accept-low-confidence --reason` flag to `complete-quick-fix`, mirroring the merged `--accept-compliance-warn` (QF-20260524-587). It clears ONLY the self-verification LOW-CONFIDENCE "Proceed anyway?" prompt (`verification.js` confidence<80 branch) so non-interactive completions work without the over-broad `--force-complete` (which also clears blockers/LOC/compliance). Blockers, the LOC cap, compliance FAIL/WARN, and scope-creep all stay enforced.

**Part B:** inside a QF worktree, skip the always-failing `leo-stack.sh restart` and print a calm informational note instead of the red "restart failed" warning. LEAD code review confirmed that warning never fed self-verification confidence (the 70% floor comes from the scope-creep check at `quickfix-self-verifier.js:82`) — so Part B is a cosmetic/ergonomics fix that removes the nudge toward `--force-complete` (scope reduced ~15% from the original feedback's false "confidence-math" premise).

## Changes
- `cli.js`: parseArgs option + `[ACCEPT_LOW_CONFIDENCE_NO_REASON]` reason-guard + options mapping + help text
- `orchestrator.js`: thread `acceptLowConfidence` into `validateSelfVerification`; worktree-aware restart message
- `verification.js`: the `acceptLowConfidence` branch in the confidence<80 block (after the blocker branch — blockers stay `--force-complete`-only)
- `tests/unit/complete-quick-fix/accept-low-confidence.test.js`: 8 cases (FR-1 parse/reason-guard, FR-3 clears-only-prompt with prompt-spy, FR-5 blockers still gate)

## Test plan
- [x] `npx vitest run tests/unit/complete-quick-fix/ --project unit` — 142 passing (incl. 8 new)
- [x] EXEC-TO-PLAN gate 97, PLAN-TO-LEAD gate 94, FR_DELIVERY_VERIFICATION 100/100

SD: SD-FDBK-ENH-COMPLETE-QUICK-FIX-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)