### PR TITLE
fix(QF-20260525-425): disable LEARN-129 repeat-guard in ENF-15 hook tests

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce.test.js
@@ -131,10 +131,18 @@ function spawnHookEnforce(stdinPayload, extraEnv = {}) {
     stdio: ['pipe', 'pipe', 'pipe'],
     // SUPABASE_URL='' short-circuits audit-log writes so tests don't hit the DB.
     // Other ENF guards keyed off env vars set to safe-default values.
+    // QF-20260525-425: disable the LEARN-129 RCA repeat-invocation guard (ENF 11).
+    // These tests spawn the hook repeatedly with the SAME command (e.g. T3-T7,T10 all
+    // send 'git push --force-with-lease') under a constant session_id ('enf9-test'),
+    // so the session-scoped 10-min repeat counter (.claude/retry-state-enf9-test.json)
+    // accumulates across cases AND runs, tripping a tiered block that pre-empts the
+    // enforcement rule under test → non-deterministic RED. The guard is orthogonal to
+    // ENF-15/ENF-SD-CREATE-SKILL, so neutralize it (mirrors LEO_NPM_INSTALL_GUARD above).
     env: {
       ...process.env,
       SUPABASE_URL: '',
       LEO_NPM_INSTALL_GUARD: 'off',
+      LEO_RCA_ENFORCEMENT: 'off',
       ...extraEnv
     }
   });


### PR DESCRIPTION
## Summary
Fixes non-deterministic RED in `scripts/hooks/__tests__/pre-tool-enforce.test.js` (4-6 of 25 tests failing, growing on re-run).

## Root cause
The ENF-15 force-push tests (T3-T7, T10) spawn `pre-tool-enforce.cjs` repeatedly with the **identical** push command under a constant `session_id` (`enf9-test`). The RCA tiered repeat-invocation guard (ENFORCEMENT 11 / SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129) is **session-scoped and time-windowed** (`.claude/retry-state-enf9-test.json`, 10 min), so its counter accumulates across these cases **and across runs**, tripping a tiered block (`RCA TIERED ENFORCEMENT ... invoked Nx on the same target`) that pre-empts the `[ENF-15] BLOCKED` output the tests assert.

## Fix
Neutralize the orthogonal guard for `spawnHookEnforce` via `LEO_RCA_ENFORCEMENT=off` — mirroring the existing `LEO_NPM_INSTALL_GUARD=off`. Test-only; **production hook behavior unchanged**. No test in this file exercises LEARN-129 itself.

## Verification
`npx vitest run scripts/hooks/__tests__/pre-tool-enforce.test.js` → **25/25 pass deterministically** on repeated runs (was 4-6 failing).

## Notes
- Closes feedback `0fd4de4f`. **Corrects its disposition**: filed as '14 failing, git-environment-dependent'; the actual cause is 4-6 failing from repeat-guard state bleed, not git-env.
- Reduces the pre-existing-RED count that blocks the whole-suite QF completion gate (feedback `352f3cec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
