### PR TITLE
docs(SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001): orphaned-worktree recovery runbook + FR-1 glue pins

### DIFF
--- a/docs/01_architecture/worktree-first-isolation-integration.md
+++ b/docs/01_architecture/worktree-first-isolation-integration.md
@@ -259,6 +259,17 @@ try {
 | Git lock file present | Creation fails | Remove `.git/worktrees/<sdKey>/locked` |
 | Worktree path doesn't exist | Cleanup skipped (idempotent) | No action needed |
 | Uncommitted changes at cleanup | Cleanup aborts with `dirty_worktree` | Commit or `/ship` first, then re-run or use `--force` for manual cleanup |
+| Branch deleted mid-lifecycle by `--delete-branch` | Worktree orphaned (dir remains, dropped from `git worktree list`) | **Auto-recovered** — see Orphaned-Worktree Recovery below |
+
+### Orphaned-Worktree Recovery (SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001)
+
+When `gh pr merge --delete-branch` deletes `feat/<SD-KEY>` while its worktree is still active (e.g. a PR auto-merges between PLAN-TO-LEAD and LEAD-FINAL-APPROVAL), git deregisters the worktree: the directory remains on disk but drops out of `git worktree list`. Two layers now handle this:
+
+**FR-1 — handoff re-exec recovery (`scripts/handoff.js`).** Running any handoff from an orphaned-worktree cwd previously crashed with `ERR_MODULE_NOT_FOUND` (the dangling `node_modules` junction breaks bare-import resolution) and the in-body `STALE_CWD` guard could only `exit(1)`. handoff.js now runs a builtin-only preflight (`lib/handoff-reexec.mjs` `planHandoffReexec`) *before* its heavy imports — which are now dynamic — and, on detecting an orphaned cwd, **re-executes the main repo's `scripts/handoff.js` from the main root** via `spawnSync`. `process.chdir()` cannot fix this (ESM resolves the static-import graph, including `node_modules`, before any module-body statement runs), so re-exec is required. An `LEO_HANDOFF_REEXEC` env sentinel is the loop-guard; recovery only fires for a verified main repo root, otherwise the original loud failure is preserved.
+
+**FR-2 — post-merge orphan cleanup (`scripts/modules/shipping/post-merge-worktree-cleanup.js`).** `cleanupOrphanFromMergeOutput()` consumes the `detectOrphanWorktreeFromMerge` detector (`lib/exec-context-guard.mjs`) on merge stdout, maps the deleted branch to its worktree dir, and routes it through the claim-aware `cleanupWorktreeByPath` (archive-on-live-claim / archive-on-unpushed, else clean remove). Callable via `node scripts/modules/shipping/post-merge-worktree-cleanup.js --merge-output -` (stdin) or `--merge-output "<text>"`.
+
+> Tip (dogfooding): when shipping an SD that is itself about worktree lifecycle, enable auto-merge with `--squash` but **without** `--delete-branch` so the active worktree survives the remaining handoffs; clean it up after LEAD-FINAL-APPROVAL.
 
 ## User-Facing Changes
 

--- a/tests/unit/handoff-reexec.test.js
+++ b/tests/unit/handoff-reexec.test.js
@@ -10,8 +10,13 @@
  *   plus: non-STALE_CWD error re-thrown, getRepoRoot-throws, mainRoot===cwd guard.
  */
 import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { planHandoffReexec } from '../../lib/handoff-reexec.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const handoffSrc = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'handoff.js'), 'utf8');
 
 const MAIN = path.resolve('/repo/EHG_Engineer');
 const WT = path.resolve('/repo/EHG_Engineer/.worktrees/SD-X');
@@ -100,5 +105,35 @@ describe('planHandoffReexec (FR-1 re-exec recovery)', () => {
     }));
     expect(plan.reexec).toBe(false);
     expect(plan.reason).toBe('no_valid_main_root');
+  });
+});
+
+// Static-source pins for the handoff.js GLUE — the crux of FR-1. The planner
+// logic is fully tested above, but a regression that re-statically-imports the
+// heavy (node_modules-backed) graph BEFORE the preflight would silently defeat
+// re-exec recovery at module-RESOLUTION time and pass every behavioural test.
+// These pins guard exactly that failure mode.
+describe('handoff.js FR-1 glue (static-source pins)', () => {
+  it('imports the pure planner from lib/handoff-reexec.mjs', () => {
+    expect(handoffSrc).toMatch(/import\s*\{\s*planHandoffReexec\s*\}\s*from\s*['"]\.\.\/lib\/handoff-reexec\.mjs['"]/);
+  });
+
+  it('imports the heavy CLI graph DYNAMICALLY, never as a top-level static import', () => {
+    // A static `import { main } from './modules/handoff/cli/index.js'` resolves
+    // node_modules before the preflight runs → defeats FR-1 in an orphaned worktree.
+    expect(handoffSrc).not.toMatch(/^\s*import\s+\{\s*main\s*\}\s+from\s+['"]\.\/modules\/handoff\/cli\/index\.js['"]/m);
+    expect(handoffSrc).toMatch(/await import\(\s*['"]\.\/modules\/handoff\/cli\/index\.js['"]\s*\)/);
+  });
+
+  it('defers claimGuard + startHeartbeat to dynamic imports too (whole heavy graph deferred)', () => {
+    expect(handoffSrc).not.toMatch(/^\s*import\s+\{\s*claimGuard\s*\}\s+from/m);
+    expect(handoffSrc).not.toMatch(/^\s*import\s+\{\s*startHeartbeat\s*\}\s+from/m);
+    expect(handoffSrc).toMatch(/await import\(\s*['"]\.\.\/lib\/claim-guard\.mjs['"]\s*\)/);
+  });
+
+  it('calls the planner and spawns the child with the LEO_HANDOFF_REEXEC loop-guard sentinel', () => {
+    expect(handoffSrc).toMatch(/planHandoffReexec\(/);
+    expect(handoffSrc).toMatch(/spawnSync\(/);
+    expect(handoffSrc).toMatch(/LEO_HANDOFF_REEXEC/);
   });
 });


### PR DESCRIPTION
Follow-up to #4234 (SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001, already merged + SD completed).

## What
1. **Docs** — `docs/01_architecture/worktree-first-isolation-integration.md`: new *Orphaned-Worktree Recovery* subsection + failure-scenario row documenting FR-1 (handoff.js re-exec from main root on STALE_CWD) and FR-2 (`detectOrphanWorktreeFromMerge` wired into post-merge cleanup), plus the `--squash`-without-`--delete-branch` self-orphan dogfooding tip.
2. **Test hardening** — `tests/unit/handoff-reexec.test.js`: static-source glue pins (commit landed after #4234 auto-merged its earlier head, so re-applied here). Asserts handoff.js imports the planner, imports the heavy CLI graph DYNAMICALLY (never top-level static), defers claimGuard/startHeartbeat, and spawns with the `LEO_HANDOFF_REEXEC` sentinel — guarding the exact crux failure mode (a static re-import would silently defeat FR-1 at module-resolution).

## Test
- `vitest tests/unit/handoff-reexec.test.js`: **12 passed** (8 planner + 4 glue pins) against the merged handoff.js.

No migration. Docs + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)