### PR TITLE
fix(QF-20260604-273): Fix parent-orchestrator-handler ReferenceError: detectionMethod references removed vars

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001",
-  "expectedBranch": "feat/SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001",
-  "createdAt": "2026-05-28T10:21:34.811Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
-  "baseRef": "origin/main"
+  "sdKey": "QF-20260604-273",
+  "workType": "QF",
+  "workKey": "QF-20260604-273",
+  "expectedBranch": "qf/QF-20260604-273",
+  "createdAt": "2026-06-04T10:53:56.382Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/parent-orchestrator-handler.js
+++ b/scripts/modules/parent-orchestrator-handler.js
@@ -78,11 +78,15 @@ export class ParentOrchestratorHandler {
       children: children || [],
       childrenCount: children?.length || 0,
       completedCount: (children || []).filter(c => c.status === 'completed').length,
-      // Include detection details for debugging
+      // Include detection details for debugging.
+      // SD-LEO-INFRA-CONSOLIDATE-DUAL-DETECTION-001 moved the 3-signal merge into the
+      // isOrchestrator() helper (line ~59), removing the local hasIsParentFlag/
+      // isOrchestratorType/hasChildren vars. Recompute from data in scope so the debug
+      // field stays meaningful without a ReferenceError (QF-20260604-273).
       detectionMethod: {
-        hasIsParentFlag,
-        isOrchestratorType,
-        hasChildren
+        hasIsParentFlag: sd?.metadata?.is_parent === true,
+        isOrchestratorType: sd?.sd_type === 'orchestrator',
+        hasChildren: (children?.length || 0) > 0
       }
     };
   }


### PR DESCRIPTION
## Quick-Fix: QF-20260604-273

**Type:** bug
**Severity:** high

### Issue Description
generateParentPRD throws ReferenceError: hasIsParentFlag is not defined on isParent:true path; detectionMethod object literal (parent-orchestrator-handler.js:82-86) references 3 vars removed in the isOrchestrator() helper refactor. Blocks parent-orchestrator PRD generation for ALL ventures.

### Steps to Reproduce
node create-prd CLI for a parent orchestrator SD

### Expected Behavior
Parent PRD generated

### Actual Behavior
ReferenceError: hasIsParentFlag is not defined

### Changes
- **Files Changed:** 2
  - .worktree.json
  - scripts/modules/parent-orchestrator-handler.js
- **LOC:** 15 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Deterministic fix: recompute the 3 debug signals (metadata.is_parent, sd_type==='orchestrator', children.length>0) from data already in scope; eliminates ReferenceError on the isParent:true path. Verified via node --check + npx tsc --noEmit (both PASS) + pre-commit smoke (15/15).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol