### PR TITLE
fix(SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001): backend-leaf-aware GATE2 Section A/C exemption

### DIFF
--- a/scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js
+++ b/scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js
@@ -1,0 +1,80 @@
+/**
+ * Backend-leaf detection for GATE2_IMPLEMENTATION_FIDELITY Section A (design-fidelity)
+ * and Section C (data-flow-alignment). Shared by BOTH sections so the UI-surface and
+ * backend-evidence heuristics can never drift apart.
+ *
+ * SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001 (broadens PAT-GATE2-BACKEND-ONLY-001):
+ * Section A checked scope+title and exempted {database,infrastructure,documentation};
+ * Section C checked scope only and exempted only {database}; and neither matched a
+ * cross-repo BACKEND venture leaf like the DataDistill D1 distillation engine, whose
+ * "engine/worker" scope tripped no backend keyword, so it scored 77<80 and forced a
+ * documented --bypass-validation. Recurs for E1 (PII) / H1 (error middleware).
+ *
+ * Discriminator (false-pass FENCE): an SD is a backend leaf ONLY when its scope carries
+ * NO UI surface. Venture UI leaves (e.g. DataDistill F1 "Run History Dashboard - UI
+ * Layer", G1 "Feedback Widget - UI Layer") trip hasUISurface() via "dashboard"/"widget"/
+ * "UI" and are NEVER exempted here. The exemption keys on the no-UI axis, never on
+ * venture membership — validated on live data, where a blanket venture_id exemption
+ * would wrongly pass F1/G1 (they target the venture app AND carry UI scope).
+ *
+ * Pure + synchronous + never throws: callers invoke this inside their existing try/catch,
+ * so a resolver error still falls through to normal scoring (never a free 25/25 on error).
+ */
+
+// UI-surface signal: any of these in scope means the SD promises a user-facing surface,
+// so the UI/form sub-checks ARE applicable (no exemption). Word-boundaried so "platform"/
+// "transform" do not false-trip via "form", and "build" does not false-trip via "ui".
+export const UI_SURFACE_RE =
+  /\b(component|ui|frontend|form|page|view|dashboard|widget|modal|button|input|nav(?:igation)?|layout)\b/i;
+
+// Positive backend evidence: required for the UI-capable types {feature, bugfix} so a
+// vague no-signal feature is NOT exempted — only a genuine backend leaf is. Broadened
+// past the original /(script|cli|command|api|backend|server|lib\/|node)/ to catch the
+// engine/worker/service vocabulary of venture-app backend leaves (the D1 gap).
+export const BACKEND_EVIDENCE_RE =
+  /\b(script|cli|command|api|backend|server|lib\/|node|engine|worker|pipeline|service|daemon|scanner|processor|middleware|queue|job|cron|webhook|distill\w*|resolver|parser|migration|sql|rpc|endpoint|handler|gate|validator|executor|ingest\w*)\b/i;
+
+// Types that never carry a UI surface by definition → exempt on !hasUISurface alone.
+export const NO_UI_TYPES = Object.freeze(['database', 'infrastructure', 'documentation']);
+
+// Types that CAN be UI → require positive backend evidence to count as a backend leaf.
+export const BACKEND_CAPABLE_TYPES = Object.freeze(['feature', 'bugfix']);
+
+export function hasUISurface(text) {
+  return UI_SURFACE_RE.test(String(text || ''));
+}
+
+export function hasBackendEvidence(scopeText, titleText) {
+  return BACKEND_EVIDENCE_RE.test(String(scopeText || '')) ||
+         BACKEND_EVIDENCE_RE.test(String(titleText || ''));
+}
+
+/**
+ * Case-insensitive EHG_Engineer target check. The data carries both casings across
+ * venture targets (e.g. 'datadistill'/'DataDistill'); harden the platform compare too.
+ */
+export function isEhgEngineerTarget(target) {
+  return String(target || '').trim().toLowerCase() === 'ehg_engineer';
+}
+
+/**
+ * Classify whether an SD is a backend leaf (no UI surface) that should receive full
+ * Section A / Section C credit. Pure, synchronous, never throws.
+ *
+ * @param {string} sdType   - resolved sd.sd_type
+ * @param {string} scopeText - flattened scope.included text
+ * @param {string} titleText - resolved sd.title
+ * @returns {{exempt: boolean, reason: string}}
+ */
+export function classifyBackendLeaf(sdType, scopeText, titleText) {
+  const t = String(sdType || '').trim().toLowerCase();
+  // FENCE: a UI surface in scope means the UI/form sub-checks are applicable.
+  if (hasUISurface(scopeText)) return { exempt: false, reason: 'has UI surface in scope' };
+  if (NO_UI_TYPES.includes(t)) {
+    return { exempt: true, reason: `${t} SD without UI scope - no UI/form surface by type` };
+  }
+  if (BACKEND_CAPABLE_TYPES.includes(t) && hasBackendEvidence(scopeText, titleText)) {
+    return { exempt: true, reason: `backend-only ${t} SD (engine/worker/server/API) - no UI/form surface` };
+  }
+  return { exempt: false, reason: 'no backend-leaf signal' };
+}

--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -8,6 +8,7 @@ import { readdir } from 'fs/promises';
 import path from 'path';
 import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 import { getSectionEnforcement } from '../sd-type-section-policy.js';
+import { classifyBackendLeaf, isEhgEngineerTarget } from './backend-leaf-detection.js';
 
 /**
  * Validate Data Flow Alignment
@@ -52,7 +53,7 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
   // EHG_Engineer is a backend-only repo (CLI, scripts, tooling) - never has form/UI integration
   {
     const targetApp = validation.details.target_application || null;
-    if (targetApp === 'EHG_Engineer') {
+    if (isEhgEngineerTarget(targetApp)) {
       console.log('   ✅ EHG_Engineer target application (backend-only) - Section C not applicable (25/25)');
       validation.score += 25;
       validation.gate_scores.data_flow_alignment = 25;
@@ -69,7 +70,7 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
   try {
     const { resolveSdInputOrNull } = await import('../../../lib/sd-id-resolver.js');
     const { sd: sdResolved } = await resolveSdInputOrNull(sd_id, supabase);
-    let sd = sdResolved ? { sd_type: sdResolved.sd_type, scope: sdResolved.scope } : null;
+    let sd = sdResolved ? { sd_type: sdResolved.sd_type, scope: sdResolved.scope, title: sdResolved.title } : null;
     // Legacy 2-step fallback removed: resolver handles both UUID and sd_key forms via single .or() query.
 
     // Extract scope text for analysis
@@ -150,6 +151,24 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
           skipped: true,
           reason: 'EHG frontend lib-level feature with no DB/forms/UI by design (PAT-GATE2-LIBFEATURE-001)'
         };
+        return;
+      }
+    }
+
+    // SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001 (PAT-GATE2-BACKEND-ONLY-001 broadened):
+    // LAST exemption — existing exemptions (incl. PAT-GATE2-LIBFEATURE-001 above) keep
+    // precedence. Symmetric with Section A. Covers cross-repo BACKEND venture leaves (e.g.
+    // DataDistill D1 distillation engine — "engine/worker" scope, target=datadistill) and
+    // infrastructure/bugfix backend leaves whose scope/title miss the narrow keyword set
+    // above. Fence is !hasUISurface, so venture UI leaves (F1 dashboard, G1 widget) stay
+    // enforced. Pure/sync — the enclosing try/catch falls through to normal scoring on error.
+    {
+      const leaf = classifyBackendLeaf(sd?.sd_type, scopeToCheck, sd?.title);
+      if (leaf.exempt) {
+        console.log(`   ✅ Backend leaf (${leaf.reason}) - Section C not applicable (25/25) [SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001]`);
+        validation.score += 25;
+        validation.gate_scores.data_flow_alignment = 25;
+        validation.details.data_flow_alignment = { skipped: true, reason: `Backend leaf - ${leaf.reason}` };
         return;
       }
     }

--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -352,7 +352,7 @@ async function detectDatabaseScope(sd_id, supabase) {
     const hasQueries = dbSignal.test(gitDiff);
 
     return { hasMigrations, hasQueries };
-  } catch (error) {
+  } catch (_error) {
     // Conservative: on detection failure do NOT grant the N/A pass.
     return { hasMigrations: true, hasQueries: true, detection_error: true };
   }

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -7,6 +7,7 @@
 
 import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 import { getSectionEnforcement } from '../sd-type-section-policy.js';
+import { classifyBackendLeaf, isEhgEngineerTarget } from './backend-leaf-detection.js';
 
 /**
  * Validate Design Implementation Fidelity
@@ -50,7 +51,7 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
   // EHG_Engineer is a backend-only repo (CLI, scripts, tooling) - never has UI components
   {
     const targetApp = validation.details.target_application || null;
-    if (targetApp === 'EHG_Engineer') {
+    if (isEhgEngineerTarget(targetApp)) {
       console.log('   ✅ EHG_Engineer target application (backend-only) - Section A not applicable (25/25)');
       validation.score += 25;
       validation.gate_scores.design_fidelity = 25;
@@ -152,6 +153,24 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
           skipped: true,
           reason: 'EHG frontend lib-level feature with no DB/forms/UI by design (PAT-GATE2-LIBFEATURE-001)'
         };
+        return;
+      }
+    }
+
+    // SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001 (PAT-GATE2-BACKEND-ONLY-001 broadened):
+    // LAST exemption — existing exemptions (incl. PAT-GATE2-LIBFEATURE-001 above) keep
+    // precedence. Covers cross-repo BACKEND venture leaves (e.g. DataDistill D1 distillation
+    // engine — "engine/worker" scope, target=datadistill) and bugfix backend leaves whose
+    // scope/title miss the narrow keyword set above. Fence is !hasUISurface, so venture UI
+    // leaves (F1 dashboard, G1 widget) stay enforced. classifyBackendLeaf is pure/sync — the
+    // enclosing try/catch still falls through to normal scoring on a resolver error.
+    {
+      const leaf = classifyBackendLeaf(sd?.sd_type, scopeToCheck, sd?.title);
+      if (leaf.exempt) {
+        console.log(`   ✅ Backend leaf (${leaf.reason}) - Section A not applicable (25/25) [SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001]`);
+        validation.score += 25;
+        validation.gate_scores.design_fidelity = 25;
+        validation.details.design_fidelity = { skipped: true, reason: `Backend leaf - ${leaf.reason}` };
         return;
       }
     }

--- a/tests/unit/implementation-fidelity/backend-leaf-exemption.test.js
+++ b/tests/unit/implementation-fidelity/backend-leaf-exemption.test.js
@@ -1,0 +1,183 @@
+/**
+ * SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001 — broadened backend-leaf exemption
+ * (PAT-GATE2-BACKEND-ONLY-001) for GATE2_IMPLEMENTATION_FIDELITY Section A
+ * (design-fidelity) and Section C (data-flow-alignment).
+ *
+ * Cross-repo BACKEND venture leaves (no UI), e.g. the DataDistill D1 distillation
+ * engine, previously scored 77<80 because the Section A/C UI/form sub-checks penalize
+ * the absence of a UI surface and the narrow feature+scope-keyword exemption missed an
+ * "engine/worker" scope. This SD makes the exemption SD-type/backend aware while keeping
+ * the !hasUISurface fence that keeps venture UI leaves (F1 dashboard, G1 widget) enforced.
+ *
+ * Tests the shared pure helper directly (deterministic, no DB) AND the two section
+ * validators end-to-end (mirroring the existing lib-feature-exemption.test.js harness).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  classifyBackendLeaf,
+  hasUISurface,
+  hasBackendEvidence,
+  isEhgEngineerTarget,
+} from '../../../scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Part 1 — pure helper (the discriminator logic)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('backend-leaf-detection — classifyBackendLeaf (pure)', () => {
+  it('TS-1: exempts a feature backend venture leaf (D1 distillation engine, no UI scope)', () => {
+    const r = classifyBackendLeaf(
+      'feature',
+      'Distillation engine SCAN/WALK/DIST + FK-integrity transitive-closure + run/worker',
+      'DataDistill D1 Distillation Engine'
+    );
+    expect(r.exempt).toBe(true);
+  });
+
+  it('TS-1: exempts a bugfix backend leaf (H1 error middleware) and an infrastructure leaf (E1 PII)', () => {
+    expect(classifyBackendLeaf('bugfix', 'error middleware handler for the run worker', 'H1 error middleware').exempt).toBe(true);
+    expect(classifyBackendLeaf('infrastructure', 'PII masking mask-before-write fail-closed + Luhn', 'E1 PII masking').exempt).toBe(true);
+  });
+
+  it('TS-2: does NOT exempt venture UI leaves F1 (dashboard) / G1 (widget) — the false-pass fence', () => {
+    expect(classifyBackendLeaf('feature', 'Run History Dashboard - UI Layer with charts', 'F1 Run History Dashboard').exempt).toBe(false);
+    expect(classifyBackendLeaf('feature', 'Feedback Widget - UI Layer dialog form', 'G1 Feedback Widget').exempt).toBe(false);
+  });
+
+  it('conservative: a vague feature with no UI and no backend evidence is NOT exempted', () => {
+    expect(classifyBackendLeaf('feature', 'Improve some things and tidy up', '').exempt).toBe(false);
+  });
+
+  it('TS-3: sd_type comparison is case-insensitive', () => {
+    expect(classifyBackendLeaf('FEATURE', 'api server endpoint worker', 'X').exempt).toBe(true);
+    expect(classifyBackendLeaf(' Feature ', 'distillation engine', 'X').exempt).toBe(true);
+  });
+
+  it('TS-6 (fail-safe): bad/empty inputs never throw and never exempt', () => {
+    expect(() => classifyBackendLeaf(null, null, null)).not.toThrow();
+    expect(classifyBackendLeaf(null, null, null).exempt).toBe(false);
+    expect(() => classifyBackendLeaf(undefined, 123, {})).not.toThrow();
+    expect(classifyBackendLeaf(undefined, 123, {}).exempt).toBe(false);
+  });
+
+  it('hasUISurface: word-boundaried — no false trips on platform/transform/build', () => {
+    expect(hasUISurface('build a cross-platform transform pipeline')).toBe(false);
+    expect(hasUISurface('add a settings form')).toBe(true);
+    expect(hasUISurface('Run History Dashboard - UI Layer')).toBe(true);
+    expect(hasUISurface('Feedback Widget')).toBe(true);
+  });
+
+  it('hasBackendEvidence: matches engine/worker vocabulary in scope OR title', () => {
+    expect(hasBackendEvidence('distillation engine scan', '')).toBe(true);
+    expect(hasBackendEvidence('plain prose with no signal', '')).toBe(false);
+    expect(hasBackendEvidence('', 'API Server Endpoint')).toBe(true);
+  });
+
+  it('TS-3/TS-5: isEhgEngineerTarget is case/whitespace-insensitive; EHG and venture apps are not EHG_Engineer', () => {
+    expect(isEhgEngineerTarget('EHG_Engineer')).toBe(true);
+    expect(isEhgEngineerTarget('ehg_engineer')).toBe(true);
+    expect(isEhgEngineerTarget('  EHG_Engineer  ')).toBe(true);
+    expect(isEhgEngineerTarget('EHG')).toBe(false);
+    expect(isEhgEngineerTarget('datadistill')).toBe(false);
+    expect(isEhgEngineerTarget('DataDistill')).toBe(false);
+    expect(isEhgEngineerTarget(null)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Part 2 — section validators end-to-end (mirrors lib-feature-exemption.test.js)
+// ─────────────────────────────────────────────────────────────────────────────
+const h = vi.hoisted(() => ({ sd: null }));
+
+vi.mock('../../../scripts/lib/sd-id-resolver.js', () => ({
+  resolveSdInputOrNull: async () => ({ sd: h.sd }),
+  resolveSdInput: async () => ({ sd: h.sd }),
+}));
+vi.mock('../../../scripts/modules/implementation-fidelity/utils/index.js', () => ({
+  getSDSearchTerms: async () => [],
+  detectImplementationRepos: async () => [],
+  gitLogForSD: async () => '',
+}));
+
+const { validateDataFlowAlignment } = await import(
+  '../../../scripts/modules/implementation-fidelity/sections/data-flow-alignment.js'
+);
+const { validateDesignFidelity } = await import(
+  '../../../scripts/modules/implementation-fidelity/sections/design-fidelity.js'
+);
+
+function makeSupabase() {
+  const chain = {
+    from: () => chain,
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    not: () => chain,
+    single: () => Promise.resolve({ data: null, error: null }),
+    maybeSingle: () => Promise.resolve({ data: null, error: null }),
+    limit: () => Promise.resolve({ data: null, error: null }),
+  };
+  return chain;
+}
+function makeValidation({ sd_type = 'feature', target_application = 'datadistill' } = {}) {
+  return { passed: true, score: 0, issues: [], warnings: [], details: { sd_type, target_application }, gate_scores: {} };
+}
+const isBackendLeaf = (d, k) => d?.[k]?.skipped === true && typeof d?.[k]?.reason === 'string' && d[k].reason.includes('Backend leaf');
+
+// A feature scope that MISSES the narrow pre-existing regex (no script/cli/api/server/lib/)
+// but hits the broadened engine/worker evidence → exercises THIS SD's new branch.
+const D1_SCOPE = 'Distillation engine: SCAN/WALK/DIST passes, FK-integrity transitive-closure, run + worker loop';
+
+describe('backend-leaf exemption — Section C (data-flow-alignment) E2E', () => {
+  beforeEach(() => { h.sd = null; });
+
+  it('TS-1: a feature backend venture leaf is exempted (25/25) via the broadened branch', async () => {
+    h.sd = { sd_type: 'feature', scope: D1_SCOPE, title: 'D1 Distillation Engine' };
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-X', null, null, v, makeSupabase());
+    expect(v.gate_scores.data_flow_alignment).toBe(25);
+    expect(isBackendLeaf(v.details, 'data_flow_alignment')).toBe(true);
+  });
+
+  it('TS-2: a venture UI leaf (dashboard) is NOT exempted by the backend-leaf branch', async () => {
+    h.sd = { sd_type: 'feature', scope: 'Run History Dashboard - UI Layer with charts and a view', title: 'F1 Dashboard' };
+    const v = makeValidation();
+    await validateDataFlowAlignment('SD-X', null, null, v, makeSupabase());
+    expect(isBackendLeaf(v.details, 'data_flow_alignment')).toBe(false);
+  });
+
+  it('TS-5: EHG_Engineer (case-insensitive) still exempts via the earlier PAT-GATE2-BE-001 rung', async () => {
+    h.sd = { sd_type: 'feature', scope: D1_SCOPE, title: 'x' };
+    const v = makeValidation({ target_application: 'ehg_engineer' });
+    await validateDataFlowAlignment('SD-X', null, null, v, makeSupabase());
+    expect(v.gate_scores.data_flow_alignment).toBe(25);
+    expect(v.details.data_flow_alignment.reason).toMatch(/backend-only/i);
+    expect(isBackendLeaf(v.details, 'data_flow_alignment')).toBe(false); // not the new marker
+  });
+});
+
+describe('backend-leaf exemption — Section A (design-fidelity) E2E', () => {
+  beforeEach(() => { h.sd = null; });
+
+  it('TS-1: a feature backend venture leaf is exempted (25/25)', async () => {
+    h.sd = { sd_type: 'feature', scope: D1_SCOPE, title: 'D1 Distillation Engine' };
+    const v = makeValidation();
+    await validateDesignFidelity('SD-X', { some: 'design' }, v, makeSupabase());
+    expect(v.gate_scores.design_fidelity).toBe(25);
+    expect(isBackendLeaf(v.details, 'design_fidelity')).toBe(true);
+  });
+
+  it('TS-2: a venture UI leaf (widget + form) is NOT exempted by the backend-leaf branch', async () => {
+    h.sd = { sd_type: 'feature', scope: 'Feedback Widget UI Layer with a form and a button', title: 'G1 Feedback Widget' };
+    const v = makeValidation();
+    await validateDesignFidelity('SD-X', { some: 'design' }, v, makeSupabase());
+    expect(isBackendLeaf(v.details, 'design_fidelity')).toBe(false);
+  });
+
+  it('TS-4: case-insensitive EHG_Engineer exempts via the earlier rung (regression-safe)', async () => {
+    h.sd = { sd_type: 'feature', scope: D1_SCOPE, title: 'x' };
+    const v = makeValidation({ target_application: 'EHG_Engineer' });
+    await validateDesignFidelity('SD-X', { some: 'design' }, v, makeSupabase());
+    expect(v.gate_scores.design_fidelity).toBe(25);
+    expect(isBackendLeaf(v.details, 'design_fidelity')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
GATE2_IMPLEMENTATION_FIDELITY mis-scored cross-repo **BACKEND venture leaves** (no UI). A pure server-side engine — the DataDistill **D1 distillation engine** — scored **77<80** because Section A (design/UI) and Section C (data-flow/form-UI) penalize the absent UI surface, blocking EXEC-TO-PLAN and cascade-blocking PLAN-TO-LEAD Gate-3. The narrow `PAT-GATE2-BACKEND-ONLY-001` exemption only fired for `sd_type=feature` whose scope matched a short keyword set, so an "engine/worker" scope fell through and forced documented `--bypass-validation` (recurred for E1 PII / H1 error middleware).

## Fix
A shared **pure** detector `scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js` (`classifyBackendLeaf`/`hasUISurface`/`hasBackendEvidence`/`isEhgEngineerTarget`) used **symmetrically** by Section A (`design-fidelity.js`) and Section C (`data-flow-alignment.js`):
- Broadens eligibility past `sd_type=feature` (adds `bugfix` + the no-UI types) and past the narrow scope regex (engine/worker/pipeline/service/distill… in scope **or** title).
- Keeps the **`!hasUISurface` conjunction as the false-pass fence**: venture **UI** leaves (F1 "Run History Dashboard", G1 "Feedback Widget" — `target=datadistill`, `hasUIScope=true`) stay enforced. Discriminates on the **no-UI axis, never venture membership** (proven on live data to mis-fire on F1/G1).
- `target_application` compare is now case-insensitive (`datadistill`/`DataDistill`).
- Detector is pure/sync inside the existing try/catch → a resolver error falls through to normal scoring (**never a free 25/25**).
- New branch sits **LAST** so all 5 existing exemptions (incl. `PAT-GATE2-LIBFEATURE-001`) keep precedence.

## Tests
`tests/unit/implementation-fidelity/backend-leaf-exemption.test.js` (helper + Section A/C E2E: backend leaf exempted, F1/G1 UI leaves NOT exempted, case parity, fail-safe). Full implementation-fidelity suite green (**73/73**). REGRESSION sub-agent confirmed public API unchanged, 0 regressions.

LOC: +304/-3 (mostly the heavily-commented shared helper + tests). SD: SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001 (bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)