### PR TITLE
fix(SD-FDBK-ENH-S17-PARITY-TEST-001): set required decision_type on s17-parity chairman_decisions inserts

### DIFF
--- a/tests/integration/s17-parity.test.js
+++ b/tests/integration/s17-parity.test.js
@@ -165,19 +165,28 @@ describe('S17 Parity: CLI vs Frontend venture state', () => {
       lifecycle_stage: 17,
       status: 'approved',
       decision: 'proceed',
+      // SD-FDBK-ENH-S17-PARITY-TEST-001: decision_type is NOT NULL with no default;
+      // omitting it made BOTH inserts fail silently (23502), surfacing later as a
+      // misleading null-row assertion. 'stage_gate' matches the producer contract
+      // (lib/eva/chairman-decision-watcher.js) for an S17 doc-generation gate.
+      decision_type: 'stage_gate',
       summary: 'S17: Doc generation gate approved',
     };
 
-    await supabase.from('chairman_decisions').insert({
+    // Surface insert errors at the insert site (was silently discarded → null-row failures).
+    const { error: cliDecErr } = await supabase.from('chairman_decisions').insert({
       ...decisionBase,
       venture_id: cliVentureId,
       brief_data: { source: 'cli', problem_statement: FIXTURE.problem_statement },
     });
-    await supabase.from('chairman_decisions').insert({
+    expect(cliDecErr, `CLI chairman_decisions insert failed: ${cliDecErr?.message}`).toBeNull();
+
+    const { error: feDecErr } = await supabase.from('chairman_decisions').insert({
       ...decisionBase,
       venture_id: frontendVentureId,
       brief_data: { source: 'frontend', problem_statement: FIXTURE.problem_statement },
     });
+    expect(feDecErr, `Frontend chairman_decisions insert failed: ${feDecErr?.message}`).toBeNull();
 
     const { data: cliDec } = await supabase
       .from('chairman_decisions')


### PR DESCRIPTION
## SD-FDBK-ENH-S17-PARITY-TEST-001 — fix deterministic s17-parity chairman_decisions failure

### Problem
`tests/integration/s17-parity.test.js` → "chairman_decisions records match structure" failed deterministically (*expected null to be truthy*). **Root cause (rca-agent, 0.99):** `decisionBase` omitted `decision_type` — a `NOT NULL` column with no default — so **both** chairman_decisions inserts failed silently (`23502`) and the `.single()` queries returned null; the test discarded the insert `{error}`, surfacing as a misleading null-row assertion ~20 lines later (which line tripped varied with stale `parity-test-*` rows, looking like an asymmetry). Not a trigger, not the `decision` CHECK (allows `'proceed'`), not a real asymmetry.

### Fix (test-only, single file)
- Add `decision_type: 'stage_gate'` to `decisionBase` (matches the producer contract in `lib/eva/chairman-decision-watcher.js` for an S17 doc-generation gate).
- **Assert the insert `{error}`** on both inserts, so a future silent failure fails at the insert site with a descriptive message.
- Did **not** weaken the `decision_type NOT NULL` constraint (intentional `stage_gate`/`review`/`advisory` discriminator, SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001).

Full `s17-parity` db suite now **4/4** (was 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
