### PR TITLE
fix(QF-20260526-106): create-quick-fix.js — insert quick_fixes row before feedback pre-claim (fixes --feedback-id FK violation)

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -179,6 +179,50 @@ async function createQuickFix(options = {}) {
   // Generate ID
   const qfId = generateQuickFixId();
 
+  // QF-20260526-106: route + INSERT the quick_fixes row BEFORE the per-feedback-row
+  // pre-claim. The pre-claim sets feedback.quick_fix_id = qfId, which the
+  // fk_feedback_quick_fix constraint rejects unless the quick_fixes row already
+  // exists (backlog b06e04f8). The common no-feedback-id path is behaviorally
+  // identical — insert simply moves ahead of the skipped pre-claim.
+
+  // Route once; the same decision drives initial status (escalated vs open) and is reused below.
+  const scopeText = [expected, actual].filter(Boolean).join('\n');
+  const routingDecision = await routeWorkItem({
+    estimatedLoc,
+    type,
+    scope: scopeText,
+    description,
+    entryPoint: 'create-quick-fix',
+  }, supabase);
+  const isTier3 = routingDecision.tier === 3;
+  const initialStatus = isTier3 ? 'escalated' : 'open';
+
+  {
+    const { error: insertErr } = await supabase
+      .from('quick_fixes')
+      .insert({
+        id: qfId,
+        title,
+        type,
+        severity,
+        description,
+        steps_to_reproduce: steps,
+        expected_behavior: expected,
+        actual_behavior: actual,
+        estimated_loc: estimatedLoc,
+        target_application: targetApplication,
+        status: initialStatus,
+        escalation_reason: isTier3 ? routingDecision.escalationReason : null,
+        routing_tier: routingDecision.tier,
+        routing_threshold_id: routingDecision.thresholdId !== 'fallback' && routingDecision.thresholdId !== 'error-multiple-active' ? routingDecision.thresholdId : null,
+        created_at: new Date().toISOString()
+      });
+    if (insertErr) {
+      console.log('❌ Failed to create quick-fix record:', insertErr.message);
+      process.exit(1);
+    }
+  }
+
   // SD-FDBK-INFRA-PER-FEEDBACK-ROW-001 / FR-1+FR-3: atomic per-feedback-row pre-claim.
   // Skipped when --feedback-id omitted (full backward-compatibility).
   if (options.feedbackId) {
@@ -204,6 +248,7 @@ async function createQuickFix(options = {}) {
         if (!options.forceClaimReason || !String(options.forceClaimReason).trim()) {
           console.error(`\n❌ [FORCE_CLAIM_REASON_REQUIRED] --force-claim requires --force-claim-reason "<text>"`);
           if (claimed.length > 0) await releasePreclaim({ supabase, quickFixId: qfId });
+          await supabase.from('quick_fixes').delete().eq('id', qfId);
           process.exit(1);
         }
         const QUOTA = parseInt(process.env.LEO_FORCE_CLAIM_DAILY_QUOTA || '3', 10);
@@ -218,6 +263,7 @@ async function createQuickFix(options = {}) {
         if (used >= QUOTA) {
           console.error(`\n❌ [FORCE_CLAIM_QUOTA_EXHAUSTED] ${used}/${QUOTA} used in last 24h for session ${(creatorSessionId||'?').slice(0,8)}`);
           if (claimed.length > 0) await releasePreclaim({ supabase, quickFixId: qfId });
+          await supabase.from('quick_fixes').delete().eq('id', qfId);
           process.exit(1);
         }
         // Attempt to force-claim the still-conflicting rows by setting quick_fix_id over their existing claim.
@@ -241,6 +287,10 @@ async function createQuickFix(options = {}) {
           const { released } = await releasePreclaim({ supabase, quickFixId: qfId });
           console.error(`   ↩ Released ${released.length} partially-claimed sibling(s) to keep state clean.`);
         }
+        // QF-20260526-106: remove the just-created quick_fixes row so the failed
+        // pre-claim leaves no orphan (the FK we just satisfied is now the only
+        // referent — deleting it after releasing the feedback claim is safe).
+        await supabase.from('quick_fixes').delete().eq('id', qfId);
         process.exit(1);
       }
     }
@@ -254,23 +304,15 @@ async function createQuickFix(options = {}) {
     });
   }
 
-  // Unified Work-Item Router: determine tier based on LOC + risk keywords.
-  // Pass `scope` derived from the user's expected/actual fields — those describe
-  // the change itself. `description` often references existing patterns by name
-  // (e.g., "extends the needsAuth gate") which would false-trigger a description-level scan.
-  const scopeText = [expected, actual].filter(Boolean).join('\n');
-  const routingDecision = await routeWorkItem({
-    estimatedLoc,
-    type,
-    scope: scopeText,
-    description,
-    entryPoint: 'create-quick-fix',
-  }, supabase);
-
+  // QF-20260526-106: the quick_fixes row was inserted ABOVE (before pre-claim).
+  // The remaining steps just present the routing decision and (for Tier 3) exit.
   console.log(`\n📊 Routing Decision: ${routingDecision.tierLabel} (${estimatedLoc} LOC, threshold: ${routingDecision.thresholdId})`);
 
+  // Re-read the just-inserted row to keep the original return shape for callers.
+  const { data } = await supabase.from('quick_fixes').select('*').eq('id', qfId).single();
+
   // Tier 3: Escalate to full Strategic Directive
-  if (routingDecision.tier === 3) {
+  if (isTier3) {
     console.log('\n⚠️  ESCALATION REQUIRED\n');
     console.log(`Reason: ${routingDecision.escalationReason}`);
     console.log('This requires a full Strategic Directive.\n');
@@ -278,69 +320,9 @@ async function createQuickFix(options = {}) {
     console.log('   1. Create Strategic Directive with LEAD approval');
     console.log('   2. Run: node scripts/add-prd-to-database.js SD-XXX');
     console.log('   3. Follow full LEAD→PLAN→EXEC workflow\n');
-
-    // Still create the quick-fix record but mark as escalated
-    const { data, error } = await supabase
-      .from('quick_fixes')
-      .insert({
-        id: qfId,
-        title,
-        type,
-        severity,
-        description,
-        steps_to_reproduce: steps,
-        expected_behavior: expected,
-        actual_behavior: actual,
-        estimated_loc: estimatedLoc,
-        target_application: targetApplication,
-        status: 'escalated',
-        escalation_reason: routingDecision.escalationReason,
-        routing_tier: routingDecision.tier,
-        routing_threshold_id: routingDecision.thresholdId !== 'fallback' && routingDecision.thresholdId !== 'error-multiple-active' ? routingDecision.thresholdId : null,
-        created_at: new Date().toISOString()
-      })
-      .select()
-      .single();
-
-    if (error) {
-      console.log('❌ Failed to create quick-fix record:', error.message);
-      process.exit(1);
-    }
-
     console.log(`✅ Quick-fix record created: ${qfId}`);
     console.log('   Status: ESCALATED (requires full SD)');
-
     return { escalated: true, qfId, data };
-  }
-
-  // Tier 1 or Tier 2: Create quick-fix record
-  // Note: 'approved' is not a valid quick_fixes status (constraint: quick_fixes_status_check).
-  // Tier 1 QFs are auto-approved (no LEAD review) but DB status starts as 'open'.
-  const qfStatus = 'open';
-  const { data, error } = await supabase
-    .from('quick_fixes')
-    .insert({
-      id: qfId,
-      title,
-      type,
-      severity,
-      description,
-      steps_to_reproduce: steps,
-      expected_behavior: expected,
-      actual_behavior: actual,
-      estimated_loc: estimatedLoc,
-      target_application: targetApplication,
-      status: qfStatus,
-      routing_tier: routingDecision.tier,
-      routing_threshold_id: routingDecision.thresholdId !== 'fallback' && routingDecision.thresholdId !== 'error-multiple-active' ? routingDecision.thresholdId : null,
-      created_at: new Date().toISOString()
-    })
-    .select()
-    .single();
-
-  if (error) {
-    console.log('❌ Failed to create quick-fix:', error.message);
-    process.exit(1);
   }
 
   console.log(`\n✅ Quick-fix created: ${qfId}\n`);

--- a/tests/unit/feedback/create-quick-fix-insert-order.test.js
+++ b/tests/unit/feedback/create-quick-fix-insert-order.test.js
@@ -1,0 +1,60 @@
+// QF-20260526-106: prevent regression of the fk_feedback_quick_fix ordering bug.
+//
+// preclaimFeedbackRows writes feedback.quick_fix_id = <qfId>. The FK
+// fk_feedback_quick_fix requires the quick_fixes row to exist FIRST. Previously
+// create-quick-fix.js inserted the quick_fixes row AFTER the pre-claim block,
+// so `--feedback-id` always failed (backlog b06e04f8).
+//
+// Static-pattern test (same convention as orchestrator.js wiring tests in
+// validate-compliance-force-bypass.test.js): assert the source-code ordering
+// without running the script — a unit-level execution would need to mock the
+// full Supabase chain + worktree manager.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/create-quick-fix.js');
+
+describe('QF-20260526-106: create-quick-fix.js inserts quick_fixes BEFORE preclaim', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  // Tolerant of CRLF + indentation drift via regex match indices.
+  const QF_INSERT_RE = /\.from\(\s*['"]quick_fixes['"]\s*\)\s*\r?\n?\s*\.insert\(/;
+  const PRECLAIM_RE = /\bpreclaimFeedbackRows\s*\(/;
+  const ROUTE_RE = /\brouteWorkItem\s*\(/;
+
+  it('the .from("quick_fixes").insert call precedes the preclaimFeedbackRows call', () => {
+    const insertM = code.match(QF_INSERT_RE);
+    const preclaimM = code.match(PRECLAIM_RE);
+    expect(insertM?.index).toBeGreaterThanOrEqual(0);
+    expect(preclaimM?.index).toBeGreaterThanOrEqual(0);
+    expect(insertM.index).toBeLessThan(preclaimM.index);
+  });
+
+  it('routeWorkItem is called before the quick_fixes insert (status discriminator)', () => {
+    const routeM = code.match(ROUTE_RE);
+    const insertM = code.match(QF_INSERT_RE);
+    expect(routeM?.index).toBeGreaterThanOrEqual(0);
+    expect(routeM.index).toBeLessThan(insertM.index);
+  });
+
+  it('conflict-exit paths delete the orphan quick_fixes row before process.exit', () => {
+    // Every conflict-exit branch must clean up the just-created row.
+    // There are three exits in the preclaim block: REASON_REQUIRED, QUOTA_EXHAUSTED,
+    // and the non-force conflict default. Each must precede its process.exit(1)
+    // with a quick_fixes delete keyed on qfId.
+    const deleteOrphanPattern =
+      /from\('quick_fixes'\)\s*\.delete\(\)\s*\.eq\('id',\s*qfId\)/g;
+    const matches = code.match(deleteOrphanPattern) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does NOT introduce an .upsert call (which would mask a duplicate-id collision)', () => {
+    // Keep using .insert — .upsert on quick_fixes would silently overwrite if
+    // generateQuickFixId ever produced a colliding id.
+    expect(code).not.toMatch(/\.from\('quick_fixes'\)[\s\S]{0,40}\.upsert\(/);
+  });
+});


### PR DESCRIPTION
## QF-20260526-106 — fix `create-quick-fix.js --feedback-id` FK ordering bug

**Backlog:** `b06e04f8` (harness_backlog)

The `--feedback-id` path always failed with:
```
insert or update on table "feedback" violates foreign key constraint "fk_feedback_quick_fix"
```
because `preclaimFeedbackRows` writes `feedback.quick_fix_id = qfId` BEFORE the `quick_fixes` row was inserted (insert lived at `~L283/L320`, after the preclaim block at `~L184`) — so the FK had no referent.

### Fix
- Compute `routeWorkItem` once and **INSERT the `quick_fixes` row** (`status='escalated'` for Tier 3, else `'open'`) **before** the preclaim block.
- Collapse the two now-redundant later inserts into a single re-read of the inserted row (preserves the original return shape for callers).
- Each preclaim conflict-exit (`FORCE_CLAIM_REASON_REQUIRED` / `FORCE_CLAIM_QUOTA_EXHAUSTED` / non-force conflict) **deletes the just-created `quick_fixes` row** before `process.exit(1)` so no orphan is left.
- Keep `.insert` (not `.upsert`) — preserves collision detection if `generateQuickFixId` ever produced a colliding id.
- Common no-`--feedback-id` path is **behaviorally identical**: insert simply moves ahead of the skipped pre-claim.

### Tests
- New static ordering-regression test (mirrors the orchestrator wiring-test convention in `validate-compliance-force-bypass.test.js`):
  - `routeWorkItem → quick_fixes.insert → preclaimFeedbackRows`
  - ≥3 orphan-cleanup `delete().eq('id', qfId)` calls in conflict-exit paths
  - No `.upsert` introduced
- All 16 unit tests pass (4 new + 12 existing preclaim).
- `eslint` clean on the changed code (3 errors on the file are pre-existing baseline at L249/L376/L555, untouched by this commit per `git blame`).

### LOC note
Diff is `+56/-74` (source). The `-74` is dominated by collapsing two duplicate `.from('quick_fixes').insert(...)` blocks into a single re-read — pure dead-code removal. Uses the documented `--over-cap-reason` narrow bypass at completion (does NOT bypass tests/compliance/self-verification).

Closes feedback b06e04f8-8511-4406-b1b1-413667928eda

🤖 Generated with [Claude Code](https://claude.com/claude-code)
