### PR TITLE
fix(QF-20260530-493): type=documentation QFs skip the unit+e2e+tsc gate

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -594,6 +594,18 @@ export function isDocsOnlyDiff(filesChanged) {
   return filesChanged.every(isDocsOnlyPath);
 }
 
+// feedback 9b6d1e05 (QF-20260530-493): a type=documentation QF has no executable
+// source to validate even when its diff is NOT matched by isDocsOnlyDiff (e.g. a
+// 2-line .sql comment header — QF-20260530-432 — which lives in a .sql file, not a
+// docs path). Such QFs were forced through the unit+e2e gate, hanging 3-7min to
+// SIGTERM before any DB write and burning a --force-complete bypass per ship.
+// Honoring the QF's declared type is sound for the same reason as a docs-only diff:
+// there is no source to validate, CI on the PR is the authoritative gate, and
+// docmon + compliance + the self-verifier still run.
+export function canSkipTestGate({ qfType, docsOnlyDiff } = {}) {
+  return docsOnlyDiff === true || qfType === 'documentation';
+}
+
 // SD-FDBK-INFRA-CHANGE-SCOPE-COMPLETE-001 (FR-2): classify a path as
 // frontend/e2e-relevant so the orchestrator can gate the Playwright e2e smoke
 // run on whether the diff actually touches the browser surface. A backend-only

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -20,7 +20,7 @@ import os from 'os';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
-import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, touchesFrontend, getScopedUnitTestFiles } from './git-operations.js';
+import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, canSkipTestGate, touchesFrontend, getScopedUnitTestFiles } from './git-operations.js';
 import {
   validateLOC,
   validateTests,
@@ -179,6 +179,7 @@ export async function completeQuickFix(qfId, options = {}) {
   // are now computed once here and reused later in the PR-acquisition block.
   const { filesChanged, diffAnalysis } = analyzeGitDiff(testDir, qf.description);
   const docsOnlyDiff = isDocsOnlyDiff(filesChanged);
+  const skipTestGate = canSkipTestGate({ qfType: qf.type, docsOnlyDiff });
 
   // Test verification - PROGRAMMATIC (not self-reported)
   console.log('\n🧪 PROGRAMMATIC TEST VERIFICATION\n');
@@ -193,14 +194,17 @@ export async function completeQuickFix(qfId, options = {}) {
   if (options.skipTestRun) {
     testsPass = options.testsPass !== undefined ? options.testsPass : true;
     console.log(`   ⚠️  Skipping test run (--skip-tests); testsPass=${testsPass}\n`);
-  } else if (docsOnlyDiff) {
+  } else if (skipTestGate) {
     // QF-20260511-365 / feedback 869f7cf3: docs-only diff bypasses the test-run
     // gate. The diff contains zero source files (docs/, *.md, *.rst, README/
     // LICENSE/CHANGELOG, etc.), so the unit+e2e suite would only re-validate
     // unrelated pre-existing baseline failures. testsPass=true is sound here
     // because there is no source to validate; docmon + bypass-guard still run.
     testsPass = true;
-    console.log(`   📚 Docs-only diff detected (${filesChanged.length} file(s)); skipping unit+e2e tests.\n`);
+    const skipReason = docsOnlyDiff
+      ? `Docs-only diff detected (${filesChanged.length} file(s))`
+      : 'type=documentation QF (no executable source to validate)';
+    console.log(`   📚 ${skipReason}; skipping unit+e2e tests.\n`);
   } else {
     console.log('   Running tests to verify fix quality (not self-reported)...\n');
 
@@ -263,7 +267,7 @@ export async function completeQuickFix(qfId, options = {}) {
   }
 
   // TypeScript verification - PROGRAMMATIC
-  const tscResult = runTypeScriptCheck(testDir, options.skipTypeCheck);
+  const tscResult = runTypeScriptCheck(testDir, options.skipTypeCheck || qf.type === 'documentation');
   if (!validateTypeScript(tscResult)) {
     process.exit(1);
   }

--- a/tests/unit/complete-quick-fix/doc-type-test-skip.test.js
+++ b/tests/unit/complete-quick-fix/doc-type-test-skip.test.js
@@ -1,0 +1,47 @@
+/**
+ * QF-20260530-493 — type=documentation test-gate skip
+ *
+ * Closes feedback 9b6d1e05: the complete-quick-fix orchestrator skipped the
+ * unit+e2e gate ONLY when isDocsOnlyDiff() matched the diff by file pattern
+ * (*.md, docs/, README/LICENSE/CHANGELOG). A type=documentation QF whose change
+ * lives in a non-doc-pattern file (e.g. a 2-line .sql comment header —
+ * QF-20260530-432) was NOT recognized, so the full unit+e2e suite ran and
+ * SIGTERMed at 3-7min before any DB write, forcing a --force-complete bypass.
+ *
+ * canSkipTestGate honors the QF's declared type so such QFs skip the gate too.
+ * It is the pure-helper contract the orchestrator uses for the skip decision
+ * (mirrors the sibling isDocsOnlyDiff helper pinned in docs-only-test-skip.test.js).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { canSkipTestGate } from '../../../scripts/modules/complete-quick-fix/git-operations.js';
+
+describe('canSkipTestGate', () => {
+  it('skips when the diff is docs-only (regardless of type)', () => {
+    expect(canSkipTestGate({ qfType: 'bug', docsOnlyDiff: true })).toBe(true);
+    expect(canSkipTestGate({ qfType: 'polish', docsOnlyDiff: true })).toBe(true);
+  });
+
+  it('skips when qfType is documentation even if the diff is NOT docs-only', () => {
+    // The QF-20260530-432 case: a .sql comment header is type=documentation but
+    // isDocsOnlyDiff() returns false because .sql is not a docs path.
+    expect(canSkipTestGate({ qfType: 'documentation', docsOnlyDiff: false })).toBe(true);
+  });
+
+  it('does NOT skip for a non-doc type with a non-docs diff', () => {
+    expect(canSkipTestGate({ qfType: 'bug', docsOnlyDiff: false })).toBe(false);
+    expect(canSkipTestGate({ qfType: 'polish', docsOnlyDiff: false })).toBe(false);
+    expect(canSkipTestGate({ qfType: 'typo', docsOnlyDiff: false })).toBe(false);
+  });
+
+  it('requires docsOnlyDiff to be strictly true (a truthy non-boolean does not skip)', () => {
+    expect(canSkipTestGate({ qfType: 'bug', docsOnlyDiff: 'yes' })).toBe(false);
+    expect(canSkipTestGate({ qfType: 'bug', docsOnlyDiff: 1 })).toBe(false);
+  });
+
+  it('returns false for empty / missing args (cannot prove a safe skip)', () => {
+    expect(canSkipTestGate()).toBe(false);
+    expect(canSkipTestGate({})).toBe(false);
+    expect(canSkipTestGate({ qfType: undefined, docsOnlyDiff: undefined })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`complete-quick-fix` skipped the unit+e2e test gate only when `isDocsOnlyDiff()` matched the diff by **file pattern** (`*.md`, `docs/`, README/LICENSE/CHANGELOG). A `type=documentation` QF whose change lives in a non-doc-pattern file — e.g. a 2-line **`.sql` comment header** (QF-20260530-432, shipped today via `--force-complete`) — was not recognized, so the full unit+e2e suite ran and **SIGTERMed at 3-7min** before any DB write, burning a `--force-complete` bypass per ship.

## Fix
- New pure helper `canSkipTestGate({ qfType, docsOnlyDiff })` in `git-operations.js`: `docsOnlyDiff === true || qfType === 'documentation'`.
- Wired into the orchestrator's test-skip branch (reason-aware log message).
- Also skips `tsc` for `type=documentation` (no compilable source).

Sound for the same reason as the existing docs-only-diff skip: a documentation QF has no executable source to validate, CI on the PR is the authoritative gate, and docmon + compliance + the self-verifier still run.

## Verification
- +5 `canSkipTestGate` unit cases (`doc-type-test-skip.test.js`), mirroring the sibling `docs-only-test-skip.test.js`.
- Full `tests/unit/complete-quick-fix/` dir: **169/169 green** (15 files).
- `node --check` passes on both modified files.

## Provenance
Harness feedback `9b6d1e05`. Verified residual (not already-fixed): the docs-only skip exists since 2026-05-11 but is file-pattern-based and ignores the QF `type` field; QF-20260530-432's `.sql` comment edit slipped through today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)