### PR TITLE
fix(QF-20260531-948): repair SessionStart stale-main freshness hook

### DIFF
--- a/scripts/hooks/__tests__/concurrent-session-worktree.test.js
+++ b/scripts/hooks/__tests__/concurrent-session-worktree.test.js
@@ -197,8 +197,14 @@ describe('checkBranchFreshness (QF-20260511-228 — closes feedback acd4e5ab)', 
   let checkBranchFreshness;
   beforeEach(() => { ({ checkBranchFreshness } = loadHookExports()); });
 
-  it('returns null when branch is "main"', () => {
-    expect(checkBranchFreshness('main')).toBeNull();
+  it('no longer early-returns on "main" (QF-20260531-948: the defect that hid stale local main)', () => {
+    // 'main' used to early-return null, so a stale main was never warned. The guard now only
+    // skips empty/unknown branches; 'main' falls through to the fetch-first check.
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    const fnStart = src.indexOf('function checkBranchFreshness(');
+    const guard = src.slice(fnStart, fnStart + 200);
+    expect(guard).toMatch(/if \(!branch \|\| branch === 'unknown'\) return null;/);
+    expect(guard).not.toMatch(/branch === 'main'/);
   });
   it('returns null when branch is "unknown" (getBranch fallback)', () => {
     expect(checkBranchFreshness('unknown')).toBeNull();
@@ -209,28 +215,33 @@ describe('checkBranchFreshness (QF-20260511-228 — closes feedback acd4e5ab)', 
     expect(checkBranchFreshness(null)).toBeNull();
   });
 
-  it('static-guard: hook source contains the expected git rev-list and warning shape', () => {
+  it('static-guard: hook source fetches origin/main FIRST, then rev-list at threshold default 1', () => {
     const src = fs.readFileSync(HOOK_PATH, 'utf8');
-    // The function must use rev-list against origin/main (not e.g. main, not @{upstream})
+    // QF-20260531-948 defect #2: must fetch the origin/main ref BEFORE counting, else the count
+    // is vs a stale ref. Fail-open with a hard timeout so SessionStart is never blocked.
+    expect(src).toMatch(/git fetch --quiet --no-tags origin main/);
+    expect(src).toMatch(/timeout:\s*4000/);
+    // Counts against origin/main (not main, not @{upstream})
     expect(src).toMatch(/git rev-list --count HEAD\.\.origin\/main/);
-    // Threshold must be configurable via STALE_BRANCH_WARN_THRESHOLD env, default 10
+    // Threshold configurable via STALE_BRANCH_WARN_THRESHOLD, default now 1 (was 10 — defect #3)
     expect(src).toMatch(/STALE_BRANCH_WARN_THRESHOLD\b/);
-    expect(src).toMatch(/\|\|\s*['"]10['"]/);
+    expect(src).toMatch(/\|\|\s*['"]1['"]/);
     // Loud warning banner must be emitted
     expect(src).toMatch(/STALE BRANCH WARNING/);
     // Telemetry event name must match dotted convention used elsewhere
     expect(src).toMatch(/session\.stale_branch_warning/);
   });
 
-  it('static-guard: main() wires checkBranchFreshness after getBranch()', () => {
+  it('static-guard: main() runs checkBranchFreshness BEFORE the worktree + supabase bails', () => {
     const src = fs.readFileSync(HOOK_PATH, 'utf8');
-    // Anchor on `const mySessionId = getCurrentSessionId()` (unique to main())
-    // to skip the unrelated `const branch = getBranch()` inside detectWorkType().
-    const idx = src.indexOf('const mySessionId = getCurrentSessionId()');
-    expect(idx).toBeGreaterThan(0);
-    const slice = src.slice(idx, idx + 600);
-    expect(slice).toMatch(/const branch = getBranch\(\)/);
-    expect(slice).toMatch(/checkBranchFreshness\s*\(\s*branch\s*\)/);
+    // QF-20260531-948 defects #4/#5: the call must precede both bails so it fires on main and
+    // inside worktrees regardless of DB availability.
+    const callIdx = src.indexOf('checkBranchFreshness(getBranch())');
+    expect(callIdx).toBeGreaterThan(0);
+    const worktreeBailIdx = src.indexOf('if (isInsideWorktree()) {');
+    const supabaseBailIdx = src.indexOf('if (!supabase) {');
+    expect(worktreeBailIdx).toBeGreaterThan(callIdx);
+    expect(supabaseBailIdx).toBeGreaterThan(callIdx);
   });
 });
 
@@ -314,3 +325,32 @@ function chainableQuery(result) {
   };
   return chain;
 }
+
+// ─── QF-20260531-948: stale-main freshness repair ────────────────────────────
+// The decision (warn vs none) is extracted as a pure function so the threshold
+// behaviour is testable without mocking git. The key regression these guard:
+// the prior hook warned only when behind > 10, so the common "a few commits
+// behind origin/main" case (e.g. 6 behind, witnessed) passed SILENTLY and
+// already-shipped code read as "missing".
+describe('decideFreshnessAction (QF-20260531-948 stale-main repair)', () => {
+  let decideFreshnessAction;
+  beforeEach(() => { ({ decideFreshnessAction } = loadHookExports()); });
+
+  it('warns at the default threshold of 1 (1–9 behind used to pass silently)', () => {
+    expect(decideFreshnessAction(1, 1)).toBe('warn');
+    expect(decideFreshnessAction(6, 1)).toBe('warn'); // the exact case witnessed this session
+  });
+
+  it('does not warn when up to date', () => {
+    expect(decideFreshnessAction(0, 1)).toBe('none');
+  });
+
+  it('honors a custom higher threshold via STALE_BRANCH_WARN_THRESHOLD', () => {
+    expect(decideFreshnessAction(3, 5)).toBe('none');
+    expect(decideFreshnessAction(5, 5)).toBe('warn');
+  });
+
+  it('returns none for a non-finite count (git failure path)', () => {
+    expect(decideFreshnessAction(NaN, 1)).toBe('none');
+  });
+});

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -137,32 +137,53 @@ function getBranch() {
 }
 
 /**
- * QF-20260511-228 (closes feedback acd4e5ab) — Stale-branch detection.
- * Warns when HEAD is significantly behind origin/main, preventing silent
- * regression of already-shipped fixes (4× witnessed: QF-442/QF-699/QF-818
- * + 12-commit-behind session that filed the feedback). Threshold via
- * STALE_BRANCH_WARN_THRESHOLD env (default 10).
+ * QF-20260511-228 (closes feedback acd4e5ab); repaired by QF-20260531-948 (RCA adb5530d).
+ * Detect a STALE local checkout (HEAD behind origin/main) so reads reflect what SHIPS, not a
+ * pre-merge snapshot. The original guard was silent in the common case: it (1) bailed on 'main'
+ * (the most damaging case), (2) never fetched — so it counted against a stale origin/main ref,
+ * (3) warned only when >10 behind (the wrong-conclusion damage starts at 1), and its call site
+ * sat behind the Supabase + worktree bails. Now: fetch-first (fail-open, hard timeout — never
+ * blocks SessionStart), runs on EVERY branch incl. main, and warns at >= threshold (default 1).
+ * (Auto fast-forward is deliberately deferred to an opt-in follow-up; `git merge --ff-only` is
+ * the suggested manual action, safe by construction.)
  */
+function decideFreshnessAction(behind, threshold) {
+  // Pure decision (no I/O) so the threshold/main behaviour is unit-testable without git mocks.
+  if (!Number.isFinite(behind) || behind < threshold) return 'none';
+  return 'warn';
+}
+
 function checkBranchFreshness(branch) {
-  if (!branch || branch === 'main' || branch === 'unknown') return null;
+  if (!branch || branch === 'unknown') return null;
+  // Refresh ONLY the origin/main ref (cheap, single-branch). Fail-open with a hard timeout so an
+  // offline/slow network never blocks SessionStart — WITHOUT this the count is vs a stale ref
+  // (defect #2), which is exactly how an already-shipped fix reads as "missing".
+  let fetched = false;
   try {
-    const out = execSync('git rev-list --count HEAD..origin/main', {
+    execSync('git fetch --quiet --no-tags origin main', {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], timeout: 4000
+    });
+    fetched = true;
+  } catch { /* offline/timeout — compare against the last-known origin/main ref */ }
+  try {
+    const behind = parseInt(execSync('git rev-list --count HEAD..origin/main', {
       encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']
-    }).trim();
-    const behind = parseInt(out, 10);
+    }).trim(), 10);
     if (!Number.isFinite(behind)) return null;
-    const threshold = parseInt(process.env.STALE_BRANCH_WARN_THRESHOLD || '10', 10);
-    if (behind > threshold) {
+    const threshold = parseInt(process.env.STALE_BRANCH_WARN_THRESHOLD || '1', 10);
+    const warned = decideFreshnessAction(behind, threshold) === 'warn';
+    if (warned) {
       console.log('\n========================================');
-      console.log('  STALE BRANCH WARNING');
+      console.log('  STALE BRANCH WARNING — local reads may not reflect what ships');
       console.log('========================================');
-      console.log(`  Current branch: ${branch}`);
-      console.log(`  Behind origin/main by: ${behind} commit(s) (threshold ${threshold})`);
-      console.log(`  Suggestion: git pull origin main --ff-only  (or fresh worktree from main)`);
+      console.log(`  Branch: ${branch}  -  behind origin/main by ${behind} commit(s)`);
+      if (!fetched) console.log('  (offline: count is vs the last-known origin/main ref)');
+      console.log('  Sync first:  git fetch origin main && git merge --ff-only origin/main');
+      console.log('  or read what ships:  git show origin/main:<path>');
       console.log('========================================\n');
-      logEvent('session.stale_branch_warning', { branch, commits_behind_main: behind, threshold });
+      logEvent('session.stale_branch_warning', { branch, commits_behind_main: behind, threshold, fetched });
     }
-    return { behind, threshold, warned: behind > threshold };
+    return { behind, threshold, warned, fetched };
   } catch { return null; }
 }
 
@@ -667,6 +688,11 @@ async function main() {
   await cleanupStaleConcurrentWorktrees(supabase);
   pruneStaleLocalBranches();
 
+  // QF-20260531-948 (RCA adb5530d): stale-checkout warning runs BEFORE the worktree + Supabase
+  // bails below, so it fires on `main` and inside worktrees regardless of DB availability —
+  // the exact cases the prior placement (after both bails) silently skipped.
+  checkBranchFreshness(getBranch());
+
   // Skip if already inside a worktree — prevents nested worktree creation.
   // Must be checked BEFORE concurrent detection, not after.
   if (isInsideWorktree()) {
@@ -709,9 +735,6 @@ async function main() {
   const mySessionId = getCurrentSessionId();
   const codebase = getCodebase();
   const branch = getBranch();
-
-  // QF-20260511-228 (closes feedback acd4e5ab): warn when on a stale branch
-  checkBranchFreshness(branch);
 
   // FR-1: Check for concurrent sessions
   const concurrent = await findConcurrentSessions(supabase, mySessionId, codebase, branch);
@@ -861,7 +884,7 @@ async function main() {
 // Test exports (used by scripts/hooks/__tests__/concurrent-session-worktree.test.js)
 // Gating `main()` behind `require.main === module` lets tests `require()` this
 // file without triggering the SessionStart side-effects.
-module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees, checkBranchFreshness, unlinkNodeModulesJunction };
+module.exports = { isWorktreeInUseBySession, getActiveDbClaims, cleanupStaleConcurrentWorktrees, checkBranchFreshness, decideFreshnessAction, unlinkNodeModulesJunction };
 
 if (require.main === module) {
   // Run with timeout protection (hook has 5s timeout)


### PR DESCRIPTION
## Summary
RCA adb5530d. The existing SessionStart freshness guard `checkBranchFreshness()` in `scripts/hooks/concurrent-session-worktree.cjs` was silently ineffective due to 5 defects: it (1) bailed on `main`, (2) never ran `git fetch` (counted against a stale origin/main ref), (3) warned only when >10 behind, and its call sat behind the (4) Supabase and (5) worktree bails. Net effect: local `main` silently drifts behind `origin/main` and file reads reflect pre-merge code — this session, already-shipped FR-1 read as "missing," nearly causing a re-implementation. Recurring (≥7×; no `issue_patterns` row covered it).

## Fix
- **fetch-first** (`git fetch --quiet --no-tags origin main`, fail-open, 4s timeout — never blocks SessionStart)
- **runs on every branch incl. `main`** (dropped the `branch==='main'` early-return)
- **threshold ≥1** (`STALE_BRANCH_WARN_THRESHOLD` default 10 → 1)
- **call moved ahead of the worktree + Supabase bails** so it fires regardless of DB availability / worktree context
- extracted pure `decideFreshnessAction` for unit-testable threshold behaviour
- (auto fast-forward deliberately deferred to an opt-in follow-up; warn-only is the RCA-recommended safe default in a parallel-session shared-tree repo)

## Tests
25/25 in `concurrent-session-worktree.test.js` (4 new decider tests + 3 updated static guards for the new placement/threshold/fetch-first shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)