### PR TITLE
fix(QF-20260526-904): generate-retrospective.js uses bare sd_id existence check while gates require getFilteredRetrospective (6th writer-consumer-asymmetry witness; 10th hand-rolled retro-insert one-off)

### DIFF
--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -32,6 +32,7 @@
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { resolveSdInput } from './lib/sd-id-resolver.js';
+import { getFilteredRetrospective } from './modules/handoff/retro-filters.js';
 import dotenv from 'dotenv';
 // import fs from 'fs'; // Currently unused - available for file operations if needed
 
@@ -62,19 +63,21 @@ async function generateRetrospective(sdInput) {
   console.log(`SD: ${sd.sd_key} - ${sd.title}`);
   console.log(`Status: ${sd.status}, Progress: ${sd.progress}%`);
 
-  // Check if retrospective already exists
-  const { data: existing } = await supabase
-    .from('retrospectives')
-    .select('id')
-    .eq('sd_id', sdId)
-    .limit(1);
+  // QF-20260526-904: route through getFilteredRetrospective so the writer
+  // sees the same row the LEAD-FINAL-APPROVAL gate and PLAN-TO-LEAD
+  // RETROSPECTIVE_QUALITY_GATE see (retro_type='SD_COMPLETION' AND
+  // retrospective_type IS NULL AND created_at > LEAD-TO-PLAN-accepted_at).
+  // The prior bare existence check reported existed:true for handoff-time
+  // retros, forcing operators to hand-roll INSERTs to satisfy the gate
+  // (6th writer-consumer-asymmetry witness, PAT-LEO-INFRA-WCA-001).
+  const { retrospective: existing } = await getFilteredRetrospective(sdId, sd.created_at, supabase);
 
-  if (existing && existing.length > 0) {
-    console.log(`\n⚠️  Retrospective already exists (ID: ${existing[0].id})`);
+  if (existing) {
+    console.log(`\n⚠️  Retrospective already exists (ID: ${existing.id})`);
     return {
       success: true,
       existed: true,
-      retrospective_id: existing[0].id
+      retrospective_id: existing.id
     };
   }
 

--- a/tests/unit/retrospectives/generate-retrospective-filtered-existence.test.js
+++ b/tests/unit/retrospectives/generate-retrospective-filtered-existence.test.js
@@ -1,0 +1,43 @@
+// QF-20260526-904: prevent regression of the bare sd_id existence check at
+// scripts/generate-retrospective.js (L66-L79 pre-fix). The bare predicate
+//   .from('retrospectives').select('id').eq('sd_id', sdId).limit(1)
+// matched ANY row (including retrospective_type='LEAD_TO_PLAN' handoff-time
+// retros), so the generator skipped while the LEAD-FINAL-APPROVAL and
+// PLAN-TO-LEAD RETROSPECTIVE_QUALITY_GATE rejected the same row, forcing
+// hand-rolled INSERTs (10 prior witnesses in the script tree, 6th overall
+// writer-consumer-asymmetry witness, PAT-LEO-INFRA-WCA-001).
+//
+// Static-pattern assertions over the source file (same convention as
+// stale-session-sweep-stale-filter.test.js and
+// create-quick-fix-insert-order.test.js).
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/generate-retrospective.js');
+
+describe('QF-20260526-904: generate-retrospective uses gate-filter for existence check', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  it('imports getFilteredRetrospective from the canonical retro-filters module', () => {
+    expect(code).toMatch(
+      /import\s*\{\s*getFilteredRetrospective\s*\}\s*from\s*['"]\.\/modules\/handoff\/retro-filters\.js['"]/,
+    );
+  });
+
+  it('does not contain the prior bare existence-check predicate on retrospectives', () => {
+    // The exact buggy pattern: select('id').eq('sd_id', X).limit(1) on retrospectives.
+    // It must not survive the fix — getFilteredRetrospective is the only entry point.
+    const buggy = /from\(\s*['"]retrospectives['"]\s*\)\s*\.select\(\s*['"]id['"]\s*\)\s*\.eq\(\s*['"]sd_id['"]/;
+    expect(code).not.toMatch(buggy);
+  });
+
+  it('calls getFilteredRetrospective with sdId and sd.created_at (freshness arg)', () => {
+    // sd.created_at is the fallback when LEAD-TO-PLAN handoff has no acceptance row;
+    // omitting it would degrade the freshness predicate to epoch-zero.
+    expect(code).toMatch(/getFilteredRetrospective\s*\(\s*sdId\s*,\s*sd\.created_at\s*,\s*supabase\s*\)/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260526-904

**Type:** bug
**Severity:** medium

### Issue Description
scripts/generate-retrospective.js:71-84 short-circuits on .from('retrospectives').select('id').eq('sd_id', sdId).limit(1) — reports 'existed:true' whenever ANY row matches. Both PLAN-TO-LEAD RETROSPECTIVE_QUALITY_GATE and LEAD-FINAL-APPROVAL gate filter via scripts/modules/handoff/retro-filters.js::getFilteredRetrospective requiring retro_type='SD_COMPLETION' AND retrospective_type IS NULL AND created_at>LEAD-TO-PLAN-acceptance. Handoff-time retros (retrospective_type='LEAD_TO_PLAN') satisfy the generator's predicate but NOT the gate's, forcing operators to hand-roll INSERTs. RCA c0e0f442 identified 9 prior _insert*retro*/_create-retrospective* one-offs (10 with mine) confirming this is chronic, not a one-off. Fix: import getFilteredRetrospective in generate-retrospective.js and use it as the existence predicate; when no qualifying row exists, proceed with fresh-author flow. ~15 LOC. Same writer-consumer-asymmetry pattern this SD addressed on sweep — 6th witness.




### Changes
- **Files Changed:** 2
  - scripts/generate-retrospective.js
  - tests/unit/retrospectives/generate-retrospective-filtered-existence.test.js
- **LOC:** 56 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Static-pattern regression test 3/3 pass: import asserted, bare-eq predicate asserted absent, getFilteredRetrospective called with sd.created_at as freshness fallback. Tier-1 routes auto-approve. Per RCA c0e0f442, this is the 6th writer-consumer-asymmetry witness — same pattern as the SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 sweep fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol