### PR TITLE
fix(QF-20260526-436): add-prd-to-database --content shape pre-check (fail-fast)

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -99,6 +99,86 @@ export function loadContentPayload(rawValue) {
   return parsed;
 }
 
+/**
+ * QF-20260526-436: shape pre-check for --content payloads.
+ *
+ * loadContentPayload() catches JSON syntax errors (bracket-typos, trailing
+ * commas) and asserts the top-level is an object. Beyond that, payloads with
+ * the WRONG SHAPE — e.g. `integration_operationalization: []` (array instead
+ * of object), `functional_requirements: ['string']` (strings instead of
+ * objects), `risks: {}` (object instead of array) — pass loadContentPayload
+ * silently and burn full sub-agent orchestration before failing at the
+ * quality gate or quietly producing a malformed PRD row.
+ *
+ * This pure check enforces the PRD content contract used by scripts/prd/
+ * downstream code. Only validates the SHAPE / TYPE of keys when PRESENT —
+ * required-key enforcement and minimum-array-size enforcement remain in
+ * scripts/prd/quality-validator.js (which the orchestrator runs after sub-agent
+ * work).
+ *
+ * Throws Error with `code = 'CONTENT_SHAPE_VIOLATION'` and a multi-line
+ * message naming every offending key, so the user can fix them all in one
+ * edit instead of one-at-a-time discovery.
+ *
+ * @param {object} payload — already parsed JSON object (post loadContentPayload)
+ * @throws {Error} with code 'CONTENT_SHAPE_VIOLATION' if any key has the wrong type
+ */
+export function validateContentPayloadShape(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    const e = new Error(`--content: SHAPE_VIOLATION (top-level): expected object, got ${Array.isArray(payload) ? 'array' : payload === null ? 'null' : typeof payload}`);
+    e.code = 'CONTENT_SHAPE_VIOLATION';
+    throw e;
+  }
+  const errors = [];
+  const typeOf = (v) => Array.isArray(v) ? 'array' : v === null ? 'null' : typeof v;
+  const expectArray = (key) => {
+    if (!(key in payload)) return;
+    if (!Array.isArray(payload[key])) {
+      errors.push(`.${key}: expected array, got ${typeOf(payload[key])}`);
+    }
+  };
+  const expectObject = (key) => {
+    if (!(key in payload)) return;
+    const v = payload[key];
+    if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+      errors.push(`.${key}: expected object, got ${typeOf(v)}`);
+    }
+  };
+  const expectArrayOfObjects = (key) => {
+    if (!(key in payload)) return;
+    if (!Array.isArray(payload[key])) {
+      errors.push(`.${key}: expected array, got ${typeOf(payload[key])}`);
+      return;
+    }
+    payload[key].forEach((item, idx) => {
+      if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+        errors.push(`.${key}[${idx}]: expected object, got ${typeOf(item)}`);
+      }
+    });
+  };
+  // Array-of-object PRD fields (rubric requires per-item structure)
+  expectArrayOfObjects('functional_requirements');
+  expectArrayOfObjects('technical_requirements');
+  expectArrayOfObjects('test_scenarios');
+  expectArrayOfObjects('risks');
+  expectArrayOfObjects('smoke_test_steps');
+  // Loose-array fields (item shape varies; just enforce top-level type)
+  expectArray('acceptance_criteria');
+  expectArray('strategic_objectives');
+  expectArray('key_changes');
+  // Object fields (the integration_operationalization typo bit me directly here)
+  expectObject('integration_operationalization');
+  expectObject('metadata');
+  expectObject('system_architecture');
+  expectObject('implementation_approach');
+
+  if (errors.length > 0) {
+    const e = new Error(`--content: SHAPE_VIOLATIONS (${errors.length}):\n  - ${errors.join('\n  - ')}`);
+    e.code = 'CONTENT_SHAPE_VIOLATION';
+    throw e;
+  }
+}
+
 export function extractContentArg(args) {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -147,6 +227,9 @@ if (isMainModule(import.meta.url)) {
   if (contentValue !== undefined) {
     try {
       contentOverride = loadContentPayload(contentValue);
+      // QF-20260526-436: fail-fast shape pre-check BEFORE addPRDToDatabase()
+      // spends ~5 min on sub-agent orchestration on a malformed payload.
+      validateContentPayloadShape(contentOverride);
     } catch (e) {
       console.error(`\n❌ ${e.message}`);
       if (heartbeatActive) stopHeartbeat();

--- a/tests/unit/add-prd-content-arg-parser.test.js
+++ b/tests/unit/add-prd-content-arg-parser.test.js
@@ -15,6 +15,7 @@ import path from 'node:path';
 import {
   extractContentArg,
   loadContentPayload,
+  validateContentPayloadShape,
   CONTENT_PAYLOAD_MAX_BYTES
 } from '../../scripts/add-prd-to-database.js';
 
@@ -114,5 +115,78 @@ describe('loadContentPayload', () => {
 
   it('rejects empty file path (@)', () => {
     expect(() => loadContentPayload('@')).toThrow(/empty file path/);
+  });
+});
+
+// QF-20260526-436: fail-fast shape pre-check for --content payloads.
+describe('validateContentPayloadShape', () => {
+  it('accepts a fully-shaped PRD payload (all keys correct types)', () => {
+    const good = {
+      functional_requirements: [{ id: 'FR-1', requirement: 'X', acceptance_criteria: ['Y'] }],
+      technical_requirements: [{ id: 'TR-1', requirement: 'A', rationale: 'B' }],
+      test_scenarios: [{ id: 'TS-1', test_type: 'unit', scenario: 'S' }],
+      risks: [{ risk: 'R', mitigation: 'M' }],
+      smoke_test_steps: [{ step_number: 1, instruction: 'I', expected_outcome: 'O' }],
+      acceptance_criteria: ['AC-1'],
+      strategic_objectives: ['SO-1'],
+      key_changes: [{ change: 'C', impact: 'high' }],
+      integration_operationalization: { consumers: 'X', dependencies: [], data_contracts: 'Y', runtime_config: 'Z', observability_rollout: 'O' },
+      metadata: { evidence: 'ev-1' },
+      system_architecture: { overview: 'O' },
+      implementation_approach: { summary: 'S' }
+    };
+    expect(() => validateContentPayloadShape(good)).not.toThrow();
+  });
+
+  it('accepts an empty object (no keys to check)', () => {
+    expect(() => validateContentPayloadShape({})).not.toThrow();
+  });
+
+  it('rejects top-level non-object (array)', () => {
+    expect(() => validateContentPayloadShape([])).toThrow(/SHAPE_VIOLATION \(top-level\): expected object, got array/);
+  });
+
+  it('rejects top-level null', () => {
+    expect(() => validateContentPayloadShape(null)).toThrow(/SHAPE_VIOLATION \(top-level\): expected object, got null/);
+  });
+
+  it('catches the exact bug that bit me: integration_operationalization as array', () => {
+    const bad = { integration_operationalization: ['consumers', 'deps'] };
+    expect(() => validateContentPayloadShape(bad)).toThrow(/\.integration_operationalization: expected object, got array/);
+  });
+
+  it('catches functional_requirements as strings instead of objects', () => {
+    const bad = { functional_requirements: ['just a string', 'another'] };
+    expect(() => validateContentPayloadShape(bad)).toThrow(/\.functional_requirements\[0\]: expected object, got string/);
+  });
+
+  it('catches risks as object instead of array', () => {
+    const bad = { risks: { risk: 'R', mitigation: 'M' } };
+    expect(() => validateContentPayloadShape(bad)).toThrow(/\.risks: expected array, got object/);
+  });
+
+  it('reports ALL violations in one throw (multi-key fix-in-one-pass UX)', () => {
+    const bad = {
+      integration_operationalization: [],
+      risks: {},
+      functional_requirements: ['s'],
+    };
+    let err;
+    try { validateContentPayloadShape(bad); } catch (e) { err = e; }
+    expect(err).toBeDefined();
+    expect(err.code).toBe('CONTENT_SHAPE_VIOLATION');
+    expect(err.message).toMatch(/SHAPE_VIOLATIONS \(3\)/);
+    expect(err.message).toMatch(/\.integration_operationalization/);
+    expect(err.message).toMatch(/\.risks/);
+    expect(err.message).toMatch(/\.functional_requirements/);
+  });
+
+  it('absent keys are not validated (only checks shape when present)', () => {
+    expect(() => validateContentPayloadShape({ unrelated: 'key' })).not.toThrow();
+  });
+
+  it('null sub-value treated as wrong type (not as absent)', () => {
+    const bad = { metadata: null };
+    expect(() => validateContentPayloadShape(bad)).toThrow(/\.metadata: expected object, got null/);
   });
 });


### PR DESCRIPTION
Closes feedback `f812c0e5` — third (and last) of the retro-deferred items from SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001.

**Problem**: `loadContentPayload()` catches JSON syntax errors but does NOT validate the parsed object's SHAPE. Payloads with wrong types (`integration_operationalization` as array, FRs as strings, risks as object) pass and burn ~5 min of sub-agent orchestration before failing at the quality gate or producing a malformed PRD row.

The integration_operationalization-as-array bug bit me directly during the parent SD: a single bracket-typo (`],` instead of `},`) costing one 600s timeout + a retry.

**Fix**: `validateContentPayloadShape(payload)` — pure function called immediately after `loadContentPayload`:
- Validates type-only for PRESENT keys (does NOT enforce required-keys or min-array-sizes — by design, those remain post-orchestration)
- Reports ALL violations in one throw (multi-key fix-in-one-pass UX) with JSON path naming the offending key
- `error.code = 'CONTENT_SHAPE_VIOLATION'` for programmatic handling

**Coverage**: 12 PRD shape keys checked across 3 categories (array-of-objects: FRs, TRs, test_scenarios, risks, smoke_test_steps; objects: integration_operationalization, metadata, system_architecture, implementation_approach; loose arrays: acceptance_criteria, strategic_objectives, key_changes).

**Tests**: 10 new cases (24/24 total in file pass). Includes a test for the *exact* bug that filed this QF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)