### PR TITLE
fix(SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001): hard S19 SD-completion gate (no approval/skip/override bypass)

### DIFF
--- a/lib/eva/s20-pause-controller.js
+++ b/lib/eva/s20-pause-controller.js
@@ -69,9 +69,28 @@ export class S20PauseController {
       // Find linked orchestrator SDs created by S19 bridge
       const orchestratorSDs = await this._findLinkedOrchestratorSDs(ventureId);
 
-      // No SDs linked — legacy venture, skip pause
+      // No SDs linked. SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 (FR-2): FAIL CLOSED for a leo_bridge
+      // venture. Zero SDs means the build never happened (unapproved vision / failed bridge) — NOT a
+      // legacy venture. The prior fail-open ('no_sds' -> blocked:false) let a 0-SD venture sail
+      // through S20 and on to the reality gate (RCA a14ff698: DataDistill). Only genuinely legacy
+      // (non-leo_bridge) ventures keep the backward-compatible pass.
       if (orchestratorSDs.length === 0) {
-        this._logger.log(`[S20Pause] Venture ${ventureId}: no linked SDs — skipping pause (backward compatible)`);
+        let buildModel = null;
+        try {
+          const { data: vRow } = await this._supabase
+            .from('ventures').select('build_model').eq('id', ventureId).maybeSingle();
+          const { resolveBuildModel } = await import('./bridge/resolve-build-model.js');
+          buildModel = resolveBuildModel({ ventureBuildModel: vRow?.build_model });
+        } catch (e) {
+          this._logger.warn(`[S20Pause] build-model resolution failed (non-fatal): ${e.message}`);
+        }
+        if (buildModel === 'leo_bridge') {
+          this._logger.warn(
+            `[S20Pause] Venture ${ventureId}: build_model=leo_bridge with ZERO build SDs — FAIL CLOSED (the build never happened; blocking instead of advancing).`
+          );
+          return { blocked: true, status: 'no_sds_leo_bridge', data: { total_sds: 0, build_model: 'leo_bridge' } };
+        }
+        this._logger.log(`[S20Pause] Venture ${ventureId}: no linked SDs (build_model=${buildModel || 'legacy'}) — skipping pause (backward compatible)`);
         return { blocked: false, status: 'no_sds', data: { total_sds: 0 } };
       }
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -624,6 +624,48 @@ export class StageExecutionWorker {
           }
         }
 
+        // SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 (FR-1): HARD pre-advance S19 invariant gate.
+        // A leo_bridge venture MUST NOT pass Stage 19 until its orchestrator + all child SDs are
+        // completed. RCA a14ff698: an APPROVED S19 stage_gate decision triggers the pre-execution
+        // guards below to advance via pre_exec_skip (lines ~661 and ~903) BEFORE the S19 entry gate
+        // (which would block) is ever reached — bypassing the invariant (DataDistill jumped 19->23
+        // with 0 SDs). This gate runs FIRST and engages on exactly that condition (an approved S19
+        // decision while the build is incomplete): it (idempotently) runs the bridge to create the
+        // build SDs if the vision is now approved, then HARD-BLOCKS advancement if still incomplete.
+        // Non-leo_bridge ventures and fresh S19 arrivals (no approved decision) fall through to the
+        // existing entry gate, which handles their blocking.
+        if (currentStage === 19) {
+          const s19Complete = await this._isLeoBridgeBuildComplete(ventureId);
+          if (s19Complete === false) {
+            const { data: approvedS19 } = await this._supabase
+              .from('chairman_decisions')
+              .select('id')
+              .eq('venture_id', ventureId)
+              .eq('lifecycle_stage', 19)
+              .eq('status', 'approved')
+              .neq('decision_type', 'advisory')
+              .limit(1)
+              .maybeSingle();
+            if (approvedS19) {
+              // Idempotently (re)run the bridge — creates the orchestrator+children if the L2 vision
+              // is now chairman-approved; no-ops ('already exists') if they already exist.
+              try { await this._runS19Bridge(ventureId); } catch (e) {
+                this._logger.warn(`[Worker] S19 hard gate: bridge run failed (non-fatal): ${e.message}`);
+              }
+              const recheck = await this._isLeoBridgeBuildComplete(ventureId);
+              if (recheck === false) {
+                this._logger.warn(
+                  `[Worker] S19 HARD GATE (SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001): approved S19 decision but the leo_bridge build is NOT complete (orchestrator+children not all completed) — refusing to advance venture ${ventureId} past Stage 19.`
+                );
+                await this._blockS19LeoBridge(ventureId, ['s19_sd_completion_invariant']);
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 's19_sd_completion_invariant' };
+                break;
+              }
+            }
+          }
+        }
+
         // P0 UNIVERSAL pre-execution guard: check for approved decisions at ANY stage
         // before calling processStage. This prevents re-execution when chairman approves
         // stages blocked by taste gates, promotion gates, or other non-BLOCKING paths.
@@ -651,7 +693,12 @@ export class StageExecutionWorker {
             if (existingArt && existingArt.length > 0) {
               // Stage already approved + has artifacts — skip re-execution
               const govEarly = await getStageGovernance(this._supabase);
-              const isBlockingGate = govEarly.isBlocking(currentStage);
+              // SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 (FR-3): reconcile the classification schism.
+              // isBlocking() is work_type-filtered (S19 work_type='sd_required' => false) while S19 is
+              // a configured hard_gate_stage; treating only isBlocking() as authoritative let S19
+              // pre_exec_skip-advance (RCA a14ff698). Hard-gate stages must fall through to the
+              // side-effect-aware gate-specific guard below (matching this block's own comment).
+              const isBlockingGate = govEarly.isBlocking(currentStage) || await this._isInHardGateStages(currentStage);
               if (!isBlockingGate) {
                 // Non-BLOCKING stages: just advance (no vision side-effects needed)
                 this._logger.log(
@@ -3304,6 +3351,43 @@ export class StageExecutionWorker {
       orchestratorKey: bridgeResult.orchestratorKey || null,
       childKeys: bridgeResult.childKeys || [],
     };
+  }
+
+  /**
+   * SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 (FR-1, shared evaluator): is a leo_bridge venture's
+   * Stage-19 build COMPLETE — i.e. an orchestrator + child SD tree exists for the venture and every
+   * SD has reached a terminal state with at least one genuinely completed (a tree that is ALL
+   * cancelled is NOT a completed build). This is the single source of truth for the S19 hard gate
+   * (here) and the S20 pause controller (lib/eva/s20-pause-controller.js), so "build complete" can
+   * never disagree between the two enforcement points.
+   *
+   * @param {string} ventureId
+   * @returns {Promise<boolean|null>} true = leo_bridge build complete; false = leo_bridge but
+   *   incomplete (0 SDs, any non-terminal SD, or all-cancelled); null = NOT a leo_bridge venture
+   *   (the invariant does not apply — caller should fall through).
+   */
+  async _isLeoBridgeBuildComplete(ventureId) {
+    const { data: ventureRow } = await this._supabase
+      .from('ventures').select('build_model').eq('id', ventureId).maybeSingle();
+    const { data: s19Work } = await this._supabase
+      .from('venture_stage_work').select('advisory_data')
+      .eq('venture_id', ventureId).eq('lifecycle_stage', 19).maybeSingle();
+    const { resolveBuildModel } = await import('./bridge/resolve-build-model.js');
+    const buildModel = resolveBuildModel({
+      ventureBuildModel: ventureRow?.build_model,
+      legacyBuildMethod: s19Work?.advisory_data?.build_method,
+    });
+    if (buildModel !== 'leo_bridge') return null; // invariant applies only to leo_bridge ventures
+    // Explicit chairman escape hatch (consistent with the S19 vision gate honoring chairman_override).
+    if (s19Work?.advisory_data?.chairman_override === true) return true;
+    const { data: sds } = await this._supabase
+      .from('strategic_directives_v2').select('status').eq('venture_id', ventureId);
+    if (!sds || sds.length === 0) return false; // no build SDs = the build never happened
+    const TERMINAL = new Set(['completed', 'cancelled', 'archived']);
+    const COMPLETED = new Set(['completed', 'archived']);
+    const allTerminal = sds.every((sd) => TERMINAL.has(sd.status));
+    const anyCompleted = sds.some((sd) => COMPLETED.has(sd.status));
+    return allTerminal && anyCompleted;
   }
 
   /**

--- a/tests/unit/eva/s20-pause-no-sds-failclosed.test.js
+++ b/tests/unit/eva/s20-pause-no-sds-failclosed.test.js
@@ -1,0 +1,127 @@
+/**
+ * SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 / FR-2 — S20PauseController.check() fails CLOSED on the
+ * zero-SD branch for leo_bridge ventures.
+ *
+ * Before this SD the `orchestratorSDs.length === 0` branch always returned
+ * { blocked:false, status:'no_sds' } (fail-OPEN), so a leo_bridge venture whose build never
+ * produced any SDs (unapproved vision / failed bridge) sailed through S20 to the reality gate
+ * (RCA a14ff698: DataDistill). The new branch (lib/eva/s20-pause-controller.js ~77) resolves the
+ * build model from ventures.build_model and:
+ *   - build_model resolves to 'leo_bridge' → { blocked:true,  status:'no_sds_leo_bridge',
+ *                                              data:{ total_sds:0, build_model:'leo_bridge' } }
+ *   - any other (genuinely legacy) model    → { blocked:false, status:'no_sds',
+ *                                              data:{ total_sds:0 } }  (backward compatible)
+ *
+ * RESOLVER NUANCE (lib/eva/bridge/resolve-build-model.js): an UNSET build_model (null) DEFAULTS to
+ * 'leo_bridge'. So the only way to land on the backward-compatible 'no_sds' pass is an EXPLICIT
+ * non-leo_bridge opt-out — build_model='seeded_repo'. A null build_model now fails closed. These
+ * tests pin that real behavior (a null-passes assumption would be wrong post-default-flip).
+ *
+ * Test strategy (per the implementation): construct a real S20PauseController with a chainable
+ * supabase mock that supplies ventures.build_model, then stub the surrounding plumbing so check()
+ * reaches the zero-SD branch deterministically:
+ *   - _loadPauseState → null            (no prior pause state; not force_advanced / not COMPLETE)
+ *   - _getBuildMethod → 'claude_code'   (≠ 'replit_agent' so it does not take the replit fast-path)
+ *   - _findLinkedOrchestratorSDs → []   (the zero-SD condition under test)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { S20PauseController } from '../../../lib/eva/s20-pause-controller.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+/**
+ * Minimal chainable supabase mock. The only read check() makes after the stubbed methods is
+ * `ventures.select('build_model').eq('id', ventureId).maybeSingle()`, so we answer that.
+ *
+ * @param {string|null} buildModel  ventures.build_model row value (null ⇒ no row returned)
+ */
+function createMockSupabase(buildModel) {
+  const calls = { from: [], eq: [] };
+  const from = vi.fn((table) => {
+    calls.from.push(table);
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn((col, val) => { calls.eq.push({ table, col, val }); return chain; }),
+      maybeSingle: vi.fn(() => {
+        if (table === 'ventures') {
+          return Promise.resolve({ data: buildModel === null ? null : { build_model: buildModel }, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+    };
+    return chain;
+  });
+  return { from, _calls: calls };
+}
+
+/**
+ * Build a controller whose plumbing deterministically routes check() into the zero-SD branch.
+ * @param {string|null} buildModel
+ */
+function makeController(buildModel) {
+  const supabase = createMockSupabase(buildModel);
+  const controller = new S20PauseController(supabase, logger);
+  controller._loadPauseState = vi.fn().mockResolvedValue(null);
+  controller._getBuildMethod = vi.fn().mockResolvedValue('claude_code'); // not replit_agent
+  controller._findLinkedOrchestratorSDs = vi.fn().mockResolvedValue([]); // ZERO SDs
+  // Guard against accidental persistence if a later branch were reached.
+  controller._savePauseState = vi.fn().mockResolvedValue(undefined);
+  return { controller, supabase };
+}
+
+describe('SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 S20PauseController.check() — zero-SD fail-closed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('build_model=leo_bridge + 0 SDs → blocked:true, status:no_sds_leo_bridge, data flags the gap', async () => {
+    const { controller } = makeController('leo_bridge');
+
+    const result = await controller.check('v-bridge-zero');
+
+    expect(result.blocked).toBe(true);
+    expect(result.status).toBe('no_sds_leo_bridge');
+    expect(result.data).toEqual({ total_sds: 0, build_model: 'leo_bridge' });
+  });
+
+  it('build_model=seeded_repo + 0 SDs → blocked:false, status:no_sds (backward compatible legacy pass)', async () => {
+    const { controller } = makeController('seeded_repo');
+
+    const result = await controller.check('v-seeded-zero');
+
+    expect(result.blocked).toBe(false);
+    expect(result.status).toBe('no_sds');
+    expect(result.data).toEqual({ total_sds: 0 });
+  });
+
+  it('build_model UNSET (null) + 0 SDs → fails CLOSED (resolver defaults unset to leo_bridge)', async () => {
+    const { controller } = makeController(null);
+
+    const result = await controller.check('v-null-zero');
+
+    // Post default-flip, an unset build_model resolves to leo_bridge → must block, not pass.
+    expect(result.blocked).toBe(true);
+    expect(result.status).toBe('no_sds_leo_bridge');
+    expect(result.data).toEqual({ total_sds: 0, build_model: 'leo_bridge' });
+  });
+
+  it('replit_agent build method short-circuits to the legacy replit path before the zero-SD branch', async () => {
+    const { controller, supabase } = makeController('leo_bridge');
+    controller._getBuildMethod = vi.fn().mockResolvedValue('replit_agent');
+
+    const result = await controller.check('v-replit');
+
+    expect(result.blocked).toBe(false);
+    expect(result.status).toBe('replit_path');
+    // It returned before ever resolving the venture build_model for the zero-SD branch.
+    expect(controller._findLinkedOrchestratorSDs).not.toHaveBeenCalled();
+    expect(supabase._calls.from.filter((t) => t === 'ventures')).toHaveLength(0);
+  });
+
+  it('does NOT persist any pause state on the zero-SD branch (no savePauseState write)', async () => {
+    const { controller } = makeController('leo_bridge');
+
+    await controller.check('v-no-persist');
+
+    expect(controller._savePauseState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-s19-completion.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-completion.test.js
@@ -1,0 +1,214 @@
+/**
+ * SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 / FR-1 — the shared leo_bridge SD-completion evaluator
+ * StageExecutionWorker._isLeoBridgeBuildComplete(ventureId).
+ *
+ * This is the single source of truth consumed by BOTH the S19 hard gate (in-worker) and the
+ * S20 pause controller, so "build complete" can never disagree between the two enforcement points.
+ *
+ * Contract under test (lib/eva/stage-execution-worker.js ~3369):
+ *   - reads ventures.build_model + venture_stage_work(stage 19).advisory_data and resolves the model
+ *     via ./bridge/resolve-build-model.js resolveBuildModel({ventureBuildModel, legacyBuildMethod});
+ *   - buildModel !== 'leo_bridge'                     → null   (invariant does not apply)
+ *   - leo_bridge + advisory_data.chairman_override    → true   (chairman escape hatch)
+ *   - leo_bridge + 0 SDs                              → false  (the build never happened)
+ *   - TERMINAL = {completed,cancelled,archived}, COMPLETED = {completed,archived}:
+ *       returns true ONLY when every SD is TERMINAL AND at least one is COMPLETED;
+ *       an all-'cancelled' tree → false; any non-terminal SD → false.
+ *
+ * IMPORTANT resolver nuance (lib/eva/bridge/resolve-build-model.js): an UNSET build_model
+ * (null/undefined) DEFAULTS to 'leo_bridge'. So the "not a leo_bridge venture → null" case must
+ * use an explicit non-leo_bridge signal — build_model='seeded_repo' (or legacy 'replit_agent') —
+ * NOT a null build_model. This test pins that real behavior.
+ *
+ * Harness mirrors stage-execution-worker-s19-surfacing.test.js / -s19-gate.test.js: a real worker
+ * is built with an injected chainable `_supabase` mock + no-op logger. Per `from(table)` a fresh
+ * chain records `.eq()` filters and resolves the terminal `.maybeSingle()` from a per-table queue;
+ * `strategic_directives_v2` resolves its `.eq()`-terminated array via the awaitable chain (`then`).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+/**
+ * Build a chainable supabase mock tailored to _isLeoBridgeBuildComplete's three reads:
+ *   - ventures.build_model            (terminal: .maybeSingle())
+ *   - venture_stage_work(19).advisory_data (terminal: .maybeSingle())
+ *   - strategic_directives_v2.status  (terminal: awaited chain after .select().eq())
+ *
+ * @param {object} cfg
+ * @param {string|null} [cfg.buildModel]      ventures.build_model row value (null ⇒ no row)
+ * @param {object|null} [cfg.advisoryData]    venture_stage_work(19).advisory_data row value
+ * @param {Array<{status:string}>|null} [cfg.sds]  strategic_directives_v2 rows (the awaited result)
+ */
+function createMockSupabase({ buildModel = null, advisoryData = null, sds = [] } = {}) {
+  const calls = { from: [], eq: [], select: [] };
+
+  const from = vi.fn((table) => {
+    calls.from.push(table);
+
+    // The awaited result of the chain (used by strategic_directives_v2's .select().eq() terminal).
+    let awaitResult = { data: null, error: null };
+    if (table === 'strategic_directives_v2') awaitResult = { data: sds, error: null };
+
+    const single = () => {
+      if (table === 'ventures') {
+        return Promise.resolve({ data: buildModel === null ? null : { build_model: buildModel }, error: null });
+      }
+      if (table === 'venture_stage_work') {
+        return Promise.resolve({ data: advisoryData === null ? null : { advisory_data: advisoryData }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    };
+
+    const chain = {
+      select: vi.fn((cols) => { calls.select.push({ table, cols }); return chain; }),
+      eq: vi.fn((col, val) => { calls.eq.push({ table, col, val }); return chain; }),
+      in: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      maybeSingle: vi.fn(() => single()),
+      single: vi.fn(() => single()),
+      // strategic_directives_v2 ends at `.select(...).eq(...)` and is awaited directly.
+      then: (resolve) => resolve(awaitResult),
+    };
+    return chain;
+  });
+
+  return { from, _calls: calls };
+}
+
+function makeWorker(supabase) {
+  const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+  worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+  return worker;
+}
+
+const eqStrings = (calls, table) =>
+  calls.eq.filter((e) => e.table === table).map((e) => `${e.col}=${e.val}`);
+
+describe('SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 _isLeoBridgeBuildComplete', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns NULL when the venture is NOT leo_bridge (build_model=seeded_repo) — invariant does not apply', async () => {
+    const supabase = createMockSupabase({ buildModel: 'seeded_repo', sds: [{ status: 'in_progress' }] });
+    const worker = makeWorker(supabase);
+
+    const result = await worker._isLeoBridgeBuildComplete('v-seeded');
+
+    expect(result).toBeNull();
+    // Short-circuits before ever querying SDs (the invariant doesn't apply to seeded_repo).
+    expect(supabase._calls.from.filter((t) => t === 'strategic_directives_v2')).toHaveLength(0);
+  });
+
+  it('returns NULL when legacy build_method=replit_agent forces seeded_repo (not leo_bridge)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: null, // unset SSOT column…
+      advisoryData: { build_method: 'replit_agent' }, // …but legacy signal pins seeded_repo
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-legacy')).toBeNull();
+  });
+
+  it('returns TRUE on chairman_override (escape hatch) regardless of SD state', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      advisoryData: { chairman_override: true },
+      sds: [{ status: 'in_progress' }, { status: 'pending' }], // would otherwise be incomplete
+    });
+    const worker = makeWorker(supabase);
+
+    const result = await worker._isLeoBridgeBuildComplete('v-override');
+
+    expect(result).toBe(true);
+    // Escape hatch short-circuits before the SD query.
+    expect(supabase._calls.from.filter((t) => t === 'strategic_directives_v2')).toHaveLength(0);
+  });
+
+  it('returns FALSE for a leo_bridge venture with ZERO build SDs (the build never happened)', async () => {
+    const supabase = createMockSupabase({ buildModel: 'leo_bridge', sds: [] });
+    const worker = makeWorker(supabase);
+
+    const result = await worker._isLeoBridgeBuildComplete('v-no-sds');
+
+    expect(result).toBe(false);
+    // Confirms it actually reached + filtered the SD query.
+    expect(eqStrings(supabase._calls, 'strategic_directives_v2')).toContain('venture_id=v-no-sds');
+  });
+
+  it('returns TRUE when EVERY SD is completed (all terminal + at least one completed)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'completed' }, { status: 'completed' }, { status: 'completed' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-done')).toBe(true);
+  });
+
+  it('returns TRUE for a mixed completed + cancelled tree (all terminal, at least one completed)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'completed' }, { status: 'cancelled' }, { status: 'archived' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-mixed')).toBe(true);
+  });
+
+  it('returns FALSE when a single SD is still in_progress (non-terminal blocks completion)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'completed' }, { status: 'in_progress' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-inprog')).toBe(false);
+  });
+
+  it('returns FALSE when a single SD is pending (non-terminal blocks completion)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'completed' }, { status: 'pending' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-pending')).toBe(false);
+  });
+
+  it('returns FALSE for an ALL-cancelled tree (terminal, but no completed ⇒ build never delivered)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'cancelled' }, { status: 'cancelled' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-cancelled')).toBe(false);
+  });
+
+  it('treats "archived" as a completed-equivalent terminal status (all-archived ⇒ true)', async () => {
+    const supabase = createMockSupabase({
+      buildModel: 'leo_bridge',
+      sds: [{ status: 'archived' }, { status: 'archived' }],
+    });
+    const worker = makeWorker(supabase);
+
+    expect(await worker._isLeoBridgeBuildComplete('v-archived')).toBe(true);
+  });
+
+  it('queries the SD status filtered by venture_id (lifecycle_stage=19 used for the work read)', async () => {
+    const supabase = createMockSupabase({ buildModel: 'leo_bridge', sds: [{ status: 'completed' }] });
+    const worker = makeWorker(supabase);
+
+    await worker._isLeoBridgeBuildComplete('v-filters');
+
+    // The S19 work read is filtered to stage 19…
+    expect(eqStrings(supabase._calls, 'venture_stage_work')).toContain('lifecycle_stage=19');
+    expect(eqStrings(supabase._calls, 'venture_stage_work')).toContain('venture_id=v-filters');
+    // …and the ventures read + SD read are venture-scoped.
+    expect(eqStrings(supabase._calls, 'ventures')).toContain('id=v-filters');
+    expect(eqStrings(supabase._calls, 'strategic_directives_v2')).toContain('venture_id=v-filters');
+  });
+});


### PR DESCRIPTION
## Incident (RCA a14ff698)
An approved S19 `stage_gate` let the worker's `pre_exec_skip` path advance a leo_bridge venture **past Stage 19 with 0 build SDs** (DataDistill 19→23, `killed_at_reality_gate`). Three failures aligned: the S19 invariant was a soft/fire-and-forget block; a classification schism (`isBlocking(19)=false` despite S19 being a hard gate) let the skip fire; and the S20 pause failed OPEN on zero SDs.

## Fix (server-side, authoritative)
- **FR-1**: top-of-loop **hard gate** in `_processVenture` — when an approved S19 decision exists but the leo_bridge build is incomplete, idempotently run the bridge then **refuse to advance** (`break`). Runs before *every* advance path (pre_exec_skip / auto_approved / governance_override / normal). Backed by a shared `_isLeoBridgeBuildComplete` evaluator (orchestrator + ALL children completed; all-cancelled ≠ complete; `chairman_override` escape hatch).
- **FR-2**: `s20-pause-controller` **fails closed** for a leo_bridge venture with zero SDs (build never happened); legacy ventures unchanged.
- **FR-3**: reconcile the `isBlocking` vs `hard_gate_stages` schism in the P0 guard (S19 falls through to the side-effect-aware guard, matching the block's own comment).

## Tests
39/39 (16 new — evaluator + S20 fail-closed — plus 23 existing S19 suites, no regressions).

## Containment (this SD)
Interim UI guard shipped (ehg PR #675, removes the one-click Approve-review trigger). DataDistill rolled back to Stage-19 via the database-agent. Follows SD-LEO-INFRA-RELIABLE-S19-BUILD-001 (makes its S19 gate authoritative on the approve path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)