### PR TITLE
fix(db-security): remediate + prevent recurring Supabase security-linter findings

### DIFF
--- a/.github/workflows/security-linter-sentinel.yml
+++ b/.github/workflows/security-linter-sentinel.yml
@@ -1,0 +1,74 @@
+# Weekly Supabase security-linter sentinel.
+#
+# Detection backstop for the SECURITY rules remediated in
+# database/migrations/20260602_fix_security_definer_views_and_rls_recurrence.sql:
+#   security_definer_view, rls_disabled_in_public, sensitive_columns_exposed.
+#
+# Real-time prevention is the DB event trigger `leo_enforce_view_security_invoker`
+# (views) + hardened security_audit_events_create_partition() (partitions). This
+# scheduled run is the defense-in-depth detector: it goes RED if the trigger is
+# dropped/disabled or a new public table ships without RLS.
+#
+# Runs scripts/sentinels/audit-security-linter.mjs against the consolidated DB via
+# the SUPABASE_POOLER_URL secret (the script reads pg_catalog, which PostgREST does
+# not expose, so it uses a direct pg connection).
+
+name: security-linter-sentinel
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Exit non-zero if any findings (default true)'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-linter-sentinel
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Run sentinel (capture report)
+        env:
+          SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+        run: |
+          node scripts/sentinels/audit-security-linter.mjs --json > security-linter-report.json
+          echo "--- Human-readable summary ---"
+          node scripts/sentinels/audit-security-linter.mjs
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-linter-report-${{ github.run_id }}
+          path: security-linter-report.json
+          retention-days: 90
+
+      - name: Enforce (strict)
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.strict == 'true' }}
+        env:
+          SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+        run: node scripts/sentinels/audit-security-linter.mjs --strict

--- a/database/migrations/20260602_fix_security_definer_views_and_rls_recurrence.sql
+++ b/database/migrations/20260602_fix_security_definer_views_and_rls_recurrence.sql
@@ -1,0 +1,331 @@
+-- @approved-by: rickfelix@example.com
+-- ============================================================================
+-- LEO Protocol - Fix Security Definer Views + RLS (RECURRENCE remediation)
+-- Migration: 20260602_fix_security_definer_views_and_rls_recurrence.sql
+-- Supersedes the static-list approach of:
+--   20251216_fix_security_definer_views.sql
+--   20260211_fix_security_definer_views_and_rls.sql
+-- ============================================================================
+-- Purpose: Remediate a RECURRENCE of Supabase database-linter SECURITY errors:
+--   (1) security_definer_view      -- 30 public views lacking security_invoker=on
+--   (2) rls_disabled_in_public     -- 45 public base tables with RLS disabled
+--   (3) sensitive_columns_exposed  -- session_id exposed (STRICT SUBSET of #2;
+--                                     resolved transitively by enabling RLS)
+--
+-- ROOT CAUSES (confirmed against the LIVE database 2026-06-02):
+--   RC1  View recreation drops the option. Of 162 public views, 132 still carry
+--        security_invoker=on (Feb fix) and 30 do NOT. The 30 lost it because later
+--        migrations used CREATE OR REPLACE VIEW / DROP+CREATE without re-applying
+--        SET (security_invoker=on). Verified: v_active_sessions,
+--        chairman_pending_decisions, prds, v_story_test_coverage,
+--        v_patterns_with_decay all have reloptions = NULL (option absent).
+--   RC2  New objects. Many flagged objects were created after Feb and never had
+--        security_invoker / RLS to begin with.
+--   RC3  No enforcement. The Feb migration left only an advisory comment. Nothing
+--        auto-corrects or fails CI, so findings re-accumulate. -> PART E + Phase 3.
+--   RC4  Partition routine. public.security_audit_events is a partitioned parent
+--        (relkind=p) that ALREADY has RLS enabled+forced, but its 13 monthly child
+--        partitions have RLS OFF. security_audit_events_create_partition() runs
+--        CREATE TABLE ... PARTITION OF with NO subsequent ENABLE ROW LEVEL SECURITY,
+--        so every new partition is born insecure. PART D backfills the children;
+--        PART E hardens the routine at the source.
+--   RC5  Stale backup tables. backup_leo_* were created via CREATE TABLE AS SELECT
+--        (no RLS copied) and left in public. They are stale (1-12 rows) and have
+--        ZERO code references. Per "default to securing, not dropping", PART C
+--        ENABLES RLS on them rather than dropping (fully reversible). A separate
+--        human decision can drop them later.
+--
+-- ACCESS-MODEL SAFETY (why service_role-only policies are safe here):
+--   - EHG_Engineer's server-side loader (src/services/database-loader/connections.js)
+--     uses SUPABASE_SERVICE_ROLE_KEY ("bypass RLS"); SERVICE_ROLE_KEY is set in env.
+--   - service_role and postgres both have rolbypassrls=true -> unaffected by RLS.
+--   - anon/authenticated have rolbypassrls=false, BUT the blanket GRANT ALL ... TO
+--     anon, authenticated exists on 847/849 public objects (Supabase default), NOT
+--     intentional per-table browser access. None of the 30 views / 45 tables are
+--     referenced by any client/browser/React code.
+--   - The Feb migration already enabled RLS+REVOKE on 11 such tables with no app
+--     breakage -> empirical proof the service_role-only model holds.
+--   => Enabling RLS + service_role-only policies will NOT break any reader.
+--
+-- IDEMPOTENT + DYNAMIC: safe to re-run. PART A and PART B/C/D self-heal whatever
+-- the live DB currently shows (not a hand-copied static name list).
+-- ============================================================================
+
+-- ============================================================================
+-- PART A: FIX SECURITY DEFINER VIEWS (dynamic -- every public view lacking it)
+-- Self-heals RC1 + RC2; covers all 30 flagged + anything the snapshot missed.
+-- ============================================================================
+DO $$
+DECLARE
+  v RECORD;
+  fixed_count INT := 0;
+BEGIN
+  FOR v IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND NOT (COALESCE(c.reloptions, '{}') @> ARRAY['security_invoker=on'])
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('ALTER VIEW public.%I SET (security_invoker = on)', v.relname);
+    RAISE NOTICE 'PART A: set security_invoker=on for view %', v.relname;
+    fixed_count := fixed_count + 1;
+  END LOOP;
+  RAISE NOTICE 'PART A COMPLETE: % views fixed', fixed_count;
+END $$;
+
+-- ============================================================================
+-- PART C: SECURE STALE BACKUP TABLES (backup_leo_*)
+-- Default-to-securing (NOT dropping). Enables RLS + service_role-only policy.
+-- Done BEFORE PART B's blanket loop so they get an explicit, auditable record
+-- (PART B would also catch them, but naming them documents the RC5 decision).
+-- ============================================================================
+DO $$
+DECLARE
+  t RECORD;
+BEGIN
+  FOR t IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relname LIKE 'backup_leo_%'
+      AND c.relrowsecurity = false
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t.relname);
+    EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', t.relname);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = t.relname
+        AND policyname = 'service_role_full_access'
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY "service_role_full_access" ON public.%I FOR ALL TO service_role USING (true) WITH CHECK (true)',
+        t.relname);
+    END IF;
+    RAISE NOTICE 'PART C: secured stale backup table %', t.relname;
+  END LOOP;
+  RAISE NOTICE 'PART C COMPLETE';
+END $$;
+
+-- ============================================================================
+-- PART B: ENABLE RLS ON PUBLIC BASE TABLES LACKING IT (dynamic)
+-- Covers all currently-RLS-off ordinary tables (relkind='r'). Self-heals RC2/RC5.
+-- EXCLUDES the partition PARENT (relkind='p', already RLS-enabled) and partition
+-- CHILDREN (handled explicitly in PART D so the parent/child relationship is
+-- documented). Rationale for blanket-over-curated: every RLS-off public table on
+-- this DB is a service_role-only governance/internal table (see ACCESS-MODEL note);
+-- a curated list would only diverge from the dynamic set for FUTURE tables, which
+-- are handled by Phase-3 prevention instead.
+-- ============================================================================
+DO $$
+DECLARE
+  t RECORD;
+  fixed_count INT := 0;
+BEGIN
+  FOR t IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'                 -- ordinary tables only (not 'p' parents)
+      AND c.relrowsecurity = false
+      -- exclude partition children of security_audit_events (PART D owns them)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_inherits i
+        JOIN pg_class p ON p.oid = i.inhparent
+        WHERE i.inhrelid = c.oid
+          AND p.relname = 'security_audit_events'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t.relname);
+    EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', t.relname);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = t.relname
+        AND policyname = 'service_role_full_access'
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY "service_role_full_access" ON public.%I FOR ALL TO service_role USING (true) WITH CHECK (true)',
+        t.relname);
+    END IF;
+    fixed_count := fixed_count + 1;
+    RAISE NOTICE 'PART B: enabled RLS (service_role only) on %', t.relname;
+  END LOOP;
+  RAISE NOTICE 'PART B COMPLETE: % tables secured', fixed_count;
+END $$;
+
+-- ============================================================================
+-- PART D: PARTITIONED AUDIT TABLE -- backfill RLS on all child partitions (RC4)
+-- Parent public.security_audit_events already has RLS enabled+forced, but direct
+-- access to a child partition bypasses the parent's RLS unless the child also has
+-- RLS. We enable RLS on every existing child (without FORCE, matching their owner
+-- posture; postgres/service_role bypass RLS so SECURITY DEFINER inserts are fine)
+-- and attach a service_role policy. We also ensure a service_role policy exists on
+-- the parent for completeness.
+-- ============================================================================
+DO $$
+DECLARE
+  c RECORD;
+BEGIN
+  -- Ensure parent has a service_role policy (idempotent)
+  IF EXISTS (SELECT 1 FROM pg_class p JOIN pg_namespace n ON n.oid=p.relnamespace
+             WHERE n.nspname='public' AND p.relname='security_audit_events') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename='security_audit_events'
+        AND policyname='service_role_full_access'
+    ) THEN
+      EXECUTE 'CREATE POLICY "service_role_full_access" ON public.security_audit_events FOR ALL TO service_role USING (true) WITH CHECK (true)';
+      RAISE NOTICE 'PART D: added service_role policy on parent security_audit_events';
+    END IF;
+  END IF;
+
+  -- Enable RLS + policy on every child partition lacking it
+  FOR c IN
+    SELECT child.relname
+    FROM pg_inherits i
+    JOIN pg_class parent ON parent.oid = i.inhparent
+    JOIN pg_class child ON child.oid = i.inhrelid
+    JOIN pg_namespace n ON n.oid = parent.relnamespace
+    WHERE n.nspname = 'public'
+      AND parent.relname = 'security_audit_events'
+      AND child.relrowsecurity = false
+    ORDER BY child.relname
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', c.relname);
+    EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', c.relname);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename=c.relname
+        AND policyname='service_role_full_access'
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY "service_role_full_access" ON public.%I FOR ALL TO service_role USING (true) WITH CHECK (true)',
+        c.relname);
+    END IF;
+    RAISE NOTICE 'PART D: enabled RLS on child partition %', c.relname;
+  END LOOP;
+  RAISE NOTICE 'PART D COMPLETE';
+END $$;
+
+-- ============================================================================
+-- PART E: PREVENT RECURRENCE AT THE SOURCE
+--   E1. Event trigger: auto-apply security_invoker=on to any newly created/
+--       replaced public VIEW (permanently kills RC1 regardless of who recreates
+--       a view later). Verified: postgres can create event triggers on this DB.
+--   E2. Harden security_audit_events_create_partition() so FUTURE partitions are
+--       born with RLS enabled + service_role policy (fixes RC4 at the source).
+-- ============================================================================
+
+-- E1: view-invoker auto-enforcement event trigger ----------------------------
+CREATE OR REPLACE FUNCTION public.leo_enforce_view_security_invoker()
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  obj RECORD;
+  has_invoker BOOLEAN;
+BEGIN
+  FOR obj IN
+    SELECT * FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag IN ('CREATE VIEW', 'ALTER VIEW')
+      AND object_type = 'view'
+      AND schema_name = 'public'
+  LOOP
+    -- Re-entrancy guard: only ALTER when the option is currently absent. Our own
+    -- ALTER VIEW re-fires this trigger, but by then the option is present -> skip.
+    SELECT (COALESCE(c.reloptions, '{}') @> ARRAY['security_invoker=on'])
+      INTO has_invoker
+    FROM pg_class c
+    WHERE c.oid = obj.objid AND c.relkind = 'v';
+
+    IF has_invoker IS NOT NULL AND has_invoker = false THEN
+      EXECUTE format('ALTER VIEW %s SET (security_invoker = on)', obj.object_identity);
+      RAISE NOTICE 'leo_enforce_view_security_invoker: auto-applied security_invoker=on to %', obj.object_identity;
+    END IF;
+  END LOOP;
+END
+$fn$;
+
+DROP EVENT TRIGGER IF EXISTS leo_enforce_view_security_invoker;
+CREATE EVENT TRIGGER leo_enforce_view_security_invoker
+  ON ddl_command_end
+  WHEN TAG IN ('CREATE VIEW', 'ALTER VIEW')
+  EXECUTE FUNCTION public.leo_enforce_view_security_invoker();
+
+COMMENT ON FUNCTION public.leo_enforce_view_security_invoker() IS
+  'RC1/RC3 prevention (20260602): auto-applies security_invoker=on to any newly created/replaced public view so the security_definer_view linter finding cannot re-accumulate.';
+
+-- E2: harden the partition-creation routine to birth partitions with RLS ------
+CREATE OR REPLACE FUNCTION public.security_audit_events_create_partition(p_month date)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_start    date := date_trunc('month', p_month)::date;
+  v_end      date := (date_trunc('month', p_month) + interval '1 month')::date;
+  v_partname text := format('security_audit_events_%s', to_char(v_start, 'YYYY_MM'));
+BEGIN
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.security_audit_events ' ||
+    'FOR VALUES FROM (%L) TO (%L);',
+    v_partname, v_start::timestamptz, v_end::timestamptz
+  );
+
+  -- RC4 fix: born-secure partitions. RLS + service_role policy on the new child.
+  EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY;', v_partname);
+  EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated;', v_partname);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = v_partname
+      AND policyname = 'service_role_full_access'
+  ) THEN
+    EXECUTE format(
+      'CREATE POLICY "service_role_full_access" ON public.%I FOR ALL TO service_role USING (true) WITH CHECK (true);',
+      v_partname);
+  END IF;
+END
+$fn$;
+
+COMMENT ON FUNCTION public.security_audit_events_create_partition(date) IS
+  'RC4 fix (20260602): each new monthly partition is born with RLS enabled + service_role-only policy so security_audit_events_* partitions never trip the rls_disabled_in_public / sensitive_columns_exposed linter.';
+
+-- ============================================================================
+-- PART F: VERIFICATION -- assert 0 findings remain
+-- ============================================================================
+DO $$
+DECLARE
+  bad_views INT;
+  bad_tables INT;
+BEGIN
+  SELECT COUNT(*) INTO bad_views
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind = 'v'
+    AND NOT (COALESCE(c.reloptions, '{}') @> ARRAY['security_invoker=on']);
+
+  SELECT COUNT(*) INTO bad_tables
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind IN ('r','p')
+    AND c.relrowsecurity = false;
+
+  RAISE NOTICE '============================================================';
+  RAISE NOTICE 'VERIFICATION: public views WITHOUT security_invoker = %', bad_views;
+  RAISE NOTICE 'VERIFICATION: public r/p tables WITHOUT RLS         = %', bad_tables;
+  RAISE NOTICE '============================================================';
+
+  IF bad_views <> 0 OR bad_tables <> 0 THEN
+    RAISE EXCEPTION 'Remediation incomplete: % views and % tables still insecure', bad_views, bad_tables;
+  END IF;
+  RAISE NOTICE 'SUCCESS: 0 insecure views, 0 RLS-off tables.';
+END $$;

--- a/database/migrations/20260602_fix_security_definer_views_and_rls_recurrence_rollback.sql
+++ b/database/migrations/20260602_fix_security_definer_views_and_rls_recurrence_rollback.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- ROLLBACK for 20260602_fix_security_definer_views_and_rls_recurrence.sql
+-- ============================================================================
+-- WARNING: Running this rollback RE-OPENS the Supabase linter SECURITY findings
+-- it remediated (security_definer_view, rls_disabled_in_public,
+-- sensitive_columns_exposed). Only run it to recover from an unexpected
+-- application breakage caused by the forward migration.
+--
+-- This rollback reverses ONLY what the forward migration added/changed:
+--   - Drops the leo_enforce_view_security_invoker event trigger + function (PART E1)
+--   - Restores security_audit_events_create_partition() to its pre-migration body
+--     (no RLS on new partitions) (PART E2)
+--   - Drops the 'service_role_full_access' policies created by this migration and
+--     disables RLS on tables/partitions, then RE-GRANTS the Supabase default
+--     blanket grants to anon, authenticated (PART B/C/D reversal)
+--   - Removes security_invoker=on from public views (PART A reversal)
+--
+-- It is intentionally CONSERVATIVE for tables that may have had pre-existing
+-- 'service_role_full_access' policies from earlier migrations (e.g. the Feb fix):
+-- it only DISABLES RLS where this migration enabled it is NOT individually
+-- tracked, so this rollback disables RLS broadly across public r/p tables. Prefer
+-- a targeted manual revert for a single object over running this whole file.
+-- ============================================================================
+
+-- ---- Reverse PART E1: drop the view-invoker event trigger + function --------
+DROP EVENT TRIGGER IF EXISTS leo_enforce_view_security_invoker;
+DROP FUNCTION IF EXISTS public.leo_enforce_view_security_invoker();
+
+-- ---- Reverse PART E2: restore original partition routine (no RLS) -----------
+CREATE OR REPLACE FUNCTION public.security_audit_events_create_partition(p_month date)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_start    date := date_trunc('month', p_month)::date;
+  v_end      date := (date_trunc('month', p_month) + interval '1 month')::date;
+  v_partname text := format('security_audit_events_%s', to_char(v_start, 'YYYY_MM'));
+BEGIN
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.security_audit_events ' ||
+    'FOR VALUES FROM (%L) TO (%L);',
+    v_partname, v_start::timestamptz, v_end::timestamptz
+  );
+END
+$fn$;
+
+-- ---- Reverse PART B/C/D: disable RLS + drop our policy + re-grant defaults ---
+-- Child partitions of security_audit_events
+DO $$
+DECLARE c RECORD;
+BEGIN
+  FOR c IN
+    SELECT child.relname
+    FROM pg_inherits i
+    JOIN pg_class parent ON parent.oid = i.inhparent
+    JOIN pg_class child ON child.oid = i.inhrelid
+    JOIN pg_namespace n ON n.oid = parent.relnamespace
+    WHERE n.nspname='public' AND parent.relname='security_audit_events'
+    ORDER BY child.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS "service_role_full_access" ON public.%I', c.relname);
+    EXECUTE format('ALTER TABLE public.%I DISABLE ROW LEVEL SECURITY', c.relname);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.%I TO anon, authenticated', c.relname);
+    RAISE NOTICE 'ROLLBACK: reverted child partition %', c.relname;
+  END LOOP;
+END $$;
+
+-- Ordinary public tables (relkind='r') that currently have the policy we created
+DO $$
+DECLARE t RECORD;
+BEGIN
+  FOR t IN
+    SELECT DISTINCT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_policies pol ON pol.schemaname='public' AND pol.tablename=c.relname
+                        AND pol.policyname='service_role_full_access'
+    WHERE n.nspname='public' AND c.relkind='r'
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS "service_role_full_access" ON public.%I', t.relname);
+    EXECUTE format('ALTER TABLE public.%I DISABLE ROW LEVEL SECURITY', t.relname);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.%I TO anon, authenticated', t.relname);
+    RAISE NOTICE 'ROLLBACK: reverted table %', t.relname;
+  END LOOP;
+END $$;
+
+-- Parent partitioned table: drop only the policy this migration may have added
+-- (leave parent RLS enabled+forced as it pre-existed the forward migration)
+DROP POLICY IF EXISTS "service_role_full_access" ON public.security_audit_events;
+
+-- ---- Reverse PART A: remove security_invoker=on from public views -----------
+DO $$
+DECLARE v RECORD;
+BEGIN
+  FOR v IN
+    SELECT c.relname
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname='public' AND c.relkind='v'
+      AND (COALESCE(c.reloptions,'{}') @> ARRAY['security_invoker=on'])
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('ALTER VIEW public.%I RESET (security_invoker)', v.relname);
+    RAISE NOTICE 'ROLLBACK: reset security_invoker on view %', v.relname;
+  END LOOP;
+END $$;

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "chairman:seed": "node scripts/chairman-seed-data.js",
     "security:audit": "node scripts/security-audit-dashboard.js",
     "security:rls": "node scripts/audit-rls-policies.js",
+    "security:linter": "node scripts/sentinels/audit-security-linter.mjs",
     "eva:dlq:replay": "node scripts/eva-dlq-replay.js",
     "eva:constitution": "node scripts/eva/constitution-command.mjs",
     "eva:constitution:view": "node scripts/eva/constitution-command.mjs view",

--- a/scripts/sentinels/audit-security-linter.mjs
+++ b/scripts/sentinels/audit-security-linter.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Security-Linter Sentinel
+ *
+ * Detection backstop for the Supabase database-linter SECURITY rules remediated in
+ * database/migrations/20260602_fix_security_definer_views_and_rls_recurrence.sql:
+ *   - security_definer_view      : public views lacking `security_invoker=on`
+ *   - rls_disabled_in_public     : public tables/partitions with RLS disabled
+ *   - sensitive_columns_exposed  : the session_id subset of the above
+ *
+ * The recurrence is PREVENTED in real time by the event trigger
+ * `leo_enforce_view_security_invoker` (views) and the hardened
+ * `security_audit_events_create_partition()` (partitions). This sentinel is the
+ * defense-in-depth DETECTOR: if the trigger is dropped/disabled, or a new public
+ * table is created without RLS, a scheduled run goes red.
+ *
+ * Uses the pg direct connection (createDatabaseClient) because the checks read
+ * pg_catalog (reloptions / relrowsecurity / pg_event_trigger), which PostgREST
+ * does not expose. In CI, pass connectionString via the SUPABASE_POOLER_URL
+ * secret (see .github/workflows/security-linter-sentinel.yml); locally it falls
+ * back to SUPABASE_DB_PASSWORD.
+ *
+ * Usage:
+ *   node scripts/sentinels/audit-security-linter.mjs            # human-readable report
+ *   node scripts/sentinels/audit-security-linter.mjs --json     # JSON report (artifact)
+ *   node scripts/sentinels/audit-security-linter.mjs --strict   # exit 1 if any findings
+ */
+
+import { createDatabaseClient } from '../lib/supabase-connection.js';
+
+const JSON_MODE = process.argv.includes('--json');
+const STRICT = process.argv.includes('--strict');
+
+// Tables intentionally without RLS (system / PostGIS). Matches the exemption
+// set in scripts/audit-rls-policies.js.
+const EXEMPTED_TABLES = new Set(['schema_migrations', 'spatial_ref_sys']);
+
+function log(msg = '') { if (!JSON_MODE) console.log(msg); }
+
+async function main() {
+  // 'engineer' matches scripts/apply-migration.js (the same consolidated instance the
+  // remediation migration targeted). connectionString (SUPABASE_POOLER_URL) wins in CI;
+  // locally it falls back to building from SUPABASE_DB_PASSWORD.
+  const client = await createDatabaseClient('engineer', {
+    connectionString: process.env.SUPABASE_POOLER_URL,
+  });
+
+  let result;
+  try {
+    // (1) security_definer_view — views lacking security_invoker=on
+    const views = await client.query(`
+      SELECT c.relname AS name
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'v'
+        AND NOT (COALESCE(c.reloptions, '{}') @> ARRAY['security_invoker=on'])
+      ORDER BY 1`);
+
+    // (2) rls_disabled_in_public — ordinary tables ('r') + partitioned parents ('p') with RLS off
+    const tables = await client.query(`
+      SELECT c.relname AS name
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p') AND c.relrowsecurity = false
+      ORDER BY 1`);
+
+    // (3) sensitive_columns_exposed — session_id on a table/partition lacking RLS
+    const sensitive = await client.query(`
+      SELECT DISTINCT c.relname AS name
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_attribute a ON a.attrelid = c.oid AND a.attname = 'session_id'
+        AND a.attnum > 0 AND NOT a.attisdropped
+      WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p') AND c.relrowsecurity = false
+      ORDER BY 1`);
+
+    // Prevention liveness: is the view event trigger present + enabled? ('D' = disabled)
+    const trig = await client.query(
+      `SELECT evtenabled FROM pg_event_trigger WHERE evtname = 'leo_enforce_view_security_invoker'`);
+
+    result = {
+      securityDefinerViews: views.rows.map(r => r.name),
+      rlsDisabled: tables.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
+      sensitiveExposed: sensitive.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
+      triggerEnabled: trig.rows.length === 1 && trig.rows[0].evtenabled !== 'D',
+    };
+  } finally {
+    await client.end();
+  }
+
+  const findings = result.securityDefinerViews.length + result.rlsDisabled.length + result.sensitiveExposed.length;
+  const clean = findings === 0 && result.triggerEnabled;
+
+  log('');
+  log('='.repeat(60));
+  log('  SUPABASE SECURITY-LINTER SENTINEL');
+  log('='.repeat(60));
+  log(`  security_definer_view (views w/o security_invoker): ${result.securityDefinerViews.length}`);
+  log(`  rls_disabled_in_public (tables w/o RLS):            ${result.rlsDisabled.length}`);
+  log(`  sensitive_columns_exposed (session_id, no RLS):     ${result.sensitiveExposed.length}`);
+  log(`  view-invoker event trigger enabled:                 ${result.triggerEnabled}`);
+  log('  ' + '-'.repeat(40));
+  if (result.securityDefinerViews.length) log('  Views:  ' + result.securityDefinerViews.join(', '));
+  if (result.rlsDisabled.length) log('  Tables: ' + result.rlsDisabled.join(', '));
+  if (!result.triggerEnabled) log('  ⚠ PREVENTION GAP: view-invoker event trigger missing/disabled!');
+  log(clean ? '  ✓ CLEAN' : '  ✗ FINDINGS PRESENT');
+  log('='.repeat(60));
+
+  if (JSON_MODE) console.log(JSON.stringify({ findings, ...result }, null, 2));
+
+  // A missing/disabled prevention trigger is itself a strict-mode failure.
+  if (STRICT && !clean) process.exitCode = 1;
+}
+
+main().catch(err => {
+  console.error('Sentinel error:', err.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Remediates a **recurrence** of Supabase database-linter SECURITY findings on the consolidated DB and adds enforcement so they cannot re-accumulate:

- **30** `security_definer_view` (public views missing `security_invoker=on`)
- **45** `rls_disabled_in_public` (public base tables/partitions with RLS off, incl. **13** `security_audit_events_*` monthly partitions)
- the `session_id` `sensitive_columns_exposed` finding (a strict subset of the RLS-off set — resolved transitively by enabling RLS)

## Root cause (why it recurred)

Prior static-list fixes (`20251216`, `20260211`) enabled the option on a hand-copied list of view names. But **`CREATE OR REPLACE VIEW` (and `DROP`+`CREATE`) silently drops `security_invoker`**, and nothing re-applied it. Of 162 public views, 132 still carried the Feb fix and 30 had lost it because later migrations recreated them. New tables/partitions also shipped without RLS, and the partition routine (`security_audit_events_create_partition()`) created each child partition with RLS off. The Feb migration left only an advisory comment — **no enforcement** — so findings re-accumulated.

## What this PR does

**Migration (`20260602_..._recurrence.sql`) — dynamic + idempotent, self-heals against the live catalog (not a static name list):**
- Sets `security_invoker=on` on **every** public view lacking it
- Enables RLS + a `service_role` policy on every RLS-off public table/partition (service-role-only is safe here: the server loader uses the service-role key which bypasses RLS, and none of the affected objects are referenced by browser/client code — empirically proven by the Feb fix enabling RLS on 11 such tables with no breakage)
- Backfills RLS on the 13 `security_audit_events_*` partitions
- Secures stale `backup_leo_*` tables via RLS rather than dropping (fully reversible; drop is a separate human decision)

**Prevention (the actual fix for recurrence):**
- DB event trigger **`leo_enforce_view_security_invoker`** auto-applies `security_invoker=on` to any newly created/replaced public view — killing the recurrence at the source regardless of which future migration recreates a view
- Hardens `security_audit_events_create_partition()` so new partitions are born with RLS enabled

**Detection backstop (defense in depth):**
- `scripts/sentinels/audit-security-linter.mjs` (reads `pg_catalog` via a direct pg connection; `--json` / `--strict`)
- `.github/workflows/security-linter-sentinel.yml` — weekly (Mondays 14:00 UTC) + `workflow_dispatch`, strict by default; goes RED if the trigger is dropped/disabled or a new public table ships without RLS
- `npm run security:linter` alias

A matching rollback migration (`..._recurrence_rollback.sql`) is included.

## Deployment status — record-sync, not a re-apply

This migration was **already applied to prod** via `apply-migration.js --prod-deploy` and **verified 0/0/0** (zero `security_definer_view`, zero `rls_disabled_in_public`, zero sensitive-column findings). This repo's migration apply is operator-gated, not CI-automated, so **this PR does not re-apply anything on merge** — it syncs the repository to the already-deployed DB state. The migration is idempotent, so any migration-readiness check can treat it as already-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
