### PR TITLE
fix(QF-20260525-658): ENF-05 gate schema pre-flight on governing-command (skip quoted mentions)

### DIFF
--- a/scripts/hooks/__tests__/supabase-operative.test.js
+++ b/scripts/hooks/__tests__/supabase-operative.test.js
@@ -1,0 +1,70 @@
+// QF-20260525-658 (ENF-05, RCA 6188492f): the Supabase schema pre-flight gate
+// must fire on a real EXECUTION (node -e "...supabase.from('t')...") but pass
+// through a quoted MENTION inside echo / grep / git commit / gh pr --body.
+// Same quoted-mention class as ENF-15 (#3929) / ENF-12 (#3932); fix is
+// governing-command detection rather than operative-command anchoring.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isSupabaseExecution, SUPABASE_PATTERNS } = require(
+  path.resolve(__dirname, '../lib/supabase-operative.cjs')
+);
+
+describe('ENF-05 isSupabaseExecution: executions detected (validate)', () => {
+  it('node -e inline supabase.from(...) is an execution', () => {
+    expect(isSupabaseExecution(`node -e "supabase.from('ventures').select('*')"`)).toBe(true);
+  });
+  it('node -e inline .rpc(...) is an execution', () => {
+    expect(isSupabaseExecution(`node -e "await s.rpc('release_sd', { p: 1 })"`)).toBe(true);
+  });
+  it('chained cd && node -e is an execution (governing prog after &&)', () => {
+    expect(isSupabaseExecution(`cd /tmp && node -e "supabase.from('feedback').select()"`)).toBe(true);
+  });
+  it('direct .mjs script invocation with inline call arg is an execution', () => {
+    expect(isSupabaseExecution(`./scripts/probe.mjs "supabase.from('ventures')"`)).toBe(true);
+  });
+  it('tsx runner is an execution', () => {
+    expect(isSupabaseExecution(`tsx -e "supabase.from('ventures')"`)).toBe(true);
+  });
+});
+
+describe('ENF-05 isSupabaseExecution: quoted mentions pass through (skip)', () => {
+  it('echo mention does not count as execution', () => {
+    expect(isSupabaseExecution(`echo "use supabase.from('ventures') here"`)).toBe(false);
+  });
+  it('git commit -m mention does not count (reported FP class)', () => {
+    expect(isSupabaseExecution(`git commit -m "fix .from('feedback') query bug"`)).toBe(false);
+  });
+  it('gh pr create --body mention does not count', () => {
+    expect(isSupabaseExecution(`gh pr create --body "calls supabase.from('sd_v2') then .rpc('x')"`)).toBe(false);
+  });
+  it('grep over a pattern does not count', () => {
+    expect(isSupabaseExecution(`grep -r ".from('ventures')" scripts/`)).toBe(false);
+  });
+  it('git commit message that merely names node -e does not count (governor is git)', () => {
+    expect(isSupabaseExecution(`git commit -m "use node -e to call supabase.from('t')"`)).toBe(false);
+  });
+  it('a real node run followed by an echo mention: the mention is governed by echo → skip', () => {
+    // The script's own calls live in the file (not the command text); the only
+    // pattern in the command line is the echo mention, governed by echo.
+    expect(isSupabaseExecution(`node scripts/x.mjs && echo "supabase.from('t')"`)).toBe(false);
+  });
+});
+
+describe('ENF-05 isSupabaseExecution: edge cases', () => {
+  it('no supabase pattern → false', () => {
+    expect(isSupabaseExecution(`node -e "console.log(1)"`)).toBe(false);
+  });
+  it('non-string input → false', () => {
+    expect(isSupabaseExecution(null)).toBe(false);
+    expect(isSupabaseExecution(undefined)).toBe(false);
+    expect(isSupabaseExecution('')).toBe(false);
+  });
+  it('SUPABASE_PATTERNS remains a non-empty array (single source preserved)', () => {
+    expect(Array.isArray(SUPABASE_PATTERNS)).toBe(true);
+    expect(SUPABASE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/hooks/lib/supabase-operative.cjs
+++ b/scripts/hooks/lib/supabase-operative.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * ENF-05 (QF-20260525-658, RCA 6188492f): the Supabase schema pre-flight
+ * (ENFORCEMENT 7 in pre-tool-enforce.cjs) must run only when a Supabase client
+ * call is actually EXECUTED by a JS runner — not when it is a quoted MENTION
+ * inside echo / grep / git commit / gh pr --body. Same quoted-mention CLASS as
+ * ENF-15 (#3929) / ENF-12 (#3932), but those anchored a forbidden keyword to the
+ * operative command; ENF-05's real use case is the call INSIDE node -e quotes
+ * (quoted in both the real and false-positive case), so the distinguishing
+ * signal is the GOVERNING command, which this helper resolves. Pure module
+ * (mirrors coerce-literal.cjs) so it is unit-testable — the hook runs main() at load.
+ */
+
+// Single source of truth for Supabase operation detection (also used by extractTableName).
+const SUPABASE_PATTERNS = [
+  /\.from\(\s*['"`](\w+)['"`]\s*\)/,         // .from('table_name')
+  /supabase\.from\(\s*['"`](\w+)['"`]\s*\)/, // supabase.from('table_name')
+  /\.rpc\(\s*['"`](\w+)['"`]/,               // .rpc('function_name')
+];
+
+// Programs that actually evaluate JS (and would therefore execute the call).
+const JS_RUNNERS = /^(node|tsx|ts-node|deno|bun|npx|pnpm|yarn)$/;
+
+/** Earliest index any Supabase pattern matches, or -1. */
+function firstSupabaseMatchIndex(command) {
+  let idx = -1;
+  for (const p of SUPABASE_PATTERNS) {
+    const m = command.match(p);
+    if (m && (idx === -1 || m.index < idx)) idx = m.index;
+  }
+  return idx;
+}
+
+// Start of the shell segment governing `pos`: char after the last UNQUOTED
+// separator (; & | newline `(`) before pos. Quote tracking is approximate
+// (single/double/backtick) — enough to attribute a mention to its outer command.
+function segmentStart(command, pos) {
+  let start = 0, quote = null;
+  for (let i = 0; i < pos && i < command.length; i++) {
+    const ch = command[i];
+    if (quote) { if (ch === quote) quote = null; continue; }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === ';' || ch === '\n' || ch === '(' || ch === '&' || ch === '|') start = i + 1;
+  }
+  return start;
+}
+
+/** True when a Supabase call in `command` is executed (not just mentioned). */
+function isSupabaseExecution(command) {
+  if (typeof command !== 'string' || command.length === 0) return false;
+  const idx = firstSupabaseMatchIndex(command);
+  if (idx === -1) return false;
+  const segment = command.slice(segmentStart(command, idx), idx);
+  const tok = segment.match(/(?:^|\s)([^\s;|&()'"`]+)/); // governing program
+  if (!tok) return false;
+  const prog = tok[1].replace(/.*[\\/]/, ''); // basename, cross-platform
+  return JS_RUNNERS.test(prog) || /\.(c|m)?js$/.test(prog);
+}
+
+module.exports = { SUPABASE_PATTERNS, isSupabaseExecution, firstSupabaseMatchIndex };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -235,12 +235,10 @@ const VALIDATION_CONFIG = {
   // Everything else is implicitly 'skip'
 };
 
-// Regex patterns to detect Supabase operations in Bash commands
-const SUPABASE_PATTERNS = [
-  /\.from\(\s*['"`](\w+)['"`]\s*\)/,        // .from('table_name')
-  /supabase\.from\(\s*['"`](\w+)['"`]\s*\)/, // supabase.from('table_name')
-  /\.rpc\(\s*['"`](\w+)['"`]/,               // .rpc('function_name')
-];
+// Supabase operation detection + execution gate (ENF-05 / QF-20260525-658).
+// SUPABASE_PATTERNS is the single source consumed here AND for the ENFORCEMENT 7
+// gate; isSupabaseExecution distinguishes a real call from a quoted mention.
+const { SUPABASE_PATTERNS, isSupabaseExecution } = require(path.resolve(__dirname, 'lib', 'supabase-operative.cjs'));
 
 /**
  * Determine enforcement tier for the current Bash command context.
@@ -770,7 +768,9 @@ async function main() {
   // Tiered: blocking for migrations/handoffs, advisory for general scripts, skip otherwise.
   if (TOOL_NAME === 'Bash') {
     const command = input.command || '';
-    if (SUPABASE_PATTERNS.some(p => p.test(command))) {
+    // ENF-05 (QF-20260525-658): validate only when the call is actually executed
+    // by a JS runner — not when it is a quoted MENTION inside echo/git commit/gh pr.
+    if (isSupabaseExecution(command)) {
       await validateBeforeExecution(command);
     }
   }


### PR DESCRIPTION
## QF-20260525-658 — ENF-05 quoted-mention false-positive

**Problem.** ENFORCEMENT 7 (Supabase schema pre-flight) in `pre-tool-enforce.cjs` fired whenever a command matched `SUPABASE_PATTERNS`, including incidental **quoted mentions** of a client call inside `echo` / `grep` / `git commit -m` / `gh pr --body`. When such a body also contained a blocking-tier keyword (e.g. `handoff.js`, `migration`), the pre-flight could needlessly run — the same quoted-mention class as ENF-15 (#3929) and ENF-12 (#3932), per RCA `6188492f`.

**Why not the same fix.** ENF-15/ENF-12 anchored a forbidden keyword to the operative command. ENF-05 can't: its real use case is the call **inside `node -e` quotes**, so the call is quoted in both the real and the false-positive case. The distinguishing signal is the **governing command**.

**Fix.** Extract a pure, unit-tested module `scripts/hooks/lib/supabase-operative.cjs` (mirrors `coerce-literal.cjs`, since the hook runs `main()` at load):
- `SUPABASE_PATTERNS` — now the single source (also used by `extractTableName`).
- `isSupabaseExecution(command)` — resolves the shell segment governing the matched call (quote-aware separator scan) and returns true only when the governing program is a JS runner (`node`/`-e`, `tsx`, `ts-node`, `deno`, `bun`, `npx`, `pnpm`, `yarn`) or a `.js/.mjs/.cjs` script.

ENFORCEMENT 7 now gates on `isSupabaseExecution(command)` instead of `SUPABASE_PATTERNS.some(...)`.

**Tests.** `scripts/hooks/__tests__/supabase-operative.test.js` — 15 cases: real executions (`node -e`, chained `&& node -e`, `tsx`, direct `.mjs`) validate; quoted mentions in `echo`/`grep`/`git commit`/`gh pr --body` (and a message that merely *names* `node -e`) pass through; plus null/empty/no-match edges.

**Scope.** 75 source LOC (Tier-2). Pure false-positive reduction in a hook gate — no schema, auth, or migration logic changed. Resolves harness_backlog `c8c5ea99`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
