### PR TITLE
fix(QF-20260525-570): reality gate queries stage_artifact_requirements by stage_number

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -248,7 +248,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const { data: artReqs } = await supabase
       .from('stage_artifact_requirements')
       .select('artifact_type')
-      .eq('lifecycle_stage', resolvedStage); // QF-20260420-405: was 'stage_number' (wrong column)
+      .eq('stage_number', resolvedStage); // QF-20260525-570: stage_artifact_requirements uses stage_number (no lifecycle_stage col); QF-20260420-405 wrongly renamed this query, swallowed error left reality gate silently passing
     if (artReqs?.length > 0) {
       requiredArtifacts = artReqs.map(r => r.artifact_type);
       logger.log(`[Eva] Stage ${resolvedStage} requires artifacts: ${requiredArtifacts.join(', ')}`);


### PR DESCRIPTION
## Summary
The reality gate in `lib/eva/eva-orchestrator.js` silently never blocked stage transitions sourced from `stage_artifact_requirements`.

L251 queried `.eq('lifecycle_stage', resolvedStage)`, but that table's column is **`stage_number`** — there is no `lifecycle_stage` column (verified: 26 rows, columns `id, stage_number, artifact_type, required_status, is_blocking, timeout_hours, description, created_at`). The PostgREST "column does not exist" error was swallowed by the surrounding `try/catch`, leaving `requiredArtifacts=[]` → NOT_APPLICABLE → advisory pass for every transition.

`QF-20260420-405` had applied a `venture_artifacts` column rename (`stage_number`→`lifecycle_stage`) and mistakenly stamped the same change on this `stage_artifact_requirements` query too. `L477` (which queries `venture_artifacts`, a table that **does** have `lifecycle_stage`) is correct and left unchanged.

## Change
1 line: `lib/eva/eva-orchestrator.js` L251 `lifecycle_stage` → `stage_number`.

## Verification
- Confirmed `stage_artifact_requirements` schema via service-role probe: column is `stage_number`, no `lifecycle_stage`.
- Confirmed `venture_artifacts` has `lifecycle_stage` (L477 correct, untouched).

Resolves feedback `1fce4aec-0e7b-4282-8824-7bb10d59685a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)