### PR TITLE
feat(SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001): precheck-only verifier-parity gate so precheck predicts execute

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001.json
@@ -1,0 +1,132 @@
+{
+  "executive_summary": "The LEAD-TO-PLAN handoff is gated by TWO independent validation engines. Engine #1 is the gate chain in scripts/modules/handoff/executors/lead-to-plan/index.js::getRequiredGates() — the ONLY thing `handoff.js precheck` runs (via HandoffOrchestrator precheckValidationContext + validateGatesAll). Engine #2 is LeadToPlanVerifier (scripts/verify-l2p/index.js), invoked ONLY inside executeSpecific() at index.js:188-190 during `handoff.js execute`, AFTER the gate chain. The verifier applies blocking checks the gate chain does NOT: validateStrategicDirective completeness vs SD-type-aware effectiveMinScore, validateFeasibility, checkEnvironmentReadiness, and VALID_SD_STATUSES. Because precheck never runs the verifier, an SD can PASS precheck but FAIL execute — a handoff-integrity defect that wastes worker time (precheck green -> execute red -> confusing re-diagnosis). The SdMetricsSufficiencyGate (index.js:128) reconciled only the minimumMetrics check; the rest still diverge. FIX (additive, fleet-safe): add a NEW precheck-only gate that re-evaluates the verifier's PURE blocking checks side-effect-free so precheck PREDICTS execute. The gate runs ONLY when ctx.precheckMode===true (condition guard), so the execute path is byte-identical and no SD that passes execute today newly fails. Direct precedent: SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001 already surfaces execute-only checks in advisory precheckMode (HandoffOrchestrator.js:343-349). validation-agent confirmed: no duplicate active SD; the one sibling SD-PRIVACYPATROL-AI-FDBK-INFRA-UNIFY-LEAD-PLAN-001 (cancelled, administrative) proposed the INVERSE subtractive fix and is superseded by this safer additive approach.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Precheck predicts execute (verifier-parity at precheck)",
+      "description": "handoff.js precheck LEAD-TO-PLAN MUST evaluate the LeadToPlanVerifier's blocking checks (validateStrategicDirective completeness vs effectiveMinScore, validateFeasibility, checkEnvironmentReadiness, VALID_SD_STATUSES) and surface any failure as a precheck blocker, so precheck and execute report the same blocking verdict.",
+      "acceptance_criteria": [
+        "For an SD that fails the verifier's completeness/feasibility/status checks, precheck now reports the SAME blocking reason that execute would (previously precheck reported PASS)",
+        "For a fully-complete SD, precheck reports PASS and execute reports PASS (no false block introduced)",
+        "The parity gate reuses the verifier's OWN pure functions (validateStrategicDirective, validateFeasibility, checkEnvironmentReadiness) — not a reimplementation"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "Execute path byte-identical (precheck-only gate)",
+      "description": "The reconciliation MUST NOT change the execute path. The new gate runs ONLY during precheck (ctx.precheckMode===true) and is SKIPPED during execute; the LeadToPlanVerifier remains the sole execute-time enforcer.",
+      "acceptance_criteria": [
+        "The new gate declares a condition that returns true only when ctx.precheckMode===true",
+        "During execute (validateGates, precheckMode absent) the gate is skipped — verified by a test asserting the gate.condition is false for an execute-style context",
+        "No new blocking condition is added at execute; existing LEAD-TO-PLAN execute behavior/tests remain green",
+        "The gate performs NO DB writes (no createHandoffExecution/updateSdStatusAfterHandoff/rejectHandoff); it never calls verifier.verifyHandoff()"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "Parity correctness: orchestrator + threshold (the two validation-agent risks)",
+      "description": "The precheck parity check MUST match execute's verdict for the two known asymmetries: orchestrator auto-pass, and the SD-type-aware completeness threshold.",
+      "acceptance_criteria": [
+        "IR-1 (orchestrator): for sd_type==='orchestrator', the parity gate auto-passes at precheck (mirrors verifier _handleOrchestratorSd auto-pass) so orchestrators are NOT falsely blocked at precheck",
+        "IR-2 (threshold parity): the parity gate resolves effectiveMinScore via the SAME SD_TYPE_OVERRIDES path the verifier uses (verify-l2p/constants.js + index.js:105-109), so the completeness comparison matches execute exactly",
+        "A test covers an orchestrator SD passing precheck parity and a non-orchestrator marginal SD failing it"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "requirement": "Add scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.js exporting createVerifierParityGate(supabase). Validator: if sd_type==='orchestrator' -> pass; else run validateStrategicDirective(sd) (compare percentage to effectiveMinScore from SD_TYPE_OVERRIDES), validateFeasibility(sd), checkEnvironmentReadiness(supabase, sd, root), and VALID_SD_STATUSES membership; aggregate failures into issues[]; passed=false if any blocking check fails."
+    },
+    {
+      "id": "TR-2",
+      "requirement": "Gate carries condition: (ctx) => ctx.precheckMode === true (precheck-only). Wire createVerifierParityGate into getRequiredGates() in lead-to-plan/index.js. Reuse imports from ../../../../verify-l2p/sd-validation.js, ../../../../verify-l2p/environment.js, and ../../../../verify-l2p/constants.js (SD_REQUIREMENTS, SD_TYPE_OVERRIDES, VALID_SD_STATUSES)."
+    },
+    {
+      "id": "TR-3",
+      "requirement": "Tests use node:test + node:assert/strict. Add gates/verifier-parity.test.js with: marginal-SD-fails, complete-SD-passes, orchestrator-auto-pass, condition-false-at-execute, no-DB-writes (spy/mock supabase asserting only reads)."
+    },
+    {
+      "id": "TR-4",
+      "requirement": "No migration, no schema change, no edit to verify-l2p/* or BaseExecutor execute path. Scope limited to the new gate file, its test, and the getRequiredGates() wiring line in lead-to-plan/index.js. Do NOT thread handoffType into contexts (separate deferred concern — see SD metadata)."
+    }
+  ],
+  "system_architecture": {
+    "overview": "precheck (HandoffOrchestrator.precheckHandoff -> validateGatesAll over the LEAD-TO-PLAN gate chain, precheckMode=true, no writes) currently runs ONLY engine #1. execute (BaseExecutor -> validateGates over the same chain, THEN executeSpecific -> LeadToPlanVerifier.verifyHandoff) runs engine #1 + engine #2. The new precheck-only verifier-parity gate replays engine #2's pure blocking checks during precheck so the two paths agree on the blocking verdict.",
+    "data_flow": "precheck: precheckValidationContext{precheckMode:true, sd, supabase} -> validateGatesAll -> [gate.condition(ctx)===true?] verifier-parity gate -> {validateStrategicDirective vs effectiveMinScore, validateFeasibility, checkEnvironmentReadiness, status} -> passed|issues. execute: validationContext{no precheckMode} -> gate skipped via condition -> verifier runs unchanged in executeSpecific.",
+    "contract": "No external contract change. Gate result shape {passed, score, max_score, issues, warnings, details} matches the existing gate framework. The verifier's pure functions keep their signatures.",
+    "consumers": [
+      "scripts/modules/handoff/HandoffOrchestrator.js (precheckHandoff -> validateGatesAll: runs the new gate)",
+      "scripts/modules/handoff/executors/lead-to-plan/index.js (getRequiredGates: registers the new gate)"
+    ],
+    "out_of_scope_files": [
+      "scripts/verify-l2p/index.js (verifier orchestration + DB writes — unchanged)",
+      "scripts/modules/handoff/executors/BaseExecutor.js (execute path — unchanged)",
+      "scripts/modules/handoff/gates/subagent-evidence-gate.js (inert-gate handoffType fix is a deferred high-blast-radius concern)"
+    ]
+  },
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Marginal SD (fails verifier completeness or feasibility) -> verifier-parity gate FAILS at precheck", "expected": "passed=false, issue names the failing verifier check" },
+    { "id": "TS-2", "scenario": "Fully-complete SD -> verifier-parity gate PASSES at precheck", "expected": "passed=true" },
+    { "id": "TS-3", "scenario": "sd_type==='orchestrator' -> verifier-parity gate auto-passes (IR-1 parity)", "expected": "passed=true without running the 3 pure checks" },
+    { "id": "TS-4", "scenario": "Execute-style context (precheckMode absent) -> gate.condition is false (gate skipped)", "expected": "condition(ctx)===false; gate does not run at execute" },
+    { "id": "TS-5", "scenario": "Gate runs with a mock supabase spy -> only read queries (.select/.limit), zero writes", "expected": "no insert/update/delete on the spy; verifyHandoff never invoked" },
+    { "id": "TS-6", "scenario": "Threshold parity (IR-2): infrastructure-type SD uses SD_TYPE_OVERRIDES effectiveMinScore, not the default", "expected": "completeness comparison matches verify-l2p effectiveMinScore" }
+  ],
+  "acceptance_criteria": [
+    "precheck reports the SAME blocking verdict as execute for a marginal SD (TS-1) and a complete SD (TS-2)",
+    "Execute path byte-identical: gate is precheck-only via condition (TS-4); no execute regressions",
+    "Gate is side-effect-free: no DB writes, never calls verifyHandoff (TS-5)",
+    "Orchestrator auto-pass parity (IR-1, TS-3) and threshold parity (IR-2, TS-6) hold",
+    "node:test suite for verifier-parity passes; existing lead-to-plan tests remain green",
+    "No files changed outside the new gate file, its test, and the getRequiredGates wiring; verify-l2p and execute path untouched"
+  ],
+  "risks": [
+    { "risk": "Adding parity at execute (not precheck-only) would change the execute rejection path/order", "mitigation": "Gate is strictly precheck-only via condition: ctx.precheckMode===true; execute skips it; TS-4 asserts this", "severity": "medium" },
+    { "risk": "False precheck blockers on orchestrators (verifier auto-passes them before the pure checks)", "mitigation": "IR-1 guard: sd_type==='orchestrator' -> auto-pass in the parity gate; TS-3", "severity": "medium" },
+    { "risk": "Threshold mismatch causes precheck/execute to disagree in the OTHER direction", "mitigation": "IR-2: reuse SD_TYPE_OVERRIDES/effectiveMinScore from verify-l2p/constants.js; TS-6", "severity": "low" },
+    { "risk": "Accidentally invoking verifier.verifyHandoff() (which writes DB rows) from precheck", "mitigation": "Import and call ONLY the pure functions (validateStrategicDirective/validateFeasibility/checkEnvironmentReadiness); TS-5 spy asserts zero writes", "severity": "high" }
+  ],
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Pick an SD missing required completeness (e.g., empty strategic_objectives) and run: node scripts/handoff.js precheck LEAD-TO-PLAN <SD>", "expected_outcome": "precheck now reports the completeness/feasibility blocker (previously PASS)" },
+    { "step_number": 2, "instruction": "Run: node scripts/handoff.js execute LEAD-TO-PLAN <SD> on the same incomplete SD", "expected_outcome": "execute fails with the SAME blocking reason precheck reported — verdicts agree" },
+    { "step_number": 3, "instruction": "On a fully-complete SD, run precheck then execute; also run node --test on the new verifier-parity test", "expected_outcome": "both report PASS; the test suite passes (parity, orchestrator, precheck-only, no-writes)" }
+  ],
+  "strategic_objectives": [
+    "Eliminate precheck/execute verdict divergence on the LEAD-TO-PLAN handoff",
+    "Make precheck a reliable predictor of execute without changing the execute hot path"
+  ],
+  "key_changes": [
+    { "change": "Add precheck-only createVerifierParityGate that replays the verifier's pure blocking checks; wire into getRequiredGates()", "type": "fix" },
+    { "change": "Add node:test coverage (parity, orchestrator auto-pass, precheck-only condition, no-DB-writes, threshold parity)", "type": "test" }
+  ],
+  "integration_operationalization": {
+    "consumers": "Internal LEO handoff tooling only. The new gate runs inside HandoffOrchestrator.precheckHandoff (validateGatesAll) for LEAD-TO-PLAN. Operator journey: a worker runs `node scripts/handoff.js precheck LEAD-TO-PLAN <SD>` before execute; with the fix, precheck surfaces the verifier-blocking conditions so the worker fixes them BEFORE running execute, instead of discovering them only when execute fails.",
+    "dependencies": [
+      { "name": "scripts/verify-l2p/sd-validation.js", "direction": "upstream", "failure_mode": "the gate imports validateStrategicDirective/validateFeasibility; signature change there would break the gate — pinned by reuse + tests" },
+      { "name": "scripts/verify-l2p/environment.js", "direction": "upstream", "failure_mode": "imports checkEnvironmentReadiness (read-only); pinned by reuse" },
+      { "name": "scripts/verify-l2p/constants.js", "direction": "upstream", "failure_mode": "imports SD_TYPE_OVERRIDES/effectiveMinScore/VALID_SD_STATUSES for threshold+status parity" },
+      { "name": "scripts/modules/handoff/HandoffOrchestrator.js", "direction": "downstream", "failure_mode": "runs the gate in precheck via validateGatesAll; respects gate.condition (ValidationOrchestrator.js:285)" }
+    ],
+    "data_contracts": "No DB schema change. In-process gate-result contract only: {passed, score, max_score, issues, warnings, details}. Verifier pure-function signatures unchanged.",
+    "runtime_config": "No new env vars or feature flags. Pure precheck-only gate; takes effect on merge for any process running handoff precheck.",
+    "observability_rollout": "Observability: precheck output (GATE SCORES block) lists the new parity gate verdict so operators see the predicted execute blockers. Rollout: single PR to main; no migration, no deploy sequencing. Rollback: git revert of the single commit fully restores prior precheck behavior (execute was never touched). Fleet-safe: execute byte-identical means active sessions are not retroactively affected; they pick up improved precheck only on rebase."
+  },
+  "implementation_approach": {
+    "steps": [
+      "Read lead-to-plan/index.js getRequiredGates, verify-l2p/index.js (verifyHandoff lines 102-156 for the blocking-check sequence + effectiveMinScore resolution 105-109), verify-l2p/sd-validation.js, verify-l2p/environment.js, verify-l2p/constants.js",
+      "Create gates/verifier-parity.js: createVerifierParityGate(supabase) -> { name:'GATE_VERIFIER_PARITY_PRECHECK', required:true, condition:(ctx)=>ctx.precheckMode===true, validator }",
+      "validator: orchestrator auto-pass; else run the 3 pure checks + status check with effectiveMinScore from SD_TYPE_OVERRIDES; aggregate issues",
+      "Wire createVerifierParityGate(this.supabase) into getRequiredGates()",
+      "Add gates/verifier-parity.test.js (node:test) covering TS-1..TS-6 with a mock supabase",
+      "Run node --test on the new test + the existing lead-to-plan gate tests; confirm precheck on a marginal SD now flags blockers and execute is unchanged"
+    ]
+  },
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001",
+    "validation_agent_lead_evidence_id": "a4bfde58-efc2-4c5c-a101-e598d26de34f",
+    "design_note": "Precheck-only gate via condition: ctx.precheckMode===true keeps execute byte-identical (the verifier remains the sole execute enforcer). Do NOT add the parity check as an unconditional gate (would change execute rejection path/order).",
+    "deferred": "subagent-evidence gate is fleet-wide INERT (handoffType missing from precheck AND execute contexts). 'Fixing' it flips a dead gate to enforcing VALIDATION+Explore that nothing currently produces (0 Explore rows fleet-wide) -> breaks active sessions. DEFERRED to a coordinated quiet-window SD (recorded in SD metadata.deferred_concerns).",
+    "superseded_sd": "SD-PRIVACYPATROL-AI-FDBK-INFRA-UNIFY-LEAD-PLAN-001 (cancelled) proposed the inverse subtractive fix; this additive precheck-honesty approach is safer (execute unchanged)."
+  }
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
@@ -101,3 +101,13 @@ export {
 // /grill convergence artifact. Phase-1 warn (default); phase-2 hard-fail via
 // LEO_GRILL_HARD_FAIL=true. Bypass quota: 3/SD, 10/day.
 export { createGrillConvergenceGate } from './grill-convergence.js';
+
+// Verifier-Parity Gate (SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001)
+// PRECHECK-ONLY: replays the LeadToPlanVerifier's pure blocking checks
+// (completeness/status/feasibility/environment) so precheck PREDICTS execute.
+// Skipped at execute (condition: ctx.precheckMode===true) → execute byte-identical.
+export {
+  evaluateVerifierParity,
+  resolveEffectiveMinScore,
+  createVerifierParityGate
+} from './verifier-parity.js';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.js
@@ -1,0 +1,171 @@
+/**
+ * Verifier-Parity Gate (PRECHECK-ONLY) for LEAD-TO-PLAN
+ * SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001
+ *
+ * PROBLEM: The LEAD-TO-PLAN handoff is gated by TWO engines. Engine #1 is the
+ * gate chain (getRequiredGates) — the only thing `handoff.js precheck` runs.
+ * Engine #2 is the LeadToPlanVerifier (scripts/verify-l2p/index.js), invoked
+ * ONLY inside executeSpecific() during `handoff.js execute`, AFTER the gate
+ * chain. The verifier applies blocking checks the gate chain does NOT
+ * (validateStrategicDirective completeness vs SD-type-aware effectiveMinScore,
+ * validateFeasibility, checkEnvironmentReadiness, VALID_SD_STATUSES). So an SD
+ * can PASS precheck but FAIL execute — a handoff-integrity defect.
+ *
+ * FIX (additive, fleet-safe): this gate re-evaluates the verifier's PURE
+ * blocking checks so precheck PREDICTS execute. It runs ONLY during precheck
+ * (condition: ctx.precheckMode === true) and is SKIPPED at execute, so the
+ * execute path stays byte-identical (the verifier remains the sole execute-time
+ * enforcer). The gate reuses the verifier's OWN pure functions and performs NO
+ * DB writes — it NEVER calls verifier.verifyHandoff() (which writes
+ * createHandoffExecution / updateSdStatusAfterHandoff / rejectHandoff).
+ *
+ * Precedent: SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001 (HandoffOrchestrator.js:343-349)
+ * already surfaces execute-only checks in advisory precheckMode.
+ *
+ * Deliberately OUT OF SCOPE: the subagent-evidence gate's fleet-wide inertness
+ * (handoffType missing from precheck AND execute contexts) is a separate,
+ * high-blast-radius concern deferred to a coordinated quiet-window SD.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { validateStrategicDirective, validateFeasibility } from '../../../../../verify-l2p/sd-validation.js';
+import { checkEnvironmentReadiness } from '../../../../../verify-l2p/environment.js';
+import { SD_REQUIREMENTS, SD_TYPE_OVERRIDES, VALID_SD_STATUSES } from '../../../../../verify-l2p/constants.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// gates → lead-to-plan → executors → handoff → modules → scripts → <repo root>
+const EHG_ENGINEER_ROOT = path.resolve(__dirname, '../../../../../..');
+
+/**
+ * Resolve the SD-type-aware completeness threshold EXACTLY as the verifier does
+ * (verify-l2p/index.js:105-109): SD_TYPE_OVERRIDES[type].minimumScore, else
+ * SD_REQUIREMENTS.minimumScore. IR-2 (threshold parity).
+ * @param {Object} sd
+ * @returns {number}
+ */
+export function resolveEffectiveMinScore(sd) {
+  const sdType = (sd?.sd_type || '').toLowerCase();
+  const typeOverrides = SD_TYPE_OVERRIDES[sdType] || {};
+  return typeOverrides.minimumScore ?? SD_REQUIREMENTS.minimumScore;
+}
+
+/**
+ * Evaluate the verifier's blocking checks WITHOUT side effects. Mirrors the
+ * blocking sequence of LeadToPlanVerifier.verifyHandoff (SD_INCOMPLETE,
+ * SD_STATUS, FEASIBILITY, ENV_NOT_READY) but aggregates all failures (better
+ * diagnostics) instead of returning on the first.
+ *
+ * @param {Object} sd - Strategic Directive row (already loaded into ctx.sd)
+ * @param {Object} supabase - Supabase client (read-only use)
+ * @returns {Promise<Object>} { passed, score, max_score, issues, warnings, details }
+ */
+export async function evaluateVerifierParity(sd, supabase) {
+  // IR-1 (orchestrator parity): the verifier routes orchestrator SDs to
+  // _handleOrchestratorSd (auto-pass via child completion) BEFORE the four pure
+  // blocking checks run, so it never rejects an orchestrator on them. Mirror
+  // that by auto-passing here — otherwise precheck would falsely block
+  // orchestrators that execute auto-passes.
+  if ((sd?.sd_type || '').toLowerCase() === 'orchestrator') {
+    return {
+      passed: true,
+      pass: true,
+      score: 100,
+      max_score: 100,
+      issues: [],
+      warnings: [],
+      details: { orchestrator_auto_pass: true }
+    };
+  }
+
+  const issues = [];
+  const warnings = [];
+
+  // 1. Completeness (verifier: SD_INCOMPLETE when !valid || percentage < effectiveMinScore)
+  const effectiveMinScore = resolveEffectiveMinScore(sd);
+  const sdValidation = validateStrategicDirective(sd);
+  if (!sdValidation.valid || sdValidation.percentage < effectiveMinScore) {
+    issues.push(
+      `SD_INCOMPLETE: completeness ${sdValidation.percentage}% < required ${effectiveMinScore}% ` +
+      `(type: ${(sd?.sd_type || 'default').toLowerCase()})` +
+      (sdValidation.errors?.length ? ` — ${sdValidation.errors.slice(0, 5).join('; ')}` : '')
+    );
+  }
+
+  // 2. Status (verifier: SD_STATUS when status not in VALID_SD_STATUSES)
+  if (!VALID_SD_STATUSES.includes(sd?.status)) {
+    issues.push(`SD_STATUS: status '${sd?.status}' not in [${VALID_SD_STATUSES.join(', ')}]`);
+  }
+
+  // 3. Feasibility (verifier: FEASIBILITY when !passed)
+  const feasibility = validateFeasibility(sd);
+  if (!feasibility.passed) {
+    issues.push(`FEASIBILITY: ${feasibility.issues.join('; ') || 'feasibility concerns'}`);
+  }
+
+  // 4. Environment readiness (verifier: ENV_NOT_READY when !ready). Read-only.
+  const env = await checkEnvironmentReadiness(supabase, sd, EHG_ENGINEER_ROOT);
+  if (!env.ready) {
+    issues.push(`ENV_NOT_READY: ${env.issues.join('; ') || 'environment not ready'}`);
+  }
+
+  const passed = issues.length === 0;
+  return {
+    passed,
+    pass: passed,
+    score: passed ? 100 : 0,
+    max_score: 100,
+    issues,
+    warnings,
+    details: {
+      completeness_percentage: sdValidation.percentage,
+      effective_min_score: effectiveMinScore,
+      status: sd?.status,
+      predicts: 'execute LeadToPlanVerifier blocking verdict'
+    }
+  };
+}
+
+/**
+ * Create the precheck-only verifier-parity gate.
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Object} Gate configuration
+ */
+export function createVerifierParityGate(supabase) {
+  return {
+    name: 'GATE_VERIFIER_PARITY_PRECHECK',
+    // PRECHECK-ONLY: skipped at execute so the execute path is byte-identical.
+    condition: (ctx) => ctx?.precheckMode === true,
+    validator: async (ctx) => {
+      console.log('\n🔍 GATE: Verifier Parity (precheck-only — predicts execute)');
+      console.log('-'.repeat(50));
+      try {
+        const result = await evaluateVerifierParity(ctx.sd, supabase);
+        console.log(`   Completeness: ${result.details?.completeness_percentage}% (min ${result.details?.effective_min_score}%) | Result: ${result.passed ? '✅ PASS' : '❌ WOULD FAIL AT EXECUTE'}`);
+        if (!result.passed) result.issues.forEach(i => console.log(`   ❌ ${i}`));
+        return result;
+      } catch (error) {
+        // Fail-OPEN: precheck is advisory and execute remains the real enforcer.
+        // A bug in the parity helper must not crash/false-block precheck.
+        console.log(`   ⚠️  Verifier-parity check skipped (error): ${error?.message || error}`);
+        return {
+          passed: true,
+          pass: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [`Verifier-parity precheck skipped due to error: ${error?.message || error}`],
+          details: { errored: true }
+        };
+      }
+    },
+    required: true,
+    remediation:
+      'precheck predicts that `handoff.js execute LEAD-TO-PLAN` will reject this SD. ' +
+      'Fix the reported blocker(s) (completeness/status/feasibility/environment) before running execute.'
+  };
+}
+
+export default createVerifierParityGate;

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.test.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.test.js
@@ -1,0 +1,171 @@
+/**
+ * Tests for the Verifier-Parity Gate (precheck-only)
+ * SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001
+ *
+ * Run: node --test scripts/modules/handoff/executors/lead-to-plan/gates/verifier-parity.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createVerifierParityGate,
+  evaluateVerifierParity,
+  resolveEffectiveMinScore
+} from './verifier-parity.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+// A fully-valid SD scores exactly 90 in validateStrategicDirective
+// (30 required-fields + 20 objectives + 20 metrics + 10 principles + 10 risks)
+// and passes feasibility + status. Removing any component makes valid=false.
+function makeCompleteSd(overrides = {}) {
+  return {
+    id: 'test-uuid-0001',
+    sd_key: 'SD-TEST-PARITY-001',
+    title: 'Reconcile dual validation engines test SD',
+    description: 'A sufficiently long description of the test strategic directive used to exercise the verifier-parity gate.',
+    scope: 'IN SCOPE: the parity gate. OUT OF SCOPE: everything unrelated to LEAD-TO-PLAN.',
+    strategic_objectives: ['Objective one is measurable and clear', 'Objective two is also clear'],
+    key_principles: ['Backward compatible', 'Database-first'],
+    priority: 'medium',
+    status: 'draft',
+    sd_type: 'infrastructure',
+    success_metrics: [
+      { metric: 'agreement', target: '100%' },
+      { metric: 'regressions', target: '0' },
+      { metric: 'scenarios', target: '>=3' }
+    ],
+    risks: [{ risk: 'under-escalation', mitigation: 'default-escalate' }],
+    ...overrides
+  };
+}
+
+// Mock supabase whose .from().select().limit() always resolves cleanly so
+// checkEnvironmentReadiness reports ready.
+function mockSupabaseOk() {
+  const chain = {
+    select: () => chain,
+    limit: () => Promise.resolve({ data: [], error: null })
+  };
+  return { from: () => chain };
+}
+
+// Spy supabase that records every method call so we can assert NO writes occur.
+function spySupabase() {
+  const calls = [];
+  const chain = {
+    select: (...a) => { calls.push(['select', ...a]); return chain; },
+    limit: (...a) => { calls.push(['limit', ...a]); return Promise.resolve({ data: [], error: null }); },
+    eq: (...a) => { calls.push(['eq', ...a]); return chain; },
+    insert: (...a) => { calls.push(['insert', ...a]); return Promise.resolve({ data: null, error: null }); },
+    update: (...a) => { calls.push(['update', ...a]); return Promise.resolve({ data: null, error: null }); },
+    delete: (...a) => { calls.push(['delete', ...a]); return Promise.resolve({ data: null, error: null }); },
+    upsert: (...a) => { calls.push(['upsert', ...a]); return Promise.resolve({ data: null, error: null }); }
+  };
+  const client = {
+    from: (t) => { calls.push(['from', t]); return chain; },
+    rpc: (...a) => { calls.push(['rpc', ...a]); return Promise.resolve({ data: null, error: null }); }
+  };
+  return { calls, client };
+}
+
+const WRITE_METHODS = new Set(['insert', 'update', 'delete', 'upsert']);
+
+// ── TS-2: complete SD passes ─────────────────────────────────────────────────
+test('TS-2: a fully-complete SD passes the parity gate', async () => {
+  const result = await evaluateVerifierParity(makeCompleteSd(), mockSupabaseOk());
+  assert.equal(result.passed, true, `expected pass, got issues: ${result.issues.join(' | ')}`);
+  assert.equal(result.issues.length, 0);
+  assert.equal(result.details.completeness_percentage, 90);
+  assert.equal(result.details.effective_min_score, 70); // infrastructure override
+});
+
+// ── TS-1: marginal SD fails (predicts execute SD_INCOMPLETE) ──────────────────
+test('TS-1: an SD missing risks (valid=false) fails parity with SD_INCOMPLETE', async () => {
+  const result = await evaluateVerifierParity(makeCompleteSd({ risks: undefined }), mockSupabaseOk());
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some(i => i.startsWith('SD_INCOMPLETE')), `issues: ${result.issues.join(' | ')}`);
+});
+
+test('TS-1b: an SD with an invalid status fails parity with SD_STATUS', async () => {
+  const result = await evaluateVerifierParity(makeCompleteSd({ status: 'completed' }), mockSupabaseOk());
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some(i => i.startsWith('SD_STATUS')), `issues: ${result.issues.join(' | ')}`);
+});
+
+// ── TS-3: orchestrator auto-pass (IR-1 parity) ───────────────────────────────
+test('TS-3: an orchestrator SD auto-passes even when otherwise incomplete', async () => {
+  const incompleteOrchestrator = makeCompleteSd({
+    sd_type: 'orchestrator',
+    risks: undefined,
+    key_principles: undefined,
+    strategic_objectives: undefined,
+    success_metrics: undefined,
+    success_criteria: undefined
+  });
+  const result = await evaluateVerifierParity(incompleteOrchestrator, mockSupabaseOk());
+  assert.equal(result.passed, true);
+  assert.equal(result.details.orchestrator_auto_pass, true);
+});
+
+// ── TS-4: precheck-only condition (execute byte-identical) ───────────────────
+test('TS-4: gate runs ONLY in precheck (condition guards on precheckMode)', () => {
+  const gate = createVerifierParityGate(mockSupabaseOk());
+  assert.equal(gate.name, 'GATE_VERIFIER_PARITY_PRECHECK');
+  assert.equal(gate.required, true);
+  assert.equal(typeof gate.condition, 'function');
+  // precheck context → runs
+  assert.equal(gate.condition({ precheckMode: true }), true);
+  // execute-style contexts → skipped (byte-identical execute path)
+  assert.equal(gate.condition({}), false);
+  assert.equal(gate.condition({ precheckMode: false }), false);
+  assert.equal(gate.condition(null), false);
+  assert.equal(gate.condition(undefined), false);
+});
+
+// ── TS-5: side-effect-free (no DB writes; verifier never invoked) ────────────
+test('TS-5: the gate performs zero DB writes (only reads)', async () => {
+  const { calls, client } = spySupabase();
+  const gate = createVerifierParityGate(client);
+  const result = await gate.validator({ sd: makeCompleteSd(), precheckMode: true });
+  assert.equal(result.passed, true);
+  const writeCalls = calls.filter(c => WRITE_METHODS.has(c[0]));
+  assert.deepEqual(writeCalls, [], `expected no writes, found: ${JSON.stringify(writeCalls)}`);
+});
+
+// ── TS-6: threshold parity (IR-2) — same resolution as the verifier ──────────
+test('TS-6: resolveEffectiveMinScore mirrors SD_TYPE_OVERRIDES/SD_REQUIREMENTS', () => {
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'infrastructure' }), 70);
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'bugfix' }), 60);
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'database' }), 70);
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'documentation' }), 60);
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'refactor' }), 70);
+  // No override → default minimumScore (90)
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'feature' }), 90);
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'security' }), 90);
+  assert.equal(resolveEffectiveMinScore({}), 90);
+  // Case-insensitive
+  assert.equal(resolveEffectiveMinScore({ sd_type: 'INFRASTRUCTURE' }), 70);
+});
+
+// ── A throwing supabase surfaces as ENV_NOT_READY (checkEnvironmentReadiness
+//    catches internally), NOT a crash — i.e. a real blocker, correctly reported.
+test('Throwing supabase -> ENV_NOT_READY blocker (not a crash)', async () => {
+  const throwingClient = { from: () => { throw new Error('boom'); } };
+  const result = await evaluateVerifierParity(makeCompleteSd(), throwingClient);
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some(i => i.startsWith('ENV_NOT_READY')), `issues: ${result.issues.join(' | ')}`);
+});
+
+// ── Fail-open: a pure-check error must not crash/false-block precheck ─────────
+test('Fail-open: validator returns pass+warning when a pure check throws', async () => {
+  const gate = createVerifierParityGate(mockSupabaseOk());
+  // sd=null makes validateStrategicDirective throw (it reads sd.sd_type unguarded);
+  // the gate must fail-open (advisory precheck; execute is the real enforcer)
+  // rather than crash the precheck run.
+  const result = await gate.validator({ sd: null, precheckMode: true });
+  assert.equal(result.passed, true);
+  assert.ok(result.warnings.some(w => /skipped due to error/i.test(w)));
+  assert.equal(result.details.errored, true);
+});

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -36,7 +36,9 @@ import {
   // Marketing Schema Drift Gate (SD-EHG-MARKETING-DISTRIBUTION-INFRASTRUCTURE-ORCH-001-A)
   createMarketingSchemaDriftGate,
   // Grill Convergence Gate (SD-LEO-PROTOCOL-POCOCK-PATTERNS-ORCH-001-C, Child C)
-  createGrillConvergenceGate
+  createGrillConvergenceGate,
+  // Verifier-Parity Gate (SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001) — precheck-only
+  createVerifierParityGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -176,6 +178,13 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // Blocks LEAD-TO-PLAN when open_questions_for_plan_phase non-empty and no
     // fresh /grill artifact. Phase-1 warn by default; LEO_GRILL_HARD_FAIL=true → hard-fail.
     gates.push(createGrillConvergenceGate(this.supabase));
+
+    // Verifier-Parity Gate (SD-LEO-INFRA-HANDOFF-INTEGRITY-RECONCILE-001)
+    // PRECHECK-ONLY (condition: ctx.precheckMode===true): replays the
+    // LeadToPlanVerifier's pure blocking checks so precheck PREDICTS execute.
+    // Skipped at execute so the execute path stays byte-identical — the verifier
+    // (executeSpecific below) remains the sole execute-time enforcer.
+    gates.push(createVerifierParityGate(this.supabase));
 
     return gates;
   }


### PR DESCRIPTION
## Problem
The LEAD-TO-PLAN handoff is gated by **two** validation engines that can disagree:
- **Engine #1** — the gate chain (`getRequiredGates()`), the only thing `handoff.js precheck` runs.
- **Engine #2** — `LeadToPlanVerifier` (`scripts/verify-l2p/index.js`), invoked **only** inside `executeSpecific()` during `handoff.js execute`, after the gate chain.

The verifier applies blocking checks the gate chain lacks (`validateStrategicDirective` completeness vs SD-type-aware `effectiveMinScore`, `validateFeasibility`, `checkEnvironmentReadiness`, `VALID_SD_STATUSES`). So an SD can **PASS precheck but FAIL execute** — a handoff-integrity defect. The existing `SdMetricsSufficiencyGate` reconciled only one check; the rest diverged.

## Fix (additive, fleet-safe)
New **precheck-only** gate `GATE_VERIFIER_PARITY_PRECHECK` that replays the verifier's **pure** blocking checks during precheck so **precheck predicts execute**:
- Runs **only** when `ctx.precheckMode === true` (condition guard) → **execute path byte-identical**; the verifier remains the sole execute-time enforcer.
- Reuses the verifier's **own** pure functions (`validateStrategicDirective`/`validateFeasibility`/`checkEnvironmentReadiness`) — **zero DB writes**, never calls `verifyHandoff()`.
- Mirrors the verifier exactly: orchestrator auto-pass (IR-1) + `SD_TYPE_OVERRIDES`/`effectiveMinScore` threshold parity (IR-2).
- Precedent: `SD-FDBK-INFRA-PLAN-LEAD-PRECHECK-001` already surfaces execute-only checks in advisory `precheckMode`.

## Why additive (not subtractive)
The cancelled sibling `SD-PRIVACYPATROL-AI-FDBK-INFRA-UNIFY-LEAD-PLAN-001` proposed the inverse — deleting the verifier re-run. This additive approach is strictly safer: no SD that passes execute today newly fails, and active fleet sessions are not retroactively affected (execute unchanged; they pick up improved precheck only on rebase).

## Tests
- 9 `node:test` cases pass: parity fail/pass, status fail, orchestrator auto-pass, **precheck-only condition** (execute skipped), **no-DB-writes spy**, threshold parity, throwing-supabase→ENV_NOT_READY, fail-open.
- Live precheck shows `GATE_VERIFIER_PARITY_PRECHECK: 100%` (28 gates).
- 5 sibling gate-test files fail to load under `node --test` (dotenv `config` error) — **verified pre-existing on origin/main**, logged to harness backlog (not a regression).

## Deliberately deferred (high blast radius)
The `GATE_SUBAGENT_EVIDENCE` gate is **fleet-wide inert** — `handoffType` is missing from both the precheck and execute validation contexts, so `REQUIRED_SUBAGENTS[undefined] → []` → trivial pass (confirmed by 0 Explore rows fleet-wide). "Fixing" it would flip a dead gate to enforcing evidence that nothing currently produces → break every active session. Recorded in SD metadata for a coordinated quiet-window SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)