### PR TITLE
fix(QF-20260526-444): generate-retrospective.js accept sd_key (resolveSdInput parity)

### DIFF
--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -31,6 +31,7 @@
  */
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { resolveSdInput } from './lib/sd-id-resolver.js';
 import dotenv from 'dotenv';
 // import fs from 'fs'; // Currently unused - available for file operations if needed
 
@@ -48,21 +49,15 @@ function _toJsonb(arr) {
   return JSON.stringify(arr);
 }
 
-async function generateRetrospective(sdId) {
+async function generateRetrospective(sdInput) {
   console.log('\n🔍 CONTINUOUS IMPROVEMENT COACH');
   console.log('═'.repeat(60));
-  console.log(`Generating retrospective for SD: ${sdId}`);
+  console.log(`Generating retrospective for SD: ${sdInput}`);
 
-  // Get SD details
-  const { data: sd, error: sdError } = await supabase
-    .from('strategic_directives_v2')
-    .select('*')
-    .eq('id', sdId)
-    .single();
-
-  if (sdError || !sd) {
-    throw new Error(`SD not found: ${sdId}`);
-  }
+  // Accept either UUID or sd_key (parity with handoff.js and other LEO entry points).
+  // Feedback e402e5c4: usage said <SD_UUID> but downstream code keys off sd.id (UUID FK),
+  // so we resolve once here and use the canonical UUID for all subsequent queries.
+  const { sdId, sd } = await resolveSdInput(sdInput, supabase);
 
   console.log(`SD: ${sd.sd_key} - ${sd.title}`);
   console.log(`Status: ${sd.status}, Progress: ${sd.progress}%`);
@@ -339,15 +334,15 @@ async function generateRetrospective(sdId) {
 
 // CLI usage
 async function main() {
-  const sdId = process.argv[2];
+  const sdInput = process.argv[2];
 
-  if (!sdId) {
-    console.error('Usage: node generate-retrospective.js <SD_UUID>');
+  if (!sdInput) {
+    console.error('Usage: node generate-retrospective.js <SD_UUID|SD_KEY>');
     process.exit(1);
   }
 
   try {
-    const result = await generateRetrospective(sdId);
+    const result = await generateRetrospective(sdInput);
     console.log(JSON.stringify(result));
     process.exit(result.success ? 0 : 1);
   } catch (error) {

--- a/tests/unit/regression-pins/generate-retrospective-load-sd-pins.test.js
+++ b/tests/unit/regression-pins/generate-retrospective-load-sd-pins.test.js
@@ -1,0 +1,52 @@
+// Feedback e402e5c4 — static-guard regression pins.
+//
+// Pins scripts/generate-retrospective.js to the canonical resolveSdInput
+// helper. Before this fix, the CLI did .eq('id', sdId).single() and rejected
+// sd_key inputs with 'SD not found' even though the usage line advertised
+// <SD_UUID>, breaking parity with handoff.js and other LEO entry points.
+//
+// Same class as the SD-LEO-REFAC-CONSOLIDATE-KEY-RESOLUTION-001 sweep — this
+// callsite was missed because the script reads only via direct DB UUID rather
+// than going through a shared helper.
+//
+// These pins read the source file as a string (no module load) and assert
+// that the migration stays in place.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../..');
+
+function read(rel) {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+describe('feedback-e402e5c4 generate-retrospective canonical resolver pins', () => {
+  it('imports resolveSdInput from scripts/lib/sd-id-resolver', () => {
+    const src = read('scripts/generate-retrospective.js');
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveSdInput\b[^}]*\}\s*from\s*['"][^'"]*lib\/sd-id-resolver(?:\.js)?['"]/
+    );
+  });
+
+  it('generateRetrospective body calls resolveSdInput(sdInput, supabase)', () => {
+    const src = read('scripts/generate-retrospective.js');
+    const start = src.indexOf('async function generateRetrospective(');
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, start + 2000);
+    expect(body).toMatch(/\bresolveSdInput\s*\(\s*sdInput\s*,\s*supabase\s*\)/);
+  });
+
+  it('generateRetrospective body does NOT contain the legacy .eq(\'id\', sdId) fetch', () => {
+    const src = read('scripts/generate-retrospective.js');
+    const start = src.indexOf('async function generateRetrospective(');
+    // Bound to the initial-fetch region (first ~600 chars of body covers the SD lookup).
+    const head = src.slice(start, start + 600);
+    expect(head).not.toMatch(/\.eq\(\s*['"]id['"]\s*,\s*sdId\s*\)/);
+  });
+
+  it('CLI usage advertises both UUID and SD_KEY shapes', () => {
+    const src = read('scripts/generate-retrospective.js');
+    expect(src).toMatch(/Usage:.*<SD_UUID\|SD_KEY>/);
+  });
+});


### PR DESCRIPTION
## Summary

- `scripts/generate-retrospective.js` did `.eq('id', sdId).single()` on `strategic_directives_v2`, so `sd_key` inputs (the canonical CLI shape used by `handoff.js` and other LEO entry points) failed with `SD not found` even though the usage line advertised `<SD_UUID>`.
- Imports `resolveSdInput` from `scripts/lib/sd-id-resolver.js` and resolves the input once at the top of `generateRetrospective()` to the canonical `sd.id` UUID. All downstream queries (retrospectives, PRD, handoffs, feedback linkage) are unchanged — they already keyed off `sd.id`, so behavior is identical for valid UUID inputs and now also succeeds for `sd_key` inputs.
- Added regression-pin test mirroring `tests/unit/regression-pins/task-hydrator-load-sd-pins.test.js` to lock the contract: imports the helper, calls it with `(sdInput, supabase)`, and no longer contains the legacy `.eq('id', sdId)` chain.

## Verification

- `node scripts/generate-retrospective.js SD-LEO-INFRA-VENTURE-BUILD-EXEC-001` (sd_key form) → resolves, finds existing retro, exits cleanly. Previously failed.
- `node scripts/generate-retrospective.js 3b0a72f7-1e32-4c83-8ef9-06e3c65ad5ec` (UUID form) → same SD, same existing retro. Backwards compatible.
- 4/4 regression pins pass: `vitest run tests/unit/regression-pins/generate-retrospective-load-sd-pins.test.js`.

## Test plan

- [x] Regression-pin tests pass (4/4)
- [x] sd_key smoke test (existing-retro path)
- [x] UUID smoke test (backwards compat, same SD)
- [ ] CI green

Closes-feedback: e402e5c4-eef1-4565-be19-3bb0d132f61a

🤖 Generated with [Claude Code](https://claude.com/claude-code)