### PR TITLE
fix(QF-20260529-414): re-sync CLAUDE.md Work Item Routing twin with DB canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ User may override at any point by stating `[MODE: product]` or `[MODE: campaign]
 | 2 | 31-75 | Standard QF |
 | 3 | >75 | Full SD |
 
-Risk keywords (auth, migration, schema, feature) always force Tier 3.
-> Why: These change classes carry disproportionate blast radius — auth bugs cause security incidents, schema changes can corrupt data, and feature work needs full stakeholder visibility. Tier 3 ensures the gate pipeline (TESTING, SECURITY, GITHUB sub-agents) always runs for them.
+Risk keywords always force Tier 3 — **Type**: feature; **Security**: auth, authentication, authorization, rls, payments, credentials; **Schema**: migration, schema, alter/create/drop table. **Architecture-Plan Auto-Escalation (Always Tier 3)**: when an EVA architecture plan exists for the work item, triage auto-escalates — never reduce scope to fit QF tiers.
+> Why: These change classes carry disproportionate blast radius — security bugs cause incidents, schema changes can corrupt data, feature work needs full stakeholder visibility, and arch-plan scope inherently exceeds QF limits. Tier 3 ensures the gate pipeline (TESTING, SECURITY, GITHUB sub-agents) always runs for them.
 
 ## Session Initialization - SD Selection
 

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -151,8 +151,8 @@ User may override at any point by stating \`[MODE: product]\` or \`[MODE: campai
 | 2 | 31-75 | Standard QF |
 | 3 | >75 | Full SD |
 
-Risk keywords (auth, migration, schema, feature) always force Tier 3.
-> Why: These change classes carry disproportionate blast radius — auth bugs cause security incidents, schema changes can corrupt data, and feature work needs full stakeholder visibility. Tier 3 ensures the gate pipeline (TESTING, SECURITY, GITHUB sub-agents) always runs for them.
+Risk keywords always force Tier 3 — **Type**: feature; **Security**: auth, authentication, authorization, rls, payments, credentials; **Schema**: migration, schema, alter/create/drop table. **Architecture-Plan Auto-Escalation (Always Tier 3)**: when an EVA architecture plan exists for the work item, triage auto-escalates — never reduce scope to fit QF tiers.
+> Why: These change classes carry disproportionate blast radius — security bugs cause incidents, schema changes can corrupt data, feature work needs full stakeholder visibility, and arch-plan scope inherently exceeds QF limits. Tier 3 ensures the gate pipeline (TESTING, SECURITY, GITHUB sub-agents) always runs for them.
 
 ${sessionInit ? formatSection(sessionInit) : ''}
 

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -8,7 +8,7 @@
       "session_init",
       "common_commands"
     ],
-    "_removed_sections_note": "auto_proceed_mode, orchestrator_chaining, sd_continuation_truth_table, migration_execution_protocol_main, work_item_routing, skill_intent_detection, teams_protocol - moved to CORE/phase files, condensed summaries in router generator code"
+    "_removed_sections_note": "auto_proceed_mode, orchestrator_chaining, sd_continuation_truth_table, migration_execution_protocol, work_item_routing, skill_intent_detection, teams_protocol - moved to CORE/phase files, condensed summaries in router generator code"
   },
   "CLAUDE_CORE.md": {
     "description": "Essential context for ALL sessions (~11k tokens). Lean Core (2026-02-16).",


### PR DESCRIPTION
Expand the hardcoded Work Item Routing risk-keyword twin (file-generators.js + committed CLAUDE.md) to match leo_protocol_sections id 428: full Security/Schema keyword set + the Architecture-Plan Auto-Escalation rule. Also fix a stale `_removed_sections_note` key in section-file-mapping.json (`migration_execution_protocol_main`→`migration_execution_protocol`). Only the intended routing section is committed; unrelated full-regen churn reverted. Closes QF-20260529-414 (audit SD-LEO-INFRA-AUDIT-CONTENT-ROUTER-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)