### PR TITLE
fix(QF-20260525-298): verify-first banner in sd:next inbox/backlog sections

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -622,6 +622,13 @@ export class SDNextSelector {
       console.log(`  ${badge} ${cat}${title}${age > 7 ? ` ${c.red}(${age}d)${c.reset}` : ` ${c.dim}(${age}d)${c.reset}`}`);
     }
     console.log(`${c.dim}  Run /inbox to triage${c.reset}`);
+    // QF-20260525-298: surface verify-first at the moment of triage. Rows can be
+    // already-fixed (fixed before filing, or by an unrelated commit/QF that never
+    // closed this row) — investigating them wastes a session, especially on a
+    // local branch that trails origin/main.
+    if (this.feedbackItems.length > 0) {
+      console.log(`${c.dim}  ⚠️  Verify against origin/main first — items may already be fixed (git grep the cited QF/feedback-id; git show origin/main:<file>)${c.reset}`);
+    }
   }
 
   /**
@@ -683,6 +690,10 @@ export class SDNextSelector {
       console.log(`${c.dim}  +${data.count - 5} more — query feedback table (category='harness_backlog' AND status='new') or run /inbox${c.reset}`);
     }
     console.log(`${c.dim}  Process via [MODE: campaign] session or /leo audit${c.reset}`);
+    // QF-20260525-298: verify-first nudge (see displayFeedbackInbox). Backlog items
+    // are especially prone to being already-fixed-but-not-closed under heavy
+    // parallel-session QF throughput.
+    console.log(`${c.dim}  ⚠️  Verify against origin/main first — items may already be fixed (git grep the cited QF/feedback-id; git show origin/main:<file>)${c.reset}`);
   }
 
   async displayTracks() {


### PR DESCRIPTION
## Quick-Fix QF-20260525-298 — verify-first triage banner

**RCA CAPA-4** for `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001` (read-time mitigation).

### Problem
`feedback` / `harness_backlog` rows frequently stay open after their fix merges — fixed before the row was filed, or by an unrelated commit/QF that never closed *this* row. Triagers then waste a session investigating already-fixed items, especially when their local branch trails `origin/main`. (Three such cases occurred in a single `/leo next` session on 2026-05-25.)

### Change
Add a one-line verify-first nudge under the **FEEDBACK INBOX** and **HARNESS BACKLOG** sections in `SDNextSelector.js`:

> ⚠️ Verify against origin/main first — items may already be fixed (git grep the cited QF/feedback-id; git show origin/main:&lt;file&gt;)

Display-only. The inbox line is gated on `feedbackItems.length > 0`; the backlog line renders with the existing count>0 footer block.

### Validation
- `node --check` passes.
- `tests/unit/sd-next/` + `assist-engine-harness-backlog-filter`: **98/98 pass** (the "db down" log lines are mocked-failure fixtures).
- 11 LOC, Tier-1 polish.

### Scope note
This is the read-time mitigation only. The structural fixes from the same RCA are filed separately: a reference-keyed reconciler (SD), LEAD-FINAL footer-parsing closure (QF), and a filing-time already-fixed guard (QF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
