### PR TITLE
feat(SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001): venture-aware LLM-generated rubrics for /heal vision

### DIFF
--- a/database/migrations/20260527_eva_vision_rubric_cache_and_content_hash.sql
+++ b/database/migrations/20260527_eva_vision_rubric_cache_and_content_hash.sql
@@ -1,0 +1,42 @@
+-- SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 Phase 1
+-- (1) Add content_hash GENERATED STORED columns to eva_vision_documents + eva_architecture_plans
+--     (DATABASE sub-agent COND-1: source-table content_hash columns missing, blocks FR-3/TR-7).
+-- (2) Create eva_vision_rubric_cache table — additive, no FKs (stale-but-keyed acceptable).
+
+BEGIN;
+
+-- (1) content_hash on source tables — deterministic, computed at write time, no backfill.
+--     md5(text) is IMMUTABLE on text input (sha256 path requires bytea via convert_to which
+--     is STABLE, not IMMUTABLE, and GENERATED columns require IMMUTABLE expressions).
+--     md5 collision probability across <1000 venture docs is astronomically low; cache key
+--     in JS combines this with the OTHER side's hash + vision/plan keys so even a
+--     hypothetical single-side collision cannot poison the cache.
+ALTER TABLE eva_vision_documents
+  ADD COLUMN IF NOT EXISTS content_hash text
+    GENERATED ALWAYS AS (md5(coalesce(content, ''))) STORED;
+
+ALTER TABLE eva_architecture_plans
+  ADD COLUMN IF NOT EXISTS content_hash text
+    GENERATED ALWAYS AS (md5(coalesce(content, ''))) STORED;
+
+-- (2) cache table — primary key on cache_key supports ON CONFLICT DO UPDATE for setCachedRubrics
+CREATE TABLE IF NOT EXISTS eva_vision_rubric_cache (
+  cache_key text PRIMARY KEY,
+  vision_key text NOT NULL,
+  plan_key text NOT NULL,
+  vision_content_hash text,
+  plan_content_hash text,
+  rubrics jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_hit_at timestamptz,
+  generator_model text,
+  generator_cost_usd numeric(8,4)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eva_vision_rubric_cache_keys
+  ON eva_vision_rubric_cache (vision_key, plan_key);
+
+COMMENT ON TABLE eva_vision_rubric_cache IS
+  'SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001: LLM-generated venture rubrics cached by SHA-256(vision_key+plan_key+both content_hashes). Stale-but-keyed acceptable; content_hash is the freshness signal. EHG self-scoring uses the static rubric library and never touches this table.';
+
+COMMIT;

--- a/lib/eva/rubric-cache.js
+++ b/lib/eva/rubric-cache.js
@@ -1,0 +1,86 @@
+/**
+ * rubric-cache.js — Content-hash cache for LLM-generated venture rubrics.
+ *
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-3).
+ *
+ * Cache key = SHA-256 hex of stringified {vision_key, plan_key, vision_content_hash,
+ * plan_content_hash}. When either source document's content changes, content_hash
+ * (GENERATED STORED) changes → cache_key changes → next scoring run regenerates.
+ *
+ * No TTL. Stale-but-keyed rows are acceptable (content_hash is the freshness signal).
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * Compute the cache key for a (vision, plan) pair.
+ * Pure function; no IO.
+ *
+ * @param {object} input
+ * @param {string} input.vision_key
+ * @param {string} input.plan_key
+ * @param {string} [input.vision_content_hash]
+ * @param {string} [input.plan_content_hash]
+ * @returns {string} SHA-256 hex digest
+ */
+export function computeCacheKey({ vision_key, plan_key, vision_content_hash, plan_content_hash }) {
+  const payload = JSON.stringify({
+    vision_key,
+    plan_key,
+    vision_content_hash: vision_content_hash ?? null,
+    plan_content_hash: plan_content_hash ?? null,
+  });
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+/**
+ * Look up cached rubrics by cache key.
+ * On hit: updates last_hit_at (advisory; not awaited for the hot path).
+ *
+ * @param {object} supabase - Supabase service client
+ * @param {string} cacheKey
+ * @returns {Promise<Map<string, object>|null>} Map<dimId, rubric> or null on miss.
+ */
+export async function getCachedRubrics(supabase, cacheKey) {
+  const { data, error } = await supabase
+    .from('eva_vision_rubric_cache')
+    .select('rubrics')
+    .eq('cache_key', cacheKey)
+    .maybeSingle();
+  if (error) throw new Error(`getCachedRubrics: ${error.message}`);
+  if (!data) return null;
+  await supabase
+    .from('eva_vision_rubric_cache')
+    .update({ last_hit_at: new Date().toISOString() })
+    .eq('cache_key', cacheKey);
+  return new Map(Object.entries(data.rubrics));
+}
+
+/**
+ * Persist generated rubrics for a (vision, plan) pair.
+ * UPSERTs on cache_key — concurrent writers for the same key are race-safe.
+ *
+ * @param {object} supabase
+ * @param {string} cacheKey
+ * @param {Map<string, object>} rubrics - Map<dimId, rubric>
+ * @param {object} keyMeta - { vision_key, plan_key, vision_content_hash, plan_content_hash }
+ * @param {object} [genMeta] - { generator_model, generator_cost_usd }
+ * @returns {Promise<void>}
+ */
+export async function setCachedRubrics(supabase, cacheKey, rubrics, keyMeta, genMeta = {}) {
+  const rubricsObj = Object.fromEntries(rubrics);
+  const row = {
+    cache_key: cacheKey,
+    vision_key: keyMeta.vision_key,
+    plan_key: keyMeta.plan_key,
+    vision_content_hash: keyMeta.vision_content_hash ?? null,
+    plan_content_hash: keyMeta.plan_content_hash ?? null,
+    rubrics: rubricsObj,
+    generator_model: genMeta.generator_model ?? null,
+    generator_cost_usd: genMeta.generator_cost_usd ?? null,
+  };
+  const { error } = await supabase
+    .from('eva_vision_rubric_cache')
+    .upsert(row, { onConflict: 'cache_key' });
+  if (error) throw new Error(`setCachedRubrics: ${error.message}`);
+}

--- a/lib/eva/rubric-generator.js
+++ b/lib/eva/rubric-generator.js
@@ -1,0 +1,156 @@
+/**
+ * rubric-generator.js — Venture-aware rubric synthesis via LLM.
+ *
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-2).
+ *
+ * Generates evidence rubrics dynamically by prompting an LLM with each
+ * vision/arch extracted_dimension and the venture target-path. Output is
+ * validated by validateRubricStrict (FR-4) and constrained to the 6
+ * deterministic check types (file_exists, code_pattern, anti_pattern,
+ * export_exists, db_row_exists, file_count) so downstream runRubricChecks
+ * operates unchanged.
+ *
+ * When no LLM client is available, throws explicitly (TR-6: refused-silent-
+ * fallback — never silently revert to EHG rubrics for a venture).
+ */
+
+import { getLLMClient } from '../llm/client-factory.js';
+import { parseJSON } from './utils/parse-json.js';
+import {
+  ALLOWED_CHECK_TYPES,
+  validateRubricStrict,
+} from '../../scripts/eva/evidence-rubrics/index.js';
+
+const SYSTEM_PROMPT = `You are an evidence-rubric generator for the /heal vision scoring pipeline.
+Given a venture dimension (vision or architecture), produce a binary-check rubric
+in strict JSON. Each check must use one of EXACTLY these 6 types:
+${ALLOWED_CHECK_TYPES.join(', ')}
+
+Rules:
+- Output a single JSON object — no prose, no markdown fences.
+- Schema: {
+    "id": "<dimId>",         // e.g. "V01" or "A03"
+    "name": "<dim_name>",
+    "checks": [
+      {
+        "id": "<dimId>-C1",
+        "label": "<one-line human description>",
+        "type": "<one of the 6 allowed types>",
+        "weight": <number; the 3-5 check weights must sum to 100>,
+        "params": {
+          // For file_exists / code_pattern / anti_pattern / file_count: include "glob" (string)
+          //   and for code_pattern / anti_pattern also include "pattern" (regex string).
+          //   Optional: "minMatches" / "maxMatches" / "minCount" integer.
+          // For export_exists: include "module" (relative path string, e.g. "src/foo.js")
+          //   and "exportName" (string).
+          // For db_row_exists: include "table" (string); optional "column" + "value" or "filter".
+        }
+      }
+      // ...3 to 5 checks total. Weights MUST sum to 100.
+    ]
+  }
+- "params" MUST contain at least one of: glob, pattern, module, table (a concrete
+  reference into the venture codebase or database). Empty params objects will be REJECTED.
+- Reference real files/exports/tables in the venture codebase (rooted at the targetPath
+  the user provides). Do not invent paths that obviously cannot exist (e.g., do not
+  reference "scripts/modules/auto-proceed/*" unless the venture actually has that path).
+- Prefer file_exists / code_pattern over db_row_exists unless the dimension is genuinely
+  database-defined.`;
+
+function buildUserPrompt({ dimId, dim, targetPath, side }) {
+  const name = dim.key || dim.name || dimId;
+  const description = dim.description || dim.summary || '';
+  return `Venture target codebase: ${targetPath}
+Dimension side: ${side}  (vision dim → V## ids; architecture dim → A## ids)
+Dimension id: ${dimId}
+Dimension name: ${name}
+Dimension description: ${description || '(none provided)'}
+Dimension weight in overall score: ${dim.weight || 0}
+
+Produce a JSON rubric (no markdown, no prose) that evaluates evidence FOR THIS
+SPECIFIC DIMENSION in the venture codebase at the target path above. Use 3-5
+binary checks whose weights sum to 100.`;
+}
+
+async function generateOneRubric({ dimId, dim, targetPath, side, llmClient, retries }) {
+  let lastErr;
+  const userPrompt = buildUserPrompt({ dimId, dim, targetPath, side });
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const response = await llmClient.complete(SYSTEM_PROMPT, userPrompt);
+    let parsed;
+    try {
+      parsed = parseJSON(response);
+    } catch (err) {
+      lastErr = err;
+      continue;
+    }
+    parsed.id = parsed.id || dimId;
+    parsed.name = parsed.name || (dim.key || dim.name || dimId);
+    if (Array.isArray(parsed.checks)) {
+      parsed.checks.forEach((c, i) => {
+        c.id = c.id || `${dimId}-C${i + 1}`;
+      });
+    }
+    try {
+      validateRubricStrict(parsed, dimId);
+      return parsed;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new Error(`generateVentureRubrics: failed to produce a valid rubric for ${dimId} after ${retries + 1} attempt(s) — ${lastErr?.message || 'unknown error'}`);
+}
+
+/**
+ * Generate venture-aware rubrics for all vision + arch dimensions.
+ *
+ * @param {object} args
+ * @param {object} args.vision - eva_vision_documents row with extracted_dimensions[]
+ * @param {object} args.arch   - eva_architecture_plans row with extracted_dimensions[]
+ * @param {string} args.targetPath - absolute path to the venture codebase
+ * @param {object} [args.llmClient] - injected (for tests); when absent, fetched via getLLMClient
+ * @param {number} [args.retries=1] - retry attempts per dimension on validation failure
+ * @returns {Promise<{ rubrics: Map<string, object>, meta: { generator_model?: string, total_input_tokens?: number, total_output_tokens?: number } }>}
+ */
+export async function generateVentureRubrics({ vision, arch, targetPath, llmClient, retries = 1 }) {
+  const client = llmClient ?? getLLMClient({ purpose: 'generation' });
+  if (client.isInlineOnly) {
+    throw new Error(
+      'rubric-generator: no cloud LLM client available (client-factory cascade exhausted). ' +
+      'Set ANTHROPIC_API_KEY / GEMINI_API_KEY / GOOGLE_AI_API_KEY, or pre-populate eva_vision_rubric_cache. ' +
+      'REFUSING silent fallback to EHG rubrics (would produce misleading scores for ventures).'
+    );
+  }
+
+  const rubrics = new Map();
+  let totalInput = 0;
+  let totalOutput = 0;
+  const usedModel = client.model || client.adapter?.model;
+
+  const visionDims = Array.isArray(vision?.extracted_dimensions) ? vision.extracted_dimensions : [];
+  const archDims = Array.isArray(arch?.extracted_dimensions) ? arch.extracted_dimensions : [];
+
+  for (let i = 0; i < visionDims.length; i++) {
+    const dimId = `V${String(i + 1).padStart(2, '0')}`;
+    const rubric = await generateOneRubric({
+      dimId, dim: visionDims[i], targetPath, side: 'vision', llmClient: client, retries,
+    });
+    rubrics.set(dimId, rubric);
+  }
+  for (let i = 0; i < archDims.length; i++) {
+    const dimId = `A${String(i + 1).padStart(2, '0')}`;
+    const rubric = await generateOneRubric({
+      dimId, dim: archDims[i], targetPath, side: 'arch', llmClient: client, retries,
+    });
+    rubrics.set(dimId, rubric);
+  }
+
+  return {
+    rubrics,
+    meta: {
+      generator_model: usedModel,
+      total_input_tokens: totalInput || undefined,
+      total_output_tokens: totalOutput || undefined,
+    },
+  };
+}

--- a/scripts/eva/README.md
+++ b/scripts/eva/README.md
@@ -1,0 +1,125 @@
+# /heal vision evidence scoring — two modes
+
+`scripts/eva/vision-evidence-scorer.js` deterministically scores vision +
+architecture documents against the codebase they describe. Two modes:
+
+## Mode 1 — EHG self-scoring (deterministic)
+
+**When:** `args.visionKey` matches `/^VISION-EHG[-_]/i` (default
+`VISION-EHG-L1-001`).
+
+**How:** Static rubrics under `scripts/eva/evidence-rubrics/`
+(`V01-V11`, `A01-A07`, `T01-T02`) reference EHG codebase paths/exports.
+`loadAllRubrics()` returns `Map<dimId, rubric>` and `runRubricChecks()` evaluates
+each check at `process.cwd()` (the EHG_Engineer repo root).
+
+No LLM is called. Pure file/AST/DB introspection. Same codebase → same score.
+
+Regression-pinned via `tests/unit/eva/ehg-self-scoring-regression-pin.test.js`:
+the fixture `tests/fixtures/ehg-baseline-score.json` captures the per-dim and
+total score at the time SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 merged.
+Per-dim drift > 2 pts fails the regression pin.
+
+```bash
+node scripts/eva/vision-evidence-scorer.js                 # score EHG self
+node scripts/eva/vision-evidence-scorer.js --persist       # ...and persist
+node scripts/eva/vision-evidence-scorer.js --verbose       # show per-check evidence
+LIVE_EHG_SCORE=1 npx vitest run tests/unit/eva/ehg-self-scoring-regression-pin.test.js
+# ↑ re-runs the scorer end-to-end and asserts ±2pt baseline match
+```
+
+## Mode 2 — Venture scoring (LLM-generated, content-hash cached)
+
+**When:** `args.visionKey` does NOT match the EHG regex (any venture vision-key,
+e.g. `VISION-CRONGENIUS-API-L2-001`).
+
+**Why a separate path:** EHG rubrics are HARD-CODED to EHG paths (V01 →
+`scripts/modules/auto-proceed/urgency-scorer.js`, etc.). Positional matching
+pairs V01 with whatever the venture's first vision dimension happens to be —
+but the rubric's checks still assert EHG paths. Result: every venture scored
+under EHG rubrics produces meaningless evidence. SD-CRONGENIUS-MAKE-HEAL-VISION-001
+shipped a `--target-path` flag so checks RESOLVE against the venture codebase;
+this SD closes the SEMANTIC gap by generating rubrics that REFERENCE the
+venture codebase from the start.
+
+**How:**
+1. Fetch `vision` and `arch` rows (both have a `content_hash` GENERATED STORED
+   column, added by migration `20260527_eva_vision_rubric_cache_and_content_hash.sql`).
+2. Compute `cacheKey = SHA-256(JSON({vision_key, plan_key, vision_content_hash, plan_content_hash}))`.
+3. `getCachedRubrics(supabase, cacheKey)`:
+   - HIT → use cached `Map<dimId, rubric>` directly. O(1) DB lookup, no LLM call.
+   - MISS → call `generateVentureRubrics({vision, arch, targetPath, retries: 1})`
+     which prompts an LLM (`lib/llm/client-factory.js` cascade: Google →
+     Anthropic → OpenAI → Ollama) once per dimension. Output is validated via
+     `validateRubricStrict()` (≥3 checks, allowed types only, concrete params,
+     weights sum to 100 ±2). Persisted via `setCachedRubrics()`.
+4. Generated rubrics flow through the same `runRubricChecks(rubric, {targetPath})`
+   path as the static EHG rubrics — there is no downstream divergence.
+
+**Cache invalidation:** implicit. When `eva_vision_documents.content` or
+`eva_architecture_plans.content` changes, `content_hash` recomputes, the cache
+key changes, the next scoring run sees a cache MISS and regenerates.
+
+```bash
+# CronGenius example:
+node scripts/eva/vision-evidence-scorer.js \
+  --vision-key VISION-CRONGENIUS-API-L2-001 \
+  --target-path /path/to/CronGenius
+# Arch-key auto-derives to ARCH-CRONGENIUS-001 (pass --arch-key to override).
+```
+
+**Cost characteristics:**
+- 1 LLM call per dimension per cache miss. Typical venture has ~20 dims (≤13
+  vision + ≤7 arch) → ~20 calls per fresh generation.
+- At medium-tier model pricing (~$0.02/call), one full generation is ~$0.40.
+- All subsequent calls (with unchanged content) are O(1) DB lookups.
+
+**Failure mode (TR-6 — refused-silent-fallback):** when no cloud LLM key is
+available and no cache row exists, `generateVentureRubrics()` throws with an
+explicit remediation hint. It does NOT silently fall back to EHG rubrics —
+doing so would produce misleading scores for ventures (the exact bug this
+SD fixes).
+
+## Components
+
+| Path | Purpose |
+|------|---------|
+| `scripts/eva/vision-evidence-scorer.js` | CLI entry; exports `isEhgVisionKey()`, `selectRubricMap()`, `resolveArchKey()`, `deriveArchKeyFromVisionKey()` |
+| `scripts/eva/evidence-rubrics/index.js` | `loadAllRubrics()`, `validateRubric()`, `validateRubricStrict()`, `ALLOWED_CHECK_TYPES` |
+| `scripts/eva/evidence-rubrics/V01..V11, A01..A07, T01..T02` | Static EHG rubric definitions |
+| `scripts/eva/evidence-checks/check-types.js` | The 6 deterministic check-type implementations (factory: `createCheckTypes({targetPath})`) |
+| `scripts/eva/evidence-checks/check-runner.js` | `runRubricChecks(rubric, {supabase, targetPath?})` |
+| `lib/eva/rubric-generator.js` | `generateVentureRubrics({vision, arch, targetPath, llmClient?, retries?})` (FR-2) |
+| `lib/eva/rubric-cache.js` | `computeCacheKey()`, `getCachedRubrics()`, `setCachedRubrics()` (FR-3) |
+| `eva_vision_rubric_cache` table | Generated-rubric cache, keyed on `cache_key` SHA-256 hex |
+
+## The 6 deterministic check types (LLM is constrained to these)
+
+| Type | Params | Behavior |
+|------|--------|----------|
+| `file_exists` | `glob`, optional `minMatches` | Pass when ≥ `minMatches` files match |
+| `code_pattern` | `glob`, `pattern` (regex), optional `minMatches` | Pass when ≥ `minMatches` files contain the pattern |
+| `anti_pattern` | `glob`, `pattern`, optional `maxMatches` (default 0) | Pass when ≤ `maxMatches` files contain the pattern |
+| `export_exists` | `module` (relative path), `exportName` | Dynamic-import the module and check the export |
+| `db_row_exists` | `table`, optional `column` + `value` or `filter` | Pass when the Supabase query returns ≥ 1 row |
+| `file_count` | `glob`, `minCount` | Pass when match count ≥ `minCount` |
+
+All checks have a 10s timeout; a throwing check scores as `passed: false`.
+
+## Adding new dimensions (EHG)
+
+1. Bump the `extracted_dimensions` array on `eva_vision_documents` /
+   `eva_architecture_plans` for `VISION-EHG-L1-001` / `ARCH-EHG-L1-001`.
+2. Add a new `V{NN}-name.js` or `A{NN}-name.js` file under
+   `scripts/eva/evidence-rubrics/` that exports a rubric matching the schema.
+3. Run `node scripts/eva/vision-evidence-scorer.js` to verify scoring; commit
+   the updated fixture `tests/fixtures/ehg-baseline-score.json` if the EHG
+   total or per-dim scores changed (the regression pin will catch silent drift
+   otherwise).
+
+## Adding new dimensions (venture)
+
+You don't. Venture rubrics are generated from the venture's `extracted_dimensions`
+JSONB — add or revise dimensions on the venture's vision/arch doc and the next
+scoring run will regenerate rubrics for the changed shape (content_hash drives
+cache invalidation automatically).

--- a/scripts/eva/evidence-rubrics/index.js
+++ b/scripts/eva/evidence-rubrics/index.js
@@ -14,8 +14,9 @@ const RUBRIC_FILE_PATTERN = /^(V\d{2}|A\d{2}|T\d{2})-/;
 
 /**
  * Validate a rubric definition has required fields.
+ * Exported so SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 rubric-generator can reuse.
  */
-function validateRubric(rubric, filename) {
+export function validateRubric(rubric, filename) {
   const errors = [];
   if (!rubric.id) errors.push('missing id');
   if (!rubric.name) errors.push('missing name');
@@ -32,6 +33,55 @@ function validateRubric(rubric, filename) {
   }
   if (errors.length > 0) {
     throw new Error(`Invalid rubric ${filename}: ${errors.join(', ')}`);
+  }
+}
+
+/**
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-4): stricter rules for
+ * LLM-generated rubrics. Runs validateRubric first, then enforces:
+ *   (a) checks.length >= 3
+ *   (b) each check.type ∈ ALLOWED_CHECK_TYPES (the 6 deterministic types)
+ *   (c) each check.params has a concrete-reference field with a non-empty
+ *       string value (glob / pattern / module / table)
+ *   (d) sum of check.weight values ∈ [98, 102] (±2 tolerance for rounding)
+ *
+ * @param {object} rubric - rubric to validate
+ * @param {string} source - identifier used in error messages
+ * @throws {Error} on violation
+ */
+export const ALLOWED_CHECK_TYPES = Object.freeze([
+  'file_exists',
+  'code_pattern',
+  'anti_pattern',
+  'export_exists',
+  'db_row_exists',
+  'file_count',
+]);
+
+const CONCRETE_PARAM_FIELDS = ['glob', 'pattern', 'module', 'table'];
+
+export function validateRubricStrict(rubric, source) {
+  validateRubric(rubric, source);
+  const errors = [];
+  if (rubric.checks.length < 3) {
+    errors.push(`checks.length=${rubric.checks.length} (LLM rubrics require >= 3 checks per dimension)`);
+  }
+  let weightSum = 0;
+  for (const check of rubric.checks) {
+    if (!ALLOWED_CHECK_TYPES.includes(check.type)) {
+      errors.push(`check ${check.id} type='${check.type}' is not in ALLOWED_CHECK_TYPES (${ALLOWED_CHECK_TYPES.join(',')})`);
+    }
+    const hasConcrete = CONCRETE_PARAM_FIELDS.some(f => typeof check.params[f] === 'string' && check.params[f].length > 0);
+    if (!hasConcrete) {
+      errors.push(`check ${check.id} params has no non-empty concrete-reference field (one of: ${CONCRETE_PARAM_FIELDS.join(',')})`);
+    }
+    weightSum += Number(check.weight) || 0;
+  }
+  if (weightSum < 98 || weightSum > 102) {
+    errors.push(`weight sum=${weightSum} is outside [98,102] (rubric weights must sum to ~100)`);
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid LLM rubric ${source}: ${errors.join('; ')}`);
   }
 }
 

--- a/scripts/eva/vision-evidence-scorer.js
+++ b/scripts/eva/vision-evidence-scorer.js
@@ -27,6 +27,9 @@ import { dirname, join } from 'path';
 import { loadAllRubrics } from './evidence-rubrics/index.js';
 import { runRubricChecks, computeDimensionScore, generateReasoning, generateGaps } from './evidence-checks/check-runner.js';
 import { ensureFresh, getGitMeta, warnIfWorktree } from './git-freshness.js';
+// SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1/FR-2/FR-3): venture-aware rubric path
+import { computeCacheKey, getCachedRubrics, setCachedRubrics } from '../../lib/eva/rubric-cache.js';
+import { generateVentureRubrics } from '../../lib/eva/rubric-generator.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 config({ path: join(__dirname, '../../.env') });
@@ -99,6 +102,74 @@ function parseArgs(argv) {
  *     return error so caller can fail loudly (no silent EHG fallback).
  *   - Explicit --arch-key always wins.
  */
+/**
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1):
+ *   Pure predicate; identifies EHG self-scoring vision-keys for the
+ *   early-return path that preserves the deterministic rubric library.
+ *   Accepts `VISION-EHG-...` and `VISION-EHG_...` (case-insensitive).
+ */
+export function isEhgVisionKey(visionKey) {
+  return typeof visionKey === 'string' && /^VISION-EHG[-_]/i.test(visionKey);
+}
+
+/**
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1):
+ *   Resolve which rubric Map to use for a given vision-key, with optional
+ *   dependency injection for testing (cache/generator/loader can be replaced).
+ *
+ * @param {object} args
+ * @param {string} args.visionKey
+ * @param {string} args.planKey
+ * @param {object} args.vision - eva_vision_documents row (must include extracted_dimensions; content_hash optional)
+ * @param {object} args.arch - eva_architecture_plans row (must include extracted_dimensions; content_hash optional)
+ * @param {object} args.supabase - service client (used by cache get/set)
+ * @param {string} [args.targetPath]
+ * @param {object} [args.deps] - injection hatch: { loadAllRubrics, computeCacheKey, getCachedRubrics, setCachedRubrics, generateVentureRubrics }
+ * @returns {Promise<{ rubrics: Map<string, object>, source: string }>}
+ */
+export async function selectRubricMap({ visionKey, planKey, vision, arch, supabase, targetPath, deps = {} }) {
+  const loaders = {
+    loadAllRubrics: deps.loadAllRubrics ?? loadAllRubrics,
+    computeCacheKey: deps.computeCacheKey ?? computeCacheKey,
+    getCachedRubrics: deps.getCachedRubrics ?? getCachedRubrics,
+    setCachedRubrics: deps.setCachedRubrics ?? setCachedRubrics,
+    generateVentureRubrics: deps.generateVentureRubrics ?? generateVentureRubrics,
+  };
+  if (isEhgVisionKey(visionKey)) {
+    const rubrics = await loaders.loadAllRubrics();
+    return { rubrics, source: 'Loaded EHG deterministic rubrics (static library)' };
+  }
+  const cacheKey = loaders.computeCacheKey({
+    vision_key: visionKey,
+    plan_key: planKey,
+    vision_content_hash: vision?.content_hash,
+    plan_content_hash: arch?.content_hash,
+  });
+  const cached = await loaders.getCachedRubrics(supabase, cacheKey);
+  if (cached) {
+    return {
+      rubrics: cached,
+      source: `Loaded venture-aware rubrics from cache (cache_key=${cacheKey.slice(0, 12)}…)`,
+    };
+  }
+  const { rubrics: generated, meta } = await loaders.generateVentureRubrics({
+    vision, arch, targetPath, retries: 1,
+  });
+  await loaders.setCachedRubrics(
+    supabase, cacheKey, generated,
+    {
+      vision_key: visionKey, plan_key: planKey,
+      vision_content_hash: vision?.content_hash,
+      plan_content_hash: arch?.content_hash,
+    },
+    { generator_model: meta.generator_model, generator_cost_usd: null }
+  );
+  return {
+    rubrics: generated,
+    source: `Generated ${generated.size} venture-aware rubrics (model=${meta.generator_model || 'unknown'}, persisted to eva_vision_rubric_cache)`,
+  };
+}
+
 export function resolveArchKey({ visionKey, archKey, explicitArchKey }) {
   if (explicitArchKey && archKey) {
     return { archKey, derived: false, error: null };
@@ -163,20 +234,19 @@ async function main() {
   }
   console.log(`   Scoring codebase at: ${gitMeta.shortSha} (${gitMeta.branch})\n`);
 
-  // 1. Load rubrics
-  const rubrics = await loadAllRubrics();
-  console.log(`   Loaded ${rubrics.size} evidence rubrics`);
-
-  // 2. Load dimension metadata (weights) from DB
+  // 1. Load dimension metadata (vision + arch) FIRST — needed before rubric branch.
+  //    SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1): includes content + content_hash
+  //    (GENERATED STORED via 20260527_eva_vision_rubric_cache_and_content_hash.sql) so the
+  //    venture branch can compute a stable cache key without re-hashing content in JS.
   const { data: vision } = await supabase
     .from('eva_vision_documents')
-    .select('id, extracted_dimensions')
+    .select('id, extracted_dimensions, content, content_hash')
     .eq('vision_key', args.visionKey)
     .single();
 
   const { data: arch } = await supabase
     .from('eva_architecture_plans')
-    .select('id, extracted_dimensions')
+    .select('id, extracted_dimensions, content, content_hash')
     .eq('plan_key', args.archKey)
     .single();
 
@@ -190,6 +260,19 @@ async function main() {
     console.error(`❌ Derived arch-key '${args.archKey}' not found in eva_architecture_plans. Create the arch plan first via 'archplan-command.mjs upsert --plan-key ${args.archKey} --vision-key ${args.visionKey}' OR pass --arch-key explicitly. Refusing silent fallback to EHG architecture.`);
     process.exit(1);
   }
+
+  // 2. Load rubrics — branch on vision-key.
+  //    SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1):
+  //    - EHG vision-key (matches /^VISION-EHG[-_]/i): static deterministic rubrics (unchanged).
+  //    - Non-EHG vision-key: LLM-generated venture-aware rubrics, content-hash cached.
+  //    Refuses silent fallback to EHG rubrics when the venture branch fails (TR-6).
+  const { rubrics, source: rubricSource } = await selectRubricMap({
+    visionKey: args.visionKey,
+    planKey: args.archKey,
+    vision, arch, supabase,
+    targetPath: resolvedTargetPath || process.cwd(),
+  });
+  console.log(`   ${rubricSource}: ${rubrics.size} rubrics`);
 
   // 3. Build dimension weight map from DB metadata
   const dbDimensions = [

--- a/tests/fixtures/ehg-baseline-score.json
+++ b/tests/fixtures/ehg-baseline-score.json
@@ -1,0 +1,132 @@
+{
+  "dimensions": [
+    {
+      "id": "A01",
+      "name": "stateless_shared_services",
+      "score": 100,
+      "reasoning": "Passed (4/4): VentureContextManager exports createVentureContextManager; No singleton pattern in domain services; Service index re-exports multiple service modules; Stage templates are stateless functions (no class state).",
+      "gaps": []
+    },
+    {
+      "id": "A02",
+      "name": "database_single_source_of_truth",
+      "score": 100,
+      "reasoning": "Passed (5/5): Supabase client used throughout the codebase; Database migrations directory has migration files; Artifact versioning exports createVersionedArtifact; No file-based state for venture data (no JSON flat-file state); Strategic directives stored in database table.",
+      "gaps": []
+    },
+    {
+      "id": "A03",
+      "name": "eva_hub_and_orchestration_model",
+      "score": 100,
+      "reasoning": "Passed (5/5): EVA orchestrator exports processStage; Concurrent venture orchestrator exports class; Stage-zero orchestrator exports executeStageZero; EVA orchestrator routes to stages without embedded domain logic; Orchestrator state machine exports validateStateTransition.",
+      "gaps": []
+    },
+    {
+      "id": "A04",
+      "name": "event_rounds_priority_queue_work_routing",
+      "score": 100,
+      "reasoning": "Passed (4/4): Rounds scheduler exports registerRound; Event bus exports initializeEventBus; Urgency scorer exports calculateUrgencyScore for prioritization; Run-rounds CLI executes registered rounds.",
+      "gaps": []
+    },
+    {
+      "id": "A05",
+      "name": "event_bus_integration",
+      "score": 100,
+      "reasoning": "Passed (4/4): Handler registry exports registerHandler; Event router exports processEvent; Multiple event handler implementations exist; Event handlers cover lifecycle events (stage-completed, gate-evaluated).",
+      "gaps": []
+    },
+    {
+      "id": "A06",
+      "name": "lifecycle_stage_orchestration_and_artifact_versioning",
+      "score": 100,
+      "reasoning": "Passed (4/4): At least 25 stage template files exist; Artifact versioning exports createVersionedArtifact; Artifact version chain exports createChain; Venture state machine exports VentureStateMachine class.",
+      "gaps": []
+    },
+    {
+      "id": "A07",
+      "name": "chairman_governance_gatekeeping",
+      "score": 100,
+      "reasoning": "Passed (5/5): Chairman decision watcher polls for pending decisions; No timeout enforcement on chairman decisions; Chairman override tracker provides absolute authority; Chairman governance panels module exists; DFE escalation gate routes decisions to chairman_decisions table.",
+      "gaps": []
+    },
+    {
+      "id": "V01",
+      "name": "automation_by_default",
+      "score": 100,
+      "reasoning": "Passed (4/4): Urgency scorer exports calculateUrgencyScore; Stage execution engine exports executeStage; Stage templates have deterministic execute functions; Auto-proceed state persisted to file or DB.",
+      "gaps": []
+    },
+    {
+      "id": "V02",
+      "name": "chairman_governance_model",
+      "score": 100,
+      "reasoning": "Passed (5/5): Chairman decision watcher exists and polls for decisions; Chairman preference store manages thresholds; Chairman override tracker at stage entry; No auto-approval or timeout bypass in chairman modules; Chairman backend modules exist (>=5 chairman-*.js).",
+      "gaps": []
+    },
+    {
+      "id": "V03",
+      "name": "analysisstep_active_intelligence",
+      "score": 100,
+      "reasoning": "Passed (4/4): Analysis steps index registers stage analysis modules; At least 20 individual stage analysis files exist; Analysis steps produce structured output (return object/JSON); Analysis steps reference prior stage data (compounding).",
+      "gaps": []
+    },
+    {
+      "id": "V04",
+      "name": "decision_filter_engine_escalation",
+      "score": 100,
+      "reasoning": "Passed (4/4): DFE exports evaluateDecision function; DFE has multiple trigger types defined; DFE context adapter exports transformForPresentation; Reality gates export evaluateRealityGate.",
+      "gaps": []
+    },
+    {
+      "id": "V05",
+      "name": "cross_stage_data_contracts",
+      "score": 100,
+      "reasoning": "Passed (4/4): Stage contracts module exports getContract; YAML contract loader exports loadContractsFromYaml; Contracts define consumes/produces per stage; Output schema extractor exports extractOutputSchema.",
+      "gaps": []
+    },
+    {
+      "id": "V06",
+      "name": "cli_authoritative_workflow",
+      "score": 100,
+      "reasoning": "Passed (4/4): run-stage.js imports and invokes stage execution engine; run-rounds.js imports and invokes rounds scheduler; CLI commands registered in package.json scripts; Stage execution engine exports executeStage.",
+      "gaps": []
+    },
+    {
+      "id": "V07",
+      "name": "unlimited_compute_posture",
+      "score": 100,
+      "reasoning": "Passed (5/5): Token tracker exports recordTokenUsage; DFE cost_threshold trigger exists for awareness; Compute posture scorer exports scoreComputePosture; No hard budget enforcement blocking LLM calls; Governance compute posture exports getComputePosture.",
+      "gaps": []
+    },
+    {
+      "id": "V08",
+      "name": "chairman_dashboard_scope",
+      "score": 100,
+      "reasoning": "Passed (4/4): Scope validation enforcer exports validateScope; Never-autonomous registry exports checkAutonomousAllowed; V08 scope auth scorer produces deterministic score; Never-autonomous registry exports enforceAutonomousCheck.",
+      "gaps": []
+    },
+    {
+      "id": "V09",
+      "name": "strategic_governance_cascade",
+      "score": 100,
+      "reasoning": "Passed (5/5): Cascade validator exports validateCascade; aegis_constitutions table has records; eva_vision_documents and eva_architecture_plans have records; Cascade validation produces blocking failures on violation; Cascade invalidation engine exports getStaleDocuments.",
+      "gaps": []
+    },
+    {
+      "id": "V10",
+      "name": "okr_driven_prioritization",
+      "score": 100,
+      "reasoning": "Passed (4/4): OKR monthly handler exports runOkrMonthlySnapshot; OKR monthly generator exports runOkrMonthlyGeneration; OKR hard tier integrated into urgency scoring; OKR stale archival exports archiveStaleOkrs.",
+      "gaps": []
+    },
+    {
+      "id": "V11",
+      "name": "governance_guardrail_enforcement",
+      "score": 100,
+      "reasoning": "Passed (4/4): Guardrail validator exports validateGuardrails; Guardrail registry defines named guardrails; Guardrail intelligence analyzer exports analyzeGuardrailResults; Guardrail registry exports check enforcement function.",
+      "gaps": []
+    }
+  ],
+  "total_score": 100,
+  "summary": "Evidence-based scoring: 18/18 dimensions pass (>= 93). Total: 100/100."
+}

--- a/tests/unit/eva/ehg-self-scoring-regression-pin.test.js
+++ b/tests/unit/eva/ehg-self-scoring-regression-pin.test.js
@@ -1,0 +1,75 @@
+/**
+ * EHG self-scoring regression-pin.
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-5 / TS-15).
+ *
+ * Pins the EHG early-return identity preservation. The fixture
+ * tests/fixtures/ehg-baseline-score.json captures the score at the time
+ * this SD merged; any subsequent regression in the EHG path causes the
+ * total or per-dim score to drift, which this test catches structurally.
+ *
+ * Live-scoring assertion (`it.runIf(LIVE_EHG_SCORE=1)`) re-runs the actual
+ * scorer against DB+filesystem and asserts ±2 pt delta from baseline.
+ * Default-skipped to keep unit tests hermetic.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, '../../fixtures/ehg-baseline-score.json');
+const SCORER_PATH = join(__dirname, '../../../scripts/eva/vision-evidence-scorer.js');
+const LIVE = process.env.LIVE_EHG_SCORE === '1';
+
+function loadBaseline() {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+}
+
+describe('EHG self-scoring regression-pin (fixture)', () => {
+  it('baseline fixture exists', () => {
+    expect(existsSync(FIXTURE_PATH)).toBe(true);
+  });
+
+  it('baseline has total_score 90-100 (sanity)', () => {
+    const b = loadBaseline();
+    expect(typeof b.total_score).toBe('number');
+    expect(b.total_score).toBeGreaterThanOrEqual(90);
+    expect(b.total_score).toBeLessThanOrEqual(100);
+  });
+
+  it('baseline contains 18 dimensions (V01-V11 + A01-A07)', () => {
+    const b = loadBaseline();
+    expect(Array.isArray(b.dimensions)).toBe(true);
+    expect(b.dimensions).toHaveLength(18);
+    const ids = b.dimensions.map(d => d.id).sort();
+    expect(ids).toContain('V01');
+    expect(ids).toContain('V11');
+    expect(ids).toContain('A01');
+    expect(ids).toContain('A07');
+  });
+
+  it('every baseline dimension has a numeric score, name, reasoning', () => {
+    const b = loadBaseline();
+    for (const d of b.dimensions) {
+      expect(typeof d.score).toBe('number');
+      expect(d.name).toBeTypeOf('string');
+      expect(d.reasoning).toBeTypeOf('string');
+    }
+  });
+
+  it.runIf(LIVE)('LIVE: re-running EHG scorer produces overall + per-dim scores within ±2pt of baseline', () => {
+    const baseline = loadBaseline();
+    const out = execFileSync('node', [SCORER_PATH], { encoding: 'utf8', cwd: join(__dirname, '../../..'), timeout: 180_000 });
+    const m = out.match(/===EVIDENCE_SCORE_JSON===\n([\s\S]*?)===END_JSON===/);
+    expect(m, 'scorer should emit ===EVIDENCE_SCORE_JSON=== block').toBeTruthy();
+    const current = JSON.parse(m[1]);
+    expect(Math.abs(current.total_score - baseline.total_score)).toBeLessThanOrEqual(2);
+    const baseById = new Map(baseline.dimensions.map(d => [d.id, d]));
+    for (const cur of current.dimensions) {
+      const base = baseById.get(cur.id);
+      expect(base, `dim ${cur.id} missing from baseline`).toBeTruthy();
+      expect(Math.abs(cur.score - base.score), `dim ${cur.id} drifted ${cur.score} vs ${base.score}`).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/tests/unit/eva/rubric-cache.test.js
+++ b/tests/unit/eva/rubric-cache.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for lib/eva/rubric-cache.js
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 FR-3 (TS-1..TS-4, TS-3b).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  computeCacheKey,
+  getCachedRubrics,
+  setCachedRubrics,
+} from '../../../lib/eva/rubric-cache.js';
+
+function makeSupabaseMock({ row = null, upsertError = null, updateError = null } = {}) {
+  const calls = { update: [], upsert: [], select: [] };
+  return {
+    calls,
+    from: (table) => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => {
+            calls.select.push({ table });
+            return { data: row, error: null };
+          },
+        }),
+      }),
+      update: (patch) => ({
+        eq: (col, val) => {
+          calls.update.push({ table, patch, col, val });
+          return { error: updateError };
+        },
+      }),
+      upsert: (newRow, opts) => {
+        calls.upsert.push({ table, newRow, opts });
+        return { error: upsertError };
+      },
+    }),
+  };
+}
+
+describe('computeCacheKey', () => {
+  it('TS-3 (vision side): key differs when vision_content_hash changes', () => {
+    const k1 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'X' });
+    const k2 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'B', plan_content_hash: 'X' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('TS-3b (arch side): key differs when plan_content_hash changes (TR-7 dual-hash)', () => {
+    const k1 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'X' });
+    const k2 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'Y' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('is deterministic for same inputs', () => {
+    const k1 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'X' });
+    const k2 = computeCacheKey({ vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'X' });
+    expect(k1).toBe(k2);
+  });
+
+  it('produces a 64-char hex SHA-256', () => {
+    const k = computeCacheKey({ vision_key: 'V', plan_key: 'P' });
+    expect(k).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('getCachedRubrics', () => {
+  it('TS-1: returns null on cache miss', async () => {
+    const sb = makeSupabaseMock({ row: null });
+    const result = await getCachedRubrics(sb, 'anykey');
+    expect(result).toBeNull();
+  });
+
+  it('TS-4: returns Map on hit and updates last_hit_at', async () => {
+    const rubricsObj = { V01: { id: 'V01', name: 'foo', checks: [] } };
+    const sb = makeSupabaseMock({ row: { rubrics: rubricsObj } });
+    const result = await getCachedRubrics(sb, 'somekey');
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(1);
+    expect(result.get('V01').id).toBe('V01');
+    const hitUpdate = sb.calls.update.find(u => u.col === 'cache_key' && u.val === 'somekey');
+    expect(hitUpdate).toBeDefined();
+    expect(hitUpdate.patch.last_hit_at).toBeTypeOf('string');
+  });
+});
+
+describe('setCachedRubrics', () => {
+  it('TS-2: upserts the rubrics row keyed on cache_key', async () => {
+    const sb = makeSupabaseMock();
+    const rubrics = new Map([['V01', { id: 'V01', name: 'foo', checks: [] }]]);
+    await setCachedRubrics(
+      sb, 'somekey', rubrics,
+      { vision_key: 'V', plan_key: 'P', vision_content_hash: 'A', plan_content_hash: 'X' },
+      { generator_model: 'claude-sonnet-4-6', generator_cost_usd: 0.0123 }
+    );
+    expect(sb.calls.upsert).toHaveLength(1);
+    const call = sb.calls.upsert[0];
+    expect(call.table).toBe('eva_vision_rubric_cache');
+    expect(call.newRow.cache_key).toBe('somekey');
+    expect(call.newRow.vision_key).toBe('V');
+    expect(call.newRow.plan_key).toBe('P');
+    expect(call.newRow.vision_content_hash).toBe('A');
+    expect(call.newRow.plan_content_hash).toBe('X');
+    expect(call.newRow.rubrics).toEqual({ V01: { id: 'V01', name: 'foo', checks: [] } });
+    expect(call.newRow.generator_model).toBe('claude-sonnet-4-6');
+    expect(call.newRow.generator_cost_usd).toBe(0.0123);
+    expect(call.opts).toEqual({ onConflict: 'cache_key' });
+  });
+
+  it('throws when upsert errors', async () => {
+    const sb = makeSupabaseMock({ upsertError: { message: 'boom' } });
+    const rubrics = new Map();
+    await expect(setCachedRubrics(sb, 'k', rubrics, { vision_key: 'V', plan_key: 'P' }))
+      .rejects.toThrow(/boom/);
+  });
+});
+
+describe('round-trip', () => {
+  it('TS-2 (full roundtrip): setCachedRubrics then getCachedRubrics returns same Map content', async () => {
+    let stored = null;
+    const sb = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: stored, error: null }),
+          }),
+        }),
+        update: () => ({ eq: () => ({ error: null }) }),
+        upsert: (row) => {
+          stored = { rubrics: row.rubrics };
+          return { error: null };
+        },
+      }),
+    };
+    const before = new Map([
+      ['V01', { id: 'V01', name: 'foo', checks: [{ id: 'V01-C1', type: 'file_exists', weight: 100, params: { glob: 'x' } }] }],
+      ['A01', { id: 'A01', name: 'bar', checks: [] }],
+    ]);
+    await setCachedRubrics(sb, 'rtkey', before, { vision_key: 'V', plan_key: 'P' });
+    const after = await getCachedRubrics(sb, 'rtkey');
+    expect(after).toBeInstanceOf(Map);
+    expect(after.size).toBe(2);
+    expect(after.get('V01')).toEqual(before.get('V01'));
+    expect(after.get('A01')).toEqual(before.get('A01'));
+  });
+});

--- a/tests/unit/eva/rubric-generator.test.js
+++ b/tests/unit/eva/rubric-generator.test.js
@@ -1,0 +1,192 @@
+/**
+ * Tests for lib/eva/rubric-generator.js
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-2 / TS-5..TS-10).
+ */
+import { describe, it, expect } from 'vitest';
+import { generateVentureRubrics } from '../../../lib/eva/rubric-generator.js';
+
+function makeValidRubric(dimId) {
+  return {
+    id: dimId,
+    name: 'venture_dim_' + dimId,
+    checks: [
+      { id: `${dimId}-C1`, label: 'has worker file', type: 'file_exists', weight: 40, params: { glob: 'src/workers/*.js' } },
+      { id: `${dimId}-C2`, label: 'exports run', type: 'export_exists', weight: 30, params: { module: 'src/main.js', exportName: 'run' } },
+      { id: `${dimId}-C3`, label: 'config schema', type: 'code_pattern', weight: 30, params: { glob: 'src/**/*.js', pattern: 'z\\.object' } },
+    ],
+  };
+}
+
+function makeMockClient(responses) {
+  const calls = [];
+  const queue = [...responses];
+  return {
+    calls,
+    isInlineOnly: false,
+    model: 'mock-model',
+    async complete(system, user) {
+      calls.push({ system, user });
+      if (queue.length === 0) {
+        return { content: '{}' };
+      }
+      const next = queue.shift();
+      return { content: typeof next === 'string' ? next : JSON.stringify(next) };
+    },
+  };
+}
+
+function makeInlineOnlyClient() {
+  return {
+    isInlineOnly: true,
+    async complete() { return { content: '{}' }; },
+  };
+}
+
+describe('generateVentureRubrics', () => {
+  it('TS-5: generates valid Map<dimId, rubric> for 2 vision + 2 arch dims (mocked LLM)', async () => {
+    const client = makeMockClient([
+      makeValidRubric('V01'),
+      makeValidRubric('V02'),
+      makeValidRubric('A01'),
+      makeValidRubric('A02'),
+    ]);
+    const vision = { extracted_dimensions: [{ name: 'd1', weight: 0.5 }, { name: 'd2', weight: 0.5 }] };
+    const arch = { extracted_dimensions: [{ name: 'a1', weight: 0.5 }, { name: 'a2', weight: 0.5 }] };
+    const { rubrics, meta } = await generateVentureRubrics({
+      vision, arch, targetPath: '/fake/venture', llmClient: client, retries: 0,
+    });
+    expect(rubrics).toBeInstanceOf(Map);
+    expect(rubrics.size).toBe(4);
+    expect(rubrics.get('V01').id).toBe('V01');
+    expect(rubrics.get('A02').id).toBe('A02');
+    expect(rubrics.get('V01').checks.length).toBeGreaterThanOrEqual(3);
+    expect(meta.generator_model).toBe('mock-model');
+    expect(client.calls.length).toBe(4);
+  });
+
+  it('TS-6: rejects LLM rubric with <3 checks (validateRubricStrict catches)', async () => {
+    const tooFew = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { id: 'V01-C1', label: 'a', type: 'file_exists', weight: 50, params: { glob: 'a' } },
+        { id: 'V01-C2', label: 'b', type: 'file_exists', weight: 50, params: { glob: 'b' } },
+      ],
+    };
+    const client = makeMockClient([tooFew, tooFew]); // returns 2 checks both attempts
+    const vision = { extracted_dimensions: [{ name: 'd1' }] };
+    await expect(generateVentureRubrics({
+      vision, arch: { extracted_dimensions: [] }, targetPath: '/x', llmClient: client, retries: 1,
+    })).rejects.toThrow(/checks\.length=2/);
+  });
+
+  it('TS-7: rejects LLM rubric with check.type outside ALLOWED_CHECK_TYPES', async () => {
+    const badType = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { id: 'V01-C1', label: 'a', type: 'sql_query', weight: 34, params: { table: 't' } },
+        { id: 'V01-C2', label: 'b', type: 'file_exists', weight: 33, params: { glob: 'b' } },
+        { id: 'V01-C3', label: 'c', type: 'file_exists', weight: 33, params: { glob: 'c' } },
+      ],
+    };
+    const client = makeMockClient([badType, badType]);
+    await expect(generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client, retries: 1,
+    })).rejects.toThrow(/type='sql_query'/);
+  });
+
+  it('TS-8: rejects LLM rubric with empty params (no concrete-reference field)', async () => {
+    const empty = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { id: 'V01-C1', label: 'a', type: 'file_exists', weight: 34, params: {} },
+        { id: 'V01-C2', label: 'b', type: 'file_exists', weight: 33, params: { glob: 'b' } },
+        { id: 'V01-C3', label: 'c', type: 'file_exists', weight: 33, params: { glob: 'c' } },
+      ],
+    };
+    const client = makeMockClient([empty, empty]);
+    await expect(generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client, retries: 1,
+    })).rejects.toThrow(/no non-empty concrete-reference field/);
+  });
+
+  it('TS-9: retries once on validation failure; succeeds on second valid response', async () => {
+    const bad = { id: 'V01', name: 'foo', checks: [] }; // invalid: empty
+    const good = makeValidRubric('V01');
+    const client = makeMockClient([bad, good]);
+    const { rubrics } = await generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client, retries: 1,
+    });
+    expect(rubrics.size).toBe(1);
+    expect(rubrics.get('V01').checks.length).toBeGreaterThanOrEqual(3);
+    expect(client.calls.length).toBe(2);
+  });
+
+  it('TS-10: throws explicit error when LLM client is inline-only (TR-6 refused-silent-fallback)', async () => {
+    const client = makeInlineOnlyClient();
+    await expect(generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client, retries: 1,
+    })).rejects.toThrow(/REFUSING silent fallback to EHG rubrics/);
+  });
+
+  it('weights must sum to 100 ±2 — boundary tolerance', async () => {
+    // Same rubric with weights summing to 95 should be rejected; 101 should pass.
+    const w95 = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { id: 'V01-C1', label: 'a', type: 'file_exists', weight: 30, params: { glob: 'a' } },
+        { id: 'V01-C2', label: 'b', type: 'file_exists', weight: 30, params: { glob: 'b' } },
+        { id: 'V01-C3', label: 'c', type: 'file_exists', weight: 35, params: { glob: 'c' } },
+      ],
+    };
+    const client95 = makeMockClient([w95, w95]);
+    await expect(generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client95, retries: 1,
+    })).rejects.toThrow(/weight sum=95/);
+
+    const w101 = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { id: 'V01-C1', label: 'a', type: 'file_exists', weight: 34, params: { glob: 'a' } },
+        { id: 'V01-C2', label: 'b', type: 'file_exists', weight: 34, params: { glob: 'b' } },
+        { id: 'V01-C3', label: 'c', type: 'file_exists', weight: 33, params: { glob: 'c' } },
+      ],
+    };
+    const client101 = makeMockClient([w101]);
+    const { rubrics } = await generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client101, retries: 0,
+    });
+    expect(rubrics.get('V01').checks.length).toBe(3);
+  });
+
+  it('auto-assigns missing check ids', async () => {
+    const noIds = {
+      id: 'V01', name: 'foo',
+      checks: [
+        { label: 'a', type: 'file_exists', weight: 34, params: { glob: 'a' } },
+        { label: 'b', type: 'file_exists', weight: 33, params: { glob: 'b' } },
+        { label: 'c', type: 'file_exists', weight: 33, params: { glob: 'c' } },
+      ],
+    };
+    const client = makeMockClient([noIds]);
+    const { rubrics } = await generateVentureRubrics({
+      vision: { extracted_dimensions: [{ name: 'd1' }] },
+      arch: { extracted_dimensions: [] },
+      targetPath: '/x', llmClient: client, retries: 0,
+    });
+    const r = rubrics.get('V01');
+    expect(r.checks[0].id).toBe('V01-C1');
+    expect(r.checks[2].id).toBe('V01-C3');
+  });
+});

--- a/tests/unit/eva/rubric-validator-strict.test.js
+++ b/tests/unit/eva/rubric-validator-strict.test.js
@@ -1,0 +1,88 @@
+/**
+ * Tests for validateRubricStrict() in scripts/eva/evidence-rubrics/index.js.
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-4 / TS-11).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOWED_CHECK_TYPES,
+  validateRubric,
+  validateRubricStrict,
+} from '../../../scripts/eva/evidence-rubrics/index.js';
+
+function valid(dimId = 'V01') {
+  return {
+    id: dimId,
+    name: 'foo',
+    checks: [
+      { id: `${dimId}-C1`, label: 'a', type: 'file_exists', weight: 34, params: { glob: 'a' } },
+      { id: `${dimId}-C2`, label: 'b', type: 'export_exists', weight: 33, params: { module: 'src/main.js', exportName: 'run' } },
+      { id: `${dimId}-C3`, label: 'c', type: 'code_pattern', weight: 33, params: { glob: 'src/**.js', pattern: 'foo' } },
+    ],
+  };
+}
+
+describe('validateRubricStrict', () => {
+  it('passes a well-formed rubric', () => {
+    expect(() => validateRubricStrict(valid(), 'V01')).not.toThrow();
+  });
+
+  it('throws on <3 checks', () => {
+    const r = valid();
+    r.checks.pop();
+    expect(() => validateRubricStrict(r, 'V01')).toThrow(/checks\.length=2/);
+  });
+
+  it('throws on disallowed check type', () => {
+    const r = valid();
+    r.checks[0].type = 'http_get';
+    expect(() => validateRubricStrict(r, 'V01')).toThrow(/type='http_get'.*ALLOWED_CHECK_TYPES/);
+  });
+
+  it('throws on empty params (no concrete-reference field)', () => {
+    const r = valid();
+    r.checks[0].params = {};
+    expect(() => validateRubricStrict(r, 'V01')).toThrow(/no non-empty concrete-reference field/);
+  });
+
+  it('accepts params with `table` for db_row_exists', () => {
+    const r = valid();
+    r.checks[0] = { id: 'V01-C1', label: 'rows exist', type: 'db_row_exists', weight: 34, params: { table: 'foo' } };
+    expect(() => validateRubricStrict(r, 'V01')).not.toThrow();
+  });
+
+  it('TS-11 boundary: weight sum 102 passes (within ±2 tolerance)', () => {
+    const r = valid();
+    r.checks[0].weight = 36; // 36+33+33 = 102
+    expect(() => validateRubricStrict(r, 'V01')).not.toThrow();
+  });
+
+  it('TS-11 boundary: weight sum 98 passes (within ±2 tolerance)', () => {
+    const r = valid();
+    r.checks[0].weight = 32; // 32+33+33 = 98
+    expect(() => validateRubricStrict(r, 'V01')).not.toThrow();
+  });
+
+  it('TS-11 boundary: weight sum 90 throws (outside ±2 tolerance)', () => {
+    const r = valid();
+    r.checks[0].weight = 24; // 24+33+33 = 90
+    expect(() => validateRubricStrict(r, 'V01')).toThrow(/weight sum=90/);
+  });
+
+  it('ALLOWED_CHECK_TYPES is frozen and contains the 6 deterministic types', () => {
+    expect(Object.isFrozen(ALLOWED_CHECK_TYPES)).toBe(true);
+    expect(ALLOWED_CHECK_TYPES).toEqual([
+      'file_exists', 'code_pattern', 'anti_pattern',
+      'export_exists', 'db_row_exists', 'file_count',
+    ]);
+  });
+
+  it('still requires basic validateRubric fields (delegates to non-strict first)', () => {
+    expect(() => validateRubricStrict({ checks: [] }, 'X')).toThrow(/Invalid rubric.*missing id/);
+  });
+});
+
+describe('validateRubric (exported now per FR-4)', () => {
+  it('is exported and callable', () => {
+    expect(validateRubric).toBeTypeOf('function');
+  });
+});

--- a/tests/unit/eva/scorer-venture-branch.test.js
+++ b/tests/unit/eva/scorer-venture-branch.test.js
@@ -1,0 +1,120 @@
+/**
+ * Tests for scripts/eva/vision-evidence-scorer.js — venture/EHG branch.
+ * SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001 (FR-1 / TS-12, TS-13, TS-14).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { isEhgVisionKey, selectRubricMap } from '../../../scripts/eva/vision-evidence-scorer.js';
+
+const fakeSupabase = {}; // selectRubricMap never touches it directly — only the injected deps do.
+const fakeVision = { extracted_dimensions: [{ name: 'd1' }], content_hash: 'vhash1' };
+const fakeArch = { extracted_dimensions: [{ name: 'a1' }], content_hash: 'phash1' };
+
+describe('isEhgVisionKey', () => {
+  it('accepts VISION-EHG-L1-001', () => {
+    expect(isEhgVisionKey('VISION-EHG-L1-001')).toBe(true);
+  });
+  it('accepts VISION-EHG_FOO (underscore variant)', () => {
+    expect(isEhgVisionKey('VISION-EHG_FOO')).toBe(true);
+  });
+  it('accepts case-insensitive vision-ehg-l1-001', () => {
+    expect(isEhgVisionKey('vision-ehg-l1-001')).toBe(true);
+  });
+  it('rejects VISION-CRONGENIUS-API-L2-001', () => {
+    expect(isEhgVisionKey('VISION-CRONGENIUS-API-L2-001')).toBe(false);
+  });
+  it('rejects undefined / non-string', () => {
+    expect(isEhgVisionKey(undefined)).toBe(false);
+    expect(isEhgVisionKey(null)).toBe(false);
+    expect(isEhgVisionKey(123)).toBe(false);
+  });
+});
+
+describe('selectRubricMap', () => {
+  it('TS-12: EHG vision-key triggers loadAllRubrics; never calls cache/generator', async () => {
+    const ehgMap = new Map([['V01', { id: 'V01' }]]);
+    const deps = {
+      loadAllRubrics: vi.fn().mockResolvedValue(ehgMap),
+      computeCacheKey: vi.fn(),
+      getCachedRubrics: vi.fn(),
+      setCachedRubrics: vi.fn(),
+      generateVentureRubrics: vi.fn(),
+    };
+    const { rubrics, source } = await selectRubricMap({
+      visionKey: 'VISION-EHG-L1-001',
+      planKey: 'ARCH-EHG-L1-001',
+      vision: fakeVision, arch: fakeArch, supabase: fakeSupabase, targetPath: '/x',
+      deps,
+    });
+    expect(rubrics).toBe(ehgMap);
+    expect(source).toContain('EHG');
+    expect(deps.loadAllRubrics).toHaveBeenCalledTimes(1);
+    expect(deps.computeCacheKey).not.toHaveBeenCalled();
+    expect(deps.getCachedRubrics).not.toHaveBeenCalled();
+    expect(deps.generateVentureRubrics).not.toHaveBeenCalled();
+    expect(deps.setCachedRubrics).not.toHaveBeenCalled();
+  });
+
+  it('TS-13: venture vision-key with cache HIT uses cached map; skips generator + setCachedRubrics', async () => {
+    const cachedMap = new Map([['V01', { id: 'V01', name: 'cached' }]]);
+    const deps = {
+      loadAllRubrics: vi.fn(),
+      computeCacheKey: vi.fn().mockReturnValue('cachekey_abcdef'),
+      getCachedRubrics: vi.fn().mockResolvedValue(cachedMap),
+      setCachedRubrics: vi.fn(),
+      generateVentureRubrics: vi.fn(),
+    };
+    const { rubrics, source } = await selectRubricMap({
+      visionKey: 'VISION-CRONGENIUS-API-L2-001',
+      planKey: 'ARCH-CRONGENIUS-001',
+      vision: fakeVision, arch: fakeArch, supabase: fakeSupabase, targetPath: '/venture',
+      deps,
+    });
+    expect(rubrics).toBe(cachedMap);
+    expect(source).toContain('cache');
+    expect(deps.computeCacheKey).toHaveBeenCalledWith({
+      vision_key: 'VISION-CRONGENIUS-API-L2-001',
+      plan_key: 'ARCH-CRONGENIUS-001',
+      vision_content_hash: 'vhash1',
+      plan_content_hash: 'phash1',
+    });
+    expect(deps.getCachedRubrics).toHaveBeenCalledTimes(1);
+    expect(deps.loadAllRubrics).not.toHaveBeenCalled();
+    expect(deps.generateVentureRubrics).not.toHaveBeenCalled();
+    expect(deps.setCachedRubrics).not.toHaveBeenCalled();
+  });
+
+  it('TS-14: venture vision-key with cache MISS generates + persists; subsequent caller hits cache', async () => {
+    let stored = null;
+    const genMap = new Map([['V01', { id: 'V01', name: 'generated' }]]);
+    const deps = {
+      loadAllRubrics: vi.fn(),
+      computeCacheKey: vi.fn().mockReturnValue('cachekey_xyz'),
+      getCachedRubrics: vi.fn().mockImplementation(async () => stored),
+      setCachedRubrics: vi.fn().mockImplementation(async (sb, key, rubrics) => { stored = rubrics; }),
+      generateVentureRubrics: vi.fn().mockResolvedValue({ rubrics: genMap, meta: { generator_model: 'mock-llm' } }),
+    };
+    const first = await selectRubricMap({
+      visionKey: 'VISION-CRONGENIUS-API-L2-001',
+      planKey: 'ARCH-CRONGENIUS-001',
+      vision: fakeVision, arch: fakeArch, supabase: fakeSupabase, targetPath: '/venture',
+      deps,
+    });
+    expect(first.rubrics).toBe(genMap);
+    expect(first.source).toContain('Generated');
+    expect(first.source).toContain('mock-llm');
+    expect(deps.generateVentureRubrics).toHaveBeenCalledTimes(1);
+    expect(deps.setCachedRubrics).toHaveBeenCalledTimes(1);
+    expect(deps.loadAllRubrics).not.toHaveBeenCalled();
+
+    // Second call hits the (mock) cache via stored
+    const second = await selectRubricMap({
+      visionKey: 'VISION-CRONGENIUS-API-L2-001',
+      planKey: 'ARCH-CRONGENIUS-001',
+      vision: fakeVision, arch: fakeArch, supabase: fakeSupabase, targetPath: '/venture',
+      deps,
+    });
+    expect(second.rubrics).toBe(genMap);
+    expect(deps.generateVentureRubrics).toHaveBeenCalledTimes(1); // not called again
+    expect(deps.setCachedRubrics).toHaveBeenCalledTimes(1); // not called again
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the SEMANTIC gap in `/heal vision`: hard-coded EHG rubrics (V01-V11/A01-A07/T01-T02) reference EHG codebase paths, so positional matching to a venture's `extracted_dimensions` produces meaningless evidence
- Branches on `/^VISION-EHG[-_]/i` — EHG path unchanged (regression-pinned ±2 pt); venture path generates rubrics via LLM cascade (`lib/llm/client-factory.js`), content-hash cached in new `eva_vision_rubric_cache` table
- TR-6 refused-silent-fallback preserved: LLM-unavailable throws explicit error, never silently returns EHG rubrics for a venture (the exact bug being fixed)

## Test plan
- [x] 41/41 unit tests pass + 1 skipped (LIVE-only): `npx vitest run tests/unit/eva/{rubric-cache,rubric-generator,scorer-venture-branch,ehg-self-scoring-regression-pin,rubric-validator-strict}.test.js`
- [x] EHG self-scoring regression-pin: `node scripts/eva/vision-evidence-scorer.js` → total_score=100, 18/18 dims pass (bit-identical to pre-fix baseline)
- [x] Migration applied to production: 275/275 vision docs + 230/230 arch plans backfilled with `content_hash` (md5 GENERATED STORED); `eva_vision_rubric_cache` table created + indexed
- [x] Sub-agents converged: PLAN/TESTING c10b110b (CONDITIONAL_PASS 92, conditions resolved), PLAN/DATABASE 66ac5b4d (CONDITIONAL_PASS 88, conditions resolved), EXEC/TESTING a8193ad3 (PASS 95), EXEC/DATABASE c5f167ec (PASS 96), VERIFY/VALIDATION a72fe9f1 (PASS 96), VERIFY/REGRESSION (PASS 95)
- [ ] Post-merge smoke: `node scripts/eva/vision-evidence-scorer.js --vision-key VISION-CRONGENIUS-API-L2-001 --target-path <CronGenius repo>` should emit cache row + reference CronGenius paths (first integration use)

## Implementation phases
1. `database/migrations/20260527_eva_vision_rubric_cache_and_content_hash.sql` — `md5()` GENERATED STORED `content_hash` columns + new cache table (md5 chosen because `sha256(convert_to(...))` is STABLE not IMMUTABLE; md5 IS IMMUTABLE on text)
2. `lib/eva/rubric-generator.js` — LLM-aware rubric synthesis with retry-once + refused-silent-fallback
3. `scripts/eva/vision-evidence-scorer.js` — `isEhgVisionKey()` + `selectRubricMap()` helpers; branch at line ~167
4. `scripts/eva/evidence-rubrics/index.js` — exports `validateRubric`, adds `validateRubricStrict` + `ALLOWED_CHECK_TYPES`
5. `scripts/eva/README.md` + `tests/fixtures/ehg-baseline-score.json` regression-pin fixture

## Stats
- 13 files, +1305/-9 LOC
- Source: ~385 LOC (within 250-320 estimate + docs)
- Tests: ~370 LOC

PRD: PRD-SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001
Retrospective: d3f11163-d050-4842-9195-85249f823681 (quality 90, PUBLISHED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)