### PR TITLE
fix(QF-20260525-419): harden deleteVentureFully gh repo-delete (SEC-D-01/02)

### DIFF
--- a/lib/deleteVentureFully.js
+++ b/lib/deleteVentureFully.js
@@ -25,7 +25,7 @@
  * returned per-phase result rather than thrown.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createSupabaseServiceClient } from './supabase-client.js';
@@ -47,7 +47,9 @@ export const PROTECTED_REPOS = new Set([
 // Injection-safe slug: owner/repo of only safe path characters. Anything with
 // shell metacharacters, spaces, or extra path segments is rejected before any
 // shell invocation. (Hardening over master-reset, which only counted segments.)
-const SAFE_SLUG_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+// QF-20260525-419 (SEC-D-01): neither segment may START with '-' — a leading dash
+// would otherwise be parsed by gh as a flag (arg-injection on a destructive delete).
+const SAFE_SLUG_RE = /^[A-Za-z0-9_.][A-Za-z0-9_.-]*\/[A-Za-z0-9_.][A-Za-z0-9_.-]*$/;
 
 /**
  * Extract and validate the owner/repo slug from a venture repo URL.
@@ -179,9 +181,18 @@ function deleteGithubRepo(repoUrl, { dryRun = false } = {}) {
   }
 
   try {
-    execSync(`gh repo delete ${slug} --yes`, { timeout: 15000, stdio: 'pipe' });
+    // QF-20260525-419 (SEC-D-01): execFileSync = no shell, and '--' terminates flag
+    // parsing so the slug can never be read as a gh flag (defense-in-depth with the
+    // leading-dash-forbidding SAFE_SLUG_RE above).
+    execFileSync('gh', ['repo', 'delete', '--yes', '--', slug], { timeout: 15000, stdio: 'pipe' });
     return { slug, status: 'deleted' };
   } catch (err) {
+    // QF-20260525-419 (SEC-D-02): a missing gh binary throws ENOENT ("command not
+    // found"), whose message contains "not found" — classify it as a real failure
+    // BEFORE the already-gone branch so a missing CLI is never mistaken for success.
+    if (err.code === 'ENOENT' || /ENOENT|command not found/i.test(err.message || '')) {
+      return { slug, status: 'failed', reason: 'gh CLI not found (ENOENT)' };
+    }
     const msg = err.stderr?.toString() || err.message || '';
     if (msg.includes('not found') || msg.includes('404')) {
       return { slug, status: 'deleted', reason: 'already gone' };

--- a/tests/unit/deleteVentureFully.test.js
+++ b/tests/unit/deleteVentureFully.test.js
@@ -21,14 +21,14 @@
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-const { execSyncMock, runTeardownMock, markResourcesMock, cleanupCredsMock } = vi.hoisted(() => ({
-  execSyncMock: vi.fn(),
+const { execFileSyncMock, runTeardownMock, markResourcesMock, cleanupCredsMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
   runTeardownMock: vi.fn(),
   markResourcesMock: vi.fn(),
   cleanupCredsMock: vi.fn(),
 }));
 
-vi.mock('child_process', () => ({ execSync: execSyncMock }));
+vi.mock('child_process', () => ({ execFileSync: execFileSyncMock }));
 vi.mock('../../lib/cleanup/index.js', () => ({ runTeardown: runTeardownMock }));
 vi.mock('../../lib/venture-resources.js', () => ({ markResourcesCleaned: markResourcesMock }));
 vi.mock('../../lib/cleanup/credentials.js', () => ({ cleanup: cleanupCredsMock }));
@@ -68,7 +68,7 @@ function makeSupabase(repoUrl = null, rpc) {
 
 describe('deleteVentureFully — destructive path security invariants', () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     runTeardownMock.mockReset().mockResolvedValue({ success: true });
     markResourcesMock.mockReset().mockResolvedValue(1);
     cleanupCredsMock.mockReset().mockResolvedValue({ revoked: [], failed: [], skipped: [] });
@@ -78,7 +78,7 @@ describe('deleteVentureFully — destructive path security invariants', () => {
     const result = await deleteVentureFully(null, { supabase: makeSupabase() });
     expect(result.success).toBe(false);
     expect(result.error).toBe('ventureId is required');
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 
   // FR-2: PROTECTED_REPOS guard ------------------------------------------------
@@ -86,8 +86,10 @@ describe('deleteVentureFully — destructive path security invariants', () => {
     const supabase = makeSupabase('https://github.com/rickfelix/canvas-ai');
     const result = await deleteVentureFully(VENTURE_ID, { supabase });
 
-    expect(execSyncMock).toHaveBeenCalledTimes(1);
-    expect(execSyncMock.mock.calls[0][0]).toBe('gh repo delete rickfelix/canvas-ai --yes');
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    // QF-20260525-419: shell-free execFileSync with the slug after '--' (cannot be a flag).
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('gh');
+    expect(execFileSyncMock.mock.calls[0][1]).toEqual(['repo', 'delete', '--yes', '--', 'rickfelix/canvas-ai']);
     expect(result.phases.github_repo.status).toBe('deleted');
     expect(result.phases.github_repo.slug).toBe('rickfelix/canvas-ai');
   });
@@ -100,7 +102,7 @@ describe('deleteVentureFully — destructive path security invariants', () => {
     const supabase = makeSupabase(url);
     const result = await deleteVentureFully(VENTURE_ID, { supabase });
 
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(result.phases.github_repo.status).toBe('skipped');
     expect(result.phases.github_repo.reason).toMatch(/PROTECTED/);
   });
@@ -114,7 +116,7 @@ describe('deleteVentureFully — destructive path security invariants', () => {
     const supabase = makeSupabase(url);
     const result = await deleteVentureFully(VENTURE_ID, { supabase });
 
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(result.phases.github_repo.status).toBe('failed');
     expect(result.phases.github_repo.reason).toMatch(/invalid or unsafe/);
   });
@@ -158,7 +160,7 @@ describe('deleteVentureFully — destructive path security invariants', () => {
 
     expect(result.success).toBe(false);
     expect(result.phases.db.success).toBe(false);
-    expect(execSyncMock).not.toHaveBeenCalled(); // never reached the gh delete after DB failure
+    expect(execFileSyncMock).not.toHaveBeenCalled(); // never reached the gh delete after DB failure
   });
 
   it('dryRun: skips the DB delete and the gh repo delete', async () => {
@@ -168,9 +170,36 @@ describe('deleteVentureFully — destructive path security invariants', () => {
     const result = await deleteVentureFully(VENTURE_ID, { supabase, dryRun: true });
 
     expect(rpc).not.toHaveBeenCalled();
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(result.phases.db.dryRun).toBe(true);
     expect(result.phases.github_repo.status).toBe('skipped');
+  });
+
+  // QF-20260525-419 SEC-D-01: a leading-dash slug (arg-injection vector) is rejected
+  // before any delete invocation — it would otherwise be parsed by gh as a flag.
+  it('SEC-D-01: rejects a leading-dash slug before any delete invocation', async () => {
+    const supabase = makeSupabase('https://github.com/-rf/victim');
+    const result = await deleteVentureFully(VENTURE_ID, { supabase });
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(result.phases.github_repo.status).toBe('failed');
+    expect(result.phases.github_repo.reason).toMatch(/invalid or unsafe/);
+  });
+
+  // QF-20260525-419 SEC-D-02: a missing gh binary throws ENOENT ("command not found").
+  // It must be classified as a real failure, never mistaken for an "already gone" success.
+  it('SEC-D-02: classifies a missing gh binary (ENOENT) as failed, not deleted', async () => {
+    execFileSyncMock.mockImplementation(() => {
+      const e = new Error('spawn gh ENOENT');
+      e.code = 'ENOENT';
+      throw e;
+    });
+    const supabase = makeSupabase('https://github.com/rickfelix/canvas-ai');
+    const result = await deleteVentureFully(VENTURE_ID, { supabase });
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(result.phases.github_repo.status).toBe('failed');
+    expect(result.phases.github_repo.reason).toMatch(/gh CLI not found/);
   });
 });
 
@@ -186,6 +215,12 @@ describe('parseRepoSlug / isProtectedRepo', () => {
   it('flags slugs with shell metacharacters as invalid', () => {
     expect(parseRepoSlug('https://github.com/rickfelix/evil;whoami').valid).toBe(false);
     expect(parseRepoSlug(null)).toEqual({ slug: null, valid: false });
+  });
+
+  it('SEC-D-01: rejects a leading-dash owner or repo segment (mid-segment dashes still valid)', () => {
+    expect(parseRepoSlug('https://github.com/-rf/victim').valid).toBe(false);
+    expect(parseRepoSlug('https://github.com/owner/-evil').valid).toBe(false);
+    expect(parseRepoSlug('https://github.com/rickfelix/canvas-ai').valid).toBe(true);
   });
 
   it('treats the core repos (and lowercase variants) as protected', () => {


### PR DESCRIPTION
## Summary
Defense-in-depth hardening of `lib/deleteVentureFully.js` `deleteGithubRepo()`, from feedback `bec0806b` (SECURITY review of SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-D, evidence `26696bbc`).

**SEC-D-01 — arg-injection on a destructive `gh repo delete`:**
- `SAFE_SLUG_RE` now forbids a **leading dash** in either segment (mid-segment dashes like `canvas-ai` stay valid).
- Replaced `execSync(\`gh repo delete ${slug} --yes\`)` (shell string interpolation) with `execFileSync('gh', ['repo','delete','--yes','--', slug])` — **no shell**, and the slug sits after `--` so it can never be parsed as a `gh` flag.

**SEC-D-02 — error misclassification:** a missing `gh` binary throws `ENOENT` ("command not found"), whose message contains "not found" and was mapped to `status:'deleted' ('already gone')` — a **false success**. The catch now checks `err.code==='ENOENT'` (and the message) **first** and returns `status:'failed'`.

## Tests
Updated the `child_process` mock to `execFileSync` + the FR-2 assertion to args-array form; added **SEC-D-01** (leading-dash slug rejected before any delete), **SEC-D-02** (ENOENT → failed, not deleted), and a `parseRepoSlug` leading-dash unit case. **18/18 pass.** +11 net source LOC.

QF-20260525-419 · Tier-1 · target EHG_Engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)