### PR TITLE
fix(QF-20260602-607): Derive venture_id from linked vision in archplan-upsert (fixes orphaned architecture plans)

### DIFF
--- a/lib/eva/__tests__/archplan-upsert.test.js
+++ b/lib/eva/__tests__/archplan-upsert.test.js
@@ -7,6 +7,7 @@ import { upsertArchPlan } from '../archplan-upsert.js';
 
 // Mock supabase with chainable query builder
 function mockSupabase({ visionDoc = null, visionErr = null, existing = null, upsertResult = null, upsertError = null } = {}) {
+  const captured = { upsertRecord: null };
   const chainable = (finalData, finalError) => ({
     select: vi.fn(() => ({
       eq: vi.fn(() => ({
@@ -14,11 +15,14 @@ function mockSupabase({ visionDoc = null, visionErr = null, existing = null, ups
         maybeSingle: vi.fn(async () => ({ data: existing, error: null })),
       })),
     })),
-    upsert: vi.fn(() => ({
-      select: vi.fn(() => ({
-        single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
-      })),
-    })),
+    upsert: vi.fn((record) => {
+      captured.upsertRecord = record;
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({ data: upsertResult, error: upsertError })),
+        })),
+      };
+    }),
   });
 
   return {
@@ -27,6 +31,7 @@ function mockSupabase({ visionDoc = null, visionErr = null, existing = null, ups
       if (table === 'eva_architecture_plans') return chainable(existing, null);
       return chainable(null, null);
     }),
+    __captured: captured,
   };
 }
 
@@ -81,5 +86,38 @@ describe('upsertArchPlan', () => {
     // Should succeed (mock returns result)
     expect(supabase.from).toHaveBeenCalledWith('eva_vision_documents');
     expect(supabase.from).toHaveBeenCalledWith('eva_architecture_plans');
+  });
+
+  // QF-20260602-607: arch plans must inherit venture_id from their linked vision
+  // (the archplan sibling of the vision-side fix QF-20260527-948), else they orphan.
+  test('inherits venture_id from the linked vision when ventureId is not passed', async () => {
+    const visionDoc = { id: 'vision-uuid', vision_key: 'V-1', level: 'L2', status: 'active', version: 1, venture_id: 'venture-xyz' };
+    const result = { id: 'arch-uuid', plan_key: 'A-1', version: 1, status: 'active', vision_id: 'vision-uuid' };
+    const supabase = mockSupabase({ visionDoc, upsertResult: result });
+
+    await upsertArchPlan({ supabase, planKey: 'A-1', visionKey: 'V-1', content: 'x' });
+
+    expect(supabase.__captured.upsertRecord).toBeTruthy();
+    expect(supabase.__captured.upsertRecord.venture_id).toBe('venture-xyz');
+  });
+
+  test('explicit ventureId overrides the vision venture_id', async () => {
+    const visionDoc = { id: 'vision-uuid', vision_key: 'V-1', level: 'L2', status: 'active', version: 1, venture_id: 'venture-from-vision' };
+    const result = { id: 'arch-uuid', plan_key: 'A-1', version: 1, status: 'active', vision_id: 'vision-uuid' };
+    const supabase = mockSupabase({ visionDoc, upsertResult: result });
+
+    await upsertArchPlan({ supabase, planKey: 'A-1', visionKey: 'V-1', content: 'x', ventureId: 'explicit-venture' });
+
+    expect(supabase.__captured.upsertRecord.venture_id).toBe('explicit-venture');
+  });
+
+  test('omits venture_id when neither ventureId nor vision.venture_id is present (no regression for platform plans)', async () => {
+    const visionDoc = { id: 'vision-uuid', vision_key: 'V-1', level: 'L2', status: 'active', version: 1 }; // no venture_id
+    const result = { id: 'arch-uuid', plan_key: 'A-1', version: 1, status: 'active', vision_id: 'vision-uuid' };
+    const supabase = mockSupabase({ visionDoc, upsertResult: result });
+
+    await upsertArchPlan({ supabase, planKey: 'A-1', visionKey: 'V-1', content: 'x' });
+
+    expect('venture_id' in supabase.__captured.upsertRecord).toBe(false);
   });
 });

--- a/lib/eva/archplan-upsert.js
+++ b/lib/eva/archplan-upsert.js
@@ -16,7 +16,7 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
   // Resolve vision_id and version from vision_key
   const { data: visionDoc, error: visionErr } = await supabase
     .from('eva_vision_documents')
-    .select('id, vision_key, level, status, version')
+    .select('id, vision_key, level, status, version, venture_id')
     .eq('vision_key', visionKey)
     .single();
 
@@ -102,7 +102,10 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
     chairman_approved: true,
     created_by: createdBy,
     source_file_path: null,
-    ...(ventureId ? { venture_id: ventureId } : {}),
+    // QF-20260602-607: inherit venture_id from the linked vision when not explicitly
+    // passed, so arch plans aren't orphaned (mirrors the vision-side fix QF-20260527-948).
+    // Explicit ventureId still wins; a vision with no venture_id leaves it unset (no regression).
+    ...((ventureId || visionDoc.venture_id) ? { venture_id: ventureId || visionDoc.venture_id } : {}),
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
     ...(sections ? { sections } : {}),
   };


### PR DESCRIPTION
## Quick-Fix: QF-20260602-607

**Type:** bug
**Severity:** medium

### Issue Description
upsertArchPlan never sets venture_id unless explicitly passed, and does not read venture_id from the linked vision document, so every architecture plan created via archplan-command.mjs (and the stage-19 cascade) orphans with venture_id NULL. Venture-scoped lookups and the S19 vision-artifact gate then cannot resolve the plan. Mirror of completed QF-20260527-948 (the vision-side sibling of this propagation gap). Fix: select venture_id from eva_vision_documents in upsertArchPlan and default ventureId = ventureId || visionDoc.venture_id. Surfaced via DataDistill ARCH-DATADISTILL-002 (venture_id NULL; hand-relinked this session).




### Changes
- **Files Changed:** 2
  - lib/eva/__tests__/archplan-upsert.test.js
  - lib/eva/archplan-upsert.js
- **LOC:** 48 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Regression surface run externally in the isolated worktree: archplan-upsert 9/9 (incl. 3 new venture_id-derivation tests), full lib/eva 38 files/531 tests, cascade-watcher 9/9 (the venture arch-plan creation consumer). tsc --noEmit exit 0. Skipped only the full 'vitest run --project unit' advisory suite (known ~500 pre-existing failures unrelated to this change, per SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001). Backend pure-lib change, no UI/route surface so e2e smoke is N/A; UAT = the unit regression above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol