### PR TITLE
feat(SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001): cascade SD cancellation in kill_venture + delete_venture

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,8 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-AUTOMATE-STAGE-CASCADE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-AUTOMATE-STAGE-CASCADE-001",
-  "createdAt": "2026-05-28T01:15:11.078Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
+  "sdKey": "SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001",
+  "expectedBranch": "feat/SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001",
+  "createdAt": "2026-05-28T10:21:34.811Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260528113000_chairman_venture_delete_cancel_sd_cascade.sql
+++ b/database/migrations/20260528113000_chairman_venture_delete_cancel_sd_cascade.sql
@@ -1,0 +1,193 @@
+-- SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001 / FR-A
+-- Extend kill_venture and delete_venture so cancelling OR deleting a venture also
+-- cancels its NON-TERMINAL strategic directives instead of leaving them orphaned.
+--
+-- Today delete_venture orphans SDs (UPDATE strategic_directives_v2 SET venture_id = NULL)
+-- and kill_venture ignores them entirely. After this migration, both RPCs set the
+-- venture's in-flight SDs (status NOT IN completed,cancelled) to 'cancelled' with a
+-- reason + metadata.cancelled_due_to_venture, inside their existing transaction.
+-- completed/cancelled SDs are left untouched. Additive + idempotent (CREATE OR REPLACE;
+-- the cascade UPDATE no-ops when zero non-terminal SDs are linked).
+
+-- ── kill_venture: add SD-cancellation cascade ──────────────────────────────────
+CREATE OR REPLACE FUNCTION public.kill_venture(p_venture_id uuid, p_rationale text)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_killer_uid UUID := auth.uid();
+  v_kill_log_id UUID;
+  v_sd_cancelled INT := 0;  -- SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001
+BEGIN
+  -- A-1: Role check via canonical helper (chairman/admin/owner accepted)
+  IF NOT public.fn_is_chairman() THEN
+    RAISE EXCEPTION 'Only chairman or lead can reject a venture'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Length check (matches CHECK on table; defense-in-depth; cleaner error)
+  IF length(p_rationale) < 20 THEN
+    RAISE EXCEPTION 'Rationale must be at least 20 characters (got %)', length(p_rationale)
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- A-3 + A-8 step 1: dual-state UPDATE on ventures
+  UPDATE public.ventures
+  SET
+    status = 'cancelled',
+    workflow_status = 'killed',
+    killed_at = now(),
+    kill_reason = p_rationale,
+    updated_at = now()
+  WHERE id = p_venture_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Venture % not found', p_venture_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001: cancel the venture's NON-TERMINAL
+  -- strategic directives so a killed venture no longer leaves orphaned active SDs.
+  UPDATE public.strategic_directives_v2
+  SET
+    status = 'cancelled',
+    cancellation_reason = p_rationale,
+    metadata = COALESCE(metadata, '{}'::jsonb)
+               || jsonb_build_object('cancelled_due_to_venture', p_venture_id, 'cancelled_at', now()),
+    updated_at = now()
+  WHERE venture_id = p_venture_id
+    AND status NOT IN ('completed', 'cancelled');
+  GET DIAGNOSTICS v_sd_cancelled = ROW_COUNT;
+
+  -- A-8 step 2: INSERT ventures_kill_log audit row
+  INSERT INTO public.ventures_kill_log (venture_id, killed_by_user_id, rationale, metadata)
+  VALUES (p_venture_id, v_killer_uid, p_rationale,
+          jsonb_build_object('strategic_directives_cancelled', v_sd_cancelled))
+  RETURNING id INTO v_kill_log_id;
+
+  -- A-8 step 3 + A-2: emit eva_events row
+  INSERT INTO public.eva_events (event_type, event_source, event_data, eva_venture_id)
+  VALUES (
+    'status_change',
+    'kill_venture_rpc',
+    jsonb_build_object(
+      'type', 'venture.killed',
+      'venture_id', p_venture_id,
+      'killed_by_user_id', v_killer_uid,
+      'rationale', p_rationale,
+      'killed_at', now(),
+      'kill_log_id', v_kill_log_id,
+      'strategic_directives_cancelled', v_sd_cancelled
+    ),
+    p_venture_id
+  );
+
+  -- A-8 step 4 + A-5: operations_audit_log governance trail
+  INSERT INTO public.operations_audit_log (entity_type, entity_id, action, performed_by, severity, metadata)
+  VALUES (
+    'venture',
+    p_venture_id::text,
+    'kill',
+    v_killer_uid,
+    'warning',
+    jsonb_build_object(
+      'rationale', p_rationale,
+      'kill_log_id', v_kill_log_id,
+      'strategic_directives_cancelled', v_sd_cancelled,
+      'sd_id', '5474573f-3fd9-43e5-8c9e-4584a0cedfdc'
+    )
+  );
+
+  RETURN v_kill_log_id;
+END;
+$function$;
+
+-- ── delete_venture: cancel non-terminal SDs BEFORE the existing venture_id=NULL ──
+CREATE OR REPLACE FUNCTION public.delete_venture(p_venture_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_name TEXT;
+  v_deleted_counts JSONB := '{}'::JSONB;
+  v_count INT;
+BEGIN
+  SELECT name INTO v_name FROM ventures WHERE id = p_venture_id;
+  IF v_name IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found');
+  END IF;
+  DELETE FROM chairman_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_decisions', v_count);
+  DELETE FROM chairman_directives WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_directives', v_count);
+  DELETE FROM governance_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('governance_decisions', v_count);
+  DELETE FROM compliance_gate_events WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('compliance_gate_events', v_count);
+  DELETE FROM risk_escalation_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_escalation_log', v_count);
+  DELETE FROM risk_gate_passage_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_gate_passage_log', v_count);
+
+  -- SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001: cancel NON-TERMINAL linked SDs BEFORE
+  -- the existing venture_id=NULL orphaning, so deletion leaves a cancellation audit
+  -- trail instead of silently orphaning active SDs. completed/cancelled SDs untouched.
+  UPDATE strategic_directives_v2
+  SET status = 'cancelled',
+      cancellation_reason = 'Cancelled by venture deletion (' || v_name || ')',
+      metadata = COALESCE(metadata, '{}'::jsonb)
+                 || jsonb_build_object('cancelled_due_to_venture', p_venture_id, 'cancelled_at', now()),
+      updated_at = now()
+  WHERE venture_id = p_venture_id
+    AND status NOT IN ('completed', 'cancelled');
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('strategic_directives_cancelled', v_count);
+
+  UPDATE strategic_directives_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_phase_handoffs SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_proposals SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE product_requirements_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE venture_dependencies SET dependent_venture_id = NULL WHERE dependent_venture_id = p_venture_id;
+  UPDATE venture_dependencies SET provider_venture_id = NULL WHERE provider_venture_id = p_venture_id;
+  UPDATE venture_capabilities SET origin_venture_id = NULL WHERE origin_venture_id = p_venture_id;
+  UPDATE venture_templates SET source_venture_id = NULL WHERE source_venture_id = p_venture_id;
+  UPDATE venture_nursery SET promoted_to_venture_id = NULL WHERE promoted_to_venture_id = p_venture_id;
+  UPDATE agent_registry SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE ventures SET
+    brief_id = NULL,
+    vision_id = NULL,
+    architecture_plan_id = NULL,
+    ceo_agent_id = NULL,
+    portfolio_id = NULL,
+    company_id = NULL,
+    source_blueprint_id = NULL
+  WHERE id = p_venture_id;
+  DELETE FROM ventures WHERE id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  IF v_count = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture delete returned 0 rows');
+  END IF;
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_name,
+    'deleted_counts', v_deleted_counts
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'detail', SQLSTATE
+  );
+END;
+$function$;

--- a/tests/integration/venture-sd-cascade.test.js
+++ b/tests/integration/venture-sd-cascade.test.js
@@ -1,0 +1,84 @@
+/**
+ * Integration test: venture delete/kill -> strategic-directive cancellation cascade.
+ * SD: SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001 / FR-A + FR-D
+ *
+ * Verifies the migration 20260528113000_chairman_venture_delete_cancel_sd_cascade.sql:
+ * delete_venture (and the identical block in kill_venture) cancels a venture's
+ * NON-TERMINAL strategic directives, leaves completed SDs untouched, records a
+ * reason + metadata.cancelled_due_to_venture, and is idempotent.
+ *
+ * LIVE-gated: runs only when SUPABASE_POOLER_URL is set (a direct Postgres
+ * connection). Hermetic-by-default — skips cleanly in CI without a pooler.
+ * All work happens inside a transaction that is ALWAYS rolled back, so no data
+ * is persisted; session_replication_role=replica disables the company-access
+ * trigger for the throwaway inserts.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'crypto';
+
+const LIVE = !!process.env.SUPABASE_POOLER_URL;
+
+describe.skipIf(!LIVE)('venture delete -> SD cancellation cascade (LIVE)', () => {
+  let pg, client;
+
+  beforeAll(async () => {
+    pg = (await import('pg')).default;
+    client = new pg.Client({ connectionString: process.env.SUPABASE_POOLER_URL, ssl: { rejectUnauthorized: false } });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  it('cancels non-terminal SDs, preserves completed SDs, sets reason+metadata, idempotent', async () => {
+    const vid = randomUUID();
+    const sdDraft = randomUUID(), sdInprog = randomUUID(), sdDone = randomUUID();
+    const mkId = (s) => 'SD-TEST-CASCADE-' + s.slice(0, 8);
+    try {
+      await client.query('BEGIN');
+      await client.query("SET LOCAL session_replication_role = 'replica'");
+      await client.query(
+        "INSERT INTO ventures (id, name, problem_statement, status) VALUES ($1,$2,$3,'active')",
+        [vid, 'TEST Cascade Venture', 'test problem statement for cascade verification']
+      );
+      const insSD = async (uuid, status) => {
+        const idv = mkId(uuid);
+        await client.query(
+          `INSERT INTO strategic_directives_v2
+            (id, uuid_internal_pk, sd_key, sd_code_user_facing, title, description, rationale, scope, category, priority, sequence_rank, status, venture_id)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+          [idv, uuid, idv, idv, 'TEST SD ' + status, 'desc', 'rationale', 'scope', 'feature', 'low', 9999, status, vid]
+        );
+      };
+      await insSD(sdDraft, 'draft');
+      await insSD(sdInprog, 'in_progress');
+      await insSD(sdDone, 'completed');
+
+      const res = await client.query('SELECT delete_venture($1) AS r', [vid]);
+      const r = res.rows[0].r;
+      expect(r.success).toBe(true);
+      expect(r.deleted_counts.strategic_directives_cancelled).toBe(2);
+
+      const rows = await client.query(
+        'SELECT uuid_internal_pk, status, cancellation_reason, metadata FROM strategic_directives_v2 WHERE uuid_internal_pk = ANY($1)',
+        [[sdDraft, sdInprog, sdDone]]
+      );
+      const byId = Object.fromEntries(rows.rows.map((x) => [x.uuid_internal_pk, x]));
+      expect(byId[sdDraft].status).toBe('cancelled');
+      expect(byId[sdInprog].status).toBe('cancelled');
+      expect(byId[sdDone].status).toBe('completed');
+      expect(byId[sdDraft].cancellation_reason).toContain('venture deletion');
+      expect(byId[sdDraft].metadata.cancelled_due_to_venture).toBe(vid);
+      expect(byId[sdDone].cancellation_reason).toBeNull();
+
+      const again = await client.query(
+        "UPDATE strategic_directives_v2 SET status='cancelled' WHERE uuid_internal_pk = ANY($1) AND status NOT IN ('completed','cancelled')",
+        [[sdDraft, sdInprog, sdDone]]
+      );
+      expect(again.rowCount).toBe(0);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Backend half of the cross-repo SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001 (UI PR in rickfelix/ehg).

- Extend `kill_venture` and `delete_venture` RPCs to cancel a venture's **non-terminal** strategic directives (`status NOT IN (completed,cancelled)` → `cancelled` + `cancellation_reason` + `metadata.cancelled_due_to_venture`) instead of orphaning them.
- `delete_venture` cancels **before** its existing `venture_id=NULL` step; `kill_venture` cancels after the venture status update. Additive, in-transaction, idempotent; completed SDs untouched.
- Fixes silent SD orphaning: today `delete_venture` sets `venture_id=NULL` while leaving status active (16 non-terminal SDs across 16 ventures exposed).

## Test plan
- [x] LIVE-gated rollback-txn integration test (`tests/integration/venture-sd-cascade.test.js`): 2 non-terminal SDs cancelled, completed untouched, `strategic_directives_cancelled=2`, idempotent. Passes.
- [x] DATABASE sub-agent verified live byte-for-byte; all 48 `strategic_directives_v2` triggers analyzed (`trg_require_cancellation_reason` satisfied).
- [x] delete_venture's 4 existing callers (full-delete, bulk, master-reset, deleteVentureFully) unaffected (additive + return shape preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)