### PR TITLE
feat(SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001): surface DB-only validation-rule gates in PLAN-TO-LEAD precheck

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -340,14 +340,29 @@ export class HandoffOrchestrator {
         console.log('   [GatePolicy] Using hardcoded gate set (DB policy unavailable)');
       }
 
-      // Run ALL gates using batch validation (doesn't stop on first failure)
-      const result = await this.validationOrchestrator.validateGatesAll(filteredGates, {
+      // SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001: surface DB-only validation rules
+      // (dual-namespace gates like 3:subAgentOrchestration) in precheck, matching
+      // execute (BaseExecutor.js:316) and dryRunHandoff (HandoffOrchestrator.js:558),
+      // which both merge buildGatesFromRules. Without this, precheck silently omits
+      // any gate defined only in leo_validation_rules, so operators don't see a
+      // failure execute will enforce. Advisory-only: validateGatesAll runs in
+      // precheckMode (no writes; LLM gates skipped) and the execute path is unchanged.
+      const precheckValidationContext = {
         sdId,
+        sd_id: sd?.id || sdId,
         sd,
         options,
         precheckMode: true,
         supabase: this.supabase
-      });
+      };
+      const gatesWithRules = await this.validationOrchestrator.buildGatesFromRules(
+        filteredGates,
+        normalizedType,
+        precheckValidationContext
+      );
+
+      // Run ALL gates using batch validation (doesn't stop on first failure)
+      const result = await this.validationOrchestrator.validateGatesAll(gatesWithRules, precheckValidationContext);
 
       // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Show gate scores and thresholds
       if (result.gateResults && Object.keys(result.gateResults).length > 0) {

--- a/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
@@ -1,6 +1,10 @@
 /**
  * QF-20260508-515: precheckHandoff applies gate policies (writer/consumer asymmetry).
  * Verifies precheck honors validation_gate_registry DISABLED rows.
+ *
+ * SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001: precheck also merges DB-only validation
+ * rules via validationOrchestrator.buildGatesFromRules (parity with execute +
+ * dryRun), so dual-namespace gates like 3:subAgentOrchestration are surfaced.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -9,6 +13,8 @@ const applyGatePoliciesMock = vi.fn();
 const validateGatesAllMock = vi.fn().mockResolvedValue({
   passed: true, gateResults: {}, failedGates: [], passedGates: [], normalizedScore: 100
 });
+// Default: passthrough (no DB rules) — returns the policy-filtered gates unchanged.
+const buildGatesFromRulesMock = vi.fn(async (gates) => gates);
 
 vi.mock('./gate-policy-resolver.js', () => ({ applyGatePolicies: applyGatePoliciesMock }));
 vi.mock('./gates/dfe-escalation-gate.js', () => ({
@@ -21,23 +27,72 @@ vi.mock('../../../lib/supabase-client.js', () => ({ createSupabaseServiceClient:
 
 const { HandoffOrchestrator } = await import('./HandoffOrchestrator.js');
 
-beforeEach(() => { applyGatePoliciesMock.mockReset(); validateGatesAllMock.mockClear(); });
+function makeOrchestrator(sdRow, requiredGates) {
+  return new HandoffOrchestrator({
+    supabase: { mock: true },
+    sdRepo: { getById: vi.fn().mockResolvedValue(sdRow) },
+    validationOrchestrator: {
+      validateGatesAll: validateGatesAllMock,
+      buildGatesFromRules: buildGatesFromRulesMock
+    },
+    executors: { 'PLAN-TO-LEAD': { getRequiredGates: vi.fn().mockResolvedValue(requiredGates) } }
+  });
+}
+
+const INFRA_SD = { id: 'X', sd_key: 'X', sd_type: 'infrastructure', title: 't' };
+
+beforeEach(() => {
+  applyGatePoliciesMock.mockReset();
+  validateGatesAllMock.mockClear();
+  buildGatesFromRulesMock.mockClear();
+  buildGatesFromRulesMock.mockImplementation(async (gates) => gates);
+});
 
 describe('HandoffOrchestrator.precheckHandoff applies gate policies', () => {
-  it('calls applyGatePolicies and passes filteredGates to validateGatesAll', async () => {
+  it('calls applyGatePolicies and passes filteredGates through buildGatesFromRules to validateGatesAll', async () => {
     applyGatePoliciesMock.mockResolvedValue({
       filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
     });
-    const orchestrator = new HandoffOrchestrator({
-      supabase: { mock: true },
-      sdRepo: { getById: vi.fn().mockResolvedValue({ id: 'X', sd_key: 'X', sd_type: 'infrastructure', title: 't' }) },
-      validationOrchestrator: { validateGatesAll: validateGatesAllMock },
-      executors: { 'LEAD-TO-PLAN': { getRequiredGates: vi.fn().mockResolvedValue([{ name: 'GATE_KEEP' }, { name: 'GATE_VISION_SCORE' }]) } }
-    });
-    await orchestrator.precheckHandoff('LEAD-TO-PLAN', 'X');
+    const orchestrator = makeOrchestrator(INFRA_SD, [{ name: 'GATE_KEEP' }, { name: 'GATE_VISION_SCORE' }]);
+    await orchestrator.precheckHandoff('PLAN-TO-LEAD', 'X');
+
     expect(applyGatePoliciesMock).toHaveBeenCalledTimes(1);
     expect(applyGatePoliciesMock.mock.calls[0][2].sdType).toBe('infrastructure');
-    const filteredNames = validateGatesAllMock.mock.calls[0][0].map(g => g.name);
-    expect(filteredNames).toEqual(['GATE_KEEP']);
+    // buildGatesFromRules receives the policy-filtered gates (passthrough mock => unchanged)
+    expect(buildGatesFromRulesMock).toHaveBeenCalledTimes(1);
+    expect(buildGatesFromRulesMock.mock.calls[0][0].map(g => g.name)).toEqual(['GATE_KEEP']);
+    const finalNames = validateGatesAllMock.mock.calls[0][0].map(g => g.name);
+    expect(finalNames).toEqual(['GATE_KEEP']);
+  });
+
+  it('surfaces DB-only rule gates (e.g. 3:subAgentOrchestration) by passing buildGatesFromRules output to validateGatesAll', async () => {
+    applyGatePoliciesMock.mockResolvedValue({
+      filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
+    });
+    // Simulate the DB-rule merge: buildGatesFromRules appends a dual-namespace gate.
+    buildGatesFromRulesMock.mockImplementation(async (gates) => [...gates, { name: '3:subAgentOrchestration' }]);
+    const orchestrator = makeOrchestrator(INFRA_SD, [{ name: 'GATE_KEEP' }]);
+    await orchestrator.precheckHandoff('PLAN-TO-LEAD', 'X');
+
+    const finalNames = validateGatesAllMock.mock.calls[0][0].map(g => g.name);
+    expect(finalNames).toContain('3:subAgentOrchestration');
+    // Wiring: the merged set (not the raw filteredGates) reaches validateGatesAll.
+    expect(finalNames).toEqual(['GATE_KEEP', '3:subAgentOrchestration']);
+  });
+
+  it('forwards sd + precheckMode in the context so buildGatesFromRules can apply orchestrator-child policy and stay write-free', async () => {
+    applyGatePoliciesMock.mockResolvedValue({
+      filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
+    });
+    const childSd = { id: 'C', sd_key: 'C', sd_type: 'infrastructure', title: 'child', metadata: { parent_orchestrator: 'ORCH-1' } };
+    const orchestrator = makeOrchestrator(childSd, [{ name: 'GATE_KEEP' }]);
+    await orchestrator.precheckHandoff('PLAN-TO-LEAD', 'C');
+
+    // buildGatesFromRules (the real impl) early-returns hardcoded gates for children;
+    // precheck must hand it the sd + handoffType + precheckMode so it can decide.
+    const [, handoffType, ctx] = buildGatesFromRulesMock.mock.calls[0];
+    expect(handoffType).toBe('PLAN-TO-LEAD');
+    expect(ctx.sd).toBe(childSd);
+    expect(ctx.precheckMode).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `precheckHandoff` (HandoffOrchestrator.js) now calls `validationOrchestrator.buildGatesFromRules()` after `applyGatePolicies` and passes the merged set to `validateGatesAll` — matching what `execute` (BaseExecutor.js:316) and `dryRun` (HandoffOrchestrator.js:558) already do.
- This surfaces DB-only `leo_validation_rules` (dual-namespace gates like `3:subAgentOrchestration`) in `handoff.js precheck PLAN-TO-LEAD`, which previously omitted them — so operators couldn't see a gate `execute` would enforce.
- Advisory-only and behavior-preserving: `precheckMode` ⇒ no DB writes, LLM gates skipped; `execute`/`dryRun` untouched; orchestrator children still skip DB rules (buildGatesFromRules early-return).
- Extended `HandoffOrchestrator.precheck-policy.test.js` (+3 cases).

## Why
PLAN-TO-LEAD `execute` could fail on the legacy `3:subAgentOrchestration` DB-rule gate while `precheck` showed nothing — a writer/consumer asymmetry, same class as QF-20260508-515 (gate policies) and QF-20260520-358 (_appPath), both already fixed for precheck.

## Scope
Issue #1 only. Issue #2 (`GATE5_GIT_COMMIT_ENFORCEMENT` cross-worktree false-positive) was split to a follow-up (shared fail-closed gate, higher blast radius) and logged to the harness backlog.

## Test plan
- [x] `npx vitest run scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js` — 3/3 pass
- [x] Full `scripts/modules/handoff/` suite: zero new regressions (the 4 failing files fail identically on main; +2 new passing tests)
- [x] `node --check` clean; VALIDATION + REGRESSION sub-agents PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)