### PR TITLE
feat(SD-FDBK-INFRA-RETROFIT-LIB-EVA-001): route lifecycle-sd-bridge venture-enrichment through getActiveSDFilter

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -49,6 +49,7 @@ import { summarizeArtifacts, enrichSDDescription } from './artifact-enrichment-p
 import { validateIntegrity } from './referential-integrity-rubric.js';
 // QF: target_application capability lookup (suppress api layer for SPA-only targets)
 import { getTargetApplicationCapabilities } from './config/target-application-capabilities.js';
+import { getActiveSDFilter } from '../sd/active-sd-predicate.js';
 import { normalizeVentureName } from './bridge/venture-routing-error.js';
 import { emitFeedback } from '../governance/emit-feedback.js';
 
@@ -1062,18 +1063,19 @@ export async function reEnrichExistingSDs(supabase, ventureId, options = {}) {
     return { enriched: 0, skipped: 0, errors: ['No artifacts found for stages 0-18'] };
   }
 
-  // Load existing SDs for this venture
-  // active-sd-predicate-exempt: deferred-retrofit-follow-up
-  // Reason: SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C FR-6 retrofits drain-orchestrator only (≥1 consumer
-  // satisfies the writer/consumer asymmetry mitigation). Retrofitting this query would also add an
-  // `archived_at IS NULL` filter (the new shared predicate's full definition), which is a behavior
-  // change for venture-scoped enrichment that warrants its own SD + test pass. Track as backlog.
-  const { data: existingSDs } = await supabase
-    .from('strategic_directives_v2')
-    .select('id, sd_key, title, description, metadata, sd_type')
-    .eq('venture_id', ventureId)
-    .neq('sd_type', 'orchestrator')
-    .in('status', ['draft', 'in_progress', 'active']);
+  // Load existing SDs for this venture.
+  // SD-FDBK-INFRA-RETROFIT-LIB-EVA-001: routes through getActiveSDFilter (the
+  // canonical active-SD predicate shipped by SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C
+  // FR-6). Behavior change: enrichment now also excludes archived venture SDs
+  // (`archived_at IS NOT NULL`) and inactive ones (`is_active = false`). The
+  // status set (draft/in_progress/active) is unchanged.
+  const { data: existingSDs } = await getActiveSDFilter(
+    supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, description, metadata, sd_type')
+      .eq('venture_id', ventureId)
+      .neq('sd_type', 'orchestrator')
+  );
 
   if (!existingSDs?.length) {
     return { enriched: 0, skipped: 0, errors: ['No active SDs found for this venture'] };

--- a/tests/unit/eva/lifecycle-sd-bridge-active-sd-predicate.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge-active-sd-predicate.test.js
@@ -1,0 +1,61 @@
+// SD-FDBK-INFRA-RETROFIT-LIB-EVA-001 / FR-2 + FR-3 + parity
+//
+// Verifies lib/eva/lifecycle-sd-bridge.js venture-enrichment query consumes the
+// canonical getActiveSDFilter helper (shipped by parent SD-EVA-SUPPORT-CLI-
+// SKILL-ORCH-001-C FR-6). The retrofit changes behavior in two ways:
+//   1. Excludes `archived_at IS NOT NULL` SDs (FR-2 archived exclusion).
+//   2. Excludes `is_active = false` SDs (parity with the canonical predicate).
+//
+// Plus parity guard: non-archived SDs with status IN (draft, in_progress, active)
+// and is_active!=false continue to flow through enrichment (FR-3).
+//
+// Static-pattern test (same convention as create-quick-fix-insert-order.test.js
+// and other regression-pin tests this session): inspect source ordering and
+// helper-import to confirm the retrofit landed, without mocking the entire
+// enrichment pipeline.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../lib/eva/lifecycle-sd-bridge.js');
+
+describe('SD-FDBK-INFRA-RETROFIT-LIB-EVA-001: lifecycle-sd-bridge venture-enrichment uses getActiveSDFilter', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  it('imports getActiveSDFilter from the canonical lib/sd/active-sd-predicate module', () => {
+    expect(code).toMatch(
+      /import\s*\{\s*getActiveSDFilter\s*\}\s*from\s*['"]\.\.\/sd\/active-sd-predicate\.js['"]/,
+    );
+  });
+
+  it('does not contain the prior inline status filter for venture-enrichment', () => {
+    // Pre-retrofit pattern: `.in('status', ['draft', 'in_progress', 'active'])`
+    // appearing in the venture-enrichment query. The retrofit replaces this with
+    // a wrapping getActiveSDFilter call.
+    expect(code).not.toMatch(
+      /\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]draft['"]\s*,\s*['"]in_progress['"]\s*,\s*['"]active['"]\s*\]\s*\)/,
+    );
+  });
+
+  it('calls getActiveSDFilter with a Supabase query builder wrapping the venture-enrichment query', () => {
+    // The retrofit wraps the .from('strategic_directives_v2')...neq('sd_type','orchestrator')
+    // chain inside a getActiveSDFilter() call. Verify both the call and that
+    // venture_id + non-orchestrator filters are still chained on the inner builder.
+    expect(code).toMatch(
+      /getActiveSDFilter\(\s*\n?\s*supabase\s*\n?\s*\.from\(\s*['"]strategic_directives_v2['"]\s*\)/,
+    );
+    expect(code).toMatch(/\.eq\(\s*['"]venture_id['"]\s*,\s*ventureId\s*\)/);
+    expect(code).toMatch(/\.neq\(\s*['"]sd_type['"]\s*,\s*['"]orchestrator['"]\s*\)/);
+  });
+
+  it('the deferred-retrofit-follow-up exempt comment has been removed', () => {
+    // FR-6 placed an `active-sd-predicate-exempt: deferred-retrofit-follow-up`
+    // marker at the venture-enrichment query site. This SD's retrofit must
+    // remove it; presence post-retrofit indicates the wrong call site was
+    // edited or the marker was left stale.
+    expect(code).not.toMatch(/active-sd-predicate-exempt:\s*deferred-retrofit-follow-up/);
+  });
+});


### PR DESCRIPTION
## Summary
- Retrofits `lib/eva/lifecycle-sd-bridge.js` venture-enrichment query to consume the canonical `getActiveSDFilter` helper shipped by parent SD-EVA-SUPPORT-CLI-SKILL-ORCH-001-C FR-6.
- Removes the `active-sd-predicate-exempt: deferred-retrofit-follow-up` marker that FR-6 placed; this SD IS that deferred retrofit.
- Adds `is_active OR-null` and `archived_at IS NULL` predicates (consequences of moving to the canonical helper).
- Closes the 9th writer/consumer-asymmetry retrofit witness (PAT-LEO-INFRA-WCA-001 family).

## Behavior change
Archived venture SDs (`archived_at IS NOT NULL`) no longer flow through the enrichment pass — intentional per chairman intent + parity with drain-orchestrator.mjs (the other consumer FR-6 retrofitted).

## Test plan
- [x] 4/4 static-pattern regression tests pass locally
- [ ] CI green
- [ ] Verify no behavior change for non-archived ventures (parity assertion guarded by import + call-shape tests)

Closes SD-FDBK-INFRA-RETROFIT-LIB-EVA-001  
Closes feedback `3bbe507c-79cc-41e1-8c14-fa9f8a6397e0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)