### PR TITLE
fix(QF-20260528-563): pin sigstore/cosign-installer to v3.8.0 (v4 tag does not exist)

### DIFF
--- a/.github/workflows/sign-policies.yml
+++ b/.github/workflows/sign-policies.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3.8.0
 
       - name: Install policy tools
         run: |

--- a/.github/workflows/slsa-verification.yml
+++ b/.github/workflows/slsa-verification.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install cosign
         if: steps.extract.outputs.digests_found == 'true'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3.8.0
 
       - name: Verify SLSA provenance
         if: steps.extract.outputs.digests_found == 'true'


### PR DESCRIPTION
## Quick-Fix QF-20260528-563 (Tier 1, bug)

### Problem
The **Sign Policy Bundle** workflow failed on `main` (run [26509729859](https://github.com/rickfelix/EHG_Engineer/actions/runs/26509729859)):

```
##[error]Unable to resolve action `sigstore/cosign-installer@v4`, unable to find version `v4`
```

Two workflows pinned the nonexistent `@v4` tag:
- `.github/workflows/sign-policies.yml:37`
- `.github/workflows/slsa-verification.yml:73`

### Fix
Repin both to `@v3.8.0` — the version already used by `policy-verification.yml` and `sign-artifacts.yml` in this repo (proven-working pin). 2 lines, no behavior change beyond making the action resolvable.

Closes feedback cb8d183d-3171-4f99-835a-d4881cbb3bf6

🤖 Generated with [Claude Code](https://claude.com/claude-code)