### PR TITLE
fix(QF-20260527-645): create-quick-fix.js: clean up 4 pre-existing lint errors surfaced by QF-250 compliance check

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -297,7 +297,7 @@ async function createQuickFix(options = {}) {
       // FR-3: force-claim override with per-session daily quota
       if (options.forceClaim) {
         if (!options.forceClaimReason || !String(options.forceClaimReason).trim()) {
-          console.error(`\n❌ [FORCE_CLAIM_REASON_REQUIRED] --force-claim requires --force-claim-reason "<text>"`);
+          console.error('\n❌ [FORCE_CLAIM_REASON_REQUIRED] --force-claim requires --force-claim-reason "<text>"');
           if (claimed.length > 0) await releasePreclaim({ supabase, quickFixId: qfId });
           await supabase.from('quick_fixes').delete().eq('id', qfId);
           process.exit(1);
@@ -424,7 +424,7 @@ async function createQuickFix(options = {}) {
       }
 
       // Dynamically import worktree-manager (ESM)
-      const { createWorkTypeWorktree, symlinkNodeModules } = await import('../lib/worktree-manager.js');
+      const { createWorkTypeWorktree, symlinkNodeModules: _symlinkNodeModules } = await import('../lib/worktree-manager.js');
 
       const result = createWorkTypeWorktree({
         workType: 'QF',
@@ -572,7 +572,7 @@ for (let i = 0; i < args.length; i++) {
     // QF-20260527-250: audited override for dedup gate.
     options.allowDuplicate = args[++i];
     if (!options.allowDuplicate || !String(options.allowDuplicate).trim()) {
-      console.error(`❌ --allow-duplicate requires a non-empty reason`);
+      console.error('❌ --allow-duplicate requires a non-empty reason');
       process.exit(1);
     }
   } else if (arg === '--help' || arg === '-h') {
@@ -611,7 +611,7 @@ Tiered Routing:
     process.exit(0);
   } else {
     console.error(`❌ Unknown argument: ${arg}`);
-    console.error(`   Run with --help for usage information.`);
+    console.error('   Run with --help for usage information.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Quick-Fix: QF-20260527-645

**Type:** bug
**Severity:** low

### Issue Description
Surfaced during QF-20260527-250 compliance scoring (PR #3992). Four lint errors pre-date that PR but the file is now load-bearing for the dedup gate so cleanliness matters. (1) L300 + L575 + L614 (post-edit line numbers after #3992): non-interpolated template literals violate eslint quotes:single — convert backticks to single quotes (same fix I applied to my own L206/L207/L227 in #3992). (2) L427: import symlinkNodeModules from ../lib/worktree-manager.js is destructured but never referenced — either prefix with _ to match the /^_/u allowlist or drop from the import. Mechanical fix, ~4 source LOC. Lint passing IS the test.

### Steps to Reproduce
1. cd EHG_Engineer; 2. npx eslint scripts/create-quick-fix.js — observe 4 errors at L300/L427/L575/L614.

### Expected Behavior
0 lint errors

### Actual Behavior
4 errors (3 quotes, 1 no-unused-vars)

### Changes
- **Files Changed:** 1
  - scripts/create-quick-fix.js
- **LOC:** 11 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Tier-1 lint cleanup. npx eslint scripts/create-quick-fix.js reports 0 errors post-edit (4 errors pre-edit at L300/L427/L575/L614). Mechanical fix: 3 non-interpolated template literals → single quotes (allowed inside the single-quote span because none contain literal apostrophes); 1 unused-var rename via _ prefix to match eslint allowlist. Lint passing IS the test for this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol