### PR TITLE
fix(QF-20260529-729): git-state precheck ignores per-worktree metadata noise

### DIFF
--- a/scripts/check-git-state.js
+++ b/scripts/check-git-state.js
@@ -18,6 +18,17 @@ import { pathToFileURL } from 'url';
 
 const execAsync = promisify(exec);
 
+// QF-20260529-729 (backlog a23355c1): .worktree.json + .worktree-nm-mode are deliberately
+// TRACKED per-worktree metadata (see the .gitignore note) that worktree provisioning rewrites
+// for each worktree, so inside a worktree they ALWAYS appear "modified". That is git noise,
+// not real uncommitted work — it must not block a handoff (it tripped STEP 1 at every
+// LEAD-TO-PLAN handoff run from a worktree). Excluded from the blocking classification below;
+// this does NOT untrack them (honors the deliberate tracking decision).
+const PER_WORKTREE_METADATA = ['.worktree.json', '.worktree-nm-mode'];
+function isPerWorktreeMetadata(file) {
+  return PER_WORKTREE_METADATA.includes((file || '').trim());
+}
+
 async function gitCommand(command, cwd) {
   try {
     const { stdout, stderr } = await execAsync(command, cwd ? { cwd } : undefined);
@@ -64,6 +75,9 @@ async function checkGitState(options = {}) {
     lines.forEach(line => {
       const status = line.substring(0, 2);
       const file = line.substring(3);
+
+      // QF-20260529-729: skip per-worktree metadata noise — never blocks a handoff.
+      if (isPerWorktreeMetadata(file)) return;
 
       // Classify by status
       if (status[0] === '?' && status[1] === '?') {
@@ -189,7 +203,7 @@ async function checkGitState(options = {}) {
   return result;
 }
 
-export { checkGitState };
+export { checkGitState, isPerWorktreeMetadata, PER_WORKTREE_METADATA };
 
 // CLI execution — only when run directly (node scripts/check-git-state.js), NOT when
 // imported. Without this guard, importing the module (e.g. from the handoff precheck CLI

--- a/tests/unit/check-git-state-worktree-metadata.test.js
+++ b/tests/unit/check-git-state-worktree-metadata.test.js
@@ -1,0 +1,38 @@
+/**
+ * Regression: the handoff STEP-1 git-state check must not block on tracked-but-per-worktree
+ * metadata noise.
+ *
+ * QF-20260529-729 (backlog a23355c1): .worktree.json + .worktree-nm-mode are deliberately
+ * TRACKED per-worktree metadata that provisioning rewrites for each worktree, so inside a
+ * worktree they always show as "modified" → checkGitState set passed=false → blocked every
+ * LEAD-TO-PLAN handoff from a worktree. Fix excludes them from the blocking classification
+ * (without untracking them).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { isPerWorktreeMetadata, PER_WORKTREE_METADATA } from '../../scripts/check-git-state.js';
+
+const srcPath = fileURLToPath(new URL('../../scripts/check-git-state.js', import.meta.url));
+
+describe('check-git-state ignores per-worktree metadata noise (QF-20260529-729)', () => {
+  it('treats .worktree.json + .worktree-nm-mode as non-blocking metadata', () => {
+    expect(isPerWorktreeMetadata('.worktree.json')).toBe(true);
+    expect(isPerWorktreeMetadata('.worktree-nm-mode')).toBe(true);
+    expect(PER_WORKTREE_METADATA).toEqual(
+      expect.arrayContaining(['.worktree.json', '.worktree-nm-mode'])
+    );
+  });
+
+  it('does NOT ignore real source files', () => {
+    expect(isPerWorktreeMetadata('src/index.js')).toBe(false);
+    expect(isPerWorktreeMetadata('scripts/check-git-state.js')).toBe(false);
+    expect(isPerWorktreeMetadata('')).toBe(false);
+    expect(isPerWorktreeMetadata(null)).toBe(false);
+  });
+
+  it('the classification loop is actually wired to skip them (QF-888 dead-code lesson)', () => {
+    const src = readFileSync(srcPath, 'utf8');
+    expect(src).toMatch(/if \(isPerWorktreeMetadata\(file\)\) return;/);
+  });
+});


### PR DESCRIPTION
fix(QF-20260529-729): git-state precheck ignores per-worktree metadata noise

Backlog a23355c1: scripts/check-git-state.js (STEP 1 of the handoff precheck) classified
.worktree.json + .worktree-nm-mode as modified files and set passed=false, blocking every
LEAD-TO-PLAN handoff run from inside a worktree. Those files are deliberately TRACKED
per-worktree metadata (see .gitignore note) that provisioning rewrites per worktree, so they
always show "modified" in a worktree — git noise, not real uncommitted work. The existing
untracked-ignore list didn't help (they're tracked, not untracked).

Fix: exclude the two known per-worktree metadata files from the blocking staged/modified
classification (PER_WORKTREE_METADATA + isPerWorktreeMetadata skip in the loop). Does NOT
untrack them — honors the deliberate tracking decision; readers still get the on-disk file.
Merging only helps other live sessions (they stop getting the same false-block).

Tests: tests/unit/check-git-state-worktree-metadata.test.js (3) — predicate + a wiring
assertion (QF-888 dead-code lesson: prove the loop USES the predicate, not just defines it).

Closes harness backlog a23355c1

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
