### PR TITLE
fix(sd-next): only auto-start status='open' QFs in topStartableQF (QF-20260525-701)

### DIFF
--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -97,7 +97,12 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
   summary.topQF = classified[0] || null;
   // QF-20260525-522: exclude verify-first (possibly-superseded) QFs from the
   // auto-startable pick so AUTO-PROCEED doesn't route a session to dead work.
-  summary.topStartableQF = classified.find(qf => !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst) || null;
+  // QF-20260525-701: also require status==='open'. Loaders fetch [open, in_progress],
+  // and _verifyFirst only flags 'open' rows — so an orphaned in_progress QF (dead holder
+  // => claiming_session_id null, no PR) would otherwise be emitted as AUTO_PROCEED_ACTION:
+  // qf_start and auto-started without verify-first. in_progress is either actively owned or
+  // orphaned; neither is auto-startable.
+  summary.topStartableQF = classified.find(qf => qf.status === 'open' && !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst) || null;
 
   return { summary, classified };
 }

--- a/tests/unit/sd-next/topstartable-qf-status-open.test.js
+++ b/tests/unit/sd-next/topstartable-qf-status-open.test.js
@@ -1,0 +1,48 @@
+// QF-20260525-701: topStartableQF must only auto-start status='open' QFs.
+// Loaders fetch [open, in_progress]; an orphaned in_progress QF (dead holder => null claim,
+// no PR) previously slipped into topStartableQF (=> AUTO_PROCEED_ACTION:qf_start) because the
+// predicate did not check status and _verifyFirst only flags 'open' rows.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifyQuickFixes } from '../../../scripts/modules/sd-next/display/quick-fixes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/modules/sd-next/display/quick-fixes.js');
+
+const nowIso = () => new Date().toISOString();
+
+describe('QF-20260525-701: topStartableQF excludes in_progress', () => {
+  it('does NOT auto-start an orphaned in_progress QF (null claim, no PR)', () => {
+    const qfs = [
+      { id: 'QF-A', status: 'in_progress', claiming_session_id: null, pr_url: null, commit_sha: null, severity: 'medium', created_at: nowIso() },
+    ];
+    const { summary } = classifyQuickFixes(qfs);
+    expect(summary.topStartableQF).toBeNull();
+  });
+
+  it('DOES auto-start a fresh, open, unclaimed QF', () => {
+    const qfs = [
+      { id: 'QF-OPEN', status: 'open', claiming_session_id: null, pr_url: null, commit_sha: null, severity: 'medium', created_at: nowIso() },
+    ];
+    const { summary } = classifyQuickFixes(qfs);
+    expect(summary.topStartableQF?.id).toBe('QF-OPEN');
+  });
+
+  it('prefers the open QF over an in_progress one in the same set', () => {
+    const qfs = [
+      { id: 'QF-WIP', status: 'in_progress', claiming_session_id: null, pr_url: null, commit_sha: null, severity: 'critical', created_at: nowIso() },
+      { id: 'QF-OPEN', status: 'open', claiming_session_id: null, pr_url: null, commit_sha: null, severity: 'low', created_at: nowIso() },
+    ];
+    const { summary } = classifyQuickFixes(qfs);
+    // even though QF-WIP sorts first (critical), it is not auto-startable
+    expect(summary.topStartableQF?.id).toBe('QF-OPEN');
+  });
+
+  it('source predicate requires status === \'open\'', () => {
+    const src = readFileSync(SRC, 'utf8');
+    expect(src).toMatch(/topStartableQF\s*=\s*classified\.find\(qf =>\s*qf\.status === ['"]open['"]/);
+  });
+});


### PR DESCRIPTION
## QF-20260525-701 — topStartableQF status guard

`topStartableQF` (quick-fixes.js:100) filtered `_escalate`/`_isClaimedByOther`/`_verifyFirst` but **not status**. Loaders fetch `[open, in_progress]` and `_verifyFirst` only flags `open` rows — so an orphaned `in_progress` QF (dead holder ⇒ `claiming_session_id` null, no PR) passed every predicate and was emitted as `AUTO_PROCEED_ACTION:qf_start`, auto-starting dead work with no verify-first.

**Fix:** add `qf.status === 'open'` to the predicate. `in_progress` is either actively owned or orphaned — neither is auto-startable.

### Tests (4)
`classifyQuickFixes` excludes an orphaned `in_progress` QF, picks a fresh open QF, prefers an open QF over a *critical* `in_progress` one, plus a static predicate pin. All pass.

Tier-1, ~4 source LOC. No risk keywords.

Closes feedback 67041ad1-fd6a-4edb-a840-47dbe3306305

🤖 Generated with [Claude Code](https://claude.com/claude-code)