### PR TITLE
feat(SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001): wire Stage-0 teardown to the differentiation board

### DIFF
--- a/lib/competitive-intelligence/board-result-projection.js
+++ b/lib/competitive-intelligence/board-result-projection.js
@@ -1,0 +1,68 @@
+/**
+ * Board-result projection (SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001 / FR-2).
+ *
+ * Pure mapper that projects the return of `runDifferentiationBoard` (the producer)
+ * into the exact `ExtendedStageZeroResult` shape the ehg Stage-0 UI consumes from
+ * `stage_zero_requests.result`. The producer and consumer use DIFFERENT field names
+ * and value vocabularies, so this mapper is the single bridge between them — keeping
+ * the contract in one tested place instead of scattering ad-hoc field access across
+ * the worker (the "half-fix" risk: copying the raw board return would leave the UI
+ * reading `undefined` for verdict/score).
+ *
+ * Producer (runDifferentiationBoard return, lib/competitive-intelligence/differentiation-board.js):
+ *   { gate: { seedable:boolean, delta:number, threshold:number, reason:string },
+ *     strategy: { angle:string, unique_advantages:string[], ... },
+ *     sanitization_status: 'passed' | 'flagged' | 'pending' }
+ *
+ * Consumer (ehg competitorClone.ts ExtendedStageZeroResult):
+ *   { differentiation_strategy?: string,
+ *     delta_gate?: { verdict?: 'seedable'|'me_too', score?: number, threshold?: number, reason?: string },
+ *     sanitization_status?: 'passed' | 'pending' | 'failed' }
+ *
+ * Mapping (see PRD FR-2 contract_mappings):
+ *   - delta_gate.verdict  = gate.seedable ? 'seedable' : 'me_too'
+ *   - delta_gate.score    = gate.delta            (the authoritative gate delta, NOT the bare column)
+ *   - delta_gate.threshold/reason pass through
+ *   - differentiation_strategy = String(strategy.angle)   (object -> string projection)
+ *   - sanitization_status: 'flagged' -> 'failed' (UI union has no 'flagged'); 'passed'/'pending' pass through
+ */
+
+/**
+ * @param {object|null|undefined} board - the return value of runDifferentiationBoard
+ * @returns {{differentiation_strategy: string, delta_gate: {verdict: ('seedable'|'me_too'), score: number, threshold: number, reason: string}, sanitization_status: ('passed'|'pending'|'failed'|undefined)}|null}
+ *   the ExtendedStageZeroResult-shaped projection, or null when there is no board output to project.
+ */
+export function projectBoardResultToStageZero(board) {
+  if (!board || typeof board !== 'object') return null;
+
+  const gate = board.gate && typeof board.gate === 'object' ? board.gate : {};
+  // strategy is the sanitized strategy object; project its `angle` to the UI's string field.
+  const strategy = board.strategy;
+  const angle =
+    strategy && typeof strategy === 'object' ? strategy.angle : strategy;
+
+  return {
+    differentiation_strategy: angle != null ? String(angle) : '',
+    delta_gate: {
+      verdict: gate.seedable ? 'seedable' : 'me_too',
+      score: gate.delta,
+      threshold: gate.threshold,
+      reason: gate.reason,
+    },
+    sanitization_status: mapSanitizationStatus(board.sanitization_status),
+  };
+}
+
+/**
+ * Map the producer sanitization status vocabulary to the UI vocabulary.
+ * Producer: 'passed' | 'flagged' | 'pending'. UI: 'passed' | 'pending' | 'failed'.
+ * Only 'flagged' differs — it maps to 'failed' (a residual competitor reference is a
+ * hard stop the UI surfaces as a failed sanitization). Other values pass through.
+ *
+ * @param {string|undefined} status
+ * @returns {('passed'|'pending'|'failed'|undefined)}
+ */
+export function mapSanitizationStatus(status) {
+  if (status === 'flagged') return 'failed';
+  return status;
+}

--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -84,11 +84,20 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
       // shape. Best-effort: a board failure (LLM timeout, etc.) must never break the
       // teardown — it just leaves the result without board fields and the UI degrades.
       if (seededRecordIds.length > 0) {
+        // Always surface the PRIMARY competitor_intelligence record id so the Stage-0
+        // confirm step links that record to the seeded venture — CompetitorCloneForm
+        // reads result.competitor_intelligence_id (the field its own code anticipated
+        // "the backend stamps"). This link must NOT depend on the board succeeding,
+        // because setting competitor_intelligence.venture_id is what lets Stage-4 and
+        // the on-demand refresh read the record by venture_id. The board output is
+        // merged on top when it succeeds; on failure only the board-display fields are
+        // absent and the UI degrades gracefully (the venture link still works).
+        boardProjection = { competitor_intelligence_id: seededRecordIds[0] };
         try {
           const board = await runBoard(seededRecordIds[0], { supabase });
-          boardProjection = projectBoardResultToStageZero(board);
+          Object.assign(boardProjection, projectBoardResultToStageZero(board) || {});
           logger.log(
-            `   Differentiation board complete (verdict: ${boardProjection?.delta_gate?.verdict ?? 'n/a'})`
+            `   Differentiation board complete (verdict: ${boardProjection.delta_gate?.verdict ?? 'n/a'})`
           );
         } catch (boardErr) {
           logger.warn(`   Warning: differentiation board failed (non-fatal): ${boardErr.message}`);

--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -23,6 +23,11 @@ import { getMentalModelContextBlock } from '../../mental-models/index.js';
 // layer. Opt-in (deps.persistToCanonical or CI_TEARDOWN_PERSIST=true) and
 // best-effort, so the live Stage-0 flow is unchanged until explicitly enabled.
 import { persistTeardownAnalyses } from '../../../competitive-intelligence/index.js';
+// SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001: after seeding the canonical
+// record, run Child E's headless differentiation board and project its output into
+// the Stage-0 result so the ehg CompetitorCloneForm renders real board data.
+import { runDifferentiationBoard } from '../../../competitive-intelligence/differentiation-board.js';
+import { projectBoardResultToStageZero } from '../../../competitive-intelligence/board-result-projection.js';
 
 /**
  * Execute the competitor teardown path.
@@ -59,13 +64,36 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
   // never break the live Stage-0 teardown. venture_id is null here because the
   // venture does not exist yet at teardown time (it is attached on seed).
   let seededRecordIds = [];
+  // SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001 (FR-1/FR-2): projected board
+  // output (differentiation_strategy + delta_gate + sanitization_status) for the
+  // Stage-0 result. Null when the board did not run (flag OFF or no seeded record).
+  let boardProjection = null;
   const persistEnabled =
     deps.persistToCanonical === true || process.env.CI_TEARDOWN_PERSIST === 'true';
+  // Injectable for deterministic, cost-free tests; default to the real imports.
+  const persistFn = deps.persistTeardownAnalyses || persistTeardownAnalyses;
+  const runBoard = deps.runDifferentiationBoard || runDifferentiationBoard;
   if (persistEnabled && supabase) {
     try {
-      const records = await persistTeardownAnalyses(analyses, { supabase });
-      seededRecordIds = records.map((r) => r.id);
+      const records = await persistFn(analyses, { supabase });
+      seededRecordIds = (records || []).map((r) => r.id);
       logger.log(`   Seeded ${seededRecordIds.length} canonical CI record(s)`);
+
+      // FR-1/FR-2: run the differentiation board on the PRIMARY seeded record (the
+      // first competitor) and project its output into the ExtendedStageZeroResult
+      // shape. Best-effort: a board failure (LLM timeout, etc.) must never break the
+      // teardown — it just leaves the result without board fields and the UI degrades.
+      if (seededRecordIds.length > 0) {
+        try {
+          const board = await runBoard(seededRecordIds[0], { supabase });
+          boardProjection = projectBoardResultToStageZero(board);
+          logger.log(
+            `   Differentiation board complete (verdict: ${boardProjection?.delta_gate?.verdict ?? 'n/a'})`
+          );
+        } catch (boardErr) {
+          logger.warn(`   Warning: differentiation board failed (non-fatal): ${boardErr.message}`);
+        }
+      }
     } catch (err) {
       logger.warn(`   Warning: canonical CI seed failed (non-fatal): ${err.message}`);
     }
@@ -102,6 +130,10 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
       companies_analyzed: analyses.map(a => a.company_name).filter(Boolean),
       canonical_ci_record_ids: seededRecordIds,
     },
+    // FR-2: surface the projected board output so executeStageZero spreads it into
+    // stage_zero_requests.result (the exact shape the ehg Stage-0 UI reads). Omitted
+    // when the board did not run (flag OFF or no seeded record) -> UI degrades gracefully.
+    ...(boardProjection ? { result_extras: boardProjection } : {}),
   });
 }
 

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -150,6 +150,7 @@ export async function executeStageZero(params, deps = {}) {
   if (options.dryRun) {
     logger.log('\n   [DRY RUN] Skipping persistence');
     return {
+      ...(pathOutput.result_extras || {}),
       success: true,
       dryRun: true,
       brief: reviewResult.brief,
@@ -175,6 +176,11 @@ export async function executeStageZero(params, deps = {}) {
   logger.log('══════════════════════════════════════════════════\n');
 
   return {
+    // SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001 (FR-2): a path may contribute
+    // extra top-level result fields via pathOutput.result_extras (e.g. the competitor
+    // teardown's projected differentiation_strategy/delta_gate/sanitization_status).
+    // Spread FIRST so the core result fields below can never be clobbered.
+    ...(pathOutput.result_extras || {}),
     success: true,
     decision: reviewResult.decision,
     record_id: record.id,

--- a/tests/unit/competitive-intelligence/board-result-projection.test.js
+++ b/tests/unit/competitive-intelligence/board-result-projection.test.js
@@ -1,0 +1,105 @@
+/**
+ * Unit Tests: Board-result projection (SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001 / FR-2)
+ *
+ * Pins the producer->consumer contract mapping between runDifferentiationBoard's return
+ * and the ehg ExtendedStageZeroResult shape. This is the "half-fix" guard: every field
+ * mapping + the two vocabulary edges (seedable->verdict, flagged->failed) are asserted.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  projectBoardResultToStageZero,
+  mapSanitizationStatus,
+} from '../../../lib/competitive-intelligence/board-result-projection.js';
+
+describe('projectBoardResultToStageZero', () => {
+  test('TS-1: maps a seedable board return to the ExtendedStageZeroResult shape', () => {
+    const board = {
+      gate: { seedable: true, delta: 0.7, threshold: 0.5, reason: 'defensible, seedable' },
+      strategy: { angle: 'Automate the whole workflow', unique_advantages: ['a', 'b'] },
+      sanitization_status: 'passed',
+    };
+
+    const out = projectBoardResultToStageZero(board);
+
+    expect(out).toEqual({
+      differentiation_strategy: 'Automate the whole workflow',
+      delta_gate: {
+        verdict: 'seedable',
+        score: 0.7,
+        threshold: 0.5,
+        reason: 'defensible, seedable',
+      },
+      sanitization_status: 'passed',
+    });
+  });
+
+  test('TS-2: maps me_too verdict and flagged->failed sanitization edges', () => {
+    const board = {
+      gate: { seedable: false, delta: 0.2, threshold: 0.5, reason: 'me-too, blocked' },
+      strategy: { angle: 'Cheaper version' },
+      sanitization_status: 'flagged',
+    };
+
+    const out = projectBoardResultToStageZero(board);
+
+    expect(out.delta_gate.verdict).toBe('me_too');
+    expect(out.delta_gate.score).toBe(0.2);
+    expect(out.delta_gate.threshold).toBe(0.5);
+    expect(out.delta_gate.reason).toBe('me-too, blocked');
+    expect(out.differentiation_strategy).toBe('Cheaper version');
+    expect(out.sanitization_status).toBe('failed');
+  });
+
+  test('score is sourced from gate.delta (not double-sourced from a bare delta column)', () => {
+    const board = {
+      gate: { seedable: true, delta: 0.61, threshold: 0.5, reason: 'ok' },
+      // a stray top-level delta that must be ignored in favor of gate.delta
+      delta: 0.99,
+      strategy: { angle: 'x' },
+      sanitization_status: 'passed',
+    };
+    expect(projectBoardResultToStageZero(board).delta_gate.score).toBe(0.61);
+  });
+
+  test('pending sanitization passes through unchanged', () => {
+    const board = {
+      gate: { seedable: true, delta: 0.8, threshold: 0.5, reason: 'ok' },
+      strategy: { angle: 'x' },
+      sanitization_status: 'pending',
+    };
+    expect(projectBoardResultToStageZero(board).sanitization_status).toBe('pending');
+  });
+
+  test('coerces a non-string strategy.angle and a string strategy', () => {
+    expect(
+      projectBoardResultToStageZero({ gate: { seedable: true }, strategy: { angle: 123 } })
+        .differentiation_strategy
+    ).toBe('123');
+    // strategy provided as a bare string
+    expect(
+      projectBoardResultToStageZero({ gate: { seedable: false }, strategy: 'just text' })
+        .differentiation_strategy
+    ).toBe('just text');
+  });
+
+  test('missing strategy yields an empty differentiation_strategy string', () => {
+    const out = projectBoardResultToStageZero({ gate: { seedable: true, delta: 0.6, threshold: 0.5 } });
+    expect(out.differentiation_strategy).toBe('');
+  });
+
+  test('returns null for null/undefined/non-object input', () => {
+    expect(projectBoardResultToStageZero(null)).toBeNull();
+    expect(projectBoardResultToStageZero(undefined)).toBeNull();
+    expect(projectBoardResultToStageZero('nope')).toBeNull();
+  });
+});
+
+describe('mapSanitizationStatus', () => {
+  test('flagged -> failed; others pass through', () => {
+    expect(mapSanitizationStatus('flagged')).toBe('failed');
+    expect(mapSanitizationStatus('passed')).toBe('passed');
+    expect(mapSanitizationStatus('pending')).toBe('pending');
+    expect(mapSanitizationStatus(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
+++ b/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
@@ -203,6 +203,7 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     expect(boardSpy.mock.calls[0][0]).toBe('ci-rec-1');
 
     expect(result.result_extras).toEqual({
+      competitor_intelligence_id: 'ci-rec-1', // primary record stamped for the venture link
       differentiation_strategy: 'Automate the entire workflow with AI',
       delta_gate: { verdict: 'seedable', score: 0.7, threshold: 0.5, reason: 'defensible, seedable' },
       sanitization_status: 'passed',
@@ -231,7 +232,10 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     expect(boardSpy).toHaveBeenCalledTimes(1);
     expect(result).not.toBeNull();
     expect(result.origin_type).toBe('competitor_teardown');
-    expect(result.result_extras).toBeUndefined(); // graceful degradation
+    // Graceful degradation: board-display fields absent, but the venture-link id is
+    // still stamped so confirm can link the record to the venture (Stage-4 lights up).
+    expect(result.result_extras).toEqual({ competitor_intelligence_id: 'ci-rec-1' });
+    expect(result.result_extras.delta_gate).toBeUndefined();
     expect(warnLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining('differentiation board failed')
     );

--- a/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
+++ b/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
@@ -59,26 +59,29 @@ function _createMockLlm(analysisResponse, deconstructionResponse, _gapResponse) 
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Simple mock that always returns valid JSON for any LLM call
+  // Simple mock that always returns valid JSON for any LLM call.
+  // The SUT (analyzeCompetitor/deconstructToFirstPrinciples/runGapAnalysis) calls
+  // `client.complete(system, prompt, opts)` and accepts either a raw string or
+  // `{ content }`; `messages.create` is retained for any legacy callers.
+  const mockAnalysisJson = JSON.stringify({
+    company_name: 'TestCorp',
+    url: 'http://test.com',
+    business_model: 'SaaS',
+    value_proposition: 'Test value',
+    target_market: 'B2B',
+    key_features: ['feature1'],
+    work_components: [],
+    weaknesses: ['slow'],
+    differentiation_opportunities: ['AI automation'],
+    suggested_venture_name: 'AI TestCorp',
+    root_customer_problem: 'Manual processes',
+    automation_solution: 'Full automation',
+  });
   mockLlmClient = {
     _model: 'test-model',
+    complete: vi.fn().mockResolvedValue(mockAnalysisJson),
     messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify({
-          company_name: 'TestCorp',
-          url: 'http://test.com',
-          business_model: 'SaaS',
-          value_proposition: 'Test value',
-          target_market: 'B2B',
-          key_features: ['feature1'],
-          work_components: [],
-          weaknesses: ['slow'],
-          differentiation_opportunities: ['AI automation'],
-          suggested_venture_name: 'AI TestCorp',
-          root_customer_problem: 'Manual processes',
-          automation_solution: 'Full automation',
-        }) }],
-      }),
+      create: vi.fn().mockResolvedValue({ content: [{ text: mockAnalysisJson }] }),
     },
   };
 });
@@ -135,7 +138,7 @@ describe('executeCompetitorTeardown', () => {
       { logger: silentLogger, llmClient: mockLlmClient }
     );
 
-    expect(mockLlmClient.messages.create).toHaveBeenCalled();
+    expect(mockLlmClient.complete).toHaveBeenCalled();
   });
 
   test('returns valid PathOutput with suggested fields from deconstruction', async () => {
@@ -149,5 +152,109 @@ describe('executeCompetitorTeardown', () => {
     expect(result.suggested_problem).toBeDefined();
     expect(result.suggested_solution).toBeDefined();
     expect(result.target_market).toBeDefined();
+  });
+});
+
+describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INFRA-ACTIVATE-COMPETITIVE-INTELLIGENCE-001)', () => {
+  const seededBoard = {
+    gate: { seedable: true, delta: 0.7, threshold: 0.5, reason: 'defensible, seedable' },
+    strategy: { angle: 'Automate the entire workflow with AI' },
+    sanitization_status: 'passed',
+  };
+
+  test('TS-3: flag OFF — no persist, no board, no result_extras (no regression)', async () => {
+    const persistSpy = vi.fn();
+    const boardSpy = vi.fn();
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://competitor.com'] },
+      {
+        logger: silentLogger,
+        llmClient: mockLlmClient,
+        supabase: {}, // present, but persist disabled
+        persistTeardownAnalyses: persistSpy,
+        runDifferentiationBoard: boardSpy,
+      }
+    );
+
+    expect(persistSpy).not.toHaveBeenCalled();
+    expect(boardSpy).not.toHaveBeenCalled();
+    expect(result.result_extras).toBeUndefined();
+    expect(result.origin_type).toBe('competitor_teardown');
+  });
+
+  test('TS-4: flag ON + board success — result_extras carries the mapped ExtendedStageZeroResult shape', async () => {
+    const persistSpy = vi.fn().mockResolvedValue([{ id: 'ci-rec-1' }, { id: 'ci-rec-2' }]);
+    const boardSpy = vi.fn().mockResolvedValue(seededBoard);
+
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://a.com', 'http://b.com'] },
+      {
+        logger: silentLogger,
+        llmClient: mockLlmClient,
+        supabase: {},
+        persistToCanonical: true,
+        persistTeardownAnalyses: persistSpy,
+        runDifferentiationBoard: boardSpy,
+      }
+    );
+
+    // board runs on the PRIMARY (first) seeded record
+    expect(boardSpy).toHaveBeenCalledTimes(1);
+    expect(boardSpy.mock.calls[0][0]).toBe('ci-rec-1');
+
+    expect(result.result_extras).toEqual({
+      differentiation_strategy: 'Automate the entire workflow with AI',
+      delta_gate: { verdict: 'seedable', score: 0.7, threshold: 0.5, reason: 'defensible, seedable' },
+      sanitization_status: 'passed',
+    });
+    // canonical record ids still surfaced in metadata
+    expect(result.metadata.canonical_ci_record_ids).toEqual(['ci-rec-1', 'ci-rec-2']);
+  });
+
+  test('TS-5: flag ON + board throws — teardown still completes, no result_extras, warning logged', async () => {
+    const persistSpy = vi.fn().mockResolvedValue([{ id: 'ci-rec-1' }]);
+    const boardSpy = vi.fn().mockRejectedValue(new Error('LLM timeout'));
+    const warnLogger = { log: vi.fn(), warn: vi.fn() };
+
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://competitor.com'] },
+      {
+        logger: warnLogger,
+        llmClient: mockLlmClient,
+        supabase: {},
+        persistToCanonical: true,
+        persistTeardownAnalyses: persistSpy,
+        runDifferentiationBoard: boardSpy,
+      }
+    );
+
+    expect(boardSpy).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(result.origin_type).toBe('competitor_teardown');
+    expect(result.result_extras).toBeUndefined(); // graceful degradation
+    expect(warnLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('differentiation board failed')
+    );
+  });
+
+  test('flag ON but persist returns zero records — board is skipped', async () => {
+    const persistSpy = vi.fn().mockResolvedValue([]);
+    const boardSpy = vi.fn();
+
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://competitor.com'] },
+      {
+        logger: silentLogger,
+        llmClient: mockLlmClient,
+        supabase: {},
+        persistToCanonical: true,
+        persistTeardownAnalyses: persistSpy,
+        runDifferentiationBoard: boardSpy,
+      }
+    );
+
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(boardSpy).not.toHaveBeenCalled();
+    expect(result.result_extras).toBeUndefined();
   });
 });


### PR DESCRIPTION
Activates the Competitive Intelligence capability end-to-end. After the Stage-0 teardown worker persists the canonical competitor_intelligence record (behind the existing CI_TEARDOWN_PERSIST flag, default OFF), it now runs Child E's runDifferentiationBoard on the primary seeded record and projects the output into stage_zero_requests.result — the ExtendedStageZeroResult shape the ehg CompetitorCloneForm reads (differentiation_strategy + delta_gate{verdict,score,threshold,reason} + sanitization_status + competitor_intelligence_id for the venture link). New pure mapper lib/competitive-intelligence/board-result-projection.js bridges the producer/consumer shape mismatch; best-effort board (never breaks teardown); 8 mapper + 4 teardown integration tests. No DB migration. Pairs with the ehg type-regen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
