### PR TITLE
fix(SD-LEO-INFRA-STOP-RETRO-TRIGGER-001): stop retro-trigger test leaking into prod retrospectives + gated purge

### DIFF
--- a/scripts/one-off/purge-retro-test-fixture-pollution.mjs
+++ b/scripts/one-off/purge-retro-test-fixture-pollution.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * One-shot remediation for SD-LEO-INFRA-STOP-RETRO-TRIGGER-001.
+ *
+ * Purges the test-fixture pollution that the pre-fix
+ * tests/integration/retro-trigger-draft-insert.test.js leaked into the production
+ * retrospectives table (all under sd_id f91556d5-6226-486f-a179-27c9b602029f).
+ *
+ * SAFETY (this is a destructive PROD delete — read before running):
+ *  - DRY-RUN by default: opens a transaction, performs the DELETE, prints the
+ *    counts, then ROLLBACKs. Nothing is committed without --apply.
+ *  - --apply COMMITs, but ONLY if every guard passes, else it ROLLBACKs + exits 1:
+ *      * --expected-count <N> must equal the live matched-row count (re-measure first);
+ *      * the genuine (non-matching) row count must be unchanged by the delete;
+ *      * all PRESERVE_ID_PREFIXES must still resolve to a row after the delete.
+ *  - Uses `SET LOCAL session_replication_role = replica` so the AFTER-DELETE audit
+ *    trigger (trg_retrospectives_audit, whose non-deferrable FK references the row
+ *    being deleted) does not block the hard delete. SET LOCAL is scoped to this txn.
+ *  - COORDINATOR-GATED: run with --apply ONLY after explicit coordinator greenlight
+ *    (signal the exact predicate + a FRESH live count and wait for go-ahead).
+ *  - NOT wired to CI or any test. Manual, deliberate invocation only.
+ *
+ * Usage:
+ *   node scripts/one-off/purge-retro-test-fixture-pollution.mjs                       # dry-run
+ *   node scripts/one-off/purge-retro-test-fixture-pollution.mjs --apply --expected-count 2294
+ */
+import { createDatabaseClient } from '../../lib/supabase-connection.js';
+
+const TEST_SD_UUID = 'f91556d5-6226-486f-a179-27c9b602029f';
+
+// Genuine retrospectives for SD-LEO-FIX-FIX-AUTO-POPULATE-001 that must SURVIVE the
+// purge (validated at LEAD: none match the purge predicate). Stored as id prefixes.
+const PRESERVE_ID_PREFIXES = ['f2f44f90', 'ad5a698c', '1d11cdd9'];
+
+// The fixture-only predicate. Validated at LEAD to match exactly the leaked rows
+// with 0 genuine rows caught. Each limb independently selects the same set.
+const PREDICATE = `sd_id = $1 AND (project_name LIKE 'TEST-RETRO-%' OR title LIKE 'Regression %row%')`;
+
+const apply = process.argv.includes('--apply');
+const ecIdx = process.argv.indexOf('--expected-count');
+const expectedCount = ecIdx !== -1 ? Number(process.argv[ecIdx + 1]) : null;
+
+function fail(msg) {
+  console.error(`✗ ${msg}`);
+  process.exitCode = 1;
+}
+
+const client = await createDatabaseClient('engineer', { verify: false });
+let committed = false;
+try {
+  await client.query('BEGIN');
+  await client.query(`SET LOCAL session_replication_role = replica`);
+
+  const preserveSql = PRESERVE_ID_PREFIXES.map((_, i) => `id::text LIKE $${i + 2}`).join(' OR ');
+  const preserveParams = PRESERVE_ID_PREFIXES.map(p => `${p}%`);
+
+  const matched = (await client.query(`SELECT count(*)::int AS n FROM retrospectives WHERE ${PREDICATE}`, [TEST_SD_UUID])).rows[0].n;
+  const genuineBefore = (await client.query(`SELECT count(*)::int AS n FROM retrospectives WHERE sd_id = $1 AND NOT (${PREDICATE.replace('$1', '$1')})`, [TEST_SD_UUID])).rows[0].n;
+  const preservedBefore = (await client.query(`SELECT count(*)::int AS n FROM retrospectives WHERE sd_id = $1 AND (${preserveSql})`, [TEST_SD_UUID, ...preserveParams])).rows[0].n;
+
+  console.log(`Mode:               ${apply ? 'APPLY (will COMMIT if guards pass)' : 'DRY-RUN (will ROLLBACK)'}`);
+  console.log(`sd_id:              ${TEST_SD_UUID}`);
+  console.log(`Matched (to purge): ${matched}`);
+  console.log(`Genuine (NOT predicate, must be preserved): ${genuineBefore}`);
+  console.log(`Known preserve-prefixes resolved (expect ${PRESERVE_ID_PREFIXES.length}): ${preservedBefore}`);
+
+  const del = await client.query(`DELETE FROM retrospectives WHERE ${PREDICATE}`, [TEST_SD_UUID]);
+  const deleted = del.rowCount;
+
+  const genuineAfter = (await client.query(`SELECT count(*)::int AS n FROM retrospectives WHERE sd_id = $1`, [TEST_SD_UUID])).rows[0].n;
+  const preservedAfter = (await client.query(`SELECT count(*)::int AS n FROM retrospectives WHERE sd_id = $1 AND (${preserveSql})`, [TEST_SD_UUID, ...preserveParams])).rows[0].n;
+
+  console.log(`Deleted:            ${deleted}`);
+  console.log(`Remaining for sd_id (genuine, after): ${genuineAfter}`);
+  console.log(`Preserve-prefixes still present (after): ${preservedAfter}`);
+
+  // ---- Guards ----
+  const guards = [];
+  if (deleted !== matched) guards.push(`deleted(${deleted}) != matched(${matched})`);
+  if (genuineAfter !== genuineBefore) guards.push(`genuine rows changed: before=${genuineBefore} after=${genuineAfter} (would delete a genuine row!)`);
+  if (preservedBefore !== PRESERVE_ID_PREFIXES.length) guards.push(`only ${preservedBefore}/${PRESERVE_ID_PREFIXES.length} preserve-prefixes found BEFORE — refusing`);
+  if (preservedAfter !== preservedBefore) guards.push(`preserve-prefix count changed: before=${preservedBefore} after=${preservedAfter}`);
+  if (apply && expectedCount === null) guards.push('--apply requires --expected-count <N> (re-measure the live count first)');
+  if (apply && expectedCount !== null && expectedCount !== matched) guards.push(`--expected-count(${expectedCount}) != live matched(${matched}); re-confirm with coordinator`);
+
+  if (guards.length) {
+    console.error('\nGUARDS FAILED — rolling back:');
+    for (const g of guards) console.error(`  - ${g}`);
+    await client.query('ROLLBACK');
+    fail('purge aborted (rolled back)');
+  } else if (apply) {
+    await client.query('COMMIT');
+    committed = true;
+    console.log(`\n✓ COMMITTED: purged ${deleted} fixture rows; ${genuineAfter} genuine rows preserved.`);
+  } else {
+    await client.query('ROLLBACK');
+    console.log(`\n✓ DRY-RUN OK: would purge ${deleted} rows, preserve ${genuineAfter}. Re-run with --apply --expected-count ${matched} after coordinator greenlight.`);
+  }
+} catch (e) {
+  try { if (!committed) await client.query('ROLLBACK'); } catch { /* ignore */ }
+  fail(`error (rolled back): ${e.message}`);
+} finally {
+  await client.end();
+}

--- a/tests/integration/retro-trigger-draft-insert.test.js
+++ b/tests/integration/retro-trigger-draft-insert.test.js
@@ -1,214 +1,161 @@
 /**
- * Regression test for SD-LEO-FIX-FIX-AUTO-POPULATE-001.
+ * Regression test for SD-LEO-FIX-FIX-AUTO-POPULATE-001 (auto_populate trigger
+ * predicate) and SD-FDBK-FIX-FIX-RETROSPECTIVE-TRIGGER-001 (publish-gate firing
+ * order). Asserts the live DB-side trigger behavior that vitest stubs cannot reach:
+ *   1. DRAFT insert with rich arrays and no pre-set quality_score lands and
+ *      auto_validate computes quality_score >= 70.
+ *   2. PUBLISHED insert with a low computed score raises P0001.
+ *   3. Direct PUBLISHED insert with rich content and no pre-set score succeeds
+ *      (firing-order fix — the gate runs AFTER the score is computed).
+ *   4. Status-only DRAFT->PUBLISHED update with a low stored score raises P0001.
  *
- * Locks in the fix for the auto_populate_retrospective_fields() trigger predicate
- * bug (filed feedback d637a3fb-12c9-4f1d-aca6-25f32d9febd0). Before the fix, every
- * INSERT — including status='DRAFT' — fired the PUBLISHED-only quality_score >= 70
- * gate, blocking manual SD_COMPLETION retrospective inserts.
+ * SD-LEO-INFRA-STOP-RETRO-TRIGGER-001: this test PREVIOUSLY inserted SD_COMPLETION
+ * retrospectives into the PRODUCTION retrospectives table via the Supabase JS client
+ * and tried to remove them in afterEach. That delete SILENTLY FAILED — the
+ * AFTER-DELETE audit trigger (trg_retrospectives_audit) inserts an audit row whose
+ * non-deferrable FK (retrospectives_audit_retrospective_id_fkey) references the row
+ * being deleted, so a hard DELETE raises a FK violation — and the afterEach never
+ * checked the error, leaking 3 rows per run (~2,294 accumulated, ~30% of the table).
  *
- * Test scenarios:
- *   1. Happy path: DRAFT insert with rich arrays and no pre-set quality_score lands
- *      and the auto_validate trigger computes quality_score >= 70.
- *   2. Negative path: PUBLISHED insert with low quality_score still raises P0001.
+ * It now runs every scenario inside a pg-client BEGIN/ROLLBACK transaction. ROLLBACK
+ * discards both the inserted retrospective AND its audit row, so the audit-FK block
+ * never arises and no session_replication_role=replica is needed here. A unique
+ * per-run marker (RUN_ID) plus a final zero-survivors assertion fails the suite
+ * loudly if any future regression commits a row instead of rolling it back.
  *
- * The test runs against the live linked database (read/write); skips when no
- * service-role key is available.
+ * Pattern mirrors tests/integration/registry-aware-target-application-trigger.test.js.
+ * LIVE-gated: skips (does not fail) when no pg connection URL is configured, so
+ * hermetic CI without DB creds stays green.
  */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import { describe, test, expect, afterEach } from 'vitest';
-import { createClient } from '@supabase/supabase-js';
+const HAS_DB = !!(process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.SUPABASE_DB_URL);
+const TEST_SD_UUID = 'f91556d5-6226-486f-a179-27c9b602029f';
 
-const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const HAS_DB = Boolean(SUPABASE_URL && SUPABASE_KEY);
-const supabase = HAS_DB ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
+// Unique per-run marker. The zero-survivors assertion keys on this exact value, so
+// it is robust against (a) concurrent sessions running this same test and (b) the
+// historical fixture rows — both use different TEST-RETRO- prefixes. Any row bearing
+// this RUN_ID that survives the suite means a scenario committed instead of rolling
+// back (the leak has regressed). All RUN_ID values still match the purge predicate's
+// `project_name LIKE 'TEST-RETRO-%'`, so an accidental leak remains purgeable.
+const RUN_ID = `TEST-RETRO-RUN-${Date.now()}-${process.pid}`;
 
-const skipIfNoDb = HAS_DB ? test : test.skip;
+const PUB_GATE_RE = /PUBLISHED retrospectives must have quality_score >= 70|non-empty action_items/;
 
-const insertedRetroIds = [];
+// quality_score is intentionally NOT set: the auto_validate trigger overrides any
+// pre-set value, computing it from the content arrays (rich -> >=70, empty -> low).
+const INSERT_SQL = `INSERT INTO retrospectives
+  (sd_id, project_name, retro_type, title, description, status, generated_by,
+   learning_category, target_application, auto_generated, conducted_date,
+   what_went_well, key_learnings, action_items, what_needs_improvement)
+  VALUES ($1,$2,'SD_COMPLETION',$3,$4,$5,'MANUAL','PROCESS_IMPROVEMENT','EHG_Engineer',false,now(),
+   $6::jsonb,$7::jsonb,$8::jsonb,$9::jsonb)
+  RETURNING id, status, quality_score, retro_type`;
 
-afterEach(async () => {
-  if (!HAS_DB) return;
-  while (insertedRetroIds.length > 0) {
-    const id = insertedRetroIds.pop();
-    await supabase.from('retrospectives').delete().eq('id', id);
+const RICH_WW = [
+  'Trigger fix landed cleanly via CREATE OR REPLACE; idempotent.',
+  'Integration test catches the regression at insert time, not at handoff time.',
+  'Source-side fix protects all callers — no per-script workaround needed.',
+  'Single-line predicate change with verbatim preservation of every other branch.',
+  'Verification via pg_get_functiondef confirmed the new predicate is in place.'
+];
+const RICH_KL = [
+  'BEFORE-row triggers fire alphabetically by trigger NAME, so the gate ran before the score compute.',
+  'is_status_changing_to_published needs both TG_OP and NEW.status checked together.',
+  'The auto_validate trigger overrides NEW.quality_score, so any pre-set value is transient.',
+  'Rolling back a transaction discards the inserted row and its audit row together.',
+  'Pure root-cause fixes preserve the audit trail; bypass quota does not.'
+];
+const RICH_AI = [
+  'Mirror the sibling registry-aware test BEGIN/ROLLBACK pattern in all live DB tests.',
+  'Keep a per-run marker so a future leak fails the suite loudly.',
+  'Purge the accumulated fixture pollution under coordinator gating.'
+];
+const RICH_WNI = [
+  'Trigger ordering implications should be documented when a new retrospectives trigger is added.',
+  'Regression coverage on retrospectives triggers was thin before this SD.',
+  'Live-DB tests must isolate writes in rolled-back transactions, never best-effort deletes.'
+];
+
+const insertArgs = (title, status, ww, kl, ai, wni) => [
+  TEST_SD_UUID, RUN_ID, title, `${title} (rolled back; RUN_ID ${RUN_ID})`, status,
+  JSON.stringify(ww), JSON.stringify(kl), JSON.stringify(ai), JSON.stringify(wni)
+];
+
+describe.skipIf(!HAS_DB)('auto_populate/auto_validate retrospective triggers (LIVE, rolled back) — SD-LEO-INFRA-STOP-RETRO-TRIGGER-001', () => {
+  let client;
+
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    client = await createDatabaseClient('engineer', { verify: false });
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    // Zero-survivors guard: nothing this run inserted may have committed.
+    const r = await client.query(
+      `SELECT count(*)::int AS n FROM retrospectives WHERE project_name = $1`, [RUN_ID]
+    );
+    await client.end();
+    expect(r.rows[0].n).toBe(0);
+  });
+
+  async function inTxn(fn) {
+    await client.query('BEGIN');
+    try {
+      const result = await fn();
+      await client.query('ROLLBACK');
+      return { ok: true, result };
+    } catch (e) {
+      await client.query('ROLLBACK');
+      return { ok: false, message: e.message };
+    }
   }
-});
 
-describe('auto_populate_retrospective_fields trigger predicate (SD-LEO-FIX-FIX-AUTO-POPULATE-001)', () => {
-  // Use this SD's own UUID for FK satisfaction; the test row is identifiable by title prefix
-  // and is deleted in afterEach. Avoids creating throwaway SD rows.
-  const TEST_SD_UUID = 'f91556d5-6226-486f-a179-27c9b602029f';
-
-  skipIfNoDb('DRAFT insert with rich arrays lands without pre-set quality_score', async () => {
-    const sdId = TEST_SD_UUID;
-    const payload = {
-      sd_id: sdId,
-      project_name: `TEST-RETRO-TRIGGER-FIX-${Date.now()}`,
-      retro_type: 'SD_COMPLETION',
-      title: `Regression test row for SD-LEO-FIX-FIX-AUTO-POPULATE-001 ${Date.now()}`,
-      status: 'DRAFT',
-      generated_by: 'MANUAL',
-      learning_category: 'PROCESS_IMPROVEMENT',
-      target_application: 'EHG_Engineer',
-      affected_components: ['scripts/triage-test', 'lib/test-target'],
-      technical_debt_addressed: false,
-      auto_generated: false,
-      conducted_date: new Date().toISOString(),
-      what_went_well: [
-        'Trigger fix landed cleanly via CREATE OR REPLACE; idempotent.',
-        'Integration test catches the regression at insert time, not at handoff time.',
-        'Source-side fix protects all callers — no per-script workaround needed.',
-        'Single-line predicate change with verbatim preservation of every other branch.',
-        'Verification via pg_get_functiondef confirmed the new predicate is in place 50 lines into the function definition.'
-      ],
-      key_learnings: [
-        'Trigger ordering is alphabetical by trigger NAME — auto_populate_retrospective_fields runs before auto_validate_retrospective_quality, which is why the gate fired before the score was computed.',
-        'is_status_changing_to_published is a composite signal that needs both TG_OP and NEW.status to be checked together; the OR-disjunct without status was the bug.',
-        'The auto_validate trigger overrides NEW.quality_score in its run, so any value the inserter pre-sets is transient — the buggy gate just needed a satisfying value to pass through.',
-        'Workarounds that pre-set quality_score to 80 produce honest stored scores after auto_validate runs, but they bypass the legitimate gate semantics on the way through (database-agent flagged this in 2026-05-05 review).',
-        'Pure root-cause fixes preserve the audit trail; bypass quota does not.'
-      ],
-      action_items: [
-        'Resume SD-MAN-INFRA-TRIAGE-377-PRE-001 retrospective insert without the quality_score=80 workaround.',
-        'Mark feedback d637a3fb-12c9-4f1d-aca6-25f32d9febd0 as resolved.',
-        'Confirm no other consumers of the buggy trigger relied on the implicit DRAFT-as-PUBLISHED semantics.'
-      ],
-      what_needs_improvement: [
-        'Trigger ordering implications could have been documented when the second trigger was added.',
-        'Regression coverage on retrospectives.* triggers was thin enough that this bug shipped without detection.',
-        'PRD acceptance criteria validators should accept either array-of-strings or array-of-{criterion, measure} shape; the auto-enrichment fallback is fragile.'
-      ]
-    };
-
-    const { data, error } = await supabase
-      .from('retrospectives')
-      .insert(payload)
-      .select('id, status, quality_score, retro_type')
-      .single();
-
-    expect(error).toBeNull();
-    expect(data).toBeTruthy();
-    insertedRetroIds.push(data.id);
-
-    expect(data.status).toBe('DRAFT');
-    expect(data.retro_type).toBe('SD_COMPLETION');
-    expect(data.quality_score).toBeGreaterThanOrEqual(70);
+  it('DRAFT insert with rich arrays lands and auto_validate computes quality_score >= 70', async () => {
+    const r = await inTxn(async () => {
+      const ins = await client.query(INSERT_SQL, insertArgs('Regression row — DRAFT happy path', 'DRAFT', RICH_WW, RICH_KL, RICH_AI, RICH_WNI));
+      return ins.rows[0];
+    });
+    expect(r.ok).toBe(true);
+    expect(r.result.status).toBe('DRAFT');
+    expect(r.result.retro_type).toBe('SD_COMPLETION');
+    expect(r.result.quality_score).toBeGreaterThanOrEqual(70);
   });
 
-  skipIfNoDb('PUBLISHED insert with low quality_score still raises P0001', async () => {
-    const sdId = TEST_SD_UUID;
-    const payload = {
-      sd_id: sdId,
-      project_name: `TEST-RETRO-TRIGGER-FIX-${Date.now()}`,
-      retro_type: 'SD_COMPLETION',
-      title: 'Regression test row — negative path',
-      status: 'PUBLISHED',
-      generated_by: 'MANUAL',
-      learning_category: 'PROCESS_IMPROVEMENT',
-      target_application: 'EHG_Engineer',
-      auto_generated: false,
-      conducted_date: new Date().toISOString(),
-      what_went_well: [],
-      key_learnings: [],
-      action_items: [],
-      what_needs_improvement: [],
-      quality_score: 0
-    };
-
-    const { data, error } = await supabase.from('retrospectives').insert(payload).select('id');
-    if (data && data[0]) insertedRetroIds.push(data[0].id);
-
-    expect(error).toBeTruthy();
-    expect(error.message).toMatch(/PUBLISHED retrospectives must have quality_score >= 70|non-empty action_items/);
+  it('PUBLISHED insert with a low computed quality_score still raises P0001', async () => {
+    const r = await inTxn(() => client.query(INSERT_SQL, insertArgs('Regression row — PUBLISHED low-score negative path', 'PUBLISHED', [], [], [], [])));
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(PUB_GATE_RE);
   });
 
-  // SD-FDBK-FIX-FIX-RETROSPECTIVE-TRIGGER-001 (harness_backlog 8bc451f0): the publish-gate
-  // quality_score>=70 check used to fire (alphabetically) BEFORE the score-compute trigger,
-  // so a direct PUBLISHED insert with good content but no pre-set score raised P0001. The
-  // enforcement was relocated to run AFTER the score is computed, on every publish path.
-
-  skipIfNoDb('direct PUBLISHED insert with rich content and no pre-set quality_score succeeds (firing-order fix)', async () => {
-    const payload = {
-      sd_id: TEST_SD_UUID,
-      project_name: `TEST-RETRO-GATE-ORDER-${Date.now()}`,
-      retro_type: 'SD_COMPLETION',
-      title: `Regression row — direct PUBLISHED positive path ${Date.now()}`,
-      status: 'PUBLISHED',
-      generated_by: 'MANUAL',
-      learning_category: 'PROCESS_IMPROVEMENT',
-      target_application: 'EHG_Engineer',
-      auto_generated: false,
-      conducted_date: new Date().toISOString(),
-      what_went_well: [
-        'Publish-gate enforcement now runs after the score is computed.',
-        'Direct PUBLISHED inserts no longer require the DRAFT-then-PUBLISH workaround.',
-        'Fix is order-independent: enforcement lives in the compute trigger.',
-        'Trigger names were preserved so historical migrations are not orphaned.',
-        'Scoring logic was kept byte-identical, verified by smoke tests.'
-      ],
-      key_learnings: [
-        'PostgreSQL fires BEFORE-row triggers alphabetically by name, placing the check before the compute.',
-        'Relocating the quality_score>=70 check into auto_validate_retrospective_quality removes the ordering dependency.',
-        'The should_recalculate=false path must still enforce the gate using the stored score on status-only updates.',
-        'Co-locating compute and enforcement makes the gate robust to future trigger additions.',
-        'Regression tests assert the score is computed and lands at >=70 with no pre-set value.'
-      ],
-      action_items: [
-        'Drop the DRAFT-then-PUBLISH workaround in retro-writing tooling where convenient.',
-        'Resolve harness_backlog 8bc451f0.',
-        'Keep this regression test to prevent re-break.'
-      ],
-      what_needs_improvement: [
-        'Trigger ordering implications should be documented when a new retrospectives trigger is added.',
-        'Regression coverage on retrospectives triggers was thin before this SD.',
-        'A lint could flag publish gates that read a column another trigger computes.'
-      ]
-    };
-
-    const { data, error } = await supabase
-      .from('retrospectives')
-      .insert(payload)
-      .select('id, status, quality_score')
-      .single();
-
-    expect(error).toBeNull();
-    expect(data).toBeTruthy();
-    insertedRetroIds.push(data.id);
-    expect(data.status).toBe('PUBLISHED');
-    expect(data.quality_score).toBeGreaterThanOrEqual(70);
+  it('direct PUBLISHED insert with rich content and no pre-set quality_score succeeds (firing-order fix)', async () => {
+    const r = await inTxn(async () => {
+      const ins = await client.query(INSERT_SQL, insertArgs('Regression row — direct PUBLISHED positive path', 'PUBLISHED', RICH_WW, RICH_KL, RICH_AI, RICH_WNI));
+      return ins.rows[0];
+    });
+    expect(r.ok).toBe(true);
+    expect(r.result.status).toBe('PUBLISHED');
+    expect(r.result.quality_score).toBeGreaterThanOrEqual(70);
   });
 
-  skipIfNoDb('status-only DRAFT->PUBLISHED update with a low stored score still raises P0001', async () => {
-    // Insert a low-quality DRAFT (lands; publish gate not applied), then publish via a
-    // status-only update (no content change -> score NOT recomputed). The gate must enforce
-    // the STORED score and raise — no publish path may bypass the >=70 gate.
-    const draft = {
-      sd_id: TEST_SD_UUID,
-      project_name: `TEST-RETRO-GATE-ORDER-${Date.now()}`,
-      retro_type: 'SD_COMPLETION',
-      title: `Regression row — status-only publish enforcement ${Date.now()}`,
-      status: 'DRAFT',
-      generated_by: 'MANUAL',
-      learning_category: 'PROCESS_IMPROVEMENT',
-      target_application: 'EHG_Engineer',
-      auto_generated: false,
-      conducted_date: new Date().toISOString(),
-      what_went_well: ['one'],
-      key_learnings: ['two'],
-      action_items: ['three'],
-      what_needs_improvement: ['four']
-    };
-
-    const { data: draftRow, error: draftErr } = await supabase
-      .from('retrospectives').insert(draft).select('id, quality_score').single();
-    expect(draftErr).toBeNull();
-    insertedRetroIds.push(draftRow.id);
-    expect(draftRow.quality_score).toBeLessThan(70);
-
-    const { error: pubErr } = await supabase
-      .from('retrospectives').update({ status: 'PUBLISHED' }).eq('id', draftRow.id);
+  it('status-only DRAFT->PUBLISHED update with a low stored score still raises P0001', async () => {
+    await client.query('BEGIN');
+    let draftScore;
+    let pubErr;
+    try {
+      const ins = await client.query(INSERT_SQL, insertArgs('Regression row — status-only publish enforcement', 'DRAFT', ['one'], ['two'], ['three'], ['four']));
+      draftScore = ins.rows[0].quality_score;
+      try {
+        await client.query(`UPDATE retrospectives SET status='PUBLISHED' WHERE id=$1`, [ins.rows[0].id]);
+      } catch (e) {
+        pubErr = e;
+      }
+    } finally {
+      await client.query('ROLLBACK');
+    }
+    expect(draftScore).toBeLessThan(70);
     expect(pubErr).toBeTruthy();
-    expect(pubErr.message).toMatch(/PUBLISHED retrospectives must have quality_score >= 70|non-empty action_items/);
+    expect(pubErr.message).toMatch(PUB_GATE_RE);
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-STOP-RETRO-TRIGGER-001

Stops `tests/integration/retro-trigger-draft-insert.test.js` from leaking into the **production** `retrospectives` table, and adds a gated remediation for the rows it already leaked.

### Problem
The test inserted `SD_COMPLETION` retrospectives into prod (under `sd_id f91556d5`) via the Supabase JS client and relied on an `afterEach` delete to clean up. That delete **silently failed** — the `AFTER-DELETE` audit trigger (`trg_retrospectives_audit`) inserts an audit row whose non-deferrable FK references the row being deleted, so a hard `DELETE` raises an FK violation — and the `afterEach` never checked the error. Result: **~3 rows leaked per run, ~2,309 accumulated** (~30% of the `retrospectives` table, ~60% of the `SD_COMPLETION` namespace; 614 were `PUBLISHED quality_score>=70`, poisoning learning-extraction).

### Fix
1. **Test refactor** — every scenario now runs inside a pg-client `BEGIN`/`ROLLBACK` transaction (mirrors the sibling `tests/integration/registry-aware-target-application-trigger.test.js`). `ROLLBACK` discards the inserted retrospective *and* its audit row together, so the audit-FK never blocks and **no `replica` role is needed in the test**. The broken Supabase-JS delete loop is removed. A unique per-run `RUN_ID` marker + an `afterAll` zero-survivors assertion makes any future leak fail the suite loudly (robust against concurrent sessions and historical fixtures).
   - **Ran live: 4/4 pass, 0 rows leaked.**
2. **Remediation script** — `scripts/one-off/purge-retro-test-fixture-pollution.mjs`: one-shot, **dry-run by default**, **coordinator-gated**. Uses a `SET LOCAL session_replication_role=replica` transaction (the only way to hard-delete past the audit-FK) with guards: `deleted==matched`, genuine-row count unchanged, and the 3 genuine rows (`f2f44f90`/`ad5a698c`/`1d11cdd9`) preserved; `COMMIT` only with `--apply --expected-count <fresh>`. **Not wired to CI.**
   - Dry-run verified: matched=2309, deleted=2309, genuine 3→3 preserved.

### Purge execution (post-merge, gated)
The destructive purge (`--apply`) is intentionally **not run in this PR**. Per coordinator guidance ("land the fix first or it re-pollutes"), it runs **after merge** under explicit coordinator greenlight, with the live count re-measured at that moment.

### Provenance / validation
Fleet audit finding #1. LEAD validation, DESIGN, DATABASE, RISK, STORIES, TESTING, RETRO sub-agents all PASS. Gate scores: LEAD-TO-PLAN 93, PLAN-TO-EXEC 94, EXEC-TO-PLAN 93, PLAN-TO-LEAD 95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
