### PR TITLE
feat(SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001): vision-grounded acceptance gate at S19->S20

### DIFF
--- a/.claude/commands/leo-verify-venture.md
+++ b/.claude/commands/leo-verify-venture.md
@@ -1,0 +1,98 @@
+<!-- reasoning_effort: high -->
+
+---
+description: Verify a built leo_bridge venture against its chairman-approved vision before S19→S20 (session-hosted judge; records a verdict, never advances/approves)
+argument-hint: [--venture-id <uuid> | --venture <name>] [--dry-run]
+---
+
+# /leo-verify-venture — vision-grounded acceptance JUDGE (session-hosted)
+
+You are the **session-hosted live judge** for the vision-grounded acceptance gate
+(SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 — campaign "intelligent-venture-build" #3 of 3). After
+the leo_bridge build consumer (`/leo-build-venture`) drives a venture's SD tree to completion at
+Stage 19, this skill judges whether the **built venture actually satisfies the chairman-approved
+vision's acceptance criteria** and records a pass/gaps verdict. The headless `stage-execution-worker`
+S19 gate then READS that verdict and HOLDs the venture on a FAIL — it is the worker, never you, that
+advances S19→S20.
+
+The pure GATHER + STORE logic lives in `lib/eva/bridge/venture-vision-verifier.js`. You ARE the
+injected `verifyVenture` judge, because comparing a running venture against a vision needs live
+inspection (reading the repo, opening the deployment) that no headless loop can do.
+
+## ⚠️ NEVER-ADVANCE / NEVER-APPROVE invariant (RCA a14ff998 — the S19 gate-bypass incident)
+
+You MUST NOT, under any circumstance:
+- advance the venture, write `ventures.current_lifecycle_stage`, or call any `_advanceStage` path
+- create or approve a `chairman_decision`, set `chairman_approved`, or approve/modify a vision
+- mark the venture "verified-good" by any means other than recording the verdict below
+
+The venture **stays at Stage 19** the entire time. Your only write is the recorded
+`vision_acceptance_verdict` (via `--record`). A PASS verdict merely lets the worker's existing,
+exit-gated advance proceed; a FAIL verdict HOLDs the venture for corrective work. You never advance.
+
+## Step 1 — Resolve the venture and introspect (ZERO writes)
+
+Determine the `<venture-id>` (from `--venture-id`, or resolve `--venture <name>` against
+`ventures.name`). Then introspect — this makes **zero writes**:
+
+```bash
+node lib/eva/bridge/venture-vision-verifier.js --venture-id <venture-id> --dry-run
+```
+
+This prints `visionPresent`, the current `vision_acceptance_verdict` (or `(none)`), and the gathered
+inputs (`repoUrl`, `deploymentUrl`, `buildVerdict`, and the count of vision `extracted_dimensions`).
+
+- If `visionPresent` is false → **STOP**. There is no chairman-approved L2 vision to verify against;
+  the existing `VISION_MISSING` gate already owns that case. Do not record a verdict.
+- If a current verdict already exists and you were only asked to introspect (`--dry-run` passed by the
+  operator) → report it and stop.
+- Otherwise proceed to Step 2.
+
+## Step 2 — Judge the built venture against the vision (you ARE verifyVenture)
+
+Gather the acceptance criteria and the built result, then judge each criterion with EVIDENCE:
+
+1. **Read the vision's acceptance criteria** — the chairman-approved L2 `eva_vision_documents` row's
+   `extracted_dimensions` (each `{ name, description, weight }`) plus its `content`. These are what
+   "good" means for this venture.
+2. **Inspect the RUNNING built venture** — read the cloned repo at `applications.local_path` (its real
+   structure, routes, components, data layer) and, where useful, open the `deployment_url`. Ground
+   every judgment in what the venture ACTUALLY contains, exactly as enhancement #1 grounded
+   decomposition in the real repo — do not judge from the SD titles or the marketing copy.
+3. **Score each dimension** `pass` / `gap` with a one-line evidence string citing what you found (or
+   failed to find) in the repo/deployment. Treat `buildVerdict === 'FAIL'` as a strong negative signal.
+4. **Decide the overall verdict**: `pass = true` only if every load-bearing dimension is satisfied;
+   otherwise `pass = false` with a `gaps` list. For each gap, propose a **corrective SD stub**
+   (`{ title, rationale }`) in `corrective_sds` — these are PROPOSALS for the operator/chairman, never
+   auto-created here.
+
+It is purely informational grounding for the operator; it never relaxes the never-advance /
+never-approve constraints above.
+
+## Step 3 — Record the verdict (the only write)
+
+Write your judgment to a temp JSON and persist it through the canonical store (read-merge-write into
+`venture_stage_work.advisory_data.vision_acceptance_verdict` + a `system_events` audit row):
+
+```bash
+# verdict.json — your judgment:
+# { "pass": false,
+#   "criteria_results": [ { "name": "Landing converts", "pass": true, "evidence": "Hero + CTA present in src/pages/Home.tsx" } ],
+#   "gaps": [ { "name": "Email capture", "evidence": "No signup form or POST handler found in the repo" } ],
+#   "corrective_sds": [ { "title": "Add email capture form + handler", "rationale": "Vision dimension 'Email capture' unmet" } ],
+#   "evaluated_by": "leo-verify-venture" }
+node lib/eva/bridge/venture-vision-verifier.js --venture-id <venture-id> --record verdict.json
+```
+
+This is a RECORD, not a headless judge (no `verifyVenture` runs) — it never advances or approves.
+Delete the temp `verdict.json` afterward.
+
+## Step 4 — Report
+
+Summarize: the venture, `pass`/`gaps`, the per-dimension evidence, and (on gaps) the proposed
+corrective SDs. Remind the operator:
+
+- On **PASS**: the worker's existing S19→S20 exit gate will advance the venture on its next poll
+  (confirm by re-reading `ventures.current_lifecycle_stage` — it is the WORKER, not you, that advances).
+- On **GAPS**: the venture is safely HELD at Stage 19 (`VISION_ACCEPTANCE_GATE` default ON). Create the
+  proposed corrective SDs (or escalate to the chairman) and re-run `/leo-verify-venture` after they land.

--- a/lib/eva/bridge/venture-vision-verifier.js
+++ b/lib/eva/bridge/venture-vision-verifier.js
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * venture-vision-verifier — the GATHER + STORE half of the vision-grounded acceptance gate.
+ *
+ * SD: SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-3). Campaign "intelligent-venture-build" #3 of 3.
+ *
+ * After the leo_bridge build consumer drives a venture's SD tree to completion at Stage 19, the
+ * built venture must be VERIFIED against the chairman-approved vision's acceptance criteria before the
+ * worker advances S19->S20. The per-venture JUDGMENT (reading the running venture vs the vision
+ * dimensions) needs a live Claude session, so — exactly like venture-build-consumer's runConsume
+ * ({driveLeaf}) seam — this module owns the headlessly-testable GATHER + STORE and the judge is
+ * INJECTED: runVerify({ verifyVenture }). The production judge is the .claude/commands/leo-verify-venture
+ * skill. The CLI here supports only --dry-run introspection (it refuses to "verify" headlessly).
+ *
+ * The recorded verdict lives at venture_stage_work.advisory_data.vision_acceptance_verdict
+ * (lifecycle_stage=19); the worker S19 hold path (FR-2, vision-acceptance-gate.js) reads it and HOLDs
+ * on a FAIL. No schema change — advisory_data is an existing JSONB column; the audit trail reuses the
+ * existing system_events.payload/details columns.
+ *
+ * NEVER-ADVANCE / NEVER-APPROVE invariant (RCA a14ff998). This module:
+ *   - NEVER advances the venture, adds an advance path, or writes the venture lifecycle stage column
+ *   - NEVER creates or approves a governance decision and NEVER approves a vision
+ *   - performs PURE filesystem/database reads when gathering the built-venture artifacts — it never
+ *     spawns/exec/evals repo code and never fetches-and-runs the deployment URL (all live inspection
+ *     happens inside the supervised /leo-verify-venture skill, never in this lib).
+ * An executable static-source guardrail test enforces this invariant.
+ *
+ * Usage:
+ *   node lib/eva/bridge/venture-vision-verifier.js --venture-id <uuid> --dry-run   # introspect, ZERO writes
+ *   (a real verify is session-hosted: invoke the /leo-verify-venture skill in a live Claude session)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import pg from 'pg';
+
+export const S19 = 19;
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+function buildPgClient() {
+  const conn = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.POSTGRES_URL;
+  if (!conn) return null; // graceful — no PG conn → marker/last-writer semantics (still read-merge-write)
+  return new pg.Client({ connectionString: conn });
+}
+
+async function tryAdvisoryLock(client, name) {
+  if (!client) return { acquired: true, mock: true }; // no client → no real lock; read-merge-write still applies
+  const k = await client.query('SELECT hashtext($1)::int AS k', [name]);
+  const r = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [k.rows[0].k]);
+  return { acquired: r.rows[0].acquired === true, key: k.rows[0].k, mock: false };
+}
+
+async function releaseAdvisoryLock(client, key) {
+  if (!client || key == null) return;
+  try { await client.query('SELECT pg_advisory_unlock($1)', [key]); } catch { /* best-effort */ }
+}
+
+/**
+ * PURE read-only gather of the verification inputs: the chairman-approved L2 vision dimensions plus
+ * the built-venture artifacts. Never mutates; never executes repo/deployment code.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @returns {Promise<object>} inputs for the judge
+ */
+export async function gatherVerificationInputs(supabase, ventureId) {
+  // Chairman-approved L2 vision — select extracted_dimensions EXPLICITLY (assertVentureVisionReady
+  // returns only vision_key/version/content/updated_at; the acceptance criteria are extracted_dimensions).
+  const { data: vision } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, version, content, updated_at, extracted_dimensions')
+    .eq('venture_id', ventureId)
+    .eq('level', 'L2')
+    .eq('status', 'active')
+    .eq('chairman_approved', true)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // Built-venture repo + deployment — ventures is the SSOT (the venture_resources repo_url/deployment_url
+  // columns were never applied to live; ERROR 42703).
+  const { data: venture } = await supabase
+    .from('ventures')
+    .select('repo_url, deployment_url, name')
+    .eq('id', ventureId)
+    .maybeSingle();
+
+  // build_mvp_build artifact — ground the built-state on artifact_data.verdict (FAIL = failed build),
+  // mirroring verifyBuildMvpBuildPresent in lib/eva/lifecycle/exit-gate-verifiers.js.
+  const { data: buildArtifact } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data, content')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'build_mvp_build')
+    .eq('is_current', true)
+    .limit(1)
+    .maybeSingle();
+  const buildVerdict = buildArtifact?.artifact_data?.verdict ?? null;
+
+  // Best-effort local clone path (the judge can also resolve the repo via repo_url). Tolerant: any
+  // lookup error leaves localPath null rather than aborting the gather.
+  let localPath = null;
+  try {
+    if (venture?.repo_url) {
+      const { data: app } = await supabase
+        .from('applications')
+        .select('id, local_path, repo_url')
+        .eq('repo_url', venture.repo_url)
+        .limit(1)
+        .maybeSingle();
+      localPath = app?.local_path ?? null;
+    }
+  } catch { /* applications lookup is best-effort */ }
+
+  return {
+    visionPresent: !!vision,
+    visionDimensions: vision?.extracted_dimensions || [],
+    visionKey: vision?.vision_key || null,
+    visionContent: vision?.content || null,
+    ventureName: venture?.name || null,
+    repoUrl: venture?.repo_url || null,
+    deploymentUrl: venture?.deployment_url || null,
+    buildVerdict,
+    localPath,
+  };
+}
+
+async function readStageWork(supabase, ventureId) {
+  const { data } = await supabase
+    .from('venture_stage_work')
+    .select('id, advisory_data')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', S19)
+    .maybeSingle();
+  return data || null;
+}
+
+/**
+ * Append-only audit row for a recorded verdict. system_events has NO event_data column — dual-write
+ * to payload + details (mirrors _emitS19HardGateEvent). Best-effort + non-fatal.
+ */
+async function emitVerdictEvent(supabase, ventureId, verdict) {
+  try {
+    const stamp = verdict.evaluated_at || new Date().toISOString();
+    const payload = {
+      venture_id: ventureId, from_stage: S19, build_model: 'leo_bridge',
+      verdict_pass: verdict.pass,
+      gaps: Array.isArray(verdict.gaps) ? verdict.gaps.length : 0,
+      corrective_sds: verdict.corrective_sds || [],
+      evaluated_by: verdict.evaluated_by,
+    };
+    await supabase.from('system_events').insert({
+      event_type: 'VISION_ACCEPTANCE_VERDICT',
+      venture_id: ventureId,
+      idempotency_key: `VISION_ACCEPTANCE_VERDICT:${ventureId}:${Date.parse(stamp)}`,
+      payload,
+      details: payload,
+      created_at: stamp,
+    });
+  } catch { /* audit is best-effort, non-fatal */ }
+}
+
+/**
+ * Read-merge-write the verdict into venture_stage_work.advisory_data.vision_acceptance_verdict — set
+ * ONLY the verdict key, never clobber sibling S19 keys (reason / bridge_failed / chairman_override).
+ * Guarded by a per-venture advisory lock when a PG connection is available (marker/last-writer
+ * otherwise). Plus the append-only system_events audit row.
+ */
+async function storeVerdict({ supabase, pgClient, ventureId, verdict, logger }) {
+  const client = pgClient !== undefined ? pgClient : buildPgClient();
+  let connected = false;
+  let lockKey = null;
+  try {
+    if (client && typeof client.connect === 'function') {
+      try { await client.connect(); connected = true; } catch { /* fall back to read-merge-write */ }
+    }
+    const lock = await tryAdvisoryLock(connected ? client : null, `vision-verify:${ventureId}`);
+    lockKey = lock.key;
+
+    const row = await readStageWork(supabase, ventureId);
+    const merged = { ...(row?.advisory_data || {}), vision_acceptance_verdict: verdict };
+    if (row?.id) {
+      await supabase.from('venture_stage_work').update({ advisory_data: merged }).eq('id', row.id);
+    } else {
+      await supabase.from('venture_stage_work').insert({ venture_id: ventureId, lifecycle_stage: S19, advisory_data: merged });
+    }
+    await emitVerdictEvent(supabase, ventureId, verdict);
+  } finally {
+    if (connected) {
+      await releaseAdvisoryLock(client, lockKey);
+      try { await client.end(); } catch { /* best-effort */ }
+    }
+  }
+  logger?.log?.(`[verify] recorded vision_acceptance_verdict (pass=${verdict.pass}) for venture ${ventureId}`);
+}
+
+/**
+ * Gather the vision + built-venture artifacts, run the INJECTED judge, and record the verdict.
+ *
+ *   - dryRun=true OR no verifyVenture injected → introspect only (gather + read current verdict),
+ *     ZERO writes, NEVER invokes the judge. This is the read-only CLI path.
+ *   - no chairman-approved L2 vision → skip (defer to the existing VISION_MISSING gate); never approve.
+ *   - otherwise → verdict = verifyVenture(visionDimensions, ventureArtifacts); stamp + read-merge-write.
+ *
+ * The judge signature: verifyVenture(visionDimensions, ventureArtifacts) ->
+ *   { pass:boolean, criteria_results?:[], gaps?:[], corrective_sds?:[], evaluated_by?:string }.
+ *
+ * @param {{supabase:object, ventureId:string, verifyVenture?:Function, dryRun?:boolean, logger?:object, pgClient?:any}} args
+ */
+export async function runVerify({ supabase, ventureId, verifyVenture, dryRun = false, logger = console, pgClient = undefined }) {
+  if (!ventureId) throw new Error('runVerify: ventureId required');
+
+  const inputs = await gatherVerificationInputs(supabase, ventureId);
+  const stageWork = await readStageWork(supabase, ventureId);
+  const currentVerdict = stageWork?.advisory_data?.vision_acceptance_verdict ?? null;
+
+  // Read-only introspection: dry-run, or no live judge injected (the real judge is session-hosted).
+  if (dryRun || typeof verifyVenture !== 'function') {
+    return { dryRun: true, wrote: false, ventureId, visionPresent: inputs.visionPresent, currentVerdict, inputs };
+  }
+
+  if (!inputs.visionPresent) {
+    logger?.warn?.(`[verify] venture ${ventureId}: no chairman-approved L2 vision — skipping (defer to VISION_MISSING gate)`);
+    return { dryRun: false, wrote: false, skipped: true, reason: 'no_approved_l2_vision', ventureId };
+  }
+
+  const judged = await verifyVenture(inputs.visionDimensions, {
+    repoUrl: inputs.repoUrl, deploymentUrl: inputs.deploymentUrl, localPath: inputs.localPath,
+    buildVerdict: inputs.buildVerdict, visionKey: inputs.visionKey, visionContent: inputs.visionContent,
+    ventureName: inputs.ventureName,
+  });
+
+  const verdict = normalizeVerdict(judged);
+  await storeVerdict({ supabase, pgClient, ventureId, verdict, logger });
+  return { dryRun: false, wrote: true, ventureId, verdict };
+}
+
+/**
+ * Coerce a raw judge verdict into the canonical recorded shape. pass is strictly === true (an absent
+ * or non-boolean pass becomes false, never a silent pass — mirrors classifyVisionAcceptance's
+ * undefined-vs-false care).
+ * @param {object|null|undefined} raw
+ */
+export function normalizeVerdict(raw) {
+  return {
+    pass: raw?.pass === true,
+    criteria_results: Array.isArray(raw?.criteria_results) ? raw.criteria_results : [],
+    gaps: Array.isArray(raw?.gaps) ? raw.gaps : [],
+    corrective_sds: Array.isArray(raw?.corrective_sds) ? raw.corrective_sds : [],
+    evaluated_at: raw?.evaluated_at || new Date().toISOString(),
+    evaluated_by: raw?.evaluated_by || 'leo-verify-venture',
+  };
+}
+
+/**
+ * Persist a verdict the live judge (the /leo-verify-venture skill) has ALREADY produced — through the
+ * same canonical read-merge-write store + audit as runVerify. This is NOT headless judging (no
+ * verifyVenture is invoked); it only records the session-hosted judgment. Never advances/approves.
+ * @param {{supabase:object, ventureId:string, verdict:object, pgClient?:any, logger?:object}} args
+ */
+export async function recordVerdict({ supabase, ventureId, verdict, pgClient = undefined, logger = console }) {
+  if (!ventureId) throw new Error('recordVerdict: ventureId required');
+  const normalized = normalizeVerdict(verdict);
+  await storeVerdict({ supabase, pgClient, ventureId, verdict: normalized, logger });
+  return { wrote: true, ventureId, verdict: normalized };
+}
+
+function parseArgs(argv) {
+  const a = { ventureId: null, dryRun: false, record: null, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const x = argv[i];
+    if (x === '--venture-id' && argv[i + 1]) a.ventureId = argv[++i];
+    else if (x === '--dry-run') a.dryRun = true;
+    else if (x === '--record' && argv[i + 1]) a.record = argv[++i];
+    else if (x === '--help' || x === '-h') a.help = true;
+  }
+  return a;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.ventureId) {
+    console.log('Usage: node lib/eva/bridge/venture-vision-verifier.js --venture-id <uuid> [--dry-run | --record <verdict.json>]');
+    console.log('  --dry-run         introspect the recorded vision_acceptance_verdict + gathered inputs (ZERO writes).');
+    console.log('  --record <file>   persist a verdict the live /leo-verify-venture judge already produced (read-merge-write + audit).');
+    console.log('  A real verify is session-hosted: invoke the /leo-verify-venture skill in a live Claude session.');
+    process.exit(args.ventureId ? 0 : 2);
+  }
+  const supabase = buildSupabase();
+  if (args.record) {
+    // Persist a verdict the live session-hosted judge already produced. This RECORDS (read-merge-write
+    // + audit) — it does NOT judge headlessly (no verifyVenture is invoked) and never advances/approves.
+    const fs = await import('fs');
+    const raw = JSON.parse(fs.readFileSync(args.record, 'utf8'));
+    const res = await recordVerdict({ supabase, ventureId: args.ventureId, verdict: raw });
+    console.log(`Recorded vision_acceptance_verdict (pass=${res.verdict.pass}, gaps=${res.verdict.gaps.length}) for venture ${args.ventureId}`);
+    process.exit(0);
+  }
+  if (!args.dryRun) {
+    // The verification JUDGE is a live Claude session (the /leo-verify-venture skill); the CLI refuses
+    // to verify headlessly (there is no headless judge). Only --dry-run introspection is supported.
+    console.error('Refusing headless verify: the live judge is session-hosted (/leo-verify-venture). Re-run with --dry-run to introspect.');
+    process.exit(2);
+  }
+  const res = await runVerify({ supabase, ventureId: args.ventureId, dryRun: true });
+  console.log(JSON.stringify({
+    ventureId: res.ventureId,
+    visionPresent: res.visionPresent,
+    currentVerdict: res.currentVerdict || '(none)',
+    gatheredInputs: {
+      repoUrl: res.inputs?.repoUrl || null,
+      deploymentUrl: res.inputs?.deploymentUrl || null,
+      buildVerdict: res.inputs?.buildVerdict || null,
+      visionDimensions: Array.isArray(res.inputs?.visionDimensions) ? res.inputs.visionDimensions.length : 0,
+    },
+  }, null, 2));
+  process.exit(0);
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('lib/eva/bridge/venture-vision-verifier.js');
+if (invokedDirectly) {
+  main().catch((err) => { console.error(`[verify] fatal: ${err.message}`); process.exit(2); });
+}

--- a/lib/eva/bridge/vision-acceptance-gate.js
+++ b/lib/eva/bridge/vision-acceptance-gate.js
@@ -1,0 +1,97 @@
+/**
+ * SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-1): the single, pure, tested decision for whether
+ * a leo_bridge venture must HOLD at Stage 19 because its built result has not been verified to
+ * satisfy the chairman-approved vision. No DB access, no side effects — the truth table is
+ * unit-testable in isolation and the worker S19 hold path (FR-2) consumes exactly ONE decision.
+ *
+ * Campaign "intelligent-venture-build" enhancement #3 of 3 (after #1 repo-grounded decomposition and
+ * #2 context-aware dependency-ordered execution): the pipeline now VERIFIES its result against the
+ * vision before advancement — "plan from reality -> build with context -> verify against vision". The
+ * verdict itself is produced session-hosted (the /leo-verify-venture skill is the injected judge in
+ * venture-vision-verifier.js) and recorded in venture_stage_work.advisory_data.vision_acceptance_verdict;
+ * this module only CLASSIFIES a recorded verdict and decides hold/advance.
+ *
+ * Never-advance invariant (RCA a14ff998 — the S19 gate-bypass incident): this lib contains no advance
+ * path, no venture stage write, and no governance/vision approval. The worker change it backs is a
+ * break-HOLD only, which reaches zero of the seven _advanceStage call sites.
+ */
+
+/** Classification of a recorded vision-acceptance verdict. */
+export const VISION_ACCEPTANCE = Object.freeze({
+  VERIFIED_PASS: 'verified_pass',   // verdict.pass === true  → the built venture satisfies the vision
+  VERIFIED_GAPS: 'verified_gaps',   // verdict.pass === false → gaps vs the vision → HOLD
+  NOT_EVALUATED: 'not_evaluated',   // no verdict recorded yet (undefined/null/no boolean pass key)
+  NO_VISION: 'no_vision',           // explicit "no chairman-approved vision" marker
+});
+
+/**
+ * Classify a recorded verdict object into exactly one VISION_ACCEPTANCE outcome.
+ *
+ * null / undefined / {} (no boolean `pass` key) map to NOT_EVALUATED and must NEVER be coerced to
+ * VERIFIED_PASS — the undefined-vs-false distinction is load-bearing: it decides whether the gate is
+ * even active (mirrors the null-vs-false care in s19-advance-decision.js). An explicit
+ * { no_vision: true } marker maps to NO_VISION so the caller can defer to the existing VISION_MISSING
+ * gate rather than double-handling the no-vision case.
+ *
+ * @param {{pass?: boolean, no_vision?: boolean}|null|undefined} verdict
+ * @returns {string} one of VISION_ACCEPTANCE
+ */
+export function classifyVisionAcceptance(verdict) {
+  if (verdict && verdict.no_vision === true) return VISION_ACCEPTANCE.NO_VISION;
+  if (!verdict || typeof verdict.pass !== 'boolean') return VISION_ACCEPTANCE.NOT_EVALUATED;
+  return verdict.pass === true ? VISION_ACCEPTANCE.VERIFIED_PASS : VISION_ACCEPTANCE.VERIFIED_GAPS;
+}
+
+/**
+ * THE single hold/advance decision for the vision-acceptance gate at Stage 19.
+ *
+ *   - buildComplete === false → no-hold. A venture is only vision-verified once its build is COMPLETE.
+ *     The NOOP_EMPTY 0-payload case proceeds past shouldHoldAtS19 with buildComplete===false (nothing
+ *     was built), and a stale VERIFIED_GAPS from a prior partial build must not block a later-completed
+ *     build. (buildComplete===true, or null for a non-leo_bridge built venture, proceed to evaluation.)
+ *   - VERIFIED_GAPS → HOLD always (the built venture has verified gaps vs the vision).
+ *   - VERIFIED_PASS → no-hold (the built venture satisfies the vision; the existing normal advance runs).
+ *   - NO_VISION    → no-hold (defer to the existing shouldHoldAtS19 VISION_MISSING gate; never race it).
+ *   - NOT_EVALUATED → HOLD only under strict mode. The default fail-open posture is a zero-regression
+ *     rollout (detection on an explicit FAIL only); strict flips it to enforce verify-before-advance
+ *     once the session-hosted verifier is wired into the autonomous build flow.
+ *
+ * @param {{verdict?: object|null, buildComplete?: boolean|null, strict?: boolean}} [args]
+ * @returns {boolean} true = HOLD at S19 (do not advance); false = ADVANCE / no-op
+ */
+export function shouldHoldForVisionAcceptance({ verdict, buildComplete, strict = false } = {}) {
+  if (buildComplete === false) return false; // only a complete build is verified
+  const outcome = classifyVisionAcceptance(verdict);
+  switch (outcome) {
+    case VISION_ACCEPTANCE.VERIFIED_GAPS: return true;             // gaps vs vision → HOLD
+    case VISION_ACCEPTANCE.VERIFIED_PASS: return false;            // satisfies vision → advance
+    case VISION_ACCEPTANCE.NO_VISION:     return false;            // defer to existing VISION_MISSING gate
+    case VISION_ACCEPTANCE.NOT_EVALUATED: return strict === true;  // fail-open unless strict
+    default:                              return false;
+  }
+}
+
+/**
+ * Feature flag: the vision-acceptance gate. Default ON; only an explicit false/0/off/no disables it
+ * (then the worker S19 hold block is skipped entirely — byte-identical legacy advance). Mirrors
+ * isDependencyOrderedExecutionEnabled in venture-build-consumer.js.
+ */
+export function isVisionAcceptanceGateEnabled() {
+  const v = process.env.VISION_ACCEPTANCE_GATE;
+  if (v === undefined || v === '') return true;
+  const s = String(v).toLowerCase();
+  return s !== 'false' && s !== '0' && s !== 'off' && s !== 'no';
+}
+
+/**
+ * Strict mode: when ON, a NOT_EVALUATED venture (no recorded verdict) HOLDS at S19 — enforcing
+ * verify-before-advance. Default OFF (fail-open on an unrecorded verdict) for a zero-regression
+ * rollout; flip ON once the session-hosted /leo-verify-venture verifier writes verdicts in the
+ * autonomous build flow (proven against a real venture, e.g. DataDistill).
+ */
+export function isVisionAcceptanceStrict() {
+  const v = process.env.VISION_ACCEPTANCE_STRICT;
+  if (v === undefined || v === '') return false;
+  const s = String(v).toLowerCase();
+  return s === 'true' || s === '1' || s === 'on' || s === 'yes';
+}

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -41,6 +41,8 @@ import { shouldOpenChairmanGate } from './should-open-chairman-gate.js';
 // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single pure bridge-outcome classifier + S19
 // hold/advance decision shared by every S19 gate consumer (closes RCA 7610876f schism).
 import { classifyBridgeOutcome, shouldHoldAtS19, S19_BRIDGE_OUTCOME } from './bridge/s19-advance-decision.js';
+// SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-2): vision-grounded acceptance gate (pure decision).
+import { shouldHoldForVisionAcceptance, isVisionAcceptanceGateEnabled, isVisionAcceptanceStrict } from './bridge/vision-acceptance-gate.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -1342,6 +1344,29 @@ export class StageExecutionWorker {
             // idempotent / chairman_override). Resolve any pending vision_approval decision so it
             // clears the chairman Decision Deck once the venture advances past S19.
             await this._resolveVisionPendingDecision(ventureId);
+          }
+        }
+
+        // SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-2): vision-grounded acceptance gate.
+        // The S19 build-readiness gate above has PROCEEDED (so the venture is past the vision_pending
+        // and build-incomplete holds). Consult the session-hosted vision-acceptance verdict recorded
+        // in advisory_data and HOLD (fail CLOSED) when the built venture has verified GAPS vs the
+        // chairman-approved vision. This is a break-HOLD only — it reaches ZERO _advanceStage call
+        // sites and adds no advance path. Default fail-open on an unrecorded verdict (strict=OFF) for a
+        // zero-regression rollout; flag OFF skips the block entirely (byte-identical legacy advance).
+        if (currentStage === 19 && isVisionAcceptanceGateEnabled()) {
+          const { hold: visionHold, verdict: visionVerdict } = await this._evaluateVisionAcceptanceHold(ventureId);
+          if (visionHold) {
+            this._logger.error(`[Worker] S19 gate (vision-acceptance): HOLD — built venture ${ventureId} failed vision acceptance (verdict.pass=${visionVerdict?.pass ?? 'none'}, strict=${isVisionAcceptanceStrict()}, gaps=${Array.isArray(visionVerdict?.gaps) ? visionVerdict.gaps.length : 0}).`);
+            await this._emitS19HardGateEvent(ventureId, 'S19_VISION_ACCEPTANCE_HOLD', {
+              verdict_pass: visionVerdict?.pass ?? null,
+              gaps: Array.isArray(visionVerdict?.gaps) ? visionVerdict.gaps.length : null,
+              strict: isVisionAcceptanceStrict(),
+              reason: 'vision_acceptance_pending', decided_by: 's19_vision_acceptance_gate',
+            });
+            releaseState = ORCHESTRATOR_STATES.BLOCKED;
+            lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'vision_acceptance_pending' };
+            break;
           }
         }
 
@@ -3450,6 +3475,25 @@ export class StageExecutionWorker {
     const allTerminal = sds.every((sd) => TERMINAL.has(sd.status));
     const anyCompleted = sds.some((sd) => COMPLETED.has(sd.status));
     return allTerminal && anyCompleted;
+  }
+
+  /**
+   * SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-2): evaluate the vision-acceptance HOLD for the
+   * S19 gate. PURE of side effects (DB reads only — no advance, no stage write, no governance/vision
+   * write): reads the session-hosted vision_acceptance_verdict recorded in advisory_data, recomputes
+   * buildComplete, and delegates to the pure shouldHoldForVisionAcceptance decision. The caller
+   * performs the break-HOLD; this method never advances. Extracted as a thin testable seam.
+   * @param {string} ventureId
+   * @returns {Promise<{hold: boolean, verdict: object|undefined}>}
+   */
+  async _evaluateVisionAcceptanceHold(ventureId) {
+    const { data: vaWork } = await this._supabase
+      .from('venture_stage_work').select('advisory_data')
+      .eq('venture_id', ventureId).eq('lifecycle_stage', 19).maybeSingle();
+    const verdict = vaWork?.advisory_data?.vision_acceptance_verdict;
+    const buildComplete = await this._isLeoBridgeBuildComplete(ventureId);
+    const hold = shouldHoldForVisionAcceptance({ verdict, buildComplete, strict: isVisionAcceptanceStrict() });
+    return { hold, verdict };
   }
 
   /**

--- a/tests/unit/eva/bridge/venture-vision-verifier.test.js
+++ b/tests/unit/eva/bridge/venture-vision-verifier.test.js
@@ -1,0 +1,184 @@
+/**
+ * SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-3) — the GATHER + STORE verifier lib. Mirrors the
+ * MockSB pattern of dependency-ordered-execution.test.js. The judge is INJECTED (no live agent), so
+ * these run headlessly. VA-18..VA-24 from the PRD test_scenarios.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import {
+  runVerify, gatherVerificationInputs, recordVerdict, normalizeVerdict,
+} from '../../../../lib/eva/bridge/venture-vision-verifier.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = resolve(__dirname, '../../../../lib/eva/bridge/venture-vision-verifier.js');
+
+// ---- Minimal mutable mock of the supabase query builder (records selects/inserts/updates) ----
+class MockQuery {
+  constructor(sb, table) { this.sb = sb; this.table = table; this._op = 'select'; this._filters = []; this._payload = null; this._limit = null; this._single = false; }
+  select(cols) { this._op = this._op === 'insert' || this._op === 'update' ? this._op : 'select'; this._cols = cols; this.sb.selects.push({ table: this.table, cols }); return this; }
+  insert(obj) { this._op = 'insert'; this._payload = obj; return this; }
+  update(obj) { this._op = 'update'; this._payload = obj; return this; }
+  eq(c, v) { this._filters.push(['eq', c, v]); return this; }
+  order() { return this; }
+  limit(n) { this._limit = n; return this; }
+  maybeSingle() { this._single = true; return this._exec(); }
+  then(res, rej) { return this._exec().then(res, rej); }
+  _match(row) { return this._filters.every(([op, c, v]) => (op === 'eq' ? row[c] === v : true)); }
+  async _exec() {
+    const rows = this.sb.tables[this.table] || (this.sb.tables[this.table] = []);
+    if (this._op === 'insert') {
+      const items = Array.isArray(this._payload) ? this._payload : [this._payload];
+      for (const it of items) { rows.push({ ...it }); this.sb.inserts.push({ table: this.table, row: it }); }
+      return { data: items, error: null };
+    }
+    const matched = rows.filter((r) => this._match(r));
+    if (this._op === 'update') {
+      for (const r of matched) Object.assign(r, this._payload);
+      this.sb.updates.push({ table: this.table, payload: this._payload, count: matched.length });
+      return { data: null, error: null };
+    }
+    let out = matched.map((r) => ({ ...r }));
+    if (this._limit != null) out = out.slice(0, this._limit);
+    if (this._single) return { data: out[0] || null, error: null };
+    return { data: out, error: null };
+  }
+}
+class MockSB {
+  constructor(tables) { this.tables = tables; this.inserts = []; this.updates = []; this.selects = []; }
+  from(name) { return new MockQuery(this, name); }
+}
+
+const VID = 'venture-xyz';
+function baseTables(overrides = {}) {
+  return {
+    eva_vision_documents: overrides.vision !== undefined ? overrides.vision : [
+      { venture_id: VID, level: 'L2', status: 'active', chairman_approved: true, vision_key: 'V-1', version: 3, content: 'vision text', updated_at: '2026-06-01', extracted_dimensions: [{ name: 'Convert', weight: 1 }, { name: 'Capture', weight: 1 }] },
+    ],
+    ventures: [{ id: VID, repo_url: 'https://github.com/x/y', deployment_url: 'https://y.example', name: 'Y' }],
+    venture_artifacts: [{ venture_id: VID, artifact_type: 'build_mvp_build', is_current: true, artifact_data: { verdict: 'PASS' }, content: null }],
+    applications: [{ id: 'app1', local_path: 'C:/repos/y', repo_url: 'https://github.com/x/y' }],
+    venture_stage_work: overrides.stageWork !== undefined ? overrides.stageWork : [{ id: 'sw1', venture_id: VID, lifecycle_stage: 19, advisory_data: { reason: 'vision_pending', bridge_failed: true } }],
+    system_events: [],
+  };
+}
+
+describe('gatherVerificationInputs (VA-18)', () => {
+  it('VA-18: selects extracted_dimensions from the chairman-approved L2 vision + the built-venture artifacts', async () => {
+    const sb = new MockSB(baseTables());
+    const inputs = await gatherVerificationInputs(sb, VID);
+    expect(inputs.visionPresent).toBe(true);
+    expect(inputs.visionDimensions).toHaveLength(2);
+    expect(inputs.repoUrl).toBe('https://github.com/x/y');
+    expect(inputs.deploymentUrl).toBe('https://y.example');
+    expect(inputs.buildVerdict).toBe('PASS');
+    expect(inputs.localPath).toBe('C:/repos/y');
+    // the vision select must request extracted_dimensions explicitly (assertVentureVisionReady does not)
+    const visionSelect = sb.selects.find((s) => s.table === 'eva_vision_documents');
+    expect(visionSelect.cols).toMatch(/extracted_dimensions/);
+  });
+
+  it('VA-18b: chairman_approved=false → not matched → visionPresent false (filter is real)', async () => {
+    const sb = new MockSB(baseTables({ vision: [{ venture_id: VID, level: 'L2', status: 'active', chairman_approved: false, vision_key: 'V-1', extracted_dimensions: [] }] }));
+    const inputs = await gatherVerificationInputs(sb, VID);
+    expect(inputs.visionPresent).toBe(false);
+  });
+});
+
+describe('runVerify (VA-19..VA-22)', () => {
+  it('VA-19 + VA-20 + VA-21: invokes the judge, merges the verdict into advisory_data, emits the audit event', async () => {
+    const sb = new MockSB(baseTables());
+    let judgeArgs = null;
+    const verifyVenture = (dims, artifacts) => { judgeArgs = { dims, artifacts }; return { pass: false, gaps: [{ name: 'Capture', evidence: 'no form' }], corrective_sds: [{ title: 'Add form' }] }; };
+    const res = await runVerify({ supabase: sb, ventureId: VID, verifyVenture, pgClient: null });
+
+    // VA-19: judge invoked with dimensions + artifacts
+    expect(judgeArgs.dims).toHaveLength(2);
+    expect(judgeArgs.artifacts.repoUrl).toBe('https://github.com/x/y');
+    expect(judgeArgs.artifacts.buildVerdict).toBe('PASS');
+
+    // VA-20: verdict written, sibling advisory_data keys preserved
+    expect(res.wrote).toBe(true);
+    expect(res.verdict.pass).toBe(false);
+    const row = sb.tables.venture_stage_work[0];
+    expect(row.advisory_data.vision_acceptance_verdict.pass).toBe(false);
+    expect(row.advisory_data.reason).toBe('vision_pending');   // NOT clobbered
+    expect(row.advisory_data.bridge_failed).toBe(true);        // NOT clobbered
+    expect(sb.updates.length).toBe(1);
+
+    // VA-21: system_events VISION_ACCEPTANCE_VERDICT on the payload column (no event_data)
+    const ev = sb.inserts.find((i) => i.table === 'system_events');
+    expect(ev.row.event_type).toBe('VISION_ACCEPTANCE_VERDICT');
+    expect(ev.row.payload).toBeDefined();
+    expect(ev.row.details).toBeDefined();
+    expect(ev.row.event_data).toBeUndefined();
+    expect(ev.row.payload.verdict_pass).toBe(false);
+  });
+
+  it('VA-20b: inserts a stage-work row when none exists (no clobber path)', async () => {
+    const sb = new MockSB(baseTables({ stageWork: [] }));
+    await runVerify({ supabase: sb, ventureId: VID, verifyVenture: () => ({ pass: true }), pgClient: null });
+    const inserted = sb.inserts.find((i) => i.table === 'venture_stage_work');
+    expect(inserted.row.lifecycle_stage).toBe(19);
+    expect(inserted.row.advisory_data.vision_acceptance_verdict.pass).toBe(true);
+  });
+
+  it('VA-22: dryRun=true → ZERO writes, never invokes the judge', async () => {
+    const sb = new MockSB(baseTables());
+    let judged = false;
+    const res = await runVerify({ supabase: sb, ventureId: VID, verifyVenture: () => { judged = true; return { pass: false }; }, dryRun: true, pgClient: null });
+    expect(judged).toBe(false);
+    expect(res.dryRun).toBe(true);
+    expect(res.wrote).toBe(false);
+    expect(sb.updates.length).toBe(0);
+    expect(sb.inserts.length).toBe(0);
+    expect(res.currentVerdict).toBeNull();
+  });
+
+  it('VA-22b: no judge injected → introspect only (zero writes)', async () => {
+    const sb = new MockSB(baseTables());
+    const res = await runVerify({ supabase: sb, ventureId: VID, pgClient: null }); // no verifyVenture
+    expect(res.dryRun).toBe(true);
+    expect(sb.updates.length + sb.inserts.length).toBe(0);
+  });
+
+  it('no chairman-approved vision → skip (defer to VISION_MISSING gate), never writes', async () => {
+    const sb = new MockSB(baseTables({ vision: [] }));
+    const res = await runVerify({ supabase: sb, ventureId: VID, verifyVenture: () => ({ pass: false }), pgClient: null });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe('no_approved_l2_vision');
+    expect(sb.updates.length + sb.inserts.length).toBe(0);
+  });
+});
+
+describe('normalizeVerdict + recordVerdict', () => {
+  it('normalizeVerdict coerces a non-boolean pass to false (never a silent pass)', () => {
+    expect(normalizeVerdict({ pass: true }).pass).toBe(true);
+    expect(normalizeVerdict({}).pass).toBe(false);
+    expect(normalizeVerdict(null).pass).toBe(false);
+    expect(normalizeVerdict({ pass: 'yes' }).pass).toBe(false);
+    const n = normalizeVerdict({ pass: false });
+    expect(n.criteria_results).toEqual([]);
+    expect(n.evaluated_by).toBe('leo-verify-venture');
+    expect(typeof n.evaluated_at).toBe('string');
+  });
+
+  it('recordVerdict persists a pre-judged verdict via the canonical store (read-merge-write + audit)', async () => {
+    const sb = new MockSB(baseTables());
+    const res = await recordVerdict({ supabase: sb, ventureId: VID, verdict: { pass: false, gaps: [{ name: 'X' }] }, pgClient: null });
+    expect(res.wrote).toBe(true);
+    expect(sb.tables.venture_stage_work[0].advisory_data.vision_acceptance_verdict.pass).toBe(false);
+    expect(sb.inserts.find((i) => i.table === 'system_events').row.event_type).toBe('VISION_ACCEPTANCE_VERDICT');
+  });
+});
+
+describe('static never-advance guardrail (VA-24)', () => {
+  it('VA-24: verifier source has zero advance/stage-write/chairman tokens (writes advisory_data/system_events only)', () => {
+    const src = readFileSync(LIB_PATH, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(src).not.toMatch(/_advanceStage/);
+    expect(src).not.toMatch(/current_lifecycle_stage\s*:/);   // no stage WRITE (object-key form)
+    expect(src).not.toMatch(/chairman_decisions|chairman_approved\s*:/); // no chairman write (bare read predicate is absent too)
+    expect(src).not.toMatch(/advance_venture_stage/);
+  });
+});

--- a/tests/unit/eva/bridge/vision-acceptance-gate.test.js
+++ b/tests/unit/eva/bridge/vision-acceptance-gate.test.js
@@ -1,0 +1,135 @@
+/**
+ * SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-1) — the pure vision-acceptance classifier + the
+ * single hold/advance decision + the flag helpers. These truth tables are the keystone the worker
+ * S19 gate (FR-2) consumes, so a regression here is a regression everywhere. VA-1..VA-12, VA-23,
+ * VA-26, VA-27 from the PRD test_scenarios.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import {
+  classifyVisionAcceptance,
+  shouldHoldForVisionAcceptance,
+  isVisionAcceptanceGateEnabled,
+  isVisionAcceptanceStrict,
+  VISION_ACCEPTANCE,
+} from '../../../../lib/eva/bridge/vision-acceptance-gate.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = resolve(__dirname, '../../../../lib/eva/bridge/vision-acceptance-gate.js');
+const A = VISION_ACCEPTANCE;
+
+describe('classifyVisionAcceptance (VA-1..VA-5)', () => {
+  it('VA-1: { pass:true } → VERIFIED_PASS', () => {
+    expect(classifyVisionAcceptance({ pass: true })).toBe(A.VERIFIED_PASS);
+  });
+  it('VA-2: { pass:false } → VERIFIED_GAPS', () => {
+    expect(classifyVisionAcceptance({ pass: false })).toBe(A.VERIFIED_GAPS);
+  });
+  it('VA-3: undefined → NOT_EVALUATED', () => {
+    expect(classifyVisionAcceptance(undefined)).toBe(A.NOT_EVALUATED);
+  });
+  it('VA-4: null / {} / non-boolean pass → NOT_EVALUATED (never coerced to PASS — load-bearing)', () => {
+    expect(classifyVisionAcceptance(null)).toBe(A.NOT_EVALUATED);
+    expect(classifyVisionAcceptance({})).toBe(A.NOT_EVALUATED);
+    expect(classifyVisionAcceptance({ pass: 'true' })).toBe(A.NOT_EVALUATED); // string is not boolean true
+    expect(classifyVisionAcceptance({ pass: 1 })).toBe(A.NOT_EVALUATED);
+  });
+  it('VA-5: explicit { no_vision:true } marker → NO_VISION (checked before pass)', () => {
+    expect(classifyVisionAcceptance({ no_vision: true })).toBe(A.NO_VISION);
+    expect(classifyVisionAcceptance({ no_vision: true, pass: false })).toBe(A.NO_VISION);
+  });
+});
+
+describe('shouldHoldForVisionAcceptance (VA-6..VA-12)', () => {
+  it('VA-6: VERIFIED_GAPS → HOLD (any strict, buildComplete=true)', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: { pass: false }, buildComplete: true, strict: false })).toBe(true);
+    expect(shouldHoldForVisionAcceptance({ verdict: { pass: false }, buildComplete: true, strict: true })).toBe(true);
+  });
+  it('VA-7: VERIFIED_PASS → no-hold', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: { pass: true }, buildComplete: true })).toBe(false);
+  });
+  it('VA-8: NOT_EVALUATED + strict=false → no-hold (fail-open)', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: undefined, buildComplete: true, strict: false })).toBe(false);
+  });
+  it('VA-9: NO_VISION → no-hold (defer to existing VISION_MISSING gate)', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: { no_vision: true }, buildComplete: true, strict: true })).toBe(false);
+  });
+  it('VA-10: NOT_EVALUATED + strict=true → HOLD', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: undefined, buildComplete: true, strict: true })).toBe(true);
+    expect(shouldHoldForVisionAcceptance({ verdict: null, buildComplete: null, strict: true })).toBe(true);
+  });
+  it('VA-11: buildComplete=false → no-hold even for VERIFIED_GAPS (only complete builds are verified)', () => {
+    expect(shouldHoldForVisionAcceptance({ verdict: { pass: false }, buildComplete: false, strict: true })).toBe(false);
+    expect(shouldHoldForVisionAcceptance({ verdict: undefined, buildComplete: false, strict: true })).toBe(false);
+  });
+  it('VA-12: full parity sweep — every classification × strict × buildComplete', () => {
+    const verdicts = [
+      { v: { pass: true }, cls: A.VERIFIED_PASS },
+      { v: { pass: false }, cls: A.VERIFIED_GAPS },
+      { v: undefined, cls: A.NOT_EVALUATED },
+      { v: { no_vision: true }, cls: A.NO_VISION },
+    ];
+    for (const { v, cls } of verdicts) {
+      for (const strict of [true, false]) {
+        for (const buildComplete of [true, false, null]) {
+          const got = shouldHoldForVisionAcceptance({ verdict: v, buildComplete, strict });
+          let expected;
+          if (buildComplete === false) expected = false;          // incomplete build never holds here
+          else if (cls === A.VERIFIED_GAPS) expected = true;
+          else if (cls === A.NOT_EVALUATED) expected = strict === true;
+          else expected = false;                                  // VERIFIED_PASS / NO_VISION
+          expect(got, `cls=${cls} strict=${strict} buildComplete=${buildComplete}`).toBe(expected);
+        }
+      }
+    }
+  });
+  it('default args do not throw and yield no-hold', () => {
+    expect(shouldHoldForVisionAcceptance()).toBe(false);
+    expect(shouldHoldForVisionAcceptance({})).toBe(false);
+  });
+});
+
+describe('flag helpers (VA-26, VA-27) — hermetic env', () => {
+  let savedGate, savedStrict;
+  beforeEach(() => { savedGate = process.env.VISION_ACCEPTANCE_GATE; savedStrict = process.env.VISION_ACCEPTANCE_STRICT; delete process.env.VISION_ACCEPTANCE_GATE; delete process.env.VISION_ACCEPTANCE_STRICT; });
+  afterEach(() => {
+    if (savedGate === undefined) delete process.env.VISION_ACCEPTANCE_GATE; else process.env.VISION_ACCEPTANCE_GATE = savedGate;
+    if (savedStrict === undefined) delete process.env.VISION_ACCEPTANCE_STRICT; else process.env.VISION_ACCEPTANCE_STRICT = savedStrict;
+  });
+
+  it('VA-26: VISION_ACCEPTANCE_GATE default ON (unset and =true); OFF for false/0/off/no', () => {
+    expect(isVisionAcceptanceGateEnabled()).toBe(true); // unset → ON
+    process.env.VISION_ACCEPTANCE_GATE = '';
+    expect(isVisionAcceptanceGateEnabled()).toBe(true); // empty → ON
+    process.env.VISION_ACCEPTANCE_GATE = 'true';
+    expect(isVisionAcceptanceGateEnabled()).toBe(true);
+    for (const off of ['false', '0', 'off', 'no', 'FALSE', 'Off']) {
+      process.env.VISION_ACCEPTANCE_GATE = off;
+      expect(isVisionAcceptanceGateEnabled(), off).toBe(false);
+    }
+  });
+
+  it('VA-27: VISION_ACCEPTANCE_STRICT default OFF (unset and =false); ON for true/1/on/yes', () => {
+    expect(isVisionAcceptanceStrict()).toBe(false); // unset → OFF
+    process.env.VISION_ACCEPTANCE_STRICT = '';
+    expect(isVisionAcceptanceStrict()).toBe(false);
+    process.env.VISION_ACCEPTANCE_STRICT = 'false';
+    expect(isVisionAcceptanceStrict()).toBe(false);
+    for (const on of ['true', '1', 'on', 'yes', 'TRUE', 'On']) {
+      process.env.VISION_ACCEPTANCE_STRICT = on;
+      expect(isVisionAcceptanceStrict(), on).toBe(true);
+    }
+  });
+});
+
+describe('static never-advance guardrail (VA-23)', () => {
+  it('VA-23: vision-acceptance-gate.js source has zero advance/stage/chairman/vision-write tokens', () => {
+    const src = readFileSync(LIB_PATH, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(src).not.toMatch(/_advanceStage/);
+    expect(src).not.toMatch(/current_lifecycle_stage\s*:/);
+    expect(src).not.toMatch(/chairman_decisions|chairman_approved\s*:/);
+    expect(src).not.toMatch(/advance_venture_stage/);
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-vision-acceptance.test.js
+++ b/tests/unit/eva/stage-execution-worker-vision-acceptance.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-2) — worker-level tests that drive the REAL
+ * _evaluateVisionAcceptanceHold seam (mirroring stage-execution-worker-s19-harden.test.js), plus the
+ * static exactly-7 _advanceStage invariant (VA-25) and the flag-guard structure (VA-15). VA-13..VA-16,
+ * VA-25 from the PRD test_scenarios.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn(), releaseProcessingLock: vi.fn(), markCompleted: vi.fn(),
+  getOrchestratorState: vi.fn().mockResolvedValue({ state: 'processing' }),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', KILLED_AT_REALITY_GATE: 'killed_at_reality_gate' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({ createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn() }));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue({}) }));
+vi.mock('../../../lib/eva/autonomy-model.js', () => ({ checkAutonomy: vi.fn().mockResolvedValue({ action: 'block', level: 'L0' }) }));
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn().mockResolvedValue({ isBlocking: () => false, isReview: () => false }),
+}));
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKER_PATH = resolve(__dirname, '../../../lib/eva/stage-execution-worker.js');
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+const VID = 'venture-w';
+
+/**
+ * Chainable supabase fake serving per-table terminal data — drives the REAL
+ * _evaluateVisionAcceptanceHold + _isLeoBridgeBuildComplete (the latter reads ventures + the same
+ * venture_stage_work + strategic_directives_v2; resolve-build-model.js runs for real).
+ */
+function makeSupabase({ verdict, sdRows = [{ status: 'completed' }], buildModel = 'leo_bridge', advisoryExtra = {} } = {}) {
+  const advisory_data = { ...advisoryExtra };
+  if (verdict !== undefined) advisory_data.vision_acceptance_verdict = verdict;
+  const stageWork = { advisory_data };
+  const ventureRow = { build_model: buildModel };
+  const from = (table) => {
+    const terminalData =
+      table === 'strategic_directives_v2' ? sdRows :
+      table === 'ventures' ? ventureRow :
+      table === 'venture_stage_work' ? stageWork : null;
+    const chain = {
+      select: () => chain, eq: () => chain, neq: () => chain, in: () => chain, gt: () => chain,
+      order: () => chain, limit: () => chain,
+      maybeSingle: async () => ({ data: terminalData, error: null }),
+      single: async () => ({ data: terminalData, error: null }),
+      then: (res) => res({ data: terminalData, error: null }),
+    };
+    return chain;
+  };
+  return { from };
+}
+
+function makeWorker(supabase) {
+  return new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+}
+
+describe('_evaluateVisionAcceptanceHold (VA-13..VA-16)', () => {
+  let savedStrict;
+  beforeEach(() => { savedStrict = process.env.VISION_ACCEPTANCE_STRICT; delete process.env.VISION_ACCEPTANCE_STRICT; });
+  afterEach(() => { if (savedStrict === undefined) delete process.env.VISION_ACCEPTANCE_STRICT; else process.env.VISION_ACCEPTANCE_STRICT = savedStrict; });
+
+  it('VA-13: recorded pass=false + complete build → HOLD (with the verdict surfaced for the caller)', async () => {
+    const worker = makeWorker(makeSupabase({ verdict: { pass: false, gaps: [{ name: 'x' }] } }));
+    const { hold, verdict } = await worker._evaluateVisionAcceptanceHold(VID);
+    expect(hold).toBe(true);
+    expect(verdict.pass).toBe(false);
+  });
+
+  it('VA-14: recorded pass=true → no-hold (the existing normal advance proceeds)', async () => {
+    const worker = makeWorker(makeSupabase({ verdict: { pass: true } }));
+    expect((await worker._evaluateVisionAcceptanceHold(VID)).hold).toBe(false);
+  });
+
+  it('VA-16a: no recorded verdict + strict OFF (default) → no-hold (fail-open, zero regression)', async () => {
+    const worker = makeWorker(makeSupabase({ verdict: undefined }));
+    expect((await worker._evaluateVisionAcceptanceHold(VID)).hold).toBe(false);
+  });
+
+  it('VA-16b: no recorded verdict + VISION_ACCEPTANCE_STRICT=true → HOLD (verify-before-advance)', async () => {
+    process.env.VISION_ACCEPTANCE_STRICT = 'true';
+    const worker = makeWorker(makeSupabase({ verdict: undefined }));
+    expect((await worker._evaluateVisionAcceptanceHold(VID)).hold).toBe(true);
+  });
+
+  it('VA-11(worker): incomplete build (draft SDs) → no-hold even with a stale pass=false verdict', async () => {
+    const worker = makeWorker(makeSupabase({ verdict: { pass: false }, sdRows: [{ status: 'draft' }] }));
+    expect((await worker._evaluateVisionAcceptanceHold(VID)).hold).toBe(false);
+  });
+
+  it('non-leo_bridge built venture (buildComplete=null) with gaps still holds (vision applies)', async () => {
+    const worker = makeWorker(makeSupabase({ verdict: { pass: false }, buildModel: 'seeded_repo' }));
+    expect((await worker._evaluateVisionAcceptanceHold(VID)).hold).toBe(true);
+  });
+});
+
+describe('never-advance invariant (VA-25) + flag-guard structure (VA-15)', () => {
+  it('VA-25: stage-execution-worker.js has exactly 7 this._advanceStage( call sites', () => {
+    const src = readFileSync(WORKER_PATH, 'utf8');
+    const matches = src.match(/this\._advanceStage\(/g) || [];
+    expect(matches.length).toBe(7);
+  });
+
+  it('VA-15: the vision-acceptance worker block is guarded by isVisionAcceptanceGateEnabled() (flag OFF skips it)', () => {
+    const src = readFileSync(WORKER_PATH, 'utf8');
+    expect(src).toMatch(/currentStage === 19 && isVisionAcceptanceGateEnabled\(\)/);
+    // and the HOLD is a break, not a new advance, inside that block
+    expect(src).toMatch(/_evaluateVisionAcceptanceHold/);
+  });
+
+  it('the worker imports the pure decision from vision-acceptance-gate.js', () => {
+    const src = readFileSync(WORKER_PATH, 'utf8');
+    expect(src).toMatch(/from '\.\/bridge\/vision-acceptance-gate\.js'/);
+  });
+});


### PR DESCRIPTION
## WHAT

A fail-closed **vision-grounded acceptance gate** at the leo_bridge **S19→S20** boundary. A session-hosted judge (`/leo-verify-venture`) records a pass/gaps verdict in `venture_stage_work.advisory_data.vision_acceptance_verdict`, and the worker **HOLDs** the venture at S19 on a FAIL.

This is campaign **#3 of 3** of intelligent-venture-build: `plan-from-reality` → `build-with-context` → **`verify-against-vision`**.

## FRs

- **FR-1** — pure `vision-acceptance-gate.js`: `classifyVisionAcceptance` (4-enum) + `shouldHoldForVisionAcceptance` + feature flags.
- **FR-2** — thin break-HOLD in `stage-execution-worker.js` via `_evaluateVisionAcceptanceHold`.
- **FR-3** — `venture-vision-verifier.js` `runVerify({ verifyVenture })` gather+store, with `--dry-run` and `--record`.
- **FR-4** — the `/leo-verify-venture` skill + `VISION_ACCEPTANCE_GATE` (default **ON**) / `VISION_ACCEPTANCE_STRICT` (default **OFF**) + static guardrails + 35 unit tests.

## SAFETY

- The hard **never-advance** invariant is preserved — `this._advanceStage` stays **EXACTLY 7** (a new static test asserts this).
- **No schema change** — `advisory_data` is an existing JSONB column.
- The gate **fails CLOSED at S19** — verify-first found that S20's pause-controller `check()` fails **OPEN**, so S19 is the correct home for the gate.
- **Default fail-open on an unrecorded verdict** for a zero-regression rollout (verified live: DataDistill dry-run shows `currentVerdict=(none)`, not held).

## TESTS

- **35 new unit tests** pass.
- **57 neighboring** worker/bridge tests pass (no regressions).
- CLI `--dry-run` validated against the real **DataDistill** venture (reads 7 vision `extracted_dimensions`, **zero writes**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
