### PR TITLE
fix(QF-20260602-825): Align regression.js storeResults insert keys to live result-table columns

### DIFF
--- a/lib/sub-agents/regression.js
+++ b/lib/sub-agents/regression.js
@@ -776,10 +776,11 @@ async function storeResults(sdId, results) {
     await supabase.from('sub_agent_execution_results').insert({
       sd_id: normalizedSdId,
       sub_agent_code: 'REGRESSION',
+      sub_agent_name: 'Regression Validator Sub-Agent', // NOT-NULL column; was omitted → insert failed even before the column renames
       verdict: results.verdict,
-      confidence_score: results.confidence,
-      execution_time_ms: 0, // Would need to track
-      findings: results.findings,
+      confidence: results.confidence,
+      execution_time: 0, // seconds; mirrors canonical writer default (lib/sub-agent-executor/results-storage.js)
+      detailed_analysis: results.findings,
       critical_issues: results.critical_issues,
       warnings: results.warnings,
       recommendations: results.recommendations,


### PR DESCRIPTION
## Quick-Fix: QF-20260602-825

**Type:** bug
**Severity:** medium

### Issue Description
lib/sub-agents/regression.js storeResults inserts confidence_score, execution_time_ms, findings but sub_agent_execution_results uses confidence, execution_time, detailed_analysis. The direct insert bypasses normalizeConfidence in results-storage.js so the built-in execute write fails. Rename the three insert keys to the live column names.




### Changes
- **Files Changed:** 1
  - lib/sub-agents/regression.js
- **LOC:** 4 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Fixes harness feedback 7a98fbda. Renamed confidence_score->confidence, execution_time_ms->execution_time, findings->detailed_analysis to match live sub_agent_execution_results columns, and added NOT-NULL sub_agent_name (omitted before, so the insert failed even pre-rename). Verified by inserting the exact corrected record shape into the live table (INSERT_OK) then deleting it; mirrors the canonical writer lib/sub-agent-executor/results-storage.js.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol