### PR TITLE
feat(SD-LEO-INFRA-LINT-METADATA-ORPHAN-001): metadata.is_* orphan/phantom flag lint

### DIFF
--- a/.github/workflows/metadata-flag-lint.yml
+++ b/.github/workflows/metadata-flag-lint.yml
@@ -1,0 +1,39 @@
+name: Metadata Flag Lint
+
+# SD-LEO-INFRA-LINT-METADATA-ORPHAN-001
+# Classifies every metadata.is_* flag as HEALTHY / ORPHAN / PHANTOM / SCAFFOLDING-ONLY
+# and fails on any un-allow-listed ORPHAN/PHANTOM flag.
+#
+# ADVISORY-FIRST (FR-6): the lint step is `continue-on-error: true` so it CANNOT turn an
+# in-flight parallel-session PR red on day one. The report is always surfaced in the job
+# log. Flip to blocking (remove continue-on-error) once the team has lived with it and the
+# allow-list has settled — tracked as a follow-up.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'database/migrations/**/*.sql'
+      - 'scripts/lint/metadata-flag-lint.mjs'
+      - 'scripts/lint/metadata-flag-allowlist.json'
+      - '.github/workflows/metadata-flag-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  metadata-flag-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Classify metadata.is_* flags (advisory)
+        continue-on-error: true
+        run: node scripts/lint/metadata-flag-lint.mjs

--- a/lib/sd/type-detection.js
+++ b/lib/sd/type-detection.js
@@ -110,7 +110,13 @@ export function isOrchestratorSync(sd) {
  * OR-merges:
  *   - sd.venture_id is set (canonical writer)
  *   - sd.sd_type === 'venture'  (rare; most ventures use other sd_types)
- *   - sd.metadata?.is_venture === true
+ *
+ * Note: a former `sd.metadata?.is_venture === true` branch was removed by
+ * SD-LEO-INFRA-LINT-METADATA-ORPHAN-001 (FR-5). The audit
+ * SD-LEO-INFRA-AUDIT-METADATA-ORPHAN-001 found metadata.is_venture is a PHANTOM
+ * read — nothing writes it in EHG_Engineer, and the shared ehg repo was swept with
+ * zero hits. Removing the dead branch is behavior-neutral: every real venture is
+ * identified by venture_id (or sd_type='venture').
  *
  * Note: sd_key prefix patterns (SD-VENTURE-*, SD-CRONGENIUS-*) are intentionally NOT
  * a signal here — sd_key prefixes drift (e.g., SD-CRONGENIUS-LEO-INFRA-* was
@@ -123,8 +129,7 @@ export function isVenture(sd) {
   if (!sd) return false;
   return (
     Boolean(sd.venture_id) ||
-    sd.sd_type === 'venture' ||
-    sd.metadata?.is_venture === true
+    sd.sd_type === 'venture'
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "protocol:lint:test": "node scripts/protocol-lint/cli.mjs test",
     "protocol:lint:promote": "node scripts/protocol-lint/cli.mjs promote",
     "protocol:lint:review": "node scripts/protocol-lint/cli.mjs review",
+    "lint:metadata-flags": "node scripts/lint/metadata-flag-lint.mjs",
     "test:smoke": "vitest run tests/smoke.test.js",
     "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs",
     "test:sd-key-generator-gate": "node --test tests/unit/sd-key-generator-coverage.test.mjs",

--- a/scripts/lint/metadata-flag-allowlist.json
+++ b/scripts/lint/metadata-flag-allowlist.json
@@ -1,0 +1,60 @@
+{
+  "_doc": "Allow-list for metadata-flag-lint.mjs (SD-LEO-INFRA-LINT-METADATA-ORPHAN-001). Each entry suppresses the CI FAIL for one ORPHAN/PHANTOM metadata.is_* flag and REQUIRES a non-empty reason. The flag is still REPORTED with its classification; the allow-list only stops it from failing the build. Prefer resolving a flag (add a real reader / remove a dead writer) over adding an entry. The entries below baseline the pre-existing findings from the one-time audit SD-LEO-INFRA-AUDIT-METADATA-ORPHAN-001 so the lint can fail on NEW orphan/phantom flags. Most are intentional provenance/informational metadata (written for debugging/denormalization, never branched on) or defensive optional reads whose canonical source is a real column.",
+  "allow": [
+    {
+      "flag": "is_async",
+      "classification": "ORPHAN",
+      "reason": "Informational provenance on uat_test_cases.metadata (scripts/lib/test-registrar.js) recording whether a scanned test case is async. Stored for audit/debugging only; no code branches on it."
+    },
+    {
+      "flag": "is_fallback",
+      "classification": "ORPHAN",
+      "reason": "Provenance on stage-18 artifact rows (server/routes/stage18.js) marking sections produced by the fallback copy path. Informational; not consumed as a behavioral flag in EHG_Engineer."
+    },
+    {
+      "flag": "is_phase_boundary",
+      "classification": "ORPHAN",
+      "reason": "Provenance tag on correction-task metadata (lib/tasks/correction-manager.js) marking a 'wall' task as a phase boundary. Informational; no reader branches on it."
+    },
+    {
+      "flag": "is_sub_parent",
+      "classification": "ORPHAN",
+      "reason": "One-time historical seed written into an SD's metadata by migration 20251206_vision_transition_parent_orchestrator.sql. Superseded by parent-orchestrator sd_type detection; never read."
+    },
+    {
+      "flag": "is_synthetic",
+      "classification": "ORPHAN",
+      "reason": "Provenance on synthetic-venture metadata (lib/eva/pipeline-runner/pipeline-executor.js) marking pipeline-generated test ventures. Consumed by the EHG venture app, not by EHG_Engineer (cross-repo reader the static scan cannot see)."
+    },
+    {
+      "flag": "is_warning",
+      "classification": "ORPHAN",
+      "reason": "Provenance on eva_event_log metadata (lib/eva/routing-state-machine.js) duplicating the row's severity='warning'. Informational; the canonical signal is the severity column."
+    },
+    {
+      "flag": "is_working_on",
+      "classification": "ORPHAN",
+      "reason": "Denormalized copy of the strategic_directives_v2.is_working_on COLUMN into the inbox-item payload (lib/inbox/unified-inbox-builder.js) for the dashboard UI. The canonical reader uses the real column, not metadata."
+    },
+    {
+      "flag": "is_emergency_hotfix",
+      "classification": "PHANTOM",
+      "reason": "Defensive fallback read: scripts/modules/adaptive-threshold-calculator.js and src/services/CalibrationService.js read `sd.is_emergency_hotfix || sd.metadata?.is_emergency_hotfix`. The canonical source is the sd.is_emergency_hotfix column read on the same line; the metadata branch is a harmless optional fallback."
+    },
+    {
+      "flag": "is_production_deployment",
+      "classification": "PHANTOM",
+      "reason": "Defensive fallback read: adaptive-threshold-calculator.js and CalibrationService.js read `sd.is_production_deployment || sd.metadata?.is_production_deployment || category includes 'production'`. Canonical source is the column / category; the metadata branch is a harmless optional fallback."
+    },
+    {
+      "flag": "is_orchestrator",
+      "classification": "PHANTOM",
+      "reason": "Optional escape-hatch read in an OR-chain (lib/sd/type-detection.js, scripts/orchestrator-preflight.js): `sd.metadata?.is_orchestrator === true`. Canonical orchestrator signals are sd_type='orchestrator', metadata.is_parent (HEALTHY), and child-count; the metadata.is_orchestrator branch is a harmless legacy optional."
+    },
+    {
+      "flag": "is_test",
+      "classification": "PHANTOM",
+      "reason": "metadata.is_test=true is set on test-harness SD fixtures (test code is excluded from the production scan by design). The production reader (scripts/modules/sd-next/display/*) intentionally filters those test SDs out of the queue/recommendations (QF-20260512-300)."
+    }
+  ]
+}

--- a/scripts/lint/metadata-flag-lint.mjs
+++ b/scripts/lint/metadata-flag-lint.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * metadata.is_* Orphan / Phantom Flag Lint
+ * SD-LEO-INFRA-LINT-METADATA-ORPHAN-001
+ *
+ * Codifies the one-time audit SD-LEO-INFRA-AUDIT-METADATA-ORPHAN-001 into a
+ * recurring lint. Statically classifies every `metadata.is_*` boolean flag by
+ * pairing its production WRITERS and READERS:
+ *
+ *   HEALTHY          writers >= 1 AND readers >= 1
+ *   ORPHAN           writers >= 1 AND readers == 0   (written, never read — dead write)
+ *   PHANTOM          writers == 0 AND readers >= 1   (read, never written — always undefined)
+ *   SCAFFOLDING-ONLY writers == 0 AND readers == 0   (defensive; not collected)
+ *
+ * Fails (exit 1) on any ORPHAN or PHANTOM flag not in the allow-list.
+ *
+ * Metadata-SCOPED matching keeps it low-noise: only `metadata.is_x` /
+ * `metadata->>'is_x'` reads and `is_x:` keys INSIDE a metadata object literal /
+ * jsonb writes count. Identically-named table columns (sd.is_active),
+ * plpgsql locals (is_venture_agent), and local result-objects
+ * (details: { is_orchestrator: true }) are NOT metadata flags and are ignored.
+ *
+ * Usage:
+ *   node scripts/lint/metadata-flag-lint.mjs [--json] [--root <dir>]
+ *   npm run lint:metadata-flags
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ALLOWLIST_PATH = path.join(__dirname, 'metadata-flag-allowlist.json');
+
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx', '.sql']);
+
+// Non-production paths: their writes/reads do NOT count toward classification.
+const EXCLUDE_DIR_SEGMENTS = [
+  'node_modules', '.git', '.worktrees', '.cursor', 'archive', 'one-off',
+  '__tests__', 'tests', 'test', 'coverage', 'dist', 'build', 'applications',
+  'press-kit', '.next', 'playwright-report',
+  'lint', // this tool + its allow-list/docs are not production metadata usage
+];
+const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;
+
+/** Strip comments so doc/example mentions of metadata.is_* never count as code. */
+export function stripComments(src, ext) {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, ' '); // block comments (JS + SQL)
+  if (ext === '.sql') out = out.replace(/--[^\n]*/g, ' '); // SQL line comments
+  else out = out.replace(/(^|[^:"'`\\])\/\/.*$/gm, '$1'); // JS line comments (guard :// and strings)
+  return out;
+}
+
+const FLAG = 'is_[a-z0-9_]+';
+
+// ── Pure extraction (exported for unit tests) ────────────────────────────────
+
+/** Capture the balanced {...} body starting at the first '{' at/after openFrom. */
+function extractBalanced(src, openFrom) {
+  const openIdx = src.indexOf('{', openFrom);
+  if (openIdx < 0) return '';
+  let depth = 0;
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return src.slice(openIdx, i + 1);
+  }
+  return src.slice(openIdx);
+}
+
+/** Object-literal bodies that ARE a metadata value (metadata: {...}, metadata = {...}, {...metadata, ...}). */
+function metadataObjectBodies(src) {
+  const bodies = [];
+  for (const re of [/\bmetadata\s*:\s*\{/g, /\bmetadata\s*=\s*\{/g]) {
+    let m;
+    while ((m = re.exec(src))) bodies.push(extractBalanced(src, m.index + m[0].length - 1));
+  }
+  // Spread of an existing metadata value into a new object literal. Recognizes
+  // `{ ...metadata }`, `{ ...row.metadata }`, and `{ ...(row?.metadata || {}) }`
+  // — the last form is common in update paths (e.g. coordinator.is_coordinator)
+  // and was previously a false-negative source.
+  const spread = /\{\s*\.\.\.\s*\(?\s*[\w$?.]*\bmetadata\b/g;
+  let s;
+  while ((s = spread.exec(src))) bodies.push(extractBalanced(src, s.index));
+  return bodies;
+}
+
+/** Extract metadata.is_* reads + writes from JS/TS source. Returns {reads:Set, writes:Set}. */
+export function extractFromJs(src) {
+  const reads = new Set();
+  const writes = new Set();
+
+  // READS: metadata.is_x / metadata?.is_x  (not the LHS of an assignment)
+  for (const m of src.matchAll(new RegExp(`\\bmetadata\\s*\\??\\.\\s*(${FLAG})\\b(?!\\s*=(?!=))`, 'gi'))) {
+    reads.add(m[1]);
+  }
+  // WRITES (assignment): metadata.is_x = ...
+  for (const m of src.matchAll(new RegExp(`\\bmetadata\\s*\\??\\.\\s*(${FLAG})\\s*=(?!=)`, 'gi'))) {
+    writes.add(m[1]);
+  }
+  // WRITES (object literal): is_x: ... or shorthand is_x , / } inside a metadata object body
+  for (const body of metadataObjectBodies(src)) {
+    for (const m of body.matchAll(new RegExp(`\\b(${FLAG})\\s*[:,}]`, 'gi'))) writes.add(m[1]);
+  }
+  return { reads, writes };
+}
+
+/** Extract metadata.is_* reads + writes from SQL source. Returns {reads:Set, writes:Set}. */
+export function extractFromSql(src) {
+  const reads = new Set();
+  const writes = new Set();
+  // READS: metadata->>'is_x' / metadata->'is_x'. The leading \b prevents matching the
+  // tail of a DIFFERENT jsonb column such as governance_metadata->>'is_x'.
+  for (const m of src.matchAll(new RegExp(`\\bmetadata\\s*->>?\\s*'(${FLAG})'`, 'gi'))) reads.add(m[1]);
+  // WRITES (jsonb_build_object): count only when the object is assigned into a metadata
+  // column, NOT a bare function-return payload (e.g. RETURN jsonb_build_object('is_claimed',
+  // ...)). Require a `metadata` token within the preceding window.
+  for (const m of src.matchAll(new RegExp(`jsonb_build_object\\s*\\(\\s*'(${FLAG})'`, 'gi'))) {
+    if (/\bmetadata\b/i.test(src.slice(Math.max(0, m.index - 80), m.index))) writes.add(m[1]);
+  }
+  // WRITES (jsonb_set path '{is_x}' and jsonb object literal "is_x":) — these forms occur
+  // only inside metadata-shaped jsonb (jsonb_set(metadata,'{is_x}',...) / '{"is_x": ...}').
+  for (const m of src.matchAll(new RegExp(`'\\{\\s*(${FLAG})\\s*\\}'`, 'gi'))) writes.add(m[1]);
+  for (const m of src.matchAll(new RegExp(`"(${FLAG})"\\s*:`, 'gi'))) writes.add(m[1]);
+  return { reads, writes };
+}
+
+// ── Pure classifier (exported for unit tests) ────────────────────────────────
+
+export const CLASSIFICATIONS = { HEALTHY: 'HEALTHY', ORPHAN: 'ORPHAN', PHANTOM: 'PHANTOM', SCAFFOLDING: 'SCAFFOLDING-ONLY' };
+
+/**
+ * @param {Map<string,number>|Object} writerCounts flag -> #writers
+ * @param {Map<string,number>|Object} readerCounts flag -> #readers
+ * @param {Set<string>} allow flags suppressed by the (validated) allow-list
+ * @returns {Array<{flag,writers,readers,classification,allowlisted,fail}>}
+ */
+export function classifyFlags(writerCounts, readerCounts, allow = new Set()) {
+  const w = writerCounts instanceof Map ? writerCounts : new Map(Object.entries(writerCounts));
+  const r = readerCounts instanceof Map ? readerCounts : new Map(Object.entries(readerCounts));
+  const flags = new Set([...w.keys(), ...r.keys()]);
+  const rows = [];
+  for (const flag of [...flags].sort()) {
+    const writers = w.get(flag) || 0;
+    const readers = r.get(flag) || 0;
+    let classification;
+    if (writers > 0 && readers > 0) classification = CLASSIFICATIONS.HEALTHY;
+    else if (writers > 0) classification = CLASSIFICATIONS.ORPHAN;
+    else if (readers > 0) classification = CLASSIFICATIONS.PHANTOM;
+    else classification = CLASSIFICATIONS.SCAFFOLDING;
+    const offending = classification === CLASSIFICATIONS.ORPHAN || classification === CLASSIFICATIONS.PHANTOM;
+    const allowlisted = allow.has(flag);
+    rows.push({ flag, writers, readers, classification, allowlisted, fail: offending && !allowlisted });
+  }
+  return rows;
+}
+
+// ── Allow-list loading (exported) ────────────────────────────────────────────
+
+/** Load + validate the allow-list. Every entry must carry a non-empty reason (AC-4). */
+export function loadAllowlist(p = ALLOWLIST_PATH) {
+  if (!fs.existsSync(p)) return { allow: new Set(), errors: [] };
+  let parsed;
+  try { parsed = JSON.parse(fs.readFileSync(p, 'utf8')); }
+  catch (e) { return { allow: new Set(), errors: [`allow-list is not valid JSON: ${e.message}`] }; }
+  const allow = new Set();
+  const errors = [];
+  for (const entry of parsed.allow || []) {
+    if (!entry || !entry.flag) { errors.push(`allow-list entry missing "flag": ${JSON.stringify(entry)}`); continue; }
+    if (!entry.reason || !String(entry.reason).trim()) { errors.push(`allow-list entry "${entry.flag}" missing a non-empty "reason"`); continue; }
+    allow.add(entry.flag);
+  }
+  return { allow, errors };
+}
+
+// ── Scanner ──────────────────────────────────────────────────────────────────
+
+function isExcluded(rel) {
+  const segs = rel.split(/[\\/]/);
+  if (segs.some((s) => EXCLUDE_DIR_SEGMENTS.includes(s))) return true;
+  if (EXCLUDE_FILE_RE.test(rel)) return true;
+  return false;
+}
+
+function* walk(dir, root) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    const rel = path.relative(root, full);
+    if (e.isDirectory()) {
+      if (EXCLUDE_DIR_SEGMENTS.includes(e.name)) continue;
+      yield* walk(full, root);
+    } else if (SCAN_EXTENSIONS.has(path.extname(e.name)) && !isExcluded(rel)) {
+      yield full;
+    }
+  }
+}
+
+/** Scan the tree and return {writers:Map, readers:Map} of metadata.is_* flags. */
+export function scanTree(root = REPO_ROOT) {
+  const writers = new Map();
+  const readers = new Map();
+  const bump = (map, flag) => map.set(flag, (map.get(flag) || 0) + 1);
+  for (const file of walk(root, root)) {
+    let src;
+    try { src = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (!src.includes('metadata')) continue;
+    const ext = path.extname(file);
+    const code = stripComments(src, ext);
+    const { reads, writes } = ext === '.sql' ? extractFromSql(code) : extractFromJs(code);
+    for (const f of reads) bump(readers, f);
+    for (const f of writes) bump(writers, f);
+  }
+  return { writers, readers };
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const rootArg = args.indexOf('--root');
+  const root = rootArg >= 0 ? path.resolve(args[rootArg + 1]) : REPO_ROOT;
+
+  const { allow, errors: allowErrors } = loadAllowlist();
+  const { writers, readers } = scanTree(root);
+  const rows = classifyFlags(writers, readers, allow);
+  const failing = rows.filter((r) => r.fail);
+
+  if (asJson) {
+    console.log(JSON.stringify({ rows, allowErrors, failing: failing.map((r) => r.flag) }, null, 2));
+  } else {
+    console.log('metadata.is_* flag classification\n' + '─'.repeat(64));
+    for (const r of rows) {
+      const tag = r.allowlisted ? ' [allow-listed]' : r.fail ? '  ❌ FAIL' : '';
+      console.log(`  ${r.classification.padEnd(16)} ${r.flag.padEnd(28)} w=${r.writers} r=${r.readers}${tag}`);
+    }
+    console.log('─'.repeat(64));
+    if (allowErrors.length) {
+      console.log('Allow-list errors:');
+      for (const e of allowErrors) console.log(`  ❌ ${e}`);
+    }
+    if (failing.length) {
+      console.log(`\n❌ ${failing.length} un-allow-listed ORPHAN/PHANTOM flag(s): ${failing.map((r) => r.flag).join(', ')}`);
+      console.log('   Resolve (add a writer / remove the dead reader) or add a justified allow-list entry.');
+    } else {
+      console.log('\n✅ No un-allow-listed ORPHAN/PHANTOM metadata flags.');
+    }
+  }
+
+  process.exit(failing.length > 0 || allowErrors.length > 0 ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/'))) {
+  main();
+}

--- a/tests/unit/metadata-flag-lint.test.js
+++ b/tests/unit/metadata-flag-lint.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for metadata.is_* orphan/phantom flag lint.
+ * SD-LEO-INFRA-LINT-METADATA-ORPHAN-001 — FR-7 / TS-1..TS-5, FR-3 FP guards, FR-4 allow-list.
+ *
+ * Pure-function tests (no fs/DB/network): exercise the exported classifier and the
+ * JS/SQL extractors, plus regression cases for the three matcher accuracy fixes
+ * (spread false-negative, governance_metadata suffix FP, jsonb return-payload FP).
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import {
+  extractFromJs,
+  extractFromSql,
+  classifyFlags,
+  loadAllowlist,
+  CLASSIFICATIONS,
+} from '../../scripts/lint/metadata-flag-lint.mjs';
+
+const byFlag = (rows, flag) => rows.find((r) => r.flag === flag);
+
+describe('classifyFlags (FR-1/FR-2 core classifier)', () => {
+  it('TS-1: synthetic ORPHAN (writer, no reader) -> ORPHAN and fails', () => {
+    const row = byFlag(classifyFlags({ is_orphan_x: 1 }, {}), 'is_orphan_x');
+    expect(row.classification).toBe(CLASSIFICATIONS.ORPHAN);
+    expect(row.fail).toBe(true);
+  });
+
+  it('TS-2: synthetic PHANTOM (reader, no writer) -> PHANTOM and fails', () => {
+    const row = byFlag(classifyFlags({}, { is_phantom_x: 1 }), 'is_phantom_x');
+    expect(row.classification).toBe(CLASSIFICATIONS.PHANTOM);
+    expect(row.fail).toBe(true);
+  });
+
+  it('TS-3: synthetic HEALTHY (writer + reader) -> HEALTHY and passes', () => {
+    const row = byFlag(classifyFlags({ is_h: 2 }, { is_h: 3 }), 'is_h');
+    expect(row.classification).toBe(CLASSIFICATIONS.HEALTHY);
+    expect(row.fail).toBe(false);
+  });
+
+  it('SCAFFOLDING-ONLY (neither) never fails', () => {
+    // Not produced by the scanner, but the classifier must treat it as non-failing.
+    const rows = classifyFlags(new Map(), new Map());
+    expect(rows.length).toBe(0);
+  });
+
+  it('TS-4: allow-listed PHANTOM passes (still classified PHANTOM)', () => {
+    const row = byFlag(classifyFlags({}, { is_p: 1 }, new Set(['is_p'])), 'is_p');
+    expect(row.classification).toBe(CLASSIFICATIONS.PHANTOM);
+    expect(row.allowlisted).toBe(true);
+    expect(row.fail).toBe(false);
+  });
+
+  it('FR-2 AC: exit-fail iff an un-allow-listed ORPHAN/PHANTOM exists', () => {
+    const rows = classifyFlags({ is_orphan_x: 1, is_h: 1 }, { is_phantom_x: 1, is_h: 1 });
+    const failing = rows.filter((r) => r.fail).map((r) => r.flag).sort();
+    expect(failing).toEqual(['is_orphan_x', 'is_phantom_x']);
+    // HEALTHY never fails:
+    expect(byFlag(rows, 'is_h').fail).toBe(false);
+  });
+
+  it('accepts plain objects or Maps for counts', () => {
+    const m = byFlag(classifyFlags(new Map([['is_m', 1]]), new Map([['is_m', 1]])), 'is_m');
+    expect(m.classification).toBe(CLASSIFICATIONS.HEALTHY);
+  });
+});
+
+describe('extractFromJs (FR-3 metadata-scoped JS matching)', () => {
+  it('counts is_x writes only inside a metadata object literal', () => {
+    const src = `await sb.from('t').insert({ metadata: { is_real: true, note: 'x' } });`;
+    const { writes } = extractFromJs(src);
+    expect(writes.has('is_real')).toBe(true);
+  });
+
+  it('reads metadata?.is_x and metadata.is_x', () => {
+    const src = `if (sd.metadata?.is_venture === true || other.metadata.is_thing) {}`;
+    const { reads } = extractFromJs(src);
+    expect(reads.has('is_venture')).toBe(true);
+    expect(reads.has('is_thing')).toBe(true);
+  });
+
+  it('TS-5 FP: a non-metadata result object (details: { is_orchestrator: true }) is NOT a write', () => {
+    const src = `const details = { is_orchestrator: true, kind: 'x' }; return details;`;
+    const { writes } = extractFromJs(src);
+    expect(writes.has('is_orchestrator')).toBe(false);
+  });
+
+  it('TS-5 FP: a plain column reference (sd.is_active) is NOT a metadata read', () => {
+    const src = `if (sd.is_active && sd.is_working_on) doThing();`;
+    const { reads } = extractFromJs(src);
+    expect(reads.has('is_active')).toBe(false);
+    expect(reads.has('is_working_on')).toBe(false);
+  });
+
+  it('regression: spread of an existing metadata value counts the new key (is_coordinator FN fix)', () => {
+    const src = `const merged = { ...(row?.metadata || {}), is_coordinator: true, ts: now() };`;
+    const { writes } = extractFromJs(src);
+    expect(writes.has('is_coordinator')).toBe(true);
+  });
+
+  it('regression: { ...row.metadata, is_x } also counts', () => {
+    const src = `return { ...row.metadata, is_flagged: true };`;
+    expect(extractFromJs(src).writes.has('is_flagged')).toBe(true);
+  });
+});
+
+describe('extractFromSql (FR-3 metadata-scoped SQL matching)', () => {
+  it('reads metadata->> and metadata-> jsonb paths', () => {
+    const src = `WHERE metadata->>'is_test' = 'true' OR metadata->'is_foo' IS NOT NULL`;
+    const { reads } = extractFromSql(src);
+    expect(reads.has('is_test')).toBe(true);
+    expect(reads.has('is_foo')).toBe(true);
+  });
+
+  it('counts a metadata jsonb_build_object write', () => {
+    const src = `UPDATE t SET metadata = jsonb_build_object('is_real', true);`;
+    expect(extractFromSql(src).writes.has('is_real')).toBe(true);
+  });
+
+  it('counts jsonb_set path and jsonb object-literal writes', () => {
+    const setSrc = `SELECT jsonb_set(metadata, '{is_sub_parent}', 'true');`;
+    expect(extractFromSql(setSrc).writes.has('is_sub_parent')).toBe(true);
+    const litSrc = `INSERT INTO t (metadata) VALUES ('{"is_seed": true}');`;
+    expect(extractFromSql(litSrc).writes.has('is_seed')).toBe(true);
+  });
+
+  it('TS-5 FP: governance_metadata->> path is NOT a metadata read (word-boundary fix)', () => {
+    const src = `WHERE governance_metadata->>'is_parent_change_history' = 'false'`;
+    expect(extractFromSql(src).reads.has('is_parent_change_history')).toBe(false);
+  });
+
+  it('FP: a bare RETURN jsonb_build_object payload is NOT a metadata write (window-scope fix)', () => {
+    const src = `IF x THEN RETURN jsonb_build_object('is_claimed', false, 'err', 'none'); END IF;`;
+    expect(extractFromSql(src).writes.has('is_claimed')).toBe(false);
+  });
+
+  it('TS-5 FP: a plpgsql local var is_venture_agent is NOT a metadata flag', () => {
+    const src = `DECLARE is_venture_agent boolean; BEGIN is_venture_agent := true; END;`;
+    const { reads, writes } = extractFromSql(src);
+    expect(reads.has('is_venture_agent')).toBe(false);
+    expect(writes.has('is_venture_agent')).toBe(false);
+  });
+});
+
+describe('loadAllowlist (FR-4)', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const liveAllowlist = path.resolve(__dirname, '../../scripts/lint/metadata-flag-allowlist.json');
+
+  it('the shipped allow-list loads without errors (every entry has a reason)', () => {
+    const { errors } = loadAllowlist(liveAllowlist);
+    expect(errors).toEqual([]);
+  });
+
+  it('a missing file yields an empty allow-list, no error', () => {
+    const { allow, errors } = loadAllowlist(path.resolve(__dirname, 'does-not-exist.json'));
+    expect(allow.size).toBe(0);
+    expect(errors).toEqual([]);
+  });
+});

--- a/tests/unit/sd-type-detection/sd-type-detection.test.js
+++ b/tests/unit/sd-type-detection/sd-type-detection.test.js
@@ -143,8 +143,12 @@ describe('isVenture / isVentureSync', () => {
     expect(isVenture({ sd_type: 'venture' })).toBe(true);
   });
 
-  it('returns true when metadata.is_venture === true', () => {
-    expect(isVenture({ metadata: { is_venture: true } })).toBe(true);
+  it('does NOT use metadata.is_venture (dead PHANTOM branch removed by SD-LEO-INFRA-LINT-METADATA-ORPHAN-001 / FR-5)', () => {
+    // metadata.is_venture had zero writers in EHG_Engineer and the shared ehg repo
+    // (audit SD-LEO-INFRA-AUDIT-METADATA-ORPHAN-001). The dead reader was removed;
+    // venture_id / sd_type='venture' remain the canonical signals.
+    expect(isVenture({ metadata: { is_venture: true } })).toBe(false);
+    expect(isVenture({ venture_id: 'v-1', metadata: { is_venture: true } })).toBe(true);
   });
 
   it('returns false when none of the venture signals are set', () => {


### PR DESCRIPTION
## Summary
Codifies the one-time audit `SD-LEO-INFRA-AUDIT-METADATA-ORPHAN-001` into a **recurring CI lint** that classifies every `metadata.is_*` flag as HEALTHY / ORPHAN / PHANTOM / SCAFFOLDING-ONLY (pairing production writers↔readers) and fails on un-allow-listed ORPHAN/PHANTOM flags — so new dead/phantom metadata flags are caught at PR time.

## What's included
- **scripts/lint/metadata-flag-lint.mjs** — metadata-scoped JS+SQL static analysis; pure exported functions for unit-testing.
- **scripts/lint/metadata-flag-allowlist.json** — baseline of 11 pre-existing findings, each with a justified reason (FR-4).
- **FR-5**: removed the dead `metadata.is_venture` reader branch in `lib/sd/type-detection.js` (PHANTOM; zero writers in EHG_Engineer and the swept ehg repo; behavior-neutral — regression-agent confirmed zero production callers).
- **FR-6**: `npm run lint:metadata-flags` + advisory-first CI workflow (`continue-on-error`).
- **FR-7**: 21 unit tests (synthetic ORPHAN/PHANTOM/HEALTHY/allow-listed + FP guards).

### Matcher accuracy fixes (verified each finding at its source)
- Recognize `{ ...(row?.metadata || {}), is_x }` spreads → fixed `is_coordinator` false-negative (now HEALTHY).
- Word-boundary SQL reads so `governance_metadata->>'is_x'` is not matched as `metadata`.
- Window-scope `jsonb_build_object` so RPC RETURN payloads (`is_claimed`) are not counted as metadata writes.

## Evidence
- TESTING (EXEC): PASS — 49 tests, lint exit 0
- VALIDATION (PLAN): PASS 95 · REGRESSION (PLAN): PASS 97
- Handoffs: EXEC-TO-PLAN 93, PLAN-TO-LEAD 97

🤖 Generated with [Claude Code](https://claude.com/claude-code)