### PR TITLE
feat(SD-LEO-INFRA-SURFACE-INERT-WORKER-001): surface inert worker-revival via default-OFF sweep detector + operator wake-prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,3 +166,11 @@ LEO_VISION_REPAIR_LOOP_ENABLED=false
 # diagnostic SQL on 2026-04-29). Loop exits cleanly with non-blocking warning
 # when cumulative usage exceeds this cap.
 LEO_VISION_REPAIR_LOOP_TOKEN_BUDGET=540800
+
+# SD-LEO-INFRA-SURFACE-INERT-WORKER-001 — surface inert worker-revival to the operator (default-OFF)
+# When true, the stale-session sweep flags aged-unconsumed pending worker_spawn_requests and emits
+# ONE de-duped operator alert carrying the paste-able fleet-worker /loop wake prompt. Read-only, fail-open.
+SURFACE_INERT_WORKER_V1=false
+# Minimum requested_at age (minutes) before a pending unfulfilled spawn request is flagged.
+INERT_WORKER_AGE_MIN=360
+

--- a/docs/protocol/coordinator-worker-revival.md
+++ b/docs/protocol/coordinator-worker-revival.md
@@ -155,3 +155,13 @@ FROM worker_spawn_requests
 WHERE status='pending' AND expires_at > NOW()
 ORDER BY requested_at ASC;
 ```
+
+## Inert on this host (surfaced via sweep detector)
+
+No spawn-execution layer consumes `worker_spawn_requests` on this host, so revival is **inert**: `/coordinator revive` files requests that are never fulfilled (`fulfilled_at` stays NULL). SD-LEO-INFRA-SURFACE-INERT-WORKER-001 adds a READ-ONLY detector to the stale-session sweep that surfaces this instead of letting requests pile up silently.
+
+- **Flag (default-OFF):** `SURFACE_INERT_WORKER_V1=true` enables the detector. Inert (zero reads/writes) when unset.
+- **Threshold:** `INERT_WORKER_AGE_MIN` (default 360) — minimum `requested_at` age (minutes) before a pending, unfulfilled request is flagged. Expired-but-still-pending rows count.
+- **Alert:** on a match, ONE de-duped `session_coordination` row (`message_type=INFO`, `payload.kind=inert_worker_alert`, `target_session=broadcast-coordinator`, 24h expiry) carries the paste-able fleet-worker `/loop` startup prompt — the only path that restores capacity today. De-dup skips while an unacknowledged, unexpired alert exists.
+- **Scope:** detection + operator surfacing only. Building the spawn-execution daemon remains out of scope (see above).
+

--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const { runDetectors } = require('./detectors.cjs');
+const { runDetectors, detectInertWorkerRevival } = require('./detectors.cjs');
 
 /** detector_version stamped on every emitted coordination_events row. */
 const DETECTOR_VERSION = 'COORD_DETECTORS_V2';
@@ -203,6 +203,121 @@ async function runAndLogDetectors(supabase, data, opts) {
   return out;
 }
 
+/**
+ * Default-OFF flag for the inert-worker-revival surfacing feature
+ * (SD-LEO-INFRA-SURFACE-INERT-WORKER-001). Independent of COORD_DETECTORS_V2 so
+ * the operator alert can roll out / back separately. Mirrors coordDetectorsEnabled.
+ */
+function inertWorkerDetectorEnabled(env) {
+  env = env || process.env;
+  return String(env.SURFACE_INERT_WORKER_V1 ?? 'false').toLowerCase() !== 'false';
+}
+
+/** Inert-worker age threshold (ms) from INERT_WORKER_AGE_MIN (default 360 min). */
+function inertWorkerThresholdMs(env) {
+  env = env || process.env;
+  return (Number(env.INERT_WORKER_AGE_MIN) || 360) * 60 * 1000;
+}
+
+/**
+ * Canonical paste-able fleet-worker /loop startup prompt embedded in the operator
+ * alert (FR-2). The coordinator cannot restore worker capacity on this host (no
+ * spawn-executor consumes worker_spawn_requests); pasting this into an idle Claude
+ * Code window is the only path that wakes a worker today. Single source of truth
+ * (coordinator.md has no marked prompt block); concise + actionable.
+ */
+const FLEET_WORKER_STARTUP_PROMPT = [
+  '/loop You are an autonomous LEO fleet worker under the active coordinator. Each pass:',
+  '1) Read your session_coordination inbox; act on any coordinator directive.',
+  '2) Run "npm run sd:next" and claim the highest-priority workable SD with "node scripts/sd-start.js <SD-KEY>" (or resume one you already hold).',
+  '3) Drive it LEAD->PLAN->EXEC via "node scripts/handoff.js execute <PHASE> <SD-KEY>"; invoke the required sub-agents (Task tool) before each handoff so fresh evidence exists.',
+  '4) Re-affirm your claim (re-run sd-start, idempotent) after long sub-agent runs and before each handoff.',
+  '5) Route any blocker to the coordinator via "node scripts/worker-signal.cjs <type> <msg>"; never stop for the human.',
+  '6) ScheduleWakeup at the end of each pass to stay alive. NEVER run /coordinator stop.',
+].join('\n');
+
+/** Build the inert-worker detector input from the live DB. READ-ONLY, fail-soft. */
+async function gatherInertWorkerInputs(supabase) {
+  let requests = [];
+  try {
+    const { data } = await supabase
+      .from('worker_spawn_requests')
+      .select('id, requested_callsign, status, requested_at, fulfilled_at, expires_at')
+      .eq('status', 'pending')
+      .is('fulfilled_at', null);
+    requests = data || [];
+  } catch (_) { requests = []; }
+  return { requests };
+}
+
+/**
+ * Emit ONE de-duped operator alert (session_coordination INFO + payload.kind).
+ * FAIL-OPEN. Skips when an unacknowledged, unexpired inert_worker_alert exists.
+ * No new coordination_message_type enum value (INFO + payload discrimination).
+ * @returns {Promise<{ ok: boolean, skipped?: boolean, id?: string, error?: string }>}
+ */
+async function emitInertWorkerAlert(supabase, evidence, opts) {
+  opts = opts || {};
+  const nowMs = opts.now ?? Date.now();
+  try {
+    const nowIso = new Date(nowMs).toISOString();
+    const { data: dupes } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('message_type', 'INFO')
+      .eq('payload->>kind', 'inert_worker_alert')
+      .is('acknowledged_at', null)
+      .gt('expires_at', nowIso)
+      .limit(1);
+    if (dupes && dupes.length > 0) {
+      return { ok: true, skipped: true, id: dupes[0].id };
+    }
+    const aged = (evidence && evidence.aged_count) || 0;
+    const expiresAt = new Date(nowMs + 24 * 3600 * 1000).toISOString();
+    const body = 'Worker-revival is INERT on this host: ' + aged + ' pending worker_spawn_requests are aged past threshold with no spawn-executor consuming them. The coordinator cannot restore worker capacity automatically. Paste the prompt below into an idle Claude Code window to wake a worker:\n\n' + FLEET_WORKER_STARTUP_PROMPT;
+    const row = {
+      target_session: 'broadcast-coordinator',
+      sender_type: 'sweep',
+      message_type: 'INFO',
+      subject: '[INERT_WORKER_ALERT] ' + aged + ' aged spawn request(s) unconsumed - paste prompt to wake a worker',
+      body,
+      payload: { kind: 'inert_worker_alert', severity: 'critical', aged_count: aged, evidence },
+      expires_at: expiresAt,
+    };
+    const { data, error } = await supabase.from('session_coordination').insert(row).select('id').single();
+    if (error) {
+      console.warn('   [INERT_WORKER_ALERT_FAILED] ' + error.message + ' (non-fatal)');
+      return { ok: false, error: error.message };
+    }
+    return { ok: true, id: data.id };
+  } catch (e) {
+    console.warn('   [INERT_WORKER_ALERT_THREW] ' + ((e && e.message) || e) + ' (non-fatal)');
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * Flag-gated, fail-open: detect inert worker-revival and (on match) emit ONE
+ * de-duped operator alert. OFF flag => null with ZERO reads/writes.
+ * @returns {Promise<{ matched: boolean, aged_count?: number, alert?: object } | null>}
+ */
+async function runInertWorkerSurfacing(supabase, opts) {
+  opts = opts || {};
+  const env = opts.env || process.env;
+  if (!inertWorkerDetectorEnabled(env)) return null;
+  try {
+    const now = opts.now ?? Date.now();
+    const inputs = await gatherInertWorkerInputs(supabase);
+    const res = detectInertWorkerRevival({ requests: inputs.requests, now, thresholdMs: inertWorkerThresholdMs(env) });
+    if (!res.matched) return { matched: false };
+    const alert = await emitInertWorkerAlert(supabase, res.evidence, { now });
+    return { matched: true, aged_count: res.evidence.aged_count, alert };
+  } catch (e) {
+    console.warn('   [INERT_WORKER_SURFACING_THREW] ' + ((e && e.message) || e) + ' (non-fatal)');
+    return null;
+  }
+}
+
 module.exports = {
   DETECTOR_VERSION,
   coordDetectorsEnabled,
@@ -210,4 +325,10 @@ module.exports = {
   gatherDetectorInputs,
   logCoordinationEvent,
   runAndLogDetectors,
+  inertWorkerDetectorEnabled,
+  inertWorkerThresholdMs,
+  FLEET_WORKER_STARTUP_PROMPT,
+  gatherInertWorkerInputs,
+  emitInertWorkerAlert,
+  runInertWorkerSurfacing,
 };

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -209,6 +209,41 @@ function runDetectors(data, opts) {
     .map((r) => ({ event_type: r.event_type, severity: r.severity, reason: r.res.reason, evidence: r.res.evidence }));
 }
 
+/** Default INERT_WORKER threshold (ms) — pending spawn-request age with no consumption (360 min). */
+const DEFAULT_INERT_WORKER_AGE_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * INERT_WORKER_REVIVAL — pending worker_spawn_requests aged past threshold with no
+ * consumption (fulfilled_at NULL). Surfaces that no spawn-execution layer consumes
+ * revival requests on this host (SD-LEO-INFRA-SURFACE-INERT-WORKER-001). PURE;
+ * read-only injected rows. Expired-but-still-pending rows COUNT (status never
+ * transitions when the consumer is absent). Decoupled from runDetectors: its own
+ * flag + emit target (operator alert), not coordination_events.
+ * @param {{ requests: Array<object>, now?: number, thresholdMs?: number }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectInertWorkerRevival(data) {
+  const now = (data && data.now) ?? Date.now();
+  const thresholdMs = (data && data.thresholdMs) ?? DEFAULT_INERT_WORKER_AGE_MS;
+  const aged = [];
+  for (const r of ((data && data.requests) || [])) {
+    if (!r || r.status !== 'pending') continue;
+    if (r.fulfilled_at) continue;
+    const ageMs = now - toMs(r.requested_at);
+    if (ageMs > thresholdMs) {
+      aged.push({ id: r.id, callsign: r.requested_callsign, age_ms: ageMs });
+    }
+  }
+  if (aged.length > 0) {
+    return {
+      matched: true,
+      reason: 'pending_spawn_requests_unconsumed_past_threshold',
+      evidence: { aged_count: aged.length, threshold_ms: thresholdMs, samples: aged.slice(0, 10) },
+    };
+  }
+  return { matched: false, reason: 'no_inert_spawn_requests', evidence: { threshold_ms: thresholdMs } };
+}
+
 module.exports = {
   DEFAULT_COORDINATOR_FRESH_MS,
   DEFAULT_REPLY_STARVATION_MS,
@@ -219,4 +254,6 @@ module.exports = {
   detectStuckWorker,
   detectClaimHalfWrite,
   runDetectors,
+  DEFAULT_INERT_WORKER_AGE_MS,
+  detectInertWorkerRevival,
 };

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1721,6 +1721,22 @@ async function main() {
     console.log('COORD_DETECTORS: ' + (coordDetErr && coordDetErr.message ? coordDetErr.message : 'unknown'));
   }
 
+  // SD-LEO-INFRA-SURFACE-INERT-WORKER-001 — surface INERT worker-revival to the
+  // operator. DEFAULT-OFF behind SURFACE_INERT_WORKER_V1, READ-ONLY over
+  // worker_spawn_requests, fail-open. Emits ONE de-duped operator alert (carrying
+  // a paste-able fleet-worker /loop prompt) when pending spawn requests age past
+  // threshold with no spawn-executor consuming them. Fully inert when flag off.
+  try {
+    const inert = await _coordEventsModule.runInertWorkerSurfacing(supabase, {});
+    if (inert && inert.matched) {
+      const a = inert.alert || {};
+      const tail = a.skipped ? ' (alert deduped)' : a.ok ? ' - operator alert emitted' : ' (alert emit failed)';
+      console.log('  INERT_WORKER: ' + inert.aged_count + ' aged unconsumed spawn request(s)' + tail);
+    }
+  } catch (inertErr) {
+    console.log('INERT_WORKER: ' + (inertErr && inertErr.message ? inertErr.message : 'unknown'));
+  }
+
   // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-4d — SIGNAL_RESOLVED notification.
   // For each contributing signal where payload.routed_to_sd_key is non-null AND the SD
   // status is 'completed' AND payload.notification_sent is not yet true, look up

--- a/tests/unit/coordinator/inert-worker.test.js
+++ b/tests/unit/coordinator/inert-worker.test.js
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the inert-worker-revival surfacing feature.
+ * SD-LEO-INFRA-SURFACE-INERT-WORKER-001
+ *
+ * Pure detector over injected fixtures + mocked-supabase writer (fail-open + dedup).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  detectInertWorkerRevival,
+  DEFAULT_INERT_WORKER_AGE_MS,
+} from '../../../lib/coordinator/detectors.cjs';
+import {
+  inertWorkerDetectorEnabled,
+  inertWorkerThresholdMs,
+  FLEET_WORKER_STARTUP_PROMPT,
+  emitInertWorkerAlert,
+  runInertWorkerSurfacing,
+} from '../../../lib/coordinator/coordination-events.cjs';
+
+const NOW = 1_750_000_000_000;
+const minsAgo = (m) => new Date(NOW - m * 60_000).toISOString();
+const THRESH = DEFAULT_INERT_WORKER_AGE_MS;
+
+describe('detectInertWorkerRevival', () => {
+  it('matches an aged, pending, unfulfilled request', () => {
+    const requests = [{ id: '1', requested_callsign: 'Echo', status: 'pending', requested_at: minsAgo(500), fulfilled_at: null }];
+    const r = detectInertWorkerRevival({ requests, now: NOW, thresholdMs: THRESH });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.aged_count).toBe(1);
+    expect(r.evidence.samples[0].callsign).toBe('Echo');
+  });
+  it('counts expired-but-still-pending rows (status never transitions when inert)', () => {
+    const requests = [{ id: '1', requested_callsign: 'Alpha', status: 'pending', requested_at: minsAgo(12000), fulfilled_at: null, expires_at: minsAgo(11940) }];
+    expect(detectInertWorkerRevival({ requests, now: NOW, thresholdMs: THRESH }).matched).toBe(true);
+  });
+  it('does not match fresh / fulfilled / non-pending / empty', () => {
+    expect(detectInertWorkerRevival({ requests: [{ id: '1', status: 'pending', requested_at: minsAgo(10), fulfilled_at: null }], now: NOW, thresholdMs: THRESH }).matched).toBe(false);
+    expect(detectInertWorkerRevival({ requests: [{ id: '2', status: 'pending', requested_at: minsAgo(500), fulfilled_at: minsAgo(1) }], now: NOW, thresholdMs: THRESH }).matched).toBe(false);
+    expect(detectInertWorkerRevival({ requests: [{ id: '3', status: 'cancelled', requested_at: minsAgo(500), fulfilled_at: null }], now: NOW, thresholdMs: THRESH }).matched).toBe(false);
+    expect(detectInertWorkerRevival({ requests: [], now: NOW, thresholdMs: THRESH }).matched).toBe(false);
+  });
+  it('threshold boundary: at-threshold no fire, one ms past fires', () => {
+    const at = [{ id: '1', status: 'pending', requested_at: new Date(NOW - THRESH).toISOString(), fulfilled_at: null }];
+    const past = [{ id: '1', status: 'pending', requested_at: new Date(NOW - THRESH - 1).toISOString(), fulfilled_at: null }];
+    expect(detectInertWorkerRevival({ requests: at, now: NOW, thresholdMs: THRESH }).matched).toBe(false);
+    expect(detectInertWorkerRevival({ requests: past, now: NOW, thresholdMs: THRESH }).matched).toBe(true);
+  });
+});
+
+describe('inertWorkerDetectorEnabled / threshold / prompt', () => {
+  it('is OFF by default and ON when flag set', () => {
+    expect(inertWorkerDetectorEnabled({})).toBe(false);
+    expect(inertWorkerDetectorEnabled({ SURFACE_INERT_WORKER_V1: 'false' })).toBe(false);
+    expect(inertWorkerDetectorEnabled({ SURFACE_INERT_WORKER_V1: 'true' })).toBe(true);
+  });
+  it('reads INERT_WORKER_AGE_MIN (default 360)', () => {
+    expect(inertWorkerThresholdMs({})).toBe(360 * 60_000);
+    expect(inertWorkerThresholdMs({ INERT_WORKER_AGE_MIN: '10' })).toBe(10 * 60_000);
+  });
+  it('prompt constant carries the /loop wake instruction', () => {
+    expect(FLEET_WORKER_STARTUP_PROMPT).toContain('/loop');
+    expect(FLEET_WORKER_STARTUP_PROMPT).toContain('sd-start');
+  });
+});
+
+function mockSupabase({ dupes = [], insertError = null, throwOn = null }) {
+  return {
+    from() {
+      return {
+        select() { return this; }, eq() { return this; }, is() { return this; }, gt() { return this; },
+        limit() {
+          if (throwOn === 'select') throw new Error('boom-select');
+          return Promise.resolve({ data: dupes, error: null });
+        },
+        insert() {
+          if (throwOn === 'insert') throw new Error('boom-insert');
+          return { select() { return { single() { return Promise.resolve({ data: insertError ? null : { id: 'new-1' }, error: insertError }); } }; } };
+        },
+      };
+    },
+  };
+}
+
+describe('emitInertWorkerAlert (dedup + fail-open)', () => {
+  it('inserts one alert when no live dupe exists', async () => {
+    const res = await emitInertWorkerAlert(mockSupabase({ dupes: [] }), { aged_count: 3 }, { now: NOW });
+    expect(res.ok).toBe(true); expect(res.skipped).toBeUndefined(); expect(res.id).toBe('new-1');
+  });
+  it('skips insert when an unacknowledged, unexpired alert already exists', async () => {
+    const res = await emitInertWorkerAlert(mockSupabase({ dupes: [{ id: 'old-1' }] }), { aged_count: 3 }, { now: NOW });
+    expect(res.ok).toBe(true); expect(res.skipped).toBe(true); expect(res.id).toBe('old-1');
+  });
+  it('fail-open on insert error', async () => {
+    const res = await emitInertWorkerAlert(mockSupabase({ dupes: [], insertError: { message: 'db down' } }), { aged_count: 1 }, { now: NOW });
+    expect(res.ok).toBe(false); expect(res.error).toBe('db down');
+  });
+  it('fail-open when the select throws', async () => {
+    const res = await emitInertWorkerAlert(mockSupabase({ throwOn: 'select' }), { aged_count: 1 }, { now: NOW });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('runInertWorkerSurfacing', () => {
+  it('returns null with ZERO I/O when flag is OFF', async () => {
+    const sb = { from: vi.fn(() => { throw new Error('should not be called'); }) };
+    const res = await runInertWorkerSurfacing(sb, { env: {} });
+    expect(res).toBeNull();
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Surfaces INERT coordinator worker-revival. coordinator-revive.cjs writes worker_spawn_requests but no consumer fulfills them (live: 7 pending ~8 days, 0 ever fulfilled). Adds a read-only, DEFAULT-OFF detector (SURFACE_INERT_WORKER_V1) in the stale-session sweep that, on aged-unconsumed pending requests, emits ONE de-duped operator alert (session_coordination INFO + payload.kind=inert_worker_alert, no DB migration) carrying the paste-able fleet-worker /loop wake prompt. Fail-open; detection + surfacing only (no auto-spawn). 12 new unit tests; 33/33 coordinator tests pass. SD-LEO-INFRA-SURFACE-INERT-WORKER-001.