### PR TITLE
docs(QF-20260527-833): refresh NODE_MODULES_LOCK comment in lib/worktree-manager.js

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -10,20 +10,20 @@
  *
  * Legacy session-keyed API is supported via deprecation adapter.
  *
- * ─── NODE_MODULES_LOCK is a phantom protocol (QF-20260508-403) ─────────────
- * Coordinator dashboards may show INFO broadcasts subjected `NODE_MODULES_LOCK`.
- * These are advisory narrative only. There is NO lock protocol:
- *   • `NODE_MODULES_LOCK` is not a value in the `coordination_message_type` enum
- *     (DB rejects `INSERT ... message_type='NODE_MODULES_LOCK'`).
- *   • Zero producer scripts broadcast a real lock.
- *   • Zero consumer scripts gate `npm install` / `node_modules` operations on it.
- * The actual blast-radius safety for concurrent npm install across worktrees is
- * filesystem-level: junction-safe recursive rm via `safeRecursiveRm` (below) plus
- * npm's atomic `.staging` swaps which keep concurrent installs on a junction-
- * symlinked tree safe in practice.
- * Do NOT add producer/consumer hooks expecting a coordination-channel lock; the
- * intent was never realized. RCA evidence: `sub_agent_execution_results.id =
- * 0b0168b7-1d0a-4e84-bb85-19ee25fffa38` (paired with QF-20260508-102).
+ * ─── NODE_MODULES_LOCK protocol (payload-based, not enum-based) ─────────────
+ * NODE_MODULES_LOCK is NOT a `coordination_message_type` enum value
+ * (DB rejects `INSERT ... message_type='NODE_MODULES_LOCK'`). The real lock
+ * lives in `lib/npm-install-lock.cjs` (SD-MAN-INFRA-FLEET-NPM-INSTALL-001) and
+ * is implemented as a payload-based protocol over the existing INFO channel:
+ *   message_type='INFO', subject='NODE_MODULES_LOCK', payload.lock_type='NODE_MODULES'
+ * Producer/consumer: `scripts/sd-start.js` L1562-1567 wraps every npm install
+ * with `acquireLock`/`waitForLock`/`releaseLock`. Stale locks auto-expire after
+ * `LOCK_TTL_MS` (120s). Tests: `tests/lib/npm-install-lock.test.js`.
+ * Filesystem-level safety still applies as defense-in-depth: junction-safe
+ * recursive rm via `safeRecursiveRm` (below) + npm's atomic `.staging` swaps.
+ * Historical note: QF-20260508-403 documented this as a phantom protocol when
+ * `sub_agent_execution_results.id=0b0168b7-1d0a-4e84-bb85-19ee25fffa38` was
+ * written; that snapshot pre-dated SD-MAN-INFRA-FLEET-NPM-INSTALL-001.
  * ────────────────────────────────────────────────────────────────────────────
  */
 


### PR DESCRIPTION
## Summary
The phantom-protocol comment from QF-20260508-403 in `lib/worktree-manager.js` (L13-27) was accurate at write time but pre-dated SD-MAN-INFRA-FLEET-NPM-INSTALL-001, which shipped a payload-based NODE_MODULES lock at `lib/npm-install-lock.cjs` and wired it into `scripts/sd-start.js` L1562-1567. The comment claiming "zero producer scripts broadcast a real lock" is now contradicted by sd-start.js.

This QF refreshes the comment to:
- Point at `lib/npm-install-lock.cjs`
- Describe the payload-based pattern (`subject='NODE_MODULES_LOCK'`, `message_type='INFO'`, `payload.lock_type='NODE_MODULES'`)
- Preserve the historical RCA reference for traceability

## Why
Future readers hit a documentation/code asymmetry: the comment says "no lock", but `sd-start.js` acquires one on every install. Comment drift in a high-traffic harness file is exactly the class of memory-vs-reality bug we just spent a sweep closing.

Closes feedback c5143e50.

## Test plan
- [x] Doc-only change (14 LOC in/out)
- [x] No code paths touched
- [x] References verified: `lib/npm-install-lock.cjs` exists, `sd-start.js:1562` uses it, `tests/lib/npm-install-lock.test.js` covers it