### PR TITLE
feat(SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001): activate claim-sweep in-flight protection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "SWEEP_RESPECT_INFLIGHT_AGENT": "1"
   },
   "statusLine": {
     "type": "command",

--- a/database/migrations/20260606033759_cleanup_stale_sessions_respect_inflight_agent.sql
+++ b/database/migrations/20260606033759_cleanup_stale_sessions_respect_inflight_agent.sql
@@ -1,0 +1,191 @@
+-- ============================================================================
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 — ENABLEMENT of the claim-sweep in-flight
+-- protection (FR-2 of SD-FDBK-INFRA-CLAIM-SWEEP-LIVENESS-001).
+--
+-- PROVENANCE / WHY THIS RE-APPLY:
+--   The cleanup_stale_sessions() FR-2 in-flight-respect logic was ALREADY deployed
+--   to prod on 2026-06-05 via database/migrations/20260605_atomic_lease_sweep_respect_inflight.sql
+--   (schema_migrations_applied id 5be997be-ceae-42f9-ab02-da80e4306897, success=true,
+--   prod_deploy=true). The live pg_get_functiondef body is BYTE-IDENTICAL to the
+--   function below — this file was authored directly FROM the live definition.
+--
+--   This SD's GO-GATE requires authoring the CREATE OR REPLACE from the LIVE def and
+--   re-verifying it (TS-1..TS-4 BEGIN..ROLLBACK) before activation. This file is that
+--   faithful re-issue: applying it is an idempotent no-op against the function body
+--   (CREATE OR REPLACE with the same definition) and records a fresh audit row under
+--   this SD. The ACTUAL activation is the post-deploy flag flip
+--   (chairman_dashboard_config.metadata.sweep_respect_inflight_agent: false -> true),
+--   performed separately AFTER this deploy succeeds.
+--
+-- GO-GATE GUARANTEES (preserved exactly from the live def):
+--  1. DEFAULT-OFF — protective predicate gated behind config flag
+--     chairman_dashboard_config.metadata->>'sweep_respect_inflight_agent'
+--     (COALESCE to false). Flag false/absent => byte-for-byte current behavior.
+--  2. HARD-CAP CEILING (unconditional) — the in-flight exemption applies ONLY while
+--     heartbeat_at is within (30 + claim_ttl_minutes) minutes of NOW(); a session
+--     past the cap is ALWAYS marked stale, even with the flag ON and a future
+--     expected_silence_until. A dead claim can never be wedged open forever.
+--  3. FAIL-OPEN — the config read is wrapped in EXCEPTION WHEN OTHERS; any error
+--     (missing column / bad cast / missing row) falls back to flag=false, ttl=15.
+--     A NULL/absent expected_silence_until NEVER blocks the sweep (released normally).
+--  4. RELEASE-PAYLOAD INTEGRITY — the release UPDATE clears sd_key + worktree_branch
+--     + worktree_path TOGETHER, so it can never leave a row violating
+--     ck_claude_sessions_worktree_state_consistency
+--     (CHECK ((sd_key IS NOT NULL) OR (worktree_path IS NULL AND worktree_branch IS NULL))).
+--
+-- VERIFIED (this SD, BEGIN..ROLLBACK against live DB, 2026-06-06):
+--   TS-1 PASS  flag=true + future ESU + recent-ish heartbeat -> NOT released (stays active, sd_key/worktree preserved)
+--   TS-2 PASS  same aged past 45-min hard-cap -> released (sd_key+worktree cleared together)
+--   TS-3 PASS  NULL ESU -> released normally (fail-open), all cleared together
+--   TS-4 PASS  flag=false -> in-flight session IS released (predicate gated off)
+--
+-- Idempotent. DEPLOY (nothing in CI applies migrations):
+--   node scripts/apply-migration.js --issue-token
+--   MIGRATION_APPLY_TOKEN=<tok> node scripts/apply-migration.js \
+--     database/migrations/20260606033759_cleanup_stale_sessions_respect_inflight_agent.sql --prod-deploy
+-- After deploy, enable protection (separate guarded UPDATE):
+--   chairman_dashboard_config.metadata.sweep_respect_inflight_agent = true
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.cleanup_stale_sessions(
+  p_stale_threshold_seconds integer DEFAULT 120,
+  p_batch_size integer DEFAULT 100
+) RETURNS jsonb
+LANGUAGE plpgsql
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+  -- FR-2 in-flight-respect config (fail-open defaults = current main behavior)
+  v_respect_inflight BOOLEAN := false;  -- default OFF
+  v_ttl_minutes      INTEGER := 15;     -- claim TTL, mirrors existing config knob
+  v_hardcap_minutes  INTEGER := 45;     -- ceiling above which exemption never applies
+BEGIN
+  -- FAIL-OPEN config read. Any error here leaves the defaults above (flag OFF),
+  -- so the function degrades to today's behavior rather than aborting cleanup.
+  BEGIN
+    SELECT
+      COALESCE((metadata->>'sweep_respect_inflight_agent')::boolean, false),
+      COALESCE((metadata->>'claim_ttl_minutes')::integer, 15)
+    INTO v_respect_inflight, v_ttl_minutes
+    FROM chairman_dashboard_config
+    WHERE config_key = 'default'
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_respect_inflight := false;
+    v_ttl_minutes := 15;
+  END;
+
+  -- Hard-cap ceiling = max in-flight silence window (30 min, per FR-1
+  -- MAX_SILENCE_MS) + claim TTL margin. Beyond this, no expected_silence_until
+  -- can exempt a session: a dead claim cannot be wedged open forever.
+  v_hardcap_minutes := 30 + GREATEST(COALESCE(v_ttl_minutes, 15), 0);
+
+  -- Step 1: Mark active/idle sessions as stale if heartbeat too old.
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+      -- FR-2 in-flight exemption (DEFAULT-OFF). When v_respect_inflight is false
+      -- the whole parenthesised term is false and NOT(false)=true, so this clause
+      -- is a no-op → identical to current main. When the flag is ON, a session
+      -- with a future expected_silence_until is skipped, UNLESS its heartbeat is
+      -- already older than the hard-cap ceiling (then it is marked stale anyway).
+      AND NOT (
+        v_respect_inflight
+        AND expected_silence_until IS NOT NULL
+        AND expected_silence_until > NOW()
+        AND heartbeat_at >= NOW() - (v_hardcap_minutes || ' minutes')::INTERVAL
+      )
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE claude_sessions cs
+    SET status = 'stale',
+        stale_at = NOW(),
+        stale_reason = 'HEARTBEAT_TIMEOUT',
+        updated_at = NOW()
+    FROM stale_sessions ss
+    WHERE cs.session_id = ss.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_stale_count FROM updated;
+
+  -- Step 2: Release stale sessions that have been stale for >30 seconds.
+  -- RELEASE-PAYLOAD INTEGRITY: clearing sd_key would violate
+  -- ck_claude_sessions_worktree_state_consistency unless worktree_path and
+  -- worktree_branch are NULL too, so we clear all three together.
+  WITH release_sessions AS (
+    SELECT session_id, sd_key
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  released AS (
+    UPDATE claude_sessions cs
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'STALE_CLEANUP',
+        sd_key = NULL,
+        track = NULL,
+        claimed_at = NULL,
+        worktree_branch = NULL,
+        worktree_path = NULL,
+        updated_at = NOW()
+    FROM release_sessions rs
+    WHERE cs.session_id = rs.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_released_count FROM released;
+
+  -- LAYER-SIDE-CLAIMING-001 FR-4: clear claiming_session_id alongside
+  -- active_session_id. (sd_claims table reference removed — table does not exist
+  -- in current schema.)
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+  WHERE active_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  )
+  OR claiming_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'respect_inflight_agent', v_respect_inflight,
+    'hardcap_minutes', v_hardcap_minutes,
+    'executed_at', NOW()
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION cleanup_stale_sessions IS
+  'Batch cleanup of stale sessions: marks stale after threshold, releases after 30s stale. '
+  'FR-2 (SD-FDBK-INFRA-CLAIM-SWEEP-LIVENESS-001): DEFAULT-OFF in-flight exemption honors '
+  'expected_silence_until under config flag sweep_respect_inflight_agent, bounded by a '
+  '(30 + claim_ttl) minute hard cap; fail-open config read; release clears worktree_branch/path. '
+  'Re-issued + verified under SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 ahead of flag enablement.';
+
+-- ============================================================================
+-- ROLLBACK (manual, if ever needed):
+--   Re-create the prior definition (without v_respect_inflight / the in-flight
+--   exemption clause and without worktree_branch/worktree_path in the release
+--   UPDATE) via CREATE OR REPLACE FUNCTION, and:
+--     UPDATE chairman_dashboard_config
+--        SET metadata = metadata - 'sweep_respect_inflight_agent'
+--      WHERE config_key = 'default';
+-- ============================================================================

--- a/docs/ops/claim-sweep-inflight-protection.md
+++ b/docs/ops/claim-sweep-inflight-protection.md
@@ -1,0 +1,54 @@
+# Claim-sweep in-flight protection (enablement runbook)
+
+**SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001**
+
+Activates the (previously inert) protection that stops the stale-session sweep from
+releasing a worker's claim while it is mid-`Task`/`Agent` sub-agent run — the failure
+mode where fleet workers "go dormant" because `cleanup_stale_sessions` released their
+claim during a long sub-agent that fires no heartbeat.
+
+## The chain (writer → telemetry → consumer)
+
+```
+long Task/Agent dispatch
+   └─(writer)─> claude_sessions.expected_silence_until = now() + window   [pre-tool-enforce.cjs FR-1]
+                   │
+   cleanup_stale_sessions() runs ──(consumer)──> WHEN sweep_respect_inflight_agent = true
+                                                  AND expected_silence_until > now()
+                                                  AND NOT past the 45-min hard-cap
+                                                     => SKIP release (claim survives)
+```
+
+## Three enablement pieces (all required for end-to-end)
+
+1. **Consumer** — `cleanup_stale_sessions()` honors `expected_silence_until`
+   (flag-gated, NULL-safe/fail-open, 45-min hard-cap preserved). Applied via the audited
+   `apply-migration.js --prod-deploy`
+   (`database/migrations/20260606033759_cleanup_stale_sessions_respect_inflight_agent.sql`).
+2. **Flag** — `chairman_dashboard_config.metadata.sweep_respect_inflight_agent = true`
+   (default-OFF; flipped true by this SD, **after** the consumer was confirmed live).
+3. **Writer** — `SWEEP_RESPECT_INFLIGHT_AGENT=1` in `.claude/settings.json` `env` so the
+   PreToolUse hook **await-persists** `expected_silence_until` on Task/Agent dispatch
+   (the else-branch fire-and-forget write is killed by `process.exit`; the gated branch awaits).
+
+## Safety properties (verified TS-1..TS-4, BEGIN..ROLLBACK)
+
+- **In-flight protected** — future `expected_silence_until` + flag true ⇒ NOT released.
+- **Hard-cap preserved** — a session past the 45-minute cap is ALWAYS released
+  (`sd_key` + `worktree_path` + `worktree_branch` cleared together).
+- **Fail-open** — a NULL/absent `expected_silence_until` never blocks the sweep.
+- **Flag-gated** — with the flag false, behavior reverts to legacy (no exemption).
+
+## Deploy nuance
+
+The PreToolUse hook reads `.claude/settings.json` from the **main checkout**
+(`CLAUDE_PROJECT_DIR`), not from a worktree. The `SWEEP_RESPECT_INFLIGHT_AGENT=1` env
+takes effect for the running fleet only **after the main checkout updates** to include
+this change (merged ≠ deployed). The DB-layer pieces (consumer + flag) are already live.
+
+## Rollback
+
+- **Instant DB-layer revert**: set `chairman_dashboard_config.metadata.sweep_respect_inflight_agent = false`
+  (the exemption predicate is gated off immediately; the sweep returns to legacy behavior).
+- Optionally remove `SWEEP_RESPECT_INFLIGHT_AGENT` from `.claude/settings.json` to stop
+  the writer. The 45-minute hard-cap remains in force throughout.

--- a/tests/integration/claim-sweep-inflight-protection.test.js
+++ b/tests/integration/claim-sweep-inflight-protection.test.js
@@ -1,0 +1,247 @@
+/**
+ * Integration test for SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 (ENABLEMENT of FR-2 from
+ * SD-FDBK-INFRA-CLAIM-SWEEP-LIVENESS-001): the live cleanup_stale_sessions() function
+ * must honor claude_sessions.expected_silence_until when the config flag
+ * chairman_dashboard_config.metadata.sweep_respect_inflight_agent = true, while
+ * preserving a (30 + claim_ttl)-minute HARD CAP and FAILING OPEN on NULL telemetry.
+ *
+ * Why this test runs against the LIVE function (not a stub):
+ *   cleanup_stale_sessions() is a SECURITY-sensitive plpgsql function whose exemption
+ *   predicate, hard-cap arithmetic, and release-payload integrity (clearing sd_key +
+ *   worktree_path + worktree_branch TOGETHER so ck_claude_sessions_worktree_state_consistency
+ *   can never be violated) cannot be reached by a JS mock. The defect this whole SD chain
+ *   guards against — a sweep releasing a session mid-sub-agent-run — is purely a DB-side
+ *   behavior, so the regression must be asserted against the real function body.
+ *
+ * Isolation contract (ZERO PROD LEAK):
+ *   Every scenario runs inside a single pg-client BEGIN ... ROLLBACK transaction. All
+ *   throwaway claude_sessions rows are seeded with a unique per-run RUN_ID prefix and the
+ *   transaction is ALWAYS rolled back, so no row — and no chairman_dashboard_config flag
+ *   mutation (TS-4 flips the flag inside the txn) — ever commits. A final zero-survivors
+ *   assertion (afterAll) fails the suite loudly if any future regression commits instead
+ *   of rolling back. We NEVER touch a real session, never touch any SD-TEST-* fixture, and
+ *   never leave chairman_dashboard_config mutated.
+ *
+ * cleanup_stale_sessions() is a TWO-STEP function in one call:
+ *   Step 1 — marks active/idle sessions 'stale' when heartbeat_at is older than the stale
+ *            threshold, UNLESS the in-flight exemption applies (flag ON + future ESU +
+ *            heartbeat within the hard cap).
+ *   Step 2 — releases rows already in status='stale' whose stale_at is older than 30s,
+ *            clearing the claim payload.
+ * A freshly-marked-stale row therefore does NOT release in the same call (its stale_at is
+ * "now"). To deterministically drive the FULL lifecycle to 'released' for the scenarios
+ * that assert a release (TS-2/TS-3/TS-4) without a 30s real-time wait, we run cleanup once
+ * (Step 1 marks stale), backdate stale_at by 90s INSIDE the rolled-back txn, then run
+ * cleanup again (Step 2 releases). This exercises both the exemption decision (Step 1) and
+ * the release-payload integrity (Step 2) for real. TS-1 (protected) asserts after a single
+ * pass that the session was never even marked stale.
+ *
+ * Pattern mirrors tests/integration/retro-trigger-draft-insert.test.js (BEGIN/ROLLBACK +
+ * per-run marker + zero-survivors guard). LIVE-gated: skips (does not fail) when no pg
+ * connection URL is configured, so hermetic CI without DB creds stays green.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const HAS_DB = !!(process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.SUPABASE_DB_URL);
+
+// Unique per-run marker. The zero-survivors assertion keys on this exact prefix, so it is
+// robust against concurrent sessions running this same test. SD-SWEEPTEST- is distinct from
+// any SD-TEST-* fixture namespace.
+const RUN_ID = `SD-SWEEPTEST-${Date.now()}-${process.pid}`;
+const sid = (suffix) => `${RUN_ID}-${suffix}`;
+
+describe.skipIf(!HAS_DB)('cleanup_stale_sessions in-flight protection (LIVE, rolled back) — SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001', () => {
+  let client;
+
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    client = await createDatabaseClient('engineer', { verify: false });
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    // Defensive: ensure no open txn leaked a row. Run OUTSIDE any txn.
+    let n = -1;
+    try {
+      const r = await client.query(
+        `SELECT count(*)::int AS n FROM claude_sessions WHERE session_id LIKE $1`,
+        [`${RUN_ID}-%`]
+      );
+      n = r.rows[0].n;
+    } finally {
+      await client.end();
+    }
+    // Zero-survivors guard: nothing this run seeded may have committed.
+    expect(n).toBe(0);
+  });
+
+  // ---- helpers (all operate inside the caller's open transaction) ----
+
+  // Seed a throwaway claimed session. heartbeatMinAgo backdates both claimed_at and
+  // heartbeat_at; esuMinFromNow sets expected_silence_until in the future (null => NULL).
+  // The row always carries a worktree (sd_key + worktree_path + worktree_branch) so the
+  // release-payload integrity assertion is meaningful.
+  async function seedActive({ suffix, heartbeatMinAgo, esuMinFromNow }) {
+    const session_id = sid(suffix);
+    await client.query(
+      `INSERT INTO claude_sessions
+         (session_id, status, sd_key, track, worktree_path, worktree_branch,
+          claimed_at, heartbeat_at, expected_silence_until)
+       VALUES ($1, 'active', $2, 'STANDALONE', $3, $4,
+          now() - ($5 || ' minutes')::interval,
+          now() - ($5 || ' minutes')::interval,
+          CASE WHEN $6::numeric IS NULL THEN NULL ELSE now() + ($6 || ' minutes')::interval END)`,
+      [
+        session_id,
+        `${RUN_ID}-CLAIM-${suffix}`,
+        `/tmp/sweeptest/wt/${session_id}`,
+        `sweeptest/${session_id}`,
+        String(heartbeatMinAgo),
+        esuMinFromNow == null ? null : String(esuMinFromNow),
+      ]
+    );
+    return session_id;
+  }
+
+  async function getRow(session_id) {
+    const r = await client.query(
+      `SELECT status, sd_key, worktree_path, worktree_branch, track, claimed_at
+       FROM claude_sessions WHERE session_id = $1`,
+      [session_id]
+    );
+    return r.rows[0];
+  }
+
+  async function runCleanup() {
+    // Default 120s stale threshold mirrors the production call site.
+    const r = await client.query(`SELECT cleanup_stale_sessions(120, 100) AS result`);
+    return r.rows[0].result;
+  }
+
+  // Backdate a just-marked-stale row's stale_at past the 30s release gate so the next
+  // cleanup pass releases it — deterministic, no real-time wait. Scoped to status='stale'.
+  async function ageStale(session_id) {
+    await client.query(
+      `UPDATE claude_sessions SET stale_at = now() - interval '90 seconds'
+       WHERE session_id = $1 AND status = 'stale'`,
+      [session_id]
+    );
+  }
+
+  async function setFlag(value) {
+    await client.query(
+      `UPDATE chairman_dashboard_config
+         SET metadata = jsonb_set(metadata, '{sweep_respect_inflight_agent}', $1::jsonb, true)
+       WHERE config_key = 'default'`,
+      [JSON.stringify(value)]
+    );
+  }
+
+  // Run a scenario inside its own BEGIN..ROLLBACK so flag mutations and seeded rows are
+  // fully discarded between tests (and the live flag state is never disturbed).
+  async function inTxn(fn) {
+    await client.query('BEGIN');
+    try {
+      return await fn();
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  }
+
+  it('TS-1: in-flight protected — flag ON + future expected_silence_until + recent-enough heartbeat → claim NOT swept', async () => {
+    const out = await inTxn(async () => {
+      await setFlag(true);
+      // heartbeat 5min old: older than the 120s stale threshold (so absent the exemption it
+      // WOULD be marked stale) but well within the 45-min hard cap.
+      const s = await seedActive({ suffix: 'TS1', heartbeatMinAgo: 5, esuMinFromNow: 10 });
+      const cleanup = await runCleanup();
+      const row = await getRow(s);
+      return { cleanup, row, sessionId: s };
+    });
+    expect(out.cleanup.respect_inflight_agent).toBe(true);
+    expect(out.cleanup.hardcap_minutes).toBe(45);
+    // Still holds its claim, untouched — never even marked stale. sd_key/worktree unchanged.
+    expect(out.row.status).toBe('active');
+    expect(out.row.sd_key).toBe(`${RUN_ID}-CLAIM-TS1`);
+    expect(out.row.worktree_path).toBe(`/tmp/sweeptest/wt/${out.sessionId}`);
+    expect(out.row.worktree_branch).toBe(`sweeptest/${out.sessionId}`);
+  });
+
+  it('TS-2: hard-cap preserved — same in-flight session aged past the 45-min hard cap → IS released; sd_key + worktree cleared together', async () => {
+    const out = await inTxn(async () => {
+      await setFlag(true);
+      // heartbeat 50min old: PAST the (30 + 15) = 45-min hard cap, even though ESU is still
+      // in the future. The exemption must be denied → Step 1 marks it stale.
+      const s = await seedActive({ suffix: 'TS2', heartbeatMinAgo: 50, esuMinFromNow: 10 });
+
+      const pass1 = await runCleanup();
+      const afterPass1 = await getRow(s);
+
+      await ageStale(s);
+      const pass2 = await runCleanup();
+      const afterPass2 = await getRow(s);
+
+      return { pass1, afterPass1, pass2, afterPass2 };
+    });
+    // Exemption denied at the hard cap: marked stale despite flag ON + future ESU.
+    expect(out.afterPass1.status).toBe('stale');
+    // Then released, with the full claim payload cleared TOGETHER (constraint-safe).
+    expect(out.afterPass2.status).toBe('released');
+    expect(out.afterPass2.sd_key).toBeNull();
+    expect(out.afterPass2.worktree_path).toBeNull();
+    expect(out.afterPass2.worktree_branch).toBeNull();
+    expect(out.afterPass2.track).toBeNull();
+    expect(out.afterPass2.claimed_at).toBeNull();
+  });
+
+  it('TS-3: fail-open — stale session with NULL expected_silence_until → released normally', async () => {
+    const out = await inTxn(async () => {
+      await setFlag(true); // flag ON, but NULL ESU must never block the sweep
+      // heartbeat 20min old, NO expected_silence_until. Within the cap, flag ON — but the
+      // exemption requires a non-NULL future ESU, so fail-open: it is swept normally.
+      const s = await seedActive({ suffix: 'TS3', heartbeatMinAgo: 20, esuMinFromNow: null });
+
+      const pass1 = await runCleanup();
+      const afterPass1 = await getRow(s);
+
+      await ageStale(s);
+      const pass2 = await runCleanup();
+      const afterPass2 = await getRow(s);
+
+      return { pass1, afterPass1, pass2, afterPass2 };
+    });
+    // NULL ESU → no exemption → marked stale in pass1 ...
+    expect(out.afterPass1.status).toBe('stale');
+    // ... and released (payload cleared together) in pass2.
+    expect(out.afterPass2.status).toBe('released');
+    expect(out.afterPass2.sd_key).toBeNull();
+    expect(out.afterPass2.worktree_path).toBeNull();
+    expect(out.afterPass2.worktree_branch).toBeNull();
+  });
+
+  it('TS-4: flag gates it — sweep_respect_inflight_agent = false → an in-flight session (future ESU, within cap) IS released', async () => {
+    const out = await inTxn(async () => {
+      await setFlag(false); // exemption gated OFF
+      // Identical in-flight shape to TS-1 (heartbeat 5min, future ESU, within cap) — the ONLY
+      // difference is the flag. With the flag OFF the exemption must not apply.
+      const s = await seedActive({ suffix: 'TS4', heartbeatMinAgo: 5, esuMinFromNow: 10 });
+
+      const pass1 = await runCleanup();
+      const afterPass1 = await getRow(s);
+
+      await ageStale(s);
+      const pass2 = await runCleanup();
+      const afterPass2 = await getRow(s);
+
+      return { pass1, afterPass1, pass2, afterPass2 };
+    });
+    // Flag OFF → exemption not applied → in-flight session marked stale ...
+    expect(out.pass1.respect_inflight_agent).toBe(false);
+    expect(out.afterPass1.status).toBe('stale');
+    // ... then released, payload cleared together.
+    expect(out.afterPass2.status).toBe('released');
+    expect(out.afterPass2.sd_key).toBeNull();
+    expect(out.afterPass2.worktree_path).toBeNull();
+    expect(out.afterPass2.worktree_branch).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Activates the previously-inert protection that stops `cleanup_stale_sessions` from releasing a worker's claim **mid-sub-agent** — the failure mode where fleet workers "go dormant" during long `Task`/`Agent` runs that fire no heartbeat.

Delivered as 3-part deploy **enablement** (not a new build):
- **Consumer**: `cleanup_stale_sessions()` honors `claude_sessions.expected_silence_until` (flag-gated, NULL-safe/fail-open, **45-min hard-cap preserved**) — re-authored from the LIVE `pg_get_functiondef` and applied via the audited `apply-migration.js --prod-deploy` (`schema_migrations_applied` `33cf894c`).
- **Flag**: `chairman_dashboard_config.metadata.sweep_respect_inflight_agent` flipped `false→true` (after the consumer was confirmed live).
- **Writer**: `SWEEP_RESPECT_INFLIGHT_AGENT=1` in `.claude/settings.json` so the PreToolUse hook **await-persists** `expected_silence_until` on Task/Agent dispatch.

## Verify-before-build correction
The initial "consumer migration unapplied" premise was a **false negative** (queried `migration_name`; the column is `migration_path`). The consumer was already deployed 2026-06-05; the database-agent confirmed via LIVE `pg_get_functiondef`. The real residual was the flag + writer env.

## Tests
`tests/integration/claim-sweep-inflight-protection.test.js` — 4 live-DB `BEGIN..ROLLBACK` tests, all green: in-flight protected · hard-cap preserved · fail-open on NULL · flag-gated. Zero row leak.

## Deploy nuance
`.claude/settings.json` is read by the hook from the **main checkout**, so the writer env activates for the running fleet only after the main checkout updates (merged ≠ deployed). DB-layer pieces are already live. Rollback = flip the flag `false`.

## Evidence
DATABASE `2e2333ed` (migration applied + TS-1..TS-4 verified), TESTING `e65b3a2d` (4/4 green). Retro `3aa29da2` (q100). LEO gates: LEAD-TO-PLAN/PLAN-TO-EXEC/EXEC-TO-PLAN/PLAN-TO-LEAD 96/94/94/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
