### PR TITLE
feat(SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001): vision-grounded venture-build enrichment

### DIFF
--- a/lib/eva/artifact-enrichment-pipeline.js
+++ b/lib/eva/artifact-enrichment-pipeline.js
@@ -162,25 +162,80 @@ Respond in JSON format: { "summary": "...", "tags": ["tag1", "tag2", ...] }`;
  * @param {Object} [options.logger] - Logger
  * @returns {Promise<Object>} { enrichedDescription, artifactReferences }
  */
-export async function enrichSDDescription(params, options = {}) {
-  const { sdTitle, sdDescription, sdLayer, resolvedArtifacts, summaryMap, ventureContext } = params;
-  const { logger: _logger = console } = options;
+/**
+ * SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: Render the active chairman-approved
+ * L2 vision (+ architecture plan) into an authoritative grounding text block.
+ *
+ * extracted_dimensions (array of { name, description, ... }) is the load-bearing
+ * signal and is preferred; freeform `content` is the fallback when dimensions are
+ * absent/empty. Returns null when nothing usable is present so the caller emits no
+ * empty block (keeping the pre-grounding prompt byte-identical).
+ *
+ * @param {Object|null} visionGrounding - { vision_key, version, dimensions, content, plan }
+ * @returns {string|null} grounding text, or null when no usable grounding exists
+ */
+export function formatVisionGrounding(visionGrounding) {
+  if (!visionGrounding) return null;
+  const MAX_CONTENT = 1500;
+  const MAX_DESC = 280;
+  const renderDimensions = (dims) => {
+    if (!Array.isArray(dims) || dims.length === 0) return null;
+    const lines = dims.map((d) => {
+      const name = (d && (d.name ?? d.dimension ?? d.title)) || '';
+      const desc = (d && (d.description ?? d.summary ?? d.detail)) || '';
+      if (!name && !desc) return null;
+      const trimmed = String(desc).slice(0, MAX_DESC);
+      return name ? `- ${name}: ${trimmed}` : `- ${trimmed}`;
+    }).filter(Boolean);
+    return lines.length ? lines.join('\n') : null;
+  };
 
-  const allArtifacts = [...(resolvedArtifacts.required || []), ...(resolvedArtifacts.supplemental || [])];
-
-  if (allArtifacts.length === 0) {
-    throw new Error(`[EnrichmentPipeline] Pass 2 FAILED: no artifacts resolved for SD "${sdTitle}" (layer: ${sdLayer})`);
+  const sections = [];
+  const visionDims = renderDimensions(visionGrounding.dimensions);
+  if (visionDims) {
+    sections.push(`L2 Vision dimensions${visionGrounding.vision_key ? ` (${visionGrounding.vision_key})` : ''}:\n${visionDims}`);
+  } else if (visionGrounding.content) {
+    sections.push(`L2 Vision${visionGrounding.vision_key ? ` (${visionGrounding.vision_key})` : ''}:\n${String(visionGrounding.content).slice(0, MAX_CONTENT)}`);
   }
 
-  // Build artifact context block
-  const artifactContext = allArtifacts.map(art => {
-    const summary = summaryMap.get(art.artifact_type);
-    return `[${art.classification.toUpperCase()}] ${art.artifact_type} (Stage ${art.lifecycle_stage}):
-  ${summary ? summary.summary_text : 'No summary available'}
-  Tags: ${summary ? summary.tags.join(', ') : 'none'}`;
-  }).join('\n\n');
+  const plan = visionGrounding.plan;
+  if (plan) {
+    const planDims = renderDimensions(plan.dimensions);
+    if (planDims) {
+      sections.push(`Architecture Plan dimensions${plan.plan_key ? ` (${plan.plan_key})` : ''}:\n${planDims}`);
+    } else if (plan.content) {
+      sections.push(`Architecture Plan${plan.plan_key ? ` (${plan.plan_key})` : ''}:\n${String(plan.content).slice(0, MAX_CONTENT)}`);
+    }
+  }
 
-  const prompt = `You are enriching an SD (Strategic Directive) description with upstream artifact context.
+  return sections.length ? sections.join('\n\n') : null;
+}
+
+/**
+ * SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: Pure prompt assembler for Pass 2
+ * enrichment. Extracted from enrichSDDescription so prompt assembly is
+ * deterministically unit-testable.
+ *
+ * When `visionGrounding` yields usable text, the active chairman-approved L2 vision
+ * + architecture plan are emitted FIRST as AUTHORITATIVE and a
+ * prefer-vision-over-stage-artifacts-on-conflict instruction is added. When it does
+ * not, the prompt is byte-identical to the pre-grounding behavior.
+ *
+ * @returns {string} the assembled LLM prompt
+ */
+export function buildEnrichmentPrompt({ sdTitle, sdDescription, sdLayer, artifactContext, visionGrounding, ventureContext }) {
+  const visionText = formatVisionGrounding(visionGrounding);
+  const groundingBlock = visionText
+    ? `Authoritative Vision & Architecture (CURRENT, chairman-approved — takes precedence over the stage artifacts below on any conflict):
+${visionText}
+
+`
+    : '';
+  const conflictRule = visionText
+    ? '\n0. CRITICAL: Ground every choice (technology stack, product modality, persona, data model, scope) in the Authoritative Vision & Architecture above. Where the Upstream Artifact Context contradicts it (e.g. a superseded stack or a stale product modality from an earlier stage), PREFER the Vision/Architecture and DISCARD the stale artifact detail.'
+    : '';
+
+  return `You are enriching an SD (Strategic Directive) description with upstream artifact context.
 
 SD Title: ${sdTitle}
 SD Layer: ${sdLayer}
@@ -189,10 +244,10 @@ Venture: ${ventureContext?.name || 'Unknown'}
 Original Description:
 ${sdDescription}
 
-Upstream Artifact Context:
+${groundingBlock}Upstream Artifact Context:
 ${artifactContext}
 
-Generate an enriched SD description that:
+Generate an enriched SD description that:${conflictRule}
 1. Preserves the original intent and scope
 2. Adds specific persona names/characteristics from identity artifacts
 3. References specific wireframe sections or UI patterns if applicable
@@ -212,6 +267,29 @@ Respond in JSON format:
     "wireframe_sections": []
   }
 }`;
+}
+
+export async function enrichSDDescription(params, options = {}) {
+  const { sdTitle, sdDescription, sdLayer, resolvedArtifacts, summaryMap, ventureContext, visionGrounding } = params;
+  const { logger: _logger = console } = options;
+
+  const allArtifacts = [...(resolvedArtifacts.required || []), ...(resolvedArtifacts.supplemental || [])];
+
+  if (allArtifacts.length === 0) {
+    throw new Error(`[EnrichmentPipeline] Pass 2 FAILED: no artifacts resolved for SD "${sdTitle}" (layer: ${sdLayer})`);
+  }
+
+  // Build artifact context block
+  const artifactContext = allArtifacts.map(art => {
+    const summary = summaryMap.get(art.artifact_type);
+    return `[${art.classification.toUpperCase()}] ${art.artifact_type} (Stage ${art.lifecycle_stage}):
+  ${summary ? summary.summary_text : 'No summary available'}
+  Tags: ${summary ? summary.tags.join(', ') : 'none'}`;
+  }).join('\n\n');
+
+  const prompt = buildEnrichmentPrompt({
+    sdTitle, sdDescription, sdLayer, artifactContext, visionGrounding, ventureContext,
+  });
 
   let result;
   try {
@@ -264,7 +342,7 @@ Respond in JSON format:
  * @returns {Promise<Object[]>} Array of { sdIndex, enrichedDescription, artifactReferences, extractedContext }
  */
 export async function runEnrichmentPipeline(supabase, ventureId, artifacts, sdSpecs, mapping, ventureContext, options = {}) {
-  const { logger = console } = options;
+  const { logger = console, visionGrounding = null } = options;
   const { resolveArtifactsForSD } = await import('./artifact-mapping-resolver.js');
 
   // Pass 1: Summarize all artifacts (cached)
@@ -283,6 +361,7 @@ export async function runEnrichmentPipeline(supabase, ventureId, artifacts, sdSp
       resolvedArtifacts: resolved,
       summaryMap,
       ventureContext,
+      visionGrounding,
     }, { logger });
 
     results.push({

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -237,7 +237,10 @@ export async function assertVentureVisionReady(supabase, ventureId, ventureName)
 
   const { data: canonical } = await supabase
     .from('eva_vision_documents')
-    .select('vision_key, version, content, updated_at')
+    // SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: extracted_dimensions is the
+    // load-bearing grounding signal for enrichment (content is freeform prose);
+    // widened here so callers can reuse this row without a second fetch.
+    .select('vision_key, version, content, updated_at, extracted_dimensions')
     .eq('venture_id', ventureId)
     .eq('level', 'L2')
     .eq('status', 'active')
@@ -407,7 +410,9 @@ export async function convertSprintToSDs(params, deps = {}) {
     // SD-LEO-INFRA-UNIFY-VENTURE-NON-001 / Child C: refuse generation if no
     // chairman-approved canonical L2 vision doc exists for this venture.
     // ServiceError message names the exact /brainstorm unblock command.
-    await assertVentureVisionReady(supabase, ventureContext?.id, ventureContext?.name);
+    // SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: capture the canonical L2 vision row
+    // (incl. extracted_dimensions) so enrichment can ground on it without a second fetch.
+    const canonicalVision = await assertVentureVisionReady(supabase, ventureContext?.id, ventureContext?.name);
 
     // Generate orchestrator SD key
     const orchestratorKey = await generateSDKey({
@@ -483,9 +488,20 @@ export async function convertSprintToSDs(params, deps = {}) {
     // ── SD-LEO-INFRA-BRIDGE-ARTIFACT-ENRICHMENT-001: Artifact enrichment ──
     let enrichmentResults = null;
     if (!skipEnrichment && ventureContext?.id) {
+      // SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: ground enrichment in the active
+      // chairman-approved L2 vision + architecture plan so stale S0-S18 stage artifacts
+      // cannot re-contaminate child SD descriptions after a re-vision. FAIL-SOFT: the L2
+      // vision is already guaranteed by assertVentureVisionReady above; the arch-plan
+      // read is best-effort and a failure yields null grounding (it never aborts the build).
+      const visionGrounding = await buildVisionGrounding({
+        supabase, logger,
+        vision: canonicalVision,
+        planKey: evaKeys.plan_key || null,
+        visionKey: canonicalVision?.vision_key || evaKeys.vision_key || null,
+      });
       try {
         enrichmentResults = await loadAndEnrichArtifacts({
-          supabase, logger, ventureId: ventureContext.id, ventureContext, payloads,
+          supabase, logger, ventureId: ventureContext.id, ventureContext, payloads, visionGrounding,
         });
       } catch (enrichErr) {
         // FAIL-CLOSED: if enrichment fails, entire bridge fails
@@ -1156,13 +1172,74 @@ function getSupabaseClient() {
 // ── Artifact Enrichment Helpers (SD-LEO-INFRA-BRIDGE-ARTIFACT-ENRICHMENT-001) ──
 
 /**
+ * SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001: Assemble the vision/architecture
+ * grounding object passed to enrichment so the enrichment LLM prioritizes the
+ * active chairman-approved L2 vision over stale S0-S18 stage artifacts.
+ *
+ * The L2 vision row is already fetched + guaranteed by assertVentureVisionReady
+ * (it gates the bridge), so no vision re-fetch happens here. The architecture plan
+ * is resolved best-effort by plan_key (the gate-accepted plan) then by vision_key
+ * linkage — NOT a venture_id-only query, which is frequently NULL for un-backfilled
+ * ventures and would silently yield inert grounding.
+ *
+ * FAIL-SOFT: any read error returns the vision-only grounding (or null) rather than
+ * throwing — this helper must never introduce a new fail-closed path into the build.
+ *
+ * @param {Object} params
+ * @param {Object} params.supabase
+ * @param {Object} params.logger
+ * @param {Object|null} params.vision - canonical L2 row { vision_key, version, content, extracted_dimensions }
+ * @param {string|null} params.planKey - gate-accepted architecture plan_key (preferred)
+ * @param {string|null} params.visionKey - vision_key for arch-plan linkage fallback
+ * @returns {Promise<Object|null>} { vision_key, version, dimensions, content, plan } or null
+ */
+async function buildVisionGrounding({ supabase, logger = console, vision, planKey, visionKey }) {
+  if (!vision) return null;
+  let plan = null;
+  try {
+    let row = null;
+    if (planKey) {
+      ({ data: row } = await supabase
+        .from('eva_architecture_plans')
+        .select('plan_key, content, extracted_dimensions')
+        .eq('plan_key', planKey)
+        .order('version', { ascending: false })
+        .limit(1)
+        .maybeSingle());
+    }
+    if (!row && visionKey) {
+      ({ data: row } = await supabase
+        .from('eva_architecture_plans')
+        .select('plan_key, content, extracted_dimensions')
+        .eq('vision_key', visionKey)
+        .order('version', { ascending: false })
+        .limit(1)
+        .maybeSingle());
+    }
+    if (row) {
+      plan = { plan_key: row.plan_key || null, dimensions: row.extracted_dimensions || null, content: row.content || null };
+    }
+  } catch (err) {
+    logger.log(`[LifecycleSDBridge] vision grounding: architecture plan fetch failed (fail-soft, vision-only grounding): ${err.message}`);
+    plan = null;
+  }
+  return {
+    vision_key: vision.vision_key || null,
+    version: vision.version || null,
+    dimensions: vision.extracted_dimensions || null,
+    content: vision.content || null,
+    plan,
+  };
+}
+
+/**
  * Load venture artifacts from stages 0-18 and run enrichment pipeline.
  * Returns a Map of payload index -> enrichment result.
  *
  * @param {Object} params
  * @returns {Promise<Map<number, Object>>} Map of sdIndex -> { enrichedDescription, artifactReferences, extractedContext }
  */
-async function loadAndEnrichArtifacts({ supabase, logger, ventureId, ventureContext, payloads }) {
+async function loadAndEnrichArtifacts({ supabase, logger, ventureId, ventureContext, payloads, visionGrounding = null }) {
   // Load all current artifacts for this venture (stages 0-18)
   const { data: artifacts, error: artError } = await supabase
     .from('venture_artifacts')
@@ -1204,6 +1281,7 @@ async function loadAndEnrichArtifacts({ supabase, logger, ventureId, ventureCont
       resolvedArtifacts: resolved,
       summaryMap,
       ventureContext,
+      visionGrounding,
     }, { logger });
 
     results.set(i, enrichment);

--- a/tests/unit/eva/artifact-enrichment-pipeline.test.js
+++ b/tests/unit/eva/artifact-enrichment-pipeline.test.js
@@ -1,0 +1,128 @@
+/**
+ * SD-FDBK-INFRA-VENTURE-BUILD-ENRICHMENT-001 — Vision-grounded enrichment.
+ *
+ * Deterministic tests for the pure prompt assembler (buildEnrichmentPrompt) and the
+ * grounding formatter (formatVisionGrounding) extracted from enrichSDDescription.
+ * These prove the active chairman-approved L2 vision is emitted FIRST as authoritative
+ * with a prefer-vision-on-conflict instruction, that arch grounding is null-safe, and
+ * that the no-grounding path is byte-identical to the pre-change behavior.
+ *
+ * Maps to PRD test_scenarios TS-1..TS-6 and FR-1/FR-3/FR-5/FR-6/FR-8.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildEnrichmentPrompt, formatVisionGrounding } from '../../../lib/eva/artifact-enrichment-pipeline.js';
+
+const baseArgs = {
+  sdTitle: 'Connections API',
+  sdDescription: 'Build the data-source connections API for the venture.',
+  sdLayer: 'api',
+  artifactContext: '[REQUIRED] technical_architecture (Stage 14):\n  The build uses Supabase as the database and auth.\n  Tags: stack, supabase',
+  ventureContext: { name: 'DataDistill' },
+};
+
+const replitVision = {
+  vision_key: 'VIS-DD-002',
+  version: 2,
+  content: 'DataDistill is a SaaS product hosted on Replit.',
+  dimensions: [
+    { name: 'Deployment Model', weight: 0.3, description: 'Hosted SaaS on Replit Deployments (Autoscale); NOT Supabase, NOT a CLI.' },
+    { name: 'Value Proposition', weight: 0.4, description: 'Automated data distillation for analysts.' },
+  ],
+  plan: {
+    plan_key: 'PLAN-DD-002',
+    dimensions: [{ name: 'Auth', weight: 0.5, description: 'Clerk auth on Replit; Replit Postgres for storage.' }],
+    content: 'Architecture: TanStack Start + React 19 on Replit.',
+  },
+};
+
+describe('formatVisionGrounding (FR-1, FR-8)', () => {
+  it('returns null for null/undefined grounding', () => {
+    expect(formatVisionGrounding(null)).toBeNull();
+    expect(formatVisionGrounding(undefined)).toBeNull();
+  });
+
+  it('prefers extracted_dimensions as the primary signal (FR-1)', () => {
+    const text = formatVisionGrounding(replitVision);
+    expect(text).toContain('L2 Vision dimensions (VIS-DD-002)');
+    expect(text).toContain('- Deployment Model: Hosted SaaS on Replit');
+    // dimensions present -> freeform content is NOT used for the vision section
+    expect(text).not.toContain('DataDistill is a SaaS product hosted on Replit.');
+  });
+
+  it('falls back to content when extracted_dimensions are null/empty (TS-6, FR-8)', () => {
+    const text = formatVisionGrounding({ vision_key: 'VIS-X', dimensions: null, content: 'Vision prose fallback.', plan: null });
+    expect(text).toContain('L2 Vision (VIS-X)');
+    expect(text).toContain('Vision prose fallback.');
+    const text2 = formatVisionGrounding({ vision_key: 'VIS-Y', dimensions: [], content: 'Empty-dims fallback.', plan: null });
+    expect(text2).toContain('Empty-dims fallback.');
+  });
+
+  it('emits no architecture block when the plan is absent (TS-4, FR-8)', () => {
+    const text = formatVisionGrounding({ ...replitVision, plan: null });
+    expect(text).toContain('L2 Vision dimensions');
+    expect(text).not.toContain('Architecture Plan');
+  });
+
+  it('emits no architecture block when the plan has neither dimensions nor content (TS-4)', () => {
+    const text = formatVisionGrounding({ ...replitVision, plan: { plan_key: 'PLAN-EMPTY', dimensions: [], content: null } });
+    expect(text).not.toContain('Architecture Plan');
+  });
+
+  it('returns null when nothing usable is present (no empty block)', () => {
+    expect(formatVisionGrounding({ vision_key: 'V', dimensions: [], content: null, plan: null })).toBeNull();
+  });
+});
+
+describe('buildEnrichmentPrompt — vision-grounded (TS-1, TS-2, TS-3)', () => {
+  it('emits the vision/arch grounding block BEFORE the S0-S18 artifact context (TS-1)', () => {
+    const prompt = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: replitVision });
+    const groundingIdx = prompt.indexOf('Authoritative Vision & Architecture');
+    const artifactIdx = prompt.indexOf('Upstream Artifact Context:');
+    expect(groundingIdx).toBeGreaterThan(-1);
+    expect(artifactIdx).toBeGreaterThan(-1);
+    expect(groundingIdx).toBeLessThan(artifactIdx);
+  });
+
+  it('includes the prefer-vision-over-stage-artifacts-on-conflict instruction (TS-2)', () => {
+    const prompt = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: replitVision });
+    expect(prompt).toContain('0. CRITICAL');
+    expect(prompt).toMatch(/PREFER the Vision\/Architecture and DISCARD the stale artifact/);
+  });
+
+  it('frames the active vision stack (Replit) as authoritative over a stale artifact (Supabase) (TS-3 — the witnessed bug)', () => {
+    const prompt = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: replitVision });
+    // Replit appears inside the authoritative grounding block, ahead of the stale Supabase artifact line
+    const replitIdx = prompt.indexOf('Replit');
+    const supabaseIdx = prompt.indexOf('Supabase as the database');
+    expect(replitIdx).toBeGreaterThan(-1);
+    expect(supabaseIdx).toBeGreaterThan(-1);
+    expect(replitIdx).toBeLessThan(supabaseIdx);
+    expect(prompt).toContain('Architecture Plan dimensions (PLAN-DD-002)');
+  });
+});
+
+describe('buildEnrichmentPrompt — backward compatibility (TS-5, FR-5)', () => {
+  it('produces no grounding block or conflict rule when grounding is absent', () => {
+    const prompt = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: null });
+    expect(prompt).not.toContain('Authoritative Vision & Architecture');
+    expect(prompt).not.toContain('0. CRITICAL');
+    // artifact context follows the original description block directly
+    expect(prompt).toContain(`Original Description:\n${baseArgs.sdDescription}\n\nUpstream Artifact Context:`);
+    expect(prompt).toContain('Generate an enriched SD description that:\n1. Preserves the original intent and scope');
+  });
+
+  it('is byte-identical whether grounding is null or reduces to null (empty dims, no content)', () => {
+    const withNull = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: null });
+    const withEmpty = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: { dimensions: [], content: null, plan: null } });
+    expect(withEmpty).toBe(withNull);
+  });
+
+  it('preserves the JSON response contract in both modes', () => {
+    for (const vg of [null, replitVision]) {
+      const prompt = buildEnrichmentPrompt({ ...baseArgs, visionGrounding: vg });
+      expect(prompt).toContain('"enriched_description": "..."');
+      expect(prompt).toContain('"artifact_references"');
+      expect(prompt).toContain('"extracted_context"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Enrichment **grounding-override** (the prevention half) complementing the already-shipped vision-drift **detection** gate. The venture-build S19→bridge enrichment LLM grounded child SD descriptions on stale **S0–S18 stage artifacts only**, ignoring the active chairman-approved **L2 vision/architecture plan** — so a superseded stack (Supabase) re-contaminated 4 child SDs after a re-vision to Replit (DataDistill SaaS regen, 2026-06-02), requiring manual per-SD scrubbing.

## What changed (3 files, +306/−21)
- **`lib/eva/artifact-enrichment-pipeline.js`** — extract pure exported `buildEnrichmentPrompt()` + `formatVisionGrounding()`. The active L2 vision `extracted_dimensions` (+ arch plan) are emitted **first as authoritative** with a *prefer-vision-over-stage-artifacts-on-conflict* instruction. New optional `visionGrounding` param (default `undefined` ⇒ **byte-identical** legacy prompt) keeps `reEnrichExistingSDs` unbroken.
- **`lib/eva/lifecycle-sd-bridge.js`** — widen `assertVentureVisionReady` select to `extracted_dimensions` and capture its row; new **fail-soft** `buildVisionGrounding()` resolves the arch plan via `plan_key` then `vision_key` linkage (not `venture_id`-only, which is often NULL); thread grounding through `loadAndEnrichArtifacts → enrichSDDescription`. No new fail-closed path.
- **`tests/unit/eva/artifact-enrichment-pipeline.test.js`** — 12 deterministic prompt-assembly tests.

## Verification
- 12 new tests + 54 bridge regression tests = **66/66 green** (TESTING sub-agent verified independently).
- Byte-identical no-grounding path proven (backward compat).

## Provenance
Prospective testing-agent @LEAD caught 4 hard blockers (inert content-only inject, false reuse premise, fail-closed trap, untestable inline prompt) → encoded as TR-1/TR-3 + DR-1. Scope **locked to grounding-override**; artifact-refresh (re-vision invalidating downstream S13/S18 artifacts) + S19 planner re-grounding **deferred** to a follow-up SD (~50% Q8 scope cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)