### PR TITLE
fix(QF-20260527-948): brainstorm-to-vision.mjs propagate venture_id (F4 from UNIFY)

### DIFF
--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -234,6 +234,7 @@ async function main() {
           status: 'draft',
           chairman_approved: false,
           source_brainstorm_id: session.id,
+          venture_id: session.metadata?.venture_id || null,
           created_by: 'brainstorm-to-vision-pipeline',
         }, { onConflict: 'vision_key' });
 


### PR DESCRIPTION
## Summary

F4 finding from SD-LEO-INFRA-UNIFY-VENTURE-NON-001 Phase-0 spike (retro action item #1 from SD-LEO-INFRA-CLEANUP-NON-VENTURE-001). 

L213 already extracts `session.metadata?.venture_id` for `vision_key` construction. The upsert payload at L228-237 was missing `venture_id` as a top-level column, so every venture brainstorm produced rows with `venture_id=NULL` — breaking the A.2 unique partial index filter and the Child C refusal gate filter (both query on venture_id).

## Test plan

- [x] 1-line addition: `venture_id: session.metadata?.venture_id || null`
- [x] Future venture brainstorms will populate venture_id correctly
- [x] No-op for non-venture brainstorms (session.metadata.venture_id is undefined → null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)