### PR TITLE
fix(SD-FDBK-INFRA-HARNESS-F22-STALE-001): WARN on stale CLAUDE_SESSION_ID (F22 reaped-ghost guard)

### DIFF
--- a/lib/session-identity-sot.js
+++ b/lib/session-identity-sot.js
@@ -516,7 +516,11 @@ export function discoverRepoRoot() {
  * @returns {{mismatch: true, envId: string, ambientId: string}|null}
  */
 export function detectEnvAmbientMismatch(options = {}) {
-  const { ccPid, env = process.env, repoRoot } = options;
+  const { ccPid, env = process.env } = options;
+  // Default to the canonical MAIN repo root (discoverRepoRoot strips /.worktrees/) so the
+  // pid marker resolves where capture-session-id wrote it even when called from a worktree
+  // cwd (the F22 resume scenario) - per adversarial-review finding.
+  const repoRoot = options.repoRoot || discoverRepoRoot();
   const envId = env.CLAUDE_SESSION_ID || null;
   if (!envId || !ccPid) return null;
   let ambientId = null;

--- a/lib/session-identity-sot.js
+++ b/lib/session-identity-sot.js
@@ -501,7 +501,36 @@ export function discoverRepoRoot() {
   }
 }
 
+/**
+ * SD-FDBK-INFRA-HARNESS-F22-STALE-001: detect a stale/hardcoded CLAUDE_SESSION_ID
+ * (the F22 reaped-ghost). Reads the pid-keyed marker for the CURRENT Claude Code
+ * process DIRECTLY (not via getTerminalId, which prefers the env var and would mask
+ * the stale id) and compares its session_id to env.CLAUDE_SESSION_ID. Flag-independent:
+ * the pid marker is written by capture-session-id regardless of SESSION_IDENTITY_SOT_ENABLED.
+ * Returns null (silent) when the ambient is unresolvable or matches.
+ *
+ * @param {object} [options]
+ * @param {number} [options.ccPid] - current Claude Code pid (from findClaudeCodePid())
+ * @param {object} [options.env=process.env]
+ * @param {string} [options.repoRoot]
+ * @returns {{mismatch: true, envId: string, ambientId: string}|null}
+ */
+export function detectEnvAmbientMismatch(options = {}) {
+  const { ccPid, env = process.env, repoRoot } = options;
+  const envId = env.CLAUDE_SESSION_ID || null;
+  if (!envId || !ccPid) return null;
+  let ambientId = null;
+  try {
+    const pidMarker = path.join(getIdentityDir(repoRoot), `pid-${ccPid}.json`);
+    const obj = JSON.parse(fs.readFileSync(pidMarker, 'utf8'));
+    ambientId = (obj && typeof obj.session_id === 'string') ? obj.session_id : null;
+  } catch { return null; }
+  if (!ambientId || ambientId === envId) return null;
+  return { mismatch: true, envId, ambientId };
+}
+
 export default {
+  detectEnvAmbientMismatch,
   FLAG_NAME,
   getIdentityDir,
   isEnabled,

--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -119,7 +119,7 @@ function scanForClaudeCodeProcess(ssePort) {
  *
  * @returns {string|null} The Claude Code process PID, or null if not found
  */
-function findClaudeCodePid() {
+export function findClaudeCodePid() {
   if (_cachedCCPid !== undefined) return _cachedCCPid;
 
   // Method 1: Walk the process ancestry chain

--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -10,6 +10,8 @@
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 import { createHandoffSystem } from '../index.js';
 import dotenv from 'dotenv';
+import { findClaudeCodePid } from '../../../../lib/terminal-identity.js';
+import { detectEnvAmbientMismatch } from '../../../../lib/session-identity-sot.js';
 
 // AUTO-PROCEED continuation imports
 import { getNextReadyChild, getOrchestratorContext } from '../child-sd-selector.js';
@@ -420,6 +422,17 @@ export async function handlePrecheckCommand(precheckType, precheckSdId) {
     return { success: false };
   }
 
+  // SD-FDBK-INFRA-HARNESS-F22-STALE-001: non-blocking WARN when CLAUDE_SESSION_ID != ambient (reaped ghost)
+  try {
+    const _f22 = detectEnvAmbientMismatch({ ccPid: findClaudeCodePid() });
+    if (_f22) {
+      console.warn('');
+      console.warn('⚠️  SESSION IDENTITY MISMATCH (F22): CLAUDE_SESSION_ID=' + _f22.envId + ' but this process ambient session is ' + _f22.ambientId + '.');
+      console.warn('   You may be operating under a stale/hardcoded session id (reaped ghost).');
+      console.warn('   Re-derive before continuing: export CLAUDE_SESSION_ID=' + _f22.ambientId);
+      console.warn('');
+    }
+  } catch { /* non-blocking */ }
   // SD-LEARN-FIX-ADDRESS-PAT-RETRO-001: Universal CLAUDE_SESSION_ID pre-flight check
   if (!process.env.CLAUDE_SESSION_ID) {
     console.warn('');
@@ -728,6 +741,17 @@ export async function handleExecuteCommand(handoffType, sdId, args) {
     }
   }
 
+  // SD-FDBK-INFRA-HARNESS-F22-STALE-001: non-blocking WARN when CLAUDE_SESSION_ID != ambient (reaped ghost)
+  try {
+    const _f22 = detectEnvAmbientMismatch({ ccPid: findClaudeCodePid() });
+    if (_f22) {
+      console.warn('');
+      console.warn('⚠️  SESSION IDENTITY MISMATCH (F22): CLAUDE_SESSION_ID=' + _f22.envId + ' but this process ambient session is ' + _f22.ambientId + '.');
+      console.warn('   You may be operating under a stale/hardcoded session id (reaped ghost).');
+      console.warn('   Re-derive before continuing: export CLAUDE_SESSION_ID=' + _f22.ambientId);
+      console.warn('');
+    }
+  } catch { /* non-blocking */ }
   // SD-LEARN-FIX-ADDRESS-PAT-RETRO-001: Universal CLAUDE_SESSION_ID pre-flight check
   if (!process.env.CLAUDE_SESSION_ID) {
     console.warn('');

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -28,6 +28,7 @@ import { assertValidClaim, ClaimIdentityError } from '../lib/claim-validity-gate
 // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001: FR-3 inbox poll + FR-2 sd_key drift detector
 import { hasRecentClaimReleased, formatClaimReleasedAbort, detectSdKeyDrift } from '../lib/claim-lifecycle-release.mjs';
 import sessionIdentitySot from '../lib/session-identity-sot.js';
+import { findClaudeCodePid } from '../lib/terminal-identity.js';
 import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
 // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — pre-claim multi-signal evidence-of-life gate.
 // Wraps claimGuard's heartbeat/inactive auto-release to prevent hostile reclaim
@@ -905,6 +906,14 @@ async function main() {
     // legacy identity path can still succeed. Disagreements surface at claim gate.
     console.warn(`${colors.yellow}⚠ session-identity reconciliation error (non-blocking): ${reconcileErr.message}${colors.reset}`);
   }
+
+  // SD-FDBK-INFRA-HARNESS-F22-STALE-001: non-blocking WARN when the env
+  // CLAUDE_SESSION_ID differs from this Claude Code process’s ambient session
+  // (a stale/hardcoded id self-heals into a reaped ghost — re-derive before claiming).
+  try {
+    const _f22 = sessionIdentitySot.detectEnvAmbientMismatch({ ccPid: findClaudeCodePid() });
+    if (_f22) console.warn(`${colors.yellow}⚠  SESSION IDENTITY MISMATCH (F22): CLAUDE_SESSION_ID=${_f22.envId} but this process’s ambient session is ${_f22.ambientId}. You may be operating under a stale/hardcoded session id (reaped ghost) — re-derive: export CLAUDE_SESSION_ID=${_f22.ambientId}${colors.reset}`);
+  } catch { /* non-blocking */ }
 
   // 2a-pre. SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-3: honor recent CLAIM_RELEASED
   // inbox messages BEFORE attempting any claim write. If a peer session has emitted

--- a/tests/unit/session-identity-mismatch.test.js
+++ b/tests/unit/session-identity-mismatch.test.js
@@ -1,0 +1,46 @@
+/**
+ * SD-FDBK-INFRA-HARNESS-F22-STALE-001 — detectEnvAmbientMismatch (the F22 guard).
+ *
+ * Verifies the non-blocking session-id-mismatch detector reads the pid-keyed marker
+ * DIRECTLY (the flag-independent ambient source) and compares it to the env
+ * CLAUDE_SESSION_ID — flagging a stale/hardcoded "reaped ghost" id, staying silent
+ * when sources match or the ambient is unresolvable.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { detectEnvAmbientMismatch, getIdentityDir } from '../../lib/session-identity-sot.js';
+
+function tmpRepoWithPidMarker(ccPid, sessionId) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'f22-'));
+  const dir = getIdentityDir(root);
+  fs.mkdirSync(dir, { recursive: true });
+  if (sessionId !== undefined) {
+    fs.writeFileSync(path.join(dir, `pid-${ccPid}.json`), JSON.stringify({ session_id: sessionId, cc_pid: ccPid }));
+  }
+  return root;
+}
+
+describe('detectEnvAmbientMismatch (F22 reaped-ghost guard)', () => {
+  it('returns mismatch when env CLAUDE_SESSION_ID differs from the pid-marker ambient', () => {
+    const root = tmpRepoWithPidMarker(12345, 'AMBIENT-uuid');
+    const r = detectEnvAmbientMismatch({ ccPid: 12345, env: { CLAUDE_SESSION_ID: 'STALE-uuid' }, repoRoot: root });
+    expect(r).toEqual({ mismatch: true, envId: 'STALE-uuid', ambientId: 'AMBIENT-uuid' });
+  });
+
+  it('returns null (silent) when env matches the ambient', () => {
+    const root = tmpRepoWithPidMarker(12345, 'SAME-uuid');
+    expect(detectEnvAmbientMismatch({ ccPid: 12345, env: { CLAUDE_SESSION_ID: 'SAME-uuid' }, repoRoot: root })).toBeNull();
+  });
+
+  it('returns null (silent) when no pid marker exists (ambient unresolvable)', () => {
+    const root = tmpRepoWithPidMarker(99999, undefined); // dir exists, no pid-12345 marker
+    expect(detectEnvAmbientMismatch({ ccPid: 12345, env: { CLAUDE_SESSION_ID: 'X' }, repoRoot: root })).toBeNull();
+  });
+
+  it('returns null when env unset or ccPid missing (non-blocking, no false positive)', () => {
+    expect(detectEnvAmbientMismatch({ ccPid: 1, env: {} })).toBeNull();
+    expect(detectEnvAmbientMismatch({ env: { CLAUDE_SESSION_ID: 'X' } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- F22: a stale/hardcoded `CLAUDE_SESSION_ID` in a resume/handoff prompt self-heals into a reaped ghost (stale heartbeat + dead pid) → claim livelock. Existing guards only warned when the var was *unset*, never when it *mismatched* the live ambient session.
- Adds non-blocking `detectEnvAmbientMismatch()` (lib/session-identity-sot.js) that reads the pid-keyed marker `.claude/session-identity/pid-<ccPid>.json` **directly** (the flag-independent ambient — getTerminalId/getIdentityCandidates prefer the env var and would mask the stale id) and compares to `CLAUDE_SESSION_ID`. Silent on match/unresolvable.
- Exported `findClaudeCodePid` (lib/terminal-identity.js); wired the WARN into `sd-start.js` + the handoff CLI (precheck + execute).
- **Verify-first**: the full SOT agreement machinery already exists but is dormant behind `SESSION_IDENTITY_SOT_ENABLED` (default off) — enabling it fleet-wide is out of scope; this is the lightweight flag-independent WARN the SD asked for. No claim/heartbeat/sweep change, no DB migration.

## Test plan
- `tests/unit/session-identity-mismatch.test.js` +4 (mismatch→warns, match→silent, no-marker→silent, unset/missing→silent).
- 53 session-identity tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)