### PR TITLE
fix(QF-20260529-810): FR-3 ignores sweep-originated CLAIM_RELEASED (no re-claim livelock)

### DIFF
--- a/lib/claim-lifecycle-release.mjs
+++ b/lib/claim-lifecycle-release.mjs
@@ -137,6 +137,12 @@ export async function hasRecentClaimReleased(sdKey) {
     .select('id,created_at')
     .eq('target_sd', sdKey)
     .eq('message_type', 'CLAIM_RELEASED')
+    // 50615d1b: ignore sweep-originated releases. The stale-session sweep re-emits
+    // CLAIM_RELEASED (sender_type='sweep') for DEAD holders every few minutes, perpetually
+    // resetting this 5-min honor window and livelocking legitimate re-claims of a now-free SD.
+    // A sweep release means the holder is already dead — there is no live peer to yield to.
+    // Genuine peer/operator releases (and any null sender_type) are still honored.
+    .or('sender_type.is.null,sender_type.neq.sweep')
     .gte('created_at', cutoffIso)
     .order('created_at', { ascending: false })
     .limit(1);

--- a/tests/unit/claim-lifecycle-release.test.js
+++ b/tests/unit/claim-lifecycle-release.test.js
@@ -100,6 +100,17 @@ describe('FR-3: hasRecentClaimReleased READ-ONLY contract (AC-3.2)', () => {
     expect(src).not.toMatch(/\.eq\(['"]payload\.event_type/);
     expect(src).not.toMatch(/\.gte\(['"]payload\.event_type/);
   });
+
+  it('50615d1b: FR-3 inbox poll excludes sweep-originated releases', () => {
+    const src = readFileSync(HELPER_PATH, 'utf8');
+    const fnMatch = src.match(/export async function hasRecentClaimReleased[\s\S]*?^}/m);
+    expect(fnMatch).toBeTruthy();
+    const body = fnMatch[0];
+    // Sweep-emitted CLAIM_RELEASED (dead-holder reaping) must NOT keep the 5-min FR-3
+    // honor window alive — that livelocked re-claims of now-free SDs. Genuine peer/operator
+    // releases (and any null sender_type) are still honored.
+    expect(body).toMatch(/\.or\(['"]sender_type\.is\.null,sender_type\.neq\.sweep['"]\)/);
+  });
 });
 
 // ── AC-3.6: TTL_remaining formula via formatClaimReleasedAbort ────────────


### PR DESCRIPTION
All 148 CLAIM_RELEASED rows are sweep-emitted (dead-holder reaping), so FR-3's 5-min honor window never retired and re-claims of now-free SDs livelocked. Add `.or('sender_type.is.null,sender_type.neq.sweep')` to the read-only inbox poll; genuine peer/operator releases still honored. 18/18 unit + empirical 0 non-sweep rows. Closes feedback 50615d1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)