### PR TITLE
feat(SD-LEO-INFRA-RELIABLE-S19-BUILD-001): reliable S19 build-SD generation — auto-draft L2 vision + fail-loud block

### DIFF
--- a/lib/eva/__tests__/stage-17-doc-generation.test.js
+++ b/lib/eva/__tests__/stage-17-doc-generation.test.js
@@ -3,7 +3,7 @@
  * SD: SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-C
  */
 import { describe, test, expect, vi } from 'vitest';
-import { generateDocs } from '../stage-templates/analysis-steps/stage-17-doc-generation.js';
+import { generateDocs, seedDraftL2Vision } from '../stage-templates/analysis-steps/stage-17-doc-generation.js';
 
 // Silent logger for tests
 const silentLogger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
@@ -159,5 +159,139 @@ describe('generateDocs', () => {
     // If the upsert was called, the content was processed through sanitizeForPrompt
     // which wraps content in [USER_INPUT]...[/USER_INPUT] delimiters
     expect(result.errors.length).toBe(0);
+  });
+});
+
+// SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-1 — seedDraftL2Vision
+//
+// Mock surface for seedDraftL2Vision's eva_vision_documents access:
+//   1) existence check : .select().eq('venture_id').eq('level').limit().maybeSingle()
+//   2) key collisions  : .select().like()           (returns array)
+//   3) insert          : .insert().select().single()
+// plus venture_artifacts: .select().eq('venture_id').eq('is_current')
+function mockSeedSupabase({ existingL2 = null, artifacts = [], keyCollisions = [], insertResult } = {}) {
+  const insertCalls = [];
+  return {
+    _insertCalls: insertCalls,
+    from: vi.fn((table) => {
+      if (table === 'venture_artifacts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(async () => ({ data: artifacts, error: null })),
+            })),
+          })),
+        };
+      }
+      if (table === 'eva_vision_documents') {
+        return {
+          select: vi.fn(() => ({
+            // existence check chain
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn(async () => ({ data: existingL2, error: null })),
+                })),
+              })),
+            })),
+            // key-collision chain
+            like: vi.fn(async () => ({ data: keyCollisions, error: null })),
+          })),
+          insert: vi.fn((record) => {
+            insertCalls.push(record);
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: insertResult ?? {
+                    id: 'seed-uuid',
+                    vision_key: record.vision_key,
+                    level: record.level,
+                    version: record.version,
+                    status: record.status,
+                    chairman_approved: record.chairman_approved,
+                    created_by: record.created_by,
+                  },
+                  error: null,
+                })),
+              })),
+            };
+          }),
+        };
+      }
+      return { select: vi.fn(() => ({ eq: vi.fn(async () => ({ data: [], error: null })) })) };
+    }),
+  };
+}
+
+describe('seedDraftL2Vision (FR-1)', () => {
+  test('throws if ventureId is missing', async () => {
+    await expect(seedDraftL2Vision({ supabase: {}, logger: silentLogger }))
+      .rejects.toThrow('ventureId is required');
+  });
+
+  test('throws if supabase is missing', async () => {
+    await expect(seedDraftL2Vision({ ventureId: 'v-1', logger: silentLogger }))
+      .rejects.toThrow('supabase client is required');
+  });
+
+  test('writes exactly one draft_seed L2 row, chairman_approved=false, content non-null', async () => {
+    const supabase = mockSeedSupabase({ existingL2: null, artifacts: [] });
+    const res = await seedDraftL2Vision({
+      supabase, ventureId: 'v-1', ventureName: 'CronGenius', logger: silentLogger,
+    });
+
+    expect(res.skipped).toBe(false);
+    expect(res.error).toBeNull();
+    expect(supabase._insertCalls.length).toBe(1);
+
+    const rec = supabase._insertCalls[0];
+    expect(rec.level).toBe('L2');
+    expect(rec.status).toBe('draft_seed');
+    expect(rec.chairman_approved).toBe(false);
+    expect(rec.venture_id).toBe('v-1');
+    expect(rec.version).toBe(1);
+    expect(rec.extracted_dimensions).toBeNull();
+    expect(rec.created_by).toBe('auto-draft-l2-vision');
+    // content must be non-null (placeholder sections guarantee this even with no artifacts)
+    expect(typeof rec.content).toBe('string');
+    expect(rec.content.length).toBeGreaterThan(0);
+    // vision_key follows VISION-<slug>-L2-DRAFT-SEED-001
+    expect(rec.vision_key).toBe('VISION-CRONGENIUS-L2-DRAFT-SEED-001');
+  });
+
+  test('NEVER writes status=active or chairman_approved=true', async () => {
+    const supabase = mockSeedSupabase({ existingL2: null, artifacts: [] });
+    await seedDraftL2Vision({ supabase, ventureId: 'v-1', ventureName: 'Acme', logger: silentLogger });
+    const rec = supabase._insertCalls[0];
+    expect(rec.status).not.toBe('active');
+    expect(rec.chairman_approved).not.toBe(true);
+  });
+
+  test('is idempotent — no-op when an L2 already exists (any status)', async () => {
+    const supabase = mockSeedSupabase({
+      existingL2: { id: 'x', vision_key: 'VISION-ACME-L2-001', status: 'active' },
+    });
+    const res = await seedDraftL2Vision({ supabase, ventureId: 'v-1', ventureName: 'Acme', logger: silentLogger });
+    expect(res.skipped).toBe(true);
+    expect(supabase._insertCalls.length).toBe(0);
+  });
+
+  test('also no-ops when an existing L2 is itself a draft_seed', async () => {
+    const supabase = mockSeedSupabase({
+      existingL2: { id: 'y', vision_key: 'VISION-ACME-L2-DRAFT-SEED-001', status: 'draft_seed' },
+    });
+    const res = await seedDraftL2Vision({ supabase, ventureId: 'v-1', ventureName: 'Acme', logger: silentLogger });
+    expect(res.skipped).toBe(true);
+    expect(supabase._insertCalls.length).toBe(0);
+  });
+
+  test('suffixes the vision_key when a DRAFT-SEED key collision is possible', async () => {
+    const supabase = mockSeedSupabase({
+      existingL2: null,
+      keyCollisions: [{ vision_key: 'VISION-ACME-L2-DRAFT-SEED-001' }],
+    });
+    await seedDraftL2Vision({ supabase, ventureId: 'v-1', ventureName: 'Acme', logger: silentLogger });
+    const rec = supabase._insertCalls[0];
+    expect(rec.vision_key).toBe('VISION-ACME-L2-DRAFT-SEED-002');
   });
 });

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -174,6 +174,10 @@ export class StageExecutionWorker {
       [17, async (ventureId) => {
         await this._postStageHook_S17_GvosLock(ventureId);
         await this._postStageHook_S17_DocGen(ventureId);
+        // SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-1: auto-draft a draft_seed L2 vision so
+        // leo_bridge ventures have SOMETHING for the S19 gate to escalate on (and a human to
+        // approve) instead of silently producing 0 SDs. Non-throwing.
+        await this._postStageHook_S17_SeedDraftVision(ventureId);
       }],
       [19, (ventureId) => this._postStageHook_S19_Bridge(ventureId)],
     ]);
@@ -1209,7 +1213,72 @@ export class StageExecutionWorker {
             }
             this._logger.log(`[Worker] S19 gate (seeded_repo): repo URL set (${repoUrl}) — proceeding`);
           } else {
-            this._logger.log('[Worker] S19 gate (leo_bridge): venture builds via the LEO-SD bridge — not blocking on Replit seeding.');
+            // SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-2: HARD CUTOVER fail-loud gate.
+            // Synchronously run the LEO-SD bridge and BLOCK advancement on a real failure
+            // (e.g. VENTURE_L2_VISION_MISSING) instead of letting the fire-and-forget hook
+            // swallow it and the venture silently advance past S19 un-built.
+            const advisory = s19Work?.advisory_data || {};
+
+            // Chairman override escape hatch: an operator can force advancement past S19.
+            if (advisory.chairman_override === true) {
+              this._logger.log('[Worker] S19 gate (leo_bridge): chairman_override=true — proceeding past S19 without a bridge-built SD set.');
+            } else if (
+              // Cheap fast-path: a prior run already blocked on a pending vision AND no
+              // approved L2 vision exists yet → re-block without re-running the slow bridge.
+              advisory.bridge_failed === true &&
+              advisory.reason === 'vision_pending'
+            ) {
+              const { data: approvedVision } = await this._supabase
+                .from('eva_vision_documents')
+                .select('vision_key')
+                .eq('venture_id', ventureId)
+                .eq('level', 'L2')
+                .eq('status', 'active')
+                .eq('chairman_approved', true)
+                .limit(1)
+                .maybeSingle();
+              if (!approvedVision) {
+                this._logger.error(`[Worker] S19 gate (leo_bridge): re-blocking — prior vision_pending block stands, still no chairman-approved L2 vision for venture ${ventureId}.`);
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'leo_bridge_vision_pending' };
+                break;
+              }
+              // Approved vision now exists — fall through to (re)run the bridge below.
+              const bridge = await this._runS19Bridge(ventureId);
+              const errs = bridge.errors || [];
+              const errStr = JSON.stringify(errs);
+              const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
+              if (bridge.created || isIdempotent) {
+                this._logger.log(`[Worker] S19 gate (leo_bridge): bridge ${bridge.created ? 'created SDs' : 'idempotent no-op'} after vision approval — proceeding.`);
+              } else {
+                this._logger.error(`[Worker] S19 gate (leo_bridge): bridge still failing after vision approval for venture ${ventureId}. Errors: ${errStr}`);
+                await this._blockS19LeoBridge(ventureId, errs);
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'leo_bridge_vision_pending' };
+                break;
+              }
+            } else {
+              // Primary path: run the bridge and discriminate the three created:false cases
+              // exactly like the NC-7 regex logic (~_runS19Bridge):
+              //   created===true                          → proceed
+              //   created===false AND (no errors OR /already exists/i) → idempotency → proceed
+              //   else (real failure, incl. vision-missing) → BLOCK + break
+              const bridge = await this._runS19Bridge(ventureId);
+              const errs = bridge.errors || [];
+              const errStr = JSON.stringify(errs);
+              const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
+              if (bridge.created) {
+                this._logger.log(`[Worker] S19 gate (leo_bridge): bridge created SDs (orchestrator=${bridge.orchestratorKey}, children=${bridge.childKeys?.length || 0}) — proceeding.`);
+              } else if (isIdempotent) {
+                this._logger.log('[Worker] S19 gate (leo_bridge): bridge no-op (idempotency / existing orchestrator) — proceeding.');
+              } else {
+                this._logger.error(`[Worker] S19 gate (leo_bridge): BLOCKING — bridge failed for venture ${ventureId} (vision pending / real failure). Errors: ${errStr}`);
+                await this._blockS19LeoBridge(ventureId, errs);
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'leo_bridge_vision_pending' };
+                break;
+              }
+            }
           }
         }
 
@@ -2787,6 +2856,50 @@ export class StageExecutionWorker {
   }
 
   /**
+   * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-1: auto-draft a draft_seed L2 vision.
+   *
+   * Runs AFTER _postStageHook_S17_DocGen. Only fires for leo_bridge ventures (the
+   * seeded_repo path does NOT use the LEO-SD bridge, so it never needs an L2 vision).
+   * seedDraftL2Vision is idempotent (no-op if any L2 doc already exists) and writes
+   * status='draft_seed' / chairman_approved=false — never active/approved. Non-throwing.
+   *
+   * @param {string} ventureId
+   */
+  async _postStageHook_S17_SeedDraftVision(ventureId) {
+    const logger = this._logger;
+    try {
+      // Resolve build_model via the SINGLE arbiter; skip unless leo_bridge.
+      const { data: s19Work } = await this._supabase
+        .from('venture_stage_work')
+        .select('advisory_data')
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', 19)
+        .maybeSingle();
+      const { data: ventureRow } = await this._supabase
+        .from('ventures').select('name, build_model').eq('id', ventureId).maybeSingle();
+      const { resolveBuildModel } = await import('./bridge/resolve-build-model.js');
+      const buildModel = resolveBuildModel({
+        ventureBuildModel: ventureRow?.build_model,
+        legacyBuildMethod: s19Work?.advisory_data?.build_method,
+      });
+      if (buildModel !== 'leo_bridge') {
+        logger.log(`[Worker] S17 SeedDraftVision: build_model=${buildModel} — skipping (only leo_bridge ventures need an L2 vision for the bridge).`);
+        return;
+      }
+
+      const { seedDraftL2Vision } = await import('./stage-templates/analysis-steps/stage-17-doc-generation.js');
+      await seedDraftL2Vision({
+        supabase: this._supabase,
+        ventureId,
+        ventureName: ventureRow?.name,
+        logger,
+      });
+    } catch (err) {
+      logger.warn(`[Worker] S17 SeedDraftVision hook failed (non-fatal): ${err.message}`);
+    }
+  }
+
+  /**
    * S17 post-stage hook: freeze the GVOS design snapshot (GVOS FR-6).
    *
    * SD-LEO-REFAC-RETIRE-LEGACY-STAGE-001
@@ -2959,10 +3072,32 @@ export class StageExecutionWorker {
 
   /**
    * S19 post-stage hook: Convert sprint plan → LEO Strategic Directives via lifecycle-sd-bridge.
-   * Queries S19 artifacts for sd_bridge_payloads, creates orchestrator + child SDs.
+   *
+   * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-2: this is now a THIN WRAPPER around the
+   * synchronous _runS19Bridge (defense-in-depth — the synchronous S19 entry gate is the
+   * primary path that blocks advancement; this fire-and-forget post-stage hook stays as a
+   * net, with its NC-7 escalation block intact inside _runS19Bridge).
+   *
    * @param {string} ventureId
    */
   async _postStageHook_S19_Bridge(ventureId) {
+    await this._runS19Bridge(ventureId);
+  }
+
+  /**
+   * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-2: synchronous S19 bridge run.
+   *
+   * Extracted from the former _postStageHook_S19_Bridge body so the SYNCHRONOUS S19 entry
+   * gate can await it and BLOCK advancement on a real failure (e.g. VENTURE_L2_VISION_MISSING)
+   * instead of the venture silently advancing past S19 via the fire-and-forget hook.
+   *
+   * Queries S19 artifacts for sd_bridge_payloads, creates orchestrator + child SDs.
+   * Keeps the NC-7 anti-silent-no-op escalation block as a net.
+   *
+   * @param {string} ventureId
+   * @returns {Promise<{ created: boolean, errors: any, orchestratorKey: string|null, childKeys: string[] }>}
+   */
+  async _runS19Bridge(ventureId) {
     const { data: ventureRow } = await this._supabase
       .from('ventures').select('name').eq('id', ventureId).single();
 
@@ -3002,7 +3137,9 @@ export class StageExecutionWorker {
           work_type: 'sd_required',
           advisory_data: { build_method: 'replit_agent', awaiting_replit_sync: true },
         }, { onConflict: 'venture_id,lifecycle_stage' });
-      return;
+      // seeded_repo never creates SDs — treat as "created:true" so the gate proceeds (the
+      // seeded_repo branch of the entry gate handles its own repo-seeding block separately).
+      return { created: true, errors: [], orchestratorKey: null, childKeys: [] };
     }
     this._logger.log('[Worker] S19 Bridge: build_model=leo_bridge — creating orchestrator + child SDs via convertSprintToSDs.');
 
@@ -3044,14 +3181,23 @@ export class StageExecutionWorker {
 
     if (sdBridgePayloads.length === 0) {
       this._logger.log('[Worker] S19 post-stage hook: No sd_bridge_payloads found in artifacts');
-      return;
+      // No payloads = nothing to build; not a vision failure. created:false + empty errors
+      // → the entry gate treats this as the idempotency/no-op case and proceeds.
+      return { created: false, errors: [], orchestratorKey: null, childKeys: [] };
     }
 
-    // Query EVA records for vision_key and plan_key
+    // Query EVA records for vision_key and plan_key.
+    // SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-3: filter to the gate-ACCEPTED doc
+    // (level='L2', status='active', chairman_approved=true) so the advisory vision_key
+    // equals what assertVentureVisionReady accepts. A venture with only an L1 + an
+    // unapproved draft_seed L2 yields vision_key=null.
     const { data: visionDoc } = await this._supabase
       .from('eva_vision_documents')
       .select('vision_key')
       .eq('venture_id', ventureId)
+      .eq('level', 'L2')
+      .eq('status', 'active')
+      .eq('chairman_approved', true)
       .order('version', { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -3143,6 +3289,45 @@ export class StageExecutionWorker {
           this._logger.warn(`[Worker] S19 NC-7 escalation upsert failed: ${escErr.message}`);
         }
       }
+    }
+
+    // FR-2: return the bridge outcome so the synchronous S19 entry gate can discriminate
+    // created:true / idempotency-no-op / real-failure and block advancement accordingly.
+    return {
+      created: bridgeResult.created === true,
+      errors: bridgeResult.errors || bridgeResult.error || [],
+      orchestratorKey: bridgeResult.orchestratorKey || null,
+      childKeys: bridgeResult.childKeys || [],
+    };
+  }
+
+  /**
+   * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-2: write the S19 leo_bridge block row.
+   *
+   * Upserts venture_stage_work (venture_id, lifecycle_stage:19) → stage_status:'blocked',
+   * work_type:'sd_required', advisory_data tagged with reason:'vision_pending' so the
+   * dashboard surfaces it AND the gate fast-path can re-block without re-running the bridge.
+   *
+   * @param {string} ventureId
+   * @param {any} bridgeErrors
+   */
+  async _blockS19LeoBridge(ventureId, bridgeErrors) {
+    try {
+      await this._supabase.from('venture_stage_work').upsert({
+        venture_id: ventureId,
+        lifecycle_stage: 19,
+        stage_status: 'blocked',
+        work_type: 'sd_required',
+        advisory_data: {
+          build_model: 'leo_bridge',
+          bridge_failed: true,
+          reason: 'vision_pending',
+          bridge_errors: bridgeErrors,
+          escalated_at: new Date().toISOString(),
+        },
+      }, { onConflict: 'venture_id,lifecycle_stage' });
+    } catch (err) {
+      this._logger.warn(`[Worker] S19 leo_bridge block upsert failed (non-fatal): ${err.message}`);
     }
   }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
@@ -42,6 +42,164 @@ const ARCH_SECTION_SOURCES = {
 };
 
 /**
+ * Derive the venture key slug — the EXACT algorithm used by generateDocs and
+ * seedDraftL2Vision so both produce identical vision keys for a venture.
+ *
+ * @param {string} ventureName
+ * @returns {string}
+ */
+function deriveVentureSlug(ventureName) {
+  return (ventureName || 'VENTURE')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 30);
+}
+
+/**
+ * Assemble the artifact-seeded Vision section map + markdown content from the
+ * venture's current artifacts. Mirrors the exact section-assembly logic
+ * generateDocs uses (VISION_SECTION_SOURCES + the '[Section pending…]'
+ * fallbacks), so content is ALWAYS non-null.
+ *
+ * @param {Object} artifactsByType - venture_artifacts indexed by artifact_type
+ * @returns {{ sections: Object, content: string }}
+ */
+function buildVisionSections(artifactsByType) {
+  const visionSections = {};
+  for (const [sectionKey, sourceTypes] of Object.entries(VISION_SECTION_SOURCES)) {
+    const parts = [];
+    for (const artifactType of sourceTypes) {
+      const artifact = artifactsByType[artifactType];
+      if (artifact) {
+        const raw = artifact.content || (artifact.artifact_data ? JSON.stringify(artifact.artifact_data) : '');
+        if (raw) {
+          parts.push(sanitizeForPrompt(raw, 2000));
+        }
+      }
+    }
+    if (parts.length > 0) {
+      visionSections[sectionKey] = parts.join('\n\n');
+    } else {
+      visionSections[sectionKey] = sectionKey === 'ui_ux_wireframes'
+        ? 'N/A — no UI component identified in venture artifacts'
+        : `[Section pending — source artifacts (${sourceTypes.join(', ')}) not yet available]`;
+    }
+  }
+
+  const content = Object.entries(visionSections)
+    .map(([key, body]) => `## ${key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}\n\n${body}`)
+    .join('\n\n');
+
+  return { sections: visionSections, content };
+}
+
+/**
+ * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-1 — Auto-draft an L2 vision (artifact-seeded).
+ *
+ * The lifecycle-SD bridge refuses to generate build SDs unless a chairman-approved
+ * L2 vision exists (assertVentureVisionReady). Nothing in the pipeline auto-creates
+ * even a DRAFT, so leo_bridge ventures hit VENTURE_L2_VISION_MISSING and produce 0 SDs.
+ * This seeds a status='draft_seed' L2 doc so the venture has SOMETHING to escalate on
+ * (the S19 gate blocks until a human approves it — it is NEVER active/approved here).
+ *
+ * NOTE: this does NOT reuse upsertVision — that helper hardcodes status='active' +
+ * chairman_approved=true WITHOUT extracted_dimensions, which the DB CHECK
+ * eva_vision_documents_active_rich_check rejects. status='draft_seed' passes the
+ * CHECK vacuously.
+ *
+ * Idempotent: if ANY L2 row exists for the venture (any status) this is a no-op.
+ *
+ * @param {Object} params
+ * @param {Object} params.supabase - Supabase service client
+ * @param {string} params.ventureId - UUID of the venture
+ * @param {string} [params.ventureName] - Human name for key generation
+ * @param {Object} [params.logger] - Logger (defaults to console)
+ * @returns {Promise<Object>} { vision: <row|null>, skipped: boolean, error: <err|null> }
+ */
+export async function seedDraftL2Vision({ supabase, ventureId, ventureName, logger = console } = {}) {
+  if (!ventureId) throw new Error('ventureId is required');
+  if (!supabase) throw new Error('supabase client is required');
+
+  // Idempotency: if ANY L2 row exists for this venture (any status), no-op.
+  const { data: existingL2, error: existErr } = await supabase
+    .from('eva_vision_documents')
+    .select('id, vision_key, status')
+    .eq('venture_id', ventureId)
+    .eq('level', 'L2')
+    .limit(1)
+    .maybeSingle();
+
+  if (existErr) {
+    logger.warn?.('[Stage17-SeedDraftVision] L2 existence check failed:', existErr.message);
+    return { vision: null, skipped: false, error: existErr };
+  }
+  if (existingL2) {
+    logger.log?.(`[Stage17-SeedDraftVision] L2 vision already exists for venture ${ventureId} (vision_key=${existingL2.vision_key}, status=${existingL2.status}) — no-op.`);
+    return { vision: existingL2, skipped: true, error: null };
+  }
+
+  // Fetch current artifacts for artifact-seeded content.
+  const { data: artifacts, error: fetchErr } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_type, artifact_data, content, lifecycle_stage')
+    .eq('venture_id', ventureId)
+    .eq('is_current', true);
+
+  if (fetchErr) {
+    logger.warn?.('[Stage17-SeedDraftVision] artifact fetch failed:', fetchErr.message);
+    return { vision: null, skipped: false, error: fetchErr };
+  }
+
+  const artifactsByType = {};
+  for (const a of artifacts || []) {
+    artifactsByType[a.artifact_type] = a;
+  }
+
+  const { content } = buildVisionSections(artifactsByType);
+
+  // Build a globally-unique vision_key. Base on the venture slug; suffix if a
+  // collision is possible (different venture sharing a slug, or a re-run race).
+  const ventureSlug = deriveVentureSlug(ventureName);
+  const baseKey = `VISION-${ventureSlug}-L2-DRAFT-SEED-001`;
+  let visionKey = baseKey;
+  const { data: keyCollisions } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key')
+    .like('vision_key', `VISION-${ventureSlug}-L2-DRAFT-SEED-%`);
+  if ((keyCollisions?.length || 0) > 0) {
+    const suffix = String((keyCollisions.length || 0) + 1).padStart(3, '0');
+    visionKey = `VISION-${ventureSlug}-L2-DRAFT-SEED-${suffix}`;
+  }
+
+  const record = {
+    vision_key: visionKey,
+    level: 'L2',
+    venture_id: ventureId,
+    content,
+    status: 'draft_seed',        // NEVER 'active' — passes the active_rich_check vacuously.
+    chairman_approved: false,    // NEVER true — requires human approval downstream.
+    version: 1,
+    extracted_dimensions: null,
+    created_by: 'auto-draft-l2-vision',
+  };
+
+  const { data, error } = await supabase
+    .from('eva_vision_documents')
+    .insert(record)
+    .select('id, vision_key, level, version, status, chairman_approved, created_by')
+    .single();
+
+  if (error) {
+    logger.warn?.('[Stage17-SeedDraftVision] insert failed:', error.message);
+    return { vision: null, skipped: false, error };
+  }
+
+  logger.log?.(`[Stage17-SeedDraftVision] Seeded draft_seed L2 vision ${visionKey} for venture ${ventureId}.`);
+  return { vision: data, skipped: false, error: null };
+}
+
+/**
  * Generate Vision and Architecture documents from venture artifacts.
  *
  * @param {Object} params
@@ -85,39 +243,11 @@ export async function generateDocs({
     artifactsByType[a.artifact_type] = a;
   }
 
-  // 2. Generate venture key slug
-  const ventureSlug = (ventureName || 'VENTURE')
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .substring(0, 30);
+  // 2. Generate venture key slug (shared algorithm — see deriveVentureSlug)
+  const ventureSlug = deriveVentureSlug(ventureName);
 
-  // 3. Build Vision document content
-  const visionSections = {};
-  for (const [sectionKey, sourceTypes] of Object.entries(VISION_SECTION_SOURCES)) {
-    const parts = [];
-    for (const artifactType of sourceTypes) {
-      const artifact = artifactsByType[artifactType];
-      if (artifact) {
-        const raw = artifact.content || (artifact.artifact_data ? JSON.stringify(artifact.artifact_data) : '');
-        if (raw) {
-          parts.push(sanitizeForPrompt(raw, 2000));
-        }
-      }
-    }
-    if (parts.length > 0) {
-      visionSections[sectionKey] = parts.join('\n\n');
-    } else {
-      visionSections[sectionKey] = sectionKey === 'ui_ux_wireframes'
-        ? 'N/A — no UI component identified in venture artifacts'
-        : `[Section pending — source artifacts (${sourceTypes.join(', ')}) not yet available]`;
-    }
-  }
-
-  // Build Vision content markdown
-  const visionContent = Object.entries(visionSections)
-    .map(([key, body]) => `## ${key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}\n\n${body}`)
-    .join('\n\n');
+  // 3. Build Vision document content (shared assembly — see buildVisionSections)
+  const { sections: visionSections, content: visionContent } = buildVisionSections(artifactsByType);
 
   // Generate vision key
   // Find next available number

--- a/scripts/one-off/backfill-draft-l2-vision.mjs
+++ b/scripts/one-off/backfill-draft-l2-vision.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-4 — backfill draft_seed L2 vision docs.
+ *
+ * In-flight leo_bridge ventures already past S17 never ran the new
+ * _postStageHook_S17_SeedDraftVision, so they have NO L2 vision and would hit
+ * VENTURE_L2_VISION_MISSING at the S19 gate (now fail-loud). This seeds a
+ * status='draft_seed' L2 vision for each affected venture using the SAME
+ * seedDraftL2Vision logic the S17 hook uses.
+ *
+ * Selection: ventures with current_lifecycle_stage BETWEEN 17 AND 20,
+ *   COALESCE(build_model,'leo_bridge') <> 'seeded_repo',
+ *   and NO eva_vision_documents row with level='L2' + status='active' + chairman_approved=true.
+ * seedDraftL2Vision itself is idempotent (no-op if ANY L2 doc — incl. draft_seed — exists),
+ * so a venture that already has an unapproved draft_seed L2 is left untouched.
+ *
+ * Does NOT auto-approve and does NOT reroute build_model.
+ *
+ * DRY-RUN by default (lists affected ventures); pass --apply to mutate.
+ *
+ * Usage:
+ *   node scripts/one-off/backfill-draft-l2-vision.mjs           # dry-run
+ *   node scripts/one-off/backfill-draft-l2-vision.mjs --apply   # mutate
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { seedDraftL2Vision } from '../lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js';
+
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  const supabase = await createSupabaseServiceClient('engineer');
+
+  console.log(`[backfill-draft-l2] mode=${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+
+  // 1. Candidate ventures: stage 17-20, not seeded_repo.
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, name, current_lifecycle_stage, build_model')
+    .gte('current_lifecycle_stage', 17)
+    .lte('current_lifecycle_stage', 20);
+
+  if (vErr) {
+    console.error('[backfill-draft-l2] venture query failed:', vErr);
+    process.exit(1);
+  }
+
+  const candidates = (ventures || []).filter(
+    (v) => (v.build_model || 'leo_bridge') !== 'seeded_repo'
+  );
+  console.log(`[backfill-draft-l2] stage 17-20 ventures: ${ventures?.length ?? 0}; non-seeded_repo candidates: ${candidates.length}`);
+
+  // 2. Exclude ventures that already have a chairman-approved canonical L2 vision.
+  const affected = [];
+  for (const v of candidates) {
+    const { data: approved, error: aErr } = await supabase
+      .from('eva_vision_documents')
+      .select('vision_key')
+      .eq('venture_id', v.id)
+      .eq('level', 'L2')
+      .eq('status', 'active')
+      .eq('chairman_approved', true)
+      .limit(1)
+      .maybeSingle();
+    if (aErr) {
+      console.error(`[backfill-draft-l2] approved-L2 check failed for ${v.id}:`, aErr.message);
+      process.exit(2);
+    }
+    if (!approved) affected.push(v);
+  }
+
+  console.log(`[backfill-draft-l2] ventures needing a draft_seed L2 (no approved canonical L2): ${affected.length}`);
+  for (const v of affected) {
+    console.log(`   - ${v.name || '(unnamed)'} (id=${v.id}, stage=${v.current_lifecycle_stage}, build_model=${v.build_model || 'leo_bridge (default)'})`);
+  }
+
+  if (affected.length === 0) {
+    console.log('[backfill-draft-l2] Nothing to backfill. Idempotent no-op.');
+    return;
+  }
+
+  if (!APPLY) {
+    console.log('[backfill-draft-l2] DRY-RUN — no changes made. Re-run with --apply to seed draft_seed L2 visions.');
+    return;
+  }
+
+  let seeded = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const v of affected) {
+    const res = await seedDraftL2Vision({
+      supabase,
+      ventureId: v.id,
+      ventureName: v.name,
+      logger: console,
+    });
+    if (res.error) {
+      console.error(`[backfill-draft-l2] FAILED for ${v.id}:`, res.error.message);
+      failed += 1;
+    } else if (res.skipped) {
+      // An L2 (e.g. an existing unapproved draft_seed) already exists — left untouched.
+      skipped += 1;
+    } else {
+      console.log(`[backfill-draft-l2] OK ${v.name || v.id}: seeded ${res.vision?.vision_key}`);
+      seeded += 1;
+    }
+  }
+
+  console.log(`[backfill-draft-l2] Done. seeded=${seeded}, skipped(existing L2)=${skipped}, failed=${failed}`);
+  if (failed > 0) process.exit(3);
+}
+
+main().catch((e) => {
+  console.error('[backfill-draft-l2] Unexpected error:', e);
+  process.exit(99);
+});

--- a/tests/unit/eva/stage-execution-worker-s19-gate.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-gate.test.js
@@ -1,0 +1,219 @@
+/**
+ * SD-LEO-INFRA-RELIABLE-S19-BUILD-001 / FR-2 + FR-3
+ *
+ * The fail-loud S19 leo_bridge gate. Verifies _runS19Bridge returns the
+ * { created, errors, orchestratorKey, childKeys } contract for the discriminated
+ * cases (created / idempotency-no-op / VENTURE_L2_VISION_MISSING real-failure), the
+ * S19 entry-gate block-decision discrimination mirrors the NC-7 /already exists/ regex,
+ * _blockS19LeoBridge writes the reason:'vision_pending' block row, and the FR-3
+ * vision_key lookup filters to the chairman-approved canonical L2 only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the bridge module so _runS19Bridge's dynamic import resolves to a controllable stub.
+const convertSprintToSDs = vi.fn();
+vi.mock('../../../lib/eva/lifecycle-sd-bridge.js', () => ({
+  convertSprintToSDs: (...args) => convertSprintToSDs(...args),
+  buildBridgeArtifactRecord: vi.fn(() => ({ lifecycle_stage: 19, artifact_type: 'x', title: 't', content: {}, metadata: {} })),
+}));
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({ writeArtifact: vi.fn() }));
+
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn(), releaseProcessingLock: vi.fn(), markCompleted: vi.fn(),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', KILLED_AT_REALITY_GATE: 'killed_at_reality_gate' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({ createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn() }));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue({}) }));
+vi.mock('../../../lib/eva/autonomy-model.js', () => ({ checkAutonomy: vi.fn().mockResolvedValue({ action: 'block', level: 'L0' }) }));
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn().mockResolvedValue({ isBlocking: () => false, isReview: () => false }),
+}));
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+/**
+ * Chainable supabase mock. `responses` maps an ordered queue of resolved values
+ * per (table) for the terminal awaits (.maybeSingle / .single). The chain records
+ * upserts/inserts and the .eq filter args (so FR-3 filters can be asserted).
+ */
+function createMockSupabase({ ventureName = 'CronGenius', buildModel = 'leo_bridge', visionDoc = null, archPlan = null, artifacts = [] } = {}) {
+  const upsertCalls = [];
+  const eqArgs = [];
+  // Per-table terminal resolvers (LIFO queues consumed by maybeSingle/single).
+  const make = () => {
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn((col, val) => { eqArgs.push({ col, val }); return chain; }),
+      in: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      maybeSingle: vi.fn(),
+      single: vi.fn(),
+      upsert: vi.fn((payload) => { upsertCalls.push(payload); return Promise.resolve({ data: null, error: null }); }),
+      insert: vi.fn(() => chain),
+      update: vi.fn(() => chain),
+    };
+    return chain;
+  };
+  const from = vi.fn((table) => {
+    const chain = make();
+    if (table === 'ventures') {
+      chain.single.mockResolvedValue({ data: { name: ventureName }, error: null });
+      chain.maybeSingle.mockResolvedValue({ data: { name: ventureName, build_model: buildModel }, error: null });
+    } else if (table === 'venture_stage_work') {
+      chain.maybeSingle.mockResolvedValue({ data: { advisory_data: { build_method: null } }, error: null });
+    } else if (table === 'venture_artifacts') {
+      // terminal await is the chained .limit() result for the artifacts query path
+      chain.limit.mockReturnValue(Promise.resolve({ data: artifacts, error: null }));
+    } else if (table === 'eva_vision_documents') {
+      chain.maybeSingle.mockResolvedValue({ data: visionDoc, error: null });
+    } else if (table === 'eva_architecture_plans') {
+      chain.maybeSingle.mockResolvedValue({ data: archPlan, error: null });
+    } else {
+      chain.maybeSingle.mockResolvedValue({ data: null, error: null });
+      chain.single.mockResolvedValue({ data: null, error: null });
+    }
+    return chain;
+  });
+  return { from, _upsertCalls: upsertCalls, _eqArgs: eqArgs };
+}
+
+// A venture S19 with one sd_bridge_payload so _runS19Bridge reaches convertSprintToSDs.
+const ARTIFACTS_WITH_PAYLOAD = [
+  {
+    content: JSON.stringify({
+      sprint_name: 'Sprint 1', sprint_goal: 'g', sprint_duration_days: 14,
+      sd_bridge_payloads: [{ title: 'A', type: 'feature', description: 'd', scope: 's', success_criteria: 'sc' }],
+    }),
+    metadata: null,
+  },
+];
+
+describe('_runS19Bridge (FR-2 contract + FR-3 vision filter)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('VENTURE_L2_VISION_MISSING → created:false with the missing-vision error (real failure)', async () => {
+    convertSprintToSDs.mockResolvedValue({
+      created: false, orchestratorKey: null, childKeys: [], grandchildKeys: [],
+      errors: ['Venture CronGenius: no L2 vision document found.\nTo unblock orchestrator generation, run:'],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+    expect(res.created).toBe(false);
+    expect(res.errors.length).toBeGreaterThan(0);
+    expect(JSON.stringify(res.errors)).toContain('no L2 vision document found');
+    expect(JSON.stringify(res.errors)).not.toMatch(/already exists/i);
+  });
+
+  it('created:true → returns created:true with orchestratorKey', async () => {
+    convertSprintToSDs.mockResolvedValue({
+      created: true, orchestratorKey: 'SD-LEO-ORCH-1', childKeys: ['c1', 'c2'], grandchildKeys: [], errors: [],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+    expect(res.created).toBe(true);
+    expect(res.orchestratorKey).toBe('SD-LEO-ORCH-1');
+    expect(res.childKeys).toEqual(['c1', 'c2']);
+  });
+
+  it('idempotency (existing orchestrator) → created:false, errors empty', async () => {
+    convertSprintToSDs.mockResolvedValue({
+      created: false, orchestratorKey: 'SD-LEO-ORCH-EXISTING', childKeys: ['c1'], grandchildKeys: [], errors: [],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+    expect(res.created).toBe(false);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('FR-3: vision_key lookup filters to level=L2 + status=active + chairman_approved=true', async () => {
+    convertSprintToSDs.mockResolvedValue({ created: true, orchestratorKey: 'o', childKeys: [], grandchildKeys: [], errors: [] });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    await worker._runS19Bridge('v-1');
+
+    // The eva_vision_documents lookup must have applied all three FR-3 filters.
+    const cols = supabase._eqArgs.map((e) => `${e.col}=${e.val}`);
+    expect(cols).toContain('level=L2');
+    expect(cols).toContain('status=active');
+    expect(cols).toContain('chairman_approved=true');
+  });
+
+  it('seeded_repo → created:true (gate proceeds; repo-seeding handled separately)', async () => {
+    const supabase = createMockSupabase({ buildModel: 'seeded_repo', artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+    expect(res.created).toBe(true);
+    expect(convertSprintToSDs).not.toHaveBeenCalled();
+  });
+});
+
+describe('_blockS19LeoBridge (FR-2 block row)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('upserts a vision_pending blocked / sd_required row keyed on (venture_id,lifecycle_stage)', async () => {
+    const supabase = createMockSupabase();
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+
+    await worker._blockS19LeoBridge('v-1', ['Venture CronGenius: no L2 vision document found.']);
+
+    const row = supabase._upsertCalls.at(-1);
+    expect(row.venture_id).toBe('v-1');
+    expect(row.lifecycle_stage).toBe(19);
+    expect(row.stage_status).toBe('blocked');
+    expect(row.work_type).toBe('sd_required');
+    expect(row.advisory_data.build_model).toBe('leo_bridge');
+    expect(row.advisory_data.bridge_failed).toBe(true);
+    expect(row.advisory_data.reason).toBe('vision_pending');
+    expect(Array.isArray(row.advisory_data.bridge_errors)).toBe(true);
+    expect(typeof row.advisory_data.escalated_at).toBe('string');
+  });
+});
+
+/**
+ * Gate discrimination logic (mirrors the NC-7 regex branch in the S19 entry gate).
+ * The block decision is inline in the _processVenture loop; this characterization
+ * test replicates the exact discriminator so a regression in the rule is caught.
+ */
+function gateDecision(bridge, advisory = {}) {
+  if (advisory.chairman_override === true) return 'proceed';
+  const errs = bridge.errors || [];
+  const errStr = JSON.stringify(errs);
+  const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
+  if (bridge.created || isIdempotent) return 'proceed';
+  return 'block';
+}
+
+describe('S19 entry-gate discrimination (mirrors inline gate logic)', () => {
+  it('VENTURE_L2_VISION_MISSING → block + no advance', () => {
+    expect(gateDecision({ created: false, errors: ['Venture X: no L2 vision document found.'] })).toBe('block');
+  });
+  it('errors empty (idempotency) → proceed', () => {
+    expect(gateDecision({ created: false, errors: [] })).toBe('proceed');
+  });
+  it('/already exists/ → proceed', () => {
+    expect(gateDecision({ created: false, errors: ['Orchestrator already exists for venture'] })).toBe('proceed');
+  });
+  it('created:true → proceed', () => {
+    expect(gateDecision({ created: true, errors: [] })).toBe('proceed');
+  });
+  it('chairman_override → proceed even on a real failure', () => {
+    expect(gateDecision({ created: false, errors: ['no L2 vision document found'] }, { chairman_override: true })).toBe('proceed');
+  });
+});


### PR DESCRIPTION
## Root cause (RCA aafbf4a5)
`leo_bridge` ventures reach Stage 19 with a sprint plan but **0 SDs**: the lifecycle-SD bridge requires a chairman-approved L2 vision document that the pipeline never creates even a *draft* of, and the S19 bridge hook is fire-and-forget so the venture **silently advances past S19 un-built** (DataDistill reached stage 19/20/21 with 0 SDs and no S19 stage-work row). The chairman-approval gate is **intentional and stays** — this gives it an on-ramp and makes the silent failure loud.

## Changes
- **FR-1** — `seedDraftL2Vision` (stage-17-doc-generation.js): auto-creates an **artifact-seeded** DRAFT L2 vision (`status=draft_seed`, `chairman_approved=false`), idempotent; wired into the S17 hook chain, gated on `build_model=leo_bridge`, non-throwing. Never writes `active`/approved; does **not** reuse `upsertVision` (which `active_rich_check` rejects for thin content).
- **FR-2** (hard cutover, no flag) — extract `_runS19Bridge`; the **synchronous** S19 entry gate now awaits it and **BLOCKS** (`venture_stage_work` `stage_status=blocked`, `reason=vision_pending`) instead of silently advancing — discriminating idempotency/`already exists` (proceed) from real failure (block + break). Honors `advisory_data.chairman_override`; cheap re-block fast-path. Legacy hook delegates to `_runS19Bridge` (NC-7 net retained).
- **FR-3** — worker `vision_key` lookup filtered to `level=L2` + `status=active` + `chairman_approved` to match `assertVentureVisionReady`.
- **FR-4** — `scripts/one-off/backfill-draft-l2-vision.mjs` (dry-run default) seeds draft L2 visions for in-flight `leo_bridge` ventures so the fail-loud block does **not** strand them (no auto-approval, no reroute).

## Tests / safety
- **40 passing** (7 FR-1 + 11 FR-2/FR-3 new, + 3 canonical regression suites green). `node --check` clean on all changed files.
- **No schema migration** (`draft_seed` + `level=L2` exist; `active_rich_check` is NOT VALID).
- Fail-safe: vision-missing → clean block; an unexpected throw propagates *before* the advance logic, so the venture never silently advances.

## PR size
822 LOC, but 355 are tests + 116 a standalone backfill script. FR-1+FR-2 ship **atomically** per the RCA blast-radius ruling (fail-loud without auto-draft strands in-flight ventures), so the set is not safely splittable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)