### PR TITLE
fix(QF-20260530-155): disable FR-C sync-SD generation in stage-20 persist unit tests

### DIFF
--- a/tests/unit/eva/stage-templates/stage-20-persistence.test.js
+++ b/tests/unit/eva/stage-templates/stage-20-persistence.test.js
@@ -93,6 +93,12 @@ const adapted = (canonical = [], skipped = []) => ({ canonical, skipped, hashes:
 describe('persistAnalyzerFindings — FR-B', () => {
   let supabase;
   beforeEach(() => {
+    // QF-20260530-155: these are persist-path unit tests. The FR-C sync-SD
+    // generator (writeFinding → maybeGenerateSdForFinding) has its own coverage
+    // and would otherwise fire on the high-severity fixture (TS-1), logging a
+    // 2nd `fr_c_sync_generator.error` audit_log against the persist-only mock.
+    // Disable it so audit_log assertions reflect only the persist summary.
+    process.env.LEO_FR_C_SYNC_GENERATION_ENABLED = 'false';
     supabase = makeMockSupabase();
   });
 


### PR DESCRIPTION
## Problem
`tests/unit/eva/stage-templates/stage-20-persistence.test.js` TS-1 expected 1 audit_log insert from `persistAnalyzerFindings` but got 2. TS-1's high-severity npm_audit fixture correctly triggers the FR-C sync-SD generator (`writeFinding → maybeGenerateSdForFinding`), which fails against the persist-only mock (no sd-generator query support) and logs a best-effort `fr_c_sync_generator.error` audit row. **Not a code bug** — the generator behaves as designed.

## Fix (test-only)
These are persist-path unit tests; the FR-C sync generator has its own dedicated coverage. Disable it via `LEO_FR_C_SYNC_GENERATION_ENABLED=false` in `beforeEach`, so audit_log assertions reflect only the persist summary.

## Verification
- `npx vitest run tests/unit/eva/stage-templates/stage-20-persistence.test.js` → **6/6 pass** (TS-1 was failing).
- `npx eslint` → clean.

Drains harness-backlog item `7b730865`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)