### PR TITLE
feat(SD-LEO-INFRA-POLICY-GATED-AUTO-001B): policy schema + storage-layer meta-stability + reversibility classifier

### DIFF
--- a/database/migrations/20260607_auto_exec_policy.sql
+++ b/database/migrations/20260607_auto_exec_policy.sql
@@ -1,0 +1,161 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- ============================================================================
+-- Migration: Policy-gated auto-execution policy schema + STORAGE-LAYER
+--            meta-stability guard.
+--
+-- SD: SD-LEO-INFRA-POLICY-GATED-AUTO-001B
+--     (child of the policy-gated auto-execution engine)
+-- sd_id: c6fc6355-3db7-431a-95b2-156711dbcc9c
+--
+-- GOAL
+--   App-layer-only meta-stability is a CRITICAL gap: the auto-execution
+--   engine must be UNABLE to write its own policy/guardrails even if the
+--   application code is compromised. This migration adds the defense at the
+--   STORAGE (table-privilege) layer:
+--
+--     1. leo_auto_exec_policy      — per-action-class execution policy.
+--     2. leo_auto_exec_forbidden   — hard deny-list of action classes that
+--                                    must never auto-execute.
+--     3. leo_engine_ro             — a restricted NOLOGIN database role with
+--                                    SELECT-ONLY access to the policy /
+--                                    forbidden / feature-flag / kill-switch
+--                                    tables. NOT superuser, NOT BYPASSRLS.
+--
+--   With only SELECT granted, any write the engine attempts under
+--   leo_engine_ro fails with "permission denied for table ..." — at the
+--   storage layer, BEFORE any RLS policy or application check. This is
+--   defense-in-depth BEYOND RLS.
+--
+-- PROPERTIES
+--   * Additive only.
+--   * Fully idempotent (IF NOT EXISTS / guarded DO blocks / ON CONFLICT).
+--   * Reversible — see the DOWN / ROLLBACK SQL block at the bottom.
+--   * Does NOT weaken any existing grant on leo_feature_flags /
+--     leo_kill_switches for other roles (leo_engine_ro is a brand-new,
+--     distinct role; SELECT-only grants are purely additive).
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. leo_auto_exec_policy
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.leo_auto_exec_policy (
+  action_class   TEXT PRIMARY KEY,
+  preconditions  JSONB,
+  canary         JSONB,
+  rollback       JSONB,
+  blast_radius   JSONB,
+  observe_window JSONB,
+  escalation     JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.leo_auto_exec_policy IS
+  'Per-action-class auto-execution policy (preconditions, canary, rollback, blast radius, observe window, escalation). Engine reads via leo_engine_ro (SELECT-only); writes are operator/service-role only. SD-LEO-INFRA-POLICY-GATED-AUTO-001B.';
+
+ALTER TABLE public.leo_auto_exec_policy ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- 2. leo_auto_exec_forbidden
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.leo_auto_exec_forbidden (
+  action_class    TEXT PRIMARY KEY,
+  reason          TEXT,
+  outward_facing  BOOLEAN DEFAULT false,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.leo_auto_exec_forbidden IS
+  'Hard deny-list of action classes that must never auto-execute (irreversible / outward-facing). Engine reads via leo_engine_ro (SELECT-only). SD-LEO-INFRA-POLICY-GATED-AUTO-001B.';
+
+ALTER TABLE public.leo_auto_exec_forbidden ENABLE ROW LEVEL SECURITY;
+
+-- Seed the forbidden deny-list (idempotent).
+INSERT INTO public.leo_auto_exec_forbidden (action_class, reason, outward_facing) VALUES
+  ('hard_delete',               'irreversible destructive delete',  false),
+  ('prod_purge_no_soft_delete', 'irreversible prod data purge',     false),
+  ('external_email',            'outward-facing communication',     true),
+  ('repo_delete',               'irreversible repo deletion',       false),
+  ('force_push',                'history-destructive',              false)
+ON CONFLICT (action_class) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 3. Restricted engine role: leo_engine_ro  (STORAGE-LAYER meta-stability)
+-- ---------------------------------------------------------------------------
+-- Idempotent role creation. NOLOGIN (cannot be used to authenticate
+-- directly — assumed via SET ROLE / role membership by the engine path).
+-- Explicitly NOT a superuser and NOT BYPASSRLS.
+--
+-- NOTE: a standalone `ALTER ROLE ... NOSUPERUSER/NOBYPASSRLS` requires
+-- SUPERUSER to execute (even when setting the flags OFF), and the Supabase
+-- `postgres` role is CREATEROLE-but-NOT-superuser. We therefore set the safe
+-- attributes at CREATE time only — a non-superuser CREATEROLE member is
+-- allowed to create a role with the DEFAULT (NOSUPERUSER, NOBYPASSRLS,
+-- NOLOGIN) attributes. We do NOT emit a separate ALTER ROLE.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leo_engine_ro') THEN
+    CREATE ROLE leo_engine_ro NOLOGIN NOSUPERUSER NOBYPASSRLS;
+  END IF;
+END
+$$;
+
+-- Defense-in-depth assertion: fail the migration (rolling everything back) if
+-- the role somehow carries SUPERUSER / BYPASSRLS / LOGIN (e.g. drift from a
+-- prior definition). This only READS pg_roles, so it needs no superuser.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_roles
+    WHERE rolname = 'leo_engine_ro' AND (rolsuper OR rolbypassrls OR rolcanlogin)
+  ) THEN
+    RAISE EXCEPTION 'leo_engine_ro must be NOSUPERUSER, NOBYPASSRLS, NOLOGIN (privilege-escalation guard)';
+  END IF;
+END
+$$;
+
+-- Allow the table owner (postgres) to assume the role via SET ROLE so the
+-- engine's read path — and the rejection tests — can exercise it. This is a
+-- membership grant only; it does NOT give leo_engine_ro any extra privilege.
+GRANT leo_engine_ro TO postgres;
+
+-- Schema usage (required to reference any object in public).
+GRANT USAGE ON SCHEMA public TO leo_engine_ro;
+
+-- SELECT-ONLY on the four governance tables. No INSERT/UPDATE/DELETE granted,
+-- so writes fail at the table-privilege layer.
+GRANT SELECT ON public.leo_auto_exec_policy    TO leo_engine_ro;
+GRANT SELECT ON public.leo_auto_exec_forbidden TO leo_engine_ro;
+GRANT SELECT ON public.leo_feature_flags       TO leo_engine_ro;
+GRANT SELECT ON public.leo_kill_switches       TO leo_engine_ro;
+
+-- Be explicit: revoke any write privilege (no-op if never granted; guarantees
+-- the deny holds even against a future default-privilege or prior grant).
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_policy    FROM leo_engine_ro;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_forbidden FROM leo_engine_ro;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_feature_flags       FROM leo_engine_ro;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_kill_switches       FROM leo_engine_ro;
+
+-- ============================================================================
+-- DOWN / ROLLBACK  (apply manually to reverse this migration)
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--   -- Drop the restricted role's privileges first, then the role.
+--   REVOKE ALL ON public.leo_auto_exec_policy    FROM leo_engine_ro;
+--   REVOKE ALL ON public.leo_auto_exec_forbidden FROM leo_engine_ro;
+--   REVOKE ALL ON public.leo_feature_flags       FROM leo_engine_ro;
+--   REVOKE ALL ON public.leo_kill_switches       FROM leo_engine_ro;
+--   REVOKE USAGE ON SCHEMA public FROM leo_engine_ro;
+--   REVOKE leo_engine_ro FROM postgres;
+--   DROP ROLE IF EXISTS leo_engine_ro;
+--
+--   -- Drop the two new tables (additive objects only — pre-existing
+--   -- leo_feature_flags / leo_kill_switches are untouched).
+--   DROP TABLE IF EXISTS public.leo_auto_exec_forbidden;
+--   DROP TABLE IF EXISTS public.leo_auto_exec_policy;
+-- COMMIT;
+-- ============================================================================

--- a/lib/auto-exec-policy.js
+++ b/lib/auto-exec-policy.js
@@ -1,0 +1,146 @@
+/**
+ * Auto-exec policy gates — SD-LEO-INFRA-POLICY-GATED-AUTO-001B (child of the
+ * policy-gated auto-execution engine).
+ *
+ * The safety gates the engine (001C) consults BEFORE any action. No control loop
+ * and no auto-execution live here. Three concerns:
+ *
+ *  1. Reversibility classifier (FM-C) — an action is auto-eligible ONLY if it is
+ *     reversible within a bounded window AND not outward-facing AND not in the
+ *     human-owned forbidden-class set. Anything unknown/ambiguous defaults to
+ *     FORBIDDEN (fail-safe).
+ *  2. Path-overlap guard (FM-D, file side) — the engine may never target its own
+ *     guardrail paths (policy/forbidden/flag/kill-switch storage + settings.json).
+ *     The DB side of meta-stability is enforced at the storage layer by the
+ *     leo_engine_ro role's write-deny (see the migration + db test); this guard
+ *     covers filesystem/config targets static role grants cannot.
+ *  3. Fail-closed policy reader — loading an action-class policy that is missing
+ *     any required facet yields not-eligible, never a partial-policy proceed.
+ *
+ * The pure functions are unit-tested with no DB; the two async helpers wrap a
+ * supabase client and are exercised by the db-project integration test.
+ */
+
+/** Facets every action-class policy MUST define for the engine to act on it. */
+export const REQUIRED_POLICY_FACETS = Object.freeze([
+  'preconditions', 'canary', 'rollback', 'blast_radius', 'observe_window', 'escalation',
+]);
+
+/** Guardrail targets the engine must never act on (file/config side). */
+export const DEFAULT_GUARDRAIL_PATHS = Object.freeze([
+  '.claude/settings.json',
+  '.claude/settings.local.json',
+  'leo_auto_exec_policy',
+  'leo_auto_exec_forbidden',
+  'leo_feature_flags',
+  'leo_kill_switches',
+]);
+
+const norm = (p) => String(p ?? '').replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '').toLowerCase();
+
+/**
+ * Pure reversibility classifier. Default-safe: returns FORBIDDEN unless the action
+ * is provably reversible, not outward-facing, and not in the forbidden set.
+ *
+ * @param {object} action {action_class, target?, outward_facing?, reversible?, rollback_window_ms?}
+ * @param {object} opts {forbiddenClasses?: string[]}
+ * @returns {{eligible: boolean, verdict: 'reversible'|'forbidden', reason: string}}
+ */
+export function classifyReversibility(action, opts = {}) {
+  const forbidden = new Set((opts.forbiddenClasses || []).map((c) => String(c).toLowerCase()));
+  if (!action || typeof action !== 'object' || !action.action_class) {
+    return { eligible: false, verdict: 'forbidden', reason: 'no action_class (default-safe)' };
+  }
+  const cls = String(action.action_class).toLowerCase();
+  if (forbidden.has(cls)) {
+    return { eligible: false, verdict: 'forbidden', reason: `action_class '${action.action_class}' is in the forbidden set` };
+  }
+  if (action.outward_facing === true) {
+    return { eligible: false, verdict: 'forbidden', reason: 'outward-facing action is never auto-eligible' };
+  }
+  const windowMs = Number(action.rollback_window_ms);
+  if (action.reversible === true && Number.isFinite(windowMs) && windowMs > 0) {
+    return { eligible: true, verdict: 'reversible', reason: `reversible within ${windowMs}ms rollback window` };
+  }
+  return { eligible: false, verdict: 'forbidden', reason: 'not provably reversible within a bounded window (default-safe)' };
+}
+
+/**
+ * Pure path-overlap guard. Blocks an action whose target equals, contains, or is
+ * contained by any guardrail path (so the engine cannot edit its own safety layer).
+ *
+ * @param {string} target file path or table identifier the action would touch
+ * @param {object} opts {guardrailPaths?: string[]}
+ * @returns {{blocked: boolean, reason: string}}
+ */
+export function checkPathOverlap(target, opts = {}) {
+  const guardrails = (opts.guardrailPaths || DEFAULT_GUARDRAIL_PATHS).map(norm);
+  const t = norm(target);
+  if (!t) return { blocked: true, reason: 'empty target (default-safe)' };
+  for (const g of guardrails) {
+    if (t === g || t.startsWith(g + '/') || g.startsWith(t + '/')) {
+      return { blocked: true, reason: `target '${target}' overlaps guardrail path '${g}'` };
+    }
+  }
+  return { blocked: false, reason: 'target does not overlap any guardrail path' };
+}
+
+/** Pure: does a policy object define every required facet (non-null)? */
+export function validatePolicyShape(policy) {
+  if (!policy || typeof policy !== 'object') return { ok: false, missing: [...REQUIRED_POLICY_FACETS] };
+  const missing = REQUIRED_POLICY_FACETS.filter((f) => policy[f] == null);
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Combined eligibility decision for one action against one action-class policy.
+ * Pure — the engine composes the DB reads (loadActionPolicy / fetchForbiddenClasses)
+ * and passes the results in. ALL gates must pass; any failure is fail-safe FORBIDDEN.
+ */
+export function decideAutoExecEligibility(action, { policy, forbiddenClasses = [], guardrailPaths } = {}) {
+  const cls = classifyReversibility(action, { forbiddenClasses });
+  if (!cls.eligible) return { eligible: false, gate: 'reversibility', reason: cls.reason };
+
+  const overlap = checkPathOverlap(action.target, { guardrailPaths });
+  if (overlap.blocked) return { eligible: false, gate: 'path-overlap', reason: overlap.reason };
+
+  const shape = validatePolicyShape(policy);
+  if (!shape.ok) return { eligible: false, gate: 'policy', reason: `policy incomplete (missing: ${shape.missing.join(', ')})` };
+
+  return { eligible: true, gate: null, reason: 'all gates passed' };
+}
+
+/**
+ * DB: load an action-class policy (fail-closed). Returns {ok:false} when the policy
+ * is absent or incomplete so a partial policy can never authorize an action.
+ */
+export async function loadActionPolicy(db, actionClass) {
+  try {
+    const { data, error } = await db
+      .from('leo_auto_exec_policy')
+      .select('action_class, preconditions, canary, rollback, blast_radius, observe_window, escalation')
+      .eq('action_class', actionClass)
+      .maybeSingle();
+    if (error) return { ok: false, reason: `policy query error: ${error.message}` };
+    if (!data) return { ok: false, reason: `no policy for action_class '${actionClass}'` };
+    const shape = validatePolicyShape(data);
+    if (!shape.ok) return { ok: false, reason: `policy for '${actionClass}' incomplete (missing: ${shape.missing.join(', ')})` };
+    return { ok: true, policy: data };
+  } catch (e) {
+    return { ok: false, reason: `policy load failed: ${e.message}` };
+  }
+}
+
+/** DB: read the human-owned forbidden action-class set. Fail-safe: a read error
+ *  returns a sentinel so callers treat everything as forbidden, never as allowed. */
+export async function fetchForbiddenClasses(db) {
+  try {
+    const { data, error } = await db
+      .from('leo_auto_exec_forbidden')
+      .select('action_class, outward_facing');
+    if (error || !data) return { ok: false, classes: [], reason: 'forbidden-set read failed (treat all as forbidden)' };
+    return { ok: true, classes: data.map((r) => r.action_class) };
+  } catch (e) {
+    return { ok: false, classes: [], reason: `forbidden-set read failed: ${e.message}` };
+  }
+}

--- a/lib/auto-exec-policy.js
+++ b/lib/auto-exec-policy.js
@@ -78,7 +78,10 @@ export function checkPathOverlap(target, opts = {}) {
   const t = norm(target);
   if (!t) return { blocked: true, reason: 'empty target (default-safe)' };
   for (const g of guardrails) {
-    if (t === g || t.startsWith(g + '/') || g.startsWith(t + '/')) {
+    // equality; target inside a guardrail dir; a guardrail dir inside the target;
+    // or a guardrail path appearing as a path-boundary SUFFIX of an absolute /
+    // prefixed target (e.g. 'C:/proj/.claude/settings.json' or 'repo/leo_feature_flags').
+    if (t === g || t.startsWith(g + '/') || g.startsWith(t + '/') || t.endsWith('/' + g)) {
       return { blocked: true, reason: `target '${target}' overlaps guardrail path '${g}'` };
     }
   }

--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
     "session:worktree": "node scripts/session-worktree.js",
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "session:park": "node scripts/park-worker.cjs",
+    "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "registry:backfill-pending": "node scripts/backfill-pending-enablement-registry.mjs",
     "coord:email-summary": "node scripts/coordinator-email-summary.mjs",
     "worktree:remove": "node scripts/safe-worktree-remove.mjs",

--- a/scripts/auto-exec-policy-check.mjs
+++ b/scripts/auto-exec-policy-check.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * auto-exec-policy-check — operator/CI inspection CLI for the auto-exec policy gates.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001B.
+ *
+ * Given a candidate action, prints the reversibility classification, the
+ * path-overlap verdict, and (if --action-class names a policy) the fail-closed
+ * policy-load result + combined eligibility. Read-only; never executes anything.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/auto-exec-policy-check.mjs \
+ *     --action-class checkout_sync --target git-stash --reversible --window-ms 600000
+ *   node --env-file=.env scripts/auto-exec-policy-check.mjs --action-class hard_delete --target repo
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  classifyReversibility,
+  checkPathOverlap,
+  loadActionPolicy,
+  fetchForbiddenClasses,
+  decideAutoExecEligibility,
+} from '../lib/auto-exec-policy.js';
+
+function getArg(flag, def = undefined) {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--') ? process.argv[i + 1] : def;
+}
+const has = (flag) => process.argv.includes(flag);
+
+const action = {
+  action_class: getArg('--action-class'),
+  target: getArg('--target'),
+  outward_facing: has('--outward-facing'),
+  reversible: has('--reversible'),
+  rollback_window_ms: Number(getArg('--window-ms', '0')),
+};
+
+if (!action.action_class) {
+  console.error('ERROR: --action-class is required. See the header for usage.');
+  process.exit(2);
+}
+
+const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const forbidden = await fetchForbiddenClasses(db);
+const cls = classifyReversibility(action, { forbiddenClasses: forbidden.classes });
+const overlap = checkPathOverlap(action.target);
+const policy = await loadActionPolicy(db, action.action_class);
+const decision = decideAutoExecEligibility(action, {
+  policy: policy.ok ? policy.policy : null,
+  forbiddenClasses: forbidden.classes,
+});
+
+console.log('=== auto-exec policy check ===');
+console.log(`action_class : ${action.action_class}`);
+console.log(`target       : ${action.target ?? '(none)'}`);
+console.log(`forbidden-set: ${forbidden.ok ? forbidden.classes.join(', ') || '(empty)' : 'READ FAILED → treat all as forbidden'}`);
+console.log(`reversibility: ${cls.verdict} — ${cls.reason}`);
+console.log(`path-overlap : ${overlap.blocked ? 'BLOCKED' : 'ok'} — ${overlap.reason}`);
+console.log(`policy load  : ${policy.ok ? 'complete' : 'NOT ELIGIBLE'} — ${policy.ok ? 'all facets present' : policy.reason}`);
+console.log(`DECISION     : ${decision.eligible ? 'AUTO-ELIGIBLE' : `BLOCKED@${decision.gate}`} — ${decision.reason}`);
+
+// Non-zero exit when the action would be blocked, so CI/automation can gate on it.
+process.exit(decision.eligible ? 0 : 1);

--- a/tests/auto-exec-policy.test.js
+++ b/tests/auto-exec-policy.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit tests (no DB) for the auto-exec policy gates.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001B.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  REQUIRED_POLICY_FACETS,
+  DEFAULT_GUARDRAIL_PATHS,
+  classifyReversibility,
+  checkPathOverlap,
+  validatePolicyShape,
+  decideAutoExecEligibility,
+} from '../lib/auto-exec-policy.js';
+
+const FORBIDDEN = ['hard_delete', 'prod_purge_no_soft_delete', 'external_email', 'repo_delete', 'force_push'];
+
+describe('classifyReversibility (FM-C)', () => {
+  it('soft-delete with a rollback window is reversible (near-miss vs hard_delete)', () => {
+    const r = classifyReversibility({ action_class: 'soft_delete', reversible: true, rollback_window_ms: 600000 }, { forbiddenClasses: FORBIDDEN });
+    expect(r.eligible).toBe(true);
+    expect(r.verdict).toBe('reversible');
+  });
+  it('hard-delete is FORBIDDEN (in the forbidden set)', () => {
+    const r = classifyReversibility({ action_class: 'hard_delete', reversible: true, rollback_window_ms: 600000 }, { forbiddenClasses: FORBIDDEN });
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/forbidden set/);
+  });
+  it('internal notify reversible vs external email FORBIDDEN (outward-facing)', () => {
+    expect(classifyReversibility({ action_class: 'internal_notify', reversible: true, rollback_window_ms: 1000 }, { forbiddenClasses: FORBIDDEN }).eligible).toBe(true);
+    const ext = classifyReversibility({ action_class: 'external_email', outward_facing: true, reversible: true, rollback_window_ms: 1000 }, { forbiddenClasses: FORBIDDEN });
+    expect(ext.eligible).toBe(false);
+    expect(ext.reason).toMatch(/forbidden set|outward-facing/);
+  });
+  it('outward-facing alone is FORBIDDEN even if class is not listed', () => {
+    const r = classifyReversibility({ action_class: 'novel_broadcast', outward_facing: true, reversible: true, rollback_window_ms: 1000 }, { forbiddenClasses: FORBIDDEN });
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/outward-facing/);
+  });
+  it('reversible=true but no rollback window → FORBIDDEN (default-safe)', () => {
+    expect(classifyReversibility({ action_class: 'x', reversible: true, rollback_window_ms: 0 }).eligible).toBe(false);
+  });
+  it('unknown/ambiguous action → FORBIDDEN (fail-safe)', () => {
+    expect(classifyReversibility({ action_class: 'mystery' }).eligible).toBe(false);
+  });
+  it('missing action_class / garbage → FORBIDDEN', () => {
+    expect(classifyReversibility(null).eligible).toBe(false);
+    expect(classifyReversibility({}).eligible).toBe(false);
+  });
+});
+
+describe('checkPathOverlap (FM-D, file side)', () => {
+  it('blocks settings.json', () => expect(checkPathOverlap('.claude/settings.json').blocked).toBe(true));
+  it('blocks a guardrail table identifier', () => expect(checkPathOverlap('leo_feature_flags').blocked).toBe(true));
+  it('blocks a path INSIDE a guardrail dir', () => expect(checkPathOverlap('.claude/settings.json/nested').blocked).toBe(true));
+  it('blocks a parent of a guardrail path', () => expect(checkPathOverlap('.claude').blocked).toBe(true));
+  it('allows an unrelated target', () => expect(checkPathOverlap('src/components/Foo.tsx').blocked).toBe(false));
+  it('normalizes backslashes and ./ prefix', () => expect(checkPathOverlap('.\\.claude\\settings.json').blocked).toBe(true));
+  it('blocks empty target (default-safe)', () => expect(checkPathOverlap('').blocked).toBe(true));
+  it('respects a custom guardrail set', () => {
+    expect(checkPathOverlap('secret.env', { guardrailPaths: ['secret.env'] }).blocked).toBe(true);
+  });
+});
+
+describe('validatePolicyShape (fail-closed)', () => {
+  const complete = Object.fromEntries(REQUIRED_POLICY_FACETS.map((f) => [f, { x: 1 }]));
+  it('ok when every facet present', () => expect(validatePolicyShape(complete).ok).toBe(true));
+  it('not-ok and lists the missing facet', () => {
+    const partial = { ...complete }; delete partial.rollback;
+    const r = validatePolicyShape(partial);
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain('rollback');
+  });
+  it('not-ok for null', () => expect(validatePolicyShape(null).ok).toBe(false));
+  it('exposes the canonical 6 facets', () => expect(REQUIRED_POLICY_FACETS).toHaveLength(6));
+  it('default guardrails include settings.json and the 4 guardrail tables', () => {
+    expect(DEFAULT_GUARDRAIL_PATHS).toEqual(expect.arrayContaining(['.claude/settings.json', 'leo_feature_flags', 'leo_kill_switches', 'leo_auto_exec_policy', 'leo_auto_exec_forbidden']));
+  });
+});
+
+describe('decideAutoExecEligibility (composed)', () => {
+  const policy = Object.fromEntries(REQUIRED_POLICY_FACETS.map((f) => [f, {}]));
+  const goodAction = { action_class: 'checkout_sync', target: 'git-stash', reversible: true, rollback_window_ms: 600000 };
+  it('eligible when all gates pass', () => {
+    const d = decideAutoExecEligibility(goodAction, { policy, forbiddenClasses: FORBIDDEN });
+    expect(d.eligible).toBe(true);
+  });
+  it('blocked at reversibility for a forbidden class', () => {
+    const d = decideAutoExecEligibility({ ...goodAction, action_class: 'hard_delete' }, { policy, forbiddenClasses: FORBIDDEN });
+    expect(d).toMatchObject({ eligible: false, gate: 'reversibility' });
+  });
+  it('blocked at path-overlap when targeting a guardrail', () => {
+    const d = decideAutoExecEligibility({ ...goodAction, target: '.claude/settings.json' }, { policy, forbiddenClasses: FORBIDDEN });
+    expect(d).toMatchObject({ eligible: false, gate: 'path-overlap' });
+  });
+  it('blocked at policy when the policy is incomplete', () => {
+    const partial = { ...policy }; delete partial.canary;
+    const d = decideAutoExecEligibility(goodAction, { policy: partial, forbiddenClasses: FORBIDDEN });
+    expect(d).toMatchObject({ eligible: false, gate: 'policy' });
+  });
+});

--- a/tests/auto-exec-policy.test.js
+++ b/tests/auto-exec-policy.test.js
@@ -54,6 +54,13 @@ describe('checkPathOverlap (FM-D, file side)', () => {
   it('blocks a path INSIDE a guardrail dir', () => expect(checkPathOverlap('.claude/settings.json/nested').blocked).toBe(true));
   it('blocks a parent of a guardrail path', () => expect(checkPathOverlap('.claude').blocked).toBe(true));
   it('allows an unrelated target', () => expect(checkPathOverlap('src/components/Foo.tsx').blocked).toBe(false));
+  it('blocks a guardrail path that is a SUFFIX of an absolute/prefixed target', () => {
+    expect(checkPathOverlap('C:/proj/.claude/settings.json').blocked).toBe(true);
+    expect(checkPathOverlap('repo/leo_feature_flags').blocked).toBe(true);
+  });
+  it('does NOT false-positive on a non-boundary substring', () => {
+    expect(checkPathOverlap('my_leo_feature_flags_archive').blocked).toBe(false);
+  });
   it('normalizes backslashes and ./ prefix', () => expect(checkPathOverlap('.\\.claude\\settings.json').blocked).toBe(true));
   it('blocks empty target (default-safe)', () => expect(checkPathOverlap('').blocked).toBe(true));
   it('respects a custom guardrail set', () => {

--- a/tests/integration/auto-exec-policy.db.test.js
+++ b/tests/integration/auto-exec-policy.db.test.js
@@ -1,0 +1,217 @@
+// SD-LEO-INFRA-POLICY-GATED-AUTO-001B
+// STORAGE-LAYER meta-stability: the auto-execution engine must be UNABLE to
+// write its own policy / guardrail tables, even if application code is
+// compromised. The defense lives at the table-privilege layer: the engine's
+// database role `leo_engine_ro` holds SELECT-ONLY grants on the four
+// governance tables (leo_auto_exec_policy, leo_auto_exec_forbidden,
+// leo_feature_flags, leo_kill_switches) and is NOT superuser / NOT BYPASSRLS.
+// Any write it attempts therefore raises `permission denied for table ...`
+// BEFORE any RLS policy or app check.
+//
+// HOW THIS TEST CONNECTS — DIRECT pg, NOT supabase-js:
+//   `SET ROLE leo_engine_ro` is a session-level Postgres command that cannot be
+//   issued over the supabase-js REST/PostgREST client (which always runs as the
+//   service role and exposes no SET ROLE). The deny we are codifying is a
+//   STORAGE-layer guarantee, so the test must hold a real pg socket. We open a
+//   single direct `pg.Client` on SUPABASE_POOLER_URL (falling back to
+//   DATABASE_URL), run the ENTIRE scenario inside ONE transaction with
+//   per-statement SAVEPOINTs (a permission-denied error aborts the surrounding
+//   (sub)transaction in Postgres, so each denied write is wrapped in a savepoint
+//   so we can roll back to it and continue), then ROLLBACK at the end so NOTHING
+//   touches committed prod state. This mirrors
+//   tests/integration/migrations/cleanup-stale-sessions-respect-inflight.test.js
+//   and scripts/apply-migration.js.
+//
+// SKIP CONTRACT: when no direct pg connection string is configured (CI without
+// DB secrets / local without creds) the suite SKIPS cleanly via describeDb's
+// HAS_REAL_DB guard AND a local connection-string guard — it never reds.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from 'pg';
+import dotenv from 'dotenv';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+
+dotenv.config();
+
+// Direct-pg connection string. Strip any sslmode= param the way
+// scripts/lib/supabase-connection.js does so node-postgres' own ssl config wins.
+function resolveConnString() {
+  const raw = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || '';
+  if (!raw) return null;
+  return raw.replace(/[?&]sslmode=[^&]*/i, '');
+}
+
+const CONN_STRING = resolveConnString();
+// Run only when BOTH a real Supabase env is configured (db-available helper)
+// AND we have a direct pg connection string for SET ROLE.
+const HAS_DB = Boolean(HAS_REAL_DB && CONN_STRING);
+
+// Pooler presents a self-signed Supabase Root 2021 CA absent from the local
+// trust store; mirror apply-migration.js for this READ-then-ROLLBACK probe.
+function makeSslConfig() {
+  return { rejectUnauthorized: false };
+}
+
+const GOVERNANCE_TABLES = [
+  'leo_auto_exec_policy',
+  'leo_auto_exec_forbidden',
+  'leo_feature_flags',
+  'leo_kill_switches',
+];
+
+describe.skipIf(!HAS_DB)(
+  'SD-LEO-INFRA-POLICY-GATED-AUTO-001B: storage-layer meta-stability (leo_engine_ro write-deny)',
+  () => {
+    /** @type {import('pg').Client} */
+    let client;
+    let inTxn = false;
+
+    beforeAll(async () => {
+      client = new Client({ connectionString: CONN_STRING, ssl: makeSslConfig() });
+      await client.connect();
+    });
+
+    afterAll(async () => {
+      if (client) {
+        if (inTxn) {
+          try { await client.query('ROLLBACK'); } catch { /* already rolled back */ }
+        }
+        await client.end().catch(() => {});
+      }
+    });
+
+    // Helper: run `sql` and expect a permission-denied error, wrapped in a
+    // savepoint so the aborted (sub)transaction can be rolled back and the
+    // suite continues.
+    async function expectPermissionDenied(sql) {
+      await client.query('SAVEPOINT sp');
+      try {
+        await client.query(sql);
+        await client.query('RELEASE SAVEPOINT sp');
+        return { denied: false, message: null };
+      } catch (e) {
+        await client.query('ROLLBACK TO SAVEPOINT sp');
+        return { denied: true, message: String(e.message || e) };
+      }
+    }
+
+    it('the migration objects exist: 2 tables (RLS on) + restricted non-privileged role + SELECT-only grants', async () => {
+      const tabs = await client.query(
+        `SELECT c.relname, c.relrowsecurity
+           FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relname IN ('leo_auto_exec_policy','leo_auto_exec_forbidden')
+          ORDER BY c.relname`
+      );
+      expect(tabs.rows.map(r => r.relname)).toEqual([
+        'leo_auto_exec_forbidden',
+        'leo_auto_exec_policy',
+      ]);
+      // RLS enabled on both new tables.
+      expect(tabs.rows.every(r => r.relrowsecurity === true)).toBe(true);
+
+      // Role exists and is NOT superuser / NOT bypassrls / NOT login.
+      const role = await client.query(
+        `SELECT rolsuper, rolbypassrls, rolcanlogin
+           FROM pg_roles WHERE rolname = 'leo_engine_ro'`
+      );
+      expect(role.rowCount).toBe(1);
+      expect(role.rows[0].rolsuper).toBe(false);
+      expect(role.rows[0].rolbypassrls).toBe(false);
+      expect(role.rows[0].rolcanlogin).toBe(false);
+
+      // SELECT-only grants on the four governance tables — and NO write grant.
+      const grants = await client.query(
+        `SELECT table_name, privilege_type
+           FROM information_schema.role_table_grants
+          WHERE grantee = 'leo_engine_ro'
+            AND table_name = ANY($1::text[])
+          ORDER BY table_name, privilege_type`,
+        [GOVERNANCE_TABLES]
+      );
+      const byTable = {};
+      for (const g of grants.rows) {
+        (byTable[g.table_name] ??= []).push(g.privilege_type);
+      }
+      for (const t of GOVERNANCE_TABLES) {
+        expect(byTable[t], `expected grants on ${t}`).toEqual(['SELECT']);
+      }
+    });
+
+    it('SET ROLE leo_engine_ro: SELECT works, but ALL writes are denied at the storage layer; operator (service-role) can write', async () => {
+      await client.query('BEGIN');
+      inTxn = true;
+
+      // --- under the restricted engine role ---
+      await client.query('SET ROLE leo_engine_ro');
+      expect((await client.query('SELECT current_user')).rows[0].current_user).toBe('leo_engine_ro');
+
+      // SELECT must NOT raise a permission error on any governance table.
+      // (RLS may filter rows to zero for this non-owner role; we assert only
+      // that the SELECT *privilege* is present, not a specific row count.)
+      for (const t of GOVERNANCE_TABLES) {
+        await expect(
+          client.query(`SELECT count(*) FROM public.${t}`)
+        ).resolves.toBeDefined();
+      }
+
+      // Every write must be denied with "permission denied for table".
+      const denials = {
+        'UPDATE leo_auto_exec_policy': await expectPermissionDenied(
+          `UPDATE public.leo_auto_exec_policy SET updated_at = now() WHERE action_class = '__none__'`
+        ),
+        'INSERT leo_feature_flags': await expectPermissionDenied(
+          `INSERT INTO public.leo_feature_flags (flag_key, display_name) VALUES ('engine_attempt','engine attempt')`
+        ),
+        'DELETE leo_kill_switches': await expectPermissionDenied(
+          `DELETE FROM public.leo_kill_switches WHERE switch_key = '__none__'`
+        ),
+        'INSERT leo_auto_exec_policy': await expectPermissionDenied(
+          `INSERT INTO public.leo_auto_exec_policy (action_class) VALUES ('engine_attempt')`
+        ),
+        'INSERT leo_auto_exec_forbidden': await expectPermissionDenied(
+          `INSERT INTO public.leo_auto_exec_forbidden (action_class) VALUES ('engine_attempt')`
+        ),
+      };
+      for (const [label, res] of Object.entries(denials)) {
+        expect(res.denied, `${label} should be denied`).toBe(true);
+        expect(res.message, `${label} error text`).toMatch(/permission denied for table/i);
+      }
+
+      // --- back to the operator (service-role / postgres) ---
+      await client.query('RESET ROLE');
+      expect((await client.query('SELECT current_user')).rows[0].current_user).not.toBe('leo_engine_ro');
+
+      // Operator CAN write the policy table (asserted in-txn; rolled back).
+      await client.query('SAVEPOINT op');
+      await client.query(
+        `INSERT INTO public.leo_auto_exec_policy (action_class, preconditions)
+         VALUES ('__operator_probe__', '{"k":true}'::jsonb)`
+      );
+      const probe = await client.query(
+        `SELECT count(*)::int AS n FROM public.leo_auto_exec_policy WHERE action_class = '__operator_probe__'`
+      );
+      expect(probe.rows[0].n).toBe(1);
+      await client.query('ROLLBACK TO SAVEPOINT op');
+
+      // Operator CAN write a feature flag too.
+      await client.query('SAVEPOINT op2');
+      await expect(
+        client.query(
+          `INSERT INTO public.leo_feature_flags (flag_key, display_name) VALUES ('__operator_probe__','operator probe')`
+        )
+      ).resolves.toBeDefined();
+      await client.query('ROLLBACK TO SAVEPOINT op2');
+
+      // Roll back the whole scenario — zero committed prod impact.
+      await client.query('ROLLBACK');
+      inTxn = false;
+
+      // Confirm nothing leaked.
+      const leftover = await client.query(
+        `SELECT count(*)::int AS n FROM public.leo_auto_exec_policy WHERE action_class = '__operator_probe__'`
+      );
+      expect(leftover.rows[0].n).toBe(0);
+    });
+  }
+);


### PR DESCRIPTION
## Child 001B of SD-LEO-INFRA-POLICY-GATED-AUTO-001 (policy-gated auto-execution engine)

The **safety foundation** (low blast, **no auto-execution**): builds and *proves* the gates the engine (001C) will consult before any action.

### What
- **Migration** — `leo_auto_exec_policy` + `leo_auto_exec_forbidden` (RLS enabled) + a **restricted engine role `leo_engine_ro`** (NOSUPERUSER/NOBYPASSRLS/NOLOGIN) with **SELECT-only** grants on policy/forbidden/`leo_feature_flags`/`leo_kill_switches`. Applied via the audited `apply-migration.js --prod-deploy`. Forbidden set seeded (hard_delete, prod_purge_no_soft_delete, external_email, repo_delete, force_push).
- **Storage-layer meta-stability (FM-D)** — the engine cannot write its own guardrails. Proven by a live `SET ROLE leo_engine_ro` rejection test: `permission denied` on UPDATE/INSERT/DELETE of every guardrail table, while the operator (service-role) write still succeeds. This is at the **table-privilege layer**, not app code (app-layer-only would be a critical gap).
- **lib/auto-exec-policy.js** — pure **reversibility classifier** (FM-C; default-safe FORBIDDEN; rejects forbidden-class, outward-facing, and non-reversible-within-window), **path-overlap guard** (engine may not target `settings.json` / guardrail tables), **fail-closed policy reader**, and a composed `decideAutoExecEligibility`.
- **scripts/auto-exec-policy-check.mjs** (`npm run policy:check`) — operator/CI inspection CLI; read-only.

### Tests
- **24 unit** — soft-vs-hard-delete & internal-vs-external-email near-misses, fail-safe defaults (unknown/ambiguous → FORBIDDEN), path-overlap (incl. settings.json, parent/child paths, custom sets), fail-closed policy shape.
- **2 DB integration** (direct `pg.Client`, self-skips without DB) — `SET ROLE` write-deny on all four guardrail tables + operator write succeeds.

### Reversibility / safety
Additive + reversible (down-migration drops tables + role). No control loop, no auto-exec. **Carry to 001C:** add a permissive SELECT RLS policy for `leo_engine_ro` so the engine can *read* policy under the restricted role (writes stay denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)