### PR TITLE
fix(QF-20260602-767): memoize detectImplementationRepos + case-insensitive repo resolve (EXEC-TO-PLAN >600s)

### DIFF
--- a/scripts/modules/implementation-fidelity/utils/__tests__/repo-detection.test.js
+++ b/scripts/modules/implementation-fidelity/utils/__tests__/repo-detection.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests for repo-detection (QF-20260602-767 / RCA 4460c80b):
+ * R1 — detectImplementationRepos is memoized per sd_id (collapses the ~11 redundant GATE2 calls).
+ * R2 — resolveReposForSD matches target_application case-INSENSITIVELY (titlecase "EHG" must not
+ *      fall through to scanning all active repos when the registry name is lowercase "ehg").
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  resolveReposForSD,
+  detectImplementationRepos,
+  clearImplementationReposCache,
+} from '../repo-detection.js';
+
+// Minimal chainable supabase stub: every resolveReposForSD/getSDSearchTerms query resolves to
+// { data: { target_application } }. getSDSearchTerms tolerates the shape (it catches + falls back).
+function mockSupabase(targetApp) {
+  const result = { data: { target_application: targetApp }, error: null };
+  const chain = {
+    select: () => chain,
+    or: () => chain,
+    eq: () => chain,
+    limit: () => chain,
+    single: async () => result,
+    maybeSingle: async () => result,
+  };
+  return { from: () => chain };
+}
+
+describe('resolveReposForSD — case-insensitive target_application match (R2)', () => {
+  it('resolves a title-cased registered app to exactly ONE repo (does not fall through to all)', async () => {
+    // "EHG" is a registered active app; its registry name is lowercase "ehg".
+    const repos = await resolveReposForSD('fake-sd-r2a', mockSupabase('EHG'));
+    expect(Array.isArray(repos)).toBe(true);
+    expect(repos).toHaveLength(1); // strict === would have returned ALL active repos
+  });
+
+  it('resolves title-case and lowercase of the same app IDENTICALLY (the invariant)', async () => {
+    const upper = await resolveReposForSD('fake-sd-r2b', mockSupabase('EHG'));
+    const lower = await resolveReposForSD('fake-sd-r2b', mockSupabase('ehg'));
+    expect(upper).toEqual(lower);
+  });
+});
+
+describe('detectImplementationRepos — per-sd_id memoization (R1)', () => {
+  beforeEach(() => clearImplementationReposCache());
+
+  it('returns the SAME cached promise for a repeated sd_id (collapses N calls to 1)', async () => {
+    const sb = mockSupabase('EHG');
+    const p1 = detectImplementationRepos('fake-sd-mem', sb);
+    const p2 = detectImplementationRepos('fake-sd-mem', sb);
+    expect(p1).toBe(p2); // identical promise object => the second call did zero new work
+    await Promise.allSettled([p1]); // let the underlying git scan settle (no unhandled rejection)
+  });
+
+  it('keys the cache by sd_id (different SDs get different promises)', async () => {
+    const sb = mockSupabase('EHG');
+    const a = detectImplementationRepos('fake-sd-A', sb);
+    const b = detectImplementationRepos('fake-sd-B', sb);
+    expect(a).not.toBe(b);
+    await Promise.allSettled([a, b]);
+  });
+
+  it('clearImplementationReposCache forces a fresh promise', async () => {
+    const sb = mockSupabase('EHG');
+    const first = detectImplementationRepos('fake-sd-clear', sb);
+    clearImplementationReposCache();
+    const second = detectImplementationRepos('fake-sd-clear', sb);
+    expect(first).not.toBe(second);
+    await Promise.allSettled([first, second]);
+  });
+});

--- a/scripts/modules/implementation-fidelity/utils/repo-detection.js
+++ b/scripts/modules/implementation-fidelity/utils/repo-detection.js
@@ -62,7 +62,12 @@ export async function resolveReposForSD(sd_id, supabase) {
 
   // 3. If target_application set, return only that app's path
   if (targetApp) {
-    const match = activeApps.find(a => a.name === targetApp || a.id === targetApp);
+    // QF-20260602-767 (R2 / RCA 4460c80b): case-INSENSITIVE match. Registry names are lowercase
+    // (e.g. "ehg", "datadistill") but target_application is often title-cased (e.g. "EHG"); a
+    // strict === miss falls through to scanning ALL active repos (~9x the git spawns). Only
+    // narrows WHEN a match exists — a blank/unregistered target_application still falls through.
+    const targetAppLc = String(targetApp).toLowerCase();
+    const match = activeApps.find(a => a.name?.toLowerCase() === targetAppLc || a.id?.toLowerCase() === targetAppLc);
     if (match && match.local_path) {
       const resolved = path.resolve(match.local_path);
       console.log(`   📋 Registry resolved ${targetApp} → ${resolved}`);
@@ -97,14 +102,45 @@ export async function resolveReposForSD(sd_id, supabase) {
 }
 
 /**
+ * Per-sd_id memoization of detectImplementationRepos (QF-20260602-767 / RCA 4460c80b).
+ * GATE2_IMPLEMENTATION_FIDELITY calls detectImplementationRepos ~11x per run with identical
+ * (sd_id, supabase); each call spawns N git subprocesses (~16s) → >600s SIGTERM for sd_type=feature
+ * SDs. Caching the in-flight Promise collapses 11→1 and dedupes concurrent callers. Keyed by sd_id:
+ * within a handoff run, cwd + the SD's repos are constant, so results are byte-identical (the gate
+ * still scores the same). Cleared via clearImplementationReposCache() for long-lived processes.
+ */
+const implementationReposCache = new Map();
+
+/** Clear the per-sd_id implementation-repos cache (mirrors clearSearchTermsCache). */
+export function clearImplementationReposCache() {
+  implementationReposCache.clear();
+}
+
+/**
  * Detect ALL repositories containing implementation for this SD.
  * Returns an array of repo root paths where SD artifacts were found.
+ * Memoized per sd_id (see implementationReposCache above).
  *
  * @param {string} sd_id - Strategic Directive ID
  * @param {Object} supabase - Supabase client
  * @returns {Promise<string[]>} - Array of repo root paths with SD artifacts
  */
-export async function detectImplementationRepos(sd_id, supabase) {
+// NOTE: deliberately NOT async — returns the cached Promise object directly so repeated calls for
+// the same sd_id share one in-flight computation (true single-flight). An async wrapper would mint
+// a new Promise per call, defeating identity-based dedupe.
+export function detectImplementationRepos(sd_id, supabase) {
+  if (implementationReposCache.has(sd_id)) {
+    return implementationReposCache.get(sd_id);
+  }
+  const promise = _detectImplementationReposUncached(sd_id, supabase);
+  // Evict on rejection so a transient failure can't poison later calls (the impl catches its own
+  // errors + falls back to cwd today, but this keeps the cache safe if that ever changes).
+  promise.catch(() => implementationReposCache.delete(sd_id));
+  implementationReposCache.set(sd_id, promise);
+  return promise;
+}
+
+async function _detectImplementationReposUncached(sd_id, supabase) {
   const searchTerms = await getSDSearchTerms(sd_id, supabase);
 
   // PAT-WORKTREE-LIFECYCLE-001: If running inside a worktree for this SD, include cwd first

--- a/tests/unit/implementation-fidelity/cross-repo-worktree-resolution.test.js
+++ b/tests/unit/implementation-fidelity/cross-repo-worktree-resolution.test.js
@@ -57,7 +57,7 @@ vi.mock('fs/promises', () => ({
   readFile: async () => { throw new Error('no registry (test fixture)'); },
 }));
 
-const { detectImplementationRepos, EHG_ROOT, EHG_ENGINEER_ROOT } = await import(
+const { detectImplementationRepos, clearImplementationReposCache, EHG_ROOT, EHG_ENGINEER_ROOT } = await import(
   '../../../scripts/modules/implementation-fidelity/utils/repo-detection.js'
 );
 
@@ -77,6 +77,7 @@ function makeSupabase() {
 
 describe('GATE2 cross-repo worktree resolution (SD-FDBK-ENH-GATE2-IMPLEMENTATION-FIDELITY-002)', () => {
   beforeEach(() => {
+    clearImplementationReposCache(); // QF-20260602-767: reset the per-sd_id memo so cases reusing an sd_id see fresh detection
     h.worktreeReturn = null;
     h.resolveCalls = [];
     h.foundSet = new Set();


### PR DESCRIPTION
Per RCA 4460c80b: GATE2_IMPLEMENTATION_FIDELITY made EXEC-TO-PLAN exceed the 600s cap for sd_type=feature SDs. R1: memoize detectImplementationRepos per sd_id (~11 calls to 1; non-async wrapper = true single-flight) + clearImplementationReposCache(). R2: case-insensitive target_application match in resolveReposForSD (mis-cased 'EHG' vs registry 'ehg' fell through to scanning all 9 active repos; now resolves to 1). Byte-identical results (gate still scores 83 PASS), no single-repo regression (infrastructure SDs early-return unchanged; blank/unregistered target_application still falls through). Tests: +5 (case-insensitive resolve + memoization/keying/clear) + cache-clear in the cross-repo-worktree test; implementation-fidelity suite 63/63. Unblocks the DataDistill venture build and every mis-cased feature SD's EXEC-TO-PLAN. QF-20260602-767.