### PR TITLE
refactor(SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001): adopt canonical resolveSessionId in 2 PostToolUse hooks

### DIFF
--- a/scripts/hooks/__tests__/model-tracking.test.js
+++ b/scripts/hooks/__tests__/model-tracking.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001 — model-tracking session-id resolution.
+ *
+ * getModelInfo() now accepts an OPTIONAL resolved sessionId (supplied by main() from the
+ * canonical lib/hooks/session-id.cjs cascade). The no-arg path preserves the prior
+ * env-based behavior for backward compatibility.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const HOOK_PATH = path.resolve(__dirname, '../model-tracking.cjs');
+
+function loadHook() {
+  delete require.cache[require.resolve(HOOK_PATH)];
+  return require(HOOK_PATH);
+}
+
+describe('model-tracking getModelInfo session-id resolution', () => {
+  const orig = process.env.CLAUDE_SESSION_ID;
+  beforeEach(() => { delete process.env.CLAUDE_SESSION_ID; });
+  afterEach(() => { if (orig === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = orig; });
+
+  it('uses the explicit resolved sessionId when provided (FR-1 / AC-1)', () => {
+    const { getModelInfo } = loadHook();
+    expect(getModelInfo('abc123').session_id).toBe('abc123');
+  });
+
+  it("falls back to 'unknown' with no arg and no env (backward-compatible no-arg behavior)", () => {
+    const { getModelInfo } = loadHook();
+    expect(getModelInfo().session_id).toBe('unknown');
+  });
+
+  it('falls back to CLAUDE_SESSION_ID env with no arg (unchanged legacy path)', () => {
+    process.env.CLAUDE_SESSION_ID = 'env-sess-9';
+    const { getModelInfo } = loadHook();
+    expect(getModelInfo().session_id).toBe('env-sess-9');
+  });
+
+  it('an explicit sessionId takes precedence over the env var', () => {
+    process.env.CLAUDE_SESSION_ID = 'env-sess-9';
+    const { getModelInfo } = loadHook();
+    expect(getModelInfo('explicit-1').session_id).toBe('explicit-1');
+  });
+
+  it('still returns model_id and a timestamp (no behavioral regression)', () => {
+    const { getModelInfo } = loadHook();
+    const info = getModelInfo('s1');
+    expect(typeof info.model_id).toBe('string');
+    expect(typeof info.timestamp).toBe('string');
+  });
+});

--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -116,6 +116,29 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     expect(fs.existsSync(outFile)).toBe(false);
   });
 
+  it('TS-19: resolves session_id from the stdin payload when env is absent (SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001)', () => {
+    // Real PostToolUse contract: CLAUDE_SESSION_ID is NOT propagated to the hook
+    // subprocess, but the stdin payload carries session_id. Before the fix this hook
+    // resolved from env BEFORE reading stdin → '' → silent no-op. Now it must resolve
+    // from payload.session_id and write the outcome file.
+    const payloadSession = 'payload-sess-' + Math.random().toString(36).slice(2);
+    const payload = JSON.stringify({
+      session_id: payloadSession,
+      tool_name: 'Bash',
+      tool_response: { exit_code: 2, stderr: 'TypeError: x' },
+    });
+    const env = { ...process.env, CLAUDE_TOOL_NAME: 'Bash', LEO_RETRY_STATE_DIR: tmpDir };
+    delete env.CLAUDE_SESSION_ID; // simulate the real PostToolUse env (no session id)
+    delete env.SESSION_ID;
+    const result = spawnSync('node', [HOOK_PATH], { input: payload, env, encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${payloadSession}.json`);
+    expect(fs.existsSync(outFile)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.tool_name).toBe('Bash');
+    expect(written.exit_code).toBe(2);
+  });
+
   it('non-Bash tool → no file written (signatures are file_path-keyed)', () => {
     const payload = JSON.stringify({
       tool_name: 'Edit',

--- a/scripts/hooks/model-tracking.cjs
+++ b/scripts/hooks/model-tracking.cjs
@@ -47,16 +47,23 @@ function saveSessionState(state) {
 }
 
 /**
- * Get model info from environment or Claude Code metadata
+ * Get model info from environment or Claude Code metadata.
+ *
+ * @param {string} [sessionId] - Resolved session id (from the canonical cascade in
+ *   main()). When omitted, falls back to the env var for backward compatibility.
  */
-function getModelInfo() {
+function getModelInfo(sessionId) {
   // Claude Code sets these environment variables
   const modelId = process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'unknown';
-  const sessionId = process.env.CLAUDE_SESSION_ID || 'unknown';
+  // SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001: prefer the resolved session id.
+  // PostToolUse subprocesses do NOT receive CLAUDE_SESSION_ID, so the env-only read
+  // collapsed every tracked row onto session_id='unknown'. The no-arg path preserves
+  // the prior env-based behavior for any direct/legacy caller.
+  const resolvedSessionId = sessionId || process.env.CLAUDE_SESSION_ID || 'unknown';
 
   return {
     model_id: modelId,
-    session_id: sessionId,
+    session_id: resolvedSessionId,
     timestamp: new Date().toISOString()
   };
 }
@@ -64,9 +71,20 @@ function getModelInfo() {
 /**
  * Main hook execution
  */
-function main() {
+async function main() {
+  // SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001: resolve the session id via the
+  // canonical cascade (stdin session_id → CLAUDE_SESSION_ID env → session-identity
+  // marker → null). PostToolUse does not propagate CLAUDE_SESSION_ID, so the prior
+  // env-only read recorded 'unknown' for every tool execution. Fail-open: any resolver
+  // error leaves sessionId undefined and getModelInfo() falls back to env.
+  let sessionId;
+  try {
+    const { resolveSessionId } = require('../../lib/hooks/session-id.cjs');
+    sessionId = await resolveSessionId();
+  } catch { /* fall back to env inside getModelInfo */ }
+
   const state = loadSessionState();
-  const modelInfo = getModelInfo();
+  const modelInfo = getModelInfo(sessionId);
 
   // Increment tool executions
   state.tool_executions = (state.tool_executions || 0) + 1;

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -82,15 +82,24 @@ function digestStderr(stderr) {
     const flag = (process.env.LEO_RCA_OUTCOME_CAPTURE || 'on').toLowerCase();
     if (flag === 'off' || flag === '0' || flag === 'false') return;
 
-    // Resolve session id (env first per existing hook precedent).
+    // SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001: read the stdin payload FIRST,
+    // then resolve session_id from it (canonical cascade: stdin session_id → env).
+    // PostToolUse does NOT propagate CLAUDE_SESSION_ID, so the prior env-only resolve
+    // (run BEFORE the stdin read) always yielded '' and this hook silently no-op'd —
+    // the last-outcome file was never written and the RCA tiered-signature feature was
+    // effectively dead. stdin is single-consumption, so resolve from the already-parsed
+    // payload via the canonical isValidSessionId rather than calling resolveSessionId()
+    // (which would re-read drained stdin).
+    const payload = await getStdinJson(STDIN_TIMEOUT_MS);
+    if (!payload || typeof payload !== 'object') return;
+
+    const { isValidSessionId } = require('../../lib/hooks/session-id.cjs');
     const sessionId =
+      (isValidSessionId(payload.session_id) && payload.session_id) ||
       process.env.CLAUDE_SESSION_ID ||
       process.env.SESSION_ID ||
       '';
     if (!sessionId) return;
-
-    const payload = await getStdinJson(STDIN_TIMEOUT_MS);
-    if (!payload || typeof payload !== 'object') return;
 
     // Claude Code hook payload: tool_response is the structured outcome.
     // Accept multiple shapes for robustness across hook protocol versions.


### PR DESCRIPTION
## Summary
Two PostToolUse hooks still resolved session-id from the unpropagated `CLAUDE_SESSION_ID` env var (Claude Code does not pass it to PostToolUse subprocesses):
- **model-tracking.cjs** recorded `session_id='unknown'` for every tracked row. `getModelInfo()` now takes an **optional** `sessionId` (no-arg behavior unchanged); `main()` is async and awaits `resolveSessionId()` from `lib/hooks/session-id.cjs` (fail-open).
- **post-tool-rca-outcome.cjs** resolved session-id from env **before** reading stdin, then early-returned → **silent no-op** (the `last-outcome` file was never written, so the RCA tiered-signature feature was effectively dead). It now reads the stdin payload first and resolves `session_id` from `payload.session_id` via the canonical `isValidSessionId` (env fallback). stdin is consumed once (it does **not** call `resolveSessionId()`).

A per-file audit (LEAD verify-claims) found these are the **only two** genuine env-only-resolution bugs; the rest of `scripts/hooks` resolve session-id by design (PID-tree/DB/generated/already-migrated) or are git hooks — out of scope (scope reduced 60%).

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/model-tracking.test.js scripts/hooks/__tests__/post-tool-rca-outcome.test.js --project unit` — **15 passing** (new model-tracking.test.js ×5 + rca-outcome TS-19 payload-resolution)
- [x] regression-agent PASS (97): API-signature parity (no-arg `getModelInfo` byte-for-byte), import resolution, behavioral parity
- [x] EXEC-TO-PLAN 96, PLAN-TO-LEAD 93, retrospective 100/100

SD: SD-FDBK-REFAC-ADOPT-RESOLVESESSIONID-CASCADE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)