### PR TITLE
feat(SD-LEO-INFRA-POLICY-GATED-AUTO-001A): Pending-Enablement Registry (child 001A)

### DIFF
--- a/database/migrations/20260607_leo_feature_flags_pending_enablement_registry.sql
+++ b/database/migrations/20260607_leo_feature_flags_pending_enablement_registry.sql
@@ -1,0 +1,146 @@
+-- ============================================================================
+-- 20260607_leo_feature_flags_pending_enablement_registry.sql
+-- ----------------------------------------------------------------------------
+-- SD: SD-LEO-INFRA-POLICY-GATED-AUTO-001A
+-- UUID: 508f56a9-4ab4-4f36-95d1-32388cf781bd
+-- Phase: EXEC (database-agent design + apply output)
+--
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Purpose:
+--   Extend the EXISTING public.leo_feature_flags table (NOT a parallel table)
+--   with 5 additive, nullable columns so that every default-OFF rollout can
+--   self-register as a "Pending-Enablement Registry" entry. This lets the
+--   exec-email aged-pending surfacer find flags that shipped default-OFF and
+--   have never been enabled / reviewed, without inventing a second table.
+--
+--   New columns:
+--     gates_what          text         -- what the flag guards
+--     enablement_criteria text         -- what must be true to enable it
+--     rolled_out_at       timestamptz  -- when the default-OFF rollout shipped
+--     last_reviewed_at    timestamptz  -- last operator review of this pending flag
+--     target              text         -- target app/scope (e.g. 'EHG_Engineer')
+--
+-- Status-semantics note (lifecycle_state):
+--   lifecycle_state is the ENUM type `feature_flag_lifecycle_state` whose ONLY
+--   allowed values are: draft, enabled, disabled, expired, archived.
+--   There is NO pending / retired / deprecated value, and there is NO CHECK
+--   constraint adding extra values. Therefore "pending enablement" is NOT a
+--   first-class lifecycle_state; it must be DERIVED:
+--
+--     pending  := is_enabled = false
+--                 AND rolled_out_at IS NOT NULL
+--                 AND lifecycle_state IN ('draft','disabled')  -- not retired
+--
+--   ("retired"/"end-of-life" maps to lifecycle_state IN ('expired','archived');
+--    those should NOT be surfaced as pending-enablement work.)
+--   The surfacer derives "aged pending" by comparing now() against
+--   rolled_out_at / last_reviewed_at. No enum change is required (and none is
+--   made here) — keeping this migration purely additive and reversible.
+--
+-- Risk / lock rationale:
+--   * ADD COLUMN ... IF NOT EXISTS with literal NULL default on PostgreSQL 11+
+--     is a metadata-only operation: brief AccessExclusiveLock, no row rewrite,
+--     no full-table scan (PG verified 17.x in production). 6 existing rows are
+--     untouched; all new columns read back NULL on existing rows.
+--   * Additive + nullable ONLY. No existing column is altered or dropped; no
+--     existing row data is modified.
+--   * IF NOT EXISTS makes each ADD COLUMN idempotent / re-runnable.
+--
+-- Down / rollback (additive-only, fully reversible — see also footer):
+--   BEGIN;
+--     ALTER TABLE public.leo_feature_flags DROP COLUMN IF EXISTS target;
+--     ALTER TABLE public.leo_feature_flags DROP COLUMN IF EXISTS last_reviewed_at;
+--     ALTER TABLE public.leo_feature_flags DROP COLUMN IF EXISTS rolled_out_at;
+--     ALTER TABLE public.leo_feature_flags DROP COLUMN IF EXISTS enablement_criteria;
+--     ALTER TABLE public.leo_feature_flags DROP COLUMN IF EXISTS gates_what;
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+-- 1) gates_what — free-text description of what behaviour/path the flag guards.
+ALTER TABLE public.leo_feature_flags
+  ADD COLUMN IF NOT EXISTS gates_what TEXT DEFAULT NULL;
+
+COMMENT ON COLUMN public.leo_feature_flags.gates_what IS
+  'Pending-Enablement Registry: human-readable description of WHAT this flag '
+  'guards (the behaviour/code path that is OFF while is_enabled=false). '
+  'Populated by default-OFF rollouts that self-register. '
+  'See SD-LEO-INFRA-POLICY-GATED-AUTO-001A.';
+
+-- 2) enablement_criteria — what must be true before an operator flips it ON.
+ALTER TABLE public.leo_feature_flags
+  ADD COLUMN IF NOT EXISTS enablement_criteria TEXT DEFAULT NULL;
+
+COMMENT ON COLUMN public.leo_feature_flags.enablement_criteria IS
+  'Pending-Enablement Registry: the conditions that must hold before this '
+  'default-OFF flag is enabled (e.g. "consumer migration deployed; 24h soak '
+  'with no errors"). Read by the exec-email aged-pending surfacer. '
+  'See SD-LEO-INFRA-POLICY-GATED-AUTO-001A.';
+
+-- 3) rolled_out_at — when the default-OFF rollout shipped. Presence of this
+--    value (with is_enabled=false) is the primary "this is a pending flag" signal.
+ALTER TABLE public.leo_feature_flags
+  ADD COLUMN IF NOT EXISTS rolled_out_at TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN public.leo_feature_flags.rolled_out_at IS
+  'Pending-Enablement Registry: timestamp when the default-OFF rollout that '
+  'introduced this flag shipped. NULL = not a self-registered pending rollout. '
+  'pending := is_enabled=false AND rolled_out_at IS NOT NULL AND lifecycle_state '
+  'IN (draft,disabled). Aged-pending = now() - rolled_out_at exceeds threshold. '
+  'See SD-LEO-INFRA-POLICY-GATED-AUTO-001A.';
+
+-- 4) last_reviewed_at — last operator review of this pending flag (drives "aged").
+ALTER TABLE public.leo_feature_flags
+  ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN public.leo_feature_flags.last_reviewed_at IS
+  'Pending-Enablement Registry: timestamp of the last operator review of this '
+  'pending flag. NULL = never reviewed since rollout. The aged-pending surfacer '
+  'uses COALESCE(last_reviewed_at, rolled_out_at) as the staleness anchor. '
+  'See SD-LEO-INFRA-POLICY-GATED-AUTO-001A.';
+
+-- 5) target — target app/scope this flag applies to (e.g. EHG_Engineer / EHG).
+ALTER TABLE public.leo_feature_flags
+  ADD COLUMN IF NOT EXISTS target TEXT DEFAULT NULL;
+
+COMMENT ON COLUMN public.leo_feature_flags.target IS
+  'Pending-Enablement Registry: target application / scope this flag applies to '
+  '(e.g. "EHG_Engineer", "EHG"). NULL = unscoped / global. '
+  'See SD-LEO-INFRA-POLICY-GATED-AUTO-001A.';
+
+COMMIT;
+
+-- ============================================================================
+-- Post-deploy verification (run separately, e.g. in psql or a scripted check):
+--
+--   SELECT column_name
+--   FROM information_schema.columns
+--   WHERE table_schema = 'public'
+--     AND table_name   = 'leo_feature_flags'
+--     AND column_name IN ('gates_what','enablement_criteria',
+--                         'rolled_out_at','last_reviewed_at','target')
+--   ORDER BY column_name;
+--   -- expect exactly 5 rows.
+-- ============================================================================
+
+-- ============================================================================
+-- BEGIN..ROLLBACK rehearsal snippet (proves add + rollback are clean; makes NO
+-- permanent change because it ends in ROLLBACK). Run via a raw pg client; do NOT
+-- run through apply-migration.js (that path COMMITs):
+--
+--   BEGIN;
+--     ALTER TABLE public.leo_feature_flags ADD COLUMN IF NOT EXISTS gates_what TEXT;
+--     ALTER TABLE public.leo_feature_flags ADD COLUMN IF NOT EXISTS enablement_criteria TEXT;
+--     ALTER TABLE public.leo_feature_flags ADD COLUMN IF NOT EXISTS rolled_out_at TIMESTAMPTZ;
+--     ALTER TABLE public.leo_feature_flags ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ;
+--     ALTER TABLE public.leo_feature_flags ADD COLUMN IF NOT EXISTS target TEXT;
+--     -- inspect:
+--     SELECT column_name, data_type, is_nullable
+--     FROM information_schema.columns
+--     WHERE table_name='leo_feature_flags'
+--       AND column_name IN ('gates_what','enablement_criteria','rolled_out_at','last_reviewed_at','target')
+--     ORDER BY column_name;
+--   ROLLBACK;   -- everything above is discarded; table returns to prior shape.
+-- ============================================================================

--- a/lib/pending-enablement-registry.js
+++ b/lib/pending-enablement-registry.js
@@ -1,0 +1,159 @@
+/**
+ * Pending-Enablement Registry — SD-LEO-INFRA-POLICY-GATED-AUTO-001A (child of the
+ * policy-gated auto-execution engine).
+ *
+ * Every default-OFF rollout must self-register so it cannot silently linger
+ * (the deploy-gap that hid the inert claim-sweep fixes). The registry EXTENDS
+ * the existing leo_feature_flags table with five additive columns
+ * (gates_what, enablement_criteria, rolled_out_at, last_reviewed_at, target);
+ * no parallel table exists.
+ *
+ * lifecycle_state is the enum feature_flag_lifecycle_state
+ * {draft, enabled, disabled, expired, archived} — there is no `pending`/`retired`
+ * label, so "pending enablement" is DERIVED, not stored:
+ *   pending := is_enabled = false AND rolled_out_at IS NOT NULL
+ *              AND lifecycle_state IN ('draft','disabled')
+ *   retired := lifecycle_state IN ('expired','archived')   // excluded from surfacer
+ * Staleness anchor for "aged" := COALESCE(last_reviewed_at, rolled_out_at).
+ *
+ * The pure predicates/renderers are unit-tested with no DB; the two async DB
+ * helpers are exercised by the db-project integration test and fail open so a
+ * registry hiccup can never break the 15-min executive email.
+ */
+
+export const PENDING_AGE_DAYS = 7;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PENDING_STATES = ['draft', 'disabled'];
+
+/** A flag is a pending-enablement registry item: a registered default-OFF rollout. */
+export function isPendingRegistryFlag(flag) {
+  if (!flag || typeof flag !== 'object') return false;
+  return flag.is_enabled === false
+    && flag.rolled_out_at != null
+    && PENDING_STATES.includes(flag.lifecycle_state);
+}
+
+/** Staleness anchor: last review if any, else the rollout date. Returns ms epoch or null. */
+export function pendingSinceMs(flag) {
+  const anchor = flag?.last_reviewed_at || flag?.rolled_out_at;
+  if (!anchor) return null;
+  const ms = new Date(anchor).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Whole days a flag has been pending (since the staleness anchor). */
+export function pendingAgeDays(flag, now = Date.now()) {
+  const since = pendingSinceMs(flag);
+  if (since == null) return null;
+  return Math.floor((now - since) / DAY_MS);
+}
+
+/** A pending item that has aged past the threshold (the operator should decide). */
+export function isAgedPending(flag, { now = Date.now(), ageDays = PENDING_AGE_DAYS } = {}) {
+  if (!isPendingRegistryFlag(flag)) return false;
+  const age = pendingAgeDays(flag, now);
+  return age != null && age > ageDays;
+}
+
+/** Pure: select + sort (oldest first) the aged-pending items from a flag list. */
+export function selectAgedPending(flags, opts = {}) {
+  return (Array.isArray(flags) ? flags : [])
+    .filter((f) => isAgedPending(f, opts))
+    .sort((a, b) => (pendingSinceMs(a) ?? 0) - (pendingSinceMs(b) ?? 0));
+}
+
+const escHtml = (s) => String(s ?? '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Plain-text "Pending your decision" block. Empty string when nothing is aged. */
+export function renderAgedPendingText(items, { now = Date.now() } = {}) {
+  if (!items || items.length === 0) return '';
+  const lines = items.map((f) => {
+    const age = pendingAgeDays(f, now);
+    const gates = f.gates_what ? ` — ${f.gates_what}` : '';
+    const crit = f.enablement_criteria ? ` [enable when: ${f.enablement_criteria}]` : '';
+    const tgt = f.target ? ` (${f.target})` : '';
+    return `  • ${f.flag_key}${tgt}${gates} — pending ${age}d${crit} → enable / defer / retire`;
+  });
+  return `⏳ ${items.length} default-OFF rollout${items.length > 1 ? 's' : ''} pending your decision (>${PENDING_AGE_DAYS}d):\n${lines.join('\n')}\n\n`;
+}
+
+/** HTML "Pending your decision" block. Empty string when nothing is aged. */
+export function renderAgedPendingHtml(items, { now = Date.now() } = {}) {
+  if (!items || items.length === 0) return '';
+  const rows = items.map((f) => {
+    const age = pendingAgeDays(f, now);
+    const gates = f.gates_what ? ` — ${escHtml(f.gates_what)}` : '';
+    const crit = f.enablement_criteria
+      ? ` <span style="color:#999;font-size:13px">[enable when: ${escHtml(f.enablement_criteria)}]</span>` : '';
+    const tgt = f.target ? ` <span style="color:#777">(${escHtml(f.target)})</span>` : '';
+    return `• <b>${escHtml(f.flag_key)}</b>${tgt}${gates} — pending ${age}d${crit} <span style="color:#777;font-size:13px">→ enable / defer / retire</span>`;
+  });
+  return `<p style="font-size:15px;margin:0 0 10px;padding:10px 12px;background:#eef5ff;border-left:4px solid #3b82f6;border-radius:3px"><b>⏳ ${items.length} default-OFF rollout${items.length > 1 ? 's' : ''} pending your decision (&gt;${PENDING_AGE_DAYS}d)</b><br>${rows.join('<br>')}</p>`;
+}
+
+/**
+ * DB: fetch aged-pending registry items. Fail-open — returns [] on any error so
+ * the executive email never breaks because of the registry.
+ */
+export async function fetchAgedPendingFlags(db, opts = {}) {
+  try {
+    const { data, error } = await db
+      .from('leo_feature_flags')
+      .select('flag_key, display_name, is_enabled, lifecycle_state, gates_what, enablement_criteria, rolled_out_at, last_reviewed_at, target')
+      .eq('is_enabled', false)
+      .in('lifecycle_state', PENDING_STATES)
+      .not('rolled_out_at', 'is', null);
+    if (error) return [];
+    return selectAgedPending(data, opts);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * DB: register (or refresh) a default-OFF rollout in the registry. Idempotent —
+ * an existing row keeps its is_enabled/lifecycle_state and only has NULL registry
+ * fields filled (never overwrites a human edit). A new row is inserted default-OFF.
+ * Returns { row, created }.
+ */
+export async function registerPendingFlag(db, entry) {
+  if (!entry || !entry.flag_key) throw new Error('registerPendingFlag: flag_key is required');
+  const { data: existing } = await db
+    .from('leo_feature_flags').select('*').eq('flag_key', entry.flag_key).maybeSingle();
+
+  const registryFields = {
+    gates_what: entry.gates_what ?? null,
+    enablement_criteria: entry.enablement_criteria ?? null,
+    rolled_out_at: entry.rolled_out_at ?? null,
+    target: entry.target ?? null,
+  };
+
+  if (existing) {
+    // Only fill registry columns that are still NULL — never clobber human edits.
+    const patch = {};
+    for (const [k, v] of Object.entries(registryFields)) {
+      if (existing[k] == null && v != null) patch[k] = v;
+    }
+    if (Object.keys(patch).length === 0) return { row: existing, created: false };
+    const { data, error } = await db
+      .from('leo_feature_flags').update(patch).eq('flag_key', entry.flag_key).select().maybeSingle();
+    if (error) throw error;
+    return { row: data, created: false };
+  }
+
+  const insert = {
+    flag_key: entry.flag_key,
+    display_name: entry.display_name || entry.flag_key,
+    description: entry.description ?? null,
+    is_enabled: false,
+    lifecycle_state: 'disabled',
+    risk_tier: entry.risk_tier || 'low',
+    is_temporary: false,
+    ...registryFields,
+  };
+  const { data, error } = await db
+    .from('leo_feature_flags').insert(insert).select().maybeSingle();
+  if (error) throw error;
+  return { row: data, created: true };
+}

--- a/package.json
+++ b/package.json
@@ -346,6 +346,8 @@
     "session:worktree": "node scripts/session-worktree.js",
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "session:park": "node scripts/park-worker.cjs",
+    "registry:backfill-pending": "node scripts/backfill-pending-enablement-registry.mjs",
+    "coord:email-summary": "node scripts/coordinator-email-summary.mjs",
     "worktree:remove": "node scripts/safe-worktree-remove.mjs",
     "worktree:reap": "node scripts/worktree-reaper.mjs",
     "worktree:reap:execute": "node scripts/worktree-reaper.mjs --execute",

--- a/scripts/backfill-pending-enablement-registry.mjs
+++ b/scripts/backfill-pending-enablement-registry.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Backfill the Pending-Enablement Registry with existing default-OFF rollouts
+ * so the operator gets the full inert-flag inventory, not just future rollouts.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001A.
+ *
+ * Idempotent: re-running only fills NULL registry columns; it never flips
+ * is_enabled / lifecycle_state on an existing row and never overwrites a human
+ * edit (see registerPendingFlag). Safe to run repeatedly.
+ *
+ * Usage:  node --env-file=.env scripts/backfill-pending-enablement-registry.mjs [--dry-run]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { registerPendingFlag } from '../lib/pending-enablement-registry.js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Known shipped-but-default-OFF flags across the fleet. rolled_out_at is the
+// best-known ship date; items surface in the exec email once aged past the
+// review threshold (>7d).
+const INERT_FLAGS = [
+  {
+    flag_key: 'COORD_TEARDOWN_SAFETY_V2',
+    display_name: 'Coordinator Cron-Teardown Safety V2',
+    gates_what: 'Unified coordinator teardown helper that fixes the self-reversing /coordinator stop (inbox cron re-asserts the pointer).',
+    enablement_criteria: 'Operator confirms coordinator teardown is reliable across inbox-cron re-assertion.',
+    target: 'EHG_Engineer',
+    rolled_out_at: '2026-06-06T00:00:00Z',
+    risk_tier: 'medium',
+  },
+  {
+    flag_key: 'COORDINATOR_TWOWAY_V2',
+    display_name: 'Two-Way Coordinator (DB-canonical election)',
+    gates_what: 'resolve.cjs DB-canonical coordinator election + two-way worker/coordinator signaling.',
+    enablement_criteria: 'Operator confirms DB-canonical election is stable under multi-session load.',
+    target: 'EHG_Engineer',
+    rolled_out_at: '2026-06-05T00:00:00Z',
+    risk_tier: 'high',
+  },
+  {
+    flag_key: 'COORD_DETECTORS_V2',
+    display_name: 'Coordination Observability Detectors',
+    gates_what: 'Read-only SPLIT_BRAIN/THUNDERING_HERD/REPLY_STARVATION/STUCK_WORKER/CLAIM_HALF_WRITE detectors.',
+    enablement_criteria: 'Operator confirms detector signal-to-noise is acceptable on real coordination data.',
+    target: 'EHG_Engineer',
+    rolled_out_at: '2026-06-05T00:00:00Z',
+    risk_tier: 'low',
+  },
+  {
+    flag_key: 'SURFACE_INERT_WORKER_V1',
+    display_name: 'Surface Inert Worker Revival',
+    gates_what: 'Read-only detector that surfaces INERT worker-revival (worker_spawn_requests with 0 consumers).',
+    enablement_criteria: 'Operator confirms inert-worker alerts are actionable and de-duped.',
+    target: 'EHG_Engineer',
+    rolled_out_at: '2026-06-06T00:00:00Z',
+    risk_tier: 'low',
+  },
+];
+
+let created = 0, filled = 0, unchanged = 0;
+for (const entry of INERT_FLAGS) {
+  if (DRY_RUN) {
+    console.log(`[dry-run] would register ${entry.flag_key}`);
+    continue;
+  }
+  try {
+    const { row, created: isNew } = await registerPendingFlag(db, entry);
+    if (isNew) { created++; console.log(`  + created ${entry.flag_key}`); }
+    else if (row && (row.gates_what === entry.gates_what || row.target === entry.target)) { filled++; console.log(`  ~ filled  ${entry.flag_key}`); }
+    else { unchanged++; console.log(`  = unchanged ${entry.flag_key}`); }
+  } catch (e) {
+    console.error(`  ! failed ${entry.flag_key}: ${e.message}`);
+  }
+}
+console.log(`\nBackfill done: created=${created} filled=${filled} unchanged=${unchanged} (dry_run=${DRY_RUN})`);

--- a/scripts/coordinator-email-summary.mjs
+++ b/scripts/coordinator-email-summary.mjs
@@ -15,6 +15,7 @@ import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { readFileSync, writeFileSync } from 'fs';
+import { fetchAgedPendingFlags, renderAgedPendingHtml, renderAgedPendingText } from '../lib/pending-enablement-registry.js';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -83,6 +84,13 @@ const qLabel = (q) => {
   return { text: String(q.description || q.title || '').replace(/\s+/g, ' ').trim(), who, sd };
 };
 
+// ── pending-enablement registry: default-OFF rollouts aged past the review threshold ──
+//    (SD-LEO-INFRA-POLICY-GATED-AUTO-001A) — fail-open: a registry hiccup must never break the email.
+const pending = await fetchAgedPendingFlags(db, { now: t });
+const pN = pending.length;
+const pendingHtml = renderAgedPendingHtml(pending, { now: t });
+const pendingText = renderAgedPendingText(pending, { now: t });
+
 // ── render ──
 const dot = { red: '🔴', yellow: '🟡', green: '🟢' }[overall];
 const word = { red: 'RED', yellow: 'YELLOW', green: 'GREEN' }[overall];
@@ -96,19 +104,20 @@ const meaning = workable === 0 ? 'idle — no open work'
 const when = new Date(t).toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
 const gauge = liveWorkers === 0 ? 'no live workers' : `${assigned} building · ${remaining} queued${idleWorkers ? ` · ${idleWorkers} idle` : ''}`;
 const qFlag = qN ? `❓${qN} · ` : '';
-const subject = qFlag + (workable === 0
+const pFlag = pN ? `⏳${pN} · ` : '';
+const subject = qFlag + pFlag + (workable === 0
   ? `Fleet ${dot} ${word} ${trendArrow} · idle (no work)`
   : `Fleet ${dot} ${word} ${trendArrow} · ${assigned} bld · ${remaining} queued${idleWorkers ? ` · ${idleWorkers} idle` : ''}`);
 const qHtml = qN ? `<p style="font-size:15px;margin:0 0 10px;padding:10px 12px;background:#fff8e1;border-left:4px solid #f5a623;border-radius:3px"><b>❓ ${qN} question${qN > 1 ? 's' : ''} need${qN > 1 ? '' : 's'} your input</b><br>${questions.map(q => { const l = qLabel(q); return `• ${esc(l.text)} <span style="color:#999;font-size:13px">— ${esc(l.who)}${esc(l.sd)}</span>`; }).join('<br>')}</p>` : '';
 const html = `<p style="font-size:17px;margin:0 0 10px"><b>${dot} ${word}</b> — ${meaning} <span style="color:#777;font-size:14px">(${trendWord} ${trendArrow})</span></p>
-${qHtml}<p style="font-size:14px;margin:0 0 6px"><b>Active workers:</b> ${gauge}${workable ? ` · ${workable} item${workable > 1 ? 's' : ''} in play` : ''}</p>
+${qHtml}${pendingHtml}<p style="font-size:14px;margin:0 0 6px"><b>Active workers:</b> ${gauge}${workable ? ` · ${workable} item${workable > 1 ? 's' : ''} in play` : ''}</p>
 <p style="font-size:11px;color:#999;margin:14px 0 0">${when} ET</p>`;
 const qText = qN ? `❓ ${qN} question${qN > 1 ? 's' : ''} need${qN > 1 ? '' : 's'} your input:\n${questions.map(q => { const l = qLabel(q); return `  • ${l.text} — ${l.who}${l.sd}`; }).join('\n')}\n\n` : '';
-const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\n\n${when} ET`;
+const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}${pendingText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\n\n${when} ET`;
 
 if (DRY_RUN) {
   console.log('=== [DRY RUN] no email sent ===\nSUBJECT: ' + subject + '\n---\n' + text + '\n---');
-  console.log(`overall=${overall} assigned=${assigned} idle=${idleWorkers} remaining=${remaining} liveWorkers=${liveWorkers} workable=${workable} builderKeys=${builderKeys.size} shortBy=${shortBy} questions=${qN}`);
+  console.log(`overall=${overall} assigned=${assigned} idle=${idleWorkers} remaining=${remaining} liveWorkers=${liveWorkers} workable=${workable} builderKeys=${builderKeys.size} shortBy=${shortBy} questions=${qN} pending=${pN}`);
 } else {
   const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
   const r = await mod.sendEmail({ from: 'Fleet Coordinator <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });

--- a/tests/integration/pending-enablement-registry.db.test.js
+++ b/tests/integration/pending-enablement-registry.db.test.js
@@ -1,0 +1,85 @@
+/**
+ * Integration tests (live DB) for the Pending-Enablement Registry.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001A. Self-skips without a real DB.
+ *
+ * Proves: the 5 registry columns exist; registerPendingFlag is idempotent and
+ * non-destructive; and WRITER/CONSUMER PARITY — a registered aged default-OFF
+ * row is actually returned by fetchAgedPendingFlags and rendered in the email body.
+ */
+import { afterAll, beforeAll, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { describeDb, itDb } from '../helpers/db-available.js';
+import {
+  registerPendingFlag,
+  fetchAgedPendingFlags,
+  renderAgedPendingHtml,
+} from '../../lib/pending-enablement-registry.js';
+
+const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const AGED_KEY = 'TEST_PENDING_REGISTRY_AGED_001A';
+const FRESH_KEY = 'TEST_PENDING_REGISTRY_FRESH_001A';
+const daysAgoIso = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+
+async function cleanup() {
+  await db.from('leo_feature_flags').delete().in('flag_key', [AGED_KEY, FRESH_KEY]);
+}
+
+describeDb('Pending-Enablement Registry (live DB)', () => {
+  beforeAll(cleanup);
+  afterAll(cleanup);
+
+  itDb('the 5 registry columns exist on leo_feature_flags', async () => {
+    const { error } = await db
+      .from('leo_feature_flags')
+      .select('gates_what, enablement_criteria, rolled_out_at, last_reviewed_at, target')
+      .limit(1);
+    expect(error).toBeNull();
+  });
+
+  itDb('registerPendingFlag inserts a new default-OFF row', async () => {
+    const { row, created } = await registerPendingFlag(db, {
+      flag_key: AGED_KEY,
+      display_name: 'Test Aged Pending 001A',
+      gates_what: 'test guard',
+      enablement_criteria: 'never (test only)',
+      target: 'EHG_Engineer',
+      rolled_out_at: daysAgoIso(30),
+    });
+    expect(created).toBe(true);
+    expect(row.is_enabled).toBe(false);
+    expect(row.lifecycle_state).toBe('disabled');
+    expect(row.gates_what).toBe('test guard');
+  });
+
+  itDb('registerPendingFlag is idempotent and non-destructive on re-run', async () => {
+    const { created } = await registerPendingFlag(db, {
+      flag_key: AGED_KEY,
+      gates_what: 'DIFFERENT — must NOT overwrite the human-set value',
+      rolled_out_at: daysAgoIso(1),
+    });
+    expect(created).toBe(false);
+    const { data } = await db.from('leo_feature_flags').select('gates_what, rolled_out_at').eq('flag_key', AGED_KEY).maybeSingle();
+    expect(data.gates_what).toBe('test guard'); // unchanged — never clobbered
+  });
+
+  itDb('WRITER/CONSUMER PARITY: an aged registered row is fetched AND rendered in the email', async () => {
+    const aged = await fetchAgedPendingFlags(db, { now: Date.now() });
+    const keys = aged.map((f) => f.flag_key);
+    expect(keys).toContain(AGED_KEY); // consumer (surfacer query) sees the writer's row
+
+    const html = renderAgedPendingHtml(aged, { now: Date.now() });
+    expect(html).toContain(AGED_KEY); // and it actually renders into the email body
+  });
+
+  itDb('a fresh (<7d) pending row is registered but NOT surfaced', async () => {
+    await registerPendingFlag(db, {
+      flag_key: FRESH_KEY,
+      display_name: 'Test Fresh Pending 001A',
+      gates_what: 'fresh test guard',
+      target: 'EHG_Engineer',
+      rolled_out_at: daysAgoIso(2),
+    });
+    const aged = await fetchAgedPendingFlags(db, { now: Date.now() });
+    expect(aged.map((f) => f.flag_key)).not.toContain(FRESH_KEY);
+  });
+});

--- a/tests/pending-enablement-registry.test.js
+++ b/tests/pending-enablement-registry.test.js
@@ -11,6 +11,7 @@ import {
   selectAgedPending,
   renderAgedPendingText,
   renderAgedPendingHtml,
+  fetchAgedPendingFlags,
 } from '../lib/pending-enablement-registry.js';
 
 const NOW = Date.parse('2026-06-07T00:00:00Z');
@@ -96,5 +97,27 @@ describe('renderers', () => {
     const out = renderAgedPendingHtml([evil], { now: NOW });
     expect(out).toContain('&lt;script&gt;');
     expect(out).not.toContain('<script>');
+  });
+  it('html escapes flag_key, target and enablement_criteria too', () => {
+    const evil = {
+      ...agedPending, flag_key: '<b>k</b>', target: '<i>t</i>', enablement_criteria: '<u>c</u>',
+    };
+    const out = renderAgedPendingHtml([evil], { now: NOW });
+    expect(out).toContain('&lt;b&gt;k&lt;/b&gt;');
+    expect(out).toContain('&lt;i&gt;t&lt;/i&gt;');
+    expect(out).toContain('&lt;u&gt;c&lt;/u&gt;');
+  });
+});
+
+describe('fetchAgedPendingFlags fail-open', () => {
+  it('returns [] when the db client throws (registry must never break the email)', async () => {
+    const throwingDb = { from() { throw new Error('db down'); } };
+    await expect(fetchAgedPendingFlags(throwingDb, { now: NOW })).resolves.toEqual([]);
+  });
+  it('returns [] when the query reports an error', async () => {
+    const errorDb = {
+      from: () => ({ select: () => ({ eq: () => ({ in: () => ({ not: () => ({ data: null, error: { message: 'boom' } }) }) }) }) }),
+    };
+    await expect(fetchAgedPendingFlags(errorDb, { now: NOW })).resolves.toEqual([]);
   });
 });

--- a/tests/pending-enablement-registry.test.js
+++ b/tests/pending-enablement-registry.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit tests (no DB) for the Pending-Enablement Registry pure logic.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001A.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PENDING_AGE_DAYS,
+  isPendingRegistryFlag,
+  pendingAgeDays,
+  isAgedPending,
+  selectAgedPending,
+  renderAgedPendingText,
+  renderAgedPendingHtml,
+} from '../lib/pending-enablement-registry.js';
+
+const NOW = Date.parse('2026-06-07T00:00:00Z');
+const daysAgo = (n) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
+
+const agedPending = {
+  flag_key: 'OLD_FLAG', is_enabled: false, lifecycle_state: 'disabled',
+  rolled_out_at: daysAgo(30), gates_what: 'guards X', enablement_criteria: 'when Y', target: 'EHG_Engineer',
+};
+const freshPending = { ...agedPending, flag_key: 'NEW_FLAG', rolled_out_at: daysAgo(2) };
+const enabledFlag = { ...agedPending, flag_key: 'ON_FLAG', is_enabled: true, lifecycle_state: 'enabled' };
+const retiredFlag = { ...agedPending, flag_key: 'GONE_FLAG', lifecycle_state: 'archived' };
+const noRollout = { ...agedPending, flag_key: 'NO_DATE', rolled_out_at: null };
+
+describe('isPendingRegistryFlag', () => {
+  it('true for a registered default-OFF (disabled) flag with a rollout date', () => {
+    expect(isPendingRegistryFlag(agedPending)).toBe(true);
+  });
+  it('true for a draft default-OFF flag', () => {
+    expect(isPendingRegistryFlag({ ...agedPending, lifecycle_state: 'draft' })).toBe(true);
+  });
+  it('false when enabled', () => expect(isPendingRegistryFlag(enabledFlag)).toBe(false));
+  it('false when retired (archived/expired)', () => {
+    expect(isPendingRegistryFlag(retiredFlag)).toBe(false);
+    expect(isPendingRegistryFlag({ ...agedPending, lifecycle_state: 'expired' })).toBe(false);
+  });
+  it('false when never rolled out (not yet a registry item)', () => expect(isPendingRegistryFlag(noRollout)).toBe(false));
+  it('false for null/garbage', () => {
+    expect(isPendingRegistryFlag(null)).toBe(false);
+    expect(isPendingRegistryFlag('x')).toBe(false);
+  });
+});
+
+describe('pendingAgeDays + staleness anchor', () => {
+  it('counts whole days since rollout', () => expect(pendingAgeDays(agedPending, NOW)).toBe(30));
+  it('uses last_reviewed_at over rolled_out_at when present', () => {
+    const reviewed = { ...agedPending, last_reviewed_at: daysAgo(3) };
+    expect(pendingAgeDays(reviewed, NOW)).toBe(3);
+  });
+  it('null when no anchor', () => expect(pendingAgeDays(noRollout, NOW)).toBe(null));
+});
+
+describe('isAgedPending threshold', () => {
+  it(`aged when older than ${PENDING_AGE_DAYS}d`, () => expect(isAgedPending(agedPending, { now: NOW })).toBe(true));
+  it('not aged when within the window', () => expect(isAgedPending(freshPending, { now: NOW })).toBe(false));
+  it('exactly at the threshold is not yet aged (strictly greater)', () => {
+    const exactly7 = { ...agedPending, rolled_out_at: daysAgo(7) };
+    expect(isAgedPending(exactly7, { now: NOW })).toBe(false);
+  });
+  it('recently reviewed pending item resets the clock', () => {
+    const reviewed = { ...agedPending, last_reviewed_at: daysAgo(1) };
+    expect(isAgedPending(reviewed, { now: NOW })).toBe(false);
+  });
+  it('enabled / retired never aged-pending', () => {
+    expect(isAgedPending(enabledFlag, { now: NOW })).toBe(false);
+    expect(isAgedPending(retiredFlag, { now: NOW })).toBe(false);
+  });
+});
+
+describe('selectAgedPending', () => {
+  it('keeps only aged-pending, oldest first', () => {
+    const older = { ...agedPending, flag_key: 'OLDER', rolled_out_at: daysAgo(40) };
+    const out = selectAgedPending([freshPending, agedPending, enabledFlag, retiredFlag, older], { now: NOW });
+    expect(out.map((f) => f.flag_key)).toEqual(['OLDER', 'OLD_FLAG']);
+  });
+  it('handles non-array input', () => expect(selectAgedPending(null)).toEqual([]));
+});
+
+describe('renderers', () => {
+  it('empty string when nothing aged', () => {
+    expect(renderAgedPendingText([], { now: NOW })).toBe('');
+    expect(renderAgedPendingHtml([], { now: NOW })).toBe('');
+  });
+  it('text includes flag_key, age, gates, and the decision affordance', () => {
+    const out = renderAgedPendingText([agedPending], { now: NOW });
+    expect(out).toContain('OLD_FLAG');
+    expect(out).toContain('pending 30d');
+    expect(out).toContain('guards X');
+    expect(out).toContain('enable / defer / retire');
+  });
+  it('html escapes injected content', () => {
+    const evil = { ...agedPending, flag_key: 'X', gates_what: '<script>alert(1)</script>' };
+    const out = renderAgedPendingHtml([evil], { now: NOW });
+    expect(out).toContain('&lt;script&gt;');
+    expect(out).not.toContain('<script>');
+  });
+});


### PR DESCRIPTION
## Child 001A of SD-LEO-INFRA-POLICY-GATED-AUTO-001 (policy-gated auto-execution engine)

First child (near-zero blast, standalone value): a Pending-Enablement Registry so **no default-OFF rollout silently lingers** (the deploy-gap that hid the inert claim-sweep fixes until a worker RCA surfaced them).

### What
- **Migration** — 5 additive, nullable columns on the EXISTING `leo_feature_flags` table (`gates_what`, `enablement_criteria`, `rolled_out_at`, `last_reviewed_at`, `target`). No parallel table. Applied via the audited `apply-migration.js --prod-deploy` (recorded in `schema_migrations_applied`).
- **lib/pending-enablement-registry.js** — derives *pending* (`is_enabled=false` + `rolled_out_at` + `lifecycle_state ∈ {draft,disabled}`; `lifecycle_state` is an enum with no `pending` label), ages it on `COALESCE(last_reviewed_at, rolled_out_at)` past **>7d**, pure renderers (HTML-escaped), a **fail-open** DB fetch, and an **idempotent, non-destructive** `registerPendingFlag` (only fills NULL registry columns — never clobbers a human edit).
- **coordinator-email-summary.mjs** — adds an aged-pending "Pending your decision" section (subject flag + HTML + text). Fail-open: a registry hiccup can never break the 15-min executive email.
- **backfill** — idempotent seeding of known default-OFF flags (COORD_TEARDOWN_SAFETY_V2, COORDINATOR_TWOWAY_V2, COORD_DETECTORS_V2, SURFACE_INERT_WORKER_V1).

### Tests
- **19 unit** (no DB): predicates, 7-day boundary (strictly greater), staleness-anchor reset on review, enabled/retired exclusion, HTML-injection escaping, empty-render.
- **5 DB integration** (self-skip without DB): columns exist; insert default-OFF; **idempotent + non-destructive** re-run; **WRITER/CONSUMER PARITY** (a registered aged row is both fetched by the surfacer query AND rendered into the email body); fresh (<7d) row is registered but NOT surfaced.

### Safety / reversibility
Additive nullable columns (down-migration drops them); surfacer is read-only and fail-open; backfill never flips `is_enabled`/`lifecycle_state` on existing rows. Recently-shipped flags correctly do not surface until aged >7d.

PR-size note: cohesive registry mechanism (schema + lib + surfacer + backfill); splitting smaller would ship a half-feature. ~280 LOC prod + ~190 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)