### PR TITLE
fix(QF-20260604-088): re-arm fail-open session-writer + exec-context-guard static-pinning lints

### DIFF
--- a/tests/unit/lib/exec-context-guard-pinning.test.js
+++ b/tests/unit/lib/exec-context-guard-pinning.test.js
@@ -99,9 +99,14 @@ describe('SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 — static guard pinning (FR-6, A
   describe('sd-start.js (FR-4) — own-vs-foreign worktree differentiation', () => {
     const src = readScript('scripts/sd-start.js');
 
-    it('imports classifyWorktreeOwnership from lib/exec-context-guard.mjs', () => {
+    // QF-20260604-088 repin: SD-FDBK-INFRA-START-NON-INTERACTIVE-001 (FR-1, 2026-05-28)
+    // extracted the duplicated own-conflict re-attach logic into the pure
+    // decideOwnConflictReattach(), which now wraps classifyWorktreeOwnership +
+    // the already_checked_out gate internally. sd-start.js wires that wrapper,
+    // so the pin follows the wiring to its current name (stays fail-closed).
+    it('imports decideOwnConflictReattach from lib/exec-context-guard.mjs', () => {
       expect(src).toMatch(
-        /import\s*\{\s*classifyWorktreeOwnership\s*\}\s*from\s*['"`].*exec-context-guard\.mjs['"`]/
+        /import\s*\{\s*decideOwnConflictReattach\s*\}\s*from\s*['"`].*exec-context-guard\.mjs['"`]/
       );
     });
 
@@ -114,23 +119,24 @@ describe('SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 — static guard pinning (FR-6, A
       );
     });
 
-    it('Site #1 — creation-failure path: applies classifyWorktreeOwnership when code=already_checked_out and exits 2 (recoverable) on own', () => {
+    // QF-20260604-088 repin: the `already_checked_out` code-gate is now encapsulated
+    // inside decideOwnConflictReattach() (guard module), so it no longer appears as a
+    // literal at the wiring site — pin the wrapper call + recoverable exit instead.
+    it('Site #1 — creation-failure path: calls decideOwnConflictReattach and exits 2 (recoverable, claim preserved) on own', () => {
       // Find the block where releaseClaimOnWorktreeFailure('creation') is called
       const idx = src.indexOf("releaseClaimOnWorktreeFailure('creation')");
       expect(idx).toBeGreaterThan(-1);
       const block = src.slice(Math.max(0, idx - 2000), idx);
-      expect(block).toMatch(/already_checked_out/);
-      expect(block).toMatch(/classifyWorktreeOwnership/);
+      expect(block).toMatch(/decideOwnConflictReattach/);
       expect(block).toMatch(/process\.exit\(2\)/);
       expect(block).toMatch(/Claim PRESERVED/);
     });
 
-    it('Site #2 — resolution-error path: applies classifyWorktreeOwnership when code=already_checked_out and exits 2 (recoverable) on own', () => {
+    it('Site #2 — resolution-error path: calls decideOwnConflictReattach and exits 2 (recoverable) on own', () => {
       const idx = src.indexOf("releaseClaimOnWorktreeFailure('resolution')");
       expect(idx).toBeGreaterThan(-1);
       const block = src.slice(Math.max(0, idx - 2000), idx);
-      expect(block).toMatch(/already_checked_out/);
-      expect(block).toMatch(/classifyWorktreeOwnership/);
+      expect(block).toMatch(/decideOwnConflictReattach/);
       expect(block).toMatch(/process\.exit\(2\)/);
     });
   });
@@ -139,7 +145,9 @@ describe('SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 — static guard pinning (FR-6, A
     it('all 4 named exports of lib/exec-context-guard.mjs are referenced by at least one wiring script', () => {
       // Read the module's exports
       const modSrc = readScript('lib/exec-context-guard.mjs');
-      const exports = ['assertCwdValid', 'assertSweepHandoffGate', 'classifyWorktreeOwnership', 'detectOrphanWorktreeFromMerge'];
+      // QF-20260604-088: classifyWorktreeOwnership is now an internal helper wrapped by
+      // decideOwnConflictReattach (the export sd-start.js actually wires) — pin the wrapper.
+      const exports = ['assertCwdValid', 'assertSweepHandoffGate', 'decideOwnConflictReattach', 'detectOrphanWorktreeFromMerge'];
       for (const name of exports) {
         // Match: `export function`, `export async function`, `export class`,
         // `export const`, OR `name` listed inside a brace-grouped re-export.
@@ -160,8 +168,8 @@ describe('SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 — static guard pinning (FR-6, A
       expect(allConsumerSrc).toMatch(/assertCwdValid/);
       // assertSweepHandoffGate → stale-session-sweep
       expect(allConsumerSrc).toMatch(/assertSweepHandoffGate/);
-      // classifyWorktreeOwnership → sd-start
-      expect(allConsumerSrc).toMatch(/classifyWorktreeOwnership/);
+      // decideOwnConflictReattach → sd-start (wraps classifyWorktreeOwnership internally)
+      expect(allConsumerSrc).toMatch(/decideOwnConflictReattach/);
       // detectOrphanWorktreeFromMerge — pure utility, may be consumed by post-merge-worktree-cleanup.js
       // OR live as a documented utility for future use. Test passes when it's defined in the module
       // even if no consumer wires it yet (canary surfaces the asymmetry as INFO, not failure).

--- a/tests/unit/session-writer/no-bypass.test.js
+++ b/tests/unit/session-writer/no-bypass.test.js
@@ -63,7 +63,28 @@ const ALLOWLIST = new Set([
   // Category B — release/status writes (branch not relevant to state transition)
   'lib/commands/claim-command.js',
   'lib/context/unified-state-manager.js',
+
+  // ── QF-20260604-088: re-arm after ALLOWLIST drift (RCA PAT-LINT-STATIC-PINNING-DRIFT-001,
+  //    issue_patterns 3914509b). Each verified to write NO current_branch column (benign drift). ──
+  // Category B — metadata / status / telemetry / worktree-state writes (current_branch N/A)
+  'lib/coordinator/resolve.cjs',                  // metadata-only merge patch
+  'lib/fleet-lock-hash.mjs',                      // released_reason on lock fracture (release write)
+  'lib/lifecycle/worktree-state-writer.mjs',      // worktree_path/worktree_branch (NOT current_branch)
+  'lib/worktree-manager.js',                      // cleanup_pending marker
+  'scripts/cancel-sd.js',                         // release transition (status/sd_key/worktree nulls)
+  'scripts/cleanup-pending-sweep.mjs',            // clears cleanup_pending flag
+  'scripts/lib/sessions/loop-state-tracker.cjs',  // loop_state telemetry counter
+  // Category C — archived one-time / non-interactive probe
+  'scripts/one-off/backfill-stale-worktree-state.mjs',  // one-time worktree-state backfill
+  'scripts/smoke/verify-claim-col-preservation.mjs',    // smoke probe (sd_key CAS), not runtime
 ]);
+
+// QF-20260604-088: archived one-off evidence / migration-plan scripts under
+// scripts/one-off/_* are kept for audit only and never run interactively. Their
+// claude_sessions matches (real CAS writes or example payloads embedded in PRD
+// strings) are not live source. The leading underscore is the repo's archived-
+// one-off convention — exclude these from the guard rather than allowlisting each.
+const ARCHIVED_ONE_OFF_RE = /^scripts\/one-off\/_/;
 
 // Roots to scan (source code only — skip node_modules, tests, build output)
 const SCAN_ROOTS = ['lib', 'scripts'];
@@ -106,6 +127,7 @@ describe('LINT-SESSION-WRITER-001: no raw claude_sessions.update outside helper'
       for (const file of walk(rootPath)) {
         const relative = path.relative(repoRoot, file).split(path.sep).join('/');
         if (ALLOWLIST.has(relative)) continue;
+        if (ARCHIVED_ONE_OFF_RE.test(relative)) continue; // QF-20260604-088
         let content;
         try {
           content = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
## Quick-Fix QF-20260604-088

Re-arms two **fail-open** unit guards that had been RED on `origin/main` (no-bypass since ~2026-04-26; exec-context pinning since the 2026-05-28 FR-1 extraction). RCA: **PAT-LINT-STATIC-PINNING-DRIFT-001** (issue_patterns `3914509b`). Because CI baseline-ratchets the red tests, a *new* real bypass could merge silently — this restores fail-closed behaviour.

### Changes (test/CI only — no production code)
**`tests/unit/session-writer/no-bypass.test.js`** (LINT-SESSION-WRITER-001)
- Added 9 drifted-but-legitimate `claude_sessions` writers to the ALLOWLIST with per-file **A/B/C** justification. Each was verified (via the exact test regex) to write **no `current_branch` column** — confirming the RCA's *benign drift* verdict.
- Excluded archived `scripts/one-off/_*` evidence/migration-plan scripts from the scan (leading-underscore = repo archive convention; their matches are CAS writes or PRD-embedded example payloads, not live source).

**`tests/unit/lib/exec-context-guard-pinning.test.js`**
- Repinned the worktree-ownership wiring assertions from `classifyWorktreeOwnership` → `decideOwnConflictReattach`, the pure wrapper `sd-start.js` now wires (SD-FDBK-INFRA-START-NON-INTERACTIVE-001 FR-1). `classifyWorktreeOwnership` + the `already_checked_out` gate are now encapsulated inside it. Stays **fail-closed**.

### Verification
- Both target suites green: **14/14 passing** (were 5 failing).
- Source LOC = 0 (both files are tests); diff +41/-11.

### Deferred CAPA (out of scope for this QF)
- Add `tests/unit/session-writer/` to `protected-unit-suites.yml` **after 2+ green CI runs** (make fail-closed in CI).
- Preventive: replace the frozen ALLOWLIST Set with in-source sentinel comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)