### PR TITLE
feat(leo-stack): skip restart-pull when another live session is on main

### DIFF
--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -537,13 +537,18 @@ function Sync-Repo {
             Write-Log "WARN" "[SYNC] $Name on '$branch' (not main) - serving local, not auto-pulling" "Yellow"
             return
         }
-        # Only pull a genuinely-idle primary tree. Two layers:
+        # Only pull a genuinely-idle primary tree. Three layers:
         #  (1) skip if there are uncommitted *tracked* changes beyond the auto-churn
         #      safelist (.claude/.protocol-sync) — protects a session actively editing
         #      in the primary tree, without the safelisted file blocking every pull.
         #      Untracked files are ignored: ff-only can't harm them and the tree
         #      always carries many (scripts/one-off/, etc.).
-        #  (2) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
+        #  (2) skip if another live Claude Code session is on this branch — a clean
+        #      tree can still have a session reading/about-to-edit it, and ff-merge
+        #      rewrites tracked files under it (the concurrent-session corruption
+        #      class). safe-to-pull-tree.mjs prints BUSY/IDLE; key on the token so a
+        #      crash/missing-creds prints neither and fails OPEN to ff-only safety.
+        #  (3) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
         git fetch origin main --quiet 2>$null
         $behind = (git rev-list --count HEAD..origin/main 2>$null)
         if (-not ($behind -match '^\d+$' -and [int]$behind -gt 0)) {
@@ -555,6 +560,12 @@ function Sync-Repo {
         if ($meaningful.Count -gt 0) {
             $files = ($meaningful | ForEach-Object { ($_ -replace '^...', '').Trim() }) -join ', '
             Write-Log "WARN" "[SYNC] $Name is $behind behind but has uncommitted edits ($files) - NOT pulling, protecting in-progress work (commit/stash to update)" "Yellow"
+            return
+        }
+        $pullGuard = ""
+        try { $pullGuard = (& node (Join-Path $EngineerDir "scripts/lib/safe-to-pull-tree.mjs") $branch 2>$null | Out-String) } catch { $pullGuard = "" }
+        if ($pullGuard -match 'BUSY') {
+            Write-Log "WARN" "[SYNC] $Name is $behind behind but another live session is on '$branch' ($($pullGuard.Trim())) - NOT pulling, avoids mutating files under an active session" "Yellow"
             return
         }
         Write-Log "INFO" "[SYNC] $Name is $behind commit(s) behind origin/main - fast-forwarding..." "Blue"

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -391,12 +391,17 @@ sync_repo() {
             log "WARN" "${YELLOW}[SYNC] $name on '$branch' (not main) - serving local, not auto-pulling${NC}"
             exit 0
         fi
-        # Only pull a genuinely-idle primary tree. Two layers:
+        # Only pull a genuinely-idle primary tree. Three layers:
         #  (1) skip if there are uncommitted *tracked* changes beyond the auto-churn
         #      safelist (.claude/.protocol-sync) — protects a session actively editing
         #      in the primary tree, without the safelisted file blocking every pull.
         #      Untracked files are ignored (ff-only can't harm them; the tree carries many).
-        #  (2) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
+        #  (2) skip if another live Claude Code session is on this branch — a clean
+        #      tree can still have a session reading/about-to-edit it, and ff-merge
+        #      rewrites tracked files under it (the concurrent-session corruption
+        #      class). safe-to-pull-tree.mjs prints BUSY/IDLE; key on the token so a
+        #      crash/missing-creds prints neither and fails OPEN to ff-only safety.
+        #  (3) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
         git fetch origin main --quiet 2>/dev/null
         local behind
         behind=$(git rev-list --count HEAD..origin/main 2>/dev/null)
@@ -410,6 +415,12 @@ sync_repo() {
             local files
             files=$(echo "$meaningful" | sed 's/^...//' | paste -sd ',' -)
             log "WARN" "${YELLOW}[SYNC] $name is $behind behind but has uncommitted edits ($files) - NOT pulling, protecting in-progress work (commit/stash to update)${NC}"
+            exit 0
+        fi
+        local guard
+        guard=$(node "$ENGINEER_DIR/scripts/lib/safe-to-pull-tree.mjs" "$branch" 2>/dev/null || true)
+        if echo "$guard" | grep -q '^BUSY'; then
+            log "WARN" "${YELLOW}[SYNC] $name is $behind behind but another live session is on '$branch' ($guard) - NOT pulling, avoids mutating files under an active session${NC}"
             exit 0
         fi
         log "INFO" "${BLUE}[SYNC] $name is $behind commit(s) behind origin/main - fast-forwarding...${NC}"

--- a/scripts/lib/safe-to-pull-tree.mjs
+++ b/scripts/lib/safe-to-pull-tree.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * safe-to-pull-tree — is it safe for leo-stack to ff-pull a primary tree?
+ *
+ * Follow-up to the leo-stack restart-pull work (#3939/#3940). The existing
+ * Sync-Repo guards skip the pull on a feature branch or when there are uncommitted
+ * tracked changes. This adds the missing case: a CLEAN primary tree (on main) that
+ * another live Claude Code session is actively working in. `git merge --ff-only`
+ * rewrites tracked files, and doing that under an active session mutates files
+ * mid-session — the concurrent-session "internal error" class that
+ * concurrent-session-worktree.cjs exists to prevent.
+ *
+ * "Idle" = no OTHER live session (active|idle, fresh heartbeat) is on the branch
+ * being pulled (main). Sessions isolated in a git worktree sit on their own feat/*
+ * branch, so they are naturally excluded — a primary-tree pull can't touch them.
+ * v_active_sessions (the SSOT, read directly here) does not populate
+ * codebase/worktree_path, so current_branch is the only reliable signal; this is
+ * intentionally branch-centric and conservative across both repos — over-skipping
+ * just serves local, the existing safe fallback. The invoking session excludes
+ * itself via CLAUDE_SESSION_ID.
+ *
+ *   node scripts/lib/safe-to-pull-tree.mjs [branch=main]
+ *
+ * Output: a line starting with "BUSY" or "IDLE" — leo-stack keys on this token, so a
+ * crash/error (which prints neither, or "UNKNOWN") fails OPEN to the existing
+ * ff-only safety. Exit: 0 idle | 1 busy | 2 unknown. A minimal client
+ * (autoRefreshToken/persistSession off) is used so the process exits cleanly with
+ * the intended code instead of the libuv-teardown crash the shared client triggers.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const branch = (process.argv[2] || 'main').trim();
+const self = process.env.CLAUDE_SESSION_ID || null;
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.log('UNKNOWN missing supabase credentials');
+  process.exit(2);
+}
+
+const sb = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+// v_active_sessions already excludes stale rows (computed_status drives liveness).
+const { data, error } = await sb
+  .from('v_active_sessions')
+  .select('session_id,computed_status,current_branch')
+  .in('computed_status', ['active', 'idle']);
+
+if (error) {
+  console.log(`UNKNOWN session query failed: ${error.message}`);
+  process.exit(2);
+}
+
+// Other (non-self) live sessions on the branch we are about to fast-forward.
+// Only count current_branch === target: a null branch is a not-yet-stamped /
+// telemetry session, not a confirmed primary-tree occupant.
+const occupants = (data || []).filter(
+  (s) => s && s.session_id !== self && s.current_branch === branch
+);
+
+if (occupants.length > 0) {
+  const who = occupants
+    .map((s) => `${String(s.session_id || '?').slice(0, 8)}(${s.computed_status || '?'})`)
+    .join(', ');
+  console.log(`BUSY ${occupants.length} other session(s) on '${branch}': ${who}`);
+  process.exit(1);
+}
+
+console.log(`IDLE no other sessions on '${branch}'`);
+process.exit(0);


### PR DESCRIPTION
## Follow-up to the leo-stack restart-pull guards (#3939 / #3940)

Those guards skip the ff-pull on a feature branch or when there are uncommitted *tracked* changes. But a **clean primary tree on `main`** can still have a live Claude Code session reading it or about to edit it — and `git merge --ff-only origin/main` rewrites tracked files under that session, which is the concurrent-session corruption class (`concurrent-session-worktree.cjs` exists to prevent exactly this). This adds the missing **"idle tree"** layer.

### What changed
- **`scripts/lib/safe-to-pull-tree.mjs`** (new) — reports `BUSY` when another (non-self) live session (`v_active_sessions`, status `active|idle`) is on the branch being pulled, else `IDLE`. Self excludes via `CLAUDE_SESSION_ID`.
- **`leo-stack.ps1` / `leo-stack.sh`** — `Sync-Repo` / `sync_repo` skip the pull on the `BUSY` token (between the existing dirty-check and the `ff-only` merge).

### Design notes
- **Keys on the stdout token, not the exit code.** A crash / missing creds prints neither `BUSY` nor `IDLE` → the caller **fails OPEN** to the existing `ff-only` safety (which never clobbers). (Node 24 on Windows throws a cosmetic libuv assertion on `process.exit()` during socket teardown — token-keying sidesteps it; Linux/CI exits cleanly.)
- **Conservative when self can't be identified.** If `CLAUDE_SESSION_ID` doesn't reach the subprocess, the invoking session counts as "on main" → `BUSY` → serves local. Safe, and matches "only pull an idle tree."
- **Signal is `current_branch`.** `v_active_sessions` doesn't populate `codebase`/`worktree_path`, so per-repo precision isn't available; worktree-isolated sessions sit on `feat/*` branches and are naturally excluded. Intentionally conservative across both repos — over-skipping just serves local.

### Validation (both shells)
`BUSY → skip`, `IDLE → pull`, `crash/bad-path → pull (fail-open)` confirmed on PowerShell and bash. ~98 LOC (helper-dominated; the two-script wiring is ~13 lines each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)