### PR TITLE
fix(harness): advisory filing-time prior-fix scan in log-harness-bug (QF-20260525-785)

### DIFF
--- a/scripts/log-harness-bug.js
+++ b/scripts/log-harness-bug.js
@@ -18,8 +18,55 @@
 // Idempotent: a SHA-256 dedup_hash over (date::symptom::file) prevents duplicate inserts.
 // Filter rows: category='harness_backlog' AND status='new' for the open backlog.
 import 'dotenv/config';
+import { execSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 import { emitFeedback } from '../lib/governance/emit-feedback.js';
+
+/**
+ * QF-20260525-785 (RCA CAPA-3): best-effort, NON-BLOCKING scan of origin/main for a likely
+ * prior fix of this symptom, so born-stale harness_backlog rows surface a hint at filing time
+ * (e.g. filing against a 50-commits-behind tree for something already fixed). Never throws and
+ * never blocks the insert — purely advisory. Returns { commit, when, subject, via } or null.
+ */
+export function findPossiblePriorFix({ symptom, file } = {}) {
+  const git = (args) => {
+    try {
+      return execSync(`git ${args}`, { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    } catch {
+      return '';
+    }
+  };
+  // Only commits within this window count as a meaningful "maybe already fixed" signal —
+  // every existing file has *some* last-touching commit, so unbounded matches would be noise.
+  const RECENT_DAYS = 21;
+  const cutoff = Date.now() - RECENT_DAYS * 864e5;
+  const parse = (line, via) => {
+    const [hash, iso, ...rest] = (line || '').split('|');
+    if (!hash) return null;
+    const when = Date.parse(iso);
+    if (!Number.isFinite(when) || when < cutoff) return null;
+    return { commit: hash, when: iso, subject: rest.join('|'), via };
+  };
+  try {
+    // Source 1: most recent origin/main commit touching the cited file.
+    if (file) {
+      const hit = parse(git(`log origin/main -n 1 --format="%h|%cI|%s" -- "${file.replace(/"/g, '')}"`), 'file:' + file);
+      if (hit) return hit;
+    }
+    // Source 2: the most distinctive identifier/path token from the symptom, matched (literal,
+    // case-insensitive) against recent origin/main commit messages. Cheap vs. full-history pickaxe.
+    const token = (symptom || '').match(/[A-Za-z0-9_./-]{8,}/g)?.sort((a, b) => b.length - a.length)[0];
+    if (token) {
+      const hit = parse(git(`log origin/main -n 1 --format="%h|%cI|%s" -F -i --grep="${token.replace(/"/g, '')}"`), 'keyword:' + token);
+      if (hit) return hit;
+    }
+  } catch {
+    /* advisory only — never throw, never block filing */
+  }
+  return null;
+}
 
 async function main() {
   const rawArgs = process.argv.slice(2);
@@ -44,6 +91,13 @@ async function main() {
   const file = flags.file ?? null;
   const sd = flags.sd ?? null;
   const severity = flags.severity ?? 'medium';
+
+  // QF-20260525-785 (CAPA-3): advisory prior-fix hint — never blocks filing.
+  const priorFix = findPossiblePriorFix({ symptom, file });
+  if (priorFix) {
+    console.warn(`⚠️  possible prior fix on origin/main: ${priorFix.commit} "${priorFix.subject}" (${priorFix.when}, via ${priorFix.via})`);
+    console.warn('   Advisory only — filing will proceed. Verify the symptom is still live (e.g. git show origin/main:<file>).');
+  }
 
   const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -72,6 +126,9 @@ async function main() {
         // completes (deferred_from_sd_key alone is overloaded: emit-feedback uses
         // it for bundled-CAPA that the SD *does* resolve).
         defer_only: true,
+        // QF-20260525-785 (CAPA-3): stamp the advisory prior-fix hint (or null) so a triager
+        // can see at a glance whether this row may already be fixed on origin/main.
+        possible_prior_fix: priorFix || null,
       },
     });
 
@@ -91,7 +148,19 @@ async function main() {
   }
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exitCode = 1;
-});
+// QF-20260525-785: only auto-run when invoked directly (node scripts/log-harness-bug.js ...),
+// not when imported for unit testing of findPossiblePriorFix.
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/harness/log-harness-bug-prior-fix-scan.test.js
+++ b/tests/unit/harness/log-harness-bug-prior-fix-scan.test.js
@@ -1,0 +1,64 @@
+// QF-20260525-785 (RCA CAPA-3): log-harness-bug.js advisory prior-fix scan.
+// findPossiblePriorFix does a best-effort, NON-BLOCKING git scan of origin/main and must
+// never throw or block filing; main() stamps metadata.possible_prior_fix.
+// Behavioral tests are deterministic (gibberish → null, never throws); positive matches
+// depend on live git history and are covered by the static format pin + manual verification.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findPossiblePriorFix } from '../../../scripts/log-harness-bug.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/log-harness-bug.js');
+const src = readFileSync(SRC, 'utf8');
+
+describe('QF-20260525-785: findPossiblePriorFix is best-effort and never throws', () => {
+  it('returns null for a clearly non-existent file + gibberish symptom', () => {
+    const r = findPossiblePriorFix({ symptom: 'zzqqxx totally fake symptom 99', file: 'does/not/exist/anywhere.js' });
+    expect(r).toBeNull();
+  });
+
+  it('does not throw on missing/empty/odd inputs', () => {
+    expect(() => findPossiblePriorFix()).not.toThrow();
+    expect(() => findPossiblePriorFix({})).not.toThrow();
+    expect(() => findPossiblePriorFix({ symptom: null, file: null })).not.toThrow();
+    // quotes/special chars in symptom must not break the underlying git command
+    expect(() => findPossiblePriorFix({ symptom: 'weird "quoted" $(rm -rf) `tok`', file: null })).not.toThrow();
+  });
+
+  it('a hit (when returned) has the expected shape', () => {
+    // symptom token "log-harness-bug" matches this very commit's message in most checkouts;
+    // assert shape only when a hit is produced (history-dependent, so tolerate null in CI).
+    const r = findPossiblePriorFix({ symptom: 'log-harness-bug advisory prior-fix scan', file: 'scripts/log-harness-bug.js' });
+    if (r !== null) {
+      expect(r).toHaveProperty('commit');
+      expect(r).toHaveProperty('when');
+      expect(r).toHaveProperty('subject');
+      expect(r.via).toMatch(/^(file|keyword):/);
+    }
+  });
+});
+
+describe('QF-20260525-785: source-level guards', () => {
+  it('git --format is quoted (regression pin: unquoted | is a shell pipe and breaks the scan)', () => {
+    expect(src).toMatch(/--format="%h\|%cI\|%s"/);
+    expect(src).not.toMatch(/--format=%h\|%cI\|%s(?!")/);
+  });
+
+  it('main() is guarded so importing the module does not run the CLI', () => {
+    expect(src).toMatch(/invokedDirectly/);
+    expect(src).toMatch(/if \(invokedDirectly\) \{/);
+  });
+
+  it('the prior-fix hint is advisory (console.warn) and stamped into metadata', () => {
+    expect(src).toMatch(/console\.warn\(`⚠️  possible prior fix on origin\/main/);
+    expect(src).toMatch(/possible_prior_fix:\s*priorFix \|\| null/);
+  });
+
+  it('the scan only counts recent commits (avoids matching every file\'s last commit)', () => {
+    expect(src).toMatch(/RECENT_DAYS/);
+    expect(src).toMatch(/when < cutoff/);
+  });
+});


### PR DESCRIPTION
## QF-20260525-785 — Advisory filing-time prior-fix scan (RCA CAPA-3)

`log-harness-bug.js` inserted `harness_backlog` rows with **no** check whether the symptom was already fixed on `origin/main` — producing *born-stale* rows (filed against a many-commits-behind tree for something already shipped). This was a recurring drag (the queue itself warns "verify against origin/main first — items may already be fixed").

### Fix
A new exported `findPossiblePriorFix({ symptom, file })` — best-effort, **NON-BLOCKING**:
1. The cited `--file`'s most recent `origin/main` commit.
2. The most distinctive symptom token, matched literal + case-insensitive against recent commit messages (`-F -i --grep`).

Gated to commits within the last **21 days** so it doesn't flag every file's last-touching commit. On a hit it prints `⚠️ possible prior fix: <commit>` and stamps `metadata.possible_prior_fix`; **filing always proceeds** (advisory only, never hard-blocks).

### Also
- **Quote the git `--format` string** (`"%h|%cI|%s"`): unquoted, the `|` is a shell pipe that silently broke the scan — caught during behavioral verification (the scan returned `null` until quoted).
- **Guard `main()` behind `invokedDirectly`** so the module can be imported for unit testing without running the CLI (the recurring ESM "require.main" gap).

### Tests (`tests/unit/harness/log-harness-bug-prior-fix-scan.test.js`, 7)
- Behavioral — returns `null` for gibberish/non-existent file; never throws on missing/empty/odd input (including injection-y symptom text); hit-shape assertions when a match is produced.
- Static pins — quoted `--format` (pins the shell-pipe bug), import guard, advisory `console.warn` + `metadata.possible_prior_fix` stamp, recency gate.

All 7 pass. Verified live: file-scan and keyword-scan both correctly surface a recent commit; gibberish → null; import does not run `main()`.

### Scope
Tier-2 QF, ~56 source LOC + tests. No auth/schema/migration risk keywords; additive advisory hint, no change to insert/dedup behavior.

Closes feedback c6051297-7fed-44b6-970f-ccebb180f744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
