### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-1 de-bypass venture-SD creation

### DIFF
--- a/lib/eva/bridge/venture-governance-metadata.js
+++ b/lib/eva/bridge/venture-governance-metadata.js
@@ -1,0 +1,38 @@
+/**
+ * venture-governance-metadata.js — SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-1.
+ *
+ * Governance metadata for the SDs the lifecycle bridge creates for a venture build
+ * tree (orchestrator -> children -> grandchildren, plus post-lifecycle expansion).
+ *
+ * DE-BYPASS: these SDs carry NO `automation_context.bypass_governance` and NO
+ * `bypass_reason`. Venture SDs are held to FULL LEO rigor — they pass the real
+ * LEAD-TO-PLAN gates (the SD_TYPE_VALIDATION gate is non-blocking: a type mismatch
+ * warns or auto-corrects, it never fails). The bridge previously stamped
+ * bypass_governance, which made `isTypeLocked` short-circuit that validation; the
+ * chairman directive is that ventures get the same bar as platform work, so the
+ * bypass is removed.
+ *
+ * Throughput is solved by ORCHESTRATION, not bypass: `headless: true` records that
+ * the tree is created + advanced by the orchestrator-child-agent (no interactive
+ * protocol-read per SD), while governance still runs. `actor_role` + `created_via`
+ * preserve provenance for audit.
+ *
+ * @module lib/eva/bridge/venture-governance-metadata
+ */
+
+/**
+ * @param {'orchestrator'|'child'|'grandchild'|'expansion'} tier
+ * @returns {{automation_context: {actor_role: string, created_via: string, headless: boolean, tier: string}}}
+ */
+export function ventureGovernanceMetadata(tier) {
+  return {
+    automation_context: {
+      actor_role: 'LEO_ORCHESTRATOR',
+      created_via: 'lifecycle-sd-bridge',
+      headless: true,
+      tier,
+    },
+  };
+}
+
+export default ventureGovernanceMetadata;

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -25,6 +25,9 @@
 import { ServiceError } from './shared-services.js';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
+// SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-1: venture SDs are created with full LEO
+// rigor (NO bypass_governance) — this helper supplies the de-bypassed provenance.
+import { ventureGovernanceMetadata } from './bridge/venture-governance-metadata.js';
 import {
   generateSDKey,
   generateChildKey,
@@ -193,10 +196,7 @@ export async function convertSprintToSDs(params, deps = {}) {
         key_changes: payloads.map(p => ({ change: p.title, type: p.type })),
         smoke_test_steps: [],
         risks: [],
-        governance_metadata: {
-          bypass_reason: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning',
-          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning' },
-        },
+        governance_metadata: ventureGovernanceMetadata('orchestrator'),
         metadata: {
           ...provenance,
           created_via: 'lifecycle-sd-bridge',
@@ -272,10 +272,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           risks: (payload.risks || []).map(r =>
             typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
           ),
-          governance_metadata: {
-            bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition',
-          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition' },
-          },
+          governance_metadata: ventureGovernanceMetadata('child'),
           metadata: {
             ...provenance,
             created_via: 'lifecycle-sd-bridge',
@@ -447,10 +444,7 @@ async function createGrandchildren({
         key_changes: [{ change: `${layer.label} for ${childPayload.title}`, type: childPayload.type || 'feature' }],
         smoke_test_steps: [],
         risks: [],
-        governance_metadata: {
-          bypass_reason: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition',
-          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition' },
-        },
+        governance_metadata: ventureGovernanceMetadata('grandchild'),
         metadata: {
           ...provenance,
           created_via: 'lifecycle-sd-bridge',
@@ -729,10 +723,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       key_changes: [{ change: expansionTitle, type: dbType }],
       smoke_test_steps: [],
       risks: [],
-      governance_metadata: {
-        bypass_reason: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision',
-        automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision' },
-      },
+      governance_metadata: ventureGovernanceMetadata('expansion'),
       metadata: {
         ...provenance,
         created_via: 'lifecycle-sd-bridge-expand',

--- a/tests/unit/venture-governance-metadata.test.js
+++ b/tests/unit/venture-governance-metadata.test.js
@@ -1,0 +1,51 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-1 / TS-5: no-bypass venture-SD creation.
+ *
+ * The lifecycle bridge must create the venture build tree (orchestrator -> children
+ * -> grandchildren -> expansion) with NO governance bypass, so each SD is held to
+ * full LEO rigor and reaches the REAL SD_TYPE_VALIDATION gate (not the
+ * `isTypeLocked` short-circuit). This pins the de-bypassed governance metadata.
+ */
+import { describe, it, expect } from 'vitest';
+import { ventureGovernanceMetadata } from '../../lib/eva/bridge/venture-governance-metadata.js';
+
+// Mirror of the gate predicate (scripts/.../sd-type-validation.js::isTypeLocked and
+// scripts/prd/index.js::isTypeLocked) — the only two readers of bypass_governance.
+function isTypeLocked(govMeta) {
+  if (!govMeta) return false;
+  if (govMeta.type_locked === true) return true;
+  if (govMeta.automation_context?.bypass_governance === true) return true;
+  return false;
+}
+
+const TIERS = ['orchestrator', 'child', 'grandchild', 'expansion'];
+
+describe('FR-1 / TS-5: venture governance metadata carries no bypass', () => {
+  for (const tier of TIERS) {
+    const gm = ventureGovernanceMetadata(tier);
+
+    it(`${tier}: no automation_context.bypass_governance`, () => {
+      expect(gm.automation_context).toBeDefined();
+      expect(gm.automation_context.bypass_governance).toBeUndefined();
+    });
+
+    it(`${tier}: no bypass_reason / type_locked anywhere`, () => {
+      expect(gm.bypass_reason).toBeUndefined();
+      expect(gm.automation_context.bypass_reason).toBeUndefined();
+      expect(gm.type_locked).toBeUndefined();
+    });
+
+    it(`${tier}: the gate sees it as NOT type-locked → real validation runs`, () => {
+      expect(isTypeLocked(gm)).toBe(false);
+    });
+
+    it(`${tier}: preserves headless automation provenance for audit`, () => {
+      expect(gm.automation_context).toMatchObject({
+        actor_role: 'LEO_ORCHESTRATOR',
+        created_via: 'lifecycle-sd-bridge',
+        headless: true,
+        tier,
+      });
+    });
+  }
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-1 (de-bypass)

Fourth PR. Removes the governance bypass from venture-SD creation — the chairman no-bypass non-negotiable.

### What
- New pure helper `lib/eva/bridge/venture-governance-metadata.js` supplies governance metadata with **NO** `automation_context.bypass_governance` / `bypass_reason`.
- All four `lifecycle-sd-bridge` creation tiers (orchestrator / child / grandchild / expansion) now use it — venture SDs are held to full LEO rigor.

### Why it is safe (verified, not assumed)
- With no bypass, `isTypeLocked` returns false, so the real `SD_TYPE_VALIDATION` gate runs. That gate is **non-blocking**: a type mismatch warns or auto-corrects (`pass: true`); the only `pass:false` paths are an invalid `sd_type` or a DB error, neither triggered here.
- Per the prospective TESTING analysis (C3), removing bypass does **not** trip DB guards at INSERT: orphan/type triggers are `BEFORE UPDATE OF sd_type` (not INSERT), and `validate_child_sd_phase` does not read bypass (children insert as `draft` → pass).
- Both runtime readers of `bypass_governance` (`sd-type-validation.js`, `scripts/prd/index.js`) are the same advisory `isTypeLocked` short-circuit.
- Provenance preserved: `actor_role` / `created_via` / `headless: true` — throughput stays orchestration-driven, not bypass-driven.

### Scope
This is the **de-bypass core** of FR-1. The remaining FR-1 item — replacing the `convertSprintToSDs` direct-insert with a programmatic validated-creation path that generates sub-agent evidence headlessly — is intertwined with FR-4 orchestration and is tracked for follow-up.

### Tests
`tests/unit/venture-governance-metadata.test.js` — TS-5: all four tiers carry no bypass, gate sees them as not-locked (real validation runs), provenance preserved. 16/16 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
