### PR TITLE
feat(SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001): flag provider/test-stub noise in auto_rca issue_patterns

### DIFF
--- a/lib/rca/noise-classifier.js
+++ b/lib/rca/noise-classifier.js
@@ -1,0 +1,66 @@
+/**
+ * Noise classifier for auto_rca issue_patterns
+ * (SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001)
+ *
+ * The auto_rca pipeline records every api_failure TriggerEvent as a PAT-AUTO
+ * issue_pattern. Some of those are NOT protocol defects: LLM provider
+ * quota/billing errors and test-stub fixtures. This classifier identifies that
+ * noise so it can be flagged (data_quality_status='noise') at capture and
+ * excluded from the /leo audit view — WITHOUT dropping any row.
+ *
+ * Design contract (precision over recall):
+ *  - test scaffolding markers ('test-stub', 'stub-stuck')  -> noise (always)
+ *  - provider quota / rate-limit (429 RESOURCE_EXHAUSTED / quota) -> noise
+ *  - provider config/billing ("Budget … invalid")          -> noise
+ *  - GENUINE outages (5xx), network errors, and any non-API / gate / handoff
+ *    failure                                                -> NOT noise (real signal)
+ *
+ * The matcher is message-based so the SAME logic serves both the live capture
+ * path (full TriggerEvent) and the one-time backfill (only issue_summary text).
+ */
+
+/**
+ * Core pure predicate: does this error message describe provider/test-stub noise?
+ * @param {string} message
+ * @returns {boolean}
+ */
+export function isNoiseMessage(message) {
+  if (!message || typeof message !== 'string') return false;
+  const m = message.toLowerCase();
+
+  // Test scaffolding markers are noise regardless of context — these strings
+  // are emitted only by test stubs, never by a genuine provider failure.
+  if (m.includes('test-stub') || m.includes('stub-stuck')) return true;
+
+  // Beyond test markers, only API/provider errors are eligible to be noise.
+  // This guard keeps gate failures, handoff failures, migration errors, and
+  // script crashes OUT of the noise bucket even if they mention a number.
+  const isApiError = m.includes('api error') || m.includes('api_error');
+  if (!isApiError) return false;
+
+  // Provider quota / rate-limit exhaustion (not a defect — billing/plan limit).
+  if (m.includes('resource_exhausted')) return true;
+  if (m.includes('429') && m.includes('quota')) return true;
+
+  // Provider configuration/billing misconfiguration, e.g.
+  // "Budget 0 is invalid. This model only works in thinking mode." — a config
+  // problem, not a recurring protocol failure worth surfacing in the audit.
+  if (m.includes('budget') && m.includes('invalid')) return true;
+
+  // Genuine outages (5xx), auth errors, etc. fall through as REAL signal.
+  return false;
+}
+
+/**
+ * Classify a TriggerEvent (live capture path).
+ * Fail-open: if the event has no usable message, treat it as real signal
+ * (return false) rather than mislabeling it noise.
+ * @param {{error_message?: string}} triggerEvent
+ * @returns {boolean}
+ */
+export function isNoiseTriggerEvent(triggerEvent) {
+  if (!triggerEvent || typeof triggerEvent !== 'object') return false;
+  return isNoiseMessage(triggerEvent.error_message);
+}
+
+export default { isNoiseMessage, isNoiseTriggerEvent };

--- a/lib/rca/rca-orchestrator.js
+++ b/lib/rca/rca-orchestrator.js
@@ -18,6 +18,8 @@ import { checkRateLimit, CLASSIFICATIONS } from './trigger-sdk.js';
 import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
 // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven target_application
 import { getCurrentVenture } from '../venture-resolver.js';
+// SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001: flag provider/test-stub noise at capture
+import { isNoiseTriggerEvent } from './noise-classifier.js';
 
 dotenv.config();
 
@@ -231,6 +233,10 @@ function determineTier(triggerEvent) {
  */
 async function upsertIssuePattern(supabase, triggerEvent, rcrId, log, resolvedSdId = null) {
   const category = mapClassificationToPatternCategory(triggerEvent.classification);
+  // SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001: provider quota/billing + test-stub
+  // events are not protocol defects. Flag (never drop) so /leo audit + the
+  // /learn scorer can exclude them while the row stays queryable for forensics.
+  const isNoise = isNoiseTriggerEvent(triggerEvent);
 
   // Look for existing pattern with similar fingerprint prefix
   const fingerprintPrefix = triggerEvent.fingerprint.slice(0, 8);
@@ -248,7 +254,9 @@ async function upsertIssuePattern(supabase, triggerEvent, rcrId, log, resolvedSd
       .update({
         occurrence_count: (existing.occurrence_count || 0) + 1,
         last_seen_sd_id: resolvedSdId || existing.last_seen_sd_id,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
+        // Only stamp when noise; never clobber an existing classification with null.
+        ...(isNoise ? { data_quality_status: 'noise' } : {})
       })
       .eq('pattern_id', existing.pattern_id);
 
@@ -267,6 +275,7 @@ async function upsertIssuePattern(supabase, triggerEvent, rcrId, log, resolvedSd
       category,
       severity: determineSeverity(triggerEvent),
       issue_summary: triggerEvent.error_message?.slice(0, 500) || 'Auto-captured issue',
+      data_quality_status: isNoise ? 'noise' : null,
       occurrence_count: 1,
       first_seen_sd_id: resolvedSdId,
       last_seen_sd_id: resolvedSdId,

--- a/scripts/backfill-noise-data-quality.mjs
+++ b/scripts/backfill-noise-data-quality.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Backfill issue_patterns.data_quality_status='noise' for existing
+ * provider/test-stub PAT-AUTO patterns.
+ * (SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001, FR-4)
+ *
+ * Idempotent: only stamps rows that match the SAME classifier used at capture
+ * (lib/rca/noise-classifier.js::isNoiseMessage) and are not already flagged.
+ * Re-running changes 0 rows. Scoped to source='auto_rca' so manually-curated
+ * patterns are never touched. Reversible: UPDATE issue_patterns SET
+ * data_quality_status=NULL WHERE data_quality_status='noise'.
+ *
+ * Usage:
+ *   node scripts/backfill-noise-data-quality.mjs            # apply
+ *   node scripts/backfill-noise-data-quality.mjs --dry-run  # preview only
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { isNoiseMessage } from '../lib/rca/noise-classifier.js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Error: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+    process.exit(1);
+  }
+  const sb = createClient(url, key);
+
+  // Only auto_rca-sourced patterns are eligible; the classifier decides which.
+  const { data: rows, error } = await sb
+    .from('issue_patterns')
+    .select('pattern_id, issue_summary, data_quality_status, occurrence_count, source')
+    .eq('source', 'auto_rca')
+    .limit(5000);
+  if (error) {
+    console.error('Query failed:', error.message);
+    process.exit(1);
+  }
+
+  const candidates = (rows || []).filter(
+    (r) => isNoiseMessage(r.issue_summary) && r.data_quality_status !== 'noise'
+  );
+  const alreadyFlagged = (rows || []).filter((r) => r.data_quality_status === 'noise').length;
+  const noiseOcc = candidates.reduce((sum, r) => sum + (r.occurrence_count || 0), 0);
+
+  console.log(`auto_rca patterns scanned: ${(rows || []).length}`);
+  console.log(`already flagged noise:      ${alreadyFlagged}`);
+  console.log(`to flag this run:           ${candidates.length} (${noiseOcc} occurrences)`);
+
+  if (candidates.length === 0) {
+    console.log('Nothing to do — idempotent no-op.');
+    return;
+  }
+  for (const r of candidates.slice(0, 50)) {
+    console.log(`  ${r.pattern_id} | occ=${r.occurrence_count} | ${(r.issue_summary || '').slice(0, 70)}`);
+  }
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run: no rows changed.');
+    return;
+  }
+
+  let updated = 0;
+  for (const r of candidates) {
+    // Idempotency comes from the JS `candidates` filter above (excludes rows
+    // already flagged 'noise'). Do NOT add a `.neq('data_quality_status',
+    // 'noise')` guard here: NULL != 'noise' is NULL (not TRUE) in SQL, so it
+    // would match 0 rows and silently no-op the backfill.
+    const { error: ue, count } = await sb
+      .from('issue_patterns')
+      .update({ data_quality_status: 'noise', updated_at: new Date().toISOString() }, { count: 'exact' })
+      .eq('pattern_id', r.pattern_id);
+    if (ue) console.error(`  FAILED ${r.pattern_id}: ${ue.message}`);
+    else if (count === 0) console.error(`  WARN ${r.pattern_id}: matched 0 rows`);
+    else updated++;
+  }
+  console.log(`\nFlagged ${updated} pattern(s) as noise. Total now: ${alreadyFlagged + updated}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/leo-audit.js
+++ b/scripts/leo-audit.js
@@ -34,7 +34,7 @@ async function main() {
   const [patternsResult, alertsResult, retrosResult] = await Promise.all([
     supabase
       .from('issue_patterns')
-      .select('pattern_id, category, severity, issue_summary, occurrence_count, status, trend, created_at, updated_at, proven_solutions, last_seen_sd_id')
+      .select('pattern_id, category, severity, issue_summary, occurrence_count, status, trend, created_at, updated_at, proven_solutions, last_seen_sd_id, data_quality_status')
       .order('occurrence_count', { ascending: false })
       .limit(100),
     supabase
@@ -53,8 +53,15 @@ async function main() {
   const alerts = alertsResult.data || [];
   const retros = retrosResult.data || [];
 
+  // SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001: split provider/test-stub noise
+  // (data_quality_status='noise') out of the real signal. JS filter keeps NULL
+  // rows — `!== 'noise'` is true for null/undefined — so real patterns stay.
+  const noisePatterns = patterns.filter(p => p.data_quality_status === 'noise');
+  const signalPatterns = patterns.filter(p => p.data_quality_status !== 'noise');
+
   if (jsonOutput) {
-    process.stdout.write(JSON.stringify({ patterns, alerts, retros }, null, 2) + '\n');
+    // patterns = real signal only; noise surfaced separately for transparency.
+    process.stdout.write(JSON.stringify({ patterns: signalPatterns, noise_patterns: noisePatterns, alerts, retros }, null, 2) + '\n');
     return;
   }
 
@@ -68,13 +75,19 @@ async function main() {
   lines.push('');
 
   // Section 1: Issue Patterns
-  const activePatterns = patterns.filter(p => p.status !== 'resolved');
-  const resolvedPatterns = patterns.filter(p => p.status === 'resolved');
+  // SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001: signalPatterns already excludes
+  // provider/test-stub noise (computed above, shared with the JSON path).
+  const activePatterns = signalPatterns.filter(p => p.status !== 'resolved');
+  const resolvedPatterns = signalPatterns.filter(p => p.status === 'resolved');
 
   lines.push('-'.repeat(60));
   lines.push('  ISSUE PATTERNS');
   lines.push('-'.repeat(60));
-  lines.push(`  Active: ${activePatterns.length}  |  Resolved: ${resolvedPatterns.length}  |  Total: ${patterns.length}`);
+  lines.push(`  Active: ${activePatterns.length}  |  Resolved: ${resolvedPatterns.length}  |  Total: ${patterns.length - noisePatterns.length}`);
+  if (noisePatterns.length > 0) {
+    const noiseOcc = noisePatterns.reduce((sum, p) => sum + (p.occurrence_count || 0), 0);
+    lines.push(`  Noise excluded: ${noisePatterns.length} pattern(s), ${noiseOcc} occurrence(s) (provider quota / test-stub)`);
+  }
   lines.push('');
 
   if (activePatterns.length === 0) {

--- a/tests/unit/rca-orchestrator-noise.test.js
+++ b/tests/unit/rca-orchestrator-noise.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-SUPPRESS-PROVIDER-TEST-001
+ * Unit tests for the auto_rca noise classifier.
+ *
+ * Pure functions — no DB, no subprocess. Covers the PRD test scenarios:
+ *  TS-1 provider quota (429 RESOURCE_EXHAUSTED) -> noise
+ *  TS-2 test-stub fixture                       -> noise
+ *  TS-3 genuine 5xx outage                      -> NOT noise (real defect preserved)
+ *  TS-4 gate-validation failure                 -> NOT noise
+ * plus the 400-Budget config case, stub-stuck marker, and fail-open edges.
+ */
+import { describe, it, expect } from 'vitest';
+import { isNoiseMessage, isNoiseTriggerEvent } from '../../lib/rca/noise-classifier.js';
+
+describe('isNoiseMessage — provider/test-stub noise', () => {
+  it('TS-2: flags test-stub fixtures', () => {
+    expect(isNoiseMessage('google API error: unknown - test-stub')).toBe(true);
+    expect(isNoiseMessage('openai API error: unknown - test-stub')).toBe(true);
+    expect(isNoiseMessage('anthropic API error: unknown - test-stub')).toBe(true);
+  });
+
+  it('flags stub-stuck markers', () => {
+    expect(isNoiseMessage('anthropic API error: unknown - stub-stuck')).toBe(true);
+  });
+
+  it('TS-1: flags provider quota / rate-limit (429 RESOURCE_EXHAUSTED / quota)', () => {
+    expect(isNoiseMessage('google API error: 429 - Google API error 429: { "status": "RESOURCE_EXHAUSTED" }')).toBe(true);
+    expect(isNoiseMessage('openai API error: 429 - You exceeded your current quota, please check your plan')).toBe(true);
+  });
+
+  it('flags provider config/billing ("Budget … invalid")', () => {
+    expect(isNoiseMessage('google API error: 400 - Budget 0 is invalid. This model only works in thinking mode.')).toBe(true);
+  });
+});
+
+describe('isNoiseMessage — real signal is preserved', () => {
+  it('TS-3: a genuine 5xx outage is NOT noise', () => {
+    expect(isNoiseMessage('anthropic API error: 500 - Internal Server Error')).toBe(false);
+    expect(isNoiseMessage('openai API error: 503 - Service Unavailable')).toBe(false);
+  });
+
+  it('TS-4: a gate-validation failure is NOT noise', () => {
+    expect(isNoiseMessage('Gate ACCEPTANCE_CRITERIA_VALIDATION failed: score 50/100')).toBe(false);
+    expect(isNoiseMessage('PLAN-TO-EXEC rejected: PRD does not meet quality standards')).toBe(false);
+  });
+
+  it('a handoff failure is NOT noise', () => {
+    expect(isNoiseMessage('LEAD-TO-PLAN gate failed - GATE_CLAIM_VALIDITY wrong_worktree')).toBe(false);
+  });
+
+  it('a network error without API-error context is NOT noise', () => {
+    expect(isNoiseMessage('connect ECONNRESET 10.0.0.1:443')).toBe(false);
+  });
+
+  it('a 429 WITHOUT quota context (e.g. app rate limit) is NOT noise', () => {
+    // Conservative: only provider quota is suppressed, not every 429.
+    expect(isNoiseMessage('HTTP 429 Too Many Requests from internal endpoint')).toBe(false);
+  });
+});
+
+describe('isNoiseMessage — defensive edges (fail-open to real signal)', () => {
+  it('returns false for empty/non-string input', () => {
+    expect(isNoiseMessage('')).toBe(false);
+    expect(isNoiseMessage(null)).toBe(false);
+    expect(isNoiseMessage(undefined)).toBe(false);
+    expect(isNoiseMessage(42)).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isNoiseMessage('GOOGLE API ERROR: 429 - RESOURCE_EXHAUSTED quota exceeded')).toBe(true);
+    expect(isNoiseMessage('Test-Stub marker')).toBe(true);
+  });
+});
+
+describe('isNoiseTriggerEvent — TriggerEvent wrapper', () => {
+  it('classifies via error_message', () => {
+    expect(isNoiseTriggerEvent({ error_message: 'google API error: unknown - test-stub', trigger_type: 'api_failure' })).toBe(true);
+    expect(isNoiseTriggerEvent({ error_message: 'anthropic API error: 500 - Internal Server Error', trigger_type: 'api_failure' })).toBe(false);
+  });
+
+  it('fail-open: malformed / missing event is treated as real signal (false)', () => {
+    expect(isNoiseTriggerEvent(null)).toBe(false);
+    expect(isNoiseTriggerEvent({})).toBe(false);
+    expect(isNoiseTriggerEvent({ trigger_type: 'api_failure' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
auto_rca recorded LLM provider quota/billing errors and test-stub fixtures as PAT-AUTO `issue_patterns`, crowning the `/leo audit` frequency view (top-4 were all noise) and burying real gate/handoff failures.

- **lib/rca/noise-classifier.js** (NEW): pure `isNoiseMessage`/`isNoiseTriggerEvent` — flags `test-stub`/`stub-stuck`, `429`+quota/`RESOURCE_EXHAUSTED`, `400` Budget-invalid; leaves 5xx outages, network errors, and gate/handoff failures as real signal.
- **lib/rca/rca-orchestrator.js**: stamp `data_quality_status='noise'` at `upsertIssuePattern` (flag, never drop; conditional update never clobbers an existing classification).
- **scripts/leo-audit.js**: exclude noise from ISSUE PATTERNS (JS filter keeps NULL rows) + a "Noise excluded: N" transparency line; JSON path surfaces `noise_patterns` separately.
- **scripts/backfill-noise-data-quality.mjs** (NEW): idempotent backfill reusing the classifier; flagged 9 existing patterns / ~5557 occurrences.
- **tests**: 13 unit assertions (noise classes + real-signal preservation + fail-open edges).

Precise count is **9 patterns** — the originating Session-5 audit's "~22" was a loose-regex over-count that swept genuine API defects (e.g. Invalid-JSON-payload occ=1380), which correctly remain as signal. Verified not under-catching (all 28 unflagged API-ish patterns confirmed real defects or transient outages).

No schema migration; reversible (`UPDATE issue_patterns SET data_quality_status=NULL WHERE data_quality_status='noise'`).

## Test plan
- [x] `npx vitest run tests/unit/rca-orchestrator-noise.test.js` → 13/13 pass
- [x] TESTING sub-agent PASS (precision boundary: 5xx/gate/handoff failures NOT flagged)
- [x] Backfill applied (9 patterns) + idempotent re-run (0 changes)
- [x] `node scripts/leo-audit.js` excludes noise; real gate-failure patterns surface at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)
