### PR TITLE
feat(SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001): consolidate dual-detection drift via 3 canonical helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,6 @@ nul
 tests/e2e/ehg-app/.auth/
 tests/e2e/.auth/
 tests/uat/.auth/
+
+# SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-1 audit JSON intermediates (regenerable)
+/.audit-out/

--- a/.worktree-nm-mode
+++ b/.worktree-nm-mode
@@ -1,0 +1,1 @@
+isolated

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001",
-  "createdAt": "2026-05-26T19:22:01.637Z",
+  "sdKey": "SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001",
+  "createdAt": "2026-05-27T23:43:32.951Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
+++ b/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
@@ -2,17 +2,17 @@
 
 Generated (deterministic): 2026-05-28T00:00:00Z
 Repo: EHG_Engineer
-Git HEAD: 1b450c8113
-Files scanned: 2973
+Git HEAD: b6a7a99d6f
+Files scanned: 2974
 
 ## Summary
 
 | Cluster | Description | Total | MIGRATE | KEEP_META_ONLY | FOLLOW_UP | EXCLUDE |
 |---------|-------------|------:|--------:|---------------:|----------:|--------:|
 | A | SD-type detection | 92 | 12 | 3 | 39 | 38 |
-| B | Claim ownership detection | 72 | 26 | 0 | 22 | 24 |
-| C | Gate-skip detection | 15 | 3 | 0 | 6 | 6 |
-| **Total** | — | **179** | **41** | — | **67** | — |
+| B | Claim ownership detection | 83 | 26 | 0 | 22 | 35 |
+| C | Gate-skip detection | 16 | 4 | 0 | 6 | 6 |
+| **Total** | — | **191** | **42** | — | **67** | — |
 
 **This SD ships MIGRATE + KEEP_METADATA_ONLY.** MIGRATE_FOLLOW_UP sites file as a follow-up SD/QF after this one merges. EXCLUDE_OUT_OF_SCOPE sites are not touched.
 
@@ -142,6 +142,17 @@ Multiple call sites determine "who holds this SD" by reading claude_sessions.cla
 | B.5 | `lib/claim/holding-statuses.cjs` | 23 | EXCLUDE_OUT_OF_SCOPE | `const CLAIM_HOLDING_STATUSES = new Set([` |
 | B.5 | `lib/claim/holding-statuses.cjs` | 41 | EXCLUDE_OUT_OF_SCOPE | `if (CLAIM_HOLDING_STATUSES.has(s.status)) claimed.add(s.sd_key);` |
 | B.5 | `lib/claim/holding-statuses.cjs` | 46 | EXCLUDE_OUT_OF_SCOPE | `module.exports = { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys };` |
+| B.5 | `lib/claim/ownership-detection.js` | 18 | EXCLUDE_OUT_OF_SCOPE | `* Re-exports CLAIM_HOLDING_STATUSES from lib/claim/holding-statuses.cjs so consumers` |
+| B.5 | `lib/claim/ownership-detection.js` | 24 | EXCLUDE_OUT_OF_SCOPE | `const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('./holding-statuses.cjs');` |
+| B.5 | `lib/claim/ownership-detection.js` | 26 | EXCLUDE_OUT_OF_SCOPE | `export { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys };` |
+| B.1 | `lib/claim/ownership-detection.js` | 64 | EXCLUDE_OUT_OF_SCOPE | `if (sdErr \|\| !sd \|\| !sd.claiming_session_id) return null;` |
+| B.1 | `lib/claim/ownership-detection.js` | 69 | EXCLUDE_OUT_OF_SCOPE | `.eq('session_id', sd.claiming_session_id)` |
+| B.4 | `lib/claim/ownership-detection.js` | 80 | EXCLUDE_OUT_OF_SCOPE | `is_alive: session.is_alive === true,` |
+| B.6 | `lib/claim/ownership-detection.js` | 81 | EXCLUDE_OUT_OF_SCOPE | `has_uncommitted_changes: session.has_uncommitted_changes === true,` |
+| B.5 | `lib/claim/ownership-detection.js` | 102 | EXCLUDE_OUT_OF_SCOPE | `* CLAIM_HOLDING_STATUSES). Used by sweep and dashboard to render active workers.` |
+| B.5 | `lib/claim/ownership-detection.js` | 119 | EXCLUDE_OUT_OF_SCOPE | `if (CLAIM_HOLDING_STATUSES.has(holdingStatus)) {` |
+| B.6 | `lib/claim/ownership-detection.js` | 142 | EXCLUDE_OUT_OF_SCOPE | `if (session.has_uncommitted_changes === true) return 'ALIVE_SOURCE_SIDE';` |
+| B.4 | `lib/claim/ownership-detection.js` | 146 | EXCLUDE_OUT_OF_SCOPE | `if (session.is_alive === true) return 'ALIVE_NO_HEARTBEAT';` |
 | B.3 | `lib/inbox/unified-inbox-builder.js` | 153 | MIGRATE_FOLLOW_UP | `is_working_on: row.is_working_on,` |
 | B.3 | `lib/quality/context-analyzer.js` | 132 | MIGRATE_FOLLOW_UP | `const adjustedScore = sd.is_working_on ? score * 1.5 : score;` |
 | B.3 | `lib/quality/context-analyzer.js` | 193 | MIGRATE_FOLLOW_UP | `const workingSD = recentSDs.find(sd => sd.is_working_on);` |
@@ -216,7 +227,8 @@ Multiple call sites decide whether a handoff gate should run by checking gate.co
 | C.4 | `scripts/create-refactor-brief.js` | 85 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'refactor') {` |
 | C.4 | `scripts/hooks/stop-subagent-enforcement/post-completion-validator.js` | 104 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'orchestrator') {` |
 | C.4 | `scripts/lib/governance-policy-checker.js` | 176 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'orchestrator' && !sd.relationship_type?.includes('orchestrator')) return null;` |
-| C.4 | `scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js` | 36 | MIGRATE | `if (sd.sd_type !== 'refactor') {` |
+| C.1 | `scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js` | 29 | MIGRATE | `import { shouldSkipForType } from '../../../../../../lib/handoff/gate-skip-detection.js';` |
+| C.1 | `scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js` | 39 | MIGRATE | `const skip = shouldSkipForType(sd, ['refactor'], { gateName: 'GATE_ADRS_CONSULTED' });` |
 | C.1 | `scripts/modules/handoff/validation/ValidationOrchestrator.js` | 250 | MIGRATE | `if (gate.condition && !(await gate.condition(context))) {` |
 | C.1 | `scripts/modules/handoff/validation/ValidationOrchestrator.js` | 1028 | MIGRATE | `if (gate.condition && !(await gate.condition(context))) {` |
 | C.4 | `scripts/modules/intensity-detector.js` | 106 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'refactor') {` |

--- a/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
+++ b/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
@@ -2,17 +2,17 @@
 
 Generated (deterministic): 2026-05-28T00:00:00Z
 Repo: EHG_Engineer
-Git HEAD: b5ece84460
-Files scanned: 2971
+Git HEAD: 0410b70d33
+Files scanned: 2973
 
 ## Summary
 
 | Cluster | Description | Total | MIGRATE | KEEP_META_ONLY | FOLLOW_UP | EXCLUDE |
 |---------|-------------|------:|--------:|---------------:|----------:|--------:|
-| A | SD-type detection | 74 | 20 | 7 | 39 | 8 |
-| B | Claim ownership detection | 71 | 26 | 0 | 22 | 23 |
-| C | Gate-skip detection | 9 | 3 | 0 | 6 | 0 |
-| **Total** | — | **154** | **49** | — | **67** | — |
+| A | SD-type detection | 98 | 14 | 7 | 39 | 38 |
+| B | Claim ownership detection | 72 | 26 | 0 | 22 | 24 |
+| C | Gate-skip detection | 15 | 3 | 0 | 6 | 6 |
+| **Total** | — | **185** | **43** | — | **67** | — |
 
 **This SD ships MIGRATE + KEEP_METADATA_ONLY.** MIGRATE_FOLLOW_UP sites file as a follow-up SD/QF after this one merges. EXCLUDE_OUT_OF_SCOPE sites are not touched.
 
@@ -32,6 +32,30 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.2 | `lib/governance/guardrail-registry.js` | 183 | MIGRATE_FOLLOW_UP | `const isOrchestrator = childrenCount >= 3 \|\| sdData.sd_type === 'orchestrator';` |
 | A.3 | `lib/handoff/parent-detection.js` | 36 | EXCLUDE_OUT_OF_SCOPE | `const metadataFlag = sd.metadata?.is_parent === true;` |
 | A.3 | `lib/handoff/parent-detection.js` | 66 | EXCLUDE_OUT_OF_SCOPE | `return sd?.metadata?.is_parent === true;` |
+| A.7 | `lib/sd/type-detection.js` | 19 | EXCLUDE_OUT_OF_SCOPE | `*   - lib/eva/bridge/sd-router.js — LEGITIMATE_NO_VENTURE_SD_TYPES Set` |
+| A.7 | `lib/sd/type-detection.js` | 32 | EXCLUDE_OUT_OF_SCOPE | `import { LEGITIMATE_NO_VENTURE_SD_TYPES } from '../eva/bridge/sd-router.js';` |
+| A.1 | `lib/sd/type-detection.js` | 53 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.sd_type === 'orchestrator'` |
+| A.2 | `lib/sd/type-detection.js` | 53 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.sd_type === 'orchestrator'` |
+| A.4 | `lib/sd/type-detection.js` | 54 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.metadata?.is_orchestrator === true` |
+| A.3 | `lib/sd/type-detection.js` | 55 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.metadata?.is_parent === true   (legacy parent-orchestrator flag)` |
+| A.1 | `lib/sd/type-detection.js` | 68 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'orchestrator' \|\|` |
+| A.2 | `lib/sd/type-detection.js` | 68 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'orchestrator' \|\|` |
+| A.4 | `lib/sd/type-detection.js` | 69 | EXCLUDE_OUT_OF_SCOPE | `sd.metadata?.is_orchestrator === true \|\|` |
+| A.3 | `lib/sd/type-detection.js` | 70 | EXCLUDE_OUT_OF_SCOPE | `sd.metadata?.is_parent === true` |
+| A.1 | `lib/sd/type-detection.js` | 100 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'orchestrator' \|\|` |
+| A.2 | `lib/sd/type-detection.js` | 100 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'orchestrator' \|\|` |
+| A.4 | `lib/sd/type-detection.js` | 101 | EXCLUDE_OUT_OF_SCOPE | `sd.metadata?.is_orchestrator === true \|\|` |
+| A.3 | `lib/sd/type-detection.js` | 102 | EXCLUDE_OUT_OF_SCOPE | `sd.metadata?.is_parent === true` |
+| A.1 | `lib/sd/type-detection.js` | 112 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.sd_type === 'venture'  (rare; most ventures use other sd_types)` |
+| A.2 | `lib/sd/type-detection.js` | 112 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.sd_type === 'venture'  (rare; most ventures use other sd_types)` |
+| A.5 | `lib/sd/type-detection.js` | 113 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.metadata?.is_venture === true` |
+| A.1 | `lib/sd/type-detection.js` | 126 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'venture' \|\|` |
+| A.2 | `lib/sd/type-detection.js` | 126 | EXCLUDE_OUT_OF_SCOPE | `sd.sd_type === 'venture' \|\|` |
+| A.5 | `lib/sd/type-detection.js` | 127 | EXCLUDE_OUT_OF_SCOPE | `sd.metadata?.is_venture === true` |
+| A.7 | `lib/sd/type-detection.js` | 141 | EXCLUDE_OUT_OF_SCOPE | `*   - sd.sd_type is in LEGITIMATE_NO_VENTURE_SD_TYPES (from lib/eva/bridge/sd-router.js)` |
+| A.7 | `lib/sd/type-detection.js` | 148 | EXCLUDE_OUT_OF_SCOPE | `return LEGITIMATE_NO_VENTURE_SD_TYPES.has(sd.sd_type);` |
+| A.3 | `lib/sd/type-detection.js` | 168 | EXCLUDE_OUT_OF_SCOPE | `if (sd.metadata?.is_orchestrator === true \|\| sd.metadata?.is_parent === true) {` |
+| A.4 | `lib/sd/type-detection.js` | 168 | EXCLUDE_OUT_OF_SCOPE | `if (sd.metadata?.is_orchestrator === true \|\| sd.metadata?.is_parent === true) {` |
 | A.1 | `lib/utils/sd-type-validation.js` | 259 | EXCLUDE_OUT_OF_SCOPE | `requiresDatabase: sd.sd_type === 'database' \|\| (sd.scope \|\| '').toLowerCase().includes('schema'),` |
 | A.1 | `lib/utils/sd-type-validation.js` | 262 | EXCLUDE_OUT_OF_SCOPE | `requiresDesign: sd.sd_type === 'feature' && ((sd.scope \|\| '').toLowerCase().includes('ui') \|\|` |
 | A.2 | `lib/utils/sd-type-validation.js` | 262 | EXCLUDE_OUT_OF_SCOPE | `requiresDesign: sd.sd_type === 'feature' && ((sd.scope \|\| '').toLowerCase().includes('ui') \|\|` |
@@ -60,7 +84,6 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.3 | `scripts/lib/handoff-preflight.js` | 294 | KEEP_METADATA_ONLY | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
 | A.1 | `scripts/modules/auto-trigger-stories.mjs` | 398 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'database' && prd.metadata?.schema) {` |
 | A.3 | `scripts/modules/decomposition-gate.js` | 107 | KEEP_METADATA_ONLY | `if (sd.metadata?.is_parent === true \|\| sd.metadata?.requires_children === true) {` |
-| A.2 | `scripts/modules/handoff/executors/BaseExecutor.js` | 115 | MIGRATE | `const isOrchestrator = sd?.sd_type === 'orchestrator';` |
 | A.3 | `scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js` | 133 | MIGRATE | `return sd?.metadata?.is_parent === true;` |
 | A.6 | `scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js` | 44 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return false;` |
 | A.6 | `scripts/modules/handoff/executors/plan-to-lead/index.js` | 110 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return;` |
@@ -79,12 +102,15 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.2 | `scripts/modules/leo-orchestrator/requirement-validators.js` | 118 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
 | A.2 | `scripts/modules/orchestrator-validation.mjs` | 152 | MIGRATE_FOLLOW_UP | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
 | A.2 | `scripts/modules/orchestrator/phase-requirements.js` | 95 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
-| A.2 | `scripts/modules/parent-orchestrator-handler.js` | 58 | MIGRATE | `// 2. sd_type === 'orchestrator' (type-based)` |
-| A.3 | `scripts/modules/parent-orchestrator-handler.js` | 60 | MIGRATE | `const hasIsParentFlag = sd.metadata?.is_parent === true;` |
-| A.1 | `scripts/modules/parent-orchestrator-handler.js` | 61 | MIGRATE | `const isOrchestratorType = sd.sd_type === 'orchestrator';` |
-| A.2 | `scripts/modules/parent-orchestrator-handler.js` | 61 | MIGRATE | `const isOrchestratorType = sd.sd_type === 'orchestrator';` |
+| A.2 | `scripts/modules/parent-orchestrator-handler.js` | 57 | MIGRATE | `// sd_type === 'orchestrator', DB-children) now lives inside the canonical helper.` |
 | A.1 | `scripts/modules/sd-next/SDNextSelector.js` | 415 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'orchestrator' && sd.status !== 'completed' && sd.status !== 'cancelled') {` |
 | A.2 | `scripts/modules/sd-next/SDNextSelector.js` | 415 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'orchestrator' && sd.status !== 'completed' && sd.status !== 'cancelled') {` |
+| A.7 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 9 | EXCLUDE_OUT_OF_SCOPE | `*   A - SD-type detection (sd_type column, metadata.is_* flags, sd_key prefix, LEGITIMATE_NO_VENTURE_SD_TYPES)` |
+| A.1 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 41 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'A.1', description: 'sd_type direct comparison (e.g. sd.sd_type === "orchestrator")', pattern: /\bsd\.sd` |
+| A.2 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 41 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'A.1', description: 'sd_type direct comparison (e.g. sd.sd_type === "orchestrator")', pattern: /\bsd\.sd` |
+| A.7 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 47 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'A.7', description: 'LEGITIMATE_NO_VENTURE_SD_TYPES usage', pattern: /\bLEGITIMATE_NO_VENTURE_SD_TYPES\b` |
+| A.8 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 48 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'A.8', description: 'category check (sd.category === "...")', pattern: /\bsd\.category\s*===?\s*["']/ },` |
+| A.7 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 332 | EXCLUDE_OUT_OF_SCOPE | `description: 'Multiple call sites classify an SD\'s type by reading sd_type column, metadata.is_* flags, sd_ke` |
 | A.4 | `scripts/orchestrator-preflight.js` | 135 | MIGRATE | `sd.metadata?.is_orchestrator === true \|\|` |
 | A.1 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
 | A.2 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
@@ -92,14 +118,12 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.1 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
 | A.2 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
 | A.2 | `scripts/sd-start.js` | 359 | MIGRATE | `* When a child is itself an orchestrator (sd_type === 'orchestrator' or has children),` |
-| A.1 | `scripts/sd-start.js` | 1496 | MIGRATE | `if (sd.sd_type === 'orchestrator' && wtBranch && !wtBranch.includes(effectiveId)) {` |
-| A.2 | `scripts/sd-start.js` | 1496 | MIGRATE | `if (sd.sd_type === 'orchestrator' && wtBranch && !wtBranch.includes(effectiveId)) {` |
 | A.1 | `scripts/verify-l2p/prd-readiness.js` | 301 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'documentation') return result;` |
 | A.2 | `scripts/verify-l2p/prd-readiness.js` | 301 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'documentation') return result;` |
 
 ### Rationale per classification
 
-- **EXCLUDE_OUT_OF_SCOPE**: Canonical helper file — defines the pattern, not a consumer.
+- **EXCLUDE_OUT_OF_SCOPE**: Canonical helper file — defines the pattern, not a consumer. / One-off diagnostic script; not part of production routing.
 - **KEEP_METADATA_ONLY**: Hot-path runs mid-handoff; metadata-flag-only preserves read-after-write transactional consistency (per RISK C1). Uses sync helper variant.
 - **MIGRATE**: HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.
 - **MIGRATE_FOLLOW_UP**: Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.
@@ -148,6 +172,7 @@ Multiple call sites determine "who holds this SD" by reading claude_sessions.cla
 | B.1 | `scripts/modules/sd-next/display/recommendations.js` | 273 | MIGRATE | `if (sd.claiming_session_id && sd.claiming_session_id !== currentSessionId) {` |
 | B.1 | `scripts/modules/sd-next/display/recommendations.js` | 276 | MIGRATE | `const claimingSession = activeSessions.find(s => s.session_id === sd.claiming_session_id);` |
 | B.1 | `scripts/modules/sd-next/display/recommendations.js` | 279 | MIGRATE | `claimingSessionId: sd.claiming_session_id,` |
+| B.5 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 62 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'B.5', description: 'CLAIM_HOLDING_STATUSES import or use', pattern: /\bCLAIM_HOLDING_STATUSES\b/ },` |
 | B.1 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 291 | EXCLUDE_OUT_OF_SCOPE | `console.log('claiming_session_id:', data.claiming_session_id);` |
 | B.3 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 292 | EXCLUDE_OUT_OF_SCOPE | `console.log('is_working_on:', data.is_working_on);` |
 | B.1 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 296 | EXCLUDE_OUT_OF_SCOPE | `if (data.claiming_session_id !== SESSION) {` |
@@ -203,9 +228,16 @@ Multiple call sites decide whether a handoff gate should run by checking gate.co
 | C.4 | `scripts/modules/intensity-detector.js` | 106 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'refactor') {` |
 | C.2 | `scripts/modules/traceability-validation/sections/recommendation-adherence.js` | 88 | MIGRATE_FOLLOW_UP | `\|\| designAnalysis?.metadata?.skip_reason` |
 | C.2 | `scripts/modules/traceability-validation/sections/recommendation-adherence.js` | 89 | MIGRATE_FOLLOW_UP | `\|\| designAnalysis?.results?.metadata?.skip_reason;` |
+| C.1 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 11 | EXCLUDE_OUT_OF_SCOPE | `*   C - Gate-skip detection (gate.condition, context.skipGate, metadata.skip_*)` |
+| C.3 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 11 | EXCLUDE_OUT_OF_SCOPE | `*   C - Gate-skip detection (gate.condition, context.skipGate, metadata.skip_*)` |
+| C.1 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 66 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'C.1', description: 'gate.condition or shouldSkip pattern', pattern: /\b(?:gate\.condition\|shouldSkipGa` |
+| C.3 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 68 | EXCLUDE_OUT_OF_SCOPE | `{ id: 'C.3', description: 'context.skipGate explicit injection', pattern: /\bcontext\.skipGate\b/ },` |
+| C.1 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 342 | EXCLUDE_OUT_OF_SCOPE | `description: 'Multiple call sites decide whether a handoff gate should run by checking gate.condition callback` |
+| C.3 | `scripts/one-off/_audit-dual-detection-clusters.mjs` | 342 | EXCLUDE_OUT_OF_SCOPE | `description: 'Multiple call sites decide whether a handoff gate should run by checking gate.condition callback` |
 
 ### Rationale per classification
 
+- **EXCLUDE_OUT_OF_SCOPE**: One-off diagnostic script; not part of production routing.
 - **MIGRATE**: HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.
 - **MIGRATE_FOLLOW_UP**: Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.
 

--- a/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
+++ b/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
@@ -1,0 +1,227 @@
+# Dual-detection cluster audit — SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001
+
+Generated (deterministic): 2026-05-28T00:00:00Z
+Repo: EHG_Engineer
+Git HEAD: b5ece84460
+Files scanned: 2971
+
+## Summary
+
+| Cluster | Description | Total | MIGRATE | KEEP_META_ONLY | FOLLOW_UP | EXCLUDE |
+|---------|-------------|------:|--------:|---------------:|----------:|--------:|
+| A | SD-type detection | 74 | 20 | 7 | 39 | 8 |
+| B | Claim ownership detection | 71 | 26 | 0 | 22 | 23 |
+| C | Gate-skip detection | 9 | 3 | 0 | 6 | 0 |
+| **Total** | — | **154** | **49** | — | **67** | — |
+
+**This SD ships MIGRATE + KEEP_METADATA_ONLY.** MIGRATE_FOLLOW_UP sites file as a follow-up SD/QF after this one merges. EXCLUDE_OUT_OF_SCOPE sites are not touched.
+
+## Cluster A: SD-type detection
+
+Multiple call sites classify an SD's type by reading sd_type column, metadata.is_* flags, sd_key prefix, or LEGITIMATE_NO_VENTURE_SD_TYPES set. Migration target: `lib/sd/type-detection.js` (FR-2).
+
+| Rule | File | Line | Classification | Snippet |
+|------|------|-----:|----------------|---------|
+| A.2 | `lib/analysis/scope-complexity-scorer.js` | 156 | MIGRATE_FOLLOW_UP | `const isOrchestrator = parentSd.sd_type === 'orchestrator' \|\|` |
+| A.4 | `lib/analysis/scope-complexity-scorer.js` | 157 | MIGRATE_FOLLOW_UP | `parentSd.metadata?.is_orchestrator === true \|\|` |
+| A.1 | `lib/drain-orchestrator.mjs` | 143 | MIGRATE_FOLLOW_UP | `const typeMatch = sd.sd_type === 'migration';` |
+| A.2 | `lib/eva-support/sd-blocker-surface.js` | 146 | MIGRATE_FOLLOW_UP | `if (parentRow.sd_type === 'orchestrator') return true; // orchestrator children activate independently` |
+| A.7 | `lib/eva/bridge/sd-router.js` | 40 | EXCLUDE_OUT_OF_SCOPE | `export const LEGITIMATE_NO_VENTURE_SD_TYPES = new Set([` |
+| A.7 | `lib/eva/bridge/sd-router.js` | 53 | EXCLUDE_OUT_OF_SCOPE | `if (sd_type && LEGITIMATE_NO_VENTURE_SD_TYPES.has(sd_type)) return true;` |
+| A.7 | `lib/eva/bridge/sd-router.js` | 80 | EXCLUDE_OUT_OF_SCOPE | `Array.from(LEGITIMATE_NO_VENTURE_SD_TYPES).join(', ') +` |
+| A.2 | `lib/governance/guardrail-registry.js` | 183 | MIGRATE_FOLLOW_UP | `const isOrchestrator = childrenCount >= 3 \|\| sdData.sd_type === 'orchestrator';` |
+| A.3 | `lib/handoff/parent-detection.js` | 36 | EXCLUDE_OUT_OF_SCOPE | `const metadataFlag = sd.metadata?.is_parent === true;` |
+| A.3 | `lib/handoff/parent-detection.js` | 66 | EXCLUDE_OUT_OF_SCOPE | `return sd?.metadata?.is_parent === true;` |
+| A.1 | `lib/utils/sd-type-validation.js` | 259 | EXCLUDE_OUT_OF_SCOPE | `requiresDatabase: sd.sd_type === 'database' \|\| (sd.scope \|\| '').toLowerCase().includes('schema'),` |
+| A.1 | `lib/utils/sd-type-validation.js` | 262 | EXCLUDE_OUT_OF_SCOPE | `requiresDesign: sd.sd_type === 'feature' && ((sd.scope \|\| '').toLowerCase().includes('ui') \|\|` |
+| A.2 | `lib/utils/sd-type-validation.js` | 262 | EXCLUDE_OUT_OF_SCOPE | `requiresDesign: sd.sd_type === 'feature' && ((sd.scope \|\| '').toLowerCase().includes('ui') \|\|` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 232 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.2 | `scripts/batch-enrich-draft-sds.js` | 232 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 236 | MIGRATE_FOLLOW_UP | `} else if (sd.sd_type === 'infrastructure') {` |
+| A.2 | `scripts/batch-enrich-draft-sds.js` | 236 | MIGRATE_FOLLOW_UP | `} else if (sd.sd_type === 'infrastructure') {` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 240 | MIGRATE_FOLLOW_UP | `} else if (sd.sd_type === 'refactor') {` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 279 | MIGRATE_FOLLOW_UP | `impact: `${sd.sd_type === 'fix' ? 'Fix' : 'Improve'} ${extractPurpose(title)} in ${dir}`` |
+| A.2 | `scripts/batch-enrich-draft-sds.js` | 279 | MIGRATE_FOLLOW_UP | `impact: `${sd.sd_type === 'fix' ? 'Fix' : 'Improve'} ${extractPurpose(title)} in ${dir}`` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 286 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.2 | `scripts/batch-enrich-draft-sds.js` | 286 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.1 | `scripts/batch-enrich-draft-sds.js` | 320 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.2 | `scripts/batch-enrich-draft-sds.js` | 320 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'fix' \|\| sd.sd_type === 'bugfix') {` |
+| A.1 | `scripts/claim-orchestrator-for-rollup.mjs` | 50 | MIGRATE_FOLLOW_UP | `let isOrchestrator = sd.sd_type === 'orchestrator';` |
+| A.2 | `scripts/claim-orchestrator-for-rollup.mjs` | 50 | MIGRATE_FOLLOW_UP | `let isOrchestrator = sd.sd_type === 'orchestrator';` |
+| A.1 | `scripts/hooks/pre-tool-enforce.cjs` | 818 | MIGRATE_FOLLOW_UP | `if (sd && sd.sd_type === 'bugfix') {` |
+| A.8 | `scripts/lead-dossier.js` | 248 | MIGRATE_FOLLOW_UP | `const hasComplexType = ['orchestrator'].includes(sd.sd_type) \|\| sd.category === 'Orchestrator';` |
+| A.1 | `scripts/lead-dossier.js` | 305 | MIGRATE_FOLLOW_UP | `: sd.sd_type === 'infrastructure' ? 'MEDIUM'` |
+| A.2 | `scripts/lead-dossier.js` | 305 | MIGRATE_FOLLOW_UP | `: sd.sd_type === 'infrastructure' ? 'MEDIUM'` |
+| A.7 | `scripts/leo-create-sd.js` | 53 | MIGRATE_FOLLOW_UP | `import { LEGITIMATE_NO_VENTURE_SD_TYPES } from '../lib/eva/bridge/sd-router.js';` |
+| A.7 | `scripts/leo-create-sd.js` | 1762 | MIGRATE_FOLLOW_UP | `// engineering/governance LEO work (sd_type in LEGITIMATE_NO_VENTURE_SD_TYPES, or` |
+| A.7 | `scripts/leo-create-sd.js` | 1767 | MIGRATE_FOLLOW_UP | `const isNoVentureWork = LEGITIMATE_NO_VENTURE_SD_TYPES.has(sdData.sd_type)` |
+| A.2 | `scripts/leo-orchestrator/validation.js` | 44 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
+| A.3 | `scripts/lib/handoff-preflight.js` | 163 | KEEP_METADATA_ONLY | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
+| A.3 | `scripts/lib/handoff-preflight.js` | 294 | KEEP_METADATA_ONLY | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
+| A.1 | `scripts/modules/auto-trigger-stories.mjs` | 398 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'database' && prd.metadata?.schema) {` |
+| A.3 | `scripts/modules/decomposition-gate.js` | 107 | KEEP_METADATA_ONLY | `if (sd.metadata?.is_parent === true \|\| sd.metadata?.requires_children === true) {` |
+| A.2 | `scripts/modules/handoff/executors/BaseExecutor.js` | 115 | MIGRATE | `const isOrchestrator = sd?.sd_type === 'orchestrator';` |
+| A.3 | `scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js` | 133 | MIGRATE | `return sd?.metadata?.is_parent === true;` |
+| A.6 | `scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js` | 44 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return false;` |
+| A.6 | `scripts/modules/handoff/executors/plan-to-lead/index.js` | 110 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return;` |
+| A.2 | `scripts/modules/handoff/orchestrator-completion-guardian.js` | 77 | KEEP_METADATA_ONLY | `// 1. sd_type === 'orchestrator'` |
+| A.2 | `scripts/modules/handoff/orchestrator-completion-guardian.js` | 80 | KEEP_METADATA_ONLY | `const isOrchestratorType = parent.sd_type === 'orchestrator';` |
+| A.3 | `scripts/modules/handoff/orchestrator-completion-guardian.js` | 81 | KEEP_METADATA_ONLY | `const hasIsParentFlag = parent.metadata?.is_parent === true;` |
+| A.1 | `scripts/modules/handoff/verifiers/lead-to-plan/prd-readiness.js` | 286 | MIGRATE | `if (sd.sd_type === 'documentation') return result;` |
+| A.2 | `scripts/modules/handoff/verifiers/lead-to-plan/prd-readiness.js` | 286 | MIGRATE | `if (sd.sd_type === 'documentation') return result;` |
+| A.3 | `scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js` | 84 | MIGRATE | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
+| A.1 | `scripts/modules/human-verification-validator.js` | 392 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'database') {` |
+| A.1 | `scripts/modules/human-verification-validator.js` | 398 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'security') {` |
+| A.2 | `scripts/modules/implementation-fidelity/sections/data-flow-alignment.js` | 109 | MIGRATE_FOLLOW_UP | `if (sd?.sd_type === 'feature' && !hasUIScope) {` |
+| A.2 | `scripts/modules/implementation-fidelity/sections/data-flow-alignment.js` | 136 | MIGRATE_FOLLOW_UP | `if (sd?.sd_type === 'feature' && (validation.details.target_application \|\| null) === 'EHG') {` |
+| A.2 | `scripts/modules/implementation-fidelity/sections/design-fidelity.js` | 108 | MIGRATE_FOLLOW_UP | `if (sd?.sd_type === 'feature' && !hasUIScope) {` |
+| A.2 | `scripts/modules/implementation-fidelity/sections/design-fidelity.js` | 138 | MIGRATE_FOLLOW_UP | `if (sd?.sd_type === 'feature' && (validation.details.target_application \|\| null) === 'EHG') {` |
+| A.2 | `scripts/modules/leo-orchestrator/requirement-validators.js` | 118 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
+| A.2 | `scripts/modules/orchestrator-validation.mjs` | 152 | MIGRATE_FOLLOW_UP | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
+| A.2 | `scripts/modules/orchestrator/phase-requirements.js` | 95 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
+| A.2 | `scripts/modules/parent-orchestrator-handler.js` | 58 | MIGRATE | `// 2. sd_type === 'orchestrator' (type-based)` |
+| A.3 | `scripts/modules/parent-orchestrator-handler.js` | 60 | MIGRATE | `const hasIsParentFlag = sd.metadata?.is_parent === true;` |
+| A.1 | `scripts/modules/parent-orchestrator-handler.js` | 61 | MIGRATE | `const isOrchestratorType = sd.sd_type === 'orchestrator';` |
+| A.2 | `scripts/modules/parent-orchestrator-handler.js` | 61 | MIGRATE | `const isOrchestratorType = sd.sd_type === 'orchestrator';` |
+| A.1 | `scripts/modules/sd-next/SDNextSelector.js` | 415 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'orchestrator' && sd.status !== 'completed' && sd.status !== 'cancelled') {` |
+| A.2 | `scripts/modules/sd-next/SDNextSelector.js` | 415 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'orchestrator' && sd.status !== 'completed' && sd.status !== 'cancelled') {` |
+| A.4 | `scripts/orchestrator-preflight.js` | 135 | MIGRATE | `sd.metadata?.is_orchestrator === true \|\|` |
+| A.1 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
+| A.2 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
+| A.3 | `scripts/phase-preflight.js` | 261 | KEEP_METADATA_ONLY | `explicitFlag: sd.metadata?.is_parent === true,` |
+| A.1 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
+| A.2 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
+| A.2 | `scripts/sd-start.js` | 359 | MIGRATE | `* When a child is itself an orchestrator (sd_type === 'orchestrator' or has children),` |
+| A.1 | `scripts/sd-start.js` | 1496 | MIGRATE | `if (sd.sd_type === 'orchestrator' && wtBranch && !wtBranch.includes(effectiveId)) {` |
+| A.2 | `scripts/sd-start.js` | 1496 | MIGRATE | `if (sd.sd_type === 'orchestrator' && wtBranch && !wtBranch.includes(effectiveId)) {` |
+| A.1 | `scripts/verify-l2p/prd-readiness.js` | 301 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'documentation') return result;` |
+| A.2 | `scripts/verify-l2p/prd-readiness.js` | 301 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'documentation') return result;` |
+
+### Rationale per classification
+
+- **EXCLUDE_OUT_OF_SCOPE**: Canonical helper file — defines the pattern, not a consumer.
+- **KEEP_METADATA_ONLY**: Hot-path runs mid-handoff; metadata-flag-only preserves read-after-write transactional consistency (per RISK C1). Uses sync helper variant.
+- **MIGRATE**: HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.
+- **MIGRATE_FOLLOW_UP**: Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.
+
+## Cluster B: Claim ownership detection
+
+Multiple call sites determine "who holds this SD" by reading claude_sessions.claiming_session_id, .active_session_id, .is_working_on, .is_alive, .has_uncommitted_changes. Migration target: `lib/claim/ownership-detection.js` (FR-3).
+
+| Rule | File | Line | Classification | Snippet |
+|------|------|-----:|----------------|---------|
+| B.1 | `lib/claim-lifecycle-release.mjs` | 67 | MIGRATE | `if (error \|\| !data \|\| !data.claiming_session_id) return null;` |
+| B.1b | `lib/claim-lifecycle-release.mjs` | 96 | MIGRATE | `.eq('claiming_session_id', snapshot.claiming_session_id)` |
+| B.1 | `lib/claim-validity-gate.js` | 323 | MIGRATE | `if (!sd.claiming_session_id) {` |
+| B.1 | `lib/claim-validity-gate.js` | 331 | MIGRATE | `if (sd.claiming_session_id !== mySessionId) {` |
+| B.1 | `lib/claim-validity-gate.js` | 338 | MIGRATE | `.eq('session_id', sd.claiming_session_id)` |
+| B.1 | `lib/claim-validity-gate.js` | 355 | MIGRATE | `.eq('claiming_session_id', sd.claiming_session_id);` |
+| B.1b | `lib/claim-validity-gate.js` | 355 | MIGRATE | `.eq('claiming_session_id', sd.claiming_session_id);` |
+| B.1 | `lib/claim-validity-gate.js` | 360 | MIGRATE | `await releaseClaimsByHolder({ holderSessionId: sd.claiming_session_id });` |
+| B.1 | `lib/claim-validity-gate.js` | 368 | MIGRATE | ``[claim-validity-gate] Auto-released orphaned claim on ${sdKey}: owner ${sd.claiming_session_id} ` +` |
+| B.1 | `lib/claim-validity-gate.js` | 379 | MIGRATE | `released_owner_session: sd.claiming_session_id,` |
+| B.1 | `lib/claim-validity-gate.js` | 388 | MIGRATE | `ownerSessionId: sd.claiming_session_id,` |
+| B.5 | `lib/claim/holding-statuses.cjs` | 23 | EXCLUDE_OUT_OF_SCOPE | `const CLAIM_HOLDING_STATUSES = new Set([` |
+| B.5 | `lib/claim/holding-statuses.cjs` | 41 | EXCLUDE_OUT_OF_SCOPE | `if (CLAIM_HOLDING_STATUSES.has(s.status)) claimed.add(s.sd_key);` |
+| B.5 | `lib/claim/holding-statuses.cjs` | 46 | EXCLUDE_OUT_OF_SCOPE | `module.exports = { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys };` |
+| B.3 | `lib/inbox/unified-inbox-builder.js` | 153 | MIGRATE_FOLLOW_UP | `is_working_on: row.is_working_on,` |
+| B.3 | `lib/quality/context-analyzer.js` | 132 | MIGRATE_FOLLOW_UP | `const adjustedScore = sd.is_working_on ? score * 1.5 : score;` |
+| B.3 | `lib/quality/context-analyzer.js` | 193 | MIGRATE_FOLLOW_UP | `const workingSD = recentSDs.find(sd => sd.is_working_on);` |
+| B.3 | `lib/quality/context-analyzer.js` | 241 | MIGRATE_FOLLOW_UP | `if (related.sd.is_working_on) {` |
+| B.1 | `scripts/cancel-sd.js` | 92 | MIGRATE_FOLLOW_UP | `const claimedSessionId = sd.claiming_session_id;` |
+| B.3 | `scripts/cancel-sd.js` | 128 | MIGRATE_FOLLOW_UP | `old_value: { status: sd.status, current_phase: sd.current_phase, is_working_on: sd.is_working_on },` |
+| B.1 | `scripts/cancel-sd.js` | 178 | MIGRATE_FOLLOW_UP | `console.log(`  Claim: ${sd.claiming_session_id ? sd.claiming_session_id.slice(0, 8) : '(none)'}`);` |
+| B.1 | `scripts/claim-orchestrator-for-rollup.mjs` | 73 | MIGRATE_FOLLOW_UP | `if (sd.claiming_session_id && sd.claiming_session_id !== sessionId) {` |
+| B.1 | `scripts/claim-orchestrator-for-rollup.mjs` | 77 | MIGRATE_FOLLOW_UP | `.eq('session_id', sd.claiming_session_id)` |
+| B.1 | `scripts/claim-orchestrator-for-rollup.mjs` | 83 | MIGRATE_FOLLOW_UP | `return { ok: false, action: 'refused', reason: `parent ${sd.sd_key} is claimed by a different LIVE session ${s` |
+| B.3b | `scripts/eva/friday-meeting.mjs` | 609 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true),` |
+| B.3b | `scripts/eva/friday-meeting.mjs` | 613 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', false),` |
+| B.1 | `scripts/get-working-on-sd.js` | 133 | MIGRATE_FOLLOW_UP | `Claimed by: ${sd.claiming_session_id \|\| 'unknown (legacy is_working_on)'}` |
+| B.3b | `scripts/handoff-export.cjs` | 92 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true)` |
+| B.3b | `scripts/hooks/auto-learning-capture.cjs` | 197 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true)` |
+| B.3b | `scripts/hooks/concurrent-session-worktree.cjs` | 327 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true)` |
+| B.3 | `scripts/leo-cleanup.js` | 136 | MIGRATE | `const workingOn = sd.is_working_on ? '🔴' : '⚪';` |
+| B.3b | `scripts/leo-continuous.js` | 345 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true)` |
+| B.3b | `scripts/modules/claim-health/triangulate.js` | 270 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true);` |
+| B.1 | `scripts/modules/handoff/executors/lead-final-approval/helpers.js` | 78 | MIGRATE | `{ supabase, shippingResults, callerSessionId: sd.claiming_session_id }` |
+| B.1 | `scripts/modules/handoff/executors/lead-final-approval/helpers.js` | 106 | MIGRATE | `{ supabase, shippingResults, callerSessionId: sd.claiming_session_id }` |
+| B.1 | `scripts/modules/sd-next/display/recommendations.js` | 273 | MIGRATE | `if (sd.claiming_session_id && sd.claiming_session_id !== currentSessionId) {` |
+| B.1 | `scripts/modules/sd-next/display/recommendations.js` | 276 | MIGRATE | `const claimingSession = activeSessions.find(s => s.session_id === sd.claiming_session_id);` |
+| B.1 | `scripts/modules/sd-next/display/recommendations.js` | 279 | MIGRATE | `claimingSessionId: sd.claiming_session_id,` |
+| B.1 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 291 | EXCLUDE_OUT_OF_SCOPE | `console.log('claiming_session_id:', data.claiming_session_id);` |
+| B.3 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 292 | EXCLUDE_OUT_OF_SCOPE | `console.log('is_working_on:', data.is_working_on);` |
+| B.1 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 296 | EXCLUDE_OUT_OF_SCOPE | `if (data.claiming_session_id !== SESSION) {` |
+| B.3 | `scripts/one-off/_lead-enrich-sd-fdbk-infra-cascade-trigger-overreach-001.mjs` | 300 | EXCLUDE_OUT_OF_SCOPE | `if (data.is_working_on !== true) {` |
+| B.1 | `scripts/one-off/_lead-merge-subagent-findings-sd-fdbk-cascade-trigger-overreach-001.mjs` | 404 | EXCLUDE_OUT_OF_SCOPE | `console.log('claiming_session_id:', data.claiming_session_id);` |
+| B.3 | `scripts/one-off/_lead-merge-subagent-findings-sd-fdbk-cascade-trigger-overreach-001.mjs` | 405 | EXCLUDE_OUT_OF_SCOPE | `console.log('is_working_on:', data.is_working_on);` |
+| B.1 | `scripts/one-off/_lead-merge-subagent-findings-sd-fdbk-cascade-trigger-overreach-001.mjs` | 412 | EXCLUDE_OUT_OF_SCOPE | `if (data.claiming_session_id !== SESSION) {` |
+| B.3 | `scripts/one-off/_lead-merge-subagent-findings-sd-fdbk-cascade-trigger-overreach-001.mjs` | 416 | EXCLUDE_OUT_OF_SCOPE | `if (data.is_working_on !== true) {` |
+| B.1 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 12 | EXCLUDE_OUT_OF_SCOPE | `claiming_session_id: before.data.claiming_session_id,` |
+| B.3 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 13 | EXCLUDE_OUT_OF_SCOPE | `is_working_on: before.data.is_working_on,` |
+| B.2 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 14 | EXCLUDE_OUT_OF_SCOPE | `active_session_id: before.data.active_session_id,` |
+| B.1 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 39 | EXCLUDE_OUT_OF_SCOPE | `before_claim_state: !!(before.data.claiming_session_id && before.data.is_working_on && before.data.active_sess` |
+| B.2 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 39 | EXCLUDE_OUT_OF_SCOPE | `before_claim_state: !!(before.data.claiming_session_id && before.data.is_working_on && before.data.active_sess` |
+| B.3 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 39 | EXCLUDE_OUT_OF_SCOPE | `before_claim_state: !!(before.data.claiming_session_id && before.data.is_working_on && before.data.active_sess` |
+| B.1 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 41 | EXCLUDE_OUT_OF_SCOPE | `cascade_overreach_reproduced: (before.data.claiming_session_id && !upd.data?.claiming_session_id) \|\|` |
+| B.3 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 42 | EXCLUDE_OUT_OF_SCOPE | `(before.data.is_working_on && !upd.data?.is_working_on) \|\|` |
+| B.2 | `scripts/one-off/_risk-probe-cascade-multifield.mjs` | 43 | EXCLUDE_OUT_OF_SCOPE | `(before.data.active_session_id && !upd.data?.active_session_id)` |
+| B.1 | `scripts/one-off/_risk-probe-cascade-reproduce.mjs` | 23 | EXCLUDE_OUT_OF_SCOPE | `const cleared_claiming = before.data.claiming_session_id && !upd.data?.claiming_session_id;` |
+| B.3 | `scripts/one-off/_risk-probe-cascade-reproduce.mjs` | 24 | EXCLUDE_OUT_OF_SCOPE | `const cleared_working = before.data.is_working_on && !upd.data?.is_working_on;` |
+| B.2 | `scripts/one-off/_risk-probe-cascade-reproduce.mjs` | 25 | EXCLUDE_OUT_OF_SCOPE | `const cleared_active = before.data.active_session_id && !upd.data?.active_session_id;` |
+| B.3b | `scripts/run-leo.cjs` | 94 | MIGRATE_FOLLOW_UP | `const { data } = await supabase.from('strategic_directives_v2').select('id, title, current_phase, status').eq(` |
+| B.3b | `scripts/sd-next/display.js` | 304 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true)` |
+| B.6 | `scripts/session-check-concurrency.js` | 52 | MIGRATE_FOLLOW_UP | `const dirty = session.has_uncommitted_changes === true;` |
+| B.5 | `scripts/stale-session-sweep.cjs` | 33 | MIGRATE | `const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('../lib/claim/holding-statuses.cjs');` |
+| B.1b | `scripts/stale-session-sweep.cjs` | 415 | MIGRATE | `.eq('claiming_session_id', qf.claiming_session_id); // race guard: only if still held by the same dead session` |
+| B.1b | `scripts/stale-session-sweep.cjs` | 1022 | MIGRATE | `.eq('claiming_session_id', s.session_id);` |
+| B.5 | `scripts/stale-session-sweep.cjs` | 1153 | MIGRATE | `// SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): use the same CLAIM_HOLDING_STATUSES` |
+| B.5 | `scripts/stale-session-sweep.cjs` | 1157 | MIGRATE | `const activeSessions = classified.filter(s => CLAIM_HOLDING_STATUSES.has(s.status));` |
+| B.1 | `scripts/stale-session-sweep.cjs` | 1235 | MIGRATE | `if (sd.claiming_session_id !== s.session_id) {` |
+| B.3 | `scripts/stale-session-sweep.cjs` | 1242 | MIGRATE | `} else if (!sd.is_working_on) {` |
+| B.5 | `scripts/stale-session-sweep.cjs` | 1384 | MIGRATE | `// QF-20260526-279: route through CLAIM_HOLDING_STATUSES so STALE/DEAD render` |
+| B.5 | `scripts/stale-session-sweep.cjs` | 1388 | MIGRATE | `const stale = classified.filter(s => !CLAIM_HOLDING_STATUSES.has(s.status));` |
+| B.3b | `server/websocket.js` | 132 | MIGRATE_FOLLOW_UP | `.eq('is_working_on', true);` |
+
+### Rationale per classification
+
+- **EXCLUDE_OUT_OF_SCOPE**: Canonical helper file — defines the pattern, not a consumer. / One-off diagnostic script; not part of production routing.
+- **MIGRATE**: HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.
+- **MIGRATE_FOLLOW_UP**: Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.
+
+## Cluster C: Gate-skip detection
+
+Multiple call sites decide whether a handoff gate should run by checking gate.condition callbacks, context.skipGate injection, metadata.skip_* flags, or SD-type-conditional skip. Migration target: `lib/handoff/gate-skip-detection.js` (FR-4).
+
+| Rule | File | Line | Classification | Snippet |
+|------|------|-----:|----------------|---------|
+| C.4 | `scripts/create-refactor-brief.js` | 85 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'refactor') {` |
+| C.4 | `scripts/hooks/stop-subagent-enforcement/post-completion-validator.js` | 104 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'orchestrator') {` |
+| C.4 | `scripts/lib/governance-policy-checker.js` | 176 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'orchestrator' && !sd.relationship_type?.includes('orchestrator')) return null;` |
+| C.4 | `scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js` | 36 | MIGRATE | `if (sd.sd_type !== 'refactor') {` |
+| C.1 | `scripts/modules/handoff/validation/ValidationOrchestrator.js` | 250 | MIGRATE | `if (gate.condition && !(await gate.condition(context))) {` |
+| C.1 | `scripts/modules/handoff/validation/ValidationOrchestrator.js` | 1028 | MIGRATE | `if (gate.condition && !(await gate.condition(context))) {` |
+| C.4 | `scripts/modules/intensity-detector.js` | 106 | MIGRATE_FOLLOW_UP | `if (sd.sd_type !== 'refactor') {` |
+| C.2 | `scripts/modules/traceability-validation/sections/recommendation-adherence.js` | 88 | MIGRATE_FOLLOW_UP | `\|\| designAnalysis?.metadata?.skip_reason` |
+| C.2 | `scripts/modules/traceability-validation/sections/recommendation-adherence.js` | 89 | MIGRATE_FOLLOW_UP | `\|\| designAnalysis?.results?.metadata?.skip_reason;` |
+
+### Rationale per classification
+
+- **MIGRATE**: HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.
+- **MIGRATE_FOLLOW_UP**: Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.
+
+## Methodology
+
+- File list sourced from `git ls-files` (tracked files only), filtered to *.js / *.mjs / *.cjs.
+- Per-file scan via native JS RegExp; matches recorded with file:line + classification.
+- Excluded prefixes: tests/, test/, scripts/archive/, .prd-payloads/, .rca/, .audit-out/, docs/audits/, node_modules/, .worktrees/, dist/, build/
+- Excluded suffixes: *.test.{js,mjs,cjs}, *.spec.{js,mjs,cjs}
+- Classification (per RISK C1 from LEAD sub-agent review):
+  - **MIGRATE**: standard call site; migrated to canonical helper in Phase 2/3/4/5.
+  - **KEEP_METADATA_ONLY**: hot-path files (handoff-preflight, phase-preflight, orchestrator-completion-guardian, decomposition-gate) where read-after-write consistency requires the sync helper variant.
+  - **EXCLUDE_OUT_OF_SCOPE**: canonical helper files, one-off diagnostic scripts, database migrations.
+- Output is deterministic-sorted (file alphabetical → line ascending → rule_id) for diffability across runs (TR-2).
+- Read-only enforcement (TR-1): script refuses to run when SUPABASE_SERVICE_ROLE_KEY is set in env.
+
+## Phase 2-5 scoping
+
+The migration count in each Phase MUST match the per-cluster MIGRATE counts in this report. KEEP_METADATA_ONLY sites use the sync helper variant. EXCLUDE_OUT_OF_SCOPE sites are not touched by this SD.

--- a/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
+++ b/docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md
@@ -2,17 +2,17 @@
 
 Generated (deterministic): 2026-05-28T00:00:00Z
 Repo: EHG_Engineer
-Git HEAD: 0410b70d33
+Git HEAD: 1b450c8113
 Files scanned: 2973
 
 ## Summary
 
 | Cluster | Description | Total | MIGRATE | KEEP_META_ONLY | FOLLOW_UP | EXCLUDE |
 |---------|-------------|------:|--------:|---------------:|----------:|--------:|
-| A | SD-type detection | 98 | 14 | 7 | 39 | 38 |
+| A | SD-type detection | 92 | 12 | 3 | 39 | 38 |
 | B | Claim ownership detection | 72 | 26 | 0 | 22 | 24 |
 | C | Gate-skip detection | 15 | 3 | 0 | 6 | 6 |
-| **Total** | — | **185** | **43** | — | **67** | — |
+| **Total** | — | **179** | **41** | — | **67** | — |
 
 **This SD ships MIGRATE + KEEP_METADATA_ONLY.** MIGRATE_FOLLOW_UP sites file as a follow-up SD/QF after this one merges. EXCLUDE_OUT_OF_SCOPE sites are not touched.
 
@@ -80,11 +80,7 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.7 | `scripts/leo-create-sd.js` | 1762 | MIGRATE_FOLLOW_UP | `// engineering/governance LEO work (sd_type in LEGITIMATE_NO_VENTURE_SD_TYPES, or` |
 | A.7 | `scripts/leo-create-sd.js` | 1767 | MIGRATE_FOLLOW_UP | `const isNoVentureWork = LEGITIMATE_NO_VENTURE_SD_TYPES.has(sdData.sd_type)` |
 | A.2 | `scripts/leo-orchestrator/validation.js` | 44 | MIGRATE | `return currentSD && (currentSD.priority \|\| currentSD.sd_type === 'infrastructure');` |
-| A.3 | `scripts/lib/handoff-preflight.js` | 163 | KEEP_METADATA_ONLY | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
-| A.3 | `scripts/lib/handoff-preflight.js` | 294 | KEEP_METADATA_ONLY | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
 | A.1 | `scripts/modules/auto-trigger-stories.mjs` | 398 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'database' && prd.metadata?.schema) {` |
-| A.3 | `scripts/modules/decomposition-gate.js` | 107 | KEEP_METADATA_ONLY | `if (sd.metadata?.is_parent === true \|\| sd.metadata?.requires_children === true) {` |
-| A.3 | `scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js` | 133 | MIGRATE | `return sd?.metadata?.is_parent === true;` |
 | A.6 | `scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js` | 44 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return false;` |
 | A.6 | `scripts/modules/handoff/executors/plan-to-lead/index.js` | 110 | MIGRATE | `if (sdKey.startsWith('SD-LEARN-')) return;` |
 | A.2 | `scripts/modules/handoff/orchestrator-completion-guardian.js` | 77 | KEEP_METADATA_ONLY | `// 1. sd_type === 'orchestrator'` |
@@ -92,7 +88,6 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.3 | `scripts/modules/handoff/orchestrator-completion-guardian.js` | 81 | KEEP_METADATA_ONLY | `const hasIsParentFlag = parent.metadata?.is_parent === true;` |
 | A.1 | `scripts/modules/handoff/verifiers/lead-to-plan/prd-readiness.js` | 286 | MIGRATE | `if (sd.sd_type === 'documentation') return result;` |
 | A.2 | `scripts/modules/handoff/verifiers/lead-to-plan/prd-readiness.js` | 286 | MIGRATE | `if (sd.sd_type === 'documentation') return result;` |
-| A.3 | `scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js` | 84 | MIGRATE | `const isParentOrchestrator = sd.metadata?.is_parent === true;` |
 | A.1 | `scripts/modules/human-verification-validator.js` | 392 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'database') {` |
 | A.1 | `scripts/modules/human-verification-validator.js` | 398 | MIGRATE_FOLLOW_UP | `if (sd.sd_type === 'security') {` |
 | A.2 | `scripts/modules/implementation-fidelity/sections/data-flow-alignment.js` | 109 | MIGRATE_FOLLOW_UP | `if (sd?.sd_type === 'feature' && !hasUIScope) {` |
@@ -114,7 +109,6 @@ Multiple call sites classify an SD's type by reading sd_type column, metadata.is
 | A.4 | `scripts/orchestrator-preflight.js` | 135 | MIGRATE | `sd.metadata?.is_orchestrator === true \|\|` |
 | A.1 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
 | A.2 | `scripts/pcvp-anomaly-detection.cjs` | 107 | MIGRATE_FOLLOW_UP | `severity: sd.sd_type === 'feature' ? 'critical' : 'warning',` |
-| A.3 | `scripts/phase-preflight.js` | 261 | KEEP_METADATA_ONLY | `explicitFlag: sd.metadata?.is_parent === true,` |
 | A.1 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
 | A.2 | `scripts/sd-start.js` | 284 | MIGRATE | `*   1. sd.sd_type === 'orchestrator'` |
 | A.2 | `scripts/sd-start.js` | 359 | MIGRATE | `* When a child is itself an orchestrator (sd_type === 'orchestrator' or has children),` |

--- a/lib/claim/ownership-detection.js
+++ b/lib/claim/ownership-detection.js
@@ -1,0 +1,184 @@
+/**
+ * Unified Claim Ownership Detection
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-3
+ *
+ * Single source of truth for "who currently holds this SD?" detection across the sweep,
+ * dashboard, sd-start, and handoff infrastructure.
+ *
+ * BEFORE this helper, the same question was answered by reading different subsets of
+ * claude_sessions columns (claiming_session_id, active_session_id, is_working_on, is_alive,
+ * has_uncommitted_changes) across N call sites. Each picked 1-2 signals; combinations
+ * differed; liveness thresholds (300s LIVENESS / 600s DISPLAY) were duplicated inline.
+ *
+ * PER LEAD DESIGN Q3: uncached by default. Inputs are sdKey strings (not sd objects),
+ * consumers poll, claim state mutates frequently. Different access pattern than the
+ * Cluster A sd-type helper which uses WeakMap. Optional getClaimHolderCached() with
+ * Map+ttlMs is exposed for handoff sub-call bursts.
+ *
+ * Re-exports CLAIM_HOLDING_STATUSES from lib/claim/holding-statuses.cjs so consumers
+ * have a single import surface.
+ */
+
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('./holding-statuses.cjs');
+
+export { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys };
+
+/**
+ * Liveness thresholds (seconds). Documented at the helper boundary so consumers
+ * don't reimplement them inline. Two thresholds per SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001
+ * (board decision 20260406):
+ *   LIVENESS  = 300s — heartbeat staleness for "still holding" classification
+ *   DISPLAY   = 600s — heartbeat staleness for UI render-as-active
+ */
+export const LIVENESS_THRESHOLD_SECONDS = 300;
+export const DISPLAY_THRESHOLD_SECONDS = 600;
+
+/**
+ * Optional Map-keyed TTL cache for getClaimHolderCached. Default getClaimHolder
+ * does NOT use this cache.
+ */
+const ttlCache = new Map();
+
+function cacheKey(sdKey) {
+  return `claim:${sdKey}`;
+}
+
+/**
+ * Returns the claim holder for a given SD, or null if unclaimed.
+ *
+ * @param {string} sdKey
+ * @param {Object} supabase
+ * @returns {Promise<null | {session_id: string, sd_key: string, status: string, is_alive: boolean, has_uncommitted_changes: boolean, holding_status: string}>}
+ */
+export async function getClaimHolder(sdKey, supabase) {
+  if (!sdKey || !supabase) return null;
+
+  const { data: sd, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, claiming_session_id')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+
+  if (sdErr || !sd || !sd.claiming_session_id) return null;
+
+  const { data: session, error: sessErr } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_key, status, is_alive, has_uncommitted_changes, last_heartbeat')
+    .eq('session_id', sd.claiming_session_id)
+    .maybeSingle();
+
+  if (sessErr || !session) return null;
+
+  const holdingStatus = classifyHoldingStatus(session);
+
+  return {
+    session_id: session.session_id,
+    sd_key: session.sd_key,
+    status: session.status,
+    is_alive: session.is_alive === true,
+    has_uncommitted_changes: session.has_uncommitted_changes === true,
+    holding_status: holdingStatus,
+  };
+}
+
+/**
+ * Returns true iff the SD is currently claimed by the given session.
+ *
+ * @param {string} sdKey
+ * @param {string} sessionId
+ * @param {Object} supabase
+ * @returns {Promise<boolean>}
+ */
+export async function isClaimedBy(sdKey, sessionId, supabase) {
+  if (!sdKey || !sessionId || !supabase) return false;
+  const holder = await getClaimHolder(sdKey, supabase);
+  return holder !== null && holder.session_id === sessionId;
+}
+
+/**
+ * Returns all currently-live claim holders (those whose holding_status is in
+ * CLAIM_HOLDING_STATUSES). Used by sweep and dashboard to render active workers.
+ *
+ * @param {Object} supabase
+ * @returns {Promise<Array<{sd_key: string, session_id: string, holding_status: string}>>}
+ */
+export async function getLiveClaimHolders(supabase) {
+  if (!supabase) return [];
+  const { data: sessions, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_key, status, is_alive, has_uncommitted_changes, last_heartbeat')
+    .not('sd_key', 'is', null);
+
+  if (error || !Array.isArray(sessions)) return [];
+
+  const out = [];
+  for (const session of sessions) {
+    const holdingStatus = classifyHoldingStatus(session);
+    if (CLAIM_HOLDING_STATUSES.has(holdingStatus)) {
+      out.push({
+        sd_key: session.sd_key,
+        session_id: session.session_id,
+        holding_status: holdingStatus,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Classify a claude_sessions row into one of the holding statuses.
+ *   ALIVE_SOURCE_SIDE  — has uncommitted_changes (source-side evidence overrides heartbeat staleness)
+ *   ACTIVE             — heartbeat fresher than LIVENESS_THRESHOLD_SECONDS
+ *   ALIVE_NO_HEARTBEAT — is_alive flag true OR heartbeat fresher than DISPLAY_THRESHOLD_SECONDS but stale beyond LIVENESS
+ *   STALE_UNKNOWN      — heartbeat older than DISPLAY threshold
+ *
+ * @param {Object} session - claude_sessions row
+ * @returns {string} status code
+ */
+export function classifyHoldingStatus(session) {
+  if (!session) return 'STALE_UNKNOWN';
+  if (session.has_uncommitted_changes === true) return 'ALIVE_SOURCE_SIDE';
+
+  const heartbeatSec = heartbeatAgeSeconds(session.last_heartbeat);
+  if (heartbeatSec !== null && heartbeatSec <= LIVENESS_THRESHOLD_SECONDS) return 'ACTIVE';
+  if (session.is_alive === true) return 'ALIVE_NO_HEARTBEAT';
+  if (heartbeatSec !== null && heartbeatSec <= DISPLAY_THRESHOLD_SECONDS) return 'ALIVE_NO_HEARTBEAT';
+  return 'STALE_UNKNOWN';
+}
+
+function heartbeatAgeSeconds(timestamp) {
+  if (!timestamp) return null;
+  const t = typeof timestamp === 'string' ? Date.parse(timestamp) : timestamp;
+  if (Number.isNaN(t)) return null;
+  return Math.floor((Date.now() - t) / 1000);
+}
+
+/**
+ * Optional cached variant of getClaimHolder for handoff sub-call bursts where
+ * multiple gates query the same sdKey in quick succession. TTL defaults to
+ * 5000ms — short enough that stale results are rare, long enough to amortize
+ * DB cost across a single handoff execution.
+ *
+ * @param {string} sdKey
+ * @param {Object} options - { supabase, ttlMs? }
+ * @returns {Promise<null|Object>}
+ */
+export async function getClaimHolderCached(sdKey, { supabase, ttlMs = 5000 } = {}) {
+  if (!sdKey || !supabase) return null;
+  const key = cacheKey(sdKey);
+  const entry = ttlCache.get(key);
+  if (entry && Date.now() - entry.t < ttlMs) return entry.v;
+
+  const value = await getClaimHolder(sdKey, supabase);
+  ttlCache.set(key, { t: Date.now(), v: value });
+  return value;
+}
+
+/**
+ * Test helper: clear the TTL cache. Production code should never call this.
+ */
+export function _clearCache() {
+  ttlCache.clear();
+}

--- a/lib/handoff/gate-skip-detection.js
+++ b/lib/handoff/gate-skip-detection.js
@@ -1,0 +1,91 @@
+/**
+ * Unified Gate-Skip Detection
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-4
+ *
+ * Per LEAD VALIDATION C4, the Cluster C semantic audit (Phase 1 audit deliverable)
+ * confirmed gate-skip decisions split into TWO distinct shapes:
+ *   1. Type-based skip — "this gate doesn't apply to sd_type=X"
+ *   2. Status/phase-based skip — "this gate doesn't apply when SD is in status=Y"
+ *
+ * Rather than collapse them into a single shouldSkipGate(), this helper exposes
+ * BOTH shapes as separate predicates. Mixing them in one API would conflate two
+ * orthogonal decisions (type vs lifecycle state).
+ *
+ * Each predicate returns `{ skip: boolean, reason: string }` so call sites can
+ * log a structured skip rationale at the same time as making the decision.
+ *
+ * Delegates SD-type classification to the Cluster A helper
+ * (lib/sd/type-detection.js classifySDType) so the type signal is consistent
+ * across detection clusters.
+ */
+
+import { classifySDType } from '../sd/type-detection.js';
+
+/**
+ * Decide whether a gate should be skipped because the SD type doesn't apply.
+ *
+ * @param {Object} sd
+ * @param {string[]|Set<string>} applicableTypes - sd_types this gate applies to
+ * @param {Object} [options]
+ * @param {string} [options.gateName] - included in skip reason
+ * @returns {{ skip: boolean, reason: string }}
+ */
+export function shouldSkipForType(sd, applicableTypes, options = {}) {
+  const gateName = options.gateName || 'gate';
+  if (!sd) return { skip: true, reason: `${gateName}: sd is null` };
+
+  const sdType = classifySDType(sd) || sd.sd_type;
+  const allowed = applicableTypes instanceof Set ? applicableTypes : new Set(applicableTypes || []);
+
+  if (!sdType) {
+    return { skip: false, reason: `${gateName}: sd_type unset; no skip applied (default-include)` };
+  }
+  if (allowed.size === 0) {
+    return { skip: false, reason: `${gateName}: no applicableTypes specified; default-include` };
+  }
+  if (allowed.has(sdType)) {
+    return { skip: false, reason: `${gateName}: sd_type='${sdType}' is in applicable set` };
+  }
+  return {
+    skip: true,
+    reason: `${gateName}: sd_type='${sdType}' is not in applicable types [${[...allowed].join(', ')}]`,
+  };
+}
+
+/**
+ * Decide whether a gate should be skipped because the SD's status/phase doesn't apply.
+ *
+ * @param {Object} sd
+ * @param {string[]|Set<string>} applicableStatuses
+ * @param {Object} [options]
+ * @param {string} [options.gateName]
+ * @returns {{ skip: boolean, reason: string }}
+ */
+export function shouldSkipForStatus(sd, applicableStatuses, options = {}) {
+  const gateName = options.gateName || 'gate';
+  if (!sd) return { skip: true, reason: `${gateName}: sd is null` };
+
+  const status = sd.status;
+  const allowed = applicableStatuses instanceof Set ? applicableStatuses : new Set(applicableStatuses || []);
+
+  if (!status) {
+    return { skip: false, reason: `${gateName}: status unset; no skip applied (default-include)` };
+  }
+  if (allowed.size === 0) {
+    return { skip: false, reason: `${gateName}: no applicableStatuses specified; default-include` };
+  }
+  if (allowed.has(status)) {
+    return { skip: false, reason: `${gateName}: status='${status}' is in applicable set` };
+  }
+  return {
+    skip: true,
+    reason: `${gateName}: status='${status}' is not in applicable statuses [${[...allowed].join(', ')}]`,
+  };
+}
+
+/**
+ * Test helper.
+ */
+export function _clearCache() {
+  // No cache for this helper.
+}

--- a/lib/sd/type-detection.js
+++ b/lib/sd/type-detection.js
@@ -1,0 +1,182 @@
+/**
+ * Unified SD-Type Detection
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-2
+ *
+ * Single source of truth for "what kind of SD is this?" classification questions.
+ *
+ * BEFORE this helper, the same questions were answered by checking different subsets
+ * of signals across N call sites — surveyed by the Phase 1 audit at
+ * docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md. Each call site
+ * picked 1-2 signals; combinations differed; verdicts diverged on edge cases.
+ *
+ * API mirrors lib/handoff/parent-detection.js (PR #4021 canonical reference):
+ *   - Async classify(...) + sync ...Sync(...) variants
+ *   - WeakMap cache keyed on sd object identity
+ *   - OR-merge of all available signals
+ *
+ * Per LEAD VALIDATION C2: this helper MUST import (not duplicate)
+ *   - lib/sd-type-enum.js — canonical CANONICAL_SD_TYPES Set + assertValidSdType
+ *   - lib/eva/bridge/sd-router.js — LEGITIMATE_NO_VENTURE_SD_TYPES Set
+ *
+ * Per LEAD DESIGN Q3: this helper uses WeakMap cache (sd objects are mostly
+ * request-scoped); the Cluster B ownership-detection.js helper does NOT cache
+ * by default (different access pattern). Each cluster's helper picks the
+ * cache strategy that matches its consumer pattern.
+ *
+ * Sibling: lib/utils/sd-type-validation.js handles a DIFFERENT abstraction
+ * (validation REQUIREMENTS — does this SD need TESTING/UAT/E2E?) and is
+ * intentionally left in place.
+ */
+
+import { CANONICAL_SD_TYPES, isValidSdType } from '../sd-type-enum.js';
+import { LEGITIMATE_NO_VENTURE_SD_TYPES } from '../eva/bridge/sd-router.js';
+
+const cache = new WeakMap();
+
+function readCache(sd, key) {
+  const entry = cache.get(sd);
+  return entry && key in entry ? entry[key] : undefined;
+}
+
+function writeCache(sd, key, value) {
+  const entry = cache.get(sd) || {};
+  entry[key] = value;
+  cache.set(sd, entry);
+  return value;
+}
+
+/**
+ * Returns true if SD is an orchestrator. Async — performs a DB children lookup
+ * when neither sd_type nor metadata flags assert the answer.
+ *
+ * OR-merges:
+ *   - sd.sd_type === 'orchestrator'
+ *   - sd.metadata?.is_orchestrator === true
+ *   - sd.metadata?.is_parent === true   (legacy parent-orchestrator flag)
+ *   - DB query: at least 1 child in strategic_directives_v2 WHERE parent_sd_id = sd.id
+ *
+ * @param {Object} sd
+ * @param {Object|null} supabase - Pass null/undefined to skip the DB-query branch
+ * @returns {Promise<boolean>}
+ */
+export async function isOrchestrator(sd, supabase) {
+  if (!sd) return false;
+  const cached = readCache(sd, 'isOrchestrator');
+  if (cached !== undefined) return cached;
+
+  if (
+    sd.sd_type === 'orchestrator' ||
+    sd.metadata?.is_orchestrator === true ||
+    sd.metadata?.is_parent === true
+  ) {
+    return writeCache(sd, 'isOrchestrator', true);
+  }
+
+  if (!supabase || !sd.id) {
+    return writeCache(sd, 'isOrchestrator', false);
+  }
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('parent_sd_id', sd.id)
+    .limit(1);
+
+  const hasChildren = !error && Array.isArray(data) && data.length > 0;
+  return writeCache(sd, 'isOrchestrator', hasChildren);
+}
+
+/**
+ * Sync orchestrator check (metadata + sd_type only — no DB lookup).
+ * Use in hot-path mid-handoff sites where read-after-write transactional consistency
+ * matters more than catching DB-only parents (per LEAD RISK C1).
+ *
+ * @param {Object} sd
+ * @returns {boolean}
+ */
+export function isOrchestratorSync(sd) {
+  if (!sd) return false;
+  return (
+    sd.sd_type === 'orchestrator' ||
+    sd.metadata?.is_orchestrator === true ||
+    sd.metadata?.is_parent === true
+  );
+}
+
+/**
+ * Returns true if SD belongs to a venture (i.e. delivers product to a venture's
+ * codebase, not engineering/governance infra work).
+ *
+ * OR-merges:
+ *   - sd.venture_id is set (canonical writer)
+ *   - sd.sd_type === 'venture'  (rare; most ventures use other sd_types)
+ *   - sd.metadata?.is_venture === true
+ *
+ * Note: sd_key prefix patterns (SD-VENTURE-*, SD-CRONGENIUS-*) are intentionally NOT
+ * a signal here — sd_key prefixes drift (e.g., SD-CRONGENIUS-LEO-INFRA-* was
+ * prefix-misleading per pilot journal P-FAIL-5). Trust the venture_id column.
+ *
+ * @param {Object} sd
+ * @returns {boolean}
+ */
+export function isVenture(sd) {
+  if (!sd) return false;
+  return (
+    Boolean(sd.venture_id) ||
+    sd.sd_type === 'venture' ||
+    sd.metadata?.is_venture === true
+  );
+}
+
+/** Alias — venture detection has no async branch (no DB lookup needed). */
+export function isVentureSync(sd) {
+  return isVenture(sd);
+}
+
+/**
+ * Returns true if SD's sd_type is on the canonical "no venture needed" list
+ * (engineering / governance / LEO infrastructure work).
+ *
+ * Signals merged:
+ *   - sd.sd_type is in LEGITIMATE_NO_VENTURE_SD_TYPES (from lib/eva/bridge/sd-router.js)
+ *
+ * @param {Object} sd
+ * @returns {boolean}
+ */
+export function isInfraNoVenture(sd) {
+  if (!sd || !sd.sd_type) return false;
+  return LEGITIMATE_NO_VENTURE_SD_TYPES.has(sd.sd_type);
+}
+
+/** Alias — no async branch. */
+export function isInfraNoVentureSync(sd) {
+  return isInfraNoVenture(sd);
+}
+
+/**
+ * Returns the canonical sd_type for this SD, applying the OR-merge priority:
+ *   1. Explicit sd.sd_type if it's a canonical value
+ *   2. 'orchestrator' if metadata.is_orchestrator or metadata.is_parent is true
+ *   3. null (caller decides default — usually 'feature')
+ *
+ * @param {Object} sd
+ * @returns {string|null}
+ */
+export function classifySDType(sd) {
+  if (!sd) return null;
+  if (sd.sd_type && isValidSdType(sd.sd_type)) return sd.sd_type;
+  if (sd.metadata?.is_orchestrator === true || sd.metadata?.is_parent === true) {
+    return 'orchestrator';
+  }
+  return null;
+}
+
+/**
+ * Test helper: signal that the WeakMap cache should be considered cleared.
+ * WeakMap entries are released when sd objects are GCed; this helper exists so
+ * tests can document their cache-reset intent. Production code should never
+ * call this.
+ */
+export function _clearCache() {
+  // No-op. Pass fresh sd object instances in tests instead.
+}

--- a/scripts/lib/handoff-preflight.js
+++ b/scripts/lib/handoff-preflight.js
@@ -160,7 +160,10 @@ async function validateSDHandoffState(sdId, targetPhase, _options = {}) {
     };
 
     // Check for modified workflow SD types
-    const isParentOrchestrator = sd.metadata?.is_parent === true;
+    // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: sync helper preserves
+    // hot-path read-after-write transactional consistency (per LEAD RISK C1).
+    const { isParentOrchestratorSync } = await import('../../lib/handoff/parent-detection.js');
+    const isParentOrchestrator = isParentOrchestratorSync(sd);
     const sdType = sd.sd_type?.toLowerCase() || 'feature';
 
     let skipHandoffs = [];
@@ -291,7 +294,9 @@ async function verifyCompleteHandoffChain(sdId) {
     }
 
     // Check for modified workflow
-    const isParentOrchestrator = sd.metadata?.is_parent === true;
+    // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: sync helper (hot-path).
+    const { isParentOrchestratorSync } = await import('../../lib/handoff/parent-detection.js');
+    const isParentOrchestrator = isParentOrchestratorSync(sd);
     const sdType = sd.sd_type?.toLowerCase() || 'feature';
 
     let expectedChain = [...result.chain.expected];

--- a/scripts/modules/decomposition-gate.js
+++ b/scripts/modules/decomposition-gate.js
@@ -20,6 +20,8 @@
 
 import dotenv from 'dotenv';
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+// SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: canonical parent-detection helper.
+import { isParentOrchestratorSync } from '../../lib/handoff/parent-detection.js';
 
 dotenv.config();
 
@@ -104,7 +106,11 @@ function checkStructuralSignals(sd) {
   }
 
   // Check for explicit parent flag
-  if (sd.metadata?.is_parent === true || sd.metadata?.requires_children === true) {
+  // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: is_parent delegates to canonical
+  // helper (static import at top of file — checkStructuralSignals is sync);
+  // requires_children is decomposition-gate-specific (not part of generic parent
+  // detection) and intentionally preserved as a separate signal.
+  if (isParentOrchestratorSync(sd) || sd.metadata?.requires_children === true) {
     signals.hasExplicitParentFlag = true;
     signals.details.push('Explicitly flagged as parent/requires children');
   }

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -112,7 +112,10 @@ export class BaseExecutor {
       // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-094: Orchestrator SDs are exempt from worktree
       // isolation (check c) because they coordinate children and don't produce code directly.
       // They still must pass identity (a) and ownership (b) checks.
-      const isOrchestrator = sd?.sd_type === 'orchestrator';
+      // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-2: use canonical helper
+      // (sync variant — hot-path mid-handoff, metadata-flag-only per RISK C1).
+      const { isOrchestratorSync } = await import('../../../../lib/sd/type-detection.js');
+      const isOrchestrator = isOrchestratorSync(sd);
       try {
         const { assertValidClaim, ClaimIdentityError } = await import('../../../../lib/claim-validity-gate.js');
         const sdKeyForGate = sd?.sd_key || sdId;

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js
@@ -26,6 +26,8 @@ const STOP_KEYWORDS_DEFAULT = [
   'adversarial sub-agent', 'progressive disclosure', 'skill body',
 ];
 
+import { shouldSkipForType } from '../../../../../../lib/handoff/gate-skip-detection.js';
+
 export function createAdrsConsultedGate(supabase) {
   return {
     name: 'GATE_ADRS_CONSULTED',
@@ -33,14 +35,16 @@ export function createAdrsConsultedGate(supabase) {
     threshold: 70,
     async execute(sd) {
       // Scope: refactor SDs only
-      if (sd.sd_type !== 'refactor') {
+      // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-4: use canonical helper.
+      const skip = shouldSkipForType(sd, ['refactor'], { gateName: 'GATE_ADRS_CONSULTED' });
+      if (skip.skip) {
         return {
           name: 'GATE_ADRS_CONSULTED',
           score: 100,
           passed: true,
-          message: 'SD is not refactor type — gate not applicable',
+          message: skip.reason,
           warnings: [],
-          details: { sd_type: sd.sd_type, skipped: true },
+          details: { sd_type: sd.sd_type, skipped: true, skip_reason: skip.reason },
         };
       }
 

--- a/scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js
@@ -120,15 +120,17 @@ export function getParentOrchestratorGates(supabase, prdRepo, sd, _options) {
 /**
  * Check if SD is a parent orchestrator (synchronous shim — metadata-flag only).
  *
- * Delegates to lib/handoff/parent-detection.js for the canonical detection logic.
- * This sync wrapper preserves the existing call site at plan-to-exec/index.js:97,
- * which runs before any supabase client is available. For full detection including
- * DB-side children query, prefer the async lib/handoff/parent-detection.js
- * isParentOrchestrator() — see SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-1.
+ * Delegates to lib/handoff/parent-detection.js — the documented canonical helper from
+ * SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-1. SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001
+ * Phase 5: replaces the inline check that previously doc-lied about delegating.
+ *
+ * For full detection including DB-side children query, prefer the async
+ * lib/handoff/parent-detection.js isParentOrchestrator() directly.
  *
  * @param {Object} sd - Strategic Directive
- * @returns {boolean} True if metadata.is_parent === true
+ * @returns {boolean} True if metadata.is_parent === true (or legacy is_orchestrator flag)
  */
+import { isParentOrchestratorSync } from '../../../../../lib/handoff/parent-detection.js';
 export function isParentOrchestrator(sd) {
-  return sd?.metadata?.is_parent === true;
+  return isParentOrchestratorSync(sd);
 }

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -81,7 +81,11 @@ export class PlanToExecVerifier {
       }
 
       // PAT-PARENT-DET: Detect parent orchestrator SDs
-      const isParentOrchestrator = sd.metadata?.is_parent === true;
+      // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: use canonical helper.
+      // Async variant OR-merges metadata flag with DB children query — strictly broader
+      // than the prior metadata-only check; catches parents with children-in-DB but no flag.
+      const { isParentOrchestrator: detectParentOrchestrator } = await import('../../../../../lib/handoff/parent-detection.js');
+      const isParentOrchestrator = await detectParentOrchestrator(sd, this.supabase);
       if (isParentOrchestrator) {
         console.log('\n   🎯 PARENT ORCHESTRATOR DETECTED');
         console.log('      Skipping implementation-specific validation (user stories, workflow review)');

--- a/scripts/modules/parent-orchestrator-handler.js
+++ b/scripts/modules/parent-orchestrator-handler.js
@@ -53,14 +53,13 @@ export class ParentOrchestratorHandler {
     }
 
     // SD-LEO-FIX-PARENT-BLOCK-001: Robust parent detection
-    // Check multiple indicators:
-    // 1. metadata.is_parent === true (explicit flag)
-    // 2. sd_type === 'orchestrator' (type-based)
-    // 3. Has children in database (dynamic check)
-    const hasIsParentFlag = sd.metadata?.is_parent === true;
-    const isOrchestratorType = sd.sd_type === 'orchestrator';
+    // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-2: 3-signal OR-merge (metadata.is_parent,
+    // sd_type === 'orchestrator', DB-children) now lives inside the canonical helper.
+    const { isOrchestrator } = await import('../../lib/sd/type-detection.js');
+    const isParent = await isOrchestrator(sd, this.supabase);
 
-    // Get children (also used for dynamic parent detection)
+    // Get children for the surface payload (helper does its own child-lookup for detection;
+    // we still need the row data here for the rendered children[] array below).
     const { data: children } = await this.supabase
       .from('strategic_directives_v2')
       // SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Removed legacy_id (column dropped 2026-01-24)
@@ -68,10 +67,6 @@ export class ParentOrchestratorHandler {
       .eq('parent_sd_id', sd.id)
       // SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Removed legacy_id (column dropped 2026-01-24)
     .order('sd_key', { ascending: true });
-
-    // SD-LEO-FIX-PARENT-BLOCK-001: Accept as parent if any indicator is true
-    const hasChildren = children && children.length > 0;
-    const isParent = hasIsParentFlag || isOrchestratorType || hasChildren;
 
     if (!isParent) {
       return { isParent: false, sd, children: [] };

--- a/scripts/one-off/_audit-dual-detection-clusters.mjs
+++ b/scripts/one-off/_audit-dual-detection-clusters.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+/**
+ * Audit dual-detection clusters across EHG_Engineer production code
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-1
+ *
+ * READ-ONLY. Hard-asserts no DB writes by refusing to run when SUPABASE_SERVICE_ROLE_KEY is set.
+ *
+ * Three clusters enumerated:
+ *   A - SD-type detection (sd_type column, metadata.is_* flags, sd_key prefix, LEGITIMATE_NO_VENTURE_SD_TYPES)
+ *   B - Claim ownership detection (claiming_session_id, active_session_id, is_working_on, is_alive)
+ *   C - Gate-skip detection (gate.condition, context.skipGate, metadata.skip_*)
+ *
+ * Output:
+ *   .audit-out/dual-detection-clusters.json — JSON intermediate (gitignored)
+ *   docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md — markdown deliverable
+ *
+ * Determinism: output is sorted alphabetical-path then ascending-line. Two runs on the same
+ * tree produce byte-identical files (TR-2).
+ *
+ * Portability: uses `git ls-files` + native JS regex scanning. No external grep/rg dependency.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// TR-1: read-only assertion. Audit must never run with service-role credentials.
+if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('REFUSED: audit script must run without SUPABASE_SERVICE_ROLE_KEY (read-only enforcement per TR-1).');
+  console.error('Unset the env var before running, e.g.:  unset SUPABASE_SERVICE_ROLE_KEY && node scripts/one-off/_audit-dual-detection-clusters.mjs');
+  process.exit(2);
+}
+
+const CLUSTER_PATTERNS = {
+  A: [
+    { id: 'A.1', description: 'sd_type direct comparison (e.g. sd.sd_type === "orchestrator")', pattern: /\bsd\.sd_type\s*===?\s*["']/ },
+    { id: 'A.2', description: 'destructured sd_type comparison ({ sd_type } === "...")', pattern: /\bsd_type\s*===?\s*["'](?:orchestrator|venture|infrastructure|feature|fix|documentation)/ },
+    { id: 'A.3', description: 'metadata.is_parent boolean read', pattern: /metadata\?\.is_parent\s*===?\s*true/ },
+    { id: 'A.4', description: 'metadata.is_orchestrator boolean read', pattern: /metadata\?\.is_orchestrator\s*===?\s*true/ },
+    { id: 'A.5', description: 'metadata.is_venture boolean read', pattern: /metadata\?\.is_venture\s*===?\s*true/ },
+    { id: 'A.6', description: 'sd_key prefix check (startsWith SD-LEO/SD-FDBK/etc.)', pattern: /\.startsWith\(["']SD-(?:LEO|FDBK|VENTURE|QF|CRONGENIUS|LEARN|MAN|CANVAS)/ },
+    { id: 'A.7', description: 'LEGITIMATE_NO_VENTURE_SD_TYPES usage', pattern: /\bLEGITIMATE_NO_VENTURE_SD_TYPES\b/ },
+    { id: 'A.8', description: 'category check (sd.category === "...")', pattern: /\bsd\.category\s*===?\s*["']/ },
+  ],
+  B: [
+    // Cluster B patterns are READ-FOR-DECISION only. Writes (.update({...}), .insert({...})) and SQL
+    // SELECT column lists are out of scope for the ownership-detection helper (which only ANSWERS
+    // "who holds this SD?", it doesn't SET the holder). Writes need their own consolidation, but
+    // that's a separate SD — out of scope per the brief's framing of Cluster B as "detection."
+    { id: 'B.1', description: 'claiming_session_id property read (sd.X, data.X, etc.)', pattern: /(?<!')\b(?:sd|data|row|session|claim|holder)\.claiming_session_id\b/ },
+    { id: 'B.1b', description: 'claiming_session_id supabase .eq() filter (read-intent query)', pattern: /\.eq\(\s*["']claiming_session_id["']/ },
+    { id: 'B.2', description: 'active_session_id property read', pattern: /(?<!')\b(?:sd|data|row|session|claim|holder)\.active_session_id\b/ },
+    { id: 'B.2b', description: 'active_session_id supabase .eq() filter (read-intent query)', pattern: /\.eq\(\s*["']active_session_id["']/ },
+    { id: 'B.3', description: 'is_working_on property read', pattern: /(?<!')\b(?:sd|data|row|session|claim|holder)\.is_working_on\b/ },
+    { id: 'B.3b', description: 'is_working_on supabase .eq() filter', pattern: /\.eq\(\s*["']is_working_on["']/ },
+    { id: 'B.4', description: 'is_alive property read', pattern: /(?<!')\b(?:sd|data|row|session|claim|holder)\.is_alive\b/ },
+    { id: 'B.5', description: 'CLAIM_HOLDING_STATUSES import or use', pattern: /\bCLAIM_HOLDING_STATUSES\b/ },
+    { id: 'B.6', description: 'has_uncommitted_changes property read', pattern: /(?<!')\b(?:sd|data|row|session|claim|holder)\.has_uncommitted_changes\b/ },
+  ],
+  C: [
+    { id: 'C.1', description: 'gate.condition or shouldSkip pattern', pattern: /\b(?:gate\.condition|shouldSkipGate|shouldSkipFor[A-Z])/ },
+    { id: 'C.2', description: 'metadata.skip_* flag read', pattern: /metadata\?\.skip_[a-z_]+/ },
+    { id: 'C.3', description: 'context.skipGate explicit injection', pattern: /\bcontext\.skipGate\b/ },
+    { id: 'C.4', description: 'SD-type-gated gate skip (e.g. sd_type !== "orchestrator" return)', pattern: /if\s*\(\s*sd\.sd_type\s*!==?\s*["']/ },
+  ],
+};
+
+const EXCLUDE_PATH_PREFIXES = [
+  'tests/',
+  'test/',
+  'scripts/archive/',
+  '.prd-payloads/',
+  '.rca/',
+  '.audit-out/',
+  'docs/audits/',
+  'node_modules/',
+  '.worktrees/',
+  'dist/',
+  'build/',
+];
+
+const EXCLUDE_FILE_SUFFIXES = [
+  '.test.js',
+  '.test.mjs',
+  '.test.cjs',
+  '.spec.js',
+  '.spec.mjs',
+  '.spec.cjs',
+];
+
+function isExcluded(file) {
+  for (const prefix of EXCLUDE_PATH_PREFIXES) {
+    if (file.startsWith(prefix)) return true;
+  }
+  for (const suffix of EXCLUDE_FILE_SUFFIXES) {
+    if (file.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+function listProductionFiles(repoRoot) {
+  const raw = execSync('git ls-files', { cwd: repoRoot, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  return raw
+    .split('\n')
+    .filter(Boolean)
+    .map(f => f.replace(/\\/g, '/'))
+    .filter(f => /\.(?:js|mjs|cjs)$/i.test(f))
+    .filter(f => !isExcluded(f))
+    .sort();
+}
+
+function scanFile(filePath, repoRoot) {
+  const abs = path.join(repoRoot, filePath);
+  let content;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch (err) {
+    return [];
+  }
+  const lines = content.split('\n');
+  const hits = [];
+  for (const [clusterId, rules] of Object.entries(CLUSTER_PATTERNS)) {
+    for (const rule of rules) {
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (rule.pattern.test(line)) {
+          hits.push({
+            cluster: clusterId,
+            rule_id: rule.id,
+            rule_description: rule.description,
+            file: filePath,
+            line: i + 1,
+            content: line.trim().slice(0, 240),
+          });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+// HIGH-IMPACT path matchers — these ARE the production routing/handoff/claim infrastructure
+// where dual-detection drift causes real bugs. This SD migrates HIGH-IMPACT in-scope.
+// Everything else routes to MIGRATE_FOLLOW_UP (filed as a follow-up SD/QF after this one ships).
+const HIGH_IMPACT_PATTERNS = [
+  /^lib\/handoff\//,
+  /^lib\/claim/,
+  /^scripts\/modules\/handoff\//,
+  /^scripts\/lib\/handoff-/,
+  /^scripts\/modules\/parent-orchestrator-handler\.js$/,
+  /^scripts\/modules\/decomposition-gate\.js$/,
+  /^scripts\/phase-preflight\.js$/,
+  /^scripts\/sd-start\.js$/,
+  /^scripts\/stale-session-sweep\.cjs$/,
+  /^scripts\/leo-cleanup\.js$/,
+  /^scripts\/modules\/sd-next\/display\/recommendations\.js$/,
+  /^scripts\/modules\/handoff\/validation\//,
+  /^scripts\/leo-orchestrator\//,
+  /^scripts\/modules\/leo-orchestrator\//,
+  /^scripts\/orchestrator-preflight\.js$/,
+  /^scripts\/modules\/orchestrator\//,
+];
+
+function isHighImpact(file) {
+  return HIGH_IMPACT_PATTERNS.some(re => re.test(file));
+}
+
+function classify(hit) {
+  const hotPathFiles = new Set([
+    'scripts/lib/handoff-preflight.js',
+    'scripts/phase-preflight.js',
+    'scripts/modules/handoff/orchestrator-completion-guardian.js',
+    'scripts/modules/decomposition-gate.js',
+  ]);
+  const canonicalHelperFiles = new Set([
+    'lib/handoff/parent-detection.js',
+    'lib/sd/type-detection.js',
+    'lib/claim/ownership-detection.js',
+    'lib/handoff/gate-skip-detection.js',
+    'lib/claim/holding-statuses.cjs',
+    'lib/sd-type-enum.js',
+    'lib/eva/bridge/sd-router.js',
+    'lib/utils/sd-type-validation.js',
+  ]);
+  if (canonicalHelperFiles.has(hit.file)) {
+    return { classification: 'EXCLUDE_OUT_OF_SCOPE', rationale: 'Canonical helper file — defines the pattern, not a consumer.' };
+  }
+  if (hit.file.startsWith('scripts/one-off/')) {
+    return { classification: 'EXCLUDE_OUT_OF_SCOPE', rationale: 'One-off diagnostic script; not part of production routing.' };
+  }
+  if (hit.file.startsWith('database/') || hit.file.startsWith('migrations/')) {
+    return { classification: 'EXCLUDE_OUT_OF_SCOPE', rationale: 'Database migration / schema metadata — not a detection consumer.' };
+  }
+  if (hotPathFiles.has(hit.file)) {
+    return { classification: 'KEEP_METADATA_ONLY', rationale: 'Hot-path runs mid-handoff; metadata-flag-only preserves read-after-write transactional consistency (per RISK C1). Uses sync helper variant.' };
+  }
+  if (isHighImpact(hit.file)) {
+    return { classification: 'MIGRATE', rationale: 'HIGH-IMPACT call site on the production handoff/claim/routing path. In scope for this SD.' };
+  }
+  return { classification: 'MIGRATE_FOLLOW_UP', rationale: 'Lower-impact consumer (enrichment script, utility CLI, server route). Files as follow-up SD/QF after this SD ships.' };
+}
+
+function renderMarkdown(audit) {
+  const lines = [];
+  lines.push('# Dual-detection cluster audit — SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001');
+  lines.push('');
+  lines.push(`Generated (deterministic): ${audit.generated_at}`);
+  lines.push(`Repo: ${audit.repo}`);
+  lines.push(`Git HEAD: ${audit.git_head}`);
+  lines.push(`Files scanned: ${audit.files_scanned}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Cluster | Description | Total | MIGRATE | KEEP_META_ONLY | FOLLOW_UP | EXCLUDE |');
+  lines.push('|---------|-------------|------:|--------:|---------------:|----------:|--------:|');
+  for (const cId of ['A', 'B', 'C']) {
+    const hits = audit.clusters[cId].hits;
+    const migrate = hits.filter(h => h.classification === 'MIGRATE').length;
+    const keep = hits.filter(h => h.classification === 'KEEP_METADATA_ONLY').length;
+    const followUp = hits.filter(h => h.classification === 'MIGRATE_FOLLOW_UP').length;
+    const exclude = hits.filter(h => h.classification === 'EXCLUDE_OUT_OF_SCOPE').length;
+    lines.push(`| ${cId} | ${audit.clusters[cId].name} | ${hits.length} | ${migrate} | ${keep} | ${followUp} | ${exclude} |`);
+  }
+  const totalAll = ['A', 'B', 'C'].reduce((s, c) => s + audit.clusters[c].hits.length, 0);
+  const totalMigrate = ['A', 'B', 'C'].reduce((s, c) => s + audit.clusters[c].hits.filter(h => h.classification === 'MIGRATE').length, 0);
+  const totalFollowUp = ['A', 'B', 'C'].reduce((s, c) => s + audit.clusters[c].hits.filter(h => h.classification === 'MIGRATE_FOLLOW_UP').length, 0);
+  lines.push(`| **Total** | — | **${totalAll}** | **${totalMigrate}** | — | **${totalFollowUp}** | — |`);
+  lines.push('');
+  lines.push('**This SD ships MIGRATE + KEEP_METADATA_ONLY.** MIGRATE_FOLLOW_UP sites file as a follow-up SD/QF after this one merges. EXCLUDE_OUT_OF_SCOPE sites are not touched.');
+  lines.push('');
+
+  for (const cId of ['A', 'B', 'C']) {
+    const cluster = audit.clusters[cId];
+    lines.push(`## Cluster ${cId}: ${cluster.name}`);
+    lines.push('');
+    lines.push(cluster.description);
+    lines.push('');
+    if (cluster.hits.length === 0) {
+      lines.push('_No matches found._');
+      lines.push('');
+      continue;
+    }
+    lines.push('| Rule | File | Line | Classification | Snippet |');
+    lines.push('|------|------|-----:|----------------|---------|');
+    for (const hit of cluster.hits) {
+      const snippet = hit.content.replace(/\|/g, '\\|').slice(0, 110);
+      lines.push(`| ${hit.rule_id} | \`${hit.file}\` | ${hit.line} | ${hit.classification} | \`${snippet}\` |`);
+    }
+    lines.push('');
+    const byClass = {};
+    for (const hit of cluster.hits) {
+      if (!byClass[hit.classification]) byClass[hit.classification] = new Set();
+      byClass[hit.classification].add(hit.rationale);
+    }
+    lines.push('### Rationale per classification');
+    lines.push('');
+    for (const [cls, rationales] of Object.entries(byClass).sort()) {
+      lines.push(`- **${cls}**: ${[...rationales].sort().join(' / ')}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Methodology');
+  lines.push('');
+  lines.push('- File list sourced from `git ls-files` (tracked files only), filtered to *.js / *.mjs / *.cjs.');
+  lines.push('- Per-file scan via native JS RegExp; matches recorded with file:line + classification.');
+  lines.push('- Excluded prefixes: tests/, test/, scripts/archive/, .prd-payloads/, .rca/, .audit-out/, docs/audits/, node_modules/, .worktrees/, dist/, build/');
+  lines.push('- Excluded suffixes: *.test.{js,mjs,cjs}, *.spec.{js,mjs,cjs}');
+  lines.push('- Classification (per RISK C1 from LEAD sub-agent review):');
+  lines.push('  - **MIGRATE**: standard call site; migrated to canonical helper in Phase 2/3/4/5.');
+  lines.push('  - **KEEP_METADATA_ONLY**: hot-path files (handoff-preflight, phase-preflight, orchestrator-completion-guardian, decomposition-gate) where read-after-write consistency requires the sync helper variant.');
+  lines.push('  - **EXCLUDE_OUT_OF_SCOPE**: canonical helper files, one-off diagnostic scripts, database migrations.');
+  lines.push('- Output is deterministic-sorted (file alphabetical → line ascending → rule_id) for diffability across runs (TR-2).');
+  lines.push('- Read-only enforcement (TR-1): script refuses to run when SUPABASE_SERVICE_ROLE_KEY is set in env.');
+  lines.push('');
+  lines.push('## Phase 2-5 scoping');
+  lines.push('');
+  lines.push('The migration count in each Phase MUST match the per-cluster MIGRATE counts in this report. KEEP_METADATA_ONLY sites use the sync helper variant. EXCLUDE_OUT_OF_SCOPE sites are not touched by this SD.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function main() {
+  const auditOutDir = path.join(REPO_ROOT, '.audit-out');
+  const docsDir = path.join(REPO_ROOT, 'docs', 'audits');
+  fs.mkdirSync(auditOutDir, { recursive: true });
+  fs.mkdirSync(docsDir, { recursive: true });
+
+  const gitHead = (() => {
+    try {
+      return execSync('git rev-parse --short HEAD', { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+    } catch {
+      return 'unknown';
+    }
+  })();
+
+  const files = listProductionFiles(REPO_ROOT);
+
+  const allHits = [];
+  for (const file of files) {
+    const hits = scanFile(file, REPO_ROOT);
+    for (const hit of hits) {
+      const { classification, rationale } = classify(hit);
+      hit.classification = classification;
+      hit.rationale = rationale;
+    }
+    allHits.push(...hits);
+  }
+
+  // Deterministic sort across all hits
+  allHits.sort((a, b) => {
+    if (a.cluster !== b.cluster) return a.cluster.localeCompare(b.cluster);
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    if (a.line !== b.line) return a.line - b.line;
+    return a.rule_id.localeCompare(b.rule_id);
+  });
+
+  const audit = {
+    sd_key: 'SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001',
+    generated_at: '2026-05-28T00:00:00Z',
+    repo: 'EHG_Engineer',
+    git_head: gitHead,
+    files_scanned: files.length,
+    clusters: {
+      A: {
+        name: 'SD-type detection',
+        description: 'Multiple call sites classify an SD\'s type by reading sd_type column, metadata.is_* flags, sd_key prefix, or LEGITIMATE_NO_VENTURE_SD_TYPES set. Migration target: `lib/sd/type-detection.js` (FR-2).',
+        hits: allHits.filter(h => h.cluster === 'A'),
+      },
+      B: {
+        name: 'Claim ownership detection',
+        description: 'Multiple call sites determine "who holds this SD" by reading claude_sessions.claiming_session_id, .active_session_id, .is_working_on, .is_alive, .has_uncommitted_changes. Migration target: `lib/claim/ownership-detection.js` (FR-3).',
+        hits: allHits.filter(h => h.cluster === 'B'),
+      },
+      C: {
+        name: 'Gate-skip detection',
+        description: 'Multiple call sites decide whether a handoff gate should run by checking gate.condition callbacks, context.skipGate injection, metadata.skip_* flags, or SD-type-conditional skip. Migration target: `lib/handoff/gate-skip-detection.js` (FR-4).',
+        hits: allHits.filter(h => h.cluster === 'C'),
+      },
+    },
+  };
+
+  const jsonPath = path.join(auditOutDir, 'dual-detection-clusters.json');
+  fs.writeFileSync(jsonPath, JSON.stringify(audit, null, 2), 'utf8');
+
+  const mdPath = path.join(docsDir, 'sd-leo-infra-consolidate-dual-detection-001-audit.md');
+  fs.writeFileSync(mdPath, renderMarkdown(audit), 'utf8');
+
+  console.log('Audit complete.');
+  console.log(`  Files scanned: ${files.length}`);
+  console.log(`  JSON:     ${path.relative(REPO_ROOT, jsonPath)}`);
+  console.log(`  Markdown: ${path.relative(REPO_ROOT, mdPath)}`);
+  console.log('');
+  for (const cId of ['A', 'B', 'C']) {
+    const hits = audit.clusters[cId].hits;
+    const migrate = hits.filter(h => h.classification === 'MIGRATE').length;
+    const keep = hits.filter(h => h.classification === 'KEEP_METADATA_ONLY').length;
+    const exclude = hits.filter(h => h.classification === 'EXCLUDE_OUT_OF_SCOPE').length;
+    console.log(`  Cluster ${cId}: total=${hits.length} MIGRATE=${migrate} KEEP_METADATA_ONLY=${keep} EXCLUDE_OUT_OF_SCOPE=${exclude}`);
+  }
+}
+
+main();

--- a/scripts/phase-preflight.js
+++ b/scripts/phase-preflight.js
@@ -257,8 +257,11 @@ async function detectParentChildHierarchy(sd) {
   console.log('='.repeat(60));
 
   // Check multiple signals for parent status - not just a boolean flag
+  // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 Phase 5: explicitFlag delegates to canonical
+  // helper (sync variant — surrounding multi-signal collection is intentionally preserved).
+  const { isParentOrchestratorSync } = await import('../lib/handoff/parent-detection.js');
   const parentSignals = {
-    explicitFlag: sd.metadata?.is_parent === true,
+    explicitFlag: isParentOrchestratorSync(sd),
     hasChildDefinitions: Array.isArray(sd.metadata?.child_sds) && sd.metadata.child_sds.length > 0,
     hasChildCount: (sd.metadata?.child_count || 0) > 0,
     hasPhases: Array.isArray(sd.metadata?.phases) && sd.metadata.phases.length > 1,

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1492,8 +1492,10 @@ async function main() {
 
     // QF-20260314-250: Child claim verification gate
     // Warn when orchestrator sd:start resolves to a child's worktree
+    // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-2: use canonical helper.
     const wtBranch = worktreeInfo.worktree.branch || '';
-    if (sd.sd_type === 'orchestrator' && wtBranch && !wtBranch.includes(effectiveId)) {
+    const { isOrchestratorSync } = await import('../lib/sd/type-detection.js');
+    if (isOrchestratorSync(sd) && wtBranch && !wtBranch.includes(effectiveId)) {
       const childMatch = wtBranch.match(/SD-[A-Z0-9-]+/);
       if (childMatch) {
         console.log(`\n${colors.yellow}⚠️  CHILD CLAIM VERIFICATION REQUIRED${colors.reset}`);

--- a/tests/unit/claim-ownership-detection/claim-ownership-detection.test.js
+++ b/tests/unit/claim-ownership-detection/claim-ownership-detection.test.js
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for lib/claim/ownership-detection.js
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-3
+ *
+ * Verifies the helper's contract:
+ *   - getClaimHolder is UNCACHED by default (per LEAD DESIGN Q3)
+ *   - getClaimHolderCached honors ttlMs
+ *   - classifyHoldingStatus boundary behavior (300s LIVENESS, 600s DISPLAY)
+ *   - alive_source_side overrides heartbeat staleness
+ *   - null safety for missing inputs
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getClaimHolder,
+  getClaimHolderCached,
+  isClaimedBy,
+  classifyHoldingStatus,
+  LIVENESS_THRESHOLD_SECONDS,
+  DISPLAY_THRESHOLD_SECONDS,
+  CLAIM_HOLDING_STATUSES,
+  _clearCache,
+} from '../../../lib/claim/ownership-detection.js';
+
+beforeEach(() => {
+  _clearCache();
+});
+
+// Build a fake supabase client supporting .from(t).select(...).eq(...).maybeSingle()
+function makeSupabase({ sds = {}, sessions = {}, calls = { from: 0 } } = {}) {
+  return {
+    _calls: calls,
+    from(table) {
+      calls.from++;
+      const data = table === 'strategic_directives_v2' ? sds : sessions;
+      const builder = {
+        _filters: {},
+        select() { return builder; },
+        eq(col, val) { builder._filters[col] = val; return builder; },
+        not() { return builder; },
+        maybeSingle: async () => {
+          const sdKey = builder._filters.sd_key;
+          const sessionId = builder._filters.session_id;
+          const key = sdKey || sessionId;
+          if (!key) return { data: null, error: null };
+          const row = data[key];
+          return { data: row || null, error: null };
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('classifyHoldingStatus boundaries', () => {
+  it('returns ALIVE_SOURCE_SIDE when has_uncommitted_changes overrides heartbeat staleness', () => {
+    const stale = new Date(Date.now() - 9999 * 1000).toISOString();
+    expect(classifyHoldingStatus({ has_uncommitted_changes: true, last_heartbeat: stale, is_alive: false })).toBe('ALIVE_SOURCE_SIDE');
+  });
+
+  it('returns ACTIVE when heartbeat is fresh (within LIVENESS 300s)', () => {
+    const fresh = new Date(Date.now() - 100 * 1000).toISOString();
+    expect(classifyHoldingStatus({ last_heartbeat: fresh, is_alive: true })).toBe('ACTIVE');
+  });
+
+  it('returns ALIVE_NO_HEARTBEAT at LIVENESS boundary + 5s when is_alive=true', () => {
+    const stale = new Date(Date.now() - (LIVENESS_THRESHOLD_SECONDS + 5) * 1000).toISOString();
+    expect(classifyHoldingStatus({ last_heartbeat: stale, is_alive: true })).toBe('ALIVE_NO_HEARTBEAT');
+  });
+
+  it('returns ALIVE_NO_HEARTBEAT for heartbeat between LIVENESS and DISPLAY thresholds', () => {
+    const between = new Date(Date.now() - (LIVENESS_THRESHOLD_SECONDS + 100) * 1000).toISOString();
+    expect(classifyHoldingStatus({ last_heartbeat: between, is_alive: false })).toBe('ALIVE_NO_HEARTBEAT');
+  });
+
+  it('returns STALE_UNKNOWN past DISPLAY threshold with no is_alive flag', () => {
+    const veryStale = new Date(Date.now() - (DISPLAY_THRESHOLD_SECONDS + 100) * 1000).toISOString();
+    expect(classifyHoldingStatus({ last_heartbeat: veryStale, is_alive: false })).toBe('STALE_UNKNOWN');
+  });
+
+  it('returns STALE_UNKNOWN for null session', () => {
+    expect(classifyHoldingStatus(null)).toBe('STALE_UNKNOWN');
+  });
+});
+
+describe('CLAIM_HOLDING_STATUSES contains the 3 alive states', () => {
+  it('includes ACTIVE, ALIVE_NO_HEARTBEAT, ALIVE_SOURCE_SIDE', () => {
+    expect(CLAIM_HOLDING_STATUSES.has('ACTIVE')).toBe(true);
+    expect(CLAIM_HOLDING_STATUSES.has('ALIVE_NO_HEARTBEAT')).toBe(true);
+    expect(CLAIM_HOLDING_STATUSES.has('ALIVE_SOURCE_SIDE')).toBe(true);
+    expect(CLAIM_HOLDING_STATUSES.has('STALE_UNKNOWN')).toBe(false);
+    expect(CLAIM_HOLDING_STATUSES.has('DEAD')).toBe(false);
+  });
+});
+
+describe('getClaimHolder', () => {
+  it('returns null when sdKey is missing', async () => {
+    await expect(getClaimHolder(null, makeSupabase())).resolves.toBeNull();
+    await expect(getClaimHolder('', makeSupabase())).resolves.toBeNull();
+  });
+
+  it('returns null when supabase is missing', async () => {
+    await expect(getClaimHolder('SD-X', null)).resolves.toBeNull();
+  });
+
+  it('returns null when SD row not found', async () => {
+    const supabase = makeSupabase({ sds: {} });
+    await expect(getClaimHolder('SD-NOT-EXIST', supabase)).resolves.toBeNull();
+  });
+
+  it('returns null when SD has no claiming_session_id (unclaimed)', async () => {
+    const supabase = makeSupabase({ sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: null } } });
+    await expect(getClaimHolder('SD-A', supabase)).resolves.toBeNull();
+  });
+
+  it('returns the holder when SD has a claim and session exists', async () => {
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-1' } },
+      sessions: {
+        'sess-1': { session_id: 'sess-1', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+    });
+    const holder = await getClaimHolder('SD-A', supabase);
+    expect(holder).not.toBeNull();
+    expect(holder.session_id).toBe('sess-1');
+    expect(holder.is_alive).toBe(true);
+    expect(holder.holding_status).toBe('ACTIVE');
+  });
+
+  it('is UNCACHED — 2 sequential calls each query DB (per DESIGN Q3)', async () => {
+    const calls = { from: 0 };
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-1' } },
+      sessions: {
+        'sess-1': { session_id: 'sess-1', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+      calls,
+    });
+    await getClaimHolder('SD-A', supabase);
+    await getClaimHolder('SD-A', supabase);
+    // Each call queries 2 tables (strategic_directives_v2 + claude_sessions) = 4 .from() calls total
+    expect(calls.from).toBe(4);
+  });
+});
+
+describe('isClaimedBy', () => {
+  it('returns true when SD claim matches the given session id', async () => {
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-1' } },
+      sessions: {
+        'sess-1': { session_id: 'sess-1', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+    });
+    await expect(isClaimedBy('SD-A', 'sess-1', supabase)).resolves.toBe(true);
+  });
+
+  it('returns false when SD claim differs', async () => {
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-other' } },
+      sessions: {
+        'sess-other': { session_id: 'sess-other', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+    });
+    await expect(isClaimedBy('SD-A', 'sess-1', supabase)).resolves.toBe(false);
+  });
+
+  it('returns false when SD has no claim', async () => {
+    const supabase = makeSupabase({ sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: null } } });
+    await expect(isClaimedBy('SD-A', 'sess-1', supabase)).resolves.toBe(false);
+  });
+
+  it('returns false for null inputs', async () => {
+    await expect(isClaimedBy(null, 'sess-1', makeSupabase())).resolves.toBe(false);
+    await expect(isClaimedBy('SD-A', null, makeSupabase())).resolves.toBe(false);
+    await expect(isClaimedBy('SD-A', 'sess-1', null)).resolves.toBe(false);
+  });
+});
+
+describe('getClaimHolderCached (opt-in TTL cache)', () => {
+  it('caches result within ttlMs window — 2 calls = 1 DB query', async () => {
+    const calls = { from: 0 };
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-1' } },
+      sessions: {
+        'sess-1': { session_id: 'sess-1', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+      calls,
+    });
+    await getClaimHolderCached('SD-A', { supabase, ttlMs: 60000 });
+    await getClaimHolderCached('SD-A', { supabase, ttlMs: 60000 });
+    expect(calls.from).toBe(2); // first call's 2 queries; second call cache hit
+  });
+
+  it('respects ttlMs expiry — refetches after ttl elapses', async () => {
+    const calls = { from: 0 };
+    const now = new Date().toISOString();
+    const supabase = makeSupabase({
+      sds: { 'SD-A': { sd_key: 'SD-A', claiming_session_id: 'sess-1' } },
+      sessions: {
+        'sess-1': { session_id: 'sess-1', sd_key: 'SD-A', status: 'active', is_alive: true, has_uncommitted_changes: false, last_heartbeat: now },
+      },
+      calls,
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-28T00:00:00Z'));
+    await getClaimHolderCached('SD-A', { supabase, ttlMs: 1000 });
+    vi.setSystemTime(new Date('2026-05-28T00:00:02Z')); // +2s past 1s TTL
+    await getClaimHolderCached('SD-A', { supabase, ttlMs: 1000 });
+    vi.useRealTimers();
+    expect(calls.from).toBe(4); // both calls hit DB
+  });
+});

--- a/tests/unit/gate-skip-detection/gate-skip-detection.test.js
+++ b/tests/unit/gate-skip-detection/gate-skip-detection.test.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for lib/handoff/gate-skip-detection.js
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-4
+ *
+ * Two predicates: type-based skip and status-based skip. Each returns a {skip, reason}
+ * pair so consumers can log structured rationale alongside the decision.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  shouldSkipForType,
+  shouldSkipForStatus,
+} from '../../../lib/handoff/gate-skip-detection.js';
+
+describe('shouldSkipForType', () => {
+  it('returns skip=true when sd_type is not in applicable set', () => {
+    const r = shouldSkipForType({ sd_type: 'feature' }, ['refactor', 'documentation'], { gateName: 'adrs' });
+    expect(r.skip).toBe(true);
+    expect(r.reason).toMatch(/adrs/);
+    expect(r.reason).toMatch(/feature/);
+  });
+
+  it('returns skip=false when sd_type IS in applicable set', () => {
+    const r = shouldSkipForType({ sd_type: 'refactor' }, ['refactor'], { gateName: 'adrs' });
+    expect(r.skip).toBe(false);
+    expect(r.reason).toMatch(/refactor/);
+  });
+
+  it('accepts Set as applicableTypes', () => {
+    const r = shouldSkipForType({ sd_type: 'refactor' }, new Set(['refactor']));
+    expect(r.skip).toBe(false);
+  });
+
+  it('returns skip=true with null-sd reason when sd is null', () => {
+    const r = shouldSkipForType(null, ['feature']);
+    expect(r.skip).toBe(true);
+    expect(r.reason).toMatch(/null/);
+  });
+
+  it('returns skip=false default-include when applicableTypes is empty', () => {
+    const r = shouldSkipForType({ sd_type: 'feature' }, []);
+    expect(r.skip).toBe(false);
+    expect(r.reason).toMatch(/default-include/);
+  });
+
+  it('returns skip=false default-include when sd_type is missing', () => {
+    const r = shouldSkipForType({}, ['feature']);
+    expect(r.skip).toBe(false);
+    expect(r.reason).toMatch(/default-include/);
+  });
+
+  it('delegates to classifySDType — picks up metadata.is_orchestrator if sd_type missing', () => {
+    const r = shouldSkipForType({ metadata: { is_orchestrator: true } }, ['orchestrator']);
+    expect(r.skip).toBe(false);
+  });
+});
+
+describe('shouldSkipForStatus', () => {
+  it('returns skip=true when status is not applicable', () => {
+    const r = shouldSkipForStatus({ status: 'draft' }, ['in_progress'], { gateName: 'verify' });
+    expect(r.skip).toBe(true);
+    expect(r.reason).toMatch(/draft/);
+  });
+
+  it('returns skip=false when status IS applicable', () => {
+    const r = shouldSkipForStatus({ status: 'in_progress' }, ['in_progress']);
+    expect(r.skip).toBe(false);
+  });
+
+  it('returns skip=true with null-sd reason when sd is null', () => {
+    const r = shouldSkipForStatus(null, ['active']);
+    expect(r.skip).toBe(true);
+  });
+
+  it('returns skip=false default-include when applicableStatuses is empty', () => {
+    const r = shouldSkipForStatus({ status: 'draft' }, []);
+    expect(r.skip).toBe(false);
+    expect(r.reason).toMatch(/default-include/);
+  });
+});

--- a/tests/unit/sd-type-detection/sd-type-detection.test.js
+++ b/tests/unit/sd-type-detection/sd-type-detection.test.js
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for lib/sd/type-detection.js
+ * SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 FR-2
+ *
+ * Test surface mirrors lib/handoff/parent-detection.js precedent: OR-merge of all
+ * signals, sync vs async variants, WeakMap cache semantics, missing-input defaults.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isOrchestrator,
+  isOrchestratorSync,
+  isVenture,
+  isVentureSync,
+  isInfraNoVenture,
+  isInfraNoVentureSync,
+  classifySDType,
+  _clearCache,
+} from '../../../lib/sd/type-detection.js';
+
+// Mock supabase factory: stub .from().select().eq().limit() returning { data, error }
+function makeSupabase({ children = [], error = null } = {}) {
+  const calls = { from: 0, eq: 0 };
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn(function (col, val) {
+      calls.eq++;
+      this._lastEq = { col, val };
+      return this;
+    }),
+    limit: vi.fn().mockResolvedValue({ data: children, error }),
+  };
+  return {
+    from: vi.fn(() => {
+      calls.from++;
+      return builder;
+    }),
+    _calls: calls,
+  };
+}
+
+describe('isOrchestrator (async, OR-merged)', () => {
+  it('returns true when sd_type === "orchestrator" without consulting DB', async () => {
+    const sd = { id: 'sd-1', sd_type: 'orchestrator' };
+    const supabase = makeSupabase();
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(true);
+    expect(supabase._calls.from).toBe(0);
+  });
+
+  it('returns true when metadata.is_orchestrator === true even if sd_type is feature', async () => {
+    const sd = { id: 'sd-2', sd_type: 'feature', metadata: { is_orchestrator: true } };
+    const supabase = makeSupabase();
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(true);
+    expect(supabase._calls.from).toBe(0);
+  });
+
+  it('returns true when metadata.is_parent === true (legacy flag) even if sd_type is infrastructure', async () => {
+    const sd = { id: 'sd-3', sd_type: 'infrastructure', metadata: { is_parent: true } };
+    const supabase = makeSupabase();
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(true);
+    expect(supabase._calls.from).toBe(0);
+  });
+
+  it('returns true when sd_type and metadata are not orchestrator-y but DB has child rows', async () => {
+    const sd = { id: 'sd-4', sd_type: 'feature' };
+    const supabase = makeSupabase({ children: [{ id: 'child-1' }] });
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(true);
+    expect(supabase._calls.from).toBe(1);
+  });
+
+  it('returns false when sd_type is feature, no metadata flags, and DB returns 0 children', async () => {
+    const sd = { id: 'sd-5', sd_type: 'feature' };
+    const supabase = makeSupabase({ children: [] });
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(false);
+  });
+
+  it('returns false when DB query errors (treats error as "no children")', async () => {
+    const sd = { id: 'sd-6', sd_type: 'feature' };
+    const supabase = makeSupabase({ error: { message: 'connection refused' } });
+    await expect(isOrchestrator(sd, supabase)).resolves.toBe(false);
+  });
+
+  it('returns false when supabase is null and metadata flags are unset', async () => {
+    const sd = { id: 'sd-7', sd_type: 'feature' };
+    await expect(isOrchestrator(sd, null)).resolves.toBe(false);
+  });
+
+  it('returns false when sd is null or undefined', async () => {
+    await expect(isOrchestrator(null, null)).resolves.toBe(false);
+    await expect(isOrchestrator(undefined, null)).resolves.toBe(false);
+  });
+
+  it('caches result across multiple calls with same sd object identity (1 DB query)', async () => {
+    const sd = { id: 'sd-cache', sd_type: 'feature' };
+    const supabase = makeSupabase({ children: [{ id: 'child-1' }] });
+    await isOrchestrator(sd, supabase);
+    await isOrchestrator(sd, supabase);
+    await isOrchestrator(sd, supabase);
+    expect(supabase._calls.from).toBe(1); // single DB query across 3 calls
+  });
+
+  it('does NOT cache across different sd object instances (no false sharing)', async () => {
+    const sdA = { id: 'sd-shared', sd_type: 'feature' };
+    const sdB = { id: 'sd-shared', sd_type: 'feature' }; // same id, different object
+    const supabase = makeSupabase({ children: [{ id: 'child-1' }] });
+    await isOrchestrator(sdA, supabase);
+    await isOrchestrator(sdB, supabase);
+    expect(supabase._calls.from).toBe(2); // independent objects → independent queries
+  });
+});
+
+describe('isOrchestratorSync (metadata + sd_type only)', () => {
+  it('returns true for sd_type === "orchestrator"', () => {
+    expect(isOrchestratorSync({ sd_type: 'orchestrator' })).toBe(true);
+  });
+
+  it('returns true for metadata.is_orchestrator', () => {
+    expect(isOrchestratorSync({ sd_type: 'feature', metadata: { is_orchestrator: true } })).toBe(true);
+  });
+
+  it('returns true for legacy metadata.is_parent', () => {
+    expect(isOrchestratorSync({ sd_type: 'feature', metadata: { is_parent: true } })).toBe(true);
+  });
+
+  it('returns false when no metadata flags and sd_type is not orchestrator', () => {
+    expect(isOrchestratorSync({ sd_type: 'feature' })).toBe(false);
+    expect(isOrchestratorSync({ sd_type: 'infrastructure' })).toBe(false);
+  });
+
+  it('returns false for null/undefined sd', () => {
+    expect(isOrchestratorSync(null)).toBe(false);
+    expect(isOrchestratorSync(undefined)).toBe(false);
+  });
+});
+
+describe('isVenture / isVentureSync', () => {
+  it('returns true when venture_id is set (canonical signal)', () => {
+    expect(isVenture({ venture_id: 'v-1' })).toBe(true);
+    expect(isVentureSync({ venture_id: 'v-1' })).toBe(true);
+  });
+
+  it('returns true when sd_type === "venture"', () => {
+    expect(isVenture({ sd_type: 'venture' })).toBe(true);
+  });
+
+  it('returns true when metadata.is_venture === true', () => {
+    expect(isVenture({ metadata: { is_venture: true } })).toBe(true);
+  });
+
+  it('returns false when none of the venture signals are set', () => {
+    expect(isVenture({ sd_type: 'infrastructure' })).toBe(false);
+    expect(isVenture({ sd_type: 'feature' })).toBe(false);
+  });
+
+  it('does NOT use sd_key prefix as a signal (prefix is misleading per P-FAIL-5)', () => {
+    // SD-CRONGENIUS-LEO-INFRA-MAKE-HEAL-VISION-001 was prefixed CRONGENIUS but venture_id=null;
+    // helper must trust venture_id, not the prefix.
+    const sd = { sd_key: 'SD-CRONGENIUS-LEO-INFRA-MAKE-HEAL-VISION-001', sd_type: 'infrastructure', venture_id: null };
+    expect(isVenture(sd)).toBe(false);
+  });
+});
+
+describe('isInfraNoVenture / isInfraNoVentureSync', () => {
+  it('returns true for canonical no-venture sd_types', () => {
+    // LEGITIMATE_NO_VENTURE_SD_TYPES from lib/eva/bridge/sd-router.js typically includes
+    // 'infrastructure', 'documentation', 'refactor', etc.
+    expect(isInfraNoVenture({ sd_type: 'infrastructure' })).toBe(true);
+    expect(isInfraNoVentureSync({ sd_type: 'infrastructure' })).toBe(true);
+  });
+
+  it('returns false for sd_types that DO need ventures', () => {
+    expect(isInfraNoVenture({ sd_type: 'feature' })).toBe(false);
+  });
+
+  it('returns false when sd_type is missing', () => {
+    expect(isInfraNoVenture({})).toBe(false);
+    expect(isInfraNoVenture(null)).toBe(false);
+  });
+});
+
+describe('classifySDType', () => {
+  it('returns explicit sd_type when canonical', () => {
+    expect(classifySDType({ sd_type: 'orchestrator' })).toBe('orchestrator');
+    expect(classifySDType({ sd_type: 'feature' })).toBe('feature');
+  });
+
+  it('returns "orchestrator" when sd_type missing but metadata.is_orchestrator', () => {
+    expect(classifySDType({ metadata: { is_orchestrator: true } })).toBe('orchestrator');
+  });
+
+  it('returns "orchestrator" when sd_type missing but metadata.is_parent (legacy)', () => {
+    expect(classifySDType({ metadata: { is_parent: true } })).toBe('orchestrator');
+  });
+
+  it('returns null when sd_type non-canonical and no metadata flags', () => {
+    expect(classifySDType({ sd_type: 'fix' })).toBeNull();
+    expect(classifySDType({})).toBeNull();
+    expect(classifySDType(null)).toBeNull();
+  });
+});
+
+describe('_clearCache is a no-op for production safety', () => {
+  it('does not throw and returns undefined', () => {
+    expect(() => _clearCache()).not.toThrow();
+    expect(_clearCache()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Applies the SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 (PR #4021) `lib/handoff/parent-detection.js` pattern to 3 additional dual-detection clusters where the same condition was checked in N ad-hoc places that silently diverged.

- **Cluster A** (sd_type, metadata.is_*, sd_key prefix, LEGITIMATE_NO_VENTURE_SD_TYPES) → `lib/sd/type-detection.js` + 28 tests + 3 hot-site migrations
- **Cluster B** (claim ownership detection across claude_sessions + strategic_directives_v2 + liveness thresholds) → `lib/claim/ownership-detection.js` + 19 tests
- **Cluster C** (gate-skip — type-based vs status-based) → `lib/handoff/gate-skip-detection.js` + 11 tests + 1 site migration

**Phase 1 audit deliverable** (`docs/audits/sd-leo-infra-consolidate-dual-detection-001-audit.md`) enumerates 191 detection sites with per-site classification (MIGRATE / KEEP_METADATA_ONLY / MIGRATE_FOLLOW_UP / EXCLUDE_OUT_OF_SCOPE). Audit script is read-only with `SUPABASE_SERVICE_ROLE_KEY` refusal assertion + deterministic-sorted output for diffability.

**Phase 5 carry-over**: 6 production `metadata?.is_parent === true` sites migrated to the existing canonical `lib/handoff/parent-detection.js` helper (closing the loop on PR #4021).

## Architecture

Each helper follows the canonical PR #4021 shape (async classify + sync fast-path + cache + OR-merge) with cluster-appropriate variations:
- Cluster A: WeakMap cache (sd objects are request-scoped)
- Cluster B: uncached default + opt-in Map+ttlMs cache (sdKey strings, polling consumers)
- Cluster C: no cache (pure predicates), decomposed into shouldSkipForType + shouldSkipForStatus (orthogonal decisions per Phase 1 audit)

Liveness thresholds (300s LIVENESS / 600s DISPLAY from SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001) live inside the Cluster B helper instead of being duplicated at every consumer.

## Scope reduction (documented)

FR-3 and FR-4 acceptance bars (≥4 / ≥3 consumer migrations per cluster) are NOT fully met by this SD:
- FR-2 Cluster A: 10 sites migrated (✓ exceeds ≥4)
- FR-3 Cluster B: 0 consumer migrations (helper + tests only)
- FR-4 Cluster C: 1 site migration (≥3 not met — 2 other audit candidates are ValidationOrchestrator meta-level, not type-based skip)

67 MIGRATE_FOLLOW_UP sites tagged in the audit will ship via follow-up SDs/QFs. Helpers themselves are production-ready.

## Test plan

- [x] 58/58 new unit tests pass (`npx vitest run tests/unit/sd-type-detection/ tests/unit/claim-ownership-detection/ tests/unit/gate-skip-detection/`)
- [x] 8/8 pre-existing parent-detection.js tests pass (no regression)
- [x] Audit re-runs are byte-identical (TR-2 determinism verified)
- [x] Audit script refuses to run with SUPABASE_SERVICE_ROLE_KEY set (TR-1 read-only)
- [x] All migrated files pass `node --check` syntax validation
- [ ] Post-merge: regression-pin against a previously-PASS handoff (smoke TS-20)
- [ ] Post-merge: file follow-up SD(s) for 67 MIGRATE_FOLLOW_UP audit-tagged sites

## Sub-agent verdicts

- LEAD: VALIDATION 92 / RISK 78 / DESIGN 88 (all CONDITIONAL_PASS, 8 binding conditions tracked in PRD)
- PLAN: DESIGN/DATABASE/RISK/STORIES all PASS
- EXEC: TESTING 88 CONDITIONAL_PASS
- PLAN_VERIFICATION: VALIDATION 90 CONDITIONAL_PASS, REGRESSION 92 PASS

## Pre-existing failures

21 tests in `tests/unit/handoff/handoff-orchestrator.test.js` fail; these are pre-existing per PR #4021 retrospective (verified via stash A/B in REGRESSION sub-agent), not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)