### PR TITLE
fix(QF-20260525-254): array-guard runData in ShippingContextBuilder.getCIContext

### DIFF
--- a/scripts/modules/shipping/ShippingContextBuilder.js
+++ b/scripts/modules/shipping/ShippingContextBuilder.js
@@ -236,7 +236,13 @@ export class ShippingContextBuilder {
         { timeout: 15000 }
       );
 
-      const runData = JSON.parse(runs);
+      // Quick-fix QF-20260525-254: the shell fallback (|| echo "[]") can yield a
+      // non-array when JSON.parse returns the string "[]" (e.g. Windows cmd echoes
+      // the quotes). runData.length>0 then passes but runData.filter() below throws
+      // "runData.filter is not a function". Guard to an array so CI context degrades
+      // gracefully to empty instead of erroring out.
+      const parsedRuns = JSON.parse(runs);
+      const runData = Array.isArray(parsedRuns) ? parsedRuns : [];
       context.recentRuns = runData;
 
       if (runData.length > 0) {


### PR DESCRIPTION
## Quick-Fix QF-20260525-254

`ShippingContextBuilder.getCIContext()` does `const runData = JSON.parse(runs)` then `runData.filter(...)`. When the `gh run list ... || echo "[]"` shell fallback yields the **string** `"[]"` (Windows `cmd` echoes the quotes, so `JSON.parse('"[]"')` is a 2-char string), `runData.length > 0` passes but `runData.filter` throws `runData.filter is not a function`. It is caught as a non-blocking `[ShippingContext] CI context error`, but **silently empties** the CI shipping context (`recentRuns`/`failingChecks`), degrading LLM shipping decisions on Windows.

### Fix
`const parsedRuns = JSON.parse(runs); const runData = Array.isArray(parsedRuns) ? parsedRuns : [];` — degrade gracefully to an empty array. ~8 LOC.

### Validation
- `node --check` passes.
- Behavior verified: string `"[]"` -> `[]` (no throw, 0 failing checks); real array `[{conclusion:"failure"}]` -> 1. Prior code threw on the string case.
- No existing `getCIContext` unit test (function shells out to `gh`; a hermetic test would need an injectability refactor — out of scope for a non-blocking guard).

### Scope note
Narrowed from feedback `f3f3d34d`: that filing headline ("precheck does not run the prerequisite preflight — parity gap") is **already fixed on origin/main** (`HandoffOrchestrator.precheckHandoff` already calls `runPrerequisitePreflight`, identical to `executeHandoff`). This PR is the real remaining defect from that filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
