### PR TITLE
fix(QF-20260604-729): auto-learning-capture hook spawns archived/missing engine - silent false-success banner

### DIFF
--- a/docs/reference/auto-learning-capture-hooks.md
+++ b/docs/reference/auto-learning-capture-hooks.md
@@ -368,6 +368,17 @@ const LEARNING_WORTHY_PATHS = {
 
 ### Retrospective Creation
 
+> ⚠️ **ARCHIVED / INACTIVE (QF-20260604-729).** The capture engine that ran this insert was moved to
+> `scripts/archive/one-time/auto-learning-capture.js` by a bulk-archive sweep. The live hook
+> (`scripts/hooks/auto-learning-capture.cjs`) now fail-safes when the engine is absent, so **no
+> retrospective is currently written** for non-SD merges. The snippet below is retained for historical
+> reference only (see RCA acde2541 / `PAT-HOOK-ARCHIVE-ORPHAN-001`).
+>
+> ⚠️ **Known anti-pattern — do NOT copy as-is if resurrecting.** `status: 'PUBLISHED'` + a client-set
+> `quality_score: 70` is overwritten/rejected by the `auto_validate_retrospective_quality` trigger, which
+> recomputes the score from content and enforces the ≥70 publish floor. Use the insert-DRAFT-then-promote
+> pattern (`generate-retrospective.js`); see QF-20260604-797 (#4236) and SD-FDBK-ENH-COMPLETION-HEAL-LEARNING-001.
+
 ```javascript
 const retrospective = {
   title: `Auto-Captured: ${prTitle}`,

--- a/scripts/hooks/auto-learning-capture.cjs
+++ b/scripts/hooks/auto-learning-capture.cjs
@@ -288,7 +288,18 @@ async function checkCommitMessages(prNumber) {
  * @param {string} prNumber - PR number
  */
 function spawnLearningCapture(prNumber) {
+  const fs = require('fs');
   const captureScript = path.join(PROJECT_DIR, 'scripts', 'auto-learning-capture.js');
+
+  // QF-20260604-729 fail-safe: the capture engine was archived to scripts/archive/one-time/
+  // by a bulk-archive sweep without updating this spawn target. Because the spawn below uses
+  // stdio:'ignore'+detached+unref(), a missing engine yields a swallowed MODULE_NOT_FOUND while
+  // the "AUTO-LEARNING CAPTURE TRIGGERED" banner still prints — a silent false success. If the
+  // engine is absent, skip honestly (warn, no banner, no spawn). RCA acde2541 / PAT-HOOK-ARCHIVE-ORPHAN-001.
+  if (!fs.existsSync(captureScript)) {
+    log('warn', 'capture_engine_missing', { pr: prNumber, script: captureScript, action: 'skip_no_capture' });
+    return;
+  }
 
   log('info', 'spawning_capture_engine', { pr: prNumber, script: captureScript });
 

--- a/tests/unit/settings-claude-project-dir.test.js
+++ b/tests/unit/settings-claude-project-dir.test.js
@@ -40,3 +40,30 @@ describe('QF-628 SETTINGS-3: statusLine command also uses ${CLAUDE_PROJECT_DIR}'
     expect(j.statusLine.command).toMatch(/\$\{?CLAUDE_PROJECT_DIR\}?/);
   });
 });
+
+// QF-20260604-729 — a wired hook command must point at a file that exists.
+// A bulk-archive sweep silently orphaned a hook's spawn target (scripts/auto-learning-capture.js)
+// while leaving the hook wired; the detached stdio:'ignore' spawn then masked the break and the hook
+// printed a false-success banner. This locks down the directly-wired command files (the first,
+// zero-false-positive layer). The deeper transitive guard (spawn/require targets *inside* hooks, which
+// have mixed resolution bases across the fleet) is tracked separately — RCA acde2541 / PAT-HOOK-ARCHIVE-ORPHAN-001.
+const REPO_ROOT = path.resolve(__dirname, '../../');
+
+function wiredProjectFiles() {
+  const j = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  const cmds = allHookCommands();
+  if (j.statusLine && j.statusLine.command) cmds.push(j.statusLine.command);
+  const files = [];
+  for (const c of cmds) {
+    const m = c.match(/\$\{?CLAUDE_PROJECT_DIR\}?[\\/]+([^\s"']+)/);
+    if (m) files.push(m[1]);
+  }
+  return [...new Set(files)];
+}
+
+describe('QF-729 SETTINGS-4: every wired hook command points at an existing file', () => {
+  it('no settings.json hook/statusLine command references a missing ${CLAUDE_PROJECT_DIR} file', () => {
+    const missing = wiredProjectFiles().filter(rel => !fs.existsSync(path.resolve(REPO_ROOT, rel)));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260604-729

**Type:** bug
**Severity:** medium

### Issue Description
PostToolUse hook scripts/hooks/auto-learning-capture.cjs (wired in .claude/settings.json) fires on 'gh pr merge', prints banner 'AUTO-LEARNING CAPTURE TRIGGERED ... Capturing learning automatically', then spawns 'node scripts/auto-learning-capture.js --pr N' with {stdio:'ignore',detached:true,unref()}. But scripts/auto-learning-capture.js does NOT exist (absent on disk + origin/main); a bulk-archive sweep moved the engine to scripts/archive/one-time/. node MODULE_NOT_FOUND is swallowed -> hook reports success while capturing nothing. RCA acde2541: root cause = no guard asserts hook command/spawn-target file existence; detached+ignored spawn masks the break. Fix = REPAIR-TO-FAIL-SAFE (existsSync guard, no banner/spawn when engine missing) + preventive test that settings.json hook commands and transitive spawn targets resolve + doc honesty note. Corrects stale feedback 1b4cee40 (premise PUBLISHED+70 insert is moot - engine never runs).

### Steps to Reproduce
1. On a non-SD branch, run gh pr merge for a PR. 2. Hook detects non-SD merge, prints AUTO-LEARNING CAPTURE TRIGGERED. 3. Observe scripts/auto-learning-capture.js does not exist; no retrospective is created; no error surfaces.

### Expected Behavior
Hook must not report a false success: when the capture engine is missing it should skip silently (or warn) and NOT print the success banner. A test should prevent settings.json hooks (and their spawn targets) from being orphaned by archive moves.

### Actual Behavior
Hook prints success banner then silently spawns a non-existent module (stdio ignored, detached) -> captures nothing; feature SD-LEO-SELF-IMPROVE-001D dead since the archive sweep with zero signal.

### Changes
- **Files Changed:** 3
  - docs/reference/auto-learning-capture-hooks.md
  - scripts/hooks/auto-learning-capture.cjs
  - tests/unit/settings-claude-project-dir.test.js
- **LOC:** 54 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
RCA acde2541 confirmed root cause. node --check passes; existsSync guard returns before banner/spawn when engine absent; SETTINGS-4 + 3 existing settings tests pass (4/4). Diff non-empty.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol