### PR TITLE
fix(QF-20260529-822): leo_sub_agents queries use live active column, not is_active

### DIFF
--- a/lib/agent-experience-factory/adapters/skills-adapter.js
+++ b/lib/agent-experience-factory/adapters/skills-adapter.js
@@ -18,7 +18,9 @@ export class SkillsAdapter extends BaseAdapter {
     const { data, error } = await this.supabase
       .from('leo_sub_agents')
       .select('code, name, description, capabilities, metadata')
-      .eq('is_active', true)
+      // QF-20260529-822: live column is `active` (not `is_active`); is_active threw
+      // "column leo_sub_agents.is_active does not exist" → DESIGN analysis scored 0/100.
+      .eq('active', true)
       .order('priority', { ascending: false })
       .limit(20); // Fetch more, filter client-side by relevance
 

--- a/scripts/claude-gen/data-fetchers.js
+++ b/scripts/claude-gen/data-fetchers.js
@@ -53,7 +53,9 @@ export async function getSubAgents() {
   const { data, error } = await supabase
     .from('leo_sub_agents')
     .select('*')
-    .eq('is_active', true)
+    // QF-20260529-822: live column is `active` (not `is_active`); is_active silently
+    // warned + returned [], dropping every sub-agent from the generated CLAUDE.md.
+    .eq('active', true)
     .order('code');
 
   if (error) console.warn(`⚠️ Sub-agents: ${error.message}`);

--- a/tests/unit/leo-sub-agents-active-column.test.js
+++ b/tests/unit/leo-sub-agents-active-column.test.js
@@ -1,0 +1,62 @@
+/**
+ * Regression: leo_sub_agents queries must filter on the live column `active`, not `is_active`.
+ *
+ * QF-20260529-822 / RCA d276bbf3: lib/agent-experience-factory/adapters/skills-adapter.js
+ * filtered `.eq('is_active', true)` and threw "leo_sub_agents query failed: column
+ * leo_sub_agents.is_active does not exist", which add-prd-to-database.js DESIGN orchestration
+ * surfaced -> DESIGN scored 0/100. scripts/claude-gen/data-fetchers.js getSubAgents() did the
+ * same and silently returned [] (dropping every sub-agent from the generated CLAUDE.md).
+ * The live leo_sub_agents column is `active` (6 other call sites already use it).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const skillsPath = fileURLToPath(
+  new URL('../../lib/agent-experience-factory/adapters/skills-adapter.js', import.meta.url)
+);
+const fetchersPath = fileURLToPath(new URL('../../scripts/claude-gen/data-fetchers.js', import.meta.url));
+
+describe('leo_sub_agents queries use the live `active` column (QF-20260529-822)', () => {
+  const skillsSrc = readFileSync(skillsPath, 'utf8');
+  const fetchersSrc = readFileSync(fetchersPath, 'utf8');
+
+  it('skills-adapter queries leo_sub_agents with .eq("active") and never is_active', () => {
+    expect(skillsSrc).toMatch(/\.from\('leo_sub_agents'\)[\s\S]{0,400}\.eq\('active',\s*true\)/);
+    expect(skillsSrc).not.toMatch(/\.eq\('is_active'/);
+  });
+
+  it('data-fetchers getSubAgents queries leo_sub_agents with active, not is_active', () => {
+    // Scope to the leo_sub_agents block (the file legitimately uses is_active on OTHER tables).
+    expect(fetchersSrc).toMatch(/\.from\('leo_sub_agents'\)[\s\S]{0,400}\.eq\('active',\s*true\)/);
+    expect(fetchersSrc).not.toMatch(/\.from\('leo_sub_agents'\)[\s\S]{0,400}\.eq\('is_active'/);
+  });
+});
+
+// Behavioral: the SkillsAdapter query must run against the live schema without throwing.
+// DB-gated: skips cleanly without service-role creds (e.g. CI without secrets).
+const hasCreds = !!(
+  process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+);
+
+describe.skipIf(!hasCreds)('SkillsAdapter — runs against live leo_sub_agents schema', () => {
+  let SkillsAdapter, supabase;
+
+  beforeAll(async () => {
+    const { createClient } = await import('@supabase/supabase-js');
+    supabase = createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+    ({ SkillsAdapter } = await import('../../lib/agent-experience-factory/adapters/skills-adapter.js'));
+  });
+
+  it('_doFetch does not throw on the leo_sub_agents query (pre-fix: is_active threw)', async () => {
+    const adapter = new SkillsAdapter(supabase);
+    const result = await adapter._doFetch({ domain: 'testing', category: 'quality' });
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result.items)).toBe(true);
+  });
+});


### PR DESCRIPTION
fix(QF-20260529-822): leo_sub_agents queries use live `active` column, not is_active

RCA d276bbf3: two queries filtered leo_sub_agents on a non-existent column `is_active`
(the live column is `active`; 6 other call sites already use it).
- lib/agent-experience-factory/adapters/skills-adapter.js THREW "leo_sub_agents query
  failed: column leo_sub_agents.is_active does not exist", which add-prd-to-database.js
  DESIGN orchestration surfaced -> DESIGN analysis scored 0/100.
- scripts/claude-gen/data-fetchers.js getSubAgents() warned + returned [], silently
  dropping every sub-agent from the generated CLAUDE.md.

Fix: .eq('is_active', true) -> .eq('active', true) in both. Verified live: leo_sub_agents
has active + priority (not is_active); the corrected query returns rows; the buggy one
errors exactly as reported.

Tests: tests/unit/leo-sub-agents-active-column.test.js (3) — static guards scoped to the
leo_sub_agents queries + a DB-gated behavioral test that instantiates SkillsAdapter and
proves _doFetch no longer throws. Regression: agent-experience-factory + claude-md-generator
suites 28/28 pass.

Closes harness backlog d276bbf3

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
