### PR TITLE
fix(QF-20260604-797): Clear retrospective_type when enhanceRetrospective promotes a retro to SD_COMPLETION

### DIFF
--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -230,6 +230,14 @@ export async function enhanceRetrospective(supabase, existingId, newRetro, exist
       success_patterns: mergedSuccessPatterns,
       failure_patterns: mergedFailurePatterns,
       retro_type: 'SD_COMPLETION',
+      // QF-20260604-797 / feedback a6cdecee: when promoting an existing retro to the
+      // canonical SD-completion retro, clear retrospective_type. Otherwise a stale
+      // handoff-phase tag (e.g. 'PLAN_TO_EXEC' from the earlier handoff retro this row
+      // started as) is preserved, and RETROSPECTIVE_QUALITY_GATE's filter
+      // (.or retrospective_type.is.null,retrospective_type.eq.SD_COMPLETION) rejects it,
+      // forcing manual reclassification before PLAN-TO-LEAD. Matches the canonical
+      // fresh-insert writer, which leaves retrospective_type NULL for completion retros.
+      retrospective_type: null,
       conducted_date: newRetro.conducted_date,
       objectives_met: newRetro.objectives_met,
       on_schedule: newRetro.on_schedule,

--- a/lib/sub-agents/retro/db-operations.test.js
+++ b/lib/sub-agents/retro/db-operations.test.js
@@ -1,0 +1,114 @@
+/**
+ * Regression test for QF-20260604-797 / feedback a6cdecee.
+ *
+ * enhanceRetrospective() promotes an existing retro row (often the earlier
+ * PLAN_TO_EXEC / LEAD_TO_PLAN handoff retro) into the canonical SD-completion
+ * retro. It set retro_type='SD_COMPLETION' but used to leave retrospective_type
+ * untouched, so a stale handoff-phase tag survived. The PLAN-TO-LEAD
+ * RETROSPECTIVE_QUALITY_GATE filters PUBLISHED retros on
+ *   retrospective_type IS NULL  OR  retrospective_type = 'SD_COMPLETION'
+ * so the enhanced row matched neither branch and the gate hard-failed,
+ * forcing manual reclassification. The fix clears retrospective_type to null,
+ * matching the canonical fresh-insert writer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { enhanceRetrospective } from './db-operations.js';
+
+// Mock supabase that captures the payload passed to .update() and resolves the
+// .from().update().eq().select().single() chain enhanceRetrospective uses.
+function makeMockSupabase() {
+  const calls = { updatePayload: null };
+  const supabase = {
+    from() {
+      return {
+        update(payload) {
+          calls.updatePayload = payload;
+          return {
+            eq() {
+              return {
+                select() {
+                  return {
+                    single: async () => ({ data: { id: 'retro-1', ...payload }, error: null }),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { supabase, calls };
+}
+
+// enhanceRetrospective takes a semanticDeduplicateArray(existing, incoming, type)
+// helper; a simple concat is sufficient for asserting the written payload shape.
+const passThroughDedup = (a, b) => [...(a || []), ...(b || [])];
+
+const baseNewRetro = {
+  quality_score: 100,
+  title: 'Completion retro',
+  description: 'completion description',
+  conducted_date: '2026-06-04',
+  objectives_met: true,
+  on_schedule: true,
+  within_scope: true,
+  team_satisfaction: 5,
+  velocity_achieved: 1,
+  business_value_delivered: 'value',
+  key_learnings: ['l1'],
+  what_went_well: ['w1'],
+  what_needs_improvement: ['i1'],
+  action_items: ['a1'],
+  success_patterns: ['s1'],
+  failure_patterns: ['f1'],
+  protocol_improvements: [],
+};
+
+// The existing row started life as a handoff retro — the defect's precondition.
+const baseExisting = {
+  quality_score: 60,
+  title: 'PLAN_TO_EXEC handoff retro',
+  retro_type: 'SD_COMPLETION',
+  retrospective_type: 'PLAN_TO_EXEC',
+  key_learnings: [],
+  what_went_well: [],
+  what_needs_improvement: [],
+  action_items: [],
+  success_patterns: [],
+  failure_patterns: [],
+  protocol_improvements: [],
+};
+
+describe('enhanceRetrospective — retrospective_type normalization (QF-20260604-797 / a6cdecee)', () => {
+  it('clears retrospective_type to null when promoting an enhanced row to SD_COMPLETION', async () => {
+    const { supabase, calls } = makeMockSupabase();
+    const res = await enhanceRetrospective(
+      supabase,
+      'retro-1',
+      { ...baseNewRetro },
+      { ...baseExisting },
+      passThroughDedup
+    );
+    expect(res.success).toBe(true);
+    expect(calls.updatePayload).toBeTruthy();
+    // Core regression assertion: the stale 'PLAN_TO_EXEC' tag must be cleared.
+    expect(calls.updatePayload.retrospective_type).toBeNull();
+    expect(calls.updatePayload.retro_type).toBe('SD_COMPLETION');
+  });
+
+  it('produces a row the RETROSPECTIVE_QUALITY_GATE PUBLISHED filter accepts', async () => {
+    const { supabase, calls } = makeMockSupabase();
+    await enhanceRetrospective(
+      supabase,
+      'retro-1',
+      { ...baseNewRetro },
+      { ...baseExisting, retrospective_type: 'LEAD_TO_PLAN' },
+      passThroughDedup
+    );
+    const rt = calls.updatePayload.retrospective_type;
+    // Gate accepts when retrospective_type IS NULL OR = 'SD_COMPLETION'.
+    expect(rt === null || rt === 'SD_COMPLETION').toBe(true);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260604-797

**Type:** bug
**Severity:** medium

### Issue Description
enhanceRetrospective in lib/sub-agents/retro/db-operations.js promotes an existing retro to a completion retro by setting retro_type=SD_COMPLETION (line 232) but never sets retrospective_type, so a stale handoff-phase tag (e.g. PLAN_TO_EXEC from the earlier handoff retro) is preserved. The RETROSPECTIVE_QUALITY_GATE consumer filters PUBLISHED retros on retrospective_type IS NULL (or =SD_COMPLETION), so the enhanced row matches neither branch and the gate hard-fails at PLAN-TO-LEAD, requiring manual retro reclassification. Fix: add retrospective_type: null to the enhanced update payload, aligning the enhance path with the canonical fresh-insert writer (which leaves it null). RCA verified: 9 of 142 recent SDs affected. Feedback a6cdecee.

### Steps to Reproduce
Complete an SD where the newest pre-completion retro row is a PLAN_TO_EXEC handoff retro; retro-agent takes the enhance-in-place path; PLAN-TO-LEAD RETROSPECTIVE_QUALITY_GATE then finds zero qualifying rows.

### Expected Behavior
Enhanced SD_COMPLETION retro has retrospective_type=null and passes the gate filter without manual reclassification.

### Actual Behavior
Enhanced row keeps retrospective_type=PLAN_TO_EXEC; gate hard-fails; manual reclassification required every time.

### Changes
- **Files Changed:** 2
  - lib/sub-agents/retro/db-operations.js
  - lib/sub-agents/retro/db-operations.test.js
- **LOC:** 126 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Pure 1-line writer fix: enhanceRetrospective now sets retrospective_type:null when promoting a retro to SD_COMPLETION, matching the canonical fresh-insert writer. Verified via co-located mock-based regression test lib/sub-agents/retro/db-operations.test.js (2/2 pass): asserts the captured .update() payload has retrospective_type===null and retro_type==='SD_COMPLETION', and that the row satisfies the RETROSPECTIVE_QUALITY_GATE PUBLISHED filter (null OR =SD_COMPLETION). Test fails on unfixed code (undefined !== null). RCA-verified root cause (a6cdecee); consumer selection is correct, this is the writer-side fix. No DB mutation in test (mock supabase). Resolves feedback a6cdecee.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol