### PR TITLE
feat(SD-LEO-INFRA-COMPLETE-TWO-WAY-001): complete two-way coordinator channel (default-OFF)

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -250,6 +250,20 @@ Behavior:
 
 Display the script output directly to the user.
 
+#### Worker request -> coordinator reply round-trip (SD-LEO-INFRA-COMPLETE-TWO-WAY-001, DEFAULT-OFF):
+
+Completes the two-way channel: a worker can ask a question and block until the coordinator's correlated reply arrives (or a timeout), instead of fire-and-forget signalling. **Gated by `COORDINATOR_TWOWAY_V2=on`** (unset/`off` = no-op; the channel behaves exactly as before). No DB migration — correlation rides in `session_coordination.payload` (`message_type` stays `INFO`).
+
+```bash
+# Worker side: send a request and await the coordinator's reply (prints correlation_id)
+node scripts/worker-signal.cjs request "<question>" [--timeout <ms>]
+
+# Coordinator side: reply to a specific worker's request by correlation id
+node scripts/coordinator-reply.cjs --to <worker_session_id> --correlation <id> "<reply body>"
+```
+
+Mechanics: the request row carries `payload.correlation_id` + `expects_reply` (no `signal_type`, so it is NOT scooped by the FR-3a signal inbox or signal-router). The reply carries `payload.kind='coordinator_reply'` + `reply_to=<correlation_id>` and targets the specific worker (never `broadcast-coordinator`). The worker's inbox hook leaves `coordinator_reply` rows unread (`shouldSkipCoordinatorReply`) so the worker's `awaitCoordinatorReply()` poll consumes them. Resolution itself becomes DB-canonical with deterministic single-coordinator election when the same flag is on (`lib/coordinator/resolve.cjs`).
+
 #### For `help`:
 
 Display:

--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -41,7 +41,81 @@ async function queryDbForCoordinator(supabase) {
   return data[0];
 }
 
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-1: feature flag, default-OFF.
+// Read INSIDE function bodies only (never at module scope) so requiring this
+// module with the flag off triggers zero new behavior and zero DB calls at
+// import time. With the flag off the resolution path below is byte-identical to
+// the prior SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 behavior.
+function isTwoWayV2Enabled() {
+  return process.env.COORDINATOR_TWOWAY_V2 === 'on';
+}
+
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-3: deterministic single-winner election.
+// Pure: given candidate coordinator rows, pick ONE authoritative winner by
+// (coordinator_since DESC, NULLS LAST, session_id ASC). Most-recently-started
+// coordinator wins — matching the legacy file-overwrite "last /coordinator start
+// wins" intent and preventing a zombie incumbent from blocking a fresh takeover.
+// NULL coordinator_since is ordered last; session_id is a stable deterministic
+// tiebreak so resolution never flaps between equally-ranked candidates.
+function pickCanonicalCoordinator(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const candidates = rows
+    .filter(r => r && typeof r.session_id === 'string')
+    .map(r => ({
+      session_id: r.session_id,
+      since: (r.metadata && typeof r.metadata.coordinator_since === 'string')
+        ? r.metadata.coordinator_since
+        : null
+    }));
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    // coordinator_since DESC, NULLS LAST
+    if (a.since !== null || b.since !== null) {
+      if (a.since === null) return 1;
+      if (b.since === null) return -1;
+      if (a.since !== b.since) return a.since > b.since ? -1 : 1;
+    }
+    // tiebreak: session_id ASC (stable + deterministic)
+    if (a.session_id < b.session_id) return -1;
+    if (a.session_id > b.session_id) return 1;
+    return 0;
+  });
+  return candidates[0];
+}
+
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-3+FR-4: DB-canonical election.
+// Fetch ALL fresh is_coordinator sessions (not limit-1) and elect a single
+// winner. Returns a session_id or null. Fail-open (GG-5): any error returns null
+// so the caller falls back to the legacy file-first chain; this function never
+// throws and never mutates is_coordinator (GG-6, read-only resolution).
+async function electCoordinatorFromDb(supabase) {
+  try {
+    const cutoff = new Date(Date.now() - STALE_THRESHOLD_MIN * 60_000).toISOString();
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at, metadata')
+      .gte('heartbeat_at', cutoff)
+      .filter('metadata->>is_coordinator', 'eq', 'true');
+    if (error || !Array.isArray(data) || data.length === 0) return null;
+    const winner = pickCanonicalCoordinator(data);
+    return winner ? winner.session_id : null;
+  } catch {
+    return null;
+  }
+}
+
 async function getActiveCoordinatorId(supabase) {
+  // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-3+FR-4 (default-OFF): when enabled, the
+  // DB is the canonical pointer — elect a single authoritative coordinator from
+  // claude_sessions and return it (the local file is demoted to a cache used only
+  // by the legacy path below). Fail-open: on no-result/error we fall through to
+  // the byte-identical legacy file-first resolution, so flag-OFF is unchanged.
+  if (isTwoWayV2Enabled() && supabase) {
+    const elected = await electCoordinatorFromDb(supabase);
+    if (elected) return elected;
+    // DB reachable-but-empty or errored → fall through to legacy chain (fail-open).
+  }
+
   // 1) File-first lookup. The pointer file is rewritten on every /coordinator start
   //    so its session_id is always the most-recently-started coordinator.
   const pointer = readPointerFile();
@@ -137,5 +211,9 @@ module.exports = {
   clearActiveCoordinator,
   // exported for tests
   readPointerFile,
-  writePointerFile
+  writePointerFile,
+  // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 (additive, default-OFF) — exported for tests
+  isTwoWayV2Enabled,
+  pickCanonicalCoordinator,
+  electCoordinatorFromDb
 };

--- a/lib/coordinator/resolve.test.js
+++ b/lib/coordinator/resolve.test.js
@@ -293,3 +293,172 @@ describe('RES-12: clearActiveCoordinator removes file and DB metadata flag', () 
     expect(updateCalledWith.metadata.other).toBe('kept');
   });
 });
+
+// ============================================================================
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 — M1: authoritative single-coordinator
+// resolution + machine-canonical pointer, all DEFAULT-OFF behind
+// COORDINATOR_TWOWAY_V2. Flag-OFF MUST stay byte-identical to the prior behavior
+// (the RES-5..RES-8 tests above already pin that with the flag unset).
+// ============================================================================
+
+// v2 mock: supports the election terminal (.select().gte().filter() awaitable),
+// the legacy DB scan (.filter().order().limit()), and the legacy file-heartbeat
+// verify (.select().eq().gte().maybeSingle()).
+function buildV2Mock({ coordinatorRows = [], error = null, fileVerifyRow = null } = {}) {
+  const result = { data: coordinatorRows, error };
+  function filterThenable() {
+    const p = Promise.resolve(result);                 // election awaits .filter()
+    p.order = vi.fn(() => ({ limit: vi.fn().mockResolvedValue(result) })); // legacy chain
+    return p;
+  }
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        gte: vi.fn(() => ({ filter: vi.fn(() => filterThenable()) })),
+        eq: vi.fn(() => ({ gte: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: fileVerifyRow, error: null }) })) }))
+      })),
+      update: vi.fn(() => ({ eq: vi.fn(() => ({ gte: vi.fn().mockResolvedValue({ data: null, error: null }) })) }))
+    }))
+  };
+}
+
+describe('TWOWAY-V2 flag (FR-1) + zero-DB-at-import (GG-8)', () => {
+  afterEach(() => { delete process.env.COORDINATOR_TWOWAY_V2; });
+
+  it('isTwoWayV2Enabled defaults OFF and reads env inside the function body', () => {
+    delete process.env.COORDINATOR_TWOWAY_V2;
+    expect(resolve.isTwoWayV2Enabled()).toBe(false);
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    expect(resolve.isTwoWayV2Enabled()).toBe(true);
+    process.env.COORDINATOR_TWOWAY_V2 = 'off';
+    expect(resolve.isTwoWayV2Enabled()).toBe(false);
+  });
+
+  it('requiring resolve.cjs issues ZERO DB calls at module scope (flag ON or OFF)', () => {
+    // The module never imports/creates a supabase client — callers inject it.
+    // So module load is side-effect-free regardless of the flag. Re-require under
+    // flag ON and assert the public API loaded without any DB dependency.
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    vi.resetModules();
+    const fresh = require('./resolve.cjs');
+    expect(typeof fresh.getActiveCoordinatorId).toBe('function');
+    expect(typeof fresh.electCoordinatorFromDb).toBe('function');
+  });
+});
+
+describe('CHAR: flag-OFF is byte-identical to legacy (FR-2 characterization)', () => {
+  afterEach(() => { delete process.env.COORDINATOR_TWOWAY_V2; });
+
+  it('flag OFF does NOT elect: returns file-first coordinator even when DB has multiple coordinators', async () => {
+    delete process.env.COORDINATOR_TWOWAY_V2; // OFF
+    resolve.writePointerFile({ session_id: 'file-coord', started_at: '2026-06-05T00:00:00Z', host: 'h' });
+    const sb = buildV2Mock({
+      coordinatorRows: [
+        { session_id: 'db-coord-A', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T01:00:00Z' } },
+        { session_id: 'db-coord-B', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T02:00:00Z' } }
+      ],
+      fileVerifyRow: { session_id: 'file-coord', heartbeat_at: new Date().toISOString() }
+    });
+    const id = await resolve.getActiveCoordinatorId(sb);
+    expect(id).toBe('file-coord'); // legacy file-first wins; no election happened
+  });
+});
+
+describe('ELECT: pickCanonicalCoordinator (FR-3, pure)', () => {
+  it('ELECT-1: most-recent coordinator_since wins', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'a', metadata: { coordinator_since: '2026-06-05T01:00:00Z' } },
+      { session_id: 'b', metadata: { coordinator_since: '2026-06-05T03:00:00Z' } },
+      { session_id: 'c', metadata: { coordinator_since: '2026-06-05T02:00:00Z' } }
+    ]);
+    expect(w.session_id).toBe('b');
+  });
+
+  it('ELECT-2: NULL coordinator_since ordered last', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'no-since', metadata: {} },
+      { session_id: 'has-since', metadata: { coordinator_since: '2026-06-05T01:00:00Z' } }
+    ]);
+    expect(w.session_id).toBe('has-since');
+  });
+
+  it('ELECT-3: session_id ASC tiebreak when coordinator_since equal', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'zzz', metadata: { coordinator_since: '2026-06-05T01:00:00Z' } },
+      { session_id: 'aaa', metadata: { coordinator_since: '2026-06-05T01:00:00Z' } }
+    ]);
+    expect(w.session_id).toBe('aaa');
+  });
+
+  it('ELECT-3b: session_id ASC tiebreak when both coordinator_since null', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'yyy', metadata: {} },
+      { session_id: 'bbb', metadata: null }
+    ]);
+    expect(w.session_id).toBe('bbb');
+  });
+
+  it('ELECT-4: empty / invalid input returns null', () => {
+    expect(resolve.pickCanonicalCoordinator([])).toBeNull();
+    expect(resolve.pickCanonicalCoordinator(null)).toBeNull();
+    expect(resolve.pickCanonicalCoordinator([{ no_session: true }])).toBeNull();
+  });
+});
+
+describe('ELECT: electCoordinatorFromDb (FR-3, fail-open)', () => {
+  it('ELECT-5: returns elected winner session_id from fresh coordinators', async () => {
+    const sb = buildV2Mock({ coordinatorRows: [
+      { session_id: 'old', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T01:00:00Z' } },
+      { session_id: 'new', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T05:00:00Z' } }
+    ]});
+    expect(await resolve.electCoordinatorFromDb(sb)).toBe('new');
+  });
+
+  it('ELECT-6a: DB error returns null (fail-open)', async () => {
+    const sb = buildV2Mock({ coordinatorRows: null, error: { message: 'db down' } });
+    expect(await resolve.electCoordinatorFromDb(sb)).toBeNull();
+  });
+
+  it('ELECT-6b: thrown error returns null (never throws)', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    await expect(resolve.electCoordinatorFromDb(sb)).resolves.toBeNull();
+  });
+
+  it('ELECT-6c: empty coordinator set returns null', async () => {
+    const sb = buildV2Mock({ coordinatorRows: [] });
+    expect(await resolve.electCoordinatorFromDb(sb)).toBeNull();
+  });
+});
+
+describe('V2: getActiveCoordinatorId DB-canonical when flag ON (FR-3 + FR-4)', () => {
+  afterEach(() => { delete process.env.COORDINATOR_TWOWAY_V2; });
+
+  it('V2-1: flag ON returns the DB-elected winner, overriding a disagreeing pointer file (DB is canonical)', async () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    resolve.writePointerFile({ session_id: 'stale-file-coord', started_at: '2026-06-05T00:00:00Z', host: 'h' });
+    const sb = buildV2Mock({ coordinatorRows: [
+      { session_id: 'db-old', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T01:00:00Z' } },
+      { session_id: 'db-new', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T04:00:00Z' } }
+    ]});
+    const id = await resolve.getActiveCoordinatorId(sb);
+    expect(id).toBe('db-new'); // DB wins over the stale file
+  });
+
+  it('V2-2: flag ON + no DB coordinator falls through to legacy file-first (fail-open)', async () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    resolve.writePointerFile({ session_id: 'file-coord', started_at: '2026-06-05T00:00:00Z', host: 'h' });
+    const sb = buildV2Mock({ coordinatorRows: [], fileVerifyRow: { session_id: 'file-coord', heartbeat_at: new Date().toISOString() } });
+    const id = await resolve.getActiveCoordinatorId(sb);
+    expect(id).toBe('file-coord'); // election empty → legacy chain returns file pointer
+  });
+
+  it('V2-3: flag ON + missing pointer file still resolves the DB coordinator (file not required)', async () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    if (fs.existsSync(resolve.ACTIVE_COORDINATOR_FILE)) fs.unlinkSync(resolve.ACTIVE_COORDINATOR_FILE);
+    const sb = buildV2Mock({ coordinatorRows: [
+      { session_id: 'db-only-coord', heartbeat_at: new Date().toISOString(), metadata: { coordinator_since: '2026-06-05T01:00:00Z' } }
+    ]});
+    const id = await resolve.getActiveCoordinatorId(sb);
+    expect(id).toBe('db-only-coord'); // DB-canonical: no file needed
+  });
+});

--- a/scripts/coordinator-reply.cjs
+++ b/scripts/coordinator-reply.cjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-5 — coordinator reply verb.
+// Completes the two-way round-trip: a worker sends a request via
+//   node scripts/worker-signal.cjs request "<question>"
+// (payload.correlation_id + expects_reply); the coordinator replies here with the
+// worker's session_id + correlation_id. The reply is a session_coordination row
+// with message_type='INFO' (existing enum value — no ALTER TYPE, P0-2) and
+// payload.kind='coordinator_reply' + reply_to=<correlation_id>. The worker inbox
+// hook SKIPS coordinator_reply rows (FR-6) so the worker's awaitCoordinatorReply()
+// poll consumes it. Correlation rides entirely in payload JSONB — no migration.
+//
+// DEFAULT-OFF behind COORDINATOR_TWOWAY_V2=on, mirroring the worker request path,
+// so production behavior is byte-unchanged until the round-trip is enabled.
+//
+// Usage:
+//   node scripts/coordinator-reply.cjs --to <worker_session_id> --correlation <id> "<reply body>"
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
+const { redact, BODY_HARD_CAP } = require('./worker-signal.cjs');
+
+// Default reply lifetime — comfortably exceeds the worker await window (30s) plus margin.
+const REPLY_DEFAULT_TTL_MS = 60 * 60_000;
+
+// Pure + exported (TS): the exact reply payload written to session_coordination.payload.
+function buildReplyPayload({ correlationId, body, coordinatorSession }) {
+  const payload = {
+    kind: 'coordinator_reply',
+    reply_to: correlationId,
+    sender: coordinatorSession || null
+  };
+  if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);
+  // INVARIANT: no signal_type (would be scooped by signal-router) / no intent_action.
+  return payload;
+}
+
+// Insert the reply row. Read-only w.r.t. resolution; targets the SPECIFIC worker
+// (never 'broadcast-coordinator', per P1-3). Returns { data, error }.
+async function sendCoordinatorReply(supabase, { coordinatorSession, workerSession, correlationId, body, ttlMs = REPLY_DEFAULT_TTL_MS }) {
+  const payload = buildReplyPayload({ correlationId, body, coordinatorSession });
+  const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+  const subject = `[COORDINATOR_REPLY ${String(correlationId).slice(0, 8)}]`;
+  return supabase
+    .from('session_coordination')
+    .insert({
+      sender_session: coordinatorSession,
+      sender_type: 'coordinator',
+      target_session: workerSession,
+      message_type: 'INFO',
+      subject,
+      body: payload.body || null,
+      payload,
+      expires_at: expiresAt
+    })
+    .select('id, created_at')
+    .single();
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--to' || a === '--correlation' || a === '--ttl') {
+      flags[a.slice(2)] = args[++i];
+    } else if (a.startsWith('--')) {
+      flags[a.slice(2)] = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : true;
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+async function main() {
+  if (!isTwoWayV2Enabled()) {
+    console.error('ERROR: coordinator reply is gated by COORDINATOR_TWOWAY_V2=on (currently OFF — no-op).');
+    process.exit(3);
+  }
+
+  const { flags, positional } = parseArgs(process.argv);
+  const workerSession = typeof flags.to === 'string' ? flags.to : null;
+  const correlationId = typeof flags.correlation === 'string' ? flags.correlation : null;
+  const body = positional.join(' ').trim();
+
+  if (!workerSession || !correlationId || !body) {
+    console.error('Usage: node scripts/coordinator-reply.cjs --to <worker_session_id> --correlation <id> "<reply body>"');
+    process.exit(2);
+  }
+
+  const coordinatorSession = process.env.CLAUDE_SESSION_ID;
+  if (!coordinatorSession) {
+    console.error('ERROR: CLAUDE_SESSION_ID env var required (set by SessionStart hook).');
+    process.exit(1);
+  }
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+
+  const ttlMs = Number(flags.ttl) > 0 ? Number(flags.ttl) : REPLY_DEFAULT_TTL_MS;
+  const { data, error } = await sendCoordinatorReply(supabase, {
+    coordinatorSession, workerSession, correlationId, body, ttlMs
+  });
+  if (error) {
+    console.error('ERROR: failed to insert reply:', error.message);
+    process.exit(1);
+  }
+
+  console.log('✓ Coordinator reply sent');
+  console.log('  reply_id:', data.id);
+  console.log('  to_worker:', workerSession);
+  console.log('  reply_to:', correlationId);
+}
+
+module.exports = { buildReplyPayload, sendCoordinatorReply, parseArgs, REPLY_DEFAULT_TTL_MS };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('UNHANDLED:', err.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -340,6 +340,22 @@ async function insertDeliveredRowIfRequested(supabase, sessionId, msg) {
   }
 }
 
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-6 (P0-1 mitigation): a coordinator reply
+// row (payload.kind='coordinator_reply') targeting this worker must be left UNREAD
+// for the worker's awaitCoordinatorReply() poll to consume — otherwise this
+// PostToolUse hook marks it read_at first and the await never sees it. Mirror of
+// the FR-3a coordinator-skip in the message loop. DEFAULT-OFF: inert unless
+// COORDINATOR_TWOWAY_V2='on' (and such rows only exist when the round-trip is used),
+// so flag-OFF inbox behavior is byte-identical (GG-2). Read the flag inside the
+// function body (GG-1). Exported for unit testing.
+function shouldSkipCoordinatorReply(msg) {
+  if (process.env.COORDINATOR_TWOWAY_V2 !== 'on') return false;
+  return !!msg
+    && msg.message_type === 'INFO'
+    && !!msg.payload
+    && msg.payload.kind === 'coordinator_reply';
+}
+
 // QF-20260504-007: Claude Code passes hook payload as JSON on stdin per its
 // PostToolUse protocol. The session_id field is the only reliable identifier of
 // the calling session — env vars (CLAUDE_SESSION_ID) are NOT propagated to hook
@@ -438,6 +454,11 @@ async function main() {
     for (const msg of messages) {
       // QF-20260508-988: defer worker FR-3a signals to /coordinator inbox.
       if (amCoordinator && msg.message_type === 'INFO' && msg.payload && msg.payload.signal_type) {
+        continue;
+      }
+      // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-6 (P0-1): leave coordinator-reply
+      // rows for the worker's awaitCoordinatorReply() to consume (default-OFF).
+      if (shouldSkipCoordinatorReply(msg)) {
         continue;
       }
       const typeLabel = {
@@ -573,5 +594,7 @@ module.exports = {
   getThrottleFile,
   getHeartbeatFile,
   // SD-LEO-INFRA-COORDINATOR-WORKER-DELIVERED-001 — exposed for unit tests
-  insertDeliveredRowIfRequested
+  insertDeliveredRowIfRequested,
+  // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-6 — exposed for unit tests
+  shouldSkipCoordinatorReply
 };

--- a/scripts/twoway-roundtrip.test.js
+++ b/scripts/twoway-roundtrip.test.js
@@ -1,0 +1,146 @@
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 — M2: discovery -> reply -> await round-trip.
+// Covers FR-5 (coordinator reply verb), FR-6 (inbox reply-skip / P0-1), FR-7
+// (worker request payload + awaitCoordinatorReply). All correlation in payload
+// JSONB; message_type stays INFO (no migration, P0-2).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const workerSignal = require('./worker-signal.cjs');
+const coordinatorReply = require('./coordinator-reply.cjs');
+const inbox = require('./hooks/coordination-inbox.cjs');
+
+// --- minimal supabase mocks ---------------------------------------------------
+function mockSelectChain(rows) {
+  // awaitCoordinatorReply: from().select().eq().eq().order().limit() -> await
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: () => Promise.resolve({ data: rows, error: null })
+            })
+          })
+        })
+      })
+    })
+  };
+}
+
+// =============================================================================
+describe('FR-7: buildRequestPayload (worker request shape)', () => {
+  it('carries correlation_id + expects_reply + kind, and NEVER signal_type/intent_action', () => {
+    const p = workerSignal.buildRequestPayload({ correlationId: 'corr-1', body: 'need a decision', senderCallsign: 'Alpha', repo: '/repo' });
+    expect(p.kind).toBe('coordinator_request');
+    expect(p.correlation_id).toBe('corr-1');
+    expect(p.expects_reply).toBe(true);
+    expect(p.sender_callsign).toBe('Alpha');
+    expect(p.body).toBe('need a decision');
+    expect(p.signal_type).toBeUndefined();   // must not be scooped by signal-router
+    expect(p.intent_action).toBeUndefined();  // must not be scooped by intent sweep
+  });
+
+  it('redacts secrets in the request body', () => {
+    const p = workerSignal.buildRequestPayload({ correlationId: 'c', body: 'token ghp_' + 'a'.repeat(36) });
+    expect(p.body).toContain('[REDACTED:GH_TOKEN]');
+  });
+});
+
+describe('FR-7: awaitCoordinatorReply (poll + fail-open)', () => {
+  it('AWAIT-1: resolves with the correlated reply when present', async () => {
+    const replyRow = { id: 'r1', payload: { kind: 'coordinator_reply', reply_to: 'corr-1', body: 'do X' }, sender_session: 'coord', created_at: 'now' };
+    const sb = mockSelectChain([replyRow]);
+    const res = await workerSignal.awaitCoordinatorReply(sb, { sessionId: 'me', correlationId: 'corr-1', timeoutMs: 1000 });
+    expect(res.ok).toBe(true);
+    expect(res.timedOut).toBe(false);
+    expect(res.reply.id).toBe('r1');
+    expect(res.reply.payload.reply_to).toBe('corr-1');
+  });
+
+  it('AWAIT-2: times out cleanly when no reply (no hang)', async () => {
+    const sb = mockSelectChain([]); // never any reply
+    const res = await workerSignal.awaitCoordinatorReply(sb, { sessionId: 'me', correlationId: 'corr-x', timeoutMs: 0, sleep: () => Promise.resolve() });
+    expect(res.ok).toBe(false);
+    expect(res.timedOut).toBe(true);
+    expect(res.reply).toBeNull();
+  });
+
+  it('AWAIT-3: fail-open — DB throw is swallowed and treated as no-reply -> timeout', async () => {
+    const sb = { from: () => { throw new Error('db down'); } };
+    const res = await workerSignal.awaitCoordinatorReply(sb, { sessionId: 'me', correlationId: 'c', timeoutMs: 0, sleep: () => Promise.resolve() });
+    expect(res.timedOut).toBe(true);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('FR-6: shouldSkipCoordinatorReply (inbox skip / P0-1, default-OFF)', () => {
+  afterEach(() => { delete process.env.COORDINATOR_TWOWAY_V2; });
+
+  const replyMsg = { message_type: 'INFO', payload: { kind: 'coordinator_reply', reply_to: 'c' } };
+
+  it('SKIP-1: flag OFF -> never skips (byte-identical inbox behavior)', () => {
+    delete process.env.COORDINATOR_TWOWAY_V2;
+    expect(inbox.shouldSkipCoordinatorReply(replyMsg)).toBe(false);
+  });
+
+  it('SKIP-2: flag ON -> skips a coordinator_reply INFO row', () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    expect(inbox.shouldSkipCoordinatorReply(replyMsg)).toBe(true);
+  });
+
+  it('SKIP-3: flag ON -> does NOT skip ordinary rows (signals, work assignments, null payload)', () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    expect(inbox.shouldSkipCoordinatorReply({ message_type: 'INFO', payload: { signal_type: 'stuck' } })).toBe(false);
+    expect(inbox.shouldSkipCoordinatorReply({ message_type: 'WORK_ASSIGNMENT', payload: { kind: 'coordinator_reply' } })).toBe(false);
+    expect(inbox.shouldSkipCoordinatorReply({ message_type: 'INFO', payload: null })).toBe(false);
+    expect(inbox.shouldSkipCoordinatorReply(null)).toBe(false);
+  });
+});
+
+describe('FR-5: coordinator-reply (buildReplyPayload + sendCoordinatorReply)', () => {
+  it('REPLY-1: buildReplyPayload sets kind=coordinator_reply + reply_to, no signal_type', () => {
+    const p = coordinatorReply.buildReplyPayload({ correlationId: 'corr-9', body: 'approved', coordinatorSession: 'coord-1' });
+    expect(p.kind).toBe('coordinator_reply');
+    expect(p.reply_to).toBe('corr-9');
+    expect(p.sender).toBe('coord-1');
+    expect(p.body).toBe('approved');
+    expect(p.signal_type).toBeUndefined();
+  });
+
+  it('REPLY-2: sendCoordinatorReply inserts an INFO row targeting the worker, never broadcast', async () => {
+    let captured = null;
+    const sb = {
+      from: () => ({
+        insert: (row) => { captured = row; return { select: () => ({ single: () => Promise.resolve({ data: { id: 'reply-1' }, error: null }) }) }; }
+      })
+    };
+    const { data } = await coordinatorReply.sendCoordinatorReply(sb, {
+      coordinatorSession: 'coord-1', workerSession: 'worker-7', correlationId: 'corr-9', body: 'approved'
+    });
+    expect(data.id).toBe('reply-1');
+    expect(captured.message_type).toBe('INFO');         // no new enum value (P0-2)
+    expect(captured.target_session).toBe('worker-7');   // specific worker, not broadcast (P1-3)
+    expect(captured.target_session).not.toBe('broadcast-coordinator');
+    expect(captured.payload.kind).toBe('coordinator_reply');
+    expect(captured.payload.reply_to).toBe('corr-9');
+    expect(captured.payload.signal_type).toBeUndefined();
+    expect(typeof captured.expires_at).toBe('string');
+  });
+});
+
+describe('Round-trip correlation invariant', () => {
+  it('worker request correlation_id matches the reply reply_to the await polls for', async () => {
+    const correlationId = 'rt-correlation-123';
+    const reqPayload = workerSignal.buildRequestPayload({ correlationId, body: 'q' });
+    const replyPayload = coordinatorReply.buildReplyPayload({ correlationId, body: 'a', coordinatorSession: 'c' });
+    expect(replyPayload.reply_to).toBe(reqPayload.correlation_id);
+
+    // The await keys on payload->>reply_to == correlation_id; simulate the matched row.
+    const sb = mockSelectChain([{ id: 'x', payload: replyPayload, sender_session: 'c', created_at: 't' }]);
+    const res = await workerSignal.awaitCoordinatorReply(sb, { sessionId: 'w', correlationId, timeoutMs: 1000 });
+    expect(res.ok).toBe(true);
+    expect(res.reply.payload.reply_to).toBe(correlationId);
+  });
+});

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -16,8 +16,9 @@
 //   M2: slice body to 4096 chars AFTER redaction
 
 require('dotenv').config();
+const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
-const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 
 const SIGNAL_TYPES = ['stuck', 'need-sweep', 'prd-ambiguous', 'gate-bug', 'spec-conflict', 'harness-bug', 'feedback', 'other'];
 const SEVERITIES = ['low', 'medium', 'high', 'critical'];
@@ -235,12 +236,170 @@ async function intentMain(flags, positional) {
   console.log('  target_files:', payload[INTENT_PAYLOAD_KEYS.files].length ? payload[INTENT_PAYLOAD_KEYS.files].join(', ') : '(none)');
 }
 
+// ============================================================================
+// SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-7 — worker request -> reply -> await
+// round-trip. DEFAULT-OFF behind COORDINATOR_TWOWAY_V2 (read via resolve.cjs
+// isTwoWayV2Enabled). A request row carries message_type='INFO' +
+// payload.correlation_id + expects_reply=true (NO signal_type, NO intent_action
+// — so signal-router and the intent sweep never scoop it). The coordinator
+// replies via scripts/coordinator-reply.cjs writing payload.kind=
+// 'coordinator_reply' + reply_to=<correlation_id>; the worker inbox hook SKIPS
+// those (FR-6) so awaitCoordinatorReply owns consumption. Correlation rides in
+// payload JSONB — no migration, no new enum value (P0-2).
+// ============================================================================
+const REQUEST_DEFAULT_TIMEOUT_MS = 30_000;
+const REQUEST_DEFAULT_POLL_MS = 1_000;
+
+// Pure + exported (TS): the exact request payload the worker emits.
+function buildRequestPayload({ correlationId, body, senderCallsign, repo }) {
+  const payload = {
+    kind: 'coordinator_request',
+    correlation_id: correlationId,
+    expects_reply: true,
+    sender_callsign: senderCallsign || null,
+    repo: repo || null
+  };
+  if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);
+  // INVARIANT: no signal_type / no intent_action on request rows.
+  return payload;
+}
+
+// Poll session_coordination for the coordinator's correlated reply. Returns
+// { ok, reply, timedOut }. Read-only + never throws (errors → "no reply yet").
+// Injectable `sleep` keeps it unit-testable without real timers.
+async function awaitCoordinatorReply(supabase, opts = {}) {
+  const {
+    sessionId, correlationId,
+    timeoutMs = REQUEST_DEFAULT_TIMEOUT_MS,
+    pollMs = REQUEST_DEFAULT_POLL_MS,
+    sleep,
+    now
+  } = opts;
+  const clock = typeof now === 'function' ? now : () => Date.now();
+  const doSleep = typeof sleep === 'function' ? sleep : (ms) => new Promise(r => setTimeout(r, ms));
+  const deadline = clock() + timeoutMs;
+  for (;;) {
+    let row = null;
+    try {
+      const { data } = await supabase
+        .from('session_coordination')
+        .select('id, payload, body, sender_session, created_at')
+        .eq('target_session', sessionId)
+        .eq('payload->>reply_to', correlationId)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      row = Array.isArray(data) && data.length ? data[0] : null;
+    } catch { row = null; }
+    if (row) return { ok: true, reply: row, timedOut: false };
+    if (clock() >= deadline) return { ok: false, reply: null, timedOut: true };
+    await doSleep(pollMs);
+  }
+}
+
+// Usage: node scripts/worker-signal.cjs request "<question>" [--timeout <ms>]
+async function requestMain(flags, positional) {
+  if (!isTwoWayV2Enabled()) {
+    console.error('ERROR: request/await round-trip is gated by COORDINATOR_TWOWAY_V2=on (currently OFF — no-op).');
+    process.exit(3);
+  }
+
+  const body = positional.slice(1).join(' ').trim();
+  if (!body) {
+    console.error('ERROR: request requires a "<question>" body.');
+    console.error('Usage: node scripts/worker-signal.cjs request "<question>" [--timeout <ms>]');
+    process.exit(2);
+  }
+
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) {
+    console.error('ERROR: CLAUDE_SESSION_ID env var required (set by SessionStart hook).');
+    process.exit(1);
+  }
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+
+  const coordinatorId = await getActiveCoordinatorId(supabase);
+  if (!coordinatorId) {
+    console.error('ERROR: no live coordinator to request from (none resolved). Try again once a coordinator is active.');
+    process.exit(4);
+  }
+
+  let senderCallsign = null;
+  try {
+    const { data: senderRow } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    senderCallsign = senderRow?.metadata?.fleet_identity?.callsign || null;
+  } catch { /* best-effort */ }
+
+  const correlationId = crypto.randomUUID();
+  const timeoutMs = Number(flags.timeout) > 0 ? Number(flags.timeout) : REQUEST_DEFAULT_TIMEOUT_MS;
+  const payload = buildRequestPayload({ correlationId, body, senderCallsign, repo: process.cwd() });
+  const subject = `[WORKER_REQUEST] ${payload.body.slice(0, 80)}`;
+  // Request expiry guards the coordinator's reply window (request + reply margin).
+  const expiresAt = new Date(Date.now() + timeoutMs + 5 * 60_000).toISOString();
+
+  const { error: insErr } = await supabase
+    .from('session_coordination')
+    .insert({
+      sender_session: sessionId,
+      sender_type: 'worker',
+      target_session: coordinatorId,
+      message_type: 'INFO',
+      subject,
+      body: payload.body,
+      payload,
+      expires_at: expiresAt
+    });
+  if (insErr) {
+    console.error('ERROR: failed to insert request:', insErr.message);
+    process.exit(1);
+  }
+
+  console.log('✓ Request sent; awaiting coordinator reply');
+  console.log('  correlation_id:', correlationId);
+  console.log('  coordinator:', coordinatorId);
+  console.log('  timeout_ms:', timeoutMs);
+
+  const result = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs });
+  if (result.timedOut) {
+    console.log('⌛ No reply within timeout. Reply (if any) will arrive later as a coordinator_reply row.');
+    process.exit(0);
+  }
+
+  // Consume: mark the reply read so it does not linger (the FR-6 inbox skip left it for us).
+  try {
+    await supabase
+      .from('session_coordination')
+      .update({ read_at: new Date().toISOString(), acknowledged_at: new Date().toISOString() })
+      .eq('id', result.reply.id);
+  } catch { /* best-effort */ }
+
+  console.log('✓ Reply received');
+  console.log('  from:', result.reply.sender_session);
+  console.log('  reply:', (result.reply.payload && result.reply.payload.body) || result.reply.body || '(empty)');
+}
+
 async function main() {
   const { flags, positional } = parseArgs(process.argv);
 
   // FR-1: route the `intent` subcommand before the legacy signal path.
   if (positional[0] === 'intent') {
     return intentMain(flags, positional);
+  }
+
+  // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-7: route the `request` subcommand
+  // (request -> await coordinator reply) before the legacy signal path.
+  if (positional[0] === 'request') {
+    return requestMain(flags, positional);
   }
 
   if (flags.help || positional.length < 2) {
@@ -351,7 +510,9 @@ async function main() {
 module.exports = {
   redact, parseArgs, REDACTION_PATTERNS, SIGNAL_TYPES, SEVERITIES, BODY_HARD_CAP,
   // FR-1 (SD-FDBK-INFRA-CROSS-SESSION-CONFLICTION-001)
-  INTENT_ACTIONS, INTENT_PAYLOAD_KEYS, buildIntentPayload, DECONFLICTION_ENABLED
+  INTENT_ACTIONS, INTENT_PAYLOAD_KEYS, buildIntentPayload, DECONFLICTION_ENABLED,
+  // FR-7 (SD-LEO-INFRA-COMPLETE-TWO-WAY-001) — request/await round-trip
+  buildRequestPayload, awaitCoordinatorReply, REQUEST_DEFAULT_TIMEOUT_MS, REQUEST_DEFAULT_POLL_MS
 };
 
 if (require.main === module) {


### PR DESCRIPTION
Completes the two-way coordinator↔worker channel begun by SD-LEO-INFRA-TWO-WAY-COORDINATOR-001. **All new behavior is DEFAULT-OFF behind `COORDINATOR_TWOWAY_V2`; with the flag unset, resolution and signalling are byte-for-byte identical to current main.** No DB migration; `message_type` stays `INFO` (correlation rides in `payload` JSONB).

## Deliverables
- **Authoritative single-coordinator resolution** (`lib/coordinator/resolve.cjs`): `pickCanonicalCoordinator()` deterministic single-winner election `(coordinator_since DESC, NULLS LAST, session_id ASC)`; `electCoordinatorFromDb()` fail-open.
- **Machine-canonical pointer**: when the flag is ON, the DB is authoritative and `.claude/active-coordinator.json` is demoted to a cache; fail-open to the legacy file-first path.
- **discovery→reply→await round-trip**: worker `request` subcommand + `awaitCoordinatorReply()` (`scripts/worker-signal.cjs`), inbox reply-skip so the await owns consumption (`scripts/hooks/coordination-inbox.cjs`, P0-1 fix), and a coordinator `reply` verb (`scripts/coordinator-reply.cjs`) targeting the specific worker.

## Safety
- Flag read inside function bodies only; **zero DB calls at module import** (GG-8); exports additive (GG-3); all new reads fail-open (GG-5); election is read-only (never mutates `is_coordinator`, GG-6).
- Coordinator (session 5237807d) signalled pre-merge per GG-7. Flag-OFF parity + zero-DB-at-import verified by the EXEC testing-agent.

## Tests
39 passing (28 resolve incl. election/NULLS-last/tiebreak/zero-DB-import/flag-OFF characterization; 11 round-trip). 13 pre-existing resolve tests unweakened. Both CLIs refuse with exit-3 when the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
