### PR TITLE
feat(SD-LEO-INFRA-HARDEN-S19-S20-001): harden S19->S20 leo_bridge advance invariant

### DIFF
--- a/lib/eva/bridge/s19-advance-decision.js
+++ b/lib/eva/bridge/s19-advance-decision.js
@@ -1,0 +1,85 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single, pure, tested bridge between the S19
+ * leo_bridge build outcome and EVERY gate that decides whether a venture may advance past
+ * Stage 19. No DB access, no side effects — so the truth table is unit-testable in isolation
+ * and all consumers (the FR-1 entry hard-gate, the two S19 entry-gate bridge paths, the
+ * _advanceStage choke-point, the post-stage hook log) share ONE decision and cannot diverge.
+ *
+ * Background (RCA 7610876f / a14ff998): the prior code re-derived "is this idempotent?" inline
+ * as `!bridge.created && errors.length === 0` at multiple sites. That overloaded sentinel made a
+ * silent zero-SDs failure indistinguishable from a legitimate no-op, so the S19 exit gate advanced
+ * an unbuilt venture (DataDistill reached S20 with a 26-SD all-draft tree). This module replaces
+ * that re-derivation with an explicit outcome enum + one hold/advance decision.
+ */
+
+/** The five canonical outcomes of running the S19 leo_bridge for a venture. */
+export const S19_BRIDGE_OUTCOME = Object.freeze({
+  CREATED: 'created',                 // SDs newly created (or seeded_repo proceed) — a tree now exists
+  NOOP_EXISTS: 'noop_exists',         // idempotent: the orchestrator/tree already exists
+  NOOP_EMPTY: 'noop_empty',           // nothing to build: 0 sd_bridge_payloads
+  ZERO_SDS_FAILURE: 'zero_sds_failure', // payloads present but convertSprintToSDs produced 0 SDs (the schism)
+  VISION_MISSING: 'vision_missing',   // no chairman-approved L2 vision (assertVentureVisionReady)
+});
+
+const VISION_ERR_RE = /VENTURE_L2_VISION|draft_seed|no L2 vision/i;
+const EXISTS_ERR_RE = /already exists/i;
+
+/**
+ * Classify a `_runS19Bridge` result into exactly one canonical outcome.
+ *
+ * The discriminant that the old inline code lacked is `payloadCount`: a `created:false` with
+ * empty errors means NOOP_EMPTY when there were zero payloads (nothing to build → advance) but
+ * ZERO_SDS_FAILURE when payloads were present (the build silently produced nothing → must hold).
+ * Idempotent "the orchestrator already exists" re-runs are recognised by an `orchestratorKey`
+ * being present even though `created` is false (matching the existing FR-2 test contract).
+ *
+ * @param {{created?: boolean, errors?: any[], orchestratorKey?: string|null}} bridgeResult
+ * @param {number} payloadCount  number of sd_bridge_payloads the bridge saw (0 = nothing to build)
+ * @returns {string} one of S19_BRIDGE_OUTCOME
+ */
+export function classifyBridgeOutcome(bridgeResult, payloadCount) {
+  if (bridgeResult && bridgeResult.created === true) return S19_BRIDGE_OUTCOME.CREATED;
+
+  const errs = (bridgeResult && bridgeResult.errors) || [];
+  const errStr = JSON.stringify(errs);
+
+  // A genuine vision-missing failure carries the assertVentureVisionReady message (it is caught
+  // inside convertSprintToSDs and returned, not thrown — so derive it from the error text, never
+  // via try/catch which would mask the {created:false} return and re-open the silent-advance bug).
+  if (VISION_ERR_RE.test(errStr)) return S19_BRIDGE_OUTCOME.VISION_MISSING;
+
+  // Idempotent no-op: either the explicit "already exists" message, or an existing orchestrator
+  // key surfaced with no failure errors (the canonical idempotency contract from FR-2).
+  if (EXISTS_ERR_RE.test(errStr)) return S19_BRIDGE_OUTCOME.NOOP_EXISTS;
+  if (bridgeResult && bridgeResult.orchestratorKey && errs.length === 0) {
+    return S19_BRIDGE_OUTCOME.NOOP_EXISTS;
+  }
+
+  // created:false, no idempotency/vision signal. payloadCount is the load-bearing discriminant:
+  if (!payloadCount || payloadCount <= 0) return S19_BRIDGE_OUTCOME.NOOP_EMPTY; // nothing to build
+  return S19_BRIDGE_OUTCOME.ZERO_SDS_FAILURE;                                   // built nothing from N payloads
+}
+
+/**
+ * THE single hold/advance decision for a leo_bridge venture at Stage 19.
+ *
+ * `buildComplete` is the result of `_isLeoBridgeBuildComplete(ventureId)`:
+ *   true  = tree complete (>=1 SD completed, all terminal) OR chairman_override → ADVANCE
+ *   null  = NOT a leo_bridge venture → the invariant does not apply → ADVANCE (fall through)
+ *   false = leo_bridge but incomplete (0 SDs, any non-terminal, or all-cancelled)
+ *
+ * When buildComplete===false the outcome enum disambiguates the ONLY case that should still
+ * advance: NOOP_EMPTY (0 payloads → genuinely nothing to build). Every other incomplete state —
+ * CREATED-but-draft, NOOP_EXISTS-but-in-progress, ZERO_SDS_FAILURE, VISION_MISSING — HOLDS at S19.
+ *
+ * @param {string} outcome  a S19_BRIDGE_OUTCOME value
+ * @param {boolean|null} buildComplete
+ * @returns {boolean} true = HOLD at S19 (do not advance); false = ADVANCE
+ */
+export function shouldHoldAtS19(outcome, buildComplete) {
+  if (buildComplete === true) return false;   // complete tree OR chairman_override → advance
+  if (buildComplete === null) return false;   // not a leo_bridge venture → never hold here
+  // buildComplete === false (or any non-true/non-null): leo_bridge, incomplete.
+  if (outcome === S19_BRIDGE_OUTCOME.NOOP_EMPTY) return false; // nothing to build → advance
+  return true;                                 // every other incomplete state → HOLD
+}

--- a/lib/eva/bridge/s19-reconciliation.js
+++ b/lib/eva/bridge/s19-reconciliation.js
@@ -1,0 +1,55 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-5): the S19->S20 reconciliation invariant. Surfaces any
+ * leo_bridge venture that has advanced PAST Stage 19 while its SD tree is NOT complete — the
+ * defining symptom of the a14ff998/7610876f gate-bypass (which left zero audit trail, so a
+ * queryable backstop is the only way to detect a future recurrence).
+ *
+ * Reuses the EXACT _isLeoBridgeBuildComplete semantics (lib/eva/stage-execution-worker.js): a tree
+ * is complete only when every SD is terminal AND at least one genuinely completed; an empty tree,
+ * any non-terminal SD, or an all-cancelled tree is INCOMPLETE. ventures.build_model is the SSOT.
+ * The chairman_override escape hatch (advisory_data.chairman_override===true) is the sanctioned way
+ * to advance an incomplete tree and is excluded. Read-only; safe on any schedule.
+ */
+
+const TERMINAL = new Set(['completed', 'cancelled', 'archived']);
+const COMPLETED = new Set(['completed', 'archived']);
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Array<{venture_id:string,name:string,current_lifecycle_stage:number,tree_count:number,reason:string}>>}
+ */
+export async function findS19AdvanceViolations(supabase) {
+  const { data: ventures, error } = await supabase
+    .from('ventures')
+    .select('id, name, current_lifecycle_stage, build_model')
+    .eq('build_model', 'leo_bridge')
+    .gt('current_lifecycle_stage', 19);
+  if (error) throw new Error(`s19-reconciliation: ventures query failed: ${error.message}`);
+
+  const violations = [];
+  for (const v of (ventures || [])) {
+    // chairman_override escape hatch — a sanctioned advance, not a violation.
+    const { data: s19Work } = await supabase
+      .from('venture_stage_work').select('advisory_data')
+      .eq('venture_id', v.id).eq('lifecycle_stage', 19).maybeSingle();
+    if (s19Work && s19Work.advisory_data && s19Work.advisory_data.chairman_override === true) continue;
+
+    const { data: sds } = await supabase
+      .from('strategic_directives_v2').select('status').eq('venture_id', v.id);
+    const tree = sds || [];
+    const treeCount = tree.length;
+    const allTerminal = treeCount > 0 && tree.every((sd) => TERMINAL.has(sd.status));
+    const anyCompleted = tree.some((sd) => COMPLETED.has(sd.status));
+    const buildComplete = allTerminal && anyCompleted;
+    if (!buildComplete) {
+      violations.push({
+        venture_id: v.id,
+        name: v.name,
+        current_lifecycle_stage: v.current_lifecycle_stage,
+        tree_count: treeCount,
+        reason: treeCount === 0 ? 'no_build_sds' : (!allTerminal ? 'tree_not_all_terminal' : 'all_cancelled'),
+      });
+    }
+  }
+  return violations;
+}

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -42,7 +42,7 @@ import { normalizeBuildTaskCompletion } from '../bridge/repo-readiness.js';
 async function verifyBuildMvpBuildPresent({ supabase, ventureId }) {
   const { data, error } = await supabase
     .from('venture_artifacts')
-    .select('id, artifact_data')
+    .select('id, artifact_data, content')
     .eq('venture_id', ventureId)
     .eq('artifact_type', 'build_mvp_build')
     .eq('is_current', true)
@@ -67,8 +67,30 @@ async function verifyBuildMvpBuildPresent({ supabase, ventureId }) {
     return {
       satisfied: false,
       reason: `build incomplete: ${completion.complete}/${completion.total} build tasks verified complete. `
-        + `S19->S20 requires evidence-based completion (a registered deployment URL alone does not `
+        + 'S19->S20 requires evidence-based completion (a registered deployment URL alone does not '
         + `prove the build is done). Supply a verified build_tasks_complete >= ${completion.total}.`,
+    };
+  }
+
+  // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-4): reject a PRESENT failing build verdict. The
+  // build_mvp_build emitter writes artifact_data.verdict='FAIL' (mirrored in content) when build/
+  // repo verification failed (e.g. DataDistill's clone was refused on a bare-slug repo_url). But
+  // normalizeBuildTaskCompletion exposes no verdict/checks_run, so the completion check above is a
+  // NO-OP for such an artifact and the venture advanced past S19 with verdict=FAIL (RCA 7610876f).
+  // Reject ONLY a present verdict==='FAIL'; an advisory/reentry artifact with no verdict field
+  // (v===undefined) is NOT rejected — preserving existence-only semantics for those emitters.
+  let parsedContent = null;
+  if (typeof data.content === 'string') {
+    try { parsedContent = JSON.parse(data.content); } catch { /* non-JSON content → ignore */ }
+  } else if (data.content && typeof data.content === 'object') {
+    parsedContent = data.content;
+  }
+  const verdict = (data.artifact_data && data.artifact_data.verdict) ?? (parsedContent && parsedContent.verdict);
+  if (typeof verdict === 'string' && verdict.toUpperCase() === 'FAIL') {
+    return {
+      satisfied: false,
+      reason: 'build_mvp_build verdict=FAIL — repo/build verification did not pass (presence is not '
+        + 'sufficiency). Resolve the build failure and re-run verification until verdict is not FAIL.',
     };
   }
   return { satisfied: true, reason: '' };

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -38,6 +38,9 @@ import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
 import { shouldOpenChairmanGate } from './should-open-chairman-gate.js';
+// SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single pure bridge-outcome classifier + S19
+// hold/advance decision shared by every S19 gate consumer (closes RCA 7610876f schism).
+import { classifyBridgeOutcome, shouldHoldAtS19, S19_BRIDGE_OUTCOME } from './bridge/s19-advance-decision.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -624,44 +627,41 @@ export class StageExecutionWorker {
           }
         }
 
-        // SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 (FR-1): HARD pre-advance S19 invariant gate.
-        // A leo_bridge venture MUST NOT pass Stage 19 until its orchestrator + all child SDs are
-        // completed. RCA a14ff698: an APPROVED S19 stage_gate decision triggers the pre-execution
-        // guards below to advance via pre_exec_skip (lines ~661 and ~903) BEFORE the S19 entry gate
-        // (which would block) is ever reached — bypassing the invariant (DataDistill jumped 19->23
-        // with 0 SDs). This gate runs FIRST and engages on exactly that condition (an approved S19
-        // decision while the build is incomplete): it (idempotently) runs the bridge to create the
-        // build SDs if the vision is now approved, then HARD-BLOCKS advancement if still incomplete.
-        // Non-leo_bridge ventures and fresh S19 arrivals (no approved decision) fall through to the
-        // existing entry gate, which handles their blocking.
+        // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-2): DECISION-STATE-INDEPENDENT hard pre-advance S19
+        // invariant gate. A leo_bridge venture MUST NOT pass Stage 19 until its orchestrator + all
+        // child SDs are complete. Predecessor SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 only blocked
+        // INSIDE if(approvedS19); RCA 7610876f proved that a CANCELLED/absent S19 chairman_decision
+        // skipped the block entirely, letting DataDistill advance to S20 with a 26-SD all-draft tree.
+        // We now run the bridge idempotently (creating SDs if the L2 vision is now chairman-approved),
+        // then HOLD via the single shared decision regardless of decision state. Non-leo_bridge
+        // ventures (_isLeoBridgeBuildComplete===null) and the NOOP_EMPTY 0-payload case fall through.
         if (currentStage === 19) {
           const s19Complete = await this._isLeoBridgeBuildComplete(ventureId);
           if (s19Complete === false) {
-            const { data: approvedS19 } = await this._supabase
-              .from('chairman_decisions')
-              .select('id')
-              .eq('venture_id', ventureId)
-              .eq('lifecycle_stage', 19)
-              .eq('status', 'approved')
-              .neq('decision_type', 'advisory')
-              .limit(1)
-              .maybeSingle();
-            if (approvedS19) {
-              // Idempotently (re)run the bridge — creates the orchestrator+children if the L2 vision
-              // is now chairman-approved; no-ops ('already exists') if they already exist.
-              try { await this._runS19Bridge(ventureId); } catch (e) {
-                this._logger.warn(`[Worker] S19 hard gate: bridge run failed (non-fatal): ${e.message}`);
-              }
-              const recheck = await this._isLeoBridgeBuildComplete(ventureId);
-              if (recheck === false) {
-                this._logger.warn(
-                  `[Worker] S19 HARD GATE (SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001): approved S19 decision but the leo_bridge build is NOT complete (orchestrator+children not all completed) — refusing to advance venture ${ventureId} past Stage 19.`
-                );
-                await this._blockS19LeoBridge(ventureId, ['s19_sd_completion_invariant']);
-                releaseState = ORCHESTRATOR_STATES.BLOCKED;
-                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 's19_sd_completion_invariant' };
-                break;
-              }
+            // Run-then-recheck (preserved from the predecessor FR-1): idempotently (re)run the
+            // bridge first so a just-approved vision gets its SDs created BEFORE we evaluate
+            // completeness — never block a fresh arrival before the bridge has had its chance.
+            let bridgeOutcome;
+            try {
+              const bridge = await this._runS19Bridge(ventureId);
+              bridgeOutcome = bridge.outcome;
+            } catch (e) {
+              this._logger.warn(`[Worker] S19 hard gate: bridge run failed (non-fatal): ${e.message}`);
+              bridgeOutcome = S19_BRIDGE_OUTCOME.ZERO_SDS_FAILURE; // a thrown bridge built nothing → hold
+            }
+            const recheck = await this._isLeoBridgeBuildComplete(ventureId);
+            if (shouldHoldAtS19(bridgeOutcome, recheck)) {
+              this._logger.warn(
+                `[Worker] S19 HARD GATE (SD-LEO-INFRA-HARDEN-S19-S20-001): leo_bridge build NOT complete (outcome=${bridgeOutcome}, buildComplete=${recheck}) — refusing to advance venture ${ventureId} past Stage 19 regardless of decision state.`
+              );
+              await this._blockS19LeoBridge(ventureId, ['s19_sd_completion_invariant']);
+              await this._emitS19HardGateEvent(ventureId, 'S19_HARD_GATE_BLOCK', {
+                build_complete: recheck, bridge_outcome: bridgeOutcome,
+                reason: 's19_sd_completion_invariant', decided_by: 'fr1_entry_hard_gate',
+              });
+              releaseState = ORCHESTRATOR_STATES.BLOCKED;
+              lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 's19_sd_completion_invariant' };
+              break;
             }
           }
         }
@@ -1299,40 +1299,43 @@ export class StageExecutionWorker {
                 break;
               }
               // Approved vision now exists — fall through to (re)run the bridge below.
+              // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): decide via the single shared
+              // classifier+decision instead of re-deriving idempotency inline (schism root cause).
               const bridge = await this._runS19Bridge(ventureId);
-              const errs = bridge.errors || [];
-              const errStr = JSON.stringify(errs);
-              const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
-              if (bridge.created || isIdempotent) {
-                this._logger.log(`[Worker] S19 gate (leo_bridge): bridge ${bridge.created ? 'created SDs' : 'idempotent no-op'} after vision approval — proceeding.`);
-              } else {
-                this._logger.error(`[Worker] S19 gate (leo_bridge): bridge still failing after vision approval for venture ${ventureId}. Errors: ${errStr}`);
-                await this._blockS19LeoBridge(ventureId, errs);
+              const buildComplete = await this._isLeoBridgeBuildComplete(ventureId);
+              if (shouldHoldAtS19(bridge.outcome, buildComplete)) {
+                this._logger.error(`[Worker] S19 gate (leo_bridge): HOLD after vision approval for venture ${ventureId} (outcome=${bridge.outcome}, buildComplete=${buildComplete}). Errors: ${JSON.stringify(bridge.errors || [])}`);
+                await this._blockS19LeoBridge(ventureId, bridge.errors || []);
+                await this._emitS19HardGateEvent(ventureId, 'S19_HARD_GATE_BLOCK', {
+                  build_complete: buildComplete, bridge_outcome: bridge.outcome,
+                  reason: 'leo_bridge_vision_pending', decided_by: 's19_entry_gate_fastpath',
+                });
                 releaseState = ORCHESTRATOR_STATES.BLOCKED;
                 lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'leo_bridge_vision_pending' };
                 break;
               }
+              this._logger.log(`[Worker] S19 gate (leo_bridge): proceeding after vision approval (outcome=${bridge.outcome}).`);
             } else {
-              // Primary path: run the bridge and discriminate the three created:false cases
-              // exactly like the NC-7 regex logic (~_runS19Bridge):
-              //   created===true                          → proceed
-              //   created===false AND (no errors OR /already exists/i) → idempotency → proceed
-              //   else (real failure, incl. vision-missing) → BLOCK + break
+              // Primary path. SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the bridge OUTCOME enum +
+              // the single shared shouldHoldAtS19 decision replace the inline idempotency
+              // re-derivation. The old `!created && errors.length===0` rule mis-read a
+              // ZERO_SDS_FAILURE (payloads>0, 0 SDs, empty errors) as idempotent → advanced an
+              // unbuilt venture (RCA 7610876f). Now: HOLD on every incomplete state except the
+              // NOOP_EMPTY 0-payload case; proceed when the build is complete / chairman_override.
               const bridge = await this._runS19Bridge(ventureId);
-              const errs = bridge.errors || [];
-              const errStr = JSON.stringify(errs);
-              const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
-              if (bridge.created) {
-                this._logger.log(`[Worker] S19 gate (leo_bridge): bridge created SDs (orchestrator=${bridge.orchestratorKey}, children=${bridge.childKeys?.length || 0}) — proceeding.`);
-              } else if (isIdempotent) {
-                this._logger.log('[Worker] S19 gate (leo_bridge): bridge no-op (idempotency / existing orchestrator) — proceeding.');
-              } else {
-                this._logger.error(`[Worker] S19 gate (leo_bridge): BLOCKING — bridge failed for venture ${ventureId} (vision pending / real failure). Errors: ${errStr}`);
-                await this._blockS19LeoBridge(ventureId, errs);
+              const buildComplete = await this._isLeoBridgeBuildComplete(ventureId);
+              if (shouldHoldAtS19(bridge.outcome, buildComplete)) {
+                this._logger.error(`[Worker] S19 gate (leo_bridge): HOLD — outcome=${bridge.outcome}, buildComplete=${buildComplete} for venture ${ventureId}. Errors: ${JSON.stringify(bridge.errors || [])}`);
+                await this._blockS19LeoBridge(ventureId, bridge.errors || []);
+                await this._emitS19HardGateEvent(ventureId, 'S19_HARD_GATE_BLOCK', {
+                  build_complete: buildComplete, bridge_outcome: bridge.outcome,
+                  reason: 'leo_bridge_vision_pending', decided_by: 's19_entry_gate_primary',
+                });
                 releaseState = ORCHESTRATOR_STATES.BLOCKED;
                 lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'leo_bridge_vision_pending' };
                 break;
               }
+              this._logger.log(`[Worker] S19 gate (leo_bridge): proceeding (outcome=${bridge.outcome}, orchestrator=${bridge.orchestratorKey}, children=${bridge.childKeys?.length || 0}).`);
             }
             // SD-LEO-FEAT-SURFACE-S19-VISION-001 (FR-2): every block path above `break`s out of the
             // venture loop, so reaching here means the vision gate is PROCEEDING (approved /
@@ -2203,6 +2206,50 @@ export class StageExecutionWorker {
 
   async _advanceStage(ventureId, fromStage, toStage, context = {}) {
     const { result = null, durationMs = 0, advancementType = 'normal' } = context;
+
+    // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-3): load-bearing choke-point backstop. _advanceStage is
+    // the single side-effecting advance for ALL stages; an UNTRUSTED advance FROM Stage 19 of a
+    // leo_bridge venture whose tree exists but is incomplete is the exact a14ff998/7610876f incident
+    // (a pre_exec_skip path advanced DataDistill past S19 with a 26-SD all-draft tree). We re-assert
+    // here (side-effect-free — we do NOT run the bridge; the entry gate already does) and REFUSE.
+    // Strict on fromStage===19 so the other 24 stages short-circuit with zero extra queries. The
+    // trusted gate-cleared advance may carry advancementType==='s19_bridge_cleared' to skip this.
+    // FAIL-OPEN on evaluator error (a transient DB blip must not become fleet-wide denial-of-progress
+    // — mirrors s20-pause-controller.js), emitting a system_events alarm instead of blocking.
+    if (fromStage === 19 && advancementType !== 's19_bridge_cleared') {
+      let buildComplete;
+      try {
+        buildComplete = await this._isLeoBridgeBuildComplete(ventureId);
+      } catch (e) {
+        await this._emitS19HardGateEvent(ventureId, 'S19_HARD_GATE_ADVANCE', {
+          build_complete: null, reason: 'choke_point_eval_error_failopen',
+          error: e.message, decided_by: 'advance_stage_backstop',
+        });
+        buildComplete = undefined; // fail open — fall through to the advance
+      }
+      // ===false means leo_bridge AND incomplete (null=non-leo_bridge falls through, never blocked).
+      if (buildComplete === false) {
+        // Distinguish an incomplete tree that EXISTS (the incident → refuse) from a venture with
+        // nothing built (0 SDs: NOOP_EMPTY / a failure the entry gate owns → allow through here).
+        let sdCount = 0;
+        try {
+          const { data: sds } = await this._supabase
+            .from('strategic_directives_v2').select('id').eq('venture_id', ventureId);
+          sdCount = (sds || []).length;
+        } catch { /* unreadable → treat as 0 (fail open for the count) */ }
+        if (sdCount > 0) {
+          this._logger.error(
+            `[Worker] _advanceStage S19 CHOKE-POINT (SD-LEO-INFRA-HARDEN-S19-S20-001): REFUSING untrusted advance of leo_bridge venture ${ventureId} past Stage 19 — tree exists but is incomplete (${sdCount} SDs, buildComplete=false, advancementType=${advancementType}).`
+          );
+          await this._emitS19HardGateEvent(ventureId, 'S19_HARD_GATE_BLOCK', {
+            build_complete: false, sd_count: sdCount, from_stage: fromStage,
+            reason: 'advance_stage_choke_point', decided_by: 'advance_stage_backstop',
+            advancement_type: advancementType,
+          });
+          return { advanced: false, blocked: true, reason: 'advance_stage_choke_point' };
+        }
+      }
+    }
 
     // Side-effect 1: Update ventures.current_lifecycle_stage
     await this._supabase
@@ -3199,7 +3246,8 @@ export class StageExecutionWorker {
         }, { onConflict: 'venture_id,lifecycle_stage' });
       // seeded_repo never creates SDs — treat as "created:true" so the gate proceeds (the
       // seeded_repo branch of the entry gate handles its own repo-seeding block separately).
-      return { created: true, errors: [], orchestratorKey: null, childKeys: [] };
+      // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): tag the explicit outcome.
+      return { created: true, errors: [], orchestratorKey: null, childKeys: [], outcome: S19_BRIDGE_OUTCOME.CREATED };
     }
     this._logger.log('[Worker] S19 Bridge: build_model=leo_bridge — creating orchestrator + child SDs via convertSprintToSDs.');
 
@@ -3241,9 +3289,11 @@ export class StageExecutionWorker {
 
     if (sdBridgePayloads.length === 0) {
       this._logger.log('[Worker] S19 post-stage hook: No sd_bridge_payloads found in artifacts');
-      // No payloads = nothing to build; not a vision failure. created:false + empty errors
-      // → the entry gate treats this as the idempotency/no-op case and proceeds.
-      return { created: false, errors: [], orchestratorKey: null, childKeys: [] };
+      // No payloads = nothing to build; not a vision failure.
+      // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): NOOP_EMPTY is the ONLY incomplete state that still
+      // advances past S19 — shouldHoldAtS19 distinguishes it from a ZERO_SDS_FAILURE (payloads>0,
+      // 0 SDs), which otherwise looks identical (both created:false + empty errors + 0 SDs).
+      return { created: false, errors: [], orchestratorKey: null, childKeys: [], outcome: S19_BRIDGE_OUTCOME.NOOP_EMPTY };
     }
 
     // Query EVA records for vision_key and plan_key.
@@ -3353,12 +3403,16 @@ export class StageExecutionWorker {
 
     // FR-2: return the bridge outcome so the synchronous S19 entry gate can discriminate
     // created:true / idempotency-no-op / real-failure and block advancement accordingly.
-    return {
+    // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): attach the canonical outcome enum so all consumers
+    // share ONE discriminant instead of re-deriving idempotency inline (the schism root cause).
+    const result = {
       created: bridgeResult.created === true,
       errors: bridgeResult.errors || bridgeResult.error || [],
       orchestratorKey: bridgeResult.orchestratorKey || null,
       childKeys: bridgeResult.childKeys || [],
     };
+    result.outcome = classifyBridgeOutcome(result, sdBridgePayloads.length);
+    return result;
   }
 
   /**
@@ -3396,6 +3450,33 @@ export class StageExecutionWorker {
     const allTerminal = sds.every((sd) => TERMINAL.has(sd.status));
     const anyCompleted = sds.some((sd) => COMPLETED.has(sd.status));
     return allTerminal && anyCompleted;
+  }
+
+  /**
+   * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-5): emit an audit row for an S19 hard-gate decision.
+   * The recurrence (RCA 7610876f) left ZERO audit trail; every block/advance decision must now be
+   * observable. system_events has NO event_data column — dual-write the body to BOTH `details`
+   * (canonical for venture-lifecycle reads) and `payload` (matches the leo-build-starter emitter).
+   * Best-effort + non-fatal: an audit failure must never destabilize the gate it documents.
+   * @param {string} ventureId
+   * @param {'S19_HARD_GATE_BLOCK'|'S19_HARD_GATE_ADVANCE'} eventType
+   * @param {Record<string, any>} body
+   */
+  async _emitS19HardGateEvent(ventureId, eventType, body = {}) {
+    try {
+      const payload = { venture_id: ventureId, from_stage: 19, build_model: 'leo_bridge', ...body };
+      const stamp = new Date().toISOString();
+      await this._supabase.from('system_events').insert({
+        event_type: eventType,
+        venture_id: ventureId,
+        idempotency_key: `${eventType}:${ventureId}:${Date.parse(stamp)}`,
+        payload,
+        details: payload,
+        created_at: stamp,
+      });
+    } catch (err) {
+      this._logger.warn(`[Worker] S19 hard-gate event emit failed (non-fatal): ${err.message}`);
+    }
   }
 
   /**

--- a/scripts/diagnostics/s19-reconciliation.mjs
+++ b/scripts/diagnostics/s19-reconciliation.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-5): diagnostic/cron runner for the S19->S20 reconciliation
+ * invariant. Prints every leo_bridge venture that has advanced past Stage 19 with an incomplete
+ * SD tree. Exit code 2 when violations exist (so CI/cron can alert), 0 when clean.
+ *
+ *   node scripts/diagnostics/s19-reconciliation.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { findS19AdvanceViolations } from '../../lib/eva/bridge/s19-reconciliation.js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const violations = await findS19AdvanceViolations(supabase);
+console.log(JSON.stringify({ invariant: 's19_advance_completion', count: violations.length, violations }, null, 2));
+if (violations.length > 0) {
+  console.error(`\n[s19-reconciliation] ${violations.length} violation(s): leo_bridge venture(s) past S19 with an incomplete tree.`);
+  process.exit(2);
+}
+console.log('[s19-reconciliation] OK — no leo_bridge venture has bypassed the S19 completion invariant.');
+process.exit(0);

--- a/tests/unit/eva/bridge/s19-advance-decision.test.js
+++ b/tests/unit/eva/bridge/s19-advance-decision.test.js
@@ -1,0 +1,79 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1) — the pure bridge-outcome classifier + the single S19
+ * hold/advance decision. These truth tables are the keystone: every gate consumer shares this
+ * logic, so a regression here is a regression everywhere. TS-1 (classifyBridgeOutcome) and
+ * TS-2 (shouldHoldAtS19) from the PRD test_scenarios.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyBridgeOutcome,
+  shouldHoldAtS19,
+  S19_BRIDGE_OUTCOME,
+} from '../../../../lib/eva/bridge/s19-advance-decision.js';
+
+const O = S19_BRIDGE_OUTCOME;
+
+describe('classifyBridgeOutcome (TS-1)', () => {
+  it('created:true → CREATED (regardless of payload count)', () => {
+    expect(classifyBridgeOutcome({ created: true, errors: [] }, 0)).toBe(O.CREATED);
+    expect(classifyBridgeOutcome({ created: true, errors: [] }, 5)).toBe(O.CREATED);
+  });
+
+  it('vision-missing error text → VISION_MISSING (derived from errStr, not a throw)', () => {
+    expect(classifyBridgeOutcome({ created: false, errors: ['Venture X: no L2 vision document found.'] }, 1)).toBe(O.VISION_MISSING);
+    expect(classifyBridgeOutcome({ created: false, errors: ['VENTURE_L2_VISION_MISSING'] }, 1)).toBe(O.VISION_MISSING);
+    expect(classifyBridgeOutcome({ created: false, errors: ['needs draft_seed vision'] }, 1)).toBe(O.VISION_MISSING);
+  });
+
+  it('"already exists" error → NOOP_EXISTS', () => {
+    expect(classifyBridgeOutcome({ created: false, errors: ['Orchestrator already exists for venture'] }, 1)).toBe(O.NOOP_EXISTS);
+  });
+
+  it('existing orchestratorKey + empty errors → NOOP_EXISTS (idempotency contract)', () => {
+    expect(classifyBridgeOutcome({ created: false, errors: [], orchestratorKey: 'SD-LEO-ORCH-EXISTING' }, 1)).toBe(O.NOOP_EXISTS);
+  });
+
+  it('created:false + empty errors + 0 payloads → NOOP_EMPTY (nothing to build)', () => {
+    expect(classifyBridgeOutcome({ created: false, errors: [], orchestratorKey: null }, 0)).toBe(O.NOOP_EMPTY);
+    expect(classifyBridgeOutcome({ created: false, errors: [] }, undefined)).toBe(O.NOOP_EMPTY);
+  });
+
+  it('created:false + empty errors + payloads present → ZERO_SDS_FAILURE (THE SCHISM)', () => {
+    // This is exactly the case the old `!created && errors.length===0` rule mis-read as idempotent.
+    expect(classifyBridgeOutcome({ created: false, errors: [], orchestratorKey: null }, 3)).toBe(O.ZERO_SDS_FAILURE);
+  });
+
+  it('created:false + non-idempotent failure errors + payloads → ZERO_SDS_FAILURE', () => {
+    expect(classifyBridgeOutcome({ created: false, errors: ['SD_TYPE_CHANGE rollback'], orchestratorKey: null }, 2)).toBe(O.ZERO_SDS_FAILURE);
+  });
+});
+
+describe('shouldHoldAtS19 (TS-2)', () => {
+  const ALL = [O.CREATED, O.NOOP_EXISTS, O.NOOP_EMPTY, O.ZERO_SDS_FAILURE, O.VISION_MISSING];
+
+  it('buildComplete===true → ADVANCE for every outcome (complete tree OR chairman_override)', () => {
+    for (const o of ALL) expect(shouldHoldAtS19(o, true)).toBe(false);
+  });
+
+  it('buildComplete===null → ADVANCE for every outcome (non-leo_bridge falls through)', () => {
+    for (const o of ALL) expect(shouldHoldAtS19(o, null)).toBe(false);
+  });
+
+  it('buildComplete===false + NOOP_EMPTY → ADVANCE (the infinite-hold guard)', () => {
+    expect(shouldHoldAtS19(O.NOOP_EMPTY, false)).toBe(false);
+  });
+
+  it('buildComplete===false + every other outcome → HOLD', () => {
+    expect(shouldHoldAtS19(O.CREATED, false)).toBe(true);
+    expect(shouldHoldAtS19(O.NOOP_EXISTS, false)).toBe(true);
+    expect(shouldHoldAtS19(O.ZERO_SDS_FAILURE, false)).toBe(true);
+    expect(shouldHoldAtS19(O.VISION_MISSING, false)).toBe(true);
+  });
+
+  it('the ONLY signal that distinguishes 0-SD advance from 0-SD hold is the outcome enum', () => {
+    // Both NOOP_EMPTY and ZERO_SDS_FAILURE yield _isLeoBridgeBuildComplete===false (0 SDs);
+    // only the enum tells them apart.
+    expect(shouldHoldAtS19(O.NOOP_EMPTY, false)).toBe(false);     // advance
+    expect(shouldHoldAtS19(O.ZERO_SDS_FAILURE, false)).toBe(true); // hold
+  });
+});

--- a/tests/unit/eva/bridge/s19-reconciliation.test.js
+++ b/tests/unit/eva/bridge/s19-reconciliation.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-5): the reconciliation invariant. Flags a leo_bridge venture
+ * past S19 with an incomplete tree; excludes chairman_override and completed trees. TS-11.
+ */
+import { describe, it, expect } from 'vitest';
+import { findS19AdvanceViolations } from '../../../../lib/eva/bridge/s19-reconciliation.js';
+
+/**
+ * Mock supabase routing by table. `ventures` returns the configured leo_bridge ventures past S19;
+ * `venture_stage_work` and `strategic_directives_v2` resolve per-venture via the ventureId in .eq.
+ */
+function makeSupabase({ ventures = [], stageWorkByVenture = {}, sdsByVenture = {} }) {
+  const from = (table) => {
+    let ventureId = null;
+    const chain = {
+      select: () => chain,
+      eq: (col, val) => { if (col === 'venture_id') ventureId = val; return chain; },
+      gt: () => chain,
+      async maybeSingle() {
+        if (table === 'venture_stage_work') return { data: stageWorkByVenture[ventureId] || null, error: null };
+        return { data: null, error: null };
+      },
+      then: (resolve) => {
+        if (table === 'ventures') return resolve({ data: ventures, error: null });
+        if (table === 'strategic_directives_v2') return resolve({ data: sdsByVenture[ventureId] || [], error: null });
+        return resolve({ data: null, error: null });
+      },
+    };
+    return chain;
+  };
+  return { from };
+}
+
+describe('findS19AdvanceViolations (TS-11)', () => {
+  it('flags a leo_bridge venture past S19 with an all-draft (incomplete) tree', async () => {
+    const supabase = makeSupabase({
+      ventures: [{ id: 'dd', name: 'DataDistill', current_lifecycle_stage: 20, build_model: 'leo_bridge' }],
+      stageWorkByVenture: { dd: { advisory_data: {} } },
+      sdsByVenture: { dd: [{ status: 'draft' }, { status: 'draft' }] },
+    });
+    const v = await findS19AdvanceViolations(supabase);
+    expect(v).toHaveLength(1);
+    expect(v[0].venture_id).toBe('dd');
+    expect(v[0].reason).toBe('tree_not_all_terminal');
+  });
+
+  it('flags a venture with NO build SDs (never built)', async () => {
+    const supabase = makeSupabase({
+      ventures: [{ id: 'e', name: 'Empty', current_lifecycle_stage: 22, build_model: 'leo_bridge' }],
+      sdsByVenture: { e: [] },
+    });
+    const v = await findS19AdvanceViolations(supabase);
+    expect(v).toHaveLength(1);
+    expect(v[0].reason).toBe('no_build_sds');
+  });
+
+  it('EXCLUDES a chairman_override venture (sanctioned advance)', async () => {
+    const supabase = makeSupabase({
+      ventures: [{ id: 'o', name: 'Override', current_lifecycle_stage: 20, build_model: 'leo_bridge' }],
+      stageWorkByVenture: { o: { advisory_data: { chairman_override: true } } },
+      sdsByVenture: { o: [{ status: 'draft' }] },
+    });
+    const v = await findS19AdvanceViolations(supabase);
+    expect(v).toHaveLength(0);
+  });
+
+  it('does NOT flag a completed tree (>=1 completed, all terminal)', async () => {
+    const supabase = makeSupabase({
+      ventures: [{ id: 'c', name: 'Complete', current_lifecycle_stage: 21, build_model: 'leo_bridge' }],
+      stageWorkByVenture: { c: { advisory_data: {} } },
+      sdsByVenture: { c: [{ status: 'completed' }, { status: 'cancelled' }] },
+    });
+    const v = await findS19AdvanceViolations(supabase);
+    expect(v).toHaveLength(0);
+  });
+
+  it('flags an all-cancelled tree (terminal but nothing genuinely completed)', async () => {
+    const supabase = makeSupabase({
+      ventures: [{ id: 'x', name: 'AllCancelled', current_lifecycle_stage: 20, build_model: 'leo_bridge' }],
+      stageWorkByVenture: { x: { advisory_data: {} } },
+      sdsByVenture: { x: [{ status: 'cancelled' }, { status: 'cancelled' }] },
+    });
+    const v = await findS19AdvanceViolations(supabase);
+    expect(v).toHaveLength(1);
+    expect(v[0].reason).toBe('all_cancelled');
+  });
+});

--- a/tests/unit/eva/lifecycle/exit-gate-verifier-verdict.test.js
+++ b/tests/unit/eva/lifecycle/exit-gate-verifier-verdict.test.js
@@ -1,0 +1,67 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-4): verifyBuildMvpBuildPresent rejects a PRESENT failing
+ * build verdict. DataDistill's build_mvp_build artifact carried artifact_data.verdict='FAIL' yet
+ * passed the S19->S20 exit gate because normalizeBuildTaskCompletion has no verdict field and the
+ * artifact had no build_tasks_total (so the completion check was a no-op). TS-9 / TS-10.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveVerifier } from '../../../../lib/eva/lifecycle/exit-gate-verifiers.js';
+
+function mockSupabase({ data = null, error = null } = {}) {
+  const chain = {
+    from() { return chain; },
+    select() { return chain; },
+    eq() { return chain; },
+    limit() { return chain; },
+    async maybeSingle() { return { data, error }; },
+  };
+  return chain;
+}
+
+const VID = '11111111-2222-3333-4444-555555555555';
+const verifier = resolveVerifier('Application deployed');
+
+describe('verifyBuildMvpBuildPresent — present-failing-verdict reject (FR-4)', () => {
+  it('TS-9: rejects an artifact carrying artifact_data.verdict=FAIL (mirrors DataDistill)', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a1', artifact_data: { verdict: 'FAIL', checks_run: 0, findings: [{ severity: 'critical' }] }, content: null },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/verdict=FAIL/i);
+  });
+
+  it('TS-9b: rejects when the FAIL verdict is only in the (string) content mirror', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a2', artifact_data: null, content: JSON.stringify({ verdict: 'FAIL' }) },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/verdict=FAIL/i);
+  });
+
+  it('TS-10: does NOT reject an advisory artifact with no verdict and no completion ledger', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a3', artifact_data: { awaiting_replit_sync: true }, content: null },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('does NOT reject a passing verdict', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a4', artifact_data: { verdict: 'PASS', build_tasks_total: 3, build_tasks_complete: 3 }, content: null },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('still rejects the pre-existing complete<total incomplete-ledger case (no regression)', async () => {
+    const supabase = mockSupabase({
+      data: { id: 'a5', artifact_data: { build_tasks_total: 7, build_tasks_complete: 3 }, content: null },
+    });
+    const r = await verifier({ supabase, ventureId: VID });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/incomplete: 3\/7/);
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-s19-gate.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-gate.test.js
@@ -31,6 +31,8 @@ vi.mock('../../../lib/eva/stage-governance.js', () => ({
 }));
 
 import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+// SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the real shared decision now backs the entry gate.
+import { classifyBridgeOutcome, shouldHoldAtS19 } from '../../../lib/eva/bridge/s19-advance-decision.js';
 
 const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
 
@@ -187,33 +189,37 @@ describe('_blockS19LeoBridge (FR-2 block row)', () => {
 });
 
 /**
- * Gate discrimination logic (mirrors the NC-7 regex branch in the S19 entry gate).
- * The block decision is inline in the _processVenture loop; this characterization
- * test replicates the exact discriminator so a regression in the rule is caught.
+ * S19 entry-gate discrimination. SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1) replaced the inline
+ * `!created && errors.length===0` idempotency re-derivation (the schism root cause) with the shared
+ * classifyBridgeOutcome + shouldHoldAtS19 — exhaustively covered in
+ * tests/unit/eva/bridge/s19-advance-decision.test.js. This block re-characterizes the gate decision
+ * through the REAL shared functions (no inline copy), including the case the OLD rule got WRONG.
+ * chairman_override surfaces as _isLeoBridgeBuildComplete===true (honored upstream).
  */
-function gateDecision(bridge, advisory = {}) {
-  if (advisory.chairman_override === true) return 'proceed';
-  const errs = bridge.errors || [];
-  const errStr = JSON.stringify(errs);
-  const isIdempotent = !bridge.created && (!errs || errs.length === 0 || /already exists/i.test(errStr));
-  if (bridge.created || isIdempotent) return 'proceed';
-  return 'block';
+function gateDecision(bridge, { buildComplete = false, payloadCount = 1, chairmanOverride = false } = {}) {
+  const complete = chairmanOverride ? true : buildComplete;
+  const outcome = classifyBridgeOutcome(bridge, payloadCount);
+  return shouldHoldAtS19(outcome, complete) ? 'block' : 'proceed';
 }
 
-describe('S19 entry-gate discrimination (mirrors inline gate logic)', () => {
-  it('VENTURE_L2_VISION_MISSING → block + no advance', () => {
-    expect(gateDecision({ created: false, errors: ['Venture X: no L2 vision document found.'] })).toBe('block');
+describe('S19 entry-gate discrimination (real shared decision, FR-1)', () => {
+  it('VENTURE_L2_VISION_MISSING + incomplete → block', () => {
+    expect(gateDecision({ created: false, errors: ['Venture X: no L2 vision document found.'] }, { buildComplete: false })).toBe('block');
   });
-  it('errors empty (idempotency) → proceed', () => {
-    expect(gateDecision({ created: false, errors: [] })).toBe('proceed');
+  it('existing-orchestrator idempotency + complete tree → proceed', () => {
+    expect(gateDecision({ created: false, errors: [], orchestratorKey: 'SD-EXISTING' }, { buildComplete: true })).toBe('proceed');
   });
-  it('/already exists/ → proceed', () => {
-    expect(gateDecision({ created: false, errors: ['Orchestrator already exists for venture'] })).toBe('proceed');
+  it('created:true but tree still incomplete → HOLD (the completion invariant)', () => {
+    expect(gateDecision({ created: true, errors: [] }, { buildComplete: false })).toBe('block');
   });
-  it('created:true → proceed', () => {
-    expect(gateDecision({ created: true, errors: [] })).toBe('proceed');
+  it('SCHISM FIXED: created:false + empty errors + payloads present (zero_sds_failure) → block', () => {
+    // The OLD inline rule mis-read this as idempotent and PROCEEDED — the RCA 7610876f bug.
+    expect(gateDecision({ created: false, errors: [], orchestratorKey: null }, { buildComplete: false, payloadCount: 3 })).toBe('block');
   });
   it('chairman_override → proceed even on a real failure', () => {
-    expect(gateDecision({ created: false, errors: ['no L2 vision document found'] }, { chairman_override: true })).toBe('proceed');
+    expect(gateDecision({ created: false, errors: ['no L2 vision document found'] }, { chairmanOverride: true })).toBe('proceed');
+  });
+  it('noop_empty (0 payloads) + incomplete → proceed (infinite-hold guard)', () => {
+    expect(gateDecision({ created: false, errors: [] }, { buildComplete: false, payloadCount: 0 })).toBe('proceed');
   });
 });

--- a/tests/unit/eva/stage-execution-worker-s19-harden.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-harden.test.js
@@ -1,0 +1,169 @@
+/**
+ * SD-LEO-INFRA-HARDEN-S19-S20-001 — worker-level enforcement tests that drive the REAL methods
+ * (the existing stage-execution-worker-advancement.test.js replicates _advanceStage inline and does
+ * NOT exercise the real method, per the prospective testing-agent). Covers FR-3 (_advanceStage S19
+ * choke-point: TS-6/7/8 + null fall-through + noop-empty + non-S19 short-circuit) and FR-5
+ * (_emitS19HardGateEvent dual-write payload+details, no event_data).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn(), releaseProcessingLock: vi.fn(), markCompleted: vi.fn(),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', KILLED_AT_REALITY_GATE: 'killed_at_reality_gate' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({ createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn() }));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue({}) }));
+vi.mock('../../../lib/eva/autonomy-model.js', () => ({ checkAutonomy: vi.fn().mockResolvedValue({ action: 'block', level: 'L0' }) }));
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn().mockResolvedValue({ isBlocking: () => false, isReview: () => false }),
+}));
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+/**
+ * Thenable chainable supabase fake: `await chain` (after .eq) resolves { data: <per-table>, error };
+ * .maybeSingle/.single resolve the same; .insert/.upsert/.update are tracked. This lets the REAL
+ * _advanceStage run its side-effect chain against benign data while we assert the FR-3 outcome.
+ */
+function makeSupabase({ sdRows = [{ id: 'sd1', status: 'draft' }], ventureRow = { build_model: 'leo_bridge' }, stageWork = { advisory_data: {} } } = {}) {
+  const calls = { venturesUpdate: 0, systemEvents: [], stageWorkUpserts: [] };
+  const from = (table) => {
+    const terminalData =
+      table === 'strategic_directives_v2' ? sdRows :
+      table === 'ventures' ? ventureRow :
+      table === 'venture_stage_work' ? stageWork : null;
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      neq: () => chain,
+      in: () => chain,
+      gt: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: async () => ({ data: terminalData, error: null }),
+      single: async () => ({ data: terminalData, error: null }),
+      upsert: async (row) => { if (table === 'venture_stage_work') calls.stageWorkUpserts.push(row); return { data: null, error: null }; },
+      insert: async (row) => { if (table === 'system_events') calls.systemEvents.push(row); return { data: null, error: null }; },
+      update: () => { if (table === 'ventures') calls.venturesUpdate += 1; return chain; },
+      then: (resolve) => resolve({ data: terminalData, error: null }),
+    };
+    return chain;
+  };
+  return { from, calls };
+}
+
+function makeWorker(supabase, { buildComplete } = {}) {
+  const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+  // Neutralise the heavy non-FR-3 side-effects of the advance path so we isolate the guard.
+  worker._logStageTransition = vi.fn().mockResolvedValue(undefined);
+  worker._runPostStageHooks = vi.fn().mockResolvedValue(undefined);
+  if (buildComplete !== undefined) {
+    worker._isLeoBridgeBuildComplete = vi.fn().mockResolvedValue(buildComplete);
+  }
+  return worker;
+}
+
+describe('_advanceStage S19 choke-point (FR-3) — real method', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('TS-6: REFUSES an untrusted from-S19 advance of an incomplete leo_bridge venture (tree exists)', async () => {
+    const supabase = makeSupabase({ sdRows: [{ id: 'sd1', status: 'draft' }] });
+    const worker = makeWorker(supabase, { buildComplete: false });
+
+    const r = await worker._advanceStage('v-1', 19, 20, { advancementType: 'pre_exec_skip' });
+
+    expect(supabase.calls.venturesUpdate).toBe(0);            // current_lifecycle_stage NOT written
+    expect(r && r.blocked).toBe(true);
+    const ev = supabase.calls.systemEvents.at(-1);
+    expect(ev.event_type).toBe('S19_HARD_GATE_BLOCK');
+    expect(ev.payload.reason).toBe('advance_stage_choke_point');
+    expect(ev.payload.sd_count).toBe(1);
+    expect(ev).not.toHaveProperty('event_data');             // FR-5: never the non-existent column
+  });
+
+  it('TS-7: trusted marker (s19_bridge_cleared) advances and never queries completeness', async () => {
+    const supabase = makeSupabase();
+    const worker = makeWorker(supabase);
+    worker._isLeoBridgeBuildComplete = vi.fn(); // spy — must NOT be called
+
+    await worker._advanceStage('v-1', 19, 20, { advancementType: 's19_bridge_cleared' });
+
+    expect(worker._isLeoBridgeBuildComplete).not.toHaveBeenCalled();
+    expect(supabase.calls.venturesUpdate).toBe(1);
+  });
+
+  it('TS-8: fails OPEN (advances) + emits a system_events alarm when the evaluator throws', async () => {
+    const supabase = makeSupabase();
+    const worker = makeWorker(supabase);
+    worker._isLeoBridgeBuildComplete = vi.fn().mockRejectedValue(new Error('db down'));
+
+    await worker._advanceStage('v-1', 19, 20, { advancementType: 'pre_exec_skip' });
+
+    expect(supabase.calls.venturesUpdate).toBe(1);           // advanced (fail-open)
+    const ev = supabase.calls.systemEvents.at(-1);
+    expect(ev.event_type).toBe('S19_HARD_GATE_ADVANCE');
+    expect(ev.payload.reason).toBe('choke_point_eval_error_failopen');
+  });
+
+  it('non-leo_bridge (buildComplete===null) falls through and advances — null is never blocked', async () => {
+    const supabase = makeSupabase({ ventureRow: { build_model: 'seeded_repo' } });
+    const worker = makeWorker(supabase, { buildComplete: null });
+
+    await worker._advanceStage('v-1', 19, 20, { advancementType: 'pre_exec_skip' });
+
+    expect(supabase.calls.venturesUpdate).toBe(1);
+    expect(supabase.calls.systemEvents.length).toBe(0);       // no block event
+  });
+
+  it('noop-empty (buildComplete===false but 0 SDs) advances — the infinite-hold guard', async () => {
+    const supabase = makeSupabase({ sdRows: [] });             // 0 SDs => nothing built
+    const worker = makeWorker(supabase, { buildComplete: false });
+
+    await worker._advanceStage('v-1', 19, 20, { advancementType: 'pre_exec_skip' });
+
+    expect(supabase.calls.venturesUpdate).toBe(1);
+    expect(supabase.calls.systemEvents.length).toBe(0);
+  });
+
+  it('fromStage!==19 short-circuits: no completeness query, no blast radius on other stages', async () => {
+    const supabase = makeSupabase();
+    const worker = makeWorker(supabase);
+    worker._isLeoBridgeBuildComplete = vi.fn();
+
+    await worker._advanceStage('v-1', 10, 11, { advancementType: 'normal' });
+
+    expect(worker._isLeoBridgeBuildComplete).not.toHaveBeenCalled();
+    expect(supabase.calls.venturesUpdate).toBe(1);
+  });
+});
+
+describe('_emitS19HardGateEvent (FR-5)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('dual-writes the body to BOTH payload and details, with no event_data column', async () => {
+    const supabase = makeSupabase();
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+
+    await worker._emitS19HardGateEvent('v-9', 'S19_HARD_GATE_BLOCK', { build_complete: false, bridge_outcome: 'zero_sds_failure', reason: 's19_sd_completion_invariant', decided_by: 'fr1_entry_hard_gate' });
+
+    const ev = supabase.calls.systemEvents.at(-1);
+    expect(ev.event_type).toBe('S19_HARD_GATE_BLOCK');
+    expect(ev.venture_id).toBe('v-9');
+    expect(ev.payload).toEqual(ev.details);                   // dual-write
+    expect(ev.payload.build_model).toBe('leo_bridge');
+    expect(ev.payload.from_stage).toBe(19);
+    expect(ev.payload.bridge_outcome).toBe('zero_sds_failure');
+    expect(typeof ev.idempotency_key).toBe('string');
+    expect(ev.idempotency_key.startsWith('S19_HARD_GATE_BLOCK:v-9:')).toBe(true);
+    expect(ev).not.toHaveProperty('event_data');
+  });
+
+  it('is non-fatal: a system_events insert failure does not throw', async () => {
+    const supabase = { from: () => ({ insert: async () => { throw new Error('boom'); } }) };
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    await expect(worker._emitS19HardGateEvent('v-1', 'S19_HARD_GATE_ADVANCE', {})).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Closes a **fresh recurrence** of the S19 gate-bypass incident (RCA `7610876f`, conf 90): DataDistill advanced Stage 19→20 with a 26-SD all-draft tree and **zero audit trail**. Two-layer root cause in `lib/eva/stage-execution-worker.js`, fixed via a single pure shared decision (the writer/consumer-asymmetry pattern, PAT witnessed 5×).

## Changes (5 FRs)
- **FR-1 (keystone):** new `lib/eva/bridge/s19-advance-decision.js` — `classifyBridgeOutcome` (5-value enum: created / noop_exists / noop_empty / zero_sds_failure / vision_missing) + `shouldHoldAtS19`. `_runS19Bridge` now returns `outcome`. All gate consumers share ONE decision instead of re-deriving `!created && errors.length===0` inline — the schism that let a `zero_sds_failure` masquerade as idempotent and advance.
- **FR-2:** the S19 hard gate is now **decision-state-independent** (block moved out of `if(approvedS19)`) — a cancelled/absent S19 decision no longer skips the hold. `noop_empty` (0 payloads) still advances (no infinite-hold of a legit empty-sprint venture).
- **FR-3:** `_advanceStage` side-effect-free **choke-point backstop** refuses an *untrusted* from-S19 advance when an incomplete tree EXISTS (`buildComplete===false && sdCount>0`); **fails OPEN** + `system_events` alarm on evaluator error (mirrors s20-pause-controller).
- **FR-4:** `verifyBuildMvpBuildPresent` rejects a present `artifact_data.verdict==='FAIL'` (`normalizeBuildTaskCompletion` has no verdict field → the old check was a no-op on DataDistill's artifact). Advisory artifacts without a verdict are unaffected.
- **FR-5:** `_emitS19HardGateEvent` (dual-write `payload`+`details`, no `event_data`) + `findS19AdvanceViolations` reconciliation invariant (+ `scripts/diagnostics/s19-reconciliation.mjs`) — returns 1 row today (DataDistill).

## Tests
30 new tests (pure truth tables + the **real** `_advanceStage`/emit/reconciliation/verifier methods). The existing S19 suites stay green — the stale inline `gateDecision` replica is repointed at the real shared functions and now encodes the schism fix. The 5 unrelated pre-existing failures (Stitch/health/resilience/s20-no-SDs) are confirmed on baseline.

## Safety
**NO new advance path** is introduced — the existing single advance path is hardened. The `null`-vs-`false` `_isLeoBridgeBuildComplete` contract is used literally (non-leo_bridge falls through, never blocked).

## Out of scope (deferred)
DataDistill data correction (database-agent), the agent-runtime consumer SD, and the s20-pause-controller all-cancelled-tree SSOT reconciliation (documented divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)