### PR TITLE
feat(SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001): handoff retros use retro_type=HANDOFF

### DIFF
--- a/database/migrations/20260604_normalize_handoff_retro_type.sql
+++ b/database/migrations/20260604_normalize_handoff_retro_type.sql
@@ -1,0 +1,50 @@
+-- SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001
+-- Normalize handoff retrospective type-column semantics.
+--
+-- Problem: the 3 handoff retro writers (plan-to-exec / lead-to-plan /
+-- exec-to-plan/retrospective.js) hardcode retro_type='SD_COMPLETION' and store
+-- the real phase in retrospective_type, so ~3,683 handoff retros pollute the
+-- retro_type='SD_COMPLETION' namespace. The SD-completion gate
+-- (retro-filters.js getFilteredRetrospective) must then compensate downstream
+-- with a brittle retrospective_type filter. Separately, the live
+-- retrospective_type CHECK omitted EXEC_TO_PLAN, so the exec-to-plan writer was
+-- silently rejected and zero EXEC_TO_PLAN retros ever persisted.
+--
+-- Fix:
+--   FR-1: add 'HANDOFF' to retrospectives_retro_type_check (preserves the 9
+--         live values + the = ANY(ARRAY[..]) form; NULL stays implicitly allowed).
+--   FR-3: add 'EXEC_TO_PLAN' to retrospectives_retrospective_type_check so the
+--         exec-to-plan handoff retro can persist.
+--   FR-2: backfill existing handoff retros out of the SD_COMPLETION namespace.
+--
+-- Verified via prod BEGIN..ROLLBACK dry-run (database-agent): the ADD CONSTRAINT
+-- validates against all 7,469 existing rows and the backfill reclassifies ~3,683
+-- rows (LEAD_TO_PLAN 2013 + PLAN_TO_EXEC 1670 + EXEC_TO_PLAN 0); the completion
+-- gate SELECT still returns genuine SD_COMPLETION retros afterward.
+
+BEGIN;
+
+-- FR-1: HANDOFF becomes a first-class retro_type.
+ALTER TABLE retrospectives DROP CONSTRAINT IF EXISTS retrospectives_retro_type_check;
+ALTER TABLE retrospectives ADD CONSTRAINT retrospectives_retro_type_check
+  CHECK (retro_type = ANY (ARRAY[
+    'SPRINT', 'SD_COMPLETION', 'INCIDENT', 'MILESTONE', 'WEEKLY', 'MONTHLY',
+    'ARCHITECTURE_DECISION', 'RELEASE', 'AUDIT', 'HANDOFF'
+  ]));
+
+-- FR-3: permit EXEC_TO_PLAN on retrospective_type (repairs the dead exec-to-plan writer).
+ALTER TABLE retrospectives DROP CONSTRAINT IF EXISTS retrospectives_retrospective_type_check;
+ALTER TABLE retrospectives ADD CONSTRAINT retrospectives_retrospective_type_check
+  CHECK (retrospective_type = ANY (ARRAY[
+    'LEAD_TO_PLAN', 'PLAN_TO_EXEC', 'EXEC_TO_PLAN', 'SD_COMPLETION'
+  ]));
+
+-- FR-2: reclassify existing handoff-time retros so they no longer occupy the
+-- SD_COMPLETION namespace. Genuine completion retros (retrospective_type NULL or
+-- SD_COMPLETION) are excluded by the WHERE clause and remain unchanged.
+UPDATE retrospectives
+   SET retro_type = 'HANDOFF'
+ WHERE retro_type = 'SD_COMPLETION'
+   AND retrospective_type IN ('LEAD_TO_PLAN', 'PLAN_TO_EXEC', 'EXEC_TO_PLAN');
+
+COMMIT;

--- a/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
@@ -380,7 +380,7 @@ export async function createExecToPlanRetrospective(supabase, sdId, sd, handoffR
     const retrospective = {
       sd_id: sd?.id || sdId,
       project_name: sd.title,
-      retro_type: 'SD_COMPLETION',
+      retro_type: 'HANDOFF', // SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001: handoff retros are NOT SD-completion retros
       retrospective_type: 'EXEC_TO_PLAN',
       title: `EXEC Phase Retrospective: ${sd.title}`,
       description: `Implementation retrospective for EXEC-TO-PLAN handoff of ${sd.sd_key}`,

--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -280,8 +280,8 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
     const retrospective = {
       sd_id: sd?.id || sdId,
       project_name: sd.title,
-      retro_type: 'SD_COMPLETION', // Use valid enum value
-      retrospective_type: retrospectiveType, // Store actual handoff type here
+      retro_type: 'HANDOFF', // SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001: handoff retros are NOT SD-completion retros
+      retrospective_type: retrospectiveType, // Store actual handoff phase here (LEAD_TO_PLAN)
       title: `${retrospectiveType} Handoff Retrospective: ${sd.title}`,
       description: `Retrospective for ${retrospectiveType} handoff of ${sd.sd_key}`,
       conducted_date: new Date().toISOString(),

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -189,8 +189,8 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
     const retrospective = {
       sd_id: sd?.id || sdId,
       project_name: sd.title,
-      retro_type: 'SD_COMPLETION', // Use valid enum value
-      retrospective_type: retrospectiveType, // Store actual handoff type here
+      retro_type: 'HANDOFF', // SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001: handoff retros are NOT SD-completion retros
+      retrospective_type: retrospectiveType, // Store actual handoff phase here (PLAN_TO_EXEC)
       title: `${retrospectiveType} Handoff Retrospective: ${sd.title}`,
       description: `Retrospective for ${retrospectiveType} handoff of ${sd.sd_key}`,
       conducted_date: new Date().toISOString(),

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
@@ -20,7 +20,7 @@ import { createMockSD } from '../../../../../../tests/factories/validator-contex
 function buildSupabase({ children = [], retrospective = null, childError = null, handoffRow = null }) {
   const makeChainable = (resolveValue) => {
     const c = {
-      select: () => c, eq: () => c, neq: () => c, gt: () => c, gte: () => c, lt: () => c, lte: () => c, is: () => c,
+      select: () => c, eq: () => c, neq: () => c, or: () => c, gt: () => c, gte: () => c, lt: () => c, lte: () => c, is: () => c,
       order: () => c, limit: () => c,
       single: () => Promise.resolve(resolveValue),
       maybeSingle: () => Promise.resolve(resolveValue),

--- a/scripts/modules/handoff/retro-filters.js
+++ b/scripts/modules/handoff/retro-filters.js
@@ -4,17 +4,20 @@
  * Both PLAN-TO-LEAD (retrospective-quality.js) and LEAD-FINAL-APPROVAL
  * (createRetrospectiveExistsGate) must enforce the same invariants:
  *   1. Existence: at least one retrospective row for the SD
- *   2. Type: retro_type = 'SD_COMPLETION' (excludes SPRINT/INCIDENT/AUDIT)
- *   3. Not a handoff-time retro: retrospective_type IS NULL (handoff-time
- *      retros tag this column with LEAD_TO_PLAN / PLAN_TO_EXEC / etc.)
+ *   2. Type: retro_type = 'SD_COMPLETION' (excludes SPRINT/INCIDENT/AUDIT/HANDOFF)
+ *   3. Not a handoff-time retro: retrospective_type IS NULL (defense in depth)
  *   4. Freshness: created_at > the SD's LEAD-TO-PLAN acceptance timestamp
- *      (defense in depth — catches any handoff-type retros missed by #3)
+ *      (defense in depth)
  *
- * Handoff-time retrospectives are written with retro_type='SD_COMPLETION'
- * but also set retrospective_type to the handoff phase (see
- * scripts/modules/handoff/executors/lead-to-plan/retrospective.js line 283-284),
- * so retro_type alone does not distinguish them from true SD-completion retros.
- * The retrospective_type and timestamp filters are both required.
+ * SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001: handoff-time retrospectives
+ * are now written with retro_type='HANDOFF' (the 3 handoff retro writers), so the
+ * retro_type='SD_COMPLETION' filter (#2) excludes them on its own — that is the
+ * primary mechanism. The retrospective_type (#3) and timestamp (#4) filters are
+ * retained as defense-in-depth: they still exclude any legacy rows from before the
+ * backfill that a manual writer might leave tagged with a handoff phase under
+ * retro_type='SD_COMPLETION'. (Previously handoff retros shared
+ * retro_type='SD_COMPLETION', so retro_type alone could NOT distinguish them and
+ * #3/#4 were load-bearing — see git history pre-NORMALIZE-HANDOFF.)
  */
 
 /**

--- a/scripts/modules/handoff/retro-filters.test.js
+++ b/scripts/modules/handoff/retro-filters.test.js
@@ -12,7 +12,7 @@ import { getFilteredRetrospective, resolveLeadToPlanAcceptedAt } from './retro-f
 function buildSupabase({ handoffRow = null, retrospective = null } = {}) {
   const makeChainable = (resolveValue) => {
     const c = {
-      select: () => c, eq: () => c, gt: () => c, is: () => c, order: () => c, limit: () => c,
+      select: () => c, eq: () => c, or: () => c, gt: () => c, is: () => c, order: () => c, limit: () => c,
       maybeSingle: () => Promise.resolve(resolveValue),
       single: () => Promise.resolve(resolveValue),
       then: (fn) => Promise.resolve(resolveValue).then(fn),
@@ -78,5 +78,89 @@ describe('getFilteredRetrospective', () => {
     const { leadToPlanAcceptedAt } =
       await getFilteredRetrospective('sd-uuid', null, supabase);
     expect(leadToPlanAcceptedAt).toBe(accepted);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001 — regression: the gate must
+ * exclude handoff-time retros (now retro_type='HANDOFF') and admit only genuine
+ * SD-completion retros (retro_type='SD_COMPLETION' with retrospective_type NULL
+ * or 'SD_COMPLETION'). The no-op mock above cannot express predicate exclusion,
+ * so this mock actually APPLIES the gate's .eq()/.or()/.gt()/order/limit query
+ * against a candidate row set — proving the filter semantics, not just plumbing.
+ */
+function buildPredicateSupabase({ handoffRow = null, rows = [] } = {}) {
+  const retroChain = () => {
+    const eqs = {};
+    let orPred = null;
+    let gtPred = null;
+    let orderDesc = false;
+    const c = {
+      select: () => c,
+      eq: (col, val) => { eqs[col] = val; return c; },
+      or: (str) => { orPred = str; return c; },
+      gt: (col, val) => { gtPred = { col, val }; return c; },
+      is: () => c,
+      order: (_col, opts) => { orderDesc = opts && opts.ascending === false; return c; },
+      limit: () => c,
+      maybeSingle: () => {
+        let out = rows.filter((r) => Object.entries(eqs).every(([k, v]) => r[k] === v));
+        if (orPred) {
+          // Parse the exact gate clause: retrospective_type.is.null,retrospective_type.eq.SD_COMPLETION
+          out = out.filter((r) => r.retrospective_type == null || r.retrospective_type === 'SD_COMPLETION');
+        }
+        if (gtPred) out = out.filter((r) => r[gtPred.col] > gtPred.val);
+        if (orderDesc) out = [...out].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+        return Promise.resolve({ data: out[0] || null, error: null });
+      },
+    };
+    return c;
+  };
+  return {
+    from: vi.fn((table) => {
+      if (table === 'sd_phase_handoffs') {
+        const c = {
+          select: () => c, eq: () => c, order: () => c, limit: () => c,
+          maybeSingle: () => Promise.resolve({ data: handoffRow, error: null }),
+        };
+        return c;
+      }
+      if (table === 'retrospectives') return { select: () => retroChain() };
+      return { select: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) };
+    }),
+  };
+}
+
+describe('getFilteredRetrospective — HANDOFF exclusion (NORMALIZE-HANDOFF-RETROSPECTIVE-001)', () => {
+  const sdUuid = 'sd-uuid';
+  const accepted = '2026-04-01T00:00:00.000Z';
+
+  it('excludes a HANDOFF row even when it is the newest, and returns the SD_COMPLETION|null completion retro', async () => {
+    const rows = [
+      { id: 'handoff-newest', sd_id: sdUuid, retro_type: 'HANDOFF', retrospective_type: 'PLAN_TO_EXEC', created_at: '2026-04-20T00:00:00.000Z' },
+      { id: 'completion', sd_id: sdUuid, retro_type: 'SD_COMPLETION', retrospective_type: null, created_at: '2026-04-10T00:00:00.000Z' },
+    ];
+    const supabase = buildPredicateSupabase({ handoffRow: { accepted_at: accepted }, rows });
+    const { retrospective } = await getFilteredRetrospective(sdUuid, null, supabase);
+    expect(retrospective?.id).toBe('completion');
+  });
+
+  it('admits a SD_COMPLETION|SD_COMPLETION retro (retro-agent enhance shape, QF-670)', async () => {
+    const rows = [
+      { id: 'enhanced', sd_id: sdUuid, retro_type: 'SD_COMPLETION', retrospective_type: 'SD_COMPLETION', created_at: '2026-04-12T00:00:00.000Z' },
+      { id: 'handoff', sd_id: sdUuid, retro_type: 'HANDOFF', retrospective_type: 'LEAD_TO_PLAN', created_at: '2026-04-13T00:00:00.000Z' },
+    ];
+    const supabase = buildPredicateSupabase({ handoffRow: { accepted_at: accepted }, rows });
+    const { retrospective } = await getFilteredRetrospective(sdUuid, null, supabase);
+    expect(retrospective?.id).toBe('enhanced');
+  });
+
+  it('returns null when the only row is a HANDOFF retro (no completion retro exists)', async () => {
+    const rows = [
+      { id: 'handoff-only', sd_id: sdUuid, retro_type: 'HANDOFF', retrospective_type: 'PLAN_TO_EXEC', created_at: '2026-04-20T00:00:00.000Z' },
+    ];
+    const supabase = buildPredicateSupabase({ handoffRow: { accepted_at: accepted }, rows });
+    const { retrospective } = await getFilteredRetrospective(sdUuid, null, supabase);
+    expect(retrospective).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Handoff-time retrospective writers hardcoded `retro_type='SD_COMPLETION'` (storing the real phase in `retrospective_type`), so ~3,685 handoff retros polluted the `SD_COMPLETION` namespace and the completion gate had to compensate downstream. This gives handoff retros a first-class `retro_type='HANDOFF'` and repairs the silently-rejected exec-to-plan writer.

SD: **SD-LEO-INFRA-NORMALIZE-HANDOFF-RETROSPECTIVE-001** (infrastructure). Complementary to QF-20260604-797 (which fixed the retro-agent *enhance* path).

## Changes
- **Migration** (`20260604_normalize_handoff_retro_type.sql`): add `HANDOFF` to `retrospectives_retro_type_check`; add `EXEC_TO_PLAN` to `retrospectives_retrospective_type_check` (the exec-to-plan writer's `retrospective_type='EXEC_TO_PLAN'` was constraint-rejected → 0 rows ever); backfill 3,685 handoff rows out of `SD_COMPLETION`.
- **3 handoff retro writers** now emit `retro_type='HANDOFF'`.
- **retro-filters.js**: gate now excludes handoff retros by `retro_type` alone; `retrospective_type`/timestamp filters retained as defense-in-depth (comment refresh only — query unchanged).
- **Regression test**: predicate-applying mock proving `HANDOFF` rows are excluded while `SD_COMPLETION|NULL` and `SD_COMPLETION|SD_COMPLETION` are admitted.
- **Pre-existing fix**: two stale-mock failures (QF-670 added `.or()` to the gate query but the test mocks lacked it) — `retro-filters.test.js`, `retrospective-quality.test.js`.

## Verification
- database-agent prod `BEGIN..ROLLBACK` dry-run → then applied for real. Post-apply: **0** leftover `SD_COMPLETION`+handoff-phase rows; **3,685** `HANDOFF`; **3,772** genuine `SD_COMPLETION` retros untouched (conservation check exact).
- Explore consumer analysis: all 9 consumers of `retro_type='SD_COMPLETION'` SAFE; `retro-clobber-guard` becomes more precise.
- Retro-gate test family: **34 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
