### PR TITLE
fix(SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001): flag s17-parity test ventures is_demo=true + leak-safe drift teardown

### DIFF
--- a/tests/integration/s17-parity.test.js
+++ b/tests/integration/s17-parity.test.js
@@ -40,6 +40,7 @@ const FIXTURE = {
 let supabase;
 let cliVentureId;
 let frontendVentureId;
+let driftVentureId; // SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001: hoisted so afterAll can clean it even if the drift assertion fails before the inline delete
 
 beforeAll(async () => {
   supabase = getSupabaseClient();
@@ -73,6 +74,7 @@ beforeAll(async () => {
       discovery_strategy: FIXTURE.discovery_strategy,
       current_lifecycle_stage: 17,
       status: 'active',
+      is_demo: true, // SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001: flag fixture so it never surfaces in the Ventures route
       metadata: {
         stage_zero: {
           solution: FIXTURE.solution,
@@ -111,6 +113,7 @@ beforeAll(async () => {
       discovery_strategy: FIXTURE.discovery_strategy,
       current_lifecycle_stage: 17,
       status: 'active',
+      is_demo: true, // SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001: flag fixture so it never surfaces in the Ventures route
       metadata: { problem_statement: FIXTURE.problem_statement },
     })
     .select('id')
@@ -123,7 +126,7 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!supabase) return;
   // Clean up test ventures and related records
-  const ids = [cliVentureId, frontendVentureId].filter(Boolean);
+  const ids = [cliVentureId, frontendVentureId, driftVentureId].filter(Boolean);
   if (ids.length === 0) return;
 
   await supabase.from('chairman_decisions').delete().in('venture_id', ids);
@@ -249,10 +252,13 @@ describe('S17 Parity: CLI vs Frontend venture state', () => {
         portfolio_synergy_score: FIXTURE.portfolio_synergy_score,
         current_lifecycle_stage: 17,
         status: 'active',
+        is_demo: true, // SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001: flag drift fixture too
         metadata: {},
       })
       .select('id')
       .single();
+
+    driftVentureId = driftVenture.id; // capture for afterAll safety-net cleanup
 
     const { data: cliData } = await supabase
       .from('ventures')


### PR DESCRIPTION
## SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 — stop parity test ventures polluting the Ventures route

### Problem
`tests/integration/s17-parity.test.js` direct-inserts `parity-test-cli/-frontend/-drift` ventures **without setting `is_demo`** (defaults false/null). When the process is killed before `afterAll` — or the drift assertion fails before its inline delete — these persist as fake "Active" ventures in the EHG app's Ventures route (the `is_demo` filter can't hide `false`/`null`). The leaked rows had `repo_url NULL`, confirming the source is the test's direct inserts, **not** `provisionVenture` as the SD title implied.

### Fix (EHG_Engineer, ~8 LOC, test-only)
- Set `is_demo: true` on all three fixture inserts → the existing `useVentures` `is_demo` filter hides them even if teardown never runs ("flag their test ventures").
- Hoist `driftVentureId` so `afterAll` cleans the drift venture even when its assertion fails (inline delete kept, idempotent).
- `is_demo` is not a compared `TYPED_COLUMN`, so the parity comparison is unchanged.

### Verification
- Suite with the change: **3/4 pass** (typed-columns, artifacts, drift-detection).
- Stashed the edits, ran the **unmodified baseline**: identical **1-fail/3-pass** — the failing `chairman_decisions` test (`feDec` null, L196) is **pre-existing and out of scope** ("redesigning the parity test's comparison logic"), tracked as harness_backlog `a4dd49bc`.

### Follow-ups (out of scope)
- EHG app `listVentures()` filters neither `is_demo` nor `deleted_at` — small QF to add those (defense-in-depth).
- Fix the pre-existing `chairman_decisions` parity assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
