### PR TITLE
fix(db-security): pin search_path on SECURITY DEFINER functions + make sentinel run in CI

### DIFF
--- a/.github/workflows/security-linter-sentinel.yml
+++ b/.github/workflows/security-linter-sentinel.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Run sentinel (capture report)
         env:
           SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           node scripts/sentinels/audit-security-linter.mjs --json > security-linter-report.json
           echo "--- Human-readable summary ---"
@@ -71,4 +72,5 @@ jobs:
         if: ${{ github.event_name == 'schedule' || github.event.inputs.strict == 'true' }}
         env:
           SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: node scripts/sentinels/audit-security-linter.mjs --strict

--- a/database/migrations/20260602_pin_search_path_security_definer_functions.sql
+++ b/database/migrations/20260602_pin_search_path_security_definer_functions.sql
@@ -1,0 +1,127 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- Pin search_path on SECURITY DEFINER functions (function_search_path_mutable)
+-- =============================================================================
+-- Supabase linter finding: SECURITY DEFINER functions in `public` that do NOT
+-- pin search_path resolve unqualified object names against the CALLER's
+-- search_path while running with the OWNER's elevated privileges. This is the
+-- CVE-2018-1058 privilege-escalation vector: a caller can prepend a schema that
+-- shadows a table/function the elevated function relies on.
+--
+-- FIX: pin a correct, MINIMAL search_path on each affected function. We do NOT
+-- rewrite function bodies (no `search_path=''` + fully-qualify rewrite — too
+-- invasive for live LEO-governance functions). ALTER FUNCTION ... SET
+-- search_path is non-destructive to the body and takes effect on next call.
+--
+-- Schema analysis (pg_get_functiondef inspected for every target):
+--   * 12 of 14 functions reference ONLY `public` tables/functions + pg_catalog
+--     builtins (jsonb_*, NOW(), set_config, pg_try_advisory_xact_lock, hashtext,
+--     to_jsonb, current_setting, pg_tables, EXTRACT). Helper functions they call
+--     unqualified (fn_is_chairman, _get_venture_archetype) live in `public`.
+--     -> pinned path: public, pg_catalog
+--   * get_schema_columns() and get_schema_columns(text) read
+--     information_schema.columns (already schema-qualified, so it resolves under
+--     any path, but we include information_schema explicitly for clarity/robustness).
+--     -> pinned path: public, pg_catalog, information_schema
+--
+-- pg_catalog is implicitly searched by Postgres regardless, but we pin it
+-- explicitly so the effective resolution order is fully deterministic and the
+-- linter finding clears. pg_temp is intentionally NOT included: none of these
+-- functions create or reference temp objects, and omitting pg_temp from a
+-- SECURITY DEFINER path is the safer default (prevents temp-object shadowing).
+--
+-- IDEMPOTENT: the DO-block selects the exact "SECURITY DEFINER + mutable" target
+-- set by predicate, so re-running after a partial apply is a no-op for any
+-- function already pinned, and ALTER ... SET search_path is itself idempotent.
+-- OVERLOAD-SAFE: iterates pg_proc and uses pg_get_function_identity_arguments()
+-- so the two get_schema_columns overloads are pinned by full identity signature.
+--
+-- SD: function_search_path_mutable hardening (security-relevant subset)
+-- =============================================================================
+
+DO $pin$
+DECLARE
+  r RECORD;
+  v_path TEXT;
+BEGIN
+  FOR r IN
+    SELECT p.oid,
+           p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND p.prosecdef
+      -- Only touch functions that do NOT already pin search_path (idempotent re-run).
+      AND NOT EXISTS (
+        SELECT 1 FROM unnest(coalesce(p.proconfig, '{}'::text[])) x
+        WHERE x LIKE 'search_path=%'
+      )
+      -- Restrict to the explicit reviewed target set (defense-in-depth: even if a
+      -- NEW unreviewed SECURITY DEFINER function lands before this runs, we will
+      -- NOT silently pin it with the wrong path).
+      AND p.proname IN (
+        'master_reset_portfolio',
+        'export_blueprint_review',
+        'fn_rollback_sd_hierarchy',
+        'export_blueprint_review_with_eva',
+        'rescan_stage_20',
+        'fn_atomic_exec_to_plan_transition',
+        'advance_venture_to_stage',
+        'check_feedback_rate_limit',
+        'get_schema_columns',
+        'rpc_activate_vision_with_bypass',
+        'fn_complete_stitch_curation',
+        'trg_retrospectives_audit',
+        'fn_atomic_lead_to_plan_transition'
+      )
+  LOOP
+    -- get_schema_columns (both overloads) reads information_schema.columns.
+    IF r.proname = 'get_schema_columns' THEN
+      v_path := 'public, pg_catalog, information_schema';
+    ELSE
+      v_path := 'public, pg_catalog';
+    END IF;
+
+    EXECUTE format(
+      'ALTER FUNCTION public.%I(%s) SET search_path = %s',
+      r.proname, r.args, v_path
+    );
+
+    RAISE NOTICE 'Pinned search_path on public.%(%) -> %', r.proname, r.args, v_path;
+  END LOOP;
+END
+$pin$;
+
+-- -----------------------------------------------------------------------------
+-- Verification: assert ZERO SECURITY DEFINER functions in public remain with a
+-- mutable search_path (across the reviewed target set + any other public secdef
+-- function). If any remain, raise so the migration fails loudly.
+-- -----------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_remaining INTEGER;
+  v_detail TEXT;
+BEGIN
+  SELECT count(*),
+         string_agg(p.oid::regprocedure::text, ', ')
+    INTO v_remaining, v_detail
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.prokind = 'f'
+    AND p.prosecdef
+    AND NOT EXISTS (
+      SELECT 1 FROM unnest(coalesce(p.proconfig, '{}'::text[])) x
+      WHERE x LIKE 'search_path=%'
+    );
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'function_search_path_mutable NOT cleared: % SECURITY DEFINER function(s) still mutable: %',
+      v_remaining, v_detail;
+  END IF;
+
+  RAISE NOTICE 'Verification passed: 0 SECURITY DEFINER functions in public with mutable search_path.';
+END
+$verify$;

--- a/database/migrations/20260602_pin_search_path_security_definer_functions_rollback.sql
+++ b/database/migrations/20260602_pin_search_path_security_definer_functions_rollback.sql
@@ -1,0 +1,63 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK: unpin search_path on the SECURITY DEFINER functions pinned by
+-- 20260602_pin_search_path_security_definer_functions.sql
+-- =============================================================================
+-- The forward migration pinned search_path on a reviewed set of 14 functions
+-- (overload-safe: 13 names, get_schema_columns has 2 overloads). All of them had
+-- NO prior search_path in proconfig (verified live: the detection query returned
+-- exactly these because they lacked any `search_path=%` entry). Therefore the
+-- exact inverse is `ALTER FUNCTION ... RESET search_path`, which removes the
+-- pinned entry and returns each function to inheriting the caller's search_path.
+--
+-- IDEMPOTENT + OVERLOAD-SAFE: iterates pg_proc filtered to the reviewed target
+-- set and RESETs only those that currently HAVE a pinned search_path. Re-running
+-- after a partial rollback is a no-op.
+--
+-- WARNING: applying this rollback RE-OPENS the function_search_path_mutable
+-- finding (re-introduces the CVE-2018-1058 vector). Only run to recover from a
+-- regression where a pinned path broke a function at call time.
+-- =============================================================================
+
+DO $unpin$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT p.oid,
+           p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND p.prosecdef
+      -- Only RESET functions that currently HAVE a pinned search_path (idempotent).
+      AND EXISTS (
+        SELECT 1 FROM unnest(coalesce(p.proconfig, '{}'::text[])) x
+        WHERE x LIKE 'search_path=%'
+      )
+      AND p.proname IN (
+        'master_reset_portfolio',
+        'export_blueprint_review',
+        'fn_rollback_sd_hierarchy',
+        'export_blueprint_review_with_eva',
+        'rescan_stage_20',
+        'fn_atomic_exec_to_plan_transition',
+        'advance_venture_to_stage',
+        'check_feedback_rate_limit',
+        'get_schema_columns',
+        'rpc_activate_vision_with_bypass',
+        'fn_complete_stitch_curation',
+        'trg_retrospectives_audit',
+        'fn_atomic_lead_to_plan_transition'
+      )
+  LOOP
+    EXECUTE format(
+      'ALTER FUNCTION public.%I(%s) RESET search_path',
+      r.proname, r.args
+    );
+    RAISE NOTICE 'Unpinned search_path on public.%(%)', r.proname, r.args;
+  END LOOP;
+END
+$unpin$;

--- a/scripts/sentinels/audit-security-linter.mjs
+++ b/scripts/sentinels/audit-security-linter.mjs
@@ -39,10 +39,12 @@ function log(msg = '') { if (!JSON_MODE) console.log(msg); }
 
 async function main() {
   // 'engineer' matches scripts/apply-migration.js (the same consolidated instance the
-  // remediation migration targeted). connectionString (SUPABASE_POOLER_URL) wins in CI;
-  // locally it falls back to building from SUPABASE_DB_PASSWORD.
+  // remediation migration targeted). In CI the connectionString comes from DATABASE_URL
+  // (SUPABASE_POOLER_URL is not a configured secret in this repo — DATABASE_URL is the
+  // canonical fallback, same as scripts/check-migration-readiness.mjs). Locally, with
+  // neither set, createDatabaseClient builds the string from SUPABASE_DB_PASSWORD.
   const client = await createDatabaseClient('engineer', {
-    connectionString: process.env.SUPABASE_POOLER_URL,
+    connectionString: process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL,
   });
 
   let result;
@@ -71,6 +73,16 @@ async function main() {
       WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p') AND c.relrowsecurity = false
       ORDER BY 1`);
 
+    // (4) function_search_path_mutable — SECURITY DEFINER functions without a pinned
+    // search_path. WARN-class in Supabase's linter, but the SECURITY DEFINER subset is a
+    // real privilege-escalation surface (CVE-2018-1058 class), so the sentinel enforces it.
+    const secdefFns = await client.query(`
+      SELECT p.proname AS name
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.prokind = 'f' AND p.prosecdef
+        AND NOT EXISTS (SELECT 1 FROM unnest(COALESCE(p.proconfig, '{}')) x WHERE x LIKE 'search_path=%')
+      ORDER BY 1`);
+
     // Prevention liveness: is the view event trigger present + enabled? ('D' = disabled)
     const trig = await client.query(
       `SELECT evtenabled FROM pg_event_trigger WHERE evtname = 'leo_enforce_view_security_invoker'`);
@@ -79,13 +91,15 @@ async function main() {
       securityDefinerViews: views.rows.map(r => r.name),
       rlsDisabled: tables.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
       sensitiveExposed: sensitive.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
+      securityDefinerMutableFns: secdefFns.rows.map(r => r.name),
       triggerEnabled: trig.rows.length === 1 && trig.rows[0].evtenabled !== 'D',
     };
   } finally {
     await client.end();
   }
 
-  const findings = result.securityDefinerViews.length + result.rlsDisabled.length + result.sensitiveExposed.length;
+  const findings = result.securityDefinerViews.length + result.rlsDisabled.length
+    + result.sensitiveExposed.length + result.securityDefinerMutableFns.length;
   const clean = findings === 0 && result.triggerEnabled;
 
   log('');
@@ -95,10 +109,12 @@ async function main() {
   log(`  security_definer_view (views w/o security_invoker): ${result.securityDefinerViews.length}`);
   log(`  rls_disabled_in_public (tables w/o RLS):            ${result.rlsDisabled.length}`);
   log(`  sensitive_columns_exposed (session_id, no RLS):     ${result.sensitiveExposed.length}`);
+  log(`  function_search_path_mutable (SECURITY DEFINER fn): ${result.securityDefinerMutableFns.length}`);
   log(`  view-invoker event trigger enabled:                 ${result.triggerEnabled}`);
   log('  ' + '-'.repeat(40));
   if (result.securityDefinerViews.length) log('  Views:  ' + result.securityDefinerViews.join(', '));
   if (result.rlsDisabled.length) log('  Tables: ' + result.rlsDisabled.join(', '));
+  if (result.securityDefinerMutableFns.length) log('  Functions: ' + result.securityDefinerMutableFns.join(', '));
   if (!result.triggerEnabled) log('  ⚠ PREVENTION GAP: view-invoker event trigger missing/disabled!');
   log(clean ? '  ✓ CLEAN' : '  ✗ FINDINGS PRESENT');
   log('='.repeat(60));


### PR DESCRIPTION
Continues today's Supabase security-linter remediation.

## DB hardening — `function_search_path_mutable`

Pinned `search_path` on the **14** public `SECURITY DEFINER` functions that had a mutable `search_path`. A `SECURITY DEFINER` function without a pinned `search_path` resolves unqualified object names against the **caller's** `search_path` while running with the **owner's** elevated privileges — the CVE-2018-1058 privilege-escalation vector (a caller can prepend a schema that shadows a table/function the elevated function relies on).

- **12** functions pinned to `public, pg_catalog` (they reference only `public` objects + `pg_catalog` builtins).
- **2** functions (`get_schema_columns` overloads) also include `information_schema`.
- Affected functions include `rpc_activate_vision_with_bypass`, `master_reset_portfolio`, `advance_venture_to_stage`, and the `fn_atomic_*_transition` family.
- The migration uses `ALTER FUNCTION ... SET search_path` (non-destructive — does not rewrite function bodies), is **idempotent** (target set selected by predicate), and **overload-safe** (iterates `pg_proc` by full identity signature). A matching rollback migration is included.

> **Note:** this migration was **already applied to prod** via `apply-migration.js --prod-deploy` and **verified 0 remaining**. This PR is a **record-sync** — it does **not** re-apply on merge.

## Sentinel / CI fix

A manual dispatch of the `security-linter-sentinel` workflow (added earlier today in #4164) **failed in CI** because it referenced `SUPABASE_POOLER_URL`, which is **not a configured secret** in this repo (the empty value broke the DB connection).

- `audit-security-linter.mjs`: connect via `SUPABASE_POOLER_URL || DATABASE_URL`. `DATABASE_URL` is the canonical fallback (matches `scripts/check-migration-readiness.mjs`).
- Added a **4th sentinel check** — `SECURITY DEFINER` functions with a mutable `search_path` — so the weekly job catches new offenders of this class. It feeds the findings count and strict-mode exit.
- `security-linter-sentinel.yml`: pass `DATABASE_URL` to both sentinel steps.

Sentinel runs green locally (exit 0); `node --check` passes on the workflow edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
