### PR TITLE
fix(QF-20260527-029): Stage 19 sprint plan test — pass ventureName to analyzeStage19

### DIFF
--- a/tests/integration/eva/analysis-steps.test.js
+++ b/tests/integration/eva/analysis-steps.test.js
@@ -1078,6 +1078,7 @@ describe('Stage 19: analyzeStage19', () => {
 
     const result = await analyzeStage19({
       stage18Data: genStage18(),
+      ventureName: 'IntegrationTestVenture',
       logger: silentLogger,
     });
 


### PR DESCRIPTION
## Summary
1 LOC test fixture fix. Adds `ventureName: 'IntegrationTestVenture'` to the Stage 19 `analyzeStage19` call (same convention as Stage 20 test on L1114). Without it, `resolveTargetApplication` was called with `undefined` and tripped the null-venture fail-closed branch from SD-LEO-INFRA-FAIL-CLOSED-VENTURE-001-B (PR #3553).

Closes feedback 50332f8e.

## Test plan
- [x] Failing test `tests/integration/eva/analysis-steps.test.js > Stage 19 > produces valid sprint plan with mandatory capabilities included` reproduced (`VentureNotRegisteredError: Venture "" not in registry`)
- [x] After fix: passes (1 passed | 51 skipped)