### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001): venture pipeline discoverability at LEAD entry path

### DIFF
--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-05-27 4:44:53 PM
+**Generated**: 2026-05-28 6:30:24 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -293,6 +293,27 @@ Before approving parallel work on multiple SDs:
 > Why: Parallel edits to the same files guarantee merge conflicts. Even if both branches pass tests individually, the merge can resolve incorrectly — and tests only catch this after both branches are in review, doubling the rework cost.
 3. Use `npm run sd:next` to see track assignments
 
+
+## Venture Lifecycle Pipeline
+
+When a LEAD worker engages a **venture** SD (venture_id set) or an **orchestrator** SD (sd_type=orchestrator), the work sits inside a canonical pipeline. Know where you are in it before acting.
+
+### Canonical sequence
+1. **/brainstorm** — 6-seat board (CSO/CRO/CTO/CISO/COO/CFO) debates the venture.
+2. **L2 vision doc** — brainstorm-to-vision writes a rich L2 vision (extracted_dimensions, sections).
+3. **Chairman approval** — chairman sets chairman_approved=true on the L2 vision.
+4. **archplan upsert** — architecture plan generated/upserted for the approved vision.
+5. **Vision-approval cascade** — approval auto-cascades to create the orchestrator SD (SD-LEO-INFRA-AUTOMATE-STAGE-CASCADE-001, #4028).
+6. **Orchestrator + children** — lifecycle-sd-bridge generates the orchestrator and child SDs. This is GATED: `assertVentureVisionReady()` (lib/eva/lifecycle-sd-bridge.js) throws **VENTURE_L2_VISION_MISSING** or **VENTURE_L2_VISION_DRAFT_SEED** with the exact `/brainstorm` unblock command if no chairman-approved L2 exists. The bridge CANNOT generate children before the brainstorm. (SD-LEO-INFRA-UNIFY-VENTURE-NON-001 Child C, #3993.)
+7. **LEAD → PLAN → EXEC** — normal LEO workflow per child.
+
+### LEAD is a CIRCUIT-BREAKER (not a redesign layer)
+At a venture orchestrator, LEAD **APPROVES** the decomposition or **BUBBLES UP** to the chairman. LEAD does **NOT** redesign the decomposition itself. If the children look wrong, the fix is upstream (re-brainstorm / re-vision), not LEAD re-authoring the plan. (CronGenius pilot P-FAIL-2: LEAD-as-remediation-layer was caught by the chairman.)
+
+### Per-child cancellation evaluation
+When a venture orchestrator's children are misaligned, evaluate **each child individually** — do NOT cancel all children uniformly. (CronGenius pilot P-FAIL-4: all 5 children were cancelled uniformly, but only A/B were truly misaligned; C/D/E were adjustable.) Cancel with a `cancellation_reason` and, when superseded, set `metadata.superseded_by_sd`.
+
+> Source: CronGenius first-venture pilot (P-FAIL-2/3/4). Behavioral enforcement already shipped: bridge refusal gate (#3993) + vision-to-orchestrator cascade (#4028). This section closes the discoverability gap (SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001).
 
 ## Strategic Directive Creation Process
 
@@ -1559,6 +1580,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-05-27*
+*Generated from database: 2026-05-28*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/lib/leo/venture-pipeline-pointer.js
+++ b/lib/leo/venture-pipeline-pointer.js
@@ -1,0 +1,35 @@
+/**
+ * venture-pipeline-pointer.js — sd-start pointer to the Venture Lifecycle Pipeline.
+ *
+ * SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001 (FR-4).
+ *
+ * When sd-start claims an orchestrator or venture SD, it surfaces a one-line
+ * pointer to the canonical pipeline section in CLAUDE_LEAD.md — so the LEAD
+ * worker sees the sequence (brainstorm → L2 vision → approval → cascade →
+ * orchestrator → LEAD-as-circuit-breaker) at the exact moment they engage.
+ * Ordinary non-venture SDs get no pointer (no noise).
+ */
+
+/**
+ * Decide whether to show the venture-pipeline pointer for an SD.
+ * Pure predicate — no IO. Reuses the same signals sd-start already selects
+ * (sd_type, venture_id, metadata.is_parent).
+ *
+ * @param {object} sd - SD row (must include sd_type; may include venture_id, metadata)
+ * @returns {boolean}
+ */
+export function shouldShowVenturePipelinePointer(sd) {
+  if (!sd || typeof sd !== 'object') return false;
+  if (sd.sd_type === 'orchestrator') return true;
+  if (sd.venture_id) return true;
+  if (sd.metadata && sd.metadata.is_parent === true) return true;
+  return false;
+}
+
+/**
+ * The one-line pointer text. Plain string (caller adds any color codes).
+ */
+export const VENTURE_PIPELINE_POINTER =
+  'Venture pipeline: see CLAUDE_LEAD.md "Venture Lifecycle Pipeline" — ' +
+  'brainstorm (6-seat board) → L2 vision → chairman approval → cascade → orchestrator. ' +
+  'LEAD is a CIRCUIT-BREAKER: approve OR bubble up to chairman; do NOT redesign the decomposition.';

--- a/scripts/one-off/_insert-venture-pipeline-section.mjs
+++ b/scripts/one-off/_insert-venture-pipeline-section.mjs
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const content = `## Venture Lifecycle Pipeline
+
+When a LEAD worker engages a **venture** SD (venture_id set) or an **orchestrator** SD (sd_type=orchestrator), the work sits inside a canonical pipeline. Know where you are in it before acting.
+
+### Canonical sequence
+1. **/brainstorm** — 6-seat board (CSO/CRO/CTO/CISO/COO/CFO) debates the venture.
+2. **L2 vision doc** — brainstorm-to-vision writes a rich L2 vision (extracted_dimensions, sections).
+3. **Chairman approval** — chairman sets chairman_approved=true on the L2 vision.
+4. **archplan upsert** — architecture plan generated/upserted for the approved vision.
+5. **Vision-approval cascade** — approval auto-cascades to create the orchestrator SD (SD-LEO-INFRA-AUTOMATE-STAGE-CASCADE-001, #4028).
+6. **Orchestrator + children** — lifecycle-sd-bridge generates the orchestrator and child SDs. This is GATED: \`assertVentureVisionReady()\` (lib/eva/lifecycle-sd-bridge.js) throws **VENTURE_L2_VISION_MISSING** or **VENTURE_L2_VISION_DRAFT_SEED** with the exact \`/brainstorm\` unblock command if no chairman-approved L2 exists. The bridge CANNOT generate children before the brainstorm. (SD-LEO-INFRA-UNIFY-VENTURE-NON-001 Child C, #3993.)
+7. **LEAD → PLAN → EXEC** — normal LEO workflow per child.
+
+### LEAD is a CIRCUIT-BREAKER (not a redesign layer)
+At a venture orchestrator, LEAD **APPROVES** the decomposition or **BUBBLES UP** to the chairman. LEAD does **NOT** redesign the decomposition itself. If the children look wrong, the fix is upstream (re-brainstorm / re-vision), not LEAD re-authoring the plan. (CronGenius pilot P-FAIL-2: LEAD-as-remediation-layer was caught by the chairman.)
+
+### Per-child cancellation evaluation
+When a venture orchestrator's children are misaligned, evaluate **each child individually** — do NOT cancel all children uniformly. (CronGenius pilot P-FAIL-4: all 5 children were cancelled uniformly, but only A/B were truly misaligned; C/D/E were adjustable.) Cancel with a \`cancellation_reason\` and, when superseded, set \`metadata.superseded_by_sd\`.
+
+> Source: CronGenius first-venture pilot (P-FAIL-2/3/4). Behavioral enforcement already shipped: bridge refusal gate (#3993) + vision-to-orchestrator cascade (#4028). This section closes the discoverability gap (SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001).`;
+
+await sb.from('leo_protocol_sections').delete().eq('section_type', 'venture_lifecycle_pipeline');
+const { data, error } = await sb.from('leo_protocol_sections').insert({
+  protocol_id: 'leo-v4-3-3-ui-parity',
+  section_type: 'venture_lifecycle_pipeline',
+  title: 'Venture Lifecycle Pipeline',
+  content,
+  order_index: 32,
+  context_tier: 'REFERENCE',
+  priority: 'STANDARD',
+  target_file: 'CLAUDE_LEAD.md',
+  metadata: { sd_key: 'SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001', pilot_findings: ['P-FAIL-2', 'P-FAIL-3', 'P-FAIL-4'] },
+}).select('id').single();
+if (error) { console.error('INSERT ERR:', error.message); process.exit(1); }
+const { data: check } = await sb.from('leo_protocol_sections').select('content').eq('id', data.id).single();
+console.log('Inserted id:', data.id);
+console.log('HAS assertVentureVisionReady:', check.content.includes('assertVentureVisionReady'));
+console.log('HAS backtick:', check.content.includes(String.fromCharCode(96)));
+console.log('LEN:', check.content.length);

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -60,6 +60,7 @@ import {
 } from '../lib/fleet-lock-hash.mjs';
 // SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
 import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
+import { shouldShowVenturePipelinePointer, VENTURE_PIPELINE_POINTER } from '../lib/leo/venture-pipeline-pointer.js';
 
 dotenv.config();
 
@@ -1691,6 +1692,12 @@ async function main() {
   // 6.5. Phase-appropriate context file (SD-LEO-INFRA-RESUME-INTEGRITY-HANDOFF-001)
   const contextFile = getPhaseContextFile(sd.current_phase);
   console.log(`\n${colors.bold}Load context:${colors.reset} ${colors.cyan}${contextFile}${colors.reset}`);
+
+  // SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001 (FR-4): surface the venture pipeline
+  // pointer for orchestrator/venture SDs so LEAD sees the canonical sequence + circuit-breaker rule.
+  if (shouldShowVenturePipelinePointer(sd)) {
+    console.log(`\n${colors.bold}${colors.cyan}${VENTURE_PIPELINE_POINTER}${colors.reset}`);
+  }
 
   // 6.7. Handoff count warning (SD-LEO-INFRA-SESSION-COMPACTION-CLAIM-001)
   // Warns when claiming an SD with extensive prior work — possible compacted session

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -79,6 +79,7 @@
       "knowledge_retrieval",
       "parent_child_sd_governance",
       "parent_child_lead",
+      "venture_lifecycle_pipeline",
       "multi_track_parallel_execution",
       "vision_v2_lead",
       "governance_okr_alignment_lead",

--- a/tests/unit/leo/venture-pipeline-pointer.test.js
+++ b/tests/unit/leo/venture-pipeline-pointer.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests for lib/leo/venture-pipeline-pointer.js
+ * SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001 (FR-4 / TS-3, TS-4, TS-5).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  shouldShowVenturePipelinePointer,
+  VENTURE_PIPELINE_POINTER,
+} from '../../../lib/leo/venture-pipeline-pointer.js';
+
+describe('shouldShowVenturePipelinePointer', () => {
+  it('TS-3: true for an orchestrator SD', () => {
+    expect(shouldShowVenturePipelinePointer({ sd_type: 'orchestrator' })).toBe(true);
+  });
+
+  it('TS-4: true for a venture SD (venture_id set)', () => {
+    expect(shouldShowVenturePipelinePointer({ sd_type: 'infrastructure', venture_id: 'abc-123' })).toBe(true);
+  });
+
+  it('true when metadata.is_parent', () => {
+    expect(shouldShowVenturePipelinePointer({ sd_type: 'feature', metadata: { is_parent: true } })).toBe(true);
+  });
+
+  it('TS-5: false for an ordinary non-venture infrastructure SD (no noise)', () => {
+    expect(shouldShowVenturePipelinePointer({ sd_type: 'infrastructure', venture_id: null, metadata: {} })).toBe(false);
+  });
+
+  it('false for a plain feature SD', () => {
+    expect(shouldShowVenturePipelinePointer({ sd_type: 'feature' })).toBe(false);
+  });
+
+  it('false for null / non-object', () => {
+    expect(shouldShowVenturePipelinePointer(null)).toBe(false);
+    expect(shouldShowVenturePipelinePointer(undefined)).toBe(false);
+    expect(shouldShowVenturePipelinePointer('SD-X')).toBe(false);
+  });
+});
+
+describe('VENTURE_PIPELINE_POINTER', () => {
+  it('points to the CLAUDE_LEAD.md section and names the circuit-breaker rule', () => {
+    expect(VENTURE_PIPELINE_POINTER).toContain('Venture Lifecycle Pipeline');
+    expect(VENTURE_PIPELINE_POINTER).toContain('CIRCUIT-BREAKER');
+    expect(VENTURE_PIPELINE_POINTER).toContain('brainstorm');
+    expect(VENTURE_PIPELINE_POINTER).toMatch(/do NOT redesign/i);
+  });
+});

--- a/tests/unit/leo/venture-pipeline-section.test.js
+++ b/tests/unit/leo/venture-pipeline-section.test.js
@@ -1,0 +1,48 @@
+/**
+ * Verifies the Venture Lifecycle Pipeline section is present in the generated
+ * CLAUDE_LEAD.md and contains the load-bearing rules.
+ * SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001 (FR-1, FR-2, FR-3 / TS-1, TS-6).
+ *
+ * Hermetic: reads the committed generated file (no DB). If the section is
+ * dropped from the section-file-mapping or the leo_protocol_sections row is
+ * removed, regeneration drops it from CLAUDE_LEAD.md and this test fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LEAD_PATH = join(__dirname, '../../../CLAUDE_LEAD.md');
+const lead = readFileSync(LEAD_PATH, 'utf8');
+
+describe('CLAUDE_LEAD.md — Venture Lifecycle Pipeline section', () => {
+  it('TS-1: contains the section heading', () => {
+    expect(lead).toContain('Venture Lifecycle Pipeline');
+  });
+
+  it('documents the canonical ordered sequence', () => {
+    expect(lead).toMatch(/brainstorm/i);
+    expect(lead).toMatch(/L2 vision/i);
+    expect(lead).toMatch(/[Cc]hairman approval/);
+    expect(lead).toMatch(/cascade/i);
+    expect(lead).toMatch(/[Oo]rchestrator/);
+  });
+
+  it('names the bridge refusal gate + unblock command (greppable against code)', () => {
+    expect(lead).toContain('assertVentureVisionReady');
+    expect(lead).toContain('VENTURE_L2_VISION_MISSING');
+    expect(lead).toContain('/brainstorm');
+  });
+
+  it('FR-2: encodes LEAD-as-circuit-breaker discipline', () => {
+    expect(lead).toContain('CIRCUIT-BREAKER');
+    // content bolds "**NOT**" so match the contiguous unmarked span
+    expect(lead).toMatch(/redesign the decomposition/i);
+  });
+
+  it('FR-3 / TS-6: encodes per-child cancellation evaluation', () => {
+    expect(lead).toMatch(/each child individually/i);
+    expect(lead).toMatch(/do NOT cancel all children uniformly/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes CronGenius pilot **P-FAIL-3**: the canonical venture pipeline (brainstorm → L2 vision → chairman approval → cascade → orchestrator → LEAD-as-circuit-breaker) was invisible at the LEAD entry path. The behavioral half already shipped (#3993 bridge refusal gate + #4028 vision→orchestrator cascade); this closes the discoverability half.
- New `leo_protocol_sections` row "Venture Lifecycle Pipeline" (section_type `venture_lifecycle_pipeline`) + `section-file-mapping.json` entry → regenerated into `CLAUDE_LEAD.md`. Encodes **P-FAIL-2** (LEAD-as-circuit-breaker: approve OR bubble up, do NOT redesign) and **P-FAIL-4** (per-child cancellation evaluation, not uniform).
- `lib/leo/venture-pipeline-pointer.js` wired into `scripts/sd-start.js` (FR-4): one-line pointer shown for orchestrator/venture SDs, silent for ordinary SDs.

## Test plan
- [x] 12/12 unit tests pass: `npx vitest run tests/unit/leo/`
- [x] Section greppable against code: `assertVentureVisionReady` exists in `lib/eva/lifecycle-sd-bridge.js`; `VENTURE_L2_VISION_MISSING`/`DRAFT_SEED` are real error codes
- [x] REGRESSION: `section-file-mapping.json` CLAUDE_LEAD.md sections 24→25 (zero dropped, one added, no dupes); pointer silent for ordinary SDs
- [x] Sub-agents: TESTING 05b2a34c PASS 95, VALIDATION 9920e408 PASS 95, REGRESSION 719b7d85 PASS 96

## Notes
- Only `CLAUDE_LEAD.md` regenerated/committed; other `CLAUDE*.md` reverted to avoid sweeping unrelated stale-main protocol churn into this PR.
- Recovered after the worktree was reaped mid-EXEC by a concurrent session (DB work survived; file edits re-applied + committed immediately).

PRD: PRD-SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001
Retrospective: fd1c4370 (quality 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)