### PR TITLE
fix(QF-20260527-673): SUB_AGENT_REPO_RESOLUTION gate: normalize worktree-path mismatch before treating as VIOLATION

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
@@ -39,6 +39,30 @@ const INTRA_REPO_TARGETS = new Set(['EHG', 'EHG_Engineer']);
 // Statuses that block the gate (BLOCKED verdict)
 const BLOCKING_STATUSES = new Set(['cwd_leak', 'violation', 'explicit_null']);
 
+/**
+ * QF-20260527-673: normalize a filesystem path for cross-platform gate
+ * comparison. Forward-slashifies backslashes (Windows writers vs Linux CI
+ * applications.local_path) and strips trailing slashes.
+ */
+function normalizePathForGate(p) {
+  if (!p || typeof p !== 'string') return null;
+  return p.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+/**
+ * QF-20260527-673: a writer-emitted repo_path is "toplevel-compatible" with
+ * the expected repo path when they're equal post-normalization OR when the
+ * writer is a `.worktrees/<id>` subdirectory of the expected toplevel. A
+ * sub-agent that ran from a git worktree records the worktree path (per
+ * resolve-repo.js executed_from_cwd semantics) — a valid path inside the
+ * same repo per `git rev-parse --show-toplevel` but not string-equal.
+ */
+function pathsAreToplevelCompatible(writerNorm, expectedNorm) {
+  if (!writerNorm || !expectedNorm) return false;
+  if (writerNorm === expectedNorm) return true;
+  return writerNorm.startsWith(expectedNorm + '/.worktrees/');
+}
+
 // Statuses that downgrade to CONDITIONAL_PASS
 const CONDITIONAL_STATUSES = new Set(['skipped', 'empty_probe', 'unresolved_intra']);
 
@@ -84,6 +108,20 @@ function classifyRow(viewRow, rawRow, targetApp) {
     };
   }
   if (viewRow.compliance_status === 'violation') {
+    // QF-20260527-673: worktree-path normalization. The view does strict-
+    // equality between metadata.repo_path and applications.local_path, which
+    // false-positive blocks worktree paths (valid same-repo paths) and
+    // slash-variant mismatches. Override only when post-normalize writer
+    // resolves under the expected toplevel.
+    const writerNorm = normalizePathForGate(viewRow.metadata_repo_path);
+    const expectedNorm = normalizePathForGate(viewRow.expected_repo_path);
+    if (pathsAreToplevelCompatible(writerNorm, expectedNorm)) {
+      return {
+        status: 'healthy',
+        reasonCode: REASON_CODES.HEALTHY,
+        detail: `worktree-path normalized: ${writerNorm} resolves under ${expectedNorm}`
+      };
+    }
     return {
       status: 'violation',
       reasonCode: REASON_CODES.VIOLATION,

--- a/tests/unit/gates/sub-agent-repo-resolution.test.js
+++ b/tests/unit/gates/sub-agent-repo-resolution.test.js
@@ -326,4 +326,82 @@ describe('SUB_AGENT_REPO_RESOLUTION gate', () => {
     expect(result.score).toBe(50);
     expect(result.warnings.some(w => w.includes('connection refused'))).toBe(true);
   });
+
+  // QF-20260527-673: worktree-path normalization. The view's strict-equality
+  // false-positives a sub-agent run in a git worktree (valid same-repo path).
+  // Pre-normalize forward-slashes and accept `.worktrees/<id>` subpaths.
+  describe('QF-20260527-673: worktree-path normalization (view violation override)', () => {
+    it('overrides VIOLATION to HEALTHY when writer is `.worktrees/<id>` subpath of expected (backslashes)', async () => {
+      const viewRows = [{
+        id: 'W1', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+        metadata_repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C',
+        metadata_repo_resolved: true,
+        executed_from_cwd: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C',
+        compliance_status: 'violation',
+      }];
+      const rawRows = [{ id: 'W1', sub_agent_code: 'DESIGN', metadata: { repo_path: 'C:\\...\\EHG_Engineer\\.worktrees\\SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.details.buckets.healthy).toHaveLength(1);
+      expect(result.details.buckets.violation).toHaveLength(0);
+    });
+
+    it('overrides VIOLATION to HEALTHY when slashes differ but normalized paths match', async () => {
+      const viewRows = [{
+        id: 'S1', sub_agent_code: 'SECURITY', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+        metadata_repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer',
+        metadata_repo_resolved: true,
+        executed_from_cwd: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer',
+        compliance_status: 'violation',
+      }];
+      const rawRows = [{ id: 'S1', sub_agent_code: 'SECURITY', metadata: { repo_path: 'C:\\...\\EHG_Engineer', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.details.buckets.healthy).toHaveLength(1);
+    });
+
+    it('preserves BLOCKED VIOLATION when writer is genuinely different repo (must not regress)', async () => {
+      const viewRows = [{
+        id: 'V1', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: '/path/to/EHG_Engineer',
+        metadata_repo_path: '/path/to/different-repo',
+        metadata_repo_resolved: true,
+        executed_from_cwd: '/path/to/EHG_Engineer',
+        compliance_status: 'violation',
+      }];
+      const rawRows = [{ id: 'V1', sub_agent_code: 'DESIGN', metadata: { repo_path: '/path/to/different-repo', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.reasonCode).toBe(REASON_CODES.VIOLATION);
+      expect(result.details.buckets.violation).toHaveLength(1);
+    });
+
+    it('preserves BLOCKED VIOLATION when writer is a sibling .worktrees of a different repo', async () => {
+      const viewRows = [{
+        id: 'V2', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: '/path/to/EHG_Engineer',
+        metadata_repo_path: '/path/to/different-repo/.worktrees/SD-X-001',
+        metadata_repo_resolved: true,
+        executed_from_cwd: '/path/to/EHG_Engineer',
+        compliance_status: 'violation',
+      }];
+      const rawRows = [{ id: 'V2', sub_agent_code: 'DESIGN', metadata: { repo_path: '/path/to/different-repo/.worktrees/SD-X-001', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(false);
+      expect(result.details.buckets.violation).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260527-673

**Type:** bug
**Severity:** high

### Issue Description
scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js classifyRow trusts v_sub_agent_repo_compliance.compliance_status='violation' verbatim. The view does strict-equality between metadata.repo_path and applications.local_path. When a sub-agent runs in a git worktree (e.g. C:/.../EHG_Engineer/.worktrees/SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C with backslashes), the path is a valid path INSIDE the same repo per git rev-parse --show-toplevel but does NOT string-equal C:/.../EHG_Engineer (slashes differ + worktree-suffix). Gate blocks legitimate cross-repo cwd-corrected runs. Currently blocking session ea257a69 (Legion-Laptop) on SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C PLAN-TO-EXEC handoff. Fix: in classifyRow, BEFORE the viewRow.compliance_status==='violation' branch, add a normalization step: forward-slashify both metadata_repo_path and expected_repo_path, strip trailing slashes; if normalize(writer)===normalize(expected) OR normalize(writer).startsWith(normalize(expected)+'/.worktrees/') then override to compliant. Surgical override: only affects rows that view classifies as violation AND post-normalize paths are toplevel-compatible. Does NOT change legacy/cwd_leak/explicit_null/healthy paths. Tier-2 QF: ~20 source LOC + 20 test LOC.

### Steps to Reproduce
1. Run any PLAN-TO-EXEC handoff for an SD where a sub-agent (e.g. DESIGN) ran in a worktree. 2. Observe gate BLOCKED with VIOLATION reason despite worktree being valid git-repo path.

### Expected Behavior
Gate PASSES when metadata.repo_path is a path inside applications.local_path (worktree subpath or different slash variant).

### Actual Behavior
Gate returns BLOCKED with repo_path mismatch error; PLAN-TO-EXEC handoff cannot proceed without bypass.

### Changes
- **Files Changed:** 2
  - scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
  - tests/unit/gates/sub-agent-repo-resolution.test.js
- **LOC:** 123 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
13/13 vitest pass (9 existing regression + 4 new for QF-673). Surgical override on classifyRow's VIOLATION branch — does NOT change LEGACY/CWD_LEAK/EXPLICIT_NULL/UNRESOLVED/HEALTHY paths. Regression guards: (1) genuinely different repo path still VIOLATION, (2) sibling .worktrees of wrong toplevel still VIOLATION. Unblocks ea257a69 (Legion-Laptop) session on SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C PLAN-TO-EXEC.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol