### PR TITLE
feat(SD-FDBK-ENH-FLEET-WORKER-ATTRITION-001): default-OFF Stop hook + wake-prompt mandate to prevent /loop idle-gap stall

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -204,6 +204,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-completion-tail-enforcement.cjs",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/stop-loop-wakeup-reminder.cjs",
+            "timeout": 10
           }
         ]
       }

--- a/docs/protocol/coordinator-worker-revival.md
+++ b/docs/protocol/coordinator-worker-revival.md
@@ -165,3 +165,21 @@ No spawn-execution layer consumes `worker_spawn_requests` on this host, so reviv
 - **Alert:** on a match, ONE de-duped `session_coordination` row (`message_type=INFO`, `payload.kind=inert_worker_alert`, `target_session=broadcast-coordinator`, 24h expiry) carries the paste-able fleet-worker `/loop` startup prompt — the only path that restores capacity today. De-dup skips while an unacknowledged, unexpired alert exists.
 - **Scope:** detection + operator surfacing only. Building the spawn-execution daemon remains out of scope (see above).
 
+## Idle-Gap Stall Prevention — always arm a ScheduleWakeup
+
+**SD**: `SD-FDBK-ENH-FLEET-WORKER-ATTRITION-001` (attrition cause #4)
+
+Revival (above) is the *cure* for an exited worker. The idle-gap stall is the *cause* of the most common silent exit: an autonomous `/loop` only re-fires on a `ScheduleWakeup` tick (or a human message), so a worker that **ends a turn at an idle/decision point without arming a `ScheduleWakeup` goes silent indefinitely** — it still shows `claude_sessions.loop_state='active'` (phantom-active) but never wakes, and its idle worktree is then reaped by the claim-sweep. The most common trigger is emitting a bare `/compact` and stopping (a worker cannot self-invoke `/compact`, so this just ends the turn with no wakeup armed).
+
+### The mandate (worker-loop guidance)
+- **Arm a `ScheduleWakeup` at the END of EVERY iteration** — short delay when work is in-flight, ~20min when idle — **not only** in the no-workable-SD branch. The canonical paste-able wake-prompt (`FLEET_WORKER_STARTUP_PROMPT` in `lib/coordinator/coordination-events.cjs`) states this.
+- **Never emit a bare `/compact` and stop.** If context is heavy, the harness auto-summarizes (just continue) or invoke the `/context-compact` skill and keep going.
+- **To END the loop on purpose**, set `claude_sessions.loop_state='exited'` for your session, then stop. That is the legitimate, non-stall exit.
+
+### Enforcement hook (default-OFF)
+`scripts/hooks/stop-loop-wakeup-reminder.cjs` (Stop hook, gated by `LEO_LOOP_WAKEUP_REMINDER`, default off) detects a `/loop` worker ending a turn with `loop_state='active'` (no wakeup armed) and **blocks the stop once** with a reminder to arm a `ScheduleWakeup` or set `loop_state='exited'`.
+
+- **State signal:** relies on `loop_state` (`loop-state-tracker.cjs`) — `awaiting_tick` means a wakeup IS armed (no reminder); `active` means mid-iteration with none armed (reminder fires); `exited`/null are never reminded.
+- **Anti-infinite-loop:** never blocks when `stop_hook_active` is already true (the worker saw the reminder once and chose to stop) — it yields on the second pass.
+- **Fail-open:** any error, unresolvable session, or DB-unavailable condition allows the stop (the hook never traps a worker). Default-OFF means the wiring is a runtime no-op until an operator sets the flag.
+

--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -233,7 +233,8 @@ const FLEET_WORKER_STARTUP_PROMPT = [
   '3) Drive it LEAD->PLAN->EXEC via "node scripts/handoff.js execute <PHASE> <SD-KEY>"; invoke the required sub-agents (Task tool) before each handoff so fresh evidence exists.',
   '4) Re-affirm your claim (re-run sd-start, idempotent) after long sub-agent runs and before each handoff.',
   '5) Route any blocker to the coordinator via "node scripts/worker-signal.cjs <type> <msg>"; never stop for the human.',
-  '6) ScheduleWakeup at the end of each pass to stay alive. NEVER run /coordinator stop.',
+  '6) MANDATORY: ScheduleWakeup at the END of EVERY pass (short delay if work is in-flight, ~20min if idle) — NOT only when no SD is workable. A /loop only re-fires on a wakeup tick, so ending a pass without one = SILENT incognito (the #1 attrition cause; your idle worktree then gets reaped by the claim-sweep). Do NOT emit a bare /compact and stop.',
+  '7) To END the loop on purpose, set claude_sessions.loop_state to exited for your session, then stop. NEVER run /coordinator stop.',
 ].join('\n');
 
 /** Build the inert-worker detector input from the live DB. READ-ONLY, fail-soft. */

--- a/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
+++ b/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
@@ -1,0 +1,96 @@
+// Tests for SD-FDBK-ENH-FLEET-WORKER-ATTRITION-001 — stop-loop-wakeup-reminder.cjs
+// shouldRemind() is the pure decision: block-and-remind ONLY when the reminder is enabled,
+// the /loop worker is mid-iteration with no wakeup armed (loop_state='active'), and we have
+// not already reminded this turn (stop_hook_active false). The hook wrapper is fail-open.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const HOOK_PATH = path.resolve(__dirname, '../stop-loop-wakeup-reminder.cjs');
+const { shouldRemind, isFlagEnabled } = require(HOOK_PATH); // require.main guard → main() does NOT run
+
+describe('stop-loop-wakeup-reminder — shouldRemind (pure)', () => {
+  it('TS-1: returns false when the flag is disabled, even for an active /loop worker', () => {
+    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: false })).toBe(false);
+  });
+
+  it('TS-2: returns true when enabled, loop_state=active, and first stop (no wakeup armed)', () => {
+    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true })).toBe(true);
+  });
+
+  it('TS-3: returns false when a wakeup is already armed (loop_state=awaiting_tick)', () => {
+    expect(shouldRemind({ loopState: 'awaiting_tick', stopHookActive: false, flagEnabled: true })).toBe(false);
+  });
+
+  it('TS-4: returns false on the second pass (stop_hook_active true) — never block twice', () => {
+    expect(shouldRemind({ loopState: 'active', stopHookActive: true, flagEnabled: true })).toBe(false);
+  });
+
+  it('TS-5: returns false for exited / null / unknown loop_state (escape + non-loop sessions)', () => {
+    expect(shouldRemind({ loopState: 'exited', stopHookActive: false, flagEnabled: true })).toBe(false);
+    expect(shouldRemind({ loopState: null, stopHookActive: false, flagEnabled: true })).toBe(false);
+    expect(shouldRemind({ loopState: undefined, stopHookActive: false, flagEnabled: true })).toBe(false);
+    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true })).toBe(false);
+  });
+});
+
+describe('stop-loop-wakeup-reminder — isFlagEnabled (env)', () => {
+  const orig = process.env.LEO_LOOP_WAKEUP_REMINDER;
+  const restore = () => { if (orig === undefined) delete process.env.LEO_LOOP_WAKEUP_REMINDER; else process.env.LEO_LOOP_WAKEUP_REMINDER = orig; };
+
+  it('defaults OFF when unset', () => {
+    delete process.env.LEO_LOOP_WAKEUP_REMINDER;
+    expect(isFlagEnabled()).toBe(false);
+    restore();
+  });
+
+  it('is ON for on / 1 / true (case-insensitive)', () => {
+    for (const v of ['on', '1', 'true', 'ON', 'True']) {
+      process.env.LEO_LOOP_WAKEUP_REMINDER = v;
+      expect(isFlagEnabled()).toBe(true);
+    }
+    restore();
+  });
+
+  it('is OFF for off / 0 / false / garbage', () => {
+    for (const v of ['off', '0', 'false', 'maybe', '']) {
+      process.env.LEO_LOOP_WAKEUP_REMINDER = v;
+      expect(isFlagEnabled()).toBe(false);
+    }
+    restore();
+  });
+});
+
+describe('stop-loop-wakeup-reminder — wrapper fail-open (TS-6, spawn)', () => {
+  function runHook(stdinPayload, env = {}) {
+    const { spawnSync } = require('node:child_process');
+    const r = spawnSync('node', [HOOK_PATH], {
+      input: typeof stdinPayload === 'string' ? stdinPayload : JSON.stringify(stdinPayload),
+      env: { ...process.env, ...env },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    return r;
+  }
+
+  it('flag OFF → exits 0 and emits no block decision (allows stop)', () => {
+    const r = runHook({ stop_hook_active: false, session_id: 'nonexistent' }, { LEO_LOOP_WAKEUP_REMINDER: 'off' });
+    expect(r.status).toBe(0);
+    expect(r.stdout || '').not.toMatch(/"decision"\s*:\s*"block"/);
+  });
+
+  it('flag ON but stop_hook_active=true → exits 0, no block (never block twice)', () => {
+    const r = runHook({ stop_hook_active: true, session_id: 'nonexistent' }, { LEO_LOOP_WAKEUP_REMINDER: 'on' });
+    expect(r.status).toBe(0);
+    expect(r.stdout || '').not.toMatch(/"decision"\s*:\s*"block"/);
+  });
+
+  it('flag ON but unparseable stdin → exits 0 (fail-open, never throws/hangs)', () => {
+    // Force no resolvable session id so the wrapper fail-opens without touching the DB (hermetic).
+    const r = runHook('not-json-at-all', { LEO_LOOP_WAKEUP_REMINDER: 'on', CLAUDE_SESSION_ID: '', SESSION_ID: '' });
+    expect(r.status).toBe(0);
+    expect(r.stdout || '').not.toMatch(/"decision"\s*:\s*"block"/);
+  });
+});

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Stop hook — remind an autonomous /loop worker to arm a ScheduleWakeup before it
+ * ends a turn and goes silently incognito (fleet-worker attrition cause #4: idle-gap stall).
+ *
+ * SD: SD-FDBK-ENH-FLEET-WORKER-ATTRITION-001
+ *
+ * The loop-state machine (loop-state-tracker.cjs) marks a /loop worker:
+ *   - 'awaiting_tick' once it arms a ScheduleWakeup (post-tool-loop-state.cjs), or
+ *   - 'active' while it is mid-iteration (set by session-register.cjs when a wakeup fires).
+ * A worker that ENDS a turn while still 'active' has NOT armed a wakeup → the /loop never
+ * re-fires → it goes silent indefinitely and the idle worktree is reaped by the claim-sweep.
+ *
+ * When the session's loop_state is 'active' at Stop (and this is the FIRST stop this turn),
+ * this hook BLOCKS the stop once with a reminder to arm a ScheduleWakeup (short delay if work
+ * is in-flight, ~20min if idle) or set loop_state='exited' to legitimately end the loop.
+ *
+ * SAFETY:
+ *   - Flag-gated: LEO_LOOP_WAKEUP_REMINDER (default off) → fast no-op (allow stop).
+ *   - Anti-infinite-loop: never blocks when stop_hook_active is already true (the worker saw
+ *     the reminder once and chose to stop) — respects the worker, prevents a block loop.
+ *   - Escape: loop_state='exited' (or any non-'active' state) → never blocks.
+ *   - Fail-open: any error / no session / DB-unavailable → allow stop (exit 0), never throws.
+ */
+
+const { LOOP_STATE_ACTIVE } = require('../lib/sessions/loop-state-tracker.cjs');
+
+/**
+ * Pure decision: should the Stop hook block-and-remind this turn?
+ * Block ONLY when the reminder is enabled AND this is a /loop worker mid-iteration
+ * ('active' = no wakeup armed) AND we have not already reminded this turn.
+ * @param {{ loopState: string|null|undefined, stopHookActive: boolean, flagEnabled: boolean }} args
+ * @returns {boolean}
+ */
+function shouldRemind({ loopState, stopHookActive, flagEnabled }) {
+  if (!flagEnabled) return false;          // default-OFF: no-op
+  if (stopHookActive) return false;        // never block twice — worker already saw the reminder
+  return loopState === LOOP_STATE_ACTIVE;  // only 'active' (no wakeup armed); 'awaiting_tick'/'exited'/null are fine
+}
+
+function isFlagEnabled() {
+  const v = (process.env.LEO_LOOP_WAKEUP_REMINDER || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+const REMINDER = [
+  '/loop worker stopping with NO ScheduleWakeup armed (loop_state=active) — you will go INCOGNITO.',
+  'An autonomous /loop only re-fires on a ScheduleWakeup tick; ending the turn now strands your claimed SD',
+  'and your worktree gets reaped by the claim-sweep. Before you stop:',
+  '  • arm a ScheduleWakeup (short delay if work is in-flight, ~20min if idle), OR',
+  "  • if you intend to END the loop, set claude_sessions.loop_state='exited' for your session.",
+  '(This reminder fires once — if you stop again it will let you through.)',
+].join('\n');
+
+/** Read+parse the Stop-hook stdin payload once; resolve {} on any error/timeout. */
+function readStdinPayload(timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    let data = '';
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      try { resolve(JSON.parse(data || '{}')); } catch { resolve({}); }
+    };
+    try {
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', (c) => { data += c; });
+      process.stdin.on('end', finish);
+      process.stdin.on('error', () => { if (!settled) { settled = true; resolve({}); } });
+      setTimeout(finish, timeoutMs);
+    } catch { resolve({}); }
+  });
+}
+
+async function main() {
+  try {
+    const flagEnabled = isFlagEnabled();
+    if (!flagEnabled) { process.exit(0); }            // default-OFF fast path
+
+    const payload = await readStdinPayload();
+    const stopHookActive = payload.stop_hook_active === true;
+    if (stopHookActive) { process.exit(0); }          // already reminded — let it stop
+
+    const sessionId = payload.session_id || process.env.CLAUDE_SESSION_ID || process.env.SESSION_ID || '';
+    if (!sessionId) { process.exit(0); }              // can't resolve — fail-open
+
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    const supabase = createSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('loop_state')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) { process.exit(0); }                   // DB error — fail-open
+
+    const loopState = data ? data.loop_state : null;
+    if (shouldRemind({ loopState, stopHookActive, flagEnabled })) {
+      process.stdout.write(JSON.stringify({ decision: 'block', reason: REMINDER }));
+    }
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write(`[stop-loop-wakeup-reminder] ${e.message}\n`);
+    process.exit(0);                                  // fail-open: never trap a worker
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { shouldRemind, isFlagEnabled };


### PR DESCRIPTION
## Summary
Fleet-worker attrition cause #4 (idle-gap stall): an autonomous `/loop` only re-fires on a `ScheduleWakeup` tick, so a worker that ends a turn without arming one goes **silent** — `claude_sessions.loop_state` stays `'active'` (phantom-active) but never wakes, and the idle worktree is reaped by the claim-sweep. Most common trigger: emitting a bare `/compact` and stopping.

## Fix (5 files, +232/-1)
- **NEW `scripts/hooks/stop-loop-wakeup-reminder.cjs`** — Stop hook, **default-OFF** via `LEO_LOOP_WAKEUP_REMINDER`. When `loop_state='active'` at Stop (no wakeup armed) it **blocks the stop once** with a reminder to arm a `ScheduleWakeup` or set `loop_state='exited'`. Pure `shouldRemind()` + fail-open wrapper + `stop_hook_active` anti-infinite-loop guard + `require.main` test guard.
- Wired into `.claude/settings.json` Stop array (flag-gated → default-OFF runtime no-op).
- Strengthened the canonical `FLEET_WORKER_STARTUP_PROMPT` (`lib/coordinator/coordination-events.cjs`): mandate `ScheduleWakeup` at EVERY pass end (not only the no-work branch) + `loop_state=exited` escape + do-not-bare-`/compact`-and-stop.
- Documented the prevention in `docs/protocol/coordinator-worker-revival.md`.

## Safety
- **Cannot trap a worker** (SECURITY 95): double guard (`stop_hook_active` + `shouldRemind`), `loop_state='exited'`/null escape, fail-open on every error path, default-OFF.
- **+11 unit tests** (TESTING 94); gates EXEC-TO-PLAN 92 / PLAN-TO-LEAD 93; retro q=100.

## Note
Dogfooded — this fixes the exact failure mode the author's own `/loop` hit this session (diagnosed at session start, fix demonstrated by a wakeup that re-fired cleanly). Verify-before-build corrected the PRD's doc targets to the real artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)