### PR TITLE
feat(SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001): completion-side issue_patterns closure-loop

### DIFF
--- a/database/migrations/20260606_resolve_patterns_on_sd_complete.sql
+++ b/database/migrations/20260606_resolve_patterns_on_sd_complete.sql
@@ -1,0 +1,117 @@
+-- 20260606_resolve_patterns_on_sd_complete.sql
+-- SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Completion-side closure-loop for issue_patterns. Mirrors the cancel-side
+-- trg_reset_patterns_on_sd_cancel / trg_fn_reset_patterns_on_sd_cancel /
+-- reset_cancelled_sd_patterns(), but RESOLVES assigned patterns when an SD
+-- reaches status='completed' (for ALL sources). This fixes the gap where
+-- resolveLearningItems() (lead-final-approval/helpers.js) only resolves patterns
+-- for metadata.source='learn_command' SDs, stranding auto_rca/retrospective
+-- patterns as status='assigned' on completed SDs (invisible to v_patterns_with_decay,
+-- which filters status='active').
+--
+-- Follow-up to SD-LEO-INFRA-CLOSE-ISSUE-PATTERN-001 (cancel-side class).
+-- assigned_sd_id may hold EITHER the SD uuid OR the sd_key, so all matching uses
+-- `assigned_sd_id IN (p_sd_id, p_sd_key)` (same approach as the cancel-side helper).
+-- (In practice assigned_sd_id holds the uuid id — FK issue_patterns_assigned_sd_id_fkey
+--  references strategic_directives_v2(id) — so the p_sd_id arm is the load-bearing
+--  match; the p_sd_key arm is harmless defensive redundancy.)
+
+-- ============================================================================
+-- 1. Helper: resolve assigned patterns for one completed SD (returns count)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.resolve_completed_sd_patterns(p_sd_id text, p_sd_key text)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_count INTEGER := 0;
+BEGIN
+  WITH updated AS (
+    UPDATE issue_patterns
+    SET status = 'resolved',
+        resolution_date = now(),
+        resolution_notes = COALESCE(resolution_notes, '') ||
+          CASE WHEN resolution_notes IS NOT NULL AND resolution_notes != '' THEN '; ' ELSE '' END ||
+          'Auto-resolved: assigned SD ' || COALESCE(p_sd_key, p_sd_id) || ' reached completed (closure-loop)',
+        updated_at = now()
+    WHERE status = 'assigned'
+      AND assigned_sd_id IS NOT NULL
+      AND assigned_sd_id IN (p_sd_id, p_sd_key)
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_count FROM updated;
+  RETURN v_count;
+END;
+$function$;
+
+-- ============================================================================
+-- 2. Trigger wrapper: exception-isolated so a failure NEVER blocks SD completion
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.trg_fn_resolve_patterns_on_sd_complete()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_resolved INTEGER;
+BEGIN
+  BEGIN
+    v_resolved := resolve_completed_sd_patterns(NEW.id::text, NEW.sd_key);
+    IF v_resolved > 0 THEN
+      RAISE NOTICE 'closure-loop: resolved % assigned issue_pattern(s) for completed SD %',
+        v_resolved, COALESCE(NEW.sd_key, NEW.id::text);
+    END IF;
+  EXCEPTION WHEN OTHERS THEN
+    -- Failure isolation: degrade to a warning; the SD stays completed.
+    RAISE WARNING 'closure-loop: resolve_completed_sd_patterns failed for SD % (%): % — completion preserved',
+      COALESCE(NEW.sd_key, ''), NEW.id, SQLERRM;
+  END;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================================
+-- 3. Trigger: fire only on the not-completed -> completed transition
+--    (AFTER UPDATE OF status, same shape as the cancel-side trigger)
+-- ============================================================================
+CREATE OR REPLACE TRIGGER trg_resolve_patterns_on_sd_complete
+  AFTER UPDATE OF status ON public.strategic_directives_v2
+  FOR EACH ROW
+  WHEN (((NEW.status)::text = 'completed'::text) AND ((OLD.status)::text IS DISTINCT FROM 'completed'::text))
+  EXECUTE FUNCTION public.trg_fn_resolve_patterns_on_sd_complete();
+
+-- ============================================================================
+-- 4. One-time reconcile of historical danglers (idempotent; re-run finds 0 rows)
+-- ============================================================================
+
+-- (a) Patterns assigned to ALREADY-completed SDs -> resolved (was 15)
+UPDATE issue_patterns p
+SET status = 'resolved',
+    resolution_date = now(),
+    resolution_notes = COALESCE(p.resolution_notes, '') ||
+      CASE WHEN p.resolution_notes IS NOT NULL AND p.resolution_notes != '' THEN '; ' ELSE '' END ||
+      'Auto-resolved (reconcile): owning SD already completed - closure-loop backfill (SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001)',
+    updated_at = now()
+FROM strategic_directives_v2 s
+WHERE p.status = 'assigned'
+  AND p.assigned_sd_id IS NOT NULL
+  AND p.assigned_sd_id IN (s.id::text, s.sd_key)
+  AND s.status = 'completed';
+
+-- (b) Orphaned assignments with NULL assigned_sd_id -> active (was 9)
+UPDATE issue_patterns
+SET status = 'active',
+    assignment_date = NULL,
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'last_orphan_reset', jsonb_build_object(
+        'reason', 'was status=assigned with NULL assigned_sd_id (no SD to key on)',
+        'reset_by', 'SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001',
+        'reset_at', now()
+      )
+    ),
+    updated_at = now()
+WHERE status = 'assigned'
+  AND assigned_sd_id IS NULL;

--- a/tests/integration/sd-completion-pattern-resolve.test.js
+++ b/tests/integration/sd-completion-pattern-resolve.test.js
@@ -1,0 +1,127 @@
+/**
+ * Integration test: SD-completion -> issue_patterns closure-loop resolve.
+ * SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001 (follow-up to SD-LEO-INFRA-CLOSE-ISSUE-PATTERN-001).
+ *
+ * Verifies migration 20260606_resolve_patterns_on_sd_complete.sql:
+ *  - resolve_completed_sd_patterns(p_sd_id, p_sd_key) flips a completed SD's
+ *    assigned patterns to 'resolved' (resolution_date + resolution_notes set),
+ *    for ALL sources (auto_rca/retrospective/manual — NOT only learn_command,
+ *    which was the resolveLearningItems() gap), preserves assigned_sd_id as
+ *    provenance, leaves patterns of OTHER SDs untouched, is idempotent, and
+ *    does not perturb the dedup fingerprint.
+ *  - the trigger trg_resolve_patterns_on_sd_complete is wired AFTER UPDATE OF
+ *    status, condition-gated to the status->completed transition.
+ *  - the trigger function carries the failure-isolation contract (EXCEPTION WHEN
+ *    OTHERS + unconditional RETURN NEW) so a resolve failure can never abort a
+ *    completion.
+ *
+ * Mirrors tests/integration/sd-cancellation-pattern-reset.test.js. Tests the
+ * resolve FUNCTION directly (no SD insert/UPDATE) so it never locks the shared SD
+ * table — safe under parallel sessions. Behavioral trigger firing was verified in
+ * the db-agent BEGIN..ROLLBACK rehearsal at apply time; here we pin it structurally.
+ *
+ * assigned_sd_id is FK -> strategic_directives_v2(id), so test patterns are
+ * assigned to REAL existing SD ids. LIVE-gated on SUPABASE_POOLER_URL. All work is
+ * in a transaction ALWAYS rolled back — nothing persists.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const LIVE = !!process.env.SUPABASE_POOLER_URL;
+
+describe.skipIf(!LIVE)('SD-completion issue_patterns closure-loop resolve (LIVE)', () => {
+  let pg, client;
+
+  beforeAll(async () => {
+    pg = (await import('pg')).default;
+    client = new pg.Client({ connectionString: process.env.SUPABASE_POOLER_URL, ssl: { rejectUnauthorized: false } });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  const insPattern = async (patternId, assignedSdId, source = 'manual') => {
+    await client.query(
+      `INSERT INTO issue_patterns
+         (pattern_id, category, severity, issue_summary, status, source, occurrence_count, assigned_sd_id, assignment_date)
+       VALUES ($1,'process','medium',$2,'assigned',$3,3,$4, now())`,
+      [patternId, `closure-loop test ${patternId}`, source, assignedSdId]
+    );
+  };
+
+  it('resolves a completed SD assigned patterns (all sources), preserves other SDs, is idempotent, keeps fingerprint', async () => {
+    try {
+      await client.query('BEGIN');
+
+      // Real fixtures: a completed SD (resolve target) and a non-completed SD (control).
+      const completed = (await client.query(
+        "SELECT id, sd_key FROM strategic_directives_v2 WHERE status='completed' LIMIT 1")).rows[0];
+      const control = (await client.query(
+        "SELECT id, sd_key FROM strategic_directives_v2 WHERE status <> 'completed' LIMIT 1")).rows[0];
+      expect(completed).toBeTruthy();
+      expect(control).toBeTruthy();
+
+      const stamp = Date.now().toString(36);
+      const pAuto = `PAT-TEST-AUTO-${stamp}`;   // assigned to completed SD, source=auto_rca (the bug class)
+      const pRetro = `PAT-TEST-RETRO-${stamp}`; // assigned to completed SD, source=retrospective (the bug class)
+      const pC = `PAT-TEST-C-${stamp}`;         // control: assigned to a non-completed SD
+      await insPattern(pAuto, completed.id, 'auto_rca');
+      await insPattern(pRetro, completed.id, 'retrospective');
+      await insPattern(pC, control.id, 'manual');
+
+      const fpBefore = (await client.query(
+        'SELECT dedup_fingerprint FROM issue_patterns WHERE pattern_id=$1', [pAuto])).rows[0].dedup_fingerprint;
+
+      // Core: the shipped resolve function (called with both id and sd_key forms).
+      const r1 = await client.query('SELECT resolve_completed_sd_patterns($1,$2) AS n', [completed.id, completed.sd_key]);
+      expect(Number(r1.rows[0].n)).toBe(2); // pAuto + pRetro (both assigned to the completed SD)
+
+      const a = (await client.query('SELECT status, assigned_sd_id, resolution_date, resolution_notes, dedup_fingerprint FROM issue_patterns WHERE pattern_id=$1', [pAuto])).rows[0];
+      const retro = (await client.query('SELECT status FROM issue_patterns WHERE pattern_id=$1', [pRetro])).rows[0];
+      const c = (await client.query('SELECT status, assigned_sd_id FROM issue_patterns WHERE pattern_id=$1', [pC])).rows[0];
+
+      // Resolved row: status resolved, date + notes set, assigned_sd_id PRESERVED (provenance).
+      expect(a.status).toBe('resolved');
+      expect(a.resolution_date).toBeTruthy();
+      expect(a.resolution_notes).toMatch(/closure-loop/i);
+      expect(a.assigned_sd_id).toBe(completed.id);
+
+      // All-source coverage: the retrospective-sourced pattern is also resolved
+      // (this is exactly what resolveLearningItems' learn_command-only gate missed).
+      expect(retro.status).toBe('resolved');
+
+      // Control: pattern of a non-completed SD is untouched.
+      expect(c.status).toBe('assigned');
+      expect(c.assigned_sd_id).toBe(control.id);
+
+      // Fingerprint unchanged (resolve touches no fingerprint inputs).
+      expect(a.dedup_fingerprint).toBe(fpBefore);
+
+      // Idempotent: a second call resolves nothing.
+      const r2 = await client.query('SELECT resolve_completed_sd_patterns($1,$2) AS n', [completed.id, completed.sd_key]);
+      expect(Number(r2.rows[0].n)).toBe(0);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('trigger trg_resolve_patterns_on_sd_complete is wired AFTER UPDATE OF status and gated to status->completed', async () => {
+    const row = (await client.query(`
+      SELECT t.tgenabled, pg_get_triggerdef(t.oid) AS def
+      FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+      WHERE c.relname = 'strategic_directives_v2' AND t.tgname = 'trg_resolve_patterns_on_sd_complete'`)).rows[0];
+    expect(row).toBeTruthy();
+    expect(row.tgenabled).toBe('O');
+    expect(row.def).toMatch(/AFTER UPDATE OF status/i);
+    expect(row.def).toMatch(/WHEN /i);
+    expect(row.def).toMatch(/completed/i);
+  });
+
+  it('trigger function carries the failure-isolation contract (EXCEPTION WHEN OTHERS + RETURN NEW)', async () => {
+    const def = (await client.query(
+      "SELECT pg_get_functiondef(oid) AS def FROM pg_proc WHERE proname='trg_fn_resolve_patterns_on_sd_complete'")).rows[0].def;
+    expect(def).toMatch(/EXCEPTION\s+WHEN\s+OTHERS/i);
+    expect(def).toMatch(/RETURN NEW/i);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001 — completion-side issue_patterns closure-loop

Follow-up to SD-LEO-INFRA-CLOSE-ISSUE-PATTERN-001 (which closed the **cancelled**-SD class). This closes the **completed**-SD class.

### Problem
`resolveLearningItems()` only resolved assigned `issue_patterns` for SDs with `metadata.source='learn_command'`, so patterns sourced from `auto_rca`/`retrospective` were stranded `status='assigned'` on **completed** SDs — invisible to `v_patterns_with_decay` (which filters `status='active'`). Verified live: **15** stranded on completed SDs + **9** orphaned with NULL `assigned_sd_id`.

### Fix (`database/migrations/20260606_resolve_patterns_on_sd_complete.sql`)
- New trigger `trg_resolve_patterns_on_sd_complete` (AFTER UPDATE OF status, gated to the not-completed→completed transition) mirroring the cancel-side trigger, via exception-isolated wrapper + `resolve_completed_sd_patterns()` helper. Resolves assigned patterns on completion for **all sources**.
- One-time reconcile: 15 completed-stranded → `resolved`, 9 NULL-orphans → `active`.
- Deployed to prod via audited `apply-migration.js --prod-deploy` (`schema_migrations_applied` 2ac35d5a); danglers verified **15→0** and **9→0**.

### Test (`tests/integration/sd-completion-pattern-resolve.test.js`)
Mirrors the cancel-side test: direct-function test + all-source coverage + structural trigger pins. DATABASE sub-agent ran a BEGIN..ROLLBACK behavioral trigger rehearsal (PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
