### PR TITLE
fix(QF-20260529-315): pre-unlink node_modules junction before git worktree remove in SessionStart cleanup hook

### DIFF
--- a/scripts/hooks/__tests__/concurrent-session-worktree.test.js
+++ b/scripts/hooks/__tests__/concurrent-session-worktree.test.js
@@ -234,6 +234,55 @@ describe('checkBranchFreshness (QF-20260511-228 — closes feedback acd4e5ab)', 
   });
 });
 
+describe('unlinkNodeModulesJunction (f4028ef8 — pre-unlink before git worktree remove)', () => {
+  let unlinkNodeModulesJunction;
+  beforeEach(() => { ({ unlinkNodeModulesJunction } = loadHookExports()); });
+
+  // Build a worktree whose node_modules is a link to a shared target
+  // (junction on Windows, symlink on POSIX) — the shape that bricks the shared
+  // store when git follows it during `worktree remove --force`.
+  function makeWtWithLinkedNm() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-nm-'));
+    const shared = path.join(root, 'shared_node_modules');
+    fs.mkdirSync(shared);
+    fs.writeFileSync(path.join(shared, 'sentinel.txt'), 'keep me');
+    const wt = path.join(root, 'wt');
+    fs.mkdirSync(wt);
+    const nm = path.join(wt, 'node_modules');
+    fs.symlinkSync(shared, nm, process.platform === 'win32' ? 'junction' : 'dir');
+    return { root, shared, wt, nm };
+  }
+
+  it('unlinks a node_modules junction and leaves the shared target intact', () => {
+    const { root, shared, wt, nm } = makeWtWithLinkedNm();
+    try {
+      unlinkNodeModulesJunction(wt);
+      expect(fs.existsSync(nm)).toBe(false);                                // link removed
+      expect(fs.existsSync(path.join(shared, 'sentinel.txt'))).toBe(true);  // target preserved
+    } finally { cleanupTemp(root); }
+  });
+
+  it('does NOT touch a real (isolated) node_modules directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-nm-'));
+    const nm = path.join(root, 'wt', 'node_modules');
+    fs.mkdirSync(nm, { recursive: true });
+    fs.writeFileSync(path.join(nm, 'pkg.txt'), 'real dep');
+    try {
+      unlinkNodeModulesJunction(path.join(root, 'wt'));
+      expect(fs.existsSync(path.join(nm, 'pkg.txt'))).toBe(true);           // real dir untouched
+    } finally { cleanupTemp(root); }
+  });
+
+  it('is a no-op when node_modules is absent (does not throw)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-nm-'));
+    const wt = path.join(root, 'wt');
+    fs.mkdirSync(wt);
+    try {
+      expect(() => unlinkNodeModulesJunction(wt)).not.toThrow();
+    } finally { cleanupTemp(root); }
+  });
+});
+
 // ─── Mock supabase client ───────────────────────────────────────────────────
 
 function mockSupabase({ sdRows = [], sdError = null, sessionRows = [] } = {}) {

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -52,6 +52,26 @@ function getAliveMarkerSessionIds() {
   return alive;
 }
 
+// f4028ef8: unlink a worktree's node_modules junction/symlink BEFORE any
+// `git worktree remove --force`, so git cannot follow the link into the shared
+// main-repo node_modules and delete its contents. Best-effort + idempotent (no
+// link / already gone is a no-op). Mirrors preUnlinkWorktreeNodeModules +
+// _unlinkSymOrJunction (lib/worktree-manager.js); inlined to keep this hot CJS
+// SessionStart hook free of ESM dynamic imports.
+function unlinkNodeModulesJunction(wtPath) {
+  try {
+    const nm = path.join(wtPath, 'node_modules');
+    if (!fs.lstatSync(nm).isSymbolicLink()) return;
+    try {
+      fs.unlinkSync(nm);
+    } catch (err) {
+      // Windows: directory junctions sometimes need rmdir to drop the reparse point.
+      if (process.platform === 'win32' && (err.code === 'EPERM' || err.code === 'EISDIR')) fs.rmdirSync(nm);
+      else throw err;
+    }
+  } catch { /* no node_modules, not a link, or already gone — nothing to unlink */ }
+}
+
 // Configuration
 const STALENESS_WINDOW_S = parseInt(process.env.WORKTREE_STALENESS_WINDOW_S || '300', 10);
 const RECHECK_DELAY_MS = parseInt(process.env.WORKTREE_RECHECK_DELAY_MS || '1000', 10);
@@ -481,6 +501,10 @@ async function cleanupStaleConcurrentWorktrees(supabase) {
       });
     } catch { /* not locked or already unlocked */ }
 
+    // f4028ef8: pre-unlink the node_modules junction so the PRIMARY
+    // `git worktree remove --force` below (not just the rmSync fallback) cannot
+    // follow it into the shared main-repo node_modules and wipe it.
+    unlinkNodeModulesJunction(wtPath);
     try {
       gitViaPowerShell(`worktree remove --force "${wtPath}"`, {
         cwd: repoRoot, timeout: 5000
@@ -506,11 +530,7 @@ async function cleanupStaleConcurrentWorktrees(supabase) {
         let lastErr = null;
         for (let attempt = 0; attempt < CJS_RETRY_DELAYS_MS.length; attempt++) {
           try {
-            const nm = path.join(wtPath, 'node_modules');
-            try {
-              const lst = fs.lstatSync(nm);
-              if (lst.isSymbolicLink()) fs.unlinkSync(nm);
-            } catch { /* no junction or doesn't exist */ }
+            unlinkNodeModulesJunction(wtPath); // f4028ef8: DRY with the pre-unlink above
             fs.rmSync(wtPath, { recursive: true, force: true });
             rmOk = !fs.existsSync(wtPath);
             if (rmOk) break;
@@ -820,7 +840,7 @@ async function main() {
 // Test exports (used by scripts/hooks/__tests__/concurrent-session-worktree.test.js)
 // Gating `main()` behind `require.main === module` lets tests `require()` this
 // file without triggering the SessionStart side-effects.
-module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees, checkBranchFreshness };
+module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees, checkBranchFreshness, unlinkNodeModulesJunction };
 
 if (require.main === module) {
   // Run with timeout protection (hook has 5s timeout)


### PR DESCRIPTION
## Summary
Closes harness_backlog **f4028ef8** (HIGH).

`scripts/hooks/concurrent-session-worktree.cjs` `cleanupStaleConcurrentWorktrees` ran its **primary** `git worktree remove --force` without first unlinking the worktree's `node_modules` junction. On Windows, git follows the junction into the **shared main-repo `node_modules`** and deletes its contents (observed: `@supabase/supabase-js` removed), bricking all DB tooling until `npm install`. The junction-unlink existed only in the rmSync `catch` fallback — which runs *after* git already followed the link.

This was the **last unprotected `git worktree remove --force` site**: all 4 sites in `lib/worktree-manager.js` and the reaper (`removeWorktreeViaGit`) already pre-unlink via `preUnlinkWorktreeNodeModules`.

## Changes
- Add `unlinkNodeModulesJunction(wtPath)` helper (lstat → `isSymbolicLink` → `unlinkSync`, with Windows `EPERM`/`EISDIR` → `rmdirSync` fallback; best-effort + idempotent). Mirrors `preUnlinkWorktreeNodeModules` + `_unlinkSymOrJunction` in `lib/worktree-manager.js`; inlined to keep the hot CJS SessionStart hook free of ESM dynamic imports.
- Call it **before** the primary `git worktree remove --force`.
- DRY the rmSync catch-block to reuse the same helper.
- 3 real-fs regression tests (junction unlinked + shared target preserved; real dir untouched; absent = no-op).

## Test plan
- `npx vitest run scripts/hooks/__tests__/concurrent-session-worktree.test.js` → 21/21 pass (18 existing + 3 new).
- `node --check` on the hook → OK.
- Cross-platform: symlink on POSIX/CI, junction on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)