### PR TITLE
fix(QF-20260601-055): S19 bridge gate not preempted by advisory REQUIRE_REVIEW

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1222,7 +1222,15 @@ export class StageExecutionWorker {
           break;
         }
 
-        if (result.filterDecision?.action === 'REQUIRE_REVIEW' && !this._waitForReview) {
+        // QF-20260601-055: at S19 the stage-specific leo_bridge bridge gate (below) is the
+        // authoritative gate (vision-ready → generate orchestrator+children, else block), and the
+        // venture still HOLDS at S19 via that gate + the advance_venture_stage exit-gate-enforcer
+        // (build_mvp_build) + the ENFORCE-S19-COMPLETION-001 FR-1 hard gate. A generic ADVISORY
+        // REQUIRE_REVIEW (e.g. budget_exceeded MEDIUM after QF-20260601-345) must NOT preempt the
+        // deterministic, zero-cost build generation — it would block the bridge without advancing.
+        // Skip the generic review pause at S19 and let the S19 gate decide. NO BYPASS: the bridge
+        // GENERATES the SDs but never ADVANCES past S19 here (STOP/HIGH still blocks above).
+        if (result.filterDecision?.action === 'REQUIRE_REVIEW' && !this._waitForReview && currentStage !== 19) {
           this._logger.log(`[Worker] Review required at stage ${currentStage}, pausing`);
           await this._writeHealthScore(ventureId, currentStage); // QF: ensure health_score on filter REQUIRE_REVIEW
           releaseState = ORCHESTRATOR_STATES.BLOCKED;


### PR DESCRIPTION
Final layer of the DataDistill unblock (after #4151). The generic advisory REQUIRE_REVIEW pause ran upstream of the S19 bridge gate, so a budget-advisory blocked the deterministic build generation. Carve out currentStage===19. Regression-agent PASS (0.95): generate-then-hold, no advance past S19 (FR-1 hard gate + exit-gate-enforcer intact); STOP/HIGH unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)