### PR TITLE
fix(QF-20260529-564): load PRD into precheck gate context (fixes false No PRD provided)

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -347,10 +347,26 @@ export class HandoffOrchestrator {
       // any gate defined only in leo_validation_rules, so operators don't see a
       // failure execute will enforce. Advisory-only: validateGatesAll runs in
       // precheckMode (no writes; LLM gates skipped) and the execute path is unchanged.
+      // QF-20260529-564: load the PRD so DB-rule gates that read context.prd (e.g.
+      // 1:prdQualityValidation) evaluate in precheck the way execute does
+      // (BaseExecutor.js:302). Without it, precheck false-fails "No PRD provided" for
+      // sd_types where that gate is enabled (e.g. feature). Non-fatal: precheck is advisory.
+      let precheckPrd = null;
+      try {
+        const bySdId = await this.supabase.from('product_requirements_v2').select('*').eq('sd_id', sd.id);
+        precheckPrd = bySdId?.data?.[0] || null;
+        if (!precheckPrd) {
+          const byDirective = await this.supabase.from('product_requirements_v2').select('*').eq('directive_id', sd.id);
+          precheckPrd = byDirective?.data?.[0] || null;
+        }
+      } catch (e) {
+        console.warn(`   [precheck] PRD load skipped: ${e.message}`);
+      }
       const precheckValidationContext = {
         sdId,
         sd_id: sd?.id || sdId,
         sd,
+        prd: precheckPrd,
         options,
         precheckMode: true,
         supabase: this.supabase

--- a/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
@@ -95,4 +95,30 @@ describe('HandoffOrchestrator.precheckHandoff applies gate policies', () => {
     expect(ctx.sd).toBe(childSd);
     expect(ctx.precheckMode).toBe(true);
   });
+
+  it('loads the PRD into the precheck context so prd-reading gates (e.g. 1:prdQualityValidation) evaluate (QF-20260529-564)', async () => {
+    applyGatePoliciesMock.mockResolvedValue({
+      filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
+    });
+    const prdRow = { id: 'PRD-X', sd_id: 'X', title: 'PRD', status: 'approved' };
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq: vi.fn(async () => ({ data: [prdRow], error: null })) }))
+      }))
+    };
+    const orchestrator = new HandoffOrchestrator({
+      supabase,
+      sdRepo: { getById: vi.fn().mockResolvedValue(INFRA_SD) },
+      validationOrchestrator: {
+        validateGatesAll: validateGatesAllMock,
+        buildGatesFromRules: buildGatesFromRulesMock
+      },
+      executors: { 'PLAN-TO-LEAD': { getRequiredGates: vi.fn().mockResolvedValue([{ name: 'GATE_KEEP' }]) } }
+    });
+    await orchestrator.precheckHandoff('PLAN-TO-LEAD', 'X');
+
+    // The PRD must reach the gate context so context.prd-reading gates don't false-fail.
+    const ctx = validateGatesAllMock.mock.calls[0][1];
+    expect(ctx.prd).toEqual(prdRow);
+  });
 });


### PR DESCRIPTION
fix(QF-20260529-564): load PRD into precheck gate context (fixes false "No PRD provided")

precheckHandoff (HandoffOrchestrator.js) built precheckValidationContext without a prd
key, so DB-rule gates that read context.prd (e.g. 1:prdQualityValidation) returned
"No PRD provided" (score 0) in PRECHECK even when an approved PRD existed — only biting
sd_types where that gate is enabled (e.g. feature). The execute path was always correct
(BaseExecutor.js:302 sets context.prd). Fix: load the PRD (by sd_id, then directive_id
fallback; non-fatal try/catch) and include it in precheckValidationContext, mirroring
execute. Precheck is advisory (dry-run) so blast radius is low. Witnessed on
SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C PLAN-TO-EXEC precheck. +1 unit test (4 pass).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
