### PR TITLE
feat(SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001): extend WAIT verdict to TESTING + SUB_AGENT + MIGRATION gates

### DIFF
--- a/lib/handoff/wait-verdict.js
+++ b/lib/handoff/wait-verdict.js
@@ -1,0 +1,242 @@
+/**
+ * Centralized WAIT-verdict helper for handoff gates.
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+ *
+ * Background: PR #4021 (SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001) introduced the
+ * "WAIT" verdict — a gate result shaped like a failure (passed:false) but carrying
+ * `wait:true`, which the ValidationOrchestrator treats as a transient race-window
+ * block rather than a real failure. Unlike a FAIL, a WAIT does NOT burn retry
+ * budget or trigger RCA; the orchestrator re-checks the gate later.
+ *
+ * PR #4021 applied this ONLY to the parent-orchestrator prerequisite check
+ * (scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js).
+ * This module extends the pattern to the TESTING, SUB_AGENT_EVIDENCE, and
+ * MIGRATION gates and adds a max-wait safety ceiling so a permanently-stuck
+ * race window eventually surfaces as a real failure (TR-4).
+ *
+ * SHAPE CONTRACT (mirrors prerequisite-check.js wait verdict — do not diverge):
+ *   { passed:false, wait:true, score, max_score, issues, wait_reason, details }
+ * plus optional `warnings` and `remediation` passthroughs (the orchestrator copies
+ * `warnings` into its aggregate, and `wait_reason` into waitReasons).
+ *
+ * TR-1: all gate WAIT/FAIL result construction goes through buildWaitResult /
+ * buildFailResult — no inline `{ passed:false, wait:true, ... }` literals in gate code.
+ */
+
+/**
+ * Build a WAIT verdict (transient race-window block, NOT a failure).
+ * Mirrors the prerequisite-check.js wait-result shape exactly.
+ *
+ * @param {Object} opts
+ * @param {number} [opts.score=0]
+ * @param {number} [opts.max_score=100]
+ * @param {string} opts.wait_reason - Human-readable reason for the wait.
+ * @param {string[]} [opts.issues=[]] - Should normally be empty for waits.
+ * @param {string[]} [opts.warnings] - Optional warning strings (orchestrator copies these).
+ * @param {string} [opts.remediation] - Optional remediation guidance.
+ * @param {Object} [opts.details={}] - Gate-specific details (placed under `details`).
+ * @returns {Object} WAIT-shaped gate result.
+ */
+export function buildWaitResult({
+  score = 0,
+  max_score = 100,
+  wait_reason,
+  issues = [],
+  warnings,
+  remediation,
+  details = {},
+} = {}) {
+  const result = {
+    passed: false,
+    wait: true,
+    score,
+    max_score,
+    issues,
+    wait_reason: wait_reason || 'Transient race-window block; re-checking later',
+    details,
+  };
+  // Default warnings to surface the wait reason if the caller didn't supply any.
+  result.warnings = Array.isArray(warnings)
+    ? warnings
+    : [`WAIT: ${result.wait_reason}`];
+  if (remediation) result.remediation = remediation;
+  return result;
+}
+
+/**
+ * Build a normal FAIL verdict (real failure — burns retry budget, may trigger RCA).
+ * Explicitly carries `wait:false` so callers/consumers can distinguish it from a WAIT.
+ *
+ * @param {Object} opts
+ * @param {number} [opts.score=0]
+ * @param {number} [opts.max_score=100]
+ * @param {string[]} [opts.issues=[]]
+ * @param {string} [opts.remediation] - Optional remediation guidance.
+ * @param {string[]} [opts.warnings] - Optional warning strings.
+ * @param {Object} [opts.details={}]
+ * @returns {Object} FAIL-shaped gate result.
+ */
+export function buildFailResult({
+  score = 0,
+  max_score = 100,
+  issues = [],
+  remediation,
+  warnings,
+  details = {},
+} = {}) {
+  const result = {
+    passed: false,
+    wait: false,
+    score,
+    max_score,
+    issues,
+    warnings: Array.isArray(warnings) ? warnings : [],
+    details,
+  };
+  if (remediation) result.remediation = remediation;
+  return result;
+}
+
+/**
+ * Classify a test-runner exit into 'timeout' (environmental), 'failure'
+ * (real test failure / user error), or 'pass'.
+ *
+ * RISK-2 / TR-2: WHITELIST-based ONLY. We NEVER scan arbitrary user error text
+ * for the word "timeout" — a user-thrown Error("connection timeout") is a REAL
+ * failure, not an environmental one. Letting bad code through (by misclassifying
+ * a failure as an environmental timeout → WAIT) is the worst outcome of this SD,
+ * so the default is always 'failure'/'pass', never 'timeout'.
+ *
+ * Environmental-timeout whitelist (the ONLY things that map to 'timeout'):
+ *   - Exit codes: 124 (GNU coreutils `timeout`), 137 (SIGKILL/128+9 OOM-kill),
+ *     143 (SIGTERM/128+15)
+ *   - vitest `--reporter=json` duration timeout markers
+ *   - jest:       "Timeout - Async callback was not invoked"
+ *   - playwright: "Test timeout of <N>ms exceeded"
+ *
+ * @param {number} exitCode - Process exit code from the test runner.
+ * @param {string} [stderrOrMessage=''] - Captured stderr / error message.
+ * @returns {'timeout'|'failure'|'pass'}
+ */
+export function classifyTestRunnerExit(exitCode, stderrOrMessage = '') {
+  const code = Number(exitCode);
+
+  // Environmental-timeout exit codes (whitelist).
+  if (code === 124 || code === 137 || code === 143) {
+    return 'timeout';
+  }
+
+  const text = String(stderrOrMessage || '');
+
+  // Strict runner-emitted environmental-timeout markers (whitelist).
+  // These are framework-controlled strings, NOT arbitrary user error text.
+  const ENV_TIMEOUT_MARKERS = [
+    // jest async-callback timeout
+    /Timeout - Async callback was not invoked/,
+    // playwright per-test timeout: "Test timeout of 30000ms exceeded"
+    /Test timeout of \d+ms exceeded/,
+    // vitest hook/test timeout: "Test timed out in 5000ms." / "Hook timed out in 5000ms."
+    /(?:Test|Hook) timed out in \d+ms/,
+    // vitest --reporter=json duration-timeout marker
+    /"reason"\s*:\s*"timeout"/,
+  ];
+  for (const marker of ENV_TIMEOUT_MARKERS) {
+    if (marker.test(text)) return 'timeout';
+  }
+
+  // Exit code 0 with no environmental marker → pass.
+  if (code === 0) return 'pass';
+
+  // Anything else (assertion errors, user-thrown errors whose messages merely
+  // contain "timeout", unknown non-zero exits) → real failure. NEVER 'timeout'.
+  return 'failure';
+}
+
+/**
+ * Parse a timestamp treating naive (no-TZ) strings as UTC, matching the
+ * convention used by subagent-evidence-gate.js (PostgREST returns
+ * timestamp-without-time-zone as naive strings; new Date() would parse them
+ * as LOCAL and skew the comparison).
+ *
+ * @param {string|Date|number} ts
+ * @returns {Date|null}
+ */
+function parseAsUTC(ts) {
+  if (ts === null || ts === undefined) return null;
+  if (ts instanceof Date) return ts;
+  if (typeof ts === 'number') return new Date(ts);
+  const s = String(ts);
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(s);
+  return new Date(hasTZ ? s : s + 'Z');
+}
+
+/**
+ * Whether `now - startedAt` is within `windowSeconds` (i.e. still inside the
+ * race window). Used by the SUB_AGENT_EVIDENCE gate (30s race window) and any
+ * other time-bounded race-window check.
+ *
+ * Defensive: a missing/unparseable startedAt returns false (outside window →
+ * the caller FAILs rather than WAITs forever — safe default).
+ *
+ * @param {string|Date|number} startedAtIso
+ * @param {number} windowSeconds
+ * @param {Date|number} [now=Date.now()] - Injectable clock for tests.
+ * @returns {boolean}
+ */
+export function isWithinRaceWindow(startedAtIso, windowSeconds, now = Date.now()) {
+  const started = parseAsUTC(startedAtIso);
+  if (!started || Number.isNaN(started.getTime())) return false;
+  const nowMs = now instanceof Date ? now.getTime() : Number(now);
+  const elapsedSec = (nowMs - started.getTime()) / 1000;
+  if (Number.isNaN(elapsedSec)) return false;
+  return elapsedSec <= Number(windowSeconds);
+}
+
+/**
+ * Decide whether a gate that keeps returning WAIT has exceeded the safety
+ * ceiling and must now escalate to a real FAIL (TR-4 / FR-5 / RISK-3).
+ *
+ * Two independent caps (either one trips):
+ *   - wait_attempts >= maxAttempts          → WAIT_LIMIT_EXCEEDED
+ *   - now - first_wait_at >= maxWallClockMs → WAIT_TIMEOUT_EXCEEDED
+ *
+ * @param {Object} opts
+ * @param {number} [opts.wait_attempts=0] - Count of consecutive WAITs SO FAR
+ *   (i.e. before the current attempt). With maxAttempts=10, a value of 10 means
+ *   10 prior waits already happened, so the 11th attempt must FAIL.
+ * @param {string|Date|number} [opts.first_wait_at] - Timestamp of the first WAIT.
+ * @param {number} [opts.maxAttempts=10]
+ * @param {number} [opts.maxWallClockMs=86400000] - 24h.
+ * @param {Date|number} [opts.now=Date.now()] - Injectable clock for tests.
+ * @returns {{ exceeded:boolean, reason:('WAIT_LIMIT_EXCEEDED'|'WAIT_TIMEOUT_EXCEEDED'|null) }}
+ */
+export function hasExceededMaxWait({
+  wait_attempts = 0,
+  first_wait_at,
+  maxAttempts = 10,
+  maxWallClockMs = 24 * 60 * 60 * 1000,
+  now = Date.now(),
+} = {}) {
+  const attempts = Number(wait_attempts) || 0;
+  if (attempts >= maxAttempts) {
+    return { exceeded: true, reason: 'WAIT_LIMIT_EXCEEDED' };
+  }
+
+  const first = parseAsUTC(first_wait_at);
+  if (first && !Number.isNaN(first.getTime())) {
+    const nowMs = now instanceof Date ? now.getTime() : Number(now);
+    if (nowMs - first.getTime() >= maxWallClockMs) {
+      return { exceeded: true, reason: 'WAIT_TIMEOUT_EXCEEDED' };
+    }
+  }
+
+  return { exceeded: false, reason: null };
+}
+
+export default {
+  buildWaitResult,
+  buildFailResult,
+  classifyTestRunnerExit,
+  isWithinRaceWindow,
+  hasExceededMaxWait,
+};

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -306,6 +306,12 @@ export class BaseExecutor {
         gitContext  // SD-LEO-FIX-HANDOFF-PIPELINE-GIT-001: Cached git state (branch, diffFiles, gitRoot)
       };
 
+      // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5/TR-4: surface prior consecutive-wait
+      // accounting so the orchestrator's max-wait ceiling can escalate a perpetually
+      // WAITing gate to FAIL. Best-effort: read the most recent WAIT row's
+      // metadata.{wait_attempts,first_wait_at} for this SD + handoff type.
+      validationContext.waitState = await this._loadPriorWaitState(sd?.id || sdId);
+
       // Use database-driven gates when available, fall back to hardcoded
       const gates = await this.validationOrchestrator.buildGatesFromRules(
         policyFilteredGates,
@@ -373,6 +379,9 @@ export class BaseExecutor {
           waitVerdict: true,
           waitingGates: gateResults.waitingGates,
           waitReasons: gateResults.waitReasons,
+          // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5: carry the updated wait
+          // accounting so HandoffRecorder.recordWait persists it for the next attempt.
+          waitMetadata: gateResults.waitMetadata || null,
           message: gateResults.waitReasons.join('; ') || 'Handoff blocked — waiting on prerequisites',
           warnings: gateResults.warnings,
           gateResults: gateResults.gateResults,
@@ -591,6 +600,39 @@ export class BaseExecutor {
    */
   async getRequiredGates(_sd, _options) {
     throw new Error('Subclass must implement getRequiredGates()');
+  }
+
+  /**
+   * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5/TR-4: load the prior consecutive-wait
+   * accounting for this SD + handoff type from the most recent WAIT row's metadata.
+   * Returns { wait_attempts, first_wait_at } (zeroed when none / on any error).
+   * Best-effort — a lookup failure must never block a handoff.
+   *
+   * @param {string} sdUuid
+   * @returns {Promise<{wait_attempts:number, first_wait_at:(string|null)}>}
+   */
+  async _loadPriorWaitState(sdUuid) {
+    const empty = { wait_attempts: 0, first_wait_at: null };
+    if (!sdUuid || !this.supabase) return empty;
+    try {
+      const { data, error } = await this.supabase
+        .from('sd_phase_handoffs')
+        .select('metadata, created_at')
+        .eq('sd_id', sdUuid)
+        .eq('handoff_type', this.handoffType)
+        .eq('status', 'blocked')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error || !data?.metadata?.wait) return empty;
+      const md = data.metadata;
+      return {
+        wait_attempts: Number(md.wait_attempts) || 0,
+        first_wait_at: md.first_wait_at || null
+      };
+    } catch {
+      return empty;
+    }
   }
 
   /**

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.js
@@ -18,7 +18,38 @@
 import { getValidationRequirements } from '../../../../../../lib/utils/sd-type-validation.js';
 // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-044: Import centralized policy for advisory mode override
 import { getValidatorRequirement } from '../../../validation/sd-type-applicability-policy.js';
+// SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-3): WHITELIST-based timeout classifier
+import { buildWaitResult, buildFailResult, classifyTestRunnerExit } from '../../../../../../lib/handoff/wait-verdict.js';
 import { execSync } from 'child_process';
+
+/**
+ * FR-3: Resolve test-runner exit info for WAIT classification.
+ * Prefers executor-supplied ctx.testRunner = { exitCode, output|stderr|message };
+ * falls back to the stored TESTING result row's exit fields (metadata.exit_code /
+ * metadata.runner_output / details). Returns null when no runner info is available
+ * (→ caller keeps the unchanged verdict-based FAIL).
+ *
+ * @param {Object} ctx
+ * @param {Object} [testingRow] - The latest sub_agent_execution_results row.
+ * @returns {{ exitCode:(number|null), message:string }|null}
+ */
+function resolveTestRunnerExit(ctx, testingRow) {
+  const tr = ctx?.testRunner || ctx?.test_runner;
+  if (tr && (tr.exitCode !== undefined || tr.exit_code !== undefined || tr.output || tr.stderr || tr.message)) {
+    return {
+      exitCode: tr.exitCode ?? tr.exit_code ?? null,
+      message: String(tr.output || tr.stderr || tr.message || '')
+    };
+  }
+  const md = testingRow?.metadata || testingRow?.details;
+  if (md && (md.exit_code !== undefined || md.exitCode !== undefined || md.runner_output || md.output || md.stderr)) {
+    return {
+      exitCode: md.exit_code ?? md.exitCode ?? null,
+      message: String(md.runner_output || md.output || md.stderr || '')
+    };
+  }
+  return null;
+}
 
 /**
  * Detect code file changes in the current branch/working directory
@@ -66,6 +97,21 @@ function detectCodeChanges() {
 
 /**
  * Create the MANDATORY_TESTING_VALIDATION gate validator
+ *
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-3): a non-passing TESTING verdict is
+ * re-classified. An ENVIRONMENTAL test timeout returns WAIT (preserve retry
+ * budget; re-check later); a REAL test failure returns FAIL (unchanged).
+ *
+ * WAIT-detection WHITELIST (RISK-2 — the ONLY signals that yield WAIT):
+ *   - exit codes 124 (coreutils timeout), 137 (SIGKILL/OOM), 143 (SIGTERM)
+ *   - vitest `--reporter=json` duration timeout / "Test timed out in <N>ms"
+ *   - jest "Timeout - Async callback was not invoked"
+ *   - playwright "Test timeout of <N>ms exceeded"
+ * Everything else — assertion errors, AND user-thrown errors whose messages
+ * merely contain the word "timeout" (e.g. "connection timeout") — is a REAL
+ * failure → FAIL. We NEVER pattern-match arbitrary user error text for the word
+ * "timeout"; misclassifying a real failure as environmental would let bad code
+ * through, the worst outcome of this SD.
  *
  * @param {Object} supabase - Supabase client
  * @returns {Object} Gate configuration
@@ -129,7 +175,7 @@ export function createMandatoryTestingValidationGate(supabase) {
       const sdUuid = ctx.sd?.id || ctx.sdId;
       const { data: testingResults, error } = await supabase
         .from('sub_agent_execution_results')
-        .select('id, verdict, confidence, created_at')
+        .select('id, verdict, confidence, created_at, metadata')
         .eq('sd_id', sdUuid)
         .eq('sub_agent_code', 'TESTING')
         .order('created_at', { ascending: false })
@@ -197,14 +243,35 @@ export function createMandatoryTestingValidationGate(supabase) {
       console.log(`   📊 TESTING result found: ${result.verdict} (${result.confidence}% confidence)`);
 
       if (!['PASS', 'CONDITIONAL_PASS'].includes(result.verdict)) {
+        // FR-3: re-classify the non-passing verdict. ENVIRONMENTAL timeout → WAIT
+        // (preserve retry budget); everything else → FAIL (unchanged). WHITELIST
+        // only (RISK-2): see createMandatoryTestingValidationGate JSDoc.
+        const runnerExit = resolveTestRunnerExit(ctx, result);
+        if (runnerExit) {
+          const classification = classifyTestRunnerExit(runnerExit.exitCode, runnerExit.message);
+          if (classification === 'timeout') {
+            console.log(`   ⏳ WAIT: environmental test timeout (exit=${runnerExit.exitCode}) — not a real failure`);
+            return buildWaitResult({
+              score: 0,
+              max_score: 100,
+              wait_reason: `Environmental test timeout (exit code ${runnerExit.exitCode ?? 'n/a'}); re-running may succeed`,
+              details: {
+                reason: 'TEST_TIMEOUT',
+                verdict: result.verdict,
+                runner_exit_code: runnerExit.exitCode ?? null,
+                classification
+              },
+              remediation: 'Re-run the test suite — the timeout appears environmental (CI slowness / OOM-kill), not a code defect. If it persists past the wait ceiling it will surface as a real failure.'
+            });
+          }
+        }
         console.log(`   ❌ TESTING verdict ${result.verdict} - must pass`);
-        return {
-          passed: false,
+        return buildFailResult({
           score: 0,
           max_score: 100,
           issues: [`TESTING verdict ${result.verdict} - must be PASS or CONDITIONAL_PASS`],
-          warnings: []
-        };
+          details: { verdict: result.verdict }
+        });
       }
 
       // 9. Validate freshness (default 24h)

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.test.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.test.js
@@ -151,6 +151,93 @@ describe('MANDATORY_TESTING_VALIDATION gate', () => {
     const result = await gate.validator(ctx);
 
     expect(result.passed).toBe(false);
+    expect(result.wait).toBe(false);
     expect(result.issues[0]).toMatch(/TESTING verdict FAIL/);
+  });
+
+  // ─── FR-3: WAIT verdict for environmental test timeouts ────────────────────
+  // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+  describe('FR-3 WAIT branch (environmental test timeout)', () => {
+    const freshDate = () => new Date(Date.now() - 3600000).toISOString();
+    const withTestingRow = (row) => {
+      const chainable = (val) => {
+        const c = {
+          select: () => c, eq: () => c, order: () => c, limit: () => c,
+          single: () => Promise.resolve(val),
+          then: (fn) => Promise.resolve(val).then(fn),
+        };
+        return c;
+      };
+      mockFrom.mockReturnValue({ select: () => chainable({ data: [row], error: null }) });
+    };
+
+    it('exit code 124 (via ctx.testRunner) + non-pass verdict → WAIT', async () => {
+      withTestingRow({ id: 1, verdict: 'FAIL', confidence: 0, created_at: freshDate() });
+      const ctx = {
+        sd: createMockSD({ sd_type: 'feature', id: 'uuid-124' }),
+        testRunner: { exitCode: 124, output: '' },
+      };
+      const result = await gate.validator(ctx);
+      expect(result.passed).toBe(false);
+      expect(result.wait).toBe(true);
+      expect(result.details.reason).toBe('TEST_TIMEOUT');
+      expect(result.issues).toEqual([]);
+    });
+
+    it('playwright timeout marker (via stored row metadata) → WAIT', async () => {
+      withTestingRow({
+        id: 1, verdict: 'TIMEOUT', confidence: 0, created_at: freshDate(),
+        metadata: { exit_code: 1, runner_output: 'Test timeout of 30000ms exceeded' },
+      });
+      const ctx = { sd: createMockSD({ sd_type: 'feature', id: 'uuid-pw' }) };
+      const result = await gate.validator(ctx);
+      expect(result.passed).toBe(false);
+      expect(result.wait).toBe(true);
+      expect(result.details.classification).toBe('timeout');
+    });
+
+    it('exit 137 (SIGKILL/OOM) → WAIT', async () => {
+      withTestingRow({ id: 1, verdict: 'FAIL', confidence: 0, created_at: freshDate() });
+      const ctx = {
+        sd: createMockSD({ sd_type: 'feature', id: 'uuid-137' }),
+        testRunner: { exitCode: 137, output: '' },
+      };
+      const result = await gate.validator(ctx);
+      expect(result.wait).toBe(true);
+    });
+
+    // RISK-2 NEGATIVE CONTROL: user-thrown error containing "timeout" → FAIL, never WAIT
+    it('[RISK-2 negative control] user Error("connection timeout") → FAIL (not WAIT)', async () => {
+      withTestingRow({
+        id: 1, verdict: 'FAIL', confidence: 0, created_at: freshDate(),
+        metadata: { exit_code: 1, runner_output: 'Error: connection timeout at db.connect (db.js:10)' },
+      });
+      const ctx = { sd: createMockSD({ sd_type: 'feature', id: 'uuid-userto' }) };
+      const result = await gate.validator(ctx);
+      expect(result.passed).toBe(false);
+      expect(result.wait).toBe(false);
+      expect(result.issues[0]).toMatch(/TESTING verdict FAIL/);
+    });
+
+    // Assertion error → FAIL
+    it('assertion error in runner output → FAIL (not WAIT)', async () => {
+      withTestingRow({
+        id: 1, verdict: 'FAIL', confidence: 0, created_at: freshDate(),
+        metadata: { exit_code: 1, runner_output: 'AssertionError: expected 1 to equal 2' },
+      });
+      const ctx = { sd: createMockSD({ sd_type: 'feature', id: 'uuid-assert' }) };
+      const result = await gate.validator(ctx);
+      expect(result.passed).toBe(false);
+      expect(result.wait).toBe(false);
+    });
+
+    // Ambiguous (non-pass verdict, no runner exit info available) → FAIL (default)
+    it('non-pass verdict with NO runner info → FAIL (ambiguous defaults to FAIL)', async () => {
+      withTestingRow({ id: 1, verdict: 'FAIL', confidence: 0, created_at: freshDate() });
+      const ctx = { sd: createMockSD({ sd_type: 'feature', id: 'uuid-amb' }) };
+      const result = await gate.validator(ctx);
+      expect(result.passed).toBe(false);
+      expect(result.wait).toBe(false);
+    });
   });
 });

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.js
@@ -7,7 +7,36 @@
  * Fixes GAP-001 (SDs missing from DB after successful migration).
  */
 
+// SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-4): WAIT for the "applied but not yet
+// verified" race window; FAIL only when verification actually ran and crashed.
+import { buildWaitResult, buildFailResult } from '../../../../../../lib/handoff/wait-verdict.js';
+
 const BLOCKING_SD_TYPES = ['database'];
+
+/**
+ * FR-4: classify a migration's verification state from its tracking fields.
+ *   - applied_at IS NOT NULL && verified_at IS NULL && last_verification_error IS NULL
+ *       → 'wait' (migration applied, verification not yet attempted — race window)
+ *   - last_verification_error IS NOT NULL
+ *       → 'fail' (verification ran and crashed — a real failure, not a race window)
+ *   - otherwise → 'ok' (verified, or not-yet-applied / no tracking info)
+ *
+ * @param {Object} m - Migration descriptor (may carry applied_at/verified_at/last_verification_error).
+ * @returns {'wait'|'fail'|'ok'}
+ */
+function classifyMigrationVerificationState(m) {
+  if (!m) return 'ok';
+  const lastErr = m.last_verification_error ?? null;
+  if (lastErr !== null && lastErr !== undefined && String(lastErr).length > 0) {
+    return 'fail';
+  }
+  const appliedAt = m.applied_at ?? null;
+  const verifiedAt = m.verified_at ?? null;
+  if (appliedAt && !verifiedAt) {
+    return 'wait';
+  }
+  return 'ok';
+}
 
 /**
  * Create the GATE_MIGRATION_DATA_VERIFICATION gate validator
@@ -45,6 +74,51 @@ export function createMigrationDataVerificationGate(supabase) {
         }
 
         console.log(`   📋 Found ${migrations.length} migration(s)`);
+
+        // FR-4: verification-state race window. A migration that is applied but
+        // not yet verified (and has no recorded verification error) is mid-flight
+        // — return WAIT (preserve retry budget; re-check later). A migration whose
+        // verification actually ran and recorded an error is a REAL failure → FAIL.
+        const stateClassified = migrations.map(m => ({ m, state: classifyMigrationVerificationState(m) }));
+        const crashed = stateClassified.filter(x => x.state === 'fail');
+        const unverifiedYet = stateClassified.filter(x => x.state === 'wait');
+
+        if (crashed.length > 0) {
+          const errs = crashed.map(x => `${x.m.name || 'migration'}: ${x.m.last_verification_error}`);
+          console.log(`   ❌ Migration verification crashed (real failure): ${errs.join('; ')}`);
+          return buildFailResult({
+            score: 0,
+            max_score: 100,
+            issues: [
+              `Migration verification FAILED for ${crashed.length}/${migrations.length} migration(s)`,
+              ...errs
+            ],
+            details: {
+              reason: 'MIGRATION_VERIFICATION_ERROR',
+              sdType,
+              migrationCount: migrations.length,
+              failed: crashed.map(x => ({ name: x.m.name, last_verification_error: x.m.last_verification_error }))
+            },
+            remediation: 'Migration verification ran and crashed — inspect last_verification_error, fix the migration or verifier, then re-run.'
+          });
+        }
+
+        if (unverifiedYet.length > 0) {
+          const names = unverifiedYet.map(x => x.m.name || 'migration');
+          console.log(`   ⏳ WAIT: ${unverifiedYet.length} migration(s) applied but not yet verified: ${names.join(', ')}`);
+          return buildWaitResult({
+            score: 0,
+            max_score: 100,
+            wait_reason: `${unverifiedYet.length} migration(s) applied but verification not yet attempted: ${names.join(', ')}`,
+            details: {
+              reason: 'MIGRATION_VERIFICATION_PENDING',
+              sdType,
+              migrationCount: migrations.length,
+              pending: names
+            },
+            remediation: 'Migration is applied; verification has not run yet. Re-check shortly. If it never verifies before the wait ceiling, it will surface as a real failure.'
+          });
+        }
 
         // Step 2: Verify each migration's data was applied
         const results = [];
@@ -165,7 +239,12 @@ async function findSdMigrations(supabase, sdId, sdKey) {
         migrations.push({
           name: m.name || m.file || 'unknown',
           tables: m.tables || m.target_tables || [],
-          expectedRows: m.expected_rows || m.row_count || null
+          expectedRows: m.expected_rows || m.row_count || null,
+          // FR-4: verification-state tracking fields (no schema change — these
+          // travel in the PLAN-TO-EXEC handoff metadata migration descriptor).
+          applied_at: m.applied_at ?? null,
+          verified_at: m.verified_at ?? null,
+          last_verification_error: m.last_verification_error ?? null
         });
       }
     }

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.test.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests: GATE_MIGRATION_DATA_VERIFICATION — FR-4 WAIT branch
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+ *
+ * Covers each combination of applied_at / verified_at / last_verification_error:
+ *   - applied, unverified, no error            → WAIT  (race window)
+ *   - last_verification_error present          → FAIL  (verification crashed)
+ *   - applied AND verified, no error           → OK    (proceeds to data check → PASS)
+ *   - not applied (no tracking fields)         → OK    (proceeds to data check → PASS)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMigrationDataVerificationGate } from './migration-data-verification.js';
+
+/**
+ * Mock supabase whose sd_phase_handoffs query returns a metadata.migrations[]
+ * array (the source findSdMigrations reads). All other tables return empty so
+ * the data-verification step is a no-op (tables with no target → verified=true).
+ */
+function makeSupabase(metadataMigrations) {
+  return {
+    from(table) {
+      if (table === 'sd_phase_handoffs') {
+        const q = {
+          select: () => q,
+          eq: () => q,
+          order: () => q,
+          limit: () => q,
+          maybeSingle: () => Promise.resolve({
+            data: { metadata: { migrations: metadataMigrations } },
+            error: null
+          })
+        };
+        return q;
+      }
+      // sd_deliverables fallback (only hit when no metadata migrations)
+      if (table === 'sd_deliverables') {
+        const q = { select: () => q, eq: () => q, ilike: () => Promise.resolve({ data: [], error: null }) };
+        return q;
+      }
+      // target-table count queries during data verification
+      return {
+        select: () => Promise.resolve({ count: 5, error: null })
+      };
+    }
+  };
+}
+
+const SD = { id: 'sd-uuid-mig', sd_key: 'SD-MIG-001', sd_type: 'database' };
+
+describe('GATE_MIGRATION_DATA_VERIFICATION — FR-4 verification-state WAIT/FAIL', () => {
+  let gate;
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('applied_at set, verified_at null, no error → WAIT', async () => {
+    const supabase = makeSupabase([
+      { name: 'm1', applied_at: '2026-04-24T20:00:00Z', verified_at: null, last_verification_error: null }
+    ]);
+    gate = createMigrationDataVerificationGate(supabase);
+    const result = await gate.validator({ sd: SD });
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(true);
+    expect(result.details.reason).toBe('MIGRATION_VERIFICATION_PENDING');
+    expect(result.issues).toEqual([]);
+  });
+
+  it('last_verification_error present → FAIL (verification crashed, not a race)', async () => {
+    const supabase = makeSupabase([
+      {
+        name: 'm1',
+        applied_at: '2026-04-24T20:00:00Z',
+        verified_at: null,
+        last_verification_error: 'relation "foo" does not exist'
+      }
+    ]);
+    gate = createMigrationDataVerificationGate(supabase);
+    const result = await gate.validator({ sd: SD });
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(false);
+    expect(result.details.reason).toBe('MIGRATION_VERIFICATION_ERROR');
+    expect(result.issues.some(i => /relation "foo" does not exist/.test(i))).toBe(true);
+  });
+
+  it('last_verification_error present takes precedence even if verified_at also set → FAIL', async () => {
+    const supabase = makeSupabase([
+      {
+        name: 'm1',
+        applied_at: '2026-04-24T20:00:00Z',
+        verified_at: '2026-04-24T20:05:00Z',
+        last_verification_error: 'constraint violation'
+      }
+    ]);
+    gate = createMigrationDataVerificationGate(supabase);
+    const result = await gate.validator({ sd: SD });
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(false);
+    expect(result.details.reason).toBe('MIGRATION_VERIFICATION_ERROR');
+  });
+
+  it('applied_at AND verified_at set, no error → not WAIT/FAIL (proceeds to data check → PASS)', async () => {
+    const supabase = makeSupabase([
+      {
+        name: 'm1',
+        applied_at: '2026-04-24T20:00:00Z',
+        verified_at: '2026-04-24T20:05:00Z',
+        last_verification_error: null,
+        tables: []
+      }
+    ]);
+    gate = createMigrationDataVerificationGate(supabase);
+    const result = await gate.validator({ sd: SD });
+    expect(result.passed).toBe(true);
+    expect(result.wait).toBeUndefined();
+  });
+
+  it('no tracking fields (not-yet-applied descriptor) → not WAIT/FAIL (proceeds → PASS)', async () => {
+    const supabase = makeSupabase([
+      { name: 'm1', tables: [] } // no applied_at/verified_at/last_verification_error
+    ]);
+    gate = createMigrationDataVerificationGate(supabase);
+    const result = await gate.validator({ sd: SD });
+    expect(result.passed).toBe(true);
+    expect(result.wait).toBeUndefined();
+  });
+});

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -7,6 +7,9 @@
 
 import { isInfrastructureSDSync } from '../../../../sd-type-checker.js';
 import { autoResolveFailedHandoffs } from '../../../gates/auto-resolve-failures.js';
+// SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 TR-1: construct the WAIT verdict through
+// the shared helper (this gate is the PR #4021 precedent; shape is unchanged).
+import { buildWaitResult } from '../../../../../../lib/handoff/wait-verdict.js';
 
 /**
  * Create the PREREQUISITE_HANDOFF_CHECK gate validator
@@ -159,11 +162,9 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
       incompleteChildren.forEach(c => {
         console.log(`      - ${c.sd_key || c.id}: ${c.status}`);
       });
-      return {
-        passed: false,
+      return buildWaitResult({
         score: 0,
         max_score: 100,
-        wait: true,
         wait_reason: `Parent orchestrator waiting on ${incompleteChildren.length} child SD(s) to complete: ${incompleteList.join(', ')}`,
         issues: [],
         warnings: [`WAIT: parent orchestrator blocked until children complete (${incompleteList.length} pending)`],
@@ -174,7 +175,7 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
           completed_children: completedChildren.length,
           incomplete_children: incompleteList,
         },
-      };
+      });
     }
 
     console.log('   ✅ All children completed - parent SD ready for final approval');

--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -11,7 +11,19 @@
  *   - That gate: keyed on sd_type, required:false (advisory), no freshness
  *
  * Emergency bypass: set LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 (writes audit_log warning).
+ *
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-2): when no evidence row exists yet
+ * AND the phase started within RACE_WINDOW_SECONDS (the agent may be mid-write),
+ * return a WAIT verdict instead of FAIL so the orchestrator re-checks later
+ * without burning retry budget. Outside the window → FAIL (unchanged).
  */
+import { buildWaitResult, buildFailResult, isWithinRaceWindow } from '../../../../lib/handoff/wait-verdict.js';
+
+/**
+ * Race window (seconds) during which a missing evidence row is treated as a
+ * transient write-lag (WAIT) rather than a real absence (FAIL).
+ */
+const RACE_WINDOW_SECONDS = 30;
 
 /**
  * Required sub-agents per handoff type.
@@ -271,22 +283,38 @@ export async function validateSubagentEvidence(ctx, supabase) {
     };
   }
 
+  // FR-2: race-window WAIT. If the phase started within RACE_WINDOW_SECONDS the
+  // required agent(s) may still be writing their row(s) — return WAIT (not FAIL)
+  // so retry budget is preserved and the orchestrator re-checks later. The
+  // phase-start anchor is derived from the prior handoff's accepted_at (RISK-1:
+  // there is NO invoked_at column). A missing/epoch anchor is far in the past,
+  // so isWithinRaceWindow returns false → FAIL (safe default).
+  const sharedDetails = {
+    required,
+    present: [...present],
+    missing,
+    phase_started_at: phaseStartedAt.toISOString()
+  };
+
+  if (isWithinRaceWindow(phaseStartedAt, RACE_WINDOW_SECONDS)) {
+    console.log(`   ⏳ WAIT: evidence row(s) not yet written (within ${RACE_WINDOW_SECONDS}s race window): ${missing.join(', ')}`);
+    return buildWaitResult({
+      score: 0,
+      max_score: 100,
+      wait_reason: `Sub-agent evidence not yet written for ${missing.join(', ')} (phase started <${RACE_WINDOW_SECONDS}s ago; agent may be mid-write)`,
+      details: { reason: 'SUBAGENT_EVIDENCE_WRITE_LAG', race_window_seconds: RACE_WINDOW_SECONDS, ...sharedDetails },
+      remediation: `Re-check shortly; the required sub-agent(s) (${missing.join(', ')}) may still be writing to sub_agent_execution_results. If still missing after the race window, invoke them via the Task tool.`
+    });
+  }
+
   console.log(`   ❌ SUBAGENT_EVIDENCE_MISSING: ${missing.join(', ')}`);
-  return {
-    passed: false,
+  return buildFailResult({
     score: 0,
     max_score: 100,
     issues: [`SUBAGENT_EVIDENCE_MISSING: ${missing.join(', ')}`],
-    warnings: [],
-    details: {
-      reason: 'SUBAGENT_EVIDENCE_MISSING',
-      required,
-      present: [...present],
-      missing,
-      phase_started_at: phaseStartedAt.toISOString()
-    },
+    details: { reason: 'SUBAGENT_EVIDENCE_MISSING', ...sharedDetails },
     remediation: `Invoke the missing sub-agent(s) via Task tool for SD ${sdKey} before re-running the ${handoffType} handoff, OR set LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 as an emergency bypass.`
-  };
+  });
 }
 
 /**

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -448,7 +448,11 @@ export class HandoffRecorder {
         wait: true,
         waiting_gates: waitingGates,
         wait_reasons: waitReasons,
-        wait_protocol: 'SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001'
+        wait_protocol: 'SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001',
+        // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5: persist wait-loop accounting
+        // so the NEXT attempt's max-wait ceiling can detect a perpetually-stuck gate.
+        wait_attempts: Number(result.waitMetadata?.wait_attempts) || 0,
+        first_wait_at: result.waitMetadata?.first_wait_at || new Date().toISOString()
       },
       created_by: 'UNIFIED-HANDOFF-SYSTEM'
     };

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -36,6 +36,16 @@ import { OIVGate, OIV_GATE_WEIGHT } from './oiv/index.js';
 // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Gate context preloader
 import { preloadGateContext, getGateNumberForRule } from './validator-registry/gate-context-preloader.js';
 
+// SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-5/TR-4): max-wait ceiling guard.
+// Escalates a perpetually-WAITing gate to FAIL after N consecutive waits OR a
+// wall-clock timeout, protecting ALL wait-returning gates (incl. PR #4021
+// prerequisite-check) from infinite WAIT loops.
+import { hasExceededMaxWait } from '../../../../lib/handoff/wait-verdict.js';
+
+// Max-wait ceiling constants (FR-5). N=10 consecutive waits; 24h wall-clock.
+const WAIT_MAX_ATTEMPTS = 10;
+const WAIT_MAX_WALL_CLOCK_MS = 24 * 60 * 60 * 1000;
+
 export class ValidationOrchestrator {
   constructor(supabase, options = {}) {
     if (!supabase) {
@@ -120,6 +130,27 @@ export class ValidationOrchestrator {
       console.log(`   [ValidationOrchestrator] Warning: SD_TYPE_THRESHOLD registry check failed: ${err.message}`);
       return { disabled: false, reason: null };
     }
+  }
+
+  /**
+   * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5: resolve the prior consecutive-wait
+   * accounting for a gate. The executor persists { wait_attempts, first_wait_at }
+   * into sd_phase_handoffs.metadata on each WAIT and surfaces the prior values on
+   * context.waitState (optionally keyed per-gate via context.waitStateByGate).
+   *
+   * Returns a zeroed state when no prior wait is recorded (first wait). Kept
+   * synchronous + context-driven so unit tests need no live DB (TR-5).
+   *
+   * @param {object} context - Validation context.
+   * @param {string} gateName - Gate name (for per-gate keyed state).
+   * @returns {{ wait_attempts: number, first_wait_at: (string|null) }}
+   */
+  _resolveWaitState(context = {}, gateName = '') {
+    const perGate = context.waitStateByGate && context.waitStateByGate[gateName];
+    const raw = perGate || context.waitState || {};
+    const attempts = Number(raw.wait_attempts) || 0;
+    const firstWaitAt = raw.first_wait_at || null;
+    return { wait_attempts: attempts, first_wait_at: firstWaitAt };
   }
 
   /**
@@ -216,7 +247,11 @@ export class ValidationOrchestrator {
       // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-4/FR-5: WAIT verdict tracking
       waitVerdict: false,      // True if any required gate returned wait=true (not a failure)
       waitingGates: [],        // Gate names that returned wait=true
-      waitReasons: []          // Per-gate wait_reason strings
+      waitReasons: [],         // Per-gate wait_reason strings
+      // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5: wait-loop accounting. The
+      // executor persists these into sd_phase_handoffs.metadata so the NEXT
+      // attempt can detect when the wait ceiling has been exceeded.
+      waitMetadata: null       // { wait_attempts, first_wait_at } when waitVerdict=true
     };
 
     // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pre-fetch shared gate data
@@ -313,17 +348,53 @@ export class ValidationOrchestrator {
           // failed-gate path so the executor can record blocked_wait status without
           // burning retry budget or triggering RCA.
           if (gateResult.wait === true) {
-            results.waitVerdict = true;
-            results.waitingGates.push(gate.name);
-            if (gateResult.wait_reason) {
-              results.waitReasons.push(`${gate.name}: ${gateResult.wait_reason}`);
+            // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5/TR-4: max-wait ceiling.
+            // Read prior consecutive-wait accounting (persisted by the executor in
+            // sd_phase_handoffs.metadata, surfaced on context.waitState). If the
+            // ceiling is already exceeded BEFORE this attempt, escalate WAIT → FAIL
+            // so a permanently-stuck race window surfaces as a real failure rather
+            // than looping forever. Applies to ALL wait gates incl. prerequisite-check.
+            const prior = this._resolveWaitState(context, gate.name);
+            const ceiling = hasExceededMaxWait({
+              wait_attempts: prior.wait_attempts,
+              first_wait_at: prior.first_wait_at,
+              maxAttempts: WAIT_MAX_ATTEMPTS,
+              maxWallClockMs: WAIT_MAX_WALL_CLOCK_MS
+            });
+
+            if (ceiling.exceeded) {
+              // Escalate to a real failure. NOT a wait anymore.
+              results.passed = false;
+              if (!results.failedGate) results.failedGate = gate.name;
+              const reasonMsg = ceiling.reason === 'WAIT_TIMEOUT_EXCEEDED'
+                ? `${gate.name}: WAIT_TIMEOUT_EXCEEDED — gate has been waiting >${Math.round(WAIT_MAX_WALL_CLOCK_MS / 3600000)}h (first wait ${prior.first_wait_at}); escalating to failure`
+                : `${gate.name}: WAIT_LIMIT_EXCEEDED — gate returned WAIT ${prior.wait_attempts}× (max ${WAIT_MAX_ATTEMPTS}); escalating to failure`;
+              results.issues.push(reasonMsg);
+              if (gateResult.wait_reason) {
+                results.issues.push(`${gate.name} underlying wait reason: ${gateResult.wait_reason}`);
+              }
+              console.log(`   ⛔ ${reasonMsg}`);
+              earlyExit = true;
+            } else {
+              results.waitVerdict = true;
+              results.waitingGates.push(gate.name);
+              if (gateResult.wait_reason) {
+                results.waitReasons.push(`${gate.name}: ${gateResult.wait_reason}`);
+              }
+              // FR-5: advance the wait accounting so the executor persists the new
+              // count + first-wait anchor (first wait stamps "now"; subsequent waits
+              // preserve the original anchor for the wall-clock guard).
+              results.waitMetadata = {
+                wait_attempts: prior.wait_attempts + 1,
+                first_wait_at: prior.first_wait_at || new Date().toISOString()
+              };
+              // Still mark not-passed so handoff doesn't advance, but DO NOT set failedGate
+              // (failedGate is a failure marker — wait is not a failure).
+              results.passed = false;
+              // Defensive: still copy warnings (which include the WAIT message) but skip issues
+              // since the gate already returned issues=[] for wait verdicts.
+              earlyExit = true;
             }
-            // Still mark not-passed so handoff doesn't advance, but DO NOT set failedGate
-            // (failedGate is a failure marker — wait is not a failure).
-            results.passed = false;
-            // Defensive: still copy warnings (which include the WAIT message) but skip issues
-            // since the gate already returned issues=[] for wait verdicts.
-            earlyExit = true;
           } else {
             results.passed = false;
             if (!results.failedGate) results.failedGate = gate.name;

--- a/tests/unit/handoff/validation-orchestrator-wait-ceiling.test.js
+++ b/tests/unit/handoff/validation-orchestrator-wait-ceiling.test.js
@@ -1,0 +1,147 @@
+/**
+ * Unit tests: ValidationOrchestrator max-wait ceiling guard (FR-5 / TR-4)
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+ *
+ * A WAIT-returning gate must escalate to FAIL after N=10 consecutive WAITs
+ * (WAIT_LIMIT_EXCEEDED) AND after 24h wall-clock (WAIT_TIMEOUT_EXCEEDED). The
+ * guard protects ALL wait gates including the PR #4021 prerequisite-check.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Telemetry no-op
+vi.mock('../../../lib/telemetry/workflow-timer.js', () => ({
+  startSpan: vi.fn(),
+  endSpan: vi.fn(),
+}));
+
+vi.mock('../../../lib/utils/sd-type-validation.js', () => ({
+  shouldSkipCodeValidation: vi.fn(() => false),
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/sd-type-applicability-policy.js', () => ({
+  createSkippedResult: vi.fn(),
+  isSkippedResult: vi.fn(() => false),
+  ValidatorStatus: { PASS: 'PASS', FAIL: 'FAIL', SKIPPED: 'SKIPPED' },
+  SkipReasonCode: { NON_APPLICABLE_SD_TYPE: 'NON_APPLICABLE_SD_TYPE' },
+}));
+
+vi.mock('../../../scripts/modules/sd-type-checker.js', () => ({
+  THRESHOLD_PROFILES: { default: { gateThreshold: 0 } },
+}));
+
+// CRITICAL: this mock PRESERVES the wait discriminators (wait/wait_reason) and
+// normalizes max_score -> maxScore so the orchestrator's wait branch sees them.
+vi.mock('../../../scripts/modules/handoff/validation/gate-result-schema.js', () => ({
+  validateGateResult: vi.fn((result) => ({
+    passed: result.passed ?? true,
+    score: result.score ?? 100,
+    maxScore: result.maxScore ?? result.max_score ?? 100,
+    issues: result.issues || [],
+    warnings: result.warnings || [],
+    wait: result.wait,
+    wait_reason: result.wait_reason,
+  })),
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/ValidatorRegistry.js', () => ({
+  validatorRegistry: { getOrCreateFallback: vi.fn(), normalizeResult: vi.fn(r => r) },
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/oiv/index.js', () => {
+  class MockOIVGate { constructor() { this.validateHandoff = vi.fn(() => ({ passed: true, score: 100, issues: [] })); } }
+  return { OIVGate: MockOIVGate, OIV_GATE_WEIGHT: 0.15 };
+});
+
+vi.mock('../../../scripts/modules/handoff/validation/validator-registry/gate-context-preloader.js', () => ({
+  preloadGateContext: vi.fn(() => ({})),
+  getGateNumberForRule: vi.fn(() => null),
+}));
+
+vi.mock('../../../scripts/modules/handoff/ResultBuilder.js', () => ({
+  default: { logGateResult: vi.fn() },
+}));
+
+import { ValidationOrchestrator } from '../../../scripts/modules/handoff/validation/ValidationOrchestrator.js';
+
+/** A gate that always returns a WAIT verdict. */
+function waitGate(name = 'PREREQUISITE_HANDOFF_CHECK') {
+  return {
+    name,
+    required: true,
+    validator: async () => ({
+      passed: false,
+      wait: true,
+      score: 0,
+      max_score: 100,
+      issues: [],
+      wait_reason: 'parent orchestrator waiting on children',
+      warnings: ['WAIT: parent orchestrator waiting on children'],
+    }),
+  };
+}
+
+const mockSupabase = { from: vi.fn(() => ({ select: () => ({ eq: () => ({ limit: () => Promise.resolve({ data: [], error: null }) }) }) })) };
+
+describe('ValidationOrchestrator — FR-5 max-wait ceiling', () => {
+  let orch;
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    orch = new ValidationOrchestrator(mockSupabase);
+  });
+
+  it('first WAIT (no prior state) → waitVerdict (not failure), waitMetadata advances to 1', async () => {
+    const r = await orch.validateGates([waitGate()], { sd: {} });
+    expect(r.passed).toBe(false);
+    expect(r.waitVerdict).toBe(true);
+    expect(r.failedGate).toBe(null);
+    expect(r.waitMetadata.wait_attempts).toBe(1);
+    expect(typeof r.waitMetadata.first_wait_at).toBe('string');
+  });
+
+  it('9 prior waits → still WAIT (not yet at ceiling), advances to 10', async () => {
+    const r = await orch.validateGates([waitGate()], {
+      sd: {},
+      waitState: { wait_attempts: 9, first_wait_at: new Date().toISOString() },
+    });
+    expect(r.waitVerdict).toBe(true);
+    expect(r.failedGate).toBe(null);
+    expect(r.waitMetadata.wait_attempts).toBe(10);
+  });
+
+  // FR-5 acceptance: 10 WAITs → FAIL on the 11th attempt
+  it('10 prior waits → escalate to FAIL (WAIT_LIMIT_EXCEEDED)', async () => {
+    const r = await orch.validateGates([waitGate()], {
+      sd: {},
+      waitState: { wait_attempts: 10, first_wait_at: new Date().toISOString() },
+    });
+    expect(r.passed).toBe(false);
+    expect(r.waitVerdict).toBe(false);
+    expect(r.failedGate).toBe('PREREQUISITE_HANDOFF_CHECK');
+    expect(r.issues.some(i => /WAIT_LIMIT_EXCEEDED/.test(i))).toBe(true);
+  });
+
+  // FR-5 acceptance: 24h elapsed → FAIL
+  it('first_wait_at 25h ago → escalate to FAIL (WAIT_TIMEOUT_EXCEEDED)', async () => {
+    const first = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const r = await orch.validateGates([waitGate()], {
+      sd: {},
+      waitState: { wait_attempts: 2, first_wait_at: first },
+    });
+    expect(r.passed).toBe(false);
+    expect(r.waitVerdict).toBe(false);
+    expect(r.failedGate).toBe('PREREQUISITE_HANDOFF_CHECK');
+    expect(r.issues.some(i => /WAIT_TIMEOUT_EXCEEDED/.test(i))).toBe(true);
+  });
+
+  // TR-4: guard applies to ANY wait gate, including non-prerequisite gates
+  it('TR-4: ceiling also protects a non-prerequisite wait gate (e.g. SUB_AGENT)', async () => {
+    const r = await orch.validateGates([waitGate('GATE_SUBAGENT_EVIDENCE')], {
+      sd: {},
+      waitState: { wait_attempts: 10, first_wait_at: new Date().toISOString() },
+    });
+    expect(r.passed).toBe(false);
+    expect(r.waitVerdict).toBe(false);
+    expect(r.failedGate).toBe('GATE_SUBAGENT_EVIDENCE');
+  });
+});

--- a/tests/unit/handoff/wait-verdict.test.js
+++ b/tests/unit/handoff/wait-verdict.test.js
@@ -1,0 +1,197 @@
+/**
+ * Unit tests: centralized WAIT-verdict helper (FR-1)
+ * SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+ *
+ * Covers TS-1..TS-9 plus the RISK-2 regression-pin: a user-thrown Error whose
+ * message merely contains "timeout" must classify as 'failure', NOT 'timeout'.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildWaitResult,
+  buildFailResult,
+  classifyTestRunnerExit,
+  isWithinRaceWindow,
+  hasExceededMaxWait,
+} from '../../../lib/handoff/wait-verdict.js';
+
+describe('buildWaitResult', () => {
+  // TS-5: shape matches prerequisite-check.js wait verdict
+  it('produces the canonical wait shape (passed:false, wait:true, all 7 keys)', () => {
+    const r = buildWaitResult({
+      score: 0,
+      max_score: 100,
+      wait_reason: 'evidence row not yet written',
+      issues: [],
+      details: { reason: 'RACE_WINDOW' },
+    });
+    expect(r.passed).toBe(false);
+    expect(r.wait).toBe(true);
+    expect(r.score).toBe(0);
+    expect(r.max_score).toBe(100);
+    expect(r.issues).toEqual([]);
+    expect(r.wait_reason).toBe('evidence row not yet written');
+    expect(r.details).toEqual({ reason: 'RACE_WINDOW' });
+    // mirrors prerequisite-check.js which also carries warnings
+    expect(Array.isArray(r.warnings)).toBe(true);
+  });
+
+  it('defaults a warning from wait_reason when none supplied', () => {
+    const r = buildWaitResult({ wait_reason: 'parent waiting on children' });
+    expect(r.warnings[0]).toMatch(/WAIT: parent waiting on children/);
+  });
+
+  it('passes through explicit warnings and remediation', () => {
+    const r = buildWaitResult({
+      wait_reason: 'x',
+      warnings: ['custom warn'],
+      remediation: 'wait and retry',
+    });
+    expect(r.warnings).toEqual(['custom warn']);
+    expect(r.remediation).toBe('wait and retry');
+  });
+});
+
+describe('buildFailResult', () => {
+  it('produces a normal failure with wait:false', () => {
+    const r = buildFailResult({
+      score: 0,
+      max_score: 100,
+      issues: ['ERR_TESTING_REQUIRED'],
+      remediation: 'run TESTING',
+      details: { tier: 'REQUIRED' },
+    });
+    expect(r.passed).toBe(false);
+    expect(r.wait).toBe(false);
+    expect(r.issues).toEqual(['ERR_TESTING_REQUIRED']);
+    expect(r.remediation).toBe('run TESTING');
+    expect(r.details).toEqual({ tier: 'REQUIRED' });
+  });
+
+  it('never sets wait:true', () => {
+    const r = buildFailResult({ issues: ['boom'] });
+    expect(r.wait).toBe(false);
+  });
+});
+
+describe('classifyTestRunnerExit', () => {
+  // TS-1
+  it('TS-1: exit 124 → timeout (GNU coreutils timeout)', () => {
+    expect(classifyTestRunnerExit(124, '')).toBe('timeout');
+  });
+
+  it('exit 137 (SIGKILL/OOM) → timeout', () => {
+    expect(classifyTestRunnerExit(137, '')).toBe('timeout');
+  });
+
+  it('exit 143 (SIGTERM) → timeout', () => {
+    expect(classifyTestRunnerExit(143, '')).toBe('timeout');
+  });
+
+  it('jest async-callback timeout marker → timeout', () => {
+    expect(
+      classifyTestRunnerExit(1, 'Timeout - Async callback was not invoked within the 5000 ms timeout')
+    ).toBe('timeout');
+  });
+
+  it('playwright per-test timeout marker → timeout', () => {
+    expect(classifyTestRunnerExit(1, 'Test timeout of 30000ms exceeded')).toBe('timeout');
+  });
+
+  it('vitest "Test timed out in 5000ms" marker → timeout', () => {
+    expect(classifyTestRunnerExit(1, 'Error: Test timed out in 5000ms.')).toBe('timeout');
+  });
+
+  // TS-2
+  it('TS-2: assertion error → failure', () => {
+    expect(classifyTestRunnerExit(1, 'AssertionError: expected 1 to equal 2')).toBe('failure');
+  });
+
+  // TS-3 — RISK-2 REGRESSION PIN
+  it('TS-3 [REGRESSION-PIN]: user Error containing "timeout" → failure (NOT timeout)', () => {
+    expect(classifyTestRunnerExit(1, 'Error: connection timeout')).toBe('failure');
+    expect(classifyTestRunnerExit(1, 'Error: connection timeout at db.connect (db.js:10)')).toBe(
+      'failure'
+    );
+  });
+
+  // TS-4
+  it('TS-4: exit 0, no marker → pass', () => {
+    expect(classifyTestRunnerExit(0, '')).toBe('pass');
+  });
+
+  it('unknown non-zero exit with no marker → failure (never timeout)', () => {
+    expect(classifyTestRunnerExit(255, 'some unknown crash')).toBe('failure');
+  });
+});
+
+describe('isWithinRaceWindow', () => {
+  const NOW = new Date('2026-04-24T20:00:30.000Z').getTime();
+
+  // TS-6
+  it('TS-6: started 5s ago, window 30s → true', () => {
+    const started = new Date(NOW - 5_000).toISOString();
+    expect(isWithinRaceWindow(started, 30, NOW)).toBe(true);
+  });
+
+  // TS-7
+  it('TS-7: started 35s ago, window 30s → false', () => {
+    const started = new Date(NOW - 35_000).toISOString();
+    expect(isWithinRaceWindow(started, 30, NOW)).toBe(false);
+  });
+
+  it('exactly at the boundary (30s, window 30s) → true (inclusive)', () => {
+    const started = new Date(NOW - 30_000).toISOString();
+    expect(isWithinRaceWindow(started, 30, NOW)).toBe(true);
+  });
+
+  it('naive (no-TZ) timestamp is treated as UTC', () => {
+    // 5s before NOW, expressed naively
+    const started = '2026-04-24T20:00:25.000';
+    expect(isWithinRaceWindow(started, 30, NOW)).toBe(true);
+  });
+
+  it('missing/unparseable startedAt → false (safe default → FAIL not WAIT-forever)', () => {
+    expect(isWithinRaceWindow(null, 30, NOW)).toBe(false);
+    expect(isWithinRaceWindow('not-a-date', 30, NOW)).toBe(false);
+  });
+});
+
+describe('hasExceededMaxWait', () => {
+  // TS-8
+  it('TS-8: wait_attempts=10, maxAttempts=10 → exceeded (WAIT_LIMIT_EXCEEDED)', () => {
+    const r = hasExceededMaxWait({ wait_attempts: 10, maxAttempts: 10 });
+    expect(r.exceeded).toBe(true);
+    expect(r.reason).toBe('WAIT_LIMIT_EXCEEDED');
+  });
+
+  it('wait_attempts=9, maxAttempts=10 → not exceeded', () => {
+    const r = hasExceededMaxWait({ wait_attempts: 9, maxAttempts: 10 });
+    expect(r.exceeded).toBe(false);
+    expect(r.reason).toBe(null);
+  });
+
+  // TS-9
+  it('TS-9: first_wait_at 25h ago → exceeded (WAIT_TIMEOUT_EXCEEDED)', () => {
+    const now = Date.now();
+    const first = new Date(now - 25 * 60 * 60 * 1000).toISOString();
+    const r = hasExceededMaxWait({ wait_attempts: 1, first_wait_at: first, now });
+    expect(r.exceeded).toBe(true);
+    expect(r.reason).toBe('WAIT_TIMEOUT_EXCEEDED');
+  });
+
+  it('first_wait_at 1h ago, few attempts → not exceeded', () => {
+    const now = Date.now();
+    const first = new Date(now - 1 * 60 * 60 * 1000).toISOString();
+    const r = hasExceededMaxWait({ wait_attempts: 2, first_wait_at: first, now });
+    expect(r.exceeded).toBe(false);
+  });
+
+  it('attempt-limit trips even when wall-clock is fresh', () => {
+    const now = Date.now();
+    const first = new Date(now - 1000).toISOString();
+    const r = hasExceededMaxWait({ wait_attempts: 10, first_wait_at: first, now });
+    expect(r.exceeded).toBe(true);
+    expect(r.reason).toBe('WAIT_LIMIT_EXCEEDED');
+  });
+});

--- a/tests/unit/subagent-evidence-gate.test.js
+++ b/tests/unit/subagent-evidence-gate.test.js
@@ -180,9 +180,11 @@ describe('validateSubagentEvidence', () => {
     expect(result.passed).toBe(true);
     expect(result.warnings[0]).toMatch(/BYPASSED/);
     expect(auditSpy).toHaveBeenCalledTimes(1);
+    // QF-20260509-AUDIT-LOG-SHAPE: canonical audit_log shape is event_type
+    // (NOT action — audit_log has no `action` column). Pin the current shape.
     expect(auditSpy).toHaveBeenCalledWith(expect.objectContaining({
       severity: 'warning',
-      action: 'gate_bypass',
+      event_type: 'gate_bypass',
       metadata: expect.objectContaining({ gate: 'GATE_SUBAGENT_EVIDENCE' })
     }));
   });
@@ -231,5 +233,59 @@ describe('validateSubagentEvidence', () => {
     const result = await validateSubagentEvidence(ctx, null);
     expect(result.passed).toBe(false);
     expect(result.details.reason).toBe('MISSING_CONTEXT');
+  });
+});
+
+// ─── FR-2: WAIT verdict on race-window write-lag ─────────────────────────────
+// SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001
+describe('validateSubagentEvidence — FR-2 WAIT branch', () => {
+  beforeEach(() => { delete process.env.LEO_DISABLE_SUBAGENT_EVIDENCE_GATE; });
+  afterEach(() => { delete process.env.LEO_DISABLE_SUBAGENT_EVIDENCE_GATE; });
+
+  // 5s elapsed → WAIT (phase started within the 30s race window; agent mid-write)
+  it('5s elapsed, missing evidence → WAIT (not FAIL)', async () => {
+    const phaseStart = new Date(Date.now() - 5_000).toISOString();
+    const supabase = makeSupabase({ phaseStart, evidenceRows: [] });
+    const ctx = { sd: makeSD(), handoffType: 'PLAN-TO-EXEC' };
+    const result = await validateSubagentEvidence(ctx, supabase);
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(true);
+    expect(result.details.reason).toBe('SUBAGENT_EVIDENCE_WRITE_LAG');
+    expect(result.wait_reason).toMatch(/TESTING/);
+    expect(result.issues).toEqual([]); // waits carry no issues
+  });
+
+  // 35s elapsed → FAIL (outside the 30s race window; unchanged behavior)
+  it('35s elapsed, missing evidence → FAIL (outside race window)', async () => {
+    const phaseStart = new Date(Date.now() - 35_000).toISOString();
+    const supabase = makeSupabase({ phaseStart, evidenceRows: [] });
+    const ctx = { sd: makeSD(), handoffType: 'PLAN-TO-EXEC' };
+    const result = await validateSubagentEvidence(ctx, supabase);
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(false);
+    expect(result.details.reason).toBe('SUBAGENT_EVIDENCE_MISSING');
+  });
+
+  // No prior handoff AND no SD created_at → epoch anchor → outside window → FAIL (safe default)
+  it('no prior handoff (epoch anchor), missing evidence → FAIL (safe default, not WAIT-forever)', async () => {
+    const supabase = makeSupabase({ phaseStart: null, sdCreatedAt: null, evidenceRows: [] });
+    const ctx = { sd: makeSD(), handoffType: 'PLAN-TO-EXEC' };
+    const result = await validateSubagentEvidence(ctx, supabase);
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(false);
+    expect(result.details.reason).toBe('SUBAGENT_EVIDENCE_MISSING');
+  });
+
+  // Evidence row present (even inside the race window) → PASS (unchanged)
+  it('evidence row present within race window → PASS (unchanged)', async () => {
+    const phaseStart = new Date(Date.now() - 5_000).toISOString();
+    const supabase = makeSupabase({
+      phaseStart,
+      evidenceRows: [{ sub_agent_code: 'TESTING', created_at: new Date().toISOString(), verdict: 'PASS' }]
+    });
+    const ctx = { sd: makeSD(), handoffType: 'PLAN-TO-EXEC' };
+    const result = await validateSubagentEvidence(ctx, supabase);
+    expect(result.passed).toBe(true);
+    expect(result.wait).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Extends PR #4021's WAIT verdict (transient race-window block that does NOT burn retry budget or trigger RCA) from the lone parent-orchestrator prerequisite check to three more gates, via a centralized helper, plus a max-wait safety ceiling.

- **FR-1** `lib/handoff/wait-verdict.js` — central helper, 5 exports (`buildWaitResult`, `buildFailResult`, `classifyTestRunnerExit`, `isWithinRaceWindow`, `hasExceededMaxWait`). Verdict shape mirrors #4021's `prerequisite-check.js` exactly so `ValidationOrchestrator` consumes it unchanged.
- **FR-2** SUB_AGENT_EVIDENCE gate WAIT branch — race window keyed on the prior handoff's `accepted_at` (RISK-1: there is no `invoked_at` column).
- **FR-3** TESTING gate WAIT branch — WHITELIST-only environmental-timeout detection (exit 124/137/143 + framework markers). RISK-2: a user-thrown `Error("connection timeout")` classifies as FAIL, protected by a regression-pin test.
- **FR-4** MIGRATION gate WAIT branch — `applied_at`+`verified_at IS NULL`+`last_verification_error IS NULL` → WAIT; `last_verification_error` present → FAIL.
- **FR-5** ValidationOrchestrator ceiling — escalate WAIT→FAIL after N=10 consecutive waits (`WAIT_LIMIT_EXCEEDED`) or 24h wall-clock (`WAIT_TIMEOUT_EXCEEDED`), protecting ALL wait gates incl the #4021 precedent (TR-4).
- **TR-1** all gate WAIT/FAIL construction routed through the helper (even the #4021 precedent gate refactored to use it).

## PR size justification
~1182 insertions (≈566 LOC code + ≈616 LOC tests across 13 files). Above the infra "ideal" but this is an **atomic feature**: the helper and its four consuming gates cannot be split without broken intermediate states (a helper with no consumers fails WIRE_CHECK; gates referencing a not-yet-merged helper fail import). Scoped as one SD with four phases in the PRD. GITHUB/PR-size validation is skipped for infrastructure SDs per the LEO type workflow.

## Test plan
- [x] 71 unit tests pass (vitest, mocked supabase, no live DB)
- [x] FR-1 regression-pin: `classifyTestRunnerExit(1, "Error: connection timeout")` → `'failure'`
- [x] RISK-1: zero references to non-existent `invoked_at` column
- [x] Pre-existing `handoff-orchestrator.test.js` failures confirmed unrelated (identical count with changes stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)