### PR TITLE
feat(SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B): repoint EHG_Engineer readers to venture_stages

### DIFF
--- a/lib/eva/cross-venture-learning.js
+++ b/lib/eva/cross-venture-learning.js
@@ -68,7 +68,7 @@ async function analyzeKillStageFrequency(supabase, ventureIds) {
   if (stageNumbers.length === 0) return [];
 
   const { data: stageConfig } = await supabase
-    .from('lifecycle_stage_config')
+    .from('venture_stages') // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset
     .select('stage_number, stage_name')
     .in('stage_number', stageNumbers);
 

--- a/lib/eva/lifecycle/exit-gate-enforcer.js
+++ b/lib/eva/lifecycle/exit-gate-enforcer.js
@@ -77,7 +77,7 @@ export async function checkExitGates({ supabase, ventureId, fromStage }) {
 
   // Read the gates.exit declaration for this stage.
   const { data: stageConfig, error: cfgError } = await supabase
-    .from('lifecycle_stage_config')
+    .from('venture_stages') // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset
     .select('metadata')
     .eq('stage_number', fromStage)
     .maybeSingle();
@@ -86,7 +86,7 @@ export async function checkExitGates({ supabase, ventureId, fromStage }) {
     // Treat config read failure as a hard block — surface the error to the caller.
     return {
       allowed: false,
-      blocked_by: [`lifecycle_stage_config read failed: ${cfgError.message}`],
+      blocked_by: [`venture_stages read failed: ${cfgError.message}`],
       gates_checked: [],
       stage_number: fromStage,
       flag_enforced: true,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1597,7 +1597,7 @@ export class StageExecutionWorker {
   async _getStageTimeoutMs(stageNumber) {
     try {
       const { data: cfg } = await this._supabase
-        .from('lifecycle_stage_config')
+        .from('venture_stages') /* SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset */
         .select('metadata')
         .eq('stage_number', stageNumber)
         .single();
@@ -3588,7 +3588,7 @@ export class StageExecutionWorker {
     let workType = 'artifact_only'; // fallback
     try {
       const { data: cfg } = await this._supabase
-        .from('lifecycle_stage_config')
+        .from('venture_stages') /* SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset */
         .select('work_type')
         .eq('stage_number', stageNumber)
         .single();

--- a/lib/eva/stage-governance.js
+++ b/lib/eva/stage-governance.js
@@ -1,10 +1,16 @@
 /**
  * Stage Governance — single DB-backed source of truth for venture stage gating.
  *
- * SD-LEO-REFAC-CANONICALIZE-STAGE-CONFIG-001 FR-2: canonical sets are now
- * derived from `lifecycle_stage_config.work_type` (4-way enum), not from
- * `stage_config.gate_type` (lossy 3-value mirror). This closes the 28th
- * witness of PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+ * SD-LEO-REFAC-CANONICALIZE-STAGE-CONFIG-001 FR-2: canonical sets are derived
+ * from work_type (4-way enum), not from gate_type alone (lossy 3-value mirror).
+ * This closes the 28th witness of PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.
+ *
+ * SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: read the unified `venture_stages`
+ * table (a verified superset of the legacy stage_config + lifecycle_stage_config
+ * created by Child A). Because each venture_stages row carries BOTH gate_type
+ * AND work_type, the prior dual-table read + in-memory join on stage_number is
+ * replaced by a SINGLE SELECT, and the two realtime channels collapse to one.
+ * Behavior is byte-identical — gate classification is unchanged.
  *
  * Canonical rule:
  *   - killStages       = stages where work_type='decision_gate' AND gate_type='kill'
@@ -16,8 +22,7 @@
  *
  * Cache strategy:
  *   - In-process module-level cache, 60s TTL.
- *   - Supabase realtime UPDATE/INSERT/DELETE on either stage_config or
- *     lifecycle_stage_config invalidates immediately.
+ *   - Supabase realtime UPDATE/INSERT/DELETE on venture_stages invalidates immediately.
  *   - If realtime subscription fails, falls back to TTL-only refresh.
  */
 
@@ -28,21 +33,15 @@ let _subscription = null;
 let _subscriptionSupabase = null;
 
 async function _readFresh(supabase) {
-  // Read both canonical sources and JOIN in-memory on stage_number.
-  // lifecycle_stage_config.work_type is canonical; stage_config supplies
-  // gate_type/review_mode/stage_name/stage_key/chunk/description.
-  const [stageRes, lifecycleRes] = await Promise.all([
-    supabase.from('stage_config').select('stage_number, stage_name, stage_key, gate_type, review_mode, chunk, description').order('stage_number'),
-    supabase.from('lifecycle_stage_config').select('stage_number, work_type').order('stage_number'),
-  ]);
-  if (stageRes.error) throw stageRes.error;
-  if (lifecycleRes.error) throw lifecycleRes.error;
-
-  // Build work_type lookup
-  const workTypeByStage = new Map();
-  for (const row of lifecycleRes.data || []) {
-    workTypeByStage.set(row.stage_number, row.work_type);
-  }
+  // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single read from the unified
+  // `venture_stages` superset. Each row carries gate_type, review_mode AND
+  // work_type, so the prior in-memory join of stage_config + lifecycle_stage_config
+  // is no longer needed.
+  const { data, error } = await supabase
+    .from('venture_stages')
+    .select('stage_number, stage_name, stage_key, gate_type, review_mode, chunk, description, work_type')
+    .order('stage_number');
+  if (error) throw error;
 
   const killStages = new Set();
   const promotionStages = new Set();
@@ -50,15 +49,13 @@ async function _readFresh(supabase) {
   const stages = new Map();
 
   // Defensive: null/undefined data (empty table or minimal test mocks) yields empty sets.
-  for (const row of stageRes.data || []) {
-    const workType = workTypeByStage.get(row.stage_number);
-    const merged = { ...row, work_type: workType };
-    stages.set(row.stage_number, merged);
+  for (const row of data || []) {
+    stages.set(row.stage_number, row);
 
     // Canonical rule: work_type='decision_gate' is required to participate
     // in kill/promotion classification. sd_required + automated_check +
     // artifact_only stages are EXCLUDED.
-    if (workType === 'decision_gate') {
+    if (row.work_type === 'decision_gate') {
       if (row.gate_type === 'kill') killStages.add(row.stage_number);
       if (row.gate_type === 'promotion') promotionStages.add(row.stage_number);
     }
@@ -78,16 +75,14 @@ function _ensureSubscription(supabase) {
     _subscription = null;
   }
   try {
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single channel on venture_stages
+    // (which is in the supabase_realtime publication) replaces the prior two
+    // channels on stage_config + lifecycle_stage_config — equivalent coverage.
     _subscription = supabase
-      .channel('stage-governance-invalidation')
+      .channel('stage-governance-venture-stages-invalidation')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'stage_config' },
-        () => { _cache = null; }
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'lifecycle_stage_config' },
+        { event: '*', schema: 'public', table: 'venture_stages' },
         () => { _cache = null; }
       )
       .subscribe((status) => {
@@ -122,8 +117,8 @@ function _publicView(c) {
 
 /**
  * Returns the canonical stage governance view for the venture pipeline.
- * Sets derived from lifecycle_stage_config.work_type (canonical) joined
- * with stage_config (auxiliary).
+ * Sets derived from the unified `venture_stages` table per the canonical rule
+ * (kill/promotion require work_type='decision_gate').
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  */

--- a/lib/eva/stage-registry.js
+++ b/lib/eva/stage-registry.js
@@ -5,7 +5,7 @@
  * Follows the ValidatorRegistry pattern (register/get/has/getStats).
  * Provides unified lookup for stage templates with:
  * - File-based registration for built-in stages (1-26)
- * - Database-driven configuration via lifecycle_stage_config
+ * - Database-driven configuration via venture_stages
  * - 5-minute TTL cache for DB-loaded configs
  * - Graceful fallback to file-based templates when DB unavailable
  *
@@ -149,7 +149,7 @@ export class StageRegistry {
   }
 
   /**
-   * Load stage configurations from lifecycle_stage_config DB table.
+   * Load stage configurations from the unified venture_stages DB table.
    * DB entries are cached with 5-minute TTL.
    * @param {Object} [supabaseClient] - Optional Supabase client override
    * @returns {Promise<number>} Number of stages loaded from DB
@@ -158,47 +158,31 @@ export class StageRegistry {
     try {
       const supabase = supabaseClient || createSupabaseServiceClient();
 
-      // SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-2: stage_name is sourced
-      // from `stage_config` (name-authoritative per lib/eva/stage-governance.js).
-      // lifecycle_stage_config remains the source for phase_name / metadata.
-      // See sibling reader: lib/eva/stage-registry/index.js for the same pattern.
-      const [lifecycleRes, nameRes] = await Promise.all([
-        supabase
-          .from('lifecycle_stage_config')
-          .select('stage_number, stage_name, phase_name, metadata, description')
-          .order('stage_number'),
-        supabase
-          .from('stage_config')
-          .select('stage_number, stage_name')
-          .order('stage_number'),
-      ]);
-      const { data, error } = lifecycleRes;
-      const { data: nameRows, error: nameError } = nameRes;
+      // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: read the unified `venture_stages`
+      // superset (Child A) in a SINGLE query. venture_stages has one canonical
+      // stage_name, so the prior second `stage_config` name-authority read and the
+      // override Map are removed. Behavior is unchanged — the legacy tables were
+      // reconciled to agree on names (SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001)
+      // and venture_stages carries that canonical name directly.
+      const { data, error } = await supabase
+        .from('venture_stages')
+        .select('stage_number, stage_name, phase_name, metadata, description')
+        .order('stage_number');
 
       if (error) {
         this.stats.dbErrors++;
-        console.warn(`StageRegistry: DB load failed (lifecycle_stage_config): ${error.message}`);
+        console.warn(`StageRegistry: DB load failed (venture_stages): ${error.message}`);
         return 0;
-      }
-      if (nameError) {
-        // Non-fatal: fall back to lifecycle name if stage_config is unreachable.
-        console.warn(`StageRegistry: stage_config name lookup failed, falling back to lifecycle name: ${nameError.message}`);
-      }
-
-      const authoritativeName = new Map();
-      for (const r of nameRows || []) {
-        authoritativeName.set(r.stage_number, r.stage_name);
       }
 
       let loaded = 0;
       const now = Date.now();
       for (const row of data || []) {
         // Build a template-compatible config from DB row.
-        // title is the user-facing stage name — sourced from stage_config (FR-2).
-        const canonicalName = authoritativeName.get(row.stage_number) || row.stage_name;
+        // title is the user-facing stage name — sourced from venture_stages.
         const dbConfig = {
           id: `stage-${String(row.stage_number).padStart(2, '0')}`,
-          title: canonicalName,
+          title: row.stage_name,
           phase: row.phase_name,
           description: row.description || '',
           version: row.metadata?.version || '1.0.0',
@@ -207,8 +191,8 @@ export class StageRegistry {
         };
 
         // Merge DB config with file-based template if available.
-        // FR-2: dbConfig.title is already the name-authoritative value from
-        // stage_config; preserve it over the file template's title.
+        // dbConfig.title is the canonical venture_stages name; preserve it over
+        // the file template's title.
         const fileEntry = this.stages.get(row.stage_number);
         if (fileEntry) {
           const merged = {

--- a/lib/eva/stage-registry/index.js
+++ b/lib/eva/stage-registry/index.js
@@ -3,14 +3,14 @@
  * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
  *
  * Creates and configures a StageRegistry instance.
- * Supports loading from database (lifecycle_stage_config) with
+ * Supports loading from database (venture_stages) with
  * graceful fallback to file-based stage templates.
  */
 
 import { StageRegistry } from './core.js';
 
 /**
- * Load stage configurations from lifecycle_stage_config table
+ * Load stage configurations from the unified venture_stages table.
  * @param {StageRegistry} registry
  * @param {object} supabase - Supabase client
  * @returns {Promise<{loaded: number, error: string|null}>}
@@ -25,52 +25,33 @@ export async function loadFromDatabase(registry, supabase) {
   }
 
   try {
-    // SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001 / FR-2: stage_name is sourced
-    // from `stage_config` (name-authoritative per lib/eva/stage-governance.js).
-    // lifecycle_stage_config remains the source for work_type / phase / artifacts.
-    // The migration in 20260526_reconcile_lifecycle_stage_config_names_sd_lifecycle_001.sql
-    // makes the two tables agree; reading the name from stage_config here means a
-    // future drift in lifecycle_stage_config.stage_name cannot resurface stale names
-    // through this reader. Belt + suspenders with the FR-6 CI parity assertion.
-    const [lifecycleRes, nameRes] = await Promise.all([
-      supabase
-        .from('lifecycle_stage_config')
-        .select('stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, advisory_enabled, depends_on, required_artifacts, metadata')
-        .order('stage_number', { ascending: true }),
-      supabase
-        .from('stage_config')
-        .select('stage_number, stage_name')
-        .order('stage_number', { ascending: true }),
-    ]);
-    const { data, error } = lifecycleRes;
-    const { data: nameRows, error: nameError } = nameRes;
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: read the unified `venture_stages`
+    // superset (Child A) in a SINGLE query. venture_stages has one canonical
+    // stage_name per stage, so the prior second `stage_config` read and the
+    // name-authority override Map are removed. Behavior is unchanged because
+    // the legacy tables were reconciled to agree on names
+    // (SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001) and venture_stages carries
+    // that canonical name directly.
+    const { data, error } = await supabase
+      .from('venture_stages')
+      .select('stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, advisory_enabled, depends_on, required_artifacts, metadata')
+      .order('stage_number', { ascending: true });
 
     if (error) {
-      console.warn(`[StageRegistry] DB load failed (lifecycle_stage_config): ${error.message}`);
+      console.warn(`[StageRegistry] DB load failed (venture_stages): ${error.message}`);
       return { loaded: 0, error: error.message };
-    }
-    if (nameError) {
-      // Non-fatal: fall back to lifecycle_stage_config.stage_name if stage_config is unreachable.
-      console.warn(`[StageRegistry] stage_config name lookup failed, falling back to lifecycle name: ${nameError.message}`);
     }
 
     if (!data || data.length === 0) {
       return { loaded: 0, error: 'No stage configs found in database' };
     }
 
-    // Build name-authoritative override map keyed by stage_number.
-    const authoritativeName = new Map();
-    for (const row of nameRows || []) {
-      authoritativeName.set(row.stage_number, row.stage_name);
-    }
-
     // Clear existing DB-loaded stages (keep fallbacks)
     registry.clear();
 
     for (const row of data) {
-      const canonicalName = authoritativeName.get(row.stage_number) || row.stage_name;
       registry.register(row.stage_number, {
-        stage_name: canonicalName,
+        stage_name: row.stage_name,
         description: row.description,
         phase_number: row.phase_number,
         phase_name: row.phase_name,

--- a/tests/integration/lifecycle/exit-gate.test.js
+++ b/tests/integration/lifecycle/exit-gate.test.js
@@ -19,7 +19,7 @@ const VENTURE_ID = '11111111-2222-3333-4444-555555555555';
 
 /**
  * Build a Supabase mock that responds to:
- *   - lifecycle_stage_config: returns { metadata: { gates: { exit: [...] } } }
+ *   - venture_stages: returns { metadata: { gates: { exit: [...] } } }
  *   - venture_artifacts: returns { id: 'art' } if buildArtifactPresent
  *   - ventures: returns ventureRow if both repo_url + deployment_url populated, else null
  *   - rpc('fn_advance_venture_stage'): returns { success: true } unless rpcError set
@@ -43,7 +43,7 @@ function buildSupabaseMock({
 
   return {
     from: vi.fn((table) => {
-      if (table === 'lifecycle_stage_config') {
+      if (table === 'venture_stages') {
         return {
           select: vi.fn(() => buildEqChain({
             data: { metadata: { gates: { exit: exitGates } } },

--- a/tests/lib/eva/stage-governance.test.js
+++ b/tests/lib/eva/stage-governance.test.js
@@ -3,8 +3,9 @@
  *
  * BASELINE + canonical-truth tests for lib/eva/stage-governance.js.
  *
- * Asserts the canonical post-refactor behavior (sets derived from
- * lifecycle_stage_config.work_type). Module had zero existing coverage
+ * Asserts the canonical post-refactor behavior (sets derived from work_type).
+ * SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: the reader now reads the unified
+ * `venture_stages` superset in a SINGLE query. Module had zero existing coverage
  * before this SD — these tests establish that coverage AND verify the
  * refactor (FR-2) produces correct classifications.
  */
@@ -178,29 +179,24 @@ describe('stage-governance — cache behavior', () => {
     const mod = await import('../../../lib/eva/stage-governance.js');
     mod._resetCacheForTest();
     let callCount = 0;
-    // Module reads 2 tables per fresh fetch (stage_config + lifecycle_stage_config)
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: ONE venture_stages read per fresh fetch.
     const sb = {
-      from: (table) => ({
+      from: () => ({
         select: () => ({
           order: () => {
             callCount++;
-            return Promise.resolve({
-              data: table === 'lifecycle_stage_config'
-                ? STAGE_FIXTURE.map(s => ({ stage_number: s.stage_number, work_type: s.work_type }))
-                : STAGE_FIXTURE,
-              error: null,
-            });
+            return Promise.resolve({ data: STAGE_FIXTURE, error: null });
           },
         }),
       }),
       channel: () => ({ on: function () { return this; }, subscribe: function () { return this; }, unsubscribe: () => undefined }),
     };
     await mod.getStageGovernance(sb);
-    // After first call: 2 DB queries (stage_config + lifecycle_stage_config)
-    expect(callCount).toBe(2);
+    // After first call: 1 DB query (venture_stages)
+    expect(callCount).toBe(1);
     await mod.getStageGovernance(sb);
-    // Second call cached: still 2 (no additional queries)
-    expect(callCount).toBe(2);
+    // Second call cached: still 1 (no additional queries)
+    expect(callCount).toBe(1);
   });
 
   it('_resetCacheForTest forces fresh fetch on next call', async () => {
@@ -208,26 +204,21 @@ describe('stage-governance — cache behavior', () => {
     mod._resetCacheForTest();
     let callCount = 0;
     const sb = {
-      from: (table) => ({
+      from: () => ({
         select: () => ({
           order: () => {
             callCount++;
-            return Promise.resolve({
-              data: table === 'lifecycle_stage_config'
-                ? STAGE_FIXTURE.map(s => ({ stage_number: s.stage_number, work_type: s.work_type }))
-                : STAGE_FIXTURE,
-              error: null,
-            });
+            return Promise.resolve({ data: STAGE_FIXTURE, error: null });
           },
         }),
       }),
       channel: () => ({ on: function () { return this; }, subscribe: function () { return this; }, unsubscribe: () => undefined }),
     };
     await mod.getStageGovernance(sb);
-    expect(callCount).toBe(2);
+    expect(callCount).toBe(1);
     mod._resetCacheForTest();
     await mod.getStageGovernance(sb);
-    // Reset forces 2 more queries
-    expect(callCount).toBe(4);
+    // Reset forces 1 more query
+    expect(callCount).toBe(2);
   });
 });

--- a/tests/unit/eva/cross-venture-learning.test.js
+++ b/tests/unit/eva/cross-venture-learning.test.js
@@ -201,7 +201,7 @@ describe('analyzeCrossVenturePatterns', () => {
         // Third call: proceed decisions for success patterns
         { data: [{ venture_id: 'v1', lifecycle_stage: 5, decision: 'proceed', health_score: 'green' }], error: null },
       ],
-      lifecycle_stage_config: {
+      venture_stages: {
         data: [
           { stage_number: 3, stage_name: 'Market Validation' },
           { stage_number: 5, stage_name: 'Profitability Forecast' },
@@ -233,7 +233,7 @@ describe('analyzeCrossVenturePatterns', () => {
           { data: [{ venture_id: 'v2', lifecycle_stage: 5 }], error: null },
           { data: [], error: null },
         ],
-        lifecycle_stage_config: {
+        venture_stages: {
           data: [{ stage_number: 5, stage_name: 'Profitability Forecast' }],
           error: null,
         },
@@ -287,7 +287,7 @@ describe('analyzeKillStageFrequency', () => {
           error: null,
         },
       ],
-      lifecycle_stage_config: {
+      venture_stages: {
         data: [
           { stage_number: 3, stage_name: 'Market Validation' },
           { stage_number: 5, stage_name: 'Profitability Forecast' },
@@ -313,7 +313,7 @@ describe('analyzeKillStageFrequency', () => {
         { data: [{ venture_id: 'v1', lifecycle_stage: 5 }], error: null },
         { data: [{ venture_id: 'v1', lifecycle_stage: 5 }], error: null },
       ],
-      lifecycle_stage_config: {
+      venture_stages: {
         data: [{ stage_number: 5, stage_name: 'Profitability Forecast' }],
         error: null,
       },
@@ -612,7 +612,7 @@ describe('output format', () => {
         { data: [], error: null },
         { data: [], error: null },
       ],
-      lifecycle_stage_config: { data: [], error: null },
+      venture_stages: { data: [], error: null },
       assumption_sets: { data: [], error: null },
       venture_artifacts: { data: [], error: null },
     });
@@ -637,7 +637,7 @@ describe('output format', () => {
         { data: [], error: null },
         { data: [], error: null },
       ],
-      lifecycle_stage_config: { data: [], error: null },
+      venture_stages: { data: [], error: null },
       assumption_sets: { data: [], error: null },
       venture_artifacts: { data: [], error: null },
     });

--- a/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
+++ b/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
@@ -38,7 +38,7 @@ function buildSupabaseMock({
 
   return {
     from: vi.fn((table) => {
-      if (table === 'lifecycle_stage_config') {
+      if (table === 'venture_stages') {
         return {
           select: vi.fn(() => buildEqChain({
             data: configError ? null : { metadata: { gates: stageConfig } },
@@ -198,12 +198,12 @@ describe('exit-gate-enforcer', () => {
       warnSpy.mockRestore();
     });
 
-    it('blocks with structured reason when lifecycle_stage_config read fails', async () => {
+    it('blocks with structured reason when venture_stages read fails', async () => {
       const { checkExitGates } = await importEnforcerWithFlag('on');
       const supabase = buildSupabaseMock({ configError: { message: 'simulated PG error' } });
       const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
       expect(result.allowed).toBe(false);
-      expect(result.blocked_by[0]).toMatch(/lifecycle_stage_config read failed/);
+      expect(result.blocked_by[0]).toMatch(/venture_stages read failed/);
       expect(result.blocked_by[0]).toMatch(/simulated PG error/);
     });
   });

--- a/tests/unit/eva/reconcile-venture-lifecycle.test.js
+++ b/tests/unit/eva/reconcile-venture-lifecycle.test.js
@@ -2,12 +2,16 @@
  * Tests for SD-LEO-INFRA-RECONCILE-VENTURE-LIFECYCLE-001
  *
  * Covers:
- *   - FR-2: StageRegistry readers source stage_name from stage_config (not
- *           lifecycle_stage_config), proving that even if lifecycle_stage_config
- *           drifts back to a stale name in the future, the reader returns the
- *           canonical name from the name-authoritative table.
+ *   - FR-2: StageRegistry readers source stage config from the unified
+ *           `venture_stages` table (SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B).
+ *           venture_stages has ONE canonical stage_name per stage, so the prior
+ *           stage_config name-authority override + lifecycle fallback are gone;
+ *           the reader returns the canonical name directly from venture_stages.
  *   - FR-6: scripts/generate-stage-config.cjs cross-table name-parity assertion
- *           detects divergence and returns it (TS-1 from the PRD).
+ *           detects divergence between the legacy tables and returns it (TS-1).
+ *           NOTE: FR-6 validates a standalone migration-era guard script that
+ *           still inspects the legacy tables directly; it is intentionally
+ *           unaffected by the reader repoint.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -20,14 +24,17 @@ const require = createRequire(import.meta.url);
 
 /**
  * Build a fake Supabase client that returns the supplied rows for
- * `lifecycle_stage_config` and `stage_config` respectively. Mirrors the
- * minimal slice of the SDK surface that the reader / assertion call.
+ * `venture_stages` (the unified superset the reader now uses) and for the
+ * legacy `lifecycle_stage_config` / `stage_config` tables (still used by the
+ * FR-6 parity-assertion script). Mirrors the minimal SDK surface the callers use.
  */
-function makeFakeSupabase({ lifecycleRows = [], stageConfigRows = [], lifecycleError = null, stageConfigError = null } = {}) {
+function makeFakeSupabase({ ventureStagesRows = [], ventureStagesError = null, lifecycleRows = [], stageConfigRows = [], lifecycleError = null, stageConfigError = null } = {}) {
   return {
     from(table) {
-      const rows = table === 'lifecycle_stage_config' ? lifecycleRows : stageConfigRows;
-      const error = table === 'lifecycle_stage_config' ? lifecycleError : stageConfigError;
+      let rows, error;
+      if (table === 'venture_stages') { rows = ventureStagesRows; error = ventureStagesError; }
+      else if (table === 'lifecycle_stage_config') { rows = lifecycleRows; error = lifecycleError; }
+      else { rows = stageConfigRows; error = stageConfigError; }
       const chain = {
         _table: table,
         _rows: rows,
@@ -41,7 +48,7 @@ function makeFakeSupabase({ lifecycleRows = [], stageConfigRows = [], lifecycleE
   };
 }
 
-describe('FR-2: StageRegistry sources stage_name from stage_config', () => {
+describe('FR-2: StageRegistry sources stage config from venture_stages (unified)', () => {
   let registry;
 
   beforeEach(() => {
@@ -52,14 +59,13 @@ describe('FR-2: StageRegistry sources stage_name from stage_config', () => {
     registry.isCacheValid = () => false; // force a fresh read
   });
 
-  it('overrides lifecycle_stage_config.stage_name with stage_config.stage_name for S19', async () => {
-    const lifecycleRows = [
-      { stage_number: 19, stage_name: 'Build in Replit', description: '', phase_number: 4, phase_name: 'BUILD', work_type: 'sd_required', sd_required: true, advisory_enabled: false, depends_on: [], required_artifacts: [], metadata: {} },
+  it('reads the canonical stage_name + lifecycle fields directly from venture_stages for S19', async () => {
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: venture_stages carries the single
+    // canonical name AND the lifecycle fields in one row — no override layer.
+    const ventureStagesRows = [
+      { stage_number: 19, stage_name: 'Sprint Planning', description: '', phase_number: 4, phase_name: 'BUILD', work_type: 'sd_required', sd_required: true, advisory_enabled: false, depends_on: [], required_artifacts: [], metadata: {} },
     ];
-    const stageConfigRows = [
-      { stage_number: 19, stage_name: 'Sprint Planning' },
-    ];
-    const supabase = makeFakeSupabase({ lifecycleRows, stageConfigRows });
+    const supabase = makeFakeSupabase({ ventureStagesRows });
 
     const result = await loadFromDatabase(registry, supabase);
     expect(result.error).toBeNull();
@@ -67,23 +73,26 @@ describe('FR-2: StageRegistry sources stage_name from stage_config', () => {
 
     const s19 = registry.get(19);
     expect(s19).toBeTruthy();
-    // The whole point of FR-2: stage_config wins over lifecycle_stage_config for the NAME field.
+    // Canonical name comes straight from venture_stages.
     expect(s19.stage_name).toBe('Sprint Planning');
-    // Other lifecycle-only fields still come from lifecycle_stage_config:
+    // Lifecycle fields also come from the same venture_stages row:
     expect(s19.work_type).toBe('sd_required');
     expect(s19.phase_name).toBe('BUILD');
   });
 
-  it('falls back to lifecycle_stage_config.stage_name when stage_config is unreachable', async () => {
-    const lifecycleRows = [
+  it('uses a SINGLE venture_stages read (no second stage_config name-authority read)', async () => {
+    const ventureStagesRows = [
       { stage_number: 14, stage_name: 'Technical Architecture', description: '', phase_number: 3, phase_name: 'BLUEPRINT', work_type: 'sd_required', sd_required: true, advisory_enabled: false, depends_on: [], required_artifacts: [], metadata: {} },
     ];
-    const supabase = makeFakeSupabase({ lifecycleRows, stageConfigError: { message: 'stage_config unreachable' } });
+    const readTables = [];
+    const base = makeFakeSupabase({ ventureStagesRows });
+    const supabase = { from(table) { readTables.push(table); return base.from(table); } };
 
     const result = await loadFromDatabase(registry, supabase);
-    expect(result.error).toBeNull(); // primary read succeeded
-    const s14 = registry.get(14);
-    expect(s14.stage_name).toBe('Technical Architecture'); // fallback worked
+    expect(result.error).toBeNull();
+    expect(registry.get(14).stage_name).toBe('Technical Architecture');
+    // Only venture_stages is read; the legacy tables are never touched by the reader.
+    expect(readTables).toEqual(['venture_stages']);
   });
 });
 

--- a/tests/unit/eva/stage-execution-worker.test.js
+++ b/tests/unit/eva/stage-execution-worker.test.js
@@ -125,30 +125,30 @@ describe('StageExecutionWorker', () => {
     supabase = createMockSupabase();
     logger = createMockLogger();
 
-    // SD-LEO-INFRA-VENTURE-GATE-UNIFICATION-001 FR-3: worker now reads gate definitions
-    // from stage_config (via lib/eva/stage-governance.js) and config from chairman_dashboard_config.
+    // SD-LEO-INFRA-VENTURE-GATE-UNIFICATION-001 FR-3: SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: worker now reads gate definitions
+    // from the unified venture_stages table (via lib/eva/stage-governance.js) and config from chairman_dashboard_config.
     // Register the V2 fixture + default config so gate-dependent tests work.
     _resetGovernanceCacheForTest();
-    supabase._setTableResponse('stage_config', {
+    supabase._setTableResponse('venture_stages', {
       ...supabase._chain,
       select: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue({
         data: [
-          { stage_number: 3,  gate_type: 'kill',      review_mode: 'auto'   },
-          { stage_number: 5,  gate_type: 'kill',      review_mode: 'auto'   },
-          { stage_number: 7,  gate_type: 'none',      review_mode: 'review' },
-          { stage_number: 8,  gate_type: 'none',      review_mode: 'review' },
-          { stage_number: 9,  gate_type: 'none',      review_mode: 'review' },
-          { stage_number: 10, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 11, gate_type: 'none',      review_mode: 'review' },
-          { stage_number: 13, gate_type: 'kill',      review_mode: 'auto'   },
-          { stage_number: 16, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 17, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 18, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 19, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 23, gate_type: 'kill',      review_mode: 'auto'   },
-          { stage_number: 24, gate_type: 'promotion', review_mode: 'auto'   },
-          { stage_number: 25, gate_type: 'promotion', review_mode: 'auto'   },
+          { stage_number: 3,  gate_type: 'kill',      review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 5,  gate_type: 'kill',      review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 7,  gate_type: 'none',      review_mode: 'review', work_type: 'artifact_only'  },
+          { stage_number: 8,  gate_type: 'none',      review_mode: 'review', work_type: 'artifact_only'  },
+          { stage_number: 9,  gate_type: 'none',      review_mode: 'review', work_type: 'artifact_only'  },
+          { stage_number: 10, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 11, gate_type: 'none',      review_mode: 'review', work_type: 'artifact_only'  },
+          { stage_number: 13, gate_type: 'kill',      review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 16, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 17, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 18, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 19, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 23, gate_type: 'kill',      review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 24, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
+          { stage_number: 25, gate_type: 'promotion', review_mode: 'auto',   work_type: 'decision_gate' },
         ],
         error: null,
       }),

--- a/tests/unit/eva/stage-governance.test.js
+++ b/tests/unit/eva/stage-governance.test.js
@@ -1,6 +1,10 @@
 /**
  * Tests for lib/eva/stage-governance.js
  * SD-LEO-INFRA-VENTURE-GATE-UNIFICATION-001 FR-6.
+ * SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: reader now reads the unified
+ * `venture_stages` superset in a SINGLE query (each row carries gate_type,
+ * work_type AND review_mode), so the mock dispatches one table and one
+ * refresh == one .from() call. Behavior (the derived sets) is byte-identical.
  *
  * Validates the unified DB-backed governance reader: cache, helpers, and
  * realtime-subscription fallback behavior.
@@ -8,44 +12,37 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getStageGovernance, _resetCacheForTest } from '../../../lib/eva/stage-governance.js';
 
-const V2_FIXTURE = [
-  // gate_type=kill: 3, 5, 13, 23
-  { stage_number: 3,  stage_name: 'Comprehensive Validation', stage_key: 'comprehensive_validation', gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_TRUTH' },
-  { stage_number: 5,  stage_name: 'Profitability Forecasting', stage_key: 'profitability_forecasting', gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_TRUTH' },
-  { stage_number: 13, stage_name: 'Product Roadmap',           stage_key: 'product_roadmap',           gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_BLUEPRINT' },
-  { stage_number: 23, stage_name: 'Launch Readiness Kill Gate', stage_key: 'launch_readiness_gate',    gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_BUILD' },
-  // gate_type=promotion: 10, 16, 17, 18, 19, 24, 25
-  { stage_number: 10, stage_name: 'Customer & Brand Foundation', stage_key: 'customer_brand_foundation', gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_IDENTITY' },
-  { stage_number: 16, stage_name: 'Financial Projections',       stage_key: 'financial_projections',     gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BLUEPRINT' },
-  { stage_number: 17, stage_name: 'Blueprint Review',            stage_key: 'blueprint_review',          gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BLUEPRINT' },
-  { stage_number: 18, stage_name: 'Marketing Copy Studio',       stage_key: 'marketing_copy_studio',     gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BUILD' },
-  { stage_number: 19, stage_name: 'Sprint Planning',             stage_key: 'sprint_planning',           gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BUILD' },
-  { stage_number: 24, stage_name: 'Go Live & Announce',          stage_key: 'go_live',                   gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_LAUNCH' },
-  { stage_number: 25, stage_name: 'Post-Launch Review',          stage_key: 'post_launch_review',        gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_LAUNCH' },
-  // review_mode=review: 7, 8, 9, 11
-  { stage_number: 7,  stage_name: 'Revenue Architecture',  stage_key: 'revenue_architecture',  gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE' },
-  { stage_number: 8,  stage_name: 'Business Model Canvas', stage_key: 'business_model_canvas', gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE' },
-  { stage_number: 9,  stage_name: 'Exit Strategy',         stage_key: 'exit_strategy',         gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE' },
-  { stage_number: 11, stage_name: 'Naming & Visual Identity', stage_key: 'naming_visual_identity', gate_type: 'none', review_mode: 'review', chunk: 'THE_IDENTITY' },
+// venture_stages rows carry gate_type + work_type + review_mode together.
+// work_type='decision_gate' is required for kill/promotion classification;
+// review_mode='review' is independent of work_type.
+const VENTURE_STAGES_FIXTURE = [
+  // gate_type=kill (work_type=decision_gate): 3, 5, 13, 23
+  { stage_number: 3,  stage_name: 'Comprehensive Validation', stage_key: 'comprehensive_validation', gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_TRUTH',     work_type: 'decision_gate' },
+  { stage_number: 5,  stage_name: 'Profitability Forecasting', stage_key: 'profitability_forecasting', gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_TRUTH',     work_type: 'decision_gate' },
+  { stage_number: 13, stage_name: 'Product Roadmap',           stage_key: 'product_roadmap',           gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_BLUEPRINT', work_type: 'decision_gate' },
+  { stage_number: 23, stage_name: 'Launch Readiness Kill Gate', stage_key: 'launch_readiness_gate',    gate_type: 'kill',      review_mode: 'auto',   chunk: 'THE_BUILD',     work_type: 'decision_gate' },
+  // gate_type=promotion (work_type=decision_gate): 10, 16, 17, 18, 19, 24, 25
+  { stage_number: 10, stage_name: 'Customer & Brand Foundation', stage_key: 'customer_brand_foundation', gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_IDENTITY', work_type: 'decision_gate' },
+  { stage_number: 16, stage_name: 'Financial Projections',       stage_key: 'financial_projections',     gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BLUEPRINT', work_type: 'decision_gate' },
+  { stage_number: 17, stage_name: 'Blueprint Review',            stage_key: 'blueprint_review',          gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BLUEPRINT', work_type: 'decision_gate' },
+  { stage_number: 18, stage_name: 'Marketing Copy Studio',       stage_key: 'marketing_copy_studio',     gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BUILD',     work_type: 'decision_gate' },
+  { stage_number: 19, stage_name: 'Sprint Planning',             stage_key: 'sprint_planning',           gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_BUILD',     work_type: 'decision_gate' },
+  { stage_number: 24, stage_name: 'Go Live & Announce',          stage_key: 'go_live',                   gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_LAUNCH',    work_type: 'decision_gate' },
+  { stage_number: 25, stage_name: 'Post-Launch Review',          stage_key: 'post_launch_review',        gate_type: 'promotion', review_mode: 'auto', chunk: 'THE_LAUNCH',    work_type: 'decision_gate' },
+  // review_mode=review (NOT decision_gate): 7, 8, 9, 11
+  { stage_number: 7,  stage_name: 'Revenue Architecture',  stage_key: 'revenue_architecture',  gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE',   work_type: 'artifact_only' },
+  { stage_number: 8,  stage_name: 'Business Model Canvas', stage_key: 'business_model_canvas', gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE',   work_type: 'artifact_only' },
+  { stage_number: 9,  stage_name: 'Exit Strategy',         stage_key: 'exit_strategy',         gate_type: 'none', review_mode: 'review', chunk: 'THE_ENGINE',   work_type: 'artifact_only' },
+  { stage_number: 11, stage_name: 'Naming & Visual Identity', stage_key: 'naming_visual_identity', gate_type: 'none', review_mode: 'review', chunk: 'THE_IDENTITY', work_type: 'artifact_only' },
 ];
 
-// QF-20260526-511: stage-governance._readFresh now Promise.all-reads BOTH
-// stage_config AND lifecycle_stage_config, and requires lifecycle.work_type=
-// 'decision_gate' to classify kill/promotion. Mock must dispatch per table;
-// using V2_FIXTURE rows (no work_type) for both silently empties kill/promotion.
-function deriveLifecycleRows(stageRows) {
-  return stageRows.map((r) => ({
-    stage_number: r.stage_number,
-    work_type: r.gate_type === 'kill' || r.gate_type === 'promotion' ? 'decision_gate' : 'artifact_only',
-  }));
-}
-
+// SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single venture_stages table read.
+// One refresh == exactly one .from('venture_stages') call.
 function mockSupabase(rows, { failChannel = false } = {}) {
-  const lifecycleRows = deriveLifecycleRows(rows);
   return {
-    from: vi.fn((table) => ({
+    from: vi.fn(() => ({
       select: vi.fn(() => ({
-        order: vi.fn(async () => ({ data: table === 'lifecycle_stage_config' ? lifecycleRows : rows, error: null })),
+        order: vi.fn(async () => ({ data: rows, error: null })),
       })),
     })),
     channel: failChannel
@@ -62,16 +59,28 @@ describe('stage-governance', () => {
   beforeEach(() => { _resetCacheForTest(); });
   afterEach(() => { _resetCacheForTest(); });
 
-  test('builds correct kill / promotion / review / blocking sets from stage_config', async () => {
-    const gov = await getStageGovernance(mockSupabase(V2_FIXTURE));
+  test('builds correct kill / promotion / review / blocking sets from venture_stages', async () => {
+    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE));
     expect([...gov.killStages].sort((a, b) => a - b)).toEqual([3, 5, 13, 23]);
     expect([...gov.promotionStages].sort((a, b) => a - b)).toEqual([10, 16, 17, 18, 19, 24, 25]);
     expect([...gov.reviewStages].sort((a, b) => a - b)).toEqual([7, 8, 9, 11]);
     expect([...gov.blockingStages].sort((a, b) => a - b)).toEqual([3, 5, 10, 13, 16, 17, 18, 19, 23, 24, 25]);
   });
 
+  test('canonical equivalence: a kill gate_type WITHOUT decision_gate work_type is excluded', async () => {
+    // Proves the repoint preserves the canonical rule (kill/promotion require
+    // work_type=decision_gate). Stage 3 here has gate_type=kill but work_type
+    // is artifact_only, so it must NOT appear in killStages.
+    const rows = VENTURE_STAGES_FIXTURE.map((r) =>
+      r.stage_number === 3 ? { ...r, work_type: 'artifact_only' } : r
+    );
+    const gov = await getStageGovernance(mockSupabase(rows));
+    expect(gov.isKill(3)).toBe(false);
+    expect([...gov.killStages].sort((a, b) => a - b)).toEqual([5, 13, 23]);
+  });
+
   test('isKill / isPromotion / isReview / isBlocking helpers agree with sets', async () => {
-    const gov = await getStageGovernance(mockSupabase(V2_FIXTURE));
+    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE));
     expect(gov.isKill(3)).toBe(true);
     expect(gov.isKill(8)).toBe(false);
     expect(gov.isPromotion(16)).toBe(true);
@@ -85,36 +94,37 @@ describe('stage-governance', () => {
   });
 
   test('getStage returns the row for known stages and null for unknown', async () => {
-    const gov = await getStageGovernance(mockSupabase(V2_FIXTURE));
+    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE));
     expect(gov.getStage(8)).toMatchObject({ stage_number: 8, stage_name: 'Business Model Canvas', gate_type: 'none', review_mode: 'review' });
     expect(gov.getStage(99)).toBeNull();
   });
 
   test('S16 is promotion (audit Issue B fix — was missing from prior PROMOTION_GATE_STAGES)', async () => {
-    const gov = await getStageGovernance(mockSupabase(V2_FIXTURE));
+    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE));
     expect(gov.isPromotion(16)).toBe(true);
     expect(gov.isBlocking(16)).toBe(true);
   });
 
-  test('cache: second call within TTL does not re-fetch (one refresh = 2 .from() calls — stage_config + lifecycle_stage_config)', async () => {
-    // QF-20260526-511: 2 .from() per refresh after the _readFresh Promise.all of both tables.
-    const supabase = mockSupabase(V2_FIXTURE);
+  test('cache: second call within TTL does not re-fetch (one refresh = 1 .from() call on venture_stages)', async () => {
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single-table read → 1 .from() per refresh
+    // (was 2 when stage_config + lifecycle_stage_config were read separately).
+    const supabase = mockSupabase(VENTURE_STAGES_FIXTURE);
     await getStageGovernance(supabase);
+    await getStageGovernance(supabase);
+    expect(supabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  test('_resetCacheForTest forces a re-fetch', async () => {
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: 2 refreshes × 1 table = 2 .from() calls.
+    const supabase = mockSupabase(VENTURE_STAGES_FIXTURE);
+    await getStageGovernance(supabase);
+    _resetCacheForTest();
     await getStageGovernance(supabase);
     expect(supabase.from).toHaveBeenCalledTimes(2);
   });
 
-  test('_resetCacheForTest forces a re-fetch', async () => {
-    // QF-20260526-511: 2 refreshes × 2 tables = 4 .from() calls.
-    const supabase = mockSupabase(V2_FIXTURE);
-    await getStageGovernance(supabase);
-    _resetCacheForTest();
-    await getStageGovernance(supabase);
-    expect(supabase.from).toHaveBeenCalledTimes(4);
-  });
-
   test('falls back gracefully when realtime channel API is unavailable', async () => {
-    const supabase = mockSupabase(V2_FIXTURE, { failChannel: true });
+    const supabase = mockSupabase(VENTURE_STAGES_FIXTURE, { failChannel: true });
     const gov = await getStageGovernance(supabase);
     expect(gov.isKill(3)).toBe(true);
     expect(gov.isReview(8)).toBe(true);

--- a/tests/unit/eva/stage-registry.test.js
+++ b/tests/unit/eva/stage-registry.test.js
@@ -1,6 +1,10 @@
 /**
  * Tests for StageRegistry — A03 Stage Framework Extensibility
  * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ * SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: loadFromDatabase/loadFromDB now read
+ * the unified `venture_stages` superset in a SINGLE query (no second
+ * stage_config name-authority read), so the mocks represent venture_stages rows
+ * and stage_name is asserted to come straight from the row.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -94,19 +98,23 @@ describe('StageRegistry Core', () => {
   });
 });
 
-describe('StageRegistry — loadFromDatabase', () => {
-  it('loads stages from lifecycle_stage_config', async () => {
+describe('StageRegistry — loadFromDatabase (venture_stages)', () => {
+  it('loads stages from venture_stages in a single read', async () => {
     const registry = new StageRegistry();
     const mockData = [
       { stage_number: 1, stage_name: 'Draft Idea', phase_number: 1, phase_name: 'THE TRUTH', work_type: 'artifact_only', sd_required: false, advisory_enabled: false, depends_on: [], required_artifacts: ['truth_idea_brief'], metadata: {}, description: '' },
       { stage_number: 2, stage_name: 'Chairman Review', phase_number: 1, phase_name: 'THE TRUTH', work_type: 'decision_gate', sd_required: false, advisory_enabled: false, depends_on: [1], required_artifacts: [], metadata: {}, description: '' },
     ];
 
+    let fromCalls = 0;
     const supabase = {
-      from: vi.fn(() => ({
-        select: vi.fn().mockReturnThis(),
-        order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
-      })),
+      from: vi.fn(() => {
+        fromCalls++;
+        return {
+          select: vi.fn().mockReturnThis(),
+          order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+        };
+      }),
     };
 
     const result = await loadFromDatabase(registry, supabase);
@@ -115,6 +123,24 @@ describe('StageRegistry — loadFromDatabase', () => {
     expect(registry.has(1)).toBe(true);
     expect(registry.has(2)).toBe(true);
     expect(registry.isCacheValid()).toBe(true);
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: a single venture_stages read (no second stage_config read).
+    expect(fromCalls).toBe(1);
+    expect(supabase.from).toHaveBeenCalledWith('venture_stages');
+  });
+
+  it('stage_name comes straight from the venture_stages row (no name-authority override)', async () => {
+    const registry = new StageRegistry();
+    const mockData = [
+      { stage_number: 3, stage_name: 'Comprehensive Validation', phase_number: 1, phase_name: 'THE_TRUTH', work_type: 'decision_gate', sd_required: false, advisory_enabled: true, depends_on: [2], required_artifacts: [], metadata: {}, description: 'Deep validation' },
+    ];
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+      })),
+    };
+    await loadFromDatabase(registry, supabase);
+    expect(registry.get(3).stage_name).toBe('Comprehensive Validation');
   });
 
   it('returns cached data within TTL', async () => {


### PR DESCRIPTION
## Summary
Child B of **SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001**. Repoints all EHG_Engineer JS readers from the two legacy tables (`stage_config` + `lifecycle_stage_config`) to the unified **`venture_stages`** superset table that Child A created, applied, and verified LIVE.

**Pure JS read-repointing** — no migration, no DDL, no change to `fn_advance_venture_stage` (Child C), the legacy tables, or the sync triggers.

## Behavior is byte-identical (verified against live data)
`venture_stages` carries both `gate_type` AND `work_type` in each row, so the canonical classification rule is preserved. Live old-vs-new comparison:
- kill `{3,5,13,23}`, promotion `{16,17,24}`, review `{7,8,9,11}`, blocking `{3,5,13,16,17,23,24}` — **identical** before and after.

> Note: promotion resolves to `{16,17,24}` (not the raw `gate_type='promotion'` set `{10,16,17,18,19,24,25}`) because the long-standing canonical rule excludes `sd_required` / `artifact_only` stages — that exclusion is unchanged by this PR.

## Changes
- **stage-governance.js**: single `venture_stages` SELECT (drops the in-memory `stage_config`×`lifecycle_stage_config` join); two realtime channels collapse to one channel on `venture_stages`.
- **stage-registry/index.js** + **stage-registry.js**: single `venture_stages` read; drop the `stage_config` name-authority override (one canonical `stage_name`).
- **stage-execution-worker.js**: two direct `lifecycle_stage_config` reads (`_getStageTimeoutMs`, `_syncStageWork`) → `venture_stages`.
- **exit-gate-enforcer.js** + **cross-venture-learning.js**: `metadata` / `stage_name` reads → `venture_stages`. `artifact-persistence-service.js` is fixed transitively (consumes `checkExitGates`; it has no direct legacy read).
- **Tests**: updated 8 test files from per-table mock dispatch to a single `venture_stages` read + added canonical-equivalence assertions. **134 affected-suite tests pass** (2 skipped).

## Test plan
- `npx vitest run` on the 11 directly-affected suites → 134 passed / 2 skipped.
- Live equivalence harness confirms old (dual-table join) == new (venture_stages) classification.

PR size: 14 files, net **-4 LOC** (consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)