### PR TITLE
fix(SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001): type would-be-parent children as orchestrator at creation

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -451,6 +451,20 @@ export async function convertSprintToSDs(params, deps = {}) {
       const childKey = generateChildKey(orchestratorKey, i);
       const dbType = TYPE_MAP[payload.type] || 'feature';
 
+      // SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001 FR-1: a child that WILL gain grandchildren must be
+      // created as sd_type='orchestrator' from the start. When a grandchild is later inserted with
+      // parent_sd_id=childId, the AFTER-INSERT trigger trg_enforce_parent_orchestrator_type fires a
+      // nested feature->orchestrator UPDATE on the child; the type-change governance chain rejects
+      // that UPDATE (bridge SDs deliberately carry no bypass) and raised
+      // SD_TYPE_CHANGE_EXPLANATION_REQUIRED, rolling back the whole tree. Typing the parent as
+      // orchestrator up front makes that trigger a no-op (its WHERE sd_type!='orchestrator' skips it):
+      // no type change, no bypass, governance fully intact. Gate on the SAME effective layer set the
+      // grandchildren are built from, so a child is never typed orchestrator without grandchildren (FR-2).
+      const childEffectiveTarget = normalizeTargetApplication(payload.target_application || ventureContext?.name || getCurrentVenture());
+      const childSdType = (generateGrandchildren && computeEffectiveGrandchildLayers(payload, childEffectiveTarget).length > 0)
+        ? 'orchestrator'
+        : dbType;
+
       // Apply enrichment if available
       const enrichment = enrichmentResults?.get(i);
       const childDescription = enrichment?.enrichedDescription || payload.description;
@@ -465,7 +479,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           description: childDescription,
           scope: payload.scope,
           rationale: `Sprint item from "${sprintName}": ${payload.description}`,
-          sd_type: dbType,
+          sd_type: childSdType,
           status: 'draft',
           priority: payload.priority || 'medium',
           category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
@@ -710,6 +724,47 @@ function selectApplicableLayers(payload) {
 }
 
 /**
+ * Pure capability partition (NO logging / NO feedback side effects): splits candidate
+ * architecture layers into { kept, suppressed } for a target application. Extracted so the
+ * SAME suppression logic drives BOTH the at-creation orchestrator-typing decision
+ * (computeEffectiveGrandchildLayers, before the child INSERT) and the side-effectful
+ * filterLayersByCapability (during grandchild creation) — single source of truth.
+ * SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001 FR-1/FR-2.
+ *
+ * @param {Array} layers - Candidate layers from selectApplicableLayers
+ * @param {string} targetApplication - Effective target app
+ * @returns {{ kept: Array, suppressed: string[] }}
+ */
+function partitionLayersByCapability(layers, targetApplication) {
+  const caps = getTargetApplicationCapabilities(targetApplication);
+  const suppressed = [];
+  const kept = layers.filter(layer => {
+    if (layer.key === 'api' && caps.has_serverless_api === false) {
+      suppressed.push(layer.key);
+      return false;
+    }
+    return true;
+  });
+  return { kept, suppressed };
+}
+
+/**
+ * Pure: the effective (capability-filtered, capped) grandchild layer set for a child payload.
+ * A non-empty result means the child WILL gain grandchildren and must therefore be created as an
+ * orchestrator so the parent-orchestrator promotion trigger stays a no-op. No side effects, so it
+ * is safe to call before the child INSERT and on idempotent re-runs.
+ * SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001 FR-1.
+ *
+ * @param {Object} childPayload - Sprint item payload
+ * @param {string} effectiveTarget - normalized target application for the child
+ * @returns {Array} capped effective grandchild layers (empty => leaf child)
+ */
+function computeEffectiveGrandchildLayers(childPayload, effectiveTarget) {
+  const { kept } = partitionLayersByCapability(selectApplicableLayers(childPayload), effectiveTarget);
+  return kept.slice(0, MAX_GRANDCHILDREN_PER_CHILD);
+}
+
+/**
  * Filter layers by target_application capability. Removes layers the target
  * cannot host (e.g. `api` for a Vite SPA with no serverless runtime). Emits
  * one audit log line per suppression decision so the choice is auditable.
@@ -738,14 +793,9 @@ function filterLayersByCapability(
   { logger = console, parentChildKey = '', ventureName = null, parentChildId = null, supabase = null } = {},
 ) {
   const caps = getTargetApplicationCapabilities(targetApplication);
-  const suppressed = [];
-  const kept = layers.filter(layer => {
-    if (layer.key === 'api' && caps.has_serverless_api === false) {
-      suppressed.push(layer.key);
-      return false;
-    }
-    return true;
-  });
+  // SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001: delegate the filtering to the pure partition so the
+  // typing decision and the actual grandchild creation can never diverge.
+  const { kept, suppressed } = partitionLayersByCapability(layers, targetApplication);
   if (suppressed.length > 0) {
     logger.log(
       `[LifecycleSDBridge] Suppressed architecture_layer(s) [${suppressed.join(',')}] for target_application=${targetApplication} (has_serverless_api=${caps.has_serverless_api})${parentChildKey ? ` parent=${parentChildKey}` : ''}`,
@@ -1208,6 +1258,8 @@ export const _internal = {
   buildProvenance,
   insertSDIdempotent,
   selectApplicableLayers,
+  partitionLayersByCapability,
+  computeEffectiveGrandchildLayers,
   filterLayersByCapability,
   rollbackCreatedRecords,
   createGrandchildren,

--- a/tests/unit/lifecycle-sd-bridge/orchestrator-typing.test.js
+++ b/tests/unit/lifecycle-sd-bridge/orchestrator-typing.test.js
@@ -1,0 +1,212 @@
+/**
+ * SD-LEO-INFRA-COMPLETE-LEO-BRIDGE-001 FR-1/FR-2.
+ *
+ * A child that WILL gain grandchildren must be created as sd_type='orchestrator' up front. When a
+ * grandchild is inserted with parent_sd_id=child.id, the AFTER-INSERT trigger
+ * trg_enforce_parent_orchestrator_type promotes the child feature->orchestrator; that nested UPDATE
+ * was rejected by the type-change governance chain (bridge SDs carry no bypass), which raised
+ * SD_TYPE_CHANGE_EXPLANATION_REQUIRED and rolled back the whole tree. Typing the parent as
+ * orchestrator at creation makes the trigger a no-op (WHERE sd_type!='orchestrator'): no type
+ * change, no bypass, governance intact. A child is typed orchestrator ONLY when it will actually
+ * gain grandchildren (non-empty effective layer set) so we never create a childless orchestrator.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Deterministic key generation incl. generateGrandchildKey (the real module is fully replaced).
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockResolvedValue('SD-DD-LEO-ORCH-SPRINT-001'),
+  generateChildKey: vi.fn((parentKey, index) => `${parentKey}-${String.fromCharCode(65 + index)}`),
+  generateGrandchildKey: vi.fn((childKey, j) => `${childKey}-${j + 1}`),
+  normalizeVenturePrefix: vi.fn((name) => name.toUpperCase().replace(/\s+/g, '-')),
+  keyExists: vi.fn().mockResolvedValue(false),
+  SD_SOURCES: { LEO: 'LEO' },
+  SD_TYPES: { feature: 'FEAT', orchestrator: 'ORCH' },
+}));
+
+// Control capability suppression: 'spa-target' has NO serverless api (suppresses the api layer);
+// every other target keeps all layers.
+vi.mock('../../../lib/eva/config/target-application-capabilities.js', () => ({
+  getTargetApplicationCapabilities: (target) => ({
+    has_serverless_api: String(target).toLowerCase() !== 'spa-target',
+  }),
+}));
+
+import { convertSprintToSDs, _internal } from '../../../lib/eva/lifecycle-sd-bridge.js';
+const { partitionLayersByCapability, computeEffectiveGrandchildLayers } = _internal;
+
+const L = (key) => ({ key, label: `${key} Layer`, description: `${key} concern` });
+
+describe('partitionLayersByCapability (pure)', () => {
+  it('suppresses the api layer when the target has no serverless api', () => {
+    const { kept, suppressed } = partitionLayersByCapability(
+      [L('api'), L('data'), L('ui')],
+      'spa-target',
+    );
+    expect(kept.map((l) => l.key)).toEqual(['data', 'ui']);
+    expect(suppressed).toEqual(['api']);
+  });
+
+  it('keeps all layers when the target has a serverless api', () => {
+    const { kept, suppressed } = partitionLayersByCapability(
+      [L('api'), L('data')],
+      'EHG_Engineer',
+    );
+    expect(kept.map((l) => l.key)).toEqual(['api', 'data']);
+    expect(suppressed).toEqual([]);
+  });
+
+  it('has no side effects (returns a plain partition)', () => {
+    const result = partitionLayersByCapability([L('data')], 'EHG_Engineer');
+    expect(result).toEqual({ kept: [L('data')], suppressed: [] });
+  });
+});
+
+describe('computeEffectiveGrandchildLayers (pure typing predicate)', () => {
+  it('is NON-empty for a default child (all architecture layers) on a serverless target', () => {
+    const layers = computeEffectiveGrandchildLayers({ title: 'x' }, 'EHG_Engineer');
+    expect(layers.length).toBeGreaterThan(0); // => child will be typed orchestrator
+  });
+
+  it('is NON-empty for an SPA target when non-api layers remain', () => {
+    // default layers minus api still has data/ui/tests
+    const layers = computeEffectiveGrandchildLayers({ title: 'x' }, 'spa-target');
+    expect(layers.map((l) => l.key)).not.toContain('api');
+    expect(layers.length).toBeGreaterThan(0);
+  });
+
+  it('is EMPTY when the only requested layer is api on an SPA target (=> leaf child)', () => {
+    const layers = computeEffectiveGrandchildLayers(
+      { title: 'x', architecture_layers: ['api'] },
+      'spa-target',
+    );
+    expect(layers).toEqual([]); // => child stays a leaf, never a childless orchestrator
+  });
+});
+
+// ── Integration: the child insert's sd_type reflects the typing decision ──
+
+function makeRecordingSupabase() {
+  const inserts = [];
+  const sdTable = {
+    insert: vi.fn((row) => {
+      inserts.push(row);
+      return Promise.resolve({ error: null });
+    }),
+    select: vi.fn(() => ({
+      // findExistingOrchestrator: .select().eq().eq().eq().limit()
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        })),
+      })),
+      order: vi.fn(() => ({ then: vi.fn() })),
+      in: vi.fn().mockResolvedValue({ data: [], error: null }),
+    })),
+  };
+  return {
+    inserts,
+    from: vi.fn((table) => {
+      if (table === 'eva_vision_documents') {
+        const vc = {
+          select: vi.fn(() => vc),
+          eq: vi.fn(() => vc),
+          in: vi.fn(() => vc),
+          order: vi.fn(() => vc),
+          limit: vi.fn(() => vc),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { vision_key: 'VISION-DD-L2-001', version: 'v1' },
+            error: null,
+          }),
+        };
+        return vc;
+      }
+      return sdTable;
+    }),
+    rpc: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  };
+}
+
+function stageOutput({ target = 'EHG_Engineer', architecture_layers } = {}) {
+  const payload = {
+    title: 'Core feature',
+    description: 'desc',
+    priority: 'high',
+    type: 'feature',
+    scope: 'backend',
+    success_criteria: 'works',
+    dependencies: [],
+    risks: [],
+    target_application: target,
+  };
+  if (architecture_layers) payload.architecture_layers = architecture_layers;
+  return {
+    sprint_name: 'Sprint Build',
+    sprint_goal: 'Ship MVP',
+    sprint_duration_days: 14,
+    sd_bridge_payloads: [payload],
+  };
+}
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const venture = { id: 'venture-510177ba', name: 'DataDistill' };
+
+describe('convertSprintToSDs child typing (integration)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('types a child that will gain grandchildren as orchestrator (no rollback)', async () => {
+    const supabase = makeRecordingSupabase();
+    const result = await convertSprintToSDs(
+      { stageOutput: stageOutput(), ventureContext: venture, options: { skipEnrichment: true } },
+      { supabase, logger },
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.errors).toEqual([]);
+
+    const child = supabase.inserts.find((r) => r.parent_sd_id && r.sd_key === 'SD-DD-LEO-ORCH-SPRINT-001-A');
+    expect(child).toBeTruthy();
+    expect(child.sd_type).toBe('orchestrator'); // FR-1: parent typed orchestrator at creation
+
+    // FR-2: it actually has grandchildren (never a childless orchestrator)
+    const grandchildren = supabase.inserts.filter((r) => r.parent_sd_id === child.id);
+    expect(grandchildren.length).toBeGreaterThan(0);
+    expect(result.grandchildKeys.length).toBeGreaterThan(0);
+  });
+
+  it('keeps a leaf child as its work type when grandchildren are disabled', async () => {
+    const supabase = makeRecordingSupabase();
+    const result = await convertSprintToSDs(
+      {
+        stageOutput: stageOutput(),
+        ventureContext: venture,
+        options: { skipEnrichment: true, generateGrandchildren: false },
+      },
+      { supabase, logger },
+    );
+
+    expect(result.created).toBe(true);
+    const child = supabase.inserts.find((r) => r.sd_key === 'SD-DD-LEO-ORCH-SPRINT-001-A');
+    expect(child.sd_type).toBe('feature'); // no grandchildren => stays a leaf
+    expect(result.grandchildKeys).toEqual([]);
+  });
+
+  it('keeps a child a leaf when capability suppression empties its layer set (no childless orchestrator)', async () => {
+    const supabase = makeRecordingSupabase();
+    const result = await convertSprintToSDs(
+      {
+        stageOutput: stageOutput({ target: 'spa-target', architecture_layers: ['api'] }),
+        ventureContext: venture,
+        options: { skipEnrichment: true },
+      },
+      { supabase, logger },
+    );
+
+    expect(result.created).toBe(true);
+    const child = supabase.inserts.find((r) => r.sd_key === 'SD-DD-LEO-ORCH-SPRINT-001-A');
+    expect(child.sd_type).toBe('feature'); // api suppressed => empty layer set => leaf
+    expect(result.grandchildKeys).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the leo_bridge S19 venture-build, which rolled back its entire generated SD tree with `SD_TYPE_CHANGE_EXPLANATION_REQUIRED`.

**Root cause** (rca-agent `fe7739d8`, reproduced 100%) — a DB-internal trigger cascade, not app code: `createGrandchildren` inserts a grandchild with `parent_sd_id=child.id`; the AFTER-INSERT trigger `trg_enforce_parent_orchestrator_type` then fires a nested `feature->orchestrator` UPDATE on the child, which the type-change governance chain rejects (bridge SDs carry no bypass, per the chairman de-bypass directive) → throw → rollback.

**Fix (Option 1, governance-neutral)** — in `convertSprintToSDs`, type a child `sd_type='orchestrator'` at creation iff it will actually gain grandchildren (gated on a non-empty effective architecture-layer set). The promotion trigger's `WHERE sd_type!='orchestrator'` then makes it a no-op: **no type change, no bypass, governance fully intact.** Extracted pure `partitionLayersByCapability` + `computeEffectiveGrandchildLayers` as the single source of truth, so typing and grandchild-creation can never diverge → a childless orchestrator is impossible by construction.

## Tests
`tests/unit/lifecycle-sd-bridge/orchestrator-typing.test.js` — 9 new tests, all green. testing-agent verdict PASS.
The 4 pre-existing failures in `lifecycle-sd-bridge.test.js` are baseline (verified at parent revision `7bfc347ea1`) stale-mock debt — out of scope (feedback `6d8d4ff5`).

## Scope
Generation fix only. The **FR-3 auto-executor** (autonomously running generated children + advancing the venture) is deferred to follow-on **SD-LEO-INFRA-AUTO-EXECUTE-VENTURE-CHILDREN-001** — a distinct, incident-sensitive feature kept in its own cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)