### PR TITLE
fix(QF-20260527-530): F12 second writer: lib/sub-agents/modules/stories/execute.js:296 hardcodes status='ready', bypassing the default-to-draft gate

### DIFF
--- a/lib/sub-agents/modules/stories/execute.js
+++ b/lib/sub-agents/modules/stories/execute.js
@@ -11,6 +11,11 @@ import { dirname, join } from 'path';
 import { randomUUID } from 'crypto';
 import { createSupabaseServiceClient } from '../../../../scripts/lib/supabase-connection.js';
 import { validateUserStoryQuality } from '../../../../scripts/modules/user-story-quality-validation.js';
+// QF-20260527-530: F12 second-writer fix. Reuse the canonical helper from
+// SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 / PR #4019 (auto-trigger-stories.mjs)
+// rather than duplicating the 4-line logic. Layering precedent already set by
+// the two scripts/* imports above.
+import { allAcsBoilerplate } from '../../../../scripts/modules/auto-trigger-stories.mjs';
 import {
   generateQualityStoryContent,
   generateStoriesBatch,
@@ -293,7 +298,10 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
       user_benefit: storyContent.user_benefit,
       story_points: storyContent.story_points,
       priority: i === 0 ? 'critical' : (i < 3 ? 'high' : 'medium'),
-      status: 'ready',
+      // QF-20260527-530: F12 second-writer. Mirror PR #4019's pattern — stories
+      // whose ACs are all boilerplate default to 'draft' (invisible to the
+      // USER_STORY_QUALITY gate); LLM/non-boilerplate ACs stay 'ready'.
+      status: allAcsBoilerplate(storyContent.acceptance_criteria) ? 'draft' : 'ready',
       acceptance_criteria: storyContent.acceptance_criteria,
       implementation_context: implContext,
       created_by: storyContent.generated_by === 'LLM' ? 'PLAN_LLM' : 'PLAN',

--- a/tests/unit/sub-agents/stories/execute-status-default-draft.test.js
+++ b/tests/unit/sub-agents/stories/execute-status-default-draft.test.js
@@ -1,0 +1,47 @@
+// QF-20260527-530: F12 second-writer regression guard.
+//
+// Pre-fix behavior: lib/sub-agents/modules/stories/execute.js:296 hardcoded
+// status='ready' for every user_story row inserted, regardless of acceptance-
+// criteria quality. When PRD creation produced 3 boilerplate stories, all
+// landed at ready → PLAN-TO-EXEC USER_STORY_QUALITY gate blocked. Workaround
+// required manual UPDATE rows to draft. 2nd writer of the F12 default-to-draft
+// pattern that PR #4019 shipped to scripts/modules/auto-trigger-stories.mjs.
+//
+// Post-fix: status is `allAcsBoilerplate(criteria) ? 'draft' : 'ready'` —
+// mirrors PR #4019's logic, reusing the same canonical helper.
+//
+// Static-pattern test asserts (1) the helper is imported from the canonical
+// module, (2) the inline hardcoded `status: 'ready'` is gone, (3) the call
+// shape is correct.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../../lib/sub-agents/modules/stories/execute.js');
+
+describe('QF-20260527-530: stories/execute.js default-to-draft (F12 2nd writer)', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  it('imports allAcsBoilerplate from the canonical auto-trigger-stories module', () => {
+    expect(code).toMatch(
+      /import\s*\{\s*allAcsBoilerplate\s*\}\s*from\s*['"][^'"]*scripts\/modules\/auto-trigger-stories\.mjs['"]/,
+    );
+  });
+
+  it('does not contain the prior hardcoded `status: \'ready\',` for user_story inserts', () => {
+    // Match the EXACT pre-fix line shape — a bare `status: 'ready',` on its own
+    // line inside the userStory object. Post-fix uses the ternary expression.
+    // We allow `status: 'ready'` to still appear inside the ternary's else-branch.
+    const hardcodedReady = /\n\s+status:\s+['"]ready['"],\s*\n\s+acceptance_criteria:/;
+    expect(code).not.toMatch(hardcodedReady);
+  });
+
+  it('applies allAcsBoilerplate(storyContent.acceptance_criteria) to decide draft vs ready', () => {
+    expect(code).toMatch(
+      /status:\s*allAcsBoilerplate\s*\(\s*storyContent\.acceptance_criteria\s*\)\s*\?\s*['"]draft['"]\s*:\s*['"]ready['"]/,
+    );
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260527-530

**Type:** bug
**Severity:** medium

### Issue Description
PR #4019 (SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001) shipped F12 default-to-draft to scripts/auto-trigger-stories.mjs but missed the second writer at lib/sub-agents/modules/stories/execute.js:296 which still hardcodes status='ready'. Surfaced when SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 PRD was created — 3 boilerplate stories went to status=ready, blocking PLAN-TO-EXEC USER_STORY_QUALITY gate. 2nd witness of writer-consumer asymmetry on the user_stories pipeline (PAT-LEO-INFRA-WCA-001 family). Fix: replace hardcoded 'ready' with allAcsBoilerplate(storyContent.acceptance_criteria) ? 'draft' : 'ready' — mirror PR #4019's pattern. ~5-10 LOC source + small regression test.

### Steps to Reproduce
1. Run any flow that calls lib/sub-agents/modules/stories/execute.js to seed PRD user stories with boilerplate ACs. 2. Observe rows inserted with status='ready' regardless of AC quality. 3. Run PLAN-TO-EXEC USER_STORY_QUALITY gate — blocks.

### Expected Behavior
Stories with all-boilerplate ACs are inserted with status='draft'; only stories with real ACs go to 'ready'. Gate passes (or is no-op for draft rows).

### Actual Behavior
All stories hardcoded to 'ready' regardless of AC quality. Gate blocks. Workaround: manual UPDATE rows to draft.

### Changes
- **Files Changed:** 2
  - lib/sub-agents/modules/stories/execute.js
  - tests/unit/sub-agents/stories/execute-status-default-draft.test.js
- **LOC:** 63 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Tier-1 F12 second-writer fix mirroring PR #4019 logic. 3/3 static-pattern regression tests pass: canonical helper imported, prior hardcoded status='ready' line absent, ternary call shape correct. Uses existing exported allAcsBoilerplate (reuses, doesn't duplicate). Behavior parity: LLM stories stay 'ready', boilerplate stories go 'draft' — matches PR #4019 exactly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol