### PR TITLE
fix(QF-20260525-836): sweep clears stale QF claims + dashboard QUICK FIXES section

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -293,6 +293,17 @@ async function loadData() {
     for (const w of mc.workers) mcByWorker[w.session_id] = w;
   }
 
+  // QF-20260525-836: surface open/in_progress QFs (aging ones went unseen). Degrade-safe.
+  let quickFixes = [];
+  try {
+    const { data: qfRows } = await supabase
+      .from('quick_fixes')
+      .select('id, title, status, claiming_session_id, created_at')
+      .in('status', ['open', 'in_progress'])
+      .order('created_at', { ascending: true });
+    quickFixes = qfRows || [];
+  } catch { /* degrade-safe: empty QF section */ }
+
   return {
     sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap,
     claimedSdIds, activeSessions, staleSessions, idleSessions,
@@ -301,6 +312,7 @@ async function loadData() {
     drainAgents,
     mc, mcByWorker,
     executeTeams,
+    quickFixes, // QF-20260525-836
     revivalPending // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
   };
 }
@@ -511,6 +523,27 @@ function printAvailable(d) {
     }
   }
 
+  console.log('');
+}
+
+// QF-20260525-836: open/in_progress QFs (age + holder). Dashboard had no QUICK
+// FIXES section, so QFs aging with no PR went unseen. Display only.
+function printQuickFixes(d) {
+  const qfs = d.quickFixes || [];
+  console.log('QUICK FIXES (' + qfs.length + ')');
+  console.log('─'.repeat(72));
+  if (qfs.length === 0) {
+    console.log('  (no open quick-fixes)');
+    console.log('');
+    return;
+  }
+  const now = Date.now();
+  console.log('  ' + pad('ID', 18) + pad('Status', 12) + pad('Age', 6) + pad('Holder', 10) + 'Title');
+  for (const qf of qfs) {
+    const ageH = qf.created_at ? Math.max(0, Math.round((now - Date.parse(qf.created_at)) / 3600000)) + 'h' : '?';
+    const holder = qf.claiming_session_id ? String(qf.claiming_session_id).substring(0, 8) : '—';
+    console.log('  ' + pad(qf.id, 18) + pad(qf.status, 12) + pad(ageH, 6) + pad(holder, 10) + (qf.title || '').substring(0, 40));
+  }
   console.log('');
 }
 
@@ -1116,6 +1149,8 @@ async function main() {
     workers:       () => printWorkers(d),
     orchestrator:  () => printOrchestrator(d),
     available:     () => printAvailable(d),
+    quickfixes:    () => printQuickFixes(d), // QF-20260525-836
+    qf:            () => printQuickFixes(d), // QF-20260525-836 (alias)
     revival:       () => printRevivalPending(d),
     coordination:  () => printCoordination(d),
     coaching:      async () => await printCoaching(d),
@@ -1133,6 +1168,7 @@ async function main() {
       printDrainAgents(d);
       printOrchestrator(d);
       printAvailable(d);
+      printQuickFixes(d); // QF-20260525-836
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
@@ -1147,7 +1183,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, coordination, coaching, health, qa, forecast, predictions, inbox, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, team, all');
     process.exit(1);
   }
 

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -725,6 +725,44 @@ async function main() {
     }
   }
 
+  // QF-20260525-836: clear stale quick_fixes.claiming_session_id (mirrors the SD
+  // terminal-claim clear above) — a QF whose holder died stayed claimed forever.
+  // Conservative bar (holder gone or heartbeat >15min) avoids yanking a live-but-
+  // quiet worker's claim. Degrade-safe: query failure warns, never blocks the sweep.
+  try {
+    const { data: claimedQfs } = await supabase
+      .from('quick_fixes')
+      .select('id, status, claiming_session_id')
+      .in('status', ['open', 'in_progress'])
+      .not('claiming_session_id', 'is', null);
+
+    if (claimedQfs && claimedQfs.length > 0) {
+      const holderIds = [...new Set(claimedQfs.map(q => q.claiming_session_id))];
+      const { data: holderRows } = await supabase
+        .from('claude_sessions')
+        .select('session_id, heartbeat_at')
+        .in('session_id', holderIds);
+      const hbAgeBySession = new Map();
+      for (const r of (holderRows || [])) {
+        hbAgeBySession.set(r.session_id, r.heartbeat_at ? (now.getTime() - Date.parse(r.heartbeat_at)) / 1000 : Infinity);
+      }
+      for (const qf of claimedQfs) {
+        const ageSec = hbAgeBySession.has(qf.claiming_session_id) ? hbAgeBySession.get(qf.claiming_session_id) : Infinity;
+        if (ageSec <= VERY_STALE_SECONDS) continue; // holder alive/recent — leave claimed
+        const { error } = await supabase
+          .from('quick_fixes')
+          .update({ claiming_session_id: null })
+          .eq('id', qf.id)
+          .eq('claiming_session_id', qf.claiming_session_id); // race guard: only if still held by the same dead session
+        if (!error) {
+          actions.push('QF: cleared stale claiming_session_id on ' + qf.status + ' ' + qf.id + ' (holder ' + String(qf.claiming_session_id).slice(0, 8) + ' hb ' + (ageSec === Infinity ? 'gone' : Math.round(ageSec) + 's') + ')');
+        }
+      }
+    }
+  } catch (qfErr) {
+    warnings.push('QF_CLAIM_SWEEP: ' + qfErr.message);
+  }
+
   // QF-20260426-SWEEP-PHANTOM-DETECT: detect phantom in_progress SDs
   // (status=in_progress + claiming_session_id IS NULL). These are invisible to
   // sd:next's workable filter and silently park work until manual reset. Reset


### PR DESCRIPTION
## Quick-Fix QF-20260525-836 (Tier 2, 75 LOC, bug)

Two coordinator gaps around the `quick_fixes` lifecycle.

### Gap 1 — stale QF claims never released (`scripts/stale-session-sweep.cjs`)
The sweep released stale `strategic_directives_v2` claims but never cleared a stale `quick_fixes.claiming_session_id`, so a QF whose holding session died stayed claimed forever and invisible to adoption. Adds a release loop mirroring the existing SD terminal-claim clear:
- **Conservative bar:** release only when the holder session row is gone OR its heartbeat is `> VERY_STALE_SECONDS` (15min) — avoids yanking a claim from a live-but-quiet worker (compaction/context-load) and inviting duplicate work.
- **Race guard:** the clear is gated on `claiming_session_id` still equalling the dead session.
- **Degrade-safe:** any query failure warns, never blocks the sweep.

### Gap 2 — open QFs aged unseen (`scripts/fleet-dashboard.cjs`)
No QUICK FIXES section existed, so open QFs with no PR aged invisibly (QF-20260521-962/-024 sat open 4+ days). Adds a degrade-safe `loadData` query + `printQuickFixes(d)` listing open/in_progress QFs with age + claim-holder, wired into the `all` view and a `quickfixes`/`qf` section. **Display only** — does not duplicate `orphan-qf-reaper.mjs` (which closes merged-PR QFs).

### Out of scope
No database structure changes; no change to `orphan-qf-reaper.mjs`.

### Verification
- `node --check` passes on both files.
- Dashboard `qf` section renders live (3 open QFs with age/holder).
- Sweep QF-clear logic simulated read-only against live DB: correctly **holds** active-holder claims (22s/11s heartbeats) and only flags `>15min`/gone holders.
- Authoritative unit + e2e suite runs in CI (vitest excludes `**/.worktrees/**`, so local in-worktree runs find 0 files — known harness limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)