### PR TITLE
fix(SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001): clear stale missing_protocol_improvements warnings on retrospective UPDATE

### DIFF
--- a/database/migrations/20260606_clear_stale_missing_protocol_improvements.sql
+++ b/database/migrations/20260606_clear_stale_missing_protocol_improvements.sql
@@ -1,0 +1,139 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001
+--
+-- Make validate_protocol_improvements_for_process_category() symmetric + idempotent.
+--
+-- Bug (empirically confirmed against the live function):
+--   * The function only ADDED a {type:'missing_protocol_improvements'} entry to
+--     quality_issues when a PROCESS_IMPROVEMENT retro had no protocol_improvements,
+--     and NEVER removed it once protocol_improvements was backfilled.
+--   * Because it appended unconditionally, repeated UPDATEs while protocol_improvements
+--     stayed empty produced DUPLICATE warnings (and re-applied the -10 score penalty
+--     each time).
+--   * On a protocol_improvements-only UPDATE, auto_validate_retrospective_quality()
+--     early-returns (protocol_improvements is not in its should_recalculate watch list:
+--     {what_went_well,key_learnings,action_items,what_needs_improvement}), so it never
+--     rebuilt/cleared quality_issues either -> the stale warning persisted forever.
+--
+-- Fix:
+--   * Add the warning ONCE (idempotent) — only when no missing_protocol_improvements
+--     entry already exists; the -10 penalty therefore applies only on first add.
+--   * CLEAR any missing_protocol_improvements entries whenever the condition no longer
+--     holds (protocol_improvements present, or the retro is not PROCESS_IMPROVEMENT).
+--     quality_score is intentionally left unchanged on the clear path — this is a
+--     cosmetic quality_issues fix per the SD scope (score/status unaffected).
+--
+-- Note (out of scope): a missing_protocol_improvements warning does not survive a
+-- content-change INSERT/UPDATE because auto_validate_retrospective_quality() (which
+-- fires last, alphabetically) overwrites quality_issues on should_recalculate=TRUE.
+-- Unifying ownership of quality_issues across the two triggers is a separate concern.
+
+CREATE OR REPLACE FUNCTION public.validate_protocol_improvements_for_process_category()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  has_warning boolean := false;
+BEGIN
+  -- Is a missing_protocol_improvements warning already present? (array-safe)
+  IF jsonb_typeof(COALESCE(NEW.quality_issues, '[]'::jsonb)) = 'array' THEN
+    has_warning := EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(COALESCE(NEW.quality_issues, '[]'::jsonb)) e
+      WHERE e->>'type' = 'missing_protocol_improvements'
+    );
+  END IF;
+
+  IF NEW.learning_category = 'PROCESS_IMPROVEMENT'
+     AND (NEW.protocol_improvements IS NULL
+          OR jsonb_typeof(NEW.protocol_improvements) <> 'array'
+          OR jsonb_array_length(NEW.protocol_improvements) = 0) THEN
+    -- protocol_improvements missing: warn ONCE (idempotent — no duplicates; the
+    -- -10 score penalty applies only on the first add).
+    IF NOT has_warning THEN
+      NEW.quality_issues = COALESCE(NEW.quality_issues, '[]'::jsonb) ||
+        jsonb_build_array(jsonb_build_object(
+          'type', 'missing_protocol_improvements',
+          'severity', 'warning',
+          'message', 'PROCESS_IMPROVEMENT retrospective should include protocol_improvements suggestions',
+          'detected_at', now()
+        ));
+
+      IF NEW.quality_score IS NOT NULL AND NEW.quality_score > 10 THEN
+        NEW.quality_score = NEW.quality_score - 10;
+      END IF;
+    END IF;
+  ELSE
+    -- Condition no longer holds (protocol_improvements present, or not a
+    -- PROCESS_IMPROVEMENT retro): clear any stale missing_protocol_improvements
+    -- warning. quality_score is intentionally left unchanged (cosmetic fix).
+    IF has_warning THEN
+      NEW.quality_issues = COALESCE((
+        SELECT jsonb_agg(e)
+        FROM jsonb_array_elements(NEW.quality_issues) e
+        WHERE e->>'type' IS DISTINCT FROM 'missing_protocol_improvements'
+      ), '[]'::jsonb);
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- ── One-time cleanup of existing stale rows ────────────────────────────────────
+-- Removes the missing_protocol_improvements warning from retrospectives that carry
+-- it despite having protocol_improvements present (or not being PROCESS_IMPROVEMENT).
+-- Count-guarded: aborts if the affected set is implausibly large; asserts 0 remain.
+-- The UPDATE touches only quality_issues, so auto_validate_retrospective_quality()
+-- early-returns (no score recompute) and quality_score is preserved.
+DO $cleanup$
+DECLARE
+  pre_count  integer;
+  post_count integer;
+BEGIN
+  SELECT count(*) INTO pre_count
+  FROM retrospectives r
+  WHERE jsonb_typeof(COALESCE(r.quality_issues, '[]'::jsonb)) = 'array'
+    AND EXISTS (SELECT 1 FROM jsonb_array_elements(r.quality_issues) e
+                WHERE e->>'type' = 'missing_protocol_improvements')
+    AND ( r.learning_category IS DISTINCT FROM 'PROCESS_IMPROVEMENT'
+          OR (r.protocol_improvements IS NOT NULL
+              AND jsonb_typeof(r.protocol_improvements) = 'array'
+              AND jsonb_array_length(r.protocol_improvements) > 0) );
+
+  IF pre_count > 100 THEN
+    RAISE EXCEPTION 'Cleanup aborted: % stale rows exceed the sanity cap of 100 (expected a handful). Investigate before bulk-updating.', pre_count;
+  END IF;
+
+  UPDATE retrospectives r
+  SET quality_issues = COALESCE((
+        SELECT jsonb_agg(e)
+        FROM jsonb_array_elements(r.quality_issues) e
+        WHERE e->>'type' IS DISTINCT FROM 'missing_protocol_improvements'
+      ), '[]'::jsonb)
+  WHERE jsonb_typeof(COALESCE(r.quality_issues, '[]'::jsonb)) = 'array'
+    AND EXISTS (SELECT 1 FROM jsonb_array_elements(r.quality_issues) e
+                WHERE e->>'type' = 'missing_protocol_improvements')
+    AND ( r.learning_category IS DISTINCT FROM 'PROCESS_IMPROVEMENT'
+          OR (r.protocol_improvements IS NOT NULL
+              AND jsonb_typeof(r.protocol_improvements) = 'array'
+              AND jsonb_array_length(r.protocol_improvements) > 0) );
+
+  SELECT count(*) INTO post_count
+  FROM retrospectives r
+  WHERE jsonb_typeof(COALESCE(r.quality_issues, '[]'::jsonb)) = 'array'
+    AND EXISTS (SELECT 1 FROM jsonb_array_elements(r.quality_issues) e
+                WHERE e->>'type' = 'missing_protocol_improvements')
+    AND ( r.learning_category IS DISTINCT FROM 'PROCESS_IMPROVEMENT'
+          OR (r.protocol_improvements IS NOT NULL
+              AND jsonb_typeof(r.protocol_improvements) = 'array'
+              AND jsonb_array_length(r.protocol_improvements) > 0) );
+
+  IF post_count <> 0 THEN
+    RAISE EXCEPTION 'Cleanup incomplete: % stale rows remain (expected 0).', post_count;
+  END IF;
+
+  RAISE NOTICE 'SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001: cleared stale missing_protocol_improvements warning from % row(s); 0 remain.', pre_count;
+END
+$cleanup$;

--- a/tests/integration/retro-protocol-improvements-clear.test.js
+++ b/tests/integration/retro-protocol-improvements-clear.test.js
@@ -1,0 +1,133 @@
+/**
+ * Regression test for SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001.
+ *
+ * Locks in the symmetric/idempotent fix to validate_protocol_improvements_for_process_category():
+ *   - adds a missing_protocol_improvements warning ONCE (no duplicates) while
+ *     protocol_improvements is empty, and
+ *   - CLEARS that warning when protocol_improvements is backfilled or the retro is
+ *     no longer PROCESS_IMPROVEMENT.
+ *
+ * SAFETY: every scenario runs inside a pg-Client BEGIN..ROLLBACK transaction. We never
+ * COMMIT and never DELETE — ROLLBACK discards the inserted retro AND its audit-trigger
+ * rows together. (A prior retro test used supabase-js INSERT + afterEach DELETE; the
+ * AFTER-DELETE audit FK silently blocked the deletes and leaked ~2327 rows into prod —
+ * see SD-LEO-INFRA-STOP-RETRO-TRIGGER-001. Do NOT reintroduce that pattern here.)
+ *
+ * Runs against the live linked database; skips when no DB credentials are available.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+// SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001's own UUID — satisfies the sd_id FK.
+const TEST_SD_UUID = 'a41d7ab6-a1b7-42a3-b5f4-0c2a5c58607d';
+
+const CONN_STR = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || null;
+const HAS_CREDS = Boolean(
+  CONN_STR || process.env.SUPABASE_DB_PASSWORD || process.env.EHG_DB_PASSWORD
+);
+
+let client = null;
+
+beforeAll(async () => {
+  if (!HAS_CREDS) return;
+  client = await createDatabaseClient('engineer', {
+    verify: false,
+    timeout: 15000,
+    ...(CONN_STR ? { connectionString: CONN_STR } : {}),
+  });
+});
+
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+const arr = (n, prefix) =>
+  JSON.stringify(Array.from({ length: n }, (_, i) => `${prefix} item ${i + 1} with enough descriptive detail to be specific`));
+
+const warnCount = (qi) =>
+  (Array.isArray(qi) ? qi.filter((e) => e && e.type === 'missing_protocol_improvements').length : -1);
+const hasField = (qi, field) =>
+  Array.isArray(qi) && qi.some((e) => e && e.field === field);
+
+// Insert a PROCESS_IMPROVEMENT retro (protocol_improvements NULL) and return its id.
+// `wellCount` lets a caller force an auto_validate "too few items" issue (wellCount < 3).
+async function insertRetro(wellCount = 5) {
+  const r = await client.query(
+    `INSERT INTO retrospectives
+       (sd_id, project_name, retro_type, title, status, generated_by, learning_category,
+        target_application, auto_generated, conducted_date,
+        what_went_well, key_learnings, action_items, what_needs_improvement, protocol_improvements)
+     VALUES ($1,$2,'AUDIT',$3,'DRAFT','MANUAL','PROCESS_IMPROVEMENT','EHG_Engineer',false, now(),
+        $4::jsonb,$5::jsonb,$6::jsonb,$7::jsonb, NULL)
+     RETURNING id, quality_issues`,
+    [TEST_SD_UUID, `TEST-PI-CLEAR-${Date.now()}-${Math.round(performance.now())}`,
+     'retro-protocol-improvements-clear regression',
+     arr(wellCount, 'well'), arr(5, 'learn'), arr(3, 'act'), arr(3, 'imp')]
+  );
+  return r.rows[0].id;
+}
+
+const itDb = (name, fn) =>
+  test(name, async (ctx) => {
+    if (!client) { ctx.skip(); return; }
+    await client.query('BEGIN');
+    try {
+      await fn();
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+describe('validate_protocol_improvements_for_process_category (SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001)', () => {
+  itDb('adds the warning on a non-content UPDATE, then CLEARS it when protocol_improvements is backfilled', async () => {
+    const id = await insertRetro();
+
+    // TS-1: a non-content UPDATE while protocol_improvements is missing adds exactly one warning.
+    const added = await client.query(
+      `UPDATE retrospectives SET title = title || ' x' WHERE id=$1 RETURNING quality_issues`, [id]);
+    expect(warnCount(added.rows[0].quality_issues)).toBe(1);
+
+    // TS-2 (the bug): backfilling protocol_improvements (no content-field change) clears the warning.
+    const cleared = await client.query(
+      `UPDATE retrospectives SET protocol_improvements = $2::jsonb WHERE id=$1 RETURNING quality_issues`,
+      [id, JSON.stringify([{ suggestion: 'Add a guardrail to the X workflow' }])]);
+    expect(warnCount(cleared.rows[0].quality_issues)).toBe(0);
+  });
+
+  itDb('is idempotent — repeated non-content UPDATEs while missing yield a single warning (no duplicates)', async () => {
+    const id = await insertRetro();
+    await client.query(`UPDATE retrospectives SET title = title || ' x' WHERE id=$1`, [id]);
+    const second = await client.query(
+      `UPDATE retrospectives SET title = title || ' y' WHERE id=$1 RETURNING quality_issues`, [id]);
+    // Pre-fix this returned 2; the idempotent guard keeps it at 1.
+    expect(warnCount(second.rows[0].quality_issues)).toBe(1);
+  });
+
+  itDb('clears the warning when learning_category is no longer PROCESS_IMPROVEMENT', async () => {
+    const id = await insertRetro();
+    const added = await client.query(
+      `UPDATE retrospectives SET title = title || ' x' WHERE id=$1 RETURNING quality_issues`, [id]);
+    expect(warnCount(added.rows[0].quality_issues)).toBe(1);
+
+    const recat = await client.query(
+      `UPDATE retrospectives SET learning_category = 'TESTING_STRATEGY' WHERE id=$1 RETURNING quality_issues`, [id]);
+    expect(warnCount(recat.rows[0].quality_issues)).toBe(0);
+  });
+
+  itDb('preserves other quality_issues (auto_validate entries) when clearing the warning', async () => {
+    // wellCount=2 -> auto_validate emits a "too few items" issue on field=what_went_well.
+    const id = await insertRetro(2);
+    const added = await client.query(
+      `UPDATE retrospectives SET title = title || ' x' WHERE id=$1 RETURNING quality_issues`, [id]);
+    expect(warnCount(added.rows[0].quality_issues)).toBe(1);
+    expect(hasField(added.rows[0].quality_issues, 'what_went_well')).toBe(true);
+
+    const cleared = await client.query(
+      `UPDATE retrospectives SET protocol_improvements = $2::jsonb WHERE id=$1 RETURNING quality_issues`,
+      [id, JSON.stringify([{ suggestion: 'tighten the loop' }])]);
+    // The protocol warning is gone, but the auto_validate "too few items" issue survives.
+    expect(warnCount(cleared.rows[0].quality_issues)).toBe(0);
+    expect(hasField(cleared.rows[0].quality_issues, 'what_went_well')).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001 — clear stale `missing_protocol_improvements` warnings

### Problem
`retrospectives.quality_issues` kept a stale `{type:'missing_protocol_improvements'}` warning even after `protocol_improvements` was backfilled. Root cause: the BEFORE trigger **`validate_protocol_improvements_for_process_category()`** (not `auto_validate_retrospective_quality()` as the SD title implied) only *added* the warning and never *removed* it. On a `protocol_improvements`-only UPDATE, `auto_validate_retrospective_quality()` early-returns (that column isn't in its `should_recalculate` watch list), so nothing cleared it. The function also appended **duplicate** warnings (and re-applied −10) on repeated updates while missing.

### Fix
Make the function **symmetric + idempotent**:
- Add the warning **once** (only if not already present; single −10 penalty).
- **Clear** any `missing_protocol_improvements` entries when `protocol_improvements` is present or the retro is no longer `PROCESS_IMPROVEMENT`.
- `quality_score` left unchanged on the clear path (cosmetic fix, per SD scope).
- One-time **count-guarded** cleanup removed the warning from **5** existing stale rows (incl. witnessed retro `51bbafc0`).

### Verification
- Migration applied to the shared DB via `apply-migration.js --prod-deploy` (3-factor gated) → `MIGRATION_APPLY_PROD_PASS`.
- Full migration **BEGIN..ROLLBACK rehearsal** on live data: stale 5→0, idempotent, clears on backfill.
- Integration test (`tests/integration/retro-protocol-improvements-clear.test.js`, **pg-Client BEGIN..ROLLBACK** — no audit-FK leak): **4/4 pass**. Independently re-run by the TESTING sub-agent (verdict PASS, confidence 92).
- Post-deploy: 0 stale rows; witnessed retro `51bbafc0` no longer warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
