### PR TITLE
feat(SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001): vision-scorer graceful failure + audit + report (de-scoped)

### DIFF
--- a/database/migrations/20260527_capa2_vision_readiness_blocked.sql
+++ b/database/migrations/20260527_capa2_vision_readiness_blocked.sql
@@ -1,0 +1,39 @@
+-- SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-2: vision_readiness_blocked audit table
+-- De-scoped from CAPA-2 after UNIFY-VENTURE-NON-001 overlap; covers consumer-layer graceful failure events.
+-- Captures every vision-scorer.js CONDITIONAL_PASS / human_review_floor_dims event so operators
+-- can see frequency and prioritize Stage-4 enrichment campaigns.
+
+CREATE TABLE IF NOT EXISTS vision_readiness_blocked (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  vision_key text NOT NULL,
+  venture_id uuid REFERENCES ventures(id) ON DELETE SET NULL,
+  blocked_at timestamptz NOT NULL DEFAULT now(),
+  reason text NOT NULL CHECK (reason IN (
+    'vision_not_found',
+    'vision_query_error',
+    'extracted_dimensions_null',
+    'content_too_short',
+    'status_inactive',
+    'level_below_minimum',
+    'venture_id_missing'
+  )),
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  mode text NOT NULL DEFAULT 'WARNING' CHECK (mode IN ('WARNING', 'BLOCKING')),
+  attempted_by text,
+  resolved_at timestamptz,
+  resolved_by text,
+  resolution_note text
+);
+
+COMMENT ON TABLE vision_readiness_blocked IS
+  'SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-2: audit log of every vision-scorer.js graceful-failure event (verdict=human_review_floor_dims with reason=vision_not_ready). Helper at lib/eva/audit-vision-readiness.js writes rows. 60s dedup window prevents audit storm. Complementary to SD-LEO-INFRA-UNIFY-VENTURE-NON-001 (which prevents NEW unready-doc generation at the writer layer); this audit tracks consumer-side graceful failures for the 56 LEGACY unready docs.';
+
+CREATE INDEX IF NOT EXISTS idx_vision_readiness_blocked_vision_key
+  ON vision_readiness_blocked (vision_key);
+
+CREATE INDEX IF NOT EXISTS idx_vision_readiness_blocked_blocked_at_desc
+  ON vision_readiness_blocked (blocked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vision_readiness_blocked_unresolved
+  ON vision_readiness_blocked (vision_key)
+  WHERE resolved_at IS NULL;

--- a/lib/eva/audit-vision-readiness.js
+++ b/lib/eva/audit-vision-readiness.js
@@ -1,0 +1,118 @@
+/**
+ * Vision readiness audit helper
+ *
+ * SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-2: writes a row to vision_readiness_blocked
+ * every time scripts/eva/vision-scorer.js short-circuits with a graceful-failure verdict
+ * (human_review_floor_dims / reason=vision_not_ready). Operators query the audit table to
+ * prioritize Stage-4 enrichment campaigns for the 56 legacy unready vision docs.
+ *
+ * 60-second dedup window prevents audit storm when scorer is invoked in tight loops
+ * (e.g., batch-rescore jobs against the same unready vision).
+ *
+ * Complementary to SD-LEO-INFRA-UNIFY-VENTURE-NON-001:
+ *   - UNIFY prevents NEW unready-doc generation at writer/bridge layers
+ *   - This audit tracks consumer-side graceful failures for the 56 LEGACY unready docs
+ *     that UNIFY does not retroactively repair
+ *
+ * @module lib/eva/audit-vision-readiness
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+// 60-second dedup window — collapses repeated audit writes for the same (vision_key, reason)
+const DEDUP_WINDOW_MS = 60 * 1000;
+
+// Module-scope dedup cache: Map<visionKey:reason, timestamp>
+const _dedupCache = new Map();
+
+/**
+ * Clear the dedup cache. For tests only.
+ */
+export function _clearDedupCache() {
+  _dedupCache.clear();
+}
+
+/**
+ * Reason taxonomy (must match vision_readiness_blocked.reason CHECK constraint)
+ */
+export const VISION_READINESS_REASONS = Object.freeze([
+  'vision_not_found',
+  'vision_query_error',
+  'extracted_dimensions_null',
+  'content_too_short',
+  'status_inactive',
+  'level_below_minimum',
+  'venture_id_missing',
+]);
+
+/**
+ * Write a vision_readiness_blocked audit row.
+ *
+ * @param {Object} args
+ * @param {string} args.visionKey - Required. The vision_key that failed readiness check.
+ * @param {string|null} [args.ventureId] - Optional venture UUID (FK SET NULL on venture delete).
+ * @param {string} args.reason - Required. One of VISION_READINESS_REASONS (CHECK-constrained).
+ * @param {Object} [args.evidence={}] - Optional jsonb snapshot of what was checked.
+ * @param {'WARNING'|'BLOCKING'} [args.mode='WARNING'] - Audit mode (CHECK-constrained).
+ * @param {string} [args.attemptedBy] - Optional caller identifier (sdKey, script name, etc.).
+ * @param {Object} [args.supabase] - Optional Supabase client; defaults to service client.
+ * @returns {Promise<{id: string|null, dedup: boolean, error?: string}>}
+ *   - {id, dedup:false} when a new row is inserted
+ *   - {id:null, dedup:true} when collapsed by 60s dedup window
+ *   - {id:null, dedup:false, error} when insert fails (caller may log; should NOT throw)
+ */
+export async function writeVisionReadinessBlocked({
+  visionKey,
+  ventureId = null,
+  reason,
+  evidence = {},
+  mode = 'WARNING',
+  attemptedBy = null,
+  supabase: supabaseOverride,
+} = {}) {
+  if (!visionKey) {
+    return { id: null, dedup: false, error: 'visionKey is required' };
+  }
+  if (!reason || !VISION_READINESS_REASONS.includes(reason)) {
+    return {
+      id: null,
+      dedup: false,
+      error: `reason must be one of: ${VISION_READINESS_REASONS.join(', ')}; got: ${reason}`,
+    };
+  }
+
+  // Dedup check: same (vision_key, reason) within 60s window → collapse
+  const dedupKey = `${visionKey}:${reason}`;
+  const now = Date.now();
+  const lastWrite = _dedupCache.get(dedupKey);
+  if (lastWrite && now - lastWrite < DEDUP_WINDOW_MS) {
+    return { id: null, dedup: true };
+  }
+
+  const supabase = supabaseOverride || createSupabaseServiceClient();
+
+  try {
+    const { data, error } = await supabase
+      .from('vision_readiness_blocked')
+      .insert({
+        vision_key: visionKey,
+        venture_id: ventureId,
+        reason,
+        evidence,
+        mode,
+        attempted_by: attemptedBy,
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      return { id: null, dedup: false, error: error.message };
+    }
+
+    // Update dedup cache only on successful insert
+    _dedupCache.set(dedupKey, now);
+    return { id: data.id, dedup: false };
+  } catch (err) {
+    return { id: null, dedup: false, error: err.message };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
     "git:recover": "node scripts/git-commit-recovery.js",
     "lead:dossier": "node scripts/lead-dossier.js",
     "doc:audit": "node scripts/eva/doc-health-audit.mjs",
+    "vision:readiness:report": "node scripts/eva/vision-readiness-report.mjs",
     "story:template": "node scripts/story-requirements-template.js",
     "sd:next": "node scripts/sd-next.js",
     "sd:cancel": "node scripts/cancel-sd.js",

--- a/scripts/eva/vision-readiness-report.mjs
+++ b/scripts/eva/vision-readiness-report.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Vision Readiness Report (read-only diagnostic)
+ *
+ * SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-3: single-statement remediation queue
+ * for the ~56 unready eva_vision_documents rows. Produces JSON + console table that
+ * operators use to prioritize Stage-4 enrichment campaigns. Never writes — purely
+ * diagnostic.
+ *
+ * Output: console table + JSON artifact at .rca/vision-readiness-report-<timestamp>.json
+ *
+ * Usage:
+ *   node scripts/eva/vision-readiness-report.mjs
+ *   npm run vision:readiness:report
+ *
+ * recommended_action enum:
+ *   STUB_DELETE_OR_REGENERATE — status=draft_seed OR content length < 100 chars
+ *   EXPAND_CONTENT             — content length 100-500 (has substance but below readiness threshold)
+ *   RUN_DIMENSION_EXTRACTOR    — content length > 500 but extracted_dimensions IS NULL
+ */
+
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+
+  // Fetch ALL eva_vision_documents (single query); filter readiness in JS
+  // because Postgrest doesn't support length()-on-text in .or() clause cleanly.
+  // Readiness predicate (per design-agent): extracted_dimensions IS NOT NULL
+  // AND char_length(content) > 500 AND status='active'.
+  // Unready = NOT(readiness predicate) — captured by per-row filter below.
+  const { data: unreadyDocs, error } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, venture_id, level, status, content, extracted_dimensions');
+
+  if (error) {
+    console.error('[vision-readiness-report] query failed:', error.message);
+    process.exit(1);
+  }
+
+  // Compute readiness flags + recommended_action per row
+  const enriched = (unreadyDocs || [])
+    .map((row) => {
+      const contentLength = typeof row.content === 'string' ? row.content.length : 0;
+      const hasExtractedDimensions = Array.isArray(row.extracted_dimensions) && row.extracted_dimensions.length > 0;
+      const isUnready = !hasExtractedDimensions || contentLength <= 500 || row.status === 'draft_seed';
+      if (!isUnready) return null;
+
+      let recommended_action;
+      if (row.status === 'draft_seed' || contentLength < 100) {
+        recommended_action = 'STUB_DELETE_OR_REGENERATE';
+      } else if (contentLength <= 500) {
+        recommended_action = 'EXPAND_CONTENT';
+      } else {
+        recommended_action = 'RUN_DIMENSION_EXTRACTOR';
+      }
+
+      return {
+        vision_key: row.vision_key,
+        venture_id: row.venture_id,
+        level: row.level,
+        status: row.status,
+        content_length: contentLength,
+        missing_dimensions: !hasExtractedDimensions,
+        recommended_action,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => {
+      if (a.recommended_action !== b.recommended_action) {
+        return a.recommended_action.localeCompare(b.recommended_action);
+      }
+      return String(a.venture_id || '').localeCompare(String(b.venture_id || ''));
+    });
+
+  // Summary by recommended_action
+  const summary = enriched.reduce((acc, r) => {
+    acc[r.recommended_action] = (acc[r.recommended_action] || 0) + 1;
+    return acc;
+  }, {});
+
+  console.log('\n=== Vision Readiness Report ===');
+  console.log(`Total unready docs: ${enriched.length}`);
+  console.log('Breakdown by recommended_action:');
+  for (const [action, count] of Object.entries(summary)) {
+    console.log(`  ${action.padEnd(30)} ${count}`);
+  }
+  console.log('');
+
+  // Console table (limit to first 20 for readability)
+  if (enriched.length > 0) {
+    const preview = enriched.slice(0, 20);
+    console.table(preview.map((r) => ({
+      vision_key: r.vision_key,
+      level: r.level,
+      status: r.status,
+      length: r.content_length,
+      missing_dims: r.missing_dimensions,
+      action: r.recommended_action,
+    })));
+    if (enriched.length > 20) {
+      console.log(`... ${enriched.length - 20} more rows in JSON artifact`);
+    }
+  }
+
+  // Write JSON artifact
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const artifactDir = path.join(REPO_ROOT, '.rca');
+  await fs.mkdir(artifactDir, { recursive: true });
+  const artifactPath = path.join(artifactDir, `vision-readiness-report-${timestamp}.json`);
+  await fs.writeFile(artifactPath, JSON.stringify({
+    generated_at: new Date().toISOString(),
+    sd_reference: 'SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001',
+    total_unready: enriched.length,
+    summary,
+    rows: enriched,
+  }, null, 2), 'utf8');
+
+  console.log(`\nJSON artifact: ${artifactPath}`);
+  console.log('Report complete. No DB writes performed (read-only diagnostic).');
+}
+
+main().catch((err) => {
+  console.error('[vision-readiness-report] fatal:', err.message);
+  process.exit(1);
+});

--- a/scripts/eva/vision-scorer.js
+++ b/scripts/eva/vision-scorer.js
@@ -48,9 +48,15 @@ const THRESHOLDS = {
 
 /**
  * Load Vision dimensions from eva_vision_documents.
+ *
+ * SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-1: graceful failure instead of throw.
+ * Returns {notReady: true, reason} for unready visions so scoreSD can short-circuit
+ * with verdict-shaped response (human_review_floor_dims) and emit audit row.
+ * Callers needing throw-behavior should set options.strictVisionReadiness=true on scoreSD.
+ *
  * @param {Object} supabase
  * @param {string} visionKey - e.g. 'VISION-EHG-L1-001'
- * @returns {Promise<{id: string, dimensions: Array}>}
+ * @returns {Promise<{id: string|null, dimensions: Array, qualityChecked: boolean|null, qualityIssues: any, notReady?: boolean, reason?: string, ventureId?: string|null}>}
  */
 async function loadVisionDimensions(supabase, visionKey) {
   // SD-FDBK-INFRA-EVA-VISION-DOCUMENTS-001 (Option A NARROWED, FR-1):
@@ -58,17 +64,35 @@ async function loadVisionDimensions(supabase, visionKey) {
   // emit an operator-CLI warning when qc=false. No enforcement, no skip.
   const { data, error } = await supabase
     .from('eva_vision_documents')
-    .select('id, vision_key, extracted_dimensions, status, quality_checked, quality_issues')
+    .select('id, vision_key, extracted_dimensions, status, quality_checked, quality_issues, venture_id')
     .eq('vision_key', visionKey)
     .limit(1)
     .single();
 
+  // SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-1: graceful failure (was throw)
   if (error || !data) {
-    throw new Error(`Vision document not found: ${visionKey} (${error?.message || 'no rows'})`);
+    return {
+      id: null,
+      dimensions: [],
+      qualityChecked: null,
+      qualityIssues: null,
+      notReady: true,
+      reason: 'vision_not_found',
+      ventureId: null,
+      errorMessage: error?.message || 'no rows',
+    };
   }
 
   if (!data.extracted_dimensions?.length) {
-    throw new Error(`Vision ${visionKey} has no extracted_dimensions`);
+    return {
+      id: data.id,
+      dimensions: [],
+      qualityChecked: data.quality_checked ?? null,
+      qualityIssues: data.quality_issues ?? null,
+      notReady: true,
+      reason: 'extracted_dimensions_null',
+      ventureId: data.venture_id ?? null,
+    };
   }
 
   return {
@@ -76,6 +100,7 @@ async function loadVisionDimensions(supabase, visionKey) {
     dimensions: data.extracted_dimensions,
     qualityChecked: data.quality_checked ?? null,
     qualityIssues: data.quality_issues ?? null,
+    ventureId: data.venture_id ?? null,
   };
 }
 
@@ -384,6 +409,7 @@ export async function scoreSD(options = {}) {
   } = options;
 
   const supabase = supabaseOverride || createSupabaseServiceClient();
+  const strictVisionReadiness = options.strictVisionReadiness === true;
 
   // Register vision event handlers (idempotent — safe to call on every scoreSD() invocation).
   // Handlers are subscribed here so they are always registered before vision.scored is published,
@@ -395,6 +421,44 @@ export async function scoreSD(options = {}) {
     loadVisionDimensions(supabase, visionKey),
     loadArchDimensions(supabase, archKey),
   ]);
+
+  // SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 FR-1+FR-2: vision graceful-failure short-circuit.
+  // loadVisionDimensions now returns notReady=true instead of throwing for unready docs (56/272
+  // baseline). Strict mode (options.strictVisionReadiness=true) preserves the original throw for
+  // callers that need it. Default mode: return verdict-shaped response with human_review_floor_dims
+  // (existing GATE_VISION_SCORE vocabulary; no new enum needed) + write audit row to
+  // vision_readiness_blocked so operators can prioritize Stage-4 enrichment campaigns.
+  if (visionResult.notReady) {
+    if (strictVisionReadiness) {
+      // Backward-compat: throw original error shape
+      if (visionResult.reason === 'vision_not_found') {
+        throw new Error(`Vision document not found: ${visionKey} (${visionResult.errorMessage})`);
+      }
+      throw new Error(`Vision ${visionKey} has no extracted_dimensions`);
+    }
+    // Default mode: graceful failure + audit
+    const { writeVisionReadinessBlocked } = await import('../../lib/eva/audit-vision-readiness.js');
+    await writeVisionReadinessBlocked({
+      visionKey,
+      ventureId: visionResult.ventureId,
+      reason: visionResult.reason,
+      evidence: { vision_key: visionKey, extracted_dimensions: null, error_message: visionResult.errorMessage },
+      mode: 'WARNING',
+      attemptedBy: sdKey || 'unknown',
+      supabase,
+    }).catch((auditErr) => {
+      // Audit failure must NOT crash scoreSD — log and continue
+      console.warn(`[VisionScorer] audit write failed (non-fatal): ${auditErr.message}`);
+    });
+    console.log(`[VisionScorer] vision_not_ready (${visionResult.reason}) for ${visionKey}; returning human_review_floor_dims verdict`);
+    return {
+      verdict: 'human_review_floor_dims',
+      confidence: 60,
+      totalScore: null,
+      reason: 'vision_not_ready',
+      evidence: { vision_key: visionKey, vision_reason: visionResult.reason, extracted_dimensions: null },
+    };
+  }
 
   // SD-FDBK-INFRA-EVA-VISION-DOCUMENTS-001 (Option A NARROWED, FR-3 + FR-4):
   // emit at most one operator-CLI warning per scoreSD() invocation when either

--- a/tests/unit/audit-vision-readiness.test.js
+++ b/tests/unit/audit-vision-readiness.test.js
@@ -1,0 +1,163 @@
+/**
+ * SD-LEO-INFRA-VISION-DOCUMENT-READINESS-001 — unit tests for lib/eva/audit-vision-readiness.js
+ *
+ * Validates:
+ *  - 60s dedup window collapses repeat writes
+ *  - reason CHECK enum enforced at helper layer (defense-in-depth before DB)
+ *  - Missing visionKey rejected
+ *  - Insert failure does NOT throw (returns {error} for caller-side logging)
+ *  - Successful insert returns {id, dedup:false}
+ *  - Dedup cache cleared via _clearDedupCache for test isolation
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  writeVisionReadinessBlocked,
+  _clearDedupCache,
+  VISION_READINESS_REASONS,
+} from '../../lib/eva/audit-vision-readiness.js';
+
+// Mock supabase client (in-memory; no real DB writes in unit test)
+function makeMockSupabase({ shouldFail = false, errorMessage = 'mock error' } = {}) {
+  return {
+    from(_table) {
+      return {
+        insert(_row) {
+          return {
+            select(_cols) {
+              return {
+                single() {
+                  if (shouldFail) {
+                    return Promise.resolve({ data: null, error: { message: errorMessage } });
+                  }
+                  return Promise.resolve({
+                    data: { id: 'mock-uuid-' + Math.random().toString(36).slice(2, 10) },
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('writeVisionReadinessBlocked', () => {
+  beforeEach(() => _clearDedupCache());
+
+  it('inserts a row and returns {id, dedup:false} on success', async () => {
+    const supabase = makeMockSupabase();
+    const result = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-TEST-L2-001',
+      reason: 'extracted_dimensions_null',
+      supabase,
+    });
+    expect(result.id).toMatch(/^mock-uuid-/);
+    expect(result.dedup).toBe(false);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects missing visionKey (returns error, no throw)', async () => {
+    const result = await writeVisionReadinessBlocked({
+      reason: 'extracted_dimensions_null',
+    });
+    expect(result.id).toBeNull();
+    expect(result.error).toBe('visionKey is required');
+  });
+
+  it('rejects reason not in CHECK enum', async () => {
+    const result = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-TEST-L2-001',
+      reason: 'invalid_reason',
+    });
+    expect(result.id).toBeNull();
+    expect(result.error).toContain('reason must be one of');
+  });
+
+  it('collapses repeat writes within 60s dedup window', async () => {
+    const supabase = makeMockSupabase();
+    const first = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-DEDUP-L2-001',
+      reason: 'vision_not_found',
+      supabase,
+    });
+    expect(first.dedup).toBe(false);
+    expect(first.id).toMatch(/^mock-uuid-/);
+
+    const second = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-DEDUP-L2-001',
+      reason: 'vision_not_found',
+      supabase,
+    });
+    expect(second.dedup).toBe(true);
+    expect(second.id).toBeNull();
+  });
+
+  it('different reasons for same vision_key bypass dedup', async () => {
+    const supabase = makeMockSupabase();
+    const first = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-MULTI-L2-001',
+      reason: 'vision_not_found',
+      supabase,
+    });
+    const second = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-MULTI-L2-001',
+      reason: 'extracted_dimensions_null',
+      supabase,
+    });
+    expect(first.dedup).toBe(false);
+    expect(second.dedup).toBe(false);
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it('does NOT throw when insert fails (returns {error} for caller logging)', async () => {
+    const supabase = makeMockSupabase({ shouldFail: true, errorMessage: 'simulated FK violation' });
+    const result = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-FAIL-L2-001',
+      reason: 'extracted_dimensions_null',
+      supabase,
+    });
+    expect(result.id).toBeNull();
+    expect(result.dedup).toBe(false);
+    expect(result.error).toBe('simulated FK violation');
+  });
+
+  it('does NOT update dedup cache when insert fails', async () => {
+    const failingSupabase = makeMockSupabase({ shouldFail: true });
+    await writeVisionReadinessBlocked({
+      visionKey: 'VISION-RETRY-L2-001',
+      reason: 'vision_not_found',
+      supabase: failingSupabase,
+    });
+
+    // Retry with working supabase — should NOT be deduped because previous failed
+    const workingSupabase = makeMockSupabase();
+    const retry = await writeVisionReadinessBlocked({
+      visionKey: 'VISION-RETRY-L2-001',
+      reason: 'vision_not_found',
+      supabase: workingSupabase,
+    });
+    expect(retry.dedup).toBe(false);
+    expect(retry.id).toMatch(/^mock-uuid-/);
+  });
+});
+
+describe('VISION_READINESS_REASONS enum', () => {
+  it('exports the 7 documented reason values', () => {
+    expect(VISION_READINESS_REASONS).toEqual([
+      'vision_not_found',
+      'vision_query_error',
+      'extracted_dimensions_null',
+      'content_too_short',
+      'status_inactive',
+      'level_below_minimum',
+      'venture_id_missing',
+    ]);
+  });
+
+  it('enum is frozen (immutable)', () => {
+    expect(Object.isFrozen(VISION_READINESS_REASONS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

De-scoped CAPA-2 after validation-agent surfaced material overlap with in-progress SD-LEO-INFRA-UNIFY-VENTURE-NON-001. Ships THREE non-overlapping consumer-layer FRs for vision readiness.

UNIFY-VENTURE-NON-001 covers writer/storage/bridge layers; this SD provides graceful degradation at the LEAD-TO-PLAN gate for the 57 LEGACY unready vision docs that UNIFY does not retroactively repair.

**10th witness** of PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.

## What ships

- **FR-1** `scripts/eva/vision-scorer.js` graceful failure — loadVisionDimensions returns notReady-shaped object instead of throwing at L67 (vision not found) / L71 (no extracted_dimensions). scoreSD detects notReady, writes audit row, returns verdict='human_review_floor_dims' (existing GATE_VISION_SCORE vocabulary; zero new enum values needed). Backward compat: options.strictVisionReadiness=true preserves throw.
- **FR-2** `vision_readiness_blocked` audit table (11 cols, 3 indexes, FK to ventures ON DELETE SET NULL, 7-value reason CHECK, mode CHECK, resolution tracking) + `lib/eva/audit-vision-readiness.js` helper with 60s dedup window. Helper does NOT throw on insert failure (returns {error} for caller-side logging).
- **FR-3** `scripts/eva/vision-readiness-report.mjs` + `npm run vision:readiness:report` — read-only diagnostic CLI producing JSON + console table of unready docs with recommended_action enum (STUB_DELETE_OR_REGENERATE / EXPAND_CONTENT / RUN_DIMENSION_EXTRACTOR). Live verification: **57 unready docs found** (matches 56 baseline ±5).

## Test plan

- [x] `npx vitest run tests/unit/audit-vision-readiness.test.js` — 9/9 pass (202ms)
- [x] vision-scorer.js smoke-import clean
- [x] audit helper smoke-import clean (exports writeVisionReadinessBlocked + 7-reason frozen enum)
- [x] `npm run vision:readiness:report` succeeds against live DB, JSON artifact written
- [x] LEAD-TO-PLAN @ 96 / PLAN-TO-EXEC @ 94 / EXEC-TO-PLAN @ 88 / PLAN-TO-LEAD @ 95

## Out of scope (covered by UNIFY-VENTURE-NON-001)

- isVisionReady predicate function (UNIFY storage CHECK constraint covers)
- lifecycle-sd-bridge ServiceError refusal (UNIFY Child C)
- Stub-writer excision at eva-orchestrator.js:183-191 (UNIFY Child B.2)
- Archive 10 stub L2 docs to status='draft_seed' (UNIFY Child B.1)
- Unique partial index on (venture_id, level) (already shipped earlier as `eva_vision_documents_venture_level_active_uniq`)

## Companion SDs

- SD-LEO-INFRA-UNIFY-VENTURE-NON-001 (in_progress EXEC) — writer/storage/bridge layers
- SD-LEO-INFRA-FLEET-WIDE-SUB-001 (COMPLETED, PR #3988) — fleet sub-agent cross-repo resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)