### PR TITLE
test(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-4 lock artifact-anchored venture touch point

### DIFF
--- a/tests/unit/lifecycle-sd-bridge-artifact-anchored.test.js
+++ b/tests/unit/lifecycle-sd-bridge-artifact-anchored.test.js
@@ -1,0 +1,43 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-4: artifact-anchored touch point.
+ *
+ * The venture-build touch point must trigger SD-tree creation on ARTIFACT presence
+ * (stageOutput.sd_bridge_payloads), NOT a hardcoded stage number. This locks that
+ * invariant: with no sd_bridge_payloads, convertSprintToSDs is a no-op and never
+ * touches the DB — regardless of any stage number — so no stage-number path can
+ * trigger creation. (The companion SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 owns
+ * stage-number reconciliation; this SD only guards artifact-anchoring.)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { convertSprintToSDs } from '../../lib/eva/lifecycle-sd-bridge.js';
+
+const silentLogger = { log: () => {}, warn: () => {}, error: () => {} };
+
+describe('FR-4: SD-tree creation is artifact-anchored (sd_bridge_payloads), not stage-number', () => {
+  it('no sd_bridge_payloads → no-op, DB never touched (no stage-number trigger)', async () => {
+    const fromSpy = vi.fn(() => { throw new Error('DB must not be touched when no payloads'); });
+    const result = await convertSprintToSDs(
+      {
+        stageOutput: { sprint_name: 'S', sprint_goal: 'g', lifecycle_stage: 19 },
+        ventureContext: { id: 'venture-1', name: 'CronLinter' },
+      },
+      { supabase: { from: fromSpy }, logger: silentLogger },
+    );
+    expect(result.created).toBe(false);
+    expect(result.errors).toContain('No sprint items to convert');
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('empty sd_bridge_payloads array → same artifact-anchored no-op', async () => {
+    const fromSpy = vi.fn(() => { throw new Error('DB must not be touched when payloads empty'); });
+    const result = await convertSprintToSDs(
+      {
+        stageOutput: { sprint_name: 'S', sd_bridge_payloads: [] },
+        ventureContext: { id: 'venture-1', name: 'CronLinter' },
+      },
+      { supabase: { from: fromSpy }, logger: silentLogger },
+    );
+    expect(result.created).toBe(false);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-4 (artifact-anchored touch point)

Fifth PR. Locks FR-4's verifiable acceptance criterion with a regression guard.

### Finding
FR-4's touch point was **already artifact-anchored** in existing code:
- `convertSprintToSDs` gates SD-tree creation on `stageOutput.sd_bridge_payloads` presence — not a stage number.
- `buildBridgeArtifactRecord` is parameterized (called with `19`), not a hardcoded `18`.
- The worker S19 bridge fetches artifacts across `[19,18]` and filters by `sd_bridge_payloads` presence.

So FR-4 needed no behavior change; the value is **preventing regression**.

### What
`tests/unit/lifecycle-sd-bridge-artifact-anchored.test.js`: with no / empty `sd_bridge_payloads`, `convertSprintToSDs` is a no-op and **never touches the DB** regardless of `lifecycle_stage` — proving no stage-number path can trigger creation. 2/2 green.

### Scope
AC#1 (orchestrator-child-agent drives the tree) and AC#3 (S20 gate) are existing capability. AC#2 (no new hardcoded stage numbers; artifact-presence trigger) is locked here. Stage-number reconciliation itself remains with companion `SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
