### PR TITLE
feat(SD-LEO-INFRA-AUTO-EXECUTE-LEO-002): session-hosted leo_bridge build consumer

### DIFF
--- a/.claude/commands/leo-build-venture.md
+++ b/.claude/commands/leo-build-venture.md
@@ -1,0 +1,89 @@
+<!-- reasoning_effort: high -->
+
+---
+description: Drive a build-ready leo_bridge venture's generated SD tree to completion (session-hosted consumer; holds at S19, never advances)
+argument-hint: [--venture-id <uuid> | --venture <name>] [--dry-run] [--max-leaves N]
+---
+
+# /leo-build-venture — leo_bridge build CONSUMER (session-hosted)
+
+You are the **session host** for the leo_bridge build consumer (SD-LEO-INFRA-AUTO-EXECUTE-LEO-002).
+The detector (`scripts/cron/leo-build-starter.mjs`) has signalled a venture as build-ready
+(orchestrator `metadata.build_ready_at`). This skill drives that venture's **nested** SD tree to
+completion by repeatedly driving the next workable **leaf** SD to LEAD-FINAL-APPROVAL via an
+`orchestrator-child-agent` teammate, until no draft/active descendant remains.
+
+The pure logic (introspection, bounds, completion, finalize) lives in
+`lib/eva/bridge/venture-build-consumer.js`. This skill is the **driver** the lib's `runConsume`
+expects — you ARE `driveLeaf`, because per-child builds need a live Claude session (Task/TeamCreate).
+
+## ⚠️ NEVER-ADVANCE invariant (RCA a14ff998 — the S19 gate-bypass incident)
+
+You MUST NOT, under any circumstance:
+- advance the venture, write `ventures.current_lifecycle_stage`, or call any `_advanceStage` path
+- create or approve a `chairman_decision`, set `chairman_approved`, or approve a vision
+- treat a `cancelled` child as something to force-complete (cancelled is an accepted terminal)
+
+The venture **stays at Stage 19** the entire time. The existing `stage-execution-worker` advances
+S19→S20 **itself**, via its existing exit-gated path, once every child is terminal. You only drive
+the child SDs and (optionally) run `--finalize` to set the idempotency marker + idle-nudge.
+
+## Step 1 — Resolve the venture and confirm eligibility
+
+Determine the `<venture-id>` (from `--venture-id`, or resolve `--venture <name>` against
+`ventures.name`). Then introspect — this makes **zero writes**:
+
+```bash
+node lib/eva/bridge/venture-build-consumer.js --venture-id <venture-id> --dry-run
+```
+
+- If it prints `skipped=true` (reason `not_leo_bridge`, `no_approved_l2_vision`, `not_at_s19`,
+  `already_consumed`, …) → **STOP** and report the reason. Do not drive.
+- If it prints `nextLeaf=(none)` and the tree is complete → go to Step 3 (finalize).
+- Otherwise it prints the next workable **LEAF** sd_key (a grandchild, not just a child-orchestrator)
+  and the `workableLeaves` count. Note the bounds: a per-venture start budget (`--max-leaves`,
+  default 60), a wall-clock cap, and a per-leaf attempt cap of 2.
+
+If `--dry-run` was passed by the operator, stop here after reporting — that is the smoke demo.
+
+## Step 2 — Drive loop (bounded, fail-closed)
+
+Track: `leavesDriven` (start budget), `attemptsByLeaf` (per-leaf attempt cap = 2), and wall-clock.
+Repeat:
+
+1. Run the `--dry-run` introspection again to get the current `nextLeaf` and `workableLeaves`.
+   - `skipped`/complete/`nextLeaf=(none)` → exit the loop.
+2. **Bounds check** — if `leavesDriven >= max-leaves`, the wall-clock cap is exceeded, or this leaf
+   has already been attempted twice, **STOP the loop and HOLD** (leave the venture at S19). Report
+   which bound tripped. Do NOT spin.
+3. **Drive the leaf** — spawn an `orchestrator-child-agent` teammate (via the Task tool) whose job is
+   to take SD `<nextLeaf>` through its **full LEO cycle to LEAD-FINAL-APPROVAL** in its own worktree
+   (LEAD-TO-PLAN → PLAN-TO-EXEC → EXEC → PLAN-TO-LEAD → LEAD-FINAL-APPROVAL, with all sub-agent
+   evidence — the child runs the normal protocol). It MUST NOT touch the venture stage or any
+   chairman/vision row. Increment `attemptsByLeaf[nextLeaf]` and `leavesDriven`.
+4. **Verify** — re-query the SD's status. If it reached `completed`, continue the loop (the next
+   introspection will surface the next leaf; child-orchestrators bubble-complete automatically). If
+   it did not, loop again (the same leaf will be re-selected until its attempt cap, then HOLD per
+   step 2).
+
+This is exactly the algorithm of `runConsume` in the lib — keep it identical; the lib's unit tests
+(TS-1..TS-11) are the contract.
+
+## Step 3 — Finalize (only when the tree is complete)
+
+When the loop exits because the tree is complete, set the idempotency marker and idle-nudge the
+worker (safe — it only writes when genuinely complete, never advances):
+
+```bash
+node lib/eva/bridge/venture-build-consumer.js --venture-id <venture-id> --finalize
+```
+
+Report: leaves driven, completion status, and whether the idle-nudge fired. The
+`stage-execution-worker` will advance the venture S19→S20 on its next poll — confirm by re-reading
+`ventures.current_lifecycle_stage` (it is the WORKER, not you, that advances it).
+
+## Step 4 — Report
+
+Summarize: venture, leaves driven / total, completed vs held (and which bound if held), and the
+final venture stage. If HELD, the venture is safe at S19 and a later `/leo-build-venture` re-run
+resumes from the remaining draft leaves (idempotent — `build_consumed_at` blocks a completed re-run).

--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+/**
+ * venture-build-consumer — the CONSUMER half of the leo_bridge automatic venture-build pipeline.
+ *
+ * SD: SD-LEO-INFRA-AUTO-EXECUTE-LEO-002 (follow-on to the detector SD-LEO-INFRA-AUTO-EXECUTE-LEO-001).
+ *
+ * The detector (scripts/cron/leo-build-starter.mjs) signals a leo_bridge venture parked at Stage 19
+ * with a generated-but-unstarted SD tree (orchestrator metadata.build_ready_at). NOTHING consumes
+ * that signal today. This module is the OUTER TREE-WALKER that drives the venture's NESTED SD tree
+ * to completion: it repeatedly selects the next workable LEAF and drives it through its full LEO
+ * cycle to LEAD-FINAL-APPROVAL (via an injected driveLeaf — the live session spawns the
+ * orchestrator-child-agent teammate), until no draft/active descendant remains. Parent
+ * orchestrators auto-complete by bubble-up. It is bounded (start budget, wall-clock, per-leaf
+ * attempt cap) and fail-closed (a stuck/failing leaf or a bound STOPS the walk and leaves the
+ * venture in a safe Stage-19 HOLD).
+ *
+ * The pure introspection + bounded loop live here (headlessly testable); the per-leaf BUILD needs a
+ * live Claude session (Task/TeamCreate via orchestrator-child-agent), so the production driver is
+ * the .claude/commands/leo-build-venture skill, which hosts driveLeaf. The CLI here supports only
+ * --dry-run introspection (it will NOT drive headlessly).
+ *
+ * NEVER-ADVANCE invariant (RCA a14ff998 — the S19 gate-bypass incident). This module:
+ *   - NEVER advances the venture, adds an advance path, or writes the venture lifecycle stage column
+ *   - NEVER creates or approves a governance decision, sets the vision-approved flag, or approves a vision
+ *   - drives child SDs only; the existing stage-execution-worker advances Stage 19 to Stage 20 itself,
+ *     via its existing exit-gated path, once every child reaches a terminal status.
+ * The only venture write is the OPTIONAL orchestrator_state='idle' accelerator nudge (conditional on
+ * a currently-blocked state, a no-op while the build is incomplete) which merely hands control back
+ * to the authoritative worker a poll cycle sooner. An executable static-source guardrail test
+ * enforces this invariant. Exit codes: 0 healthy / 1 operational issue / 2 fatal misconfiguration.
+ *
+ * Usage:
+ *   node lib/eva/bridge/venture-build-consumer.js --venture-id <uuid> --dry-run   # introspect, ZERO writes
+ *   (a real build is session-hosted: invoke the /leo-build-venture skill in a live Claude session)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import pg from 'pg';
+
+export const S19 = 19;
+export const NON_TERMINAL = ['draft', 'active'];
+export const TERMINAL = ['completed', 'cancelled', 'archived'];
+const VENTURE_DEAD = ['killed', 'retired', 'cancelled', 'archived'];
+
+export const DEFAULT_BOUNDS = Object.freeze({
+  maxLeaves: 60,                     // per-venture start budget: max leaf drives per consume run
+  wallClockMs: 6 * 60 * 60 * 1000,   // 6h wall-clock cap
+  maxAttemptsPerLeaf: 2,             // per-leaf attempt cap (DISTINCT from the inner 50-iter children cap)
+});
+
+export function parseArgs(argv) {
+  const args = { ventureId: null, dryRun: false, finalize: false, once: false, help: false, bounds: { ...DEFAULT_BOUNDS } };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--venture-id' && argv[i + 1]) args.ventureId = argv[++i];
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--finalize') args.finalize = true;
+    else if (a === '--once') args.once = true;
+    else if (a === '--max-leaves' && argv[i + 1]) args.bounds.maxLeaves = Number(argv[++i]);
+    else if (a === '--wall-clock-ms' && argv[i + 1]) args.bounds.wallClockMs = Number(argv[++i]);
+    else if (a === '--max-attempts-per-leaf' && argv[i + 1]) args.bounds.maxAttemptsPerLeaf = Number(argv[++i]);
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+function buildPgClient() {
+  const conn = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.POSTGRES_URL;
+  if (!conn) return null; // graceful — fall back to the build_consumed_at marker for idempotency
+  return new pg.Client({ connectionString: conn });
+}
+
+export async function tryAdvisoryLock(client, name) {
+  if (!client) return { acquired: true, mock: true }; // no client → marker carries idempotency
+  const k = await client.query('SELECT hashtext($1)::int AS k', [name]);
+  const r = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [k.rows[0].k]);
+  return { acquired: r.rows[0].acquired === true, key: k.rows[0].k, mock: false };
+}
+
+async function releaseAdvisoryLock(client, key) {
+  if (!client || key == null) return;
+  try { await client.query('SELECT pg_advisory_unlock($1)', [key]); } catch {}
+}
+
+/**
+ * Read-only venture eligibility — mirrors the detector / the existing S19 gate's preconditions.
+ * Never mutates. Returns { eligible, reason }.
+ */
+export async function ventureEligibility(supabase, ventureId) {
+  const { data: v } = await supabase
+    .from('ventures')
+    .select('id, build_model, status, current_lifecycle_stage, deleted_at')
+    .eq('id', ventureId)
+    .maybeSingle();
+  if (!v) return { eligible: false, reason: 'venture_not_found' };
+  if (v.deleted_at) return { eligible: false, reason: 'tombstoned' };
+  if (v.build_model !== 'leo_bridge') return { eligible: false, reason: `not_leo_bridge(${v.build_model})` };
+  if (VENTURE_DEAD.includes(v.status)) return { eligible: false, reason: `venture_${v.status}` };
+  if (v.current_lifecycle_stage !== S19) return { eligible: false, reason: `not_at_s19(${v.current_lifecycle_stage})` };
+  const { data: vision } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key')
+    .eq('venture_id', ventureId)
+    .eq('level', 'L2')
+    .eq('status', 'active')
+    .eq('chairman_approved', true)
+    .limit(1)
+    .maybeSingle();
+  if (!vision) return { eligible: false, reason: 'no_approved_l2_vision' };
+  return { eligible: true, reason: 'ok' };
+}
+
+/** The TOP orchestrator (parent_sd_id IS NULL) for the venture. Read-only. */
+export async function findTopOrchestrator(supabase, ventureId) {
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, metadata')
+    .eq('venture_id', ventureId)
+    .eq('sd_type', 'orchestrator')
+    .is('parent_sd_id', null)
+    .limit(1)
+    .maybeSingle();
+  return data || null;
+}
+
+/**
+ * Recursive plain-SELECT walk of all descendants under the top orchestrator (BFS by parent_sd_id).
+ * Plain reads only — NEVER getNextReadyChild (whose stale-claim auto-release mutates state).
+ */
+export async function fetchDescendants(supabase, topId) {
+  const all = [];
+  const seen = new Set();
+  let frontier = [topId];
+  while (frontier.length) {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status, sd_type, parent_sd_id, sequence_rank')
+      .in('parent_sd_id', frontier);
+    const next = [];
+    for (const k of (data || [])) {
+      if (seen.has(k.id)) continue;
+      seen.add(k.id); all.push(k); next.push(k.id);
+    }
+    frontier = next;
+  }
+  return all;
+}
+
+/** True when no descendant is still draft/active (aligns with the worker's terminal-tolerance). */
+export function isTreeComplete(descendants) {
+  return !descendants.some((d) => NON_TERMINAL.includes(d.status));
+}
+
+/**
+ * The workable LEAVES to drive, deepest-first then by sequence_rank: a non-terminal, non-orchestrator
+ * SD with NO non-terminal descendant of its own. Child-orchestrators are excluded (they bubble-complete
+ * via checkAndCompleteParent once their grandchildren finish — they are never driven directly).
+ */
+export function computeWorkableLeaves(descendants) {
+  const byId = new Map(descendants.map((d) => [d.id, d]));
+  const byParent = new Map();
+  for (const d of descendants) {
+    if (!byParent.has(d.parent_sd_id)) byParent.set(d.parent_sd_id, []);
+    byParent.get(d.parent_sd_id).push(d);
+  }
+  const hasNonTerminalDescendant = (id) => {
+    for (const k of (byParent.get(id) || [])) {
+      if (NON_TERMINAL.includes(k.status)) return true;
+      if (hasNonTerminalDescendant(k.id)) return true;
+    }
+    return false;
+  };
+  const depthOf = (d) => {
+    let n = 0, cur = d;
+    while (cur && cur.parent_sd_id && byId.has(cur.parent_sd_id)) { n++; cur = byId.get(cur.parent_sd_id); }
+    return n;
+  };
+  const leaves = descendants.filter((d) =>
+    NON_TERMINAL.includes(d.status) &&
+    d.sd_type !== 'orchestrator' &&
+    !hasNonTerminalDescendant(d.id),
+  );
+  leaves.sort((a, b) => depthOf(b) - depthOf(a) || (a.sequence_rank ?? 0) - (b.sequence_rank ?? 0));
+  return leaves;
+}
+
+/** Emit one observability row to system_events (payload column — there is no event_data column). */
+export async function emitEvent(supabase, eventType, payload, { ventureId, sdId, dryRun, logger = console } = {}) {
+  if (dryRun) { logger.log?.(`[venture-build-consumer] DRY: would emit ${eventType} ${JSON.stringify(payload)}`); return { emitted: false, dryRun: true }; }
+  const { error } = await supabase.from('system_events').insert({ event_type: eventType, payload, venture_id: ventureId, sd_id: sdId });
+  if (error) logger.warn?.(`[venture-build-consumer] system_events insert failed: ${error.message}`);
+  return { emitted: !error };
+}
+
+/** Mark the tree consumed (idempotency marker) — only after the tree is fully terminal. */
+export async function markConsumed(supabase, topId, { dryRun = false } = {}) {
+  if (dryRun) return { marked: false, dryRun: true };
+  const { data: fresh } = await supabase.from('strategic_directives_v2').select('metadata').eq('id', topId).maybeSingle();
+  const newMeta = { ...(fresh?.metadata || {}), build_consumed_at: new Date().toISOString(), build_consumed_by: 'venture-build-consumer' };
+  const { error } = await supabase.from('strategic_directives_v2').update({ metadata: newMeta }).eq('id', topId);
+  if (error) throw new Error(`build_consumed_at update failed: ${error.message}`);
+  return { marked: true };
+}
+
+/**
+ * OPTIONAL accelerator: conditionally flip orchestrator_state blocked->idle so the authoritative
+ * worker re-polls and advances a poll cycle sooner. Conditional + count-checked: a no-op unless the
+ * venture is currently blocked. This is NOT a stage write and NOT an advance — the worker still
+ * re-applies the real S19 gate before advancing. Call ONLY after the tree is complete.
+ */
+export async function maybeIdleNudge(supabase, ventureId, { dryRun = false } = {}) {
+  if (dryRun) return { nudged: false, dryRun: true };
+  const { data, error } = await supabase
+    .from('ventures')
+    .update({ orchestrator_state: 'idle' })
+    .eq('id', ventureId)
+    .eq('orchestrator_state', 'blocked')
+    .select('id');
+  if (error) return { nudged: false, error: error.message };
+  return { nudged: (data || []).length > 0 };
+}
+
+/**
+ * The bounded, fail-closed OUTER TREE-WALKER. driveLeaf(leaf, ctx) => { completed: boolean } is
+ * injected: the live-session skill spawns an orchestrator-child-agent teammate to take the leaf SD
+ * through its full LEO cycle to LEAD-FINAL-APPROVAL; unit tests inject a mock. The consumer NEVER
+ * advances the venture — the existing worker does that once the tree completes.
+ */
+export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFAULT_BOUNDS, dryRun = false, logger = console, now = () => Date.now() }) {
+  const result = { ventureId, drivenLeaves: [], completed: false, held: false, skipped: false, reason: null, dryRun };
+
+  const elig = await ventureEligibility(supabase, ventureId);
+  if (!elig.eligible) {
+    result.skipped = true; result.reason = elig.reason;
+    await emitEvent(supabase, 'LEO_BUILD_SKIPPED', { reason: elig.reason }, { ventureId, dryRun, logger });
+    return result;
+  }
+  const top = await findTopOrchestrator(supabase, ventureId);
+  if (!top) { result.skipped = true; result.reason = 'no_top_orchestrator'; return result; }
+  if (top.metadata?.build_consumed_at) {
+    result.skipped = true; result.reason = 'already_consumed';
+    return result;
+  }
+
+  const start = now();
+  const attemptsByLeaf = new Map();
+  let leavesDriven = 0;
+
+  while (true) {
+    if (now() - start > bounds.wallClockMs) { result.held = true; result.reason = 'wall_clock_exceeded'; break; }
+    if (leavesDriven >= bounds.maxLeaves) { result.held = true; result.reason = 'start_budget_exceeded'; break; }
+
+    const descendants = await fetchDescendants(supabase, top.id);
+    if (isTreeComplete(descendants)) { result.completed = true; break; }
+
+    const leaves = computeWorkableLeaves(descendants);
+    if (!leaves.length) { result.held = true; result.reason = 'no_workable_leaf'; break; }
+
+    const leaf = leaves[0];
+    const prior = attemptsByLeaf.get(leaf.sd_key) || 0;
+    if (prior >= bounds.maxAttemptsPerLeaf) { result.held = true; result.reason = `leaf_attempt_cap:${leaf.sd_key}`; break; }
+
+    if (dryRun) {
+      result.dryRun = true; result.nextLeaf = leaf.sd_key; result.workableLeafCount = leaves.length;
+      await emitEvent(supabase, 'LEO_BUILD_DRYRUN', { next_leaf: leaf.sd_key, workable_leaves: leaves.length }, { ventureId, sdId: top.id, dryRun: true, logger });
+      break;
+    }
+
+    attemptsByLeaf.set(leaf.sd_key, prior + 1);
+    let driven = null;
+    try { driven = await driveLeaf(leaf, { attempt: prior + 1, supabase, logger }); }
+    catch (err) { logger.error?.(`[venture-build-consumer] driveLeaf threw for ${leaf.sd_key}: ${err.message}`); driven = { completed: false }; }
+    leavesDriven++;
+
+    const ok = !!(driven && driven.completed);
+    result.drivenLeaves.push({ sd_key: leaf.sd_key, attempt: prior + 1, completed: ok });
+    await emitEvent(supabase, ok ? 'LEO_BUILD_LEAF_DRIVEN' : 'LEO_BUILD_LEAF_ATTEMPT_FAILED', { leaf: leaf.sd_key, attempt: prior + 1 }, { ventureId, sdId: leaf.id, dryRun, logger });
+    // On failure the outer loop re-selects the same leaf until its attempt cap, then fail-closed HOLD.
+  }
+
+  if (result.completed) {
+    await markConsumed(supabase, top.id, { dryRun });
+    const nudge = await maybeIdleNudge(supabase, ventureId, { dryRun });
+    await emitEvent(supabase, 'LEO_BUILD_CONSUMED', { driven: result.drivenLeaves.length, idle_nudged: !!nudge.nudged }, { ventureId, sdId: top.id, dryRun, logger });
+  } else if (result.held) {
+    await emitEvent(supabase, 'LEO_BUILD_HELD', { reason: result.reason, driven: result.drivenLeaves.length }, { ventureId, sdId: top.id, dryRun, logger });
+  }
+  return result;
+}
+
+/**
+ * FINALIZE (real writes, SAFE): only when the tree is genuinely complete, set the build_consumed_at
+ * idempotency marker and optionally idle-nudge the worker. NEVER advances the venture. This is the
+ * step the session-hosted skill runs after its drive loop reports the tree complete.
+ */
+export async function finalizeConsume({ supabase, ventureId, logger = console }) {
+  const top = await findTopOrchestrator(supabase, ventureId);
+  if (!top) return { complete: false, consumed: false, idleNudged: false, reason: 'no_top_orchestrator' };
+  const descendants = await fetchDescendants(supabase, top.id);
+  if (!isTreeComplete(descendants)) return { complete: false, consumed: false, idleNudged: false, reason: 'tree_incomplete' };
+  await markConsumed(supabase, top.id, {});
+  const nudge = await maybeIdleNudge(supabase, ventureId, {});
+  await emitEvent(supabase, 'LEO_BUILD_CONSUMED', { finalize: true, idle_nudged: !!nudge.nudged }, { ventureId, sdId: top.id, logger });
+  return { complete: true, consumed: true, idleNudged: !!nudge.nudged };
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('venture-build-consumer --venture-id <uuid> [--dry-run | --finalize]   (a real per-leaf build is session-hosted via the /leo-build-venture skill)');
+    return { exitCode: 0 };
+  }
+  const logger = deps.logger || console;
+  if (!args.ventureId) { logger.error?.('[venture-build-consumer] --venture-id is required'); return { exitCode: 2 }; }
+
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) { logger.error?.(`[venture-build-consumer] fatal misconfiguration: ${err.message}`); return { exitCode: 2 }; }
+
+  if (!args.dryRun && !args.finalize) {
+    // A real per-leaf build requires a live Claude session (orchestrator-child-agent teammates).
+    // The CLI refuses to "drive" headlessly — it only introspects (--dry-run) or finalizes (--finalize).
+    logger.log?.('[venture-build-consumer] real driving is session-hosted: invoke the /leo-build-venture skill in a live Claude session. CLI supports --dry-run and --finalize only.');
+    return { exitCode: 0, sessionHosted: true };
+  }
+
+  const pgClient = deps.pgClient !== undefined ? deps.pgClient : buildPgClient();
+  if (pgClient) { try { await pgClient.connect(); } catch (err) { logger.warn?.(`[venture-build-consumer] pg connect failed (${err.message}); marker idempotency only`); } }
+
+  let exitCode = 0;
+  let result = {};
+  let lock = null;
+  try {
+    lock = await tryAdvisoryLock(pgClient, `venture-build-consumer:${args.ventureId}`);
+    if (!lock.acquired) { logger.log?.('[venture-build-consumer] lock held by concurrent run — skipping'); return { exitCode: 0, lockHeld: true }; }
+    if (args.dryRun) {
+      result = await runConsume({ supabase, ventureId: args.ventureId, driveLeaf: async () => ({ completed: false }), bounds: args.bounds, dryRun: true, logger });
+      logger.log?.(`[venture-build-consumer] DRY RUN venture=${args.ventureId} nextLeaf=${result.nextLeaf || '(none)'} workableLeaves=${result.workableLeafCount || 0} skipped=${result.skipped || false} reason=${result.reason || '-'}`);
+    } else {
+      result = await finalizeConsume({ supabase, ventureId: args.ventureId, logger });
+      logger.log?.(`[venture-build-consumer] FINALIZE venture=${args.ventureId} complete=${result.complete} consumed=${result.consumed} idleNudged=${result.idleNudged} reason=${result.reason || '-'}`);
+    }
+  } catch (err) {
+    logger.error?.(`[venture-build-consumer] failed: ${err.message}`); exitCode = 1;
+  } finally {
+    if (lock && lock.acquired && !lock.mock) await releaseAdvisoryLock(pgClient, lock.key);
+    if (pgClient) { try { await pgClient.end(); } catch {} }
+  }
+  return { exitCode, ...result };
+}
+
+const isMain = (() => {
+  try {
+    const here = new URL(import.meta.url).pathname;
+    const argv = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
+    return here.endsWith(argv) || argv.endsWith(here);
+  } catch { return false; }
+})();
+
+if (isMain) {
+  main().then(({ exitCode }) => process.exit(exitCode))
+        .catch((err) => { console.error('venture-build-consumer fatal:', err.message); process.exit(2); });
+}

--- a/tests/unit/eva/bridge/venture-build-consumer.test.js
+++ b/tests/unit/eva/bridge/venture-build-consumer.test.js
@@ -1,0 +1,308 @@
+// Tests for the leo_bridge build CONSUMER (SD-LEO-INFRA-AUTO-EXECUTE-LEO-002).
+// TS-1..TS-11 from the prospective testing-agent (row 97f8e272). The keystone TS-1 drives a NESTED
+// tree end-to-end against a mutable mock, so a single-seed (non-tree-walker) implementation fails it.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import {
+  runConsume, computeWorkableLeaves, isTreeComplete, fetchDescendants,
+  ventureEligibility, maybeIdleNudge, tryAdvisoryLock, finalizeConsume, TERMINAL, NON_TERMINAL,
+} from '../../../../lib/eva/bridge/venture-build-consumer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = resolve(__dirname, '../../../../lib/eva/bridge/venture-build-consumer.js');
+
+// ---- Minimal mutable mock of the supabase query builder (only the chains the lib uses) ----
+class MockQuery {
+  constructor(sb, table) { this.sb = sb; this.table = table; this._op = 'select'; this._filters = []; this._payload = null; this._limit = null; this._single = false; this._returnData = false; }
+  select(cols) { if (this._op === 'update') { this._returnData = true; return this; } this._op = 'select'; this._cols = cols; return this; }
+  insert(obj) { this._op = 'insert'; this._payload = obj; return this; }
+  update(obj) { this._op = 'update'; this._payload = obj; return this; }
+  eq(c, v) { this._filters.push(['eq', c, v]); return this; }
+  is(c, v) { this._filters.push(['is', c, v]); return this; }
+  in(c, arr) { this._filters.push(['in', c, arr]); return this; }
+  order() { return this; }
+  limit(n) { this._limit = n; return this; }
+  maybeSingle() { this._single = true; return this._exec(); }
+  then(res, rej) { return this._exec().then(res, rej); }
+  _match(row) {
+    return this._filters.every(([op, c, v]) => {
+      if (op === 'eq') return row[c] === v;
+      if (op === 'is') return v === null ? (row[c] === null || row[c] === undefined) : row[c] === v;
+      if (op === 'in') return v.includes(row[c]);
+      return true;
+    });
+  }
+  async _exec() {
+    const rows = this.sb.tables[this.table] || (this.sb.tables[this.table] = []);
+    if (this._op === 'insert') {
+      const items = Array.isArray(this._payload) ? this._payload : [this._payload];
+      for (const it of items) { rows.push({ ...it }); this.sb.inserts.push({ table: this.table, row: it }); }
+      return { data: items, error: null };
+    }
+    const matched = rows.filter((r) => this._match(r));
+    if (this._op === 'update') {
+      for (const r of matched) Object.assign(r, this._payload);
+      this.sb.updates.push({ table: this.table, payload: this._payload, count: matched.length });
+      return { data: this._returnData ? matched.map((r) => ({ ...r })) : null, error: null };
+    }
+    let out = matched.map((r) => ({ ...r }));
+    if (this._limit != null) out = out.slice(0, this._limit);
+    if (this._single) return { data: out[0] || null, error: null };
+    return { data: out, error: null };
+  }
+}
+class MockSB {
+  constructor(tables) { this.tables = tables; this.inserts = []; this.updates = []; }
+  from(name) { return new MockQuery(this, name); }
+}
+
+const VID = 'venture-1';
+function eligibleTables(extra = {}) {
+  return {
+    ventures: [{ id: VID, build_model: 'leo_bridge', status: 'active', current_lifecycle_stage: 19, deleted_at: null, orchestrator_state: 'blocked' }],
+    eva_vision_documents: [{ venture_id: VID, level: 'L2', status: 'active', chairman_approved: true, vision_key: 'V-1' }],
+    strategic_directives_v2: [],
+    system_events: [],
+    ...extra,
+  };
+}
+
+// Build a nested tree: 1 top orch -> C child-orchs -> G grandchildren each (all draft).
+function nestedTree({ children = 5, grandkidsEach = 4 } = {}) {
+  const sds = [{ id: 'orch-top', sd_key: 'ORCH-TOP', venture_id: VID, sd_type: 'orchestrator', parent_sd_id: null, status: 'draft', sequence_rank: 0, metadata: {} }];
+  for (let c = 0; c < children; c++) {
+    const cid = `orch-${c}`;
+    sds.push({ id: cid, sd_key: `ORCH-${c}`, venture_id: VID, sd_type: 'orchestrator', parent_sd_id: 'orch-top', status: 'draft', sequence_rank: c });
+    for (let g = 0; g < grandkidsEach; g++) {
+      sds.push({ id: `leaf-${c}-${g}`, sd_key: `LEAF-${c}-${g}`, venture_id: VID, sd_type: 'feature', parent_sd_id: cid, status: 'draft', sequence_rank: g });
+    }
+  }
+  return sds;
+}
+
+// Mock driveLeaf that completes the leaf and bubble-completes parents (mirrors checkAndCompleteParent).
+function makeDriveLeaf(tables, { failKeys = new Set() } = {}) {
+  return async (leaf) => {
+    if (failKeys.has(leaf.sd_key)) return { completed: false };
+    const all = tables.strategic_directives_v2;
+    const row = all.find((r) => r.sd_key === leaf.sd_key);
+    if (!row) return { completed: false };
+    row.status = 'completed';
+    let pid = row.parent_sd_id;
+    while (pid) {
+      const parent = all.find((r) => r.id === pid);
+      if (!parent) break;
+      const kids = all.filter((r) => r.parent_sd_id === parent.id);
+      if (kids.length && kids.every((k) => TERMINAL.includes(k.status))) { parent.status = 'completed'; pid = parent.parent_sd_id; }
+      else break;
+    }
+    return { completed: true };
+  };
+}
+
+describe('venture-build-consumer — introspection', () => {
+  it('computeWorkableLeaves returns only non-orchestrator leaves with no non-terminal descendant, deepest-first', () => {
+    const sds = nestedTree({ children: 2, grandkidsEach: 2 });
+    // exclude the top orchestrator (fetchDescendants never returns it)
+    const descendants = sds.filter((s) => s.id !== 'orch-top');
+    const leaves = computeWorkableLeaves(descendants);
+    expect(leaves.length).toBe(4); // 2 child-orchs * 2 grandkids
+    expect(leaves.every((l) => l.sd_type === 'feature')).toBe(true); // never a child-orchestrator
+  });
+
+  it('isTreeComplete is true only when no descendant is draft/active', () => {
+    const sds = nestedTree({ children: 1, grandkidsEach: 2 }).filter((s) => s.id !== 'orch-top');
+    expect(isTreeComplete(sds)).toBe(false);
+    sds.forEach((s) => { s.status = 'completed'; });
+    expect(isTreeComplete(sds)).toBe(true);
+  });
+});
+
+describe('TS-1 — nested-tree drive (keystone)', () => {
+  it('drives every workable leaf across all child-orchestrators to completion (single-seed would fail)', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 5, grandkidsEach: 4 }) });
+    const sb = new MockSB(tables);
+    const driveLeaf = makeDriveLeaf(tables);
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf, bounds: { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 } });
+    expect(res.completed).toBe(true);
+    expect(res.held).toBe(false);
+    expect(res.drivenLeaves.length).toBe(20); // 5 * 4 grandchildren, NOT just one child-orch's 4
+    const drivenChildGroups = new Set(res.drivenLeaves.map((d) => d.sd_key.split('-')[1]));
+    expect(drivenChildGroups.size).toBe(5); // proves it crossed all 5 child-orchestrators (nested walk)
+    // idempotency marker set after completion
+    const top = tables.strategic_directives_v2.find((r) => r.id === 'orch-top');
+    expect(top.metadata.build_consumed_at).toBeTruthy();
+  });
+});
+
+describe('TS-2 / TS-3 — read-safe starter-only static guardrail', () => {
+  it('the consumer source (comments stripped) contains no advance / stage-write / decision-write tokens', () => {
+    const raw = readFileSync(LIB_PATH, 'utf-8');
+    const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    const forbidden = [
+      /_advanceStage/, /advance_venture_stage/, /chairman_decisions/, /getNextReadyChild/,
+      /release_sd/, /TeamCreate/, /spawnTeammate/, /Task\s*\(/, /sd-start/,
+      /current_lifecycle_stage\s*:/, /chairman_approved\s*:/,
+    ];
+    for (const pat of forbidden) expect(code, `forbidden token ${pat}`).not.toMatch(pat);
+  });
+
+  it('still permits legitimate READS of stage and the vision-approved flag', () => {
+    const raw = readFileSync(LIB_PATH, 'utf-8');
+    // these reads must exist and must NOT be a write object-key (no trailing colon)
+    expect(raw).toMatch(/current_lifecycle_stage(,| )/); // read in a select list / property access
+    expect(raw).toMatch(/eq\('chairman_approved', true\)/); // read predicate, not a write
+  });
+});
+
+describe('TS-4 — per-leaf attempt cap stops a failing leaf and HOLDs', () => {
+  it('retries the failing leaf up to the cap then holds with the venture untouched', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 1 }) });
+    const sb = new MockSB(tables);
+    const driveLeaf = makeDriveLeaf(tables, { failKeys: new Set(['LEAF-0-0']) });
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf, bounds: { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 } });
+    expect(res.held).toBe(true);
+    expect(res.reason).toMatch(/^leaf_attempt_cap:LEAF-0-0/);
+    expect(res.drivenLeaves.filter((d) => !d.completed).length).toBe(2); // exactly 2 attempts
+    // no idle-nudge / no stage write happened on the held path
+    const stageWrites = sb.updates.filter((u) => 'current_lifecycle_stage' in u.payload);
+    expect(stageWrites.length).toBe(0);
+  });
+});
+
+describe('TS-5 — wall-clock / start-budget cap', () => {
+  it('start-budget cap holds after maxLeaves drives', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 2, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), bounds: { maxLeaves: 1, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 } });
+    expect(res.completed).toBe(false);
+    expect(res.held).toBe(true);
+    expect(res.reason).toBe('start_budget_exceeded');
+  });
+
+  it('wall-clock cap holds when time exceeds the bound', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 2, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    let t = 0;
+    const now = () => (t === 0 ? (t = 1, 0) : 10_000); // first check 0, subsequent checks past the cap
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), bounds: { maxLeaves: 100, wallClockMs: 5_000, maxAttemptsPerLeaf: 2 }, now });
+    expect(res.held).toBe(true);
+    expect(res.reason).toBe('wall_clock_exceeded');
+  });
+});
+
+describe('TS-6 — concurrency: exactly one driver', () => {
+  it('tryAdvisoryLock reports not-acquired when pg returns false, and mock-acquired with no client', async () => {
+    const fakePg = { query: async (sql) => (/pg_try_advisory_lock/.test(sql) ? { rows: [{ acquired: false }] } : { rows: [{ k: 123 }] }) };
+    const held = await tryAdvisoryLock(fakePg, 'venture-build-consumer:v');
+    expect(held.acquired).toBe(false);
+    const noClient = await tryAdvisoryLock(null, 'x');
+    expect(noClient.acquired).toBe(true);
+    expect(noClient.mock).toBe(true);
+  });
+});
+
+describe('TS-7 — idempotency: re-run after complete is a no-op', () => {
+  it('skips when build_consumed_at is already set', async () => {
+    const tree = nestedTree({ children: 1, grandkidsEach: 1 });
+    tree.find((r) => r.id === 'orch-top').metadata = { build_consumed_at: '2026-06-01T00:00:00Z' };
+    const sb = new MockSB(eligibleTables({ strategic_directives_v2: tree }));
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(sb.tables) });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe('already_consumed');
+    expect(res.drivenLeaves.length).toBe(0);
+  });
+});
+
+describe('TS-8 — resume from live tree state after a partial build', () => {
+  it('drives only the remaining draft leaves (derived from live state, not a start marker)', async () => {
+    const tree = nestedTree({ children: 2, grandkidsEach: 2 });
+    // simulate a prior partial build: first child-orch fully completed
+    tree.filter((r) => r.parent_sd_id === 'orch-0').forEach((r) => { r.status = 'completed'; });
+    tree.find((r) => r.id === 'orch-0').status = 'completed';
+    const tables = eligibleTables({ strategic_directives_v2: tree });
+    const sb = new MockSB(tables);
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), bounds: { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 } });
+    expect(res.completed).toBe(true);
+    expect(res.drivenLeaves.length).toBe(2); // only orch-1's two remaining leaves
+    expect(res.drivenLeaves.every((d) => d.sd_key.startsWith('LEAF-1-'))).toBe(true);
+  });
+});
+
+describe('TS-9 — idle-nudge no-op while incomplete; conditional when complete', () => {
+  it('maybeIdleNudge only flips a currently-blocked venture', async () => {
+    const blocked = new MockSB({ ventures: [{ id: VID, orchestrator_state: 'blocked' }] });
+    expect((await maybeIdleNudge(blocked, VID)).nudged).toBe(true);
+    const idle = new MockSB({ ventures: [{ id: VID, orchestrator_state: 'idle' }] });
+    expect((await maybeIdleNudge(idle, VID)).nudged).toBe(false); // count-checked no-op
+  });
+
+  it('a HELD run performs no idle-nudge (venture stays blocked)', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 1 }) });
+    const sb = new MockSB(tables);
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables, { failKeys: new Set(['LEAF-0-0']) }), bounds: { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 1 } });
+    const nudges = sb.updates.filter((u) => u.table === 'ventures' && u.payload.orchestrator_state === 'idle');
+    expect(nudges.length).toBe(0);
+    expect(tables.ventures[0].orchestrator_state).toBe('blocked');
+  });
+});
+
+describe('TS-10 — fail-closed for non-leo_bridge / empty trees', () => {
+  it('skips a non-leo_bridge venture with no writes', async () => {
+    const tables = eligibleTables();
+    tables.ventures[0].build_model = 'seeded_repo';
+    const sb = new MockSB(tables);
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables) });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toMatch(/not_leo_bridge/);
+    expect(sb.updates.length).toBe(0);
+  });
+
+  it('treats a 0-descendant tree as complete without driving anything', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: [{ id: 'orch-top', sd_key: 'ORCH-TOP', venture_id: VID, sd_type: 'orchestrator', parent_sd_id: null, status: 'draft', metadata: {} }] });
+    const sb = new MockSB(tables);
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables) });
+    expect(res.completed).toBe(true);
+    expect(res.drivenLeaves.length).toBe(0);
+  });
+});
+
+describe('FR-3 — finalize only writes when the tree is genuinely complete', () => {
+  it('finalize on an incomplete tree marks nothing and nudges nothing', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    const r = await finalizeConsume({ supabase: sb, ventureId: VID });
+    expect(r.complete).toBe(false);
+    expect(r.consumed).toBe(false);
+    expect(sb.updates.length).toBe(0);
+    expect(tables.ventures[0].orchestrator_state).toBe('blocked');
+  });
+
+  it('finalize on a complete tree marks consumed and idle-nudges the blocked venture', async () => {
+    const tree = nestedTree({ children: 1, grandkidsEach: 2 });
+    tree.forEach((r) => { if (r.id !== 'orch-top') r.status = 'completed'; });
+    const tables = eligibleTables({ strategic_directives_v2: tree });
+    const sb = new MockSB(tables);
+    const r = await finalizeConsume({ supabase: sb, ventureId: VID });
+    expect(r.complete).toBe(true);
+    expect(r.consumed).toBe(true);
+    expect(r.idleNudged).toBe(true);
+    expect(tables.strategic_directives_v2.find((x) => x.id === 'orch-top').metadata.build_consumed_at).toBeTruthy();
+    expect(tables.ventures[0].orchestrator_state).toBe('idle');
+  });
+});
+
+describe('TS-11 — observability emission (payload column, no event_data)', () => {
+  it('emits LEAF_DRIVEN + CONSUMED rows using the payload column', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), bounds: { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 } });
+    const events = sb.inserts.filter((i) => i.table === 'system_events').map((i) => i.row);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.every((e) => 'payload' in e && !('event_data' in e))).toBe(true);
+    expect(events.some((e) => e.event_type === 'LEO_BUILD_CONSUMED')).toBe(true);
+    expect(events.some((e) => e.event_type === 'LEO_BUILD_LEAF_DRIVEN')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the leo_bridge **detector→consumer** gap (follow-on to the completed detector SD-LEO-INFRA-AUTO-EXECUTE-LEO-001). A session-hosted **outer tree-walker** drives a build-ready leo_bridge venture's **nested** SD tree to completion — bounded + fail-closed — **holding at Stage 19** and **never adding a new advance path** (RCA a14ff998 invariant; `stage-execution-worker.js` is untouched, `_advanceStage` call-site count stays 7). The existing worker advances S19→S20 itself once the tree completes.

## What's new (3 files, 767 LOC)
- `lib/eva/bridge/venture-build-consumer.js` — recursive plain-read nested-tree introspection → deepest-first workable leaves; bounded fail-closed `runConsume(driveLeaf seam)`; per-venture pg_advisory_lock; `build_consumed_at` idempotency; optional conditional `orchestrator_state='idle'` accelerator nudge; `finalizeConsume`; `system_events` (payload column).
- `.claude/commands/leo-build-venture.md` — the **live-session host** for `driveLeaf` (spawns `orchestrator-child-agent` teammates per leaf; the per-child build needs a live session — no headless `claude -p` loop exists). The CLI refuses to drive headlessly (`--dry-run`/`--finalize` only).
- `tests/unit/eva/bridge/venture-build-consumer.test.js` — **18 passing**: TS-1..TS-11 + a read-safe starter-only static guardrail + finalize tests.

## Key design (verify-first)
- **TRAP-1 (caught by the mandatory prospective testing-agent, before code):** a single `handleExecuteWithContinuation` seed can't drive a nested tree (direct children only). Fix: an outer recursive tree-walker; keystone **TS-1** drives orch→5 child-orch→20 grandchild and asserts all 5 groups crossed (a single-seed impl fails it).
- **TRAP-2:** the worker already self-advances once children complete (the S19 hold oscillates), so the idle-nudge is an idempotent **accelerator**, not the advance path.
- **Guardrail (mutation-tested):** strips comments, forbids write/advance object-key tokens, permits legitimate stage/vision **reads**.

## Smoke (Q9)
`--dry-run` against DataDistill (510177ba) reports `nextLeaf=…-A1` (a grandchild) + `workableLeaves=20` with **zero writes** (stage stays 19).

Sub-agent evidence: validation `bfa82a6b`, risk `66301412`, prospective-testing `97f8e272`, testing `1b7d7b4e`, retro `445a634c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)