### PR TITLE
chore(SD-LEO-INFRA-AUTO-CLOSE-QUICK-001): add qf:link npm alias

### DIFF
--- a/database/migrations/20260525_auto_close_quick_fixes_on_sd_completion.sql
+++ b/database/migrations/20260525_auto_close_quick_fixes_on_sd_completion.sql
@@ -1,0 +1,101 @@
+-- Migration: Auto-close quick-fixes superseded by a completing SD
+-- SD: SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+-- @approved-by: rickfelix@example.com
+-- Pattern: clones fn_auto_close_deliverables_on_sd_completion (20260221) — chosen
+-- over the feedback fn (20260207) because the deliverables fn carries the
+-- EXCEPTION WHEN OTHERS handler + GET DIAGNOSTICS, so a failure here never aborts
+-- the SD-completion transaction.
+--
+-- Problem: quick_fixes is the only work-item type with no SD-completion
+-- reconciliation. feedback and sd_scope_deliverables auto-close on SD completion;
+-- a QF resolved by a DIFFERENT SD (with no PR of its own) stays status='open' and
+-- is re-recommended by sd-next indefinitely (incident: QF-20260521-962 sat open
+-- 4 days after SD-LEO-REFAC-RETIRE-LEGACY-STAGE-001 fixed its symptom).
+
+-- ============================================================================
+-- FR-1: resolution link column. Additive, nullable, no backfill.
+--   - ON DELETE SET NULL: it is a resolution pointer (like feedback.resolution_sd_id),
+--     so deleting a resolving SD must NOT block — it just nulls the link.
+--   - Exactly ONE FK (avoid the duplicate-FK anti-pattern on feedback.quick_fix_id).
+-- ============================================================================
+
+-- resolution_sd_id is TEXT: strategic_directives_v2.id is the sd_key (e.g.
+-- 'SD-LEO-...'), not a UUID (the UUID lives in uuid_id). Mirrors feedback.resolution_sd_id.
+ALTER TABLE quick_fixes
+  ADD COLUMN IF NOT EXISTS resolution_sd_id TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'quick_fixes_resolution_sd_id_fkey'
+  ) THEN
+    ALTER TABLE quick_fixes
+      ADD CONSTRAINT quick_fixes_resolution_sd_id_fkey
+      FOREIGN KEY (resolution_sd_id)
+      REFERENCES strategic_directives_v2(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_quick_fixes_resolution_sd_id
+  ON quick_fixes(resolution_sd_id)
+  WHERE resolution_sd_id IS NOT NULL;
+
+COMMENT ON COLUMN quick_fixes.resolution_sd_id IS
+  'SD that resolved/superseded this QF. When that SD completes, trg_auto_close_quick_fixes_on_sd_completion cancels this QF. Populated operator-confirmed via the FR-3 close-the-loop prompt (SD-LEO-INFRA-AUTO-CLOSE-QUICK-001).';
+
+-- ============================================================================
+-- FR-2: trigger — cancel linked open QFs when the resolving SD completes.
+--   - Target status='cancelled' (NOT 'completed'): the completed_requires_verification
+--     CHECK rejects completing an unverified QF, which under a non-blocking trigger
+--     would silently no-op and leave the QF open. 'cancelled' carries no verification
+--     requirement and is semantically correct for supersession. It is also NOT in the
+--     WHEN set of trg_auto_close_feedback_on_qf_completion (completed/shipped), so no
+--     SD->QF->feedback cascade is triggered.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION fn_auto_close_quick_fixes_on_sd_completion()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_updated_count INTEGER;
+BEGIN
+  -- Only fire when SD transitions TO completed status
+  IF NEW.status = 'completed' AND (OLD.status IS NULL OR OLD.status != 'completed') THEN
+    UPDATE quick_fixes
+    SET
+      status = 'cancelled',
+      completed_at = COALESCE(completed_at, NOW()),
+      verified_by = COALESCE(verified_by, 'auto: SD completion'),
+      verification_notes = COALESCE(verification_notes, '') ||
+        CASE WHEN verification_notes IS NOT NULL AND verification_notes != '' THEN '; ' ELSE '' END ||
+        'Auto-cancelled: superseded by SD ' || COALESCE(NEW.sd_key, NEW.id::text) || ' which reached completed status'
+    WHERE resolution_sd_id = NEW.id
+      AND status NOT IN ('completed', 'cancelled', 'escalated', 'closed');
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count > 0 THEN
+      RAISE NOTICE 'Auto-cancelled % superseded quick-fix(es) for SD % (%)', v_updated_count, NEW.sd_key, NEW.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Non-blocking: log warning but never prevent SD completion
+  RAISE WARNING 'fn_auto_close_quick_fixes_on_sd_completion failed for SD %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Idempotent re-create
+DROP TRIGGER IF EXISTS trg_auto_close_quick_fixes_on_sd_completion ON strategic_directives_v2;
+
+CREATE TRIGGER trg_auto_close_quick_fixes_on_sd_completion
+  AFTER UPDATE ON strategic_directives_v2
+  FOR EACH ROW
+  WHEN (NEW.status = 'completed' AND OLD.status IS DISTINCT FROM 'completed')
+  EXECUTE FUNCTION fn_auto_close_quick_fixes_on_sd_completion();
+
+-- No backfill: there is no reliable signal for which historical open QFs were
+-- superseded by which completed SD (the link did not exist). The FR-3 advisory
+-- prompt populates resolution_sd_id going forward.

--- a/lib/qf/suggest-resolution-links.js
+++ b/lib/qf/suggest-resolution-links.js
@@ -1,0 +1,76 @@
+/**
+ * suggest-resolution-links — advisory matcher for the QF close-the-loop (FR-3)
+ * SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+ *
+ * Finds OPEN quick-fixes that a given SD plausibly supersedes, by token overlap
+ * between the SD (title/scope/description) and each QF (title/description/files_changed).
+ *
+ * This is a DELIBERATELY WEAK, ADVISORY signal (testing-agent R6): file/topic
+ * overlap is noisy (shared utils, empty files_changed). It NEVER auto-links —
+ * callers surface candidates for an operator to confirm. The function is
+ * non-blocking by contract: it never throws; on any error it returns [].
+ */
+
+const STOP = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'to', 'from', 'with', 'of', 'for', 'in',
+  'on', 'at', 'is', 'are', 'be', 'when', 'not', 'no', 'sd', 'qf', 'fix', 'fixes',
+  'add', 'use', 'via', 'into', 'that', 'this', 'it', 'its', 'by', 'so',
+]);
+
+/** Tokenize text into a Set of meaningful lowercased words (len >= 4, non-stopword). */
+export function tokenize(text) {
+  if (!text || typeof text !== 'string') return new Set();
+  return new Set(
+    text.toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length >= 4 && !STOP.has(w)),
+  );
+}
+
+/** Jaccard-ish overlap score (0..1): shared tokens / smaller set size. */
+export function overlapScore(aTokens, bTokens) {
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  let shared = 0;
+  for (const t of bTokens) if (aTokens.has(t)) shared++;
+  return shared / Math.min(aTokens.size, bTokens.size);
+}
+
+/**
+ * @param {object} opts
+ * @param {object} opts.supabase - supabase client
+ * @param {object} opts.sd - SD row (needs sd_key/id + title + scope/description)
+ * @param {number} [opts.threshold=0.34] - minimum overlap to suggest
+ * @param {number} [opts.limit=5] - max candidates returned
+ * @returns {Promise<Array<{id,title,severity,score}>>} ranked candidates (never throws)
+ */
+export async function findResolutionLinkCandidates({ supabase, sd, threshold = 0.34, limit = 5 }) {
+  try {
+    if (!supabase || !sd) return [];
+    const sdTokens = tokenize(
+      [sd.title, sd.scope, sd.description].filter(Boolean).join(' '),
+    );
+    if (sdTokens.size === 0) return [];
+
+    const { data, error } = await supabase
+      .from('quick_fixes')
+      .select('id, title, description, severity, files_changed, status, resolution_sd_id')
+      .in('status', ['open', 'in_progress'])
+      .is('resolution_sd_id', null)
+      .limit(200);
+    if (error || !Array.isArray(data)) return [];
+
+    const sdKey = sd.sd_key || sd.id;
+    const candidates = [];
+    for (const qf of data) {
+      const filesText = Array.isArray(qf.files_changed) ? qf.files_changed.join(' ') : (qf.files_changed || '');
+      const qfTokens = tokenize([qf.title, qf.description, filesText].filter(Boolean).join(' '));
+      const score = overlapScore(sdTokens, qfTokens);
+      if (score >= threshold) {
+        candidates.push({ id: qf.id, title: qf.title, severity: qf.severity, score: Number(score.toFixed(2)), suggested_sd: sdKey });
+      }
+    }
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates.slice(0, limit);
+  } catch {
+    // Advisory + non-blocking: never throw.
+    return [];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "skill:audit": "node scripts/skill-audit.js",
     "skill:audit:body": "node scripts/pocock/audit-skill-bodies.mjs",
     "prio:top3": "node scripts/wsjf-priority-fetcher.js",
+    "qf:link": "node scripts/qf-link-resolution.mjs",
     "session:prologue": "node scripts/generate-session-prologue.js",
     "db:create": "node scripts/execute-database-sql.js",
     "db:timeline": "node scripts/execute-database-sql.js database/schema/sd_execution_timeline.sql",

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/qf-resolution-link-advisory.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/qf-resolution-link-advisory.js
@@ -1,0 +1,27 @@
+/**
+ * qf-resolution-link-advisory — FR-3 close-the-loop advisory hook
+ * SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+ *
+ * After an SD completes, surface OPEN quick-fixes whose scope plausibly overlaps
+ * this SD's — candidates the SD may have superseded. ADVISORY ONLY: it prints
+ * suggestions + the exact link command and NEVER auto-links, prompts, or blocks.
+ * Operator confirms by setting quick_fixes.resolution_sd_id (and, since the SD is
+ * already completed, cancelling the QF) — see the printed command.
+ */
+import { findResolutionLinkCandidates } from '../../../../../../lib/qf/suggest-resolution-links.js';
+
+/**
+ * @returns {Promise<{outcome:string, detail?:string, candidates?:Array}>}
+ */
+export async function runQfResolutionLinkAdvisory(sd, supabase) {
+  const candidates = await findResolutionLinkCandidates({ supabase, sd });
+  if (!candidates.length) return { outcome: 'no_candidates' };
+
+  const sdKey = sd.sd_key || sd.id;
+  console.log(`   [qf-link-advisory] ${candidates.length} open QF(s) may be superseded by ${sdKey} (advisory — verify before linking):`);
+  for (const c of candidates) {
+    console.log(`      • ${c.id} (${c.severity}, overlap ${c.score}) — ${String(c.title).slice(0, 60)}`);
+  }
+  console.log(`      To link+close a confirmed match: node scripts/qf-link-resolution.mjs <QF-ID> ${sdKey}`);
+  return { outcome: 'surfaced', detail: `${candidates.length} candidate(s)`, candidates };
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -505,6 +505,17 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       console.warn(`   ⚠️  PR-tracking populator failed (non-blocking): ${populatorError.message}`);
     }
 
+    // SD-LEO-INFRA-AUTO-CLOSE-QUICK-001 (FR-3): close-the-loop advisory.
+    // Surface open QFs this SD may have superseded so the operator can link them
+    // (quick_fixes.resolution_sd_id) for trg_auto_close_quick_fixes_on_sd_completion.
+    // Advisory only — never auto-links, prompts, or blocks completion.
+    try {
+      const { runQfResolutionLinkAdvisory } = await import('./hooks/qf-resolution-link-advisory.js');
+      await runQfResolutionLinkAdvisory(sd, this.supabase);
+    } catch (qfAdvisoryError) {
+      console.warn(`   ⚠️  QF resolution-link advisory failed (non-blocking): ${qfAdvisoryError.message}`);
+    }
+
     // SD-LEO-INFRA-PROGRAMMATIC-TOOL-CALLING-001: Auto-populate retrospective via programmatic scorer.
     // Generates SD-specific insights with real file references — avoids RETROSPECTIVE_QUALITY_GATE failures.
     // Fail-safe: non-blocking, never prevents SD completion.

--- a/scripts/qf-link-resolution.mjs
+++ b/scripts/qf-link-resolution.mjs
@@ -1,0 +1,55 @@
+/**
+ * qf-link-resolution — operator-confirmed close-the-loop link (FR-3)
+ * SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+ *
+ * Links a quick-fix to the SD that resolved it (sets quick_fixes.resolution_sd_id).
+ * If that SD is ALREADY completed (the common case at LEAD-FINAL, where the
+ * completion trigger has already fired and won't re-fire), it also cancels the QF
+ * directly so the loop is closed. Otherwise the link stands and
+ * trg_auto_close_quick_fixes_on_sd_completion cancels the QF when the SD completes.
+ *
+ * Usage: node scripts/qf-link-resolution.mjs <QF-ID> <SD-KEY> [--no-cancel]
+ *
+ * This is the operator-confirmed step — it is never invoked automatically.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const [qfId, sdKey, ...rest] = process.argv.slice(2);
+const noCancel = rest.includes('--no-cancel');
+
+if (!qfId || !sdKey) {
+  console.error('Usage: node scripts/qf-link-resolution.mjs <QF-ID> <SD-KEY> [--no-cancel]');
+  process.exit(2);
+}
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const { data: sd, error: sdErr } = await supabase
+  .from('strategic_directives_v2').select('id, status').eq('id', sdKey).maybeSingle();
+if (sdErr || !sd) { console.error(`SD ${sdKey} not found${sdErr ? ': ' + sdErr.message : ''}`); process.exit(1); }
+
+const { data: qf, error: qfErr } = await supabase
+  .from('quick_fixes').select('id, status').eq('id', qfId).maybeSingle();
+if (qfErr || !qf) { console.error(`QF ${qfId} not found${qfErr ? ': ' + qfErr.message : ''}`); process.exit(1); }
+
+// Always set the link (idempotent record of supersession).
+const update = { resolution_sd_id: sdKey };
+
+// If the resolving SD is already completed, the trigger won't fire again — cancel now.
+const sdDone = sd.status === 'completed';
+const qfOpen = !['completed', 'cancelled', 'escalated', 'closed'].includes(qf.status);
+if (sdDone && qfOpen && !noCancel) {
+  update.status = 'cancelled';
+  update.completed_at = new Date().toISOString();
+  update.verified_by = update.verified_by || 'operator: qf-link-resolution';
+  update.verification_notes = `Auto-cancelled: linked to already-completed SD ${sdKey} (close-the-loop).`;
+}
+
+const { error: upErr } = await supabase.from('quick_fixes').update(update).eq('id', qfId);
+if (upErr) { console.error('Link failed:', upErr.message); process.exit(1); }
+
+console.log(`Linked ${qfId} → ${sdKey} (resolution_sd_id set).`);
+if (update.status === 'cancelled') console.log(`  SD already completed → ${qfId} cancelled now.`);
+else if (sdDone) console.log(`  SD already completed and QF already closed — link recorded only.`);
+else console.log(`  SD not yet completed — QF will auto-cancel when ${sdKey} completes.`);

--- a/tests/integration/auto-close-quick-fixes-trigger.integration.mjs
+++ b/tests/integration/auto-close-quick-fixes-trigger.integration.mjs
@@ -1,0 +1,101 @@
+/**
+ * Integration test — trg_auto_close_quick_fixes_on_sd_completion (TS-1..TS-8)
+ * SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+ *
+ * Runs entirely inside ONE transaction that is ROLLED BACK — no live data is
+ * mutated. To exercise ONLY the new trigger (and not the ~46 SD-lifecycle
+ * governance triggers that would block a throwaway SD→completed transition),
+ * it disables USER triggers on the two tables and re-enables just the trigger
+ * under test. FK / ON DELETE SET NULL are system constraints (not USER
+ * triggers) so they remain enforced. A short lock_timeout keeps the brief
+ * ACCESS EXCLUSIVE lock from stalling parallel sessions.
+ *
+ * Run: node tests/integration/auto-close-quick-fixes-trigger.integration.mjs
+ * Exit 0 = all assertions pass.
+ */
+import 'dotenv/config';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+const SUF = Math.random().toString(36).slice(2, 8);
+const SD = `SD-TEST-ACQ-${SUF}`;
+const fails = [];
+const ok = (cond, label) => { console.log(`${cond ? 'PASS' : 'FAIL'}  ${label}`); if (!cond) fails.push(label); };
+
+const c = await createDatabaseClient();
+try {
+  await c.query("SET lock_timeout='4s'");
+  await c.query("SET statement_timeout='30s'");
+  await c.query('BEGIN');
+  await c.query('ALTER TABLE strategic_directives_v2 DISABLE TRIGGER USER');
+  await c.query('ALTER TABLE quick_fixes DISABLE TRIGGER USER');
+  // Re-enable ONLY the trigger under test.
+  await c.query('ALTER TABLE strategic_directives_v2 ENABLE TRIGGER trg_auto_close_quick_fixes_on_sd_completion');
+
+  // TS-1: schema objects exist (column + single FK + index)
+  const obj = await c.query(`
+    SELECT
+      (SELECT count(*) FROM information_schema.columns WHERE table_name='quick_fixes' AND column_name='resolution_sd_id' AND is_nullable='YES')::int AS col,
+      (SELECT count(*) FROM pg_constraint WHERE conname='quick_fixes_resolution_sd_id_fkey' AND confdeltype='n')::int AS fk_setnull,
+      (SELECT count(*) FROM pg_constraint c JOIN pg_class t ON c.conrelid=t.oid WHERE t.relname='quick_fixes' AND c.contype='f' AND c.conkey = (SELECT array_agg(attnum) FROM pg_attribute WHERE attrelid=t.oid AND attname='resolution_sd_id'))::int AS fk_count,
+      (SELECT count(*) FROM pg_indexes WHERE tablename='quick_fixes' AND indexname='idx_quick_fixes_resolution_sd_id')::int AS idx`);
+  const o = obj.rows[0];
+  ok(o.col === 1, 'TS-1 nullable resolution_sd_id column exists');
+  ok(o.fk_setnull === 1, 'TS-1 FK is ON DELETE SET NULL (confdeltype=n)');
+  ok(Number(o.fk_count) === 1, 'TS-1 exactly ONE FK on resolution_sd_id');
+  ok(o.idx === 1, 'TS-1 index idx_quick_fixes_resolution_sd_id exists');
+
+  // throwaway SD (minimal NOT-NULL cols), status active
+  await c.query(`INSERT INTO strategic_directives_v2
+    (id, sd_key, title, status, category, priority, description, rationale, scope, sequence_rank, sd_code_user_facing, uuid_internal_pk)
+    VALUES ($1::text,$1::text,'ACQ trigger test','active','infrastructure','low','t','t','t',99999,$1::text, gen_random_uuid())`, [SD]);
+
+  // TS-6: bad FK rejected (savepoint so the txn survives)
+  await c.query('SAVEPOINT s_badfk');
+  let badFkRejected = false;
+  try {
+    await c.query(`INSERT INTO quick_fixes (id,title,type,severity,description,status,resolution_sd_id) VALUES ('QF-ACQ-BAD-${SUF}','x','bug','low','d','open','SD-NOPE-${SUF}')`);
+  } catch { badFkRejected = true; }
+  await c.query('ROLLBACK TO SAVEPOINT s_badfk');
+  ok(badFkRejected, 'TS-6 bad resolution_sd_id FK rejected');
+
+  // linked unverified open QF + an unlinked open QF
+  const QF_LINK = `QF-ACQ-L-${SUF}`, QF_FREE = `QF-ACQ-F-${SUF}`;
+  await c.query(`INSERT INTO quick_fixes (id,title,type,severity,description,status,tests_passing,uat_verified,force_completed,resolution_sd_id)
+                 VALUES ($1,'linked','bug','medium','d','open',false,false,false,$2)`, [QF_LINK, SD]);
+  await c.query(`INSERT INTO quick_fixes (id,title,type,severity,description,status,resolution_sd_id) VALUES ($1,'unlinked','bug','low','d','open',NULL)`, [QF_FREE]);
+
+  // TS-2 / TS-3: SD -> completed cancels the linked (unverified) QF, no CHECK violation
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed' WHERE id=$1`, [SD]);
+  const a1 = await c.query(`SELECT status FROM quick_fixes WHERE id=$1`, [QF_LINK]);
+  ok(a1.rows[0].status === 'cancelled', 'TS-2/TS-3 linked unverified QF auto-cancelled on SD completion (no CHECK error)');
+  const a2 = await c.query(`SELECT status FROM quick_fixes WHERE id=$1`, [QF_FREE]);
+  ok(a2.rows[0].status === 'open', 'TS-5 unlinked QF untouched');
+
+  // TS-4: re-fire is a no-op. Re-link a fresh open QF, re-run completed->completed update.
+  const QF_2 = `QF-ACQ-2-${SUF}`;
+  await c.query(`INSERT INTO quick_fixes (id,title,type,severity,description,status,resolution_sd_id) VALUES ($1,'second','bug','low','d','open',$2)`, [QF_2, SD]);
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed' WHERE id=$1`, [SD]); // OLD already completed -> WHEN false
+  const a3 = await c.query(`SELECT status FROM quick_fixes WHERE id=$1`, [QF_2]);
+  ok(a3.rows[0].status === 'open', 'TS-4 re-fire (completed->completed) is a no-op; new linked QF stays open');
+
+  // TS-7: ON DELETE SET NULL — deleting the SD nulls the link, QF survives
+  await c.query(`DELETE FROM strategic_directives_v2 WHERE id=$1`, [SD]);
+  const a4 = await c.query(`SELECT resolution_sd_id, status FROM quick_fixes WHERE id=$1`, [QF_LINK]);
+  ok(a4.rows.length === 1 && a4.rows[0].resolution_sd_id === null, 'TS-7 ON DELETE SET NULL: QF survives with null link');
+
+  // TS-8: trigger error never aborts SD completion — verified by construction
+  // (EXCEPTION WHEN OTHERS -> RAISE WARNING -> RETURN NEW). Asserted via code review;
+  // a forced-error path can't be induced without mutating the live function body.
+  ok(true, 'TS-8 trigger is non-blocking by construction (EXCEPTION WHEN OTHERS -> RETURN NEW)');
+
+  await c.query('ROLLBACK');
+} catch (e) {
+  console.error('ERROR:', e.message);
+  try { await c.query('ROLLBACK'); } catch { /* already rolled back */ }
+  fails.push('exception: ' + e.message);
+} finally {
+  await c.end();
+}
+
+console.log(`\n${fails.length === 0 ? '✅ ALL PASS' : '❌ ' + fails.length + ' FAIL'} (TS-1..TS-8)`);
+process.exit(fails.length === 0 ? 0 : 1);

--- a/tests/unit/qf/suggest-resolution-links.test.js
+++ b/tests/unit/qf/suggest-resolution-links.test.js
@@ -1,0 +1,71 @@
+/**
+ * Unit test — suggest-resolution-links matcher (FR-3, TS-9)
+ * SD-LEO-INFRA-AUTO-CLOSE-QUICK-001
+ *
+ * The matcher is ADVISORY and NON-BLOCKING by contract: it must never throw and
+ * must return [] on any error or no-match, so wiring it into the LEAD-FINAL hook
+ * can never break SD completion.
+ */
+import { describe, it, expect } from 'vitest';
+import { tokenize, overlapScore, findResolutionLinkCandidates } from '../../../lib/qf/suggest-resolution-links.js';
+
+// Minimal supabase stub whose query chain resolves to a fixed result.
+function stub(result) {
+  const chain = {
+    select() { return chain; },
+    in() { return chain; },
+    is() { return chain; },
+    limit() { return Promise.resolve(result); },
+  };
+  return { from() { return chain; } };
+}
+
+describe('suggest-resolution-links (FR-3 / TS-9)', () => {
+  it('tokenize drops stopwords and short tokens', () => {
+    const t = tokenize('Fix the Stage17 blank archetype profile');
+    expect(t.has('stage17')).toBe(true);
+    expect(t.has('archetype')).toBe(true);
+    expect(t.has('the')).toBe(false); // stopword
+    expect(t.has('fix')).toBe(false); // stopword
+  });
+
+  it('overlapScore is 0 when either side is empty', () => {
+    expect(overlapScore(new Set(), tokenize('archetype profile'))).toBe(0);
+    expect(overlapScore(tokenize('archetype'), new Set())).toBe(0);
+  });
+
+  it('surfaces a strongly-overlapping open QF as a candidate', async () => {
+    const supabase = stub({
+      data: [{ id: 'QF-A', title: 'Stage17 archetype profile blank', description: 'composer surface', severity: 'high', files_changed: null, status: 'open', resolution_sd_id: null }],
+      error: null,
+    });
+    const sd = { sd_key: 'SD-X', title: 'Fix Stage17 archetype profile composer surface', scope: 'archetype profile rendering' };
+    const out = await findResolutionLinkCandidates({ supabase, sd });
+    expect(out.length).toBe(1);
+    expect(out[0].id).toBe('QF-A');
+    expect(out[0].suggested_sd).toBe('SD-X');
+    expect(out[0].score).toBeGreaterThanOrEqual(0.34);
+  });
+
+  it('excludes weakly-overlapping QFs below threshold', async () => {
+    const supabase = stub({
+      data: [{ id: 'QF-B', title: 'unrelated coordinator sweep release', description: 'inbox heartbeat', severity: 'low', files_changed: null, status: 'open', resolution_sd_id: null }],
+      error: null,
+    });
+    const sd = { sd_key: 'SD-X', title: 'Stage17 archetype profile composer', scope: 'design surface' };
+    const out = await findResolutionLinkCandidates({ supabase, sd });
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] (never throws) on a query error — non-blocking contract', async () => {
+    const supabase = stub({ data: null, error: { message: 'db down' } });
+    const sd = { sd_key: 'SD-X', title: 'archetype profile', scope: 'x' };
+    await expect(findResolutionLinkCandidates({ supabase, sd })).resolves.toEqual([]);
+  });
+
+  it('returns [] when supabase/sd missing or SD has no usable tokens', async () => {
+    await expect(findResolutionLinkCandidates({ supabase: null, sd: { title: 'x' } })).resolves.toEqual([]);
+    await expect(findResolutionLinkCandidates({ supabase: stub({ data: [], error: null }), sd: null })).resolves.toEqual([]);
+    await expect(findResolutionLinkCandidates({ supabase: stub({ data: [], error: null }), sd: { title: '' } })).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #3934. Adds the `qf:link` npm alias for `scripts/qf-link-resolution.mjs` (FR-3 operator CLI), making it a discoverable entry point and resolving the WIRE_CHECK leaf-CLI false-positive legitimately (no bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)