### PR TITLE
feat(SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A): competitive-intelligence data spine

### DIFF
--- a/database/migrations/20260531180000_competitive_intelligence_spine.sql
+++ b/database/migrations/20260531180000_competitive_intelligence_spine.sql
@@ -1,0 +1,309 @@
+-- =============================================================================
+-- Migration: 20260531180000_competitive_intelligence_spine.sql
+-- SD: SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (Child A)
+-- Purpose: Create the data spine for the Competitive Intelligence feature.
+--          Two new tables: competitor_intelligence + ci_snapshots.
+--          ADDITIVE ONLY — no existing tables are altered, dropped, or touched.
+-- Author: Principal Database Architect sub-agent
+-- Date: 2026-05-31
+-- Reversible: YES — see companion DOWN script
+--             20260531180000_competitive_intelligence_spine_DOWN.sql
+-- =============================================================================
+
+-- RLS POLICY PATTERN (mirrors `competitors` table):
+--   - service_role: ALL (unrestricted)
+--   - public role: SELECT/INSERT/UPDATE/DELETE scoped to rows where
+--       venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid())
+--   - Pre-seed rows (venture_id IS NULL) are accessible to service_role only
+--     until the venture link is attached.
+--   Source: SELECT * FROM pg_policies WHERE tablename = 'competitors';
+
+-- =============================================================================
+-- TABLE 1: competitor_intelligence
+-- =============================================================================
+-- Operator-owned competitive-intelligence asset.
+-- ONE row per competitor analysis, OPTIONALLY linked to a venture.
+-- Stage-0 teardown produces rows BEFORE a venture exists (venture_id nullable).
+-- The venture link is attached later when the venture is seeded.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS competitor_intelligence (
+    id                       uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Nullable: Stage-0 pre-seed records have no venture yet.
+    -- Set to NULL (not deleted) when the referenced venture is removed.
+    venture_id               uuid        NULL
+        REFERENCES ventures(id) ON DELETE SET NULL,
+
+    -- FK to global_competitors: table EXISTS (confirmed via information_schema).
+    -- Set to NULL when the referenced global competitor record is removed.
+    global_competitor_id     uuid        NULL
+        REFERENCES global_competitors(id) ON DELETE SET NULL,
+
+    competitor_url           text,
+    competitor_name          text,
+
+    -- How this record was produced.
+    source                   text        NOT NULL DEFAULT 'manual'
+        CHECK (source IN ('teardown', 'differentiation_research', 'discovery', 'manual')),
+
+    -- Four-bucket framework: facts / assumptions / simulations / unknowns.
+    four_buckets             jsonb,
+
+    -- Structured competitive analysis: company / product / market / swot.
+    competitive_intelligence jsonb,
+
+    -- Slot for Child E board output (differentiation strategy).
+    differentiation_strategy jsonb       NULL,
+
+    -- Slot for Child E delta gate result.
+    differentiation_delta    numeric     NULL,
+
+    -- Data sanitization state.
+    sanitization_status      text        NOT NULL DEFAULT 'pending'
+        CHECK (sanitization_status IN ('pending', 'passed', 'flagged')),
+
+    -- Quality metadata: confidence_score, data_quality, etc.
+    quality                  jsonb,
+
+    -- Operator who created the record; nullable for system/service writes.
+    created_by               uuid        NULL,
+
+    created_at               timestamptz NOT NULL DEFAULT now(),
+    updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE competitor_intelligence IS
+    'Operator-owned competitive-intelligence asset. One row per competitor analysis. '
+    'venture_id is nullable because Stage-0 teardown produces these records before a '
+    'venture is seeded; the link is attached later. '
+    'SD: SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A';
+
+COMMENT ON COLUMN competitor_intelligence.venture_id IS
+    'Nullable FK to ventures.id. NULL for pre-seed Stage-0 records.';
+COMMENT ON COLUMN competitor_intelligence.global_competitor_id IS
+    'Nullable FK to global_competitors.id (table confirmed present). '
+    'ON DELETE SET NULL keeps the CI record even if the global competitor is removed.';
+COMMENT ON COLUMN competitor_intelligence.four_buckets IS
+    'Four-bucket framework storage: {facts, assumptions, simulations, unknowns}';
+COMMENT ON COLUMN competitor_intelligence.competitive_intelligence IS
+    'Structured analysis: {company, product, market, swot}';
+COMMENT ON COLUMN competitor_intelligence.differentiation_strategy IS
+    'Slot for Child E board output; NULL until Child E writes here.';
+COMMENT ON COLUMN competitor_intelligence.differentiation_delta IS
+    'Slot for Child E delta gate numeric result; NULL until Child E writes here.';
+COMMENT ON COLUMN competitor_intelligence.quality IS
+    'Quality metadata: {confidence_score, data_quality}';
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_competitor_intelligence_venture_id
+    ON competitor_intelligence(venture_id);
+
+CREATE INDEX IF NOT EXISTS idx_competitor_intelligence_created_by
+    ON competitor_intelligence(created_by);
+
+CREATE INDEX IF NOT EXISTS idx_competitor_intelligence_global_competitor_id
+    ON competitor_intelligence(global_competitor_id);
+
+CREATE INDEX IF NOT EXISTS idx_competitor_intelligence_sanitization_status
+    ON competitor_intelligence(sanitization_status);
+
+-- updated_at auto-touch trigger (reuses the existing house function
+-- update_updated_at_column — confirmed present in pg_proc; same convention
+-- used by execution_sequences_v2, hap_blocks_v2, sdip_submissions, etc.)
+CREATE OR REPLACE TRIGGER trg_competitor_intelligence_updated_at
+    BEFORE UPDATE ON competitor_intelligence
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- RLS for competitor_intelligence
+-- Mirrors the `competitors` table policy pattern exactly.
+-- =============================================================================
+
+ALTER TABLE competitor_intelligence ENABLE ROW LEVEL SECURITY;
+
+-- 1. service_role: unrestricted full access (mirrors "Service role full access competitors")
+CREATE POLICY ci_service_role_all ON competitor_intelligence
+    AS PERMISSIVE
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- 2. Authenticated users can SELECT their own venture's records.
+--    Pre-seed rows (venture_id IS NULL) are visible only to service_role until linked.
+--    (Mirrors "Users can view own venture competitors")
+CREATE POLICY ci_select_own_venture ON competitor_intelligence
+    AS PERMISSIVE
+    FOR SELECT
+    TO public
+    USING (
+        venture_id IN (
+            SELECT id FROM ventures WHERE created_by = auth.uid()
+        )
+    );
+
+-- 3. Authenticated users can INSERT records for their own ventures.
+--    Pre-seed inserts (venture_id IS NULL) must go through service_role.
+--    (Mirrors "Users can insert own venture competitors")
+CREATE POLICY ci_insert_own_venture ON competitor_intelligence
+    AS PERMISSIVE
+    FOR INSERT
+    TO public
+    WITH CHECK (
+        venture_id IN (
+            SELECT id FROM ventures WHERE created_by = auth.uid()
+        )
+    );
+
+-- 4. Authenticated users can UPDATE their own venture's records.
+--    (Mirrors "Users can update own venture competitors")
+CREATE POLICY ci_update_own_venture ON competitor_intelligence
+    AS PERMISSIVE
+    FOR UPDATE
+    TO public
+    USING (
+        venture_id IN (
+            SELECT id FROM ventures WHERE created_by = auth.uid()
+        )
+    );
+
+-- 5. Authenticated users can DELETE their own venture's records.
+--    (Mirrors "Users can delete own venture competitors")
+CREATE POLICY ci_delete_own_venture ON competitor_intelligence
+    AS PERMISSIVE
+    FOR DELETE
+    TO public
+    USING (
+        venture_id IN (
+            SELECT id FROM ventures WHERE created_by = auth.uid()
+        )
+    );
+
+-- =============================================================================
+-- TABLE 2: ci_snapshots
+-- =============================================================================
+-- Point-in-time history of a competitor_intelligence record.
+-- Append-only: CASCADE on parent deletion keeps history consistent
+-- (rows are removed when the parent CI record is removed).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS ci_snapshots (
+    id                          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- FK to parent CI record; CASCADE so history is removed with the parent.
+    competitor_intelligence_id  uuid        NOT NULL
+        REFERENCES competitor_intelligence(id) ON DELETE CASCADE,
+
+    captured_at                 timestamptz NOT NULL DEFAULT now(),
+
+    -- Full point-in-time copy of the competitor_intelligence row at capture time.
+    snapshot                    jsonb       NOT NULL,
+
+    -- Computed diff vs the immediately prior snapshot; NULL for the first snapshot.
+    diff_from_prior             jsonb       NULL,
+
+    -- What triggered this snapshot.
+    source                      text
+        CHECK (source IN ('refresh', 'seed', 'enrichment')),
+
+    created_at                  timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE ci_snapshots IS
+    'Point-in-time history snapshots for competitor_intelligence records. '
+    'Append-only; rows cascade-delete when the parent CI record is deleted. '
+    'SD: SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A';
+
+COMMENT ON COLUMN ci_snapshots.snapshot IS
+    'Full point-in-time copy of the competitor_intelligence row at capture time.';
+COMMENT ON COLUMN ci_snapshots.diff_from_prior IS
+    'Computed JSON diff vs the immediately prior snapshot. NULL for first snapshot.';
+COMMENT ON COLUMN ci_snapshots.source IS
+    'What triggered this snapshot: refresh | seed | enrichment';
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_ci_snapshots_competitor_intelligence_id
+    ON ci_snapshots(competitor_intelligence_id);
+
+CREATE INDEX IF NOT EXISTS idx_ci_snapshots_captured_at
+    ON ci_snapshots(captured_at);
+
+-- =============================================================================
+-- RLS for ci_snapshots
+-- Mirrors the `competitors` table policy pattern.
+-- Snapshots are scoped to users who own the parent CI record's venture.
+-- The join-through-competitor_intelligence makes the ownership chain explicit.
+-- =============================================================================
+
+ALTER TABLE ci_snapshots ENABLE ROW LEVEL SECURITY;
+
+-- 1. service_role: unrestricted full access
+CREATE POLICY ci_snapshots_service_role_all ON ci_snapshots
+    AS PERMISSIVE
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- 2. SELECT: visible when the parent CI record belongs to user's venture.
+CREATE POLICY ci_snapshots_select_own_venture ON ci_snapshots
+    AS PERMISSIVE
+    FOR SELECT
+    TO public
+    USING (
+        competitor_intelligence_id IN (
+            SELECT ci.id
+            FROM competitor_intelligence ci
+            JOIN ventures v ON v.id = ci.venture_id
+            WHERE v.created_by = auth.uid()
+        )
+    );
+
+-- 3. INSERT: allowed when the parent CI record belongs to user's venture.
+CREATE POLICY ci_snapshots_insert_own_venture ON ci_snapshots
+    AS PERMISSIVE
+    FOR INSERT
+    TO public
+    WITH CHECK (
+        competitor_intelligence_id IN (
+            SELECT ci.id
+            FROM competitor_intelligence ci
+            JOIN ventures v ON v.id = ci.venture_id
+            WHERE v.created_by = auth.uid()
+        )
+    );
+
+-- 4. UPDATE: allowed when parent belongs to user's venture.
+CREATE POLICY ci_snapshots_update_own_venture ON ci_snapshots
+    AS PERMISSIVE
+    FOR UPDATE
+    TO public
+    USING (
+        competitor_intelligence_id IN (
+            SELECT ci.id
+            FROM competitor_intelligence ci
+            JOIN ventures v ON v.id = ci.venture_id
+            WHERE v.created_by = auth.uid()
+        )
+    );
+
+-- 5. DELETE: allowed when parent belongs to user's venture.
+CREATE POLICY ci_snapshots_delete_own_venture ON ci_snapshots
+    AS PERMISSIVE
+    FOR DELETE
+    TO public
+    USING (
+        competitor_intelligence_id IN (
+            SELECT ci.id
+            FROM competitor_intelligence ci
+            JOIN ventures v ON v.id = ci.venture_id
+            WHERE v.created_by = auth.uid()
+        )
+    );
+
+-- =============================================================================
+-- END OF MIGRATION
+-- To roll back: run 20260531180000_competitive_intelligence_spine_DOWN.sql
+-- =============================================================================

--- a/database/migrations/20260531180000_competitive_intelligence_spine_DOWN.sql
+++ b/database/migrations/20260531180000_competitive_intelligence_spine_DOWN.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- DOWN / ROLLBACK Script
+-- Migration: 20260531180000_competitive_intelligence_spine_DOWN.sql
+-- SD: SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (Child A)
+-- Purpose: Fully reverse the UP migration.
+--          Drops both tables (and their dependent indexes, triggers, policies)
+--          in the correct dependency order (ci_snapshots first, then
+--          competitor_intelligence, because ci_snapshots has an FK into it).
+--          DOES NOT touch any pre-existing tables.
+-- =============================================================================
+-- WARNING: This drops all data in competitor_intelligence and ci_snapshots.
+--          Only run in a context where that data loss is acceptable, or wrap
+--          this script in a transaction that you ROLL BACK to verify syntax.
+-- =============================================================================
+
+-- Step 1: Drop ci_snapshots (depends on competitor_intelligence via FK CASCADE,
+--         so must be dropped first to avoid FK violation on Step 2).
+--         Policies, triggers, and indexes on this table are dropped automatically
+--         when the table is dropped.
+
+DROP TABLE IF EXISTS ci_snapshots CASCADE;
+
+-- Step 2: Drop competitor_intelligence.
+--         Policies, triggers, and indexes are dropped automatically.
+
+DROP TABLE IF EXISTS competitor_intelligence CASCADE;
+
+-- =============================================================================
+-- END OF DOWN SCRIPT
+-- After running this script the database is back to the pre-migration state.
+-- To re-apply: run 20260531180000_competitive_intelligence_spine.sql
+-- =============================================================================

--- a/docs/competitive-intelligence/childA-design-and-spike.md
+++ b/docs/competitive-intelligence/childA-design-and-spike.md
@@ -1,0 +1,40 @@
+# Child A — Design Justification & Differentiation-Research Spike
+
+**SD:** SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (data spine)
+**Validation evidence:** sub_agent_execution_results `f2855298-15d7-4b0a-9fa3-c75b99abe5f4` (VALIDATION@LEAD)
+**Migration:** `database/migrations/20260531180000_competitive_intelligence_spine.sql` (+ `_DOWN.sql`), DATABASE evidence `f8cc7fd5-01d5-4541-922c-0bee8b86977d` (EXEC, PASS 98)
+
+---
+
+## FR-6 — New tables vs. extending existing infrastructure (design justification)
+
+The original design referenced a `competitor_tracking` table as "segment-keyed, no history." **That table does not exist** (validation-agent finding — the vision/arch wording was wrong). The real existing competitor infrastructure is:
+
+| Table | What it is | Venture-scoped | History | Why not reused |
+|-------|-----------|:---:|:---:|----------------|
+| `competitors` | Roster of named competitors per venture (`analysis_data`, `swot`, `threat_level`, FK → `global_competitors`) | Yes | No (`uq_competitors_venture_name` blocks snapshot rows) | A *roster entry* is not the same object as a *compounding intelligence asset + history*. Extending it would require dropping its unique constraint and adding `snapshot_at`, conflating two concerns and risking the live roster. |
+| `global_competitors` | Canonical competitor dedup registry, no analysis payload | No | No | Pure identity/dedup; no place for per-venture intelligence. **Referenced** by `competitor_intelligence.global_competitor_id` (FK) rather than duplicated. |
+| `intelligence_analysis` | Generic venture-scoped agent results store (`agent_type`, `results`), 0 production rows | Yes (nullable) | Yes | No competitor identity columns (url/name), no differentiation/sanitization semantics. A purpose-built pair is clearer than overloading a generic store. |
+
+**Decision:** create two purpose-built tables that *reference* the existing roster instead of duplicating it:
+
+- **`competitor_intelligence`** — the compounding, operator-owned competitor-intelligence asset. **Operator-owned with an optional `venture_id`** because the Stage-0 teardown produces it *before* a venture exists; the venture link is attached on seed (Child B). Holds the synthesized payload plus the slots Children E/sanitization fill: `differentiation_strategy`, `differentiation_delta`, `sanitization_status`.
+- **`ci_snapshots`** — point-in-time history (FK → `competitor_intelligence` ON DELETE CASCADE), with `diff_from_prior` for the on-demand refresh (Child D).
+
+This adds the *intelligence-asset + history* layer on top of the existing *roster* layer — directly removing the fragmentation the feature targets, with **zero changes to any existing table** (additive + reversible; reversibility proved UP→DOWN-in-rollback→tables present).
+
+**RLS:** mirrors the `competitors` pattern exactly — `service_role` ALL + `public` CRUD scoped to `venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid())`. Pre-seed records (`venture_id` NULL) are service-role-managed (server-side teardown writes) until linked to a venture, at which point operator ownership applies. No stricter/looser model than the existing tables was invented.
+
+---
+
+## FR-5 — Differentiation-research service-contract spike
+
+**Question (chairman flag):** can the external `differentiation-research` FastAPI agent persist `venture_id`, and what are its cost/latency characteristics — is it load-bearing?
+
+**Contract (from the codebase):** `ehg` → `VentureCompetitorResearch.tsx` → `differentiationResearchAPI` → `POST ${AGENT_PLATFORM_URL}/api/differentiation-research/analyze` (job submit) + poll. It is a **raw competitive-DATA** source (offerings/pricing/positioning), job/poll style.
+
+**`venture_id` persistence:** resolved by this child, not by the external service. The canonical `competitor_intelligence` record carries `venture_id` (nullable) and `source` (`differentiation_research` is an allowed value). Any data the external agent returns is persisted *through the canonical layer* with the venture link, so end-to-end `venture_id` persistence does not depend on the external service's own storage.
+
+**Cost / latency:** not load-bearing, so no blocking live benchmark was run. Per the architecture decision (arch v4), the **differentiation ENGINE is the internal automated Board-of-Directors deliberation** (`lib/brainstorm/*`, Child E) — which we own and whose feasibility is therefore resolved. The external service sits behind the data-layer abstraction as **one optional raw-data source** alongside the Stage-0 teardown worker; the data layer can substitute teardown-worker output without rework.
+
+**Recommendation:** KEEP the external `differentiation-research` service as an *optional* raw-data input behind the canonical data layer. It is **not load-bearing** and introduces **no spike dependency** for the orchestrator. If it later becomes a primary source, run a live latency/cost benchmark at that point (Child E or a follow-up), gated behind the SSRF egress fetcher (CISO launch-blocker). No blocker for proceeding.

--- a/docs/competitive-intelligence/childa-design-and-spike.md
+++ b/docs/competitive-intelligence/childa-design-and-spike.md
@@ -1,3 +1,12 @@
+---
+Category: Database
+Status: Draft
+Version: 1.0.0
+Author: LEO Protocol
+Last Updated: 2026-05-31
+Tags: database, competitive-intelligence, design, spike
+---
+
 # Child A — Design Justification & Differentiation-Research Spike
 
 **SD:** SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (data spine)

--- a/lib/competitive-intelligence/canonical-store.js
+++ b/lib/competitive-intelligence/canonical-store.js
@@ -1,0 +1,221 @@
+/**
+ * Canonical Competitive-Intelligence Store — data-layer abstraction
+ * SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (Phase 1 data spine)
+ *
+ * The SINGLE access path for the compounding per-venture competitor-intelligence
+ * record (competitor_intelligence) and its point-in-time history (ci_snapshots).
+ * Every consumer — the Stage-0 teardown seed adapter, the discovery service, the
+ * differentiation board (Child E), and the UI surfaces (Children B/C/D) — goes
+ * through this contract rather than touching the tables directly.
+ *
+ * The record is OPERATOR-owned with an OPTIONAL venture link: a Stage-0 teardown
+ * produces it BEFORE a venture exists, and the venture_id is attached later when
+ * the venture is seeded.
+ *
+ * Supabase is injectable (opts.supabase) so the layer is unit-testable without
+ * a live DB.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+let _client = null;
+
+/**
+ * Resolve a Supabase service client. Prefers an injected client (tests), else a
+ * lazily-created singleton from env. Returns null if env is not configured.
+ * @param {Object} [injected]
+ * @returns {Object|null}
+ */
+export function resolveClient(injected) {
+  if (injected) return injected;
+  if (_client) return _client;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (url && key) _client = createClient(url, key);
+  return _client;
+}
+
+const TABLE = 'competitor_intelligence';
+const SNAPSHOTS = 'ci_snapshots';
+
+/**
+ * Fetch competitor-intelligence records by id, venture, or competitor URL.
+ * Returns a single record when `id` is given, otherwise an array.
+ *
+ * @param {Object} filters
+ * @param {string} [filters.id]
+ * @param {string} [filters.ventureId]
+ * @param {string} [filters.competitorUrl]
+ * @param {Object} [opts]
+ * @param {Object} [opts.supabase]
+ * @returns {Promise<Object|Array|null>}
+ */
+export async function getCompetitorIntelligence(filters = {}, opts = {}) {
+  const supabase = resolveClient(opts.supabase);
+  if (!supabase) throw new Error('Supabase client not configured');
+
+  let query = supabase.from(TABLE).select('*');
+  if (filters.id) query = query.eq('id', filters.id);
+  if (filters.ventureId) query = query.eq('venture_id', filters.ventureId);
+  if (filters.competitorUrl) query = query.eq('competitor_url', filters.competitorUrl);
+  query = query.order('created_at', { ascending: false });
+
+  const { data, error } = await query;
+  if (error) throw new Error(`getCompetitorIntelligence failed: ${error.message}`);
+  if (filters.id) return (data && data[0]) || null;
+  return data || [];
+}
+
+/**
+ * Insert or update a competitor-intelligence record. When `record.id` is
+ * present an update is performed; otherwise a new row is inserted.
+ *
+ * @param {Object} record - column subset of competitor_intelligence
+ * @param {Object} [opts]
+ * @param {Object} [opts.supabase]
+ * @returns {Promise<Object>} the persisted row
+ */
+export async function upsertCompetitorIntelligence(record = {}, opts = {}) {
+  const supabase = resolveClient(opts.supabase);
+  if (!supabase) throw new Error('Supabase client not configured');
+
+  // Whitelist persisted columns so callers can pass richer objects safely.
+  const row = pickColumns(record, [
+    'id',
+    'venture_id',
+    'global_competitor_id',
+    'competitor_url',
+    'competitor_name',
+    'source',
+    'four_buckets',
+    'competitive_intelligence',
+    'differentiation_strategy',
+    'differentiation_delta',
+    'sanitization_status',
+    'quality',
+    'created_by',
+  ]);
+
+  if (row.id) {
+    const { id, ...updates } = row;
+    const { data, error } = await supabase
+      .from(TABLE)
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) throw new Error(`upsertCompetitorIntelligence (update) failed: ${error.message}`);
+    return data;
+  }
+
+  const { data, error } = await supabase.from(TABLE).insert(row).select().single();
+  if (error) throw new Error(`upsertCompetitorIntelligence (insert) failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * Append a point-in-time snapshot for a competitor-intelligence record. The
+ * diff against the previous snapshot is computed automatically unless an
+ * explicit `diff` is supplied.
+ *
+ * @param {string} competitorIntelligenceId
+ * @param {Object} snapshot - the point-in-time payload to record
+ * @param {Object} [opts]
+ * @param {string} [opts.source] - one of 'refresh' | 'seed' | 'enrichment'
+ * @param {Object} [opts.diff] - explicit diff override
+ * @param {Object} [opts.supabase]
+ * @returns {Promise<Object>} the persisted snapshot row
+ */
+export async function appendSnapshot(competitorIntelligenceId, snapshot, opts = {}) {
+  const supabase = resolveClient(opts.supabase);
+  if (!supabase) throw new Error('Supabase client not configured');
+  if (!competitorIntelligenceId) throw new Error('competitorIntelligenceId is required');
+
+  let diff = opts.diff;
+  if (diff === undefined) {
+    const prior = await listSnapshots(competitorIntelligenceId, { supabase, limit: 1 });
+    diff = prior.length ? computeDiff(prior[0].snapshot, snapshot) : null;
+  }
+
+  const { data, error } = await supabase
+    .from(SNAPSHOTS)
+    .insert({
+      competitor_intelligence_id: competitorIntelligenceId,
+      snapshot,
+      diff_from_prior: diff,
+      source: opts.source || null,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`appendSnapshot failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * List snapshots for a record, newest first.
+ *
+ * @param {string} competitorIntelligenceId
+ * @param {Object} [opts]
+ * @param {number} [opts.limit]
+ * @param {Object} [opts.supabase]
+ * @returns {Promise<Array>}
+ */
+export async function listSnapshots(competitorIntelligenceId, opts = {}) {
+  const supabase = resolveClient(opts.supabase);
+  if (!supabase) throw new Error('Supabase client not configured');
+
+  let query = supabase
+    .from(SNAPSHOTS)
+    .select('*')
+    .eq('competitor_intelligence_id', competitorIntelligenceId)
+    .order('captured_at', { ascending: false });
+  if (opts.limit) query = query.limit(opts.limit);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`listSnapshots failed: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Compute a shallow top-level diff between two snapshot payloads. Pure — used by
+ * appendSnapshot and the on-demand refresh (Child D). Returns { added, removed,
+ * changed } keyed by top-level field.
+ *
+ * @param {Object} prev
+ * @param {Object} next
+ * @returns {{added: string[], removed: string[], changed: string[]}}
+ */
+export function computeDiff(prev, next) {
+  const a = prev && typeof prev === 'object' ? prev : {};
+  const b = next && typeof next === 'object' ? next : {};
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  const added = [];
+  const removed = [];
+  const changed = [];
+  for (const k of keys) {
+    const inA = Object.prototype.hasOwnProperty.call(a, k);
+    const inB = Object.prototype.hasOwnProperty.call(b, k);
+    if (inA && !inB) removed.push(k);
+    else if (!inA && inB) added.push(k);
+    else if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) changed.push(k);
+  }
+  return { added, removed, changed };
+}
+
+/**
+ * Internal: copy only whitelisted keys that are actually present on the source.
+ * @param {Object} src
+ * @param {string[]} keys
+ * @returns {Object}
+ */
+function pickColumns(src, keys) {
+  const out = {};
+  for (const k of keys) {
+    if (src && Object.prototype.hasOwnProperty.call(src, k) && src[k] !== undefined) {
+      out[k] = src[k];
+    }
+  }
+  return out;
+}

--- a/lib/competitive-intelligence/four-buckets.js
+++ b/lib/competitive-intelligence/four-buckets.js
@@ -1,0 +1,123 @@
+/**
+ * Four-Buckets Epistemic Tagging — Canonical Layer
+ * SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (Phase 1 data spine)
+ *
+ * Ported out of lib/research/competitor-intelligence.js so the epistemic
+ * tagging is OWNED by the canonical competitive-intelligence layer rather than
+ * a single analysis path. competitor-intelligence.js now imports from here, so
+ * there is exactly one owner of FACT/ASSUMPTION/SIMULATION/UNKNOWN semantics.
+ *
+ * These are pure functions (no I/O, no `this`) — safe to unit-test in isolation
+ * and reuse from any competitor data source (teardown worker, differentiation
+ * research, discovery).
+ */
+
+// Four Buckets classification for epistemic honesty.
+export const FOUR_BUCKETS = {
+  FACT: 'fact', // Verified from source
+  ASSUMPTION: 'assumption', // Reasonable inference
+  SIMULATION: 'simulation', // AI-generated projection
+  UNKNOWN: 'unknown', // Cannot determine
+};
+
+/**
+ * Extract the value from a bucket-structured field ({ value, bucket }) or a
+ * plain scalar.
+ * @param {*} field
+ * @returns {*} the underlying value, or null
+ */
+export function extractValue(field) {
+  if (!field) return null;
+  return typeof field === 'object' ? field.value : field;
+}
+
+/**
+ * Walk an analysis object and collect every leaf tagged with the given bucket.
+ * @param {Object} analysis - the raw AI analysis tree
+ * @param {string} bucket - one of FOUR_BUCKETS values
+ * @returns {Array<{path: string, value: *, evidence: *}>}
+ */
+export function extractByBucket(analysis, bucket) {
+  const items = [];
+
+  const traverse = (obj, path = '') => {
+    if (!obj || typeof obj !== 'object') return;
+
+    if (obj.bucket && obj.bucket.toUpperCase() === bucket.toUpperCase()) {
+      items.push({
+        path,
+        value: obj.value,
+        evidence: obj.evidence || obj.reasoning,
+      });
+    }
+
+    if (Array.isArray(obj)) {
+      obj.forEach((item, i) => traverse(item, `${path}[${i}]`));
+    } else {
+      Object.entries(obj).forEach(([key, value]) => {
+        traverse(value, path ? `${path}.${key}` : key);
+      });
+    }
+  };
+
+  traverse(analysis);
+  return items;
+}
+
+/**
+ * Structure a raw AI competitor analysis into the canonical Four-Buckets shape.
+ * Behaviour is byte-identical to the original
+ * CompetitorIntelligenceService.structureWithFourBuckets so existing callers
+ * (opportunity-discovery, the dead Express route) keep getting the same shape.
+ *
+ * @param {Object} analysis - raw AI analysis (with per-leaf {value, bucket})
+ * @param {string} url - the competitor URL (used for fallback naming)
+ * @returns {Object} structured analysis with four_buckets + competitive_intelligence + quality
+ */
+export function structureWithFourBuckets(analysis, url) {
+  const domain = new URL(url).hostname.replace('www.', '');
+
+  // Extract venture suggestion for the API response
+  const suggestion = analysis.venture_suggestion || {};
+
+  return {
+    // Standard API response fields (for backward compatibility)
+    name: extractValue(suggestion.name) || `${domain.split('.')[0].toUpperCase()} Alternative`,
+    problem_statement:
+      extractValue(suggestion.problem_statement) ||
+      `Compete with ${domain} by addressing their market gaps`,
+    solution:
+      extractValue(suggestion.solution) ||
+      'Differentiated platform addressing competitor weaknesses',
+    target_market:
+      extractValue(suggestion.target_market) || "Underserved segments of competitor's market",
+    competitor_reference: url,
+
+    // Four Buckets classified data
+    four_buckets: {
+      facts: extractByBucket(analysis, FOUR_BUCKETS.FACT),
+      assumptions: extractByBucket(analysis, FOUR_BUCKETS.ASSUMPTION),
+      simulations: extractByBucket(analysis, FOUR_BUCKETS.SIMULATION),
+      unknowns: extractByBucket(analysis, FOUR_BUCKETS.UNKNOWN),
+    },
+
+    // Full competitive intelligence
+    competitive_intelligence: {
+      company: analysis.company,
+      product: analysis.product,
+      market: analysis.market,
+      swot: {
+        strengths: analysis.strengths,
+        weaknesses: analysis.weaknesses,
+        opportunities: analysis.opportunities,
+      },
+    },
+
+    // Quality metrics
+    quality: {
+      confidence_score: analysis.confidence_score || 0.5,
+      data_quality: analysis.data_quality || 'medium',
+      analysis_notes: analysis.analysis_notes,
+    },
+  };
+}

--- a/lib/competitive-intelligence/index.js
+++ b/lib/competitive-intelligence/index.js
@@ -1,0 +1,115 @@
+/**
+ * Canonical Competitive-Intelligence Layer — public contract
+ * SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A (Phase 1 data spine)
+ *
+ * The single import surface for competitor intelligence. Consumers should import
+ * from here rather than reaching into lib/research/competitor-intelligence.js or
+ * the raw tables:
+ *
+ *   import { analyzeCompetitor, getCompetitorIntelligence } from 'lib/competitive-intelligence/index.js';
+ *
+ * - Four-Buckets tagging is owned by ./four-buckets.js
+ * - Persistence (competitor_intelligence + ci_snapshots) is owned by ./canonical-store.js
+ * - analyzeCompetitor() delegates to the existing CompetitorIntelligenceService
+ *   engine (output parity) and can optionally persist the result.
+ */
+
+import CompetitorIntelligenceService from '../research/competitor-intelligence.js';
+
+export {
+  FOUR_BUCKETS,
+  extractValue,
+  extractByBucket,
+  structureWithFourBuckets,
+} from './four-buckets.js';
+
+export {
+  resolveClient,
+  getCompetitorIntelligence,
+  upsertCompetitorIntelligence,
+  appendSnapshot,
+  listSnapshots,
+  computeDiff,
+} from './canonical-store.js';
+
+import { upsertCompetitorIntelligence, appendSnapshot } from './canonical-store.js';
+
+/**
+ * Analyze a competitor URL through the canonical layer. Delegates to the
+ * existing CompetitorIntelligenceService engine so the structured output is
+ * byte-identical to the legacy path; optionally persists a competitor_intelligence
+ * record + seed snapshot.
+ *
+ * @param {string} url - competitor website URL
+ * @param {Object} [opts]
+ * @param {boolean} [opts.persist=false] - persist a competitor_intelligence record
+ * @param {string} [opts.ventureId] - optional venture link (usually null pre-seed)
+ * @param {string} [opts.createdBy] - operator id
+ * @param {string} [opts.source='discovery'] - record source tag
+ * @param {Object} [opts.serviceConfig] - passthrough config for CompetitorIntelligenceService
+ * @param {Object} [opts.supabase] - injectable client (persistence)
+ * @returns {Promise<Object>} structured analysis; when persisted, includes `record` + `snapshot`
+ */
+export async function analyzeCompetitor(url, opts = {}) {
+  const service = new CompetitorIntelligenceService(opts.serviceConfig || {});
+  const analysis = await service.analyzeCompetitor(url);
+
+  if (!opts.persist) return analysis;
+
+  const record = await upsertCompetitorIntelligence(
+    {
+      venture_id: opts.ventureId || null,
+      competitor_url: url,
+      competitor_name: analysis.name || null,
+      source: opts.source || 'discovery',
+      four_buckets: analysis.four_buckets || null,
+      competitive_intelligence: analysis.competitive_intelligence || null,
+      quality: analysis.quality || null,
+      created_by: opts.createdBy || null,
+    },
+    { supabase: opts.supabase }
+  );
+
+  const snapshot = await appendSnapshot(record.id, analysis, {
+    source: 'seed',
+    supabase: opts.supabase,
+  });
+
+  return { ...analysis, record, snapshot };
+}
+
+/**
+ * Persist the competitor analyses produced by the Stage-0 teardown worker
+ * (lib/eva/stage-zero/paths/competitor-teardown.js) through the canonical layer.
+ * One competitor_intelligence record + seed snapshot per analyzed competitor.
+ *
+ * The venture usually does not exist yet at teardown time, so venture_id is left
+ * null and attached later when the venture is seeded (Child B).
+ *
+ * @param {Array<Object>} analyses - teardown analyses (company_name, url, ...)
+ * @param {Object} [opts]
+ * @param {string} [opts.ventureId]
+ * @param {string} [opts.createdBy]
+ * @param {Object} [opts.supabase]
+ * @returns {Promise<Array<Object>>} persisted records
+ */
+export async function persistTeardownAnalyses(analyses = [], opts = {}) {
+  const records = [];
+  for (const a of analyses) {
+    if (!a || a.error) continue; // skip failed analyses
+    const record = await upsertCompetitorIntelligence(
+      {
+        venture_id: opts.ventureId || null,
+        competitor_url: a.url || null,
+        competitor_name: a.company_name || null,
+        source: 'teardown',
+        competitive_intelligence: a,
+        created_by: opts.createdBy || null,
+      },
+      { supabase: opts.supabase }
+    );
+    await appendSnapshot(record.id, a, { source: 'seed', supabase: opts.supabase });
+    records.push(record);
+  }
+  return records;
+}

--- a/lib/discovery/opportunity-discovery-service.js
+++ b/lib/discovery/opportunity-discovery-service.js
@@ -14,7 +14,11 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
-import CompetitorIntelligenceService from '../research/competitor-intelligence.js';
+// SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A: migrated from the standalone
+// competitor-intelligence.js path to the canonical competitive-intelligence layer.
+// analyzeCompetitor() delegates to the same engine under the hood, so the
+// structured output is byte-identical to the pre-migration path.
+import { analyzeCompetitor as analyzeCompetitorCanonical } from '../competitive-intelligence/index.js';
 import GapAnalyzer from './gap-analyzer.js';
 import OpportunityScorer from './opportunity-scorer.js';
 import BlueprintGenerator from './blueprint-generator.js';
@@ -43,8 +47,8 @@ class OpportunityDiscoveryService {
       ...config
     };
 
-    // Initialize sub-services
-    this.competitorService = new CompetitorIntelligenceService(config);
+    // Initialize sub-services. Competitor analysis now routes through the
+    // canonical competitive-intelligence layer (see analyzeCompetitorCanonical).
     this.gapAnalyzer = new GapAnalyzer(config);
     this.opportunityScorer = new OpportunityScorer(config);
     this.blueprintGenerator = new BlueprintGenerator(config);
@@ -78,7 +82,7 @@ class OpportunityDiscoveryService {
       // Step 1: Gather market intelligence
       let competitorData;
       if (scanType === 'competitor' && targetUrl) {
-        competitorData = await this.competitorService.analyzeCompetitor(targetUrl);
+        competitorData = await analyzeCompetitorCanonical(targetUrl, { serviceConfig: this.config });
       } else {
         // For market_trend or full scans, we'll need additional data sources
         // For now, return error if no targetUrl

--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -18,6 +18,11 @@
 import { createPathOutput } from '../interfaces.js';
 import { getValidationClient } from '../../../llm/client-factory.js';
 import { getMentalModelContextBlock } from '../../mental-models/index.js';
+// SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A: optional seed adapter that
+// persists teardown analyses through the canonical competitive-intelligence
+// layer. Opt-in (deps.persistToCanonical or CI_TEARDOWN_PERSIST=true) and
+// best-effort, so the live Stage-0 flow is unchanged until explicitly enabled.
+import { persistTeardownAnalyses } from '../../../competitive-intelligence/index.js';
 
 /**
  * Execute the competitor teardown path.
@@ -49,6 +54,23 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
     logger.log(`   Completed: ${analysis.company_name || url}`);
   }
 
+  // Step 1b (optional, opt-in): seed the canonical competitive-intelligence
+  // record(s) through the data layer. Best-effort — a persistence failure must
+  // never break the live Stage-0 teardown. venture_id is null here because the
+  // venture does not exist yet at teardown time (it is attached on seed).
+  let seededRecordIds = [];
+  const persistEnabled =
+    deps.persistToCanonical === true || process.env.CI_TEARDOWN_PERSIST === 'true';
+  if (persistEnabled && supabase) {
+    try {
+      const records = await persistTeardownAnalyses(analyses, { supabase });
+      seededRecordIds = records.map((r) => r.id);
+      logger.log(`   Seeded ${seededRecordIds.length} canonical CI record(s)`);
+    } catch (err) {
+      logger.warn(`   Warning: canonical CI seed failed (non-fatal): ${err.message}`);
+    }
+  }
+
   // Step 2: First-principles deconstruction
   logger.log('   Applying first-principles deconstruction...');
   const deconstruction = await deconstructToFirstPrinciples(analyses, { logger, llmClient });
@@ -78,6 +100,7 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
       path: 'competitor_teardown',
       url_count: urls.length,
       companies_analyzed: analyses.map(a => a.company_name).filter(Boolean),
+      canonical_ci_record_ids: seededRecordIds,
     },
   });
 }

--- a/lib/research/competitor-intelligence.js
+++ b/lib/research/competitor-intelligence.js
@@ -12,15 +12,12 @@ import axios from 'axios';
 import dotenv from 'dotenv';
 import { getLLMClient } from '../llm/client-factory.js';
 import { getOpenAIModel } from '../config/model-config.js';
+// Four-Buckets epistemic tagging is now OWNED by the canonical competitive-
+// intelligence layer (SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A). This
+// file delegates to it so there is exactly one owner of the FACT/ASSUMPTION/
+// SIMULATION/UNKNOWN semantics.
+import { structureWithFourBuckets as structureWithFourBucketsCanonical } from '../competitive-intelligence/four-buckets.js';
 dotenv.config();
-
-// Four Buckets classification for epistemic honesty
-const FOUR_BUCKETS = {
-  FACT: 'fact',           // Verified from source
-  ASSUMPTION: 'assumption', // Reasonable inference
-  SIMULATION: 'simulation', // AI-generated projection
-  UNKNOWN: 'unknown'       // Cannot determine
-};
 
 class CompetitorIntelligenceService {
   constructor(config = {}) {
@@ -49,8 +46,8 @@ class CompetitorIntelligenceService {
       // Step 2: Analyze with AI
       const analysis = await this.performAIAnalysis(url, websiteContent);
 
-      // Step 3: Structure response with Four Buckets
-      const structuredAnalysis = this.structureWithFourBuckets(analysis, url);
+      // Step 3: Structure response with Four Buckets (canonical layer)
+      const structuredAnalysis = structureWithFourBucketsCanonical(analysis, url);
 
       // Add metadata
       structuredAnalysis.metadata = {
@@ -316,92 +313,6 @@ Respond in valid JSON format:
     };
   }
 
-  /**
-   * Structure analysis with Four Buckets for the API response
-   */
-  structureWithFourBuckets(analysis, url) {
-    const domain = new URL(url).hostname.replace('www.', '');
-
-    // Extract venture suggestion for the API response
-    const suggestion = analysis.venture_suggestion || {};
-
-    return {
-      // Standard API response fields (for backward compatibility)
-      name: this.extractValue(suggestion.name) || `${domain.split('.')[0].toUpperCase()} Alternative`,
-      problem_statement: this.extractValue(suggestion.problem_statement) ||
-        `Compete with ${domain} by addressing their market gaps`,
-      solution: this.extractValue(suggestion.solution) ||
-        'Differentiated platform addressing competitor weaknesses',
-      target_market: this.extractValue(suggestion.target_market) ||
-        'Underserved segments of competitor\'s market',
-      competitor_reference: url,
-
-      // Four Buckets classified data
-      four_buckets: {
-        facts: this.extractByBucket(analysis, FOUR_BUCKETS.FACT),
-        assumptions: this.extractByBucket(analysis, FOUR_BUCKETS.ASSUMPTION),
-        simulations: this.extractByBucket(analysis, FOUR_BUCKETS.SIMULATION),
-        unknowns: this.extractByBucket(analysis, FOUR_BUCKETS.UNKNOWN)
-      },
-
-      // Full competitive intelligence
-      competitive_intelligence: {
-        company: analysis.company,
-        product: analysis.product,
-        market: analysis.market,
-        swot: {
-          strengths: analysis.strengths,
-          weaknesses: analysis.weaknesses,
-          opportunities: analysis.opportunities
-        }
-      },
-
-      // Quality metrics
-      quality: {
-        confidence_score: analysis.confidence_score || 0.5,
-        data_quality: analysis.data_quality || 'medium',
-        analysis_notes: analysis.analysis_notes
-      }
-    };
-  }
-
-  /**
-   * Extract value from bucket-structured field
-   */
-  extractValue(field) {
-    if (!field) return null;
-    return typeof field === 'object' ? field.value : field;
-  }
-
-  /**
-   * Extract all items classified with a specific bucket
-   */
-  extractByBucket(analysis, bucket) {
-    const items = [];
-
-    const traverse = (obj, path = '') => {
-      if (!obj || typeof obj !== 'object') return;
-
-      if (obj.bucket && obj.bucket.toUpperCase() === bucket.toUpperCase()) {
-        items.push({
-          path,
-          value: obj.value,
-          evidence: obj.evidence || obj.reasoning
-        });
-      }
-
-      if (Array.isArray(obj)) {
-        obj.forEach((item, i) => traverse(item, `${path}[${i}]`));
-      } else {
-        Object.entries(obj).forEach(([key, value]) => {
-          traverse(value, path ? `${path}.${key}` : key);
-        });
-      }
-    };
-
-    traverse(analysis);
-    return items;
-  }
 }
 
 export default CompetitorIntelligenceService;

--- a/tests/unit/competitive-intelligence/canonical-layer.test.js
+++ b/tests/unit/competitive-intelligence/canonical-layer.test.js
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the canonical competitive-intelligence layer.
+ * SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001-A
+ *
+ * Covers:
+ *  - Four-Buckets epistemic tagging (ported pure functions) — TS-4 parity
+ *  - canonical-store CRUD + snapshot diffing via an injected mock client
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  FOUR_BUCKETS,
+  extractValue,
+  extractByBucket,
+  structureWithFourBuckets,
+} from '../../../lib/competitive-intelligence/four-buckets.js';
+import {
+  upsertCompetitorIntelligence,
+  appendSnapshot,
+  listSnapshots,
+  computeDiff,
+} from '../../../lib/competitive-intelligence/canonical-store.js';
+
+// ---------------------------------------------------------------------------
+// Mock Supabase: chainable + awaitable query builder. Per-table results are
+// consumed in call order so a function that makes two from(<table>) calls can
+// get two different results.
+// ---------------------------------------------------------------------------
+function makeQuery(result) {
+  const q = {
+    select: () => q,
+    eq: () => q,
+    order: () => q,
+    limit: () => q,
+    insert: () => q,
+    update: () => q,
+    single: () => Promise.resolve(result),
+    then: (resolve, reject) => Promise.resolve(result).then(resolve, reject),
+  };
+  return q;
+}
+function makeSupabase(tableResults = {}) {
+  const counters = {};
+  return {
+    from(table) {
+      const arr = tableResults[table] || [];
+      const idx = counters[table] ?? 0;
+      counters[table] = idx + 1;
+      const result = arr[idx] ?? arr[arr.length - 1] ?? { data: [], error: null };
+      return makeQuery(result);
+    },
+  };
+}
+
+describe('four-buckets: constants and extractValue', () => {
+  it('exposes the four epistemic buckets', () => {
+    expect(FOUR_BUCKETS).toEqual({
+      FACT: 'fact',
+      ASSUMPTION: 'assumption',
+      SIMULATION: 'simulation',
+      UNKNOWN: 'unknown',
+    });
+  });
+
+  it('extractValue unwraps {value,bucket} objects and passes scalars through', () => {
+    expect(extractValue({ value: 'Acme', bucket: 'FACT' })).toBe('Acme');
+    expect(extractValue('plain')).toBe('plain');
+    expect(extractValue(null)).toBeNull();
+    expect(extractValue(undefined)).toBeNull();
+  });
+});
+
+describe('four-buckets: extractByBucket', () => {
+  const analysis = {
+    company: { name: { value: 'Acme', bucket: 'FACT' } },
+    product: { pricing_model: { value: 'Freemium', bucket: 'ASSUMPTION' } },
+    opportunities: [{ value: 'AI automation', bucket: 'SIMULATION', reasoning: 'cost edge' }],
+    market: { founded: { value: 'Unknown', bucket: 'UNKNOWN' } },
+  };
+
+  it('collects only leaves tagged with the requested bucket', () => {
+    const facts = extractByBucket(analysis, FOUR_BUCKETS.FACT);
+    expect(facts).toHaveLength(1);
+    expect(facts[0].value).toBe('Acme');
+    expect(facts[0].path).toBe('company.name');
+  });
+
+  it('classifies each bucket independently and captures evidence/reasoning', () => {
+    expect(extractByBucket(analysis, FOUR_BUCKETS.ASSUMPTION)).toHaveLength(1);
+    const sims = extractByBucket(analysis, FOUR_BUCKETS.SIMULATION);
+    expect(sims[0].evidence).toBe('cost edge');
+    expect(extractByBucket(analysis, FOUR_BUCKETS.UNKNOWN)).toHaveLength(1);
+  });
+
+  it('is case-insensitive on the bucket tag', () => {
+    const a = { x: { value: 'v', bucket: 'fact' } };
+    expect(extractByBucket(a, FOUR_BUCKETS.FACT)).toHaveLength(1);
+  });
+});
+
+describe('four-buckets: structureWithFourBuckets (TS-4 parity contract)', () => {
+  const raw = {
+    company: { name: { value: 'Acme', bucket: 'FACT' } },
+    product: { description: { value: 'CRM', bucket: 'FACT' } },
+    market: { industry: { value: 'SaaS', bucket: 'ASSUMPTION' } },
+    strengths: [{ value: 'brand', bucket: 'FACT' }],
+    weaknesses: [{ value: 'price', bucket: 'ASSUMPTION' }],
+    opportunities: [{ value: 'automation', bucket: 'SIMULATION' }],
+    venture_suggestion: {
+      name: { value: 'AcmeRival', bucket: 'SIMULATION' },
+      problem_statement: { value: 'too pricey', bucket: 'SIMULATION' },
+      solution: { value: 'cheaper AI CRM', bucket: 'SIMULATION' },
+    },
+    confidence_score: 0.8,
+    data_quality: 'high',
+  };
+
+  it('produces the canonical structured shape', () => {
+    const out = structureWithFourBuckets(raw, 'https://www.acme.com/pricing');
+    expect(out.name).toBe('AcmeRival');
+    expect(out.competitor_reference).toBe('https://www.acme.com/pricing');
+    expect(out.four_buckets.facts.length).toBeGreaterThanOrEqual(2);
+    expect(out.four_buckets.simulations.length).toBeGreaterThanOrEqual(3);
+    expect(out.competitive_intelligence.swot.strengths).toEqual(raw.strengths);
+    expect(out.quality.confidence_score).toBe(0.8);
+    expect(out.quality.data_quality).toBe('high');
+  });
+
+  it('falls back to a domain-derived name when no suggestion is present', () => {
+    const out = structureWithFourBuckets({}, 'https://www.example.com');
+    expect(out.name).toBe('EXAMPLE Alternative');
+    expect(out.quality.confidence_score).toBe(0.5); // default
+  });
+});
+
+describe('canonical-store: computeDiff', () => {
+  it('detects added, removed, and changed top-level keys', () => {
+    const diff = computeDiff(
+      { a: 1, b: 2, c: { x: 1 } },
+      { b: 3, c: { x: 1 }, d: 4 }
+    );
+    expect(diff.added).toEqual(['d']);
+    expect(diff.removed).toEqual(['a']);
+    expect(diff.changed).toEqual(['b']); // c is deep-equal, not changed
+  });
+
+  it('treats null/undefined snapshots as empty objects', () => {
+    expect(computeDiff(null, { a: 1 })).toEqual({ added: ['a'], removed: [], changed: [] });
+    expect(computeDiff({ a: 1 }, null)).toEqual({ added: [], removed: ['a'], changed: [] });
+  });
+});
+
+describe('canonical-store: upsertCompetitorIntelligence', () => {
+  it('inserts a new record (no id) and whitelists columns', async () => {
+    const inserted = { id: 'ci-1', competitor_url: 'https://x.com', source: 'teardown' };
+    const supabase = makeSupabase({ competitor_intelligence: [{ data: inserted, error: null }] });
+    const out = await upsertCompetitorIntelligence(
+      { competitor_url: 'https://x.com', source: 'teardown', not_a_column: 'dropped' },
+      { supabase }
+    );
+    expect(out).toEqual(inserted);
+  });
+
+  it('updates when an id is present', async () => {
+    const updated = { id: 'ci-1', sanitization_status: 'passed' };
+    const supabase = makeSupabase({ competitor_intelligence: [{ data: updated, error: null }] });
+    const out = await upsertCompetitorIntelligence(
+      { id: 'ci-1', sanitization_status: 'passed' },
+      { supabase }
+    );
+    expect(out.sanitization_status).toBe('passed');
+  });
+
+  it('throws a descriptive error on DB failure', async () => {
+    const supabase = makeSupabase({
+      competitor_intelligence: [{ data: null, error: { message: 'boom' } }],
+    });
+    await expect(
+      upsertCompetitorIntelligence({ competitor_url: 'https://x.com' }, { supabase })
+    ).rejects.toThrow(/boom/);
+  });
+});
+
+describe('canonical-store: snapshots', () => {
+  it('appendSnapshot computes a diff against the most recent prior snapshot', async () => {
+    const prior = { data: [{ snapshot: { price: 10, name: 'A' } }], error: null };
+    const inserted = { data: { id: 'snap-2', diff_from_prior: { changed: ['price'] } }, error: null };
+    const supabase = makeSupabase({ ci_snapshots: [prior, inserted] });
+    const out = await appendSnapshot('ci-1', { price: 20, name: 'A' }, { supabase, source: 'refresh' });
+    expect(out.id).toBe('snap-2');
+  });
+
+  it('appendSnapshot uses a null diff when there is no prior snapshot', async () => {
+    const noPrior = { data: [], error: null };
+    const inserted = { data: { id: 'snap-1' }, error: null };
+    const supabase = makeSupabase({ ci_snapshots: [noPrior, inserted] });
+    const out = await appendSnapshot('ci-1', { price: 10 }, { supabase, source: 'seed' });
+    expect(out.id).toBe('snap-1');
+  });
+
+  it('appendSnapshot requires a record id', async () => {
+    const supabase = makeSupabase({});
+    await expect(appendSnapshot(null, {}, { supabase })).rejects.toThrow(/required/);
+  });
+
+  it('listSnapshots returns rows newest-first', async () => {
+    const rows = [{ id: 's2' }, { id: 's1' }];
+    const supabase = makeSupabase({ ci_snapshots: [{ data: rows, error: null }] });
+    const out = await listSnapshots('ci-1', { supabase });
+    expect(out).toEqual(rows);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 (data spine) of the Competitive Intelligence orchestrator (SD-COMPETITIVE-INTELLIGENCE-ACROSS-THE-ORCH-001). Establishes the shared, venture-scoped competitor-intelligence record + canonical data layer that Children B/C/D/E will consume, reconciling the scattered competitor surfaces behind one contract.

## Changes
- **Migration (additive, reversible, RLS):** `competitor_intelligence` (operator-owned compounding CI asset; optional `venture_id` link because Stage-0 teardown runs before a venture exists; `differentiation_strategy` / `differentiation_delta` / `sanitization_status` slots for Children E + sanitization) and `ci_snapshots` (point-in-time history + `diff_from_prior`). RLS mirrors the existing `competitors` venture-ownership pattern. Reversibility proved (UP→DOWN-in-rollback→tables present) via the database-agent.
- **Canonical layer** (`lib/competitive-intelligence/`): `four-buckets.js` (Four-Buckets epistemic tagging ported here as the single owner), `canonical-store.js` (CRUD + snapshot diffing, supabase injectable), `index.js` (public contract + `analyzeCompetitor` wrapper + teardown seed helper).
- `competitor-intelligence.js` delegates Four-Buckets to the canonical layer (one owner; file retained until its last importer is migrated).
- `opportunity-discovery-service.js` migrated to the canonical layer (same engine underneath → output parity; only live importer).
- `competitor-teardown.js`: opt-in (default OFF), best-effort seed adapter that writes through the canonical layer; the live Stage-0 flow is unchanged until enabled.

## Testing
- 16 unit tests (`tests/unit/competitive-intelligence/canonical-layer.test.js`) — Four-Buckets tagging, store CRUD, snapshot diffing — all passing.
- Live end-to-end smoke against the real DB: insert → readback → snapshot diff → update (trigger) → FK cascade cleanup, all verified.

## PR size
Larger than the ≤100 LOC target but justified: the migration + foundational subsystem are atomic (the canonical layer needs the tables; the caller migration needs the layer) — splitting would create broken intermediate states. ~460 LOC logic; the remainder is migration SQL, tests, and docs.

## Notes
- A validation-agent duplicate-check corrected the design: there is no `competitor_tracking` table; the real existing table is `competitors` (roster). New tables reference the roster rather than duplicating it. See `docs/competitive-intelligence/childA-design-and-spike.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)