### PR TITLE
feat(SD-LEO-INFRA-PARKED-STATUS-REPLACE-001): park/unpark SDs via status='deferred'

### DIFF
--- a/database/migrations/20260606012331_v_sd_next_candidates_exclude_deferred.sql
+++ b/database/migrations/20260606012331_v_sd_next_candidates_exclude_deferred.sql
@@ -1,0 +1,81 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260606012331_v_sd_next_candidates_exclude_deferred.sql
+--
+-- SD-LEO-INFRA-PARKED-STATUS-REPLACE-001
+--
+-- Make status='deferred' the canonical "parked" state by excluding it from the
+-- work-selection view v_sd_next_candidates. Previously the final WHERE blocklist
+-- only excluded 'completed' and 'cancelled'; a parked (deferred) SD therefore
+-- still surfaced as next-candidate work. This adds 'deferred' to the blocklist
+-- so parked SDs disappear from the queue but remain queryable/recoverable.
+--
+-- The view body below is reproduced EXACTLY from the live definition
+-- (pg_get_viewdef('public.v_sd_next_candidates')) as of 2026-06-06; the ONLY
+-- change is the final WHERE array:
+--   ARRAY['completed','cancelled']  ->  ARRAY['completed','cancelled','deferred']
+-- Both the CASE/readiness_priority expression and the ORDER BY are preserved
+-- verbatim. No other behavior is altered.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.v_sd_next_candidates AS
+ WITH active_baseline AS (
+         SELECT sd_execution_baselines.id
+           FROM sd_execution_baselines
+          WHERE sd_execution_baselines.is_active = true
+         LIMIT 1
+        ), dependency_status AS (
+         SELECT bi_1.sd_id,
+            bi_1.sequence_rank,
+            bi_1.track,
+            bi_1.dependencies_snapshot,
+            COALESCE(( SELECT count(*) = 0
+                   FROM jsonb_array_elements_text(bi_1.dependencies_snapshot) dep(value)
+                  WHERE NOT (EXISTS ( SELECT 1
+                           FROM strategic_directives_v2 sd2
+                          WHERE sd2.sd_key = split_part(dep.value, ' '::text, 1) AND sd2.status::text = 'completed'::text))), true) AS deps_satisfied
+           FROM sd_baseline_items bi_1
+          WHERE bi_1.baseline_id = (( SELECT active_baseline.id
+                   FROM active_baseline))
+        )
+ SELECT bi.sd_id,
+    sd.title,
+    sd.priority,
+    sd.status,
+    sd.progress_percentage,
+    bi.sequence_rank,
+    bi.track,
+    bi.track_name,
+    bi.estimated_effort_hours,
+    bi.dependency_health_score,
+    ds.deps_satisfied,
+    ea.status AS execution_status,
+    sd.is_working_on,
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying, 'active'::character varying]::text[])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END AS readiness_priority
+   FROM sd_baseline_items bi
+     JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key
+     JOIN dependency_status ds ON bi.sd_id = ds.sd_id
+     LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id AND ea.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline))
+  WHERE bi.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline)) AND (sd.status::text <> ALL (ARRAY['completed'::character varying, 'cancelled'::character varying, 'deferred'::character varying]::text[]))
+  ORDER BY (
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying, 'active'::character varying]::text[])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END), bi.sequence_rank;
+
+COMMIT;
+
+-- Rollback (manual): re-run CREATE OR REPLACE VIEW with the final WHERE array
+-- restored to ARRAY['completed'::character varying, 'cancelled'::character varying]::text[].

--- a/docs/ops/sd-park.md
+++ b/docs/ops/sd-park.md
@@ -1,0 +1,59 @@
+# Parking a Strategic Directive (cancel ≠ park)
+
+**SD-LEO-INFRA-PARKED-STATUS-REPLACE-001**
+
+To set an SD aside **without abandoning it**, *park* it — do **not** cancel it.
+
+## TL;DR
+
+```bash
+# Park (set aside, recoverable, excluded from sd:next + the sweep):
+node scripts/sd-park.js park SD-XXX-001 --reason "fleet wind-down; resume after epic #3"
+
+# Unpark (back to a workable, claimable status):
+node scripts/sd-park.js unpark SD-XXX-001
+# then re-claim normally:
+node scripts/sd-start.js SD-XXX-001
+```
+
+## `deferred` is the canonical parked state
+
+Parking sets `strategic_directives_v2.status = 'deferred'`. That value already exists in
+the status CHECK constraint and is already excluded from every live work-selection path
+(`sd:next` recommendations, `sd-start`, the fleet dashboard) and from the claim-liveness
+sweep — but it was previously unused. Park adopts it and records `metadata.park_reason`,
+`parked_at`, `parked_by`, and `parked_from_status`, so a parked SD stays **fully queryable
+and reversible**.
+
+Park also **releases the atomic claim** across both `strategic_directives_v2`
+(`claiming_session_id`, `is_working_on`) and `claude_sessions` (`sd_key` + worktree fields,
+cleared together) in one transaction, and **never touches `current_phase`**.
+
+## Why not `cancel` (the anti-pattern)
+
+Using `status='cancelled'` to defer an SD is harmful:
+
+- It fires **cancel-only side-effects** — the `trg_reset_patterns_on_sd_cancel` trigger
+  resets assigned `issue_patterns`, and other cancel cascades run — that you do **not**
+  want for work you intend to resume.
+- It pollutes the `cancelled` set, mixing truly-abandoned SDs with merely-parked ones.
+
+Park (`deferred`) fires **none** of those cascades.
+
+## Retired: `metadata.do_not_auto_start`
+
+The `metadata.do_not_auto_start` flag is **dead** — it never had a production consumer
+(the live work-selection paths use positive status allowlists, which the flag was never
+wired into). It is **superseded by park**. Do not set it; park instead.
+
+## Edge cases (documented, intentional)
+
+- **`progress >= 100` in EXEC/PLAN**: park normalizes `progress` to 99 in the same update
+  so `auto_transition_status` does not flip the SD to `pending_approval`; the original
+  value is restored on unpark (`metadata.parked_progress_original`).
+- **Actor role**: park/unpark must run under a **non-EXEC** actor
+  (`enforce_doctrine_of_constraint` raises under `EXEC`). The CLI defaults to `cli`.
+- **Parked child of an orchestrator**: a parked (deferred) child keeps the parent in
+  `WAITING_FOR_CHILDREN` — correct, since the child is deliberately not done.
+- **Venture teardown**: `delete_venture`/`kill_venture` still force-cancel a parked SD on
+  a killed venture — reasonable teardown behavior; left as-is.

--- a/lib/sd-park.js
+++ b/lib/sd-park.js
@@ -1,0 +1,115 @@
+/**
+ * SD park / unpark — set a Strategic Directive aside without abandoning it.
+ *
+ * Reuses the existing-but-unused status='deferred' as the canonical "parked" state
+ * (no new enum value, no status migration). Park releases the atomic claim across
+ * strategic_directives_v2 + claude_sessions in ONE transaction, never touches
+ * current_phase, runs under a non-EXEC actor, and guards the auto_transition_status
+ * edge (progress>=100 in EXEC/PLAN would otherwise flip status to pending_approval).
+ *
+ * Replaces the dead metadata.do_not_auto_start flag and the cancel-to-park workaround:
+ * deferred is already excluded from every live work-selection allowlist and from the
+ * claim-liveness sweep, and (unlike cancel) does NOT fire trg_reset_patterns_on_sd_cancel
+ * or trigger_retro_notification — so a parked SD stays recoverable and queryable.
+ *
+ * SD-LEO-INFRA-PARKED-STATUS-REPLACE-001.
+ */
+export const PARK_STATUS = 'deferred';
+const WORKABLE = ['draft', 'active', 'planning', 'in_progress'];
+const TERMINAL = ['completed', 'cancelled'];
+const PARK_META_KEYS = ['park_reason', 'parked_at', 'parked_by', 'parked_from_status', 'parked_progress_original'];
+
+/**
+ * Pure planning helper (no DB) — decide the park transition for a loaded SD row.
+ * Throws on a terminal SD or an EXEC/empty actor. `edge` means progress must be
+ * normalized to 99 so auto_transition_status does not override status='deferred'.
+ * @param {{sd_key,status,current_phase,progress}} sd
+ * @returns {{edge:boolean, parkMetaPatch:object}}
+ */
+export function computeParkPlan(sd, reason, actor, nowIso) {
+  if (!reason) throw new Error('park requires a reason');
+  if (!actor || actor === 'EXEC') throw new Error(`park requires a non-EXEC actor (got: ${actor})`);
+  if (TERMINAL.includes(sd.status)) throw new Error(`Cannot park ${sd.sd_key}: terminal status (${sd.status})`);
+  const edge = Number(sd.progress) >= 100 && ['EXEC', 'PLAN'].includes(sd.current_phase);
+  return {
+    edge,
+    parkMetaPatch: {
+      park_reason: reason,
+      parked_at: nowIso || new Date().toISOString(),
+      parked_by: actor,
+      parked_from_status: sd.status,
+      parked_progress_original: edge ? Number(sd.progress) : null,
+    },
+  };
+}
+
+/**
+ * Park an SD: status->deferred + release claim (both tables, one txn).
+ * @param {{query:Function}} client - pg client (injectable for tests)
+ */
+export async function park(client, sdKey, { reason, actor }) {
+  const { rows } = await client.query(
+    'SELECT sd_key, status, current_phase, progress, metadata FROM strategic_directives_v2 WHERE sd_key=$1',
+    [sdKey]
+  );
+  if (!rows.length) throw new Error(`SD not found: ${sdKey}`);
+  const sd = rows[0];
+  const { edge, parkMetaPatch } = computeParkPlan(sd, reason, actor);
+  try {
+    await client.query('BEGIN');
+    // SD side: deferred + release-claim mirror + edge guard + merged park metadata. No current_phase write.
+    await client.query(
+      `UPDATE strategic_directives_v2
+         SET status=$2, is_working_on=false, claiming_session_id=NULL, active_session_id=NULL,
+             progress = CASE WHEN $3 THEN 99 ELSE progress END,
+             metadata = COALESCE(metadata,'{}'::jsonb) || $4::jsonb,
+             updated_at=now(), updated_by=$5
+       WHERE sd_key=$1`,
+      [sdKey, PARK_STATUS, edge, JSON.stringify(parkMetaPatch), actor]
+    );
+    // Session side: release the claim; clear worktree fields WITH sd_key (ck_claude_sessions_worktree_state_consistency).
+    await client.query(
+      `UPDATE claude_sessions
+         SET sd_key=NULL, worktree_path=NULL, worktree_branch=NULL, status='idle', updated_at=now()
+       WHERE sd_key=$1`,
+      [sdKey]
+    );
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  }
+  return { sdKey, status: PARK_STATUS, parked_from_status: sd.status, edge };
+}
+
+/**
+ * Unpark an SD: restore a workable status + strip park metadata. Claim-neutral
+ * (re-claim via the normal sd-start atomic path). Never touches current_phase.
+ */
+export async function unpark(client, sdKey, { actor = 'cli', restoreStatus } = {}) {
+  if (actor === 'EXEC') throw new Error('unpark requires a non-EXEC actor');
+  const { rows } = await client.query(
+    'SELECT sd_key, status, metadata FROM strategic_directives_v2 WHERE sd_key=$1',
+    [sdKey]
+  );
+  if (!rows.length) throw new Error(`SD not found: ${sdKey}`);
+  const sd = rows[0];
+  if (sd.status !== PARK_STATUS) throw new Error(`SD ${sdKey} is not parked (status=${sd.status})`);
+  const md = { ...(sd.metadata || {}) };
+  const from = md.parked_from_status;
+  const target = restoreStatus || (WORKABLE.includes(from) ? from : 'draft');
+  const origProg = md.parked_progress_original;
+  for (const k of PARK_META_KEYS) delete md[k];
+  // RETURNING the persisted status, because restoring progress>=100 in EXEC/PLAN makes
+  // auto_transition_status flip status to 'pending_approval' (correct resume behavior) —
+  // so the requested target and the actual status can differ. Report the truth.
+  const { rows: out } = await client.query(
+    `UPDATE strategic_directives_v2
+       SET status=$2, progress = COALESCE($3, progress), metadata=$4::jsonb, updated_at=now(), updated_by=$5
+     WHERE sd_key=$1
+     RETURNING status`,
+    [sdKey, target, origProg ?? null, JSON.stringify(md), actor]
+  );
+  const actual = (out[0] && out[0].status) || target;
+  return { sdKey, status: actual, requested: target };
+}

--- a/scripts/sd-park.js
+++ b/scripts/sd-park.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * CLI: park / unpark a Strategic Directive (status='deferred' = the canonical parked
+ * state). Replaces the cancel-to-park anti-pattern and the dead do_not_auto_start flag.
+ *
+ *   node scripts/sd-park.js park   <SD-KEY> --reason "<why>" [--actor <role>]
+ *   node scripts/sd-park.js unpark <SD-KEY> [--restore <status>] [--actor <role>]
+ *
+ * Park excludes the SD from sd:next recommendations + the stale-session sweep while
+ * keeping it fully queryable; unpark restores a workable status (re-claim via sd-start).
+ * SD-LEO-INFRA-PARKED-STATUS-REPLACE-001.
+ */
+import 'dotenv/config';
+import { park, unpark } from '../lib/sd-park.js';
+
+function flag(rest, name) {
+  const i = rest.indexOf('--' + name);
+  return i >= 0 ? rest[i + 1] : undefined;
+}
+
+async function main() {
+  const [verb, sdKey, ...rest] = process.argv.slice(2);
+  if (!['park', 'unpark'].includes(verb) || !sdKey) {
+    console.error('Usage:');
+    console.error('  node scripts/sd-park.js park   <SD-KEY> --reason "<why>" [--actor <role>]');
+    console.error('  node scripts/sd-park.js unpark <SD-KEY> [--restore <status>] [--actor <role>]');
+    process.exit(1);
+  }
+  const actor = flag(rest, 'actor') || 'cli';
+  if (actor === 'EXEC') { console.error('refusing --actor EXEC (enforce_doctrine_of_constraint)'); process.exit(1); }
+  const { createDatabaseClient } = await import('../lib/supabase-connection.js');
+  const client = await createDatabaseClient('engineer', { verify: false });
+  try {
+    if (verb === 'park') {
+      const reason = flag(rest, 'reason');
+      if (!reason) { console.error('park requires --reason "<why>"'); process.exit(1); }
+      const r = await park(client, sdKey, { reason, actor });
+      console.log(`✓ parked ${r.sdKey}: ${r.parked_from_status} → ${r.status}${r.edge ? ' (progress normalized to dodge auto_transition)' : ''}; claim released`);
+    } else {
+      const r = await unpark(client, sdKey, { actor, restoreStatus: flag(rest, 'restore') });
+      console.log(`✓ unparked ${r.sdKey} → ${r.status} (re-claim via: node scripts/sd-start.js ${r.sdKey})`);
+    }
+  } finally {
+    if (client && typeof client.end === 'function') await client.end();
+  }
+}
+
+main().catch((e) => { console.error('ERROR:', e.message); process.exit(1); });

--- a/tests/integration/sd-park.test.js
+++ b/tests/integration/sd-park.test.js
@@ -1,0 +1,333 @@
+/**
+ * Integration tests for lib/sd-park.js park() / unpark() against the LIVE
+ * consolidated database — SD-LEO-INFRA-PARKED-STATUS-REPLACE-001 (TS-1..TS-6).
+ *
+ * ZERO-LEAK contract: every test runs inside ONE outer real transaction that is
+ * ROLLED BACK in afterAll. The real lib issues its own BEGIN/COMMIT/ROLLBACK, so
+ * we hand it a SAVEPOINT-translating wrapper (savepointClient): the lib's
+ * BEGIN -> SAVEPOINT, COMMIT -> RELEASE SAVEPOINT, ROLLBACK -> ROLLBACK TO
+ * SAVEPOINT. Nothing the lib "commits" actually commits — the outer ROLLBACK
+ * discards every seeded row (and its governance_audit row) together. We do NOT
+ * use INSERT-then-afterEach-DELETE (a prior SD leaked 2327 rows that way).
+ *
+ * The REAL lib/sd-park.js is imported and exercised verbatim; it is never
+ * reimplemented here. Throwaway rows use a unique RUN_ID and are seeded inside
+ * the rolled-back txn; the real SD-LEO-INFRA-PARKED-STATUS-REPLACE-001 and any
+ * SD-TEST-* fixture are never touched.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+import { park, unpark, PARK_STATUS } from '../../lib/sd-park.js';
+
+const describeDb = describe.skipIf(!HAS_REAL_DB);
+
+const RUN_ID = `PARKTEST-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const sdKeyFor = (suffix) => `SD-${RUN_ID}-${suffix}`;
+
+let rawClient;          // the real pg Client (one outer txn)
+let savepointClient;    // wrapper handed to park()/unpark()
+let spCounter = 0;
+
+/**
+ * Wrap a connected pg client so that the lib's transaction control nests inside
+ * the outer transaction via SAVEPOINTs instead of committing for real.
+ */
+function makeSavepointClient(client) {
+  let activeSp = null;
+  return {
+    _raw: client,
+    async query(sql, params) {
+      if (typeof sql === 'string') {
+        const t = sql.trim().toUpperCase();
+        if (t === 'BEGIN') {
+          activeSp = `sp_park_${++spCounter}`;
+          return client.query(`SAVEPOINT ${activeSp}`);
+        }
+        if (t === 'COMMIT') {
+          const sp = activeSp; activeSp = null;
+          return client.query(`RELEASE SAVEPOINT ${sp}`);
+        }
+        if (t === 'ROLLBACK') {
+          const sp = activeSp; activeSp = null;
+          // Roll back to and release the savepoint so the outer txn stays usable.
+          await client.query(`ROLLBACK TO SAVEPOINT ${sp}`);
+          return client.query(`RELEASE SAVEPOINT ${sp}`);
+        }
+      }
+      return client.query(sql, params);
+    },
+  };
+}
+
+/** Seed a throwaway SD inside the outer txn. Non-EXEC actor (doctrine guard). */
+async function seedSd(suffix, { status = 'in_progress', current_phase = 'EXEC', progress = 0, metadata = {} } = {}) {
+  const sdKey = sdKeyFor(suffix);
+  const id = sdKey; // strategic_directives_v2.id is varchar; use the key as id
+  await rawClient.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, status, category, priority, description, rationale, scope,
+        current_phase, progress, metadata, created_by, updated_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13,$14)`,
+    [
+      id, sdKey, `Throwaway park test ${suffix}`, status, 'infrastructure', 'low',
+      `Throwaway row for ${RUN_ID} ${suffix}. Safe to roll back.`,
+      `Regression fixture for SD-LEO-INFRA-PARKED-STATUS-REPLACE-001 (${suffix}).`,
+      `Seeded inside a rolled-back transaction; never committed.`,
+      current_phase, progress, JSON.stringify(metadata), 'TEST', 'TEST',
+    ],
+  );
+  return sdKey;
+}
+
+async function readSd(sdKey) {
+  const { rows } = await rawClient.query(
+    `SELECT sd_key, status, current_phase, progress, is_working_on,
+            claiming_session_id, active_session_id, metadata
+       FROM strategic_directives_v2 WHERE sd_key=$1`,
+    [sdKey],
+  );
+  return rows[0];
+}
+
+describeDb('lib/sd-park.js park()/unpark() — live DB, savepoint-isolated', () => {
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    rawClient = await createDatabaseClient('engineer');
+    await rawClient.query('BEGIN'); // outer txn — rolled back in afterAll
+    savepointClient = makeSavepointClient(rawClient);
+  });
+
+  afterAll(async () => {
+    if (rawClient) {
+      // Discard EVERYTHING seeded this run — zero rows reach prod.
+      await rawClient.query('ROLLBACK');
+      // Sanity: confirm none of our throwaway SDs survived the rollback.
+      const { rows } = await rawClient.query(
+        `SELECT count(*)::int AS n FROM strategic_directives_v2 WHERE sd_key LIKE $1`,
+        [`SD-${RUN_ID}-%`],
+      );
+      expect(rows[0].n).toBe(0);
+      await rawClient.end();
+    }
+  });
+
+  // Each test gets its own savepoint so a seed in one test never bleeds into the
+  // next, while the outer txn (and its single final ROLLBACK) still owns cleanup.
+  let testSp;
+  beforeEach(async () => {
+    testSp = `sp_test_${++spCounter}`;
+    await rawClient.query(`SAVEPOINT ${testSp}`);
+    return async () => {
+      await rawClient.query(`ROLLBACK TO SAVEPOINT ${testSp}`);
+      await rawClient.query(`RELEASE SAVEPOINT ${testSp}`);
+    };
+  });
+
+  it('TS: park sets status=deferred, clears claim flags, leaves current_phase UNCHANGED, writes park metadata', async () => {
+    const sdKey = await seedSd('basic', { status: 'in_progress', current_phase: 'EXEC', progress: 40 });
+    const before = await readSd(sdKey);
+
+    const res = await park(savepointClient, sdKey, { reason: 'parking for TS', actor: 'PLAN' });
+    expect(res.status).toBe(PARK_STATUS);
+    expect(res.parked_from_status).toBe('in_progress');
+
+    const after = await readSd(sdKey);
+    expect(after.status).toBe('deferred');
+    expect(after.is_working_on).toBe(false);
+    expect(after.claiming_session_id).toBeNull();
+    expect(after.active_session_id).toBeNull();
+    // current_phase must be untouched by park.
+    expect(after.current_phase).toBe(before.current_phase);
+    expect(after.current_phase).toBe('EXEC');
+    // park metadata recorded.
+    expect(after.metadata.park_reason).toBe('parking for TS');
+    expect(after.metadata.parked_from_status).toBe('in_progress');
+    expect(after.metadata.parked_by).toBe('PLAN');
+    expect(after.metadata.parked_at).toBeTruthy();
+  });
+
+  it('TS-4: claim release spans BOTH tables; claude_sessions sd_key+worktree_path+worktree_branch cleared together (consistency check holds, txn commits)', async () => {
+    const sdKey = await seedSd('claim', { status: 'in_progress', current_phase: 'EXEC', progress: 30 });
+    const sessionId = `sess-${RUN_ID}-claim`;
+    // Mark the SD as claimed by this session.
+    await rawClient.query(
+      `UPDATE strategic_directives_v2 SET is_working_on=true, claiming_session_id=$2, active_session_id=$2 WHERE sd_key=$1`,
+      [sdKey, sessionId],
+    );
+    // Seed a claude_sessions row holding the claim WITH worktree fields set.
+    await rawClient.query(
+      `INSERT INTO claude_sessions (session_id, sd_key, worktree_path, worktree_branch, status)
+       VALUES ($1,$2,$3,$4,'active')`,
+      [sessionId, sdKey, `C:/wt/${RUN_ID}`, `feat/${RUN_ID}`],
+    );
+
+    // park must COMMIT successfully — i.e. the worktree-consistency CHECK is satisfied
+    // because sd_key + worktree_path + worktree_branch are cleared in the SAME update.
+    await park(savepointClient, sdKey, { reason: 'release claim', actor: 'PLAN' });
+
+    const sd = await readSd(sdKey);
+    expect(sd.claiming_session_id).toBeNull();
+    expect(sd.active_session_id).toBeNull();
+    expect(sd.is_working_on).toBe(false);
+
+    const { rows: sess } = await rawClient.query(
+      `SELECT sd_key, worktree_path, worktree_branch, status FROM claude_sessions WHERE session_id=$1`,
+      [sessionId],
+    );
+    expect(sess.length).toBe(1);
+    expect(sess[0].sd_key).toBeNull();
+    expect(sess[0].worktree_path).toBeNull();
+    expect(sess[0].worktree_branch).toBeNull();
+    expect(sess[0].status).toBe('idle');
+  });
+
+  it('TS-1: a parked SD is ABSENT from v_sd_next_candidates while a non-parked control still appears', async () => {
+    // Seed a temporary ACTIVE baseline (partial-unique idx allows exactly one;
+    // there are currently zero) + two baseline items: parked + active control.
+    const parkedKey = await seedSd('view-parked', { status: 'active', current_phase: 'LEAD', progress: 0 });
+    const controlKey = await seedSd('view-control', { status: 'active', current_phase: 'LEAD', progress: 0 });
+    const { rows: bl } = await rawClient.query(
+      `INSERT INTO sd_execution_baselines (baseline_name, baseline_type, is_active, created_by)
+       VALUES ($1,'test',true,'TEST') RETURNING id`,
+      [`baseline-${RUN_ID}`],
+    );
+    const baselineId = bl[0].id;
+    await rawClient.query(
+      `INSERT INTO sd_baseline_items (baseline_id, sd_id, sequence_rank, dependencies_snapshot)
+       VALUES ($1,$2,1,'[]'::jsonb), ($1,$3,2,'[]'::jsonb)`,
+      [baselineId, parkedKey, controlKey],
+    );
+
+    // Before park: both appear in the candidate view.
+    const beforeRows = await rawClient.query(
+      `SELECT sd_id FROM v_sd_next_candidates WHERE sd_id IN ($1,$2)`,
+      [parkedKey, controlKey],
+    );
+    const beforeSet = beforeRows.rows.map((r) => r.sd_id).sort();
+    expect(beforeSet).toEqual([controlKey, parkedKey].sort());
+
+    // Park one of them.
+    await park(savepointClient, parkedKey, { reason: 'hide from queue', actor: 'PLAN' });
+
+    // After park: parked SD returns ZERO rows; control still present.
+    const parkedRows = await rawClient.query(
+      `SELECT sd_id FROM v_sd_next_candidates WHERE sd_id=$1`,
+      [parkedKey],
+    );
+    expect(parkedRows.rows.length).toBe(0);
+
+    const controlRows = await rawClient.query(
+      `SELECT sd_id FROM v_sd_next_candidates WHERE sd_id=$1`,
+      [controlKey],
+    );
+    expect(controlRows.rows.length).toBe(1);
+
+    // And the parked SD's status is not in the positive-allowlist selector set
+    // (draft/active/in_progress/planning) that work-selection paths key on.
+    const sd = await readSd(parkedKey);
+    expect(['draft', 'active', 'in_progress', 'planning']).not.toContain(sd.status);
+    expect(sd.status).toBe('deferred');
+  });
+
+  it('TS-2: park fires NEITHER trg_reset_patterns_on_sd_cancel NOR trigger_retro_notification', async () => {
+    const sdKey = await seedSd('cascades', { status: 'in_progress', current_phase: 'EXEC', progress: 20 });
+    // Assign an issue_patterns row to the SD.
+    const patternId = `PAT-${RUN_ID}`;
+    await rawClient.query(
+      `INSERT INTO issue_patterns (pattern_id, category, issue_summary, severity, status, occurrence_count, assigned_sd_id)
+       VALUES ($1,'process','throwaway park-cascade fixture','medium','assigned',1,$2)`,
+      [patternId, sdKey],
+    );
+    // Snapshot retro_notifications count for this SD (by sd_id = the SD id/key).
+    const retroBefore = await rawClient.query(
+      `SELECT count(*)::int AS n FROM retro_notifications WHERE sd_id=$1`,
+      [sdKey],
+    );
+
+    await park(savepointClient, sdKey, { reason: 'no cascades', actor: 'PLAN' });
+
+    // issue_patterns assignment unchanged — the cancel trigger (status->cancelled) did NOT fire.
+    const { rows: pat } = await rawClient.query(
+      `SELECT status, assigned_sd_id FROM issue_patterns WHERE pattern_id=$1`,
+      [patternId],
+    );
+    expect(pat[0].assigned_sd_id).toBe(sdKey);
+    expect(pat[0].status).toBe('assigned');
+
+    // retro_notifications count unchanged — the completion trigger did NOT fire.
+    const retroAfter = await rawClient.query(
+      `SELECT count(*)::int AS n FROM retro_notifications WHERE sd_id=$1`,
+      [sdKey],
+    );
+    expect(retroAfter.rows[0].n).toBe(retroBefore.rows[0].n);
+  });
+
+  it('TS-3: progress>=100 & current_phase=EXEC edge -> status=deferred, progress=99, metadata.parked_progress_original=100 (NOT pending_approval)', async () => {
+    const sdKey = await seedSd('edge', { status: 'in_progress', current_phase: 'EXEC', progress: 100 });
+
+    const res = await park(savepointClient, sdKey, { reason: 'park at 100', actor: 'PLAN' });
+    expect(res.edge).toBe(true);
+
+    const after = await readSd(sdKey);
+    expect(after.status).toBe('deferred');
+    expect(after.status).not.toBe('pending_approval');
+    expect(after.progress).toBe(99);
+    expect(after.current_phase).toBe('EXEC'); // unchanged
+    // metadata stores the original progress (JSON number).
+    expect(Number(after.metadata.parked_progress_original)).toBe(100);
+  });
+
+  it('TS-5: park -> unpark round-trip restores the workable status and strips park_* metadata', async () => {
+    const sdKey = await seedSd('roundtrip', { status: 'active', current_phase: 'LEAD', progress: 0, metadata: { keep_me: 'yes' } });
+    const before = await readSd(sdKey);
+
+    await park(savepointClient, sdKey, { reason: 'temporary', actor: 'PLAN' });
+    const parked = await readSd(sdKey);
+    expect(parked.status).toBe('deferred');
+    expect(parked.metadata.park_reason).toBe('temporary');
+
+    const res = await unpark(savepointClient, sdKey, { actor: 'PLAN' });
+    expect(res.status).toBe('active'); // restored to the pre-park workable status
+
+    const after = await readSd(sdKey);
+    expect(after.status).toBe('active');
+    expect(after.current_phase).toBe(before.current_phase); // never touched
+    // All park_* keys stripped; unrelated metadata preserved.
+    expect(after.metadata.park_reason).toBeUndefined();
+    expect(after.metadata.parked_at).toBeUndefined();
+    expect(after.metadata.parked_by).toBeUndefined();
+    expect(after.metadata.parked_from_status).toBeUndefined();
+    expect(after.metadata.parked_progress_original).toBeUndefined();
+    expect(after.metadata.keep_me).toBe('yes');
+  });
+
+  it('TS-5b: unpark of an SD parked from the 100/EXEC edge -> persisted status=pending_approval, and unpark returns that truthfully', async () => {
+    const sdKey = await seedSd('edge-unpark', { status: 'in_progress', current_phase: 'EXEC', progress: 100 });
+
+    await park(savepointClient, sdKey, { reason: 'park at edge', actor: 'PLAN' });
+    const parked = await readSd(sdKey);
+    expect(parked.status).toBe('deferred');
+    expect(parked.progress).toBe(99);
+
+    // unpark restores progress->100 in EXEC, so auto_transition_status flips
+    // status to 'pending_approval'. unpark must RETURN the actual persisted status.
+    const res = await unpark(savepointClient, sdKey, { actor: 'PLAN' });
+    const after = await readSd(sdKey);
+    expect(after.progress).toBe(100);
+    expect(after.status).toBe('pending_approval');
+    expect(res.status).toBe('pending_approval'); // truthful contract: returns the persisted status, not the request
+  });
+
+  it('TS-6: park rejects actor=EXEC (throws) and leaves the SD status UNCHANGED (no DB write)', async () => {
+    const sdKey = await seedSd('exec-actor', { status: 'in_progress', current_phase: 'EXEC', progress: 50 });
+
+    await expect(
+      park(savepointClient, sdKey, { reason: 'should be rejected', actor: 'EXEC' }),
+    ).rejects.toThrow(/non-EXEC actor/i);
+
+    // Status untouched — the guard fired before any persistence.
+    const after = await readSd(sdKey);
+    expect(after.status).toBe('in_progress');
+    expect(after.metadata.park_reason).toBeUndefined();
+  });
+});

--- a/tests/unit/sd-park.computeParkPlan.test.js
+++ b/tests/unit/sd-park.computeParkPlan.test.js
@@ -1,0 +1,96 @@
+/**
+ * Pure-logic unit tests for lib/sd-park.js computeParkPlan().
+ *
+ * No DB: exercises the terminal-status guard, the non-EXEC actor guard, the
+ * reason guard, and the progress>=100 EXEC/PLAN edge detection + metadata patch
+ * that auto_transition_status would otherwise flip to 'pending_approval'.
+ *
+ * SD-LEO-INFRA-PARKED-STATUS-REPLACE-001 — covers the pure portion of TS-3 and TS-6.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeParkPlan, PARK_STATUS } from '../../lib/sd-park.js';
+
+const NOW = '2026-06-05T00:00:00.000Z';
+
+describe('computeParkPlan — guards', () => {
+  it('PARK_STATUS is the existing deferred enum (no new status value)', () => {
+    expect(PARK_STATUS).toBe('deferred');
+  });
+
+  it('throws when no reason is provided', () => {
+    expect(() => computeParkPlan(
+      { sd_key: 'SD-X', status: 'active', current_phase: 'EXEC', progress: 50 },
+      '', 'PLAN', NOW,
+    )).toThrow(/reason/i);
+  });
+
+  it('throws when actor is EXEC (non-EXEC actor guard — TS-6)', () => {
+    expect(() => computeParkPlan(
+      { sd_key: 'SD-X', status: 'active', current_phase: 'EXEC', progress: 50 },
+      'parking it', 'EXEC', NOW,
+    )).toThrow(/non-EXEC actor/i);
+  });
+
+  it('throws when actor is empty/undefined (treated like EXEC)', () => {
+    expect(() => computeParkPlan(
+      { sd_key: 'SD-X', status: 'active', current_phase: 'EXEC', progress: 50 },
+      'parking it', undefined, NOW,
+    )).toThrow(/non-EXEC actor/i);
+  });
+
+  it('throws when SD is in a terminal status (completed)', () => {
+    expect(() => computeParkPlan(
+      { sd_key: 'SD-X', status: 'completed', current_phase: 'EXEC', progress: 100 },
+      'parking it', 'PLAN', NOW,
+    )).toThrow(/terminal status/i);
+  });
+
+  it('throws when SD is in a terminal status (cancelled)', () => {
+    expect(() => computeParkPlan(
+      { sd_key: 'SD-X', status: 'cancelled', current_phase: 'LEAD', progress: 0 },
+      'parking it', 'LEAD', NOW,
+    )).toThrow(/terminal status/i);
+  });
+});
+
+describe('computeParkPlan — edge detection + metadata patch', () => {
+  it('flags edge=true and records original progress when progress>=100 in EXEC (TS-3)', () => {
+    const plan = computeParkPlan(
+      { sd_key: 'SD-X', status: 'in_progress', current_phase: 'EXEC', progress: 100 },
+      'set aside', 'PLAN', NOW,
+    );
+    expect(plan.edge).toBe(true);
+    expect(plan.parkMetaPatch.parked_progress_original).toBe(100);
+    expect(plan.parkMetaPatch.parked_from_status).toBe('in_progress');
+    expect(plan.parkMetaPatch.park_reason).toBe('set aside');
+    expect(plan.parkMetaPatch.parked_by).toBe('PLAN');
+    expect(plan.parkMetaPatch.parked_at).toBe(NOW);
+  });
+
+  it('flags edge=true when progress>=100 in PLAN', () => {
+    const plan = computeParkPlan(
+      { sd_key: 'SD-X', status: 'in_progress', current_phase: 'PLAN', progress: 100 },
+      'set aside', 'LEAD', NOW,
+    );
+    expect(plan.edge).toBe(true);
+    expect(plan.parkMetaPatch.parked_progress_original).toBe(100);
+  });
+
+  it('edge=false (no normalization) when progress<100 even in EXEC', () => {
+    const plan = computeParkPlan(
+      { sd_key: 'SD-X', status: 'in_progress', current_phase: 'EXEC', progress: 99 },
+      'set aside', 'PLAN', NOW,
+    );
+    expect(plan.edge).toBe(false);
+    expect(plan.parkMetaPatch.parked_progress_original).toBeNull();
+  });
+
+  it('edge=false when progress>=100 but phase is LEAD (auto_transition only triggers in EXEC/PLAN)', () => {
+    const plan = computeParkPlan(
+      { sd_key: 'SD-X', status: 'active', current_phase: 'LEAD', progress: 100 },
+      'set aside', 'LEAD', NOW,
+    );
+    expect(plan.edge).toBe(false);
+    expect(plan.parkMetaPatch.parked_progress_original).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
First-class **park/unpark** capability for Strategic Directives — set an SD aside without abandoning it.

LEAD/PLAN de-risk (risk + validation + database sub-agents, LIVE-DB-grounded) reframed the original "add a new 'parked' status" premise:
- `metadata.do_not_auto_start` is **dead** (0 production consumers; 8 carrier rows all terminal).
- `status='deferred'` **already exists** in the status CHECK constraint and is already excluded from every live work-selection allowlist + the claim-liveness sweep — but had 0 live rows.

So park is delivered by **reusing `status='deferred'`** — no new enum value, no status migration.

## Changes
- `lib/sd-park.js` + `scripts/sd-park.js` — park/unpark (status-only; releases the atomic claim across `strategic_directives_v2` + `claude_sessions` in one txn; never touches `current_phase`; guards the `auto_transition_status` progress≥100 edge; non-EXEC actor).
- `database/migrations/20260606012331_v_sd_next_candidates_exclude_deferred.sql` — the **one** corrective DDL (already applied to prod via audited `apply-migration.js --prod-deploy`); excludes `deferred` from the view blocklist.
- `tests/unit/sd-park.computeParkPlan.test.js` (10) + `tests/integration/sd-park.test.js` (8) — all green.
- `docs/ops/sd-park.md` — cancel ≠ park; `deferred` is the parked state; `do_not_auto_start` retired.

## Why deferred is safe
Unlike `cancelled`, `deferred` fires **neither** `trg_reset_patterns_on_sd_cancel` **nor** `trigger_retro_notification` (verified) — parked SDs stay recoverable + queryable.

## Evidence
DATABASE `225c2454` (migration applied + 25/25 functional), SECURITY `9a45bddf` (PASS-WITH-NOTES), TESTING (10 unit + 8 integration green). Retro `6816c7d9` (q=90). LEO phases LEAD→PLAN→EXEC→VERIFICATION→FINAL all passed (EXEC-TO-PLAN 92, PLAN-TO-LEAD 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
