### PR TITLE
feat(SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001): twinned cross-repo design-prompts parity gate + gate-integrity fix (Phase 3)

### DIFF
--- a/.github/workflows/design-prompts-cross-repo.yml
+++ b/.github/workflows/design-prompts-cross-repo.yml
@@ -1,0 +1,60 @@
+name: Design Prompts Cross-Repo Parity
+
+# SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 (Phase 3) — twinned advisory gate.
+#
+# The shared design-prompt bodies (the 3 design audits + the required Feedback
+# page) are vendored byte-equivalent into both repos: S17 (rickfelix/ehg UI,
+# src/components/stage17/gvos/shared-design-prompts.json) and S19 (here,
+# lib/eva/bridge/shared-design-prompts.json). This runs on PRs that touch the
+# shared source or its tooling, shallow-clones the sibling rickfelix/ehg repo,
+# and compares canonical checksums so the two copies can never silently diverge
+# (the QF/PR #3941 class of drift). The twin workflow lives in rickfelix/ehg and
+# triggers on the frontend copy.
+#
+# ADVISORY: continue-on-error: true. Flip to blocking (remove that line + add
+# "Design Prompts Cross-Repo Parity" to required status checks) in a 1-line
+# follow-up once the false-positive rate is confirmed ~0.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/eva/bridge/shared-design-prompts.json'
+      - 'lib/eva/bridge/shared-design-prompts.sha256'
+      - 'lib/eva/bridge/design-prompts-writer.js'
+      - 'scripts/design-prompts-sync.mjs'
+      - 'scripts/design-prompts-cross-repo-check.mjs'
+      - '.github/workflows/design-prompts-cross-repo.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true  # ADVISORY; remove this line to make blocking
+    steps:
+      - name: Checkout EHG_Engineer
+        uses: actions/checkout@v4
+
+      - name: Checkout sibling EHG repo
+        uses: actions/checkout@v4
+        with:
+          repository: rickfelix/ehg
+          path: ehg-sibling
+          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Compare shared design-prompts checksum across repos
+        run: node scripts/design-prompts-cross-repo-check.mjs ehg-sibling/src/components/stage17/gvos/shared-design-prompts.json
+
+      - name: Note about advisory mode
+        if: failure()
+        run: |
+          echo "::warning ::S17/S19 shared design-prompts diverged. This gate is in advisory mode (continue-on-error). Re-vendor the shared JSON into both repos and run 'npm run design-prompts:sync'. See SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001."

--- a/scripts/design-prompts-cross-repo-check.mjs
+++ b/scripts/design-prompts-cross-repo-check.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * design-prompts-cross-repo-check — advisory cross-repo parity gate.
+ * SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 (Phase 3, advisory)
+ *
+ * The shared design-prompt bodies (the 3 design audits + the Feedback page) are
+ * vendored byte-equivalent into BOTH repos — S17 (ehg UI:
+ * src/components/stage17/gvos/shared-design-prompts.json) and S19 (here:
+ * lib/eva/bridge/shared-design-prompts.json). This compares THIS repo's canonical
+ * checksum against the sibling copy (path passed as argv[2]) and exits non-zero on
+ * divergence, so the twinned CI workflow can flag drift. A twin script + workflow
+ * live in rickfelix/ehg.
+ *
+ * Uses the same canonicalChecksum the freshness gate uses (parse + NFC + compact
+ * stringify + sha256) so the comparison is apples-to-apples across repos.
+ *
+ * Advisory for now (the CI job runs continue-on-error: true). Flip to blocking by
+ * removing that line + adding the check to required status checks once the
+ * false-positive rate is confirmed ~0.
+ *
+ *   node scripts/design-prompts-cross-repo-check.mjs <path-to-sibling-shared-json>
+ */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { canonicalChecksum } from './design-prompts-sync.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const LOCAL = join(here, '..', 'lib', 'eva', 'bridge', 'shared-design-prompts.json');
+const siblingPath = process.argv[2];
+
+if (!siblingPath) {
+  console.error('usage: design-prompts-cross-repo-check.mjs <sibling-shared-design-prompts.json>');
+  process.exit(2);
+}
+
+const local = canonicalChecksum(readFileSync(LOCAL, 'utf8'));
+let sibling;
+try {
+  sibling = canonicalChecksum(readFileSync(siblingPath, 'utf8'));
+} catch (e) {
+  console.error(`::warning ::cannot read sibling shared design-prompts at ${siblingPath}: ${e.message}`);
+  process.exit(2);
+}
+
+if (local !== sibling) {
+  console.log(`::warning ::S17/S19 shared design-prompts DIVERGED — this repo ${local} vs sibling ${sibling}. The 3 audits + Feedback page are out of sync across repos; re-vendor the shared JSON into both and run \`npm run design-prompts:sync\`. (advisory — will block once promoted)`);
+  process.exit(1);
+}
+console.log(`[design-prompts cross-repo] OK — S17 == S19 — ${local}`);

--- a/scripts/design-prompts-sync.mjs
+++ b/scripts/design-prompts-sync.mjs
@@ -13,7 +13,7 @@
  *   node scripts/design-prompts-sync.mjs            # write the checksum
  *   node scripts/design-prompts-sync.mjs --check    # exit 1 if the checksum is stale
  */
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, realpathSync } from 'fs';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -30,18 +30,28 @@ export function canonicalChecksum(jsonText) {
   return createHash('sha256').update(JSON.stringify(norm)).digest('hex');
 }
 
-const sum = canonicalChecksum(readFileSync(SRC, 'utf8'));
-const check = process.argv.includes('--check');
+// Run the CLI body ONLY when executed directly (`node scripts/design-prompts-sync.mjs`),
+// not when imported for canonicalChecksum. Otherwise importing this module (the parity
+// test, the cross-repo check) would rewrite SUM as a side effect and silently defeat the
+// freshness gate — a corrupted committed checksum would be overwritten before the test
+// ever reads it. (SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 Phase 3)
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
 
-if (check) {
-  let committed = '';
-  try { committed = readFileSync(SUM, 'utf8').trim(); } catch { /* missing */ }
-  if (committed !== sum) {
-    console.error(`[design-prompts] checksum STALE\n  committed: ${committed || '(none)'}\n  actual:    ${sum}\n  run: npm run design-prompts:sync`);
-    process.exit(1);
+if (invokedDirectly) {
+  const sum = canonicalChecksum(readFileSync(SRC, 'utf8'));
+  const check = process.argv.includes('--check');
+
+  if (check) {
+    let committed = '';
+    try { committed = readFileSync(SUM, 'utf8').trim(); } catch { /* missing */ }
+    if (committed !== sum) {
+      console.error(`[design-prompts] checksum STALE\n  committed: ${committed || '(none)'}\n  actual:    ${sum}\n  run: npm run design-prompts:sync`);
+      process.exit(1);
+    }
+    console.log('[design-prompts] checksum OK', sum);
+  } else {
+    writeFileSync(SUM, sum + '\n', 'utf8');
+    console.log('[design-prompts] wrote checksum', sum);
   }
-  console.log('[design-prompts] checksum OK', sum);
-} else {
-  writeFileSync(SUM, sum + '\n', 'utf8');
-  console.log('[design-prompts] wrote checksum', sum);
 }


### PR DESCRIPTION
## Phase 3 of SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 (EHG_Engineer side) — advisory

The final piece of the single-source unification: a **twinned cross-repo CI gate** so the shared design-prompt bodies (the 3 design audits + the Feedback page) can never silently diverge between **S17** (ehg UI) and **S19** (this seeder). Pairs with the ehg twin PR.

### What it does
On PRs touching the shared source or its tooling, the workflow shallow-clones `rickfelix/ehg` (via `GH_TOKEN_CROSS_REPO`, same pattern as `stage17-contract-smoke.yml`) and compares the **canonical checksums** of the two `shared-design-prompts.json` copies. Divergence → `::warning` + non-zero exit.

**Advisory** (`continue-on-error: true`) for now — flips to blocking via a 1-line follow-up (remove that line + add to required checks) once the false-positive rate is confirmed ~0. Per the chosen rollout.

### Gate-integrity fix (bonus — this gate surfaced it)
`design-prompts-sync.mjs` ran its CLI body at **module top-level**, so importing it for `canonicalChecksum` (the parity test, the new cross-repo check) **rewrote the committed `.sha256` as a side effect** — silently defeating the freshness test (a corrupted checksum was overwritten before the test could read it). Confirmed empirically: corrupting `.sha256` still passed the freshness test pre-fix.

Fixed with the standard ESM main-module guard (`realpathSync(argv[1]) === this module`). Post-fix, corrupting `.sha256` correctly **fails** the freshness test; the CLI (`sync` / `--check`) and the exported `canonicalChecksum` are unchanged. The **same fix lands in ehg** in the twin PR (its sync script had the identical structure from Phase 1).

### Files
- `scripts/design-prompts-cross-repo-check.mjs` — local-vs-sibling canonical checksum compare (tested locally: positive=OK/0, divergence=warn/1, missing=warn/2)
- `.github/workflows/design-prompts-cross-repo.yml` — advisory twinned gate
- `scripts/design-prompts-sync.mjs` — main-module guard (no side-effects on import)

Cross-repo SD; `metadata.target_repos = [EHG, EHG_Engineer]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)