### PR TITLE
fix(SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001): auto-validate PLAN-created draft user stories at EXEC-TO-PLAN

### DIFF
--- a/scripts/auto-validate-user-stories-on-exec-complete.js
+++ b/scripts/auto-validate-user-stories-on-exec-complete.js
@@ -36,11 +36,30 @@ async function autoValidateUserStories(sdId, sbClient) {
 
   console.log(`🔍 Checking user stories for ${sdId}...`);
 
+  // SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001: the EXEC-TO-PLAN gate passes ctx.sd.id (the UUID),
+  // but the CLI path (process.argv[2]) may pass an sd_key. user_stories.sd_id stores the UUID, so
+  // resolve an sd_key form to the UUID first — otherwise the queries below match nothing and no
+  // stories are ever auto-validated.
+  const isUuid = typeof sdId === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
+  let resolvedSdId = sdId;
+  if (sdId && !isUuid) {
+    const { data: sdRow } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('sd_key', sdId)
+      .maybeSingle();
+    if (sdRow?.id) {
+      resolvedSdId = sdRow.id;
+      console.log(`   ↳ resolved sd_key ${sdId} → ${resolvedSdId}`);
+    }
+  }
+
   // 1. Get all user stories for this SD
   const { data: stories, error: storiesError } = await supabase
     .from('user_stories')
     .select('id, title, status, validation_status')
-    .eq('sd_id', sdId);
+    .eq('sd_id', resolvedSdId);
 
   if (storiesError) {
     console.error('❌ Error fetching user stories:', storiesError.message);
@@ -56,7 +75,7 @@ async function autoValidateUserStories(sdId, sbClient) {
   const { data: deliverables, error: delError } = await supabase
     .from('sd_scope_deliverables')
     .select('deliverable_name, completion_status')
-    .eq('sd_id', sdId);
+    .eq('sd_id', resolvedSdId);
 
   if (delError) {
     console.error('❌ Error fetching deliverables:', delError.message);
@@ -71,20 +90,23 @@ async function autoValidateUserStories(sdId, sbClient) {
     return { validated: false, message: 'Deliverables incomplete' };
   }
 
-  // 2b. Promote status='ready' -> 'completed' (deliverables prove the work landed)
-  const readyStories = stories.filter(s => s.status === 'ready');
-  if (readyStories.length > 0) {
-    console.log(`📈 Promoting ${readyStories.length} ready stories to completed (deliverables done)...`);
+  // 2b. Promote status IN ('ready','draft') -> 'completed' (deliverables prove the work landed).
+  // SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001: PLAN / add-prd-to-database create user stories as
+  // status='draft'. Promoting only 'ready' left those draft stories untouched, so they failed
+  // USER_STORY_COVERAGE at EXEC-TO-PLAN and had to be hand-completed every SD. Include 'draft'.
+  const promotableStories = stories.filter(s => s.status === 'ready' || s.status === 'draft');
+  if (promotableStories.length > 0) {
+    console.log(`📈 Promoting ${promotableStories.length} ready/draft stories to completed (deliverables done)...`);
     const { error: promoteError } = await supabase
       .from('user_stories')
       .update({ status: 'completed' })
-      .eq('sd_id', sdId)
-      .eq('status', 'ready');
+      .eq('sd_id', resolvedSdId)
+      .in('status', ['ready', 'draft']);
     if (promoteError) {
-      console.error('❌ Error promoting ready->completed:', promoteError.message);
+      console.error('❌ Error promoting ready/draft->completed:', promoteError.message);
       return { validated: false, error: promoteError.message };
     }
-    readyStories.forEach(s => { s.status = 'completed'; });
+    promotableStories.forEach(s => { s.status = 'completed'; });
   }
 
   // 3. Auto-validate completed user stories (must be both completed AND pending validation)
@@ -108,7 +130,7 @@ async function autoValidateUserStories(sdId, sbClient) {
   const { data: updated, error: updateError } = await supabase
     .from('user_stories')
     .update({ validation_status: 'validated' })
-    .eq('sd_id', sdId)
+    .eq('sd_id', resolvedSdId)
     .eq('status', 'completed')
     .eq('validation_status', 'pending')
     .select('id, title, status');

--- a/tests/unit/auto-validate-user-stories-draft.test.js
+++ b/tests/unit/auto-validate-user-stories-draft.test.js
@@ -1,0 +1,91 @@
+/**
+ * SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001 (feedback d53400a5)
+ *
+ * autoValidateUserStories() had two gaps that left PLAN-created user stories stuck at
+ * EXEC-TO-PLAN (forcing a manual `update user_stories set status='completed', validation_status='validated'`):
+ *   1. It queried user_stories by sd_id and only worked when passed the SD UUID — an sd_key
+ *      (CLI path) matched nothing.
+ *   2. It only promoted status='ready' -> 'completed'; add-prd creates stories as status='draft',
+ *      so draft stories were never promoted and never auto-validated.
+ *
+ * These tests inject a mock Supabase client (the function accepts sbClient) and assert:
+ *   - an sd_key is resolved to the UUID via strategic_directives_v2 before querying;
+ *   - draft stories are included in the ready/draft -> completed promotion (.in('status',['ready','draft']))
+ *     and then validation_status -> validated.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { autoValidateUserStories } from '../../scripts/auto-validate-user-stories-on-exec-complete.js';
+
+/**
+ * Minimal chainable + awaitable mock of the supabase-js query builder.
+ * opts: { uuid, stories, deliverables }. Returns { client, recorded }.
+ */
+function makeClient(opts) {
+  const recorded = { resolvedByKey: null, promoteStatusIn: null, validateCalled: false };
+  function builder(table) {
+    const st = { table, op: 'select', updateData: null, eqs: {}, ins: {} };
+    const resolve = () => {
+      if (st.table === 'strategic_directives_v2') {
+        recorded.resolvedByKey = st.eqs.sd_key ?? null;
+        return { data: { id: opts.uuid }, error: null };
+      }
+      if (st.table === 'sd_scope_deliverables') return { data: opts.deliverables, error: null };
+      if (st.table === 'user_stories') {
+        if (st.op === 'update') {
+          if (st.updateData?.status === 'completed') recorded.promoteStatusIn = st.ins.status ?? null;
+          if (st.updateData?.validation_status === 'validated') recorded.validateCalled = true;
+          return { data: opts.stories, error: null };
+        }
+        return { data: opts.stories, error: null };
+      }
+      return { data: [], error: null };
+    };
+    const api = {
+      select() { return api; },
+      update(d) { st.op = 'update'; st.updateData = d; return api; },
+      eq(k, v) { st.eqs[k] = v; return api; },
+      in(k, arr) { st.ins[k] = arr; return api; },
+      maybeSingle() { return Promise.resolve(resolve()); },
+      then(res, rej) { return Promise.resolve(resolve()).then(res, rej); },
+    };
+    return api;
+  }
+  return { client: { from: builder }, recorded };
+}
+
+test('draft stories are promoted (ready+draft) and then validated', async () => {
+  const stories = [{ id: 's1', title: 'Story 1', status: 'draft', validation_status: 'pending' }];
+  const { client, recorded } = makeClient({
+    uuid: '11111111-1111-1111-1111-111111111111',
+    stories,
+    deliverables: [{ deliverable_name: 'd', completion_status: 'completed' }],
+  });
+  const res = await autoValidateUserStories('11111111-1111-1111-1111-111111111111', client);
+  assert.deepEqual(recorded.promoteStatusIn, ['ready', 'draft'], 'promotion must include draft, not just ready');
+  assert.equal(recorded.validateCalled, true, 'completed stories must be auto-validated');
+  assert.equal(res.validated, true);
+});
+
+test('an sd_key is resolved to the UUID before querying user_stories', async () => {
+  const stories = [{ id: 's1', title: 'Story 1', status: 'draft', validation_status: 'pending' }];
+  const { client, recorded } = makeClient({
+    uuid: '22222222-2222-2222-2222-222222222222',
+    stories,
+    deliverables: [{ deliverable_name: 'd', completion_status: 'completed' }],
+  });
+  await autoValidateUserStories('SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001', client);
+  assert.equal(recorded.resolvedByKey, 'SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001',
+    'a non-UUID sd_key must be resolved via strategic_directives_v2');
+});
+
+test('a UUID is used directly (no sd_key resolution lookup)', async () => {
+  const stories = [{ id: 's1', title: 'Story 1', status: 'ready', validation_status: 'pending' }];
+  const { client, recorded } = makeClient({
+    uuid: 'unused',
+    stories,
+    deliverables: [{ deliverable_name: 'd', completion_status: 'completed' }],
+  });
+  await autoValidateUserStories('33333333-3333-3333-3333-333333333333', client);
+  assert.equal(recorded.resolvedByKey, null, 'a UUID must not trigger an sd_key resolution lookup');
+});

--- a/tests/unit/auto-validate-user-stories-draft.test.js
+++ b/tests/unit/auto-validate-user-stories-draft.test.js
@@ -89,3 +89,44 @@ test('a UUID is used directly (no sd_key resolution lookup)', async () => {
   await autoValidateUserStories('33333333-3333-3333-3333-333333333333', client);
   assert.equal(recorded.resolvedByKey, null, 'a UUID must not trigger an sd_key resolution lookup');
 });
+
+// SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001 FR-3: regression + edge coverage (>=6 cases total).
+
+test('ready stories still promoted+validated (no regression for the original path)', async () => {
+  const stories = [{ id: 's1', title: 'Story 1', status: 'ready', validation_status: 'pending' }];
+  const { client, recorded } = makeClient({
+    uuid: '44444444-4444-4444-4444-444444444444',
+    stories,
+    deliverables: [{ deliverable_name: 'd', completion_status: 'completed' }],
+  });
+  const res = await autoValidateUserStories('44444444-4444-4444-4444-444444444444', client);
+  assert.deepEqual(recorded.promoteStatusIn, ['ready', 'draft'], 'ready stories still promoted via the widened set');
+  assert.equal(recorded.validateCalled, true);
+  assert.equal(res.validated, true);
+});
+
+test('deliverables incomplete short-circuits with no promotion or validation', async () => {
+  const stories = [{ id: 's1', title: 'Story 1', status: 'draft', validation_status: 'pending' }];
+  const { client, recorded } = makeClient({
+    uuid: '55555555-5555-5555-5555-555555555555',
+    stories,
+    deliverables: [{ deliverable_name: 'd', completion_status: 'pending' }],
+  });
+  const res = await autoValidateUserStories('55555555-5555-5555-5555-555555555555', client);
+  assert.equal(res.validated, false, 'incomplete deliverables must not validate');
+  assert.equal(res.message, 'Deliverables incomplete');
+  assert.equal(recorded.promoteStatusIn, null, 'no promotion when deliverables are incomplete');
+  assert.equal(recorded.validateCalled, false, 'no validation when deliverables are incomplete');
+});
+
+test('no user stories returns the {validated:true,count:0} contract (infra/docs SDs)', async () => {
+  const { client, recorded } = makeClient({
+    uuid: '66666666-6666-6666-6666-666666666666',
+    stories: [],
+    deliverables: [{ deliverable_name: 'd', completion_status: 'completed' }],
+  });
+  const res = await autoValidateUserStories('66666666-6666-6666-6666-666666666666', client);
+  assert.equal(res.validated, true, 'no stories is an acceptable pass for infra/docs SDs');
+  assert.equal(res.count, 0);
+  assert.equal(recorded.promoteStatusIn, null, 'nothing to promote when there are no stories');
+});


### PR DESCRIPTION
## Summary
`scripts/auto-validate-user-stories-on-exec-complete.js` (the STORY_AUTO_VALIDATION gate at EXEC-TO-PLAN) left PLAN-created user stories unvalidated, forcing **every** worker to hand-run `update user_stories set status=completed, validation_status=validated` — the single most-repeated manual gate-tax in the fleet. Two root causes:
1. The promoter only handled `status='ready'→'completed'`, but PLAN/add-prd create stories as **`status='draft'`** → drafts were never promoted/validated.
2. The function queried `.eq('sd_id', sdId)`, so a caller passing a **sd_key** (the CLI path / gate fallback) silently matched 0 rows.

## Fix (confined to one script + its test)
- Promoter widened to `.in('status', ['ready','draft'])` when all deliverables are completed, so PLAN-created draft stories reach completed+validated.
- A non-UUID `sdId` is resolved to the SD UUID via `strategic_directives_v2` before querying.
- The `{validated,count,message}` return contract is preserved for both callers (story-auto-validation.js gate, test-evidence.js).

## Tests
- **6/6** `node:test` cases (`node --test tests/unit/auto-validate-user-stories-draft.test.js`): draft+ready promotion, sd_key→UUID resolution, UUID passthrough, deliverables-incomplete short-circuit, no-stories contract.
- TESTING 94 / SECURITY 96 (no injection — parameterized; fail-closed wrong-SD; over-validation gated on deliverables-complete). Gates EXEC-TO-PLAN 94 / PLAN-TO-LEAD 97; retro q=90.

## Note
Finishing-worker pickup: the code fix was committed by a prior worker (8234091207); I verified it, added 3 tests to meet the ≥6 spec (d5ccec9709), and drove the stalled SD lifecycle to completion. Removes the #1 manual gate-tax fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)