### PR TITLE
feat(s19-seed): sync design-prompts with S17 — landing-aware audits + Feedback page

### DIFF
--- a/lib/eva/bridge/build-tasks-writer.js
+++ b/lib/eva/bridge/build-tasks-writer.js
@@ -70,7 +70,8 @@ export function buildBuildTasks(ctx = {}) {
   const promptsGuide =
     '> For each page below: follow **Prompt 1** in `docs/design-prompts.md` (it inherits ' +
     "the landing page's design system), then run **Prompts 2-4** (typography, layout, and " +
-    "build-quality audits). Fill Prompt 1's brief from the matching screen in `docs/wireframes.md`.";
+    "build-quality audits). Fill Prompt 1's brief from the matching screen in `docs/wireframes.md`. " +
+    "Every venture also ships a **Feedback page** — build it with **Prompt 5**.";
 
   let child2;
   if (screens.length === 0) {
@@ -112,6 +113,11 @@ ${promptsGuide}${landingNote}
 ${grandchildren}`;
     }
   }
+
+  // Every venture ships a Feedback page (docs/design-prompts.md Prompt 5), regardless
+  // of which wireframe screens exist — append it as a required Child-2 task.
+  child2 += `
+- [ ] **Feedback page (required in every venture)** — build the \`/feedback\` page following \`docs/design-prompts.md\` **Prompt 5**; wire the landing footer "Feedback" link to it.`;
 
   const child3 = `
 

--- a/lib/eva/bridge/claude-md-writer.js
+++ b/lib/eva/bridge/claude-md-writer.js
@@ -42,6 +42,7 @@ export function buildClaudeMd(ctx = {}) {
 - **You (Claude Code) build the features here, in this repo**, and commit/push to GitHub. **Replit hosts** the result (it pulls from GitHub). Do **not** rely on the Replit AI Agent — it is metered, undoes Claude Code's work, and has removed load-bearing packages it deemed "orphaned." Keep it OFF this repo.
 - Work through **\`docs/build-tasks.md\`** in order (orchestrator → children → grandchildren); do one grandchild task at a time, commit, move on. Lead task is always "discover current state" — do not assume the repo is unbuilt.
 - **Building an additional page?** Follow **\`docs/design-prompts.md\`**: use **Prompt 1** (it inherits the landing page's design system from \`src/routes/index.tsx\`) to create the page, then run **Prompts 2-4** (typography, layout, and build-quality audits). The landing page was built by Lovable — do **not** rebuild it.
+- **Every venture ships a Feedback page.** Build the \`/feedback\` page with **Prompt 5** in \`docs/design-prompts.md\` and wire the landing footer "Feedback" link to it.
 - Keep changes **additive and scoped**; match the existing design system and conventions.
 
 ## Backend: Replit-native ONLY — never Supabase

--- a/lib/eva/bridge/design-prompts-writer.js
+++ b/lib/eva/bridge/design-prompts-writer.js
@@ -3,16 +3,20 @@
  * SD-S17S19-LANDINGFIRST-BUILD-TRIM-ORCH-001-B (Child B / FR-1)
  *
  * Pure builder: returns the contents of the venture repo's `docs/design-prompts.md`
- * — the four reusable, product-agnostic design prompts the venture builder (Claude
- * Code) uses to build the venture's ADDITIONAL pages at Stage 19, after Lovable has
- * built the landing page. Prompt 1 creates a new page that inherits the landing's
- * design system; Prompts 2-4 are complementary audits (text/typography, layout, and
- * build quality).
+ * — the reusable, product-agnostic design prompts the venture builder (Claude Code)
+ * uses to build the venture's ADDITIONAL pages at Stage 19, after Lovable has built
+ * the landing page. Prompt 1 creates a new page that inherits the landing's design
+ * system; Prompts 2-4 are complementary audits (text/typography, layout, build
+ * quality) that each LEAD with a landing-page focus; Prompt 5 is the required
+ * Feedback page every venture ships.
  *
- * These are mirrored verbatim from the ehg frontend
- * (src/components/stage17/gvos/designPrompts.ts → DESIGN_PROMPTS). Kept as the single
- * backend source so the seeder can emit the doc without a cross-repo runtime
- * dependency; a unit test asserts the four labels/summaries stay in sync.
+ * Shared parts (audits 2-4 + Feedback page 5) are mirrored verbatim from the ehg
+ * frontend (src/components/stage17/gvos/designPrompts.ts → DESIGN_PROMPTS). The
+ * CREATION prompt is intentionally stage-specific and NOT mirrored: S17 (ehg) leads
+ * with "Landing Page Creation" (it builds the landing page); S19 (here) leads with
+ * "New Page Creation" (the landing already exists — build the rest). Kept as the
+ * single backend source so the seeder emits the doc without a cross-repo runtime
+ * dependency; a unit test asserts the shared parts stay in sync.
  *
  * Pure (no DB / git / fs) so it is unit-testable in isolation — mirrors the existing
  * seeder helpers (buildClaudeMd, buildBuildTasks). The file write happens in
@@ -42,7 +46,8 @@ creative liberty).
 Use the prompts below for the wireframe pages **after** the landing page is designed.
 For each additional page: **follow Prompt 1** (it inherits the landing design system),
 then run **Prompts 2, 3, and 4** as audits. Fill Prompt 1's brief from the relevant
-screen section in \`docs/wireframes.md\`.
+screen section in \`docs/wireframes.md\`. Every venture also ships the **Feedback
+page (Prompt 5)** — build it even if no wireframe screen calls for it.
 
 ---
 
@@ -99,6 +104,13 @@ Text & Typography Audit
 
 You are a senior typography reviewer. Walk through every text element on the page — across every section and region — and evaluate each against the criteria below. For every issue, name the section, quote the offending text, describe the problem, and recommend a fix. (Layout, grid, and composition are audited separately — stay on text here.)
 
+Landing-page focus (apply first when this is the landing page):
+The value proposition — from the hero headline + subhead alone, can a first-time visitor say what this is, who it's for, and the outcome, in under 5 seconds? If not, that is the top finding.
+Hero hierarchy — the headline is the single loudest element above the fold; the subhead supports without competing; an eyebrow (if any) hugs the headline.
+CTA labels — action-led and specific ("Start free", "Get the API key"), never a generic primary action ("Submit", "Learn more"); the primary CTA label is identical every time it repeats.
+Scannability — section headings alone should tell the story; nothing between the visitor and the CTA reads as a wall of text.
+Trust copy — metrics and testimonials are specific and consistently formatted ("10,000+ schedules parsed", not "lots of users").
+
 Evaluate for:
 
 Hierarchy — Is the visual weight (size, color, leading, tracking) consistent with the content's importance? Does the eye know where to land first, second, third?
@@ -131,6 +143,13 @@ Specific Tailwind/CSS suggestions where applicable (e.g. text-balance, leading-[
 Layout & Composition Audit
 
 You are a senior design director reviewing this page's layout and composition. This is a structural pass — evaluate shape, grid, spacing, and alignment, not copy or typography (text is audited separately). Do this layout pass on its own; layout is the skeleton, text is the skin — if you mix them you fix kerning and never notice a whole block is the wrong shape.
+
+Landing-page focus (apply first when this is the landing page):
+Above the fold — check at 1440px AND 390px: are the value-prop headline AND the primary CTA visible without scrolling? A primary CTA below the fold on mobile is a critical finding.
+Hero silhouette sets the page — describe it; the hero's column ratio is the ratio later sections should echo. The logo-derived full-bleed background must not fight the headline — verify the contrast overlay keeps text AA-legible over the image's busiest/lightest region.
+Scroll narrative — walk hero, then proof, problem/solution, how-it-works, CTA. Do the section silhouettes relate, or does the page read as mismatched rectangles? Is there one clear conversion path rather than competing ones?
+CTA rhythm — the primary CTA appears at the hero and again near the end; flag if it is buried or if equal-weight CTAs dilute it.
+Social proof — a deliberate, evenly-weighted band (logos / metrics), not an afterthought row.
 
 Operating principles (read before starting)
 Nothing is presumed intentional. If a container is max-w-2xl centered inside a max-w-[1280px] section, that is a finding to investigate, not a stylistic choice to respect. Ask: why is this width? What does it relate to? Does it earn its negative space?
@@ -194,6 +213,13 @@ Build Quality Audit
 
 You are a senior front-end engineer reviewing whether this page ships well — beyond how it looks in a static screenshot. This pass covers performance, behavior under real/variable content, every interaction state, and both color themes. For each issue, name the section or component, describe the condition that exposes it, and recommend a fix.
 
+Landing-page focus (apply first when this is the landing page):
+LCP is the hero — on a landing page the LCP element is almost always the hero headline or hero media. Identify it; nothing above it may block render. The logo-derived full-bleed hero background MUST be a modern format (AVIF/WebP), correctly sized/responsive, with fetchpriority="high" — it is the #1 LCP and layout-shift risk.
+Primary CTA interactive immediately — no hydration delay that blocks the first click; check INP on the CTA specifically.
+Hero overlay — the WCAG-AA contrast overlay holds in BOTH themes and over the image's lightest region.
+Conversion states — the primary CTA has hover / focus-visible / active, and, if it triggers async (waitlist/signup), a pending + success state; a visitor must never click into silence.
+(Marketing copy is fixed, so dynamic-content stress matters less here — but still confirm a 2–3× longer headline and a failed hero image degrade gracefully, with reserved space and no shift.)
+
 Performance & Core Web Vitals
 The page must measure fast, not just look fast:
 Images: every image has explicit width/height or aspect-ratio so it reserves space (the #1 cause of layout shift); responsive srcset/sizes; a modern format (AVIF/WebP); loading="lazy" below the fold and fetchpriority="high" on the LCP image.
@@ -229,6 +255,29 @@ Deliver:
 A pass/fail verdict per area (performance / dynamic content / interaction states / theming).
 A prioritized list of fixes (Critical → Nice-to-have).
 Specific Tailwind/CSS suggestions where applicable (e.g. aspect-[16/9], loading="lazy", break-words, line-clamp-2, dark: variants, a theme token in place of a literal color).
+
+---
+
+## Prompt 5 — Feedback page (required in every venture)
+
+Feedback Page (required in every venture)
+Build a Feedback page at route /feedback that visually and tonally extends the landing page. Follow EVERY rule in the "New Page Creation Prompt" above (design-system inheritance, shared Nav/Footer, motion, state/validation, acceptance) — this brief only fills in its placeholders.
+
+Page brief
+Purpose: let any visitor send the team feedback in under a minute.
+Primary action: submit feedback.
+Form fields (in order):
+- Message — required, multiline textarea, 1–2000 chars, validation: must be non-empty.
+- Rating — optional, 1–5 (stars or faces).
+- Email — optional, for follow-up; validate format only if provided.
+Auxiliary actions: none.
+Trust signals adjacent to CTA: one line of reassurance (e.g. "We read every message").
+Wireframe role: form.
+
+Layout: single centered, low-distraction column (max-w-xl), matching the landing type scale, spacing rhythm, and tokens.
+State & validation: controlled inputs; disable Submit until Message is non-empty; inline, accessible per-field errors (not just a red border); show a success/confirmation state after submit; submit handler stub with e.preventDefault() and a comment marking where real submission would wire in.
+Wiring: this is the page the landing footer "Feedback" link routes to — ensure that link resolves to /feedback.
+Acceptance: renders at /feedback with no console errors; reads correctly in light AND dark themes; desktop + mobile screenshots attached; introduces no max-w-*, padding tier, or eyebrow style beyond the landing system.
 `;
 }
 

--- a/tests/unit/eva/s19-claude-code-ready-writers.test.js
+++ b/tests/unit/eva/s19-claude-code-ready-writers.test.js
@@ -87,11 +87,21 @@ describe('buildBuildTasks', () => {
 
 describe('buildDesignPrompts (FR-1)', () => {
   const md = buildDesignPrompts();
-  it('emits all four reusable prompts', () => {
+  it('emits the New Page creation prompt (S19 builds additional pages, not the landing)', () => {
     expect(md).toMatch(/New page creation|New Page Creation/);
     expect(md).toContain('Text & Typography Audit');
     expect(md).toContain('Layout & Composition Audit');
     expect(md).toContain('Build Quality Audit');
+  });
+  // Parity with the ehg S17 source (designPrompts.ts): the shared parts — the
+  // landing-page focus on every audit, and the required Feedback page — must be present.
+  it('each audit leads with a landing-page focus (in sync with S17)', () => {
+    expect(md.match(/Landing-page focus/g) || []).toHaveLength(3);
+  });
+  it('includes the required Feedback page (Prompt 5)', () => {
+    expect(md).toContain('Prompt 5');
+    expect(md).toMatch(/Feedback [Pp]age/);
+    expect(md).toContain('/feedback');
   });
   it('inherits the landing design system and does not rebuild the landing', () => {
     expect(md).toContain('src/routes/index.tsx');


### PR DESCRIPTION
## Why
The S19 seed (`docs/design-prompts.md`, built by `design-prompts-writer.js`, read by Claude Code) had **drifted** from the S17 source (`ehg designPrompts.ts`): no landing-page focus on the audits, and the **Feedback page was missing entirely** — so at Stage 19 Claude Code was never told to build `/feedback`.

## Changes (EHG_Engineer)
- **`design-prompts-writer.js`**: landing-page-focus lens on audits 2–4 (verbatim with S17) + **Prompt 5 (Feedback page)** + updated lead-in. **Prompt 1 stays "New Page Creation"** — correct for S19 (the landing already exists; build the rest). Only the *shared* parts (audits + Feedback) mirror S17; the creation prompt is intentionally stage-specific (S17 = Landing creation, S19 = New-page), now documented in the header.
- **`build-tasks-writer.js`**: append a required **Feedback page** Child-2 task (always emitted) + reference Prompt 5 — so Claude Code actually builds `/feedback`.
- **`claude-md-writer.js`**: add the Feedback-page instruction to the build playbook.
- **`s19-claude-code-ready-writers.test.js`**: assert the shared parts stay in sync — 3 landing-focus blocks + the Feedback page (Prompt 5 / `/feedback`).

## Verified
Ran the pure builders: 3 landing-focus blocks, Prompt 5 + `/feedback` present, New Page Creation retained, build-tasks emits the Feedback task. CI runs the unit suite.

Part 1 of 2 — a follow-up SD will unify the duplicated S17/S19 prompt sources (single source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)