### PR TITLE
chore(llm): bump Opus model references 4.7 -> 4.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ AUTO-PROCEED is ON by default. You continue through phase transitions, PRD creat
 
 If your reason for pausing is not on the five-point list above, KEEP WORKING. When in doubt: pick the highest-value option, state it in one sentence, and execute.
 
-> Why: Opus 4.7 interprets instructions literally — implicit "the user approved the SD at LEAD" inferences do not auto-extend across downstream phase boundaries unless enumerated. Confirmation-fishing is the most common AUTO-PROCEED failure mode. This section is canonical; any other doc that conflicts defers to the five-point list here.
+> Why: Opus 4.8 interprets instructions literally — implicit "the user approved the SD at LEAD" inferences do not auto-extend across downstream phase boundaries unless enumerated. Confirmation-fishing is the most common AUTO-PROCEED failure mode. This section is canonical; any other doc that conflicts defers to the five-point list here.
 
 ## Issue Resolution
 When you encounter ANY issue: **STOP. Do not retry blindly. Do not work around it.**
@@ -39,7 +39,7 @@ Invoke the RCA Sub-Agent (`subagent_type="rca-agent"`). Your prompt MUST contain
 1. **Follow LEAD→PLAN→EXEC** - Target gate pass rate: 85%. SD-type overrides (60-90% range) require documented justification per CLAUDE_LEAD.md.
 > Why: Each phase produces a gate-validated artifact (strategic intent → PRD → code). Skipping phases means the next gate has no artifact to validate against, causing failures that are expensive to unwind.
 2. **Sub-agent evidence required at every handoff** - Invoke required agents via the Task tool before running `handoff.js execute`. Each agent writes to `sub_agent_execution_results`; handoff blocks with `SUBAGENT_EVIDENCE_MISSING` if no fresh row exists for the current phase. Manual DB checks are not evidence.
-> Why: Gates query `sub_agent_execution_results` for formal, database-backed validation. Opus 4.7 defaults to fewer sub-agent spawns — this rule makes invocation a hard requirement, not a best practice. Prompt-level "should use sub-agents" is not enforceable; the row is.
+> Why: Gates query `sub_agent_execution_results` for formal, database-backed validation. Opus 4.8 defaults to fewer sub-agent spawns — this rule makes invocation a hard requirement, not a best practice. Prompt-level "should use sub-agents" is not enforceable; the row is.
 3. **Database-first** - No markdown files as source of truth
 > Why: Markdown files drift silently and are never validated. The DB enforces schema constraints, tracks state transitions, and is the only source future sessions can query reliably to resume work.
 4. **USE PROCESS SCRIPTS** - ⚠️ Never bypass add-prd-to-database.js or handoff.js outside a documented emergency path ⚠️
@@ -86,7 +86,7 @@ Sessions operate in one of two modes that govern how you treat harness bugs (LEO
 - Current SD is any other type → **product mode**
 - No SD claimed and user intent is ambiguous → ask the user once; otherwise default to **product mode**
 
-> Why: Opus 4.7 reads instructions literally and resists rationalizing around countable rules. Without a declared mode, implicit "is this harness work or product work" inference drifts, causing product sessions to get consumed by opportunistic meta-work. The mode declaration turns user intent into a literal switch — product sessions defer, campaign sessions fix inline, no judgment calls in between.
+> Why: Opus 4.8 reads instructions literally and resists rationalizing around countable rules. Without a declared mode, implicit "is this harness work or product work" inference drifts, causing product sessions to get consumed by opportunistic meta-work. The mode declaration turns user intent into a literal switch — product sessions defer, campaign sessions fix inline, no judgment calls in between.
 
 User may override at any point by stating `[MODE: product]` or `[MODE: campaign]` in the conversation. Most recent declaration wins. If mode is unclear at the start of substantive work, state the mode you've inferred in one sentence before proceeding (e.g., *"Treating this as [MODE: product] — current SD is SD-EHG-MARKETING-..."*).
 

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -86,7 +86,7 @@ Skipping CLAUDE_CORE.md causes: unknown SD type requirements, missed gate thresh
 1. **Follow LEAD→PLAN→EXEC** - Target gate pass rate: 85%. SD-type overrides (60-90% range) require documented justification per CLAUDE_LEAD.md.
 > Why: Each phase produces a gate-validated artifact (strategic intent → PRD → code). Skipping phases means the next gate has no artifact to validate against, causing failures that are expensive to unwind.
 2. **Sub-agent evidence required at every handoff** - Invoke required agents via the Task tool before running `handoff.js execute`. Each agent writes to `sub_agent_execution_results`; handoff blocks with `SUBAGENT_EVIDENCE_MISSING` if no fresh row exists for the current phase. Manual DB checks are not evidence.
-> Why: Gates query `sub_agent_execution_results` for formal, database-backed validation. Opus 4.7 defaults to fewer sub-agent spawns — this rule makes invocation a hard requirement, not a best practice. Prompt-level "should use sub-agents" is not enforceable; the row is.
+> Why: Gates query `sub_agent_execution_results` for formal, database-backed validation. Opus 4.8 defaults to fewer sub-agent spawns — this rule makes invocation a hard requirement, not a best practice. Prompt-level "should use sub-agents" is not enforceable; the row is.
 3. **Database-first** - No markdown files as source of truth
 > Why: Markdown files drift silently and are never validated. The DB enforces schema constraints, tracks state transitions, and is the only source future sessions can query reliably to resume work.
 4. **USE PROCESS SCRIPTS** - ⚠️ Never bypass add-prd-to-database.js or handoff.js outside a documented emergency path ⚠️

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -3,7 +3,7 @@
 **Generated**: 2026-05-27 4:44:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
-**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.7 guidance)
+**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
 
 > For Issue Resolution Protocol + Five-Point Brief, see CLAUDE.md.
 > For migration execution and phase transitions, see CLAUDE_CORE.md.

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -8,7 +8,7 @@
 
 **Protocol**: LEO 4.4.1
 **Purpose**: Implementation requirements and constraints (<10k chars)
-**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.7 guidance)
+**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
 
 ---
 

--- a/database/migrations/20260528_add_claude_opus_4_8.sql
+++ b/database/migrations/20260528_add_claude_opus_4_8.sql
@@ -1,0 +1,54 @@
+-- Migration: Add Claude Opus 4.8 to model registry, deprecate Opus 4.7
+-- Date: 2026-05-28
+-- Context: Anthropic released Opus 4.8. Sonnet stays at 4.6 and Haiku at 4.5 —
+-- only Opus advanced. Mirrors database/migrations/20260422_add_claude_opus_4_7.sql.
+-- Code defaults for `generation` (S17 variant HTML), `complex-reasoning`, the
+-- brainstorm anthropic rotation, and the eva-support default model were bumped to
+-- claude-opus-4-8 in the same change set.
+--
+-- Idempotent: INSERT uses WHERE NOT EXISTS; the deprecate UPDATE is guarded on status.
+--
+-- ⚠️ PRICING: input_per_1m / output_per_1m below are carried over from Opus 4.7
+-- ($15 / $75). VERIFY against Anthropic's pricing page before relying on cost
+-- tracking, and correct here + in lib/ai/multimodal-client.js if they differ.
+
+-- 1. Insert Opus 4.8 (leo_tier copied from the existing 4.7 row to preserve routing)
+INSERT INTO llm_models (
+  provider_id, model_key, model_name, model_family, model_version,
+  model_tier, context_window, max_output_tokens,
+  supports_function_calling, supports_vision, supports_streaming, supports_system_prompt,
+  pricing, status, release_date, metadata, leo_tier
+)
+SELECT
+  (SELECT id FROM llm_providers WHERE provider_key = 'anthropic'),
+  'claude-opus-4-8', 'Claude Opus 4.8', 'claude', '4.8',
+  'flagship', 1000000, 8192,
+  true, true, true, true,
+  '{"input_per_1m": 15.00, "output_per_1m": 75.00}'::jsonb,  -- VERIFY: carried over from 4.7
+  'active', '2026-05-28',
+  jsonb_build_object(
+    'supersedes', 'claude-opus-4-7',
+    'added_at', '2026-05-28',
+    'added_by', 'opus 4.7->4.8 mechanical model bump'
+  ),
+  (SELECT leo_tier FROM llm_models WHERE model_key = 'claude-opus-4-7')
+WHERE NOT EXISTS (
+  SELECT 1 FROM llm_models WHERE model_key = 'claude-opus-4-8'
+);
+
+-- 2. Deprecate Opus 4.7 (row kept — usage logs reference it)
+UPDATE llm_models
+SET status = 'deprecated',
+    deprecation_date = CURRENT_DATE,
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'superseded_by', 'claude-opus-4-8',
+      'deprecated_at', CURRENT_DATE::text
+    )
+WHERE model_key = 'claude-opus-4-7'
+  AND status != 'deprecated';
+
+-- 3. Verify
+--   SELECT model_key, status, deprecation_date, context_window, leo_tier
+--   FROM llm_models
+--   WHERE model_key LIKE 'claude-opus-4-%'
+--   ORDER BY model_key;

--- a/database/migrations/20260528_opus48_prose_alignment.mjs
+++ b/database/migrations/20260528_opus48_prose_alignment.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Migration: Opus 4.8 prose alignment — model-name bump in protocol sections
+ * Date: 2026-05-28
+ *
+ * Companion to 20260528_add_claude_opus_4_8.sql. The CLAUDE.md family is
+ * regenerated from leo_protocol_sections, so any section content that names the
+ * operating model ("Opus 4.7" / "claude-opus-4-7") must be bumped in the DB or
+ * the next `generate-claude-md-from-db.js` run will re-introduce "Opus 4.7".
+ *
+ * This is a MECHANICAL rename only (model identifier). It does NOT re-evaluate
+ * the behavioral claims attached to that name (e.g. "interprets instructions
+ * literally", "defaults to fewer sub-agent spawns") — that is the deferred
+ * Tier-3 harness-alignment question.
+ *
+ * Mirrors the surgical, hash-logged style of 20260424_opus47_harness_alignment.mjs
+ * but uses substring replacement (robust to surrounding-text drift) scoped to rows
+ * that actually contain the tokens.
+ *
+ * Run:
+ *   node database/migrations/20260528_opus48_prose_alignment.mjs          (DRY — preview only)
+ *   node database/migrations/20260528_opus48_prose_alignment.mjs --apply  (write)
+ *
+ * Idempotent: re-running after apply is a no-op (the old tokens no longer match).
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+
+const APPLY = process.argv.includes('--apply');
+
+const REPLACEMENTS = [
+  { find: /Opus 4\.7/g,       replace: 'Opus 4.8' },
+  { find: /claude-opus-4-7/g, replace: 'claude-opus-4-8' },
+];
+
+const sha8 = (s) => crypto.createHash('sha256').update(s).digest('hex').slice(0, 8);
+
+function applyAll(text) {
+  let out = text;
+  for (const r of REPLACEMENTS) out = out.replace(r.find, r.replace);
+  return out;
+}
+
+// Pull the lines that changed so the operator can eyeball the diff in --dry.
+function changedLines(before, after) {
+  const b = before.split('\n');
+  const a = after.split('\n');
+  const out = [];
+  for (let i = 0; i < Math.max(b.length, a.length); i++) {
+    if (b[i] !== a[i]) out.push({ before: b[i], after: a[i] });
+  }
+  return out;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) {
+    console.error('[opus48-prose] MISSING CREDS — need SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env.');
+    process.exit(1);
+  }
+  const s = createClient(url, key);
+  console.log(`[opus48-prose] mode=${APPLY ? 'APPLY' : 'DRY'} date=2026-05-28`);
+
+  const { data: rows, error } = await s
+    .from('leo_protocol_sections')
+    .select('id, title, content');
+  if (error) {
+    console.error('[opus48-prose] FETCH FAILED:', error.message);
+    process.exit(1);
+  }
+
+  let touched = 0, updated = 0, failed = 0;
+
+  for (const row of rows) {
+    const before = row.content || '';
+    if (!/Opus 4\.7|claude-opus-4-7/.test(before)) continue;
+
+    const after = applyAll(before);
+    if (after === before) continue;
+
+    touched++;
+    console.log(`\n[id=${row.id}] ${row.title}  ${sha8(before)} -> ${sha8(after)}`);
+    for (const { before: b, after: a } of changedLines(before, after)) {
+      console.log(`  - ${b.trim().slice(0, 140)}`);
+      console.log(`  + ${a.trim().slice(0, 140)}`);
+    }
+
+    if (!APPLY) continue;
+
+    const { error: uerr } = await s
+      .from('leo_protocol_sections')
+      .update({ content: after })
+      .eq('id', row.id);
+    if (uerr) {
+      console.error(`  UPDATE FAILED:`, uerr.message);
+      failed++;
+    } else {
+      console.log('  UPDATE OK');
+      updated++;
+    }
+  }
+
+  console.log(`\n[opus48-prose] summary — rows_with_token=${touched} updated=${updated} failed=${failed}`);
+  if (!APPLY && touched > 0) {
+    console.log('[opus48-prose] DRY run only. Re-run with --apply to write, then regenerate:');
+    console.log('  node scripts/generate-claude-md-from-db.js');
+  }
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/lib/ai/multimodal-client.js
+++ b/lib/ai/multimodal-client.js
@@ -34,7 +34,8 @@ class MultimodalClient {
       'claude-sonnet-4-6': { input: 3.00, output: 15.00 },  // Claude Sonnet 4.6
       'claude-sonnet-4': { input: 3.00, output: 15.00 },  // Claude Sonnet 4 (legacy)
       'claude-sonnet-3.7': { input: 3.00, output: 15.00 },  // Claude Sonnet 3.7 (legacy)
-      'claude-opus-4-7': { input: 15.00, output: 75.00 },  // Claude Opus 4.7
+      'claude-opus-4-8': { input: 15.00, output: 75.00 },  // Claude Opus 4.8 — VERIFY pricing against Anthropic pricing page (assumed same as 4.7)
+      'claude-opus-4-7': { input: 15.00, output: 75.00 },  // Claude Opus 4.7 (superseded)
       'claude-opus-4-6': { input: 15.00, output: 75.00 },  // Claude Opus 4.6 (deprecated)
       'claude-opus-4': { input: 15.00, output: 75.00 },  // Claude Opus 4 (legacy)
       'claude-haiku-4-5-20251001': { input: 1.00, output: 5.00 },  // Claude Haiku 4.5
@@ -461,7 +462,7 @@ Respond in JSON format:
   getAvailableModels() {
     const models = {
       openai: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano'],
-      anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5-20251001'],
+      anthropic: ['claude-sonnet-4-6', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-haiku-4-5-20251001'],
       google: ['gemini-2.5-pro', 'gemini-2.5-flash'],
       gemini: ['gemini-2.5-pro', 'gemini-2.5-flash'],
       local: ['llava', 'blip', 'cogvlm']
@@ -527,7 +528,7 @@ Respond in JSON format:
       'high-accuracy': 'gemini-2.5-pro',  // Best accuracy, multimodal native
       'balanced': 'gemini-2.5-flash',  // Good balance of cost and performance
       'low-cost': 'gemini-2.5-flash',  // Cheapest option
-      'complex-reasoning': 'claude-opus-4-7',  // Complex analysis
+      'complex-reasoning': 'claude-opus-4-8',  // Complex analysis
       'fast-screening': 'gemini-2.5-flash',  // Quick checks
       'default': 'gemini-2.5-pro'
     };

--- a/lib/brainstorm/provider-rotation.js
+++ b/lib/brainstorm/provider-rotation.js
@@ -57,7 +57,7 @@ export function getProviderAssignments(sessionIndex, seatCodes) {
  */
 function getModelIdForProvider(provider) {
   const defaults = {
-    anthropic: 'claude-opus-4-7',
+    anthropic: 'claude-opus-4-8',
     google: 'gemini-2.5-pro',
     openai: 'gpt-5.4'
   };

--- a/lib/config/model-config.js
+++ b/lib/config/model-config.js
@@ -40,7 +40,7 @@ const MODEL_DEFAULTS = {
   claude: {
     validation: 'claude-sonnet-4-6',
     classification: 'claude-haiku-4-5-20251001',
-    generation: 'claude-sonnet-4-6',   // Downgraded from opus-4-7 (2026-04-19). Claude is now fallback provider — Google Gemini is default for cost control. Opus 4.7 only used in archetype-generator.js for S17 variant HTML.
+    generation: 'claude-sonnet-4-6',   // Downgraded from opus (2026-04-19). Claude is now fallback provider — Google Gemini is default for cost control. Opus 4.8 only used in archetype-generator.js for S17 variant HTML.
     fast: 'claude-haiku-4-5-20251001',
     vision: 'claude-haiku-4-5-20251001',
   },

--- a/lib/eva/stage-17/refinement.js
+++ b/lib/eva/stage-17/refinement.js
@@ -32,11 +32,11 @@ import { writeArtifact } from '../artifact-persistence-service.js';
  */
 export async function generateRefinedVariants(ventureId, screenName, selectedHtmls, tokens, supabase, options = {}) {
   const { getLLMClient } = await import('../../llm/client-factory.js');
-  // COST CONTROL (2026-04-19): Refined variant HTML generation uses Opus 4.7 explicitly.
-  // Same rationale as generateArchetypeVariants above — variant HTML requires Opus-level
-  // design fidelity. All other LLM calls default to Google Gemini for cost savings.
-  // Override via CLAUDE_MODEL_S17_GENERATION env var if needed.
-  const generationModel = process.env.CLAUDE_MODEL_S17_GENERATION || 'claude-opus-4-7';
+  // COST CONTROL (2026-04-19; model bumped 2026-05-28): Refined variant HTML generation
+  // uses Opus 4.8 explicitly. Same rationale as generateArchetypeVariants above — variant
+  // HTML requires Opus-level design fidelity. All other LLM calls default to Google Gemini
+  // for cost savings. Override via CLAUDE_MODEL_S17_GENERATION env var if needed.
+  const generationModel = process.env.CLAUDE_MODEL_S17_GENERATION || 'claude-opus-4-8';
   const client = getLLMClient({ purpose: 'generation', provider: 'anthropic', model: generationModel });
 
   const mobileContext = options.mobileContextHtml

--- a/lib/eva/utils/token-tracker.js
+++ b/lib/eva/utils/token-tracker.js
@@ -32,7 +32,7 @@ const budgetCache = new Map();
  * @param {number} [params.usage.outputTokens=0]
  * @param {Object} [params.metadata] - Additional metadata
  * @param {string} [params.metadata.agentType] - e.g. 'claude', 'openai'
- * @param {string} [params.metadata.modelId] - e.g. 'claude-opus-4-7'
+ * @param {string} [params.metadata.modelId] - e.g. 'claude-opus-4-8'
  * @param {string} [params.metadata.operationType] - e.g. 'analysis', 'generation'
  * @param {string} [params.metadata.stepId] - Analysis step identifier
  * @param {number} [params.metadata.attempt] - Retry attempt number

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -10,7 +10,7 @@
  * 5. Provides unified interface for all LLM operations
  * 6. Cascade priority: Google/Gemini → Anthropic → OpenAI → Ollama
  *    (Changed 2026-04-19: Google promoted to default to reduce Anthropic API costs.
- *     Anthropic Opus 4.7 reserved for S17 variant HTML only — see archetype-generator.js.
+ *     Anthropic Opus 4.8 reserved for S17 variant HTML only — see archetype-generator.js.
  *     Set LLM_PROVIDER=anthropic to override back to Anthropic-first.)
  *
  * @module lib/llm/client-factory
@@ -334,7 +334,7 @@ export function getLLMClient(options = {}) {
 
     // Priority: Google Gemini → Anthropic (thinking) → OpenAI → inline stub
     // COST CONTROL (2026-04-19): Google is default to reduce Anthropic API spend.
-    // Anthropic Opus 4.7 reserved for S17 variant HTML generation only (archetype-generator.js).
+    // Anthropic Opus 4.8 reserved for S17 variant HTML generation only (archetype-generator.js).
     // LLM_PROVIDER=anthropic skips Google even when key is present
     if ((process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY) && preferredProvider !== 'anthropic') {
       const googleModel = effortOrTier === 'high'

--- a/scripts/eva-support/_internal/anthropic-client.js
+++ b/scripts/eva-support/_internal/anthropic-client.js
@@ -8,7 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
-export const DEFAULT_MODEL = 'claude-opus-4-7';
+export const DEFAULT_MODEL = 'claude-opus-4-8';
 
 export function createAnthropicClient() {
   const apiKey = process.env.ANTHROPIC_API_KEY;

--- a/scripts/modules/claude-md-generator/digest-generators.js
+++ b/scripts/modules/claude-md-generator/digest-generators.js
@@ -322,7 +322,7 @@ function generateExecDigest(data, fileMapping, metadata) {
 
 **Protocol**: LEO ${protocol.version}
 **Purpose**: Implementation requirements and constraints (<10k chars)
-**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.7 guidance)
+**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
 
 ---
 

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -98,7 +98,7 @@ AUTO-PROCEED is ON by default. You continue through phase transitions, PRD creat
 
 If your reason for pausing is not on the five-point list above, KEEP WORKING. When in doubt: pick the highest-value option, state it in one sentence, and execute.
 
-> Why: Opus 4.7 interprets instructions literally — implicit "the user approved the SD at LEAD" inferences do not auto-extend across downstream phase boundaries unless enumerated. Confirmation-fishing is the most common AUTO-PROCEED failure mode. This section is canonical; any other doc that conflicts defers to the five-point list here.
+> Why: Opus 4.8 interprets instructions literally — implicit "the user approved the SD at LEAD" inferences do not auto-extend across downstream phase boundaries unless enumerated. Confirmation-fishing is the most common AUTO-PROCEED failure mode. This section is canonical; any other doc that conflicts defers to the five-point list here.
 
 ## Issue Resolution
 When you encounter ANY issue: **STOP. Do not retry blindly. Do not work around it.**
@@ -123,7 +123,7 @@ Sessions operate in one of two modes that govern how you treat harness bugs (LEO
 - Current SD is any other type → **product mode**
 - No SD claimed and user intent is ambiguous → ask the user once; otherwise default to **product mode**
 
-> Why: Opus 4.7 reads instructions literally and resists rationalizing around countable rules. Without a declared mode, implicit "is this harness work or product work" inference drifts, causing product sessions to get consumed by opportunistic meta-work. The mode declaration turns user intent into a literal switch — product sessions defer, campaign sessions fix inline, no judgment calls in between.
+> Why: Opus 4.8 reads instructions literally and resists rationalizing around countable rules. Without a declared mode, implicit "is this harness work or product work" inference drifts, causing product sessions to get consumed by opportunistic meta-work. The mode declaration turns user intent into a literal switch — product sessions defer, campaign sessions fix inline, no judgment calls in between.
 
 User may override at any point by stating \`[MODE: product]\` or \`[MODE: campaign]\` in the conversation. Most recent declaration wins. If mode is unclear at the start of substantive work, state the mode you've inferred in one sentence before proceeding (e.g., *"Treating this as [MODE: product] — current SD is SD-EHG-MARKETING-..."*).
 
@@ -404,7 +404,7 @@ function generateExec(data, fileMapping) {
 **Generated**: ${today} ${time}
 **Protocol**: LEO ${protocol.version}
 **Purpose**: EXEC agent implementation requirements and testing
-**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.7 guidance)
+**Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
 
 > For Issue Resolution Protocol + Five-Point Brief, see CLAUDE.md.
 > For migration execution and phase transitions, see CLAUDE_CORE.md.


### PR DESCRIPTION
## Summary
Mechanical Opus model-version bump (Tiers 1–2 of `docs/reference/model-version-upgrade-runbook.md`). Behavioral harness re-tuning is intentionally **deferred** — this only renames the model and updates the registry.

**Functional defaults → `claude-opus-4-8`:**
- `lib/eva/stage-17/refinement.js` — S17 variant-HTML generation default (the one live Opus path)
- `lib/ai/multimodal-client.js` — added 4.8 pricing + available-list entry (4.7 kept for back-compat), swapped `complex-reasoning` recommendation
- `lib/brainstorm/provider-rotation.js` — anthropic default
- `scripts/eva-support/_internal/anthropic-client.js` — `DEFAULT_MODEL`
- reservation comments in `lib/llm/client-factory.js`, `lib/config/model-config.js`, doc example in `token-tracker.js`

**Protocol prose `Opus 4.7` → `Opus 4.8`:**
- generator sources (`claude-md-generator/{file,digest}-generators.js`)
- regenerated artifacts: `CLAUDE.md`, `CLAUDE_DIGEST.md`, `CLAUDE_EXEC.md`, `CLAUDE_EXEC_DIGEST.md`

**DB scripts (run separately — no DB creds in the agent shell):**
- `database/migrations/20260528_add_claude_opus_4_8.sql` — registry: add 4.8, deprecate 4.7 (mirrors `20260422`)
- `database/migrations/20260528_opus48_prose_alignment.mjs` — `leo_protocol_sections` token rename; run `--apply` then regenerate CLAUDE.md

## Notes / follow-ups
- ⚠️ **Pricing**: 4.8 carried over 4.7's `$15/$75` with a `VERIFY` comment — confirm against Anthropic's pricing page.
- Layer-1 tier routing (`config/phase-model-config.json`, uses `haiku`/`sonnet`/`opus`) unchanged by design.
- Pre-existing failing test (NOT caused here): `tests/claude-md-generator/opus47-alignment.test.js` Module-G asserts a `docs/harness-backlog.md` reference that has 0 matches at HEAD.

## Test plan
- [x] `node --check` on all 9 edited JS/MJS files
- [x] `opus47-alignment.test.js` → 14/15 pass; the 1 failure is pre-existing & unrelated (confirmed 0 matches at HEAD before edits)
- [ ] After merge: apply both migrations + `node scripts/generate-claude-md-from-db.js`, confirm regenerated CLAUDE.md matches
- [ ] Confirm 4.8 pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)