### PR TITLE
fix(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-2.C1 logger function for provisionVenture (E2E-surfaced)

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1392,8 +1392,15 @@ export class StageExecutionWorker {
 
     // FR-2.C1: pass the venture UUID. `supabase` is intentionally NOT forwarded —
     // provisionVenture owns its own client and silently ignored the arg before.
+    // provisionVenture expects `logger` to be a FUNCTION (its default is console.log) and
+    // calls it as ctx.log(msg); this._logger is the console OBJECT, so wrap its .log method
+    // — passing the object directly crashes with "ctx.log is not a function" (surfaced by the
+    // CronGenius leo_bridge E2E, which is the first run to reach provisioning with a real UUID).
     const repoPath = provState?.github_repo_url || null;
-    const result = await provisionVenture(ventureId, { logger: this._logger, ventureRepoPath: repoPath });
+    const result = await provisionVenture(ventureId, {
+      logger: (m) => this._logger.log(m),
+      ventureRepoPath: repoPath,
+    });
 
     if (!result || result.success !== true) {
       const reason = result?.error || 'unknown provisioning failure';


### PR DESCRIPTION
## FR-2.C1 follow-up — leo_bridge provisioning logger crash

The **CronGenius leo_bridge E2E** (first run to reach provisioning with a real venture UUID) surfaced a defect in FR-2.C1:

- `provisionVenture` expects `logger` to be a **function** (default `console.log`, called as `ctx.log(msg)`).
- `_verifyAndProvisionVenture` passed `this._logger`, which is the console **object** (`this._logger = options.logger || console`).
- The original name-not-UUID bug returned early (before the step loop), masking it. FR-2.C1's correct UUID reaches the steps → **crash `ctx.log is not a function`** → every leo_bridge S19 provisioning would fail.

**Fix (1 line):** wrap the object's method — `logger: (m) => this._logger.log(m)`.

**Validation:** the CronGenius E2E re-runs provisioning via the corrected path (clone → `applications.local_path` write-through → worktree-inside-clone). De-bypass tree creation (FR-1) already proven live this run (6 SDs, zero `bypass_governance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
