### PR TITLE
fix(SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001): unblock S20 repo resolution (shorthand + isSafeRepoUrl regex)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js
@@ -54,10 +54,32 @@ const INSTALL_COMMAND = 'npm install --ignore-scripts (via sandbox .npmrc)';
  * non-URL-safe character that has shell meaning.
  */
 const SAFE_REPO_URL_RE = /^https:\/\/(?:[\w.-]+@)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?\/?$/;
-function isSafeRepoUrl(url) {
+export function isSafeRepoUrl(url) {
   if (typeof url !== 'string' || url.length > 512) return false;
-  if (/[$`;|&><\\n\\r"'\s]/.test(url)) return false;
+  if (/[$`;|&><\n\r"'\s]/.test(url)) return false;
   return SAFE_REPO_URL_RE.test(url);
+}
+
+/**
+ * SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001: normalize an `owner/repo` shorthand
+ * into a full GitHub HTTPS URL so a provisioner-written shorthand
+ * resource_identifier (lib/eva/bridge/venture-provisioner.js writes the
+ * `owner/repo` shorthand, with the full URL only in resource metadata) can pass
+ * isSafeRepoUrl() instead of permanently blocking S20.
+ *
+ * SECURITY: normalization is gated on a STRICT shorthand shape (exactly one
+ * slash, characters limited to [A-Za-z0-9_.-]) which contains no shell
+ * metacharacter or whitespace. Anything else is returned untouched, and
+ * isSafeRepoUrl() still validates the result downstream — so this can never
+ * turn an unsafe string into a passing URL.
+ */
+const REPO_SHORTHAND_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+export function normalizeRepoUrl(candidate) {
+  if (typeof candidate !== 'string') return candidate;
+  if (REPO_SHORTHAND_RE.test(candidate)) {
+    return `https://github.com/${candidate}`;
+  }
+  return candidate;
 }
 
 // SD-LEO-INFRA-STAGE-CODE-QUALITY-001: expanded from 4 to 8 repo-scannable checks.
@@ -409,7 +431,23 @@ export async function analyzeStage20CodeQuality(params) {
   // returned `verdict='FAIL'` with "No GitHub repo URL found" for every venture
   // since the redesign shipped (PR #3209, 2026-04-22). Surfaced 2026-04-29
   // during the LexiGuard S19→S20 pre-approval review.
+  // SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001: resolve the repo URL by evaluating
+  // candidates in precedence order and taking the FIRST that is a valid GitHub
+  // URL after normalizing `owner/repo` shorthand. Previously the first *truthy*
+  // candidate was taken unconditionally, so a shorthand resource_identifier
+  // (written that way by venture-provisioner.js) shadowed a valid
+  // ventures.repo_url and permanently FAILed S20. normalizeRepoUrl +
+  // isSafeRepoUrl keep the anti-shell-injection guard authoritative.
   let repoUrl = null;
+  let fallbackRawUrl = null;
+  const considerCandidate = (raw) => {
+    if (typeof raw !== 'string' || !raw) return;
+    if (fallbackRawUrl === null) fallbackRawUrl = raw;
+    if (repoUrl) return;
+    const normalized = normalizeRepoUrl(raw);
+    if (isSafeRepoUrl(normalized)) repoUrl = normalized;
+  };
+
   if (supabase && ventureId) {
     // Primary: canonical row-per-resource registry
     const { data: resourceRow } = await supabase
@@ -421,23 +459,34 @@ export async function analyzeStage20CodeQuality(params) {
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
-    repoUrl = resourceRow?.resource_identifier || null;
+    considerCandidate(resourceRow?.resource_identifier);
 
-    // Secondary: legacy slot on the ventures table (older provisioning paths
-    // populated this directly; kept as a fallback for backward-compat).
+    // Secondary: legacy slot on the ventures table. Queried whenever the primary
+    // did not yield a VALID URL (not merely a falsy one), so a malformed resource
+    // row no longer shadows a valid ventures.repo_url.
     if (!repoUrl) {
       const { data: ventureRow } = await supabase
         .from('ventures')
         .select('repo_url')
         .eq('id', ventureId)
         .maybeSingle();
-      repoUrl = ventureRow?.repo_url || null;
+      considerCandidate(ventureRow?.repo_url);
     }
   }
 
   // Tertiary fallback: stage19Data may carry it on some venture-pipeline paths.
   if (!repoUrl && stage19Data) {
-    repoUrl = stage19Data.github_repo || stage19Data.repo_url || stage19Data.__byType?.build_mvp_build?.github_repo;
+    considerCandidate(stage19Data.github_repo);
+    considerCandidate(stage19Data.repo_url);
+    considerCandidate(stage19Data.__byType?.build_mvp_build?.github_repo);
+  }
+
+  // If no candidate produced a valid GitHub URL, fall back to the first raw
+  // candidate so cloneRepo() surfaces the existing "refused to clone" FAIL for
+  // genuinely malformed data rather than silently downgrading to the no-repo
+  // advisory (unchanged terminal behavior).
+  if (!repoUrl && fallbackRawUrl) {
+    repoUrl = fallbackRawUrl;
   }
 
   if (!repoUrl) {

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-20-code-quality.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-20-code-quality.test.js
@@ -27,6 +27,8 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   analyzeStage20CodeQuality,
   persistAnalyzerFindings,
+  normalizeRepoUrl,
+  isSafeRepoUrl,
   CHECK_TYPES,
   SEVERITY_LEVELS,
   VERDICT_OPTIONS,
@@ -134,33 +136,35 @@ describe('stage-20-code-quality.js — analyzer resolution path (no-clone)', () 
     expect(tablesQueried.indexOf('venture_resources')).toBeLessThan(tablesQueried.indexOf('ventures'));
   });
 
-  it('(c) does NOT query ventures table when venture_resources returns a row (short-circuits at primary)', async () => {
-    // Seed venture_resources with a non-clone-friendly URL so the analyzer
-    // gets past resolution but cloneRepo refuses (isSafeRepoUrl rejects
-    // strings without the github.com host); we then verify the resolver
-    // stopped at the primary path. The clone failure produces a deterministic
-    // FAIL with 'Failed to clone repo' — which proves we NEVER fell through
-    // to the ventures or stage19Data fallback.
+  it('(c) continues to the ventures fallback when venture_resources holds an INVALID resource_identifier (SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001)', async () => {
+    // SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001 changed resolution from "first
+    // truthy candidate" to "first VALID candidate". An invalid primary (a
+    // non-github-host string) no longer short-circuits — the resolver now
+    // queries the ventures fallback so a malformed venture_resources row cannot
+    // shadow a valid ventures.repo_url. (This test previously asserted the OLD
+    // short-circuit behavior, which was the bug.) All candidates here are
+    // invalid, so cloneRepo refuses before any network call — pure unit test.
     const supabase = makeSupabaseMock({
       venture_resources: { resource_identifier: 'not-a-github-url' },
-      ventures: { repo_url: 'https://github.com/should-not-reach/this' },
+      ventures: { repo_url: 'also-not-a-github-url' },
     });
     const result = await analyzeStage20CodeQuality({
-      stage19Data: { github_repo: 'https://github.com/should-not-reach/either' },
+      stage19Data: { github_repo: 'still-not-a-github-url' },
       ventureName: 'V3',
       ventureId: '00000000-0000-0000-0000-000000000004',
       supabase,
       logger: silentLogger,
     });
-    // The analyzer used the primary URL — we know because cloneRepo refused
-    // it (isSafeRepoUrl) and produced a FAIL with the original bad URL.
+    // No valid candidate anywhere -> terminal fallback to the first raw
+    // candidate -> cloneRepo refuses it -> deterministic FAIL (no network).
     expect(result.verdict).toBe('FAIL');
     expect(result.findings[0].title).toContain('not-a-github-url');
-    // ventures must NOT have been queried.
+    // The ventures fallback WAS consulted — proves the resolver no longer
+    // short-circuits on an invalid primary (the core of the resolution fix).
     const tablesQueried = supabase.__calls
       .filter(c => c.op === 'from')
       .map(c => c.table);
-    expect(tablesQueried).not.toContain('ventures');
+    expect(tablesQueried).toContain('ventures');
   });
 
   it('(c) uses stage19Data.github_repo as tertiary fallback when supabase yields no row', async () => {
@@ -251,5 +255,90 @@ describe('stage-20-code-quality.js — constant exports', () => {
     // missing-precondition state distinct from the 3 normal verdicts
     // (PASS/FAIL/WARN). buildNoRepoReport returns it directly.
     expect(VERDICT_OPTIONS).toEqual(['PASS', 'FAIL', 'WARN']);
+  });
+});
+
+// SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001 — repo URL resolution fix.
+// Background: venture-provisioner.js writes venture_resources.resource_identifier
+// as an `owner/repo` shorthand (full URL only in resource metadata). The old
+// resolver returned the first *truthy* candidate as-is, so the shorthand failed
+// isSafeRepoUrl and S20 hard-FAILed even when a valid ventures.repo_url existed.
+describe('normalizeRepoUrl — owner/repo shorthand normalization (FR-1)', () => {
+  it('normalizes a bare owner/repo shorthand to a full GitHub HTTPS URL', () => {
+    expect(normalizeRepoUrl('rickfelix/datadistill')).toBe('https://github.com/rickfelix/datadistill');
+  });
+
+  it('normalizes owner/repo.git shorthand (dot is allowed in the repo segment)', () => {
+    expect(normalizeRepoUrl('rickfelix/datadistill.git')).toBe('https://github.com/rickfelix/datadistill.git');
+  });
+
+  it('leaves an already-full HTTPS URL unchanged', () => {
+    expect(normalizeRepoUrl('https://github.com/rickfelix/datadistill.git'))
+      .toBe('https://github.com/rickfelix/datadistill.git');
+  });
+
+  it('does NOT normalize a string with shell metacharacters (no single owner/repo shape)', () => {
+    const evil = 'rickfelix/data; rm -rf /';
+    expect(normalizeRepoUrl(evil)).toBe(evil);
+  });
+
+  it('does NOT normalize a single token with no slash', () => {
+    expect(normalizeRepoUrl('justonetoken')).toBe('justonetoken');
+  });
+
+  it('does NOT normalize a 3-segment path (only a single owner/repo qualifies)', () => {
+    expect(normalizeRepoUrl('owner/repo/extra')).toBe('owner/repo/extra');
+  });
+
+  it('returns non-string input unchanged', () => {
+    expect(normalizeRepoUrl(null)).toBeNull();
+    expect(normalizeRepoUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('normalizeRepoUrl + isSafeRepoUrl composition — injection guard preserved (FR-3)', () => {
+  it('a shorthand becomes a URL that passes the strict GitHub-HTTPS guard', () => {
+    expect(isSafeRepoUrl(normalizeRepoUrl('rickfelix/datadistill'))).toBe(true);
+  });
+
+  it('shell-metacharacter candidates never pass the guard after normalization', () => {
+    expect(isSafeRepoUrl(normalizeRepoUrl('rickfelix/data; rm -rf /'))).toBe(false);
+    expect(isSafeRepoUrl(normalizeRepoUrl('rickfelix/data`whoami`'))).toBe(false);
+  });
+
+  it('a non-github host is not coerced into validity', () => {
+    expect(isSafeRepoUrl(normalizeRepoUrl('https://evil.example.com/a/b'))).toBe(false);
+  });
+
+  it('an already-valid full GitHub URL still passes', () => {
+    expect(isSafeRepoUrl(normalizeRepoUrl('https://github.com/rickfelix/datadistill'))).toBe(true);
+  });
+});
+
+describe('analyzer resolution — skip invalid candidate and continue (FR-2)', () => {
+  it('queries ventures.repo_url even when venture_resources holds an INVALID resource_identifier', async () => {
+    // OLD behavior: a truthy-but-invalid resource_identifier short-circuited
+    // resolution (ventures was never queried) and S20 hard-FAILed. NEW behavior:
+    // an invalid primary does not satisfy isSafeRepoUrl, so the ventures fallback
+    // IS queried. Both candidates here are invalid, so no real git clone runs
+    // (isSafeRepoUrl rejects before execAsync) — keeping this a pure unit test.
+    const supabase = makeSupabaseMock({
+      venture_resources: { resource_identifier: 'not a valid url at all' },
+      ventures: { repo_url: 'also-not-valid' },
+    });
+    const result = await analyzeStage20CodeQuality({
+      stage19Data: null,
+      ventureName: 'ShadowVenture',
+      ventureId: '00000000-0000-0000-0000-000000000002',
+      supabase,
+      logger: silentLogger,
+    });
+    // The ventures table WAS consulted — proves resolution continued past the
+    // invalid primary instead of shadowing a potential valid fallback.
+    expect(supabase.__calls.some((c) => c.table === 'ventures')).toBe(true);
+    // Terminal behavior preserved: invalid-only candidates -> clone refused -> FAIL
+    // (not silently downgraded to the no-repo advisory).
+    expect(result.verdict).toBe('FAIL');
+    expect(result.repo_url).toBe('not a valid url at all');
   });
 });


### PR DESCRIPTION
## SD-FDBK-FIX-STAGE-REPOURL-RESOLUTION-001 — Stage-20 repo URL resolution fix

Fixes the Stage-20 Code Quality Gate permanently FAILing valid ventures (live: DataDistill `510177ba`) by refusing to clone their repo. Two root causes in `lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js`:

### 1. Resolution took the first *truthy* candidate (shorthand shadowing)
`venture-provisioner.js:134` writes `venture_resources.resource_identifier` as `owner/repo` **shorthand** (full URL only in resource metadata). The resolver returned that shorthand as-is — it failed `isSafeRepoUrl` and **shadowed** the valid `ventures.repo_url` fallback (the fallback only ran when the primary was falsy).
- **`normalizeRepoUrl()`** converts a strict `owner/repo` shorthand → `https://github.com/owner/repo`.
- Resolution now selects the **first VALID** candidate (normalize → `isSafeRepoUrl`), skip-invalid-and-continue, preserving precedence + DB-query frugality. Terminal fallback to the first raw candidate preserves the existing clone-refused FAIL.

### 2. `isSafeRepoUrl` regex bug (the dominant cause — found via TDD)
The FR-D metachar guard used `\n\r` written as `\n\r` (matching the **literal** characters backslash/`n`/`r`) instead of `\n`/`\r` (newline/CR). It rejected **any** URL containing the letters n or r — e.g. `rickfelix/...`. Fixed to match the documented intent. `SAFE_REPO_URL_RE` still constrains to `github.com/<owner>/<repo>` and `\s` still rejects newline/CR, so the anti-shell-injection guarantee is preserved.

### Validation
- **+11 unit tests** (normalizeRepoUrl, `isSafeRepoUrl∘normalizeRepoUrl` composition, skip-invalid resolution); existing test `(c)` updated for the new first-valid behavior.
- **88/88** stage-20 + code-quality tests green, **0 regressions** (9 files).
- **TESTING** sub-agent: PASS (coverage 92, conf 90). **SECURITY** sub-agent: PASS (conf 96) — 41 adversarial cases, all injection/newline/CR/wrong-host/traversal inputs rejected; valid URLs (incl. n/r owners) accepted.

### Scope
Read-side only. `venture-provisioner.js` (peer SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001) untouched. No schema/migration. Write-side normalization + malformed-row de-dup left as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
