### PR TITLE
test(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-6 platform repoRoot regression net

### DIFF
--- a/lib/venture-repo-root.js
+++ b/lib/venture-repo-root.js
@@ -1,0 +1,73 @@
+/**
+ * Venture repo-root resolution (pure, dependency-injected).
+ *
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 / FR-6 (platform-regression net) + FR-3.
+ *
+ * Decides which repo root an SD's worktree should be created under, given the
+ * SD's `target_application`. Extracted from `scripts/resolve-sd-workdir.js`
+ * (the inline venture-override block) so the platform invariant can be tested
+ * WITHOUT pulling in that file's heavy import graph (worktree-manager, quota,
+ * supabase-client, …), which is prone to vitest collection-time load failures.
+ *
+ * Platform invariant (TS-2): when `target_application` is null/undefined or
+ * 'EHG_Engineer', the default (EHG_Engineer) repoRoot is returned UNCHANGED,
+ * source === 'platform', and NO `worktree.venture_repo_resolved` event is
+ * produced. A venture repoRoot override happens only for a non-platform
+ * `target_application` whose clone exists on disk with a `.git` entry.
+ *
+ * The function is side-effect free: it returns the structured `logs` it would
+ * have emitted so the caller owns logging (and tests can assert on them).
+ *
+ * @module lib/venture-repo-root
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * @typedef {Object} VentureRepoRootResult
+ * @property {string} repoRoot - resolved repo root (default for platform SDs)
+ * @property {'platform'|'venture'|'venture_not_found'} source
+ * @property {Array<Object>} logs - structured events the caller should emit
+ *   (each WITHOUT sdKey/timestamp; caller enriches). Empty for the platform case.
+ */
+
+/**
+ * @param {string|null|undefined} targetApp - SD's target_application
+ * @param {string} defaultRepoRoot - the platform (EHG_Engineer) root to keep for platform SDs
+ * @param {Object} [deps]
+ * @param {(targetApp: string) => (string|null)} [deps.getVenturePath] - venture path resolver
+ * @param {(p: string) => boolean} [deps.existsSync] - fs existence check (injectable for tests)
+ * @returns {VentureRepoRootResult}
+ */
+export function resolveVentureRepoRoot(targetApp, defaultRepoRoot, deps = {}) {
+  const existsSyncFn = deps.existsSync || fs.existsSync;
+  const getVenturePathFn = deps.getVenturePath;
+  const logs = [];
+
+  // Platform SDs (null/undefined/EHG_Engineer) NEVER take a venture path.
+  // Return BEFORE consulting any resolver so no extra work and no logs occur —
+  // byte-identical to the original `if (targetApp && targetApp !== 'EHG_Engineer')`
+  // guard skipping the block entirely.
+  if (!targetApp || targetApp === 'EHG_Engineer') {
+    return { repoRoot: defaultRepoRoot, source: 'platform', logs };
+  }
+
+  // Without a venture-path resolver we cannot route to a venture clone; stay on
+  // the platform root rather than guessing (mirrors the registry-only,
+  // no-auto-discovery posture of venture-resolver.getVenturePath).
+  if (typeof getVenturePathFn !== 'function') {
+    return { repoRoot: defaultRepoRoot, source: 'venture_not_found', logs };
+  }
+
+  const venturePath = getVenturePathFn(targetApp);
+  if (venturePath && existsSyncFn(path.join(venturePath, '.git'))) {
+    logs.push({ event: 'worktree.venture_repo_resolved', targetApp, repoRoot: venturePath });
+    return { repoRoot: venturePath, source: 'venture', logs };
+  }
+
+  logs.push({ event: 'worktree.venture_repo_not_found', targetApp, resolvedPath: venturePath });
+  return { repoRoot: defaultRepoRoot, source: 'venture_not_found', logs };
+}
+
+export default { resolveVentureRepoRoot };

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -21,6 +21,7 @@
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { getVenturePath } from '../lib/venture-resolver.js';
+import { resolveVentureRepoRoot } from '../lib/venture-repo-root.js';
 import { sanitizeBranchName, checkDirtyWorktree, verifyGitignore, acquireWorktreeLock, releaseLock } from '../lib/worktree-guards.js';
 import { enforceWorktreeQuota, MAX_WORKTREE_COUNT, WORKTREE_QUOTA_HELPERS } from '../lib/worktree-quota.js';
 // SD-LEO-INFRA-START-WORKTREE-BRANCH-001: delegate base-ref resolution + fetch
@@ -520,14 +521,18 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     }
   }
 
-  if (targetApp && targetApp !== 'EHG_Engineer') {
-    const venturePath = getVenturePath(targetApp);
-    if (venturePath && fs.existsSync(path.join(venturePath, '.git'))) {
-      repoRoot = venturePath;
-      emitLog({ event: 'worktree.venture_repo_resolved', sdKey, targetApp, repoRoot: venturePath });
-    } else {
-      emitLog({ event: 'worktree.venture_repo_not_found', sdKey, targetApp, resolvedPath: venturePath });
-      // Fall through to default repoRoot (EHG_Engineer)
+  // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-6: venture-vs-platform repoRoot decision
+  // is extracted to the pure lib/venture-repo-root.js helper so the platform
+  // invariant (null/EHG_Engineer never routes to a venture) is regression-tested
+  // without this file's heavy import graph. Behavior is identical: platform SDs
+  // keep `repoRoot` untouched and emit nothing; a venture with a real .git clone
+  // overrides repoRoot and emits venture_repo_resolved; a missing clone falls
+  // through to the default and emits venture_repo_not_found.
+  {
+    const ventureRoot = resolveVentureRepoRoot(targetApp, repoRoot, { getVenturePath });
+    repoRoot = ventureRoot.repoRoot;
+    for (const logEntry of ventureRoot.logs) {
+      emitLog({ ...logEntry, sdKey });
     }
   }
 
@@ -666,4 +671,4 @@ if (isMainScript) {
   });
 }
 
-export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath };
+export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot };

--- a/tests/unit/resolve-sd-workdir/platform-invariant.test.js
+++ b/tests/unit/resolve-sd-workdir/platform-invariant.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-6 / TS-2: PLATFORM REGRESSION INVARIANT.
+ *
+ * This is the regression NET that gates every other FR in this SD. It proves the
+ * platform build flow is byte-identical regardless of the venture-build wiring:
+ * for `target_application` IN (null, undefined, 'EHG_Engineer'), repoRoot resolution
+ * stays on the EHG_Engineer root, `source` is never 'venture', and NO
+ * `worktree.venture_repo_resolved` event is produced (the venture-path resolver is
+ * never even consulted).
+ *
+ * It targets the pure `resolveVentureRepoRoot` helper (lib/venture-repo-root.js),
+ * which `scripts/resolve-sd-workdir.js` delegates the decision to — so this asserts
+ * the exact branch that decides platform-vs-venture without dragging in that file's
+ * heavy import graph (worktree-manager / quota / supabase-client).
+ *
+ * TS-3 (venture happy path) and the not-found / no-resolver paths are included so
+ * the extraction is proven behavior-preserving in both directions.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+import { resolveVentureRepoRoot } from '../../../lib/venture-repo-root.js';
+import { ENGINEER_ROOT } from '../../../lib/repo-paths.js';
+
+const PLATFORM_TARGETS = [null, undefined, 'EHG_Engineer'];
+
+describe('FR-6 / TS-2: platform repoRoot invariant', () => {
+  for (const targetApp of PLATFORM_TARGETS) {
+    it(`target_application=${JSON.stringify(targetApp)} → stays on ENGINEER_ROOT, source!=venture, zero venture logs`, () => {
+      const getVenturePath = vi.fn(() => '/should/never/be/used');
+      const existsSync = vi.fn(() => true);
+
+      const result = resolveVentureRepoRoot(targetApp, ENGINEER_ROOT, { getVenturePath, existsSync });
+
+      // repoRoot unchanged === ENGINEER_ROOT
+      expect(result.repoRoot).toBe(ENGINEER_ROOT);
+      // source is never 'venture' for a platform SD
+      expect(result.source).not.toBe('venture');
+      expect(result.source).toBe('platform');
+      // zero venture_repo_resolved logs (in fact, zero logs at all)
+      expect(result.logs).toEqual([]);
+      expect(result.logs.some((l) => l.event === 'worktree.venture_repo_resolved')).toBe(false);
+      // the venture-path resolver is NEVER consulted for a platform SD
+      expect(getVenturePath).not.toHaveBeenCalled();
+      expect(existsSync).not.toHaveBeenCalled();
+    });
+  }
+
+  it('no venture_repo_resolved log is emitted across all platform targets', () => {
+    const allLogs = PLATFORM_TARGETS.flatMap(
+      (t) => resolveVentureRepoRoot(t, ENGINEER_ROOT, { getVenturePath: () => '/x', existsSync: () => true }).logs,
+    );
+    expect(allLogs).toHaveLength(0);
+  });
+});
+
+describe('TS-3 + fallthrough: venture routing is preserved by the extraction', () => {
+  it('a non-platform target with a real .git clone overrides repoRoot and logs venture_repo_resolved', () => {
+    const venturePath = path.join(path.sep, 'repos', 'commitcraft-ai');
+    const existsSync = vi.fn((p) => p === path.join(venturePath, '.git'));
+
+    const result = resolveVentureRepoRoot('commitcraft-ai', ENGINEER_ROOT, {
+      getVenturePath: () => venturePath,
+      existsSync,
+    });
+
+    expect(result.repoRoot).toBe(venturePath);
+    expect(result.source).toBe('venture');
+    expect(result.logs).toEqual([
+      { event: 'worktree.venture_repo_resolved', targetApp: 'commitcraft-ai', repoRoot: venturePath },
+    ]);
+  });
+
+  it("'ehg' (a separate platform repo, NOT the EHG_Engineer self-target) still routes off ENGINEER_ROOT", () => {
+    // Guards against over-broadening the platform check to all platform repos:
+    // only null/EHG_Engineer is the protected invariant; 'ehg' is its own repo.
+    const ehgPath = path.join(path.sep, 'repos', 'ehg');
+    const result = resolveVentureRepoRoot('ehg', ENGINEER_ROOT, {
+      getVenturePath: () => ehgPath,
+      existsSync: () => true,
+    });
+    expect(result.repoRoot).toBe(ehgPath);
+    expect(result.source).toBe('venture');
+  });
+
+  it('a venture with no on-disk .git clone falls through to the default root + logs venture_repo_not_found', () => {
+    const venturePath = path.join(path.sep, 'repos', 'not-cloned');
+    const result = resolveVentureRepoRoot('not-cloned', ENGINEER_ROOT, {
+      getVenturePath: () => venturePath,
+      existsSync: () => false,
+    });
+    expect(result.repoRoot).toBe(ENGINEER_ROOT);
+    expect(result.source).toBe('venture_not_found');
+    expect(result.logs).toEqual([
+      { event: 'worktree.venture_repo_not_found', targetApp: 'not-cloned', resolvedPath: venturePath },
+    ]);
+  });
+
+  it('a registry miss (getVenturePath → null) falls through to the default root', () => {
+    const result = resolveVentureRepoRoot('ghost-venture', ENGINEER_ROOT, {
+      getVenturePath: () => null,
+      existsSync: () => true,
+    });
+    expect(result.repoRoot).toBe(ENGINEER_ROOT);
+    expect(result.source).toBe('venture_not_found');
+  });
+
+  it('no resolver injected → falls through to the default root without throwing', () => {
+    const result = resolveVentureRepoRoot('some-venture', ENGINEER_ROOT, {});
+    expect(result.repoRoot).toBe(ENGINEER_ROOT);
+    expect(result.source).toBe('venture_not_found');
+    expect(result.logs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-6 (platform-regression net)

First PR of the venture-build EXEC loop. Ships the **platform-regression invariant** BEFORE any behavior change, so it gates every later FR in this SD.

### What
- Extracts the venture-vs-platform repoRoot decision out of `scripts/resolve-sd-workdir.js` into a pure, dependency-injected helper `lib/venture-repo-root.js`.
- Adds `tests/unit/resolve-sd-workdir/platform-invariant.test.js` (TS-2): for `target_application` IN (null, undefined, EHG_Engineer), repoRoot stays on the EHG_Engineer root, `source` is never `venture`, and zero `worktree.venture_repo_resolved` logs are emitted (the venture resolver is never even consulted).
- TS-3 + fallthrough cases prove the extraction is behavior-preserving for venture targets too (including that `ehg` still routes to its own repo).

### Why
This is the net. The HIGHEST-risk later FR (FR-2 local_path SSOT) can silently route venture work to the EHG_Engineer fallback; this invariant catches any platform regression introduced by FRs 1–5.

### Tests
9/9 green locally (vitest, 188ms, no DB / no heavy import graph). Behavior-preserving refactor — `resolve()` delegates the same decision to the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
