### PR TITLE
feat(SD-LEO-INFRA-PATH-SCOPED-BLOCKING-001): path-scoped blocking CI gate for verified-green unit suites (seed: stage-zero)

### DIFF
--- a/.github/workflows/protected-unit-suites.yml
+++ b/.github/workflows/protected-unit-suites.yml
@@ -1,0 +1,74 @@
+name: protected-unit-suites
+
+# Path-scoped BLOCKING vitest gates for verified-green unit-test directories.
+#
+# SD-LEO-INFRA-PATH-SCOPED-BLOCKING-001. Generalizes the path-scoped blocking
+# pattern already used by can-auto-advance-tests.yml and s19-design-prompts-tests.yml
+# into ONE matrix-driven workflow.
+#
+# WHY: the broad unit suite runs ADVISORY (test-coverage.yml uses continue-on-error),
+# gated only by a COUNT-BASED, suite-wide delta (scripts/compare-to-main-snapshot.mjs)
+# that cannot protect a specific freshly-greened directory from silently re-rotting
+# (44 stage-zero tests drifted red unnoticed -> SD-LEO-INFRA-REPAIR-STALE-STAGE-001, #4158).
+# Each matrix entry below hard-gates ONE directory: any failing test = red check.
+#
+# ADMISSION CRITERION: add a directory to matrix.suite ONLY after its tests are
+# verified green in CI across >=2 consecutive runs (NOT just one local run).
+# Adding a directory is a two-list edit:
+#   (1) one matrix.suite entry  { name, test_path },  AND
+#   (2) append that directory's production + test globs to on.pull_request.paths.
+# See docs/reference/protected-unit-suites.md (admission rule, how-to, tradeoffs,
+# and the list of deferred candidate directories).
+
+on:
+  pull_request:
+    paths:
+      # --- stage-zero (seed; 36 files, 553/0 as of PR #4158) ---
+      - 'lib/eva/stage-zero/**'          # production SUTs: a prod-only break must still trip the gate
+      - 'tests/unit/eva/stage-zero/**'   # the tests themselves
+      # self-validation: edits to this workflow re-run it (mirrors can-auto-advance L14 / s19 L20)
+      - '.github/workflows/protected-unit-suites.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  protected:
+    # Job/check name is the suite name -> the PR check reads "protected-unit-suites / stage-zero".
+    name: ${{ matrix.suite.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      # Don't cancel sibling suites if one fails — each protected directory reports independently.
+      fail-fast: false
+      matrix:
+        suite:
+          - name: stage-zero
+            test_path: tests/unit/eva/stage-zero/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --no-audit --no-fund
+      - name: Run ${{ matrix.suite.name }} unit tests (BLOCKING)
+        # NO continue-on-error: a failing test fails the job (red check). That is the
+        # whole point — stricter and directory-scoped, unlike the count-based suite-wide ratchet.
+        env:
+          # Defensive: tests/setup.js falls back to https://test.invalid.local when
+          # SUPABASE_URL is unset, and any test that issues a real .from() call then
+          # hangs until vitest's 60s timeout force-kills the worker (exit 1 = false red)
+          # — see test-coverage.yml + SD-LEO-INFRA-VITEST-EXITS-61S-001. Passing the
+          # secrets gives any DB-touching test a real endpoint; hermetic (mocked) tests ignore them.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: npx vitest run ${{ matrix.suite.test_path }}

--- a/docs/reference/protected-unit-suites.md
+++ b/docs/reference/protected-unit-suites.md
@@ -1,0 +1,124 @@
+# Protected Unit Suites
+
+Path-scoped, **blocking** CI gates for unit-test directories that are verified green,
+so they cannot silently re-rot.
+
+## Metadata
+
+- **Source SD**: SD-LEO-INFRA-PATH-SCOPED-BLOCKING-001
+- **Effective**: 2026-06-01
+- **Status**: ACTIVE
+- **Workflow**: [`.github/workflows/protected-unit-suites.yml`](../../.github/workflows/protected-unit-suites.yml)
+- **Generalizes**: `can-auto-advance-tests.yml`, `s19-design-prompts-tests.yml`
+- **Complements (does NOT replace)**: SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 (the suite-wide ratchet; completed)
+
+## Why this exists
+
+The broad unit suite runs **advisory** in CI: `test-coverage.yml` executes it with
+`continue-on-error: true`, and its authoritative gate is a **count-based, suite-wide
+delta** (`scripts/compare-to-main-snapshot.mjs`) that compares only the *total*
+`numFailedTests` against the latest `main` snapshot and rewrites that baseline on every
+push to main.
+
+That design is correct for burning down the ~500 pre-existing failures without blocking
+unrelated PRs — but it **cannot protect a specific freshly-greened directory** from
+re-rotting: a handful of new failures in one area hides inside the global count, or is
+offset by a same-PR fix elsewhere. That is exactly how 44 stage-zero unit tests drifted
+red on `main` unnoticed (repaired by **SD-LEO-INFRA-REPAIR-STALE-STAGE-001**, PR #4158).
+
+The repo already protects two *individual* high-value test files with dedicated
+path-scoped **blocking** workflows (`can-auto-advance-tests.yml`,
+`s19-design-prompts-tests.yml`). This workflow **generalizes that proven pattern** into a
+single matrix-driven file so any provably-green directory can be locked in cheaply.
+
+## How it works
+
+`protected-unit-suites.yml` has a job-level `strategy.matrix.suite` list. Each entry maps
+a directory `name` to a vitest `test_path`. On a PR that touches any protected path, the
+workflow triggers and runs `npx vitest run <test_path>` for each entry as a **blocking**
+job (no `continue-on-error`): any failing test = a red check. The check name is
+`protected-unit-suites / <name>`.
+
+This is **stricter and directory-scoped** — the opposite of the count-based, suite-wide
+ratchet. It does not touch `test-coverage.yml` or the ratchet.
+
+## What is gated today
+
+| Directory | Files | Status |
+|-----------|------:|--------|
+| `tests/unit/eva/stage-zero/` | 36 | **Gated** — 553/0 green (seed; PR #4158). Verified green with `CI_TEARDOWN_PERSIST` both set and unset (hermetic). |
+
+## Admission criterion (READ BEFORE ADDING A DIRECTORY)
+
+> A directory may be added to the matrix **only after its tests are verified green in CI
+> across ≥2 consecutive runs** — not on the strength of a single local run.
+
+**Why the discipline:** "green right now" is not the same as "safe to hard-gate." Much of
+the broad suite is only intermittently green (env/timing-dependent; see the
+`tests/setup.js` invalid-host fallback note in `test-coverage.yml`). A **flaky blocking
+gate is strictly worse than no gate** — it red-lights unrelated PRs and erodes trust in
+CI. Earn each gate with verified stability.
+
+## How to add a protected directory
+
+It is a two-list edit:
+
+1. Confirm the directory has been **green in CI for ≥2 consecutive runs**.
+2. Add one entry to `strategy.matrix.suite`:
+   ```yaml
+   - name: <short-name>
+     test_path: tests/unit/<dir>/
+   ```
+3. Append that directory's **production** and **test** globs to `on.pull_request.paths`
+   (both — a prod-only change that breaks the suite must still trip the gate):
+   ```yaml
+   - 'lib/<prod-dir>/**'
+   - 'tests/unit/<dir>/**'
+   ```
+4. (Optional, to make the check *block* merge) ask a repo admin to add
+   `protected-unit-suites / <name>` to the branch-protection **required status checks**.
+
+## Making a check block merge
+
+The workflow produces a red/green check. To make a red check actually **block merge**, a
+repo admin adds `protected-unit-suites / <name>` to the branch-protection required status
+checks — a one-time activation, analogous to enabling a feature flag. (The two precedent
+workflows are activated the same way.)
+
+## Cross-trigger tradeoff
+
+`on.pull_request.paths` is a **union** across all entries, so a PR touching directory A
+also runs directory B's job. With the admission criterion (≥2 green CI runs) this is safe
+— admitted directories rarely false-red, and a genuine regression in B *should* surface.
+If coupling ever becomes a problem, switch to per-job path isolation (e.g.
+`dorny/paths-filter@v3` keyed per suite); this is a deliberate future option, not needed
+for the current seed.
+
+## Deferred candidates (audited 2026-06-01, NOT yet admitted)
+
+Local-only audit (`CI_TEARDOWN_PERSIST` unset). None are admitted — each must first meet
+the ≥2-green-CI-runs criterion. Directories with pre-existing failures belong to the
+suite-wide ratchet's burndown (SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001), not here.
+
+| Directory | Local result | Reason deferred |
+|-----------|--------------|-----------------|
+| `tests/unit/orchestrator-child/` | 16/16 green (local) | **Candidate** — promote after ≥2 green CI runs |
+| `tests/unit/sub-agents/` | 1 failed / 140 | Has a pre-existing failure; repair before admitting |
+| `tests/unit/gates/` | 3 failed / 218 | Pre-existing failures; repair before admitting |
+| `tests/unit/risk-classifier/` | 5 failed / 137 | Pre-existing failures; repair before admitting |
+
+(Other high-value directories — `handoff`, `complete-quick-fix`, `governance`, `scripts`,
+`lib` — are not yet audited and remain candidates pending a green-state check.)
+
+## Relationship to the suite-wide ratchet
+
+This gate is **complementary** to SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001 (completed), which
+owns the advisory suite + count-based delta and returns to strict mode at ≤100 main
+failures. This workflow does not modify `test-coverage.yml`, the ratchet, or any
+production code — it only locks in corners that are provably green so they cannot regress
+before the ratchet sunsets.
+
+## Rollback
+
+Revert the commit that adds (or extends) this workflow. No production, migration, or data
+impact.

--- a/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
+++ b/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
@@ -9,7 +9,7 @@
  * - Runs gap analysis for multiple competitors
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../../../../lib/llm/client-factory.js', () => ({
   getValidationClient: vi.fn(() => mockLlmClient),
@@ -161,6 +161,22 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     strategy: { angle: 'Automate the entire workflow with AI' },
     sanitization_status: 'passed',
   };
+
+  // Hermetic env control (SD-LEO-INFRA-PATH-SCOPED-BLOCKING-001): persist is enabled
+  // by EITHER the `persistToCanonical` dep OR the CI_TEARDOWN_PERSIST env fallback
+  // (SUT competitor-teardown.js:71-72). The flag-ON cases below opt in via the dep, so
+  // clear the env fallback here — otherwise an ambient CI_TEARDOWN_PERSIST=true (e.g. a
+  // local .env after the capability was enabled) flips the flag-OFF case (TS-3) and the
+  // suite goes red only locally. This keeps the suite green regardless of flag state.
+  let savedTeardownFlag;
+  beforeEach(() => {
+    savedTeardownFlag = process.env.CI_TEARDOWN_PERSIST;
+    delete process.env.CI_TEARDOWN_PERSIST;
+  });
+  afterEach(() => {
+    if (savedTeardownFlag === undefined) delete process.env.CI_TEARDOWN_PERSIST;
+    else process.env.CI_TEARDOWN_PERSIST = savedTeardownFlag;
+  });
 
   test('TS-3: flag OFF — no persist, no board, no result_extras (no regression)', async () => {
     const persistSpy = vi.fn();


### PR DESCRIPTION
## Summary
Adds `.github/workflows/protected-unit-suites.yml` — a matrix-driven, **path-scoped BLOCKING** vitest gate that hard-gates a verified-green unit-test directory against silent re-rot. Generalizes the repo's two existing path-scoped blocking precedents (`can-auto-advance-tests.yml`, `s19-design-prompts-tests.yml`) into one extensible workflow.

- **Seed**: `tests/unit/eva/stage-zero/` (36 files, 553/0; verified green with `CI_TEARDOWN_PERSIST` both set and unset).
- **Why**: the suite-wide ratchet (`test-coverage.yml` + `compare-to-main-snapshot.mjs`) is count-based and cannot protect one directory from re-rot — exactly how 44 stage-zero tests drifted red (repaired by #4158). Complements (does NOT touch) that ratchet (SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001, completed).
- **Admission criterion**: a directory joins only after ≥2 green CI runs (see `docs/reference/protected-unit-suites.md`).
- **Folded-in hermetic fix**: `competitor-teardown.test.js` TS-3 relied on `CI_TEARDOWN_PERSIST` being ambiently unset; this session enabled that flag in `.env`, so the test now clears the env fallback in its describe block (flag-ON cases opt in via the dep). Seed suite is green under any flag state.

## Verification
- `npx vitest run tests/unit/eva/stage-zero/` → 553/0 with the flag both set and unset.
- This PR self-validates: it touches `.github/workflows/protected-unit-suites.yml` and `tests/unit/eva/stage-zero/**`, so the new `protected-unit-suites / stage-zero` check runs here.
- Diff = workflow + reference doc + the one hermetic test fix. Zero production (lib/scripts/src) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
