### PR TITLE
fix(QF-20260525-378): handoff precheck folds prerequisite-preflight failure into verdict (execute parity)

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -24,6 +24,32 @@ import {
 import { captureHandoffGate } from '../../../lib/flywheel/capture.js';
 import { runPrerequisitePreflight } from './pre-checks/prerequisite-preflight.js';
 
+/**
+ * QF-20260525-378: fold a FAILED prerequisite preflight into a precheck verdict
+ * for parity with execute(), which HARD-FAILS on it. Precheck previously only
+ * logged a failed preflight and returned success=result.passed from the gates
+ * alone, so precheck PASSED while execute FAILED on e.g. USER_STORIES_MISSING.
+ * Pure + exported for unit testing.
+ * @param {{passed?:boolean, issues?:object[], failedGates?:object[]}} result Gate-validation result
+ * @param {{passed?:boolean, issues?:{code:string,message:string}[]}} preflight Prerequisite preflight result
+ * @returns {{success:boolean, issues:object[], failedGates:object[]}}
+ */
+export function applyPreflightToVerdict(result, preflight) {
+  const failed = !!preflight && preflight.passed === false;
+  const pfIssues = failed ? preflight.issues.map(i => `[${i.code}] ${i.message}`) : [];
+  return {
+    success: (result?.passed ?? false) && !failed,
+    issues: [
+      ...pfIssues.map(issue => ({ gate: 'PREREQUISITE_PREFLIGHT', issue })),
+      ...((result && result.issues) || [])
+    ],
+    failedGates: [
+      ...(failed ? [{ name: 'PREREQUISITE_PREFLIGHT', issues: pfIssues }] : []),
+      ...((result && result.failedGates) || [])
+    ]
+  };
+}
+
 export class HandoffOrchestrator {
   constructor(options = {}) {
     // Create or use injected Supabase client
@@ -344,12 +370,15 @@ export class HandoffOrchestrator {
         console.log('─'.repeat(60));
       }
 
+      // QF-20260525-378: fold a failed prerequisite preflight into the verdict
+      // for parity with execute() (which hard-fails on it). See helper above.
+      const verdict = applyPreflightToVerdict(result, preflight);
       return {
-        success: result.passed,
         handoffType: normalizedType,
         sdId,
         sdTitle: sd.title,
-        ...result
+        ...result,
+        ...verdict
       };
 
     } catch (error) {

--- a/tests/unit/handoff/precheck-preflight-parity.test.js
+++ b/tests/unit/handoff/precheck-preflight-parity.test.js
@@ -1,0 +1,51 @@
+// QF-20260525-378: handoff precheck must fold a FAILED prerequisite preflight
+// into its verdict, for parity with execute() (which hard-fails on it).
+// Pre-fix, precheck only logged the failed preflight and reported
+// success=result.passed, so precheck PASSED while execute FAILED on
+// USER_STORIES_MISSING (false-pass). Unit-test the extracted pure helper.
+
+import { describe, it, expect } from 'vitest';
+import { applyPreflightToVerdict } from '../../../scripts/modules/handoff/HandoffOrchestrator.js';
+
+const failedPreflight = {
+  passed: false,
+  issues: [{ code: 'USER_STORIES_MISSING', message: 'No user stories for SD' }],
+};
+
+describe('QF-378 applyPreflightToVerdict', () => {
+  it('failed preflight forces success=false even when gates pass', () => {
+    const v = applyPreflightToVerdict({ passed: true, issues: [], failedGates: [] }, failedPreflight);
+    expect(v.success).toBe(false);
+    expect(v.failedGates.some(g => g.name === 'PREREQUISITE_PREFLIGHT')).toBe(true);
+    expect(v.issues.some(i => i.gate === 'PREREQUISITE_PREFLIGHT' && /USER_STORIES_MISSING/.test(i.issue))).toBe(true);
+  });
+
+  it('passed preflight preserves gate verdict and adds no preflight gate', () => {
+    const v = applyPreflightToVerdict({ passed: true, issues: [], failedGates: [] }, { passed: true, issues: [] });
+    expect(v.success).toBe(true);
+    expect(v.failedGates.some(g => g.name === 'PREREQUISITE_PREFLIGHT')).toBe(false);
+  });
+
+  it('failing gates stay failing regardless of preflight', () => {
+    const v = applyPreflightToVerdict(
+      { passed: false, issues: [{ gate: 'GATE2', issue: 'low score' }], failedGates: [{ name: 'GATE2', issues: ['low'] }] },
+      { passed: true, issues: [] }
+    );
+    expect(v.success).toBe(false);
+    expect(v.failedGates.some(g => g.name === 'GATE2')).toBe(true);
+  });
+
+  it('null/absent preflight is treated as not-failed', () => {
+    expect(applyPreflightToVerdict({ passed: true }, null).success).toBe(true);
+    expect(applyPreflightToVerdict({ passed: true }, undefined).success).toBe(true);
+  });
+
+  it('merges preflight issues ahead of existing gate issues', () => {
+    const v = applyPreflightToVerdict(
+      { passed: false, issues: [{ gate: 'GATE2', issue: 'x' }], failedGates: [{ name: 'GATE2', issues: ['x'] }] },
+      failedPreflight
+    );
+    expect(v.issues[0].gate).toBe('PREREQUISITE_PREFLIGHT');
+    expect(v.failedGates[0].name).toBe('PREREQUISITE_PREFLIGHT');
+  });
+});


### PR DESCRIPTION
## QF-20260525-378 — handoff precheck/execute parity on prerequisite preflight

**Problem (false-pass).** `HandoffOrchestrator.precheckHandoff` runs `runPrerequisitePreflight`, but on failure it only **logs** the issues ("Continuing with full gate check…") and then returns `success: result.passed` from the gate results alone. `execute()` (HandoffOrchestrator.js ~line 131) **hard-fails** on the same preflight. Net effect: `precheck PLAN-TO-EXEC` reports **pass** while `execute` then **fails** on `USER_STORIES_MISSING` — exactly the "fix issues before execute" guarantee precheck is supposed to provide.

**Fix.** Extract a pure, exported `applyPreflightToVerdict(result, preflight)`:
- `success = result.passed && !preflightFailed`
- prepends a `PREREQUISITE_PREFLIGHT` entry to both `issues` and `failedGates` when the preflight failed.

`precheckHandoff` now returns `{ ...result, ...verdict }`, so the preflight failure is reflected in the verdict (parity with `execute`). Passing preflights are unchanged.

**Tests.** `tests/unit/handoff/precheck-preflight-parity.test.js` — 5 cases: failed preflight forces `success:false` + surfaces the gate; passing preflight preserves the gate verdict; failing gates stay failing; null/absent preflight is a no-op; preflight issues merge ahead of gate issues. 33 source LOC (Tier-2).

**Scope note.** This addresses the blocking symptom of feedback `f3f3d34d`. Its other two symptoms: `ShippingContext runData.filter` was already fixed (QF-20260525-254 / #3928); the non-blocking worktree "Cannot find module" warnings reference stale paths (`executors/auto-complete-deliverables.js`, `modules/verify-git-commit-status.js`) and are re-filed separately.

Closes feedback f3f3d34d-9101-432e-aef4-15adc0720a4d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
