### PR TITLE
fix(QF-20260604-385): Fix corrective-finding-recorder feedback_type enum violation

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260604-273",
+  "sdKey": "QF-20260604-385",
   "workType": "QF",
-  "workKey": "QF-20260604-273",
-  "expectedBranch": "qf/QF-20260604-273",
-  "createdAt": "2026-06-04T10:53:56.382Z",
+  "workKey": "QF-20260604-385",
+  "expectedBranch": "qf/QF-20260604-385",
+  "createdAt": "2026-06-04T11:03:04.010Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/corrective-finding-recorder.js
+++ b/lib/eva/corrective-finding-recorder.js
@@ -88,7 +88,11 @@ export async function recordCorrectiveFinding(supabase, finding) {
     type: 'issue',
     source_application: 'EHG_Engineer',
     source_type: 'auto_capture',
-    feedback_type: 'corrective_finding',
+    // feedback_type is constrained to the venture user-feedback channel enum
+    // (feedback_feedback_type_check). The finding's real classification lives in
+    // category='corrective_finding' + corrective_class; use 'sentry_error' to match the
+    // auto_capture / harness_backlog internal-feedback convention (QF-20260604-385).
+    feedback_type: 'sentry_error',
     title: title.slice(0, 500),
     description: description.slice(0, 5000),
     category: 'corrective_finding',


### PR DESCRIPTION
## Quick-Fix: QF-20260604-385

**Type:** bug
**Severity:** high

### Issue Description
recordCorrectiveFinding sets feedback_type='corrective_finding' which violates feedback_feedback_type_check (allowed: sentry_error/user_bug/user_feature_request/user_usability/user_other). Insert always fails so sub-threshold Vision/heal corrective findings never persist. Use 'sentry_error' to match the auto_capture/harness_backlog internal convention (category+corrective_class carry the real classification).

### Steps to Reproduce
node scripts/eva/heal-command.mjs sd generate <scoreId> after a sub-threshold heal

### Expected Behavior
Corrective finding row inserted

### Actual Behavior
insert violates feedback_feedback_type_check

### Changes
- **Files Changed:** 2
  - .worktree.json
  - lib/eva/corrective-finding-recorder.js
- **LOC:** 9 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Live verify-first probe: feedback_type='corrective_finding' REJECTED by feedback_feedback_type_check; 'sentry_error' INSERTS cleanly (also proves no other NOT-NULL col missing). Probe row deleted. node --check + tsc + smoke 15/15 pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol