### PR TITLE
fix(QF-20260604-457): guard prd-quality-rubric scenario.steps against non-array

### DIFF
--- a/scripts/modules/rubrics/prd-quality-rubric.js
+++ b/scripts/modules/rubrics/prd-quality-rubric.js
@@ -519,8 +519,12 @@ SD UUID: ${prd.sd_uuid || 'Not linked'}`;
           }
 
           // Legacy format (steps, expected_result)
-          if (scenario.steps && scenario.steps.length > 0) {
+          // Quick-fix QF-20260604-457: guard with Array.isArray — a string `steps`
+          // passes the .length>0 check but has no .join, crashing the validator.
+          if (Array.isArray(scenario.steps) && scenario.steps.length > 0) {
             details.push(`Steps: ${scenario.steps.join('; ')}`);
+          } else if (typeof scenario.steps === 'string' && scenario.steps.trim()) {
+            details.push(`Steps: ${scenario.steps}`);
           }
           if (scenario.expected_result) {
             details.push(`Expected: ${scenario.expected_result}`);


### PR DESCRIPTION
## Summary
`prd-quality-rubric.js` guarded `scenario.steps` with `.length > 0` then called `.join('; ')`. A string `steps` value passes the length check but has no `.join`, crashing the live PRD quality validator (imported by `plan-to-exec/index.js` and `prd-quality-validation.js`). Now guards with `Array.isArray` and renders a string value as-is.

Tier-1 quick-fix, +5/-1 LOC. Source: harness_backlog `1b4cee40` (its other two findings are dead/niche — the NON_SD_CAPTURE hook calls a non-existent `scripts/auto-learning-capture.js`, and the `retrospectives_audit` delete-trigger is a DBA concern, not a code defect).

## Verification
- Targeted suites pass: `tests/unit/prd-quality-heuristic.test.js` + `prd-quality-validator.test.js` (23 tests).
- `npx tsc --noEmit` passes; `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
