### PR TITLE
fix(QF-20260521-024): monitor-venture-run requires VENTURE_ID (drop deleted-LexiGuard default)

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -13,8 +13,11 @@ require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-const VENTURE_ID = process.env.VENTURE_ID || '94856fc6-9ba9-4f56-9a5c-85041031a0fc';
-const VENTURE_NAME = process.env.VENTURE_NAME || 'LexiGuard';
+// Quick-fix QF-20260521-024: VENTURE_ID is required (no hard-coded default — the
+// former LexiGuard default 94856fc6 was a since-deleted venture). main() guards the
+// live path below; --dry-run-validate needs no venture and runs without it.
+const VENTURE_ID = process.env.VENTURE_ID;
+const VENTURE_NAME = process.env.VENTURE_NAME || (VENTURE_ID ? `venture ${VENTURE_ID.slice(0, 8)}` : null);
 const STOP_AT_STAGE = parseInt(process.env.STOP_AT_STAGE || '17', 10);
 const POLL_MS = 30000;
 
@@ -502,6 +505,13 @@ async function main() {
     process.exit(0);
   }
 
+  // Quick-fix QF-20260521-024: the live monitor path needs a real venture. Fail fast
+  // with a clear message instead of querying a deleted/blank venture id.
+  if (!VENTURE_ID) {
+    console.error('[FATAL] VENTURE_ID env var is required for the live monitor (set VENTURE_ID=<uuid> [VENTURE_NAME=<name>]).');
+    process.exit(1);
+  }
+
   // Load DB-authoritative artifact map BEFORE polling begins. On failure, exit non-zero
   // rather than silently falling back to stale data — operator must see the error.
   try {
@@ -569,4 +579,8 @@ async function main() {
   }, 10800000);
 }
 
-main().catch(e => { console.error('FATAL:', e); process.exit(1); });
+// Quick-fix QF-20260521-024: only auto-run as the direct entry point. Tests require()
+// this module for its pure exports (isWorkerSourceForStage etc.) and must not trigger main().
+if (require.main === module) {
+  main().catch(e => { console.error('FATAL:', e); process.exit(1); });
+}


### PR DESCRIPTION
@
## Quick-Fix QF-20260521-024

**Scope reduced after verify-first:** Item (1) of the original filing — `isWorkerSourceForStage` recognizing `analysis-step:stage-NN[-suffix]` sources — was **already shipped by QF-20260523-132 (#3858)** (filed 2026-05-23, after this QF on 2026-05-21). This PR covers only the remaining item (2).

### Change
- `monitor-venture-run.cjs` no longer defaults `VENTURE_ID`/`VENTURE_NAME` to the since-deleted LexiGuard venture (`94856fc6`). The live monitor now **requires `VENTURE_ID`** and fails fast with a clear message.
- `--dry-run-validate` still runs venture-less (guard placed after its short-circuit).
- Auto-run gated on `require.main === module` so test `require()` of the pure exports (`isWorkerSourceForStage`, etc.) no longer triggers `main()` (was producing an unhandled `process.exit(1)` under vitest).

### Validation
- `tests/unit/monitor-venture-run-validate.test.js` + `tests/scripts/monitor-venture-run-sd-required-guard.test.js`: **29/29 pass**, no unhandled errors (baseline had clean pass; the require.main guard keeps it clean).
- Direct run with no `VENTURE_ID` → fails fast with FATAL guard message.
- ~20 LOC (Tier-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@