### PR TITLE
feat(SD-LEO-INFRA-SESSION-AWARE-AUTO-001): session-aware QF auto-proceed

### DIFF
--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -97,7 +97,7 @@ If qualified for quick-fix:
 
 2. **Create branch:**
    ```bash
-   git checkout -b quick-fix/QF-YYYYMMDD-NNN
+   git checkout -b qf/QF-YYYYMMDD-NNN
    ```
 
 3. **Implement fix:**

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -25,6 +25,7 @@ import dotenv from 'dotenv';
 import { createRequire } from 'module';
 import { getStaleThresholdSeconds } from './claim/stale-threshold.js';
 import { isProcessRunning } from './heartbeat-manager.mjs';
+import { claimQuickFix } from './quick-fix-claim.mjs';
 import os from 'os';
 
 // stampBranch keeps current_branch fresh on heartbeat writes — see
@@ -157,10 +158,21 @@ function getSupabase() {
 // claim cols, so re-running sd-start always converges to a consistent state.
 async function reaffirmClaimColumns(supabase, sdKey, sessionId) {
   if (sdKey.startsWith('QF-')) {
-    await supabase
-      .from('quick_fixes')
-      .update({ claiming_session_id: sessionId, status: 'in_progress' })
-      .eq('id', sdKey);
+    // SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-1b, prospective DEFECT 4):
+    // The previous NON-CAS `.update(...).eq('id', sdKey)` would clobber a
+    // DIFFERENT live holder's claim on every reaffirm. Route through the shared
+    // fail-closed CAS (null-OR-self guard) so reaffirm stays idempotent for the
+    // OWNING session but refuses to steal a peer's QF. Reaffirm is best-effort
+    // defense-in-depth — the authoritative claim/bail lives at the adopt
+    // entrypoint (classify-quick-fix.js, FR-2) — so a lost CAS here only warns.
+    const { claimed, holder } = await claimQuickFix(supabase, sdKey, sessionId);
+    if (!claimed) {
+      console.warn(
+        `[claimGuard] reaffirm: QF ${sdKey} held by another session ` +
+        `(${holder ? String(holder).slice(0, 8) : 'unknown'}) — not clobbering. ` +
+        `Authoritative claim is enforced at the QF adopt entrypoint.`
+      );
+    }
   } else {
     await supabase
       .from('strategic_directives_v2')

--- a/lib/quick-fix-claim.mjs
+++ b/lib/quick-fix-claim.mjs
@@ -1,0 +1,86 @@
+/**
+ * Shared Quick-Fix CAS Claim Helper
+ * SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-1)
+ *
+ * Single source of truth for the atomic compare-and-swap that takes ownership
+ * of a quick_fixes row. The QF auto-proceed / adopt path was previously
+ * session-blind: two parallel sessions could both run `/leo <QF-id>` and start
+ * the same quick-fix. This helper closes that race the same way the SD path
+ * already does — a fail-closed CAS guarded on the current holder.
+ *
+ * Guard semantics: `claiming_session_id IS NULL OR claiming_session_id = sessionId`.
+ *   - NULL      → unclaimed; this session takes it.
+ *   - = self    → idempotent self re-adopt (prospective DEFECT 4). A session
+ *                 that already holds the claim (e.g. re-running /quick-fix, or
+ *                 the reaffirm path in claim-guard) must NOT lose its own claim
+ *                 or be told it lost a race against itself. The self branch of
+ *                 the guard makes claimQuickFix a no-op-safe re-affirm.
+ *   - = other   → a DIFFERENT live/stale holder owns it → 0 rows updated →
+ *                 claimed:false (the legitimate "lost race" signal). The
+ *                 stale-claim release in scripts/stale-session-sweep.cjs
+ *                 (clearStaleQfClaims) is what frees a dead holder's claim;
+ *                 we deliberately do NOT take over here.
+ *
+ * @module quick-fix-claim
+ * @see scripts/create-quick-fix.js:405-414 - the proven NULL-only CAS shape this generalizes
+ * @see scripts/stale-session-sweep.cjs clearStaleQfClaims() - stale-holder release (no takeover here)
+ */
+
+/**
+ * Atomically claim a quick-fix for a session.
+ *
+ * Fail-closed: a real PostgREST error THROWS (the caller must not silently
+ * proceed as if it claimed). A 0-row result is NOT an error — it is the
+ * legitimate "a different holder owns it" signal and returns claimed:false.
+ *
+ * @param {object} supabase - supabase-js client (anon or service role)
+ * @param {string} qfId - quick_fixes.id (e.g. 'QF-20260101-001')
+ * @param {string} sessionId - the claiming session's id
+ * @returns {Promise<{ claimed: boolean, holder: string|null }>}
+ *   claimed=true  → this session now holds the claim (null-or-self path); holder=sessionId.
+ *   claimed=false → a different holder owns it; holder=current claiming_session_id (best-effort read).
+ */
+export async function claimQuickFix(supabase, qfId, sessionId) {
+  if (!supabase) throw new Error('claimQuickFix requires a supabase client');
+  if (!qfId || !sessionId) throw new Error('claimQuickFix requires both qfId and sessionId');
+
+  // Fail-closed CAS. The .or() filter encodes (claiming_session_id IS NULL OR
+  // claiming_session_id = sessionId) so a foreign live/stale holder yields 0 rows.
+  const { data, error } = await supabase
+    .from('quick_fixes')
+    .update({
+      claiming_session_id: sessionId,
+      status: 'in_progress',
+      started_at: new Date().toISOString(),
+    })
+    .eq('id', qfId)
+    .or(`claiming_session_id.is.null,claiming_session_id.eq.${sessionId}`)
+    .select('id,claiming_session_id')
+    .maybeSingle();
+
+  // FAIL LOUD on a real error — never treat a query failure as a lost race.
+  if (error) {
+    throw new Error(`claimQuickFix CAS failed for ${qfId}: ${error.message}`);
+  }
+
+  if (data) {
+    return { claimed: true, holder: data.claiming_session_id || sessionId };
+  }
+
+  // 0 rows → a DIFFERENT holder owns it. Follow-up read to report who, for the
+  // caller's BLOCK message. Best-effort: if this read fails, holder stays null.
+  let holder = null;
+  try {
+    const { data: cur } = await supabase
+      .from('quick_fixes')
+      .select('claiming_session_id')
+      .eq('id', qfId)
+      .maybeSingle();
+    holder = cur?.claiming_session_id || null;
+  } catch {
+    /* best-effort holder lookup; leave null */
+  }
+  return { claimed: false, holder };
+}
+
+export default { claimQuickFix };

--- a/scripts/classify-quick-fix.js
+++ b/scripts/classify-quick-fix.js
@@ -20,6 +20,8 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { analyzePatterns, createPatternRetrospective } from '../lib/utils/quickfix-rca-integration.js';
+// SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-2): session-aware QF adoption.
+import { claimQuickFix } from '../lib/quick-fix-claim.mjs';
 
 dotenv.config();
 
@@ -217,10 +219,34 @@ async function classifyQuickFix(qfId, options = {}) {
 
   // Final verdict
   if (qualifies) {
+    // SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-2): claim the QF for THIS session
+    // before emitting implementation guidance. /quick-fix and /leo <QF-id> run
+    // this script early; previously nothing claimed the QF here, so two parallel
+    // sessions could both adopt the same quick-fix. Fail-closed CAS via the
+    // shared helper closes that race at the actual adopt entrypoint.
+    // Gate on session id presence exactly like create-quick-fix.js — a
+    // non-session invocation (no CLAUDE_SESSION_ID) must never crash classify.
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    if (!sessionId) {
+      console.log('ℹ️  No CLAUDE_SESSION_ID — skipping QF claim (non-session invocation).\n');
+    } else {
+      const { claimed, holder } = await claimQuickFix(supabase, qfId, sessionId);
+      if (!claimed) {
+        const holderShort = holder ? String(holder).slice(0, 8) : 'another session';
+        console.log('\n🛑 BLOCKED — QF ALREADY CLAIMED\n');
+        console.log(`   QF ${qfId} is already claimed by session ${holderShort}.`);
+        console.log('   Pick different work — run /leo next.\n');
+        // Non-zero, distinct from the exit(1) error path, so the skill can act
+        // on "foreign claim" without proceeding to implementation guidance.
+        process.exit(2);
+      }
+      console.log(`\n🔒 Claimed QF ${qfId} for session ${String(sessionId).slice(0, 8)}\n`);
+    }
+
     console.log('\n✅ QUALIFIES FOR QUICK-FIX WORKFLOW\n');
     console.log('📍 Next steps:');
     console.log(`   1. Read details: node scripts/read-quick-fix.js ${qfId}`);
-    console.log(`   2. Create branch: git checkout -b quick-fix/${qfId}`);
+    console.log(`   2. Create branch: git checkout -b qf/${qfId}`);
     console.log(`   3. Implement fix (≤${CLASSIFICATION_RULES.maxLoc} LOC)`);
     console.log('   4. Run tests: npm run test:unit && npm run test:e2e');
     console.log(`   5. Complete: node scripts/complete-quick-fix.js ${qfId}\n`);

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -6,10 +6,21 @@
 
 import { colors } from '../colors.js';
 import { analyzeClaimRelationship } from '../claim-analysis.js';
+import { getStaleThresholdSeconds } from '../../../../lib/claim/stale-threshold.js';
 
 const MAX_DISPLAY = 10;
 
 const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+// SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-4): liveness-boundary parity with the
+// sweep. scripts/stale-session-sweep.cjs clearStaleQfClaims() uses
+// STALE_THRESHOLD_SECONDS * 3 (= 900s by default) as the "holder is definitely
+// dead" bar before it nulls quick_fixes.claiming_session_id. We MUST use the
+// SAME boundary here: a QF whose holder heartbeat is older than this (or whose
+// holder row is gone) is NOT live, so it must NOT be permanently held out of
+// topStartableQF — the sweep will free it, and meanwhile it is adoptable.
+// Computed from the shared threshold so the two stay in lockstep.
+const QF_HOLDER_LIVE_SECONDS = getStaleThresholdSeconds() * 3;
 
 // QF-20260525-522: freshness/supersession gate. AUTO-PROCEED must NOT auto-route
 // to a QF that may have been resolved by a *different* SD (one with no PR of its
@@ -51,25 +62,63 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
     let claimBadge = '';
     let isClaimedByOther = false;
 
+    // SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-3): the live-QF-holder signal is
+    // quick_fixes.claiming_session_id (NOT claude_sessions.sd_key — that column
+    // never holds QF ids). claimedSDs is keyed by SD-key and will never contain
+    // a QF id, so this reduces to qf.claiming_session_id; kept as a fallback for
+    // forward-compat only.
     const claimingSessionId = qf.claiming_session_id || claimedSDs.get(qf.id);
     if (claimingSessionId && currentSession) {
       if (claimingSessionId === currentSession.session_id) {
         claimBadge = `${colors.green}YOURS${colors.reset} `;
       } else {
-        isClaimedByOther = true;
         const claimingSession = activeSessions.find(s => s.session_id === claimingSessionId);
-        if (claimingSession) {
+        // SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-4): a claim only excludes a QF
+        // from auto-start while its holder is LIVE. We protect to the SAME 900s
+        // boundary the sweep (clearStaleQfClaims) uses before it nulls the claim,
+        // measured against the holder's real heartbeat (heartbeat_age_seconds),
+        // NOT the view's is_alive/computed_status (the two-threshold model puts
+        // the display-stale line at 600s — see lib/claim/stale-threshold.js).
+        //   - holder row missing  ⇒ NOT live (released/gone) ⇒ adoptable.
+        //   - heartbeat > 900s    ⇒ NOT live (sweep will null it) ⇒ adoptable.
+        //   - heartbeat <= 900s   ⇒ live ⇒ protect/exclude.
+        // NOTE: activeSessions is sourced from v_active_sessions filtered at the
+        // 600s display-stale boundary, so a holder in the 600–900s band is absent
+        // here and treated as not-live — i.e. we free a QF no LATER than the
+        // sweep, occasionally slightly earlier. That is adoptability-conservative
+        // and harmless: the fail-closed CAS at the adopt entrypoint (FR-2) is the
+        // authoritative race guard, so an early-freed QF still cannot be
+        // double-adopted. A precise 600–900s read would require the data loader
+        // to surface display-stale holders too; intentionally out of scope here.
+        const holderAgeSec = claimingSession?.heartbeat_age_seconds;
+        const holderLive =
+          !!claimingSession &&
+          Number.isFinite(holderAgeSec) &&
+          holderAgeSec <= QF_HOLDER_LIVE_SECONDS;
+
+        if (!holderLive) {
+          // Stale/dead/absent holder — the sweep will null this claim. Surface a
+          // STALE badge but leave isClaimedByOther=false so topStartableQF can
+          // pick it up (FR-4: a stale claim must not permanently exclude).
+          claimBadge = `${colors.yellow}STALE${colors.reset} `;
+        } else {
+          isClaimedByOther = true;
           const analysis = analyzeClaimRelationship({ claimingSessionId, claimingSession, currentSession });
           if (analysis.relationship === 'same_conversation') {
             claimBadge = `${colors.green}${analysis.displayLabel}${colors.reset} `;
+            isClaimedByOther = false;
+          } else if (analysis.canAutoRelease) {
+            // analyzeClaimRelationship flagged this holder as safe-to-release
+            // (stale_inactive / stale_dead). Even within the 900s window, an
+            // explicitly released/dead-PID holder is not live work — keep it
+            // adoptable rather than blocking auto-start.
+            claimBadge = `${colors.yellow}${analysis.displayLabel}${colors.reset} `;
             isClaimedByOther = false;
           } else {
             claimBadge = analysis.relationship.startsWith('stale')
               ? `${colors.yellow}${analysis.displayLabel}${colors.reset} `
               : `${colors.yellow}CLAIMED${colors.reset} `;
           }
-        } else {
-          claimBadge = `${colors.yellow}CLAIMED${colors.reset} `;
         }
       }
     }

--- a/scripts/read-quick-fix.js
+++ b/scripts/read-quick-fix.js
@@ -177,7 +177,7 @@ async function readQuickFix(qfId, options = {}) {
   if (qf.status === 'open') {
     console.log('📍 NEXT STEPS\n');
     console.log(`   1. Classify:       node scripts/classify-quick-fix.js ${qfId}`);
-    console.log(`   2. Create branch:  git checkout -b quick-fix/${qfId}`);
+    console.log(`   2. Create branch:  git checkout -b qf/${qfId}`);
     console.log('   3. Implement fix:  (≤50 LOC, single file preferred)');
     console.log('   4. Restart server: pkill -f "npm run dev" && npm run dev');
     console.log('   5. Run tests:      npm run test:unit && npm run test:e2e');

--- a/tests/unit/claim-guard-reaffirm-sd-row.test.js
+++ b/tests/unit/claim-guard-reaffirm-sd-row.test.js
@@ -8,6 +8,13 @@
  *
  * Static-pin pattern: read source via fs, assert the helper + 3 invocations
  * appear in expected positions. Mocking-independent.
+ *
+ * SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-1b): the QF branch of
+ * reaffirmClaimColumns no longer touches the quick_fixes table inline — it
+ * delegates to the shared fail-closed CAS helper claimQuickFix so a reaffirm
+ * cannot clobber a DIFFERENT live holder's claim. The QF-table write contract
+ * itself is pinned by tests/unit/qf-claim-cas.test.js; this file pins that the
+ * branch routes through the helper and that no inline NON-CAS update returns.
  */
 import { describe, test, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -33,12 +40,22 @@ describe('claim-guard: reaffirmClaimColumns (QF-20260511-016)', () => {
     expect(fnBody).toMatch(/is_working_on:\s*true/);
   });
 
-  test('helper writes claiming_session_id for QFs', () => {
+  test('helper claims QFs via the shared fail-closed CAS (SD-LEO-INFRA-SESSION-AWARE-AUTO-001 FR-1b)', () => {
+    // FR-1b moved the QF write-path out of an inline NON-CAS
+    // `.from('quick_fixes').update(...)` and into the shared fail-closed CAS
+    // helper claimQuickFix (lib/quick-fix-claim.mjs), so a reaffirm can no
+    // longer clobber a DIFFERENT live holder's claim. The QF branch is still
+    // gated on the QF- prefix; the actual quick_fixes table write now lives in
+    // the CAS helper (pinned separately by qf-claim-cas.test.js). Pin the new
+    // contract: the QF branch delegates to claimQuickFix rather than touching
+    // the table inline.
     const fnStart = src.indexOf('async function reaffirmClaimColumns');
     const fnEnd = src.indexOf('\n}\n', fnStart);
     const fnBody = src.slice(fnStart, fnEnd);
-    expect(fnBody).toMatch(/quick_fixes/);
     expect(fnBody).toMatch(/sdKey\.startsWith\('QF-'\)/);
+    expect(fnBody).toMatch(/claimQuickFix\(supabase,\s*sdKey,\s*sessionId\)/);
+    // The non-CAS inline update on quick_fixes must NOT be reintroduced.
+    expect(fnBody).not.toMatch(/from\(\s*['"]quick_fixes['"]\s*\)\s*[\s\S]{0,80}update\(/);
   });
 
   test('Case 1 (already_owned) calls reaffirmClaimColumns before return', () => {

--- a/tests/unit/qf-claim-cas.test.js
+++ b/tests/unit/qf-claim-cas.test.js
@@ -1,0 +1,217 @@
+/**
+ * claimQuickFix — fail-closed CAS unit tests
+ * SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-1, FR-2)
+ *
+ * Covers the prospective DEFECTs the QF auto-proceed/adopt path was previously
+ * blind to:
+ *   - TS-1  CAS concurrency (DEFECT 3): two sessions race the same QF; exactly
+ *           one wins. The 2nd .update matches 0 rows once claiming_session_id is
+ *           non-null-and-not-self.
+ *   - TS-2  self re-adopt idempotency (DEFECT 4): the owning session may re-claim
+ *           its own QF without a spurious "lost race" bail (the OR ...eq.self leg).
+ *   - TS-2b foreign-bail message: a QF held by another session returns
+ *           claimed:false with holder = the other session id.
+ *
+ * The fake supabase below is a FAITHFUL model of the PostgREST query-builder
+ * surface claimQuickFix uses (.from().update().eq().or().select().maybeSingle()
+ * and .from().select().eq().maybeSingle()). Crucially it enforces the SAME
+ * (claiming_session_id IS NULL OR claiming_session_id = sessionId) WHERE
+ * semantics the real `.or('claiming_session_id.is.null,claiming_session_id.eq.X')`
+ * filter encodes — so the CAS race is genuinely exercised against row state, not
+ * stubbed return values.
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import { claimQuickFix } from '../../lib/quick-fix-claim.mjs';
+
+/**
+ * Build a stateful fake supabase backed by a single in-memory quick_fixes row.
+ * Returns { supabase, store } so a test can inspect/seed the row directly.
+ *
+ * The .or() parser understands exactly the one shape the helper emits:
+ *   `claiming_session_id.is.null,claiming_session_id.eq.<sessionId>`
+ * and applies it as (col IS NULL) OR (col === sessionId). Any other .or() shape
+ * throws — so a future change to the filter shape can't silently no-op the guard.
+ */
+function makeFakeSupabase(initialRow) {
+  const store = { row: initialRow ? { ...initialRow } : null };
+
+  function parseOr(orExpr) {
+    // Only the canonical CAS shape is supported; anything else is a test bug.
+    const m = /^claiming_session_id\.is\.null,claiming_session_id\.eq\.(.+)$/.exec(orExpr);
+    if (!m) throw new Error(`fake supabase: unsupported .or() shape: ${orExpr}`);
+    const self = m[1];
+    return (row) => row.claiming_session_id == null || row.claiming_session_id === self;
+  }
+
+  function from(table) {
+    if (table !== 'quick_fixes') throw new Error(`fake supabase: unexpected table ${table}`);
+
+    // ----- UPDATE builder -----
+    function updateBuilder(patch) {
+      const filters = { id: undefined, orPred: null };
+      const api = {
+        eq(col, val) {
+          if (col !== 'id') throw new Error(`fake supabase update: only .eq('id') modelled, got ${col}`);
+          filters.id = val;
+          return api;
+        },
+        or(expr) {
+          filters.orPred = parseOr(expr);
+          return api;
+        },
+        select() { return api; },
+        async maybeSingle() {
+          const row = store.row;
+          // .eq('id') miss → 0 rows.
+          if (!row || (filters.id !== undefined && row.id !== filters.id)) {
+            return { data: null, error: null };
+          }
+          // CAS guard: the .or() predicate must hold against the CURRENT row.
+          if (filters.orPred && !filters.orPred(row)) {
+            return { data: null, error: null }; // 0 rows updated — lost race.
+          }
+          // Apply the patch (mutates the shared store → models real persistence).
+          Object.assign(row, patch);
+          return { data: { id: row.id, claiming_session_id: row.claiming_session_id }, error: null };
+        },
+      };
+      return api;
+    }
+
+    // ----- SELECT builder (best-effort holder read) -----
+    function selectBuilder() {
+      const filters = { id: undefined };
+      const api = {
+        eq(col, val) {
+          if (col !== 'id') throw new Error(`fake supabase select: only .eq('id') modelled, got ${col}`);
+          filters.id = val;
+          return api;
+        },
+        async maybeSingle() {
+          const row = store.row;
+          if (!row || (filters.id !== undefined && row.id !== filters.id)) {
+            return { data: null, error: null };
+          }
+          return { data: { claiming_session_id: row.claiming_session_id }, error: null };
+        },
+      };
+      return api;
+    }
+
+    return {
+      update: (patch) => updateBuilder(patch),
+      select: () => selectBuilder(),
+    };
+  }
+
+  return { supabase: { from }, store };
+}
+
+const QF = 'QF-20260101-001';
+const SESS_A = 'session-aaaaaaaa';
+const SESS_B = 'session-bbbbbbbb';
+
+describe('claimQuickFix — argument guards', () => {
+  test('throws without a supabase client', async () => {
+    await expect(claimQuickFix(null, QF, SESS_A)).rejects.toThrow(/supabase client/);
+  });
+  test('throws without qfId or sessionId', async () => {
+    const { supabase } = makeFakeSupabase({ id: QF, claiming_session_id: null });
+    await expect(claimQuickFix(supabase, '', SESS_A)).rejects.toThrow(/qfId and sessionId/);
+    await expect(claimQuickFix(supabase, QF, '')).rejects.toThrow(/qfId and sessionId/);
+  });
+});
+
+describe('TS-1 CAS concurrency (DEFECT 3): two sessions race the same unclaimed QF', () => {
+  test('exactly one session wins; the loser gets claimed=false holder=winner', async () => {
+    // Single shared row, initially unclaimed (claiming_session_id = null).
+    const { supabase, store } = makeFakeSupabase({ id: QF, claiming_session_id: null, status: 'open' });
+
+    // First session claims — the row is null → CAS matches → it wins.
+    const first = await claimQuickFix(supabase, QF, SESS_A);
+    // Second session claims AFTER the row is now non-null-and-not-self → 0 rows.
+    const second = await claimQuickFix(supabase, QF, SESS_B);
+
+    const winners = [first, second].filter(r => r.claimed === true);
+    const losers = [first, second].filter(r => r.claimed === false);
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+
+    expect(first.claimed).toBe(true);
+    expect(first.holder).toBe(SESS_A);
+
+    expect(second.claimed).toBe(false);
+    expect(second.holder).toBe(SESS_A); // the winner is reported as the holder
+
+    // Row reflects the winner only; the loser never overwrote it.
+    expect(store.row.claiming_session_id).toBe(SESS_A);
+    expect(store.row.status).toBe('in_progress');
+  });
+
+  test('claim flips status→in_progress and stamps started_at on the winner', async () => {
+    const { supabase, store } = makeFakeSupabase({ id: QF, claiming_session_id: null, status: 'open' });
+    const before = Date.now();
+    const res = await claimQuickFix(supabase, QF, SESS_A);
+    expect(res.claimed).toBe(true);
+    expect(store.row.status).toBe('in_progress');
+    expect(typeof store.row.started_at).toBe('string');
+    expect(new Date(store.row.started_at).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('TS-2 self re-adopt idempotency (DEFECT 4): same session claims twice', () => {
+  test('both calls return claimed=true (the OR ...eq.self leg), no spurious bail', async () => {
+    const { supabase, store } = makeFakeSupabase({ id: QF, claiming_session_id: null, status: 'open' });
+
+    const first = await claimQuickFix(supabase, QF, SESS_A);
+    const second = await claimQuickFix(supabase, QF, SESS_A); // re-adopt by the SAME session
+
+    expect(first.claimed).toBe(true);
+    expect(first.holder).toBe(SESS_A);
+    expect(second.claimed).toBe(true);
+    expect(second.holder).toBe(SESS_A);
+    expect(store.row.claiming_session_id).toBe(SESS_A);
+  });
+
+  test('re-adopt works even when the row already carries this session as holder', async () => {
+    // Seed the row as already held by SESS_A (e.g. claim-guard reaffirm path).
+    const { supabase } = makeFakeSupabase({ id: QF, claiming_session_id: SESS_A, status: 'in_progress' });
+    const res = await claimQuickFix(supabase, QF, SESS_A);
+    expect(res.claimed).toBe(true);
+    expect(res.holder).toBe(SESS_A);
+  });
+});
+
+describe('TS-2b foreign-bail message: QF held by a different session', () => {
+  test('returns claimed=false with holder = the other session id', async () => {
+    // Row already claimed by SESS_B; SESS_A attempts to claim.
+    const { supabase, store } = makeFakeSupabase({ id: QF, claiming_session_id: SESS_B, status: 'in_progress' });
+    const res = await claimQuickFix(supabase, QF, SESS_A);
+    expect(res.claimed).toBe(false);
+    expect(res.holder).toBe(SESS_B); // best-effort follow-up read surfaces the real holder
+    // SESS_A must NOT have overwritten SESS_B's claim.
+    expect(store.row.claiming_session_id).toBe(SESS_B);
+  });
+});
+
+describe('fail-loud on a real PostgREST error', () => {
+  test('a query error THROWS (never silently treated as a lost race)', async () => {
+    const erroringSupabase = {
+      from() {
+        return {
+          update() {
+            return {
+              eq() { return this; },
+              or() { return this; },
+              select() { return this; },
+              async maybeSingle() {
+                return { data: null, error: { message: 'connection reset' } };
+              },
+            };
+          },
+        };
+      },
+    };
+    await expect(claimQuickFix(erroringSupabase, QF, SESS_A)).rejects.toThrow(/CAS failed.*connection reset/);
+  });
+});

--- a/tests/unit/qf-classify-live-holder.test.js
+++ b/tests/unit/qf-classify-live-holder.test.js
@@ -1,0 +1,186 @@
+/**
+ * classifyQuickFixes — live-holder exclusion & stale-vs-alive adoptability
+ * SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-3, FR-4)
+ *
+ * TS-3 (HIGHEST RISK — DEFECT 1): the live-QF-holder signal is
+ *   quick_fixes.claiming_session_id, NOT claude_sessions.sd_key. A QF whose
+ *   claiming_session_id maps to a LIVE active session is excluded from
+ *   topStartableQF — and this MUST hold even when no claude_sessions.sd_key
+ *   references the QF id at all (claimedSDs has no QF entry).
+ *
+ * TS-4 (DEFECT 2): a claim only protects while the holder is LIVE. Holder
+ *   heartbeat <= QF_HOLDER_LIVE_SECONDS (900s default) ⇒ protected/excluded;
+ *   holder heartbeat > 900s OR holder absent from activeSessions ⇒ adoptable
+ *   (STALE badge, present in topStartableQF).
+ *
+ * These tests construct holders that are deliberately NOT same-conversation
+ * with the current session (distinct UUID terminal_ids) so the liveness
+ * boundary — not terminal-id recovery — is what is under test.
+ */
+import { describe, test, expect } from 'vitest';
+import { classifyQuickFixes } from '../../scripts/modules/sd-next/display/quick-fixes.js';
+
+// Distinct UUID terminal_ids so isSameConversation(...) === false (two different
+// UUIDs compare literally → false), keeping us on the heartbeat-liveness path.
+const TID_CURRENT = '11111111-1111-1111-1111-111111111111';
+const TID_HOLDER = '22222222-2222-2222-2222-222222222222';
+
+const CURRENT_SESSION = { session_id: 'sess-current', terminal_id: TID_CURRENT };
+const HOLDER_SESSION_ID = 'sess-holder';
+
+/** A minimal open QF row, claimed by HOLDER_SESSION_ID unless overridden. */
+function qfRow(overrides = {}) {
+  return {
+    id: 'QF-20260101-001',
+    title: 'Fix a thing',
+    type: 'bug',
+    severity: 'medium',
+    status: 'open',
+    estimated_loc: 10,
+    created_at: new Date().toISOString(), // recent → not verify-first
+    pr_url: null,
+    commit_sha: null,
+    claiming_session_id: HOLDER_SESSION_ID,
+    ...overrides,
+  };
+}
+
+/** An activeSessions holder row with a controllable heartbeat age. */
+function holderSession(heartbeatAgeSeconds, overrides = {}) {
+  return {
+    session_id: HOLDER_SESSION_ID,
+    terminal_id: TID_HOLDER,
+    heartbeat_age_seconds: heartbeatAgeSeconds,
+    pid: null, // no PID → analyzeClaimRelationship can't mark it dead via PID
+    hostname: 'some-other-host', // different host → no PID liveness shortcut
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function classify(quickFixes, sessionContext) {
+  return classifyQuickFixes(quickFixes, new Map(), sessionContext);
+}
+
+describe('TS-3 (DEFECT 1): live holder detected via claiming_session_id, NOT sd_key', () => {
+  test('a QF held by a LIVE session is _isClaimedByOther=true and ABSENT from topStartableQF — with NO sd_key referencing the QF', () => {
+    const qf = qfRow(); // claiming_session_id = HOLDER_SESSION_ID
+    const sessionContext = {
+      currentSession: CURRENT_SESSION,
+      // LIVE holder: heartbeat well under the 900s QF liveness boundary.
+      activeSessions: [holderSession(60)],
+      // CRITICAL: claimedSDs (keyed by SD-key) contains NO entry for the QF id.
+      // If detection relied on sd_key, this would be empty and the QF would
+      // wrongly appear startable. It must rely on qf.claiming_session_id instead.
+      claimedSDs: new Map(),
+    };
+
+    const { summary, classified } = classify([qf], sessionContext);
+    const row = classified.find(r => r.id === qf.id);
+
+    expect(row._isClaimedByOther).toBe(true);
+    // Excluded from the auto-startable pick.
+    expect(summary.topStartableQF).toBeNull();
+    // Sanity: no claude_sessions.sd_key referenced the QF id at all.
+    expect([...sessionContext.claimedSDs.keys()]).not.toContain(qf.id);
+  });
+
+  test('current-session holder ⇒ YOURS, not claimed-by-other', () => {
+    const qf = qfRow({ claiming_session_id: CURRENT_SESSION.session_id });
+    const { classified } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [],
+      claimedSDs: new Map(),
+    });
+    const row = classified.find(r => r.id === qf.id);
+    expect(row._isClaimedByOther).toBe(false);
+    expect(row._claimBadge).toMatch(/YOURS/);
+  });
+
+  test('unclaimed QF (claiming_session_id null) is startable', () => {
+    const qf = qfRow({ claiming_session_id: null });
+    const { summary } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [],
+      claimedSDs: new Map(),
+    });
+    expect(summary.topStartableQF?.id).toBe(qf.id);
+  });
+});
+
+describe('TS-4 (DEFECT 2): stale-vs-alive holder governs adoptability', () => {
+  test('holder heartbeat <= 900s (LIVE) ⇒ protected: _isClaimedByOther=true, absent from topStartableQF', () => {
+    const qf = qfRow();
+    const { summary, classified } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [holderSession(120)], // 120s << 900s → live
+      claimedSDs: new Map(),
+    });
+    const row = classified.find(r => r.id === qf.id);
+    expect(row._isClaimedByOther).toBe(true);
+    expect(summary.topStartableQF).toBeNull();
+  });
+
+  test('holder heartbeat > 900s ⇒ adoptable: _isClaimedByOther=false, STALE badge, present in topStartableQF', () => {
+    const qf = qfRow();
+    const { summary, classified } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [holderSession(1200)], // 1200s > 900s → not live
+      claimedSDs: new Map(),
+    });
+    const row = classified.find(r => r.id === qf.id);
+    expect(row._isClaimedByOther).toBe(false);
+    expect(row._claimBadge).toMatch(/STALE/);
+    expect(summary.topStartableQF?.id).toBe(qf.id);
+  });
+
+  test('holder ABSENT from activeSessions (released/gone) ⇒ adoptable, STALE badge', () => {
+    const qf = qfRow(); // claiming_session_id set, but holder not in activeSessions
+    const { summary, classified } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [], // holder row missing entirely
+      claimedSDs: new Map(),
+    });
+    const row = classified.find(r => r.id === qf.id);
+    expect(row._isClaimedByOther).toBe(false);
+    expect(row._claimBadge).toMatch(/STALE/);
+    expect(summary.topStartableQF?.id).toBe(qf.id);
+  });
+
+  test('boundary: heartbeat exactly at 900s is treated as LIVE (<=) ⇒ protected', () => {
+    const qf = qfRow();
+    // QF_HOLDER_LIVE_SECONDS = getStaleThresholdSeconds() * 3 = 300 * 3 = 900 by default.
+    const { summary, classified } = classify([qf], {
+      currentSession: CURRENT_SESSION,
+      activeSessions: [holderSession(900)],
+      claimedSDs: new Map(),
+    });
+    const row = classified.find(r => r.id === qf.id);
+    expect(row._isClaimedByOther).toBe(true);
+    expect(summary.topStartableQF).toBeNull();
+  });
+});
+
+describe('TS-3/TS-4 combined: two QFs, one live-held, one stale-held', () => {
+  test('only the stale-held QF is offered as topStartableQF', () => {
+    const liveHeld = qfRow({ id: 'QF-LIVE-0001', claiming_session_id: 'sess-live' });
+    const staleHeld = qfRow({ id: 'QF-STALE-0001', claiming_session_id: 'sess-stale' });
+
+    const activeSessions = [
+      { session_id: 'sess-live', terminal_id: TID_HOLDER, heartbeat_age_seconds: 30, pid: null, hostname: 'h2', status: 'active' },
+      { session_id: 'sess-stale', terminal_id: '33333333-3333-3333-3333-333333333333', heartbeat_age_seconds: 5000, pid: null, hostname: 'h3', status: 'active' },
+    ];
+
+    const { summary, classified } = classify([liveHeld, staleHeld], {
+      currentSession: CURRENT_SESSION,
+      activeSessions,
+      claimedSDs: new Map(),
+    });
+
+    const live = classified.find(r => r.id === 'QF-LIVE-0001');
+    const stale = classified.find(r => r.id === 'QF-STALE-0001');
+    expect(live._isClaimedByOther).toBe(true);
+    expect(stale._isClaimedByOther).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-STALE-0001');
+  });
+});

--- a/tests/unit/qf-dual-prefix.test.js
+++ b/tests/unit/qf-dual-prefix.test.js
@@ -1,0 +1,34 @@
+/**
+ * QF dual-prefix invariant — regression pin
+ * SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-5 step 3)
+ *
+ * FR-5 step 1 changed the HUMAN-DOC "next steps" branch hint from
+ * `quick-fix/<id>` to the canonical `qf/<id>`. FR-5 step 2 mandates that
+ * dual-prefix ACCEPTANCE is preserved everywhere. This single cross-module
+ * test pins that both the canonical `qf/` and the legacy `quick-fix/` prefixes
+ * resolve to the SAME QF key via the branch-key extractor AND are detected by
+ * the ship qf-detector — so a future "consistency" cleanup cannot silently drop
+ * legacy-prefix support (which production merges still use).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractKey } from '../../scripts/lib/branch-key-extractor.js';
+import { isQuickFixBranch, extractQFId } from '../../lib/ship/qf-detector.mjs';
+
+describe('QF dual-prefix invariant (SD-LEO-INFRA-SESSION-AWARE-AUTO-001 FR-5)', () => {
+  const QF_ID = 'QF-20260101-001';
+  const canonical = `qf/${QF_ID}`;
+  const legacy = `quick-fix/${QF_ID}`;
+
+  it('extractKey resolves both prefixes to the same QF key', () => {
+    expect(extractKey(canonical)).toEqual({ kind: 'QF', key: QF_ID });
+    expect(extractKey(legacy)).toEqual({ kind: 'QF', key: QF_ID });
+  });
+
+  it('qf-detector detects both prefixes and extracts the same id', () => {
+    expect(isQuickFixBranch(canonical)).toBe(true);
+    expect(isQuickFixBranch(legacy)).toBe(true);
+    expect(extractQFId(canonical)).toBe(QF_ID);
+    expect(extractQFId(legacy)).toBe(QF_ID);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the QF parallel-session duplicate-work gap (RCA `PAT-QF-AUTOPROCEED-NO-CLAIM-001`): two sessions could both adopt the same quick-fix because the QF auto-proceed/adopt path never wrote `quick_fixes.claiming_session_id`. **No migration** (column + status value already exist).

## Changes
- **FR-1** `lib/quick-fix-claim.mjs` (new): shared **fail-closed CAS** claim — `WHERE id=$qf AND (claiming_session_id IS NULL OR = self)`; idempotent self re-adopt. `claim-guard.mjs reaffirmClaimColumns` QF branch now uses it (warns, never clobbers a live peer).
- **FR-2** `classify-quick-fix.js`: claims on the adopt entrypoint (gated on `CLAUDE_SESSION_ID`); blocks + `exit 2` when a live peer holds it.
- **FR-3/FR-4** `sd-next/display/quick-fixes.js`: excludes live-held QFs via `claiming_session_id` (**not** `sd_key` — which never holds QF ids); liveness boundary matches the sweep (`heartbeat>900s` or missing ⇒ adoptable, so no deadlock).
- **FR-5**: QF branch-doc strings → `qf/<id>`; dual-prefix support retained.

## Testing
TESTING sub-agent **PASS** (evidence `a8be3027`). 25/25 SD-scope assertions: CAS concurrency, self-readopt, foreign-bail, **live-holder-without-sd_key** (TS-3, highest-risk), stale-vs-alive, dual-prefix. No regressions in changed-file-adjacent suites (sd-next 119✓, claim/qf 231✓); one brittle static-pin updated to the new contract.

Design corrected by prospective TESTING (`6f20b938`) — caught that the naive sd_key approach would have been inert. DATABASE confirmed no-migration (`162fcae5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)