### PR TITLE
fix(QF-20260525-597): correct broken relative-import depths in exec-to-plan handoff modules

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/git-verification.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/git-verification.js
@@ -30,7 +30,7 @@ export async function verifyGitCommits(sdId, sd, determineTargetRepository) {
   }
 
   try {
-    const { default: GitCommitVerifier } = await import('../../../verify-git-commit-status.js');
+    const { default: GitCommitVerifier } = await import('../../../../verify-git-commit-status.js');
     const appPath = determineTargetRepository(sd);
     // SD-LEO-GEN-RENAME-COLUMNS-SELF-001-E: Pass sd_key for commit search
     const verifier = new GitCommitVerifier(sdId, appPath, { sdKey: sd?.sd_key });

--- a/scripts/modules/handoff/executors/exec-to-plan/test-evidence.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/test-evidence.js
@@ -164,7 +164,7 @@ export async function autoCompleteDeliverablesForSD(supabase, sdId) {
   console.log('-'.repeat(50));
 
   try {
-    const { autoCompleteDeliverables, checkDeliverablesNeedCompletion } = await import('../auto-complete-deliverables.js');
+    const { autoCompleteDeliverables, checkDeliverablesNeedCompletion } = await import('../../auto-complete-deliverables.js');
 
     const needsCompletion = await checkDeliverablesNeedCompletion(sdId, supabase);
     if (needsCompletion.needs_completion) {


### PR DESCRIPTION
Two dynamic imports in EXEC-TO-PLAN handoff modules resolved to non-existent paths (swallowed as non-blocking warnings → silent degradation of deliverables auto-completion + git-commit verification):

- `exec-to-plan/test-evidence.js` imported `../auto-complete-deliverables.js` → corrected to `../../` (file lives at `scripts/modules/handoff/auto-complete-deliverables.js`)
- `exec-to-plan/git-verification.js` imported `../../../verify-git-commit-status.js` → corrected to `../../../../` (file lives at `scripts/verify-git-commit-status.js`)

Both corrected depths verified to resolve to existing modules; both old paths confirmed missing. `plan-to-lead/gates/git-commit-enforcement.js` already used the correct depth and is unchanged. Surfaced as the residual non-blocking symptom of feedback f3f3d34d (its blocking symptom shipped as QF-20260525-378 / #3952; `runData.filter` was already fixed by QF-20260525-254 / #3928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)