### PR TITLE
fix(QF-20260526-976): lightweight deployment-URL endpoint for S17 capture (no build_mvp_build artifact)

### DIFF
--- a/server/routes/stage19.js
+++ b/server/routes/stage19.js
@@ -252,4 +252,86 @@ router.post('/:ventureId/register-deployment', asyncHandler(async (req, res) => 
   });
 }));
 
+/**
+ * POST /api/stage19/:ventureId/deployment-url
+ * QF-20260526-976 — lightweight live-deployment-URL capture (used by the Stage-17 field).
+ *
+ * Records ONLY the live deployment URL in the CANONICAL venture_resources slot
+ * (resource_type='replit_deployment', resource_identifier + deployment_url column) so it
+ * flows to every existing consumer: the S19->S20 exit gate, the integration-test-runner
+ * stagingUrl, Stage-21 visual assets, and the venture registry. Unlike register-deployment
+ * this does NOT emit the build_mvp_build artifact and does NOT advance the stage, so
+ * recording the URL early (e.g. at Stage 17) never prematurely satisfies the "build done"
+ * gate. The field is multi-consumer, so we reuse the existing resource_type rather than
+ * renaming/forking it.
+ *
+ * Request body: { deployment_url: string } — must be a valid https:// URL.
+ * Returns 200 with { ventureId, deployment_url, resource_id }.
+ */
+router.post('/:ventureId/deployment-url', asyncHandler(async (req, res) => {
+  const { ventureId } = req.params;
+  if (!isValidUuid(ventureId)) {
+    return res.status(400).json({ error: 'Invalid ventureId format', code: 'INVALID_VENTURE_ID' });
+  }
+  const deployment_url = typeof req.body?.deployment_url === 'string' ? req.body.deployment_url.trim() : '';
+  if (!deployment_url || !HTTPS_URL_RE.test(deployment_url)) {
+    return res.status(400).json({
+      error: 'URL validation failed',
+      code: 'VALIDATION_FAILED',
+      invalid: ['deployment_url'],
+      reason: { deployment_url: 'must be a valid https:// URL' },
+    });
+  }
+
+  // venture_resources RLS permits writes for service_role only (same constraint as
+  // register-deployment); the per-request authed client is SELECT-only. The auth
+  // middleware has already authenticated the caller before this handler runs.
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: 'Supabase client unavailable', code: 'NO_SUPABASE' });
+  }
+  const { createClient } = await import('@supabase/supabase-js');
+  const supabase = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  // Carry the venture's existing repo_url onto the row (the column is set on the canonical
+  // row by register-deployment) so a new resource row is complete regardless of nullability.
+  const { data: venture } = await supabase
+    .from('ventures')
+    .select('repo_url')
+    .eq('id', ventureId)
+    .maybeSingle();
+
+  // Canonical upsert — same store + unique key as register-deployment, but resource-only:
+  // NO build_mvp_build artifact, NO stage advance.
+  const { data: resourceRow, error: upsertErr } = await supabase
+    .from('venture_resources')
+    .upsert({
+      venture_id: ventureId,
+      resource_type: 'replit_deployment',
+      resource_identifier: deployment_url,
+      provider: 'replit',
+      status: 'active',
+      repo_url: venture?.repo_url ?? null,
+      deployment_url,
+    }, { onConflict: 'venture_id,resource_type,resource_identifier' })
+    .select('id')
+    .single();
+
+  if (upsertErr) {
+    console.error('[stage19-route] deployment-url upsert failed', upsertErr.message);
+    return res.status(500).json({
+      error: 'Failed to persist venture_resources',
+      code: 'RESOURCE_UPSERT_FAILED',
+      detail: upsertErr.message,
+    });
+  }
+
+  return res.status(200).json({
+    ventureId,
+    deployment_url,
+    resource_id: resourceRow?.id,
+  });
+}));
+
 export default router;

--- a/tests/integration/api-routes/stage19-endpoints.test.js
+++ b/tests/integration/api-routes/stage19-endpoints.test.js
@@ -22,6 +22,20 @@ vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
   writeArtifact: (...args) => mockWriteArtifact(...args),
 }));
 
+// QF-20260526-976: both POST handlers (register-deployment + deployment-url) perform
+// service-role writes and construct their OWN supabase client via `createClient(url, key)`
+// — they do NOT use req.app.locals.supabase. Mock @supabase/supabase-js so createClient
+// returns the mock the test installed via buildSupabaseMock(). A hoisted reference holds
+// the "current" mock; createMockReq updates it so each test wires both the per-request
+// (req.app.locals.supabase) and the in-handler (createClient) supabase to the same object.
+// Also seed env so the endpoints' (!supabaseUrl || !serviceRoleKey) gate passes.
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
+let currentMockSupabase = null;
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => currentMockSupabase),
+}));
+
 // Mock validateUuid so we control validation independently of the regex impl.
 vi.mock('../../../server/middleware/validate.js', () => ({
   isValidUuid: (v) => typeof v === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v),
@@ -49,7 +63,7 @@ const VALID_UUID = '11111111-2222-3333-4444-555555555555';
 const VALID_REPO = 'https://github.com/owner/repo';
 const VALID_DEPLOYMENT = 'https://my-app.example.replit.app';
 
-function buildSupabaseMock({ upsertResult = null, upsertError = null } = {}) {
+function buildSupabaseMock({ upsertResult = null, upsertError = null, ventureRepoUrl = null } = {}) {
   const upsertSpy = vi.fn().mockReturnValue({
     select: vi.fn(() => ({
       single: vi.fn().mockResolvedValue({
@@ -58,18 +72,33 @@ function buildSupabaseMock({ upsertResult = null, upsertError = null } = {}) {
       }),
     })),
   });
+  // QF-20260526-976: the lightweight deployment-url endpoint also reads
+  // ventures.repo_url so the new resource row is complete; chain shape =
+  // .from('ventures').select('repo_url').eq('id', ...).maybeSingle().
+  const venturesSelectSpy = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      maybeSingle: vi.fn().mockResolvedValue({ data: ventureRepoUrl ? { repo_url: ventureRepoUrl } : null, error: null }),
+    })),
+  }));
   return {
     from: vi.fn((table) => {
       if (table === 'venture_resources') {
         return { upsert: upsertSpy };
       }
+      if (table === 'ventures') {
+        return { select: venturesSelectSpy };
+      }
       return { upsert: vi.fn() };
     }),
     _upsertSpy: upsertSpy,
+    _venturesSelectSpy: venturesSelectSpy,
   };
 }
 
 function createMockReq(params = {}, body = {}, supabase = buildSupabaseMock()) {
+  // Wire the test's mock supabase into BOTH consumers: req.app.locals.supabase (legacy
+  // per-request client) AND the in-handler createClient() (the actual write path).
+  currentMockSupabase = supabase;
   return { params, body, app: { locals: { supabase } } };
 }
 
@@ -226,6 +255,130 @@ describe('Stage 19 register-deployment endpoint', () => {
       expect(res.jsonData.code).toBe('VALIDATION_FAILED');
       expect(res.jsonData.invalid.sort()).toEqual(['deployment_url', 'repo_url']);
     });
+  });
+});
+
+// QF-20260526-976 — lightweight deployment-URL endpoint (no build_mvp_build artifact,
+// no stage advance) so a Stage-17 field can record the live deployment URL into the
+// canonical venture_resources slot without tripping the S19→S20 build-done gate.
+describe('Stage 19 deployment-url endpoint (lightweight, no artifact)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteArtifact.mockResolvedValue('artifact-1');
+  });
+
+  const handlers = findRoute('post', '/:ventureId/deployment-url');
+
+  it('TS-DU-A: happy path → 200, upserts canonical venture_resources, NO writeArtifact (NO build_mvp_build emitted)', async () => {
+    const supabase = buildSupabaseMock({ ventureRepoUrl: VALID_REPO });
+    const req = createMockReq(
+      { ventureId: VALID_UUID },
+      { deployment_url: VALID_DEPLOYMENT },
+      supabase,
+    );
+    const res = createMockRes();
+    await runHandlerChain(handlers, req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonData).toEqual(expect.objectContaining({
+      ventureId: VALID_UUID,
+      deployment_url: VALID_DEPLOYMENT,
+      resource_id: 'res-1',
+    }));
+    // Response intentionally does NOT include an artifact_id / artifact_type — this
+    // endpoint is build_mvp_build-free.
+    expect(res.jsonData).not.toHaveProperty('artifact_id');
+    expect(res.jsonData).not.toHaveProperty('artifact_type');
+
+    // Canonical write: same store + same resource_type + same unique key as register-deployment.
+    expect(supabase._upsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venture_id: VALID_UUID,
+        resource_type: 'replit_deployment',
+        resource_identifier: VALID_DEPLOYMENT,
+        deployment_url: VALID_DEPLOYMENT,
+        // ventures.repo_url is carried onto the row when present (defensive completeness).
+        repo_url: VALID_REPO,
+      }),
+      expect.objectContaining({ onConflict: expect.any(String) }),
+    );
+
+    // CRITICAL contract: this endpoint must NEVER emit the build_mvp_build artifact —
+    // an early Stage-17 capture must not falsely satisfy the S19→S20 "build done" gate.
+    expect(mockWriteArtifact).not.toHaveBeenCalled();
+  });
+
+  it('TS-DU-A2: ventures.repo_url is null → upsert still proceeds with repo_url=null', async () => {
+    // The endpoint pulls repo_url defensively; an empty/null venture row must not block the write.
+    const supabase = buildSupabaseMock({ ventureRepoUrl: null });
+    const req = createMockReq(
+      { ventureId: VALID_UUID },
+      { deployment_url: VALID_DEPLOYMENT },
+      supabase,
+    );
+    const res = createMockRes();
+    await runHandlerChain(handlers, req, res);
+    expect(res.statusCode).toBe(200);
+    expect(supabase._upsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venture_id: VALID_UUID,
+        resource_type: 'replit_deployment',
+        resource_identifier: VALID_DEPLOYMENT,
+        deployment_url: VALID_DEPLOYMENT,
+        repo_url: null,
+      }),
+      expect.any(Object),
+    );
+    expect(mockWriteArtifact).not.toHaveBeenCalled();
+  });
+
+  it('TS-DU-B-1: rejects http:// (insecure) deployment_url with 400 VALIDATION_FAILED', async () => {
+    const req = createMockReq(
+      { ventureId: VALID_UUID },
+      { deployment_url: 'http://insecure.example' },
+    );
+    const res = createMockRes();
+    await runHandlerChain(handlers, req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonData.code).toBe('VALIDATION_FAILED');
+    expect(res.jsonData.invalid).toContain('deployment_url');
+    expect(mockWriteArtifact).not.toHaveBeenCalled();
+  });
+
+  it('TS-DU-B-2: rejects empty / missing deployment_url with 400 VALIDATION_FAILED', async () => {
+    const req = createMockReq({ ventureId: VALID_UUID }, {});
+    const res = createMockRes();
+    await runHandlerChain(handlers, req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonData.code).toBe('VALIDATION_FAILED');
+    expect(res.jsonData.invalid).toContain('deployment_url');
+  });
+
+  it('TS-DU-C: idempotent — re-submitting the same URL returns the same resource_id (unique key on venture_id+resource_type+resource_identifier)', async () => {
+    const supabase = buildSupabaseMock({ ventureRepoUrl: VALID_REPO, upsertResult: { id: 'res-1' } });
+    const body = { deployment_url: VALID_DEPLOYMENT };
+    const req1 = createMockReq({ ventureId: VALID_UUID }, body, supabase);
+    const res1 = createMockRes();
+    await runHandlerChain(handlers, req1, res1);
+    const req2 = createMockReq({ ventureId: VALID_UUID }, body, supabase);
+    const res2 = createMockRes();
+    await runHandlerChain(handlers, req2, res2);
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(200);
+    expect(res1.jsonData.resource_id).toBe(res2.jsonData.resource_id);
+    expect(mockWriteArtifact).not.toHaveBeenCalled();
+  });
+
+  it('TS-DU-D: rejects invalid UUID with 400 INVALID_VENTURE_ID', async () => {
+    const req = createMockReq(
+      { ventureId: 'not-a-uuid' },
+      { deployment_url: VALID_DEPLOYMENT },
+    );
+    const res = createMockRes();
+    await runHandlerChain(handlers, req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonData.code).toBe('INVALID_VENTURE_ID');
+    expect(mockWriteArtifact).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Lightweight deployment-URL endpoint for Stage-17 capture (QF-20260526-976)

**What**: Adds `POST /api/stage19/:ventureId/deployment-url` that records the live deployment URL (e.g. `https://*.replit.dev`) into the **canonical** `venture_resources` slot (`resource_type='replit_deployment'`, `resource_identifier` + `deployment_url` column).

**Why this is separate from `register-deployment`**: The existing `register-deployment` endpoint does the right *storage* but **also emits the `build_mvp_build` artifact** — the "build done" signal the S19→S20 readiness contract reads. This new endpoint is the same storage **minus** the artifact + stage-advance, so an early Stage-17 capture (the chairman's chosen home for the URL) can record it without prematurely satisfying the build-done gate.

**Multi-consumer reuse**: The `replit_deployment` slot is intentionally multi-consumer — it feeds the S19→S20 exit gate, the integration-test-runner `stagingUrl`, Stage-21 visual assets, and the venture registry. The audit confirmed it's NOT safe to rename, so this endpoint reuses the canonical slot to keep all consumers fed.

### Bonus: fixed pre-existing test bug

While adding tests I discovered the existing `register-deployment` `TS-A` (happy path) and `TS-C` (idempotency) tests were **already failing on `origin/main`** — the handler constructs its own service-role client via `createClient(supabaseUrl, serviceRoleKey)` but the test only mocked `req.app.locals.supabase`, so the handler hit a 500 (or real DB) on every happy-path run. Fixed it systemically: `vi.mock('@supabase/supabase-js')` + a hoisted `currentMockSupabase` wired by `createMockReq`. Both broken existing tests now pass.

### Test coverage (16/16 pass)

```
✓ TS-DU-A   happy path → 200, canonical venture_resources upsert, NO writeArtifact
✓ TS-DU-A2  ventures.repo_url=null → upsert proceeds with repo_url=null
✓ TS-DU-B-1 http:// (insecure) rejected with 400 VALIDATION_FAILED
✓ TS-DU-B-2 empty/missing deployment_url rejected with 400 VALIDATION_FAILED
✓ TS-DU-C   idempotent (unique key on venture_id+resource_type+resource_identifier)
✓ TS-DU-D   invalid UUID rejected with 400 INVALID_VENTURE_ID
✓ TS-A,TS-C register-deployment happy path + idempotency (previously failing on main)
✓ 8 others  validation + GET readiness contract (unchanged, still pass)
```

### What this pairs with

The follow-up EHG-app Stage-17 field (a future cross-repo QF) will POST here and read the existing value back on mount — that closes the loop you flagged about the replit URL disappearing from Stage-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
