### PR TITLE
fix(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-3 DB-first venture worktree routing (pilot-surfaced)

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -22,6 +22,7 @@
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { getVenturePath } from '../lib/venture-resolver.js';
 import { resolveVentureRepoRoot } from '../lib/venture-repo-root.js';
+import { resolveRepoPathDbFirst } from '../lib/repo-paths.js';
 import { sanitizeBranchName, checkDirtyWorktree, verifyGitignore, acquireWorktreeLock, releaseLock } from '../lib/worktree-guards.js';
 import { enforceWorktreeQuota, MAX_WORKTREE_COUNT, WORKTREE_QUOTA_HELPERS } from '../lib/worktree-quota.js';
 // SD-LEO-INFRA-START-WORKTREE-BRANCH-001: delegate base-ref resolution + fetch
@@ -521,15 +522,29 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     }
   }
 
-  // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-6: venture-vs-platform repoRoot decision
-  // is extracted to the pure lib/venture-repo-root.js helper so the platform
-  // invariant (null/EHG_Engineer never routes to a venture) is regression-tested
-  // without this file's heavy import graph. Behavior is identical: platform SDs
-  // keep `repoRoot` untouched and emit nothing; a venture with a real .git clone
-  // overrides repoRoot and emits venture_repo_resolved; a missing clone falls
-  // through to the default and emits venture_repo_not_found.
+  // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-6 + FR-3: venture-vs-platform repoRoot decision.
+  // The platform invariant (null/EHG_Engineer never routes to a venture) is held by the
+  // pure lib/venture-repo-root.js helper (regression-tested without this file's heavy graph).
+  // FR-3: the venture path is resolved DB-FIRST (applications.local_path via
+  // resolveRepoPathDbFirst, registry fallback) — getVenturePath alone is registry-only and
+  // misses DB-tracked ventures (e.g. CronLinter) backfilled into applications but never
+  // written to registry.json, so their worktree wrongly fell through to EHG_Engineer.
   {
-    const ventureRoot = resolveVentureRepoRoot(targetApp, repoRoot, { getVenturePath });
+    // Platform SDs make NO DB call and never enter the venture branch (helper short-circuits) —
+    // byte-identical platform path, FR-6 invariant intact.
+    let resolveVenturePathFn = getVenturePath;
+    if (targetApp && targetApp !== 'EHG_Engineer') {
+      try {
+        const sb = createSupabaseServiceClient();
+        const dbPath = await resolveRepoPathDbFirst(targetApp, sb);
+        // resolveRepoPathDbFirst already falls back to the registry resolver, so its result
+        // is the authoritative venture path; wrap it as a sync closure for the pure helper.
+        resolveVenturePathFn = () => dbPath;
+      } catch {
+        // DB unavailable — keep the registry-only resolver (prior behavior).
+      }
+    }
+    const ventureRoot = resolveVentureRepoRoot(targetApp, repoRoot, { getVenturePath: resolveVenturePathFn });
     repoRoot = ventureRoot.repoRoot;
     for (const logEntry of ventureRoot.logs) {
       emitLog({ ...logEntry, sdKey });


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-3 follow-up (pilot-surfaced)

The **CronLinter pilot** surfaced a real gap and this fixes it.

### Gap
`resolve-sd-workdir` resolved the venture `repoRoot` via `getVenturePath` (registry.json **only**). DB-tracked ventures backfilled into `applications.local_path` (e.g. **CronLinter**) are not in registry.json, so `getVenturePath` returned `null` and a venture SD's worktree fell through to **EHG_Engineer** instead of the venture clone — the leo_bridge loop was broken for DB-only ventures.

```
getVenturePath('CronLinter')        [registry] = null
resolveRepoPathDbFirst('CronLinter')   [DB]    = C:\Users\rickf\Projects\_EHG\cronlinter
```

### Fix
`resolve()`'s venture branch now resolves the path **DB-first** via `resolveRepoPathDbFirst` (which itself falls back to the registry resolver). Platform SDs (null/EHG_Engineer) make **no** DB call and never enter the venture branch — byte-identical platform path. **FR-6 net still green (9/9).**

### Pilot proof (CronLinter — build_model=leo_bridge, repo_url set)
- `ensureVentureClone` cloned the real repo to `applications.local_path` → `_EHG/cronlinter`, origin `rickfelix/cronlinter`, branch `main`.
- `resolve-sd-workdir --target-app CronLinter` now emits `worktree.venture_repo_resolved repoRoot=_EHG/cronlinter` and resolves there — the per-SD worktree routes **inside the venture clone off its origin/main**.

This proves the EXEC loop's core end-to-end (clone → worktree-inside-clone) for a DB-tracked venture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
