### PR TITLE
fix(QF-20260529-888): guard complete-quick-fix prompts under --non-interactive

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -750,8 +750,12 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
 
       // QF-20260509-552: --force-complete auto-confirms commit/push prompts
       // so --non-interactive flow does not wedge.
-      const shouldCommit = flags.forceComplete
-        ? (console.log(`   ⚠️  --force-complete: auto-confirm commit (reason="${flags.reason}")`), 'yes')
+      // QF-20260529-888: auto-confirm under --non-interactive too (the comment above
+      // assumed it's always paired with --force-complete — it isn't; a plain
+      // --non-interactive run otherwise wedges/rejects on this prompt).
+      const autoConfirmGit = flags.forceComplete || flags.nonInteractive;
+      const shouldCommit = autoConfirmGit
+        ? (console.log(`   ⚠️  ${flags.forceComplete ? '--force-complete' : '--non-interactive'}: auto-confirm commit (reason="${flags.reason || 'n/a'}")`), 'yes')
         : await prompt('   Commit these changes? (yes/no): ');
 
       if (shouldCommit.toLowerCase().startsWith('y')) {
@@ -767,8 +771,8 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
         commitSha = newCommitSha;
         console.log(`   ✅ Committed: ${newCommitSha.substring(0, 7)}\n`);
 
-        const shouldPush = flags.forceComplete
-          ? (console.log(`   ⚠️  --force-complete: auto-confirm push (reason="${flags.reason}")`), 'yes')
+        const shouldPush = autoConfirmGit
+          ? (console.log(`   ⚠️  ${flags.forceComplete ? '--force-complete' : '--non-interactive'}: auto-confirm push`), 'yes')
           : await prompt('   Push to remote? (yes/no): ');
 
         if (shouldPush.toLowerCase().startsWith('y')) {
@@ -853,9 +857,15 @@ export async function mergeToMain(testDir, qf, prUrl, prompt, flags = {}) {
     // QF-20260509-552: 7th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
     // --force-complete auto-confirms the merge prompt so --non-interactive flow
     // does not wedge after validators were patched in QF-407 / SD-FDBK FR-2.
+    // QF-20260529-888: under plain --non-interactive (no --force-complete), SKIP the
+    // direct merge rather than prompting (which rejects). Auto-merging via `gh pr merge
+    // --merge` immediately is unsafe without a CI gate, so the safe default is to let
+    // `gh pr merge --auto` / CI handle it (or re-run with --force-complete to force).
     const shouldMerge = flags.forceComplete
       ? (console.log(`   ⚠️  --force-complete: auto-confirm merge (reason="${flags.reason}")`), 'yes')
-      : await prompt('   Merge to main now? (yes/no): ');
+      : flags.nonInteractive
+        ? (console.log('   ℹ️  --non-interactive: skipping direct merge (use `gh pr merge --auto` / CI, or re-run with --force-complete).'), 'no')
+        : await prompt('   Merge to main now? (yes/no): ');
 
     if (shouldMerge.toLowerCase().startsWith('y')) {
       console.log('\n   🔀 Merging to main...');

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -314,7 +314,10 @@ export async function completeQuickFix(qfId, options = {}) {
   // options.verificationNotes if provided; the prompt below only runs without
   // --non-interactive when no notes were supplied).
   let verificationNotes = options.verificationNotes;
-  if (!verificationNotes) {
+  // QF-20260529-888: actually honor the guard the comment above describes — under
+  // --non-interactive (or --force-complete) this optional prompt must NOT fire, else
+  // prompt() rejects and fails the whole completion. Absent notes default to null below.
+  if (!verificationNotes && !options.nonInteractive && !options.forceComplete) {
     verificationNotes = await prompt('\nVerification notes (optional): ');
   }
 

--- a/tests/unit/complete-quick-fix-noninteractive-prompts.test.js
+++ b/tests/unit/complete-quick-fix-noninteractive-prompts.test.js
@@ -1,0 +1,48 @@
+/**
+ * Regression: complete-quick-fix.js prompts must be guarded under --non-interactive.
+ *
+ * QF-20260529-888 (found dogfooding QF-852): four operator prompts checked only
+ * flags.forceComplete, so a plain --non-interactive run rejected with [NON_INTERACTIVE]
+ * when a value was absent. The verificationNotes prompt actually FAILED completion; the
+ * "Merge to main now?" prompt rejected (caught but noisy); commit/push shared the gap.
+ * Fix: guard all four — verificationNotes skipped, commit/push auto-confirmed, merge
+ * skipped-with-log (auto-merge without CI is unsafe) — under --non-interactive.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const orchPath = fileURLToPath(
+  new URL('../../scripts/modules/complete-quick-fix/orchestrator.js', import.meta.url)
+);
+const gitOpsPath = fileURLToPath(
+  new URL('../../scripts/modules/complete-quick-fix/git-operations.js', import.meta.url)
+);
+
+const orch = readFileSync(orchPath, 'utf8');
+const gitOps = readFileSync(gitOpsPath, 'utf8');
+
+describe('complete-quick-fix prompts guarded under --non-interactive (QF-20260529-888)', () => {
+  it('verificationNotes prompt is skipped under --non-interactive / --force-complete', () => {
+    expect(orch).toMatch(
+      /if \(!verificationNotes && !options\.nonInteractive && !options\.forceComplete\)/
+    );
+  });
+
+  it('commit + push auto-confirm under --non-interactive (not only --force-complete)', () => {
+    expect(gitOps).toMatch(/const autoConfirmGit = flags\.forceComplete \|\| flags\.nonInteractive/);
+    expect(gitOps).toMatch(/shouldCommit = autoConfirmGit/);
+    expect(gitOps).toMatch(/shouldPush = autoConfirmGit/);
+  });
+
+  it('merge is skipped (not prompted) under --non-interactive', () => {
+    expect(gitOps).toMatch(/skipping direct merge/);
+    expect(gitOps).toMatch(/:\s*flags\.nonInteractive/); // shouldMerge has a nonInteractive branch
+  });
+
+  it('interactive mode still prompts (regression guard — behavior unchanged when no flags)', () => {
+    expect(gitOps).toMatch(/await prompt\('   Merge to main now\?/);
+    expect(gitOps).toMatch(/await prompt\('   Commit these changes\?/);
+    expect(orch).toMatch(/await prompt\('\\nVerification notes/);
+  });
+});


### PR DESCRIPTION
fix(QF-20260529-888): guard complete-quick-fix prompts under --non-interactive

Found dogfooding QF-852: four operator prompts in the completion flow checked only
flags.forceComplete, so a plain --non-interactive run rejected with [NON_INTERACTIVE]
when a value was absent. The verificationNotes prompt (orchestrator.js) FAILED the whole
completion; the "Merge to main now?" prompt (git-operations.js) rejected (caught but
noisy); commit + push shared the gap and would break a --non-interactive run with
uncommitted changes. Each prompt's own comment claimed --non-interactive was handled, but
the code only ever checked --force-complete.

Fix — guard all four with safe defaults:
- verificationNotes (orchestrator.js): skipped under --non-interactive/--force-complete
  (optional; defaults to null).
- commit + push (git-operations.js): auto-confirmed under --non-interactive (matching the
  existing --force-complete behavior).
- merge (git-operations.js): SKIPPED with an informational log under --non-interactive
  (auto-merging via `gh pr merge --merge` without a CI gate is unsafe; let
  `gh pr merge --auto`/CI handle it, or re-run with --force-complete). --force-complete
  still auto-merges; interactive mode still prompts (unchanged).

Tests: tests/unit/complete-quick-fix-noninteractive-prompts.test.js (4) static guards +
interactive-unchanged regression. Full complete-quick-fix suite: 177/177 pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
