### PR TITLE
fix(QF-20260529-492): ENF-15 resolves pushed branch from refspec, not the hook checkout

### DIFF
--- a/scripts/hooks/lib/force-push-branch.cjs
+++ b/scripts/hooks/lib/force-push-branch.cjs
@@ -1,0 +1,97 @@
+'use strict';
+/**
+ * ENF-15 helper (dbcd817c): resolve the branch(es) a `git push … --force[-with-lease]`
+ * command would WRITE, so the force-push gate judges the actual push target rather than
+ * whatever branch the hook's own checkout happens to be on.
+ *
+ * The hook process runs in (or near) the main checkout, so `git rev-parse HEAD` there
+ * returns `main` even when the command pushes a topic branch from a worktree or via
+ * `git -C <dir>` — producing a false `protected_branch_denylist` block. Deriving the
+ * branch from the refspec DESTINATION is both correct (it is the ref being written) and
+ * cwd-independent.
+ *
+ * Fail-closed contract: when nothing can be resolved this returns `[]` and the caller
+ * treats the empty/unknown branch as not-allowlisted (block). Any protected destination
+ * in a multi-refspec push is surfaced so the gate still blocks it.
+ */
+
+const { execSync } = require('child_process');
+
+const PROTECTED_RE = /^(main|master|develop|release\/.*)$/;
+
+/**
+ * Parse explicit refspec destination branch names from a `git push` command segment.
+ * Handles `git -C <dir>`, leading remote, `src:dst` refspecs, `+force` prefix and
+ * `refs/heads/` prefixes, and multiple refspecs.
+ * @param {string} cmd
+ * @returns {string[]}
+ */
+function pushRefspecDsts(cmd) {
+  const m = String(cmd).match(/\bgit\s+(?:-C\s+(?:"[^"]+"|'[^']+'|\S+)\s+)?push\b([^\n;&|]*)/);
+  if (!m) return [];
+  const toks = m[1].trim().split(/\s+/).filter(Boolean).filter((t) => !t.startsWith('-'));
+  if (toks.length === 0) return [];
+  let refs;
+  if (toks.length === 1) {
+    const t = toks[0];
+    // a lone token with no '/' or ':' is a bare remote name (e.g. `git push origin`) — no explicit branch
+    if (!t.includes('/') && !t.includes(':')) return [];
+    refs = [t];
+  } else {
+    refs = toks.slice(1); // drop the remote, keep the refspec(s)
+  }
+  return refs
+    .map((r) => {
+      let dst = r.includes(':') ? r.split(':').pop() : r; // src:dst -> dst
+      return dst.replace(/^\+/, '').replace(/^refs\/heads\//, '');
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Resolve candidate destination branch names for a force-push command.
+ * Priority: explicit refspec destination(s) → current branch in the push cwd
+ * (`git -C <dir>` target, else sessionCwd) → [].
+ * @param {string} cmd full Bash command
+ * @param {string} [sessionCwd] PreToolUse payload `cwd`
+ * @param {(c:string,o:object)=>string} [exec] injectable exec (testing)
+ * @returns {string[]}
+ */
+function forcePushTargetBranches(cmd, sessionCwd, exec) {
+  const run =
+    exec ||
+    ((c, o) => execSync(c, { encoding: 'utf8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'], ...o }).trim());
+  const dsts = pushRefspecDsts(cmd);
+  if (dsts.length) return dsts;
+  // Bare push: resolve the current branch in the push directory. Try the `git -C <dir>`
+  // target, then the session cwd, then the hook's own process cwd (current behavior) — first
+  // that yields a branch wins. The process-cwd fallback guarantees no regression when an
+  // upstream-supplied cwd is in a form this platform's exec cannot chdir into.
+  const dirMatch = String(cmd).match(/\bgit\s+-C\s+("[^"]+"|'[^']+'|\S+)\s+push\b/);
+  const dirs = [];
+  if (dirMatch) dirs.push(dirMatch[1].replace(/^['"]|['"]$/g, ''));
+  if (sessionCwd) dirs.push(sessionCwd);
+  dirs.push(null); // process cwd
+  for (const d of dirs) {
+    try {
+      const b = run('git rev-parse --abbrev-ref HEAD', d ? { cwd: d } : {});
+      if (b) return [b];
+    } catch {
+      /* try next directory */
+    }
+  }
+  return [];
+}
+
+/**
+ * The single branch ENF-15 should judge: any PROTECTED destination wins (fail-closed,
+ * multi-refspec safe), otherwise the last explicit target. '' when nothing resolved.
+ * @param {string[]} candidates
+ * @returns {string}
+ */
+function effectiveForcePushBranch(candidates) {
+  if (!candidates || candidates.length === 0) return '';
+  return candidates.find((b) => PROTECTED_RE.test(b)) || candidates[candidates.length - 1];
+}
+
+module.exports = { pushRefspecDsts, forcePushTargetBranches, effectiveForcePushBranch, PROTECTED_RE };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1042,11 +1042,15 @@ async function main() {
         const HAS_WITH_LEASE = /--force-with-lease\b/.test(cmd);
         const envVarSet = process.env.LEO_FORCE_PUSH_OWN_BRANCH === 'allow';
 
-        // Resolve current branch (test seam: TEST_OVERRIDE_BRANCH)
+        // Resolve the branch the push WRITES (dbcd817c, QF-20260529-492): from the refspec
+        // destination, else the current branch in the push cwd — NOT the hook checkout (which
+        // is ~always main and false-blocked a topic-branch push from a worktree / via `git -C`).
+        // A protected destination in a multi-refspec push still wins. Test seam: TEST_OVERRIDE_BRANCH.
         let branch = process.env.TEST_OVERRIDE_BRANCH || '';
         if (!branch) {
           try {
-            branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+            const { forcePushTargetBranches, effectiveForcePushBranch } = require('./lib/force-push-branch.cjs');
+            branch = effectiveForcePushBranch(forcePushTargetBranches(cmd, input && input.cwd));
           } catch { branch = ''; }
         }
 

--- a/tests/unit/force-push-branch.test.js
+++ b/tests/unit/force-push-branch.test.js
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the ENF-15 force-push branch resolver (dbcd817c / QF-20260529-492).
+ *
+ * Pins both directions: a topic-branch push from a worktree resolves to the topic
+ * branch (no false protected_branch_denylist), AND any push that writes a protected
+ * branch (incl. multi-refspec and HEAD:main) still surfaces the protected name so the
+ * gate blocks it. Bare pushes resolve via the push cwd through an injected exec.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import pkg from '../../scripts/hooks/lib/force-push-branch.cjs';
+const { pushRefspecDsts, forcePushTargetBranches, effectiveForcePushBranch, PROTECTED_RE } = pkg;
+
+describe('pushRefspecDsts — explicit refspec destinations', () => {
+  it('extracts a feature branch from `origin <branch>`', () => {
+    expect(pushRefspecDsts('git push --force-with-lease origin feat/SD-X')).toEqual(['feat/SD-X']);
+  });
+  it('extracts main when pushing to main', () => {
+    expect(pushRefspecDsts('git push --force origin main')).toEqual(['main']);
+  });
+  it('takes the DST of a src:dst refspec (HEAD:main → main)', () => {
+    expect(pushRefspecDsts('git push --force-with-lease origin HEAD:main')).toEqual(['main']);
+  });
+  it('returns ALL destinations for a multi-refspec push', () => {
+    expect(pushRefspecDsts('git push --force origin main feat/X')).toEqual(['main', 'feat/X']);
+  });
+  it('handles `git -C <dir>` prefix + a quoted dir', () => {
+    expect(pushRefspecDsts('git -C "/c/wt/QF-1" push --force-with-lease origin qf/QF-1')).toEqual(['qf/QF-1']);
+  });
+  it('strips a leading + and refs/heads/', () => {
+    expect(pushRefspecDsts('git push origin +refs/heads/feat/SD-Y')).toEqual(['feat/SD-Y']);
+  });
+  it('treats a lone remote (no slash/colon) as no explicit branch', () => {
+    expect(pushRefspecDsts('git push --force-with-lease origin')).toEqual([]);
+  });
+  it('returns [] when there is no git push', () => {
+    expect(pushRefspecDsts('echo git push --force')).not.toContain('main');
+  });
+});
+
+describe('forcePushTargetBranches — bare push falls back to the push cwd', () => {
+  it('uses the session cwd branch when no refspec is given', () => {
+    const exec = vi.fn(() => 'feat/SD-Z');
+    expect(forcePushTargetBranches('git push --force-with-lease', '/c/wt/SD-Z', exec)).toEqual(['feat/SD-Z']);
+    expect(exec).toHaveBeenCalledWith('git rev-parse --abbrev-ref HEAD', { cwd: '/c/wt/SD-Z' });
+  });
+  it('resolves main for a bare push from main cwd (still blockable)', () => {
+    const exec = vi.fn(() => 'main');
+    expect(forcePushTargetBranches('git push --force-with-lease', '/c/main', exec)).toEqual(['main']);
+  });
+  it('prefers an explicit refspec over the cwd', () => {
+    const exec = vi.fn(() => 'main');
+    expect(forcePushTargetBranches('git push --force-with-lease origin feat/SD-A', '/c/main', exec)).toEqual(['feat/SD-A']);
+    expect(exec).not.toHaveBeenCalled();
+  });
+  it('resolves the `git -C <dir>` target for a bare push', () => {
+    const exec = vi.fn((c, o) => (o && o.cwd === '/c/wt/B' ? 'feat/SD-B' : 'main'));
+    expect(forcePushTargetBranches('git -C /c/wt/B push --force-with-lease', '/c/main', exec)).toEqual(['feat/SD-B']);
+  });
+  it('returns [] when resolution throws (fail-closed at caller)', () => {
+    const exec = vi.fn(() => { throw new Error('not a git repo'); });
+    expect(forcePushTargetBranches('git push --force-with-lease', '', exec)).toEqual([]);
+  });
+});
+
+describe('effectiveForcePushBranch — protected target wins (fail-closed, multi-refspec safe)', () => {
+  it('returns the protected branch when present among candidates', () => {
+    expect(effectiveForcePushBranch(['main', 'feat/X'])).toBe('main');
+    expect(effectiveForcePushBranch(['feat/X', 'develop'])).toBe('develop');
+  });
+  it('returns the last candidate when none are protected', () => {
+    expect(effectiveForcePushBranch(['feat/A', 'qf/QF-1'])).toBe('qf/QF-1');
+  });
+  it('returns empty string for no candidates (caller blocks as not-allowlisted)', () => {
+    expect(effectiveForcePushBranch([])).toBe('');
+    expect(PROTECTED_RE.test('')).toBe(false);
+  });
+});


### PR DESCRIPTION
ENF-15 resolved the branch via `git rev-parse HEAD` in the hook's checkout (~always main), false-blocking a force-with-lease push of a topic branch from a worktree/`git -C` as protected_branch_denylist. New unit-tested helper resolves the actual refspec destination (multi-refspec/`-C`/`src:dst` aware), falling back to the push cwd for bare pushes; fail-closed preserved, any protected destination still blocks. 16 unit + 4 integration spawn-tests pass. Closes feedback dbcd817c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)