### PR TITLE
fix(SD-LEO-FIX-FIX-STAGE-QUEUE-001): stop Stage-0 queue runaway that duplicated ventures

### DIFF
--- a/database/migrations/20260606_stage_zero_processing_attempts.sql
+++ b/database/migrations/20260606_stage_zero_processing_attempts.sql
@@ -1,0 +1,24 @@
+-- Migration: stage_zero_requests.processing_attempts
+-- SD: SD-LEO-FIX-FIX-STAGE-QUEUE-001
+-- Purpose: Bound stale-claim re-processing so a request that keeps stalling/failing WITHOUT
+--          producing a venture is failed-terminal instead of being re-queued forever. Part of the
+--          fix for the Stage-0 queue runaway that generated 131 duplicate "discovery" ventures
+--          (2026-05-31..06-06): the queue processor's stale-claim sweep increments this counter
+--          each time it re-queues a venture-less request and fails it once it reaches
+--          STAGE_ZERO_MAX_ATTEMPTS (default 3).
+-- Safety:  ADD COLUMN ... NOT NULL DEFAULT 0 is metadata-only in PostgreSQL 11+ (no full table
+--          rewrite / no backfill scan); only a brief ACCESS EXCLUSIVE lock. Idempotent via
+--          IF NOT EXISTS so re-running is a no-op.
+-- Date:    2026-06-06
+-- @approved-by: codestreetlabs@gmail.com
+
+ALTER TABLE stage_zero_requests
+  ADD COLUMN IF NOT EXISTS processing_attempts INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN stage_zero_requests.processing_attempts IS
+  'Number of times this request has been (re-)claimed for processing. Incremented by the Stage-0 queue processor stale-claim sweep when a request is re-queued without having produced a venture; at STAGE_ZERO_MAX_ATTEMPTS the request is failed-terminal rather than looped. SD-LEO-FIX-FIX-STAGE-QUEUE-001.';
+
+-- ============================================================
+-- ROLLBACK (run manually if migration needs reverting)
+-- ============================================================
+-- ALTER TABLE stage_zero_requests DROP COLUMN IF EXISTS processing_attempts;

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -83,7 +83,11 @@ export async function conductChairmanReview(brief, deps = {}) {
  * @returns {Promise<Object>} Created venture record
  */
 export async function persistVentureBrief(reviewResult, deps = {}) {
-  const { supabase, logger = console } = deps;
+  // SD-LEO-FIX-FIX-STAGE-QUEUE-001: requestId is threaded from the Stage-0 queue processor so the
+  // created venture carries a durable back-reference to its originating stage_zero_requests row.
+  // This lets the processor detect "this request already made a venture" even when the request's
+  // own venture_id write was lost to a mid-run process death — preventing duplicate synthesis.
+  const { supabase, logger = console, requestId = null } = deps;
 
   if (!supabase) {
     throw new Error('supabase client is required');
@@ -129,6 +133,8 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
         company_id: companyId,
         metadata: {
           stage_zero: {
+            // SD-LEO-FIX-FIX-STAGE-QUEUE-001: durable request→venture link (idempotency anchor).
+            stage_zero_request_id: requestId,
             solution: brief.solution,
             raw_chairman_intent: brief.raw_chairman_intent,
             synthesis_archetype: brief.archetype,

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -33,6 +33,11 @@ import { randomUUID } from 'crypto';
 const POLL_INTERVAL_S = parseInt(process.env.STAGE_ZERO_POLL_INTERVAL_SECONDS || '30', 10);
 const STALE_CLAIM_MIN = parseInt(process.env.STAGE_ZERO_STALE_CLAIM_MINUTES || '30', 10);
 const EXECUTION_TIMEOUT_MS = parseInt(process.env.STAGE_ZERO_EXECUTION_TIMEOUT_MS || '300000', 10);
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: bound stale-claim re-processing so a request that keeps
+// stalling/failing without producing a venture is failed-terminal instead of looping forever.
+const MAX_ATTEMPTS = parseInt(process.env.STAGE_ZERO_MAX_ATTEMPTS || '3', 10);
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: narrow same-user window for conservative discovery_mode dedup.
+const DISCOVERY_DEDUP_MIN = parseInt(process.env.STAGE_ZERO_DISCOVERY_DEDUP_MINUTES || '10', 10);
 const ONCE_MODE = process.argv.includes('--once');
 const SESSION_ID = `sz-processor-${randomUUID().slice(0, 8)}`;
 
@@ -56,26 +61,101 @@ const log = {
   error: (...args) => console.error(`[${new Date().toISOString()}] [SZ-PROC] ERROR:`, ...args),
 };
 
+// ── Request → Venture Linkage (idempotency core) ───────────────────
+
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: Determine whether a request already produced a venture.
+// The request's own venture_id is only written in the SAME terminal update as status='completed',
+// so a process death between venture creation and that write leaves venture_id NULL. To stay
+// idempotent across that window we ALSO check the durable back-reference stamped into the venture
+// (metadata.stage_zero.stage_zero_request_id). Returns { id, source } or null. Fails OPEN (returns
+// null) on lookup error so a transient read failure never blocks legitimate processing.
+async function findVentureForRequest(supabase, request) {
+  if (request.venture_id) {
+    return { id: request.venture_id, source: 'request.venture_id' };
+  }
+
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('id')
+    .eq('metadata->stage_zero->>stage_zero_request_id', request.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    log.warn(`Venture-link lookup failed for request ${request.id}:`, error.message);
+    return null; // fail-open
+  }
+  return data ? { id: data.id, source: 'venture.metadata.stage_zero_request_id' } : null;
+}
+
 // ── Stale Claim Recovery ───────────────────────────────────────────
 
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: Venture-aware stale-claim sweep. The previous version blindly
+// reset every stale claimed/in_progress row to 'pending' with no check for an already-created
+// venture — so a request whose venture was created (but whose 'completed' write was lost to a
+// process death) got re-queued and re-synthesized into ANOTHER venture (the 131-duplicate runaway).
+// Now each stale row is classified:
+//   (a) venture already exists → move terminal 'completed' + backfill venture_id (NEVER re-pend);
+//   (b) no venture, attempts < cap → re-pend with processing_attempts incremented;
+//   (c) no venture, attempts >= cap → fail-terminal (bounded retry, no infinite loop).
 async function releaseStaleClaims(supabase) {
   const staleThreshold = new Date(Date.now() - STALE_CLAIM_MIN * 60 * 1000).toISOString();
 
-  const { data, error } = await supabase
+  const { data: staleRows, error } = await supabase
     .from('stage_zero_requests')
-    .update({ status: 'pending', claimed_by_session: null, claimed_at: null })
+    .select('id, venture_id, processing_attempts, metadata')
     .in('status', ['claimed', 'in_progress'])
-    .lt('claimed_at', staleThreshold)
-    .select('id');
+    .lt('claimed_at', staleThreshold);
 
   if (error) {
-    log.warn('Failed to release stale claims:', error.message);
+    log.warn('Failed to fetch stale claims:', error.message);
     return 0;
   }
-  if (data?.length > 0) {
-    log.info(`Released ${data.length} stale claim(s) older than ${STALE_CLAIM_MIN}min`);
+  if (!staleRows || staleRows.length === 0) return 0;
+
+  let repended = 0, completed = 0, failed = 0;
+
+  for (const row of staleRows) {
+    // (a) Already produced a venture — record it, never re-synthesize.
+    const venture = await findVentureForRequest(supabase, row);
+    if (venture) {
+      await updateStatus(supabase, row.id, {
+        status: 'completed',
+        venture_id: venture.id,
+        claimed_by_session: null,
+        completed_at: new Date().toISOString(),
+      });
+      completed++;
+      continue;
+    }
+
+    // (b)/(c) No venture — bounded retry.
+    const attempts = (row.processing_attempts || 0) + 1;
+    if (attempts >= MAX_ATTEMPTS) {
+      await updateStatus(supabase, row.id, {
+        status: 'failed',
+        processing_attempts: attempts,
+        claimed_by_session: null,
+        error_message: `Exceeded STAGE_ZERO_MAX_ATTEMPTS (${MAX_ATTEMPTS}) without producing a venture`,
+        error_details: { error_type: 'attempt_cap_exceeded', attempts },
+        completed_at: new Date().toISOString(),
+      });
+      failed++;
+    } else {
+      await updateStatus(supabase, row.id, {
+        status: 'pending',
+        processing_attempts: attempts,
+        claimed_by_session: null,
+        claimed_at: null,
+      });
+      repended++;
+    }
   }
-  return data?.length || 0;
+
+  if (repended || completed || failed) {
+    log.info(`Stale-claim sweep (>${STALE_CLAIM_MIN}min): ${repended} re-pended, ${completed} completed (venture existed), ${failed} failed-terminal (>=${MAX_ATTEMPTS} attempts)`);
+  }
+  return repended;
 }
 
 // ── Poll for Next Pending Request ──────────────────────────────────
@@ -149,7 +229,9 @@ function mapRequestToParams(request) {
         path: 'discovery_mode',
         pathParams: {
           strategy: request.metadata?.strategy || 'trend_scanner',
-          candidateCount: request.metadata?.candidate_count || 5,
+          // SD-LEO-FIX-FIX-STAGE-QUEUE-001: the Explore UI writes metadata.candidateCount
+          // (camelCase); read both casings so the value is not silently dropped to the default.
+          candidateCount: request.metadata?.candidate_count ?? request.metadata?.candidateCount ?? 5,
           constraints: request.metadata?.constraints || {},
         },
         options: { nonInteractive: true },
@@ -186,32 +268,92 @@ function withTimeout(promise, ms) {
 
 // ── Deduplication ─────────────────────────────────────────────────
 
-async function checkForDuplicate(supabase, request) {
-  const path = request.metadata?.path || 'blueprint_browse';
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: normalized dedup key for discovery_mode requests.
+// Reads candidate count from both casings (see mapRequestToParams) so the key is stable.
+function discoveryDedupKey(metadata = {}) {
+  const strategy = metadata.strategy || 'trend_scanner';
+  const candidateCount = metadata.candidate_count ?? metadata.candidateCount ?? 5;
+  const constraints = JSON.stringify(metadata.constraints || {});
+  return `${strategy}::${candidateCount}::${constraints}`;
+}
 
-  // Only dedup blueprint_browse with an explicit blueprint_id
-  if (path !== 'blueprint_browse' || !request.blueprint_id) return null;
-
-  const since = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1 hour lookback
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001: conservative discovery_mode dedup. Discovery is intentionally
+// stochastic, so we never collapse independent requests; we only suppress an accidental
+// re-submission — an identical request (same requester + same strategy/constraints/candidateCount)
+// that already completed within DISCOVERY_DEDUP_MIN. Same-requester scoped; never copies one user's
+// result onto another's request.
+async function findRecentDiscoveryDuplicate(supabase, request) {
+  if (!request.requested_by) return null; // cannot scope safely without a requester
+  const since = new Date(Date.now() - DISCOVERY_DEDUP_MIN * 60 * 1000).toISOString();
+  const key = discoveryDedupKey(request.metadata);
 
   const { data, error } = await supabase
     .from('stage_zero_requests')
-    .select('id, result')
+    .select('id, result, metadata')
     .eq('status', 'completed')
-    .eq('blueprint_id', request.blueprint_id)
+    .eq('requested_by', request.requested_by)
     .gt('completed_at', since)
     .neq('id', request.id)
-    .limit(1)
-    .maybeSingle();
+    .order('completed_at', { ascending: false })
+    .limit(10);
 
-  if (error || !data?.result) return null;
-  return data;
+  if (error || !data) return null;
+  const match = data.find(r =>
+    (r.metadata?.path || 'blueprint_browse') === 'discovery_mode' &&
+    discoveryDedupKey(r.metadata) === key &&
+    r.result
+  );
+  return match || null;
+}
+
+async function checkForDuplicate(supabase, request) {
+  const path = request.metadata?.path || 'blueprint_browse';
+
+  // blueprint_browse: dedup against a recent completed run for the same blueprint (unchanged).
+  if (path === 'blueprint_browse' && request.blueprint_id) {
+    const since = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1 hour lookback
+
+    const { data, error } = await supabase
+      .from('stage_zero_requests')
+      .select('id, result')
+      .eq('status', 'completed')
+      .eq('blueprint_id', request.blueprint_id)
+      .gt('completed_at', since)
+      .neq('id', request.id)
+      .limit(1)
+      .maybeSingle();
+
+    if (error || !data?.result) return null;
+    return data;
+  }
+
+  // discovery_mode: conservative same-user accidental-resubmit suppression.
+  if (path === 'discovery_mode') {
+    return await findRecentDiscoveryDuplicate(supabase, request);
+  }
+
+  return null;
 }
 
 // ── Process a Single Request ───────────────────────────────────────
 
 async function processRequest(supabase, request) {
   log.info(`Processing request ${request.id} | path=${request.metadata?.path || 'blueprint_browse'} | priority=${request.priority}`);
+
+  // SD-LEO-FIX-FIX-STAGE-QUEUE-001: idempotency guard. If this exact request already produced a
+  // venture (its own venture_id, OR a venture stamped with this request id), do NOT re-synthesize —
+  // record the terminal status and backfill the link. This closes the re-claim-after-death loop
+  // that generated 131 duplicate ventures.
+  const existingVenture = await findVentureForRequest(supabase, request);
+  if (existingVenture) {
+    log.info(`Idempotent skip: request ${request.id} already linked to venture ${existingVenture.id} (${existingVenture.source}); completing without re-synthesis`);
+    await updateStatus(supabase, request.id, {
+      status: 'completed',
+      venture_id: existingVenture.id,
+      completed_at: new Date().toISOString(),
+    });
+    return true;
+  }
 
   // Check for duplicate completed request before doing expensive work
   const duplicate = await checkForDuplicate(supabase, request);
@@ -236,7 +378,9 @@ async function processRequest(supabase, request) {
     const deadline = Date.now() + EXECUTION_TIMEOUT_MS;
 
     const result = await withTimeout(
-      executeStageZero({ ...params, options: { ...params.options, deadline } }, { supabase, logger: log }),
+      // SD-LEO-FIX-FIX-STAGE-QUEUE-001: thread requestId so persistVentureBrief stamps the
+      // durable request→venture back-reference (metadata.stage_zero.stage_zero_request_id).
+      executeStageZero({ ...params, options: { ...params.options, deadline } }, { supabase, logger: log, requestId: request.id }),
       EXECUTION_TIMEOUT_MS
     );
 
@@ -366,4 +510,4 @@ if (isMainModule(import.meta.url)) {
   });
 }
 
-export { pollOnce, processRequest, mapRequestToParams, releaseStaleClaims };
+export { pollOnce, processRequest, mapRequestToParams, releaseStaleClaims, findVentureForRequest, checkForDuplicate };

--- a/tests/unit/scripts/stage-zero-queue-processor.test.js
+++ b/tests/unit/scripts/stage-zero-queue-processor.test.js
@@ -23,7 +23,13 @@ vi.mock('../../../lib/eva/stage-zero/stage-zero-orchestrator.js', () => ({
 }));
 
 import { executeStageZero } from '../../../lib/eva/stage-zero/stage-zero-orchestrator.js';
-import { processRequest } from '../../../scripts/stage-zero-queue-processor.js';
+import {
+  processRequest,
+  releaseStaleClaims,
+  checkForDuplicate,
+  findVentureForRequest,
+  mapRequestToParams,
+} from '../../../scripts/stage-zero-queue-processor.js';
 
 let updateCalls;
 let supabase;
@@ -138,5 +144,162 @@ describe('processRequest — success path (FR-4e)', () => {
 
     const successUpdate = updateCalls.find(u => u.status === 'completed');
     expect(successUpdate.prompt_version).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// SD-LEO-FIX-FIX-STAGE-QUEUE-001 — duplicate-venture runaway fix
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Programmable supabase stub. Distinguishes the queries the fix issues:
+ *  - ventures + .maybeSingle()  → findVentureForRequest back-reference lookup
+ *  - stage_zero_requests + .in() (then awaited) → releaseStaleClaims stale fetch
+ *  - stage_zero_requests + .limit() (then awaited) → discovery dedup list
+ *  - .update(...).eq(...)       → status writes (captured in updateCalls)
+ */
+function makeSupabaseV2({ ventures = [], staleRows = [], completed = [] } = {}) {
+  const updateCalls = [];
+  function makeBuilder(table) {
+    const ctx = { table, eqs: {}, usedIn: false, isUpdate: false };
+    const resolveList = () => {
+      if (ctx.isUpdate) return { data: null, error: null };
+      if (table === 'stage_zero_requests') {
+        return ctx.usedIn ? { data: staleRows, error: null } : { data: completed, error: null };
+      }
+      return { data: [], error: null };
+    };
+    const b = {
+      select: () => b,
+      eq: (col, val) => { ctx.eqs[col] = val; return b; },
+      neq: () => b,
+      gt: () => b,
+      lt: () => b,
+      in: () => { ctx.usedIn = true; return b; },
+      order: () => b,
+      limit: () => b,
+      update: (payload) => { ctx.isUpdate = true; updateCalls.push({ table, payload, eqs: ctx.eqs }); return b; },
+      maybeSingle: async () => {
+        if (table === 'ventures') {
+          const reqId = ctx.eqs['metadata->stage_zero->>stage_zero_request_id'];
+          const v = ventures.find((x) => x.requestId === reqId);
+          return { data: v ? { id: v.id } : null, error: null };
+        }
+        return { data: null, error: null };
+      },
+      then: (onF, onR) => Promise.resolve(resolveList()).then(onF, onR),
+    };
+    return b;
+  }
+  return { from: vi.fn((t) => makeBuilder(t)), updateCalls };
+}
+
+describe('FR-6 — mapRequestToParams candidateCount casing (TS-5)', () => {
+  test('honors camelCase metadata.candidateCount', () => {
+    const params = mapRequestToParams({ metadata: { path: 'discovery_mode', candidateCount: 8 } });
+    expect(params.pathParams.candidateCount).toBe(8);
+  });
+  test('still honors snake_case metadata.candidate_count', () => {
+    const params = mapRequestToParams({ metadata: { path: 'discovery_mode', candidate_count: 7 } });
+    expect(params.pathParams.candidateCount).toBe(7);
+  });
+  test('falls back to default 5 when neither casing present', () => {
+    const params = mapRequestToParams({ metadata: { path: 'discovery_mode' } });
+    expect(params.pathParams.candidateCount).toBe(5);
+  });
+});
+
+describe('FR-1/FR-2 — request→venture idempotency guard', () => {
+  test('findVentureForRequest resolves via the durable metadata back-reference when venture_id is NULL', async () => {
+    const supabase = makeSupabaseV2({ ventures: [{ id: 'v-1', requestId: 'req-stale' }] });
+    const venture = await findVentureForRequest(supabase, { id: 'req-stale', venture_id: null });
+    expect(venture).toEqual({ id: 'v-1', source: 'venture.metadata.stage_zero_request_id' });
+  });
+
+  test('processRequest does NOT re-synthesize when the request already produced a venture (TS-1 core)', async () => {
+    const supabase = makeSupabaseV2({ ventures: [{ id: 'v-9', requestId: 'req-x' }] });
+    const request = { id: 'req-x', venture_id: null, requested_by: 'u1', metadata: { path: 'discovery_mode', strategy: 'trend_scanner' } };
+
+    await processRequest(supabase, request);
+
+    expect(executeStageZero).not.toHaveBeenCalled();
+    const completedUpdate = supabase.updateCalls.find((u) => u.payload.status === 'completed');
+    expect(completedUpdate).toBeDefined();
+    expect(completedUpdate.payload.venture_id).toBe('v-9');
+  });
+});
+
+describe('FR-3/FR-4 — venture-aware releaseStaleClaims', () => {
+  test('TS-1: a stale row whose venture already exists is COMPLETED (never re-pended)', async () => {
+    const supabase = makeSupabaseV2({
+      ventures: [{ id: 'v-1', requestId: 'req-stale' }],
+      staleRows: [{ id: 'req-stale', venture_id: null, processing_attempts: 0, metadata: { path: 'discovery_mode' } }],
+    });
+
+    const repended = await releaseStaleClaims(supabase);
+
+    expect(repended).toBe(0); // nothing re-pended
+    const upd = supabase.updateCalls.find((u) => u.eqs.id === 'req-stale');
+    expect(upd.payload.status).toBe('completed');
+    expect(upd.payload.venture_id).toBe('v-1');
+    // CRITICAL: the duplicate-generation bug was re-pending a venture-bearing row.
+    expect(supabase.updateCalls.some((u) => u.payload.status === 'pending')).toBe(false);
+  });
+
+  test('FR-4: a venture-less stale row under the cap is re-pended with processing_attempts incremented', async () => {
+    const supabase = makeSupabaseV2({
+      ventures: [],
+      staleRows: [{ id: 'req-retry', venture_id: null, processing_attempts: 0, metadata: {} }],
+    });
+
+    const repended = await releaseStaleClaims(supabase);
+
+    expect(repended).toBe(1);
+    const upd = supabase.updateCalls.find((u) => u.eqs.id === 'req-retry');
+    expect(upd.payload.status).toBe('pending');
+    expect(upd.payload.processing_attempts).toBe(1);
+  });
+
+  test('TS-2: a venture-less stale row AT the attempt cap is failed-terminal (no infinite loop)', async () => {
+    // Default STAGE_ZERO_MAX_ATTEMPTS = 3; processing_attempts 2 -> 3 -> failed.
+    const supabase = makeSupabaseV2({
+      ventures: [],
+      staleRows: [{ id: 'req-fail', venture_id: null, processing_attempts: 2, metadata: {} }],
+    });
+
+    const repended = await releaseStaleClaims(supabase);
+
+    expect(repended).toBe(0);
+    const upd = supabase.updateCalls.find((u) => u.eqs.id === 'req-fail');
+    expect(upd.payload.status).toBe('failed');
+    expect(upd.payload.processing_attempts).toBe(3);
+    expect(upd.payload.error_details.error_type).toBe('attempt_cap_exceeded');
+  });
+});
+
+describe('FR-5 — conservative discovery_mode dedup (TS-3)', () => {
+  const reqBase = { id: 'req-new', requested_by: 'u1', metadata: { path: 'discovery_mode', strategy: 'trend_scanner', candidateCount: 5, constraints: {} } };
+
+  test('identical recent same-user request is a dedup hit', async () => {
+    const supabase = makeSupabaseV2({
+      completed: [{ id: 'req-old', result: { ok: true }, metadata: { path: 'discovery_mode', strategy: 'trend_scanner', candidateCount: 5, constraints: {} } }],
+    });
+    const dup = await checkForDuplicate(supabase, reqBase);
+    expect(dup).not.toBeNull();
+    expect(dup.id).toBe('req-old');
+  });
+
+  test('different params (distinct discovery) is NOT collapsed', async () => {
+    const supabase = makeSupabaseV2({
+      completed: [{ id: 'req-other', result: { ok: true }, metadata: { path: 'discovery_mode', strategy: 'competitor_gap', candidateCount: 5, constraints: {} } }],
+    });
+    const dup = await checkForDuplicate(supabase, reqBase);
+    expect(dup).toBeNull();
+  });
+
+  test('no recent completed request (outside window → DB returns none) → no dedup', async () => {
+    const supabase = makeSupabaseV2({ completed: [] });
+    const dup = await checkForDuplicate(supabase, reqBase);
+    expect(dup).toBeNull();
   });
 });


### PR DESCRIPTION
## SD-LEO-FIX-FIX-STAGE-QUEUE-001 — Fix Stage-0 queue processor runaway (duplicate ventures)

**Problem.** The Stage-0 queue processor wrote a request's `venture_id` only in the same terminal update as `status='completed'`. A process death in the window between venture creation (`executeStageZero`) and that write left the request `in_progress` with `venture_id` NULL. `releaseStaleClaims()` then re-pended it with **no venture check**, the poller re-claimed it, and `executeStageZero()` synthesized **another** venture — producing **131 duplicate "discovery" ventures** (2026-05-31..06-06). Compounded by `checkForDuplicate()` covering only `blueprint_browse` (no `discovery_mode` dedup) and no retry cap.

**Root-cause fix** (`scripts/stage-zero-queue-processor.js` + `lib/eva/stage-zero/chairman-review.js`):
- Stamp a **durable `stage_zero_request_id` back-reference** into the created venture's `metadata.stage_zero` (threaded via `persistVentureBrief`) so "did this request already make a venture?" is answerable even when `venture_id` is NULL.
- `findVentureForRequest()` + a **pre-synthesis idempotency guard** in `processRequest` (complete + backfill instead of re-synthesizing).
- **Venture-aware `releaseStaleClaims()`**: a stale row with a venture → terminal `completed` (never re-pended); a venture-less row → re-pend with `processing_attempts` incremented, then **fail-terminal** at `STAGE_ZERO_MAX_ATTEMPTS` (default 3).
- **Conservative `discovery_mode` dedup** (same-user, narrow window, suppress-only) — no over-collapse of intentionally-distinct stochastic requests; `blueprint_browse` behavior byte-unchanged.
- Reconcile `candidateCount` (camelCase UI) vs `candidate_count` read mismatch.

**Migration.** Adds `stage_zero_requests.processing_attempts INTEGER NOT NULL DEFAULT 0` (metadata-only, idempotent) — applied to the shared DB via the audited `apply-migration.js --prod-deploy` path.

**Tests.** +11 regression tests (death-window re-claim → exactly 1 venture; attempt-cap fail-terminal; discovery dedup hit / no-collapse; casing). **571 stage-zero tests pass, 0 regressions.**

**Out of scope** (separate operator-coordinated ops task): reconciliation/cleanup of the 131 existing duplicate ventures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
