### PR TITLE
feat(SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001): fix sweep/dashboard liveness writer-consumer asymmetry

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-C",
-  "expectedBranch": "feat/SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-C",
-  "createdAt": "2026-05-20T14:53:41.788Z",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
+  "sdKey": "SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001",
+  "createdAt": "2026-05-26T19:22:01.637Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260526_v_active_sessions_expose_liveness.sql
+++ b/database/migrations/20260526_v_active_sessions_expose_liveness.sql
@@ -1,0 +1,144 @@
+-- Migration: Expose claim-owner liveness columns through v_active_sessions
+-- SD: SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-1)
+--
+-- Problem: claude_sessions already carries is_alive (PID-liveness check) and
+-- has_uncommitted_changes (git working-tree dirty), but v_active_sessions did
+-- not pass them through. Consumers therefore either re-derived liveness from
+-- raw fields (creating the writer-consumer asymmetry RCA 269e55cc) or displayed
+-- a placeholder. fleet-dashboard.cjs L396 already reads has_uncommitted_changes
+-- and rendered a dash because the view never selected it — this migration
+-- un-breaks that column.
+--
+-- Strictly additive. Two new columns appended at the end (positions 36, 37).
+-- All pre-existing columns preserved with their original name, order, and
+-- type. No rename, no drop, no reorder — CREATE OR REPLACE VIEW permits the
+-- tail-append shape used here.
+--
+-- Live view shape (DO NOT MODIFY without re-checking pg_get_viewdef):
+-- The view uses a two-layer LATERAL structure — an inner subquery (alias _v)
+-- builds the SD/QF claim model, then an outer LEFT JOIN to claude_sessions
+-- (alias _cs) tail-appends per-session passthrough columns. The outer-join
+-- pattern was introduced by a prior migration to add loop_state (pos 35); this
+-- migration follows the same pattern to tail-append is_alive and
+-- has_uncommitted_changes (positions 36, 37) from the same outer join.
+--
+-- The inner subquery body (FROM line 91 onward, ending in
+-- "ORDER BY cs.track, cs.claimed_at DESC) _v") is preserved verbatim from
+-- 20260426_v_active_sessions_qf_claim_visibility.sql so the SD/QF claim model
+-- is unchanged. The outer SELECT (lines 6-43) selects each inner column by
+-- name in order, then appends the new ones — this is the shape that survives
+-- CREATE OR REPLACE VIEW without "cannot change name of view column" errors.
+--
+-- Authoring note: an earlier draft of this migration was written against the
+-- 20260426 baseline (34 columns ending at parent_session_id) and failed at
+-- runtime because the live view has 35 columns (loop_state was added later via
+-- the outer-join pattern). The reconciled DDL below was captured via
+-- pg_get_viewdef() against dedlbzhpgkmetvhbkyzq on 2026-05-26 and is what
+-- actually applied. If a future migration needs to add another passthrough
+-- column, follow the same _cs outer-join pattern at the tail.
+--
+-- Rollback: replay 20260426_v_active_sessions_qf_claim_visibility.sql plus the
+-- loop_state outer-join migration. No data backfill needed (read-model view).
+--
+-- Two-threshold model context: this view encodes the 600s DISPLAY-STALE
+-- threshold deliberately; the 300s LIVENESS/CLAIM threshold lives in
+-- lib/claim/stale-threshold.js. See SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 FR-2.
+
+CREATE OR REPLACE VIEW v_active_sessions AS
+SELECT _v.id,
+    _v.session_id,
+    _v.sd_id,
+    _v.sd_key,
+    _v.sd_title,
+    _v.qf_id,
+    _v.qf_title,
+    _v.qf_status,
+    _v.track,
+    _v.tty,
+    _v.pid,
+    _v.hostname,
+    _v.codebase,
+    _v.current_branch,
+    _v.machine_id,
+    _v.terminal_id,
+    _v.terminal_identity,
+    _v.claimed_at,
+    _v.heartbeat_at,
+    _v.status,
+    _v.released_reason,
+    _v.released_at,
+    _v.stale_reason,
+    _v.stale_at,
+    _v.metadata,
+    _v.created_at,
+    _v.heartbeat_age_seconds,
+    _v.heartbeat_age_minutes,
+    _v.seconds_until_stale,
+    _v.computed_status,
+    _v.claim_duration_minutes,
+    _v.heartbeat_age_human,
+    _v.is_virtual,
+    _v.parent_session_id,
+    _cs.loop_state,
+    -- SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-1): liveness columns passthrough
+    _cs.is_alive,
+    _cs.has_uncommitted_changes
+   FROM ( SELECT cs.id,
+            cs.session_id,
+            cs.sd_key AS sd_id,
+            cs.sd_key,
+            COALESCE(sd.title, qf.title::character varying) AS sd_title,
+            qf_active.id AS qf_id,
+            qf_active.title AS qf_title,
+            qf_active.status AS qf_status,
+            cs.track,
+            cs.tty,
+            cs.pid,
+            cs.hostname,
+            cs.codebase,
+            cs.current_branch,
+            cs.machine_id,
+            cs.terminal_id,
+            cs.terminal_identity,
+            cs.claimed_at,
+            cs.heartbeat_at,
+            cs.status,
+            cs.released_reason,
+            cs.released_at,
+            cs.stale_reason,
+            cs.stale_at,
+            cs.metadata,
+            cs.created_at,
+            EXTRACT(epoch FROM now() - cs.heartbeat_at) AS heartbeat_age_seconds,
+            EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0 AS heartbeat_age_minutes,
+            GREATEST(0::numeric, 600.0 - EXTRACT(epoch FROM now() - cs.heartbeat_at)) AS seconds_until_stale,
+                CASE
+                    WHEN cs.status = 'released'::text THEN 'released'::text
+                    WHEN cs.status = 'stale'::text THEN 'stale'::text
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) > 600::numeric THEN 'stale'::text
+                    WHEN cs.sd_key IS NULL AND qf_active.id IS NULL THEN 'idle'::text
+                    ELSE 'active'::text
+                END AS computed_status,
+                CASE
+                    WHEN cs.claimed_at IS NOT NULL THEN EXTRACT(epoch FROM now() - cs.claimed_at) / 60.0
+                    ELSE NULL::numeric
+                END AS claim_duration_minutes,
+                CASE
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 60::numeric THEN EXTRACT(epoch FROM now() - cs.heartbeat_at)::integer || 's ago'::text
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 3600::numeric THEN (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0)::integer || 'm ago'::text
+                    ELSE (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 3600.0)::integer || 'h ago'::text
+                END AS heartbeat_age_human,
+            cs.is_virtual,
+            cs.parent_session_id
+           FROM claude_sessions cs
+             LEFT JOIN strategic_directives_v2 sd ON cs.sd_key = sd.sd_key
+             LEFT JOIN quick_fixes qf ON cs.sd_key = qf.id
+             LEFT JOIN quick_fixes qf_active ON qf_active.claiming_session_id = cs.session_id AND (qf_active.status = ANY (ARRAY['open'::text, 'in_progress'::text]))
+          WHERE cs.status <> 'released'::text
+          ORDER BY cs.track, cs.claimed_at DESC) _v
+     LEFT JOIN claude_sessions _cs ON _cs.session_id = _v.session_id;
+
+COMMENT ON VIEW v_active_sessions IS 'Active sessions view with 600s display-stale threshold (intentionally distinct from the 300s liveness/claim threshold in lib/claim/stale-threshold.js; see SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 FR-2 for the two-threshold model). Surfaces SD claims (cs.sd_key), in-flight QF claims (quick_fixes.claiming_session_id), and base-table liveness signals (is_alive, has_uncommitted_changes) so consumers do not need to re-derive them.';
+
+-- Reload PostgREST schema cache so the new columns are immediately visible
+NOTIFY pgrst, 'reload schema';

--- a/lib/claim/holding-statuses.cjs
+++ b/lib/claim/holding-statuses.cjs
@@ -1,0 +1,46 @@
+/**
+ * Claim-holding session status set + pure helper.
+ * SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3)
+ *
+ * Single definition of which classified-session statuses count as "this session
+ * is currently holding its SD claim". Used by stale-session-sweep.cjs in BOTH
+ * the available-to-claim filter and the worker-render filter, so a holder is
+ * never simultaneously rendered as a live worker AND advertised as available.
+ *
+ * Absorbed scope of QF-20260526-577 (the same fix targeted only the sweep's
+ * available-filter; this module is the durable shared definition).
+ *
+ * Background: scripts/stale-session-sweep.cjs::classifySessions emits statuses
+ *   ALIVE_SOURCE_SIDE | ACTIVE | ALIVE_NO_HEARTBEAT | STALE_UNKNOWN | DEAD
+ * The first three indicate the holding session is still alive on some signal
+ * (source-side / fresh heartbeat / live PID despite stale heartbeat), so its
+ * SD must be excluded from the available-to-claim pool. STALE_UNKNOWN/DEAD
+ * holders are eligible for reclamation by claim-guard (out of scope here).
+ *
+ * Pure: no DB, no fs, no process state. Safe to unit test with synthetic input.
+ */
+
+const CLAIM_HOLDING_STATUSES = new Set([
+  'ACTIVE',
+  'ALIVE_NO_HEARTBEAT',
+  'ALIVE_SOURCE_SIDE',
+]);
+
+/**
+ * Compute the set of sd_keys currently held by a live (claim-holding) session.
+ * @param {Array<{sd_key?: string|null, status?: string}>} classified
+ *   Output of classifySessions() — each item has a sd_key (may be null/empty
+ *   for idle sessions) and a classified status string.
+ * @returns {Set<string>} Set of sd_key strings held by live sessions.
+ */
+function computeClaimedSdKeys(classified) {
+  const claimed = new Set();
+  if (!Array.isArray(classified)) return claimed;
+  for (const s of classified) {
+    if (!s || !s.sd_key) continue;
+    if (CLAIM_HOLDING_STATUSES.has(s.status)) claimed.add(s.sd_key);
+  }
+  return claimed;
+}
+
+module.exports = { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys };

--- a/lib/claim/holding-statuses.test.js
+++ b/lib/claim/holding-statuses.test.js
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the claim-holding status set + computeClaimedSdKeys helper.
+ * SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3) — absorbs QF-20260526-577.
+ *
+ * Invariant: a session classified as a claim-holding status must NEVER appear
+ * available-to-claim. The same set drives the worker-render filter, so if this
+ * test passes, the two stale-session-sweep call sites cannot disagree.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('./holding-statuses.cjs');
+
+describe('CLAIM_HOLDING_STATUSES (FR-3 invariant)', () => {
+  it('contains exactly the three classified statuses that mean "session is holding its claim"', () => {
+    // Pinning the set guards against silent drift if classifySessions() adds a
+    // new alive-status without updating this definition.
+    expect([...CLAIM_HOLDING_STATUSES].sort()).toEqual(
+      ['ACTIVE', 'ALIVE_NO_HEARTBEAT', 'ALIVE_SOURCE_SIDE']
+    );
+  });
+
+  it('does NOT include STALE_UNKNOWN or DEAD (those statuses release the claim)', () => {
+    expect(CLAIM_HOLDING_STATUSES.has('STALE_UNKNOWN')).toBe(false);
+    expect(CLAIM_HOLDING_STATUSES.has('DEAD')).toBe(false);
+  });
+});
+
+describe('computeClaimedSdKeys (FR-3 — the consistency helper)', () => {
+  it('treats all three live statuses as claim-holding', () => {
+    const result = computeClaimedSdKeys([
+      { sd_key: 'SD-A', status: 'ACTIVE' },
+      { sd_key: 'SD-B', status: 'ALIVE_NO_HEARTBEAT' },
+      { sd_key: 'SD-C', status: 'ALIVE_SOURCE_SIDE' },
+    ]);
+    expect(result).toBeInstanceOf(Set);
+    expect([...result].sort()).toEqual(['SD-A', 'SD-B', 'SD-C']);
+  });
+
+  // The original RCA 269e55cc symptom: a lone ALIVE_NO_HEARTBEAT holder was
+  // advertised available-to-claim while still rendered as a worker. This test
+  // is the regression pin.
+  it('keeps a lone ALIVE_NO_HEARTBEAT holder out of the available-to-claim pool', () => {
+    const claimed = computeClaimedSdKeys([
+      { sd_key: 'SD-X', status: 'ALIVE_NO_HEARTBEAT' },
+    ]);
+    expect(claimed.has('SD-X')).toBe(true);
+  });
+
+  it('keeps a lone ALIVE_SOURCE_SIDE holder out of the available-to-claim pool', () => {
+    const claimed = computeClaimedSdKeys([
+      { sd_key: 'SD-Y', status: 'ALIVE_SOURCE_SIDE' },
+    ]);
+    expect(claimed.has('SD-Y')).toBe(true);
+  });
+
+  it('excludes STALE_UNKNOWN and DEAD holders (claim-guard subsystem reclaims those)', () => {
+    const claimed = computeClaimedSdKeys([
+      { sd_key: 'SD-STALE', status: 'STALE_UNKNOWN' },
+      { sd_key: 'SD-DEAD', status: 'DEAD' },
+    ]);
+    expect(claimed.size).toBe(0);
+  });
+
+  it('ignores idle sessions (no sd_key)', () => {
+    const claimed = computeClaimedSdKeys([
+      { sd_key: null, status: 'ACTIVE' },
+      { sd_key: '', status: 'ACTIVE' },
+      { status: 'ACTIVE' }, // no sd_key field at all
+    ]);
+    expect(claimed.size).toBe(0);
+  });
+
+  it('returns an empty set for malformed input rather than throwing', () => {
+    expect(computeClaimedSdKeys(null).size).toBe(0);
+    expect(computeClaimedSdKeys(undefined).size).toBe(0);
+    expect(computeClaimedSdKeys('not an array').size).toBe(0);
+  });
+
+  it('deduplicates when two sessions hold the same sd_key (rare race)', () => {
+    const claimed = computeClaimedSdKeys([
+      { sd_key: 'SD-DUP', status: 'ACTIVE' },
+      { sd_key: 'SD-DUP', status: 'ALIVE_NO_HEARTBEAT' },
+    ]);
+    expect(claimed.size).toBe(1);
+    expect(claimed.has('SD-DUP')).toBe(true);
+  });
+});

--- a/lib/claim/stale-threshold.js
+++ b/lib/claim/stale-threshold.js
@@ -1,21 +1,50 @@
 /**
  * Shared Stale Session Threshold Configuration
- * SD-LEO-INFRA-CLAIM-SYSTEM-IMPROVEMENTS-001 (FR-004)
+ * SD-LEO-INFRA-CLAIM-SYSTEM-IMPROVEMENTS-001 (FR-004) — original
+ * SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-2) — two-threshold model documented
  *
- * Single source of truth for session staleness threshold.
- * Used by: claim-guard.mjs, v_active_sessions view, cleanup_stale_sessions RPC,
- *          /claim command, sd-next recommendations.
+ * Two-threshold model (intentional, not a bug):
  *
- * Override via STALE_SESSION_THRESHOLD_SECONDS environment variable.
- * Default: 300 seconds (5 minutes) — matches v_active_sessions view.
+ *   1. LIVENESS / CLAIM threshold = 300s (DEFAULT_STALE_THRESHOLD_SECONDS).
+ *      The boundary at which a session is treated as no-longer-claim-holding.
+ *      Used by: claim-guard.mjs, stale-session-sweep.cjs (status='ACTIVE'
+ *      boundary at line 122), fleet-dashboard.cjs (idle classification, line
+ *      65), /claim command, sd-next recommendations.
+ *      Tuning rationale: short enough that a crashed session yields its claim
+ *      quickly, long enough that a session loading context / between tool
+ *      calls is not prematurely reclaimed. The PID-liveness fallback covers
+ *      the in-between case (status='ALIVE_NO_HEARTBEAT').
+ *      Override: STALE_SESSION_THRESHOLD_SECONDS env var.
+ *
+ *   2. DISPLAY-STALE threshold = 600s (DISPLAY_STALE_THRESHOLD_SECONDS).
+ *      The boundary at which v_active_sessions.computed_status flips to
+ *      'stale' in dashboards. Intentionally LARGER than the liveness
+ *      threshold so a session momentarily over the 300s mark is not shown
+ *      as stale to a human reading the dashboard — display flap costs
+ *      attention without changing claim semantics.
+ *      Encoded in the SQL view (database/migrations/20260406_v_active_sessions
+ *      _stale_threshold_600s.sql; preserved by 20260426 and 20260526) as a
+ *      hardcoded numeric. The JS constant exported here is for documentation
+ *      and discoverability — the view does not import JS.
+ *
+ * The two thresholds measure DIFFERENT things on purpose. Collapsing them to
+ * one value reverts the deliberate 20260406 board decision and trades display
+ * flap for claim-churn (or vice versa). Touch with explicit RCA evidence only.
+ *
+ * Prior comment claimed "Default: 300 ... matches v_active_sessions view".
+ * That was false from migration 20260406 onward and was caught by RCA 269e55cc
+ * (writer-consumer asymmetry, 5th witness of PAT-LEO-INFRA-WRITER-CONSUMER-
+ * ASYMMETRY-001).
  */
 
 const DEFAULT_STALE_THRESHOLD_SECONDS = 300;
+const DISPLAY_STALE_THRESHOLD_SECONDS = 600;
 
 /**
- * Get the stale session threshold in seconds.
- * Reads from STALE_SESSION_THRESHOLD_SECONDS env var, falls back to 300s default.
- * @returns {number} Threshold in seconds
+ * Get the liveness/claim stale threshold in seconds.
+ * Reads from STALE_SESSION_THRESHOLD_SECONDS env var, falls back to 300s.
+ * Do NOT use this value for display formatting — see DISPLAY_STALE_THRESHOLD_SECONDS.
+ * @returns {number} Liveness threshold in seconds.
  */
 export function getStaleThresholdSeconds() {
   const envVal = process.env.STALE_SESSION_THRESHOLD_SECONDS;
@@ -26,5 +55,9 @@ export function getStaleThresholdSeconds() {
   return DEFAULT_STALE_THRESHOLD_SECONDS;
 }
 
-export { DEFAULT_STALE_THRESHOLD_SECONDS };
-export default { getStaleThresholdSeconds, DEFAULT_STALE_THRESHOLD_SECONDS };
+export { DEFAULT_STALE_THRESHOLD_SECONDS, DISPLAY_STALE_THRESHOLD_SECONDS };
+export default {
+  getStaleThresholdSeconds,
+  DEFAULT_STALE_THRESHOLD_SECONDS,
+  DISPLAY_STALE_THRESHOLD_SECONDS,
+};

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -26,6 +26,11 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
+// SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): single shared definition of which
+// classified session statuses count as "currently holding the SD claim" — used
+// by BOTH the available-to-claim filter and the worker-render filter below so
+// they cannot drift. Absorbs QF-20260526-577.
+const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('../lib/claim/holding-statuses.cjs');
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3b — top-level require so wire-check
 // call-graph builder can statically resolve the dependency on lib/coordinator/signal-router.cjs.
 const _signalRouterModule = require('../lib/coordinator/signal-router.cjs');
@@ -1118,7 +1123,11 @@ async function main() {
 
   // Dependency-aware availability: only suggest SDs whose deps are all completed
   const completedKeys = new Set(allSDs.filter(c => c.status === 'completed').map(c => c.sd_key));
-  const claimedByActive = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_key));
+  // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3) / absorbed QF-20260526-577: was
+  // `status === 'ACTIVE'` only, which let an ALIVE_NO_HEARTBEAT or
+  // ALIVE_SOURCE_SIDE holder's SD be advertised available-to-claim while the
+  // same session was simultaneously rendered as a live worker below (L1144).
+  const claimedByActive = computeClaimedSdKeys(classified);
 
   const available = allSDs
     .filter(c => {
@@ -1141,7 +1150,11 @@ async function main() {
     })
     .map(c => c.sd_key);
 
-  const activeSessions = classified.filter(s => s.status === 'ACTIVE' || s.status === 'ALIVE_NO_HEARTBEAT');
+  // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): use the same CLAIM_HOLDING_STATUSES
+  // set the available-filter above uses, so worker-render and available-listing
+  // can never disagree about who is holding a claim. Previously omitted the
+  // third claim-holding status, ALIVE_SOURCE_SIDE.
+  const activeSessions = classified.filter(s => CLAIM_HOLDING_STATUSES.has(s.status));
 
   // 6b. QA — Claim Integrity: detect idle sessions with no SD claim and nudge them
   const { data: idleSessions } = await supabase


### PR DESCRIPTION
## Summary

Three grounded fixes for RCA `269e55cc` (5th witness of `PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001`). Symptom: an `ALIVE_NO_HEARTBEAT` claim-holder was rendered as a live worker AND advertised as available-to-claim by the same sweep run. Cosmetic (claim-validity gate is fail-closed); fix removes phantom-claim confusion and un-breaks `fleet-dashboard.cjs:396`'s `has_uncommitted_changes` column.

### FR-1 — `v_active_sessions` exposes liveness columns
`database/migrations/20260526_v_active_sessions_expose_liveness.sql` — `CREATE OR REPLACE VIEW` appends `is_alive` and `has_uncommitted_changes` passthrough from `claude_sessions` (positions 36/37) via the live two-layer LATERAL pattern. **Strictly additive** — no rename/reorder/drop.

### FR-2 — two-threshold model documented (not collapsed)
`lib/claim/stale-threshold.js` — 300s LIVENESS/CLAIM threshold and 600s DISPLAY-STALE threshold measure different axes by design. Removed the false `"matches the view"` comment; added named `DISPLAY_STALE_THRESHOLD_SECONDS` export. **No behavior change.**

### FR-3 — consistent claim-holding status set across sweep call sites
`lib/claim/holding-statuses.cjs` (new) + `scripts/stale-session-sweep.cjs` (L1121, L1144) — shared `CLAIM_HOLDING_STATUSES = {ACTIVE, ALIVE_NO_HEARTBEAT, ALIVE_SOURCE_SIDE}` set + pure `computeClaimedSdKeys(classified)` helper used by BOTH the available-to-claim filter and the worker-render filter, so they cannot drift. **Absorbs QF-20260526-577** (linked + cancelled at LEAD scope-lock).

## Tests
9-case unit suite (`lib/claim/holding-statuses.test.js`) pins the RCA-269e55cc regression for a lone `ALIVE_NO_HEARTBEAT` holder. Broader sweep: 14/14 unit tests pass (claim-health + holding-statuses).

## Migration applied
By `database-agent` against `dedlbzhpgkmetvhbkyzq` (evidence `sub_agent_execution_results.id=46d2977e`). View reconciled against live `pg_get_viewdef` because the worktree migration baseline was older than production by one `loop_state` migration; canonical file in this PR matches what actually applied.

## Out of scope (deletion audit, 25%)
- `claim-guard` claim-theft/release eligibility — separate subsystem, HOLD/risk-7 per RCA brainstorm — unchanged.
- `findExistingSession()` PID-inheritance — distinct RCA mis-attached to this SD's auto-enriched description — unchanged.

## Follow-ups (filed post-LEAD-FINAL, do not block this PR)
- **QF**: sweep `L1385` inverse-negation duplicate (same asymmetry pattern, display side — TESTING agent flagged out-of-scope).
- **QF**: `scripts/generate-retrospective.js:71` uses `sd_id=X` existence check while gates require the full `getFilteredRetrospective` predicate (6th witness of same asymmetry pattern; RCA `c0e0f442`).
- **SD**: shared retro-payload factory + pre-flight validator (RCA recommendation).

## Gates
- LEAD-TO-PLAN: 96 ✅
- PLAN-TO-EXEC: 96 ✅
- PLAN-TO-LEAD: 94 ✅ (RETROSPECTIVE_QUALITY_GATE 90, SMOKE_TEST_EVIDENCE 100, SUBAGENT_EVIDENCE 100, USER_STORIES 100, ACCEPTANCE_CRITERIA 100)
- Sub-agents PASS: VALIDATION 97, DESIGN/DATABASE/RISK/STORIES, DATABASE 95, TESTING 92, RCA 95

## PR size rationale (201-400 tier)
~120 LOC source + ~85 tests + ~140 SQL = 345 LOC. **Atomic unit**: FR-1 (view) + FR-3 (helper + consumers) + 9-case regression pin must ship together — releasing FR-1 alone leaves the L1121/L1144 asymmetry; releasing FR-3 alone leaves fleet-dashboard's `has_uncommitted_changes` column broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
