### PR TITLE
feat(SD-LEO-INFRA-AUTO-ENFORCE-POST-001): auto-enforce post-completion document/heal/learn tail

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -198,6 +198,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/auto-proceed-pause-lint.cjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-completion-tail-enforcement.cjs",
+            "timeout": 10
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,7 @@ src/client/dist/
 .claude/unified-session-state.json
 .claude/auto-proceed-state.json
 .claude/continuation-state.json
+.claude/post-completion-pending.json
 .claude/status-line/
 .claude/plans/
 .claude/projects/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ AUTO-PROCEED is ON by default. You continue through phase transitions, PRD creat
 - Any "warrants confirmation" / "want me to continue?" rationalization
 - Numbered menu presentations at decision points
 - Intent to provide a "status checkpoint" after a successful handoff
+- Post-completion /document, /heal, /learn after an SD reaches LEAD-FINAL-APPROVAL — these are CONTINUATION steps, never pause points; "I didn't run them — say the word if you want them" is confirmation-fishing. Run the tail (or drive completion via /leo complete, which sequences /document → /heal → /learn automatically). Enforced by the post-completion-tail-enforcement Stop hook (SD-LEO-INFRA-AUTO-ENFORCE-POST-001).
 
 If your reason for pausing is not on the five-point list above, KEEP WORKING. When in doubt: pick the highest-value option, state it in one sentence, and execute.
 

--- a/scripts/hooks/__tests__/auto-proceed-pause-lint-post-completion.test.js
+++ b/scripts/hooks/__tests__/auto-proceed-pause-lint-post-completion.test.js
@@ -1,0 +1,71 @@
+// Tests for SD-LEO-INFRA-AUTO-ENFORCE-POST-001 FR-003 — auto-proceed-pause-lint
+// recognizes post-completion confirmation-fishing ("say the word if you want
+// me to run /document and /learn") without false-positiving on benign reports.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const HOOK = path.resolve(__dirname, '../auto-proceed-pause-lint.cjs').replace(/\\/g, '/');
+
+let cwd;
+beforeEach(() => { cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'pauselint-')); fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true }); });
+afterEach(() => { try { fs.rmSync(cwd, { recursive: true, force: true }); } catch {} });
+
+function writeTranscript(text) {
+  const p = path.join(cwd, 't.jsonl');
+  fs.writeFileSync(p, JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } }));
+  return p;
+}
+
+function spawnLint(assistantText, { autoProceedOff = false } = {}) {
+  if (autoProceedOff) fs.writeFileSync(path.join(cwd, '.claude', 'auto-proceed-state.json'), JSON.stringify({ auto_proceed: false }));
+  const transcript = writeTranscript(assistantText);
+  const { spawn } = require('node:child_process');
+  const p = spawn('node', [HOOK], { stdio: ['pipe', 'pipe', 'pipe'], cwd, env: { ...process.env } });
+  p.stdin.end(JSON.stringify({ transcript_path: transcript }));
+  return new Promise((resolve) => {
+    let stderr = '';
+    p.stderr.on('data', (c) => { stderr += c; });
+    p.on('close', (code) => resolve({ stderr, code }));
+  });
+}
+
+describe('FR-003 post-completion confirmation-fishing detection', () => {
+  it('flags "say the word if you want me to run /document and /learn"', async () => {
+    const r = await spawnLint('The retro and memory are already written. Say the word if you want me to run /document and /learn.');
+    expect(r.stderr).toContain('PROTOCOL VIOLATION');
+    expect(r.stderr).toContain('CONTINUATION');
+  });
+
+  it('flags "I did not run /document and /learn" (paired with offering)', async () => {
+    const r = await spawnLint('I did not run /document and /learn yet. Let me know if you want them.');
+    expect(r.stderr).toContain('PROTOCOL VIOLATION');
+  });
+
+  it('flags "didn\'t run the post-completion tail"', async () => {
+    const r = await spawnLint("I didn't run the post-completion tail.");
+    expect(r.stderr).toContain('PROTOCOL VIOLATION');
+  });
+
+  it('does NOT flag a benign completion report', async () => {
+    const r = await spawnLint('Done — I ran /document and /learn; PR #4198 merged. Recommend /compact next.');
+    expect(r.stderr).toBe('');
+  });
+
+  it('does NOT flag unrelated prose', async () => {
+    const r = await spawnLint('The populator records the pending tail and the Stop hook reminds until evidence exists.');
+    expect(r.stderr).toBe('');
+  });
+
+  it('still flags the pre-existing generic pause phrasing (no regression)', async () => {
+    const r = await spawnLint('This is a good stopping point — want me to continue?');
+    expect(r.stderr).toContain('PROTOCOL VIOLATION');
+  });
+
+  it('does not flag even fishing phrasing when AUTO-PROCEED is OFF', async () => {
+    const r = await spawnLint('Say the word if you want me to run /document and /learn.', { autoProceedOff: true });
+    expect(r.stderr).toBe('');
+  });
+});

--- a/scripts/hooks/__tests__/post-completion-tail-enforcement.test.js
+++ b/scripts/hooks/__tests__/post-completion-tail-enforcement.test.js
@@ -1,0 +1,162 @@
+// Tests for SD-LEO-INFRA-AUTO-ENFORCE-POST-001
+//   FR-001 — post-completion-tail-populator (import)
+//   FR-002 — post-completion-tail-enforcement Stop hook (subprocess spawn)
+//
+// Hermetic: POST_COMPLETION_TEST_ROOT redirects the .claude/ anchor to a temp
+// dir; POST_COMPLETION_SKIP_DB=1 skips the learning_runs query.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+import { runPostCompletionTailPopulator } from '../../modules/handoff/executors/lead-final-approval/hooks/post-completion-tail-populator.js';
+
+const HOOK = path.resolve(__dirname, '../post-completion-tail-enforcement.cjs').replace(/\\/g, '/');
+
+function mkRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pctail-'));
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  return dir;
+}
+function stateFile(root) { return path.join(root, '.claude', 'post-completion-pending.json'); }
+function writeState(root, obj) { fs.writeFileSync(stateFile(root), JSON.stringify(obj)); }
+function readState(root) { return JSON.parse(fs.readFileSync(stateFile(root), 'utf8')); }
+function exists(root) { return fs.existsSync(stateFile(root)); }
+
+function spawnHook(payload, root, extraEnv = {}) {
+  const { spawn } = require('node:child_process');
+  const p = spawn('node', [HOOK], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, POST_COMPLETION_TEST_ROOT: root, POST_COMPLETION_SKIP_DB: '1', ...extraEnv },
+  });
+  p.stdin.end(payload == null ? '' : JSON.stringify(payload));
+  return new Promise((resolve) => {
+    let stdout = ''; let stderr = '';
+    p.stdout.on('data', (c) => { stdout += c; });
+    p.stderr.on('data', (c) => { stderr += c; });
+    p.on('close', (code) => resolve({ stdout, stderr, code }));
+  });
+}
+
+describe('FR-002 post-completion-tail-enforcement Stop hook', () => {
+  let root;
+  beforeEach(() => { root = mkRoot(); });
+  afterEach(() => { try { fs.rmSync(root, { recursive: true, force: true }); } catch {} });
+
+  it('is a cheap no-op when the pending file is absent', async () => {
+    const r = await spawnHook({ session_id: 'S1' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+  });
+
+  it('reminds (continuation framing) when steps are pending', async () => {
+    writeState(root, { sd_key: 'SD-X', sd_id: 'u1', pending: ['document'], completed_at: new Date().toISOString(), session_id: 'S1' });
+    const r = await spawnHook({ session_id: 'S1' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain('post-completion-tail-enforcement');
+    expect(r.stderr).toContain('/document');
+    expect(r.stderr.toUpperCase()).toContain('CONTINUATION');
+  });
+
+  it('never blocks: a malformed pending file degrades to a no-op and is dropped', async () => {
+    fs.writeFileSync(stateFile(root), '{ not json');
+    const r = await spawnHook({ session_id: 'S1' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    expect(exists(root)).toBe(false);
+  });
+
+  it('ignores another session\'s obligation (session mismatch)', async () => {
+    writeState(root, { sd_key: 'SD-X', sd_id: 'u1', pending: ['document'], completed_at: new Date().toISOString(), session_id: 'OTHER' });
+    const r = await spawnHook({ session_id: 'MINE' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    expect(exists(root)).toBe(true); // untouched — not ours to clear
+  });
+
+  it('does not remind when AUTO-PROCEED is OFF', async () => {
+    fs.writeFileSync(path.join(root, '.claude', 'auto-proceed-state.json'), JSON.stringify({ auto_proceed: false }));
+    writeState(root, { sd_key: 'SD-X', sd_id: 'u1', pending: ['document'], completed_at: new Date().toISOString(), session_id: 'S1' });
+    const r = await spawnHook({ session_id: 'S1' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+  });
+
+  it('clears a step when the transcript shows the skill ran after completion', async () => {
+    const completedAt = new Date(Date.now() - 60000).toISOString();
+    const transcript = path.join(root, 'transcript.jsonl');
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'assistant', timestamp: new Date().toISOString(), message: { content: [{ type: 'tool_use', name: 'Skill', input: { skill: 'document' } }] } }),
+    ].join('\n'));
+    writeState(root, { sd_key: 'SD-X', sd_id: 'u1', pending: ['document'], completed_at: completedAt, session_id: 'S1' });
+    const r = await spawnHook({ session_id: 'S1', transcript_path: transcript }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');           // nothing left to remind about
+    expect(exists(root)).toBe(false);    // file removed once fully satisfied
+  });
+
+  it('drains a stale (>6h old) pending file without nagging', async () => {
+    writeState(root, { sd_key: 'SD-OLD', sd_id: 'u9', pending: ['document'], completed_at: new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(), session_id: 'S1' });
+    const r = await spawnHook({ session_id: 'S1' }, root);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    expect(exists(root)).toBe(false);
+  });
+
+  it('keeps /learn pending without evidence and clears it when transcript shows /learn', async () => {
+    const completedAt = new Date(Date.now() - 60000).toISOString();
+    // No evidence → learn stays pending → reminder.
+    writeState(root, { sd_key: 'SD-F', sd_id: 'u2', pending: ['learn'], completed_at: completedAt, session_id: 'S1' });
+    const r1 = await spawnHook({ session_id: 'S1' }, root);
+    expect(r1.stderr).toContain('/learn');
+
+    // Transcript shows /leo complete (runs the whole tail) → learn cleared.
+    const transcript = path.join(root, 't2.jsonl');
+    fs.writeFileSync(transcript, JSON.stringify({ type: 'user', timestamp: new Date().toISOString(), message: { content: '/leo complete' } }));
+    writeState(root, { sd_key: 'SD-F', sd_id: 'u2', pending: ['learn'], completed_at: completedAt, session_id: 'S1' });
+    const r2 = await spawnHook({ session_id: 'S1', transcript_path: transcript }, root);
+    expect(r2.stderr).toBe('');
+    expect(exists(root)).toBe(false);
+  });
+});
+
+describe('FR-001 post-completion-tail-populator', () => {
+  let root;
+  beforeEach(() => { root = mkRoot(); process.env.POST_COMPLETION_TEST_ROOT = root; delete process.env.CLAUDE_PROJECT_DIR; });
+  afterEach(() => { delete process.env.POST_COMPLETION_TEST_ROOT; try { fs.rmSync(root, { recursive: true, force: true }); } catch {} });
+
+  it('records the full ceremony tail for a feature SD', async () => {
+    const res = await runPostCompletionTailPopulator({ sd_type: 'feature', id: 'u1', sd_key: 'SD-FEAT', source: '' });
+    expect(res.written).toBe(true);
+    expect(res.pending).toEqual(['document', 'heal', 'learn']);
+    expect(readState(root).pending).toEqual(['document', 'heal', 'learn']);
+  });
+
+  it('records only /document for an infrastructure SD (canonical source rules)', async () => {
+    const res = await runPostCompletionTailPopulator({ sd_type: 'infrastructure', id: 'u2', sd_key: 'SD-INFRA', source: '' });
+    expect(res.written).toBe(true);
+    expect(res.pending).toEqual(['document']);
+  });
+
+  it('writes nothing for an orchestrator SD (no ceremony steps)', async () => {
+    const res = await runPostCompletionTailPopulator({ sd_type: 'orchestrator', id: 'u3', sd_key: 'SD-ORCH', source: '' });
+    expect(res.written).toBe(false);
+    expect(res.pending).toEqual([]);
+    expect(exists(root)).toBe(false);
+  });
+
+  it('honors LEARN_SKIP_SOURCES (source=learn excludes /learn)', async () => {
+    const res = await runPostCompletionTailPopulator({ sd_type: 'feature', id: 'u4', sd_key: 'SD-LEARN', source: 'learn' });
+    expect(res.pending).toContain('document');
+    expect(res.pending).not.toContain('learn');
+  });
+
+  it('does not record a nudge when AUTO-PROCEED is OFF', async () => {
+    fs.writeFileSync(path.join(root, '.claude', 'auto-proceed-state.json'), JSON.stringify({ auto_proceed: false }));
+    const res = await runPostCompletionTailPopulator({ sd_type: 'feature', id: 'u5', sd_key: 'SD-OFF', source: '' });
+    expect(res.written).toBe(false);
+    expect(res.reason).toBe('auto_proceed_off');
+    expect(exists(root)).toBe(false);
+  });
+});

--- a/scripts/hooks/auto-proceed-pause-lint.cjs
+++ b/scripts/hooks/auto-proceed-pause-lint.cjs
@@ -19,6 +19,12 @@ const fs = require('fs');
 
 const FORBIDDEN = /(want me to (continue|proceed)|pause here|warrants confirmation|good stopping point|substantial[^.]{0,80}(confirm|pause|proceed)|continue.*or pause)/i;
 
+// SD-LEO-INFRA-AUTO-ENFORCE-POST-001 (FR-003): post-completion confirmation-fishing.
+// Catches "I didn't run /document and /learn — say the word if you want them" style
+// asking that the generic FORBIDDEN regex above misses. Tuned to NOT match benign
+// reports like "I ran /document and /learn".
+const FORBIDDEN_POST_COMPLETION = /(say the word|let me know if you(?:'?d| would)?\s+(?:want|like)|(?:did|do|does|have|has)\s*n['o]?t\s+(?:yet\s+)?run[^.\n]{0,60}(?:document|learn|heal|tail)|want(?:\s+me)?\s+to\s+run\s+(?:them|\/?document|\/?learn|the\s+tail)|if you want(?:\s+me)?(?:\s+to)?(?:\s+run)?\s+(?:them|\/?document|\/?learn))/i;
+
 function readStdin() {
   try {
     return fs.readFileSync(0, 'utf8');
@@ -65,12 +71,18 @@ function main() {
   const text = getLastAssistantText(payload.transcript_path);
   if (!text) { process.exit(0); }
   const m = text.match(FORBIDDEN);
-  if (!m) { process.exit(0); }
+  const mPost = text.match(FORBIDDEN_POST_COMPLETION);
+  if (!m && !mPost) { process.exit(0); }
   if (!autoProceedOn()) { process.exit(0); }
 
+  const hit = (m && m[0]) || (mPost && mPost[0]);
+  const context = mPost
+    ? `Post-completion /document, /heal, and /learn are CONTINUATION steps, NOT pause points — run them now without asking ("say the word if you want them" IS the anti-pattern; /leo complete sequences the full tail). `
+    : `Phase boundaries, scope size, and "substantial work" are NOT pause points. `;
+
   process.stderr.write(
-    `[auto-proceed-pause-lint] PROTOCOL VIOLATION DETECTED: assistant suggested pausing/confirmation ("${m[0]}") while AUTO-PROCEED is ON. ` +
-    `Phase boundaries, scope size, and "substantial work" are NOT pause points. ` +
+    `[auto-proceed-pause-lint] PROTOCOL VIOLATION DETECTED: assistant suggested pausing/confirmation ("${hit}") while AUTO-PROCEED is ON. ` +
+    context +
     `Per CLAUDE.md AUTO-PROCEED Mode, only these stop: orchestrator completion, blocking errors, test failures (2 retries), merge conflicts, all children blocked. ` +
     `Continue working without asking.\n`
   );

--- a/scripts/hooks/post-completion-tail-enforcement.cjs
+++ b/scripts/hooks/post-completion-tail-enforcement.cjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * post-completion-tail-enforcement
+ *
+ * Stop hook: when an SD has just completed via LEAD-FINAL-APPROVAL and its
+ * canonical post-completion tail (/document, /heal, /learn) has NOT yet run,
+ * emit a high-visibility system reminder telling the model to run the
+ * remaining steps NOW as CONTINUATION (not a pause point, not something to ask
+ * permission for).
+ *
+ * The obligation is recorded by the LEAD-FINAL-APPROVAL executor populator
+ * (scripts/modules/handoff/executors/lead-final-approval/hooks/post-completion-tail-populator.js)
+ * into .claude/post-completion-pending.json. This hook reads that file, clears
+ * steps for which evidence now exists (learning_runs row for /learn; a
+ * /document, /heal, or /leo complete skill invocation in the transcript for the
+ * others), rewrites/deletes the file, and reminds on whatever remains.
+ *
+ * Fail-safe contract (mirrors auto-proceed-pause-lint.cjs / post-ship-enforcement.cjs):
+ *   - Never throws to the caller; all errors degrade to a no-op.
+ *   - NEVER returns decision:block — reminder-only, so it can never trap a session.
+ *   - Cheap on the common path: if the pending file is absent, exit 0 immediately
+ *     with no DB query and no transcript read.
+ *
+ * Wired in .claude/settings.json under "Stop".
+ *
+ * SD-LEO-INFRA-AUTO-ENFORCE-POST-001 (FR-002).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// The hook file physically lives at <main-repo>/scripts/hooks/, loaded by
+// settings.json via ${CLAUDE_PROJECT_DIR}. So __dirname is ALWAYS the main
+// repo's scripts/hooks — resolving the state path here is cwd-independent and
+// needs no git call (keeps the common-path no-op cheap).
+// POST_COMPLETION_TEST_ROOT overrides the repo-root anchor for hermetic tests.
+const ROOT = process.env.POST_COMPLETION_TEST_ROOT || path.resolve(__dirname, '..', '..');
+const STATE_FILE = path.join(ROOT, '.claude', 'post-completion-pending.json');
+
+// Safety drain: a pending file older than this is considered abandoned (session
+// crashed / moved on) and is cleared without nagging forever.
+const MAX_AGE_MS = 6 * 60 * 60 * 1000; // 6h
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function autoProceedOn() {
+  // Same cheap check auto-proceed-pause-lint.cjs uses. Absent file ⇒ ON (default).
+  try {
+    const p = path.join(ROOT, '.claude', 'auto-proceed-state.json');
+    if (!fs.existsSync(p)) return true;
+    const j = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return j.auto_proceed !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Scan the transcript for evidence that the given ceremony skills ran AFTER the
+ * SD completed. Detects: a Skill tool_use ({name:'Skill', input.skill:'document'}),
+ * a slash-command in user/assistant text ('/document', '/heal', '/learn'), and
+ * '/leo complete' (which runs the entire tail → satisfies all).
+ * Tolerant: unreadable/malformed transcript ⇒ returns an empty set (we simply
+ * don't clear those steps and re-remind next turn — safe).
+ *
+ * @returns {Set<string>} subset of ['document','heal','learn'] with evidence
+ */
+function skillsEvidencedSince(transcriptPath, sinceMs) {
+  const found = new Set();
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return found;
+  let lines;
+  try {
+    lines = fs.readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return found;
+  }
+  const CEREMONY = ['document', 'heal', 'learn'];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    // Honor the completion boundary when the entry carries a timestamp; if it
+    // has none, fall through and inspect it (better to over-clear than to miss).
+    const ts = obj.timestamp ? Date.parse(obj.timestamp) : NaN;
+    if (!Number.isNaN(ts) && ts < sinceMs) continue;
+
+    const content = obj?.message?.content;
+    const blocks = Array.isArray(content) ? content : (content ? [content] : []);
+    for (const b of blocks) {
+      // Structured Skill tool_use
+      if (b && b.type === 'tool_use' && (b.name === 'Skill' || b.name === 'skill')) {
+        const skill = String(b.input?.skill || b.input?.command || '').toLowerCase();
+        if (skill.includes('leo') && skill.includes('complete')) { CEREMONY.forEach(c => found.add(c)); }
+        for (const c of CEREMONY) if (skill.includes(c)) found.add(c);
+      }
+      // Slash-command in text (user-typed or echoed)
+      const text = typeof b === 'string' ? b : (b && b.type === 'text' ? String(b.text || '') : '');
+      if (text) {
+        const t = text.toLowerCase();
+        if (t.includes('/leo complete')) CEREMONY.forEach(c => found.add(c));
+        for (const c of CEREMONY) if (t.includes('/' + c)) found.add(c);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Authoritative DB check: a learning_runs row (completed/success) for this SD
+ * proves /learn ran. Only called when 'learn' is still pending (lazy). Any
+ * failure ⇒ returns false (don't clear; re-remind — safe).
+ */
+async function learnRanInDb(sdId) {
+  if (!sdId) return false;
+  if (process.env.POST_COMPLETION_SKIP_DB === '1') return false; // hermetic tests
+  try {
+    const dotenv = await import('dotenv');
+    dotenv.config();
+    const { createClient } = await import('@supabase/supabase-js');
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return false;
+    const supabase = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+    const { data, error } = await supabase
+      .from('learning_runs')
+      .select('id')
+      .eq('sd_id', sdId)
+      .in('status', ['completed', 'success'])
+      .limit(1)
+      .maybeSingle();
+    if (error) return false;
+    return !!data;
+  } catch {
+    return false;
+  }
+}
+
+function clearStateFile() {
+  try { fs.unlinkSync(STATE_FILE); } catch { /* already gone */ }
+}
+
+async function main() {
+  // Cheap common-path no-op: absent file ⇒ nothing pending.
+  if (!fs.existsSync(STATE_FILE)) { process.exit(0); }
+
+  let payload = {};
+  try { payload = JSON.parse(readStdin() || '{}'); } catch {}
+
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+  } catch {
+    // Malformed ⇒ drop it (no-op).
+    clearStateFile();
+    process.exit(0);
+  }
+
+  const pending = Array.isArray(state.pending) ? state.pending.slice() : [];
+  if (pending.length === 0) { clearStateFile(); process.exit(0); }
+
+  // Safety drain on age.
+  const completedMs = state.completed_at ? Date.parse(state.completed_at) : NaN;
+  if (!Number.isNaN(completedMs) && (Date.now() - completedMs) > MAX_AGE_MS) {
+    clearStateFile();
+    process.exit(0);
+  }
+
+  // Multi-session safety: only the session that completed the SD should be
+  // nudged. If both ids are present and differ, this isn't our obligation.
+  const mySession = payload.session_id || process.env.CLAUDE_SESSION_ID || null;
+  if (state.session_id && mySession && state.session_id !== mySession) {
+    process.exit(0);
+  }
+
+  // Clear steps that now have evidence.
+  const sinceMs = Number.isNaN(completedMs) ? 0 : completedMs;
+  const evidenced = skillsEvidencedSince(payload.transcript_path, sinceMs);
+  let remaining = pending.filter((step) => !evidenced.has(step));
+
+  // /learn has an authoritative DB marker — check it if still pending.
+  if (remaining.includes('learn')) {
+    const ran = await learnRanInDb(state.sd_id);
+    if (ran) remaining = remaining.filter((s) => s !== 'learn');
+  }
+
+  // Persist the decremented list (or delete when fully satisfied).
+  if (remaining.length === 0) {
+    clearStateFile();
+    process.exit(0);
+  }
+  if (remaining.length !== pending.length) {
+    try {
+      fs.writeFileSync(STATE_FILE, JSON.stringify({ ...state, pending: remaining }, null, 2));
+    } catch { /* non-fatal */ }
+  }
+
+  // Only nudge under AUTO-PROCEED (when OFF, continuation already pauses).
+  if (!autoProceedOn()) { process.exit(0); }
+
+  const sdLabel = state.sd_key || state.sd_id || 'the just-completed SD';
+  const cmds = remaining.map((s) => '/' + s).join(' → ');
+  process.stderr.write(
+    `[post-completion-tail-enforcement] ${sdLabel} completed but its post-completion tail is not done: ${cmds}. ` +
+    `These are CONTINUATION steps, NOT a pause point — run them now without asking. ` +
+    `Do NOT say "say the word if you want" or otherwise confirmation-fish: that is the anti-pattern this rule exists to stop. ` +
+    `(/document updates docs; /learn writes learning_runs/patterns future PRDs query.) ` +
+    `Prefer driving completion via /leo complete so the full tail sequences automatically.\n`
+  );
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -95,6 +95,7 @@ AUTO-PROCEED is ON by default. You continue through phase transitions, PRD creat
 - Any "warrants confirmation" / "want me to continue?" rationalization
 - Numbered menu presentations at decision points
 - Intent to provide a "status checkpoint" after a successful handoff
+- Post-completion /document, /heal, /learn after an SD reaches LEAD-FINAL-APPROVAL — these are CONTINUATION steps, never pause points; "I didn't run them — say the word if you want them" is confirmation-fishing. Run the tail (or drive completion via /leo complete, which sequences /document → /heal → /learn automatically). Enforced by the post-completion-tail-enforcement Stop hook (SD-LEO-INFRA-AUTO-ENFORCE-POST-001).
 
 If your reason for pausing is not on the five-point list above, KEEP WORKING. When in doubt: pick the highest-value option, state it in one sentence, and execute.
 

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/post-completion-tail-populator.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/post-completion-tail-populator.js
@@ -1,0 +1,119 @@
+/**
+ * Post-Completion Tail Populator
+ * SD-LEO-INFRA-AUTO-ENFORCE-POST-001 (FR-001)
+ *
+ * Runs at LEAD-FINAL-APPROVAL completion. Records the canonical post-completion
+ * "ceremony" tail (/document, /heal, /learn) that this SD type requires, into
+ * <main-repo>/.claude/post-completion-pending.json, so the Stop hook
+ * (scripts/hooks/post-completion-tail-enforcement.cjs) can nudge the session
+ * to run whatever has not yet run — instead of the tail being silently dropped
+ * on the raw `handoff.js execute LEAD-FINAL-APPROVAL` path (it only runs inside
+ * the /leo complete skill flow).
+ *
+ * Single source of truth: the required steps come from
+ * lib/utils/post-completion-requirements.js (getPostCompletionRequirementsFromSD),
+ * NOT a hardcoded copy. That module already encodes type rules (document for all
+ * non-orchestrator SDs; heal/learn for full-sequence types) and the
+ * LEARN_SKIP_SOURCES / HEAL_SKIP_SOURCES recursion guards.
+ *
+ * Fail-safe: never throws; the caller wraps in try/catch and treats any error
+ * as non-blocking. Writing nothing is always a safe outcome.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getPostCompletionRequirementsFromSD } from '../../../../../../lib/utils/post-completion-requirements.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const CEREMONY_STEPS = ['document', 'heal', 'learn'];
+
+/**
+ * Resolve the MAIN repo root so the state file lands where the Stop hook reads
+ * it (<main>/.claude/), regardless of whether the handoff ran from main or a
+ * worktree. Order: CLAUDE_PROJECT_DIR → git common-dir parent → module walk-up.
+ * @returns {string}
+ */
+function resolveMainRepoRoot() {
+  if (process.env.POST_COMPLETION_TEST_ROOT) return process.env.POST_COMPLETION_TEST_ROOT; // hermetic tests
+  if (process.env.CLAUDE_PROJECT_DIR) return process.env.CLAUDE_PROJECT_DIR;
+  try {
+    // From any worktree, --git-common-dir points at <main>/.git
+    const { execSync } = require('node:child_process');
+    const common = execSync('git rev-parse --git-common-dir', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim();
+    if (common) {
+      const abs = path.isAbsolute(common) ? common : path.resolve(process.cwd(), common);
+      return path.dirname(abs); // parent of .git
+    }
+  } catch {
+    /* git unavailable — fall through */
+  }
+  // hooks → lead-final-approval → executors → handoff → modules → scripts → ROOT
+  return path.resolve(__dirname, '..', '..', '..', '..', '..', '..');
+}
+
+/**
+ * Is AUTO-PROCEED ON? Absent state file ⇒ ON (default), matching the hooks.
+ * When OFF, continuation already pauses, so no nudge is recorded.
+ */
+function autoProceedOn(root) {
+  try {
+    const p = path.join(root, '.claude', 'auto-proceed-state.json');
+    if (!fs.existsSync(p)) return true;
+    const j = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return j.auto_proceed !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * @param {Object} sd - The completing SD (needs sd_type, source, scope, id, sd_key)
+ * @param {Object} [_supabase] - unused; accepted for hook-signature symmetry
+ * @returns {Promise<{written: boolean, pending: string[], reason?: string}>}
+ */
+export async function runPostCompletionTailPopulator(sd, _supabase) {
+  const root = resolveMainRepoRoot();
+  const stateFile = path.join(root, '.claude', 'post-completion-pending.json');
+
+  // AUTO-PROCEED OFF ⇒ don't record a nudge (continuation pauses anyway).
+  if (!autoProceedOn(root)) {
+    return { written: false, pending: [], reason: 'auto_proceed_off' };
+  }
+
+  // Canonical required tail for this SD type/source (single source of truth).
+  const reqs = getPostCompletionRequirementsFromSD(sd);
+  const pending = CEREMONY_STEPS.filter((step) => reqs[step] === true);
+
+  if (pending.length === 0) {
+    // Nothing to nudge (e.g. orchestrator, or a skip-source SD). Clear any stale
+    // file so we don't nag about a prior SD.
+    try { if (fs.existsSync(stateFile)) fs.unlinkSync(stateFile); } catch { /* ignore */ }
+    return { written: false, pending: [], reason: 'no_ceremony_steps' };
+  }
+
+  const record = {
+    sd_key: sd.sd_key || sd.id || null,
+    sd_id: sd.id || null,
+    sd_type: (sd.sd_type || 'feature').toLowerCase(),
+    completed_at: new Date().toISOString(),
+    pending,
+    session_id: process.env.CLAUDE_SESSION_ID || null,
+  };
+
+  try {
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+    fs.writeFileSync(stateFile, JSON.stringify(record, null, 2));
+  } catch (err) {
+    return { written: false, pending, reason: `write_failed:${err.message}` };
+  }
+
+  return { written: true, pending };
+}
+
+export default { runPostCompletionTailPopulator };

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -539,6 +539,23 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     // Fail-safe: non-blocking, never prevents SD completion.
     await runProgrammaticRetrospective(sd);
 
+    // SD-LEO-INFRA-AUTO-ENFORCE-POST-001 (FR-001): record the post-completion
+    // ceremony tail (/document, /heal, /learn) this SD type requires into
+    // .claude/post-completion-pending.json, so the Stop hook
+    // (scripts/hooks/post-completion-tail-enforcement.cjs) can nudge the session
+    // to run whatever was not run on the raw handoff path (the tail otherwise
+    // only runs inside the /leo complete skill flow). Single source of truth:
+    // getPostCompletionRequirementsFromSD. Fail-safe: never blocks completion.
+    try {
+      const { runPostCompletionTailPopulator } = await import('./hooks/post-completion-tail-populator.js');
+      const tailResult = await runPostCompletionTailPopulator(sd, this.supabase);
+      if (tailResult.written) {
+        console.log(`   [post-completion-tail] recorded pending tail: ${tailResult.pending.map(s => '/' + s).join(', ')}`);
+      }
+    } catch (tailError) {
+      console.warn(`   ⚠️  Post-completion tail populator failed (non-blocking): ${tailError.message}`);
+    }
+
     // SD-MAN-INFRA-WIRE-HEAL-VISION-002: Auto-trigger /heal vision on orchestrator or vision-linked SD completion.
     // Checks trigger predicates (orchestrator done, vision_key present) and cooldown before running.
     // Fail-safe: non-blocking, never prevents SD completion.


### PR DESCRIPTION
## Summary
Gives the existing (toothless) post-completion tracking **teeth** so the `/document → /heal → /learn` ceremony runs reliably even when an SD completes via the raw `handoff.js execute LEAD-FINAL-APPROVAL` path (it otherwise only runs inside the `/leo complete` skill flow), and kills the **confirmation-fishing** anti-pattern ("say the word if you want them").

## What changed
- **FR-001 populator** (`lead-final-approval/hooks/post-completion-tail-populator.js`): at completion, records the canonical ceremony tail into `.claude/post-completion-pending.json` using `getPostCompletionRequirementsFromSD` (single source of truth — feature→document,heal,learn; infrastructure→document; orchestrator→none).
- **FR-002 Stop hook** (`scripts/hooks/post-completion-tail-enforcement.cjs`): reminder-first, **never blocks** (never traps a session), cheap no-op when the pending file is absent, multi-session-aware, clears steps as evidence appears (`learning_runs` row for `/learn`; transcript scan for `/document`,`/heal`,`/leo complete`). Wired as a 4th independent Stop entry in `.claude/settings.json`.
- **FR-003** (`scripts/hooks/auto-proceed-pause-lint.cjs`): regex now catches post-completion fishing phrasings ("say the word if you want me to run /document and /learn") without flagging benign reports ("I ran /document and /learn").
- **FR-004** (`file-generators.js` + `CLAUDE.md`): the canonical "NOT pause triggers" list now states the post-completion tail is a CONTINUATION step, never a pause point.
- **FR-005**: 20 unit tests (populator + Stop hook + regex precision), all hermetic.

## Validation
- 20/20 new unit tests pass.
- TESTING sub-agent verdict: **PASS (90% confidence)** — path coordination, never-blocks contract, regex precision (0 false-positives across 13 benign cases), canonical-source reuse, and fail-safe all verified.

SD: SD-LEO-INFRA-AUTO-ENFORCE-POST-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)