### PR TITLE
feat(SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001): ship unmerged BLOCK-CLAIMS-CANCELLED layers (FR-1 + FR-5 + FR-6)

### DIFF
--- a/database/migrations/393_enforce_no_claim_on_cancelled_sd.sql
+++ b/database/migrations/393_enforce_no_claim_on_cancelled_sd.sql
@@ -49,7 +49,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS tr_enforce_no_claim_on_cancelled_sd ON strategic_directives_v2;
-CREATE TRIGGER tr_enforce_no_claim_on_cancelled_sd
+-- CREATE OR REPLACE TRIGGER (PG14+) makes this idempotent on re-apply without a
+-- separate DROP, and keeps the pre-merge migration-readiness probe happy when the
+-- object already exists (it was applied + live-verified during EXEC).
+CREATE OR REPLACE TRIGGER tr_enforce_no_claim_on_cancelled_sd
 BEFORE UPDATE ON strategic_directives_v2 FOR EACH ROW
 EXECUTE FUNCTION enforce_no_claim_on_cancelled_sd();

--- a/database/migrations/393_enforce_no_claim_on_cancelled_sd.sql
+++ b/database/migrations/393_enforce_no_claim_on_cancelled_sd.sql
@@ -1,0 +1,55 @@
+-- Migration 393: Block claims on cancelled SDs (FR-5)
+-- SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001
+--
+-- Ships the DB-level fail-closed layer of the cancelled-SD claim defense. The original
+-- SD-LEO-INFRA-BLOCK-CLAIMS-CANCELLED-001 was marked completed, but this trigger (and the
+-- claim-guard.mjs FR-1 refusal) never merged (stale PR #3672). claimGuard reads status at
+-- the code layer (FR-1); this trigger backstops EVERY writer that sets is_working_on /
+-- claiming_session_id, regardless of code path.
+--
+-- Design validated against the LIVE schema (database-agent, PLAN phase, evidence
+-- 5f1375a9-0f2c-487a-86bc-60a7dbcd86bf):
+--   * strategic_directives_v2.status is varchar (CHECK constraint, 'cancelled' is valid, NOT NULL)
+--   * claim columns that exist: is_working_on (bool), claiming_session_id (text)
+--     (claimed_by / current_owner do NOT exist on this table)
+--   * keyed on OLD.status so the cancellation UPDATE itself (active -> cancelled, clearing
+--     the claim in the same statement) is NOT blocked; only claims on ALREADY-cancelled rows are.
+--   * COALESCE(OLD.status::text,'') makes the NULL / non-cancelled / non-claim path fall
+--     straight through to RETURN NEW (fallback branch never throws). The ::text cast is a
+--     harmless no-op today and future-proofs against an enum migration.
+-- Behavioral probes (rolled-back txn against live data): claim-on-cancelled REJECTED;
+-- claim-on-active SUCCEEDS; non-claim UPDATE on cancelled SUCCEEDS; release on cancelled
+-- SUCCEEDS; cancel-sd.js pattern (active->cancelled + clear claim) SUCCEEDS.
+--
+-- Fleet risk: LOW (additive BEFORE-UPDATE trigger, never mutates rows, only RAISEs on the
+-- precise NULL->claim transition against already-cancelled rows). Safe to apply while the
+-- fleet is active.
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS tr_enforce_no_claim_on_cancelled_sd ON strategic_directives_v2;
+--   DROP FUNCTION IF EXISTS enforce_no_claim_on_cancelled_sd();
+
+CREATE OR REPLACE FUNCTION enforce_no_claim_on_cancelled_sd()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Outer guard: only act on rows that are ALREADY cancelled. The COALESCE(...::text,'')
+    -- makes the NULL / non-cancelled / non-claim path fall straight through to RETURN NEW.
+    IF COALESCE(OLD.status::text, '') = 'cancelled' THEN
+        -- Block acquiring a claim (NULL -> NOT NULL). Releasing (NOT NULL -> NULL) stays allowed.
+        IF NEW.claiming_session_id IS NOT NULL AND OLD.claiming_session_id IS NULL THEN
+            RAISE EXCEPTION 'claiming_session_id cannot be set on cancelled SD %: cancellation_reason=%',
+                OLD.sd_key, COALESCE(OLD.cancellation_reason, '(none)') USING ERRCODE = 'P0001';
+        END IF;
+        -- Block flipping is_working_on false/null -> true.
+        IF COALESCE(NEW.is_working_on, false) = true AND COALESCE(OLD.is_working_on, false) = false THEN
+            RAISE EXCEPTION 'is_working_on cannot be set true on cancelled SD %', OLD.sd_key USING ERRCODE = 'P0001';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS tr_enforce_no_claim_on_cancelled_sd ON strategic_directives_v2;
+CREATE TRIGGER tr_enforce_no_claim_on_cancelled_sd
+BEFORE UPDATE ON strategic_directives_v2 FOR EACH ROW
+EXECUTE FUNCTION enforce_no_claim_on_cancelled_sd();

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -272,6 +272,28 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
 
   const supabase = getSupabase();
 
+  // FR-1 (SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001): pre-acquire refusal on cancelled SDs.
+  // The original SD-LEO-INFRA-BLOCK-CLAIMS-CANCELLED-001 was marked completed but this
+  // layer never merged (PR #3672) — claimGuard previously never read
+  // strategic_directives_v2.status, so a session could acquire a claim on a cancelled SD.
+  // Refuse early with a distinct sd_cancelled reason. FAIL-OPEN: a missing row or a query
+  // error must NOT block (the identity/claim logic below still runs); only a definite
+  // status='cancelled' blocks. The DB trigger (migration 393) backstops this at the data
+  // layer for any writer that bypasses claimGuard.
+  const { data: sdStatusRow, error: sdStatusError } = await supabase
+    .from('strategic_directives_v2')
+    .select('status, cancellation_reason')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (!sdStatusError && sdStatusRow && sdStatusRow.status === 'cancelled') {
+    return {
+      success: false,
+      error: 'sd_cancelled',
+      cancelled: true,
+      cancellation_reason: sdStatusRow.cancellation_reason || null
+    };
+  }
+
   // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Fetch TTL from config on first call.
   // SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): resolve a LOCAL sd_type-aware
   // effective TTL (lengthen-only; the module-global STALE_THRESHOLD_SECONDS stays
@@ -583,6 +605,21 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
  */
 export function formatClaimFailure(result) {
   if (result.success) return '';
+
+  // FR-1 (SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001): distinct banner for a cancelled-SD
+  // refusal — this is NOT a foreign-claim conflict, so the message must differ.
+  if (result.cancelled || result.error === 'sd_cancelled') {
+    return [
+      '╔══════════════════════════════════════════════════════════╗',
+      '║  CLAIM GUARD: SD IS CANCELLED — CANNOT CLAIM            ║',
+      '╚══════════════════════════════════════════════════════════╝',
+      `  Reason:    ${result.cancellation_reason || '(none recorded)'}`,
+      '',
+      '  This SD has status=cancelled. Cancelled SDs cannot be claimed.',
+      '  Pick a different SD; if this is wrong, re-open the SD first.',
+      '',
+    ].join('\n');
+  }
 
   const lines = [
     '╔══════════════════════════════════════════════════════════╗',

--- a/tests/unit/harness/block-claims-cancelled.test.js
+++ b/tests/unit/harness/block-claims-cancelled.test.js
@@ -1,0 +1,94 @@
+// SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001 (FR-6): source-pin guards for the cancelled-SD
+// claim defense. The original SD-LEO-INFRA-BLOCK-CLAIMS-CANCELLED-001 was marked completed
+// but FR-1 (claim-guard.mjs refusal) + FR-5 (migration 393 trigger) never merged (stale
+// PR #3672). These tests pin both layers so the gap cannot silently re-open.
+// Static source assertions (matches cancel-sd-accountability.test.js convention); CI-runnable, no DB.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const guardPath = path.join(repoRoot, 'lib/claim-guard.mjs');
+const migrationPath = path.join(repoRoot, 'database/migrations/393_enforce_no_claim_on_cancelled_sd.sql');
+const guardSrc = fs.readFileSync(guardPath, 'utf-8');
+
+describe('FR-1: claim-guard.mjs refuses claims on cancelled SDs', () => {
+  it('reads strategic_directives_v2.status (+ cancellation_reason) by sd_key before acquiring', () => {
+    // Anchor on the FR-1-specific select (there is an earlier sd_type select in the TTL resolver).
+    const selIdx = guardSrc.indexOf(".select('status, cancellation_reason')");
+    expect(selIdx).toBeGreaterThan(0);
+    const block = guardSrc.slice(selIdx - 80, selIdx + 200);
+    expect(block).toMatch(/from\(['"]strategic_directives_v2['"]\)/);
+    expect(block).toMatch(/\.eq\(['"]sd_key['"],\s*sdKey\)/);
+    expect(block).toMatch(/\.maybeSingle\(\)/);
+  });
+
+  it('returns a distinct sd_cancelled refusal when status === cancelled', () => {
+    expect(guardSrc).toMatch(/sdStatusRow\.status === ['"]cancelled['"]/);
+    expect(guardSrc).toMatch(/error:\s*['"]sd_cancelled['"]/);
+    expect(guardSrc).toMatch(/cancelled:\s*true/);
+  });
+
+  it('is FAIL-OPEN: only a definite cancelled status blocks (missing row / query error does not)', () => {
+    // The refusal must be gated on (no error) AND (row present) AND (status === cancelled),
+    // so a Supabase hiccup or a missing row falls through to the existing claim logic.
+    expect(guardSrc).toMatch(/!sdStatusError\s*&&\s*sdStatusRow\s*&&\s*sdStatusRow\.status === ['"]cancelled['"]/);
+  });
+
+  it('the status check runs BEFORE the claude_sessions claim query (pre-acquire)', () => {
+    const statusIdx = guardSrc.indexOf(".select('status, cancellation_reason')");
+    const sessionsIdx = guardSrc.indexOf("from('claude_sessions')");
+    expect(statusIdx).toBeGreaterThan(0);
+    expect(sessionsIdx).toBeGreaterThan(statusIdx);
+  });
+
+  it('formatClaimFailure renders a distinct cancelled banner (not the foreign-claim one)', () => {
+    expect(guardSrc).toMatch(/result\.cancelled\s*\|\|\s*result\.error === ['"]sd_cancelled['"]/);
+    expect(guardSrc).toMatch(/SD IS CANCELLED/);
+  });
+});
+
+describe('FR-5: migration 393 is the DB-level fail-closed backstop', () => {
+  it('the migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  const migSrc = fs.existsSync(migrationPath) ? fs.readFileSync(migrationPath, 'utf-8') : '';
+
+  it('defines a BEFORE UPDATE trigger on strategic_directives_v2', () => {
+    expect(migSrc).toMatch(/CREATE OR REPLACE FUNCTION enforce_no_claim_on_cancelled_sd\(\)/);
+    expect(migSrc).toMatch(/BEFORE UPDATE ON strategic_directives_v2/);
+  });
+
+  it('keys on OLD.status (cancellation UPDATE itself stays allowed) with an enum-cast-safe fallback', () => {
+    expect(migSrc).toMatch(/COALESCE\(OLD\.status::text,\s*''\)\s*=\s*'cancelled'/);
+    // Must NOT key on NEW.status (that would block the active->cancelled transition).
+    expect(migSrc).not.toMatch(/NEW\.status::text\)?\s*=\s*'cancelled'/);
+  });
+
+  it('blocks both claim transitions (claiming_session_id NULL->set and is_working_on false->true)', () => {
+    expect(migSrc).toMatch(/NEW\.claiming_session_id IS NOT NULL AND OLD\.claiming_session_id IS NULL/);
+    expect(migSrc).toMatch(/COALESCE\(NEW\.is_working_on,\s*false\)\s*=\s*true AND COALESCE\(OLD\.is_working_on,\s*false\)\s*=\s*false/);
+    expect(migSrc).toMatch(/RAISE EXCEPTION/);
+  });
+
+  it('documents a reversible rollback (DROP TRIGGER + DROP FUNCTION)', () => {
+    expect(migSrc).toMatch(/DROP TRIGGER IF EXISTS tr_enforce_no_claim_on_cancelled_sd/);
+    expect(migSrc).toMatch(/DROP FUNCTION IF EXISTS enforce_no_claim_on_cancelled_sd/);
+  });
+});
+
+describe('is_working_on writer guard: claim acquisition routes through claim-guard', () => {
+  it('the canonical claim writer (reaffirmClaimColumns) is the one setting is_working_on: true', () => {
+    // claimGuard delegates the claim-column write to reaffirmClaimColumns, which is the
+    // single is_working_on:true writer in claim-guard.mjs. Pinning this keeps the FR-1
+    // status check on the same path as the acquire (the DB trigger backstops other writers).
+    const idx = guardSrc.indexOf('function reaffirmClaimColumns');
+    expect(idx).toBeGreaterThan(0);
+    const block = guardSrc.slice(idx, idx + 600);
+    expect(block).toMatch(/is_working_on:\s*true/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the partial-phantom safety gap left by **SD-LEO-INFRA-BLOCK-CLAIMS-CANCELLED-001** (marked completed 2026-05-10) whose delivery **PR #3672 never merged**. FR-2/3/7 landed via sibling work; FR-1, FR-5, FR-6 did not — `claimGuard()` never read `strategic_directives_v2.status`, so a session could still acquire a claim on a cancelled SD.

**Supersedes #3672** (stale, conflicting). This PR re-implements the three missing layers adapted to current `main`.

## What changed
- **FR-1** `lib/claim-guard.mjs` — pre-acquire `status='cancelled'` refusal with a distinct `sd_cancelled` reason + banner. Fail-open (missing row / query error does not block; only a definite cancelled status blocks). Runs before the `claude_sessions` claim query.
- **FR-5** `database/migrations/393_enforce_no_claim_on_cancelled_sd.sql` — BEFORE-UPDATE PG trigger refusing claim transitions (`is_working_on` false→true, `claiming_session_id` NULL→set) on already-cancelled SDs. Keyed on `OLD.status` (cancellation UPDATE itself stays allowed); enum-cast-safe fallback. **Applied to the engineer DB** (validated by database-agent, 6 rolled-back probes).
- **FR-6** `tests/unit/harness/block-claims-cancelled.test.js` — 11 source-pin tests (FR-1 refusal + FR-5 trigger + writer guard). All pass.

## Verification (live)
- Trigger present; blocks `is_working_on=true` on a real cancelled SD (rolled back) ✓
- Active-SD claim NOT blocked (no false positive) ✓
- `claimGuard()` refuses a cancelled SD with `error: 'sd_cancelled'` ✓
- 11/11 new tests pass; harness suite 94/94. Pre-existing `multi-session-claim-gate` / `claim-default` failures verified (git-stash) as NOT caused by this change.

## Sub-agent evidence
- LEAD VALIDATION: PASS 92% (de0d9613) · PLAN DATABASE: PASS 92% (5f1375a9) · PLAN STORIES: PASS 100/100 (102f5069)

🤖 Generated with [Claude Code](https://claude.com/claude-code)