### PR TITLE
docs(QF-20260530-432): record @approved-by header for applied cleanup_pending SQL

### DIFF
--- a/database/migrations/20260510_worktree_cleanup_pending.sql
+++ b/database/migrations/20260510_worktree_cleanup_pending.sql
@@ -5,6 +5,8 @@
 -- UUID: a6642ea8-33fe-40dc-814b-54245e41e4c8
 -- Phase: PLAN (database-agent design output)
 --
+-- @approved-by: rickfelix@example.com
+--
 -- Purpose:
 --   Add cleanup_pending TIMESTAMPTZ marker column to claude_sessions so the
 --   orphan-worktree-reaper can safely defer Windows-EBUSY-blocked filesystem


### PR DESCRIPTION
## What

Commits the 2-line `-- @approved-by: rickfelix@example.com` header that the canonical `scripts/apply-migration.js --prod-deploy` 3-factor guard required when applying `database/migrations/20260510_worktree_cleanup_pending.sql` to production.

## Why

The migration (adds `claude_sessions.cleanup_pending` + partial index — additive, metadata-only) was applied live this session (ledger `schema_migrations_applied` row `a094a21f`, `success=true`). The guard records the **with-header** file's sha256, so committing the header keeps the repo file in parity with the ledger.

## Scope

Documentation-only — a 2-line SQL comment header. No executable change, no behavior change. The DDL is already live; this is repo↔ledger hygiene.

QF: QF-20260530-432 (Tier-1, documentation, auto-approve). Original migration SD: SD-LEO-INFRA-WORKTREE-CLEANUP-WINDOWS-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)