### PR TITLE
fix(SD-LEO-INFRA-REPAIR-STALE-STAGE-001): repair stale stage-zero unit tests (client.complete mock drift + stale assertions)

### DIFF
--- a/tests/unit/eva/stage-zero/data-pollers/apple-rss-poller.test.js
+++ b/tests/unit/eva/stage-zero/data-pollers/apple-rss-poller.test.js
@@ -82,10 +82,14 @@ describe('pollAppleRSS', () => {
 
   test('continues processing other categories when one fails', async () => {
     const mockSupabase = createMockSupabase();
-    let callCount = 0;
-    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return Promise.resolve({ ok: false, status: 503 });
+    // SUT wraps each category fetch in withRetry (up to 2 retries). Gate by the
+    // category id embedded in the URL so the failing category (6013) fails ALL of
+    // its attempts, while the second category (6015) succeeds — otherwise a retry
+    // of the "failing" category would succeed and inflate the count.
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (String(url).includes('/6013/')) {
+        return Promise.resolve({ ok: false, status: 503 });
+      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve(sampleAppleResponse) });
     });
 

--- a/tests/unit/eva/stage-zero/data-pollers/gplay-scraper.test.js
+++ b/tests/unit/eva/stage-zero/data-pollers/gplay-scraper.test.js
@@ -67,10 +67,14 @@ describe('pollGooglePlay', () => {
 
   test('continues processing when one category fails', async () => {
     const mockSupabase = createMockSupabase();
-    let callCount = 0;
-    mockList.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return Promise.reject(new Error('RequestError'));
+    // SUT wraps each gplay.list call in withRetry (up to 2 retries). Gate by the
+    // category argument so the failing category (EDUCATION) rejects on ALL of its
+    // attempts, while FINANCE succeeds — otherwise a retry of the "failing"
+    // category would succeed and inflate the count.
+    mockList.mockImplementation(({ category }) => {
+      if (category === 'EDUCATION') {
+        return Promise.reject(new Error('RequestError'));
+      }
       return Promise.resolve(sampleResults);
     });
 

--- a/tests/unit/eva/stage-zero/data-pollers/producthunt-poller.test.js
+++ b/tests/unit/eva/stage-zero/data-pollers/producthunt-poller.test.js
@@ -67,15 +67,22 @@ describe('pollProductHunt', () => {
       status: 401,
     });
 
+    // SUT wraps fetch in withRetry and aggregates per-topic errors: a 401 is
+    // detected (thrown as '401 Unauthorized', logged per attempt) but, once all
+    // retries are exhausted with no data collected, the aggregate result reports
+    // the generic 'No data collected from any topic' error.
+    const logger = { log: vi.fn(), warn: vi.fn() };
     const result = await pollProductHunt({
       supabase: createMockSupabase(),
-      logger: silentLogger,
+      logger,
       topics: ['ai'],
       apiToken: 'bad-token',
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('401 Unauthorized');
+    expect(result.error).toBe('No data collected from any topic');
+    // The specific HTTP failure is surfaced through the logger.
+    expect(logger.log.mock.calls.flat().some(arg => String(arg).includes('401 Unauthorized'))).toBe(true);
   });
 
   test('returns error on 429 rate limit', async () => {
@@ -85,14 +92,16 @@ describe('pollProductHunt', () => {
       headers: { get: () => '60' },
     });
 
+    const logger = { log: vi.fn(), warn: vi.fn() };
     const result = await pollProductHunt({
       supabase: createMockSupabase(),
-      logger: silentLogger,
+      logger,
       topics: ['ai'],
       apiToken: 'test-token',
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('429 Rate Limited');
+    expect(result.error).toBe('No data collected from any topic');
+    expect(logger.log.mock.calls.flat().some(arg => String(arg).includes('429 Rate Limited'))).toBe(true);
   });
 });

--- a/tests/unit/eva/stage-zero/gate-thresholds.test.js
+++ b/tests/unit/eva/stage-zero/gate-thresholds.test.js
@@ -17,7 +17,6 @@ import {
 } from '../../../../lib/eva/stage-zero/profile-service.js';
 import {
   evaluateRealityGate,
-  BOUNDARY_CONFIG,
 } from '../../../../lib/eva/reality-gates.js';
 
 describe('LEGACY_GATE_THRESHOLDS', () => {
@@ -36,19 +35,26 @@ describe('LEGACY_GATE_THRESHOLDS', () => {
     }
   });
 
-  test('matches BOUNDARY_CONFIG values for shared boundaries', () => {
-    // LEGACY_GATE_THRESHOLDS covers boundaries 5->6, 9->10, 12->13, 17->18, 23->24
-    // BOUNDARY_CONFIG covers boundaries 5->6, 9->10, 12->13, 17->18, 23->24
-    // They share 5->6, 12->13, 17->18 with identical artifact types.
-    // 9->10 and last boundary differ (legacy has old artifact types, config was updated).
-    const sharedBoundaries = ['5->6', '12->13', '17->18'];
-    for (const boundary of sharedBoundaries) {
-      const config = BOUNDARY_CONFIG[boundary];
-      for (const artifact of config.required_artifacts) {
-        expect(LEGACY_GATE_THRESHOLDS[boundary][artifact.artifact_type])
-          .toBe(artifact.min_quality_score);
-      }
-    }
+  test('exposes the corrected gate_boundary_config artifact-type thresholds', () => {
+    // SD-LEO-INFRA-REALITY-GATE-ARTIFACT-001 FR-3: LEGACY_GATE_THRESHOLDS is now a
+    // synchronous fallback mirroring the corrected `gate_boundary_config` seeds. Its
+    // artifact_type keys are the canonical phase-prefixed types — intentionally distinct
+    // from the deprecated hardcoded BOUNDARY_CONFIG fallback in reality-gates.js (the two
+    // are independently sourced and no longer share artifact types per boundary).
+    expect(LEGACY_GATE_THRESHOLDS['5->6']).toEqual({
+      truth_idea_brief: 0.5,
+      truth_validation_decision: 0.6,
+      truth_financial_model: 0.6,
+    });
+    expect(LEGACY_GATE_THRESHOLDS['12->13']).toEqual({
+      engine_business_model_canvas: 0.7,
+      identity_persona_brand: 0.5,
+      identity_gtm_sales_strategy: 0.5,
+    });
+    expect(LEGACY_GATE_THRESHOLDS['17->18']).toEqual({
+      system_devils_advocate_review: 0.6,
+      blueprint_financial_projection: 0.5,
+    });
   });
 });
 
@@ -78,17 +84,24 @@ describe('resolveGateThreshold', () => {
   test('returns legacy default when profile has no override for artifact type', () => {
     const profile = {
       gate_thresholds: {
-        '5->6': { problem_statement: 0.4 },
+        '5->6': { truth_idea_brief: 0.4 },
       },
     };
 
-    const result = resolveGateThreshold(profile, '5->6', 'value_proposition');
+    // truth_validation_decision is a current 5->6 legacy key (0.6)
+    const result = resolveGateThreshold(profile, '5->6', 'truth_validation_decision');
     expect(result).toBe(0.6); // Legacy default
   });
 
-  test('returns legacy default when profile is null', () => {
+  test('returns 0.5 fallback when profile is null and artifact type is not in legacy boundary', () => {
+    // 'problem_statement' is no longer a 5->6 legacy key; falls through to the 0.5 floor.
     const result = resolveGateThreshold(null, '5->6', 'problem_statement');
-    expect(result).toBe(0.6); // Legacy default
+    expect(result).toBe(0.5); // SECURITY C4 fallback floor
+  });
+
+  test('returns legacy default for a current legacy artifact type when profile is null', () => {
+    const result = resolveGateThreshold(null, '5->6', 'truth_idea_brief');
+    expect(result).toBe(0.5); // Legacy default
   });
 
   test('returns legacy default when profile has empty gate_thresholds', () => {
@@ -125,14 +138,14 @@ describe('resolveAllGateThresholds', () => {
   test('merges profile overrides with legacy defaults', () => {
     const profile = {
       gate_thresholds: {
-        '5->6': { problem_statement: 0.4 },
+        '5->6': { truth_idea_brief: 0.4 },
       },
     };
 
     const result = resolveAllGateThresholds(profile, '5->6');
-    expect(result.problem_statement).toBe(0.4); // Profile override
-    expect(result.target_market_analysis).toBe(0.5); // Legacy default
-    expect(result.value_proposition).toBe(0.6); // Legacy default
+    expect(result.truth_idea_brief).toBe(0.4); // Profile override
+    expect(result.truth_validation_decision).toBe(0.6); // Legacy default
+    expect(result.truth_financial_model).toBe(0.6); // Legacy default
   });
 
   test('returns empty object for unknown boundary', () => {
@@ -176,13 +189,15 @@ describe('evaluateRealityGate with profileThresholds', () => {
   }
 
   test('uses profile threshold instead of BOUNDARY_CONFIG default', async () => {
+    // BOUNDARY_CONFIG[5->6] requires truth_problem_statement(0.6),
+    // truth_target_market_analysis(0.5), truth_value_proposition(0.6).
     const artifacts = [
-      { artifact_type: 'problem_statement', quality_score: 0.55, file_url: null, is_current: true },
-      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
-      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+      { artifact_type: 'truth_problem_statement', quality_score: 0.55, file_url: null, is_current: true },
+      { artifact_type: 'truth_target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'truth_value_proposition', quality_score: 0.6, file_url: null, is_current: true },
     ];
 
-    // Default threshold for problem_statement is 0.6, so 0.55 would fail
+    // Default threshold for truth_problem_statement is 0.6, so 0.55 would fail
     // But with profile override of 0.5, it should pass
     const result = await evaluateRealityGate({
       ventureId: 'test-uuid',
@@ -190,21 +205,23 @@ describe('evaluateRealityGate with profileThresholds', () => {
       toStage: 6,
       supabase: createMockSupabase(artifacts),
       logger: silentLogger,
-      profileThresholds: { problem_statement: 0.5 },
+      profileThresholds: { truth_problem_statement: 0.5 },
     });
 
     expect(result.status).toBe('PASS');
     expect(result.profile_thresholds_applied).toBe(true);
   });
 
-  test('fails when score below profile threshold even though above legacy', async () => {
+  test('blocks when score below profile threshold even though above default', async () => {
+    // BOUNDARY_CONFIG[12->13] requires engine_business_model_canvas(0.7),
+    // blueprint_technical_architecture(0.6), blueprint_project_plan(0.5).
     const artifacts = [
       { artifact_type: 'engine_business_model_canvas', quality_score: 0.75, file_url: null, is_current: true },
-      { artifact_type: 'technical_architecture', quality_score: 0.65, file_url: null, is_current: true },
-      { artifact_type: 'project_plan', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'blueprint_technical_architecture', quality_score: 0.65, file_url: null, is_current: true },
+      { artifact_type: 'blueprint_project_plan', quality_score: 0.5, file_url: null, is_current: true },
     ];
 
-    // Legacy threshold for business_model_canvas is 0.7 (would pass at 0.75)
+    // Default threshold for engine_business_model_canvas is 0.7 (would pass at 0.75)
     // Profile overrides to 0.8 (should fail at 0.75)
     const result = await evaluateRealityGate({
       ventureId: 'test-uuid',
@@ -215,7 +232,9 @@ describe('evaluateRealityGate with profileThresholds', () => {
       profileThresholds: { engine_business_model_canvas: 0.8 },
     });
 
-    expect(result.status).toBe('FAIL');
+    // SUT returns BLOCKED (not FAIL) when artifacts exist but a check fails —
+    // "Chairman decides venture fate" (reality-gates.js).
+    expect(result.status).toBe('BLOCKED');
     const failReason = result.reasons.find(r =>
       r.artifact_type === 'engine_business_model_canvas' &&
       r.code === 'QUALITY_SCORE_BELOW_THRESHOLD'
@@ -227,12 +246,12 @@ describe('evaluateRealityGate with profileThresholds', () => {
 
   test('uses BOUNDARY_CONFIG default when no profile thresholds provided', async () => {
     const artifacts = [
-      { artifact_type: 'problem_statement', quality_score: 0.55, file_url: null, is_current: true },
-      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
-      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+      { artifact_type: 'truth_problem_statement', quality_score: 0.55, file_url: null, is_current: true },
+      { artifact_type: 'truth_target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'truth_value_proposition', quality_score: 0.6, file_url: null, is_current: true },
     ];
 
-    // Without profile, problem_statement at 0.55 < 0.6 default should fail
+    // Without profile, truth_problem_statement at 0.55 < 0.6 default should block.
     const result = await evaluateRealityGate({
       ventureId: 'test-uuid',
       fromStage: 5,
@@ -241,18 +260,19 @@ describe('evaluateRealityGate with profileThresholds', () => {
       logger: silentLogger,
     });
 
-    expect(result.status).toBe('FAIL');
+    // SUT returns BLOCKED (not FAIL) when a required artifact is below its default.
+    expect(result.status).toBe('BLOCKED');
     expect(result.profile_thresholds_applied).toBeUndefined();
   });
 
   test('includes threshold_overrides in result when profile applied', async () => {
     const artifacts = [
-      { artifact_type: 'problem_statement', quality_score: 0.6, file_url: null, is_current: true },
-      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
-      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+      { artifact_type: 'truth_problem_statement', quality_score: 0.6, file_url: null, is_current: true },
+      { artifact_type: 'truth_target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'truth_value_proposition', quality_score: 0.6, file_url: null, is_current: true },
     ];
 
-    const overrides = { problem_statement: 0.5, value_proposition: 0.5 };
+    const overrides = { truth_problem_statement: 0.5, truth_value_proposition: 0.5 };
 
     const result = await evaluateRealityGate({
       ventureId: 'test-uuid',

--- a/tests/unit/eva/stage-zero/paths/blueprint-browse.test.js
+++ b/tests/unit/eva/stage-zero/paths/blueprint-browse.test.js
@@ -24,10 +24,13 @@ import {
 
 const silentLogger = { log: vi.fn(), warn: vi.fn() };
 
+// SUT reads `blueprint.title` and the flat opportunity_blueprints columns
+// (problem_statement, solution_concept, target_market) via buildTemplateData —
+// not a nested `template_data` object. suggested_name resolves to blueprint.title.
 const sampleBlueprints = [
-  { id: 'bp-1', name: 'SaaS Template', category: 'saas', description: 'SaaS venture', template_data: { name: 'SaaS MVP', problem_statement: 'SaaS problem', solution: 'SaaS solution', target_market: 'B2B' }, is_active: true },
-  { id: 'bp-2', name: 'E-commerce Template', category: 'ecommerce', description: 'E-commerce venture', template_data: { name: 'Store', problem_statement: 'Commerce problem', solution: 'Store solution', target_market: 'Consumers' }, is_active: true },
-  { id: 'bp-3', name: 'SaaS Pro', category: 'saas', description: 'Advanced SaaS', template_data: { name: 'SaaS Pro', problem_statement: 'Advanced problem', solution: 'Pro solution', target_market: 'Enterprise' }, is_active: true },
+  { id: 'bp-1', title: 'SaaS MVP', category: 'saas', summary: 'SaaS venture', problem_statement: 'SaaS problem', solution_concept: 'SaaS solution', target_market: 'B2B', is_active: true },
+  { id: 'bp-2', title: 'Store', category: 'ecommerce', summary: 'E-commerce venture', problem_statement: 'Commerce problem', solution_concept: 'Store solution', target_market: 'Consumers', is_active: true },
+  { id: 'bp-3', title: 'SaaS Pro', category: 'saas', summary: 'Advanced SaaS', problem_statement: 'Advanced problem', solution_concept: 'Pro solution', target_market: 'Enterprise', is_active: true },
 ];
 
 function createMockSupabase(blueprints = sampleBlueprints) {

--- a/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
+++ b/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
@@ -207,6 +207,10 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
       differentiation_strategy: 'Automate the entire workflow with AI',
       delta_gate: { verdict: 'seedable', score: 0.7, threshold: 0.5, reason: 'defensible, seedable' },
       sanitization_status: 'passed',
+      // SD-LEO-INFRA-SURFACE-DIFFERENTIATION-BOARD-001 FR-1: the projection now also
+      // surfaces the board strategy's unique_advantages as opportunity cards. The
+      // seededBoard fixture has no unique_advantages, so this is an empty array.
+      differentiation_opportunities: [],
     });
     // canonical record ids still surfaced in metadata
     expect(result.metadata.canonical_ci_record_ids).toEqual(['ci-rec-1', 'ci-rec-2']);

--- a/tests/unit/eva/stage-zero/stage-of-death-predictor.test.js
+++ b/tests/unit/eva/stage-zero/stage-of-death-predictor.test.js
@@ -89,7 +89,7 @@ describe('stage-of-death-predictor', () => {
       expect(result).toHaveProperty('archetype', 'democratizer');
     });
 
-    it('death_stage is between 1 and 25', () => {
+    it('death_stage is between 1 and 26', () => {
       const result = predictStageOfDeath({
         archetype: 'democratizer',
         componentScores: WEAK_MOAT_SCORES,
@@ -98,7 +98,7 @@ describe('stage-of-death-predictor', () => {
       });
 
       expect(result.death_stage).toBeGreaterThanOrEqual(1);
-      expect(result.death_stage).toBeLessThanOrEqual(25);
+      expect(result.death_stage).toBeLessThanOrEqual(26);
     });
 
     it('probability is between 0 and 1', () => {
@@ -192,14 +192,15 @@ describe('stage-of-death-predictor', () => {
   });
 
   describe('buildMortalityCurve', () => {
-    it('returns 25 stage entries', () => {
+    it('returns one entry per stage (TOTAL_STAGES)', () => {
       const curve = buildMortalityCurve({
         archetypeData: ARCHETYPE_WITH_HISTORY,
         profileWeights: LEGACY_WEIGHTS,
         componentScores: STRONG_SCORES,
       });
 
-      expect(Object.keys(curve)).toHaveLength(25);
+      expect(TOTAL_STAGES).toBe(26);
+      expect(Object.keys(curve)).toHaveLength(TOTAL_STAGES);
     });
 
     it('all mortality rates are non-negative', () => {
@@ -237,7 +238,7 @@ describe('stage-of-death-predictor', () => {
       const stage12 = curve[12];
       const avgOther = Object.entries(curve)
         .filter(([s]) => s !== '5' && s !== '12')
-        .reduce((sum, [, v]) => sum + v, 0) / 23;
+        .reduce((sum, [, v]) => sum + v, 0) / 24;
 
       expect(stage5).toBeGreaterThan(avgOther);
       expect(stage12).toBeGreaterThan(avgOther);

--- a/tests/unit/eva/stage-zero/synthesis/archetype-mapping.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/archetype-mapping.test.js
@@ -34,6 +34,6 @@ describe('archetype-mapping', () => {
   });
 
   it('maps experience_designer (the failing case) correctly', () => {
-    expect(toDbArchetype('experience_designer')).toBe('content');
+    expect(toDbArchetype('experience_designer')).toBe('media');
   });
 });

--- a/tests/unit/eva/stage-zero/synthesis/design-evaluation.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/design-evaluation.test.js
@@ -12,21 +12,14 @@ import {
 function createMockLLMClient(responseJson) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify(responseJson) }],
-        usage: { input_tokens: 100, output_tokens: 200 },
-      }),
-    },
+    complete: vi.fn().mockResolvedValue(JSON.stringify(responseJson)),
   };
 }
 
 function createFailingLLMClient(errorMessage) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
-    },
+    complete: vi.fn().mockRejectedValue(new Error(errorMessage)),
   };
 }
 
@@ -87,24 +80,19 @@ describe('evaluateDesignPotential', () => {
       llmClient: client,
     });
 
-    expect(client.messages.create).toHaveBeenCalledTimes(1);
-    const callArgs = client.messages.create.mock.calls[0][0];
-    expect(callArgs.model).toBe('test-model');
-    expect(callArgs.max_tokens).toBe(1500);
-    expect(callArgs.messages).toHaveLength(1);
-    expect(callArgs.messages[0].role).toBe('user');
-    expect(callArgs.messages[0].content).toContain('DesignFirst');
+    expect(client.complete).toHaveBeenCalledTimes(1);
+    const callArgs = client.complete.mock.calls[0];
+    // SUT calls: client.complete(systemPrompt, userPrompt, { max_tokens, timeout })
+    expect(callArgs[0]).toBe('');
+    expect(callArgs[1]).toContain('DesignFirst');
+    expect(callArgs[2].max_tokens).toBe(8192);
+    expect(callArgs[2].timeout).toBe(120000);
   });
 
   test('returns default result when LLM response is unparseable', async () => {
     const client = {
       _model: 'test-model',
-      messages: {
-        create: vi.fn().mockResolvedValue({
-          content: [{ text: 'This is not JSON at all' }],
-          usage: { input_tokens: 50, output_tokens: 30 },
-        }),
-      },
+      complete: vi.fn().mockResolvedValue('This is not JSON at all'),
     };
 
     const result = await evaluateDesignPotential(mockPathOutput, {
@@ -259,15 +247,10 @@ describe('evaluateDesignPotential', () => {
     expect(result.design_opportunities).toEqual([]);
   });
 
-  test('handles empty content array from LLM', async () => {
+  test('handles empty content from LLM', async () => {
     const client = {
       _model: 'test-model',
-      messages: {
-        create: vi.fn().mockResolvedValue({
-          content: [],
-          usage: { input_tokens: 10, output_tokens: 0 },
-        }),
-      },
+      complete: vi.fn().mockResolvedValue(''),
     };
 
     const result = await evaluateDesignPotential(mockPathOutput, {

--- a/tests/unit/eva/stage-zero/synthesis/narrative-risk.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/narrative-risk.test.js
@@ -48,20 +48,14 @@ const validLLMResponse = {
 function createMockLLMClient(responseJson) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify(responseJson) }],
-      }),
-    },
+    complete: vi.fn().mockResolvedValue(JSON.stringify(responseJson)),
   };
 }
 
 function createFailingLLMClient(errorMessage) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
-    },
+    complete: vi.fn().mockRejectedValue(new Error(errorMessage)),
   };
 }
 
@@ -119,11 +113,7 @@ describe('analyzeNarrativeRisk', () => {
   test('returns default result when LLM returns unparseable text', async () => {
     const client = {
       _model: 'test-model',
-      messages: {
-        create: vi.fn().mockResolvedValue({
-          content: [{ text: 'I cannot analyze narrative risk in JSON format.' }],
-        }),
-      },
+      complete: vi.fn().mockResolvedValue('I cannot analyze narrative risk in JSON format.'),
     };
     const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
 

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -99,7 +99,7 @@ beforeEach(() => {
 });
 
 describe('runSynthesis', () => {
-  test('runs all 12 synthesis components', async () => {
+  test('runs all 14 synthesis components', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
 
     expect(crossReferenceIntellectualCapital).toHaveBeenCalledWith(validPathOutput, expect.anything());
@@ -115,8 +115,8 @@ describe('runSynthesis', () => {
     expect(analyzeNarrativeRisk).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(analyzeTechTrajectory).toHaveBeenCalledWith(validPathOutput, expect.anything());
 
-    expect(result.metadata.synthesis.components_run).toBe(12);
-    expect(result.metadata.synthesis.components_total).toBe(12);
+    expect(result.metadata.synthesis.components_run).toBe(14);
+    expect(result.metadata.synthesis.components_total).toBe(14);
   });
 
   test('handles component failure gracefully', async () => {

--- a/tests/unit/eva/stage-zero/synthesis/tech-trajectory.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/tech-trajectory.test.js
@@ -79,20 +79,14 @@ const validLLMResponse = {
 function createMockLLMClient(responseJson) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify(responseJson) }],
-      }),
-    },
+    complete: vi.fn().mockResolvedValue(JSON.stringify(responseJson)),
   };
 }
 
 function createFailingLLMClient(errorMessage) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
-    },
+    complete: vi.fn().mockRejectedValue(new Error(errorMessage)),
   };
 }
 
@@ -168,11 +162,7 @@ describe('analyzeTechTrajectory', () => {
   test('returns default result when LLM returns unparseable text', async () => {
     const client = {
       _model: 'test-model',
-      messages: {
-        create: vi.fn().mockResolvedValue({
-          content: [{ text: 'I cannot analyze technology trajectory in JSON format.' }],
-        }),
-      },
+      complete: vi.fn().mockResolvedValue('I cannot analyze technology trajectory in JSON format.'),
     };
     const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
 

--- a/tests/unit/eva/stage-zero/synthesis/virality.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/virality.test.js
@@ -46,20 +46,14 @@ const validLLMResponse = {
 function createMockLLMClient(responseJson) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockResolvedValue({
-        content: [{ text: JSON.stringify(responseJson) }],
-      }),
-    },
+    complete: vi.fn().mockResolvedValue(JSON.stringify(responseJson)),
   };
 }
 
 function createFailingLLMClient(errorMessage) {
   return {
     _model: 'test-model',
-    messages: {
-      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
-    },
+    complete: vi.fn().mockRejectedValue(new Error(errorMessage)),
   };
 }
 
@@ -104,11 +98,7 @@ describe('analyzeVirality', () => {
   test('returns default result when LLM returns unparseable text', async () => {
     const client = {
       _model: 'test-model',
-      messages: {
-        create: vi.fn().mockResolvedValue({
-          content: [{ text: 'I cannot analyze this venture in JSON format.' }],
-        }),
-      },
+      complete: vi.fn().mockResolvedValue('I cannot analyze this venture in JSON format.'),
     };
     const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
 


### PR DESCRIPTION
TEST-ONLY repair of 44 stale failing unit tests across 13 tests/unit/eva/stage-zero/ suites — production code was correct, tests lagged shipped refactors. Class A (LLM client.complete mock drift in synthesis suites), Class B (stale assertions: gate-thresholds keys, blueprint name->title, synthesis 12->14, archetype-mapping, data-pollers withRetry semantics), Class C (stage-of-death 25->26). Also fixes the competitor-teardown TS-4 drift from SD-LEO-INFRA-SURFACE-DIFFERENTIATION-BOARD-001's projection extension. Final: 553 passed / 0 failed; git diff is test-only (zero production files). Resolves harness backlog feedback 839edd59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)