### PR TITLE
fix(QF-20260601-345): budget_exceeded advisory (MEDIUM) — unblock zero-cost S19 SD bridge

### DIFF
--- a/lib/eva/decision-filter-engine.js
+++ b/lib/eva/decision-filter-engine.js
@@ -151,11 +151,17 @@ export function evaluateDecision(input = {}, options = {}) {
   if (input.budgetStatus) {
     const bs = input.budgetStatus;
     if (bs.is_over_budget) {
+      // ADVISORY (QF-20260601-345, RCA a8c479493): MEDIUM not HIGH — mirrors sibling Rule 1
+      // (cost_threshold, SD-MAN-FEAT-CORRECTIVE-VISION-GAP-070). A HIGH trigger here maps to
+      // FILTER_ACTION.STOP, which breaks the worker venture loop BEFORE the zero-LLM-cost S19
+      // SD bridge (convertSprintToSDs), so an over-budget leo_bridge venture with a ready
+      // sprint plan could never generate its build SDs. MEDIUM still fires PRESENT_TO_CHAIRMAN
+      // (the Chairman is informed) but does NOT hard-halt the pipeline.
       triggers.push({
         type: 'budget_exceeded',
-        severity: 'HIGH',
-        message: `Token budget exceeded: ${bs.usage_percentage}% used (${bs.tokens_used} / ${bs.budget_limit} tokens)`,
-        details: { tokensUsed: bs.tokens_used, budgetLimit: bs.budget_limit, usagePercentage: bs.usage_percentage },
+        severity: 'MEDIUM',
+        message: `Token budget exceeded: ${bs.usage_percentage}% used (${bs.tokens_used} / ${bs.budget_limit} tokens) (advisory — pipeline continues)`,
+        details: { tokensUsed: bs.tokens_used, budgetLimit: bs.budget_limit, usagePercentage: bs.usage_percentage, advisory: true },
       });
     } else if (bs.usage_percentage >= 80) {
       triggers.push({

--- a/tests/unit/eva/decision-filter-budget.test.js
+++ b/tests/unit/eva/decision-filter-budget.test.js
@@ -19,7 +19,11 @@ describe('Decision Filter Engine - budget_exceeded trigger', () => {
     expect(budgetIdx).toBeLessThan(techIdx);
   });
 
-  it('should fire HIGH trigger when over budget', () => {
+  // QF-20260601-345 (RCA a8c479493): over-budget is ADVISORY (MEDIUM), not HIGH. A HIGH trigger
+  // here maps to FILTER_ACTION.STOP, which breaks the worker venture loop BEFORE the zero-LLM-cost
+  // S19 SD bridge (convertSprintToSDs), so an over-budget leo_bridge venture with a ready sprint
+  // plan could never generate its build SDs (DataDistill 510177ba). Mirrors sibling Rule 1.
+  it('should fire MEDIUM (advisory) trigger when over budget — never HIGH (HIGH would STOP the S19 bridge)', () => {
     const result = evaluateDecision({
       budgetStatus: {
         is_over_budget: true,
@@ -31,11 +35,17 @@ describe('Decision Filter Engine - budget_exceeded trigger', () => {
 
     const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
     expect(budgetTrigger).toBeTruthy();
-    expect(budgetTrigger.severity).toBe('HIGH');
+    expect(budgetTrigger.severity).toBe('MEDIUM');
     expect(budgetTrigger.details.tokensUsed).toBe(575000);
     expect(budgetTrigger.details.budgetLimit).toBe(500000);
-    expect(result.auto_proceed).toBe(false);
-    expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN');
+    expect(budgetTrigger.details.advisory).toBe(true);
+    expect(budgetTrigger.message).toContain('advisory');
+    // REGRESSION GUARD: over-budget alone must NOT emit ANY HIGH trigger — the orchestrator only
+    // maps to FILTER_ACTION.STOP when a HIGH trigger is present, so a HIGH here re-introduces the
+    // pipeline halt that blocked DataDistill's S19 bridge.
+    expect(result.triggers.every(t => t.severity !== 'HIGH')).toBe(true);
+    // MEDIUM still surfaces to the Chairman (informed) but does not hard-halt the pipeline.
+    expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN_WITH_MITIGATIONS');
   });
 
   it('should fire MEDIUM trigger at 80% usage', () => {


### PR DESCRIPTION
RCA a8c479493: a HIGH `budget_exceeded` trigger maps to FILTER_ACTION.STOP, breaking the worker venture loop BEFORE the deterministic S19 `convertSprintToSDs` bridge — so an over-budget leo_bridge venture (DataDistill, 779%) could never generate its build SDs. Downgrade to MEDIUM, mirroring the already-advisory sibling Rule 1 (cost_threshold). MEDIUM still fires PRESENT_TO_CHAIRMAN. Regression guard added; budget tests 8/8. The 9 pre-existing legacy decision-filter-engine.test.js failures (cost_threshold HIGH / trigger-count drift) are unrelated — verified identical on base origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)