### PR TITLE
fix(retro-gate): default retrospectives.retrospective_type to NULL (a558baf6 CAPA)

### DIFF
--- a/database/migrations/20260528_retrospective_type_default_null.sql
+++ b/database/migrations/20260528_retrospective_type_default_null.sql
@@ -1,0 +1,30 @@
+-- Migration: Default retrospectives.retrospective_type to NULL
+-- SD: SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001 (CAPA for harness-backlog a558baf6)
+--
+-- Root cause: migration 20251210_retrospective_self_improvement_system.sql set
+--   retrospectives.retrospective_type DEFAULT 'SD_COMPLETION', but the PLAN-TO-LEAD
+--   RETROSPECTIVE_QUALITY_GATE (scripts/modules/handoff/retro-filters.js::getFilteredRetrospective)
+--   selects the SD-completion retro via: retro_type='SD_COMPLETION' AND retrospective_type IS NULL
+--   AND created_at > leadToPlanAcceptedAt. Any writer that OMITS retrospective_type received the
+--   'SD_COMPLETION' default and failed the gate (recurred twice 2026-05-28:
+--   VENTURE-LIFECYCLE-PIPELINE-001 + ADD-CMO-CHIEF-001, requiring a manual UPDATE workaround).
+--
+-- Fix: align the column default with the gate contract. Completion writers that omit the field now
+--   get NULL (which the gate accepts); handoff writers continue to set LEAD_TO_PLAN/PLAN_TO_EXEC
+--   explicitly and are unaffected.
+--
+-- Safety (verified by DATABASE sub-agent, evidence 1e95a781):
+--   * Forward-looking: existing rows are NOT backfilled (their SDs already passed the gate).
+--   * CHECK constraint retrospectives_retrospective_type_check already permits NULL.
+--   * Default-only: the trigger that historically copied retrospective_type into the NOT NULL
+--     protocol_improvement_queue.source_type is ORPHANED on the live DB (the live function hardcodes
+--     source_type='retrospective' and never reads retrospective_type). Proven empirically via a
+--     BEGIN/ROLLBACK insert of a NULL-retrospective_type retro with qualifying improvements (succeeded).
+--   * SET DEFAULT is an instant catalog change (no table rewrite / lock contention) — safe to apply
+--     while parallel sessions complete SDs.
+--   * Idempotent: re-running SET DEFAULT NULL is a no-op.
+--
+-- NOTE: re-applying 20251210 would re-attach the unsafe (retrospective_type-reading) trigger; that
+--   migration should be marked superseded re: the trigger (tracked as a follow-up, out of scope here).
+
+ALTER TABLE retrospectives ALTER COLUMN retrospective_type SET DEFAULT NULL;

--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -161,11 +161,11 @@ async function generateRetrospective(sdInput) {
     target_application: sd.target_application || 'EHG_engineer',
     project_name: sd.title,
     retro_type: 'SD_COMPLETION',
-    // QF-20260528-171: explicitly NULL so the SD_COMPLETION retro passes
-    // RETROSPECTIVE_QUALITY_GATE. The column defaults to 'SD_COMPLETION'
-    // (migration 20251210_retrospective_self_improvement_system.sql), but the
-    // gate requires retrospective_type IS NULL for completion retros — omitting
-    // the key lets the default through and silently fails the gate.
+    // QF-20260528-171 + SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001: the
+    // RETROSPECTIVE_QUALITY_GATE selects the SD-completion retro via
+    // retro_type='SD_COMPLETION' AND retrospective_type IS NULL. The column default is now
+    // NULL (was 'SD_COMPLETION' in migration 20251210; realigned by the SD above), so
+    // omitting the key also yields NULL — this explicit null is kept as defense-in-depth.
     retrospective_type: null,
     title: `${sd.sd_key} Retrospective`,
     description: `Retrospective analysis for ${sd.title} - completed at ${sd.progress}% with ${sd.status} status`,

--- a/tests/unit/retrospectives/retrospective-type-default-null.test.js
+++ b/tests/unit/retrospectives/retrospective-type-default-null.test.js
@@ -1,0 +1,40 @@
+// SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001 (CAPA for harness-backlog a558baf6).
+//
+// The retrospectives.retrospective_type column DEFAULT was 'SD_COMPLETION' (migration 20251210),
+// which contradicts the PLAN-TO-LEAD RETROSPECTIVE_QUALITY_GATE: it selects the SD-completion
+// retro via retro_type='SD_COMPLETION' AND retrospective_type IS NULL (retro-filters.js
+// getFilteredRetrospective). Any writer that OMITTED retrospective_type received the default and
+// failed the gate (recurred twice 2026-05-28). The migration realigns the default to NULL; the
+// live column_default was verified NULL after applying it.
+//
+// Static-pattern assertions (same convention as generate-retrospective-filtered-existence.test.js)
+// guard against regression of the default and keep the generator's intent documented. Hermetic —
+// no DB connection required.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION = path.resolve(__dirname, '../../../database/migrations/20260528_retrospective_type_default_null.sql');
+const GENERATOR = path.resolve(__dirname, '../../../scripts/generate-retrospective.js');
+
+describe('retrospective_type column default = NULL (CAPA a558baf6)', () => {
+  it('the migration sets the retrospective_type column default to NULL', () => {
+    const sql = fs.readFileSync(MIGRATION, 'utf8');
+    expect(sql).toMatch(
+      /ALTER\s+TABLE\s+retrospectives\s+ALTER\s+COLUMN\s+retrospective_type\s+SET\s+DEFAULT\s+NULL/i,
+    );
+  });
+
+  it('generate-retrospective.js documents the NULL default and keeps the explicit null', () => {
+    const code = fs.readFileSync(GENERATOR, 'utf8');
+    // Comment updated to reflect the realigned default (references the SD that realigned it).
+    expect(code).toMatch(/SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001/);
+    // Completion retros still write retrospective_type: null as defense-in-depth.
+    expect(code).toMatch(/retrospective_type:\s*null/);
+    // retro_type is still SD_COMPLETION (the gate keys completion retros on this).
+    expect(code).toMatch(/retro_type:\s*'SD_COMPLETION'/);
+  });
+});


### PR DESCRIPTION
## Summary
CAPA for harness-backlog **a558baf6** (the recurring PLAN-TO-LEAD `RETROSPECTIVE_QUALITY_GATE` failure). SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001.

**Root cause (spec conflict):** `retrospectives.retrospective_type` column DEFAULT was `'SD_COMPLETION'` (migration 20251210), but the gate selects the SD-completion retro via `retro_type='SD_COMPLETION' AND retrospective_type IS NULL` (retro-filters.js `getFilteredRetrospective`). Any writer that **omitted** `retrospective_type` got the default and failed the gate — `generate-retrospective.js` band-aided it (explicit null), but the retro-agent path did not, so it recurred twice on 2026-05-28.

**Fix (default-only):** `ALTER TABLE retrospectives ALTER COLUMN retrospective_type SET DEFAULT NULL`. Omit-writers now get NULL (gate accepts); handoff writers still set `LEAD_TO_PLAN`/`PLAN_TO_EXEC` explicitly.

- Migration (idempotent, forward-looking — no backfill).
- Comment fix in `generate-retrospective.js`.
- Hermetic regression test.

## Why it's safe (during live parallel sessions)
- `SET DEFAULT` is an instant catalog change; existing rows untouched; CHECK already permits NULL.
- The trigger that historically copied `retrospective_type` → NOT NULL `protocol_improvement_queue.source_type` is **orphaned** on live (the live function hardcodes `source_type='retrospective'`) — proven via BEGIN/ROLLBACK. So a NULL default cannot break retro INSERTs.
- Strictly beneficial: it makes omit-writer completion retros PASS the gate (previously failed); cannot break in-flight completions.

## Test plan
- [x] Live `information_schema` column_default = NULL (verified; NULL row count 307→308 as a new completion retro took the default)
- [x] Hermetic regression test 2/2 + existing retrospectives tests 3/3
- [x] **Dogfood:** this SD's own completion retro stored `retrospective_type=NULL` by *omitting* the field — no manual UPDATE
- [x] Gates: LEAD-TO-PLAN 97, PLAN-TO-EXEC 95, EXEC-TO-PLAN 93, PLAN-TO-LEAD 96; sub-agents PASS (DATABASE proved trigger orphaned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)