### PR TITLE
fix(QF-20260602-532): regenerate stale committed dist/ uat handlers

### DIFF
--- a/dist/api/uat/handlers.js
+++ b/dist/api/uat/handlers.js
@@ -180,7 +180,6 @@ export async function closeUATRun(run_id) {
  * Infer suspected files based on test case ID
  */
 function inferSuspectedFiles(case_id) {
-    const files = [];
     // Parse test ID to determine likely files
     const [, section] = case_id.split('-');
     const fileMap = {
@@ -304,18 +303,30 @@ export async function getTestCasesBySection(section) {
 }
 /**
  * Get open defects for a run
+ * SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001: Query unified feedback table
  */
 export async function getOpenDefects(run_id) {
     try {
         const { data, error } = await supabase
-            .from('uat_defects')
+            .from('feedback')
             .select('*')
-            .eq('run_id', run_id)
-            .eq('status', 'open')
+            .eq('source_type', 'uat_failure')
+            .contains('metadata', { test_run_id: run_id })
+            .in('status', ['new', 'open', 'triaged'])
             .order('severity');
         if (error)
             throw error;
-        return data || [];
+        // Map feedback fields to expected defect format for backward compatibility
+        return (data || []).map(item => ({
+            id: item.id,
+            run_id: item.metadata?.test_run_id || run_id,
+            case_id: item.metadata?.case_id || item.metadata?.scenario_id,
+            severity: item.severity === 'high' ? 'critical' : item.severity === 'medium' ? 'major' : 'minor',
+            summary: item.title,
+            description: item.description,
+            status: item.status === 'new' ? 'open' : item.status,
+            created_at: item.created_at
+        }));
     }
     catch (err) {
         console.error('Error getting open defects:', err);

--- a/dist/scripts/api/uat/handlers.js
+++ b/dist/scripts/api/uat/handlers.js
@@ -180,7 +180,6 @@ export async function closeUATRun(run_id) {
  * Infer suspected files based on test case ID
  */
 function inferSuspectedFiles(case_id) {
-    const files = [];
     // Parse test ID to determine likely files
     const [, section] = case_id.split('-');
     const fileMap = {
@@ -304,18 +303,30 @@ export async function getTestCasesBySection(section) {
 }
 /**
  * Get open defects for a run
+ * SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001: Query unified feedback table
  */
 export async function getOpenDefects(run_id) {
     try {
         const { data, error } = await supabase
-            .from('uat_defects')
+            .from('feedback')
             .select('*')
-            .eq('run_id', run_id)
-            .eq('status', 'open')
+            .eq('source_type', 'uat_failure')
+            .contains('metadata', { test_run_id: run_id })
+            .in('status', ['new', 'open', 'triaged'])
             .order('severity');
         if (error)
             throw error;
-        return data || [];
+        // Map feedback fields to expected defect format for backward compatibility
+        return (data || []).map(item => ({
+            id: item.id,
+            run_id: item.metadata?.test_run_id || run_id,
+            case_id: item.metadata?.case_id || item.metadata?.scenario_id,
+            severity: item.severity === 'high' ? 'critical' : item.severity === 'medium' ? 'major' : 'minor',
+            summary: item.title,
+            description: item.description,
+            status: item.status === 'new' ? 'open' : item.status,
+            created_at: item.created_at
+        }));
     }
     catch (err) {
         console.error('Error getting open defects:', err);


### PR DESCRIPTION
## Quick-Fix QF-20260602-532

Harness-backlog drain (feedback id `c2093879`). `dist/api/uat/handlers.js` and `dist/scripts/api/uat/handlers.js` (byte-identical) still carried the pre-deprecation `getOpenDefects()` querying `.from('uat_defects')`, while the `.ts` source was migrated to the unified `feedback` table by SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001.

### Why it drifted
The committed compiled output was last built 2026-04-24 (`5a2e3006a7`) and **no standard build regenerates it** — `tsconfig.json` only compiles `src/services/database-loader`; these UAT handlers were ad-hoc `tsc`-compiled (per `docs/05_testing/README.md`).

### Fix
Regenerated both copies via the documented ESM `tsc` to match current source:
- `getOpenDefects()` now queries `feedback` (`source_type=uat_failure`, `metadata.test_run_id`) and maps to the defect shape
- drops a dead `const files = []` the source had already removed

42 lines (+32/-10), both copies identical. No runtime importer loads these dist copies (repo importers use the `.ts` source) — pure artifact-sync.

> Follow-up (noted, not in scope): these dist artifacts have no maintaining build and will drift again; wire them into a build or stop committing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)