### PR TITLE
fix(SD-LEO-INFRA-FIX-SUPABASE-LINTER-001): close migration 03 false-green (REVOKE FROM PUBLIC + has_function_privilege assert)

### DIFF
--- a/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated.sql
+++ b/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated.sql
@@ -27,7 +27,9 @@
 --       Deriving this dynamically auto-protects future policy usage too.
 --   (2) EXPLICIT auth primitives (defense-in-depth): the set above plus
 --       fn_user_has_company_access (a sibling helper not currently in a policy).
--- Everything NOT in the allowlist is revoked from BOTH anon and authenticated.
+-- Everything NOT in the allowlist is revoked from anon, authenticated, AND PUBLIC
+-- (anon/authenticated inherit the PUBLIC grant, so revoking only the named roles
+--  leaves the function callable — PUBLIC must be revoked too).
 --
 -- The allowlisted functions (~6) intentionally remain authenticated-executable and
 -- will still appear in the linter — that is correct-by-design (revoking them breaks
@@ -74,12 +76,16 @@ BEGIN
       AND pg_get_userbyid(p.proowner) = current_user      -- only what we own
       AND NOT (p.proname = ANY(v_allow))                  -- skip allowlisted
   LOOP
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION public.%I(%s) FROM anon, authenticated',
+    -- Revoke from PUBLIC too: anon/authenticated inherit the PUBLIC pseudo-role, so
+    -- revoking only the named roles leaves the function callable via its PUBLIC grant
+    -- (verified 2026-06-03: 95 of these functions carried `=X/postgres` = a PUBLIC
+    -- EXECUTE grant, so name-only revoke was a no-op for them).
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION public.%I(%s) FROM anon, authenticated, PUBLIC',
                    r.proname, r.args);
     v_count := v_count + 1;
   END LOOP;
 
-  RAISE NOTICE 'C COMPLETE: revoked anon/authenticated EXECUTE on % SECURITY DEFINER function(s).', v_count;
+  RAISE NOTICE 'C COMPLETE: revoked anon/authenticated/PUBLIC EXECUTE on % SECURITY DEFINER function(s).', v_count;
 END
 $revoke$;
 
@@ -101,15 +107,17 @@ BEGIN
     'fn_is_chairman','fn_is_service_role','fn_user_has_company_access',
     'fn_user_has_venture_access','is_leo_admin','check_feedback_rate_limit'];
 
+  -- Use has_function_privilege (NOT aclexplode of the direct ACL): it resolves
+  -- EXECUTE inherited via the PUBLIC pseudo-role. The prior direct-ACL check was a
+  -- FALSE-GREEN — it passed while 95 non-allowlisted functions stayed anon-callable
+  -- through their PUBLIC grant.
   SELECT count(*), string_agg(DISTINCT p.proname, ', ')
     INTO v_bad, v_detail
   FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
-  CROSS JOIN LATERAL aclexplode(p.proacl) a
-  JOIN pg_roles ro ON ro.oid = a.grantee
   WHERE n.nspname='public' AND p.prokind='f' AND p.prosecdef
-    AND a.privilege_type='EXECUTE'
-    AND ro.rolname IN ('anon','authenticated')
-    AND NOT (p.proname = ANY(v_allow));
+    AND NOT (p.proname = ANY(v_allow))
+    AND (has_function_privilege('anon',          p.oid, 'EXECUTE')
+      OR has_function_privilege('authenticated', p.oid, 'EXECUTE'));
 
   IF v_bad > 0 THEN
     RAISE EXCEPTION 'C NOT cleared: % non-allowlisted SECDEF function(s) still executable by anon/authenticated: %', v_bad, v_detail;

--- a/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated_rollback.sql
+++ b/database/migrations/20260603_03_revoke_secdef_execute_from_anon_authenticated_rollback.sql
@@ -1,7 +1,9 @@
 -- @approved-by: rickfelix@example.com
 -- =============================================================================
 -- ROLLBACK C. Restore the Supabase default: GRANT EXECUTE on every public
--- SECURITY DEFINER function to anon, authenticated. Idempotent.
+-- SECURITY DEFINER function to anon, authenticated, PUBLIC. Idempotent.
+-- (The default EXECUTE grant was to PUBLIC, which anon/authenticated inherit; the
+--  forward migration revoked PUBLIC, so the rollback must re-GRANT it to fully undo.)
 -- =============================================================================
 DO $rb$
 DECLARE
@@ -14,9 +16,9 @@ BEGIN
     WHERE n.nspname = 'public' AND p.prokind = 'f' AND p.prosecdef
       AND pg_get_userbyid(p.proowner) = current_user
   LOOP
-    EXECUTE format('GRANT EXECUTE ON FUNCTION public.%I(%s) TO anon, authenticated', r.proname, r.args);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION public.%I(%s) TO anon, authenticated, PUBLIC', r.proname, r.args);
     v_count := v_count + 1;
   END LOOP;
-  RAISE NOTICE 'ROLLBACK C: re-granted anon/authenticated EXECUTE on % function(s).', v_count;
+  RAISE NOTICE 'ROLLBACK C: re-granted anon/authenticated/PUBLIC EXECUTE on % function(s).', v_count;
 END
 $rb$;


### PR DESCRIPTION
Implements **SD-LEO-INFRA-FIX-SUPABASE-LINTER-001** — follow-up to SD-LEO-INFRA-SUPABASE-DATABASE-LINTER-001 (#4205).

A transaction-rollback dry-run (DB sub-agent, `BEGIN … ROLLBACK`, nothing persisted) proved migration 03 was a **false-green**: it ran `REVOKE EXECUTE … FROM anon, authenticated` (name-only) while **111 non-allowlisted public SECURITY DEFINER functions carry a PUBLIC EXECUTE grant** that anon/authenticated inherit — so they stayed anon-callable (e.g. `advance_venture_stage`), and 03's assert (which inspected the *direct* ACL) passed anyway.

## Fix
- **Forward**: `REVOKE EXECUTE … FROM anon, authenticated, PUBLIC` for non-allowlisted fns; assert rewritten to use `has_function_privilege(...)` (resolves PUBLIC inheritance) instead of `aclexplode` of the direct ACL.
- **Rollback**: `GRANT EXECUTE … TO anon, authenticated, PUBLIC` to fully restore.
- **Allowlist** (6 RLS/auth primitives + policy-referenced fns) untouched.

## Empirical confirmation (re-dry-run, rolled back)
- non-allowlisted anon/authenticated-executable: **111 → 0**
- `advance_venture_stage`: anon **true → false**
- all 6 allowlist fns still authenticated-executable (RLS eval preserved)

⚠️ Files-only — **not applied**. Same windowed deploy discipline as the rest of the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)