### PR TITLE
fix(QF-20260526-913): make activation-invariant Lane-2 matching negation-aware

### DIFF
--- a/docs/reference/activation-invariant-rule.md
+++ b/docs/reference/activation-invariant-rule.md
@@ -71,6 +71,8 @@ The Stage-1 implementation uses path heuristics + free-text regexes. False posit
 - Adjusting the `SCHEMA_TYPES`, `SURFACE_TYPES`, `WORKER_TYPES` sets and the `SCHEMA_TEXT_REGEX`, `SURFACE_TEXT_REGEX`, `WORKER_TEXT_REGEX` patterns at the top of `trigger-evaluator.js`.
 - Documenting tuning decisions in this file and the SD's retrospective.
 
+**Negation-awareness (backlog `50a9da45`):** Lane-2 matches are negation-aware via `hasAffirmativeMatch()` — an occurrence preceded within its clause by a hard negation cue (`no` / `not` / `never` / `without` / `none` / `neither` / `nor`, or an `n't` contraction) is not counted, so `"no schema migration"` no longer false-triggers a UI-only SD. Soft "pre-existing" qualifiers (`existing` / `current`) are **intentionally not** suppressed: an existing consumer reading newly-written data is precisely the writer-consumer asymmetry this gate must catch, so suppressing them would risk false-negatives (a real chain shipping untested) — strictly worse than a false-positive, which the operator clears with the `ACTIV-CHAIN-DEFERRED` bypass.
+
 Future Stage-2 tuning may add acorn-based AST call-graph analysis for more precise touched-file classification.
 
 ## Anti-patterns

--- a/scripts/modules/activation-invariant/trigger-evaluator.js
+++ b/scripts/modules/activation-invariant/trigger-evaluator.js
@@ -35,6 +35,56 @@ const SCHEMA_TEXT_REGEX = /\b(schema (migration|change|update|adds)|migration (a
 const SURFACE_TEXT_REGEX = /\b(ui[ -]?component|react[- ]component|new[- ]component|chairman[^.]*view|dashboard|user[- ]facing|panel[^.]*renders|page[^.]*renders|component[^.]*renders)\b/i;
 const WORKER_TEXT_REGEX = /\b(s\d+ worker|stage[ -]\d+ worker|worker[^.]*(populates|writes|consumes|reads|hook)|consumer[^.]*(reads|consumes|populates)|new[- ](consumer|worker|api))\b/i;
 
+// Negation-awareness (backlog 50a9da45): the Lane-2 regexes above are pure
+// keyword matchers, so "no schema migration" / "without a new worker" match the
+// same as the affirmative form — a UI-only SD that disclaims data-layer work
+// then false-triggers (witnessed on SD-LEO-INFRA-STAGE-BUILD-MODEL-001).
+// hasAffirmativeMatch() skips any occurrence negated within its own clause.
+// HARD negations only (no/not/never/without/none/neither/nor + n't): soft
+// "existing/current" qualifiers are deliberately NOT suppressed, because an
+// existing consumer reading newly-written data is exactly the writer-consumer
+// asymmetry this gate must catch — a false-negative (real chain ships untested)
+// is worse than a false-positive (cleared via the ACTIV-CHAIN-DEFERRED bypass).
+const NEGATION_CUE_REGEX = /\b(?:no|not|never|without|none|neither|nor|rather than|instead of)\b|n['’]t\b/i;
+
+// Look back at most this many chars before a match for a negation cue, and never
+// across a hard clause boundary ([.;:,] or newline) so a negation in a prior
+// clause ("No data layer. The worker writes X.") does not leak forward.
+const NEGATION_LOOKBACK_CHARS = 40;
+
+/**
+ * True iff `regex` has at least one occurrence in `text` that is NOT negated —
+ * i.e. not immediately preceded, within the same clause and within
+ * NEGATION_LOOKBACK_CHARS, by a hard negation cue. Drop-in replacement for a
+ * bare `regex.test(text)` that no longer counts negated phrasing as a positive
+ * signal (backlog 50a9da45).
+ *
+ * @param {RegExp} regex  case-insensitive, non-global signal regex
+ * @param {string} text   aggregated free text
+ * @returns {boolean}
+ */
+function hasAffirmativeMatch(regex, text) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  // Clone with the global flag so exec() can iterate every occurrence.
+  const scanner = new RegExp(regex.source, regex.flags.includes('g') ? regex.flags : regex.flags + 'g');
+  let m;
+  while ((m = scanner.exec(text)) !== null) {
+    if (m[0].length === 0) { scanner.lastIndex++; continue; } // defensive; signal regexes never match empty
+    let preceding = text.slice(Math.max(0, m.index - NEGATION_LOOKBACK_CHARS), m.index);
+    // Trim to the current clause: drop up to & including the last hard boundary
+    // so only a SAME-clause negation counts.
+    const boundary = Math.max(
+      preceding.lastIndexOf('.'), preceding.lastIndexOf(';'),
+      preceding.lastIndexOf(':'), preceding.lastIndexOf(','),
+      preceding.lastIndexOf('\n'),
+    );
+    if (boundary !== -1) preceding = preceding.slice(boundary + 1);
+    if (!NEGATION_CUE_REGEX.test(preceding)) return true; // an affirmative occurrence
+    // else this occurrence is negated — keep scanning for a non-negated one.
+  }
+  return false;
+}
+
 /**
  * Pull all free-text fields from a single key_changes entry. Tolerant of
  * heterogeneous shapes; coerces non-string values to empty string.
@@ -129,9 +179,11 @@ export function evaluateTrigger(sd) {
   const lane1Passed = lane1SchemaMatch && lane1ConsumerMatch;
 
   const text = collectFreeText(sd);
-  const lane2SchemaMatch = SCHEMA_TEXT_REGEX.test(text);
-  const lane2SurfaceMatch = SURFACE_TEXT_REGEX.test(text);
-  const lane2WorkerMatch = WORKER_TEXT_REGEX.test(text);
+  // Negation-aware (backlog 50a9da45): a negated phrase ("no schema migration")
+  // does NOT count as a positive signal. See hasAffirmativeMatch above.
+  const lane2SchemaMatch = hasAffirmativeMatch(SCHEMA_TEXT_REGEX, text);
+  const lane2SurfaceMatch = hasAffirmativeMatch(SURFACE_TEXT_REGEX, text);
+  const lane2WorkerMatch = hasAffirmativeMatch(WORKER_TEXT_REGEX, text);
   const lane2ConsumerMatch = lane2SurfaceMatch || lane2WorkerMatch;
   const lane2Passed = lane2SchemaMatch && lane2ConsumerMatch;
 
@@ -175,7 +227,9 @@ export const TRIGGER_INTERNALS = {
   SCHEMA_TEXT_REGEX,
   SURFACE_TEXT_REGEX,
   WORKER_TEXT_REGEX,
+  NEGATION_CUE_REGEX,
   entryFreeText,
   collectStructuredTypes,
   collectFreeText,
+  hasAffirmativeMatch,
 };

--- a/scripts/modules/activation-invariant/trigger-evaluator.test.js
+++ b/scripts/modules/activation-invariant/trigger-evaluator.test.js
@@ -164,3 +164,53 @@ describe('evaluateTrigger — false-positive guards', () => {
     expect(result.lane1.types).toEqual([]);
   });
 });
+
+describe('evaluateTrigger — negation-aware Lane 2 (backlog 50a9da45)', () => {
+  const { hasAffirmativeMatch, SCHEMA_TEXT_REGEX, SURFACE_TEXT_REGEX, WORKER_TEXT_REGEX } = TRIGGER_INTERNALS;
+
+  it('UI-only SD that disclaims schema work does NOT trigger (the witnessed case)', () => {
+    // SD-LEO-INFRA-STAGE-BUILD-MODEL-001: a display-only panel SD saying
+    // "No schema migration" must not false-trigger the schema+UI+worker gate.
+    const sd = {
+      key_changes: [{
+        title: 'Build-model panel',
+        detail: 'New dashboard panel renders build progress. No schema migration; reads existing columns.',
+      }],
+    };
+    const result = evaluateTrigger(sd);
+    expect(result.triggered).toBe(false);
+    // Consumer signal IS present — it's the negated schema that stops the trigger,
+    // proving the negation logic (not a missing consumer) did the work.
+    expect(result.lane2.consumerMatch).toBe(true);
+    expect(result.lane2.schemaMatch).toBe(false);
+  });
+
+  it('suppresses a schema signal negated within its clause', () => {
+    expect(hasAffirmativeMatch(SCHEMA_TEXT_REGEX, 'this SD has no schema migration')).toBe(false);
+    expect(hasAffirmativeMatch(SCHEMA_TEXT_REGEX, 'ships without a new table')).toBe(false);
+    expect(hasAffirmativeMatch(SCHEMA_TEXT_REGEX, 'this SD ships a schema migration')).toBe(true);
+  });
+
+  it('suppresses surface/worker signals after no / never / n\'t cues', () => {
+    expect(hasAffirmativeMatch(WORKER_TEXT_REGEX, "doesn't add a new worker")).toBe(false);
+    expect(hasAffirmativeMatch(SURFACE_TEXT_REGEX, 'never renders a new dashboard')).toBe(false);
+    expect(hasAffirmativeMatch(WORKER_TEXT_REGEX, 'a new worker populates the table')).toBe(true);
+    expect(hasAffirmativeMatch(SURFACE_TEXT_REGEX, 'a new dashboard for the chairman')).toBe(true);
+  });
+
+  it('a negation in a PRIOR clause does not leak onto an affirmative chain', () => {
+    const sd = {
+      description: 'No legacy support. Schema migration adds gvos_x; a worker populates it and the dashboard renders the result.',
+    };
+    const result = evaluateTrigger(sd);
+    expect(result.triggered).toBe(true);
+    expect(result.lane2.schemaMatch).toBe(true);
+  });
+
+  it('does NOT suppress on soft "existing/current" qualifiers (avoids false-negatives)', () => {
+    // An existing consumer reading newly-written data is exactly the asymmetry the
+    // gate must catch, so "existing"/"current" are deliberately NOT negation cues.
+    expect(hasAffirmativeMatch(WORKER_TEXT_REGEX, 'the existing worker writes telemetry')).toBe(true);
+    expect(hasAffirmativeMatch(SURFACE_TEXT_REGEX, 'the current dashboard renders it')).toBe(true);
+  });
+});


### PR DESCRIPTION
## QF-20260526-913 — negation-aware activation-invariant trigger

**Backlog:** `50a9da45` (harness_backlog)

The Lane-2 free-text regexes in `scripts/modules/activation-invariant/trigger-evaluator.js` were negation-blind: `"no schema migration"` matched `"schema migration"`, so a UI-only SD that explicitly disclaims data-layer work false-triggered the schema+UI+worker activation-invariant gate (witnessed on SD-LEO-INFRA-STAGE-BUILD-MODEL-001, cleared via `ACTIV-CHAIN-DEFERRED`).

### Fix
- New `hasAffirmativeMatch(regex, text)` replaces the bare `regex.test()` in Lane 2. It iterates every match and skips any occurrence preceded **within its own clause** (≤40 chars, never across `[.;:,]`/newline) by a hard negation cue: `no` / `not` / `never` / `without` / `none` / `neither` / `nor`, or an `n't` contraction.
- **Conservative hard-negations only.** Soft `existing` / `current` qualifiers are deliberately *not* suppressed — an existing consumer reading newly-written data is exactly the writer-consumer asymmetry the gate must catch, so suppressing them would risk false-negatives (a real chain shipping untested), strictly worse than a false-positive (which the operator clears with the rate-limited bypass).
- Lane 1 (structured `key_changes[*].type`) is unchanged.

### Tests
- 5 new negated-phrase regression tests, including a design-lock test asserting `existing` / `current` is NOT suppressed.
- All 19 `trigger-evaluator.test.js` tests pass (299ms, scoped run).

### LOC
- Source 62 (logic 60 + doc 2), test 50 — within the Tier-2 75 source cap.

Closes feedback 50a9da45-3719-4b2e-8b37-208a6b16cb0b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
