### PR TITLE
fix(SD-LEO-INFRA-HARDEN-SUPABASE-LINTER-001): harden linter migration 05 (ownership precheck + atomicity + apply-role doc)

### DIFF
--- a/database/migrations/20260603_05_move_extensions_out_of_public.sql
+++ b/database/migrations/20260603_05_move_extensions_out_of_public.sql
@@ -6,17 +6,26 @@
 -- !!! BRANCH. Verify vector / pg_trgm / ltree queries AND index creation work
 -- !!! afterwards. This is the riskiest migration in this set — keep it last.
 --
+-- !!! APPLY AS `supabase_admin` (the extension owner) OR A SUPERUSER — e.g. via the
+-- !!! Supabase Dashboard SQL Editor. The `postgres` pooler role used by the normal
+-- !!! migration runner is NOT the extension owner and is NOT a superuser, so
+-- !!! `ALTER EXTENSION ... SET SCHEMA` fails with "must be owner of extension".
+-- !!! Verified 2026-06-03: vector/ltree/pg_trgm are owned by `supabase_admin`, not
+-- !!! `postgres`. The ownership precheck (step 0 below) ABORTS cleanly — before ANY
+-- !!! change — if the current role cannot ALTER the extensions.
+--
 -- Supabase linter `extension_in_public`: vector / pg_trgm / ltree are installed in
 -- `public` (the Supabase default). Recommended remediation is to relocate them to a
 -- dedicated `extensions` schema so they are not part of the exposed API surface.
 --
--- LIVE-VERIFIED PRECONDITIONS (all green):
+-- LIVE-VERIFIED PRECONDITIONS (all green, re-verified read-only 2026-06-03):
 --   * All three are extrelocatable = true.
 --   * None has any RELATION member (no tables/indexes owned BY the extension), so
 --     `ALTER EXTENSION ... SET SCHEMA` is a clean metadata move. Dependent objects
 --     in OTHER tables — `vector`-typed columns, GIN/GiST trgm indexes, ltree cols —
 --     reference the type/opclass by OID and KEEP WORKING after the move.
 --   * The `extensions` schema already exists (holds pgcrypto/pgjwt etc.).
+--   * Owner = `supabase_admin` (NOT postgres) — see apply-role note above.
 --
 -- WHY search_path MUST be updated FIRST: unqualified references resolved at QUERY
 -- time — the `vector` type in `::vector` casts, the `<->`/`<=>` operators, `%` and
@@ -26,23 +35,65 @@
 -- moving so there is never a window where these resolve to nothing. (Our own
 -- functions were already pinned `..., extensions` by the 2026-06-02 sweep, which
 -- deliberately prepared for exactly this move.)
+--
+-- ATOMICITY: the role-search_path change, the extension move, and the verification
+-- run inside ONE DO block (a single statement). An unhandled error anywhere in that
+-- block rolls the WHOLE block back, so a failed move can NEVER leave the API roles'
+-- search_path changed without the move having happened. This holds whether or not
+-- the migration runner wraps the file in an outer transaction.
 -- =============================================================================
+
+-- 0. Ownership precheck — FAIL FAST before any change if the current role cannot
+--    ALTER these extensions. pg_has_role(current_user, owner, 'MEMBER') is true for
+--    the owner, members of the owner role, AND superusers.
+DO $precheck$
+DECLARE
+  r     RECORD;
+  v_bad TEXT := '';
+BEGIN
+  FOR r IN
+    SELECT x.extname, o.rolname AS owner
+    FROM pg_extension x
+    JOIN pg_namespace n ON n.oid = x.extnamespace
+    JOIN pg_roles o     ON o.oid = x.extowner
+    WHERE x.extname IN ('vector','ltree','pg_trgm') AND n.nspname = 'public'
+  LOOP
+    IF NOT pg_has_role(current_user, r.owner, 'MEMBER') THEN
+      v_bad := v_bad || format(' %s(owner=%s)', r.extname, r.owner);
+    END IF;
+  END LOOP;
+
+  IF v_bad <> '' THEN
+    RAISE EXCEPTION
+      'E ABORTED (no changes made): role "%" cannot ALTER EXTENSION — it must own the extension, be a member of the owner role, or be a superuser. Blocked:%. Apply migration 05 as supabase_admin via the Supabase Dashboard SQL Editor — NOT the postgres pooler.',
+      current_user, v_bad;
+  END IF;
+  RAISE NOTICE 'E precheck OK: role % can ALTER the target extensions.', current_user;
+END
+$precheck$;
 
 -- 1. Ensure target schema + usage grants (idempotent).
 CREATE SCHEMA IF NOT EXISTS extensions;
 GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
 
--- 2. Put `extensions` on the search_path of the API roles BEFORE the move.
---    (postgres already has `"$user", public, extensions`; we leave it untouched.)
-ALTER ROLE anon          SET search_path TO "$user", public, extensions;
-ALTER ROLE authenticated SET search_path TO "$user", public, extensions;
-ALTER ROLE service_role  SET search_path TO "$user", public, extensions;
-
--- 3. Relocate the three extensions (guarded so each is a no-op if already moved).
-DO $move$
+-- 2+3+4. ATOMIC: set the API roles' search_path FIRST, then relocate the three
+--    extensions, then verify — all inside one DO block so a failed move cannot leave
+--    the search_path changed.
+DO $apply$
 DECLARE
-  e TEXT;
+  e        TEXT;
+  v_bad    INTEGER;
+  v_detail TEXT;
 BEGIN
+  -- 2. search_path FIRST. ALTER ROLE ... SET search_path replaces ONLY the
+  --    search_path setting and preserves other per-role settings (e.g. the
+  --    statement_timeout currently set on anon/authenticated). Run via EXECUTE
+  --    because utility commands are not allowed as direct PL/pgSQL statements.
+  EXECUTE 'ALTER ROLE anon          SET search_path TO "$user", public, extensions';
+  EXECUTE 'ALTER ROLE authenticated SET search_path TO "$user", public, extensions';
+  EXECUTE 'ALTER ROLE service_role  SET search_path TO "$user", public, extensions';
+
+  -- 3. Relocate the three extensions (guarded so each is a no-op if already moved).
   FOREACH e IN ARRAY ARRAY['vector','ltree','pg_trgm'] LOOP
     IF EXISTS (
       SELECT 1 FROM pg_extension x JOIN pg_namespace n ON n.oid = x.extnamespace
@@ -54,23 +105,16 @@ BEGIN
       RAISE NOTICE 'E: extension % not in public (already moved or absent) — skipped', e;
     END IF;
   END LOOP;
-END
-$move$;
 
--- 4. Verification: none of the three remain in `public`.
-DO $verify$
-DECLARE
-  v_bad INTEGER;
-  v_detail TEXT;
-BEGIN
+  -- 4. Verification (same atomic block): none of the three remain in `public`.
   SELECT count(*), string_agg(x.extname, ', ')
     INTO v_bad, v_detail
   FROM pg_extension x JOIN pg_namespace n ON n.oid = x.extnamespace
   WHERE x.extname IN ('vector','ltree','pg_trgm') AND n.nspname = 'public';
 
   IF v_bad > 0 THEN
-    RAISE EXCEPTION 'E NOT cleared: % extension(s) still in public: %', v_bad, v_detail;
+    RAISE EXCEPTION 'E NOT cleared: % extension(s) still in public: % (whole block rolled back)', v_bad, v_detail;
   END IF;
   RAISE NOTICE 'E VERIFIED: vector/ltree/pg_trgm are no longer in public.';
 END
-$verify$;
+$apply$;

--- a/database/migrations/20260603_05_move_extensions_out_of_public_rollback.sql
+++ b/database/migrations/20260603_05_move_extensions_out_of_public_rollback.sql
@@ -4,8 +4,43 @@
 -- search_paths to their prior state (anon/authenticated/service_role had NO
 -- search_path override before migration E; postgres was never modified).
 -- Move FIRST (while extensions is still on the path), then reset the path.
+--
+-- !!! APPLY AS `supabase_admin` (the extension owner) OR A SUPERUSER — same as the
+-- !!! forward migration. The `postgres` pooler role cannot ALTER EXTENSION. The
+-- !!! ownership precheck (step 0) aborts cleanly (no changes) if it cannot.
+--
+-- ATOMICITY: the move-back and the search_path RESET run inside ONE DO block, so a
+-- failed move-back can never leave the search_path reset (or vice versa).
 -- =============================================================================
-DO $move$
+
+-- 0. Ownership precheck — fail fast (no changes) if current role cannot ALTER.
+DO $precheck$
+DECLARE
+  r     RECORD;
+  v_bad TEXT := '';
+BEGIN
+  FOR r IN
+    SELECT x.extname, o.rolname AS owner
+    FROM pg_extension x JOIN pg_roles o ON o.oid = x.extowner
+    WHERE x.extname IN ('vector','ltree','pg_trgm')
+  LOOP
+    IF NOT pg_has_role(current_user, r.owner, 'MEMBER') THEN
+      v_bad := v_bad || format(' %s(owner=%s)', r.extname, r.owner);
+    END IF;
+  END LOOP;
+
+  IF v_bad <> '' THEN
+    RAISE EXCEPTION
+      'ROLLBACK E ABORTED (no changes made): role "%" cannot ALTER EXTENSION — must own it, be a member of the owner role, or be a superuser. Blocked:%. Apply as supabase_admin via the Supabase Dashboard SQL Editor — NOT the postgres pooler.',
+      current_user, v_bad;
+  END IF;
+  RAISE NOTICE 'ROLLBACK E precheck OK: role % can ALTER the target extensions.', current_user;
+END
+$precheck$;
+
+-- ATOMIC: move back to public FIRST (while `extensions` is still on the path), then
+-- reset the API-role search_paths — all-or-nothing in one DO block.
+DO $apply$
 DECLARE
   e TEXT;
 BEGIN
@@ -18,10 +53,11 @@ BEGIN
       RAISE NOTICE 'ROLLBACK E: moved extension % extensions -> public', e;
     END IF;
   END LOOP;
-END
-$move$;
 
--- Restore prior role search_paths (these three roles had no override originally).
-ALTER ROLE anon          RESET search_path;
-ALTER ROLE authenticated RESET search_path;
-ALTER ROLE service_role  RESET search_path;
+  -- Restore prior role search_paths (these three roles had no override originally).
+  -- RESET removes only the search_path setting; preserves other per-role settings.
+  EXECUTE 'ALTER ROLE anon          RESET search_path';
+  EXECUTE 'ALTER ROLE authenticated RESET search_path';
+  EXECUTE 'ALTER ROLE service_role  RESET search_path';
+END
+$apply$;

--- a/database/migrations/supabase-linter-remediation.md
+++ b/database/migrations/supabase-linter-remediation.md
@@ -43,7 +43,19 @@ with **no relation members**, so the move is a clean metadata relocation — exi
 type/operator references resolve via `search_path` at query time, so the migration
 adds `extensions` to the API roles' path *before* moving. Still:
 
-- Apply it **in a maintenance window, after testing on a Supabase DB branch.**
+- **Apply as `supabase_admin` (or a superuser) — e.g. the Supabase Dashboard SQL
+  Editor.** vector/ltree/pg_trgm are owned by **`supabase_admin`, NOT `postgres`**
+  (re-verified read-only 2026-06-03), so the normal pooler `postgres` role **cannot**
+  `ALTER EXTENSION … SET SCHEMA`. The migration's **step-0 ownership precheck aborts
+  cleanly — before any change** — if run by a role that can't, with a message telling
+  you to use `supabase_admin`.
+- The role-`search_path` change, the move, and the verification run in **one atomic
+  DO block**, so a failed move can never leave the API roles' `search_path` changed
+  without the move having happened (`_rollback.sql` is hardened the same way).
+- Apply it **in a maintenance window, after testing on a Supabase DB branch**, and
+  **recycle the connection pooler** afterward — `ALTER ROLE … SET search_path` only
+  affects new connections, so pooled sessions opened before the move keep the old
+  path until recycled.
 - Afterwards, verify embedding queries (`<->`/`<=>`/`::vector`), `pg_trgm`
   similarity/`%`, and `ltree` operators, plus that new index creation works.
 - Apply **after** 01–04 are validated. Keep it as its own deploy step.


### PR DESCRIPTION
Implements **SD-LEO-INFRA-HARDEN-SUPABASE-LINTER-001** — a follow-up to SD-LEO-INFRA-SUPABASE-DATABASE-LINTER-001 (#4205).

A read-only de-risk (DB sub-agent, 2026-06-03) found migration 05 (move vector/ltree/pg_trgm out of `public`) would **fail mid-apply** under the `postgres` pooler role: the extensions are owned by `supabase_admin`, so `ALTER EXTENSION … SET SCHEMA` needs the owner/superuser, and the `ALTER ROLE search_path` change ran *before* the move with no transaction wrapper — a step-3 failure left the API-role `search_path` changed.

## Hardening
- **Step-0 ownership precheck** — aborts cleanly (no changes) via `pg_has_role(current_user, owner, 'MEMBER')` if the role can't `ALTER EXTENSION`, pointing to `supabase_admin`.
- **Atomicity** — the role `search_path` change + extension move + verification now run in **one DO block**, so a failed move can never leave `search_path` changed. The `_rollback.sql` (move-back + reset) is hardened the same way.
- **Docs** — the migration headers + `supabase-linter-remediation.md` now document the **apply-as-`supabase_admin` (Dashboard SQL Editor, not the postgres pooler)** requirement + the connection-pooling recycle note.

⚠️ Files-only — **not applied**. No change to 05's net effect (same move + verification assert); only adds the precheck + atomicity + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)