### PR TITLE
fix(SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001): reserve parked-worker callsigns to stop fleet identity flapping

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -94,6 +94,23 @@ function dedupeAssignedCallsigns(assigned) {
   return { kept, demoted };
 }
 
+// SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001: reserve callsigns/colors held by recently-seen,
+// non-terminated sessions that are temporarily OUT of the 5-min active-view (parked between SDs
+// or briefly stale-heartbeat). Without this, the reap cycle dropping a parked worker frees its
+// callsign for a NEW worker; when the parked worker returns it collides and gets re-assigned a
+// different callsign — making callsigns FLAP (e.g. Charlie->Echo->Delta->Charlie). Mutates and
+// returns the used-sets so identity is idempotent per session_id (a session keeps its callsign
+// until terminated). Pure + DB-free for unit testing.
+function reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, activeSessionIds) {
+  for (const s of recentSessions || []) {
+    if (!s || activeSessionIds.has(s.session_id)) continue; // active sessions are already reserved
+    const id = s.metadata?.fleet_identity;
+    if (id?.callsign) usedCallsigns.add(id.callsign);
+    if (id?.color) usedColors.add(id.color);
+  }
+  return { usedCallsigns, usedColors };
+}
+
 const ANSI = {
   red: '\x1b[31m', blue: '\x1b[34m', green: '\x1b[32m', yellow: '\x1b[33m',
   purple: '\x1b[35m', orange: '\x1b[38;5;208m', pink: '\x1b[38;5;213m', cyan: '\x1b[36m',
@@ -216,6 +233,21 @@ async function main() {
   // so a demoted duplicate's callsign/color is free for reassignment.
   const usedCallsigns = new Set(assigned.map(w => w.metadata.fleet_identity.callsign));
   const usedColors = new Set(assigned.map(w => w.metadata.fleet_identity.color));
+
+  // SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001: also reserve callsigns/colors of recently-seen,
+  // non-terminated sessions that are temporarily OUT of the 5-min active-view (parked between SDs
+  // or briefly stale-heartbeat after the reap), so a new worker never steals a parked worker's
+  // callsign and cause it to flap when it returns. 60-min window keeps the NATO pool from being
+  // permanently consumed by long-dead (but un-terminated) sessions; the reaper marks truly dead
+  // sessions 'terminated', which frees their callsign here.
+  const reserveWindow = new Date(Date.now() - 60 * 60_000).toISOString();
+  const { data: recentSessions } = await supabase
+    .from('claude_sessions')
+    .select('session_id, metadata')
+    .neq('status', 'terminated')
+    .gte('heartbeat_at', reserveWindow);
+  const activeSessionIds = new Set(uniqueWorkers.map(w => w.session_id));
+  reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, activeSessionIds);
 
   // Find next available callsign and color for new workers
   function nextAvailable(pool, usedSet) {
@@ -353,7 +385,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -13,7 +13,8 @@ const {
   filterOutCoordinators,
   filterOutGhostSessions,
   isTestSessionId,
-  dedupeAssignedCallsigns
+  dedupeAssignedCallsigns,
+  reserveParkedIdentities
 } = require('../../scripts/assign-fleet-identities.cjs');
 
 describe('filterOutCoordinators (QF-20260508-648)', () => {
@@ -216,5 +217,73 @@ describe('dedupeAssignedCallsigns (QF-20260528-581 / Bug A)', () => {
     const { kept, demoted } = dedupeAssignedCallsigns([null, mk('s1', 'Alpha'), undefined]);
     expect(kept.map(w => w.session_id)).toEqual(['s1']);
     expect(demoted).toEqual([]);
+  });
+});
+
+// SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001: reserve callsigns/colors of recently-seen but
+// out-of-active-view (parked) sessions so a new worker can't steal a parked worker's callsign
+// — which made callsigns FLAP (Charlie->Echo->Delta->Charlie) when the parked worker returned.
+describe('reserveParkedIdentities (SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001)', () => {
+  const sess = (id, callsign, color = 'blue') => ({
+    session_id: id,
+    metadata: { fleet_identity: { callsign, color } }
+  });
+
+  it('reserves a parked (non-active) session\'s callsign AND color', () => {
+    const usedCallsigns = new Set();
+    const usedColors = new Set();
+    const recent = [sess('parked-1', 'Foxtrot', 'orange')];
+    reserveParkedIdentities(usedCallsigns, usedColors, recent, new Set());
+    expect(usedCallsigns.has('Foxtrot')).toBe(true);
+    expect(usedColors.has('orange')).toBe(true);
+  });
+
+  it('does NOT re-reserve an ACTIVE session (already covered by the assigned set)', () => {
+    const usedCallsigns = new Set();
+    const usedColors = new Set();
+    const recent = [sess('active-1', 'Bravo', 'red')];
+    reserveParkedIdentities(usedCallsigns, usedColors, recent, new Set(['active-1']));
+    expect(usedCallsigns.has('Bravo')).toBe(false);
+    expect(usedColors.has('red')).toBe(false);
+  });
+
+  it('the FLAP fix: a parked callsign stays reserved so a new worker never reuses it', () => {
+    // Pool order mirrors the NATO list; simulate nextAvailable skipping reserved entries.
+    const pool = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo'];
+    const usedCallsigns = new Set(['Alpha', 'Bravo']); // currently-active assigned workers
+    const usedColors = new Set();
+    // Charlie is parked (heartbeat stale, dropped from the 5-min active-view) but recently seen.
+    reserveParkedIdentities(usedCallsigns, usedColors, [sess('parked-charlie', 'Charlie')], new Set());
+    const nextFree = pool.find(c => !usedCallsigns.has(c));
+    expect(nextFree).toBe('Delta'); // NOT Charlie — the parked worker keeps it, no flap
+  });
+
+  it('ignores sessions without a fleet_identity / callsign', () => {
+    const usedCallsigns = new Set();
+    const usedColors = new Set();
+    const recent = [
+      { session_id: 's-no-meta' },
+      { session_id: 's-empty-meta', metadata: {} },
+      { session_id: 's-empty-identity', metadata: { fleet_identity: {} } }
+    ];
+    reserveParkedIdentities(usedCallsigns, usedColors, recent, new Set());
+    expect(usedCallsigns.size).toBe(0);
+    expect(usedColors.size).toBe(0);
+  });
+
+  it('handles null/undefined recentSessions and null entries without throwing', () => {
+    const a = new Set(), b = new Set();
+    expect(() => reserveParkedIdentities(a, b, null, new Set())).not.toThrow();
+    expect(() => reserveParkedIdentities(a, b, undefined, new Set())).not.toThrow();
+    expect(() => reserveParkedIdentities(a, b, [null, undefined], new Set())).not.toThrow();
+    expect(a.size).toBe(0);
+  });
+
+  it('preserves callsigns already in the used-set (additive, non-destructive)', () => {
+    const usedCallsigns = new Set(['Alpha']);
+    const usedColors = new Set(['red']);
+    reserveParkedIdentities(usedCallsigns, usedColors, [sess('p', 'Golf', 'green')], new Set());
+    expect([...usedCallsigns].sort()).toEqual(['Alpha', 'Golf']);
+    expect([...usedColors].sort()).toEqual(['green', 'red']);
   });
 });


### PR DESCRIPTION
## SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001 — Fleet identity idempotency

**Problem:** `scripts/assign-fleet-identities.cjs` computed its used callsign/color set only from the 5-minute active-view of `claude_sessions`. When a worker parks (heartbeat stale during a long sub-agent run / between SDs) the reap cycle drops it from that view, so its callsign was treated as free and handed to a new worker — callsigns **flapped** (e.g. Charlie→Echo→Delta→Charlie). Worker Bravo received 6 repeated SET_IDENTITY messages in one session.

**Fix:** add a pure helper `reserveParkedIdentities()` plus a 60-minute reserve-window query in `main()` that seeds `usedCallsigns`/`usedColors` from recently-seen non-terminated sessions **before** new-worker assignment. Identity is now idempotent per `session_id` — a session keeps its callsign until the reaper terminates it. The 60-min window prevents NATO-pool exhaustion.

**Changes:**
- `scripts/assign-fleet-identities.cjs`: `+ reserveParkedIdentities()` helper, `+` 60-min reserve query in `main()`, `+` export.
- `tests/unit/assign-fleet-identities-coordinator-filter.test.js`: `+6` cases (parked reservation, active-skip, flap-fix, no-identity skip, null-safety, additive). **27/27 pass** (0 regressions).

Source: coordinator-review feedback `6e271d35` (Delta/e68e1cb8, 2026-06-06). Gates: LEAD-TO-PLAN 95 / PLAN-TO-EXEC 98 / EXEC-TO-PLAN 98 / PLAN-TO-LEAD 98. Retro quality 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
