### PR TITLE
docs(venture-pipeline): Venture Pipeline Playbook v1.1 (CronGenius M1 pilot learnings)

### DIFF
--- a/docs/reference/venture-pipeline-playbook.md
+++ b/docs/reference/venture-pipeline-playbook.md
@@ -1,0 +1,135 @@
+# Venture Pipeline Playbook v1.1
+
+> **Forward-looking guide for taking a venture through the EHG pipeline**, distilled from the **CronGenius M1 pilot** — the first venture to complete a full orchestrator (parent + 3 children) end-to-end. **Two-session-validated**: cross-checked across the independent executions of Child B (Phase 2: auth + abuse prevention) and Child C (Phase 3: observability + portal).
+>
+> Read this **before** starting venture #2. The blow-by-blow detail lives in the pilot journal (`project_crongenius_first_venture_pilot_2026_05_27.md`, findings F1–F22 + P-FAIL-1–6).
+
+---
+
+## The one-line principle
+
+The EHG control plane (LEO tooling + DB state, in `EHG_Engineer`) is a **different repo** from a venture's product code. The pipeline still has places that silently assume "the target is EHG/EHG_Engineer." Until those are all DB-resolved, **location and a handful of metadata flags are load-bearing** — this playbook is the checklist that keeps them correct so a venture ships without re-discovering every gap.
+
+---
+
+## 1. Canonical happy path
+
+```
+Stage 0–19 artifacts
+  → brainstorm board (now 7-seat incl. CMO + CGO)
+  → L2 vision (chairman-approved)
+  → archplan-command.mjs upsert        (MUST produce an implementation_phases section)
+  → create-orchestrator-from-plan.js --auto-children
+  → LEAD = CIRCUIT BREAKER             (approve if aligned, or bubble up — NEVER redesign)
+  → per child: LEAD → PLAN → EXEC → /ship   (code lives in the venture repo)
+  → parent EXEC is a WAIT-STATE        (idle until all children complete)
+  → parent auto-rolls-up to completed  (triggered by the LAST child to finish)
+```
+
+- **LEAD is a circuit breaker.** Approve if the decomposition matches the arch plan, or bubble up to the chairman. Do **not** redesign the decomposition at LEAD — that is an arch-layer decision (P-FAIL-2).
+- The pipeline tools are now discoverable from `CLAUDE_LEAD.md` + `sd-start` output (P-FAIL-3 fixed).
+- **Parent rollup is automatic** (ORCH-PARENT-LIFECYCLE-001): when the last child reaches `completed`, the parent rolls up to 100% with **zero manual parent handoff**. The trigger is the last child *by completion timestamp* — not a designated "final" child.
+
+---
+
+## 2. Pre-flight checklist (set/verify these, or a gate will block you)
+
+| ✔ | Item | Why / finding |
+|---|------|---------------|
+| ☐ | `target_application` = the venture (not `EHG_Engineer`) on the orchestrator **and every child** | `create-orchestrator-from-plan` still defaults `EHG_Engineer` (F3) |
+| ☐ | Worker shell stands **in the venture worktree**; LEO tooling invoked by absolute path + `--env-file` | native git, no `git -C` footgun (see Conventions) |
+| ☐ | **Re-derive the ambient session id on resume** — `echo $CLAUDE_SESSION_ID`; never trust a session id hardcoded in a resume/handoff prompt | F22: a stale id self-heals into a reaped "ghost"; re-claims under it resurrect a corpse |
+| ☐ | Arch plan contains an `implementation_phases` section | else `create-orchestrator` maps **0** children (F2) |
+| ☐ | Each child: `metadata.inherited_from_parent=true` (or a real `scope_slice`) | else SCOPE_COMPLETION scores the child against the **full parent** deliverable list (F17) |
+| ☐ | Each child that ships **UI** (a portal/SSR route): plan to clear WIRING_VALIDATION (see §4 F20) | backend-only children don't engage UI-wiring; UI children do (Child C) |
+| ☐ | LEAD enriches auto-gen child fields (`smoke_test_steps`, `risks`, description, scope) before LEAD-TO-PLAN | `create-orchestrator` leaves them skeletal (F5) — this is enrichment, not redesign |
+| ☐ | Sub-agents emit **forward-slash** `repo_path` = the venture `local_path` | the writer mangles Windows backslashes + the gate has no latest-row filter (F10/F11) |
+| ☐ | bun-on-Windows ventures: `bun install` in the worktree before `bun test` | `sd-start` "install skipped" is unreliable (F14); local prettier/eslint **CRLF errors are spurious** (`core.autocrlf=true` stores LF on commit) |
+| ☐ | Heartbeat: confirm your tick daemon is alive before claiming a reaped SD | F15 / heartbeat reference |
+
+---
+
+## 3. Already fixed — do **not** re-derive (shipped during the pilot)
+
+| Venture gap | Shipped SD |
+|-------------|-----------|
+| `/heal vision` path resolution to the venture repo (F1/F2/F3) | `SD-CRONGENIUS-LEO-INFRA-MAKE-HEAL-VISION-001` |
+| venture rubric **semantics** (LLM-generated at scoring time, content-hash cached) (F1) | `SD-LEO-INFRA-VENTURE-RUBRIC-SEMANTIC-001` |
+| auto-generated boilerplate stories hard-blocking PLAN-TO-EXEC (F12) | `SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001` (stories default `status=draft`) |
+| orchestrator-parent EXEC = wait-state + PLAN-TO-LEAD `WAIT` verdict + auto-rollup (F6/F7/F8) | `SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001` (`leo_protocol_sections` id 439) |
+| pipeline discoverability + LEAD-circuit-breaker + per-child cancel evaluation (P-FAIL-2/3/4) | `SD-LEO-INFRA-VENTURE-LIFECYCLE-PIPELINE-001` |
+| CMO + CGO brainstorm board seats (GTM voice) | `SD-LEO-INFRA-ADD-CMO-CHIEF-001` |
+| `retrospectives.target_application` accepts venture names (registry-aware trigger) | `SD-LEO-INFRA-VENTURE-REPO-AWARE-001` |
+
+*Confirmed still-working across both Child B and Child C: F12 held (no PLAN-TO-EXEC story block), VENTURE-REPO-AWARE retro accepted, F18 stayed advisory.*
+
+---
+
+## 4. Still assumes EHG — open gaps + the workaround for each (expect these)
+
+| Finding | Symptom on a venture | Workaround **now** | Backlog / SD |
+|---------|----------------------|--------------------|--------------|
+| **F10/F11** | sub-agent `repo_path` defaults to EHG; stale rows block the gate (no latest-row filter) | instruct forward-slash venture paths; surgically `UPDATE` the bad row's `metadata.repo_path` (preserve `repo_path_original`) | `SD-LEO-INFRA-VENTURE-SUBAGENT-RESOLUTION-001` (LEAD-approved, **unshipped**) |
+| **F16** | GATE2 ambiguity scan matches the word on an **unchanged git-show context line** | `--bypass-validation` (TOOLING_BUG rubric wording) | feedback `a75b4c19` |
+| **F17** | SCOPE_COMPLETION uses the **parent** arch's full file list | `metadata.inherited_from_parent=true` → soft-pass 70 | `86d4b91e` |
+| **F18** | GIT STATE quick-check scans the `EHG_Engineer` tree, not the venture worktree | **advisory only** — does not block; ignore | `228f1f78` |
+| **F19** | GatePolicyResolver resolves the target to EHG and disables GATE5 | harmless here (verify the venture commits actually exist) | `aabf0d46` |
+| **F20** | WIRE_CHECK / WIRING_VALIDATION are venture-unaware; UI children hit it as a **real block** | **two paths** — see below | `228f1f78` |
+| **F21** | GATE2 hard-requires E2E tests uniformly; backend/SSR slices score 0/20 on `[D1] "No E2E tests found"` → ride the YELLOW band; one slightly-lower score then hard-blocks | ensure other GATE2 dimensions are strong so the total stays in the YELLOW pass band; add E2E only where it makes sense | (propose new SD) |
+| **F22** | a **stale session id** carried in a resume/handoff prompt self-heals into a reaped ghost; re-claims under it fail | `echo $CLAUDE_SESSION_ID` to get the **ambient** id → `claimGuard(sd, ambientId)` → prefix all scripts with it. No code fix. (adjacent to F15) | (propose new SD) |
+| **F15** | FR-3 gate livelocks re-claim of a reaped SD (sweep re-emits `CLAIM_RELEASED` every ~5 min) | confirm the claim is genuinely free + your heartbeat is healthy, then claim — **no bypass** | `50615d1b` |
+
+### F20 — WIRING_VALIDATION has TWO recovery paths (important nuance from Child C)
+1. **Pre-flight (cleanest):** set `metadata.wiring_required=false` + a `wiring_opt_out_reason` *before* the gate fires → the gate becomes advisory and passes. Right for a separate-repo / non-EHG-wired venture API.
+2. **Post-fire recovery:** if the gate already fired (you didn't opt out in time), run
+   `node scripts/wiring-validators/wiring-validation-runner.js <SD>`
+   → it upserts `leo_wiring_validations`, the `trg_zz_maintain_wiring_validated` trigger derives `wiring_validated=true`, and the gate **passes 100%**.
+   The runner itself **exits FAIL** on `spec_code_drift` + `e2e_demo`, but those check-types are **non-required** — *ignore the exit code*.
+   - Sub-finding: the `e2e-demo-recorder` literally **shell-executes the PRD's prose demo steps** (e.g. "Open the /metrics page" → `Open` is not a recognized command) → spurious `e2e_demo` FAIL. Harmless given the above, but worth fixing.
+
+### The durable fix (the #1 stage-setting investment)
+**One Track-2 `[MODE: campaign]` umbrella SD: make every completion-pipeline gate resolve the target repo from `applications.local_path` (the resolver already exists) instead of the shell's cwd.** That single change retires **F16, F17, F18, F19, F20** as a class — location stops being load-bearing. It is the sibling of the already-shipped F3/F10 "defaults to EHG" fixes.
+
+---
+
+## 5. Conventions (established during the pilot)
+
+- **Working directory + post-merge sync** (`reference-venture-working-directory-convention`): stand in the venture worktree; GitHub is source-of-truth; after a squash-merge `git -C <venture-main> fetch && merge --ff-only origin/main`, then `worktree remove --force` + `branch -D` your finished worktree (only your own — others are reaped by their owners).
+- **Session / heartbeat / claim** (`reference-session-heartbeat-and-fr3-claim-livelock`): the interactive heartbeat is a detached `session-tick.cjs` daemon; re-derive the ambient `CLAUDE_SESSION_ID` on resume (F22).
+- **LEAD = circuit breaker**: approve or bubble up; never redesign.
+- **Per-child evaluation** before any bulk-cancel of an orchestrator's children (P-FAIL-4).
+- **Forward-slash `repo_path`** on every sub-agent evidence row.
+- **Bypass rubric**: noun{gate,validator,tool,script} + term{bug,false-positive,broken,regression}; avoid {unclear, too strict, skip}. (A `SEMANTIC_MISMATCH` category — "the gate's semantics don't apply to this SD type" — is a proposed addition, F8c.)
+- **Deterministic-first venture code**: e.g. CronGenius shipped a metrics-from-counters surface rather than new DB tables — smaller footprint, testable without external keys.
+
+---
+
+## 6. Forward-looking: a per-venture telemetry contract (from Child C)
+
+Child C shipped `/v1/metrics`; combined with Child B's API-key auth, that is the natural **per-venture telemetry surface for the chairman's portfolio rollup**: EHG pulls each venture's `/v1/metrics`, while ventures keep **isolated databases**. Worth standardizing as a **telemetry contract** (auth + `/v1/metrics` shape) for ventures 2..N so portfolio-level observability is uniform without coupling venture data stores.
+
+---
+
+## 7. The pilot meta-process (reusable for every venture)
+
+1. File a **pilot journal** for the venture.
+2. Run the venture through the pipeline; apply the §2 checklist and §4 workarounds as you go.
+3. Capture findings — `node scripts/log-harness-bug.js "<symptom>"` writes to `feedback` (`category=harness_backlog`) for a later sweep.
+4. Consolidate findings into Track-2 SDs; LEAD-approve.
+5. **Mode discipline:** `[MODE: product]` sessions **journal + backlog** (defer meta-SDs) and keep shipping; `[MODE: campaign]` sessions **file + fix**. A product session that trips a known gap applies the workaround and continues — it does not stop to fix the harness mid-flight.
+6. **Cross-validate** the playbook across at least two independent child executions before trusting it for the next venture (this v1.1 was validated across Child B + Child C).
+
+---
+
+## Provenance
+
+| | |
+|---|---|
+| Pilot | CronGenius (first venture), M1 launch orchestrator |
+| Orchestrator | `SD-CRONGENIUS-M1-LAUNCH-ORCHESTRATOR-ORCH-001` — completed 100% |
+| Child A | Phase 1: core inference primitive — `rickfelix/crongenius` PR #1 |
+| Child B | Phase 2: auth + abuse prevention — PR #4 (LEAD-FINAL 99) |
+| Child C | Phase 3: observability + /metrics portal — PR #3 (LEAD-FINAL 98) |
+| Findings | F1–F22, P-FAIL-1–6, O1–O6 (pilot journal) |
+| Validated by | independent executions of Child B (session 0241b644) + Child C (session 42e60e9c) |
+| Version | v1.1 — 2026-05-28 |


### PR DESCRIPTION
## Summary
Adds the **Venture Pipeline Playbook v1.1** (`docs/reference/venture-pipeline-playbook.md`) — a forward-looking guide for taking ventures through the EHG pipeline, distilled from the **CronGenius M1 pilot** (the first venture to complete a full orchestrator end-to-end: parent + 3 children).

**Two-session-validated** — cross-checked across the independent executions of Child B (Phase 2: auth + abuse prevention) and Child C (Phase 3: observability + portal). Contents:
- The canonical happy path + LEAD-as-circuit-breaker
- A pre-flight checklist (`target_application`, venture worktree, `inherited_from_parent`, wiring opt-out, ambient session-id hygiene, bun-on-Windows, …)
- What's **already fixed** vs. where the pipeline **still assumes EHG** (findings F1–F22) + the concrete workaround for each
- The durable fix (make completion gates resolve the repo from `applications.local_path`) and a proposed per-venture telemetry contract (`/v1/metrics` + API-key auth)
- The reusable pilot meta-process

This is pilot output — the explicit deliverable of running CronGenius as the first venture: capture the learnings so ventures 2..N start from them instead of re-discovering every gap.

## Test plan
- Documentation only; no code paths or behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
