### PR TITLE
fix(QF-20260529-375): GATE2 Section D scans bare tests/ root so backend/venture coverage counts toward D1

### DIFF
--- a/scripts/modules/implementation-fidelity/sections/enhanced-testing.js
+++ b/scripts/modules/implementation-fidelity/sections/enhanced-testing.js
@@ -12,6 +12,15 @@ import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../uti
 import { getSectionEnforcement } from '../sd-type-section-policy.js';
 
 /**
+ * Directories scanned for test files in [D1]. F21 (367cab56): the bare `tests/`
+ * root is scanned recursively (which subsumes tests/e2e, tests/integration,
+ * tests/unit) so backend/venture slices that place tests in `tests/` rather
+ * than `tests/unit` get their unit/integration coverage counted toward D1
+ * instead of a false "No E2E tests found" 0/20. Exported for unit testing.
+ */
+export const TEST_DIRS = ['tests', 'e2e', 'playwright/tests'];
+
+/**
  * Validate Enhanced Testing
  *
  * @param {string} sd_id - Strategic Directive ID
@@ -48,13 +57,7 @@ export async function validateEnhancedTesting(sd_id, designAnalysis, databaseAna
   try {
     const implementationRepos = await detectImplementationRepos(sd_id, supabase);
 
-    const testDirs = [
-      'tests/e2e',
-      'tests/integration',
-      'tests/unit',
-      'e2e',
-      'playwright/tests'
-    ];
+    const testDirs = TEST_DIRS;
 
     let testFiles = [];
     for (const repo of implementationRepos) {

--- a/tests/unit/implementation-fidelity/enhanced-testing-testdirs.test.js
+++ b/tests/unit/implementation-fidelity/enhanced-testing-testdirs.test.js
@@ -1,0 +1,28 @@
+/**
+ * F21 (367cab56): GATE2 Section D [D1] test discovery must scan the bare
+ * `tests/` root so backend/venture slices that place tests in `tests/` (not
+ * `tests/unit`) have their unit/integration coverage counted toward D1 instead
+ * of a false "No E2E tests found" 0/20. Witnessed: CronGenius Child C (GATE2 83
+ * YELLOW). Broadening is additive — it can only reduce false negatives.
+ */
+import { describe, it, expect } from 'vitest';
+import { TEST_DIRS } from '../../../scripts/modules/implementation-fidelity/sections/enhanced-testing.js';
+
+describe('enhanced-testing TEST_DIRS (F21 367cab56)', () => {
+  it('scans the bare tests/ root so unit/integration coverage counts toward D1', () => {
+    expect(TEST_DIRS).toContain('tests');
+  });
+
+  it('retains top-level e2e and playwright dirs', () => {
+    expect(TEST_DIRS).toContain('e2e');
+    expect(TEST_DIRS).toContain('playwright/tests');
+  });
+
+  it('drops the redundant tests/* subdirs (tests/ recursive subsumes them)', () => {
+    // readdir(tests/, { recursive: true }) reaches tests/e2e|integration|unit,
+    // so listing them separately would only double-count.
+    expect(TEST_DIRS).not.toContain('tests/unit');
+    expect(TEST_DIRS).not.toContain('tests/e2e');
+    expect(TEST_DIRS).not.toContain('tests/integration');
+  });
+});


### PR DESCRIPTION
## Summary
Closes harness_backlog **367cab56** (F21, medium).

GATE2 `implementation-fidelity` Section D `[D1]` only scanned `tests/e2e`, `tests/integration`, `tests/unit`, `e2e`, `playwright/tests`. Repos that place test files in the **bare `tests/` root** (e.g. the CronGenius venture backend slice) scored a false **0/20 "No E2E tests found"** CRITICAL despite unit+integration coverage — passing only via the YELLOW band (80–85), so a child scoring slightly lower elsewhere could hard-block.

## Change
- Hoist `testDirs` to an exported `TEST_DIRS` constant and scan **`tests/` recursively** (which subsumes the former `tests/e2e|integration|unit` entries), keeping top-level `e2e` and `playwright/tests`.
- This implements the feedback's *"count unit+SSR coverage toward it"* option.
- **Additive discovery only**: it can only *reduce* false negatives — it never newly-blocks an SD that previously passed.
- +3 unit tests (`enhanced-testing-testdirs.test.js`).

## Test plan
- `npx vitest run tests/unit/implementation-fidelity/enhanced-testing-testdirs.test.js tests/unit/implementation-fidelity/sd-type-section-policy.test.js` → 19/19 pass.
- `node --check` on the module → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)