### PR TITLE
fix(coordinator): stop sweep claim-churn on terminal SDs + cancel-sd accountability (QF-20260525-211)

### DIFF
--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -114,9 +114,36 @@ async function cancelSD(sd, reason) {
   }
   console.log(`✓ SD ${sd.sd_key} cancelled (status=cancelled, current_phase=CANCELLED)`);
 
-  // Release the holder's claude_sessions row, if any
+  // QF-20260525-211 (A1): write an audit_log row so cancellations are visible to the audit
+  // stream. Previously the reason landed ONLY in the cancellation_reason column, which
+  // coordination tooling does not surface — which is why a cancellation trace appeared
+  // missing during investigation. Non-fatal: the SD is already cancelled; a failed audit
+  // write should not mask that, but it is surfaced loudly.
+  const { error: auditErr } = await supabase
+    .from('audit_log')
+    .insert({
+      event_type: 'sd_cancelled',
+      entity_type: 'strategic_directive',
+      entity_id: sd.sd_key || sd.id,
+      old_value: { status: sd.status, current_phase: sd.current_phase, is_working_on: sd.is_working_on },
+      new_value: { status: 'cancelled', current_phase: 'CANCELLED' },
+      metadata: { reason, prior_claiming_session: claimedSessionId || null, source: 'cancel-sd.js' },
+      severity: 'warning',
+      created_by: 'cancel-sd.js',
+    });
+  if (auditErr) {
+    console.warn(`⚠️  audit_log write for ${sd.sd_key} failed (non-fatal):`, auditErr.message);
+  } else {
+    console.log(`✓ audit_log: sd_cancelled recorded for ${sd.sd_key}`);
+  }
+
+  // Release the holder's claude_sessions row, if any.
+  // QF-20260525-211 (A2): VERIFIED release. A fire-and-forget warn-and-swallow could silently
+  // fail (e.g. a CHECK violation returning 204) and leave the dangling claim that feeds the
+  // stale-session-sweep CLAIM_FIX churn. A genuine error is now fatal so the caller knows the
+  // claim was NOT released. (Zero rows affected is expected & fine — the holder already moved on.)
   if (claimedSessionId) {
-    const { error: csErr } = await supabase
+    const { data: releasedRows, error: csErr } = await supabase
       .from('claude_sessions')
       .update({
         status: 'released',
@@ -126,11 +153,16 @@ async function cancelSD(sd, reason) {
         released_at: new Date().toISOString(),
       })
       .eq('session_id', claimedSessionId)
-      .eq('sd_key', sd.sd_key);  // only release if THIS SD was the active claim
+      .eq('sd_key', sd.sd_key)  // only release if THIS SD was the active claim
+      .select('session_id');
     if (csErr) {
-      console.warn(`⚠️  claude_sessions release for ${claimedSessionId.slice(0, 8)} failed (non-fatal):`, csErr.message);
-    } else {
+      console.error(`❌ claude_sessions release for ${claimedSessionId.slice(0, 8)} FAILED:`, csErr.message);
+      console.error('   SD is cancelled but its claim was NOT released — the dangling claim will feed sweep churn. Resolve manually.');
+      process.exit(1);
+    } else if (releasedRows && releasedRows.length > 0) {
       console.log(`✓ Released claude_sessions row for holder ${claimedSessionId.slice(0, 8)}`);
+    } else {
+      console.log(`ℹ️  Holder ${claimedSessionId.slice(0, 8)} no longer claimed ${sd.sd_key} (already released) — nothing to do.`);
     }
   }
 

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -372,6 +372,52 @@ function checkNpmInstallLock() {
   }
 }
 
+/**
+ * QF-20260525-836 + QF-20260525-211 (early-exit gap): clear stale quick_fixes.claiming_session_id.
+ * Extracted from main() and called BEFORE the "No sessions with claims" early-return so an
+ * orphaned QF claim is reaped even when zero SD-claiming sessions remain — the exact common case
+ * after the fleet winds down (verified live 2026-05-25: QF-20260525-127 stayed claimed across
+ * multiple sweeps because each early-returned before this block ever ran).
+ * Conservative bar (holder gone or heartbeat > VERY_STALE) avoids yanking a live worker's claim.
+ * Degrade-safe: query failure warns, never blocks the sweep.
+ */
+async function clearStaleQfClaims(supabase, now, actions, warnings) {
+  const veryStaleSeconds = STALE_THRESHOLD_SECONDS * 3; // 15min = definitely dead
+  try {
+    const { data: claimedQfs } = await supabase
+      .from('quick_fixes')
+      .select('id, status, claiming_session_id')
+      .in('status', ['open', 'in_progress'])
+      .not('claiming_session_id', 'is', null);
+
+    if (claimedQfs && claimedQfs.length > 0) {
+      const holderIds = [...new Set(claimedQfs.map(q => q.claiming_session_id))];
+      const { data: holderRows } = await supabase
+        .from('claude_sessions')
+        .select('session_id, heartbeat_at')
+        .in('session_id', holderIds);
+      const hbAgeBySession = new Map();
+      for (const r of (holderRows || [])) {
+        hbAgeBySession.set(r.session_id, r.heartbeat_at ? (now.getTime() - Date.parse(r.heartbeat_at)) / 1000 : Infinity);
+      }
+      for (const qf of claimedQfs) {
+        const ageSec = hbAgeBySession.has(qf.claiming_session_id) ? hbAgeBySession.get(qf.claiming_session_id) : Infinity;
+        if (ageSec <= veryStaleSeconds) continue; // holder alive/recent — leave claimed
+        const { error } = await supabase
+          .from('quick_fixes')
+          .update({ claiming_session_id: null })
+          .eq('id', qf.id)
+          .eq('claiming_session_id', qf.claiming_session_id); // race guard: only if still held by the same dead session
+        if (!error) {
+          actions.push('QF: cleared stale claiming_session_id on ' + qf.status + ' ' + qf.id + ' (holder ' + String(qf.claiming_session_id).slice(0, 8) + ' hb ' + (ageSec === Infinity ? 'gone' : Math.round(ageSec) + 's') + ')');
+        }
+      }
+    }
+  } catch (qfErr) {
+    warnings.push('QF_CLAIM_SWEEP: ' + qfErr.message);
+  }
+}
+
 async function main() {
   const now = new Date();
   const actions = [];
@@ -390,8 +436,16 @@ async function main() {
     process.exit(1);
   }
 
+  // QF-20260525-211 (early-exit gap): reap orphaned QF claims BEFORE the early-return below,
+  // so a stale QF claim is cleared even when zero SD-claiming sessions remain (fleet wound down).
+  await clearStaleQfClaims(supabase, now, actions, warnings);
+
   if (!sessions || sessions.length === 0) {
-    console.log('[' + now.toLocaleTimeString() + '] SWEEP: No sessions with claims. All clear.');
+    if (actions.length > 0) {
+      console.log('[' + now.toLocaleTimeString() + '] SWEEP: ' + actions.join('; '));
+    } else {
+      console.log('[' + now.toLocaleTimeString() + '] SWEEP: No sessions with claims. All clear.');
+    }
     return;
   }
 
@@ -562,12 +616,17 @@ async function main() {
   const sdStatusMap = {};
   (claimedSdStatus || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
 
+  // QF-20260525-211 (B2): include 'cancelled', not just 'completed'. Cancelled SDs with a
+  // live claiming session previously skipped this bilateral release and fell through to the
+  // SD-only clear (FIX #2 below), leaving the session's stale sd_key to feed CLAIM_FIX churn.
   const workingOnCompleted = classified.filter(s => {
     const sd = sdStatusMap[s.sd_key];
-    return sd && sd.status === 'completed';
+    return sd && (sd.status === 'completed' || sd.status === 'cancelled');
   });
 
   for (const s of workingOnCompleted) {
+    const sdTerminalStatus = sdStatusMap[s.sd_key]?.status;
+    const releasedReason = sdTerminalStatus === 'cancelled' ? 'SWEEP_SD_CANCELLED' : 'SWEEP_SD_ALREADY_COMPLETED';
     // Use 'released' not 'idle' — stale sessions can't become 'idle' due to
     // idx_claude_sessions_unique_terminal_active (one active/idle per terminal).
     // Using 'idle' silently fails when another session on the same terminal exists.
@@ -584,7 +643,7 @@ async function main() {
         sd_key: null,
         status: targetStatus,
         released_at: now.toISOString(),
-        released_reason: 'SWEEP_SD_ALREADY_COMPLETED',
+        released_reason: releasedReason,
         worktree_path: null,
         worktree_branch: null,
         has_uncommitted_changes: false,
@@ -598,8 +657,8 @@ async function main() {
         .from('strategic_directives_v2')
         .update({ claiming_session_id: null, is_working_on: false })
         .eq('sd_key', s.sd_key);
-      await resetSdPhaseOnRelease(s.sd_key, 'SWEEP_SD_ALREADY_COMPLETED');
-      actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — ' + s.sd_key + ' already completed');
+      await resetSdPhaseOnRelease(s.sd_key, releasedReason);
+      actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — ' + s.sd_key + ' already ' + (sdTerminalStatus || 'completed'));
     }
   }
 
@@ -726,43 +785,9 @@ async function main() {
     }
   }
 
-  // QF-20260525-836: clear stale quick_fixes.claiming_session_id (mirrors the SD
-  // terminal-claim clear above) — a QF whose holder died stayed claimed forever.
-  // Conservative bar (holder gone or heartbeat >15min) avoids yanking a live-but-
-  // quiet worker's claim. Degrade-safe: query failure warns, never blocks the sweep.
-  try {
-    const { data: claimedQfs } = await supabase
-      .from('quick_fixes')
-      .select('id, status, claiming_session_id')
-      .in('status', ['open', 'in_progress'])
-      .not('claiming_session_id', 'is', null);
-
-    if (claimedQfs && claimedQfs.length > 0) {
-      const holderIds = [...new Set(claimedQfs.map(q => q.claiming_session_id))];
-      const { data: holderRows } = await supabase
-        .from('claude_sessions')
-        .select('session_id, heartbeat_at')
-        .in('session_id', holderIds);
-      const hbAgeBySession = new Map();
-      for (const r of (holderRows || [])) {
-        hbAgeBySession.set(r.session_id, r.heartbeat_at ? (now.getTime() - Date.parse(r.heartbeat_at)) / 1000 : Infinity);
-      }
-      for (const qf of claimedQfs) {
-        const ageSec = hbAgeBySession.has(qf.claiming_session_id) ? hbAgeBySession.get(qf.claiming_session_id) : Infinity;
-        if (ageSec <= VERY_STALE_SECONDS) continue; // holder alive/recent — leave claimed
-        const { error } = await supabase
-          .from('quick_fixes')
-          .update({ claiming_session_id: null })
-          .eq('id', qf.id)
-          .eq('claiming_session_id', qf.claiming_session_id); // race guard: only if still held by the same dead session
-        if (!error) {
-          actions.push('QF: cleared stale claiming_session_id on ' + qf.status + ' ' + qf.id + ' (holder ' + String(qf.claiming_session_id).slice(0, 8) + ' hb ' + (ageSec === Infinity ? 'gone' : Math.round(ageSec) + 's') + ')');
-        }
-      }
-    }
-  } catch (qfErr) {
-    warnings.push('QF_CLAIM_SWEEP: ' + qfErr.message);
-  }
+  // QF-20260525-211: the QF stale-claim clear formerly inlined here now runs via
+  // clearStaleQfClaims() before the early-return above, so it executes on every sweep
+  // (including the zero-SD-claim case). Do not re-add it here — that would double-run it.
 
   // QF-20260426-SWEEP-PHANTOM-DETECT: detect phantom in_progress SDs
   // (status=in_progress + claiming_session_id IS NULL). These are invisible to
@@ -1165,11 +1190,33 @@ async function main() {
   for (const s of classified.filter(c => c.status === 'ACTIVE' && c.sd_key)) {
     const { data: sd } = await supabase
       .from('strategic_directives_v2')
-      .select('sd_key, claiming_session_id, is_working_on')
+      .select('sd_key, status, claiming_session_id, is_working_on')
       .eq('sd_key', s.sd_key)
       .single();
 
     if (!sd) continue;
+
+    // QF-20260525-211 (B1): never re-assert a claim on a terminal SD. FIX #2 above cleared
+    // claiming_session_id on completed/cancelled SDs; without this guard CLAIM_FIX would
+    // immediately re-assert it (the live session's sd_key still matches), oscillating the
+    // claim every 5-min cycle. Instead clear the session's stale sd_key (bilateral release).
+    if (sd.status === 'completed' || sd.status === 'cancelled') {
+      await supabase
+        .from('claude_sessions')
+        .update({
+          sd_key: null,
+          status: s.status === 'ACTIVE' ? 'idle' : 'released',
+          released_at: now.toISOString(),
+          released_reason: 'SWEEP_SD_TERMINAL_CLAIM_FIX',
+          worktree_path: null,
+          worktree_branch: null,
+          current_branch: null,
+        })
+        .eq('session_id', s.session_id)
+        .eq('sd_key', s.sd_key); // race guard: only clear if still pointing at this terminal SD
+      actions.push('CLAIM_FIX: cleared stale sd_key on session ' + s.session_id.substring(0, 20) + ' (SD ' + s.sd_key + ' is ' + sd.status + ')');
+      continue;
+    }
 
     // Fix broken claim: session thinks it owns SD but SD doesn't know
     if (sd.claiming_session_id !== s.session_id) {

--- a/tests/unit/harness/cancel-sd-accountability.test.js
+++ b/tests/unit/harness/cancel-sd-accountability.test.js
@@ -1,0 +1,68 @@
+// QF-20260525-211 (A1/A2): accountability guards for cancel-sd.js.
+//   A1 — every cancellation writes an audit_log row (event_type=sd_cancelled), so the
+//        cancellation is visible to the audit stream (not only in cancellation_reason).
+//   A2 — the claude_sessions release is VERIFIED: a genuine error is fatal (process.exit)
+//        rather than warn-and-swallow, so a dangling claim can no longer silently survive
+//        and feed the stale-session-sweep CLAIM_FIX churn.
+// Static source assertions (matches cancel-sd-script.test.js convention); CI-runnable, no DB.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const scriptPath = path.join(repoRoot, 'scripts/cancel-sd.js');
+const src = fs.readFileSync(scriptPath, 'utf-8');
+
+describe('QF-20260525-211 (A1): cancel-sd.js writes an audit_log row', () => {
+  it('inserts into audit_log', () => {
+    expect(src).toMatch(/from\(['"]audit_log['"]\)\s*\n?\s*\.insert\(/);
+  });
+
+  it('uses event_type sd_cancelled on the strategic_directive entity', () => {
+    expect(src).toMatch(/event_type:\s*['"]sd_cancelled['"]/);
+    expect(src).toMatch(/entity_type:\s*['"]strategic_directive['"]/);
+  });
+
+  it('records the reason and the prior claiming session in the audit row', () => {
+    const idx = src.indexOf("event_type: 'sd_cancelled'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 500);
+    expect(block).toMatch(/reason/);
+    expect(block).toMatch(/prior_claiming_session/);
+  });
+
+  it('audit write happens AFTER the SD is cancelled (so it records a real transition)', () => {
+    const cancelLogIdx = src.indexOf('cancelled (status=cancelled, current_phase=CANCELLED)');
+    const auditIdx = src.indexOf("event_type: 'sd_cancelled'");
+    expect(cancelLogIdx).toBeGreaterThan(0);
+    expect(auditIdx).toBeGreaterThan(cancelLogIdx);
+  });
+});
+
+describe('QF-20260525-211 (A2): claude_sessions release is verified, not fire-and-forget', () => {
+  it('a release error is fatal (process.exit), not a swallowed warning', () => {
+    const idx = src.indexOf('release for ${claimedSessionId.slice(0, 8)} FAILED');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx - 100, idx + 400);
+    expect(block).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('uses .select() to verify the affected rows (distinguishes error from already-released)', () => {
+    expect(src).toMatch(/const\s*\{\s*data:\s*releasedRows,\s*error:\s*csErr\s*\}\s*=\s*await supabase/);
+    expect(src).toMatch(/\.select\(['"]session_id['"]\)/);
+  });
+
+  it('does not treat zero affected rows as a failure (holder may have already moved on)', () => {
+    expect(src).toMatch(/already released/);
+  });
+
+  it('regression-pin: the old non-fatal "(non-fatal)" swallow on the SESSION release is gone', () => {
+    // the audit write is intentionally non-fatal; the SESSION release must NOT be.
+    const sessionIdx = src.indexOf("from('claude_sessions')");
+    const sessionBlock = src.slice(sessionIdx, sessionIdx + 700);
+    expect(sessionBlock).not.toMatch(/release for \$\{claimedSessionId\.slice\(0, 8\)\} failed \(non-fatal\)/);
+  });
+});

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -1,0 +1,92 @@
+// QF-20260525-211: regression guards for the sweep claim-churn fixes.
+//   B1 — CLAIM_FIX never re-asserts a claim on a terminal (completed/cancelled) SD.
+//   B2 — workingOnCompleted bilateral-release covers cancelled, not just completed.
+//   Early-exit — the QF stale-claim clear (originally QF-20260525-836) runs BEFORE the
+//                "No sessions with claims" early-return, so it executes even with zero
+//                SD-claiming sessions (the fleet-wound-down common case).
+// Static source assertions (matches the project convention for this monolithic script —
+// see stale-sweep-cancelled-claims.test.js / cancel-sd-script.test.js); CI-runnable, no DB.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs');
+const src = readFileSync(SCRIPT, 'utf8');
+
+describe('QF-20260525-211 (B1): CLAIM_FIX terminal-status guard', () => {
+  it('CLAIM_FIX SELECT includes status so terminal SDs can be detected', () => {
+    // the broken-claim loop must read status, not just sd_key/claiming_session_id/is_working_on
+    expect(src).toMatch(/select\(\s*['"]sd_key,\s*status,\s*claiming_session_id,\s*is_working_on['"]\s*\)/);
+  });
+
+  it('skips re-assertion on terminal SDs (completed OR cancelled)', () => {
+    expect(src).toMatch(/if\s*\(\s*sd\.status === ['"]completed['"] \|\| sd\.status === ['"]cancelled['"]\s*\)/);
+  });
+
+  it('clears the live session\'s stale sd_key instead of re-asserting the claim', () => {
+    const idx = src.indexOf("released_reason: 'SWEEP_SD_TERMINAL_CLAIM_FIX'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx - 400, idx + 400);
+    expect(block).toMatch(/sd_key:\s*null/);
+    // race guard: only clear if the session still points at this terminal SD
+    expect(block).toMatch(/\.eq\(['"]sd_key['"],\s*s\.sd_key\)/);
+  });
+
+  it('uses continue to avoid falling through into the re-assert branch', () => {
+    const guardIdx = src.indexOf('SWEEP_SD_TERMINAL_CLAIM_FIX');
+    const afterGuard = src.slice(guardIdx, guardIdx + 700);
+    expect(afterGuard).toMatch(/continue;/);
+  });
+});
+
+describe('QF-20260525-211 (B2): workingOnCompleted covers cancelled', () => {
+  it('workingOnCompleted filter matches completed OR cancelled', () => {
+    const idx = src.indexOf('const workingOnCompleted');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 250);
+    expect(block).toMatch(/sd\.status === ['"]completed['"] \|\| sd\.status === ['"]cancelled['"]/);
+  });
+
+  it('release reason reflects cancellation (SWEEP_SD_CANCELLED) distinctly', () => {
+    expect(src).toMatch(/SWEEP_SD_CANCELLED/);
+    expect(src).toMatch(/releasedReason\s*=\s*sdTerminalStatus === ['"]cancelled['"]/);
+  });
+});
+
+describe('QF-20260525-211 (early-exit gap): QF claim clear runs before the early-return', () => {
+  it('clearStaleQfClaims is extracted as a standalone, callable function', () => {
+    expect(src).toMatch(/async function clearStaleQfClaims\(supabase, now, actions, warnings\)/);
+  });
+
+  it('clearStaleQfClaims is invoked BEFORE the "No sessions with claims" early-return', () => {
+    const callIdx = src.indexOf('await clearStaleQfClaims(supabase, now, actions, warnings)');
+    // target the actual early-return console.log, not the docstring mention of the phrase
+    const earlyReturnIdx = src.indexOf('No sessions with claims. All clear.');
+    expect(callIdx).toBeGreaterThan(0);
+    expect(earlyReturnIdx).toBeGreaterThan(0);
+    expect(callIdx).toBeLessThan(earlyReturnIdx);
+  });
+
+  it('the early-return path flushes accumulated actions (so a cleared QF claim is reported)', () => {
+    // when sessions is empty, print accumulated actions if any exist, else "All clear"
+    expect(src).toMatch(/if\s*\(\s*!sessions[\s\S]{0,200}actions\.length > 0[\s\S]{0,200}No sessions with claims/);
+  });
+
+  it('does NOT double-run: the inline QF clear block was removed from main()', () => {
+    // exactly one definition site (the helper), and the old inline VERY_STALE_SECONDS gate is gone
+    expect(src.match(/from\(['"]quick_fixes['"]\)\s*\n\s*\.select\(['"]id, status, claiming_session_id['"]\)/g) || []).toHaveLength(1);
+    expect(src).not.toMatch(/if\s*\(ageSec <= VERY_STALE_SECONDS\)/);
+  });
+
+  it('preserves QF-836 safety: race guard + conservative staleness bar', () => {
+    const idx = src.indexOf('async function clearStaleQfClaims');
+    const fn = src.slice(idx, idx + 1600);
+    // only clear if still held by the same (dead) session
+    expect(fn).toMatch(/\.eq\(['"]claiming_session_id['"],\s*qf\.claiming_session_id\)/);
+    // leave alive/recent holders alone
+    expect(fn).toMatch(/if\s*\(ageSec <= veryStaleSeconds\)\s*continue;/);
+    // only open/in_progress QFs are candidates
+    expect(fn).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]open['"]\s*,\s*['"]in_progress['"]\s*\]/);
+  });
+});


### PR DESCRIPTION
## QF-20260525-211 — Sweep claim-churn + cancel-sd accountability

RCA-backed (rca-agent acedf44f, confidence 0.94). Two latent coordinator/lifecycle defects.

### `stale-session-sweep.cjs`
- **B1 — CLAIM_FIX terminal-status guard.** The broken-claim loop now reads SD `status` and never re-asserts `claiming_session_id` on a terminal (completed/cancelled) SD. It clears the live session's stale `sd_key` instead (bilateral release, race-guarded on `sd_key`). Previously FIX #2 cleared the SD claim and CLAIM_FIX immediately re-asserted it every 5-min cycle (the live session's `sd_key` still matched).
- **B2 — `workingOnCompleted` covers cancelled.** Bilateral release now triggers for cancelled SDs, not only completed; release reason is reported distinctly (`SWEEP_SD_CANCELLED`).
- **Early-exit gap.** The QF stale-claim clear (originally QF-20260525-836) is extracted into `clearStaleQfClaims()` and called **before** the "No sessions with claims" early-return, so an orphaned QF claim is reaped even when zero SD-claiming sessions remain (verified live: a released-holder QF stayed claimed across multiple sweeps because each early-returned first). The early-return path now flushes accumulated actions. QF-836 safety preserved (race guard + conservative >15min staleness bar); no double-run.

### `cancel-sd.js`
- **A1 — audit accountability.** Writes an `audit_log` row (`event_type=sd_cancelled`) recording the reason and prior claiming session, so cancellations are visible to the audit stream instead of landing only in the `cancellation_reason` column. Non-fatal (the SD is already cancelled).
- **A2 — verified release.** The `claude_sessions` release is now verified via `.select()` — a genuine error is fatal (`process.exit(1)`) instead of warn-and-swallow, so a dangling claim can no longer silently survive and feed sweep churn. Zero affected rows is treated as "already released", not a failure.

### Tests
Static source-assertion regressions (project convention for this monolithic script — see `stale-sweep-cancelled-claims.test.js` / `cancel-sd-script.test.js`); CI-runnable, no DB:
- `tests/unit/stale-sweep-qf211-claim-guards.test.js` (11) — B1/B2, early-exit relocation + no-double-run, QF-836 safety.
- `tests/unit/harness/cancel-sd-accountability.test.js` (8) — audit_log contract + verified-release contract.

All 19 new + 22 sibling sweep/cancel tests pass.

### Notes
- No database structure change; no behavior change for active or genuinely-blocked SDs.
- Source churn (+287/-48 total incl. tests) exceeds the Tier-2 75-source-LOC cap, almost entirely due to **relocation churn** (extracting the inline QF-claim-clear into a testable helper) plus the coordinator-appended early-exit-gap addendum — not new feature surface. No auth/schema/migration risk keywords.
- Follow-up (separate SD, not this QF): a canonical `lib/sd/cancel.js` enforcing the bilateral cancellation contract for all callers (`blocked-state-detector.js`, `update-directive-status.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
