### PR TITLE
feat(SD-LEO-INFRA-STAGE-CODE-QUALITY-001): expand Stage-20 analyzer 4->8 finding categories

### DIFF
--- a/lib/eva/quality-findings/legacy-adapter.js
+++ b/lib/eva/quality-findings/legacy-adapter.js
@@ -26,6 +26,13 @@ const LEGACY_CHECK_MAP = Object.freeze({
   lint: 'lint',
   test_suite: 'test_suite',
   capability: 'capability',
+  // SD-LEO-INFRA-STAGE-CODE-QUALITY-001: the analyzer now emits these canonical
+  // QA + Vision-Compliance categories directly (identity map) so they persist
+  // under their own category instead of collapsing to the 'capability' fallback.
+  unit_test: 'unit_test',
+  e2e_test: 'e2e_test',
+  feedback_widget_present: 'feedback_widget_present',
+  error_capture_wired: 'error_capture_wired',
 });
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
@@ -12,8 +12,11 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { writeFile, lstat, unlink } from 'fs/promises';
+import { writeFile, lstat, unlink, readFile } from 'fs/promises';
 import path from 'path';
+// SD-LEO-INFRA-STAGE-CODE-QUALITY-001: reference the canonical category set so the
+// analyzer is structurally aware of every Stage-20 finding category (implemented + deferred).
+import { FINDING_CATEGORIES } from '../../quality-findings/finding-shape.js';
 // SD-LEO-INFRA-STAGE-QUALITY-ANALYZER-001 FR-A: adopt the canonical FindingShape
 // from the parent SD's foundation modules. Output is a parallel
 // `canonical_findings` array on the result so downstream FR-B (writer) can
@@ -51,9 +54,40 @@ function isSafeRepoUrl(url) {
   return SAFE_REPO_URL_RE.test(url);
 }
 
-const CHECK_TYPES = ['npm_audit', 'secret_detection', 'lint', 'test_suite'];
+// SD-LEO-INFRA-STAGE-CODE-QUALITY-001: expanded from 4 to 8 repo-scannable checks.
+// 'secret_detection' is the legacy emitted label for the canonical 'secrets' category.
+const CHECK_TYPES = [
+  'npm_audit', 'secret_detection', 'lint', 'test_suite',
+  'unit_test', 'e2e_test', 'feedback_widget_present', 'error_capture_wired',
+];
 const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low', 'info'];
 const VERDICT_OPTIONS = ['PASS', 'FAIL', 'WARN'];
+
+// SD-LEO-INFRA-STAGE-CODE-QUALITY-001: canonical category coverage.
+// Implemented here (repo-scannable): npm_audit, secrets (emitted as 'secret_detection'),
+// lint, test_suite, unit_test, e2e_test, feedback_widget_present, error_capture_wired.
+// DEFERRED to SD-LEO-INFRA-STAGE-ANALYZER-ADD-001 (DB-sourced UAT / environment,
+// NOT repo-scannable): uat_test, bug_report, uat_signoff, capability — they require
+// venture UAT/bug data-source design rather than scanning the cloned repo.
+const IMPLEMENTED_CANONICAL_CATEGORIES = Object.freeze([
+  'npm_audit', 'secrets', 'lint', 'test_suite',
+  'unit_test', 'e2e_test', 'feedback_widget_present', 'error_capture_wired',
+]);
+const DEFERRED_CANONICAL_CATEGORIES = Object.freeze(
+  FINDING_CATEGORIES.filter((c) => !IMPLEMENTED_CANONICAL_CATEGORIES.includes(c))
+);
+
+// Vision-Compliance "absence is the failure" severity. Kept as a single named
+// constant (currently 'medium' so it surfaces without flipping any currently-PASS
+// venture to WARN/FAIL) for an easy future chairman tightening.
+const VISION_ABSENCE_SEVERITY = 'medium';
+
+// package.json dependency-name fragments (matched case-insensitively as substrings)
+// that indicate each category's instrumentation is present.
+const FEEDBACK_WIDGET_SIGNATURES = ['@sentry/', 'logrocket', 'fullstory', '@fullstory/', 'hotjar', 'react-hotjar', 'userback', 'birdeatsbug'];
+const ERROR_CAPTURE_SIGNATURES = ['@sentry/', '@bugsnag/', 'bugsnag', 'rollbar', '@rollbar/', '@datadog/browser-rum', 'datadog-rum', 'airbrake', 'honeybadger'];
+const UNIT_TEST_SIGNATURES = ['vitest', 'jest', '@jest/', 'mocha', 'ava', 'tape', 'node-tap', 'jasmine', 'uvu'];
+const E2E_TEST_SIGNATURES = ['playwright', '@playwright/test', 'cypress', 'puppeteer', 'webdriverio', 'nightwatch', 'testcafe'];
 
 // Secret patterns to scan for (common API key formats)
 const SECRET_PATTERNS = [
@@ -273,6 +307,81 @@ async function runTestSuite(repoDir) {
 }
 
 /**
+ * SD-LEO-INFRA-STAGE-CODE-QUALITY-001: read package.json dependency names from a
+ * cloned repo dir. Pure fs read (no subprocess) for deterministic, sandbox-safe
+ * detection. Returns ok=false (not a throw) when package.json is absent/unparseable.
+ * @returns {Promise<{names: Set<string>, scripts: object, ok: boolean}>}
+ */
+async function readPackageDeps(repoDir) {
+  try {
+    const raw = await readFile(path.join(repoDir, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw);
+    const names = new Set(
+      [
+        ...Object.keys(pkg.dependencies || {}),
+        ...Object.keys(pkg.devDependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {}),
+        ...Object.keys(pkg.optionalDependencies || {}),
+      ].map((n) => n.toLowerCase())
+    );
+    return { names, scripts: pkg.scripts || {}, ok: true };
+  } catch {
+    return { names: new Set(), scripts: {}, ok: false };
+  }
+}
+
+function depsMatch(names, signatures) {
+  for (const dep of names) {
+    for (const sig of signatures) {
+      if (dep.includes(sig.toLowerCase())) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * QA — unit_test: detect a unit-test runner in package.json. Absence is a finding.
+ */
+export async function detectUnitTests(repoDir) {
+  const { names, ok } = await readPackageDeps(repoDir);
+  if (!ok) return [{ check: 'unit_test', title: 'No package.json — unit tests undetectable', severity: 'info', detail: 'Skipped unit-test detection (no package.json).' }];
+  if (depsMatch(names, UNIT_TEST_SIGNATURES)) return [];
+  return [{ check: 'unit_test', title: 'No unit-test runner detected', severity: 'medium', detail: `No unit-test runner (${UNIT_TEST_SIGNATURES.slice(0, 4).join(', ')}, ...) found in package.json dependencies.` }];
+}
+
+/**
+ * QA — e2e_test: detect an end-to-end framework in package.json. Absence is a finding (low).
+ */
+export async function detectE2eTests(repoDir) {
+  const { names, ok } = await readPackageDeps(repoDir);
+  if (!ok) return [{ check: 'e2e_test', title: 'No package.json — e2e tests undetectable', severity: 'info', detail: 'Skipped e2e-test detection (no package.json).' }];
+  if (depsMatch(names, E2E_TEST_SIGNATURES)) return [];
+  return [{ check: 'e2e_test', title: 'No end-to-end test framework detected', severity: 'low', detail: `No e2e framework (${E2E_TEST_SIGNATURES.slice(0, 3).join(', ')}, ...) found in package.json dependencies.` }];
+}
+
+/**
+ * Vision Compliance — feedback_widget_present: detect a user-feedback widget SDK.
+ * Absence is the failure (chairman mandate).
+ */
+export async function scanFeedbackWidget(repoDir) {
+  const { names, ok } = await readPackageDeps(repoDir);
+  if (!ok) return [{ check: 'feedback_widget_present', title: 'No package.json — feedback widget undetectable', severity: 'info', detail: 'Skipped feedback-widget detection (no package.json).' }];
+  if (depsMatch(names, FEEDBACK_WIDGET_SIGNATURES)) return [];
+  return [{ check: 'feedback_widget_present', title: 'No user-feedback widget detected', severity: VISION_ABSENCE_SEVERITY, detail: 'package.json has no feedback-widget SDK (Sentry feedback / LogRocket / FullStory / Hotjar / equivalent). Chairman Vision-Compliance mandate: ship a user-feedback channel.' }];
+}
+
+/**
+ * Vision Compliance — error_capture_wired: detect an error-capture SDK.
+ * Absence is the failure (chairman mandate).
+ */
+export async function scanErrorCapture(repoDir) {
+  const { names, ok } = await readPackageDeps(repoDir);
+  if (!ok) return [{ check: 'error_capture_wired', title: 'No package.json — error capture undetectable', severity: 'info', detail: 'Skipped error-capture detection (no package.json).' }];
+  if (depsMatch(names, ERROR_CAPTURE_SIGNATURES)) return [];
+  return [{ check: 'error_capture_wired', title: 'No error-capture SDK detected', severity: VISION_ABSENCE_SEVERITY, detail: 'package.json has no error-capture SDK (Sentry / Bugsnag / Rollbar / Datadog RUM / equivalent). Chairman Vision-Compliance mandate: wire error capture.' }];
+}
+
+/**
  * Main analysis function for S20 Code Quality Gate.
  */
 export async function analyzeStage20CodeQuality(params) {
@@ -338,15 +447,27 @@ export async function analyzeStage20CodeQuality(params) {
   }
 
   try {
-    // Run all 4 checks
-    const [auditFindings, secretFindings, lintFindings, testFindings] = await Promise.all([
+    // SD-LEO-INFRA-STAGE-CODE-QUALITY-001: run all 8 checks (4 code-review +
+    // 2 QA + 2 Vision-Compliance). The 4 new checks are package.json-based and
+    // emit canonical category names directly.
+    const [
+      auditFindings, secretFindings, lintFindings, testFindings,
+      unitFindings, e2eFindings, feedbackFindings, errorCaptureFindings,
+    ] = await Promise.all([
       runNpmAudit(clone.dir),
       runSecretScan(clone.dir),
       runLintCheck(clone.dir),
       runTestSuite(clone.dir),
+      detectUnitTests(clone.dir),
+      detectE2eTests(clone.dir),
+      scanFeedbackWidget(clone.dir),
+      scanErrorCapture(clone.dir),
     ]);
 
-    const allFindings = [...auditFindings, ...secretFindings, ...lintFindings, ...testFindings];
+    const allFindings = [
+      ...auditFindings, ...secretFindings, ...lintFindings, ...testFindings,
+      ...unitFindings, ...e2eFindings, ...feedbackFindings, ...errorCaptureFindings,
+    ];
 
     // FR-D AC-4.4: stamp every finding with sandbox provenance so downstream
     // consumers (FR-B persistence, FR-F aggregator) can reproduce the run.
@@ -395,6 +516,10 @@ export async function analyzeStage20CodeQuality(params) {
           secret_detection: secretFindings.length,
           lint: lintFindings.length,
           test_suite: testFindings.length,
+          unit_test: unitFindings.length,
+          e2e_test: e2eFindings.length,
+          feedback_widget_present: feedbackFindings.length,
+          error_capture_wired: errorCaptureFindings.length,
         },
       },
       checks_run: CHECK_TYPES.length,
@@ -495,4 +620,4 @@ function buildCloneFailedReport(ventureName, repoUrl, error) {
   };
 }
 
-export { CHECK_TYPES, SEVERITY_LEVELS, VERDICT_OPTIONS };
+export { CHECK_TYPES, SEVERITY_LEVELS, VERDICT_OPTIONS, DEFERRED_CANONICAL_CATEGORIES };

--- a/tests/unit/eva/stage-20-code-quality-categories.test.js
+++ b/tests/unit/eva/stage-20-code-quality-categories.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-STAGE-CODE-QUALITY-001
+ *
+ * Unit tests for the four new repo-scannable Stage-20 canonical finding
+ * categories added to the code-quality analyzer:
+ *   QA:                unit_test, e2e_test
+ *   Vision Compliance: feedback_widget_present, error_capture_wired  (absence = finding)
+ *
+ * Each detection function reads package.json from a synthetic fixture repo dir
+ * (no clone, no DB, no network) so the tests are fully deterministic. Also
+ * guards the legacy-adapter mapping so the new categories persist under their
+ * own canonical category instead of collapsing into the 'capability' fallback.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  detectUnitTests,
+  detectE2eTests,
+  scanFeedbackWidget,
+  scanErrorCapture,
+} from '../../../lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js';
+import { adaptLegacyBatch } from '../../../lib/eva/quality-findings/legacy-adapter.js';
+
+const createdDirs = [];
+
+async function repoWithPackage(pkg) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 's20cq-'));
+  createdDirs.push(dir);
+  await writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg ?? {}, null, 2), 'utf-8');
+  return dir;
+}
+
+async function emptyDir() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 's20cq-nopkg-'));
+  createdDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  for (const d of createdDirs) {
+    try { await rm(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describe('Stage-20 analyzer — QA + Vision-Compliance categories', () => {
+  it('detectUnitTests: absent runner -> medium finding; present -> no finding', async () => {
+    const absent = await detectUnitTests(await repoWithPackage({ devDependencies: { eslint: '^9' } }));
+    expect(absent).toHaveLength(1);
+    expect(absent[0].check).toBe('unit_test');
+    expect(absent[0].severity).toBe('medium');
+
+    const present = await detectUnitTests(await repoWithPackage({ devDependencies: { vitest: '^4' } }));
+    expect(present).toHaveLength(0);
+  });
+
+  it('detectE2eTests: absent -> low finding; present (@playwright/test) -> no finding', async () => {
+    const absent = await detectE2eTests(await repoWithPackage({ devDependencies: {} }));
+    expect(absent).toHaveLength(1);
+    expect(absent[0].check).toBe('e2e_test');
+    expect(absent[0].severity).toBe('low');
+
+    const present = await detectE2eTests(await repoWithPackage({ devDependencies: { '@playwright/test': '^1' } }));
+    expect(present).toHaveLength(0);
+  });
+
+  it('scanFeedbackWidget: no widget SDK -> finding; with LogRocket -> no finding', async () => {
+    const absent = await scanFeedbackWidget(await repoWithPackage({ dependencies: { react: '^18' } }));
+    expect(absent).toHaveLength(1);
+    expect(absent[0].check).toBe('feedback_widget_present');
+    expect(absent[0].severity).toBe('medium');
+
+    const present = await scanFeedbackWidget(await repoWithPackage({ dependencies: { logrocket: '^8' } }));
+    expect(present).toHaveLength(0);
+  });
+
+  it('scanErrorCapture: no error-capture SDK -> finding; with @sentry/react -> no finding', async () => {
+    const absent = await scanErrorCapture(await repoWithPackage({ dependencies: { react: '^18' } }));
+    expect(absent).toHaveLength(1);
+    expect(absent[0].check).toBe('error_capture_wired');
+    expect(absent[0].severity).toBe('medium');
+
+    const present = await scanErrorCapture(await repoWithPackage({ dependencies: { '@sentry/react': '^8' } }));
+    expect(present).toHaveLength(0);
+  });
+
+  it('no package.json -> info "undetectable" finding (graceful, not a hard failure)', async () => {
+    const r = await scanErrorCapture(await emptyDir());
+    expect(r).toHaveLength(1);
+    expect(r[0].severity).toBe('info');
+  });
+
+  it('adaptLegacyBatch maps the 4 new categories to canonical (not the capability fallback)', () => {
+    const legacy = [
+      { check: 'unit_test', title: 'no runner', severity: 'medium' },
+      { check: 'e2e_test', title: 'no e2e', severity: 'low' },
+      { check: 'feedback_widget_present', title: 'no widget', severity: 'medium' },
+      { check: 'error_capture_wired', title: 'no capture', severity: 'medium' },
+    ];
+    const { canonical } = adaptLegacyBatch(legacy, { venture_id: '00000000-0000-4000-8000-00000000abcd' });
+    const cats = canonical.map((c) => c.finding_category).sort();
+    expect(cats).toEqual(['e2e_test', 'error_capture_wired', 'feedback_widget_present', 'unit_test']);
+    expect(cats).not.toContain('capability');
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-20-code-quality.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-20-code-quality.test.js
@@ -235,8 +235,11 @@ describe('stage-20-code-quality.js — persistAnalyzerFindings', () => {
 });
 
 describe('stage-20-code-quality.js — constant exports', () => {
-  it('CHECK_TYPES enumerates exactly the 4 documented checks', () => {
-    expect(CHECK_TYPES).toEqual(['npm_audit', 'secret_detection', 'lint', 'test_suite']);
+  it('CHECK_TYPES enumerates the 8 documented checks (SD-LEO-INFRA-STAGE-CODE-QUALITY-001 expanded 4->8)', () => {
+    expect(CHECK_TYPES).toEqual([
+      'npm_audit', 'secret_detection', 'lint', 'test_suite',
+      'unit_test', 'e2e_test', 'feedback_widget_present', 'error_capture_wired',
+    ]);
   });
 
   it('SEVERITY_LEVELS covers the 5 npm-audit-compatible levels', () => {


### PR DESCRIPTION
## Summary
Expands the Stage-20 venture-pipeline code-quality analyzer from **4 to 8** repo-scannable canonical finding categories so the Stage-20 verdict reflects QA + Vision-Compliance, not code review alone:
- **QA**: `unit_test`, `e2e_test`
- **Vision Compliance** (chairman mandate — *absence is the finding*): `feedback_widget_present`, `error_capture_wired`

Each new check is a **deterministic package.json dependency scan** (pure `fs` read, no subprocess) emitting **≤ medium severity**, so the verdict (critical→FAIL / high→WARN / else PASS) is **unchanged for every currently-passing venture**.

## Changes
- `stage-20-code-quality.js`: +4 exported detection fns wired into the parallel run, `summary.by_check`, `CHECK_TYPES` (now 8); references canonical `FINDING_CATEGORIES`; exports `DEFERRED_CANONICAL_CATEGORIES`.
- `legacy-adapter.js`: **additively** maps the 4 new canonical categories into `LEGACY_CHECK_MAP` (else they'd collapse to the `capability` fallback).
- New deterministic synthetic-fixture unit tests (6/6); updated the `CHECK_TYPES` contract test 4→8.

## Scope (verify-first)
The canonical set is actually **12** categories (not the recorded 10). This SD ships the coherent **repo-scannable** slice; the **DB-sourced UAT** (`uat_test`, `bug_report`, `uat_signoff`) + environment `capability` categories are deferred to filed **SD-LEO-INFRA-STAGE-ANALYZER-ADD-001** (documented in code).

## Testing
6/6 new tests pass; broader Stage-20 suite **59 pass / 1 pre-existing failure** (stage-20-persistence TS-1 — fails identically on `main`, logged as harness feedback `7b730865`, out of scope). TESTING sub-agent PASS@95.

SD: SD-LEO-INFRA-STAGE-CODE-QUALITY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)