### PR TITLE
fix(SD-FDBK-ENH-VENTURE-STAGE-TRANSITIONS-001): map advancementType to a valid transition_type

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -38,6 +38,7 @@ import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
 import { shouldOpenChairmanGate } from './should-open-chairman-gate.js';
+import { toValidTransitionType } from './transition-type.js';
 // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single pure bridge-outcome classifier + S19
 // hold/advance decision shared by every S19 gate consumer (closes RCA 7610876f schism).
 import { classifyBridgeOutcome, shouldHoldAtS19, S19_BRIDGE_OUTCOME } from './bridge/s19-advance-decision.js';
@@ -2431,7 +2432,7 @@ export class StageExecutionWorker {
             venture_id: ventureId,
             from_stage: fromStage,
             to_stage: toStage,
-            transition_type: advancementType === 'governance_override' ? 'governance_override' : 'normal',
+            transition_type: toValidTransitionType(advancementType),
           });
         if (insertErr) throw insertErr;
       } catch (insertErr) {

--- a/lib/eva/transition-type.js
+++ b/lib/eva/transition-type.js
@@ -1,0 +1,32 @@
+/**
+ * transition-type — map an internal stage-advancement type to a
+ * venture_stage_transitions.transition_type value allowed by the
+ * venture_stage_transitions_transition_type_check constraint.
+ *
+ * SD-FDBK-ENH-VENTURE-STAGE-TRANSITIONS-001: stage-execution-worker._advanceStage
+ * previously wrote the literal advancementType (e.g. 'governance_override') into
+ * venture_stage_transitions.transition_type, violating the CHECK constraint. Supabase v2
+ * returns that error non-fatally, so the advance proceeded but the audit transition row
+ * was silently dropped (DataDistill 510177ba missing S15->16, S18->19, S22->23). The
+ * precise advancementType is still preserved in venture_stage_work.advisory_data.advancement_type.
+ *
+ * Pure + dependency-free so it can be unit-tested in isolation.
+ */
+
+/** Values permitted by the venture_stage_transitions_transition_type_check constraint. */
+export const VALID_TRANSITION_TYPES = ['normal', 'skip', 'rollback', 'pivot'];
+
+/**
+ * @param {string} advancementType - internal advance type (normal, governance_override,
+ *   auto_approved, re_entry, pre_exec_skip, pre_exec_skip_trigger, s19_bridge_cleared, ...)
+ * @returns {'normal'|'skip'|'rollback'|'pivot'} a constraint-valid transition_type
+ */
+export function toValidTransitionType(advancementType) {
+  // governance_override force-advances past a BLOCKED gate — semantically a skip.
+  if (advancementType === 'governance_override') return 'skip';
+  // An advancementType that is already a valid enum value passes through unchanged.
+  if (VALID_TRANSITION_TYPES.includes(advancementType)) return advancementType;
+  // Any other internal advancement type maps to 'normal' so the CHECK constraint
+  // can never be violated again, even if new advancement types are added.
+  return 'normal';
+}

--- a/lib/eva/transition-type.test.js
+++ b/lib/eva/transition-type.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { toValidTransitionType, VALID_TRANSITION_TYPES } from './transition-type.js';
+
+/**
+ * SD-FDBK-ENH-VENTURE-STAGE-TRANSITIONS-001
+ * Regression guard: governance_override advances used to write
+ * transition_type='governance_override', violating the
+ * venture_stage_transitions_transition_type_check constraint so the audit row was
+ * silently dropped. toValidTransitionType maps every internal advancementType to a
+ * value the CHECK constraint accepts.
+ */
+describe('toValidTransitionType (SD-FDBK-ENH-VENTURE-STAGE-TRANSITIONS-001)', () => {
+  it('maps governance_override to a valid enum (skip), not the literal value', () => {
+    expect(toValidTransitionType('governance_override')).toBe('skip');
+  });
+
+  it('keeps normal as normal', () => {
+    expect(toValidTransitionType('normal')).toBe('normal');
+  });
+
+  it('maps non-enum internal advancement types to normal', () => {
+    for (const t of ['auto_approved', 're_entry', 'pre_exec_skip', 'pre_exec_skip_trigger', 's19_bridge_cleared']) {
+      expect(toValidTransitionType(t)).toBe('normal');
+    }
+  });
+
+  it('passes through values that are already valid enum members', () => {
+    expect(toValidTransitionType('skip')).toBe('skip');
+    expect(toValidTransitionType('rollback')).toBe('rollback');
+    expect(toValidTransitionType('pivot')).toBe('pivot');
+  });
+
+  it('defaults unknown / nullish input to normal', () => {
+    expect(toValidTransitionType('something_new')).toBe('normal');
+    expect(toValidTransitionType(undefined)).toBe('normal');
+    expect(toValidTransitionType(null)).toBe('normal');
+    expect(toValidTransitionType('')).toBe('normal');
+  });
+
+  it('always returns a constraint-valid transition_type', () => {
+    const inputs = ['governance_override', 'normal', 'auto_approved', 're_entry', 'pre_exec_skip', 'skip', 'rollback', 'pivot', 'xyz', undefined];
+    for (const i of inputs) {
+      expect(VALID_TRANSITION_TYPES).toContain(toValidTransitionType(i));
+    }
+  });
+});


### PR DESCRIPTION
## SD-FDBK-ENH-VENTURE-STAGE-TRANSITIONS-001

`_advanceStage` wrote `transition_type='governance_override'` for governance-override advances, violating `venture_stage_transitions_transition_type_check` (normal|skip|rollback|pivot). Supabase v2 returns the error non-fatally, so the advance proceeded but the **audit transition row was silently dropped** (DataDistill 510177ba missing S15→16, S18→19, S22→23, each with a matching `eva_orchestration_events` `transition_record_failed` escalation).

### Changes
- **`lib/eva/transition-type.js`** (new) — pure, dependency-free `toValidTransitionType()`: `governance_override`→`skip`; valid enum values pass through; anything else→`normal` (so the CHECK can never be re-violated).
- **`lib/eva/stage-execution-worker.js`** — `_advanceStage` insert now uses the helper instead of the inline ternary.
- **`lib/eva/transition-type.test.js`** (new) — 6-case unit test.

No DB migration; advancement behavior unchanged; the precise `advancementType` is still preserved in `advisory_data.advancement_type`.

### Verification
- `node --check` both files OK; new unit test 6/6; full `lib/eva/` suite **41 files / 558 tests pass, 0 failures**.
- TESTING sub-agent CONDITIONAL_PASS (conf 90). Evidence venture: DataDistill (510177ba).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
