### PR TITLE
fix(QF-20260527-583): auto-validate-user-stories: extend ready->completed promotion + document EXEC transition

### DIFF
--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1457,6 +1457,15 @@ The ACCEPTANCE_CRITERIA_VALIDATION gate scores stories as follows:
 
 Threshold: overall score >= 60 AND no story scores 0.
 
+### Status Transition Reference (EXEC-TO-PLAN)
+
+At EXEC-TO-PLAN, user stories must end in `status='completed'` with `validation_status='validated'`. Two distinct promotions happen:
+
+1. **`status='ready' → 'completed'`** — proves the work landed. Auto-promoted by `scripts/auto-validate-user-stories-on-exec-complete.js` when all `sd_scope_deliverables` for the SD are `completion_status='completed'`. Manual promotion is also valid when you cite per-story evidence (see Anti-Pattern above).
+2. **`validation_status='pending' → 'validated'`** — proves the work meets acceptance criteria. Auto-promoted by the same script for stories already at `status='completed'`.
+
+The script runs as part of the EXEC-TO-PLAN gate pipeline; both transitions are required for the ACCEPTANCE_CRITERIA_VALIDATION gate to score above 50.
+
 ## Playwright MCP Integration
 
 ## 🎭 Playwright MCP Integration

--- a/scripts/auto-validate-user-stories-on-exec-complete.js
+++ b/scripts/auto-validate-user-stories-on-exec-complete.js
@@ -6,10 +6,14 @@
  * validated after EXEC completion, blocking PLAN_verification at 0% progress
  * despite all deliverables being complete.
  *
- * **PREVENTION**: This script auto-validates user stories when:
- * 1. EXEC→PLAN handoff is created
- * 2. All deliverables are marked complete
- * 3. User stories exist but are still 'pending'
+ * **PREVENTION**: This script performs TWO promotions at EXEC-TO-PLAN, in order:
+ * 1. status='ready' → status='completed' when all sd_scope_deliverables are completed
+ * 2. validation_status='pending' → 'validated' for stories that are status='completed'
+ *
+ * Both transitions are universally required at EXEC-TO-PLAN. Sampled feature SDs at
+ * handoff (POST-LAUNCH-001, VISUAL-ASSETS-001, ARTIFACT-INTEGRATION-001, VISION-V2-006,
+ * E2E-VENTURE-LIFECYCLE-003) all show stories ending in status=completed+validated.
+ * See CLAUDE_EXEC.md "User stories at EXEC-TO-PLAN" for the protocol description.
  *
  * **Integration Point**: Called by EXEC-TO-PLAN gate pipeline (SD-LEO-FIX-STORIES-SUB-AGENT-001)
  *
@@ -65,6 +69,22 @@ async function autoValidateUserStories(sdId, sbClient) {
   if (!allDeliverablesComplete) {
     console.log('⏸️  Deliverables not all complete, skipping auto-validation');
     return { validated: false, message: 'Deliverables incomplete' };
+  }
+
+  // 2b. Promote status='ready' -> 'completed' (deliverables prove the work landed)
+  const readyStories = stories.filter(s => s.status === 'ready');
+  if (readyStories.length > 0) {
+    console.log(`📈 Promoting ${readyStories.length} ready stories to completed (deliverables done)...`);
+    const { error: promoteError } = await supabase
+      .from('user_stories')
+      .update({ status: 'completed' })
+      .eq('sd_id', sdId)
+      .eq('status', 'ready');
+    if (promoteError) {
+      console.error('❌ Error promoting ready->completed:', promoteError.message);
+      return { validated: false, error: promoteError.message };
+    }
+    readyStories.forEach(s => { s.status = 'completed'; });
   }
 
   // 3. Auto-validate completed user stories (must be both completed AND pending validation)


### PR DESCRIPTION
## Quick-Fix: QF-20260527-583

**Type:** bug
**Severity:** high

### Issue Description
EXEC user_stories.status='ready'->'completed' transition is universally required at EXEC-TO-PLAN but undocumented in CLAUDE_EXEC.md. auto-validate-user-stories-on-exec-complete.js only promotes completed->validated, not ready->completed. Witnessed 2026-05-07 SD-LEO-FEAT-STAGE-POST-LAUNCH-002 EXEC-TO-PLAN (RCA evidence 58e253f0-9ae8-463c-b4d4-c76344cbd754). Fix: extend script to promote ready->completed when all scope_deliverables are completed; document the transition in CLAUDE_EXEC.md. Closes feedback efbf111f-ef7c-4b14-aba5-8921ea7311bf.




### Changes
- **Files Changed:** 2
  - CLAUDE_EXEC.md
  - scripts/auto-validate-user-stories-on-exec-complete.js
- **LOC:** 40 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol