### PR TITLE
fix(venture-lifecycle): discovery venture_id backfill + parity-test stale sweep

### DIFF
--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -247,11 +247,14 @@ async function processRequest(supabase, request) {
       ?? result?.brief?.prompt_version
       ?? null;
 
-    // Store success
+    // Store success. Backfill venture_id when the run synthesized a venture so the
+    // discovery <-> venture link is reliable (previously always null) — lets the UI
+    // "Recent Discoveries" link and dismiss-self-clean target the right venture.
     await updateStatus(supabase, request.id, {
       status: 'completed',
       result: { ...result, prompt_version: promptVersion },
       prompt_version: promptVersion,
+      venture_id: result?.record_type === 'venture' ? (result.record_id ?? null) : null,
       completed_at: new Date().toISOString(),
     });
 

--- a/tests/integration/s17-parity.test.js
+++ b/tests/integration/s17-parity.test.js
@@ -44,6 +44,16 @@ let frontendVentureId;
 beforeAll(async () => {
   supabase = getSupabaseClient();
 
+  // Self-clean: remove any parity-test ventures leaked by prior runs that were killed
+  // before afterAll ran (mirrors the afterAll teardown, scoped by name prefix).
+  const { data: stale } = await supabase.from('ventures').select('id').like('name', 'parity-test-%');
+  const staleIds = (stale ?? []).map((v) => v.id);
+  if (staleIds.length > 0) {
+    await supabase.from('chairman_decisions').delete().in('venture_id', staleIds);
+    await supabase.from('venture_analysis_artifacts').delete().in('venture_id', staleIds);
+    await supabase.from('ventures').delete().in('id', staleIds);
+  }
+
   // Seed CLI-path venture (mirrors chairman-review.js insert pattern)
   const { data: cliVenture, error: cliErr } = await supabase
     .from('ventures')


### PR DESCRIPTION
## Summary
Two venture-hygiene follow-ups from the auto-created-ventures cleanup (backlog items 2 + 3).

**1. Backfill `stage_zero_requests.venture_id` (item 2 backend).** The Stage-0 discovery processor stored the run `result` (with `brief.name`) but never set `venture_id` on the request — so every synthesized finder venture was orphaned from its discovery. Now backfilled from `result.record_id` when `result.record_type==='venture'`. This gives the "Recent Discoveries" link a real target and lets the dismiss-self-clean (ehg PR) reliably find the venture.

**2. Sweep stale `parity-test-*` ventures (item 3).** `s17-parity.test.js` seeds ventures in `beforeAll` and cleans in `afterAll`, but runs killed before `afterAll` leaked them (4 found this session). Added a `beforeAll` sweep (mirrors the `afterAll` teardown, scoped by name prefix) so killed runs self-clean.

## Test plan
- [x] `stage-zero-queue-processor.test.js` passes (7/7) after the backfill
- [x] `s17-parity.test.js` runs the sweep cleanly (the 1 pre-existing `chairman_decisions` failure is unrelated — confirmed identical on the un-edited file)
- [ ] CI green

Pairs with ehg PR (dismiss deletes the synthesized venture).