### PR TITLE
feat(SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001): build-model honesty + S19 build-task signal (FR-2, FR-3)

### DIFF
--- a/lib/eva/bridge/repo-readiness.js
+++ b/lib/eva/bridge/repo-readiness.js
@@ -41,6 +41,24 @@ function parseContent(content) {
 }
 
 /**
+ * PURE: normalize a build-task completion signal (from the latest build_mvp_build
+ * artifact_data) into { total, complete, ratio } or null.
+ * SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 / FR-3. Degrade-safe — any missing/invalid input
+ * yields null so the readiness contract is unchanged from before FR-3.
+ *
+ * @param {Object|null} input - e.g. { build_tasks_total, build_tasks_complete } or { total, complete }
+ * @returns {{ total: number, complete: number, ratio: number } | null}
+ */
+export function normalizeBuildTaskCompletion(input) {
+  if (!input || typeof input !== 'object') return null;
+  const total = Number(input.total ?? input.build_tasks_total);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const completeRaw = Number(input.complete ?? input.build_tasks_complete);
+  const complete = Number.isFinite(completeRaw) ? Math.max(0, Math.min(completeRaw, total)) : 0;
+  return { total, complete, ratio: Math.round((complete / total) * 100) / 100 };
+}
+
+/**
  * PURE: build the readiness summary from already-resolved inputs.
  *
  * buildPlanSummary mirrors build-tasks-writer.js (buildBuildTasks): the
@@ -51,9 +69,10 @@ function parseContent(content) {
  * @param {boolean} [args.repoReady] - a canonical repo resolves for the venture
  * @param {string} [args.ventureName]
  * @param {Array} [args.screens] - normalized screens (from resolveBuildScreens)
- * @returns {{ repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object }}
+ * @param {Object|null} [args.buildTaskCompletion] - latest build_mvp_build artifact_data (FR-3); normalized, degrade-safe
+ * @returns {{ repoReady: boolean, seededArtifacts: string[], buildPlanSummary: object, buildTaskCompletion: object|null }}
  */
-export function buildReadinessSummary({ repoReady = false, ventureName = 'Venture', screens = [] } = {}) {
+export function buildReadinessSummary({ repoReady = false, ventureName = 'Venture', screens = [], buildTaskCompletion = null } = {}) {
   const name = (ventureName && String(ventureName).trim()) || 'Venture';
   const screenCount = Array.isArray(screens) ? screens.length : 0;
   return {
@@ -66,6 +85,8 @@ export function buildReadinessSummary({ repoReady = false, ventureName = 'Ventur
       featureTaskCount: screenCount > 0 ? screenCount : 1,
       source: screenCount > 0 ? 'screens' : 'skeleton',
     },
+    // FR-3: build-task completeness from the latest build_mvp_build artifact (null when none).
+    buildTaskCompletion: normalizeBuildTaskCompletion(buildTaskCompletion),
   };
 }
 
@@ -120,7 +141,24 @@ export async function resolveRepoReadiness(ventureId, { supabase } = {}) {
       screens = resolveBuildScreens({ blueprintWireframes, wireframeScreensArtifact }).screens;
     } catch { /* degrade to zero screens */ }
 
-    return buildReadinessSummary({ repoReady: !!repoUrl, ventureName, screens });
+    // FR-3 (SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001): surface build-task completeness from the
+    // latest build_mvp_build artifact (emitted at register-deployment). Degrade-safe — a
+    // missing artifact or absent fields normalizes to null, leaving the contract unchanged.
+    let buildTaskCompletion = null;
+    try {
+      const { data: bmb } = await db
+        .from('venture_artifacts')
+        .select('artifact_data')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', 'build_mvp_build')
+        .eq('is_current', true)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      buildTaskCompletion = bmb?.artifact_data || null;
+    } catch { /* degrade to null */ }
+
+    return buildReadinessSummary({ repoReady: !!repoUrl, ventureName, screens, buildTaskCompletion });
   } catch {
     return buildReadinessSummary({ repoReady: false });
   }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1178,9 +1178,9 @@ export class StageExecutionWorker {
           break;
         }
 
-        // Replit build method gate: block at S19 when build_method is replit_agent
-        // to give the chairman time to create & seed the GitHub repo, import into Replit,
-        // and copy prompts before the worker auto-advances to S20.
+        // S19 build-readiness gate: block at S19 when build_method is replit_agent until the
+        // GitHub repo is seeded and a deployment is registered — giving the chairman time to
+        // create & seed the repo and build it with Claude Code before the worker auto-advances to S20.
         if (currentStage === 19) {
           const { data: s19Work } = await this._supabase
             .from('venture_stage_work')
@@ -2933,9 +2933,11 @@ export class StageExecutionWorker {
     const { data: ventureRow } = await this._supabase
       .from('ventures').select('name').eq('id', ventureId).single();
 
-    // SD-LEO-INFRA-REPLIT-ALTERNATIVE-BUILD-001: Check build_method before SD bridge
-    // When build_method is 'replit_agent', skip SD creation entirely — the venture
-    // will be built in Replit and imported back via the re-entry adapter.
+    // build_method='replit_agent' is the retained behavioral enum for the post-cost-pivot
+    // SINGLE build model (SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001): skip per-venture SD creation
+    // because venture features are governed by the stage pipeline + the S20 Code Quality Gate,
+    // NOT by LEO platform SDs. The venture is built by Claude Code from the seeded GitHub repo
+    // (CLAUDE.md + docs/build-tasks.md) and hosted on Replit. (Legacy ref: SD-LEO-INFRA-REPLIT-ALTERNATIVE-BUILD-001.)
     const { data: s19Work } = await this._supabase
       .from('venture_stage_work')
       .select('advisory_data')
@@ -2946,7 +2948,7 @@ export class StageExecutionWorker {
     const buildMethod = s19Work?.advisory_data?.build_method;
     if (buildMethod === 'replit_agent') {
       this._logger.log(
-        '[Worker] S19 Bridge: build_method=replit_agent — skipping SD creation. Venture will be built in Replit.'
+        '[Worker] S19 Bridge: build_method=replit_agent — skipping per-venture SD creation. Venture is built by Claude Code from the seeded repo; Replit hosts.'
       );
       // Write the build_method to Stage 20 so BUILD_PENDING knows to check Replit sync
       await this._supabase

--- a/scripts/one-off/_update-s19-stage-config-description.mjs
+++ b/scripts/one-off/_update-s19-stage-config-description.mjs
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 / FR-2 — Build-model honesty (DB content).
+ *
+ * Idempotent UPDATE of the lifecycle_stage_config stage-19 row DESCRIPTION to the honest
+ * post-cost-pivot framing ("Claude Code builds from the seeded repo; Replit hosts").
+ *
+ * CRITICAL: This touches the `description` ONLY. metadata.build_method ('replit_agent') is
+ * BEHAVIORAL — the worker (stage-execution-worker.js) branches on it to skip per-venture SD
+ * creation and to require the registered repo/deployment URL. It is intentionally LEFT UNCHANGED.
+ *
+ * Captures the prior description (printed for rollback) and verifies build_method is unchanged.
+ * Re-runnable: a second run is a no-op (description already canonical).
+ */
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+const NEW_DESCRIPTION =
+  'Build the venture MVP. Lovable conduits the Stitch landing page to GitHub; Claude Code builds ' +
+  'the remaining features from the Claude-Code-ready seeded repo (CLAUDE.md + docs/build-tasks.md); ' +
+  'Replit hosts the running app. The S20 Code Quality Gate validates the built repo.';
+
+const sb = createSupabaseServiceClient();
+
+const { data: before, error: readErr } = await sb
+  .from('lifecycle_stage_config')
+  .select('stage_number, description, metadata')
+  .eq('stage_number', 19)
+  .single();
+
+if (readErr) {
+  console.error(JSON.stringify({ step: 'read', error: readErr.message }));
+  process.exit(1);
+}
+
+const priorBuildMethod = before?.metadata?.build_method ?? null;
+console.log(JSON.stringify({
+  step: 'before',
+  prior_description: before.description,
+  build_method: priorBuildMethod,
+}, null, 2));
+
+if (before.description === NEW_DESCRIPTION) {
+  console.log(JSON.stringify({ step: 'noop', message: 'description already canonical' }));
+  process.exit(0);
+}
+
+const { error: updErr } = await sb
+  .from('lifecycle_stage_config')
+  .update({ description: NEW_DESCRIPTION })
+  .eq('stage_number', 19);
+
+if (updErr) {
+  console.error(JSON.stringify({ step: 'update', error: updErr.message }));
+  process.exit(1);
+}
+
+const { data: after, error: verifyErr } = await sb
+  .from('lifecycle_stage_config')
+  .select('description, metadata')
+  .eq('stage_number', 19)
+  .single();
+
+if (verifyErr) {
+  console.error(JSON.stringify({ step: 'verify', error: verifyErr.message }));
+  process.exit(1);
+}
+
+const afterBuildMethod = after?.metadata?.build_method ?? null;
+const ok = after.description === NEW_DESCRIPTION && afterBuildMethod === priorBuildMethod;
+console.log(JSON.stringify({
+  step: 'after',
+  description: after.description,
+  build_method: afterBuildMethod,
+  build_method_unchanged: afterBuildMethod === priorBuildMethod,
+  verified: ok,
+}, null, 2));
+process.exit(ok ? 0 : 1);

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -142,10 +142,19 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
     });
   }
 
-  const supabase = req.app.locals.supabase;
-  if (!supabase) {
+  // register-deployment performs privileged canonical writes — the venture_resources
+  // upsert + the build_mvp_build artifact the Stage 19->20 readiness contract reads.
+  // venture_resources RLS permits writes for service_role only (no authenticated
+  // INSERT/UPDATE policy) and the per-request authed client (req.supabase) is SELECT-only
+  // here, so use a service-role client (mirrors the master-reset route). The auth
+  // middleware has already authenticated the caller (req.user) before this handler runs.
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
     return res.status(500).json({ error: 'Supabase client unavailable', code: 'NO_SUPABASE' });
   }
+  const { createClient } = await import('@supabase/supabase-js');
+  const supabase = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
 
   // Upsert venture_resources row using the existing unique key
   // (venture_id, resource_type, resource_identifier) for idempotency.
@@ -172,6 +181,23 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
     });
   }
 
+  // SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 / FR-3: enrich the "build is done" signal with
+  // build-task completeness (not merely a registered URL). Degrade-safe — resolveRepoReadiness
+  // never throws; build_tasks_complete falls back to the total (registering a deployment asserts
+  // the build is complete) but an explicit build_tasks_complete in the body is honored when present.
+  // The S20 Code Quality Gate remains the authoritative downstream validator.
+  let buildTasksTotal = null;
+  let buildTasksComplete = null;
+  try {
+    const readiness = await resolveRepoReadiness(ventureId, { supabase });
+    const total = readiness?.buildPlanSummary?.featureTaskCount;
+    if (Number.isFinite(total)) {
+      buildTasksTotal = total;
+      const reported = Number(req.body?.build_tasks_complete);
+      buildTasksComplete = Number.isFinite(reported) ? Math.max(0, Math.min(reported, total)) : total;
+    }
+  } catch { /* degrade-safe: omit the completion fields entirely */ }
+
   // Emit build_mvp_build artifact (writeArtifact handles dedup via is_current).
   let artifactId;
   try {
@@ -184,6 +210,9 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
         repo_url,
         deployment_url,
         registered_at: new Date().toISOString(),
+        ...(buildTasksTotal !== null
+          ? { build_tasks_total: buildTasksTotal, build_tasks_complete: buildTasksComplete }
+          : {}),
       },
       metadata: {
         registered_via: 'POST /api/stage19/:ventureId/register-deployment',

--- a/tests/unit/bridge/repo-readiness-build-completion.test.js
+++ b/tests/unit/bridge/repo-readiness-build-completion.test.js
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for lib/eva/bridge/repo-readiness.js — FR-3 build-task completion.
+ * SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001.
+ *
+ * Covers:
+ *   - normalizeBuildTaskCompletion (PURE) — degrade-safe normalization to {total,complete,ratio}|null.
+ *   - buildReadinessSummary (PURE) — new buildTaskCompletion field; existing buildPlanSummary shape unchanged.
+ *   - resolveRepoReadiness (ASYNC, injected mock supabase — NO real DB/server) — end-to-end plumbing
+ *     of the build_mvp_build artifact through to summary.buildTaskCompletion (TS-5 / TS-6).
+ *   - The stage19 register-deployment completion-count derivation contract (TS-5 / TS-6), exercised
+ *     against the same pure functions the route consumes, plus a faithful re-implementation of the
+ *     route's derivation expression so the [0,total]-clamp / default-to-total / degrade-safe-omit
+ *     behavior is asserted without a live Express server.
+ *
+ * Scenario mapping:
+ *   TS-5: artifact carries build_tasks_total / build_tasks_complete.
+ *   TS-6: absent fields -> no throw, behaves as today (null / omitted).
+ *   TS-7: build_method enum unchanged — verified by the migration script
+ *         scripts/one-off/_update-s19-stage-config-description.mjs (asserts build_method stays
+ *         'replit_agent'). Documented here; intentionally NOT exercised against prod DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeBuildTaskCompletion,
+  buildReadinessSummary,
+  resolveRepoReadiness,
+  SEEDED_ARTIFACTS,
+} from '../../../lib/eva/bridge/repo-readiness.js';
+
+const VID = '4f71b3bd-8a1e-462e-a8b2-76efb8607206';
+
+// ---------------------------------------------------------------------------
+// normalizeBuildTaskCompletion (PURE)
+// ---------------------------------------------------------------------------
+describe('normalizeBuildTaskCompletion', () => {
+  it('returns null for null / undefined / non-object input (TS-6 degrade-safe)', () => {
+    expect(normalizeBuildTaskCompletion(null)).toBeNull();
+    expect(normalizeBuildTaskCompletion(undefined)).toBeNull();
+    expect(normalizeBuildTaskCompletion('nope')).toBeNull();
+    expect(normalizeBuildTaskCompletion(42)).toBeNull();
+    expect(normalizeBuildTaskCompletion(true)).toBeNull();
+  });
+
+  it('returns null when total is 0 (no finite positive total)', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 0 })).toBeNull();
+    expect(normalizeBuildTaskCompletion({ total: 0 })).toBeNull();
+  });
+
+  it('returns null when total is missing / non-numeric / negative', () => {
+    expect(normalizeBuildTaskCompletion({})).toBeNull();
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 'x' })).toBeNull();
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: -3 })).toBeNull();
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: NaN })).toBeNull();
+  });
+
+  it('computes {total, complete, ratio} for a partial build (TS-5)', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 4, build_tasks_complete: 2 }))
+      .toEqual({ total: 4, complete: 2, ratio: 0.5 });
+  });
+
+  it('clamps complete > total down to total (ratio 1)', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 4, build_tasks_complete: 9 }))
+      .toEqual({ total: 4, complete: 4, ratio: 1 });
+  });
+
+  it('clamps negative complete up to 0 (ratio 0)', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 4, build_tasks_complete: -2 }))
+      .toEqual({ total: 4, complete: 0, ratio: 0 });
+  });
+
+  it('defaults missing complete to 0 (ratio 0)', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 5 }))
+      .toEqual({ total: 5, complete: 0, ratio: 0 });
+  });
+
+  it('treats non-numeric complete as 0', () => {
+    expect(normalizeBuildTaskCompletion({ build_tasks_total: 5, build_tasks_complete: 'two' }))
+      .toEqual({ total: 5, complete: 0, ratio: 0 });
+  });
+
+  it('accepts {total, complete} alias keys', () => {
+    expect(normalizeBuildTaskCompletion({ total: 4, complete: 2 }))
+      .toEqual({ total: 4, complete: 2, ratio: 0.5 });
+  });
+
+  it('rounds ratio to 2 decimals', () => {
+    // 1/3 -> 0.33
+    expect(normalizeBuildTaskCompletion({ total: 3, complete: 1 }).ratio).toBe(0.33);
+    // 2/3 -> 0.67
+    expect(normalizeBuildTaskCompletion({ total: 3, complete: 2 }).ratio).toBe(0.67);
+  });
+
+  it('prefers {total} alias when both alias and build_tasks_* are present (?? precedence)', () => {
+    // input.total ?? input.build_tasks_total -> total wins when defined
+    expect(normalizeBuildTaskCompletion({ total: 2, build_tasks_total: 99, complete: 1 }))
+      .toEqual({ total: 2, complete: 1, ratio: 0.5 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReadinessSummary (PURE)
+// ---------------------------------------------------------------------------
+describe('buildReadinessSummary', () => {
+  it('includes buildTaskCompletion when given a complete build (TS-5)', () => {
+    const out = buildReadinessSummary({
+      repoReady: true,
+      ventureName: 'Acme',
+      screens: [{ id: 's1' }, { id: 's2' }, { id: 's3' }],
+      buildTaskCompletion: { build_tasks_total: 3, build_tasks_complete: 3 },
+    });
+    expect(out.buildTaskCompletion).toEqual({ total: 3, complete: 3, ratio: 1 });
+  });
+
+  it('buildTaskCompletion === null when no buildTaskCompletion arg (TS-6 degrade-safe)', () => {
+    const out = buildReadinessSummary({ repoReady: true, ventureName: 'Acme', screens: [] });
+    expect(out.buildTaskCompletion).toBeNull();
+  });
+
+  it('keeps the existing buildPlanSummary shape unchanged (childCount:3, featureTaskCount from screens)', () => {
+    const out = buildReadinessSummary({
+      repoReady: true,
+      ventureName: 'Acme',
+      screens: [{ id: 's1' }, { id: 's2' }, { id: 's3' }],
+    });
+    expect(out.buildPlanSummary).toEqual({
+      orchestrator: 'Acme build',
+      childCount: 3,
+      screenCount: 3,
+      featureTaskCount: 3,
+      source: 'screens',
+    });
+    expect(out.repoReady).toBe(true);
+    expect(out.seededArtifacts).toEqual([...SEEDED_ARTIFACTS]);
+  });
+
+  it('skeleton path: zero screens -> featureTaskCount 1, source skeleton (unchanged)', () => {
+    const out = buildReadinessSummary({ repoReady: false, ventureName: '', screens: [] });
+    expect(out.buildPlanSummary).toEqual({
+      orchestrator: 'Venture build',
+      childCount: 3,
+      screenCount: 0,
+      featureTaskCount: 1,
+      source: 'skeleton',
+    });
+    expect(out.repoReady).toBe(false);
+  });
+
+  it('defaults safely with no args at all (degrade-safe not-ready summary)', () => {
+    const out = buildReadinessSummary();
+    expect(out.repoReady).toBe(false);
+    expect(out.buildTaskCompletion).toBeNull();
+    expect(out.buildPlanSummary.childCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRepoReadiness (ASYNC) — injected mock supabase, NO real DB.
+// Verifies the build_mvp_build artifact plumbing end-to-end (never throws).
+// ---------------------------------------------------------------------------
+
+// Chainable supabase mock keyed by table; mirrors tests/unit/bridge/resolve-venture-repo.test.js.
+// `responses` maps table -> { data, error }. rpc() returns rpcResponse.
+function makeSupabase({ tables = {}, rpcResponse = { data: null, error: null } } = {}) {
+  return {
+    from(table) {
+      const resp = tables[table] ?? { data: null, error: null };
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        order: () => builder,
+        limit: () => builder,
+        maybeSingle: () => Promise.resolve(resp),
+        single: () => Promise.resolve(resp),
+      };
+      return builder;
+    },
+    rpc: () => Promise.resolve(rpcResponse),
+  };
+}
+
+describe('resolveRepoReadiness (mock supabase, no DB)', () => {
+  it('surfaces buildTaskCompletion from the latest build_mvp_build artifact (TS-5)', async () => {
+    const supabase = makeSupabase({
+      tables: {
+        ventures: { data: { name: 'Acme', repo_url: 'https://github.com/x/y' }, error: null },
+        venture_artifacts: {
+          data: { artifact_data: { build_tasks_total: 4, build_tasks_complete: 2 } },
+          error: null,
+        },
+      },
+    });
+    const out = await resolveRepoReadiness(VID, { supabase });
+    expect(out.buildTaskCompletion).toEqual({ total: 4, complete: 2, ratio: 0.5 });
+    // never-throw contract: a well-formed summary is always returned
+    expect(out.buildPlanSummary.childCount).toBe(3);
+    expect(out.seededArtifacts).toEqual([...SEEDED_ARTIFACTS]);
+  });
+
+  it('buildTaskCompletion is null when the build_mvp_build artifact has no completion fields (TS-6)', async () => {
+    const supabase = makeSupabase({
+      tables: {
+        ventures: { data: { name: 'Acme' }, error: null },
+        venture_artifacts: { data: { artifact_data: { repo_url: 'https://github.com/x/y' } }, error: null },
+      },
+    });
+    const out = await resolveRepoReadiness(VID, { supabase });
+    expect(out.buildTaskCompletion).toBeNull();
+  });
+
+  it('buildTaskCompletion is null when no artifact exists at all (TS-6)', async () => {
+    const supabase = makeSupabase({
+      tables: {
+        ventures: { data: { name: 'Acme' }, error: null },
+        venture_artifacts: { data: null, error: null },
+      },
+    });
+    const out = await resolveRepoReadiness(VID, { supabase });
+    expect(out.buildTaskCompletion).toBeNull();
+  });
+
+  it('NEVER throws — a supabase that rejects yields a safe not-ready summary (FR-3 contract)', async () => {
+    const exploding = {
+      from() { throw new Error('db is down'); },
+      rpc() { throw new Error('db is down'); },
+    };
+    const out = await resolveRepoReadiness(VID, { supabase: exploding });
+    expect(out).toMatchObject({ repoReady: false, buildTaskCompletion: null });
+    expect(out.buildPlanSummary.childCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stage19 register-deployment completion-count DERIVATION contract (TS-5 / TS-6).
+//
+// The route (server/routes/stage19.js, register-deployment handler) derives the
+// build_tasks_total / build_tasks_complete it writes into the build_mvp_build
+// artifact_data from:
+//   total = readiness.buildPlanSummary.featureTaskCount
+//   if Number.isFinite(total):
+//     buildTasksTotal = total
+//     reported = Number(req.body.build_tasks_complete)
+//     buildTasksComplete = Number.isFinite(reported) ? clamp(reported, 0, total) : total
+//     -> artifact gets { build_tasks_total, build_tasks_complete }
+//   else:
+//     -> completion fields OMITTED entirely (degrade-safe)
+//
+// A full Express integration test would need a live server + service-role DB and
+// would be brittle, so we assert this contract two ways:
+//   (1) faithful re-implementation of the derivation expression (below), and
+//   (2) round-trip: feed the derived fields back through normalizeBuildTaskCompletion
+//       (what resolveRepoReadiness later does) to prove the artifact is consumable.
+// ---------------------------------------------------------------------------
+
+/** Faithful mirror of the route's derivation (stage19.js lines ~189-199). */
+function deriveArtifactCompletion({ featureTaskCount, bodyBuildTasksComplete } = {}) {
+  const total = featureTaskCount;
+  if (!Number.isFinite(total)) return {}; // degrade-safe: completion fields omitted
+  const reported = Number(bodyBuildTasksComplete);
+  const buildTasksComplete = Number.isFinite(reported)
+    ? Math.max(0, Math.min(reported, total))
+    : total;
+  return { build_tasks_total: total, build_tasks_complete: buildTasksComplete };
+}
+
+describe('stage19 register-deployment completion derivation', () => {
+  it('TS-5: default build_tasks_complete = total when body omits it (registering asserts done)', () => {
+    const fields = deriveArtifactCompletion({ featureTaskCount: 3, bodyBuildTasksComplete: undefined });
+    expect(fields).toEqual({ build_tasks_total: 3, build_tasks_complete: 3 });
+    // consumable: round-trips through the readiness normalizer to a complete build
+    expect(normalizeBuildTaskCompletion(fields)).toEqual({ total: 3, complete: 3, ratio: 1 });
+  });
+
+  it('TS-5: honors an explicit body build_tasks_complete', () => {
+    const fields = deriveArtifactCompletion({ featureTaskCount: 4, bodyBuildTasksComplete: 2 });
+    expect(fields).toEqual({ build_tasks_total: 4, build_tasks_complete: 2 });
+    expect(normalizeBuildTaskCompletion(fields)).toEqual({ total: 4, complete: 2, ratio: 0.5 });
+  });
+
+  it('clamps an explicit body value above total down to total', () => {
+    const fields = deriveArtifactCompletion({ featureTaskCount: 3, bodyBuildTasksComplete: 99 });
+    expect(fields).toEqual({ build_tasks_total: 3, build_tasks_complete: 3 });
+  });
+
+  it('clamps a negative explicit body value up to 0', () => {
+    const fields = deriveArtifactCompletion({ featureTaskCount: 3, bodyBuildTasksComplete: -5 });
+    expect(fields).toEqual({ build_tasks_total: 3, build_tasks_complete: 0 });
+  });
+
+  it('treats a non-numeric body value as "not reported" -> defaults to total', () => {
+    const fields = deriveArtifactCompletion({ featureTaskCount: 3, bodyBuildTasksComplete: 'all' });
+    expect(fields).toEqual({ build_tasks_total: 3, build_tasks_complete: 3 });
+  });
+
+  it('TS-6: degrade-safe — omits completion fields when featureTaskCount is not finite', () => {
+    expect(deriveArtifactCompletion({ featureTaskCount: undefined, bodyBuildTasksComplete: 2 })).toEqual({});
+    expect(deriveArtifactCompletion({ featureTaskCount: NaN, bodyBuildTasksComplete: 2 })).toEqual({});
+    expect(deriveArtifactCompletion({})).toEqual({});
+  });
+});


### PR DESCRIPTION
**SD**: SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 (feature) · cross-repo (this PR = EHG_Engineer backend; sibling PR in `rickfelix/ehg` carries FR-1/4/5 UI)

Finalizes the venture-build cost-pivot so the single model is honest: **Lovable conduits the Stitch landing → GitHub; Claude Code builds the rest from the seeded repo; Replit hosts.**

### FR-2 — Build-model honesty (text only, behavior unchanged)
- Corrects the stale "Replit Agent builds" framing in `lib/eva/stage-execution-worker.js` (`_postStageHook_S19_Bridge` comment + log, and the S19 build-readiness gate comment).
- Updates the `lifecycle_stage_config` stage-19 **description** to "Claude Code builds from the seeded repo; Replit hosts" (idempotent script `scripts/one-off/_update-s19-stage-config-description.mjs`, prior value captured for rollback, applied to shared DB).
- **`metadata.build_method='replit_agent'` is RETAINED** — it is the behavioral enum the worker branches on (skip per-venture SD creation + gate on the registered URL). Verified unchanged.

### FR-3 — Real S19 build-task signal (degrade-safe)
- `server/routes/stage19.js` register-deployment: adds `build_tasks_total`/`build_tasks_complete` to the `build_mvp_build` artifact_data (total from readiness `featureTaskCount`; complete from request body, default = total, clamped). Also folds the stranded service-role-client fix (the 2 `venture_resources` migrations were already applied to prod).
- `lib/eva/bridge/repo-readiness.js`: `resolveRepoReadiness` surfaces a degrade-safe `buildTaskCompletion {total,complete,ratio}` from the latest artifact via the new pure `normalizeBuildTaskCompletion`. Absent fields → `null` (prior behavior). No new artifact_type/migration/CHECK. The **S20 Code Quality Gate remains the authoritative validator**.

### Tests
26 pure unit tests (`tests/unit/bridge/repo-readiness-build-completion.test.js`) — all pass. Pre-existing full-suite failures are unrelated (no source files of this SD among them).

### Notes
FR-4 (delete `workflowStages.ts`) was **descoped** — it has 6 live importers (verify-then-migrate follow-up). Size exceeds the 100-LOC target (feature SD, mostly tests + the idempotent config script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
