### PR TITLE
feat(SD-FDBK-INFRA-LEO-CREATE-PLAN-001): --from-plan extractors + front-matter target_application

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -902,6 +902,17 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     mitigation: r.mitigation || 'Address during implementation'
   }));
 
+  // SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-2): build the four newly-extractable fields
+  // from parsed.* and pass them through createOptions. Each is null when the plan omitted
+  // the section, so createSD's fallthrough applies buildDefault*/inline-default (and warns,
+  // FR-4) — preserving current behavior for plans that lack these sections.
+  // success_metrics + smoke_test_steps are gate-relevant (SUCCESS_METRICS_PLACEHOLDER_VALUE /
+  // SMOKE_TEST_SPECIFICATION); key_principles + scope are non-gating enrichment.
+  const successMetrics = (parsed.successMetrics ?? []);
+  const smokeTestSteps = (parsed.smokeTestSteps ?? []);
+  const keyPrinciples = (parsed.keyPrinciples ?? []);
+  const planScope = parsed.planScope || null;
+
   // QF-20260509-LEO-CREATE-PLAN-DUP-GUARD (closes feedback 082b421c).
   // Compute SHA256 of the (whitespace-normalized) plan content. We use the
   // hash for both (i) provenance metadata and (ii) the duplicate-detection
@@ -924,8 +935,15 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
     strategic_objectives: strategicObjectives.length > 0 ? strategicObjectives : null,
     // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-3): pass scope and key_changes through createOptions
     // so createSD INSERTs them atomically — no UPDATE-after-INSERT race, and detector at the buildDefault* call site sees rich content.
-    scope: scope || null,
+    // SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-2): an explicit `## Scope` section wins over the
+    // file-table/summary-derived scope; falls back to the prior value when the plan omits it.
+    scope: planScope || scope || null,
     key_changes: keyChanges.length > 0 ? keyChanges : null,
+    // SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-2): newly-extractable fields — null when absent so
+    // createSD applies buildDefault*/inline-default and emits the FR-4 section-named warning.
+    success_metrics: successMetrics.length > 0 ? successMetrics : null,
+    smoke_test_steps: smokeTestSteps.length > 0 ? smokeTestSteps : null,
+    key_principles: keyPrinciples.length > 0 ? keyPrinciples : null,
     metadata: {
       source: 'plan',
       plan_content: parsed.fullContent,
@@ -1461,6 +1479,25 @@ async function createSD(options) {
     // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-2): three-step fallback so detector sees scope from BOTH caller paths
     // (plan-file passes options.scope after FR-3 atomic-INSERT refactor; /leo create stores it in options.metadata.scope).
     : buildDefaultSmokeTestSteps(type, title, options.scope ?? options.metadata?.scope ?? description);
+
+  // SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-4): when a --from-plan SD falls back to a
+  // buildDefault*() generic for a gate-relevant field, surface the gap at creation time
+  // (naming the field and the plan section it expected) instead of letting a placeholder
+  // slip through to a downstream handoff gate. Non-blocking; creation continues. Only
+  // fires for plan-sourced SDs — interactive /leo create and inherited child SDs use
+  // defaults intentionally. No warning is emitted when the field was extracted from the plan.
+  if (metadata?.source === 'plan') {
+    const extractedSuccessMetrics = Array.isArray(success_metrics) && success_metrics.length > 0;
+    const extractedSmokeTestSteps = Array.isArray(smoke_test_steps) && smoke_test_steps.length > 0;
+    if (!extractedSuccessMetrics) {
+      process.stderr.write('⚠️  --from-plan: success_metrics not found in plan; using generic default. Add a "## Success Metrics" section to avoid placeholder gate failures.\n');
+    }
+    // buildDefaultSmokeTestSteps returns [] for lightweight types (no placeholder substituted),
+    // so only warn when a default was actually produced.
+    if (!extractedSmokeTestSteps && Array.isArray(finalSmokeTestSteps) && finalSmokeTestSteps.length > 0) {
+      process.stderr.write('⚠️  --from-plan: smoke_test_steps not found in plan; using generic default. Add a "## Smoke Test Steps" section to avoid placeholder gate failures.\n');
+    }
+  }
 
   // ========================================================================
   // GOVERNANCE GUARDRAILS (SD-MAN-FEAT-CORRECTIVE-VISION-GAP-007)

--- a/scripts/modules/plan-parser.js
+++ b/scripts/modules/plan-parser.js
@@ -229,15 +229,35 @@ export function extractExplicitType(content) {
  * Closes feedback row 7f0a4f54 — autodetect was falling through to
  * detectFromKeyChanges even when the plan literally said the target.
  *
+ * SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-3): Also reads HTML-comment front-matter of the
+ * form `<!-- ... target_application: VALUE ... -->` (front-matter is typically a
+ * top-of-file HTML comment containing several `key: value` pairs). The `## Target
+ * Application` H2 header keeps PRECEDENCE — when both are present the H2 value wins, so
+ * plans that work today produce byte-identical output. Front-matter is an additive
+ * secondary source consulted only when the H2 header is absent.
+ *
  * @param {string} content - Plan file content
  * @returns {string|null} Header value (preserved case) or null
  */
 export function extractExplicitTargetApplication(content) {
   if (!content) return null;
-  const match = content.match(/^##\s+Target\s+Application\s*\n+\s*([A-Za-z][A-Za-z0-9_.-]*)/m);
-  if (!match) return null;
-  const value = match[1].trim();
-  return value || null;
+  // Primary source: explicit `## Target Application` H2 header (keeps precedence).
+  const headerMatch = content.match(/^##\s+Target\s+Application\s*\n+\s*([A-Za-z][A-Za-z0-9_.-]*)/m);
+  if (headerMatch) {
+    const value = headerMatch[1].trim();
+    if (value) return value;
+  }
+  // Additive secondary source: `target_application: VALUE` inside an HTML comment.
+  // Only consulted when the H2 header is absent, so existing plans are unaffected.
+  const frontMatterBlock = content.match(/<!--([\s\S]*?)-->/);
+  if (frontMatterBlock) {
+    const fmMatch = frontMatterBlock[1].match(/target_application\s*:\s*([A-Za-z][A-Za-z0-9_.-]*)/i);
+    if (fmMatch) {
+      const value = fmMatch[1].trim();
+      if (value) return value;
+    }
+  }
+  return null;
 }
 
 /** Canonical priority values accepted by strategic_directives_v2. */
@@ -415,6 +435,128 @@ export function extractSuccessCriteria(content) {
 }
 
 /**
+ * Extract key principles from plan content.
+ *
+ * SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-1): New extractor. Parses "## Key Principles"
+ * or "## Principles" sections; bullets map to plain strings.
+ * Returns null when the section is absent so leo-create-sd.js falls back to its inline
+ * default (and surfaces the gap) rather than emitting a placeholder here.
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<string>|null} Array of principle strings, or null when absent
+ */
+export function extractKeyPrinciples(content) {
+  if (!content) return null;
+
+  const sectionPattern = /^##\s+(Key Principles|Principles|Guiding Principles)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
+  const match = content.match(sectionPattern);
+
+  if (!match) return null;
+
+  const principles = [];
+  const sectionContent = match[2];
+  const bulletPattern = /^[-*]\s+(.+)$/gm;
+  let bulletMatch;
+  while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+    principles.push(bulletMatch[1].trim());
+  }
+
+  return principles.slice(0, 10);
+}
+
+/**
+ * Extract smoke test steps from plan content.
+ *
+ * SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-1): New extractor. Parses "## Smoke Test"
+ * or "## Smoke Test Steps" sections; bullets map to {step_number, instruction, expected_outcome}
+ * objects shaped to match buildDefaultSmokeTestSteps so the SMOKE_TEST_SPECIFICATION gate accepts them.
+ * Returns null when the section is absent so leo-create-sd.js falls back to buildDefaultSmokeTestSteps
+ * (and warns) rather than emitting a placeholder here.
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{step_number: number, instruction: string, expected_outcome: string}>|null} Array of steps, or null when absent
+ */
+export function extractSmokeTestSteps(content) {
+  if (!content) return null;
+
+  const sectionPattern = /^##\s+(Smoke Test Steps|Smoke Tests|Smoke Test)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
+  const match = content.match(sectionPattern);
+
+  if (!match) return null;
+
+  const steps = [];
+  const sectionContent = match[2];
+  const bulletPattern = /^[-*]\s+(.+)$/gm;
+  let bulletMatch;
+  while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+    steps.push({
+      step_number: steps.length + 1,
+      instruction: bulletMatch[1].trim(),
+      expected_outcome: 'See plan for details'
+    });
+  }
+
+  return steps.slice(0, 10);
+}
+
+/**
+ * Extract success metrics from plan content.
+ *
+ * SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-1): New extractor. Parses "## Success Metrics"
+ * or "## Metrics" sections; bullets map to {metric, target} objects shaped to match
+ * buildDefaultSuccessMetrics so the SUCCESS_METRICS_PLACEHOLDER_VALUE gate accepts them.
+ * Returns null when the section is absent so leo-create-sd.js falls back to
+ * buildDefaultSuccessMetrics (and warns) rather than emitting a placeholder here.
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{metric: string, target: string}>|null} Array of metrics, or null when absent
+ */
+export function extractSuccessMetrics(content) {
+  if (!content) return null;
+
+  const sectionPattern = /^##\s+(Success Metrics|Metrics|Key Metrics)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
+  const match = content.match(sectionPattern);
+
+  if (!match) return null;
+
+  const metrics = [];
+  const sectionContent = match[2];
+  const bulletPattern = /^[-*]\s+(.+)$/gm;
+  let bulletMatch;
+  while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+    metrics.push({
+      metric: bulletMatch[1].trim(),
+      target: 'See plan for details'
+    });
+  }
+
+  return metrics.slice(0, 10);
+}
+
+/**
+ * Extract an explicit scope description from plan content.
+ *
+ * SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-1): New extractor. Parses "## Scope" or
+ * "## In Scope" sections and returns the section body as a string (trimmed, markdown
+ * emphasis stripped). Returns null when the section is absent so leo-create-sd.js falls
+ * back to the file-table/summary-derived scope rather than emitting a placeholder here.
+ *
+ * @param {string} content - Plan file content
+ * @returns {string|null} Scope body string, or null when absent
+ */
+export function extractScope(content) {
+  if (!content) return null;
+
+  const sectionPattern = /^##\s+(Scope|In Scope|Scope of Work)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
+  const match = content.match(sectionPattern);
+
+  if (!match) return null;
+
+  const scope = match[2].trim().replace(/\*\*/g, '').replace(/\*/g, '');
+  return scope || null;
+}
+
+/**
  * Parse a complete plan file and extract all structured content
  *
  * @param {string} content - Plan file content
@@ -431,6 +573,10 @@ export function parsePlanFile(content) {
       strategicObjectives: null,
       risks: null,
       successCriteria: null,
+      keyPrinciples: null,
+      smokeTestSteps: null,
+      successMetrics: null,
+      planScope: null,
       type: 'feature',
       priority: null,
       fullContent: ''
@@ -451,6 +597,10 @@ export function parsePlanFile(content) {
     strategicObjectives: extractStrategicObjectives(content),
     risks: extractRisks(content),
     successCriteria: extractSuccessCriteria(content),
+    keyPrinciples: extractKeyPrinciples(content),
+    smokeTestSteps: extractSmokeTestSteps(content),
+    successMetrics: extractSuccessMetrics(content),
+    planScope: extractScope(content),
     type: explicitType ?? inferSDType(content),
     priority: explicitPriority,
     targetApplication: explicitTargetApplication,
@@ -505,6 +655,10 @@ export default {
   extractStrategicObjectives,
   extractRisks,
   extractSuccessCriteria,
+  extractKeyPrinciples,
+  extractSmokeTestSteps,
+  extractSuccessMetrics,
+  extractScope,
   inferSDType,
   extractExplicitType,
   extractExplicitPriority,

--- a/scripts/modules/plan-parser.test.js
+++ b/scripts/modules/plan-parser.test.js
@@ -12,6 +12,11 @@ import {
   extractStrategicObjectives,
   extractRisks,
   extractSuccessCriteria,
+  extractKeyPrinciples,
+  extractSmokeTestSteps,
+  extractSuccessMetrics,
+  extractScope,
+  extractExplicitTargetApplication,
   SUMMARY_CAP,
   EXPLICIT_TYPE_ENUM,
   EXPLICIT_PRIORITY_ENUM,
@@ -225,4 +230,175 @@ test('extractStrategicObjectives: absent section returns null (removed summary f
 test('extractRisks: absent section returns null', () => {
   const content = '## Summary\n\nNo risks section here.';
   assert.equal(extractRisks(content), null);
+});
+
+// ---------- SD-FDBK-INFRA-LEO-CREATE-PLAN-001 (FR-1, FR-3) ----------
+
+// extractKeyPrinciples (FR-1)
+
+test('extractKeyPrinciples: present with bullets returns string[]', () => {
+  const content = '## Key Principles\n- Keep it backward compatible\n- Fail fast on bad input\n';
+  assert.deepEqual(extractKeyPrinciples(content), [
+    'Keep it backward compatible',
+    'Fail fast on bad input',
+  ]);
+});
+
+test('extractKeyPrinciples: matches ## Principles alias', () => {
+  const content = '## Principles\n- One principle\n';
+  assert.deepEqual(extractKeyPrinciples(content), ['One principle']);
+});
+
+test('extractKeyPrinciples: absent section returns null (not [])', () => {
+  const content = '# Plan\n\n## Summary\n\nNo principles section here.';
+  assert.equal(extractKeyPrinciples(content), null);
+});
+
+// extractSmokeTestSteps (FR-1)
+
+test('extractSmokeTestSteps: present with bullets returns {step_number, instruction, expected_outcome}[]', () => {
+  const content = '## Smoke Test Steps\n- Run the parser on a fixture\n- Confirm null when section absent\n';
+  assert.deepEqual(extractSmokeTestSteps(content), [
+    { step_number: 1, instruction: 'Run the parser on a fixture', expected_outcome: 'See plan for details' },
+    { step_number: 2, instruction: 'Confirm null when section absent', expected_outcome: 'See plan for details' },
+  ]);
+});
+
+test('extractSmokeTestSteps: matches ## Smoke Test alias', () => {
+  const content = '## Smoke Test\n- Single step\n';
+  const out = extractSmokeTestSteps(content);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].instruction, 'Single step');
+});
+
+test('extractSmokeTestSteps: absent section returns null (not [])', () => {
+  const content = '# Plan\n\n## Summary\n\nNo smoke test section here.';
+  assert.equal(extractSmokeTestSteps(content), null);
+});
+
+// extractSuccessMetrics (FR-1)
+
+test('extractSuccessMetrics: TS-1 — present returns {metric, target}[]', () => {
+  const content = '## Success Metrics\n- Parser extracts all 4 fields\n- Zero placeholder gate failures\n';
+  assert.deepEqual(extractSuccessMetrics(content), [
+    { metric: 'Parser extracts all 4 fields', target: 'See plan for details' },
+    { metric: 'Zero placeholder gate failures', target: 'See plan for details' },
+  ]);
+});
+
+test('extractSuccessMetrics: matches ## Metrics alias', () => {
+  const content = '## Metrics\n- Latency under 100ms\n';
+  assert.deepEqual(extractSuccessMetrics(content), [
+    { metric: 'Latency under 100ms', target: 'See plan for details' },
+  ]);
+});
+
+test('extractSuccessMetrics: TS-2 — absent section returns null (not [])', () => {
+  const content = '# Plan\n\n## Summary\n\nNo success metrics section here.';
+  assert.equal(extractSuccessMetrics(content), null);
+});
+
+// extractScope (FR-1)
+
+test('extractScope: present returns trimmed body string', () => {
+  const content = '## Scope\n\nModify plan-parser.js and leo-create-sd.js only.\n\n## Next\n\nOther.';
+  assert.equal(extractScope(content), 'Modify plan-parser.js and leo-create-sd.js only.');
+});
+
+test('extractScope: strips markdown emphasis', () => {
+  const content = '## In Scope\n\n**Bold** scope text.\n';
+  assert.equal(extractScope(content), 'Bold scope text.');
+});
+
+test('extractScope: absent section returns null', () => {
+  const content = '# Plan\n\n## Summary\n\nNo scope section here.';
+  assert.equal(extractScope(content), null);
+});
+
+// TS-3: each new extractor returns parsed value when present and null when absent (composite)
+
+test('TS-3: extractScope, extractKeyPrinciples, extractSmokeTestSteps each parse-when-present / null-when-absent', () => {
+  const present = '## Scope\n\nNarrow.\n\n## Key Principles\n- P1\n\n## Smoke Test Steps\n- S1\n';
+  assert.equal(extractScope(present), 'Narrow.');
+  assert.deepEqual(extractKeyPrinciples(present), ['P1']);
+  assert.equal(extractSmokeTestSteps(present).length, 1);
+
+  const absent = '# Plan\n\n## Summary\n\nNothing else.';
+  assert.equal(extractScope(absent), null);
+  assert.equal(extractKeyPrinciples(absent), null);
+  assert.equal(extractSmokeTestSteps(absent), null);
+});
+
+// parsePlanFile integration — new fields exposed
+
+test('parsePlanFile: exposes keyPrinciples, smokeTestSteps, successMetrics, planScope', () => {
+  const content = [
+    '# Plan',
+    '## Scope',
+    'Narrow scope.',
+    '## Key Principles',
+    '- Backward compatible',
+    '## Smoke Test Steps',
+    '- Run it',
+    '## Success Metrics',
+    '- It works',
+  ].join('\n\n');
+  const parsed = parsePlanFile(content);
+  assert.equal(parsed.planScope, 'Narrow scope.');
+  assert.deepEqual(parsed.keyPrinciples, ['Backward compatible']);
+  assert.equal(parsed.smokeTestSteps[0].instruction, 'Run it');
+  assert.equal(parsed.successMetrics[0].metric, 'It works');
+});
+
+test('parsePlanFile: new fields are null when sections absent', () => {
+  const parsed = parsePlanFile('# Plan\n\n## Summary\n\nNothing.');
+  assert.equal(parsed.planScope, null);
+  assert.equal(parsed.keyPrinciples, null);
+  assert.equal(parsed.smokeTestSteps, null);
+  assert.equal(parsed.successMetrics, null);
+});
+
+test('parsePlanFile: empty content default shape includes null new fields', () => {
+  const parsed = parsePlanFile('');
+  assert.equal(parsed.keyPrinciples, null);
+  assert.equal(parsed.smokeTestSteps, null);
+  assert.equal(parsed.successMetrics, null);
+  assert.equal(parsed.planScope, null);
+});
+
+// extractExplicitTargetApplication (FR-3)
+
+test('extractExplicitTargetApplication: TS-4 — front-matter-only plan resolves from front-matter', () => {
+  const content = '<!-- Type: feature, target_application: EHG -->\n\n# Plan\n\n## Summary\n\nBody.';
+  assert.equal(extractExplicitTargetApplication(content), 'EHG');
+});
+
+test('extractExplicitTargetApplication: front-matter multi-line comment resolves', () => {
+  const content = '<!--\nType: infrastructure\ntarget_application: EHG_Engineer\n-->\n# Plan';
+  assert.equal(extractExplicitTargetApplication(content), 'EHG_Engineer');
+});
+
+test('extractExplicitTargetApplication: TS-5 — both H2 header and front-matter resolve to the H2 value (precedence)', () => {
+  const content = '<!-- target_application: EHG -->\n\n# Plan\n\n## Target Application\n\nEHG_Engineer\n\n## Summary\n\nBody.';
+  assert.equal(extractExplicitTargetApplication(content), 'EHG_Engineer');
+});
+
+test('extractExplicitTargetApplication: H2-only plan unchanged (byte-identical legacy path)', () => {
+  const content = '# Plan\n\n## Target Application\n\nEHG_Engineer (Stage 0 venture engine)\n';
+  assert.equal(extractExplicitTargetApplication(content), 'EHG_Engineer');
+});
+
+test('extractExplicitTargetApplication: TS-6 — neither present returns null (default path applies)', () => {
+  const content = '# Plan\n\n## Summary\n\nNo target signal anywhere.';
+  assert.equal(extractExplicitTargetApplication(content), null);
+});
+
+test('extractExplicitTargetApplication: HTML comment without target_application key returns null', () => {
+  const content = '<!-- Type: feature, Priority: high -->\n\n# Plan\n\n## Summary\n\nBody.';
+  assert.equal(extractExplicitTargetApplication(content), null);
+});
+
+test('extractExplicitTargetApplication: front-matter is case-insensitive on the key', () => {
+  const content = '<!-- Target_Application: EHG -->\n# Plan';
+  assert.equal(extractExplicitTargetApplication(content), 'EHG');
 });


### PR DESCRIPTION
## Summary
Fixes two `leo-create-sd --from-plan` gaps that forced manual enrichment and caused wrong target_application.

- **FR-1**: 4 new extractors in `scripts/modules/plan-parser.js` (extractKeyPrinciples, extractSmokeTestSteps, extractSuccessMetrics, extractScope), each returning `null` when the section is absent — mirroring the existing extractStrategicObjectives/extractRisks contract so they never emit placeholders (which would re-mask the SUCCESS_METRICS_PLACEHOLDER_VALUE gap).
- **FR-2**: wired into `leo-create-sd.js` so extracted values win and `buildDefault*()` runs only on null (backward compatible).
- **FR-3**: `extractExplicitTargetApplication` now also reads HTML-comment front-matter (`<!-- target_application: EHG -->`) as an additive source; the `## Target Application` H2 header keeps precedence so existing plans are byte-identical.
- **FR-4**: section-named stderr warnings when buildDefault is used, surfacing the gap at creation time instead of at a downstream gate.

## Test plan
- [x] 55 tests pass (32 pre-existing + 23 new) via `node --test scripts/modules/plan-parser.test.js`
- [x] Null-when-absent asserted for all 4 extractors; target_application precedence cases (front-matter-only, both→H2 wins, neither→default) covered
- [x] Existing-plan output byte-identical (H2 precedence preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)