### PR TITLE
fix(eva): canonicalize venture target_application casing across the SD tree (QF-20260602-280)

### DIFF
--- a/lib/eva/lifecycle-sd-bridge-target-app-normalize.test.js
+++ b/lib/eva/lifecycle-sd-bridge-target-app-normalize.test.js
@@ -11,8 +11,21 @@ describe('lifecycle-sd-bridge target_application normalization (QF-20260504-716)
     expect(SRC).toMatch(/function normalizeTargetApplication\s*\(/);
   });
 
-  it('wraps every target_application write site (5 sites expected)', () => {
-    const matches = SRC.match(/normalizeTargetApplication\(/g) || [];
-    expect(matches.length).toBeGreaterThanOrEqual(6); // 1 declaration + 5 call sites
+  it('wraps every target_application write site (normalizeTargetApplication or resolveTreeTargetApplication)', () => {
+    // QF-20260602-280: sprint-tree descendant write sites now route through
+    // resolveTreeTargetApplication (which itself calls normalizeTargetApplication) so the
+    // whole venture tree shares ONE casing; root/expand still call normalizeTargetApplication.
+    const wrapped = (SRC.match(/(normalizeTargetApplication|resolveTreeTargetApplication)\(/g) || []).length;
+    expect(wrapped).toBeGreaterThanOrEqual(6);
+    // No RAW (unwrapped) call-style write: every `target_application: fn(` must use a wrapper.
+    const callWrites = SRC.match(/target_application:\s*([A-Za-z_][A-Za-z0-9_]*)\(/g) || [];
+    expect(callWrites.length).toBeGreaterThan(0);
+    for (const w of callWrites) {
+      expect(w).toMatch(/target_application:\s*(normalizeTargetApplication|resolveTreeTargetApplication)\(/);
+    }
+  });
+
+  it('declares resolveTreeTargetApplication (QF-20260602-280 tree-casing helper)', () => {
+    expect(SRC).toMatch(/function resolveTreeTargetApplication\s*\(/);
   });
 });

--- a/lib/eva/lifecycle-sd-bridge-tree-target-casing.test.js
+++ b/lib/eva/lifecycle-sd-bridge-tree-target-casing.test.js
@@ -1,0 +1,52 @@
+/**
+ * QF-20260602-280: a venture SD tree must carry ONE target_application casing.
+ *
+ * Root cause: the sprint ROOT orchestrator was stamped from ventureContext.name (display
+ * form, e.g. "DataDistill") while DESCENDANTS resolved payload.target_application from the
+ * registry slug ("datadistill"), and normalizeTargetApplication only canonicalizes
+ * ehg/ehg_engineer — so DataDistill's tree fragmented into root="DataDistill" + 25
+ * descendants="datadistill". resolveTreeTargetApplication() collapses the casing to the
+ * venture display name when the per-SD value is the same venture (case-insensitive) or
+ * absent, while preserving a genuine cross-application per-SD target.
+ */
+import { describe, it, expect } from 'vitest';
+import { _internal } from './lifecycle-sd-bridge.js';
+
+const { resolveTreeTargetApplication, normalizeTargetApplication } = _internal;
+
+describe('resolveTreeTargetApplication — one casing per venture tree (QF-20260602-280)', () => {
+  it('collapses the registry slug to the venture display name', () => {
+    expect(resolveTreeTargetApplication('datadistill', 'DataDistill')).toBe('DataDistill');
+  });
+
+  it('leaves the display form unchanged', () => {
+    expect(resolveTreeTargetApplication('DataDistill', 'DataDistill')).toBe('DataDistill');
+  });
+
+  it('uses the venture display name when the per-SD target is absent', () => {
+    expect(resolveTreeTargetApplication(null, 'DataDistill')).toBe('DataDistill');
+    expect(resolveTreeTargetApplication(undefined, 'DataDistill')).toBe('DataDistill');
+    expect(resolveTreeTargetApplication('', 'DataDistill')).toBe('DataDistill');
+  });
+
+  it('ROOT and DESCENDANT inputs now yield the SAME value (the core regression)', () => {
+    const root = resolveTreeTargetApplication('DataDistill', 'DataDistill');   // root site input
+    const child = resolveTreeTargetApplication('datadistill', 'DataDistill');  // descendant slug input
+    expect(child).toBe(root);
+    expect(root).toBe('DataDistill');
+  });
+
+  it('preserves a genuine cross-application per-SD target (not the same venture)', () => {
+    expect(resolveTreeTargetApplication('EHG', 'DataDistill')).toBe('EHG');
+    // and still canonicalizes ehg/ehg_engineer casing on that cross-app target
+    expect(resolveTreeTargetApplication('ehg', 'DataDistill')).toBe('EHG');
+    expect(resolveTreeTargetApplication('ehg_engineer', 'DataDistill')).toBe('EHG_Engineer');
+  });
+
+  it('still applies the ehg/ehg_engineer canonical-case map (QF-20260504-716 intact)', () => {
+    expect(normalizeTargetApplication('ehg')).toBe('EHG');
+    expect(normalizeTargetApplication('ehg_engineer')).toBe('EHG_Engineer');
+    // a venture slug with no display context passes through unchanged (unchanged behavior)
+    expect(normalizeTargetApplication('datadistill')).toBe('datadistill');
+  });
+});

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -72,6 +72,21 @@ function normalizeTargetApplication(value) {
   return TARGET_APP_CANONICAL[value.toLowerCase()] ?? value;
 }
 
+// QF-20260602-280: keep ONE target_application casing across a venture SD tree. The sprint
+// ROOT orchestrator is stamped from ventureContext.name (display form, e.g. "DataDistill"),
+// but DESCENDANTS resolve payload.target_application from the registry slug ("datadistill")
+// and normalizeTargetApplication only canonicalizes ehg/ehg_engineer — so the tree fragmented
+// (root "DataDistill" vs descendants "datadistill"). Prefer the venture's display name whenever
+// the per-SD value is the SAME venture (case-insensitive) or absent; preserve a genuine
+// cross-application per-SD target otherwise. (getCurrentVenture fallback preserved.)
+function resolveTreeTargetApplication(perSdTarget, ventureName) {
+  const display = (typeof ventureName === 'string' && ventureName) ? ventureName : null;
+  if (display && (!perSdTarget || String(perSdTarget).toLowerCase() === display.toLowerCase())) {
+    return normalizeTargetApplication(display);
+  }
+  return normalizeTargetApplication(perSdTarget || display || getCurrentVenture());
+}
+
 // Type mapping from Stage 18 types to database sd_type
 const TYPE_MAP = {
   feature: 'feature',
@@ -489,7 +504,7 @@ export async function convertSprintToSDs(params, deps = {}) {
       // orchestrator up front makes that trigger a no-op (its WHERE sd_type!='orchestrator' skips it):
       // no type change, no bypass, governance fully intact. Gate on the SAME effective layer set the
       // grandchildren are built from, so a child is never typed orchestrator without grandchildren (FR-2).
-      const childEffectiveTarget = normalizeTargetApplication(payload.target_application || ventureContext?.name || getCurrentVenture());
+      const childEffectiveTarget = resolveTreeTargetApplication(payload.target_application, ventureContext?.name);
       const childSdType = (generateGrandchildren && computeEffectiveGrandchildLayers(payload, childEffectiveTarget).length > 0)
         ? 'orchestrator'
         : dbType;
@@ -513,7 +528,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           priority: payload.priority || 'medium',
           category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
           current_phase: 'LEAD',
-          target_application: normalizeTargetApplication(payload.target_application || ventureContext?.name || getCurrentVenture()),
+          target_application: resolveTreeTargetApplication(payload.target_application, ventureContext?.name),
           created_by: 'lifecycle-sd-bridge',
           parent_sd_id: orchestratorId,
           dependencies: childBuildDeps[i], // FR-4: earlier-architecture-layer child SD keys → resolver gates build order
@@ -660,7 +675,7 @@ async function createGrandchildren({
   // interpolation of user-supplied values; per database-agent C-DB-3 reuse
   // emitFeedback (single canonical write path); per database-agent C-DB-2 use
   // feedback.sd_id (UUID).
-  const effectiveTarget = normalizeTargetApplication(childPayload.target_application || ventureContext?.name || getCurrentVenture());
+  const effectiveTarget = resolveTreeTargetApplication(childPayload.target_application, ventureContext?.name);
   const layers = filterLayersByCapability(candidateLayers, effectiveTarget, {
     logger,
     parentChildKey,
@@ -699,7 +714,7 @@ async function createGrandchildren({
         priority: childPayload.priority || 'medium',
         category: 'Feature',
         current_phase: 'LEAD',
-        target_application: normalizeTargetApplication(childPayload.target_application || ventureContext?.name || getCurrentVenture()),
+        target_application: resolveTreeTargetApplication(childPayload.target_application, ventureContext?.name),
         created_by: 'lifecycle-sd-bridge',
         parent_sd_id: parentChildId,
         dependencies: gcDependencies, // FR-4: earlier-layer grandchild keys gate intra-child build order
@@ -1299,6 +1314,8 @@ export async function reEnrichExistingSDs(supabase, ventureId, options = {}) {
 export const _internal = {
   TYPE_MAP,
   ARCHITECTURE_LAYERS,
+  normalizeTargetApplication,
+  resolveTreeTargetApplication,
   MAX_CHILDREN_PER_ORCHESTRATOR,
   MAX_HIERARCHY_DEPTH,
   MAX_GRANDCHILDREN_PER_CHILD,


### PR DESCRIPTION
## QF-20260602-280

### Problem (RCA)
A venture's SD tree fragmented its `target_application` casing. The lifecycle-sd-bridge stamped the sprint **ROOT** orchestrator from `ventureContext.name` (display form, e.g. `"DataDistill"`), but **DESCENDANTS** resolved `payload.target_application` from the registry slug (`"datadistill"`) via the resolver. Because `normalizeTargetApplication` only canonicalizes `ehg`/`ehg_engineer`, venture-named targets passed through unchanged — so the tree split (DataDistill: 1 root `"DataDistill"` vs 25 descendants `"datadistill"`), fragmenting per-venture rollups that group by `target_application`.

### Fix
Add `resolveTreeTargetApplication(perSdTarget, ventureName)`: prefer the venture **display name** when the per-SD target is the same venture (case-insensitive) or absent, while **preserving a genuine cross-application** per-SD target. Applied at the **4 descendant write sites** (child + grandchild, both the stored `target_application` and the capability-compute `effectiveTarget`). The root and expand paths already use the display name, so they are untouched. The `getCurrentVenture()` fallback is preserved.

### Behavior preservation
Behavior-preserving for `EHG`/`EHG_Engineer` (still canonicalized via `normalizeTargetApplication`). Venture-relevant consumers are case-insensitive. A real cross-application target on a per-SD payload is still respected.

### Tests
72 lifecycle-sd-bridge tests pass:
- new behavioral test (`lifecycle-sd-bridge-tree-target-casing.test.js`)
- updated wrapper-count test (`lifecycle-sd-bridge-target-app-normalize.test.js`)
- 63 existing tests
- `node --check` passes

### Scope
Does **NOT** backfill existing SDs. The active DataDistill tree is session `d8bcef6b`'s chairman-directed regen target; the regen recreates those SDs with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)