### PR TITLE
fix(SD-LEO-FIX-FIX-ADVANCE-VENTURE-001): advance_venture_stage non-gate advancement

### DIFF
--- a/database/migrations/20260606_fix_advance_venture_stage_nongate.sql
+++ b/database/migrations/20260606_fix_advance_venture_stage_nongate.sql
@@ -1,0 +1,191 @@
+-- SD-LEO-FIX-FIX-ADVANCE-VENTURE-001 — fix advance_venture_stage for NON-GATE stages
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Function: public.advance_venture_stage(uuid, integer, integer, text)  (oid 633099)
+--
+-- BUG: For a NON-GATE from_stage (i.e. p_from_stage NOT in {3,5,13,17,18,23,24}),
+--   the gate-enforcement block is skipped, so the RECORD variable `v_gate_decision`
+--   is never assigned. The venture_stage_transitions INSERT then reads
+--   `v_gate_decision.id` UNCONDITIONALLY for the handoff_data JSONB, raising
+--   `record "v_gate_decision" is not assigned yet`. The EXCEPTION WHEN OTHERS
+--   handler swallows it and returns {success:false, error:'record "v_gate_decision"
+--   is not assigned yet'} — so non-gate advances silently fail.
+--
+-- FIX (Option A — minimal, 3 deltas; ZERO other change vs the LIVE def):
+--   1. DECLARE: add `v_gate_decision_id UUID := NULL;`
+--   2. Gate block: AFTER the existing `SELECT ... INTO v_gate_decision` and its
+--      `IF NOT FOUND` guard (kept verbatim), add `v_gate_decision_id := v_gate_decision.id;`
+--   3. INSERT handoff_data: replace `v_gate_decision.id` with `v_gate_decision_id`.
+--   Result: gate_decision_id = NULL for non-gate stages (correct), real UUID for
+--   gate stages (unchanged behaviour).
+--
+-- BASIS: This CREATE OR REPLACE was built from the LIVE definition retrieved via
+--   pg_get_functiondef(633099::regprocedure) on 2026-06-06 — NOT from the stale
+--   on-disk migration 20260322_update_advance_stage_gates_26.sql. It preserves the
+--   live behaviour the on-disk file lacks: uuid_generate_v5 idempotency_key, the
+--   two stage_events emits (STAGE_COMPLETE / STAGE_ENTRY), approved_by='system:advance',
+--   handoff_data, and `ON CONFLICT DO NOTHING`.
+--
+-- Idempotent: CREATE OR REPLACE. No DOWN block required (a re-run of the prior live
+--   def would revert; the prior def is preserved verbatim above except the 3 deltas).
+
+CREATE OR REPLACE FUNCTION public.advance_venture_stage(p_venture_id uuid, p_from_stage integer, p_to_stage integer, p_transition_type text DEFAULT 'normal'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  -- 26-stage gate arrays (SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001)
+  v_kill_gates INTEGER[] := ARRAY[3, 5, 13, 24];
+  v_promotion_gates INTEGER[] := ARRAY[17, 18, 23];
+  v_all_gates INTEGER[] := ARRAY[3, 5, 13, 17, 18, 23, 24];
+  v_gate_decision RECORD;
+  v_gate_decision_id UUID := NULL;  -- DELTA 1: NULL for non-gate stages; real id assigned in gate block
+  v_idempotency UUID;
+BEGIN
+  -- Validate venture exists and lock row
+  SELECT current_lifecycle_stage, name
+    INTO v_current_stage, v_venture_name
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'venture_not_found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- Validate from_stage matches current
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'stage_mismatch',
+      'current_stage', v_current_stage,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  -- Validate to_stage range (26-stage lifecycle)
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_to_stage',
+      'to_stage', p_to_stage
+    );
+  END IF;
+
+  -- Gate enforcement: if from_stage is a gate, require approved decision
+  IF p_from_stage = ANY(v_all_gates) THEN
+    SELECT id, decision, status INTO v_gate_decision
+      FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+        AND decision IN ('pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release')
+      ORDER BY created_at DESC
+      LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_not_approved',
+        'gate_stage', p_from_stage,
+        'gate_type', CASE
+          WHEN p_from_stage = ANY(v_kill_gates) THEN 'kill'
+          WHEN p_from_stage = ANY(v_promotion_gates) THEN 'promotion'
+          ELSE 'unknown'
+        END,
+        'message', format('Chairman approval required at stage %s before advancing', p_from_stage)
+      );
+    END IF;
+
+    v_gate_decision_id := v_gate_decision.id;  -- DELTA 2: capture real id only on the gate path (guarded above)
+  END IF;
+
+  -- Mark current stage as completed
+  UPDATE venture_stage_work
+    SET stage_status = 'completed',
+        completed_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_from_stage;
+
+  -- Advance ventures.current_lifecycle_stage
+  UPDATE ventures
+    SET current_lifecycle_stage = p_to_stage,
+        updated_at = NOW()
+    WHERE id = p_venture_id;
+
+  -- Mark next stage as in_progress
+  UPDATE venture_stage_work
+    SET stage_status = 'in_progress',
+        started_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_to_stage;
+
+  -- Emit STAGE_COMPLETE event for from_stage
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_from_stage, 'STAGE_COMPLETE',
+    jsonb_build_object('advanced_to', p_to_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  -- Emit STAGE_ENTRY event for to_stage
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_to_stage, 'STAGE_ENTRY',
+    jsonb_build_object('advanced_from', p_from_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  -- Record transition (correct column names: approved_by, handoff_data, idempotency_key)
+  v_idempotency := uuid_generate_v5(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    p_venture_id::text || ':' || p_from_stage::text || ':' || p_to_stage::text
+      || ':' || COALESCE(
+        (SELECT COUNT(*)::text FROM venture_stage_transitions
+         WHERE venture_id = p_venture_id
+           AND from_stage = p_from_stage
+           AND to_stage = p_to_stage),
+        '0')
+  );
+
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, p_transition_type,
+    'system:advance', jsonb_build_object(
+      'gate_decision_id', v_gate_decision_id,  -- DELTA 3: was v_gate_decision.id (unconditional read)
+      'venture_name', v_venture_name
+    ), v_idempotency
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage,
+    'transition_type', p_transition_type,
+    'gate_created', false,
+    'idempotency_key', v_idempotency
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'venture_id', p_venture_id,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage
+  );
+END;
+$function$;

--- a/tests/unit/database/migrations/advance-venture-nongate.db.test.js
+++ b/tests/unit/database/migrations/advance-venture-nongate.db.test.js
@@ -1,0 +1,193 @@
+/**
+ * Regression test for advance_venture_stage(uuid,integer,integer,text) — the
+ * NON-GATE bug fixed by 20260606_fix_advance_venture_stage_nongate.sql
+ * (SD-LEO-FIX-FIX-ADVANCE-VENTURE-001).
+ *
+ * BUG: For a non-gate from_stage (NOT in {3,5,13,17,18,23,24}) the gate-enforcement
+ * block was skipped, leaving the RECORD `v_gate_decision` unassigned. The
+ * venture_stage_transitions INSERT then read `v_gate_decision.id` UNCONDITIONALLY,
+ * raising `record "v_gate_decision" is not assigned yet`. The function's
+ * EXCEPTION WHEN OTHERS handler swallowed it and returned
+ * {success:false, error:'record "v_gate_decision" is not assigned yet'} — so
+ * every non-gate advance silently failed.
+ *
+ * FIX (Option A): a NULL-initialized scalar `v_gate_decision_id UUID := NULL` that
+ * is assigned `v_gate_decision.id` ONLY inside the gate path; the INSERT reads the
+ * scalar. Result: gate_decision_id = NULL for non-gate stages, real UUID for gate
+ * stages.
+ *
+ * Why this test is MEANINGFUL (fails against the OLD buggy shape):
+ *   - The behavioural test advances a venture FROM a non-gate stage and asserts
+ *     {success:true} with handoff_data.gate_decision_id === null. Against the old
+ *     function this returns {success:false, error:'record ... not assigned yet'} —
+ *     so the assertion fails loudly.
+ *   - The structural test inspects the LIVE pg_get_functiondef and asserts the
+ *     INSERT no longer contains the unconditional `'gate_decision_id', v_gate_decision.id`
+ *     read and that `v_gate_decision_id` is declared — a second, source-level guard
+ *     that also fails against the pre-fix definition.
+ *
+ * ZERO-LEAK contract (mirrors tests/integration/sd-park.test.js): the whole suite
+ * runs inside ONE outer real transaction that is ROLLED BACK in afterAll; each
+ * test nests in its own SAVEPOINT. No live venture / stage_event / transition is
+ * ever committed. Routed to the opt-in `db` vitest project via the `.db.test.js`
+ * suffix (vitest.config.js DB_INCLUDE), so a no-DB `npm test` run skips it cleanly.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { HAS_REAL_DB } from '../../../helpers/db-available.js';
+
+const describeDb = describe.skipIf(!HAS_REAL_DB);
+
+const NON_GATE_FROM = 1; // stage 1 is NOT in {3,5,13,17,18,23,24}
+const NON_GATE_TO = 2;
+const GATE_FROM = 3;     // stage 3 is a kill gate
+const GATE_TO = 4;
+const ALL_GATES = [3, 5, 13, 17, 18, 23, 24];
+
+const RUN_ID = `ADVNG-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+let rawClient;
+let spCounter = 0;
+let companyId;
+
+/** Seed a throwaway venture inside the outer txn, bypassing the Stage-0 origin
+ *  guard (SET LOCAL leo.stage0_bypass) and supplying an explicit company_id so the
+ *  auto_populate_company_id BEFORE-INSERT trigger does not require an auth.uid(). */
+async function seedVenture(stage, { tier = 1 } = {}) {
+  // leo.stage0_bypass is transaction-scoped (SET LOCAL); re-assert per seed is cheap
+  // and harmless. tier=1 avoids the Tier-0 stage-3 cap on the gate-path 3->4 advance.
+  await rawClient.query(`SET LOCAL leo.stage0_bypass = 'true'`);
+  const { rows } = await rawClient.query(
+    `INSERT INTO ventures (name, problem_statement, current_lifecycle_stage, company_id, tier)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    [`${RUN_ID} venture s${stage}`, `regression fixture ${RUN_ID}`, stage, companyId, tier],
+  );
+  return rows[0].id;
+}
+
+async function callAdvance(ventureId, fromStage, toStage) {
+  const { rows } = await rawClient.query(
+    `SELECT advance_venture_stage($1, $2, $3, 'normal') AS result`,
+    [ventureId, fromStage, toStage],
+  );
+  return rows[0].result;
+}
+
+async function readTransitionHandoff(ventureId) {
+  const { rows } = await rawClient.query(
+    `SELECT handoff_data FROM venture_stage_transitions WHERE venture_id = $1`,
+    [ventureId],
+  );
+  return rows.map((r) => r.handoff_data);
+}
+
+describeDb('advance_venture_stage — non-gate regression (live DB, savepoint-isolated)', () => {
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../../../lib/supabase-connection.js');
+    rawClient = await createDatabaseClient('engineer');
+    await rawClient.query('BEGIN'); // outer txn — rolled back in afterAll
+    // Pick any existing company to satisfy the company_id FK on ventures.
+    const { rows } = await rawClient.query(`SELECT id FROM companies LIMIT 1`);
+    expect(rows.length).toBe(1); // environment sanity: at least one company exists
+    companyId = rows[0].id;
+  });
+
+  afterAll(async () => {
+    if (rawClient) {
+      await rawClient.query('ROLLBACK'); // discard EVERY seeded row — zero reach prod
+      const { rows } = await rawClient.query(
+        `SELECT count(*)::int AS n FROM ventures WHERE name LIKE $1`,
+        [`${RUN_ID}%`],
+      );
+      expect(rows[0].n).toBe(0); // confirm rollback cleaned up the fixtures
+      await rawClient.end();
+    }
+  });
+
+  let testSp;
+  beforeEach(async () => {
+    testSp = `sp_advng_${++spCounter}`;
+    await rawClient.query(`SAVEPOINT ${testSp}`);
+    return async () => {
+      await rawClient.query(`ROLLBACK TO SAVEPOINT ${testSp}`);
+      await rawClient.query(`RELEASE SAVEPOINT ${testSp}`);
+    };
+  });
+
+  it('sanity: the chosen NON_GATE_FROM stage is genuinely not a gate', () => {
+    expect(ALL_GATES).not.toContain(NON_GATE_FROM);
+  });
+
+  it('advancing FROM a non-gate stage returns {success:true} with gate_decision_id NULL (no "record not assigned" error)', async () => {
+    const ventureId = await seedVenture(NON_GATE_FROM);
+
+    const result = await callAdvance(ventureId, NON_GATE_FROM, NON_GATE_TO);
+
+    // The exact failure shape the old buggy function produced — must NOT appear.
+    if (result?.success === false) {
+      expect(result.error).not.toMatch(/record "?v_gate_decision"? is not assigned yet/i);
+    }
+    expect(result.success).toBe(true);
+    expect(result.from_stage).toBe(NON_GATE_FROM);
+    expect(result.to_stage).toBe(NON_GATE_TO);
+
+    const handoffs = await readTransitionHandoff(ventureId);
+    expect(handoffs.length).toBe(1);
+    // gate_decision_id is present in the JSONB and is explicitly null for a non-gate advance.
+    expect(handoffs[0]).toHaveProperty('gate_decision_id');
+    expect(handoffs[0].gate_decision_id).toBeNull();
+  });
+
+  it('the gate path still records the REAL chairman_decision id (fix did not break gate stages)', async () => {
+    const ventureId = await seedVenture(GATE_FROM);
+    const { rows: cd } = await rawClient.query(
+      `INSERT INTO chairman_decisions (venture_id, lifecycle_stage, decision, status, decision_type)
+       VALUES ($1, $2, 'pass', 'approved', 'gate_review')
+       RETURNING id`,
+      [ventureId, GATE_FROM],
+    );
+    const decisionId = cd[0].id;
+
+    const result = await callAdvance(ventureId, GATE_FROM, GATE_TO);
+    expect(result.success).toBe(true);
+
+    const handoffs = await readTransitionHandoff(ventureId);
+    expect(handoffs.length).toBe(1);
+    expect(handoffs[0].gate_decision_id).toBe(decisionId);
+  });
+
+  it('a gate stage WITHOUT an approved decision is still rejected (gate enforcement intact)', async () => {
+    const ventureId = await seedVenture(GATE_FROM);
+    // No chairman_decisions row inserted → gate not approved.
+    const result = await callAdvance(ventureId, GATE_FROM, GATE_TO);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('gate_not_approved');
+    expect(result.error).not.toMatch(/not assigned yet/i);
+  });
+
+  it('STRUCTURAL guard: live function declares v_gate_decision_id and the INSERT no longer reads v_gate_decision.id unconditionally', async () => {
+    const { rows } = await rawClient.query(
+      `SELECT pg_get_functiondef('public.advance_venture_stage(uuid,integer,integer,text)'::regprocedure) AS def`,
+    );
+    const def = rows[0].def;
+
+    // Delta 1: scalar declared and NULL-initialized.
+    expect(def).toMatch(/v_gate_decision_id\s+UUID\s*:=\s*NULL\s*;/);
+    // Delta 2: assigned only on the gate path.
+    expect(def).toMatch(/v_gate_decision_id\s*:=\s*v_gate_decision\.id\s*;/);
+    // Delta 3: the JSONB handoff key now binds to the scalar, NOT the record field.
+    expect(def).toMatch(/'gate_decision_id',\s*v_gate_decision_id\b/);
+
+    // The OLD buggy shape — the JSONB key bound to the unguarded record field —
+    // must be gone. (Strip line comments so a "-- was v_gate_decision.id" note in
+    // the source does not produce a false match.)
+    const codeOnly = def
+      .split('\n')
+      .map((l) => l.replace(/--.*$/, ''))
+      .join('\n');
+    expect(codeOnly).not.toMatch(/'gate_decision_id',\s*v_gate_decision\.id\b/);
+    // In executable code, v_gate_decision.id appears exactly once: the guarded assignment.
+    const dotIdRefs = (codeOnly.match(/v_gate_decision\.id/g) || []).length;
+    expect(dotIdRefs).toBe(1);
+  });
+});


### PR DESCRIPTION
## SD-LEO-FIX-FIX-ADVANCE-VENTURE-001 — Fix advance_venture_stage non-gate advancement

**Problem.** `public.advance_venture_stage(uuid,integer,integer,text)` (oid 633099) declares `v_gate_decision RECORD` and assigns it (SELECT INTO) **only** inside the gate block guarded by `p_from_stage = ANY(v_all_gates = {3,5,13,17,18,23,24})`, but the `venture_stage_transitions` INSERT reads `v_gate_decision.id` **unconditionally** in the `handoff_data` jsonb. For non-gate stages the gate block is skipped, so PL/pgSQL raises `record "v_gate_decision" is not assigned yet` → caught by `EXCEPTION WHEN OTHERS` → `{success:false}`. This broke DB-RPC advancement FROM every non-gate stage (1,2,4,6-12,14-16,19,20,21,22,25,26), including the entire post-build **S19→S20→S21→S22** progression (verified live on DataDistill `510177ba`, S20→S21). The JS `_advanceStage` worker path is separate (unaffected), which is why ventures still moved; the UI **Advance** button + manual advances were broken.

**Fix (Option A — minimal, built from the LIVE `pg_get_functiondef(633099)`; the on-disk `20260322` migration is stale):**
- Add `v_gate_decision_id UUID := NULL` to DECLARE.
- Capture `v_gate_decision_id := v_gate_decision.id` **inside** the gate block (after the preserved `IF NOT FOUND` approval guard).
- Reference the scalar (not `v_gate_decision.id`) in the transition INSERT.

Result: `gate_decision_id = NULL` for non-gate stages (correct), the real `chairman_decision` UUID for gate stages (**unchanged**). No schema/data change; live idempotency (`uuid_generate_v5` + `ON CONFLICT DO NOTHING`), `stage_events` emits, and `approved_by` preserved.

**Deploy + test.** Applied to the shared DB via `apply-migration.js --prod-deploy` (verified via `pg_get_functiondef`). Regression test `advance-venture-nongate.db.test.js` — **5/5 pass** (zero-leak savepoints), proven to fail against the old buggy shape. Sub-agent evidence: VALIDATION (conf 96), DATABASE (PASS conf 98, applied + BEGIN..ROLLBACK), TESTING (PASS conf 95).

**Out of scope (follow-up):** converging with the newer gate-type-aware `fn_advance_venture_stage(...,jsonb,uuid)` (oid 726872).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
