### PR TITLE
fix(QF-20260530-302): mock strategic_directives_v2.update() in 3 claim-guard Case-1 tests

### DIFF
--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -124,7 +124,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     await claimGuard('SD-TEST-001', 'session-1');
@@ -157,7 +157,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     await claimGuard('SD-TEST-001', 'session-1');
@@ -195,7 +195,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     const result = await claimGuard('SD-TEST-001', 'session-1');


### PR DESCRIPTION
## Summary
Three Case-1 tests in `lib/claim-guard.test.js` failed on `origin/main` with `TypeError: supabase.from(...).update is not a function` at `reaffirmClaimColumns` (`claim-guard.mjs:167`). Their `mockFrom` fallback returned `{ select, eq }` only, but `reaffirmClaimColumns` (added by QF-20260511-016) calls `.from('strategic_directives_v2').update().eq()` in every successful / already-owned path.

## Fix
Adds an `update -> eq` resolved-value mock to the fallback return in the 3 Case-1 tests (3 LOC). No SUT change.

## Verification
- Before (origin/main, isolated worktree): 3 tests RED with the exact TypeError.
- After: `lib/claim-guard.test.js` → **41/41 pass**.

## Provenance
Pre-existing baseline debt, logged as harness feedback `658d4135` last session and verified RED via an origin/main worktree run before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)