### PR TITLE
fix(QF-20260527-981): apply allAcsBoilerplate to 2nd user_stories writer

### DIFF
--- a/lib/sub-agents/modules/stories/execute.js
+++ b/lib/sub-agents/modules/stories/execute.js
@@ -11,6 +11,7 @@ import { dirname, join } from 'path';
 import { randomUUID } from 'crypto';
 import { createSupabaseServiceClient } from '../../../../scripts/lib/supabase-connection.js';
 import { validateUserStoryQuality } from '../../../../scripts/modules/user-story-quality-validation.js';
+import { allAcsBoilerplate } from '../../../../scripts/modules/auto-trigger-stories.mjs';
 import {
   generateQualityStoryContent,
   generateStoriesBatch,
@@ -293,7 +294,10 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
       user_benefit: storyContent.user_benefit,
       story_points: storyContent.story_points,
       priority: i === 0 ? 'critical' : (i < 3 ? 'high' : 'medium'),
-      status: 'ready',
+      // SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B (PR #4019): 2nd writer
+      // parity — boilerplate ACs default to draft so PLAN-TO-EXEC USER_STORY_QUALITY
+      // gate doesn't block until a human promotes via promote-user-stories.js.
+      status: allAcsBoilerplate(storyContent.acceptance_criteria) ? 'draft' : 'ready',
       acceptance_criteria: storyContent.acceptance_criteria,
       implementation_context: implContext,
       created_by: storyContent.generated_by === 'LLM' ? 'PLAN_LLM' : 'PLAN',


### PR DESCRIPTION
## Summary
2nd-writer parity for SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 (PR #4019). `lib/sub-agents/modules/stories/execute.js:296` was missed when the default-to-draft pattern was applied to `scripts/modules/auto-trigger-stories.mjs` — this writer kept hard-coding `status='ready'`, so boilerplate-AC stories generated through it blocked the PLAN-TO-EXEC USER_STORY_QUALITY gate.

## Why
Discovered immediately after #4019 shipped: SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 PRD generation emitted 3 boilerplate stories via `execute.js` — gate blocked, manual `UPDATE` rows to draft was the workaround. 2nd witness of writer-consumer asymmetry on the user_stories pipeline.

Closes feedback `973c21c3`.

## Test plan
- [x] Import resolves (smoke-test passed: `import('./lib/sub-agents/modules/stories/execute.js')` → IMPORT_OK)
- [x] +5/-1 LOC, Tier-1
- [x] `allAcsBoilerplate` is the canonical export from `scripts/modules/auto-trigger-stories.mjs:45`, used at L899 and L1129 in that file — identical semantics applied here