### PR TITLE
fix(SD-FDBK-ENH-WORKTREE-REAPER-MJS-001): don't reap LIVE-claimed worktrees mid-build

### DIFF
--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -317,7 +317,29 @@ async function loadSdKeySets(supabase) {
   // quick_fixes.id holds the QF string key (e.g., 'QF-20260417-029') directly.
   try { for (const k of await paginate('quick_fixes', 'id')) qfMap.add(k); }
   catch { /* ignore */ }
-  return { sdMap, qfMap };
+
+  // SD-FDBK-ENH-WORKTREE-REAPER-MJS-001: sd_keys of SDs still being ACTIVELY worked. The
+  // shipped-stale reaper must never git-remove a live SD's worktree: a freshly sd-start-created
+  // branch has no commits yet so it reads as patch-equivalent-to-main (shipped-stale), and a
+  // heartbeat-stale claim-guard false-negative (Task/Agent sub-agents emit no heartbeat) would
+  // otherwise let the reaper remove an in-flight worktree mid-build. Best-effort: on error the
+  // set is empty and the claim-guard remains the primary defense (no over-reap, no crash).
+  const activeSdSet = new Set();
+  try {
+    const pageSize = 1000;
+    for (let start = 0; start < 20000; start += pageSize) {
+      const { data, error } = await supabase
+        .from('strategic_directives_v2')
+        .select('sd_key, status')
+        .in('status', ['draft', 'active', 'in_progress'])
+        .range(start, start + pageSize - 1);
+      if (error || !data || data.length === 0) break;
+      for (const r of data) if (r.sd_key) activeSdSet.add(r.sd_key);
+      if (data.length < pageSize) break;
+    }
+  } catch { /* best-effort */ }
+
+  return { sdMap, qfMap, activeSdSet };
 }
 
 // ── Git / Gh runners ───────────────────────────────────────────────────
@@ -397,7 +419,21 @@ async function classifyWorktree(wt, ctx) {
   } catch (e) {
     shipped = { matched: false, reason: 'error', evidence: { error: String(e?.message || e) } };
   }
-  if (shipped.matched) { categories.push('shipped-stale'); reasons['shipped-stale'] = shipped; }
+  if (shipped.matched) {
+    // SD-FDBK-ENH-WORKTREE-REAPER-MJS-001: never reap a LIVE SD's worktree as shipped-stale.
+    // The worktree dir basename is the sd_key (.worktrees/<sd_key>); if that SD is still being
+    // actively worked (draft/active/in_progress), suppress shipped-stale so the cron cannot
+    // git-remove an in-flight, not-yet-committed worktree. Legitimate cleanup of completed/
+    // cancelled SDs' worktrees is unchanged (they are not in activeSdSet). This is a SECOND
+    // defense atop the heartbeat claim-guard — either alone now protects an active worktree.
+    const sdKey = path.basename(wt.path);
+    if (ctx.activeSdSet && ctx.activeSdSet.has(sdKey)) {
+      reasons['shipped-stale-suppressed'] = { ...shipped, suppressed: true, reason: 'active-sd-protected', sd_key: sdKey };
+    } else {
+      categories.push('shipped-stale');
+      reasons['shipped-stale'] = shipped;
+    }
+  }
 
   let idle = { matched: false, reason: 'skipped', evidence: {} };
   try {
@@ -620,13 +656,13 @@ export async function main(argv = process.argv) {
   }
 
   // Load reference data (best-effort — reaper is useful even with empty maps).
-  const [claimMap, { sdMap, qfMap }] = await Promise.all([
+  const [claimMap, { sdMap, qfMap, activeSdSet }] = await Promise.all([
     loadClaimMap(supabase),
     loadSdKeySets(supabase),
   ]);
 
   const idleThresholdMs = opts.days * 24 * 60 * 60 * 1000;
-  const ctx = { repoRoot, claimMap, sdMap, qfMap, idleThresholdMs };
+  const ctx = { repoRoot, claimMap, sdMap, qfMap, activeSdSet, idleThresholdMs };
 
   const header = humanTableHeader();
   const now = Date.now();

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -292,7 +292,9 @@ async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 100
 async function loadSdKeySets(supabase) {
   const sdMap = new Set();
   const qfMap = new Set();
-  if (!supabase) return { sdMap, qfMap };
+  // SD-FDBK-ENH-WORKTREE-REAPER-MJS-001: always return activeSdSet (empty when no supabase)
+  // so callers/ctx never see it undefined.
+  if (!supabase) return { sdMap, qfMap, activeSdSet: new Set() };
 
   // Supabase defaults to 1000 rows per select even with .limit(5000). Paginate
   // explicitly with .range() to ensure the full set is loaded — otherwise

--- a/tests/unit/worktree-reaper/active-sd-shipped-stale-guard.test.js
+++ b/tests/unit/worktree-reaper/active-sd-shipped-stale-guard.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-FDBK-ENH-WORKTREE-REAPER-MJS-001 — the worktree-reaper must NOT git-remove a
+ * live-claimed (active-SD) worktree as "shipped-stale".
+ *
+ * Root cause (RCA f76fc1ec): a freshly sd-start-created branch has no commits yet, so
+ * isPatchEquivalentToMain returns matched=true (shipped-stale); combined with a
+ * heartbeat-stale claim-guard false-negative the cron git-removed in-flight worktrees
+ * mid-build. Fix = classifyWorktree suppresses shipped-stale when the worktree's SD
+ * (basename of .worktrees/<sd_key>) is in activeSdSet (status IN draft/active/in_progress).
+ *
+ * These tests FAIL against the pre-fix reaper (which always pushed 'shipped-stale').
+ */
+import { describe, test, expect, vi } from 'vitest';
+
+// Force the shipped-stale signal ON and every other category OFF so the test isolates the guard.
+vi.mock('../../../lib/worktree-reaper/detectors.js', () => ({
+  isNested: vi.fn(() => ({ matched: false })),
+  isZombieOnMain: vi.fn(() => ({ matched: false })),
+  hasOrphanSD: vi.fn(() => ({ matched: false })),
+  isPatchEquivalentToMain: vi.fn(async () => ({ matched: true, reason: 'patch_equivalent_absorbed', evidence: {} })),
+  isIdle: vi.fn(() => ({ matched: false })),
+}));
+
+import { classifyWorktree, stageForCategories, loadSdKeySets } from '../../../scripts/worktree-reaper.mjs';
+
+const baseCtx = (activeSdSet) => ({
+  repoRoot: '/repo',
+  claimMap: new Map(),
+  sdMap: new Set(),
+  qfMap: new Set(),
+  activeSdSet,
+  idleThresholdMs: 7 * 24 * 60 * 60 * 1000,
+});
+
+describe('active-SD shipped-stale guard (classifyWorktree)', () => {
+  test('SUPPRESSES shipped-stale for a worktree whose SD is active -> kept, not reaped', async () => {
+    const wt = { path: '/repo/.worktrees/SD-ACTIVE-001', branch: 'feat/SD-ACTIVE-001' };
+    const { categories, reasons } = await classifyWorktree(wt, baseCtx(new Set(['SD-ACTIVE-001'])));
+    expect(categories).not.toContain('shipped-stale');
+    expect(reasons['shipped-stale-suppressed']).toBeDefined();
+    expect(reasons['shipped-stale-suppressed'].reason).toBe('active-sd-protected');
+    expect(reasons['shipped-stale-suppressed'].sd_key).toBe('SD-ACTIVE-001');
+    expect(stageForCategories(categories).verdict).toBe('keep');
+  });
+
+  test('STILL flags shipped-stale for a worktree whose SD is NOT active -> legitimate cleanup preserved', async () => {
+    const wt = { path: '/repo/.worktrees/SD-DONE-002', branch: 'feat/SD-DONE-002' };
+    const { categories } = await classifyWorktree(wt, baseCtx(new Set(['SD-ACTIVE-001'])));
+    expect(categories).toContain('shipped-stale');
+    expect(stageForCategories(categories).verdict).toBe('stage1_remove');
+  });
+
+  test('missing/empty activeSdSet does not crash and does not suppress (claim-guard remains primary)', async () => {
+    const wt = { path: '/repo/.worktrees/SD-X-003', branch: 'feat/SD-X-003' };
+    const { categories } = await classifyWorktree(wt, baseCtx(undefined));
+    expect(categories).toContain('shipped-stale');
+    expect(stageForCategories(categories).verdict).toBe('stage1_remove');
+  });
+});
+
+describe('loadSdKeySets returns activeSdSet', () => {
+  function mockSupabase({ sdKeys = [], qfIds = [], activeRows = [] }) {
+    return {
+      from: vi.fn((table) => {
+        const builder = { _table: table, _inStatus: false };
+        builder.select = vi.fn(() => builder);
+        builder.in = vi.fn(() => { builder._inStatus = true; return builder; });
+        builder.range = vi.fn(async (start) => {
+          if (start > 0) return { data: [], error: null };
+          if (table === 'strategic_directives_v2') {
+            return builder._inStatus
+              ? { data: activeRows, error: null }
+              : { data: sdKeys.map((k) => ({ sd_key: k })), error: null };
+          }
+          if (table === 'quick_fixes') return { data: qfIds.map((id) => ({ id })), error: null };
+          return { data: [], error: null };
+        });
+        return builder;
+      }),
+    };
+  }
+
+  test('builds activeSdSet from draft/active/in_progress rows', async () => {
+    const supabase = mockSupabase({
+      sdKeys: ['SD-A', 'SD-B', 'SD-C'],
+      qfIds: ['QF-1'],
+      activeRows: [{ sd_key: 'SD-A', status: 'active' }, { sd_key: 'SD-C', status: 'draft' }],
+    });
+    const { sdMap, qfMap, activeSdSet } = await loadSdKeySets(supabase);
+    expect(sdMap.has('SD-A')).toBe(true);
+    expect(qfMap.has('QF-1')).toBe(true);
+    expect(activeSdSet.has('SD-A')).toBe(true);
+    expect(activeSdSet.has('SD-C')).toBe(true);
+    expect(activeSdSet.has('SD-B')).toBe(false); // present in sdMap but not active
+  });
+
+  test('activeSdSet is empty (no crash) when supabase is absent', async () => {
+    const { activeSdSet } = await loadSdKeySets(null);
+    expect(activeSdSet instanceof Set).toBe(true);
+    expect(activeSdSet.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/worktree-reaper.mjs` (CRON) was removing **live-claimed** worktrees mid-build (~9min after creation). Two false-positive sources:
1. Its 'shipped-stale / patch_equivalent_absorbed_without_pr' classifier flagged freshly-created-from-origin/main branches (0 commits yet → read as patch-absorbed).
2. It relied on `v_active_sessions.computed_status`, which flips `'stale'` at >600s heartbeat silence (e.g. during a no-heartbeat DATABASE sub-agent run).

## Fix (CAPA P1, no deploy needed)
worktree-reaper.mjs now **excludes worktrees whose SD status IN (draft, active, in_progress)** from the shipped-stale `stage1_remove` path, regardless of heartbeat — shipped-stale only fires for completed/cancelled SDs. SD status (the authoritative claim signal) is a second defense layered atop the heartbeat claim-guard. Confined to `scripts/worktree-reaper.mjs` (+48) + a new isolation test (+102, 5 tests).

## Tests & gates
- **5/5** unit tests (`tests/unit/worktree-reaper/active-sd-shipped-stale-guard.test.js`), verified post-merge with current main.
- Gates: EXEC-TO-PLAN accepted (prior worker) / PLAN-TO-LEAD 97; retro q=90.
- Finishing-worker note: claimed at PLAN_VERIFICATION, merged a ~7-PR-behind base up to current origin/main (3-dot diff confirmed no phantom deletions) before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)