### PR TITLE
fix(QF-20260531-411): correct eva import path in backfill-draft-l2-vision.mjs

### DIFF
--- a/scripts/one-off/backfill-draft-l2-vision.mjs
+++ b/scripts/one-off/backfill-draft-l2-vision.mjs
@@ -24,7 +24,7 @@
  */
 
 import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
-import { seedDraftL2Vision } from '../lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js';
+import { seedDraftL2Vision } from '../../lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js';
 
 const APPLY = process.argv.includes('--apply');
 


### PR DESCRIPTION
One-line fix: the FR-4 backfill script (from SD-LEO-INFRA-RELIABLE-S19-BUILD-001) imported `seedDraftL2Vision` from `../lib/eva/...` (resolves to nonexistent `scripts/lib/eva/`) instead of `../../lib/eva/...` (repo-root). The script crashed with ERR_MODULE_NOT_FOUND and could not run. Verified the dry-run now correctly lists the 3 in-flight leo_bridge ventures needing a draft L2 vision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)