### PR TITLE
docs(plans): venture-build-model design + 4 archived SD plans

### DIFF
--- a/docs/plans/archived/sd-leo-feat-finalize-claude-code-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-finalize-claude-code-001-plan.md
@@ -1,0 +1,47 @@
+<!-- Archived from: docs/plans/converge-venture-build-claude-code-model.md -->
+<!-- SD Key: SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 -->
+<!-- Archived at: 2026-05-25T12:30:59.484Z -->
+
+# Finalize the Claude-Code-from-repo venture build model + Stage-0 app-type capture
+
+## Type
+feature
+
+## Priority
+medium
+
+## Summary
+Finish the cost-pivot rewiring of the venture build/deploy path that was started but never completed. Building a venture's features is governed by the **venture stage pipeline (S17–S26, incl. the S20 Code Quality Gate)** — NOT by LEO platform SDs. So the single venture build model is: **Lovable conduits the Stitch landing → GitHub; Claude Code builds the rest from the Claude-Code-ready seeded repo (`CLAUDE.md` + `docs/build-tasks.md` + `.replit`); Replit hosts.** This SD makes that model honest, gives it a real completion gate, and adds the missing front-end capture of the venture's target platform. It does NOT generate LEO SDs per venture-feature (a rejected, separately-attempted-and-cancelled approach that conflates building-the-factory with building-the-products).
+
+## Scope
+Cross-repo (EHG app frontend + EHG_Engineer backend/worker/DB-config). Four focused changes:
+
+- **FR-1 — Build-model honesty.** Correct the stale pre-pivot semantics: the build model is "Claude Code builds from the seeded repo; Replit hosts," NOT "Replit Agent builds." Drop the build-method selector in `ehg/src/components/stages/shared/BuildMethodSelector.tsx`; fix the misleading comment in `lib/eva/stage-execution-worker.js` `_postStageHook_S19_Bridge`; update the `lifecycle_stage_config` S19 row description (drop `build_method: replit_agent` framing). The `replit_agent` SD-bridge skip STAYS (no SDs by design under model (b)).
+- **FR-2 — Real completion gate.** Gate the S19→S20 advance on `docs/build-tasks.md` build-task completeness (the features are actually built), not merely on a registered deployment URL. The existing S20 Code Quality Gate (npm audit/lint/tests on the real repo) remains the downstream validator.
+- **FR-3 — Stage-0 app-type capture.** Add a front-end control at Stage 0 to set `ventures.target_platform` (web | mobile | both). The backend already consumes this column (`lib/eva/bridge/replit-prompt-formatter.js`, `mobile-security-defaults.js`) to select Expo/mobile vs web templates; only the capture UI is missing (it currently defaults to `web`). Surface the existing decision rubric (`docs/reference/target-platform-decision-rubric.md`) as guidance.
+- **FR-4 — Cleanup.** Delete the dead/legacy `ehg/src/types/workflowStages.ts` (the live SSOT is `ehg/src/config/venture-workflow.ts`, already aligned to the marketing-first pipeline) — after confirming zero imports.
+
+## Key Changes
+- Relabel/clarify the venture build model across UI + worker comment + stage config (FR-1).
+- New build-completeness gate at S19 advance, keyed off `docs/build-tasks.md` (FR-2).
+- New Stage-0 UI control writing `ventures.target_platform` (FR-3).
+- Remove dead `workflowStages.ts` (FR-4).
+
+## Success Criteria
+- No surface refers to the venture build as "Replit Agent builds"; the single model is "Claude Code builds from the seeded repo, Replit hosts"; the build-method selector is gone.
+- S19→S20 advance is blocked until the seeded `docs/build-tasks.md` tasks are complete (not merely a registered URL).
+- A venture's `target_platform` (web/mobile/both) is settable from the Stage-0 UI and flows to the backend template selection that already consumes it.
+- `workflowStages.ts` is removed with no broken imports; `venture-workflow.ts` remains the SSOT.
+
+## Out of Scope
+- NO generation of LEO Strategic Directives for venture builds (the rejected model (c)); `lib/eva/lifecycle-sd-bridge.js` stays unused for ventures.
+- NO changes to the already-live backend platform-branching, Expo templates, mobile-security defaults, marketing-first S18–S26 pipeline, or the venture→LEO bridge.
+- The register-deployment 3-layer live fix (service-role client in `server/routes/stage19.js` + the two `ehg/supabase/migrations/` files already applied to prod) ships as a SEPARATE QF/PR, not in this SD.
+- Retiring the obsolete `replit_agent` skip + re-entry-adapter machinery is a possible follow-up only if it proves to be dead code (guarded deletion with tests), not part of this SD.
+
+## Risks
+- `docs/build-tasks.md`-based completion gating needs a reliable "task done" signal; design it to degrade safely (don't hard-block on a parse failure).
+- Deleting `workflowStages.ts` requires a verified zero-import check first (legacy type file; confirm nothing imports it).
+
+## Vision
+VISION-S19-CLAUDE-CODE-READY-REPO-L2-001 (arch: ARCH-S19-CLAUDE-CODE-READY-REPO-001)

--- a/docs/plans/archived/sd-leo-feat-s17-lovable-build-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-s17-lovable-build-001-plan.md
@@ -1,0 +1,35 @@
+<!-- Archived from: C:/Users/rickf/AppData/Local/Temp/b1-lovable-preamble-plan.md -->
+<!-- SD Key: SD-LEO-FEAT-S17-LOVABLE-BUILD-001 -->
+<!-- Archived at: 2026-05-23T22:03:26.104Z -->
+
+# Plan: S17 Lovable build preamble — inject Replit-native build requirements at the Stitch-to-Lovable handoff
+
+## Summary
+At Stage 17 a venture's brand-grounded GVOS prompt is pasted into Google Stitch (which produces an HTML/Tailwind design), then the design is transferred Stitch -> Lovable. That transfer opens Lovable pre-populated with the design image AND an EDITABLE prompt — the single moment where build requirements can steer Lovable before it scaffolds the full-stack foundation. Today nothing is injected there, so Lovable builds a generic, Supabase-coupled scaffold that ignores the venture's actual problem/scope and hard-wires Supabase. That later forces manual rework to reach the portfolio's Replit-native target (the Canvas AI migration was exactly this rework, done by hand). This SD generates a concise, copy-paste "Lovable build preamble" from the venture's planning artifacts and surfaces it on the Stage-17 Lovable-handoff panel so the chairman pastes it into Lovable's prompt at transfer time.
+
+## Problem
+The venture foundation is built by a design-tool chain (Stitch design-only -> Lovable fixed React/Vite/Supabase stack) that carries no build spec and defaults to Supabase. Nothing steers Lovable's initial build toward (a) the venture's real scope/problem (Replit flagged problem-statement + stack mismatches on the first build-into venture) or (b) a Replit-native-portable backend. Result: every venture's foundation diverges from plan and is Supabase-coupled, requiring downstream manual migration.
+
+## Success Criteria
+- The formatter produces a preamble containing the venture name, a one-line problem/value, target users, the key screens/features, brand tokens, and a Replit-native portability block.
+- GET /api/stage17/:ventureId/lovable-preamble returns the preamble for a venture with S17 artifacts and degrades gracefully (never 500) when artifacts are sparse.
+- The Stage-17 Lovable-handoff panel shows the preamble with a working Copy action and a one-line "paste into Lovable at Stitch transfer" instruction.
+- Unit tests cover artifact extraction, presence of the portability block, char-budget enforcement, and graceful degradation; existing S17/S19 prompt behavior is unchanged (purely additive).
+
+## Key Changes
+- [EHG_Engineer] New lib/eva/bridge/lovable-preamble-formatter.js — pure formatter: venture + export_blueprint_review artifacts -> concise preamble (<~2500 chars). No DB writes.
+- [EHG_Engineer] Replit-native portability block in the preamble: instruct Lovable to keep data access behind a thin typed data module (not Supabase calls scattered through components), read all backend config from env vars, avoid Supabase-only constructs as business logic (no app logic in RLS/Edge Functions), and include a /feedback page (feedback table: title+description) plus Sentry. Goal: the Supabase scaffold Lovable emits migrates cleanly to Replit-native at S19 instead of needing manual surgery. The preamble does NOT make Lovable use Replit directly (it can't) — it makes the coupling shallow and swappable.
+- [EHG_Engineer] New route GET /api/stage17/:ventureId/lovable-preamble in server/routes/stage17.js — resolves venture, calls the formatter, returns { preamble, charCount }. Read-only.
+- [EHG] New "Build preamble" section on the Stage-17 Lovable-handoff panel — reuse the existing CopyableBlock pattern in src/components/stage17/gvos/ComposerPreviewPanel.tsx, fetch the route, render the preamble + copy.
+- [EHG_Engineer] tests/unit/bridge/lovable-preamble.test.js.
+
+## Risks
+- Lovable may ignore or override parts of an injected prompt. Severity: medium. Mitigation: keep the preamble concise + imperative; treat as best-effort steering and validate empirically on the next venture.
+- The preamble could contradict the attached Stitch design image. Severity: low. Mitigation: the preamble defers all visual/layout decisions to the attached design; it adds only scope + backend-portability, never layout.
+- Char-budget overflow truncating the portability block. Severity: low. Mitigation: enforce a budget that preserves the portability block (mirror formatPlanModePrompt's budget pattern).
+
+## Out of Scope
+- Automating the Stitch->Lovable transfer itself (remains a manual chairman action).
+- Changing Lovable's scaffold stack (fixed by the tool).
+- The portfolio-wide de-Supabase of the S19/replit.md generators (separate strategic SD).
+- Retroactively fixing already-built ventures (handled per-venture, e.g., Canvas AI).

--- a/docs/plans/archived/sd-leo-feat-s19-builds-into-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-s19-builds-into-001-plan.md
@@ -1,0 +1,53 @@
+<!-- Archived from: C:/Users/rickf/.claude/plans/s19-build-into-s17-design-repo.md -->
+<!-- SD Key: SD-LEO-FEAT-S19-BUILDS-INTO-001 -->
+<!-- Archived at: 2026-05-23T13:51:23.564Z -->
+
+# S19 builds into the venture's S17 design repo instead of creating a blank one
+
+## Type
+feature
+
+## Priority
+high
+
+## Target Application
+EHG_Engineer
+
+## Summary
+At Stage 17, a venture's design is captured as a GitHub repo (e.g. Canvas AI → rickfelix/contribution-hub, a real working Lovable app: Vite + TypeScript + TanStack Router + shadcn, 7 routed pages, a design system) and stored in venture_artifacts(artifact_type='s17_approved').metadata.lovable_artifact as a github_sync entry. At Stage 19 the "Create & Seed GitHub Repository" button creates a NEW blank repo (rickfelix/<venture-slug>) and seeds only markdown docs into it, ignoring the S17 design repo. The result: the design work is abandoned and the Replit build starts from scratch instead of continuing from the working prototype. This SD makes Stage 19 build INTO the venture's existing S17 design repo — seeding additive docs/ on the main branch — so the build continues from the design. Decision (chairman): the build proceeds in Replit (not Lovable), so seeding additive docs/ into main is safe and non-destructive.
+
+## Strategic Objectives
+- Stop abandoning the S17 design at build time: the Replit build must continue from the venture's actual design repo, not a blank one.
+- Establish ventures.repo_url as the single source of truth for the venture's git repo (FR-1, shipped ehg PR #635).
+- Make the Stage-19 build path consistent across all ventures: reuse the existing repo when one exists; create-new only as a fallback for repo-less ventures.
+
+## Key Changes
+| File | Action | Purpose |
+|------|--------|---------|
+| `ehg/supabase/migrations/20260523120000_ssot_venture_repo_url_from_s17.sql` | CREATE | FR-1 (DONE, ehg PR #635): trigger + backfill populating ventures.repo_url from the S17 github_sync capture |
+| `EHG_Engineer/lib/eva/bridge/resolve-venture-repo.js` | CREATE | FR-2: resolveVentureRepoUrl = ventures.repo_url ?? normalized S17 artifact repo |
+| `EHG_Engineer/server/routes/github-repo.js` | MODIFY | FR-2: when an existing repo resolves, skip gh-repo-create and use build-into mode |
+| `EHG_Engineer/lib/eva/bridge/replit-repo-seeder.js` | MODIFY | FR-2: build-into mode — authenticated clone of the private repo, additive docs/ on main, preserve existing replit.md, never force-push |
+| `ehg/src/components/stages/shared/BuildMethodSelector.tsx` | MODIFY | FR-3: Stage-19 UI reflects "seed into existing repo" when ventures.repo_url is set |
+
+## Success Criteria
+- For a venture with ventures.repo_url set, S19 "Create & Seed" seeds docs additively into that existing repo with NO new repo created (gh repo create is not invoked).
+- The existing repo's files are preserved: the Lovable-generated root replit.md is not overwritten; docs/ is additive on main; the seeder never force-pushes.
+- The build path (Open in Replit / build-method) targets the existing repo via ventures.repo_url.
+- For a repo-less venture, the current create-new behavior is preserved as a fallback.
+- Validated end-to-end against a throwaway private repo before any live venture; never tested destructively against contribution-hub.
+
+## Risks
+- HIGH blast radius: changes the Stage-19 build path for every venture.
+- Private-repo git auth: cloning and pushing a private repo server-side must be authenticated (verify the existing credential helper covers same-owner private repos).
+- Pushes to live GitHub repos: must be additive and must never force-push; validate on a throwaway repo first.
+- Cross-repo coordination: requires both an EHG_Engineer PR (resolver/route/seeder) and an EHG PR (frontend).
+
+## Tasks
+- [ ] FR-1 SSOT: ventures.repo_url populated from S17 capture (DONE — ehg PR #635, applied to dedlbzhpgkmetvhbkyzq)
+- [ ] FR-2 resolveVentureRepoUrl helper + github-repo.js build-into branch (skip gh-repo-create when a repo exists)
+- [ ] FR-2 replit-repo-seeder.js build-into mode: authenticated private clone, additive docs/ on main, preserve replit.md, never force-push
+- [ ] FR-3 BuildMethodSelector.tsx reflects "seed into existing repo" when ventures.repo_url is set
+- [ ] FR-4 seeder design-copy fallback for repo-less ventures (lower priority)
+- [ ] FR-5 slug-collision guard on the create-new path
+- [ ] Validate end-to-end against a throwaway private repo (never force-push, never destructive against contribution-hub)

--- a/docs/plans/archived/sd-leo-feat-stage-replit-prompts-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-stage-replit-prompts-001-plan.md
@@ -1,0 +1,51 @@
+<!-- Archived from: C:/Users/rickf/.claude/plans/s19-prompts-build-into-aware.md -->
+<!-- SD Key: SD-LEO-FEAT-STAGE-REPLIT-PROMPTS-001 -->
+<!-- Archived at: 2026-05-23T17:31:24.180Z -->
+
+# Stage-19 Replit prompts are build-into-aware (continue the existing app, don't scaffold a new one)
+
+## Type
+feature
+
+## Priority
+high
+
+## Target Application
+EHG_Engineer
+
+## Summary
+SD-LEO-FEAT-S19-BUILDS-INTO-001 made Stage 19 build INTO the venture's existing Stage-17 design repo (e.g. Canvas AI → rickfelix/contribution-hub, a real working Lovable app: Vite + TypeScript + TanStack Router + shadcn) and seed additive docs/ + an EHG-BUILD-CONTEXT marker into replit.md. But the Replit prompts the chairman pastes still assume a BLANK repo: the Step-2 scaffold prompt says "Scaffold a new web app", and the Plan-Mode / per-feature / replit.md prompts reference only generic seeded docs/ — including docs/designs/, which is EMPTY for github_sync-captured ventures — and never the actual app. No build-into signal reaches the prompt route (GET /api/stage19/:ventureId/replit-prompts is mode-agnostic; the frontend knows the mode via ventures.repo_url but doesn't pass it). Result: a chairman following the prompts would tell Replit to scaffold a fresh app alongside the existing one — re-doing the work build-into was meant to preserve. This SD makes the S19 prompts mode-aware: in build-into mode they instruct Replit to CONTINUE the existing app (inspect its stack/routes/design system and match them; build additively; do NOT scaffold or re-create) and stop pointing at the empty docs/designs/. create-new prompts are unchanged.
+
+## Strategic Objectives
+- Close the contradiction between the build-into plumbing (shipped) and the operator-facing prompts (still blank-repo).
+- Make the chairman's Replit workflow continue from the real app, not re-scaffold it.
+- Use the venture's existing app (already in the repo) as the design reference, not the empty docs/designs/, for github_sync ventures.
+- Delegate repo introspection to Replit Agent (which is IN the repo) via prompt language, rather than adding heavy backend repo-cloning to the prompt route.
+
+## Key Changes
+| File | Action | Purpose |
+|------|--------|---------|
+| `EHG_Engineer/server/routes/stage19.js` | MODIFY | Resolve build-into vs create-new (via ventures.repo_url SSOT / resolveVentureRepoUrl, or an explicit `?mode=`) and thread `mode` into formatReplitOptimized |
+| `EHG_Engineer/lib/eva/bridge/replit-prompt-formatter.js` | MODIFY | `formatReplitOptimized(ventureId, { mode })` passes mode to the three format strategies |
+| `EHG_Engineer/lib/eva/bridge/replit-format-strategies.js` | MODIFY | Mode-aware `formatPlanModePrompt` / `formatFeaturePrompts` / `formatReplitMd`: build-into → "continue the existing app, inspect + match its stack/routes/design system, build additively"; drop the docs/designs/ reference when build-into / no designs |
+| `ehg/src/components/stages/shared/BuildMethodSelector.tsx` | MODIFY | Pass `?mode=build-into` to the prompt route when ventures.repo_url is set; build-into variant of the static Step-2 scaffold prompt ("continue from the existing app") |
+
+## Success Criteria
+- For a venture with ventures.repo_url set (build-into), the S19 Step-2 / Plan-Mode / per-feature prompts instruct Replit to continue/build on the existing app and do NOT say "scaffold a new app" or reference docs/designs/.
+- For a repo-less venture (create-new), every prompt is byte-identical to today's output (no regression).
+- The build-into prompts reference the EHG-BUILD-CONTEXT marker + the existing app as the design source.
+- Validated against Canvas AI (build-into) and a repo-less venture (create-new) by inspecting the generated prompts.
+
+## Risks
+- Prompt regression for create-new ventures → mode-guard every change; create-new is the default and stays byte-identical.
+- Over-instructing Replit Agent (verbose prompts) → keep build-into language concise and additive.
+- Mode detection drift between frontend (ventures.repo_url) and backend → resolve mode server-side from the SSOT as the source of truth; treat the frontend `?mode=` as a hint only.
+- No new backend repo-cloning in the prompt route (latency/auth) → delegate introspection to Replit Agent via prompt language.
+
+## Tasks
+- [ ] FR-1: thread build-into mode to the prompt generators (server-side resolve from ventures.repo_url; optional `?mode=` hint from the frontend)
+- [ ] FR-2: mode-aware prompt language (build-into = continue/extend the existing app; inspect + match its stack/routes/design system; build additively; never scaffold)
+- [ ] FR-3: build-into prompts use the existing app + EHG-BUILD-CONTEXT marker as the design reference and drop the empty docs/designs/ reference
+- [ ] FR-4: build-into variant of the static Step-2 scaffold prompt (BuildMethodSelector.tsx)
+- [ ] FR-5: create-new behavior byte-identical (no regression for repo-less ventures)
+- [ ] Validate generated prompts for Canvas AI (build-into) + a repo-less venture (create-new)

--- a/docs/plans/converge-venture-build-claude-code-model.md
+++ b/docs/plans/converge-venture-build-claude-code-model.md
@@ -1,0 +1,43 @@
+# Finalize the Claude-Code-from-repo venture build model + Stage-0 app-type capture
+
+## Type
+feature
+
+## Priority
+medium
+
+## Summary
+Finish the cost-pivot rewiring of the venture build/deploy path that was started but never completed. Building a venture's features is governed by the **venture stage pipeline (S17–S26, incl. the S20 Code Quality Gate)** — NOT by LEO platform SDs. So the single venture build model is: **Lovable conduits the Stitch landing → GitHub; Claude Code builds the rest from the Claude-Code-ready seeded repo (`CLAUDE.md` + `docs/build-tasks.md` + `.replit`); Replit hosts.** This SD makes that model honest, gives it a real completion gate, and adds the missing front-end capture of the venture's target platform. It does NOT generate LEO SDs per venture-feature (a rejected, separately-attempted-and-cancelled approach that conflates building-the-factory with building-the-products).
+
+## Scope
+Cross-repo (EHG app frontend + EHG_Engineer backend/worker/DB-config). Four focused changes:
+
+- **FR-1 — Build-model honesty.** Correct the stale pre-pivot semantics: the build model is "Claude Code builds from the seeded repo; Replit hosts," NOT "Replit Agent builds." Drop the build-method selector in `ehg/src/components/stages/shared/BuildMethodSelector.tsx`; fix the misleading comment in `lib/eva/stage-execution-worker.js` `_postStageHook_S19_Bridge`; update the `lifecycle_stage_config` S19 row description (drop `build_method: replit_agent` framing). The `replit_agent` SD-bridge skip STAYS (no SDs by design under model (b)).
+- **FR-2 — Real completion gate.** Gate the S19→S20 advance on `docs/build-tasks.md` build-task completeness (the features are actually built), not merely on a registered deployment URL. The existing S20 Code Quality Gate (npm audit/lint/tests on the real repo) remains the downstream validator.
+- **FR-3 — Stage-0 app-type capture.** Add a front-end control at Stage 0 to set `ventures.target_platform` (web | mobile | both). The backend already consumes this column (`lib/eva/bridge/replit-prompt-formatter.js`, `mobile-security-defaults.js`) to select Expo/mobile vs web templates; only the capture UI is missing (it currently defaults to `web`). Surface the existing decision rubric (`docs/reference/target-platform-decision-rubric.md`) as guidance.
+- **FR-4 — Cleanup.** Delete the dead/legacy `ehg/src/types/workflowStages.ts` (the live SSOT is `ehg/src/config/venture-workflow.ts`, already aligned to the marketing-first pipeline) — after confirming zero imports.
+
+## Key Changes
+- Relabel/clarify the venture build model across UI + worker comment + stage config (FR-1).
+- New build-completeness gate at S19 advance, keyed off `docs/build-tasks.md` (FR-2).
+- New Stage-0 UI control writing `ventures.target_platform` (FR-3).
+- Remove dead `workflowStages.ts` (FR-4).
+
+## Success Criteria
+- No surface refers to the venture build as "Replit Agent builds"; the single model is "Claude Code builds from the seeded repo, Replit hosts"; the build-method selector is gone.
+- S19→S20 advance is blocked until the seeded `docs/build-tasks.md` tasks are complete (not merely a registered URL).
+- A venture's `target_platform` (web/mobile/both) is settable from the Stage-0 UI and flows to the backend template selection that already consumes it.
+- `workflowStages.ts` is removed with no broken imports; `venture-workflow.ts` remains the SSOT.
+
+## Out of Scope
+- NO generation of LEO Strategic Directives for venture builds (the rejected model (c)); `lib/eva/lifecycle-sd-bridge.js` stays unused for ventures.
+- NO changes to the already-live backend platform-branching, Expo templates, mobile-security defaults, marketing-first S18–S26 pipeline, or the venture→LEO bridge.
+- The register-deployment 3-layer live fix (service-role client in `server/routes/stage19.js` + the two `ehg/supabase/migrations/` files already applied to prod) ships as a SEPARATE QF/PR, not in this SD.
+- Retiring the obsolete `replit_agent` skip + re-entry-adapter machinery is a possible follow-up only if it proves to be dead code (guarded deletion with tests), not part of this SD.
+
+## Risks
+- `docs/build-tasks.md`-based completion gating needs a reliable "task done" signal; design it to degrade safely (don't hard-block on a parse failure).
+- Deleting `workflowStages.ts` requires a verified zero-import check first (legacy type file; confirm nothing imports it).
+
+## Vision
+VISION-S19-CLAUDE-CODE-READY-REPO-L2-001 (arch: ARCH-S19-CLAUDE-CODE-READY-REPO-001)


### PR DESCRIPTION
## Summary
Commits 5 untracked documentation files that belong in version control. Everything else untracked in the working tree (`.claude/` session state, `scripts/one-off/*` SD execution scaffolding) is local/throwaway and intentionally left out.

## Files
- **`docs/plans/converge-venture-build-claude-code-model.md`** (new design doc) — active reference for the venture build model: Lovable conduits the Stitch landing → GitHub, Claude Code builds the rest from the Claude-Code-ready seeded repo, Replit hosts. Adds Stage-0 target-platform capture.
- `docs/plans/archived/sd-leo-feat-finalize-claude-code-001-plan.md`
- `docs/plans/archived/sd-leo-feat-s17-lovable-build-001-plan.md`
- `docs/plans/archived/sd-leo-feat-s19-builds-into-001-plan.md`
- `docs/plans/archived/sd-leo-feat-stage-replit-prompts-001-plan.md`

The four archived docs are SD plan records left untracked after their SDs completed, and match the existing `docs/plans/archived/` convention (100+ similar plan docs already tracked).

## Notes
- Docs-only, +229/-0. No code, no DB, no behavior change.
- Branch type `docs/` — exempt from smoke tests; passed all other pre-commit gates (secret scan, DOCMON database-first, script-reference protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
