### PR TITLE
fix(QF-20260529-168): thread --non-interactive into git-ops calls (activate QF-888 guards)

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -425,7 +425,8 @@ export async function completeQuickFix(qfId, options = {}) {
   }
 
   // Commit & Push (QF-20260509-552: forward {forceComplete,reason} flags)
-  commitSha = await commitAndPushChanges(testDir, qf, { commitSha, branchName }, actualLoc, filesChanged, finalPrUrl, testsPass, prompt, { forceComplete: options.forceComplete, reason: options.reason });
+  // QF-20260529-168: thread nonInteractive so git-operations' commit/push guards (QF-888) fire.
+  commitSha = await commitAndPushChanges(testDir, qf, { commitSha, branchName }, actualLoc, filesChanged, finalPrUrl, testsPass, prompt, { forceComplete: options.forceComplete, reason: options.reason, nonInteractive: options.nonInteractive });
 
   // Update record
   console.log('🔄 Updating quick-fix record...\n');
@@ -497,7 +498,8 @@ export async function completeQuickFix(qfId, options = {}) {
   displayCompletionSummary(qf, actualLoc, commitSha, branchName, finalPrUrl, filesChanged);
 
   // Merge to Main (QF-20260509-552: forward {forceComplete,reason} flags)
-  await mergeToMain(testDir, qf, finalPrUrl, prompt, { forceComplete: options.forceComplete, reason: options.reason });
+  // QF-20260529-168: thread nonInteractive so mergeToMain's skip-under-non-interactive guard (QF-888) fires.
+  await mergeToMain(testDir, qf, finalPrUrl, prompt, { forceComplete: options.forceComplete, reason: options.reason, nonInteractive: options.nonInteractive });
 
   // SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-1: post-merge feedback auto-resolve.
   // Parse "Closes (feedback|harness backlog) <uuid>" footers from PR body and

--- a/tests/unit/complete-quick-fix-noninteractive-threading.test.js
+++ b/tests/unit/complete-quick-fix-noninteractive-threading.test.js
@@ -1,0 +1,28 @@
+/**
+ * Regression: the orchestrator must thread `nonInteractive` into the git-operations calls,
+ * otherwise QF-888's commit/push/merge guards are dead code.
+ *
+ * QF-20260529-168 (found dogfooding QF-888): git-operations.js gained nonInteractive guards
+ * in QF-888, but orchestrator.js called commitAndPushChanges / mergeToMain with only
+ * { forceComplete, reason } — so a --non-interactive completion still hit the "Merge to main
+ * now?" prompt. QF-888's static test only checked the guards EXIST, not that they're wired,
+ * so it passed while the behavior was broken. This pins the wiring.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const orchPath = fileURLToPath(
+  new URL('../../scripts/modules/complete-quick-fix/orchestrator.js', import.meta.url)
+);
+const orch = readFileSync(orchPath, 'utf8');
+
+describe('orchestrator threads nonInteractive into git-ops calls (QF-20260529-168)', () => {
+  it('commitAndPushChanges receives nonInteractive: options.nonInteractive', () => {
+    expect(orch).toMatch(/commitAndPushChanges\([^\n]*nonInteractive:\s*options\.nonInteractive/);
+  });
+
+  it('mergeToMain receives nonInteractive: options.nonInteractive', () => {
+    expect(orch).toMatch(/mergeToMain\([^\n]*nonInteractive:\s*options\.nonInteractive/);
+  });
+});


### PR DESCRIPTION
fix(QF-20260529-168): thread --non-interactive into git-ops calls (activate QF-888 guards)

Found dogfooding QF-888: git-operations.js gained nonInteractive guards for commit/push/
merge in QF-888, but orchestrator.js called commitAndPushChanges (L428) and mergeToMain
(L500) with only { forceComplete, reason } — never threading options.nonInteractive — so
those guards were dead code. A --non-interactive completion still hit the "Merge to main
now?" prompt and rejected (caught gracefully but noisy). QF-888's test only asserted the
guards EXIST, not that they were wired, so it passed while the behavior stayed broken
(static guards aren't enough — dogfooding caught it).

Fix: add nonInteractive: options.nonInteractive to both flags objects (sibling of the
existing forceComplete/reason). Now the merge skips cleanly + commit/push auto-confirm
under --non-interactive. New test pins the wiring at both call sites.

Tests: tests/unit/complete-quick-fix-noninteractive-threading.test.js (2) + QF-888 prompts
test + complete-quick-fix suite: 170/170 pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
