### PR TITLE
fix(SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001): ancestry-safe Windows terminal identity

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -23,7 +23,7 @@
  */
 
 import { execSync } from 'child_process';
-import { readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
@@ -201,12 +201,14 @@ function _getAncestorPids() {
  * marker file with a unique session_id.
  *
  * @param {string} [ssePort] - Optional SSE port to filter markers
+ * @param {Set<string>} [precomputedAncestorPids] - Optional ancestor PID set; avoids a
+ *   redundant PowerShell ancestry walk when the caller already computed it.
  * @returns {string|null} The session_id from the matching marker, or null
  */
-function _scanMarkersByAncestry(ssePort) {
+function _scanMarkersByAncestry(ssePort, precomputedAncestorPids) {
   try {
     const markerDir = resolve(_repoRoot, '.claude/session-identity');
-    const ancestorPids = _getAncestorPids();
+    const ancestorPids = precomputedAncestorPids || _getAncestorPids();
     if (ancestorPids.size === 0) return null;
 
     const files = readdirSync(markerDir).filter(f => f.startsWith('pid-') && f.endsWith('.json'));
@@ -302,39 +304,34 @@ export function getTerminalId() {
       return claudeSessionId;
     }
 
-    // Priority 2: Match marker file by SSE port (no PowerShell needed).
-    // The SessionStart hook writes pid-{ccPid}.json with sse_port inside.
-    // Instead of discovering the ancestor PID (which requires PowerShell),
-    // scan all marker files and match by CLAUDE_CODE_SSE_PORT — unique per conversation.
-    // With 1-5 concurrent sessions, SSE port is an unambiguous identifier.
+    // Priority 2: Ancestry-verified marker match.
+    // SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001: The previous implementation picked the
+    // NEWEST-mtime pid-*.json marker matching CLAUDE_CODE_SSE_PORT. On a SHARED SSE port
+    // that newest marker can belong to a DIFFERENT (sibling) conversation, so this process
+    // would adopt a foreign session UUID and session-manager would mint a SECOND
+    // claude_sessions row for one conversation (the canonical row's sd_key then goes NULL).
+    // We now compute the ancestor PID set ONCE and only accept a marker whose owning PID is
+    // an ancestor of THIS process; a non-ancestry-verified marker is never returned or cached.
     const ssePortForMarker = process.env.CLAUDE_CODE_SSE_PORT;
+    const _ancestorPids = ssePortForMarker ? _getAncestorPids() : new Set();
     if (ssePortForMarker) {
-      try {
-        const markerDir = resolve(_repoRoot, '.claude/session-identity');
-        const files = readdirSync(markerDir).filter(f => f.startsWith('pid-') && f.endsWith('.json'));
-        // Sort by mtime descending — most recent first
-        const sorted = files
-          .map(f => ({ name: f, mtime: statSync(resolve(markerDir, f)).mtimeMs }))
-          .sort((a, b) => b.mtime - a.mtime);
-        for (const { name } of sorted) {
-          const marker = JSON.parse(readFileSync(resolve(markerDir, name), 'utf8'));
-          if (marker.sse_port === ssePortForMarker && marker.session_id) {
-            // Cache in process.env so child processes and subsequent calls
-            // resolve instantly without re-walking markers or process tree.
-            process.env.CLAUDE_SESSION_ID = marker.session_id;
-            return marker.session_id;
-          }
-        }
-      } catch {
-        // Marker scan failed — fall through
+      const ancestrySessionId = _scanMarkersByAncestry(ssePortForMarker, _ancestorPids);
+      if (ancestrySessionId) {
+        // Safe to cache: the marker was ancestry-verified for this process, so child
+        // processes and subsequent calls can resolve instantly without re-walking.
+        process.env.CLAUDE_SESSION_ID = ancestrySessionId;
+        return ancestrySessionId;
       }
     }
 
-    // Priority 2b (legacy): Read by exact PID match if findClaudeCodePid succeeds.
-    // This path still uses PowerShell but is no longer the primary mechanism.
+    // Priority 2b: Exact-PID marker read — ONLY when the discovered PID is ancestry-verified.
+    // findClaudeCodePid() falls back to a process SCAN when the tree-walk fails; on a shared
+    // SSE port that scan can return a sibling conversation's node PID. Adopting its marker is
+    // exactly the split-identity bug, so we require the PID to be in this process's ancestry
+    // before reading or caching its marker UUID.
     try {
       const ccPid = findClaudeCodePid();
-      if (ccPid) {
+      if (ccPid && _ancestorPids.has(String(ccPid))) {
         const markerPath = resolve(__dirname, '../.claude/session-identity', `pid-${ccPid}.json`);
         const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
         if (marker.session_id) {
@@ -349,19 +346,15 @@ export function getTerminalId() {
     if (process.platform === 'win32') {
       const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
       if (ssePort) {
-        // Disambiguate with Claude Code ancestor PID (unique per conversation)
+        // Disambiguate with the Claude Code ancestor PID — ONLY when it is ancestry-verified.
+        // SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001: a process-scan PID on a shared SSE port may
+        // belong to a sibling conversation; returning win-cc-{port}-{siblingPid} here would
+        // re-introduce a cross-session collision. If unverified, fall through to the per-PID
+        // unique fallback below. (Priority 2 already ran the ancestry-verified marker scan
+        // with this same ancestor set, so no second scan is needed here.)
         const ccPid = findClaudeCodePid();
-        if (ccPid) {
+        if (ccPid && _ancestorPids.has(String(ccPid))) {
           return `win-cc-${ssePort}-${ccPid}`;
-        }
-        // Priority 3: Scan marker files by ancestry match.
-        // When findClaudeCodePid() fails (exclusion list mismatch, broken chain),
-        // collect ALL ancestor PIDs and match against pid-*.json markers written
-        // by the SessionStart hook. Each session has a unique marker because
-        // each Claude Code instance has a unique PID in a different ancestry chain.
-        const markerSessionId = _scanMarkersByAncestry(ssePort);
-        if (markerSessionId) {
-          return markerSessionId;
         }
         // SD-MAN-INFRA-FIX-SESSION-UNIQUENESS-001: Write per-PID fallback marker.
         // Previous implementation used fallback-{ssePort}.json shared across all

--- a/test/unit/terminal-identity-ancestry-split.test.js
+++ b/test/unit/terminal-identity-ancestry-split.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tests for SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001
+ *
+ * The Windows session-identity split: when CLAUDE_SESSION_ID is unset and the
+ * process-ancestry tree-walk fails, getTerminalId() previously adopted the
+ * NEWEST-mtime pid-*.json marker (Priority 2) or the process-SCAN PID's marker
+ * (Priority 2b). On a SHARED SSE port that marker can belong to a SIBLING
+ * conversation, minting a second claude_sessions row with a foreign UUID.
+ *
+ * The fix makes identity resolution ANCESTRY-VERIFIED in the env-unset window:
+ *   FR-1 ancestor-owned marker wins over a sibling's marker
+ *   FR-2 a non-ancestry-verified UUID is never cached to process.env
+ *   FR-3 with no ancestry match, fall through to the per-PID unique fallback
+ *   FR-4 Priority-1 (CLAUDE_SESSION_ID set) is unchanged
+ *
+ * Strategy: terminal-identity.js shells out to PowerShell via execSync for the
+ * ancestor walk, the tree-walk, and the process scan, and reads pid-*.json
+ * markers via fs. We mock both 'child_process' and 'fs' and dispatch the
+ * execSync mock by decoding the base64 -EncodedCommand payloads.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const PORT = '22186';
+const ANCESTOR_PID = '1000';
+const SIBLING_PID = '5555';
+const UUID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'; // ancestor-owned marker (correct identity)
+const UUID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'; // sibling-owned marker (foreign — must never win)
+
+// Mutable scenario shared with the mock factories (read at call time).
+const S = {
+  ancestors: '',   // CSV returned by the ancestor walk ($pids -join ",")
+  treewalk: '',     // chain returned by the tree-walk ($chain -join ";")
+  scan: '',         // "pid|cmdline" returned by the process scan ($results -join ";")
+  markers: {},      // { 'pid-NNNN.json': { session_id, sse_port } }
+  wrote: {}         // captured writeFileSync payloads
+};
+
+function decodeEncodedCommand(cmd) {
+  const m = /-EncodedCommand (\S+)/.exec(cmd);
+  if (!m) return null;
+  return Buffer.from(m[1], 'base64').toString('utf16le');
+}
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn((cmd) => {
+    if (typeof cmd === 'string' && cmd.includes('git rev-parse')) return 'C:/fake-repo/.git';
+    const script = decodeEncodedCommand(cmd);
+    if (script) {
+      if (script.includes('$chain -join')) return S.treewalk;       // tree-walk
+      if (script.includes('$pids -join')) return S.ancestors;        // ancestor walk
+      if (script.includes('$results -join')) return S.scan;          // process scan
+    }
+    if (typeof cmd === 'string' && cmd.includes('SessionId')) return '1';
+    return '';
+  })
+}));
+
+vi.mock('fs', () => {
+  const findMarker = (p) => Object.keys(S.markers).find((k) => String(p).includes(k));
+  return {
+    readdirSync: vi.fn(() => Object.keys(S.markers)),
+    readFileSync: vi.fn((p) => {
+      const key = findMarker(p);
+      if (key) return JSON.stringify(S.markers[key]);
+      const e = new Error('ENOENT: ' + p);
+      e.code = 'ENOENT';
+      throw e;
+    }),
+    existsSync: vi.fn((p) => String(p).replace(/\\/g, '/').endsWith('.claude/session-identity')),
+    writeFileSync: vi.fn((p, data) => { S.wrote[String(p)] = data; }),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(() => ({ mtimeMs: 0 }))
+  };
+});
+
+async function loadGetTerminalId() {
+  vi.resetModules();
+  const mod = await import('../../lib/terminal-identity.js');
+  return mod.getTerminalId;
+}
+
+describe('getTerminalId() ancestry-safe resolution (SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001)', () => {
+  let savedSid, savedPort, savedPlatform;
+
+  beforeEach(() => {
+    savedSid = process.env.CLAUDE_SESSION_ID;
+    savedPort = process.env.CLAUDE_CODE_SSE_PORT;
+    savedPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    delete process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_CODE_SSE_PORT = PORT;
+    // reset scenario
+    S.ancestors = '';
+    S.treewalk = '';
+    S.scan = '';
+    S.markers = {};
+    S.wrote = {};
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
+    if (savedSid === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = savedSid;
+    if (savedPort === undefined) delete process.env.CLAUDE_CODE_SSE_PORT; else process.env.CLAUDE_CODE_SSE_PORT = savedPort;
+    vi.restoreAllMocks();
+  });
+
+  it('FR-1/TS-1: ancestor-owned marker wins over a sibling marker on a shared SSE port', async () => {
+    // Tree-walk fails; ancestry includes ANCESTOR_PID (which owns marker UUID-A).
+    // A sibling marker (UUID-B) also matches the port and could be the newest by mtime.
+    S.treewalk = '';
+    S.ancestors = `${process.pid},${ANCESTOR_PID}`;
+    S.scan = `${SIBLING_PID}|node.exe foo --port ${PORT}`;
+    S.markers = {
+      [`pid-${ANCESTOR_PID}.json`]: { session_id: UUID_A, sse_port: PORT },
+      [`pid-${SIBLING_PID}.json`]: { session_id: UUID_B, sse_port: PORT }
+    };
+    const getTerminalId = await loadGetTerminalId();
+    const id = getTerminalId();
+    expect(id).toBe(UUID_A);
+    expect(id).not.toBe(UUID_B);
+    expect(process.env.CLAUDE_SESSION_ID).toBe(UUID_A); // ancestry-verified, safe to cache
+  });
+
+  it('FR-3/TS-2: with only a non-ancestor sibling marker, falls through to a unique per-PID fallback (never the sibling UUID)', async () => {
+    // Tree-walk fails; ancestry does NOT include the sibling PID; only the sibling marker exists.
+    S.treewalk = '';
+    S.ancestors = `${process.pid},${ANCESTOR_PID},2000`;
+    S.scan = `${SIBLING_PID}|node.exe foo --port ${PORT}`;
+    S.markers = {
+      [`pid-${SIBLING_PID}.json`]: { session_id: UUID_B, sse_port: PORT }
+    };
+    const getTerminalId = await loadGetTerminalId();
+    const id = getTerminalId();
+    expect(id).not.toBe(UUID_B);
+    expect(id).toMatch(/^win-(fallback-22186-\d+-[0-9a-f]{8}|pid-\d+)$/);
+  });
+
+  it('FR-2/TS-4: a non-ancestry-verified sibling UUID is never cached to process.env.CLAUDE_SESSION_ID', async () => {
+    S.treewalk = '';
+    S.ancestors = `${process.pid},${ANCESTOR_PID}`;
+    S.scan = `${SIBLING_PID}|node.exe foo --port ${PORT}`;
+    S.markers = {
+      [`pid-${SIBLING_PID}.json`]: { session_id: UUID_B, sse_port: PORT }
+    };
+    const getTerminalId = await loadGetTerminalId();
+    getTerminalId();
+    expect(process.env.CLAUDE_SESSION_ID).not.toBe(UUID_B);
+  });
+
+  it('FR-4/TS-3: when CLAUDE_SESSION_ID is set, it is returned verbatim regardless of on-disk markers', async () => {
+    process.env.CLAUDE_SESSION_ID = 'env-set-uuid-1234';
+    // Even if a sibling marker exists, Priority-1 must short-circuit.
+    S.markers = { [`pid-${SIBLING_PID}.json`]: { session_id: UUID_B, sse_port: PORT } };
+    const getTerminalId = await loadGetTerminalId();
+    expect(getTerminalId()).toBe('env-set-uuid-1234');
+  });
+
+  it('FR-1 edge: ancestry match also wins when the ancestor PID equals the discoverable CC PID (single-session legit case)', async () => {
+    // Single conversation: exactly one marker, owned by an ancestor → resolves to its UUID.
+    S.treewalk = '';
+    S.ancestors = `${process.pid},${ANCESTOR_PID}`;
+    S.markers = { [`pid-${ANCESTOR_PID}.json`]: { session_id: UUID_A, sse_port: PORT } };
+    const getTerminalId = await loadGetTerminalId();
+    expect(getTerminalId()).toBe(UUID_A);
+  });
+
+  it('FR-1 negative: sibling marker on a DIFFERENT sse_port is ignored even if its PID were an ancestor', async () => {
+    // sse_port mismatch guard inside _scanMarkersByAncestry still applies.
+    S.treewalk = '';
+    S.ancestors = `${process.pid},${ANCESTOR_PID}`;
+    S.scan = `${SIBLING_PID}|node.exe foo --port ${PORT}`;
+    S.markers = {
+      [`pid-${ANCESTOR_PID}.json`]: { session_id: UUID_B, sse_port: '99999' } // wrong port
+    };
+    const getTerminalId = await loadGetTerminalId();
+    const id = getTerminalId();
+    expect(id).not.toBe(UUID_B);
+    expect(id).toMatch(/^win-(fallback-22186-\d+-[0-9a-f]{8}|pid-\d+)$/);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001 — Ancestry-safe Windows terminal identity

Fixes the Windows **session-identity split**: for one Claude Code conversation, two `claude_sessions` rows could be created ~12s apart, inflating fleet worker counts and confusing claim ownership (the canonical row's `sd_key` goes NULL).

### Root cause
`lib/terminal-identity.js` `getTerminalId()` already honors `CLAUDE_SESSION_ID` first (Priority 1). But in the **`CLAUDE_SESSION_ID`-unset window** (a subprocess that didn't inherit `CLAUDE_ENV_FILE`, or a pre-export race) it adopted:
- **Priority 2** — the *newest-mtime* `pid-*.json` marker matching the SSE port, and
- **Priority 2b** — the *process-scan* PID's marker.

On a **shared SSE port** (e.g. 22186) either can belong to a **sibling conversation**, so `session-manager.getOrCreateSession()` minted a second row keyed to that foreign UUID. (Confirmed via live DB: duplicate same-conversation UUID pairs born 4–27s apart.)

### Fix (lib/terminal-identity.js only, net −7 LOC)
- Compute the ancestor PID set **once** and only accept a marker/PID that is **ancestry-verified** (`_scanMarkersByAncestry` / `_getAncestorPids`, both pre-existing).
- Ancestry-guard Priority-2b and the `win-cc-{port}-{pid}` return.
- **Never cache** an unverified UUID to `process.env.CLAUDE_SESSION_ID`.
- On no ancestry match, fall through to the existing **per-PID unique fallback** (`win-fallback-{port}-{pid}-{uuid8}`).
- Removed the now-redundant Priority-3 scan and the unused `statSync` import.

Priority-1 (env set) is unchanged — no hot-path regression, no PowerShell when `CLAUDE_SESSION_ID` is set.

### Validation
- **6 new unit tests** (`test/unit/terminal-identity-ancestry-split.test.js`): ancestor-wins-over-sibling, no-foreign-cache, unique-fallback fallthrough, env passthrough, sse_port-mismatch guard.
- **Regression**: existing `port-only-terminal-id` + `session-identity-stability` suites green (25).
- **TESTING sub-agent**: PASS (coverage adequate, not shallow).
- **SECURITY sub-agent**: PASS — net integrity *improvement*; a sibling can never satisfy the ancestry check; no new injection surface.

### Out of scope
Reaping already-orphaned duplicate rows; marker-dir poison cleanup; the Unix TTY path; redesigning the tree-walk algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
