### PR TITLE
feat(SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001): default auto-stories to draft + gate filter

### DIFF
--- a/database/migrations/20260527_user_stories_status_default_draft.sql
+++ b/database/migrations/20260527_user_stories_status_default_draft.sql
@@ -1,0 +1,19 @@
+-- SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 (Option B): change user_stories.status
+-- default from 'ready' to 'draft' so future auto-generated stories with
+-- all-boilerplate acceptance_criteria default to invisible-to-quality-gate state.
+--
+-- Defense-in-depth: scripts/modules/auto-trigger-stories.mjs also sets status
+-- explicitly based on allAcsBoilerplate(). This migration is a safety net for
+-- any future code path that omits status.
+--
+-- REVERSIBLE: see down-migration at the bottom.
+
+ALTER TABLE user_stories ALTER COLUMN status SET DEFAULT 'draft';
+
+COMMENT ON COLUMN user_stories.status IS
+  'Story lifecycle status. Default changed to draft 2026-05-27 per SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B. Auto-generated boilerplate stories default to draft (invisible to USER_STORY_QUALITY gate); human/sub-agent enrichment + scripts/promote-user-stories.js moves them to ready (scoreable). Existing rows unaffected by this migration.';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Down-migration (run only if reverting):
+--   ALTER TABLE user_stories ALTER COLUMN status SET DEFAULT 'ready';
+-- ──────────────────────────────────────────────────────────────────────────

--- a/scripts/modules/auto-trigger-stories.mjs
+++ b/scripts/modules/auto-trigger-stories.mjs
@@ -28,6 +28,25 @@ import { randomUUID } from 'crypto';
 import { isPersonaStoryRoleEnabled } from '../lib/persona-extractor.js';
 import { getLLMClient } from '../../lib/llm/client-factory.js';
 
+/**
+ * SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B helper.
+ *
+ * Returns true when every acceptance criterion in the array carries
+ * is_boilerplate=true, indicating the auto-generation took the boilerplate
+ * template path (lib/sub-agents/modules/stories/quality-generation.js
+ * generateAcceptanceCriteria sets this flag on every templated AC).
+ *
+ * Used at story-insert time to default such stories to status='draft',
+ * keeping them invisible to USER_STORY_QUALITY gate until a human/sub-agent
+ * promotes them via scripts/promote-user-stories.js.
+ *
+ * Exported for unit testing.
+ */
+export function allAcsBoilerplate(criteria) {
+  if (!Array.isArray(criteria) || criteria.length === 0) return false;
+  return criteria.every(ac => ac && typeof ac === 'object' && ac.is_boilerplate === true);
+}
+
 // ============================================
 // LLM Configuration for Story Generation (v1.2.0)
 // Uses factory-resolved model with opus tier for PLAN phase
@@ -873,7 +892,11 @@ export async function autoTriggerStories(supabase, sdId, prdId, options = {}) {
           user_benefit: story.user_benefit,
           story_points: story.story_points || 3,
           priority: normalizePriorityForUserStory(story.priority),
-          status: 'ready',
+          // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: auto-generated stories
+          // with all-boilerplate acceptance criteria default to draft so they don't
+          // block PLAN-TO-EXEC until a human promotes them via promote-user-stories.js.
+          // LLM-generated stories (non-boilerplate ACs) stay at ready (no regression).
+          status: allAcsBoilerplate(story.acceptance_criteria) ? 'draft' : 'ready',
           acceptance_criteria: story.acceptance_criteria,
           implementation_context: typeof story.implementation_context === 'object'
             ? JSON.stringify(story.implementation_context)
@@ -1100,7 +1123,10 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
       user_benefit: extractUserBenefit(fr.description, fr.rationale),
       story_points: storyPoints,
       priority: priority,
-      status: 'ready',
+      // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: see allAcsBoilerplate
+      // helper. Boilerplate-template path almost always returns true here; LLM-path
+      // (other generator above) returns false for high-quality stories.
+      status: allAcsBoilerplate(transformedCriteria) ? 'draft' : 'ready',
       acceptance_criteria: transformedCriteria, // Now SD-type-aware
       implementation_context: fr.description || fr.requirement || 'Implementation details to be defined during EXEC phase',
       given_when_then: [],
@@ -1108,6 +1134,8 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
       architecture_references: [],
       technical_notes: fr.rationale || '',
       created_by: 'PRODUCT_REQUIREMENTS_EXPERT',
+      // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: see note above on
+      // status assignment. Boilerplate template path → draft; promote after enrichment.
       // E2E Test Path (v1.3.0): Auto-populated based on SD type
       e2e_test_path: e2eConfig.path,
       e2e_test_status: e2eConfig.status,

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -166,7 +166,12 @@ export class PlanToExecVerifier {
         console.log(`\n📝 User stories check: SKIPPED (sd_type='${sd.sd_type}')`);
       } else {
         console.log('\n📝 Checking for user stories...');
-        const { data: stories, error: userStoriesError } = await this.supabase
+        // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: USER_STORY_QUALITY gate
+        // only scores promoted stories (status IN ready, active). Auto-generated
+        // boilerplate stories default to status=draft; PRD author/sub-agent must
+        // run scripts/promote-user-stories.js after enriching them. Two-tier query:
+        // (1) all stories for visibility/messaging; (2) scoreable stories for the gate.
+        const { data: allStories, error: userStoriesError } = await this.supabase
           .from('user_stories')
           .select('id, story_key, title, status, user_role, user_want, user_benefit, acceptance_criteria, story_points, implementation_context, sd_id')
           .eq('sd_id', sd.id);
@@ -174,6 +179,10 @@ export class PlanToExecVerifier {
         if (userStoriesError) {
           return rejectHandoff(this.supabase,sdId, 'USER_STORIES_ERROR', `Error querying user stories: ${userStoriesError.message}`);
         }
+
+        const scoreableStatuses = ['ready', 'active'];
+        const stories = (allStories || []).filter(s => scoreableStatuses.includes(s.status));
+        const draftCount = (allStories || []).filter(s => s.status === 'draft').length;
 
         if (!stories || stories.length === 0) {
           // Fallback: check if PRD content has embedded user_stories before rejecting
@@ -187,6 +196,18 @@ export class PlanToExecVerifier {
             console.log(`   ⚠️  No user stories in table, but found ${embeddedStories.length} in PRD content (fallback)`);
             console.log('   💡 Run add-prd-to-database.js to migrate stories to the user_stories table');
             userStories = embeddedStories;
+          } else if (draftCount > 0) {
+            // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: stories exist but
+            // all are at status=draft (auto-generated boilerplate). Treat as
+            // pending-promotion rather than missing. SOFT-PASS the user-stories
+            // existence check; ALSO short-circuit the downstream quality validator
+            // (cannot score draft stories without LLM cost burned on boilerplate).
+            console.log(`   ⚠️  ${draftCount} story(ies) at status=draft (auto-generated, pending promotion)`);
+            console.log(`   💡 Run: node scripts/promote-user-stories.js --sd-id ${sd.sd_key} --all-non-boilerplate`);
+            console.log('       (or --story-keys US-001,US-002 to promote specific stories after enrichment)');
+            userStories = [];  // empty scoreable set; quality validator path skipped below
+            // Mark this SD as in soft-pass mode so the quality validator block early-returns.
+            // Using a local symbol via storyQualityResult preset (set below at the validation block).
           } else {
             console.log('   ❌ No user stories found');
             return rejectHandoff(this.supabase,sdId, 'NO_USER_STORIES', 'User stories are MANDATORY before EXEC phase.', {
@@ -195,18 +216,29 @@ export class PlanToExecVerifier {
               hint: 'If stories exist in the PRD, run add-prd-to-database.js to sync them to the user_stories table.'
             });
           }
+        } else {
+          userStories = stories;
+          console.log(`   ✅ User stories found: ${userStories.length} scoreable (status IN ready, active)`);
+          if (draftCount > 0) {
+            console.log(`   ℹ️  ${draftCount} additional story(ies) at status=draft (pending promotion; not scored)`);
+          }
+          completedStories = userStories.filter(s => s.status === 'completed').length;
+          console.log(`   📊 Status: ${completedStories}/${userStories.length} completed`);
         }
-
-        userStories = stories;
-        console.log(`   ✅ User stories found: ${userStories.length}`);
-        completedStories = userStories.filter(s => s.status === 'completed').length;
-        console.log(`   📊 Status: ${completedStories}/${userStories.length} completed`);
       }
 
       // 3a-2. User Story Quality Validation
       let storyQualityResult = { valid: true, averageScore: 100, warnings: [] };
 
-      if (!isParentOrchestrator && requiresUserStories) {
+      // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B: if userStories is empty
+      // because all stories are at status=draft (pending promotion), short-circuit
+      // the quality validator. Soft-pass with promotion-suggestion warning instead.
+      const scoreableEmpty = (!isParentOrchestrator && requiresUserStories && userStories.length === 0);
+      if (scoreableEmpty) {
+        console.log('\n🔍 Validating user story quality... ⏭  SKIPPED (all stories at status=draft pending promotion)');
+        console.log(`   💡 Quality gate will run once stories are promoted via scripts/promote-user-stories.js`);
+        storyQualityResult = { valid: true, averageScore: null, warnings: ['No stories at status=ready or active to score; promotion pending'] };
+      } else if (!isParentOrchestrator && requiresUserStories) {
         console.log('\n🔍 Validating user story quality...');
         const storyMinimumScore = getStoryMinimumScoreByCategory(sd.category, sd.sd_type);
         console.log(`   SD Type: ${sd.sd_type || 'unknown'}, Category: ${sd.category || 'unknown'} → Minimum Score: ${storyMinimumScore}%`);

--- a/scripts/prd/README.md
+++ b/scripts/prd/README.md
@@ -1,0 +1,40 @@
+# scripts/prd
+
+PRD authoring + lifecycle utilities.
+
+## Auto-generated user stories (SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B)
+
+When you run `add-prd-to-database.js` with a PRD containing `functional_requirements`, the system auto-generates user stories from those FRs via `scripts/modules/auto-trigger-stories.mjs`. The lifecycle is now:
+
+1. **Auto-generation** — generated user_story rows default to:
+   - `status='draft'` when ALL acceptance criteria carry `is_boilerplate=true` (boilerplate-template path)
+   - `status='ready'` when the LLM-quality-generation path produced enriched ACs
+
+2. **USER_STORY_QUALITY gate** at PLAN-TO-EXEC handoff (`scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js`) filters to `status IN ('ready', 'active')` before invoking the Gemini quality evaluator:
+   - SDs with only draft stories: **SOFT-PASS** with a suggestion to run the promotion CLI (handoff continues; no LLM-cost burned on boilerplate)
+   - SDs with ready/active stories: scored as before (no regression)
+
+3. **Promotion** — after enriching the acceptance criteria of one or more stories (set `is_boilerplate=false` on each AC, add concrete given/when/then), promote them via:
+
+   ```bash
+   # Promote specific stories
+   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --story-keys US-001,US-002
+
+   # Promote all stories where at least one AC is non-boilerplate
+   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --all-non-boilerplate
+
+   # Dry-run first
+   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --all --dry-run
+   ```
+
+   The CLI refuses to promote stories where all ACs are still flagged boilerplate (unless `--force` is passed).
+
+4. **Re-run** `node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX-001` — the gate now scores the promoted stories.
+
+### Why this design
+
+Two prior retrospectives (in `scripts/one-off/insert-retro-fdbk-learn.cjs` and `_record-stories-result-finalize-claude-code.mjs`) documented the same defect before this SD was filed: auto-generated user stories scored ~14/100 by the LLM quality evaluator (because the templated boilerplate text isn't testable/specific/benefit-articulated), hard-blocking every venture or feature SD at PLAN-TO-EXEC. CronGenius pilot 2026-05-27 surfaced it again as finding F12.
+
+LEAD chose Option B (default-to-draft + gate filter + explicit promotion CLI) over Option A (gate exempts boilerplate stories) and Option C (LLM-enriched generation by default) because Option B has the smallest blast radius, the cleanest audit trail (status field is canonical), and the easiest rollback (single ALTER COLUMN SET DEFAULT reverse).
+
+See `project_crongenius_first_venture_pilot_2026_05_27.md` for the full pilot narrative.

--- a/scripts/promote-user-stories.js
+++ b/scripts/promote-user-stories.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * promote-user-stories.js
+ *
+ * SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 (Option B): canonical workflow for
+ * moving auto-generated user stories from status=draft to status=ready after
+ * human/sub-agent enrichment.
+ *
+ * Auto-generated stories with all-boilerplate acceptance criteria default to
+ * status=draft (invisible to USER_STORY_QUALITY gate). This script promotes
+ * them to status=ready (scoreable) after their ACs have been enriched.
+ *
+ * Usage:
+ *   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --all-non-boilerplate
+ *   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --story-keys US-001,US-002
+ *   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --all --dry-run
+ *   node scripts/promote-user-stories.js --sd-id SD-XXX-001 --story-keys US-003 --force
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+function parseArgs(argv) {
+  const args = { sdId: null, storyKeys: null, all: false, allNonBoilerplate: false, dryRun: false, force: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--sd-id' && argv[i + 1]) args.sdId = argv[++i];
+    else if (argv[i] === '--story-keys' && argv[i + 1]) args.storyKeys = argv[++i].split(',').map(s => s.trim()).filter(Boolean);
+    else if (argv[i] === '--all') args.all = true;
+    else if (argv[i] === '--all-non-boilerplate') args.allNonBoilerplate = true;
+    else if (argv[i] === '--dry-run') args.dryRun = true;
+    else if (argv[i] === '--force') args.force = true;
+  }
+  return args;
+}
+
+function isStoryAllBoilerplate(story) {
+  const acs = story.acceptance_criteria;
+  if (!Array.isArray(acs) || acs.length === 0) return false;
+  return acs.every(ac => ac && typeof ac === 'object' && ac.is_boilerplate === true);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.sdId) {
+    console.error('❌ --sd-id is required');
+    process.exit(1);
+  }
+  const modeCount = [args.all, args.allNonBoilerplate, !!args.storyKeys].filter(Boolean).length;
+  if (modeCount !== 1) {
+    console.error('❌ Exactly one of --all, --all-non-boilerplate, --story-keys is required');
+    process.exit(1);
+  }
+
+  // Resolve SD UUID from sd_key
+  let sdUuid = args.sdId;
+  if (args.sdId.startsWith('SD-') || args.sdId.startsWith('QF-')) {
+    const { data: sd, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id,sd_key')
+      .eq('sd_key', args.sdId)
+      .single();
+    if (error || !sd) {
+      console.error(`❌ SD not found: ${args.sdId}`);
+      process.exit(1);
+    }
+    sdUuid = sd.id;
+  }
+
+  // Fetch draft stories
+  const { data: drafts, error: fetchErr } = await supabase
+    .from('user_stories')
+    .select('id, story_key, title, status, acceptance_criteria')
+    .eq('sd_id', sdUuid)
+    .eq('status', 'draft');
+  if (fetchErr) {
+    console.error('❌ Fetch error:', fetchErr.message);
+    process.exit(1);
+  }
+  if (!drafts || drafts.length === 0) {
+    console.log(`ℹ️  No user_stories at status=draft for ${args.sdId}. Nothing to promote.`);
+    return;
+  }
+
+  // Decide which to promote
+  let toPromote;
+  if (args.storyKeys) {
+    const keySet = new Set(args.storyKeys);
+    toPromote = drafts.filter(s => keySet.has(s.story_key) || keySet.has(s.story_key.split(':').pop()));
+    if (toPromote.length !== args.storyKeys.length) {
+      const found = toPromote.map(s => s.story_key.split(':').pop());
+      const missing = args.storyKeys.filter(k => !found.includes(k));
+      console.warn(`⚠️  ${missing.length} story-key(s) not found at status=draft: ${missing.join(', ')}`);
+    }
+  } else if (args.all) {
+    toPromote = drafts;
+  } else if (args.allNonBoilerplate) {
+    toPromote = drafts.filter(s => !isStoryAllBoilerplate(s));
+    const skippedBoilerplate = drafts.length - toPromote.length;
+    if (skippedBoilerplate > 0) {
+      console.log(`ℹ️  Skipping ${skippedBoilerplate} story(ies) still flagged all-boilerplate (enrich ACs first or use --force).`);
+    }
+  }
+
+  if (toPromote.length === 0) {
+    console.log('ℹ️  Nothing to promote after filtering.');
+    return;
+  }
+
+  // Re-check boilerplate (unless --force) for the chosen set; refuse to promote all-boilerplate without --force
+  if (!args.force) {
+    const stillBoilerplate = toPromote.filter(isStoryAllBoilerplate);
+    if (stillBoilerplate.length > 0) {
+      console.error(`❌ Refusing to promote ${stillBoilerplate.length} story(ies) still flagged all-boilerplate:`);
+      stillBoilerplate.forEach(s => console.error('   - ' + s.story_key + ': ' + s.title));
+      console.error('   Enrich their acceptance_criteria first (clear is_boilerplate=true on each AC), OR re-run with --force to override.');
+      process.exit(1);
+    }
+  }
+
+  // Show plan
+  console.log(`Planned promotion: ${toPromote.length} story(ies) draft → ready for ${args.sdId}`);
+  toPromote.forEach(s => console.log('   • ' + s.story_key + ': ' + (s.title || '').substring(0, 80)));
+
+  if (args.dryRun) {
+    console.log('\n--dry-run: no UPDATE performed.');
+    return;
+  }
+
+  // Execute UPDATE
+  const ids = toPromote.map(s => s.id);
+  const { error: updErr } = await supabase
+    .from('user_stories')
+    .update({ status: 'ready', updated_at: new Date().toISOString() })
+    .in('id', ids);
+  if (updErr) {
+    console.error('❌ UPDATE error:', updErr.message);
+    process.exit(1);
+  }
+  console.log(`\n✅ Promoted ${ids.length} story(ies) draft → ready.`);
+  console.log(`   Next: re-run handoff PLAN-TO-EXEC on ${args.sdId} — USER_STORY_QUALITY gate will score the promoted stories.`);
+}
+
+main().catch(e => { console.error('FATAL:', e.message); process.exit(1); });

--- a/tests/unit/auto-story-quality-gate/auto-story-quality-gate.test.js
+++ b/tests/unit/auto-story-quality-gate/auto-story-quality-gate.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 (Option B).
+ *
+ * Validates:
+ *   T1: allAcsBoilerplate helper detects all-boilerplate criteria correctly
+ *   T2: Mixed acceptance_criteria (some boilerplate, some not) returns false (defaults to ready)
+ *   T3: Empty / non-array criteria returns false (no false-positive draft)
+ *   T4: Regression-pin signature for promote-user-stories.js CLI args parsing
+ */
+
+import { describe, it, expect } from 'vitest';
+import { allAcsBoilerplate } from '../../../scripts/modules/auto-trigger-stories.mjs';
+
+describe('SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 allAcsBoilerplate', () => {
+  it('T1: returns true when every AC has is_boilerplate=true', () => {
+    const criteria = [
+      { id: 'AC-1', is_boilerplate: true, scenario: 'a' },
+      { id: 'AC-2', is_boilerplate: true, scenario: 'b' },
+      { id: 'AC-3', is_boilerplate: true, scenario: 'c' },
+    ];
+    expect(allAcsBoilerplate(criteria)).toBe(true);
+  });
+
+  it('T2: returns false when any AC has is_boilerplate=false or missing flag (mixed = ready)', () => {
+    const mixedFalse = [
+      { id: 'AC-1', is_boilerplate: true, scenario: 'a' },
+      { id: 'AC-2', is_boilerplate: false, scenario: 'b (real)' },
+    ];
+    expect(allAcsBoilerplate(mixedFalse)).toBe(false);
+
+    const mixedMissing = [
+      { id: 'AC-1', is_boilerplate: true, scenario: 'a' },
+      { id: 'AC-2', scenario: 'b (no flag)' },
+    ];
+    expect(allAcsBoilerplate(mixedMissing)).toBe(false);
+  });
+
+  it('T3: returns false for empty array, non-array, null, undefined (no false-positive draft)', () => {
+    expect(allAcsBoilerplate([])).toBe(false);
+    expect(allAcsBoilerplate(null)).toBe(false);
+    expect(allAcsBoilerplate(undefined)).toBe(false);
+    expect(allAcsBoilerplate('not an array')).toBe(false);
+    expect(allAcsBoilerplate(42)).toBe(false);
+  });
+
+  it('T4: returns false when AC items are strings (legacy format), not objects', () => {
+    // Some older PRDs have acceptance_criteria as array of strings; those should
+    // default to ready (not draft) since they don't carry the is_boilerplate signal.
+    const stringCriteria = ['Validate input', 'Persist data', 'Return response'];
+    expect(allAcsBoilerplate(stringCriteria)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **F12 fix** from CronGenius first-venture pilot 2026-05-27 (LEAD Option B).
- Auto-generated user stories with all-boilerplate acceptance criteria now default to `status=draft` (invisible to USER_STORY_QUALITY gate). LLM-quality stories preserve `status=ready` (no regression).
- USER_STORY_QUALITY gate at PLAN-TO-EXEC filters to `status IN ('ready', 'active')`; SOFT-PASS when only drafts exist (with promotion CLI suggestion).
- New `scripts/promote-user-stories.js` CLI for human/sub-agent promotion workflow.

## Why
Two prior retrospectives + CronGenius pilot finding F12 documented the same defect: auto-generated user stories scored ~14/100 by Gemini LLM quality evaluator (templated boilerplate text isn't testable/specific), hard-blocking every venture or feature SD at PLAN-TO-EXEC. Unblocks every SD created via `add-prd-to-database.js`.

## Test plan
- [x] 4/4 vitest unit tests pass (`tests/unit/auto-story-quality-gate/auto-story-quality-gate.test.js`)
- [x] Migration applied via database-agent (0 rows changed, atthasdef=true confirmed)
- [ ] Post-merge regression-pin: rerun `handoff.js execute PLAN-TO-EXEC SD-CRONGENIUS-M1-LAUNCH-ORCHESTRATOR-ORCH-001-A` — should PASS without manual story enrichment
- [ ] Post-merge: smoke test the promote-user-stories.js CLI against a fresh SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)