### PR TITLE
feat(SD-LEO-INFRA-VENTURE-REPO-AWARE-001): registry-aware retrospectives constraint

### DIFF
--- a/database/migrations/20260528_registry_aware_retrospectives_target_application.sql
+++ b/database/migrations/20260528_registry_aware_retrospectives_target_application.sql
@@ -1,0 +1,105 @@
+-- ============================================================================
+-- MIGRATION: Registry-aware retrospectives.check_target_application
+-- SD-LEO-INFRA-VENTURE-REPO-AWARE-001 (CronGenius first-venture pilot, Track-2)
+-- ============================================================================
+-- Purpose: Replace the static CHECK (target_application = ANY (ARRAY['EHG','EHG_Engineer']))
+--          with a trigger that validates target_application against the authoritative
+--          `applications` registry table, so ANY registered app (including ventures
+--          like 'CronGenius') is accepted with NO per-venture migration. This is the
+--          single NON-bypassable blocker that stopped CronGenius child A's LEAD-FINAL
+--          retrospective.
+--
+-- Safety:  PURE LOOSENING. Today's constraint only allows 'EHG'/'EHG_Engineer'; every
+--          currently-succeeding insert writes one of those two. Both are short-circuited
+--          to RETURN NEW *before* the applications query, so no currently-valid insert can
+--          break (fail-open for platform values). The trigger only ACCEPTS MORE (registered
+--          ventures) and rejects exactly what the old CHECK already rejected (unregistered).
+--          Reversible — see ROLLBACK at the bottom.
+--
+-- Matching: case/separator-insensitive, mirroring lib/repo-paths.js normalizeAppName
+--           (lowercase + strip non-alphanumeric), so 'CronGenius'/'crongenius'/'cron-genius'
+--           all resolve.
+-- ============================================================================
+
+-- 1) Drop the static two-value CHECK (the venture-blocking constraint).
+ALTER TABLE retrospectives DROP CONSTRAINT IF EXISTS check_target_application;
+
+-- 2) Registry-aware validation function.
+CREATE OR REPLACE FUNCTION validate_retrospective_target_application()
+RETURNS trigger AS $$
+BEGIN
+  -- Platform repos are always valid (also present in applications); checked FIRST so
+  -- platform retrospective writes never depend on the applications query (fail-open).
+  IF NEW.target_application IN ('EHG', 'EHG_Engineer') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Registry-aware: accept any active registered application (case/separator-insensitive).
+  IF EXISTS (
+    SELECT 1 FROM applications
+    WHERE status = 'active'
+      AND regexp_replace(lower(name), '[^a-z0-9]', '', 'g')
+        = regexp_replace(lower(NEW.target_application), '[^a-z0-9]', '', 'g')
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'retrospectives.target_application "%" is not a registered application. Register it in the applications table (the registry source of truth) or use a registered application name.', NEW.target_application
+    USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3) (Re)create the BEFORE INSERT OR UPDATE trigger. OF target_application limits UPDATE
+--    firing to changes of that column (no surprise re-validation on unrelated updates).
+DROP TRIGGER IF EXISTS trg_validate_retrospective_target_application ON retrospectives;
+CREATE TRIGGER trg_validate_retrospective_target_application
+  BEFORE INSERT OR UPDATE OF target_application ON retrospectives
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_retrospective_target_application();
+
+-- 4) Invariants — fail the migration LOUDLY if the change did not take.
+DO $$
+BEGIN
+  -- 4a. The old static CHECK must be gone.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'check_target_application' AND conrelid = 'retrospectives'::regclass
+  ) THEN
+    RAISE EXCEPTION 'INVARIANT FAILED: static check_target_application still present on retrospectives';
+  END IF;
+
+  -- 4b. The validation trigger must exist.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_validate_retrospective_target_application'
+      AND tgrelid = 'retrospectives'::regclass
+  ) THEN
+    RAISE EXCEPTION 'INVARIANT FAILED: validation trigger not created on retrospectives';
+  END IF;
+
+  -- 4c. Regression safety: every distinct existing target_application value must still be
+  --     accepted by the new rule (platform short-circuit OR registered in applications).
+  IF EXISTS (
+    SELECT 1
+    FROM (SELECT DISTINCT target_application AS ta FROM retrospectives) r
+    WHERE r.ta NOT IN ('EHG', 'EHG_Engineer')
+      AND NOT EXISTS (
+        SELECT 1 FROM applications a
+        WHERE a.status = 'active'
+          AND regexp_replace(lower(a.name), '[^a-z0-9]', '', 'g')
+            = regexp_replace(lower(r.ta), '[^a-z0-9]', '', 'g')
+      )
+  ) THEN
+    RAISE EXCEPTION 'INVARIANT FAILED: an existing retrospectives.target_application value would be rejected by the new rule (regression)';
+  END IF;
+
+  RAISE NOTICE 'OK: registry-aware retrospectives.target_application validation installed; all existing values remain valid';
+END $$;
+
+-- ============================================================================
+-- ROLLBACK (manual):
+--   DROP TRIGGER IF EXISTS trg_validate_retrospective_target_application ON retrospectives;
+--   DROP FUNCTION IF EXISTS validate_retrospective_target_application();
+--   ALTER TABLE retrospectives ADD CONSTRAINT check_target_application
+--     CHECK (target_application = ANY (ARRAY['EHG','EHG_Engineer']));
+-- ============================================================================

--- a/lib/repo-paths.js
+++ b/lib/repo-paths.js
@@ -180,6 +180,55 @@ export async function resolveRepoPathDbFirst(targetApp, supabase) {
 }
 
 /**
+ * Resolve a target_application input to its CANONICAL registered name (the
+ * `applications.name` form), so writers store a registry-consistent value.
+ *
+ * DB-first (applications table), registry.json fallback, matching is
+ * case/separator-insensitive via normalizeAppName. Platform values pass through
+ * unchanged. Returns the input UNCHANGED when no registered match is found — it
+ * NEVER silently rewrites an unknown app to a platform default (the DB constraint
+ * is the authority on validity).
+ *
+ * SD-LEO-INFRA-VENTURE-REPO-AWARE-001 (FR-3/TR-3): reuses the existing resolver;
+ * no new resolver module. Pairs with the registry-aware retrospectives trigger.
+ *
+ * @param {string} targetApp - Application name (e.g. 'CronGenius', 'crongenius', 'EHG')
+ * @param {import('@supabase/supabase-js').SupabaseClient} [supabase] - service client; when omitted, registry-only
+ * @returns {Promise<string>} the canonical applications.name, or the input unchanged if unmatched
+ */
+export async function resolveCanonicalAppName(targetApp, supabase) {
+  if (!targetApp) return 'EHG_Engineer';
+  // Platform passthrough (canonical display forms) — never depends on the registry query.
+  if (targetApp === 'EHG' || targetApp === 'EHG_Engineer') return targetApp;
+  const needle = normalizeAppName(targetApp);
+  if (needle === 'ehgengineer') return 'EHG_Engineer';
+  if (needle === 'ehg') return 'EHG';
+
+  if (supabase) {
+    try {
+      const { data, error } = await supabase
+        .from('applications')
+        .select('name, status')
+        .eq('status', 'active');
+      if (!error && Array.isArray(data)) {
+        const hit = data.find((a) => a.name && normalizeAppName(a.name) === needle);
+        if (hit) return hit.name;
+      }
+    } catch {
+      // DB unavailable is NOT an authoritative miss — fall through to the registry mirror.
+    }
+  }
+
+  // Registry (file) fallback.
+  const { apps } = loadValidatedRegistry();
+  const hit = apps.find((a) => normalizeAppName(a.name) === needle);
+  if (hit) return hit.name;
+
+  // No registered match: return the input unchanged; the DB constraint validates.
+  return targetApp;
+}
+
+/**
  * Resolve a target_application to its GitHub org/repo string.
  *
  * @param {string} targetApp - Application name
@@ -313,6 +362,7 @@ export default {
   getRepoPaths,
   resolveRepoPath,
   resolveRepoPathDbFirst,
+  resolveCanonicalAppName,
   resolveGitHubRepo,
   normalizeAppName,
   isVentureRepo,

--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -33,6 +33,7 @@
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { resolveSdInput } from './lib/sd-id-resolver.js';
 import { getFilteredRetrospective } from './modules/handoff/retro-filters.js';
+import { resolveCanonicalAppName } from '../lib/repo-paths.js';
 import dotenv from 'dotenv';
 // import fs from 'fs'; // Currently unused - available for file operations if needed
 
@@ -156,9 +157,15 @@ async function generateRetrospective(sdInput) {
 
   // Generate high-quality retrospective content
   // Note: quality_score will be auto-calculated by trigger based on content quality
+  // SD-LEO-INFRA-VENTURE-REPO-AWARE-001 (FR-3): canonicalize target_application via the
+  // existing registry resolver so the value matches a registered applications.name (e.g.
+  // a venture like 'CronGenius'), and so the null-fallback yields constraint-valid
+  // 'EHG_Engineer' (the prior literal 'EHG_engineer' was lowercase and would itself violate
+  // the registry-aware check_target_application validation).
+  const canonicalTargetApp = await resolveCanonicalAppName(sd.target_application, supabase);
   const retrospective = {
     sd_id: sdId,
-    target_application: sd.target_application || 'EHG_engineer',
+    target_application: canonicalTargetApp,
     project_name: sd.title,
     retro_type: 'SD_COMPLETION',
     // QF-20260528-171 + SD-LEO-INFRA-DEFAULT-RETROSPECTIVES-RETROSPECTIVE-001: the

--- a/tests/integration/registry-aware-target-application-trigger.test.js
+++ b/tests/integration/registry-aware-target-application-trigger.test.js
@@ -1,0 +1,96 @@
+/**
+ * SD-LEO-INFRA-VENTURE-REPO-AWARE-001 — integration coverage for the
+ * registry-aware retrospectives.target_application trigger.
+ *
+ * Complements the unit test (tests/unit/registry-aware-target-application.test.js,
+ * which exercises the JS resolver against stubs) by asserting the actual DB-side
+ * trigger behavior — including the UPDATE path and the NULL edge — that vitest
+ * stubs cannot reach. All assertions run inside rolled-back transactions, so the
+ * suite never persists rows.
+ *
+ * LIVE-gated: requires a real DB connection. Skips (does not fail) when no pooler
+ * URL is configured, so hermetic CI without DB creds stays green.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const HAS_DB = !!(process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.SUPABASE_DB_URL);
+const SD = 'ad881b08-afc0-49ae-ac31-ba9b8c66d234';
+
+const COLS = `(sd_id, target_application, project_name, retro_type, title, description, conducted_date,
+   learning_category, quality_score, key_learnings, what_went_well, action_items,
+   what_needs_improvement, agents_involved, retrospective_type)`;
+const VALS = `($1,$2,'integration-test','SD_COMPLETION','x','x',now(),'PROCESS_IMPROVEMENT',85,
+   '[{"learning":"x"}]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb, ARRAY['LEAD'], NULL)`;
+
+describe.skipIf(!HAS_DB)('registry-aware target_application trigger (LIVE, rolled back)', () => {
+  let client;
+
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    client = await createDatabaseClient('engineer', { verify: false });
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  async function inTxn(fn) {
+    await client.query('BEGIN');
+    try {
+      const result = await fn();
+      await client.query('ROLLBACK');
+      return { ok: true, result };
+    } catch (e) {
+      await client.query('ROLLBACK');
+      return { ok: false, message: e.message };
+    }
+  }
+
+  const insert = (app) =>
+    client.query(`INSERT INTO retrospectives ${COLS} VALUES ${VALS} RETURNING id`, [SD, app]);
+
+  it('INSERT: accepts a registered venture (CronGenius)', async () => {
+    const r = await inTxn(() => insert('CronGenius'));
+    expect(r.ok).toBe(true);
+  });
+
+  it('INSERT: accepts a registered venture case-insensitively (crongenius)', async () => {
+    const r = await inTxn(() => insert('crongenius'));
+    expect(r.ok).toBe(true);
+  });
+
+  it('INSERT: accepts platform values via fail-open short-circuit (EHG, EHG_Engineer)', async () => {
+    expect((await inTxn(() => insert('EHG'))).ok).toBe(true);
+    expect((await inTxn(() => insert('EHG_Engineer'))).ok).toBe(true);
+  });
+
+  it('INSERT: rejects an unregistered app with the actionable error', async () => {
+    const r = await inTxn(() => insert('BogusUnregistered_zzz'));
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/not a registered application/);
+  });
+
+  it('INSERT: rejects NULL target_application (column is NOT NULL + trigger guard)', async () => {
+    const r = await inTxn(() => insert(null));
+    expect(r.ok).toBe(false);
+  });
+
+  it('UPDATE: re-validates target_application — rejects change to an unregistered value', async () => {
+    const r = await inTxn(async () => {
+      const ins = await insert('EHG');
+      const id = ins.rows[0].id;
+      await client.query(`UPDATE retrospectives SET target_application='BogusUnregistered_zzz' WHERE id=$1`, [id]);
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/not a registered application/);
+  });
+
+  it('UPDATE: accepts change to a registered venture (EHG -> CronGenius)', async () => {
+    const r = await inTxn(async () => {
+      const ins = await insert('EHG');
+      const id = ins.rows[0].id;
+      await client.query(`UPDATE retrospectives SET target_application='CronGenius' WHERE id=$1`, [id]);
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/tests/integration/registry-aware-target-application-trigger.test.js
+++ b/tests/integration/registry-aware-target-application-trigger.test.js
@@ -16,11 +16,15 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 const HAS_DB = !!(process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.SUPABASE_DB_URL);
 const SD = 'ad881b08-afc0-49ae-ac31-ba9b8c66d234';
 
-const COLS = `(sd_id, target_application, project_name, retro_type, title, description, conducted_date,
+// Fully static SQL — only $1 (sd_id) and $2 (target_application) are bound parameters;
+// every other column is a constant literal. No variable interpolation into the query string.
+const INSERT_SQL = `INSERT INTO retrospectives
+  (sd_id, target_application, project_name, retro_type, title, description, conducted_date,
    learning_category, quality_score, key_learnings, what_went_well, action_items,
-   what_needs_improvement, agents_involved, retrospective_type)`;
-const VALS = `($1,$2,'integration-test','SD_COMPLETION','x','x',now(),'PROCESS_IMPROVEMENT',85,
-   '[{"learning":"x"}]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb, ARRAY['LEAD'], NULL)`;
+   what_needs_improvement, agents_involved, retrospective_type)
+  VALUES ($1,$2,'integration-test','SD_COMPLETION','x','x',now(),'PROCESS_IMPROVEMENT',85,
+   '[{"learning":"x"}]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb,'["x"]'::jsonb, ARRAY['LEAD'], NULL)
+  RETURNING id`;
 
 describe.skipIf(!HAS_DB)('registry-aware target_application trigger (LIVE, rolled back)', () => {
   let client;
@@ -46,8 +50,7 @@ describe.skipIf(!HAS_DB)('registry-aware target_application trigger (LIVE, rolle
     }
   }
 
-  const insert = (app) =>
-    client.query(`INSERT INTO retrospectives ${COLS} VALUES ${VALS} RETURNING id`, [SD, app]);
+  const insert = (app) => client.query(INSERT_SQL, [SD, app]);
 
   it('INSERT: accepts a registered venture (CronGenius)', async () => {
     const r = await inTxn(() => insert('CronGenius'));

--- a/tests/unit/registry-aware-target-application.test.js
+++ b/tests/unit/registry-aware-target-application.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveCanonicalAppName, normalizeAppName, clearCache } from '../../lib/repo-paths.js';
+
+// Minimal stub mirroring the supabase chain used by resolveCanonicalAppName:
+//   supabase.from('applications').select('name, status').eq('status','active') -> { data, error }
+function stubSupabase(rows, { error = null } = {}) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            eq() {
+              return Promise.resolve({ data: rows, error });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('SD-LEO-INFRA-VENTURE-REPO-AWARE-001 — resolveCanonicalAppName', () => {
+  beforeEach(() => clearCache());
+
+  describe('null / empty / platform passthrough (FR-3 casing fix)', () => {
+    it('null/undefined fall back to constraint-valid "EHG_Engineer" (NOT lowercase "EHG_engineer")', async () => {
+      expect(await resolveCanonicalAppName(null)).toBe('EHG_Engineer');
+      expect(await resolveCanonicalAppName(undefined)).toBe('EHG_Engineer');
+      expect(await resolveCanonicalAppName('')).toBe('EHG_Engineer');
+    });
+
+    it('platform values pass through unchanged without needing the registry', async () => {
+      expect(await resolveCanonicalAppName('EHG')).toBe('EHG');
+      expect(await resolveCanonicalAppName('EHG_Engineer')).toBe('EHG_Engineer');
+    });
+
+    it('normalizes platform case/separator variants to canonical form', async () => {
+      expect(await resolveCanonicalAppName('ehg')).toBe('EHG');
+      expect(await resolveCanonicalAppName('EHG_ENGINEER')).toBe('EHG_Engineer');
+      expect(await resolveCanonicalAppName('ehg_engineer')).toBe('EHG_Engineer');
+    });
+  });
+
+  describe('DB-first registry resolution (case/separator-insensitive)', () => {
+    const apps = [
+      { name: 'CronGenius', status: 'active' },
+      { name: 'CommitCraft AI', status: 'active' },
+    ];
+
+    it('canonicalizes a registered venture to its applications.name', async () => {
+      expect(await resolveCanonicalAppName('crongenius', stubSupabase(apps))).toBe('CronGenius');
+      expect(await resolveCanonicalAppName('CRON-GENIUS', stubSupabase(apps))).toBe('CronGenius');
+      expect(await resolveCanonicalAppName('CronGenius', stubSupabase(apps))).toBe('CronGenius');
+    });
+
+    it('matches across separator drift (display name vs slug)', async () => {
+      expect(await resolveCanonicalAppName('commitcraft-ai', stubSupabase(apps))).toBe('CommitCraft AI');
+      expect(await resolveCanonicalAppName('commitcraft_ai', stubSupabase(apps))).toBe('CommitCraft AI');
+    });
+
+    it('returns the input UNCHANGED for an unregistered app (no silent platform fallback)', async () => {
+      expect(await resolveCanonicalAppName('BogusUnregistered', stubSupabase(apps))).toBe('BogusUnregistered');
+    });
+
+    it('falls through to the registry mirror when the DB query errors', async () => {
+      // commitcraft-ai is APP005 in applications/registry.json (the file fallback tier)
+      const errored = stubSupabase(null, { error: { message: 'db down' } });
+      expect(await resolveCanonicalAppName('commitcraft-ai', errored)).toBe('commitcraft-ai');
+    });
+  });
+
+  describe('JS/SQL normalize parity (pins the trigger contract)', () => {
+    // The migration trigger uses regexp_replace(lower(x), \'[^a-z0-9]\', \'\', \'g\').
+    // normalizeAppName MUST collapse the same way so a value accepted in JS is accepted in SQL.
+    it('normalizeAppName = lowercase + strip non-alphanumeric', () => {
+      expect(normalizeAppName('CronGenius')).toBe('crongenius');
+      expect(normalizeAppName('cron-genius')).toBe('crongenius');
+      expect(normalizeAppName('Cron Genius')).toBe('crongenius');
+      expect(normalizeAppName('CommitCraft AI')).toBe('commitcraftai');
+      expect(normalizeAppName('EHG_Engineer')).toBe('ehgengineer');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Foundation for the venture-repo-aware LEO completion pipeline (CronGenius first-venture pilot, Track-2). The `retrospectives.check_target_application` CHECK (`= ANY (ARRAY['EHG','EHG_Engineer'])`) was the single **non-bypassable** blocker stopping a venture (CronGenius) from completing its LEAD-FINAL retrospective.

- **Migration** (`database/migrations/20260528_registry_aware_retrospectives_target_application.sql`): drops the static 2-value CHECK; adds a `BEFORE INSERT/UPDATE` trigger validating `target_application` against the authoritative `applications` registry table (case/separator-insensitive). Platform values (`EHG`/`EHG_Engineer`) short-circuit **before** the query (fail-open), so the change is **strictly more permissive** than the old CHECK — it cannot break any currently-valid insert. A `DO`-block regression invariant asserts every existing value stays valid. **Already applied live.**
- **`lib/repo-paths.js`**: added thin `resolveCanonicalAppName` (DB-first against `applications`, registry fallback, platform passthrough) — **reuses** the existing resolver, no new module.
- **`scripts/generate-retrospective.js`**: fixed line-161 fallback casing `'EHG_engineer'` → `'EHG_Engineer'` (the lowercase value would itself violate the constraint) + canonicalizes via the resolver.

**Mechanism choice:** trigger over FK (too case-sensitive) and JS-only (weakens DB integrity). **VERIFY-FIRST** shrank scope ~60% — the resolver + `applications` table already existed.

**Deferred to separate SDs:** repo-aware SCOPE_COMPLETION; GATE2 ambiguity scan; venture PR_MERGE_VERIFICATION + computeReposForSD; skip-and-continue timestamp bug; bypass-rubric 'unclear' false-classify.

## Test plan
- [x] Unit: `tests/unit/registry-aware-target-application.test.js` — 8/8 (resolver + JS/SQL normalize parity)
- [x] Integration (LIVE-gated): `tests/integration/registry-aware-target-application-trigger.test.js` — 7/7 (INSERT accept/reject + UPDATE re-validation + NULL)
- [x] Live smoke: CronGenius / EHG / EHG_Engineer / crongenius ACCEPTED; bogus REJECTED with actionable error
- [x] Dogfood: this SD's own retrospective insert passed through the new trigger; old CHECK confirmed gone
- [x] Regression: existing values (EHG ×987, EHG_Engineer ×5498) remain valid (migration invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)