### PR TITLE
fix(SD-FDBK-FIX-FIX-STALE-HARNESS-001): unstale S15 artifact taxonomy + protocol-file-read-gate tests

### DIFF
--- a/database/migrations/20260525_remove_stale_s15_blueprint_wireframes_artifact.sql
+++ b/database/migrations/20260525_remove_stale_s15_blueprint_wireframes_artifact.sql
@@ -1,0 +1,18 @@
+-- SD-FDBK-FIX-FIX-STALE-HARNESS-001 (part a)
+-- Remove the stale pre-Stitch 'blueprint_wireframes' artifact from Stage 15 (Design Studio)
+-- lifecycle_stage_config.required_artifacts.
+--
+-- The Google-Stitch replacement (SD-LEO-ORCH-REPLACE-GOOGLE-STITCH-001) now emits
+-- 'wireframe_screens' (already present in the array), so 'blueprint_wireframes' is dead
+-- and was causing scripts/monitor-venture-run.cjs (loadExpectedArtifactsByStage reads this
+-- DB-authoritative column) to false-flag "S15 missing_artifact: blueprint_wireframes" on
+-- every venture run (observed live on venture 0e6449d9, 2026-05-24).
+--
+-- Surgical + idempotent: array_remove is a no-op if the element is already gone; the
+-- ANY() guard keeps the UPDATE from touching rows that don't need it. 'wireframe_screens'
+-- is retained.
+UPDATE lifecycle_stage_config
+SET required_artifacts = array_remove(required_artifacts, 'blueprint_wireframes'),
+    updated_at = NOW()
+WHERE stage_number = 15
+  AND 'blueprint_wireframes' = ANY(required_artifacts);

--- a/tests/unit/partial-read-detection/protocol-file-read-gate.test.js
+++ b/tests/unit/partial-read-detection/protocol-file-read-gate.test.js
@@ -5,9 +5,23 @@
  * Tests for partial read warning and confirmation in protocol-file-read-gate.js
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+
+// SD-FDBK-FIX-FIX-STALE-HARNESS-001: hermetic session-state isolation. The gate resolves
+// its state file via session-state-resolver.cjs (scoped path, SD-FDBK-ENH-SESSION-STATE-
+// SCOPING-001); without controlling that path the gate read a different file than these
+// tests wrote, causing stale failures. Mock the resolver to a unique temp file.
+const hoisted = vi.hoisted(() => {
+  const tmpDir = process.env.RUNNER_TEMP || process.env.TEMP || process.env.TMP || process.env.TMPDIR || '.';
+  return { stateFile: `${tmpDir}/pfrg-partial-hermetic-${process.pid}-${Date.now()}.json` };
+});
+vi.mock('../../../scripts/hooks/lib/session-state-resolver.cjs', () => ({
+  getSessionStateFilePath: () => hoisted.stateFile,
+  resolveStateReadPath: () => hoisted.stateFile,
+}));
+
 import {
   validateProtocolFileRead,
   getPartialReadDetails,
@@ -17,9 +31,9 @@ import {
   markProtocolFileRead
 } from '../../../scripts/modules/handoff/gates/protocol-file-read-gate.js';
 
-// Test environment setup
-const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer';
-const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
+// Test environment setup — state file is the hermetic temp path (see vi.mock above) so the
+// gate's reads/writes and these helpers operate on the same file.
+const SESSION_STATE_FILE = hoisted.stateFile;
 const BACKUP_FILE = SESSION_STATE_FILE + '.test-backup';
 
 // Helper to read session state
@@ -169,7 +183,9 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
             lastReadAt: '2026-01-30T10:00:00.000Z',
             lastReadWasPartial: true,
             lastPartialRead: {
-              limit: 200,
+              // limit < 30 (SUFFICIENT_READ_THRESHOLD) so it exercises the confirmation
+              // path; >=30 now auto-passes per SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-063.
+              limit: 20,
               offset: 0,
               readAt: '2026-01-30T10:00:00.000Z'
             }
@@ -177,7 +193,9 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }
       });
 
-      const result = await validateProtocolFileRead('EXEC-TO-PLAN', {});
+      // EXEC-TO-PLAN now maps to CLAUDE_PLAN.md; this fixture is a CLAUDE_EXEC.md partial,
+      // so use PLAN-TO-EXEC (the handoff that requires CLAUDE_EXEC.md) to exercise it.
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
 
       expect(result.pass).toBe(false);
       expect(result.requiresConfirmation).toBe(true);
@@ -194,7 +212,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
             lastReadAt: '2026-01-30T10:00:00.000Z',
             lastReadWasPartial: true,
             lastPartialRead: {
-              limit: 150,
+              // limit < 30 so the warning/confirmation path runs (>=30 auto-passes).
+              limit: 20,
               offset: 50,
               readAt: '2026-01-30T10:00:00.000Z'
             }
@@ -202,9 +221,10 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }
       });
 
-      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
+      // Fixture is a CLAUDE_PLAN.md partial; EXEC-TO-PLAN requires CLAUDE_PLAN.md (dest-phase).
+      const result = await validateProtocolFileRead('EXEC-TO-PLAN', {});
 
-      expect(result.warnings.some(w => w.includes('limit=150'))).toBe(true);
+      expect(result.warnings.some(w => w.includes('limit=20'))).toBe(true);
     });
   });
 
@@ -218,7 +238,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
             lastReadAt: '2026-01-30T10:00:00.000Z',
             lastReadWasPartial: true,
             lastPartialRead: {
-              limit: 200,
+              // limit < 30 so the confirmFullRead path runs (>=30 auto-passes).
+              limit: 20,
               offset: 0,
               readAt: '2026-01-30T10:00:00.000Z'
             }
@@ -226,7 +247,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }
       });
 
-      const result = await validateProtocolFileRead('EXEC-TO-PLAN', { confirmFullRead: true });
+      // CLAUDE_EXEC.md fixture → PLAN-TO-EXEC (requires CLAUDE_EXEC.md).
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', { confirmFullRead: true });
 
       expect(result.pass).toBe(true);
       expect(result.score).toBe(85);
@@ -246,7 +268,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
             lastReadAt: '2026-01-30T10:00:00.000Z',
             lastReadWasPartial: true,
             lastPartialRead: {
-              limit: 100,
+              // limit < 30 so the partial-read path runs and the prior confirmation applies.
+              limit: 20,
               offset: 0,
               readAt: '2026-01-30T10:00:00.000Z'
             }
@@ -259,7 +282,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }]
       });
 
-      const result = await validateProtocolFileRead('LEAD-TO-PLAN', {});
+      // CLAUDE_LEAD.md fixture → PLAN-TO-LEAD (requires CLAUDE_LEAD.md).
+      const result = await validateProtocolFileRead('PLAN-TO-LEAD', {});
 
       expect(result.pass).toBe(true);
       expect(result.score).toBe(85);
@@ -280,7 +304,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }
       });
 
-      const result = await validateProtocolFileRead('EXEC-TO-PLAN', {});
+      // CLAUDE_EXEC.md fixture → PLAN-TO-EXEC (requires CLAUDE_EXEC.md).
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
 
       expect(result.pass).toBe(true);
       expect(result.score).toBe(100);
@@ -361,7 +386,8 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
         }
       });
 
-      const result = await validateProtocolFileRead('EXEC-TO-PLAN', {});
+      // CLAUDE_EXEC.md fixture → PLAN-TO-EXEC (requires CLAUDE_EXEC.md).
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
 
       expect(result.warnings.length).toBeGreaterThan(0);
       expect(result.warnings.some(w => w.includes('CLAUDE_EXEC.md'))).toBe(true);

--- a/tests/unit/protocol-file-read-gate.test.js
+++ b/tests/unit/protocol-file-read-gate.test.js
@@ -10,9 +10,24 @@
  * - Structured logging
  */
 
-import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+
+// SD-FDBK-FIX-FIX-STALE-HARNESS-001: hermetic session-state isolation. The gate resolves
+// its state file via session-state-resolver.cjs (scoped path, SD-FDBK-ENH-SESSION-STATE-
+// SCOPING-001). Without this, the gate read/wrote a scoped path the tests didn't control,
+// causing stale failures. Mock the resolver to a unique temp file so these tests control
+// state deterministically and never touch the real .claude/ session state.
+const hoisted = vi.hoisted(() => {
+  const tmpDir = process.env.RUNNER_TEMP || process.env.TEMP || process.env.TMP || process.env.TMPDIR || '.';
+  return { stateFile: `${tmpDir}/pfrg-hermetic-${process.pid}-${Date.now()}.json` };
+});
+vi.mock('../../scripts/hooks/lib/session-state-resolver.cjs', () => ({
+  getSessionStateFilePath: () => hoisted.stateFile,
+  resolveStateReadPath: () => hoisted.stateFile,
+}));
+
 import protocolFileReadGate, {
   validateProtocolFileRead,
   createProtocolFileReadGate,
@@ -24,8 +39,8 @@ import protocolFileReadGate, {
 
 const { HANDOFF_FILE_REQUIREMENTS } = protocolFileReadGate;
 
-// Test session state file
-const TEST_SESSION_STATE_FILE = path.join(process.cwd(), '.claude', 'unified-session-state.json');
+// Test session state file (hermetic temp path — see vi.mock above)
+const TEST_SESSION_STATE_FILE = hoisted.stateFile;
 
 describe('Protocol File Read Gate', () => {
   beforeEach(() => {
@@ -38,49 +53,52 @@ describe('Protocol File Read Gate', () => {
     clearProtocolFileReadState();
   });
 
+  // SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001 remapped each handoff to its DESTINATION
+  // phase's protocol file (the phase you're going TO), not the source phase.
   describe('HANDOFF_FILE_REQUIREMENTS mapping', () => {
-    it('should map LEAD-TO-PLAN to CLAUDE_LEAD.md', () => {
-      expect(HANDOFF_FILE_REQUIREMENTS['LEAD-TO-PLAN']).toBe('CLAUDE_LEAD.md');
+    it('should map LEAD-TO-PLAN to CLAUDE_PLAN.md (destination phase)', () => {
+      expect(HANDOFF_FILE_REQUIREMENTS['LEAD-TO-PLAN']).toBe('CLAUDE_PLAN.md');
     });
 
-    it('should map PLAN-TO-EXEC to CLAUDE_PLAN.md', () => {
-      expect(HANDOFF_FILE_REQUIREMENTS['PLAN-TO-EXEC']).toBe('CLAUDE_PLAN.md');
+    it('should map PLAN-TO-EXEC to CLAUDE_EXEC.md (destination phase)', () => {
+      expect(HANDOFF_FILE_REQUIREMENTS['PLAN-TO-EXEC']).toBe('CLAUDE_EXEC.md');
     });
 
-    it('should map EXEC-TO-PLAN to CLAUDE_EXEC.md', () => {
-      expect(HANDOFF_FILE_REQUIREMENTS['EXEC-TO-PLAN']).toBe('CLAUDE_EXEC.md');
+    it('should map EXEC-TO-PLAN to CLAUDE_PLAN.md (destination phase)', () => {
+      expect(HANDOFF_FILE_REQUIREMENTS['EXEC-TO-PLAN']).toBe('CLAUDE_PLAN.md');
     });
   });
 
   describe('validateProtocolFileRead', () => {
-    it('should BLOCK when required file has not been read (LEAD-TO-PLAN)', async () => {
+    // SD-LEO-FIX-COMPLETION-WORKFLOW-001 added a fallback PASS: when the required file is
+    // untracked in session state but EXISTS on disk (it always does for CLAUDE_*.md), the
+    // gate passes with score 90 + a "fallback validation used" warning rather than blocking.
+    // (The hard-BLOCK path still exists only for a genuinely missing file.)
+    it('should FALLBACK-PASS when required file is untracked but exists on disk (LEAD-TO-PLAN)', async () => {
       const result = await validateProtocolFileRead('LEAD-TO-PLAN', {});
 
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.issues).toContain('Protocol file not read: CLAUDE_LEAD.md');
-      expect(result.issues.some(i => i.includes('LEAD-TO-PLAN'))).toBe(true);
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(90);
+      expect(result.warnings.some(w => w.toLowerCase().includes('fallback'))).toBe(true);
     });
 
-    it('should BLOCK when required file has not been read (PLAN-TO-EXEC)', async () => {
+    it('should FALLBACK-PASS when required file is untracked but exists on disk (PLAN-TO-EXEC)', async () => {
       const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
 
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.issues).toContain('Protocol file not read: CLAUDE_PLAN.md');
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(90);
     });
 
-    it('should BLOCK when required file has not been read (EXEC-TO-PLAN)', async () => {
+    it('should FALLBACK-PASS when required file is untracked but exists on disk (EXEC-TO-PLAN)', async () => {
       const result = await validateProtocolFileRead('EXEC-TO-PLAN', {});
 
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.issues).toContain('Protocol file not read: CLAUDE_EXEC.md');
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(90);
     });
 
-    it('should PASS when required file has been marked as read', async () => {
-      // Mark the file as read
-      markProtocolFileRead('CLAUDE_LEAD.md');
+    it('should PASS with score 100 when the destination file has been marked as read', async () => {
+      // LEAD-TO-PLAN requires the destination file CLAUDE_PLAN.md (not CLAUDE_LEAD.md).
+      markProtocolFileRead('CLAUDE_PLAN.md');
 
       const result = await validateProtocolFileRead('LEAD-TO-PLAN', {});
 
@@ -151,29 +169,31 @@ describe('Protocol File Read Gate', () => {
       expect(gate.blocking).toBe(true);
     });
 
-    it('should include correct file in remediation message', () => {
+    it('should include correct destination file in remediation message', () => {
       const leadGate = createProtocolFileReadGate('LEAD-TO-PLAN');
       const planGate = createProtocolFileReadGate('PLAN-TO-EXEC');
       const execGate = createProtocolFileReadGate('EXEC-TO-PLAN');
 
-      expect(leadGate.remediation).toContain('CLAUDE_LEAD.md');
-      expect(planGate.remediation).toContain('CLAUDE_PLAN.md');
-      expect(execGate.remediation).toContain('CLAUDE_EXEC.md');
+      // Destination-phase mapping (SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001).
+      expect(leadGate.remediation).toContain('CLAUDE_PLAN.md');
+      expect(planGate.remediation).toContain('CLAUDE_EXEC.md');
+      expect(execGate.remediation).toContain('CLAUDE_PLAN.md');
     });
 
-    it('should have working validator function', async () => {
+    it('should have working validator function (fallback-pass then tracked-pass)', async () => {
       const gate = createProtocolFileReadGate('LEAD-TO-PLAN');
 
-      // Test blocking
-      const blockResult = await gate.validator({});
-      expect(blockResult.pass).toBe(false);
+      // Untracked but file exists on disk → fallback PASS (score 90).
+      const fallbackResult = await gate.validator({});
+      expect(fallbackResult.pass).toBe(true);
+      expect(fallbackResult.score).toBe(90);
 
-      // Mark as read
-      markProtocolFileRead('CLAUDE_LEAD.md');
+      // Mark the destination file (CLAUDE_PLAN.md) as fully read → score 100.
+      markProtocolFileRead('CLAUDE_PLAN.md');
 
-      // Test passing
       const passResult = await gate.validator({});
       expect(passResult.pass).toBe(true);
+      expect(passResult.score).toBe(100);
     });
   });
 


### PR DESCRIPTION
## Summary
Two stale-harness signals were lying; this corrects both (bugfix, EHG_Engineer).

### (a) S15 artifact taxonomy
`lifecycle_stage_config.required_artifacts` for stage 15 (Design Studio) still listed the pre-Stitch `blueprint_wireframes` alongside the current `wireframe_screens`. `monitor-venture-run.cjs` reads this DB-authoritative column, so it false-flagged **"S15 missing_artifact: blueprint_wireframes"** on every venture run (observed live on venture `0e6449d9`). The array **already contained** `wireframe_screens`, so the fix is a **removal** (not the "replace" the feedback implied). Applied to the live engineer DB + captured in an idempotent `array_remove` migration.

### (b) protocol-file-read-gate tests (19 pre-existing-RED failures)
Two unit-test files asserted a gate contract that **four documented SDs superseded** — they were never updated:
- destination-phase file mapping (`SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001`)
- fallback-PASS when the file exists on disk (`SD-LEO-FIX-COMPLETION-WORKFLOW-001`)
- ≥30-line partial-read auto-pass (`SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-063`)
- scoped session-state path (`SD-FDBK-ENH-SESSION-STATE-SCOPING-001`)

Repaired to the **current documented contract** via assertion/fixture/handoff-type alignment + a **hermetic `session-state-resolver` `vi.mock`** (temp file) for deterministic, side-effect-free state. All **34 tests salvaged** — no mock-to-green, no quarantine. A second-order bug surfaced (fixtures paired the wrong protocol file with each handoff under the new mapping) and was fixed by aligning handoff types.

## No production logic change
`git diff` is **empty** for `scripts/modules/handoff/gates/protocol-file-read-gate.js` and `scripts/monitor-venture-run.cjs` — the gate/monitor are correct; only stale DB data + stale tests were fixed.

## Tests
- protocol-file-read-gate suites: **34/34 pass** (was 19 failing).
- Collateral (monitor + stage-15): 42 pass, 3 pre-existing skips, 0 failures.

3 files changed: 1 migration + 2 test files. SD: SD-FDBK-FIX-FIX-STALE-HARNESS-001 (bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)