### PR TITLE
fix(QF-20260525-049): align catch binding in search-prior-issues.js

### DIFF
--- a/scripts/search-prior-issues.js
+++ b/scripts/search-prior-issues.js
@@ -307,7 +307,7 @@ for (let i = 1; i < args.length; i++) {
       const query = args.join(' ');
       await searchIssues(query, options);
     }
-  } catch (_error) {
+  } catch (error) {
     console.error('\n❌ Error:', error.message);
     console.error('\nFull error:', error);
     process.exit(1);


### PR DESCRIPTION
## QF-20260525-049 — fix masked errors in search-prior-issues.js

### Problem
The main IIFE catch block bound the caught value to `_error` but its body referenced `error` (undefined). Any thrown error in the CLI's main path therefore produced `ReferenceError: error is not defined`, masking the real failure.

### Fix
Rename the catch binding `_error` → `error` so it matches the two references in the body (1 LOC). The unrelated catch at line 96 intentionally ignores its binding (underscore convention, no body reference) and is left unchanged.

### Verification
- `node --check scripts/search-prior-issues.js` → OK
- Confirmed no other `_error`/`error` mismatch remains in the file.

### Scope
Tier 1 quick-fix (1 LOC). Surfaced by worker signal (Delta, 2026-05-25). Not covered by PR #3822 / QF-20260521-729 (which touches only issue-knowledge-base.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
