### PR TITLE
fix(QF-20260528-171): set retrospective_type=null on SD_COMPLETION retros

### DIFF
--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -161,6 +161,12 @@ async function generateRetrospective(sdInput) {
     target_application: sd.target_application || 'EHG_engineer',
     project_name: sd.title,
     retro_type: 'SD_COMPLETION',
+    // QF-20260528-171: explicitly NULL so the SD_COMPLETION retro passes
+    // RETROSPECTIVE_QUALITY_GATE. The column defaults to 'SD_COMPLETION'
+    // (migration 20251210_retrospective_self_improvement_system.sql), but the
+    // gate requires retrospective_type IS NULL for completion retros — omitting
+    // the key lets the default through and silently fails the gate.
+    retrospective_type: null,
     title: `${sd.sd_key} Retrospective`,
     description: `Retrospective analysis for ${sd.title} - completed at ${sd.progress}% with ${sd.status} status`,
     conducted_date: new Date().toISOString(),


### PR DESCRIPTION
## Summary
`scripts/generate-retrospective.js` set `retro_type: 'SD_COMPLETION'` but omitted `retrospective_type`, so the column DEFAULT `'SD_COMPLETION'` (migration `20251210_retrospective_self_improvement_system.sql:28`) was applied. `RETROSPECTIVE_QUALITY_GATE` (and the LEAD-FINAL retro-exists gate) require `retrospective_type IS NULL` for completion retros — so every auto-generated retro silently failed the gate, forcing hand-rolled `UPDATE`s.

Fix: explicitly set `retrospective_type: null` in the insert object (1 line + comment).

Resolves harness-backlog item `a558baf6`. Root-caused via retro-agent this session; the mechanism was proven by retro row `651ab323` (explicit null → passed the gate). Bit both campaign SDs (#4026, #4031) at PLAN-TO-LEAD.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Tier 1 (1 LOC) — auto-approve
- [x] Mechanism verified: an explicit `retrospective_type=null` retro passes the three-filter gate (`retro-filters.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)