### PR TITLE
fix(learning): guard non-array proven_solutions in issue-knowledge-base (QF-20260525-885)

### DIFF
--- a/lib/learning/issue-knowledge-base.js
+++ b/lib/learning/issue-knowledge-base.js
@@ -121,7 +121,9 @@ export class IssueKnowledgeBase {
   async getSolution(patternId) {
     const pattern = await this.getPattern(patternId);
 
-    if (!pattern || !pattern.proven_solutions || pattern.proven_solutions.length === 0) {
+    // QF-20260525-885: proven_solutions may arrive as a non-array jsonb value
+    // (object/string); Array.isArray guards the .sort() below from throwing.
+    if (!pattern || !Array.isArray(pattern.proven_solutions) || pattern.proven_solutions.length === 0) {
       return null;
     }
 
@@ -165,7 +167,8 @@ export class IssueKnowledgeBase {
     const newCount = pattern.occurrence_count + 1;
 
     // Update proven solutions
-    let solutions = pattern.proven_solutions || [];
+    // QF-20260525-885: coerce non-array proven_solutions to [] so .find() below is safe.
+    let solutions = Array.isArray(pattern.proven_solutions) ? pattern.proven_solutions : [];
     const existingSolution = solutions.find(s =>
       s.solution.toLowerCase() === solution_applied.toLowerCase()
     );
@@ -441,7 +444,9 @@ export class IssueKnowledgeBase {
   }
 
   calculateSuccessRate(pattern) {
-    if (!pattern.proven_solutions || pattern.proven_solutions.length === 0) {
+    // QF-20260525-885: Array.isArray guards the .reduce() calls below from throwing
+    // when proven_solutions is a non-array jsonb value (the reported crash site).
+    if (!Array.isArray(pattern.proven_solutions) || pattern.proven_solutions.length === 0) {
       return 0;
     }
 

--- a/tests/unit/learning/issue-knowledge-base-proven-solutions-guard.test.js
+++ b/tests/unit/learning/issue-knowledge-base-proven-solutions-guard.test.js
@@ -1,0 +1,64 @@
+// QF-20260525-885: non-array proven_solutions must not crash the KB.
+// calculateSuccessRate / getSolution / recordOccurrence all guarded proven_solutions with
+// "!x || .length===0", which a non-array jsonb value (object/string) slips past, throwing
+// "<x> is not a function" on .reduce()/.sort()/.find(). Closes feedback 62cfbdd8 (primary).
+// The secondary catch-binding at search-prior-issues.js:311 was already fixed by QF-20260525-049.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { IssueKnowledgeBase } from '../../../lib/learning/issue-knowledge-base.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../lib/learning/issue-knowledge-base.js');
+
+describe('QF-20260525-885: calculateSuccessRate is non-array safe', () => {
+  const kb = new IssueKnowledgeBase();
+
+  it('returns 0 (no throw) when proven_solutions is a non-array object', () => {
+    expect(() => kb.calculateSuccessRate({ proven_solutions: {} })).not.toThrow();
+    expect(kb.calculateSuccessRate({ proven_solutions: {} })).toBe(0);
+  });
+
+  it('returns 0 (no throw) when proven_solutions is a string', () => {
+    expect(() => kb.calculateSuccessRate({ proven_solutions: 'oops' })).not.toThrow();
+    expect(kb.calculateSuccessRate({ proven_solutions: 'oops' })).toBe(0);
+  });
+
+  it('returns 0 when proven_solutions is null/undefined/empty', () => {
+    expect(kb.calculateSuccessRate({ proven_solutions: null })).toBe(0);
+    expect(kb.calculateSuccessRate({})).toBe(0);
+    expect(kb.calculateSuccessRate({ proven_solutions: [] })).toBe(0);
+  });
+
+  it('still computes the correct rate for a valid array', () => {
+    const pattern = { proven_solutions: [
+      { times_applied: 4, times_successful: 3 },
+      { times_applied: 6, times_successful: 3 },
+    ] };
+    // 6 successful / 10 applied = 0.6
+    expect(kb.calculateSuccessRate(pattern)).toBeCloseTo(0.6, 5);
+  });
+});
+
+describe('QF-20260525-885: all three proven_solutions sites use Array.isArray', () => {
+  const src = readFileSync(SRC, 'utf8');
+
+  it('getSolution guards .sort() with Array.isArray', () => {
+    expect(src).toMatch(/if \(!pattern \|\| !Array\.isArray\(pattern\.proven_solutions\)/);
+  });
+
+  it('recordOccurrence coerces non-array proven_solutions to []', () => {
+    expect(src).toMatch(/Array\.isArray\(pattern\.proven_solutions\) \? pattern\.proven_solutions : \[\]/);
+  });
+
+  it('calculateSuccessRate guards .reduce() with Array.isArray', () => {
+    expect(src).toMatch(/if \(!Array\.isArray\(pattern\.proven_solutions\) \|\| pattern\.proven_solutions\.length === 0\)/);
+  });
+
+  it('no remaining unguarded "!pattern.proven_solutions ||" length guards that precede array ops', () => {
+    // both length-guards now lead with Array.isArray; the bare truthy guard is gone from these sites
+    expect(src).not.toMatch(/if \(!pattern\.proven_solutions \|\| pattern\.proven_solutions\.length === 0\) \{\s*\n\s*return 0;/);
+  });
+});


### PR DESCRIPTION
## QF-20260525-885 — Guard non-array `proven_solutions` in issue-knowledge-base

`lib/learning/issue-knowledge-base.js` had three sites that guarded `proven_solutions` with `!x || .length === 0` and then called array methods — a **non-array** jsonb value (object/string) slips that guard and throws `<x> is not a function`:

| Method | Line | Op that threw |
|--------|------|---------------|
| `calculateSuccessRate` | 448 | `.reduce()` (the reported crash) |
| `getSolution` | 130 | `.sort()` |
| `recordOccurrence` | 169 | `.find()` |

This breaks the prior-issue KB search path that RCA agents rely on. Fix: an `Array.isArray` guard at all three sites so a non-array value is treated as empty.

- Found by rca-agent during QF-20260525-522 RCA.
- The secondary catch-binding `ReferenceError` at `search-prior-issues.js:311` cited in the same harness-backlog item was **already fixed** by QF-20260525-049 (#3942) — verified against current `main`, so this PR scopes only the still-live primary crash.

### Tests
`tests/unit/learning/issue-knowledge-base-proven-solutions-guard.test.js` (8):
- Behavioral — `calculateSuccessRate` returns `0` / does not throw for object, string, null, `{}`, `[]`; computes the correct rate for a valid array.
- Static — all three sites use `Array.isArray`; the bare truthy-length guard is gone.

All 8 pass.

### Scope
Tier-1 QF, ~9 source LOC + tests. No auth/schema/migration risk keywords; pure defensive guard, no behavior change for valid array inputs.

Closes feedback 62cfbdd8-19c4-4be2-81a3-2410de1fe2ae

🤖 Generated with [Claude Code](https://claude.com/claude-code)
