### PR TITLE
fix(SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001): hoist coordination-events require to top-level (WIRE_CHECK)

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -34,6 +34,7 @@ const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('../lib/claim/h
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3b — top-level require so wire-check
 // call-graph builder can statically resolve the dependency on lib/coordinator/signal-router.cjs.
 const _signalRouterModule = require('../lib/coordinator/signal-router.cjs');
+const _coordEventsModule = require('../lib/coordinator/coordination-events.cjs'); // SD-LEO-INFRA-COORDINATION-OBSERVABILITY-ANOMALY-001 (epic #4) — top-level require so WIRE_CHECK reaches detectors.cjs
 
 // SD-FDBK-INFRA-CROSS-SESSION-CONFLICTION-001 / FR-2 — INTENT collision detection.
 // Reuse the INTENT payload key contract owned by the WRITER (worker-signal.cjs) so the
@@ -1707,7 +1708,7 @@ async function main() {
   // coordination_events row per match (consumed later by epic #3). Fully inert
   // (zero reads/writes) when the flag is off.
   try {
-    const coordEvents = require('../lib/coordinator/coordination-events.cjs');
+    const coordEvents = _coordEventsModule;
     if (coordEvents.coordDetectorsEnabled()) {
       const coordInputs = await coordEvents.gatherDetectorInputs(supabase, {});
       const coordMatches = await coordEvents.runAndLogDetectors(supabase, coordInputs);


### PR DESCRIPTION
## Summary
Follow-up to PR #4268 (epic #4 coordination detectors). The LEAD-FINAL-APPROVAL **WIRE_CHECK** gate flagged `lib/coordinator/detectors.cjs` + `lib/coordinator/coordination-events.cjs` as "not reachable from any entry point" because the sweep wired them via a **lazy `require()` inside a function body** — the gate only follows **top-level** requires.

## Change (1 file, 2 lines)
- `scripts/stale-session-sweep.cjs`: hoist `require('../lib/coordinator/coordination-events.cjs')` to a **top-level** `const _coordEventsModule` (mirroring `_signalRouterModule` at L36, which carries the same "top-level require so wire-check…" rationale). The detector block now references the module variable.

Behavior is **unchanged** — the detectors remain flag-gated behind `COORD_DETECTORS_V2` (default-OFF) and fail-open. `coordination-events.cjs` top-level-requires `detectors.cjs`, so both are now statically reachable from the sweep entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)