### PR TITLE
fix(SD-LEO-INFRA-CREATION-PATH-PRECISION-001): context-aware RISK_KEYWORDS escalation

### DIFF
--- a/lib/utils/work-item-router.js
+++ b/lib/utils/work-item-router.js
@@ -74,6 +74,79 @@ export function findRiskKeyword(text) {
   return match ? match[1].toLowerCase() : null;
 }
 
+// SD-LEO-INFRA-CREATION-PATH-PRECISION-001: descriptor suffixes that turn a risk word
+// into a topic adjective ("security-adjacent", "auth-related") rather than a change verb.
+export const RISK_DESCRIPTOR_SUFFIXES = [
+  'adjacent', 'related', 'sensitive', 'aware', 'focused', 'oriented',
+  'specific', 'conscious', 'centric', 'minded', 'agnostic', 'facing', 'like', 'style',
+];
+
+/**
+ * Context-aware risk detection (SD-LEO-INFRA-CREATION-PATH-PRECISION-001).
+ *
+ * Unlike schema nouns, risk keywords (security/auth/rls/payments/credentials) name a
+ * security SURFACE — mentioning it is itself a signal regardless of grammatical role.
+ * A verb-context guard (the schema approach) would be UNSAFE here: prospective
+ * testing-agent (evidence 7e299abc) proved a verb mirror suppresses ~11/12 genuine-risk
+ * phrases ("auth bypass", "rls policy", "rotate credentials", ...).
+ *
+ * So this helper INVERTS the schema model: default-escalate on ANY whole-word risk match,
+ * and suppress ONLY a narrow, enumerated set of provably-safe NOUN contexts. Fail-safe —
+ * if ANY occurrence is non-safe, escalate; ambiguous always escalates.
+ *
+ * Safe noun contexts (per occurrence):
+ *   (a) SQL clause: "SECURITY DEFINER" / "SECURITY INVOKER" (Postgres function attribute
+ *       naming the subject-under-test, not a security change).
+ *   (b) adjective compound: "<risk>-<descriptor>" / "<descriptor>-<risk>"
+ *       (e.g. "security-adjacent", "auth-related") — describes the topic, not the change.
+ *   (c) test-file path: the risk word is inside a *.test.* / *.spec.* path token
+ *       (e.g. "auth.test.js") — a reference to the thing under test.
+ *
+ * @param {string} text
+ * @returns {string|null} lowercased keyword to escalate on, or null when all matches are safe
+ */
+export function findRiskKeywordWithContext(text) {
+  if (!text || typeof text !== 'string') return null;
+  // Fast-exit: no risk keyword present at all.
+  if (!RISK_REGEX.test(text)) return null;
+
+  const rawTokens = text.split(/\s+/).filter(Boolean);
+  const strip = (s) => s.toLowerCase().replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
+
+  for (let i = 0; i < rawTokens.length; i++) {
+    const token = rawTokens[i];
+    const m = token.match(RISK_REGEX);
+    if (!m) continue; // token carries no risk word
+    const kw = m[1].toLowerCase();
+    const lowerToken = token.toLowerCase();
+
+    // (c) test-file path token: subject-under-test reference, not a risk change.
+    if (/\.(test|spec)\./.test(lowerToken) || /\.(test|spec)\.[a-z0-9]+$/.test(lowerToken)) {
+      continue;
+    }
+
+    // (b) adjective compound "<risk>-<descriptor>" / "<descriptor>-<risk>".
+    const cleaned = strip(token);
+    let compoundSafe = false;
+    for (const suf of RISK_DESCRIPTOR_SUFFIXES) {
+      if (cleaned === `${kw}-${suf}` || cleaned === `${suf}-${kw}`) { compoundSafe = true; break; }
+    }
+    if (compoundSafe) continue;
+
+    // (a) SQL clause "SECURITY DEFINER" / "SECURITY INVOKER".
+    if (kw === 'security') {
+      const next = rawTokens[i + 1] ? strip(rawTokens[i + 1]) : '';
+      if (next === 'definer' || next === 'invoker') continue;
+    }
+
+    // Genuine risk mention — escalate (fail-safe).
+    return kw;
+  }
+
+  // Every risk occurrence was a provably-safe noun context.
+  return null;
+}
+
 /**
  * Find the first schema-change keyword matching as a whole word in the given text.
  *
@@ -273,16 +346,17 @@ function checkRiskEscalation(input) {
 
   // Scan the focused fields (scope/keyChanges) by preference; fall back to
   // description with a warning. Schema branch uses verb-context per
-  // SD-LEO-INFRA-TIER-ESCALATOR-ROUTING-001; risk branch stays on word-boundary.
+  // SD-LEO-INFRA-TIER-ESCALATOR-ROUTING-001; risk branch uses context-aware noun-only suppression
+  // (SD-LEO-INFRA-CREATION-PATH-PRECISION-001: default-escalate, suppress only provably-safe noun contexts).
   const { text, source } = getRiskScanText(input);
   if (text) {
     const schemaMatch = findSchemaKeywordWithVerbContext(text);
     if (schemaMatch) {
       return `Schema change keyword detected (verb-context, source=${source}): "${schemaMatch}"`;
     }
-    const riskMatch = findRiskKeyword(text);
+    const riskMatch = findRiskKeywordWithContext(text);
     if (riskMatch) {
-      return `Security/risk keyword detected (source=${source}): "${riskMatch}"`;
+      return `Security/risk keyword detected (context-aware, source=${source}): "${riskMatch}"`;
     }
   }
 
@@ -378,4 +452,4 @@ export async function routeWorkItem(input, supabase) {
   return decision;
 }
 
-export default { routeWorkItem, getActiveThresholds, clearThresholdCache, findRiskKeyword, findSchemaKeyword, findSchemaKeywordWithVerbContext, RISK_KEYWORDS, SCHEMA_KEYWORDS, RISK_REGEX, SCHEMA_REGEX, VERBS, VERB_WINDOW };
+export default { routeWorkItem, getActiveThresholds, clearThresholdCache, findRiskKeyword, findRiskKeywordWithContext, RISK_DESCRIPTOR_SUFFIXES, findSchemaKeyword, findSchemaKeywordWithVerbContext, RISK_KEYWORDS, SCHEMA_KEYWORDS, RISK_REGEX, SCHEMA_REGEX, VERBS, VERB_WINDOW };

--- a/lib/utils/work-item-router.test.js
+++ b/lib/utils/work-item-router.test.js
@@ -355,3 +355,113 @@ test('getRiskScanText empty-string scope falls through to keyChanges/description
   assert.equal(result.source, 'keyChanges');
   assert.equal(result.text, 'add a helper');
 });
+
+// ============================================================================
+// SD-LEO-INFRA-CREATION-PATH-PRECISION-001 — context-aware RISK_KEYWORDS detection.
+// Default-escalate; suppress ONLY narrow provably-safe noun contexts. Fail-safe:
+// any non-safe occurrence escalates. Prospective testing-agent evidence 7e299abc.
+// ============================================================================
+
+import {
+  findRiskKeywordWithContext,
+  RISK_DESCRIPTOR_SUFFIXES,
+  routeWorkItem,
+  clearThresholdCache,
+} from './work-item-router.js';
+
+// ---------- CPP negative: provably-safe noun contexts are suppressed ----------
+
+test('CPP-NEG-1: "SECURITY DEFINER" subject-under-test does NOT escalate (QF-20260530-003 repro)', () => {
+  assert.equal(findRiskKeywordWithContext('Add unit test asserting the SECURITY DEFINER function returns expected rows'), null);
+});
+
+test('CPP-NEG-2: "SECURITY INVOKER" clause does NOT escalate', () => {
+  assert.equal(findRiskKeywordWithContext('Document the SECURITY INVOKER attribute behaviour'), null);
+});
+
+test('CPP-NEG-3: adjective compound "security-adjacent" does NOT escalate', () => {
+  assert.equal(findRiskKeywordWithContext('Refactor a security-adjacent helper for clarity'), null);
+});
+
+test('CPP-NEG-4: adjective compound "auth-related" does NOT escalate', () => {
+  assert.equal(findRiskKeywordWithContext('Rename an auth-related variable in the formatter'), null);
+});
+
+test('CPP-NEG-5: risk word inside a *.test.* / *.spec.* path token does NOT escalate', () => {
+  assert.equal(findRiskKeywordWithContext('Add coverage in lib/utils/auth.test.js for the parser'), null);
+  assert.equal(findRiskKeywordWithContext('Update rls.spec.ts snapshot'), null);
+});
+
+// ---------- CPP positive: genuine risk phrases STILL escalate (fail-safe) ----------
+
+test('CPP-POS-1: terse no-verb risk phrases still escalate', () => {
+  assert.equal(findRiskKeywordWithContext('auth bypass'), 'auth');
+  assert.equal(findRiskKeywordWithContext('rls policy'), 'rls');
+  assert.equal(findRiskKeywordWithContext('disable rls'), 'rls');
+  assert.equal(findRiskKeywordWithContext('rotate credentials'), 'credentials');
+  assert.equal(findRiskKeywordWithContext('grant authorization'), 'authorization');
+  assert.equal(findRiskKeywordWithContext('security review before merge'), 'security');
+  assert.equal(findRiskKeywordWithContext('payments webhook signature'), 'payments');
+});
+
+test('CPP-POS-2: no-verb genuine-risk "fix auth token rotation" still escalates (not verb-required)', () => {
+  assert.equal(findRiskKeywordWithContext('Fix auth token rotation in session daemon'), 'auth');
+});
+
+test('CPP-POS-3: bare risk tokens still escalate (ambiguous defaults to escalate)', () => {
+  assert.equal(findRiskKeywordWithContext('auth'), 'auth');
+  assert.equal(findRiskKeywordWithContext('rls'), 'rls');
+  assert.equal(findRiskKeywordWithContext('credentials'), 'credentials');
+});
+
+test('CPP-POS-4: a safe occurrence does NOT mask a genuine one (any non-safe escalates)', () => {
+  assert.equal(findRiskKeywordWithContext('Test the SECURITY DEFINER function and also add auth bypass handling'), 'auth');
+});
+
+test('CPP-POS-5: "auth-token" compound is NOT a safe descriptor (still escalates)', () => {
+  assert.equal(findRiskKeywordWithContext('Rotate the auth-token header'), 'auth');
+});
+
+// ---------- CPP contract: findRiskKeyword UNCHANGED (FR-3) ----------
+
+test('CPP-CONTRACT-1: findRiskKeyword retains old (context-free) semantics', () => {
+  assert.equal(findRiskKeyword('Refactor a security-adjacent helper'), 'security');
+  assert.equal(findRiskKeyword('the SECURITY DEFINER function'), 'security');
+});
+
+test('CPP-CONTRACT-2: findRiskKeywordWithContext malformed input returns null', () => {
+  assert.equal(findRiskKeywordWithContext(null), null);
+  assert.equal(findRiskKeywordWithContext(undefined), null);
+  assert.equal(findRiskKeywordWithContext(''), null);
+  assert.equal(findRiskKeywordWithContext(42), null);
+  assert.equal(findRiskKeywordWithContext({}), null);
+});
+
+test('CPP-EXPORT: default export includes findRiskKeywordWithContext + RISK_DESCRIPTOR_SUFFIXES', async () => {
+  const mod = await import('./work-item-router.js');
+  assert.equal(typeof mod.default.findRiskKeywordWithContext, 'function');
+  assert.ok(Array.isArray(mod.default.RISK_DESCRIPTOR_SUFFIXES));
+  assert.ok(RISK_DESCRIPTOR_SUFFIXES.includes('adjacent'));
+});
+
+// ---------- CPP end-to-end via routeWorkItem (tier outcome) ----------
+
+const _cppMockThresholds = {
+  from() { return { select() { return { eq() { return Promise.resolve({ data: [{ id: 'cpp-test', tier1_max_loc: 30, tier2_max_loc: 75 }], error: null }); } }; } }; },
+};
+
+test('CPP-E2E-1: low-LOC test-only item mentioning SECURITY DEFINER routes to Tier 1 (not forced Tier 3)', async () => {
+  clearThresholdCache();
+  const decision = await routeWorkItem({ estimatedLoc: 10, description: 'Add unit test asserting the SECURITY DEFINER function returns rows' }, _cppMockThresholds);
+  assert.equal(decision.tier, 1);
+  assert.equal(decision.escalationReason, null);
+  clearThresholdCache();
+});
+
+test('CPP-E2E-2: low-LOC genuine "auth bypass" item still forced to Tier 3', async () => {
+  clearThresholdCache();
+  const decision = await routeWorkItem({ estimatedLoc: 10, description: 'Add auth bypass handling to the gateway' }, _cppMockThresholds);
+  assert.equal(decision.tier, 3);
+  assert.match(decision.escalationReason, /auth/);
+  clearThresholdCache();
+});


### PR DESCRIPTION
## What
work-item-router forced **Tier-3 (full SD)** on any *noun-only* mention of a risk word (security/auth/rls/payments/credentials) — needlessly escalating test-only / non-risk work. Witnessed: **QF-20260530-003** escalated purely for `SECURITY DEFINER` (naming the function under test) / `security-adjacent`.

## Fix
Add `findRiskKeywordWithContext`: **default-escalate** on any whole-word risk match, suppress **ONLY** narrow provably-safe noun contexts:
- (a) `SECURITY DEFINER` / `SECURITY INVOKER` SQL clause
- (b) `<risk>-<descriptor>` adjective compounds (`security-adjacent`, `auth-related`)
- (c) `*.test.*` / `*.spec.*` path tokens

**Fail-safe:** any non-safe occurrence escalates; ambiguous always escalates. Deliberately **NOT** a mirror of the schema verb-context guard — prospective testing-agent (evidence `7e299abc`) proved that under-escalates ~11/12 genuine-risk phrases (`auth bypass`, `rls policy`, `rotate credentials`...). `findRiskKeyword` left intact (FR-3); `RoutingDecision` contract unchanged.

## Tests
+15 `node:test` cases (**60 total, was 45**): 5 negative (incl. QF-20260530-003 repro), 5 positive fail-safe (incl. no-verb `fix auth token rotation`, bare tokens, mixed safe+unsafe), 2 contract, 1 export, 2 `routeWorkItem` e2e. All green.

## Scope
FR2 (`child-parent promotion governance`) was undefined in the originating SD → de-scoped (Q8 deletion audit ~50%). Only `lib/utils/work-item-router.js` + its test changed; the 5 sibling files with their own `RISK_KEYWORDS` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)