### PR TITLE
refactor(SD-LEO-REFAC-RECONCILE-EVA-EXIT-001): cut 6 dead-path eva-exit routes; port readiness scoring to unit-tested lib

### DIFF
--- a/lib/eva/exit/readiness-score.js
+++ b/lib/eva/exit/readiness-score.js
@@ -1,0 +1,84 @@
+/**
+ * EVA Exit Business-Readiness Scoring
+ *
+ * Extracted from server/routes/eva-exit.js by SD-LEO-REFAC-RECONCILE-EVA-EXIT-001 (FR-3 / M2)
+ * when the zero-caller PATCH /readiness/:ventureId route was removed. That route was a dead
+ * path (it did an .update()-only on the 0-row, never-inserted venture_exit_readiness table,
+ * so it could never match a row), but this scoring + chairman-escalation logic is
+ * non-duplicated business IP. It is preserved here as a unit-tested library so it survives
+ * the route cut and is independently reusable/testable.
+ *
+ * The behavior below is a faithful port of the original inline implementation — no semantic
+ * change (this SD is a behavior-preserving structural refactor).
+ *
+ * Originally introduced by SD-LEO-INFRA-EXIT-BUSINESS-READINESS-001.
+ */
+
+/** Default readiness threshold (score above which chairman review may latch). */
+export const DEFAULT_READINESS_THRESHOLD = 70;
+
+/**
+ * Compute business-readiness score from metrics (0-100, integer).
+ *
+ * Weighted average of whichever ratios are present: ARR (0.4), customer count (0.3),
+ * growth rate (0.3). Each ratio is capped at 1.5. Weights are renormalized over only the
+ * metrics actually present, so a partial metric set still scores on a 0-100 scale. Returns
+ * 0 when no usable ratio exists (no metric with a positive target and a non-null actual).
+ *
+ * @param {Object} [m]
+ * @param {number} [m.target_arr]
+ * @param {number} [m.actual_arr]
+ * @param {number} [m.target_customer_count]
+ * @param {number} [m.actual_customer_count]
+ * @param {number} [m.growth_rate_target]
+ * @param {number} [m.growth_rate_actual]
+ * @returns {number} readiness score, integer 0-100
+ */
+export function computeReadinessScore({
+  target_arr,
+  actual_arr,
+  target_customer_count,
+  actual_customer_count,
+  growth_rate_target,
+  growth_rate_actual,
+} = {}) {
+  const ratios = [];
+  if (target_arr > 0 && actual_arr != null) ratios.push({ weight: 0.4, value: Math.min(actual_arr / target_arr, 1.5) });
+  if (target_customer_count > 0 && actual_customer_count != null) ratios.push({ weight: 0.3, value: Math.min(actual_customer_count / target_customer_count, 1.5) });
+  if (growth_rate_target > 0 && growth_rate_actual != null) ratios.push({ weight: 0.3, value: Math.min(growth_rate_actual / growth_rate_target, 1.5) });
+
+  if (ratios.length === 0) return 0;
+
+  const totalWeight = ratios.reduce((s, r) => s + r.weight, 0);
+  const weighted = ratios.reduce((s, r) => s + r.value * r.weight, 0) / totalWeight;
+  return Math.round(Math.min(100, weighted * 100));
+}
+
+/**
+ * Decide whether to LATCH the chairman-review flag.
+ *
+ * Mirrors the original PATCH /readiness escalation rule: latch once when the readiness score
+ * is above the threshold for two consecutive periods (the previous score AND the newly
+ * computed score) and the flag is not already set. Idempotent — returns false once already
+ * triggered — and it never un-sets the flag (callers only ever set it true).
+ *
+ * A null/undefined previousScore compares false (`undefined > n` === false), matching the
+ * original behavior when no prior record existed.
+ *
+ * @param {Object} [p]
+ * @param {number|null|undefined} [p.previousScore] prior readiness_score
+ * @param {number} [p.newScore] newly computed readiness_score
+ * @param {number} [p.threshold=DEFAULT_READINESS_THRESHOLD]
+ * @param {boolean} [p.alreadyTriggered=false] current chairman_review_triggered value
+ * @returns {boolean} true => set chairman_review_triggered = true
+ */
+export function shouldTriggerChairmanReview({
+  previousScore,
+  newScore,
+  threshold = DEFAULT_READINESS_THRESHOLD,
+  alreadyTriggered = false,
+} = {}) {
+  const previousAbove = previousScore > threshold;
+  const currentAbove = newScore > threshold;
+  return previousAbove && currentAbove && !alreadyTriggered;
+}

--- a/lib/eva/exit/readiness-score.test.js
+++ b/lib/eva/exit/readiness-score.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the EVA exit business-readiness scoring lib
+ * (SD-LEO-REFAC-RECONCILE-EVA-EXIT-001, FR-3 / M2).
+ *
+ * Verifies the extracted logic is a faithful, behavior-preserving port of the original
+ * inline implementation that lived in server/routes/eva-exit.js (PATCH /readiness/:ventureId):
+ *   - weighted ARR 0.4 / customer 0.3 / growth 0.3
+ *   - per-ratio 1.5 cap
+ *   - weight renormalization over only the metrics present
+ *   - zero-ratio fallback => 0
+ *   - overall 100 cap + integer rounding
+ *   - the 2-consecutive-period chairman-escalation latch (idempotent)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeReadinessScore,
+  shouldTriggerChairmanReview,
+  DEFAULT_READINESS_THRESHOLD,
+} from './readiness-score.js';
+
+describe('computeReadinessScore', () => {
+  it('weights ARR(0.4)/customer(0.3)/growth(0.3) when all three are present', () => {
+    // ARR 0.8, customer 0.9, growth 0.5 → 0.8*0.4 + 0.9*0.3 + 0.5*0.3 = 0.74 → 74
+    const score = computeReadinessScore({
+      target_arr: 100, actual_arr: 80,
+      target_customer_count: 100, actual_customer_count: 90,
+      growth_rate_target: 10, growth_rate_actual: 5,
+    });
+    expect(score).toBe(74);
+  });
+
+  it('caps each ratio at 1.5 (overshoot does not exceed the cap)', () => {
+    // ARR-only, actual/target = 10 → capped to 1.5 → renormalized over weight 0.4 → 1.5 → 150 → 100
+    const score = computeReadinessScore({ target_arr: 100, actual_arr: 1000 });
+    expect(score).toBe(100);
+  });
+
+  it('renormalizes weights over only the metrics present (partial metric set)', () => {
+    // customer-only 0.5 → renormalized over weight 0.3 → 0.5 → 50
+    const score = computeReadinessScore({ target_customer_count: 100, actual_customer_count: 50 });
+    expect(score).toBe(50);
+  });
+
+  it('returns 0 when no usable ratio exists (empty input)', () => {
+    expect(computeReadinessScore({})).toBe(0);
+    expect(computeReadinessScore()).toBe(0);
+  });
+
+  it('skips a metric whose target is not > 0 (zero/negative target => no ratio)', () => {
+    // target_arr 0 disqualifies ARR; nothing else present → 0
+    expect(computeReadinessScore({ target_arr: 0, actual_arr: 50 })).toBe(0);
+  });
+
+  it('skips a metric whose actual is null/undefined', () => {
+    // ARR present but actual null → skipped; customer present → scores on customer only
+    const score = computeReadinessScore({
+      target_arr: 100, actual_arr: null,
+      target_customer_count: 100, actual_customer_count: 80,
+    });
+    expect(score).toBe(80); // 0.8 renormalized over weight 0.3
+  });
+
+  it('caps the overall score at 100 when every ratio hits the 1.5 cap', () => {
+    const score = computeReadinessScore({
+      target_arr: 1, actual_arr: 100,
+      target_customer_count: 1, actual_customer_count: 100,
+      growth_rate_target: 1, growth_rate_actual: 100,
+    });
+    expect(score).toBe(100);
+  });
+
+  it('rounds to the nearest integer', () => {
+    // ARR-only 0.855 → 85.5 → round → 86
+    expect(computeReadinessScore({ target_arr: 1000, actual_arr: 855 })).toBe(86);
+  });
+});
+
+describe('shouldTriggerChairmanReview', () => {
+  it('latches when above threshold for two consecutive periods and not already triggered', () => {
+    expect(shouldTriggerChairmanReview({ previousScore: 80, newScore: 85, threshold: 70, alreadyTriggered: false })).toBe(true);
+  });
+
+  it('is idempotent: returns false once already triggered', () => {
+    expect(shouldTriggerChairmanReview({ previousScore: 80, newScore: 85, threshold: 70, alreadyTriggered: true })).toBe(false);
+  });
+
+  it('does not latch when the previous period was below threshold', () => {
+    expect(shouldTriggerChairmanReview({ previousScore: 60, newScore: 85, threshold: 70, alreadyTriggered: false })).toBe(false);
+  });
+
+  it('does not latch when the current period is below threshold', () => {
+    expect(shouldTriggerChairmanReview({ previousScore: 80, newScore: 65, threshold: 70, alreadyTriggered: false })).toBe(false);
+  });
+
+  it('does not latch when there is no previous score (undefined compares false)', () => {
+    expect(shouldTriggerChairmanReview({ previousScore: undefined, newScore: 85, threshold: 70 })).toBe(false);
+  });
+
+  it('uses DEFAULT_READINESS_THRESHOLD (70) when threshold is omitted', () => {
+    expect(DEFAULT_READINESS_THRESHOLD).toBe(70);
+    // 80 and 90 both > 70 → latch
+    expect(shouldTriggerChairmanReview({ previousScore: 80, newScore: 90 })).toBe(true);
+    // 65 not > 70 → no latch
+    expect(shouldTriggerChairmanReview({ previousScore: 65, newScore: 90 })).toBe(false);
+  });
+});

--- a/server/routes/eva-exit.js
+++ b/server/routes/eva-exit.js
@@ -338,74 +338,14 @@ router.get('/portfolio-readiness', asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
-// ── Separability Scores (Phase 2) ──────────────────────────────
-// SD: SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-B
-
-/**
- * GET /api/eva/exit/scores/:ventureId
- * Get separability score history for a venture.
- */
-router.get('/scores/:ventureId', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const { data, error } = await dbLoader.supabase
-    .from('venture_separability_scores')
-    .select('*')
-    .eq('venture_id', req.params.ventureId)
-    .order('scored_at', { ascending: false });
-
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data || []);
-}));
-
-/**
- * GET /api/eva/exit/scores/:ventureId/latest
- * Get most recent separability score.
- */
-router.get('/scores/:ventureId/latest', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const { data, error } = await dbLoader.supabase
-    .from('venture_separability_scores')
-    .select('*')
-    .eq('venture_id', req.params.ventureId)
-    .order('scored_at', { ascending: false })
-    .limit(1)
-    .single();
-
-  if (error) return res.status(404).json({ error: 'No scores found' });
-  res.json(data);
-}));
-
-// ── Data Room Artifacts (Phase 2) ──────────────────────────────
-
-/**
- * GET /api/eva/exit/data-room/:ventureId
- * List current data room artifacts for a venture.
- */
-router.get('/data-room/:ventureId', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const { data, error } = await dbLoader.supabase
-    .from('venture_data_room_artifacts')
-    .select('id, artifact_type, artifact_version, content, content_hash, is_current, generated_at')
-    .eq('venture_id', req.params.ventureId)
-    .eq('is_current', true)
-    .order('artifact_type');
-
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data || []);
-}));
-
-/**
- * POST /api/eva/exit/data-room/:ventureId/generate
- * Trigger data room artifact refresh.
- */
-router.post('/data-room/:ventureId/generate', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const { generateDataRoom } = await import('../../lib/eva/exit/data-room-generator.js');
-  const { types } = req.body;
-
-  const result = await generateDataRoom(req.params.ventureId, {
-    supabase: dbLoader.supabase,
-    types: types || undefined,
-  });
-
-  res.json(result);
-}));
+// ── Separability Scores + Data Room Artifact read/generate routes (Phase 2) ──
+// REMOVED by SD-LEO-REFAC-RECONCILE-EVA-EXIT-001 (FR-2): GET /scores/:ventureId,
+// GET /scores/:ventureId/latest, GET /data-room/:ventureId, and
+// POST /data-room/:ventureId/generate were zero-caller dead paths. The underlying
+// tables (venture_separability_scores, venture_data_room_artifacts) and
+// lib/eva/exit/data-room-generator.js persist; the internal scheduler
+// (lib/eva/operations/domain-handler.js) drives generation directly, so the HTTP
+// generate wrapper was redundant.
 
 // ── Separation Rehearsal (Phase 3) ────────────────────────────
 // SD: SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-C
@@ -481,88 +421,14 @@ router.get('/:ventureId/data-room/completeness', validateUuidParam('ventureId'),
 
 // ── Business Readiness ─────────────────────────────────────────
 // SD: SD-LEO-INFRA-EXIT-BUSINESS-READINESS-001
-
-/**
- * Compute readiness score from business metrics (0-100).
- * Weighted average: ARR ratio (40%), customer ratio (30%), growth ratio (30%).
- */
-function computeReadinessScore({ target_arr, actual_arr, target_customer_count, actual_customer_count, growth_rate_target, growth_rate_actual }) {
-  const ratios = [];
-  if (target_arr > 0 && actual_arr != null) ratios.push({ weight: 0.4, value: Math.min(actual_arr / target_arr, 1.5) });
-  if (target_customer_count > 0 && actual_customer_count != null) ratios.push({ weight: 0.3, value: Math.min(actual_customer_count / target_customer_count, 1.5) });
-  if (growth_rate_target > 0 && growth_rate_actual != null) ratios.push({ weight: 0.3, value: Math.min(growth_rate_actual / growth_rate_target, 1.5) });
-
-  if (ratios.length === 0) return 0;
-
-  const totalWeight = ratios.reduce((s, r) => s + r.weight, 0);
-  const weighted = ratios.reduce((s, r) => s + r.value * r.weight, 0) / totalWeight;
-  return Math.round(Math.min(100, weighted * 100));
-}
-
-/**
- * GET /api/eva/exit/readiness/:ventureId
- * Get business readiness metrics for a venture.
- */
-router.get('/readiness/:ventureId', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const { data, error } = await dbLoader.supabase
-    .from('venture_exit_readiness')
-    .select('*')
-    .eq('venture_id', req.params.ventureId)
-    .single();
-
-  if (error) return res.status(404).json({ error: 'No readiness record found' });
-  res.json(data);
-}));
-
-/**
- * PATCH /api/eva/exit/readiness/:ventureId
- * Update business readiness metrics. Auto-computes readiness_score and chairman escalation.
- */
-router.patch('/readiness/:ventureId', validateUuidParam('ventureId'), asyncHandler(async (req, res) => {
-  const ventureId = req.params.ventureId;
-  const { target_arr, actual_arr, target_customer_count, actual_customer_count, growth_rate_target, growth_rate_actual, market_multiple_current, readiness_threshold } = req.body;
-
-  // Get current record for escalation check
-  const { data: current } = await dbLoader.supabase
-    .from('venture_exit_readiness')
-    .select('readiness_score, readiness_threshold, chairman_review_triggered')
-    .eq('venture_id', ventureId)
-    .single();
-
-  const updates = {};
-  if (target_arr !== undefined) updates.target_arr = target_arr;
-  if (actual_arr !== undefined) updates.actual_arr = actual_arr;
-  if (target_customer_count !== undefined) updates.target_customer_count = target_customer_count;
-  if (actual_customer_count !== undefined) updates.actual_customer_count = actual_customer_count;
-  if (growth_rate_target !== undefined) updates.growth_rate_target = growth_rate_target;
-  if (growth_rate_actual !== undefined) updates.growth_rate_actual = growth_rate_actual;
-  if (market_multiple_current !== undefined) updates.market_multiple_current = market_multiple_current;
-  if (readiness_threshold !== undefined) updates.readiness_threshold = readiness_threshold;
-
-  // Merge with existing values for score computation
-  const merged = { ...current, ...updates };
-  const score = computeReadinessScore(merged);
-  updates.readiness_score = score;
-
-  // Chairman escalation: trigger if score > threshold for 2+ consecutive periods
-  const threshold = merged.readiness_threshold || 70;
-  const previousAbove = current?.readiness_score > threshold;
-  const currentAbove = score > threshold;
-  if (previousAbove && currentAbove && !current?.chairman_review_triggered) {
-    updates.chairman_review_triggered = true;
-  }
-
-  updates.updated_at = new Date().toISOString();
-
-  const { data, error } = await dbLoader.supabase
-    .from('venture_exit_readiness')
-    .update(updates)
-    .eq('venture_id', ventureId)
-    .select()
-    .single();
-
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
-}));
+// REMOVED by SD-LEO-REFAC-RECONCILE-EVA-EXIT-001 (FR-2/FR-3): GET /readiness/:ventureId
+// and PATCH /readiness/:ventureId were zero-caller dead paths. FR-1 (database-introspected)
+// found venture_exit_readiness is the live CANONICAL table but has 0 rows and no inserter,
+// so GET always 404'd and PATCH's .update() could never match a row. The PATCH route's
+// non-duplicated scoring + chairman-escalation logic (computeReadinessScore + the
+// 2-consecutive-period latch) was preserved — not lost — by porting it to the unit-tested
+// lib/eva/exit/readiness-score.js (computeReadinessScore, shouldTriggerChairmanReview).
+// (exit_readiness_tracking, referenced by the ehg useExitReadiness hook, does not exist —
+// its migration was never applied; tracked as an M3 follow-on, out of scope here.)
 
 export default router;


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup of `eva-exit` routes plus extraction of readiness scoring into a unit-tested lib.

**FR-1 (DB-introspected reconciliation)** — Introspected the live schema: `venture_exit_readiness` is the canonical table actually in use. The presumed dual-write counterpart `exit_readiness_tracking` **does not exist** (it lives only in an unapplied migration). There is therefore **no dual-write pair** to reconcile — the premise was stale. No migration was applied or required.

**FR-2 (dead-path route removal)** — Removed 5 zero-caller dead-path routes (caller count confirmed across the codebase before removal).

**FR-3 (dead PATCH /readiness route)** — Cut the dead `PATCH /readiness` route. Its scoring + chairman-escalation logic was **preserved** by porting it to `lib/eva/exit/readiness-score.js`, now covered by **14 passing unit tests**.

## Impact

- **Net −134 LOC** in the route file.
- **Behavior-preserving**: no migration, no wired/live route touched.
- **Gates**: REGRESSION `9c77f7c5` PASS, TESTING `3dd54eb7` PASS.

## Follow-on

- `SD-LEO-FIX-REPOINT-REMOVE-BROKEN-001` opened to address the broken `useExitReadiness` hook in the ehg app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
