### PR TITLE
fix(QF-20260528-224): create-orchestrator children inherited_from_parent + fail-loud on zero phases

### DIFF
--- a/lib/eva/__tests__/create-orchestrator-from-plan.test.js
+++ b/lib/eva/__tests__/create-orchestrator-from-plan.test.js
@@ -170,6 +170,12 @@ describe('buildChildSD', () => {
     });
     expect(record.target_application).toBe('AcmeVenture');
   });
+  it('F17 create-side (QF-20260528-224): child carries metadata.inherited_from_parent=true', () => {
+    const { record } = buildChildSD({
+      phase: { number: 1, title: 'P1' }, orchestratorRecord, orchestratorKey: 'SD-X-ORCH-001', orchestratorId: 'uuid-x', targetApplication: 'AcmeVenture',
+    });
+    expect(record.metadata.inherited_from_parent).toBe(true);
+  });
   it('non-vertical detector flags backend-only phases', () => {
     const { record, sliceCheck } = buildChildSD({
       phase: { number: 1, title: 'database migration', description: 'add column', content: 'sql schema rls' },

--- a/lib/eva/create-orchestrator-from-plan.js
+++ b/lib/eva/create-orchestrator-from-plan.js
@@ -345,6 +345,11 @@ export function buildChildSD({ phase, orchestratorRecord, orchestratorKey, orche
       phase_number: phase.number,
       parent_orchestrator: orchestratorKey,
       auto_generated: true,
+      // F17 create-side (QF-20260528-224): every buildChildSD child is a parent-derived
+      // slice (it inherits the orchestrator's arch). Flag it so SCOPE_COMPLETION_VERIFICATION
+      // soft-passes the child instead of scoring it against the parent's full multi-phase
+      // deliverable list. Pairs with the gate-side read shipped in SD-LEO-INFRA-VENTURE-AWARE-COMPLETION-001.
+      inherited_from_parent: true,
       wiring_required: true,
       vertical_slice_check: {
         non_vertical: sliceCheck.non_vertical,

--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -121,6 +121,15 @@ async function main() {
     || await resolveTargetApplication(supabase, visionDoc);
   console.log(`   🎯 Target application: ${targetApplication}`);
 
+  // F2 fail-loud (QF-20260528-224): --auto-children was requested but ZERO implementation_phases
+  // were extracted (neither sections.implementation_phases nor parsePhases yielded any). Refuse
+  // to silently ship a childless orchestrator — surface the extraction failure instead.
+  if (autoChildren && phases.length === 0) {
+    console.error('Error: --auto-children requested but ZERO implementation_phases were extracted from the vision/architecture plan.');
+    console.error('   Fix: ensure the architecture plan has sections.implementation_phases (or parseable "Phase N" content) before generating children.');
+    process.exit(1);
+  }
+
   // Generate traceable metrics
   const { visionMetrics, archMetrics } = await generateTraceableMetrics(supabase, visionKey, archKey);
   const allMetrics = [...visionMetrics, ...archMetrics];


### PR DESCRIPTION
## Summary
Quick-fix for the remaining B3 venture-pipeline work (CronGenius pilot, feedback 279a91a1). **Verify-first found F3 + F5 already shipped**; only two items remained:

- **F17 create-side**: `buildChildSD` now sets `metadata.inherited_from_parent=true` on every auto-generated child (parent-derived slices), so SCOPE_COMPLETION_VERIFICATION soft-passes them instead of scoring against the parent's full multi-phase deliverable list. Removes the manual LEAD enrichment every venture child needed; pairs with the gate-side read shipped in B1 (PR #4058).
- **F2 fail-loud**: `create-orchestrator-from-plan.js --auto-children` now errors (non-zero exit) when zero `implementation_phases` are extracted, instead of silently shipping a childless orchestrator.

## Tests
29/29 orchestrator unit tests pass (new F17 assertion + existing). 20 LOC, backend tooling (no UI/E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)