### PR TITLE
fix(QF-20260527-992): refuse parent-branch-switch on WORKTREE_QUOTA_EXCEEDED

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -485,8 +485,19 @@ async function createQuickFix(options = {}) {
       }
     } catch (err) {
       console.log(`   ❌ Worktree creation failed: ${err.message}`);
-      console.log('   Falling back to branch-only mode.\n');
 
+      // Feedback fa98a703: when quota is the cause, refuse to fall back into
+      // `git checkout -b` in the parent CWD — that switches the in-flight
+      // session's branch and forces a manual restore.
+      if (err.errorCode === 'WORKTREE_QUOTA_EXCEEDED') {
+        console.log('   ❌ Quota exhausted — aborting to preserve parent branch.');
+        console.log('   💡 Reap stale worktrees first, then retry:');
+        console.log('      node scripts/worktree-reaper.mjs --execute');
+        console.log('      node scripts/worktree-reaper.mjs --execute --stage2 --yes');
+        process.exit(1);
+      }
+
+      console.log('   Falling back to branch-only mode.\n');
       process.env.EHG_WORKTREE_MODE = 'main-fallback';
 
       // Fallback: try simple branch creation


### PR DESCRIPTION
## Summary
When `createWorkTypeWorktree` throws `WORKTREE_QUOTA_EXCEEDED`, the catch block at `scripts/create-quick-fix.js:486` previously fell through to `git checkout -b qf/<id>` in the parent CWD — which switches the active session's branch and forces a manual restore. Witnessed twice on 2026-05-04 (QF-20260504-081 + QF-20260504-425), each disrupting an in-flight session.

This QF adds an early exit when `err.errorCode === 'WORKTREE_QUOTA_EXCEEDED'`, emitting a remediation hint and aborting with exit 1. The parent's branch stays unchanged.

Other worktree errors (permissions, non-git, etc.) keep the existing branch-only fallback behavior.

Closes feedback fa98a703.

## Test plan
- [x] Code review: error path delta is +12/-1 LOC, clear branch
- [x] No tests touched
- [x] WORKTREE_QUOTA_EXCEEDED contract verified in `lib/worktree-manager.js:834` and `lib/worktree-quota.test.js:161`