### PR TITLE
feat(leo-stack): only auto-pull a genuinely-idle primary tree (protect WIP)

### DIFF
--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -537,21 +537,32 @@ function Sync-Repo {
             Write-Log "WARN" "[SYNC] $Name on '$branch' (not main) - serving local, not auto-pulling" "Yellow"
             return
         }
-        # No pre-emptive dirty check: rely on `merge --ff-only`, which fast-forwards
-        # cleanly when uncommitted files (e.g. the perpetually-churned .claude/.protocol-sync)
-        # are NOT in the incoming diff, and safely aborts (never clobbers) when they are.
+        # Only pull a genuinely-idle primary tree. Two layers:
+        #  (1) skip if there are uncommitted *tracked* changes beyond the auto-churn
+        #      safelist (.claude/.protocol-sync) — protects a session actively editing
+        #      in the primary tree, without the safelisted file blocking every pull.
+        #      Untracked files are ignored: ff-only can't harm them and the tree
+        #      always carries many (scripts/one-off/, etc.).
+        #  (2) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
         git fetch origin main --quiet 2>$null
         $behind = (git rev-list --count HEAD..origin/main 2>$null)
-        if ($behind -match '^\d+$' -and [int]$behind -gt 0) {
-            Write-Log "INFO" "[SYNC] $Name is $behind commit(s) behind origin/main - fast-forwarding..." "Blue"
-            git merge --ff-only origin/main --quiet 2>$null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Log "INFO" "[SYNC] $Name updated to $(git rev-parse --short HEAD)" "Green"
-            } else {
-                Write-Log "WARN" "[SYNC] $Name ff-only merge declined (diverged or local changes conflict) - serving local" "Yellow"
-            }
-        } else {
+        if (-not ($behind -match '^\d+$' -and [int]$behind -gt 0)) {
             Write-Log "INFO" "[SYNC] $Name already current with origin/main" "Green"
+            return
+        }
+        $meaningful = @(git status --porcelain --untracked-files=no 2>$null |
+            Where-Object { $_ -and ($_ -notmatch '\.claude[\\/]\.protocol-sync') })
+        if ($meaningful.Count -gt 0) {
+            $files = ($meaningful | ForEach-Object { ($_ -replace '^...', '').Trim() }) -join ', '
+            Write-Log "WARN" "[SYNC] $Name is $behind behind but has uncommitted edits ($files) - NOT pulling, protecting in-progress work (commit/stash to update)" "Yellow"
+            return
+        }
+        Write-Log "INFO" "[SYNC] $Name is $behind commit(s) behind origin/main - fast-forwarding..." "Blue"
+        git merge --ff-only origin/main --quiet 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "INFO" "[SYNC] $Name updated to $(git rev-parse --short HEAD)" "Green"
+        } else {
+            Write-Log "WARN" "[SYNC] $Name ff-only merge declined (diverged or local changes conflict) - serving local" "Yellow"
         }
     } finally {
         Pop-Location

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -391,21 +391,32 @@ sync_repo() {
             log "WARN" "${YELLOW}[SYNC] $name on '$branch' (not main) - serving local, not auto-pulling${NC}"
             exit 0
         fi
-        # No pre-emptive dirty check: rely on `merge --ff-only`, which fast-forwards
-        # cleanly when uncommitted files (e.g. the perpetually-churned .claude/.protocol-sync)
-        # are NOT in the incoming diff, and safely aborts (never clobbers) when they are.
+        # Only pull a genuinely-idle primary tree. Two layers:
+        #  (1) skip if there are uncommitted *tracked* changes beyond the auto-churn
+        #      safelist (.claude/.protocol-sync) — protects a session actively editing
+        #      in the primary tree, without the safelisted file blocking every pull.
+        #      Untracked files are ignored (ff-only can't harm them; the tree carries many).
+        #  (2) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
         git fetch origin main --quiet 2>/dev/null
         local behind
         behind=$(git rev-list --count HEAD..origin/main 2>/dev/null)
-        if [ -n "$behind" ] && [ "$behind" -gt 0 ] 2>/dev/null; then
-            log "INFO" "${BLUE}[SYNC] $name is $behind commit(s) behind origin/main - fast-forwarding...${NC}"
-            if git merge --ff-only origin/main --quiet 2>/dev/null; then
-                log "INFO" "${GREEN}[SYNC] $name updated to $(git rev-parse --short HEAD)${NC}"
-            else
-                log "WARN" "${YELLOW}[SYNC] $name ff-only merge declined (diverged or local changes conflict) - serving local${NC}"
-            fi
-        else
+        if [ -z "$behind" ] || ! [ "$behind" -gt 0 ] 2>/dev/null; then
             log "INFO" "${GREEN}[SYNC] $name already current with origin/main${NC}"
+            exit 0
+        fi
+        local meaningful
+        meaningful=$(git status --porcelain --untracked-files=no 2>/dev/null | grep -vE '\.claude/\.protocol-sync')
+        if [ -n "$meaningful" ]; then
+            local files
+            files=$(echo "$meaningful" | sed 's/^...//' | paste -sd ',' -)
+            log "WARN" "${YELLOW}[SYNC] $name is $behind behind but has uncommitted edits ($files) - NOT pulling, protecting in-progress work (commit/stash to update)${NC}"
+            exit 0
+        fi
+        log "INFO" "${BLUE}[SYNC] $name is $behind commit(s) behind origin/main - fast-forwarding...${NC}"
+        if git merge --ff-only origin/main --quiet 2>/dev/null; then
+            log "INFO" "${GREEN}[SYNC] $name updated to $(git rev-parse --short HEAD)${NC}"
+        else
+            log "WARN" "${YELLOW}[SYNC] $name ff-only merge declined (diverged or local changes conflict) - serving local${NC}"
         fi
     )
 }


### PR DESCRIPTION
Hardens the restart git-freshness (#3939) so it never fast-forwards a primary tree a session is actively editing.

## Behavior
Before pulling, **skip if there are uncommitted *tracked* changes beyond the auto-churn safelist** (`.claude/.protocol-sync`); log which files held the pull.

**Two layers:**
1. **NEW dirty-aware skip** — protects a session editing directly in the primary tree, while the safelist keeps the perpetually-churned `.protocol-sync` from blocking *every* pull. Untracked files are ignored (`--ff-only` can't harm them; the tree always carries many one-offs).
2. **`merge --ff-only` backstop** — still never clobbers; aborts on real conflict.

## Why not "skip if any session is active"?
There are usually 5–7 active sessions, so that would *never* pull and kill the feature. The precise signal is *"the primary tree has real uncommitted edits"*, checked directly here. (Parallel sessions in their own worktrees were never in scope — `Sync-Repos` only touches the two primary trees.)

## Verified
- Scratch-repo test: clean+behind → **pulls**; tracked edit (`file.txt`)+behind → **NOT pulling**; only-`.protocol-sync`-dirty+behind → **pulls and preserves** the dirty file.
- `bash -n` + PowerShell parse pass on both scripts. Parity `leo-stack.ps1` + `leo-stack.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)