### PR TITLE
feat(SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001): out-of-band reaper + TS-5 isolated-node_modules guard

### DIFF
--- a/scripts/fleet/worktree-reaper-tick.cjs
+++ b/scripts/fleet/worktree-reaper-tick.cjs
@@ -20,14 +20,16 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { spawn } = require('node:child_process');
 
 const DEFAULT_CADENCE = 12; // every 12th sweep ≈ 1 hour at 5-min intervals
 const STATE_RELATIVE = path.join('.claude', 'worktree-reaper-state.json');
 const STATE_SCHEMA_VERSION = 1;
 
 function readState(statePath) {
-  if (!fs.existsSync(statePath)) return { schema_version: STATE_SCHEMA_VERSION, sweep_counter: 0, last_run_at: null, last_result: null };
+  // SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001: last_pid/last_spawn_at are additive
+  // (schema stays v1); old state files without them default to null.
+  if (!fs.existsSync(statePath)) return { schema_version: STATE_SCHEMA_VERSION, sweep_counter: 0, last_run_at: null, last_result: null, last_pid: null, last_spawn_at: null };
   try {
     const raw = fs.readFileSync(statePath, 'utf8');
     const parsed = JSON.parse(raw);
@@ -36,9 +38,27 @@ function readState(statePath) {
       sweep_counter: Number.isFinite(parsed.sweep_counter) ? parsed.sweep_counter : 0,
       last_run_at: parsed.last_run_at || null,
       last_result: parsed.last_result || null,
+      last_pid: Number.isInteger(parsed.last_pid) ? parsed.last_pid : null,
+      last_spawn_at: parsed.last_spawn_at || null,
     };
   } catch {
-    return { schema_version: STATE_SCHEMA_VERSION, sweep_counter: 0, last_run_at: null, last_result: null };
+    return { schema_version: STATE_SCHEMA_VERSION, sweep_counter: 0, last_run_at: null, last_result: null, last_pid: null, last_spawn_at: null };
+  }
+}
+
+/**
+ * Liveness probe via signal-0. Returns true if the pid is a running process
+ * (ours → clean return; alive-but-not-ours → EPERM). A missing process throws
+ * ESRCH → false. Used by the single-flight guard so a new tick never stacks a
+ * second reaper on top of one that is still running.
+ */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return !!(e && e.code === 'EPERM');
   }
 }
 
@@ -105,44 +125,68 @@ function tick(opts = {}) {
     return { invoked: false, counter: state.sweep_counter, cadence, result: 'script_missing', enabled: true };
   }
 
+  // Single-flight guard: if the previous reaper is still running, do not stack a
+  // second one. A new sweep tick fires hourly; a slow stage2 reap could still be
+  // mid-run, and overlapping reapers race on the same worktrees.
+  if (isPidAlive(state.last_pid)) {
+    logger(`WORKTREE REAPER TICK: sweep=${state.sweep_counter} — prior reaper (pid=${state.last_pid}) still running; skipping launch`);
+    state.last_run_at = new Date().toISOString();
+    state.last_result = 'skipped_in_flight';
+    writeState(statePath, state);
+    return { invoked: false, counter: state.sweep_counter, cadence, result: 'skipped_in_flight', pid: state.last_pid, enabled: true };
+  }
+
   const args = [reaperScript];
   if (execute) args.push('--execute');
   if (stage2) args.push('--stage2', '--yes');
 
   logger(`WORKTREE REAPER TICK: sweep=${state.sweep_counter} cadence=${cadence} execute=${execute} stage2=${stage2}`);
 
+  // SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001: run the reaper OUT-OF-BAND.
+  // Previously this blocked the sweep on a synchronous spawnSync (timeout 5 min).
+  // The sweep is launched by the coordinator with a ~2-min process budget, so a slow
+  // stage2 reap blocked the sweep past its budget and the WHOLE sweep was SIGTERM'd
+  // (exit 143). A detached + unref'd child lets the sweep return immediately while the
+  // reaper runs independently; its stdout/stderr go to a log file instead of the
+  // sweep's stdio. The reaper self-recovers on later ticks, so a killed/slow reap is safe.
   let result = 'unknown';
+  let pid = null;
   try {
-    const res = spawnSync(process.execPath, args, {
-      cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      encoding: 'utf8',
-      windowsHide: true,
-      timeout: 5 * 60 * 1000,
-    });
-    if (res.error) {
-      result = 'spawn_error:' + (res.error.code || 'unknown');
-    } else if (res.status === 0) {
-      result = 'pass';
-    } else if (res.status === 2) {
-      result = 'cwd_guard_triggered';
-    } else {
-      result = `exit_${res.status}`;
+    const logPath = path.join(repoRoot, '.claude', 'worktree-reaper-last.log');
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    const logFd = fs.openSync(logPath, 'a');
+    try {
+      fs.writeSync(logFd, `\n=== reaper spawned ${new Date().toISOString()} sweep=${state.sweep_counter} execute=${execute} stage2=${stage2} ===\n`);
+      const child = spawn(process.execPath, args, {
+        cwd: repoRoot,
+        detached: true,
+        windowsHide: true,
+        stdio: ['ignore', logFd, logFd],
+      });
+      child.unref();
+      pid = child.pid || null;
+      result = 'spawned';
+      logger(`  reaper spawned out-of-band (pid=${pid}) — output -> ${logPath}`);
+    } finally {
+      fs.closeSync(logFd); // child has its own duped fd; closing the parent copy is safe
     }
-    // Emit one summary line; full output goes to the sweep's stderr/stdout.
-    const stdout = (res.stdout || '').split('\n').filter(Boolean);
-    const summaryLine = stdout.find((l) => l.startsWith('Stage 1') || l.includes('WORKTREE REAPER')) || '';
-    if (summaryLine) logger(`  ${summaryLine.trim()}`);
   } catch (e) {
-    result = 'exception';
-    logger(`  reaper threw: ${e && e.message ? e.message : String(e)}`);
+    // Never throw — the sweep's claim-cleanup must complete regardless.
+    result = 'spawn_error:' + (e && e.code ? e.code : 'unknown');
+    logger(`  reaper spawn failed: ${e && e.message ? e.message : String(e)}`);
   }
 
   state.last_run_at = new Date().toISOString();
   state.last_result = result;
+  if (result === 'spawned') {
+    state.last_pid = pid;
+    state.last_spawn_at = new Date().toISOString();
+  } else {
+    state.last_pid = null;
+  }
   writeState(statePath, state);
 
-  return { invoked: true, counter: state.sweep_counter, cadence, result, enabled: true };
+  return { invoked: result === 'spawned', counter: state.sweep_counter, cadence, result, pid, enabled: true };
 }
 
 module.exports = {
@@ -150,6 +194,7 @@ module.exports = {
   readState,
   writeState,
   isEnabled,
+  isPidAlive,
   resolveExecuteMode,
   DEFAULT_CADENCE,
   STATE_RELATIVE,

--- a/tests/integration/worktree-reaper.test.js
+++ b/tests/integration/worktree-reaper.test.js
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
+import { execFileSync } from 'node:child_process';
 import {
   parseArgs,
   stageForCategories,
@@ -20,6 +21,7 @@ import {
   preserveUntrackedFiles,
   runPhantomOnlyMode,
   loadClaimMap,
+  removeWorktree,
 } from '../../scripts/worktree-reaper.mjs';
 
 // ── parseArgs ──────────────────────────────────────────────────────────
@@ -338,5 +340,54 @@ describe('loadClaimMap (QF-20260510-WT-CLAIM-PROTECT-001)', () => {
   it('returns empty map (no throw) when supabase client is absent', async () => {
     const map = await loadClaimMap(null);
     expect(map.size).toBe(0);
+  });
+});
+
+// ── TS-5: removeWorktree junction-safety regression guard ──────────────
+// SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001 part (b).
+// Pins QF-446 / QF-347 / QF-102: removing a worktree whose node_modules is a
+// REAL isolated directory (not a junction) must NOT reach out and delete the
+// shared main-repo node_modules. Prior witnessed incidents (2026-05-11T23:33Z)
+// destroyed the main repo's node_modules across 4 parallel sessions.
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+describe('removeWorktree — TS-5 real isolated node_modules (SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001)', () => {
+  let mainRepo;
+
+  beforeEach(() => {
+    mainRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-ts5-'));
+    git(['init', '-q', '-b', 'main'], mainRepo);
+    git(['config', 'user.email', 'ts5@test.local'], mainRepo);
+    git(['config', 'user.name', 'ts5'], mainRepo);
+    git(['commit', '--allow-empty', '-q', '-m', 'init'], mainRepo);
+    // The SHARED main-repo node_modules (the store that must survive).
+    fs.mkdirSync(path.join(mainRepo, 'node_modules', 'left-pad'), { recursive: true });
+    fs.writeFileSync(path.join(mainRepo, 'node_modules', 'left-pad', 'index.js'), 'MAIN_STORE_SENTINEL');
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(mainRepo, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('removes a worktree with a REAL isolated node_modules and leaves the shared main store intact', () => {
+    const wt = path.join(mainRepo, '.worktrees', 'SD-TS5');
+    git(['worktree', 'add', '-q', '--detach', wt], mainRepo);
+    // Real isolated node_modules inside the worktree (a genuine directory, NOT a junction).
+    fs.mkdirSync(path.join(wt, 'node_modules', 'dep'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'node_modules', 'dep', 'index.js'), 'WORKTREE_LOCAL_DEP');
+    expect(fs.existsSync(wt)).toBe(true);
+
+    const res = removeWorktree({ wtPath: wt, repoRoot: mainRepo });
+
+    expect(res.ok).toBe(true);
+    // Worktree directory is gone…
+    expect(fs.existsSync(wt)).toBe(false);
+    // …but the SHARED main-repo node_modules + sentinel are byte-for-byte intact.
+    const sentinel = path.join(mainRepo, 'node_modules', 'left-pad', 'index.js');
+    expect(fs.existsSync(sentinel)).toBe(true);
+    expect(fs.readFileSync(sentinel, 'utf8')).toBe('MAIN_STORE_SENTINEL');
   });
 });

--- a/tests/unit/worktree-reaper/tick.test.js
+++ b/tests/unit/worktree-reaper/tick.test.js
@@ -118,3 +118,84 @@ describe('worktree-reaper-tick', () => {
     expect(() => tick({ repoRoot: brokenRepo, cadence: 12, logger: () => {} })).not.toThrow();
   });
 });
+
+/**
+ * SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001 — out-of-band reaper launch.
+ *
+ * The reaper now runs DETACHED so a slow reap can never block/abort the sweep.
+ * These tests exercise the real (un-mocked) spawn path against a tiny fake
+ * reaper script that exits immediately.
+ */
+describe('worktree-reaper-tick — out-of-band launch (SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001)', () => {
+  let tmpRoot;
+  const origEnv = { ...process.env };
+
+  function writeFakeReaper(root) {
+    const dir = path.join(root, 'scripts');
+    fs.mkdirSync(dir, { recursive: true });
+    // Exits 0 immediately; the tick must not wait for it.
+    fs.writeFileSync(path.join(dir, 'worktree-reaper.mjs'), 'process.exit(0);\n');
+  }
+  function readStateFile(root) {
+    return JSON.parse(fs.readFileSync(path.join(root, '.claude', 'worktree-reaper-state.json'), 'utf8'));
+  }
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-oob-'));
+    fs.mkdirSync(path.join(tmpRoot, '.claude'), { recursive: true });
+    delete process.env.WORKTREE_REAPER_ENABLED;
+    delete process.env.WORKTREE_REAPER_EXECUTE;
+  });
+  afterEach(() => {
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    process.env = { ...origEnv };
+  });
+
+  it('AC-1: launches the reaper detached and returns result=spawned with a pid (does not block)', () => {
+    writeFakeReaper(tmpRoot);
+    const { tick } = loadTickModule();
+    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} });
+    expect(res.result).toBe('spawned');
+    expect(typeof res.pid).toBe('number');
+    const state = readStateFile(tmpRoot);
+    expect(state.last_result).toBe('spawned');
+    expect(state.last_pid).toBe(res.pid);
+    expect(typeof state.last_spawn_at).toBe('string');
+    // Output log file should have been created/appended.
+    expect(fs.existsSync(path.join(tmpRoot, '.claude', 'worktree-reaper-last.log'))).toBe(true);
+    try { process.kill(res.pid, 0); /* may already be gone */ } catch { /* fine */ }
+  });
+
+  it('AC-2: single-flight — skips launch when the prior reaper pid is still alive', () => {
+    writeFakeReaper(tmpRoot);
+    // Pre-seed state with a guaranteed-alive pid (this test process).
+    fs.writeFileSync(
+      path.join(tmpRoot, '.claude', 'worktree-reaper-state.json'),
+      JSON.stringify({ schema_version: 1, sweep_counter: 11, last_run_at: null, last_result: 'spawned', last_pid: process.pid, last_spawn_at: new Date().toISOString() }),
+    );
+    const { tick } = loadTickModule();
+    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} });
+    expect(res.result).toBe('skipped_in_flight');
+    expect(res.invoked).toBe(false);
+  });
+
+  it('AC-3: returns a spawn_error result (never throws) when the log path cannot be created', () => {
+    writeFakeReaper(tmpRoot);
+    // Replace the .claude directory with a FILE so mkdir/openSync for the log fail.
+    fs.rmSync(path.join(tmpRoot, '.claude'), { recursive: true, force: true });
+    fs.writeFileSync(path.join(tmpRoot, '.claude'), 'not a directory');
+    const { tick } = loadTickModule();
+    let res;
+    expect(() => { res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} }); }).not.toThrow();
+    expect(res.result.startsWith('spawn_error')).toBe(true);
+  });
+
+  it('isPidAlive: true for this process, false for a dead/invalid pid', () => {
+    const { isPidAlive } = loadTickModule();
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(2 ** 30)).toBe(false); // almost certainly not a live pid
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(null)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The in-sweep worktree-reaper-tick ran the reaper via a **synchronous** `spawnSync` (5-min timeout) at the end of `stale-session-sweep.cjs`. The sweep's coordinator budget is ~2 min, so a slow stage2 reap blocked the sweep past its budget and the **whole sweep got SIGTERM'd (exit 143)** — observed hourly at sweep counters 516/600/612.

Fix: launch the reaper **out-of-band** as a detached, `unref`'d child (output → `.claude/worktree-reaper-last.log`) so a slow reap can never block or abort the sweep. A **single-flight PID guard** (`process.kill(pid,0)` liveness) prevents a new tick from stacking a second reaper. State gains additive `last_pid`/`last_spawn_at` (schema stays v1). The **never-throws** safety contract is preserved (spawn failures → `'spawn_error:<code>'`). A GitHub Actions reaper cron already runs the reaper out-of-band, so this only changes the in-sweep secondary trigger.

## Changes
- `scripts/fleet/worktree-reaper-tick.cjs`: detached spawn + single-flight guard + `isPidAlive` + state fields
- `tests/unit/worktree-reaper/tick.test.js`: +4 (spawned / single-flight skip / spawn_error never-throws / isPidAlive) — 12 passing
- `tests/integration/worktree-reaper.test.js`: **TS-5** — real git worktree fixture with a REAL isolated `node_modules`; `removeWorktree` leaves the shared main-repo `node_modules` byte-for-byte intact (pins QF-446/347/102 junction-safety) — 26 passing

## Test plan
- [x] `npx vitest run tests/unit/worktree-reaper/tick.test.js` — 12 passing
- [x] `npx vitest run tests/integration/worktree-reaper.test.js` — 26 passing (incl. TS-5)
- [x] EXEC-TO-PLAN 96, PLAN-TO-LEAD 94, retrospective 100/100

SD: SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)