### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001): default-OFF unified coordinator teardown contract

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -229,7 +229,29 @@ const { clearActiveCoordinator } = require('./lib/coordinator/resolve.cjs');
 "
 ```
 
-Removes `.claude/active-coordinator.json` and clears `claude_sessions.metadata.is_coordinator` for this session. Subsequent worker `/signal` invocations will fall back to `target_session=broadcast-coordinator` until a new coordinator runs `/coordinator start`. Cron loops created by `/coordinator start` continue running independently.
+Removes `.claude/active-coordinator.json` and clears `claude_sessions.metadata.is_coordinator` for this session. Subsequent worker `/signal` invocations will fall back to `target_session=broadcast-coordinator` until a new coordinator runs `/coordinator start`.
+
+> ⚠️ **Self-reversing stop (legacy / flag-OFF behavior):** the command above clears the pointer but leaves the cron loops running. The **inbox loop re-asserts the pointer every ~2 min** (it calls `setActiveCoordinator`), so on the next tick the stop is silently undone. This is the known footgun behind "NEVER run /coordinator stop".
+
+**Teardown safety — `COORD_TEARDOWN_SAFETY_V2` (default-OFF), SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001:**
+When `COORD_TEARDOWN_SAFETY_V2=on`, perform a CONSISTENT teardown instead — crons FIRST, pointer SECOND:
+1. Run **`CronList`** (harness tool) to get all active cron jobs + their ids.
+2. Identify coordinator-owned jobs — any whose command contains `stale-session-sweep.cjs`, `fleet-dashboard.cjs` (covers both `all`/dashboard and `inbox`), or `assign-fleet-identities.cjs` (plus the email loop). Programmatic helper: `selectCoordinatorCronJobs(cronListJobs)` in `lib/coordinator/teardown-coordinator.cjs`.
+3. **`CronDelete`** each of those job ids — ALL of them, BEFORE step 4 (deleting the inbox loop is what prevents the re-assert).
+4. THEN clear the pointer (session-scoped + fail-open; refuses to clear a pointer this session does not own unless `force:true`):
+   ```bash
+   node -e "
+   require('dotenv').config();
+   const { createClient } = require('@supabase/supabase-js');
+   const { clearCoordinatorPointer } = require('./lib/coordinator/teardown-coordinator.cjs');
+   (async () => {
+     const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+     const r = await clearCoordinatorPointer(sb, { sessionId: process.env.CLAUDE_SESSION_ID });
+     console.log(JSON.stringify(r, null, 2));
+   })();
+   "
+   ```
+   With the flag unset/off this helper is a no-op and the legacy `clearActiveCoordinator` command above remains the path (byte-identical behavior).
 
 #### For `revive [callsign]` or `revive-all` (SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001):
 
@@ -354,10 +376,24 @@ Fill in the dynamic values from the dashboard output:
 This banner signals the fleet has finished all work. Display it once per dashboard cycle where the queue is empty; do not repeat if already shown in the same coordinator session.
 
 **After displaying the banner**, tear down the coordinator:
-1. Cancel both cron loops using `CronDelete` (sweep and dashboard jobs)
+
+**Default / flag-OFF (legacy):**
+1. Cancel the sweep and dashboard cron loops using `CronDelete`.
 2. Confirm to the user:
    ```
    Coordinator shut down. Sweep and dashboard loops cancelled — no more work to monitor.
+   ```
+
+> ⚠️ The legacy path above is **asymmetric**: it cancels only sweep+dashboard (leaving identity/inbox/email orphaned) and never clears the coordinator pointer — so `getActiveCoordinatorId` still resolves a dead coordinator and the orphaned inbox loop re-asserts the pointer.
+
+**`COORD_TEARDOWN_SAFETY_V2=on` (SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001) — consistent teardown:**
+Use the SAME contract as `/coordinator stop` so both paths converge (crons FIRST, pointer SECOND):
+1. `CronList` → identify ALL coordinator-owned jobs (`selectCoordinatorCronJobs` in `lib/coordinator/teardown-coordinator.cjs` — matches sweep/dashboard/identity/inbox; plus the email loop).
+2. `CronDelete` every one of them (not just sweep+dashboard).
+3. Clear the pointer via `clearCoordinatorPointer(sb, { sessionId: process.env.CLAUDE_SESSION_ID })` (session-scoped, fail-open) — see the `/coordinator stop` section for the exact snippet.
+4. Confirm:
+   ```
+   Coordinator shut down. All coordinator cron loops cancelled and pointer cleared — fleet idle.
    ```
 
 ---

--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -10,10 +10,12 @@ const os = require('os');
 const STALE_THRESHOLD_MIN = 10;
 const ACTIVE_COORDINATOR_FILE = path.resolve(__dirname, '../../.claude/active-coordinator.json');
 
-function readPointerFile() {
+function readPointerFile(file = ACTIVE_COORDINATOR_FILE) {
+  // SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001 FR-7: optional file arg for test
+  // injectability; defaults to ACTIVE_COORDINATOR_FILE so existing callers are byte-identical.
   try {
-    if (!fs.existsSync(ACTIVE_COORDINATOR_FILE)) return null;
-    const raw = fs.readFileSync(ACTIVE_COORDINATOR_FILE, 'utf8');
+    if (!fs.existsSync(file)) return null;
+    const raw = fs.readFileSync(file, 'utf8');
     const data = JSON.parse(raw);
     if (!data || typeof data.session_id !== 'string') return null;
     return data;
@@ -180,9 +182,12 @@ async function setActiveCoordinator(supabase, sessionId) {
     .eq('session_id', sessionId);
 }
 
-async function clearActiveCoordinator(supabase, sessionId) {
+async function clearActiveCoordinator(supabase, sessionId, opts = {}) {
+  // SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001 FR-7: optional opts.pointerFile for test
+  // injectability; defaults to ACTIVE_COORDINATOR_FILE so existing 2-arg callers are byte-identical.
+  const pointerFile = (opts && opts.pointerFile) || ACTIVE_COORDINATOR_FILE;
   try {
-    if (fs.existsSync(ACTIVE_COORDINATOR_FILE)) fs.unlinkSync(ACTIVE_COORDINATOR_FILE);
+    if (fs.existsSync(pointerFile)) fs.unlinkSync(pointerFile);
   } catch { /* ignore */ }
 
   if (!supabase || !sessionId) return;

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -39,19 +39,20 @@ const COORDINATOR_CRONS = [
   { key: 'dashboard', cadence: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *',  command: 'node scripts/fleet-dashboard.cjs all',     re_asserts_pointer: false },
   { key: 'identity',  cadence: '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',  command: 'node scripts/assign-fleet-identities.cjs', re_asserts_pointer: false },
   { key: 'inbox',     cadence: '*/2 * * * *',                                command: 'node scripts/fleet-dashboard.cjs inbox',  re_asserts_pointer: true },
-  // email: coordinator-confirmed live; exact command pending coordinator reply (prd-ambiguous).
-  // Non-critical for the re-assert bug (does not touch the pointer). Add its marker when confirmed.
-  { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: null, needs_confirmation: true, re_asserts_pointer: false }
+  // email: coordinator-confirmed command (coordinator signal 2026-06-06 01:42). Non-critical for
+  // the re-assert bug (does not touch the pointer) but still a coordinator cron teardown must remove.
+  { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: 'node scripts/coordinator-email-summary.mjs', re_asserts_pointer: false }
 ];
 
 // Basename markers used to recognise coordinator-owned jobs in a CronList() result. The
 // fleet-dashboard.cjs marker intentionally covers BOTH the `all` (dashboard) and `inbox`
 // invocations, so the critical pointer-re-asserting inbox cron is matched regardless of the
-// exact prompt string. (email's separate script is added here once its command is confirmed.)
+// exact prompt string. The email loop is a separate script (coordinator-confirmed).
 const COORD_SCRIPT_MARKERS = [
   'stale-session-sweep.cjs',
   'fleet-dashboard.cjs',
-  'assign-fleet-identities.cjs'
+  'assign-fleet-identities.cjs',
+  'coordinator-email-summary.mjs'
 ];
 
 function isEnabled() {

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -1,0 +1,156 @@
+// SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001
+// Unified, DEFAULT-OFF coordinator teardown contract.
+//
+// PROBLEM: the coordinator has TWO divergent teardown paths (.claude/commands/coordinator.md):
+//   - `/coordinator stop` clears the pointer but historically leaves crons running.
+//   - queue-empty auto-teardown CronDeletes only sweep+dashboard and never clears the pointer.
+// Either way, the inbox loop (cadence */2) calls setActiveCoordinator(...) every ~2min and
+// RE-ASSERTS the pointer on the next tick — so any teardown that does not remove the inbox
+// cron BEFORE clearing the pointer silently self-reverses.
+//
+// CONTRACT (both paths must follow, gated by COORD_TEARDOWN_SAFETY_V2):
+//   1. CronList()                              <- harness tool (NOT Node-callable)
+//   2. selectCoordinatorCronJobs(list)         <- this module: pick coordinator-owned jobs
+//   3. CronDelete(each.id)  for ALL of them    <- harness tool, BEFORE step 4
+//   4. clearCoordinatorPointer(...)            <- this module: session-scoped, fail-open
+//
+// Cron deletion MUST precede the pointer clear (coordinator guidance 2186782f). This module
+// CANNOT delete crons (CronList/CronDelete are Claude Code harness tools, not Node APIs); it
+// supplies the canonical inventory + matcher + the pointer clear, and the .md wiring sequences
+// the harness cron deletion before calling clearCoordinatorPointer.
+//
+// When COORD_TEARDOWN_SAFETY_V2 is unset/off, clearCoordinatorPointer is a no-op and both
+// teardown paths keep their current (legacy) behavior byte-for-byte.
+
+'use strict';
+
+const resolve = require('./resolve.cjs');
+
+const FLAG = 'COORD_TEARDOWN_SAFETY_V2';
+
+// Single source of truth for the coordinator's recurring crons.
+// committed coordinator.md Step 4 documents only sweep/dashboard/identity; inbox + email are
+// coordinator-confirmed live (creation-vs-reality DRIFT, signalled prd-ambiguous). Listed here
+// so creation and teardown can be reconciled to one inventory. `command` is informational; the
+// runtime matcher (selectCoordinatorCronJobs) keys on `markers` so it is robust to exact-command
+// drift. The inbox loop is the critical one (re_asserts_pointer:true).
+const COORDINATOR_CRONS = [
+  { key: 'sweep',     cadence: '*/5 * * * *',                                command: 'node scripts/stale-session-sweep.cjs',     re_asserts_pointer: false },
+  { key: 'dashboard', cadence: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *',  command: 'node scripts/fleet-dashboard.cjs all',     re_asserts_pointer: false },
+  { key: 'identity',  cadence: '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',  command: 'node scripts/assign-fleet-identities.cjs', re_asserts_pointer: false },
+  { key: 'inbox',     cadence: '*/2 * * * *',                                command: 'node scripts/fleet-dashboard.cjs inbox',  re_asserts_pointer: true },
+  // email: coordinator-confirmed live; exact command pending coordinator reply (prd-ambiguous).
+  // Non-critical for the re-assert bug (does not touch the pointer). Add its marker when confirmed.
+  { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: null, needs_confirmation: true, re_asserts_pointer: false }
+];
+
+// Basename markers used to recognise coordinator-owned jobs in a CronList() result. The
+// fleet-dashboard.cjs marker intentionally covers BOTH the `all` (dashboard) and `inbox`
+// invocations, so the critical pointer-re-asserting inbox cron is matched regardless of the
+// exact prompt string. (email's separate script is added here once its command is confirmed.)
+const COORD_SCRIPT_MARKERS = [
+  'stale-session-sweep.cjs',
+  'fleet-dashboard.cjs',
+  'assign-fleet-identities.cjs'
+];
+
+function isEnabled() {
+  const v = process.env[FLAG];
+  return v === 'on' || v === 'true' || v === '1';
+}
+
+function listCoordinatorCrons() {
+  return COORDINATOR_CRONS.map((c) => ({ ...c }));
+}
+
+// Pick coordinator-owned jobs out of a CronList() result. A job matches if its command/prompt
+// string contains any canonical coordinator script basename. Robust to the 3-vs-5 inventory
+// drift: whatever coordinator crons are actually running get matched for deletion.
+function selectCoordinatorCronJobs(cronJobs) {
+  if (!Array.isArray(cronJobs)) return [];
+  return cronJobs.filter((j) => {
+    if (!j) return false;
+    const cmd = String(j.prompt || j.command || j.cron_command || j.task || '');
+    return COORD_SCRIPT_MARKERS.some((m) => cmd.includes(m));
+  });
+}
+
+// FR-2 (session-scope) + FR-3 (fail-open): clear the coordinator pointer + is_coordinator
+// metadata, but ONLY for this session's own pointer unless force=true. Reuses
+// resolve.clearActiveCoordinator (TR-3). Never throws. MUST be called AFTER the harness has
+// CronDeleted all coordinator crons (else the inbox loop re-asserts the pointer).
+//
+// opts: { sessionId, force=false, pointerFile, readPointer, cronsDeleted }
+//   - pointerFile : inject an alternate pointer path (tests; FR-7). Default = live pointer.
+//   - readPointer : inject a pointer reader (tests). Default = resolve.readPointerFile.
+//   - cronsDeleted: caller asserts it already CronDeleted the crons (advisory; recorded in result).
+async function clearCoordinatorPointer(supabase, opts = {}) {
+  const { sessionId, force = false, pointerFile, readPointer, cronsDeleted } = opts;
+  const result = {
+    flag: FLAG,
+    enabled: isEnabled(),
+    crons_to_delete: listCoordinatorCrons(),
+    crons_deleted_asserted: Boolean(cronsDeleted),
+    pointer_cleared: false,
+    refused: false,
+    forced: false,
+    errors: []
+  };
+
+  // FR-5: flag-OFF => no-op passthrough (legacy teardown unchanged, byte-identical).
+  if (!isEnabled()) {
+    result.action = 'noop';
+    result.message = FLAG + ' is off — legacy teardown unchanged (no pointer/cron side effects).';
+    return result;
+  }
+
+  // FR-2: ownership check. Fail-safe: if the pointer cannot be read and force is not set,
+  // REFUSE (do not risk clobbering an unknown/foreign pointer).
+  let owner = null;
+  let readErr = null;
+  try {
+    const reader = readPointer || resolve.readPointerFile;
+    const pointer = reader(pointerFile);
+    owner = pointer && typeof pointer.session_id === 'string' ? pointer.session_id : null;
+  } catch (e) {
+    readErr = e;
+    result.errors.push('pointer-read: ' + (e && e.message ? e.message : String(e)));
+  }
+  if (readErr && !force) {
+    result.refused = true;
+    result.message = 'Refused: could not verify pointer ownership (fail-safe). Pass force=true to override.';
+    return result;
+  }
+  if (owner && sessionId && owner !== sessionId && !force) {
+    result.refused = true;
+    result.owner = owner;
+    result.message = 'Refused: active-coordinator pointer owned by ' + String(owner).slice(0, 8) +
+      ' != this session ' + String(sessionId).slice(0, 8) + '. Pass force=true to override (protects the LIVE coordinator).';
+    return result;
+  }
+  result.forced = Boolean(force && owner && sessionId && owner !== sessionId);
+
+  // FR-3: fail-open clear via resolve.clearActiveCoordinator (pointer file + is_coordinator metadata).
+  try {
+    await resolve.clearActiveCoordinator(supabase, sessionId, pointerFile ? { pointerFile } : undefined);
+    result.pointer_cleared = true;
+  } catch (e) {
+    result.errors.push('clear: ' + (e && e.message ? e.message : String(e)));
+  }
+
+  const pendingEmail = COORDINATOR_CRONS.some((c) => c.needs_confirmation);
+  result.message = (result.pointer_cleared ? 'Pointer cleared. ' : 'Pointer clear attempted (see errors). ') +
+    'Caller MUST have CronDeleted all coordinator crons FIRST (' + result.crons_to_delete.length + ' canonical' +
+    (pendingEmail ? '; email command pending confirmation' : '') + ').';
+  return result;
+}
+
+module.exports = {
+  FLAG,
+  COORDINATOR_CRONS,
+  COORD_SCRIPT_MARKERS,
+  isEnabled,
+  listCoordinatorCrons,
+  selectCoordinatorCronJobs,
+  clearCoordinatorPointer
+};

--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -48,11 +48,13 @@ describe('teardown-coordinator: inventory + matcher', () => {
       { id: 'b', prompt: 'node scripts/fleet-dashboard.cjs all' },
       { id: 'c', prompt: 'node scripts/fleet-dashboard.cjs inbox' }, // critical: same basename as dashboard
       { id: 'd', prompt: 'node scripts/assign-fleet-identities.cjs' },
+      { id: 'f', prompt: 'COORD_EMAIL_TICK=27801 node scripts/coordinator-email-summary.mjs' }, // email loop (coordinator-confirmed)
       { id: 'e', prompt: 'node scripts/some-worker-loop.cjs' } // NOT a coordinator cron
     ];
     const matched = selectCoordinatorCronJobs(jobs);
-    expect(matched.map((j) => j.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+    expect(matched.map((j) => j.id).sort()).toEqual(['a', 'b', 'c', 'd', 'f']);
     expect(matched.find((j) => j.prompt.includes('inbox'))).toBeTruthy();
+    expect(matched.find((j) => j.prompt.includes('coordinator-email-summary'))).toBeTruthy();
     expect(selectCoordinatorCronJobs(null)).toEqual([]);
   });
 });

--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -1,0 +1,125 @@
+// SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001 — unit tests for the unified teardown helper.
+// NFR-1: no live pointer/cron/DB is touched — tmp pointer files + null/throwing supabase only.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const {
+  FLAG,
+  COORDINATOR_CRONS,
+  isEnabled,
+  listCoordinatorCrons,
+  selectCoordinatorCronJobs,
+  clearCoordinatorPointer
+} = require('./teardown-coordinator.cjs');
+
+const FLAG_NAME = 'COORD_TEARDOWN_SAFETY_V2';
+let tmpPointer;
+
+function writePointer(sessionId) {
+  fs.writeFileSync(tmpPointer, JSON.stringify({ session_id: sessionId, started_at: 'x', host: 'h' }), 'utf8');
+}
+
+beforeEach(() => {
+  delete process.env[FLAG_NAME];
+  tmpPointer = path.join(os.tmpdir(), 'teardown-test-' + process.pid + '-' + Math.floor(performance.now() * 1000) + '.json');
+});
+afterEach(() => {
+  delete process.env[FLAG_NAME];
+  try { if (fs.existsSync(tmpPointer)) fs.unlinkSync(tmpPointer); } catch { /* ignore */ }
+});
+
+describe('teardown-coordinator: inventory + matcher', () => {
+  it('listCoordinatorCrons enumerates all 5 coordinator crons incl the pointer-re-asserting inbox loop', () => {
+    const crons = listCoordinatorCrons();
+    expect(crons.length).toBe(5);
+    const inbox = crons.find((c) => c.key === 'inbox');
+    expect(inbox).toBeTruthy();
+    expect(inbox.re_asserts_pointer).toBe(true); // the crux: missing this cron self-reverses teardown
+    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email']);
+  });
+
+  it('TS-6: selectCoordinatorCronJobs matches coordinator crons (incl inbox via fleet-dashboard.cjs marker) and excludes non-coordinator jobs', () => {
+    const jobs = [
+      { id: 'a', prompt: 'node scripts/stale-session-sweep.cjs' },
+      { id: 'b', prompt: 'node scripts/fleet-dashboard.cjs all' },
+      { id: 'c', prompt: 'node scripts/fleet-dashboard.cjs inbox' }, // critical: same basename as dashboard
+      { id: 'd', prompt: 'node scripts/assign-fleet-identities.cjs' },
+      { id: 'e', prompt: 'node scripts/some-worker-loop.cjs' } // NOT a coordinator cron
+    ];
+    const matched = selectCoordinatorCronJobs(jobs);
+    expect(matched.map((j) => j.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+    expect(matched.find((j) => j.prompt.includes('inbox'))).toBeTruthy();
+    expect(selectCoordinatorCronJobs(null)).toEqual([]);
+  });
+});
+
+describe('teardown-coordinator: clearCoordinatorPointer', () => {
+  it('TS-4: flag-OFF is a no-op passthrough (byte-identical legacy behavior, pointer untouched)', async () => {
+    writePointer('me');
+    const res = await clearCoordinatorPointer(null, { sessionId: 'me', pointerFile: tmpPointer });
+    expect(res.enabled).toBe(false);
+    expect(res.action).toBe('noop');
+    expect(res.pointer_cleared).toBe(false);
+    expect(fs.existsSync(tmpPointer)).toBe(true); // not cleared when flag off
+  });
+
+  it('TS-1: flag-ON owner teardown clears the pointer and returns the cron inventory', async () => {
+    process.env[FLAG_NAME] = 'true';
+    writePointer('me');
+    const res = await clearCoordinatorPointer(null, { sessionId: 'me', pointerFile: tmpPointer });
+    expect(res.enabled).toBe(true);
+    expect(res.refused).toBe(false);
+    expect(res.pointer_cleared).toBe(true);
+    expect(res.crons_to_delete.length).toBe(5);
+    expect(fs.existsSync(tmpPointer)).toBe(false); // pointer file removed
+  });
+
+  it('TS-2: session-scope guard refuses a non-owner (pointer left intact) — protects the LIVE coordinator', async () => {
+    process.env[FLAG_NAME] = 'on';
+    writePointer('SOMEONE-ELSE');
+    const res = await clearCoordinatorPointer(null, { sessionId: 'me', pointerFile: tmpPointer });
+    expect(res.refused).toBe(true);
+    expect(res.pointer_cleared).toBe(false);
+    expect(res.owner).toBe('SOMEONE-ELSE');
+    expect(fs.existsSync(tmpPointer)).toBe(true); // untouched
+  });
+
+  it('TS-3: force=true overrides the session-scope guard', async () => {
+    process.env[FLAG_NAME] = 'on';
+    writePointer('SOMEONE-ELSE');
+    const res = await clearCoordinatorPointer(null, { sessionId: 'me', force: true, pointerFile: tmpPointer });
+    expect(res.refused).toBe(false);
+    expect(res.forced).toBe(true);
+    expect(res.pointer_cleared).toBe(true);
+    expect(fs.existsSync(tmpPointer)).toBe(false);
+  });
+
+  it('TS-2b: fail-safe refuses when pointer cannot be read and force is not set', async () => {
+    process.env[FLAG_NAME] = 'on';
+    const throwingReader = () => { throw new Error('boom'); };
+    const res = await clearCoordinatorPointer(null, { sessionId: 'me', pointerFile: tmpPointer, readPointer: throwingReader });
+    expect(res.refused).toBe(true);
+    expect(res.pointer_cleared).toBe(false);
+    expect(res.errors.some((e) => e.includes('pointer-read'))).toBe(true);
+  });
+
+  it('TS-5: fail-open — a throwing supabase does NOT throw; returns a structured error result', async () => {
+    process.env[FLAG_NAME] = 'on';
+    writePointer('me');
+    const throwingSupabase = { from() { throw new Error('db-down'); } };
+    let threw = false;
+    let res;
+    try {
+      res = await clearCoordinatorPointer(throwingSupabase, { sessionId: 'me', pointerFile: tmpPointer });
+    } catch (e) {
+      threw = true;
+    }
+    expect(threw).toBe(false); // never throws (fail-open)
+    expect(res).toBeTruthy();
+    expect(res.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -291,6 +291,7 @@
     "sd:cancel": "node scripts/cancel-sd.js",
     "signal": "node scripts/worker-signal.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
+    "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",
     "sd:recover": "node scripts/sd-recover.js",

--- a/scripts/coordinator-teardown.cjs
+++ b/scripts/coordinator-teardown.cjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001 — thin CLI for the unified teardown contract.
+// Wired entry point (package.json "coordinator:teardown") for lib/coordinator/teardown-coordinator.cjs.
+//
+// Prints the canonical coordinator cron inventory the harness must CronDelete FIRST (CronList ->
+// CronDelete are Claude Code harness tools, NOT Node-callable — this CLI never deletes crons),
+// then clears the coordinator pointer (session-scoped, fail-open) when COORD_TEARDOWN_SAFETY_V2=on.
+// With the flag off, the pointer clear is a no-op and the legacy /coordinator stop path applies.
+//
+// Usage: node scripts/coordinator-teardown.cjs [--force]
+//   --force  clear the pointer even if this session does not own it (use only when intentionally
+//            taking over a dead coordinator; default refuses to protect the LIVE coordinator).
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const {
+  clearCoordinatorPointer,
+  listCoordinatorCrons,
+  isEnabled,
+  FLAG
+} = require('../lib/coordinator/teardown-coordinator.cjs');
+
+(async () => {
+  const force = process.argv.includes('--force');
+  const sessionId = process.env.CLAUDE_SESSION_ID || null;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const sb = url ? createClient(url, process.env.SUPABASE_SERVICE_ROLE_KEY) : null;
+
+  console.log('Coordinator crons to CronDelete FIRST (run CronList -> CronDelete for each, BEFORE the pointer clear):');
+  for (const c of listCoordinatorCrons()) {
+    console.log('  - ' + c.key.padEnd(10) + ' [' + c.cadence + '] ' + (c.command || '(command pending coordinator confirm)') +
+      (c.re_asserts_pointer ? '  <-- re-asserts the pointer; MUST delete' : ''));
+  }
+
+  if (!isEnabled()) {
+    console.log('\n' + FLAG + ' is OFF — pointer clear is a no-op (legacy /coordinator stop path applies; behavior unchanged).');
+    return;
+  }
+  const r = await clearCoordinatorPointer(sb, { sessionId, force });
+  console.log('\nPointer clear result:\n' + JSON.stringify(r, null, 2));
+})().catch((e) => {
+  // Fail-open even at the CLI boundary: never hard-fail a teardown.
+  console.error('coordinator-teardown (fail-open):', e && e.message ? e.message : String(e));
+  process.exit(0);
+});


### PR DESCRIPTION
## SD-LEO-INFRA-COORDINATOR-CRON-TEARDOWN-001 — default-OFF unified coordinator teardown contract

Fixes the coordinator teardown asymmetry where `/coordinator stop` is **self-reversing**: the inbox cron loop (`*/2`) calls `setActiveCoordinator` every ~2min and re-asserts the pointer on the next tick. Separately, the queue-empty auto-teardown CronDeleted only sweep+dashboard and never cleared the pointer (orphaning identity/inbox/email + a stale pointer).

### Fix (all behind `COORD_TEARDOWN_SAFETY_V2`, default-OFF)
- `lib/coordinator/teardown-coordinator.cjs` (new): canonical 5-cron inventory; `selectCoordinatorCronJobs()` matches coordinator crons from a `CronList` result by script basename (the `fleet-dashboard.cjs` marker covers both the dashboard and the critical inbox loop, so it's robust to the committed-3-vs-live-5 cron drift); `clearCoordinatorPointer()` is session-scoped (won't clear a pointer this session doesn't own, unless `force`) + fail-open. Returns cron-ids for the harness — `CronList`/`CronDelete` are Claude Code harness tools, not Node-callable.
- `lib/coordinator/resolve.cjs`: additive `pointerFile`/`file` params for test injectability (existing callers byte-identical).
- `.claude/commands/coordinator.md`: both `/coordinator stop` + queue-empty auto-teardown wired to the flag-gated contract (crons-FIRST, pointer-SECOND). Legacy path preserved when flag off.
- `scripts/coordinator-teardown.cjs` + `package.json` `coordinator:teardown`: wired CLI entry point.

### Safety
- **Default-OFF**: flag-OFF is byte-identical to current main (golden test). Merging does NOT change live behavior until `COORD_TEARDOWN_SAFETY_V2` is enabled.
- Session-scoped pointer guard cannot clobber the LIVE coordinator pointer.
- No live pointer/cron/DB touched in tests.

### Tests
8 new unit tests (flag-OFF parity, owner clear, session-scope guard, force, fail-open, matcher); full `lib/coordinator` suite **77/77** green, zero regressions.

### Gates
LEAD 95 · PRD 93 · PLAN-TO-EXEC 92 · EXEC-TO-PLAN 93 · PLAN-TO-LEAD 96 · retro 100 · TESTING PASS.

### Follow-ups
- Confirm the email cron exact command (signalled prd-ambiguous) + add its matcher marker.
- Reconcile `coordinator.md` Step 4 to create all coordinator crons from one canonical inventory.
- `SD-LEO-INFRA-COORDINATOR-CRON-BACKOFF-001` for adaptive-backoff Layer 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
