### PR TITLE
fix(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-3 ensure local clone when GitHub repo pre-exists (E2E-surfaced)

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -74,8 +74,12 @@ const DEFAULT_STEPS = [
     name: 'repo_created',
     check: async (ctx) => {
       if (ctx.stepsCompleted.includes('repo_created')) return true;
-      // Also check if GitHub repo already exists
       if (!ctx.venture) return false;
+      // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3: "done" requires BOTH the GitHub repo AND
+      // the local clone. A pre-existing GitHub repo (operator-created, or the S17 design repo)
+      // with no local clone must NOT skip this step — otherwise ensureVentureClone never runs
+      // and the leo_bridge EXEC loop has no clone to route per-SD worktrees into.
+      if (!existsSync(join(ctx.venture.localPath, '.git'))) return false;
       try {
         execFileSync('gh', ['repo', 'view', `rickfelix/${ctx.venture.repoName}`, '--json', 'name'], { stdio: 'pipe', encoding: 'utf8' });
         return true;
@@ -91,11 +95,21 @@ const DEFAULT_STEPS = [
       }
       const { repoName } = ctx.venture;
 
-      // Create GitHub repo via gh CLI
-      ctx.log(`[repo_created] Creating GitHub repo: rickfelix/${repoName}`);
-      execFileSync('gh', ['repo', 'create', `rickfelix/${repoName}`, REPO_VISIBILITY, '--description', `EHG Venture: ${ctx.venture.name}`], {
-        stdio: 'pipe', encoding: 'utf8', timeout: 30000
-      });
+      // FR-3: create the GitHub repo only if it does not already exist (idempotent — the repo
+      // may be operator-created or be the S17 design repo). Then ALWAYS ensure the local clone.
+      let repoExists = false;
+      try {
+        execFileSync('gh', ['repo', 'view', `rickfelix/${repoName}`, '--json', 'name'], { stdio: 'pipe', encoding: 'utf8' });
+        repoExists = true;
+      } catch { /* not found — create below */ }
+      if (repoExists) {
+        ctx.log(`[repo_created] GitHub repo rickfelix/${repoName} already exists — ensuring local clone`);
+      } else {
+        ctx.log(`[repo_created] Creating GitHub repo: rickfelix/${repoName}`);
+        execFileSync('gh', ['repo', 'create', `rickfelix/${repoName}`, REPO_VISIBILITY, '--description', `EHG Venture: ${ctx.venture.name}`], {
+          stdio: 'pipe', encoding: 'utf8', timeout: 30000
+        });
+      }
 
       // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3: ensure the persistent local clone
       // exists AND is current — clone-if-missing / refresh-if-present, NEVER delete.
@@ -109,7 +123,7 @@ const DEFAULT_STEPS = [
       );
       ctx.ventureRepoPath = ctx.venture.localPath;
       ctx.log(
-        `[repo_created] GitHub repo created: rickfelix/${repoName} — clone ${cloneResult.action}` +
+        `[repo_created] GitHub repo ready: rickfelix/${repoName} — clone ${cloneResult.action}` +
         `${cloneResult.reason ? ` (${cloneResult.reason})` : ''} at ${ctx.venture.localPath}`
       );
 


### PR DESCRIPTION
## FR-3 follow-up — clone skipped when the GitHub repo pre-exists

The CronGenius leo_bridge E2E (operator pre-created `rickfelix/crongenius`) surfaced that `repo_created` skipped its entire `execute` — including `ensureVentureClone` — whenever `gh repo view` succeeded. So a venture whose repo already exists (operator-created, or the S17 design repo) never got a **local clone**, and the leo_bridge EXEC loop had nothing to route worktrees into.

**Fix:** (1) the `check` now also requires the local clone (`.git` at `localPath`) before declaring the step done; (2) `execute` makes `gh repo create` idempotent (skip if the repo exists) and **always** runs `ensureVentureClone` (clone-if-missing). Validated in the E2E — `repo_created` now clones a pre-existing repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
