### PR TITLE
feat(SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001): Phase 1 — venture-build defensive reconciliation

### DIFF
--- a/database/migrations/20260525_applications_trust_tier_additive.sql
+++ b/database/migrations/20260525_applications_trust_tier_additive.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Migration: 20260525_applications_trust_tier_additive.sql
+-- SD: SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (C2 / SECURITY VB-2) — ADDITIVE
+-- Purpose: Add a trust_tier to the applications registry so the auto-merge path
+--          (lib/ship/auto-merge.mjs) and future routing have a DB-backed SSOT for
+--          which repos may be merged unattended vs. require a human gate.
+-- Mode: IDEMPOTENT + ADDITIVE ONLY. Safe to re-run.
+--
+-- Tiers:
+--   'platform' — EHG platform repos; eligible for unattended auto-merge.
+--   'trusted'  — vetted internal repos that may auto-merge (none by default).
+--   'external' — venture / third-party repos; auto-merge REFUSED, human merge required.
+--
+-- Note: auto-merge.mjs ALSO hard-codes the two platform repos as a fail-closed
+--   default (defense-in-depth), so a missing/corrupt registry can never widen the
+--   auto-merge surface beyond ehg + EHG_Engineer. This column is the broader SSOT.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.applications
+  ADD COLUMN IF NOT EXISTS trust_tier varchar(20) NOT NULL DEFAULT 'external';
+
+-- Constraint added separately so re-runs don't error if it already exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ck_applications_trust_tier'
+  ) THEN
+    ALTER TABLE public.applications
+      ADD CONSTRAINT ck_applications_trust_tier
+      CHECK (trust_tier IN ('platform','trusted','external'));
+  END IF;
+END $$;
+
+-- Platform repos are the only unattended-auto-merge tier by default.
+UPDATE public.applications
+  SET trust_tier = 'platform'
+  WHERE kind = 'platform' AND trust_tier <> 'platform';
+
+-- Ventures default to 'external' (the column default already enforces this for
+-- new rows); make existing venture rows explicit.
+UPDATE public.applications
+  SET trust_tier = 'external'
+  WHERE kind = 'venture' AND trust_tier NOT IN ('external','trusted');
+
+COMMENT ON COLUMN public.applications.trust_tier IS
+  'auto-merge eligibility: platform=unattended OK, trusted=vetted internal, external=human merge required (venture/3rd-party). SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C2/VB-2.';
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, if needed):
+--   ALTER TABLE public.applications DROP CONSTRAINT IF EXISTS ck_applications_trust_tier;
+--   ALTER TABLE public.applications DROP COLUMN IF EXISTS trust_tier;
+-- ============================================================================

--- a/database/migrations/20260525_venture_build_routing_isolation_additive.sql
+++ b/database/migrations/20260525_venture_build_routing_isolation_additive.sql
@@ -1,0 +1,110 @@
+-- ============================================================================
+-- Migration: 20260525_venture_build_routing_isolation_additive.sql
+-- SD: SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5) — ADDITIVE / NON-BREAKING
+-- Purpose: Stand up the canonical `applications` registry, seed/backfill it
+--          from live data, and HEAL the missing vw_venture_registry view that
+--          lib/venture-resolver.js::getVentureConfigAsync (line 182) queries.
+-- Mode: IDEMPOTENT + ADDITIVE ONLY. No DROP/DELETE/ALTER TYPE. Safe to re-run.
+--
+-- NOTE: The fail-closed validating trigger on strategic_directives_v2 is
+--       DELIBERATELY NOT in this file. It is deferred to
+--       20260525_venture_build_routing_isolation_trigger_DEFERRED.sql
+--       (NOT applied yet) until the leo-create-sd path auto-registers a
+--       venture in `applications` before creating its SD. Enabling the trigger
+--       prematurely would block SD creation fleet-wide for any unregistered
+--       venture name.
+--
+-- KEY FINDING: target_application lives on strategic_directives_v2 (NOT on
+--   ventures). Routing data (3260 rows) is on sd_v2.target_application.
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (1) Canonical applications registry table. Backs applications/registry.json
+--     AND vw_venture_registry.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.applications (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            varchar(120) NOT NULL,          -- canonical target_application value
+  normalized_name varchar(120) NOT NULL,          -- NFKD/lower, matches venture-resolver normalizer
+  kind            varchar(20)  NOT NULL DEFAULT 'venture'
+                    CHECK (kind IN ('platform','venture')),
+  github_repo     text,
+  local_path      text,
+  repo_url        text,
+  deployment_url  text,
+  deployment_target varchar(60),
+  supabase_project_id text,
+  current_lifecycle_stage integer,
+  status          varchar(20)  NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','inactive','retired')),
+  venture_id      uuid REFERENCES public.ventures(id) ON DELETE SET NULL,
+  metadata        jsonb        NOT NULL DEFAULT '{}'::jsonb,
+  created_at      timestamptz  NOT NULL DEFAULT now(),
+  updated_at      timestamptz  NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_applications_name_lower
+  ON public.applications (lower(name));
+CREATE UNIQUE INDEX IF NOT EXISTS uq_applications_normalized_name
+  ON public.applications (normalized_name);
+CREATE INDEX IF NOT EXISTS idx_applications_status ON public.applications (status);
+
+COMMENT ON TABLE public.applications IS
+  'Canonical registry of valid target_application routing values (platform repos + ventures). SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-5. Backs vw_venture_registry + applications/registry.json.';
+
+-- updated_at trigger (idempotent)
+CREATE OR REPLACE FUNCTION public.set_updated_at_applications()
+RETURNS trigger LANGUAGE plpgsql AS $fn$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$fn$;
+DROP TRIGGER IF EXISTS trg_applications_updated_at ON public.applications;
+CREATE TRIGGER trg_applications_updated_at
+  BEFORE UPDATE ON public.applications
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_applications();
+
+-- ---------------------------------------------------------------------------
+-- (2) Seed platform repos + DISTINCT existing target_application values so the
+--     registry already covers every live value. ON CONFLICT DO NOTHING => re-runnable.
+-- ---------------------------------------------------------------------------
+INSERT INTO public.applications (name, normalized_name, kind, github_repo, local_path, status)
+VALUES
+  ('EHG',          'ehg',          'platform', 'rickfelix/ehg.git',          NULL, 'active'),
+  ('EHG_Engineer', 'ehg_engineer', 'platform', 'rickfelix/EHG_Engineer.git', NULL, 'active')
+ON CONFLICT (lower(name)) DO NOTHING;
+
+-- Backfill every distinct non-platform value currently in use (CodeGuardian CI,
+-- PrivacyPatrol AI, CronRead, CommitCraft AI, Cron Canary, CronLinter, Canvas AI, ...).
+INSERT INTO public.applications (name, normalized_name, kind, status)
+SELECT DISTINCT s.target_application,
+       lower(regexp_replace(s.target_application, '\s+', '_', 'g')),
+       'venture', 'active'
+FROM public.strategic_directives_v2 s
+WHERE s.target_application IS NOT NULL
+  AND lower(s.target_application) NOT IN ('ehg','ehg_engineer')
+ON CONFLICT (lower(name)) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- (3) Create the MISSING vw_venture_registry view that the SHIPPED
+--     lib/venture-resolver.js::getVentureConfigAsync already queries (exact 10
+--     named cols). Today that query throws -> this heals latent breakage.
+--     ventures lacks normalized_name AND local_path, so the view sources from
+--     applications, not ventures.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.vw_venture_registry AS
+  SELECT a.id, a.name, a.normalized_name, a.local_path, a.repo_url,
+         a.deployment_url, a.deployment_target, a.status,
+         a.current_lifecycle_stage, a.created_at
+  FROM public.applications a
+  WHERE a.status = 'active';
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, if needed):
+--   DROP VIEW IF EXISTS public.vw_venture_registry;
+--   DROP TRIGGER IF EXISTS trg_applications_updated_at ON public.applications;
+--   DROP FUNCTION IF EXISTS public.set_updated_at_applications();
+--   DROP TABLE IF EXISTS public.applications;   -- only if no FK dependents created
+-- ============================================================================

--- a/database/migrations/20260525_venture_build_routing_isolation_additive.sql
+++ b/database/migrations/20260525_venture_build_routing_isolation_additive.sql
@@ -59,8 +59,11 @@ CREATE OR REPLACE FUNCTION public.set_updated_at_applications()
 RETURNS trigger LANGUAGE plpgsql AS $fn$
 BEGIN NEW.updated_at = now(); RETURN NEW; END;
 $fn$;
-DROP TRIGGER IF EXISTS trg_applications_updated_at ON public.applications;
-CREATE TRIGGER trg_applications_updated_at
+-- CREATE OR REPLACE TRIGGER (PG14+) is the idempotent form the pre-merge migration-readiness
+-- probe accepts on an already-existing object (this migration is applied during EXEC, then the
+-- file rides the PR — so the trigger already exists at merge-check time). Equivalent to the prior
+-- DROP-IF-EXISTS + CREATE, re-runnable cleanly.
+CREATE OR REPLACE TRIGGER trg_applications_updated_at
   BEFORE UPDATE ON public.applications
   FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_applications();
 

--- a/database/migrations/20260525_venture_build_routing_isolation_trigger_DEFERRED.sql
+++ b/database/migrations/20260525_venture_build_routing_isolation_trigger_DEFERRED.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- Migration: 20260525_venture_build_routing_isolation_trigger_DEFERRED.sql
+-- SD: SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5) — FAIL-CLOSED ENFORCEMENT
+--
+-- ⚠️  DEFERRED — DO NOT APPLY YET. ⚠️
+--
+-- This migration enables a fail-closed BEFORE INSERT OR UPDATE OF
+-- target_application trigger on strategic_directives_v2. Applying it before the
+-- leo-create-sd path is updated to AUTO-REGISTER a venture in public.applications
+-- (BEFORE creating its SD) would block SD creation FLEET-WIDE for any venture
+-- name not yet present in the registry — including in-flight parallel sessions.
+--
+-- PRECONDITIONS before applying this file (all must be true):
+--   1. The additive migration (20260525_venture_build_routing_isolation_additive.sql)
+--      has been applied and `public.applications` is populated (0 orphans).
+--   2. leo-create-sd.js (and any other SD-creation path) auto-registers the
+--      target_application in public.applications before INSERTing the SD row.
+--   3. A guard exists so legitimate no-venture LEO work (sd_type in
+--      infrastructure/governance/leo/documentation/refactor, or
+--      metadata.engineering_only=true) defaults to a registered platform repo
+--      (EHG / EHG_Engineer), mirroring lib/eva/bridge/sd-router.js.
+--
+-- Apply with: node scripts/run-sql-migration.js \
+--   database/migrations/20260525_venture_build_routing_isolation_trigger_DEFERRED.sql
+-- (or via the proven single-transaction direct-connection pattern).
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Pre-flight: assert backfill covered every existing row. Fails LOUD so the
+-- trigger is never activated against an inconsistent table.
+-- ---------------------------------------------------------------------------
+DO $preflight$
+DECLARE orphan_cnt integer;
+BEGIN
+  SELECT count(*) INTO orphan_cnt
+  FROM public.strategic_directives_v2 s
+  LEFT JOIN public.applications a ON lower(a.name) = lower(s.target_application)
+  WHERE s.target_application IS NOT NULL AND a.id IS NULL;
+  IF orphan_cnt > 0 THEN
+    RAISE EXCEPTION 'Backfill incomplete: % sd_v2 rows have target_application not in registry. Run the additive migration first.', orphan_cnt;
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------------
+-- Fail-closed validating function. Registry-backed, case-insensitive.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_target_application_registry()
+RETURNS trigger LANGUAGE plpgsql AS $enforce$
+BEGIN
+  -- Fail-closed: target_application must be NON-NULL and registry-known.
+  IF NEW.target_application IS NULL OR btrim(NEW.target_application) = '' THEN
+    RAISE EXCEPTION 'target_application is required (fail-closed routing). SD %', NEW.sd_key
+      USING HINT = 'Set target_application to a registered application name (see public.applications).';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.applications a
+    WHERE lower(a.name) = lower(NEW.target_application) AND a.status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'target_application % is not a registered active application. SD %',
+      NEW.target_application, NEW.sd_key
+      USING HINT = 'Register the application in public.applications first, or fix the typo.';
+  END IF;
+  RETURN NEW;
+END
+$enforce$;
+
+-- Fire ONLY when target_application is set/changed => historical completed
+-- rows are never re-validated by unrelated UPDATEs (non-breaking).
+DROP TRIGGER IF EXISTS trg_enforce_target_application_registry ON public.strategic_directives_v2;
+CREATE TRIGGER trg_enforce_target_application_registry
+  BEFORE INSERT OR UPDATE OF target_application ON public.strategic_directives_v2
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_target_application_registry();
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, if needed):
+--   DROP TRIGGER IF EXISTS trg_enforce_target_application_registry ON public.strategic_directives_v2;
+--   DROP FUNCTION IF EXISTS public.enforce_target_application_registry();
+-- ============================================================================

--- a/database/migrations/20260525_ventures_build_model_additive.sql
+++ b/database/migrations/20260525_ventures_build_model_additive.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- Migration: 20260525_ventures_build_model_additive.sql
+-- SD: SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d) — ADDITIVE / NON-BREAKING
+-- Purpose: Add ventures.build_model — the SINGLE SSOT arbiter for which build path a venture
+--          takes at Stage 19 ('leo_bridge' = LEO-SD bridge | 'seeded_repo' = seed+Replit-Agent+S20).
+--          Resolves the un-arbitered "model schism" where the S19 entry gate and the post-stage
+--          bridge hook each independently read venture_stage_work.advisory_data.build_method and
+--          defaulted to 'replit_agent', so the seeded path silently won (0 SDs for CronLinter/Canvas AI).
+-- Mode: IDEMPOTENT + ADDITIVE. NULLABLE with NO default → existing rows stay NULL → the arbiter
+--       (lib/eva/bridge/resolve-build-model.js) resolves NULL to the safe default (seeded_repo via
+--       legacy build_method), so in-flight ventures are UNAFFECTED. 'leo_bridge' is an explicit
+--       per-venture opt-in (FR-3 sets it on CronLinter/Canvas AI).
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.ventures ADD COLUMN IF NOT EXISTS build_model varchar(20);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ck_ventures_build_model') THEN
+    ALTER TABLE public.ventures
+      ADD CONSTRAINT ck_ventures_build_model
+      CHECK (build_model IS NULL OR build_model IN ('leo_bridge', 'seeded_repo'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.ventures.build_model IS
+  'SSOT venture build path at Stage 19: leo_bridge (LEO-SD bridge — orchestrator+child SDs) | seeded_repo (seed repo + Replit Agent + S20 gate) | NULL (arbiter default = seeded_repo until the venture EXEC loop ships). SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001.';
+
+COMMIT;
+
+-- ROLLBACK (manual): ALTER TABLE public.ventures DROP CONSTRAINT IF EXISTS ck_ventures_build_model;
+--                    ALTER TABLE public.ventures DROP COLUMN IF EXISTS build_model;

--- a/lib/__tests__/repo-paths-git-capable.test.js
+++ b/lib/__tests__/repo-paths-git-capable.test.js
@@ -70,6 +70,36 @@ describe('isVentureRepo', () => {
   });
 });
 
+// ── normalizeAppName + separator/case-insensitive resolution ───────────────
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001: an existing venture clone was
+// unresolvable because resolveRepoPath did an exact lowercase compare
+// ("commitcraft-ai" !== "commitcraft ai"). normalizeAppName collapses separators+case.
+
+describe('normalizeAppName', () => {
+  it('collapses case + all non-alphanumerics to one canonical key', async () => {
+    const { normalizeAppName } = await import('../repo-paths.js');
+    const k = 'commitcraftai';
+    expect(normalizeAppName('CommitCraft AI')).toBe(k);
+    expect(normalizeAppName('commitcraft-ai')).toBe(k);
+    expect(normalizeAppName('commitcraft_ai')).toBe(k);
+    expect(normalizeAppName('Commit Craft  AI')).toBe(k);
+    expect(normalizeAppName('EHG_Engineer')).toBe('ehgengineer');
+    expect(normalizeAppName(null)).toBe('');
+    expect(normalizeAppName(undefined)).toBe('');
+  });
+});
+
+describe('resolveRepoPath separator/case-insensitive matching', () => {
+  it('resolves all separator/case variants of EHG_Engineer to the same root (env-independent self-ref)', async () => {
+    const { clearCache, resolveRepoPath, ENGINEER_ROOT } = await import('../repo-paths.js');
+    clearCache();
+    const variants = ['EHG_Engineer', 'ehg_engineer', 'EHG Engineer', 'ehg-engineer', 'EHGEngineer'];
+    for (const v of variants) {
+      expect(resolveRepoPath(v)).toBe(ENGINEER_ROOT);
+    }
+  });
+});
+
 // ── GATE6 branch-enforcement self-skip ─────────────────────────────────────
 
 describe('GATE6 branch-enforcement self-skip', () => {

--- a/lib/__tests__/repo-paths-git-capable.test.js
+++ b/lib/__tests__/repo-paths-git-capable.test.js
@@ -51,6 +51,25 @@ describe('isGitCapableRepo', () => {
   });
 });
 
+// ── isVentureRepo (drives the platform-skip vs venture-fail-closed branch) ──
+
+describe('isVentureRepo', () => {
+  it('returns false for platform repos (EHG, EHG_Engineer — case-insensitive)', async () => {
+    const { isVentureRepo } = await import('../repo-paths.js');
+    expect(isVentureRepo('EHG')).toBe(false);
+    expect(isVentureRepo('ehg')).toBe(false);
+    expect(isVentureRepo('EHG_Engineer')).toBe(false);
+    expect(isVentureRepo('ehg_engineer')).toBe(false);
+  });
+
+  it('returns true for any non-platform (venture) target', async () => {
+    const { isVentureRepo } = await import('../repo-paths.js');
+    expect(isVentureRepo('CronLinter')).toBe(true);
+    expect(isVentureRepo('Canvas AI')).toBe(true);
+    expect(isVentureRepo('FakeVentureXYZ')).toBe(true);
+  });
+});
+
 // ── GATE6 branch-enforcement self-skip ─────────────────────────────────────
 
 describe('GATE6 branch-enforcement self-skip', () => {
@@ -72,6 +91,27 @@ describe('GATE6 branch-enforcement self-skip', () => {
     expect(result.issues).toHaveLength(0);
     expect(result.warnings.length).toBeGreaterThan(0);
     expect(result.warnings[0]).toMatch(/GATE6 N\/A/);
+  });
+
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4): a not-git-capable VENTURE
+  // target must FAIL-CLOSED, not free-pass like the EHG platform repo.
+  it('FAILS-CLOSED for a not-git-capable VENTURE target (no free-pass)', async () => {
+    const { createBranchEnforcementGate } = await import(
+      '../../scripts/modules/handoff/executors/plan-to-exec/gates/branch-enforcement.js'
+    );
+
+    // FakeVentureXYZ: not in registry → resolveRepoPath null → isGitCapableRepo false;
+    // not a platform repo → isVentureRepo true → fail-closed.
+    const sd = { target_application: 'FakeVentureXYZ', title: 'venture SD', sd_type: 'feature' };
+    const gate = createBranchEnforcementGate(sd, '/bogus/path');
+    const result = await gate.validator({ sdId: 'SD-VENTURE-TEST-001' });
+
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.details.fail_closed_venture_repo).toBe(true);
+    expect(result.details.target_application).toBe('FakeVentureXYZ');
+    expect(result.issues[0]).toMatch(/FAIL-CLOSED/);
+    expect(result.issues[0]).toMatch(/VB-4/);
   });
 
   it('does NOT self-skip for EHG_Engineer target (proceeds to verifier path)', async () => {
@@ -126,6 +166,29 @@ describe('GATE5 git-commit-enforcement self-skip', () => {
     expect(result.details.skipped_not_applicable).toBe(true);
     expect(result.details.target_application).toBe('EHG');
     expect(result.warnings[0]).toMatch(/GATE5 N\/A/);
+  });
+
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4): venture target fail-closed.
+  it('FAILS-CLOSED for a not-git-capable VENTURE target (non-infra sd_type)', async () => {
+    const { createGitCommitEnforcementGate } = await import(
+      '../../scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js'
+    );
+
+    // sd_type='feature' so the infra/bugfix relaxed early-return does NOT fire.
+    const sd = { target_application: 'FakeVentureXYZ', title: 'venture SD', sd_type: 'feature' };
+    const supabase = {
+      from: () => ({ select: () => ({ eq: async () => ({ data: [] }) }) })
+    };
+
+    const gate = createGitCommitEnforcementGate(supabase, sd, '/bogus/path');
+    const result = await gate.validator({ sdId: 'SD-VENTURE-TEST-002', sd });
+
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.details.fail_closed_venture_repo).toBe(true);
+    expect(result.details.target_application).toBe('FakeVentureXYZ');
+    expect(result.issues[0]).toMatch(/FAIL-CLOSED/);
+    expect(result.issues[0]).toMatch(/VB-4/);
   });
 
   it('infra sd_type still takes the original relaxed path (existing behaviour unchanged)', async () => {

--- a/lib/eva/bridge/replit-reentry-adapter.js
+++ b/lib/eva/bridge/replit-reentry-adapter.js
@@ -31,6 +31,22 @@ export async function importReplitBuild(ventureId, syncData, options = {}) {
     return { success: false, stagesWritten: [], errors: ['No commit SHA in sync data'] };
   }
 
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d): this adapter is the seeded-repo
+  // S19-BYPASS — it writes S20/21/22 directly, skipping Stage 19 and its bridge hook (exactly how
+  // Canvas AI never got LEO SDs). Refuse ventures whose build_model is explicitly 'leo_bridge':
+  // they MUST build via the LEO-SD bridge at Stage 19, not have a Replit build imported around it.
+  try {
+    const { data: v } = await supabase.from('ventures').select('build_model').eq('id', ventureId).maybeSingle();
+    const { resolveBuildModel } = await import('./resolve-build-model.js');
+    if (resolveBuildModel({ ventureBuildModel: v?.build_model }) === 'leo_bridge') {
+      return {
+        success: false,
+        stagesWritten: [],
+        errors: [`refusing Replit build import for leo_bridge venture ${ventureId} — it must build via the LEO-SD bridge at Stage 19 (RECONCILE-VENTURE-BUILD-001 SSOT arbiter).`],
+      };
+    }
+  } catch { /* fail-open: a transient arbiter lookup error must not block legacy seeded imports */ }
+
   // Build the Stage 20 (Build Execution) record
   const stage20Data = {
     venture_id: ventureId,

--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -28,6 +28,71 @@ import { buildClaudeMd } from './claude-md-writer.js';
 import { buildBuildTasks } from './build-tasks-writer.js';
 import { buildDesignPrompts } from './design-prompts-writer.js';
 import { buildReplitConfig } from './replit-config-writer.js';
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C5 + C3 (SECURITY VB-5/VB-3): fail-closed
+// venture-repo routing + secret scan before any push to an external venture repo.
+import { SAFE_GITHUB_HTTPS } from './resolve-venture-repo.js';
+import { scanSecrets } from '../../../scripts/modules/session-summary/secret-redactor.js';
+
+// Platform repos must NEVER be a venture-seed target — seeding venture content into
+// EHG/EHG_Engineer is a routing escape (C5/VB-5). Matched after .git/trailing-slash strip.
+const PLATFORM_REPO_URL_RES = [
+  /^https:\/\/github\.com\/rickfelix\/ehg$/i,
+  /^https:\/\/github\.com\/rickfelix\/EHG_Engineer$/i,
+];
+
+/**
+ * C5 (SECURITY VB-5): fail-closed venture-repo routing guard. The seeder clones and
+ * PUSHES to repoUrl, so an empty/unknown/hostile/platform URL must hard-fail rather than
+ * fall through (e.g. clone garbage, or push venture docs into the platform repo).
+ *
+ * @param {string} repoUrl
+ * @returns {string} normalized https URL (no .git)
+ * @throws if not a safe non-platform GitHub HTTPS venture URL
+ */
+export function assertSeedableVentureRepo(repoUrl) {
+  const normalized = (repoUrl || '').trim().replace(/\.git\/?$/, '');
+  if (!normalized || !SAFE_GITHUB_HTTPS.test(normalized)) {
+    throw new Error(
+      `[seeder] FAIL-CLOSED: repoUrl '${repoUrl ?? ''}' is not a valid GitHub HTTPS venture repo URL — `
+      + `refusing to clone/seed (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C5 / SECURITY VB-5; no fall-through to platform).`
+    );
+  }
+  if (PLATFORM_REPO_URL_RES.some((re) => re.test(normalized))) {
+    throw new Error(
+      `[seeder] FAIL-CLOSED: refusing to seed venture content into the PLATFORM repo '${normalized}' `
+      + `(C5 / VB-5 — venture builds must target their own repo, never EHG/EHG_Engineer).`
+    );
+  }
+  return normalized;
+}
+
+// Text file extensions worth scanning for secrets before push (skip binaries: png/jpg/etc).
+const SCANNABLE_EXT_RE = /\.(md|markdown|json|jsonc|js|cjs|mjs|ts|tsx|jsx|txt|env|ya?ml|sh|bash|html?|css|toml|ini|cfg|conf|xml|svg)$/i;
+const SCANNABLE_EXACT = new Set(['.replit', 'CLAUDE.md', 'replit.md', '.env', 'Dockerfile']);
+
+/**
+ * C3 (SECURITY VB-3): scan the text files staged for push for stack-aware secrets.
+ * Returns the list of hits ({ file, categories }). Binary files are skipped. Pure
+ * (fs read only) so it is unit-testable against a fixture dir.
+ *
+ * @param {string} repoDir
+ * @param {string[]} stagedRelPaths - repo-relative paths (e.g. from git diff --cached --name-only)
+ * @returns {{ file: string, categories: string[] }[]}
+ */
+export function scanStagedFilesForSecrets(repoDir, stagedRelPaths) {
+  const hits = [];
+  for (const rel of stagedRelPaths || []) {
+    const base = rel.split('/').pop() || rel;
+    if (!SCANNABLE_EXT_RE.test(rel) && !SCANNABLE_EXACT.has(base)) continue;
+    const abs = join(repoDir, rel);
+    if (!existsSync(abs)) continue;
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); } catch { continue; }
+    const { found, categories } = scanSecrets(content);
+    if (found) hits.push({ file: rel, categories });
+  }
+  return hits;
+}
 
 /**
  * Parse content that may be a JSON string.
@@ -706,6 +771,13 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
   // or 'build-into' (seed into the venture's existing design repo).
   const mode = options.mode === 'build-into' ? 'build-into' : 'create-new';
 
+  // C5 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-5): fail-closed routing.
+  // The seeder clones AND pushes to repoUrl — an empty/unknown/hostile/platform URL must
+  // hard-fail here rather than fall through to clone garbage or push venture content into
+  // the platform repo. Validate for its throw side-effect; keep the caller's original URL
+  // form (e.g. trailing .git) for downstream clone + venture_resources provenance.
+  assertSeedableVentureRepo(repoUrl);
+
   // Fetch all artifacts via the RPC
   const { data, error } = await supabase.rpc('export_blueprint_review', { p_venture_id: ventureId });
   if (error) throw new Error(`export_blueprint_review failed: ${error.message}`);
@@ -730,10 +802,38 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
   // the clone + push authenticate. Non-fatal — if gh isn't available the clone
   // below surfaces the failure (we never silently fall back to a new repo).
   if (mode === 'build-into') {
-    try {
-      execSync('gh auth setup-git', { encoding: 'utf-8', timeout: 15000 });
-    } catch (err) {
-      errors.push(`gh auth setup-git failed (private clone may not authenticate): ${err.message}`);
+    // C1 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-1): per-venture token seam.
+    // PREFERRED: a per-venture least-privilege token (a GitHub App installation token scoped to
+    // THIS venture repo) supplied via options.tokenProvider. The shared ambient gh PAT grants
+    // the harness write access to every repo the operator's gh login can reach — a lateral-
+    // movement surface across all ventures + both platform repos. When no provider is wired we
+    // fall back to that ambient credential helper and WARN loudly. FULL closure of VB-1 requires
+    // provisioning the GitHub App (ops prerequisite) — and that closure GATES the FR-3 venture
+    // re-route (routing the harness into untrusted venture repos under the shared PAT is exactly
+    // the exposure C1 must remove first).
+    let perVentureTokenConfigured = false;
+    if (typeof options.tokenProvider === 'function') {
+      try {
+        const provided = await options.tokenProvider({ ventureId, repoUrl });
+        if (provided && typeof provided.configureGit === 'function') {
+          await provided.configureGit({ repoDir, repoUrl });
+          perVentureTokenConfigured = true;
+        }
+      } catch (err) {
+        errors.push(`per-venture tokenProvider failed: ${err.message}`);
+      }
+    }
+    if (!perVentureTokenConfigured) {
+      console.warn(
+        '[seeder] ⚠ C1/VB-1: no per-venture tokenProvider supplied — falling back to the shared ambient '
+        + 'gh PAT (broad write surface). Provision the GitHub App + pass options.tokenProvider to scope a '
+        + 'least-privilege per-venture token. FR-3 venture re-route MUST NOT run until VB-1 is closed.'
+      );
+      try {
+        execSync('gh auth setup-git', { encoding: 'utf-8', timeout: 15000 });
+      } catch (err) {
+        errors.push(`gh auth setup-git failed (private clone may not authenticate): ${err.message}`);
+      }
     }
   }
 
@@ -1231,23 +1331,39 @@ export async function seedRepo(ventureId, repoUrl, options = {}) {
     if (!hasStagedChanges) {
       console.log('[github-repo] No changes to commit (repo already up-to-date) — skipping commit+push');
     } else {
-      execSync(
-        'git commit -m "docs: seed reference documents from EHG venture pipeline\n\nAdds branding, architecture, wireframes, approved designs, roadmap,\nGTM strategy, and color palette from Stages 0-17 planning artifacts."',
-        { cwd: repoDir, encoding: 'utf-8' }
-      );
-      try {
-        execSync('git push', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });
-      } catch (pushErr) {
-        // SD-LEO-FEAT-S19-BUILDS-INTO-001: in build-into, a live repo may have
-        // advanced between clone and push (non-fast-forward). Rebase onto the
-        // latest remote and retry ONCE. NEVER force-push (would clobber the
-        // venture's design). create-new keeps the original throw behavior.
-        if (mode === 'build-into') {
-          console.warn('[seeder] build-into push failed; pull --rebase + retry:', pushErr.message);
-          execSync('git pull --rebase', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });
+      // C3 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-3): scan staged text files
+      // for stack-aware secrets (Clerk/Gemini/Replit/…) BEFORE commit/push. Fail CLOSED — never
+      // push a secret into an external venture repo. On a hit: record the error, unstage, and
+      // skip commit+push (the caller surfaces `errors`).
+      const stagedList = (execSync('git diff --cached --name-only', { cwd: repoDir, encoding: 'utf-8' }) || '')
+        .split('\n').map((s) => s.trim()).filter(Boolean);
+      const secretHits = scanStagedFilesForSecrets(repoDir, stagedList);
+      if (secretHits.length > 0) {
+        const detail = secretHits.map((h) => `${h.file} [${h.categories.join(', ')}]`).join('; ');
+        errors.push(
+          `[seeder] FAIL-CLOSED (C3/VB-3): refusing to commit/push — secrets detected in staged files: ${detail}. `
+          + 'Remove the secret(s) before re-seeding.'
+        );
+        try { execSync('git reset', { cwd: repoDir, encoding: 'utf-8' }); } catch { /* best-effort unstage */ }
+      } else {
+        execSync(
+          'git commit -m "docs: seed reference documents from EHG venture pipeline\n\nAdds branding, architecture, wireframes, approved designs, roadmap,\nGTM strategy, and color palette from Stages 0-17 planning artifacts."',
+          { cwd: repoDir, encoding: 'utf-8' }
+        );
+        try {
           execSync('git push', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });
-        } else {
-          throw pushErr;
+        } catch (pushErr) {
+          // SD-LEO-FEAT-S19-BUILDS-INTO-001: in build-into, a live repo may have
+          // advanced between clone and push (non-fast-forward). Rebase onto the
+          // latest remote and retry ONCE. NEVER force-push (would clobber the
+          // venture's design). create-new keeps the original throw behavior.
+          if (mode === 'build-into') {
+            console.warn('[seeder] build-into push failed; pull --rebase + retry:', pushErr.message);
+            execSync('git pull --rebase', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });
+            execSync('git push', { cwd: repoDir, encoding: 'utf-8', timeout: 30000 });
+          } else {
+            throw pushErr;
+          }
         }
       }
     }

--- a/lib/eva/bridge/resolve-build-model.js
+++ b/lib/eva/bridge/resolve-build-model.js
@@ -1,0 +1,64 @@
+/**
+ * resolve-build-model — the single ARBITER for which build path a venture takes at Stage 19.
+ *
+ * SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d): the venture-build "model schism".
+ * Before this, TWO paths competed with no arbiter, each independently reading
+ * `venture_stage_work.advisory_data.build_method` and defaulting to 'replit_agent':
+ *   - the S19 entry gate (stage-execution-worker.js ~1191), and
+ *   - the S19 post-stage bridge hook skip-guard (~2948).
+ * Plus a THIRD bypass: importReplitBuild (replit-reentry-adapter.js) wrote S20/21/22 directly,
+ * skipping S19 entirely. The seeded path silently won for every new venture → the LEO-SD bridge
+ * produced 0 SDs (CronLinter, Canvas AI). This function is the one place that decides.
+ *
+ * Models:
+ *   'leo_bridge'  — build the venture via the LEO-SD bridge (orchestrator + child SDs routed by
+ *                   target_application), the same machinery EHG_Engineer uses to build EHG. SSOT goal.
+ *   'seeded_repo' — seed CLAUDE.md/docs/build-tasks.md into the venture repo + a Replit Agent builds;
+ *                   S20 Code Quality Gate validates. (The FINALIZE-CLAUDE-CODE-001 path.)
+ *
+ * Resolution precedence (explicit wins; safe default):
+ *   1. ventures.build_model, when explicitly 'leo_bridge' | 'seeded_repo' (the SSOT field).
+ *   2. legacy venture_stage_work.advisory_data.build_method ('replit_agent' => 'seeded_repo';
+ *      'leo_bridge' => 'leo_bridge') — backward-compat for in-flight ventures.
+ *   3. DEFAULT_BUILD_MODEL — 'seeded_repo'. NOTE: the chairman SSOT intent is 'leo_bridge', but the
+ *      default is intentionally held at 'seeded_repo' until the venture-build EXEC loop (clone the
+ *      venture repo locally + route child-SD EXEC into it + push back) is wired — flipping the
+ *      default before that loop exists would create SD trees that cannot auto-build (a regression
+ *      vs. the seeded path that does build). Flip DEFAULT_BUILD_MODEL to 'leo_bridge' as the final
+ *      convergence step once the EXEC loop ships.
+ *
+ * @module lib/eva/bridge/resolve-build-model
+ */
+
+export const BUILD_MODELS = Object.freeze(['leo_bridge', 'seeded_repo']);
+
+/** Held at seeded_repo until the venture-build EXEC loop is wired (see module doc). */
+export const DEFAULT_BUILD_MODEL = 'seeded_repo';
+
+/**
+ * Resolve the build model for a venture at Stage 19. Pure.
+ *
+ * @param {Object} args
+ * @param {string|null} [args.ventureBuildModel] - ventures.build_model (the SSOT column)
+ * @param {string|null} [args.legacyBuildMethod] - venture_stage_work.advisory_data.build_method
+ * @returns {'leo_bridge'|'seeded_repo'}
+ */
+export function resolveBuildModel({ ventureBuildModel = null, legacyBuildMethod = null } = {}) {
+  // 1. Explicit SSOT field wins.
+  if (ventureBuildModel === 'leo_bridge' || ventureBuildModel === 'seeded_repo') {
+    return ventureBuildModel;
+  }
+  // 2. Legacy per-stage signal (backward-compat for in-flight ventures).
+  if (legacyBuildMethod === 'replit_agent' || legacyBuildMethod === 'seeded_repo') return 'seeded_repo';
+  if (legacyBuildMethod === 'leo_bridge') return 'leo_bridge';
+  // 3. Safe default (see module doc — chairman SSOT is leo_bridge, gated on the EXEC loop).
+  return DEFAULT_BUILD_MODEL;
+}
+
+/** True when the venture should build via the LEO-SD bridge (create orchestrator + child SDs). */
+export function isLeoBridge(args) { return resolveBuildModel(args) === 'leo_bridge'; }
+
+/** True when the venture should build via the seeded-repo + Replit-Agent + S20 path. */
+export function isSeededRepo(args) { return resolveBuildModel(args) === 'seeded_repo'; }
+
+export default { resolveBuildModel, isLeoBridge, isSeededRepo, BUILD_MODELS, DEFAULT_BUILD_MODEL };

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -14,6 +14,11 @@
  * @module lib/eva/lifecycle/exit-gate-verifiers
  */
 
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4: reuse the canonical pure
+// completion normalizer rather than re-rolling the parse (DRY — same shape the
+// register-deployment route and resolveRepoReadiness produce/consume).
+import { normalizeBuildTaskCompletion } from '../bridge/repo-readiness.js';
+
 /**
  * @typedef {Object} VerifierResult
  * @property {boolean} satisfied
@@ -37,7 +42,7 @@
 async function verifyBuildMvpBuildPresent({ supabase, ventureId }) {
   const { data, error } = await supabase
     .from('venture_artifacts')
-    .select('id')
+    .select('id, artifact_data')
     .eq('venture_id', ventureId)
     .eq('artifact_type', 'build_mvp_build')
     .eq('is_current', true)
@@ -46,9 +51,27 @@ async function verifyBuildMvpBuildPresent({ supabase, ventureId }) {
   if (error) {
     return { satisfied: false, reason: `venture_artifacts query failed: ${error.message}` };
   }
-  return data
-    ? { satisfied: true, reason: '' }
-    : { satisfied: false, reason: 'build_mvp_build artifact missing or not is_current' };
+  if (!data) {
+    return { satisfied: false, reason: 'build_mvp_build artifact missing or not is_current' };
+  }
+
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4): evidence-based, not asserted.
+  // When the artifact carries build-task completion (build_tasks_total > 0), the build is "done"
+  // for the purpose of advancing S19->S20 ONLY if complete >= total. This closes the free-pass
+  // where a bare register-deployment (a registered URL with no verified completion) advanced the
+  // venture on an unverified N/N assertion. Artifacts that carry no completion fields (e.g. the
+  // Replit-reentry advisory artifact) retain prior existence-only semantics — this gate hardens
+  // the register-deployment path without breaking other emitters.
+  const completion = normalizeBuildTaskCompletion(data.artifact_data);
+  if (completion && completion.total > 0 && completion.complete < completion.total) {
+    return {
+      satisfied: false,
+      reason: `build incomplete: ${completion.complete}/${completion.total} build tasks verified complete. `
+        + `S19->S20 requires evidence-based completion (a registered deployment URL alone does not `
+        + `prove the build is done). Supply a verified build_tasks_complete >= ${completion.total}.`,
+    };
+  }
+  return { satisfied: true, reason: '' };
 }
 
 /**

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1188,17 +1188,28 @@ export class StageExecutionWorker {
             .eq('venture_id', ventureId)
             .eq('lifecycle_stage', 19)
             .maybeSingle();
-          const buildMethod = s19Work?.advisory_data?.build_method || 'replit_agent';
-          if (buildMethod === 'replit_agent') {
-            // Check if the chairman has signaled Replit setup is complete
+          // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d): resolve the build model via the
+          // SINGLE arbiter (ventures.build_model SSOT, legacy build_method fallback) instead of this
+          // gate independently defaulting to 'replit_agent' — the schism that let the seeded path win.
+          const { data: ventureBM } = await this._supabase
+            .from('ventures').select('build_model').eq('id', ventureId).maybeSingle();
+          const { resolveBuildModel } = await import('./bridge/resolve-build-model.js');
+          const buildModel = resolveBuildModel({
+            ventureBuildModel: ventureBM?.build_model,
+            legacyBuildMethod: s19Work?.advisory_data?.build_method,
+          });
+          if (buildModel === 'seeded_repo') {
+            // Seeded path: block at S19 until the chairman has seeded the repo + a deployment is registered.
             const repoUrl = s19Work?.advisory_data?.replit_repo_url;
             if (!repoUrl) {
-              this._logger.log('[Worker] S19 Replit gate: blocking — build_method=replit_agent but no repo URL set. Chairman needs to create & seed repo first.');
+              this._logger.log('[Worker] S19 gate: blocking — build_model=seeded_repo but no repo URL set. Chairman needs to create & seed repo first.');
               releaseState = ORCHESTRATOR_STATES.BLOCKED;
               lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'replit_setup_pending' };
               break;
             }
-            this._logger.log(`[Worker] S19 Replit gate: repo URL set (${repoUrl}) — proceeding`);
+            this._logger.log(`[Worker] S19 gate (seeded_repo): repo URL set (${repoUrl}) — proceeding`);
+          } else {
+            this._logger.log('[Worker] S19 gate (leo_bridge): venture builds via the LEO-SD bridge — not blocking on Replit seeding.');
           }
         }
 
@@ -2945,10 +2956,19 @@ export class StageExecutionWorker {
       .eq('lifecycle_stage', 19)
       .maybeSingle();
 
-    const buildMethod = s19Work?.advisory_data?.build_method;
-    if (buildMethod === 'replit_agent') {
+    // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d): single arbiter (ventures.build_model
+    // SSOT) decides — NOT this hook independently checking build_method. Skip LEO-SD creation only for
+    // the seeded path; for leo_bridge, fall through to convertSprintToSDs.
+    const { data: ventureBM2 } = await this._supabase
+      .from('ventures').select('build_model').eq('id', ventureId).maybeSingle();
+    const { resolveBuildModel } = await import('./bridge/resolve-build-model.js');
+    const buildModel = resolveBuildModel({
+      ventureBuildModel: ventureBM2?.build_model,
+      legacyBuildMethod: s19Work?.advisory_data?.build_method,
+    });
+    if (buildModel === 'seeded_repo') {
       this._logger.log(
-        '[Worker] S19 Bridge: build_method=replit_agent — skipping per-venture SD creation. Venture is built by Claude Code from the seeded repo; Replit hosts.'
+        '[Worker] S19 Bridge: build_model=seeded_repo — skipping per-venture SD creation. Venture is built by Claude Code from the seeded repo; Replit hosts.'
       );
       // Write the build_method to Stage 20 so BUILD_PENDING knows to check Replit sync
       await this._supabase
@@ -2962,6 +2982,7 @@ export class StageExecutionWorker {
         }, { onConflict: 'venture_id,lifecycle_stage' });
       return;
     }
+    this._logger.log('[Worker] S19 Bridge: build_model=leo_bridge — creating orchestrator + child SDs via convertSprintToSDs.');
 
     // Verify venture provisioning before SD bridge conversion
     await this._verifyAndProvisionVenture(ventureId, ventureRow?.name);
@@ -3076,6 +3097,30 @@ export class StageExecutionWorker {
     } else {
       const errors = bridgeResult.errors || bridgeResult.error || 'unknown';
       this._logger.error(`[Worker] S19 post-stage hook: Bridge FAILED to create SDs for venture ${ventureId}. Errors: ${JSON.stringify(errors)}`);
+      // NC-7 anti-silent-no-op (RCA 813d4c3d CAPA): a leo_bridge venture with payloads that produced
+      // 0 SDs must NOT pass silently (the original drift). Escalate: mark S19 blocked with the reason
+      // so it surfaces on the dashboard instead of advancing un-built.
+      const alreadyExists = /already exists/i.test(JSON.stringify(errors));
+      if (!alreadyExists) {
+        try {
+          await this._supabase.from('venture_stage_work').upsert({
+            venture_id: ventureId,
+            lifecycle_stage: 19,
+            stage_status: 'blocked',
+            work_type: 'sd_required',
+            advisory_data: {
+              build_model: 'leo_bridge',
+              bridge_failed: true,
+              bridge_errors: errors,
+              payload_count: sdBridgePayloads.length,
+              escalated_at: new Date().toISOString(),
+            },
+          }, { onConflict: 'venture_id,lifecycle_stage' });
+          this._logger.error(`[Worker] S19 NC-7 escalation: marked venture ${ventureId} S19 BLOCKED (leo_bridge produced 0 SDs from ${sdBridgePayloads.length} payloads).`);
+        } catch (escErr) {
+          this._logger.warn(`[Worker] S19 NC-7 escalation upsert failed: ${escErr.message}`);
+        }
+      }
     }
   }
 

--- a/lib/repo-paths.js
+++ b/lib/repo-paths.js
@@ -93,25 +93,42 @@ export function getRepoPaths() {
 }
 
 /**
+ * Canonical comparison key for application names: lowercase + strip ALL
+ * non-alphanumeric characters. Bridges the separator/case drift between the
+ * DB `target_application` ("CommitCraft AI"), the registry.json `name`
+ * ("commitcraft-ai"), and the `normalized_name` form ("commitcraft_ai") — all
+ * collapse to "commitcraftai" so a venture resolves regardless of which form a
+ * caller passes. SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (discovered: an existing
+ * venture clone was unresolvable because resolveRepoPath did an exact lowercase
+ * compare, "commitcraft-ai" !== "commitcraft ai").
+ *
+ * @param {string} name
+ * @returns {string} canonical key (may be '')
+ */
+export function normalizeAppName(name) {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/**
  * Resolve a target_application string to its local filesystem path.
  *
- * @param {string} targetApp - Application name (e.g., 'EHG_Engineer', 'ehg', 'commitcraft-ai')
+ * @param {string} targetApp - Application name (e.g., 'EHG_Engineer', 'ehg', 'CommitCraft AI')
  * @returns {string|null} Absolute local path, or null if not found
  */
 export function resolveRepoPath(targetApp) {
   if (!targetApp) return ENGINEER_ROOT;
 
   const { apps } = loadValidatedRegistry();
-  const needle = targetApp.toLowerCase();
+  const needle = normalizeAppName(targetApp);
 
   for (const app of apps) {
-    if (app.name.toLowerCase() === needle) {
+    if (normalizeAppName(app.name) === needle) {
       return path.resolve(app.local_path);
     }
   }
 
   // EHG_Engineer self-reference
-  if (needle === 'ehg_engineer') return ENGINEER_ROOT;
+  if (needle === 'ehgengineer') return ENGINEER_ROOT;
 
   return null;
 }
@@ -126,10 +143,10 @@ export function resolveGitHubRepo(targetApp) {
   if (!targetApp) return 'rickfelix/EHG_Engineer';
 
   const { apps } = loadValidatedRegistry();
-  const needle = targetApp.toLowerCase();
+  const needle = normalizeAppName(targetApp);
 
   for (const app of apps) {
-    if (app.name.toLowerCase() === needle && app.github_repo) {
+    if (normalizeAppName(app.name) === needle && app.github_repo) {
       return app.github_repo.replace(/\.git$/, '');
     }
   }
@@ -232,6 +249,7 @@ export default {
   getRepoPaths,
   resolveRepoPath,
   resolveGitHubRepo,
+  normalizeAppName,
   isVentureRepo,
   isGitCapableRepo,
   clearCache,

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -17,6 +17,25 @@
 
 import { spawnSync } from 'node:child_process';
 
+/**
+ * C2 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-2): platform repos
+ * eligible for UNATTENDED auto-merge. Routing the harness's merge automation at an
+ * untrusted external/venture repo without human review is a supply-chain risk — so
+ * everything NOT in this set (including unknown/unresolvable repos) fails closed and
+ * requires a human merge. This hardcoded allowlist is the fail-closed default; it does
+ * not depend on registry availability (defense-in-depth: even a corrupt registry can
+ * only ever auto-merge the two known platform repos). The applications registry
+ * trust_tier column is the broader SSOT and may be consulted via an injected
+ * isTrustedRepo predicate.
+ */
+export const AUTO_MERGE_PLATFORM_REPOS = new Set(['rickfelix/ehg', 'rickfelix/ehg_engineer']);
+
+/** True only for the platform repos eligible for unattended auto-merge. */
+export function isPlatformRepo(repoOwner, repoName) {
+  if (!repoOwner || !repoName) return false;
+  return AUTO_MERGE_PLATFORM_REPOS.has(`${repoOwner}/${repoName}`.toLowerCase());
+}
+
 /** Default runner: invokes gh CLI synchronously and returns { code, stdout, stderr }. */
 function defaultRunner(args) {
   const result = spawnSync('gh', args, { encoding: 'utf8' });
@@ -137,9 +156,32 @@ export async function attemptAutoMerge({
   repoName,
   runner = defaultRunner,
   logger = defaultLogger,
+  // C2 (SECURITY VB-2): trust gate. isTrustedRepo decides auto-merge eligibility;
+  // defaults to the platform allowlist. allowExternalMerge is an explicit, audited
+  // override for the rare case a caller has a human already in the loop.
+  isTrustedRepo = isPlatformRepo,
+  allowExternalMerge = false,
 }) {
   if (!prNumber) {
     return { ok: false, reason: 'prNumber required', exitCode: 2 };
+  }
+
+  // C2 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-2): fail-closed human
+  // merge-gate for non-platform (venture/external) repos. The bridge can route venture
+  // build PRs at external repos; unattended auto-merge there would let the harness merge
+  // untrusted code without human review. Refuse unless the repo is platform-trusted (or
+  // an explicit allowExternalMerge override is passed). Unknown/unresolvable repo => refuse.
+  if (!allowExternalMerge && !isTrustedRepo(repoOwner, repoName)) {
+    logger.warn(
+      `⛔ Auto-merge refused for PR #${prNumber}: ${repoOwner || '?'}/${repoName || '?'} is not a platform repo. `
+      + `External/venture repos require a human merge (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-2).`
+    );
+    return {
+      ok: false,
+      requiresHumanMerge: true,
+      reason: `non-platform repo ${repoOwner || '?'}/${repoName || '?'} requires human merge (auto-merge gated per SECURITY VB-2)`,
+      exitCode: 0,
+    };
   }
 
   // 1. Detect + handle draft state.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -48,6 +48,9 @@ import { runTriageGate } from './modules/triage-gate.js';
 import { evaluateVisionReadiness, formatRubricResult } from './modules/vision-readiness-rubric.js';
 import { scoreSD } from './eva/vision-scorer.js';
 import { trackWriteSource } from '../lib/eva/cli-write-gate.js';
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5): canonical no-venture sd_type set — used to
+// guard the applications auto-register so engineering/governance work never mints a spurious venture.
+import { LEGITIMATE_NO_VENTURE_SD_TYPES } from '../lib/eva/bridge/sd-router.js';
 import { validateSDFields } from './modules/validate-sd-fields.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: path-based target detector
@@ -1741,15 +1744,32 @@ async function createSD(options) {
   try {
     const appName = sdData.target_application;
     if (appName) {
-      const { data: existing } = await supabase
-        .from('applications').select('id').ilike('name', appName).limit(1);
-      if (!existing || existing.length === 0) {
-        const PLATFORM_REPOS = new Set(['ehg', 'ehg_engineer']);
-        const kind = PLATFORM_REPOS.has(String(appName).toLowerCase()) ? 'platform' : 'venture';
-        const normalized = String(appName).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-        const { error: regErr } = await supabase
-          .from('applications').insert({ name: appName, normalized_name: normalized, kind, status: 'active' });
-        if (!regErr) console.log(`   📇 Registered target_application '${appName}' (${kind}) in applications registry`);
+      const PLATFORM_REPOS = new Set(['ehg', 'ehg_engineer']);
+      const isPlatform = PLATFORM_REPOS.has(String(appName).toLowerCase());
+      // FR-5 NO-VENTURE GUARD (mirrors lib/eva/bridge/sd-router.js isLegitimateNoVenture):
+      // engineering/governance LEO work (sd_type in LEGITIMATE_NO_VENTURE_SD_TYPES, or
+      // metadata.engineering_only=true) must NOT mint a NEW 'venture' registry entry. Such an SD
+      // legitimately targets a platform repo (default EHG_Engineer); a NON-platform target on it
+      // is a misroute, so we skip registration (surfaced loudly) rather than polluting the registry
+      // with a phantom venture the deferred fail-closed trigger would then accept.
+      const isNoVentureWork = LEGITIMATE_NO_VENTURE_SD_TYPES.has(sdData.sd_type)
+        || sdData.metadata?.engineering_only === true;
+      if (!isPlatform && isNoVentureWork) {
+        console.warn(
+          `   ⚠️  Skipping applications auto-register: engineering SD (sd_type=${sdData.sd_type}) has a `
+          + `non-platform target_application '${appName}'. Engineering/governance work should target a `
+          + `platform repo (EHG/EHG_Engineer) — refusing to mint a phantom venture (FR-5 no-venture guard).`
+        );
+      } else {
+        const { data: existing } = await supabase
+          .from('applications').select('id').ilike('name', appName).limit(1);
+        if (!existing || existing.length === 0) {
+          const kind = isPlatform ? 'platform' : 'venture';
+          const normalized = String(appName).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+          const { error: regErr } = await supabase
+            .from('applications').insert({ name: appName, normalized_name: normalized, kind, status: 'active' });
+          if (!regErr) console.log(`   📇 Registered target_application '${appName}' (${kind}) in applications registry`);
+        }
       }
     }
   } catch (regErr) {

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1733,6 +1733,29 @@ async function createSD(options) {
     console.warn(`   ⚠️  GATE_SD_QUALITY pre-check skipped: ${vErr.message}`);
   }
 
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5): auto-register target_application in the
+  // `applications` registry BEFORE the SD insert, so the (deferred) fail-closed routing trigger
+  // never blocks legitimate SD creation on an unregistered name. Fail-soft: a registry write
+  // error must NOT block SD creation — the registry is a precondition, not a gate, and the
+  // enforcing trigger is not yet active.
+  try {
+    const appName = sdData.target_application;
+    if (appName) {
+      const { data: existing } = await supabase
+        .from('applications').select('id').ilike('name', appName).limit(1);
+      if (!existing || existing.length === 0) {
+        const PLATFORM_REPOS = new Set(['ehg', 'ehg_engineer']);
+        const kind = PLATFORM_REPOS.has(String(appName).toLowerCase()) ? 'platform' : 'venture';
+        const normalized = String(appName).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+        const { error: regErr } = await supabase
+          .from('applications').insert({ name: appName, normalized_name: normalized, kind, status: 'active' });
+        if (!regErr) console.log(`   📇 Registered target_application '${appName}' (${kind}) in applications registry`);
+      }
+    }
+  } catch (regErr) {
+    console.warn(`   ⚠️  applications registry auto-register skipped (non-blocking): ${regErr.message}`);
+  }
+
   const { data, error } = await supabase
     .from('strategic_directives_v2')
     .insert(sdData)

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/branch-enforcement.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/branch-enforcement.js
@@ -84,15 +84,34 @@ export function createBranchEnforcementGate(sd, appPath) {
     name: 'GATE6_BRANCH_ENFORCEMENT',
     validator: async (ctx) => {
       // Self-skip when the target repo has no usable git (e.g. EHG consolidated repo)
-      const { isGitCapableRepo } = await import('../../../../../../lib/repo-paths.js');
+      const { isGitCapableRepo, isVentureRepo } = await import('../../../../../../lib/repo-paths.js');
       if (sd && sd.target_application && !isGitCapableRepo(sd.target_application)) {
-        console.log('\n🔒 GATE 6: SKIPPED — target repo not git-capable (N/A)');
+        // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4): legitimate skip ONLY for
+        // PLATFORM repos (EHG detached HEAD; branch ops genuinely N/A, isolation via worktree). For a
+        // VENTURE repo, "not git-capable" = not locally cloned / no branch — fail CLOSED rather than
+        // free-pass branch enforcement (the exact gate-self-skip this reconciliation removes).
+        if (isVentureRepo(sd.target_application)) {
+          console.log(`\n🔒 GATE 6: FAIL-CLOSED — venture repo '${sd.target_application}' not locally git-capable`);
+          return {
+            passed: false,
+            score: 0,
+            max_score: 100,
+            issues: [
+              `GATE6 FAIL-CLOSED: venture repo '${sd.target_application}' is not locally git-capable, so branch `
+              + `isolation cannot be verified. Free-pass removed per SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 / `
+              + `SECURITY VB-4. Clone the venture repo (or route via the bridge with a git-capable checkout) first.`
+            ],
+            warnings: [],
+            details: { fail_closed_venture_repo: true, target_application: sd.target_application }
+          };
+        }
+        console.log('\n🔒 GATE 6: SKIPPED — platform target repo not git-capable (N/A, detached HEAD)');
         return {
           passed: true,
           score: 100,
           max_score: 100,
           issues: [],
-          warnings: [`GATE6 N/A: target_application='${sd.target_application}' has no usable git repository; branch isolation via worktree`],
+          warnings: [`GATE6 N/A: platform target_application='${sd.target_application}' has no usable git repository; branch isolation via worktree`],
           details: { skipped_not_applicable: true, target_application: sd.target_application }
         };
       }

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js
@@ -57,13 +57,37 @@ export function createGitCommitEnforcementGate(supabase, sd, appPath) {
     validator: async (ctx) => {
       // Self-skip when the target repo has no usable git (e.g. EHG consolidated repo).
       // This fires for any sd_type (refactor/database/security/feature/…) targeting EHG.
-      const { isGitCapableRepo } = await import('../../../../../../lib/repo-paths.js');
+      const { isGitCapableRepo, isVentureRepo } = await import('../../../../../../lib/repo-paths.js');
       const isGitIncapableTarget = sd && sd.target_application && !isGitCapableRepo(sd.target_application);
       if (isGitIncapableTarget) {
+        // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4): a not-git-capable target
+        // is a legitimate skip ONLY for PLATFORM repos — EHG is locked to detached HEAD, so its
+        // branch/commit ops are genuinely N/A and its commits live in the EHG_Engineer worktree.
+        // For a VENTURE repo, "not git-capable" means it is not locally cloned / has no branch;
+        // silently free-passing commit enforcement there is the exact gate-self-skip this SD closes.
+        if (isVentureRepo(sd.target_application)) {
+          console.log('\n🔒 GATE 5: Git Commit Enforcement');
+          console.log('-'.repeat(50));
+          console.log(`   ⛔ venture target_application='${sd.target_application}' is not locally git-capable`);
+          console.log('   ❌ FAIL-CLOSED: cannot verify venture build commits (no local clone/branch)');
+          return {
+            passed: false,
+            score: 0,
+            max_score: 100,
+            issues: [
+              `GATE5 FAIL-CLOSED: venture repo '${sd.target_application}' is not locally git-capable, so commit status `
+              + `cannot be verified. Free-pass removed per SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 / SECURITY VB-4. `
+              + `Clone the venture repo (or route via the bridge with a git-capable checkout) before this handoff.`
+            ],
+            warnings: [],
+            details: { fail_closed_venture_repo: true, target_application: sd.target_application }
+          };
+        }
+        // Platform repo (EHG) — legitimate N/A skip (detached HEAD; commits in EHG_Engineer worktree).
         console.log('\n🔒 GATE 5: Git Commit Enforcement');
         console.log('-'.repeat(50));
-        console.log(`   ℹ️  target_application='${sd.target_application}' has no usable git repository`);
-        console.log('   ✅ Skipping strict commit enforcement (git-incapable target)');
+        console.log(`   ℹ️  platform target_application='${sd.target_application}' has no usable git repository (detached HEAD)`);
+        console.log('   ✅ Skipping strict commit enforcement (git-incapable platform target)');
         console.log('   📝 Branch isolation handled via worktree; commits live in EHG_Engineer');
 
         return {
@@ -71,11 +95,11 @@ export function createGitCommitEnforcementGate(supabase, sd, appPath) {
           score: 100,
           max_score: 100,
           issues: [],
-          warnings: [`GATE5 N/A: target_application='${sd.target_application}' has no usable git repository; commit enforcement skipped`],
+          warnings: [`GATE5 N/A: platform target_application='${sd.target_application}' has no usable git repository; commit enforcement skipped`],
           details: {
             skipped_not_applicable: true,
             target_application: sd.target_application,
-            workflow_modification: 'Commit enforcement skipped — target repo is not git-capable'
+            workflow_modification: 'Commit enforcement skipped — platform target repo is not git-capable'
           }
         };
       }

--- a/scripts/modules/sd-next/rank-items.js
+++ b/scripts/modules/sd-next/rank-items.js
@@ -36,6 +36,27 @@ export const SEVERITY_TO_RANK = {
   low:      1000,
 };
 
+/**
+ * Platform application names — target_application values that are NOT ventures.
+ * Kept local (a tiny stable Set) to preserve this module's pure / IO-free contract;
+ * mirrors the name-based platform set in lib/repo-paths.js (isVentureRepo).
+ */
+const PLATFORM_APPLICATIONS = new Set(['ehg', 'ehg_engineer']);
+
+/**
+ * FR-5 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001): a venture-build SD is any SD whose
+ * target_application is set to a non-platform value. These are ISOLATED into a dedicated
+ * `ventureTrack` (returned separately from `tracks`) so they never starve or pollute the
+ * platform sd:next recommendation/display, which read tracks.A/B/C/STANDALONE.
+ *
+ * @param {Object} sd
+ * @returns {boolean}
+ */
+export function isVentureBuildSD(sd) {
+  const ta = (sd?.target_application || '').trim().toLowerCase();
+  return ta.length > 0 && !PLATFORM_APPLICATIONS.has(ta);
+}
+
 /** Branch-name keywords that promote a bug-type QF to Track A (Infrastructure). */
 const TRACK_A_BRANCH_KEYWORDS = [
   'infra',
@@ -160,6 +181,10 @@ export function rankItems(items, context = {}) {
 
   const now = context.now ?? Date.now();
   const tracks = { A: [], B: [], C: [], STANDALONE: [] };
+  // FR-5: isolated venture-build queue — returned separately from `tracks` so platform
+  // sd:next recommendation/display (which read tracks.A/B/C/STANDALONE) never surface or
+  // get starved by venture SDs. A future venture-specific view can read this field.
+  const ventureTrack = [];
   const misplacedDeps = [];
   const orphanBaseline = [];
 
@@ -240,7 +265,7 @@ export function rankItems(items, context = {}) {
     const urgencyBand = sd.metadata?.urgency_band ?? (urgencyScore !== null ? scoreToBand(urgencyScore) : 'P3');
     const urgencyNumeric = bandToNumeric(urgencyBand);
 
-    tracks[trackKey].push({
+    const rankedEntry = {
       ...(baselineItem || {}),
       ...sd,
       kind: 'sd',
@@ -256,21 +281,31 @@ export function rankItems(items, context = {}) {
       urgency_numeric: urgencyNumeric,
       is_deferred: isDeferred,
       actual: actuals[sd.sd_key] || actuals[sd.id]
-    });
+    };
+
+    // FR-5: venture-build SDs go to the isolated ventureTrack, NOT the platform tracks.
+    if (isVentureBuildSD(sd)) {
+      rankedEntry.track = 'VENTURE';
+      ventureTrack.push(rankedEntry);
+    } else {
+      tracks[trackKey].push(rankedEntry);
+    }
   }
 
   // Sort within each track: urgency band (P0 first) → urgency score (desc) → composite_rank
+  const byUrgencyThenRank = (a, b) => {
+    const bandDiff = (a.urgency_numeric ?? 3) - (b.urgency_numeric ?? 3);
+    if (bandDiff !== 0) return bandDiff;
+    const scoreDiff = (b.urgency_score ?? 0) - (a.urgency_score ?? 0);
+    if (scoreDiff !== 0) return scoreDiff;
+    return (a.composite_rank ?? a.sequence_rank ?? 9999) - (b.composite_rank ?? b.sequence_rank ?? 9999);
+  };
   for (const trackKey of Object.keys(tracks)) {
-    tracks[trackKey].sort((a, b) => {
-      const bandDiff = (a.urgency_numeric ?? 3) - (b.urgency_numeric ?? 3);
-      if (bandDiff !== 0) return bandDiff;
-      const scoreDiff = (b.urgency_score ?? 0) - (a.urgency_score ?? 0);
-      if (scoreDiff !== 0) return scoreDiff;
-      return (a.composite_rank ?? a.sequence_rank ?? 9999) - (b.composite_rank ?? b.sequence_rank ?? 9999);
-    });
+    tracks[trackKey].sort(byUrgencyThenRank);
   }
+  ventureTrack.sort(byUrgencyThenRank);
 
-  return { tracks, misplacedDeps, orphanBaseline };
+  return { tracks, ventureTrack, misplacedDeps, orphanBaseline };
 }
 
 /**

--- a/scripts/modules/session-summary/secret-redactor.js
+++ b/scripts/modules/session-summary/secret-redactor.js
@@ -51,6 +51,21 @@ const SECRET_PATTERNS = [
   { pattern: /sk-[a-zA-Z0-9]{48}/g, replacement: '[OPENAI_KEY_REDACTED]' },
   { pattern: /sk-ant-[a-zA-Z0-9\-]{80,}/g, replacement: '[ANTHROPIC_KEY_REDACTED]' },
 
+  // ── Venture-stack secrets (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C3 / SECURITY VB-3) ──
+  // The venture build stack is Clerk (auth) + Gemini/Google AI + Replit (host) — NOT the
+  // Supabase/GitHub the platform scanner already knew. Without these, a ventures secret
+  // leaking into a seeded/pushed artifact scanned PASS (false negative). label is used by
+  // scanSecrets() to name the leak class in the blocking-gate message.
+  // Clerk live secret key (sk_live_/sk_test_) — the high-blast-radius one.
+  { pattern: /sk_(?:live|test)_[a-zA-Z0-9]{20,}/g, replacement: '[CLERK_SECRET_KEY_REDACTED]', label: 'clerk_secret_key' },
+  // Clerk publishable key (pk_live_/pk_test_) — lower sensitivity but named in VB-3.
+  { pattern: /pk_(?:live|test)_[a-zA-Z0-9]{20,}/g, replacement: '[CLERK_PUBLISHABLE_KEY_REDACTED]', label: 'clerk_publishable_key' },
+  // Google AI / Gemini API key (AIza + 35 chars).
+  { pattern: /AIza[a-zA-Z0-9_\-]{35}/g, replacement: '[GOOGLE_AI_KEY_REDACTED]', label: 'google_ai_key' },
+  // Replit DB URL (carries an embedded credential) + REPLIT_* env-style secrets.
+  { pattern: /https?:\/\/[^\s'"@]+:[^\s'"@]+@[^\s'"]*\.replit\.[a-z]+/gi, replacement: '[REPLIT_DB_URL_REDACTED]', label: 'replit_db_url' },
+  { pattern: /REPLIT_[A-Z0-9_]*(?:TOKEN|KEY|SECRET|DB_URL|PASSWORD)\s*[=:]\s*['"]?([^\s'"]+)['"]?/gi, replacement: 'REPLIT_SECRET=[REDACTED]', label: 'replit_secret' },
+
   // Generic secret patterns
   { pattern: /secret\s*[=:]\s*['"]?([^\s'"]{16,})['"]?/gi, replacement: 'secret=[REDACTED]' },
   { pattern: /token\s*[=:]\s*['"]?([^\s'"]{16,})['"]?/gi, replacement: 'token=[REDACTED]' },
@@ -148,9 +163,38 @@ export function containsSecrets(text) {
   return false;
 }
 
+/**
+ * Scan text for secrets and report WHICH classes matched.
+ *
+ * Unlike containsSecrets (boolean), this returns the distinct category labels so a
+ * blocking gate (e.g. the venture push path, SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001
+ * C3 / VB-3) can tell the operator exactly what leaked. Category is the pattern's
+ * `label` when present, else a slug derived from its replacement token.
+ *
+ * @param {string} text
+ * @returns {{ found: boolean, categories: string[] }}
+ */
+export function scanSecrets(text) {
+  if (!text || typeof text !== 'string') {
+    return { found: false, categories: [] };
+  }
+  const categories = new Set();
+  for (const { pattern, replacement, label } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    if (pattern.test(text)) {
+      const category = label
+        || String(replacement).replace(/[=:].*$/, '').replace(/[\[\]]/g, '').replace(/_?REDACTED/i, '').replace(/_+$/,'').toLowerCase()
+        || 'secret';
+      categories.add(category);
+    }
+  }
+  return { found: categories.size > 0, categories: [...categories] };
+}
+
 export default {
   redactSecrets,
   redactObject,
   containsSecrets,
+  scanSecrets,
   SECRET_PATTERNS
 };

--- a/scripts/reroute-venture-to-bridge.mjs
+++ b/scripts/reroute-venture-to-bridge.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * reroute-venture-to-bridge — re-route an in-flight venture onto the LEO-SD bridge (Stage 19 SSOT).
+ *
+ * SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / FR-3 (RCA 813d4c3d). For ventures whose S19 bridge hook
+ * never fired (the seeded-path schism), this invokes the SAME canonical machinery the hook would
+ * (convertSprintToSDs on the existing Stage-18 sd_bridge_payloads), and pins them to the bridge:
+ *   1. ventures.build_model = 'leo_bridge'   (SSOT arbiter — future S19 runs/reentry honor it)
+ *   2. register the venture in public.applications (routing precondition; future fail-closed trigger)
+ *   3. convertSprintToSDs(existing payloads)  → orchestrator + child SDs routed by target_application
+ *
+ * SAFE to re-run: convertSprintToSDs has an idempotency guard keyed on (venture_id, sprint_name) —
+ * a second run no-ops if an orchestrator already exists. DRY-RUN by default; pass --apply to mutate.
+ *
+ * Usage:  node scripts/reroute-venture-to-bridge.mjs "<venture name or uuid>" [--apply]
+ */
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { convertSprintToSDs } from '../lib/eva/lifecycle-sd-bridge.js';
+
+const arg = process.argv[2];
+const APPLY = process.argv.includes('--apply');
+const NO_GC = process.argv.includes('--no-grandchildren'); // bounded pilot: orchestrator + children only
+const SKIP_ENRICH = process.argv.includes('--skip-enrichment'); // skip the slow loadAndEnrichArtifacts step
+if (!arg) { console.error('Usage: node scripts/reroute-venture-to-bridge.mjs "<venture name or uuid>" [--apply] [--no-grandchildren] [--skip-enrichment]'); process.exit(2); }
+
+const sb = await createSupabaseServiceClient('engineer');
+const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(arg);
+
+const { data: venture } = isUuid
+  ? await sb.from('ventures').select('id,name,repo_url,build_model').eq('id', arg).maybeSingle()
+  : await sb.from('ventures').select('id,name,repo_url,build_model').ilike('name', arg).limit(1).maybeSingle();
+if (!venture) { console.error(`Venture not found: ${arg}`); process.exit(1); }
+
+console.log(`\n=== Re-route venture onto LEO-SD bridge ${APPLY ? '(APPLY)' : '(DRY-RUN)'} ===`);
+console.log(`  venture: ${venture.name} (${venture.id})`);
+console.log(`  repo_url: ${venture.repo_url || 'NULL'}`);
+console.log(`  current build_model: ${venture.build_model ?? 'NULL'}`);
+
+// Fetch the current Stage-18 sprint plan (sd_bridge_payloads).
+const { data: art } = await sb.from('venture_artifacts')
+  .select('artifact_data,created_at')
+  .eq('venture_id', venture.id).eq('artifact_type', 'blueprint_sprint_plan').eq('is_current', true)
+  .order('created_at', { ascending: false }).limit(1).maybeSingle();
+const ad = art?.artifact_data || {};
+const payloads = ad.sd_bridge_payloads || ad.stage18_data?.sd_bridge_payloads || [];
+const sprintName = ad.sprint_name || ad.stage18_data?.sprint_name || `Sprint ${new Date().toISOString().slice(0,10)}`;
+const sprintGoal = ad.sprint_goal || ad.stage18_data?.sprint_goal || '';
+const sprintDuration = ad.sprint_duration_days || ad.stage18_data?.sprint_duration_days || 14;
+console.log(`  blueprint_sprint_plan: ${art ? 'is_current' : 'MISSING'} | sd_bridge_payloads: ${Array.isArray(payloads) ? payloads.length : '(none)'} | sprint_name: "${sprintName}"`);
+if (!Array.isArray(payloads) || payloads.length === 0) { console.error('  No sd_bridge_payloads — cannot re-route.'); process.exit(1); }
+const gcPerChild = NO_GC ? 0 : 4; // ARCHITECTURE_LAYERS (data/api/ui/tests)
+const gcTotal = gcPerChild * payloads.length;
+console.log(`  Would create: 1 orchestrator + ${payloads.length} children${NO_GC ? ' (--no-grandchildren: grandchildren deferred)' : ` + ~${gcTotal} grandchildren`} = ${1 + payloads.length + gcTotal} SDs (target_application=${venture.name}):`);
+payloads.forEach((p, i) => console.log(`    child[${i}] ${p.type || 'feature'}: ${p.title}`));
+
+// Existing orchestrator? (idempotency)
+const { data: existingOrch } = await sb.from('strategic_directives_v2')
+  .select('sd_key').eq('venture_id', venture.id).eq('sd_type', 'orchestrator')
+  .filter('metadata->>sprint_name', 'eq', sprintName).limit(1).maybeSingle();
+console.log(`  existing orchestrator for this sprint: ${existingOrch ? existingOrch.sd_key + ' (would no-op)' : 'none'}`);
+
+if (!APPLY) { console.log('\n  DRY-RUN — no changes. Re-run with --apply to execute.'); process.exit(0); }
+
+// ── APPLY ──
+// 1. Pin to the bridge (SSOT).
+await sb.from('ventures').update({ build_model: 'leo_bridge' }).eq('id', venture.id);
+console.log('\n  ✓ set ventures.build_model = leo_bridge');
+
+// 2. Register in applications (routing precondition).
+const { data: appRow } = await sb.from('applications').select('id').ilike('name', venture.name).limit(1).maybeSingle();
+if (!appRow) {
+  const normalized = String(venture.name).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const { error: regErr } = await sb.from('applications').insert({
+    name: venture.name, normalized_name: normalized, kind: 'venture', status: 'active',
+    repo_url: venture.repo_url || null, venture_id: venture.id, trust_tier: 'external',
+  });
+  console.log(regErr ? `  ⚠ applications register failed: ${regErr.message}` : `  ✓ registered '${venture.name}' in applications (venture, trust_tier=external)`);
+} else {
+  console.log(`  · already in applications registry`);
+}
+
+// 3. Invoke the canonical bridge.
+const { data: visionDoc } = await sb.from('eva_vision_documents').select('vision_key').eq('venture_id', venture.id).order('version', { ascending: false }).limit(1).maybeSingle();
+const { data: archPlan } = await sb.from('eva_architecture_plans').select('plan_key').eq('venture_id', venture.id).order('version', { ascending: false }).limit(1).maybeSingle();
+const result = await convertSprintToSDs(
+  {
+    stageOutput: { sd_bridge_payloads: payloads, sprint_name: sprintName, sprint_goal: sprintGoal, sprint_duration_days: sprintDuration },
+    ventureContext: { id: venture.id, name: venture.name },
+    evaKeys: { vision_key: visionDoc?.vision_key || null, plan_key: archPlan?.plan_key || null },
+    options: { generateGrandchildren: !NO_GC, skipEnrichment: SKIP_ENRICH },
+  },
+  { supabase: sb, logger: console },
+);
+console.log('\n=== convertSprintToSDs result ===');
+console.log(`  created: ${result.created} | orchestrator: ${result.orchestratorKey} | children: ${result.childKeys?.length || 0} | errors: ${JSON.stringify(result.errors || [])}`);
+
+// 4. Verify the SD tree.
+const { data: tree } = await sb.from('strategic_directives_v2')
+  .select('sd_key,sd_type,status,target_application,parent_sd_id').eq('target_application', venture.name).order('sd_type');
+console.log(`\n=== verify: SDs with target_application='${venture.name}' (${tree?.length || 0}) ===`);
+for (const s of (tree || [])) console.log(`  ${s.sd_type.padEnd(13)} ${s.sd_key} status=${s.status} parent=${s.parent_sd_id ? 'yes' : '—'}`);
+process.exit(0);

--- a/scripts/wsjf-priority-fetcher.js
+++ b/scripts/wsjf-priority-fetcher.js
@@ -2,6 +2,9 @@
 import { createSupabaseClient } from '../lib/supabase-client.js';
 import dotenv from 'dotenv';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+// FR-5 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001): exclude venture-build SDs from prio:top3
+// so they don't starve the platform priority queue (same isolation as sd:next's ventureTrack).
+import { isVentureBuildSD } from './modules/sd-next/rank-items.js';
 
 dotenv.config();
 
@@ -14,7 +17,7 @@ class WSJFPriorityFetcher {
     try {
       const { data: directives, error } = await this.supabase
         .from('strategic_directives_v2')
-        .select('id, title, status, priority, created_at')
+        .select('id, title, status, priority, created_at, target_application')
         .in('status', ['draft', 'in_progress', 'active', 'pending_approval'])
         .order('created_at', { ascending: false })
         .limit(50);
@@ -24,9 +27,16 @@ class WSJFPriorityFetcher {
         return [];
       }
 
+      // FR-5: drop venture-build SDs — they live in the isolated venture queue, not the
+      // platform top-3. Platform SDs (target_application null or ehg/ehg_engineer) remain.
+      const platformDirectives = directives.filter((d) => !isVentureBuildSD(d));
+      if (platformDirectives.length === 0) {
+        return [];
+      }
+
       // Fallback: prioritize by priority field (if exists) then status order then created_at
       const statusPriority = { 'in_progress': 4, 'active': 3, 'pending_approval': 2, 'draft': 1 };
-      const sorted = directives.sort((a, b) => {
+      const sorted = platformDirectives.sort((a, b) => {
         // First sort by priority if available
         if (a.priority && b.priority) {
           if (a.priority !== b.priority) return b.priority - a.priority;

--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -181,11 +181,15 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
     });
   }
 
-  // SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 / FR-3: enrich the "build is done" signal with
-  // build-task completeness (not merely a registered URL). Degrade-safe — resolveRepoReadiness
-  // never throws; build_tasks_complete falls back to the total (registering a deployment asserts
-  // the build is complete) but an explicit build_tasks_complete in the body is honored when present.
-  // The S20 Code Quality Gate remains the authoritative downstream validator.
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / FR-4: the "build is done" signal must be
+  // EVIDENCE-BASED, not asserted. Registering a deployment URL records the build PLAN total
+  // but does NOT by itself prove the build is complete — build_tasks_complete now defaults to
+  // null (unverified) rather than the total. Only an explicit, verified build_tasks_complete in
+  // the request body is honored. The S19->S20 exit gate (verifyBuildMvpBuildPresent) and the S20
+  // Code Quality Gate enforce real completion downstream.
+  //   Superseded prior behavior (SD-LEO-FEAT-FINALIZE-CLAUDE-CODE-001 / FR-3): complete fell back
+  //   to the total, so a bare register-deployment asserted an unverified N/N (e.g. CronLinter 7/7).
+  // Degrade-safe — resolveRepoReadiness never throws.
   let buildTasksTotal = null;
   let buildTasksComplete = null;
   try {
@@ -194,7 +198,7 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
     if (Number.isFinite(total)) {
       buildTasksTotal = total;
       const reported = Number(req.body?.build_tasks_complete);
-      buildTasksComplete = Number.isFinite(reported) ? Math.max(0, Math.min(reported, total)) : total;
+      buildTasksComplete = Number.isFinite(reported) ? Math.max(0, Math.min(reported, total)) : null;
     }
   } catch { /* degrade-safe: omit the completion fields entirely */ }
 
@@ -211,7 +215,14 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
         deployment_url,
         registered_at: new Date().toISOString(),
         ...(buildTasksTotal !== null
-          ? { build_tasks_total: buildTasksTotal, build_tasks_complete: buildTasksComplete }
+          ? {
+              build_tasks_total: buildTasksTotal,
+              build_tasks_complete: buildTasksComplete,
+              // FR-4: explicit provenance — true only when a verified completion count
+              // (>= total) was supplied. A bare register-deployment leaves this false.
+              build_completion_verified:
+                buildTasksComplete !== null && buildTasksComplete >= buildTasksTotal,
+            }
           : {}),
       },
       metadata: {

--- a/tests/rank-items.test.js
+++ b/tests/rank-items.test.js
@@ -9,6 +9,7 @@ import {
   SEVERITY_TO_RANK,
   qfUrgencyBand,
   qfTrack,
+  isVentureBuildSD,
 } from '../scripts/modules/sd-next/rank-items.js';
 
 /** Minimal SD factory so each test only spells out what it cares about. */
@@ -337,5 +338,47 @@ describe('rankItems — Phase 3 Quick Fix interleaving', () => {
     const { tracks } = rankItems(items, { now: NOW });
     const allIds = [...tracks.A, ...tracks.B, ...tracks.C, ...tracks.STANDALONE].map(x => x.id);
     assert.deepEqual(allIds, ['QF-OPEN']);
+  });
+});
+
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-5: venture-build queue isolation.
+describe('isVentureBuildSD + venture queue isolation (FR-5)', () => {
+  it('isVentureBuildSD: only non-platform target_application is a venture', () => {
+    assert.equal(isVentureBuildSD({ target_application: null }), false);
+    assert.equal(isVentureBuildSD({ target_application: '' }), false);
+    assert.equal(isVentureBuildSD({ target_application: 'ehg' }), false);
+    assert.equal(isVentureBuildSD({ target_application: 'EHG' }), false);
+    assert.equal(isVentureBuildSD({ target_application: 'EHG_Engineer' }), false);
+    assert.equal(isVentureBuildSD({ target_application: 'CronLinter' }), true);
+    assert.equal(isVentureBuildSD({ target_application: 'Canvas AI' }), true);
+  });
+
+  it('routes venture-build SDs to ventureTrack, NOT the platform tracks', () => {
+    const items = [
+      sd({ id: 'SD-PLAT-1', sd_key: 'SD-PLAT-1', status: 'active', category: 'infrastructure', target_application: null }),
+      sd({ id: 'SD-PLAT-2', sd_key: 'SD-PLAT-2', status: 'active', category: 'quality', target_application: 'EHG_Engineer' }),
+      sd({ id: 'SD-VEN-1', sd_key: 'SD-VEN-1', status: 'active', category: 'feature', target_application: 'CronLinter' }),
+      sd({ id: 'SD-VEN-2', sd_key: 'SD-VEN-2', status: 'active', category: 'infrastructure', target_application: 'Canvas AI' }),
+    ];
+    const result = rankItems(items, {});
+    const platformIds = [...result.tracks.A, ...result.tracks.B, ...result.tracks.C, ...result.tracks.STANDALONE].map(x => x.sd_id);
+    const ventureIds = result.ventureTrack.map(x => x.sd_id);
+
+    assert.ok(Array.isArray(result.ventureTrack), 'ventureTrack is an array');
+    assert.deepEqual(ventureIds.sort(), ['SD-VEN-1', 'SD-VEN-2']);
+    assert.ok(!platformIds.includes('SD-VEN-1') && !platformIds.includes('SD-VEN-2'), 'venture SDs absent from platform tracks');
+    assert.ok(platformIds.includes('SD-PLAT-1') && platformIds.includes('SD-PLAT-2'), 'platform SDs present in platform tracks');
+    assert.ok(result.ventureTrack.every(x => x.track === 'VENTURE'), 'ventureTrack entries marked track=VENTURE');
+  });
+
+  it('completed/cancelled venture SDs are excluded from both tracks and ventureTrack', () => {
+    const items = [
+      sd({ id: 'SD-VEN-DONE', sd_key: 'SD-VEN-DONE', status: 'completed', target_application: 'CronLinter' }),
+      sd({ id: 'SD-VEN-CANCEL', sd_key: 'SD-VEN-CANCEL', status: 'cancelled', target_application: 'Canvas AI' }),
+    ];
+    const result = rankItems(items, {});
+    assert.equal(result.ventureTrack.length, 0);
+    const platformIds = [...result.tracks.A, ...result.tracks.B, ...result.tracks.C, ...result.tracks.STANDALONE];
+    assert.equal(platformIds.length, 0);
   });
 });

--- a/tests/unit/eva/bridge/resolve-build-model.test.js
+++ b/tests/unit/eva/bridge/resolve-build-model.test.js
@@ -1,0 +1,43 @@
+/**
+ * resolve-build-model (SSOT arbiter) — SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d).
+ * The single decision point that resolves the venture-build "model schism": explicit
+ * ventures.build_model wins; legacy build_method is honored for backward-compat; unset falls
+ * to the safe default (seeded_repo, gated on the venture EXEC loop).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveBuildModel, isLeoBridge, isSeededRepo, DEFAULT_BUILD_MODEL, BUILD_MODELS,
+} from '../../../../lib/eva/bridge/resolve-build-model.js';
+
+describe('resolveBuildModel', () => {
+  it('explicit ventures.build_model wins over legacy build_method', () => {
+    expect(resolveBuildModel({ ventureBuildModel: 'leo_bridge', legacyBuildMethod: 'replit_agent' })).toBe('leo_bridge');
+    expect(resolveBuildModel({ ventureBuildModel: 'seeded_repo', legacyBuildMethod: 'leo_bridge' })).toBe('seeded_repo');
+  });
+
+  it('legacy build_method=replit_agent => seeded_repo (backward-compat for in-flight ventures)', () => {
+    expect(resolveBuildModel({ legacyBuildMethod: 'replit_agent' })).toBe('seeded_repo');
+  });
+
+  it('legacy build_method=leo_bridge => leo_bridge', () => {
+    expect(resolveBuildModel({ legacyBuildMethod: 'leo_bridge' })).toBe('leo_bridge');
+  });
+
+  it('unset resolves to the safe default (seeded_repo, gated on the EXEC loop)', () => {
+    expect(resolveBuildModel({})).toBe('seeded_repo');
+    expect(resolveBuildModel()).toBe('seeded_repo');
+    expect(DEFAULT_BUILD_MODEL).toBe('seeded_repo');
+  });
+
+  it('invalid ventureBuildModel falls through to legacy/default', () => {
+    expect(resolveBuildModel({ ventureBuildModel: 'garbage', legacyBuildMethod: 'leo_bridge' })).toBe('leo_bridge');
+    expect(resolveBuildModel({ ventureBuildModel: '' })).toBe('seeded_repo');
+  });
+
+  it('isLeoBridge / isSeededRepo helpers agree with resolveBuildModel', () => {
+    expect(isLeoBridge({ ventureBuildModel: 'leo_bridge' })).toBe(true);
+    expect(isSeededRepo({ ventureBuildModel: 'leo_bridge' })).toBe(false);
+    expect(isSeededRepo({})).toBe(true);
+    expect(BUILD_MODELS).toEqual(['leo_bridge', 'seeded_repo']);
+  });
+});

--- a/tests/unit/eva/lifecycle/exit-gate-build-completion.test.js
+++ b/tests/unit/eva/lifecycle/exit-gate-build-completion.test.js
@@ -1,0 +1,88 @@
+/**
+ * Regression: S19->S20 exit gate is EVIDENCE-BASED, not asserted.
+ * SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-4 (SECURITY VB-4).
+ *
+ * Proves an INCOMPLETE venture build is BLOCKED at S20: the build_mvp_build
+ * "Application deployed" verifier (verifyBuildMvpBuildPresent, reached via
+ * resolveVerifier) now fails closed when the artifact carries build-task
+ * completion with complete < total. A bare register-deployment (which, after
+ * the FR-4 stage19.js change, emits build_tasks_complete=null => 0) no longer
+ * free-passes the transition. Artifacts with NO completion fields keep prior
+ * existence-only semantics (backward compat for the Replit-reentry advisory).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveVerifier } from '../../../../lib/eva/lifecycle/exit-gate-verifiers.js';
+
+// Chainable supabase fake: every builder method returns `this`; maybeSingle
+// resolves the configured { data, error }. Mirrors the venture_artifacts query
+// shape in verifyBuildMvpBuildPresent.
+function mockSupabase({ data = null, error = null } = {}) {
+  const chain = {
+    from() { return chain; },
+    select() { return chain; },
+    eq() { return chain; },
+    limit() { return chain; },
+    async maybeSingle() { return { data, error }; },
+  };
+  return chain;
+}
+
+const VID = '11111111-2222-3333-4444-555555555555';
+const verifier = resolveVerifier('Application deployed');
+
+describe('S19->S20 exit gate — build completion (FR-4)', () => {
+  it('resolveVerifier maps "Application deployed" to a verifier', () => {
+    expect(typeof verifier).toBe('function');
+  });
+
+  it('BLOCKS an incomplete build (complete < total)', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a1', artifact_data: { build_tasks_total: 7, build_tasks_complete: 3 } },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/incomplete: 3\/7/);
+  });
+
+  it('BLOCKS the bare register-deployment case (complete=null => 0)', async () => {
+    // After the FR-4 stage19.js change, a register-deployment with no verified
+    // count emits build_tasks_complete: null. normalizeBuildTaskCompletion treats
+    // that as 0, so 0 < total => fail-closed.
+    const supabase = mockSupabase({
+      data: { id: 'a2', artifact_data: { build_tasks_total: 7, build_tasks_complete: null, build_completion_verified: false } },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/0\/7/);
+  });
+
+  it('ALLOWS a verified-complete build (complete >= total)', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a3', artifact_data: { build_tasks_total: 7, build_tasks_complete: 7, build_completion_verified: true } },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('ALLOWS an artifact with NO completion fields (reentry advisory — backward compat)', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a4', artifact_data: { repo_url: 'https://github.com/x/y', deployment_url: 'https://x.repl.co' } },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('BLOCKS when the artifact is missing / not is_current', async () => {
+    const supabase = mockSupabase({ data: null });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/missing or not is_current/);
+  });
+
+  it('FAILS-CLOSED on a query error', async () => {
+    const supabase = mockSupabase({ data: null, error: { message: 'boom' } });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/query failed/);
+  });
+});

--- a/tests/unit/eva/replit-repo-seeder.fail-closed.test.js
+++ b/tests/unit/eva/replit-repo-seeder.fail-closed.test.js
@@ -1,0 +1,71 @@
+/**
+ * Seeder fail-closed hardening — SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001
+ *   C5 / SECURITY VB-5 (AT-SEC-1): assertSeedableVentureRepo refuses empty/unknown/
+ *     hostile/platform repo URLs (no fall-through to the platform repo).
+ *   C3 / SECURITY VB-3: scanStagedFilesForSecrets flags stack secrets in staged TEXT
+ *     files (skips binaries) so the push path can fail closed before pushing to an
+ *     external venture repo.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { assertSeedableVentureRepo, scanStagedFilesForSecrets } from '../../../lib/eva/bridge/replit-repo-seeder.js';
+
+describe('assertSeedableVentureRepo (C5 / VB-5 fail-closed routing)', () => {
+  it('returns the normalized https URL for a valid venture repo (strips .git)', () => {
+    expect(assertSeedableVentureRepo('https://github.com/rickfelix/cronlinter')).toBe('https://github.com/rickfelix/cronlinter');
+    expect(assertSeedableVentureRepo('https://github.com/rickfelix/cronlinter.git')).toBe('https://github.com/rickfelix/cronlinter');
+  });
+
+  it('THROWS on empty / null (no fall-through to platform)', () => {
+    expect(() => assertSeedableVentureRepo('')).toThrow(/FAIL-CLOSED/);
+    expect(() => assertSeedableVentureRepo(null)).toThrow(/FAIL-CLOSED/);
+    expect(() => assertSeedableVentureRepo(undefined)).toThrow(/FAIL-CLOSED/);
+  });
+
+  it('THROWS on non-GitHub or shell-meta URLs', () => {
+    expect(() => assertSeedableVentureRepo('https://gitlab.com/x/y')).toThrow(/FAIL-CLOSED/);
+    expect(() => assertSeedableVentureRepo('https://github.com/x/y;rm -rf /')).toThrow(/FAIL-CLOSED/);
+  });
+
+  it('THROWS when the target is a PLATFORM repo (routing escape)', () => {
+    expect(() => assertSeedableVentureRepo('https://github.com/rickfelix/ehg')).toThrow(/PLATFORM/);
+    expect(() => assertSeedableVentureRepo('https://github.com/rickfelix/ehg.git')).toThrow(/PLATFORM/);
+    expect(() => assertSeedableVentureRepo('https://github.com/rickfelix/EHG_Engineer')).toThrow(/PLATFORM/);
+  });
+});
+
+describe('scanStagedFilesForSecrets (C3 / VB-3 secret scan before push)', () => {
+  let dir;
+  // Assemble the secret-SHAPED fixture at runtime so no literal secret lands in committed
+  // source (GitHub push-protection would otherwise flag this test value).
+  const CLERK_SK = ['sk', '_live_', 'aBcdEFgh1234567890ZyXwVu'].join('');
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'seedscan-'));
+    mkdirSync(join(dir, 'docs'), { recursive: true });
+    writeFileSync(join(dir, 'docs', 'clean.md'), '# Roadmap\nventure CronLinter normal text build_tasks_complete=7');
+    writeFileSync(join(dir, 'docs', 'leak.md'), `config: secretKey "${CLERK_SK}"`);
+    writeFileSync(join(dir, 'CLAUDE.md'), 'no secrets here');
+    // .png with secret-looking bytes must be SKIPPED (binary ext, not scanned)
+    writeFileSync(join(dir, 'docs', 'image.png'), `${CLERK_SK} pretend-binary`);
+  });
+  afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+  it('flags exactly the text file containing a secret, with its category', () => {
+    const hits = scanStagedFilesForSecrets(dir, ['docs/clean.md', 'docs/leak.md', 'CLAUDE.md', 'docs/image.png', 'docs/missing.md']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe('docs/leak.md');
+    expect(hits[0].categories).toContain('clerk_secret_key');
+  });
+
+  it('skips binary extensions and missing files; clean files are not flagged', () => {
+    const hits = scanStagedFilesForSecrets(dir, ['docs/image.png', 'docs/missing.md', 'docs/clean.md', 'CLAUDE.md']);
+    expect(hits).toHaveLength(0);
+  });
+
+  it('returns [] for empty/undefined staged list', () => {
+    expect(scanStagedFilesForSecrets(dir, [])).toEqual([]);
+    expect(scanStagedFilesForSecrets(dir, undefined)).toEqual([]);
+  });
+});

--- a/tests/unit/session-summary/secret-redactor.test.js
+++ b/tests/unit/session-summary/secret-redactor.test.js
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { redactSecrets, redactObject, containsSecrets } from '../../../scripts/modules/session-summary/secret-redactor.js';
+import { redactSecrets, redactObject, containsSecrets, scanSecrets } from '../../../scripts/modules/session-summary/secret-redactor.js';
 
 describe('SecretRedactor', () => {
   describe('redactSecrets', () => {
@@ -243,6 +243,57 @@ describe('SecretRedactor', () => {
 
     it('should handle special regex characters in surrounding text', () => {
       expect(redactSecrets('[test] api_key=secret_value_12345 {info}')).toContain('[REDACTED]');
+    });
+  });
+
+  // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C3 / SECURITY VB-3 / AT-SEC-3:
+  // stack-aware secret detection for the venture build stack (Clerk + Gemini + Replit),
+  // which the platform Supabase/GitHub scanner previously missed (false-PASS).
+  describe('C3 venture-stack secrets (Clerk / Gemini / Replit)', () => {
+    // Assemble secret-SHAPED fixtures at runtime so no literal secret lands in committed
+    // source — GitHub push-protection / secret-scanning would otherwise flag these test
+    // values (the very patterns C3 detects). join() yields the full string at runtime.
+    const j = (...p) => p.join('');
+    const CLERK_SK = j('sk', '_live_', 'aBcdEFgh1234567890ZyXwVu');
+    const CLERK_PK = j('pk', '_live_', 'ZHVtbXkxMjM0NTY3ODkwYWJjZGVm');
+    const GEMINI = j('AIza', 'SyD1234567890abcdefghIJKLMNOPqrstuv');
+
+    it('detects + redacts a BARE Clerk secret key (sk_live_)', () => {
+      const src = `createClerkClient({ secretKey: "${CLERK_SK}" })`;
+      expect(containsSecrets(src)).toBe(true);
+      const red = redactSecrets(src);
+      expect(red).not.toContain(CLERK_SK);
+      expect(red).toContain('CLERK_SECRET_KEY_REDACTED');
+      expect(scanSecrets(src).categories).toContain('clerk_secret_key');
+    });
+
+    it('detects a Clerk publishable key (pk_live_)', () => {
+      expect(scanSecrets(CLERK_PK).categories).toContain('clerk_publishable_key');
+    });
+
+    it('detects + redacts a bare Gemini / Google AI key (AIza...)', () => {
+      const src = `url=https://generativelanguage.googleapis.com/v1?key=${GEMINI}`;
+      expect(containsSecrets(src)).toBe(true);
+      const red = redactSecrets(src);
+      expect(red).not.toContain(GEMINI);
+      expect(red).toContain('GOOGLE_AI_KEY_REDACTED');
+      expect(scanSecrets(src).categories).toContain('google_ai_key');
+    });
+
+    it('detects a Replit DB URL (embedded credential) and REPLIT_* secrets', () => {
+      expect(scanSecrets(j('DATABASE_URL=https://u:', 'p4ss', '@db.app.replit.dev/x')).categories).toContain('replit_db_url');
+      expect(scanSecrets(j('REPLIT_TOKEN=', 'abc123def456ghi789')).categories).toContain('replit_secret');
+    });
+
+    it('scanSecrets reports multiple distinct categories and is empty for benign text', () => {
+      const multi = `${CLERK_SK} and key=${GEMINI}`;
+      const cats = scanSecrets(multi).categories;
+      expect(cats).toContain('clerk_secret_key');
+      expect(cats).toContain('google_ai_key');
+
+      const benign = scanSecrets('ventureName=CronLinter build_tasks_complete=7 just normal text');
+      expect(benign.found).toBe(false);
+      expect(benign.categories).toEqual([]);
     });
   });
 });

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -14,6 +14,7 @@ import {
   buildMergeArgs,
   verifyMerged,
   verifyBranchDeleted,
+  isPlatformRepo,
 } from '../../../lib/ship/auto-merge.mjs';
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
@@ -170,6 +171,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       prNumber: 42,
       repoOwner: 'o',
       repoName: 'r',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
       runner,
       logger: silentLogger,
     });
@@ -191,6 +193,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       prNumber: 42,
       repoOwner: 'o',
       repoName: 'r',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
       runner,
       logger: silentLogger,
     });
@@ -310,6 +313,7 @@ describe('attemptAutoMerge — hard-fail (FR-3, TS-4)', () => {
       prNumber: 99,
       repoOwner: 'o',
       repoName: 'r',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
       runner,
       logger: silentLogger,
     });
@@ -338,6 +342,7 @@ describe('attemptAutoMerge — race recovery (FR-4, TS-5)', () => {
       prNumber: 99,
       repoOwner: 'o',
       repoName: 'r',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
       runner,
       logger: silentLogger,
     });
@@ -352,6 +357,7 @@ describe('attemptAutoMerge — input validation', () => {
       prNumber: undefined,
       repoOwner: 'o',
       repoName: 'r',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
       runner: vi.fn(),
       logger: silentLogger,
     });
@@ -510,5 +516,92 @@ describe('attemptAutoMerge — branch-deletion verification (QF-20260509-VERIFY-
 
     expect(r.ok).toBe(true);
     expect(infos.some((m) => /not verified/.test(m))).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 C2 / AT-SEC-2: external-repo human merge-gate.
+describe('isPlatformRepo (C2 trust allowlist)', () => {
+  it('is true only for the two platform repos (case-insensitive)', () => {
+    expect(isPlatformRepo('rickfelix', 'ehg')).toBe(true);
+    expect(isPlatformRepo('rickfelix', 'EHG_Engineer')).toBe(true);
+    expect(isPlatformRepo('RickFelix', 'EHG')).toBe(true);
+  });
+  it('is false for venture/external/unknown repos and missing args', () => {
+    expect(isPlatformRepo('rickfelix', 'commitcraft-ai')).toBe(false);
+    expect(isPlatformRepo('someorg', 'someventure')).toBe(false);
+    expect(isPlatformRepo(null, 'ehg')).toBe(false);
+    expect(isPlatformRepo('rickfelix', undefined)).toBe(false);
+  });
+});
+
+describe('attemptAutoMerge — C2 external-repo merge-gate (SECURITY VB-2)', () => {
+  it('REFUSES a non-platform (venture) repo by default and never calls gh', async () => {
+    const { runner, calls } = makeRunner([]); // any gh call would be "unmatched"
+    const r = await attemptAutoMerge({
+      prNumber: 7,
+      repoOwner: 'rickfelix',
+      repoName: 'commitcraft-ai', // a venture repo, not platform
+      runner,
+      logger: silentLogger,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.requiresHumanMerge).toBe(true);
+    expect(r.reason).toMatch(/requires human merge/);
+    expect(r.exitCode).toBe(0); // gated, not an error
+    expect(calls).toHaveLength(0); // fail-closed BEFORE any gh invocation
+  });
+
+  it('REFUSES an unknown/unresolvable repo (fail-closed)', async () => {
+    const { runner, calls } = makeRunner([]);
+    const r = await attemptAutoMerge({ prNumber: 7, repoOwner: undefined, repoName: undefined, runner, logger: silentLogger });
+    expect(r.ok).toBe(false);
+    expect(r.requiresHumanMerge).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('ALLOWS a platform repo (proceeds to merge)', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+      { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-25T00:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+      { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+      { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+    ]);
+    const r = await attemptAutoMerge({ prNumber: 7, repoOwner: 'rickfelix', repoName: 'ehg', runner, logger: silentLogger });
+    expect(r.ok).toBe(true);
+    expect(r.requiresHumanMerge).toBeUndefined();
+  });
+
+  it('allowExternalMerge:true overrides the gate for a non-platform repo', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+      { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-25T00:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+      { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+      { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+    ]);
+    const r = await attemptAutoMerge({ prNumber: 7, repoOwner: 'someorg', repoName: 'someventure', runner, logger: silentLogger, allowExternalMerge: true });
+    expect(r.ok).toBe(true);
+  });
+
+  it('honors an injected isTrustedRepo predicate', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+      { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-05-25T00:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+      { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+      { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+    ]);
+    const r = await attemptAutoMerge({
+      prNumber: 7, repoOwner: 'trusted', repoName: 'venture', runner, logger: silentLogger,
+      isTrustedRepo: (o, n) => o === 'trusted' && n === 'venture',
+    });
+    expect(r.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 — Phase 1: defensive reconciliation

Closes **4 of 5** SECURITY attack surfaces (evidence `b88dc459`) + success criteria **3 & 4 (queue half)**. These are the fail-closed/additive controls that are **independent of the prod re-route (FR-3)** and the ops-gated items, so they're safe to land now while the SD continues.

> ⚠️ **Review requested — auto-merge intentionally NOT enabled.** ~870 LOC touching security-sensitive load-bearing files (handoff gates, auto-merge, the seeder). vitest excludes worktrees, so each control was verified via direct `node` import (CI is authoritative — please let it run).

### What's in this PR

| Control | Surface | Change |
|---|---|---|
| **FR-4** | VB-4 / criterion 3 | `stage19.js` no longer defaults `build_tasks_complete=total`; the S19→S20 exit-gate verifier is completion-aware (fails closed when `complete<total`); GATE5/6 fail-closed for uncloned **venture** repos (legit EHG-platform skip preserved). |
| **C2** | VB-2 | `auto-merge.mjs` refuses unattended auto-merge for non-platform repos (fail-closed; unknown=refuse) + `applications.trust_tier` column (**migration APPLIED**, DATABASE evidence `abe1bbd5`). |
| **C3** | VB-3 | `secret-redactor.js` gains Clerk/Gemini/Replit patterns + `scanSecrets()` (categories). |
| **C5 + C3-block + C1-seam** | VB-5 / VB-3 / VB-1(partial) | `replit-repo-seeder.js`: `assertSeedableVentureRepo` fail-closed routing + `scanStagedFilesForSecrets` push-block + `options.tokenProvider` seam with a loud ambient-PAT warning. |
| **FR-5** | criterion 4 | `rank-items.js` isolates venture-build SDs into a separate `ventureTrack` (out of platform tracks); `wsjf-priority-fetcher.js` (prio:top3) filters them; `leo-create-sd.js` no-venture guard stops phantom-venture auto-registration. |

### NOT in this PR — ops-gated Phase 2 (SD stays `in_progress`)
Recorded in `strategic_directives_v2.metadata.exec_progress_increments`:
- **Full C1 (VB-1)** — replace the shared PAT with a per-venture **GitHub App** installation token (needs App provisioning + `@octokit/auth-app`; an ops prerequisite). The seam + warning ship here.
- **FR-5 trigger activation** — the deferred fail-closed `target_application` trigger blocks **every** SD-insert path; needs a path audit + maintenance window + ops sign-off.
- **FR-3** — live re-route of CronLinter/Canvas AI onto the bridge (creates real prod SD trees; hard-to-reverse). Per the SECURITY evidence, gated on full C1–C5 — so it waits for the GitHub App.

### Testing
`exit-gate-build-completion`, `repo-paths-git-capable` (venture fail-close), `auto-merge` (C2 gate), `secret-redactor` (C3), `replit-repo-seeder.fail-closed` (C5/C3), `rank-items` (FR-5 — `node --test` 27/27). Secret-shaped test fixtures are assembled at runtime so no literal secret is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
