### PR TITLE
fix(QF-20260529-852): complete-quick-fix.js exits cleanly instead of hanging ~2min

### DIFF
--- a/scripts/complete-quick-fix.js
+++ b/scripts/complete-quick-fix.js
@@ -31,8 +31,23 @@ if (showHelp) {
   process.exit(0);
 }
 
-// Run
-completeQuickFix(qfId, options).catch((err) => {
-  console.error('❌ Error:', err.message);
-  process.exit(1);
-});
+// Run.
+// QF-20260529-852 (RCA c6a002d5): a CLI entrypoint must terminate deterministically.
+// completeQuickFix awaits every durable step (DB write, merge, push, feedback-resolve)
+// before it resolves, but the orchestrator used to leave a background handle open (the
+// supabase-js auth refresh timer, now disabled at the client) so the loop never drained
+// and the process hung to the external ~2-min timeout. On success we set exitCode=0 and
+// let the loop drain naturally — a clean exit that avoids the Windows libuv assertion
+// (UV_HANDLE_CLOSING) that an immediate process.exit() triggers while a handle is mid-
+// teardown. The unref()'d fallback force-exits only if some module still leaves a handle
+// open, so the CLI can never hang again. Nothing durable is truncated — it all completed
+// before the promise resolved.
+completeQuickFix(qfId, options)
+  .then(() => {
+    process.exitCode = 0;
+    setTimeout(() => process.exit(0), 1500).unref();
+  })
+  .catch((err) => {
+    console.error('❌ Error:', err.message);
+    process.exit(1);
+  });

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -63,7 +63,14 @@ export async function completeQuickFix(qfId, options = {}) {
     process.exit(1);
   }
 
-  const supabase = createClient(supabaseUrl, supabaseKey);
+  // QF-20260529-852 (RCA c6a002d5): disable the auth background-refresh setInterval and
+  // session persistence on this short-lived service-role CLI client. Service-role keys do
+  // not expire, so there is nothing to refresh — and the default auto-refresh timer is the
+  // handle that kept the event loop alive after the completion write, hanging the process
+  // to the external ~2-min timeout. With it off, the loop drains naturally for a clean exit.
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
 
   // QF-20260511-258: Stale-branch guard for the post-merge feedback auto-resolver.
   // If origin/main has commits touching resolver paths that the worker's HEAD

--- a/tests/unit/complete-quick-fix-exits-on-success.test.js
+++ b/tests/unit/complete-quick-fix-exits-on-success.test.js
@@ -1,0 +1,103 @@
+/**
+ * Regression: complete-quick-fix.js must terminate deterministically on success.
+ *
+ * QF-20260529-852 / RCA c6a002d5: the CLI wrapper only exited on failure
+ * (completeQuickFix().catch(exit 1)) and relied on event-loop drain for success.
+ * The orchestrator transitively opens background handles (the supabase-js client's
+ * default background-refresh setInterval, idle sockets) that outlive all awaited
+ * work, so after the quick_fixes row was written to "completed" and the promise
+ * resolved, the process hung to the external ~2-min timeout. Fix: symmetric
+ * process.exit(0) on the resolve path.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const wrapperPath = fileURLToPath(new URL('../../scripts/complete-quick-fix.js', import.meta.url));
+const orchestratorPath = fileURLToPath(
+  new URL('../../scripts/modules/complete-quick-fix/orchestrator.js', import.meta.url)
+);
+
+describe('complete-quick-fix — deterministic, non-hanging exit wiring', () => {
+  const wrapperSrc = readFileSync(wrapperPath, 'utf8');
+  const orchestratorSrc = readFileSync(orchestratorPath, 'utf8');
+
+  it('sets a deterministic success exit code with a non-hanging unref() fallback', () => {
+    expect(wrapperSrc).toMatch(/process\.exitCode\s*=\s*0/);
+    expect(wrapperSrc).toMatch(/\.unref\(\)/);
+  });
+
+  it('still exits non-zero on failure', () => {
+    expect(wrapperSrc).toMatch(/\.catch\([\s\S]*?process\.exit\(1\)/);
+  });
+
+  it('disables the supabase auth refresh timer on the CLI client (root cause)', () => {
+    expect(orchestratorSrc).toMatch(/autoRefreshToken:\s*false/);
+  });
+});
+
+// Behavioral proof: spawn the real CLI against an already-completed QF (a fast,
+// side-effect-free path that returns early) and assert the process TERMINATES.
+// Pre-fix this hangs on the lingering supabase refresh timer; post-fix it exits 0.
+// DB-gated: skips cleanly without service-role creds (e.g. CI without secrets).
+const hasCreds = !!(
+  process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+);
+
+describe.skipIf(!hasCreds)('complete-quick-fix CLI — terminates on success (no hang)', () => {
+  let completedId = null;
+
+  beforeAll(async () => {
+    try {
+      const { createClient } = await import('@supabase/supabase-js');
+      const sb = createClient(
+        process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+        process.env.SUPABASE_SERVICE_ROLE_KEY
+      );
+      const { data } = await sb
+        .from('quick_fixes')
+        .select('id')
+        .eq('status', 'completed')
+        .order('completed_at', { ascending: false })
+        .limit(1);
+      completedId = data?.[0]?.id || null;
+    } catch {
+      completedId = null;
+    }
+  });
+
+  it('exits 0 within 45s on an already-completed QF (would hang pre-fix)', async () => {
+    if (!completedId) return; // no fixture in this DB — skip cleanly
+    const result = await new Promise((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [
+          wrapperPath,
+          completedId,
+          '--non-interactive',
+          '--allow-stale-branch',
+          '--reason',
+          'regression: QF-20260529-852 exit-0 on resolve',
+        ],
+        { stdio: 'ignore' }
+      );
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve({ code: null, timedOut: true });
+      }, 45000);
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        resolve({ code, timedOut: false });
+      });
+      child.on('error', () => {
+        clearTimeout(timer);
+        resolve({ code: -1, timedOut: false, errored: true });
+      });
+    });
+
+    expect(result.timedOut).toBe(false); // core anti-hang assertion
+    expect(result.code).toBe(0); // success path → deterministic exit 0
+  }, 60000);
+});

--- a/tests/unit/regression-pins/qf-orchestrator-service-role-pins.test.js
+++ b/tests/unit/regression-pins/qf-orchestrator-service-role-pins.test.js
@@ -44,9 +44,11 @@ describe('QF-20260511-122 orchestrator service-role key pins', () => {
     const src = read('scripts/modules/complete-quick-fix/orchestrator.js');
     const start = src.indexOf('export async function completeQuickFix');
     const body = src.slice(start, start + 2000);
-    // createClient(supabaseUrl, supabaseKey) must be present, and the key var must be the
-    // service-role-sourced one validated above.
-    expect(body).toMatch(/createClient\(\s*supabaseUrl\s*,\s*supabaseKey\s*\)/);
+    // createClient(supabaseUrl, supabaseKey, ...) must be present, and the key var must be the
+    // service-role-sourced one validated above. An optional 3rd options arg is allowed
+    // (QF-20260529-852 disables the auth refresh timer there); the pin only protects that
+    // supabaseKey remains the service-role-sourced 2nd argument.
+    expect(body).toMatch(/createClient\(\s*supabaseUrl\s*,\s*supabaseKey\s*[,)]/);
   });
 
   it('orchestrator error message names SUPABASE_SERVICE_ROLE_KEY when credentials missing', () => {


### PR DESCRIPTION
fix(QF-20260529-852): complete-quick-fix.js exits cleanly instead of hanging ~2min

RCA c6a002d5: the CLI hung to the external ~2-min timeout AFTER the quick_fixes row
was written to completed. Root cause: scripts/modules/complete-quick-fix/orchestrator.js
created its supabase client with default options, whose auth background-refresh
setInterval kept the Node event loop alive after all awaited work finished; the wrapper
had no success-path exit, so the loop never drained. (An immediate process.exit(0)
"fix" instead trips the Windows libuv UV_HANDLE_CLOSING assertion -> exit code
3221226505, so that is NOT the fix.)

Fix (systemic, root-cause):
- orchestrator.js: createClient(..., { auth: { autoRefreshToken: false,
  persistSession: false } }) on the short-lived service-role CLI client. Service-role
  keys never refresh, so there is nothing to refresh; removing the timer lets the loop
  drain naturally.
- complete-quick-fix.js: on success set process.exitCode = 0 and let the loop drain
  (clean exit, no teardown-race crash), with an unref()'d 1.5s fallback force-exit so the
  CLI can never hang again even if a future module leaves a handle open.

Tests: tests/unit/complete-quick-fix-exits-on-success.test.js (4) — static guards plus a
DB-gated behavioral spawn proving the CLI exits 0 in ~1s on the already-completed path
(was hanging + crashing pre-fix). Relaxed qf-orchestrator-service-role-pins.test.js:49 to
allow the options arg (intent unchanged: supabaseKey stays the service-role 2nd arg).
Full regression: 177/177 pass across 17 files.

Closes harness backlog c6a002d5-5bd4-4f44-8b6f-bd1df49c28de

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
