### PR TITLE
fix(QF-20260525-522): freshness/supersession gate for sd-next QF recommender

### DIFF
--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -11,6 +11,14 @@ const MAX_DISPLAY = 10;
 
 const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
 
+// QF-20260525-522: freshness/supersession gate. AUTO-PROCEED must NOT auto-route
+// to a QF that may have been resolved by a *different* SD (one with no PR of its
+// own). A QF that is old, still 'open', unclaimed, and has no PR/commit is a
+// supersession risk — it gets flagged 'verify-first' and held out of
+// topStartableQF so AUTO_PROCEED_ACTION:qf_start is not emitted for it (the queue
+// falls through to /leo assist instead). Tunable via SD_NEXT_QF_STALE_DAYS.
+const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;
+
 /**
  * Classify open quick fixes: compute per-QF escalation flag, claim badge,
  * and return the summary + classified list. Pure presentation-adjacent logic;
@@ -66,7 +74,16 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
       }
     }
 
-    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther };
+    // QF-20260525-522: supersession risk — old, open, unclaimed, no PR/commit.
+    const verifyFirst =
+      !escalate &&
+      qf.status === 'open' &&
+      !claimingSessionId &&
+      !qf.pr_url &&
+      !qf.commit_sha &&
+      ageDays(qf.created_at) >= STALE_QF_DAYS;
+
+    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther, _verifyFirst: verifyFirst };
   });
 
   classified.sort((a, b) => {
@@ -78,7 +95,9 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
   });
 
   summary.topQF = classified[0] || null;
-  summary.topStartableQF = classified.find(qf => !qf._escalate && !qf._isClaimedByOther) || null;
+  // QF-20260525-522: exclude verify-first (possibly-superseded) QFs from the
+  // auto-startable pick so AUTO-PROCEED doesn't route a session to dead work.
+  summary.topStartableQF = classified.find(qf => !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst) || null;
 
   return { summary, classified };
 }
@@ -109,8 +128,13 @@ export function renderQFRow(qf, indent = '') {
     const tier = qf._triage ? qf._triage.tier : inferTier(qf.estimated_loc);
     const tierBadge = `[T${tier}]`;
     const statusBadge = qf.status === 'in_progress' ? `${colors.cyan}WIP${colors.reset} ` : '';
-    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+    // QF-20260525-522: surface why a stale QF was held out of auto-start.
+    const verifyBadge = qf._verifyFirst ? `${colors.yellow}⚠ VERIFY-FIRST${colors.reset} ` : '';
+    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${verifyBadge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
     console.log(`${indent}       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
+    if (qf._verifyFirst) {
+      console.log(`${indent}       ${colors.dim}⚠ open ${ageDays(qf.created_at)}d & unclaimed — may already be resolved by another SD; verify before starting (not auto-routed)${colors.reset}`);
+    }
   }
 }
 
@@ -154,12 +178,20 @@ function inferTier(estimatedLoc) {
 }
 
 /**
+ * Whole-day age of a timestamp. QF-20260525-522: shared by the freshness gate
+ * and formatAge so the "verify-first" threshold and the displayed age agree.
+ */
+function ageDays(createdAt) {
+  if (!createdAt) return 0;
+  return Math.floor((Date.now() - new Date(createdAt).getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
  * Format a human-readable age from a timestamp.
  */
 function formatAge(createdAt) {
   if (!createdAt) return '';
-  const diffMs = Date.now() - new Date(createdAt).getTime();
-  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const days = ageDays(createdAt);
   if (days === 0) return 'today';
   if (days === 1) return '1d old';
   return `${days}d old`;

--- a/tests/unit/sd-next/quick-fix-freshness-gate.test.js
+++ b/tests/unit/sd-next/quick-fix-freshness-gate.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit test: QF freshness/supersession gate in classifyQuickFixes
+ * QF-20260525-522
+ *
+ * A QF that is old, still 'open', unclaimed, and has no PR/commit may have been
+ * resolved by a *different* SD (one with no PR of its own). Such QFs must be
+ * flagged `_verifyFirst` and held OUT of `topStartableQF` so AUTO-PROCEED does
+ * not emit AUTO_PROCEED_ACTION:qf_start and route a session to dead/regressive
+ * work (e.g. QF-20260521-962, which sat open 4 days after a sibling SD fixed it).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyQuickFixes } from '../../../scripts/modules/sd-next/display/quick-fixes.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (n) => new Date(Date.now() - n * DAY_MS).toISOString();
+
+// Default gate is 3 days (SD_NEXT_QF_STALE_DAYS). Build a minimal open QF.
+const qf = (over = {}) => ({
+  id: 'QF-X',
+  title: 'x',
+  type: 'bug',
+  severity: 'medium',
+  status: 'open',
+  estimated_loc: 10,
+  created_at: daysAgo(5),
+  claiming_session_id: null,
+  pr_url: null,
+  commit_sha: null,
+  ...over,
+});
+
+describe('QF freshness/supersession gate (QF-20260525-522)', () => {
+  it('flags an old, open, unclaimed, PR-less QF as verify-first and excludes it from topStartableQF', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-STALE', created_at: daysAgo(5) })]);
+    expect(classified[0]._verifyFirst).toBe(true);
+    expect(summary.topStartableQF).toBeNull(); // not auto-routed
+    expect(summary.topQF).not.toBeNull();      // still visible in the queue
+  });
+
+  it('keeps a fresh QF startable (not verify-first)', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-FRESH', created_at: daysAgo(0) })]);
+    expect(classified[0]._verifyFirst).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-FRESH');
+  });
+
+  it('prefers the fresh QF over a stale one as the auto-startable pick', () => {
+    const { summary } = classifyQuickFixes([
+      qf({ id: 'QF-STALE', created_at: daysAgo(10) }),
+      qf({ id: 'QF-FRESH', created_at: daysAgo(0) }),
+    ]);
+    expect(summary.topStartableQF?.id).toBe('QF-FRESH');
+  });
+
+  it('does NOT flag a stale QF that already has a PR/commit (own work in flight)', () => {
+    const { classified } = classifyQuickFixes([
+      qf({ id: 'QF-PR', created_at: daysAgo(9), pr_url: 'https://github.com/x/y/pull/1' }),
+      qf({ id: 'QF-SHA', created_at: daysAgo(9), commit_sha: 'abc123' }),
+    ]);
+    expect(classified.find(q => q.id === 'QF-PR')._verifyFirst).toBe(false);
+    expect(classified.find(q => q.id === 'QF-SHA')._verifyFirst).toBe(false);
+  });
+
+  it('does NOT flag a stale in_progress QF (actively being worked)', () => {
+    const { classified } = classifyQuickFixes([qf({ id: 'QF-WIP', created_at: daysAgo(9), status: 'in_progress' })]);
+    expect(classified[0]._verifyFirst).toBe(false);
+  });
+
+  it('does NOT flag a stale QF claimed by the current session', () => {
+    const { summary, classified } = classifyQuickFixes(
+      [qf({ id: 'QF-MINE', created_at: daysAgo(9), claiming_session_id: 'sess-1' })],
+      new Map(),
+      { currentSession: { session_id: 'sess-1' } },
+    );
+    expect(classified[0]._verifyFirst).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-MINE');
+  });
+
+  it('treats a QF under the default 3-day threshold (2d old) as startable', () => {
+    const { summary } = classifyQuickFixes([qf({ id: 'QF-2D', created_at: daysAgo(2) })]);
+    expect(summary.topStartableQF?.id).toBe('QF-2D');
+  });
+});


### PR DESCRIPTION
## Summary
`sd-next`'s `classifyQuickFixes()` computed `topStartableQF` (the QF that `AUTO_PROCEED_ACTION:qf_start` auto-routes a session to) with **no freshness/supersession check**, and `loadOpenQuickFixes` orders oldest-first. A QF resolved by a **different** SD (one with no PR of its own) stays `status=open` and is auto-recommended indefinitely.

**Incident:** `QF-20260521-962` sat `open` for 4 days after `SD-LEO-REFAC-RETIRE-LEGACY-STAGE-001` fixed its symptom; AUTO-PROCEED routed a session to it — and its proposed fix would have *regressed* that completed SD.

## Fix
Tag QFs that are old (≥ `SD_NEXT_QF_STALE_DAYS`, default **3**) **AND** `open` **AND** unclaimed **AND** have no `pr_url`/`commit_sha` as `_verifyFirst`, and exclude them from `topStartableQF`. When the only startable QFs are stale, `topStartableQF` is `null`, so AUTO-PROCEED falls through to `/leo assist` instead of auto-routing to possibly-dead work. Stale QFs stay visible (flagged `⚠ VERIFY-FIRST … not auto-routed`) and remain **manually** startable.

## Why this control (RCA)
This is corrective **P1** from the RCA. It is the *only* control that would have prevented this specific incident: the QF was filed **after** the resolving SD already existed and was never linked to it, so an SD-completion trigger or a ship-pipeline prompt (P2/P3, tracked separately as a Tier-3 SD) would have had nothing to match on. A recommender-side staleness gate catches the unlinkable cases.

## Tests
- New `tests/unit/sd-next/quick-fix-freshness-gate.test.js` (7 cases): stale→verify-first+excluded; fresh→startable; fresh preferred over stale; QFs with PR/commit not flagged; in_progress not flagged; current-session-claimed not flagged; under-threshold (2d) startable.
- Full `tests/unit/sd-next/` suite green (93 passing).

Net source change: +37/-5 LOC (Tier 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)