### PR TITLE
fix(harness): check-git-state preserves porcelain leading whitespace (trim -> trimEnd)

### DIFF
--- a/scripts/check-git-state.js
+++ b/scripts/check-git-state.js
@@ -32,10 +32,15 @@ function isPerWorktreeMetadata(file) {
 async function gitCommand(command, cwd) {
   try {
     const { stdout, stderr } = await execAsync(command, cwd ? { cwd } : undefined);
-    return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
+    // trimEnd() — NOT trim(): leading whitespace is SIGNIFICANT for `git status
+    // --porcelain` (its first line begins with the 2-char status code, e.g.
+    // " M .worktree.json"). A bare .trim() strips the first line's leading space,
+    // shifting the parse (status " M"→"M ", file ".worktree.json"→"worktree.json")
+    // so per-worktree metadata misses the skip-list and wrongly blocks the handoff.
+    return { stdout: stdout.trimEnd(), stderr: stderr.trim(), success: true };
   } catch (error) {
     return {
-      stdout: error.stdout?.trim() || '',
+      stdout: error.stdout?.trimEnd() || '',
       stderr: error.stderr?.trim() || error.message,
       success: false
     };

--- a/tests/unit/check-git-state-porcelain-leading-space.test.js
+++ b/tests/unit/check-git-state-porcelain-leading-space.test.js
@@ -1,0 +1,67 @@
+/**
+ * Regression (harness-bug, signalled by 9e371f17 2026-06-01): gitCommand() ran
+ * `stdout.trim()`, which strips the leading space of the FIRST `git status
+ * --porcelain` line. For an unstaged ' M .worktree.json' first line that shifts
+ * the parse — status " M"->"M " (misread as STAGED) and file ".worktree.json"->
+ * "worktree.json" (dot dropped) — so isPerWorktreeMetadata() misses the QF-729
+ * skip-list and checkGitState set passed=false, blocking every worker's first
+ * LEAD-TO-PLAN handoff from a freshly sd-start-provisioned worktree.
+ *
+ * Fix: gitCommand returns stdout.trimEnd() (preserve leading whitespace; only
+ * trailing newline is noise). This test feeds a leading-space metadata line as
+ * the FIRST porcelain line through the real gitCommand->parse path (exec mocked
+ * via promisify.custom) and asserts it is still skipped.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const srcPath = fileURLToPath(new URL('../../scripts/check-git-state.js', import.meta.url));
+
+function mockExecWith(porcelainStdout) {
+  vi.resetModules();
+  vi.doMock('child_process', async () => {
+    const { promisify } = await import('util');
+    const exec = function () {};
+    // child_process.exec resolves to { stdout, stderr } under promisify — replicate
+    // that via the custom symbol so `const execAsync = promisify(exec)` behaves.
+    exec[promisify.custom] = (cmd) => {
+      if (cmd.includes('--porcelain')) return Promise.resolve({ stdout: porcelainStdout, stderr: '' });
+      if (cmd.includes('branch')) return Promise.resolve({ stdout: 'feat/x\n', stderr: '' });
+      return Promise.resolve({ stdout: '', stderr: '' }); // unpushed-log etc.
+    };
+    return { exec };
+  });
+}
+
+describe('check-git-state preserves porcelain leading whitespace (harness-bug 9e371f17)', () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => { vi.doUnmock('child_process'); vi.resetModules(); });
+
+  it('does NOT block when .worktree.json is the FIRST (leading-space) porcelain line', async () => {
+    mockExecWith(' M .worktree.json\n');
+    const { checkGitState } = await import('../../scripts/check-git-state.js');
+    const r = await checkGitState();
+    // With the old stdout.trim() bug this line parsed as staged "worktree.json"
+    // (passed=false). With trimEnd() it stays " M .worktree.json" -> skipped.
+    expect(r.details.stagedFiles).toEqual([]);
+    expect(r.details.modifiedFiles).toEqual([]);
+    expect(r.details.uncommittedFiles).toEqual([]);
+    expect(r.passed).toBe(true);
+  });
+
+  it('still classifies a real first-line unstaged change as modified (leading space intact)', async () => {
+    mockExecWith(' M src/real.js\n');
+    const { checkGitState } = await import('../../scripts/check-git-state.js');
+    const r = await checkGitState();
+    expect(r.details.modifiedFiles).toEqual(['src/real.js']);
+    expect(r.details.stagedFiles).toEqual([]);
+    expect(r.passed).toBe(false);
+  });
+
+  it('source guard: gitCommand returns trimEnd() for stdout, never a bare stdout.trim()', () => {
+    const src = readFileSync(srcPath, 'utf8');
+    expect(src).toMatch(/stdout:\s*stdout\.trimEnd\(\)/);
+    expect(src).not.toMatch(/stdout:\s*stdout\.trim\(\)/);
+  });
+});


### PR DESCRIPTION
## Problem

`gitCommand()` in `scripts/check-git-state.js` ran `stdout.trim()`, which strips the **leading** space of the FIRST `git status --porcelain` line.

The porcelain format begins each line with a 2-char status code, so the first line for an unstaged change looks like `" M .worktree.json"`. With a bare `.trim()` that leading space is lost, shifting the parse on the first line only:

- status `" M"` → `"M "` — misread as **STAGED** instead of modified-unstaged
- file `".worktree.json"` → `"worktree.json"` — the leading dot is dropped

Because the filename no longer matched, `isPerWorktreeMetadata()` missed the QF-20260529-729 skip-list, so `checkGitState` set `passed=false` and **blocked every worker's first `LEAD-TO-PLAN` handoff** from a freshly `sd-start`-provisioned worktree (where ` M .worktree.json` is the first porcelain line).

## Fix

`gitCommand` now returns `stdout.trimEnd()` instead of `stdout.trim()`. Leading whitespace is **significant** for porcelain output; only the trailing newline is noise, so `trimEnd()` preserves the first line's status code and filename intact. The same change is applied to the error-path `error.stdout` handling.

## Blast radius

Contained: `gitCommand` is a private function within `scripts/check-git-state.js` (not exported), so the change cannot affect other modules.

## Testing

`tests/unit/check-git-state-porcelain-leading-space.test.js` (new) feeds a leading-space metadata line as the FIRST porcelain line through the real `gitCommand`→parse path (`exec` mocked via `promisify.custom`) and asserts:

1. `.worktree.json` as the first line is still skipped (`passed=true`, empty file lists) — fails under the old `trim()`.
2. A real first-line unstaged change (`src/real.js`) is still classified as modified (`passed=false`) — leading space intact.
3. Source guard: `gitCommand` returns `stdout.trimEnd()`, never a bare `stdout.trim()`.

`node --check` passes. **6/6 tests pass** (3 new behavioral/guard + the existing 3 worktree-metadata tests; no regression).

Resolves the harness-bug signalled by session `9e371f17` on 2026-06-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)