### PR TITLE
feat(SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001): maturity-weighted, portfolio-aware capability anchoring

### DIFF
--- a/lib/capabilities/scanner-context.js
+++ b/lib/capabilities/scanner-context.js
@@ -12,48 +12,161 @@
 const MAX_CONTEXT_CHARS = 2000;
 const MAX_CAPABILITIES = 20;
 
+// SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: maturity-weighted, portfolio-aware anchoring.
+// The capability block's INFLUENCE scales with portfolio maturity (explore-early / exploit-late):
+// at immaturity the block is softened (fewer capabilities + an exploratory preamble that favors
+// latent capability + market opportunity over the thin proven ledger), preventing the degenerate
+// "echo the trunk's internal infra back as venture ideas" cron-bias. As proven, reusable capability
+// accumulates, the block rises to full strength.
+const MIN_CAPABILITIES = 3;        // floor — soften, never fully empty, the block at immaturity
+const EXPLOIT_THRESHOLD = 0.33;    // maturityScore below this gets the exploratory preamble
+// Saturation constants for the maturity signal (documented thresholds; tuned for an immature
+// portfolio so current data yields a deliberately LOW score).
+const PROD_SATURATION = 100;       // production-grade capabilities for full prod-signal
+const REUSE_SATURATION = 50;       // reuse events for full reuse-signal
+const VENTURE_SATURATION = 20;     // shipped ventures for full venture-signal
+
+const EXPLORATORY_PREAMBLE =
+  '> NOTE: EHG\'s proven, reusable capability base is still small (early-stage portfolio). ' +
+  'Treat the capabilities below as a WEAK prior, not a mandate — prioritize latent capability ' +
+  'and market opportunity over echoing existing internal strengths.\n\n';
+
 /**
- * Get a formatted capability context block for a specific scanner type.
+ * Compute a portfolio-maturity signal from the populated capability graph.
+ * Derived on-the-fly (no dedicated table): production-grade count + reuse volume + venture count,
+ * each saturated to [0,1] and averaged into maturityScore ∈ [0,1].
+ *
+ * Fail-soft: on any error (or when reuse_log is empty) the signal degrades gracefully. A total
+ * failure returns maturityScore=1 so the block falls back to current FULL-strength behavior
+ * (no regression) — the documented PRD tradeoff (FR-1 / fail-soft AC).
+ *
+ * @param {Object} supabase
+ * @returns {Promise<{productionGradeCount:number, reuseVolume:number, ventureCount:number, maturityScore:number}>}
+ */
+export async function computePortfolioMaturity(supabase) {
+  const fullWeight = { productionGradeCount: 0, reuseVolume: 0, ventureCount: 0, maturityScore: 1 };
+  if (!supabase) return fullWeight;
+  try {
+    const [prodRes, reuseRes, ventureRes] = await Promise.all([
+      supabase.from('v_unified_capabilities').select('*', { count: 'exact', head: true }).eq('maturity_level', 'production'),
+      supabase.from('capability_reuse_log').select('*', { count: 'exact', head: true }),
+      supabase.from('ventures').select('*', { count: 'exact', head: true }),
+    ]);
+    // A query error on any single signal is treated as 0 for that signal (valid low signal),
+    // NOT a total failure — only a thrown exception triggers the full-weight fallback.
+    const productionGradeCount = prodRes.error ? 0 : (prodRes.count || 0);
+    const reuseVolume = reuseRes.error ? 0 : (reuseRes.count || 0);
+    const ventureCount = ventureRes.error ? 0 : (ventureRes.count || 0);
+
+    const prodC = Math.min(1, productionGradeCount / PROD_SATURATION);
+    const reuseC = Math.min(1, reuseVolume / REUSE_SATURATION);
+    const ventureC = Math.min(1, ventureCount / VENTURE_SATURATION);
+    const maturityScore = (prodC + reuseC + ventureC) / 3;
+
+    return { productionGradeCount, reuseVolume, ventureCount, maturityScore };
+  } catch (err) {
+    console.warn(`[scanner-context] portfolio-maturity computation failed, defaulting to full weight: ${err.message}`);
+    return fullWeight;
+  }
+}
+
+/**
+ * Monotonic map: how many capabilities the block surfaces at a given maturity.
+ * maturityScore 0 → MIN_CAPABILITIES; 1 → MAX_CAPABILITIES. Strictly non-decreasing.
+ */
+export function maturityToCapCount(maturityScore) {
+  const s = Math.max(0, Math.min(1, Number(maturityScore) || 0));
+  return Math.max(MIN_CAPABILITIES, Math.round(MIN_CAPABILITIES + s * (MAX_CAPABILITIES - MIN_CAPABILITIES)));
+}
+
+/** Map the portfolio view's categorical maturity_level to the numeric maturity_score formatters expect. */
+function maturityLevelToScore(level) {
+  switch (String(level || '').toLowerCase()) {
+    case 'production': return 5;
+    case 'stable': return 4;
+    case 'beta': return 3;
+    case 'experimental': return 2;
+    case 'deprecated': return 1;
+    default: return 0;
+  }
+}
+
+/**
+ * Remap a v_unified_capabilities row to the column shape the formatters read. The portfolio view
+ * exposes name/capability_type/scope/plane1_score/maturity_level but NOT the ledger's
+ * capability_key/maturity_score/reuse_count/first_registered_at — without this remap the formatters
+ * would emit `undefined`. (FR-3 column-contract safety.)
+ */
+function remapUnifiedRow(r) {
+  return {
+    capability_key: r.name,
+    name: r.name,
+    capability_type: r.capability_type,
+    plane1_score: r.plane1_score,
+    maturity_score: maturityLevelToScore(r.maturity_level),
+    maturity_level: r.maturity_level,
+    reuse_count: 0,            // reuse volume is not surfaced per-capability in the portfolio view yet
+    registered_by_sd: r.source_key,
+    first_registered_at: null, // portfolio view has no per-capability registration timestamp
+    scope: r.scope,
+  };
+}
+
+/**
+ * Get a formatted capability context block for a specific scanner type, weighted by portfolio maturity.
  *
  * @param {Object} supabase - Supabase client
  * @param {string} scannerType - One of: trend_scanner, democratization_finder, capability_overhang, nursery_reeval
+ * @param {number|null} [maturityScore] - Portfolio maturity ∈ [0,1]. If null, it is computed here
+ *                                         (fail-soft to full weight). Callers running multiple scanners
+ *                                         can compute once and pass it to avoid recomputation.
  * @returns {Promise<string>} Formatted markdown context block, or empty string if no data
  */
-export async function getCapabilityContextBlock(supabase, scannerType) {
+export async function getCapabilityContextBlock(supabase, scannerType, maturityScore = null) {
   if (!supabase) return '';
 
   try {
-    const { data: capabilities, error } = await supabase
-      .from('v_capability_ledger')
-      .select('capability_key, name, capability_type, plane1_score, maturity_score, reuse_count, registered_by_sd, first_registered_at')
-      .order('plane1_score', { ascending: false })
-      .limit(MAX_CAPABILITIES);
-
-    if (error) {
-      console.warn(`[scanner-context] Query error: ${error.message}`);
-      return '';
-    }
-
-    if (!capabilities || capabilities.length === 0) {
-      return '';
-    }
-
+    // SD-LEO-INFRA-ANCHOR-SIMPLE-VENTURE-001: capability anchoring is OPT-IN.
+    // Only EXPLICITLY mapped scanner types receive a capability block. Unknown/unmapped types
+    // (e.g. 'simple_venture') return an empty block instead of leaking internal context.
     const formatters = {
       trend_scanner: formatForTrendScanner,
       democratization_finder: formatForDemocratization,
       capability_overhang: formatForOverhang,
       nursery_reeval: formatForNurseryReeval,
     };
-
-    // SD-LEO-INFRA-ANCHOR-SIMPLE-VENTURE-001: capability anchoring is OPT-IN.
-    // Only EXPLICITLY mapped scanner types receive a capability block. Previously,
-    // unmapped types (e.g. 'simple_venture') silently fell through to formatForOverhang,
-    // injecting EHG's internal-infrastructure ledger into prompts that should not be
-    // capability-anchored — biasing Simple Venture Finder toward cron/scheduling tooling.
-    // Unknown/unmapped types now return an empty block instead of leaking internal context.
     const formatter = formatters[scannerType];
     if (!formatter) return '';
-    const block = formatter(capabilities);
+
+    const maturity = maturityScore == null
+      ? (await computePortfolioMaturity(supabase)).maturityScore
+      : Math.max(0, Math.min(1, Number(maturityScore) || 0));
+
+    // FR-3: portfolio-wide source (platform + application + venture) with column remap.
+    const { data: rows, error } = await supabase
+      .from('v_unified_capabilities')
+      .select('name, capability_type, plane1_score, maturity_level, scope, source_key')
+      .order('plane1_score', { ascending: false, nullsFirst: false })
+      .limit(MAX_CAPABILITIES);
+
+    if (error) {
+      console.warn(`[scanner-context] Query error: ${error.message}`);
+      return '';
+    }
+    if (!rows || rows.length === 0) {
+      return '';
+    }
+
+    // FR-2: maturity weighting — surface fewer capabilities at low maturity.
+    const capCount = maturityToCapCount(maturity);
+    const capabilities = rows.slice(0, capCount).map(remapUnifiedRow);
+
+    let block = formatter(capabilities);
+
+    // Soften framing at immaturity so the thin ledger is a weak prior, not a mandate.
+    if (maturity < EXPLOIT_THRESHOLD) {
+      block = EXPLORATORY_PREAMBLE + block;
+    }
 
     // Hard cap enforcement
     if (block.length > MAX_CONTEXT_CHARS) {

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -211,7 +211,9 @@ async function runTrendScanner({ constraints, candidateCount, strategyConfig }, 
   }
 
   // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
-  const capabilityBlock = await getCapabilityContextBlock(supabase, 'trend_scanner');
+  // SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: weight the block by portfolio maturity
+  // (computed once upstream in loadStrategicContext; self-computed fail-soft if absent).
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'trend_scanner', strategicContext?.raw?.portfolioMaturity?.maturityScore ?? null);
 
   // Mental model context injection (Layer 1)
   const mentalModelBlock = await getMentalModelContextBlock(
@@ -285,7 +287,8 @@ async function runDemocratizationFinder({ constraints, candidateCount, strategyC
     : '';
 
   // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
-  const capabilityBlock = await getCapabilityContextBlock(supabase, 'democratization_finder');
+  // SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: maturity-weighted (see trend_scanner).
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'democratization_finder', strategicContext?.raw?.portfolioMaturity?.maturityScore ?? null);
 
   // Mental model context injection (Layer 1)
   const mentalModelBlock = await getMentalModelContextBlock(
@@ -342,7 +345,8 @@ async function runCapabilityOverhang({ constraints, candidateCount, strategyConf
     : '';
 
   // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject real capability data
-  const capabilityBlock = await getCapabilityContextBlock(supabase, 'capability_overhang');
+  // SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: maturity-weighted (see trend_scanner).
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'capability_overhang', strategicContext?.raw?.portfolioMaturity?.maturityScore ?? null);
 
   // Mental model context injection (Layer 1)
   const mentalModelBlock = await getMentalModelContextBlock(
@@ -467,11 +471,12 @@ Return a JSON array:
  * whose conditions may have changed.
  */
 async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
-  const { supabase, logger = console, llmClient } = deps;
+  const { supabase, logger = console, llmClient, strategicContext } = deps;
   const client = llmClient || getValidationClient();
 
   // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
-  const capabilityBlock = await getCapabilityContextBlock(supabase, 'nursery_reeval');
+  // SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: maturity-weighted (see trend_scanner).
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'nursery_reeval', strategicContext?.raw?.portfolioMaturity?.maturityScore ?? null);
 
   // Mental model context injection (Layer 1)
   const mentalModelBlock = await getMentalModelContextBlock(

--- a/lib/eva/stage-zero/strategic-context-loader.js
+++ b/lib/eva/stage-zero/strategic-context-loader.js
@@ -10,6 +10,8 @@
  * Part of SD-LEO-FIX-ADD-MISSION-VISION-001
  */
 
+import { computePortfolioMaturity } from '../../capabilities/scanner-context.js';
+
 /**
  * Load all strategic context for Stage 0 ideation.
  *
@@ -26,17 +28,19 @@ export async function loadStrategicContext(supabase, options = {}) {
   }
 
   // Run all sub-loaders in parallel - each catches independently
-  const [mission, visionDimensions, okrGaps, themes] = await Promise.all([
+  const [mission, visionDimensions, okrGaps, themes, portfolioMaturity] = await Promise.all([
     loadMission(supabase, logger),
     loadVisionDimensions(supabase, logger),
     loadOkrGaps(supabase, logger),
     loadStrategicThemes(supabase, logger),
+    loadPortfolioMaturity(supabase, logger),
   ]);
 
   const agentEconomyContext = getAgentEconomyContext();
 
-  const raw = { mission, visionDimensions, okrGaps, themes, agentEconomyContext };
+  const raw = { mission, visionDimensions, okrGaps, themes, agentEconomyContext, portfolioMaturity };
 
+  // portfolioMaturity is informational context, not a presence signal — exclude it from isEmpty.
   const isEmpty = !mission
     && visionDimensions.length === 0
     && okrGaps.length === 0
@@ -138,6 +142,20 @@ async function loadStrategicThemes(supabase, logger) {
 }
 
 /**
+ * Load the portfolio-maturity signal (SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001).
+ * Surfaces explore-early/exploit-late state to the strategic context. Fail-soft (the
+ * underlying compute never throws); never blocks Stage-0.
+ */
+async function loadPortfolioMaturity(supabase, logger) {
+  try {
+    return await computePortfolioMaturity(supabase);
+  } catch (err) {
+    logger.warn(`   Warning: Portfolio maturity load failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * Format all strategic context into a prompt block for LLM injection.
  */
 function formatPromptBlock(raw) {
@@ -181,6 +199,16 @@ function formatPromptBlock(raw) {
     for (const t of raw.themes) {
       sections.push(`  - ${t.name}${t.description ? ': ' + t.description : ''}`);
     }
+  }
+
+  if (raw.portfolioMaturity) {
+    const pm = raw.portfolioMaturity;
+    const pct = Math.round((pm.maturityScore ?? 0) * 100);
+    const stance = (pm.maturityScore ?? 0) < 0.33 ? 'EXPLORE (favor latent capability + market opportunity)'
+      : (pm.maturityScore ?? 0) < 0.66 ? 'BALANCED' : 'EXPLOIT (lean on proven capabilities)';
+    sections.push('\nPORTFOLIO MATURITY:');
+    sections.push(`  Maturity: ${pct}% → stance: ${stance}`);
+    sections.push(`  Signals: ${pm.productionGradeCount} production-grade capabilities, ${pm.reuseVolume} reuse events, ${pm.ventureCount} ventures`);
   }
 
   if (raw.agentEconomyContext) {

--- a/tests/unit/capabilities/maturity-weighting.test.js
+++ b/tests/unit/capabilities/maturity-weighting.test.js
@@ -1,0 +1,122 @@
+/**
+ * Maturity-Weighted Portfolio-Aware Capability Anchoring Tests
+ * SD: SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001 (FR-1..FR-5)
+ *
+ * Covers:
+ *   - maturityToCapCount: monotonicity + bounds (pure, no DB).
+ *   - computePortfolioMaturity: fail-soft to full weight (no DB), and live signal (DB).
+ *   - getCapabilityContextBlock: portfolio-wide source (v_unified_capabilities), no
+ *     undefined-column regression, exploratory preamble at immaturity, monotonic influence,
+ *     and simple_venture remains de-anchored (DB).
+ */
+
+import { describe, it, expect } from 'vitest';
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+import {
+  computePortfolioMaturity,
+  maturityToCapCount,
+  getCapabilityContextBlock,
+} from '../../../lib/capabilities/scanner-context.js';
+
+dotenv.config();
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+// Count capability rows in a formatted block (overhang/trend use '| ' table rows or '- ' bullets).
+const countCapabilityLines = (s) => (s.match(/^[|\-] /gm) || []).length;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UNIT — no DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('maturityToCapCount — monotonicity + bounds (no DB)', () => {
+  it('MW-1: is monotonically non-decreasing across maturity', () => {
+    const samples = [0, 0.1, 0.25, 0.4, 0.5, 0.66, 0.8, 1];
+    const counts = samples.map(maturityToCapCount);
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]).toBeGreaterThanOrEqual(counts[i - 1]);
+    }
+  });
+
+  it('MW-2: floors at MIN (3) for zero maturity and caps at MAX (20) for full maturity', () => {
+    expect(maturityToCapCount(0)).toBe(3);
+    expect(maturityToCapCount(1)).toBe(20);
+    // Strictly higher influence at full vs zero maturity (documented threshold behavior).
+    expect(maturityToCapCount(1)).toBeGreaterThan(maturityToCapCount(0));
+  });
+
+  it('MW-3: clamps out-of-range / non-numeric inputs to the floor or cap', () => {
+    expect(maturityToCapCount(-5)).toBe(3);
+    expect(maturityToCapCount(2)).toBe(20);
+    expect(maturityToCapCount(NaN)).toBe(3);
+    expect(maturityToCapCount(undefined)).toBe(3);
+  });
+});
+
+describe('computePortfolioMaturity — fail-soft (no DB)', () => {
+  it('MW-4: returns full weight (maturityScore=1) when no supabase client is provided', async () => {
+    const m = await computePortfolioMaturity(null);
+    expect(m.maturityScore).toBe(1);
+    expect(m.productionGradeCount).toBe(0);
+    expect(m.reuseVolume).toBe(0);
+    expect(m.ventureCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB INTEGRATION — skipped when no real DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!HAS_REAL_DB)('maturity-weighted anchoring — DB integration', () => {
+  const supabase = createSupabaseServiceClient();
+
+  it('MW-5: computes a low, well-typed maturity signal from the (immature) live portfolio', async () => {
+    const m = await computePortfolioMaturity(supabase);
+    expect(typeof m.maturityScore).toBe('number');
+    expect(m.maturityScore).toBeGreaterThanOrEqual(0);
+    expect(m.maturityScore).toBeLessThanOrEqual(1);
+    // Portfolio is immature today → below the EXPLOIT band.
+    expect(m.maturityScore).toBeLessThan(0.66);
+    expect(Number.isInteger(m.productionGradeCount)).toBe(true);
+    expect(Number.isInteger(m.ventureCount)).toBe(true);
+    // reuse_count=0 / empty capability_reuse_log is a VALID low signal, not an error.
+    expect(m.reuseVolume).toBeGreaterThanOrEqual(0);
+  });
+
+  it('MW-6: capability block draws from v_unified_capabilities with NO undefined-column regression', async () => {
+    const block = await getCapabilityContextBlock(supabase, 'capability_overhang', 1);
+    expect(typeof block).toBe('string');
+    expect(block.length).toBeGreaterThan(0);
+    // FR-3 column-contract guard: the remap must not leak `undefined` into any formatter cell.
+    expect(block).not.toContain('undefined');
+  });
+
+  it('MW-7: applies the exploratory preamble at immaturity and omits it at full maturity', async () => {
+    const low = await getCapabilityContextBlock(supabase, 'capability_overhang', 0.05);
+    const high = await getCapabilityContextBlock(supabase, 'capability_overhang', 1);
+    expect(low).toContain('WEAK prior');       // EXPLORATORY_PREAMBLE present below threshold
+    expect(high).not.toContain('WEAK prior');   // full strength above threshold
+    expect(low).not.toContain('undefined');
+    expect(high).not.toContain('undefined');
+  });
+
+  it('MW-8: surfaces more capabilities at higher maturity (monotonic influence on the block)', async () => {
+    const low = await getCapabilityContextBlock(supabase, 'capability_overhang', 0.05);
+    const high = await getCapabilityContextBlock(supabase, 'capability_overhang', 1);
+    expect(countCapabilityLines(high)).toBeGreaterThanOrEqual(countCapabilityLines(low));
+  });
+
+  it('MW-9: simple_venture remains de-anchored (empty block) regardless of maturity', async () => {
+    const block = await getCapabilityContextBlock(supabase, 'simple_venture', 0.5);
+    expect(block).toBe('');
+  });
+
+  it('MW-10: self-computes maturity (fail-soft) when no maturityScore is passed', async () => {
+    const block = await getCapabilityContextBlock(supabase, 'trend_scanner');
+    expect(typeof block).toBe('string'); // computes internally; does not throw
+  });
+});

--- a/tests/unit/scanner-context.test.js
+++ b/tests/unit/scanner-context.test.js
@@ -17,12 +17,17 @@ function mockSupabase(data = [], error = null) {
   };
 }
 
+// SD-LEO-INFRA-MATURITY-WEIGHTED-PORTFOLIO-001: getCapabilityContextBlock now sources the
+// portfolio-wide v_unified_capabilities view (scope-aware), not v_capability_ledger. That view
+// exposes name/capability_type/plane1_score/maturity_level/scope/source_key but NOT the ledger's
+// per-capability reuse_count or first_registered_at — so the democratization "reused Nx" annotation
+// and the nursery recency ordering degrade gracefully (the remap sets reuse_count=0, ts=null).
 const SAMPLE_CAPABILITIES = [
-  { capability_key: 'ai_image_classification', name: 'AI Image Classification', capability_type: 'ai_automation', plane1_score: 18.5, maturity_score: 4, reuse_count: 3, registered_by_sd: 'SD-IMG-001', first_registered_at: '2026-03-01T00:00:00Z' },
-  { capability_key: 'natural_language_processing', name: 'Natural Language Processing', capability_type: 'ai_automation', plane1_score: 16.2, maturity_score: 3, reuse_count: 5, registered_by_sd: 'SD-NLP-001', first_registered_at: '2026-03-02T00:00:00Z' },
-  { capability_key: 'supabase_integration', name: 'Supabase Integration', capability_type: 'infrastructure', plane1_score: 14.0, maturity_score: 5, reuse_count: 10, registered_by_sd: 'SD-INFRA-001', first_registered_at: '2026-02-15T00:00:00Z' },
-  { capability_key: 'payment_processing', name: 'Payment Processing', capability_type: 'integration', plane1_score: 12.0, maturity_score: 3, reuse_count: 2, registered_by_sd: 'SD-PAY-001', first_registered_at: '2026-02-20T00:00:00Z' },
-  { capability_key: 'automated_reporting', name: 'Automated Reporting', capability_type: 'application', plane1_score: 10.5, maturity_score: 2, reuse_count: 1, registered_by_sd: 'SD-RPT-001', first_registered_at: '2026-03-03T00:00:00Z' },
+  { name: 'AI Image Classification', capability_type: 'ai_automation', plane1_score: 18.5, maturity_level: 'stable', scope: 'platform', source_key: 'SD-IMG-001' },
+  { name: 'Natural Language Processing', capability_type: 'ai_automation', plane1_score: 16.2, maturity_level: 'beta', scope: 'platform', source_key: 'SD-NLP-001' },
+  { name: 'Supabase Integration', capability_type: 'infrastructure', plane1_score: 14.0, maturity_level: 'production', scope: 'platform', source_key: 'SD-INFRA-001' },
+  { name: 'Payment Processing', capability_type: 'integration', plane1_score: 12.0, maturity_level: 'beta', scope: 'application', source_key: 'SD-PAY-001' },
+  { name: 'Automated Reporting', capability_type: 'application', plane1_score: 10.5, maturity_level: 'experimental', scope: 'application', source_key: 'SD-RPT-001' },
 ];
 
 describe('getCapabilityContextBlock', () => {
@@ -53,12 +58,15 @@ describe('getCapabilityContextBlock', () => {
     expect(result).toContain('infrastructure');
   });
 
-  it('formats democratization_finder with reuse focus', async () => {
+  it('formats democratization_finder listing reusable capabilities', async () => {
     const supabase = mockSupabase(SAMPLE_CAPABILITIES);
     const result = await getCapabilityContextBlock(supabase, 'democratization_finder');
 
     expect(result).toContain('Reusable Capabilities');
-    expect(result).toContain('reused');
+    // Portfolio view does not surface per-capability reuse_count, so the "reused Nx" annotation
+    // is absent; the block still lists the capabilities by name.
+    expect(result).toContain('AI Image Classification');
+    expect(result).not.toContain('undefined');
   });
 
   it('formats capability_overhang with full detail table', async () => {
@@ -72,16 +80,16 @@ describe('getCapabilityContextBlock', () => {
     expect(result).toContain('AI Image Classification');
   });
 
-  it('formats nursery_reeval with recent capabilities', async () => {
+  it('formats nursery_reeval listing capabilities', async () => {
     const supabase = mockSupabase(SAMPLE_CAPABILITIES);
     const result = await getCapabilityContextBlock(supabase, 'nursery_reeval');
 
     expect(result).toContain('Recently Added');
     expect(result).toContain('added');
-    // Most recent should be first (2026-03-03)
-    const reportIdx = result.indexOf('Automated Reporting');
-    const nlpIdx = result.indexOf('Natural Language Processing');
-    expect(reportIdx).toBeLessThan(nlpIdx);
+    // Portfolio view has no per-capability registration timestamp, so recency ordering is not
+    // available (dates render as 'unknown'); the block still lists the capabilities.
+    expect(result).toContain('Natural Language Processing');
+    expect(result).not.toContain('undefined');
   });
 
   it('enforces 2000 character cap', async () => {


### PR DESCRIPTION
## Summary
**Capstone (SD-4) of the capability-flywheel family** — completes it (SD-1 cron-bias fix → SD-2 scoring → SD-3 portfolio-unify → **SD-4 maturity-weighted anchoring**). Makes Stage-0 discovery capability anchoring **explore-early / exploit-late** so it does not echo the trunk's internal infra back as venture ideas while the portfolio is immature.

- **FR-1:** `computePortfolioMaturity()` derives `{productionGradeCount, reuseVolume, ventureCount, maturityScore∈[0,1]}` on-the-fly from `v_unified_capabilities` + `capability_reuse_log` + `ventures` (no new table; reuse=0 valid; fail-soft to full weight). Surfaced in strategic context.
- **FR-2:** `getCapabilityContextBlock` weights the block by maturity — `maturityToCapCount` monotonic (3→20); exploratory preamble below 0.33 reframes the thin ledger as a weak prior.
- **FR-3:** source switched `v_capability_ledger` (EHG_Engineer-only) → portfolio-wide `v_unified_capabilities` (platform+application+venture) with a column remap (no undefined-column regression).
- **FR-4:** 4 anchored discovery runners thread the maturity signal (computed once upstream); `simple_venture` stays de-anchored.
- **FR-5:** `tests/unit/capabilities/maturity-weighting.test.js` (10 tests).

## Test plan
- `maturity-weighting.test.js`: **10/10** (monotonicity, bounds, fail-soft, live signal, no-undefined-column, preamble, de-anchoring).
- `scanner-context.test.js` updated for the portfolio-view source (reuse/recency embellishments degrade gracefully): **pass**.
- Regression (discovery-mode ×4, path-router, ranking-pipeline, queue-processor): **pass** — no regression from the source switch. **76 tests green** across touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)