### PR TITLE
fix(QF-20260530-869): stateful git mock for createWorktree post-condition

### DIFF
--- a/tests/unit/worktree-manager.test.js
+++ b/tests/unit/worktree-manager.test.js
@@ -28,6 +28,25 @@ const {
   _resetDeprecationWarning
 } = await import('../../lib/worktree-manager.js');
 
+// QF-20260530-869: stateful git mock for createWorktree tests. Captures the
+// worktree path from `git worktree add` and echoes it back in
+// `git worktree list --porcelain` so verifyWorktreeRegisteredSync passes.
+function mockStatefulGit() {
+  const added = [];
+  execSync.mockImplementation((cmd) => {
+    if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
+    if (cmd.includes('worktree add')) {
+      const m = cmd.match(/"([^"]*\.worktrees[^"]*)"/);
+      if (m) added.push(m[1]);
+      return '';
+    }
+    if (cmd.includes('worktree list --porcelain')) {
+      return added.map((p) => `worktree ${p}`).join('\n') + '\n';
+    }
+    return '';
+  });
+}
+
 describe('Worktree Manager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -113,19 +132,13 @@ describe('Worktree Manager', () => {
 
   describe('createWorktree', () => {
     it('should use sdKey for worktree path', () => {
-      execSync.mockImplementation((cmd) => {
-        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
-        if (cmd.includes('show-ref')) return '';
-        if (cmd.includes('ls-remote')) return '';
-        if (cmd.includes('worktree add')) return '';
-        return '';
-      });
+      mockStatefulGit();
 
       // Mock fs operations
       const origExists = fs.existsSync;
       const origMkdir = fs.mkdirSync;
       const origWrite = fs.writeFileSync;
-      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.existsSync = vi.fn().mockImplementation((p) => String(p).replace(/\\/g, '/').endsWith('/.git'));
       fs.mkdirSync = vi.fn();
       fs.writeFileSync = vi.fn();
 
@@ -145,18 +158,12 @@ describe('Worktree Manager', () => {
     it('should map legacy session to sdKey with deprecation warning', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      execSync.mockImplementation((cmd) => {
-        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
-        if (cmd.includes('show-ref')) return '';
-        if (cmd.includes('ls-remote')) return '';
-        if (cmd.includes('worktree add')) return '';
-        return '';
-      });
+      mockStatefulGit();
 
       const origExists = fs.existsSync;
       const origMkdir = fs.mkdirSync;
       const origWrite = fs.writeFileSync;
-      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.existsSync = vi.fn().mockImplementation((p) => String(p).replace(/\\/g, '/').endsWith('/.git'));
       fs.mkdirSync = vi.fn();
       fs.writeFileSync = vi.fn();
 
@@ -177,18 +184,12 @@ describe('Worktree Manager', () => {
     it('should rate-limit deprecation warning to once per process', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      execSync.mockImplementation((cmd) => {
-        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
-        if (cmd.includes('show-ref')) return '';
-        if (cmd.includes('ls-remote')) return '';
-        if (cmd.includes('worktree add')) return '';
-        return '';
-      });
+      mockStatefulGit();
 
       const origExists = fs.existsSync;
       const origMkdir = fs.mkdirSync;
       const origWrite = fs.writeFileSync;
-      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.existsSync = vi.fn().mockImplementation((p) => String(p).replace(/\\/g, '/').endsWith('/.git'));
       fs.mkdirSync = vi.fn();
       fs.writeFileSync = vi.fn();
 
@@ -211,18 +212,12 @@ describe('Worktree Manager', () => {
     it('should prefer sdKey over session when both provided', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      execSync.mockImplementation((cmd) => {
-        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
-        if (cmd.includes('show-ref')) return '';
-        if (cmd.includes('ls-remote')) return '';
-        if (cmd.includes('worktree add')) return '';
-        return '';
-      });
+      mockStatefulGit();
 
       const origExists = fs.existsSync;
       const origMkdir = fs.mkdirSync;
       const origWrite = fs.writeFileSync;
-      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.existsSync = vi.fn().mockImplementation((p) => String(p).replace(/\\/g, '/').endsWith('/.git'));
       fs.mkdirSync = vi.fn();
       fs.writeFileSync = vi.fn();
 


### PR DESCRIPTION
## Quick-Fix QF-20260530-869

**Type:** bug (test-only) · **Severity:** low · **LOC:** +27/-32

### Problem
4 `createWorktree` cases in `tests/unit/worktree-manager.test.js` failed at the `verifyWorktreeRegisteredSync` post-condition (`lib/worktree-manager.js:436`, added by SD-LEO-FIX-WORKTREE-CREATION-ATOMICITY-001). Their `execSync` mock returned `''` for `git worktree list --porcelain` and `fs.existsSync` always returned `false`, so the new post-condition (path must appear in the porcelain list **and** the `.git` pointer must exist) threw `WORKTREE_POST_CONDITION_FAILED`. Pre-existing test drift, not a regression (surfaced during SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001, validation row e301f128).

### Fix
- Extract a shared `mockStatefulGit()` helper (replaces 4 duplicated inline mocks) that captures the worktree path from `git worktree add` and echoes it back in `git worktree list --porcelain`.
- Make `fs.existsSync` path-aware: `true` only for the `.git` pointer, `false` for the worktree-dir pre-check.

### Verification
- `npx vitest run --project unit tests/unit/worktree-manager.test.js` → **33/33 pass** (was 4 failed).
- Suite duration 4.8s → 0.4s (post-condition no longer spins its 1s retry loop per failing case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)