### PR TITLE
fix(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-3 venture-aware worktree substrate + canonical root (G-A/G-B, E2E-surfaced)

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -15,7 +15,7 @@ import { resolve, join } from 'path';
 import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../../supabase-client.js';
 import { registerVentureResource } from '../../venture-resources.js';
-import { normalizeAppName } from '../../repo-paths.js';
+import { normalizeAppName, getRepoRoot } from '../../repo-paths.js';
 import { ensureVentureClone } from './ensure-venture-clone.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
@@ -65,7 +65,9 @@ async function resolveVentureMetadata(ventureId) {
   if (!data) return null;
   // Normalize name to kebab-case for repo/directory naming
   const repoName = data.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  const localPath = resolve(ENGINEER_ROOT, '..', repoName);
+  // FR-3 (G-B): canonical main root (getRepoRoot strips any `.worktrees/<sd>` suffix) so the venture
+  // sibling-clone path is `_EHG/<repoName>` whether provisioning runs from main or a worktree.
+  const localPath = resolve(getRepoRoot(), '..', repoName);
   return { name: data.name, repoName, localPath };
 }
 

--- a/lib/repo-paths.js
+++ b/lib/repo-paths.js
@@ -256,8 +256,9 @@ export function clearCache() {
  * cwd-sensitive scripts such as `scripts/sd-start.js`. From within a
  * worktree, `--show-toplevel` returns the worktree path, not the main
  * repo; callers that expect "main repo" get silent breakage. This helper
- * always returns the EHG_Engineer root that repo-paths.js itself resolves
- * from its own module location (`__dirname/..`), which is invariant.
+ * always returns the EHG_Engineer root that repo-paths.js resolves from its own
+ * module location (`__dirname/..`), with any trailing `/.worktrees/<sd>` suffix
+ * stripped so it is the canonical main root whether called from main or a worktree.
  *
  * @param {object} [options]
  * @param {string} [options.cwd] - Optional cwd for diagnostic detection. When
@@ -266,8 +267,25 @@ export function clearCache() {
  *   that want to fail-fast with an actionable error.
  * @returns {string} absolute path of the canonical main repo root
  */
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3 (G-B): strip a trailing `/.worktrees/<name>` segment
+ * from a repo path, yielding the canonical main repo root. Pure + exported for testing/reuse.
+ * No-op when the path is not inside a `.worktrees/` subtree (returns the input unchanged).
+ * @param {string} p
+ * @returns {string}
+ */
+export function stripWorktreeSuffix(p) {
+  const root = String(p || '').replace(/\\/g, '/');
+  const idx = root.indexOf('/.worktrees/');
+  return idx === -1 ? p : path.resolve(root.slice(0, idx));
+}
+
 export function getRepoRoot(options = {}) {
-  return ENGINEER_ROOT;
+  // ENGINEER_ROOT is module-location-derived, so when repo-paths.js is loaded from a
+  // `.worktrees/<sd>` checkout it IS the worktree, not the main repo — silently breaking
+  // sibling/venture path derivation. stripWorktreeSuffix delivers the documented contract:
+  // the canonical main root from main OR a worktree. No-op from main (byte-identical to ENGINEER_ROOT).
+  return stripWorktreeSuffix(ENGINEER_ROOT);
 }
 
 /**
@@ -301,6 +319,7 @@ export default {
   isGitCapableRepo,
   clearCache,
   getRepoRoot,
+  stripWorktreeSuffix,
   isInsideWorktree,
   ENGINEER_ROOT,
   FALLBACK_REPOS,

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -56,9 +56,23 @@ export const SUBSTRATE_ITEMS = Object.freeze([
 ]);
 
 /**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3: substrate for a VENTURE worktree (created INSIDE a
+ * venture clone, not EHG_Engineer). A venture worktree legitimately lacks the EHG_Engineer items:
+ * scripts/lib are EHG_Engineer tooling, and node_modules/.env are installed by the venture's own
+ * build during EXEC — they are NOT prerequisites at claim time. The minimal "the venture content
+ * checked out, not an empty/broken worktree" guard is .git + package.json. resolve-sd-workdir
+ * passes this set to validateWorktreeSubstrate when the worktree's repoRoot is a venture clone.
+ */
+export const VENTURE_SUBSTRATE_ITEMS = Object.freeze([
+  '.git',
+  'package.json'
+]);
+
+/**
  * SD-LEO-INFRA-LEO-INFRA-WORKTREE-001 (FR-002):
  * Pure synchronous substrate presence check for a worktree directory.
- * Iterates SUBSTRATE_ITEMS and returns the subset that does not exist.
+ * Iterates the given substrate item list (SUBSTRATE_ITEMS by default) and returns the subset
+ * that does not exist. Pass VENTURE_SUBSTRATE_ITEMS for venture-clone worktrees.
  *
  * Witnessed 2026-05-02: a worktree was reported as successfully created but
  * contained only .claude/ and scripts/ — claim was recorded, every downstream
@@ -80,14 +94,14 @@ export const SUBSTRATE_ITEMS = Object.freeze([
  *   otherwise.
  * @throws {TypeError} if worktreePath is not a non-empty string.
  */
-export function validateWorktreeSubstrate(worktreePath) {
+export function validateWorktreeSubstrate(worktreePath, items = SUBSTRATE_ITEMS) {
   if (typeof worktreePath !== 'string' || worktreePath.length === 0) {
     throw new TypeError(
       `validateWorktreeSubstrate: worktreePath must be a non-empty string (got ${typeof worktreePath})`
     );
   }
   const missing = [];
-  for (const item of SUBSTRATE_ITEMS) {
+  for (const item of items) {
     const stat = fs.lstatSync(path.join(worktreePath, item), { throwIfNoEntry: false });
     if (!stat) {
       missing.push(item);

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -30,7 +30,7 @@ import { enforceWorktreeQuota, MAX_WORKTREE_COUNT, WORKTREE_QUOTA_HELPERS } from
 // cannot drift away from the createWorktree behavior.
 // SD-LEO-INFRA-LEO-INFRA-WORKTREE-001: SUBSTRATE_ITEMS + validateWorktreeSubstrate
 // for the post-creation completeness gate.
-import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError, SUBSTRATE_ITEMS, validateWorktreeSubstrate } from '../lib/worktree-manager.js';
+import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError, SUBSTRATE_ITEMS, VENTURE_SUBSTRATE_ITEMS, validateWorktreeSubstrate } from '../lib/worktree-manager.js';
 import { provisionWorktreeNodeModules, getIsolationMode, getFreeDiskBytes, countActiveFreshSessions } from '../lib/worktree-provision.js';
 import { execSync } from 'child_process';
 import fs from 'fs';
@@ -367,7 +367,13 @@ function createWorktree(sdKey, repoRoot, opts = {}) {
   // via lib/protocol-policies/worktree-failure-classification.js), releases
   // the claim via release_sd RPC, and exits non-zero. The incomplete worktree
   // directory is preserved on disk for operator inspection.
-  const substrate = validateWorktreeSubstrate(worktreePath);
+  // FR-3: a venture worktree (inside a venture clone) uses the minimal venture substrate
+  // (.git + package.json) — it legitimately lacks EHG_Engineer's scripts/lib, and node_modules/.env
+  // are installed by the venture's own build during EXEC, not prerequisites at claim time.
+  const substrate = validateWorktreeSubstrate(
+    worktreePath,
+    opts.isVentureWorktree ? VENTURE_SUBSTRATE_ITEMS : SUBSTRATE_ITEMS
+  );
   if (!substrate.ok) {
     emitLog({
       event: 'worktree.incomplete',
@@ -529,6 +535,9 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
   // resolveRepoPathDbFirst, registry fallback) — getVenturePath alone is registry-only and
   // misses DB-tracked ventures (e.g. CronLinter) backfilled into applications but never
   // written to registry.json, so their worktree wrongly fell through to EHG_Engineer.
+  // FR-3: track whether the per-SD worktree will live INSIDE a venture clone — drives the
+  // venture-aware substrate gate (a venture worktree lacks EHG_Engineer's scripts/lib/node_modules/.env).
+  let isVentureWorktree = false;
   {
     // Platform SDs make NO DB call and never enter the venture branch (helper short-circuits) —
     // byte-identical platform path, FR-6 invariant intact.
@@ -546,6 +555,7 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
     }
     const ventureRoot = resolveVentureRepoRoot(targetApp, repoRoot, { getVenturePath: resolveVenturePathFn });
     repoRoot = ventureRoot.repoRoot;
+    isVentureWorktree = ventureRoot.source === 'venture';
     for (const logEntry of ventureRoot.logs) {
       emitLog({ ...logEntry, sdKey });
     }
@@ -600,7 +610,7 @@ async function resolve(sdKey, mode, repoRoot, targetApp) {
   if (mode === 'claim') {
     // Create one
     try {
-      const created = createWorktree(sdKey, repoRoot, { activeSessionCount: _activeSessionCount });
+      const created = createWorktree(sdKey, repoRoot, { activeSessionCount: _activeSessionCount, isVentureWorktree });
       emitLog({ event: 'worktree.resolved', sdKey, source: 'created', resolvedCwd: created.path, outcome: 'success' });
 
       // Persist to DB

--- a/tests/unit/venture-worktree-hardening.test.js
+++ b/tests/unit/venture-worktree-hardening.test.js
@@ -1,0 +1,82 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-3 — venture-worktree hardening (E2E-surfaced gaps).
+ *
+ * G-A: a venture worktree (inside a venture clone) legitimately lacks EHG_Engineer's
+ *      scripts/lib/node_modules/.env. validateWorktreeSubstrate must accept a venture substrate
+ *      set (.git + package.json) so the post-creation gate stops rejecting venture worktrees.
+ * G-B: stripWorktreeSuffix yields the canonical main root from a `.worktrees/<sd>` path, so
+ *      venture sibling-clone derivation is correct whether run from main or a worktree.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { SUBSTRATE_ITEMS, VENTURE_SUBSTRATE_ITEMS, validateWorktreeSubstrate } from '../../lib/worktree-manager.js';
+import { stripWorktreeSuffix } from '../../lib/repo-paths.js';
+
+describe('G-A: venture-aware worktree substrate', () => {
+  it('VENTURE_SUBSTRATE_ITEMS is the minimal venture checkout (.git + package.json) — no EHG_Engineer tooling', () => {
+    expect(VENTURE_SUBSTRATE_ITEMS).toEqual(['.git', 'package.json']);
+    for (const ehgItem of ['scripts', 'lib', 'node_modules', '.env']) {
+      expect(VENTURE_SUBSTRATE_ITEMS).not.toContain(ehgItem);
+    }
+  });
+
+  it('a venture worktree (only .git + package.json) PASSES the venture set but FAILS the EHG_Engineer set', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'venture-wt-'));
+    try {
+      mkdirSync(join(dir, '.git'));
+      writeFileSync(join(dir, 'package.json'), '{"name":"crongenius"}');
+      // Venture substrate: satisfied.
+      expect(validateWorktreeSubstrate(dir, VENTURE_SUBSTRATE_ITEMS)).toEqual({ ok: true, missing: [] });
+      // EHG_Engineer substrate: still requires scripts/lib/node_modules/.env (proves the default is unchanged
+      // and that a venture worktree would have been wrongly rejected without the venture set).
+      const platform = validateWorktreeSubstrate(dir, SUBSTRATE_ITEMS);
+      expect(platform.ok).toBe(false);
+      expect(platform.missing).toEqual(['scripts', 'lib', 'node_modules', '.env']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('default items is still SUBSTRATE_ITEMS (parity preserved for platform worktrees)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'platform-wt-'));
+    try {
+      mkdirSync(join(dir, '.git'));
+      writeFileSync(join(dir, 'package.json'), '{}');
+      // No items arg → defaults to SUBSTRATE_ITEMS → still misses the EHG_Engineer items.
+      expect(validateWorktreeSubstrate(dir).missing).toEqual(['scripts', 'lib', 'node_modules', '.env']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('venture set still catches a broken/empty worktree (missing .git)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'broken-wt-'));
+    try {
+      writeFileSync(join(dir, 'package.json'), '{}'); // no .git
+      expect(validateWorktreeSubstrate(dir, VENTURE_SUBSTRATE_ITEMS)).toEqual({ ok: false, missing: ['.git'] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('G-B: stripWorktreeSuffix canonical main root', () => {
+  it('no-op when not inside a .worktrees subtree', () => {
+    expect(stripWorktreeSuffix('C:/Users/x/_EHG/EHG_Engineer')).toBe('C:/Users/x/_EHG/EHG_Engineer');
+    expect(stripWorktreeSuffix('/home/x/_EHG/EHG_Engineer')).toBe('/home/x/_EHG/EHG_Engineer');
+  });
+
+  it('strips a trailing /.worktrees/<sd> to the canonical main root', () => {
+    const main = path.resolve('C:/Users/x/_EHG/EHG_Engineer');
+    expect(stripWorktreeSuffix('C:/Users/x/_EHG/EHG_Engineer/.worktrees/SD-FOO-001')).toBe(main);
+  });
+
+  it('handles Windows backslash paths', () => {
+    const out = stripWorktreeSuffix('C:\\Users\\x\\_EHG\\EHG_Engineer\\.worktrees\\SD-FOO-001');
+    expect(out.replace(/\\/g, '/')).toBe(path.resolve('C:/Users/x/_EHG/EHG_Engineer').replace(/\\/g, '/'));
+    expect(out).not.toMatch(/\.worktrees/);
+  });
+});


### PR DESCRIPTION
## FR-3 follow-up — two gaps surfaced by the CronGenius leo_bridge E2E

**G-A (blocker):** `validateWorktreeSubstrate` required EHG_Engineer's `scripts/lib/node_modules/.env`, which a venture worktree (inside a venture clone) legitimately lacks → `WORKTREE_INCOMPLETE` blocked every venture-SD claim even though the worktree landed correctly inside the clone off the venture's `origin/main`. Fix: `VENTURE_SUBSTRATE_ITEMS` (`.git` + `package.json`) + an `items` param (defaults to `SUBSTRATE_ITEMS`, so the parity guard + platform behavior are unchanged); `resolve-sd-workdir` threads `isVentureWorktree` (`ventureRoot.source === 'venture'`). `ensureWorktreeEssentials` is already repoRoot-relative, so it needed no change. **Validated E2E: a CronGenius child worktree claim now returns `success:true`.**

**G-B (latent hardening):** `getRepoRoot` returned `ENGINEER_ROOT` (module-location), which *is* the worktree when loaded from a `.worktrees/<sd>` checkout — silently breaking venture sibling-clone derivation in `resolveVentureMetadata`. It now honors its documented contract via a pure `stripWorktreeSuffix` (**no-op from main**, byte-identical for every existing main-context caller); `resolveVentureMetadata` uses `getRepoRoot()` instead of raw `ENGINEER_ROOT`.

### Tests
`tests/unit/venture-worktree-hardening.test.js` (7) — venture vs platform substrate, parity-preserved default, broken-worktree still caught, `stripWorktreeSuffix` (no-op / strip / Windows paths). Substrate-parity guard + FR-6 platform net both still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
