### PR TITLE
fix(SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001): Stage 19 build consolidates generated tests into the shipped venture app + wires a test script

### DIFF
--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -43,6 +43,13 @@ import { parseDependencies } from '../../../scripts/modules/sd-next/dependency-r
 import { scanArtifactsForStackCompliance } from '../standards/venture-stack-compliance.js';
 // SD-LEO-INFRA-WIRE-PRE-BUILD-002 (FR-1): per-leaf enrichment introspection (--enrich-leaf --dry-run).
 import { introspectLeafEnrichment } from './panel-driver.js';
+// SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001: post-build test consolidation needs fs/git + the canonical
+// DB-first venture repo-path resolver (never hand-rolled). All filesystem/git access is injectable so
+// the consolidation helpers stay headlessly unit-testable, matching this module's existing test design.
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { join, dirname, relative, resolve as resolvePath, sep } from 'path';
+import { resolveRepoPathDbFirst, normalizeAppName, ENGINEER_ROOT } from '../../repo-paths.js';
 
 export const S19 = 19;
 export const NON_TERMINAL = ['draft', 'active'];
@@ -443,20 +450,215 @@ export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFA
   return result;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001 — post-build test consolidation.
+// After the venture build tree is complete, the generated tests live scattered in the
+// per-child-SD EXEC worktrees (created INSIDE the venture clone) and never reach the
+// shipped venture app — so every venture arrives at Stage-20 with "no tests". These
+// helpers gather those tests into the venture's canonical test dir, wire a runnable
+// `test` script (package-manager aware, no clobber), and commit ONLY those paths to the
+// venture main branch. fs/git are INJECTABLE so the logic is headlessly unit-testable.
+// Consolidation is invoked from finalizeConsume inside a try/catch and is best-effort.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const defaultFs = { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync };
+const defaultGit = (args, { cwd } = {}) => execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+const TEST_FILE_RE = /\.(test|spec)\.[cm]?[jt]sx?$/;
+const CONSOLIDATE_IGNORE_DIRS = new Set(['node_modules', '.git', '.worktrees', 'dist', 'build', '.next', 'coverage', '.turbo']);
+
+/**
+ * TR-2: deterministic package-manager detection. Precedence:
+ *   package.json `packageManager` field > bun lockfile > pnpm-lock.yaml > yarn.lock >
+ *   package-lock.json > npm (default). fs is injectable for headless tests.
+ */
+export function detectPackageManager(repoPath, { fs = defaultFs } = {}) {
+  try {
+    const pkgPath = join(repoPath, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      const field = typeof pkg.packageManager === 'string' ? pkg.packageManager.split('@')[0].trim().toLowerCase() : '';
+      if (['npm', 'bun', 'pnpm', 'yarn'].includes(field)) return field;
+    }
+  } catch { /* fall through to lockfile sniffing */ }
+  if (fs.existsSync(join(repoPath, 'bun.lockb')) || fs.existsSync(join(repoPath, 'bun.lock'))) return 'bun';
+  if (fs.existsSync(join(repoPath, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (fs.existsSync(join(repoPath, 'yarn.lock'))) return 'yarn';
+  if (fs.existsSync(join(repoPath, 'package-lock.json'))) return 'npm';
+  return 'npm';
+}
+
+/**
+ * Resolve the venture's main repo local path from its UUID, reusing the canonical DB-first
+ * resolver (applications.local_path, registry.json fallback). Returns null — so the caller
+ * safely no-ops — when the venture has no name, resolves to a platform repo, or the clone is
+ * absent. NEVER returns the EHG_Engineer root (defense-in-depth: we must never commit venture
+ * tests into THIS repo). Pure read; never throws.
+ */
+export async function resolveVentureRepoPath(supabase, ventureId, { fs = defaultFs } = {}) {
+  try {
+    const { data } = await supabase.from('ventures').select('name').eq('id', ventureId).maybeSingle();
+    const name = data?.name;
+    if (!name || typeof name !== 'string' || !name.trim()) return null;
+    const needle = normalizeAppName(name);
+    if (!needle || needle === 'ehgengineer' || needle === 'ehg') return null; // never a platform repo
+    const repoPath = await resolveRepoPathDbFirst(name, supabase);
+    if (!repoPath) return null;
+    if (resolvePath(repoPath) === resolvePath(ENGINEER_ROOT)) return null;    // hard guard: never this repo
+    if (!fs.existsSync(join(repoPath, '.git'))) return null;
+    return repoPath;
+  } catch { return null; }
+}
+
+/**
+ * Enumerate the per-child EXEC worktrees registered in the venture clone (excluding the main
+ * worktree itself) via `git worktree list --porcelain` — naming-convention agnostic. git is
+ * injectable; best-effort (returns [] on any failure).
+ */
+export function enumerateChildWorktrees(ventureRepoPath, { git = defaultGit } = {}) {
+  try {
+    const out = git(['worktree', 'list', '--porcelain'], { cwd: ventureRepoPath }) || '';
+    const norm = (p) => String(p).replace(/\\/g, '/').replace(/\/+$/, '');
+    const mainNorm = norm(ventureRepoPath);
+    const paths = [];
+    for (const line of String(out).split('\n')) {
+      if (line.startsWith('worktree ')) {
+        const p = line.slice('worktree '.length).trim();
+        if (p && norm(p) !== mainNorm) paths.push(p);
+      }
+    }
+    return paths;
+  } catch { return []; }
+}
+
+/** Recursively list test files under `root` using the injectable fs (Dirent-based — no real-FS assumption). */
+function listTestFiles(root, fs) {
+  const out = [];
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const ent of entries || []) {
+      const name = ent.name;
+      const full = join(dir, name);
+      const isDir = typeof ent.isDirectory === 'function' && ent.isDirectory();
+      if (isDir) { if (!CONSOLIDATE_IGNORE_DIRS.has(name)) stack.push(full); }
+      else if (TEST_FILE_RE.test(name)) out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * FR-1..FR-3 / FR-5: consolidate generated tests from the child-SD worktrees into the venture's
+ * canonical test dir, wire a runnable `test` script (pm-aware, no clobber), and commit ONLY those
+ * paths to the venture main branch (path-scoped add; no empty commit). De-duplicated by repo-relative
+ * test path; idempotent (skips files already present). fs/git are injectable. Returns a summary for
+ * the LEO_BUILD_CONSUMED event. MAY throw on a git failure — finalizeConsume's try/catch is the net (TS-6).
+ */
+export async function consolidateGeneratedTests({ ventureRepoPath, childWorktreePaths, fs = defaultFs, git = defaultGit, logger = console }) {
+  // canonical venture test dir: prefer an existing tests/ or test/, else default tests/
+  const testDirName = fs.existsSync(join(ventureRepoPath, 'tests')) ? 'tests'
+    : fs.existsSync(join(ventureRepoPath, 'test')) ? 'test'
+      : 'tests';
+  const ventureTestDir = join(ventureRepoPath, testDirName);
+
+  const seen = new Set();
+  let copied = 0;
+  for (const wt of (childWorktreePaths || [])) {
+    for (const abs of listTestFiles(wt, fs)) {
+      // worktree-relative path, with any leading tests/ or test/ stripped so we re-root cleanly
+      const rel = relative(wt, abs).split(sep).join('/').replace(/^tests?\//, '');
+      if (seen.has(rel)) continue;            // de-dupe identical relative paths across worktrees
+      seen.add(rel);
+      const dest = join(ventureTestDir, rel);
+      if (fs.existsSync(dest)) continue;       // idempotent: already consolidated
+      fs.mkdirSync(dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, fs.readFileSync(abs));
+      copied++;
+    }
+  }
+
+  // wire a runnable `test` script (no clobber), package-manager aware
+  const pkgPath = join(ventureRepoPath, 'package.json');
+  let pm = 'npm';
+  let testScriptWired = false;
+  if (fs.existsSync(pkgPath)) {
+    pm = detectPackageManager(ventureRepoPath, { fs });
+    let pkg = null;
+    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch { pkg = null; }
+    if (pkg && typeof pkg === 'object') {
+      pkg.scripts = pkg.scripts || {};
+      if (!pkg.scripts.test) {                 // never clobber an existing test script
+        pkg.scripts.test = 'vitest run';        // EHG-standard runner; discovers *.test.* / *.spec.*
+        fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+        testScriptWired = true;
+      }
+    }
+  }
+
+  // commit ONLY the test dir + package.json (path-scoped; skip an empty commit)
+  if (copied > 0 || testScriptWired) {
+    git(['add', testDirName, 'package.json'], { cwd: ventureRepoPath });
+    const staged = String(git(['diff', '--cached', '--name-only'], { cwd: ventureRepoPath }) || '').trim();
+    if (staged) {
+      const msg = `chore(build): consolidate ${copied} generated test file(s) + wire test script\n\n`
+        + `Auto-consolidated by venture-build-consumer (SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001). package_manager=${pm}.`;
+      git(['commit', '-m', msg], { cwd: ventureRepoPath });
+    }
+  }
+
+  logger.log?.(`[venture-build-consumer] consolidated ${copied} test file(s) into ${testDirName}/ — test_script_wired=${testScriptWired} pm=${pm}`);
+  return { tests_consolidated: copied, test_script_wired: testScriptWired, package_manager: pm, skipped: false };
+}
+
 /**
  * FINALIZE (real writes, SAFE): only when the tree is genuinely complete, set the build_consumed_at
- * idempotency marker and optionally idle-nudge the worker. NEVER advances the venture. This is the
- * step the session-hosted skill runs after its drive loop reports the tree complete.
+ * idempotency marker, optionally idle-nudge the worker, and consolidate the generated tests into the
+ * venture app (SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001). NEVER advances the venture. This is the step
+ * the session-hosted skill runs after its drive loop reports the tree complete. Consolidation is
+ * BEST-EFFORT — wrapped in try/catch so a fs/git error can NEVER break the build finalize.
  */
-export async function finalizeConsume({ supabase, ventureId, logger = console }) {
+export async function finalizeConsume({ supabase, ventureId, logger = console, deps = {} }) {
   const top = await findTopOrchestrator(supabase, ventureId);
   if (!top) return { complete: false, consumed: false, idleNudged: false, reason: 'no_top_orchestrator' };
   const descendants = await fetchDescendants(supabase, top.id);
   if (!isTreeComplete(descendants)) return { complete: false, consumed: false, idleNudged: false, reason: 'tree_incomplete' };
   await markConsumed(supabase, top.id, {});
   const nudge = await maybeIdleNudge(supabase, ventureId, {});
-  await emitEvent(supabase, 'LEO_BUILD_CONSUMED', { finalize: true, idle_nudged: !!nudge.nudged }, { ventureId, sdId: top.id, logger });
-  return { complete: true, consumed: true, idleNudged: !!nudge.nudged };
+
+  // FR-4: consolidate generated tests — runs ONLY after the tree is complete, guarded by repo
+  // resolution + existence, and NEVER throws out of finalize (best-effort, mirrors the module's
+  // existing fail-safe pattern). The summary feeds the coupled Stage-20 checker (FR-5).
+  let consolidation = { tests_consolidated: 0, test_script_wired: false, package_manager: null, skipped: true, reason: 'not_run' };
+  try {
+    const resolveRepo = deps.resolveVentureRepoPath || resolveVentureRepoPath;
+    const enumerate = deps.enumerateChildWorktrees || enumerateChildWorktrees;
+    const consolidate = deps.consolidateGeneratedTests || consolidateGeneratedTests;
+    const _fs = deps.fs || defaultFs;
+    const _git = deps.git || defaultGit;
+    const ventureRepoPath = await resolveRepo(supabase, ventureId, { fs: _fs });
+    if (!ventureRepoPath) {
+      consolidation = { tests_consolidated: 0, test_script_wired: false, package_manager: null, skipped: true, reason: 'venture_repo_unresolved' };
+      logger.log?.('[venture-build-consumer] test consolidation skipped: venture repo path unresolved or absent');
+    } else {
+      const childWorktreePaths = enumerate(ventureRepoPath, { git: _git });
+      consolidation = await consolidate({ ventureRepoPath, childWorktreePaths, fs: _fs, git: _git, logger });
+    }
+  } catch (err) {
+    consolidation = { tests_consolidated: 0, test_script_wired: false, package_manager: null, skipped: true, error: err.message };
+    logger.error?.(`[venture-build-consumer] consolidateGeneratedTests failed (non-fatal — finalize unaffected): ${err.message}`);
+  }
+
+  await emitEvent(supabase, 'LEO_BUILD_CONSUMED', {
+    finalize: true,
+    idle_nudged: !!nudge.nudged,
+    tests_consolidated: consolidation.tests_consolidated,
+    test_script_wired: consolidation.test_script_wired,
+    package_manager: consolidation.package_manager,
+  }, { ventureId, sdId: top.id, logger });
+  return { complete: true, consumed: true, idleNudged: !!nudge.nudged, consolidation };
 }
 
 export async function main(argv = process.argv, deps = {}) {

--- a/tests/unit/eva/bridge/venture-build-consumer.test.js
+++ b/tests/unit/eva/bridge/venture-build-consumer.test.js
@@ -8,6 +8,8 @@ import { dirname, resolve } from 'path';
 import {
   runConsume, computeWorkableLeaves, isTreeComplete, fetchDescendants,
   ventureEligibility, maybeIdleNudge, tryAdvisoryLock, finalizeConsume, TERMINAL, NON_TERMINAL,
+  // SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001
+  consolidateGeneratedTests, detectPackageManager, enumerateChildWorktrees,
 } from '../../../../lib/eva/bridge/venture-build-consumer.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -342,5 +344,174 @@ describe('FR-3 (stack gate) — fail-closed venture-stack compliance HOLD at S19
     expect(res.skipped).toBe(false);
     expect(res.completed).toBe(true);
     expect(res.drivenLeaves.length).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001 — generated-test consolidation (TS-1..TS-6 + extras).
+// In-memory fs + git mock so the consolidation logic runs with NO real filesystem or git.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Minimal in-memory fs honoring only what the consolidation helpers call. Paths are
+// POSIX-normalized so node path.join's backslashes (Windows) resolve consistently.
+function makeMemFs(initial = {}) {
+  const norm = (p) => (String(p).replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/+$/, '') || '/');
+  const files = new Map();
+  const dirs = new Set(['/']);
+  const addAncestors = (n) => { const parts = n.split('/'); let cur = ''; for (let i = 1; i < parts.length - 1; i++) { cur += '/' + parts[i]; dirs.add(cur); } };
+  for (const [k, v] of Object.entries(initial)) { const nk = norm(k); files.set(nk, v); addAncestors(nk); }
+  return {
+    existsSync(p) { const n = norm(p); return files.has(n) || dirs.has(n) || [...files.keys()].some((k) => k.startsWith(n + '/')); },
+    readFileSync(p) { const n = norm(p); if (!files.has(n)) throw new Error('ENOENT ' + n); return files.get(n); },
+    writeFileSync(p, data) { const n = norm(p); files.set(n, data); addAncestors(n); },
+    mkdirSync(p) { const n = norm(p); dirs.add(n); addAncestors(n); },
+    readdirSync(p) {
+      const n = norm(p);
+      const children = new Map(); // name -> isDir
+      const consider = (full) => {
+        if (full === n || !full.startsWith(n + '/')) return;
+        const rest = full.slice(n.length + 1);
+        const name = rest.split('/')[0];
+        const childIsDir = rest.includes('/');
+        if (!children.has(name) || childIsDir) children.set(name, childIsDir || children.get(name) || false);
+      };
+      for (const k of files.keys()) consider(k);
+      for (const d of dirs) consider(d);
+      return [...children.entries()].map(([name, d]) => ({ name, isDirectory: () => d }));
+    },
+  };
+}
+
+function makeGitMock({ staged = '', failOn = null, worktreeOut = '' } = {}) {
+  const calls = [];
+  const git = (args, opts) => {
+    calls.push({ args, opts });
+    if (failOn && args[0] === failOn) throw new Error(`git ${failOn} failed`);
+    if (args[0] === 'worktree') return worktreeOut;
+    if (args[0] === 'diff') return staged;
+    return '';
+  };
+  git.calls = calls;
+  return git;
+}
+
+describe('consolidateGeneratedTests — SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001', () => {
+  it('TS-1 copies generated tests from child worktrees into the venture test dir', async () => {
+    const fs = makeMemFs({
+      '/v/package.json': JSON.stringify({ scripts: { test: 'vitest run' } }),
+      '/v/.git/HEAD': 'ref',
+      '/wt/a/tests/auth.test.js': 'A',
+      '/wt/b/tests/landing-copy.test.js': 'B',
+    });
+    const git = makeGitMock({ staged: 'tests/auth.test.js\ntests/landing-copy.test.js' });
+    const res = await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: ['/wt/a', '/wt/b'], fs, git, logger: { log() {} } });
+    expect(res.tests_consolidated).toBe(2);
+    expect(fs.existsSync('/v/tests/auth.test.js')).toBe(true);
+    expect(fs.existsSync('/v/tests/landing-copy.test.js')).toBe(true);
+  });
+
+  it('TS-2 wires a runnable test script when absent and detects npm', async () => {
+    const fs = makeMemFs({
+      '/v/package.json': JSON.stringify({ scripts: { dev: 'vite', build: 'vite build' } }),
+      '/v/package-lock.json': '{}',
+      '/v/.git/HEAD': 'ref',
+    });
+    const git = makeGitMock({ staged: 'package.json' });
+    const res = await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: [], fs, git, logger: { log() {} } });
+    expect(res.test_script_wired).toBe(true);
+    expect(res.package_manager).toBe('npm');
+    const pkg = JSON.parse(fs.readFileSync('/v/package.json'));
+    expect(pkg.scripts.test).toBeTruthy();
+    expect(pkg.scripts.dev).toBe('vite'); // existing scripts preserved
+  });
+
+  it('TS-3 never clobbers an existing test script', async () => {
+    const fs = makeMemFs({
+      '/v/package.json': JSON.stringify({ scripts: { test: 'vitest run --coverage' } }),
+      '/v/.git/HEAD': 'ref',
+    });
+    const git = makeGitMock({ staged: '' });
+    const res = await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: [], fs, git, logger: { log() {} } });
+    expect(res.test_script_wired).toBe(false);
+    const pkg = JSON.parse(fs.readFileSync('/v/package.json'));
+    expect(pkg.scripts.test).toBe('vitest run --coverage');
+    expect(git.calls.some((c) => c.args[0] === 'commit')).toBe(false); // no copy + no wire → no commit
+  });
+
+  it('TS-4 detectPackageManager honors lockfiles + packageManager field with npm default', () => {
+    expect(detectPackageManager('/r', { fs: makeMemFs({ '/r/bun.lockb': '' }) })).toBe('bun');
+    expect(detectPackageManager('/r', { fs: makeMemFs({ '/r/pnpm-lock.yaml': '' }) })).toBe('pnpm');
+    expect(detectPackageManager('/r', { fs: makeMemFs({ '/r/yarn.lock': '' }) })).toBe('yarn');
+    expect(detectPackageManager('/r', { fs: makeMemFs({}) })).toBe('npm');
+    const field = makeMemFs({ '/r/package.json': JSON.stringify({ packageManager: 'pnpm@9.1.0' }), '/r/package-lock.json': '' });
+    expect(detectPackageManager('/r', { fs: field })).toBe('pnpm'); // field beats lockfile
+  });
+
+  it('TS-5 is a no-op (no copy, no commit, no error) when there are no new tests', async () => {
+    const fs = makeMemFs({
+      '/v/package.json': JSON.stringify({ scripts: { test: 'vitest run' } }),
+      '/v/tests/existing.test.js': 'X',     // already consolidated
+      '/wt/a/tests/existing.test.js': 'X',   // same rel path → dest exists → skip
+      '/v/.git/HEAD': 'ref',
+    });
+    const git = makeGitMock({ staged: '' });
+    const res = await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: ['/wt/a'], fs, git, logger: { log() {} } });
+    expect(res.tests_consolidated).toBe(0);
+    expect(res.test_script_wired).toBe(false);
+    expect(git.calls.some((c) => c.args[0] === 'commit')).toBe(false);
+  });
+
+  it('TS-6 finalizeConsume returns complete even when consolidation throws (best-effort)', async () => {
+    const tree = nestedTree({ children: 1, grandkidsEach: 2 });
+    tree.forEach((r) => { if (r.id !== 'orch-top') r.status = 'completed'; });
+    const sb = new MockSB(eligibleTables({ strategic_directives_v2: tree }));
+    const errors = [];
+    const logger = { log() {}, warn() {}, error(m) { errors.push(m); } };
+    const r = await finalizeConsume({
+      supabase: sb, ventureId: VID, logger,
+      deps: {
+        resolveVentureRepoPath: async () => '/fake/venture',
+        enumerateChildWorktrees: () => [],
+        consolidateGeneratedTests: async () => { throw new Error('git boom'); },
+      },
+    });
+    expect(r.complete).toBe(true);
+    expect(r.consumed).toBe(true);
+    expect(errors.some((m) => /git boom/.test(m))).toBe(true);
+  });
+
+  it('de-duplicates the same relative test path across worktrees (copied once, first wins)', async () => {
+    const fs = makeMemFs({
+      '/v/package.json': JSON.stringify({ scripts: { test: 'vitest run' } }),
+      '/v/.git/HEAD': 'ref',
+      '/wt/a/tests/dup.test.js': 'A',
+      '/wt/b/tests/dup.test.js': 'B',
+    });
+    const git = makeGitMock({ staged: 'tests/dup.test.js' });
+    const res = await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: ['/wt/a', '/wt/b'], fs, git, logger: { log() {} } });
+    expect(res.tests_consolidated).toBe(1);
+    expect(fs.readFileSync('/v/tests/dup.test.js')).toBe('A');
+  });
+
+  it('git add is path-scoped to the test dir + package.json (never -A or .)', async () => {
+    const fs = makeMemFs({ '/v/package.json': JSON.stringify({ scripts: {} }), '/v/.git/HEAD': 'ref', '/wt/a/tests/x.test.js': 'X' });
+    const git = makeGitMock({ staged: 'tests/x.test.js\npackage.json' });
+    await consolidateGeneratedTests({ ventureRepoPath: '/v', childWorktreePaths: ['/wt/a'], fs, git, logger: { log() {} } });
+    const addCall = git.calls.find((c) => c.args[0] === 'add');
+    expect(addCall).toBeTruthy();
+    expect(addCall.args).toContain('package.json');
+    expect(addCall.args).toContain('tests');
+    expect(addCall.args).not.toContain('-A');
+    expect(addCall.args).not.toContain('.');
+  });
+
+  it('enumerateChildWorktrees parses porcelain output and excludes the main worktree', () => {
+    const out = [
+      'worktree /v', 'HEAD abc', 'branch refs/heads/main', '',
+      'worktree /v/.worktrees/SD-CHILD-A', 'HEAD def', '',
+      'worktree /v/.worktrees/SD-CHILD-B', 'HEAD ghi', '',
+    ].join('\n');
+    const paths = enumerateChildWorktrees('/v', { git: () => out });
+    expect(paths).toEqual(['/v/.worktrees/SD-CHILD-A', '/v/.worktrees/SD-CHILD-B']);
   });
 });

--- a/tests/unit/eva/bridge/venture-build-consumer.test.js
+++ b/tests/unit/eva/bridge/venture-build-consumer.test.js
@@ -9,8 +9,9 @@ import {
   runConsume, computeWorkableLeaves, isTreeComplete, fetchDescendants,
   ventureEligibility, maybeIdleNudge, tryAdvisoryLock, finalizeConsume, TERMINAL, NON_TERMINAL,
   // SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001
-  consolidateGeneratedTests, detectPackageManager, enumerateChildWorktrees,
+  consolidateGeneratedTests, detectPackageManager, enumerateChildWorktrees, resolveVentureRepoPath,
 } from '../../../../lib/eva/bridge/venture-build-consumer.js';
+import { ENGINEER_ROOT } from '../../../../lib/repo-paths.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LIB_PATH = resolve(__dirname, '../../../../lib/eva/bridge/venture-build-consumer.js');
@@ -513,5 +514,41 @@ describe('consolidateGeneratedTests — SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001',
     ].join('\n');
     const paths = enumerateChildWorktrees('/v', { git: () => out });
     expect(paths).toEqual(['/v/.worktrees/SD-CHILD-A', '/v/.worktrees/SD-CHILD-B']);
+  });
+});
+
+describe('resolveVentureRepoPath — SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001 (safety guards)', () => {
+  it('resolves a venture to its DB-registered local path when the clone exists', async () => {
+    const ventureRepo = resolve('/repos/datadistill');             // OS-correct absolute path
+    const fs = makeMemFs({ [ventureRepo.replace(/\\/g, '/') + '/.git/HEAD']: 'ref' });
+    const sb = new MockSB({
+      ventures: [{ id: 'v9', name: 'DataDistill' }],
+      applications: [{ name: 'DataDistill', local_path: ventureRepo, status: 'active', deleted_at: null }],
+    });
+    expect(await resolveVentureRepoPath(sb, 'v9', { fs })).toBe(ventureRepo);
+  });
+
+  it('returns null for a platform-repo name (never EHG_Engineer / ehg)', async () => {
+    const sb = new MockSB({ ventures: [{ id: 'vEng', name: 'EHG_Engineer' }] });
+    expect(await resolveVentureRepoPath(sb, 'vEng', { fs: makeMemFs({}) })).toBe(null);
+  });
+
+  it('HARD-GUARD: returns null even if the DB resolves a venture to the EHG_Engineer root', async () => {
+    // a misconfigured applications row pointing a venture at THIS repo must never be committed into.
+    const sb = new MockSB({
+      ventures: [{ id: 'vx', name: 'SomeVenture' }],
+      applications: [{ name: 'SomeVenture', local_path: ENGINEER_ROOT, status: 'active', deleted_at: null }],
+    });
+    const fs = makeMemFs({ [ENGINEER_ROOT.replace(/\\/g, '/') + '/.git/HEAD']: 'ref' });
+    expect(await resolveVentureRepoPath(sb, 'vx', { fs })).toBe(null);
+  });
+
+  it('returns null when the resolved clone has no .git (absent/uncloned)', async () => {
+    const ventureRepo = resolve('/repos/notcloned');
+    const sb = new MockSB({
+      ventures: [{ id: 'v9', name: 'NotCloned' }],
+      applications: [{ name: 'NotCloned', local_path: ventureRepo, status: 'active', deleted_at: null }],
+    });
+    expect(await resolveVentureRepoPath(sb, 'v9', { fs: makeMemFs({}) })).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary
Closes the gap where leo_bridge ventures reached Stage-20's Code Quality Gate with **"no tests"**: child-SD-generated tests stayed scattered in the per-child EXEC worktrees (created inside the venture clone) and never reached the shipped venture app.

`finalizeConsume()` now consolidates generated tests after the build tree completes — confined to **`lib/eva/bridge/venture-build-consumer.js`** (+ its unit test).

## What changed (4 new exported helpers, all injectable fs/git → headlessly testable)
- **`consolidateGeneratedTests`** — globs child-worktree `*.test.*`/`*.spec.*`, de-dupes by relative path, copies into the venture's canonical test dir (idempotent — skips existing), wires a `test` script (no clobber), then **path-scoped** `git add <testdir> package.json` + commit (never `-A`; skips empty commits).
- **`detectPackageManager`** — precedence: `packageManager` field > bun > pnpm > yarn > package-lock > npm default.
- **`resolveVentureRepoPath`** — reuses the canonical DB-first resolver; **hard-guarded to never resolve the EHG_Engineer root** or a platform repo (defense against committing venture tests into this repo).
- **`enumerateChildWorktrees`** — `git worktree list --porcelain`, convention-agnostic.
- **`finalizeConsume`** — invokes consolidation **best-effort inside try/catch** (NEVER throws out of finalize); adds `tests_consolidated`/`test_script_wired`/`package_manager` to the `LEO_BUILD_CONSUMED` event for the coupled Stage-20 checker (SD-LEO-FIX-FIX-STAGE-CODE-001).

## Tests & evidence
- **34/34** unit tests green (13 new: TS-1..TS-6 + de-dupe + path-scoped-add + enumerate + 4 `resolveVentureRepoPath` safety-guard tests). 0 regressions.
- **TESTING** sub-agent: CONDITIONAL_PASS (82) → flagged the hard-guard coverage gap, **closed post-review** (suite 30→34).
- **SECURITY** sub-agent: PASS (96) — execFileSync array args (no shell injection), path-traversal not lexically reachable, never-advance guardrail intact.
- Gates: EXEC-TO-PLAN **97**, PLAN-TO-LEAD **98**.

## Safety / scope
- NEVER advances the venture (static guardrail test enforces no advance/stage-write/governance tokens).
- Best-effort: a fs/git error can never break the build finalize.
- Confined to one lib file + its test (no Stage-20 file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)