### PR TITLE
feat(SD-FDBK-ENH-CLAIM-WORKING-GOES-001): re-acquire self-owned sweep-released claim at handoff chokepoint

### DIFF
--- a/lib/claim/reacquire-self-live.mjs
+++ b/lib/claim/reacquire-self-live.mjs
@@ -1,0 +1,300 @@
+/**
+ * Reacquire Self-Live Claim — SD-FDBK-ENH-CLAIM-WORKING-GOES-001 (Approach B)
+ *
+ * THE BUG
+ * -------
+ * During long (10+ min) parallel sub-agent runs the owning Claude Code session
+ * makes zero tool calls, its PostToolUse heartbeat never fires, and the sd-start
+ * heartbeat daemon has already exited. stale-session-sweep
+ * (scripts/stale-session-sweep.cjs) ages the claim out: claude_sessions flips
+ * active->stale (~120s) then stale->released (~30s later), clearing
+ * claude_sessions.sd_key AND directly clearing
+ * strategic_directives_v2.{claiming_session_id, is_working_on}. The
+ * sync_is_working_on_with_session trigger CLEAR branch independently flips
+ * is_working_on=false on that release.
+ *
+ * After that, `node scripts/handoff.js execute ...` hard-fails because
+ * trg_enforce_is_working_on_handoffs RAISEs
+ * "Cannot create handoff for SD without active session claim" whenever
+ * strategic_directives_v2.is_working_on is not TRUE.
+ *
+ * Critically, the sync trigger's SET branch only fires on
+ *   (OLD.sd_key IS NULL AND NEW.sd_key IS NOT NULL AND NEW.status='active')
+ * — i.e. a fresh NULL->non-NULL claim transition on claude_sessions. When the
+ * live session's claude_sessions row is still (or again) active/idle with sd_key
+ * already stamped, there is NO such transition, so re-writing claude_sessions
+ * does NOT restore is_working_on. The Step-1 "activeClaim" early-return in
+ * BaseExecutor._claimSDForSession only refreshes claude_sessions.heartbeat_at and
+ * never touches strategic_directives_v2.is_working_on, so the handoff INSERT
+ * still trips the enforce trigger. THIS is the residual gap (a prior fix,
+ * 20260511_sync_is_working_on_preserve_recoverable_stale.sql, only protected the
+ * ~30s recoverable-stale grace window, not the 10+min released case).
+ *
+ * THE FIX (Approach B — re-acquire at the handoff claim chokepoint)
+ * ----------------------------------------------------------------
+ * At the handoff claim chokepoint, re-acquire
+ * strategic_directives_v2.is_working_on=true (+ claiming_session_id=self) for a
+ * claim THIS live session legitimately owns that the sweep released — so the
+ * handoff proceeds — while preserving all protection against dead/foreign
+ * sessions.
+ *
+ * Because routing via claude_sessions would NOT re-fire the trigger SET branch
+ * for the already-active-row case (see above), this uses a GUARDED, fail-closed
+ * compare-and-swap directly on strategic_directives_v2 (the same column write
+ * claim_sd / reaffirmClaimColumns already perform), gated by two witnesses:
+ *
+ *   FR-2(a) SELF-OWNERSHIP: process.cwd() is inside sd.worktree_path (normalized
+ *           — same ownership signal as claim-validity-gate CHECK 3; a foreign
+ *           session is not in this SD's worktree). For orchestrator SDs with no
+ *           worktree_path, fall back to resolveOwnSession returning
+ *           deterministically (source !== 'heartbeat_fallback') a session whose
+ *           sd_key === sd.sd_key.
+ *   FR-2(b) NO LIVE FOREIGN HOLDER: checkPreClaimEvidence(...).allowReclaim !== false.
+ *
+ * Deliberately NOT used as liveness signals (per FR-2): claude_sessions.is_alive
+ * (sticky; survives kill -9), process_alive_at (fleet-broken), or a fresh
+ * heartbeat (stale by definition in this bug). The implicit liveness witness is
+ * that THIS handoff process is executing right now.
+ *
+ * FR-3 fail-closed CAS: the write only sets when claiming_session_id IS NULL OR
+ * already equals self, so a concurrent FOREIGN claim wins safely and is never
+ * clobbered. No DB migration / no schema change. stale-session-sweep is NOT
+ * modified.
+ *
+ * FR-4: gated behind DEFAULT-ON env flag CLAIM_REACQUIRE_SELF_LIVE (disabled
+ * only when === 'false'); disabling reverts to today's hard-fail.
+ *
+ * @module reacquire-self-live
+ */
+
+/**
+ * FR-2(a) self-ownership predicate (pure). True when `cwd` is the SD's
+ * registered worktree directory or a descendant of it.
+ *
+ * Mirrors the canonical normalization in claim-validity-gate.js CHECK 3:
+ * on win32, convert forward slashes to backslashes and lowercase (the
+ * filesystem is case-insensitive); compare exact OR prefix + separator so a
+ * sibling like `.worktrees/SD-FOO-001-OTHER` does not match
+ * `.worktrees/SD-FOO-001`.
+ *
+ * @param {string|null|undefined} cwd - current working directory
+ * @param {string|null|undefined} worktreePath - SD's registered worktree_path
+ * @param {string} [platform=process.platform] - injectable for tests
+ * @returns {boolean}
+ */
+export function isCwdInsideWorktree(cwd, worktreePath, platform = process.platform) {
+  if (!cwd || !worktreePath) return false;
+  const normalize = (p) => {
+    let s = String(p);
+    if (platform === 'win32') {
+      s = s.replace(/\//g, '\\').toLowerCase();
+    }
+    return s;
+  };
+  // Derive the separator from the `platform` argument (NOT path.sep, which is
+  // host-dependent — on a Windows host path.sep is '\\' even when callers inject
+  // platform='linux' for tests).
+  const sep = platform === 'win32' ? '\\' : '/';
+  const nCwd = normalize(cwd);
+  const nWt = normalize(worktreePath);
+  return nCwd === nWt || nCwd.startsWith(nWt + sep);
+}
+
+/**
+ * Determine whether this live session legitimately self-owns `sd` (FR-2(a)),
+ * returning the resolved session id when known.
+ *
+ * Primary signal: cwd inside worktree_path. Orchestrator/no-worktree fallback:
+ * resolveOwnSession deterministic (source !== 'heartbeat_fallback') with
+ * resolved sd_key === sd.sd_key.
+ *
+ * @param {object} args
+ * @param {object} args.sd - SD record (must include sd_key; worktree_path optional)
+ * @param {string} args.cwd - current working directory
+ * @param {Function} args.resolveSession - async () => { data, source } (resolveOwnSession bound to supabase)
+ * @param {string} [args.platform]
+ * @returns {Promise<{selfOwned: boolean, via: string, sessionId: string|null}>}
+ */
+export async function resolveSelfOwnership({ sd, cwd, resolveSession, platform }) {
+  // Primary: cwd inside the SD's registered worktree.
+  if (sd?.worktree_path && isCwdInsideWorktree(cwd, sd.worktree_path, platform)) {
+    // We still try to learn our session id (for the claiming_session_id write),
+    // but ownership is already established by the worktree witness.
+    let sessionId = null;
+    try {
+      const resolved = await resolveSession();
+      if (resolved?.data && resolved.source !== 'heartbeat_fallback') {
+        sessionId = resolved.data.session_id || null;
+      }
+    } catch {
+      // Non-fatal — worktree witness alone proves self-ownership; sessionId stays null.
+    }
+    return { selfOwned: true, via: 'worktree_path', sessionId };
+  }
+
+  // Fallback (orchestrator / no worktree_path): deterministic session whose
+  // sd_key matches this SD.
+  try {
+    const resolved = await resolveSession();
+    if (
+      resolved?.data &&
+      resolved.source !== 'heartbeat_fallback' &&
+      resolved.data.sd_key &&
+      sd?.sd_key &&
+      resolved.data.sd_key === sd.sd_key
+    ) {
+      return { selfOwned: true, via: 'resolve_own_session_sd_key', sessionId: resolved.data.session_id || null };
+    }
+  } catch {
+    // Non-fatal — fall through to not-self-owned.
+  }
+
+  return { selfOwned: false, via: 'none', sessionId: null };
+}
+
+/**
+ * Re-acquire is_working_on for a self-owned, sweep-released claim at the handoff
+ * chokepoint. Fail-closed, idempotent, and a strict no-op on the healthy path.
+ *
+ * Returns a structured outcome describing what happened (never throws — callers
+ * wrap in try/catch too, but this function additionally degrades internally so
+ * any failure leaves today's behavior intact).
+ *
+ * @param {object} supabase - Supabase service client
+ * @param {object} opts
+ * @param {object} opts.sd - SD record from the handoff (used for sd_key + cheap is_working_on pre-filter)
+ * @param {Function} opts.resolveSession - async () => resolveOwnSession(...) result, already bound to supabase
+ * @param {Function} opts.checkPreClaimEvidence - async (supabase, sdKey, {mySessionId}) => { allowReclaim, ... }
+ * @param {string} [opts.cwd=process.cwd()]
+ * @param {string} [opts.platform=process.platform]
+ * @param {object} [opts.env=process.env]
+ * @param {Function} [opts.log=console.log]
+ * @returns {Promise<{reacquired: boolean, reason: string, via?: string, sessionId?: string|null}>}
+ */
+export async function reacquireSelfLiveClaim(supabase, opts = {}) {
+  const {
+    sd,
+    resolveSession,
+    checkPreClaimEvidence,
+    cwd = process.cwd(),
+    platform = process.platform,
+    env = process.env,
+    log = console.log,
+  } = opts;
+
+  // FR-4: default-ON env flag; disabled only on explicit 'false'.
+  if (env.CLAIM_REACQUIRE_SELF_LIVE === 'false') {
+    return { reacquired: false, reason: 'flag_disabled' };
+  }
+
+  const sdKey = sd?.sd_key;
+  if (!sdKey) {
+    return { reacquired: false, reason: 'no_sd_key' };
+  }
+
+  try {
+    // Cheap pre-filter: skip entirely on the common healthy path where the
+    // caller's (possibly cached) SD already shows is_working_on=true.
+    if (sd?.is_working_on === true) {
+      return { reacquired: false, reason: 'already_working_cached' };
+    }
+
+    // Re-read FRESH claim state (the caller's `sd` may be stale — it was loaded
+    // before the sweep ran). Only proceed when the live row confirms the claim
+    // is NOT currently held as working.
+    const { data: fresh, error: freshErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, is_working_on, claiming_session_id, active_session_id, worktree_path')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+
+    if (freshErr) {
+      return { reacquired: false, reason: `fresh_read_error:${freshErr.message}` };
+    }
+    if (!fresh) {
+      return { reacquired: false, reason: 'sd_not_found' };
+    }
+    if (fresh.is_working_on === true) {
+      // Healthy (or already restored by a concurrent path) — nothing to do.
+      return { reacquired: false, reason: 'already_working' };
+    }
+
+    // FR-2(a): self-ownership witness. Prefer the fresh worktree_path; fall back
+    // to the caller-provided one.
+    const sdForOwnership = { sd_key: sdKey, worktree_path: fresh.worktree_path ?? sd?.worktree_path ?? null };
+    const ownership = await resolveSelfOwnership({ sd: sdForOwnership, cwd, resolveSession, platform });
+    if (!ownership.selfOwned) {
+      // Dead/other-self protection: we cannot prove THIS live session owns the
+      // claim, so we must not re-acquire.
+      return { reacquired: false, reason: 'not_self_owned' };
+    }
+
+    // FR-2(b): no live foreign holder. allowReclaim === false means a live
+    // holder blocks reclaim; anything else (unclaimed/clean, dead ghost, or
+    // query degradation returning allowReclaim:true) permits it.
+    let allowReclaim = true;
+    try {
+      const evidence = await checkPreClaimEvidence(supabase, sdKey, { mySessionId: ownership.sessionId || undefined });
+      allowReclaim = evidence?.allowReclaim !== false;
+    } catch (egErr) {
+      // Fail-open on the evidence probe ONLY (matches sweep's own degradation
+      // policy); the CAS guard below still prevents clobbering a foreign claim.
+      log(`[claim-reacquire] evidence probe degraded for ${sdKey} (${egErr?.message || egErr}) — relying on CAS guard`);
+      allowReclaim = true;
+    }
+    if (!allowReclaim) {
+      return { reacquired: false, reason: 'live_foreign_holder' };
+    }
+
+    // FR-3: fail-closed compare-and-swap. Only set when the SD is currently
+    // unclaimed (claiming_session_id IS NULL) OR already claimed by self. A
+    // concurrent FOREIGN claim acquired between our read and write makes this a
+    // no-op (0 rows updated) — we never clobber it.
+    const selfId = ownership.sessionId;
+    const orFilter = selfId
+      ? `claiming_session_id.is.null,claiming_session_id.eq.${selfId}`
+      : 'claiming_session_id.is.null';
+
+    const update = { is_working_on: true };
+    if (selfId) {
+      update.claiming_session_id = selfId;
+      update.active_session_id = selfId;
+    }
+
+    const { data: updated, error: casErr } = await supabase
+      .from('strategic_directives_v2')
+      .update(update)
+      .eq('sd_key', sdKey)
+      .or(orFilter)
+      .select('sd_key, is_working_on, claiming_session_id');
+
+    if (casErr) {
+      return { reacquired: false, reason: `cas_error:${casErr.message}` };
+    }
+    const rowCount = Array.isArray(updated) ? updated.length : (updated ? 1 : 0);
+    if (rowCount === 0) {
+      // CAS lost the race to a foreign claim (or the row no longer matches).
+      return { reacquired: false, reason: 'cas_noop_foreign_or_changed' };
+    }
+
+    // FR-5: one structured log line on an actual re-acquire.
+    log(JSON.stringify({
+      event: 'claim_reacquire_self_live',
+      sd_key: sdKey,
+      session: selfId || null,
+      via: ownership.via,
+      sweep_released: true,
+      note: 'sweep-released claim re-acquired for live self-owned session at handoff chokepoint (SD-FDBK-ENH-CLAIM-WORKING-GOES-001)',
+      timestamp: new Date().toISOString(),
+    }));
+
+    return { reacquired: true, reason: 'reacquired', via: ownership.via, sessionId: selfId };
+  } catch (err) {
+    // FR: any failure degrades to today's behavior (never throw out of the
+    // claim step).
+    log(`[claim-reacquire] degraded for ${sdKey} (non-fatal): ${err?.message || err}`);
+    return { reacquired: false, reason: `degraded:${err?.message || err}` };
+  }
+}
+
+export default { reacquireSelfLiveClaim, resolveSelfOwnership, isCwdInsideWorktree };

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -867,6 +867,19 @@ export class BaseExecutor {
 
     const claimId = sd.sd_key || sdId;
 
+    // Step 0: SD-FDBK-ENH-CLAIM-WORKING-GOES-001 (Approach B) — re-acquire
+    // is_working_on for a self-owned, sweep-released claim BEFORE the rest of
+    // the claim flow. During long parallel sub-agent runs the heartbeat goes
+    // stale, the sweep flips active->stale->released and clears the SD's
+    // is_working_on, and the sync trigger's SET branch won't re-fire (no
+    // claude_sessions sd_key NULL->non-NULL transition for an already-active
+    // row). Without this, Step 1's activeClaim early-return refreshes only the
+    // heartbeat and the handoff INSERT trips trg_enforce_is_working_on_handoffs.
+    // Fail-closed (CAS), self-ownership-gated, default-ON
+    // (CLAIM_REACQUIRE_SELF_LIVE), strict no-op on the healthy path, and wrapped
+    // so any failure degrades to today's hard-fail behavior.
+    await this._reacquireSelfLiveClaimIfReleased(sdId, sd, claimId);
+
     // Step 1: Check if a valid claim already exists (from sd:start or parent conversation).
     // SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001: sd_claims dropped — claude_sessions is the
     // single source of truth. Active claims are sessions with sd_id set and status='active'.
@@ -956,6 +969,47 @@ export class BaseExecutor {
 
     // Show duration estimate (non-blocking)
     await this._showDurationEstimate(sd);
+  }
+
+  /**
+   * SD-FDBK-ENH-CLAIM-WORKING-GOES-001 (Approach B): re-acquire is_working_on
+   * for a self-owned, sweep-released claim at the handoff chokepoint.
+   *
+   * Thin BaseExecutor seam over the testable, DB-agnostic core in
+   * lib/claim/reacquire-self-live.mjs. Binds resolveOwnSession +
+   * checkPreClaimEvidence to this.supabase and supplies process.cwd(). Never
+   * throws — any failure degrades to today's behavior (the rest of
+   * _claimSDForSession runs unchanged and the handoff hard-fails as before if
+   * the claim cannot be legitimately re-acquired).
+   *
+   * @param {string} sdId
+   * @param {object} sd - SD record (for sd_key + cheap is_working_on pre-filter)
+   * @param {string} claimId - resolved sd_key/id
+   */
+  async _reacquireSelfLiveClaimIfReleased(sdId, sd, claimId) {
+    try {
+      const { reacquireSelfLiveClaim } = await import('../../../../lib/claim/reacquire-self-live.mjs');
+      const { resolveOwnSession } = await import('../../../../lib/resolve-own-session.js');
+      const { checkPreClaimEvidence } = await import('../../claim-health/triangulate.js');
+
+      const result = await reacquireSelfLiveClaim(this.supabase, {
+        sd: { ...sd, sd_key: sd?.sd_key || claimId },
+        resolveSession: () => resolveOwnSession(this.supabase, {
+          select: 'session_id, sd_key, status, heartbeat_at',
+          warnOnFallback: false
+        }),
+        checkPreClaimEvidence,
+        cwd: process.cwd()
+      });
+
+      if (result?.reacquired) {
+        console.log(`   [Claim] ♻️  Re-acquired sweep-released claim for ${result.sessionId ? result.sessionId.slice(0, 8) : 'self'} on ${claimId} (via ${result.via})`);
+      }
+    } catch (e) {
+      // Non-fatal — degrade to today's behavior. The downstream claim flow and
+      // the DB enforce-trigger remain the safety net.
+      console.debug('[BaseExecutor] reacquire-self-live suppressed:', e?.message || e);
+    }
   }
 
   /**

--- a/tests/unit/claim-reacquire-self-live.test.js
+++ b/tests/unit/claim-reacquire-self-live.test.js
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for lib/claim/reacquire-self-live.mjs
+ * SD-FDBK-ENH-CLAIM-WORKING-GOES-001 (Approach B)
+ *
+ * Covers the re-acquire predicate + fail-closed CAS at the handoff claim
+ * chokepoint. DB-agnostic: Supabase is mocked the way neighboring tests do
+ * (claim-validity-gate.test.js routing mock).
+ *
+ * Mandatory scenarios:
+ *   TS-1 positive: self-owned (cwd in worktree) + sweep-released + no live
+ *                  foreign holder => re-acquires (CAS fires, is_working_on set).
+ *   TS-2 negative: foreign session holds the claim (allowReclaim=false) => no re-acquire.
+ *   TS-3 negative: not self-owned (cwd outside worktree AND resolveOwnSession
+ *                  sd_key != claim) => no re-acquire.
+ *   TS-4 race:     CAS uses claiming_session_id IS NULL / self guard; a
+ *                  concurrent foreign claim makes the update a no-op.
+ *   TS-5 flag off: CLAIM_REACQUIRE_SELF_LIVE='false' => no-op.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  reacquireSelfLiveClaim,
+  resolveSelfOwnership,
+  isCwdInsideWorktree,
+} from '../../lib/claim/reacquire-self-live.mjs';
+
+const SD_KEY = 'SD-FOO-001';
+const WT = '/repo/.worktrees/SD-FOO-001';
+const SELF = 'session_self_123';
+const FOREIGN = 'session_foreign_999';
+
+/**
+ * Routing Supabase mock.
+ * - SELECT path: .from('strategic_directives_v2').select(cols).eq('sd_key',k).maybeSingle() => { data: freshRow }
+ * - UPDATE path: .from(...).update(payload).eq('sd_key',k).or(filter).select(cols) => resolves with `updateReturns`
+ *   and records the call in _updateCalls (payload + the .or() filter string).
+ *
+ * @param {object} opts
+ * @param {object|null} opts.freshRow   row returned by the fresh SELECT
+ * @param {Array|null}  opts.updateReturns  rows the CAS .select() resolves to ([] => no-op)
+ * @param {object} [opts.selectError]  optional error for the SELECT
+ * @param {object} [opts.updateError]  optional error for the UPDATE
+ */
+function buildSupabase({ freshRow, updateReturns = [{ sd_key: SD_KEY, is_working_on: true, claiming_session_id: SELF }], selectError = null, updateError = null }) {
+  const updateCalls = [];
+  const sb = {
+    from: vi.fn(() => ({
+      // SELECT branch (fresh read)
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: freshRow, error: selectError })),
+        })),
+      })),
+      // UPDATE branch (CAS)
+      update: vi.fn((payload) => ({
+        eq: vi.fn((col, val) => ({
+          or: vi.fn((orFilter) => ({
+            select: vi.fn(() => {
+              updateCalls.push({ payload, where: [col, val], orFilter });
+              return Promise.resolve({ data: updateError ? null : updateReturns, error: updateError });
+            }),
+          })),
+        })),
+      })),
+    })),
+    _updateCalls: updateCalls,
+  };
+  return sb;
+}
+
+const allowReclaim = (allow) => vi.fn(() => Promise.resolve({ allowReclaim: allow, evidence: [], classification: allow ? null : 'healthy' }));
+const resolveSelf = (data, source = 'env_var') => vi.fn(() => Promise.resolve({ data, source }));
+const silentLog = () => {};
+
+describe('isCwdInsideWorktree (FR-2a predicate)', () => {
+  it('matches exact + descendant, case-insensitive on win32, rejects siblings', () => {
+    expect(isCwdInsideWorktree('C:/r/.worktrees/SD-A', 'C:/r/.worktrees/SD-A', 'win32')).toBe(true);
+    expect(isCwdInsideWorktree('C:\\r\\.worktrees\\SD-A\\sub', 'C:/r/.worktrees/SD-A', 'win32')).toBe(true);
+    expect(isCwdInsideWorktree('C:/R/.WORKTREES/sd-a', 'C:/r/.worktrees/SD-A', 'win32')).toBe(true);
+    expect(isCwdInsideWorktree('C:/r/.worktrees/SD-A-OTHER', 'C:/r/.worktrees/SD-A', 'win32')).toBe(false);
+  });
+  it('matches descendant + rejects sibling on posix', () => {
+    expect(isCwdInsideWorktree('/r/.worktrees/SD-A/x', '/r/.worktrees/SD-A', 'linux')).toBe(true);
+    expect(isCwdInsideWorktree('/r/.worktrees/SD-A-OTHER', '/r/.worktrees/SD-A', 'linux')).toBe(false);
+  });
+  it('returns false on missing inputs', () => {
+    expect(isCwdInsideWorktree(null, '/x', 'linux')).toBe(false);
+    expect(isCwdInsideWorktree('/x', undefined, 'linux')).toBe(false);
+  });
+});
+
+describe('resolveSelfOwnership (FR-2a)', () => {
+  it('self-owns via worktree_path when cwd is inside it', async () => {
+    const r = await resolveSelfOwnership({
+      sd: { sd_key: SD_KEY, worktree_path: WT },
+      cwd: `${WT}/sub`,
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      platform: 'linux',
+    });
+    expect(r.selfOwned).toBe(true);
+    expect(r.via).toBe('worktree_path');
+    expect(r.sessionId).toBe(SELF);
+  });
+
+  it('orchestrator fallback: no worktree_path but deterministic session sd_key matches', async () => {
+    const r = await resolveSelfOwnership({
+      sd: { sd_key: SD_KEY, worktree_path: null },
+      cwd: '/some/other/dir',
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      platform: 'linux',
+    });
+    expect(r.selfOwned).toBe(true);
+    expect(r.via).toBe('resolve_own_session_sd_key');
+  });
+
+  it('NOT self-owned: cwd outside worktree AND resolved sd_key differs', async () => {
+    const r = await resolveSelfOwnership({
+      sd: { sd_key: SD_KEY, worktree_path: WT },
+      cwd: '/repo/main',
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: 'SD-OTHER-002' }),
+      platform: 'linux',
+    });
+    expect(r.selfOwned).toBe(false);
+  });
+
+  it('NOT self-owned via fallback when resolveOwnSession is heartbeat_fallback', async () => {
+    const r = await resolveSelfOwnership({
+      sd: { sd_key: SD_KEY, worktree_path: null },
+      cwd: '/repo/main',
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }, 'heartbeat_fallback'),
+      platform: 'linux',
+    });
+    expect(r.selfOwned).toBe(false);
+  });
+});
+
+describe('reacquireSelfLiveClaim', () => {
+  // TS-1
+  it('TS-1 positive: self-owned + sweep-released + no live foreign holder => re-acquires (CAS fires)', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(true);
+    expect(result.via).toBe('worktree_path');
+    expect(sb._updateCalls).toHaveLength(1);
+    expect(sb._updateCalls[0].payload).toMatchObject({ is_working_on: true, claiming_session_id: SELF, active_session_id: SELF });
+    expect(sb._updateCalls[0].where).toEqual(['sd_key', SD_KEY]);
+  });
+
+  // TS-2
+  it('TS-2 negative: foreign session holds the claim (allowReclaim=false) => no re-acquire, no CAS write', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: FOREIGN, active_session_id: FOREIGN, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(false), // live foreign holder
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('live_foreign_holder');
+    expect(sb._updateCalls).toHaveLength(0); // never wrote
+  });
+
+  // TS-3
+  it('TS-3 negative: not self-owned (cwd outside worktree AND resolved sd_key != claim) => no re-acquire', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: 'SD-OTHER-002' }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: '/repo/main', // NOT inside WT
+      platform: 'linux',
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('not_self_owned');
+    expect(sb._updateCalls).toHaveLength(0);
+  });
+
+  // TS-4
+  it('TS-4 race: CAS guards on claiming_session_id IS NULL / self; concurrent foreign claim makes it a no-op', async () => {
+    // Fresh read saw unclaimed, but the CAS .select() returns [] (0 rows) because
+    // a foreign claim landed between read and write — the .or() guard excluded it.
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+      updateReturns: [], // CAS matched 0 rows
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('cas_noop_foreign_or_changed');
+    // The CAS was attempted with the null/self guard.
+    expect(sb._updateCalls).toHaveLength(1);
+    expect(sb._updateCalls[0].orFilter).toBe(`claiming_session_id.is.null,claiming_session_id.eq.${SELF}`);
+  });
+
+  it('TS-4b: when self session id is unknown, CAS guards on claiming_session_id IS NULL only', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      // worktree witness proves ownership; resolveSession yields no usable session id
+      resolveSession: resolveSelf(null, 'env_var'),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(true);
+    expect(sb._updateCalls[0].orFilter).toBe('claiming_session_id.is.null');
+    // No claiming_session_id written when self id is unknown (still sets is_working_on).
+    expect(sb._updateCalls[0].payload).toEqual({ is_working_on: true });
+  });
+
+  // TS-5
+  it('TS-5 flag off: CLAIM_REACQUIRE_SELF_LIVE="false" => strict no-op (no DB calls)', async () => {
+    const sb = buildSupabase({ freshRow: null });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      env: { CLAIM_REACQUIRE_SELF_LIVE: 'false' },
+      log: silentLog,
+    });
+
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('flag_disabled');
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+
+  it('default-on: unset flag behaves as enabled', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      env: {}, // flag unset
+      log: silentLog,
+    });
+    expect(result.reacquired).toBe(true);
+  });
+
+  it('healthy path: cached is_working_on=true => no-op, no DB read', async () => {
+    const sb = buildSupabase({ freshRow: null });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: true, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('already_working_cached');
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+
+  it('fresh read shows is_working_on=true (restored concurrently) => no-op, no CAS', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: true, claiming_session_id: SELF, active_session_id: SELF, worktree_path: WT },
+    });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT }, // cached stale=false
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('already_working');
+    expect(sb._updateCalls).toHaveLength(0);
+  });
+
+  it('degrades (no throw) when fresh read errors => no re-acquire', async () => {
+    const sb = buildSupabase({ freshRow: null, selectError: { message: 'db down' } });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toMatch(/^fresh_read_error:/);
+  });
+
+  it('evidence probe throwing degrades to fail-open; CAS guard still protects', async () => {
+    const sb = buildSupabase({
+      freshRow: { sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT },
+    });
+    const throwingEvidence = vi.fn(() => Promise.reject(new Error('triangulate exploded')));
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+      resolveSession: resolveSelf({ session_id: SELF, sd_key: SD_KEY }),
+      checkPreClaimEvidence: throwingEvidence,
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+    // Fail-open on the probe → proceeds to CAS (which here succeeds).
+    expect(result.reacquired).toBe(true);
+    expect(sb._updateCalls).toHaveLength(1);
+  });
+
+  it('no sd_key => no-op', async () => {
+    const sb = buildSupabase({ freshRow: null });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { is_working_on: false },
+      resolveSession: resolveSelf({ session_id: SELF }),
+      checkPreClaimEvidence: allowReclaim(true),
+      cwd: WT,
+      platform: 'linux',
+      log: silentLog,
+    });
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('no_sd_key');
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the recurring **mid-SD handoff failure** where a live session's claim is released by `stale-session-sweep` during long (10+ min) sub-agent runs, after which the DB trigger `trg_enforce_is_working_on_handoffs` hard-fails **every** subsequent handoff with "Cannot create handoff for SD without active session claim". Recurred ~5× in a single SD. (SD-FDBK-ENH-CLAIM-WORKING-GOES-001, infrastructure.)

## Root cause
The `sync_is_working_on_with_session` trigger's SET branch only fires on a `claude_sessions` `sd_key` NULL→non-NULL transition. When the live session's row is *already* active with `sd_key` stamped, re-touching it does **not** restore `strategic_directives_v2.is_working_on`, and `_claimSDForSession` Step 1 only refreshes the heartbeat — so the handoff INSERT trips the enforce trigger. A prior fix (#3703) only covered the ~30s recoverable-stale grace window, not the 10+min released case.

## Fix — Approach B (LEAD-locked; approach A "persistent heartbeat" descoped)
Re-acquire `is_working_on` at the handoff claim chokepoint (`BaseExecutor._claimSDForSession` **Step 0**, before the Step-1 early-return) for a claim **this live session legitimately owns** that the sweep released — **fail-closed** and witness-gated:
- **Self-ownership**: `process.cwd()` inside `sd.worktree_path` (claim-validity CHECK-3 normalization; a foreign session isn't in this SD's worktree). Orchestrator fallback = deterministic `resolveOwnSession` `sd_key` match.
- **No live foreign holder**: `checkPreClaimEvidence(...).allowReclaim`.
- **Deliberately NOT** `is_alive` (sticky; survives `kill -9`), `process_alive_at` (fleet-broken), or fresh-heartbeat (stale *by definition* here).
- **CAS guard**: `WHERE claiming_session_id IS NULL OR = self` → a concurrent foreign claim wins (no-op), never clobbered.
- **Default-ON flag** `CLAIM_REACQUIRE_SELF_LIVE`; structured re-acquire log; any failure degrades to today's behavior.

New `lib/claim/reacquire-self-live.mjs` (DB-agnostic core). No schema change; `stale-session-sweep` untouched.

## Test plan
- 19 new unit tests incl. **2 mandatory negatives** (foreign-stale rejected, dead/other-self rejected) — mutation-verified to hold.
- Regression neighbors (claim-guard / multi-session-claim-gate / base-executor-marker-race): green, no regressions.
- Sub-agent evidence: validation 88, risk 86 (HIGH, B-now/A-later), testing 92.

Gate scores: LEAD-TO-PLAN 95 · PLAN-TO-EXEC 98 · EXEC-TO-PLAN 93 · PLAN-TO-LEAD 97.
Follow-up: repair the fleet-broken `session-tick.cjs` `process_alive_at` writer (Approach A).
Cross-links SD-FDBK-INFRA-CASCADE-TRIGGER-OVERREACH-001 (PR #3703).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
