### PR TITLE
feat(SD-FDBK-ENH-GATE2-AWARE-SECTION-001): N/A-aware GATE2 Section C for zero-DB SDs

### DIFF
--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -3,6 +3,9 @@
  * Part of SD-LEO-REFACTOR-IMPL-FIDELITY-001
  */
 
+import { existsSync } from 'fs';
+import { readdir } from 'fs/promises';
+import path from 'path';
 import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 import { getSectionEnforcement } from '../sd-type-section-policy.js';
 
@@ -154,6 +157,27 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
     // Continue with normal validation
   }
 
+  // SD-FDBK-ENH-GATE2-AWARE-SECTION-001: N/A-aware Section C, mirroring the Section B
+  // fix in PR #3911 (database-fidelity.js). Zero DB footprint (no SD-matched migration
+  // files AND no .from()/.rpc()/SQL DDL/DML in the diff) → Section C is Not Applicable;
+  // award full credit instead of the ~13/25 partial that RED-capped zero-DB frontend
+  // feature SDs. Full credit == denominator-neutral under the hardcoded max_score=100
+  // score-as-percentage model (index.js unchanged, as in PR #3911). Sits AFTER the
+  // existing exemptions (they keep precedence); any DB signal / detection error falls
+  // through to normal C1/C2/C3 scoring below.
+  const dbScope = await detectDatabaseScope(sd_id, supabase);
+  if (!dbScope.hasMigrations && !dbScope.hasQueries) {
+    validation.score += 25;
+    validation.gate_scores.data_flow_alignment = 25;
+    validation.details.data_flow_alignment = {
+      applicable: false,
+      reason: 'Not applicable — SD has zero database footprint (no migration files, no database queries detected)',
+      db_scope: dbScope,
+    };
+    console.log('   ✅ Section C N/A — zero database footprint (no migrations, no DB queries) — full credit (25/25)');
+    return;
+  }
+
   // Re-use exemptSections from top of function for sub-section checks
   const isC1Exempt = exemptSections.includes('C1_queries');
   const isC2Exempt = exemptSections.includes('C2_form_integration');
@@ -262,4 +286,55 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
   validation.gate_scores.data_flow_alignment = sectionScore;
   validation.details.data_flow_alignment = sectionDetails;
   console.log(`\n   Section C Score: ${sectionScore}/25`);
+}
+
+/**
+ * SD-FDBK-ENH-GATE2-AWARE-SECTION-001: zero-DB-footprint detector for the Section C
+ * N/A check. DELIBERATE byte-for-byte DUPLICATE of detectDatabaseScope in
+ * database-fidelity.js (PR #3911) so both DB-centric sections agree — TODO: extract
+ * to utils/index.js (deferred to avoid touching the PR #3911 file + its mock test).
+ * Signals: hasMigrations (SD-matched migration file on disk) + hasQueries (.from(/.rpc(
+ * or SQL DDL/DML in the diff). Conservative: returns true/true on error (no free N/A).
+ * @returns {Promise<{hasMigrations:boolean, hasQueries:boolean, detection_error?:boolean}>}
+ */
+async function detectDatabaseScope(sd_id, supabase) {
+  try {
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    const searchTerms = await getSDSearchTerms(sd_id, supabase);
+    const searchLower = searchTerms.map(t => t.replace('SD-', '').toLowerCase());
+
+    // Signal 1: SD-matched migration files on disk (mirrors B1 detection).
+    let hasMigrations = false;
+    const migrationDirs = ['database/migrations', 'supabase/migrations', 'migrations'];
+    for (const repo of implementationRepos) {
+      for (const dir of migrationDirs) {
+        const fullPath = path.join(repo, dir);
+        if (existsSync(fullPath)) {
+          const files = await readdir(fullPath);
+          if (files.some(f => searchLower.some(term => f.toLowerCase().includes(term)))) {
+            hasMigrations = true;
+          }
+        }
+      }
+    }
+
+    // Signal 2: database query signals in the SD's diff.
+    let gitDiff = '';
+    for (const repo of implementationRepos) {
+      try {
+        gitDiff += await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
+          searchTerms,
+          { timeout: 15000 }
+        );
+      } catch (_) { /* skip repos without matching commits */ }
+    }
+    const dbSignal = /\.from\(|\.rpc\(|create\s+table|alter\s+table|insert\s+into|update\s+\w+\s+set|delete\s+from|create\s+policy|alter\s+policy/i;
+    const hasQueries = dbSignal.test(gitDiff);
+
+    return { hasMigrations, hasQueries };
+  } catch (error) {
+    // Conservative: on detection failure do NOT grant the N/A pass.
+    return { hasMigrations: true, hasQueries: true, detection_error: true };
+  }
 }

--- a/tests/unit/implementation-fidelity/data-flow-na-aware.test.js
+++ b/tests/unit/implementation-fidelity/data-flow-na-aware.test.js
@@ -1,0 +1,115 @@
+/**
+ * SD-FDBK-ENH-GATE2-AWARE-SECTION-001 — N/A-aware Section C (Data Flow Alignment).
+ *
+ * When an SD has a genuinely zero database footprint (no SD-matched migration files
+ * AND no database query signals in its diff), Section C is Not Applicable and earns
+ * full credit (25/25) — instead of the ~13/25 partial (C1 no-DB-query 5/10 + crude
+ * C2/C3 string heuristics) that dragged zero-DB frontend feature SDs to a RED GATE2
+ * verdict (regressed SD-S17S19-LANDINGFIRST-BUILD-TRIM-ORCH-001-C). Mirrors the
+ * Section B fix shipped in PR #3911. Any DB signal — or a detection error — falls
+ * through to normal C1/C2/C3 scoring (conservative). Existing exemptions keep
+ * precedence (the new check sits after them).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted holder so the vi.mock factory can read per-test git-diff content.
+const h = vi.hoisted(() => ({ repos: [], gitDiff: '', throwRepos: false }));
+
+vi.mock('../../../scripts/modules/implementation-fidelity/utils/index.js', () => ({
+  getSDSearchTerms: async () => ['SD-TEST-001'],
+  detectImplementationRepos: async () => {
+    if (h.throwRepos) throw new Error('repo detection boom');
+    return h.repos;
+  },
+  gitLogForSD: async () => h.gitDiff,
+}));
+
+// Section C resolves the SD via the canonical resolver inside an exemption block.
+// Stub it to "no match" so the non-EHG_Engineer tests fall through cleanly to the
+// new detectDatabaseScope check (the resolver is orthogonal to the N/A logic).
+vi.mock('../../../scripts/lib/sd-id-resolver.js', () => ({
+  resolveSdInputOrNull: async () => ({ sd: null }),
+}));
+
+const { validateDataFlowAlignment } = await import(
+  '../../../scripts/modules/implementation-fidelity/sections/data-flow-alignment.js'
+);
+
+function makeValidation({ sd_type = 'feature', target_application = 'EHG' } = {}) {
+  return {
+    passed: true,
+    score: 0,
+    issues: [],
+    warnings: [],
+    details: { sd_type, target_application },
+    gate_scores: {},
+  };
+}
+
+// Section C never reaches a live DB in the zero-DB / signal paths (mocked utils and
+// a stubbed resolver), but the signature requires a supabase arg. Minimal stub.
+function makeSupabase() {
+  const chain = {
+    from: () => chain,
+    select: () => Promise.resolve({ data: [], error: null }),
+    eq: () => chain,
+  };
+  return chain;
+}
+
+describe('GATE2 Section C — N/A-aware data flow alignment (SD-...-AWARE-SECTION-001)', () => {
+  // A fake repo path (no migration dirs on disk → hasMigrations=false) so detection
+  // keys purely on the git-diff signal.
+  beforeEach(() => { h.repos = ['/fake/repo']; h.gitDiff = ''; h.throwRepos = false; });
+
+  it('zero DB footprint (no migrations, no queries) → Section C N/A, full credit 25/25', async () => {
+    h.gitDiff = 'diff --git a/src/components/Foo.tsx b/src/components/Foo.tsx\n+ const x = 1;';
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+
+    expect(v.gate_scores.data_flow_alignment).toBe(25);
+    expect(v.details.data_flow_alignment.applicable).toBe(false);
+    expect(v.details.data_flow_alignment.reason).toMatch(/Not applicable.*zero database footprint/i);
+  });
+
+  it('diff with supabase .from() → NOT N/A, falls through to normal scoring', async () => {
+    h.gitDiff = 'diff --git a/x.js b/x.js\n+ const { data } = await supabase.from("ventures").select("*");';
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+
+    // The N/A early-return must NOT have fired.
+    expect(v.details.data_flow_alignment.applicable).not.toBe(false);
+  });
+
+  it('diff with supabase .rpc() → NOT N/A (client DB call counts as a query)', async () => {
+    h.gitDiff = '+ await supabase.rpc("delete_venture", { p_venture_id: id });';
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+    expect(v.details.data_flow_alignment.applicable).not.toBe(false);
+  });
+
+  it('diff with SQL DDL (CREATE TABLE) → NOT N/A', async () => {
+    h.gitDiff = '+ CREATE TABLE public.things (id uuid primary key);';
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+    expect(v.details.data_flow_alignment.applicable).not.toBe(false);
+  });
+
+  it('conservative: a scope-detection error does NOT grant the N/A pass', async () => {
+    h.throwRepos = true; // detectDatabaseScope catch → {hasMigrations:true, hasQueries:true}
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+    expect(v.details.data_flow_alignment.applicable).not.toBe(false);
+  });
+
+  it('preserves the existing EHG_Engineer backend-only exemption (fires before the N/A check)', async () => {
+    const v = makeValidation({ target_application: 'EHG_Engineer' });
+    await validateDataFlowAlignment('SD-TEST-001', null, null, v, makeSupabase());
+
+    expect(v.gate_scores.data_flow_alignment).toBe(25);
+    expect(v.details.data_flow_alignment.skipped).toBe(true);
+    expect(v.details.data_flow_alignment.reason).toMatch(/backend-only/i);
+    // The pre-existing exemption uses skipped:true, NOT the new applicable:false marker.
+    expect(v.details.data_flow_alignment.applicable).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Extends the N/A-aware GATE2 implementation-fidelity pattern that **PR #3911** shipped for Section B (Database fidelity) to **Section C (Data Flow Alignment)** in `scripts/modules/implementation-fidelity/sections/data-flow-alignment.js`.

When an SD has a genuinely **zero database footprint** (no SD-matched migration files AND no `.from()`/`.rpc()`/SQL DDL/DML in its diff), Section C now short-circuits to `applicable:false` + full credit (25/25) — instead of the ~13/25 partial (C1 no-DB-query 5/10 + crude C2/C3 string heuristics) that RED-capped zero-DB frontend feature SDs (regressed `SD-S17S19-LANDINGFIRST-BUILD-TRIM-ORCH-001-C`, ~73% vs the 85% adaptive threshold).

## How
- New self-contained `detectDatabaseScope(sd_id, supabase)` helper, mirroring the Section B (PR #3911) helper byte-for-byte (same migration dirs + same DB-signal regex). Documented as a deliberate duplication with a TODO for a future shared-util extraction.
- Short-circuit placed **after** the existing exemptions (EHG_Engineer target, database-no-UI, backend-only, PAT-GATE2-LIBFEATURE-001) so they keep precedence.
- **Conservative**: any DB signal — or a detection error (`catch` returns `hasMigrations:true,hasQueries:true`) — falls through to normal C1/C2/C3 scoring. No free N/A on a scan failure.
- **No `index.js` change.** PR #3911 did not touch `index.js` either; under the hardcoded `max_score=100` score-as-percentage model (`checkGatePassed` compares the raw score to a % threshold), awarding full credit is the section-neutralizing mechanism. (This is a deliberate scope reframe vs the raw feedback's "thread through index.js" wording, verified against the merged #3911 commit.)

## Tests
- New `tests/unit/implementation-fidelity/data-flow-na-aware.test.js` (6 cases): zero-DB → 25/25 + `applicable:false`; `.from()`/`.rpc()`/`CREATE TABLE` → NOT N/A; detection-error → conservative; EHG_Engineer exemption precedence preserved.
- Full implementation-fidelity suite green (5 files / 49 tests), incl. the Section B regression test.

SD: SD-FDBK-ENH-GATE2-AWARE-SECTION-001 (enhancement) · +75 source LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)