### PR TITLE
feat(SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001): durable Completion Flags capture + path-independent enforcement

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -398,7 +398,17 @@ Run the post-completion sequence for the current working SD.
    ```
    Invoke the `learn` skill using Skill tool.
 
-   **Step 5: Next**
+   **Step 5: Capture Completion Flags**
+   ```
+   🚩 Running completion-flags capture...
+   ```
+   Answer the FR-6 reflective interrogation — **"Are there any gaps we failed to close?"** (incidental findings, harness friction, deferred/descoped items, data discrepancies noticed, anything surprising or worked around) — then capture each finding to its durable channel:
+   ```bash
+   node scripts/capture-completion-flags.js --sd <SD-KEY> --flags '<json-array>' --reflection '{"asked":true,"checklist_items":<n>,"gaps_found":<n>}'
+   ```
+   Emit the printed **Completion Flags** block (item | type | routed-to | id) as the LAST section of the completion message; "0 flags" is shown explicitly (never silently omitted). A no-findings SD still writes a witness record. The post-completion Stop hook (`post-completion-validator.js`) reminds if this record is missing. SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001.
+
+   **Step 6: Next**
    ```
    📋 Showing next SD in queue...
    ```
@@ -415,6 +425,7 @@ Run the post-completion sequence for the current working SD.
    - /ship - Changes committed and PR created
    - /heal sd - Codebase verified against SD promises
    - /learn - Patterns captured
+   - capture-completion-flags - Incidental findings flagged to a durable channel (Completion Flags block emitted)
    - sd:next - Queue displayed
    ```
 

--- a/lib/governance/completion-flag-keys.js
+++ b/lib/governance/completion-flag-keys.js
@@ -1,0 +1,22 @@
+/**
+ * Shared frozen contract for completion-flag metadata keys.
+ *
+ * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 / TR-2.
+ *
+ * Imported by BOTH the writer (scripts/capture-completion-flags.js) and the consumer
+ * (scripts/hooks/stop-subagent-enforcement/post-completion-validator.js) so the metadata
+ * keys cannot drift across files — a single source of truth defeats
+ * PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (writer/consumer key drift makes the
+ * enforcement gate a silent permanent no-op).
+ *
+ * Both consumers are ESM (`import`/`export`), so this is a single ESM module — no
+ * CJS mirror is needed and there is exactly ONE literal source for every key.
+ *
+ * @module lib/governance/completion-flag-keys
+ */
+
+export const COMPLETION_FLAG = Object.freeze({
+  ORIGIN_KEY: 'origin',
+  ORIGIN_VALUE: 'completion_flag',
+  SOURCE_SD_KEY: 'source_sd',
+});

--- a/lib/governance/emit-feedback.js
+++ b/lib/governance/emit-feedback.js
@@ -100,12 +100,15 @@ function _validatePriority(priority) {
  */
 function _buildRowObject(args, enrichedMetadata, dedupHash) {
   const { type, category, severity, source_application, source_type, sd_id,
-    title, description, source_id, priority, priority_reasoning } = args;
+    title, description, source_id, priority, priority_reasoning, status, resolution_notes } = args;
   const cappedTitle = title.length > 120 ? `${title.slice(0, 117)}...` : title;
   const row = {
     type,
     category,
-    status: 'new',
+    // SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 TR-1: status is additive — when the
+    // caller omits it (status === undefined/null) the row defaults to 'new', preserving
+    // every legacy caller's behavior. Completion-flag witnesses pass status:'backlog'.
+    status: status || 'new',
     severity,
     source_application,
     source_type,
@@ -123,6 +126,9 @@ function _buildRowObject(args, enrichedMetadata, dedupHash) {
   if (source_id !== undefined && source_id !== null) row.source_id = source_id;
   if (priority !== undefined && priority !== null) row.priority = priority;
   if (priority_reasoning !== undefined && priority_reasoning !== null) row.priority_reasoning = priority_reasoning;
+  // SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 TR-1: resolution_notes pass-through —
+  // mirrors the source_id/priority pattern; only set when supplied. MUST NOT join dedup_hash.
+  if (resolution_notes !== undefined && resolution_notes !== null) row.resolution_notes = resolution_notes;
   return row;
 }
 
@@ -146,6 +152,8 @@ function _buildRowObject(args, enrichedMetadata, dedupHash) {
  * @param {string|null} [args.source_id] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: source-tracking id (UAT scenario id, retro id, etc). Pass-through only — does NOT join dedup_hash.
  * @param {string|null} [args.priority] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: 'critical' | 'high' | 'medium' | 'low'. Validated app-level (TR-4). Pass-through only.
  * @param {string|null} [args.priority_reasoning] - SD-FDBK-INFRA-MIGRATE-EMIT-FEEDBACK-001 FR-1: human-readable rationale for priority. Pass-through only.
+ * @param {string|null} [args.status] - SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 TR-1: feedback.status enum value (additive). When omitted, defaults to 'new' — preserving legacy behavior. Used by completion-flag witnesses (status:'backlog'). MUST NOT join dedup_hash.
+ * @param {string|null} [args.resolution_notes] - SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 TR-1: optional resolution_notes column (additive). Only set when supplied. Pass-through only — MUST NOT join dedup_hash.
  * @param {Object} [args.metadata={}] - Caller-supplied structured metadata
  * @param {string|null} [args.dedup_key] - Dedup component (file path, layer name, etc.)
  * @returns {Promise<{ id: string|null, deduped: boolean }>} insert id, or deduped=true if existing row found
@@ -163,6 +171,8 @@ export async function emitFeedback({
   source_id = null,
   priority = null,
   priority_reasoning = null,
+  status = null,
+  resolution_notes = null,
   metadata = {},
   dedup_key = null,
 } = {}) {
@@ -203,7 +213,7 @@ export async function emitFeedback({
 
   const row = _buildRowObject(
     { type, category, severity, source_application, source_type, sd_id,
-      title, description, source_id, priority, priority_reasoning },
+      title, description, source_id, priority, priority_reasoning, status, resolution_notes },
     enrichedMetadata,
     dedupHash,
   );
@@ -340,6 +350,9 @@ export async function emitFeedbackBatch({ supabase, items = [], shared = {} } = 
       source_id: item.source_id ?? null,
       priority: item.priority ?? null,
       priority_reasoning: item.priority_reasoning ?? null,
+      // SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 TR-1: additive batch pass-through.
+      status: item.status ?? null,
+      resolution_notes: item.resolution_notes ?? null,
     };
     toInsert.push(_buildRowObject(args, enrichedMetadata, dedupHash));
     dualWriteContexts.push({

--- a/scripts/capture-completion-flags.js
+++ b/scripts/capture-completion-flags.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * Completion Flags — capture incidental findings discovered at SD completion to a
+ * durable channel (the `feedback` table) via the canonical writer, then surface them.
+ *
+ * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 / TR-3, TR-4, TR-5 + FR-1, FR-2, FR-6.
+ *
+ * No new tables. Every flag is routed to a (category, type, status) tuple and written
+ * through lib/governance/emit-feedback.js so dedup + audit semantics are shared with
+ * every other feedback writer. The consumer that enforces presence of this record is
+ * scripts/hooks/stop-subagent-enforcement/post-completion-validator.js (FR-4); both
+ * sides import the frozen metadata-key contract from lib/governance/completion-flag-keys.js
+ * so the keys cannot drift (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 defense).
+ *
+ * Usage:
+ *   node scripts/capture-completion-flags.js --sd <SD-KEY> \
+ *     --flags '[{"type":"harness","item":"sweep fired no heartbeat"}]' \
+ *     [--reflection '{"asked":true,"checklist_items":4,"gaps_found":1}']
+ *
+ *   # No findings (still writes the no-flags witness):
+ *   node scripts/capture-completion-flags.js --sd <SD-KEY> --flags '[]'
+ *
+ * @module scripts/capture-completion-flags
+ */
+import 'dotenv/config';
+import crypto from 'node:crypto';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { emitFeedback } from '../lib/governance/emit-feedback.js';
+import { COMPLETION_FLAG } from '../lib/governance/completion-flag-keys.js';
+
+/**
+ * Flag classes whose base routing lands in the harness backlog (deferred-class).
+ * These are intentionally EXCLUDED from /leo assist by
+ * lib/quality/assist-engine.js::splitEnhancementsExcludingHarnessBacklog and surface in
+ * the `npm run sd:next` HARNESS BACKLOG section instead.
+ * @private
+ */
+const HARNESS_FLAG_TYPES = Object.freeze(new Set(['harness', 'quirk', 'friction']));
+
+/**
+ * TR-5: the pinned witness tuple. status:'backlog' parks the row "on the shelf"
+ * (mapFeedbackLifecycle('backlog') === 'ON_THE_SHELF') so it is durable evidence the
+ * reflection ran, without nagging the operator on every assist fall-through. Requires
+ * TR-1 (emit-feedback.js status param).
+ * @private
+ */
+const WITNESS_TUPLE = Object.freeze({ type: 'enhancement', category: 'harness_backlog', status: 'backlog' });
+
+/**
+ * NON-harness category for findings that need a human decision. There is NO CHECK
+ * constraint on feedback.category (verified against information_schema for
+ * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001), so a dedicated free-text value is safe and
+ * keeps these rows OUT of the harness-backlog exclusion — i.e. they reach /leo assist.
+ * @private
+ */
+const NEEDS_DECISION_CATEGORY = 'completion_flag';
+
+function sha256(input) {
+  return crypto.createHash('sha256').update(String(input)).digest('hex');
+}
+
+/**
+ * Stable string used both for the per-finding dedup_key and as the human-facing item
+ * when an explicit `item` was not supplied.
+ * @private
+ */
+function flagFindingText(flag) {
+  return flag.item || flag.finding || flag.description || flag.title || JSON.stringify(flag);
+}
+
+/**
+ * TR-4: pure routing — map a flag to its destination tuple. Unit-testable in isolation.
+ *
+ * Classes:
+ *   - 'harness' | 'quirk' | 'friction' -> harness_backlog / enhancement / new
+ *   - 'needs_decision'                 -> completion_flag (NON-harness) / issue / new
+ *   - 'tied_to_sd'                     -> base class routing + sd_id = flag.sd_id
+ *   - 'already_homed'                  -> { link_only: true } (NO new row)
+ *
+ * For 'tied_to_sd', the underlying class is read from flag.base_type (defaults to
+ * 'harness' when unspecified).
+ *
+ * @param {Object} flag
+ * @param {string} flag.type
+ * @returns {{ category?: string, feedbackType?: string, status?: string, sd_id?: string, link_only?: boolean }}
+ */
+export function routeFlag(flag) {
+  const type = flag?.type;
+
+  if (type === 'already_homed') {
+    // No new row — reference the existing record only.
+    return { link_only: true, existing_id: flag.existing_id ?? null, sd_id: flag.sd_id ?? null };
+  }
+
+  if (type === 'needs_decision') {
+    return { category: NEEDS_DECISION_CATEGORY, feedbackType: 'issue', status: 'new' };
+  }
+
+  if (type === 'tied_to_sd') {
+    // Same routing as the base class, but pinned to a specific SD.
+    const base = routeFlag({ type: flag.base_type || 'harness' });
+    return { ...base, sd_id: flag.sd_id ?? null };
+  }
+
+  // Default / harness family.
+  if (HARNESS_FLAG_TYPES.has(type)) {
+    return { category: 'harness_backlog', feedbackType: 'enhancement', status: 'new' };
+  }
+
+  // Unknown class: treat conservatively as harness-backlog (deferred), never silently drop.
+  return { category: 'harness_backlog', feedbackType: 'enhancement', status: 'new' };
+}
+
+/**
+ * FR-6: build the reflection metadata bag, applying a sane default when absent.
+ * @private
+ */
+function normalizeReflection(reflection) {
+  const r = reflection && typeof reflection === 'object' ? reflection : {};
+  return {
+    asked: r.asked === true,
+    checklist_items: Number.isFinite(r.checklist_items) ? r.checklist_items : 0,
+    gaps_found: Number.isFinite(r.gaps_found) ? r.gaps_found : 0,
+  };
+}
+
+/**
+ * TR-3 / FR-2 / FR-6: write each non-link-only flag to the durable feedback channel via
+ * the canonical writer, and — when there are no real findings — write exactly ONE no-flags
+ * witness (TR-5). The reflection object is always carried in metadata (FR-6).
+ *
+ * @param {Object} args
+ * @param {Object} args.supabase - Supabase client
+ * @param {string} args.sdKey - The SD key (e.g. SD-LEO-INFRA-...)
+ * @param {Array<Object>} [args.flags=[]] - Incidental findings
+ * @param {Object} [args.reflection] - { asked, checklist_items, gaps_found }
+ * @returns {Promise<Array<{ item: string, type: string, routedTo: string, id: string|null }>>}
+ *   One entry per real flag (link-only included with routedTo='already_homed (link only)').
+ */
+export async function captureCompletionFlags({ supabase, sdKey, flags = [], reflection } = {}) {
+  if (!supabase) throw new Error('captureCompletionFlags: supabase client is required');
+  if (!sdKey) throw new Error('captureCompletionFlags: sdKey is required');
+
+  const reflectionBag = normalizeReflection(reflection);
+  const baseMeta = {
+    [COMPLETION_FLAG.ORIGIN_KEY]: COMPLETION_FLAG.ORIGIN_VALUE,
+    [COMPLETION_FLAG.SOURCE_SD_KEY]: sdKey,
+    reflection: reflectionBag,
+  };
+
+  const list = Array.isArray(flags) ? flags : [];
+  const results = [];
+
+  for (const flag of list) {
+    const route = routeFlag(flag);
+    const finding = flagFindingText(flag);
+
+    // 'already_homed' -> link only, no new row.
+    if (route.link_only) {
+      results.push({
+        item: finding,
+        type: flag.type,
+        routedTo: 'already_homed (link only)',
+        id: route.existing_id ?? route.sd_id ?? null,
+      });
+      continue;
+    }
+
+    const dedupKey = `completion-flag::${sdKey}::${sha256(finding).slice(0, 16)}`;
+    const { id } = await emitFeedback({
+      supabase,
+      title: `Completion flag (${flag.type}) — ${sdKey}`,
+      description: finding,
+      type: route.feedbackType,
+      category: route.category,
+      status: route.status,
+      sd_id: route.sd_id ?? null,
+      dedup_key: dedupKey,
+      metadata: {
+        ...baseMeta,
+        flag_class: flag.type,
+      },
+    });
+
+    results.push({
+      item: finding,
+      type: flag.type,
+      routedTo: route.category,
+      id,
+    });
+  }
+
+  // TR-5: no real findings -> write a single no-flags witness so the validator can prove
+  // the reflection happened. Pinned tuple {enhancement, harness_backlog, backlog}.
+  const realFlagCount = results.filter(r => r.routedTo !== 'already_homed (link only)').length;
+  if (realFlagCount === 0) {
+    await emitFeedback({
+      supabase,
+      title: `Completion flags witness — ${sdKey}`,
+      description: `No incidental findings flagged at completion of ${sdKey}.`,
+      type: WITNESS_TUPLE.type,
+      category: WITNESS_TUPLE.category,
+      status: WITNESS_TUPLE.status,
+      dedup_key: `completion-flag-witness::${sdKey}`,
+      metadata: {
+        ...baseMeta,
+        no_flags: true,
+      },
+    });
+  }
+
+  return results;
+}
+
+/**
+ * FR-1: render the standardized "Completion Flags" block. When there are zero real flags
+ * the block prints exactly `- 0 flags` (explicit, never omitted) so the surface is
+ * unambiguous in the completion output.
+ *
+ * @param {Array<{ item: string, type: string, routedTo: string, id: string|null }>} results
+ * @returns {string}
+ */
+export function formatCompletionFlagsBlock(results = []) {
+  const rows = Array.isArray(results) ? results : [];
+  const lines = ['## Completion Flags'];
+  if (rows.length === 0) {
+    lines.push('- 0 flags');
+    return lines.join('\n');
+  }
+  for (const r of rows) {
+    lines.push(`- ${r.item} | ${r.type} | ${r.routedTo} | ${r.id ?? '(deduped)'}`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal `--key value` parser matching house style (scripts/log-harness-bug.js).
+ * @private
+ */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--sd') out.sd = argv[++i];
+    else if (a === '--flags') out.flags = argv[++i];
+    else if (a === '--reflection') out.reflection = argv[++i];
+  }
+  return out;
+}
+
+function parseJsonArg(raw, label, fallback) {
+  if (raw === undefined || raw === null) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`capture-completion-flags: --${label} is not valid JSON: ${e.message}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.sd) {
+    console.error('Usage: node scripts/capture-completion-flags.js --sd <SD-KEY> --flags <json-array> [--reflection <json>]');
+    process.exitCode = 1;
+    return;
+  }
+
+  const flags = parseJsonArg(args.flags, 'flags', []);
+  if (!Array.isArray(flags)) {
+    console.error('capture-completion-flags: --flags must be a JSON array');
+    process.exitCode = 1;
+    return;
+  }
+  const reflection = parseJsonArg(args.reflection, 'reflection', undefined);
+
+  const { createSupabaseServiceClient } = await import('../lib/supabase-client.js');
+  const supabase = createSupabaseServiceClient();
+
+  const results = await captureCompletionFlags({ supabase, sdKey: args.sd, flags, reflection });
+
+  console.log(formatCompletionFlagsBlock(results));
+  const ids = results.map(r => r.id).filter(Boolean);
+  if (ids.length > 0) {
+    console.log(`\nFeedback IDs: ${ids.join(', ')}`);
+  }
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
+++ b/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
@@ -12,6 +12,52 @@
  */
 
 import { execSync } from 'child_process';
+import { COMPLETION_FLAG } from '../../../lib/governance/completion-flag-keys.js';
+
+/**
+ * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 / FR-4 + TR-6.
+ *
+ * Reminder-first witness check: every completed SD should have a durable
+ * "completion flags" record (written by scripts/capture-completion-flags.js) proving the
+ * end-of-SD incidental-findings reflection ran. This runs for ALL completed SD types
+ * (NOT gated by isCodeProducing) and only ever appends to `missingRecommended` — it must
+ * NEVER cause process.exit(2). The query uses the SAME frozen metadata-key contract the
+ * writer uses, so writer/consumer keys cannot drift.
+ *
+ * Returns a WARN string to push into missingRecommended, or null when a valid record exists.
+ * MUST NOT throw — any error resolves to null (no warning, no block).
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdKey - The SD key
+ * @returns {Promise<string|null>}
+ * @private
+ */
+async function _checkCompletionFlagsWitness(supabase, sdKey) {
+  try {
+    const { data: flagRecords, error } = await supabase
+      .from('feedback')
+      .select('id, metadata')
+      .eq('metadata->>' + COMPLETION_FLAG.ORIGIN_KEY, COMPLETION_FLAG.ORIGIN_VALUE)
+      .eq('metadata->>' + COMPLETION_FLAG.SOURCE_SD_KEY, sdKey);
+
+    if (error) return null; // fail-soft: never block on a query error
+
+    const records = flagRecords || [];
+    if (records.length === 0) {
+      return `completion-flags record missing for ${sdKey}; run scripts/capture-completion-flags.js`;
+    }
+
+    // A record is "complete" when its reflection carries a numeric checklist_items count.
+    const hasComplete = records.some(r => typeof r?.metadata?.reflection?.checklist_items === 'number');
+    if (!hasComplete) {
+      return `completion-flags record incomplete for ${sdKey}; run scripts/capture-completion-flags.js`;
+    }
+
+    return null;
+  } catch {
+    return null; // fail-soft
+  }
+}
 
 /**
  * Validate that post-completion commands were executed for a completed SD.
@@ -110,6 +156,16 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
     }
   }
 
+  // SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 / FR-4 + TR-6: completion-flags witness check.
+  // Deliberately OUTSIDE the isCodeProducing branch — every completed SD (regardless of type,
+  // including orchestrators and non-code SDs) should carry the durable completion-flags record.
+  // Reminder-first: this only ever appends to missingRecommended (never missingRequired), so it
+  // can never trigger the process.exit(2) BLOCK path below.
+  const completionFlagsWarn = await _checkCompletionFlagsWitness(supabase, sdKey);
+  if (completionFlagsWarn) {
+    missingRecommended.push('COMPLETION_FLAGS');
+  }
+
   // Output results
   if (missingRequired.length > 0) {
     console.error(`\n⚠️  Post-Completion Validation for ${sdKey}`);
@@ -149,6 +205,9 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
     }
     if (missingRecommended.includes('DOCUMENT')) {
       console.error('   Consider running /document to update documentation');
+    }
+    if (missingRecommended.includes('COMPLETION_FLAGS')) {
+      console.error(`   ${completionFlagsWarn}`);
     }
     console.error('   (Not blocking - these improve continuous improvement)');
   } else {

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -95,7 +95,7 @@ AUTO-PROCEED is ON by default. You continue through phase transitions, PRD creat
 - Any "warrants confirmation" / "want me to continue?" rationalization
 - Numbered menu presentations at decision points
 - Intent to provide a "status checkpoint" after a successful handoff
-- Post-completion /document, /heal, /learn after an SD reaches LEAD-FINAL-APPROVAL — these are CONTINUATION steps, never pause points; "I didn't run them — say the word if you want them" is confirmation-fishing. Run the tail (or drive completion via /leo complete, which sequences /document → /heal → /learn automatically). Enforced by the post-completion-tail-enforcement Stop hook (SD-LEO-INFRA-AUTO-ENFORCE-POST-001).
+- Post-completion /document, /heal, /learn, and **completion-flags capture** after an SD reaches LEAD-FINAL-APPROVAL — these are CONTINUATION steps, never pause points; "I didn't run them — say the word if you want them" is confirmation-fishing. Run the tail (or drive completion via /leo complete, which sequences /document → /heal → /learn → capture-completion-flags automatically). Before emitting the Completion Flags block, answer the reflective interrogation "Are there any gaps we failed to close?" and route each finding via scripts/capture-completion-flags.js (incidental findings → durable feedback channel; "0 flags" shown explicitly). Enforced by the post-completion-tail-enforcement Stop hook (SD-LEO-INFRA-AUTO-ENFORCE-POST-001) + the completion-flags witness check in post-completion-validator.js (SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001).
 
 If your reason for pausing is not on the five-point list above, KEEP WORKING. When in doubt: pick the highest-value option, state it in one sentence, and execute.
 

--- a/tests/unit/governance/completion-flags.test.js
+++ b/tests/unit/governance/completion-flags.test.js
@@ -63,7 +63,7 @@ function buildEmitSupabase({ existingByHash = {} } = {}) {
   };
 
   const supabase = {
-    from: vi.fn((table) => ({
+    from: vi.fn((_table) => ({
       select: vi.fn(() => makeDedupChain()),
       insert: vi.fn((row) => {
         rows.push(row);
@@ -366,7 +366,7 @@ describe('TS-6 reflection completeness gates the validator warning', () => {
 // ---------------------------------------------------------------------------
 describe('TS-7 emitFeedback additive status param (backward-compat)', () => {
   function buildInsertCaptureSupabase() {
-    const insert = vi.fn((row) => ({
+    const insert = vi.fn((_row) => ({
       select: vi.fn(() => ({ single: vi.fn(async () => ({ data: { id: 'fb-1' }, error: null })) })),
     }));
     const dedupSelect = vi.fn(() => ({

--- a/tests/unit/governance/completion-flags.test.js
+++ b/tests/unit/governance/completion-flags.test.js
@@ -1,0 +1,417 @@
+/**
+ * Unit tests for the Completion Flags mechanism.
+ *
+ * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 — TS-1..TS-7.
+ *
+ * Covers:
+ *   TS-1 routeFlag tuple mapping per class
+ *   TS-2 writer/consumer frozen-key contract (constant identity)
+ *   TS-3 witness 3-filter invariant (lifecycle + assist exclusion via the REAL functions)
+ *   TS-4 validator placement (WARN in missingRecommended, no exit(2); record present -> no warn)
+ *   TS-5 idempotency (same-day dedup; distinct findings -> distinct dedup_key)
+ *   TS-6 reflection non-empty (empty -> warns; full -> passes)
+ *   TS-7 emitFeedback backward-compat (no status -> row.status === 'new')
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  routeFlag,
+  captureCompletionFlags,
+  formatCompletionFlagsBlock,
+} from '../../../scripts/capture-completion-flags.js';
+import { COMPLETION_FLAG } from '../../../lib/governance/completion-flag-keys.js';
+import { emitFeedback } from '../../../lib/governance/emit-feedback.js';
+
+// REAL consumer functions (TS-3) — assert the witness tuple against actual behavior.
+import { mapFeedbackLifecycle } from '../../../lib/inbox/unified-inbox-builder.js';
+import { splitEnhancementsExcludingHarnessBacklog } from '../../../lib/quality/assist-engine.js';
+
+// Consumer under test for TS-4/TS-6.
+import { validatePostCompletion } from '../../../scripts/hooks/stop-subagent-enforcement/post-completion-validator.js';
+
+// ---------------------------------------------------------------------------
+// Supabase mock helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock for emit-feedback's dedup+insert chain:
+ *   from('feedback').select(...).eq(...).eq(...).maybeSingle()  -> dedup probe
+ *   from('feedback').insert(row).select('id').single()          -> insert
+ * Records every inserted row on `_rows` and every probed dedup_hash on `_probes`.
+ * `existingByHash` lets a test simulate an already-present row (dedup hit).
+ */
+function buildEmitSupabase({ existingByHash = {} } = {}) {
+  const rows = [];
+  const probes = [];
+
+  const makeDedupChain = () => {
+    let captured = {};
+    const chain = {
+      eq: vi.fn((col, val) => {
+        if (col === 'category') captured.category = val;
+        if (col === 'metadata->>dedup_hash') captured.hash = val;
+        return chain;
+      }),
+      maybeSingle: vi.fn(async () => {
+        probes.push(captured.hash);
+        const hit = existingByHash[captured.hash] || null;
+        return { data: hit, error: null };
+      }),
+    };
+    return chain;
+  };
+
+  const supabase = {
+    from: vi.fn((table) => ({
+      select: vi.fn(() => makeDedupChain()),
+      insert: vi.fn((row) => {
+        rows.push(row);
+        return {
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: { id: `fb-${rows.length}` }, error: null })),
+          })),
+        };
+      }),
+    })),
+    _rows: rows,
+    _probes: probes,
+  };
+  return supabase;
+}
+
+/**
+ * Mock for the post-completion validator. Routes each table to a canned result set.
+ * The `feedback` table responds to the completion-flags witness query
+ * (.eq('metadata->>origin', ...).eq('metadata->>source_sd', ...)).
+ */
+function buildValidatorSupabase({ feedbackRows = [], retros = [], prRecords = [], docmon = [] } = {}) {
+  const terminal = (data) => Promise.resolve({ data, error: null });
+
+  function tableHandler(table) {
+    // Generic chainable builder; .then resolves to the canned data for non-feedback tables.
+    const result =
+      table === 'retrospectives' ? retros :
+      table === 'sd_scope_deliverables' ? prRecords :
+      table === 'sub_agent_execution_results' ? docmon :
+      [];
+
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      ilike: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => terminal(result)),
+      // Some queries end on .eq() (feedback witness) — make the chain thenable so
+      // `await supabase.from('feedback').select().eq().eq()` resolves.
+      then: (resolve) => resolve({ data: table === 'feedback' ? feedbackRows : result, error: null }),
+    };
+    return chain;
+  }
+
+  return { from: vi.fn((table) => tableHandler(table)) };
+}
+
+// ---------------------------------------------------------------------------
+// TS-1 — routeFlag tuple mapping
+// ---------------------------------------------------------------------------
+describe('TS-1 routeFlag tuple mapping per class', () => {
+  it('harness/quirk/friction -> harness_backlog / enhancement / new', () => {
+    for (const type of ['harness', 'quirk', 'friction']) {
+      expect(routeFlag({ type })).toEqual({
+        category: 'harness_backlog',
+        feedbackType: 'enhancement',
+        status: 'new',
+      });
+    }
+  });
+
+  it('needs_decision -> non-harness category / issue / new', () => {
+    const r = routeFlag({ type: 'needs_decision' });
+    expect(r.feedbackType).toBe('issue');
+    expect(r.status).toBe('new');
+    expect(r.category).not.toBe('harness_backlog'); // must NOT be excluded from /leo assist
+  });
+
+  it('tied_to_sd -> base class routing + sd_id', () => {
+    const r = routeFlag({ type: 'tied_to_sd', base_type: 'harness', sd_id: 'sd-uuid-9' });
+    expect(r.category).toBe('harness_backlog');
+    expect(r.feedbackType).toBe('enhancement');
+    expect(r.sd_id).toBe('sd-uuid-9');
+  });
+
+  it('already_homed -> link_only, no new row', () => {
+    const r = routeFlag({ type: 'already_homed', existing_id: 'fb-existing' });
+    expect(r.link_only).toBe(true);
+    expect(r.existing_id).toBe('fb-existing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-2 — writer/consumer frozen-key contract
+// ---------------------------------------------------------------------------
+describe('TS-2 writer/consumer key contract (frozen constant identity)', () => {
+  it('capture writes metadata under the frozen ORIGIN/SOURCE keys', async () => {
+    const supabase = buildEmitSupabase();
+    await captureCompletionFlags({
+      supabase,
+      sdKey: 'SD-TEST-001',
+      flags: [{ type: 'harness', item: 'sweep fired with no heartbeat' }],
+      reflection: { asked: true, checklist_items: 3, gaps_found: 0 },
+    });
+    const inserted = supabase._rows[0];
+    expect(inserted.metadata[COMPLETION_FLAG.ORIGIN_KEY]).toBe(COMPLETION_FLAG.ORIGIN_VALUE);
+    expect(inserted.metadata[COMPLETION_FLAG.SOURCE_SD_KEY]).toBe('SD-TEST-001');
+  });
+
+  it('the validator imports the SAME frozen constant object (identity)', async () => {
+    // The writer module and the validator module both `import { COMPLETION_FLAG }`
+    // from lib/governance/completion-flag-keys.js. ESM module caching guarantees a
+    // single shared object instance, so the test-visible constant IS the same object
+    // both modules reference. A drift in the literal source would break BOTH the
+    // capture assertion above AND the validator query below simultaneously.
+    const capModule = await import('../../../scripts/capture-completion-flags.js');
+    const keysModule = await import('../../../lib/governance/completion-flag-keys.js');
+    expect(keysModule.COMPLETION_FLAG).toBe(COMPLETION_FLAG); // identity, not deep-equal
+    // The constant is frozen — a mutation attempt is silently ignored, so neither the
+    // writer nor the consumer can drift it at runtime.
+    expect(Object.isFrozen(COMPLETION_FLAG)).toBe(true);
+    const before = COMPLETION_FLAG.ORIGIN_VALUE;
+    try { COMPLETION_FLAG.ORIGIN_VALUE = 'mutated'; } catch { /* strict-mode throw OK */ }
+    expect(COMPLETION_FLAG.ORIGIN_VALUE).toBe(before);
+    expect(capModule.routeFlag).toBeTypeOf('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-3 — witness 3-filter invariant
+// ---------------------------------------------------------------------------
+describe('TS-3 witness tuple invariant {enhancement, harness_backlog, backlog}', () => {
+  it('status=backlog maps to ON_THE_SHELF (NOT NEW) in the real inbox lifecycle', () => {
+    // Witness uses status:'backlog' so it parks on the shelf rather than nagging in NEW.
+    expect(mapFeedbackLifecycle('backlog')).toBe('ON_THE_SHELF');
+    expect(mapFeedbackLifecycle('backlog')).not.toBe('NEW');
+  });
+
+  it('category=harness_backlog is dropped by the real /leo assist enhancements split', () => {
+    const witnessRow = { type: 'enhancement', category: 'harness_backlog' };
+    const otherRow = { type: 'enhancement', category: 'completion_flag' };
+    const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog([witnessRow, otherRow]);
+    expect(skippedHarnessBacklog).toBe(1);
+    expect(enhancements).toHaveLength(1);
+    expect(enhancements[0].category).toBe('completion_flag'); // witness excluded, decision-flag kept
+  });
+
+  it('captureCompletionFlags writes exactly the pinned witness tuple when no flags', async () => {
+    const supabase = buildEmitSupabase();
+    await captureCompletionFlags({
+      supabase,
+      sdKey: 'SD-TEST-002',
+      flags: [],
+      reflection: { asked: true, checklist_items: 5, gaps_found: 0 },
+    });
+    expect(supabase._rows).toHaveLength(1);
+    const witness = supabase._rows[0];
+    expect(witness.type).toBe('enhancement');
+    expect(witness.category).toBe('harness_backlog');
+    expect(witness.status).toBe('backlog');
+    expect(witness.metadata.no_flags).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-4 — validator placement
+// ---------------------------------------------------------------------------
+describe('TS-4 validator placement (reminder-first, never exit(2))', () => {
+  let exitSpy;
+  let errSpy;
+  let logSpy;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('UNEXPECTED_EXIT'); });
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  // Completed, NON-code-producing SD with a completion_date so the SHIP block never fires
+  // and the isCodeProducing branch is skipped — isolating the completion-flags witness check.
+  const sd = {
+    id: 'sd-uuid-INFRA',
+    sd_key: 'SD-INFRA-XYZ-001',
+    sd_type: 'infrastructure',
+    completion_date: '2026-06-04T00:00:00Z',
+  };
+
+  it('no completion-flags record -> COMPLETION_FLAGS warning, no exit(2)', async () => {
+    const supabase = buildValidatorSupabase({ feedbackRows: [] });
+    await validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001');
+    expect(exitSpy).not.toHaveBeenCalled();
+    const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(advisories).toContain('Missing recommended');
+    expect(advisories).toMatch(/completion-flags record missing/i);
+    expect(advisories).toContain('scripts/capture-completion-flags.js');
+  });
+
+  it('valid completion-flags record present -> no COMPLETION_FLAGS warning', async () => {
+    const supabase = buildValidatorSupabase({
+      feedbackRows: [{ id: 'fb-1', metadata: { reflection: { checklist_items: 4 } } }],
+    });
+    await validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001');
+    expect(exitSpy).not.toHaveBeenCalled();
+    const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(advisories).not.toMatch(/completion-flags record (missing|incomplete)/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-5 — idempotency
+// ---------------------------------------------------------------------------
+describe('TS-5 idempotency (same-day dedup; distinct findings -> distinct keys)', () => {
+  it('capturing the same finding twice in a day dedups on the second pass', async () => {
+    // First pass: no existing rows -> insert. Capture the probed dedup_hash.
+    const first = buildEmitSupabase();
+    await captureCompletionFlags({
+      supabase: first,
+      sdKey: 'SD-TEST-005',
+      flags: [{ type: 'harness', item: 'same finding' }],
+      reflection: { asked: true, checklist_items: 1, gaps_found: 0 },
+    });
+    expect(first._rows).toHaveLength(1);
+    const hash = first._probes[0];
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+
+    // Second pass: same day + same finding -> emit-feedback's dedup probe hits -> no insert.
+    const second = buildEmitSupabase({ existingByHash: { [hash]: { id: 'fb-existing' } } });
+    const results = await captureCompletionFlags({
+      supabase: second,
+      sdKey: 'SD-TEST-005',
+      flags: [{ type: 'harness', item: 'same finding' }],
+      reflection: { asked: true, checklist_items: 1, gaps_found: 0 },
+    });
+    expect(second._rows).toHaveLength(0); // deduped: no new INSERT
+    expect(results[0].id).toBe('fb-existing');
+  });
+
+  it('distinct findings produce distinct dedup_hash probes', async () => {
+    const supabase = buildEmitSupabase();
+    await captureCompletionFlags({
+      supabase,
+      sdKey: 'SD-TEST-005b',
+      flags: [
+        { type: 'harness', item: 'finding A' },
+        { type: 'harness', item: 'finding B' },
+      ],
+      reflection: { asked: true, checklist_items: 2, gaps_found: 0 },
+    });
+    expect(supabase._probes).toHaveLength(2);
+    expect(supabase._probes[0]).not.toBe(supabase._probes[1]);
+    expect(supabase._rows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-6 — reflection non-empty
+// ---------------------------------------------------------------------------
+describe('TS-6 reflection completeness gates the validator warning', () => {
+  let exitSpy, errSpy, logSpy;
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('UNEXPECTED_EXIT'); });
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    exitSpy.mockRestore(); errSpy.mockRestore(); logSpy.mockRestore();
+  });
+
+  const sd = { id: 'sd-uuid-R', sd_key: 'SD-R-001', sd_type: 'infrastructure', completion_date: '2026-06-04T00:00:00Z' };
+
+  it('record present but reflection empty (no numeric checklist_items) -> warns', async () => {
+    const supabase = buildValidatorSupabase({
+      feedbackRows: [{ id: 'fb-1', metadata: { reflection: {} } }], // checklist_items missing
+    });
+    await validatePostCompletion(supabase, sd, 'SD-R-001');
+    const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(advisories).toMatch(/completion-flags record incomplete/i);
+  });
+
+  it('record present with full reflection (numeric checklist_items) -> no warn', async () => {
+    const supabase = buildValidatorSupabase({
+      feedbackRows: [{ id: 'fb-1', metadata: { reflection: { checklist_items: 6, asked: true, gaps_found: 1 } } }],
+    });
+    await validatePostCompletion(supabase, sd, 'SD-R-001');
+    const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(advisories).not.toMatch(/completion-flags record (missing|incomplete)/i);
+  });
+
+  it('captureCompletionFlags always carries the reflection bag in metadata (FR-6)', async () => {
+    const supabase = buildEmitSupabase();
+    await captureCompletionFlags({
+      supabase,
+      sdKey: 'SD-TEST-006',
+      flags: [{ type: 'harness', item: 'x' }],
+      reflection: { asked: true, checklist_items: 7, gaps_found: 2 },
+    });
+    const meta = supabase._rows[0].metadata;
+    expect(meta.reflection).toEqual({ asked: true, checklist_items: 7, gaps_found: 2 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS-7 — emitFeedback backward-compat
+// ---------------------------------------------------------------------------
+describe('TS-7 emitFeedback additive status param (backward-compat)', () => {
+  function buildInsertCaptureSupabase() {
+    const insert = vi.fn((row) => ({
+      select: vi.fn(() => ({ single: vi.fn(async () => ({ data: { id: 'fb-1' }, error: null })) })),
+    }));
+    const dedupSelect = vi.fn(() => ({
+      eq: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })) })),
+    }));
+    return { from: vi.fn(() => ({ select: dedupSelect, insert })), _insert: insert };
+  }
+
+  it('called WITHOUT status -> inserted row.status === "new"', async () => {
+    const supabase = buildInsertCaptureSupabase();
+    await emitFeedback({ supabase, title: 't', description: 'd' });
+    expect(supabase._insert.mock.calls[0][0].status).toBe('new');
+  });
+
+  it('called WITH status -> inserted row.status honored', async () => {
+    const supabase = buildInsertCaptureSupabase();
+    await emitFeedback({ supabase, title: 't', description: 'd', status: 'backlog' });
+    expect(supabase._insert.mock.calls[0][0].status).toBe('backlog');
+  });
+
+  it('resolution_notes is only set when supplied (additive pass-through)', async () => {
+    const supabase = buildInsertCaptureSupabase();
+    await emitFeedback({ supabase, title: 't', description: 'd' });
+    expect('resolution_notes' in supabase._insert.mock.calls[0][0]).toBe(false);
+
+    const supabase2 = buildInsertCaptureSupabase();
+    await emitFeedback({ supabase: supabase2, title: 't', description: 'd', resolution_notes: 'note' });
+    expect(supabase2._insert.mock.calls[0][0].resolution_notes).toBe('note');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-1 — output block formatting (explicit 0-flags)
+// ---------------------------------------------------------------------------
+describe('FR-1 formatCompletionFlagsBlock', () => {
+  it('prints "- 0 flags" explicitly when empty', () => {
+    const block = formatCompletionFlagsBlock([]);
+    expect(block).toContain('## Completion Flags');
+    expect(block).toContain('- 0 flags');
+  });
+
+  it('prints one row per flag with item | type | routed-to | id', () => {
+    const block = formatCompletionFlagsBlock([
+      { item: 'finding A', type: 'harness', routedTo: 'harness_backlog', id: 'fb-1' },
+    ]);
+    expect(block).toContain('- finding A | harness | harness_backlog | fb-1');
+  });
+});


### PR DESCRIPTION
## Summary
Builds a **Completion Flags** step into the SD post-completion tail so incidental findings discovered DURING an SD (harness quirks, deferred housekeeping, data discrepancies, things noticed in passing) are captured to a durable, queryable channel, surfaced compactly, and enforced so they can't be silently lost when a session closes.

Reuses existing governance plumbing — `lib/governance/emit-feedback.js`, the post-completion Stop-hook enforcement, unified-inbox — with **NO new tables**.

## What's included
- **TR-1** additive `emitFeedback` `status` + `resolution_notes` params (default `'new'`, backward-compatible) — unblocks the no-flags witness.
- **TR-2** frozen `lib/governance/completion-flag-keys.js` shared by writer + consumer (writer/consumer-drift defense, PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
- **FR-1/FR-2/FR-6** `scripts/capture-completion-flags.js`: `routeFlag()` pinned routing tuples, pinned witness tuple `{enhancement,harness_backlog,backlog}`, per-finding dedup keys, structural `metadata.reflection`, explicit `- 0 flags` block.
- **FR-4** `post-completion-validator.js` witness check **outside** `isCodeProducing` (covers infrastructure SDs), reminder-first WARN only (never `exit-2`), fail-soft.
- **FR-3** codified in the `/leo complete` sequence + the CLAUDE.md generator tail.

## Testing
`38/38` green (21 new TS-1..7 + FR-1; 17 existing emit-feedback prove TR-1 backward-compat). Prospective testing (evidence `b45b4290`) caught the TR-1 status-param blocker before implementation.

## PR size
842 lines, of which **417 are tests**. The feature is cohesive — the writer, consumer, and frozen key-contract must land atomically or the enforcement gate is a permanent no-op; splitting would create broken intermediate states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)