### PR TITLE
fix(SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001): require code-path corroboration to flip a set target_application

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
@@ -144,8 +144,13 @@ export async function validateTargetApplication(sd, supabase) {
   ];
 
   // Patterns that indicate EHG (main application)
+  // SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001 (C4): dropped 'backend' and 'venture' —
+  // category words that false-signal EHG. EHG_Engineer is itself almost entirely backend,
+  // and 'venture' pervades its venture-build / orchestrator infra SDs, so these two tokens
+  // prose-flipped backend EHG_Engineer SDs to EHG (3rd+ recurrence). The 10 genuine EHG
+  // signals below still route real frontend SDs to EHG.
   const ehgPatterns = [
-    'stage', 'venture', 'ui component', 'react', 'frontend', 'backend',
+    'stage', 'ui component', 'react', 'frontend',
     'api endpoint', 'database table', 'rls policy', 'user interface',
     'supabase function', 'edge function'
   ];
@@ -228,30 +233,48 @@ export async function validateTargetApplication(sd, supabase) {
       };
     }
 
-    // SD-LEO-INFRA-CODE-PATH-AWARE-001: code-path-aware suppression. When the
-    // flip would downgrade EHG_Engineer->EHG but the SD's key_changes/scope
-    // reference EHG_Engineer code paths (only, or mixed cross-repo), the
-    // deliverables live in EHG_Engineer regardless of marketing/UI scope
-    // vocabulary — do NOT auto-correct to EHG (this is the defect class that
-    // mislabeled SD-SURFACEAWARE B/C/E and SD-ACTIVATE). A clean EHG-only path
-    // signal (no EHG_Engineer paths) still flips through the block below.
-    if (currentTarget === 'EHG_Engineer' && inferredTarget === 'EHG') {
-      const pathSignal = detectPathSignalFromSd(sd);
-      if (pathSignal === 'EHG_Engineer' || pathSignal === 'mixed') {
-        console.log(`\n   ℹ️  Code-path signal (${pathSignal}) overrides scope-vocabulary inference; preserving target_application=EHG_Engineer.`);
-        return {
-          pass: true,
-          score: 100,
-          issues: [],
-          warnings: [`target_application=EHG_Engineer preserved: deliverables reference EHG_Engineer code paths (code-path signal=${pathSignal}); scope-vocabulary inferred EHG was suppressed (SD-LEO-INFRA-CODE-PATH-AWARE-001)`]
-        };
-      }
+    // SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001 (C1): generalizes
+    // SD-LEO-INFRA-CODE-PATH-AWARE-001 from the EHG_Engineer->EHG special case to
+    // BOTH directions. A high-confidence PROSE mismatch must NOT silently flip an
+    // already-set target_application unless a non-prose CODE-PATH signal AGREES with
+    // the inferred target. The prior block only suppressed EHG_Engineer->EHG when a
+    // path signal existed; the residual gap (witnessed 3rd+ time: backend SDs whose
+    // scope vocabulary inferred EHG with NO path signal) flipped on prose alone.
+    // Now: pathSignal must equal inferredTarget to flip; otherwise PRESERVE + loud
+    // operator WARN (no DB write). 'mixed' agrees only with EHG_Engineer (deliverables
+    // touch EHG_Engineer code → keep it), matching the prior suppression semantics.
+    // Fail-safe: detectPathSignalFromSd never throws on malformed input, but wrap it
+    // anyway — on any error treat as null (no corroboration → preserve), since an
+    // auto-flip is a silent DB mutation and preserving a set value is the reversible,
+    // operator-visible direction.
+    let pathSignal = null;
+    try {
+      pathSignal = detectPathSignalFromSd(sd);
+    } catch (_e) {
+      pathSignal = null;
+    }
+    const pathAgrees =
+      pathSignal === inferredTarget ||
+      (pathSignal === 'mixed' && inferredTarget === 'EHG_Engineer');
+
+    if (!pathAgrees) {
+      console.log('\n   ℹ️  Inferred-target mismatch NOT auto-corrected — no corroborating code-path signal.');
+      console.log(`      Current (preserved): ${currentTarget}`);
+      console.log(`      Inferred from scope-vocabulary (skipped): ${inferredTarget}`);
+      console.log(`      Code-path signal: ${pathSignal || 'none'}`);
+      console.log('      ⚠️  If this target is wrong, set it explicitly — scope vocabulary alone no longer flips a set target.');
+      return {
+        pass: true,
+        score: 100,
+        issues: [],
+        warnings: [`target_application=${currentTarget} preserved: scope-vocabulary inferred ${inferredTarget} but no corroborating code-path signal (path=${pathSignal || 'none'}); not auto-flipped (SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001)`]
+      };
     }
 
-    // Target set but doesn't match inferred with high confidence - warn and offer correction
-    console.log('\n   ⚠️  MISMATCH DETECTED');
+    // Corroborated mismatch: the code-path signal agrees with the inferred target — flip.
+    console.log('\n   ⚠️  MISMATCH DETECTED (code-path corroborated)');
     console.log(`   Current: ${currentTarget}`);
-    console.log(`   Inferred: ${inferredTarget} (high confidence)`);
+    console.log(`   Inferred: ${inferredTarget} (high confidence, path signal=${pathSignal})`);
     console.log(`   Auto-correcting to: ${inferredTarget}`);
 
     const { error } = await supabase
@@ -273,7 +296,7 @@ export async function validateTargetApplication(sd, supabase) {
       pass: true,
       score: 80,
       issues: [],
-      warnings: [`target_application corrected from ${currentTarget} to ${inferredTarget}`]
+      warnings: [`target_application corrected from ${currentTarget} to ${inferredTarget} (code-path corroborated, signal=${pathSignal})`]
     };
   }
 

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.test.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.test.js
@@ -184,6 +184,89 @@ describe('validateTargetApplication', () => {
   });
 });
 
+// SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001: corroboration-gated flip + C4 token drop.
+// The flip of an already-set target_application now requires a CODE-PATH signal that AGREES
+// with the prose-inferred target; otherwise it preserves + WARNs. And 'backend'/'venture'
+// are removed from ehgPatterns (they false-signalled EHG for backend SDs).
+describe('corroboration-gated target_application flip (SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('C1: PRESERVES a set target when prose infers a mismatch but NO code-path signal corroborates', async () => {
+    // EHG_Engineer target; scope carries genuine EHG vocabulary (infers EHG, high) but NO
+    // code path (no src/components, scripts/, CLAUDE.md, etc.) → pathSignal=null → preserve.
+    const sd = createMockSD({
+      target_application: 'EHG_Engineer',
+      scope: 'Rework the react frontend ui component user interface rendering rules',
+      title: 'Rework rendering rules',
+    });
+    delete sd.key_changes; // ensure no path corroboration from key_changes
+    const supabase = createMockSupabase();
+
+    const result = await validateTargetApplication(sd, supabase);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100); // 100 (preserved), NOT 80 (corrected)
+    expect(result.warnings.some(w => w.includes('preserved') && w.toLowerCase().includes('no corroborating'))).toBe(true);
+    expect(result.warnings.some(w => w.toLowerCase().includes('corrected'))).toBe(false);
+  });
+
+  it('C1: still FLIPS when the code-path signal AGREES with the inferred target (corroborated)', async () => {
+    // Same EHG-inferring prose, but key_changes reference an EHG app path → pathSignal=EHG
+    // agrees with inferred EHG → flip proceeds (score 80, corrected, "code-path corroborated").
+    const sd = createMockSD({
+      target_application: 'EHG_Engineer',
+      scope: 'Rework the react frontend ui component user interface rendering rules',
+      title: 'Rework rendering rules',
+      key_changes: [{ type: 'feature', change: 'src/components/widgets/Renderer.tsx' }],
+    });
+    const supabase = createMockSupabase();
+
+    const result = await validateTargetApplication(sd, supabase);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(80);
+    expect(result.warnings.some(w => w.includes('corrected') && w.includes('corroborated'))).toBe(true);
+  });
+
+  it('C4: a scope whose ONLY EHG signal was "backend"/"venture" no longer infers EHG (no flip)', async () => {
+    // Post-C4, ehgPatterns has neither token → no EHG inference; the set EHG_Engineer target
+    // is validated as-is (score 100, no "corrected" warning).
+    const sd = createMockSD({
+      target_application: 'EHG_Engineer',
+      scope: 'Backend venture pipeline worker queue distillation engine',
+      title: 'Backend venture engine worker',
+    });
+    delete sd.key_changes;
+    const supabase = createMockSupabase();
+
+    const result = await validateTargetApplication(sd, supabase);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.warnings ? result.warnings.some(w => w.toLowerCase().includes('corrected')) : false).toBe(false);
+  });
+
+  it('C4: genuine EHG SDs still infer EHG via the 10 retained tokens', async () => {
+    // No backend/venture, but react+frontend+ui component+user interface → still EHG.
+    const sd = createMockSD({
+      target_application: 'EHG',
+      scope: 'Add a react frontend ui component and user interface for the dashboard',
+      title: 'Dashboard UI',
+    });
+    const supabase = createMockSupabase();
+
+    const result = await validateTargetApplication(sd, supabase);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100); // matches set EHG target, no flip needed
+  });
+
+  // Fail-safe note: C1 wraps detectPathSignalFromSd in try/catch and treats a throw as null
+  // (→ preserve). detectPathSignalFromSd is provably null-returning on malformed input (see the
+  // detectFromKeyChanges null-safety tests + detectPathSignalFromSd's guards), so the catch is
+  // belt-and-suspenders; the null-path PRESERVE test above exercises the same preserve branch.
+});
+
 // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001
 describe('detectFromKeyChanges', () => {
   it('returns "EHG" for all-frontend paths', () => {


### PR DESCRIPTION
## Summary
The LEAD-TO-PLAN `TARGET_APPLICATION` gate (`validateTargetApplication`) silently auto-flipped an already-set `target_application` **EHG_Engineer→EHG** on **prose-only** high-confidence inference. `ehgPatterns` contained the category words **`backend`** and **`venture`** (EHG_Engineer is itself mostly backend; "venture" pervades its infra SDs), so a backend SD whose text says *"cross-repo BACKEND venture leaf"* matched ≥2 EHG tokens → high-confidence EHG → flip wrote the DB. **3rd+ recurrence** (it just bit SD-FDBK-FIX-GATE2-IMPLEMENTATION-FIDELITY-001). Prior QF-20260509-986 (explicit-guard) + SD-LEO-INFRA-CODE-PATH-AWARE-001 (one-directional code-path suppression) left a residual gap: prose-only flip when `currentTarget` is set AND `detectPathSignalFromSd` returns null.

## Fix (confined to `target-application.js`)
- **C4**: drop `backend`/`venture` from `ehgPatterns` (10 genuine EHG tokens retained).
- **C1**: generalize the code-path suppression from the `EHG_Engineer→EHG` special case to **both directions** — flipping a set target now requires `detectPathSignalFromSd(sd)` to **agree** with the inferred target; otherwise **PRESERVE + loud operator WARN** (no DB write). null/disagreement → preserve. Wrapped in try/catch (fail-safe → null → preserve), since an auto-flip is a silent mutation and a preserved value is reversible/visible.
- **Unchanged**: the `!currentTarget` auto-fill and the explicit-guard short-circuit.

## Evidence
Empirically safe over **1000 EHG SDs** (validation + risk sub-agents): **0** new wrong-direction flips; all preserve-instead-of-flip SDs are `status=completed` (historical over-flips). Tests: **24/24** in `target-application.test.js` (4 new: null-path preserve, corroborated flip, C4 no-longer-EHG, C4 genuine-EHG-retained) + downstream `target-application-code-path-aware.test.js` **17/17**. Existing tests stay green via genuine corroboration (their scope contains `CLAUDE.md`, a path-pattern token). This SD dogfooded the explicit-guard at its own LEAD-TO-PLAN (target preserved). Resolves corrective finding `feedback 7072b909`.

Single file `target-application.js` (+46/-23) + tests. SD: SD-FDBK-FIX-TARGET-APPLICATION-VOCABULARY-001 (bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)