### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-5 leo_bridge is the default build path (demote seeded_repo)

### DIFF
--- a/lib/eva/bridge/resolve-build-model.js
+++ b/lib/eva/bridge/resolve-build-model.js
@@ -16,24 +16,30 @@
  *   'seeded_repo' — seed CLAUDE.md/docs/build-tasks.md into the venture repo + a Replit Agent builds;
  *                   S20 Code Quality Gate validates. (The FINALIZE-CLAUDE-CODE-001 path.)
  *
- * Resolution precedence (explicit wins; safe default):
+ * Resolution precedence (explicit wins; leo_bridge default):
  *   1. ventures.build_model, when explicitly 'leo_bridge' | 'seeded_repo' (the SSOT field).
  *   2. legacy venture_stage_work.advisory_data.build_method ('replit_agent' => 'seeded_repo';
  *      'leo_bridge' => 'leo_bridge') — backward-compat for in-flight ventures.
- *   3. DEFAULT_BUILD_MODEL — 'seeded_repo'. NOTE: the chairman SSOT intent is 'leo_bridge', but the
- *      default is intentionally held at 'seeded_repo' until the venture-build EXEC loop (clone the
- *      venture repo locally + route child-SD EXEC into it + push back) is wired — flipping the
- *      default before that loop exists would create SD trees that cannot auto-build (a regression
- *      vs. the seeded path that does build). Flip DEFAULT_BUILD_MODEL to 'leo_bridge' as the final
- *      convergence step once the EXEC loop ships.
+ *   3. DEFAULT_BUILD_MODEL — 'leo_bridge' (SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-5). The EXEC loop
+ *      (clone the venture repo to applications.local_path + route per-SD worktrees inside it off the
+ *      venture origin/main) shipped and was pilot-proven on CronLinter, so the chairman SSOT default
+ *      is now active. seeded_repo survives ONLY as an EXPLICIT, logged opt-out via precedence 1/2 —
+ *      it is never selected silently when build_model is unset.
  *
  * @module lib/eva/bridge/resolve-build-model
  */
 
 export const BUILD_MODELS = Object.freeze(['leo_bridge', 'seeded_repo']);
 
-/** Held at seeded_repo until the venture-build EXEC loop is wired (see module doc). */
-export const DEFAULT_BUILD_MODEL = 'seeded_repo';
+/**
+ * leo_bridge is THE canonical venture build path. SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 flipped
+ * the default off 'seeded_repo' once the EXEC loop shipped + was pilot-proven on CronLinter
+ * (ensureVentureClone clones the venture repo to applications.local_path; resolve-sd-workdir
+ * routes the per-SD worktree INSIDE that clone off the venture origin/main, DB-first). seeded_repo
+ * is now a DEMOTED, EXPLICIT, LOGGED opt-out — taken ONLY when ventures.build_model='seeded_repo'
+ * or legacy build_method='replit_agent' is set (both logged by the S19 worker), never silently.
+ */
+export const DEFAULT_BUILD_MODEL = 'leo_bridge';
 
 /**
  * Resolve the build model for a venture at Stage 19. Pure.
@@ -51,7 +57,8 @@ export function resolveBuildModel({ ventureBuildModel = null, legacyBuildMethod 
   // 2. Legacy per-stage signal (backward-compat for in-flight ventures).
   if (legacyBuildMethod === 'replit_agent' || legacyBuildMethod === 'seeded_repo') return 'seeded_repo';
   if (legacyBuildMethod === 'leo_bridge') return 'leo_bridge';
-  // 3. Safe default (see module doc — chairman SSOT is leo_bridge, gated on the EXEC loop).
+  // 3. Default = leo_bridge (the EXEC loop shipped + pilot-proven; see module doc). seeded_repo
+  //    is never reached here — it requires an explicit, logged opt-out via precedence 1/2.
   return DEFAULT_BUILD_MODEL;
 }
 

--- a/tests/unit/eva/bridge/resolve-build-model.test.js
+++ b/tests/unit/eva/bridge/resolve-build-model.test.js
@@ -2,7 +2,8 @@
  * resolve-build-model (SSOT arbiter) — SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (RCA 813d4c3d).
  * The single decision point that resolves the venture-build "model schism": explicit
  * ventures.build_model wins; legacy build_method is honored for backward-compat; unset falls
- * to the safe default (seeded_repo, gated on the venture EXEC loop).
+ * to leo_bridge — SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-5 flipped the default once the EXEC
+ * loop shipped + was pilot-proven on CronLinter. seeded_repo is now an explicit, logged opt-out.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -23,21 +24,28 @@ describe('resolveBuildModel', () => {
     expect(resolveBuildModel({ legacyBuildMethod: 'leo_bridge' })).toBe('leo_bridge');
   });
 
-  it('unset resolves to the safe default (seeded_repo, gated on the EXEC loop)', () => {
-    expect(resolveBuildModel({})).toBe('seeded_repo');
-    expect(resolveBuildModel()).toBe('seeded_repo');
-    expect(DEFAULT_BUILD_MODEL).toBe('seeded_repo');
+  it('unset resolves to leo_bridge (default flipped once the EXEC loop shipped — FR-5)', () => {
+    expect(resolveBuildModel({})).toBe('leo_bridge');
+    expect(resolveBuildModel()).toBe('leo_bridge');
+    expect(DEFAULT_BUILD_MODEL).toBe('leo_bridge');
+  });
+
+  it('seeded_repo survives ONLY as an explicit opt-out (demoted, not deleted; never silent)', () => {
+    expect(resolveBuildModel({ ventureBuildModel: 'seeded_repo' })).toBe('seeded_repo');
+    expect(resolveBuildModel({ legacyBuildMethod: 'replit_agent' })).toBe('seeded_repo');
+    expect(resolveBuildModel({})).not.toBe('seeded_repo'); // never silently when build_model unset
   });
 
   it('invalid ventureBuildModel falls through to legacy/default', () => {
     expect(resolveBuildModel({ ventureBuildModel: 'garbage', legacyBuildMethod: 'leo_bridge' })).toBe('leo_bridge');
-    expect(resolveBuildModel({ ventureBuildModel: '' })).toBe('seeded_repo');
+    expect(resolveBuildModel({ ventureBuildModel: '' })).toBe('leo_bridge');
   });
 
   it('isLeoBridge / isSeededRepo helpers agree with resolveBuildModel', () => {
     expect(isLeoBridge({ ventureBuildModel: 'leo_bridge' })).toBe(true);
     expect(isSeededRepo({ ventureBuildModel: 'leo_bridge' })).toBe(false);
-    expect(isSeededRepo({})).toBe(true);
+    expect(isLeoBridge({})).toBe(true); // default is leo_bridge (FR-5)
+    expect(isSeededRepo({})).toBe(false);
     expect(BUILD_MODELS).toEqual(['leo_bridge', 'seeded_repo']);
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 — FR-5 (single build path)

Last FR. Flips `DEFAULT_BUILD_MODEL` from `seeded_repo` to `leo_bridge` — the convergence step the RECONCILE arbiter documented as *"do this once the EXEC loop ships."*

### Why now
The EXEC loop shipped and was **pilot-proven on CronLinter** this session: `ensureVentureClone` cloned the real repo to `applications.local_path`; `resolve-sd-workdir` routes the per-SD worktree **inside the clone off the venture origin/main** (DB-first).

### What
- `DEFAULT_BUILD_MODEL = 'leo_bridge'` — venture builds with an unset `build_model` now take the LEO-SD bridge path.
- `seeded_repo` is **demoted to an explicit, logged opt-out** (the AC's sanctioned form): reached only via `ventures.build_model='seeded_repo'` or legacy `build_method='replit_agent'` (both logged by the S19 worker) — **never silently** when `build_model` is unset.

### Safety
Verified **0 active ventures rely on the seeded default** (no active venture with null `build_model` at stage ≥18; CronLinter/Canvas AI are explicit `leo_bridge`; the only null rows are stage-17 parity-test fixtures). seeded is demoted, not deleted, so an explicit fallback remains. Arbiter test updated + a guard asserts seeded survives only as an explicit opt-out. 7/7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
