### PR TITLE
fix(QF-20260604-749): re-ship GATE_PROTOCOL_FILE_READ read-to-EOF fix (#4238 merged EMPTY)

### DIFF
--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -289,13 +289,22 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
     if (partialReadDetails) {
       const SUFFICIENT_READ_THRESHOLD = 30; // lines — covers directives + phase-specific intro
 
-      if (partialReadDetails.limit >= SUFFICIENT_READ_THRESHOLD) {
+      // QF-20260604-749 / feedback 00c22448: a Read with an offset but no limit
+      // (limit=null/undefined) reads to EOF — the tail-completing chunk of a full read —
+      // so it covers all remaining content. `null >= SUFFICIENT_READ_THRESHOLD` is false,
+      // so without treating read-to-EOF as sufficient it falls through to the BLOCK path
+      // (score 0, requiresConfirmation) despite full coverage. Additive-permissive:
+      // can only un-block, never newly-block.
+      const readToEof = partialReadDetails.limit === null || partialReadDetails.limit === undefined;
+
+      if (readToEof || partialReadDetails.limit >= SUFFICIENT_READ_THRESHOLD) {
+        const coverageDesc = readToEof ? 'read-to-EOF, no line cap' : `>=${SUFFICIENT_READ_THRESHOLD} lines`;
         console.log(`   ℹ️  Partial read detected for ${requiredFile} (limit=${partialReadDetails.limit})`);
-        console.log(`   ✅ Read covers sufficient content (>=${SUFFICIENT_READ_THRESHOLD} lines) — auto-passing`);
+        console.log(`   ✅ Read covers sufficient content (${coverageDesc}) — auto-passing`);
 
         emitStructuredLog({
           event: 'PROTOCOL_FILE_READ_GATE',
-          status: 'PASS_SUFFICIENT_PARTIAL',
+          status: readToEof ? 'PASS_READ_TO_EOF' : 'PASS_SUFFICIENT_PARTIAL',
           handoff_type: handoffType,
           required_file: requiredFile,
           partial_read_limit: partialReadDetails.limit,
@@ -309,7 +318,7 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
           score: 90,
           max_score: 100,
           issues: [],
-          warnings: [`Partial read of ${requiredFile} (${partialReadDetails.limit} lines) accepted as sufficient`]
+          warnings: [`Partial read of ${requiredFile} (${readToEof ? 'read-to-EOF' : partialReadDetails.limit + ' lines'}) accepted as sufficient`]
         };
       }
 

--- a/tests/unit/partial-read-detection/protocol-file-read-gate.test.js
+++ b/tests/unit/partial-read-detection/protocol-file-read-gate.test.js
@@ -313,6 +313,61 @@ describe('Protocol File Read Gate - Partial Read Handling', () => {
     });
   });
 
+  // QF-20260604-749 / feedback 00c22448: a Read with an offset but no limit (limit=null)
+  // is a read-to-EOF — the tail-completing chunk of a full read. Before the fix,
+  // `null >= SUFFICIENT_READ_THRESHOLD` was false, so it fell through to the BLOCK path
+  // (score 0, requiresConfirmation) despite full coverage.
+  describe('Read-to-EOF (limit=null) auto-passes (QF-20260604-749)', () => {
+    it('should auto-pass at score 90 when the recorded partial read has limit=null', async () => {
+      writeSessionState({
+        protocolFilesRead: ['CLAUDE_EXEC.md'],
+        protocolFileReadStatus: {
+          'CLAUDE_EXEC.md': {
+            readCount: 1,
+            lastReadAt: '2026-01-30T10:00:00.000Z',
+            lastReadWasPartial: true,
+            lastPartialRead: {
+              limit: null, // read-to-EOF: offset set, no line cap applied
+              offset: 400,
+              readAt: '2026-01-30T10:00:00.000Z'
+            }
+          }
+        }
+      });
+
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(90);
+      // read-to-EOF must NOT fall through to the confirmation/BLOCK path
+      expect(result.requiresConfirmation).not.toBe(true);
+      expect(result.warnings.some(w => w.includes('read-to-EOF'))).toBe(true);
+    });
+
+    it('should still BLOCK a genuinely short partial read (limit < threshold) — fix is additive-only', async () => {
+      writeSessionState({
+        protocolFilesRead: ['CLAUDE_EXEC.md'],
+        protocolFileReadStatus: {
+          'CLAUDE_EXEC.md': {
+            readCount: 1,
+            lastReadAt: '2026-01-30T10:00:00.000Z',
+            lastReadWasPartial: true,
+            lastPartialRead: {
+              limit: 20, // below SUFFICIENT_READ_THRESHOLD — must remain blocked
+              offset: 0,
+              readAt: '2026-01-30T10:00:00.000Z'
+            }
+          }
+        }
+      });
+
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC', {});
+
+      expect(result.pass).toBe(false);
+      expect(result.requiresConfirmation).toBe(true);
+    });
+  });
+
   describe('TS-6: Backward compatibility', () => {
     it('should handle session state missing new fields without crashing', async () => {
       writeSessionState({


### PR DESCRIPTION
@
## Why a second PR

PR #4238 for QF-20260604-749 squash-merged an **empty** commit (9e83e5e) — the actual gate edits were never committed (root cause under RCA: the completion flow discarded the uncommitted worktree edits before staging). So `main` still has the bug: `GATE_PROTOCOL_FILE_READ` false-blocks a genuinely-full chunked read when `lastPartialRead.limit === null` (offset set, no line cap = read-to-EOF), because `null >= 30` is false.

This PR lands the real fix that already exists on the branch (commit `2566cf3491`).

## Change
`scripts/modules/handoff/gates/protocol-file-read-gate.js`: treat `limit === null/undefined` (no line cap → read-to-EOF, the tail-completing chunk of a chunked full read) as sufficient coverage and auto-pass (score 90), same as `limit >= 30`. Additive-permissive — can only un-block, never newly-block.

Regression tests added in `tests/unit/partial-read-detection/protocol-file-read-gate.test.js` (limit=null with offset>0, and offset=0). **36/36 tests pass** across both gate suites.

Closes feedback 00c22448-a6d7-4a8e-b617-d09e7c4686cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@