### PR TITLE
feat(leo-stack): pull latest origin/main for both repos before starting servers

### DIFF
--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -512,10 +512,70 @@ function Test-StackHealth {
     }
 }
 
+# Git freshness — ensure a repo serves the latest origin/main before the server
+# starts. leo-stack restart restarts the *processes* but historically never pulled,
+# so the dev servers served whatever the local working tree happened to be on. That
+# is why merged work could be invisible in the running app (e.g. CronLinter showed
+# the retired Stage-19 build-method UI because the ehg tree was behind the commit
+# that removed it). Fast-forward only when safely on a clean `main`; otherwise warn
+# and serve local — never clobber a feature branch or uncommitted work. Opt out via
+# LEO_STACK_NO_PULL=1.
+function Sync-Repo {
+    param([string]$Dir, [string]$Name)
+    if (-not (Test-Path $Dir)) {
+        Write-Log "WARN" "[SYNC] $Name dir not found ($Dir) - skipping" "Yellow"
+        return
+    }
+    Push-Location $Dir
+    try {
+        $branch = (git rev-parse --abbrev-ref HEAD 2>$null)
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "WARN" "[SYNC] $Name is not a git repo - skipping" "Yellow"
+            return
+        }
+        if ($branch -ne "main") {
+            Write-Log "WARN" "[SYNC] $Name on '$branch' (not main) - serving local, not auto-pulling" "Yellow"
+            return
+        }
+        # No pre-emptive dirty check: rely on `merge --ff-only`, which fast-forwards
+        # cleanly when uncommitted files (e.g. the perpetually-churned .claude/.protocol-sync)
+        # are NOT in the incoming diff, and safely aborts (never clobbers) when they are.
+        git fetch origin main --quiet 2>$null
+        $behind = (git rev-list --count HEAD..origin/main 2>$null)
+        if ($behind -match '^\d+$' -and [int]$behind -gt 0) {
+            Write-Log "INFO" "[SYNC] $Name is $behind commit(s) behind origin/main - fast-forwarding..." "Blue"
+            git merge --ff-only origin/main --quiet 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Log "INFO" "[SYNC] $Name updated to $(git rev-parse --short HEAD)" "Green"
+            } else {
+                Write-Log "WARN" "[SYNC] $Name ff-only merge declined (diverged or local changes conflict) - serving local" "Yellow"
+            }
+        } else {
+            Write-Log "INFO" "[SYNC] $Name already current with origin/main" "Green"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Sync-Repos {
+    if ($env:LEO_STACK_NO_PULL -eq "1") {
+        Write-Log "WARN" "[SYNC] LEO_STACK_NO_PULL=1 - skipping repo freshness check (serving local)" "Yellow"
+        return
+    }
+    Write-Log "INFO" "[SYNC] Ensuring repos are current with origin/main..." "Blue"
+    Sync-Repo -Dir $EngineerDir -Name "EHG_Engineer"
+    Sync-Repo -Dir $AppDir -Name "EHG App (ehg)"
+}
+
 # Function to start all servers
 function Start-AllServers {
     $modeText = if ($Fast) { "(FAST MODE)" } else { "" }
     Write-Log "INFO" "[START] Starting LEO Stack $modeText..." "Blue"
+    Write-Host "=================================="
+
+    # Pull latest origin/main for both repos so the servers never serve stale code.
+    Sync-Repos
     Write-Host "=================================="
 
     # Optional hard reset of the EHG App Vite optimize cache (opt-in via -ClearViteCache)

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -370,12 +370,66 @@ status() {
 }
 
 # Function to start all servers
+# Git freshness — see leo-stack.ps1 Sync-Repo for the full rationale. restart
+# restarts the processes but historically never pulled, so the dev servers served
+# whatever the local working tree was on (merged work could be invisible in the
+# running app). Fast-forward only when safely on a clean `main`; otherwise warn and
+# serve local — never clobber a feature branch or uncommitted work. Opt out via
+# LEO_STACK_NO_PULL=1.
+sync_repo() {
+    local dir="$1"
+    local name="$2"
+    if [ ! -e "$dir/.git" ]; then
+        log "WARN" "${YELLOW}[SYNC] $name is not a git repo - skipping${NC}"
+        return
+    fi
+    (
+        cd "$dir" || exit 0
+        local branch
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+        if [ "$branch" != "main" ]; then
+            log "WARN" "${YELLOW}[SYNC] $name on '$branch' (not main) - serving local, not auto-pulling${NC}"
+            exit 0
+        fi
+        # No pre-emptive dirty check: rely on `merge --ff-only`, which fast-forwards
+        # cleanly when uncommitted files (e.g. the perpetually-churned .claude/.protocol-sync)
+        # are NOT in the incoming diff, and safely aborts (never clobbers) when they are.
+        git fetch origin main --quiet 2>/dev/null
+        local behind
+        behind=$(git rev-list --count HEAD..origin/main 2>/dev/null)
+        if [ -n "$behind" ] && [ "$behind" -gt 0 ] 2>/dev/null; then
+            log "INFO" "${BLUE}[SYNC] $name is $behind commit(s) behind origin/main - fast-forwarding...${NC}"
+            if git merge --ff-only origin/main --quiet 2>/dev/null; then
+                log "INFO" "${GREEN}[SYNC] $name updated to $(git rev-parse --short HEAD)${NC}"
+            else
+                log "WARN" "${YELLOW}[SYNC] $name ff-only merge declined (diverged or local changes conflict) - serving local${NC}"
+            fi
+        else
+            log "INFO" "${GREEN}[SYNC] $name already current with origin/main${NC}"
+        fi
+    )
+}
+
+sync_repos() {
+    if [ "$LEO_STACK_NO_PULL" = "1" ]; then
+        log "WARN" "${YELLOW}[SYNC] LEO_STACK_NO_PULL=1 - skipping repo freshness check (serving local)${NC}"
+        return
+    fi
+    log "INFO" "${BLUE}[SYNC] Ensuring repos are current with origin/main...${NC}"
+    sync_repo "$ENGINEER_DIR" "EHG_Engineer"
+    sync_repo "$APP_DIR" "EHG App (ehg)"
+}
+
 start_all() {
     local mode_text=""
     if [ "$FAST_MODE" = true ]; then
         mode_text="(FAST MODE)"
     fi
     log "INFO" "${BLUE}[START] Starting LEO Stack $mode_text...${NC}"
+    echo "=================================="
+
+    # Pull latest origin/main for both repos so the servers never serve stale code.
+    sync_repos
     echo "=================================="
 
     # Clean up any existing processes


### PR DESCRIPTION
## Problem
`leo-stack restart` restarts the *processes* but never `git pull`s, so the dev servers serve whatever the local working trees happen to be on. Merged work becomes invisible in the running app — e.g. **CronLinter showed the retired Stage-19 build-method UI** because the local `ehg` tree was behind the commit (`#644`) that removed it. This is the systemic "restart shows old versions" gap.

## Fix
Add `Sync-Repos` to `Start-AllServers` / `start_all` (runs on every start **and** restart): for `EHG_Engineer` and `ehg`, when on a clean-enough `main`, `git fetch` + `git merge --ff-only origin/main`.

**Safety:**
- **Feature branch → skip** (never clobbers a session's WIP / worktree branch).
- **Relies on `merge --ff-only`** instead of a pre-emptive dirty check — so it still pulls when an *unrelated* uncommitted file is present (notably the perpetually-churned `.claude/.protocol-sync`, which would otherwise block every pull), and safely **declines (serves local)** if the pull would conflict or the branch diverged.
- **Opt out** with `LEO_STACK_NO_PULL=1`.

Parity across `leo-stack.ps1` (Windows) + `leo-stack.sh` (bash).

## Verified
- `bash -n` + PowerShell `Parser::ParseFile` pass on both scripts.
- `Sync-Repos` run against the live repos: reports "already current" for both; the `LEO_STACK_NO_PULL=1` opt-out and the dirty-but-current path both behave correctly (the dirty `.protocol-sync` no longer blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)