### PR TITLE
fix(QF-20260530-548): sd-next no-SD path returns valid QF summary (not undefined)

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -75,7 +75,6 @@ import {
   displayBlockedStateBanner,
   isOrchestratorBlocked,
   displayTelemetryFindings,
-  displayQuickFixes,
   classifyQuickFixes,
   displayRoadmapAwareness,
   displayBrainstormPipelineAdvisory

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -231,7 +231,7 @@ export class SDNextSelector {
       this.displayFeedbackItems();
       this.displayHarnessBacklog();
       displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
-      if (qfSummaryNoBaseline.topStartableQF) {
+      if (qfSummaryNoBaseline?.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
       }
       return { action: 'none', sd_id: null, reason: 'No active baseline found' };
@@ -251,7 +251,7 @@ export class SDNextSelector {
       this.displayFeedbackItems();
       this.displayHarnessBacklog();
       displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
-      if (qfSummaryExhausted.topStartableQF) {
+      if (qfSummaryExhausted?.topStartableQF) {
         return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
       }
       return { action: 'none', sd_id: null, reason: 'Baseline exhausted - all items completed' };

--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -58,7 +58,13 @@ export async function showFallbackQueue(supabase, options = {}) {
 
   if (error || !sds || sds.length === 0) {
     console.log(`${colors.red}No prioritized SDs found. Run: npm run sd:baseline to create one.${colors.reset}`);
-    return;
+    // QF-20260530-548: still return a valid QF summary on the no-SD path.
+    // Callers deref `qfSummary.topStartableQF`; a bare `return` (undefined)
+    // crashes npm run sd:next / /leo next for every session with no baseline
+    // and no priority-matching SD. Classifying QFs here also lets a startable
+    // QF still route via AUTO_PROCEED_ACTION when zero SDs match.
+    const { summary: qfSummary } = classifyQuickFixes(openQuickFixes, qfTriageResults, sessionContext);
+    return qfSummary;
   }
 
   // Batch-load OKR alignment scores. Map shape: sd_uuid -> score (0-90).

--- a/tests/unit/sd-next/fallback-queue-no-sds-returns-summary.test.js
+++ b/tests/unit/sd-next/fallback-queue-no-sds-returns-summary.test.js
@@ -1,0 +1,63 @@
+// QF-20260530-548: showFallbackQueue must return a valid QF summary on its
+// no-SD early-return. A bare `return` (undefined) crashed callers in
+// SDNextSelector.js (`qfSummary.topStartableQF`), killing `npm run sd:next`
+// and `/leo next` for every session with no active baseline and no
+// priority-matching SD. This regression test pins the return contract.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { showFallbackQueue } from '../../../scripts/modules/sd-next/display/fallback-queue.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/modules/sd-next/display/fallback-queue.js');
+
+const nowIso = () => new Date().toISOString();
+
+// Minimal chainable Supabase stub. The no-SD branch only needs:
+//   chairman_dashboard_config -> .single() (config; caught/optional)
+//   strategic_directives_v2   -> .limit()  (returns the [] that triggers the branch)
+function makeSupabase({ sds = [], sdsError = null } = {}) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    order: () => chain,
+    single: async () => ({ data: null, error: null }),
+    limit: async () => ({ data: sds, error: sdsError }),
+  };
+  return { from: () => chain };
+}
+
+describe('QF-20260530-548: showFallbackQueue no-SD path returns a valid summary', () => {
+  it('returns a defined summary (not undefined) when zero prioritized SDs exist', async () => {
+    const summary = await showFallbackQueue(makeSupabase({ sds: [] }), { openQuickFixes: [] });
+    expect(summary).toBeDefined();
+    expect(summary).not.toBeNull();
+    // Callers do `summary.topStartableQF` — it must be a real (null) property.
+    expect(summary).toHaveProperty('topStartableQF', null);
+    expect(summary.totalCount).toBe(0);
+  });
+
+  it('does not throw on `.topStartableQF` of the returned value (the original crash)', async () => {
+    const summary = await showFallbackQueue(makeSupabase({ sds: [] }), { openQuickFixes: [] });
+    expect(() => summary.topStartableQF).not.toThrow();
+  });
+
+  it('still surfaces a startable QF on the no-SD path so AUTO_PROCEED can route', async () => {
+    const openQuickFixes = [
+      { id: 'QF-FRESH', status: 'open', claiming_session_id: null, pr_url: null, commit_sha: null, severity: 'medium', created_at: nowIso() },
+    ];
+    const summary = await showFallbackQueue(makeSupabase({ sds: [] }), { openQuickFixes });
+    expect(summary.topStartableQF?.id).toBe('QF-FRESH');
+  });
+
+  it('source no longer bare-returns undefined on the no-SD branch', () => {
+    const src = readFileSync(SRC, 'utf8');
+    // No bare `return;` (valueless) anywhere — that was the crash.
+    expect(src).not.toMatch(/\n\s*return;\s*(\n|$)/);
+    // The no-SD branch returns a classified summary instead.
+    expect(src).toMatch(/No prioritized SDs found[\s\S]*?return qfSummary;/);
+  });
+});


### PR DESCRIPTION
## Problem
`npm run sd:next` (and `/leo next`) crashed with `TypeError: Cannot read properties of undefined (reading 'topStartableQF')` for every session with **no active baseline and no priority-matching SD**. `showFallbackQueue()` bare-returned `undefined` on its no-SD early-return, but callers in `SDNextSelector.js` deref `qfSummary.topStartableQF`.

## Fix
- `fallback-queue.js`: on the no-SD path, classify QFs and `return qfSummary` instead of bare `return`. This also **restores QF auto-routing** when zero SDs match (a startable QF now still emits `AUTO_PROCEED_ACTION:qf_start`).
- `SDNextSelector.js`: null-safe the two `qfSummary?.topStartableQF` derefs (defense-in-depth).

## Verification
- New regression test `tests/unit/sd-next/fallback-queue-no-sds-returns-summary.test.js` (4 cases): defined-summary contract, no-throw on deref, startable-QF routing, source guard against bare `return`.
- Full sd-next unit suite green (101 tests); `tsc --noEmit` clean.
- Manually ran the patched `sd-next.js` end-to-end against the live no-baseline DB state that previously crashed — no TypeError, correct `AUTO_PROCEED_ACTION:qf_start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)