### PR TITLE
fix(QF-20260525-306): CAPA-1 parse Closes-feedback footers in LEAD-FINAL autoCloseFeedback

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -21,6 +21,9 @@ import {
 import { getRemediation } from './remediations.js';
 import { clearState as clearAutoProceedState } from '../../auto-proceed-state.js';
 import { recordSdCompleted } from '../../../../../lib/learning/outcome-tracker.js';
+// CAPA-1 (QF-20260525-306): parse "Closes feedback <uuid>" footers from merged SD
+// commits — autoCloseFeedback closes only by link, mirroring the QF orchestrator gap.
+import { parseAndExpandFeedbackFooters, resolveFeedback } from '../../../../../lib/governance/resolve-feedback.js';
 
 // Worktree cleanup (SD-LEO-INFRA-INTEGRATE-WORKTREE-CREATION-001)
 import { cleanupWorktree, validateSdKey } from '../../../../../lib/worktree-manager.js';
@@ -851,8 +854,21 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       ...linkedByDeferredFrom.map(f => f.id)
     ])];
 
+    // CAPA-1 (QF-20260525-306): also resolve feedback referenced ONLY by a
+    // "Closes feedback <uuid>" footer in the SD's merged commits — the link-based
+    // queries above miss those. Fail-soft + env opt-out; runs even with 0 links.
+    // PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+    let footerCount = 0;
+    if (process.env.RESOLVE_FEEDBACK_ON_SD_COMPLETE !== '0') {
+      try {
+        footerCount = await this.resolveFeedbackFooters(sd);
+      } catch (footerErr) {
+        console.warn(`   ⚠️  Footer-based feedback resolve failed (non-blocking): ${footerErr.message}`);
+      }
+    }
+
     if (allIds.length === 0) {
-      return { closedCount: 0 };
+      return { closedCount: footerCount };
     }
 
     const { data: updated, error: updateError } = await this.supabase
@@ -870,7 +886,51 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       throw new Error(`Failed to auto-close feedback: ${updateError.message}`);
     }
 
-    return { closedCount: updated?.length || 0 };
+    return { closedCount: (updated?.length || 0) + footerCount };
+  }
+
+  /**
+   * CAPA-1 (QF-20260525-306): parse "Closes feedback <uuid>" footers from the SD's
+   * merged commit messages (squash-merge embeds the PR body) and resolve each row,
+   * mirroring complete-quick-fix orchestrator.resolveLinkedFeedbackRows. Returns the
+   * count newly resolved. Caller wraps fail-soft.
+   * @param {Object} sd
+   * @returns {Promise<number>}
+   */
+  async resolveFeedbackFooters(sd) {
+    const sdKey = sd.sd_key || sd.id;
+    const corpus = [];
+    // Only shell out for a well-formed key (avoids any injection via --grep arg).
+    if (typeof sdKey === 'string' && /^[A-Za-z0-9_-]+$/.test(sdKey)) {
+      try {
+        const { execSync } = await import('node:child_process');
+        const log = execSync(`git log origin/main --grep="${sdKey}" --format=%B -n 30`, {
+          encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000,
+        });
+        if (log) corpus.push(log);
+      } catch {
+        /* git unavailable or no match — non-fatal */
+      }
+    }
+    if (sd.description) corpus.push(sd.description);
+
+    const { uuids, warnings } = await parseAndExpandFeedbackFooters({
+      text: corpus.join('\n'), supabase: this.supabase,
+    });
+    for (const w of warnings) console.log(`   ⚠️  ${w}`);
+
+    let resolved = 0;
+    for (const uuid of uuids) {
+      const result = await resolveFeedback({
+        supabase: this.supabase, feedbackId: uuid, sdId: sd.id,
+        notes: `Closed by footer in SD ${sdKey} (LEAD-FINAL-APPROVAL)`,
+      });
+      if (result.updated) {
+        resolved++;
+        console.log(`   ✅ feedback ${uuid} → resolved (footer in ${sdKey})`);
+      }
+    }
+    return resolved;
   }
 
   // QF-20260424-806: accept context (sdId, details, score) and forward it to

--- a/tests/unit/handoff/lead-final-footer-resolve.test.js
+++ b/tests/unit/handoff/lead-final-footer-resolve.test.js
@@ -1,0 +1,55 @@
+// QF-20260525-306 (CAPA-1, PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001):
+// LEAD-FINAL autoCloseFeedback closed feedback only by link (SD id / branch /
+// deferred_from_sd_key) and never parsed "Closes feedback <uuid>" footers, unlike
+// the complete-quick-fix orchestrator. resolveFeedbackFooters wires that in.
+// Borrow the prototype method with a fake supabase so we exercise the wiring
+// (full-UUID footer needs no DB expansion).
+
+import { describe, it, expect } from 'vitest';
+import LeadFinalApprovalExecutor from '../../../scripts/modules/handoff/executors/lead-final-approval/index.js';
+
+const UUID = 'cd74b43c-42fa-4cb7-8651-10ff06763bf3';
+
+function makeFakeSupabase(captured) {
+  const chain = {
+    update(obj) { captured.push(obj); return chain; },
+    eq() { return chain; },
+    neq() { return chain; },
+    // resolveFeedback ends in .select('id'); non-empty data => updated:true
+    select() { return Promise.resolve({ data: [{ id: UUID }], error: null }); },
+  };
+  return { from() { return chain; } };
+}
+
+describe('CAPA-1 resolveFeedbackFooters: footer-referenced rows get resolved', () => {
+  it('resolves a feedback row named only by a Closes-feedback footer', async () => {
+    const captured = [];
+    const ctx = {
+      supabase: makeFakeSupabase(captured),
+      resolveFeedbackFooters: LeadFinalApprovalExecutor.prototype.resolveFeedbackFooters,
+    };
+    // sd_key with no matching git commits → git path no-ops; footer comes from description.
+    const sd = {
+      id: 'SD-CAPA1-TEST-001',
+      sd_key: 'SD-CAPA1-TEST-001',
+      description: `Body.\nCloses feedback ${UUID}\n`,
+    };
+    const count = await ctx.resolveFeedbackFooters(sd);
+    expect(count).toBe(1);
+    expect(captured.length).toBe(1);
+    expect(captured[0].status).toBe('resolved');
+    expect(captured[0].resolution_sd_id).toBe('SD-CAPA1-TEST-001');
+  });
+
+  it('no footer → no resolve, no update issued', async () => {
+    const captured = [];
+    const ctx = {
+      supabase: makeFakeSupabase(captured),
+      resolveFeedbackFooters: LeadFinalApprovalExecutor.prototype.resolveFeedbackFooters,
+    };
+    const sd = { id: 'SD-CAPA1-TEST-002', sd_key: 'SD-CAPA1-TEST-002', description: 'No footer here.' };
+    const count = await ctx.resolveFeedbackFooters(sd);
+    expect(count).toBe(0);
+    expect(captured.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## QF-20260525-306 — CAPA-1: footer-based feedback closure in LEAD-FINAL

**Problem (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).** The handoff LEAD-FINAL `autoCloseFeedback` (`lead-final-approval/index.js`) closes feedback rows **only by link** — `strategic_directive_id` / `resolution_sd_id`, CI-failure branch name, and `metadata.deferred_from_sd_key`. It never parses `Closes feedback <uuid>` footers from the SD's merged commits, unlike the complete-quick-fix orchestrator (`resolveLinkedFeedbackRows`). A feedback row referenced **only** by a commit/PR footer therefore stays `new` forever after the SD merges. `lib/governance/resolve-feedback.js` already named this path as the planned (then out-of-scope) wiring.

**Fix.** New fail-soft `resolveFeedbackFooters(sd)` method:
- Collects a corpus from `git log origin/main --grep="<sd_key>" --format=%B` (squash-merge embeds the PR body, so footers land on main; LEAD-FINAL runs post-merge) plus `sd.description`. The git call is guarded to a well-formed key (`/^[A-Za-z0-9_-]+$/`) to avoid `--grep` arg injection.
- Runs the shared `parseAndExpandFeedbackFooters` + `resolveFeedback({ sdId })` (sets `resolution_sd_id`), mirroring the QF path.
- Wired into `autoCloseFeedback` so it runs **even when zero rows are linked**; counts combine.

**Safety.** Fully fail-soft (its own try/catch; existing caller try/catch is a second layer), idempotent via `resolveFeedback`'s `WHERE status != 'resolved'`, and disablable with `RESOLVE_FEEDBACK_ON_SD_COMPLETE=0`. No schema/auth/migration change.

**Tests.** `tests/unit/handoff/lead-final-footer-resolve.test.js` — footer-present resolves (with `resolution_sd_id`), no-footer is a clean no-op. 64 source LOC (Tier-2).

Closes feedback cd74b43c-42fa-4cb7-8651-10ff06763bf3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
