### PR TITLE
fix(QF-20260526-975): resolve-feedback footer parser accepts Closes-feedback: variant

### DIFF
--- a/lib/governance/resolve-feedback.js
+++ b/lib/governance/resolve-feedback.js
@@ -25,8 +25,15 @@ const SHORT_ID_REGEX = /^[0-9a-f]{8}$/i;
 // boundary (not anchored to end-of-line) so a footer with trailing text on the same
 // line — e.g. "Closes feedback <uuid>. Shipped via QF-..." — still matches. "Closes"
 // must still be at line start (^ + /m), so this is a footer, not a mid-sentence match.
-const FOOTER_REGEX = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f-]{36})(?![0-9a-f-])/gim;
-const FOOTER_REGEX_LOOSE = /^[ \t]*Closes\s+(?:feedback|harness\s+backlog)\s+([0-9a-f][0-9a-f-]{7,35})(?![0-9a-f-])/gim;
+//
+// QF-20260526-975 / feedback in same session: also accept the hyphenated variant
+// "Closes-feedback: <uuid>" (and "Closes-harness-backlog: <uuid>"). 3 QFs in one
+// campaign sweep used that form and were classified WEAK by the reconciler. The
+// `[-\s]` token-separator covers space, hyphen, or mix. The trailing `[:\s]+`
+// allows optional colon before the UUID. Mid-sentence rejection still holds via
+// the line-start anchor.
+const FOOTER_REGEX = /^[ \t]*Closes[-\s]+(?:feedback|harness[-\s]+backlog)[:\s]+([0-9a-f-]{36})(?![0-9a-f-])/gim;
+const FOOTER_REGEX_LOOSE = /^[ \t]*Closes[-\s]+(?:feedback|harness[-\s]+backlog)[:\s]+([0-9a-f][0-9a-f-]{7,35})(?![0-9a-f-])/gim;
 
 /**
  * Parse "Closes feedback <uuid>" / "Closes harness backlog <uuid>" footers

--- a/tests/unit/governance/resolve-feedback.test.js
+++ b/tests/unit/governance/resolve-feedback.test.js
@@ -91,6 +91,27 @@ describe('parseFeedbackFooters', () => {
     const text = `closes Feedback ${VALID_UUID_1}\nCLOSES HARNESS BACKLOG ${VALID_UUID_2}\n`;
     expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1, VALID_UUID_2]);
   });
+
+  // QF-20260526-975: hyphenated + colon variants
+  it('accepts hyphenated "Closes-feedback: <uuid>" variant', () => {
+    const text = `body\n\nCloses-feedback: ${VALID_UUID_1}\n`;
+    expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
+  });
+
+  it('accepts "Closes-harness-backlog: <uuid>" variant', () => {
+    const text = `body\n\nCloses-harness-backlog: ${VALID_UUID_1}\n`;
+    expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
+  });
+
+  it('accepts no-space "Closes-feedback:<uuid>" (colon alone as separator)', () => {
+    const text = `body\n\nCloses-feedback:${VALID_UUID_1}\n`;
+    expect(parseFeedbackFooters(text)).toEqual([VALID_UUID_1]);
+  });
+
+  it('still rejects mid-sentence hyphenated reference (line-start anchor preserved)', () => {
+    const text = `something Closes-feedback: ${VALID_UUID_1} not at line start`;
+    expect(parseFeedbackFooters(text)).toEqual([]);
+  });
 });
 
 describe('resolveFeedback', () => {
@@ -274,8 +295,8 @@ describe('resolve-feedback.js static-pin', () => {
     expect(RESOLVE_FB_SRC).toMatch(/^const SHORT_ID_REGEX = \/\^\[0-9a-f\]\{8\}\$\/i;$/m);
   });
 
-  it('FOOTER_REGEX_LOOSE accepts 8-36 char hex-and-dash payloads with a non-hex boundary (QF-20260523-167: tolerates trailing text)', () => {
-    expect(RESOLVE_FB_SRC).toMatch(/^const FOOTER_REGEX_LOOSE = \/\^\[ \\t\]\*Closes\\s\+\(\?:feedback\|harness\\s\+backlog\)\\s\+\(\[0-9a-f\]\[0-9a-f-\]\{7,35\}\)\(\?!\[0-9a-f-\]\)\/gim;$/m);
+  it('FOOTER_REGEX_LOOSE accepts 8-36 char hex-and-dash payloads with a non-hex boundary (QF-20260523-167: tolerates trailing text; QF-20260526-975: hyphenated + colon variants)', () => {
+    expect(RESOLVE_FB_SRC).toMatch(/^const FOOTER_REGEX_LOOSE = \/\^\[ \\t\]\*Closes\[-\\s\]\+\(\?:feedback\|harness\[-\\s\]\+backlog\)\[:\\s\]\+\(\[0-9a-f\]\[0-9a-f-\]\{7,35\}\)\(\?!\[0-9a-f-\]\)\/gim;$/m);
   });
 
   it('UUID range bounds use canonical "0000-0000-0000-000000000000" / "ffff-ffff-ffff-ffffffffffff" tails', () => {


### PR DESCRIPTION
Reconciler-coverage improvement caught in flight during the same campaign sweep that filed it.

**Problem**: `FOOTER_REGEX` only accepted `Closes\s+feedback\s+<uuid>` (space-separated). 3 QFs in one sweep (PRs #3979/#3980/#3982) used `Closes-feedback: <uuid>` (hyphen-separator + colon) — the form that looks more like a header — and the reconciler classified all three as WEAK matches, requiring manual resolution.

**Fix**:
- `Closes[-\s]+feedback` (was: `Closes\s+feedback`)
- `harness[-\s]+backlog` (was: `harness\s+backlog`)
- `[:\s]+UUID` (was: `\s+UUID` — now allows optional colon)

Mid-sentence rejection preserved via the line-start anchor.

**Tests**: 4 new cases (Closes-feedback:, Closes-harness-backlog:, no-space colon-only, mid-sentence-rejection) + static-pin updated. 34/34 pass.

Closes-feedback: 63f8f194-d17d-4b6c-bd69-9b540d9553a5 (testing the new format!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)