### PR TITLE
fix(SD-FDBK-ENH-GIT-WORKTREE-REMOVE-001): safe worktree-remove entrypoint + retire raw rm -rf guidance

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -455,7 +455,7 @@ function verifyWorktreeRegisteredSync(worktreePath, repoRoot) {
         if (!fs.existsSync(path.join(worktreePath, '.git'))) {
           throw new Error(
             `git worktree add reported success but ${worktreePath} has no .git pointer. ` +
-            `Remediation: rm -rf "${worktreePath}" && git worktree prune`
+            `Remediation: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)`
           );
         }
         return true;
@@ -469,7 +469,7 @@ function verifyWorktreeRegisteredSync(worktreePath, repoRoot) {
 
   const err = new Error(
     `Worktree post-condition failed: ${worktreePath} not in git worktree list after creation. ` +
-    `Remediation: rm -rf "${worktreePath}" && git worktree prune`
+    `Remediation: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)`
   );
   err.errorCode = 'WORKTREE_POST_CONDITION_FAILED';
   throw err;

--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "session:info": "node scripts/claude-session-coordinator.mjs info",
     "session:worktree": "node scripts/session-worktree.js",
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
+    "worktree:remove": "node scripts/safe-worktree-remove.mjs",
     "worktree:reap": "node scripts/worktree-reaper.mjs",
     "worktree:reap:execute": "node scripts/worktree-reaper.mjs --execute",
     "worktree:reap:full": "node scripts/worktree-reaper.mjs --execute --stage2 --yes",

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -208,7 +208,7 @@ function verifyWorktreeRegistered(worktreePath, repoRoot) {
         if (!fs.existsSync(path.join(worktreePath, '.git'))) {
           throw new Error(
             `git worktree add reported success but ${worktreePath} has no .git pointer file. ` +
-            `Remediation: rm -rf "${worktreePath}" && git worktree prune`
+            `Remediation: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)`
           );
         }
         return true;
@@ -224,7 +224,7 @@ function verifyWorktreeRegistered(worktreePath, repoRoot) {
 
   const err = new Error(
     `git worktree add reported success but ${worktreePath} is not registered in git worktree list. ` +
-    `Remediation: rm -rf "${worktreePath}" && git worktree prune\n` +
+    `Remediation: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)\n` +
     `Listed paths (${lastListed.length}):\n  - ${lastListed.join('\n  - ')}`
   );
   err.errorCode = 'WORKTREE_POST_CONDITION_FAILED';
@@ -260,7 +260,7 @@ function createWorktree(sdKey, repoRoot, opts = {}) {
     }
     const err = new Error(
       `Path ${worktreePath} exists but is not a registered worktree. ` +
-      `Remove it with: rm -rf "${worktreePath}" && git worktree prune`
+      `Remove it with: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)`
     );
     err.errorCode = 'WORKTREE_PRE_CONDITION_FAILED';
     throw err;

--- a/scripts/safe-worktree-remove.mjs
+++ b/scripts/safe-worktree-remove.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Safe worktree removal entrypoint — SD-FDBK-ENH-GIT-WORKTREE-REMOVE-001.
+ *
+ * Routes MANUAL/AGENT worktree teardown through lib/worktree-manager.js
+ * removeWorktreeViaGit, which pre-unlinks a worktree's node_modules
+ * symlink/junction (via fs.lstat().isSymbolicLink()) BEFORE `git worktree
+ * remove`. This is the safe alternative to a raw `git worktree remove --force`
+ * or `rm -rf <worktree>` — both of which follow the node_modules junction and
+ * GUT the main repo's shared node_modules (0 packages -> ERR_MODULE_NOT_FOUND
+ * @supabase/supabase-js from lib/supabase-client.js), breaking node tooling for
+ * every session sharing the main repo.
+ *
+ * Usage:
+ *   npm run worktree:remove <SD-KEY>            # resolve via git worktree list
+ *   npm run worktree:remove <path/to/worktree>  # explicit path
+ *   npm run worktree:remove <SD-KEY> --force     # remove even if live/dirty
+ *
+ * Default is GUARDED (isReapable): a worktree owned by a live session OR holding
+ * uncommitted/unpushed work is SKIPPED, not removed. --force overrides the guard
+ * but STILL pre-unlinks node_modules — the gut-prevention is unconditional.
+ */
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { removeWorktreeViaGit, getRepoRoot } from '../lib/worktree-manager.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const WORKTREES_DIR = '.worktrees';
+
+function listWorktrees(repoRoot) {
+  try {
+    const out = execSync('git worktree list --porcelain', { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' });
+    const entries = [];
+    let cur = {};
+    for (const line of out.split('\n')) {
+      if (line.startsWith('worktree ')) { if (cur.path) entries.push(cur); cur = { path: line.slice(9).trim() }; }
+      else if (line.startsWith('branch ')) cur.branch = line.slice(7).trim().replace('refs/heads/', '');
+    }
+    if (cur.path) entries.push(cur);
+    return entries;
+  } catch { return []; }
+}
+
+/** Resolve an SD-KEY or explicit path to an absolute worktree path. */
+export function resolveWorktreePath(arg, repoRoot) {
+  if (arg.includes('/') || arg.includes('\\') || fs.existsSync(arg)) return path.resolve(arg);
+  const norm = (p) => path.resolve(p).replace(/\\/g, '/');
+  const wts = listWorktrees(repoRoot);
+  const byBranch = wts.find((w) => w.branch === `feat/${arg}`);
+  if (byBranch) return norm(byBranch.path);
+  const byBase = wts.find((w) => path.basename(norm(w.path)) === arg);
+  if (byBase) return norm(byBase.path);
+  return path.join(repoRoot, WORKTREES_DIR, arg); // conventional fallback
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const force = args.includes('--force') || args.includes('-f');
+  const target = args.find((a) => !a.startsWith('-'));
+  if (!target) {
+    console.error('Usage: npm run worktree:remove <SD-KEY | path> [--force]');
+    process.exit(2);
+  }
+  const repoRoot = getRepoRoot();
+  const wtPath = resolveWorktreePath(target, repoRoot);
+
+  if (path.resolve(wtPath) === path.resolve(repoRoot)) {
+    console.error(`Refusing to remove the main repo root: ${wtPath}`);
+    process.exit(2);
+  }
+
+  // removeWorktreeViaGit pre-unlinks node_modules FIRST, then `git worktree
+  // remove --force`. guard:!force skips a live/dirty worktree (protective).
+  const res = removeWorktreeViaGit(wtPath, repoRoot, {
+    guard: !force,
+    allowFail: true,
+    logger: (m) => console.warn(m),
+  });
+
+  if (res.ok) {
+    console.log(`✓ Safely removed worktree (node_modules pre-unlinked): ${wtPath}`);
+    process.exit(0);
+  }
+  if (res.skipped) {
+    console.warn(`⏭️  Skipped (${res.reason}) — owned by a live session or has uncommitted/unpushed work.`);
+    console.warn('   Re-run with --force to remove anyway (node_modules is still pre-unlinked).');
+    process.exit(0);
+  }
+
+  // git worktree remove failed (e.g. orphan / unregistered path). The junction
+  // was already pre-unlinked above, so a recursive remove can no longer follow
+  // it into the shared store. Defensive: re-check node_modules isn't still a link.
+  try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch { /* best-effort */ }
+  if (fs.existsSync(wtPath)) {
+    const nm = path.join(wtPath, 'node_modules');
+    try {
+      if (fs.lstatSync(nm).isSymbolicLink()) {
+        try { fs.unlinkSync(nm); } catch { try { fs.rmdirSync(nm); } catch { /* noop */ } }
+      }
+    } catch { /* no node_modules / not a link */ }
+    try {
+      fs.rmSync(wtPath, { recursive: true, force: true });
+      console.log(`✓ Removed orphan worktree dir (node_modules pre-unlinked + pruned): ${wtPath}`);
+      process.exit(0);
+    } catch (e) {
+      console.error(`✗ Failed to remove ${wtPath}: ${e.message}`);
+      process.exit(1);
+    }
+  }
+  console.error(`✗ git worktree remove failed: ${res.error}`);
+  process.exit(1);
+}
+
+// Only run when invoked directly (keep resolveWorktreePath importable for tests).
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/scripts/safe-worktree-remove.test.js
+++ b/scripts/safe-worktree-remove.test.js
@@ -1,0 +1,108 @@
+/**
+ * Real-fs regression test for SD-FDBK-ENH-GIT-WORKTREE-REMOVE-001.
+ *
+ * Proves the safe removal path (lib/worktree-manager.js removeWorktreeViaGit,
+ * which scripts/safe-worktree-remove.mjs wraps) does NOT gut a shared
+ * node_modules store reached via a worktree node_modules junction — and that a
+ * raw `git worktree remove --force` (the retired guidance) DOES gut it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { removeWorktreeViaGit } from '../lib/worktree-manager.js';
+import { resolveWorktreePath } from './safe-worktree-remove.mjs';
+
+const isWin = process.platform === 'win32';
+const git = (cmd, cwd) => execSync(`git ${cmd}`, { cwd, stdio: 'pipe' });
+
+function makeSandbox() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'swt-'));
+  // decoy "main repo" shared node_modules store with a CANARY
+  const sharedStore = path.join(root, 'shared_store');
+  fs.mkdirSync(path.join(sharedStore, '@supabase', 'supabase-js'), { recursive: true });
+  const canary = path.join(sharedStore, '@supabase', 'supabase-js', 'CANARY.txt');
+  fs.writeFileSync(canary, 'do-not-delete');
+  // a real git repo to host worktrees
+  const repo = path.join(root, 'repo');
+  fs.mkdirSync(repo, { recursive: true });
+  git('init -q', repo);
+  git('config user.email t@t.t', repo);
+  git('config user.name t', repo);
+  git('config commit.gpgsign false', repo);
+  fs.writeFileSync(path.join(repo, 'README.md'), '# t');
+  git('add -A', repo);
+  git('commit -q -m init', repo);
+  return { root, repo, sharedStore, canary };
+}
+
+function addWorktreeWithJunctionNM(repo, sharedStore, name) {
+  const wt = path.join(repo, '.worktrees', name);
+  fs.mkdirSync(path.dirname(wt), { recursive: true });
+  git(`worktree add -q --detach "${wt}"`, repo);
+  // link the worktree's node_modules to the shared store (junction on win32)
+  fs.symlinkSync(sharedStore, path.join(wt, 'node_modules'), isWin ? 'junction' : 'dir');
+  return wt;
+}
+
+describe('safe-worktree-remove (SD-FDBK-ENH-GIT-WORKTREE-REMOVE-001)', () => {
+  let sb;
+  beforeEach(() => { sb = makeSandbox(); });
+  afterEach(() => {
+    // Defensive: unlink any leftover node_modules junctions before recursive rm
+    // so teardown can never follow a link.
+    try {
+      const wtDir = path.join(sb.repo, '.worktrees');
+      for (const name of (fs.existsSync(wtDir) ? fs.readdirSync(wtDir) : [])) {
+        const nm = path.join(wtDir, name, 'node_modules');
+        try { if (fs.lstatSync(nm).isSymbolicLink()) fs.unlinkSync(nm); } catch { /* noop */ }
+      }
+    } catch { /* noop */ }
+    try { fs.rmSync(sb.root, { recursive: true, force: true }); } catch { /* noop */ }
+  });
+
+  it('removeWorktreeViaGit pre-unlinks the node_modules junction — shared store CANARY survives', () => {
+    const wt = addWorktreeWithJunctionNM(sb.repo, sb.sharedStore, 'SD-A');
+    // The junction is a LIVE passthrough: reading the CANARY through the worktree
+    // path resolves into the shared store — so a follow-through delete WOULD gut it.
+    const through = path.join(wt, 'node_modules', '@supabase', 'supabase-js', 'CANARY.txt');
+    expect(fs.readFileSync(through, 'utf8')).toBe('do-not-delete');
+    expect(fs.lstatSync(path.join(wt, 'node_modules')).isSymbolicLink()).toBe(true);
+
+    const res = removeWorktreeViaGit(wt, sb.repo, { allowFail: true });
+
+    expect(res.ok).toBe(true);
+    expect(fs.existsSync(wt)).toBe(false);                          // worktree removed
+    expect(fs.existsSync(sb.canary)).toBe(true);                   // shared store NOT gutted
+    expect(fs.readFileSync(sb.canary, 'utf8')).toBe('do-not-delete');
+  });
+
+  it('isolated real-dir node_modules is removed with the worktree (no over-reach on unrelated stores)', () => {
+    const wt = path.join(sb.repo, '.worktrees', 'SD-B');
+    fs.mkdirSync(path.dirname(wt), { recursive: true });
+    git(`worktree add -q --detach "${wt}"`, sb.repo);
+    fs.mkdirSync(path.join(wt, 'node_modules'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'node_modules', 'own.txt'), 'x');
+    expect(fs.lstatSync(path.join(wt, 'node_modules')).isSymbolicLink()).toBe(false);
+
+    const res = removeWorktreeViaGit(wt, sb.repo, { allowFail: true });
+
+    expect(res.ok).toBe(true);
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(sb.canary)).toBe(true);                  // unrelated shared store intact
+  });
+
+  it.runIf(isWin)('NEGATIVE CONTROL: raw `git worktree remove --force` (no pre-unlink) GUTS the shared store', () => {
+    const wt = addWorktreeWithJunctionNM(sb.repo, sb.sharedStore, 'SD-C');
+    // The retired guidance: git follows the node_modules junction into the shared store.
+    execSync(`git worktree remove --force "${wt}"`, { cwd: sb.repo, stdio: 'pipe' });
+    expect(fs.existsSync(sb.canary)).toBe(false);                 // gutted through the junction
+  });
+
+  it('resolveWorktreePath resolves an SD-KEY to its worktree via git worktree list', () => {
+    const wt = addWorktreeWithJunctionNM(sb.repo, sb.sharedStore, 'SD-D');
+    const resolved = resolveWorktreePath('SD-D', sb.repo);
+    expect(path.resolve(resolved)).toBe(path.resolve(wt));
+  });
+});


### PR DESCRIPTION
## Summary
Closes the manual/agent worktree-cleanup gap that guts the main repo shared node_modules.

A raw `git worktree remove --force` (or `rm -rf <worktree>`) on a worktree whose node_modules is a junction to the main repo follows the junction and deletes the shared node_modules (ERR_MODULE_NOT_FOUND @supabase/supabase-js), breaking node tooling for every session sharing the repo. The AUTOMATED cleanup paths were already guarded (QF-20260529-315); this closes the MANUAL/AGENT path.

## Changes
- NEW `scripts/safe-worktree-remove.mjs` + `npm run worktree:remove <SD-KEY|path> [--force]` — routes manual/agent teardown through removeWorktreeViaGit, which pre-unlinks the node_modules junction (fs.lstat) BEFORE `git worktree remove`. Default guarded (skips live/dirty worktrees); --force overrides but still pre-unlinks.
- Retired the raw `rm -rf` remediation guidance at 5 sites (resolve-sd-workdir.js x3, worktree-manager.js x2) -> point to the safe command.
- NEW real-fs regression test (4 tests): junction node_modules survives safe removal; isolated real-dir no over-reach; win32 negative control proves raw `git worktree remove --force` guts the store; resolver test.

## Scope note (reframed at PLAN by prospective testing-agent c279c9c8)
The source feedback premises (git reparse-point / PowerShell LinkType-empty / missing marker) were refuted: the worktree node_modules is an ordinary Windows junction, LinkType reports Junction, safe-path code already uses fs.lstat, and the .worktree-nm-mode marker already exists. The real gap was the un-guarded raw shell command + docs recommending it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)