### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-EXEC-001): FR-4 venture SD-tree quality (deps + priority + sprint key)

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -81,6 +81,78 @@ const ARCHITECTURE_LAYERS = [
   { key: 'tests', label: 'Test Layer', description: 'Unit tests, integration tests, E2E tests' },
 ];
 
+// ── SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 (FR-4 orchestration-quality): correct venture SD tree ──
+// Pure + exported for testing. Address the systemic gaps the CronGenius E2E surfaced: children had
+// no build-order dependencies, the orchestrator was lower-priority than its children, and the
+// key/title doubled "Sprint".
+
+/** Priority precedence (higher = more urgent). */
+const PRIORITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+
+/**
+ * Orchestrator priority = the highest priority among its children — an orchestrator must never be
+ * dequeued below the work it coordinates. Defaults to 'high' when no child carries a priority.
+ * @param {Array<{priority?:string}>} payloads
+ * @returns {string}
+ */
+export function aggregateOrchestratorPriority(payloads) {
+  let best = 0;
+  let bestName = 'high';
+  for (const p of (payloads || [])) {
+    const r = PRIORITY_RANK[String(p?.priority || '').toLowerCase()] || 0;
+    if (r > best) { best = r; bestName = String(p.priority).toLowerCase(); }
+  }
+  return best > 0 ? bestName : 'high';
+}
+
+/**
+ * Architecture-layer rank for build ordering: data/backend (0) → api (1) → integration/auth (2) →
+ * ui/frontend (3) → tests/docs (4). Read from architecture_layer | scope | type (the sprint
+ * planner sets `scope`=backend/integration/frontend); keyword fallback; unknown → 2 (middle).
+ * @param {{architecture_layer?:string, scope?:string, type?:string}} payload
+ * @returns {number}
+ */
+const LAYER_RANK = {
+  data: 0, db: 0, schema: 0, backend: 0, migration: 0,
+  api: 1,
+  integration: 2, service: 2, auth: 2,
+  ui: 3, frontend: 3, component: 3,
+  tests: 4, test: 4, docs: 4, documentation: 4,
+};
+export function sprintItemLayerRank(payload) {
+  const fields = [payload?.architecture_layer, payload?.scope, payload?.type]
+    .filter(Boolean).map((s) => String(s).toLowerCase());
+  for (const f of fields) { if (f in LAYER_RANK) return LAYER_RANK[f]; }
+  const blob = fields.join(' ');
+  for (const kw of Object.keys(LAYER_RANK)) { if (blob.includes(kw)) return LAYER_RANK[kw]; }
+  return 2;
+}
+
+/**
+ * Build-order dependencies for each child: a child depends on every child in a strictly-earlier
+ * architecture layer, so the existing SD dependency-resolver gates the build (backend → integration
+ * → frontend). Returns an array (parallel to childKeys) of SD-key arrays. Explicit per-item
+ * dependencies are kept in metadata; this fills the (currently empty) build-order column.
+ * @param {string[]} childKeys
+ * @param {number[]} ranks
+ * @returns {string[][]}
+ */
+export function deriveChildBuildOrder(childKeys, ranks) {
+  return childKeys.map((_, i) => childKeys.filter((__, j) => ranks[j] < ranks[i]));
+}
+
+/**
+ * De-duplicate the sprint label so keys/titles do not read "Sprint: Sprint 2026-05-26" /
+ * "…SPRINT-SPRINT-…". Strips a leading "Sprint" (+ separators); falls back to the raw name.
+ * @param {string} sprintName
+ * @returns {string}
+ */
+export function normalizeSprintLabel(sprintName) {
+  const s = String(sprintName || '').trim();
+  const stripped = s.replace(/^sprint[\s:_-]*/i, '').trim();
+  return stripped || s || 'sprint';
+}
+
 /**
  * Build provenance metadata for auto-generated records.
  * @param {string} ventureId - Source venture UUID
@@ -119,6 +191,7 @@ export async function convertSprintToSDs(params, deps = {}) {
   const supabase = deps.supabase || getSupabaseClient();
 
   const sprintName = stageOutput.sprint_name;
+  const sprintLabel = normalizeSprintLabel(sprintName); // FR-4: de-dupe "Sprint Sprint …" in key/title
   const sprintGoal = stageOutput.sprint_goal;
   const sprintDuration = stageOutput.sprint_duration_days;
   let payloads = stageOutput.sd_bridge_payloads || [];
@@ -162,10 +235,17 @@ export async function convertSprintToSDs(params, deps = {}) {
     const orchestratorKey = await generateSDKey({
       source: 'LEO',
       type: 'orchestrator',
-      title: `Sprint ${sprintName}`,
+      title: `Sprint ${sprintLabel}`,
       venturePrefix,
       skipLeadValidation: true,
     });
+
+    // FR-4: precompute child keys + architecture-layer ranks → build-order dependencies, so the SD
+    // dependency-resolver gates the build (backend → integration → frontend) instead of dispatching
+    // children in arbitrary/parallel order.
+    const childKeysAll = payloads.map((_, j) => generateChildKey(orchestratorKey, j));
+    const childRanks = payloads.map(sprintItemLayerRank);
+    const childBuildDeps = deriveChildBuildOrder(childKeysAll, childRanks);
 
     // Create orchestrator SD
     const orchestratorId = randomUUID();
@@ -176,13 +256,13 @@ export async function convertSprintToSDs(params, deps = {}) {
         id: orchestratorId,
         sd_key: orchestratorKey,
         venture_id: ventureContext?.id || null,
-        title: `Sprint: ${sprintName}`,
-        description: `Orchestrator for sprint "${sprintName}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
+        title: `Sprint: ${sprintLabel}`,
+        description: `Orchestrator for sprint "${sprintLabel}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
         scope: `Sprint orchestrator coordinating ${payloads.length} child SDs for venture ${ventureContext?.name || 'unknown'}.`,
         rationale: `Stage 18 sprint planning generated ${payloads.length} items requiring LEO workflow execution.`,
         sd_type: 'orchestrator',
         status: 'draft',
-        priority: 'medium',
+        priority: aggregateOrchestratorPriority(payloads), // FR-4: never below the work it coordinates
         category: 'Feature',
         current_phase: 'LEAD',
         target_application: normalizeTargetApplication(ventureContext?.name || getCurrentVenture()),
@@ -261,6 +341,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           target_application: normalizeTargetApplication(payload.target_application || ventureContext?.name || getCurrentVenture()),
           created_by: 'lifecycle-sd-bridge',
           parent_sd_id: orchestratorId,
+          dependencies: childBuildDeps[i], // FR-4: earlier-architecture-layer child SD keys → resolver gates build order
           success_criteria: [payload.success_criteria],
           success_metrics: [
             { metric: 'Implementation completeness', target: '100%', actual: 'TBD' },

--- a/tests/unit/lifecycle-sd-bridge-tree-quality.test.js
+++ b/tests/unit/lifecycle-sd-bridge-tree-quality.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-4 — orchestration-quality of the venture SD tree.
+ *
+ * Systemic gaps the CronGenius E2E surfaced in convertSprintToSDs (now fixed):
+ *   1. children had no build-order dependencies → arbitrary/parallel dispatch (landing page before API)
+ *   2. orchestrator priority was hardcoded 'medium' (below critical/high children)
+ *   3. key/title doubled "Sprint" ("Sprint: Sprint 2026-05-26", …SPRINT-SPRINT-…)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateOrchestratorPriority,
+  sprintItemLayerRank,
+  deriveChildBuildOrder,
+  normalizeSprintLabel,
+} from '../../lib/eva/lifecycle-sd-bridge.js';
+
+describe('FR-4 #3: normalizeSprintLabel de-dupes the Sprint prefix', () => {
+  it('strips a leading "Sprint"', () => {
+    expect(normalizeSprintLabel('Sprint 2026-05-26')).toBe('2026-05-26');
+    expect(normalizeSprintLabel('Sprint: 2026-05-26')).toBe('2026-05-26');
+    expect(normalizeSprintLabel('sprint-7')).toBe('7');
+  });
+  it('leaves a non-prefixed name unchanged + falls back safely', () => {
+    expect(normalizeSprintLabel('2026-05-26')).toBe('2026-05-26');
+    expect(normalizeSprintLabel('')).toBe('sprint');
+  });
+});
+
+describe('FR-4 #2: aggregateOrchestratorPriority = max child priority', () => {
+  it('picks the highest child priority', () => {
+    expect(aggregateOrchestratorPriority([{ priority: 'high' }, { priority: 'critical' }, { priority: 'low' }])).toBe('critical');
+    expect(aggregateOrchestratorPriority([{ priority: 'high' }, { priority: 'medium' }])).toBe('high');
+  });
+  it('defaults to high when no child carries a priority (never below its work)', () => {
+    expect(aggregateOrchestratorPriority([{}, {}])).toBe('high');
+    expect(aggregateOrchestratorPriority([])).toBe('high');
+  });
+});
+
+describe('FR-4 #1: layer rank + build-order dependencies', () => {
+  it('ranks by scope (the sprint planner field): backend < integration < frontend', () => {
+    expect(sprintItemLayerRank({ scope: 'backend' })).toBe(0);
+    expect(sprintItemLayerRank({ scope: 'integration' })).toBe(2);
+    expect(sprintItemLayerRank({ scope: 'frontend' })).toBe(3);
+    expect(sprintItemLayerRank({ architecture_layer: 'api' })).toBe(1);
+    expect(sprintItemLayerRank({ type: 'feature' })).toBe(2); // unknown → middle
+  });
+
+  it('CronGenius shape: backend builds first, integration next, frontend last', () => {
+    // A=backend, B=integration, C=frontend, D=integration, E=backend (the real sprint plan)
+    const payloads = [
+      { scope: 'backend' }, { scope: 'integration' }, { scope: 'frontend' }, { scope: 'integration' }, { scope: 'backend' },
+    ];
+    const keys = ['K-A', 'K-B', 'K-C', 'K-D', 'K-E'];
+    const ranks = payloads.map(sprintItemLayerRank); // [0,2,3,2,0]
+    const deps = deriveChildBuildOrder(keys, ranks);
+    expect(deps[0]).toEqual([]);                     // A backend → no deps
+    expect(deps[4]).toEqual([]);                     // E backend → no deps
+    expect(deps[1].sort()).toEqual(['K-A', 'K-E']);  // B integration → after both backends
+    expect(deps[3].sort()).toEqual(['K-A', 'K-E']);  // D integration → after both backends
+    expect(deps[2].sort()).toEqual(['K-A', 'K-B', 'K-D', 'K-E']); // C frontend → after backend + integration
+  });
+
+  it('no cycles + deps only point to strictly-earlier layers', () => {
+    const keys = ['a', 'b', 'c'];
+    const ranks = [0, 1, 2];
+    const deps = deriveChildBuildOrder(keys, ranks);
+    expect(deps).toEqual([[], ['a'], ['a', 'b']]);
+    // a child never depends on itself or a same/later-rank child
+    deps.forEach((d, i) => expect(d).not.toContain(keys[i]));
+  });
+});


### PR DESCRIPTION
## FR-4 follow-up — systemic SD-tree quality (3 gaps from the LEO-protocol review of the CronGenius tree)

Fixed in `convertSprintToSDs` for **all** ventures:
1. **Build-order dependencies (biggest):** children had `dependencies: []` → the orchestrator could dispatch in arbitrary/parallel order (landing page before the API). Each child's top-level `dependencies` column is now the SD keys of children in **strictly-earlier architecture layers** (`sprintItemLayerRank` on `scope`: backend<api<integration<ui/frontend<tests), so the existing dependency-resolver gates the build.
2. **Orchestrator priority:** hardcoded `medium` (below `critical`/`high` children) → `aggregateOrchestratorPriority` = max child priority.
3. **Doubled token:** `Sprint: Sprint 2026-05-26` / `…SPRINT-SPRINT-…` → `normalizeSprintLabel` strips the leading "Sprint".

Helpers are pure + exported + unit-tested (incl. the real CronGenius shape: backend→integration→frontend). The existing CronGenius tree was corrected in-place with the same helpers (orchestrator→critical, children gated A,E→B,D→C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
