### PR TITLE
fix(SD-FDBK-ENH-FOLLOW-LEO-FIX-001): ship-record for ehg ventures filter fix (#688)

### DIFF
--- a/docs/ops/follow-leo-fix-ventures-filter-ship-record.md
+++ b/docs/ops/follow-leo-fix-ventures-filter-ship-record.md
@@ -1,0 +1,21 @@
+# SD-FDBK-ENH-FOLLOW-LEO-FIX-001 — Ship Record (cross-repo: EHG)
+
+Defense-in-depth follow-up to SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 (the deferred
+service-path piece). The fix lives in the **ehg** (frontend) repo; this SD is tracked in
+EHG_Engineer LEO with `metadata.target_repos = ["EHG"]`.
+
+## Shipped
+
+| PR | Repo | Change |
+|----|------|--------|
+| [#688](https://github.com/rickfelix/ehg/pull/688) | ehg | `listVentures()` (`src/services/ventures.ts`) now filters `is_demo` + `deleted_at IS NULL`; `useVentures()` (`src/hooks/useVentureData.ts`) adds an always-on `deleted_at IS NULL` (it already filtered `is_demo`). |
+
+## Verify-before-build
+
+- Confirmed on ehg `origin/main`: `listVentures()` filtered neither `is_demo` nor `deleted_at`;
+  `useVentures()` filtered `is_demo` (demo-mode) but not `deleted_at` — both leaks are real.
+- Confirmed the `ventures` table has **both** `is_demo` and `deleted_at` columns (live DB) — so the
+  added filters carry no 42703/HTTP-400 risk.
+
+Net effect: the Ventures route hides demo and soft-deleted ventures on the service path,
+regardless of demo mode.


### PR DESCRIPTION
## SD-FDBK-ENH-FOLLOW-LEO-FIX-001 — EHG_Engineer ship-record (cross-repo)

The code change ships in **ehg PR #688** (`listVentures` + `useVentures` add `is_demo` + `deleted_at` filters to hide demo/soft-deleted ventures on the Ventures-route service path). This EHG_Engineer PR carries the `docs/ops` ship-record as the LEO-side deliverable; `metadata.target_repos=[EHG,EHG_Engineer]` so PR_MERGE_VERIFICATION scans both repos.

Defense-in-depth follow-up to SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001. Both `is_demo` + `deleted_at` columns verified present on the `ventures` table (no 42703 risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
