### PR TITLE
fix(QF-20260527-250): create-quick-fix.js: add dedup check before INSERT (prevent same-feedback duplicates)

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -203,8 +203,8 @@ async function createQuickFix(options = {}) {
           console.error(`     ${qf.id} (${qf.status}): ${(qf.title || '').slice(0, 80)}`);
         }
         if (!options.allowDuplicate) {
-          console.error(`   Inspect: node scripts/read-quick-fix.js <id>`);
-          console.error(`   Override (audited): --allow-duplicate "<reason>"`);
+          console.error('   Inspect: node scripts/read-quick-fix.js <id>');
+          console.error('   Override (audited): --allow-duplicate "<reason>"');
           process.exit(1);
         }
         console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);
@@ -224,7 +224,7 @@ async function createQuickFix(options = {}) {
           console.error(`     ${qf.id} (${qf.created_at}): ${(qf.title || '').slice(0, 80)}`);
         }
         if (!options.allowDuplicate) {
-          console.error(`   Override (audited): --allow-duplicate "<reason>"`);
+          console.error('   Override (audited): --allow-duplicate "<reason>"');
           process.exit(1);
         }
         console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -176,6 +176,62 @@ async function createQuickFix(options = {}) {
     // EVA pre-check is non-blocking — continue even if it fails
   }
 
+  // QF-20260527-250: pre-INSERT dedup gate. QF-20260526-885 + QF-20260526-106
+  // were created 89s apart by UAT_AGENT for the same feedback symptom
+  // (b06e04f8) because nothing here checks for existing open QFs. HARD gate
+  // runs when --feedback-id is supplied; SOFT title-prefix gate when not.
+  // The override --allow-duplicate "<reason>" preserves audited escape.
+  let resolvedFeedbackIds = null;
+  if (options.feedbackId) {
+    try {
+      resolvedFeedbackIds = await resolveFeedbackIds(supabase, options.feedbackId);
+    } catch (e) {
+      console.error(`\n❌ [${e.code || 'FEEDBACK_ID_ERROR'}] ${e.message}`);
+      process.exit(1);
+    }
+    const { data: linkedFb } = await supabase
+      .from('feedback').select('id, quick_fix_id')
+      .in('id', resolvedFeedbackIds).not('quick_fix_id', 'is', null);
+    const linkedQfIds = [...new Set((linkedFb || []).map(r => r.quick_fix_id))];
+    if (linkedQfIds.length > 0) {
+      const { data: openRivals } = await supabase
+        .from('quick_fixes').select('id, status, title')
+        .in('id', linkedQfIds).in('status', ['open', 'in_progress']);
+      if (openRivals && openRivals.length > 0) {
+        console.error(`\n❌ [DUPLICATE_QF] feedback already claimed by ${openRivals.length} open QF(s):`);
+        for (const qf of openRivals) {
+          console.error(`     ${qf.id} (${qf.status}): ${(qf.title || '').slice(0, 80)}`);
+        }
+        if (!options.allowDuplicate) {
+          console.error(`   Inspect: node scripts/read-quick-fix.js <id>`);
+          console.error(`   Override (audited): --allow-duplicate "<reason>"`);
+          process.exit(1);
+        }
+        console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);
+      }
+    }
+  } else {
+    const prefix = (title || '').toLowerCase().slice(0, 40);
+    if (prefix.length >= 10) {
+      const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const { data: similar } = await supabase
+        .from('quick_fixes').select('id, title, created_at')
+        .eq('status', 'open').gte('created_at', since)
+        .ilike('title', `${prefix}%`);
+      if (similar && similar.length > 0) {
+        console.error(`\n⚠️  [POSSIBLE_DUPLICATE_QF] ${similar.length} similar open QF(s) created in last 60 min:`);
+        for (const qf of similar) {
+          console.error(`     ${qf.id} (${qf.created_at}): ${(qf.title || '').slice(0, 80)}`);
+        }
+        if (!options.allowDuplicate) {
+          console.error(`   Override (audited): --allow-duplicate "<reason>"`);
+          process.exit(1);
+        }
+        console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);
+      }
+    }
+  }
+
   // Generate ID
   const qfId = generateQuickFixId();
 
@@ -227,13 +283,8 @@ async function createQuickFix(options = {}) {
   // Skipped when --feedback-id omitted (full backward-compatibility).
   if (options.feedbackId) {
     const creatorSessionId = process.env.CLAUDE_SESSION_ID || null;
-    let resolvedIds;
-    try {
-      resolvedIds = await resolveFeedbackIds(supabase, options.feedbackId);
-    } catch (e) {
-      console.error(`\n❌ [${e.code || 'FEEDBACK_ID_ERROR'}] ${e.message}`);
-      process.exit(1);
-    }
+    // QF-20260527-250: feedback IDs already resolved by the dedup gate above.
+    const resolvedIds = resolvedFeedbackIds;
     const { claimed, conflicts } = await preclaimFeedbackRows({
       supabase, feedbackIds: resolvedIds, pendingQfId: qfId, sessionId: creatorSessionId,
     });
@@ -517,6 +568,13 @@ for (let i = 0; i < args.length; i++) {
     options.forceClaim = true;
   } else if (arg === '--force-claim-reason' || arg === '--reason') {
     options.forceClaimReason = args[++i];
+  } else if (arg === '--allow-duplicate') {
+    // QF-20260527-250: audited override for dedup gate.
+    options.allowDuplicate = args[++i];
+    if (!options.allowDuplicate || !String(options.allowDuplicate).trim()) {
+      console.error(`❌ --allow-duplicate requires a non-empty reason`);
+      process.exit(1);
+    }
   } else if (arg === '--help' || arg === '-h') {
     console.log(`
 LEO Quick-Fix Workflow - Create Issue
@@ -536,6 +594,7 @@ Options:
   --actual               Actual behavior
   --estimated-loc        Estimated lines of code (default: 10)
   --target-application   Target repo: 'EHG' or 'EHG_Engineer' (auto-detected from cwd)
+  --allow-duplicate      Audited override for dedup gate; requires non-empty <reason>
   --help, -h             Show this help
 
 Examples:

--- a/tests/unit/feedback/create-quick-fix-dedup-gate.test.js
+++ b/tests/unit/feedback/create-quick-fix-dedup-gate.test.js
@@ -1,0 +1,65 @@
+// QF-20260527-250: prevent regression of the missing pre-INSERT dedup gate.
+//
+// QF-20260526-885 + QF-20260526-106 were created 89s apart by UAT_AGENT for
+// the same feedback symptom (b06e04f8) because scripts/create-quick-fix.js
+// had no dedup check before the .from('quick_fixes').insert() call.
+//
+// Static-pattern assertions (same convention as create-quick-fix-insert-order
+// .test.js): inspect source ordering without running the script, which would
+// require mocking the full Supabase + worktree-manager + audit_log chain.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/create-quick-fix.js');
+
+describe('QF-20260527-250: create-quick-fix.js dedup gate runs before INSERT', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  const QF_INSERT_RE = /\.from\(\s*['"]quick_fixes['"]\s*\)\s*\r?\n?\s*\.insert\(/;
+  const HARD_GATE_RE = /\[DUPLICATE_QF\]\s+feedback already claimed/;
+  const SOFT_GATE_RE = /\[POSSIBLE_DUPLICATE_QF\]/;
+  const ALLOW_DUP_FLAG_RE = /arg\s*===\s*['"]--allow-duplicate['"]/;
+  const ALLOW_DUP_USAGE_RE = /options\.allowDuplicate/;
+
+  it('hard-gate marker [DUPLICATE_QF] is present and precedes the quick_fixes insert', () => {
+    const gateM = code.match(HARD_GATE_RE);
+    const insertM = code.match(QF_INSERT_RE);
+    expect(gateM?.index).toBeGreaterThanOrEqual(0);
+    expect(insertM?.index).toBeGreaterThanOrEqual(0);
+    expect(gateM.index).toBeLessThan(insertM.index);
+  });
+
+  it('soft-gate marker [POSSIBLE_DUPLICATE_QF] is present and precedes the quick_fixes insert', () => {
+    const gateM = code.match(SOFT_GATE_RE);
+    const insertM = code.match(QF_INSERT_RE);
+    expect(gateM?.index).toBeGreaterThanOrEqual(0);
+    expect(gateM.index).toBeLessThan(insertM.index);
+  });
+
+  it('--allow-duplicate argv flag is parsed and requires a non-empty reason', () => {
+    expect(code).toMatch(ALLOW_DUP_FLAG_RE);
+    expect(code).toMatch(ALLOW_DUP_USAGE_RE);
+    // The argv parser must reject empty reason. Matches String(...).trim() guard.
+    expect(code).toMatch(/--allow-duplicate requires a non-empty reason/);
+  });
+
+  it('soft gate is guarded by a created_at window (60 minute lookback)', () => {
+    // Prevents the soft gate from being a forever-blocker on any title-prefix collision.
+    expect(code).toMatch(/60\s*\*\s*60\s*\*\s*1000/);
+  });
+
+  it('soft gate uses ilike for case-insensitive title-prefix match', () => {
+    expect(code).toMatch(/\.ilike\(\s*['"]title['"]/);
+  });
+
+  it('preclaim block re-uses the dedup-gate-resolved feedback IDs (no double resolve)', () => {
+    // The pre-resolution above the gate is the single resolveFeedbackIds call site;
+    // the preclaim block should reference resolvedFeedbackIds, not call again.
+    const resolveCalls = code.match(/await\s+resolveFeedbackIds\s*\(/g) || [];
+    expect(resolveCalls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260527-250

**Type:** bug
**Severity:** medium

### Issue Description
create-quick-fix.js INSERTs new quick_fixes rows with no dedup check. Witness: QF-20260526-885 and QF-20260526-106 created 89s apart by UAT_AGENT for feedback b06e04f8 (the FK-violation symptom). QF-885 stranded (no feedback link, no PR); QF-106 got the link and shipped as PR #3972. Grep across scripts/create-quick-fix.js and lib/feedback/ returns zero matches for dedup/duplicate logic. classify-quick-fix.js detects similarity but threshold is 4+ and runs post-creation. Proposed fix at scripts/create-quick-fix.js ~L200 (right before the INSERT block): (1) HARD gate when --feedback-id supplied: SELECT quick_fixes joined via feedback.quick_fix_id WHERE status IN (open,in_progress) for resolved feedbackIds; abort with [DUPLICATE_QF] feedback already claimed by <existing-qf-id>. (2) SOFT gate when --feedback-id absent: SELECT quick_fixes WHERE status=open AND created_at >= now()-60min AND lower(title) LIKE <prefix>%; abort with [POSSIBLE_DUPLICATE_QF] unless --allow-duplicate <reason> override is passed. (3) Add --allow-duplicate <reason> flag (require non-empty reason, mirror --force-claim-reason pattern). (4) Add static test asserting dedup SELECT runs before INSERT. Affected files: scripts/create-quick-fix.js plus regression test. Est LOC: source ~40 + test ~20 = 60.

### Steps to Reproduce
1. Run node scripts/create-quick-fix.js --feedback-id <id> twice in quick succession (or two UAT_AGENT callers race). 2. Observe two quick_fixes rows created for the same logical issue.

### Expected Behavior
Second call detects existing open QF and aborts with [DUPLICATE_QF] error pointing at existing QF ID.

### Actual Behavior
Second call blindly INSERTs another quick_fixes row; one of the two becomes orphaned (no feedback link, no PR).

### Changes
- **Files Changed:** 2
  - scripts/create-quick-fix.js
  - tests/unit/feedback/create-quick-fix-dedup-gate.test.js
- **LOC:** 138 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Static-pattern regression tests pass (10/10 incl 6 new + 4 prior QF-106 guards). Dedup gate verified to precede .from('quick_fixes').insert via regex assertion. resolveFeedbackIds call collapsed to single site (no double-resolve). --allow-duplicate flag parsed with empty-reason guard.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol