### PR TITLE
fix(QF-20260525-542): unify coordinator SD-dependency eval on a canonical helper

### DIFF
--- a/lib/utils/parse-sd-dependencies.cjs
+++ b/lib/utils/parse-sd-dependencies.cjs
@@ -1,0 +1,52 @@
+/**
+ * Canonical SD-dependency blocker rule (CJS) — QF-20260525-542 /
+ * PAT-COORDINATOR-DEP-EVAL-DIVERGENCE-001.
+ *
+ * Mirrors the ESM SSOT parseDependencies() in
+ * scripts/modules/sd-next/dependency-resolver.js for CJS consumers (the
+ * coordinator scripts can't import the ESM module). An entry counts as a real
+ * blocker ONLY if it carries an SD-key (string value, or sd_key/id/sd_id field)
+ * matching /^SD-[A-Z0-9-]+/. Object-shaped "none/available" placeholders and
+ * free-text prerequisites are ignored — so a no-dependency SD is never falsely
+ * flagged BLOCKED. Returns an array of blocker SD-key strings (deduped).
+ *
+ * @param {string|Array|null|undefined} dependencies
+ * @returns {string[]} blocker SD-keys (empty when there are no real deps)
+ */
+const SD_KEY_RE = /^(SD-[A-Z0-9-]+)/;
+
+function parseSdDependencies(dependencies) {
+  if (!dependencies) return [];
+
+  let deps = dependencies;
+  if (typeof dependencies === 'string') {
+    try {
+      const parsed = JSON.parse(dependencies);
+      deps = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(deps)) return [];
+
+  const keys = deps
+    .map((dep) => {
+      if (typeof dep === 'string') {
+        const m = dep.match(SD_KEY_RE);
+        return m ? m[1] : null;
+      }
+      if (dep && typeof dep === 'object') {
+        const candidate = dep.sd_key || dep.id || dep.sd_id;
+        if (typeof candidate === 'string') {
+          const m = candidate.match(SD_KEY_RE);
+          return m ? m[1] : null;
+        }
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  return [...new Set(keys)];
+}
+
+module.exports = { parseSdDependencies, SD_KEY_RE };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -23,6 +23,7 @@ function normalizeRender(s) {
 }
 // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B (Phase 2)
 const teamBanner = require('../lib/execute/team-banner.cjs');
+const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 // SD-LEO-INFRA-FLEET-LIVENESS-MONTE-001 (US-004): subprocess-invoke the MC
 // engine to enrich workers with P(alive). Failures fall back to existing
 // binary display, preserving pre-MC behavior.
@@ -1054,15 +1055,10 @@ async function printPredictions(d) {
   console.log('');
 }
 
-// Helper: parse dependencies from various formats (string, array, JSONB)
-function parseDeps(deps) {
-  if (!deps) return [];
-  if (Array.isArray(deps)) return deps.map(d => typeof d === 'string' ? d : (d.sd_key || d.id || '')).filter(Boolean);
-  if (typeof deps === 'string') {
-    try { return parseDeps(JSON.parse(deps)); } catch (e) { return deps.split(',').map(s => s.trim()).filter(Boolean); }
-  }
-  return [];
-}
+// QF-20260525-542: delegate to the canonical SD-key blocker rule (was divergent
+// local logic that extracted sd_key/id and treated placeholders as available,
+// contradicting the sweep). Both tools now agree via parse-sd-dependencies.cjs.
+const parseDeps = parseSdDependencies;
 
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a — top-level require so the
 // wire-check call-graph builder (lib/static-analysis/call-graph-builder.js)

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1656,9 +1656,11 @@ async function createSD(options) {
     risks: (typeof risks !== 'undefined' && risks && risks.length > 0) ? risks : [
       { risk: 'Implementation may not fully address root cause', likelihood: 'low', impact: 'low', mitigation: 'Verify against original evidence; re-queue via /learn if pattern recurs' }
     ],
-    dependencies: (typeof dependencies !== 'undefined' && dependencies && dependencies.length > 0) ? dependencies : [
-      { dependency: 'none', type: 'internal', status: 'available' }
-    ],
+    // QF-20260525-542: write an empty array when there are no real deps. The prior
+    // { dependency: 'none', status: 'available' } placeholder is not an SD-key, so the
+    // coordinator's canonical blocker rule ignores it anyway — but an empty array keeps
+    // the column honest and avoids confusing any consumer that inspects raw entries.
+    dependencies: (typeof dependencies !== 'undefined' && dependencies && dependencies.length > 0) ? dependencies : [],
     implementation_guidelines: (typeof implementation_guidelines !== 'undefined' && implementation_guidelines && implementation_guidelines.length > 0) ? implementation_guidelines : [
       `Implement changes for: ${title}`,
       'Verify no regressions in existing functionality'

--- a/scripts/one-off/backfill-dependency-placeholder-542.cjs
+++ b/scripts/one-off/backfill-dependency-placeholder-542.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * QF-20260525-542 one-time backfill: normalize the legacy leo-create-sd
+ * { dependency:'none', status:'available' } placeholder in
+ * strategic_directives_v2.dependencies to an empty array. Idempotent — only
+ * touches rows whose dependencies carry NO real SD-key AND consist solely of the
+ * 'none' placeholder shape. Safe to re-run (a second pass finds zero targets).
+ */
+const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+const { parseSdDependencies } = require('../../lib/utils/parse-sd-dependencies.cjs');
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+  const { data: rows, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, dependencies')
+    .not('dependencies', 'is', null);
+  if (error) { console.error('Query failed:', error.message); process.exit(1); }
+
+  const targets = (rows || []).filter((r) => {
+    const d = r.dependencies;
+    if (!Array.isArray(d) || d.length === 0) return false;
+    if (parseSdDependencies(d).length > 0) return false; // real SD-key deps — leave intact
+    return d.every((e) => e && typeof e === 'object' && e.dependency === 'none'); // placeholder-only
+  });
+
+  console.log(`QF-20260525-542 backfill: ${targets.length} placeholder row(s) to normalize.`);
+  let updated = 0;
+  for (const t of targets) {
+    const { error: upErr } = await supabase
+      .from('strategic_directives_v2').update({ dependencies: [] }).eq('sd_key', t.sd_key);
+    if (upErr) console.error(`  ${t.sd_key}: ${upErr.message}`);
+    else { updated++; console.log(`  normalized ${t.sd_key}`); }
+  }
+  console.log(`Done. ${updated}/${targets.length} normalized.`);
+}
+
+main();

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -25,6 +25,7 @@ const fs = require('fs');
 const path = require('path');
 const { randomUUID } = require('crypto');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3b — top-level require so wire-check
 // call-graph builder can statically resolve the dependency on lib/coordinator/signal-router.cjs.
 const _signalRouterModule = require('../lib/coordinator/signal-router.cjs');
@@ -1098,11 +1099,10 @@ async function main() {
     .filter(c => {
       if (c.status === 'completed') return false;
       if (claimedByActive.has(c.sd_key)) return false;
-      // Check dependencies are satisfied
-      if (c.dependencies && Array.isArray(c.dependencies) && c.dependencies.length > 0) {
-        const allDepsMet = c.dependencies.every(dep => completedKeys.has(dep));
-        if (!allDepsMet) return false;
-      }
+      // QF-20260525-542: canonical SD-key blocker rule (was completedKeys.has(dep) on
+      // raw elements — object-shaped placeholders never matched → false BLOCKED).
+      const depKeys = parseSdDependencies(c.dependencies);
+      if (depKeys.length > 0 && !depKeys.every(k => completedKeys.has(k))) return false;
       return true;
     })
     .map(c => c.sd_key);
@@ -1110,8 +1110,9 @@ async function main() {
   const blocked = allSDs
     .filter(c => {
       if (c.status === 'completed') return false;
-      if (!c.dependencies || !Array.isArray(c.dependencies) || c.dependencies.length === 0) return false;
-      return !c.dependencies.every(dep => completedKeys.has(dep));
+      const depKeys = parseSdDependencies(c.dependencies); // QF-20260525-542: canonical rule
+      if (depKeys.length === 0) return false;
+      return !depKeys.every(k => completedKeys.has(k));
     })
     .map(c => c.sd_key);
 


### PR DESCRIPTION
## Quick-Fix QF-20260525-542 (bug; RCA-backed CAPA — PAT-COORDINATOR-DEP-EVAL-DIVERGENCE-001)

### Problem
`stale-session-sweep.cjs` and `fleet-dashboard.cjs` each used divergent local logic to decide whether an SD's dependencies were unmet:
- **Sweep** called `completedKeys.has(dep)` on **raw** array elements — object-shaped `{ dependency:'none', status:'available' }` placeholders (and free-text prerequisites) never matched the SD-key Set → SD falsely listed **BLOCKED**.
- **Dashboard** `parseDeps` extracted `sd_key/id` and treated the same SD as **available**.

Contradictory coordinator output for the same SD — observed live on `SD-LEO-FIX-FORMALIZE-REGISTER-DEPLOYMENT-001` (subsequently claimed, proving the BLOCKED flag was a false positive).

### Fix (systemic CAPA)
- **(a)** New `lib/utils/parse-sd-dependencies.cjs` — CJS canonical SD-key blocker rule mirroring the ESM SSOT `parseDependencies` (`scripts/modules/sd-next/dependency-resolver.js`): an entry is a real blocker only if its string value or `sd_key`/`id`/`sd_id` matches `/^SD-[A-Z0-9-]+/`. Placeholders + free-text ignored. **12/12 unit checks pass.**
- **(b)** Both coordinator scripts consume the helper and delete their divergent local logic — they now agree by construction.
- **(c)** `leo-create-sd.js` writes `[]` instead of the `none/available` placeholder when there are no real deps.
- **(d)** One-time idempotent backfill normalizing existing placeholder-only rows → `[]` (**ran: 32 rows normalized**; re-run on same rows yields 0).

### Verification
- `node --check` clean on all 5 files; helper 12/12 unit assertions pass.
- `SD-EVA-SUPPORT-CLI-SKILL-ORCH-001` still resolves its real `...-001-A` blocker, ignoring its Vision/Architecture baseline prose (so genuinely-blocked SDs stay blocked).
- A normalized SD (`raw=[]`) → `canonical=[]` → available; `fleet-dashboard.cjs available` runs clean.
- Authoritative unit + e2e suite runs in CI (vitest excludes `**/.worktrees/**` → local in-worktree run finds 0 files).

### Notes
- No DB structure change; no behavior change for genuinely-blocked SDs.
- Sequenced after QF-20260525-836 (already merged) which touches the same two files — branched off latest main, no conflict.
- 108 insertions: two inherently new files (52-line canonical helper that eliminates the divergence codebase-wide + 38-line one-time backfill); the actual consumer-logic delta is ~18 lines across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)