### PR TITLE
fix(security): remediate residual Supabase database-linter SECURITY warnings

### DIFF
--- a/database/migrations/20260603_01_pin_search_path_nonpublic_functions.sql
+++ b/database/migrations/20260603_01_pin_search_path_nonpublic_functions.sql
@@ -1,0 +1,108 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- A. Pin search_path on NON-PUBLIC owned functions (function_search_path_mutable)
+-- =============================================================================
+-- RESIDUAL of the 2026-06-02 sweep. Both prior migrations
+--   20260602_pin_search_path_security_definer_functions.sql
+--   20260602_pin_search_path_invoker_functions.sql
+-- were scoped `WHERE n.nspname='public'`. Six `postgres`-owned functions live in
+-- the custom schemas governance / governance_archive / portfolio and were never
+-- visited, so they still trip Supabase linter `function_search_path_mutable`:
+--   governance.update_eva_authority_timestamp()           (trigger)
+--   governance.update_stage_contracts_timestamp()         (trigger)
+--   governance.update_supervision_policies_timestamp()    (trigger)
+--   portfolio.update_ventures_updated_at()                (trigger)
+--   governance_archive.restore_sd_from_archive(text)
+--   governance_archive.restore_all_from_archive()
+--
+-- All six are SECURITY INVOKER and owned by `postgres` (our deploy role) — live
+-- verified. The three governance triggers + the portfolio trigger only do
+-- `NEW.updated_at := now()`. The two restore functions read
+-- information_schema.columns (qualified) and run dynamic SQL against their own
+-- schema (governance_archive.*) and public.* target tables.
+--
+-- BEHAVIOR-PRESERVING PINNED PATH:  <own_schema>, public, extensions
+--   * own schema FIRST  -> restore fns resolve their governance_archive.* sources;
+--     harmless for the triggers (which reference nothing).
+--   * public            -> restore fns resolve public.* target tables;
+--     triggers resolve nothing here.
+--   * extensions        -> belt-and-suspenders for any gen_random_uuid()/digest()
+--     (mirrors the 2026-06-02 invoker migration's `public, extensions` choice).
+--   * pg_catalog is NOT listed -> Postgres keeps searching it implicitly FIRST, so
+--     now()/NOW() and every builtin resolve exactly as today (no shadowing risk).
+--
+-- We do NOT rewrite function bodies. ALTER FUNCTION ... SET search_path is
+-- non-destructive and takes effect on the next call.
+-- IDEMPOTENT (skips anything already pinned) + OVERLOAD-SAFE (full identity sig) +
+-- OWNERSHIP-GUARDED (only ALTER functions we own).
+-- =============================================================================
+
+DO $pin$
+DECLARE
+  r RECORD;
+  v_path TEXT;
+  v_count INTEGER := 0;
+BEGIN
+  FOR r IN
+    SELECT p.oid, n.nspname AS schema, p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname IN ('governance', 'governance_archive', 'portfolio')
+      AND p.prokind = 'f'
+      AND pg_get_userbyid(p.proowner) = current_user           -- only what we own
+      AND NOT EXISTS (                                          -- not an extension member
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.classid = 'pg_proc'::regclass AND d.deptype = 'e'
+      )
+      AND NOT EXISTS (                                          -- not already pinned
+        SELECT 1 FROM unnest(coalesce(p.proconfig, '{}'::text[])) x
+        WHERE x LIKE 'search_path=%'
+      )
+      -- explicit reviewed target set (defense-in-depth: never silently pin a NEW
+      -- unreviewed function that lands in these schemas before this runs).
+      AND p.proname IN (
+        'update_eva_authority_timestamp',
+        'update_stage_contracts_timestamp',
+        'update_supervision_policies_timestamp',
+        'update_ventures_updated_at',
+        'restore_sd_from_archive',
+        'restore_all_from_archive'
+      )
+  LOOP
+    v_path := format('%I, public, extensions', r.schema);
+    EXECUTE format('ALTER FUNCTION %I.%I(%s) SET search_path = %s',
+                   r.schema, r.proname, r.args, v_path);
+    v_count := v_count + 1;
+    RAISE NOTICE 'Pinned search_path on %.%(%) -> %', r.schema, r.proname, r.args, v_path;
+  END LOOP;
+  RAISE NOTICE 'A COMPLETE: pinned % non-public function(s).', v_count;
+END
+$pin$;
+
+-- Verification: ZERO of the six target functions remain with a mutable search_path.
+DO $verify$
+DECLARE
+  v_remaining INTEGER;
+  v_detail TEXT;
+BEGIN
+  SELECT count(*), string_agg(p.oid::regprocedure::text, ', ')
+    INTO v_remaining, v_detail
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname IN ('governance', 'governance_archive', 'portfolio')
+    AND p.prokind = 'f'
+    AND p.proname IN (
+      'update_eva_authority_timestamp','update_stage_contracts_timestamp',
+      'update_supervision_policies_timestamp','update_ventures_updated_at',
+      'restore_sd_from_archive','restore_all_from_archive')
+    AND NOT EXISTS (
+      SELECT 1 FROM unnest(coalesce(p.proconfig, '{}'::text[])) x
+      WHERE x LIKE 'search_path=%');
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'A NOT cleared: % target function(s) still mutable: %', v_remaining, v_detail;
+  END IF;
+  RAISE NOTICE 'A VERIFIED: 0 target non-public functions with mutable search_path.';
+END
+$verify$;

--- a/database/migrations/20260603_01_pin_search_path_nonpublic_functions_rollback.sql
+++ b/database/migrations/20260603_01_pin_search_path_nonpublic_functions_rollback.sql
@@ -1,0 +1,27 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK A. Un-pin search_path on the six non-public functions.
+-- Restores the prior (mutable) state by RESETting search_path. Behavior-neutral:
+-- these functions resolved names against the caller's path before, and will again.
+-- =============================================================================
+DO $rb$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT n.nspname AS schema, p.proname, pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname IN ('governance','governance_archive','portfolio')
+      AND p.prokind = 'f'
+      AND pg_get_userbyid(p.proowner) = current_user
+      AND p.proname IN (
+        'update_eva_authority_timestamp','update_stage_contracts_timestamp',
+        'update_supervision_policies_timestamp','update_ventures_updated_at',
+        'restore_sd_from_archive','restore_all_from_archive')
+      AND EXISTS (SELECT 1 FROM unnest(coalesce(p.proconfig,'{}'::text[])) x WHERE x LIKE 'search_path=%')
+  LOOP
+    EXECUTE format('ALTER FUNCTION %I.%I(%s) RESET search_path', r.schema, r.proname, r.args);
+    RAISE NOTICE 'ROLLBACK A: reset search_path on %.%(%)', r.schema, r.proname, r.args;
+  END LOOP;
+END
+$rb$;

--- a/database/migrations/20260603_02_revoke_matview_api_exposure.sql
+++ b/database/migrations/20260603_02_revoke_matview_api_exposure.sql
@@ -1,0 +1,77 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- B. Remove matview Data-API exposure (materialized_view_in_api)
+-- =============================================================================
+-- Supabase linter `materialized_view_in_api`: four public materialized views are
+-- selectable by anon/authenticated and therefore exposed over PostgREST:
+--   public.mv_sd_summary
+--   public.mv_operations_dashboard
+--   public.stage_zero_experiment_telemetry
+--   public.v_gate_health_metrics
+--
+-- ROOT CAUSE: each matview was created owned by `postgres` and inherited the
+-- Supabase default grant `GRANT ALL TO anon, authenticated` (live-verified relacl:
+-- anon=arwdDxtm, authenticated=arwdDxtm). Matviews do NOT support RLS, so the only
+-- remediation is to REVOKE the API roles. The 2026-06-02 RLS sweep secured base
+-- tables (relkind r/p) but did not touch matviews (relkind m) — this closes that gap.
+--
+-- ACCESS-MODEL SAFETY (live-verified):
+--   * None of the 4 matviews is a member of any publication -> Realtime does not
+--     and cannot subscribe to them; the anon Realtime client is unaffected.
+--   * The only readers in code are SERVER-SIDE scripts (gate-health-check.js,
+--     claude-md-generator/db-queries.js, archived experiment scripts) which connect
+--     with the service_role / pooler — NEVER the anon browser key.
+--   * service_role retains its grant (we revoke only anon, authenticated) and
+--     bypasses RLS regardless. -> zero reader breakage.
+--
+-- DYNAMIC + IDEMPOTENT: self-heals every public matview that still grants anon or
+-- authenticated, so it also covers any future matview and is a no-op on re-run.
+-- =============================================================================
+
+DO $revoke$
+DECLARE
+  m RECORD;
+  v_count INTEGER := 0;
+BEGIN
+  FOR m IN
+    SELECT DISTINCT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'm'                                  -- materialized views
+      AND EXISTS (                                         -- still grants anon/authenticated
+        SELECT 1 FROM aclexplode(c.relacl) a
+        JOIN pg_roles r ON r.oid = a.grantee
+        WHERE r.rolname IN ('anon','authenticated')
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', m.relname);
+    v_count := v_count + 1;
+    RAISE NOTICE 'B: revoked anon/authenticated on matview public.%', m.relname;
+  END LOOP;
+  RAISE NOTICE 'B COMPLETE: % matview(s) de-exposed.', v_count;
+END
+$revoke$;
+
+-- Verification: ZERO public matviews still grant anon or authenticated.
+DO $verify$
+DECLARE
+  v_remaining INTEGER;
+  v_detail TEXT;
+BEGIN
+  SELECT count(DISTINCT c.relname), string_agg(DISTINCT c.relname, ', ')
+    INTO v_remaining, v_detail
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  JOIN aclexplode(c.relacl) a ON true
+  JOIN pg_roles r ON r.oid = a.grantee
+  WHERE n.nspname = 'public' AND c.relkind = 'm'
+    AND r.rolname IN ('anon','authenticated');
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'B NOT cleared: % matview(s) still expose anon/authenticated: %', v_remaining, v_detail;
+  END IF;
+  RAISE NOTICE 'B VERIFIED: 0 public matviews selectable by anon/authenticated.';
+END
+$verify$;

--- a/database/migrations/20260603_02_revoke_matview_api_exposure_rollback.sql
+++ b/database/migrations/20260603_02_revoke_matview_api_exposure_rollback.sql
@@ -1,0 +1,21 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK B. Re-grant SELECT on the four matviews to anon, authenticated.
+-- (Restores Data-API readability — the only meaningful privilege on a matview.)
+-- Guarded so it no-ops if a matview has since been dropped.
+-- =============================================================================
+DO $rb$
+DECLARE
+  m TEXT;
+BEGIN
+  FOREACH m IN ARRAY ARRAY['mv_sd_summary','mv_operations_dashboard',
+                           'stage_zero_experiment_telemetry','v_gate_health_metrics']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+               WHERE n.nspname='public' AND c.relname=m AND c.relkind='m') THEN
+      EXECUTE format('GRANT SELECT ON public.%I TO anon, authenticated', m);
+      RAISE NOTICE 'ROLLBACK B: re-granted SELECT on public.% to anon, authenticated', m;
+    END IF;
+  END LOOP;
+END
+$rb$;

--- a/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated.sql
+++ b/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated.sql
@@ -1,0 +1,119 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- C. Revoke anon/authenticated EXECUTE on public SECURITY DEFINER functions
+--    (anon_security_definer_function_executable / authenticated_*_executable)
+-- =============================================================================
+-- Supabase linter flags every public SECURITY DEFINER function that anon or
+-- authenticated can call as a REST RPC (/rest/v1/rpc/<fn>). Live-verified state:
+--   * 118 SECURITY DEFINER functions in public, ALL owned by `postgres`.
+--   * EXECUTE granted to anon on 112, to authenticated on 117 (Supabase default
+--     `GRANT EXECUTE ... TO anon, authenticated`, NOT a deliberate API surface).
+-- These include destructive/privileged operations (delete_venture, kill_venture,
+-- master_reset_portfolio, advance_venture_stage, set_global_auto_proceed, claim_sd,
+-- complete_orchestrator_sd, ...). The anon key is public (embedded client-side), so
+-- this is a genuine privilege-escalation surface.
+--
+-- ACCESS-MODEL SAFETY: the server calls every RPC with the service_role key
+-- (bypasses this revoke); the lone anon consumer (realtime-dashboard.js) only opens
+-- table subscriptions and never calls .rpc(). service_role EXECUTE is untouched.
+--
+-- ALLOWLIST — functions that MUST remain anon/authenticated-executable, or RLS
+-- evaluation / auth breaks (PostgreSQL checks EXECUTE against the CALLING role even
+-- for SECURITY DEFINER functions, INCLUDING inside RLS policy USING/WITH CHECK):
+--   (1) DYNAMIC: every public SECDEF function whose name appears in ANY RLS policy
+--       expression. Live scan found 5 in use:
+--         fn_is_chairman (19 policies), fn_user_has_venture_access (15),
+--         is_leo_admin (9), fn_is_service_role (7), check_feedback_rate_limit (1).
+--       Deriving this dynamically auto-protects future policy usage too.
+--   (2) EXPLICIT auth primitives (defense-in-depth): the set above plus
+--       fn_user_has_company_access (a sibling helper not currently in a policy).
+-- Everything NOT in the allowlist is revoked from BOTH anon and authenticated.
+--
+-- The allowlisted functions (~6) intentionally remain authenticated-executable and
+-- will still appear in the linter — that is correct-by-design (revoking them breaks
+-- authorization). Documented in the PR as accepted findings.
+--
+-- IDEMPOTENT (REVOKE on an already-revoked function is a no-op) + OVERLOAD-SAFE
+-- (revoked by full identity signature) + OWNERSHIP-GUARDED (postgres owns all 118).
+-- =============================================================================
+
+DO $revoke$
+DECLARE
+  r RECORD;
+  v_allow TEXT[];
+  v_count INTEGER := 0;
+BEGIN
+  -- Build the allowlist: policy-referenced SECDEF function names UNION explicit primitives.
+  SELECT array_agg(DISTINCT s.proname)
+    INTO v_allow
+  FROM (
+    SELECT DISTINCT p.proname
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.prokind = 'f' AND p.prosecdef
+  ) s
+  WHERE EXISTS (
+    SELECT 1 FROM pg_policy pol
+    WHERE (coalesce(pg_get_expr(pol.polqual,  pol.polrelid), '') || ' ' ||
+           coalesce(pg_get_expr(pol.polwithcheck, pol.polrelid), ''))
+          ~ ('\m' || s.proname || '\M')
+  );
+
+  v_allow := coalesce(v_allow, '{}'::text[]) || ARRAY[
+    'fn_is_chairman','fn_is_service_role','fn_user_has_company_access',
+    'fn_user_has_venture_access','is_leo_admin','check_feedback_rate_limit'
+  ];
+
+  RAISE NOTICE 'C: allowlist (kept anon/authenticated-executable) = %', v_allow;
+
+  FOR r IN
+    SELECT p.oid, p.proname, pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND p.prosecdef
+      AND pg_get_userbyid(p.proowner) = current_user      -- only what we own
+      AND NOT (p.proname = ANY(v_allow))                  -- skip allowlisted
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION public.%I(%s) FROM anon, authenticated',
+                   r.proname, r.args);
+    v_count := v_count + 1;
+  END LOOP;
+
+  RAISE NOTICE 'C COMPLETE: revoked anon/authenticated EXECUTE on % SECURITY DEFINER function(s).', v_count;
+END
+$revoke$;
+
+-- Verification: every public SECDEF function STILL executable by anon or
+-- authenticated must be in the allowlist (policy-referenced or explicit primitive).
+DO $verify$
+DECLARE
+  v_bad INTEGER;
+  v_detail TEXT;
+  v_allow TEXT[];
+BEGIN
+  SELECT array_agg(DISTINCT s.proname) INTO v_allow
+  FROM (SELECT DISTINCT p.proname FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+        WHERE n.nspname='public' AND p.prokind='f' AND p.prosecdef) s
+  WHERE EXISTS (SELECT 1 FROM pg_policy pol
+    WHERE (coalesce(pg_get_expr(pol.polqual,pol.polrelid),'')||' '||coalesce(pg_get_expr(pol.polwithcheck,pol.polrelid),''))
+          ~ ('\m'||s.proname||'\M'));
+  v_allow := coalesce(v_allow,'{}'::text[]) || ARRAY[
+    'fn_is_chairman','fn_is_service_role','fn_user_has_company_access',
+    'fn_user_has_venture_access','is_leo_admin','check_feedback_rate_limit'];
+
+  SELECT count(*), string_agg(DISTINCT p.proname, ', ')
+    INTO v_bad, v_detail
+  FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  CROSS JOIN LATERAL aclexplode(p.proacl) a
+  JOIN pg_roles ro ON ro.oid = a.grantee
+  WHERE n.nspname='public' AND p.prokind='f' AND p.prosecdef
+    AND a.privilege_type='EXECUTE'
+    AND ro.rolname IN ('anon','authenticated')
+    AND NOT (p.proname = ANY(v_allow));
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'C NOT cleared: % non-allowlisted SECDEF function(s) still executable by anon/authenticated: %', v_bad, v_detail;
+  END IF;
+  RAISE NOTICE 'C VERIFIED: only allowlisted RLS/auth primitives remain anon/authenticated-executable.';
+END
+$verify$;

--- a/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated_rollback.sql
+++ b/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated_rollback.sql
@@ -1,0 +1,22 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK C. Restore the Supabase default: GRANT EXECUTE on every public
+-- SECURITY DEFINER function to anon, authenticated. Idempotent.
+-- =============================================================================
+DO $rb$
+DECLARE
+  r RECORD;
+  v_count INTEGER := 0;
+BEGIN
+  FOR r IN
+    SELECT p.proname, pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.prokind = 'f' AND p.prosecdef
+      AND pg_get_userbyid(p.proowner) = current_user
+  LOOP
+    EXECUTE format('GRANT EXECUTE ON FUNCTION public.%I(%s) TO anon, authenticated', r.proname, r.args);
+    v_count := v_count + 1;
+  END LOOP;
+  RAISE NOTICE 'ROLLBACK C: re-granted anon/authenticated EXECUTE on % function(s).', v_count;
+END
+$rb$;

--- a/database/migrations/20260603_04_tighten_permissive_write_rls_policies.sql
+++ b/database/migrations/20260603_04_tighten_permissive_write_rls_policies.sql
@@ -1,0 +1,159 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- D. Tighten permissive "always true" WRITE policies (rls_policy_always_true)
+-- =============================================================================
+-- Supabase linter `rls_policy_always_true` flags PERMISSIVE non-SELECT policies
+-- whose decision side is literally `true`, for a NON-bypass role
+-- (anon / authenticated / PUBLIC) — i.e. RLS is effectively off for writes:
+--   * INSERT: WITH CHECK = true
+--   * UPDATE: USING = true (and/or WITH CHECK = true)
+--   * DELETE: USING = true
+--   * ALL   : USING = true (and/or WITH CHECK = true)
+-- (Pure SELECT `USING (true)` is intentionally NOT flagged — public read is fine.)
+-- Live-verified: 125 such policies (104 write-only INSERT/UPDATE/DELETE + 21 FOR ALL),
+-- spanning anon / authenticated / PUBLIC roles. NOTE: several are MISNAMED
+-- (`*_service_all`, "Service role full access") yet actually target PUBLIC, not
+-- service_role — a latent hole the linter correctly catches. The ~581 genuine
+-- service_role permissive policies are the INTENDED backend pattern and are NOT
+-- flagged / NOT touched here (service_role bypasses RLS regardless).
+--
+-- ROOT CAUSE: legacy hand-written `USING/WITH CHECK (true)` write policies that
+-- predate the service_role-only access model. The server writes with the
+-- service_role key (bypasses RLS); the only anon consumer (realtime-dashboard.js)
+-- reads via subscriptions and never writes. So no legitimate flow depends on these.
+--
+-- UNIFORM, READ-PRESERVING TRANSFORM (per flagged policy P on public table T):
+--   * P is FOR ALL  -> DROP P, then RECREATE it FOR SELECT (same name, same roles,
+--     original USING expr) so the read access ALL granted via USING is preserved,
+--     while INSERT/UPDATE/DELETE for that role are removed. This keeps the anon
+--     Realtime SELECT path and authenticated browser reads working, and also closes
+--     the `deny_write_*` ALL policies (USING true / CHECK false) whose ALL command
+--     silently allowed DELETE.
+--   * P is INSERT / UPDATE / DELETE -> DROP P (write-only; no read impact).
+--   service_role keeps its own policies and bypasses RLS regardless.
+--
+-- We only touch PERMISSIVE policies whose clause is LITERALLY `true`, so a policy
+-- with any real predicate (e.g. venture-scoped fn_user_has_venture_access) is never
+-- affected. Every change is snapshotted to migration_backup.* for exact rollback.
+--
+-- ATOMIC: the drop+recreate loop runs inside ONE DO block (one transaction), so a
+-- mid-run failure rolls back entirely — a table can never be left without the read
+-- policy its ALL policy provided. IDEMPOTENT: recreated policies are FOR SELECT and
+-- fall out of the flagged set; the snapshot INSERT is ON CONFLICT DO NOTHING.
+-- =============================================================================
+
+-- 0. Backup target in a NON-API-exposed schema (so the backup table itself does not
+--    trip rls_disabled_in_public). Idempotent.
+CREATE SCHEMA IF NOT EXISTS migration_backup;
+REVOKE ALL ON SCHEMA migration_backup FROM anon, authenticated;
+GRANT USAGE ON SCHEMA migration_backup TO service_role;
+
+CREATE TABLE IF NOT EXISTS migration_backup.rls_policy_backup_20260603 (
+  id              serial PRIMARY KEY,
+  tbl             text NOT NULL,
+  polname         text NOT NULL,
+  polcmd          "char" NOT NULL,
+  permissive      boolean NOT NULL,
+  roles_sql       text NOT NULL,    -- 'public' or 'role_a, role_b'
+  using_expr      text,             -- NULL if the policy had no USING clause
+  withcheck_expr  text,             -- NULL if the policy had no WITH CHECK clause
+  backed_up_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tbl, polname)
+);
+
+-- 1. Snapshot the exact policies we are about to change (runs BEFORE the loop).
+INSERT INTO migration_backup.rls_policy_backup_20260603
+  (tbl, polname, polcmd, permissive, roles_sql, using_expr, withcheck_expr)
+SELECT c.relname, pol.polname, pol.polcmd, pol.polpermissive,
+       CASE WHEN pol.polroles = '{0}' THEN 'public'
+            ELSE (SELECT string_agg(quote_ident(rolname), ', ') FROM pg_roles WHERE oid = ANY(pol.polroles)) END,
+       pg_get_expr(pol.polqual,      pol.polrelid),
+       pg_get_expr(pol.polwithcheck, pol.polrelid)
+FROM pg_policy pol
+JOIN pg_class c ON c.oid = pol.polrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND pol.polpermissive
+  AND pol.polcmd <> 'r'
+  AND (pg_get_expr(pol.polqual, pol.polrelid) = 'true'
+       OR pg_get_expr(pol.polwithcheck, pol.polrelid) = 'true')
+  AND NOT (pol.polroles <> '{0}'
+           AND (SELECT bool_and(rolname = 'service_role') FROM pg_roles WHERE oid = ANY(pol.polroles)))
+ON CONFLICT (tbl, polname) DO NOTHING;
+
+-- 2. Apply the transform atomically.
+DO $tighten$
+DECLARE
+  p RECORD;
+  v_roles_sql TEXT;
+  v_using TEXT;
+  v_dropped INTEGER := 0;
+  v_converted INTEGER := 0;
+BEGIN
+  FOR p IN
+    SELECT pol.polname, c.relname AS tbl, pol.polcmd, pol.polroles,
+           coalesce(pg_get_expr(pol.polqual, pol.polrelid), '') AS using_expr
+    FROM pg_policy pol
+    JOIN pg_class c ON c.oid = pol.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND pol.polpermissive
+      AND pol.polcmd <> 'r'
+      AND (pg_get_expr(pol.polqual, pol.polrelid) = 'true'
+           OR pg_get_expr(pol.polwithcheck, pol.polrelid) = 'true')
+      AND NOT (pol.polroles <> '{0}'
+               AND (SELECT bool_and(rolname = 'service_role') FROM pg_roles WHERE oid = ANY(pol.polroles)))
+    ORDER BY c.relname, pol.polname
+  LOOP
+    IF p.polroles = '{0}' THEN
+      v_roles_sql := 'public';
+    ELSE
+      SELECT string_agg(quote_ident(rolname), ', ') INTO v_roles_sql
+      FROM pg_roles WHERE oid = ANY(p.polroles);
+    END IF;
+
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', p.polname, p.tbl);
+
+    IF p.polcmd = '*' THEN
+      v_using := CASE WHEN p.using_expr = '' THEN 'true' ELSE p.using_expr END;
+      EXECUTE format(
+        'CREATE POLICY %I ON public.%I AS PERMISSIVE FOR SELECT TO %s USING (%s)',
+        p.polname, p.tbl, v_roles_sql, v_using);
+      v_converted := v_converted + 1;
+      RAISE NOTICE 'D: ALL->SELECT public.%."%" (roles: %)', p.tbl, p.polname, v_roles_sql;
+    ELSE
+      v_dropped := v_dropped + 1;
+      RAISE NOTICE 'D: dropped write policy public.%."%" (cmd: %, roles: %)', p.tbl, p.polname, p.polcmd, v_roles_sql;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'D COMPLETE: % write policies dropped, % ALL policies converted to SELECT-only.', v_dropped, v_converted;
+END
+$tighten$;
+
+-- 3. Verification: ZERO permissive non-SELECT always-true policies for a
+--    non-service_role role remain.
+DO $verify$
+DECLARE
+  v_bad INTEGER;
+  v_detail TEXT;
+BEGIN
+  SELECT count(*), string_agg(format('%s.%s', c.relname, pol.polname), ', ')
+    INTO v_bad, v_detail
+  FROM pg_policy pol
+  JOIN pg_class c ON c.oid = pol.polrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND pol.polpermissive
+    AND pol.polcmd <> 'r'
+    AND (pg_get_expr(pol.polqual, pol.polrelid) = 'true'
+         OR pg_get_expr(pol.polwithcheck, pol.polrelid) = 'true')
+    AND NOT (pol.polroles <> '{0}'
+             AND (SELECT bool_and(rolname = 'service_role') FROM pg_roles WHERE oid = ANY(pol.polroles)));
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'D NOT cleared: % permissive always-true write policy(ies) remain: %', v_bad, v_detail;
+  END IF;
+  RAISE NOTICE 'D VERIFIED: 0 permissive always-true write policies for non-service_role remain.';
+END
+$verify$;

--- a/database/migrations/20260603_04_tighten_permissive_write_rls_policies_rollback.sql
+++ b/database/migrations/20260603_04_tighten_permissive_write_rls_policies_rollback.sql
@@ -1,0 +1,60 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK D. Restore the exact pre-migration write policies from the snapshot
+-- captured in migration_backup.rls_policy_backup_20260603. For each backed-up
+-- policy: drop whatever currently bears that name (e.g. the SELECT-only conversion)
+-- and recreate the original policy verbatim (command, roles, USING, WITH CHECK).
+-- Idempotent and guarded (skips tables/policies that no longer exist).
+-- =============================================================================
+DO $rb$
+DECLARE
+  b RECORD;
+  v_cmd TEXT;
+  v_sql TEXT;
+  v_count INTEGER := 0;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'migration_backup' AND c.relname = 'rls_policy_backup_20260603'
+  ) THEN
+    RAISE NOTICE 'ROLLBACK D: no snapshot table found — nothing to restore.';
+    RETURN;
+  END IF;
+
+  FOR b IN
+    SELECT * FROM migration_backup.rls_policy_backup_20260603 ORDER BY tbl, polname
+  LOOP
+    -- Skip if the table is gone.
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE n.nspname = 'public' AND c.relname = b.tbl) THEN
+      CONTINUE;
+    END IF;
+
+    v_cmd := CASE b.polcmd
+               WHEN 'r' THEN 'SELECT' WHEN 'a' THEN 'INSERT'
+               WHEN 'w' THEN 'UPDATE' WHEN 'd' THEN 'DELETE' WHEN '*' THEN 'ALL' END;
+
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', b.polname, b.tbl);
+
+    v_sql := format('CREATE POLICY %I ON public.%I AS %s FOR %s TO %s',
+                    b.polname, b.tbl,
+                    CASE WHEN b.permissive THEN 'PERMISSIVE' ELSE 'RESTRICTIVE' END,
+                    v_cmd, b.roles_sql);
+
+    -- USING applies to SELECT / UPDATE / DELETE / ALL.
+    IF b.using_expr IS NOT NULL AND b.polcmd IN ('r','w','d','*') THEN
+      v_sql := v_sql || format(' USING (%s)', b.using_expr);
+    END IF;
+    -- WITH CHECK applies to INSERT / UPDATE / ALL.
+    IF b.withcheck_expr IS NOT NULL AND b.polcmd IN ('a','w','*') THEN
+      v_sql := v_sql || format(' WITH CHECK (%s)', b.withcheck_expr);
+    END IF;
+
+    EXECUTE v_sql;
+    v_count := v_count + 1;
+    RAISE NOTICE 'ROLLBACK D: restored public.%."%" (%)', b.tbl, b.polname, v_cmd;
+  END LOOP;
+
+  RAISE NOTICE 'ROLLBACK D COMPLETE: restored % policy(ies).', v_count;
+END
+$rb$;

--- a/database/migrations/20260603_05_move_extensions_out_of_public.sql
+++ b/database/migrations/20260603_05_move_extensions_out_of_public.sql
@@ -1,0 +1,76 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- E. Move extensions out of `public` (extension_in_public)   *** HIGH RISK ***
+-- =============================================================================
+-- !!! APPLY SEPARATELY, IN A MAINTENANCE WINDOW, AFTER TESTING ON A SUPABASE DB
+-- !!! BRANCH. Verify vector / pg_trgm / ltree queries AND index creation work
+-- !!! afterwards. This is the riskiest migration in this set — keep it last.
+--
+-- Supabase linter `extension_in_public`: vector / pg_trgm / ltree are installed in
+-- `public` (the Supabase default). Recommended remediation is to relocate them to a
+-- dedicated `extensions` schema so they are not part of the exposed API surface.
+--
+-- LIVE-VERIFIED PRECONDITIONS (all green):
+--   * All three are extrelocatable = true.
+--   * None has any RELATION member (no tables/indexes owned BY the extension), so
+--     `ALTER EXTENSION ... SET SCHEMA` is a clean metadata move. Dependent objects
+--     in OTHER tables — `vector`-typed columns, GIN/GiST trgm indexes, ltree cols —
+--     reference the type/opclass by OID and KEEP WORKING after the move.
+--   * The `extensions` schema already exists (holds pgcrypto/pgjwt etc.).
+--
+-- WHY search_path MUST be updated FIRST: unqualified references resolved at QUERY
+-- time — the `vector` type in `::vector` casts, the `<->`/`<=>` operators, `%` and
+-- `similarity()` from pg_trgm, ltree `@>`/`<@`/`lquery` operators — are looked up
+-- via the CALLER's search_path. Today only the `postgres` role has `extensions` in
+-- its path; anon/authenticated/service_role do not. We add it to those roles BEFORE
+-- moving so there is never a window where these resolve to nothing. (Our own
+-- functions were already pinned `..., extensions` by the 2026-06-02 sweep, which
+-- deliberately prepared for exactly this move.)
+-- =============================================================================
+
+-- 1. Ensure target schema + usage grants (idempotent).
+CREATE SCHEMA IF NOT EXISTS extensions;
+GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+
+-- 2. Put `extensions` on the search_path of the API roles BEFORE the move.
+--    (postgres already has `"$user", public, extensions`; we leave it untouched.)
+ALTER ROLE anon          SET search_path TO "$user", public, extensions;
+ALTER ROLE authenticated SET search_path TO "$user", public, extensions;
+ALTER ROLE service_role  SET search_path TO "$user", public, extensions;
+
+-- 3. Relocate the three extensions (guarded so each is a no-op if already moved).
+DO $move$
+DECLARE
+  e TEXT;
+BEGIN
+  FOREACH e IN ARRAY ARRAY['vector','ltree','pg_trgm'] LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_extension x JOIN pg_namespace n ON n.oid = x.extnamespace
+      WHERE x.extname = e AND n.nspname = 'public'
+    ) THEN
+      EXECUTE format('ALTER EXTENSION %I SET SCHEMA extensions', e);
+      RAISE NOTICE 'E: moved extension % from public -> extensions', e;
+    ELSE
+      RAISE NOTICE 'E: extension % not in public (already moved or absent) — skipped', e;
+    END IF;
+  END LOOP;
+END
+$move$;
+
+-- 4. Verification: none of the three remain in `public`.
+DO $verify$
+DECLARE
+  v_bad INTEGER;
+  v_detail TEXT;
+BEGIN
+  SELECT count(*), string_agg(x.extname, ', ')
+    INTO v_bad, v_detail
+  FROM pg_extension x JOIN pg_namespace n ON n.oid = x.extnamespace
+  WHERE x.extname IN ('vector','ltree','pg_trgm') AND n.nspname = 'public';
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'E NOT cleared: % extension(s) still in public: %', v_bad, v_detail;
+  END IF;
+  RAISE NOTICE 'E VERIFIED: vector/ltree/pg_trgm are no longer in public.';
+END
+$verify$;

--- a/database/migrations/20260603_05_move_extensions_out_of_public_rollback.sql
+++ b/database/migrations/20260603_05_move_extensions_out_of_public_rollback.sql
@@ -1,0 +1,27 @@
+-- @approved-by: rickfelix@example.com
+-- =============================================================================
+-- ROLLBACK E. Move vector/ltree/pg_trgm back to `public` and reset the API-role
+-- search_paths to their prior state (anon/authenticated/service_role had NO
+-- search_path override before migration E; postgres was never modified).
+-- Move FIRST (while extensions is still on the path), then reset the path.
+-- =============================================================================
+DO $move$
+DECLARE
+  e TEXT;
+BEGIN
+  FOREACH e IN ARRAY ARRAY['vector','ltree','pg_trgm'] LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_extension x JOIN pg_namespace n ON n.oid = x.extnamespace
+      WHERE x.extname = e AND n.nspname = 'extensions'
+    ) THEN
+      EXECUTE format('ALTER EXTENSION %I SET SCHEMA public', e);
+      RAISE NOTICE 'ROLLBACK E: moved extension % extensions -> public', e;
+    END IF;
+  END LOOP;
+END
+$move$;
+
+-- Restore prior role search_paths (these three roles had no override originally).
+ALTER ROLE anon          RESET search_path;
+ALTER ROLE authenticated RESET search_path;
+ALTER ROLE service_role  RESET search_path;

--- a/database/migrations/20260603_supabase_linter_remediation_README.md
+++ b/database/migrations/20260603_supabase_linter_remediation_README.md
@@ -1,0 +1,69 @@
+# Supabase database-linter remediation — 2026-06-03
+
+Closes the residual Supabase **SECURITY** linter warnings on the platform DB
+(`dedlbzhpgkmetvhbkyzq`) that the 2026-06-02 sweep
+(`security_definer_view` / `rls_disabled_in_public` / `function_search_path_mutable`
+in **public**) did not reach. All findings trace to **Supabase's blanket default
+grants to `anon`/`authenticated`**; the platform's real access model is
+**service_role-only** (server uses `SUPABASE_SERVICE_ROLE_KEY`, which bypasses RLS;
+the only `anon` consumer — `src/services/realtime-dashboard.js` — does read-only
+table subscriptions and never writes or calls `.rpc()`).
+
+Everything was live-verified read-only before authoring. Apply via the normal
+merge → migration process (these were **not** run against the live DB).
+
+## Migrations (apply in order; **05 is high-risk — see below**)
+
+| File | Linter finding | What it does | Risk |
+|------|----------------|--------------|------|
+| `20260603_01_pin_search_path_nonpublic_functions.sql` | `function_search_path_mutable` (6) | `SET search_path = <schema>, public, extensions` on 6 `postgres`-owned fns in `governance`/`governance_archive`/`portfolio` (residual of the public-only June sweep). | none (behavior-preserving) |
+| `20260603_02_revoke_matview_api_exposure.sql` | `materialized_view_in_api` (4) | `REVOKE ALL` from `anon`/`authenticated` on `mv_sd_summary`, `mv_operations_dashboard`, `stage_zero_experiment_telemetry`, `v_gate_health_metrics`. Not in any publication; only server-side (service_role) readers. | very low |
+| `20260603_03_revoke_secdef_execute_from_anon_authenticated.sql` | `anon`/`authenticated_security_definer_function_executable` (~230) | `REVOKE EXECUTE` from `anon`/`authenticated` on **112** public SECDEF RPCs; keeps an allowlist of **6** RLS/auth primitives executable (or RLS/auth breaks). | low |
+| `20260603_04_tighten_permissive_write_rls_policies.sql` | `rls_policy_always_true` (125) | Drops 104 write-only always-true policies for `anon`/`authenticated`/PUBLIC; converts 21 `FOR ALL` policies to **SELECT-only** (preserves reads incl. Realtime). Snapshots originals to `migration_backup.*` for exact rollback. | medium |
+| `20260603_05_move_extensions_out_of_public.sql` | `extension_in_public` (3) | Moves `vector`/`ltree`/`pg_trgm` to the `extensions` schema; first adds `extensions` to the `anon`/`authenticated`/`service_role` `search_path`. | **HIGH** |
+
+Each migration is idempotent, guarded, ends in a **failing verification assert**,
+and ships with a `_rollback.sql` companion (04's rollback replays the snapshot;
+05's reverses the move + role search_path).
+
+### ⚠️ Migration 05 (extensions) — apply separately
+
+`vector` (237 members), `ltree` (145), `pg_trgm` (47) are all `extrelocatable=true`
+with **no relation members**, so the move is a clean metadata relocation — existing
+`vector`-typed columns and trgm/ltree indexes keep working by OID. **But** unqualified
+type/operator references resolve via `search_path` at query time, so the migration
+adds `extensions` to the API roles' path *before* moving. Still:
+
+- Apply it **in a maintenance window, after testing on a Supabase DB branch.**
+- Afterwards, verify embedding queries (`<->`/`<=>`/`::vector`), `pg_trgm`
+  similarity/`%`, and `ltree` operators, plus that new index creation works.
+- Apply **after** 01–04 are validated. Keep it as its own deploy step.
+
+## Not fixable via SQL — platform/dashboard actions (do manually)
+
+| Finding | Action |
+|---------|--------|
+| `auth_leaked_password_protection` | Supabase Dashboard → **Authentication → Policies/Passwords** → enable **"Leaked password protection"** (HaveIBeenPwned). Or via Management API `PATCH /v1/projects/{ref}/config/auth` with `password_hibp_enabled=true`. |
+| `vulnerable_postgres_version` | Supabase Dashboard → **Settings → Infrastructure** → **Upgrade** Postgres (`supabase-postgres-17.4.1.074` has pending security patches). Schedule a maintenance window; take a backup first. |
+
+## Accepted-by-design residual warnings (after applying)
+
+These linter findings will (correctly) remain and should be **acknowledged, not
+fixed** — remediating them would break authorization:
+
+- `authenticated_security_definer_function_executable` for the 6 allowlisted
+  RLS/auth primitives: `fn_is_chairman`, `fn_user_has_venture_access`,
+  `is_leo_admin`, `fn_is_service_role`, `fn_user_has_company_access`,
+  `check_feedback_rate_limit`. They are invoked inside RLS policy evaluation for the
+  `authenticated` role; PostgreSQL checks `EXECUTE` against the *calling* role even
+  for SECURITY DEFINER functions, so revoking them breaks RLS on the venture-scoped
+  tables (`strategic_directives_v2`, `product_requirements_v2`, …).
+
+## Out of scope (separate follow-up)
+
+Migration 04 deliberately **preserves existing read access** (the conservative,
+no-breakage choice for `rls_policy_always_true`, which only targets always-true
+*writes*). Whether some tables should additionally **restrict SELECT** for
+`anon`/PUBLIC (e.g. `chairman_constraints`, `session_coordination`, whose misnamed
+`*_service_all` policies currently expose PUBLIC read) is a separate hardening task
+not covered by this linter category.

--- a/database/migrations/supabase-linter-remediation.md
+++ b/database/migrations/supabase-linter-remediation.md
@@ -1,3 +1,12 @@
+---
+Category: Database
+Status: Approved
+Version: 1.0.0
+Author: EHG Engineering
+Last Updated: 2026-06-03
+Tags: [security, supabase, database-linter, rls, migration]
+---
+
 # Supabase database-linter remediation — 2026-06-03
 
 Closes the residual Supabase **SECURITY** linter warnings on the platform DB


### PR DESCRIPTION
## Summary

Closes the residual Supabase **SECURITY** linter warnings on the platform DB (`dedlbzhpgkmetvhbkyzq`) that the 2026-06-02 sweep (scoped to `public`) did not reach. Every finding traces to **Supabase's blanket default grants to `anon`/`authenticated`**; the platform's real access model is **service_role-only** (server uses `SERVICE_ROLE_KEY` which bypasses RLS; the only `anon` consumer — `src/services/realtime-dashboard.js` — does read-only Realtime subscriptions and never writes or calls `.rpc()`).

All facts were **live-verified read-only** before authoring. **Nothing was applied to the live DB** — apply via the normal merge → migration process. Migrations are idempotent, guarded, and each ends in a failing verification assert; every one ships a `_rollback.sql`.

## Migrations (apply in order; 05 is high-risk — apply separately)

| File | Finding (count) | Action | Risk |
|------|-----------------|--------|------|
| `…_01_pin_search_path_nonpublic_functions.sql` | `function_search_path_mutable` (6) | Pin `search_path` on 6 `postgres`-owned fns in `governance`/`governance_archive`/`portfolio` | none (behavior-preserving) |
| `…_02_revoke_matview_api_exposure.sql` | `materialized_view_in_api` (4) | `REVOKE ALL` from anon/authenticated on the 4 matviews | very low |
| `…_03_revoke_secdef_execute_from_anon_authenticated.sql` | `anon`/`authenticated_security_definer_function_executable` (~230) | `REVOKE EXECUTE` on 112 SECDEF RPCs; keep a 6-fn RLS/auth-primitive allowlist | low |
| `…_04_tighten_permissive_write_rls_policies.sql` | `rls_policy_always_true` (125) | Drop 104 write-only always-true policies; convert 21 `FOR ALL`→SELECT-only (preserve reads); snapshot to `migration_backup.*` | medium |
| `…_05_move_extensions_out_of_public.sql` | `extension_in_public` (3) | Move `vector`/`ltree`/`pg_trgm` to `extensions` schema (adds it to API-role search_path first) | **HIGH — apply separately** |

### Root causes
- **01**: prior search_path sweep was `WHERE nspname='public'`; these 6 live in custom schemas.
- **02**: matviews born with the default `GRANT ALL TO anon, authenticated`; June sweep only covered `relkind in (r,p)`.
- **03**: Supabase default `GRANT EXECUTE … TO anon, authenticated` exposes every `postgres`-owned SECDEF fn as a public REST RPC (incl. `delete_venture`, `kill_venture`, `master_reset_portfolio`).
- **04**: legacy hand-written `USING/WITH CHECK (true)` write policies predating the service_role model. Several `*_service_all` policies are **misnamed** — they target PUBLIC, not `service_role`.
- **05**: extensions installed in `public` (Supabase default). All relocatable, no relation members → columns/indexes survive by OID.

## ⚠️ Migration 05 — apply separately, in a maintenance window
Test on a Supabase **DB branch** first; afterwards verify `vector` (`<->`/`<=>`/`::vector`), `pg_trgm` (`%`/`similarity`), `ltree` operators, and new index creation. The migration adds `extensions` to the `anon`/`authenticated`/`service_role` `search_path` **before** moving so unqualified references keep resolving.

## Not fixable via SQL — do in the dashboard
- **`auth_leaked_password_protection`** → Dashboard → Authentication → enable **Leaked password protection** (HaveIBeenPwned), or Management API `password_hibp_enabled=true`.
- **`vulnerable_postgres_version`** → Dashboard → Settings → Infrastructure → **upgrade Postgres** (`17.4.1.074` has pending patches); back up + maintenance window.

## Accepted-by-design residuals (do not "fix")
6 allowlisted RLS/auth primitives stay `authenticated`-executable (`fn_is_chairman`, `fn_user_has_venture_access`, `is_leo_admin`, `fn_is_service_role`, `fn_user_has_company_access`, `check_feedback_rate_limit`) — they run inside RLS policy evaluation; revoking them breaks RLS on venture-scoped tables. See the README for details.

## Validation
Read-only, against the live DB: confirmed the C allowlist resolves to exactly those 6, C revokes 112, and D's linter-accurate predicate matches 125 (104 drop + 21 ALL→SELECT). No DDL was executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
