### PR TITLE
fix(SD-FDBK-ENH-CLAIM-SWEEP-REAPS-001): in-flight claim protection default-ON for Task/Agent

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce-inflight-default-on.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce-inflight-default-on.test.js
@@ -1,0 +1,49 @@
+/**
+ * SD-FDBK-ENH-CLAIM-SWEEP-REAPS-001
+ *
+ * The ENFORCEMENT-10 in-flight telemetry writer in pre-tool-enforce.cjs used to AWAIT
+ * the expected_silence_until persist ONLY when the opt-IN env var
+ * SWEEP_RESPECT_INFLIGHT_AGENT=1 was set. That env var is NOT deployed in pre-deploy
+ * worker settings, so expected_silence_until stayed NULL during long Task/Agent
+ * sub-agent runs and cleanup_stale_sessions reaped ACTIVE in-flight claims
+ * (e.g. worker ec3f9fbd swept mid-PLAN). The consumer flag
+ * (chairman_dashboard_config.sweep_respect_inflight_agent) is live=true, so the writer
+ * now AWAITs by DEFAULT for Task/Agent dispatches (opt-OUT via SWEEP_RESPECT_INFLIGHT_AGENT=0).
+ *
+ * Static source-assertion test (the established pattern for this hook — the hook runs
+ * main() on require, so behavioral execution is impractical here). Pins the default-ON
+ * opt-OUT contract so a future edit cannot silently revert to opt-IN.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HOOK_SRC = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'pre-tool-enforce.cjs'),
+  'utf8'
+);
+
+test('in-flight writer is opt-OUT (default-ON) for Task/Agent, not opt-IN', () => {
+  // The disable predicate must check for the OFF values (opt-OUT), not the ON values.
+  assert.match(
+    HOOK_SRC,
+    /_respectInflightDisabled\s*=\s*process\.env\.SWEEP_RESPECT_INFLIGHT_AGENT\s*===\s*'0'/,
+    'expected an opt-OUT gate keyed on SWEEP_RESPECT_INFLIGHT_AGENT === "0"'
+  );
+  // The await branch fires when NOT disabled (default-ON).
+  assert.match(
+    HOOK_SRC,
+    /if\s*\(\s*!_respectInflightDisabled\s*&&\s*silenceMs\s*!==\s*null\s*&&\s*\(TOOL_NAME\s*===\s*'Task'\s*\|\|\s*TOOL_NAME\s*===\s*'Agent'\)\s*\)/,
+    'expected the awaited write to default ON for Task/Agent unless explicitly disabled'
+  );
+  // It must still AWAIT the durable write (so ESU persists before process.exit).
+  assert.match(HOOK_SRC, /await\s+writeTelemetryAwait\(_sessId,\s*patch\)/, 'expected awaited durable write');
+  // The old opt-IN gate must be gone (no `=== '1'` enabling gate on this var).
+  assert.doesNotMatch(
+    HOOK_SRC,
+    /_respectInflight\s*=\s*process\.env\.SWEEP_RESPECT_INFLIGHT_AGENT\s*===\s*'1'/,
+    'old opt-IN gate must be removed'
+  );
+});

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1235,17 +1235,23 @@ async function main() {
       }
       if (kind) patch.last_activity_kind = kind;
 
-      // SD-FDBK-INFRA-CLAIM-SWEEP-LIVENESS-001 FR-1 (default-OFF flag SWEEP_RESPECT_INFLIGHT_AGENT):
-      // On a long Task/Agent dispatch, AWAIT the telemetry write so expected_silence_until
-      // actually persists before the ALLOW-path process.exit(0) below. Otherwise the
-      // fire-and-forget PATCH is killed mid-flight (the smoking gun: expected_silence_until
-      // stays NULL during a 15-19min sub-agent run) and the stale-session-sweep /
-      // cleanup_stale_sessions STALE_UNKNOWN-release the session mid-run. Scoped to
-      // Task/Agent only (not every tool) to bound per-call latency; fail-open. Default OFF
-      // => byte-identical fire-and-forget behaviour (no exit-timing change for any tool).
-      const _respectInflight = process.env.SWEEP_RESPECT_INFLIGHT_AGENT === '1'
-        || process.env.SWEEP_RESPECT_INFLIGHT_AGENT === 'true';
-      if (_respectInflight && silenceMs !== null && (TOOL_NAME === 'Task' || TOOL_NAME === 'Agent')) {
+      // SD-FDBK-INFRA-CLAIM-SWEEP-LIVENESS-001 FR-1: on a long Task/Agent dispatch, AWAIT
+      // the telemetry write so expected_silence_until actually persists before the ALLOW-path
+      // process.exit(0) below. Otherwise the fire-and-forget PATCH is killed mid-flight
+      // (the smoking gun: expected_silence_until stays NULL during a 15-19min sub-agent run)
+      // and the stale-session-sweep / cleanup_stale_sessions STALE-release the session mid-run.
+      //
+      // SD-FDBK-ENH-CLAIM-SWEEP-REAPS-001: the original opt-IN env gate (SWEEP_RESPECT_INFLIGHT_AGENT=1)
+      // is NOT deployed in pre-deploy worker settings, so the writer never fired and ACTIVE
+      // in-flight claims were still reaped (worker ec3f9fbd swept mid-PLAN). The CONSUMER side
+      // (chairman_dashboard_config.sweep_respect_inflight_agent) is now live=true and the feature
+      // is proven, so complete the writer side: AWAIT by DEFAULT for Task/Agent dispatches
+      // (opt-OUT via SWEEP_RESPECT_INFLIGHT_AGENT=0/false). Scoped to Task/Agent only — they are
+      // already long operations, so the single awaited PATCH adds negligible latency. Fail-open
+      // preserved; non-Task/Agent tools keep byte-identical fire-and-forget behaviour.
+      const _respectInflightDisabled = process.env.SWEEP_RESPECT_INFLIGHT_AGENT === '0'
+        || process.env.SWEEP_RESPECT_INFLIGHT_AGENT === 'false';
+      if (!_respectInflightDisabled && silenceMs !== null && (TOOL_NAME === 'Task' || TOOL_NAME === 'Agent')) {
         try { await writeTelemetryAwait(_sessId, patch); } catch { /* fail-open: never block enforcement */ }
       } else {
         writeTelemetry(_sessId, patch);


### PR DESCRIPTION
## SD-FDBK-ENH-CLAIM-SWEEP-REAPS-001 — in-flight claim protection default-ON

**Problem:** `cleanup_stale_sessions` reaped **ACTIVE** in-flight claims mid-sub-agent (worker ec3f9fbd swept mid-PLAN) despite SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 enabling the consumer flag (`chairman_dashboard_config.sweep_respect_inflight_agent=true`).

**Root cause:** the WRITER in `pre-tool-enforce.cjs` ENFORCEMENT-10 that AWAIT-persists `expected_silence_until` on Task/Agent dispatch was gated **opt-IN** on env `SWEEP_RESPECT_INFLIGHT_AGENT=1` — which is **not deployed** in pre-deploy worker settings. So `expected_silence_until` stayed NULL and the sweep had no in-flight marker to respect.

**Fix:** flip the writer gate **opt-IN → opt-OUT** (default-ON for Task/Agent; disable via `SWEEP_RESPECT_INFLIGHT_AGENT=0`), completing the writer side now that the consumer is live + proven. Fail-open preserved; non-Task/Agent tools keep byte-identical fire-and-forget. Static source-assertion test pins the opt-OUT contract (1/1).

> Scope: fixes the Task/Agent-run reap case. The idle-gap case (no Task/Agent to trigger the writer) is out of scope (FLEET-WORKER-ATTRITION-001). 3rd of 3 claim-sweep SDs this session (after ISSUE-PATTERNS-CLOSURE + START-LEAVES-LOCKED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
