### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001): surface feedback work-store on coordinator dashboard

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1132,6 +1132,78 @@ async function printInbox() {
   console.log('');
 }
 
+// ── Section: Feedback work-store (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001) ──
+// READ-ONLY / additive: surfaces the feedback table (untriaged feedback + harness
+// backlog) on the coordinator single-pane view so pending feedback work is never
+// missed alongside the worker-signal inbox (printInbox) and the SD queue
+// (printAvailable). Display only — performs NO routing, lifecycle, sweep,
+// coordinator-election, or read_at mutation. Explicit columns + row limit on every
+// query so the 500+ row feedback table cannot flood the dashboard.
+async function printFeedback(d, deps = {}) {
+  const sb = (deps && deps.supabase) || supabase; // injectable for tests; defaults to module client
+  console.log('FEEDBACK');
+  console.log('─'.repeat(72));
+
+  // Untriaged feedback: pending rows not yet actioned, excluding harness backlog
+  // (surfaced as its own subsection below) to keep the two views disjoint.
+  const { data: untriaged, error: uErr } = await sb
+    .from('feedback')
+    .select('id, priority, category, title, status, created_at')
+    .not('status', 'in', '(resolved,cancelled,closed)')
+    .neq('category', 'harness_backlog')
+    .order('created_at', { ascending: false })
+    .limit(15);
+
+  // Harness backlog: deferred harness-hardening work captured during product sessions.
+  const { data: backlog, error: bErr } = await sb
+    .from('feedback')
+    .select('id, title, status, created_at')
+    .eq('category', 'harness_backlog')
+    .neq('status', 'resolved')
+    .order('created_at', { ascending: false })
+    .limit(15);
+
+  // Graceful degradation: a failed query prints a short notice and returns without
+  // throwing, so the overall /coordinator all render never crashes (mirrors printInbox).
+  if (uErr || bErr) {
+    console.log('  (feedback query failed: ' + (uErr || bErr).message + ')');
+    console.log('');
+    return;
+  }
+
+  const uRows = untriaged || [];
+  const bRows = backlog || [];
+
+  if (uRows.length === 0 && bRows.length === 0) {
+    console.log('  (no pending feedback or harness backlog)');
+    console.log('');
+    return;
+  }
+
+  const now = Date.now();
+  const ageOf = (ts) => ts ? Math.max(0, Math.round((now - Date.parse(ts)) / 3600000)) + 'h' : '?';
+
+  console.log('  Untriaged feedback (' + uRows.length + ')');
+  if (uRows.length === 0) {
+    console.log('    (none)');
+  } else {
+    for (const f of uRows) {
+      console.log('    ' + pad(f.priority || '—', 5) + pad(f.category || '-', 18) + pad(ageOf(f.created_at), 6) + (f.title || '').substring(0, 38));
+    }
+  }
+
+  console.log('  Harness backlog (' + bRows.length + ')');
+  if (bRows.length === 0) {
+    console.log('    (none)');
+  } else {
+    for (const b of bRows) {
+      console.log('    ' + pad(ageOf(b.created_at), 6) + (b.title || '').substring(0, 52));
+    }
+  }
+
+  console.log('');
+}
+
 // ── Main ──
 
 async function main() {
@@ -1156,6 +1228,7 @@ async function main() {
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
     inbox:         async () => await printInbox(),
+    feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
     all:           async () => {
       // Team banner appears at top of /coordinator all when active teams exist (otherwise no-op)
@@ -1168,6 +1241,7 @@ async function main() {
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
+      await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);
       printHealth(d);
       printQA(d);
@@ -1179,7 +1253,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, feedback, team, all');
     process.exit(1);
   }
 
@@ -1201,7 +1275,14 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('DASHBOARD ERROR:', err.message);
-  process.exit(1);
-});
+// Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
+module.exports = { printFeedback };
+
+// Only run the CLI when invoked directly, so requiring this module in a test does
+// not execute main() against the live database.
+if (require.main === module) {
+  main().catch(err => {
+    console.error('DASHBOARD ERROR:', err.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/coordinator/fleet-dashboard-feedback.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-feedback.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit smoke tests for printFeedback — the feedback work-store section of the fleet
+ * coordinator dashboard (scripts/fleet-dashboard.cjs).
+ * SD: SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
+ *
+ * printFeedback is READ-ONLY / additive: it surfaces untriaged feedback + harness
+ * backlog on the /coordinator all single-pane view. These tests inject a mock supabase
+ * client and capture console output to prove:
+ *   - both subsections render with counts when rows are present,
+ *   - an explicit empty-state line is printed when both queries return zero rows,
+ *   - every feedback query applies a status filter AND a row limit (anti-flood guard),
+ *   - a query error degrades gracefully (notice, no throw) — FR-4.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { printFeedback } = require('../../../scripts/fleet-dashboard.cjs');
+
+// Chainable mock of the supabase query builder for the `feedback` table. Records each
+// query's method chain so tests can assert a status filter + limit were applied, and
+// distinguishes the two queries: the harness-backlog query calls .eq('category',
+// 'harness_backlog'); the untriaged query calls .neq('category','harness_backlog').
+function mockSupabase({ untriaged = [], backlog = [], failOn = null } = {}) {
+  const recorded = [];
+  function builder() {
+    const state = { category_eq: null, statusFiltered: false, limited: false };
+    const chain = {
+      select() { return chain; },
+      not(col) { if (col === 'status') state.statusFiltered = true; return chain; },
+      eq(col, val) { if (col === 'category') state.category_eq = val; return chain; },
+      neq(col) { if (col === 'status') state.statusFiltered = true; return chain; },
+      order() { return chain; },
+      limit() {
+        state.limited = true;
+        recorded.push(state);
+        const isBacklog = state.category_eq === 'harness_backlog';
+        if (failOn === 'untriaged' && !isBacklog) return Promise.resolve({ data: null, error: { message: 'simulated untriaged failure' } });
+        if (failOn === 'backlog' && isBacklog) return Promise.resolve({ data: null, error: { message: 'simulated backlog failure' } });
+        return Promise.resolve({ data: isBacklog ? backlog : untriaged, error: null });
+      },
+    };
+    return chain;
+  }
+  return { from() { return builder(); }, _recorded: recorded };
+}
+
+let logSpy;
+beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { logSpy.mockRestore(); });
+const output = () => logSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+
+const hoursAgo = (h) => new Date(Date.now() - h * 3600000).toISOString();
+
+describe('printFeedback — populated', () => {
+  test('renders FEEDBACK header and both subsections with counts', async () => {
+    const sb = mockSupabase({
+      untriaged: [
+        { id: '1', priority: 'high', category: 'bug', title: 'Untriaged bug A', status: 'new', created_at: hoursAgo(1) },
+        { id: '2', priority: 'low', category: 'enhancement', title: 'Untriaged enh B', status: 'open', created_at: hoursAgo(2) },
+      ],
+      backlog: [
+        { id: '3', title: 'Deferred harness item', status: 'new', created_at: hoursAgo(5) },
+      ],
+    });
+    await printFeedback({}, { supabase: sb });
+    const out = output();
+    expect(out).toContain('FEEDBACK');
+    expect(out).toContain('Untriaged feedback (2)');
+    expect(out).toContain('Harness backlog (1)');
+    expect(out).toContain('Untriaged bug A');
+    expect(out).toContain('Deferred harness item');
+  });
+});
+
+describe('printFeedback — empty state', () => {
+  test('prints explicit no-pending line when both queries return zero rows', async () => {
+    const sb = mockSupabase({ untriaged: [], backlog: [] });
+    await printFeedback({}, { supabase: sb });
+    const out = output();
+    expect(out).toContain('FEEDBACK');
+    expect(out).toContain('(no pending feedback or harness backlog)');
+  });
+});
+
+describe('printFeedback — anti-flood guards', () => {
+  test('applies a status filter and a row limit to every feedback query', async () => {
+    const sb = mockSupabase({
+      untriaged: [{ id: '1', priority: 'med', category: 'x', title: 't', status: 'new', created_at: hoursAgo(1) }],
+      backlog: [],
+    });
+    await printFeedback({}, { supabase: sb });
+    expect(sb._recorded.length).toBe(2); // untriaged + harness backlog
+    for (const q of sb._recorded) {
+      expect(q.statusFiltered).toBe(true);
+      expect(q.limited).toBe(true);
+    }
+  });
+});
+
+describe('printFeedback — graceful error (FR-4)', () => {
+  test('prints a notice and does not throw when a query errors', async () => {
+    const sb = mockSupabase({ failOn: 'untriaged' });
+    await expect(printFeedback({}, { supabase: sb })).resolves.toBeUndefined();
+    expect(output()).toContain('feedback query failed');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001

Adds a read-only `printFeedback(d)` section to the fleet coordinator dashboard (`scripts/fleet-dashboard.cjs`) so the operator's single pane of glass surfaces the **feedback work-store** — the one store not previously shown alongside the worker-signal inbox and SD queue.

### What it does
- **Untriaged feedback**: `feedback` rows with status NOT IN (resolved, cancelled, closed), excluding harness backlog — labelled subsection with count.
- **Harness backlog**: `feedback` rows where category='harness_backlog' AND status != resolved — labelled subsection with count.
- Registered in the sections map, the `all()` aggregator (next to the inbox), and the usage line.
- Explicit empty-state line + graceful query-error degradation (notice, no crash).

### Read-only / safe by construction
Display only — **no routing, lifecycle, sweep, coordinator-election, or `read_at` mutation**. Every query uses explicit columns + a row limit (15) + a status filter so the 500+ row feedback table cannot flood the dashboard. (`printInbox` was the template but it mutates `read_at`; this section deliberately does not.)

### Testability
The 1207-line CLI had no exports and ran `main()` unconditionally. Added dependency injection (`printFeedback(d, deps)`), `module.exports`, and an `if (require.main === module)` guard so the renderer can be unit-tested without hitting the live DB.

### Tests & evidence
- `tests/unit/coordinator/fleet-dashboard-feedback.test.js` — **4/4 vitest** pass: both subsections+counts, empty state, anti-flood (status-filter+limit), graceful query-error (FR-4).
- Sub-agent evidence: TESTING `2e15fd0f` (ran 4/4 green), SECURITY `e813b542` (no findings), RETRO `1e081828` (published retro, quality 90).
- Handoffs: PLAN-TO-EXEC 92 · EXEC-TO-PLAN 93 · PLAN-TO-LEAD 96.

Fleet note: taken over at PLAN_PRD from a dead peer (coordinator-approved, claim fully cleared) and resumed from the approved PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
