### PR TITLE
fix(SD-FDBK-INFRA-GATE5-GIT-COMMIT-001): GATE5 wrong-repo fallback + regression guard

### DIFF
--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -95,6 +95,25 @@ class GitCommitVerifier {
   }
 
   /**
+   * Execute a git command in a SPECIFIC directory (not this.effectiveCwd).
+   * Used only by the wrong-repo fallback in checkCommitsExist to search sibling platform repos.
+   * Kept distinct from gitCommand() so the same-repo invariant ("fallback never invoked") is
+   * directly assertable in tests. (SD-FDBK-INFRA-GATE5-GIT-COMMIT-001)
+   */
+  async gitCommandInDir(command, cwd) {
+    try {
+      const { stdout, stderr } = await execAsync(command, { cwd });
+      return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
+    } catch (error) {
+      return {
+        stdout: error.stdout?.trim() || '',
+        stderr: error.stderr?.trim() || error.message,
+        success: false
+      };
+    }
+  }
+
+  /**
    * Check if file is a root-level temp file that should be ignored
    * These are session artifacts that shouldn't block handoffs
    */
@@ -218,6 +237,39 @@ class GitCommitVerifier {
         if (commits.length > 0) {
           allCommits = [...new Set([...allCommits, ...commits])]; // Dedupe
           matchedTerm = matchedTerm || term;
+        }
+      }
+    }
+
+    // ── FR-2/FR-3 (SD-FDBK-INFRA-GATE5-GIT-COMMIT-001): strictly-more-permissive wrong-repo fallback ──
+    // `git log --all` is REPO-OBJECT-DB-scoped (not cwd/worktree-scoped): a commit anywhere in the
+    // resolved repo is already found from any cwd in it. So the cross-WORKTREE case never caused a
+    // "no commits" false-FAIL — and the dirty/branch/upstream worktree case is ALREADY handled by
+    // resolveWorktreeCwd (SD-LEO-INFRA-BRANCH-AWARE-PLAN-001) in verify(). Do NOT re-implement
+    // worktree-aware commit lookup here (RCA 4fb06962 confirmed that rewrite is unnecessary/shipped).
+    // The only residual false-positive is wrong-REPO resolution: determineTargetRepository can
+    // misroute appPath to the wrong platform repo when target_application is null/ambiguous, leaving
+    // the commit in the SIBLING repo's object DB, invisible here. Before blocking, search the other
+    // platform repo(s). Fail-open by construction — a same-repo SD finds its commits on the first
+    // pass and never reaches this; a genuinely commitless SD finds zero everywhere and still FAILs.
+    if (allCommits.length === 0) {
+      const siblingRepos = [EHG_ENGINEER_ROOT, EHG_ROOT].filter(
+        (repo) => path.resolve(repo) !== path.resolve(this.effectiveCwd) && fs.existsSync(repo)
+      );
+      for (const repo of siblingRepos) {
+        for (const term of searchTerms) {
+          const r = await this.gitCommandInDir(`git log --all --oneline --grep="${term}"`, repo);
+          if (r.success && r.stdout.trim()) {
+            const commits = r.stdout.split('\n').filter((line) => line.trim().length > 0);
+            if (commits.length > 0) {
+              allCommits = [...new Set([...allCommits, ...commits])];
+              matchedTerm = matchedTerm || term;
+            }
+          }
+        }
+        if (allCommits.length > 0) {
+          console.log(`   ↳ commits found in sibling platform repo (${repo}) via wrong-repo fallback (RCA 4fb06962)`);
+          break;
         }
       }
     }

--- a/tests/unit/scripts/git-commit-wrong-repo-fallback.test.js
+++ b/tests/unit/scripts/git-commit-wrong-repo-fallback.test.js
@@ -1,0 +1,91 @@
+/**
+ * GATE5 git-commit-enforcement: regression guard + wrong-repo fallback
+ * SD: SD-FDBK-INFRA-GATE5-GIT-COMMIT-001 (FR-1, FR-2)
+ *
+ * RCA 4fb06962 established that the witnessed cross-WORKTREE false-positive was already fixed by
+ * SD-LEO-INFRA-BRANCH-AWARE-PLAN-001 (resolveWorktreeCwd), and that `git log --all` is repo-object-DB
+ * scoped (not cwd-scoped). These tests lock in that fix + the gate invariants, and cover the new
+ * strictly-more-permissive wrong-REPO fallback in checkCommitsExist.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the worktree resolver so TS-1 can assert verify() wires it without a real worktree.
+vi.mock('../../../lib/resolve-worktree-cwd.js', () => ({
+  resolveWorktreeCwd: () => '/fake/ehg/.worktrees/SD-TEST-GATE5',
+}));
+
+import GitCommitVerifier from '../../../scripts/verify-git-commit-status.js';
+
+describe('GitCommitVerifier.checkCommitsExist — wrong-repo fallback + invariants', () => {
+  let verifier;
+  beforeEach(() => {
+    verifier = new GitCommitVerifier('SD-TEST-GATE5', '/fake/resolved/repo');
+    verifier.effectiveCwd = '/fake/resolved/repo';
+  });
+
+  it('TS-3: same-repo commits found on first pass — sibling-repo fallback is NEVER invoked (fail-open invariant)', async () => {
+    vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: 'abc1234 fix(SD-TEST-GATE5): work', stderr: '' });
+    const inDir = vi.spyOn(verifier, 'gitCommandInDir').mockResolvedValue({ success: true, stdout: '', stderr: '' });
+
+    const ok = await verifier.checkCommitsExist();
+
+    expect(ok).toBe(true);
+    expect(verifier.results.commitsExist).toBe(true);
+    // The load-bearing same-repo guarantee: the fallback is not reached, so behavior is unchanged.
+    expect(inDir).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: wrong-repo resolution — commits found in the SIBLING platform repo via the fallback', async () => {
+    vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: '', stderr: '' }); // resolved repo: empty
+    const inDir = vi.spyOn(verifier, 'gitCommandInDir').mockResolvedValue({ success: true, stdout: 'def5678 fix(SD-TEST-GATE5): work in sibling repo', stderr: '' });
+
+    const ok = await verifier.checkCommitsExist();
+
+    expect(ok).toBe(true);
+    expect(verifier.results.commitsExist).toBe(true);
+    expect(inDir).toHaveBeenCalled(); // fallback engaged only because the first pass found nothing
+    expect(verifier.results.commitCount).toBeGreaterThan(0);
+  });
+
+  it('TS-2: no commits in ANY candidate repo — FAIL with No-commits-found blocker (true-negative preserved)', async () => {
+    vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: '', stderr: '' });
+    vi.spyOn(verifier, 'gitCommandInDir').mockResolvedValue({ success: true, stdout: '', stderr: '' });
+
+    const ok = await verifier.checkCommitsExist();
+
+    expect(ok).toBe(false);
+    expect(verifier.results.commitsExist).toBe(false);
+    expect(verifier.results.blockers.some((b) => /No commits found/.test(b))).toBe(true);
+  });
+
+  it('TS-4b: fallback de-dupes and only fails when truly empty everywhere (sibling also empty → still found nowhere)', async () => {
+    vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: '', stderr: '' });
+    // sibling returns blank/whitespace → treated as no commits
+    vi.spyOn(verifier, 'gitCommandInDir').mockResolvedValue({ success: true, stdout: '   ', stderr: '' });
+
+    const ok = await verifier.checkCommitsExist();
+
+    expect(ok).toBe(false);
+    expect(verifier.results.commitCount).toBe(0);
+  });
+});
+
+describe('GitCommitVerifier.verify — locks in resolveWorktreeCwd worktree resolution (FR-1 / TS-1)', () => {
+  it('TS-1: verify() resolves effectiveCwd to the SD worktree (guards SD-LEO-INFRA-BRANCH-AWARE-PLAN-001)', async () => {
+    // Default appPath = the real EHG_Engineer worktree root (has a .git file), so verify() does not early-return.
+    const v = new GitCommitVerifier('SD-TEST-GATE5');
+    // Stub the 5 real-git checks so verify() touches no network/filesystem beyond the resolver.
+    vi.spyOn(v, 'checkCleanWorkingDirectory').mockResolvedValue(true);
+    vi.spyOn(v, 'checkCommitsExist').mockResolvedValue(true);
+    vi.spyOn(v, 'checkAllCommitsPushed').mockResolvedValue(true);
+    vi.spyOn(v, 'checkRemoteBranchExists').mockResolvedValue(true);
+    vi.spyOn(v, 'checkBranchMatchesSD').mockResolvedValue(true);
+
+    const results = await v.verify();
+
+    expect(results.verdict).toBe('PASS');
+    // resolveWorktreeCwd (mocked) returned a worktree path distinct from appPath → effectiveCwd updated.
+    expect(v.effectiveCwd).toBe('/fake/ehg/.worktrees/SD-TEST-GATE5');
+  });
+});


### PR DESCRIPTION
## Summary
RCA-informed close-out of the GATE5 git-commit-enforcement false-positive class. **RCA `4fb06962` found the witnessed cross-worktree symptom was ALREADY FIXED** by SD-LEO-INFRA-BRANCH-AWARE-PLAN-001 (`resolveWorktreeCwd`, 2026-05-22) — and that `git log --all` is repo-object-DB-scoped (not cwd-scoped), so cross-worktree never caused "no commits found." The high-blast-radius gate rewrite was taken **off the table**; re-scoped (60% reduction) to LOW-risk, fail-open-only work safe alongside live sessions.

- **FR-2:** strictly-more-permissive **wrong-repo fallback** in `checkCommitsExist` (`verify-git-commit-status.js`) — when the resolved repo yields zero commits, search the sibling platform repo (EHG↔EHG_Engineer) before the No-commits-found blocker. Fail-open: same-repo SDs short-circuit on the first pass and never reach it; a genuinely commitless SD still FAILs. New `gitCommandInDir` helper.
- **FR-3:** inline maintainer comment citing RCA `4fb06962` so nobody re-attempts the worktree-aware rewrite.
- **FR-1:** `tests/unit/scripts/git-commit-wrong-repo-fallback.test.js` (5 tests).

## Test plan
- New test: **5/5 pass** — resolveWorktreeCwd lock-in (TS-1), true-negative FAIL (TS-2), same-repo fallback-NOT-invoked (TS-3, the fail-open invariant), wrong-repo fallback found (TS-4), sibling-empty still fails (TS-4b).
- **Meta-validation:** this SD's own EXEC-TO-PLAN exercised the modified GATE5 — Clean Working Directory PASS, Remote Branch PASS.
- Module loads (default export = function). Fail-open only → currently-passing handoffs byte-for-byte unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)