### PR TITLE
fix(QF-20260602-053): refresh stale claim-gate unit tests (11 fails)

### DIFF
--- a/tests/unit/claim-default.test.js
+++ b/tests/unit/claim-default.test.js
@@ -44,7 +44,9 @@ describe('multi-session-claim-gate ambiguous handling', () => {
 
     // Verify old ALLOW pattern is removed
     const ambiguousIdx = source.indexOf("sameConvo === 'ambiguous'");
-    const ambiguousBlock = source.substring(ambiguousIdx, ambiguousIdx + 500);
+    // Window widened: QF-20260404-512 inserted a PID-liveness block between
+    // `sameConvo === 'ambiguous'` and the DENY-on-ambiguity comment.
+    const ambiguousBlock = source.substring(ambiguousIdx, ambiguousIdx + 1500);
     expect(ambiguousBlock).not.toContain('treating as same conversation');
     expect(ambiguousBlock).toContain('DENY-on-ambiguity');
   });
@@ -59,12 +61,16 @@ describe('claim-guard TTL configuration', () => {
     expect(source).toContain('chairman_dashboard_config');
   });
 
-  it('should call fetchClaimTTL at start of claimGuard', async () => {
+  it('should resolve the claim TTL (which fetches config) inside claimGuard', async () => {
     const source = (await import('fs')).readFileSync('lib/claim-guard.mjs', 'utf8');
+    // SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 moved the TTL fetch out of claimGuard
+    // into resolveClaimTtlSeconds(), which calls fetchClaimTTL() internally.
     const claimGuardStart = source.indexOf('export async function claimGuard');
-    const fetchCall = source.indexOf('await fetchClaimTTL()', claimGuardStart);
-    expect(fetchCall).toBeGreaterThan(claimGuardStart);
-    expect(fetchCall - claimGuardStart).toBeLessThan(400); // Within first 400 chars of function
+    const resolveCall = source.indexOf('await resolveClaimTtlSeconds(', claimGuardStart);
+    expect(resolveCall).toBeGreaterThan(claimGuardStart);
+    const resolveFnStart = source.indexOf('export async function resolveClaimTtlSeconds');
+    const fetchInResolve = source.indexOf('await fetchClaimTTL()', resolveFnStart);
+    expect(fetchInResolve).toBeGreaterThan(resolveFnStart);
   });
 });
 

--- a/tests/unit/multi-session-claim-gate.test.js
+++ b/tests/unit/multi-session-claim-gate.test.js
@@ -14,6 +14,10 @@ import {
 // Helper: mock Supabase that returns active session data
 function createMockSupabase(sessions = []) {
   return {
+    // validateMultiSessionClaim first calls rpc('release_same_conversation_claims').
+    // It must resolve so the SUT skips the claude_sessions fallback (whose 3-deep
+    // .eq() chain this mock doesn't provide), otherwise the gate fails open (score 80).
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     from: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -27,6 +31,7 @@ function createMockSupabase(sessions = []) {
 // Helper: mock Supabase that returns a DB error
 function createErrorSupabase(message = 'Connection refused') {
   return {
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     from: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Quick-Fix QF-20260602-053

Harness-backlog drain (feedback id `a77db5e1`). 11 tests failed on `main` (verified baseline). **Test-only; SUT untouched.**

### multi-session-claim-gate.test.js (9 fails) — one root cause
`validateMultiSessionClaim` first calls `supabase.rpc('release_same_conversation_claims')`. The mock factories lacked `.rpc`, so it threw → the fallback `claude_sessions.eq().eq().eq()` chain (which the mock doesn't provide) threw to the outer catch → **fail-open score 80**. Added `.rpc` to `createMockSupabase` + `createErrorSupabase` so the SUT skips the fallback and takes the supported `v_active_sessions` path.

### claim-default.test.js (2 fails) — stale static-source assertions
- `DENY-on-ambiguity` got pushed past the 500-char `substring` window by QF-20260404-512's PID-liveness block → widened to 1500.
- `claimGuard` no longer calls `fetchClaimTTL()` directly — it resolves TTL via `resolveClaimTtlSeconds()` (which calls `fetchClaimTTL` internally) per SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 → assertion updated to the new wiring.

### Verification
`npx vitest run tests/unit/multi-session-claim-gate.test.js tests/unit/claim-default.test.js` → **25/25 pass** (was 11 failed / 14 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)