### PR TITLE
fix(security): repair npm run security:rls (dead exec_sql RPC → direct pg)

### DIFF
--- a/scripts/audit-rls-policies.js
+++ b/scripts/audit-rls-policies.js
@@ -7,14 +7,18 @@
  * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-J
  *
  * Usage: node scripts/audit-rls-policies.js [--json]
+ *
+ * NOTE: queries pg_catalog/pg_policies directly over a pg connection because
+ * PostgREST does not expose the catalog. (The previous supabase-js `exec_sql`
+ * RPC path was dead — the function does not exist. 2026-06-02.) In CI, pass
+ * the connection via the SUPABASE_POOLER_URL secret; locally it falls back to
+ * SUPABASE_DB_PASSWORD. See also scripts/sentinels/audit-security-linter.mjs.
  */
 
-import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { createDatabaseClient } from './lib/supabase-connection.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
-
-const supabase = createSupabaseServiceClient();
 
 const JSON_MODE = process.argv.includes('--json');
 
@@ -28,9 +32,9 @@ const EXEMPTED_TABLES = new Set([
   'spatial_ref_sys',
 ]);
 
-async function getRlsPolicies() {
-  const { data, error } = await supabase.rpc('exec_sql', {
-    sql: `
+async function getRlsPolicies(client) {
+  try {
+    const res = await client.query(`
       SELECT
         schemaname,
         tablename,
@@ -42,16 +46,16 @@ async function getRlsPolicies() {
       FROM pg_policies
       WHERE schemaname = 'public'
       ORDER BY tablename, policyname
-    `
-  });
-
-  if (error) return { data: [], error: error.message };
-  return { data: data || [], error: null };
+    `);
+    return { data: res.rows, error: null };
+  } catch (err) {
+    return { data: [], error: err.message };
+  }
 }
 
-async function getRlsEnabledTables() {
-  const { data, error } = await supabase.rpc('exec_sql', {
-    sql: `
+async function getRlsEnabledTables(client) {
+  try {
+    const res = await client.query(`
       SELECT
         relname as tablename,
         relrowsecurity as rls_enabled,
@@ -60,128 +64,141 @@ async function getRlsEnabledTables() {
       WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
         AND relkind = 'r'
       ORDER BY relname
-    `
-  });
-
-  if (error) return { data: [], error: error.message };
-  return { data: data || [], error: null };
+    `);
+    return { data: res.rows, error: null };
+  } catch (err) {
+    return { data: [], error: err.message };
+  }
 }
 
 async function main() {
-  log('');
-  log('='.repeat(60));
-  log('  RLS POLICY AUDIT');
-  log('='.repeat(60));
+  // 'engineer' matches scripts/apply-migration.js (the consolidated instance).
+  // connectionString (SUPABASE_POOLER_URL) wins in CI; locally it falls back to
+  // building from SUPABASE_DB_PASSWORD.
+  const client = await createDatabaseClient('engineer', {
+    connectionString: process.env.SUPABASE_POOLER_URL,
+  });
 
-  const { data: tables, error: tablesErr } = await getRlsEnabledTables();
-  if (tablesErr) {
-    console.error('Failed to get tables:', tablesErr);
-    process.exit(1);
-  }
+  try {
+    log('');
+    log('='.repeat(60));
+    log('  RLS POLICY AUDIT');
+    log('='.repeat(60));
 
-  const { data: policies, error: policiesErr } = await getRlsPolicies();
-  if (policiesErr) {
-    console.error('Failed to get policies:', policiesErr);
-    process.exit(1);
-  }
+    const { data: tables, error: tablesErr } = await getRlsEnabledTables(client);
+    if (tablesErr) {
+      console.error('Failed to get tables:', tablesErr);
+      process.exitCode = 1;
+      return;
+    }
 
-  // Build policy map
-  const policyMap = new Map();
-  for (const p of policies) {
-    if (!policyMap.has(p.tablename)) policyMap.set(p.tablename, []);
-    policyMap.get(p.tablename).push(p);
-  }
+    const { data: policies, error: policiesErr } = await getRlsPolicies(client);
+    if (policiesErr) {
+      console.error('Failed to get policies:', policiesErr);
+      process.exitCode = 1;
+      return;
+    }
 
-  // Categorize tables
-  const rlsEnabled = [];
-  const rlsDisabled = [];
-  const withPolicies = [];
-  const withoutPolicies = [];
+    // Build policy map
+    const policyMap = new Map();
+    for (const p of policies) {
+      if (!policyMap.has(p.tablename)) policyMap.set(p.tablename, []);
+      policyMap.get(p.tablename).push(p);
+    }
 
-  for (const t of tables) {
-    const exempt = EXEMPTED_TABLES.has(t.tablename);
-    if (exempt) continue;
+    // Categorize tables
+    const rlsEnabled = [];
+    const rlsDisabled = [];
+    const withPolicies = [];
+    const withoutPolicies = [];
 
-    if (t.rls_enabled) {
-      rlsEnabled.push(t.tablename);
-      if (policyMap.has(t.tablename)) {
-        withPolicies.push(t.tablename);
+    for (const t of tables) {
+      const exempt = EXEMPTED_TABLES.has(t.tablename);
+      if (exempt) continue;
+
+      if (t.rls_enabled) {
+        rlsEnabled.push(t.tablename);
+        if (policyMap.has(t.tablename)) {
+          withPolicies.push(t.tablename);
+        } else {
+          withoutPolicies.push(t.tablename);
+        }
       } else {
-        withoutPolicies.push(t.tablename);
+        rlsDisabled.push(t.tablename);
       }
-    } else {
-      rlsDisabled.push(t.tablename);
     }
-  }
 
-  const totalTables = rlsEnabled.length + rlsDisabled.length;
-  const coverage = totalTables > 0 ? Math.round((rlsEnabled.length / totalTables) * 100) : 0;
+    const totalTables = rlsEnabled.length + rlsDisabled.length;
+    const coverage = totalTables > 0 ? Math.round((rlsEnabled.length / totalTables) * 100) : 0;
 
-  // Report
-  log('');
-  log('  Summary');
-  log('  ' + '-'.repeat(40));
-  log(`  Total tables:        ${totalTables}`);
-  log(`  RLS enabled:         ${rlsEnabled.length} (${coverage}%)`);
-  log(`  RLS disabled:        ${rlsDisabled.length}`);
-  log(`  With policies:       ${withPolicies.length}`);
-  log(`  Without policies:    ${withoutPolicies.length}`);
-  log(`  Total policies:      ${policies.length}`);
-
-  if (rlsDisabled.length > 0) {
+    // Report
     log('');
-    log('  Tables WITHOUT RLS (security gap)');
+    log('  Summary');
     log('  ' + '-'.repeat(40));
-    for (const t of rlsDisabled.slice(0, 20)) {
-      const hasPolicies = policyMap.has(t) ? ' (has policies but RLS disabled!)' : '';
-      log(`  - ${t}${hasPolicies}`);
-    }
-    if (rlsDisabled.length > 20) {
-      log(`  ... and ${rlsDisabled.length - 20} more`);
-    }
-  }
+    log(`  Total tables:        ${totalTables}`);
+    log(`  RLS enabled:         ${rlsEnabled.length} (${coverage}%)`);
+    log(`  RLS disabled:        ${rlsDisabled.length}`);
+    log(`  With policies:       ${withPolicies.length}`);
+    log(`  Without policies:    ${withoutPolicies.length}`);
+    log(`  Total policies:      ${policies.length}`);
 
-  if (withoutPolicies.length > 0) {
+    if (rlsDisabled.length > 0) {
+      log('');
+      log('  Tables WITHOUT RLS (security gap)');
+      log('  ' + '-'.repeat(40));
+      for (const t of rlsDisabled.slice(0, 20)) {
+        const hasPolicies = policyMap.has(t) ? ' (has policies but RLS disabled!)' : '';
+        log(`  - ${t}${hasPolicies}`);
+      }
+      if (rlsDisabled.length > 20) {
+        log(`  ... and ${rlsDisabled.length - 20} more`);
+      }
+    }
+
+    if (withoutPolicies.length > 0) {
+      log('');
+      log('  RLS enabled but NO policies defined');
+      log('  ' + '-'.repeat(40));
+      for (const t of withoutPolicies) {
+        log(`  - ${t} (all access blocked!)`);
+      }
+    }
+
+    // Policy details for tables with policies
+    if (withPolicies.length > 0) {
+      log('');
+      log('  Policy Coverage Detail (first 10)');
+      log('  ' + '-'.repeat(40));
+      for (const t of withPolicies.slice(0, 10)) {
+        const tablePolicies = policyMap.get(t) || [];
+        const cmds = [...new Set(tablePolicies.map(p => p.cmd))].join(', ');
+        log(`  ${t}: ${tablePolicies.length} policies (${cmds})`);
+      }
+    }
+
     log('');
-    log('  RLS enabled but NO policies defined');
-    log('  ' + '-'.repeat(40));
-    for (const t of withoutPolicies) {
-      log(`  - ${t} (all access blocked!)`);
+    log('='.repeat(60));
+
+    if (JSON_MODE) {
+      const output = {
+        coverage,
+        totalTables,
+        rlsEnabled: rlsEnabled.length,
+        rlsDisabled: rlsDisabled.length,
+        withPolicies: withPolicies.length,
+        withoutPolicies: withoutPolicies.length,
+        totalPolicies: policies.length,
+        gaps: rlsDisabled,
+        enabledButNoPolicies: withoutPolicies,
+      };
+      console.log(JSON.stringify(output, null, 2));
     }
-  }
-
-  // Policy details for tables with policies
-  if (withPolicies.length > 0) {
-    log('');
-    log('  Policy Coverage Detail (first 10)');
-    log('  ' + '-'.repeat(40));
-    for (const t of withPolicies.slice(0, 10)) {
-      const tablePolicies = policyMap.get(t) || [];
-      const cmds = [...new Set(tablePolicies.map(p => p.cmd))].join(', ');
-      log(`  ${t}: ${tablePolicies.length} policies (${cmds})`);
-    }
-  }
-
-  log('');
-  log('='.repeat(60));
-
-  if (JSON_MODE) {
-    const output = {
-      coverage,
-      totalTables,
-      rlsEnabled: rlsEnabled.length,
-      rlsDisabled: rlsDisabled.length,
-      withPolicies: withPolicies.length,
-      withoutPolicies: withoutPolicies.length,
-      totalPolicies: policies.length,
-      gaps: rlsDisabled,
-      enabledButNoPolicies: withoutPolicies,
-    };
-    console.log(JSON.stringify(output, null, 2));
+  } finally {
+    await client.end();
   }
 }
 
 main().catch(err => {
   console.error('Audit error:', err.message);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## What was broken
`scripts/audit-rls-policies.js` (run via `npm run security:rls`) called a `public.exec_sql(sql)` RPC that does not exist. PostgREST does not expose `pg_catalog`, so every run errored with `Could not find the function public.exec_sql`.

## The fix
Switch to a direct `pg` connection via `createDatabaseClient` — the same path already used by `scripts/sentinels/audit-security-linter.mjs` and `scripts/apply-migration.js`. Reporting logic, `--json` output, `JSON_MODE`, and `EXEMPTED_TABLES` are unchanged.

## Verification
- Static-source unit tests `tests/unit/eva/security-auth.test.js`: 23/23 passing.
- Live run: exit 0, 703 tables, 100% RLS, 0 gaps.
- No DB changes are applied by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)