### PR TITLE
fix(QF-20260526-927): remove dead-weight claude_sessions.metadata.branch writer

### DIFF
--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -98,16 +98,10 @@ function getTerminalId() {
   return _getTerminalId();
 }
 
-/**
- * Get the current git branch
- */
-function getBranch() {
-  try {
-    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-  } catch {
-    return 'unknown';
-  }
-}
+// QF-20260526-927: getBranch() removed — its only consumer (the
+// `metadata.branch` write in getOrCreateSession) is gone. For live branch
+// resolution use lib/session-writer.cjs::resolveCurrentBranch / stampBranch,
+// which is what every heartbeat / claim-transition writer already uses.
 
 /**
  * Detect which codebase we're in
@@ -329,7 +323,6 @@ export async function getOrCreateSession() {
   const pid = _readCcPidFromMarker() || process.ppid || process.pid;
   const hostname = os.hostname();
   const codebase = getCodebase();
-  const branch = getBranch();
 
   // SD-LEO-INFRA-ISL-001: Get terminal identity components
   const machineId = getMachineId();
@@ -338,8 +331,14 @@ export async function getOrCreateSession() {
   // Get global defaults for new sessions
   const defaults = await getGlobalDefaults();
 
+  // QF-20260526-927: `metadata.branch` removed — it was written once at register
+  // and never updated, going stale on every branch switch (sd-start, QF-claim).
+  // The canonical current-branch source is the top-level `current_branch` column,
+  // kept fresh via lib/session-writer.cjs stampBranch() on heartbeats / claim
+  // transitions. Only consumer (scripts/modules/handoff/.../ship-review-findings-
+  // populator.js:25) reads SD metadata, not session metadata — so removing this
+  // is consumer-safe. See feedback row afa87fba.
   const metadata = {
-    branch,
     auto_proceed: defaults.auto_proceed,
     chain_orchestrators: defaults.chain_orchestrators
   };


### PR DESCRIPTION
Closes feedback `afa87fba-43a8-4fe8-95de-ba221f1f5541` — `claude_sessions.metadata.branch` writes go stale on every branch switch with no live reader to feed.

**Verified live**: 3 of the 20 most-recent sessions have divergent `metadata.branch` vs `current_branch` (including my own session, which started on `feat/SD-...` and is now on `qf/QF-...`).

**Consumer audit**: `grep -rn 'metadata.branch' lib/ scripts/` shows exactly ONE production reference — `scripts/modules/handoff/executors/lead-final-approval/hooks/ship-review-findings-populator.js:25`, which reads `sd?.metadata?.branch` on the SD record, **not** session metadata. Removing the writer is consumer-safe; existing stale values are harmless.

**Live branch resolution path**: all heartbeat / claim-transition writers already use `lib/session-writer.cjs::stampBranch()` which keeps the dedicated `current_branch` column fresh. The dead `metadata.branch` was duplicative.

**Bonus cleanup**: also removed the now-unused `getBranch()` helper (sole consumer was the removed line).

**LOC**: +11/-12 net -1, Tier-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)