### PR TITLE
feat(SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C): venture telemetry consumer backend (migration + daily pull + cron)

### DIFF
--- a/.github/workflows/venture-telemetry-pull.yml
+++ b/.github/workflows/venture-telemetry-pull.yml
@@ -1,0 +1,34 @@
+name: Venture Telemetry Daily Pull
+
+# SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C (Layer 2 consumer).
+# Daily one-way PULL of each active venture's authenticated GET /v1/metrics into the EHG
+# venture_telemetry rollup table. EHG never writes into a venture DB. Fails soft per venture.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily 06:00 UTC
+  workflow_dispatch: {}
+
+# Avoid overlapping runs (the job is idempotent — upsert per application_id — but no need to stack).
+concurrency:
+  group: venture-telemetry-pull
+  cancel-in-progress: false
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # Per-venture read keys (D5): the NAME matches applications.metrics_api_key_ref.
+      # Add one line per venture as its endpoint is configured.
+      CRONGENIUS_METRICS_API_KEY: ${{ secrets.CRONGENIUS_METRICS_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci --ignore-scripts
+      - name: Pull venture telemetry
+        run: node scripts/venture-telemetry-pull.mjs

--- a/database/migrations/20260529_venture_telemetry_consumer.sql
+++ b/database/migrations/20260529_venture_telemetry_consumer.sql
@@ -1,0 +1,70 @@
+-- SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C: EHG-side venture telemetry consumer (Layer 2).
+-- Additive + idempotent. Creates the venture_telemetry rollup table and adds the per-venture
+-- metrics endpoint + read-key REFERENCE columns to applications. EHG PULLS aggregated rollups
+-- from each venture's GET /v1/metrics (one-way) — it never writes into a venture DB.
+-- Safe to run alongside active sessions: only new objects + new NULLable columns.
+
+-- 1) applications: per-venture metrics endpoint + read-key REFERENCE.
+--    D5 — metrics_api_key_ref stores the NAME of an env var / secret, NEVER the raw key.
+ALTER TABLE public.applications
+  ADD COLUMN IF NOT EXISTS metrics_base_url text,
+  ADD COLUMN IF NOT EXISTS metrics_api_key_ref text;
+
+COMMENT ON COLUMN public.applications.metrics_base_url IS
+  'Base URL of the venture''s authenticated GET /v1/metrics endpoint (e.g. https://crongenius.<acct>.workers.dev). NULL => the daily telemetry pull skips this venture.';
+COMMENT ON COLUMN public.applications.metrics_api_key_ref IS
+  'D5: NAME of the env var / secret holding the venture read key (NOT the raw secret). The pull job resolves it at runtime via process.env[metrics_api_key_ref]. Rotation = update the secret value; this reference is unchanged.';
+
+-- 2) venture_telemetry: one upserted current-rollup row per venture, mirroring the
+--    /v1/metrics MetricsAggregate contract + ingest metadata. KILL/SCALE is DERIVED from
+--    these fields in the chairman dashboard (not stored as invented percents).
+CREATE TABLE IF NOT EXISTS public.venture_telemetry (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  application_id  uuid NOT NULL REFERENCES public.applications(id) ON DELETE CASCADE,
+  venture_id      uuid REFERENCES public.ventures(id) ON DELETE SET NULL,
+  -- contract (mirrors the producer MetricsAggregate)
+  contract_version text,
+  window_days     integer,
+  since           timestamptz,
+  generated_at    timestamptz,
+  total           integer NOT NULL DEFAULT 0,
+  by_verdict      jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  by_mode         jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  by_model        jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  avg_confidence  numeric,
+  dry_run_count   integer,
+  raw_payload     jsonb,   -- full response, for forward-compat with additive contract fields
+  -- ingest metadata
+  source_url      text,
+  http_status     integer,
+  ingest_status   text NOT NULL DEFAULT 'ok'
+                    CHECK (ingest_status IN ('ok','skipped','version_mismatch','error')),
+  ingest_note     text,
+  pulled_at       timestamptz NOT NULL DEFAULT now(),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_venture_telemetry_application UNIQUE (application_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_venture_telemetry_application_id ON public.venture_telemetry(application_id);
+CREATE INDEX IF NOT EXISTS idx_venture_telemetry_pulled_at     ON public.venture_telemetry(pulled_at DESC);
+
+-- 3) RLS: service-role writes (the pull job); anon/authenticated read (chairman dashboard).
+--    Aggregates only — no raw venture input/output is ever pulled or stored.
+ALTER TABLE public.venture_telemetry ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='venture_telemetry' AND policyname='venture_telemetry_service_all') THEN
+    CREATE POLICY venture_telemetry_service_all ON public.venture_telemetry
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='venture_telemetry' AND policyname='venture_telemetry_read') THEN
+    CREATE POLICY venture_telemetry_read ON public.venture_telemetry
+      FOR SELECT TO anon, authenticated USING (true);
+  END IF;
+END $$;
+
+-- Rollback (manual):
+--   DROP TABLE IF EXISTS public.venture_telemetry;
+--   ALTER TABLE public.applications DROP COLUMN IF EXISTS metrics_base_url, DROP COLUMN IF EXISTS metrics_api_key_ref;

--- a/scripts/venture-telemetry-pull.mjs
+++ b/scripts/venture-telemetry-pull.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Venture telemetry daily PULL — SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C (Layer 2 consumer).
+ *
+ * ONE-WAY by construction: the only outbound call is an HTTP GET of each active venture's
+ * authenticated /v1/metrics; the only DB write is a service-role write into EHG's OWN
+ * public.venture_telemetry table. EHG never opens or writes a venture database.
+ *
+ * FAIL SOFT per venture: a missing endpoint/key, non-200, bad JSON, or unsupported
+ * contract_version skips that venture (records ingest_status + note) WITHOUT overwriting a
+ * prior good rollup's metrics, and never aborts the run. The job exits 0 so one venture's
+ * outage cannot block the others or the daily schedule.
+ *
+ * D5: the per-venture read key is resolved from applications.metrics_api_key_ref, which holds
+ * the NAME of an env var / secret — never the raw key.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { pathToFileURL } from 'node:url';
+
+/** Accept any contract whose MAJOR version matches the producer's; fail soft on others. */
+export const EXPECTED_CONTRACT_MAJOR = '1';
+
+export function isContractCompatible(version) {
+  return typeof version === 'string' && version.split('.')[0] === EXPECTED_CONTRACT_MAJOR;
+}
+
+/** Ingest-metadata subset — what we write on EVERY outcome (never clobbers metric columns). */
+function ingestMeta(app, { ingest_status, ingest_note = null, httpStatus = null, sourceUrl = null }, now) {
+  return {
+    application_id: app.id,
+    venture_id: app.venture_id ?? null,
+    source_url: sourceUrl,
+    http_status: httpStatus,
+    ingest_status,
+    ingest_note,
+    pulled_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  };
+}
+
+/** Full upsert row for a SUCCESSFUL pull (metric columns + metadata). Pure. */
+export function buildOkRow(app, payload, { httpStatus, sourceUrl }, now = new Date()) {
+  return {
+    ...ingestMeta(app, { ingest_status: 'ok', httpStatus, sourceUrl }, now),
+    contract_version: payload.contract_version ?? null,
+    window_days: payload.window_days ?? null,
+    since: payload.since ?? null,
+    generated_at: payload.generated_at ?? null,
+    total: payload.total ?? 0,
+    by_verdict: payload.by_verdict ?? {},
+    by_mode: payload.by_mode ?? {},
+    by_model: payload.by_model ?? {},
+    avg_confidence: payload.avg_confidence ?? null,
+    dry_run_count: payload.dry_run_count ?? null,
+    raw_payload: payload,
+  };
+}
+
+/**
+ * Pull one venture's /v1/metrics. Pure w.r.t. injected deps (fetchFn, env, now) — performs
+ * NO database access (one-way: HTTP GET only). NEVER throws. Returns:
+ *   { outcome: 'ok',   okRow, log }                     -> caller upserts the full row
+ *   { outcome: <fail>, meta, log }                      -> caller updates metadata only
+ */
+export async function pullVenture(app, { fetchFn, env = process.env, now = new Date() } = {}) {
+  const f = fetchFn ?? fetch;
+  const baseUrl = app.metrics_base_url;
+  const keyRef = app.metrics_api_key_ref;
+  const sourceUrl = baseUrl ? `${String(baseUrl).replace(/\/+$/, '')}/v1/metrics` : null;
+
+  const fail = (ingest_status, ingest_note, httpStatus = null) => ({
+    outcome: ingest_status,
+    meta: ingestMeta(app, { ingest_status, ingest_note, httpStatus, sourceUrl }, now),
+    log: { venture: app.name, status: ingest_status, note: ingest_note },
+  });
+
+  if (!baseUrl) return fail('skipped', 'no metrics_base_url configured');
+  const apiKey = keyRef ? env?.[keyRef] : undefined;
+  if (!apiKey) return fail('skipped', `api key ref '${keyRef ?? '(none)'}' not resolvable from env`);
+
+  let res;
+  try {
+    res = await f(sourceUrl, { method: 'GET', headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' } });
+  } catch (err) {
+    return fail('error', `fetch threw: ${err?.message || err}`);
+  }
+  const httpStatus = res.status;
+  if (!res.ok) return fail('error', `HTTP ${httpStatus}`, httpStatus);
+
+  let payload;
+  try { payload = await res.json(); } catch (err) { return fail('error', `invalid JSON: ${err?.message || err}`, httpStatus); }
+
+  if (!isContractCompatible(payload?.contract_version)) {
+    return fail('version_mismatch', `unsupported contract_version '${payload?.contract_version ?? '(missing)'}' (expected major ${EXPECTED_CONTRACT_MAJOR})`, httpStatus);
+  }
+  return {
+    outcome: 'ok',
+    okRow: buildOkRow(app, payload, { httpStatus, sourceUrl }, now),
+    log: { venture: app.name, status: 'ok', total: payload.total },
+  };
+}
+
+function jlog(obj) { process.stdout.write(JSON.stringify({ ts: new Date().toISOString(), ...obj }) + '\n'); }
+
+/** Persist one pull result. ok -> full upsert; failure -> update metadata only (preserve a
+ *  prior good rollup), inserting a metadata marker only when no row exists yet. */
+export async function persistResult(supabase, app, result) {
+  if (result.outcome === 'ok') {
+    const { error } = await supabase.from('venture_telemetry').upsert(result.okRow, { onConflict: 'application_id' });
+    return { error };
+  }
+  const { data: updated, error: updErr } = await supabase
+    .from('venture_telemetry').update(result.meta).eq('application_id', app.id).select('id');
+  if (updErr) return { error: updErr };
+  if (!updated || updated.length === 0) {
+    const { error: insErr } = await supabase.from('venture_telemetry').insert(result.meta);
+    return { error: insErr };
+  }
+  return { error: null };
+}
+
+export async function main({ supabase, env = process.env, fetchFn, now = new Date() } = {}) {
+  const { data: ventures, error } = await supabase
+    .from('applications')
+    .select('id, name, venture_id, status, kind, metrics_base_url, metrics_api_key_ref')
+    .eq('kind', 'venture')
+    .eq('status', 'active');
+  if (error) { jlog({ action: 'list_ventures', status: 'error', error: error.message }); throw new Error(`list ventures failed: ${error.message}`); }
+
+  const summary = { total: ventures?.length || 0, ok: 0, skipped: 0, version_mismatch: 0, error: 0 };
+  for (const app of ventures || []) {
+    const result = await pullVenture(app, { fetchFn, env, now });
+    summary[result.outcome] = (summary[result.outcome] ?? 0) + 1;
+    const { error: persistErr } = await persistResult(supabase, app, result);
+    jlog({ action: 'pull', ...result.log, persist_error: persistErr?.message ?? null });
+  }
+  jlog({ action: 'summary', ...summary });
+  return summary;
+}
+
+// CLI entry — skipped when imported by tests.
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY'); process.exit(1); }
+  const supabase = createClient(url, key);
+  main({ supabase })
+    .then((s) => { jlog({ action: 'done', ...s }); process.exit(0); })
+    .catch((err) => { console.error('[venture-telemetry-pull] fatal:', err); process.exit(1); });
+}

--- a/tests/unit/venture-telemetry-pull.test.js
+++ b/tests/unit/venture-telemetry-pull.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isContractCompatible,
+  buildOkRow,
+  pullVenture,
+  persistResult,
+  main,
+  EXPECTED_CONTRACT_MAJOR,
+} from '../../scripts/venture-telemetry-pull.mjs';
+
+const NOW = new Date('2026-05-29T06:00:00.000Z');
+
+const APP = {
+  id: 'app-uuid-1',
+  name: 'CronGenius',
+  venture_id: 'venture-uuid-1',
+  kind: 'venture',
+  status: 'active',
+  metrics_base_url: 'https://crongenius.example.workers.dev',
+  metrics_api_key_ref: 'CRONGENIUS_METRICS_API_KEY',
+};
+
+const VALID_PAYLOAD = {
+  contract_version: '1.0',
+  window_days: 7,
+  since: '2026-05-22T06:00:00.000Z',
+  generated_at: NOW.toISOString(),
+  total: 42,
+  by_verdict: { valid: 30, invalid: 8, not_applicable: 4 },
+  by_mode: { nl_to_cron: 40, cron_to_nl: 2 },
+  by_model: { 'deterministic-v1': 42 },
+  avg_confidence: 0.91,
+  dry_run_count: 3,
+};
+
+function jsonResponse(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+describe('isContractCompatible', () => {
+  it('accepts the same major version, rejects others/missing', () => {
+    expect(EXPECTED_CONTRACT_MAJOR).toBe('1');
+    expect(isContractCompatible('1.0')).toBe(true);
+    expect(isContractCompatible('1.7')).toBe(true);
+    expect(isContractCompatible('2.0')).toBe(false);
+    expect(isContractCompatible(undefined)).toBe(false);
+    expect(isContractCompatible('')).toBe(false);
+    expect(isContractCompatible(null)).toBe(false);
+  });
+});
+
+describe('buildOkRow', () => {
+  it('maps the MetricsAggregate contract into the telemetry row', () => {
+    const row = buildOkRow(APP, VALID_PAYLOAD, { httpStatus: 200, sourceUrl: 'u' }, NOW);
+    expect(row.application_id).toBe('app-uuid-1');
+    expect(row.venture_id).toBe('venture-uuid-1');
+    expect(row.ingest_status).toBe('ok');
+    expect(row.total).toBe(42);
+    expect(row.by_verdict).toEqual({ valid: 30, invalid: 8, not_applicable: 4 });
+    expect(row.contract_version).toBe('1.0');
+    expect(row.raw_payload).toEqual(VALID_PAYLOAD);
+    expect(row.pulled_at).toBe(NOW.toISOString());
+  });
+});
+
+describe('pullVenture — one-way GET + fail-soft classification', () => {
+  it('OK: valid versioned payload -> outcome ok with the full row', async () => {
+    const calls = [];
+    const fetchFn = (url, opts) => { calls.push({ url, opts }); return Promise.resolve(jsonResponse(200, VALID_PAYLOAD)); };
+    const res = await pullVenture(APP, { fetchFn, env: { CRONGENIUS_METRICS_API_KEY: 'secret' }, now: NOW });
+    expect(res.outcome).toBe('ok');
+    expect(res.okRow.total).toBe(42);
+    // ONE-WAY: exactly one outbound call, a GET to /v1/metrics with Bearer auth, no body.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://crongenius.example.workers.dev/v1/metrics');
+    expect(calls[0].opts.method).toBe('GET');
+    expect(calls[0].opts.body).toBeUndefined();
+    expect(calls[0].opts.headers.authorization).toBe('Bearer secret');
+  });
+
+  it('skips when no metrics_base_url is configured (no fetch at all)', async () => {
+    let called = 0;
+    const res = await pullVenture({ ...APP, metrics_base_url: null }, { fetchFn: () => { called++; }, env: {}, now: NOW });
+    expect(res.outcome).toBe('skipped');
+    expect(called).toBe(0);
+    expect(res.meta.ingest_status).toBe('skipped');
+  });
+
+  it('skips when the api key ref cannot be resolved from env', async () => {
+    let called = 0;
+    const res = await pullVenture(APP, { fetchFn: () => { called++; }, env: {}, now: NOW });
+    expect(res.outcome).toBe('skipped');
+    expect(called).toBe(0);
+  });
+
+  it('version_mismatch on an unsupported contract_version (no metric overwrite)', async () => {
+    const fetchFn = () => Promise.resolve(jsonResponse(200, { ...VALID_PAYLOAD, contract_version: '2.0' }));
+    const res = await pullVenture(APP, { fetchFn, env: { CRONGENIUS_METRICS_API_KEY: 'secret' }, now: NOW });
+    expect(res.outcome).toBe('version_mismatch');
+    expect(res.meta.total).toBeUndefined(); // metadata-only; no metric columns to clobber a prior row
+  });
+
+  it('error on non-200', async () => {
+    const fetchFn = () => Promise.resolve(jsonResponse(503, {}));
+    const res = await pullVenture(APP, { fetchFn, env: { CRONGENIUS_METRICS_API_KEY: 'secret' }, now: NOW });
+    expect(res.outcome).toBe('error');
+    expect(res.meta.http_status).toBe(503);
+  });
+
+  it('error (never throws) when fetch rejects', async () => {
+    const fetchFn = () => Promise.reject(new Error('ECONNREFUSED'));
+    const res = await pullVenture(APP, { fetchFn, env: { CRONGENIUS_METRICS_API_KEY: 'secret' }, now: NOW });
+    expect(res.outcome).toBe('error');
+    expect(res.meta.ingest_note).toContain('ECONNREFUSED');
+  });
+});
+
+describe('persistResult — fail soft never clobbers a prior good rollup', () => {
+  function fakeDb({ updateReturns }) {
+    const ops = [];
+    return {
+      ops,
+      from(table) {
+        return {
+          upsert(row, opts) { ops.push({ op: 'upsert', table, row, opts }); return Promise.resolve({ error: null }); },
+          update(row) { ops.push({ op: 'update', table, row }); return { eq() { return { select() { return Promise.resolve({ data: updateReturns, error: null }); } }; } }; },
+          insert(row) { ops.push({ op: 'insert', table, row }); return Promise.resolve({ error: null }); },
+        };
+      },
+    };
+  }
+
+  it('ok -> full upsert by application_id', async () => {
+    const db = fakeDb({ updateReturns: [] });
+    await persistResult(db, APP, { outcome: 'ok', okRow: buildOkRow(APP, VALID_PAYLOAD, { httpStatus: 200, sourceUrl: 'u' }, NOW) });
+    expect(db.ops).toEqual([{ op: 'upsert', table: 'venture_telemetry', row: expect.objectContaining({ application_id: 'app-uuid-1', total: 42 }), opts: { onConflict: 'application_id' } }]);
+  });
+
+  it('failure WITH a prior row -> updates metadata only (no upsert, no insert)', async () => {
+    const db = fakeDb({ updateReturns: [{ id: 'existing' }] });
+    await persistResult(db, APP, { outcome: 'version_mismatch', meta: { application_id: APP.id, ingest_status: 'version_mismatch' } });
+    const opNames = db.ops.map(o => o.op);
+    expect(opNames).toEqual(['update']);            // metric columns preserved
+    expect(opNames).not.toContain('upsert');
+    expect(opNames).not.toContain('insert');
+  });
+
+  it('failure with NO prior row -> inserts a metadata marker', async () => {
+    const db = fakeDb({ updateReturns: [] });
+    await persistResult(db, APP, { outcome: 'skipped', meta: { application_id: APP.id, ingest_status: 'skipped' } });
+    expect(db.ops.map(o => o.op)).toEqual(['update', 'insert']);
+  });
+});
+
+describe('main — lists active ventures, one-way writes only to venture_telemetry', () => {
+  function fakeDb({ ventures }) {
+    const ops = [];
+    const tablesTouched = new Set();
+    return {
+      ops,
+      tablesTouched,
+      from(table) {
+        tablesTouched.add(table);
+        if (table === 'applications') {
+          const chain = { select() { return chain; }, eq() { return chain; }, then(resolve) { resolve({ data: ventures, error: null }); } };
+          return chain;
+        }
+        return {
+          upsert(row, opts) { ops.push({ op: 'upsert', table, row }); return Promise.resolve({ error: null }); },
+          update(row) { ops.push({ op: 'update', table, row }); return { eq() { return { select() { return Promise.resolve({ data: [{ id: 'x' }], error: null }); } }; } }; },
+          insert(row) { ops.push({ op: 'insert', table, row }); return Promise.resolve({ error: null }); },
+        };
+      },
+    };
+  }
+
+  it('processes ventures, summarizes, and only ever touches applications (read) + venture_telemetry (write)', async () => {
+    const db = fakeDb({ ventures: [APP, { ...APP, id: 'app-2', name: 'NoEndpoint', metrics_base_url: null }] });
+    const fetchFn = () => Promise.resolve(jsonResponse(200, VALID_PAYLOAD));
+    const summary = await main({ supabase: db, env: { CRONGENIUS_METRICS_API_KEY: 'secret' }, fetchFn, now: NOW });
+    expect(summary).toMatchObject({ total: 2, ok: 1, skipped: 1 });
+    // ONE-WAY: no table other than applications + venture_telemetry is ever accessed.
+    expect([...db.tablesTouched].sort()).toEqual(['applications', 'venture_telemetry']);
+    // The OK venture got a full upsert; the no-endpoint one got metadata update (existing row).
+    expect(db.ops.find(o => o.op === 'upsert')?.row.application_id).toBe('app-uuid-1');
+  });
+});


### PR DESCRIPTION
## Summary
Layer 2 (consumer) **backend** of the venture telemetry PULL pipeline — `SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C` (cross-repo; the chairman dashboard panel ships in a coordinated `rickfelix/ehg` PR). EHG runs a daily, one-way pull of each active venture's authenticated `GET /v1/metrics` into a new `venture_telemetry` rollup table. **EHG never writes into a venture DB.**

## Changes
- **Migration** `database/migrations/20260529_venture_telemetry_consumer.sql` — `venture_telemetry` (one upserted rollup per venture, mirroring the `/v1/metrics` MetricsAggregate contract + ingest metadata; `UNIQUE(application_id)`; RLS service-write / anon+authenticated-read) and `applications.metrics_base_url` + `metrics_api_key_ref` (D5: a key **reference**, never the raw secret). Additive + idempotent. **Applied + verified live** (additivity proven: 10→10 `applications` rows unchanged, new columns NULL on all).
- **Pull job** `scripts/venture-telemetry-pull.mjs` — one-way daily pull: GET each active venture's `/v1/metrics` (Bearer), validate `contract_version`, **fail soft** (skip / version_mismatch / error) **without clobbering a prior good rollup**, upsert into `venture_telemetry`. Pure injectable helpers; the only outbound op is HTTP GET, the only DB write is EHG's own table.
- **Workflow** `.github/workflows/venture-telemetry-pull.yml` — daily 06:00 UTC cron + `workflow_dispatch`.
- **Tests** `tests/unit/venture-telemetry-pull.test.js` — 12 vitest cases: contract check, all pull outcomes, **one-way GET** assertion, **fail-soft-preserve** persist, and `main` only ever touching `applications` (read) + `venture_telemetry` (write).

## Verification
- `vitest run tests/unit/venture-telemetry-pull.test.js` → **12 passed**.
- Migration applied + verified on the live DB by the database-agent (additive, RLS, indexes, UNIQUE; existing data unchanged).

## One-way / D5 invariants
- The job opens **no venture DB connection** — outbound is GET-only; the sole write is the service-role upsert into EHG's `venture_telemetry`. Asserted structurally by the tests (`main` touches only `applications` + `venture_telemetry`).
- The per-venture key is resolved from `applications.metrics_api_key_ref` (an env-var name) → `process.env[ref]`; the raw secret lives in GitHub Actions secrets. Rotation = update the secret value; the reference is unchanged.

## Follow-on (same SD)
- The chairman `/chairman/ventures` telemetry panel (`useVentureTelemetry` hook + `VentureTable` signal) ships in a coordinated `rickfelix/ehg` PR.
- CronGenius's `metrics_base_url` + read-key secret are a deploy-time config step; until set, the job **fails soft (skips)** — safe to run now.

Part of feedback `ca2465cb` (Layer 2 EHG-side ingestion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
