### PR TITLE
feat(SD-LEO-INFRA-SURFACE-DIFFERENTIATION-BOARD-001): map board unique_advantages to Stage-0 opportunity cards

### DIFF
--- a/lib/competitive-intelligence/board-result-projection.js
+++ b/lib/competitive-intelligence/board-result-projection.js
@@ -50,7 +50,31 @@ export function projectBoardResultToStageZero(board) {
       reason: gate.reason,
     },
     sanitization_status: mapSanitizationStatus(board.sanitization_status),
+    // SD-LEO-INFRA-SURFACE-DIFFERENTIATION-BOARD-001 (FR-1): surface the board's concrete
+    // unique_advantages as the UI's opportunity cards (result.differentiation_opportunities).
+    // Empty array when the board produced none -> the consumer's `opportunities.length > 0`
+    // guard keeps the section hidden (graceful).
+    differentiation_opportunities: mapUniqueAdvantagesToOpportunities(strategy),
   };
+}
+
+/**
+ * Map the board strategy's `unique_advantages` (string[]) into the ehg UI's
+ * `differentiation_opportunities` shape ([{ opportunity_name }]). Pure.
+ * The new teardown+board flow does not produce the legacy DifferentiationOpportunity
+ * sub-fields (category / customer_pains_addressed), so only opportunity_name is mapped.
+ *
+ * @param {object|string|undefined} strategy - the board return's `strategy` (sanitized) object
+ * @returns {Array<{opportunity_name: string}>} one entry per non-empty unique advantage
+ */
+export function mapUniqueAdvantagesToOpportunities(strategy) {
+  const advantages =
+    strategy && typeof strategy === 'object' && Array.isArray(strategy.unique_advantages)
+      ? strategy.unique_advantages
+      : [];
+  return advantages
+    .filter((a) => a != null && String(a).trim() !== '')
+    .map((a) => ({ opportunity_name: String(a) }));
 }
 
 /**

--- a/tests/unit/competitive-intelligence/board-result-projection.test.js
+++ b/tests/unit/competitive-intelligence/board-result-projection.test.js
@@ -10,6 +10,7 @@ import { describe, test, expect } from 'vitest';
 import {
   projectBoardResultToStageZero,
   mapSanitizationStatus,
+  mapUniqueAdvantagesToOpportunities,
 } from '../../../lib/competitive-intelligence/board-result-projection.js';
 
 describe('projectBoardResultToStageZero', () => {
@@ -31,6 +32,8 @@ describe('projectBoardResultToStageZero', () => {
         reason: 'defensible, seedable',
       },
       sanitization_status: 'passed',
+      // SURFACE-DIFFERENTIATION-BOARD-001: unique_advantages -> opportunity cards
+      differentiation_opportunities: [{ opportunity_name: 'a' }, { opportunity_name: 'b' }],
     });
   });
 
@@ -101,5 +104,34 @@ describe('mapSanitizationStatus', () => {
     expect(mapSanitizationStatus('passed')).toBe('passed');
     expect(mapSanitizationStatus('pending')).toBe('pending');
     expect(mapSanitizationStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe('differentiation_opportunities mapping (SD-LEO-INFRA-SURFACE-DIFFERENTIATION-BOARD-001 / FR-1)', () => {
+  test('projection maps strategy.unique_advantages -> differentiation_opportunities [{opportunity_name}]', () => {
+    const board = {
+      gate: { seedable: true, delta: 0.7, threshold: 0.5, reason: 'ok' },
+      strategy: { angle: 'x', unique_advantages: ['24/7 automation', 'no headcount'] },
+      sanitization_status: 'passed',
+    };
+    expect(projectBoardResultToStageZero(board).differentiation_opportunities).toEqual([
+      { opportunity_name: '24/7 automation' },
+      { opportunity_name: 'no headcount' },
+    ]);
+  });
+
+  test('projection yields an empty opportunities array when the board produced no advantages', () => {
+    const board = { gate: { seedable: true, delta: 0.6, threshold: 0.5 }, strategy: { angle: 'x' } };
+    expect(projectBoardResultToStageZero(board).differentiation_opportunities).toEqual([]);
+  });
+
+  test('mapUniqueAdvantagesToOpportunities: maps, drops empties, tolerates non-array / non-object', () => {
+    expect(mapUniqueAdvantagesToOpportunities({ unique_advantages: ['a', '', '  ', 'b'] })).toEqual([
+      { opportunity_name: 'a' },
+      { opportunity_name: 'b' },
+    ]);
+    expect(mapUniqueAdvantagesToOpportunities({ unique_advantages: 'not-an-array' })).toEqual([]);
+    expect(mapUniqueAdvantagesToOpportunities('bare string')).toEqual([]);
+    expect(mapUniqueAdvantagesToOpportunities(undefined)).toEqual([]);
   });
 });


### PR DESCRIPTION
FR-1 — the board-result projection now builds result.differentiation_opportunities 1:1 from the board's strategy.unique_advantages ([{opportunity_name}]); empty array when none. New mapUniqueAdvantagesToOpportunities helper + 3 tests; existing projected fields unchanged. Pairs with the ehg PR removing the vestigial blue-ocean grid + dead link fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)