### PR TITLE
feat(SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001): live-owner/dirty-tree worktree reapability guard

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -32,6 +32,8 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { enforceWorktreeQuota } from './worktree-quota.js';
+// SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-2): shared reapability guard.
+import { isReapable, logReapDecision } from './worktree-reapability.js';
 
 const WORKTREES_DIR = '.worktrees';
 
@@ -1373,13 +1375,32 @@ export function safeRecursiveCp(srcPath, destPath, options = {}) {
  * deletes the target contents. Mirrors the pre-unlink pattern that
  * safeRecursiveRm uses for fs.rmSync sites (PR #3590 / #3654).
  *
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-2): opt-in reapability guard.
+ * Reaper-like callers that remove OTHER sessions' worktrees pass `guard:true`
+ * (with `liveOwner` resolved from a fresh-heartbeat claim map) so a worktree
+ * owned by a live session OR holding uncommitted/unpushed work is SKIPPED — a
+ * safe no-op, never a destructive remove. Owner-initiated self-cleanup callers
+ * (post-merge cleanup, worktree-merge, eva fix-agent, the reaper which already
+ * classified) omit `guard`, so their behavior is byte-identical to before.
+ * A skip is NOT an error: it returns {ok:false, skipped:true, reason} even when
+ * allowFail is unset (the caller asked to guard, so a protective skip is expected).
+ *
  * @param {string} wtPath - Worktree directory path
  * @param {string} repoRoot - Main repo path (cwd for git)
- * @param {{ allowFail?: boolean }} [options] - allowFail returns {ok:false,error} instead of throwing
- * @returns {{ ok: boolean, error: string|null }}
+ * @param {{ allowFail?: boolean, guard?: boolean, liveOwner?: boolean, logger?: function }} [options]
+ *        allowFail returns {ok:false,error} instead of throwing; guard enables the
+ *        reapability check; liveOwner marks a fresh-heartbeat owner; logger sinks the skip line.
+ * @returns {{ ok: boolean, error: string|null, skipped?: boolean, reason?: string }}
  */
 export function removeWorktreeViaGit(wtPath, repoRoot, options = {}) {
-  const { allowFail = false } = options;
+  const { allowFail = false, guard = false, liveOwner = false, logger = console.warn } = options;
+  if (guard) {
+    const verdict = isReapable(wtPath, { liveOwner });
+    if (!verdict.reapable) {
+      logReapDecision({ worktree: wtPath, decision: 'skip', reason: verdict.reason }, logger);
+      return { ok: false, error: null, skipped: true, reason: verdict.reason };
+    }
+  }
   try {
     preUnlinkWorktreeNodeModules(wtPath);
     execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoRoot, stdio: 'pipe' });

--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -29,6 +29,9 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+// SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-4): shared reapability predicate,
+// used to exclude owned/dirty/unpushed dirs from the ORPHAN_DETECTED count.
+import { isReapable } from './worktree-reapability.js';
 
 export const MAX_WORKTREE_COUNT = 20;
 
@@ -152,25 +155,86 @@ export function countFilesystemWorktreeDirs(worktreesDir) {
 }
 
 /**
- * Emit a structured WARN log line if the filesystem count exceeds the
- * git-registered count — a signal that orphan directories are accumulating
- * under `.worktrees/`. Non-blocking: never throws, never changes flow. The
- * log is consumable by a future filesystem-reaper SD; for now it is a
- * visibility signal only.
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-4 / AC-3): classify the
+ * UNREGISTERED `.worktrees/` dirs into genuinely-reapable orphans
+ * (dead owner + clean tree + nothing unpushed) vs dirs that must NOT be counted
+ * as orphans because they are owned by a live session OR hold uncommitted/unpushed
+ * work. The raw `fsCount - registeredCount` arithmetic mis-counts the latter,
+ * inflating the ORPHAN_DETECTED signal — the same "7 orphan directories" warning
+ * that preceded the active-claim reaping incident. Reporting-accuracy only
+ * (never deletes; the orphan warning remains warning-only).
+ *
+ * @param {string} worktreesDir
+ * @param {Array<{path:string}>|string[]} [registered=[]] - git-registered worktrees (or paths)
+ * @param {{liveOwners?: Set<string>, gitRunner?: function}} [opts]
+ *        liveOwners: normalized paths owned by a fresh-heartbeat session.
+ * @returns {{reapable: number, excluded: Array<{dir:string, reason:string}>, total: number}}
+ */
+export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
+  const { liveOwners = new Set(), gitRunner } = opts;
+  if (!worktreesDir || !fs.existsSync(worktreesDir)) return { reapable: 0, excluded: [], total: 0 };
+  const registeredSet = new Set(
+    (registered || []).map((r) => normalizePath(typeof r === 'string' ? r : r.path))
+  );
+  let entries;
+  try { entries = fs.readdirSync(worktreesDir); } catch { return { reapable: 0, excluded: [], total: 0 }; }
+  const excluded = [];
+  let reapable = 0;
+  let total = 0;
+  for (const entry of entries) {
+    if (WORKTREE_QUOTA_HELPERS.has(entry)) continue;
+    const full = path.join(worktreesDir, entry);
+    try { if (!fs.statSync(full).isDirectory()) continue; } catch { continue; }
+    if (registeredSet.has(normalizePath(full))) continue; // registered → not an orphan
+    total++;
+    const normFull = normalizePath(full);
+    if (liveOwners.has(normFull)) { excluded.push({ dir: entry, reason: 'live_owner' }); continue; }
+    // A plain leftover dir (no .git) cannot carry its OWN uncommitted/unpushed
+    // state — git status from it would report the ENCLOSING repo — so it is a
+    // genuine reapable orphan. Only worktree-root dirs get the dirty/unpushed predicate.
+    if (!fs.existsSync(path.join(full, '.git'))) { reapable++; continue; }
+    const verdict = isReapable(full, { liveOwner: false, gitRunner });
+    if (verdict.reapable) reapable++;
+    else excluded.push({ dir: entry, reason: verdict.reason });
+  }
+  return { reapable, excluded, total };
+}
+
+/**
+ * Emit a structured WARN log line if orphan directories are accumulating under
+ * `.worktrees/`. Non-blocking: never throws, never changes flow.
+ *
+ * FR-4: when `options.worktreesDir` + `options.registered` are supplied, the
+ * reported orphan count counts ONLY genuinely-reapable dirs (owned/dirty/unpushed
+ * dirs are excluded, with a per-dir reason in the log). Without those options it
+ * falls back to the legacy `fsCount - registeredCount` arithmetic (back-compat).
  *
  * @param {number} fsCount - Filesystem directory count (from countFilesystemWorktreeDirs).
  * @param {number} registeredCount - Git-registered count (from countActiveWorktrees).
  * @param {(msg: string) => void} [logger=console.warn] - Emitter. Defaults to console.warn.
- * @returns {number} The orphan count (`fsCount - registeredCount`), or 0 when non-positive.
+ * @param {{worktreesDir?: string, registered?: Array, liveOwners?: Set<string>, gitRunner?: function}} [options]
+ * @returns {number} The (adjusted) orphan count, or 0 when non-positive.
  */
-export function emitOrphanWarningIfAny(fsCount, registeredCount, logger = console.warn) {
-  const orphanCount = Math.max(0, fsCount - registeredCount);
+export function emitOrphanWarningIfAny(fsCount, registeredCount, logger = console.warn, options = {}) {
+  const { worktreesDir, registered, liveOwners, gitRunner } = options;
+  let orphanCount = Math.max(0, fsCount - registeredCount);
+  let excludedNote = '';
+  if (worktreesDir && registered) {
+    const c = classifyOrphanDirs(worktreesDir, registered, { liveOwners, gitRunner });
+    orphanCount = c.reapable; // owned/dirty/unpushed dirs are NOT orphans
+    if (c.excluded.length > 0) {
+      excludedNote = ` (excluded ${c.excluded.length} owned/dirty/unpushed: ` +
+        c.excluded.map((e) => `${e.dir}:${e.reason}`).join(', ') + ')';
+    }
+  }
   if (orphanCount > 0) {
     logger(
       `[worktree-quota] ORPHAN_DETECTED: ${orphanCount} orphan directories ` +
-      `in .worktrees/ (fs=${fsCount}, git-registered=${registeredCount}). ` +
+      `in .worktrees/ (fs=${fsCount}, git-registered=${registeredCount})${excludedNote}. ` +
       `Run cleanup or invoke the reaper.`
     );
+  } else if (excludedNote) {
+    logger(`[worktree-quota] no reapable orphans${excludedNote}.`);
   }
   return orphanCount;
 }
@@ -207,10 +271,12 @@ export function createQuotaExceededError(count, max = MAX_WORKTREE_COUNT) {
  * @throws {Error} With errorCode `WORKTREE_QUOTA_EXCEEDED` when at/over limit.
  */
 export function enforceWorktreeQuota(repoRoot, worktreesDir, options = {}) {
-  const { max = MAX_WORKTREE_COUNT, logger = console.warn } = options;
-  const count = countActiveWorktrees(repoRoot);
+  const { max = MAX_WORKTREE_COUNT, logger = console.warn, liveOwners, gitRunner } = options;
+  // FR-4: reuse the registered list as both the quota count and classifier input.
+  const registered = listActiveWorktrees(repoRoot);
+  const count = registered.length;
   const fsCount = countFilesystemWorktreeDirs(worktreesDir);
-  const orphanCount = emitOrphanWarningIfAny(fsCount, count, logger);
+  const orphanCount = emitOrphanWarningIfAny(fsCount, count, logger, { worktreesDir, registered, liveOwners, gitRunner });
   if (count >= max) {
     throw createQuotaExceededError(count, max);
   }

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -1,0 +1,118 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — shared worktree reapability predicate.
+ *
+ * SINGLE SOURCE OF TRUTH for "is this worktree safe to remove?". Consumed by every
+ * worktree removal / cleanup path — the choke point `removeWorktreeViaGit`
+ * (lib/worktree-manager.js), the sweep reaper (scripts/worktree-reaper.mjs),
+ * concurrent-session cleanup (scripts/hooks/concurrent-session-worktree.cjs),
+ * cleanup-pending-sweep (scripts/cleanup-pending-sweep.mjs) — and the orphan-quota
+ * classifier (lib/worktree-quota.js), so the live-owner / dirty-tree / unpushed
+ * rule is implemented EXACTLY ONCE rather than re-derived ad hoc per path.
+ *
+ * Root defect (witnessed twice — CronGenius pilot ~2026-05-28 and
+ * SD-LEO-INFRA-LINT-METADATA-ORPHAN-001 on 2026-05-30): ad-hoc cleanup paths removed
+ * worktrees that belonged to a LIVE session or held UNCOMMITTED / UNPUSHED work,
+ * causing mid-EXEC data loss. A worktree is reapable ONLY when its owner is dead
+ * AND its tree is clean AND fully pushed.
+ *
+ * This module mirrors (and is the new home of) the dirty/unpushed helpers that
+ * previously lived locally inside scripts/worktree-reaper.mjs; the reaper now
+ * imports them from here so there is one canonical implementation.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const REAP_REASONS = Object.freeze({
+  LIVE_OWNER: 'live_owner',
+  DIRTY_TREE: 'dirty_tree',
+  UNPUSHED: 'unpushed',
+  ORPHAN_CLEAN: 'orphan_clean',
+});
+
+/** Resolve + forward-slash + lowercase, for cross-platform path-key comparison. */
+export function normalizePath(p) {
+  if (!p) return '';
+  try { return path.resolve(p).replace(/\\/g, '/').toLowerCase(); }
+  catch { return String(p).replace(/\\/g, '/').toLowerCase(); }
+}
+
+/** Default git runner: spawnSync, never throws, returns {stdout,stderr,code}. */
+export function runGit(args, cwd = process.cwd()) {
+  const res = spawnSync('git', args, {
+    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
+  });
+  return {
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+    code: res.status == null ? 1 : res.status,
+  };
+}
+
+/**
+ * Working-tree dirty status. Returns {dirtyCount, untracked, exists}.
+ * A non-existent path is reported as exists:false / dirtyCount:0 (nothing to lose).
+ */
+export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
+  if (!wtPath || !fs.existsSync(wtPath)) {
+    return { dirtyCount: 0, untracked: [], exists: false };
+  }
+  try {
+    const res = gitRunner(['status', '--porcelain', '--untracked-files=all'], wtPath);
+    if (res.code !== 0) return { dirtyCount: 0, untracked: [], exists: true };
+    const lines = (res.stdout || '').split('\n').filter(Boolean);
+    const untracked = [];
+    let dirty = 0;
+    for (const l of lines) {
+      dirty++;
+      if (l.startsWith('?? ')) untracked.push(l.slice(3).trim());
+    }
+    return { dirtyCount: dirty, untracked, exists: true };
+  } catch { return { dirtyCount: 0, untracked: [], exists: true }; }
+}
+
+/** Count commits on HEAD not yet pushed to the upstream (default origin/main). */
+export function countUnpushedCommits(wtPath, { gitRunner = runGit, upstream = 'origin/main' } = {}) {
+  if (!wtPath || !fs.existsSync(wtPath)) return 0;
+  try {
+    const res = gitRunner(['cherry', upstream, 'HEAD'], wtPath);
+    if (res.code !== 0) return 0;
+    return (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length;
+  } catch { return 0; }
+}
+
+/**
+ * THE shared reapability predicate. A worktree is reapable ONLY when ALL hold:
+ *   1. no live owner   — caller supplies `liveOwner` from a fresh-heartbeat claim map
+ *   2. clean tree      — no uncommitted/untracked changes
+ *   3. nothing unpushed — no commits ahead of the pushed upstream
+ *
+ * Reason precedence when NOT reapable: live_owner > dirty_tree > unpushed.
+ *
+ * @param {string} worktreePath
+ * @param {object} [opts]
+ * @param {boolean}  [opts.liveOwner=false] true if a fresh-heartbeat session owns this worktree
+ * @param {function} [opts.gitRunner]       injectable git runner (tests)
+ * @param {string}   [opts.upstream]        upstream ref for the unpushed check
+ * @returns {{reapable: boolean, reason: string}}
+ */
+export function isReapable(worktreePath, opts = {}) {
+  const { liveOwner = false, gitRunner = runGit, upstream = 'origin/main' } = opts;
+  if (liveOwner) return { reapable: false, reason: REAP_REASONS.LIVE_OWNER };
+  if (collectDirtyStatus(worktreePath, { gitRunner }).dirtyCount > 0) {
+    return { reapable: false, reason: REAP_REASONS.DIRTY_TREE };
+  }
+  if (countUnpushedCommits(worktreePath, { gitRunner, upstream }) > 0) {
+    return { reapable: false, reason: REAP_REASONS.UNPUSHED };
+  }
+  return { reapable: true, reason: REAP_REASONS.ORPHAN_CLEAN };
+}
+
+/**
+ * Structured skip-reason log line (FR-6). Emits a single machine-grep-able line
+ * describing a reap/skip decision so a stuck-quota condition is never silent.
+ * @param {object} logger - console-like (defaults to console.warn)
+ */
+export function logReapDecision({ worktree, decision, reason, ownerSession = null, heartbeatAgeS = null }, logger = console.warn) {
+  logger(`[reapability] ${JSON.stringify({ worktree: normalizePath(worktree), decision, reason, owner_session: ownerSession, heartbeat_age_s: heartbeatAgeS })}`);
+}

--- a/scripts/cleanup-pending-sweep.mjs
+++ b/scripts/cleanup-pending-sweep.mjs
@@ -52,6 +52,8 @@ import { createClient } from '@supabase/supabase-js';
 import {
   safeRecursiveRmWithRetry,
 } from '../lib/worktree-manager.js';
+// SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-3): shared reapability guard.
+import { isReapable } from '../lib/worktree-reapability.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -232,6 +234,18 @@ export async function processCleanupPendingQueue(supabase, opts = {}) {
           });
         }
       }
+      continue;
+    }
+
+    // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-3): defense-in-depth — a
+    // worktree flagged for cleanup may have been re-claimed and gained
+    // uncommitted/unpushed work since the flag was set. Re-check the shared
+    // reapability predicate at the moment of removal; skip (leave cleanup_pending
+    // for a later sweep / the preserve-before-delete reaper) if no longer safe.
+    const reap = isReapable(row.worktree_path);
+    if (!reap.reapable) {
+      summary.skippedUnsafe = (summary.skippedUnsafe || 0) + 1;
+      log(`${tag} SKIPPED_UNSAFE: ${reap.reason} — leaving cleanup_pending for a later sweep`);
       continue;
     }
 

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -469,6 +469,27 @@ async function cleanupStaleConcurrentWorktrees(supabase) {
           }
         } catch { /* status check failed — fall through to merge check */ }
 
+        // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-3): skip if the branch
+        // has commits NOT yet on origin/main (unpushed work). The `branch --merged
+        // main` check below consults LOCAL main, so a branch merged into a stale
+        // local main but never pushed could otherwise be removed and lose commits.
+        // Mirrors the shared isReapable() unpushed dimension
+        // (lib/worktree-reapability.js); inlined because this hook is CommonJS and
+        // the predicate module is ESM.
+        try {
+          const ahead = gitViaPowerShell(`-C "${wtPath}" rev-list --count origin/main..HEAD`, {
+            cwd: repoRoot, timeout: 3000
+          }).toString().trim();
+          const unpushed = parseInt(ahead, 10);
+          if (Number.isFinite(unpushed) && unpushed > 0) {
+            logEvent('session.cleanup_skipped_unpushed', {
+              entry, reason: 'unpushed_commits', unpushed_count: unpushed
+            });
+            skipped++;
+            continue;
+          }
+        } catch { /* rev-list failed — fall through to merge check (skips on uncertainty) */ }
+
         // Check if branch is merged into main
         const merged = gitViaPowerShell(`branch --merged main`, {
           cwd: repoRoot, timeout: 3000

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -186,6 +186,46 @@ if (process.env.TEST_DUMP_RESOLVED === '1') {
   process.exit(0);
 }
 
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-5/AC-6): detect whether THIS
+ * session is "stranded" — it holds an active SD claim whose provisioned worktree
+ * has been removed out from under it (reaped), leaving it operating on main.
+ *
+ * CONSERVATIVE by design: returns a strand descriptor ONLY on positive
+ * confirmation (a claim row whose worktree_path is set but no longer exists on
+ * disk). Missing creds, query failure, timeout, or no matching row → returns
+ * null, so the caller falls through to the unchanged hard block (fail-closed —
+ * the guard is never weakened for a session that genuinely chose to edit main).
+ *
+ * @param {string} sessionId
+ * @returns {Promise<{sd_key:string, worktree_path:string}|null>}
+ */
+async function detectStrandedClaim(sessionId) {
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey || !sessionId) return null;
+    const fs = require('fs');
+    const url = supabaseUrl +
+      '/rest/v1/strategic_directives_v2?claiming_session_id=eq.' +
+      encodeURIComponent(sessionId) + '&select=sd_key,worktree_path';
+    const resp = await Promise.race([
+      fetch(url, { headers: { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey } }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1500)),
+    ]);
+    if (!resp || !resp.ok) return null;
+    const rows = await resp.json();
+    for (const r of (Array.isArray(rows) ? rows : [])) {
+      if (r && r.worktree_path && !fs.existsSync(r.worktree_path)) {
+        return { sd_key: r.sd_key, worktree_path: r.worktree_path };
+      }
+    }
+    return null;
+  } catch {
+    return null; // any error → not confirmed → preserve the hard block
+  }
+}
+
 // --- WORKTREE CLAIM GUARD (PAT-CLMMULTI-001) ---
 // Regex to detect paths inside .worktrees/<SD-KEY>/
 const WORKTREE_PATH_RE = /[/\\]\.worktrees[/\\]([^/\\]+)/;
@@ -560,16 +600,39 @@ async function main() {
             branch = m ? m[1] : '';
           } catch { /* fail-open */ }
 
-          // (a) HARD BLOCK on main/master
+          // (a) HARD BLOCK on main/master — with FR-5 graceful strand recovery.
           if (branch === 'main' || branch === 'master') {
-            const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'WORKTREE-HYGIENE-MAIN', 'Edit/Write blocked on main/master', 'block', { branch, gitRoot });
-            process.stderr.write(
-              `WORKTREE HYGIENE GUARD: Edit/Write blocked on '${branch}'.\n` +
-              `  Run \`npm run session:worktree\` to create an isolated branch off origin/main.\n` +
-              `  If intentional (e.g., one-off doc fix), set LEO_WORKTREE_GUARD=off and retry.\n` +
-              `  Why: edits on main bypass branch isolation and force stash gymnastics at /ship.\n`
-            );
-            await auditAndExit(auditPromise, 2);
+            // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-5/AC-6): if THIS
+            // session holds an active claim whose provisioned worktree was reaped
+            // out from under it, it is stranded on main through no fault of its
+            // own — degrade to a WARNING so it can recover (write helpers, re-run
+            // sd-start) instead of being hard-locked into heredoc/bypass
+            // workarounds. The strand check runs ONLY here, on the already-
+            // exceptional main-branch edit path (the happy path — a feature branch
+            // inside a worktree — never reaches it), and degrades ONLY on positive
+            // confirmation; any uncertainty preserves the hard block.
+            // Flag-gated (FR-6): LEO_WORKTREE_STRAND_RECOVERY=off disables it.
+            const stranded = (process.env.LEO_WORKTREE_STRAND_RECOVERY !== 'off')
+              ? await detectStrandedClaim(_SESSION_ID)
+              : null;
+            if (stranded) {
+              auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'WORKTREE-HYGIENE-STRANDED', 'Stranded on main after worktree reaped — degraded to warn', 'warn', { branch, sd_key: stranded.sd_key, missing_worktree: stranded.worktree_path });
+              process.stderr.write(
+                `[worktree-hygiene] STRANDED-RECOVERY: your claimed worktree for ${stranded.sd_key} is gone\n` +
+                `  (${stranded.worktree_path}) — reaped out from under this session. Allowing this edit so\n` +
+                `  you can recover. Re-provision a fresh worktree with: node scripts/sd-start.js ${stranded.sd_key}\n`
+              );
+              // Fall through — do NOT block a session stranded through no fault of its own.
+            } else {
+              const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'WORKTREE-HYGIENE-MAIN', 'Edit/Write blocked on main/master', 'block', { branch, gitRoot });
+              process.stderr.write(
+                `WORKTREE HYGIENE GUARD: Edit/Write blocked on '${branch}'.\n` +
+                `  Run \`npm run session:worktree\` to create an isolated branch off origin/main.\n` +
+                `  If intentional (e.g., one-off doc fix), set LEO_WORKTREE_GUARD=off and retry.\n` +
+                `  Why: edits on main bypass branch isolation and force stash gymnastics at /ship.\n`
+              );
+              await auditAndExit(auditPromise, 2);
+            }
           }
 
           // (b) WARN-ONCE on inherited dirt + non-feature branch

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -58,6 +58,10 @@ import { createClient } from '@supabase/supabase-js';
 
 import { listActiveWorktrees } from '../lib/worktree-quota.js';
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../lib/worktree-manager.js';
+// SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
+// These three used to be defined locally below; the canonical home is now
+// lib/worktree-reapability.js so every removal path shares one implementation.
+import { normalizePath, collectDirtyStatus, countUnpushedCommits } from '../lib/worktree-reapability.js';
 import {
   isZombieOnMain,
   isNested,
@@ -350,11 +354,8 @@ function runGh(args, opts = {}) {
 
 // ── Core logic ─────────────────────────────────────────────────────────
 
-function normalizePath(p) {
-  if (!p) return '';
-  try { return path.resolve(p).replace(/\\/g, '/').toLowerCase(); }
-  catch { return String(p).replace(/\\/g, '/').toLowerCase(); }
-}
+// normalizePath, collectDirtyStatus, countUnpushedCommits now imported from
+// ../lib/worktree-reapability.js (SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001).
 
 function readMetadata(wtPath) {
   for (const name of ['.worktree.json', '.ehg-session.json']) {
@@ -369,32 +370,6 @@ function readMetadata(wtPath) {
 
 function isCursorWorktree(wtPath) {
   return /\.cursor[\\/]/i.test(wtPath) || /cursor[\\/]worktrees/i.test(wtPath);
-}
-
-function collectDirtyStatus(wtPath) {
-  if (!fs.existsSync(wtPath)) {
-    return { dirtyCount: 0, untracked: [], exists: false };
-  }
-  try {
-    const res = runGit(['status', '--porcelain', '--untracked-files=all'], { cwd: wtPath });
-    if (res.code !== 0) return { dirtyCount: 0, untracked: [], exists: true };
-    const lines = (res.stdout || '').split('\n').filter(Boolean);
-    const untracked = [];
-    let dirty = 0;
-    for (const l of lines) {
-      dirty++;
-      if (l.startsWith('?? ')) untracked.push(l.slice(3).trim());
-    }
-    return { dirtyCount: dirty, untracked, exists: true };
-  } catch { return { dirtyCount: 0, untracked: [], exists: true }; }
-}
-
-function countUnpushedCommits(wtPath) {
-  try {
-    const res = runGit(['cherry', 'origin/main', 'HEAD'], { cwd: wtPath });
-    if (res.code !== 0) return 0;
-    return (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length;
-  } catch { return 0; }
 }
 
 async function classifyWorktree(wt, ctx) {

--- a/tests/unit/pre-tool-enforce-strand-recovery.test.js
+++ b/tests/unit/pre-tool-enforce-strand-recovery.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — FR-5 / AC-6 + FR-6.
+ *
+ * FR-5 static guards: pre-tool-enforce.cjs runs main() on require (fail-open
+ * hook) so it cannot be required in-process; we pin the strand-recovery wiring
+ * statically so a regression that drops it (and re-hard-blocks a stranded
+ * session) fails CI. The guard MUST:
+ *   - confirm a strand via an active claim whose worktree_path no longer exists,
+ *   - degrade to a WARN (not block) ONLY on positive confirmation,
+ *   - run the strand check BEFORE the hard block, behind a flag, fail-closed.
+ *
+ * FR-6: logReapDecision emits a single structured (JSON) skip-reason line.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { logReapDecision } from '../../lib/worktree-reapability.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const hookSrc = readFileSync(join(repoRoot, 'scripts/hooks/pre-tool-enforce.cjs'), 'utf8');
+
+describe('FR-5 — pre-tool-enforce.cjs strand recovery (static guards)', () => {
+  it('defines detectStrandedClaim querying strategic_directives_v2 by claiming_session_id', () => {
+    expect(hookSrc).toMatch(/async function detectStrandedClaim\(/);
+    expect(hookSrc).toContain('claiming_session_id=eq.');
+    expect(hookSrc).toContain('worktree_path');
+  });
+
+  it('confirms a strand only when worktree_path no longer exists (fail-closed null otherwise)', () => {
+    expect(hookSrc).toMatch(/!fs\.existsSync\(r\.worktree_path\)/);
+    // Conservative: a catch / uncertain path returns null (preserves hard block).
+    expect(hookSrc).toMatch(/return null;\s*\/\/ any error/);
+  });
+
+  it('the strand check runs BEFORE the hard block on main', () => {
+    const strandIdx = hookSrc.indexOf('detectStrandedClaim(_SESSION_ID)');
+    const blockIdx = hookSrc.indexOf("'WORKTREE-HYGIENE-MAIN'");
+    expect(strandIdx).toBeGreaterThan(-1);
+    expect(blockIdx).toBeGreaterThan(-1);
+    expect(strandIdx).toBeLessThan(blockIdx);
+  });
+
+  it('degrades to a warn (WORKTREE-HYGIENE-STRANDED), not a block, when stranded', () => {
+    expect(hookSrc).toContain('WORKTREE-HYGIENE-STRANDED');
+    expect(hookSrc).toMatch(/STRANDED-RECOVERY/);
+  });
+
+  it('the hard-block path is preserved for the non-stranded case (still exit 2)', () => {
+    // The else branch must still hard-block via auditAndExit(..., 2).
+    expect(hookSrc).toMatch(/await auditAndExit\(auditPromise, 2\)/);
+  });
+
+  it('FR-6: strand recovery is flag-gated (LEO_WORKTREE_STRAND_RECOVERY)', () => {
+    expect(hookSrc).toContain('LEO_WORKTREE_STRAND_RECOVERY');
+  });
+});
+
+describe('FR-6 — logReapDecision structured skip-reason line', () => {
+  it('emits one JSON line containing decision + reason', () => {
+    const lines = [];
+    logReapDecision(
+      { worktree: '/tmp/.worktrees/SD-X', decision: 'skip', reason: 'dirty_tree' },
+      (m) => lines.push(m),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('[reapability]');
+    const json = lines[0].slice(lines[0].indexOf('{'));
+    const parsed = JSON.parse(json);
+    expect(parsed.decision).toBe('skip');
+    expect(parsed.reason).toBe('dirty_tree');
+    expect(parsed.worktree).toContain('/tmp/.worktrees/sd-x'); // normalized lowercase
+  });
+});

--- a/tests/unit/worktree-cleanup-paths-reapability-guard.test.js
+++ b/tests/unit/worktree-cleanup-paths-reapability-guard.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — FR-3 static guards.
+ *
+ * Pins that the two secondary defect paths apply a reapability guard before
+ * removing a worktree, so a regression that drops the guard fails CI:
+ *   - scripts/hooks/concurrent-session-worktree.cjs: skips on unpushed commits
+ *     (origin/main..HEAD), complementing its existing live-owner + dirty guards.
+ *   - scripts/cleanup-pending-sweep.mjs: re-checks the shared isReapable()
+ *     predicate immediately before safeRecursiveRmWithRetry.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFileSync(join(repoRoot, rel), 'utf8');
+
+describe('FR-3 — concurrent-session-worktree.cjs unpushed guard', () => {
+  const src = read('scripts/hooks/concurrent-session-worktree.cjs');
+
+  it('checks origin/main..HEAD before removing an SD-* worktree', () => {
+    expect(src).toMatch(/rev-list --count origin\/main\.\.HEAD/);
+  });
+
+  it('skips with an unpushed reason and continues (does not remove)', () => {
+    expect(src).toMatch(/cleanup_skipped_unpushed/);
+    expect(src).toContain('unpushed_commits');
+  });
+
+  it('the unpushed check precedes the destructive worktree remove', () => {
+    const guardIdx = src.indexOf('rev-list --count origin/main..HEAD');
+    // lastIndexOf: earlier matches are doc-comment mentions; the destructive
+    // gitViaPowerShell remove is the final occurrence.
+    const removeIdx = src.lastIndexOf('worktree remove --force');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(removeIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(removeIdx);
+  });
+});
+
+describe('FR-3 — cleanup-pending-sweep.mjs isReapable guard', () => {
+  const src = read('scripts/cleanup-pending-sweep.mjs');
+
+  it('imports the shared isReapable predicate', () => {
+    expect(src).toMatch(/import \{ isReapable \} from ['"]\.\.\/lib\/worktree-reapability\.js['"]/);
+  });
+
+  it('re-checks isReapable before safeRecursiveRmWithRetry', () => {
+    const guardIdx = src.indexOf('isReapable(row.worktree_path)');
+    const rmIdx = src.indexOf('safeRecursiveRmWithRetry(row.worktree_path)');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(rmIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(rmIdx);
+  });
+
+  it('skips unsafe worktrees with a logged reason', () => {
+    expect(src).toContain('SKIPPED_UNSAFE');
+  });
+});

--- a/tests/unit/worktree-manager-reapability-guard.test.js
+++ b/tests/unit/worktree-manager-reapability-guard.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — FR-2 / AC-1 / AC-2.
+ *
+ * Pins the opt-in reapability guard on the bare choke point removeWorktreeViaGit:
+ *   - guard:true + live owner   → SKIPPED no-op (never removed)        [AC-1]
+ *   - guard:true + dirty tree   → SKIPPED no-op, dir survives          [AC-2]
+ *   - guard:false (default)     → guard bypassed (byte-identical path) [back-compat]
+ *
+ * The exhaustive four-quadrant predicate logic is covered in
+ * worktree-reapability.test.js; this file covers the WIRING at the choke point.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { removeWorktreeViaGit } from '../../lib/worktree-manager.js';
+
+describe('removeWorktreeViaGit — FR-2 reapability guard wiring', () => {
+  it('guard:true + liveOwner → SKIPPED, never removes (deterministic, no git)', () => {
+    const bogus = path.join(os.tmpdir(), 'reap-guard-live-owner-does-not-exist');
+    const r = removeWorktreeViaGit(bogus, os.tmpdir(), {
+      guard: true, liveOwner: true, allowFail: true, logger: () => {},
+    });
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe('live_owner');
+    expect(r.ok).toBe(false);
+  });
+
+  it('guard:false (default) → guard bypassed, proceeds to git (no skipped flag)', () => {
+    // Bogus path: git worktree remove fails, allowFail catches it. The point is
+    // that the result is an ERROR (git ran), NOT a protective skip.
+    const bogus = path.join(os.tmpdir(), 'reap-guard-default-off-does-not-exist');
+    const r = removeWorktreeViaGit(bogus, os.tmpdir(), { allowFail: true });
+    expect(r.skipped).toBeUndefined();
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('removeWorktreeViaGit — FR-2 protects a DIRTY tree at the choke point (AC-2)', () => {
+  let repo;
+  beforeAll(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'reap-guard-dirty-'));
+    const opts = { cwd: repo, stdio: 'pipe' };
+    execSync('git init -q', opts);
+    execSync('git config user.email test@example.com', opts);
+    execSync('git config user.name test', opts);
+    execSync('git config commit.gpgsign false', opts);
+    fs.writeFileSync(path.join(repo, 'base.txt'), 'base\n');
+    execSync('git add base.txt', opts);
+    execSync('git commit -q -m base', opts);
+    // Make the tree DIRTY (uncommitted change) — the data-loss scenario.
+    fs.writeFileSync(path.join(repo, 'uncommitted.txt'), 'work in progress\n');
+  });
+  afterAll(() => { try { fs.rmSync(repo, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('guard:true on a dirty repo → SKIPPED (dirty_tree), directory + uncommitted file survive', () => {
+    const r = removeWorktreeViaGit(repo, repo, { guard: true, liveOwner: false, allowFail: true, logger: () => {} });
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe('dirty_tree');
+    // The uncommitted work was NOT destroyed.
+    expect(fs.existsSync(path.join(repo, 'uncommitted.txt'))).toBe(true);
+    expect(fs.readFileSync(path.join(repo, 'uncommitted.txt'), 'utf8')).toContain('work in progress');
+  });
+});

--- a/tests/unit/worktree-quota-orphan-classify.test.js
+++ b/tests/unit/worktree-quota-orphan-classify.test.js
@@ -1,0 +1,83 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — FR-4 / AC-3.
+ *
+ * The ORPHAN_DETECTED count must EXCLUDE dirs that are owned by a live session
+ * or hold uncommitted/unpushed work — they are not safe-to-reap orphans, and
+ * counting them inflated the "N orphan directories" warning that preceded the
+ * active-claim reaping incident. Plain leftover dirs (no .git) ARE genuine
+ * orphans and still count: such a dir cannot carry its own git state (git would
+ * report the enclosing repo), so only worktree-root dirs get the dirty/unpushed
+ * predicate.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { classifyOrphanDirs, emitOrphanWarningIfAny } from '../../lib/worktree-quota.js';
+
+const norm = (p) => path.resolve(p).replace(/\\/g, '/'); // mirrors quota-local normalizePath
+
+// Per-dir mock git: branch on cwd so each fixture worktree reports its own state.
+function mockGit(args, cwd) {
+  const c = norm(cwd);
+  if (args[0] === 'status') {
+    return { code: 0, stdout: c.includes('dirty-orphan') ? ' M work.js\n' : '', stderr: '' };
+  }
+  if (args[0] === 'cherry') {
+    return { code: 0, stdout: c.includes('unpushed-orphan') ? '+ abc123 wip\n' : '', stderr: '' };
+  }
+  return { code: 0, stdout: '', stderr: '' };
+}
+
+describe('worktree-quota — classifyOrphanDirs (FR-4)', () => {
+  let wtDir;
+  // worktree-root fixtures get a .git marker so the dirty/unpushed predicate runs;
+  // plain-leftover has NO .git (genuine orphan); registered-wt is filtered out.
+  const worktreeRoots = ['clean-orphan', 'dirty-orphan', 'unpushed-orphan', 'live-orphan', 'registered-wt'];
+  beforeAll(() => {
+    wtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'quota-orphan-'));
+    for (const d of worktreeRoots) {
+      fs.mkdirSync(path.join(wtDir, d));
+      fs.writeFileSync(path.join(wtDir, d, '.git'), 'gitdir: /fake\n');
+    }
+    fs.mkdirSync(path.join(wtDir, 'plain-leftover')); // no .git → genuine orphan
+  });
+  afterAll(() => { try { fs.rmSync(wtDir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('counts reapable orphans (clean worktree + plain leftover); excludes registered/dirty/unpushed/live', () => {
+    const registered = [{ path: path.join(wtDir, 'registered-wt') }];
+    const liveOwners = new Set([norm(path.join(wtDir, 'live-orphan'))]);
+    const r = classifyOrphanDirs(wtDir, registered, { liveOwners, gitRunner: mockGit });
+
+    // 5 unregistered dirs (registered-wt filtered out before classification).
+    expect(r.total).toBe(5);
+    // clean-orphan (predicate=clean) + plain-leftover (no .git) are reapable.
+    expect(r.reapable).toBe(2);
+    const byDir = Object.fromEntries(r.excluded.map((e) => [e.dir, e.reason]));
+    expect(byDir['dirty-orphan']).toBe('dirty_tree');
+    expect(byDir['unpushed-orphan']).toBe('unpushed');
+    expect(byDir['live-orphan']).toBe('live_owner');
+    expect(byDir['plain-leftover']).toBeUndefined(); // counted, not excluded
+    expect(byDir['registered-wt']).toBeUndefined();  // filtered, never classified
+  });
+
+  it('emitOrphanWarningIfAny with options reports the ADJUSTED (reapable-only) count', () => {
+    const registered = [{ path: path.join(wtDir, 'registered-wt') }];
+    const liveOwners = new Set([norm(path.join(wtDir, 'live-orphan'))]);
+    const logs = [];
+    // Legacy arithmetic (fs=6, registered=1) would say 5 orphans; adjusted = 2.
+    const adjusted = emitOrphanWarningIfAny(6, 1, (m) => logs.push(m), {
+      worktreesDir: wtDir, registered, liveOwners, gitRunner: mockGit,
+    });
+    expect(adjusted).toBe(2);
+    expect(logs.join('\n')).toMatch(/ORPHAN_DETECTED: 2 orphan/);
+    expect(logs.join('\n')).toMatch(/excluded 3 owned\/dirty\/unpushed/);
+  });
+
+  it('emitOrphanWarningIfAny WITHOUT options falls back to legacy arithmetic (back-compat)', () => {
+    const logs = [];
+    const n = emitOrphanWarningIfAny(5, 1, (m) => logs.push(m));
+    expect(n).toBe(4);
+    expect(logs.join('\n')).toMatch(/ORPHAN_DETECTED: 4 orphan/);
+  });
+});

--- a/tests/unit/worktree-reapability.test.js
+++ b/tests/unit/worktree-reapability.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 — FR-1 / AC-4 / AC-5.
+ *
+ * Four-quadrant matrix for the shared isReapable() predicate
+ * (live/dead owner × clean/dirty tree) plus the unpushed dimension and the
+ * "path gone" case. This is the single source of truth every removal path
+ * consults, so the truth table is pinned here.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  isReapable,
+  collectDirtyStatus,
+  countUnpushedCommits,
+  normalizePath,
+  REAP_REASONS,
+} from '../../lib/worktree-reapability.js';
+
+// Mock git runner: (args, cwd) -> { stdout, stderr, code }. Simulates a
+// dirty/clean working tree and N unpushed commits without touching real git.
+function mockGit({ dirty = false, unpushed = 0, statusCode = 0, cherryCode = 0 } = {}) {
+  return (args) => {
+    if (args[0] === 'status') {
+      return { code: statusCode, stdout: dirty ? ' M lib/file.js\n?? new.txt\n' : '', stderr: '' };
+    }
+    if (args[0] === 'cherry') {
+      const lines = Array.from({ length: unpushed }, (_, i) => `+ ${i}abc123 commit ${i}`).join('\n');
+      return { code: cherryCode, stdout: lines, stderr: '' };
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('worktree-reapability — isReapable four-quadrant matrix', () => {
+  let wt;
+  beforeAll(() => {
+    wt = fs.mkdtempSync(path.join(os.tmpdir(), 'reapability-'));
+  });
+  afterAll(() => {
+    try { fs.rmSync(wt, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('Q1 live owner + clean tree → NOT reapable (live_owner)', () => {
+    const r = isReapable(wt, { liveOwner: true, gitRunner: mockGit({ dirty: false }) });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.LIVE_OWNER);
+  });
+
+  it('Q2 live owner + dirty tree → NOT reapable (live_owner takes precedence over dirty)', () => {
+    const r = isReapable(wt, { liveOwner: true, gitRunner: mockGit({ dirty: true, unpushed: 3 }) });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.LIVE_OWNER);
+  });
+
+  it('Q3 dead owner + dirty tree → NOT reapable (dirty_tree)', () => {
+    const r = isReapable(wt, { liveOwner: false, gitRunner: mockGit({ dirty: true }) });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.DIRTY_TREE);
+  });
+
+  it('Q4 dead owner + clean tree + pushed → REAPABLE (orphan_clean, no-leak case)', () => {
+    const r = isReapable(wt, { liveOwner: false, gitRunner: mockGit({ dirty: false, unpushed: 0 }) });
+    expect(r.reapable).toBe(true);
+    expect(r.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+  });
+
+  it('dead owner + clean tree but UNPUSHED commits → NOT reapable (unpushed)', () => {
+    const r = isReapable(wt, { liveOwner: false, gitRunner: mockGit({ dirty: false, unpushed: 2 }) });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.UNPUSHED);
+  });
+
+  it('non-existent worktree path → reapable (nothing to lose)', () => {
+    const gone = path.join(wt, 'does-not-exist');
+    const r = isReapable(gone, { liveOwner: false, gitRunner: mockGit({ dirty: true, unpushed: 5 }) });
+    expect(r.reapable).toBe(true);
+    expect(r.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+  });
+});
+
+describe('worktree-reapability — helpers', () => {
+  let wt;
+  beforeAll(() => { wt = fs.mkdtempSync(path.join(os.tmpdir(), 'reapability-h-')); });
+  afterAll(() => { try { fs.rmSync(wt, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('collectDirtyStatus counts dirty + untracked lines', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: mockGit({ dirty: true }) });
+    expect(s.exists).toBe(true);
+    expect(s.dirtyCount).toBe(2);
+    expect(s.untracked).toContain('new.txt');
+  });
+
+  it('collectDirtyStatus on missing path → exists:false, dirtyCount:0', () => {
+    const s = collectDirtyStatus(path.join(wt, 'nope'), { gitRunner: mockGit({ dirty: true }) });
+    expect(s.exists).toBe(false);
+    expect(s.dirtyCount).toBe(0);
+  });
+
+  it('collectDirtyStatus treats a git error as non-dirty (fail-safe, never blocks)', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: mockGit({ statusCode: 128 }) });
+    expect(s.dirtyCount).toBe(0);
+  });
+
+  it('countUnpushedCommits counts only + lines from git cherry', () => {
+    expect(countUnpushedCommits(wt, { gitRunner: mockGit({ unpushed: 4 }) })).toBe(4);
+    expect(countUnpushedCommits(wt, { gitRunner: mockGit({ unpushed: 0 }) })).toBe(0);
+  });
+
+  it('normalizePath → forward-slash + lowercase + resolved', () => {
+    const n = normalizePath('C:\\\\Foo\\\\Bar');
+    expect(n).not.toContain('\\\\');
+    expect(n).toBe(n.toLowerCase());
+  });
+
+  it('REAP_REASONS is frozen', () => {
+    expect(Object.isFrozen(REAP_REASONS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the root defect behind a twice-witnessed data-loss incident: ad-hoc worktree cleanup paths removed worktrees owned by a LIVE session or holding uncommitted/unpushed work, destroying mid-EXEC work (CronGenius ~2026-05-28; SD-LEO-INFRA-LINT-METADATA-ORPHAN-001 on 2026-05-30).

A worktree is now reapable ONLY when its owner is dead AND its tree is clean AND nothing is unpushed — enforced through a single shared predicate.

## Changes (6 FRs)
- **FR-1** NEW `lib/worktree-reapability.js`: `isReapable(path,{liveOwner}) -> {reapable,reason}` + canonical helpers; reaper refactored to import them (single source of truth).
- **FR-2** `removeWorktreeViaGit` opt-in `{guard,liveOwner}` — reaper-like callers opt in; the 4 owner/flow callers stay byte-identical.
- **FR-3** `concurrent-session-worktree.cjs` (unpushed `origin/main..HEAD` check) + `cleanup-pending-sweep.mjs` (`isReapable` re-check before rm).
- **FR-4** `worktree-quota.js` `classifyOrphanDirs` excludes owned/dirty/unpushed worktree-root dirs from ORPHAN_DETECTED (the inflated count that preceded the incident); plain leftover dirs still count.
- **FR-5** `pre-tool-enforce.cjs` degrades the main-branch hard-block to a warn when a session's claimed worktree was reaped out from under it (fail-closed, flag-gated `LEO_WORKTREE_STRAND_RECOVERY`).
- **FR-6** structured skip-reason logging + flag-gated rollout.

## Tests
5 new files / 31 tests (four-quadrant matrix, real-git dirty-survival, orphan classifier, static guards). 106/106 across all touched areas; existing suites unchanged.

## Evidence (all PASS, gate-compliant)
REGRESSION 1b43f166/1d0d3cc0 · TESTING bdbf8bc7 · VALIDATION e301f128 (6/6 ACs) · DATABASE 508995c0 (no schema) · GITHUB 7da6d697 · retro 86c69e23 (100).

Handoffs: PLAN-TO-EXEC 95 · EXEC-TO-PLAN 90 · PLAN-TO-LEAD 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)