### PR TITLE
fix(SD-FDBK-ENH-START-LEAVES-LOCKED-001): self-recover orphan/locked worktree husk

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -232,6 +232,55 @@ function verifyWorktreeRegistered(worktreePath, repoRoot) {
 }
 
 /**
+ * SD-FDBK-ENH-START-LEAVES-LOCKED-001: recover an orphan/locked worktree husk.
+ *
+ * When .worktrees/<SD> exists but git no longer tracks it as a registered
+ * worktree (e.g. a reaper removed the registration but a process cwd-handle left
+ * the empty dir locked so rmdir/Remove-Item fail "in use"), refusing leaves the
+ * SD permanently unclaimable. Two recoverable cases:
+ *   1. Stale registration — `git worktree prune` re-validates without touching the dir.
+ *   2. Locked husk — `git worktree add --force` WRITES into the dir (writes succeed
+ *      even when delete is blocked), re-registering + repopulating it.
+ * Returns a result object on success, or null if recovery is not possible (caller
+ * then throws with remediation). Mirrors the add logic in createWorktree().
+ */
+function recoverOrphanWorktree(sdKey, worktreePath, repoRoot, worktreesDir, opts = {}) {
+  // Case 1: stale admin registration — prune may re-validate the existing dir.
+  try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch { /* best-effort */ }
+  if (isValidWorktree(worktreePath)) {
+    return { path: worktreePath, branch: getWorktreeBranch(worktreePath) || `feat/${sdKey}`, created: false, recovered: 'prune' };
+  }
+
+  // Case 2: locked husk — adopt/repopulate it with --force (tolerates the existing dir).
+  const branch = `feat/${sdKey}`;
+  const branchExists = (() => {
+    try { execSync(`git show-ref --verify --quiet refs/heads/${branch}`, { cwd: repoRoot, stdio: 'pipe' }); return true; }
+    catch { return false; }
+  })();
+  let lockPath;
+  try {
+    lockPath = acquireWorktreeLock(sdKey, process.env.CLAUDE_SESSION_ID || 'unknown', worktreesDir);
+    if (branchExists) {
+      execSync(`git worktree add --force "${worktreePath}" "${branch}"`, { cwd: repoRoot, stdio: 'pipe' });
+    } else {
+      const baseRef = resolveWorktreeBaseRef();
+      fetchBaseRef(repoRoot, baseRef);
+      execSync(`git worktree add --force -b "${branch}" "${worktreePath}" "${baseRef}"`, { cwd: repoRoot, stdio: 'pipe' });
+    }
+  } catch (e) {
+    emitLog({ event: 'worktree.recover_failed', sdKey, worktreePath, error: e.message });
+    return null;
+  } finally {
+    if (lockPath) releaseLock(lockPath);
+  }
+  if (!isValidWorktree(worktreePath)) return null;
+  const essentials = ensureWorktreeEssentials(worktreePath, repoRoot, { activeSessionCount: opts.activeSessionCount });
+  if (!essentials.ok) emitLog({ event: 'worktree.essentials_partial', sdKey, source: 'recovered-orphan', errors: essentials.errors });
+  emitLog({ event: 'worktree.recovered', sdKey, worktreePath, branch });
+  return { path: worktreePath, branch, created: true, recovered: 'force-add' };
+}
+
+/**
  * Create a new worktree for the SD
  */
 function createWorktree(sdKey, repoRoot, opts = {}) {
@@ -258,9 +307,17 @@ function createWorktree(sdKey, repoRoot, opts = {}) {
       }
       return { path: worktreePath, branch: existingBranch || `feat/${sdKey}`, created: false };
     }
+    // SD-FDBK-ENH-START-LEAVES-LOCKED-001: before refusing on an orphan husk
+    // (dir exists, unregistered — often a reaper-removed registration whose dir is
+    // locked by a process cwd-handle, so rm/rename fail "in use"), attempt
+    // self-recovery so the SD does not become permanently unclaimable.
+    const recovered = recoverOrphanWorktree(sdKey, worktreePath, repoRoot, worktreesDir, opts);
+    if (recovered) return recovered;
     const err = new Error(
-      `Path ${worktreePath} exists but is not a registered worktree. ` +
-      `Remove it with: npm run worktree:remove "${worktreePath}" (safe pre-unlink; not raw rm -rf, which guts shared node_modules)`
+      `Path ${worktreePath} exists but is not a registered worktree, and self-recovery ` +
+      `(git worktree prune + git worktree add --force) failed — the dir may be locked by ` +
+      `another process' cwd handle. Remove it with: npm run worktree:remove "${worktreePath}" ` +
+      `(safe pre-unlink; not raw rm -rf, which guts shared node_modules), or end the holding process and retry.`
     );
     err.errorCode = 'WORKTREE_PRE_CONDITION_FAILED';
     throw err;

--- a/tests/unit/resolve-sd-workdir/orphan-husk-recovery.test.js
+++ b/tests/unit/resolve-sd-workdir/orphan-husk-recovery.test.js
@@ -1,0 +1,91 @@
+/**
+ * Tests for SD-FDBK-ENH-START-LEAVES-LOCKED-001
+ * Covers the orphan/locked-worktree-husk recovery foundation in
+ * scripts/resolve-sd-workdir.js (recoverOrphanWorktree).
+ *
+ * Repro that motivated this: a reaper removed a worktree's git registration but a
+ * process cwd-handle left the empty .worktrees/<SD> dir locked, so rm/rename fail
+ * "in use" and the SD became permanently unclaimable. The fix: instead of refusing
+ * when the path exists-but-unregistered, sd-start runs `git worktree prune` then
+ * `git worktree add --force` — which WRITES into the husk (writes succeed even when
+ * delete is blocked), re-registering + repopulating it.
+ *
+ * These tests pin the two foundations the fix relies on, using os.tmpdir + git init
+ * fixtures (no main-repo mutations), mirroring worktree-atomicity.test.js.
+ * Run with: node --test tests/unit/resolve-sd-workdir/orphan-husk-recovery.test.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+
+function createFixtureRepo() {
+  const dir = join(tmpdir(), `wt-husk-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+  writeFileSync(join(dir, 'README.md'), '# test');
+  execSync('git add . && git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+const isRegistered = (repoRoot, wtPath) => {
+  const listed = execSync('git worktree list --porcelain', { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' });
+  const want = wtPath.replace(/\\/g, '/');
+  return listed.split('\n').filter(l => l.startsWith('worktree '))
+    .map(l => l.replace('worktree ', '').trim().replace(/\\/g, '/'))
+    .some(rp => rp === want);
+};
+
+// Foundation 1: an existing, content-bearing, UNREGISTERED dir at the worktree
+// path is not a registered worktree (this is the orphan-husk state the fix triggers on).
+test('orphan husk: a content dir at the worktree path is not git-registered', () => {
+  const repo = createFixtureRepo();
+  try {
+    const wtPath = join(repo, '.worktrees', 'SD-HUSK-001');
+    mkdirSync(wtPath, { recursive: true });
+    writeFileSync(join(wtPath, 'leftover.txt'), 'husk residue'); // simulate locked-husk residue
+    assert.equal(isRegistered(repo, wtPath), false, 'husk dir must NOT be a registered worktree');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// Foundation 2: `git worktree add --force <existing-EMPTY-dir> <branch>` recovers
+// the husk and re-registers + repopulates it. The real repro is an EMPTY locked
+// dir (a reaper deleted the contents but a cwd-handle left the dir undeletable);
+// writes into that empty dir succeed even when delete/rename is blocked.
+test('orphan husk: git worktree add --force adopts an existing empty unregistered dir', () => {
+  const repo = createFixtureRepo();
+  try {
+    execSync('git branch feat/SD-HUSK-001', { cwd: repo, stdio: 'pipe' });
+    const wtPath = join(repo, '.worktrees', 'SD-HUSK-001');
+    mkdirSync(wtPath, { recursive: true }); // empty husk (reaper-deleted contents)
+    assert.equal(isRegistered(repo, wtPath), false, 'precondition: husk not registered');
+
+    // The recovery the fix performs: prune (stale registration) then --force adopt.
+    execSync(`git worktree prune`, { cwd: repo, stdio: 'pipe' });
+    execSync(`git worktree add --force "${wtPath}" feat/SD-HUSK-001`, { cwd: repo, stdio: 'pipe' });
+
+    assert.equal(isRegistered(repo, wtPath), true, 'husk must be registered after --force recovery');
+    assert.ok(existsSync(join(wtPath, 'README.md')), 'worktree must be repopulated (branch content present)');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// Foundation 3: --force -b path recovers an empty husk when the branch is absent.
+test('orphan husk: git worktree add --force -b recovers when branch is absent', () => {
+  const repo = createFixtureRepo();
+  try {
+    const wtPath = join(repo, '.worktrees', 'SD-HUSK-002');
+    mkdirSync(wtPath, { recursive: true }); // empty husk
+    execSync(`git worktree add --force -b feat/SD-HUSK-002 "${wtPath}" HEAD`, { cwd: repo, stdio: 'pipe' });
+    assert.equal(isRegistered(repo, wtPath), true, 'husk must be registered after --force -b recovery');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## SD-FDBK-ENH-START-LEAVES-LOCKED-001 — self-recover orphan/locked worktree husk

**Problem:** `sd-start` (resolve-sd-workdir.js) refused when `.worktrees/<SD>` existed but was unregistered (orphan/locked husk — a reaper removed the git registration but a process cwd-handle left the empty dir locked, so rm/rename fail "in use"), auto-releasing the claim and **permanently stranding the SD**. Witnessed live this session on SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001.

**Fix (`scripts/resolve-sd-workdir.js`):** `createWorktree` now self-recovers before refusing via new `recoverOrphanWorktree()`:
- `git worktree prune` (stale-registration case), then
- `git worktree add --force` / `--force -b` (locked **empty**-husk case — writes into the dir succeed even when delete is blocked), under the existing cross-process worktree lock.

Recovery is additive (only the previously-fatal orphan-husk branch); the refusal error now names the locked-cwd-handle cause + remediation when recovery is impossible.

**Tests:** `tests/unit/resolve-sd-workdir/orphan-husk-recovery.test.js` (3/3); existing `worktree-atomicity.test.js` still 9/9 (no regression).

> Note: `--force` adopts an EMPTY existing dir (the real repro), not a non-empty one — the test fixtures and risk notes reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
