### PR TITLE
docs(SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001): runbook + changelog for session-identity split fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Table of Contents
 
+- [2026-06-06](#2026-06-06)
+  - [Bugfix](#bugfix)
 - [2026-01-29](#2026-01-29)
   - [Bugfix](#bugfix)
 - [2026-01-26](#2026-01-26)
@@ -30,6 +32,14 @@
   - [Housekeeping & CI](#housekeeping-ci)
   - [EHG_Engineering](#ehg_engineering)
   - [EHG (Venture App)](#ehg-venture-app)
+
+## 2026-06-06
+
+### Bugfix
+- **Windows session-identity split** - PR #4283 (SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001)
+  - **Issue**: One Claude Code conversation could create two `claude_sessions` rows (born seconds apart), inflating fleet worker counts and confusing claim ownership (canonical row's `sd_key` → NULL).
+  - **Root Cause**: In the `CLAUDE_SESSION_ID`-unset window, `lib/terminal-identity.js` `getTerminalId()` adopted the newest-mtime / process-scan marker, which on a shared SSE port could be a sibling conversation's UUID.
+  - **Fix**: Ancestry-verify marker/PID resolution (reuse `_scanMarkersByAncestry`/`_getAncestorPids`), never cache an unverified UUID, fall through to the per-PID unique fallback. Priority-1 (env set) unchanged. +6 unit tests; existing terminal-identity suites green.
 
 ## 2026-01-29
 

--- a/docs/06_deployment/multi-session-coordination-ops.md
+++ b/docs/06_deployment/multi-session-coordination-ops.md
@@ -398,6 +398,14 @@ WHERE session_id = 'session_abc123';
    WHERE sd_key = 'SD-XXX-001';
    ```
 
+### Issue: Duplicate claude_sessions rows for one conversation (session-identity split)
+
+**Symptom**: Two `claude_sessions` rows appear for a single Claude Code conversation (born seconds apart); fleet worker counts look inflated and claim ownership is ambiguous. The canonical row's `sd_key` may go NULL after the claim/worktree migrate to the second row.
+
+**Explanation** (Windows): When `CLAUDE_SESSION_ID` is unset in a subprocess (it did not inherit `CLAUDE_ENV_FILE`, or a pre-export race) and the process-ancestry tree-walk fails, `lib/terminal-identity.js` `getTerminalId()` historically adopted the newest-mtime `pid-*.json` marker or a process-scan PID's marker. On a shared `CLAUDE_CODE_SSE_PORT` that marker could belong to a SIBLING conversation, so `session-manager.getOrCreateSession()` created a second row keyed to the foreign UUID.
+
+**Resolution** (SD-FDBK-ENH-SESSION-IDENTITY-SPLIT-001, 2026-06-06): `getTerminalId()` is now ancestry-safe in the `CLAUDE_SESSION_ID`-unset window — it only adopts a marker/PID whose owning PID is an ancestor of the current process (via `_scanMarkersByAncestry`/`_getAncestorPids`), never caches an unverified UUID, and falls through to the per-PID unique fallback (`win-fallback-{port}-{pid}-{uuid8}`) on no match. When `CLAUDE_SESSION_ID` is set (the normal case), Priority-1 returns it unchanged. Already-orphaned duplicate rows are not auto-reaped — release them with the Manual Claim Release procedure above if needed.
+
 ## Performance Impact
 
 ### Database Overhead


### PR DESCRIPTION
Post-completion documentation for the shipped fix in #4283. Adds a troubleshooting entry (symptom/cause/resolution) to the multi-session coordination operational runbook and a CHANGELOG bugfix entry. Docs-only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)