### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-2 local_path SSOT write-through + FR-2.C1 provision fix

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -15,6 +15,7 @@ import { resolve, join } from 'path';
 import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../../supabase-client.js';
 import { registerVentureResource } from '../../venture-resources.js';
+import { normalizeAppName } from '../../repo-paths.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
@@ -161,6 +162,29 @@ const DEFAULT_STEPS = [
 
       writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n');
       ctx.log(`[registry_updated] Added ${nextId}: ${ctx.venture.repoName} to registry`);
+
+      // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-2: write-through the path to the
+      // authoritative DB column applications.local_path so the DB-first resolver
+      // (resolveRepoPathDbFirst) and vw_venture_registry stop reading NULL. The
+      // registry.json write above is the sync/fallback tier; this keeps the two in
+      // lockstep. NON-FATAL: registry.json already succeeded, so a DB hiccup leaves
+      // the fallback intact rather than failing provisioning (per FR-2 rollback plan).
+      try {
+        const sb = createSupabaseServiceClient();
+        const dbLocalPath = ctx.venture.localPath.replace(/\\/g, '/');
+        const { data: appRows } = await sb.from('applications').select('id, name').eq('status', 'active');
+        const needle = normalizeAppName(ctx.venture.name);
+        const match = (appRows || []).find((a) => normalizeAppName(a.name) === needle);
+        if (match) {
+          const { error: upErr } = await sb.from('applications').update({ local_path: dbLocalPath }).eq('id', match.id);
+          if (upErr) ctx.log(`[registry_updated] WARN: applications.local_path write-through failed: ${upErr.message}`);
+          else ctx.log(`[registry_updated] applications.local_path written for "${ctx.venture.name}" -> ${dbLocalPath}`);
+        } else {
+          ctx.log(`[registry_updated] WARN: no active applications row matches "${ctx.venture.name}" — DB local_path not written (registry.json updated)`);
+        }
+      } catch (dbErr) {
+        ctx.log(`[registry_updated] WARN: applications.local_path write-through error: ${dbErr.message}`);
+      }
     },
   },
   {

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1341,52 +1341,67 @@ export class StageExecutionWorker {
    * SD-VW-BACKEND-EXEC-RECORDS-001
    *
    * Verify venture provisioning state and auto-provision if needed.
-   * Best-effort: failures are logged but do not block the SD bridge.
-   * SD: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-G
    *
-   * @param {string} ventureId - Venture UUID
-   * @param {string} [ventureName] - Venture name for provisioning
+   * SD: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-G;
+   * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-2.C1 — two corrections:
+   *   1. provision with the venture UUID, NOT the name. provisionVenture resolves
+   *      its state + metadata BY id (getState/resolveVentureMetadata), so passing
+   *      a name silently mis-queried and never provisioned.
+   *   2. FAIL LOUD (NC-7): a provisioning failure aborts the leo_bridge SD
+   *      creation instead of silently building against a missing repo. The throw
+   *      propagates to the stage-processing layer (_processVenture try/catch),
+   *      which records it as a stage failure — matching the unwrapped error model
+   *      of the surrounding bridge flow (artifact fetch, convertSprintToSDs).
+   *
+   * @param {string} ventureId - Venture UUID (passed to provisionVenture)
+   * @param {string} [ventureName] - Venture name (provisioning-state pre-check + logs only)
    */
   async _verifyAndProvisionVenture(ventureId, ventureName) {
+    // Provisioning-state pre-check is a soft optimization. A query error (e.g. the
+    // table is absent) is tolerable: fall through to an actual provisioning attempt.
+    let provState = null;
     try {
-      // Check venture_provisioning_state
-      const { data: provState, error: provError } = await this._supabase
+      const { data, error: provError } = await this._supabase
         .from('venture_provisioning_state')
         .select('state, github_repo_url, provisioned_at')
         .eq('venture_name', ventureName)
         .maybeSingle();
-
       if (provError) {
-        // Table may not exist yet — treat as not-provisioned
-        this._logger.warn(`[Worker] Provisioning check query error (non-fatal): ${provError.message}`);
+        this._logger.warn(`[Worker] Provisioning pre-check query error (non-fatal): ${provError.message}`);
+      } else {
+        provState = data;
       }
-
-      if (provState?.state === 'provisioned' && provState?.github_repo_url) {
-        this._logger.log(`[Worker] Stage 18: Venture "${ventureName}" already provisioned (${provState.github_repo_url})`);
-        return;
-      }
-
-      // Not provisioned — attempt auto-provision via venture-provisioner.js (Child C)
-      // Falls back gracefully if provisioner module doesn't exist yet
-      this._logger.log(`[Worker] Stage 18: Venture "${ventureName}" not provisioned — attempting auto-provision`);
-
-      try {
-        const provisionerPath = new URL('./bridge/venture-provisioner.js', import.meta.url);
-        const { provisionVenture } = await import(provisionerPath.href);
-        if (typeof provisionVenture === 'function') {
-          const repoPath = provState?.github_repo_url || null;
-          await provisionVenture(ventureName, { supabase: this._supabase, logger: this._logger, ventureRepoPath: repoPath });
-          this._logger.log(`[Worker] Stage 18: Auto-provisioned venture "${ventureName}"`);
-        } else {
-          this._logger.warn('[Worker] Stage 18: provisionVenture not exported — skipping auto-provision');
-        }
-      } catch (importErr) {
-        // Expected when venture-provisioner.js (Child C) is not yet implemented
-        this._logger.warn(`[Worker] Stage 18: Auto-provision unavailable (${importErr.message}) — continuing without provisioning`);
-      }
-    } catch (err) {
-      this._logger.warn(`[Worker] Stage 18: Provisioning verification failed (non-fatal): ${err.message}`);
+    } catch (preErr) {
+      this._logger.warn(`[Worker] Provisioning pre-check failed (non-fatal): ${preErr.message}`);
     }
+
+    if (provState?.state === 'provisioned' && provState?.github_repo_url) {
+      this._logger.log(`[Worker] Venture "${ventureName}" already provisioned (${provState.github_repo_url})`);
+      return;
+    }
+
+    this._logger.log(`[Worker] Venture "${ventureName}" not provisioned — auto-provisioning (venture ${ventureId})`);
+
+    const provisionerPath = new URL('./bridge/venture-provisioner.js', import.meta.url);
+    const { provisionVenture } = await import(provisionerPath.href);
+    if (typeof provisionVenture !== 'function') {
+      // The provisioner module ships in the tree now; a missing export is a real
+      // regression, not the historical "not yet implemented" case.
+      throw new Error('[Worker] venture-provisioner.provisionVenture is not exported — cannot provision before SD bridge');
+    }
+
+    // FR-2.C1: pass the venture UUID. `supabase` is intentionally NOT forwarded —
+    // provisionVenture owns its own client and silently ignored the arg before.
+    const repoPath = provState?.github_repo_url || null;
+    const result = await provisionVenture(ventureId, { logger: this._logger, ventureRepoPath: repoPath });
+
+    if (!result || result.success !== true) {
+      const reason = result?.error || 'unknown provisioning failure';
+      this._logger.error(`[Worker] Venture provisioning FAILED for "${ventureName}" (${ventureId}): ${reason}`);
+      throw new Error(`Venture provisioning failed for ${ventureName} (${ventureId}): ${reason}`);
+    }
+
+    this._logger.log(`[Worker] Provisioned venture "${ventureName}" (steps: ${(result.stepsCompleted || []).join(', ') || 'none'})`);
   }
 
   /**

--- a/lib/repo-paths.js
+++ b/lib/repo-paths.js
@@ -134,6 +134,52 @@ export function resolveRepoPath(targetApp) {
 }
 
 /**
+ * DB-first venture/application path resolver — SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-2.
+ *
+ * Prefers the authoritative DB column `applications.local_path`, falling back to
+ * the synchronous registry.json resolver (`resolveRepoPath`) when the DB is
+ * unavailable, has no matching row, or the row's `local_path` is NULL. This is the
+ * single "DB-first, registry-fallback" resolver the venture-build loop reads.
+ *
+ * It is ADDITIVE: it does NOT change the synchronous `resolveRepoPath` relied on by
+ * the ~40 sync callers. Those stay correct because the provisioner write-through
+ * keeps registry.json in lockstep with the DB column (registry is the fallback
+ * tier, not a divergent source). Name matching uses `normalizeAppName`, so a venture
+ * resolves whether the caller passes "CronLinter", "cronlinter", or "cron-linter".
+ *
+ * Platform invariant (FR-6 / TS-2) preserved: null/EHG_Engineer return ENGINEER_ROOT
+ * WITHOUT consulting the DB or registry venture path.
+ *
+ * @param {string} targetApp - Application name
+ * @param {import('@supabase/supabase-js').SupabaseClient} [supabase] - service client; when omitted, registry-only
+ * @returns {Promise<string|null>} Absolute local path, or null if unresolved
+ */
+export async function resolveRepoPathDbFirst(targetApp, supabase) {
+  if (!targetApp) return ENGINEER_ROOT;
+  const needle = normalizeAppName(targetApp);
+  if (needle === 'ehgengineer') return ENGINEER_ROOT;
+
+  if (supabase) {
+    try {
+      const { data, error } = await supabase
+        .from('applications')
+        .select('name, local_path, status')
+        .eq('status', 'active');
+      if (!error && Array.isArray(data)) {
+        const hit = data.find((a) => a.local_path && normalizeAppName(a.name) === needle);
+        if (hit) return path.resolve(hit.local_path);
+      }
+    } catch {
+      // DB unavailable is NOT an authoritative miss — fall through to the registry
+      // mirror rather than returning null (which would route work to the fallback).
+    }
+  }
+
+  // Registry fallback (sync; kept in lockstep with the DB column by provisioner write-through).
+  return resolveRepoPath(targetApp);
+}
+
+/**
  * Resolve a target_application to its GitHub org/repo string.
  *
  * @param {string} targetApp - Application name
@@ -248,6 +294,7 @@ export { ENGINEER_ROOT, FALLBACK_REPOS };
 export default {
   getRepoPaths,
   resolveRepoPath,
+  resolveRepoPathDbFirst,
   resolveGitHubRepo,
   normalizeAppName,
   isVentureRepo,

--- a/scripts/backfill-applications-local-path.mjs
+++ b/scripts/backfill-applications-local-path.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Backfill applications.local_path — SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-2.
+ *
+ * The path SSOT historically lived only in applications/registry.json; the DB
+ * column applications.local_path was NULL for every row, so the DB-first resolver
+ * (lib/repo-paths.js::resolveRepoPathDbFirst) and vw_venture_registry returned NULL
+ * and venture work silently routed to the EHG_Engineer fallback. This one-time,
+ * idempotent backfill populates the column so the DB becomes the authoritative
+ * source while registry.json remains the in-lockstep fallback.
+ *
+ * Resolution order per active application with a NULL local_path:
+ *   1. EHG_Engineer self  -> ENGINEER_ROOT
+ *   2. registry.json match (by normalizeAppName) with a local_path -> that path
+ *   3. convention -> <parent-of-ENGINEER_ROOT>/<kebab(name)>  (matches
+ *      venture-provisioner.resolveVentureMetadata, portable across machines)
+ *
+ * Idempotent: only rows where local_path IS NULL are touched. Re-running is a no-op.
+ *
+ * Usage:
+ *   node scripts/backfill-applications-local-path.mjs [--dry-run]
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { ENGINEER_ROOT, normalizeAppName } from '../lib/repo-paths.js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ENGINEER_ROOT is derived from the module's own location, so when this runs from
+// inside a `.worktrees/<sd>` checkout it points at the worktree, not the canonical
+// main repo. Strip the worktree suffix so the derived clone paths match what the
+// venture-provisioner writes from the main repo (sibling of EHG_Engineer), keeping
+// the DB column in lockstep regardless of where the backfill is invoked.
+function canonicalMainRoot() {
+  const root = ENGINEER_ROOT.replace(/\\/g, '/');
+  const idx = root.indexOf('/.worktrees/');
+  return idx === -1 ? root : root.slice(0, idx);
+}
+const MAIN_ROOT = canonicalMainRoot();
+const PARENT_DIR = path.resolve(MAIN_ROOT, '..');
+const REGISTRY_PATH = path.resolve(MAIN_ROOT, 'applications', 'registry.json');
+
+function kebab(name) {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function loadRegistryByNormalizedName() {
+  const byNorm = new Map();
+  try {
+    const reg = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8'));
+    for (const app of Object.values(reg.applications || {})) {
+      if (app.name && app.local_path) byNorm.set(normalizeAppName(app.name), app.local_path);
+    }
+  } catch { /* registry unreadable — convention-only */ }
+  return byNorm;
+}
+
+function deriveLocalPath(name, registryByNorm) {
+  const norm = normalizeAppName(name);
+  if (norm === 'ehgengineer') return MAIN_ROOT;
+  const fromRegistry = registryByNorm.get(norm);
+  if (fromRegistry) return fromRegistry.replace(/\\/g, '/');
+  return path.resolve(PARENT_DIR, kebab(name)).replace(/\\/g, '/');
+}
+
+async function main() {
+  const sb = await createSupabaseServiceClient('engineer');
+  const registryByNorm = loadRegistryByNormalizedName();
+
+  const { data: apps, error } = await sb
+    .from('applications')
+    .select('id, name, local_path, status')
+    .eq('status', 'active');
+  if (error) { console.error('[backfill] query failed:', error.message); process.exit(1); }
+
+  const targets = (apps || []).filter((a) => !a.local_path);
+  console.log(`[backfill] ${apps?.length ?? 0} active applications, ${targets.length} with NULL local_path${DRY_RUN ? ' (dry-run)' : ''}`);
+
+  let updated = 0;
+  for (const app of targets) {
+    const localPath = deriveLocalPath(app.name, registryByNorm);
+    console.log(`  ${app.name.padEnd(22)} -> ${localPath}`);
+    if (!DRY_RUN) {
+      const { error: upErr } = await sb.from('applications').update({ local_path: localPath }).eq('id', app.id);
+      if (upErr) console.error(`    WARN update failed: ${upErr.message}`);
+      else updated++;
+    }
+  }
+  console.log(`[backfill] ${DRY_RUN ? 'would update' : 'updated'} ${DRY_RUN ? targets.length : updated} row(s)`);
+  process.exit(0);
+}
+
+main().catch((e) => { console.error('[backfill] fatal:', e.message); process.exit(1); });

--- a/tests/unit/repo-paths-db-first.test.js
+++ b/tests/unit/repo-paths-db-first.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-2 / TS-4: DB-first path resolution.
+ *
+ * resolveRepoPathDbFirst prefers the authoritative applications.local_path DB column
+ * and only falls back to the synchronous registry.json resolver when the DB is
+ * unavailable / has no row / the row's local_path is NULL. TS-4: a value present in
+ * the DB column is what gets returned — registry.json staleness does not change it.
+ *
+ * Also asserts: the FR-6 platform invariant (null/EHG_Engineer never consult the DB),
+ * normalizeAppName matching across name forms, and that DB errors degrade to the
+ * registry fallback rather than returning null (which would mis-route to EHG_Engineer).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+import { resolveRepoPathDbFirst, resolveRepoPath, ENGINEER_ROOT } from '../../lib/repo-paths.js';
+
+function mockSupabase(rows, { throwOnQuery = false } = {}) {
+  const eq = vi.fn(() =>
+    throwOnQuery ? Promise.reject(new Error('db down')) : Promise.resolve({ data: rows, error: null }),
+  );
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return { client: { from }, spies: { from, select, eq } };
+}
+
+describe('FR-6 platform invariant holds in resolveRepoPathDbFirst', () => {
+  for (const targetApp of [null, undefined, 'EHG_Engineer', 'ehg_engineer']) {
+    it(`target=${JSON.stringify(targetApp)} → ENGINEER_ROOT without consulting the DB`, async () => {
+      const { client, spies } = mockSupabase([{ name: 'EHG_Engineer', local_path: 'D:/wrong', status: 'active' }]);
+      const result = await resolveRepoPathDbFirst(targetApp, client);
+      expect(result).toBe(ENGINEER_ROOT);
+      expect(spies.from).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('FR-2 / TS-4: DB column is authoritative over registry.json', () => {
+  it('returns the DB local_path (not the registry value) for a matched venture', async () => {
+    const dbPath = 'D:/db-authoritative/commitcraft-ai';
+    const { client } = mockSupabase([{ name: 'CommitCraft AI', local_path: dbPath, status: 'active' }]);
+    // 'commitcraft-ai' normalizes to the same key as the DB row's 'CommitCraft AI'.
+    const result = await resolveRepoPathDbFirst('commitcraft-ai', client);
+    expect(result).toBe(path.resolve(dbPath));
+    // Prove it is the DB value, not the registry value, by construction (sentinel path).
+    expect(result).not.toBe(resolveRepoPath('commitcraft-ai'));
+  });
+
+  it('matches across name forms via normalizeAppName (CronLinter / cron-linter / cronlinter)', async () => {
+    const dbPath = 'D:/db-authoritative/cronlinter';
+    for (const form of ['CronLinter', 'cron-linter', 'cronlinter', 'CRON LINTER']) {
+      const { client } = mockSupabase([{ name: 'CronLinter', local_path: dbPath, status: 'active' }]);
+      expect(await resolveRepoPathDbFirst(form, client)).toBe(path.resolve(dbPath));
+    }
+  });
+});
+
+describe('FR-2: registry fallback (DB miss / NULL / error / no client)', () => {
+  it('DB has no matching row → falls back to the sync registry resolver', async () => {
+    const { client } = mockSupabase([]);
+    const target = 'definitely-not-a-real-venture-xyz';
+    expect(await resolveRepoPathDbFirst(target, client)).toBe(resolveRepoPath(target));
+  });
+
+  it('matched row with NULL local_path is ignored → registry fallback', async () => {
+    const { client } = mockSupabase([{ name: 'CronLinter', local_path: null, status: 'active' }]);
+    expect(await resolveRepoPathDbFirst('cronlinter', client)).toBe(resolveRepoPath('cronlinter'));
+  });
+
+  it('no supabase client → registry resolver (e.g. ehg resolves from registry.json)', async () => {
+    expect(await resolveRepoPathDbFirst('ehg')).toBe(resolveRepoPath('ehg'));
+  });
+
+  it('DB query throws → degrades to registry fallback, never throws or returns a bare null mis-route', async () => {
+    const { client } = mockSupabase(null, { throwOnQuery: true });
+    expect(await resolveRepoPathDbFirst('ehg', client)).toBe(resolveRepoPath('ehg'));
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-2 (local_path SSOT) + FR-2.C1 (provision call-site)

Second PR of the venture-build EXEC loop. Netted by the FR-6 platform invariant (already on main).

### FR-2.C1 — provisioning call-site (stage-execution-worker.js)
- `_verifyAndProvisionVenture` now passes the **venture UUID** to `provisionVenture` (it resolves state/metadata by id; passing the name silently never provisioned), drops the ignored `supabase` arg, **checks the return value**, and **fails loud** (NC-7): an unprovisioned venture aborts the leo_bridge SD creation instead of silently building against a missing repo. The throw is recorded by the stage-processing layer (`_processVenture` try/catch), matching the surrounding unwrapped error model.

### FR-2 — local_path SSOT (the writer/consumer asymmetry fix)
Before: `applications.local_path` was NULL for all 9 rows; readers read registry.json; a naive DB-authoritative flip would return null and mis-route venture work to the EHG_Engineer fallback.
- **Backfill** (`scripts/backfill-applications-local-path.mjs`, idempotent, portable): derives clone paths from the canonical main root (sibling convention, matching the provisioner). All 9 rows populated; **verified `vw_venture_registry.local_path` now reflects the DB column**, so the async readers (`sd-router.resolveTargetApplicationAsync` → `getVentureConfigAsync`) resolve DB-first.
- **Write-through**: `venture-provisioner` now writes `applications.local_path` alongside registry.json (keyed by `normalizeAppName`), keeping the two in lockstep — non-fatal so a DB hiccup leaves the registry fallback intact.
- **Single resolver**: `resolveRepoPathDbFirst(targetApp, supabase)` in `lib/repo-paths.js` — DB-first, registry-fallback, platform invariant preserved.

### Scope note
The ~40 synchronous `resolveRepoPath` callers are intentionally **not** force-migrated to async (that ripple is unsafe); they stay on the registry tier, which write-through now keeps in lockstep with the DB (the documented registry-fallback tier). The DB-first resolver + already-async readers (sd-router/venture-resolver via `vw_venture_registry`) deliver the DB-first behavior; FR-3 consumes `resolveRepoPathDbFirst` for the clone loop.

### Tests
`tests/unit/repo-paths-db-first.test.js` (TS-4): DB-first over registry, `normalizeAppName` matching, platform invariant (DB never consulted for null/EHG_Engineer), and graceful registry fallback on DB miss/NULL/error. 10/10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
