### PR TITLE
fix(QF-20260603-485): synthesize conditions+justification for CONDITIONAL_PASS sub-agent rows

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -126,6 +126,64 @@ function validateConfidenceValue(value) {
 }
 
 /**
+ * QF-20260603-485: Synthesize the DB-required evidence fields for a
+ * CONDITIONAL_PASS verdict. `sub_agent_execution_results` enforces
+ * check_conditions_required (non-empty `conditions` array) and
+ * check_justification_required (`justification` length >= 50) whenever
+ * verdict='CONDITIONAL_PASS'. Several sub-agent downgrade paths set the verdict
+ * without those fields (design/index.js applyRepoResolutionVerdict + the
+ * medium-risk branch; resolve-repo.js applySubAgentRepoVerdict shared by
+ * api/dependency/performance), so the write was rejected and the executor
+ * recorded a confidence:0/execution_time:0 false-fail. Derive the fields from
+ * evidence the row already carries (warnings, critical_issues, recommendations,
+ * summary) so every current and future downgrade stores cleanly.
+ *
+ * Pure + exported for unit testing. Pass-through when the caller already
+ * supplied valid values or the verdict is not CONDITIONAL_PASS.
+ *
+ * @param {Object} results - sub-agent results object (verdict already mapped)
+ * @param {string} subAgentCode - sub-agent code (for the justification preamble)
+ * @returns {{conditions: (Array|null), justification: (string|null)}}
+ */
+export function deriveConditionalPassEvidence(results, subAgentCode = 'SUB_AGENT') {
+  let conditions = results?.conditions ?? null;
+  let justification = results?.justification ?? null;
+
+  if (results?.verdict !== 'CONDITIONAL_PASS') {
+    return { conditions, justification };
+  }
+
+  // conditions: non-empty array of { action, priority, blocking }
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    const fromIssues = [...(results?.warnings || []), ...(results?.critical_issues || [])]
+      .map(w => (typeof w === 'string' ? w : (w?.recommendation || w?.issue)))
+      .filter(Boolean);
+    const fromRecs = (results?.recommendations || [])
+      .map(r => (typeof r === 'string' ? r : (r?.recommendation || r?.action)))
+      .filter(Boolean);
+    const sourced = (fromIssues.length ? fromIssues : fromRecs).slice(0, 5);
+    const actions = sourced.length
+      ? sourced
+      : ['Resolve the conditions noted by the sub-agent before treating this CONDITIONAL_PASS as fully green'];
+    conditions = actions.map(action => ({
+      action: String(action).slice(0, 300),
+      priority: 'medium',
+      blocking: false
+    }));
+  }
+
+  // justification: >= 50 chars
+  if (typeof justification !== 'string' || justification.trim().length < 50) {
+    const summary = (typeof results?.summary === 'string' && results.summary.trim())
+      || conditions[0]?.action
+      || 'a conditional pass pending the listed follow-ups';
+    justification = `CONDITIONAL_PASS recorded by ${subAgentCode}: ${summary}. See the attached conditions, warnings, and recommendations for the specific follow-ups required before this verdict is treated as fully green.`.slice(0, 2000);
+  }
+
+  return { conditions, justification };
+}
+
+/**
  * Store sub-agent execution results in database
  * @param {string} code - Sub-agent code
  * @param {string} sdId - Strategic Directive ID
@@ -264,6 +322,15 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     console.log(`   [CONFIDENCE] Source: ${confidenceResult.source}, Value: ${confidenceResult.value}`);
   }
 
+  // QF-20260603-485: a CONDITIONAL_PASS write is rejected unless it carries a
+  // non-empty conditions array + a >=50-char justification. Synthesize them from
+  // the evidence already on the row when a downgrade path omitted them, so the
+  // verdict stores instead of becoming a confidence:0/execution_time:0 false-fail.
+  const conditionalPassEvidence = deriveConditionalPassEvidence(
+    { ...results, verdict: mappedVerdict },
+    subAgent?.name || code
+  );
+
   const record = {
     sd_id: normalizedSdId,  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Use normalized UUID
     sub_agent_code: code,
@@ -277,8 +344,8 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     execution_time: executionTimeSec,
     // SD-LEO-PROTOCOL-V4-4-0: Add adaptive validation mode fields
     validation_mode: results.validation_mode || 'prospective',  // Default to prospective for backward compatibility
-    justification: results.justification || null,  // Required for CONDITIONAL_PASS (validated at DB level)
-    conditions: results.conditions || null,  // Required for CONDITIONAL_PASS (validated at DB level)
+    justification: conditionalPassEvidence.justification,  // QF-20260603-485: synthesized for CONDITIONAL_PASS if a downgrade path omitted it
+    conditions: conditionalPassEvidence.conditions,  // QF-20260603-485: synthesized for CONDITIONAL_PASS if a downgrade path omitted it
     // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-C (FR-3):
     //   Native phase column. Paired with metadata.phase via `phaseValue`
     //   above; either or both may be null. Nullable in schema.

--- a/tests/unit/sub-agent-executor/derive-conditional-pass-evidence.test.js
+++ b/tests/unit/sub-agent-executor/derive-conditional-pass-evidence.test.js
@@ -1,0 +1,86 @@
+// QF-20260603-485: deriveConditionalPassEvidence — ensures a CONDITIONAL_PASS
+// verdict always carries the DB-required evidence (non-empty conditions array +
+// justification >= 50 chars) so a sub-agent downgrade path that omitted them no
+// longer false-fails the insert (check_conditions_required /
+// check_justification_required on sub_agent_execution_results).
+
+import { describe, it, expect } from 'vitest';
+import { deriveConditionalPassEvidence } from '../../../lib/sub-agent-executor/results-storage.js';
+
+// The two surviving DB constraints for verdict='CONDITIONAL_PASS'.
+function satisfiesConstraints({ conditions, justification }) {
+  return Array.isArray(conditions)
+    && conditions.length > 0
+    && typeof justification === 'string'
+    && justification.length >= 50;
+}
+
+describe('deriveConditionalPassEvidence', () => {
+  it('synthesizes conditions + justification from warnings when a downgrade omitted them', () => {
+    // Mirrors resolve-repo.js / design index.js applyRepoResolutionVerdict output.
+    const results = {
+      verdict: 'CONDITIONAL_PASS',
+      conditions: null,
+      justification: null,
+      warnings: [{
+        severity: 'HIGH',
+        issue: 'Sub-agent scanned an unresolved or empty repo',
+        recommendation: 'Verify the SD target_application resolves to the correct repo'
+      }]
+    };
+    const out = deriveConditionalPassEvidence(results, 'DESIGN');
+    expect(satisfiesConstraints(out)).toBe(true);
+    expect(out.conditions[0].action).toMatch(/target_application|resolves/i);
+    expect(out.justification).toMatch(/^CONDITIONAL_PASS recorded by DESIGN/);
+  });
+
+  it('falls back to a default condition when there are no warnings/recommendations', () => {
+    const out = deriveConditionalPassEvidence(
+      { verdict: 'CONDITIONAL_PASS', warnings: [], critical_issues: [], recommendations: [] },
+      'API'
+    );
+    expect(satisfiesConstraints(out)).toBe(true);
+    expect(out.conditions.length).toBe(1);
+  });
+
+  it('derives conditions from critical_issues and string recommendations too', () => {
+    const out = deriveConditionalPassEvidence({
+      verdict: 'CONDITIONAL_PASS',
+      critical_issues: [{ issue: '3 accessibility violations', recommendation: 'Fix WCAG 2.1 AA' }],
+      recommendations: ['Add responsive breakpoints']
+    }, 'DESIGN');
+    expect(satisfiesConstraints(out)).toBe(true);
+    // critical_issues take precedence over recommendations as the condition source
+    expect(out.conditions.some(c => /WCAG|accessibility/i.test(c.action))).toBe(true);
+  });
+
+  it('is a pass-through for non-CONDITIONAL_PASS verdicts (does not fabricate evidence)', () => {
+    const out = deriveConditionalPassEvidence(
+      { verdict: 'PASS', conditions: null, justification: null, warnings: [{ issue: 'x' }] },
+      'SECURITY'
+    );
+    expect(out.conditions).toBe(null);
+    expect(out.justification).toBe(null);
+  });
+
+  it('does not overwrite caller-supplied valid conditions/justification', () => {
+    const supplied = {
+      verdict: 'CONDITIONAL_PASS',
+      conditions: [{ action: 'pre-existing', priority: 'low', blocking: false }],
+      justification: 'A pre-existing justification that is comfortably longer than fifty characters.'
+    };
+    const out = deriveConditionalPassEvidence(supplied, 'DOCMON');
+    expect(out.conditions).toBe(supplied.conditions);
+    expect(out.justification).toBe(supplied.justification);
+  });
+
+  it('caps each condition action length and the number of conditions', () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({ issue: 'x'.repeat(500) + i }));
+    const out = deriveConditionalPassEvidence(
+      { verdict: 'CONDITIONAL_PASS', warnings: many },
+      'PERFORMANCE'
+    );
+    expect(out.conditions.length).toBeLessThanOrEqual(5);
+    expect(out.conditions.every(c => c.action.length <= 300)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the recurring DESIGN/sub-agent **false-fail** for backend/no-UI SDs (harness backlog / feedback `a77ff85f`).

The canonical sub-agent writer (`results-storage.js`) stored `conditions`/`justification` as pass-through. Multiple paths downgrade a PASS to `CONDITIONAL_PASS` without setting them (`design/index.js` `applyRepoResolutionVerdict` + medium-risk accessibility branch; `resolve-repo.js` `applySubAgentRepoVerdict`, shared by api/dependency/performance). A `CONDITIONAL_PASS` row missing a non-empty `conditions` array (`check_conditions_required`) or a ≥50-char `justification` (`check_justification_required`) is rejected by the DB → the executor records a `confidence:0/execution_time:0` false-fail and blocks the PRD verdict.

## Fix
- New exported, pure `deriveConditionalPassEvidence(results, code)` in the canonical writer synthesizes both fields from evidence already on the row (`warnings`/`critical_issues`/`recommendations`/`summary`) when `verdict=CONDITIONAL_PASS` and they're missing/short.
- Pass-through for other verdicts and for agents that already set valid fields (e.g. `api.js`, `docmon.js`) — fixes the whole class in one chokepoint without per-caller churn.
- The mode-restriction constraint (`check_conditional_pass_retrospective`) was already dropped, so prospective `CONDITIONAL_PASS` is allowed; only conditions+justification are required.

## Test plan
- 6 new unit tests for the helper + full `sub-agent-executor` suite: **32/32 green**.
- **End-to-end DB proof**: a null-fields `CONDITIONAL_PASS` insert is REJECTED by the live constraint; the synthesized insert SUCCEEDS (`cond_len=1, just_len=206`) — probe rows deleted.

Closes feedback a77ff85f-e177-45be-8589-c3e115c2c064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
