### PR TITLE
fix(security): strip sslmode from sentinel DB connection (CI SELF_SIGNED_CERT fix)

### DIFF
--- a/scripts/sentinels/audit-security-linter.mjs
+++ b/scripts/sentinels/audit-security-linter.mjs
@@ -43,9 +43,22 @@ async function main() {
   // (SUPABASE_POOLER_URL is not a configured secret in this repo — DATABASE_URL is the
   // canonical fallback, same as scripts/check-migration-readiness.mjs). Locally, with
   // neither set, createDatabaseClient builds the string from SUPABASE_DB_PASSWORD.
-  const client = await createDatabaseClient('engineer', {
-    connectionString: process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL,
-  });
+  //
+  // Strip any `sslmode` param: the repo's DATABASE_URL carries `?sslmode=require`, which
+  // pg-connection-string promotes to verify-full and which overrides the lib's explicit
+  // ssl:{ca} (the committed Supabase root CA), causing SELF_SIGNED_CERT_IN_CHAIN on the
+  // runner. Removing it lets getSSLConfig()'s strict CA verification govern (no TLS bypass,
+  // so the ssl-bypass-lint gate stays satisfied). Verified: with sslmode -> error, without
+  // -> OK.
+  let connectionString = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL;
+  if (connectionString) {
+    try {
+      const u = new URL(connectionString);
+      u.searchParams.delete('sslmode');
+      connectionString = u.toString();
+    } catch { /* not a parseable URL — leave as-is, lib will handle/throw */ }
+  }
+  const client = await createDatabaseClient('engineer', { connectionString });
 
   let result;
   try {


### PR DESCRIPTION
The security-linter-sentinel workflow failed in CI because the DATABASE_URL secret carries ?sslmode=require, which pg-connection-string promotes to verify-full and which overrides the lib's explicit ssl:{ca} (the committed Supabase root CA), throwing SELF_SIGNED_CERT_IN_CHAIN on the runner; this fix strips sslmode from the connection string so getSSLConfig()'s strict CA verification governs the TLS handshake instead — no TLS bypass is introduced (so the ssl-bypass-lint gate stays satisfied) and strict certificate verification is preserved. Reproduced locally: with sslmode the self-signed-cert error fires; stripped, the connection succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)