### PR TITLE
fix(QF-20260528-581): dedup callsign collisions + filter ghost sessions in fleet identity

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -22,6 +22,78 @@ function filterOutCoordinators(rows) {
   return (rows || []).filter(w => w && w.metadata?.is_coordinator !== true);
 }
 
+// QF-20260528-581 (Bug B): filter out test/ghost sessions that consume the clean
+// NATO letter pool and churn real workers into overflow suffixes (Alpha-9 etc.).
+//
+// Mirrors the canonical coordinator "active worker" cohort used by the dashboard
+// and coaching loop:
+//   scripts/fleet-dashboard.cjs:150-153  — claude_sessions WHERE sd_key IS NOT NULL
+//   scripts/fleet-coaching.cjs:308-312   — claude_sessions WHERE sd_key IS NOT NULL
+// Those count a real worker as one that holds (or has held) an SD claim. A genuine
+// ghost (drain_test_*, test_execute_*, never-claimed) has sd_key=null AND is absent
+// from that cohort. We keep workers momentarily BETWEEN SDs (sd_key null) by also
+// accepting any session in `claimedSessionIds` (the dashboard cohort, passed in by
+// main()) or one that already carries a fleet_identity (only ever assigned by this
+// script to a real worker). claimed_at is NOT usable here: release_sd() nulls it
+// (database/migrations/...consolidate_sd_claims..., release_sd RPC), so a released
+// worker looks identical to a never-claimed ghost on that column alone.
+//
+// `claimedSessionIds` — Set of session_ids that currently hold an SD claim (kept
+// DB-free so this stays a pure, unit-testable function). Pass an empty Set to rely
+// on per-row signals (sd_key / fleet_identity) only.
+const GHOST_SESSION_ID_PREFIXES = ['drain_test_', 'test_execute_', 'test-session-', 'test_session_'];
+
+function isTestSessionId(sessionId) {
+  if (!sessionId || typeof sessionId !== 'string') return false;
+  return GHOST_SESSION_ID_PREFIXES.some(p => sessionId.startsWith(p));
+}
+
+function filterOutGhostSessions(rows, claimedSessionIds = new Set()) {
+  const claimed = claimedSessionIds instanceof Set ? claimedSessionIds : new Set(claimedSessionIds || []);
+  return (rows || []).filter(w => {
+    if (!w) return false;
+    // Genuine test/ghost session_ids never get a callsign, even if otherwise active.
+    if (isTestSessionId(w.session_id)) return false;
+    // Currently claiming an SD → real worker.
+    if (w.sd_key) return true;
+    // Between SDs but in the canonical claim cohort → real worker, momentarily idle.
+    if (claimed.has(w.session_id)) return true;
+    // Already assigned a fleet identity by this script → was a real worker.
+    if (w.metadata?.fleet_identity?.callsign) return true;
+    // Otherwise: never claimed, no identity → genuine ghost, drop it.
+    return false;
+  });
+}
+
+// QF-20260528-581 (Bug A): collision dedup for ALREADY-assigned workers.
+// After session_id rotation two assigned rows can share the SAME callsign (observed:
+// "Alpha" on two sessions). `assigned` arrives heartbeat-DESC (most recent first), so
+// the FIRST occurrence of a callsign is the most-recent heartbeat and is KEPT; later
+// duplicates are demoted for reassignment to the next free callsign.
+// Returns { kept: [...], demoted: [...] } — main() keeps `kept` as assigned and pushes
+// `demoted` into needsAssignment. Pure + DB-free for unit testing.
+function dedupeAssignedCallsigns(assigned) {
+  const seenCallsigns = new Set();
+  const kept = [];
+  const demoted = [];
+  for (const w of assigned || []) {
+    if (!w) continue;
+    const callsign = w.metadata?.fleet_identity?.callsign;
+    if (!callsign) {
+      // No callsign — not really "assigned"; treat as needing assignment.
+      demoted.push(w);
+      continue;
+    }
+    if (seenCallsigns.has(callsign)) {
+      demoted.push(w);
+    } else {
+      seenCallsigns.add(callsign);
+      kept.push(w);
+    }
+  }
+  return { kept, demoted };
+}
+
 const ANSI = {
   red: '\x1b[31m', blue: '\x1b[34m', green: '\x1b[32m', yellow: '\x1b[33m',
   purple: '\x1b[35m', orange: '\x1b[38;5;208m', pink: '\x1b[38;5;213m', cyan: '\x1b[36m',
@@ -73,7 +145,16 @@ async function main() {
     process.exit(1);
   }
 
-  const workers = filterOutCoordinators(rawWorkers);
+  const nonCoordinators = filterOutCoordinators(rawWorkers);
+
+  // QF-20260528-581 (Bug B): drop test/ghost sessions before they consume the NATO pool.
+  // claimedSessionIds = the canonical "currently claiming" cohort (mirrors the dashboard's
+  // claude_sessions WHERE sd_key IS NOT NULL). Built from the rows we already have — no
+  // extra DB round-trip. Workers between SDs are retained via fleet_identity (see fn doc).
+  const claimedSessionIds = new Set(
+    (rawWorkers || []).filter(w => w && w.sd_key).map(w => w.session_id)
+  );
+  const workers = filterOutGhostSessions(nonCoordinators, claimedSessionIds);
 
   if (!workers || workers.length === 0) {
     console.log('No active workers found.');
@@ -107,19 +188,32 @@ async function main() {
   }
 
   // Separate workers into already-assigned and new
-  const assigned = [];
+  const assignedRaw = [];
   const needsAssignment = [];
 
   for (const worker of uniqueWorkers) {
     const identity = worker.metadata?.fleet_identity;
     if (identity?.callsign && identity?.color && !forceReassign) {
-      assigned.push(worker);
+      assignedRaw.push(worker);
     } else {
       needsAssignment.push(worker);
     }
   }
 
-  // Collect already-used callsigns and colors
+  // QF-20260528-581 (Bug A): resolve duplicate callsigns within the assigned set
+  // (e.g. "Alpha" on two sessions after session_id rotation). Keep the most-recent
+  // heartbeat (assignedRaw is heartbeat-DESC → first occurrence wins); demote the
+  // losers into needsAssignment so they get the next free callsign.
+  const { kept: assigned, demoted } = dedupeAssignedCallsigns(assignedRaw);
+  for (const w of demoted) {
+    const dupCallsign = w.metadata?.fleet_identity?.callsign;
+    const dupCount = assignedRaw.filter(a => a.metadata?.fleet_identity?.callsign === dupCallsign).length;
+    console.log(`${ANSI.dim}↻ collision: ${dupCallsign} was on ${dupCount} sessions, reassigning ${w.session_id.substring(0, 12)}...${ANSI.reset}`);
+    needsAssignment.push(w);
+  }
+
+  // Collect already-used callsigns and colors — from the deduped `kept` set only,
+  // so a demoted duplicate's callsign/color is free for reassignment.
   const usedCallsigns = new Set(assigned.map(w => w.metadata.fleet_identity.callsign));
   const usedColors = new Set(assigned.map(w => w.metadata.fleet_identity.color));
 
@@ -259,7 +353,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -9,7 +9,12 @@ import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { filterOutCoordinators } = require('../../scripts/assign-fleet-identities.cjs');
+const {
+  filterOutCoordinators,
+  filterOutGhostSessions,
+  isTestSessionId,
+  dedupeAssignedCallsigns
+} = require('../../scripts/assign-fleet-identities.cjs');
 
 describe('filterOutCoordinators (QF-20260508-648)', () => {
   it('excludes a coordinator row (metadata.is_coordinator=true)', () => {
@@ -59,5 +64,157 @@ describe('filterOutCoordinators (QF-20260508-648)', () => {
   it('safely handles rows with null entries (does not throw on optional chain)', () => {
     const rows = [null, undefined, { session_id: 'worker-1' }];
     expect(filterOutCoordinators(rows).map(r => r.session_id)).toEqual(['worker-1']);
+  });
+});
+
+// QF-20260528-581 (Bug B): filter test/ghost sessions that consume the NATO pool.
+// Mirrors the dashboard/coaching "active worker" cohort (sd_key IS NOT NULL),
+// while retaining real workers momentarily between SDs.
+describe('filterOutGhostSessions (QF-20260528-581 / Bug B)', () => {
+  it('drops drain_test_* and test_execute_* ghost session_ids', () => {
+    const rows = [
+      { session_id: 'drain_test_123', sd_key: 'SD-A' },          // ghost despite sd_key
+      { session_id: 'test_execute_stop_999', sd_key: 'SD-B' },   // ghost despite sd_key
+      { session_id: 'real-worker-1', sd_key: 'SD-C' }
+    ];
+    const out = filterOutGhostSessions(rows, new Set(['real-worker-1']));
+    expect(out.map(r => r.session_id)).toEqual(['real-worker-1']);
+  });
+
+  it('drops test-session-* / test_session_* prefixes', () => {
+    const rows = [
+      { session_id: 'test-session-A', sd_key: 'SD-A' },
+      { session_id: 'test_session_B', sd_key: 'SD-B' },
+      { session_id: 'worker-keep', sd_key: 'SD-C' }
+    ];
+    expect(filterOutGhostSessions(rows).map(r => r.session_id)).toEqual(['worker-keep']);
+  });
+
+  it('drops never-claimed sessions (no sd_key, not in claimed set, no fleet_identity)', () => {
+    const rows = [
+      { session_id: 'ghost-never-claimed' },                                  // drop
+      { session_id: 'worker-claiming', sd_key: 'SD-A' }                       // keep
+    ];
+    const out = filterOutGhostSessions(rows, new Set(['worker-claiming']));
+    expect(out.map(r => r.session_id)).toEqual(['worker-claiming']);
+  });
+
+  it('KEEPS a real worker between SDs (null sd_key) that is in the claimed cohort', () => {
+    const rows = [
+      { session_id: 'between-sds', sd_key: null }   // momentarily idle, but currently-claimed cohort
+    ];
+    const out = filterOutGhostSessions(rows, new Set(['between-sds']));
+    expect(out.map(r => r.session_id)).toEqual(['between-sds']);
+  });
+
+  it('KEEPS a real worker between SDs that already has a fleet_identity (claimed before)', () => {
+    const rows = [
+      { session_id: 'prev-worker', sd_key: null, metadata: { fleet_identity: { callsign: 'Bravo' } } }
+    ];
+    // Empty claimed set — relies on the fleet_identity signal alone.
+    const out = filterOutGhostSessions(rows, new Set());
+    expect(out.map(r => r.session_id)).toEqual(['prev-worker']);
+  });
+
+  it('keeps normal active workers and drops ghosts in a mixed roster', () => {
+    const rows = [
+      { session_id: 'worker-a', sd_key: 'SD-1' },
+      { session_id: 'drain_test_x', sd_key: 'SD-2' },
+      { session_id: 'ghost-idle' },                                               // never claimed → drop
+      { session_id: 'worker-b-idle', sd_key: null, metadata: { fleet_identity: { callsign: 'Echo' } } },
+      { session_id: 'worker-c', sd_key: 'SD-3' }
+    ];
+    const out = filterOutGhostSessions(rows, new Set(['worker-a', 'worker-c']));
+    expect(out.map(r => r.session_id)).toEqual(['worker-a', 'worker-b-idle', 'worker-c']);
+  });
+
+  it('accepts a plain array for claimedSessionIds (not just a Set)', () => {
+    const rows = [{ session_id: 'between', sd_key: null }];
+    expect(filterOutGhostSessions(rows, ['between']).map(r => r.session_id)).toEqual(['between']);
+  });
+
+  it('handles null/undefined/empty input without throwing', () => {
+    expect(filterOutGhostSessions(null)).toEqual([]);
+    expect(filterOutGhostSessions(undefined)).toEqual([]);
+    expect(filterOutGhostSessions([])).toEqual([]);
+    expect(filterOutGhostSessions([null, undefined])).toEqual([]);
+  });
+
+  it('isTestSessionId recognizes ghost prefixes and not real ids', () => {
+    expect(isTestSessionId('drain_test_1')).toBe(true);
+    expect(isTestSessionId('test_execute_team_factory_1')).toBe(true);
+    expect(isTestSessionId('test-session-abc')).toBe(true);
+    expect(isTestSessionId('test_session_x')).toBe(true);
+    expect(isTestSessionId('win-cc-1234')).toBe(false);
+    expect(isTestSessionId(null)).toBe(false);
+    expect(isTestSessionId(undefined)).toBe(false);
+  });
+});
+
+// QF-20260528-581 (Bug A): dedup duplicate callsigns within the already-assigned set.
+// Input is heartbeat-DESC (most recent first) → first occurrence of a callsign wins.
+describe('dedupeAssignedCallsigns (QF-20260528-581 / Bug A)', () => {
+  const mk = (id, callsign, color = 'blue') => ({
+    session_id: id,
+    metadata: { fleet_identity: { callsign, color } }
+  });
+
+  it('two workers share a callsign → keeps the most-recent (first) and demotes the other', () => {
+    const assigned = [
+      mk('sess-newer', 'Alpha'),  // heartbeat-DESC: most recent first → kept
+      mk('sess-older', 'Alpha')   // duplicate → demoted
+    ];
+    const { kept, demoted } = dedupeAssignedCallsigns(assigned);
+    expect(kept.map(w => w.session_id)).toEqual(['sess-newer']);
+    expect(demoted.map(w => w.session_id)).toEqual(['sess-older']);
+  });
+
+  it('no collision → all kept, none demoted', () => {
+    const assigned = [mk('s1', 'Alpha'), mk('s2', 'Bravo'), mk('s3', 'Charlie')];
+    const { kept, demoted } = dedupeAssignedCallsigns(assigned);
+    expect(kept.map(w => w.session_id)).toEqual(['s1', 's2', 's3']);
+    expect(demoted).toEqual([]);
+  });
+
+  it('3-way collision on the same callsign → 1 kept, 2 demoted', () => {
+    const assigned = [
+      mk('s-newest', 'Alpha'),
+      mk('s-mid', 'Alpha'),
+      mk('s-oldest', 'Alpha')
+    ];
+    const { kept, demoted } = dedupeAssignedCallsigns(assigned);
+    expect(kept.map(w => w.session_id)).toEqual(['s-newest']);
+    expect(demoted.map(w => w.session_id)).toEqual(['s-mid', 's-oldest']);
+  });
+
+  it('multiple distinct collisions resolved independently', () => {
+    const assigned = [
+      mk('a1', 'Alpha'), mk('b1', 'Bravo'),
+      mk('a2', 'Alpha'), mk('b2', 'Bravo'),
+      mk('c1', 'Charlie')
+    ];
+    const { kept, demoted } = dedupeAssignedCallsigns(assigned);
+    expect(kept.map(w => w.session_id)).toEqual(['a1', 'b1', 'c1']);
+    expect(demoted.map(w => w.session_id)).toEqual(['a2', 'b2']);
+  });
+
+  it('rows without a callsign are demoted (treated as needing assignment)', () => {
+    const assigned = [
+      mk('s1', 'Alpha'),
+      { session_id: 's2', metadata: {} },        // no fleet_identity
+      { session_id: 's3', metadata: { fleet_identity: {} } } // identity but no callsign
+    ];
+    const { kept, demoted } = dedupeAssignedCallsigns(assigned);
+    expect(kept.map(w => w.session_id)).toEqual(['s1']);
+    expect(demoted.map(w => w.session_id)).toEqual(['s2', 's3']);
+  });
+
+  it('handles null/undefined/empty input and null entries without throwing', () => {
+    expect(dedupeAssignedCallsigns(null)).toEqual({ kept: [], demoted: [] });
+    expect(dedupeAssignedCallsigns(undefined)).toEqual({ kept: [], demoted: [] });
+    expect(dedupeAssignedCallsigns([])).toEqual({ kept: [], demoted: [] });
+    const { kept, demoted } = dedupeAssignedCallsigns([null, mk('s1', 'Alpha'), undefined]);
+    expect(kept.map(w => w.session_id)).toEqual(['s1']);
+    expect(demoted).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Two related fleet-identity bugs in `scripts/assign-fleet-identities.cjs`:

- **d88b0a7b** — no dedup of callsign collisions among already-assigned workers; after session_id rotation the same callsign (e.g. Alpha) persisted on two sessions. New exported `dedupeAssignedCallsigns(assigned)` keeps the most-recent-heartbeat holder and demotes duplicates for reassignment.
- **539ecfb9** — test/ghost sessions (`drain_test_*`, `test_execute_*`, never-claimed) consumed the clean NATO pool and churned real workers into overflow suffixes. New exported `filterOutGhostSessions(rows, claimedSessionIds)` mirrors the dashboard's active-worker cohort (`claude_sessions WHERE sd_key IS NOT NULL`, per `fleet-dashboard.cjs:150` / `fleet-coaching.cjs:308`), keeping between-SDs workers via the claimed cohort + existing `fleet_identity`.

Both extracted as pure, exported functions for unit testing. Resolves harness-backlog `d88b0a7b` and `539ecfb9`.

## Test plan
- [x] 21 unit tests pass (6 pre-existing + 9 ghost-filter/isTestSessionId + 6 dedup), incl. keep-between-SDs-worker and 3-way-collision cases
- [x] `claimed_at` deliberately not used (release_sd nulls it; claim-history table consolidated away) — documented in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)