### PR TITLE
feat(SD-FDBK-INFRA-START-NON-INTERACTIVE-001): extract sd-start own-conflict re-attach handler + CLI test

### DIFF
--- a/lib/exec-context-guard.mjs
+++ b/lib/exec-context-guard.mjs
@@ -324,6 +324,38 @@ export function classifyWorktreeOwnership(conflictPath, expectedPath) {
 }
 
 /**
+ * decideOwnConflictReattach(code, conflictDetail, expectedPath)
+ *
+ * SD-FDBK-INFRA-START-NON-INTERACTIVE-001 (FR-1): pure decision extracted from
+ * the two duplicated own-conflict re-attach sites in scripts/sd-start.js (the
+ * worktree creation-failure path and the resolution-error catch). Given the
+ * classified worktree-failure code, the raw git error detail/message, and the
+ * SD's expected worktree dir, decide whether sd-start should RE-ATTACH (exit 2,
+ * claim PRESERVED) or fall through to release-claim + exit 1.
+ *
+ * Re-attach is correct ONLY when the failure is an `already_checked_out`
+ * conflict whose path IS this SD's own expected worktree dir — releasing the
+ * claim in that case would leak it (harness backlog 28a71037).
+ *
+ * @param {string} code - classifyWorktreeFailure().code
+ * @param {string} conflictDetail - raw detail/message containing
+ *   "already used by worktree at '<path>'"
+ * @param {string} expectedPath - the SD's expected worktree dir
+ * @returns {{reattach: boolean, conflictPath?: string, expectedPath?: string}}
+ */
+export function decideOwnConflictReattach(code, conflictDetail, expectedPath) {
+  if (code !== 'already_checked_out') return { reattach: false };
+  const m = String(conflictDetail || '').match(/already used by worktree at ['"`]?([^'"`\n\r]+)['"`]?/i);
+  const conflictPath = m ? m[1].trim() : null;
+  if (!conflictPath || !expectedPath) return { reattach: false };
+  const ownership = classifyWorktreeOwnership(conflictPath, expectedPath);
+  if (ownership.kind === 'own') {
+    return { reattach: true, conflictPath: ownership.conflictPath, expectedPath: ownership.expectedPath };
+  }
+  return { reattach: false };
+}
+
+/**
  * FR-5: detectOrphanWorktreeFromMerge(stdoutOrOutput)
  *
  * Pure detector. Scans gh-merge-safe.mjs / `gh pr merge --delete-branch`

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -49,7 +49,7 @@ import { formatRosterClaim } from './modules/sd-next/display/claim-formatters.js
 // internally by the policy for the transient / already-checked-out / etc.
 // patterns, so no behavior regresses for existing error shapes.
 import { classify as classifyWorktreeFailure } from '../lib/protocol-policies/worktree-failure-classification.js';
-import { classifyWorktreeOwnership } from '../lib/exec-context-guard.mjs';
+import { decideOwnConflictReattach } from '../lib/exec-context-guard.mjs';
 import { getNextReadyChild } from './modules/handoff/child-sd-selector.js';
 import { checkSDAge, handleTimelineViolation, formatBlockMessage } from './modules/governance/timeline-violation-handler.js';
 import {
@@ -1304,18 +1304,14 @@ async function main() {
       // expected worktree dir, this is a benign already_checked_out — the SD's
       // own worktree exists and the user can re-attach. Releasing the claim
       // would leak it (witnessed harness backlog 28a71037).
-      if (classified.code === 'already_checked_out') {
-        const conflictMatch = String(detail).match(/already used by worktree at ['"`]?([^'"`\n\r]+)['"`]?/i);
-        const conflictPath = conflictMatch ? conflictMatch[1].trim() : null;
+      {
         const expectedPath = worktreeInfo?.worktree?.path || worktreeInfo?.cwd || null;
-        if (conflictPath && expectedPath) {
-          const ownership = classifyWorktreeOwnership(conflictPath, expectedPath);
-          if (ownership.kind === 'own') {
-            console.error(`${colors.yellow}   ⚠  Recoverable: conflict path matches this SD's expected worktree dir.${colors.reset}`);
-            console.error(`${colors.cyan}   Recovery: cd "${ownership.expectedPath}"${colors.reset}`);
-            console.error(`${colors.dim}   Claim PRESERVED — re-run sd-start from inside the existing worktree.${colors.reset}`);
-            process.exit(2); // exit 2 = recoverable; do NOT release claim
-          }
+        const reattach = decideOwnConflictReattach(classified.code, detail, expectedPath);
+        if (reattach.reattach) {
+          console.error(`${colors.yellow}   ⚠  Recoverable: conflict path matches this SD's expected worktree dir.${colors.reset}`);
+          console.error(`${colors.cyan}   Recovery: cd "${reattach.expectedPath}"${colors.reset}`);
+          console.error(`${colors.dim}   Claim PRESERVED — re-run sd-start from inside the existing worktree.${colors.reset}`);
+          process.exit(2); // exit 2 = recoverable; do NOT release claim
         }
       }
 
@@ -1337,18 +1333,14 @@ async function main() {
     // SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (FR-4, AC-6/AC-7): own-vs-foreign
     // differentiation on the resolution-error path mirrors the creation-failure
     // path above — preserve the claim when the conflict is the SD's own worktree.
-    if (classified.code === 'already_checked_out') {
-      const conflictMatch = String(wtErr.message || '').match(/already used by worktree at ['"`]?([^'"`\n\r]+)['"`]?/i);
-      const conflictPath = conflictMatch ? conflictMatch[1].trim() : null;
+    {
       const expectedPath = wtErr?.expectedWorktreePath || wtErr?.path || null;
-      if (conflictPath && expectedPath) {
-        const ownership = classifyWorktreeOwnership(conflictPath, expectedPath);
-        if (ownership.kind === 'own') {
-          console.error(`${colors.yellow}   ⚠  Recoverable: conflict path matches this SD's expected worktree dir.${colors.reset}`);
-          console.error(`${colors.cyan}   Recovery: cd "${ownership.expectedPath}"${colors.reset}`);
-          console.error(`${colors.dim}   Claim PRESERVED — re-run sd-start from inside the existing worktree.${colors.reset}`);
-          process.exit(2);
-        }
+      const reattach = decideOwnConflictReattach(classified.code, wtErr.message, expectedPath);
+      if (reattach.reattach) {
+        console.error(`${colors.yellow}   ⚠  Recoverable: conflict path matches this SD's expected worktree dir.${colors.reset}`);
+        console.error(`${colors.cyan}   Recovery: cd "${reattach.expectedPath}"${colors.reset}`);
+        console.error(`${colors.dim}   Claim PRESERVED — re-run sd-start from inside the existing worktree.${colors.reset}`);
+        process.exit(2);
       }
     }
 

--- a/tests/unit/scripts/sd-start-non-interactive-own-conflict.test.js
+++ b/tests/unit/scripts/sd-start-non-interactive-own-conflict.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-FDBK-INFRA-START-NON-INTERACTIVE-001 — CLI-entrypoint test for the
+ * sd-start own-conflict re-attach decision (AC-7).
+ *
+ * The underlying classifyWorktreeOwnership is unit-tested in
+ * tests/unit/lib/exec-context-guard.test.js. This file covers the DECISION that
+ * scripts/sd-start.js wires it into at two sites (worktree creation-failure
+ * path + resolution-error catch): match an `already_checked_out` conflict,
+ * parse the conflict path from the git error, classify ownership, and re-attach
+ * (exit 2, claim PRESERVED) ONLY when the conflict is this SD's own worktree.
+ * That decision is extracted into decideOwnConflictReattach so it is testable
+ * without spawning the CLI (sd-start.js has heavy top-level / DB side effects).
+ *
+ * The two consumer sites map the decision to process exit codes:
+ *   reattach:true  -> process.exit(2)  (re-attach, claim preserved)
+ *   reattach:false -> releaseClaim + process.exit(1)
+ * so asserting the boolean here pins the exit-code behavior at both sites.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+
+const { decideOwnConflictReattach } = await import('../../../lib/exec-context-guard.mjs');
+
+// Same absolute-looking path used for both the conflict (inside the git error
+// string) and the expected worktree dir, so path.resolve() makes them equal
+// regardless of the runner platform.
+const OWN = 'C:/main/.worktrees/sd/SD-XXX-001';
+const FOREIGN = 'C:/main/.worktrees/sd/SD-OTHER-002';
+const gitErr = (p) => `fatal: 'feat/SD-XXX-001' is already used by worktree at '${p}'`;
+
+describe('SD-FDBK-INFRA-START-NON-INTERACTIVE-001 — decideOwnConflictReattach (AC-7)', () => {
+  it('TS-1: own-conflict (creation-failure shape) -> reattach:true (CLI exit 2, claim preserved)', () => {
+    // detail = worktreeInfo.error/errorCode at scripts/sd-start.js creation-failure path
+    const result = decideOwnConflictReattach('already_checked_out', gitErr(OWN), OWN);
+    expect(result.reattach).toBe(true);
+    expect(result.expectedPath).toBe(path.resolve(OWN));
+  });
+
+  it('TS-2: own-conflict (resolution-error shape) -> reattach:true (CLI exit 2)', () => {
+    // detail = wtErr.message, expectedPath = wtErr.expectedWorktreePath at the catch site
+    const result = decideOwnConflictReattach('already_checked_out', gitErr(OWN), OWN);
+    expect(result.reattach).toBe(true);
+  });
+
+  it('TS-3: foreign-conflict -> reattach:false (CLI releases claim + exit 1)', () => {
+    const result = decideOwnConflictReattach('already_checked_out', gitErr(FOREIGN), OWN);
+    expect(result.reattach).toBe(false);
+  });
+
+  it('TS-4: non-already_checked_out code -> reattach:false even when paths would match', () => {
+    const result = decideOwnConflictReattach('unknown', gitErr(OWN), OWN);
+    expect(result.reattach).toBe(false);
+  });
+
+  it('TS-5: already_checked_out but conflict detail has no parseable path -> reattach:false', () => {
+    const result = decideOwnConflictReattach('already_checked_out', 'fatal: some unrelated worktree error', OWN);
+    expect(result.reattach).toBe(false);
+  });
+
+  it('TS-6: already_checked_out with valid detail but missing expectedPath -> reattach:false', () => {
+    expect(decideOwnConflictReattach('already_checked_out', gitErr(OWN), null).reattach).toBe(false);
+    expect(decideOwnConflictReattach('already_checked_out', gitErr(OWN), undefined).reattach).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `decideOwnConflictReattach(code, conflictDetail, expectedPath)` into `lib/exec-context-guard.mjs` — a pure function encapsulating the own-conflict re-attach decision (parse the `already_checked_out` conflict path, classify ownership, decide re-attach vs release).
- Refactor both duplicated sites in `scripts/sd-start.js` (worktree creation-failure path + resolution-error catch) to call it. Behavior-preserving: own-conflict → `exit 2` + claim PRESERVED; foreign/unrecoverable → `exit 1` + release. Removed the now-unused `classifyWorktreeOwnership` import.
- Add `tests/unit/scripts/sd-start-non-interactive-own-conflict.test.js` (6 cases) closing the AC-7 CLI-entrypoint test gap: both wired-site shapes, foreign-conflict exit-1, non-matching code, unparseable detail, missing expectedPath.

## Why
The own-conflict re-attach path (which preserves a claim to avoid a leak — harness backlog 28a71037) had no dedicated test; `classifyWorktreeOwnership` was tested but its inline wiring in `sd-start.js` was duplicated and untested.

## Test plan
- [x] `npx vitest run tests/unit/scripts/sd-start-non-interactive-own-conflict.test.js` — 6/6 pass
- [x] `npx vitest run tests/unit/lib/exec-context-guard.test.js` — 22/22 pass (regression)
- [x] `node --check` on both edited source files — clean
- [x] Behavior-preservation diff-verified by REGRESSION + VALIDATION sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)