### PR TITLE
feat(SD-LEO-INFRA-STAGE-VISION-DRIFT-001): Stage-19 vision-drift producer + leo-drift-probe judge skill

### DIFF
--- a/.claude/commands/leo-drift-probe.md
+++ b/.claude/commands/leo-drift-probe.md
@@ -1,0 +1,114 @@
+<!-- reasoning_effort: high -->
+
+---
+description: Probe a leo_bridge venture's chairman-approved L2 vision for material DRIFT vs its S13-S19 blueprint artifacts BEFORE the SD tree is built (session-hosted judge; records a verdict, never advances/approves)
+argument-hint: [--venture-id <uuid> | --venture <name>] [--dry-run]
+---
+
+# /leo-drift-probe — vision-DRIFT JUDGE (session-hosted, input-side)
+
+You are the **session-hosted live judge** for the Stage-19 vision-DRIFT gate
+(SD-LEO-INFRA-STAGE-VISION-DRIFT-001, PR-2 of STAGE-VISION-ARTIFACT). This is the INPUT-side complement
+to `/leo-verify-venture`: that skill judges the BUILT venture against the vision AFTER the tree exists;
+**you judge BEFORE the tree is generated** — has the chairman-approved L2 vision materially DRIFTED from
+what the venture's own S13-S18 blueprint artifacts + S19 sprint plan actually describe? If yes, building
+the tree now would build the wrong thing.
+
+The pure GATHER + STORE logic lives in `lib/eva/bridge/venture-drift-prober.js`. You ARE the injected
+`driftProbe` judge, because comparing a vision against a venture's evolving artifacts needs live reading
+and reasoning that no headless loop can do. The headless `stage-execution-worker` S19 seam
+(`_evaluateVisionDriftHold`) READS the verdict you record and — only once `VISION_DRIFT_GATE` is enabled —
+HOLDs the venture on material drift. It is the worker, never you, that holds or advances.
+
+## ⚠️ NEVER-ADVANCE / NEVER-APPROVE invariant (RCA a14ff998 — the S19 gate-bypass incident)
+
+You MUST NOT, under any circumstance:
+- advance the venture, write `ventures.current_lifecycle_stage`, or call any `_advanceStage` path
+- create or approve a `chairman_decision`, set `chairman_approved`, or approve/modify a vision
+- mark the venture "drift-clear" by any means other than recording the verdict below
+
+The venture **stays at Stage 19** the entire time. Your only write is the recorded `vision_drift_verdict`
+(via `--record`). A `material_drift:false` verdict merely lets the worker's existing advance proceed (when
+the gate is enabled); a `material_drift:true` verdict HOLDs the venture for chairman reconciliation. You
+never advance.
+
+## Step 1 — Resolve the venture and introspect (ZERO writes)
+
+Determine the `<venture-id>` (from `--venture-id`, or resolve `--venture <name>` against `ventures.name`).
+Then introspect — this makes **zero writes**:
+
+```bash
+node lib/eva/bridge/venture-drift-prober.js --venture-id <venture-id> --dry-run
+```
+
+This prints `visionPresent`, `sprintPresent`, the current `vision_drift_verdict` (or `(none)`), and the
+gathered-input counts (vision `extracted_dimensions`, S13-S19 artifacts).
+
+- If `visionPresent` is false → **STOP**. There is no chairman-approved L2 vision to compare against; the
+  existing `VISION_MISSING` gate already owns that case. Do not record a verdict.
+- If the packet is incomplete (e.g. `sprintPresent` is false or the S13-S18 artifacts are too sparse to
+  judge) → record a **transient** `{ "packet_incomplete": true }` verdict (Step 3) and stop; do NOT guess
+  a drift value from an incomplete packet.
+- If a current verdict already exists and you were only asked to introspect (`--dry-run`) → report and stop.
+- Otherwise proceed to Step 2.
+
+## Step 2 — Judge drift across 4 dimensions (you ARE driftProbe)
+
+Read the chairman-approved L2 `eva_vision_documents` row's `extracted_dimensions` (each `{ name,
+description, weight }`) plus its `content` — the INTENDED venture. Then read the venture's actual S13-S19
+`venture_artifacts` (`is_current = true`): the blueprint artifacts (product roadmap, technical
+architecture, data model, positioning brief, etc.) and the S19 `blueprint_sprint_plan`. Ground every
+judgment in what the artifacts ACTUALLY say — not the SD titles or marketing copy.
+
+Score **material drift** on each of these 4 dimensions, with a one-line evidence string per dimension:
+
+| Dimension | Drift question |
+|-----------|----------------|
+| **value-proposition** | Does the sprint/blueprint still build the core value the vision promised, or has the problem/solution shifted? |
+| **target-user** | Is the venture still aimed at the vision's target user/segment, or have the artifacts drifted to a different audience? |
+| **technical-modality** | Does the technical architecture match the vision's intended modality (e.g. SaaS web app vs CLI vs agent/worker), per the EHG venture-hosting standard? |
+| **deployment-model** | Does the deployment/hosting plan match the vision (e.g. hosted SaaS vs on-prem/CLI), or has it drifted? |
+
+A dimension `drift: true` means the artifacts have materially diverged from the vision on that axis.
+
+**Decide overall**: `material_drift = true` if ANY load-bearing dimension drifted (the producer reduces
+your per-dimension output the same way: any `drift:true` → `material_drift:true`). For each drifted
+dimension, the operator should reconcile the vision and the artifacts before the tree is built.
+
+If your probe could not run cleanly (e.g. an LLM/tool failure mid-judgment), record `{ "board_unavailable":
+true }` rather than a guessed drift value — the gate routes that to a transient alert/retry, never the
+chairman.
+
+## Step 3 — Record the verdict (the only write)
+
+Write your judgment to a temp JSON and persist it through the canonical store (read-merge-write into
+`venture_stage_work.advisory_data.vision_drift_verdict` + a `system_events` audit row). The producer
+REDUCES your 4-dimension output to the gate's contract shape (`material_drift` / `board_unavailable` /
+`packet_incomplete`) — record the dimensions for observability and let the producer reduce:
+
+```bash
+# verdict.json — your judgment (the producer reduces dimensions[].drift to material_drift):
+# { "dimensions": [
+#     { "dimension": "value-proposition", "drift": false, "evidence": "Sprint plan still targets the vision's core job-to-be-done" },
+#     { "dimension": "target-user",       "drift": false, "evidence": "Personas in S14 match the L2 target segment" },
+#     { "dimension": "technical-modality","drift": true,  "evidence": "Tech arch (S14) specifies a CLI, but the vision is a hosted SaaS web app" },
+#     { "dimension": "deployment-model",  "drift": true,  "evidence": "Sprint plan deploys a local binary, not the vision's hosted deployment" }
+#   ],
+#   "evaluated_by": "leo-drift-probe" }
+node lib/eva/bridge/venture-drift-prober.js --venture-id <venture-id> --record verdict.json
+```
+
+This is a RECORD, not a headless judge (no `driftProbe` runs) — it never advances or approves. Delete the
+temp `verdict.json` afterward.
+
+## Step 4 — Report
+
+Summarize: the venture, the overall `material_drift` (or transient `board_unavailable` / `packet_incomplete`),
+the per-dimension evidence, and the drifted dimensions. Remind the operator:
+
+- On **no drift**: the recorded verdict lets the worker's existing advance proceed (when `VISION_DRIFT_GATE`
+  is enabled). The gate ships **default-OFF** (observe-first), so today the verdict is recorded for
+  observability only.
+- On **material drift**: reconcile the vision and the S13-S19 artifacts (re-brainstorm / re-vision, or
+  correct the blueprint) BEFORE building the tree. When the gate is enabled, the worker will HOLD the
+  venture at Stage 19 and route a material-drift hold to the chairman.

--- a/lib/eva/bridge/venture-drift-prober.js
+++ b/lib/eva/bridge/venture-drift-prober.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/**
+ * venture-drift-prober — the GATHER + STORE half of the Stage-19 vision-DRIFT gate (the PRODUCER).
+ *
+ * SD: SD-LEO-INFRA-STAGE-VISION-DRIFT-001 (PR-2 / FR-3 of STAGE-VISION-ARTIFACT). PR-1
+ * (SD-LEO-INFRA-STAGE-VISION-ARTIFACT-001, PR #4193) shipped the dormant pure DECISION layer
+ * `lib/eva/bridge/vision-drift-gate.js` (classifyVisionDrift / shouldHoldForVisionDrift) and the
+ * worker seam `_evaluateVisionDriftHold`. This module is the missing PRODUCER: it records the verdict
+ * the gate classifies, mirroring `venture-vision-verifier.js` (the OUTPUT-side acceptance producer).
+ *
+ * INPUT-side / pre-tree: this fires BEFORE the venture's SD tree is generated, judging whether the
+ * chairman-approved L2 vision has materially DRIFTED from the venture's S13-S18 blueprint artifacts +
+ * the S19 sprint plan. The per-venture JUDGMENT needs a live Claude session, so — exactly like the
+ * acceptance verifier's runVerify({ verifyVenture }) seam — the judge is INJECTED:
+ * runDriftProbe({ driftProbe }). The production judge is the `.claude/commands/leo-drift-probe` skill.
+ * The CLI here supports only `--dry-run` introspection and `--record <file>` (it refuses to judge headlessly).
+ *
+ * The recorded verdict lives at venture_stage_work.advisory_data.vision_drift_verdict (lifecycle_stage=19)
+ * and is set-only-one-key (read-merge-write spread; never clobbers a sibling vision_acceptance_verdict).
+ * No schema change — advisory_data is an existing JSONB column. The verdict shape is pinned to the
+ * vision-drift-gate.js contract: exactly one of { material_drift:boolean | board_unavailable:true |
+ * packet_incomplete:true }. The 4-dimension judge output is REDUCED to that contract by
+ * normalizeDriftVerdict BEFORE storing — storing raw per-dimension scores would make classifyVisionDrift
+ * return NOT_EVALUATED on every verdict and the gate a permanent no-op.
+ *
+ * NEVER-ADVANCE invariant (RCA a14ff998 — the S19 gate-bypass incident). This module:
+ *   - NEVER advances the venture, adds an advance path, or writes the venture lifecycle stage column
+ *   - NEVER creates/approves a governance decision and NEVER approves a vision
+ *   - performs PURE database reads when gathering; the only write is advisory_data.vision_drift_verdict.
+ * An executable static-source guardrail test enforces this invariant AND forbids any background
+ * timer/cron entrypoint (the producer is session-hosted, never a daemon).
+ *
+ * Usage:
+ *   node lib/eva/bridge/venture-drift-prober.js --venture-id <uuid> --dry-run   # introspect, ZERO writes
+ *   (a real drift-probe is session-hosted: invoke the /leo-drift-probe skill in a live Claude session)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import pg from 'pg';
+import { summarizeArtifacts } from '../artifact-enrichment-pipeline.js';
+import { ARTIFACT_TYPES } from '../artifact-types.js';
+
+export const S19 = 19;
+/** S13 is the first Blueprint stage; the drift corpus is the S13-S19 is_current artifacts. */
+export const BLUEPRINT_STAGE_MIN = 13;
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+function buildPgClient() {
+  const conn = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.POSTGRES_URL;
+  if (!conn) return null; // graceful — no PG conn → marker/last-writer semantics (still read-merge-write)
+  return new pg.Client({ connectionString: conn });
+}
+
+async function tryAdvisoryLock(client, name) {
+  if (!client) return { acquired: true, mock: true }; // no client → no real lock; read-merge-write still applies
+  const k = await client.query('SELECT hashtext($1)::int AS k', [name]);
+  const r = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [k.rows[0].k]);
+  return { acquired: r.rows[0].acquired === true, key: k.rows[0].k, mock: false };
+}
+
+async function releaseAdvisoryLock(client, key) {
+  if (!client || key == null) return;
+  try { await client.query('SELECT pg_advisory_unlock($1)', [key]); } catch { /* best-effort */ }
+}
+
+/**
+ * PURE read-only gather of the drift-probe inputs: the chairman-approved L2 vision dimensions plus the
+ * venture's S13-S19 is_current blueprint artifacts (incl. the S19 sprint plan). Never mutates; never
+ * executes repo/deployment code. The LLM-backed `summarize` is INJECTED (default summarizeArtifacts) so
+ * the gather stays unit-testable and the dry-run path can skip summarization entirely.
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @param {{summarize?: Function|null, logger?: object}} [opts]
+ * @returns {Promise<object>} inputs for the judge
+ */
+export async function gatherDriftInputs(supabase, ventureId, { summarize, logger = console } = {}) {
+  // Chairman-approved L2 vision — the drift baseline (extracted_dimensions are the "intended" venture).
+  const { data: vision } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, version, content, updated_at, extracted_dimensions')
+    .eq('venture_id', ventureId)
+    .eq('level', 'L2')
+    .eq('status', 'active')
+    .eq('chairman_approved', true)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const { data: venture } = await supabase
+    .from('ventures')
+    .select('name')
+    .eq('id', ventureId)
+    .maybeSingle();
+
+  // S13-S19 is_current artifacts — the venture's actual blueprint/sprint decisions to compare vs vision.
+  const { data: artifactRows } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, lifecycle_stage, title, content, artifact_data, updated_at')
+    .eq('venture_id', ventureId)
+    .eq('is_current', true)
+    .gte('lifecycle_stage', BLUEPRINT_STAGE_MIN)
+    .lte('lifecycle_stage', S19);
+  const artifacts = artifactRows || [];
+  const sprintPresent = artifacts.some((a) => a.artifact_type === ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN);
+
+  // Optional LLM-backed compression of the artifact corpus for the judge (injectable; skipped on dry-run).
+  let artifactSummaries = null;
+  if (typeof summarize === 'function' && artifacts.length) {
+    try {
+      const map = await summarize(supabase, ventureId, artifacts, { logger });
+      artifactSummaries = map instanceof Map ? Object.fromEntries(map) : (map || null);
+    } catch (err) {
+      logger?.warn?.(`[drift] summarizeArtifacts failed (non-fatal, judge falls back to raw): ${err.message}`);
+    }
+  }
+
+  return {
+    visionPresent: !!vision,
+    visionDimensions: vision?.extracted_dimensions || [],
+    visionKey: vision?.vision_key || null,
+    visionContent: vision?.content || null,
+    ventureName: venture?.name || null,
+    sprintPresent,
+    // Lightweight artifact descriptors (no heavy content) — the judge reads summaries or re-fetches.
+    artifacts: artifacts.map((a) => ({ artifact_type: a.artifact_type, lifecycle_stage: a.lifecycle_stage, title: a.title || null })),
+    artifactSummaries,
+  };
+}
+
+async function readStageWork(supabase, ventureId) {
+  const { data } = await supabase
+    .from('venture_stage_work')
+    .select('id, advisory_data')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', S19)
+    .maybeSingle();
+  return data || null;
+}
+
+/**
+ * Append-only audit row for a recorded drift verdict. system_events has NO event_data column — dual-write
+ * to payload + details (mirrors _emitS19HardGateEvent). Best-effort + non-fatal.
+ */
+async function emitVerdictEvent(supabase, ventureId, verdict) {
+  try {
+    const stamp = verdict.evaluated_at || new Date().toISOString();
+    const payload = {
+      venture_id: ventureId, from_stage: S19, build_model: 'leo_bridge',
+      material_drift: verdict.material_drift ?? null,
+      board_unavailable: verdict.board_unavailable === true,
+      packet_incomplete: verdict.packet_incomplete === true,
+      evaluated_by: verdict.evaluated_by,
+    };
+    await supabase.from('system_events').insert({
+      event_type: 'VISION_DRIFT_VERDICT',
+      venture_id: ventureId,
+      idempotency_key: `VISION_DRIFT_VERDICT:${ventureId}:${Date.parse(stamp)}`,
+      payload,
+      details: payload,
+      created_at: stamp,
+    });
+  } catch { /* audit is best-effort, non-fatal */ }
+}
+
+/**
+ * Read-merge-write the verdict into venture_stage_work.advisory_data.vision_drift_verdict — set ONLY the
+ * verdict key, never clobber sibling S19 keys (vision_acceptance_verdict / reason / bridge_failed).
+ * Guarded by a per-venture advisory lock `vision-drift:${ventureId}` (DISTINCT from the acceptance
+ * verifier's `vision-verify:${ventureId}`) when a PG connection is available; marker/last-writer
+ * otherwise. Plus the append-only system_events audit row.
+ */
+async function storeVerdict({ supabase, pgClient, ventureId, verdict, logger }) {
+  const client = pgClient !== undefined ? pgClient : buildPgClient();
+  let connected = false;
+  let lockKey = null;
+  try {
+    if (client && typeof client.connect === 'function') {
+      try { await client.connect(); connected = true; } catch { /* fall back to read-merge-write */ }
+    }
+    const lock = await tryAdvisoryLock(connected ? client : null, `vision-drift:${ventureId}`);
+    lockKey = lock.key;
+
+    const row = await readStageWork(supabase, ventureId);
+    const merged = { ...(row?.advisory_data || {}), vision_drift_verdict: verdict };
+    if (row?.id) {
+      await supabase.from('venture_stage_work').update({ advisory_data: merged }).eq('id', row.id);
+    } else {
+      await supabase.from('venture_stage_work').insert({ venture_id: ventureId, lifecycle_stage: S19, advisory_data: merged });
+    }
+    await emitVerdictEvent(supabase, ventureId, verdict);
+  } finally {
+    if (connected) {
+      await releaseAdvisoryLock(client, lockKey);
+      try { await client.end(); } catch { /* best-effort */ }
+    }
+  }
+  const tag = verdict.material_drift === true ? 'material_drift'
+    : verdict.board_unavailable ? 'board_unavailable'
+    : verdict.packet_incomplete ? 'packet_incomplete' : 'no_drift';
+  logger?.log?.(`[drift] recorded vision_drift_verdict (${tag}) for venture ${ventureId}`);
+}
+
+/**
+ * Coerce a raw judge verdict into the gate's contract shape — the single most load-bearing step (the
+ * vision-drift-gate.js classifier reads ONLY material_drift / board_unavailable / packet_incomplete).
+ *
+ *   - Transient signals win FIRST: if the probe could not run cleanly ({ board_unavailable:true }) or
+ *     the read-in packet was incomplete ({ packet_incomplete:true }), the per-dimension drift values are
+ *     unreliable and must not be trusted — return the transient verdict.
+ *   - Otherwise REDUCE the 4-dimension output to a single material_drift boolean: an explicit boolean
+ *     wins; else material_drift = ANY dimension drifted (dimensions[].drift === true).
+ *   - NEVER coerce an unknown/empty probe result to material_drift:false (the undefined-vs-false
+ *     distinction is load-bearing — a silent false would advance an un-vetted vision). An unusable
+ *     result degrades to board_unavailable (transient), never NO_DRIFT.
+ *
+ * @param {object|null|undefined} raw
+ * @returns {{material_drift?:boolean, board_unavailable?:true, packet_incomplete?:true, dimensions:Array, evaluated_at:string, evaluated_by:string}}
+ */
+export function normalizeDriftVerdict(raw) {
+  const base = {
+    dimensions: Array.isArray(raw?.dimensions) ? raw.dimensions : [],
+    evaluated_at: raw?.evaluated_at || new Date().toISOString(),
+    evaluated_by: raw?.evaluated_by || 'leo-drift-probe',
+  };
+  if (raw?.board_unavailable === true) return { board_unavailable: true, ...base };
+  if (raw?.packet_incomplete === true) return { packet_incomplete: true, ...base };
+
+  let material;
+  if (typeof raw?.material_drift === 'boolean') material = raw.material_drift;
+  else if (base.dimensions.length) material = base.dimensions.some((d) => d?.drift === true);
+  else material = undefined;
+
+  if (typeof material !== 'boolean') return { board_unavailable: true, ...base }; // never silent-false
+  return { material_drift: material, ...base };
+}
+
+/**
+ * Gather the vision + S13-S19 artifacts, run the INJECTED judge, REDUCE its output to the contract
+ * verdict, and record it.
+ *
+ *   - dryRun=true OR no driftProbe injected → introspect only (gather + read current verdict), ZERO
+ *     writes, NEVER invokes the judge. This is the read-only CLI path (summarization is skipped).
+ *   - no chairman-approved L2 vision → skip (defer to the existing VISION_MISSING gate); never record.
+ *   - otherwise → judged = driftProbe(visionDimensions, packet); verdict = normalizeDriftVerdict(judged);
+ *     read-merge-write store under the vision-drift advisory lock.
+ *
+ * The judge signature: driftProbe(visionDimensions, packet) ->
+ *   { material_drift?:boolean, dimensions?:[{dimension, drift, evidence}], board_unavailable?, packet_incomplete?, evaluated_by? }.
+ *
+ * @param {{supabase:object, ventureId:string, driftProbe?:Function, dryRun?:boolean, logger?:object, pgClient?:any, summarize?:Function|null}} args
+ */
+export async function runDriftProbe({ supabase, ventureId, driftProbe, dryRun = false, logger = console, pgClient = undefined, summarize = summarizeArtifacts }) {
+  if (!ventureId) throw new Error('runDriftProbe: ventureId required');
+
+  // Skip the LLM summarizer on the read-only introspection path (keep dry-run cheap + side-effect-free).
+  const inputs = await gatherDriftInputs(supabase, ventureId, { summarize: dryRun ? undefined : summarize, logger });
+  const stageWork = await readStageWork(supabase, ventureId);
+  const currentVerdict = stageWork?.advisory_data?.vision_drift_verdict ?? null;
+
+  if (dryRun || typeof driftProbe !== 'function') {
+    return { dryRun: true, wrote: false, ventureId, visionPresent: inputs.visionPresent, sprintPresent: inputs.sprintPresent, currentVerdict, inputs };
+  }
+
+  if (!inputs.visionPresent) {
+    logger?.warn?.(`[drift] venture ${ventureId}: no chairman-approved L2 vision — skipping (defer to VISION_MISSING gate)`);
+    return { dryRun: false, wrote: false, skipped: true, reason: 'no_approved_l2_vision', ventureId };
+  }
+
+  const judged = await driftProbe(inputs.visionDimensions, {
+    visionKey: inputs.visionKey, visionContent: inputs.visionContent,
+    artifacts: inputs.artifacts, artifactSummaries: inputs.artifactSummaries,
+    sprintPresent: inputs.sprintPresent, ventureName: inputs.ventureName,
+  });
+
+  const verdict = normalizeDriftVerdict(judged);
+  await storeVerdict({ supabase, pgClient, ventureId, verdict, logger });
+  return { dryRun: false, wrote: true, ventureId, verdict };
+}
+
+/**
+ * Persist a verdict the live judge (the /leo-drift-probe skill) has ALREADY produced — through the same
+ * canonical read-merge-write store + audit + normalize as runDriftProbe. This is NOT headless judging
+ * (no driftProbe is invoked); it only records the session-hosted judgment. Never advances/approves.
+ * @param {{supabase:object, ventureId:string, verdict:object, pgClient?:any, logger?:object}} args
+ */
+export async function recordVerdict({ supabase, ventureId, verdict, pgClient = undefined, logger = console }) {
+  if (!ventureId) throw new Error('recordVerdict: ventureId required');
+  const normalized = normalizeDriftVerdict(verdict);
+  await storeVerdict({ supabase, pgClient, ventureId, verdict: normalized, logger });
+  return { wrote: true, ventureId, verdict: normalized };
+}
+
+function parseArgs(argv) {
+  const a = { ventureId: null, dryRun: false, record: null, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const x = argv[i];
+    if (x === '--venture-id' && argv[i + 1]) a.ventureId = argv[++i];
+    else if (x === '--dry-run') a.dryRun = true;
+    else if (x === '--record' && argv[i + 1]) a.record = argv[++i];
+    else if (x === '--help' || x === '-h') a.help = true;
+  }
+  return a;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.ventureId) {
+    console.log('Usage: node lib/eva/bridge/venture-drift-prober.js --venture-id <uuid> [--dry-run | --record <verdict.json>]');
+    console.log('  --dry-run         introspect the recorded vision_drift_verdict + gathered inputs (ZERO writes).');
+    console.log('  --record <file>   persist a verdict the live /leo-drift-probe judge already produced (read-merge-write + audit).');
+    console.log('  A real drift-probe is session-hosted: invoke the /leo-drift-probe skill in a live Claude session.');
+    process.exit(args.ventureId ? 0 : 2);
+  }
+  const supabase = buildSupabase();
+  if (args.record) {
+    // Persist a verdict the live session-hosted judge already produced. RECORDS (read-merge-write +
+    // audit) — does NOT judge headlessly (no driftProbe is invoked) and never advances/approves.
+    const fs = await import('fs');
+    const raw = JSON.parse(fs.readFileSync(args.record, 'utf8'));
+    const res = await recordVerdict({ supabase, ventureId: args.ventureId, verdict: raw });
+    const v = res.verdict;
+    const tag = v.material_drift === true ? 'material_drift' : v.board_unavailable ? 'board_unavailable' : v.packet_incomplete ? 'packet_incomplete' : 'no_drift';
+    console.log(`Recorded vision_drift_verdict (${tag}) for venture ${args.ventureId}`);
+    process.exit(0);
+  }
+  if (!args.dryRun) {
+    // The drift JUDGE is a live Claude session (the /leo-drift-probe skill); the CLI refuses to judge
+    // headlessly (there is no headless judge). Only --dry-run introspection is supported.
+    console.error('Refusing headless drift-probe: the live judge is session-hosted (/leo-drift-probe). Re-run with --dry-run to introspect.');
+    process.exit(2);
+  }
+  const res = await runDriftProbe({ supabase, ventureId: args.ventureId, dryRun: true });
+  console.log(JSON.stringify({
+    ventureId: res.ventureId,
+    visionPresent: res.visionPresent,
+    sprintPresent: res.sprintPresent,
+    currentVerdict: res.currentVerdict || '(none)',
+    gatheredInputs: {
+      visionDimensions: Array.isArray(res.inputs?.visionDimensions) ? res.inputs.visionDimensions.length : 0,
+      artifacts: Array.isArray(res.inputs?.artifacts) ? res.inputs.artifacts.length : 0,
+      sprintPresent: res.inputs?.sprintPresent || false,
+    },
+  }, null, 2));
+  process.exit(0);
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('lib/eva/bridge/venture-drift-prober.js');
+if (invokedDirectly) {
+  main().catch((err) => { console.error(`[drift] fatal: ${err.message}`); process.exit(2); });
+}

--- a/scripts/eva/backfill-vision-drift-marker.mjs
+++ b/scripts/eva/backfill-vision-drift-marker.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * FR-5 — one-time SET-ONCE drift-check-required backfill marker (SD-LEO-INFRA-STAGE-VISION-DRIFT-001).
+ *
+ * Ventures already parked at Stage 19 before the vision-drift producer shipped have no
+ * vision_drift_verdict, so they are invisible to the (dormant) drift gate. This backfill marks each such
+ * venture as drift-check-required so an operator/skill can run /leo-drift-probe on it — WITHOUT writing a
+ * verdict (a verdict would short-circuit the judge).
+ *
+ * SET-ONCE / idempotent (testing-agent condition C3): a venture is a candidate ONLY when
+ *   lifecycle_stage = 19 AND advisory_data.vision_drift_verdict IS NULL AND advisory_data.vision_drift_check_required IS NULL.
+ * The marker is written via read-merge-write spread (never clobbers sibling advisory_data keys, e.g. a
+ * vision_acceptance_verdict). Re-running is a no-op: an already-marked or already-evaluated venture is skipped.
+ *
+ * This script NEVER advances a venture and NEVER writes lifecycle_stage / governance — it only sets the
+ * advisory_data.vision_drift_check_required marker.
+ *
+ * Usage:
+ *   node scripts/eva/backfill-vision-drift-marker.mjs            # dry-run (default): report candidates, ZERO writes
+ *   node scripts/eva/backfill-vision-drift-marker.mjs --apply    # write the marker to candidates
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+export const S19 = 19;
+export const MARKER_KEY = 'vision_drift_check_required';
+export const VERDICT_KEY = 'vision_drift_verdict';
+
+/**
+ * Scan S19 ventures and (when apply=true) set the SET-ONCE drift-check-required marker on those with
+ * neither a recorded verdict nor an existing marker. Pure of advance/governance writes.
+ *
+ * @param {{supabase:object, apply?:boolean, nowIso?:string, logger?:object}} args
+ * @returns {Promise<{scanned:number, marked:number, skipped:number, candidates:string[]}>}
+ */
+export async function backfillDriftCheckMarker({ supabase, apply = false, nowIso, logger = console }) {
+  const { data: rows, error } = await supabase
+    .from('venture_stage_work')
+    .select('id, venture_id, advisory_data')
+    .eq('lifecycle_stage', S19);
+  if (error) throw new Error(`backfill: read venture_stage_work failed: ${error.message}`);
+
+  const result = { scanned: (rows || []).length, marked: 0, skipped: 0, candidates: [] };
+  const stamp = nowIso || new Date().toISOString();
+
+  for (const row of (rows || [])) {
+    const adv = row.advisory_data || {};
+    // SET-ONCE predicate: skip if already evaluated OR already marked.
+    if (adv[VERDICT_KEY] != null || adv[MARKER_KEY] != null) { result.skipped++; continue; }
+    result.candidates.push(row.venture_id);
+    if (!apply) continue;
+    const merged = { ...adv, [MARKER_KEY]: { requested_at: stamp, reason: 's19-backfill', set_by: 'backfill-vision-drift-marker' } };
+    const { error: upErr } = await supabase.from('venture_stage_work').update({ advisory_data: merged }).eq('id', row.id);
+    if (upErr) { logger?.warn?.(`[backfill] mark failed for venture ${row.venture_id}: ${upErr.message}`); continue; }
+    result.marked++;
+  }
+  return result;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = buildSupabase();
+  const res = await backfillDriftCheckMarker({ supabase, apply });
+  console.log(JSON.stringify({ mode: apply ? 'apply' : 'dry-run', ...res }, null, 2));
+  if (!apply && res.candidates.length) {
+    console.log(`\n${res.candidates.length} S19 venture(s) would be marked drift-check-required. Re-run with --apply to write.`);
+  }
+  process.exit(0);
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('scripts/eva/backfill-vision-drift-marker.mjs');
+if (invokedDirectly) {
+  main().catch((err) => { console.error(`[backfill] fatal: ${err.message}`); process.exit(2); });
+}

--- a/tests/unit/eva/backfill-vision-drift-marker.test.js
+++ b/tests/unit/eva/backfill-vision-drift-marker.test.js
@@ -1,0 +1,78 @@
+/**
+ * SD-LEO-INFRA-STAGE-VISION-DRIFT-001 (FR-5) — S19 drift-check-required backfill marker.
+ * TS-5: SET-ONCE idempotency — second run is a no-op; siblings preserved; predicate is
+ * lifecycle_stage=19 AND vision_drift_verdict IS NULL AND no existing marker (testing-agent C3).
+ */
+import { describe, it, expect } from 'vitest';
+import { backfillDriftCheckMarker, MARKER_KEY } from '../../../scripts/eva/backfill-vision-drift-marker.mjs';
+
+// Stateful Supabase mock: select().eq() reads state; update().eq('id',..) mutates the matching row.
+function makeStatefulMock(rows) {
+  const state = rows;
+  function builder() {
+    let pendingUpdate = null;
+    const b = {
+      select() { return b; },
+      eq(col, val) {
+        if (pendingUpdate) {
+          const row = state.find((r) => r.id === val);
+          if (row) row.advisory_data = pendingUpdate.advisory_data;
+          pendingUpdate = null;
+          return Promise.resolve({ error: null });
+        }
+        return b; // select filter (e.g. lifecycle_stage=19)
+      },
+      update(payload) { pendingUpdate = payload; return b; },
+      then(onF, onR) { return Promise.resolve({ data: state.map((r) => ({ ...r })), error: null }).then(onF, onR); },
+    };
+    return b;
+  }
+  return { from: () => builder(), __state: state };
+}
+
+describe('backfillDriftCheckMarker (FR-5, TS-5)', () => {
+  it('TS-5: SET-ONCE idempotent — marks candidates once, second run is a no-op, siblings preserved', async () => {
+    const rows = [
+      { id: 'sw1', venture_id: 'v1', advisory_data: {} },                                              // candidate
+      { id: 'sw2', venture_id: 'v2', advisory_data: { vision_drift_verdict: { material_drift: false } } }, // already evaluated → skip
+      { id: 'sw3', venture_id: 'v3', advisory_data: { vision_acceptance_verdict: { pass: true } } },       // candidate w/ sibling
+    ];
+    const supabase = makeStatefulMock(rows);
+
+    const r1 = await backfillDriftCheckMarker({ supabase, apply: true, nowIso: '2026-06-03T00:00:00Z' });
+    expect(r1.scanned).toBe(3);
+    expect(r1.marked).toBe(2);
+    expect(r1.skipped).toBe(1);
+
+    const sw3 = supabase.__state.find((r) => r.id === 'sw3');
+    expect(sw3.advisory_data.vision_acceptance_verdict).toEqual({ pass: true }); // sibling preserved
+    expect(sw3.advisory_data[MARKER_KEY].reason).toBe('s19-backfill');
+
+    // SET-ONCE: a second apply run marks nothing and does not bump the timestamp
+    const r2 = await backfillDriftCheckMarker({ supabase, apply: true, nowIso: '2026-06-04T00:00:00Z' });
+    expect(r2.marked).toBe(0);
+    expect(r2.skipped).toBe(3);
+    const sw1 = supabase.__state.find((r) => r.id === 'sw1');
+    expect(sw1.advisory_data[MARKER_KEY].requested_at).toBe('2026-06-03T00:00:00Z');
+  });
+
+  it('dry-run (apply=false) reports candidates but writes nothing', async () => {
+    const rows = [{ id: 'sw1', venture_id: 'v1', advisory_data: {} }];
+    const supabase = makeStatefulMock(rows);
+    const r = await backfillDriftCheckMarker({ supabase, apply: false });
+    expect(r.candidates).toEqual(['v1']);
+    expect(r.marked).toBe(0);
+    expect(supabase.__state[0].advisory_data[MARKER_KEY]).toBeUndefined();
+  });
+
+  it('predicate excludes non-candidates: already-evaluated and already-marked rows are skipped', async () => {
+    const rows = [
+      { id: 'sw1', venture_id: 'v1', advisory_data: { vision_drift_verdict: { board_unavailable: true } } },
+      { id: 'sw2', venture_id: 'v2', advisory_data: { [MARKER_KEY]: { requested_at: 'x' } } },
+    ];
+    const supabase = makeStatefulMock(rows);
+    const r = await backfillDriftCheckMarker({ supabase, apply: true });
+    expect(r.marked).toBe(0);
+    expect(r.skipped).toBe(2);
+  });
+});

--- a/tests/unit/eva/bridge/venture-drift-prober.test.js
+++ b/tests/unit/eva/bridge/venture-drift-prober.test.js
@@ -1,0 +1,261 @@
+/**
+ * SD-LEO-INFRA-STAGE-VISION-DRIFT-001 (PR-2) — venture-drift-prober (the PRODUCER) tests.
+ * TS-1..TS-10 from the PRD test_scenarios. Verifies the producer records a verdict the dormant PR-1
+ * vision-drift-gate.js classifier can read, with the load-bearing 4-dim -> {material_drift} reduction
+ * (C1), set-only-one-key spread-merge (C2), the vision-drift advisory lock (C2), and the never-advance /
+ * session-only static guardrail (C4, FR-6).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import {
+  normalizeDriftVerdict,
+  runDriftProbe,
+  recordVerdict,
+  gatherDriftInputs,
+} from '../../../../lib/eva/bridge/venture-drift-prober.js';
+import {
+  classifyVisionDrift,
+  shouldHoldForVisionDrift,
+  isVisionDriftGateEnabled,
+  VISION_DRIFT,
+  DRIFT_HOLD_CAUSE,
+} from '../../../../lib/eva/bridge/vision-drift-gate.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PRODUCER_PATH = resolve(__dirname, '../../../../lib/eva/bridge/venture-drift-prober.js');
+
+// ── Minimal Supabase mock (chainable + thenable) ─────────────────────────────
+function makeMockSupabase(fixtures = {}) {
+  const writes = { updates: [], inserts: [] };
+  function builder(table) {
+    const b = {
+      select() { return b; },
+      eq() { return b; },
+      gte() { return b; },
+      lte() { return b; },
+      order() { return b; },
+      limit() { return b; },
+      maybeSingle() {
+        if (table === 'eva_vision_documents') return Promise.resolve({ data: fixtures.eva_vision_documents ?? null, error: null });
+        if (table === 'ventures') return Promise.resolve({ data: fixtures.ventures ?? null, error: null });
+        if (table === 'venture_stage_work') return Promise.resolve({ data: fixtures.venture_stage_work ?? null, error: null });
+        return Promise.resolve({ data: null, error: null });
+      },
+      update(payload) {
+        return { eq: () => { writes.updates.push({ table, payload }); return Promise.resolve({ error: null }); } };
+      },
+      insert(payload) { writes.inserts.push({ table, payload }); return Promise.resolve({ error: null }); },
+      // thenable: supports `await supabase.from('venture_artifacts').select()...lte()` (no maybeSingle)
+      then(onF, onR) {
+        const data = table === 'venture_artifacts' ? (fixtures.venture_artifacts ?? []) : null;
+        return Promise.resolve({ data, error: null }).then(onF, onR);
+      },
+    };
+    return b;
+  }
+  const supabase = { from: (t) => builder(t), __writes: writes };
+  return supabase;
+}
+
+function makeMockPg(record = {}) {
+  return {
+    connect: async () => {},
+    query: async (sql, params) => {
+      if (sql.includes('hashtext')) { record.lockName = params[0]; return { rows: [{ k: 4242 }] }; }
+      if (sql.includes('pg_try_advisory_lock')) return { rows: [{ acquired: true }] };
+      return { rows: [{}] };
+    },
+    end: async () => {},
+    __record: record,
+  };
+}
+
+const VENTURE = '510177ba-0000-0000-0000-000000000000';
+const visionFixture = { vision_key: 'vk', version: 2, content: 'hosted SaaS', updated_at: '2026-06-01', extracted_dimensions: [{ name: 'v', description: 'd', weight: 1 }] };
+
+// ── TS-1: 4-dimension judge output reduced to {material_drift} (C1) ───────────
+describe('normalizeDriftVerdict — C1 reducer (TS-1, TS-2, TS-7)', () => {
+  it('TS-1: any dimension drift===true reduces to { material_drift:true } (not the raw dims)', () => {
+    const v = normalizeDriftVerdict({ dimensions: [
+      { dimension: 'value-proposition', drift: false },
+      { dimension: 'technical-modality', drift: true },
+    ] });
+    expect(v.material_drift).toBe(true);
+    expect(classifyVisionDrift(v)).toBe(VISION_DRIFT.MATERIAL_DRIFT);
+    // the raw per-dimension object must NOT be what the gate classifies
+    expect(typeof v.material_drift).toBe('boolean');
+  });
+
+  it('TS-1b: all dimensions false reduces to { material_drift:false } → NO_DRIFT', () => {
+    const v = normalizeDriftVerdict({ dimensions: [{ drift: false }, { drift: false }] });
+    expect(v.material_drift).toBe(false);
+    expect(classifyVisionDrift(v)).toBe(VISION_DRIFT.NO_DRIFT);
+  });
+
+  it('TS-1c: explicit material_drift boolean wins over dimensions', () => {
+    expect(normalizeDriftVerdict({ material_drift: true, dimensions: [{ drift: false }] }).material_drift).toBe(true);
+  });
+
+  it('TS-2: { board_unavailable:true } passes through (transient), NOT coerced to material_drift', () => {
+    const v = normalizeDriftVerdict({ board_unavailable: true, dimensions: [{ drift: false }] });
+    expect(v.board_unavailable).toBe(true);
+    expect(v.material_drift).toBeUndefined();
+    expect(classifyVisionDrift(v)).toBe(VISION_DRIFT.BOARD_UNAVAILABLE);
+  });
+
+  it('TS-2b: { packet_incomplete:true } passes through (transient)', () => {
+    const v = normalizeDriftVerdict({ packet_incomplete: true });
+    expect(v.packet_incomplete).toBe(true);
+    expect(classifyVisionDrift(v)).toBe(VISION_DRIFT.PACKET_INCOMPLETE);
+  });
+
+  it('TS-7: empty/unusable judge result degrades to board_unavailable — NEVER a silent material_drift:false', () => {
+    for (const raw of [null, undefined, {}, { dimensions: [] }, { material_drift: 'yes' }]) {
+      const v = normalizeDriftVerdict(raw);
+      expect(v.material_drift, JSON.stringify(raw)).toBeUndefined();
+      expect(v.board_unavailable, JSON.stringify(raw)).toBe(true);
+      // crucially: the gate must NOT see NO_DRIFT for an unusable probe
+      expect(classifyVisionDrift(v)).not.toBe(VISION_DRIFT.NO_DRIFT);
+    }
+  });
+
+  it('transient wins even when a drift value is also present (probe value untrusted)', () => {
+    const v = normalizeDriftVerdict({ board_unavailable: true, material_drift: true });
+    expect(v.board_unavailable).toBe(true);
+    expect(v.material_drift).toBeUndefined();
+  });
+});
+
+// ── TS-3 / TS-4 / TS-9: storeVerdict via recordVerdict ───────────────────────
+describe('recordVerdict — store contract (TS-3, TS-4, TS-9)', () => {
+  it('TS-3: spread-merge preserves sibling advisory_data keys (vision_acceptance_verdict, reason)', async () => {
+    const supabase = makeMockSupabase({ venture_stage_work: { id: 'sw1', advisory_data: { vision_acceptance_verdict: { pass: true }, reason: 'pending' } } });
+    await recordVerdict({ supabase, ventureId: VENTURE, verdict: { material_drift: true }, pgClient: null });
+    const upd = supabase.__writes.updates.find((u) => u.table === 'venture_stage_work');
+    expect(upd).toBeTruthy();
+    expect(upd.payload.advisory_data.vision_acceptance_verdict).toEqual({ pass: true });
+    expect(upd.payload.advisory_data.reason).toBe('pending');
+    expect(upd.payload.advisory_data.vision_drift_verdict.material_drift).toBe(true);
+  });
+
+  it('TS-4: advisory lock name is vision-drift:${ventureId} (NOT vision-verify)', async () => {
+    const supabase = makeMockSupabase({ venture_stage_work: { id: 'sw1', advisory_data: {} } });
+    const rec = {};
+    const pgClient = makeMockPg(rec);
+    await recordVerdict({ supabase, ventureId: VENTURE, verdict: { material_drift: false }, pgClient });
+    expect(rec.lockName).toBe(`vision-drift:${VENTURE}`);
+    expect(rec.lockName).not.toContain('vision-verify');
+  });
+
+  it('TS-9: producer-written verdict drives the PR-1 gate to HOLD/chairman', async () => {
+    const supabase = makeMockSupabase({ venture_stage_work: { id: 'sw1', advisory_data: {} } });
+    // judge flags technical-modality drift; producer reduces to material_drift:true
+    const res = await recordVerdict({ supabase, ventureId: VENTURE, verdict: { dimensions: [{ dimension: 'technical-modality', drift: true }] }, pgClient: null });
+    const decision = shouldHoldForVisionDrift({ verdict: res.verdict });
+    expect(decision.hold).toBe(true);
+    expect(decision.cause).toBe(DRIFT_HOLD_CAUSE.CHAIRMAN);
+  });
+
+  it('inserts a new stage-work row when none exists (set-only-one-key)', async () => {
+    const supabase = makeMockSupabase({ venture_stage_work: null });
+    await recordVerdict({ supabase, ventureId: VENTURE, verdict: { material_drift: false }, pgClient: null });
+    const ins = supabase.__writes.inserts.find((i) => i.table === 'venture_stage_work');
+    expect(ins).toBeTruthy();
+    expect(ins.payload.lifecycle_stage).toBe(19);
+    expect(ins.payload.advisory_data.vision_drift_verdict.material_drift).toBe(false);
+  });
+});
+
+// ── TS-8: dry-run / no-judge introspection (zero writes) ─────────────────────
+describe('runDriftProbe — introspection + judge path (TS-1 store, TS-8)', () => {
+  it('TS-8: dry-run performs ZERO writes and reports current verdict', async () => {
+    const supabase = makeMockSupabase({ eva_vision_documents: visionFixture, ventures: { name: 'V' }, venture_artifacts: [], venture_stage_work: { id: 'sw1', advisory_data: { vision_drift_verdict: { material_drift: false } } } });
+    const res = await runDriftProbe({ supabase, ventureId: VENTURE, dryRun: true });
+    expect(res.wrote).toBe(false);
+    expect(res.currentVerdict).toEqual({ material_drift: false });
+    expect(supabase.__writes.updates.length).toBe(0);
+    expect(supabase.__writes.inserts.length).toBe(0);
+  });
+
+  it('no driftProbe injected → introspect (zero writes), never invents a verdict', async () => {
+    const supabase = makeMockSupabase({ eva_vision_documents: visionFixture, venture_artifacts: [] });
+    const res = await runDriftProbe({ supabase, ventureId: VENTURE /* no driftProbe */ });
+    expect(res.wrote).toBe(false);
+    expect(supabase.__writes.updates.length + supabase.__writes.inserts.length).toBe(0);
+  });
+
+  it('no chairman-approved L2 vision → skip (defer to VISION_MISSING), zero writes', async () => {
+    const supabase = makeMockSupabase({ eva_vision_documents: null, venture_artifacts: [] });
+    const res = await runDriftProbe({ supabase, ventureId: VENTURE, driftProbe: () => ({ material_drift: true }) });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe('no_approved_l2_vision');
+    expect(supabase.__writes.updates.length + supabase.__writes.inserts.length).toBe(0);
+  });
+
+  it('TS-1(store): injected judge → reduced {material_drift:true} written to advisory_data', async () => {
+    const supabase = makeMockSupabase({ eva_vision_documents: visionFixture, ventures: { name: 'V' }, venture_artifacts: [], venture_stage_work: { id: 'sw1', advisory_data: {} } });
+    const driftProbe = () => ({ dimensions: [{ dimension: 'deployment-model', drift: true }] });
+    const res = await runDriftProbe({ supabase, ventureId: VENTURE, driftProbe, pgClient: null });
+    expect(res.wrote).toBe(true);
+    const upd = supabase.__writes.updates.find((u) => u.table === 'venture_stage_work');
+    expect(upd.payload.advisory_data.vision_drift_verdict.material_drift).toBe(true);
+    // and the stored shape classifies correctly
+    expect(classifyVisionDrift(upd.payload.advisory_data.vision_drift_verdict)).toBe(VISION_DRIFT.MATERIAL_DRIFT);
+  });
+});
+
+// ── gather: injectable summarizer, sprintPresent ─────────────────────────────
+describe('gatherDriftInputs — pure reads + injectable summarizer', () => {
+  it('reads vision + artifacts, computes sprintPresent, attaches injected summaries', async () => {
+    const supabase = makeMockSupabase({
+      eva_vision_documents: visionFixture,
+      ventures: { name: 'DataDistill' },
+      venture_artifacts: [
+        { id: 'a1', artifact_type: 'blueprint_technical_architecture', lifecycle_stage: 14, title: 'Arch' },
+        { id: 'a2', artifact_type: 'blueprint_sprint_plan', lifecycle_stage: 19, title: 'Sprint' },
+      ],
+    });
+    const summarize = async () => new Map([['blueprint_sprint_plan', { summary_text: 's', tags: ['t'] }]]);
+    const inputs = await gatherDriftInputs(supabase, VENTURE, { summarize });
+    expect(inputs.visionPresent).toBe(true);
+    expect(inputs.sprintPresent).toBe(true);
+    expect(inputs.artifacts.length).toBe(2);
+    expect(inputs.artifactSummaries.blueprint_sprint_plan.summary_text).toBe('s');
+  });
+
+  it('a failing summarizer is non-fatal (judge falls back to raw artifacts)', async () => {
+    const supabase = makeMockSupabase({ eva_vision_documents: visionFixture, venture_artifacts: [{ id: 'a1', artifact_type: 'blueprint_sprint_plan', lifecycle_stage: 19 }] });
+    const summarize = async () => { throw new Error('LLM down'); };
+    const inputs = await gatherDriftInputs(supabase, VENTURE, { summarize, logger: { warn() {} } });
+    expect(inputs.artifactSummaries).toBeNull();
+    expect(inputs.sprintPresent).toBe(true);
+  });
+});
+
+// ── TS-10: gate stays dormant ────────────────────────────────────────────────
+describe('gate dormancy (TS-10)', () => {
+  it('TS-10: VISION_DRIFT_GATE default OFF with no env set', () => {
+    const prev = process.env.VISION_DRIFT_GATE;
+    delete process.env.VISION_DRIFT_GATE;
+    expect(isVisionDriftGateEnabled()).toBe(false);
+    if (prev !== undefined) process.env.VISION_DRIFT_GATE = prev;
+  });
+});
+
+// ── TS-6 / FR-6: static never-advance + session-only guardrail ───────────────
+describe('static never-advance + session-only guardrail (TS-6, FR-6)', () => {
+  it('TS-6: producer source has no background timer/cron and no advance/lifecycle/governance tokens', () => {
+    const src = readFileSync(PRODUCER_PATH, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    // C4: forbid background timers / cron (extends the gate's DR-24 with setTimeout)
+    expect(src).not.toMatch(/setInterval\(/);
+    expect(src).not.toMatch(/setTimeout\(/);
+    expect(src).not.toMatch(/cron\.schedule|node-cron/);
+    // never-advance invariant
+    expect(src).not.toMatch(/_advanceStage/);
+    expect(src).not.toMatch(/current_lifecycle_stage\s*:/);
+    expect(src).not.toMatch(/chairman_decisions|chairman_approved\s*:/);
+    expect(src).not.toMatch(/advance_venture_stage/);
+  });
+});


### PR DESCRIPTION
## Summary
PR-2 of the STAGE-VISION-ARTIFACT family. PR-1 (#4193) shipped the **dormant, default-OFF** vision-drift DECISION layer (`lib/eva/bridge/vision-drift-gate.js`) + a worker seam that reads `venture_stage_work.advisory_data.vision_drift_verdict` — but had **no producer** to populate it. This PR wires the producer so the gate can eventually be enabled.

## What ships
- **`lib/eva/bridge/venture-drift-prober.js`** — the vision-drift PRODUCER, mirroring `venture-vision-verifier.js` (the acceptance-side producer). `runDriftProbe({driftProbe})` injectable session-hosted judge; `gatherDriftInputs` (L2 vision dims + S13-S19 `is_current` artifacts via injectable `summarizeArtifacts`); **`normalizeDriftVerdict`** (reduces the 4-dimension judge output to the gate's `{material_drift}` contract — never coerces undefined→false); `storeVerdict` (set-only-one-key spread-merge under advisory lock `vision-drift:${ventureId}` + `system_events` audit); `recordVerdict`; dry-run/`--record` CLI.
- **`.claude/commands/leo-drift-probe.md`** — session-hosted 4-dimension judge skill (value-prop / target-user / technical-modality / deployment-model).
- **`scripts/eva/backfill-vision-drift-marker.mjs`** — FR-5 SET-ONCE S19 backfill marker (idempotent).
- **22 unit tests** (TS-1..TS-10): reducer, transient-vs-material, sibling-preservation, lock-name, backfill idempotency, FR-6 static guardrail (forbids `setInterval`/`setTimeout`/cron + advance tokens — mutation-verified), producer→gate end-to-end, gate dormancy.

## Safety
- Gate stays **default-OFF** (`VISION_DRIFT_GATE`); enabling (OFF→ON→STRICT) is a separate back-tested milestone, out of scope.
- **0 `_advanceStage` call sites touched** (never-advance invariant, RCA a14ff998). Purely additive — no existing source file modified.

## Key design (prospective testing-agent, condition C1)
The 4-dimension judge emits `{value_prop:{drift},...}`; storing that raw would make `classifyVisionDrift` return `NOT_EVALUATED` on every verdict (a permanent no-op). `normalizeDriftVerdict` collapses it to `{material_drift: any-dim-drifted}` in the PRODUCER before storing — caught at LEAD, unit-tested against the real classifier (TS-1, TS-9).

## Testing
- 22 new tests pass; PR-1 `vision-drift-gate` suite stays green (18).
- Pre-existing baseline failures (`stitch-*`, `dependency-ordered-execution`) are unrelated — verified by exclusion.

LEO: SD-LEO-INFRA-STAGE-VISION-DRIFT-001 (infrastructure, [MODE: campaign]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)