### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-3 refresh-if-present venture clone for the EXEC loop

### DIFF
--- a/lib/eva/bridge/ensure-venture-clone.js
+++ b/lib/eva/bridge/ensure-venture-clone.js
@@ -1,0 +1,81 @@
+/**
+ * ensure-venture-clone.js — SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3.
+ *
+ * Ensure a venture's persistent local clone exists and is current at its registered
+ * `applications.local_path`, so the leo_bridge EXEC loop creates the per-SD worktree
+ * INSIDE the venture clone (off the venture's origin/main) rather than EHG_Engineer.
+ *
+ * Behavior:
+ *   - clone-if-missing : no `.git` at localPath  -> `git clone <repoUrl> <localPath>`
+ *   - refresh-if-present: `.git` present         -> fetch + checkout main + ff-only pull
+ *   - NEVER delete the persistent clone (refresh failures are non-fatal; the stale
+ *     clone is kept rather than removed — preserves uncommitted work + avoids churn).
+ *
+ * The clone URL MUST pass SAFE_GITHUB_HTTPS (the same guard the seeder uses) because
+ * it flows into `git clone`; anything else returns `skipped` rather than handing an
+ * unvalidated string to git. Side effects are injected (`run`, `existsSync`) so the
+ * clone/refresh decision is unit-testable without touching the network or disk
+ * (TS-3 happy path, TS-7 cleanup-safety).
+ *
+ * @module lib/eva/bridge/ensure-venture-clone
+ */
+
+import { existsSync as fsExistsSync } from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { normalizeRepoUrl, SAFE_GITHUB_HTTPS } from './resolve-venture-repo.js';
+
+/**
+ * @typedef {Object} EnsureCloneResult
+ * @property {boolean} ok
+ * @property {'cloned'|'refreshed'|'present'|'skipped'} action
+ * @property {string} path - the (intended) clone path
+ * @property {string} [reason] - why skipped / why refresh degraded to 'present'
+ */
+
+/**
+ * @param {string} repoUrl - venture GitHub https URL (may end with .git)
+ * @param {string} localPath - registered clone path (applications.local_path)
+ * @param {Object} [deps]
+ * @param {(cmd: string, args: string[]) => string} [deps.run] - command runner (default execFileSync)
+ * @param {(p: string) => boolean} [deps.existsSync] - fs existence check
+ * @param {(msg: string) => void} [deps.log]
+ * @returns {EnsureCloneResult}
+ */
+export function ensureVentureClone(repoUrl, localPath, deps = {}) {
+  const existsSync = deps.existsSync || fsExistsSync;
+  const run =
+    deps.run || ((cmd, args) => execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', timeout: 120000 }));
+  const log = deps.log || (() => {});
+
+  if (!localPath) {
+    return { ok: false, action: 'skipped', path: localPath, reason: 'no_local_path' };
+  }
+
+  const url = normalizeRepoUrl(repoUrl);
+  if (!url || !SAFE_GITHUB_HTTPS.test(url)) {
+    return { ok: false, action: 'skipped', path: localPath, reason: 'no_safe_repo_url' };
+  }
+
+  if (!existsSync(path.join(localPath, '.git'))) {
+    // clone-if-missing
+    run('git', ['clone', url, localPath]);
+    log(`cloned ${url} -> ${localPath}`);
+    return { ok: true, action: 'cloned', path: localPath };
+  }
+
+  // refresh-if-present — best-effort; NEVER delete the persistent clone.
+  try {
+    run('git', ['-C', localPath, 'fetch', 'origin', '--prune']);
+    run('git', ['-C', localPath, 'checkout', 'main']);
+    run('git', ['-C', localPath, 'pull', '--ff-only', 'origin', 'main']);
+    log(`refreshed ${localPath}`);
+    return { ok: true, action: 'refreshed', path: localPath };
+  } catch (err) {
+    // Keep the existing clone as-is (e.g. dirty tree, diverged main, offline).
+    log(`refresh non-fatal failure, keeping existing clone: ${err.message}`);
+    return { ok: true, action: 'present', path: localPath, reason: 'refresh_failed' };
+  }
+}
+
+export default ensureVentureClone;

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../../supabase-client.js';
 import { registerVentureResource } from '../../venture-resources.js';
 import { normalizeAppName } from '../../repo-paths.js';
+import { ensureVentureClone } from './ensure-venture-clone.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
@@ -96,15 +97,21 @@ const DEFAULT_STEPS = [
         stdio: 'pipe', encoding: 'utf8', timeout: 30000
       });
 
-      // Clone locally and scaffold if needed
-      if (!existsSync(ctx.venture.localPath)) {
-        ctx.log(`[repo_created] Cloning to ${ctx.venture.localPath}`);
-        execFileSync('git', ['clone', `https://github.com/rickfelix/${repoName}.git`, ctx.venture.localPath], {
-          stdio: 'pipe', encoding: 'utf8', timeout: 60000
-        });
-      }
+      // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3: ensure the persistent local clone
+      // exists AND is current — clone-if-missing / refresh-if-present, NEVER delete.
+      // The per-SD EXEC worktree is later created INSIDE this clone off the venture
+      // origin/main (resolve-sd-workdir routes repoRoot to local_path when .git is
+      // present), and pushes target the venture remote rickfelix/<repoName>.
+      const cloneResult = ensureVentureClone(
+        `https://github.com/rickfelix/${repoName}`,
+        ctx.venture.localPath,
+        { log: (m) => ctx.log(`[repo_created] ${m}`) },
+      );
       ctx.ventureRepoPath = ctx.venture.localPath;
-      ctx.log(`[repo_created] GitHub repo created: rickfelix/${repoName}`);
+      ctx.log(
+        `[repo_created] GitHub repo created: rickfelix/${repoName} — clone ${cloneResult.action}` +
+        `${cloneResult.reason ? ` (${cloneResult.reason})` : ''} at ${ctx.venture.localPath}`
+      );
 
       // Register resource in venture_resources registry
       try {

--- a/tests/unit/ensure-venture-clone.test.js
+++ b/tests/unit/ensure-venture-clone.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-3: ensureVentureClone.
+ *
+ * The persistent venture clone must be cloned-if-missing, refreshed-if-present, and
+ * NEVER deleted (TS-3 happy path + TS-7 cleanup safety). Side effects (git, fs) are
+ * injected so the clone/refresh decision and the never-delete invariant are asserted
+ * without touching the network or disk.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ensureVentureClone } from '../../lib/eva/bridge/ensure-venture-clone.js';
+
+const URL = 'https://github.com/rickfelix/cronlinter';
+const LOCAL = '/repos/cronlinter';
+
+function harness({ hasGit, failRefresh = false } = {}) {
+  const calls = [];
+  const run = vi.fn((cmd, args) => {
+    calls.push([cmd, ...args].join(' '));
+    if (failRefresh && args.includes('pull')) throw new Error('pull conflict');
+    return '';
+  });
+  const existsSync = vi.fn((p) => hasGit && p.replace(/\\/g, '/').endsWith('/.git'));
+  return { run, existsSync, calls };
+}
+
+// A destructive op never appears in the issued commands (TS-7 invariant).
+function assertNoDelete(calls) {
+  for (const c of calls) {
+    expect(c).not.toMatch(/\b(rm|rmdir|del|rd|worktree\s+remove|reset\s+--hard|clean\s+-)/i);
+  }
+}
+
+describe('FR-3 / TS-3: clone-if-missing', () => {
+  it('no .git at localPath → git clone <url> <localPath>, action=cloned', () => {
+    const { run, existsSync, calls } = harness({ hasGit: false });
+    const r = ensureVentureClone(URL, LOCAL, { run, existsSync });
+    expect(r).toMatchObject({ ok: true, action: 'cloned', path: LOCAL });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(calls[0]).toBe(`git clone ${URL} ${LOCAL}`);
+    assertNoDelete(calls);
+  });
+});
+
+describe('FR-3: refresh-if-present (fetch + checkout main + ff-only pull)', () => {
+  it('.git present → refreshes, never re-clones, action=refreshed', () => {
+    const { run, existsSync, calls } = harness({ hasGit: true });
+    const r = ensureVentureClone(URL, LOCAL, { run, existsSync });
+    expect(r).toMatchObject({ ok: true, action: 'refreshed' });
+    expect(calls).toEqual([
+      `git -C ${LOCAL} fetch origin --prune`,
+      `git -C ${LOCAL} checkout main`,
+      `git -C ${LOCAL} pull --ff-only origin main`,
+    ]);
+    expect(calls.some((c) => c.includes('clone'))).toBe(false);
+    assertNoDelete(calls);
+  });
+
+  it('refresh failure is non-fatal → action=present, clone preserved (NOT deleted)', () => {
+    const { run, existsSync, calls } = harness({ hasGit: true, failRefresh: true });
+    const r = ensureVentureClone(URL, LOCAL, { run, existsSync });
+    expect(r).toMatchObject({ ok: true, action: 'present', reason: 'refresh_failed' });
+    assertNoDelete(calls); // TS-7: a failed refresh must NEVER delete the persistent clone
+  });
+});
+
+describe('FR-3: safety guards', () => {
+  it('rejects a non-GitHub-https URL → skipped, no git command issued', () => {
+    const { run, existsSync, calls } = harness({ hasGit: false });
+    const r = ensureVentureClone('file:///etc/passwd; rm -rf /', LOCAL, { run, existsSync });
+    expect(r).toMatchObject({ ok: false, action: 'skipped', reason: 'no_safe_repo_url' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('missing localPath → skipped', () => {
+    const { run, existsSync } = harness({ hasGit: false });
+    const r = ensureVentureClone(URL, '', { run, existsSync });
+    expect(r).toMatchObject({ ok: false, action: 'skipped', reason: 'no_local_path' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a trailing .git on the URL before cloning', () => {
+    const { run, existsSync, calls } = harness({ hasGit: false });
+    ensureVentureClone(`${URL}.git`, LOCAL, { run, existsSync });
+    expect(calls[0]).toBe(`git clone ${URL} ${LOCAL}`);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-3 (venture-aware worktree + clone refresh)

Third PR of the venture-build EXEC loop. Netted by the FR-6 platform invariant on main.

### What
- New `lib/eva/bridge/ensure-venture-clone.js`: **clone-if-missing / refresh-if-present** (`fetch` + `checkout main` + `ff-only pull`) / **NEVER-delete** the persistent venture clone, gated by `SAFE_GITHUB_HTTPS`. Side effects injected for testability.
- Wired into `venture-provisioner` `repo_created`, replacing the clone-only-if-absent block so an existing clone is brought current before EXEC.

### Why this completes FR-3
The remaining FR-3 acceptance criteria were already satisfied by existing code, so this fills the one real gap (stale clones never refreshed):
- **Worktree inside the clone, off venture origin/main** — `resolve-sd-workdir` routes `repoRoot` → `local_path` when `.git` is present (FR-6 helper), and `createWorktree` bases `feat/<sd>` off that repoRoot's `origin/main`. Provisioning now reliably creates/refreshes the clone (FR-2.C1 made provisioning actually run with the venture UUID + fail-loud).
- **Push targets `rickfelix/<venture>`** — the clone's origin.
- **Cleanup preserves the clone** — `post-merge-worktree-cleanup` derives `mainRepoPath` from the worktree path (`<clone>/.worktrees/<sd>` → `<clone>`) and prunes only the per-SD worktree; the persistent clone is never removed.

### Tests
`tests/unit/ensure-venture-clone.test.js` — TS-3 (clone + refresh), TS-7 (refresh failure is non-fatal, never deletes), URL/path safety guards, `.git` URL normalization. 6/6 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
