### PR TITLE
feat(SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001): sd_type-aware claim TTL (FR19)

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -39,6 +39,19 @@ dotenv.config({ path: path.resolve(__dirname, '../.env') });
 // SD-LEO-INFRA-CLAIM-SYSTEM-IMPROVEMENTS-001 (FR-004): Use shared threshold config
 let STALE_THRESHOLD_SECONDS = getStaleThresholdSeconds();
 
+// SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): hard cap (seconds) bounding any
+// per-sd_type TTL override so a misconfigured map cannot hold a dead claim
+// indefinitely. Overridable via env; defaults to 60min.
+const CLAIM_TTL_HARD_CAP_SECONDS = (() => {
+  const v = parseInt(process.env.CLAIM_TTL_HARD_CAP_SECONDS, 10);
+  return (!isNaN(v) && v > 0) ? v : 3600;
+})();
+
+// SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): optional per-sd_type TTL
+// override map { <sd_type>: <minutes> }, cached alongside the global default by
+// fetchClaimTTL(). Null when unconfigured (pure backward-compat).
+let _ttlByTypeMinutes = null;
+
 // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001 (FR4): TTL-based claim expiry from chairman_dashboard_config
 let _ttlFetched = false;
 async function fetchClaimTTL() {
@@ -58,9 +71,73 @@ async function fetchClaimTTL() {
         console.log(`[claimGuard] TTL from chairman_dashboard_config: ${ttlMinutes}min (${STALE_THRESHOLD_SECONDS}s)`);
       }
     }
+    // SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): cache the per-sd_type map
+    // from the SAME config read (no extra round-trip).
+    const byType = data?.metadata?.claim_ttl_minutes_by_type;
+    if (byType && typeof byType === 'object' && !Array.isArray(byType)) {
+      _ttlByTypeMinutes = byType;
+    }
   } catch (e) {
     // Fail-open: config unavailable, use default threshold
     console.warn(`[claimGuard] ⚠️  TTL config fetch failed (using default ${STALE_THRESHOLD_SECONDS}s): ${e.message}`);
+  }
+}
+
+/**
+ * SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): resolve the effective claim
+ * staleness TTL (seconds) for a specific SD, making it sd_type-aware.
+ *
+ * effective = clamp( perTypeOverrideSeconds, [globalDefault, max(globalDefault, HARD_CAP)] )
+ *
+ * Invariants:
+ *  - LENGTHEN-ONLY: the result is NEVER below the global default
+ *    (STALE_THRESHOLD_SECONDS) — a per-type override lower than the default is
+ *    ignored. So no claim can ever expire SOONER than today.
+ *  - BOUNDED: the result never exceeds max(globalDefault, HARD_CAP), so a
+ *    misconfigured override cannot hold a dead claim indefinitely.
+ *  - RACE-SAFE: returns a LOCAL value; the module-global STALE_THRESHOLD_SECONDS
+ *    is never mutated per-call.
+ *  - FAIL-OPEN: any error resolving sd_type / config returns the global default
+ *    (never throws, never shortens).
+ *
+ * @param {object} supabase - service-role client
+ * @param {string} sdKey - SD key (or QF- id)
+ * @returns {Promise<number>} effective TTL in seconds
+ */
+export async function resolveClaimTtlSeconds(supabase, sdKey) {
+  await fetchClaimTTL(); // ensures STALE_THRESHOLD_SECONDS + _ttlByTypeMinutes are populated
+  const base = STALE_THRESHOLD_SECONDS;
+  try {
+    if (!_ttlByTypeMinutes || !sdKey) return base;
+
+    // Resolve the work item's type (SD- → strategic_directives_v2.sd_type;
+    // QF- → quick_fixes.type).
+    let sdType = null;
+    if (sdKey.startsWith('QF-')) {
+      const { data } = await supabase
+        .from('quick_fixes').select('type').eq('id', sdKey).single();
+      sdType = data?.type || null;
+    } else {
+      const { data } = await supabase
+        .from('strategic_directives_v2').select('sd_type').eq('sd_key', sdKey).single();
+      sdType = data?.sd_type || null;
+    }
+    if (!sdType) return base;
+
+    const overrideMin = Number(_ttlByTypeMinutes[sdType]);
+    if (!Number.isFinite(overrideMin) || overrideMin <= 0) return base;
+
+    const overrideSec = overrideMin * 60;
+    const ceiling = Math.max(base, CLAIM_TTL_HARD_CAP_SECONDS); // never below base, even if base > cap
+    const effective = Math.min(Math.max(overrideSec, base), ceiling);
+    if (effective !== base) {
+      console.log(`[claimGuard] TTL sd_type-aware: ${sdType} → ${Math.round(effective / 60)}min (${effective}s) [default ${Math.round(base / 60)}min]`);
+    }
+    return effective;
+  } catch (e) {
+    // Fail-open: never throw, never shorten below the global default.
+    console.warn(`[claimGuard] ⚠️  per-type TTL resolution failed (using default ${base}s): ${e.message}`);
+    return base;
   }
 }
 
@@ -193,10 +270,14 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
     throw new Error('claimGuard requires both sdKey and sessionId');
   }
 
-  // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Fetch TTL from config on first call
-  await fetchClaimTTL();
-
   const supabase = getSupabase();
+
+  // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Fetch TTL from config on first call.
+  // SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): resolve a LOCAL sd_type-aware
+  // effective TTL (lengthen-only; the module-global STALE_THRESHOLD_SECONDS stays
+  // the default floor and is never mutated per-call — race-safe). resolveClaimTtlSeconds
+  // calls fetchClaimTTL() internally.
+  const effectiveTtlSeconds = await resolveClaimTtlSeconds(supabase, sdKey);
 
   // Step 1: Check existing active claims from claude_sessions (single authoritative source).
   // SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001: sd_claims table has been dropped.
@@ -310,7 +391,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
     // (e.g., npm run subprocess), terminal_id falls back to SSE-port-only
     // (e.g., "win-cc-30738" instead of "win-cc-30738-12872"). This causes
     // the same conversation to create multiple sessions with different IDs.
-    if (heartbeatAge < STALE_THRESHOLD_SECONDS && myTerminalId && claim.terminal_id) {
+    if (heartbeatAge < effectiveTtlSeconds && myTerminalId && claim.terminal_id) {
       const sameConversation = isSameConversation(myTerminalId, claim.terminal_id);
 
       if (sameConversation === true) {
@@ -360,7 +441,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       // Case B: Same SSE port + different PID suffix → different conversation → HARD STOP
     }
 
-    if (heartbeatAge < STALE_THRESHOLD_SECONDS) {
+    if (heartbeatAge < effectiveTtlSeconds) {
       // Active session owns it → HARD STOP (or fallback if autoFallback enabled)
       const result = {
         success: false,
@@ -416,7 +497,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       to_session: sessionId,
       reason: sameHost && claimPid ? `stale_pid_dead_${claimPid}` : 'stale_different_host',
       heartbeat_age: claim.heartbeat_age_human,
-      ttl_seconds: STALE_THRESHOLD_SECONDS,
+      ttl_seconds: effectiveTtlSeconds,
       timestamp: new Date().toISOString()
     }));
     console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})${sameHost && claimPid ? ` — PID ${claimPid} is dead` : ' — different host or no PID'}`);

--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -833,3 +833,109 @@ describe('isSameConversation - win-pid-* format', () => {
     expect(isSameConversation('win-cc-55188-4468', 'win-cc-12345-4468')).toBe(false);
   });
 });
+
+/**
+ * SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): sd_type-aware claim TTL.
+ * resolveClaimTtlSeconds() resolves an effective staleness TTL that may only
+ * LENGTHEN (never shorten) the global default, bounded by a hard cap, fail-open.
+ */
+describe('resolveClaimTtlSeconds - FR19 sd_type-aware TTL', () => {
+  let resolveClaimTtlSeconds;
+
+  // config read: .from('chairman_dashboard_config').select('metadata').eq('config_key','default').single()
+  function mockConfigQuery(metadata) {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { metadata }, error: null })
+        })
+      })
+    };
+  }
+  // type read: .from('strategic_directives_v2'|'quick_fixes').select(col).eq(key, id).single()
+  function mockTypeQuery(row, { throws = false } = {}) {
+    const single = throws
+      ? vi.fn().mockRejectedValue(new Error('boom'))
+      : vi.fn().mockResolvedValue({ data: row, error: null });
+    return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ single }) }) };
+  }
+
+  function setup({ metadata, sdRow, sdThrows = false, qfRow } = {}) {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'chairman_dashboard_config') return mockConfigQuery(metadata);
+      if (table === 'strategic_directives_v2') return mockTypeQuery(sdRow, { throws: sdThrows });
+      if (table === 'quick_fixes') return mockTypeQuery(qfRow);
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    delete process.env.CLAIM_TTL_HARD_CAP_SECONDS;
+    delete process.env.STALE_SESSION_THRESHOLD_SECONDS;
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => mockSupabase) }));
+    vi.doMock('dotenv', () => ({ default: { config: vi.fn() }, config: vi.fn() }));
+    const mod = await import('./claim-guard.mjs');
+    resolveClaimTtlSeconds = mod.resolveClaimTtlSeconds;
+  });
+
+  it('TS-1 lengthens TTL for a configured sd_type (feature 60min)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 60 } }, sdRow: { sd_type: 'feature' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(3600); // 60min
+  });
+
+  it('TS-2/TS-6 backward-compat: no by_type map => global default (15min)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15 }, sdRow: { sd_type: 'feature' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(900); // 15min global default, unchanged
+  });
+
+  it('TS-2 no override for this sd_type => global default', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 60 } }, sdRow: { sd_type: 'infrastructure' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(900); // infrastructure has no override -> default
+  });
+
+  it('TS-3 never-shorten: override below default is ignored (floor = default)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 5 } }, sdRow: { sd_type: 'feature' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(900); // 5min < 15min default => default floor, NOT 300
+  });
+
+  it('TS-4 hard-cap clamps an absurd override (default 60min cap)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 100000 } }, sdRow: { sd_type: 'feature' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(3600); // clamped to HARD_CAP (60min)
+  });
+
+  it('TS-5 fail-open: sd_type lookup throws => global default (no throw)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 60 } }, sdThrows: true });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(900); // fell back to default
+  });
+
+  it('resolves QF- keys via quick_fixes.type', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { bug: 30 } }, qfRow: { type: 'bug' } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, 'QF-20260530-001');
+    expect(ttl).toBe(1800); // 30min
+  });
+
+  it('null sdKey => global default (guard)', async () => {
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 60 } } });
+    const ttl = await resolveClaimTtlSeconds(mockSupabase, null);
+    expect(ttl).toBe(900);
+  });
+
+  it('respects CLAIM_TTL_HARD_CAP_SECONDS env override', async () => {
+    process.env.CLAIM_TTL_HARD_CAP_SECONDS = '7200'; // 120min cap
+    vi.resetModules();
+    const mod = await import('./claim-guard.mjs');
+    setup({ metadata: { claim_ttl_minutes: 15, claim_ttl_minutes_by_type: { feature: 100000 } }, sdRow: { sd_type: 'feature' } });
+    const ttl = await mod.resolveClaimTtlSeconds(mockSupabase, 'SD-X-001');
+    expect(ttl).toBe(7200); // clamped to the raised cap
+  });
+});


### PR DESCRIPTION
## Summary
Makes the claim-staleness TTL in `lib/claim-guard.mjs` **sd_type-aware** (FR19). Long-running sd_types (e.g. feature children whose PLAN_PRD phase runs 15-25min of validation-agent + Explore sub-agents) exceed the single 15min global TTL mid-work, so a second session could wrongly contend a busy worker's claim as stale. `claimGuard` now resolves a per-invocation effective TTL from an optional `chairman_dashboard_config.metadata.claim_ttl_minutes_by_type` map.

## Safety invariant (load-bearing)
`effective = clamp(max(globalDefault, perTypeOverride), default, hard-cap)` — **lengthen-only**. No claim can ever expire *sooner* than today (neutralizes the 'a TTL bug wrongly expires an active claim' hazard). **Race-safe** (local value; module-global never mutated per-call). **Fail-open** (any config/sd_type error → global default). Absent map ⇒ byte-identical to current behavior.

## Scope
- **Only** `claim-guard.mjs` touched. `stale-session-sweep.cjs` (its own threshold + PID/MC/cross-signal reaping guards) intentionally **untouched**. **No migration.**
- Verify-first (validation-agent `204c5293`) cut scope ~70%: dropped FR9 (already written by session-manager.mjs/HandoffRecorder.js), FR10 (no-op — metadata already preserved on release), `wip_dirty` (dup of `has_uncommitted_changes`), `progress_percentage` (no consumer — deferred).

## Tests
9 new vitest cases (lengthen / never-shorten floor / hard-cap clamp / fail-open / backward-compat / QF resolution / env-cap) — **all green**. 0 new regressions (3 pre-existing Case-1 mock failures verified via `git stash`: 3-fail/29-pass pristine vs 3-fail/38-pass here; logged feedback `658d4135`).

## PR size
193 insertions / 6 deletions — ~100 of which are tests + docstrings. Infrastructure, single-file logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)