### PR TITLE
fix(QF-20260528-877): GATE4 Section B reads sub-agent evidence when gate3 telemetry absent

### DIFF
--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -308,7 +308,7 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     console.log('\n[B] Value Delivered');
     console.log('-'.repeat(60));
 
-    await validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, gateResults, validation, supabase, { sdType, gate2Required });
+    await validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, gateResults, validation, supabase, { sdType, gate2Required, sdUuid: handoffLookupId });
 
     // ===================================================================
     // SECTION C: Pattern Effectiveness (25 points)
@@ -511,13 +511,23 @@ async function validateProcessAdherence(sd_id, prdData, gateResults, validation,
  * Validate Value Delivered (Section B - 35 points - CRITICAL)
  * Phase-aware: LEAD wants to see ROI and business value
  */
-async function validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, gateResults, validation, _supabase, { sdType = 'feature', gate2Required = true } = {}) {
+async function validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, gateResults, validation, supabase, { sdType = 'feature', gate2Required = true, sdUuid = null } = {}) {
   let sectionScore = 0;
   const sectionDetails = {};
 
   // SD-LEARN-FIX-ADDRESS-PAT-AUTO-083: Infrastructure SDs get higher defaults when data absent
   // Absence of gate data != poor performance; infrastructure SDs legitimately have fewer gates
   const isInfraSdType = !gate2Required; // infrastructure, documentation, fix, corrective
+
+  // Quick-fix QF-20260528-877: gate3 sub_agent_effectiveness telemetry is frequently absent/zero
+  // at gate4 time (execution_time often null/0 = falsy; details sub-object not reliably threaded
+  // into handoff metadata). When missing, fall back to sub_agent_execution_results like gate3 does
+  // so well-validated SDs are not capped at the 7/10 default. Monotonic: only RAISES B1/B2.
+  const gate3Telemetry = gateResults.gate3?.details?.sub_agent_effectiveness;
+  let evidence = null;
+  if (supabase && sdUuid && (!gate3Telemetry?.total_execution_time_ms || !gate3Telemetry?.substantial_recommendations)) {
+    evidence = await fetchSubAgentEvidence(sdUuid, supabase);
+  }
 
   // B1: Time efficiency (10 points)
   console.log('\n   [B1] Time Efficiency...');
@@ -541,6 +551,13 @@ async function validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, g
       validation.warnings.push(`[B1] Sub-agent execution took ${totalTimeMins} minutes`);
       console.log(`   ⚠️  Sub-agent execution: ${totalTimeMins} minutes (5/10)`);
     }
+  } else if (evidence?.rowCount > 0) {
+    // QF-20260528-877: evidence rows exist but timing was not recorded (execution_time null/0).
+    // The work was demonstrably done; do not penalize on unreliable timing data.
+    sectionScore += 10;
+    sectionDetails.b1_from_evidence = true;
+    sectionDetails.sub_agents_executed = evidence.rowCount;
+    console.log(`   ✅ ${evidence.rowCount} sub-agent evidence rows present - full credit (timing not recorded)`);
   } else {
     // SD-LEARN-FIX-ADDRESS-PAT-AUTO-083: Higher default for infra SDs (data absent != poor)
     const defaultScore = isInfraSdType ? 8 : 7;
@@ -557,6 +574,13 @@ async function validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, g
     sectionScore += 10;
     sectionDetails.substantial_recommendations = true;
     console.log('   ✅ Sub-agents provided substantial recommendations');
+  } else if (evidence?.hasSubstantial) {
+    // QF-20260528-877: verify substantiality directly from evidence rows using the same
+    // >500-char threshold gate3 applies, when the threaded gate3 flag is absent.
+    sectionScore += 10;
+    sectionDetails.substantial_recommendations = true;
+    sectionDetails.b2_from_evidence = true;
+    console.log('   ✅ Sub-agent recommendations substantial (verified from evidence rows)');
   } else {
     // SD-LEARN-FIX-ADDRESS-PAT-AUTO-083: Higher default for infra SDs (data absent != poor)
     const defaultScore = isInfraSdType ? 8 : 7;
@@ -593,6 +617,27 @@ async function validateValueDelivered(sd_id, designAnalysis, databaseAnalysis, g
   validation.gate_scores.value_delivered = scaledScore;
   validation.details.value_delivered = sectionDetails;
   console.log(`\n   Section B Score: ${scaledScore}/35 (CRITICAL - ROI focus)`);
+}
+
+/**
+ * QF-20260528-877: read sub-agent execution evidence directly (mirroring gate3
+ * sub-agent-effectiveness.js). Never throws — any error yields a zeroed result so Section B
+ * falls back to its existing defaults. Returns { rowCount, hasSubstantial }.
+ */
+async function fetchSubAgentEvidence(sdUuid, supabase) {
+  try {
+    const { data, error } = await supabase
+      .from('sub_agent_execution_results')
+      .select('recommendations, detailed_analysis')
+      .eq('sd_id', sdUuid);
+    if (error || !data || data.length === 0) return { rowCount: 0, hasSubstantial: false };
+    const hasSubstantial = data.some(r =>
+      JSON.stringify({ recommendations: r.recommendations, detailed_analysis: r.detailed_analysis }).length > 500
+    );
+    return { rowCount: data.length, hasSubstantial };
+  } catch {
+    return { rowCount: 0, hasSubstantial: false };
+  }
 }
 
 /**

--- a/tests/unit/gate4-bypass-acceptance.test.js
+++ b/tests/unit/gate4-bypass-acceptance.test.js
@@ -26,7 +26,7 @@ vi.mock('../../scripts/modules/pattern-tracking.js', () => ({
   getPatternStats: vi.fn().mockResolvedValue({ total: 0, resolved: 0 })
 }));
 
-function createMockSupabase({ prdData = null, handoffs = [], retroData = null, sdData = { id: 'sd-uuid', sd_key: 'test-sd', sd_type: 'feature' } } = {}) {
+function createMockSupabase({ prdData = null, handoffs = [], retroData = null, subAgentResults = [], sdData = { id: 'sd-uuid', sd_key: 'test-sd', sd_type: 'feature' } } = {}) {
   const mockSingle = (data) => ({
     data,
     error: data ? null : { message: 'Not found', code: 'PGRST116' }
@@ -87,6 +87,15 @@ function createMockSupabase({ prdData = null, handoffs = [], retroData = null, s
               // legacy callers: .eq().single()
               single: vi.fn().mockResolvedValue(mockSingle(retroData))
             })
+          })
+        };
+      }
+      // QF-20260528-877: Section B evidence fallback queries sub_agent_execution_results
+      // via .select().eq('sd_id', uuid), awaited directly (no .single()).
+      if (table === 'sub_agent_execution_results') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: subAgentResults, error: null })
           })
         };
       }
@@ -215,5 +224,84 @@ describe('PAT-GATE4-BYPASS-001: Gate 4 Bypass Acceptance', () => {
     expect(result._gateDataSources.gate2).toBe('canonical');
     // All three handoffs were accepted, so bypass-credit tracking sees all three.
     expect(result._acceptedHandoffs).toEqual({ gate1: true, gate2: true, gate3: true });
+  });
+});
+
+describe('QF-20260528-877: Section B sub-agent evidence fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const prdData = {
+    metadata: { design_analysis: { exists: true } },
+    directive_id: 'test-sd',
+    title: 'Test',
+    created_at: new Date().toISOString()
+  };
+
+  it('awards full B1/B2 from evidence rows when gate3 telemetry is absent', async () => {
+    // gate3 is provided but WITHOUT details.sub_agent_effectiveness — the common case where the
+    // details sub-object was not threaded into PLAN-TO-LEAD handoff metadata.
+    const gateResults = {
+      gate2: { passed: true, score: 90 },
+      gate3: { passed: true, score: 85 }
+    };
+    const subAgentResults = [
+      { recommendations: 'x'.repeat(600), detailed_analysis: 'analysis' },
+      { recommendations: 'short', detailed_analysis: null }
+    ];
+
+    const supabase = createMockSupabase({ prdData, subAgentResults });
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    const b = result.details.value_delivered;
+    expect(b.b1_from_evidence).toBe(true);
+    expect(b.b2_from_evidence).toBe(true);
+    expect(b.substantial_recommendations).toBe(true);
+    // B1=10 + B2=10 + B3=5 (gate2>=80) = 25/25 raw -> scaled 35/35
+    expect(result.gate_scores.value_delivered).toBe(35);
+  });
+
+  it('preserves the 7/10 defaults when no evidence rows exist (no regression)', async () => {
+    const gateResults = {
+      gate2: { passed: true, score: 90 },
+      gate3: { passed: true, score: 85 }
+    };
+
+    const supabase = createMockSupabase({ prdData, subAgentResults: [] });
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    const b = result.details.value_delivered;
+    expect(b.b1_estimated).toBe(true);
+    expect(b.b2_estimated).toBe(true);
+    expect(b.b1_from_evidence).toBeUndefined();
+    // B1=7 + B2=7 + B3=5 = 19/25 raw -> scaled round(26.6)=27/35
+    expect(result.gate_scores.value_delivered).toBe(27);
+  });
+
+  it('uses gate3 telemetry directly when present (evidence fallback not triggered)', async () => {
+    const gateResults = {
+      gate2: { passed: true, score: 90 },
+      gate3: {
+        passed: true,
+        score: 85,
+        details: {
+          sub_agent_effectiveness: {
+            total_execution_time_ms: 5 * 60 * 1000, // 5 min < 15 -> B1=10
+            substantial_recommendations: true         // -> B2=10
+          }
+        }
+      }
+    };
+
+    const supabase = createMockSupabase({ prdData });
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    const b = result.details.value_delivered;
+    expect(b.total_execution_time_minutes).toBe(5);
+    expect(b.substantial_recommendations).toBe(true);
+    expect(b.b1_from_evidence).toBeUndefined();
+    expect(b.b2_from_evidence).toBeUndefined();
+    expect(result.gate_scores.value_delivered).toBe(35);
   });
 });


### PR DESCRIPTION
## Quick-Fix QF-20260528-877 (Tier 2, bug)

### Problem
`GATE4_WORKFLOW_ROI` Section B (Value Delivered) B1 (time efficiency) and B2 (recommendation quality) read `gateResults.gate3.details.sub_agent_effectiveness` telemetry. That telemetry is frequently absent or zero at gate4 time:
- `total_execution_time_ms` sums `r.execution_time`, which is often `null`/`0` — and gate4's `if (...total_execution_time_ms)` treats `0` as falsy.
- The gate3 `details` sub-object is not reliably threaded into the `PLAN-TO-LEAD` handoff metadata gate4 reads back.

Result: B1 and B2 collapse to the 7/10 default → Section B raw 19/25 → scaled 27/35 — an ~8pt structural loss content cannot recover, capping well-validated feature SDs below the 85% adaptive threshold (e.g. SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001 at 79).

### Fix
When the threaded gate3 telemetry is missing, `validateValueDelivered()` now reads `sub_agent_execution_results` directly (mirroring gate3's own `sub-agent-effectiveness.js`):
- **B1**: full credit when evidence rows exist (the work was done; timing data is unreliable).
- **B2**: full credit when combined `recommendations`/`detailed_analysis` exceed the same >500-char substantiality threshold gate3 applies.

**Monotonic** — this can only RAISE B1/B2 above the existing defaults; if no evidence rows exist, the prior 7/10 defaults are preserved.

### Tests
`tests/unit/gate4-bypass-acceptance.test.js` — 3 new cases (7 total pass):
- telemetry absent + evidence rows → full B1/B2 (value_delivered 35/35)
- telemetry absent + no rows → defaults preserved (27/35, no regression)
- telemetry present → unchanged (uses telemetry, fallback not triggered)

Closes harness backlog 0f45e039-9c83-435a-b0d1-c5ce7e4fd485

🤖 Generated with [Claude Code](https://claude.com/claude-code)