### PR TITLE
fix(QF-20260603-778): --auto-pr creates PR after commit+push; analyzeGitDiff working-tree fallback

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -530,16 +530,36 @@ export function analyzeGitDiff(testDir, qfDescription = '') {
     // far origin/main has advanced during the QF lifecycle. Two-dot syntax
     // (origin/main..HEAD) was producing false-positive scope-creep warnings
     // when parallel sessions merged unrelated work to main mid-flight.
-    const files = execSync('git diff origin/main...HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
+    let files = execSync('git diff origin/main...HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
       .trim()
       .split('\n')
       .filter(f => f);
+
+    // QF-20260603-778: when the QF changes are not yet committed, the 3-dot diff
+    // against origin/main is empty (HEAD == origin/main) and filesChanged would be
+    // []. partitionDirtyByScope then treats every dirty file as unrelated, so
+    // commitAndPushChanges no-ops (nothing committed → no branch commits → --auto-pr
+    // can't open a PR). Fall back to the working tree (tracked changes vs HEAD +
+    // untracked) so scope/test-coverage checks and the auto-PR body see real files.
+    let diffRange = 'origin/main...HEAD';
+    if (files.length === 0) {
+      const tracked = execSync('git diff HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
+        .trim().split('\n').filter(f => f);
+      const untracked = execSync('git ls-files --others --exclude-standard', { encoding: 'utf-8', cwd: testDir })
+        .trim().split('\n').filter(f => f);
+      const working = [...new Set([...tracked, ...untracked])];
+      if (working.length > 0) {
+        files = working;
+        diffRange = 'HEAD';
+        console.log('   ℹ️  No committed diff vs origin/main; using working-tree changes (uncommitted QF).');
+      }
+    }
     filesChanged = files;
 
     console.log(`   Files Changed: ${filesChanged.length}`);
     filesChanged.forEach(file => console.log(`      - ${file}`));
 
-    const diffStat = execSync('git diff origin/main...HEAD --stat', { encoding: 'utf-8', cwd: testDir });
+    const diffStat = execSync(`git diff ${diffRange} --stat`, { encoding: 'utf-8', cwd: testDir });
     const insertions = diffStat.match(/(\d+) insertion/);
     const deletions = diffStat.match(/(\d+) deletion/);
 

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -315,20 +315,21 @@ export async function completeQuickFix(qfId, options = {}) {
   // PR verification
   let prUrl = options.prUrl;
 
-  // QF-20260509-779: if --auto-pr is set and no --pr-url provided, create the
-  // PR FIRST so the subsequent prompt doesn't fire under --non-interactive.
-  if (!prUrl && options.autoPr) {
-    console.log('🤖 --auto-pr: creating PR via gh before PR-URL prompt');
-    const created = await createAutoPR(qfId, qf, filesChanged, actualLoc, testsPass, uatVerified, options.verificationNotes);
-    if (created) prUrl = created;
-  }
+  // QF-20260603-778: --auto-pr defers PR creation until AFTER commit+push below.
+  // createAutoPR runs `gh pr create`, which requires the branch to already have
+  // pushed commits; firing it here (before commitAndPushChanges) opened the PR
+  // against an unpushed/commit-less branch and then wedged on the PR-URL prompt
+  // under --non-interactive. Only the PR-creation side effect moves — the commit
+  // still happens after verification (this is NOT the commit-before-verify reorder).
+  const deferAutoPr = !prUrl && options.autoPr;
 
-  if (!prUrl) {
+  if (!prUrl && !options.autoPr) {
     const prInput = await prompt('\nGitHub PR URL (required): ');
     prUrl = prInput.trim();
   }
 
-  if (!validatePR(prUrl, qfId, qf.title)) {
+  // When the PR will be auto-created post-push, there is no URL to validate yet.
+  if (!deferAutoPr && !validatePR(prUrl, qfId, qf.title)) {
     process.exit(1);
   }
 
@@ -455,6 +456,22 @@ export async function completeQuickFix(qfId, options = {}) {
   // Commit & Push (QF-20260509-552: forward {forceComplete,reason} flags)
   // QF-20260529-168: thread nonInteractive so git-operations' commit/push guards (QF-888) fire.
   commitSha = await commitAndPushChanges(testDir, qf, { commitSha, branchName }, actualLoc, filesChanged, finalPrUrl, testsPass, prompt, { forceComplete: options.forceComplete, reason: options.reason, nonInteractive: options.nonInteractive });
+
+  // QF-20260603-778: with the branch now committed+pushed, create the deferred
+  // --auto-pr PR (gh pr create requires the pushed branch). finalPrUrl flows into
+  // the record update, completion summary, and merge below. If creation fails,
+  // exit loudly rather than recording an empty pr_url.
+  if (deferAutoPr && !prUrl) {
+    console.log('🤖 --auto-pr: creating PR via gh (post-push)');
+    const created = await createAutoPR(qfId, qf, filesChanged, actualLoc, testsPass, uatVerified, verificationNotes);
+    if (created) {
+      prUrl = created;
+      finalPrUrl = created;
+    }
+    if (!validatePR(prUrl, qfId, qf.title)) {
+      process.exit(1);
+    }
+  }
 
   // Update record
   console.log('🔄 Updating quick-fix record...\n');

--- a/tests/unit/complete-quick-fix/qf-779-autopr-branch-order.test.js
+++ b/tests/unit/complete-quick-fix/qf-779-autopr-branch-order.test.js
@@ -2,8 +2,15 @@
 //
 // QF-20260509-407 wired --auto-pr in cli.js but the orchestrator code path
 // still prompted for PR URL BEFORE checking options.autoPr — flag was
-// unreachable under --non-interactive. This test pins the post-hoist branch
-// order so the same regression cannot re-ship.
+// unreachable under --non-interactive. QF-779 made the flag reachable.
+//
+// QF-20260603-778 SUPERSEDES the QF-779 *ordering*: QF-779 created the PR
+// BEFORE commitAndPushChanges, so `gh pr create` ran against an unpushed/
+// commit-less branch (and wedged on the PR-URL prompt when it failed). The
+// corrected order keeps the same spirit (auto-pr reachable under
+// --non-interactive) but DEFERS createAutoPR until AFTER the branch is
+// committed+pushed, and SKIPS the PR-URL prompt entirely under --auto-pr.
+// These assertions pin the corrected order so neither regression re-ships.
 //
 // 13th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 — closes the
 // "writer ships flag, consumer not patched" defect class for this module.
@@ -18,9 +25,9 @@ const REPO_ROOT = resolve(__dirname, '../../..');
 const ORCHESTRATOR = resolve(REPO_ROOT, 'scripts/modules/complete-quick-fix/orchestrator.js');
 const GIT_OPS = resolve(REPO_ROOT, 'scripts/modules/complete-quick-fix/git-operations.js');
 
-// ── A1: orchestrator autoPr branch order (post-hoist) ──────────────────
+// ── A1: orchestrator autoPr branch order (QF-778 corrected) ────────────
 
-describe('QF-20260509-779 A1: orchestrator autoPr branch fires BEFORE the PR-URL prompt', () => {
+describe('QF-20260603-778 A1: --auto-pr defers PR creation until AFTER commit+push', () => {
   const src = readFileSync(ORCHESTRATOR, 'utf8');
 
   it('analyzeGitDiff is called BEFORE the PR-URL prompt (so filesChanged is available for createAutoPR)', () => {
@@ -31,27 +38,30 @@ describe('QF-20260509-779 A1: orchestrator autoPr branch fires BEFORE the PR-URL
     expect(analyzeIdx).toBeLessThan(promptIdx);
   });
 
-  it('autoPr branch (createAutoPR call) appears BEFORE the PR-URL prompt', () => {
-    const autoPrIdx = src.indexOf('options.autoPr');
+  it('the PR-URL prompt is SKIPPED under --auto-pr (gated by !options.autoPr)', () => {
+    // Corrected shape: `if (!prUrl && !options.autoPr) { prompt(...) }`
+    expect(src).toMatch(/if \(!prUrl && !options\.autoPr\)[\s\S]*?GitHub PR URL/);
+  });
+
+  it('createAutoPR is DEFERRED until AFTER commitAndPushChanges (branch is pushed first)', () => {
+    const pushIdx = src.indexOf('await commitAndPushChanges(');
     const createAutoPrIdx = src.indexOf('await createAutoPR(');
-    const promptIdx = src.indexOf("'\\nGitHub PR URL (required): '");
-    expect(autoPrIdx).toBeLessThan(promptIdx);
-    expect(createAutoPrIdx).toBeLessThan(promptIdx);
+    expect(pushIdx).toBeGreaterThan(0);
+    expect(createAutoPrIdx).toBeGreaterThan(0);
+    expect(createAutoPrIdx).toBeGreaterThan(pushIdx);
   });
 
-  it('PR-URL prompt is gated by `if (!prUrl)` AFTER the autoPr branch sets prUrl', () => {
-    // The post-hoist shape: `if (!prUrl && options.autoPr) { ... } if (!prUrl) { prompt ... }`
-    expect(src).toMatch(/if \(!prUrl && options\.autoPr\)[\s\S]*?if \(!prUrl\)[\s\S]*?GitHub PR URL/);
+  it('the deferred-PR branch is guarded by deferAutoPr (auto-pr stays reachable under --non-interactive)', () => {
+    expect(src).toMatch(/const deferAutoPr = !prUrl && options\.autoPr/);
+    expect(src).toMatch(/if \(deferAutoPr && !prUrl\)/);
   });
 
-  it('NO duplicate autoPr block remains after the PR-acquisition section', () => {
-    // Old shape was `if (options.autoPr && !prUrl) { finalPrUrl = await createAutoPR(...) }`
-    // after the PR prompt block. Pin that the duplicate does not return.
-    const matches = src.match(/options\.autoPr/g) || [];
-    expect(matches.length).toBeLessThanOrEqual(2); // 1 in the new branch, 0 elsewhere (allow 2 max for comments)
+  it('exactly one createAutoPR call site remains (no duplicate pre-push block)', () => {
+    const matches = src.match(/await createAutoPR\(/g) || [];
+    expect(matches.length).toBe(1);
   });
 
-  it('createAutoPR is called with filesChanged (proves analyzeGitDiff hoist is wired through)', () => {
+  it('createAutoPR is called with filesChanged (proves analyzeGitDiff result is wired through)', () => {
     expect(src).toMatch(/await createAutoPR\(\s*qfId,\s*qf,\s*filesChanged/);
   });
 });
@@ -84,6 +94,18 @@ describe('QF-20260509-779 B1: analyzeGitDiff fetches origin/main BEFORE computin
     // Look backwards for `try {`
     const beforeFetch = fnSlice.slice(0, fetchIdx);
     expect(beforeFetch).toMatch(/try\s*\{[^}]*$/s);
+  });
+
+  // QF-20260603-778 FIX-B: working-tree fallback when the 3-dot diff is empty.
+  it('falls back to the working tree when origin/main...HEAD yields no files (uncommitted QF)', () => {
+    const analyzeFnStart = src.indexOf('export function analyzeGitDiff');
+    const fnSlice = src.slice(analyzeFnStart);
+    // Empty 3-dot diff (HEAD == origin/main) → use tracked-vs-HEAD + untracked
+    // so filesChanged is populated; otherwise partitionDirtyByScope strands every
+    // dirty file as "unrelated" and commitAndPushChanges no-ops.
+    expect(fnSlice).toMatch(/if \(files\.length === 0\)/);
+    expect(fnSlice).toMatch(/git diff HEAD --name-only/);
+    expect(fnSlice).toMatch(/git ls-files --others --exclude-standard/);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes the `complete-quick-fix.js --auto-pr` ordering bug (harness backlog / feedback `52661744`).

`createAutoPR` (`gh pr create`) ran **before** `commitAndPushChanges`, so the PR was opened against an unpushed/commit-less branch and then wedged on the interactive PR-URL prompt under `--non-interactive`.

## Changes
- **FIX-A** (`orchestrator.js`): defer `createAutoPR` until **after** the branch is committed+pushed; skip the PR-URL prompt entirely under `--auto-pr`. The commit still happens **after** verification — this is *not* the commit-before-verify reorder (that remains a separate SD).
- **FIX-B** (`git-operations.js`): `analyzeGitDiff` falls back to the working tree (`git diff HEAD` + untracked) when `origin/main...HEAD` is empty, so `filesChanged` is populated for uncommitted QF changes. Without it, `partitionDirtyByScope` strands every dirty file as "unrelated" and `commitAndPushChanges` no-ops (nothing commits → no branch commits → `--auto-pr` cannot open a PR).
- Re-point the `qf-779` ordering assertions at the corrected order (the old test pinned the buggy "PR before push" shape); add a FIX-B static pin.

## Test plan
- `qf-779-autopr-branch-order.test.js`: 13/13 pass (corrected ordering + FIX-B pins).
- Full `complete-quick-fix` unit suite: **210/210 pass** (20 files, no regressions).
- Functional: `analyzeGitDiff` run against the uncommitted worktree now returns the real changed files via the fallback (previously 0).

Closes feedback 52661744-35be-448b-8a29-7f722269618b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
