### PR TITLE
feat(SD-LEO-INFRA-CONTEXT-AWARE-DEPENDENCY-001): context-aware dependency-ordered execution in venture-build consumer

### DIFF
--- a/.claude/commands/leo-build-venture.md
+++ b/.claude/commands/leo-build-venture.md
@@ -61,6 +61,17 @@ Repeat:
    (LEAD-TO-PLAN → PLAN-TO-EXEC → EXEC → PLAN-TO-LEAD → LEAD-FINAL-APPROVAL, with all sub-agent
    evidence — the child runs the normal protocol). It MUST NOT touch the venture stage or any
    chairman/vision row. Increment `attemptsByLeaf[nextLeaf]` and `leavesDriven`.
+
+   **Context-aware driving (SD-LEO-INFRA-CONTEXT-AWARE-DEPENDENCY-001, FR-2):** when
+   `DEPENDENCY_ORDERED_EXECUTION` is on (default), the lib selects leaves in build-order (a leaf is
+   only driven once its in-tree dependencies are terminal) and hands `driveLeaf` a
+   `ctx.dependencyContext = { completed: [{ sd_key, title }], context_entries: [...] }` — the leaf's
+   already-COMPLETED sibling dependencies plus the non-SD manifest entries (existing-module paths,
+   shared primitives, prerequisites) from its `dependencies` column. **Inject this into the
+   `orchestrator-child-agent` prompt** so the leaf is built WITH knowledge of what its dependencies
+   produced (e.g. "this SD consumes the typed DAL delivered by completed sibling `<sd_key>` — reuse
+   it, do not re-derive"). It is purely informational grounding — it never relaxes the never-advance
+   or chairman/vision constraints.
 4. **Verify** — re-query the SD's status. If it reached `completed`, continue the loop (the next
    introspection will surface the next leaf; child-orchestrators bubble-complete automatically). If
    it did not, loop again (the same leaf will be re-selected until its attempt cap, then HOLD per

--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -36,6 +36,9 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import pg from 'pg';
+// SD-LEO-INFRA-CONTEXT-AWARE-DEPENDENCY-001: reuse the ONE canonical dependency normalizer the
+// sd:next queue + AUTO-PROCEED already use (shape-tolerant: bare "SD-…" strings + { sd_id } objects).
+import { parseDependencies } from '../../../scripts/modules/sd-next/dependency-resolver.js';
 
 export const S19 = 19;
 export const NON_TERMINAL = ['draft', 'active'];
@@ -47,6 +50,18 @@ export const DEFAULT_BOUNDS = Object.freeze({
   wallClockMs: 6 * 60 * 60 * 1000,   // 6h wall-clock cap
   maxAttemptsPerLeaf: 2,             // per-leaf attempt cap (DISTINCT from the inner 50-iter children cap)
 });
+
+/**
+ * SD-LEO-INFRA-CONTEXT-AWARE-DEPENDENCY-001 FR-3: feature flag for dependency-ordered execution.
+ * Default ON; only an explicit false/0/off/no disables it (then selection is byte-identical legacy
+ * deepest-first/sequence_rank order, with NO dependencyContext — a clean instant rollback).
+ */
+export function isDependencyOrderedExecutionEnabled() {
+  const v = process.env.DEPENDENCY_ORDERED_EXECUTION;
+  if (v === undefined || v === '') return true;
+  const s = String(v).toLowerCase();
+  return s !== 'false' && s !== '0' && s !== 'off' && s !== 'no';
+}
 
 export function parseArgs(argv) {
   const args = { ventureId: null, dryRun: false, finalize: false, once: false, help: false, bounds: { ...DEFAULT_BOUNDS } };
@@ -141,7 +156,7 @@ export async function fetchDescendants(supabase, topId) {
   while (frontier.length) {
     const { data } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, status, sd_type, parent_sd_id, sequence_rank')
+      .select('id, sd_key, status, sd_type, parent_sd_id, sequence_rank, dependencies, title')
       .in('parent_sd_id', frontier);
     const next = [];
     for (const k of (data || [])) {
@@ -159,11 +174,12 @@ export function isTreeComplete(descendants) {
 }
 
 /**
- * The workable LEAVES to drive, deepest-first then by sequence_rank: a non-terminal, non-orchestrator
+ * The LEGACY workable LEAVES, deepest-first then by sequence_rank: a non-terminal, non-orchestrator
  * SD with NO non-terminal descendant of its own. Child-orchestrators are excluded (they bubble-complete
  * via checkAndCompleteParent once their grandchildren finish — they are never driven directly).
+ * This is the dependency-UNAWARE order; selectWorkableLeaves (FR-1) gates it on build-order deps.
  */
-export function computeWorkableLeaves(descendants) {
+export function legacyWorkableLeaves(descendants) {
   const byId = new Map(descendants.map((d) => [d.id, d]));
   const byParent = new Map();
   for (const d of descendants) {
@@ -189,6 +205,85 @@ export function computeWorkableLeaves(descendants) {
   );
   leaves.sort((a, b) => depthOf(b) - depthOf(a) || (a.sequence_rank ?? 0) - (b.sequence_rank ?? 0));
   return leaves;
+}
+
+/**
+ * Index descendants by BOTH sd_key and id so a dependency reference (parseDependencies yields
+ * { sd_id } from a bare "SD-…" string or a { sd_id } object) resolves whether it was stored as a
+ * business key or a UUID.
+ */
+function indexByKeyOrId(descendants) {
+  const m = new Map();
+  for (const d of descendants) { m.set(d.sd_key, d); m.set(d.id, d); }
+  return m;
+}
+
+/**
+ * FR-1: the in-tree build-order dependencies of `leaf` that are NOT yet terminal. Reuses the canonical
+ * parseDependencies (bare "SD-…" strings + { sd_id } objects; ignores {sd_key}-only / {predecessor}-only
+ * / free-text / blocks_phase, consistent with the queue). Dependency sd_ids ABSENT from the in-tree
+ * descendant set are ignored (treated satisfied) — cross-tree/dangling refs never block. Terminal-
+ * tolerance uses the consumer's TERMINAL set (completed OR cancelled OR archived), NOT the queue
+ * resolver's completed-only checkDependenciesResolved: a legitimately cancelled sibling must not deadlock.
+ */
+function blockingDeps(leaf, byKeyOrId) {
+  const blocking = [];
+  for (const { sd_id } of parseDependencies(leaf.dependencies)) {
+    const dep = byKeyOrId.get(sd_id);
+    if (dep && !TERMINAL.includes(dep.status)) blocking.push(dep);
+  }
+  return blocking;
+}
+
+/**
+ * FR-1: dependency-ordered leaf selection with a deadlock fail-safe. Flag OFF → byte-identical legacy
+ * order. Flag ON → only dependency-clean leaves (all in-tree build-order deps terminal); if NO leaf is
+ * clean but the legacy frontier is non-empty (an in-tree cycle, or every leaf blocked by a non-terminal
+ * sibling), FALL BACK to the full legacy order and flag fellBack — the venture must never freeze at
+ * Stage 19 with a false no_workable_leaf hold. Returns { leaves, fellBack }.
+ */
+export function selectWorkableLeaves(descendants) {
+  const legacy = legacyWorkableLeaves(descendants);
+  if (!isDependencyOrderedExecutionEnabled()) return { leaves: legacy, fellBack: false };
+  const byKeyOrId = indexByKeyOrId(descendants);
+  const clean = legacy.filter((leaf) => blockingDeps(leaf, byKeyOrId).length === 0);
+  if (clean.length > 0) return { leaves: clean, fellBack: false };
+  return { leaves: legacy, fellBack: legacy.length > 0 };
+}
+
+/**
+ * Backward-compatible array accessor (dry-run, external callers, tests). The drive loop uses
+ * selectWorkableLeaves directly so it can observe the fail-safe fallback for one-per-stall signalling.
+ */
+export function computeWorkableLeaves(descendants) {
+  return selectWorkableLeaves(descendants).leaves;
+}
+
+/**
+ * FR-2: the context handed to driveLeaf for `leaf` — its COMPLETED in-tree sibling dependencies
+ * (sd_key + title; cancelled deps produced no artifact so are excluded) plus the non-SD manifest
+ * entries parseDependencies discards (existing_module paths, shared primitives, technical prereqs)
+ * which the build agent still wants for grounding. Returns { completed, context_entries }.
+ */
+export function buildDependencyContext(leaf, descendants) {
+  const byKeyOrId = indexByKeyOrId(descendants);
+  const completed = [];
+  for (const { sd_id } of parseDependencies(leaf.dependencies)) {
+    const dep = byKeyOrId.get(sd_id);
+    if (dep && dep.status === 'completed') completed.push({ sd_key: dep.sd_key, title: dep.title });
+  }
+  return { completed, context_entries: nonSdDependencyEntries(leaf.dependencies) };
+}
+
+/** FR-2: raw `dependencies` entries that are NOT SD references (the rich manifest parseDependencies drops). */
+function nonSdDependencyEntries(dependencies) {
+  let arr = dependencies;
+  if (typeof arr === 'string') { try { arr = JSON.parse(arr); } catch { return []; } }
+  if (!Array.isArray(arr)) return [];
+  const isSdRef = (d) => typeof d === 'string'
+    ? /^SD-[A-Z0-9-]+/.test(d)
+    : !!(d && d.sd_id && /^SD-[A-Z0-9-]+/.test(String(d.sd_id)));
+  return arr.filter((d) => d && typeof d === 'object' && !isSdRef(d));
 }
 
 /** Emit one observability row to system_events (payload column — there is no event_data column). */
@@ -252,6 +347,7 @@ export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFA
   const start = now();
   const attemptsByLeaf = new Map();
   let leavesDriven = 0;
+  let fallbackSignalled = false; // FR-1: emit dependency_fallback ONCE per contiguous frontier-stall
 
   while (true) {
     if (now() - start > bounds.wallClockMs) { result.held = true; result.reason = 'wall_clock_exceeded'; break; }
@@ -260,8 +356,16 @@ export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFA
     const descendants = await fetchDescendants(supabase, top.id);
     if (isTreeComplete(descendants)) { result.completed = true; break; }
 
-    const leaves = computeWorkableLeaves(descendants);
+    const { leaves, fellBack } = selectWorkableLeaves(descendants);
     if (!leaves.length) { result.held = true; result.reason = 'no_workable_leaf'; break; }
+    if (fellBack) {
+      if (!fallbackSignalled) {
+        fallbackSignalled = true;
+        await emitEvent(supabase, 'dependency_fallback', { workable: leaves.length }, { ventureId, sdId: top.id, dryRun, logger });
+      }
+    } else {
+      fallbackSignalled = false;
+    }
 
     const leaf = leaves[0];
     const prior = attemptsByLeaf.get(leaf.sd_key) || 0;
@@ -275,7 +379,9 @@ export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFA
 
     attemptsByLeaf.set(leaf.sd_key, prior + 1);
     let driven = null;
-    try { driven = await driveLeaf(leaf, { attempt: prior + 1, supabase, logger }); }
+    // FR-2: build each leaf WITH context from its completed dependencies (flag-gated; omitted when OFF).
+    const dependencyContext = isDependencyOrderedExecutionEnabled() ? buildDependencyContext(leaf, descendants) : undefined;
+    try { driven = await driveLeaf(leaf, { attempt: prior + 1, supabase, logger, dependencyContext }); }
     catch (err) { logger.error?.(`[venture-build-consumer] driveLeaf threw for ${leaf.sd_key}: ${err.message}`); driven = { completed: false }; }
     leavesDriven++;
 

--- a/tests/unit/eva/bridge/dependency-ordered-execution.test.js
+++ b/tests/unit/eva/bridge/dependency-ordered-execution.test.js
@@ -1,0 +1,256 @@
+// Tests for SD-LEO-INFRA-CONTEXT-AWARE-DEPENDENCY-001 — context-aware dependency-ordered execution
+// in the leo_bridge venture-build consumer. DC-1..DC-15 from the prospective testing-agent
+// (row a804c8b8). The consumer reuses the canonical parseDependencies for shape-tolerance and the
+// consumer's own TERMINAL set for terminal-tolerance, with a deadlock fail-safe.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import {
+  runConsume, computeWorkableLeaves, selectWorkableLeaves, legacyWorkableLeaves,
+  buildDependencyContext, isDependencyOrderedExecutionEnabled, fetchDescendants,
+  TERMINAL,
+} from '../../../../lib/eva/bridge/venture-build-consumer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = resolve(__dirname, '../../../../lib/eva/bridge/venture-build-consumer.js');
+
+// ---- Minimal mutable mock of the supabase query builder (records .select() cols for DC-14) ----
+class MockQuery {
+  constructor(sb, table) { this.sb = sb; this.table = table; this._op = 'select'; this._filters = []; this._payload = null; this._limit = null; this._single = false; this._returnData = false; }
+  select(cols) { if (this._op === 'update') { this._returnData = true; return this; } this._op = 'select'; this._cols = cols; this.sb.selects.push({ table: this.table, cols }); return this; }
+  insert(obj) { this._op = 'insert'; this._payload = obj; return this; }
+  update(obj) { this._op = 'update'; this._payload = obj; return this; }
+  eq(c, v) { this._filters.push(['eq', c, v]); return this; }
+  is(c, v) { this._filters.push(['is', c, v]); return this; }
+  in(c, arr) { this._filters.push(['in', c, arr]); return this; }
+  order() { return this; }
+  limit(n) { this._limit = n; return this; }
+  maybeSingle() { this._single = true; return this._exec(); }
+  then(res, rej) { return this._exec().then(res, rej); }
+  _match(row) {
+    return this._filters.every(([op, c, v]) => {
+      if (op === 'eq') return row[c] === v;
+      if (op === 'is') return v === null ? (row[c] === null || row[c] === undefined) : row[c] === v;
+      if (op === 'in') return v.includes(row[c]);
+      return true;
+    });
+  }
+  async _exec() {
+    const rows = this.sb.tables[this.table] || (this.sb.tables[this.table] = []);
+    if (this._op === 'insert') {
+      const items = Array.isArray(this._payload) ? this._payload : [this._payload];
+      for (const it of items) { rows.push({ ...it }); this.sb.inserts.push({ table: this.table, row: it }); }
+      return { data: items, error: null };
+    }
+    const matched = rows.filter((r) => this._match(r));
+    if (this._op === 'update') {
+      for (const r of matched) Object.assign(r, this._payload);
+      this.sb.updates.push({ table: this.table, payload: this._payload, count: matched.length });
+      return { data: this._returnData ? matched.map((r) => ({ ...r })) : null, error: null };
+    }
+    let out = matched.map((r) => ({ ...r }));
+    if (this._limit != null) out = out.slice(0, this._limit);
+    if (this._single) return { data: out[0] || null, error: null };
+    return { data: out, error: null };
+  }
+}
+class MockSB {
+  constructor(tables) { this.tables = tables; this.inserts = []; this.updates = []; this.selects = []; }
+  from(name) { return new MockQuery(this, name); }
+}
+
+const VID = 'venture-1';
+function eligibleTables(sds) {
+  return {
+    ventures: [{ id: VID, build_model: 'leo_bridge', status: 'active', current_lifecycle_stage: 19, deleted_at: null, orchestrator_state: 'blocked' }],
+    eva_vision_documents: [{ venture_id: VID, level: 'L2', status: 'active', chairman_approved: true, vision_key: 'V-1' }],
+    strategic_directives_v2: sds,
+    system_events: [],
+  };
+}
+
+// top orch -> 1 child-orch -> leaves A,B,C (siblings). `deps`/`status` override per leaf key.
+function depTree({ deps = {}, status = {}, leaves = ['A', 'B', 'C'] } = {}) {
+  const sds = [
+    { id: 'orch-top', sd_key: 'ORCH-TOP', venture_id: VID, sd_type: 'orchestrator', parent_sd_id: null, status: 'draft', sequence_rank: 0, metadata: {} },
+    { id: 'orch-c', sd_key: 'ORCH-C', venture_id: VID, sd_type: 'orchestrator', parent_sd_id: 'orch-top', status: 'draft', sequence_rank: 0 },
+  ];
+  leaves.forEach((k, i) => {
+    sds.push({ id: `leaf-${k}`, sd_key: `SD-LEAF-${k}`, title: `Leaf ${k}`, venture_id: VID, sd_type: 'feature', parent_sd_id: 'orch-c', status: status[k] || 'draft', sequence_rank: i, dependencies: deps[k] || [] });
+  });
+  return sds;
+}
+const descendantsOf = (sds) => sds.filter((s) => s.id !== 'orch-top');
+const keys = (leaves) => leaves.map((l) => l.sd_key);
+
+// driveLeaf that completes the leaf + bubble-completes parents, capturing drive order + ctx.
+function capturingDrive(tables, captured) {
+  return async (leaf, ctx) => {
+    captured.push({ key: leaf.sd_key, dependencyContext: ctx.dependencyContext });
+    const all = tables.strategic_directives_v2;
+    const row = all.find((r) => r.sd_key === leaf.sd_key);
+    if (!row) return { completed: false };
+    row.status = 'completed';
+    let pid = row.parent_sd_id;
+    while (pid) {
+      const parent = all.find((r) => r.id === pid);
+      if (!parent) break;
+      const kids = all.filter((r) => r.parent_sd_id === parent.id);
+      if (kids.length && kids.every((k) => TERMINAL.includes(k.status))) { parent.status = 'completed'; pid = parent.parent_sd_id; }
+      else break;
+    }
+    return { completed: true };
+  };
+}
+
+// Hermetic flag handling — default state is "unset" (flag ON by default).
+let savedFlag;
+beforeEach(() => { savedFlag = process.env.DEPENDENCY_ORDERED_EXECUTION; delete process.env.DEPENDENCY_ORDERED_EXECUTION; });
+afterEach(() => { if (savedFlag === undefined) delete process.env.DEPENDENCY_ORDERED_EXECUTION; else process.env.DEPENDENCY_ORDERED_EXECUTION = savedFlag; });
+
+describe('FR-1 — dependency-ordered leaf selection', () => {
+  it('DC-1: a leaf with a non-terminal in-tree dependency is NOT selected; selectable once terminal', () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'] } }); // B depends on A (draft)
+    const d = descendantsOf(sds);
+    expect(keys(computeWorkableLeaves(d))).toEqual(['SD-LEAF-A', 'SD-LEAF-C']); // B blocked
+    d.find((x) => x.sd_key === 'SD-LEAF-A').status = 'completed';
+    expect(keys(computeWorkableLeaves(d))).toEqual(['SD-LEAF-B', 'SD-LEAF-C']); // B now selectable
+  });
+
+  it('DC-2: a cancelled dependency satisfies (terminal-tolerance, not completed-only)', () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'] }, status: { A: 'cancelled' } });
+    const d = descendantsOf(sds);
+    expect(keys(computeWorkableLeaves(d))).toContain('SD-LEAF-B'); // A is cancelled => satisfied
+  });
+
+  it('DC-3: an out-of-tree dependency sd_id is ignored (treated satisfied)', () => {
+    const sds = depTree({ deps: { B: ['SD-NOT-IN-THIS-TREE-001'] } });
+    expect(keys(computeWorkableLeaves(descendantsOf(sds)))).toContain('SD-LEAF-B');
+  });
+
+  it('DC-4: a bare "SD-…"/key string dependency gates', () => {
+    const sds = depTree({ deps: { C: ['SD-LEAF-A'] } }); // string form
+    expect(keys(computeWorkableLeaves(descendantsOf(sds)))).not.toContain('SD-LEAF-C');
+  });
+
+  it('DC-5: a { sd_id } object dependency gates', () => {
+    const sds = depTree({ deps: { C: [{ sd_id: 'SD-LEAF-A' }] } });
+    expect(keys(computeWorkableLeaves(descendantsOf(sds)))).not.toContain('SD-LEAF-C');
+  });
+
+  it('DC-6: {sd_key}-only / {predecessor}-only / free-text / blocks_phase entries are ignored', () => {
+    const sds = depTree({ deps: { B: [
+      { sd_key: 'SD-LEAF-A' }, { predecessor: 'SD-LEAF-A' },
+      { type: 'technical', dependency: 'some prereq' }, { type: 'sibling', blocks_phase: 'EXEC' },
+    ] } });
+    // none of these are SD references parseDependencies honors → B is NOT blocked even though A is draft
+    expect(keys(computeWorkableLeaves(descendantsOf(sds)))).toContain('SD-LEAF-B');
+  });
+
+  it('DC-7: a 2-node cycle falls back to legacy order and flags fellBack', () => {
+    const sds = depTree({ deps: { A: ['SD-LEAF-B'], B: ['SD-LEAF-A'] }, leaves: ['A', 'B'] });
+    const sel = selectWorkableLeaves(descendantsOf(sds));
+    expect(sel.fellBack).toBe(true);
+    expect(keys(sel.leaves)).toEqual(['SD-LEAF-A', 'SD-LEAF-B']); // full legacy order
+  });
+
+  it('DC-8: an all-blocked frontier (3-cycle) falls back to legacy order and flags fellBack', () => {
+    const sds = depTree({ deps: { A: ['SD-LEAF-C'], B: ['SD-LEAF-A'], C: ['SD-LEAF-B'] } });
+    const sel = selectWorkableLeaves(descendantsOf(sds));
+    expect(sel.fellBack).toBe(true);
+    expect(keys(sel.leaves)).toEqual(['SD-LEAF-A', 'SD-LEAF-B', 'SD-LEAF-C']);
+  });
+
+  it('DC-9: among dependency-clean leaves, ordering stays deepest-first then sequence_rank', () => {
+    const sds = depTree({ deps: { C: ['SD-LEAF-A'] } }); // C blocked by A
+    const d = descendantsOf(sds);
+    expect(keys(computeWorkableLeaves(d))).toEqual(['SD-LEAF-A', 'SD-LEAF-B']); // rank order preserved
+  });
+
+  it('DC-14: fetchDescendants SELECT includes dependencies and title', async () => {
+    const sds = depTree();
+    const sb = new MockSB(eligibleTables(sds));
+    await fetchDescendants(sb, 'orch-top');
+    const sel = sb.selects.find((s) => s.table === 'strategic_directives_v2' && /parent_sd_id/.test(s.cols));
+    expect(sel.cols).toContain('dependencies');
+    expect(sel.cols).toContain('title');
+  });
+});
+
+describe('FR-2 — context-aware driving', () => {
+  it('DC-11: buildDependencyContext carries completed-sibling keys/titles + non-SD manifest entries', () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A', { type: 'existing_module', path: 'src/x.tsx' }] }, status: { A: 'completed' } });
+    const d = descendantsOf(sds);
+    const ctx = buildDependencyContext(d.find((x) => x.sd_key === 'SD-LEAF-B'), d);
+    expect(ctx.completed).toEqual([{ sd_key: 'SD-LEAF-A', title: 'Leaf A' }]);
+    expect(ctx.context_entries).toEqual([{ type: 'existing_module', path: 'src/x.tsx' }]);
+  });
+
+  it('DC-11b: a cancelled dependency is excluded from completed context (no artifact produced)', () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'] }, status: { A: 'cancelled' } });
+    const d = descendantsOf(sds);
+    const ctx = buildDependencyContext(d.find((x) => x.sd_key === 'SD-LEAF-B'), d);
+    expect(ctx.completed).toEqual([]);
+  });
+
+  it('DC-11c: runConsume passes dependencyContext into driveLeaf', async () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'], C: ['SD-LEAF-A'] }, status: { A: 'completed' } });
+    const sb = new MockSB(eligibleTables(sds));
+    const captured = [];
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: capturingDrive(sb.tables, captured), now: () => 0 });
+    const b = captured.find((c) => c.key === 'SD-LEAF-B');
+    expect(b.dependencyContext.completed).toEqual([{ sd_key: 'SD-LEAF-A', title: 'Leaf A' }]);
+  });
+
+  it('DC-12: with the flag OFF, no dependencyContext is passed to driveLeaf', async () => {
+    process.env.DEPENDENCY_ORDERED_EXECUTION = 'false';
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'] }, status: { A: 'completed' } });
+    const sb = new MockSB(eligibleTables(sds));
+    const captured = [];
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: capturingDrive(sb.tables, captured), now: () => 0 });
+    expect(captured.every((c) => c.dependencyContext === undefined)).toBe(true);
+  });
+});
+
+describe('FR-3 — feature flag, parity, guardrail', () => {
+  it('flag default is ON; explicit false/0/off/no disables', () => {
+    expect(isDependencyOrderedExecutionEnabled()).toBe(true); // unset
+    for (const v of ['false', '0', 'off', 'no', 'FALSE']) { process.env.DEPENDENCY_ORDERED_EXECUTION = v; expect(isDependencyOrderedExecutionEnabled()).toBe(false); }
+    for (const v of ['true', '1', 'on', 'yes', '']) { process.env.DEPENDENCY_ORDERED_EXECUTION = v; expect(isDependencyOrderedExecutionEnabled()).toBe(true); }
+  });
+
+  it('DC-10: flag OFF => computeWorkableLeaves deep-equals legacy order (even with would-block deps); hermetic', () => {
+    process.env.DEPENDENCY_ORDERED_EXECUTION = 'false';
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'], C: ['SD-LEAF-A'] } }); // would block B,C when ON
+    const d = descendantsOf(sds);
+    expect(computeWorkableLeaves(d)).toEqual(legacyWorkableLeaves(d)); // B,C NOT gated out
+    expect(keys(computeWorkableLeaves(d))).toEqual(['SD-LEAF-A', 'SD-LEAF-B', 'SD-LEAF-C']);
+  });
+
+  it('DC-15: runConsume drives a dependency predecessor BEFORE its dependent leaf', async () => {
+    const sds = depTree({ deps: { B: ['SD-LEAF-A'] } }); // B depends on A (both draft)
+    const sb = new MockSB(eligibleTables(sds));
+    const captured = [];
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: capturingDrive(sb.tables, captured), now: () => 0 });
+    const order = captured.map((c) => c.key);
+    expect(order.indexOf('SD-LEAF-A')).toBeLessThan(order.indexOf('SD-LEAF-B')); // predecessor first
+  });
+
+  it('DC-7b: runConsume emits dependency_fallback once on a stalled (cyclic) frontier', async () => {
+    const sds = depTree({ deps: { A: ['SD-LEAF-B'], B: ['SD-LEAF-A'] }, leaves: ['A', 'B'] });
+    const sb = new MockSB(eligibleTables(sds));
+    const captured = [];
+    await runConsume({ supabase: sb, ventureId: VID, driveLeaf: capturingDrive(sb.tables, captured), now: () => 0 });
+    const fallbacks = sb.inserts.filter((i) => i.table === 'system_events' && i.row.event_type === 'dependency_fallback');
+    expect(fallbacks.length).toBe(1); // once per frontier-stall, not per leaf
+  });
+
+  it('DC-13: static guardrail — consumer source has zero _advanceStage and no stage/chairman/vision writes', () => {
+    const src = readFileSync(LIB_PATH, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(src).not.toMatch(/_advanceStage/);
+    expect(src).not.toMatch(/current_lifecycle_stage\s*:/); // no stage WRITE (object-key form)
+    expect(src).not.toMatch(/chairman_decisions|chairman_approved\s*:/);
+    expect(src).not.toMatch(/advance_venture_stage/);
+  });
+});


### PR DESCRIPTION
## Summary

Context-aware dependency-ordered execution in the leo_bridge venture-build consumer. The consumer now honors in-tree build-order dependencies when selecting workable leaves and threads sibling/manifest context into each child-agent build.

## Changes

### FR-1: Dependency-gated leaf selection
The leo_bridge venture-build consumer (`lib/eva/bridge/venture-build-consumer.js`) now gates leaf selection on terminal-tolerant in-tree build-order dependencies. It reuses the canonical `parseDependencies` and the consumer's existing `TERMINAL` set to decide whether a leaf's dependencies are satisfied (a dependency in a terminal state counts as satisfied). A deadlock fail-safe detects a stalled frontier (no leaf has its dependencies met) and falls back to legacy selection order, emitting `dependency_fallback` once per frontier-stall so the stall is observable without log spam.

### FR-2: Dependency context threading
`runConsume` assembles a `dependencyContext` (completed sibling SDs plus non-SD manifest entries) and passes it to `driveLeaf`. The `/leo-build-venture` skill injects this context into the child-agent prompt so each per-leaf build is aware of what its dependencies produced.

### FR-3: Feature flag + tests
`DEPENDENCY_ORDERED_EXECUTION` feature flag (default ON). When OFF, leaf selection is byte-identical to the legacy path. A 19-case unit suite covers the new behavior, including a never-advance static guardrail asserting the consumer's `_advanceStage` call-site count stays 0 (the consumer never advances stages).

## Predecessor

Builds on SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 (#4161), the writer that populates the `dependencies` column this consumer now reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
