### PR TITLE
fix(QF-20260604-006): surface auto-learning-capture engine dormancy + DRAFT-then-promote NON_SD_CAPTURE retro

### DIFF
--- a/docs/reference/auto-learning-capture-hooks.md
+++ b/docs/reference/auto-learning-capture-hooks.md
@@ -390,7 +390,12 @@ const retrospective = {
   })),
 
   action_items: [],
-  status: 'PUBLISHED',
+
+  // Insert as DRAFT — do NOT client-set status:'PUBLISHED'. The
+  // auto_validate_retrospective_quality trigger recomputes quality_score from
+  // content and the publish-gate REJECTS a thin PUBLISHED insert. quality_score
+  // here is only a placeholder to satisfy trigger ordering; it is overwritten.
+  status: 'DRAFT',
   quality_score: 70,
 
   generated_by: 'AUTO_HOOK',
@@ -409,7 +414,19 @@ const retrospective = {
   }
 };
 
-await supabase.from('retrospectives').insert(retrospective);
+// Insert DRAFT, read back the trigger-computed score, then promote to PUBLISHED
+// only if it clears the publish floor (mirror generate-retrospective.js).
+const { data: inserted } = await supabase
+  .from('retrospectives')
+  .insert(retrospective)
+  .select('id, quality_score')
+  .single();
+
+if (inserted && inserted.quality_score >= 70) {
+  await supabase.from('retrospectives')
+    .update({ status: 'PUBLISHED' })
+    .eq('id', inserted.id);
+}
 ```
 
 ### Issue Pattern Creation

--- a/scripts/hooks/auto-learning-capture.cjs
+++ b/scripts/hooks/auto-learning-capture.cjs
@@ -288,12 +288,24 @@ async function checkCommitMessages(prNumber) {
  * @param {string} prNumber - PR number
  */
 function spawnLearningCapture(prNumber) {
+  const fs = require('fs');
+  const cp = require('child_process');
   const captureScript = path.join(PROJECT_DIR, 'scripts', 'auto-learning-capture.js');
+
+  // QF-20260604-006: the engine is spawned detached with stdio:'ignore', so if the
+  // script is missing (e.g. archived/moved) the failure is INVISIBLE — the hook looks
+  // like it fired but no learning is ever captured. Surface the dormancy and skip the
+  // silent broken spawn instead of launching a node process that immediately dies.
+  if (!fs.existsSync(captureScript)) {
+    log('warn', 'capture_engine_missing', { pr: prNumber, script: captureScript });
+    console.log(`[auto-learning-capture] Engine missing (${captureScript}) — skipped, no capture. Restore the engine or retire this hook.`);
+    return;
+  }
 
   log('info', 'spawning_capture_engine', { pr: prNumber, script: captureScript });
 
   // Spawn as detached process so it doesn't block the hook
-  const child = spawn('node', [captureScript, '--pr', prNumber], {
+  const child = cp.spawn('node', [captureScript, '--pr', prNumber], {
     cwd: PROJECT_DIR,
     stdio: 'ignore',
     detached: true,
@@ -427,4 +439,10 @@ function main() {
   }, 15000);
 }
 
-main();
+// QF-20260604-006: only run on direct invocation so the hook can be unit-tested
+// (require()'d) without main() consuming stdin / arming the 15s timer.
+if (require.main === module) {
+  main();
+}
+
+module.exports = { spawnLearningCapture };

--- a/tests/unit/hooks/auto-learning-capture-engine-missing.test.js
+++ b/tests/unit/hooks/auto-learning-capture-engine-missing.test.js
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for scripts/hooks/auto-learning-capture.cjs — missing-engine guard.
+ * QF-20260604-006
+ *
+ * The hook spawns the capture engine DETACHED with stdio:'ignore'. When the engine
+ * script is missing (it is currently archived to scripts/archive/one-time/), the
+ * broken spawn used to fail SILENTLY — the hook appeared to fire but captured nothing.
+ * These tests pin the guard: missing engine => log + skip (no spawn); present => spawn.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const fs = require('fs');
+const cp = require('child_process');
+const hookPath = resolve(process.cwd(), 'scripts/hooks/auto-learning-capture.cjs');
+const { spawnLearningCapture } = require(hookPath);
+
+describe('auto-learning-capture: missing-engine guard (QF-20260604-006)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('exports spawnLearningCapture (hook is require-able without running main)', () => {
+    expect(typeof spawnLearningCapture).toBe('function');
+  });
+
+  it('skips the spawn and surfaces the dormancy when the engine is missing', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const spawnSpy = vi.spyOn(cp, 'spawn');
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+
+    expect(() => spawnLearningCapture('123')).not.toThrow();
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toMatch(/Engine missing/i);
+  });
+
+  it('spawns the engine (detached, unref) when it exists', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const fakeChild = { unref: vi.fn() };
+    const spawnSpy = vi.spyOn(cp, 'spawn').mockReturnValue(fakeChild);
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+
+    spawnLearningCapture('123');
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = spawnSpy.mock.calls[0];
+    expect(cmd).toBe('node');
+    expect(args[0]).toMatch(/auto-learning-capture\.js$/);
+    expect(opts).toMatchObject({ detached: true, stdio: 'ignore' });
+    expect(fakeChild.unref).toHaveBeenCalled();
+    expect(logs.join('\n')).not.toMatch(/Engine missing/i);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves harness-backlog feedback `1b4cee40` (NON_SD_CAPTURE auto-learning hook).

**Inverted-premise finding (verify-before-build):** the feedback reported the `NON_SD_CAPTURE` auto-learning hook inserts retrospectives with `status=PUBLISHED + client quality_score:70`. Investigation showed that insert is **dormant** — the live PostToolUse hook (`scripts/hooks/auto-learning-capture.cjs:291`) spawns `scripts/auto-learning-capture.js`, which is **missing** (engine archived to `scripts/archive/one-time/`, referenced by nothing live). With `stdio:'ignore'` + `detached`, the broken spawn fails **silently**. So 'apply DRAFT-then-promote to the insert' as logged would have edited dead code.

## Changes
1. **Live bug fix** — `auto-learning-capture.cjs`: guard `spawnLearningCapture` with `fs.existsSync` → log loud + skip when the engine is missing (no silent broken spawn; dormancy is now visible).
2. **Anti-pattern fix (propagation source)** — `docs/reference/auto-learning-capture-hooks.md`: corrected the canonical retro-insert example from `PUBLISHED + quality_score:70` to **insert-DRAFT-then-promote-if-≥70**, mirroring `generate-retrospective.js`. (`auto_validate_retrospective_quality` recomputes the score; the publish-gate rejects thin PUBLISHED inserts. Same anti-pattern `captureHealLearnings` fixed in SD-FDBK-ENH-COMPLETION-HEAL-LEARNING-001.)
3. **Testability** — hook made require-able (`require.main === module` guard + export) + new vitest unit suite (3 tests).

## Scope (deliberately bounded)
- **NOT** activating/restoring the engine (separate, higher-blast-radius decision).
- **NOT** modifying the frozen archived engine copy.
- **NOT** folding in the 2 unrelated 'Also:' sub-items (one — `test_scenarios[].steps` array check — already shipped via QF-20260604-457 #4249).

## Test
`npx vitest run tests/unit/hooks/auto-learning-capture-engine-missing.test.js` → **3 passed**. E2E N/A (backend hook, no UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)