### PR TITLE
fix(SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001): re-exec recovery for orphaned-worktree handoffs + wire orphan detector

### DIFF
--- a/lib/handoff-reexec.mjs
+++ b/lib/handoff-reexec.mjs
@@ -1,0 +1,82 @@
+/**
+ * lib/handoff-reexec.mjs
+ *
+ * SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001 (FR-1): pure planner for the
+ * STALE_CWD re-exec recovery decision used by scripts/handoff.js.
+ *
+ * Why a separate, pure module:
+ *   - handoff.js must decide "am I in an orphaned worktree → re-exec from the
+ *     main repo root" BEFORE importing its heavy graph (which pulls
+ *     @supabase/* through node_modules and fails at module-RESOLUTION time when
+ *     the orphaned worktree's node_modules junction is dangling).
+ *   - process.chdir() is INEFFECTIVE: ESM resolves the whole static-import graph
+ *     before any in-body statement runs, so the fix MUST be a re-exec, not chdir.
+ *   - Extracting the decision into an injectable pure function makes it
+ *     unit-testable (TS-1..TS-5) without spawning a child or mocking process.
+ *
+ * Builtin-only deps (node:fs, node:path) so this resolves even when cwd is an
+ * orphaned worktree with a dangling node_modules junction.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Decide whether handoff.js should re-execute itself from the main repo root.
+ *
+ * @param {object} deps
+ * @param {boolean} deps.sentinelSet     - true when LEO_HANDOFF_REEXEC is set (loop-guard:
+ *                                          the re-exec child must NOT recover again).
+ * @param {() => void} deps.assertCwdValid - throws when cwd is an orphaned worktree.
+ * @param {(err:any) => boolean} deps.isStaleCwd - classifies a thrown error as STALE_CWD.
+ * @param {() => (string|null)} deps.getRepoRoot - resolves the main repo root.
+ * @param {string} deps.cwd             - current working directory.
+ * @param {(p:string) => boolean} [deps.existsSync] - fs.existsSync (injectable for tests).
+ * @returns {{reexec:boolean, reason:string, mainRoot?:string, mainScript?:string}}
+ *   reexec=true  → caller should spawn `node <mainScript> <args>` with cwd=mainRoot.
+ *   reexec=false → caller proceeds normally; `reason` explains why no recovery:
+ *     'sentinel_set' | 'cwd_valid' | 'no_valid_main_root'.
+ *
+ * Non-STALE_CWD errors from assertCwdValid are re-thrown (never swallowed).
+ */
+export function planHandoffReexec(deps) {
+  const {
+    sentinelSet,
+    assertCwdValid,
+    isStaleCwd,
+    getRepoRoot,
+    cwd,
+    existsSync = fs.existsSync,
+  } = deps;
+
+  // Loop-guard: the re-exec child carries the sentinel and must never recover again.
+  if (sentinelSet) return { reexec: false, reason: 'sentinel_set' };
+
+  let orphaned = false;
+  try {
+    assertCwdValid();
+  } catch (err) {
+    if (isStaleCwd(err)) orphaned = true;
+    else throw err; // genuine, non-STALE_CWD failure — never swallow
+  }
+  if (!orphaned) return { reexec: false, reason: 'cwd_valid' };
+
+  let mainRoot = null;
+  try { mainRoot = getRepoRoot(); } catch { mainRoot = null; }
+
+  // Only recover to a verified main repo root that is NOT the (broken) cwd.
+  // Guards against silently swallowing a genuinely-broken main root.
+  const mainValid =
+    !!mainRoot &&
+    existsSync(path.join(mainRoot, '.git')) &&
+    path.resolve(mainRoot) !== path.resolve(cwd);
+  if (!mainValid) return { reexec: false, reason: 'no_valid_main_root' };
+
+  return {
+    reexec: true,
+    reason: 'orphaned_worktree',
+    mainRoot,
+    // Run the MAIN repo's handoff.js, NOT process.argv[1] (which points at the
+    // orphaned worktree's copy whose node_modules junction is dangling).
+    mainScript: path.join(mainRoot, 'scripts', 'handoff.js'),
+  };
+}

--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -23,10 +23,51 @@
  * @see scripts/modules/handoff/ for implementation
  */
 
-import { main } from './modules/handoff/cli/index.js';
-import { claimGuard } from '../lib/claim-guard.mjs';
-import { startHeartbeat } from '../lib/heartbeat-manager.mjs';
+// Builtin + builtin-only-lib imports ONLY at module top. These never resolve
+// through node_modules, so they load even when an orphaned worktree's
+// node_modules junction is dangling. The heavy graph (main/claimGuard/
+// startHeartbeat — which transitively pull @supabase/* via node_modules) is
+// imported DYNAMICALLY below, AFTER the FR-1 re-exec preflight.
+import { spawnSync } from 'node:child_process';
 import { assertCwdValid, ExecContextError } from '../lib/exec-context-guard.mjs';
+import { getRepoRoot } from '../lib/repo-paths.js';
+import { planHandoffReexec } from '../lib/handoff-reexec.mjs';
+
+// === FR-1 (SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001): re-exec recovery ===
+// When cwd is an orphaned worktree (its branch was deleted by
+// `gh pr merge --delete-branch`, dropping it out of `git worktree list`), the
+// heavy import graph below fails at MODULE-RESOLUTION time — earlier than any
+// in-body guard can run, and `process.chdir()` cannot re-resolve an already
+// evaluated ESM graph. So we detect-and-re-exec HERE, before the dynamic
+// imports, using a pure planner (lib/handoff-reexec.mjs, builtin-only). The
+// child runs the MAIN repo's handoff.js (whose node_modules is intact) from the
+// main root, with an env sentinel (LEO_HANDOFF_REEXEC) as a loop-guard.
+const _reexecPlan = planHandoffReexec({
+  sentinelSet: Boolean(process.env.LEO_HANDOFF_REEXEC),
+  assertCwdValid,
+  isStaleCwd: (err) => err instanceof ExecContextError && err.code === 'STALE_CWD',
+  getRepoRoot,
+  cwd: process.cwd(),
+});
+if (_reexecPlan.reexec) {
+  console.error('[handoff.js] ♻️  STALE_CWD: cwd is an orphaned worktree (branch deleted by --delete-branch).');
+  console.error(`   Re-executing from the main repo root: ${_reexecPlan.mainRoot}`);
+  const child = spawnSync(process.execPath, [_reexecPlan.mainScript, ...process.argv.slice(2)], {
+    cwd: _reexecPlan.mainRoot,
+    stdio: 'inherit',
+    shell: false,
+    env: { ...process.env, LEO_HANDOFF_REEXEC: '1' },
+  });
+  process.exit(child.status == null ? 1 : child.status);
+}
+// reexec=false (sentinel_set | cwd_valid | no_valid_main_root) → proceed.
+// If cwd is still broken (no_valid_main_root / sentinel set), the loud STALE_CWD
+// guard below preserves the original exit(1) failure (never silently swallowed).
+
+// Heavy graph: dynamic imports deferred until cwd is known-good (or re-exec'd).
+const { main } = await import('./modules/handoff/cli/index.js');
+const { claimGuard } = await import('../lib/claim-guard.mjs');
+const { startHeartbeat } = await import('../lib/heartbeat-manager.mjs');
 
 // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
 // Start an in-process heartbeat for the duration of this script. Cooperative
@@ -40,11 +81,9 @@ if (process.env.CLAUDE_SESSION_ID) {
 }
 
 // SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (FR-2): cwd-validity precondition.
-// Fail fast if the script is running from an orphaned worktree (e.g. cwd is
-// a worktree dir whose branch was deleted by `gh pr merge --delete-branch`).
-// Without this guard, downstream module imports (e.g. scripts/lib/sd-id-resolver.js)
-// crash with confusing module-not-found errors after the claim has been touched.
-// See harness backlog d66a075d for the witnessed LEAD-FINAL crash.
+// Retained as the fallback when the FR-1 preflight above could NOT recover
+// (sentinel set but cwd still broken, or no valid main root resolved). Fails
+// fast and loud rather than crashing later with a confusing module-not-found.
 try {
   assertCwdValid();
 } catch (err) {

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { createClient } from '@supabase/supabase-js';
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../../../lib/worktree-manager.js';
+import { detectOrphanWorktreeFromMerge } from '../../../lib/exec-context-guard.mjs';
 
 // Quick-fix QF-20260211-111: Post-merge worktree cleanup for /ship
 // FR-5: Added --sdKey support for external callers (SD-LEO-INFRA-UNIFIED-WORKTREE-LIFECYCLE-001)
@@ -337,33 +338,88 @@ async function cleanupBySDKey(sdKey, options = {}) {
   }
 }
 
+/**
+ * SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001 (FR-2): wire the previously-dead
+ * detectOrphanWorktreeFromMerge detector to a real consumer. Given the stdout
+ * of a `gh pr merge --delete-branch` (or gh-merge-safe.mjs) run, detect the
+ * deleted branch, map it to its worktree dir, and route that orphaned worktree
+ * through the claim-aware cleanupWorktreeByPath (archive-on-live-claim /
+ * archive-on-unpushed / else clean remove). Resolves the writer/consumer
+ * asymmetry (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001): the detector was
+ * shipped by SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 FR-5 but never consumed.
+ *
+ * @param {string} mergeOutput - stdout/stderr from the merge command
+ * @param {object} [options] - forwarded to cleanupWorktreeByPath (supabase,
+ *   heartbeatThresholdMs); options.mainRepoPath overrides repo-root resolution.
+ * @returns {Promise<object>} cleanup result annotated with {branch, candidate, source}
+ */
+async function cleanupOrphanFromMergeOutput(mergeOutput, options = {}) {
+  const { detected, branch } = detectOrphanWorktreeFromMerge(mergeOutput);
+  if (!detected || !branch) {
+    return { cleaned: false, reason: 'no_orphan_detected' };
+  }
+
+  // Resolve the main repo root (strip any /.worktrees/<key> suffix so this works
+  // whether invoked from the main repo or a sibling worktree).
+  let mainRepoPath = options.mainRepoPath || null;
+  if (!mainRepoPath) {
+    try {
+      const top = gitExec('git rev-parse --show-toplevel').replace(/\\/g, '/');
+      const idx = top.indexOf('/.worktrees/');
+      mainRepoPath = idx === -1 ? top : top.slice(0, idx);
+    } catch {
+      return { cleaned: false, reason: 'cannot_resolve_main_repo', branch };
+    }
+  }
+
+  // Map branch -> worktree dir (mirrors hasActiveClaimOnBranch candidate logic).
+  const base = _branchToBasename(branch) || String(branch).replace(/^refs\/heads\//, '');
+  if (!base) return { cleaned: false, reason: 'cannot_map_branch_to_worktree', branch };
+  const worktreesDir = path.join(mainRepoPath, '.worktrees');
+  const candidate = /^QF-/.test(base)
+    ? path.join(worktreesDir, 'qf', base)
+    : path.join(worktreesDir, base);
+
+  if (!fs.existsSync(candidate)) {
+    // Branch was deleted but no orphaned worktree dir remains — nothing to clean.
+    return { cleaned: false, reason: 'orphan_worktree_not_present', branch, candidate };
+  }
+
+  const result = await cleanupWorktreeByPath(candidate, options);
+  return { ...result, branch, candidate, source: 'merge_output_detector' };
+}
+
 // CLI entry point
 const _e = process.argv[1] || '', isMain = _e && (import.meta.url === `file://${_e}` ||
   import.meta.url === `file:///${_e.replace(/\\/g, '/')}`);
 
 if (isMain) {
-  // Parse --sdKey argument
+  // Parse --sdKey / --merge-output arguments
   const args = process.argv.slice(2);
   let sdKey = null;
+  let mergeOutputArg = null;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--sdKey' && args[i + 1]) { sdKey = args[++i]; }
+    else if (args[i] === '--merge-output' && args[i + 1]) { mergeOutputArg = args[++i]; }
   }
 
-  if (sdKey) {
+  const emit = (p) => p.then(result => {
+    process.stdout.write(JSON.stringify(result));
+  }).catch(err => {
+    process.stdout.write(JSON.stringify({ cleaned: false, reason: 'error', error: err.message }));
+  });
+
+  if (mergeOutputArg !== null) {
+    // FR-2: detect-orphan-from-merge mode. '-' reads stdin; otherwise literal.
+    const mergeOutput = mergeOutputArg === '-' ? fs.readFileSync(0, 'utf8') : mergeOutputArg;
+    emit(cleanupOrphanFromMergeOutput(mergeOutput));
+  } else if (sdKey) {
     // FR-5: External caller mode - resolve worktree from DB/scan and clean up
-    cleanupBySDKey(sdKey).then(result => {
-      process.stdout.write(JSON.stringify(result));
-    }).catch(err => {
-      process.stdout.write(JSON.stringify({ cleaned: false, reason: 'error', error: err.message }));
-    });
+    emit(cleanupBySDKey(sdKey));
   } else {
     // Original mode - clean up current worktree (if running inside one)
-    cleanupCurrentWorktree().then(result => {
-      process.stdout.write(JSON.stringify(result));
-    }).catch(err => {
-      process.stdout.write(JSON.stringify({ cleaned: false, reason: 'error', error: err.message }));
-    });
+    emit(cleanupCurrentWorktree());
   }
 }
 
-export { isInsideWorktree, getWorktreeMetadata, getMainRepoPath, cleanupCurrentWorktree, cleanupBySDKey, cleanupWorktreeByPath, hasUnpushedCommits, archiveWorktree, hasActiveClaimOnBranch };
+export { isInsideWorktree, getWorktreeMetadata, getMainRepoPath, cleanupCurrentWorktree, cleanupBySDKey, cleanupWorktreeByPath, hasUnpushedCommits, archiveWorktree, hasActiveClaimOnBranch, cleanupOrphanFromMergeOutput };

--- a/tests/unit/handoff-reexec.test.js
+++ b/tests/unit/handoff-reexec.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001 (FR-1, FR-3) — planHandoffReexec unit tests.
+ *
+ * The planner is pure with injected deps, so no module mocking is needed:
+ * assertCwdValid / getRepoRoot / existsSync are passed as stubs.
+ *
+ * Covers the prospective test matrix:
+ *   TS-1 positive re-exec, TS-2 broken-main-root negative, TS-3 loop-guard,
+ *   TS-4 valid-main-root passthrough, TS-5 live-worktree passthrough,
+ *   plus: non-STALE_CWD error re-thrown, getRepoRoot-throws, mainRoot===cwd guard.
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { planHandoffReexec } from '../../lib/handoff-reexec.mjs';
+
+const MAIN = path.resolve('/repo/EHG_Engineer');
+const WT = path.resolve('/repo/EHG_Engineer/.worktrees/SD-X');
+
+const staleErr = () => Object.assign(new Error('cwd orphaned'), { code: 'STALE_CWD' });
+const isStaleCwd = (err) => !!err && err.code === 'STALE_CWD';
+
+// Base deps for the "orphaned worktree, recoverable" happy path.
+function deps(overrides = {}) {
+  return {
+    sentinelSet: false,
+    assertCwdValid: () => { throw staleErr(); },
+    isStaleCwd,
+    getRepoRoot: () => MAIN,
+    cwd: WT,
+    existsSync: (p) => p === path.join(MAIN, '.git'),
+    ...overrides,
+  };
+}
+
+describe('planHandoffReexec (FR-1 re-exec recovery)', () => {
+  it('TS-1: orphaned worktree + valid main root → reexec with main repo handoff.js', () => {
+    const plan = planHandoffReexec(deps());
+    expect(plan.reexec).toBe(true);
+    expect(plan.reason).toBe('orphaned_worktree');
+    expect(plan.mainRoot).toBe(MAIN);
+    // Must target the MAIN repo's handoff.js, not the worktree's copy.
+    expect(plan.mainScript).toBe(path.join(MAIN, 'scripts', 'handoff.js'));
+    expect(plan.mainScript.includes('.worktrees')).toBe(false);
+  });
+
+  it('TS-2: orphaned but main root has no .git → no recovery, loud failure preserved', () => {
+    const plan = planHandoffReexec(deps({ existsSync: () => false }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('no_valid_main_root');
+  });
+
+  it('TS-3: loop-guard — sentinel set → never re-exec (and assertCwdValid not consulted)', () => {
+    let called = false;
+    const plan = planHandoffReexec(deps({
+      sentinelSet: true,
+      assertCwdValid: () => { called = true; throw staleErr(); },
+    }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('sentinel_set');
+    expect(called).toBe(false); // short-circuits before touching cwd
+  });
+
+  it('TS-4: valid main-root cwd (assertCwdValid passes) → passthrough, no re-exec', () => {
+    const plan = planHandoffReexec(deps({
+      assertCwdValid: () => { /* valid: no throw */ },
+      cwd: MAIN,
+    }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('cwd_valid');
+  });
+
+  it('TS-5: valid live worktree (in `git worktree list`, assertCwdValid passes) → passthrough', () => {
+    const plan = planHandoffReexec(deps({
+      assertCwdValid: () => { /* live worktree: no throw */ },
+    }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('cwd_valid');
+  });
+
+  it('re-throws a non-STALE_CWD error (never silently swallowed)', () => {
+    const boom = new Error('unexpected');
+    expect(() => planHandoffReexec(deps({
+      assertCwdValid: () => { throw boom; },
+    }))).toThrow('unexpected');
+  });
+
+  it('getRepoRoot throwing → treated as no valid main root (no recovery)', () => {
+    const plan = planHandoffReexec(deps({
+      getRepoRoot: () => { throw new Error('cannot resolve'); },
+    }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('no_valid_main_root');
+  });
+
+  it('guards against re-exec into the same dir (mainRoot === cwd)', () => {
+    const plan = planHandoffReexec(deps({
+      getRepoRoot: () => WT, // resolver returns the broken cwd itself
+      cwd: WT,
+      existsSync: (p) => p === path.join(WT, '.git'),
+    }));
+    expect(plan.reexec).toBe(false);
+    expect(plan.reason).toBe('no_valid_main_root');
+  });
+});

--- a/tests/unit/lib/exec-context-guard-pinning.test.js
+++ b/tests/unit/lib/exec-context-guard-pinning.test.js
@@ -170,22 +170,17 @@ describe('SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 — static guard pinning (FR-6, A
       expect(allConsumerSrc).toMatch(/assertSweepHandoffGate/);
       // decideOwnConflictReattach → sd-start (wraps classifyWorktreeOwnership internally)
       expect(allConsumerSrc).toMatch(/decideOwnConflictReattach/);
-      // detectOrphanWorktreeFromMerge — pure utility, may be consumed by post-merge-worktree-cleanup.js
-      // OR live as a documented utility for future use. Test passes when it's defined in the module
-      // even if no consumer wires it yet (canary surfaces the asymmetry as INFO, not failure).
+      // detectOrphanWorktreeFromMerge → post-merge-worktree-cleanup.js
+      // SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001 (FR-2): the detector is now WIRED
+      // into post-merge-worktree-cleanup.js (cleanupOrphanFromMergeOutput), which
+      // routes the orphaned worktree through the claim-aware cleanupWorktreeByPath.
+      // Canary PROMOTED from informational to a hard assertion: it fails if the
+      // wiring is ever removed (writer/consumer asymmetry regression guard,
+      // PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
       const orphanRef = allConsumerSrc.includes('detectOrphanWorktreeFromMerge') ||
                         readScript('scripts/modules/shipping/post-merge-worktree-cleanup.js')
                           .includes('detectOrphanWorktreeFromMerge');
-      // Canary: log if not yet consumed but don't fail (FR-5 documents this as available utility)
-      // When a future SD wires it, this assertion will trip and the test must be updated to expect=true.
-      if (!orphanRef) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          '[CANARY] detectOrphanWorktreeFromMerge is exported but not yet wired to a consumer. ' +
-          'See PRD FR-5 for the planned post-merge-worktree-cleanup.js integration path.'
-        );
-      }
-      expect(true).toBe(true); // canary is informational
+      expect(orphanRef).toBe(true);
     });
   });
 });

--- a/tests/unit/post-merge-orphan-from-merge.test.js
+++ b/tests/unit/post-merge-orphan-from-merge.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001 (FR-2, FR-3) — cleanupOrphanFromMergeOutput.
+ *
+ * Verifies the NEW seam wiring the previously-dead detectOrphanWorktreeFromMerge
+ * detector into the claim-aware post-merge cleanup:
+ *   TS-6 positive: orphan detected + live claim → routed through cleanupWorktreeByPath
+ *                  → archive-not-delete (NOT a hard delete).
+ *   TS-7 negative: merge output with no deleted branch → no_orphan_detected.
+ *   mapping: feat/<SD> → .worktrees/<SD>; qf/<QF> → .worktrees/qf/<QF>.
+ *   advisory: function returns a result object and never throws on the
+ *             negative/absent paths (does not hard-fail the /ship flow).
+ *
+ * detectOrphanWorktreeFromMerge's own parsing is covered by
+ * tests/unit/lib/exec-context-guard.test.js — here we test the routing.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { cleanupOrphanFromMergeOutput } from '../../scripts/modules/shipping/post-merge-worktree-cleanup.js';
+
+const tmpDirs = [];
+function makeTmpRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-merge-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tmpDirs.length) {
+    const d = tmpDirs.pop();
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+// Minimal supabase stub: v_active_sessions.select(...).eq('computed_status','active')
+// resolves to { data, error }. hasActiveClaimOnBranch awaits the .eq() result.
+function supabaseWithClaim(rows) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => Promise.resolve({ data: rows, error: null }),
+      }),
+    }),
+  };
+}
+
+describe('cleanupOrphanFromMergeOutput (FR-2 detector wiring)', () => {
+  it('TS-7: merge output with no deleted branch → no_orphan_detected (pure, no side effects)', async () => {
+    const res = await cleanupOrphanFromMergeOutput('✓ Merged pull request #123\n', {});
+    expect(res.cleaned).toBe(false);
+    expect(res.reason).toBe('no_orphan_detected');
+  });
+
+  it('mapping: feat/<SD> branch maps to .worktrees/<SD> (absent → orphan_worktree_not_present)', async () => {
+    const mainRepoPath = makeTmpRepo(); // empty: no .worktrees/SD-NOPE-001
+    const res = await cleanupOrphanFromMergeOutput(
+      'Deleted branch feat/SD-NOPE-001 (was abc1234)',
+      { mainRepoPath }
+    );
+    expect(res.cleaned).toBe(false);
+    expect(res.reason).toBe('orphan_worktree_not_present');
+    expect(res.branch).toBe('feat/SD-NOPE-001');
+    expect(res.candidate.replace(/\\/g, '/')).toMatch(/\.worktrees\/SD-NOPE-001$/);
+  });
+
+  it('mapping: qf/<QF> branch maps to .worktrees/qf/<QF>', async () => {
+    const mainRepoPath = makeTmpRepo();
+    const res = await cleanupOrphanFromMergeOutput(
+      'Deleted branch qf/QF-20260101-001',
+      { mainRepoPath }
+    );
+    expect(res.reason).toBe('orphan_worktree_not_present');
+    expect(res.candidate.replace(/\\/g, '/')).toMatch(/\.worktrees\/qf\/QF-20260101-001$/);
+  });
+
+  it('TS-6: orphan detected + live claim → archived (claim-aware, NOT hard-deleted)', async () => {
+    const mainRepoPath = makeTmpRepo();
+    const wt = path.join(mainRepoPath, '.worktrees', 'SD-FOO-001');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(wt, 'marker.txt'), 'work in progress');
+
+    const supabase = supabaseWithClaim([{
+      session_id: 'sess-1',
+      sd_key: 'SD-FOO-001',
+      qf_id: null,
+      current_branch: 'feat/SD-FOO-001',
+      heartbeat_at: new Date(/* now */ Date.parse('2999-01-01T00:00:00Z')).toISOString(),
+      computed_status: 'active',
+    }]);
+
+    const res = await cleanupOrphanFromMergeOutput(
+      '✓ Deleted branch feat/SD-FOO-001',
+      { mainRepoPath, supabase }
+    );
+
+    // Routed through claim-aware cleanup → archived, not deleted.
+    expect(res.cleaned).toBe(false);
+    expect(res.reason).toBe('active_claim_protect');
+    expect(res.archived).toBe(true);
+    expect(res.source).toBe('merge_output_detector');
+    // Original worktree dir moved out (archived), not left in place or hard-removed silently.
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(res.archivePath)).toBe(true);
+  });
+
+  it('advisory: never throws on negative/absent inputs (does not hard-fail /ship)', async () => {
+    await expect(cleanupOrphanFromMergeOutput('', {})).resolves.toBeTruthy();
+    await expect(cleanupOrphanFromMergeOutput(null, {})).resolves.toBeTruthy();
+    await expect(
+      cleanupOrphanFromMergeOutput('Deleted branch feat/SD-GONE-001', { mainRepoPath: makeTmpRepo() })
+    ).resolves.toMatchObject({ cleaned: false });
+  });
+});


### PR DESCRIPTION
## Summary
Makes the LEO SD lifecycle resilient to a worktree being auto-orphaned when `gh pr merge --delete-branch` deletes the feature branch mid-lifecycle (witnessed in SD-LEO-INFRA-STAGE-VISION-DRIFT-001: LEAD-FINAL crashed ERR_MODULE_NOT_FOUND from the orphaned cwd). Reuse-first, additive, no migration.

### FR-1 — re-exec recovery (universal)
`scripts/handoff.js` auto-recovers from the `STALE_CWD` precondition by **re-executing the MAIN repo's handoff.js** from the main root (`spawnSync`) instead of `exit(1)`. The decision is a pure, builtin-only planner (`lib/handoff-reexec.mjs`), and the heavy import graph is now **dynamic** so the preflight runs *before* node_modules resolution. `process.chdir()` would be inert (ESM resolves the static graph first). Env sentinel `LEO_HANDOFF_REEXEC` is the loop-guard; recovery only fires for a verified main repo root.

### FR-2 — wire the dead detector (clean-handle)
`scripts/modules/shipping/post-merge-worktree-cleanup.js` now consumes the previously-**unwired** `detectOrphanWorktreeFromMerge` (`lib/exec-context-guard.mjs`) via `cleanupOrphanFromMergeOutput`, routing an orphaned worktree through the existing claim-aware `cleanupWorktreeByPath` (archive-on-live-claim, not hard delete). Resolves writer/consumer asymmetry **PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001**.

### FR-3 — tests
Flipped the `exec-context-guard-pinning` canary from informational → hard assertion; added unit suites for the planner (TS-1..TS-5 + edge cases) and the detector wiring (TS-6 archive-on-claim, TS-7 no-orphan, branch mapping, advisory non-throwing).

## Test Results
- `vitest` unit: **48 passed** (handoff-reexec 8, post-merge-orphan 6, exec-context-guard-pinning 12, exec-context-guard 22)
- ESLint: clean
- handoff.js entrypoint smoke (`stats`): OK (dynamic-import restructure sound)

## Baseline Observation (runtime smoke)
FR-1 planner:
```
FR-1 ORPHANED cwd  -> {"reexec":true,"reason":"orphaned_worktree","mainScript":".../scripts/handoff.js"}
FR-1 sentinel set  -> {"reexec":false,"reason":"sentinel_set"}
FR-1 valid cwd     -> {"reexec":false,"reason":"cwd_valid"}
```
FR-2 detector wiring (live CLI `--merge-output -`):
```
Deleted branch feat/SD-FAKE-999  -> {"cleaned":false,"reason":"orphan_worktree_not_present","branch":"feat/SD-FAKE-999","candidate":".../.worktrees/SD-FAKE-999"}
Merged pull request #5           -> {"cleaned":false,"reason":"no_orphan_detected"}
```

## Notes
- PR size: ~190 source + ~205 test LOC; reuse-heavy seams (planner + single consumer fn). Tests ~half the diff.
- No schema/migration. Backward-safe: changes only trigger in the already-failing STALE_CWD / post-merge paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)