### PR TITLE
fix(QF-20260529-985): map --from-plan Demo sections + reject placeholder smoke steps

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
@@ -13,6 +13,7 @@
 
 import { isLightweightSDType, detectCodeProduction } from '../../../validation/sd-type-applicability-policy.js';
 import { safeTruncate } from '../../../../../../lib/utils/safe-truncate.js';
+import { isAllPlaceholderSmokeSteps } from '../../../smoke-test-defaults.js';
 
 /**
  * Validate smoke test specification
@@ -121,6 +122,13 @@ export async function validateSmokeTestSpecification(sd) {
 
   if (validSteps === 0) {
     issues.push('No valid smoke test steps (each must have instruction and expected_outcome)');
+  }
+
+  // QF-20260529-985: a code-producing SD reaching here must NOT pass on the generic
+  // auto-generated placeholder (buildDefaultSmokeTestSteps). Require a real LEAD Q9
+  // 30-second demo. (Lightweight / non-code SDs already returned above.)
+  if (isAllPlaceholderSmokeSteps(smokeTestSteps)) {
+    issues.push('Smoke test steps are the generic auto-generated placeholder — replace with a real 30-second demo (LEAD Q9): a concrete instruction + observable expected_outcome per step');
   }
 
   // Use GPT-5 Mini to validate smoke test is concrete (if available)

--- a/scripts/modules/handoff/smoke-test-defaults.js
+++ b/scripts/modules/handoff/smoke-test-defaults.js
@@ -1,0 +1,35 @@
+/**
+ * Known default ("placeholder") smoke-test markers — QF-20260529-985.
+ *
+ * leo-create-sd.js buildDefaultSmokeTestSteps emits GENERIC placeholder smoke_test_steps
+ * when a plan has no real smoke/demo section. Those steps use title-independent, fixed
+ * expected_outcome strings (below). SMOKE_TEST_SPECIFICATION uses isAllPlaceholderSmokeSteps()
+ * to BLOCK a code-producing SD whose smoke steps are ENTIRELY these placeholders, forcing a
+ * real LEAD Q9 "30-second demo" instead of a passing stub.
+ *
+ * KEEP IN SYNC with scripts/leo-create-sd.js buildDefaultSmokeTestSteps expected_outcome values.
+ */
+
+export const DEFAULT_SMOKE_OUTCOME_MARKERS = new Set([
+  // infrastructure (code-producing) defaults
+  'Script executes without errors',
+  'Output is correct and complete',
+  'Existing functionality unchanged',
+  // feature / general defaults
+  'Page loads without errors',
+  'Core feature operates correctly with expected behavior',
+  'Appropriate error handling or graceful degradation',
+]);
+
+/**
+ * True when `steps` is a non-empty array whose EVERY step's expected_outcome is one of the
+ * known generic placeholders — i.e. the auto-generated stub, not a real demo. A single
+ * real step makes it false (partial-real is acceptable).
+ *
+ * @param {Array<{expected_outcome?: string}>} steps
+ * @returns {boolean}
+ */
+export function isAllPlaceholderSmokeSteps(steps) {
+  if (!Array.isArray(steps) || steps.length === 0) return false;
+  return steps.every((s) => DEFAULT_SMOKE_OUTCOME_MARKERS.has(String(s?.expected_outcome ?? '').trim()));
+}

--- a/scripts/modules/plan-parser.js
+++ b/scripts/modules/plan-parser.js
@@ -479,19 +479,25 @@ export function extractKeyPrinciples(content) {
 export function extractSmokeTestSteps(content) {
   if (!content) return null;
 
-  const sectionPattern = /^##\s+(Smoke Test Steps|Smoke Tests|Smoke Test)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
+  // QF-20260529-985: also accept the LEAD Q9-canonical "## Demo" / "## 30-second demo"
+  // heading (with optional trailing text, e.g. "## Demo (30-second...)") and numbered list
+  // items, so a Demo section maps to real smoke_test_steps instead of falling back to the
+  // generic placeholder (which the SMOKE_TEST_SPECIFICATION gate now rejects).
+  const sectionPattern = /^##\s+(?:Smoke Test Steps|Smoke Tests|Smoke Test|Demo|30[-\s]?second demo)\b[^\n]*\n\n?([\s\S]*?)(?=\n##|\n#\s|(?![\s\S]))/mi;
   const match = content.match(sectionPattern);
 
   if (!match) return null;
 
   const steps = [];
-  const sectionContent = match[2];
-  const bulletPattern = /^[-*]\s+(.+)$/gm;
+  const sectionContent = match[1];
+  const bulletPattern = /^(?:[-*]|\d+[.)])\s+(.+)$/gm;
   let bulletMatch;
   while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+    // Strip a leading "Step N:" / ordinal prefix left over from numbered demo lists.
+    const instruction = bulletMatch[1].trim().replace(/^Step\s+\d+\s*[:.)-]\s*/i, '');
     steps.push({
       step_number: steps.length + 1,
-      instruction: bulletMatch[1].trim(),
+      instruction,
       expected_outcome: 'See plan for details'
     });
   }

--- a/tests/unit/smoke-test-placeholder-rejection.test.js
+++ b/tests/unit/smoke-test-placeholder-rejection.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Keep the gate's optional AI validator out of the unit test (no LLM call).
+vi.mock('../../scripts/modules/handoff/human-verification-validator.js', () => ({}));
+
+import {
+  DEFAULT_SMOKE_OUTCOME_MARKERS,
+  isAllPlaceholderSmokeSteps,
+} from '../../scripts/modules/handoff/smoke-test-defaults.js';
+import { extractSmokeTestSteps } from '../../scripts/modules/plan-parser.js';
+import { validateSmokeTestSpecification } from '../../scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js';
+
+const PLACEHOLDER_STEPS = [
+  { step_number: 1, instruction: 'Navigate to the relevant page/area for: X', expected_outcome: 'Page loads without errors' },
+  { step_number: 2, instruction: 'Verify the primary functionality works as expected', expected_outcome: 'Core feature operates correctly with expected behavior' },
+  { step_number: 3, instruction: 'Test an edge case or error scenario', expected_outcome: 'Appropriate error handling or graceful degradation' },
+];
+const REAL_STEPS = [
+  { step_number: 1, instruction: 'Open /chairman/ventures', expected_outcome: 'A telemetry signal of Scale shows for CronGenius' },
+];
+
+describe('isAllPlaceholderSmokeSteps', () => {
+  it('true only when EVERY step is a known generic placeholder', () => {
+    expect(isAllPlaceholderSmokeSteps(PLACEHOLDER_STEPS)).toBe(true);
+    expect(DEFAULT_SMOKE_OUTCOME_MARKERS.has('Script executes without errors')).toBe(true);
+  });
+  it('false for real steps, empty, or a mix (one real step is enough)', () => {
+    expect(isAllPlaceholderSmokeSteps(REAL_STEPS)).toBe(false);
+    expect(isAllPlaceholderSmokeSteps([])).toBe(false);
+    expect(isAllPlaceholderSmokeSteps([PLACEHOLDER_STEPS[0], REAL_STEPS[0]])).toBe(false);
+    expect(isAllPlaceholderSmokeSteps(null)).toBe(false);
+  });
+});
+
+describe('extractSmokeTestSteps — maps a Demo section (QF-20260529-985)', () => {
+  it('extracts numbered items from a "## Demo (30-second...)" section', () => {
+    const plan = '# Plan: X\n\n## Demo (30-second human-verifiable outcome)\n\n1. Run the pull job -> a venture_telemetry row appears\n2. Open the dashboard -> the signal is visible\n\n## Risks\n- a risk\n';
+    const steps = extractSmokeTestSteps(plan);
+    expect(steps).not.toBeNull();
+    expect(steps.length).toBe(2);
+    expect(steps[0].instruction).toContain('Run the pull job');
+    expect(steps[1].instruction).toContain('Open the dashboard');
+  });
+  it('still matches the legacy "## Smoke Test Steps" heading and strips a "Step N:" prefix', () => {
+    const plan = '## Smoke Test Steps\n\n- Step 1: do the thing\n- Step 2: verify the thing\n';
+    const steps = extractSmokeTestSteps(plan);
+    expect(steps.length).toBe(2);
+    expect(steps[0].instruction).toBe('do the thing');
+  });
+  it('returns null when no smoke/demo section exists', () => {
+    expect(extractSmokeTestSteps('## Goal\n\nSome goal text.')).toBeNull();
+  });
+});
+
+describe('SMOKE_TEST_SPECIFICATION — rejects the generic placeholder for code SDs', () => {
+  it('BLOCKS a feature SD whose smoke steps are entirely the auto-generated placeholder', async () => {
+    const sd = { sd_type: 'feature', title: 'X', smoke_test_steps: PLACEHOLDER_STEPS };
+    const r = await validateSmokeTestSpecification(sd);
+    expect(r.pass).toBe(false);
+    expect(r.issues.some((i) => /placeholder/i.test(i))).toBe(true);
+  });
+  it('PASSES a feature SD with real demo steps', async () => {
+    const sd = { sd_type: 'feature', title: 'X', smoke_test_steps: REAL_STEPS };
+    const r = await validateSmokeTestSpecification(sd);
+    expect(r.pass).toBe(true);
+  });
+});


### PR DESCRIPTION
fix(QF-20260529-985): map --from-plan Demo sections + reject placeholder smoke steps

RCA 472f89de: leo-create-sd.js --from-plan did not map a "## Demo" / "30-second demo"
section to smoke_test_steps (plan-parser extractSmokeTestSteps only matched "Smoke Test"
headings + dash bullets), so it fell back to the generic buildDefaultSmokeTestSteps
placeholder, and SMOKE_TEST_SPECIFICATION accepted that placeholder for code-producing SDs
(the gate checked count + field presence, not content). Witnessed on
SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001 creation (a "## Demo" plan -> placeholder passed).

Fix BOTH (the RCA noted either alone leaves a hole):
- plan-parser.js extractSmokeTestSteps now also matches "## Demo" / "## 30-second demo"
  headings (with trailing text) and NUMBERED list items, stripping a leading "Step N:" /
  ordinal prefix.
- New scripts/modules/handoff/smoke-test-defaults.js exports the known default smoke
  outcome markers + isAllPlaceholderSmokeSteps(); SMOKE_TEST_SPECIFICATION now BLOCKS a
  code-producing SD whose smoke steps are entirely those placeholders (vocab-independent
  backstop). Markers documented to stay in sync with buildDefaultSmokeTestSteps.

Tests: tests/unit/smoke-test-placeholder-rejection.test.js (7 pass) — detector, Demo
extraction + Step-prefix strip, and gate block/pass. No regression: leo-create-sd
vision-prescreen unit test passes; the from-plan integration test does not assert smoke steps.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
