### PR TITLE
feat(SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001): venture lifecycle stage-numbering SSOT reconciliation

### DIFF
--- a/database/migrations/20260526_reconcile_lifecycle_stage_config_names_sd_lifecycle_001.sql
+++ b/database/migrations/20260526_reconcile_lifecycle_stage_config_names_sd_lifecycle_001.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- Migration: 20260526_reconcile_lifecycle_stage_config_names_sd_lifecycle_001
+-- SD:        SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001
+-- FR:        FR-1 (Conform lifecycle_stage_config.stage_name to stage_config SSOT)
+-- Author:    database-agent (EXEC phase)
+-- Date:      2026-05-26
+-- ============================================================================
+--
+-- PURPOSE
+-- -------
+-- The PLAN-phase audit identified exactly two stage_number rows where
+-- `lifecycle_stage_config.stage_name` disagrees with `stage_config.stage_name`:
+--
+--   * stage_number = 14
+--       lifecycle_stage_config = 'Technical Architecture & Risk Register'
+--       stage_config           = 'Technical Architecture'
+--
+--   * stage_number = 19
+--       lifecycle_stage_config = 'Build in Replit'
+--       stage_config           = 'Sprint Planning'
+--
+-- All other stages (1-26) already agree. `stage_config` is the declared
+-- name-authoritative SSOT (see lib/eva/stage-governance.js).
+-- `lifecycle_stage_config` is gate-semantics-authoritative; only the display
+-- `stage_name` is being conformed here — no gate semantics are altered.
+--
+-- FK SAFETY
+-- ---------
+-- Live data audit (PLAN phase, evidence row 97ebe7d2-8f2b-4280-b25b-afb2d3f7a1a1)
+-- confirmed 0 rows in venture_stage_work / venture_artifacts / ventures store
+-- a stage NAME — they all key off the integer `stage_number`. The only FK
+-- against these tables is `advisory_checkpoints.stage_number` which references
+-- the integer. Therefore renaming `stage_name` is FK-safe.
+--
+-- IDEMPOTENCY RATIONALE
+-- ---------------------
+-- The `IS DISTINCT FROM` predicate guarantees that:
+--   1) NULL-safe comparison (a NULL on either side would not falsely match
+--      a non-NULL counterpart).
+--   2) On a second run, after `lsc.stage_name` already equals `sc.stage_name`,
+--      the predicate evaluates FALSE and zero rows are updated.
+-- The IN (14, 19) clause is a defensive belt-and-suspenders restrictor: even
+-- if a future SSOT drift introduced a third divergent stage_number, this
+-- migration will NOT silently rewrite it. Any new divergence must be
+-- triaged + addressed by a new SD.
+--
+-- ROLLBACK
+-- --------
+--   UPDATE lifecycle_stage_config SET stage_name = 'Technical Architecture & Risk Register' WHERE stage_number = 14;
+--   UPDATE lifecycle_stage_config SET stage_name = 'Build in Replit' WHERE stage_number = 19;
+--
+-- ============================================================================
+
+UPDATE lifecycle_stage_config lsc
+   SET stage_name = sc.stage_name,
+       updated_at = now()
+  FROM stage_config sc
+ WHERE lsc.stage_number = sc.stage_number
+   AND lsc.stage_number IN (14, 19)
+   AND lsc.stage_name IS DISTINCT FROM sc.stage_name;

--- a/lib/eva/contracts/stage-contracts.yaml
+++ b/lib/eva/contracts/stage-contracts.yaml
@@ -8,6 +8,20 @@
 #
 # Field types: string, integer, number, object, array, boolean
 # Constraints: required, minLength, min, max, minItems
+#
+# ── NAME-FIELD DISPOSITION ───────────────────────────────────────────────
+# The `name:` field on each stage in this file is HISTORICAL (pre-2026-04-21
+# redesign) and is NOT the canonical stage name. The canonical SSOT for
+# stage_number -> name is `stage_config.stage_name` (DB), accessed via
+# `lib/eva/stage-governance.js`. The role of this file at runtime is the
+# `consumes:` / `produces:` data contract, not naming.
+#
+# Do NOT rely on the `name:` values here for UI labels or anywhere a user-
+# facing stage name is needed — read from stage_config via stage-governance.
+# Cross-table parity for stage_name is enforced by:
+#   scripts/generate-stage-config.cjs --check
+# Reference: SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-4.
+# ─────────────────────────────────────────────────────────────────────────
 
 stages:
   1:

--- a/lib/eva/launch-workflow/index.js
+++ b/lib/eva/launch-workflow/index.js
@@ -91,9 +91,13 @@ export async function getChecklist(ventureId, deps = {}) {
     .gte('stage_number', 20)
     .order('stage_number', { ascending: true });
 
+  // FR-3 (SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001): source stage labels
+  // from the DB SSOT (stage_config via stage-governance) rather than a hardcoded
+  // map. The async lookup is amortized via the in-process cache in stage-governance.
+  const stageLabels = await getStageLabels(supabase);
   const items = (gates || []).map((g) => ({
     stage: g.stage_number,
-    label: STAGE_LABELS[g.stage_number] || `Stage ${g.stage_number}`,
+    label: stageLabels.get(g.stage_number) || `Stage ${g.stage_number}`,
     type: BLOCKING_GATES.includes(g.stage_number) ? 'blocking' : 'advisory',
     passed: g.passed,
     score: g.score,
@@ -126,9 +130,11 @@ export async function getTimeline(ventureId, deps = {}) {
     .eq('venture_id', ventureId)
     .order('created_at', { ascending: true });
 
+  // FR-3 (SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001): stage labels via SSOT lookup.
+  const stageLabels = await getStageLabels(supabase);
   const events = (gates || []).map((g) => ({
     stage: g.stage_number,
-    label: STAGE_LABELS[g.stage_number] || `Stage ${g.stage_number}`,
+    label: stageLabels.get(g.stage_number) || `Stage ${g.stage_number}`,
     passed: g.passed,
     score: g.score,
     timestamp: g.created_at,
@@ -150,18 +156,30 @@ export async function getTimeline(ventureId, deps = {}) {
   };
 }
 
-// Stage label reference
-const STAGE_LABELS = {
-  1: 'Idea Capture', 2: 'Idea Analysis', 3: 'Kill Gate',
-  4: 'Competitive Landscape', 5: 'Kill Gate (Financial)', 6: 'Risk Assessment',
-  7: 'Revenue Architecture', 8: 'Business Model Canvas', 9: 'Exit Strategy',
-  10: 'Customer & Brand Foundation', 11: 'Naming & Visual Identity', 12: 'GTM & Sales Strategy',
-  13: 'Product Roadmap', 14: 'Technical Architecture', 15: 'Risk Register',
-  16: 'Financial Projections', 17: 'Pre-Build Checklist', 18: 'Sprint Planning',
-  19: 'Build Execution', 20: 'Quality Assurance',
-  21: 'Build Review', 22: 'Release Readiness',
-  23: 'Marketing Preparation', 24: 'Launch Readiness', 25: 'Launch Execution',
-};
+// SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-3: stage labels are sourced
+// from the DB SSOT (stage_config via stage-governance), not a hardcoded map.
+// The hardcoded map above this comment was retired because it drifted (S19='Build
+// Execution', S20='Quality Assurance' were wrong as of the 2026-04-21 redesign).
+// getStageLabels caches per-supabase-client via the underlying stage-governance
+// 60s TTL + realtime invalidation, so call sites can invoke per request safely.
+import { getStageGovernance } from '../stage-governance.js';
+
+async function getStageLabels(supabase) {
+  const labels = new Map();
+  try {
+    const gov = await getStageGovernance(supabase);
+    // gov.stages would be ideal but the public view doesn't expose it; iterate by
+    // stage_number 1..26 via getStage(). 26 is the current ceiling per the redesign.
+    for (let n = 1; n <= 26; n += 1) {
+      const row = gov.getStage(n);
+      if (row && row.stage_name) labels.set(n, row.stage_name);
+    }
+  } catch (err) {
+    // Governance unavailable — caller falls back to `Stage N` literal.
+    console.warn(`[launch-workflow] getStageLabels via governance failed: ${err.message}`);
+  }
+  return labels;
+}
 
 // Chairman blocking gates
 const BLOCKING_GATES = [3, 10, 22, 24];

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -3,14 +3,21 @@
  *
  * SD-LEO-FEAT-LIFECYCLE-SD-BRIDGE-001
  * SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D (3-tier hierarchy, safety controls)
+ * SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-5 (docstring SSOT alignment)
  *
- * Converts Stage 18 sprint plan payloads into real LEO Strategic Directives.
- * Supports 3-tier hierarchy: orchestrator -> children -> grandchildren.
+ * Converts Stage 19 ("Sprint Planning") sprint plan payloads into real LEO
+ * Strategic Directives. Supports 3-tier hierarchy: orchestrator -> children
+ * -> grandchildren.
  *
- * Stage 18 generates `sd_bridge_payloads` with structured data for each
- * sprint item. This module consumes those payloads, creates an orchestrator
- * SD for the sprint, child SDs for each sprint item, and optional grandchild
- * SDs decomposed by architecture layer.
+ * Stage 19 (Sprint Planning) generates `sd_bridge_payloads` with structured
+ * data for each sprint item. This module consumes those payloads, creates an
+ * orchestrator SD for the sprint, child SDs for each sprint item, and optional
+ * grandchild SDs decomposed by architecture layer.
+ *
+ * NOTE: historical docstrings referenced "Stage 18" because the pre-2026-04-21
+ * schema had S18="Sprint Planning". The redesigned schema has S18="Marketing
+ * Copy Studio" and S19="Sprint Planning". Behavior is unchanged — only the
+ * stage-number references in this docstring were updated.
  *
  * Safety controls:
  * - Amplification caps (MAX_CHILDREN=10, MAX_DEPTH=2, MAX_GRANDCHILDREN_PER_CHILD=5)
@@ -168,14 +175,14 @@ function buildProvenance(ventureId) {
 }
 
 /**
- * Convert Stage 18 sprint plan output into LEO Strategic Directives.
+ * Convert Stage 19 (Sprint Planning) sprint plan output into LEO Strategic Directives.
  *
  * Creates a 3-tier hierarchy: orchestrator -> children -> grandchildren.
  * Wrapped in try/catch with rollback on failure.
  * Enforces amplification caps and provenance tagging.
  *
  * @param {Object} params
- * @param {Object} params.stageOutput - Output from Stage 18 (includes sd_bridge_payloads)
+ * @param {Object} params.stageOutput - Output from Stage 19 / Sprint Planning (includes sd_bridge_payloads)
  * @param {Object} params.ventureContext - Venture metadata { id, name }
  * @param {Object} [params.options] - Generation options
  * @param {boolean} [params.options.generateGrandchildren=true] - Whether to decompose children into grandchildren

--- a/lib/eva/stage-registry.js
+++ b/lib/eva/stage-registry.js
@@ -158,24 +158,47 @@ export class StageRegistry {
     try {
       const supabase = supabaseClient || createSupabaseServiceClient();
 
-      const { data, error } = await supabase
-        .from('lifecycle_stage_config')
-        .select('stage_number, stage_name, phase_name, metadata, description')
-        .order('stage_number');
+      // SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-2: stage_name is sourced
+      // from `stage_config` (name-authoritative per lib/eva/stage-governance.js).
+      // lifecycle_stage_config remains the source for phase_name / metadata.
+      // See sibling reader: lib/eva/stage-registry/index.js for the same pattern.
+      const [lifecycleRes, nameRes] = await Promise.all([
+        supabase
+          .from('lifecycle_stage_config')
+          .select('stage_number, stage_name, phase_name, metadata, description')
+          .order('stage_number'),
+        supabase
+          .from('stage_config')
+          .select('stage_number, stage_name')
+          .order('stage_number'),
+      ]);
+      const { data, error } = lifecycleRes;
+      const { data: nameRows, error: nameError } = nameRes;
 
       if (error) {
         this.stats.dbErrors++;
-        console.warn(`StageRegistry: DB load failed: ${error.message}`);
+        console.warn(`StageRegistry: DB load failed (lifecycle_stage_config): ${error.message}`);
         return 0;
+      }
+      if (nameError) {
+        // Non-fatal: fall back to lifecycle name if stage_config is unreachable.
+        console.warn(`StageRegistry: stage_config name lookup failed, falling back to lifecycle name: ${nameError.message}`);
+      }
+
+      const authoritativeName = new Map();
+      for (const r of nameRows || []) {
+        authoritativeName.set(r.stage_number, r.stage_name);
       }
 
       let loaded = 0;
       const now = Date.now();
       for (const row of data || []) {
-        // Build a template-compatible config from DB row
+        // Build a template-compatible config from DB row.
+        // title is the user-facing stage name — sourced from stage_config (FR-2).
+        const canonicalName = authoritativeName.get(row.stage_number) || row.stage_name;
         const dbConfig = {
           id: `stage-${String(row.stage_number).padStart(2, '0')}`,
-          title: row.stage_name,
+          title: canonicalName,
           phase: row.phase_name,
           description: row.description || '',
           version: row.metadata?.version || '1.0.0',
@@ -183,10 +206,11 @@ export class StageRegistry {
           _dbMetadata: row.metadata,
         };
 
-        // Merge DB config with file-based template if available
+        // Merge DB config with file-based template if available.
+        // FR-2: dbConfig.title is already the name-authoritative value from
+        // stage_config; preserve it over the file template's title.
         const fileEntry = this.stages.get(row.stage_number);
         if (fileEntry) {
-          // DB augments file-based template with metadata
           const merged = {
             ...fileEntry.template,
             title: dbConfig.title || fileEntry.template.title,

--- a/lib/eva/stage-registry/index.js
+++ b/lib/eva/stage-registry/index.js
@@ -25,26 +25,52 @@ export async function loadFromDatabase(registry, supabase) {
   }
 
   try {
-    const { data, error } = await supabase
-      .from('lifecycle_stage_config')
-      .select('stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, advisory_enabled, depends_on, required_artifacts, metadata')
-      .order('stage_number', { ascending: true });
+    // SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-2: stage_name is sourced
+    // from `stage_config` (name-authoritative per lib/eva/stage-governance.js).
+    // lifecycle_stage_config remains the source for work_type / phase / artifacts.
+    // The migration in 20260526_reconcile_lifecycle_stage_config_names_sd_lifecycle_001.sql
+    // makes the two tables agree; reading the name from stage_config here means a
+    // future drift in lifecycle_stage_config.stage_name cannot resurface stale names
+    // through this reader. Belt + suspenders with the FR-6 CI parity assertion.
+    const [lifecycleRes, nameRes] = await Promise.all([
+      supabase
+        .from('lifecycle_stage_config')
+        .select('stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, advisory_enabled, depends_on, required_artifacts, metadata')
+        .order('stage_number', { ascending: true }),
+      supabase
+        .from('stage_config')
+        .select('stage_number, stage_name')
+        .order('stage_number', { ascending: true }),
+    ]);
+    const { data, error } = lifecycleRes;
+    const { data: nameRows, error: nameError } = nameRes;
 
     if (error) {
-      console.warn(`[StageRegistry] DB load failed: ${error.message}`);
+      console.warn(`[StageRegistry] DB load failed (lifecycle_stage_config): ${error.message}`);
       return { loaded: 0, error: error.message };
+    }
+    if (nameError) {
+      // Non-fatal: fall back to lifecycle_stage_config.stage_name if stage_config is unreachable.
+      console.warn(`[StageRegistry] stage_config name lookup failed, falling back to lifecycle name: ${nameError.message}`);
     }
 
     if (!data || data.length === 0) {
       return { loaded: 0, error: 'No stage configs found in database' };
     }
 
+    // Build name-authoritative override map keyed by stage_number.
+    const authoritativeName = new Map();
+    for (const row of nameRows || []) {
+      authoritativeName.set(row.stage_number, row.stage_name);
+    }
+
     // Clear existing DB-loaded stages (keep fallbacks)
     registry.clear();
 
     for (const row of data) {
+      const canonicalName = authoritativeName.get(row.stage_number) || row.stage_name;
       registry.register(row.stage_number, {
-        stage_name: row.stage_name,
+        stage_name: canonicalName,
         description: row.description,
         phase_number: row.phase_number,
         phase_name: row.phase_name,

--- a/lib/eva/stage-templates/analysis-steps/README.md
+++ b/lib/eva/stage-templates/analysis-steps/README.md
@@ -1,0 +1,65 @@
+# EVA Lifecycle — Analysis Steps
+
+**Audience:** future contributors maintaining lifecycle stage analysis modules.
+**SSOT for stage names:** `stage_config` table (see `lib/eva/stage-governance.js`).
+
+## Filename ≠ Served Stage Number
+
+The filenames in this directory follow `stage-NN-<slug>.js`, but the **production
+stage_number a module currently serves is NOT necessarily NN**. Why:
+
+- The venture lifecycle was renumbered at the **2026-04-21 redesign** (commit
+  series ending in `20260421_redesign_s18_s26_lifecycle_stage_config.sql`).
+- Filenames were preserved across that redesign to keep `git log -- <file>` intact.
+- The **canonical stage_number a module serves is declared inside its module
+  exports** (typically via `TEMPLATE.id` / `TEMPLATE.stageNumber` / loader meta),
+  not inferred from the filename prefix.
+
+## Duplicate filename prefixes
+
+Several stage numbers have multiple analysis-step files (e.g. `stage-20-*.js`,
+`stage-21-*.js`). Each file represents a distinct concern that historically lived
+at that stage number:
+
+| Filename                            | Concern                       |
+| ----------------------------------- | ----------------------------- |
+| `stage-19-sprint-planning.js`       | Sprint planning logic         |
+| `stage-19-acquirability.js`         | Acquirability scoring        |
+| `stage-19-visual-convergence.js`    | Visual / design convergence  |
+| `stage-20-build-execution.js`       | Legacy "Build Execution"     |
+| `stage-20-code-quality.js`          | Code Quality Gate (current)  |
+| `stage-20-acquirability.js`         | Acquirability scoring        |
+| `stage-21-quality-assurance.js`     | Legacy "QA & Testing"        |
+| `stage-21-visual-assets.js`         | Visual Assets (current)      |
+| `stage-21-acquirability.js`         | Acquirability scoring        |
+| `stage-22-build-review.js`          | Build Review                  |
+| `stage-22-distribution-setup.js`    | Distribution Setup (current) |
+| `stage-22-acquirability.js`         | Acquirability scoring        |
+
+When a stage is renamed in the SSOT (`stage_config.stage_name`), update the
+**module's internal `TEMPLATE.title`** to match — leave the filename alone.
+
+## Why we don't bulk-rename
+
+A historical bulk-rename was rejected at LEAD review because:
+1. `git blame` continuity matters more than filename freshness for legacy analysis.
+2. Filenames are not the canonical name source — `stage_config.stage_name` is.
+3. CI guard `scripts/generate-stage-config.cjs --check` enforces name parity at the
+   DB level (cross-table parity assertion added by
+   `SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-6`); filename drift cannot
+   silently produce wrong UI labels.
+
+## Adding a new analysis step
+
+1. Pick a filename matching the **current** stage name (slug form).
+2. Set `TEMPLATE.id = 'stage-NN'` where `NN` is the served stage_number.
+3. Confirm the stage_number you serve appears in `stage_config` and
+   `lifecycle_stage_config` with matching `stage_name` (FR-6 check enforces this).
+
+## Cross-references
+
+- DB SSOT: `database/migrations/20260421_redesign_s18_s26_lifecycle_stage_config.sql`,
+  `database/migrations/20260512_stage_config_v2_parity_and_publication.sql`
+- Stage name arbitration: `lib/eva/stage-governance.js`
+- Generated stage config: `lib/proving-companion/stage-config.js`
+  (generated via `node scripts/generate-stage-config.cjs --write`)

--- a/scripts/generate-stage-config.cjs
+++ b/scripts/generate-stage-config.cjs
@@ -159,6 +159,41 @@ async function loadDBConfig() {
   return byStage;
 }
 
+// SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-6
+// Cross-table name-parity assertion. Fails when lifecycle_stage_config.stage_name
+// disagrees with stage_config.stage_name for any stage_number present in BOTH
+// tables. Pure I/O wrapper around a SQL JOIN — no business logic.
+// Exported (via _testHooks) so unit fixtures can drive it without spinning up CI.
+async function assertCrossTableNameParity(supabase) {
+  const [lifecycleRes, stageRes] = await Promise.all([
+    supabase.from('lifecycle_stage_config').select('stage_number, stage_name').order('stage_number'),
+    supabase.from('stage_config').select('stage_number, stage_name').order('stage_number'),
+  ]);
+  if (lifecycleRes.error) throw new Error(`lifecycle_stage_config read failed: ${lifecycleRes.error.message}`);
+  if (stageRes.error) throw new Error(`stage_config read failed: ${stageRes.error.message}`);
+
+  const lifecycleByStage = new Map();
+  for (const row of lifecycleRes.data || []) lifecycleByStage.set(row.stage_number, row.stage_name);
+
+  const divergences = [];
+  for (const row of stageRes.data || []) {
+    const lcName = lifecycleByStage.get(row.stage_number);
+    // INNER-join semantics: only flag when both rows exist. Stages present in only
+    // one table are out of scope for parity (different lifecycle vs config concerns).
+    if (lcName !== undefined && lcName !== row.stage_name) {
+      divergences.push({
+        stage_number: row.stage_number,
+        lifecycle_stage_config_name: lcName,
+        stage_config_name: row.stage_name,
+      });
+    }
+  }
+  return divergences;
+}
+
+// Expose for unit tests (FR-6 TS-1): allows fixture-driven verification.
+module.exports._testHooks = { assertCrossTableNameParity };
+
 // ---------------------------------------------------------------------------
 // Mapping helpers
 // ---------------------------------------------------------------------------
@@ -405,14 +440,46 @@ async function main() {
       process.exit(1);
     }
     const existing = fs.readFileSync(OUTPUT_PATH, 'utf8');
-    if (existing === output) {
-      console.error('CHECK PASSED: stage-config.js is up to date');
-      process.exit(0);
-    } else {
+    if (existing !== output) {
       console.error('CHECK FAILED: stage-config.js is out of date');
-      console.error('Run: node scripts/generate-stage-config.js --write');
+      console.error('Run: node scripts/generate-stage-config.cjs --write');
       process.exit(1);
     }
+
+    // SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-6: cross-table name parity.
+    // Reuses the existing DB connection. INNER-join semantics on stage_number;
+    // stages in only one table are out of scope. Re-fetching here (instead of
+    // sharing the loadDBConfig dbConfig variable) keeps the assertion's input
+    // narrow and explicit — the failure message names the divergent stage_number.
+    try {
+      const supabaseUrl = process.env.SUPABASE_URL;
+      const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_KEY;
+      if (supabaseUrl && supabaseKey) {
+        const supabase = createClient(supabaseUrl, supabaseKey);
+        const divergences = await assertCrossTableNameParity(supabase);
+        if (divergences.length > 0) {
+          console.error('CHECK FAILED: cross-table stage_name parity violations:');
+          for (const d of divergences) {
+            console.error(
+              `  stage_number=${d.stage_number}: lifecycle_stage_config='${d.lifecycle_stage_config_name}' vs stage_config='${d.stage_config_name}'`
+            );
+          }
+          console.error('');
+          console.error('Reconcile via: UPDATE lifecycle_stage_config SET stage_name = (SELECT stage_name FROM stage_config sc WHERE sc.stage_number = lifecycle_stage_config.stage_number)');
+          console.error('  WHERE stage_number IN (' + divergences.map((d) => d.stage_number).join(', ') + ') AND stage_name IS DISTINCT FROM (SELECT stage_name FROM stage_config sc WHERE sc.stage_number = lifecycle_stage_config.stage_number);');
+          process.exit(1);
+        }
+      } else {
+        console.error('CHECK NOTE: cross-table parity check skipped (no Supabase credentials)');
+      }
+    } catch (err) {
+      // Connectivity failure is FATAL for --check (we cannot prove parity blindly).
+      console.error(`CHECK FAILED: cross-table parity check errored: ${err.message}`);
+      process.exit(1);
+    }
+
+    console.error('CHECK PASSED: stage-config.js is up to date AND cross-table names agree');
+    process.exit(0);
   }
 
   if (FLAG_WRITE) {

--- a/tests/unit/eva/reconcile-venture-lifecycle.test.js
+++ b/tests/unit/eva/reconcile-venture-lifecycle.test.js
@@ -1,0 +1,142 @@
+/**
+ * Tests for SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001
+ *
+ * Covers:
+ *   - FR-2: StageRegistry readers source stage_name from stage_config (not
+ *           lifecycle_stage_config), proving that even if lifecycle_stage_config
+ *           drifts back to a stale name in the future, the reader returns the
+ *           canonical name from the name-authoritative table.
+ *   - FR-6: scripts/generate-stage-config.cjs cross-table name-parity assertion
+ *           detects divergence and returns it (TS-1 from the PRD).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+
+import { StageRegistry } from '../../../lib/eva/stage-registry/core.js';
+import { loadFromDatabase } from '../../../lib/eva/stage-registry/index.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Build a fake Supabase client that returns the supplied rows for
+ * `lifecycle_stage_config` and `stage_config` respectively. Mirrors the
+ * minimal slice of the SDK surface that the reader / assertion call.
+ */
+function makeFakeSupabase({ lifecycleRows = [], stageConfigRows = [], lifecycleError = null, stageConfigError = null } = {}) {
+  return {
+    from(table) {
+      const rows = table === 'lifecycle_stage_config' ? lifecycleRows : stageConfigRows;
+      const error = table === 'lifecycle_stage_config' ? lifecycleError : stageConfigError;
+      const chain = {
+        _table: table,
+        _rows: rows,
+        _error: error,
+        select() { return chain; },
+        order() { return chain; },
+        then(resolve) { return Promise.resolve({ data: chain._error ? null : chain._rows, error: chain._error }).then(resolve); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('FR-2: StageRegistry sources stage_name from stage_config', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new StageRegistry();
+    // Seed a markCacheLoaded / clear / register surface compatible with the reader.
+    registry.clear = () => { registry.stages.clear(); };
+    registry.markCacheLoaded = () => { /* noop in tests */ };
+    registry.isCacheValid = () => false; // force a fresh read
+  });
+
+  it('overrides lifecycle_stage_config.stage_name with stage_config.stage_name for S19', async () => {
+    const lifecycleRows = [
+      { stage_number: 19, stage_name: 'Build in Replit', description: '', phase_number: 4, phase_name: 'BUILD', work_type: 'sd_required', sd_required: true, advisory_enabled: false, depends_on: [], required_artifacts: [], metadata: {} },
+    ];
+    const stageConfigRows = [
+      { stage_number: 19, stage_name: 'Sprint Planning' },
+    ];
+    const supabase = makeFakeSupabase({ lifecycleRows, stageConfigRows });
+
+    const result = await loadFromDatabase(registry, supabase);
+    expect(result.error).toBeNull();
+    expect(result.loaded).toBe(1);
+
+    const s19 = registry.get(19);
+    expect(s19).toBeTruthy();
+    // The whole point of FR-2: stage_config wins over lifecycle_stage_config for the NAME field.
+    expect(s19.stage_name).toBe('Sprint Planning');
+    // Other lifecycle-only fields still come from lifecycle_stage_config:
+    expect(s19.work_type).toBe('sd_required');
+    expect(s19.phase_name).toBe('BUILD');
+  });
+
+  it('falls back to lifecycle_stage_config.stage_name when stage_config is unreachable', async () => {
+    const lifecycleRows = [
+      { stage_number: 14, stage_name: 'Technical Architecture', description: '', phase_number: 3, phase_name: 'BLUEPRINT', work_type: 'sd_required', sd_required: true, advisory_enabled: false, depends_on: [], required_artifacts: [], metadata: {} },
+    ];
+    const supabase = makeFakeSupabase({ lifecycleRows, stageConfigError: { message: 'stage_config unreachable' } });
+
+    const result = await loadFromDatabase(registry, supabase);
+    expect(result.error).toBeNull(); // primary read succeeded
+    const s14 = registry.get(14);
+    expect(s14.stage_name).toBe('Technical Architecture'); // fallback worked
+  });
+});
+
+describe('FR-6: cross-table name parity assertion', () => {
+  const { _testHooks } = require('../../../scripts/generate-stage-config.cjs');
+  const { assertCrossTableNameParity } = _testHooks;
+
+  it('returns the divergent stage_number when names disagree (TS-1)', async () => {
+    const supabase = makeFakeSupabase({
+      lifecycleRows: [
+        { stage_number: 19, stage_name: 'Build in Replit' },
+        { stage_number: 20, stage_name: 'Code Quality Gate' }, // agrees
+      ],
+      stageConfigRows: [
+        { stage_number: 19, stage_name: 'Sprint Planning' },
+        { stage_number: 20, stage_name: 'Code Quality Gate' },
+      ],
+    });
+    const divergences = await assertCrossTableNameParity(supabase);
+    expect(divergences).toHaveLength(1);
+    expect(divergences[0].stage_number).toBe(19);
+    expect(divergences[0].lifecycle_stage_config_name).toBe('Build in Replit');
+    expect(divergences[0].stage_config_name).toBe('Sprint Planning');
+  });
+
+  it('returns empty array when all stage_names agree (post-FR-1 expected state)', async () => {
+    const supabase = makeFakeSupabase({
+      lifecycleRows: [
+        { stage_number: 14, stage_name: 'Technical Architecture' },
+        { stage_number: 19, stage_name: 'Sprint Planning' },
+        { stage_number: 20, stage_name: 'Code Quality Gate' },
+      ],
+      stageConfigRows: [
+        { stage_number: 14, stage_name: 'Technical Architecture' },
+        { stage_number: 19, stage_name: 'Sprint Planning' },
+        { stage_number: 20, stage_name: 'Code Quality Gate' },
+      ],
+    });
+    const divergences = await assertCrossTableNameParity(supabase);
+    expect(divergences).toHaveLength(0);
+  });
+
+  it('ignores stages present in only one table (INNER-join semantics)', async () => {
+    const supabase = makeFakeSupabase({
+      lifecycleRows: [
+        { stage_number: 19, stage_name: 'Sprint Planning' },
+        { stage_number: 27, stage_name: 'Future Stage' }, // not in stage_config
+      ],
+      stageConfigRows: [
+        { stage_number: 19, stage_name: 'Sprint Planning' },
+      ],
+    });
+    const divergences = await assertCrossTableNameParity(supabase);
+    expect(divergences).toHaveLength(0); // 27 ignored, 19 agrees
+  });
+});


### PR DESCRIPTION
## Summary

Reconciles the venture-lifecycle `stage_number → name` SSOT across two backing DB tables and four drifted code sources. SD: **SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001** (infrastructure). Companion to the now-shipped SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 (artifact-anchored, decoupled).

The PLAN-phase DATABASE sub-agent (evidence row `97ebe7d2-8f2b-4280-b25b-afb2d3f7a1a1`) established three ground truths that materially sharpened the SD vs LEAD's framing:
1. The only divergences in `lifecycle_stage_config` vs `stage_config` are **two rows**: S14 (`'Technical Architecture & Risk Register'` vs `'Technical Architecture'`) and S19 (`'Build in Replit'` vs `'Sprint Planning'`). All other stages agree.
2. **NO venture-data migration needed** — 0 of 87 `venture_stage_work` + 218 `venture_artifacts` + 13 `ventures` rows store a stage NAME; all key off integer `stage_number`. FK is `stage_number`, FK-safe.
3. The name-authority arbitration **already exists in code** at `lib/eva/stage-governance.js` — `stage_config` is name-authoritative; `lifecycle_stage_config` is gate-semantics-authoritative. The actual bug was that the two `StageRegistry` readers bypassed this declared SSOT.

## What changed

| FR | File | Change |
|----|------|--------|
| FR-1 | `database/migrations/20260526_…sd_lifecycle_001.sql` | UPDATE 2 rows in `lifecycle_stage_config` to match `stage_config.stage_name` (idempotent via `IS DISTINCT FROM`, FK-safe). **Applied via database-agent** (EXEC evidence row `5b3ad078-14e6-48bf-b2b0-90e47e8ed753`). |
| FR-2 | `lib/eva/stage-registry/index.js`, `lib/eva/stage-registry.js` | Both readers now source `stage_name` from `stage_config` via in-JS join; lifecycle-only fields still from `lifecycle_stage_config`. Graceful fallback if `stage_config` unreachable. |
| FR-3 | `lib/eva/launch-workflow/index.js` | Removed hardcoded `STAGE_LABELS` map (drifted: S19='Build Execution', S20='Quality Assurance' from pre-2026-04-21 schema). Replaced with `getStageLabels(supabase)` delegating to stage-governance. |
| FR-4 | `lib/eva/contracts/stage-contracts.yaml` | Added NAME-FIELD DISPOSITION header documenting that `name:` fields are historical; runtime reads from `stage_config`. The yaml's runtime role is contracts (`consumes`/`produces`), not naming. |
| FR-5 | `lib/eva/lifecycle-sd-bridge.js` | Docstring-only: `'Stage 18 generates sd_bridge_payloads'` → `'Stage 19 (Sprint Planning) generates…'`. Behavior unchanged. |
| FR-6 | `scripts/generate-stage-config.cjs` | Extended `--check` with `assertCrossTableNameParity()` (exported via `module.exports._testHooks`). Fails CI on any future name divergence; names the offending `stage_number`(s). |
| FR-8 | `lib/eva/stage-templates/analysis-steps/README.md` | Documents the filename-vs-served-stage_number offset pattern (filenames preserved across the 2026-04-21 renumbering for `git blame` continuity). |

## Tests

- **New** (`tests/unit/eva/reconcile-venture-lifecycle.test.js`, 5 tests, all pass):
  - FR-2: StageRegistry overrides lifecycle name with stage_config name for S19
  - FR-2: Falls back to lifecycle name when stage_config unreachable
  - FR-6: Detects divergence and returns offending stage_number (TS-1)
  - FR-6: Returns empty array when names agree (TS-3 post-FR-1 state)
  - FR-6: INNER-join semantics — ignores stages present in only one table
- **Regression on touched files**: 52/52 PASS (`stage-registry.test.js` 19/19, `lifecycle-sd-bridge.test.js` 33/33).
- **Live DB smoke (FR-6)**: 0 divergent stages — confirmed by TESTING sub-agent direct-invoking `assertCrossTableNameParity` against prod DB post-FR-1 migration.

## Out of scope (separate work)

- **FR-7 cross-repo (EHG)**: `ehg/src/components/.../Stage21QualityAssurance.tsx` misnomer + duplicate `stage-20-*.js` / `stage-21-*.js` analysis-step files. Will ship as a separate PR against `rickfelix/ehg` per multi-repo hygiene (TR-3).

## Known pre-existing (NOT caused by this PR)

1. **`tests/unit/eva/stage-governance.test.js` 6 failures** — present on `main` HEAD before this branch. `lib/eva/stage-governance.js` is unmodified in this PR (`git diff main -- lib/eva/stage-governance.js` empty). To be filed as a separate QF.
2. **`node scripts/generate-stage-config.cjs --check` fails on the pre-existing `stage-config.js`-is-out-of-date check** (a file-vs-DB drift gate that lives BEFORE my new FR-6 parity check). Regenerating would touch 1,350+ lines of unrelated drift (NC-EXEC-001 scope creep). The FR-6 parity logic itself is proven via the 3 unit tests + live-DB direct invocation. TS-5 (full `--check` exit 0) deferred pending the file-drift QF.

## Risks & mitigation

- **Hidden consumer reads `lifecycle_stage_config.stage_name` directly** — grep for `'Build in Replit'` and `'Technical Architecture & Risk Register'` as string literals returned no consumer matches; any unfound consumer was already misaligned with frontend + `blueprint_sprint_plan` artifact.
- **Future re-drift** — FR-6 parity assertion catches divergence at CI time, naming the offending stage_number. Belt + suspenders with FR-2 routing readers to the name-authoritative table.

## Rollback

Migration includes header rollback SQL:
```sql
UPDATE lifecycle_stage_config SET stage_name = 'Technical Architecture & Risk Register' WHERE stage_number = 14;
UPDATE lifecycle_stage_config SET stage_name = 'Build in Replit' WHERE stage_number = 19;
```
Code changes are revertable via `git revert <this-commit>`.

## PR Size justification (~430 LOC)

Atomic SSOT reconciliation. Splitting would create intermediate states where the FR-6 parity assertion fails until both code (FR-2/FR-3) AND data (FR-1) are reconciled; tests (FR-2 + FR-6) depend on the assertion existing. Each individual FR is small (5–80 LOC); the aggregate reflects the cross-cutting nature of the bug.

## Evidence trail

- LEAD validation: `sub_agent_execution_results` row `e43cf843-00e0-42d2-8c98-8e57787a5d6d` (VALIDATION, PASS)
- PLAN arbitration: row `97ebe7d2-8f2b-4280-b25b-afb2d3f7a1a1` (DATABASE, PASS — the side-by-side dump + migration verdict)
- EXEC migration: row `5b3ad078-14e6-48bf-b2b0-90e47e8ed753` (DATABASE, PASS — 2 rows updated, idempotency verified)
- EXEC testing: row `20d7eca2-da9a-45bb-afa6-e3d4650513c1` (TESTING, PASS confidence 92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
