### PR TITLE
fix(QF-20260604-533): Add lib/sub-agents/ to WIRE_CHECK_GATE KNOWN_DYNAMIC_PATTERNS allowlist

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -88,7 +88,18 @@ export const KNOWN_DYNAMIC_PATTERNS = [
   /(^|\/)lib\/eva-support\//,
   // scripts/eva-support/ — the dispatcher.js + 6 sub-flow handlers. Same reasoning:
   // slash-command-loaded, no static reachability from current entry-point set.
-  /(^|\/)scripts\/eva-support\//
+  /(^|\/)scripts\/eva-support\//,
+  // lib/sub-agents/ — automated sub-agent modules. The sub-agent executor loads
+  // these via a NON-LITERAL dynamic import (`../sub-agents/${code.toLowerCase()}.js`
+  // at lib/sub-agent-executor/executor.js), where the specifier is computed from the
+  // sub-agent code at runtime. Non-literal dynamic imports emit a CAUTION and create
+  // no call-graph edge (static AST cannot resolve the specifier), so every newly
+  // registered sub-agent module appears unreachable to WIRE_CHECK. Same architectural
+  // shape as the eva-support exemption. Reachability is instead guaranteed by the
+  // executor's load convention + the filename-convention regression guard.
+  // QF-20260604-533 / feedback a38cc604 (SD-LEO-INFRA-WIRE-PRE-BUILD-001 had to
+  // `git reset --hard origin/main` post-squash to work around this false-positive).
+  /(^|\/)lib\/sub-agents\//
 ];
 
 /**
@@ -281,7 +292,7 @@ export function createWireCheckGate(_supabase) {
           max_score: 100,
           issues: [
             `WIRE_CHECK_GATE could not compute git diff against ${mainRef}: ${message}`,
-            `Required:true gate cannot validate without diff input. Investigate git availability or ref resolution.`,
+            'Required:true gate cannot validate without diff input. Investigate git availability or ref resolution.',
           ],
           warnings: refWarnings,
           details: { mainRef, refSource: refResult.source, error: message },

--- a/tests/unit/handoff/wire-check-gate.test.js
+++ b/tests/unit/handoff/wire-check-gate.test.js
@@ -163,6 +163,32 @@ describe('EXCLUSION_PATTERNS (FR-1)', () => {
       expect(isExcludedFromWireCheck('lib/eva/vision-governance-service.js')).toBe(false);
     });
   });
+
+  // QF-20260604-533 / feedback a38cc604: lib/sub-agents/ modules are loaded ONLY via
+  // the sub-agent executor's NON-LITERAL dynamic import (`../sub-agents/${code.toLowerCase()}.js`),
+  // which static AST cannot resolve, so every newly-registered sub-agent appears unreachable.
+  describe('KNOWN_DYNAMIC_PATTERNS — lib/sub-agents dynamic-load tree (a38cc604)', () => {
+    it('excludes lib/sub-agents/** modules', () => {
+      expect(isExcludedFromWireCheck('lib/sub-agents/venture_stack.js')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/sub-agents/docmon.js')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/sub-agents/github.js')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/sub-agents/design.js')).toBe(true);
+    });
+
+    it('does NOT over-match lookalike paths (boundary-safe)', () => {
+      // hyphenated boundary: a trailing-suffix dir must not match
+      expect(isExcludedFromWireCheck('lib/sub-agents-foo/x.js')).toBe(false);
+      // underscore variant is a different path and must not match the hyphenated pattern
+      expect(isExcludedFromWireCheck('lib/sub_agents/x.js')).toBe(false);
+      expect(isExcludedFromWireCheck('scripts/sub-agents/x.js')).toBe(false);
+    });
+
+    it('does NOT exempt the executor itself or unrelated lib/agents files', () => {
+      // the executor that performs the dynamic import lives outside lib/sub-agents/
+      expect(isExcludedFromWireCheck('lib/sub-agent-executor/executor.js')).toBe(false);
+      expect(isExcludedFromWireCheck('lib/agents/auto-selector.js')).toBe(false);
+    });
+  });
 });
 
 describe('call-graph-builder barrel re-export resolution (FR-2 AC-1)', () => {
@@ -184,9 +210,9 @@ describe('call-graph-builder barrel re-export resolution (FR-2 AC-1)', () => {
   }
 
   it('resolves export * from re-exports transitively (barrel pattern)', () => {
-    const entry = writeFile('entry.js', `import './index.js';\n`);
-    const index = writeFile('index.js', `export * from './foo.js';\n`);
-    const foo = writeFile('foo.js', `export const x = 1;\n`);
+    const entry = writeFile('entry.js', 'import \'./index.js\';\n');
+    const index = writeFile('index.js', 'export * from \'./foo.js\';\n');
+    const foo = writeFile('foo.js', 'export const x = 1;\n');
     const { graph } = buildCallGraph([entry, index, foo], tmpDir);
     const { reachable, unreachable } = checkReachability(graph, [entry], [foo]);
     expect(reachable.has(foo)).toBe(true);
@@ -194,9 +220,9 @@ describe('call-graph-builder barrel re-export resolution (FR-2 AC-1)', () => {
   });
 
   it('resolves export { named } from re-exports', () => {
-    const entry = writeFile('entry.js', `import './index.js';\n`);
-    const index = writeFile('index.js', `export { bar } from './bar.js';\n`);
-    const bar = writeFile('bar.js', `export const bar = 1;\n`);
+    const entry = writeFile('entry.js', 'import \'./index.js\';\n');
+    const index = writeFile('index.js', 'export { bar } from \'./bar.js\';\n');
+    const bar = writeFile('bar.js', 'export const bar = 1;\n');
     const { graph } = buildCallGraph([entry, index, bar], tmpDir);
     const { reachable } = checkReachability(graph, [entry], [bar]);
     expect(reachable.has(bar)).toBe(true);
@@ -222,15 +248,15 @@ describe('call-graph-builder dynamic import resolution (FR-2 AC-3)', () => {
   }
 
   it('resolves string-literal dynamic import() as an edge', () => {
-    const entry = writeFile('entry.js', `async function load() { await import('./handler.js'); }\nload();\n`);
-    const handler = writeFile('handler.js', `export default () => 1;\n`);
+    const entry = writeFile('entry.js', 'async function load() { await import(\'./handler.js\'); }\nload();\n');
+    const handler = writeFile('handler.js', 'export default () => 1;\n');
     const { graph } = buildCallGraph([entry, handler], tmpDir);
     const { reachable } = checkReachability(graph, [entry], [handler]);
     expect(reachable.has(handler)).toBe(true);
   });
 
   it('emits a CAUTION warning for non-literal dynamic imports, does not crash', () => {
-    const entry = writeFile('entry.js', `async function load(name) { await import(name); }\nload('x');\n`);
+    const entry = writeFile('entry.js', 'async function load(name) { await import(name); }\nload(\'x\');\n');
     const { warnings } = buildCallGraph([entry], tmpDir);
     expect(warnings.some(w => w.includes('non-literal dynamic import'))).toBe(true);
   });
@@ -255,8 +281,8 @@ describe('call-graph-builder negative control (FR-6 AC-3)', () => {
   }
 
   it('genuinely unreachable orphan file stays unreachable', () => {
-    const entry = writeFile('entry.js', `console.log('hi');\n`);
-    const orphan = writeFile('orphan.js', `export const x = 1;\n`);
+    const entry = writeFile('entry.js', 'console.log(\'hi\');\n');
+    const orphan = writeFile('orphan.js', 'export const x = 1;\n');
     const { graph } = buildCallGraph([entry, orphan], tmpDir);
     const { reachable, unreachable } = checkReachability(graph, [entry], [orphan]);
     expect(reachable.has(orphan)).toBe(false);


### PR DESCRIPTION
## Quick-Fix: QF-20260604-533

**Type:** bug
**Severity:** medium

### Issue Description
WIRE_CHECK_GATE (LEAD-FINAL) false-positives on newly-registered lib/sub-agents/<code>.js modules: the sub-agent executor loads them via a non-literal dynamic import (../sub-agents/<code>.js, lib/sub-agent-executor/executor.js line 215) that static AST cannot trace, so every first-time sub-agent registration appears unreachable. Add a lib/sub-agents/ regex to KNOWN_DYNAMIC_PATTERNS in scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js, same shape as the existing eva-support exemption, plus a mirrored test describe block. Feedback a38cc604.

### Steps to Reproduce
Register a new sub-agent (add lib/sub-agents/<code>.js) and run a LEAD-FINAL handoff; the gate flags the new module unreachable.

### Expected Behavior
lib/sub-agents/ modules are exempt from static-reachability check (known dynamic-load tree); gate passes.

### Actual Behavior
Gate false-positives and blocks LEAD-FINAL; WIRE-PRE-BUILD-001 had to git reset --hard origin/main to work around it.

### Changes
- **Files Changed:** 2
  - scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
  - tests/unit/handoff/wire-check-gate.test.js
- **LOC:** 88 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Pure-function change to isExcludedFromWireCheck (path matching). Verified via scoped unit suite tests/unit/handoff/wire-check-gate.test.js: 25/25 pass, including new lib/sub-agents/ exemption assertions — excludes lib/sub-agents/*.js; boundary-safe (rejects lib/sub-agents-foo/, lib/sub_agents/, scripts/sub-agents/, lib/sub-agent-executor/, lib/agents/). Confirmed lib/sub-agents/ was absent from KNOWN_DYNAMIC_PATTERNS on origin/main. Additive allowlist entry; no runtime/UI surface. Resolves feedback a38cc604.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol