### PR TITLE
fix(QF-20260525-345): anchor ENF-15 force-push matcher to operative command

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce.test.js
@@ -352,3 +352,39 @@ describe('ENF-15: git-environment edge cases', () => {
     expect(r.stderr).toMatch(/\[ENF-15\] BLOCKED reason=multi_author_branch/);
   });
 });
+
+// QF-20260525-345 (RCA 6188492f): ENF-15 must match only the OPERATIVE `git push …
+// --force` command, never an incidental MENTION of the phrase inside a quoted argument.
+// Pre-fix the boundary class `[\s;&|`]` admitted a bare space AND a backtick, so PR/issue
+// bodies (markdown code-spans use backticks), commit messages, and echo/grep that
+// referenced the phrase were blocked. Mirrors the QF-484 ENF-SD-CREATE-SKILL fix.
+describe('ENF-15: quoted-mention false-positives no longer block (QF-20260525-345)', () => {
+  // Non-allowlisted branch + override flag unset → a FALSE match would surface as
+  // `[ENF-15] BLOCKED reason=env_var_unset` (the reported bug). Post-fix these are not
+  // the operative command, so ENF-15 must pass-through (no [ENF-15] BLOCKED emitted).
+  const env = { LEO_FORCE_PUSH_OWN_BRANCH: '', TEST_OVERRIDE_BRANCH: 'hotfix/123' };
+
+  it('T11 gh pr --body with backtick-markdown mention does not block (reported case)', async () => {
+    const r = await spawnHookEnforce(
+      bashPayload('gh pr create --body "share the command `git push --force-with-lease` here"'),
+      env
+    );
+    expect(r.stderr).not.toMatch(/\[ENF-15\] BLOCKED/);
+  });
+
+  it('T12 git commit -m with phrase mention does not block', async () => {
+    const r = await spawnHookEnforce(
+      bashPayload('git commit -m "fix: handle git push --force edge case"'),
+      env
+    );
+    expect(r.stderr).not.toMatch(/\[ENF-15\] BLOCKED/);
+  });
+
+  it('T13 echo with phrase mention does not block', async () => {
+    const r = await spawnHookEnforce(
+      bashPayload('echo "run git push --force-with-lease to deploy"'),
+      env
+    );
+    expect(r.stderr).not.toMatch(/\[ENF-15\] BLOCKED/);
+  });
+});

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1019,7 +1019,17 @@ async function main() {
   // module-level mocking does not apply).
   if (TOOL_NAME === 'Bash') {
     const cmd = (input && input.command || '').trim();
-    const FORCE_PUSH_RE = /(^|[\s;&|`])git\s+push\b[^\n]*--force\b/;
+    // QF-20260525-345 (RCA 6188492f): match `git push … --force` only when it is the
+    // OPERATIVE command — at start-of-command or after a true shell separator
+    // (; | & ( newline, && ||) — NOT after a bare space or a backtick. The previous
+    // boundary class `[\s;&|`]` admitted a space AND a backtick, so any command that
+    // merely MENTIONED the phrase inside a quoted argument false-positived: gh pr/issue
+    // `--body "… `git push --force-with-lease` …"` (markdown code-span → backtick),
+    // `git commit -m "… git push --force …"`, `echo`, `grep`. Same class QF-484 fixed
+    // for ENF-SD-CREATE-SKILL. Dropping backtick forgoes catching a `` `git push --force` ``
+    // command-substitution — not a real force-push vector (substitution captures stdout);
+    // all realistic vectors (bare, ; && || | & (, leading-ws, flag-after-positional) still block.
+    const FORCE_PUSH_RE = /(?:^|[;&|(\n]|&&|\|\|)\s*git\s+push\b[^\n]*--force\b/;
     if (FORCE_PUSH_RE.test(cmd) && !/--help/.test(cmd)) {
       try {
         const { execSync } = require('child_process');


### PR DESCRIPTION
## Summary
Fixes an ENF-15 (force-push gate) false-positive in `scripts/hooks/pre-tool-enforce.cjs` that blocks legitimate commands which merely **mention** a force-push phrase inside a quoted argument.

## Root cause (RCA `6188492f`)
`FORCE_PUSH_RE` scanned the raw command string with boundary class `[\s;&|` + backtick `]`, admitting a **bare space** and a **backtick**. So any command containing the phrase inside a quoted argument false-positived:
- `gh pr create --body "... <code-span with backtick> ..."` (markdown code-spans use backticks) — **the reported trigger**
- `git commit -m "... <phrase> ..."`, `echo`, `grep`

This is the same false-positive class QF-20260504-484 fixed for ENF-SD-CREATE-SKILL.

## Fix
Anchor the match to the **operative command** — start-of-command or a true shell separator (`;`, `|`, `&`, `(`, newline, `&&`, `||`) — not a bare space or backtick.

Empirically verified **14/14**:
- 5 quoted-mention false-positives now pass (including the backtick-markdown case)
- 8 real force-push vectors still block: bare, after `;`/`&&`/`||`, leading-whitespace, flag-after-positional, subshell `(`

Dropping backtick forgoes catching a command-substitution force-push, which is **not a real vector** (substitution captures stdout).

## Deviation from RCA-proposed regex (verify-first)
The RCA's recommended regex **kept** backtick in the boundary class and so would **not** have fixed the reported backtick-markdown case. Verifying the agent's regex against the actual failure revealed this; dropping backtick fixes it.

## Tests
Adds a QF-484-style regression triplet (T11–T13). `npx vitest run scripts/hooks/__tests__/pre-tool-enforce.test.js` → **28/28 pass deterministically** on repeated runs.

## Follow-up (not in this PR)
RCA confirmed the same class affects **ENF-12** (npm-install) and **ENF-05** (supabase `.from`/`.rpc`). Tracked for a separate focused QF per the RCA's "don't bundle" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
