### PR TITLE
feat(SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001): repo-grounded right-sized sprint decomposition

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -89,6 +89,35 @@ const ARCHITECTURE_LAYERS = [
   { key: 'tests', label: 'Test Layer', description: 'Unit tests, integration tests, E2E tests' },
 ];
 
+// SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-2: translate the S19 planner's architectureLayer
+// taxonomy {frontend,backend,database,infrastructure,integration,security} into the bridge's
+// grandchild taxonomy {data,api,ui,tests}. frontend→ui and database→data are exact; every other
+// backend-flavoured concern (backend/integration/infrastructure/security) maps to the api layer.
+// Without this translation the planner's signal lands on a key the bridge cannot resolve, so the
+// previous code silently fell back to all four layers (the vacuous-decomposition root cause).
+const PLANNER_TO_BRIDGE_LAYER = {
+  frontend: 'ui',
+  backend: 'api',
+  database: 'data',
+  integration: 'api',
+  infrastructure: 'api',
+  security: 'api',
+};
+
+/**
+ * SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-5: feature flag gating the repo-grounded
+ * (right-sized) decomposition. Default ON — the legacy all-four-layers multiplier is the bug, not
+ * the desired behaviour. Set REPO_GROUNDED_DECOMPOSITION to false/0/off/no for a byte-identical
+ * legacy kill-switch.
+ * @returns {boolean}
+ */
+function isRepoGroundedDecompositionEnabled() {
+  const v = process.env.REPO_GROUNDED_DECOMPOSITION;
+  if (v === undefined || v === '') return true;
+  const s = String(v).toLowerCase();
+  return s !== 'false' && s !== '0' && s !== 'off' && s !== 'no';
+}
+
 // ── SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 (FR-4 orchestration-quality): correct venture SD tree ──
 // Pure + exported for testing. Address the systemic gaps the CronGenius E2E surfaced: children had
 // no build-order dependencies, the orchestrator was lower-priority than its children, and the
@@ -652,6 +681,10 @@ async function createGrandchildren({
     const layer = cappedLayers[j];
     const gcKey = generateGrandchildKey(parentChildKey, j);
     const gcId = randomUUID();
+    // SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-4: intra-child build order — each architecture
+    // layer depends on the previously-created layer (data → api → ui → tests) so the consumer can
+    // build a layered child in dependency order instead of facing empty grandchild dependencies.
+    const gcDependencies = j > 0 ? [generateGrandchildKey(parentChildKey, j - 1)] : [];
 
     const { created: gcCreated, error: gcError } = await insertSDIdempotent(supabase, {
         id: gcId,
@@ -669,6 +702,7 @@ async function createGrandchildren({
         target_application: normalizeTargetApplication(childPayload.target_application || ventureContext?.name || getCurrentVenture()),
         created_by: 'lifecycle-sd-bridge',
         parent_sd_id: parentChildId,
+        dependencies: gcDependencies, // FR-4: earlier-layer grandchild keys gate intra-child build order
         success_criteria: [`${layer.label} implementation complete and tested`],
         success_metrics: [
           { metric: `${layer.label} completeness`, target: '100%', actual: 'TBD' },
@@ -714,12 +748,27 @@ async function createGrandchildren({
  * @returns {Array} Applicable architecture layers
  */
 function selectApplicableLayers(payload) {
+  // SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-2/FR-3: honor the S19 planner's per-item
+  // architectureLayer signal — right-size to the single mapped layer instead of stamping all four.
+  // Skipped when REPO_GROUNDED_DECOMPOSITION is off (legacy kill-switch), when the planner gave no
+  // signal, or when the item is explicitly marked 'layered' (a genuinely large item that still
+  // wants full multi-layer decomposition).
+  if (
+    isRepoGroundedDecompositionEnabled() &&
+    payload && payload.architectureLayer &&
+    payload.decomposition_strategy !== 'layered'
+  ) {
+    const bridgeKey = PLANNER_TO_BRIDGE_LAYER[String(payload.architectureLayer).toLowerCase()];
+    const layer = ARCHITECTURE_LAYERS.find(l => l.key === bridgeKey);
+    if (layer) return [layer];
+  }
+  // Explicit bridge-taxonomy hint (already keyed data/api/ui/tests).
   if (payload.architecture_layers && Array.isArray(payload.architecture_layers)) {
     return payload.architecture_layers
       .map(key => ARCHITECTURE_LAYERS.find(l => l.key === key))
       .filter(Boolean);
   }
-  // Default: all layers apply
+  // Fallback: all layers apply (legacy payloads, absent signal, or decomposition_strategy='layered').
   return ARCHITECTURE_LAYERS;
 }
 
@@ -1258,6 +1307,8 @@ export const _internal = {
   buildProvenance,
   insertSDIdempotent,
   selectApplicableLayers,
+  PLANNER_TO_BRIDGE_LAYER,
+  isRepoGroundedDecompositionEnabled,
   partitionLayersByCapability,
   computeEffectiveGrandchildLayers,
   filterLayersByCapability,

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -473,6 +473,13 @@ Output ONLY valid JSON.`;
     risks: item.risks,
     target_application: item.target_application,
     app_type: item.app_type,
+    // SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-1: forward the planner's per-item
+    // architectureLayer decomposition signal (previously stripped here) so the bridge can
+    // right-size decomposition to one SD per item instead of stamping all four layers.
+    // decomposition_strategy defaults to 'leaf' (one SD); a future planner enhancement may
+    // mark a genuinely large item 'layered' to opt back into multi-layer grandchildren.
+    architectureLayer: item.architectureLayer,
+    decomposition_strategy: 'leaf',
   }));
 
   logger.log('[Stage19] Analysis complete', { duration: Date.now() - startTime });

--- a/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
@@ -1,0 +1,56 @@
+/**
+ * SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-1 — the S19 sprint planner must forward each item's
+ * architectureLayer signal (plus decomposition_strategy) into sd_bridge_payloads, instead of
+ * stripping it. Without this, the bridge's selectApplicableLayers never sees the signal and falls
+ * back to all four architecture layers (the vacuous-decomposition root cause).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Mandatory portfolio-default capabilities analyzeStage19 validates for (feedback-widget +
+// error-capture-middleware); the planner throws MissingDefaultCapabilityError without them.
+const MANDATORY_ITEMS = [
+  { title: 'Integrate Feedback Widget', description: 'Add feedback widget', type: 'infra', priority: 'medium', estimatedLoc: 30, acceptanceCriteria: 'Widget visible', architectureLayer: 'frontend', milestoneRef: 'MVP' },
+  { title: 'Wire Error Capture Middleware', description: 'Add error capture', type: 'infra', priority: 'medium', estimatedLoc: 20, acceptanceCriteria: 'Errors captured', architectureLayer: 'backend', milestoneRef: 'MVP' },
+];
+
+const mockComplete = vi.fn().mockResolvedValue(JSON.stringify({
+  sprintGoal: 'Ship the landing experience',
+  sprintItems: [
+    { title: 'Landing Hero', description: 'Hero section', type: 'feature', priority: 'high', estimatedLoc: 80, acceptanceCriteria: 'Hero renders', architectureLayer: 'frontend', milestoneRef: 'MVP' },
+    { title: 'Signup API', description: 'POST /signup', type: 'feature', priority: 'high', estimatedLoc: 120, acceptanceCriteria: 'Signup works', architectureLayer: 'backend', milestoneRef: 'MVP' },
+    ...MANDATORY_ITEMS,
+  ],
+}));
+
+vi.mock('../../../../lib/llm/index.js', () => ({ getLLMClient: () => ({ complete: mockComplete }) }));
+vi.mock('../../../../lib/eva/utils/parse-json.js', () => ({ parseJSON: (str) => JSON.parse(str), extractUsage: () => ({}) }));
+vi.mock('../../../../lib/eva/utils/four-buckets-prompt.js', () => ({ getFourBucketsPrompt: () => '' }));
+vi.mock('../../../../lib/eva/utils/four-buckets-parser.js', () => ({ parseFourBuckets: () => ({}) }));
+vi.mock('../../../../lib/eva/bridge/sd-router.js', () => ({ resolveTargetApplication: () => ({ targetApp: 'ehg' }) }));
+
+const { analyzeStage19 } = await import('../../../../lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js');
+
+describe('SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-1 — planner forwards architectureLayer', () => {
+  const baseStage18 = {
+    buildReadiness: { decision: 'go', rationale: 'ok' },
+    ventureDescription: 'Landing-first venture',
+    problemStatement: 'Need a landing page',
+  };
+  const logger = { log: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() };
+  const callArgs = { stage18Data: baseStage18, stage17Data: { decision: 'PASS' }, ventureName: 'LandingCo', logger };
+
+  it('carries each item architectureLayer into sd_bridge_payloads (previously stripped)', async () => {
+    const result = await analyzeStage19(callArgs);
+    expect(result.sd_bridge_payloads.length).toBeGreaterThan(0);
+    const byTitle = Object.fromEntries(result.sd_bridge_payloads.map(p => [p.title, p]));
+    expect(byTitle['Landing Hero'].architectureLayer).toBe('frontend');
+    expect(byTitle['Signup API'].architectureLayer).toBe('backend');
+  });
+
+  it('defaults decomposition_strategy to "leaf" (one SD per item) on every payload', async () => {
+    const result = await analyzeStage19(callArgs);
+    for (const p of result.sd_bridge_payloads) {
+      expect(p.decomposition_strategy).toBe('leaf');
+    }
+  });
+});

--- a/tests/unit/lifecycle-sd-bridge/architectureLayer-signal.test.js
+++ b/tests/unit/lifecycle-sd-bridge/architectureLayer-signal.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 — repo-grounded intelligent decomposition (bridge side).
+ *
+ * Proves that selectApplicableLayers honors the S19 planner's per-item architectureLayer signal
+ * (FR-2), right-sizes to one layer per item (FR-3), is gated by the REPO_GROUNDED_DECOMPOSITION
+ * feature flag (FR-5), and that the S19→S20 _advanceStage invariant is untouched (count stays 7).
+ *
+ * Flag handling is HERMETIC: each test sets/clears REPO_GROUNDED_DECOMPOSITION explicitly and
+ * afterEach restores the original value, so the suite is green whether the flag is ambiently set or
+ * unset (lesson from SD-LEO-INFRA-PATH-SCOPED-BLOCKING-001: a gate's seed suite must pass with the
+ * flag both SET and UNSET).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { _internal } from '../../../lib/eva/lifecycle-sd-bridge.js';
+
+const {
+  selectApplicableLayers,
+  PLANNER_TO_BRIDGE_LAYER,
+  isRepoGroundedDecompositionEnabled,
+  ARCHITECTURE_LAYERS,
+} = _internal;
+
+const FLAG = 'REPO_GROUNDED_DECOMPOSITION';
+const ALL_LAYERS = ARCHITECTURE_LAYERS.length; // 4
+
+describe('SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 — repo-grounded decomposition (bridge)', () => {
+  let saved;
+  beforeEach(() => { saved = process.env[FLAG]; });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = saved;
+  });
+
+  describe('FR-5 feature flag', () => {
+    it('defaults ON when the flag is unset', () => {
+      delete process.env[FLAG];
+      expect(isRepoGroundedDecompositionEnabled()).toBe(true);
+    });
+    it('is OFF for false/0/off/no (case-insensitive)', () => {
+      for (const v of ['false', '0', 'off', 'no', 'FALSE', 'Off']) {
+        process.env[FLAG] = v;
+        expect(isRepoGroundedDecompositionEnabled(), `value=${v}`).toBe(false);
+      }
+    });
+    it('is ON for any other truthy value', () => {
+      process.env[FLAG] = 'true';
+      expect(isRepoGroundedDecompositionEnabled()).toBe(true);
+    });
+  });
+
+  describe('FR-2 taxonomy translation', () => {
+    it('maps every planner taxonomy value to a real bridge layer key', () => {
+      const bridgeKeys = new Set(ARCHITECTURE_LAYERS.map(l => l.key));
+      for (const planner of ['frontend', 'backend', 'database', 'infrastructure', 'integration', 'security']) {
+        const mapped = PLANNER_TO_BRIDGE_LAYER[planner];
+        expect(bridgeKeys.has(mapped), `${planner}→${mapped}`).toBe(true);
+      }
+    });
+    it('maps frontend→ui and database→data exactly', () => {
+      expect(PLANNER_TO_BRIDGE_LAYER.frontend).toBe('ui');
+      expect(PLANNER_TO_BRIDGE_LAYER.database).toBe('data');
+    });
+  });
+
+  describe('FR-2 / FR-3 right-sizing (flag ON)', () => {
+    beforeEach(() => { process.env[FLAG] = 'true'; });
+
+    it('TS-1: a frontend item resolves to exactly the ui layer (not all four)', () => {
+      const layers = selectApplicableLayers({ title: 'Landing Hero', architectureLayer: 'frontend' });
+      expect(layers).toHaveLength(1);
+      expect(layers[0].key).toBe('ui');
+    });
+
+    it('TS-2: a frontend-only item never produces a data- or api-layer SD', () => {
+      const keys = selectApplicableLayers({ architectureLayer: 'frontend' }).map(l => l.key);
+      expect(keys).not.toContain('data');
+      expect(keys).not.toContain('api');
+    });
+
+    it('backend→api and database→data right-size to one layer each', () => {
+      expect(selectApplicableLayers({ architectureLayer: 'backend' }).map(l => l.key)).toEqual(['api']);
+      expect(selectApplicableLayers({ architectureLayer: 'database' }).map(l => l.key)).toEqual(['data']);
+    });
+
+    it('TS-4: the all-four multiplier is retired for a signalled item (1, not 4)', () => {
+      expect(selectApplicableLayers({ architectureLayer: 'frontend' })).toHaveLength(1);
+    });
+
+    it('a genuinely large item marked decomposition_strategy=layered still gets all four layers', () => {
+      const layers = selectApplicableLayers({ architectureLayer: 'frontend', decomposition_strategy: 'layered' });
+      expect(layers).toHaveLength(ALL_LAYERS);
+    });
+
+    it('an item with no signal falls back to all four layers', () => {
+      expect(selectApplicableLayers({})).toHaveLength(ALL_LAYERS);
+    });
+
+    it('the explicit plural architecture_layers hint is still honored', () => {
+      expect(selectApplicableLayers({ architecture_layers: ['data', 'api'] }).map(l => l.key)).toEqual(['data', 'api']);
+    });
+  });
+
+  describe('FR-5 legacy kill-switch (flag OFF)', () => {
+    beforeEach(() => { process.env[FLAG] = 'false'; });
+
+    it('TS-7: a signalled item reverts to legacy all-four behavior', () => {
+      expect(selectApplicableLayers({ architectureLayer: 'frontend' })).toHaveLength(ALL_LAYERS);
+    });
+
+    it('the plural hint and empty fallback are byte-identical to legacy', () => {
+      expect(selectApplicableLayers({ architecture_layers: ['ui'] }).map(l => l.key)).toEqual(['ui']);
+      expect(selectApplicableLayers({})).toHaveLength(ALL_LAYERS);
+    });
+  });
+
+  describe('Safety invariant — S19→S20 advance path untouched', () => {
+    it('TS-5: this._advanceStage call-count in stage-execution-worker.js stays exactly 7', () => {
+      const here = dirname(fileURLToPath(import.meta.url));
+      const workerPath = resolve(here, '../../../lib/eva/stage-execution-worker.js');
+      const src = readFileSync(workerPath, 'utf8');
+      // Strip block + line comments so a commented reference can never inflate the count.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+      const calls = (code.match(/this\._advanceStage\s*\(/g) || []).length;
+      expect(calls).toBe(7);
+    });
+  });
+});


### PR DESCRIPTION
Campaign step 1 of "intelligent-venture-build" (SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001).

## Problem
The leo_bridge venture-build pipeline multiplied every S19 sprint item into all 4 architecture layers (data/api/ui/tests), producing vacuous make-work SDs (e.g. a "Data Layer: schema/migrations" SD for a static marketing landing page). The S19 planner already emitted a per-item `architectureLayer` signal, but the bridge discarded it — a two-site mismatch on BOTH the field name (`architectureLayer` vs `architecture_layers`) and the taxonomy (planner's 6 values vs bridge's 4).

## Fix (two-site, behind a feature flag)
- **FR-1** `stage-19-sprint-planning.js`: forward `architectureLayer` + `decomposition_strategy` into `sd_bridge_payloads` (was stripped at ~L465-476).
- **FR-2** `lifecycle-sd-bridge.js::selectApplicableLayers`: honor the signal + translate planner taxonomy (6) to bridge taxonomy (4) via `PLANNER_TO_BRIDGE_LAYER`.
- **FR-3**: right-size to 1 SD per item; all-4 retained ONLY as the legacy/absent-signal fallback.
- **FR-4**: grandchildren now carry intra-child build-order `dependencies` (were empty).
- **FR-5**: `REPO_GROUNDED_DECOMPOSITION` flag (default ON; OFF = byte-identical legacy kill-switch).
- **FR-6**: new hermetic-flag bridge tests + FR-1 forwarding tests + static `this._advanceStage`=7 guardrail.

## Evidence
- Baseline observation: a frontend item went from **4 layers `[data,api,ui,tests]` to 1 layer `[ui]`**.
- **88/88** unit tests green; no regressions to existing convert/stage-19 suites.
- Safety invariant intact: `this._advanceStage` call-count stays **7** (S19→S20 advance path untouched).
- ~60 LOC production + ~185 test LOC.

In-flight trees (e.g. DataDistill venture 510177ba) are protected by `findExistingOrchestrator` NOOP_EXISTS; their regeneration is out of scope here (separate backfill). Follow-ons: campaign step 2 (consumer honors the dependencies this populates) and step 3 (vision-grounded acceptance verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
