### PR TITLE
fix(QF-20260527-904): leo-create-sd skip description enrichment for program-level visions

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -158,7 +158,19 @@ export async function enrichFromVisionArch(visionKey, archKey, sb) {
         missing.vision = true;
       } else if (vision.sections) {
         const s = vision.sections;
-        if (s.executive_summary) result.description = s.executive_summary;
+        // QF-20260527-904: skip description enrichment for program-level visions.
+        // executive_summary > 2000 chars signals a mega-program vision (e.g.
+        // VISION-LEO-WRITER-CONSUMER-ASYMMETRY-L2-001) whose multi-child plan
+        // and 10-week scope text is wrong for any narrow follow-up SD that
+        // references it. 3rd witness logged 2026-05-27.
+        const PROGRAM_VISION_SUMMARY_CHARS = 2000;
+        if (s.executive_summary) {
+          if (s.executive_summary.length > PROGRAM_VISION_SUMMARY_CHARS) {
+            console.warn(`[enrichFromVisionArch] Skipping description enrichment: vision ${visionKey} executive_summary is ${s.executive_summary.length} chars (>${PROGRAM_VISION_SUMMARY_CHARS} — program-level). Author SD-specific description manually at LEAD.`);
+          } else {
+            result.description = s.executive_summary;
+          }
+        }
         if (s.problem_statement) result.rationale = s.problem_statement;
         if (s.success_criteria) {
           result.success_criteria = (Array.isArray(s.success_criteria)


### PR DESCRIPTION
## Summary

3rd witness this session (retro action item #2 from SD-LEO-INFRA-CLEANUP-NON-VENTURE-001).

`enrichFromVisionArch` at `scripts/leo-create-sd.js:161` was copying `vision.sections.executive_summary` verbatim into the SD's `description` field, regardless of size. For program-level visions (e.g. `VISION-LEO-WRITER-CONSUMER-ASYMMETRY-L2-001` with ~3000-char executive_summary describing a 7-child / 10-week / 1k+-LOC program), this dumps the entire program description into every narrow follow-up SD that happens to reference that vision_key.

Witnessed this session:
- `SD-LEO-INFRA-LIFECYCLE-BRIDGE-ORCHESTRATOR-001` — had to be CANCELLED for description drift
- `SD-LEO-INFRA-CLEANUP-NON-VENTURE-001` — needed manual rewrite of description, scope, strategic_objectives, success_criteria, key_changes, risks, smoke_test_steps

## Fix

If `vision.sections.executive_summary.length > 2000`, log a warning and skip the description pull (LEAD authors SD-specific scope manually). Other field-level pulls (rationale, success_criteria, key_changes from arch) remain unaffected.

## Test plan

- [x] +13 LOC, -1 LOC (Tier 1 QF)
- [x] Future narrow SDs referencing program visions will get an empty description (signals LEAD to write SD-specific scope)
- [x] Future narrow SDs referencing legitimate SD-level visions (≤2000 char summary) continue to get enrichment as before
- [x] Console warning includes vision_key, char count, threshold, and remediation hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)