### PR TITLE
fix(QF-20260527-871): add dedicated path-scoped vitest job for S19 design-prompts parity tests

### DIFF
--- a/.github/workflows/s19-design-prompts-tests.yml
+++ b/.github/workflows/s19-design-prompts-tests.yml
@@ -1,0 +1,40 @@
+name: S19 design-prompts parity tests
+
+# QF-20260527-871 (SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 FR-3 follow-up):
+# The S19 Claude-Code-ready writer parity tests live in this repo at
+# tests/unit/eva/s19-claude-code-ready-writers.test.js but were only
+# advisory via the broad test-coverage.yml workflow (continue-on-error).
+# This dedicated path-scoped vitest job makes them BLOCKING for any PR
+# that touches the writer surface — matching the can-auto-advance-tests.yml
+# pattern adopted by SD-LEO-REFAC-GATE-AUTO-ADVANCE-001.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/eva/bridge/claude-md-writer.js'
+      - 'lib/eva/bridge/build-tasks-writer.js'
+      - 'lib/eva/bridge/replit-config-writer.js'
+      - 'lib/eva/bridge/design-prompts-writer.js'
+      - 'scripts/design-prompts-sync.mjs'
+      - 'tests/unit/eva/s19-claude-code-ready-writers.test.js'
+      - '.github/workflows/s19-design-prompts-tests.yml'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit tests (S19 writer parity)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --no-audit --no-fund
+      - name: Run S19 design-prompts writer tests
+        run: npx vitest run tests/unit/eva/s19-claude-code-ready-writers.test.js


### PR DESCRIPTION
## Summary
- SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001 FR-3 follow-up: gate the S19 Claude-Code-ready writer parity test (`tests/unit/eva/s19-claude-code-ready-writers.test.js`, 22 tests) as BLOCKING on PRs that touch the writer surface. Prior state: ran only via the broad `test-coverage.yml` workflow with `continue-on-error` grace — advisory only.
- Adds `.github/workflows/s19-design-prompts-tests.yml` modeled on `can-auto-advance-tests.yml` (the pattern adopted by SD-LEO-REFAC-GATE-AUTO-ADVANCE-001 for the same class of problem).
- Path-scoped to the 4 writer modules under `lib/eva/bridge/`, `scripts/design-prompts-sync.mjs`, the test file, and the workflow file itself.

## Companion
- ehg: rickfelix/ehg#657 (gates the gvos-side `shared-design-prompts.test.ts` by extending `tests-unit-ventures.yml`).

## Test plan
- [ ] CI green on this PR (the new workflow triggers on the workflow file's own path)
- [ ] Verify `s19-design-prompts-tests / unit` runs on the PR and passes (22/22 locally on origin/main HEAD pre-push)
- [ ] Verify the workflow does NOT trigger on PRs that don't touch the listed paths

Closes QF-20260527-871
Closes feedback `1316751a-9e22-4daa-bf48-aa8e68706514` (jointly with rickfelix/ehg#657)

🤖 Generated with [Claude Code](https://claude.com/claude-code)