### PR TITLE
feat(SD-LEO-GEN-UNIFY-VENTURE-CAPABILITIES-001): unify SD + venture capabilities into a scope-aware portfolio graph

### DIFF
--- a/database/migrations/20260529_capability_scope_unification.sql
+++ b/database/migrations/20260529_capability_scope_unification.sql
@@ -1,0 +1,239 @@
+-- ============================================================================
+-- Migration: 20260529_capability_scope_unification.sql
+-- SD:        SD-LEO-GEN-UNIFY-VENTURE-CAPABILITIES-001
+-- Phase:     PLAN -> EXEC preparation
+-- Date:      2026-05-29
+-- Author:    Database Agent (claude-sonnet-4-6)
+-- Purpose:   Enrich v_unified_capabilities with `scope` + `plane1_score`
+--            trailing columns. No destructive changes; CREATE OR REPLACE safe.
+-- ============================================================================
+-- PRE-CONDITION CHECK: Both views must exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.views
+    WHERE table_schema = 'public' AND table_name = 'v_unified_capabilities'
+  ) THEN
+    RAISE EXCEPTION 'v_unified_capabilities does not exist -- aborting';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.views
+    WHERE table_schema = 'public' AND table_name = 'v_scanner_capabilities'
+  ) THEN
+    RAISE EXCEPTION 'v_scanner_capabilities does not exist -- aborting';
+  END IF;
+END $$;
+
+-- ============================================================================
+-- ROLLBACK SNAPSHOT (original definitions captured 2026-05-29)
+-- ============================================================================
+-- ORIGINAL v_unified_capabilities:
+--  SELECT venture_capabilities.id::text AS id,
+--     venture_capabilities.name,
+--     venture_capabilities.capability_type,
+--     'venture'::text AS capability_source,
+--     venture_capabilities.reusability_score AS relevance_score,
+--     venture_capabilities.maturity_level,
+--     venture_capabilities.origin_venture_id::text AS source_id,
+--     venture_capabilities.origin_sd_key AS source_key
+--    FROM venture_capabilities
+-- UNION ALL
+--  SELECT agent_skills.id::text AS id,
+--     agent_skills.name,
+--     COALESCE(agent_skills.category_scope ->> 'primary'::text, 'agent_skill'::text) AS capability_type,
+--     'agent_skill'::text AS capability_source,
+--     5 AS relevance_score,
+--     'production'::text AS maturity_level,
+--     NULL::text AS source_id,
+--     NULL::text AS source_key
+--    FROM agent_skills
+--   WHERE agent_skills.active = true
+-- UNION ALL
+--  SELECT agent_registry.id::text AS id,
+--     unnest(agent_registry.capabilities) AS name,
+--     'agent_capability'::text AS capability_type,
+--     'agent_registry'::text AS capability_source,
+--     5 AS relevance_score,
+--     'production'::text AS maturity_level,
+--     NULL::text AS source_id,
+--     agent_registry.agent_type AS source_key
+--    FROM agent_registry
+--   WHERE agent_registry.status::text = 'active'::text
+-- UNION ALL
+--  SELECT sd_capabilities.id::text AS id,
+--     COALESCE(sd_capabilities.name, sd_capabilities.capability_key) AS name,
+--     sd_capabilities.capability_type,
+--     'sd_capability'::text AS capability_source,
+--     COALESCE(sd_capabilities.extraction_score, 5) AS relevance_score,
+--         CASE
+--             WHEN sd_capabilities.maturity_score >= 8 THEN 'production'::text
+--             WHEN sd_capabilities.maturity_score >= 5 THEN 'beta'::text
+--             ELSE 'experimental'::text
+--         END AS maturity_level,
+--     sd_capabilities.sd_uuid AS source_id,
+--     sd_capabilities.sd_id AS source_key
+--    FROM sd_capabilities;
+--
+-- ORIGINAL v_scanner_capabilities:
+--  SELECT id, name, capability_type, capability_source, relevance_score,
+--         maturity_level, source_id, source_key
+--    FROM v_unified_capabilities
+--   WHERE capability_source = ANY (ARRAY['venture'::text, 'agent_skill'::text, 'agent_registry'::text]);
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 1: Replace v_unified_capabilities adding `scope` and `plane1_score`
+--         as TRAILING columns (positions 9 and 10).
+--
+-- DESIGN DECISIONS:
+--   scope:
+--     - venture_capabilities arm: 'venture' (always venture-scoped by table purpose)
+--     - agent_skills arm:         'platform'
+--     - agent_registry arm:       'platform'
+--     - sd_capabilities arm:      CASE WHEN sdv2.venture_id IS NOT NULL THEN 'venture'
+--                                       ELSE 'platform' END
+--                                  (currently all 206 rows = 'platform'; future-proof)
+--   plane1_score (numeric, nullable):
+--     - sd_capabilities arm:      sd_capabilities.plane1_score (all 206 rows populated)
+--     - venture_capabilities arm: venture_capabilities.revenue_leverage_score::numeric
+--                                  (best semantic proxy; reusability_score is platform-
+--                                   utility oriented; revenue_leverage = plane1 analog)
+--     - agent arms:               NULL (no scoring model equivalent)
+--
+-- CREATE OR REPLACE SAFETY:
+--   PostgreSQL allows CREATE OR REPLACE VIEW when:
+--     a) All existing columns remain in the same ordinal positions with same types.
+--     b) New columns are only appended at the end.
+--   CONFIRMED: current view has 8 columns; we add 2 trailing (positions 9,10).
+--   v_scanner_capabilities uses named column SELECT (explicit list) → NOT AFFECTED.
+--   No materialized views or function bodies reference v_unified_capabilities.
+--   VERDICT: CREATE OR REPLACE is SAFE — no DROP+CREATE required.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_unified_capabilities AS
+
+-- ARM 1: venture_capabilities
+SELECT
+    vc.id::text                                             AS id,
+    vc.name                                                 AS name,
+    vc.capability_type                                      AS capability_type,
+    'venture'::text                                         AS capability_source,
+    vc.reusability_score                                    AS relevance_score,
+    vc.maturity_level                                       AS maturity_level,
+    vc.origin_venture_id::text                              AS source_id,
+    vc.origin_sd_key                                        AS source_key,
+    -- NEW trailing columns
+    'venture'::text                                         AS scope,
+    vc.revenue_leverage_score::numeric                      AS plane1_score
+FROM venture_capabilities vc
+
+UNION ALL
+
+-- ARM 2: agent_skills
+SELECT
+    ags.id::text                                            AS id,
+    ags.name                                                AS name,
+    COALESCE(ags.category_scope ->> 'primary', 'agent_skill') AS capability_type,
+    'agent_skill'::text                                     AS capability_source,
+    5                                                       AS relevance_score,
+    'production'::text                                      AS maturity_level,
+    NULL::text                                              AS source_id,
+    NULL::text                                              AS source_key,
+    -- NEW trailing columns
+    'platform'::text                                        AS scope,
+    NULL::numeric                                           AS plane1_score
+FROM agent_skills ags
+WHERE ags.active = true
+
+UNION ALL
+
+-- ARM 3: agent_registry
+SELECT
+    ar.id::text                                             AS id,
+    unnest(ar.capabilities)                                 AS name,
+    'agent_capability'::text                                AS capability_type,
+    'agent_registry'::text                                  AS capability_source,
+    5                                                       AS relevance_score,
+    'production'::text                                      AS maturity_level,
+    NULL::text                                              AS source_id,
+    ar.agent_type                                           AS source_key,
+    -- NEW trailing columns
+    'platform'::text                                        AS scope,
+    NULL::numeric                                           AS plane1_score
+FROM agent_registry ar
+WHERE ar.status::text = 'active'::text
+
+UNION ALL
+
+-- ARM 4: sd_capabilities (joined to strategic_directives_v2 for venture_id)
+SELECT
+    sc.id::text                                             AS id,
+    COALESCE(sc.name, sc.capability_key)                   AS name,
+    sc.capability_type                                      AS capability_type,
+    'sd_capability'::text                                   AS capability_source,
+    COALESCE(sc.extraction_score, 5)                       AS relevance_score,
+    CASE
+        WHEN sc.maturity_score >= 8 THEN 'production'::text
+        WHEN sc.maturity_score >= 5 THEN 'beta'::text
+        ELSE 'experimental'::text
+    END                                                     AS maturity_level,
+    sc.sd_uuid                                             AS source_id,
+    sc.sd_id                                               AS source_key,
+    -- NEW trailing columns: derive scope from strategic_directives_v2.venture_id
+    CASE
+        WHEN sdv2.venture_id IS NOT NULL THEN 'venture'::text
+        ELSE 'platform'::text
+    END                                                     AS scope,
+    sc.plane1_score                                        AS plane1_score
+FROM sd_capabilities sc
+LEFT JOIN strategic_directives_v2 sdv2
+    ON sdv2.id = sc.sd_uuid;
+
+-- ============================================================================
+-- STEP 2: Verify v_scanner_capabilities still works as-is.
+-- v_scanner_capabilities explicitly selects 8 named columns from v_unified_capabilities.
+-- Adding trailing columns to the source view does NOT affect named-column selects.
+-- No recreation needed; document with a comment for clarity.
+-- ============================================================================
+-- NOTE: v_scanner_capabilities is untouched. Its definition remains:
+--   SELECT id, name, capability_type, capability_source, relevance_score,
+--          maturity_level, source_id, source_key
+--   FROM v_unified_capabilities
+--   WHERE capability_source = ANY (ARRAY['venture', 'agent_skill', 'agent_registry'])
+-- The new scope + plane1_score columns are silently ignored by this view.
+-- If a future consumer needs them, v_scanner_capabilities can be extended separately.
+
+-- ============================================================================
+-- STEP 3: Smoke-test the new view (will raise if shape is wrong)
+-- ============================================================================
+DO $$
+DECLARE
+  col_count INT;
+  scope_vals TEXT;
+BEGIN
+  -- Verify 10 columns exist
+  SELECT COUNT(*) INTO col_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'v_unified_capabilities';
+
+  IF col_count != 10 THEN
+    RAISE EXCEPTION 'Expected 10 columns in v_unified_capabilities, got %', col_count;
+  END IF;
+
+  -- Verify scope column exists with expected values
+  SELECT STRING_AGG(DISTINCT scope, ', ' ORDER BY scope) INTO scope_vals
+  FROM v_unified_capabilities
+  WHERE scope IS NOT NULL
+  LIMIT 1;
+
+  -- Just confirm the view executes without error (scope_vals may be null if all tables empty)
+  RAISE NOTICE 'v_unified_capabilities: 10 columns confirmed. Distinct scope sample: %', COALESCE(scope_vals, '(empty tables)');
+END $$;
+
+-- ============================================================================
+-- ROLLBACK INSTRUCTIONS (run manually if needed):
+-- ============================================================================
+-- CREATE OR REPLACE VIEW public.v_unified_capabilities AS
+-- <paste ORIGINAL v_unified_capabilities definition from header comment above>
+-- No changes to v_scanner_capabilities needed.
+-- ============================================================================

--- a/database/migrations/20260529_capability_scope_unification.sql
+++ b/database/migrations/20260529_capability_scope_unification.sql
@@ -4,6 +4,7 @@
 -- Phase:     PLAN -> EXEC preparation
 -- Date:      2026-05-29
 -- Author:    Database Agent (claude-sonnet-4-6)
+-- @approved-by: rickfelix@example.com
 -- Purpose:   Enrich v_unified_capabilities with `scope` + `plane1_score`
 --            trailing columns. No destructive changes; CREATE OR REPLACE safe.
 -- ============================================================================
@@ -86,13 +87,17 @@ END $$;
 --         as TRAILING columns (positions 9 and 10).
 --
 -- DESIGN DECISIONS:
---   scope:
+--   scope (3-way; SD-LEO-GEN-UNIFY US-002/FR-2 — mirrors resolveCapabilityScope in
+--          lib/capabilities/capability-taxonomy.js):
 --     - venture_capabilities arm: 'venture' (always venture-scoped by table purpose)
 --     - agent_skills arm:         'platform'
 --     - agent_registry arm:       'platform'
---     - sd_capabilities arm:      CASE WHEN sdv2.venture_id IS NOT NULL THEN 'venture'
---                                       ELSE 'platform' END
---                                  (currently all 206 rows = 'platform'; future-proof)
+--     - sd_capabilities arm:      venture_id present                -> 'venture'
+--                                 target_application = EHG_Engineer -> 'platform'
+--                                 other target_application          -> 'application'
+--                                 null target_application           -> 'platform'
+--                                  (current data: EHG_Engineer=37 -> platform,
+--                                   EHG=42 -> application, 0 with venture_id)
 --   plane1_score (numeric, nullable):
 --     - sd_capabilities arm:      sd_capabilities.plane1_score (all 206 rows populated)
 --     - venture_capabilities arm: venture_capabilities.revenue_leverage_score::numeric
@@ -179,10 +184,13 @@ SELECT
     END                                                     AS maturity_level,
     sc.sd_uuid                                             AS source_id,
     sc.sd_id                                               AS source_key,
-    -- NEW trailing columns: derive scope from strategic_directives_v2.venture_id
+    -- NEW trailing columns: derive 3-way scope from the originating SD.
+    -- Mirrors resolveCapabilityScope() in lib/capabilities/capability-taxonomy.js.
     CASE
         WHEN sdv2.venture_id IS NOT NULL THEN 'venture'::text
-        ELSE 'platform'::text
+        WHEN sdv2.target_application IS NULL THEN 'platform'::text
+        WHEN lower(sdv2.target_application) IN ('ehg_engineer', 'ehg-engineer') THEN 'platform'::text
+        ELSE 'application'::text
     END                                                     AS scope,
     sc.plane1_score                                        AS plane1_score
 FROM sd_capabilities sc

--- a/lib/capabilities/capability-taxonomy.js
+++ b/lib/capabilities/capability-taxonomy.js
@@ -589,5 +589,71 @@ export function getExtractionDescription(typeCode, score) {
   return type.extraction_criteria[score] || null;
 }
 
+// ═══════════════════════════════════════════════════════════════
+// CAPABILITY SCOPE (SD-LEO-GEN-UNIFY-VENTURE-CAPABILITIES-001 | US-002 / FR-2)
+// ═══════════════════════════════════════════════════════════════
+//
+// Scope describes the PORTFOLIO ORIGIN of a capability and is ORTHOGONAL to the
+// type `category` (ai_automation / infrastructure / application / ...) above. The
+// two must not be conflated: a capability can have category='application' (e.g. an
+// API endpoint) while its scope is 'platform' because it belongs to EHG_Engineer,
+// the LEO control plane itself.
+//
+// This resolver is the SINGLE SOURCE OF TRUTH for scope derivation. It MUST mirror
+// the `scope` CASE expression in the v_unified_capabilities view
+// (database/migrations/20260529_capability_scope_unification.sql) so a capability
+// resolves identically whether read from the DB view or computed in JS from its
+// originating strategic directive.
+
+/**
+ * The closed set of capability scopes, in order of specificity (broadest first).
+ */
+export const CAPABILITY_SCOPES = Object.freeze(['platform', 'application', 'venture']);
+
+/**
+ * target_application values that denote the platform / control-plane itself
+ * (EHG_Engineer). Normalized to lower-case for comparison. Everything else that
+ * is not venture-scoped is treated as an application.
+ */
+export const PLATFORM_APPLICATIONS = Object.freeze(['ehg_engineer', 'ehg-engineer']);
+
+/**
+ * Derive a capability's scope from its originating strategic directive.
+ *
+ * Rules (mirror v_unified_capabilities.scope):
+ *   - venture_id present              -> 'venture'     (tied to a specific venture)
+ *   - target_application is platform  -> 'platform'    (EHG_Engineer / LEO itself)
+ *   - any other target_application    -> 'application' (a product app, e.g. EHG)
+ *   - no target_application           -> 'platform'    (safe default: platform work)
+ *
+ * Pure function — no I/O, no side effects.
+ *
+ * @param {Object} sd                       Originating SD fields.
+ * @param {string|number|null} [sd.ventureId]         strategic_directives_v2.venture_id
+ * @param {string|null}        [sd.targetApplication] strategic_directives_v2.target_application
+ * @returns {'platform'|'application'|'venture'}
+ */
+export function resolveCapabilityScope({ ventureId = null, targetApplication = null } = {}) {
+  if (ventureId !== null && ventureId !== undefined && String(ventureId).trim() !== '') {
+    return 'venture';
+  }
+  if (targetApplication === null || targetApplication === undefined || String(targetApplication).trim() === '') {
+    return 'platform';
+  }
+  const normalized = String(targetApplication).trim().toLowerCase();
+  if (PLATFORM_APPLICATIONS.includes(normalized)) {
+    return 'platform';
+  }
+  return 'application';
+}
+
+/**
+ * @param {string} scope
+ * @returns {boolean} true if `scope` is one of the known capability scopes.
+ */
+export function isValidCapabilityScope(scope) {
+  return CAPABILITY_SCOPES.includes(scope);
+}
+
 // Export for database migration
 export const CAPABILITY_TYPE_ENUM = getCapabilityTypeCodes().map((c) => `'${c}'`).join(', ');

--- a/lib/governance/cross-venture-capability-graph.js
+++ b/lib/governance/cross-venture-capability-graph.js
@@ -22,7 +22,10 @@ export async function buildCrossVentureGraph(supabase) {
     // Get all capabilities with their venture associations
     const { data: capabilities, error } = await supabase
       .from('venture_capabilities')
-      .select('id, capability_key, capability_type, venture_id, maturity_level, status');
+      // venture_capabilities columns are name / origin_venture_id (NOT capability_key / venture_id);
+      // alias them so downstream code keeps using cap.capability_key / cap.venture_id. No 'status'
+      // column exists — surface maturity_level as the available state proxy (see mapping below).
+      .select('id, capability_key:name, capability_type, venture_id:origin_venture_id, maturity_level');
 
     if (error) {
       return { success: false, error: error.message, sharedCapabilities: [], totalCapabilities: 0, ventureCount: 0, reuseScore: 0 };
@@ -57,7 +60,7 @@ export async function buildCrossVentureGraph(supabase) {
           instances: instances.map(i => ({
             venture_id: i.venture_id,
             maturity_level: i.maturity_level,
-            status: i.status,
+            status: i.maturity_level, // venture_capabilities has no status column; maturity_level is the state proxy
           })),
         });
       }
@@ -125,8 +128,8 @@ export async function getCapabilityVentures(capabilityKey, supabase) {
 
   const { data, error } = await supabase
     .from('venture_capabilities')
-    .select('venture_id, maturity_level, status')
-    .eq('capability_key', capabilityKey);
+    .select('venture_id:origin_venture_id, maturity_level')
+    .eq('name', capabilityKey);
 
   if (error || !data) {
     return { shared: false, ventureCount: 0, ventures: [] };

--- a/scripts/one-off/backfill-venture-capabilities.mjs
+++ b/scripts/one-off/backfill-venture-capabilities.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * One-off backfill: populate venture_capabilities from completed venture SDs.
+ * SD: SD-LEO-GEN-UNIFY-VENTURE-CAPABILITIES-001 | US-004 / FR-4
+ *
+ * The capability flywheel registers PLATFORM capabilities (sd_capabilities) via
+ * trg_capability_lifecycle when an SD completes, but VENTURE capabilities
+ * (venture_capabilities, consumed by the cross-venture graph + v_unified_capabilities
+ * 'venture' arm) have no equivalent populator. This backfill reads completed SDs that
+ * (a) carry a venture_id and (b) declare delivers_capabilities, and materializes one
+ * venture_capabilities row per declared capability.
+ *
+ * Forward-looking + no-op-safe: venture_capabilities is currently empty and the only
+ * venture SDs are cancelled with delivers_capabilities=[], so today this logs
+ * "0 to populate" explicitly (NC-7) rather than silently doing nothing.
+ *
+ * Idempotent: existence is checked by (origin_sd_key, name) in JS before insert, so
+ * re-runs make no changes and the script does not depend on a specific DB unique
+ * constraint being present.
+ *
+ * delivers_capabilities element shape (per 20251202_capability_lifecycle_automation.sql):
+ *   { capability_type, capability_key, name, description, metadata }
+ *
+ * Usage:
+ *   node scripts/one-off/backfill-venture-capabilities.mjs            # populate
+ *   node scripts/one-off/backfill-venture-capabilities.mjs --dry-run  # preview only
+ */
+import 'dotenv/config';
+import { realpathSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { createClient } from '@supabase/supabase-js';
+
+const dryRun = process.argv.includes('--dry-run');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);
+
+// Allowed venture_capabilities.maturity_level values (CHECK constraint). Note this
+// scale differs from sd_capabilities' computed production/beta/experimental — 'beta'
+// is NOT valid here — so values that fall outside the set are coerced to 'experimental'.
+export const VENTURE_MATURITY_LEVELS = Object.freeze(['experimental', 'stable', 'production', 'deprecated']);
+
+/** Clamp a score to the [0,10] CHECK range; null/non-numeric → null. */
+function clampScore(value) {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  if (Number.isNaN(n)) return null;
+  return Math.max(0, Math.min(10, n));
+}
+
+/**
+ * Map a single delivers_capabilities element + its originating SD to a
+ * venture_capabilities insert row. Pure — no I/O. Exported for unit testing.
+ * Output is guaranteed to satisfy the venture_capabilities CHECK constraints
+ * (maturity_level ∈ VENTURE_MATURITY_LEVELS; scores in [0,10] or null).
+ */
+export function toVentureCapabilityRow(cap, sd) {
+  const meta = cap.metadata || {};
+  const name = cap.name || cap.capability_key;
+  // delivers_capabilities does not carry scores/maturity directly; pull from metadata
+  // if present, else default to the lowest maturity. Forward-looking — venture SDs may
+  // enrich these. Coerce to satisfy the DB CHECK constraints.
+  const rawMaturity = meta.maturity_level || cap.maturity_level || 'experimental';
+  return {
+    name,
+    capability_type: cap.capability_type || 'tool',
+    origin_venture_id: sd.venture_id,
+    origin_sd_key: sd.sd_key,
+    maturity_level: VENTURE_MATURITY_LEVELS.includes(rawMaturity) ? rawMaturity : 'experimental',
+    reusability_score: clampScore(meta.reusability_score ?? cap.reusability_score),
+    revenue_leverage_score: clampScore(meta.revenue_leverage_score ?? cap.revenue_leverage_score),
+  };
+}
+
+async function main() {
+  console.log(`Backfill venture_capabilities  (dryRun=${dryRun})`);
+
+  // Completed SDs that carry a venture_id. delivers_capabilities array-length is
+  // filtered in JS (PostgREST cannot express jsonb_array_length in a filter).
+  const { data: sds, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, venture_id, status, delivers_capabilities')
+    .eq('status', 'completed')
+    .not('venture_id', 'is', null);
+
+  if (error) {
+    console.error(`  ERROR querying SDs: ${error.message}`);
+    process.exit(1);
+  }
+
+  const eligible = (sds || []).filter(
+    (sd) => Array.isArray(sd.delivers_capabilities) && sd.delivers_capabilities.length > 0
+  );
+
+  console.log(`  completed venture SDs: ${(sds || []).length} | with delivers_capabilities: ${eligible.length}`);
+
+  if (eligible.length === 0) {
+    // NC-7: surface the no-op explicitly so callers can distinguish "ran, nothing to do"
+    // from "did not run".
+    console.log('  ✅ 0 venture capabilities to populate (no completed venture SDs declare delivers_capabilities).');
+    return;
+  }
+
+  let inserted = 0;
+  let skipped = 0;
+  const previews = [];
+
+  for (const sd of eligible) {
+    // Existing venture_capabilities for this SD — idempotency by (origin_sd_key, name).
+    const { data: existingRows, error: exErr } = await supabase
+      .from('venture_capabilities')
+      .select('name')
+      .eq('origin_sd_key', sd.sd_key);
+    if (exErr) {
+      console.error(`  ERROR reading existing rows for ${sd.sd_key}: ${exErr.message}`);
+      process.exit(1);
+    }
+    const existingNames = new Set((existingRows || []).map((r) => r.name));
+
+    for (const cap of sd.delivers_capabilities) {
+      const row = toVentureCapabilityRow(cap, sd);
+      if (existingNames.has(row.name)) {
+        skipped++;
+        continue;
+      }
+      if (dryRun) {
+        previews.push(`${sd.sd_key} -> ${row.name} [${row.capability_type}]`);
+        inserted++; // counted as "would insert"
+        existingNames.add(row.name); // avoid double-counting dupes within the same SD payload
+        continue;
+      }
+      const { error: insErr } = await supabase.from('venture_capabilities').insert(row);
+      if (insErr) {
+        console.error(`  ERROR inserting ${row.name} (${sd.sd_key}): ${insErr.message}`);
+        process.exit(1);
+      }
+      existingNames.add(row.name);
+      inserted++;
+    }
+  }
+
+  if (dryRun) {
+    console.log(`  DRY RUN — would insert ${inserted}, skip ${skipped} (already present).`);
+    for (const p of previews.slice(0, 20)) console.log(`    + ${p}`);
+    return;
+  }
+
+  console.log(`  ✅ inserted=${inserted} skipped=${skipped} (idempotent: re-run inserts 0).`);
+}
+
+// Only run when invoked directly (not when imported by tests).
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main().catch((e) => {
+    console.error('Backfill failed:', e.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/capabilities/scope-unification.test.js
+++ b/tests/unit/capabilities/scope-unification.test.js
@@ -1,0 +1,228 @@
+/**
+ * Capability Scope Unification Tests
+ * SD: SD-LEO-GEN-UNIFY-VENTURE-CAPABILITIES-001 | US-002 / US-006 (FR-2, FR-6)
+ *
+ * Covers:
+ *   - resolveCapabilityScope (pure unit, no DB) — the canonical scope derivation
+ *     that the v_unified_capabilities view mirrors.
+ *   - toVentureCapabilityRow (pure unit) — backfill mapping determinism.
+ *   - v_unified_capabilities exposes a 3-way scope + plane1_score (DB).
+ *   - sd_capabilities rows resolve to platform (EHG_Engineer) / application (EHG) (DB).
+ *   - v_scanner_capabilities still resolves after the view change (DB regression).
+ *   - cross-venture graph returns non-empty data after seeding shared capabilities (DB).
+ *   - backfill idempotency guard detects already-present rows (DB).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+import {
+  resolveCapabilityScope,
+  isValidCapabilityScope,
+  CAPABILITY_SCOPES,
+} from '../../../lib/capabilities/capability-taxonomy.js';
+import { toVentureCapabilityRow, VENTURE_MATURITY_LEVELS } from '../../../scripts/one-off/backfill-venture-capabilities.mjs';
+import { buildCrossVentureGraph } from '../../../lib/governance/cross-venture-capability-graph.js';
+
+dotenv.config();
+
+// Gate: skip DB tests when no real DB is available (mirrors scoring-lifecycle.test.js).
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UNIT TESTS — no DB required
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveCapabilityScope — unit (no DB)', () => {
+  it('US2-1: venture_id present resolves to "venture" (even with target_application set)', () => {
+    expect(resolveCapabilityScope({ ventureId: 'abc-123', targetApplication: 'EHG' })).toBe('venture');
+    expect(resolveCapabilityScope({ ventureId: '0e6449d9-aaa1-4de5-8aba-c81fe0238b98' })).toBe('venture');
+  });
+
+  it('US2-2: EHG_Engineer target_application resolves to "platform"', () => {
+    expect(resolveCapabilityScope({ targetApplication: 'EHG_Engineer' })).toBe('platform');
+  });
+
+  it('US2-3: a non-platform application (EHG) resolves to "application"', () => {
+    expect(resolveCapabilityScope({ targetApplication: 'EHG' })).toBe('application');
+    expect(resolveCapabilityScope({ targetApplication: 'CronGenius' })).toBe('application');
+  });
+
+  it('US2-4: null/empty target_application defaults to "platform"', () => {
+    expect(resolveCapabilityScope({})).toBe('platform');
+    expect(resolveCapabilityScope({ targetApplication: null })).toBe('platform');
+    expect(resolveCapabilityScope({ targetApplication: '   ' })).toBe('platform');
+    expect(resolveCapabilityScope()).toBe('platform');
+  });
+
+  it('US2-5: platform match is case-insensitive and tolerates the hyphen variant', () => {
+    expect(resolveCapabilityScope({ targetApplication: 'ehg_engineer' })).toBe('platform');
+    expect(resolveCapabilityScope({ targetApplication: 'EHG_ENGINEER' })).toBe('platform');
+    expect(resolveCapabilityScope({ targetApplication: 'ehg-engineer' })).toBe('platform');
+  });
+
+  it('US2-6: output is always a member of the closed CAPABILITY_SCOPES set', () => {
+    const samples = [
+      { ventureId: 'x' },
+      { targetApplication: 'EHG_Engineer' },
+      { targetApplication: 'EHG' },
+      {},
+    ];
+    for (const s of samples) {
+      expect(CAPABILITY_SCOPES).toContain(resolveCapabilityScope(s));
+    }
+    expect(CAPABILITY_SCOPES).toEqual(['platform', 'application', 'venture']);
+  });
+
+  it('US2-7: isValidCapabilityScope accepts known scopes and rejects others', () => {
+    expect(isValidCapabilityScope('platform')).toBe(true);
+    expect(isValidCapabilityScope('application')).toBe(true);
+    expect(isValidCapabilityScope('venture')).toBe(true);
+    expect(isValidCapabilityScope('galaxy')).toBe(false);
+    expect(isValidCapabilityScope(undefined)).toBe(false);
+  });
+});
+
+describe('toVentureCapabilityRow — unit (no DB)', () => {
+  const sd = { sd_key: 'SD-VENTURE-TEST-001', venture_id: 'venture-uuid-1' };
+
+  it('US4-1: maps name from cap.name, falling back to capability_key', () => {
+    expect(toVentureCapabilityRow({ name: 'My Cap', capability_key: 'my-cap', capability_type: 'tool' }, sd).name)
+      .toBe('My Cap');
+    expect(toVentureCapabilityRow({ capability_key: 'my-cap', capability_type: 'tool' }, sd).name)
+      .toBe('my-cap');
+  });
+
+  it('US4-2: carries origin_sd_key + origin_venture_id from the SD', () => {
+    const row = toVentureCapabilityRow({ capability_key: 'k', capability_type: 'tool' }, sd);
+    expect(row.origin_sd_key).toBe('SD-VENTURE-TEST-001');
+    expect(row.origin_venture_id).toBe('venture-uuid-1');
+  });
+
+  it('US4-3: pulls maturity/score fields from metadata when present, else defaults', () => {
+    const enriched = toVentureCapabilityRow(
+      { capability_key: 'k', capability_type: 'tool', metadata: { maturity_level: 'production', reusability_score: 4 } },
+      sd
+    );
+    expect(enriched.maturity_level).toBe('production');
+    expect(enriched.reusability_score).toBe(4);
+
+    const bare = toVentureCapabilityRow({ capability_key: 'k', capability_type: 'tool' }, sd);
+    expect(bare.maturity_level).toBe('experimental');
+    expect(bare.reusability_score).toBeNull();
+  });
+
+  it('US4-5: output satisfies venture_capabilities CHECK constraints (maturity in set, scores clamped)', () => {
+    // 'beta' is valid for sd_capabilities but NOT for venture_capabilities → coerced.
+    const coerced = toVentureCapabilityRow(
+      { capability_key: 'k', capability_type: 'tool', metadata: { maturity_level: 'beta', reusability_score: 42 } },
+      sd
+    );
+    expect(VENTURE_MATURITY_LEVELS).toContain(coerced.maturity_level);
+    expect(coerced.maturity_level).toBe('experimental'); // invalid → lowest
+    expect(coerced.reusability_score).toBe(10); // clamped into [0,10]
+  });
+
+  it('US4-4: mapping is deterministic (same input → same output)', () => {
+    const cap = { name: 'X', capability_key: 'x', capability_type: 'agent', metadata: { maturity_level: 'beta' } };
+    expect(toVentureCapabilityRow(cap, sd)).toEqual(toVentureCapabilityRow(cap, sd));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB INTEGRATION TESTS — skipped when no real DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!HAS_REAL_DB)('capability scope unification — DB integration', () => {
+  const supabase = createSupabaseServiceClient();
+  const TEST_PREFIX = 'TEST-SCOPE-UNIFY';
+  // Two real ventures (so origin_venture_id survives any FK), from existing venture SDs.
+  const VENTURE_A = '0e6449d9-aaa1-4de5-8aba-c81fe0238b98';
+  const VENTURE_B = '4f71b3bd-8a1e-462e-a8b2-76efb8607206';
+
+  async function cleanup() {
+    await supabase.from('venture_capabilities').delete().like('name', `${TEST_PREFIX}%`);
+    await supabase.from('venture_capabilities').delete().like('origin_sd_key', `${TEST_PREFIX}%`);
+  }
+  afterEach(cleanup);
+
+  it('US6-1: v_unified_capabilities exposes non-null scope ∈ {platform,application,venture} + plane1_score column', async () => {
+    const { data, error } = await supabase
+      .from('v_unified_capabilities')
+      .select('scope, plane1_score, capability_source')
+      .limit(2000);
+    expect(error).toBeNull();
+    expect(data.length).toBeGreaterThan(0);
+    // plane1_score column is present (may be null for agent arms).
+    expect(data[0]).toHaveProperty('plane1_score');
+    const scopes = new Set(data.map((r) => r.scope));
+    for (const scope of scopes) {
+      expect(CAPABILITY_SCOPES, `unexpected scope value: ${scope}`).toContain(scope);
+    }
+    // No null scopes.
+    expect(data.every((r) => r.scope !== null && r.scope !== undefined)).toBe(true);
+  });
+
+  it('US6-2: sd_capabilities rows split platform (EHG_Engineer) vs application (EHG)', async () => {
+    const { data, error } = await supabase
+      .from('v_unified_capabilities')
+      .select('scope, capability_source')
+      .eq('capability_source', 'sd_capability')
+      .limit(2000);
+    expect(error).toBeNull();
+    const scopes = new Set(data.map((r) => r.scope));
+    // Every sd_capability row is platform or application (never venture, since 0 have venture_id today).
+    for (const s of scopes) expect(['platform', 'application']).toContain(s);
+    // The 3-way revision MUST be live: EHG-sourced rows resolve to 'application'.
+    expect(scopes.has('application'), 'expected application-scoped sd_capabilities (EHG); is the 3-way migration applied?').toBe(true);
+    expect(scopes.has('platform'), 'expected platform-scoped sd_capabilities (EHG_Engineer)').toBe(true);
+  });
+
+  it('US6-3: v_scanner_capabilities still resolves after the view change (regression)', async () => {
+    const { data, error } = await supabase
+      .from('v_scanner_capabilities')
+      .select('id, name, capability_type, capability_source, relevance_score, maturity_level, source_id, source_key')
+      .limit(5);
+    expect(error).toBeNull();
+    expect(Array.isArray(data)).toBe(true);
+    // Scanner view excludes sd_capability rows by definition.
+    for (const r of data) {
+      expect(['venture', 'agent_skill', 'agent_registry']).toContain(r.capability_source);
+    }
+  });
+
+  it('US6-4: cross-venture graph returns non-empty shared capabilities after seeding', async () => {
+    const sharedName = `${TEST_PREFIX}-shared-${Date.now()}`;
+    // Same capability name shared across two ventures.
+    const { error: e1 } = await supabase.from('venture_capabilities').insert([
+      { name: sharedName, capability_type: 'tool', origin_venture_id: VENTURE_A, origin_sd_key: `${TEST_PREFIX}-A`, maturity_level: 'stable' },
+      { name: sharedName, capability_type: 'tool', origin_venture_id: VENTURE_B, origin_sd_key: `${TEST_PREFIX}-B`, maturity_level: 'stable' },
+    ]);
+    expect(e1).toBeNull();
+
+    const graph = await buildCrossVentureGraph(supabase);
+    expect(graph.success).toBe(true);
+    const shared = graph.sharedCapabilities.find((c) => c.capability_key === sharedName);
+    expect(shared, 'seeded shared capability should appear in the cross-venture graph').toBeTruthy();
+    expect(shared.venture_count).toBe(2);
+  });
+
+  it('US6-5: backfill idempotency guard detects already-present (origin_sd_key, name)', async () => {
+    const sdKey = `${TEST_PREFIX}-IDEMPOTENT`;
+    const capName = `${TEST_PREFIX}-cap-1`;
+    await supabase.from('venture_capabilities').insert({
+      name: capName, capability_type: 'tool', origin_venture_id: VENTURE_A, origin_sd_key: sdKey, maturity_level: 'experimental',
+    });
+
+    // This is exactly the existence check the backfill performs before inserting.
+    const { data: existing } = await supabase
+      .from('venture_capabilities')
+      .select('name')
+      .eq('origin_sd_key', sdKey);
+    const existingNames = new Set((existing || []).map((r) => r.name));
+    expect(existingNames.has(capName)).toBe(true); // → backfill would SKIP, not duplicate.
+  });
+});


### PR DESCRIPTION
## Summary
Enriches the capability flywheel with a **scope-aware, scored, portfolio-wide** capability view. Part of the CAPABILITY FLYWHEEL initiative (follows the ACTIVATE-CAPABILITY-SCORING keystone; unblocks MATURITY-WEIGHTED-PORTFOLIO).

- **US-001/005 (FR-1/5):** `v_unified_capabilities` view enriched (CREATE OR REPLACE, no ALTER TABLE) with a derived **3-way `scope`** (`platform|application|venture`) + `plane1_score`. `target_application` disambiguates application vs platform. Applied live via the canonical guarded path (`apply-migration.js --prod-deploy`). Dependent `v_scanner_capabilities` preserved. Live result: EHG-sourced caps → `application` (121), EHG_Engineer → `platform` (85), 0 rows lost.
- **US-002 (FR-2):** `resolveCapabilityScope` in `lib/capabilities/capability-taxonomy.js` — pure single-source-of-truth resolver the view mirrors.
- **US-003 (FR-3):** Fixed `lib/governance/cross-venture-capability-graph.js` column bugs (`name`/`origin_venture_id`) that made it silently return empty — the cross-venture graph now returns real data.
- **US-004 (FR-4):** `scripts/one-off/backfill-venture-capabilities.mjs` — idempotent, no-op-safe backfill of `venture_capabilities`; output coerced to satisfy the table CHECK constraints.
- **US-006 (FR-6):** `tests/unit/capabilities/scope-unification.test.js` — 17 tests (HAS_REAL_DB skipIf).

## Test plan
- `scope-unification.test.js`: **17/17 pass** — 3-way scope present, sd_capability platform/application split, `v_scanner_capabilities` regression, cross-venture graph non-empty after seed, backfill idempotency.
- `scoring-lifecycle.test.js` regression: **13/13 pass**.
- Backfill dry-run + live: clean no-op (0 to populate) — explicit 0-count.
- Migration applied live: `[MIGRATION_APPLY_PROD_PASS]`, 10 columns, scanner view resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)