### PR TITLE
fix(QF-20260603-141): ignore zero-conflict cross-session scratch (last-outcome + prd-payloads/_*)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,6 +294,14 @@ src/client/dist/
 .claude/fleet-dashboard-state.json
 .claude/worktree-reaper-state.json
 .claude/retry-state-*.json.tmp-*
+
+# Cross-session scratch droppings — QF-20260603-141 (only patterns with ZERO tracked-file conflicts)
+# .claude/last-outcome-*.json: per-session Stop-hook outcome snapshots, never committed (0 tracked)
+# .prd-payloads/_*: underscore-prefixed add-prd working files (committed payloads are SD-*.json, preserved; 0 tracked _-files)
+# NOTE: scripts/one-off/_* and .rca/_* are deliberately NOT ignored — 175 and 6 such files are already
+# tracked, so committing _-prefixed scripts there is established practice; ignoring would silently block it.
+.claude/last-outcome-*.json
+.prd-payloads/_*
 .claude-code-config.json
 .claude-status-line
 .leo-status.json


### PR DESCRIPTION
## Summary
- Adds 2 directory-scoped `.gitignore` patterns that drain ~129 untracked cross-session scratch files from every parallel session's `git status`:
  - `.claude/last-outcome-*.json` (25 untracked, 0 tracked) — per-session Stop-hook outcome snapshots
  - `.prd-payloads/_*` (104 untracked, 0 tracked `_`-files) — underscore-prefixed add-prd working files
- **Zero-tracked-conflict rule**: only patterns with no already-tracked matches were added. Deliberately EXCLUDES `scripts/one-off/_*` (175 tracked) and `.rca/_*` (6 tracked), where committing `_`-prefixed files is established practice — ignoring would silently block intended `git add`.
- Destroys nothing: files stay on disk, only stop being reported as untracked.

## Test plan
- `git check-ignore` verified: positives drained (`.claude/last-outcome-*.json`, `.prd-payloads/_svp-*`); all keepers preserved (`.prd-payloads/SD-*.json`, `scripts/one-off/_check-*.mjs`, `scripts/one-off/insert-retro-*.mjs`, `.rca/_inspect-*.mjs`, `.rca/RCA-*.md`).
- Diff is `.gitignore`-only (+8 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)