### PR TITLE
feat(SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001): product-KPI telemetry contract extension + data-minimization enforcement

### DIFF
--- a/database/migrations/20260602_venture_telemetry_product_kpis.sql
+++ b/database/migrations/20260602_venture_telemetry_product_kpis.sql
@@ -1,0 +1,33 @@
+-- SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001: product-KPI storage + RLS tightening (FR-3, FR-4).
+-- Additive + idempotent. Adds a validated-KPI-subset column to venture_telemetry and tightens the
+-- read policy off `anon USING(true)`, since the KPI subset is dashboard-exposed. Safe to run
+-- alongside active sessions: one new NULLable-with-default column + a policy swap. No data loss.
+
+-- FR-4: store the VALIDATED, allowlisted product-KPI subset (written by the pull consumer's
+--       validateKpis()). Aggregates only — never PII/raw rows (enforced in code by the allowlist,
+--       NOT by this column). KILL/SCALE + portfolio rollups DERIVE from these (deriveVenturePortfolio).
+ALTER TABLE public.venture_telemetry
+  ADD COLUMN IF NOT EXISTS kpis jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.venture_telemetry.kpis IS
+  'SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001: validated, allowlisted product-KPI aggregates (signups/active_users/revenue/usage_volume/health/churn) extracted from /v1/metrics. Populated ONLY via scripts/venture-telemetry-pull.mjs validateKpis() — unknown/malformed keys are DROPPED before persistence. Aggregates only; never PII/raw rows. Feeds ventures portfolio columns via deriveVenturePortfolio().';
+
+-- FR-3: tighten the read RLS. The prior policy granted anon+authenticated SELECT USING(true);
+-- since whatever lands is dashboard-readable, an egress leak would be EXPOSED, not just stored.
+-- Restrict SELECT to authenticated (chairman dashboard); service_role keeps ALL (the pull writer).
+-- Remove anon read entirely.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='venture_telemetry' AND policyname='venture_telemetry_read') THEN
+    DROP POLICY venture_telemetry_read ON public.venture_telemetry;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='venture_telemetry' AND policyname='venture_telemetry_read_authenticated') THEN
+    CREATE POLICY venture_telemetry_read_authenticated ON public.venture_telemetry
+      FOR SELECT TO authenticated USING (true);
+  END IF;
+END $$;
+
+-- Rollback (manual):
+--   ALTER TABLE public.venture_telemetry DROP COLUMN IF EXISTS kpis;
+--   DROP POLICY IF EXISTS venture_telemetry_read_authenticated ON public.venture_telemetry;
+--   CREATE POLICY venture_telemetry_read ON public.venture_telemetry FOR SELECT TO anon, authenticated USING (true);

--- a/docs/03_protocols_and_standards/venture-metrics-standard.md
+++ b/docs/03_protocols_and_standards/venture-metrics-standard.md
@@ -1,0 +1,66 @@
+# Venture Metrics Standard (`/v1/metrics`)
+
+**Status:** Active standard — SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001, 2026-06-02
+**Applies to:** ALL EHG **portfolio ventures** (Replit-hosted products built via the venture pipeline).
+**Companion to:** the Venture Hosting Standard (`docs/03_protocols_and_standards/venture-hosting-standard.md`).
+**Does NOT apply to:** the platform (`EHG_Engineer`, `EHG` app).
+
+## Why
+
+The Venture Hosting Standard isolates every venture in its own Replit Postgres (no shared DB) — which deliberately severs the easy path to cross-venture data needed for **portfolio analysis**. This standard restores that visibility **safely**: each venture exposes a small, authenticated, **aggregates-only** metrics endpoint that the platform PULLs (one-way). The platform never opens a venture database.
+
+## The standard
+
+Every venture MUST expose an authenticated endpoint:
+
+```
+GET /v1/metrics            Authorization: Bearer <read-key>
+```
+
+| Requirement | Rule |
+|---|---|
+| **Auth** | Bearer token **required**. Return **401** when the token is absent/invalid. |
+| **Payload** | A versioned JSON `MetricsAggregate`: `contract_version` (e.g. `"1.0"`) + the metric fields. |
+| **Aggregates only** | NEVER emit PII, raw rows, identifiers, customer DB contents, or credentials. Counts, sums, ratios only. |
+| **Product-KPI block (optional, additive)** | An optional `kpis` object carrying the allowlisted product aggregates (below). |
+| **Versioning** | Additive fields ship under the **same major** version. A major bump (`2.x`) is reserved for removals/retypes/required-field changes (the platform consumer accepts `major === 1` and fails-soft on others). |
+
+### Allowlisted product-KPI fields
+
+The `kpis` object may contain ONLY these aggregate fields (the platform **drops anything else** — see Enforcement). Adding a field requires a **data-minimization sign-off**.
+
+| Field | Type / range | Meaning |
+|---|---|---|
+| `signups` | integer ≥ 0 | New signups in the window |
+| `active_users` | integer ≥ 0 | Active users in the window |
+| `revenue` | number ≥ 0 | Revenue (aggregate) in the window |
+| `usage_volume` | number ≥ 0 | Usage volume (requests/jobs/etc.) |
+| `health` | number 0..1 | Health / uptime ratio |
+| `churn` | number 0..1 | Churn rate |
+
+### Registration
+
+To participate in the daily pull, register the venture in the `applications` registry:
+- `metrics_base_url` — the venture's base URL (the platform appends `/v1/metrics`).
+- `metrics_api_key_ref` — the **NAME** of the env var/secret holding the read key (**never the raw key**; rotation = update the secret value, the reference is unchanged).
+
+## Enforcement (platform side — already implemented)
+
+The one-way pull consumer (`scripts/venture-telemetry-pull.mjs`) is the enforcement point — data minimization is **code**, not a promise:
+
+- **`KPI_ALLOWLIST`** — the single source of truth for permitted KPI fields + per-field type/range validators.
+- **`validateKpis()`** — extracts ONLY allowlisted, type/range-valid fields; **drops** unknown keys and malformed values (fail-soft, never throws). This **replaced** the former verbatim `raw_payload` passthrough.
+- **`venture_telemetry.kpis`** — stores ONLY the validated subset; `raw_payload` now holds a sanitized snapshot of recognized fields only.
+- **RLS** — `venture_telemetry` read is restricted to `authenticated` (chairman dashboard) + `service_role`; **no anon read**.
+- **`deriveVenturePortfolio()`** — maps validated KPIs onto the EXISTING `ventures` portfolio columns (`health_score`, `projected_revenue`, `risk_score`) — no parallel/duplicate fields.
+
+## Invariants (never violate)
+
+- **One-way**: the platform only ever HTTP-GETs `/v1/metrics`; it never opens or writes a venture DB.
+- **Aggregates only**: no PII/raw rows cross the boundary; the allowlist is enforced in code before persistence.
+- **Key-by-reference**: `metrics_api_key_ref` is a secret NAME, never a raw key.
+- **Fail-soft**: a missing endpoint/key, non-200, bad JSON, unknown contract version, or a dropped KPI field never aborts the pull or clobbers a prior good rollup.
+
+## Governance
+
+Edits to `KPI_ALLOWLIST` (adding/loosening a field) require a **data-minimization sign-off** — this is the choke point against scope-creep into sensitive data.

--- a/scripts/venture-telemetry-pull.mjs
+++ b/scripts/venture-telemetry-pull.mjs
@@ -25,6 +25,52 @@ export function isContractCompatible(version) {
   return typeof version === 'string' && version.split('.')[0] === EXPECTED_CONTRACT_MAJOR;
 }
 
+/**
+ * Product-KPI allowlist (SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001, FR-1/FR-2).
+ * AGGREGATES ONLY — never PII, raw rows, or identifiers. Each entry is a pure type/range
+ * validator. This object is the SINGLE SOURCE OF TRUTH for what may cross the venture→platform
+ * boundary; adding a field requires a data-minimization sign-off (FR-5).
+ */
+export const KPI_ALLOWLIST = {
+  signups:      (v) => Number.isInteger(v) && v >= 0,
+  active_users: (v) => Number.isInteger(v) && v >= 0,
+  revenue:      (v) => typeof v === 'number' && Number.isFinite(v) && v >= 0,
+  usage_volume: (v) => typeof v === 'number' && Number.isFinite(v) && v >= 0,
+  health:       (v) => typeof v === 'number' && v >= 0 && v <= 1, // health/uptime ratio 0..1
+  churn:        (v) => typeof v === 'number' && v >= 0 && v <= 1, // 0..1
+};
+
+/**
+ * Extract ONLY allowlisted, type/range-valid KPI fields from a payload's `kpis` block.
+ * Pure; NEVER throws. Unknown keys and malformed values are DROPPED (data-minimization) —
+ * this is the code mechanism that REPLACES the old verbatim raw_payload passthrough.
+ * Returns { kpis: <validated subset>, dropped: <rejected keys, for the ingest note> }.
+ */
+export function validateKpis(rawKpis) {
+  const kpis = {};
+  const dropped = [];
+  if (rawKpis && typeof rawKpis === 'object' && !Array.isArray(rawKpis)) {
+    for (const [key, val] of Object.entries(rawKpis)) {
+      const ok = Object.prototype.hasOwnProperty.call(KPI_ALLOWLIST, key) && KPI_ALLOWLIST[key](val);
+      if (ok) kpis[key] = val; else dropped.push(key);
+    }
+  }
+  return { kpis, dropped };
+}
+
+/**
+ * Map validated KPIs onto the EXISTING ventures portfolio columns (FR-4) — does NOT introduce
+ * parallel fields. Pure; returns only the columns it can derive (caller decides whether/where to
+ * persist). health -> health_score; revenue -> projected_revenue; churn -> risk_score.
+ */
+export function deriveVenturePortfolio(kpis = {}) {
+  const out = {};
+  if (typeof kpis.health === 'number') out.health_score = kpis.health;
+  if (typeof kpis.revenue === 'number') out.projected_revenue = kpis.revenue;
+  if (typeof kpis.churn === 'number') out.risk_score = kpis.churn;
+  return out;
+}
+
 /** Ingest-metadata subset — what we write on EVERY outcome (never clobbers metric columns). */
 function ingestMeta(app, { ingest_status, ingest_note = null, httpStatus = null, sourceUrl = null }, now) {
   return {
@@ -41,19 +87,29 @@ function ingestMeta(app, { ingest_status, ingest_note = null, httpStatus = null,
 
 /** Full upsert row for a SUCCESSFUL pull (metric columns + metadata). Pure. */
 export function buildOkRow(app, payload, { httpStatus, sourceUrl }, now = new Date()) {
+  const { kpis } = validateKpis(payload.kpis);
+  const contract_version = payload.contract_version ?? null;
+  const window_days = payload.window_days ?? null;
+  const since = payload.since ?? null;
+  const generated_at = payload.generated_at ?? null;
+  const total = payload.total ?? 0;
+  const by_verdict = payload.by_verdict ?? {};
+  const by_mode = payload.by_mode ?? {};
+  const by_model = payload.by_model ?? {};
+  const avg_confidence = payload.avg_confidence ?? null;
+  const dry_run_count = payload.dry_run_count ?? null;
   return {
     ...ingestMeta(app, { ingest_status: 'ok', httpStatus, sourceUrl }, now),
-    contract_version: payload.contract_version ?? null,
-    window_days: payload.window_days ?? null,
-    since: payload.since ?? null,
-    generated_at: payload.generated_at ?? null,
-    total: payload.total ?? 0,
-    by_verdict: payload.by_verdict ?? {},
-    by_mode: payload.by_mode ?? {},
-    by_model: payload.by_model ?? {},
-    avg_confidence: payload.avg_confidence ?? null,
-    dry_run_count: payload.dry_run_count ?? null,
-    raw_payload: payload,
+    contract_version, window_days, since, generated_at, total,
+    by_verdict, by_mode, by_model, avg_confidence, dry_run_count,
+    kpis, // validated, allowlisted aggregate KPIs only (FR-2)
+    // SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001 (FR-2): the verbatim full-payload passthrough is
+    // GONE. raw_payload now holds a SANITIZED snapshot of recognized contract fields + the
+    // validated KPI subset ONLY — arbitrary/unknown keys never reach platform-controlled storage.
+    raw_payload: {
+      contract_version, window_days, since, generated_at, total,
+      by_verdict, by_mode, by_model, avg_confidence, dry_run_count, kpis,
+    },
   };
 }
 

--- a/tests/unit/venture-telemetry-pull.test.js
+++ b/tests/unit/venture-telemetry-pull.test.js
@@ -112,6 +112,21 @@ describe('buildOkRow — persists ONLY the validated KPI subset (no verbatim pas
     expect(JSON.stringify(row)).not.toContain('secret_email');
     expect(JSON.stringify(row)).not.toContain('leak@x.com');
   });
+
+  it('drops TOP-LEVEL junk/PII keys (allowlist-by-construction, not blocklist)', () => {
+    const payload = { ...VALID_PAYLOAD, pii_dump: { ssn: '123-45-6789' }, api_key: 'sk-leak', customer_records: [{ email: 'a@b.com' }] };
+    const row = buildOkRow(APP, payload, { httpStatus: 200, sourceUrl: 'u' }, NOW);
+    const blob = JSON.stringify(row);
+    expect(blob).not.toContain('pii_dump');
+    expect(blob).not.toContain('api_key');
+    expect(blob).not.toContain('sk-leak');
+    expect(blob).not.toContain('customer_records');
+    // raw_payload is rebuilt from a FIXED named field set — only recognized contract keys + kpis.
+    expect(Object.keys(row.raw_payload).sort()).toEqual([
+      'avg_confidence', 'by_mode', 'by_model', 'by_verdict', 'contract_version',
+      'dry_run_count', 'generated_at', 'kpis', 'since', 'total', 'window_days',
+    ]);
+  });
 });
 
 describe('deriveVenturePortfolio — maps KPIs onto EXISTING ventures columns (no parallel fields)', () => {

--- a/tests/unit/venture-telemetry-pull.test.js
+++ b/tests/unit/venture-telemetry-pull.test.js
@@ -6,6 +6,8 @@ import {
   persistResult,
   main,
   EXPECTED_CONTRACT_MAJOR,
+  validateKpis,
+  deriveVenturePortfolio,
 } from '../../scripts/venture-telemetry-pull.mjs';
 
 const NOW = new Date('2026-05-29T06:00:00.000Z');
@@ -58,8 +60,68 @@ describe('buildOkRow', () => {
     expect(row.total).toBe(42);
     expect(row.by_verdict).toEqual({ valid: 30, invalid: 8, not_applicable: 4 });
     expect(row.contract_version).toBe('1.0');
-    expect(row.raw_payload).toEqual(VALID_PAYLOAD);
+    // FR-2: raw_payload is no longer the verbatim payload — it is a SANITIZED snapshot of
+    // recognized contract fields + the validated KPI subset (here no kpis block -> {}).
+    expect(row.raw_payload).toEqual({
+      contract_version: '1.0', window_days: 7, since: VALID_PAYLOAD.since,
+      generated_at: VALID_PAYLOAD.generated_at, total: 42,
+      by_verdict: { valid: 30, invalid: 8, not_applicable: 4 },
+      by_mode: { nl_to_cron: 40, cron_to_nl: 2 }, by_model: { 'deterministic-v1': 42 },
+      avg_confidence: 0.91, dry_run_count: 3, kpis: {},
+    });
+    expect(row.kpis).toEqual({});
     expect(row.pulled_at).toBe(NOW.toISOString());
+  });
+});
+
+// SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001 (FR-1/FR-2): product-KPI allowlist + data-minimization.
+describe('validateKpis — allowlist + type/range, drops everything else', () => {
+  it('keeps allowlisted, type/range-valid aggregates', () => {
+    const { kpis, dropped } = validateKpis({ signups: 120, active_users: 80, revenue: 4200.5, usage_volume: 1e6, health: 0.98, churn: 0.03 });
+    expect(kpis).toEqual({ signups: 120, active_users: 80, revenue: 4200.5, usage_volume: 1e6, health: 0.98, churn: 0.03 });
+    expect(dropped).toEqual([]);
+  });
+
+  it('drops unknown / non-allowlisted keys (e.g. PII, raw rows)', () => {
+    const { kpis, dropped } = validateKpis({ signups: 10, email: 'a@b.com', rows: [{ id: 1 }], customer_name: 'Acme' });
+    expect(kpis).toEqual({ signups: 10 });
+    expect(dropped.sort()).toEqual(['customer_name', 'email', 'rows']);
+  });
+
+  it('drops malformed values that fail type/range assertions', () => {
+    const { kpis, dropped } = validateKpis({ signups: 'lots', churn: 1.7, revenue: -5, active_users: 3.5, health: { nested: true } });
+    expect(kpis).toEqual({}); // signups non-int, churn>1, revenue<0, active_users non-int, health non-number
+    expect(dropped.sort()).toEqual(['active_users', 'churn', 'health', 'revenue', 'signups']);
+  });
+
+  it('returns empty for a missing / non-object kpis block (never throws)', () => {
+    expect(validateKpis(undefined)).toEqual({ kpis: {}, dropped: [] });
+    expect(validateKpis(null)).toEqual({ kpis: {}, dropped: [] });
+    expect(validateKpis([1, 2, 3])).toEqual({ kpis: {}, dropped: [] });
+    expect(validateKpis('nope')).toEqual({ kpis: {}, dropped: [] });
+  });
+});
+
+describe('buildOkRow — persists ONLY the validated KPI subset (no verbatim passthrough)', () => {
+  it('stores allowlisted KPIs and drops an injected raw/PII field', () => {
+    const payload = { ...VALID_PAYLOAD, kpis: { signups: 50, revenue: 999, churn: 0.1, secret_email: 'leak@x.com' } };
+    const row = buildOkRow(APP, payload, { httpStatus: 200, sourceUrl: 'u' }, NOW);
+    expect(row.kpis).toEqual({ signups: 50, revenue: 999, churn: 0.1 }); // secret_email dropped
+    expect(row.raw_payload.kpis).toEqual({ signups: 50, revenue: 999, churn: 0.1 });
+    // The injected raw/PII field never appears anywhere in the persisted row.
+    expect(JSON.stringify(row)).not.toContain('secret_email');
+    expect(JSON.stringify(row)).not.toContain('leak@x.com');
+  });
+});
+
+describe('deriveVenturePortfolio — maps KPIs onto EXISTING ventures columns (no parallel fields)', () => {
+  it('derives health_score / projected_revenue / risk_score from KPIs', () => {
+    expect(deriveVenturePortfolio({ health: 0.95, revenue: 1000, churn: 0.2, signups: 5 }))
+      .toEqual({ health_score: 0.95, projected_revenue: 1000, risk_score: 0.2 });
+  });
+  it('returns only derivable columns (omits absent KPIs)', () => {
+    expect(deriveVenturePortfolio({ signups: 5 })).toEqual({});
+    expect(deriveVenturePortfolio()).toEqual({});
   });
 });
 


### PR DESCRIPTION
Extends the existing one-way venture `/v1/metrics` pull contract to carry curated, **data-minimized PRODUCT KPIs** for portfolio analysis — without opening any venture DB. Venture isolation (Replit-per-venture) deliberately severs cross-venture data; this restores it safely.

## What
- **FR-1/FR-2 (the crux):** `KPI_ALLOWLIST` + `validateKpis()` in `scripts/venture-telemetry-pull.mjs` persist ONLY allowlisted, type/range-valid aggregates (signups/active_users/revenue/usage_volume/health/churn); unknown/malformed keys are dropped (fail-soft). **Removed the verbatim `raw_payload` passthrough** — it's now a sanitized snapshot rebuilt from a fixed 11-field named set (**allowlist-by-construction**, so arbitrary/PII keys are structurally unrepresentable).
- **FR-3/FR-4:** migration adds `venture_telemetry.kpis` (jsonb) and tightens the read RLS off `anon USING(true)` to authenticated + service_role; `deriveVenturePortfolio()` maps KPIs onto the EXISTING `ventures` portfolio columns (`health_score`/`projected_revenue`/`risk_score`) — no parallel fields.
- **FR-5:** `docs/03_protocols_and_standards/venture-metrics-standard.md` — the `/v1/metrics` venture standard (bearer-authed, aggregates-only, additive under contract major=1; allowlist edits require a data-minimization sign-off).

## Safety
One-way pull + fail-soft + key-by-reference invariants preserved. Data minimization is **code** (the allowlist), not a doc promise. Zero ventures currently have `metrics_base_url` configured, so enforcement lands before any live KPI data flows.

## Verification
- `venture-telemetry-pull` unit tests **20/20** (allowlist keep/drop/type-violation, injected-PII drop, top-level junk-key drop, derivation, plus the preserved one-way + fail-soft regressions).
- Migration applied + verified by database-agent (`kpis` jsonb NOT NULL default `{}`; anon read removed; 7 rows backfilled).
- Sub-agent evidence: LEAD VALIDATION (PASS 92) + RISK (conditional-pass, allowlist = crux); EXEC DATABASE (PASS) + TESTING (PASS 95, independent fuzz confirmed allowlist-by-construction).

SD: `SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001` (infrastructure). Downstream (not in this PR): venture-side `/v1/metrics` KPI exporter (first consumer DataDistill) + chairman dashboard surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
