### PR TITLE
fix(QF-20260526-279): Sweep STALE/DEAD render uses inverse-negation not CLAIM_HOLDING_STATUSES (L1385 — 7th writer-consumer-asymmetry witness)

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1381,8 +1381,11 @@ async function main() {
   });
   console.log('');
 
-  // Stale sessions (exclude ALIVE_NO_HEARTBEAT — shown above with active workers)
-  const stale = classified.filter(s => s.status !== 'ACTIVE' && s.status !== 'ALIVE_NO_HEARTBEAT');
+  // QF-20260526-279: route through CLAIM_HOLDING_STATUSES so STALE/DEAD render
+  // matches the ACTIVE WORKERS filter at L1157. The prior inverse-negation
+  // missed ALIVE_SOURCE_SIDE — a session in that state appeared in BOTH lists
+  // (7th writer-consumer-asymmetry witness, PAT-LEO-INFRA-WCA-001).
+  const stale = classified.filter(s => !CLAIM_HOLDING_STATUSES.has(s.status));
   if (stale.length > 0) {
     console.log('STALE/DEAD (' + stale.length + '):');
     stale.forEach(s => {

--- a/tests/unit/sweep/stale-session-sweep-stale-filter.test.js
+++ b/tests/unit/sweep/stale-session-sweep-stale-filter.test.js
@@ -1,0 +1,39 @@
+// QF-20260526-279: prevent regression of the inverse-negation STALE/DEAD render
+// at scripts/stale-session-sweep.cjs:L1385. The prior filter
+//   s.status !== 'ACTIVE' && s.status !== 'ALIVE_NO_HEARTBEAT'
+// missed ALIVE_SOURCE_SIDE, so a session in that state was rendered in BOTH
+// the ACTIVE WORKERS list and the STALE/DEAD list (cosmetic dup, 7th witness
+// of PAT-LEO-INFRA-WCA-001 / writer-consumer asymmetry).
+//
+// Static-pattern test mirrors create-quick-fix-insert-order.test.js — much
+// cheaper than mocking classifySessions + the full sweep render path.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/stale-session-sweep.cjs');
+
+describe('QF-20260526-279: STALE/DEAD render consumes CLAIM_HOLDING_STATUSES', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  it('the stale filter does not use the prior inverse-negation pattern', () => {
+    // Must not contain the exact buggy expression that omitted ALIVE_SOURCE_SIDE.
+    expect(code).not.toMatch(
+      /s\.status\s*!==\s*['"]ACTIVE['"]\s*&&\s*s\.status\s*!==\s*['"]ALIVE_NO_HEARTBEAT['"]/,
+    );
+  });
+
+  it('the stale filter routes through CLAIM_HOLDING_STATUSES (single SSOT)', () => {
+    // The `const stale = classified.filter(...)` line must reference the shared set.
+    const staleAssignRe = /const\s+stale\s*=\s*classified\.filter\([^)]*CLAIM_HOLDING_STATUSES\.has/;
+    expect(code).toMatch(staleAssignRe);
+  });
+
+  it('CLAIM_HOLDING_STATUSES is imported from the lib/claim/ SSOT', () => {
+    expect(code).toMatch(/require\(\s*['"]\.\.\/lib\/claim\/holding-statuses\.cjs['"]\s*\)/);
+    expect(code).toMatch(/CLAIM_HOLDING_STATUSES/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260526-279

**Type:** bug
**Severity:** medium

### Issue Description
scripts/stale-session-sweep.cjs:L1385 classifies STALE/DEAD render via inverse-negation status!=='ACTIVE' && status!=='ALIVE_NO_HEARTBEAT' and does NOT consume CLAIM_HOLDING_STATUSES (added in SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001). Result: an ALIVE_SOURCE_SIDE session appears in BOTH the ACTIVE WORKERS list AND the STALE/DEAD list (cosmetic dup, no claim-integrity impact). Same writer-consumer-asymmetry pattern this SD addressed at L1121/L1144 — third site flagged by TESTING-agent verdict 92, evidence c4a1c15d. Fix: route L1385 through CLAIM_HOLDING_STATUSES (lib/claim/holding-statuses.cjs) so all sweep-render filters consume the same status set.




### Changes
- **Files Changed:** 2
  - scripts/stale-session-sweep.cjs
  - tests/unit/sweep/stale-session-sweep-stale-filter.test.js
- **LOC:** 44 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Static-pattern regression test 3/3 pass. The buggy inverse-negation literal asserted absent; CLAIM_HOLDING_STATUSES SSOT reference asserted present at the stale filter. Tier-1 auto-approve (compliance rubric skipped per work-item-router routing decision).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol