### PR TITLE
fix(SD-LEO-INFRA-FIX-RESOLVESUBAGENTREPO-WINDOWS-001): canonicalize sub-agent evidence repo_path on Windows

### DIFF
--- a/lib/sub-agents/resolve-repo.js
+++ b/lib/sub-agents/resolve-repo.js
@@ -34,6 +34,7 @@ import {
   resolveRepoPathDbFirst,
   normalizeAppName,
   getRepoRoot,
+  stripWorktreeSuffix,
 } from '../repo-paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -62,6 +63,34 @@ function loadRegistry() {
  */
 export function clearRegistryCache() {
   _registry = null;
+}
+
+/**
+ * SD-LEO-INFRA-FIX-RESOLVESUBAGENTREPO-WINDOWS-001: canonicalize a resolved repo
+ * path for EVIDENCE storage so it byte-matches `applications.local_path` (the
+ * `v_sub_agent_repo_compliance` view compares `metadata->>'repo_path'` to
+ * `applications.local_path` by EXACT string equality).
+ *
+ * Two Windows-specific mismatches are normalized away:
+ *   1. Separators: resolveRepoPath/resolveRepoPathDbFirst return `path.resolve(...)`
+ *      which emits BACKSLASHES on Windows, while applications.local_path is stored
+ *      with forward slashes (e.g. "C:/Users/.../EHG_Engineer").
+ *   2. Worktree segment: ENGINEER_ROOT is module-location-derived, so when this
+ *      module loads from a `.worktrees/<sd>` checkout the resolved path is the
+ *      WORKTREE, not the main root — which both mismatches local_path AND can equal
+ *      executed_from_cwd (false `cwd_leak`). stripWorktreeSuffix collapses it to main.
+ *
+ * Evidence-only: callers still receive the un-normalized repoPath from
+ * resolveSubAgentRepo for filesystem scanning of in-progress worktree changes
+ * (intentional, see resolve-sub-agent-repo.test.js). No-op for an already-canonical
+ * POSIX main-root path (byte-identical).
+ *
+ * @param {string|null} p
+ * @returns {string|null}
+ */
+export function toCanonicalRepoPath(p) {
+  if (!p) return p;
+  return String(stripWorktreeSuffix(p)).replace(/\\/g, '/').replace(/\/+$/, '');
 }
 
 /**
@@ -193,7 +222,10 @@ export function applySubAgentRepoVerdict(results, resolution, opts = {}) {
 
   results.metadata = {
     ...(results.metadata || {}),
-    repo_path: resolution.repoPath,
+    // SD-LEO-INFRA-FIX-RESOLVESUBAGENTREPO-WINDOWS-001: canonicalize for the
+    // exact-equality gate comparison (Windows backslash + worktree-segment fix).
+    // executed_from_cwd below stays RAW so genuine cwd-leak detection is preserved.
+    repo_path: toCanonicalRepoPath(resolution.repoPath),
     repo_resolved: resolution.repoResolved,
     registry_source: resolution.registrySource,
     // eslint-disable-next-line no-process-cwd-in-sub-agents -- snapshot for PLAN-TO-EXEC CWD_LEAK detection; must be runtime cwd, not target_application path. Gate compares metadata.repo_path === executed_from_cwd to flag false-positive evidence rows.

--- a/tests/unit/resolve-sub-agent-repo.test.js
+++ b/tests/unit/resolve-sub-agent-repo.test.js
@@ -20,6 +20,7 @@ import {
   applySubAgentRepoVerdict,
   getSubAgentCapability,
   clearRegistryCache,
+  toCanonicalRepoPath,
 } from '../../lib/sub-agents/resolve-repo.js';
 
 describe('resolveSubAgentRepo', () => {
@@ -159,5 +160,58 @@ describe('applySubAgentRepoVerdict', () => {
     applySubAgentRepoVerdict(results, resolution);
     expect(results.verdict).toBe('CONDITIONAL_PASS');
     expect(results.metadata.probe_exists).toBe(false);
+  });
+});
+
+describe('toCanonicalRepoPath (SD-LEO-INFRA-FIX-RESOLVESUBAGENTREPO-WINDOWS-001)', () => {
+  it('normalizes a Windows worktree backslash path to the forward-slash main root', () => {
+    const wt = 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-XYZ-001';
+    expect(toCanonicalRepoPath(wt)).toBe('C:/Users/rickf/Projects/_EHG/EHG_Engineer');
+  });
+
+  it('converts backslashes to forward slashes for a main-root path (no worktree segment)', () => {
+    expect(toCanonicalRepoPath('C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer'))
+      .toBe('C:/Users/rickf/Projects/_EHG/EHG_Engineer');
+  });
+
+  it('is a no-op (byte-identical) for an already-canonical POSIX main-root path', () => {
+    const p = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+    expect(toCanonicalRepoPath(p)).toBe(p);
+  });
+
+  it('trims a trailing slash', () => {
+    expect(toCanonicalRepoPath('/home/u/ehg/')).toBe('/home/u/ehg');
+  });
+
+  it('passes null/empty through unchanged', () => {
+    expect(toCanonicalRepoPath(null)).toBeNull();
+    expect(toCanonicalRepoPath('')).toBe('');
+  });
+});
+
+describe('applySubAgentRepoVerdict evidence canonicalization (SD-LEO-INFRA-FIX-RESOLVESUBAGENTREPO-WINDOWS-001)', () => {
+  it('writes a forward-slash main-root repo_path from a Windows worktree resolution, keeping executed_from_cwd RAW', () => {
+    const results = { verdict: 'PASS', confidence: 100, warnings: [] };
+    const resolution = {
+      repoPath: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-XYZ-001',
+      repoResolved: true,
+      registrySource: 'registry',
+    };
+    applySubAgentRepoVerdict(results, resolution);
+    // Evidence path now byte-matches applications.local_path (view classifies 'compliant')
+    expect(results.metadata.repo_path).toBe('C:/Users/rickf/Projects/_EHG/EHG_Engineer');
+    // executed_from_cwd stays the raw runtime cwd so genuine cwd_leak detection is preserved
+    expect(results.metadata.executed_from_cwd).toBe(process.cwd());
+  });
+
+  it('does NOT coerce a genuinely-different repo path to a main root (equality contract not relaxed)', () => {
+    const results = { verdict: 'PASS', confidence: 100, warnings: [] };
+    const resolution = {
+      repoPath: 'C:\\Users\\rickf\\Projects\\_EHG\\some-other-venture',
+      repoResolved: true,
+      registrySource: 'db',
+    };
+    applySubAgentRepoVerdict(results, resolution);
+    expect(results.metadata.repo_path).toBe('C:/Users/rickf/Projects/_EHG/some-other-venture');
   });
 });


### PR DESCRIPTION
## Summary
- Fixes the live PLAN-TO-EXEC `SUB_AGENT_REPO_RESOLUTION` gate-blocker (harness backlog 09f02686).
- Root cause: `resolveRepoPath`/`ENGINEER_ROOT = path.resolve(__dirname,'..')` emit **backslashes** + the **worktree path** on Windows; the `v_sub_agent_repo_compliance` view compares by **exact string equality** to `applications.local_path` (forward-slash main root) → legitimate cross-repo (DESIGN/TESTING) evidence false-classifies as `violation`/`cwd_leak`.
- Fix: new `toCanonicalRepoPath` helper (reuses existing `stripWorktreeSuffix` + forces forward slashes) applied **only at the evidence write point** in `applySubAgentRepoVerdict`. Resolution stays worktree-relative (intentional FS scanning); `executed_from_cwd` stays raw (genuine cwd_leak detection preserved). **No view/migration/trigger change** — writer-side only.

## Test plan
- `tests/unit/resolve-sub-agent-repo.test.js` +7 regression tests (worktree→main-root normalization, byte-identical POSIX no-op, genuinely-wrong-path NOT coerced, executed_from_cwd raw).
- 19 resolve-repo + 20 gate tests green (39 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)