### PR TITLE
fix(QF-20260529-706): GATE5 verify-git-commit: run commit-search via argv array (no shell) to remove grep-term injection shape

### DIFF
--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -18,7 +18,7 @@
  *   node scripts/verify-git-commit-status.js SD-XXX  # defaults to EHG_Engineer (the repo this script lives in)
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -34,6 +34,7 @@ const EHG_ENGINEER_ROOT = path.resolve(__dirname, '..');
 const EHG_ROOT = resolveRepoPath('ehg');
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 class GitCommitVerifier {
   // Default appPath is EHG_Engineer (the repo this script LIVES IN), not EHG.
@@ -83,7 +84,12 @@ class GitCommitVerifier {
    */
   async gitCommand(command) {
     try {
-      const { stdout, stderr } = await execAsync(command, { cwd: this.effectiveCwd });
+      // 513c5b48: an array command runs via execFile (no shell), so an interpolated
+      // SD --grep term cannot be shell-interpreted; a string command keeps the legacy
+      // shell path for all other callers. execFile also sidesteps cmd.exe quoting on Windows.
+      const { stdout, stderr } = Array.isArray(command)
+        ? await execFileAsync('git', command, { cwd: this.effectiveCwd })
+        : await execAsync(command, { cwd: this.effectiveCwd });
       return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
     } catch (error) {
       return {
@@ -102,7 +108,10 @@ class GitCommitVerifier {
    */
   async gitCommandInDir(command, cwd) {
     try {
-      const { stdout, stderr } = await execAsync(command, { cwd });
+      // 513c5b48: array command -> execFile (no shell); string keeps the legacy shell path.
+      const { stdout, stderr } = Array.isArray(command)
+        ? await execFileAsync('git', command, { cwd })
+        : await execAsync(command, { cwd });
       return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
     } catch (error) {
       return {
@@ -230,7 +239,7 @@ class GitCommitVerifier {
 
     // Search for each term
     for (const term of searchTerms) {
-      const result = await this.gitCommand(`git log --all --oneline --grep="${term}"`);
+      const result = await this.gitCommand(['log', '--all', '--oneline', `--grep=${term}`]);
 
       if (result.success && result.stdout.trim()) {
         const commits = result.stdout.split('\n').filter(line => line.trim().length > 0);
@@ -258,7 +267,7 @@ class GitCommitVerifier {
       );
       for (const repo of siblingRepos) {
         for (const term of searchTerms) {
-          const r = await this.gitCommandInDir(`git log --all --oneline --grep="${term}"`, repo);
+          const r = await this.gitCommandInDir(['log', '--all', '--oneline', `--grep=${term}`], repo);
           if (r.success && r.stdout.trim()) {
             const commits = r.stdout.split('\n').filter((line) => line.trim().length > 0);
             if (commits.length > 0) {

--- a/tests/unit/scripts/git-commit-grep-argv.test.js
+++ b/tests/unit/scripts/git-commit-grep-argv.test.js
@@ -1,0 +1,51 @@
+/**
+ * Regression test for 513c5b48 / QF-20260529-706.
+ *
+ * checkCommitsExist() previously interpolated an SD identifier into a shell
+ * command string (`git log --all --oneline --grep="${term}"`) executed via the
+ * shell. The search now passes an argv ARRAY through gitCommand/gitCommandInDir,
+ * which run it via execFile (no shell) — removing the injection shape and the
+ * cross-platform cmd.exe quoting hazard. These tests pin the argv contract.
+ *
+ * Worktree resolver mocked exactly as in git-commit-wrong-repo-fallback.test.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/resolve-worktree-cwd.js', () => ({
+  resolveWorktreeCwd: () => '/fake/ehg/.worktrees/SD-TEST-GATE5',
+}));
+
+import GitCommitVerifier from '../../../scripts/verify-git-commit-status.js';
+
+describe('GitCommitVerifier — 513c5b48 no-shell argv commit search', () => {
+  let verifier;
+  beforeEach(() => {
+    verifier = new GitCommitVerifier('SD-TEST-GATE5', '/fake/resolved/repo');
+    verifier.effectiveCwd = '/fake/resolved/repo';
+  });
+
+  it('first-pass search passes an argv array, not an interpolated shell string', async () => {
+    const spy = vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: 'abc1234 fix(SD-TEST-GATE5): work', stderr: '' });
+
+    await verifier.checkCommitsExist();
+
+    const arg = spy.mock.calls[0][0];
+    expect(Array.isArray(arg)).toBe(true);
+    expect(arg).toContain('--grep=SD-TEST-GATE5');
+    // No shell-quoted git string survives (the injection/quoting hazard).
+    expect(arg.join(' ')).not.toContain('"');
+    expect(arg.some((a) => typeof a === 'string' && a.startsWith('git '))).toBe(false);
+  });
+
+  it('wrong-repo fallback also searches via an argv array', async () => {
+    vi.spyOn(verifier, 'gitCommand').mockResolvedValue({ success: true, stdout: '', stderr: '' });
+    const inDir = vi.spyOn(verifier, 'gitCommandInDir').mockResolvedValue({ success: true, stdout: 'def5678 fix(SD-TEST-GATE5): sibling', stderr: '' });
+
+    await verifier.checkCommitsExist();
+
+    expect(inDir).toHaveBeenCalled();
+    const arg = inDir.mock.calls[0][0];
+    expect(Array.isArray(arg)).toBe(true);
+    expect(arg).toContain('--grep=SD-TEST-GATE5');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260529-706

**Type:** bug
**Severity:** medium

### Issue Description
checkCommitsExist interpolates an SD identifier into a shell command string for git log --grep, run through exec (shell=true). The two commit-search calls now pass an argv array (execFile, no shell) so the term reaches git literally. Removes the shell-metacharacter injection shape AND fixes cross-platform quoting (cmd.exe does not honor single quotes). gitCommand/gitCommandInDir become polymorphic: array=execFile no-shell, string=exec as before, so all other callers and the existing fallback tests are unchanged.




### Changes
- **Files Changed:** 2
  - scripts/verify-git-commit-status.js
  - tests/unit/scripts/git-commit-grep-argv.test.js
- **LOC:** 72 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Targeted: git-commit-grep-argv.test.js (argv no-shell contract) + git-commit-wrong-repo-fallback.test.js invariants = 7 pass. execFile no-shell; behavior identical for string callers. Commit 5be84c7545.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol