### PR TITLE
fix(SD-FDBK-ENH-PRE-TOOL-ENFORCE-001): content-discriminate edit-throttle signature

### DIFF
--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -109,7 +109,22 @@ function signatureFor(toolName, input, lastOutcome) {
   if (toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit') {
     const fp = typeof input.file_path === 'string' ? input.file_path : '';
     if (!fp) return null;
-    return `${toolName}:${fp}`;
+    // SD-FDBK-ENH-PRE-TOOL-ENFORCE-001: mix an edit-CONTENT digest so DISTINCT edits to the
+    // same file (a legit multi-part change) get DISTINCT signatures and do NOT accumulate as
+    // retries; only IDENTICAL re-attempts (same content - the true blind-retry signal) share a
+    // signature and trip the 3-strikes counter. Mirrors the Bash command+outcome admixture.
+    let contentKey = '';
+    if (toolName === 'Edit') {
+      const o = typeof input.old_string === 'string' ? input.old_string : '';
+      const n = typeof input.new_string === 'string' ? input.new_string : '';
+      contentKey = JSON.stringify([o, n]);
+    } else if (toolName === 'Write') {
+      contentKey = typeof input.content === 'string' ? input.content : '';
+    } else {
+      try { contentKey = JSON.stringify(input.edits || []); } catch { contentKey = ''; }
+    }
+    const cdig = crypto.createHash('sha256').update(contentKey).digest('hex').slice(0, 12);
+    return `${toolName}:${fp}:${cdig}`;
   }
   return null;
 }

--- a/tests/unit/retry-state-manager-signature.test.js
+++ b/tests/unit/retry-state-manager-signature.test.js
@@ -1,0 +1,56 @@
+/**
+ * SD-FDBK-ENH-PRE-TOOL-ENFORCE-001 — signatureFor() content discrimination.
+ *
+ * The RCA tiered-enforcement edit-throttle previously keyed Edit/Write/MultiEdit
+ * signatures on the FILE PATH ALONE, so 3 distinct edits to one file (a legit
+ * multi-part change) collided into one signature and false-tripped the 3-strikes
+ * block. signatureFor now mixes an edit-content digest: distinct edits → distinct
+ * signatures (no false retry), identical re-attempts → same signature (true retry
+ * still caught). Bash signatures are unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { signatureFor } = require('../../scripts/hooks/retry-state-manager.cjs');
+
+describe('signatureFor content discrimination (SD-FDBK-ENH-PRE-TOOL-ENFORCE-001)', () => {
+  it('Edit: distinct content to the SAME file → distinct signatures (no false retry)', () => {
+    const a = signatureFor('Edit', { file_path: 'a.js', old_string: 'X', new_string: 'Y' });
+    const b = signatureFor('Edit', { file_path: 'a.js', old_string: 'P', new_string: 'Q' });
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^Edit:a\.js:[0-9a-f]{12}$/);
+  });
+
+  it('Edit: IDENTICAL content to the same file → identical signature (true retry preserved)', () => {
+    const a = signatureFor('Edit', { file_path: 'a.js', old_string: 'X', new_string: 'Y' });
+    const b = signatureFor('Edit', { file_path: 'a.js', old_string: 'X', new_string: 'Y' });
+    expect(a).toBe(b);
+  });
+
+  it('Edit: same old_string but different new_string → distinct signatures', () => {
+    const a = signatureFor('Edit', { file_path: 'a.js', old_string: 'X', new_string: 'Y' });
+    const b = signatureFor('Edit', { file_path: 'a.js', old_string: 'X', new_string: 'Z' });
+    expect(a).not.toBe(b);
+  });
+
+  it('Write: distinct content → distinct signatures', () => {
+    const a = signatureFor('Write', { file_path: 'a.js', content: 'one' });
+    const b = signatureFor('Write', { file_path: 'a.js', content: 'two' });
+    expect(a).not.toBe(b);
+  });
+
+  it('MultiEdit: distinct edits → distinct signatures', () => {
+    const a = signatureFor('MultiEdit', { file_path: 'a.js', edits: [{ old_string: 'X', new_string: 'Y' }] });
+    const b = signatureFor('MultiEdit', { file_path: 'a.js', edits: [{ old_string: 'P', new_string: 'Q' }] });
+    expect(a).not.toBe(b);
+  });
+
+  it('Bash: signature format unchanged (no content-digest regression)', () => {
+    expect(signatureFor('Bash', { command: 'ls -la' })).toMatch(/^Bash:[0-9a-f]{16}$/);
+  });
+
+  it('Edit: missing file_path → null (unchanged guard)', () => {
+    expect(signatureFor('Edit', {})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The RCA tiered-enforcement edit-throttle (LEARN-129) keyed Edit/Write/MultiEdit signatures on **file-path alone**, so 3 *distinct* edits to one file (a normal multi-part change) collided into one signature and false-tripped the 3-strikes block — forcing `EMERGENCY_RCA_BYPASS` for routine work (dogfooded finding 957ec576).
- `signatureFor()` now mixes a sha256 **edit-content digest** (Edit: `JSON.stringify([old,new])`; Write: `content`; MultiEdit: `edits[]`), mirroring the existing Bash command+outcome admixture. Distinct edits → distinct signatures (no false retry); **identical re-attempts → same signature (true blind-retry still blocked)**; Bash unchanged.
- Worst case of the change is *under*-throttling an advisory guard — it can't block/break a session, which is why it's safe mid-fleet.

## Test plan
- `tests/unit/retry-state-manager-signature.test.js` +7 (distinct→distinct, identical→same, same-old/diff-new→distinct, Write distinct, MultiEdit distinct, Bash format unchanged, missing file_path→null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)