### PR TITLE
fix(QF-20260528-426): normalize paths on cwd_leak branch of SUB_AGENT_REPO_RESOLUTION

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
@@ -94,6 +94,24 @@ function classifyRow(viewRow, rawRow, targetApp) {
 
   // View has spoken: explicit BLOCKED statuses
   if (viewRow.compliance_status === 'cwd_leak') {
+    // QF-20260528-426: extend QF-20260527-673 path normalization to the cwd_leak
+    // branch (the violation branch already had it). The view flags cwd_leak on
+    // strict equality between executed_from_cwd and metadata.repo_path — but on
+    // Windows the writer records backslashes while applications.local_path uses
+    // forward slashes, so an intra-repo sub-agent that legitimately ran from its
+    // own repo (cwd == repo == expected, modulo slashes) is false-blocked. If the
+    // normalized writer path resolves under the expected toplevel, the sub-agent
+    // ran from the CORRECT repo — not a leak. A real cross-repo leak (writer path
+    // not under expected) still falls through to BLOCKED below.
+    const writerNorm = normalizePathForGate(viewRow.metadata_repo_path);
+    const expectedNorm = normalizePathForGate(viewRow.expected_repo_path);
+    if (pathsAreToplevelCompatible(writerNorm, expectedNorm)) {
+      return {
+        status: 'healthy',
+        reasonCode: REASON_CODES.HEALTHY,
+        detail: `cwd_leak normalized: ${writerNorm} resolves under expected ${expectedNorm} (correct repo, not a leak)`
+      };
+    }
     return {
       status: 'cwd_leak',
       reasonCode: REASON_CODES.CWD_LEAK,

--- a/tests/unit/gates/sub-agent-repo-resolution.test.js
+++ b/tests/unit/gates/sub-agent-repo-resolution.test.js
@@ -404,4 +404,67 @@ describe('SUB_AGENT_REPO_RESOLUTION gate', () => {
       expect(result.details.buckets.violation).toHaveLength(1);
     });
   });
+
+  // QF-20260528-426: extend the QF-673 path normalization to the cwd_leak branch.
+  // The view flags cwd_leak on strict executed_from_cwd == metadata.repo_path, which
+  // false-blocks Windows intra-repo sub-agents (backslash cwd == backslash repo, but
+  // applications.local_path is forward-slash). Normalize first; rescue only when the
+  // writer resolves under expected. Real cross-repo leaks must still block.
+  describe('QF-20260528-426: cwd_leak normalization (view cwd_leak override)', () => {
+    it('overrides CWD_LEAK to HEALTHY when slashes differ but normalized paths match', async () => {
+      const viewRows = [{
+        id: 'CL1', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+        metadata_repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer',
+        metadata_repo_resolved: true,
+        executed_from_cwd: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer',
+        compliance_status: 'cwd_leak',
+      }];
+      const rawRows = [{ id: 'CL1', sub_agent_code: 'DESIGN', metadata: { repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.details.buckets.healthy).toHaveLength(1);
+      expect(result.details.buckets.cwd_leak).toHaveLength(0);
+    });
+
+    it('overrides CWD_LEAK to HEALTHY when writer is a `.worktrees/<id>` subpath of expected', async () => {
+      const viewRows = [{
+        id: 'CL2', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+        metadata_repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\qf\\QF-20260528-426',
+        metadata_repo_resolved: true,
+        executed_from_cwd: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\qf\\QF-20260528-426',
+        compliance_status: 'cwd_leak',
+      }];
+      const rawRows = [{ id: 'CL2', sub_agent_code: 'DESIGN', metadata: { repo_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\qf\\QF-20260528-426', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(true);
+      expect(result.details.buckets.healthy).toHaveLength(1);
+      expect(result.details.buckets.cwd_leak).toHaveLength(0);
+    });
+
+    it('preserves BLOCKED CWD_LEAK when writer is genuinely a different repo (must not regress)', async () => {
+      const viewRows = [{
+        id: 'CL3', sub_agent_code: 'DESIGN', phase: 'PLAN',
+        target_application: 'EHG_Engineer',
+        expected_repo_path: '/path/to/EHG_Engineer',
+        metadata_repo_path: '/path/to/different-repo',
+        metadata_repo_resolved: true,
+        executed_from_cwd: '/path/to/different-repo',
+        compliance_status: 'cwd_leak',
+      }];
+      const rawRows = [{ id: 'CL3', sub_agent_code: 'DESIGN', metadata: { repo_path: '/path/to/different-repo', repo_resolved: true } }];
+      const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+      const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+      expect(result.passed).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.reasonCode).toBe(REASON_CODES.CWD_LEAK);
+      expect(result.details.buckets.cwd_leak).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
`classifyRow` in `sub-agent-repo-resolution.js` applied QF-20260527-673 path normalization only to the `violation` branch, not `cwd_leak`. On Windows the design-agent records `metadata.repo_path` with backslashes while `applications.local_path` is forward-slash; when `executed_from_cwd` equals that backslash path, the view returns `cwd_leak` and **false-blocks every intra-repo SD at PLAN-TO-EXEC** (the exact bug that blocked SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001).

Fix: in the `cwd_leak` branch, if `pathsAreToplevelCompatible(normalize(metadata_repo_path), normalize(expected_repo_path))` the sub-agent ran from the correct repo → `healthy`. A real cross-repo leak (writer not under expected) still blocks. Mirrors the existing `violation`-branch logic exactly.

Resolves harness-backlog `ae85c8e6`.

## Test plan
- [x] 16/16 unit tests pass (13 existing + 3 new): slash-variance rescue, `.worktrees/<id>` subpath rescue, and a regression guard that a genuinely different repo still BLOCKS
- [x] Additive-safe: cannot make a passing case fail; only rescues normalized-equal paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)