### PR TITLE
fix(QF-20260529-533): LEAD-FINAL trailing crash: normalizeSDId shim fail-soft when sd-id-resolver module missing in stale worktree

### DIFF
--- a/scripts/modules/sd-id-normalizer.js
+++ b/scripts/modules/sd-id-normalizer.js
@@ -101,7 +101,22 @@ export async function normalizeSDId(supabase, sdId) {
   }
   const trimmedId = sdId.trim();
   const format = detectIdFormat(trimmedId);
-  const { resolveSdInput } = await import('../lib/sd-id-resolver.js');
+  // b6256a28 (QF-20260529-533): fail-soft when scripts/lib/sd-id-resolver.js is
+  // absent (worktrees provisioned before that file existed). The dynamic import
+  // otherwise rejects with ERR_MODULE_NOT_FOUND in the LEAD-FINAL post-completion
+  // path — after the DB completion write — misleading the session and aborting
+  // /learn + parent rollup. Degrade to an inline id-or-key lookup.
+  let resolveSdInput;
+  try {
+    ({ resolveSdInput } = await import('../lib/sd-id-resolver.js'));
+  } catch (importErr) {
+    const code = importErr && importErr.code;
+    if (code === 'ERR_MODULE_NOT_FOUND' || /Cannot find (module|package)/i.test((importErr && importErr.message) || '')) {
+      console.warn(`[SD-ID-NORMALIZER] resolver module unavailable (${code || 'not found'}); inline fallback for "${trimmedId}"`);
+      return await _normalizeViaDirectQuery(supabase, trimmedId, format);
+    }
+    throw importErr;
+  }
   try {
     const { sdId: canonical } = await resolveSdInput(trimmedId, supabase);
     if (canonical !== trimmedId) {
@@ -117,6 +132,48 @@ export async function normalizeSDId(supabase, sdId) {
     } else {
       console.warn('[SD-ID-NORMALIZER] Resolver error:', err.message);
     }
+    return null;
+  }
+}
+
+/**
+ * b6256a28 (QF-20260529-533): inline fallback resolution used when
+ * scripts/lib/sd-id-resolver.js cannot be imported (stale worktree). Mirrors
+ * resolveSdInput's core OR-query but returns null on not-found/error to preserve
+ * normalizeSDId's legacy silent-zero contract. Exported for unit testing.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} trimmedId - already-trimmed identifier
+ * @param {string} format - precomputed detectIdFormat(trimmedId)
+ * @returns {Promise<string|null>} canonical id, or null on not-found/error
+ */
+export async function _normalizeViaDirectQuery(supabase, trimmedId, format) {
+  // Restrict the .or() filter to validated UUID/sd_key shapes (resolveSdInput
+  // gates the same way) so a malformed identifier can't perturb the PostgREST filter.
+  if (format !== 'uuid' && format !== 'sd_key') {
+    console.warn(`[SD-ID-NORMALIZER] Unrecognized identifier format (fallback): ${trimmedId}`);
+    return null;
+  }
+  try {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key')
+      .or(`id.eq.${trimmedId},sd_key.eq.${trimmedId}`)
+      .maybeSingle();
+    if (error) {
+      console.error('[SD-ID-NORMALIZER] Fallback query error:', error.message);
+      return null;
+    }
+    if (!data) {
+      console.warn(`[SD-ID-NORMALIZER] SD not found (fallback) for identifier: ${trimmedId} (format: ${format})`);
+      return null;
+    }
+    if (data.id !== trimmedId) {
+      console.log(`[SD-ID-NORMALIZER] Normalized (fallback): "${trimmedId}" -> "${data.id}"`);
+    }
+    return data.id;
+  } catch (e) {
+    console.warn('[SD-ID-NORMALIZER] Fallback resolution failed:', e.message);
     return null;
   }
 }

--- a/tests/unit/sd-id-normalizer-fallback.test.js
+++ b/tests/unit/sd-id-normalizer-fallback.test.js
@@ -1,0 +1,70 @@
+/**
+ * Regression test for b6256a28 / QF-20260529-533.
+ *
+ * normalizeSDId's dynamic import of scripts/lib/sd-id-resolver.js used to reject
+ * with ERR_MODULE_NOT_FOUND in worktrees provisioned before that file existed,
+ * crashing the LEAD-FINAL post-completion path. The shim now falls back to
+ * _normalizeViaDirectQuery when the resolver module is absent. This test pins
+ * the fallback's contract (canonical-id resolution + null on not-found/error).
+ *
+ * Chainable-Supabase-mock pattern mirrors tests/unit/lib/sd-id-resolver.test.js.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { _normalizeViaDirectQuery } from '../../scripts/modules/sd-id-normalizer.js';
+
+function makeMockSupabase(payload, opts = {}) {
+  const calls = { froms: [], ors: [] };
+  const stub = {
+    from(table) {
+      calls.froms.push(table);
+      return {
+        select() { return this; },
+        or(filter) { calls.ors.push(filter); return this; },
+        async maybeSingle() {
+          if (opts.throw) throw new Error(opts.throw);
+          return payload;
+        },
+      };
+    },
+    _calls: calls,
+  };
+  return stub;
+}
+
+const UUID = 'b6256a28-8ba7-4d4a-826b-e5bfc2bda52c';
+
+describe('_normalizeViaDirectQuery — b6256a28 fail-soft fallback', () => {
+  it('returns the canonical id when matched by uuid', async () => {
+    const supabase = makeMockSupabase({ data: { id: UUID, sd_key: 'SD-X-001' }, error: null });
+    expect(await _normalizeViaDirectQuery(supabase, UUID, 'uuid')).toBe(UUID);
+    expect(supabase._calls.froms[0]).toBe('strategic_directives_v2');
+  });
+
+  it('normalizes an sd_key to the canonical uuid id', async () => {
+    const supabase = makeMockSupabase({ data: { id: UUID, sd_key: 'SD-X-001' }, error: null });
+    expect(await _normalizeViaDirectQuery(supabase, 'SD-X-001', 'sd_key')).toBe(UUID);
+    expect(supabase._calls.ors[0]).toContain('sd_key.eq.SD-X-001');
+  });
+
+  it('returns null when the SD is not found', async () => {
+    const supabase = makeMockSupabase({ data: null, error: null });
+    expect(await _normalizeViaDirectQuery(supabase, 'SD-MISSING-001', 'sd_key')).toBeNull();
+  });
+
+  it('returns null on a DB error', async () => {
+    const supabase = makeMockSupabase({ data: null, error: { message: 'boom' } });
+    expect(await _normalizeViaDirectQuery(supabase, 'SD-X-001', 'sd_key')).toBeNull();
+  });
+
+  it('returns null and never queries on an unrecognized format', async () => {
+    const fromSpy = vi.fn();
+    const supabase = { from: fromSpy };
+    expect(await _normalizeViaDirectQuery(supabase, 'garbage', 'unknown')).toBeNull();
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null if the underlying query throws', async () => {
+    const supabase = makeMockSupabase(null, { throw: 'network down' });
+    expect(await _normalizeViaDirectQuery(supabase, 'SD-X-001', 'sd_key')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260529-533

**Type:** bug
**Severity:** medium

### Issue Description
The normalizeSDId shim (scripts/modules/sd-id-normalizer.js) dynamically imports ../lib/sd-id-resolver.js OUTSIDE its try/catch. In worktrees checked out before that resolver file was added, the import rejects with ERR_MODULE_NOT_FOUND in the post-completion handoff path, AFTER the DB completion write lands. Work is done but exit 1 misleads the session and aborts the learn plus parent rollup steps. Fix: wrap the import and fall back to a direct id-or-key lookup so the shim degrades gracefully.




### Changes
- **Files Changed:** 2
  - scripts/modules/sd-id-normalizer.js
  - tests/unit/sd-id-normalizer-fallback.test.js
- **LOC:** 135 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Targeted regression in worktree: sd-id-normalizer-fallback.test.js (6) + lib/sd-id-resolver.test.js (19) = 25 passed. E2E (Playwright) + tsc N/A for a pure-JS backend shim; PR CI runs full suite. Commit e1f7463c79.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol