### PR TITLE
fix(QF-20260530-670): retro gate accepts retrospective_type='SD_COMPLETION' as well as NULL

### DIFF
--- a/scripts/modules/handoff/retro-filters.js
+++ b/scripts/modules/handoff/retro-filters.js
@@ -61,7 +61,11 @@ export async function getFilteredRetrospective(sdUuid, sdCreatedAt, supabase) {
     .select('*')
     .eq('sd_id', sdUuid)
     .eq('retro_type', 'SD_COMPLETION')
-    .is('retrospective_type', null)
+    // QF-20260530-670: accept retrospective_type IS NULL (canonical generate-retrospective.js)
+    // OR ='SD_COMPLETION' (retro-agent's ad-hoc inserts mistag it). Handoff-time retros tag this
+    // column with the PHASE (LEAD_TO_PLAN/PLAN_TO_EXEC/EXEC_TO_PLAN), never 'SD_COMPLETION', so
+    // they remain correctly excluded — this only admits genuine SD-completion retros.
+    .or('retrospective_type.is.null,retrospective_type.eq.SD_COMPLETION')
     .gt('created_at', leadToPlanAcceptedAt)
     .order('created_at', { ascending: false })
     .limit(1)


### PR DESCRIPTION
## Summary
- `getFilteredRetrospective` (retro-filters.js — feeds PLAN-TO-LEAD + LEAD-FINAL retro gates) filtered `.is('retrospective_type', null)`, rejecting retro-agent-generated SD_COMPLETION retros that mistag `retrospective_type='SD_COMPLETION'` (forced a manual null-UPDATE on every such SD; hit 3× this session).
- Now accepts `retrospective_type IS NULL OR ='SD_COMPLETION'`. Handoff-time retros tag the column with the *phase* (never 'SD_COMPLETION') so they stay excluded.

## Test plan
- Verified deterministically against the live DB: the `.or()` admits a 'SD_COMPLETION'-tagged retro that `.is(null)` rejects; PostgREST syntax valid (no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)