### PR TITLE
chore: repoint Dropbox _EHG doc/script paths after folder reorg

### DIFF
--- a/kb/ehg-review/00_foundations_ops_instructions.md
+++ b/kb/ehg-review/00_foundations_ops_instructions.md
@@ -196,7 +196,7 @@ Transform startup ideas into validated, scalable, and strategically aligned vent
 - Database: `dedlbzhpgkmetvhbkyzq.supabase.co`
 - EHG App: `/mnt/c/_EHG/EHG`
 - EHG_Engineer: `/mnt/c/_EHG/EHG_Engineer`
-- Mission Source: `/mnt/c/Users/rickf/Dropbox/_EHG/_EHG/Mission_v3.txt`
+- Mission Source: `/mnt/c/Users/rickf/Dropbox/_EHG/10_strategy/Mission_v3.txt`
 
 ---
 

--- a/kb/ehg-review/04_governance_kpis_prompts.md
+++ b/kb/ehg-review/04_governance_kpis_prompts.md
@@ -602,7 +602,7 @@ Note: The Chairman is the ONLY human - all board members are AI agents
 ## Sources of Truth
 - **SDIP System**: Database tables directive_submissions, gate_tracking
 - **PRD Templates**: Database table prd_templates
-- **Stage KPIs**: `/mnt/c/Users/rickf/Dropbox/_EHG/_EHG/stage kpis.csv`
+- **Stage KPIs**: `/mnt/c/Users/rickf/Dropbox/_EHG/00_operating/kpis/stage kpis.csv`
 - **Pipeline Configuration**: CI/CD yaml files in repositories
 - **Dashboard Metrics**: Real-time from Supabase and monitoring systems
 - **Prompt Library**: Database table agent_prompts

--- a/scripts/archive/one-time/import-ehg-backlog-v2.js
+++ b/scripts/archive/one-time/import-ehg-backlog-v2.js
@@ -182,7 +182,7 @@ async function main() {
   if (options.file) {
     filePath = options.file;
   } else {
-    filePath = '/mnt/c/Users/rickf/Dropbox/_EHG/_EHG/EHG Backlog for Claude.xlsx';
+    filePath = '/mnt/c/Users/rickf/Dropbox/_EHG/00_operating/backlog/EHG Backlog for Claude.xlsx';
   }
   
   if (!fs.existsSync(filePath)) {

--- a/scripts/archive/one-time/import-ehg-backlog.js
+++ b/scripts/archive/one-time/import-ehg-backlog.js
@@ -172,7 +172,7 @@ async function main() {
   if (options.file) {
     filePath = options.file;
   } else {
-    filePath = '/mnt/c/Users/rickf/Dropbox/_EHG/_EHG/EHG Backlog for Claude.xlsx';
+    filePath = '/mnt/c/Users/rickf/Dropbox/_EHG/00_operating/backlog/EHG Backlog for Claude.xlsx';
   }
   
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
## What

The Dropbox `_EHG` docs folder was reorganized; the old double-nested `_EHG/_EHG/` location was redistributed. This repoints the **3 moved files** referenced in code:

| File reference | Old | New |
|---|---|---|
| `Mission_v3.txt` | `_EHG/_EHG/` | `_EHG/10_strategy/` |
| `stage kpis.csv` | `_EHG/_EHG/` | `_EHG/00_operating/kpis/` |
| `EHG Backlog for Claude.xlsx` | `_EHG/_EHG/` | `_EHG/00_operating/backlog/` |

## Files changed (4)
- `kb/ehg-review/00_foundations_ops_instructions.md` (Mission_v3.txt)
- `kb/ehg-review/04_governance_kpis_prompts.md` (stage kpis.csv)
- `scripts/archive/one-time/import-ehg-backlog.js` (EHG Backlog for Claude.xlsx)
- `scripts/archive/one-time/import-ehg-backlog-v2.js` (EHG Backlog for Claude.xlsx)

## Notes
- Preserves the WSL `/mnt/c/...` path style already used in each file.
- The unchanged `ehg ideas/` references were deliberately left intact.
- New target paths verified to exist on disk.
- A repo-wide grep confirmed these were the **only** code references to the old nested location — no unknown/unlisted moved files.
- The `ehg` repo had **zero** old-path references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)