### PR TITLE
feat(SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001): activate capability scoring + reuse tracking

### DIFF
--- a/database/migrations/20260529_capability_reuse_dedup.sql
+++ b/database/migrations/20260529_capability_reuse_dedup.sql
@@ -1,0 +1,93 @@
+-- Migration: Capability Reuse Dedup Guard
+-- SD: SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 | FR-5
+-- Date: 2026-05-29
+-- Purpose: Make capability reuse recording idempotent. fn_record_capability_reuse
+--   previously did an unconditional INSERT + reuse_count+1 on every call, so any
+--   hook retry / backfill overlap inflated reuse_count -> graph_centrality
+--   (FLOOR(reuse_count/2)) -> plane1_score. This adds a UNIQUE(capability_id,
+--   reusing_sd_id) constraint and rewrites the function to INSERT ... ON CONFLICT
+--   DO NOTHING, incrementing reuse_count ONLY when a row was actually inserted.
+-- Validated by DATABASE sub-agent (evidence b4125535-127c-4ea1-afc3-34f694e356fc).
+
+BEGIN;
+
+-- Guard-add UNIQUE constraint (Postgres lacks ADD CONSTRAINT IF NOT EXISTS).
+-- capability_reuse_log currently has 0 rows, so no existing-data violation risk.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'uq_capability_reuse_log_cap_sd'
+      AND conrelid = 'public.capability_reuse_log'::regclass
+  ) THEN
+    ALTER TABLE public.capability_reuse_log
+      ADD CONSTRAINT uq_capability_reuse_log_cap_sd
+      UNIQUE (capability_id, reusing_sd_id);
+    RAISE NOTICE 'UNIQUE constraint uq_capability_reuse_log_cap_sd added';
+  ELSE
+    RAISE NOTICE 'UNIQUE constraint uq_capability_reuse_log_cap_sd already exists, skipping';
+  END IF;
+END
+$$;
+
+-- Replace fn_record_capability_reuse with an idempotent version.
+-- Behavior preserved except: duplicate (capability_id, reusing_sd_id) pairs are
+-- ignored (ON CONFLICT DO NOTHING) and reuse_count/reused_by_sds/last_reused_at
+-- are updated ONLY when a new log row was actually inserted.
+CREATE OR REPLACE FUNCTION public.fn_record_capability_reuse(
+  p_capability_key character varying,
+  p_reusing_sd_id  character varying,
+  p_reuse_context  text DEFAULT NULL,
+  p_reuse_type     character varying DEFAULT 'direct'
+)
+RETURNS void LANGUAGE plpgsql AS $func$
+DECLARE
+  v_capability_id UUID;
+  v_sd_uuid       UUID;
+  v_row_count     INTEGER := 0;
+BEGIN
+  SELECT id INTO v_capability_id
+  FROM public.sd_capabilities
+  WHERE capability_key = p_capability_key
+  LIMIT 1;
+
+  IF v_capability_id IS NULL THEN
+    RAISE NOTICE 'capability not found: %', p_capability_key;
+    RETURN;
+  END IF;
+
+  SELECT uuid_id INTO v_sd_uuid
+  FROM public.strategic_directives_v2
+  WHERE id = p_reusing_sd_id;
+
+  INSERT INTO public.capability_reuse_log (
+    capability_id, capability_key, reusing_sd_id, reusing_sd_uuid, reuse_context, reuse_type
+  ) VALUES (
+    v_capability_id, p_capability_key, p_reusing_sd_id, v_sd_uuid, p_reuse_context, p_reuse_type
+  )
+  ON CONFLICT (capability_id, reusing_sd_id) DO NOTHING;
+
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+
+  IF v_row_count = 0 THEN
+    RAISE NOTICE 'duplicate capability reuse ignored (capability=%, sd=%)', p_capability_key, p_reusing_sd_id;
+    RETURN;
+  END IF;
+
+  UPDATE public.sd_capabilities
+  SET
+    reuse_count    = reuse_count + 1,
+    last_reused_at = CURRENT_TIMESTAMP,
+    reused_by_sds  = reused_by_sds || jsonb_build_array(jsonb_build_object(
+      'sd_id', p_reusing_sd_id,
+      'date', CURRENT_TIMESTAMP::text,
+      'context', p_reuse_context
+    ))
+  WHERE id = v_capability_id;
+END;
+$func$;
+
+COMMENT ON FUNCTION public.fn_record_capability_reuse IS
+'Records a capability reuse event idempotently. UNIQUE(capability_id, reusing_sd_id) + ON CONFLICT DO NOTHING ensures reuse_count increments at most once per (capability, reusing SD). SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 FR-5.';
+
+COMMIT;

--- a/lib/capabilities/capability-reuse-tracker.js
+++ b/lib/capabilities/capability-reuse-tracker.js
@@ -289,6 +289,11 @@ export function generateReuseReport(capabilities) {
  * @param {string} context - Description of how it's being reused
  * @param {string} reuseType - Type of reuse (direct, extended, forked, referenced)
  */
+// Matches a v4 UUID. fn_record_capability_reuse looks up the SD via
+// `WHERE id = p_reusing_sd_id`, where `id` is the VARCHAR sd_key — a UUID would
+// silently match nothing. Mirror calculatePlane1FromLedger's UUID rejection.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function recordReuseEvent(
   supabaseClient,
   capabilityKey,
@@ -296,7 +301,31 @@ export async function recordReuseEvent(
   context = null,
   reuseType = 'direct'
 ) {
-  // Use the database function
+  // Guard 1 (SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 FR-6): reject a UUID
+  // sd id. fn_record_capability_reuse matches strategic_directives_v2.id (the
+  // VARCHAR sd_key), so a UUID resolves reusing_sd_uuid to NULL silently.
+  if (typeof reusingSDId === 'string' && UUID_REGEX.test(reusingSDId)) {
+    return { success: false, error: 'reusingSDId must be the SD key (VARCHAR id), not a UUID', invalidInput: true };
+  }
+
+  // Guard 2 (NC-7, FR-6): surface an unknown capability_key instead of the silent
+  // no-op the RPC performs (RAISE NOTICE + RETURN). A zero-effect write must not
+  // look like success.
+  const { data: capRow, error: lookupErr } = await supabaseClient
+    .from('sd_capabilities')
+    .select('id')
+    .eq('capability_key', capabilityKey)
+    .limit(1)
+    .maybeSingle();
+  if (lookupErr) {
+    console.error('Error resolving capability for reuse:', lookupErr);
+    return { success: false, error: lookupErr.message };
+  }
+  if (!capRow) {
+    return { success: false, notFound: true, error: `capability_key not found: ${capabilityKey}` };
+  }
+
+  // Use the database function (idempotent post-FR-5: ON CONFLICT DO NOTHING).
   const { error } = await supabaseClient.rpc('fn_record_capability_reuse', {
     p_capability_key: capabilityKey,
     p_reusing_sd_id: reusingSDId,

--- a/lib/capabilities/plane1-scoring.js
+++ b/lib/capabilities/plane1-scoring.js
@@ -363,6 +363,145 @@ export function formatPlane1Score(score) {
 `.trim();
 }
 
+// ═══════════════════════════════════════════════════════════════
+// CAPABILITY SCORE ACTIVATION (SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001)
+// ═══════════════════════════════════════════════════════════════
+//
+// The taxonomy scorer (calculatePlane1Score) consumes maturity_score and
+// extraction_score as pass-through inputs but never derives them, so every
+// sd_capabilities row sits at maturity=extraction=plane1=0. These helpers
+// supply the missing estimator + persistence so the existing BEFORE trigger
+// (trg_compute_plane1_score) computes a real plane1_score.
+
+// Category for each capability_type (mirrors fn_compute_plane1_score CASE).
+const SCORE_CATEGORY_BY_TYPE = {
+  agent: 'ai_automation', crew: 'ai_automation', tool: 'ai_automation', skill: 'ai_automation',
+  database_schema: 'infrastructure', database_function: 'infrastructure', rls_policy: 'infrastructure', migration: 'infrastructure',
+  api_endpoint: 'application', component: 'application', hook: 'application', service: 'application', utility: 'application',
+  workflow: 'integration', webhook: 'integration', external_integration: 'integration',
+  validation_rule: 'governance', quality_gate: 'governance', protocol: 'governance',
+};
+
+// Maturity baseline by category: a capability registered by a COMPLETED SD has
+// shipped, so it is at least "functional/reliable". Governance + infrastructure
+// capabilities are gate/schema-enforced once present (higher baseline).
+const MATURITY_BASELINE_BY_CATEGORY = {
+  governance: 4, infrastructure: 4, ai_automation: 3, application: 3, integration: 3,
+};
+
+// Extraction (reusability) baseline by type: utilities/tools/db-functions are the
+// most reusable; components/schemas/RLS policies are bound to a specific context.
+const EXTRACTION_BASELINE_BY_TYPE = {
+  utility: 4, tool: 4, database_function: 4,
+  skill: 3, hook: 3, service: 3, api_endpoint: 3, workflow: 3, webhook: 3,
+  external_integration: 3, validation_rule: 3, quality_gate: 3, protocol: 3, migration: 3,
+  agent: 3, crew: 3,
+  component: 2, database_schema: 2, rls_policy: 2,
+};
+
+const clampScore = (n) => Math.max(0, Math.min(5, Math.round(n)));
+
+/**
+ * Derive maturity_score and extraction_score (0-5 integers) for a capability.
+ *
+ * Deterministic and type-differentiated: a per-type/category baseline grounded in
+ * the taxonomy rubric, adjusted by available evidence signals (source_files count,
+ * reuse_count). plane1_score and graph_centrality_score are NOT computed here — the
+ * BEFORE trigger owns them; this only supplies maturity + extraction.
+ *
+ * @param {Object} capability - row with capability_type, source_files, reuse_count
+ * @returns {{ maturity_score: number, extraction_score: number }}
+ */
+export function deriveCapabilityScores(capability) {
+  const type = capability?.capability_type;
+  const category = SCORE_CATEGORY_BY_TYPE[type];
+  if (!category) {
+    return { maturity_score: 0, extraction_score: 0 };
+  }
+
+  let maturity = MATURITY_BASELINE_BY_CATEGORY[category] ?? 3;
+  let extraction = EXTRACTION_BASELINE_BY_TYPE[type] ?? 3;
+
+  const sourceFileCount = Array.isArray(capability.source_files) ? capability.source_files.length : 0;
+  const reuse = Number.isFinite(capability.reuse_count) ? capability.reuse_count : 0;
+
+  // Evidence adjustments: substantial implementation (>=2 source files) lifts
+  // maturity; proven reuse lifts both reusability and maturity.
+  if (sourceFileCount >= 2) maturity += 1;
+  if (reuse >= 1) { extraction += 1; maturity += 1; }
+
+  return { maturity_score: clampScore(maturity), extraction_score: clampScore(extraction) };
+}
+
+/**
+ * Score sd_capabilities rows and persist ONLY maturity_score + extraction_score.
+ * The existing trg_compute_plane1_score trigger recomputes plane1_score,
+ * graph_centrality_score, category, and category_weight on the UPDATE.
+ *
+ * Idempotent: by default only scores rows where maturity_score=0 AND
+ * extraction_score=0. force re-scores all in-scope rows.
+ *
+ * @param {Object} supabaseClient
+ * @param {Object} opts
+ * @param {string} [opts.sdId]   - scope to one SD by sd_capabilities.sd_id (VARCHAR sd_key)
+ * @param {string} [opts.sdUuid] - scope to one SD by sd_capabilities.sd_uuid (UUID)
+ * @param {boolean} [opts.all]   - scope to ALL action='registered' rows (backfill)
+ * @param {boolean} [opts.force] - re-score even rows that already have scores
+ * @param {boolean} [opts.dryRun]- compute + report without writing
+ * @returns {Promise<{ scanned:number, scored:number, skipped:number, dryRun:boolean, changes:Array, error?:string }>}
+ */
+export async function scoreAndPersistCapabilities(supabaseClient, opts = {}) {
+  const { sdId, sdUuid, all = false, force = false, dryRun = false } = opts;
+
+  let query = supabaseClient
+    .from('sd_capabilities')
+    .select('id, capability_key, capability_type, source_files, reuse_count, maturity_score, extraction_score');
+
+  if (all) {
+    query = query.eq('action', 'registered');
+  } else if (sdId) {
+    query = query.eq('sd_id', sdId);
+  } else if (sdUuid) {
+    query = query.eq('sd_uuid', sdUuid);
+  } else {
+    return { scanned: 0, scored: 0, skipped: 0, dryRun, changes: [], error: 'scoreAndPersistCapabilities requires one of: all, sdId, sdUuid' };
+  }
+
+  const { data: rows, error } = await query;
+  if (error) {
+    return { scanned: 0, scored: 0, skipped: 0, dryRun, changes: [], error: error.message };
+  }
+
+  const changes = [];
+  let skipped = 0;
+  for (const row of rows || []) {
+    const alreadyScored = (row.maturity_score || 0) !== 0 || (row.extraction_score || 0) !== 0;
+    if (alreadyScored && !force) { skipped += 1; continue; }
+    const { maturity_score, extraction_score } = deriveCapabilityScores(row);
+    changes.push({ id: row.id, capability_key: row.capability_key, capability_type: row.capability_type, maturity_score, extraction_score });
+  }
+
+  if (dryRun) {
+    return { scanned: (rows || []).length, scored: changes.length, skipped, dryRun: true, changes };
+  }
+
+  let scored = 0;
+  const errors = [];
+  for (const c of changes) {
+    // Write ONLY maturity_score + extraction_score; trigger recomputes the rest.
+    const { error: upErr } = await supabaseClient
+      .from('sd_capabilities')
+      .update({ maturity_score: c.maturity_score, extraction_score: c.extraction_score })
+      .eq('id', c.id);
+    if (upErr) { errors.push(`${c.capability_key}: ${upErr.message}`); continue; }
+    scored += 1;
+  }
+
+  const result = { scanned: (rows || []).length, scored, skipped, dryRun: false, changes };
+  if (errors.length) result.error = errors.join('; ');
+  return result;
+}
+
 export default {
   PLANE1_CONFIG,
   calculateVenturePlane1Score,
@@ -370,4 +509,6 @@ export default {
   calculateVentureAggregatedPlane1,
   calculatePlane1FromLedger,
   formatPlane1Score,
+  deriveCapabilityScores,
+  scoreAndPersistCapabilities,
 };

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js
@@ -1,0 +1,73 @@
+/**
+ * Capability Scoring + Reuse Hook (LEAD-FINAL-APPROVAL)
+ * SD: SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 | FR-4
+ *
+ * Runs at SD completion, AFTER trg_capability_lifecycle has registered the SD's
+ * delivers_capabilities into sd_capabilities (with maturity=extraction=0). For the
+ * completing SD this hook:
+ *   (a) records a reuse for each capability_key already registered by a DIFFERENT
+ *       prior SD — BEFORE scoring, so the trigger sees the updated reuse_count; then
+ *   (b) derives + persists maturity_score/extraction_score for the SD's freshly
+ *       registered rows (the BEFORE trigger recomputes plane1_score).
+ *
+ * Fail-safe: every error is caught and logged; this hook NEVER blocks SD completion.
+ */
+
+import { recordReuseEvent } from '../../../../../../lib/capabilities/capability-reuse-tracker.js';
+import { scoreAndPersistCapabilities } from '../../../../../../lib/capabilities/plane1-scoring.js';
+
+/**
+ * @param {Object} sd - completing SD (has sd_key / id)
+ * @param {Object} supabase - service-role client
+ * @returns {Promise<{ scored:number, reused:number, capabilities:number, note?:string }>}
+ */
+export async function runCapabilityScoringOnCompletion(sd, supabase) {
+  const sdKey = sd.sd_key || sd.id;
+  const summary = { scored: 0, reused: 0, capabilities: 0 };
+
+  // The completing SD's freshly-registered capability rows (sd_id is the VARCHAR sd_key).
+  const { data: ownCaps, error: ownErr } = await supabase
+    .from('sd_capabilities')
+    .select('capability_key')
+    .eq('sd_id', sdKey)
+    .eq('action', 'registered');
+
+  if (ownErr) {
+    summary.note = `lookup failed: ${ownErr.message}`;
+    return summary;
+  }
+  if (!ownCaps || ownCaps.length === 0) {
+    summary.note = 'no registered capabilities for this SD';
+    return summary;
+  }
+  summary.capabilities = ownCaps.length;
+
+  // (a) Record reuse for keys also registered by a different prior SD — before scoring.
+  for (const cap of ownCaps) {
+    const { data: priorRow } = await supabase
+      .from('sd_capabilities')
+      .select('id')
+      .eq('capability_key', cap.capability_key)
+      .neq('sd_id', sdKey)
+      .limit(1)
+      .maybeSingle();
+
+    if (priorRow) {
+      const res = await recordReuseEvent(
+        supabase,
+        cap.capability_key,
+        sdKey, // VARCHAR sd_key — NOT the uuid (FR-6/TR-2)
+        `Reused at completion of ${sdKey}`,
+        'direct'
+      );
+      if (res?.success) summary.reused += 1;
+    }
+  }
+
+  // (b) Score + persist maturity/extraction for this SD's rows (trigger recomputes plane1).
+  const scoreRes = await scoreAndPersistCapabilities(supabase, { sdId: sdKey });
+  summary.scored = scoreRes?.scored || 0;
+  if (scoreRes?.error) summary.note = `scoring partial: ${scoreRes.error}`;
+
+  return summary;
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js
@@ -48,6 +48,7 @@ export async function runCapabilityScoringOnCompletion(sd, supabase) {
       .from('sd_capabilities')
       .select('id')
       .eq('capability_key', cap.capability_key)
+      .eq('action', 'registered') // only a prior REGISTERED row counts as reuse (not deprecated/superseded)
       .neq('sd_id', sdKey)
       .limit(1)
       .maybeSingle();

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -478,6 +478,21 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     // Resolve patterns/improvements if this SD was created from /learn
     await resolveLearningItems(sd, this.supabase);
 
+    // SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 (FR-4): score the SD's freshly
+    // registered capabilities (maturity/extraction -> trigger recomputes plane1_score)
+    // and record reuse for capabilities reused from a prior SD. Reuse is recorded
+    // BEFORE scoring so the trigger sees the updated reuse_count.
+    // Fail-safe: non-blocking, never prevents SD completion.
+    try {
+      const { runCapabilityScoringOnCompletion } = await import('./hooks/capability-scoring-hook.js');
+      const capResult = await runCapabilityScoringOnCompletion(sd, this.supabase);
+      if (capResult.capabilities > 0) {
+        console.log(`   [capability-scoring] scored ${capResult.scored}, reused ${capResult.reused} of ${capResult.capabilities} capabilities${capResult.note ? ` (${capResult.note})` : ''}`);
+      }
+    } catch (capError) {
+      console.warn(`   ⚠️  Capability scoring hook failed (non-blocking): ${capError.message}`);
+    }
+
     // SD-LEO-INFRA-ENHANCE-LEARN-SESSION-001: Session retrospective - analyze rejections
     // Creates issue_patterns for gates with 2+ rejections (non-blocking)
     try {

--- a/scripts/one-off/backfill-capability-scores.mjs
+++ b/scripts/one-off/backfill-capability-scores.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * One-off backfill: score the dormant capability ledger.
+ * SD: SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 | FR-3
+ *
+ * Activates the existing (action='registered') sd_capabilities rows that sit at
+ * maturity_score=extraction_score=0 by deriving + persisting maturity/extraction
+ * (the BEFORE trigger trg_compute_plane1_score then recomputes plane1_score).
+ *
+ * Idempotent: by default only scores rows with maturity=extraction=0. After a
+ * non-dry run it asserts the resulting plane1_score distribution is meaningful
+ * (COUNT(DISTINCT plane1_score) > 1) and prints the top/bottom 10 of the ledger.
+ *
+ * Usage:
+ *   node scripts/one-off/backfill-capability-scores.mjs            # score unscored rows
+ *   node scripts/one-off/backfill-capability-scores.mjs --dry-run  # preview only
+ *   node scripts/one-off/backfill-capability-scores.mjs --force    # re-score all rows
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { scoreAndPersistCapabilities } from '../../lib/capabilities/plane1-scoring.js';
+
+const force = process.argv.includes('--force');
+const dryRun = process.argv.includes('--dry-run');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);
+
+function distinctNonZero(scores) {
+  return new Set(scores.filter((s) => Number(s) > 0).map((s) => Number(s))).size;
+}
+
+async function main() {
+  console.log(`Backfill capability scores  (force=${force}, dryRun=${dryRun})`);
+
+  const before = await supabase
+    .from('v_capability_ledger')
+    .select('plane1_score');
+  const beforeDistinct = distinctNonZero((before.data || []).map((r) => r.plane1_score));
+  console.log(`  ledger rows: ${(before.data || []).length} | distinct non-zero plane1_score before: ${beforeDistinct}`);
+
+  const result = await scoreAndPersistCapabilities(supabase, { all: true, force, dryRun });
+  if (result.error && result.scored === 0) {
+    console.error(`  ERROR: ${result.error}`);
+    process.exit(1);
+  }
+  console.log(`  scanned=${result.scanned} scored=${result.scored} skipped=${result.skipped}${result.error ? ` (partial errors: ${result.error})` : ''}`);
+
+  if (dryRun) {
+    console.log('  DRY RUN — no writes. Sample of intended changes:');
+    for (const c of result.changes.slice(0, 10)) {
+      console.log(`    ${c.capability_key} [${c.capability_type}] -> maturity=${c.maturity_score} extraction=${c.extraction_score}`);
+    }
+    return;
+  }
+
+  // Verify distribution is meaningful.
+  const after = await supabase
+    .from('v_capability_ledger')
+    .select('capability_key, capability_type, maturity_score, extraction_score, plane1_score')
+    .order('plane1_score', { ascending: false });
+  const rows = after.data || [];
+  const afterDistinct = distinctNonZero(rows.map((r) => r.plane1_score));
+  console.log(`  distinct non-zero plane1_score after: ${afterDistinct}`);
+
+  console.log('  TOP 10 by plane1_score:');
+  for (const r of rows.slice(0, 10)) {
+    console.log(`    ${r.plane1_score}  ${r.capability_key} [${r.capability_type}] m=${r.maturity_score} e=${r.extraction_score}`);
+  }
+  console.log('  BOTTOM 10 by plane1_score:');
+  for (const r of rows.slice(-10)) {
+    console.log(`    ${r.plane1_score}  ${r.capability_key} [${r.capability_type}] m=${r.maturity_score} e=${r.extraction_score}`);
+  }
+
+  if (afterDistinct <= 1) {
+    console.error('  ❌ DEGENERATE DISTRIBUTION: plane1_score has <=1 distinct non-zero value. Heuristic needs review.');
+    process.exit(1);
+  }
+  console.log('  ✅ plane1_score distribution is meaningful (>1 distinct non-zero value).');
+}
+
+main().catch((e) => {
+  console.error('Backfill failed:', e.message);
+  process.exit(1);
+});

--- a/tests/unit/capabilities/scoring-lifecycle.test.js
+++ b/tests/unit/capabilities/scoring-lifecycle.test.js
@@ -1,0 +1,366 @@
+/**
+ * Scoring Lifecycle Tests
+ * SD: SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001 | FR-7
+ *
+ * Tests the full scoring lifecycle: deriveCapabilityScores (pure unit) and
+ * scoreAndPersistCapabilities + recordReuseEvent (DB integration).
+ *
+ * Evidence row ID referenced in prospective TESTING evidence: 249afb00
+ * 13 scenarios: TS-1 through TS-13.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+import { deriveCapabilityScores, scoreAndPersistCapabilities } from '../../../lib/capabilities/plane1-scoring.js';
+import { recordReuseEvent } from '../../../lib/capabilities/capability-reuse-tracker.js';
+
+dotenv.config();
+
+// Gate: skip DB tests when no real DB is available.
+// Mirrors the pattern in tests/unit/blocked-state-detector.test.js (CA-1 CAPA).
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UNIT TESTS — no DB required
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('deriveCapabilityScores — unit (no DB)', () => {
+  // TS-1: Determinism — same input always yields same output
+  it('TS-1: returns identical scores for identical inputs (determinism)', () => {
+    const capability = { capability_type: 'agent', source_files: ['a.js', 'b.js'], reuse_count: 2 };
+    const first = deriveCapabilityScores(capability);
+    const second = deriveCapabilityScores(capability);
+    expect(first).toEqual(second);
+  });
+
+  // TS-2: Type differentiation — 'agent' vs 'database_schema' with equal evidence must differ
+  it('TS-2: different capability_types with equal evidence yield different scores', () => {
+    const evidence = { source_files: ['a.js'], reuse_count: 0 };
+    const agentScore = deriveCapabilityScores({ ...evidence, capability_type: 'agent' });
+    const dbSchemaScore = deriveCapabilityScores({ ...evidence, capability_type: 'database_schema' });
+    // 'agent' category=ai_automation maturity_baseline=3, extraction_baseline=3
+    // 'database_schema' category=infrastructure maturity_baseline=4, extraction_baseline=2
+    // So at least one score dimension must differ.
+    const hasDifference =
+      agentScore.maturity_score !== dbSchemaScore.maturity_score ||
+      agentScore.extraction_score !== dbSchemaScore.extraction_score;
+    expect(hasDifference).toBe(true);
+  });
+
+  // TS-3: Bounds — all outputs are integers in [0, 5]
+  it('TS-3: all outputs are integers in [0,5] for extreme inputs', () => {
+    const types = ['agent', 'database_schema'];
+    for (const capability_type of types) {
+      // Zero evidence
+      const low = deriveCapabilityScores({ capability_type, source_files: [], reuse_count: 0 });
+      // High evidence
+      const high = deriveCapabilityScores({ capability_type, source_files: Array(10).fill('x.js'), reuse_count: 100 });
+
+      for (const { maturity_score, extraction_score } of [low, high]) {
+        expect(Number.isInteger(maturity_score)).toBe(true);
+        expect(Number.isInteger(extraction_score)).toBe(true);
+        expect(maturity_score).toBeGreaterThanOrEqual(0);
+        expect(maturity_score).toBeLessThanOrEqual(5);
+        expect(extraction_score).toBeGreaterThanOrEqual(0);
+        expect(extraction_score).toBeLessThanOrEqual(5);
+      }
+    }
+  });
+
+  // TS-4: Coverage — all 19 capability types yield non-zero scores for at least one input
+  it('TS-4: all 19 capability types yield non-zero scores for at least one input', () => {
+    const ALL_TYPES = [
+      'agent', 'crew', 'tool', 'skill',
+      'database_schema', 'database_function', 'rls_policy', 'migration',
+      'api_endpoint', 'component', 'hook', 'service', 'utility',
+      'workflow', 'webhook', 'external_integration',
+      'validation_rule', 'quality_gate', 'protocol',
+    ];
+    expect(ALL_TYPES.length).toBe(19);
+
+    for (const capability_type of ALL_TYPES) {
+      const scores = deriveCapabilityScores({ capability_type, source_files: [], reuse_count: 0 });
+      const hasNonZero = scores.maturity_score > 0 || scores.extraction_score > 0;
+      expect(hasNonZero, `Expected non-zero score for capability_type '${capability_type}'`).toBe(true);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB INTEGRATION TESTS — skipped when no real DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!HAS_REAL_DB)('scoring lifecycle — DB integration', () => {
+  const supabase = createSupabaseServiceClient();
+
+  // Unique prefixes so these rows are isolated and cleanable.
+  const TEST_PREFIX = 'TEST-SCORING-LIFECYCLE';
+  const TEST_SD_ID = 'SD-TEST-SCORING-LIFECYCLE';
+  // FK-valid SD uuid: strategic_directives_v2.id for SD-LEO-INFRA-ACTIVATE-CAPABILITY-SCORING-001
+  const TEST_SD_UUID = 'c26f3f6d-69b4-4338-bd7f-c898c43a1717';
+
+  // Track inserted row IDs for cleanup
+  let insertedIds = [];
+
+  /**
+   * Helper: insert a test sd_capabilities row and track its id for cleanup.
+   * Returns the inserted row.
+   */
+  async function insertTestCapability(overrides = {}) {
+    const defaults = {
+      sd_uuid: TEST_SD_UUID,
+      sd_id: TEST_SD_ID,
+      capability_type: 'database_function',
+      capability_key: `${TEST_PREFIX}-CAP-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      action: 'registered',
+      maturity_score: 0,
+      extraction_score: 0,
+    };
+    const row = { ...defaults, ...overrides };
+    const { data, error } = await supabase
+      .from('sd_capabilities')
+      .insert(row)
+      .select()
+      .single();
+    if (error) throw new Error(`insertTestCapability failed: ${error.message}`);
+    insertedIds.push(data.id);
+    return data;
+  }
+
+  /** Clean up all test rows: reuse_log first (FK), then capabilities. */
+  async function cleanup() {
+    if (insertedIds.length === 0) return;
+    // Delete reuse log rows for our capability ids.
+    await supabase
+      .from('capability_reuse_log')
+      .delete()
+      .in('capability_id', insertedIds);
+    // Delete the capability rows.
+    await supabase
+      .from('sd_capabilities')
+      .delete()
+      .in('id', insertedIds);
+    // Belt-and-suspenders: also sweep by key prefix.
+    await supabase
+      .from('sd_capabilities')
+      .delete()
+      .like('capability_key', `${TEST_PREFIX}%`);
+    insertedIds = [];
+  }
+
+  // Self-heal orphans left by prior process-killed runs (>1 h old).
+  beforeAll(async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const { data: stale } = await supabase
+      .from('sd_capabilities')
+      .select('id')
+      .like('capability_key', `${TEST_PREFIX}%`)
+      .lt('created_at', oneHourAgo);
+    if (stale && stale.length > 0) {
+      const staleIds = stale.map((r) => r.id);
+      await supabase.from('capability_reuse_log').delete().in('capability_id', staleIds);
+      await supabase.from('sd_capabilities').delete().in('id', staleIds);
+    }
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    // Reset after each test so state doesn't bleed.
+    await cleanup();
+  });
+
+  // TS-5: Backfill idempotency — calling scoreAndPersistCapabilities twice yields identical results
+  it('TS-5: backfill is idempotent (second run makes no changes)', async () => {
+    await insertTestCapability({ capability_type: 'database_function', maturity_score: 0, extraction_score: 0 });
+    await insertTestCapability({ capability_type: 'tool', maturity_score: 0, extraction_score: 0 });
+
+    const firstRun = await scoreAndPersistCapabilities(supabase, { sdId: TEST_SD_ID });
+    expect(firstRun.scored).toBeGreaterThan(0);
+
+    const secondRun = await scoreAndPersistCapabilities(supabase, { sdId: TEST_SD_ID });
+    // Second run should skip all already-scored rows (not re-score without force).
+    expect(secondRun.scored).toBe(0);
+    expect(secondRun.skipped).toBe(firstRun.scored);
+  });
+
+  // TS-6: Trigger recompute — plane1_score = (maturity+extraction+centrality)*category_weight
+  // For database_function: category=infrastructure, weight=1.2, reuse_count=4 → centrality=LEAST(5,FLOOR(4/2))=2
+  // plane1_score = (3 + 2 + 2) * 1.2 = 8.4
+  it('TS-6: trigger recomputes plane1_score after maturity/extraction update', async () => {
+    const cap = await insertTestCapability({ capability_type: 'database_function', reuse_count: 4 });
+
+    const { error } = await supabase
+      .from('sd_capabilities')
+      .update({ maturity_score: 3, extraction_score: 2 })
+      .eq('id', cap.id);
+    expect(error).toBeNull();
+
+    const { data: updated } = await supabase
+      .from('sd_capabilities')
+      .select('plane1_score, graph_centrality_score')
+      .eq('id', cap.id)
+      .single();
+
+    // graph_centrality = LEAST(5, FLOOR(4/2)) = 2
+    expect(updated.graph_centrality_score).toBe(2);
+    // plane1_score = (3 + 2 + 2) * 1.2 = 8.4
+    expect(updated.plane1_score).toBeCloseTo(8.4, 1);
+  });
+
+  // TS-7: Centrality formula — reuse_count 4→centrality 2; 10→centrality 5
+  it('TS-7: graph_centrality_score follows LEAST(5, FLOOR(reuse_count/2))', async () => {
+    const cap4 = await insertTestCapability({ capability_type: 'utility', reuse_count: 4 });
+    const cap10 = await insertTestCapability({ capability_type: 'utility', reuse_count: 10 });
+
+    // Trigger fires on UPDATE; do a no-op update to force recompute.
+    for (const id of [cap4.id, cap10.id]) {
+      await supabase.from('sd_capabilities').update({ maturity_score: 1, extraction_score: 1 }).eq('id', id);
+    }
+
+    const { data: row4 } = await supabase.from('sd_capabilities').select('graph_centrality_score').eq('id', cap4.id).single();
+    const { data: row10 } = await supabase.from('sd_capabilities').select('graph_centrality_score').eq('id', cap10.id).single();
+
+    expect(row4.graph_centrality_score).toBe(2); // FLOOR(4/2)=2
+    expect(row10.graph_centrality_score).toBe(5); // LEAST(5, FLOOR(10/2))=5
+  });
+
+  // TS-8: No double-count — recording same (capability_key, sd_id) twice increments reuse_count only once
+  it('TS-8: duplicate (capability_key, sd_id) reuse events are idempotent (ON CONFLICT DO NOTHING)', async () => {
+    const cap = await insertTestCapability({ capability_type: 'tool', reuse_count: 0 });
+
+    const firstResult = await recordReuseEvent(supabase, cap.capability_key, TEST_SD_ID, 'test context', 'direct');
+    expect(firstResult.success).toBe(true);
+
+    const secondResult = await recordReuseEvent(supabase, cap.capability_key, TEST_SD_ID, 'test context', 'direct');
+    // ON CONFLICT DO NOTHING — second call must still return success (no error).
+    expect(secondResult.success).toBe(true);
+
+    // Verify exactly 1 log row for this capability+sd combination.
+    const { data: logRows } = await supabase
+      .from('capability_reuse_log')
+      .select('id')
+      .eq('capability_id', cap.id)
+      .eq('reusing_sd_id', TEST_SD_ID);
+    expect(logRows.length).toBe(1);
+
+    // reuse_count should be incremented exactly once.
+    const { data: updated } = await supabase.from('sd_capabilities').select('reuse_count').eq('id', cap.id).single();
+    expect(updated.reuse_count).toBe(1);
+  });
+
+  // TS-9: Unknown key surfaced — recordReuseEvent with unknown key returns {notFound:true}
+  it('TS-9: unknown capability_key returns {notFound:true} with no log row created', async () => {
+    const unknownKey = `${TEST_PREFIX}-DOES-NOT-EXIST-${Date.now()}`;
+    const result = await recordReuseEvent(supabase, unknownKey, TEST_SD_ID, null, 'direct');
+    expect(result.success).toBe(false);
+    expect(result.notFound).toBe(true);
+
+    // No log row should have been created.
+    const { data: logRows } = await supabase
+      .from('capability_reuse_log')
+      .select('id')
+      .eq('reusing_sd_id', TEST_SD_ID);
+    // Filter further in JS since sd_id is not FK-enforced on log.
+    expect(logRows).toHaveLength(0);
+  });
+
+  // TS-10: Valid increment — recordReuseEvent with known key + valid sd_key → 1 log row + reuse_count+1
+  it('TS-10: valid reuse event creates exactly 1 log row and increments reuse_count', async () => {
+    const cap = await insertTestCapability({ capability_type: 'service', reuse_count: 0 });
+
+    const result = await recordReuseEvent(supabase, cap.capability_key, TEST_SD_ID, 'integration context', 'direct');
+    expect(result.success).toBe(true);
+
+    // Verify 1 log row.
+    const { data: logRows } = await supabase
+      .from('capability_reuse_log')
+      .select('id, reusing_sd_id')
+      .eq('capability_id', cap.id);
+    expect(logRows.length).toBe(1);
+    expect(logRows[0].reusing_sd_id).toBe(TEST_SD_ID);
+
+    // Verify reuse_count incremented.
+    const { data: updated } = await supabase.from('sd_capabilities').select('reuse_count').eq('id', cap.id).single();
+    expect(updated.reuse_count).toBe(1);
+  });
+
+  // TS-11: Distinct distribution — after scoring >=10 rows of 2+ types, COUNT(DISTINCT plane1_score) > 1
+  it('TS-11: scoring >=10 rows of 2+ capability types produces distinct plane1_scores', async () => {
+    // Insert 6 'agent' rows and 5 'database_schema' rows — different baselines = different scores.
+    const types = [
+      ...Array(6).fill('agent'),
+      ...Array(5).fill('database_schema'),
+    ];
+    for (const capability_type of types) {
+      await insertTestCapability({ capability_type, reuse_count: 0 });
+    }
+
+    const result = await scoreAndPersistCapabilities(supabase, { sdId: TEST_SD_ID });
+    expect(result.scored).toBeGreaterThanOrEqual(10);
+
+    const { data: rows } = await supabase
+      .from('sd_capabilities')
+      .select('plane1_score')
+      .eq('sd_id', TEST_SD_ID)
+      .like('capability_key', `${TEST_PREFIX}%`);
+
+    const distinctScores = new Set(rows.map((r) => r.plane1_score));
+    expect(distinctScores.size).toBeGreaterThan(1);
+  });
+
+  // TS-12: Trigger overwrites category — insert 'tool' row with no explicit category → category becomes 'ai_automation'
+  it('TS-12: trigger sets category="ai_automation" for capability_type="tool"', async () => {
+    // Insert without category (null/omitted) and trigger must set it.
+    const cap = await insertTestCapability({ capability_type: 'tool' });
+
+    // Trigger fires on INSERT; fetch the row.
+    const { data: fetched } = await supabase
+      .from('sd_capabilities')
+      .select('category')
+      .eq('id', cap.id)
+      .single();
+
+    expect(fetched.category).toBe('ai_automation');
+  });
+
+  // TS-13: Reuse-before-score ordering — record reuse THEN score; plane1_score reflects updated centrality
+  it('TS-13: recording reuse before scoring results in plane1_score that reflects updated reuse_count centrality', async () => {
+    const cap = await insertTestCapability({ capability_type: 'workflow', reuse_count: 0 });
+
+    // Step 1: record reuse (increments reuse_count from 0 to 1)
+    const reuseResult = await recordReuseEvent(supabase, cap.capability_key, TEST_SD_ID, null, 'direct');
+    expect(reuseResult.success).toBe(true);
+
+    // Verify reuse_count is now 1
+    const { data: afterReuse } = await supabase.from('sd_capabilities').select('reuse_count').eq('id', cap.id).single();
+    expect(afterReuse.reuse_count).toBe(1);
+
+    // Step 2: score (now reuse_count=1, so extraction gets +1 boost and maturity gets +1 boost)
+    const scoreResult = await scoreAndPersistCapabilities(supabase, { sdId: TEST_SD_ID });
+    expect(scoreResult.scored).toBeGreaterThan(0);
+
+    // Fetch the final row to confirm plane1_score is non-zero and reflects centrality
+    const { data: final } = await supabase
+      .from('sd_capabilities')
+      .select('plane1_score, graph_centrality_score, maturity_score, extraction_score')
+      .eq('id', cap.id)
+      .single();
+
+    // graph_centrality = LEAST(5, FLOOR(1/2)) = 0 (reuse_count=1)
+    expect(final.graph_centrality_score).toBe(0);
+    // plane1_score should be non-zero (maturity+extraction scored >0)
+    expect(final.plane1_score).toBeGreaterThan(0);
+    // The scoring function should have boosted maturity and extraction for reuse_count>=1
+    // workflow: category=integration, maturity_baseline=3, extraction_baseline=3;
+    // reuse>=1 adds +1 to both => maturity=4, extraction=4
+    expect(final.maturity_score).toBe(4);
+    expect(final.extraction_score).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
Activates the dormant capability ledger (keystone of the capability flywheel). All 204 registered `sd_capabilities` were `plane1_score=0` because nothing assigned `maturity_score`/`extraction_score` or recorded reuse — even though the DB trigger already computes `plane1_score` from them.

## Changes
- **Scorer + persistence** (`lib/capabilities/plane1-scoring.js`): `deriveCapabilityScores` (deterministic, type-differentiated 0-5) + `scoreAndPersistCapabilities` writes ONLY maturity/extraction; the BEFORE trigger recomputes `plane1_score`/centrality.
- **Reuse guard** (`capability-reuse-tracker.js`): rejects UUID sd-id, surfaces unknown `capability_key` (NC-7).
- **Completion hook** (`lead-final-approval`): on SD completion, records reuse (guarded, before) then scores the SD's new capabilities; non-blocking.
- **Dedup migration** (applied to live DB): `UNIQUE(capability_id, reusing_sd_id)` + `ON CONFLICT DO NOTHING` in `fn_record_capability_reuse` (root fix for reuse double-count, found by prospective TESTING).
- **Backfill**: scored the 204 dormant capabilities → 7 distinct `plane1_score` values.
- **Tests**: 13-scenario suite, 13/13 pass.

## PR size justification
~348 production LOC (>150 infra target). This is a single cohesive activation path (scorer → persistence → hook → migration → backfill) with no safe intermediate split — partial states leave the ledger half-scored or reuse un-deduped. Tests (366) + migration (93) are separate concerns.

## Verify-first
Reused the existing scorer inputs (taxonomy), the compute trigger, and `fn_record_capability_reuse` — activation, not greenfield (~60% pre-existing).

## Evidence
VALIDATION 1d2e78e2 · prospective TESTING 249afb00 · DATABASE b4125535 · STORIES 07ee071a · migration dee28ee8 · TESTING (13/13) d9e17d8a

🤖 Generated with [Claude Code](https://claude.com/claude-code)