### PR TITLE
feat(SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001): coordination anomaly detectors (epic #4)

### DIFF
--- a/database/migrations/20260605_create_coordination_events.sql
+++ b/database/migrations/20260605_create_coordination_events.sql
@@ -1,0 +1,40 @@
+-- SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001 (epic #4)
+-- Coordination Observability: durable, structured store for fleet-coordination
+-- anomaly events emitted by the read-only detectors (lib/coordinator/detectors.js).
+--
+-- ADDITIVE ONLY. No existing table is altered. The detectors that write here are
+-- DEFAULT-OFF behind COORD_DETECTORS_V2, so this table stays empty until the flag
+-- is enabled. Consumed later by epic #3 (the self-improvement loop) and surfaced
+-- by fleet-dashboard. Idempotent (IF NOT EXISTS) so re-application is safe.
+--
+-- session_id / sd_key are plain text (NOT foreign keys): events are an immutable
+-- observation log that must survive the deletion/rotation of the sessions or SDs
+-- they reference.
+
+CREATE TABLE IF NOT EXISTS coordination_events (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type       text        NOT NULL,
+  detected_at      timestamptz NOT NULL DEFAULT now(),
+  severity         text        NOT NULL DEFAULT 'info'
+                     CHECK (severity IN ('info', 'warning', 'critical')),
+  session_id       text,
+  sd_key           text,
+  detector_version text,
+  payload          jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Most reads are "recent events of type X" and "recent events by severity".
+CREATE INDEX IF NOT EXISTS idx_coord_events_type_detected
+  ON coordination_events (event_type, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_coord_events_severity_detected
+  ON coordination_events (severity, detected_at DESC);
+
+COMMENT ON TABLE coordination_events IS
+  'epic #4 (SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001): structured fleet-coordination anomaly events from the read-only detectors; written only when COORD_DETECTORS_V2 is enabled.';
+COMMENT ON COLUMN coordination_events.event_type IS
+  'SPLIT_BRAIN | THUNDERING_HERD | REPLY_STARVATION | STUCK_WORKER | CLAIM_HALF_WRITE';
+COMMENT ON COLUMN coordination_events.detector_version IS
+  'Detector bundle version that emitted the row (e.g. COORD_DETECTORS_V2).';
+COMMENT ON COLUMN coordination_events.payload IS
+  'Detector {reason, evidence} — the matched predicate output.';

--- a/database/migrations/20260605_create_coordination_events.sql
+++ b/database/migrations/20260605_create_coordination_events.sql
@@ -1,6 +1,6 @@
 -- SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001 (epic #4)
 -- Coordination Observability: durable, structured store for fleet-coordination
--- anomaly events emitted by the read-only detectors (lib/coordinator/detectors.js).
+-- anomaly events emitted by the read-only detectors (lib/coordinator/detectors.cjs).
 --
 -- ADDITIVE ONLY. No existing table is altered. The detectors that write here are
 -- DEFAULT-OFF behind COORD_DETECTORS_V2, so this table stays empty until the flag

--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -1,0 +1,213 @@
+/**
+ * Coordination Observability — flag gate, read-only data gatherer, and
+ * fail-open event writer (epic #4).
+ *
+ * SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001
+ *
+ * CommonJS (.cjs) — require()-able by scripts/stale-session-sweep.cjs. The
+ * detectors (detectors.cjs) are pure; this module decides whether the feature
+ * is enabled, gathers the (READ-ONLY) fleet-state inputs, and persists matches
+ * to coordination_events. Persisting is FAIL-OPEN end to end. Default-OFF flag
+ * mirrors FLEET_MC_SWEEP_GATE (stale-session-sweep.cjs:41).
+ *
+ * @module lib/coordinator/coordination-events
+ */
+
+'use strict';
+
+const { runDetectors } = require('./detectors.cjs');
+
+/** detector_version stamped on every emitted coordination_events row. */
+const DETECTOR_VERSION = 'COORD_DETECTORS_V2';
+
+/** Holding statuses that mean a session is actively claiming work. */
+const HOLDING_STATUSES = new Set(['active', 'idle']);
+
+function coordDetectorsEnabled(env) {
+  env = env || process.env;
+  return String(env.COORD_DETECTORS_V2 ?? 'false').toLowerCase() !== 'false';
+}
+
+function resolveThresholds(env) {
+  env = env || process.env;
+  return {
+    coordinatorFreshMs: (Number(env.COORD_COORDINATOR_FRESH_SEC) || 600) * 1000,
+    replyStarvationMs: (Number(env.COORD_REPLY_STARVATION_T_SEC) || 1800) * 1000,
+    stuckWorkerMs: (Number(env.COORD_STUCK_WORKER_X_MIN) || 60) * 60 * 1000,
+  };
+}
+
+function tsMs(ts) {
+  if (!ts) return 0;
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(String(ts));
+  const n = new Date(hasTZ ? ts : ts + 'Z').getTime();
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Build the detector input bundle from the live DB. READ-ONLY (selects only).
+ * Best-effort / fail-soft: a failed sub-query degrades that one input to
+ * empty/0 rather than throwing. Never writes anything.
+ *
+ * @param {object} supabase - Supabase service client
+ * @param {object} [opts] - { now, coordinatorFreshMs }
+ * @returns {Promise<object>} bundle consumed by runDetectors
+ */
+async function gatherDetectorInputs(supabase, opts) {
+  opts = opts || {};
+  const now = opts.now ?? Date.now();
+  const freshMs = opts.coordinatorFreshMs ?? 600000;
+
+  const bundle = {
+    coordinatorCount: 0, coordinators: [],
+    idleWorkers: 0, unclaimedItems: 0,
+    signals: [], claims: [], sessions: [], sdClaims: [],
+  };
+
+  // 1) claude_sessions — derive coordinators, idle workers, sessions, claims.
+  let sessions = [];
+  try {
+    const { data } = await supabase
+      .from('claude_sessions')
+      .select('session_id, sd_key, status, heartbeat_at, metadata, current_phase');
+    sessions = data || [];
+  } catch (_) { sessions = []; }
+
+  const fresh = (s) => (now - tsMs(s.heartbeat_at)) <= freshMs;
+  const coordinators = sessions.filter((s) => s.metadata && String(s.metadata.is_coordinator) === 'true' && fresh(s));
+  bundle.coordinators = coordinators;
+  bundle.coordinatorCount = coordinators.length;
+  bundle.idleWorkers = sessions.filter((s) => !s.sd_key && HOLDING_STATUSES.has(s.status) && fresh(s)).length;
+  bundle.sessions = sessions.filter((s) => HOLDING_STATUSES.has(s.status)).map((s) => ({ session_id: s.session_id, sd_key: s.sd_key }));
+
+  // 2) strategic_directives_v2 — sdClaims, unclaimed SDs, and claim phase/updated_at.
+  let sds = [];
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, status, current_phase, updated_at, is_working_on')
+      .not('status', 'in', '(completed,cancelled,archived,superseded,deferred)');
+    sds = data || [];
+  } catch (_) { sds = []; }
+
+  const sdByKey = new Map(sds.map((s) => [s.sd_key, s]));
+  bundle.sdClaims = sds.filter((s) => s.claiming_session_id).map((s) => ({ sd_key: s.sd_key, claiming_session_id: s.claiming_session_id }));
+  let unclaimedSds = sds.filter((s) => !s.claiming_session_id && !s.is_working_on && s.status !== 'blocked').length;
+
+  // claims = sessions holding an sd_key, enriched with the SD's phase + updated_at.
+  bundle.claims = sessions
+    .filter((s) => s.sd_key && HOLDING_STATUSES.has(s.status))
+    .map((s) => {
+      const sd = sdByKey.get(s.sd_key);
+      return {
+        session_id: s.session_id,
+        sd_key: s.sd_key,
+        current_phase: (sd && sd.current_phase) || s.current_phase || null,
+        heartbeat_at: s.heartbeat_at,
+        sd_updated_at: sd ? sd.updated_at : null,
+      };
+    });
+
+  // 3) quick_fixes — unclaimed QFs add to the unclaimed-item supply.
+  let unclaimedQfs = 0;
+  try {
+    const { data } = await supabase
+      .from('quick_fixes')
+      .select('id, claiming_session_id, status')
+      .is('claiming_session_id', null)
+      .in('status', ['open', 'in_progress']);
+    unclaimedQfs = (data || []).length;
+  } catch (_) { unclaimedQfs = 0; }
+  bundle.unclaimedItems = unclaimedSds + unclaimedQfs;
+
+  // 4) session_coordination — recent worker signals for REPLY_STARVATION.
+  try {
+    const sinceIso = new Date(now - 24 * 3600 * 1000).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, sender_type, message_type, acknowledged_at, read_at, payload, created_at')
+      .gte('created_at', sinceIso)
+      .order('created_at', { ascending: false })
+      .limit(500);
+    bundle.signals = data || [];
+  } catch (_) { bundle.signals = []; }
+
+  return bundle;
+}
+
+/**
+ * Insert one coordination_events row. FAIL-OPEN: never throws.
+ * @param {object} supabase
+ * @param {{ event_type, severity, session_id?, sd_key?, payload? }} event
+ * @returns {Promise<{ ok: boolean, id?: string, error?: string }>}
+ */
+async function logCoordinationEvent(supabase, event) {
+  try {
+    const row = {
+      event_type: event.event_type,
+      severity: event.severity || 'info',
+      session_id: event.session_id ?? null,
+      sd_key: event.sd_key ?? null,
+      detector_version: DETECTOR_VERSION,
+      payload: event.payload ?? {},
+    };
+    const { data, error } = await supabase.from('coordination_events').insert(row).select('id').single();
+    if (error) {
+      console.warn(`   ⚠️  [COORD_EVENT_WRITE_FAILED] ${event.event_type}: ${error.message} (non-fatal)`);
+      return { ok: false, error: error.message };
+    }
+    return { ok: true, id: data.id };
+  } catch (e) {
+    console.warn(`   ⚠️  [COORD_EVENT_WRITE_THREW] ${event && event.event_type}: ${(e && e.message) || e} (non-fatal)`);
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * Run the detectors over an injected bundle and (flag on) log each match.
+ * Returns the structured matches so the caller can also print visible flags.
+ * FAIL-OPEN; OFF flag → [] with ZERO writes.
+ * @param {object} supabase
+ * @param {object} data - bundle from gatherDetectorInputs (or a test fixture)
+ * @param {object} [opts] - { env, now, priorPhases }
+ * @returns {Promise<Array<object>>}
+ */
+async function runAndLogDetectors(supabase, data, opts) {
+  opts = opts || {};
+  const env = opts.env || process.env;
+  if (!coordDetectorsEnabled(env)) return [];
+  const thresholds = resolveThresholds(env);
+  let matches = [];
+  try {
+    matches = runDetectors(data, {
+      now: opts.now,
+      replyStarvationMs: thresholds.replyStarvationMs,
+      stuckWorkerMs: thresholds.stuckWorkerMs,
+      priorPhases: opts.priorPhases,
+    });
+  } catch (e) {
+    console.warn(`   ⚠️  [COORD_DETECTORS_THREW] ${(e && e.message) || e} (non-fatal)`);
+    return [];
+  }
+  const out = [];
+  for (const m of matches) {
+    const res = await logCoordinationEvent(supabase, {
+      event_type: m.event_type,
+      severity: m.severity,
+      session_id: (data && data.contextSessionId) ?? null,
+      sd_key: (data && data.contextSdKey) ?? null,
+      payload: { reason: m.reason, evidence: m.evidence },
+    });
+    out.push(Object.assign({}, m, { logged: res.ok }));
+  }
+  return out;
+}
+
+module.exports = {
+  DETECTOR_VERSION,
+  coordDetectorsEnabled,
+  resolveThresholds,
+  gatherDetectorInputs,
+  logCoordinationEvent,
+  runAndLogDetectors,
+};

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -1,0 +1,222 @@
+/**
+ * Coordination Observability — pure anomaly-detection primitives (epic #4).
+ *
+ * SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001
+ *
+ * Each detector is a PURE function over INJECTED data (the sweep performs the
+ * live DB I/O; fleet-dashboard printQA maps its existing aggregates into the
+ * same predicate inputs — single source, not a third parallel detection path).
+ * Every detector returns the same shape:
+ *   { matched: boolean, reason: string, evidence: object }
+ *
+ * CommonJS (.cjs) to match the lib/coordinator convention (resolve.cjs,
+ * signal-router.cjs) and be require()-able by scripts/stale-session-sweep.cjs.
+ * Mirrors the doctrine of lib/worktree-reaper/detectors.js. Strictly READ-ONLY:
+ * nothing here writes any claim state — no collision with the atomic work-leasing
+ * machinery (epic #2). Events are persisted by lib/coordinator/coordination-events.cjs.
+ *
+ * Schema notes from the prospective testing-agent (893f6eeb):
+ *  - SPLIT_BRAIN counts sessions whose metadata.is_coordinator==='true' AND fresh
+ *    (reuse resolve.cjs queryDbForCoordinator upstream). Distinct from
+ *    detectIdentityCollisions (multiple PIDs sharing one session_id).
+ *  - STUCK_WORKER must NOT use claude_sessions.last_progress_at (NULL ~99.98%);
+ *    it keys off heartbeat/SD-updated staleness + current_phase. Distinct from
+ *    status-stuck STUCK_100/STUCK_APPROVAL.
+ *  - REPLY_STARVATION: no signal_type column; a worker ask is sender_type==='worker';
+ *    "answered" = acknowledged_at set OR payload.routed_to_feedback_id set.
+ *
+ * @module lib/coordinator/detectors
+ */
+
+'use strict';
+
+/** Default freshness window (ms) for "is this session a live coordinator". */
+const DEFAULT_COORDINATOR_FRESH_MS = 10 * 60 * 1000;
+/** Default REPLY_STARVATION threshold (ms) — unanswered worker signal age. */
+const DEFAULT_REPLY_STARVATION_MS = 30 * 60 * 1000;
+/** Default STUCK_WORKER threshold (ms) — no progress on a claimed SD. */
+const DEFAULT_STUCK_WORKER_MS = 60 * 60 * 1000;
+
+function toMs(ts) {
+  if (!ts) return 0;
+  if (ts instanceof Date) return ts.getTime();
+  // Treat naive (no-TZ) timestamps as UTC (PostgREST returns naive strings).
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(String(ts));
+  const d = new Date(hasTZ ? ts : ts + 'Z');
+  const n = d.getTime();
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * SPLIT_BRAIN — more than one live coordinator.
+ * @param {{ coordinatorCount: number, coordinators?: Array<object> }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectSplitBrain(data) {
+  const count = Number((data && data.coordinatorCount) ?? 0);
+  if (count > 1) {
+    return {
+      matched: true,
+      reason: 'multiple_live_coordinators',
+      evidence: {
+        coordinator_count: count,
+        sessions: ((data && data.coordinators) || []).map((c) => c.session_id).filter(Boolean).slice(0, 10),
+      },
+    };
+  }
+  return { matched: false, reason: 'single_or_no_coordinator', evidence: { coordinator_count: count } };
+}
+
+/**
+ * THUNDERING_HERD — more idle workers than there is distinct unclaimed work.
+ * @param {{ idleWorkers: number, unclaimedItems: number }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectThunderingHerd(data) {
+  const idle = Number((data && data.idleWorkers) ?? 0);
+  const unclaimed = Number((data && data.unclaimedItems) ?? 0);
+  if (idle > 0 && idle > unclaimed) {
+    return {
+      matched: true,
+      reason: 'idle_workers_exceed_unclaimed_items',
+      evidence: { idle_workers: idle, unclaimed_items: unclaimed, surplus: idle - unclaimed },
+    };
+  }
+  return { matched: false, reason: 'workers_within_supply', evidence: { idle_workers: idle, unclaimed_items: unclaimed } };
+}
+
+/**
+ * REPLY_STARVATION — a worker signal left unanswered beyond threshold T.
+ * "answered" = acknowledged_at set OR payload.routed_to_feedback_id set.
+ * @param {{ signals: Array<object>, now?: number, thresholdMs?: number }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectReplyStarvation(data) {
+  const now = (data && data.now) ?? Date.now();
+  const thresholdMs = (data && data.thresholdMs) ?? DEFAULT_REPLY_STARVATION_MS;
+  const starved = [];
+  for (const sig of ((data && data.signals) || [])) {
+    if ((sig && sig.sender_type) !== 'worker') continue;
+    const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id);
+    if (answered) continue;
+    if (sig.read_at) continue; // read counts as a soft answer here (no separate reply table)
+    const ageMs = now - toMs(sig.created_at);
+    if (ageMs > thresholdMs) {
+      starved.push({ id: sig.id, sender: sig.sender_session, age_ms: ageMs });
+    }
+  }
+  if (starved.length > 0) {
+    return {
+      matched: true,
+      reason: 'worker_signals_unanswered_past_threshold',
+      evidence: { starved_count: starved.length, threshold_ms: thresholdMs, samples: starved.slice(0, 10) },
+    };
+  }
+  return { matched: false, reason: 'no_starved_signals', evidence: { threshold_ms: thresholdMs } };
+}
+
+/**
+ * STUCK_WORKER — a claimed SD shows no progress for > threshold.
+ * Progress proxy: max(session heartbeat, SD updated_at) staleness. If a prior
+ * snapshot is supplied, ALSO require current_phase unchanged since then.
+ * Avoids last_progress_at (NULL ~99.98% — testing-agent HB-1).
+ * @param {{ claims: Array<object>, now?: number, thresholdMs?: number, priorPhases?: object }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectStuckWorker(data) {
+  const now = (data && data.now) ?? Date.now();
+  const thresholdMs = (data && data.thresholdMs) ?? DEFAULT_STUCK_WORKER_MS;
+  const priorPhases = (data && data.priorPhases) || null;
+  const stuck = [];
+  for (const c of ((data && data.claims) || [])) {
+    if (!c || !c.sd_key) continue;
+    const progressMs = Math.max(toMs(c.heartbeat_at), toMs(c.sd_updated_at));
+    if (progressMs === 0) continue; // no usable timing signal → emit nothing (null-tolerant)
+    const ageMs = now - progressMs;
+    if (ageMs <= thresholdMs) continue;
+    if (priorPhases && c.sd_key in priorPhases && priorPhases[c.sd_key] !== c.current_phase) continue;
+    stuck.push({ sd_key: c.sd_key, session_id: c.session_id, phase: c.current_phase || null, age_ms: ageMs });
+  }
+  if (stuck.length > 0) {
+    return {
+      matched: true,
+      reason: 'claimed_sd_no_progress_past_threshold',
+      evidence: { stuck_count: stuck.length, threshold_ms: thresholdMs, samples: stuck.slice(0, 10) },
+    };
+  }
+  return { matched: false, reason: 'all_claims_progressing', evidence: { threshold_ms: thresholdMs } };
+}
+
+/**
+ * CLAIM_HALF_WRITE — bilateral mismatch between a session's sd_key and the
+ * SD-row's claiming_session_id. OBSERVE + LOG only (the sweep already remediates
+ * earlier in main(); by the post-sweep hook only RESIDUAL mismatches remain —
+ * testing-agent C-2). Read-only; never repairs.
+ * @param {{ sessions: Array<object>, sdClaims: Array<object> }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectClaimHalfWrite(data) {
+  const sessions = (data && data.sessions) || [];
+  const sdClaims = (data && data.sdClaims) || [];
+  const sdByKey = new Map(sdClaims.map((s) => [s.sd_key, s]));
+  const sessionBySd = new Map(sessions.filter((s) => s.sd_key).map((s) => [s.sd_key, s]));
+  const mismatches = [];
+
+  for (const sess of sessions) {
+    if (!sess || !sess.sd_key) continue;
+    const sd = sdByKey.get(sess.sd_key);
+    const claimingId = sd ? sd.claiming_session_id : null;
+    if (claimingId !== sess.session_id) {
+      mismatches.push({ kind: 'session_without_sd_claim', session_id: sess.session_id, sd_key: sess.sd_key, sd_claiming_session_id: claimingId ?? null });
+    }
+  }
+  for (const sd of sdClaims) {
+    if (!sd || !sd.claiming_session_id) continue;
+    const sess = sessionBySd.get(sd.sd_key);
+    if (!sess || sess.session_id !== sd.claiming_session_id) {
+      mismatches.push({ kind: 'sd_claim_without_session', sd_key: sd.sd_key, claiming_session_id: sd.claiming_session_id });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    return {
+      matched: true,
+      reason: 'residual_claim_half_write',
+      evidence: { mismatch_count: mismatches.length, samples: mismatches.slice(0, 10) },
+    };
+  }
+  return { matched: false, reason: 'claims_consistent', evidence: {} };
+}
+
+/**
+ * Run all five detectors over an injected data bundle. PURE — no I/O.
+ * @param {object} data
+ * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases }
+ * @returns {Array<{ event_type: string, severity: string, reason: string, evidence: object }>}
+ */
+function runDetectors(data, opts) {
+  opts = opts || {};
+  const now = opts.now ?? Date.now();
+  const results = [
+    { event_type: 'SPLIT_BRAIN', severity: 'critical', res: detectSplitBrain(data) },
+    { event_type: 'THUNDERING_HERD', severity: 'warning', res: detectThunderingHerd(data) },
+    { event_type: 'REPLY_STARVATION', severity: 'warning', res: detectReplyStarvation({ signals: data && data.signals, now, thresholdMs: opts.replyStarvationMs }) },
+    { event_type: 'STUCK_WORKER', severity: 'warning', res: detectStuckWorker({ claims: data && data.claims, now, thresholdMs: opts.stuckWorkerMs, priorPhases: opts.priorPhases }) },
+    { event_type: 'CLAIM_HALF_WRITE', severity: 'info', res: detectClaimHalfWrite(data) },
+  ];
+  return results
+    .filter((r) => r.res.matched)
+    .map((r) => ({ event_type: r.event_type, severity: r.severity, reason: r.res.reason, evidence: r.res.evidence }));
+}
+
+module.exports = {
+  DEFAULT_COORDINATOR_FRESH_MS,
+  DEFAULT_REPLY_STARVATION_MS,
+  DEFAULT_STUCK_WORKER_MS,
+  detectSplitBrain,
+  detectThunderingHerd,
+  detectReplyStarvation,
+  detectStuckWorker,
+  detectClaimHalfWrite,
+  runDetectors,
+};

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1701,6 +1701,25 @@ async function main() {
     console.log('SIGNAL ROUTER: ' + (routerErr && routerErr.message ? routerErr.message : 'unknown'));
   }
 
+  // SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001 (epic #4) — coordination
+  // anomaly detectors. DEFAULT-OFF behind COORD_DETECTORS_V2. READ-ONLY over claim
+  // state + fail-open: a failure here never aborts the sweep. Logs a structured
+  // coordination_events row per match (consumed later by epic #3). Fully inert
+  // (zero reads/writes) when the flag is off.
+  try {
+    const coordEvents = require('../lib/coordinator/coordination-events.cjs');
+    if (coordEvents.coordDetectorsEnabled()) {
+      const coordInputs = await coordEvents.gatherDetectorInputs(supabase, {});
+      const coordMatches = await coordEvents.runAndLogDetectors(supabase, coordInputs);
+      for (const m of coordMatches) {
+        console.log('  COORD_DETECTOR: ' + m.event_type + ' [' + m.severity + '] ' + m.reason + (m.logged ? '' : ' (event-log-failed)'));
+      }
+      if (coordMatches.length > 0) console.log('COORD_DETECTORS: ' + coordMatches.length + ' anomaly event(s) flagged');
+    }
+  } catch (coordDetErr) {
+    console.log('COORD_DETECTORS: ' + (coordDetErr && coordDetErr.message ? coordDetErr.message : 'unknown'));
+  }
+
   // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-4d — SIGNAL_RESOLVED notification.
   // For each contributing signal where payload.routed_to_sd_key is non-null AND the SD
   // status is 'completed' AND payload.notification_sent is not yet true, look up

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for epic #4 coordination detectors.
+ * SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001
+ *
+ * Pure predicates over injected fixtures — no live DB. Each detector has a
+ * positive and a negative case; the writer is tested fail-open.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  detectSplitBrain,
+  detectThunderingHerd,
+  detectReplyStarvation,
+  detectStuckWorker,
+  detectClaimHalfWrite,
+  runDetectors,
+} from '../../../lib/coordinator/detectors.cjs';
+import {
+  coordDetectorsEnabled,
+  resolveThresholds,
+  logCoordinationEvent,
+  runAndLogDetectors,
+  DETECTOR_VERSION,
+} from '../../../lib/coordinator/coordination-events.cjs';
+
+const NOW = 1_750_000_000_000; // fixed clock
+const minsAgo = (m) => new Date(NOW - m * 60_000).toISOString();
+
+describe('detectSplitBrain', () => {
+  it('matches when more than one fresh coordinator', () => {
+    const r = detectSplitBrain({ coordinatorCount: 2, coordinators: [{ session_id: 'a' }, { session_id: 'b' }] });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.coordinator_count).toBe(2);
+    expect(r.evidence.sessions).toEqual(['a', 'b']);
+  });
+  it('does not match with a single coordinator', () => {
+    expect(detectSplitBrain({ coordinatorCount: 1 }).matched).toBe(false);
+    expect(detectSplitBrain({ coordinatorCount: 0 }).matched).toBe(false);
+  });
+});
+
+describe('detectThunderingHerd', () => {
+  it('matches when idle workers exceed unclaimed items', () => {
+    const r = detectThunderingHerd({ idleWorkers: 5, unclaimedItems: 2 });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.surplus).toBe(3);
+  });
+  it('does not match when work supply covers idle workers', () => {
+    expect(detectThunderingHerd({ idleWorkers: 2, unclaimedItems: 5 }).matched).toBe(false);
+    expect(detectThunderingHerd({ idleWorkers: 0, unclaimedItems: 0 }).matched).toBe(false);
+  });
+});
+
+describe('detectReplyStarvation', () => {
+  it('matches an old unanswered worker signal', () => {
+    const signals = [{ id: '1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} }];
+    const r = detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.starved_count).toBe(1);
+  });
+  it('does not match answered / read / non-worker / recent signals', () => {
+    const base = { sender_type: 'worker', sender_session: 'w', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const signals = [
+      { ...base, id: 'a', acknowledged_at: minsAgo(40) },                 // acknowledged
+      { ...base, id: 'b', payload: { routed_to_feedback_id: 'fb-1' } },   // routed (stampRouted)
+      { ...base, id: 'c', read_at: minsAgo(40) },                          // read
+      { ...base, id: 'd', sender_type: 'coordinator' },                   // not a worker ask
+      { ...base, id: 'e', created_at: minsAgo(5) },                        // too recent
+    ];
+    expect(detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
+  });
+});
+
+describe('detectStuckWorker', () => {
+  it('matches a claimed SD with no progress past threshold', () => {
+    const claims = [{ session_id: 's1', sd_key: 'SD-X', current_phase: 'EXEC', heartbeat_at: minsAgo(120), sd_updated_at: minsAgo(130) }];
+    const r = detectStuckWorker({ claims, now: NOW, thresholdMs: 60 * 60_000 });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.samples[0].sd_key).toBe('SD-X');
+  });
+  it('does not match fresh, null-timing, or phase-advanced claims', () => {
+    const fresh = [{ session_id: 's', sd_key: 'SD-A', current_phase: 'EXEC', heartbeat_at: minsAgo(5), sd_updated_at: minsAgo(5) }];
+    expect(detectStuckWorker({ claims: fresh, now: NOW, thresholdMs: 60 * 60_000 }).matched).toBe(false);
+    // null timing → emit nothing (null-tolerant, HB-1)
+    const nullTiming = [{ session_id: 's', sd_key: 'SD-B', current_phase: 'EXEC', heartbeat_at: null, sd_updated_at: null }];
+    expect(detectStuckWorker({ claims: nullTiming, now: NOW, thresholdMs: 60 * 60_000 }).matched).toBe(false);
+    // stale but phase advanced since prior snapshot → not stuck
+    const advanced = [{ session_id: 's', sd_key: 'SD-C', current_phase: 'PLAN', heartbeat_at: minsAgo(120), sd_updated_at: minsAgo(120) }];
+    expect(detectStuckWorker({ claims: advanced, now: NOW, thresholdMs: 60 * 60_000, priorPhases: { 'SD-C': 'LEAD' } }).matched).toBe(false);
+  });
+});
+
+describe('detectClaimHalfWrite', () => {
+  it('matches a bilateral mismatch (session holds sd_key but SD row claims nobody)', () => {
+    const sessions = [{ session_id: 's1', sd_key: 'SD-X' }];
+    const sdClaims = [{ sd_key: 'SD-X', claiming_session_id: null }];
+    const r = detectClaimHalfWrite({ sessions, sdClaims });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.mismatch_count).toBeGreaterThan(0);
+  });
+  it('does not match a consistent claim', () => {
+    const sessions = [{ session_id: 's1', sd_key: 'SD-X' }];
+    const sdClaims = [{ sd_key: 'SD-X', claiming_session_id: 's1' }];
+    expect(detectClaimHalfWrite({ sessions, sdClaims }).matched).toBe(false);
+  });
+});
+
+describe('runDetectors', () => {
+  it('returns only matched detectors with event_type + severity', () => {
+    const data = {
+      coordinatorCount: 2,
+      idleWorkers: 0, unclaimedItems: 0,
+      signals: [], claims: [], sessions: [], sdClaims: [],
+    };
+    const matches = runDetectors(data, { now: NOW });
+    expect(matches.map((m) => m.event_type)).toEqual(['SPLIT_BRAIN']);
+    expect(matches[0].severity).toBe('critical');
+  });
+});
+
+describe('coordDetectorsEnabled', () => {
+  it('defaults OFF and turns on only for an explicit truthy flag', () => {
+    expect(coordDetectorsEnabled({})).toBe(false);
+    expect(coordDetectorsEnabled({ COORD_DETECTORS_V2: 'false' })).toBe(false);
+    expect(coordDetectorsEnabled({ COORD_DETECTORS_V2: 'true' })).toBe(true);
+  });
+  it('resolveThresholds honors env overrides with safe defaults', () => {
+    expect(resolveThresholds({}).replyStarvationMs).toBe(1800 * 1000);
+    expect(resolveThresholds({ COORD_REPLY_STARVATION_T_SEC: '60' }).replyStarvationMs).toBe(60 * 1000);
+  });
+});
+
+describe('runAndLogDetectors (flag gate + fail-open writer)', () => {
+  it('does nothing and reads nothing when the flag is OFF', async () => {
+    const supabase = { from: vi.fn(() => { throw new Error('should not be called'); }) };
+    const out = await runAndLogDetectors(supabase, { coordinatorCount: 5 }, { env: {}, now: NOW });
+    expect(out).toEqual([]);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+  it('logs an event per match when the flag is ON', async () => {
+    const inserted = [];
+    const supabase = {
+      from: () => ({ insert: (row) => { inserted.push(row); return { select: () => ({ single: async () => ({ data: { id: 'evt-1' }, error: null }) }) }; } }),
+    };
+    const out = await runAndLogDetectors(supabase, { coordinatorCount: 2 }, { env: { COORD_DETECTORS_V2: 'true' }, now: NOW });
+    expect(out).toHaveLength(1);
+    expect(out[0].event_type).toBe('SPLIT_BRAIN');
+    expect(out[0].logged).toBe(true);
+    expect(inserted[0].detector_version).toBe(DETECTOR_VERSION);
+  });
+  it('is FAIL-OPEN: a throwing insert never escapes', async () => {
+    const supabase = { from: () => ({ insert: () => ({ select: () => ({ single: async () => { throw new Error('db down'); } }) }) }) };
+    const out = await runAndLogDetectors(supabase, { coordinatorCount: 2 }, { env: { COORD_DETECTORS_V2: 'true' }, now: NOW });
+    expect(out).toHaveLength(1);
+    expect(out[0].logged).toBe(false); // logged failed, but no throw
+  });
+  it('logCoordinationEvent returns {ok:false} on error rather than throwing', async () => {
+    const supabase = { from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: null, error: { message: 'boom' } }) }) }) }) };
+    const res = await logCoordinationEvent(supabase, { event_type: 'SPLIT_BRAIN', severity: 'critical' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('boom');
+  });
+});


### PR DESCRIPTION
## Summary
Closes **SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001** ("epic #4", coordinator-assigned). Adds five READ-ONLY fleet-coordination anomaly detectors that each raise a visible flag in the sweep AND log a structured row to a new `coordination_events` table. Codifies the L1–L8 manual coordination vigilance into automated detection; feeds the future epic #3 self-improvement loop. Ships **DEFAULT-OFF** behind `COORD_DETECTORS_V2`, **fail-open**, strictly **read-only** over claim machinery (no collision with epic #2 atomic work-leasing).

## Changes (5 files)
- **`lib/coordinator/detectors.cjs`** — 5 pure predicates over injected data: `SPLIT_BRAIN` (>1 fresh coordinator), `THUNDERING_HERD` (idle workers > unclaimed items), `REPLY_STARVATION` (unanswered worker signal > T), `STUCK_WORKER` (claimed SD no progress > X), `CLAIM_HALF_WRITE` (residual bilateral sd_key↔claiming_session_id mismatch).
- **`lib/coordinator/coordination-events.cjs`** — flag gate (`coordDetectorsEnabled`, default-OFF), read-only `gatherDetectorInputs`, fail-open `logCoordinationEvent` / `runAndLogDetectors`, env-overridable thresholds.
- **`database/migrations/20260605_create_coordination_events.sql`** — additive table + 2 indexes. **Already applied to prod** via database-agent with a BEGIN..ROLLBACK proof (`row_count=0` under the default-OFF flag).
- **`scripts/stale-session-sweep.cjs`** — flag-gated, fail-open detector hook after the signal-router block (inert when off; +19 lines).
- **`tests/unit/coordinator/detectors.test.js`** — 17 unit tests (positive+negative per detector, flag-off inertness, fail-open writer).

## Validation
- **17/17 unit tests** green (before and after merging current `origin/main`).
- Prospective + EXEC sub-agent evidence: VALIDATION, Explore, DATABASE, RISK, STORIES, DESIGN, **TESTING (PASS 96%)**, **SECURITY (PASS 97%, 0 findings)**, DATABASE_MIGRATION (PASS).
- Testing-agent corrections applied: STUCK_WORKER uses heartbeat/updated_at staleness (NOT `last_progress_at`, NULL 99.98%); REPLY_STARVATION uses `sender_type`+`payload.routed_to_feedback_id` (no `signal_type` column); CLAIM_HALF_WRITE observes residual post-sweep mismatches.

## Notes
- **PR size (656 LOC > 400 target):** justified — a cohesive, mostly-new-file, read-only detector suite + tests + additive migration, shipping default-OFF; the only edit to existing logic is the 19-line flag-gated sweep hook.
- **Deferred (follow-up):** FR-4 dashboard single-sourcing (`fleet-dashboard.cjs printQA`) — testing-agent C-3 (P2). The sweep is the functional detection path; the dashboard cosmetic surfacing can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)