### PR TITLE
feat(SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001): FR-1/2/5 vision linkage + deliberate approval + idempotent generation

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1396,7 +1396,29 @@ Use the brainstorm discovery answers, team perspectives (Challenger, Visionary, 
 
 ### 9.5B: Register Vision in EVA (with Key Capture)
 
-Run the vision command with dimensions derived from the vision doc's success criteria and key sections:
+**FIRST — Deliberate chairman approval decision (MANDATORY, SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 / FR-2).**
+Registering a vision is NOT silently auto-approved. Before running the upsert, present the chairman with an explicit, clear choice. Summarize the vision (topic, problem statement, success criteria) and ask:
+
+```javascript
+{
+  "questions": [{
+    "question": "Approve this vision to start the build, or save it as a draft for later review?",
+    "header": "Vision Approval Decision",
+    "multiSelect": false,
+    "options": [
+      {"label": "Approve & start build", "description": "Marks the vision chairman_approved + active. The lifecycle-SD bridge can immediately generate build SDs for this venture."},
+      {"label": "Save as draft", "description": "Stores the vision as a draft (NOT approved). No build SDs are generated until you approve it later."}
+    ]
+  }]
+}
+```
+
+- If the chairman picks **"Approve & start build"** → pass `--approved`.
+- If the chairman picks **"Save as draft"** → pass `--draft`.
+
+The upsert command **requires** exactly one of `--approved` / `--draft` and will error if neither is given — there is no silent default. Do NOT guess; use the chairman's explicit selection.
+
+Run the vision command with dimensions derived from the vision doc's success criteria and key sections, threading the approval flag from the decision above (the example shows `--approved`; substitute `--draft` when the chairman chose to save a draft):
 
 ```bash
 node scripts/eva/vision-command.mjs upsert \
@@ -1404,10 +1426,11 @@ node scripts/eva/vision-command.mjs upsert \
   --level L2 \
   --content '<VISION_CONTENT_FROM_STEP_9.5A>' \
   --brainstorm-id <SESSION_ID> \
+  --approved \
   --dimensions '<JSON_ARRAY>'
 ```
 
-Substitute `<CONTEXT>` and `<NNN>` using the derivation + collision-scan rules below.
+Substitute `<CONTEXT>` and `<NNN>` using the derivation + collision-scan rules below. The `--brainstorm-id` also drives automatic venture linkage: when the brainstorm session names exactly one venture (and is not cross-venture), the vision's `venture_id` is set automatically at write time (FR-1).
 
 **IMPORTANT**: Use `--content` to pass the in-memory vision content directly. Do NOT use `--source` with a file path — that would create a markdown file, violating the DB-only policy.
 

--- a/.claude/skills/eva-vision.skill.md
+++ b/.claude/skills/eva-vision.skill.md
@@ -150,35 +150,41 @@ If the weight sum is outside 0.9-1.1, display a warning:
 ⚠️  Dimension weights sum to <sum> — expected ~1.0. Adjust before approval.
 ```
 
-Then ask:
+Then ask (SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 / FR-2 — approval is a deliberate, explicit choice, never silent):
 
 ```javascript
 {
   "questions": [{
-    "question": "Review the extracted dimensions above. Approve to save to the database.",
-    "header": "Chairman Approval",
+    "question": "Review the extracted dimensions above. How should this vision be saved?",
+    "header": "Chairman Approval Decision",
     "multiSelect": false,
     "options": [
-      {"label": "Approve — Save to database", "description": "Upsert vision document with these dimensions"},
-      {"label": "Reject — Cancel", "description": "Do not save. No changes made."}
+      {"label": "Approve & start build", "description": "Save active + chairman_approved. Build SDs can be generated for this venture."},
+      {"label": "Save as draft", "description": "Save as a draft (NOT approved). Review later; no build SDs until approved."},
+      {"label": "Cancel", "description": "Do not save. No changes made."}
     ]
   }]
 }
 ```
 
-**Step 5: On Approve — upsert**
+**Step 5: On a save choice — upsert**
+
+The upsert command **requires** exactly one of `--approved` / `--draft`. Map the chairman's choice:
+- **"Approve & start build"** → `--approved`
+- **"Save as draft"** → `--draft`
 
 ```bash
 node scripts/eva/vision-command.mjs upsert \
   --vision-key <key> \
   --level <L1|L2> \
   --source <source-path> \
+  --approved \
   --dimensions '<dimensions-json>'
 ```
 
-Display the output confirming the stored document.
+(Substitute `--draft` for `--approved` when the chairman chose "Save as draft".) Display the output confirming the stored document and its approval state.
 
-**Step 6: On Reject**
+**Step 6: On Cancel**
 
 Output:
 ```

--- a/database/migrations/20260601_venture_build_autonomy_default_l2.sql
+++ b/database/migrations/20260601_venture_build_autonomy_default_l2.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- FR-4: Venture-build autonomy default L0 -> L2 + safe single-step setter
+-- SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001  (DATABASE evidence a81c818b)
+-- ============================================================================
+-- CONTEXT (verified against live schema dedlbzhpgkmetvhbkyzq):
+--   * eva_ventures and ventures are SEPARATE base tables (NOT a view).
+--   * checkAutonomy() reads eva_ventures.autonomy_level (enum eva_autonomy_level).
+--   * sync_ventures_to_eva_ventures_insert() OMITS autonomy_level from its INSERT
+--     column list, so for trigger-synced rows the eva_ventures COLUMN DEFAULT
+--     is what applies -> we MUST set the default on eva_ventures (the read side)
+--     AND on ventures (the source/write side).
+--   * No autonomy setter function previously existed.
+--   * RLS on both tables is service_role-write only.
+--
+-- NON-RETROACTIVE: only the DEFAULT changes. Existing rows are NOT updated.
+-- Rollback notes at bottom.
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. DEFAULT change on the gate-READ table (eva_ventures: enum eva_autonomy_level)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.eva_ventures
+  ALTER COLUMN autonomy_level SET DEFAULT 'L2'::eva_autonomy_level;
+
+-- ---------------------------------------------------------------------------
+-- 2. DEFAULT change on the source/write table (ventures: text, CHECK L0..L4)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.ventures
+  ALTER COLUMN autonomy_level SET DEFAULT 'L2';
+
+-- NOTE: NO UPDATE statements. The 24 existing ventures / 25 eva_ventures rows
+-- remain at L0 by design (column-default changes are non-retroactive).
+
+-- ---------------------------------------------------------------------------
+-- 3. Safe single-step autonomy setter
+--    - validates p_level in {L0..L4}
+--    - reads current eva_ventures.autonomy_level
+--    - enforces SINGLE-STEP transition: abs(idx(target) - idx(current)) = 1
+--    - writes BOTH eva_ventures (enum cast) AND ventures (text)
+--    - SECURITY DEFINER so it can write under service_role-only RLS
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_venture_autonomy_level(
+  p_venture_id uuid,
+  p_level      text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_order   text[] := ARRAY['L0','L1','L2','L3','L4'];
+  v_current text;
+  v_ci      int;
+  v_ti      int;
+BEGIN
+  -- Validate target level
+  IF p_level IS NULL OR p_level NOT IN ('L0','L1','L2','L3','L4') THEN
+    RAISE EXCEPTION 'Invalid autonomy level: % (must be one of L0,L1,L2,L3,L4)', p_level
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Read current level from the gate-read table
+  SELECT autonomy_level::text INTO v_current
+  FROM public.eva_ventures
+  WHERE venture_id = p_venture_id;
+
+  IF v_current IS NULL THEN
+    RAISE EXCEPTION 'Venture % not found in eva_ventures', p_venture_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  v_ci := array_position(v_order, v_current);
+  v_ti := array_position(v_order, p_level);
+
+  -- Enforce single-step (validateLevelTransition semantics: |diff| must equal 1)
+  IF abs(v_ti - v_ci) <> 1 THEN
+    RAISE EXCEPTION
+      'Single-step transition only: % -> % is % level(s) (validateLevelTransition requires exactly 1)',
+      v_current, p_level, abs(v_ti - v_ci)
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Write source table (text)
+  UPDATE public.ventures
+     SET autonomy_level = p_level
+   WHERE id = p_venture_id;
+
+  -- Write gate-read table (enum cast); sync triggers do NOT cover this column
+  UPDATE public.eva_ventures
+     SET autonomy_level = p_level::eva_autonomy_level,
+         updated_at     = now()
+   WHERE venture_id = p_venture_id;
+
+  RETURN p_level;
+END;
+$$;
+
+COMMENT ON FUNCTION public.set_venture_autonomy_level(uuid, text) IS
+  'FR-4 SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001: single-step (|diff|=1) autonomy '
+  'level setter. Writes BOTH eva_ventures (enum, gate-read) and ventures (text, source) '
+  'because the ventures->eva_ventures sync triggers do not propagate autonomy_level. '
+  'SECURITY DEFINER for service_role-only RLS.';
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, if ever needed):
+--   ALTER TABLE public.eva_ventures ALTER COLUMN autonomy_level SET DEFAULT 'L0'::eva_autonomy_level;
+--   ALTER TABLE public.ventures     ALTER COLUMN autonomy_level SET DEFAULT 'L0';
+--   DROP FUNCTION IF EXISTS public.set_venture_autonomy_level(uuid, text);
+-- ============================================================================

--- a/lib/eva/__tests__/vision-upsert.test.js
+++ b/lib/eva/__tests__/vision-upsert.test.js
@@ -1,26 +1,52 @@
 /**
  * Tests for Vision Upsert Module
  * SD: SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-C
+ * SD: SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 (FR-1 venture linkage, FR-2 deliberate approval)
  */
 import { describe, test, expect, vi } from 'vitest';
 import { upsertVision } from '../vision-upsert.js';
 
-// Mock supabase client
-function mockSupabase({ existing = null, upsertResult = null, upsertError = null } = {}) {
+// Table-aware mock supabase client.
+//  - eva_vision_documents: select(...).eq(vision_key).maybeSingle() => existing,
+//    and upsert(...).select(...).single() => upsertResult/upsertError. Captures the
+//    upserted record on `captured.record` for assertions.
+//  - brainstorm_sessions: select(...).eq(id).maybeSingle() => brainstormSession.
+function mockSupabase({
+  existing = null,
+  upsertResult = null,
+  upsertError = null,
+  brainstormSession = null,
+  captured = {},
+} = {}) {
   return {
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          maybeSingle: vi.fn(async () => ({ data: existing, error: null })),
-          single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
-        })),
-      })),
-      upsert: vi.fn(() => ({
+    from: vi.fn((table) => {
+      if (table === 'brainstorm_sessions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: brainstormSession, error: null })),
+            })),
+          })),
+        };
+      }
+      // eva_vision_documents
+      return {
         select: vi.fn(() => ({
-          single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: existing, error: null })),
+            single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
+          })),
         })),
-      })),
-    })),
+        upsert: vi.fn((record) => {
+          captured.record = record;
+          return {
+            select: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
+            })),
+          };
+        }),
+      };
+    }),
   };
 }
 
@@ -58,7 +84,7 @@ describe('upsertVision', () => {
   test('returns error on upsert failure', async () => {
     const supabase = mockSupabase({ upsertError: { message: 'DB error' } });
 
-    const { data, error } = await upsertVision({
+    const { error } = await upsertVision({
       supabase,
       visionKey: 'V-1',
       content: 'test',
@@ -76,5 +102,113 @@ describe('upsertVision', () => {
 
     // Verify the upsert was called (from was called with correct table)
     expect(supabase.from).toHaveBeenCalledWith('eva_vision_documents');
+  });
+
+  // ── FR-2: deliberate approval ──────────────────────────────────────────────
+  describe('FR-2 deliberate approval', () => {
+    test('default (no approved option) writes active + chairman_approved (backward-compat)', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test' });
+
+      expect(captured.record.status).toBe('active');
+      expect(captured.record.chairman_approved).toBe(true);
+    });
+
+    test('approved=true writes active + chairman_approved', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', approved: true });
+
+      expect(captured.record.status).toBe('active');
+      expect(captured.record.chairman_approved).toBe(true);
+    });
+
+    test('approved=false writes draft + not approved', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', approved: false });
+
+      expect(captured.record.status).toBe('draft');
+      expect(captured.record.chairman_approved).toBe(false);
+    });
+  });
+
+  // ── FR-1: vision→venture linkage at write time ─────────────────────────────
+  describe('FR-1 venture linkage at write time', () => {
+    test('explicit ventureId is used and wins (no brainstorm lookup needed)', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', ventureId: 'VEN-EXPLICIT' });
+
+      expect(captured.record.venture_id).toBe('VEN-EXPLICIT');
+    });
+
+    test('brainstorm-sourced single-venture upsert links venture_id', async () => {
+      const captured = {};
+      const supabase = mockSupabase({
+        upsertResult: { id: 'u', vision_key: 'V-1' },
+        brainstormSession: { venture_ids: ['VEN-SINGLE'], cross_venture: false },
+        captured,
+      });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', brainstormId: 'bs-1' });
+
+      expect(captured.record.venture_id).toBe('VEN-SINGLE');
+      expect(supabase.from).toHaveBeenCalledWith('brainstorm_sessions');
+    });
+
+    test('cross_venture brainstorm leaves venture_id null', async () => {
+      const captured = {};
+      const supabase = mockSupabase({
+        upsertResult: { id: 'u', vision_key: 'V-1' },
+        brainstormSession: { venture_ids: ['VEN-A'], cross_venture: true },
+        captured,
+      });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', brainstormId: 'bs-1' });
+
+      expect(captured.record.venture_id).toBeUndefined();
+    });
+
+    test('multi-venture brainstorm leaves venture_id null', async () => {
+      const captured = {};
+      const supabase = mockSupabase({
+        upsertResult: { id: 'u', vision_key: 'V-1' },
+        brainstormSession: { venture_ids: ['VEN-A', 'VEN-B'], cross_venture: false },
+        captured,
+      });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', brainstormId: 'bs-1' });
+
+      expect(captured.record.venture_id).toBeUndefined();
+    });
+
+    test('no brainstorm and no ventureId leaves venture_id null', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test' });
+
+      expect(captured.record.venture_id).toBeUndefined();
+      expect(supabase.from).not.toHaveBeenCalledWith('brainstorm_sessions');
+    });
+
+    test('brainstorm with zero venture_ids leaves venture_id null', async () => {
+      const captured = {};
+      const supabase = mockSupabase({
+        upsertResult: { id: 'u', vision_key: 'V-1' },
+        brainstormSession: { venture_ids: [], cross_venture: false },
+        captured,
+      });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test', brainstormId: 'bs-1' });
+
+      expect(captured.record.venture_id).toBeUndefined();
+    });
   });
 });

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -214,9 +214,9 @@ export async function assertVentureVisionReady(supabase, ventureId, ventureName)
       'VENTURE_L2_VISION_DRAFT_SEED',
       [
         `Venture ${ventureName || ventureId}: archived stub L2 vision found (vision_key=${archived.vision_key}, status=draft_seed).`,
-        `No chairman-approved canonical L2 exists. To unblock orchestrator generation:`,
+        'No chairman-approved canonical L2 exists. To unblock orchestrator generation:',
         `  /brainstorm --seed-from=draft_seed --venture ${ventureName || '<name>'}`,
-        `After the brainstorm completes, review the generated L2 doc and set chairman_approved=true.`,
+        'After the brainstorm completes, review the generated L2 doc and set chairman_approved=true.',
       ].join('\n'),
       'LifecycleSDBridge',
     );
@@ -226,9 +226,9 @@ export async function assertVentureVisionReady(supabase, ventureId, ventureName)
     'VENTURE_L2_VISION_MISSING',
     [
       `Venture ${ventureName || ventureId}: no L2 vision document found.`,
-      `To unblock orchestrator generation, run:`,
+      'To unblock orchestrator generation, run:',
       `  /brainstorm --venture ${ventureName || '<name>'}`,
-      `After the brainstorm completes, review the generated L2 doc and set chairman_approved=true.`,
+      'After the brainstorm completes, review the generated L2 doc and set chairman_approved=true.',
     ].join('\n'),
     'LifecycleSDBridge',
   );
@@ -246,6 +246,50 @@ function buildProvenance(ventureId) {
     generated_at: new Date().toISOString(),
     generation_version: GENERATION_VERSION,
   };
+}
+
+/**
+ * SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 / FR-5 — idempotent SD insert.
+ *
+ * Re-running build-plan generation for the same venture/sprint regenerates the
+ * SAME deterministic sd_keys (sd-key-generator is venture+index deterministic).
+ * A plain `.insert()` raises Postgres 23505 on the unique constraint
+ * `strategic_directives_v2_sd_key_key`, which previously threw → rolled back the
+ * whole run and surfaced as a hard failure. This helper makes creation
+ * idempotent on sd_key: an existing row is treated as REUSE (no overwrite, no
+ * throw).
+ *
+ * Strategy: keep the plain INSERT (so a fresh sd_key inserts exactly once) and
+ * catch 23505 as "already exists" → `{ created:false }`. We deliberately do NOT
+ * upsert-overwrite an existing SD: a re-run must not clobber an SD that may have
+ * advanced past LEAD. INSERT-or-skip is the correct idempotency semantics here.
+ *
+ * NOTE: `row.metadata` MUST be an object (`{}`), never null — the metadata
+ * trigger on strategic_directives_v2 rejects null. All call sites already pass
+ * a populated metadata object.
+ *
+ * @param {Object} supabase
+ * @param {Object} row - full strategic_directives_v2 row (must include sd_key, id, metadata:{})
+ * @returns {Promise<{ created: boolean, error: Object|null }>}
+ */
+async function insertSDIdempotent(supabase, row) {
+  const { error } = await supabase
+    .from('strategic_directives_v2')
+    .insert(row);
+
+  if (error) {
+    // 23505 = unique_violation on sd_key. Treat the collision as reuse, not
+    // failure: the deterministic key already exists from a prior generation pass.
+    // (Message fallback covers clients that don't surface error.code.)
+    const isDuplicate = error.code === '23505'
+      || /duplicate key value|strategic_directives_v2_sd_key_key/i.test(error.message || '');
+    if (isDuplicate) {
+      return { created: false, error: null };
+    }
+    return { created: false, error };
+  }
+
+  return { created: true, error: null };
 }
 
 /**
@@ -333,12 +377,10 @@ export async function convertSprintToSDs(params, deps = {}) {
     const childRanks = payloads.map(sprintItemLayerRank);
     const childBuildDeps = deriveChildBuildOrder(childKeysAll, childRanks);
 
-    // Create orchestrator SD
+    // Create orchestrator SD (FR-5: idempotent on sd_key — reuse on re-run)
     const orchestratorId = randomUUID();
     const provenance = buildProvenance(ventureContext?.id);
-    const { error: orchError } = await supabase
-      .from('strategic_directives_v2')
-      .insert({
+    const { created: orchCreated, error: orchError } = await insertSDIdempotent(supabase, {
         id: orchestratorId,
         sd_key: orchestratorKey,
         venture_id: ventureContext?.id || null,
@@ -381,8 +423,14 @@ export async function convertSprintToSDs(params, deps = {}) {
       throw new Error(`Failed to create orchestrator: ${orchError.message}`);
     }
 
-    createdIds.push(orchestratorId);
-    logger.log(`[LifecycleSDBridge] Created orchestrator: ${orchestratorKey} (${orchestratorId})`);
+    // FR-5: only track for rollback rows we actually created; a reused
+    // (pre-existing) orchestrator must NOT be cancelled if a later step fails.
+    if (orchCreated) {
+      createdIds.push(orchestratorId);
+      logger.log(`[LifecycleSDBridge] Created orchestrator: ${orchestratorKey} (${orchestratorId})`);
+    } else {
+      logger.log(`[LifecycleSDBridge] Orchestrator already existed (reused on re-run): ${orchestratorKey}`);
+    }
 
     // ── SD-LEO-INFRA-BRIDGE-ARTIFACT-ENRICHMENT-001: Artifact enrichment ──
     let enrichmentResults = null;
@@ -409,9 +457,7 @@ export async function convertSprintToSDs(params, deps = {}) {
       const childArtifactRefs = enrichment?.artifactReferences || [];
 
       const childId = randomUUID();
-      const { error: childError } = await supabase
-        .from('strategic_directives_v2')
-        .insert({
+      const { created: childCreated, error: childError } = await insertSDIdempotent(supabase, {
           id: childId,
           sd_key: childKey,
           venture_id: ventureContext?.id || null,
@@ -460,12 +506,21 @@ export async function convertSprintToSDs(params, deps = {}) {
         throw new Error(`Failed to create child ${childKey}: ${childError.message}`);
       }
 
-      createdIds.push(childId);
+      // FR-5: childKeys always reflects the full intended set (used for the
+      // return + integrity check), but only newly-created rows are tracked for
+      // rollback so a re-run never cancels pre-existing children.
       childKeys.push(childKey);
-      logger.log(`[LifecycleSDBridge] Created child: ${childKey} (${dbType})`);
+      if (childCreated) {
+        createdIds.push(childId);
+        logger.log(`[LifecycleSDBridge] Created child: ${childKey} (${dbType})`);
+      } else {
+        logger.log(`[LifecycleSDBridge] Child already existed (reused on re-run): ${childKey}`);
+      }
 
-      // Generate grandchildren for this child (US-001)
-      if (generateGrandchildren) {
+      // Generate grandchildren for this child (US-001).
+      // Skip on reuse: a pre-existing child already has its grandchildren, and
+      // its real id differs from this run's freshly-generated childId.
+      if (generateGrandchildren && childCreated) {
         const gcKeys = await createGrandchildren({
           supabase,
           logger,
@@ -584,9 +639,7 @@ async function createGrandchildren({
     const gcKey = generateGrandchildKey(parentChildKey, j);
     const gcId = randomUUID();
 
-    const { error: gcError } = await supabase
-      .from('strategic_directives_v2')
-      .insert({
+    const { created: gcCreated, error: gcError } = await insertSDIdempotent(supabase, {
         id: gcId,
         sd_key: gcKey,
         venture_id: ventureContext?.id || null,
@@ -627,9 +680,13 @@ async function createGrandchildren({
       throw new Error(`Failed to create grandchild ${gcKey}: ${gcError.message}`);
     }
 
-    createdIds.push(gcId);
     gcKeys.push(gcKey);
-    logger.log(`[LifecycleSDBridge] Created grandchild: ${gcKey} (${layer.key})`);
+    if (gcCreated) {
+      createdIds.push(gcId); // FR-5: only track newly-created rows for rollback
+      logger.log(`[LifecycleSDBridge] Created grandchild: ${gcKey} (${layer.key})`);
+    } else {
+      logger.log(`[LifecycleSDBridge] Grandchild already existed (reused on re-run): ${gcKey}`);
+    }
   }
 
   return gcKeys;
@@ -1149,6 +1206,7 @@ export const _internal = {
   GENERATION_SOURCE,
   GENERATION_VERSION,
   buildProvenance,
+  insertSDIdempotent,
   selectApplicableLayers,
   filterLayersByCapability,
   rollbackCreatedRecords,

--- a/lib/eva/vision-upsert.js
+++ b/lib/eva/vision-upsert.js
@@ -7,10 +7,48 @@
  * @module lib/eva/vision-upsert
  */
 
-export async function upsertVision({ supabase, visionKey, level = 'L2', content, sections, dimensions, ventureId, brainstormId, createdBy = 'eva-vision-upsert' }) {
+/**
+ * Upsert an EVA vision document.
+ *
+ * SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001:
+ *  - FR-1: resolve venture_id at WRITE TIME from a single-venture brainstorm
+ *    session when ventureId is not supplied directly.
+ *  - FR-2: approval is now an EXPLICIT option (`approved`). When true the doc is
+ *    written active + chairman_approved; when false it is written draft +
+ *    not-approved. Default remains `true` for backward-compat with the existing
+ *    programmatic callers (vision-repair-loop, stage-17-doc-generation); the CLI
+ *    wrapper (scripts/eva/vision-command.mjs) makes the choice mandatory so the
+ *    chairman-facing path is deliberate, not silent.
+ *
+ * @param {Object}  params
+ * @param {Object}  params.supabase   - Supabase client (required)
+ * @param {string}  params.visionKey  - vision_key (required)
+ * @param {string}  [params.level='L2']
+ * @param {string}  params.content    - rendered content (required)
+ * @param {Object}  [params.sections]
+ * @param {Array}   [params.dimensions]
+ * @param {string}  [params.ventureId] - explicit venture linkage (wins over brainstorm resolution)
+ * @param {string}  [params.brainstormId] - source brainstorm session id (used for FR-1 venture resolution)
+ * @param {string}  [params.createdBy='eva-vision-upsert']
+ * @param {boolean} [params.approved=true] - FR-2: controls chairman_approved AND status
+ * @returns {Promise<{data: Object|null, error: Object|null}>}
+ */
+export async function upsertVision({ supabase, visionKey, level = 'L2', content, sections, dimensions, ventureId, brainstormId, createdBy = 'eva-vision-upsert', approved = true }) {
   if (!supabase) throw new Error('supabase client is required');
   if (!visionKey) throw new Error('visionKey is required');
   if (!content) throw new Error('content is required');
+
+  // FR-1: vision→venture linkage at WRITE TIME.
+  // When no explicit ventureId is given but the upsert is sourced from a
+  // brainstorm session, resolve the venture from that session — but ONLY when it
+  // maps to exactly one, unambiguous venture (single venture_id AND not a
+  // cross_venture session). Anything ambiguous (multi/zero venture or
+  // cross_venture) leaves venture_id null, preserving the 200 internal-SD vision
+  // rows that must stay NULL.
+  let resolvedVentureId = ventureId || null;
+  if (!resolvedVentureId && brainstormId) {
+    resolvedVentureId = await resolveVentureFromBrainstorm(supabase, brainstormId);
+  }
 
   // Fetch existing version + addendums
   const { data: existing } = await supabase
@@ -32,19 +70,22 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
       }]
     : prevAddendums;
 
+  // FR-2: deliberate approval — `approved` controls BOTH chairman_approved and status.
+  const isApproved = approved !== false;
+
   const record = {
     vision_key: visionKey,
     level,
     content,
     extracted_dimensions: dimensions || null,
     version,
-    status: 'active',
-    chairman_approved: true,
+    status: isApproved ? 'active' : 'draft',
+    chairman_approved: isApproved,
     source_file_path: null,
     created_by: createdBy,
     addendums,
     ...(sections && Object.keys(sections).length > 0 ? { sections } : {}),
-    ...(ventureId ? { venture_id: ventureId } : {}),
+    ...(resolvedVentureId ? { venture_id: resolvedVentureId } : {}),
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
   };
 
@@ -55,4 +96,40 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
     .single();
 
   return { data, error };
+}
+
+/**
+ * FR-1: Resolve a single, unambiguous venture_id from a brainstorm session.
+ *
+ * A brainstorm session carries `venture_ids` (array) and a `cross_venture`
+ * boolean. We only link a vision to a venture when the session names EXACTLY ONE
+ * venture and is NOT cross_venture — i.e. the brainstorm is unambiguously about
+ * one venture. Any other shape (zero/multiple venture_ids, or cross_venture=true)
+ * returns null so the vision stays venture-unlinked.
+ *
+ * Fails soft: a lookup error or missing row returns null (never throws) so an
+ * upsert is never blocked by venture-resolution issues.
+ *
+ * @param {Object} supabase
+ * @param {string} brainstormId
+ * @returns {Promise<string|null>}
+ */
+async function resolveVentureFromBrainstorm(supabase, brainstormId) {
+  try {
+    const { data: session, error } = await supabase
+      .from('brainstorm_sessions')
+      .select('venture_ids, cross_venture')
+      .eq('id', brainstormId)
+      .maybeSingle();
+
+    if (error || !session) return null;
+    if (session.cross_venture === true) return null;
+
+    const ventureIds = Array.isArray(session.venture_ids) ? session.venture_ids.filter(Boolean) : [];
+    if (ventureIds.length !== 1) return null;
+
+    return ventureIds[0];
+  } catch {
+    return null;
+  }
 }

--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -223,23 +223,28 @@ async function main() {
       console.log('    🤖 Extracting dimensions...');
       const dimensions = await extractDimensions(content);
 
-      const { error: insErr } = await supabase
-        .from('eva_vision_documents')
-        .upsert({
-          vision_key: visionKey,
-          level: 'L2',
-          content,
-          extracted_dimensions: dimensions,
-          version: 1,
-          status: 'draft',
-          chairman_approved: false,
-          source_brainstorm_id: session.id,
-          venture_id: session.metadata?.venture_id || null,
-          created_by: 'brainstorm-to-vision-pipeline',
-        }, { onConflict: 'vision_key' });
+      // SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 / FR-2: route through the
+      // single canonical upsert so approval semantics live in ONE place. This
+      // pipeline NEVER auto-approves — auto-created L2 visions are drafts until a
+      // chairman explicitly approves them. `approved: false` => status='draft',
+      // chairman_approved=false (preserving prior behavior, now non-divergent).
+      // FR-1: passing the brainstorm id also lets upsertVision resolve venture_id
+      // from a single-venture session at write time.
+      const { upsertVision } = await import('../../lib/eva/vision-upsert.js');
+      const { error: insErr } = await upsertVision({
+        supabase,
+        visionKey,
+        level: 'L2',
+        content,
+        dimensions,
+        brainstormId: session.id,
+        ventureId: session.metadata?.venture_id || null,
+        createdBy: 'brainstorm-to-vision-pipeline',
+        approved: false,
+      });
 
       if (insErr) { console.error(`    ❌ Insert failed: ${insErr.message}`); continue; }
-      console.log(`    ✅ L2 vision doc created (${dimensions?.length || 0} dimensions)`);
+      console.log(`    ✅ L2 vision doc created as DRAFT (not approved; ${dimensions?.length || 0} dimensions)`);
     }
 
     processed++;

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -13,10 +13,14 @@
  *
  * Subcommands:
  *   extract --source <path>              Extract dimensions from source file (stdout JSON)
- *   upsert  --vision-key <key>           Upsert vision doc to DB after chairman approval
+ *   upsert  --vision-key <key>           Upsert vision doc to DB
  *           --level <L1|L2>
  *           --source <path>
- *           [--venture-id <id>]
+ *           (--approved | --draft)        REQUIRED: deliberate approval choice.
+ *                                         --approved => active + chairman_approved
+ *                                         --draft    => draft, not approved
+ *           [--venture-id <id>]           Explicit venture linkage
+ *           [--brainstorm-id <id>]        Source brainstorm (auto-links a single-venture session)
  *           [--dimensions <json>]
  *   addendum --vision-key <key>          Append addendum section to existing vision doc
  *            --section <text>
@@ -146,10 +150,25 @@ async function cmdExtract({ source, content: contentArg }) {
   console.log(JSON.stringify(dimensions, null, 2));
 }
 
-async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId, sections: sectionsJson, content: contentArg, stdin: stdinFlag }) {
+async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId, sections: sectionsJson, content: contentArg, stdin: stdinFlag, approved: approvedFlag, draft: draftFlag }) {
   if (!visionKey) { console.error('--vision-key is required'); process.exit(1); }
   if (!level || !['L1', 'L2'].includes(level)) { console.error('--level must be L1 or L2'); process.exit(1); }
   if (!source && !sectionsJson && !contentArg && !stdinFlag) { console.error('--source, --sections, --content, or --stdin is required'); process.exit(1); }
+
+  // FR-2 (SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001): approval must be a
+  // DELIBERATE, explicit chairman choice — never a silent default. Require
+  // exactly one of --approved / --draft so registering a vision is an explicit
+  // decision to either start the build (active + chairman_approved) or save a
+  // draft (draft + not approved).
+  if (approvedFlag && draftFlag) {
+    console.error('Pass only ONE of --approved or --draft, not both.');
+    process.exit(1);
+  }
+  if (!approvedFlag && !draftFlag) {
+    console.error('Approval decision required: pass --approved (active + chairman_approved) or --draft (saved as draft, not approved).');
+    process.exit(1);
+  }
+  const approved = Boolean(approvedFlag);
 
   // Read content from stdin when --stdin is set. Cross-platform alternative to
   // --content which hits OS CLI length limits (~8K on Windows) for large docs.
@@ -298,7 +317,7 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   const { upsertVision } = await import('../../lib/eva/vision-upsert.js');
   const { data, error } = await upsertVision({
     supabase, visionKey, level, content, sections, dimensions,
-    ventureId, brainstormId, createdBy: 'eva-vision-command',
+    ventureId, brainstormId, createdBy: 'eva-vision-command', approved,
   });
 
   if (error) { console.error('❌ Upsert failed:', error.message); process.exit(1); }
@@ -309,6 +328,7 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   console.log(`   Level:   ${data.level}`);
   console.log(`   Version: ${data.version}`);
   console.log(`   Status:  ${data.status}`);
+  console.log(`   Approval: ${approved ? 'APPROVED (chairman_approved=true, build can start)' : 'DRAFT (not approved — review then re-run with --approved to start build)'}`);
   if (dimensions) console.log(`   Dimensions: ${dimensions.length} extracted`);
   if (sections) console.log(`   Sections: ${renderSectionsSummary(sections)}`);
 }

--- a/tests/unit/eva/lifecycle-sd-bridge.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge.test.js
@@ -538,6 +538,99 @@ describe('LifecycleSDBridge', () => {
     });
   });
 
+  describe('FR-5 idempotent generation (SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001)', () => {
+    // Mock that models the real strategic_directives_v2_sd_key_key unique
+    // constraint: the first INSERT of a given sd_key succeeds; any later INSERT
+    // of the same sd_key returns Postgres 23505. The pre-existing-orchestrator
+    // idempotency short-circuit (findExistingOrchestrator) is bypassed here by
+    // returning [] from the select-limit chain, so we exercise the INSERT-level
+    // sd_key idempotency directly.
+    function createKeyConstraintSupabase() {
+      const seenKeys = new Set();
+      const insertedRows = [];
+      const sb = {
+        from: vi.fn((table) => {
+          if (table === 'eva_vision_documents') {
+            const vc = {
+              select: vi.fn(() => vc),
+              eq: vi.fn(() => vc),
+              in: vi.fn(() => vc),
+              order: vi.fn(() => vc),
+              limit: vi.fn(() => vc),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { vision_key: 'VISION-TEST-L2-001', version: 'v1', content: 'x', updated_at: '2026-05-27' }, error: null }),
+            };
+            return vc;
+          }
+          if (table === 'strategic_directives_v2') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              insert: vi.fn().mockImplementation((row) => {
+                if (seenKeys.has(row.sd_key)) {
+                  return Promise.resolve({
+                    data: null,
+                    error: { code: '23505', message: 'duplicate key value violates unique constraint "strategic_directives_v2_sd_key_key"' },
+                  });
+                }
+                seenKeys.add(row.sd_key);
+                insertedRows.push(row);
+                return Promise.resolve({ data: null, error: null });
+              }),
+              update: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            };
+          }
+          return { select: vi.fn().mockReturnThis(), insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+        }),
+        rpc: vi.fn().mockResolvedValue({ data: { cancelled_sds: 0, cancelled_prds: 0 }, error: null }),
+      };
+      return { sb, get insertedRows() { return insertedRows; } };
+    }
+
+    const sprintParams = {
+      stageOutput: {
+        sprint_name: 'Sprint Idem',
+        sprint_goal: 'Build',
+        sd_bridge_payloads: [
+          { title: 'Feature A', type: 'feature', description: 'D', scope: 'S' },
+          { title: 'Feature B', type: 'feature', description: 'D', scope: 'S' },
+        ],
+      },
+      ventureContext: { id: 'v1', name: 'Test' },
+      options: { generateGrandchildren: false, skipEnrichment: true },
+    };
+
+    it('second generation pass with identical sd_keys creates 0 new rows and does not error', async () => {
+      const { sb, insertedRows } = createKeyConstraintSupabase();
+
+      const first = await convertSprintToSDs(sprintParams, { supabase: sb, logger: silentLogger });
+      expect(first.created).toBe(true);
+      const rowsAfterFirst = insertedRows.length;
+      expect(rowsAfterFirst).toBeGreaterThan(0); // orchestrator + 2 children
+
+      // Second pass: same deterministic keys → every INSERT hits 23505 → reuse, no throw.
+      const second = await convertSprintToSDs(sprintParams, { supabase: sb, logger: silentLogger });
+
+      // No new rows inserted on the re-run.
+      expect(insertedRows.length).toBe(rowsAfterFirst);
+      // The run must not surface a hard failure (no rollback, no thrown error).
+      expect(second.errors).toEqual([]);
+      expect(sb.rpc).not.toHaveBeenCalled(); // rollback never triggered
+      // childKeys still reflect the full intended set on the reuse pass.
+      expect(second.childKeys.length).toBe(2);
+    });
+
+    it('does not roll back pre-existing rows when a later pass reuses keys', async () => {
+      const { sb } = createKeyConstraintSupabase();
+      await convertSprintToSDs(sprintParams, { supabase: sb, logger: silentLogger });
+      await convertSprintToSDs(sprintParams, { supabase: sb, logger: silentLogger });
+      // Neither pass should have attempted the rollback RPC.
+      expect(sb.rpc).not.toHaveBeenCalled();
+    });
+  });
+
   describe('buildBridgeArtifactRecord', () => {
     it('should build correct artifact for successful bridge', () => {
       const record = buildBridgeArtifactRecord('venture-1', 18, {


### PR DESCRIPTION
## SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 — FR-1, FR-2, FR-5

Addresses the chairman complaint that vision approval was silent/auto, plus venture-linkage and re-run-safety gaps in the build-plan pipeline.

### FR-1 — vision→venture linkage at WRITE TIME
- `lib/eva/vision-upsert.js` `upsertVision()` resolves `venture_id` from the source brainstorm when no explicit `ventureId` is given — **only** when the session names exactly one venture **and** `cross_venture` is false. Anything ambiguous (multi/zero venture, or cross-venture) leaves `venture_id` NULL, so the ~200 internal-SD visions stay NULL (no mass backfill; real venture visions like DataDistill/CronGenius already linked).
- Uses canonical `brainstorm_sessions.venture_ids (UUID[])` + `cross_venture (bool)` — verified against the migration schema.
- `scripts/eva/vision-command.mjs` threads `--venture-id` / `--brainstorm-id`.

### FR-2 — deliberate, non-silent approval
- `upsertVision()` replaces the hardcoded `chairman_approved:true` / `status:'active'` with an explicit `approved` option that controls **both** `chairman_approved` **and** `status` (`active` if approved else `draft`).
- **FR-2 default decision: OPTION (a) — the CLI requires an explicit choice.** `vision-command.mjs upsert` now errors unless exactly one of `--approved` / `--draft` is passed. Rationale from caller-impact grep: only the **CLI path** is chairman-facing and it has **few callers** (brainstorm.md Step 9.5B + the eva-vision skill). The library function keeps `approved=true` as default purely for backward-compat with the **2 programmatic callers** that legitimately create active docs (`vision-repair-loop.js` re-upserting an existing doc, `stage-17-doc-generation.js`). This makes the human path deliberate without breaking automation.
- `scripts/eva/brainstorm-to-vision.mjs` reconciled to route its L2 creation through the one canonical `upsertVision({approved:false})` — one coherent approval semantics, not two divergent ones.
- `.claude/commands/brainstorm.md` Step 9.5B and `.claude/skills/eva-vision.skill.md` now present an explicit **"Approve & start build" vs "Save as draft"** chairman choice and pass the matching flag. This is the fix for the user's complaint.

### FR-5 — idempotent build-plan generation
- `lib/eva/lifecycle-sd-bridge.js` adds `insertSDIdempotent()`, used by the orchestrator/child/grandchild inserts: a plain INSERT that catches Postgres `23505` on `strategic_directives_v2_sd_key_key` and treats the deterministic `sd_key` collision as **reuse** (`created:false`, no throw, no overwrite — a re-run must not clobber an SD that advanced past LEAD).
- Re-running generation for the same venture creates **0 new rows** and does **not** error. Only newly-created rows are tracked for rollback, so a re-run never cancels pre-existing SDs. `metadata` passed as `{}` (never null) per the metadata trigger. No keying on `lifecycle_stage` (column does not exist).

### Tests
- `lib/eva/__tests__/vision-upsert.test.js`: FR-1 venture-resolution matrix (single→link, cross_venture/multi/zero/no-brainstorm→null, explicit wins) + FR-2 approve→active / draft→draft / default backward-compat.
- `tests/unit/eva/lifecycle-sd-bridge.test.js`: FR-5 second-pass-creates-0-rows-and-no-error + no-rollback-on-reuse.
- 109 unit tests green across all touched files (`vision-upsert`, `lifecycle-sd-bridge`, `brainstorm-to-vision`, `stage-17-doc-generation`, `vision-repair-loop`, `lifecycle-sd-bridge-refusal`).

> Note: a companion migration file will be added to this branch before merge — **do not auto-merge**.

> Pre-existing (not introduced here): 6 lint errors in `lifecycle-sd-bridge.js` (double-quote strings + unused params in `convertExpansionToSD`), and 4 stale tests in the duplicate `tests/unit/lifecycle-sd-bridge.test.js` (grandchild-path mock gap) that fail identically on base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
