### PR TITLE
feat(SD-LEO-INFRA-POLICY-GATED-AUTO-001C): auto-exec engine control loop (default-OFF, synthetic)

### DIFF
--- a/database/migrations/20260607_auto_exec_engine_audit.sql
+++ b/database/migrations/20260607_auto_exec_engine_audit.sql
@@ -80,9 +80,12 @@ $$;
 COMMENT ON FUNCTION public.leo_auto_exec_audit_append_only() IS
   'Append-only guard for leo_auto_exec_audit: raises on any UPDATE/DELETE. SD-LEO-INFRA-POLICY-GATED-AUTO-001C.';
 
+-- CREATE OR REPLACE (PG14+) is idempotent against an already-applied trigger and
+-- satisfies the pre-merge migration-readiness probe (R5: CREATE-without-OR-REPLACE
+-- on an existing object is CONFLICTING). DROP IF EXISTS kept as belt-and-suspenders.
 DROP TRIGGER IF EXISTS trg_leo_auto_exec_audit_append_only
   ON public.leo_auto_exec_audit;
-CREATE TRIGGER trg_leo_auto_exec_audit_append_only
+CREATE OR REPLACE TRIGGER trg_leo_auto_exec_audit_append_only
   BEFORE UPDATE OR DELETE ON public.leo_auto_exec_audit
   FOR EACH ROW
   EXECUTE FUNCTION public.leo_auto_exec_audit_append_only();

--- a/database/migrations/20260607_auto_exec_engine_audit.sql
+++ b/database/migrations/20260607_auto_exec_engine_audit.sql
@@ -1,0 +1,189 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- ============================================================================
+-- Migration: Auto-execution engine APPEND-ONLY audit log + 001B SELECT-RLS
+--            carry-forward for the restricted engine role.
+--
+-- SD: SD-LEO-INFRA-POLICY-GATED-AUTO-001C
+--     (auto-exec engine control loop; child of the policy-gated
+--      auto-execution engine)
+-- sd_id: 262bd51d-5db0-4656-a362-e030bead9405
+--
+-- GOAL
+--   The auto-execution control loop needs (1) a tamper-evident, append-only
+--   audit trail of every decision/action it takes, and (2) the ability to
+--   actually READ its own policy/forbidden tables under the restricted
+--   leo_engine_ro role. 001B granted SELECT to leo_engine_ro and enabled RLS
+--   on the policy/forbidden tables, but added NO permissive SELECT policy —
+--   so RLS currently filters those reads to ZERO rows for the engine role.
+--
+--   This migration:
+--     1. Creates public.leo_auto_exec_audit — APPEND-ONLY (a BEFORE UPDATE OR
+--        DELETE trigger raises), RLS on, SELECT for service_role + leo_engine_ro,
+--        INSERT for service_role. No UPDATE/DELETE granted to anyone.
+--     2. Adds permissive SELECT RLS policies for leo_engine_ro on
+--        leo_auto_exec_policy + leo_auto_exec_forbidden so the engine can READ
+--        its policy. Writes stay denied at the storage (table-privilege) layer
+--        — 001B's SELECT-only grant is untouched, so this does NOT regress the
+--        write-deny.
+--
+-- PROPERTIES
+--   * Additive only.
+--   * Fully idempotent (IF NOT EXISTS / CREATE OR REPLACE / guarded DROP POLICY
+--     + CREATE POLICY / ON CONFLICT-free).
+--   * Reversible — see the DOWN / ROLLBACK SQL block at the bottom.
+--   * Does NOT weaken any existing grant. leo_engine_ro keeps SELECT-ONLY on
+--     the policy/forbidden tables; the new SELECT policy only un-filters the
+--     rows it is already privileged to read.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. leo_auto_exec_audit  — APPEND-ONLY control-loop audit log
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.leo_auto_exec_audit (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id       UUID,
+  action_class TEXT,
+  phase        TEXT,
+  target       TEXT,
+  decision     JSONB,
+  snapshot     JSONB,
+  outcome      TEXT,
+  detail       JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.leo_auto_exec_audit IS
+  'APPEND-ONLY audit trail for the policy-gated auto-execution control loop: one row per decision/action (run_id, action_class, phase, target, decision, snapshot, outcome, detail). UPDATE/DELETE are blocked by a BEFORE trigger AND by withheld table privileges. Engine/operators read via service_role + leo_engine_ro. SD-LEO-INFRA-POLICY-GATED-AUTO-001C.';
+
+-- Helpful index for run-scoped + time-ordered reads (additive, idempotent).
+CREATE INDEX IF NOT EXISTS idx_leo_auto_exec_audit_run_id
+  ON public.leo_auto_exec_audit (run_id);
+CREATE INDEX IF NOT EXISTS idx_leo_auto_exec_audit_created_at
+  ON public.leo_auto_exec_audit (created_at);
+
+ALTER TABLE public.leo_auto_exec_audit ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- 1a. APPEND-ONLY hard guarantee: a BEFORE UPDATE OR DELETE trigger that
+--     RAISES regardless of role (defense beyond the withheld grants).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.leo_auto_exec_audit_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'leo_auto_exec_audit is append-only: % is not permitted', TG_OP
+    USING ERRCODE = 'restrict_violation';
+END;
+$$;
+
+COMMENT ON FUNCTION public.leo_auto_exec_audit_append_only() IS
+  'Append-only guard for leo_auto_exec_audit: raises on any UPDATE/DELETE. SD-LEO-INFRA-POLICY-GATED-AUTO-001C.';
+
+DROP TRIGGER IF EXISTS trg_leo_auto_exec_audit_append_only
+  ON public.leo_auto_exec_audit;
+CREATE TRIGGER trg_leo_auto_exec_audit_append_only
+  BEFORE UPDATE OR DELETE ON public.leo_auto_exec_audit
+  FOR EACH ROW
+  EXECUTE FUNCTION public.leo_auto_exec_audit_append_only();
+
+-- ---------------------------------------------------------------------------
+-- 1b. RLS policies for leo_auto_exec_audit.
+--     SELECT: service_role + leo_engine_ro.  INSERT: service_role.
+--     (No UPDATE/DELETE policy — and no UPDATE/DELETE grant — so those paths
+--      are denied both at RLS AND at the privilege layer; the trigger is the
+--      belt-and-suspenders hard stop.)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS audit_select_service_role ON public.leo_auto_exec_audit;
+CREATE POLICY audit_select_service_role
+  ON public.leo_auto_exec_audit
+  FOR SELECT
+  TO service_role
+  USING (true);
+
+DROP POLICY IF EXISTS audit_select_engine_ro ON public.leo_auto_exec_audit;
+CREATE POLICY audit_select_engine_ro
+  ON public.leo_auto_exec_audit
+  FOR SELECT
+  TO leo_engine_ro
+  USING (true);
+
+DROP POLICY IF EXISTS audit_insert_service_role ON public.leo_auto_exec_audit;
+CREATE POLICY audit_insert_service_role
+  ON public.leo_auto_exec_audit
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+-- ---------------------------------------------------------------------------
+-- 1c. Table grants for leo_auto_exec_audit.
+--     SELECT + INSERT to service_role; SELECT to leo_engine_ro.
+--     Explicitly REVOKE write privileges from leo_engine_ro and never grant
+--     UPDATE/DELETE/TRUNCATE to anyone here.
+-- ---------------------------------------------------------------------------
+GRANT SELECT, INSERT ON public.leo_auto_exec_audit TO service_role;
+GRANT SELECT          ON public.leo_auto_exec_audit TO leo_engine_ro;
+
+-- Be explicit: leo_engine_ro must never carry a write privilege on the audit.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_audit FROM leo_engine_ro;
+-- service_role must never be able to UPDATE/DELETE the append-only log either
+-- (INSERT is its only write path). The trigger is the hard stop regardless.
+REVOKE UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_audit FROM service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. 001B CARRY-FORWARD — permissive SELECT RLS for leo_engine_ro on the
+--    policy + forbidden tables. RLS is already enabled and leo_engine_ro
+--    already holds the SELECT *privilege* (001B), but with no SELECT policy
+--    RLS filters every row out. These policies un-filter reads ONLY; they add
+--    NO write capability (no INSERT/UPDATE/DELETE policy, no write grant).
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS engine_ro_select_leo_auto_exec_policy
+  ON public.leo_auto_exec_policy;
+CREATE POLICY engine_ro_select_leo_auto_exec_policy
+  ON public.leo_auto_exec_policy
+  FOR SELECT
+  TO leo_engine_ro
+  USING (true);
+
+DROP POLICY IF EXISTS engine_ro_select_leo_auto_exec_forbidden
+  ON public.leo_auto_exec_forbidden;
+CREATE POLICY engine_ro_select_leo_auto_exec_forbidden
+  ON public.leo_auto_exec_forbidden
+  FOR SELECT
+  TO leo_engine_ro
+  USING (true);
+
+-- Re-assert (idempotent, no-op if already correct) that 001B's write-deny on
+-- the policy/forbidden tables is intact — we must NOT regress it.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_policy    FROM leo_engine_ro;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+  ON public.leo_auto_exec_forbidden FROM leo_engine_ro;
+
+-- ============================================================================
+-- DOWN / ROLLBACK  (apply manually to reverse this migration)
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--   -- 2. Drop the 001B carry-forward SELECT policies (RLS stays enabled;
+--   --    leo_engine_ro reverts to RLS-filtered-to-zero, matching 001B).
+--   DROP POLICY IF EXISTS engine_ro_select_leo_auto_exec_forbidden
+--     ON public.leo_auto_exec_forbidden;
+--   DROP POLICY IF EXISTS engine_ro_select_leo_auto_exec_policy
+--     ON public.leo_auto_exec_policy;
+--
+--   -- 1. Tear down the audit log (policies → grants → trigger → function → table).
+--   DROP POLICY  IF EXISTS audit_insert_service_role  ON public.leo_auto_exec_audit;
+--   DROP POLICY  IF EXISTS audit_select_engine_ro     ON public.leo_auto_exec_audit;
+--   DROP POLICY  IF EXISTS audit_select_service_role  ON public.leo_auto_exec_audit;
+--   REVOKE ALL ON public.leo_auto_exec_audit FROM leo_engine_ro;
+--   REVOKE ALL ON public.leo_auto_exec_audit FROM service_role;
+--   DROP TRIGGER IF EXISTS trg_leo_auto_exec_audit_append_only
+--     ON public.leo_auto_exec_audit;
+--   DROP FUNCTION IF EXISTS public.leo_auto_exec_audit_append_only();
+--   DROP INDEX  IF EXISTS public.idx_leo_auto_exec_audit_created_at;
+--   DROP INDEX  IF EXISTS public.idx_leo_auto_exec_audit_run_id;
+--   DROP TABLE  IF EXISTS public.leo_auto_exec_audit;
+-- COMMIT;
+-- ============================================================================

--- a/lib/auto-exec-engine.js
+++ b/lib/auto-exec-engine.js
@@ -1,0 +1,237 @@
+/**
+ * Auto-execution engine control loop — SD-LEO-INFRA-POLICY-GATED-AUTO-001C
+ * (child of the policy-gated auto-execution engine).
+ *
+ * The loop: flag-gate -> kill-switch -> 001B eligibility gate -> write-before-act
+ * audit -> snapshot -> canary apply -> observe -> TOCTOU re-validate ->
+ * kill-switch re-check -> commit-or-rollback -> audit + telemetry.
+ *
+ * SAFETY INVARIANTS (this child ships them as code, not aspirations):
+ *  - DEFAULT-OFF (FM-A): when the flag is off the loop is a pure no-op — no
+ *    snapshot, no apply, no audit, no DB write. Golden-test asserts byte-identity.
+ *  - RELIABLE ROLLBACK (FM-B): any apply/observe/revalidate/commit failure or
+ *    unhealthy canary rolls back to the pre-action snapshot. A rollback that
+ *    itself fails returns status 'rollback_failed' + killSwitchRecommended — it is
+ *    never silently swallowed.
+ *  - TOCTOU (FM-E): the loop re-validates the world immediately before commit and
+ *    rolls back on any mismatch.
+ *  - WRITE-BEFORE-ACT, FAIL-CLOSED AUDIT: intent is recorded before the act; if
+ *    the audit write fails the loop aborts WITHOUT acting.
+ *  - META-STABILITY: the loop only ever touches the injected action; it never
+ *    writes guardrail tables (the leo_engine_ro role + path-overlap guard from
+ *    001B make that guarantee enforceable).
+ *
+ * Runs ONLY against a SYNTHETIC, fully-reversible action here — no real
+ * shared-infra op is wired until 001D. The loop is dependency-injected so it is
+ * unit-testable without a live DB.
+ */
+
+import { decideAutoExecEligibility } from './auto-exec-policy.js';
+
+const resolveMaybe = async (v) => (typeof v === 'function' ? await v() : v);
+
+async function safeAudit(audit, row) {
+  // Post-act audits are best-effort (the act already happened / is being undone);
+  // they must never throw out of the loop. Write-before-act audit is handled
+  // separately and IS fail-closed.
+  try { await audit(row); return true; } catch { return false; }
+}
+
+/**
+ * Run one auto-execution attempt for a synthetic/real action.
+ *
+ * @param {object} action {action_class, target, reversible, rollback_window_ms,
+ *   outward_facing?, snapshot(), apply(), rollback(snap), validate(snap), canaryHealthy(), commit?()}
+ * @param {object} deps {flagEnabled, killSwitchActive, policy, forbiddenClasses,
+ *   guardrailPaths, audit, sleep, observeWindowMs, emitTelemetry, runId}
+ *   flagEnabled / killSwitchActive may be a value or an async function.
+ * @returns {Promise<{status:string, ...}>}
+ */
+export async function runAutoExec(action, deps = {}) {
+  const {
+    flagEnabled = false,
+    killSwitchActive = false,
+    policy = null,
+    forbiddenClasses = [],
+    guardrailPaths,
+    audit = async () => {},
+    sleep = async () => {},
+    observeWindowMs = 0,
+    emitTelemetry,
+    runId = 'run',
+  } = deps;
+
+  // 1. Flag gate — DEFAULT-OFF. Zero side effects when off (golden path).
+  if (!(await resolveMaybe(flagEnabled))) {
+    return { status: 'skipped', reason: 'flag_off' };
+  }
+
+  // 2. Kill-switch at entry. Fail-safe: any error => treat as active (stop).
+  let killed;
+  try { killed = await resolveMaybe(killSwitchActive); } catch { killed = true; }
+  if (killed) return { status: 'aborted', reason: 'kill_switch' };
+
+  const base = { runId, action_class: action?.action_class, target: action?.target };
+
+  // 3. Eligibility (001B gates: reversibility + path-overlap + fail-closed policy).
+  const decision = decideAutoExecEligibility(action, { policy, forbiddenClasses, guardrailPaths });
+  if (!decision.eligible) {
+    await safeAudit(audit, { ...base, phase: 'eligibility', decision, outcome: 'rejected' });
+    return { status: 'rejected', gate: decision.gate, reason: decision.reason };
+  }
+
+  // 4. Write-before-act audit — FAIL-CLOSED. If we can't record intent, we don't act.
+  try {
+    await audit({ ...base, phase: 'start', decision, outcome: 'started' });
+  } catch (e) {
+    return { status: 'aborted', reason: 'audit_write_failed', detail: e.message };
+  }
+
+  // 5. Snapshot (no mutation yet → snapshot failure needs no rollback).
+  let snapshot;
+  try {
+    snapshot = await action.snapshot();
+  } catch (e) {
+    await safeAudit(audit, { ...base, phase: 'snapshot', outcome: 'error', detail: { error: e.message } });
+    return { status: 'aborted', reason: 'snapshot_failed', detail: e.message };
+  }
+
+  const doRollback = async (reason, phase) => {
+    let rolledBack = false; let rbErr = null;
+    try { await action.rollback(snapshot); rolledBack = true; } catch (e) { rbErr = e.message; }
+    await safeAudit(audit, { ...base, phase, snapshot, outcome: rolledBack ? 'rolled_back' : 'rollback_failed', detail: { reason, rbErr } });
+    return rolledBack
+      ? { status: 'rolled_back', reason }
+      : { status: 'rollback_failed', reason, detail: rbErr, killSwitchRecommended: true };
+  };
+
+  // 6. Canary apply (smallest safe scope).
+  try { await action.apply(); } catch (e) { return doRollback(`apply_failed:${e.message}`, 'canary'); }
+
+  // 7. Observe window, then check canary health.
+  await sleep(observeWindowMs);
+  let healthy;
+  try { healthy = await action.canaryHealthy(); } catch { healthy = false; }
+  if (!healthy) return doRollback('canary_unhealthy', 'observe');
+
+  // 8. TOCTOU: re-validate the world immediately before commit.
+  let valid;
+  try { valid = await action.validate(snapshot); } catch { valid = false; }
+  if (!valid) return doRollback('toctou_revalidate_failed', 'revalidate');
+
+  // 9. Kill-switch re-check before commit (operator may have hit stop mid-observe).
+  let killed2;
+  try { killed2 = await resolveMaybe(killSwitchActive); } catch { killed2 = true; }
+  if (killed2) return doRollback('kill_switch_pre_commit', 'commit');
+
+  // 10. Commit.
+  try { if (action.commit) await action.commit(); } catch (e) { return doRollback(`commit_failed:${e.message}`, 'commit'); }
+  await safeAudit(audit, { ...base, phase: 'commit', outcome: 'committed' });
+  if (emitTelemetry) { try { await emitTelemetry({ ...base, outcome: 'committed' }); } catch { /* telemetry is best-effort */ } }
+  return { status: 'committed' };
+}
+
+/**
+ * In-memory synthetic action — safe, deterministic, fully reversible. Used by the
+ * demo CLI, the rollback-rehearsal harness, and unit tests. No real infra.
+ */
+export function makeSyntheticAction(opts = {}) {
+  const state = { value: opts.initial ?? 'A' };
+  const ext = { changed: false }; // simulate a concurrent change for TOCTOU tests
+  const failAt = opts.failAt ?? null; // 'apply' | 'observe' | 'revalidate' | 'commit'
+  return {
+    action_class: opts.action_class ?? 'synthetic_toggle',
+    target: opts.target ?? 'synthetic/value',
+    reversible: true,
+    rollback_window_ms: opts.rollback_window_ms ?? 600000,
+    outward_facing: false,
+    snapshot: () => ({ value: state.value }),
+    apply: () => {
+      if (failAt === 'apply') throw new Error('synthetic apply failure');
+      state.value = opts.next ?? 'B';
+    },
+    rollback: (snap) => { state.value = snap.value; },
+    canaryHealthy: () => failAt !== 'observe',
+    validate: () => failAt !== 'revalidate' && !ext.changed,
+    commit: () => { if (failAt === 'commit') throw new Error('synthetic commit failure'); },
+    // test/inspection helpers (not part of the action contract the loop uses):
+    read: () => state.value,
+    markExternalChange: () => { ext.changed = true; },
+  };
+}
+
+/**
+ * Rollback-rehearsal harness (FR-3): drive the loop with a synthetic action forced
+ * to fail at `failAt` and assert the target is restored to its pre-action value.
+ * Returns {failAt, status, restored}. `restored` MUST be true for every phase.
+ */
+export async function rehearseRollback(failAt, deps = {}) {
+  const action = makeSyntheticAction({ failAt });
+  const before = action.read();
+  const result = await runAutoExec(action, {
+    flagEnabled: true,
+    killSwitchActive: false,
+    policy: completeSyntheticPolicy(),
+    forbiddenClasses: [],
+    ...deps,
+  });
+  const after = action.read();
+  return { failAt, status: result.status, restored: before === after, result };
+}
+
+/** A complete in-memory policy for the synthetic action (all six facets present). */
+export function completeSyntheticPolicy() {
+  return {
+    preconditions: { note: 'synthetic — always eligible' },
+    canary: { scope: 'smallest' },
+    rollback: { strategy: 'snapshot-restore' },
+    blast_radius: { max: 'synthetic-only' },
+    observe_window: { ms: 0 },
+    escalation: { to: 'operator-email' },
+  };
+}
+
+// ── DB-backed default factories (the real wiring; injected so the loop stays pure) ──
+
+/** Flag reader: engine flag enabled AND no global feature-flag kill-switch (CONST-009). */
+export function makeFlagReader(db, flagKey = 'auto_exec_engine_v1') {
+  return async () => {
+    try {
+      const { data: flag } = await db.from('leo_feature_flags').select('is_enabled').eq('flag_key', flagKey).maybeSingle();
+      if (!flag?.is_enabled) return false;
+      const { data: ks } = await db.from('leo_kill_switches').select('is_active').eq('switch_key', 'CONST-009').maybeSingle();
+      return !ks?.is_active; // global flag kill-switch forces OFF
+    } catch {
+      return false; // fail-safe: unknown flag state => OFF
+    }
+  };
+}
+
+/** Kill-switch reader for the engine itself. Fail-safe: error => active (stop). */
+export function makeKillSwitchReader(db, switchKey = 'auto_exec_engine') {
+  return async () => {
+    try {
+      const { data } = await db.from('leo_kill_switches').select('is_active').eq('switch_key', switchKey).maybeSingle();
+      return !!data?.is_active;
+    } catch {
+      return true;
+    }
+  };
+}
+
+/** Append-only audit writer backed by leo_auto_exec_audit. */
+export function makeDbAudit(db, runId) {
+  return async (row) => {
+    const { error } = await db.from('leo_auto_exec_audit').insert({
+      run_id: runId,
+      action_class: row.action_class ?? null,
+      phase: row.phase ?? null,
+      target: row.target ?? null,
+      decision: row.decision ?? null,
+      snapshot: row.snapshot ?? null,
+      outcome: row.outcome ?? null,
+      detail: row.detail ?? null,
+    });
+    if (error) throw new Error(`audit insert failed: ${error.message}`);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "session:park": "node scripts/park-worker.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
+    "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
     "registry:backfill-pending": "node scripts/backfill-pending-enablement-registry.mjs",
     "coord:email-summary": "node scripts/coordinator-email-summary.mjs",
     "worktree:remove": "node scripts/safe-worktree-remove.mjs",

--- a/scripts/auto-exec-engine-demo.mjs
+++ b/scripts/auto-exec-engine-demo.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * auto-exec-engine-demo — register the engine's default-OFF flag in the
+ * Pending-Enablement Registry (001A) and run the SYNTHETIC engine once for
+ * operator/CI inspection. SD-LEO-INFRA-POLICY-GATED-AUTO-001C.
+ *
+ * Read-only against real infra: the only thing that touches the DB is the flag
+ * self-registration (idempotent) and append-only audit rows for the synthetic run.
+ * The engine flag defaults OFF, so a plain run is a no-op (status=skipped) until an
+ * operator enables it.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/auto-exec-engine-demo.mjs            # register flag + run (skipped if OFF)
+ *   node --env-file=.env scripts/auto-exec-engine-demo.mjs --rehearse # rollback-rehearsal for every phase
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { registerPendingFlag } from '../lib/pending-enablement-registry.js';
+import {
+  runAutoExec, makeSyntheticAction, makeFlagReader, makeKillSwitchReader, makeDbAudit,
+  rehearseRollback, completeSyntheticPolicy,
+} from '../lib/auto-exec-engine.js';
+
+const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const FLAG_KEY = 'auto_exec_engine_v1';
+
+// Self-register the engine flag (default-OFF) so it surfaces in the pending-enablement registry.
+const reg = await registerPendingFlag(db, {
+  flag_key: FLAG_KEY,
+  display_name: 'Policy-Gated Auto-Exec Engine (synthetic)',
+  gates_what: 'The auto-execution control loop. While OFF the engine is a no-op; while ON it runs ONLY the synthetic action (no real op until 001D).',
+  enablement_criteria: 'Operator confirms golden/rollback-rehearsal/TOCTOU/kill-switch all green; a real op is only attached in 001D behind its own flag.',
+  target: 'EHG_Engineer',
+  rolled_out_at: new Date().toISOString(),
+  risk_tier: 'high',
+});
+console.log(`flag '${FLAG_KEY}': ${reg.created ? 'registered (default-OFF)' : 'already registered'}`);
+
+if (process.argv.includes('--rehearse')) {
+  console.log('\n=== rollback rehearsal (every intermediate phase must restore state) ===');
+  let allRestored = true;
+  for (const failAt of ['apply', 'observe', 'revalidate', 'commit']) {
+    const r = await rehearseRollback(failAt);
+    allRestored = allRestored && r.restored;
+    console.log(`  failAt=${failAt.padEnd(11)} status=${String(r.status).padEnd(14)} restored=${r.restored}`);
+  }
+  console.log(`\nrehearsal: ${allRestored ? 'ALL phases restored ✓' : 'A PHASE DID NOT RESTORE ✗'}`);
+  process.exit(allRestored ? 0 : 1);
+}
+
+// Plain run: real flag/kill-switch readers + DB audit, synthetic action.
+const runId = (globalThis.crypto?.randomUUID && globalThis.crypto.randomUUID()) || `demo-${process.pid}`;
+const action = makeSyntheticAction({});
+const result = await runAutoExec(action, {
+  flagEnabled: makeFlagReader(db, FLAG_KEY),
+  killSwitchActive: makeKillSwitchReader(db),
+  policy: completeSyntheticPolicy(),
+  forbiddenClasses: [],
+  audit: makeDbAudit(db, runId),
+  observeWindowMs: 0,
+  runId,
+});
+console.log('\n=== synthetic engine run ===');
+console.log(`run_id  : ${runId}`);
+console.log(`result  : ${JSON.stringify(result)}`);
+console.log(result.status === 'skipped'
+  ? '(flag is OFF — engine is a no-op, as designed. Enable the flag to exercise the loop.)'
+  : `(synthetic value now: ${action.read()})`);

--- a/tests/auto-exec-engine.test.js
+++ b/tests/auto-exec-engine.test.js
@@ -1,0 +1,129 @@
+/**
+ * Unit tests (no DB) for the auto-execution engine control loop.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001C.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  runAutoExec,
+  makeSyntheticAction,
+  rehearseRollback,
+  completeSyntheticPolicy,
+} from '../lib/auto-exec-engine.js';
+
+const POLICY = completeSyntheticPolicy();
+
+// An audit recorder stub.
+function recorder() {
+  const rows = [];
+  const audit = async (r) => { rows.push(r); };
+  audit.rows = rows;
+  return audit;
+}
+
+describe('FM-A default-OFF golden path', () => {
+  it('flag OFF is a pure no-op: no audit, no mutation', async () => {
+    const action = makeSyntheticAction({});
+    const audit = recorder();
+    const r = await runAutoExec(action, { flagEnabled: false, audit, policy: POLICY });
+    expect(r).toEqual({ status: 'skipped', reason: 'flag_off' });
+    expect(audit.rows).toHaveLength(0);       // zero side effects
+    expect(action.read()).toBe('A');          // unchanged
+  });
+  it('flag OFF resolves a function-form flag too', async () => {
+    const r = await runAutoExec(makeSyntheticAction({}), { flagEnabled: async () => false });
+    expect(r.status).toBe('skipped');
+  });
+});
+
+describe('happy path', () => {
+  it('flag ON + eligible + healthy canary → commit, with write-before-act audit', async () => {
+    const action = makeSyntheticAction({});
+    const audit = recorder();
+    const r = await runAutoExec(action, { flagEnabled: true, audit, policy: POLICY, forbiddenClasses: [] });
+    expect(r.status).toBe('committed');
+    expect(action.read()).toBe('B');
+    expect(audit.rows[0]).toMatchObject({ phase: 'start', outcome: 'started' }); // write-before-act first
+    expect(audit.rows.at(-1)).toMatchObject({ phase: 'commit', outcome: 'committed' });
+  });
+});
+
+describe('FM-B rollback from every intermediate state', () => {
+  for (const failAt of ['apply', 'observe', 'revalidate', 'commit']) {
+    it(`rolls back and restores pre-action state when failing at ${failAt}`, async () => {
+      const r = await rehearseRollback(failAt);
+      expect(r.restored).toBe(true);
+      expect(['rolled_back']).toContain(r.status);
+    });
+  }
+  it('surfaces rollback_failed (never silently swallowed) when rollback itself throws', async () => {
+    const action = makeSyntheticAction({ failAt: 'observe' });
+    action.rollback = () => { throw new Error('disk gone'); };
+    const r = await runAutoExec(action, { flagEnabled: true, policy: POLICY });
+    expect(r.status).toBe('rollback_failed');
+    expect(r.killSwitchRecommended).toBe(true);
+  });
+});
+
+describe('FM-E TOCTOU re-validate before commit', () => {
+  it('aborts + rolls back when the world changes between observe and commit', async () => {
+    const action = makeSyntheticAction({});
+    action.markExternalChange(); // concurrent change invalidates validate()
+    const r = await runAutoExec(action, { flagEnabled: true, policy: POLICY });
+    expect(r).toMatchObject({ status: 'rolled_back', reason: 'toctou_revalidate_failed' });
+    expect(action.read()).toBe('A');
+  });
+});
+
+describe('kill-switch', () => {
+  it('aborts at entry with no act when kill-switch active', async () => {
+    const action = makeSyntheticAction({});
+    const audit = recorder();
+    const r = await runAutoExec(action, { flagEnabled: true, killSwitchActive: true, audit, policy: POLICY });
+    expect(r).toEqual({ status: 'aborted', reason: 'kill_switch' });
+    expect(action.read()).toBe('A');
+    expect(audit.rows).toHaveLength(0);
+  });
+  it('fail-safe: kill-switch read error is treated as active (stop)', async () => {
+    const r = await runAutoExec(makeSyntheticAction({}), { flagEnabled: true, killSwitchActive: async () => { throw new Error('db down'); }, policy: POLICY });
+    expect(r.status).toBe('aborted');
+  });
+  it('rolls back when the kill-switch flips active before commit', async () => {
+    let calls = 0;
+    const killSwitchActive = async () => { calls += 1; return calls >= 2; }; // off at entry, on before commit
+    const action = makeSyntheticAction({});
+    const r = await runAutoExec(action, { flagEnabled: true, killSwitchActive, policy: POLICY });
+    expect(r).toMatchObject({ status: 'rolled_back', reason: 'kill_switch_pre_commit' });
+    expect(action.read()).toBe('A');
+  });
+});
+
+describe('001B eligibility gate', () => {
+  it('rejects + audits a forbidden-class action without acting', async () => {
+    const action = makeSyntheticAction({ action_class: 'hard_delete' });
+    const audit = recorder();
+    const r = await runAutoExec(action, { flagEnabled: true, audit, policy: POLICY, forbiddenClasses: ['hard_delete'] });
+    expect(r).toMatchObject({ status: 'rejected', gate: 'reversibility' });
+    expect(action.read()).toBe('A');
+    expect(audit.rows).toEqual([expect.objectContaining({ phase: 'eligibility', outcome: 'rejected' })]);
+  });
+  it('rejects when the policy is incomplete (fail-closed)', async () => {
+    const partial = { ...POLICY }; delete partial.rollback;
+    const r = await runAutoExec(makeSyntheticAction({}), { flagEnabled: true, policy: partial });
+    expect(r).toMatchObject({ status: 'rejected', gate: 'policy' });
+  });
+  it('rejects when targeting a guardrail path', async () => {
+    const action = makeSyntheticAction({ target: '.claude/settings.json' });
+    const r = await runAutoExec(action, { flagEnabled: true, policy: POLICY });
+    expect(r).toMatchObject({ status: 'rejected', gate: 'path-overlap' });
+  });
+});
+
+describe('fail-closed audit', () => {
+  it('aborts WITHOUT acting when the write-before-act audit throws', async () => {
+    const action = makeSyntheticAction({});
+    const audit = async () => { throw new Error('audit table unreachable'); };
+    const r = await runAutoExec(action, { flagEnabled: true, audit, policy: POLICY });
+    expect(r).toMatchObject({ status: 'aborted', reason: 'audit_write_failed' });
+    expect(action.read()).toBe('A'); // never applied
+  });
+});

--- a/tests/integration/auto-exec-engine.db.test.js
+++ b/tests/integration/auto-exec-engine.db.test.js
@@ -1,0 +1,206 @@
+// SD-LEO-INFRA-POLICY-GATED-AUTO-001C
+// Auto-execution engine control-loop DB guarantees:
+//   1. leo_auto_exec_audit is APPEND-ONLY — owner/service-role can INSERT, but
+//      UPDATE and DELETE are blocked by a BEFORE trigger that RAISES (the hard
+//      guarantee, independent of grants).
+//   2. 001B carry-forward — the restricted engine role leo_engine_ro can now
+//      SELECT the seeded leo_auto_exec_forbidden rows (RLS SELECT policy added)
+//      while every write to the policy/forbidden tables is STILL denied at the
+//      storage (table-privilege) layer ("permission denied for table ...").
+//      i.e. the 001B write-deny did NOT regress.
+//
+// HOW THIS TEST CONNECTS — DIRECT pg, NOT supabase-js:
+//   `SET ROLE leo_engine_ro` is a session-level Postgres command that cannot be
+//   issued over supabase-js (always runs as service role, no SET ROLE). We open
+//   a single direct `pg.Client` on SUPABASE_POOLER_URL (falling back to
+//   DATABASE_URL), run the ENTIRE scenario inside ONE transaction with
+//   per-statement SAVEPOINTs (a permission-denied / trigger error aborts the
+//   surrounding (sub)transaction, so each expected-failure write is wrapped in a
+//   savepoint we roll back to and continue), then ROLLBACK at the end so NOTHING
+//   touches committed prod state. This mirrors
+//   tests/integration/auto-exec-policy.db.test.js exactly.
+//
+// SKIP CONTRACT: when no direct pg connection string is configured (CI without
+// DB secrets / local without creds) the suite SKIPS cleanly via HAS_REAL_DB AND
+// a local connection-string guard — it never reds.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from 'pg';
+import dotenv from 'dotenv';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+
+dotenv.config();
+
+// Direct-pg connection string. Strip any sslmode= param the way
+// scripts/lib/supabase-connection.js does so node-postgres' own ssl config wins.
+function resolveConnString() {
+  const raw = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || '';
+  if (!raw) return null;
+  return raw.replace(/[?&]sslmode=[^&]*/i, '');
+}
+
+const CONN_STRING = resolveConnString();
+// Run only when BOTH a real Supabase env is configured (db-available helper)
+// AND we have a direct pg connection string for SET ROLE.
+const HAS_DB = Boolean(HAS_REAL_DB && CONN_STRING);
+
+// Pooler presents a self-signed Supabase Root 2021 CA absent from the local
+// trust store; mirror apply-migration.js for this READ/INSERT-then-ROLLBACK probe.
+function makeSslConfig() {
+  return { rejectUnauthorized: false };
+}
+
+describe.skipIf(!HAS_DB)(
+  'SD-LEO-INFRA-POLICY-GATED-AUTO-001C: auto-exec engine audit (append-only) + 001B carry-forward (leo_engine_ro SELECT)',
+  () => {
+    /** @type {import('pg').Client} */
+    let client;
+    let inTxn = false;
+
+    beforeAll(async () => {
+      client = new Client({ connectionString: CONN_STRING, ssl: makeSslConfig() });
+      await client.connect();
+    });
+
+    afterAll(async () => {
+      if (client) {
+        if (inTxn) {
+          try { await client.query('ROLLBACK'); } catch { /* already rolled back */ }
+        }
+        await client.end().catch(() => {});
+      }
+    });
+
+    // Helper: run `sql` and expect it to FAIL, wrapped in a savepoint so the
+    // aborted (sub)transaction can be rolled back and the suite continues.
+    async function expectError(sql) {
+      await client.query('SAVEPOINT sp');
+      try {
+        await client.query(sql);
+        await client.query('RELEASE SAVEPOINT sp');
+        return { failed: false, message: null };
+      } catch (e) {
+        await client.query('ROLLBACK TO SAVEPOINT sp');
+        return { failed: true, message: String(e.message || e) };
+      }
+    }
+
+    it('migration objects exist: leo_auto_exec_audit (RLS on) + append-only trigger + SELECT-only grant for leo_engine_ro', async () => {
+      const tab = await client.query(
+        `SELECT c.relrowsecurity
+           FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public' AND c.relname = 'leo_auto_exec_audit'`
+      );
+      expect(tab.rowCount).toBe(1);
+      expect(tab.rows[0].relrowsecurity).toBe(true);
+
+      // Append-only trigger present, firing BEFORE UPDATE OR DELETE.
+      const trg = await client.query(
+        `SELECT t.tgname
+           FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+          WHERE c.relname = 'leo_auto_exec_audit'
+            AND NOT t.tgisinternal
+            AND t.tgname = 'trg_leo_auto_exec_audit_append_only'`
+      );
+      expect(trg.rowCount).toBe(1);
+
+      // leo_engine_ro holds SELECT-only on the audit table (no write grant).
+      const grants = await client.query(
+        `SELECT privilege_type
+           FROM information_schema.role_table_grants
+          WHERE grantee = 'leo_engine_ro' AND table_name = 'leo_auto_exec_audit'
+          ORDER BY privilege_type`
+      );
+      expect(grants.rows.map(r => r.privilege_type)).toEqual(['SELECT']);
+    });
+
+    it('leo_auto_exec_audit is APPEND-ONLY: owner can INSERT; UPDATE and DELETE RAISE', async () => {
+      await client.query('BEGIN');
+      inTxn = true;
+
+      // (a) owner / service-role INSERT works.
+      const ins = await client.query(
+        `INSERT INTO public.leo_auto_exec_audit
+            (run_id, action_class, phase, target, decision, snapshot, outcome, detail)
+         VALUES (gen_random_uuid(), 'test_class', 'EXEC', 'test_target',
+                 '{"d":1}'::jsonb, '{"s":2}'::jsonb, 'ok', '{"k":"v"}'::jsonb)
+         RETURNING id`
+      );
+      expect(ins.rowCount).toBe(1);
+      const id = ins.rows[0].id;
+
+      // (b) UPDATE must RAISE (append-only trigger).
+      const upd = await expectError(
+        `UPDATE public.leo_auto_exec_audit SET outcome = 'tamper' WHERE id = '${id}'`
+      );
+      expect(upd.failed, 'UPDATE should be blocked').toBe(true);
+      expect(upd.message, 'UPDATE error text').toMatch(/append-only/i);
+
+      // (b) DELETE must RAISE (append-only trigger).
+      const del = await expectError(
+        `DELETE FROM public.leo_auto_exec_audit WHERE id = '${id}'`
+      );
+      expect(del.failed, 'DELETE should be blocked').toBe(true);
+      expect(del.message, 'DELETE error text').toMatch(/append-only/i);
+
+      // Roll back the whole scenario — zero committed prod impact.
+      await client.query('ROLLBACK');
+      inTxn = false;
+    });
+
+    it('001B carry-forward: SET ROLE leo_engine_ro reads forbidden rows (>0) but ALL policy/forbidden/audit writes stay denied', async () => {
+      await client.query('BEGIN');
+      inTxn = true;
+
+      await client.query('SET ROLE leo_engine_ro');
+      expect((await client.query('SELECT current_user')).rows[0].current_user).toBe('leo_engine_ro');
+
+      // SELECT now RETURNS the seeded forbidden rows (>0) — the carry-forward
+      // SELECT RLS policy un-filters reads for leo_engine_ro. Before this
+      // migration, RLS filtered every row out (count was 0 despite the grant).
+      const forbidden = await client.query(
+        'SELECT count(*)::int AS n FROM public.leo_auto_exec_forbidden'
+      );
+      expect(forbidden.rows[0].n).toBeGreaterThan(0);
+
+      // The policy SELECT must also succeed (privilege present, RLS un-filtered);
+      // we assert it does not raise — row count may legitimately be 0 (unseeded).
+      await expect(
+        client.query('SELECT count(*) FROM public.leo_auto_exec_policy')
+      ).resolves.toBeDefined();
+
+      // The engine can also READ its own audit log.
+      await expect(
+        client.query('SELECT count(*) FROM public.leo_auto_exec_audit')
+      ).resolves.toBeDefined();
+
+      // Writes to policy/forbidden are STILL denied at the storage layer — the
+      // 001B write-deny did NOT regress.
+      const writeDenials = {
+        'UPDATE leo_auto_exec_policy': await expectError(
+          `UPDATE public.leo_auto_exec_policy SET updated_at = now() WHERE action_class = '__none__'`
+        ),
+        'INSERT leo_auto_exec_policy': await expectError(
+          `INSERT INTO public.leo_auto_exec_policy (action_class) VALUES ('engine_attempt')`
+        ),
+        'INSERT leo_auto_exec_forbidden': await expectError(
+          `INSERT INTO public.leo_auto_exec_forbidden (action_class) VALUES ('engine_attempt')`
+        ),
+        'DELETE leo_auto_exec_forbidden': await expectError(
+          `DELETE FROM public.leo_auto_exec_forbidden WHERE action_class = '__none__'`
+        ),
+        'INSERT leo_auto_exec_audit': await expectError(
+          `INSERT INTO public.leo_auto_exec_audit (action_class) VALUES ('engine_attempt')`
+        ),
+      };
+      for (const [label, res] of Object.entries(writeDenials)) {
+        expect(res.failed, `${label} should be denied`).toBe(true);
+        expect(res.message, `${label} error text`).toMatch(/permission denied for table/i);
+      }
+
+      await client.query('RESET ROLE');
+      await client.query('ROLLBACK');
+      inTxn = false;
+    });
+  }
+);


### PR DESCRIPTION
## Child 001C of SD-LEO-INFRA-POLICY-GATED-AUTO-001 (policy-gated auto-execution engine)

The **engine control loop** — proven against a SYNTHETIC, fully-reversible action behind a **default-OFF** flag. No real shared-infra op is wired until 001D.

### Loop
flag-gate → kill-switch → **001B eligibility gate** → **write-before-act audit** → snapshot → canary apply → observe → **TOCTOU re-validate** → kill-switch re-check → **commit-or-rollback** → audit + telemetry.

### Safety invariants shipped as code
- **FM-A default-OFF**: flag OFF ⇒ pure no-op (no snapshot/apply/audit/DB write). Golden test asserts byte-identity.
- **FM-B reliable rollback**: any apply/observe/revalidate/commit failure or unhealthy canary rolls back to the snapshot; a rollback that itself fails returns `rollback_failed` + `killSwitchRecommended` (never silently swallowed). Rehearsal restores state from **every** intermediate phase.
- **FM-E TOCTOU**: re-validate immediately before commit; rollback on mismatch.
- **Write-before-act, fail-closed audit**: intent recorded before acting; audit-write failure aborts without acting. `leo_auto_exec_audit` is **append-only** (trigger rejects UPDATE/DELETE).
- **Kill-switch**: `leo_kill_switches` checked at entry and before commit; fail-safe (error ⇒ stop).
- **Meta-stability**: the loop only touches the injected action; the 001B `leo_engine_ro` role + path-overlap guard keep it off its own guardrails.

### Also
- **001B carry-forward closed**: SELECT RLS for `leo_engine_ro` (engine can now read policy; writes still denied) + absolute-path normalization already in the guard.
- Engine flag **self-registers** (default-OFF) in the 001A Pending-Enablement Registry (dogfooding).
- `npm run engine:demo [--rehearse]` for operator/CI inspection.

### Tests
- **16 unit** (golden flag-OFF no-op, rollback from each phase, `rollback_failed` surfacing, TOCTOU, kill-switch entry/mid/fail-safe, eligibility gate, fail-closed audit).
- **3 DB integration** (append-only UPDATE/DELETE rejected + 001B carry-forward SELECT returns rows / writes denied). Demo rehearsal: ALL phases restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)