### PR TITLE
fix(QF-20260603-971): Venture-stack scanner precision: negation cues + critique-type exclusion

### DIFF
--- a/lib/eva/standards/venture-stack-compliance.js
+++ b/lib/eva/standards/venture-stack-compliance.js
@@ -13,7 +13,7 @@
  *     avoid over-blocking an under-specified-but-not-wrong venture. The high-value, low-false-positive
  *     signal is a forbidden item positively present (the B1 / DataDistill 'Replit Auth' class).
  */
-import { FORBIDDEN, REQUIRED, NEGATION_CUES, NEGATION_WINDOW } from './venture-stack-policy.js';
+import { FORBIDDEN, REQUIRED, NEGATION_CUES, NEGATION_WINDOW, EXCLUDED_ARTIFACT_TYPES } from './venture-stack-policy.js';
 
 /**
  * Is the match at `idx` in `text` negated (a prohibition/standard-citation) rather than a positive
@@ -107,10 +107,15 @@ export function scanTextForStackCompliance(texts) {
 
 /**
  * Scan an array of venture_artifacts rows (each may carry `content` text and/or `artifact_data` JSON).
- * Zero artifacts -> unscannable (fail-closed). Otherwise delegates to scanTextForStackCompliance.
+ * Adversarial-analysis / critique artifact types (EXCLUDED_ARTIFACT_TYPES) are skipped: they argue
+ * AGAINST the concept and so mention forbidden approaches without the venture adopting them. Zero
+ * SCANNABLE artifacts -> unscannable (fail-closed). Otherwise delegates to scanTextForStackCompliance.
  */
 export function scanArtifactsForStackCompliance(artifacts) {
-  if (!Array.isArray(artifacts) || artifacts.length === 0) {
+  const scannable = (Array.isArray(artifacts) ? artifacts : []).filter(
+    (a) => a && !EXCLUDED_ARTIFACT_TYPES.has(a.artifact_type),
+  );
+  if (scannable.length === 0) {
     return {
       compliant: false,
       unscannable: true,
@@ -120,8 +125,7 @@ export function scanArtifactsForStackCompliance(artifacts) {
     };
   }
   const texts = [];
-  for (const a of artifacts) {
-    if (!a) continue;
+  for (const a of scannable) {
     if (typeof a.content === 'string') texts.push(a.content);
     if (a.artifact_data != null) {
       try { texts.push(typeof a.artifact_data === 'string' ? a.artifact_data : JSON.stringify(a.artifact_data)); } catch { /* skip unserializable */ }

--- a/lib/eva/standards/venture-stack-policy.js
+++ b/lib/eva/standards/venture-stack-policy.js
@@ -80,13 +80,36 @@ export const REQUIRED = Object.freeze([
  * these, it is a prohibition / standard-citation, NOT a positive usage — do NOT flag it. This is the
  * reason a reconciliation can rephrase "Replit Auth" references token-free and why the scanner must
  * never red on "do NOT use Replit Auth" / "never add @supabase" / "remove any Supabase coupling".
+ *
+ * Two cues are subtler than the rest (added by the gate-precision pass after the gate false-fired on
+ * correct DataDistill copy):
+ *   - ' no ' (space-bounded) catches the plain prohibition "there is NO CLI product" — bare "no" is a
+ *     negation the earlier list only covered via "no longer". Space-bounded so it does not match
+ *     substrings like "casino " / "domino ".
+ *   - 'residual' catches a corrective task that QUOTES the thing to remove: "rewrite from the RESIDUAL
+ *     command-line framing (npm install x, x run)" — a citation-for-removal, not adoption.
+ * Neither suppresses a POSITIVE adoption ("X is a command-line tool" has no cue nearby), so true
+ * positives are preserved — see venture-stack-compliance.test.js.
  */
 export const NEGATION_CUES = Object.freeze([
   'not', 'never', 'avoid', 'forbidden', 'forbid', 'prohibit', 'remove', 'without',
   'instead of', 'rather than', "don't", 'do not', 'must not', 'cannot', "can't",
   'deprecat', 'ban ', 'no longer', 'drop ', 'migrate off', 'stale', 'replace',
+  'residual', ' no ',
 ]);
 
 export const NEGATION_WINDOW = 56;
 
-export default { FORBIDDEN, REQUIRED, NEGATION_CUES, NEGATION_WINDOW };
+/**
+ * Artifact types that are ADVERSARIAL ANALYSIS / CRITIQUE rather than product specifications. They
+ * exist to stress-test or argue AGAINST the venture concept, so they routinely MENTION forbidden
+ * approaches (e.g. a critique noting "a standalone CLI tool is very difficult to charge for") as part
+ * of the analysis — that is not the venture ADOPTING the stack. The compliance gate judges the SPEC,
+ * so these meta artifacts are out of scope and are skipped by scanArtifactsForStackCompliance.
+ */
+export const EXCLUDED_ARTIFACT_TYPES = Object.freeze(new Set([
+  'truth_ai_critique',
+  'system_devils_advocate_review',
+]));
+
+export default { FORBIDDEN, REQUIRED, NEGATION_CUES, NEGATION_WINDOW, EXCLUDED_ARTIFACT_TYPES };

--- a/tests/unit/eva/standards/venture-stack-compliance.test.js
+++ b/tests/unit/eva/standards/venture-stack-compliance.test.js
@@ -80,6 +80,59 @@ describe('venture-stack-compliance — required / missing (advisory) + unscannab
   });
 });
 
+describe('gate-precision — false-positive fixes from the DataDistill day-1 findings', () => {
+  // Grounded in the EXACT live DataDistill artifact text the gate first false-fired on.
+  it('does NOT flag the correct SaaS copy "there is no CLI product" (bare-no negation)', () => {
+    const r = scanTextForStackCompliance([
+      'This is the hosted SaaS dashboard the MVP delivers — there is no CLI product. Authentication uses Clerk.',
+    ]);
+    expect(r.compliant).toBe(true);
+    expect(r.violations.length).toBe(0);
+  });
+
+  it('does NOT flag a corrective task that QUOTES the residual CLI framing to remove it', () => {
+    const r = scanTextForStackCompliance([
+      'Rewrite the existing marketing site copy from the residual command-line framing ("npm install datadistill", "datadistill run") to the approved SaaS framing.',
+    ]);
+    expect(r.compliant).toBe(true);
+    expect(r.violations.length).toBe(0);
+  });
+
+  it('STILL flags positive CLI adoption — the new cues do not suppress a true positive', () => {
+    // The real identity_brand_name elevator pitch (pre-reconciliation).
+    const r = scanTextForStackCompliance([
+      'DataDistill is a command-line tool that intelligently reduces dataset size by removing statistical redundancy.',
+    ]);
+    expect(r.compliant).toBe(false);
+    expect(r.violations.some((v) => v.id === 'cli_as_product')).toBe(true);
+  });
+
+  it("' no ' is space-bounded — a word like 'casino' must not act as a negation", () => {
+    const r = scanTextForStackCompliance(['The casino CLI tool runs nightly batch jobs.']);
+    expect(r.violations.some((v) => v.id === 'cli_as_product')).toBe(true);
+  });
+
+  it('skips adversarial-critique artifact types but still scans the spec artifacts', () => {
+    const artifacts = [
+      // truth_ai_critique: argues a CLI is hard to monetise — must be SKIPPED, not flagged.
+      { artifact_type: 'truth_ai_critique', content: 'A standalone CLI tool is very difficult to charge for.' },
+      // a real spec artifact, compliant.
+      { artifact_type: 'blueprint_technical_architecture', content: 'Hosted SaaS dashboard. Auth uses Clerk. DATABASE_URL is Replit Postgres.' },
+    ];
+    const r = scanArtifactsForStackCompliance(artifacts);
+    expect(r.compliant).toBe(true);
+    expect(r.violations.length).toBe(0);
+  });
+
+  it('the SAME CLI text in a NON-excluded artifact type IS flagged (exclusion is type-scoped, not blanket)', () => {
+    const r = scanArtifactsForStackCompliance([
+      { artifact_type: 'identity_brand_name', content: 'DataDistill is a command-line tool for engineers.' },
+    ]);
+    expect(r.compliant).toBe(false);
+    expect(r.violations.some((v) => v.id === 'cli_as_product')).toBe(true);
+  });
+});
+
 describe('policy-consistency — the structured policy agrees with the canonical writers', () => {
   const claudeMd = buildClaudeMd({ name: 'Test Venture' });
   const buildTasks = buildBuildTasks({ name: 'Test Venture' });


### PR DESCRIPTION
## Quick-Fix: QF-20260603-971

**Type:** bug
**Severity:** medium

### Issue Description
The venture-stack compliance scanner false-fired on correct DataDistill copy: a plain prohibition ('there is no CLI product'), a corrective citation ('rewrite from the residual command-line framing (...)'), and an adversarial critique artifact. Add space-bounded ' no ' + 'residual' negation cues and skip adversarial-critique artifact types (EXCLUDED_ARTIFACT_TYPES). True positives preserved; 20 unit tests pass.




### Changes
- **Files Changed:** 3
  - lib/eva/standards/venture-stack-compliance.js
  - lib/eva/standards/venture-stack-policy.js
  - tests/unit/eva/standards/venture-stack-compliance.test.js
- **LOC:** 93 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
20 unit tests pass; live --check-venture 510177ba now reports COMPLIANT (was HELD); true-positives preserved per tests

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol