### PR TITLE
fix(QF-20260525-789): eva-orchestrator reality-gate queries stage_number not lifecycle_stage

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -248,7 +248,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const { data: artReqs } = await supabase
       .from('stage_artifact_requirements')
       .select('artifact_type')
-      .eq('lifecycle_stage', resolvedStage); // QF-20260420-405: was 'stage_number' (wrong column)
+      .eq('stage_number', resolvedStage); // QF-20260525-789: this table's column is 'stage_number' (no 'lifecycle_stage' column); QF-20260420-405 wrongly applied the venture_artifacts column name here, and the resulting error was swallowed by the catch{} below, silently leaving requiredArtifacts empty
     if (artReqs?.length > 0) {
       requiredArtifacts = artReqs.map(r => r.artifact_type);
       logger.log(`[Eva] Stage ${resolvedStage} requires artifacts: ${requiredArtifacts.join(', ')}`);

--- a/tests/unit/eva/eva-orchestrator.test.js
+++ b/tests/unit/eva/eva-orchestrator.test.js
@@ -149,6 +149,50 @@ describe('EvaOrchestrator', () => {
     });
   });
 
+  describe('processStage - artifact requirements query (QF-20260525-789 regression)', () => {
+    it('queries stage_artifact_requirements by stage_number, never lifecycle_stage', async () => {
+      // Regression guard: stage_artifact_requirements has a `stage_number` column and
+      // NO `lifecycle_stage` column. QF-20260420-405 wrongly used `lifecycle_stage` here;
+      // the thrown PostgREST error was swallowed by the surrounding catch{}, silently
+      // leaving requiredArtifacts empty so the reality-gate never enforced them.
+      const eqCalls = [];
+      const ventureRow = {
+        id: 'v-1', name: 'Test Venture', status: 'active',
+        current_lifecycle_stage: 1, archetype: 'saas',
+        created_at: '2026-01-01', autonomy_level: 'L0',
+      };
+      function makeBuilder(table) {
+        const builder = {
+          select: vi.fn(() => builder),
+          eq: vi.fn((col) => { eqCalls.push({ table, col }); return builder; }),
+          in: vi.fn(() => builder),
+          is: vi.fn(() => builder),
+          single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+          insert: vi.fn(() => builder),
+          update: vi.fn(() => builder),
+        };
+        return builder;
+      }
+      const mockSupabase = { from: vi.fn((table) => makeBuilder(table)) };
+
+      await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true, status: 'PASS' }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      const sarCalls = eqCalls.filter((c) => c.table === 'stage_artifact_requirements');
+      expect(sarCalls.some((c) => c.col === 'stage_number')).toBe(true);
+      expect(sarCalls.some((c) => c.col === 'lifecycle_stage')).toBe(false);
+    });
+  });
+
   describe('processStage - gate blocking', () => {
     it('should return BLOCKED when stage gate fails', async () => {
       const mockSupabase = createMockSupabase();


### PR DESCRIPTION
## Summary
`lib/eva/eva-orchestrator.js` queried `stage_artifact_requirements` with `.eq('lifecycle_stage', resolvedStage)`, but that table has **no `lifecycle_stage` column** — its column is `stage_number`. The PostgREST *"column does not exist"* error was swallowed by the surrounding `catch{}`, so `requiredArtifacts` silently stayed `[]` and the reality-gate **never enforced required artifacts**.

## Root cause
QF-20260420-405 over-applied the `venture_artifacts` column name. `venture_artifacts` *does* legitimately use `lifecycle_stage` (line 477 — **left unchanged**, schema-verified), but `stage_artifact_requirements` uses `stage_number`. The two tables differ; the prior QF changed both.

## Change
- Revert **only** the `stage_artifact_requirements` query to `.eq('stage_number', resolvedStage)` (1 prod line).
- Add a regression test asserting the query uses `stage_number` and never `lifecycle_stage` (fails on old code, passes on new).

## Verification
- Schema probed live: `stage_artifact_requirements` → `stage_number` (no `lifecycle_stage`); `venture_artifacts` → `lifecycle_stage` (no `stage_number`).
- `tests/unit/eva/eva-orchestrator.test.js`: **28 passed** (27 existing + 1 new regression).

Source: feedback `1fce4aec` (harness_backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)