### PR TITLE
feat(SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001): schema-preflight literal coercion + sanctioned parent-rollup-claim helper

### DIFF
--- a/lib/schema-preflight.cjs
+++ b/lib/schema-preflight.cjs
@@ -28,6 +28,15 @@ const JS_TO_PG_TYPE_MAP = {
  * @returns {{compatible: boolean, reason?: string}}
  */
 function checkTypeCompatibility(value, columnMeta) {
+  // SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001: 'unknown' is the extractParams placeholder
+  // for values that were NOT literal-coerced (filters/select/order columns + non-literal
+  // mutation values). Skip the type check for it — the unknown-COLUMN check in
+  // validateOperation still runs. Previously the placeholder was type-checked against the
+  // real column type, falsely flagging every non-string column (e.g. bool is_working_on).
+  if (value === 'unknown') {
+    return { compatible: true };
+  }
+
   if (value === null || value === undefined) {
     if (columnMeta.is_nullable === 'NO' && columnMeta.column_default === null) {
       return { compatible: false, reason: `Column is NOT NULL with no default` };

--- a/scripts/claim-orchestrator-for-rollup.mjs
+++ b/scripts/claim-orchestrator-for-rollup.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * claim-orchestrator-for-rollup.mjs — SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001
+ *
+ * Sanctioned, audited replacement for the ad-hoc inline UPDATE workaround used when an
+ * orchestrator CHILD finalizes (LEAD-FINAL-APPROVAL) and must write a PARENT rollup
+ * PLAN-TO-LEAD handoff. sd-start routes orchestrators to leaf children, so it cannot claim
+ * the parent directly; the rollup handoff then fails with "Cannot create handoff for SD
+ * without active session claim".
+ *
+ * This helper TRANSIENTLY claims the orchestrator parent for the rollup, and releases it.
+ * It does NOT modify sd-start core claim-routing or the heartbeat machinery (those are owned
+ * by the completed SD-FDBK-INFRA-CASCADE-TRIGGER-OVERREACH-001 / heartbeat SDs).
+ *
+ * Usage:
+ *   CLAUDE_SESSION_ID=<sid> node scripts/claim-orchestrator-for-rollup.mjs <parent-sd-key-or-uuid>
+ *   CLAUDE_SESSION_ID=<sid> node scripts/claim-orchestrator-for-rollup.mjs <parent-sd-key-or-uuid> --release
+ *
+ * Sequence: claim → (caller) run the orchestrator completion / rollup handoff → --release.
+ */
+
+const LIVE_SESSION_THRESHOLD_MS = 15 * 60 * 1000; // mirrors the claim TTL
+
+/**
+ * Core logic, decoupled from the CLI + the supabase client for testability.
+ *
+ * @param {object} supabase - Supabase client (or a mock with from().select().eq()/update().eq()).
+ * @param {object} opts
+ * @param {string} opts.sdKey - parent sd_key or uuid
+ * @param {string} opts.sessionId - resolved current session id
+ * @param {boolean} [opts.release] - release instead of claim
+ * @param {number} [opts.now] - epoch ms (injectable for tests)
+ * @returns {Promise<{ok:boolean, action:string, reason?:string, sdKey?:string}>}
+ */
+export async function claimOrchestratorForRollup(supabase, { sdKey, sessionId, release = false, now = Date.now() }) {
+  if (!sdKey) return { ok: false, action: 'error', reason: 'missing sd key/uuid argument' };
+  if (!sessionId) return { ok: false, action: 'error', reason: 'no session id (set CLAUDE_SESSION_ID)' };
+
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdKey);
+  const col = isUuid ? 'id' : 'sd_key';
+  const { data: sd, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, sd_type, is_working_on, claiming_session_id')
+    .eq(col, sdKey)
+    .maybeSingle();
+  if (sdErr) return { ok: false, action: 'error', reason: `lookup failed: ${sdErr.message}` };
+  if (!sd) return { ok: false, action: 'error', reason: `SD not found: ${sdKey}` };
+
+  // Confirm it is an orchestrator (sd_type or has children) — guards against claiming a leaf.
+  let isOrchestrator = sd.sd_type === 'orchestrator';
+  if (!isOrchestrator) {
+    const { data: kids } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('parent_sd_id', sd.id)
+      .limit(1);
+    isOrchestrator = Array.isArray(kids) && kids.length > 0;
+  }
+  if (!isOrchestrator) {
+    return { ok: false, action: 'error', reason: `${sd.sd_key} is not an orchestrator (no sd_type='orchestrator' and no children). Use sd-start for leaf SDs.` };
+  }
+
+  if (release) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({ is_working_on: false, claiming_session_id: null })
+      .eq('id', sd.id);
+    if (error) return { ok: false, action: 'error', reason: `release failed: ${error.message}` };
+    return { ok: true, action: 'released', sdKey: sd.sd_key };
+  }
+
+  // Refuse if claimed by a DIFFERENT live session (heartbeat within the TTL).
+  if (sd.claiming_session_id && sd.claiming_session_id !== sessionId) {
+    const { data: other } = await supabase
+      .from('claude_sessions')
+      .select('session_id, status, heartbeat_at')
+      .eq('session_id', sd.claiming_session_id)
+      .maybeSingle();
+    if (other) {
+      const hbMs = other.heartbeat_at ? new Date(other.heartbeat_at).getTime() : 0;
+      const live = other.status === 'active' && (now - hbMs) < LIVE_SESSION_THRESHOLD_MS;
+      if (live) {
+        return { ok: false, action: 'refused', reason: `parent ${sd.sd_key} is claimed by a different LIVE session ${sd.claiming_session_id.slice(0, 8)} (heartbeat ${Math.round((now - hbMs) / 1000)}s ago)`, sdKey: sd.sd_key };
+      }
+    }
+  }
+
+  const { error } = await supabase
+    .from('strategic_directives_v2')
+    .update({ is_working_on: true, claiming_session_id: sessionId })
+    .eq('id', sd.id);
+  if (error) return { ok: false, action: 'error', reason: `claim failed: ${error.message}` };
+  return { ok: true, action: 'claimed', sdKey: sd.sd_key };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+const isMain = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/')); }
+  catch { return false; }
+})();
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  const release = args.includes('--release');
+  const sdKey = args.find((a) => !a.startsWith('--'));
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  const { createSupabaseServiceClient } = await import('./lib/supabase-connection.js');
+  const supabase = await createSupabaseServiceClient('engineer');
+  const result = await claimOrchestratorForRollup(supabase, { sdKey, sessionId, release });
+  if (result.ok) {
+    if (result.action === 'claimed') {
+      console.log(`✓ Claimed orchestrator parent ${result.sdKey} for rollup (session ${sessionId.slice(0, 8)}).`);
+      console.log(`  Now run the completion/rollup handoff, then RELEASE:`);
+      console.log(`  CLAUDE_SESSION_ID=${sessionId} node scripts/claim-orchestrator-for-rollup.mjs ${result.sdKey} --release`);
+    } else {
+      console.log(`✓ Released orchestrator parent ${result.sdKey}.`);
+    }
+    process.exit(0);
+  } else {
+    console.error(`✗ ${result.action.toUpperCase()}: ${result.reason}`);
+    process.exit(1);
+  }
+}

--- a/scripts/hooks/lib/coerce-literal.cjs
+++ b/scripts/hooks/lib/coerce-literal.cjs
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * coerce-literal.cjs — SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001
+ *
+ * Coerce a captured Supabase-mutation value token (text extracted from a Bash command by
+ * pre-tool-enforce.cjs::extractParams) to a JS literal so lib/schema-preflight.cjs can
+ * type-check it against the real column type.
+ *
+ * ONLY unambiguous literals are coerced:
+ *   - 'true' / 'false'           -> boolean
+ *   - integer / decimal literal  -> number
+ *   - 'x' / "x" / `x`            -> the inner string
+ * Anything else (variables, expressions, arrays, nested objects, template interpolation)
+ * returns the 'unknown' placeholder, which schema-preflight treats as TYPE-CHECK-SKIP.
+ *
+ * This fixes the false-positive where every mutation value was stamped 'unknown' and then
+ * type-checked against non-string columns (e.g. bool is_working_on) → spurious "Type mismatch".
+ *
+ * @param {string} raw - the value token text (right side of `key: value`)
+ * @returns {boolean|number|string} a coerced literal, or the string 'unknown'
+ */
+function coerceLiteral(raw) {
+  const v = (raw == null ? '' : String(raw)).trim();
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(v)) return Number(v);
+  const q = v.match(/^(['"`])([\s\S]*)\1$/);
+  if (q) return q[2];
+  return 'unknown';
+}
+
+module.exports = { coerceLiteral };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -277,6 +277,11 @@ function extractTableName(command) {
  * @param {string} command
  * @returns {Object<string, *>}
  */
+// SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001: literal coercion for mutation values lives in
+// a small shared, unit-tested module (this hook runs main() at load, so it cannot be required
+// from a test — the pure coercion logic is extracted to be testable).
+const { coerceLiteral } = require(path.resolve(__dirname, 'lib', 'coerce-literal.cjs'));
+
 function extractParams(command) {
   const params = {};
   let match;
@@ -310,14 +315,20 @@ function extractParams(command) {
 
   // .insert({ col: val, ... }) / .update({ col: val, ... }) / .upsert({ col: val, ... })
   // Extract object keys from simple { key: val } patterns
+  // SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001: extract keys AND coerce literal values
+  // (true/false/number/quoted-string). Previously every value was stamped 'unknown', which
+  // the schema-preflight then type-checked against the real column udt_name — falsely flagging
+  // every non-string column (e.g. .update({ is_working_on: true }) → "Type mismatch" → BLOCK).
+  // Non-literal values stay 'unknown' (the schema-preflight type-check-skip sentinel; the
+  // unknown-column check still runs). Quoted-string alternative is first so values containing
+  // commas/colons are captured whole before the [^,]+ fallback.
   const mutationPattern = /\.(?:insert|update|upsert)\(\s*\{([^}]+)\}/g;
   while ((match = mutationPattern.exec(command)) !== null) {
     const objectBody = match[1];
-    // Extract keys from "key: value" or "key : value" patterns
-    const keyPattern = /(\w+)\s*:/g;
-    let keyMatch;
-    while ((keyMatch = keyPattern.exec(objectBody)) !== null) {
-      params[keyMatch[1]] = 'unknown';
+    const kvPattern = /(\w+)\s*:\s*('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|true|false|-?\d+(?:\.\d+)?|[^,]+)/g;
+    let kvMatch;
+    while ((kvMatch = kvPattern.exec(objectBody)) !== null) {
+      params[kvMatch[1]] = coerceLiteral(kvMatch[2]);
     }
   }
 

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -748,7 +748,14 @@ async function main() {
         } catch { /* non-fatal — handoff will surface the error */ }
 
         console.log(`\n${colors.green}✅ All children completed${colors.reset}`);
-        console.log(`   Run orchestrator completion: node scripts/handoff.js execute PLAN-TO-LEAD ${effectiveId}`);
+        // SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001: the parent completion handoff writes a
+        // rollup that requires the PARENT to be claimed, but sd-start routes orchestrators to
+        // leaves and cannot claim the parent. Use the sanctioned claim helper, run the handoff,
+        // then release — instead of an ad-hoc inline is_working_on UPDATE.
+        console.log(`   Orchestrator completion needs the PARENT claimed. Run:`);
+        console.log(`   ${colors.cyan}CLAUDE_SESSION_ID=<sid> node scripts/claim-orchestrator-for-rollup.mjs ${effectiveId}${colors.reset}`);
+        console.log(`   ${colors.cyan}node scripts/handoff.js execute PLAN-TO-LEAD ${effectiveId}${colors.reset}`);
+        console.log(`   ${colors.cyan}CLAUDE_SESSION_ID=<sid> node scripts/claim-orchestrator-for-rollup.mjs ${effectiveId} --release${colors.reset}`);
         console.log('═'.repeat(50));
         process.exit(0);
       }

--- a/tests/unit/orchestrator-child/claim-orchestrator-for-rollup.test.js
+++ b/tests/unit/orchestrator-child/claim-orchestrator-for-rollup.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001 — FR-3 / AC-5.
+ * Unit-tests the sanctioned parent-rollup-claim helper against a mock supabase client.
+ */
+import { describe, it, expect } from 'vitest';
+import { claimOrchestratorForRollup } from '../../../scripts/claim-orchestrator-for-rollup.mjs';
+
+/**
+ * Build a mock supabase whose responses are configured per (table, eq-column).
+ * Captures any .update() payload.
+ */
+function makeMock({ sd = null, children = [], session = null } = {}) {
+  const captured = { updates: [] };
+  const client = {
+    from(table) {
+      return {
+        select() {
+          return {
+            eq(col) {
+              return {
+                async maybeSingle() {
+                  if (table === 'strategic_directives_v2') return { data: sd, error: null };
+                  if (table === 'claude_sessions') return { data: session, error: null };
+                  return { data: null, error: null };
+                },
+                async limit() {
+                  if (table === 'strategic_directives_v2' && col === 'parent_sd_id') return { data: children, error: null };
+                  return { data: [], error: null };
+                },
+              };
+            },
+          };
+        },
+        update(payload) {
+          return {
+            async eq(col, val) { captured.updates.push({ table, payload, col, val }); return { error: null }; },
+          };
+        },
+      };
+    },
+  };
+  return { client, captured };
+}
+
+const ORCH = { id: 'uuid-parent', sd_key: 'SD-ORCH-001', sd_type: 'orchestrator', is_working_on: false, claiming_session_id: null };
+
+describe('claimOrchestratorForRollup (FR-3 / AC-5)', () => {
+  it('claims an unclaimed orchestrator parent (is_working_on=true + claiming_session_id)', async () => {
+    const { client, captured } = makeMock({ sd: ORCH });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: 'sess-me' });
+    expect(r).toMatchObject({ ok: true, action: 'claimed', sdKey: 'SD-ORCH-001' });
+    expect(captured.updates).toHaveLength(1);
+    expect(captured.updates[0].payload).toEqual({ is_working_on: true, claiming_session_id: 'sess-me' });
+  });
+
+  it('releases the parent (--release clears both columns)', async () => {
+    const { client, captured } = makeMock({ sd: { ...ORCH, is_working_on: true, claiming_session_id: 'sess-me' } });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: 'sess-me', release: true });
+    expect(r).toMatchObject({ ok: true, action: 'released' });
+    expect(captured.updates[0].payload).toEqual({ is_working_on: false, claiming_session_id: null });
+  });
+
+  it('refuses when the parent is claimed by a DIFFERENT live session (recent heartbeat)', async () => {
+    const now = Date.parse('2026-05-25T12:00:00Z');
+    const sd = { ...ORCH, is_working_on: true, claiming_session_id: 'sess-other' };
+    const session = { session_id: 'sess-other', status: 'active', heartbeat_at: new Date(now - 60_000).toISOString() };
+    const { client, captured } = makeMock({ sd, session });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: 'sess-me', now });
+    expect(r).toMatchObject({ ok: false, action: 'refused' });
+    expect(captured.updates).toHaveLength(0); // no mutation on refusal
+  });
+
+  it('takes over a STALE foreign claim (old heartbeat) and claims it', async () => {
+    const now = Date.parse('2026-05-25T12:00:00Z');
+    const sd = { ...ORCH, is_working_on: true, claiming_session_id: 'sess-stale' };
+    const session = { session_id: 'sess-stale', status: 'active', heartbeat_at: new Date(now - 30 * 60_000).toISOString() }; // 30 min ago > 15 min TTL
+    const { client, captured } = makeMock({ sd, session });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: 'sess-me', now });
+    expect(r).toMatchObject({ ok: true, action: 'claimed' });
+    expect(captured.updates).toHaveLength(1);
+  });
+
+  it('errors when the SD is NOT an orchestrator (no sd_type and no children)', async () => {
+    const leaf = { id: 'uuid-leaf', sd_key: 'SD-LEAF-001', sd_type: 'feature', is_working_on: false, claiming_session_id: null };
+    const { client, captured } = makeMock({ sd: leaf, children: [] });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-LEAF-001', sessionId: 'sess-me' });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe('error');
+    expect(captured.updates).toHaveLength(0);
+  });
+
+  it('treats a non-orchestrator-typed SD WITH children as an orchestrator (claims it)', async () => {
+    const parentByChildren = { id: 'uuid-p2', sd_key: 'SD-P2-001', sd_type: 'infrastructure', is_working_on: false, claiming_session_id: null };
+    const { client } = makeMock({ sd: parentByChildren, children: [{ id: 'kid-1' }] });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-P2-001', sessionId: 'sess-me' });
+    expect(r).toMatchObject({ ok: true, action: 'claimed' });
+  });
+
+  it('errors on missing session id', async () => {
+    const { client } = makeMock({ sd: ORCH });
+    const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: '' });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/tests/unit/orchestrator-child/coerce-literal.test.js
+++ b/tests/unit/orchestrator-child/coerce-literal.test.js
@@ -1,0 +1,36 @@
+/**
+ * SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001 — FR-1: literal coercion of mutation values.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+const require = createRequire(import.meta.url);
+const { coerceLiteral } = require(path.resolve(__dirname, '../../../scripts/hooks/lib/coerce-literal.cjs'));
+
+describe('coerceLiteral (FR-1 / AC-1, AC-2)', () => {
+  it('coerces boolean literals', () => {
+    expect(coerceLiteral('true')).toBe(true);
+    expect(coerceLiteral('false')).toBe(false);
+    expect(coerceLiteral('  true  ')).toBe(true);
+  });
+  it('coerces numeric literals', () => {
+    expect(coerceLiteral('5')).toBe(5);
+    expect(coerceLiteral('-3')).toBe(-3);
+    expect(coerceLiteral('2.5')).toBe(2.5);
+  });
+  it('coerces quoted strings to their inner text (single/double/backtick)', () => {
+    expect(coerceLiteral("'active'")).toBe('active');
+    expect(coerceLiteral('"draft"')).toBe('draft');
+    expect(coerceLiteral('`x`')).toBe('x');
+    expect(coerceLiteral("'a, b: c'")).toBe('a, b: c'); // commas/colons inside a string survive
+  });
+  it("returns the 'unknown' placeholder for non-literals (variables, expressions, arrays, objects)", () => {
+    expect(coerceLiteral('someVar')).toBe('unknown');
+    expect(coerceLiteral('new Date()')).toBe('unknown');
+    expect(coerceLiteral('[1, 2]')).toBe('unknown');
+    expect(coerceLiteral('{ a: 1 }')).toBe('unknown');
+    expect(coerceLiteral('sessionId')).toBe('unknown');
+    expect(coerceLiteral('')).toBe('unknown');
+    expect(coerceLiteral(null)).toBe('unknown');
+  });
+});

--- a/tests/unit/orchestrator-child/schema-preflight-unknown-skip.test.js
+++ b/tests/unit/orchestrator-child/schema-preflight-unknown-skip.test.js
@@ -1,0 +1,50 @@
+/**
+ * SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001 — FR-2 / AC-3 / AC-4.
+ *
+ * validateOperation must skip type-checking the 'unknown' placeholder (no false-positive on
+ * non-string columns), still flag unknown columns, and still catch genuine literal type
+ * mismatches. We mock the schema cache so no live DB is needed.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the transitive schema-cache require with a fixed schema:
+//   is_working_on -> bool (NOT NULL with a default, so null-checks don't interfere)
+//   status        -> varchar
+vi.mock('../../../lib/schema-cache.cjs', () => ({
+  getTableSchema: async () => new Map([
+    ['is_working_on', { udt_name: 'bool', is_nullable: 'NO', column_default: 'false', column_name: 'is_working_on' }],
+    ['status', { udt_name: 'varchar', is_nullable: 'YES', column_default: null, column_name: 'status' }],
+  ]),
+}));
+
+const { validateOperation } = await import('../../../lib/schema-preflight.cjs');
+
+describe('schema-preflight validateOperation — unknown-skip + literal type-check', () => {
+  it("AC-1: a boolean true on a bool column is valid (the is_working_on:true false-positive is gone)", async () => {
+    const r = await validateOperation('strategic_directives_v2', 'query', { is_working_on: true });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("AC-3: the 'unknown' placeholder skips the type check (no false 'Type mismatch')", async () => {
+    const r = await validateOperation('strategic_directives_v2', 'query', { is_working_on: 'unknown' });
+    expect(r.valid).toBe(true);
+  });
+
+  it('AC-3: an unknown column is still flagged regardless of value', async () => {
+    const r = await validateOperation('strategic_directives_v2', 'query', { bogus_col: 'unknown' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toMatch(/Unknown column: bogus_col/);
+  });
+
+  it('AC-4: a genuine literal type mismatch is still caught (number on a bool column)', async () => {
+    const r = await validateOperation('strategic_directives_v2', 'query', { is_working_on: 5 });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toMatch(/Type mismatch on "is_working_on"/);
+  });
+
+  it('a quoted-string literal on a varchar column is valid', async () => {
+    const r = await validateOperation('strategic_directives_v2', 'query', { status: 'active' });
+    expect(r.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Two isolated fixes for orchestrator-child completion friction. The 15-min-TTL / claim-cleared-mid-long-run part is **out of scope** — already shipped by `SD-FDBK-INFRA-CASCADE-TRIGGER-OVERREACH-001` et al. (LEAD verify-claims).

**(c) Schema-preflight false-positive.** `pre-tool-enforce.cjs extractParams()` stamped every Supabase mutation value as the string `'unknown'`, and `schema-preflight` then type-checked `'unknown'` against the real column type — falsely flagging any non-string column (e.g. `.update({ is_working_on: true })` → "Type mismatch" → BLOCK), forcing one-off `.mjs` files. Now `extractParams` coerces literals via a new unit-tested `scripts/hooks/lib/coerce-literal.cjs` (true/false→bool, numeric→number, quoted→string; non-literals stay `'unknown'`), and `schema-preflight` treats `'unknown'` as type-check-skip (unknown-column check preserved; literal mismatches still caught).

**(a) Parent-rollup claim.** New `scripts/claim-orchestrator-for-rollup.mjs` — a sanctioned, audited helper that transiently claims an orchestrator **parent** (`is_working_on=true` + `claiming_session_id`) for a rollup handoff and releases it (refusing a foreign **live** claim), replacing the ad-hoc inline UPDATE workaround. The sd-start "all children completed" remediation text now references it. **Additive only** — no change to sd-start core claim-routing or the heartbeat machinery.

## Test plan
- [x] `npx vitest run tests/unit/orchestrator-child/ --project unit` — **16 passing** (coerce-literal, schema-preflight unknown-skip + literal type-check, claim helper)
- [x] testing-agent PASS (92): verified **zero** regressions in changed paths; `schema-preflight.test.js` 25/25
- [x] 14–26 pre-existing wired-hook failures (ENF-15 force-push / QF-484 / LEARN-129 counter) are environment/order-dependent and unrelated (logged to harness backlog)
- [x] EXEC-TO-PLAN 97, PLAN-TO-LEAD 95, retrospective 100/100

SD: SD-FDBK-INFRA-HARDEN-ORCHESTRATOR-CHILD-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)