### PR TITLE
fix(SD-LEO-INFRA-CROSS-REPO-AWARE-001): DESIGN scans target_application repo; gate fails closed on unresolved/empty

### DIFF
--- a/lib/sub-agents/design/index.js
+++ b/lib/sub-agents/design/index.js
@@ -24,6 +24,7 @@
  */
 
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import dotenv from 'dotenv';
@@ -53,6 +54,53 @@ dotenv.config();
 
 // Supabase client initialized in execute() to use async createSupabaseServiceClient
 let supabase = null;
+
+/**
+ * FR-1/FR-2 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): resolve the UI repo for a DESIGN run
+ * from the SD's target_application — never cwd, never a hardcoded 'ehg'. Reports whether
+ * resolution succeeded and whether the scanned tree actually has a src/components dir.
+ * Pure + exported for unit testing.
+ *
+ * @param {Object} options - execution options (repo_path, target_application)
+ * @returns {{resolvedRepoPath: string|null, repoResolved: boolean, repoPath: string, componentsDirExists: boolean}}
+ */
+export function resolveDesignRepo(options = {}) {
+  const resolvedRepoPath = options.repo_path
+    || (options.target_application ? resolveRepoPath(options.target_application) : resolveRepoPath('ehg'));
+  const repoResolved = !!resolvedRepoPath;
+  const repoPath = resolvedRepoPath || process.cwd();
+  const componentsDirExists = repoResolved && fs.existsSync(path.join(repoPath, 'src', 'components'));
+  return { resolvedRepoPath, repoResolved, repoPath, componentsDirExists };
+}
+
+/**
+ * FR-2: attach the repo-resolution metadata contract to a DESIGN results object and fail
+ * closed — a PASS produced by scanning an unresolved/empty tree (which yields zero
+ * violations) is downgraded to CONDITIONAL_PASS. The metadata keys are read by
+ * GATE1_DESIGN_DATABASE (design-database-gates-validation). Pure + exported for testing.
+ *
+ * @param {Object} results - DESIGN results object (mutated in place)
+ * @param {{resolvedRepoPath: string|null, repoResolved: boolean, componentsDirExists: boolean}} resolution
+ * @returns {Object} the same results object
+ */
+export function applyRepoResolutionVerdict(results, resolution) {
+  results.metadata = {
+    ...(results.metadata || {}),
+    repo_path: resolution.resolvedRepoPath,
+    repo_resolved: resolution.repoResolved,
+    components_dir_exists: resolution.componentsDirExists
+  };
+  if ((!resolution.repoResolved || !resolution.componentsDirExists) && results.verdict === 'PASS') {
+    results.verdict = 'CONDITIONAL_PASS';
+    if (results.confidence > 60) results.confidence = 60;
+    results.warnings.push({
+      severity: 'HIGH',
+      issue: `DESIGN scanned an unresolved or empty repo (repo_resolved=${resolution.repoResolved}, components_dir_exists=${resolution.componentsDirExists})`,
+      recommendation: 'Verify the SD target_application resolves to the UI repo; an empty/wrong tree yields zero violations and must not pass as green'
+    });
+  }
+  return results;
+}
 
 /**
  * Execute DESIGN sub-agent
@@ -104,8 +152,12 @@ export async function execute(sdId, subAgent, options = {}) {
     options
   };
 
+  // FR-1/FR-2 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): resolve the repo from the SD's
+  // target_application — not cwd, not a hardcoded 'ehg'. The resolution feeds both the
+  // grep cwd for every check AND the fail-closed metadata contract applied before return.
+  const resolution = resolveDesignRepo(options);
   try {
-    const repoPath = options.repo_path || resolveRepoPath('ehg');
+    const repoPath = resolution.repoPath;
 
     // Phase 1: Design System Compliance
     console.log('\n🎨 Phase 1: Checking design system compliance...');
@@ -387,6 +439,12 @@ export async function execute(sdId, subAgent, options = {}) {
     console.log('\n💡 Generating recommendations...');
     generateRecommendations(results);
 
+    // FR-2 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): attach the repo-resolution metadata
+    // contract + fail closed. Zero violations from an unresolved/empty tree is NOT
+    // evidence of compliance — never report PASS off a repo we could not resolve or
+    // that has no src/components.
+    applyRepoResolutionVerdict(results, resolution);
+
     console.log(`\n🏁 DESIGN Complete: ${results.verdict} (${results.confidence}% confidence)`);
 
     return results;
@@ -402,6 +460,8 @@ export async function execute(sdId, subAgent, options = {}) {
       recommendation: 'Review error and retry',
       error: error.message
     });
+    // Still record the resolution metadata (verdict is ERROR, not downgraded).
+    applyRepoResolutionVerdict(results, resolution);
     return results;
   }
 }
@@ -483,6 +543,9 @@ async function checkForNonUISdType(sdId, options) {
         consistency_check: { skipped: true, reason: `${effectiveType} SD - no UI components` },
         workflow_review: { skipped: true, reason: `${effectiveType} SD - no user-facing workflows` }
       },
+      // FR-2 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): a legitimate non-UI skip — NOT the
+      // empty-tree always-green failure the gate guards against — so it keeps full credit.
+      metadata: { repo_resolved: true, components_dir_exists: true, skip_reason: `non_ui_sd_type:${effectiveType}` },
       options
     };
   } catch (error) {
@@ -502,7 +565,12 @@ const UI_EXTENSION_PATTERN = /\.(tsx|jsx|css|scss|sass|less|html?|vue|svelte)$/i
 
 export function checkForNonUIDiff(options = {}) {
   try {
-    const repoPath = options.repo_path || process.cwd();
+    // FR-1 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): derive the diff repo from
+    // target_application, not a bare process.cwd() — the cwd default was a
+    // writer/consumer asymmetry with the main-path 'ehg' default.
+    const repoPath = options.repo_path
+      || (options.target_application ? resolveRepoPath(options.target_application) : null)
+      || process.cwd();
     const baseRef = options.diff_base_ref || 'origin/main';
     const diff = execSync(`git diff --name-only ${baseRef}..HEAD`, {
       cwd: repoPath,
@@ -542,6 +610,9 @@ export function checkForNonUIDiff(options = {}) {
         responsive_check: { skipped: true, reason: 'backend-only diff' },
         consistency_check: { skipped: true, reason: 'backend-only diff' }
       },
+      // FR-2 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): legitimate backend-only skip — the git
+      // diff confirmed zero UI files, so this keeps full gate credit (not an empty-tree miss).
+      metadata: { repo_path: repoPath, repo_resolved: true, components_dir_exists: true, skip_reason: 'backend_only_diff' },
       options
     };
   } catch (error) {

--- a/lib/sub-agents/design/workflow-analyzer.js
+++ b/lib/sub-agents/design/workflow-analyzer.js
@@ -79,7 +79,10 @@ export async function workflowReviewCapability(sdId, prdData, userStories, curre
     };
 
     // Step 2: Load or scan codebase patterns (with caching)
-    const repoPath = options.repo_path || resolveRepoPath('ehg');
+    // FR-1 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): derive from target_application, not a
+    // hardcoded 'ehg' — this was an independent cwd/'ehg' fallback sibling to index.js:108.
+    const repoPath = options.repo_path
+      || (options.target_application ? resolveRepoPath(options.target_application) : resolveRepoPath('ehg'));
     console.log('   🔍 Loading codebase patterns...');
     const codebasePatterns = await loadOrScanPatterns(repoPath, options);
 

--- a/scripts/modules/design-database-gates-validation.js
+++ b/scripts/modules/design-database-gates-validation.js
@@ -17,6 +17,30 @@ import { getPatternStats } from './pattern-tracking.js';
 import { requiresDesignDatabaseGates, requiresDesignDatabaseGatesSync, validateStreamCompletion } from './sd-type-checker.js';
 
 /**
+ * FR-3 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): decide whether a DESIGN execution row earns
+ * its 20/20 credit. A PASS produced by scanning an unresolved/empty repo
+ * (metadata.repo_resolved === false, or metadata.components_dir_exists === false) is an
+ * always-green false-negative and must NOT score full credit. Rows predating the
+ * metadata contract (keys undefined) keep full credit for backward compatibility.
+ * Pure + exported for unit testing.
+ *
+ * @param {Object} designResult - a sub_agent_execution_results row (verdict, metadata, ...)
+ * @returns {{awardCredit: boolean, repoUnresolved: boolean, componentsMissing: boolean, repo_resolved: *, components_dir_exists: *}}
+ */
+export function evaluateDesignExecutionCredit(designResult) {
+  const dmeta = (designResult && designResult.metadata) || {};
+  const repoUnresolved = dmeta.repo_resolved === false;
+  const componentsMissing = dmeta.components_dir_exists === false;
+  return {
+    awardCredit: !(repoUnresolved || componentsMissing),
+    repoUnresolved,
+    componentsMissing,
+    repo_resolved: dmeta.repo_resolved,
+    components_dir_exists: dmeta.components_dir_exists
+  };
+}
+
+/**
  * Validate DESIGN→DATABASE workflow for PLAN→EXEC handoff
  * Phase-Aware Weighting System (Readiness Focus)
  *
@@ -167,19 +191,46 @@ export async function validateGate1PlanToExec(sd_id, supabase) {
       console.log('   ❌ DESIGN sub-agent NOT executed - BLOCKING (0/20)');
     } else {
       const designResult = designResults[0];
-      validation.score += 20;
-      validation.gate_scores.design_execution = 20;
-      validation.details.design_execution = {
-        verdict: designResult.verdict,
-        confidence: designResult.confidence,
-        timestamp: designResult.created_at,
-        workflow_analysis: designResult.metadata?.workflow_analysis
-      };
-      console.log(`   ✅ DESIGN sub-agent executed (verdict: ${designResult.verdict}) (20/20)`);
+      // FR-3 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): fail-closed on an unresolved/empty repo.
+      // A PASS verdict produced by scanning the wrong (cwd) or a non-existent repo yields
+      // zero violations — an always-green false-negative. evaluateDesignExecutionCredit
+      // withholds the 20/20 credit when the repo-resolution metadata says the scan target
+      // was unresolved/empty; legacy rows (keys undefined) keep full credit.
+      const credit = evaluateDesignExecutionCredit(designResult);
+      if (!credit.awardCredit) {
+        validation.gate_scores.design_execution = 0;
+        validation.failed_gates.push('DESIGN_EXECUTION');
+        validation.issues.push(
+          `DESIGN ran against an unresolved/empty repo (repo_resolved=${credit.repo_resolved}, ` +
+          `components_dir_exists=${credit.components_dir_exists}) — verdict ${designResult.verdict} is an ` +
+          `always-green false-negative, not valid evidence. Ensure the SD target_application resolves to the UI repo.`
+        );
+        validation.details.design_execution = {
+          verdict: designResult.verdict,
+          confidence: designResult.confidence,
+          timestamp: designResult.created_at,
+          repo_resolved: credit.repo_resolved,
+          components_dir_exists: credit.components_dir_exists,
+          credit_withheld: true
+        };
+        console.log(`   ❌ DESIGN ran against an unresolved/empty repo - credit withheld (0/20)`);
+      } else {
+        validation.score += 20;
+        validation.gate_scores.design_execution = 20;
+        validation.details.design_execution = {
+          verdict: designResult.verdict,
+          confidence: designResult.confidence,
+          timestamp: designResult.created_at,
+          repo_resolved: credit.repo_resolved,
+          components_dir_exists: credit.components_dir_exists,
+          workflow_analysis: designResult.metadata?.workflow_analysis
+        };
+        console.log(`   ✅ DESIGN sub-agent executed (verdict: ${designResult.verdict}) (20/20)`);
 
-      // Check for DESIGN failures
-      if (designResult.verdict === 'FAIL') {
-        validation.warnings.push('DESIGN sub-agent verdict was FAIL - review workflow analysis');
+        // Check for DESIGN failures
+        if (designResult.verdict === 'FAIL') {
+          validation.warnings.push('DESIGN sub-agent verdict was FAIL - review workflow analysis');
+        }
       }
     }
 

--- a/scripts/prd/sub-agent-orchestrator.js
+++ b/scripts/prd/sub-agent-orchestrator.js
@@ -10,6 +10,8 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { executeSubAgent } from '../../lib/sub-agent-executor.js';
+import { resolveRepoPathDbFirst } from '../../lib/repo-paths.js';
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
 import {
   formatObjectives,
   formatArrayField,
@@ -111,7 +113,31 @@ export async function executeDesignAnalysis(sdId, sdData, personaContextBlock = 
 
     console.log('Executing DESIGN sub-agent programmatically...\n');
 
-    const designResult = await executeSubAgent('DESIGN', sdId, { timeout: 120000 });
+    // FR-1 (SD-LEO-INFRA-CROSS-REPO-AWARE-001): resolve the SD's UI repo from
+    // target_application (DB-first) and thread it into DESIGN so it scans the right
+    // repo instead of cwd / a hardcoded 'ehg'. Without this the design gate is a
+    // silent always-green no-op for every cross-repo UI SD (RCA-DESIGN-...-CWD-001).
+    let repoPath = null;
+    try {
+      let supabase = null;
+      try {
+        supabase = await createSupabaseServiceClient('engineer', { verbose: false });
+      } catch {
+        // No client → resolveRepoPathDbFirst falls back to the registry resolver.
+      }
+      repoPath = await resolveRepoPathDbFirst(sdData.target_application, supabase);
+    } catch (resolveErr) {
+      console.warn(`   ⚠️  DESIGN repo resolution failed (${resolveErr.message}); the DESIGN module will resolve from target_application`);
+    }
+    if (repoPath) {
+      console.log(`   📁 DESIGN repo_path resolved from target_application='${sdData.target_application}': ${repoPath}`);
+    }
+
+    const designResult = await executeSubAgent('DESIGN', sdId, {
+      timeout: 120000,
+      repo_path: repoPath || undefined,
+      target_application: sdData.target_application
+    });
     const designOutput = formatSubAgentResult(designResult, 'DESIGN');
 
     console.log('Design analysis complete!\n');

--- a/tests/unit/modules/design-gate-repo-credit.test.js
+++ b/tests/unit/modules/design-gate-repo-credit.test.js
@@ -1,0 +1,42 @@
+/**
+ * SD-LEO-INFRA-CROSS-REPO-AWARE-001 — FR-3 gate fail-closed scoring.
+ *
+ * GATE1_DESIGN_DATABASE used to award the full 20/20 DESIGN-execution credit for the
+ * mere existence of a PASS-verdict row, never reading whether DESIGN actually scanned the
+ * right repo. evaluateDesignExecutionCredit makes that credit conditional on the
+ * repo-resolution metadata, while keeping legacy rows (no metadata keys) at full credit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateDesignExecutionCredit } from '../../../scripts/modules/design-database-gates-validation.js';
+
+describe('SD-LEO-INFRA-CROSS-REPO-AWARE-001 — FR-3 evaluateDesignExecutionCredit', () => {
+  it('TS-C: withholds credit when repo_resolved=false (unresolved repo)', () => {
+    const c = evaluateDesignExecutionCredit({ verdict: 'PASS', metadata: { repo_resolved: false, components_dir_exists: false } });
+    expect(c.awardCredit).toBe(false);
+    expect(c.repoUnresolved).toBe(true);
+  });
+
+  it('withholds credit when components_dir_exists=false (scanned the wrong repo)', () => {
+    const c = evaluateDesignExecutionCredit({ verdict: 'PASS', metadata: { repo_resolved: true, components_dir_exists: false } });
+    expect(c.awardCredit).toBe(false);
+    expect(c.componentsMissing).toBe(true);
+  });
+
+  it('awards credit when the repo resolved and src/components exists', () => {
+    const c = evaluateDesignExecutionCredit({ verdict: 'PASS', metadata: { repo_resolved: true, components_dir_exists: true } });
+    expect(c.awardCredit).toBe(true);
+    expect(c.repoUnresolved).toBe(false);
+    expect(c.componentsMissing).toBe(false);
+  });
+
+  it('awards credit for legacy rows missing the metadata keys (backward compatible)', () => {
+    const c = evaluateDesignExecutionCredit({ verdict: 'PASS', metadata: { workflow_analysis: {} } });
+    expect(c.awardCredit).toBe(true);
+  });
+
+  it('awards credit when metadata is absent or the row is null', () => {
+    expect(evaluateDesignExecutionCredit({ verdict: 'PASS' }).awardCredit).toBe(true);
+    expect(evaluateDesignExecutionCredit(null).awardCredit).toBe(true);
+  });
+});

--- a/tests/unit/sub-agents/design-cross-repo-resolution.test.js
+++ b/tests/unit/sub-agents/design-cross-repo-resolution.test.js
@@ -1,0 +1,167 @@
+/**
+ * SD-LEO-INFRA-CROSS-REPO-AWARE-001 — DESIGN cross-repo repo resolution.
+ *
+ * The DESIGN sub-agent used to scan cwd / a hardcoded 'ehg' instead of the SD's
+ * target_application repo, producing a silent always-green false-negative for every
+ * cross-repo UI SD (RCA-DESIGN-ANALYSIS-CROSS-REPO-CWD-001). These tests cover the two
+ * pure helpers that fix it (resolveDesignRepo, applyRepoResolutionVerdict) plus the
+ * target_application threading in checkForNonUIDiff.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub execSync at module load (mirrors design-backend-only-diff.test.js).
+const execSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', () => ({ execSync: execSyncMock }));
+
+// Override fs.existsSync while keeping the rest of fs real (dotenv.config needs readFileSync).
+const existsSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    default: { ...actual.default, existsSync: existsSyncMock },
+    existsSync: existsSyncMock,
+  };
+});
+
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({})),
+}));
+vi.mock('../../../lib/sub-agents/design/utils.js', () => ({
+  enhanceWithRiskContext: vi.fn(),
+  validateUxContractCompliance: vi.fn(),
+  parseBaselineWorkflow: vi.fn(),
+}));
+vi.mock('../../../lib/sub-agents/design/checks.js', () => ({
+  checkDesignSystem: vi.fn(),
+  analyzeComponents: vi.fn(),
+  checkAccessibility: vi.fn(),
+  checkResponsiveDesign: vi.fn(),
+  checkDesignConsistency: vi.fn(),
+  generateRecommendations: vi.fn(),
+}));
+vi.mock('../../../lib/sub-agents/design/workflow-analyzer.js', () => ({
+  workflowReviewCapability: vi.fn(),
+}));
+
+const resolveRepoPathMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/repo-paths.js', () => ({
+  resolveRepoPath: resolveRepoPathMock,
+}));
+
+const { resolveDesignRepo, applyRepoResolutionVerdict, checkForNonUIDiff } =
+  await import('../../../lib/sub-agents/design/index.js');
+
+describe('SD-LEO-INFRA-CROSS-REPO-AWARE-001 — DESIGN cross-repo repo resolution', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    existsSyncMock.mockReset();
+    resolveRepoPathMock.mockReset();
+  });
+
+  describe('resolveDesignRepo (FR-1/FR-2)', () => {
+    it('TS-2: derives the repo from target_application, not a hardcoded ehg', () => {
+      resolveRepoPathMock.mockImplementation((app) => (app === 'EHG' ? 'C:/x/ehg' : null));
+      existsSyncMock.mockReturnValue(true);
+
+      const r = resolveDesignRepo({ target_application: 'EHG' });
+
+      expect(resolveRepoPathMock).toHaveBeenCalledWith('EHG');
+      expect(r.resolvedRepoPath).toBe('C:/x/ehg');
+      expect(r.repoResolved).toBe(true);
+      expect(r.componentsDirExists).toBe(true);
+    });
+
+    it('prefers an explicit options.repo_path over target_application resolution', () => {
+      existsSyncMock.mockReturnValue(true);
+
+      const r = resolveDesignRepo({ repo_path: 'C:/explicit/path', target_application: 'EHG' });
+
+      expect(r.resolvedRepoPath).toBe('C:/explicit/path');
+      expect(resolveRepoPathMock).not.toHaveBeenCalled();
+    });
+
+    it('TS-4 (R3, HIGH): an unresolvable target_application yields repo_resolved=false, never a silent cwd pass', () => {
+      resolveRepoPathMock.mockReturnValue(null); // registry/DB miss
+
+      const r = resolveDesignRepo({ target_application: 'UnknownVenture' });
+
+      expect(r.repoResolved).toBe(false);
+      expect(r.componentsDirExists).toBe(false);
+      // repoPath still falls back to cwd as a last-ditch scan root, but repoResolved records the miss.
+      expect(r.repoPath).toBe(process.cwd());
+    });
+
+    it('reports components_dir_exists=false when the resolved repo has no src/components (wrong repo)', () => {
+      resolveRepoPathMock.mockReturnValue('C:/x/EHG_Engineer');
+      existsSyncMock.mockReturnValue(false);
+
+      const r = resolveDesignRepo({ target_application: 'EHG_Engineer' });
+
+      expect(r.repoResolved).toBe(true);
+      expect(r.componentsDirExists).toBe(false);
+    });
+  });
+
+  describe('applyRepoResolutionVerdict (FR-2 fail-closed)', () => {
+    it('TS-3: attaches the metadata contract on a resolved repo and keeps PASS', () => {
+      const results = { verdict: 'PASS', confidence: 100, warnings: [] };
+
+      applyRepoResolutionVerdict(results, { resolvedRepoPath: 'C:/x/ehg', repoResolved: true, componentsDirExists: true });
+
+      expect(results.metadata).toEqual({ repo_path: 'C:/x/ehg', repo_resolved: true, components_dir_exists: true });
+      expect(results.verdict).toBe('PASS');
+      expect(results.warnings).toHaveLength(0);
+    });
+
+    it('TS-4: downgrades PASS to CONDITIONAL_PASS when repo is unresolved', () => {
+      const results = { verdict: 'PASS', confidence: 100, warnings: [] };
+
+      applyRepoResolutionVerdict(results, { resolvedRepoPath: null, repoResolved: false, componentsDirExists: false });
+
+      expect(results.verdict).toBe('CONDITIONAL_PASS');
+      expect(results.confidence).toBeLessThanOrEqual(60);
+      expect(results.warnings).toHaveLength(1);
+      expect(results.metadata.repo_resolved).toBe(false);
+    });
+
+    it('downgrades PASS when the components dir is missing (scanned the wrong repo)', () => {
+      const results = { verdict: 'PASS', confidence: 100, warnings: [] };
+
+      applyRepoResolutionVerdict(results, { resolvedRepoPath: 'C:/x/EHG_Engineer', repoResolved: true, componentsDirExists: false });
+
+      expect(results.verdict).toBe('CONDITIONAL_PASS');
+    });
+
+    it('does not weaken a stronger BLOCKED verdict', () => {
+      const results = { verdict: 'BLOCKED', confidence: 30, warnings: [] };
+
+      applyRepoResolutionVerdict(results, { resolvedRepoPath: null, repoResolved: false, componentsDirExists: false });
+
+      expect(results.verdict).toBe('BLOCKED');
+    });
+  });
+
+  describe('checkForNonUIDiff (FR-1 + metadata)', () => {
+    it('TS-B: resolves the diff repo from target_application when no repo_path is given', () => {
+      resolveRepoPathMock.mockImplementation((app) => (app === 'EHG' ? 'C:/x/ehg' : null));
+      execSyncMock.mockReturnValue('lib/foo.js\nscripts/bar.cjs');
+
+      const result = checkForNonUIDiff({ target_application: 'EHG' });
+
+      expect(resolveRepoPathMock).toHaveBeenCalledWith('EHG');
+      expect(execSyncMock.mock.calls[0][1].cwd).toBe('C:/x/ehg');
+      expect(result).not.toBeNull();
+      expect(result.verdict).toBe('PASS');
+      expect(result.metadata).toEqual(
+        expect.objectContaining({
+          repo_path: 'C:/x/ehg',
+          repo_resolved: true,
+          components_dir_exists: true,
+          skip_reason: 'backend_only_diff',
+        })
+      );
+    });
+  });
+});

--- a/tests/unit/sub-agents/sub-agent-orchestrator-design-repo.test.js
+++ b/tests/unit/sub-agents/sub-agent-orchestrator-design-repo.test.js
@@ -1,0 +1,90 @@
+/**
+ * SD-LEO-INFRA-CROSS-REPO-AWARE-001 — FR-1 orchestrator threading.
+ *
+ * executeDesignAnalysis used to invoke executeSubAgent('DESIGN', sdId, { timeout })
+ * and drop sdData.target_application entirely. It must now resolve the UI repo DB-first
+ * and pass repo_path + target_application through to the DESIGN sub-agent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const executeSubAgentMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/sub-agent-executor.js', () => ({
+  executeSubAgent: executeSubAgentMock,
+}));
+
+const resolveRepoPathDbFirstMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/repo-paths.js', () => ({
+  resolveRepoPathDbFirst: resolveRepoPathDbFirstMock,
+}));
+
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({ __client: true })),
+}));
+
+// Formatters are imported at module top but not exercised by these assertions.
+vi.mock('../../../scripts/prd/formatters.js', () => ({
+  formatObjectives: vi.fn(),
+  formatArrayField: vi.fn(),
+  formatRisks: vi.fn(),
+  formatMetadata: vi.fn(),
+}));
+
+const { executeDesignAnalysis } = await import('../../../scripts/prd/sub-agent-orchestrator.js');
+
+describe('SD-LEO-INFRA-CROSS-REPO-AWARE-001 — FR-1 executeDesignAnalysis repo threading', () => {
+  beforeEach(() => {
+    executeSubAgentMock.mockReset();
+    resolveRepoPathDbFirstMock.mockReset();
+  });
+
+  it('TS-A: threads a target_application-resolved repo_path into executeSubAgent', async () => {
+    resolveRepoPathDbFirstMock.mockResolvedValue('C:/x/ehg');
+    executeSubAgentMock.mockResolvedValue({ verdict: 'PASS', confidence: 100 });
+
+    await executeDesignAnalysis('SD-X', { sd_type: 'feature', target_application: 'EHG' });
+
+    expect(resolveRepoPathDbFirstMock).toHaveBeenCalledWith('EHG', expect.anything());
+    expect(executeSubAgentMock).toHaveBeenCalledTimes(1);
+    const [code, sdId, opts] = executeSubAgentMock.mock.calls[0];
+    expect(code).toBe('DESIGN');
+    expect(sdId).toBe('SD-X');
+    expect(opts.repo_path).toBe('C:/x/ehg');
+    expect(opts.target_application).toBe('EHG');
+    expect(opts.timeout).toBe(120000);
+  });
+
+  it('still passes target_application when DB-first resolution returns null (registry/DB miss)', async () => {
+    resolveRepoPathDbFirstMock.mockResolvedValue(null);
+    executeSubAgentMock.mockResolvedValue({ verdict: 'PASS' });
+
+    await executeDesignAnalysis('SD-X', { sd_type: 'feature', target_application: 'CronLinter' });
+
+    const opts = executeSubAgentMock.mock.calls[0][2];
+    expect(opts.repo_path).toBeUndefined();
+    expect(opts.target_application).toBe('CronLinter');
+  });
+
+  it('does not crash DESIGN when repo resolution throws — still invokes with target_application', async () => {
+    resolveRepoPathDbFirstMock.mockRejectedValue(new Error('boom'));
+    executeSubAgentMock.mockResolvedValue({ verdict: 'PASS' });
+
+    await executeDesignAnalysis('SD-X', { sd_type: 'feature', target_application: 'EHG' });
+
+    expect(executeSubAgentMock).toHaveBeenCalledTimes(1);
+    expect(executeSubAgentMock.mock.calls[0][2].target_application).toBe('EHG');
+  });
+
+  it('skips DESIGN (returns null) for a non-UI infra SD with no UI keywords', async () => {
+    const out = await executeDesignAnalysis('SD-X', {
+      sd_type: 'infrastructure',
+      target_application: 'EHG_Engineer',
+      scope: 'backend script and cli tooling',
+      description: 'gate validator changes',
+      key_changes: [],
+    });
+
+    expect(out).toBeNull();
+    expect(executeSubAgentMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CROSS-REPO-AWARE-001 — DESIGN sub-agent: cross-repo-aware repo resolution + fail-closed gate

Fixes the silent always-green DESIGN no-op for every cross-repo UI SD documented in `RCA-DESIGN-ANALYSIS-CROSS-REPO-CWD-001` (0.9 confidence; 6th witness of `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`).

### Problem
The DESIGN sub-agent had no contract for *which repo holds an SD's UI*. The PRD orchestrator invoked DESIGN with only `{ timeout }`, dropping `sdData.target_application`. The DESIGN module then guessed the repo two divergent, cwd-anchored ways — `resolveRepoPath('ehg')` (hardcoded literal) at `lib/sub-agents/design/index.js:108` and `process.cwd()` at `:505`. For any cross-repo UI SD (target_application ≠ ehg, or LEO tooling run from EHG_Engineer cwd), the `src/components` greps hit a non-existent path → 0 violations → verdict `PASS / 100%`. `GATE1_DESIGN_DATABASE` then awarded a full 20/20 for the *mere existence* of a PASS-verdict row, never reading `design_score`/metadata. Result: real accessibility/design-system violations in the actual UI repo were never surfaced and no gate caught that DESIGN looked at the wrong (or empty) tree.

### Fix — RCA option (a)+(c) (minimal systemic)

**FR-1 — thread repo_path from `target_application`:**
- `scripts/prd/sub-agent-orchestrator.js` → resolve via the existing async `resolveRepoPathDbFirst` (DB-first + registry fallback) and pass `{repo_path, target_application}` into `executeSubAgent('DESIGN', …)`. The orchestrator previously had no supabase client and no `repo-paths` import.
- `lib/sub-agents/design/index.js:108` → derive from `options.target_application` (drop literal `'ehg'` as primary source).
- `lib/sub-agents/design/index.js:505` (`checkForNonUIDiff`) → derive from `target_application` instead of a bare `process.cwd()` default.
- `lib/sub-agents/design/workflow-analyzer.js:82` → fix the **independent** `resolveRepoPath('ehg')` fallback (4th locus, surfaced by the prospective testing-agent's R2 finding — not in the original RCA edit list).

**FR-2 — DESIGN emits a metadata contract + fails closed:**
- Two new pure helpers exported for testing: `resolveDesignRepo(options)` and `applyRepoResolutionVerdict(results, resolution)`.
- `results.metadata.{repo_path, repo_resolved, components_dir_exists}` is set at top-level on **every** return path (the success path, the non-UI sd_type skip, the backend-only-diff skip, and the catch). `results-storage` persists only top-level keys (strips `findings`).
- An unresolvable `target_application` (`resolveRepoPath` returns `null`) or a missing `src/components` dir downgrades `PASS → CONDITIONAL_PASS` — never `null || process.cwd()`, which would re-introduce the exact RCA bug.

**FR-3 — `GATE1_DESIGN_DATABASE` fails closed on unresolved/empty:**
- New pure helper `evaluateDesignExecutionCredit(designResult)` exported for testing.
- The 20/20 DESIGN-execution credit is awarded only when `metadata.repo_resolved !== false` AND `metadata.components_dir_exists !== false`. Legacy rows missing the keys keep full credit (backward compatible — pre-fix runs cannot retroactively fail).

### Why everything ships together
The prospective testing-agent flagged FR-2 as **load-bearing**: FR-1 alone leaves `resolveRepoPath` → `null` silently coercing to cwd, re-greening the exact RCA bug for venture/cross-repo SDs. Splitting would create broken intermediate states.

### Verification

**Targeted unit tests** (`npx vitest run` — vitest `related`/`--changed` are non-viable in this repo's `unit` project): **28 passed in 386ms**.
- 17 new unit tests across 3 files: `tests/unit/sub-agents/design-cross-repo-resolution.test.js`, `tests/unit/sub-agents/sub-agent-orchestrator-design-repo.test.js`, `tests/unit/modules/design-gate-repo-credit.test.js`.
- 11 existing `tests/unit/sub-agents/design-backend-only-diff.test.js` stay green (non-regression).

**Real-registry smoke check** (from EHG_Engineer cwd, no mocks):
| target_application | `repo_resolved` | `components_dir_exists` | outcome |
|---|---|---|---|
| `EHG` | `true` | `true` (`...\_EHG\ehg`) | full credit, scans the real UI tree |
| `EHG_Engineer` | `true` | **`false`** | CONDITIONAL_PASS + gate withholds credit (correctly flags wrong repo) |
| unknown venture | **`false`** | `false` | fail-closed, never silent cwd |

### Sub-agent evidence (database-backed)
- VALIDATION (LEAD): row `bfe41e27-d39a-4bc1-af64-acd49b5526a8` — PASS, non-duplicative (60+ candidate SDs scanned).
- TESTING (PLAN, prospective): row `ce716e1e-2798-401f-8ef1-cc84d8f6d814` — CONDITIONAL_PASS with 6 structural defects (3 HIGH), all designed into the PRD before authoring.
- DESIGN/DATABASE/STORIES (PLAN): PASS, score 93% (auto-run during PRD creation).
- LEAD-TO-PLAN: score 95 (20/20 gates).
- PLAN-TO-EXEC: score 96 (19/19 gates).

### Scope (Q8 deletion audit ≈40%)
**Deferred follow-ups** (not in this PR):
- RCA Option (b) standalone DESIGN-CLI path arg — redundant (CLI already runs with `{ cwd: repoPath }`).
- Preventive Control 1 — fleet-wide shared `resolveSubAgentRepo` helper for all tree-reading sub-agents. DATABASE and others don't grep the tree; DESIGN was the only forced edit.
- Preventive Control 3 — ESLint/CI guard against `process.cwd()` in `lib/sub-agents/**`. Separate CI concern (QF candidate).

### Diff
167 insertions / 16 deletions of source across 4 files + 299 new test lines across 3 files. Above the ≤100 LOC sweet spot; the testing-agent's R1/R2/R3/R5 findings made splitting unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
