### PR TITLE
fix(QF-20260529-237): fix two review-gate closed-enum false positives

### DIFF
--- a/config/review-critical-findings.json
+++ b/config/review-critical-findings.json
@@ -22,8 +22,8 @@
       "name": "sql_injection",
       "description": "String concatenation in SQL queries without parameterization",
       "patterns": [
-        "\\$\\{.*\\}.*(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)",
-        "\\+\\s*['\"]\\s*(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)",
+        "\\$\\{.*\\}.*\\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\\b",
+        "\\+\\s*['\"]\\s*\\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\\b",
         "\\.query\\s*\\(\\s*`[^`]*\\$\\{"
       ],
       "severity": "critical",
@@ -61,7 +61,7 @@
       "description": "Operations that could cause irreversible data loss",
       "patterns": [
         "rm\\s+-rf\\s+/(?!tmp)",
-        "\\.delete\\(\\)(?!.*\\.eq\\()",
+        "\\.delete\\(\\)(?!.*\\.(?:eq|neq|gt|gte|lt|lte|like|ilike|is|in|contains|containedBy|match|filter|or|not)\\()",
         "git\\s+(reset|checkout)\\s+--hard",
         "git\\s+push\\s+--force\\s+origin\\s+main"
       ],

--- a/tests/unit/review-gate-closed-enum-fp.test.js
+++ b/tests/unit/review-gate-closed-enum-fp.test.js
@@ -1,0 +1,41 @@
+/**
+ * Regression test for QF-20260529-237 (feedback a78478f9 + 03ccc4d4).
+ *
+ * Two closed-enumeration patterns in config/review-critical-findings.json produced
+ * false-positive CRITICAL merge-blocks:
+ *   - CRIT-005 data_loss: the negative lookahead allow-listed only `.eq`, so a
+ *     `.delete()` scoped by `.like()`/`.in()` (test teardown) was flagged.
+ *   - CRIT-002 sql_injection: the keyword alternation had no word boundaries, so the
+ *     substring INSERT inside the prose word "inserts" matched after an interpolation.
+ * The fix broadens the delete allow-list to all supabase filter methods and
+ * word-boundaries the SQL keyword alternation. These tests pin both directions:
+ * the false positives no longer fire AND genuine signatures still fire.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkCriticalFindings } from '../../lib/ship/review-gate.js';
+
+const names = (diff) => checkCriticalFindings(diff).findings.map((f) => f.name);
+
+describe('review-gate closed-enum false-positive fixes (a78478f9 + 03ccc4d4)', () => {
+  // CRIT-005 data_loss — scoped deletes must NOT be flagged; unscoped MUST be.
+  it('does NOT flag a .delete() scoped by .like() (the witnessed test-teardown FP)', () => {
+    expect(names("+ await sb.from('caps').delete().like('capability_key', 'TEST-%')")).not.toContain('data_loss');
+  });
+  it('does NOT flag a .delete() scoped by .in()', () => {
+    expect(names("+ await sb.from('caps').delete().in('id', staleIds)")).not.toContain('data_loss');
+  });
+  it('preserves the original .eq() allow-list', () => {
+    expect(names("+ await sb.from('caps').delete().eq('id', 1)")).not.toContain('data_loss');
+  });
+  it('STILL flags a truly unscoped .delete() (no filter)', () => {
+    expect(names("+ await sb.from('caps').delete()")).toContain('data_loss');
+  });
+
+  // CRIT-002 sql_injection — prose must NOT match; interpolated SQL keyword MUST.
+  it('does NOT flag the prose word "inserts" after an interpolation', () => {
+    expect(names('+ console.log(`Backfilled ${count} inserts complete`)')).not.toContain('sql_injection');
+  });
+  it('STILL flags an interpolated SQL keyword (real injection shape)', () => {
+    expect(names('+ const sql = `${prefix} DELETE FROM users`;')).toContain('sql_injection');
+  });
+});


### PR DESCRIPTION
Broaden CRIT-005 data_loss delete allow-list to all supabase filter methods (a `.delete()` scoped by `.like()`/`.in()` is no longer flagged; unscoped still is) and word-boundary the CRIT-002 sql_injection keyword alternation (prose word 'inserts' no longer matches). Regression: tests/unit/review-gate-closed-enum-fp.test.js (6 cases). Closes feedback a78478f9 + 03ccc4d4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)