### PR TITLE
fix(SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001): sd_type-aware resolveVenturePrefix stops ambient venture-prefix leak

### DIFF
--- a/lib/eva/bridge/sd-router.js
+++ b/lib/eva/bridge/sd-router.js
@@ -46,10 +46,13 @@ export const LEGITIMATE_NO_VENTURE_SD_TYPES = new Set([
 ]);
 
 /**
- * Internal: validate the null-venture branch against sd_type / metadata.
+ * Validate the null-venture branch against sd_type / metadata.
+ * Exported (SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001) so the single classifier is reused by
+ * the leo-create-sd venture-prefix resolver and the applications auto-register guard —
+ * one source of truth, no inline re-implementations. BEHAVIOR IS UNCHANGED (C-SEC-8B).
  * @returns {boolean} true if null-venture is legitimate
  */
-function isLegitimateNoVenture(sd_type, metadata) {
+export function isLegitimateNoVenture(sd_type, metadata) {
   if (sd_type && LEGITIMATE_NO_VENTURE_SD_TYPES.has(sd_type)) return true;
   if (metadata?.engineering_only === true) return true;
   return false;

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -48,9 +48,10 @@ import { runTriageGate } from './modules/triage-gate.js';
 import { evaluateVisionReadiness, formatRubricResult } from './modules/vision-readiness-rubric.js';
 import { scoreSD } from './eva/vision-scorer.js';
 import { trackWriteSource } from '../lib/eva/cli-write-gate.js';
-// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5): canonical no-venture sd_type set — used to
-// guard the applications auto-register so engineering/governance work never mints a spurious venture.
-import { LEGITIMATE_NO_VENTURE_SD_TYPES } from '../lib/eva/bridge/sd-router.js';
+// SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5) + SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001:
+// shared no-venture classifier — guards the applications auto-register AND the venture-prefix
+// resolver so engineering/governance work never inherits a spurious venture prefix.
+import { isLegitimateNoVenture } from '../lib/eva/bridge/sd-router.js';
 import { validateSDFields } from './modules/validate-sd-fields.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: path-based target detector
@@ -213,8 +214,45 @@ export async function enrichFromVisionArch(visionKey, archKey, sb) {
   };
 }
 
-async function resolveVenturePrefix(cliVenture = null) {
-  // 1. CLI flag (highest priority)
+/**
+ * Non-throwing alias→canonical normalizer for the venture-suppression decision ONLY.
+ * SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001: must NOT route through mapToDbType/assertValidSdType
+ * (those throw on non-canonical input such as 'governance'); classifying for a cosmetic prefix
+ * must never throw. Unknown input is returned lowercased so an unmapped type simply fails the
+ * no-venture membership check (default 'stamp' behavior preserved).
+ * @param {string|null} rawType
+ * @returns {string} canonical-ish type for the membership check (never throws)
+ */
+function normalizeTypeForVentureCheck(rawType) {
+  if (!rawType || typeof rawType !== 'string') return '';
+  const t = rawType.trim().toLowerCase();
+  const alias = {
+    infra: 'infrastructure',
+    doc: 'documentation',
+    docs: 'documentation',
+    qa: 'infrastructure',
+    testing: 'infrastructure',
+    gov: 'governance'
+  };
+  return alias[t] || t;
+}
+
+/**
+ * Resolve the venture prefix for an SD key.
+ *
+ * SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001: sd_type-aware. Legitimate-no-venture types
+ * (infrastructure/governance/leo/documentation/refactor + metadata.engineering_only) must NEVER
+ * inherit an AMBIENT venture (the VENTURE env var OR the active session's active_venture_id).
+ * Only an explicit per-invocation --venture flag stamps a prefix on such SDs. Genuine venture
+ * types and unknown types are unaffected (env → session → null, exactly as before).
+ *
+ * @param {string|null} cliVenture - explicit --venture flag value (highest priority, ALL types)
+ * @param {string|null} sdType - the SD type (raw alias accepted; normalized internally)
+ * @param {object} [deps] - test seam: { getActiveVenture } overrides the live session lookup
+ * @returns {Promise<string|null>} normalized venture prefix or null
+ */
+export async function resolveVenturePrefix(cliVenture = null, sdType = null, deps = {}) {
+  // 1. CLI flag (highest priority — explicit intent wins for ALL types, including no-venture)
   if (cliVenture) {
     const prefix = normalizeVenturePrefix(cliVenture);
     if (prefix) {
@@ -223,7 +261,17 @@ async function resolveVenturePrefix(cliVenture = null) {
     }
   }
 
-  // 2. Environment variable
+  // SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001: suppress AMBIENT venture (env + session) for
+  // legitimate-no-venture SD types. Classification uses a non-throwing normalize, then the
+  // shared isLegitimateNoVenture helper (no metadata at resolve time → sd_type-only check).
+  // Gating BOTH ambient sources is load-bearing: leaving step 2 (env) ungated leaks in CI/cron.
+  const canonicalType = normalizeTypeForVentureCheck(sdType);
+  if (isLegitimateNoVenture(canonicalType)) {
+    console.log(`   🚫 [VENTURE-SUPPRESS] sd_type=${sdType ?? '(none)'} is no-venture — ambient venture prefix suppressed (use --venture to override)`);
+    return null;
+  }
+
+  // 2. Environment variable (ambient)
   const envVenture = process.env.VENTURE;
   if (envVenture) {
     const prefix = normalizeVenturePrefix(envVenture);
@@ -233,10 +281,14 @@ async function resolveVenturePrefix(cliVenture = null) {
     }
   }
 
-  // 3. Active session context
+  // 3. Active session context (ambient)
   try {
-    const vcm = new VentureContextManager({ supabaseClient: supabase });
-    const venture = await vcm.getActiveVenture();
+    const getActiveVenture = deps.getActiveVenture
+      || (async () => {
+        const vcm = new VentureContextManager({ supabaseClient: supabase });
+        return vcm.getActiveVenture();
+      });
+    const venture = await getActiveVenture();
     if (venture) {
       const prefix = normalizeVenturePrefix(venture.name);
       if (prefix) {
@@ -290,7 +342,7 @@ async function createFromUAT(testId) {
   } catch { /* non-fatal */ }
 
   // Resolve venture context (SD-LEO-INFRA-SD-NAMESPACING-001)
-  const venturePrefix = await resolveVenturePrefix();
+  const venturePrefix = await resolveVenturePrefix(null, type);
 
   // Generate key
   const sdKey = await generateSDKey({
@@ -339,7 +391,7 @@ async function createFromLearn(patternId) {
   const type = pattern.lesson_type === 'bug' ? 'fix' : 'enhancement';
 
   // Resolve venture context (SD-LEO-INFRA-SD-NAMESPACING-001)
-  const venturePrefix = await resolveVenturePrefix();
+  const venturePrefix = await resolveVenturePrefix(null, type);
 
   // Generate key
   const sdKey = await generateSDKey({
@@ -438,7 +490,7 @@ async function createFromFeedback(feedbackId, options = {}) {
   } catch { /* non-fatal */ }
 
   // Resolve venture context (SD-LEO-INFRA-SD-NAMESPACING-001)
-  const venturePrefix = await resolveVenturePrefix();
+  const venturePrefix = await resolveVenturePrefix(null, type);
 
   // Generate key
   const sdKey = await generateSDKey({
@@ -522,7 +574,7 @@ async function createFromQF(qfId) {
   // Map QF severity → SD priority (1:1 enum overlap).
   const priority = ['critical', 'high', 'medium', 'low'].includes(qf.severity) ? qf.severity : 'medium';
 
-  const venturePrefix = await resolveVenturePrefix();
+  const venturePrefix = await resolveVenturePrefix(null, type);
   const sdKey = await generateSDKey({ source: 'LEO', type, title: qf.title, venturePrefix });
 
   const sd = await createSD({
@@ -840,7 +892,7 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
   // Step 5: Generate SD key
   // Protocol files (CLAUDE_CORE.md, CLAUDE_LEAD.md) must be read before SD creation
   // Resolve venture context (SD-LEO-INFRA-SD-NAMESPACING-001)
-  const venturePrefix = await resolveVenturePrefix();
+  const venturePrefix = await resolveVenturePrefix(null, parsed.type);
 
   const sdKey = await generateSDKey({
     source: 'LEO',
@@ -1795,19 +1847,19 @@ async function createSD(options) {
     if (appName) {
       const PLATFORM_REPOS = new Set(['ehg', 'ehg_engineer']);
       const isPlatform = PLATFORM_REPOS.has(String(appName).toLowerCase());
-      // FR-5 NO-VENTURE GUARD (mirrors lib/eva/bridge/sd-router.js isLegitimateNoVenture):
+      // FR-5 NO-VENTURE GUARD (uses the shared lib/eva/bridge/sd-router.js isLegitimateNoVenture
+      // helper — SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001 replaced the inline re-implementation):
       // engineering/governance LEO work (sd_type in LEGITIMATE_NO_VENTURE_SD_TYPES, or
       // metadata.engineering_only=true) must NOT mint a NEW 'venture' registry entry. Such an SD
       // legitimately targets a platform repo (default EHG_Engineer); a NON-platform target on it
       // is a misroute, so we skip registration (surfaced loudly) rather than polluting the registry
       // with a phantom venture the deferred fail-closed trigger would then accept.
-      const isNoVentureWork = LEGITIMATE_NO_VENTURE_SD_TYPES.has(sdData.sd_type)
-        || sdData.metadata?.engineering_only === true;
+      const isNoVentureWork = isLegitimateNoVenture(sdData.sd_type, sdData.metadata);
       if (!isPlatform && isNoVentureWork) {
         console.warn(
           `   ⚠️  Skipping applications auto-register: engineering SD (sd_type=${sdData.sd_type}) has a `
           + `non-platform target_application '${appName}'. Engineering/governance work should target a `
-          + `platform repo (EHG/EHG_Engineer) — refusing to mint a phantom venture (FR-5 no-venture guard).`
+          + 'platform repo (EHG/EHG_Engineer) — refusing to mint a phantom venture (FR-5 no-venture guard).'
         );
       } else {
         const { data: existing } = await supabase
@@ -2384,7 +2436,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // Check for --venture flag in args
       const ventureArgIdx = args.indexOf('--venture');
       const cliVenture = ventureArgIdx !== -1 ? args[ventureArgIdx + 1] : null;
-      const venturePrefix = await resolveVenturePrefix(cliVenture);
+      const venturePrefix = await resolveVenturePrefix(cliVenture, type);
 
       // Parse --vision-key and --arch-key flags (SD-MAN-INFRA-AUTOMATE-BRAINSTORM-PIPELINE-002)
       const visionKeyIdx = args.indexOf('--vision-key');

--- a/tests/unit/scripts/leo-create-sd-venture-prefix.test.js
+++ b/tests/unit/scripts/leo-create-sd-venture-prefix.test.js
@@ -1,0 +1,108 @@
+/**
+ * SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001 — witness + regression suite for the sd_type-aware
+ * venture-prefix resolver. Proves an ambient venture (VENTURE env var OR active session) is
+ * NEVER stamped onto a legitimate-no-venture SD type, while explicit intent and genuine venture
+ * work are unaffected. Plus a meta-test that derives the call-site list from the source so a
+ * future 7th call site cannot silently reintroduce the leak.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { resolveVenturePrefix } from '../../../scripts/leo-create-sd.js';
+
+// Test seam: simulate "an ambient venture is active in the session" without a live DB.
+const ambient = (name = 'DataDistill') => ({ getActiveVenture: async () => ({ name }) });
+const noAmbient = { getActiveVenture: async () => null };
+
+describe('SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001: resolveVenturePrefix sd_type-awareness', () => {
+  let savedVenture;
+  beforeEach(() => { savedVenture = process.env.VENTURE; delete process.env.VENTURE; });
+  afterEach(() => {
+    if (savedVenture === undefined) delete process.env.VENTURE;
+    else process.env.VENTURE = savedVenture;
+  });
+
+  // (a) core fix — infrastructure + ambient session venture present → NO prefix
+  it('(a) suppresses the ambient session venture for an infrastructure SD', async () => {
+    const prefix = await resolveVenturePrefix(null, 'infrastructure', ambient('DataDistill'));
+    expect(prefix).toBeNull();
+  });
+
+  // (b) explicit --venture overrides suppression for a no-venture type
+  it('(b) honors an explicit --venture flag even for a no-venture type', async () => {
+    const prefix = await resolveVenturePrefix('Acme Labs', 'infrastructure', ambient('DataDistill'));
+    expect(prefix).toBe('ACME-LABS');
+  });
+
+  // (c) no over-correction — genuine venture work (feature) still stamped
+  it('(c) still stamps the ambient venture for a genuine venture type (feature)', async () => {
+    const prefix = await resolveVenturePrefix(null, 'feature', ambient('DataDistill'));
+    expect(prefix).toBe('DATADISTILL');
+  });
+
+  // (d) alias-normalization proof — raw 'infra' behaves identically to 'infrastructure'
+  it("(d) classifies the raw alias 'infra' identically to 'infrastructure'", async () => {
+    const prefix = await resolveVenturePrefix(null, 'infra', ambient('DataDistill'));
+    expect(prefix).toBeNull();
+  });
+
+  // (d-trim) whitespace-padded / mixed-case alias still classifies as no-venture
+  it('(d-trim) tolerates whitespace and case in the alias and still suppresses', async () => {
+    expect(await resolveVenturePrefix(null, '  infra  ', ambient('DataDistill'))).toBeNull();
+    expect(await resolveVenturePrefix(null, 'INFRASTRUCTURE', ambient('DataDistill'))).toBeNull();
+  });
+
+  // (e) no-venture parity for governance and leo
+  it('(e) suppresses ambient venture for governance and leo types', async () => {
+    expect(await resolveVenturePrefix(null, 'governance', ambient())).toBeNull();
+    expect(await resolveVenturePrefix(null, 'leo', ambient())).toBeNull();
+  });
+
+  // (g) BOTH ambient sources gated — env-var path is suppressed too (CI/cron leak vector)
+  it('(g) suppresses the VENTURE env var for an infrastructure SD', async () => {
+    process.env.VENTURE = 'SomeVenture';
+    const prefix = await resolveVenturePrefix(null, 'infrastructure', noAmbient);
+    expect(prefix).toBeNull();
+  });
+
+  // env var still applies to a genuine venture type (proves we only gate no-venture types)
+  it('(env-positive) still applies the VENTURE env var for a feature SD', async () => {
+    process.env.VENTURE = 'EnvVenture';
+    const prefix = await resolveVenturePrefix(null, 'feature', noAmbient);
+    expect(prefix).toBe('ENVVENTURE');
+  });
+
+  // classification must never throw, even for non-canonical / unknown input
+  it('(robustness) never throws for governance/leo/unknown sd_type', async () => {
+    await expect(resolveVenturePrefix(null, 'governance', noAmbient)).resolves.toBeNull();
+    await expect(resolveVenturePrefix(null, 'zzz-unknown', noAmbient)).resolves.toBeNull();
+    await expect(resolveVenturePrefix(null, null, noAmbient)).resolves.toBeNull();
+  });
+});
+
+describe('SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001: call-site meta-test (derived from source)', () => {
+  it('every resolveVenturePrefix call site threads the sd_type argument', () => {
+    const srcPath = fileURLToPath(new URL('../../../scripts/leo-create-sd.js', import.meta.url));
+    const src = fs.readFileSync(srcPath, 'utf8');
+    const callRegex = /resolveVenturePrefix\(([^)]*)\)/g;
+    const offenders = [];
+    let m;
+    while ((m = callRegex.exec(src)) !== null) {
+      const args = m[1];
+      const before = src.slice(Math.max(0, m.index - 40), m.index);
+      if (before.includes('function ')) continue; // skip the definition
+      // A real call MUST pass the sd_type (2nd) argument — i.e. contain a comma.
+      if (!args.includes(',')) offenders.push(args.trim() || '(empty)');
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('finds the expected number of call sites (6) plus the definition', () => {
+    const srcPath = fileURLToPath(new URL('../../../scripts/leo-create-sd.js', import.meta.url));
+    const src = fs.readFileSync(srcPath, 'utf8');
+    const total = (src.match(/resolveVenturePrefix\(/g) || []).length;
+    // 1 definition + 6 call sites. If this changes, a call site was added/removed —
+    // update the count AND ensure the new site threads sd_type (see the offender test above).
+    expect(total).toBe(7);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001 — stop ambient venture-prefix leak onto no-venture SDs

### Problem
`scripts/leo-create-sd.js` `resolveVenturePrefix()` was `sd_type`-blind. Its fallback chain — (1) `--venture` flag → (2) `VENTURE` env → (3) ambient session `active_venture_id` — fired for **every** SD type. Creating a platform `infrastructure` SD while a venture-build session was active produced keys like `SD-DATADISTILL-LEO-INFRA-FIX-MIGRATION-OWNERSHIP-001` (target correctly EHG_Engineer, `venture_id` NULL) → wrong branch name + DataDistill mis-grouping + venture-accounting drift. Corrected in-place twice before this fix.

### Fix
- **`resolveVenturePrefix(cliVenture, sdType, deps)`** is now `sd_type`-aware: after the explicit `--venture` check, legitimate-no-venture types (`infrastructure`/`governance`/`leo`/`documentation`/`refactor`) return `null` **before** consulting the env var **or** the session — both ambient sources gated.
- **Export `isLegitimateNoVenture`** (behavior-neutral) from `lib/eva/bridge/sd-router.js` and reuse it at the `applications` auto-register guard, removing the inline re-implementation (single source of truth).
- **Non-throwing alias normalization** (`infra` == `infrastructure`, trim + case-insensitive) — does **not** route through the throwing `mapToDbType`, so classification never throws on non-canonical input.
- Threaded `sd_type` into **all 6** call sites (UAT/LEARN/FEEDBACK/QF/plan/interactive).

### Why this design (prospective-testing pre-empted 5 half-fix traps)
The LEAD-phase prospective `testing-agent` caught that the naive "thread raw type + check the set" approach would silently no-op on aliases (`infra`), throw on `governance` via `mapToDbType`, add a dead `engineering_only` param, be untestable (unexported), and leak via the env var. All five are closed; see the PRD FRs/TRs.

### Scope
- **IN:** resolver suppression, helper export + DRY guard, alias normalization, 6 call-site threading, 11-case witness suite + code-derived call-site meta-test.
- **OUT (deferred, documented):** full 3-way `LEGITIMATE_NO_VENTURE_SD_TYPES` ↔ `CANONICAL_SD_TYPES` ↔ `mapToDbType` reconciliation; `--engineering-only` flag; `--venture` plumbing into the 5 non-interactive paths; the adjacent `createSD` category-derivation raw-type bug (`leo-create-sd.js:1431`).
- `generateSDKey` (`sd-key-generator.js`) is intentionally **unmodified** (stays pure). No DB migration; behavior fix ships ON.

### Testing
- Witness suite `tests/unit/scripts/leo-create-sd-venture-prefix.test.js`: **11/11** (cases a–g incl. alias-trim, env-gated, no-over-correction, robustness, + 2 meta-tests).
- Regression: `sd-router` + `leo-create-sd-vision-prescreen` + `sd-namespacing` = **47/47** unchanged.
- **testing-agent PASS** (conf 95, `f95db614`) — 20/20 adversarial probes; **security-agent PASS** (conf 98, `201185ca`) — C-SEC-8B null-venture guard intact (export-only, routing path untouched).

### PR size
205 LOC (+184/−21). Source ≈ 60 LOC; the remaining ≈ 110 is the 11-case witness/regression suite. Justified by the 5 blocker-closing requirements + full witness coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
