### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-CRON-LIFECYCLE-001): role-aware context-compaction thresholds (default-OFF)

### DIFF
--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -98,11 +98,24 @@ const contextUsed = inputTokens + outputTokens + cacheCreation + cacheRead;
 const usableContext = Math.max(1, Math.floor(contextSize * AUTOCOMPACT_PCT / 100));
 const percentUsed = Math.min(100, Math.floor(contextUsed * 100 / usableContext));
 
+// Role-aware advisory thresholds (SD-LEO-INFRA-COORDINATOR-CRON-LIFECYCLE-001).
+// DEFAULT-OFF behind COORD_COMPACTION_THRESHOLD_V2 — when off, every role uses the
+// inline globals below (93/97), so behavior is unchanged. The status line must never
+// crash, so a module-load failure silently falls back to the inline globals.
+let thresholds = { warning: WARNING_THRESHOLD, critical: CRITICAL_THRESHOLD, emergency: EMERGENCY_THRESHOLD };
+let sessionRole = 'unknown';
+try {
+  const ct = require('../scripts/lib/compaction-thresholds.cjs');
+  const flagOn = ct.isCompactionThresholdV2Enabled(process.env);
+  sessionRole = ct.detectRoleFromFile(process.env.CLAUDE_SESSION_ID || sessionId);
+  thresholds = ct.selectThresholds(sessionRole, flagOn);
+} catch (_) { /* intentionally silent: keep inline global thresholds, never crash the status line */ }
+
 // Status level (shifted: old-red→yellow, old-yellow→hidden)
 let status = 'HEALTHY';
 let icon = '';
-if (percentUsed >= EMERGENCY_THRESHOLD) { status = 'EMERGENCY'; icon = ' !'; }
-else if (percentUsed >= CRITICAL_THRESHOLD) { status = 'CRITICAL'; icon = ' *'; }
+if (percentUsed >= thresholds.emergency) { status = 'EMERGENCY'; icon = ' !'; }
+else if (percentUsed >= thresholds.critical) { status = 'CRITICAL'; icon = ' *'; }
 
 // Progress bar
 const BAR_WIDTH = 20;
@@ -110,8 +123,8 @@ const filled = Math.floor(percentUsed * BAR_WIDTH / 100);
 const empty = BAR_WIDTH - filled;
 const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(empty);
 let barColor = GREEN;
-if (percentUsed >= EMERGENCY_THRESHOLD) barColor = RED;
-else if (percentUsed >= CRITICAL_THRESHOLD) barColor = YELLOW;
+if (percentUsed >= thresholds.emergency) barColor = RED;
+else if (percentUsed >= thresholds.critical) barColor = YELLOW;
 
 // Git info
 let gitBranch = '';
@@ -261,6 +274,7 @@ try {
     last_input_tokens: totalInputTokens,
     last_active_epoch: nowEpoch,
     session_id: sessionId,
+    role: sessionRole,
     activity_state: activityState,
     hook_triggered: false
   };

--- a/scripts/lib/compaction-thresholds.cjs
+++ b/scripts/lib/compaction-thresholds.cjs
@@ -1,0 +1,91 @@
+// ============================================================================
+// Role-aware context-compaction thresholds
+// SD-LEO-INFRA-COORDINATOR-CRON-LIFECYCLE-001
+// ============================================================================
+// Pure, dependency-light, require-safe helpers used by .claude/statusline.cjs.
+//
+// DEFAULT-OFF behind COORD_COMPACTION_THRESHOLD_V2 — when the flag is off, EVERY
+// role uses GLOBAL_THRESHOLDS, so behavior is identical to the pre-change status
+// line. When on, COORDINATOR sessions (long-lived fleet monitors) are classified
+// CRITICAL/EMERGENCY earlier so they are nudged to /compact proactively.
+//
+// AUTOCOMPACT_PCT is intentionally NOT role-aware: it mirrors the real harness
+// auto-compaction trigger (80% of the window). Keeping it fixed keeps last_percent
+// accurate against the real trigger for every role.
+// ============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const AUTOCOMPACT_PCT = 80;
+
+// Advisory classification thresholds (percent of usable context).
+const GLOBAL_THRESHOLDS = Object.freeze({ warning: 80, critical: 93, emergency: 97 });
+// Coordinators nudge ~8 points earlier than the global profile.
+const COORDINATOR_THRESHOLDS = Object.freeze({ warning: 80, critical: 85, emergency: 92 });
+
+const TRUTHY = new Set(['1', 'true', 'on', 'yes']);
+
+// Flag parser — OFF unless the value is one of 1/true/on/yes (case-insensitive).
+function isCompactionThresholdV2Enabled(env) {
+  const e = env || (typeof process !== 'undefined' ? process.env : {});
+  const v = e && e.COORD_COMPACTION_THRESHOLD_V2;
+  if (v == null) return false;
+  return TRUTHY.has(String(v).trim().toLowerCase());
+}
+
+// Reuse readCoordFile() from session-role-orient.cjs (PRD FR-2). It is require-safe
+// (guarded by require.main === module). Fall back to an inline read of the same
+// .claude/active-coordinator.json file if the require fails, so this module never
+// hard-depends on the hook being loadable.
+let _readCoordFile = null;
+try {
+  _readCoordFile = require('../hooks/session-role-orient.cjs').readCoordFile;
+} catch (_) { _readCoordFile = null; }
+
+function defaultReadCoordFile() {
+  if (typeof _readCoordFile === 'function') return _readCoordFile();
+  // Inline fallback — mirrors session-role-orient.cjs readCoordFile (single source of file format).
+  try {
+    const fp = path.resolve(__dirname, '../../.claude/active-coordinator.json');
+    return fs.existsSync(fp) ? JSON.parse(fs.readFileSync(fp, 'utf8')) : null;
+  } catch (_) { return null; }
+}
+
+// File-only role detection — NO database, NO network in the render hot path.
+// Returns 'coordinator' | 'worker' | 'solo'. Fail-safe to 'worker' (the conservative,
+// current-behavior profile) on ANY error. `reader` is injectable for tests.
+function detectRoleFromFile(sessionId, reader) {
+  const read = typeof reader === 'function' ? reader : defaultReadCoordFile;
+  let coord = null;
+  try { coord = read(); } catch (_) { return 'worker'; }
+  if (!coord || !coord.session_id) return 'solo';
+  if (sessionId && coord.session_id === sessionId) return 'coordinator';
+  return 'worker';
+}
+
+// Select advisory thresholds by role + flag. Flag OFF => GLOBAL for every role.
+function selectThresholds(role, flagEnabled) {
+  if (!flagEnabled) return GLOBAL_THRESHOLDS;
+  if (role === 'coordinator') return COORDINATOR_THRESHOLDS;
+  return GLOBAL_THRESHOLDS;
+}
+
+// Classify a usage percent against thresholds. Returns 'HEALTHY' | 'CRITICAL' | 'EMERGENCY'.
+function classifyStatus(percentUsed, thresholds) {
+  const t = thresholds || GLOBAL_THRESHOLDS;
+  if (percentUsed >= t.emergency) return 'EMERGENCY';
+  if (percentUsed >= t.critical) return 'CRITICAL';
+  return 'HEALTHY';
+}
+
+module.exports = {
+  AUTOCOMPACT_PCT,
+  GLOBAL_THRESHOLDS,
+  COORDINATOR_THRESHOLDS,
+  isCompactionThresholdV2Enabled,
+  detectRoleFromFile,
+  selectThresholds,
+  classifyStatus,
+};

--- a/tests/unit/statusline-role-thresholds.test.js
+++ b/tests/unit/statusline-role-thresholds.test.js
@@ -1,0 +1,106 @@
+// Unit tests for role-aware context-compaction thresholds.
+// SD-LEO-INFRA-COORDINATOR-CRON-LIFECYCLE-001
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const MOD_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../scripts/lib/compaction-thresholds.cjs');
+const ct = require(MOD_PATH);
+
+describe('compaction-thresholds: flag parser (isCompactionThresholdV2Enabled)', () => {
+  it('is ON only for 1/true/on/yes (case-insensitive)', () => {
+    for (const v of ['1', 'true', 'on', 'yes', 'TRUE', 'On', ' yes ']) {
+      expect(ct.isCompactionThresholdV2Enabled({ COORD_COMPACTION_THRESHOLD_V2: v })).toBe(true);
+    }
+  });
+  it('is OFF for unset / empty / falsey / arbitrary values', () => {
+    for (const v of [undefined, null, '', '0', 'false', 'off', 'no', 'maybe', 'enabled']) {
+      expect(ct.isCompactionThresholdV2Enabled({ COORD_COMPACTION_THRESHOLD_V2: v })).toBe(false);
+    }
+    expect(ct.isCompactionThresholdV2Enabled({})).toBe(false);
+  });
+});
+
+describe('compaction-thresholds: TS-1 flag OFF => global thresholds for ALL roles', () => {
+  it('coordinator, worker, and solo all get GLOBAL when flag off', () => {
+    for (const role of ['coordinator', 'worker', 'solo', 'unknown']) {
+      expect(ct.selectThresholds(role, false)).toBe(ct.GLOBAL_THRESHOLDS);
+    }
+    expect(ct.GLOBAL_THRESHOLDS).toEqual({ warning: 80, critical: 93, emergency: 97 });
+  });
+});
+
+describe('compaction-thresholds: TS-2 flag ON => coordinator nudged earlier than worker', () => {
+  it('coordinator critical/emergency are strictly lower than worker', () => {
+    const coord = ct.selectThresholds('coordinator', true);
+    const worker = ct.selectThresholds('worker', true);
+    expect(coord.critical).toBeLessThan(worker.critical);
+    expect(coord.emergency).toBeLessThan(worker.emergency);
+  });
+  it('worker and solo still get GLOBAL when flag on', () => {
+    expect(ct.selectThresholds('worker', true)).toBe(ct.GLOBAL_THRESHOLDS);
+    expect(ct.selectThresholds('solo', true)).toBe(ct.GLOBAL_THRESHOLDS);
+  });
+  it('COORDINATOR_THRESHOLDS are the expected 85/92', () => {
+    expect(ct.COORDINATOR_THRESHOLDS).toEqual({ warning: 80, critical: 85, emergency: 92 });
+  });
+});
+
+describe('compaction-thresholds: TS-3 classifyStatus differentiates by role at a boundary', () => {
+  it('at 88% a coordinator is CRITICAL but a worker is HEALTHY (flag on)', () => {
+    const coord = ct.selectThresholds('coordinator', true);
+    const worker = ct.selectThresholds('worker', true);
+    expect(ct.classifyStatus(88, coord)).toBe('CRITICAL');
+    expect(ct.classifyStatus(88, worker)).toBe('HEALTHY');
+  });
+  it('classifyStatus boundaries: >= emergency => EMERGENCY, >= critical => CRITICAL, else HEALTHY', () => {
+    expect(ct.classifyStatus(97, ct.GLOBAL_THRESHOLDS)).toBe('EMERGENCY');
+    expect(ct.classifyStatus(93, ct.GLOBAL_THRESHOLDS)).toBe('CRITICAL');
+    expect(ct.classifyStatus(92, ct.GLOBAL_THRESHOLDS)).toBe('HEALTHY');
+    expect(ct.classifyStatus(0, ct.GLOBAL_THRESHOLDS)).toBe('HEALTHY');
+  });
+});
+
+describe('compaction-thresholds: TS-4 AUTOCOMPACT_PCT invariant', () => {
+  it('AUTOCOMPACT_PCT is 80 (mirrors the real harness trigger, never role-aware)', () => {
+    expect(ct.AUTOCOMPACT_PCT).toBe(80);
+  });
+});
+
+describe('compaction-thresholds: TS-5 detectRoleFromFile fail-safe + role logic', () => {
+  it('matching session_id => coordinator', () => {
+    const reader = () => ({ session_id: 'sess-A' });
+    expect(ct.detectRoleFromFile('sess-A', reader)).toBe('coordinator');
+  });
+  it('non-matching session_id => worker', () => {
+    const reader = () => ({ session_id: 'sess-OTHER' });
+    expect(ct.detectRoleFromFile('sess-A', reader)).toBe('worker');
+  });
+  it('no coordinator file (null) => solo', () => {
+    expect(ct.detectRoleFromFile('sess-A', () => null)).toBe('solo');
+  });
+  it('file without session_id => solo', () => {
+    expect(ct.detectRoleFromFile('sess-A', () => ({}))).toBe('solo');
+  });
+  it('reader throws => fail-safe to worker (never throws in render path)', () => {
+    const reader = () => { throw new Error('boom'); };
+    expect(() => ct.detectRoleFromFile('sess-A', reader)).not.toThrow();
+    expect(ct.detectRoleFromFile('sess-A', reader)).toBe('worker');
+  });
+});
+
+describe('compaction-thresholds: TS-6 no database in the render path', () => {
+  it('module source imports no supabase client / DB factory', () => {
+    const src = readFileSync(MOD_PATH, 'utf8');
+    expect(src).not.toMatch(/@supabase\/supabase-js|createClient\s*\(/);
+  });
+  it('detectRoleFromFile with an injected reader performs no network/DB call (pure function call)', () => {
+    let called = 0;
+    const reader = () => { called += 1; return { session_id: 'x' }; };
+    ct.detectRoleFromFile('x', reader);
+    expect(called).toBe(1); // only the injected file reader is invoked
+  });
+});


### PR DESCRIPTION
## Summary
SD-LEO-INFRA-COORDINATOR-CRON-LIFECYCLE-001. Scope-reduced from a 4-in-1 stub to the one safe, separable slice: make `.claude/statusline.cjs` advisory CRITICAL/EMERGENCY thresholds **role-aware** so long-lived coordinator sessions are nudged to `/compact` earlier than short-lived workers.

- **New** `scripts/lib/compaction-thresholds.cjs` — pure, require-safe helpers (`selectThresholds`/`classifyStatus`/`detectRoleFromFile`/`isCompactionThresholdV2Enabled`).
- `statusline.cjs` uses them **defensively** (falls back to inline globals 80/93/97 if the module fails to load — the status line must never crash). `AUTOCOMPACT_PCT` stays 80 (mirrors the real harness trigger); detected `role` recorded in the state file.
- **Default-OFF** behind `COORD_COMPACTION_THRESHOLD_V2` — zero behavior change when off (coordinator/worker/solo all use 93/97).
- File-only role detection (reuses `readCoordFile`); **no DB/network** in the render hot path.

**Deferred** (live coordinator cron/stop machinery, high blast radius): adaptive backoff, idle auto-teardown, stop-clears-pointer footgun → follow-up SD.

## Test plan
- 16 unit tests (`tests/unit/statusline-role-thresholds.test.js`) — flag-off parity, flag-on differentiation, AUTOCOMPACT invariance, fail-safe role detection, no-DB source scan. All pass.
- 3-scenario integration smoke against the real `statusline.cjs` (coordinator CRITICAL @88%, worker HEALTHY @88%, flag-off coordinator HEALTHY parity). All correct.
- TESTING sub-agent verdict: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
