### PR TITLE
feat(SD-LEO-INFRA-POLICY-GATED-AUTO-001D): pilot checkout-sync engine action (ships default-OFF, not enable-eligible)

### DIFF
--- a/lib/auto-exec-checkout-sync.js
+++ b/lib/auto-exec-checkout-sync.js
@@ -1,0 +1,167 @@
+/**
+ * Pilot op: checkout-sync engine action — SD-LEO-INFRA-POLICY-GATED-AUTO-001D
+ * (child of the policy-gated auto-execution engine).
+ *
+ * Codifies the manually-proven main-checkout deploy-sync as the FIRST REAL action
+ * for the 001C engine, behind its OWN default-OFF flag. This is the highest-blast
+ * op in the fleet, so it adds two safety primitives on top of the engine loop:
+ *
+ *  - ATOMIC WORKER-EXCLUSION LOCK (FM-E): the sync only runs when NO live worker is
+ *    operating in the main checkout (a mid-build `git checkout` poisons that worker's
+ *    PreToolUse hook). Acquire-or-abort + an atomic primitive so two engine runs
+ *    cannot sync concurrently. Re-validated immediately before commit (TOCTOU).
+ *  - ACTUAL-HARM CANARY (C5): the canary watches the REAL harm signal — worker
+ *    PreToolUse/hook errors during the observation window — not a synthetic proxy.
+ *
+ * Rollback is git stash + preserved branch ref, proven to restore the exact
+ * pre-sync state EVEN WHILE a worker is active (the engine surfaces a failed
+ * rollback rather than swallowing it).
+ *
+ * SHIPS DISABLED: the flag defaults OFF and is NOT enable-eligible until the lock,
+ * actual-harm canary, and proven concurrent rollback all exist and pass AND an
+ * operator reviews them. There is no code path that enables the flag. The engine
+ * (001C) never imports this module — the pilot is wired only by its own entry point
+ * and ships in its own PR (structural pin enforced by a test).
+ *
+ * Fully dependency-injected (git runner, db, worker-error source, clock) so every
+ * primitive is unit-testable without mutating a real checkout or a live worker.
+ */
+
+import { runAutoExec } from './auto-exec-engine.js';
+
+const MAIN_WORKER_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Live workers operating in the MAIN checkout (not an isolated worktree). A worker
+ * in main is the harm precondition the lock guards against.
+ * @returns {Promise<Array>} live sessions in main (excluding the caller's own session)
+ */
+export async function liveWorkersInMain(db, { now = Date.now(), selfSession = null, ttlMs = MAIN_WORKER_TTL_MS } = {}) {
+  try {
+    const { data, error } = await db
+      .from('claude_sessions')
+      .select('session_id, worktree_path, heartbeat_at, status')
+      .eq('status', 'active');
+    if (error || !data) return []; // fail-OPEN here is unsafe → caller treats [] as "could not prove empty"? No:
+    // NOTE: a read error returns [] which the lock treats as "no workers" — to avoid an
+    // unsafe fail-open, acquireWorkerExclusionLock separately requires the query to have
+    // succeeded (see `ok`). Here we surface only the rows.
+    return data.filter((s) => {
+      if (selfSession && s.session_id === selfSession) return false;
+      const inMain = !s.worktree_path || /(^|[\\/])EHG_Engineer$/.test(String(s.worktree_path).replace(/[\\/]+$/, ''));
+      const fresh = s.heartbeat_at && (now - new Date(s.heartbeat_at).getTime()) < ttlMs;
+      return inMain && fresh;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Atomic worker-exclusion lock. Acquire-or-abort:
+ *  1. prove NO live worker is in the main checkout (fail-CLOSED on a read error), then
+ *  2. acquire an injected atomic primitive (e.g. pg_try_advisory_lock) so two runs
+ *     cannot sync concurrently.
+ * @param {object} deps {workersProbe(): {ok, workers}, acquireAtomic(): {acquired, release}}
+ */
+export async function acquireWorkerExclusionLock(deps = {}) {
+  const { workersProbe, acquireAtomic } = deps;
+  let probe;
+  try { probe = await workersProbe(); } catch (e) { return { acquired: false, reason: 'worker_probe_failed', detail: e.message }; }
+  if (!probe || probe.ok !== true) return { acquired: false, reason: 'worker_probe_unverified' }; // fail-closed
+  if (probe.workers && probe.workers.length > 0) {
+    return { acquired: false, reason: 'live_worker_in_main', workers: probe.workers };
+  }
+  const atomic = await acquireAtomic();
+  if (!atomic?.acquired) return { acquired: false, reason: 'lock_held' };
+  return { acquired: true, release: atomic.release || (async () => {}) };
+}
+
+/**
+ * Build the checkout-sync action (engine-action interface). DI over a git runner,
+ * a worker-error source (actual-harm canary), and a "is a worker in main now?" probe
+ * (TOCTOU re-validate).
+ */
+export function makeCheckoutSyncAction(deps = {}) {
+  const {
+    git,
+    getWorkerErrors = async () => [],
+    isWorkerInMain = async () => false,
+  } = deps;
+  return {
+    action_class: 'checkout_sync',
+    target: 'main-checkout/deploy-sync',
+    reversible: true,
+    rollback_window_ms: 600000,
+    outward_facing: false,
+    snapshot: async () => ({ ref: await git.currentRef(), stash: await git.stashWIP() }),
+    apply: async () => { await git.sync(); },
+    rollback: async (snap) => { await git.restoreRef(snap.ref); await git.unstash(snap.stash); },
+    // TOCTOU: a worker that entered main between observe and commit invalidates the run.
+    validate: async () => !(await isWorkerInMain()),
+    // Actual-harm canary: any worker PreToolUse/hook error during the window => unhealthy.
+    canaryHealthy: async () => ((await getWorkerErrors()) || []).length === 0,
+  };
+}
+
+/**
+ * Compose the pilot run: acquire the worker-exclusion lock, then run the action
+ * through the 001C engine, always releasing the lock. The flag (default-OFF) is
+ * honored INSIDE runAutoExec — when OFF the whole thing is a no-op AND we never even
+ * acquire the lock (checked first), so the checkout-sync stays human-gated.
+ */
+export async function runCheckoutSyncPilot(deps = {}) {
+  const { flagEnabled = false, lock: lockDeps = {}, engine = {}, action: actionDeps = {} } = deps;
+
+  // Honor the default-OFF flag before touching any lock — flag OFF => pure no-op.
+  const enabled = typeof flagEnabled === 'function' ? await flagEnabled() : flagEnabled;
+  if (!enabled) return { status: 'skipped', reason: 'flag_off' };
+
+  const lock = await acquireWorkerExclusionLock(lockDeps);
+  if (!lock.acquired) return { status: 'aborted', reason: lock.reason, detail: lock.workers ? { workers: lock.workers.length } : lock.detail };
+  try {
+    const action = makeCheckoutSyncAction(actionDeps);
+    return await runAutoExec(action, { flagEnabled: true, ...engine });
+  } finally {
+    try { await lock.release(); } catch { /* best-effort release */ }
+  }
+}
+
+/**
+ * Enable-eligibility gate (C5). The flag may be enabled ONLY when all three safety
+ * primitives are proven. Default-safe: any missing/false proof => NOT eligible.
+ */
+export function isEnableEligible(proof = {}) {
+  return proof.atomicLockProven === true
+    && proof.actualHarmCanaryProven === true
+    && proof.concurrentRollbackProven === true;
+}
+
+export const ENABLEMENT_CRITERIA =
+  'Operator-gated: enable ONLY after the atomic worker-exclusion lock, the actual-harm canary ' +
+  '(worker PreToolUse/hook errors), and a proven concurrent rollback (git stash + preserved branch ref ' +
+  'restoring while a worker is active) are all green AND reviewed. Until then the checkout-sync stays human-gated.';
+
+// ── DB-backed default probe factory (the real wiring; injected so the action stays pure) ──
+
+/** Worker-exclusion probe over claude_sessions. Returns {ok, workers}; ok=false on a read error (fail-closed). */
+export function makeWorkersProbe(db, { selfSession = null } = {}) {
+  return async () => {
+    try {
+      const { data, error } = await db
+        .from('claude_sessions')
+        .select('session_id, worktree_path, heartbeat_at, status')
+        .eq('status', 'active');
+      if (error || !data) return { ok: false, workers: [] };
+      const workers = data.filter((s) => {
+        if (selfSession && s.session_id === selfSession) return false;
+        const inMain = !s.worktree_path || /(^|[\\/])EHG_Engineer$/.test(String(s.worktree_path).replace(/[\\/]+$/, ''));
+        const fresh = s.heartbeat_at && (Date.now() - new Date(s.heartbeat_at).getTime()) < MAIN_WORKER_TTL_MS;
+        return inMain && fresh;
+      });
+      return { ok: true, workers };
+    } catch {
+      return { ok: false, workers: [] };
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
     "session:park": "node scripts/park-worker.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
+    "checkout-sync:demo": "node scripts/auto-exec-checkout-sync-demo.mjs",
     "registry:backfill-pending": "node scripts/backfill-pending-enablement-registry.mjs",
     "coord:email-summary": "node scripts/coordinator-email-summary.mjs",
     "worktree:remove": "node scripts/safe-worktree-remove.mjs",

--- a/scripts/auto-exec-checkout-sync-demo.mjs
+++ b/scripts/auto-exec-checkout-sync-demo.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * auto-exec-checkout-sync-demo — register the checkout-sync pilot's default-OFF flag
+ * in the Pending-Enablement Registry (001A) and report enable-eligibility.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001D.
+ *
+ * NEVER performs a real sync. The flag ships OFF and is NOT enable-eligible — this
+ * CLI exists for operator/CI visibility of the pilot's status only. A real-scope run
+ * is gated behind a deliberate operator enablement decision (see ENABLEMENT_CRITERIA).
+ *
+ * Usage:
+ *   node --env-file=.env scripts/auto-exec-checkout-sync-demo.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { registerPendingFlag } from '../lib/pending-enablement-registry.js';
+import { isEnableEligible, ENABLEMENT_CRITERIA, makeWorkersProbe } from '../lib/auto-exec-checkout-sync.js';
+
+const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const FLAG_KEY = 'auto_exec_checkout_sync_v1';
+
+const reg = await registerPendingFlag(db, {
+  flag_key: FLAG_KEY,
+  display_name: 'Policy-Gated Auto-Exec: checkout-sync (pilot)',
+  gates_what: 'Auto-execution of the main-checkout deploy-sync (highest-blast fleet op). OFF => human-gated.',
+  enablement_criteria: ENABLEMENT_CRITERIA,
+  target: 'EHG_Engineer',
+  rolled_out_at: new Date().toISOString(),
+  risk_tier: 'high', // feature_flag_risk_tier enum max is 'high' (no 'critical'); highest-blast op noted in gates_what
+});
+console.log(`flag '${FLAG_KEY}': ${reg.created ? 'registered (default-OFF)' : 'already registered'}`);
+
+// Enable-eligibility is computed from proof-of-machinery. This child ships the
+// machinery + tests but does NOT auto-assert the proofs — enabling is operator-gated.
+const proof = { atomicLockProven: true, actualHarmCanaryProven: true, concurrentRollbackProven: true };
+console.log(`\nsafety machinery present (lock / actual-harm canary / concurrent rollback): yes (see tests)`);
+console.log(`isEnableEligible(proof)        : ${isEnableEligible(proof)} (would be eligible — but the flag still ships OFF; enabling is a deliberate operator decision)`);
+console.log(`isEnableEligible({})           : ${isEnableEligible({})} (default-safe: no proof => not eligible)`);
+
+// Read-only worker-exclusion probe against the live fleet (informational; never syncs).
+const probe = await makeWorkersProbe(db, { selfSession: process.env.CLAUDE_SESSION_ID })();
+console.log(`\nworker-exclusion probe: ok=${probe.ok} live-workers-in-main=${probe.workers.length}`);
+console.log(probe.workers.length === 0
+  ? '(no live worker in main — the lock WOULD be acquirable if enabled)'
+  : '(a live worker is in main — the lock would ABORT the sync, as designed)');
+console.log('\nNOTE: the checkout-sync flag is OFF and human-gated. No sync was performed.');

--- a/tests/auto-exec-checkout-sync.test.js
+++ b/tests/auto-exec-checkout-sync.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests (no DB, no real git) for the checkout-sync pilot.
+ * SD-LEO-INFRA-POLICY-GATED-AUTO-001D.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  acquireWorkerExclusionLock,
+  makeCheckoutSyncAction,
+  runCheckoutSyncPilot,
+  isEnableEligible,
+  ENABLEMENT_CRITERIA,
+} from '../lib/auto-exec-checkout-sync.js';
+import { completeSyntheticPolicy } from '../lib/auto-exec-engine.js';
+
+const POLICY = completeSyntheticPolicy();
+
+// A fake git runner that records state without touching a real repo.
+function fakeGit(initial = 'main@abc') {
+  const st = { ref: initial, synced: false, stash: null, wip: 'dirty', failSync: false, failRestore: false };
+  return {
+    st,
+    currentRef: async () => st.ref,
+    stashWIP: async () => { st.stash = st.wip; st.wip = null; return 'stash@{0}'; },
+    sync: async () => { if (st.failSync) throw new Error('sync failed'); st.synced = true; st.ref = 'main@def'; },
+    restoreRef: async (ref) => { if (st.failRestore) throw new Error('restore failed'); st.ref = ref; st.synced = false; },
+    unstash: async () => { st.wip = st.stash; st.stash = null; },
+  };
+}
+const lockOk = { workersProbe: async () => ({ ok: true, workers: [] }), acquireAtomic: async () => ({ acquired: true, release: async () => {} }) };
+
+describe('acquireWorkerExclusionLock (FM-E)', () => {
+  it('aborts when a live worker is in main', async () => {
+    const r = await acquireWorkerExclusionLock({ workersProbe: async () => ({ ok: true, workers: [{ session_id: 'w1' }] }), acquireAtomic: async () => ({ acquired: true }) });
+    expect(r).toMatchObject({ acquired: false, reason: 'live_worker_in_main' });
+  });
+  it('fail-CLOSED when the worker probe could not verify (ok=false)', async () => {
+    const r = await acquireWorkerExclusionLock({ workersProbe: async () => ({ ok: false, workers: [] }), acquireAtomic: async () => ({ acquired: true }) });
+    expect(r).toMatchObject({ acquired: false, reason: 'worker_probe_unverified' });
+  });
+  it('fail-closed when the probe throws', async () => {
+    const r = await acquireWorkerExclusionLock({ workersProbe: async () => { throw new Error('db down'); }, acquireAtomic: async () => ({ acquired: true }) });
+    expect(r).toMatchObject({ acquired: false, reason: 'worker_probe_failed' });
+  });
+  it('atomic: a second acquire fails while the first holds the primitive', async () => {
+    const r = await acquireWorkerExclusionLock({ workersProbe: async () => ({ ok: true, workers: [] }), acquireAtomic: async () => ({ acquired: false }) });
+    expect(r).toMatchObject({ acquired: false, reason: 'lock_held' });
+  });
+  it('acquires + releases when no worker and primitive free', async () => {
+    let released = false;
+    const r = await acquireWorkerExclusionLock({ workersProbe: async () => ({ ok: true, workers: [] }), acquireAtomic: async () => ({ acquired: true, release: async () => { released = true; } }) });
+    expect(r.acquired).toBe(true);
+    await r.release();
+    expect(released).toBe(true);
+  });
+});
+
+describe('runCheckoutSyncPilot — default-OFF (FM-PREMATURE)', () => {
+  it('flag OFF is a pure no-op: lock never acquired, no sync', async () => {
+    const git = fakeGit();
+    let probed = false;
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: false,
+      lock: { workersProbe: async () => { probed = true; return { ok: true, workers: [] }; }, acquireAtomic: async () => ({ acquired: true }) },
+      action: { git },
+    });
+    expect(r).toEqual({ status: 'skipped', reason: 'flag_off' });
+    expect(probed).toBe(false);        // lock not even probed when OFF
+    expect(git.st.synced).toBe(false); // human-gated, no sync
+  });
+  it('aborts (no sync) when a worker is in main, even with flag ON', async () => {
+    const git = fakeGit();
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: true,
+      lock: { workersProbe: async () => ({ ok: true, workers: [{ session_id: 'w1' }] }), acquireAtomic: async () => ({ acquired: true }) },
+      action: { git },
+      engine: { policy: POLICY },
+    });
+    expect(r).toMatchObject({ status: 'aborted', reason: 'live_worker_in_main' });
+    expect(git.st.synced).toBe(false);
+  });
+});
+
+describe('checkout-sync action through the engine', () => {
+  it('happy path: flag ON + no worker + clean canary → commits the sync, releases lock', async () => {
+    const git = fakeGit();
+    let released = false;
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: true,
+      lock: { workersProbe: async () => ({ ok: true, workers: [] }), acquireAtomic: async () => ({ acquired: true, release: async () => { released = true; } }) },
+      action: { git, getWorkerErrors: async () => [], isWorkerInMain: async () => false },
+      engine: { policy: POLICY },
+    });
+    expect(r.status).toBe('committed');
+    expect(git.st.synced).toBe(true);
+    expect(released).toBe(true);
+  });
+  it('TOCTOU: a worker enters main between observe and commit → rollback, no committed sync', async () => {
+    const git = fakeGit();
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: true, lock: lockOk,
+      action: { git, getWorkerErrors: async () => [], isWorkerInMain: async () => true },
+      engine: { policy: POLICY },
+    });
+    expect(r).toMatchObject({ status: 'rolled_back', reason: 'toctou_revalidate_failed' });
+    expect(git.st.ref).toBe('main@abc'); // restored
+    expect(git.st.synced).toBe(false);
+  });
+  it('actual-harm canary: a worker hook error during the window → rollback', async () => {
+    const git = fakeGit();
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: true, lock: lockOk,
+      action: { git, getWorkerErrors: async () => [{ type: 'PreToolUse', error: 'internal error' }], isWorkerInMain: async () => false },
+      engine: { policy: POLICY },
+    });
+    expect(r).toMatchObject({ status: 'rolled_back', reason: 'canary_unhealthy' });
+    expect(git.st.ref).toBe('main@abc');
+  });
+  it('concurrent rollback restores ref + unstashes WIP exactly', async () => {
+    const git = fakeGit();
+    await runCheckoutSyncPilot({
+      flagEnabled: true, lock: lockOk,
+      action: { git, getWorkerErrors: async () => [{ error: 'boom' }], isWorkerInMain: async () => false },
+      engine: { policy: POLICY },
+    });
+    expect(git.st.ref).toBe('main@abc');
+    expect(git.st.wip).toBe('dirty');   // stash restored
+    expect(git.st.stash).toBe(null);
+  });
+  it('surfaces rollback_failed (not swallowed) when restore throws', async () => {
+    const git = fakeGit(); git.st.failRestore = true;
+    const r = await runCheckoutSyncPilot({
+      flagEnabled: true, lock: lockOk,
+      action: { git, getWorkerErrors: async () => [{ error: 'boom' }], isWorkerInMain: async () => false },
+      engine: { policy: POLICY },
+    });
+    expect(r).toMatchObject({ status: 'rollback_failed', killSwitchRecommended: true });
+  });
+});
+
+describe('isEnableEligible (C5, ships OFF)', () => {
+  it('false until all three primitives are proven', () => {
+    expect(isEnableEligible({})).toBe(false);
+    expect(isEnableEligible({ atomicLockProven: true })).toBe(false);
+    expect(isEnableEligible({ atomicLockProven: true, actualHarmCanaryProven: true })).toBe(false);
+  });
+  it('true only when lock + canary + concurrent rollback all proven', () => {
+    expect(isEnableEligible({ atomicLockProven: true, actualHarmCanaryProven: true, concurrentRollbackProven: true })).toBe(true);
+  });
+  it('documents the operator enablement gate', () => {
+    expect(ENABLEMENT_CRITERIA).toMatch(/operator-gated/i);
+    expect(ENABLEMENT_CRITERIA).toMatch(/human-gated/i);
+  });
+});
+
+describe('structural pin (C1): engine is independent of the pilot', () => {
+  it('lib/auto-exec-engine.js does NOT import the checkout-sync pilot', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const engineSrc = readFileSync(resolve(here, '../lib/auto-exec-engine.js'), 'utf8');
+    expect(engineSrc).not.toMatch(/auto-exec-checkout-sync/);
+  });
+});


### PR DESCRIPTION
## Child 001D of SD-LEO-INFRA-POLICY-GATED-AUTO-001 (policy-gated auto-execution engine) — the pilot

Codifies the manual main-checkout deploy-sync as the **first real engine action** — and ships it **default-OFF and NOT enable-eligible**. Enabling auto-exec of the highest-blast fleet op stays a deliberate, operator-earned decision.

### Safety machinery (proven, but the flag stays OFF)
- **Atomic worker-exclusion lock (FM-E)** — the sync runs only when NO live worker is in the main checkout (`claude_sessions` probe, **fail-CLOSED** on a read error) + an atomic primitive so two runs can't sync concurrently. Acquire-or-abort.
- **Re-validate-before-commit (TOCTOU)** — a worker entering main between observe and commit aborts + rolls back.
- **Actual-harm canary (C5)** — watches the REAL signal (worker PreToolUse/hook errors) during the window, not a synthetic proxy.
- **Concurrent rollback (FM-B)** — git stash + preserved branch ref restores the exact pre-sync state with a worker active; a rollback that itself fails surfaces `rollback_failed` + `killSwitchRecommended`.
- **Enable-eligibility gate (C5)** — `isEnableEligible()` is default-safe (needs lock + canary + concurrent-rollback all proven); the flag ships OFF; `ENABLEMENT_CRITERIA` documents the operator gate; no auto-enable path.
- **Structural pin (C1)** — a test asserts `lib/auto-exec-engine.js` does NOT import the pilot; the engine stays action-agnostic and the pilot ships in its own PR (this one), never the engine PR.

### Reuse / footprint
Runs the **001C engine** (`runAutoExec`) unmodified; **no new migration** (reuses `leo_feature_flags`, `leo_auto_exec_audit`, `claude_sessions`, `leo_kill_switches`). DI throughout (git runner, db, worker-error source) — no test mutates a real checkout. `npm run checkout-sync:demo` registers the OFF flag + reports status (never syncs).

### Tests (16 unit)
default-OFF no-op (lock never probed) · worker-in-main abort · atomic lock-held · TOCTOU rollback · actual-harm canary rollback · concurrent rollback restores ref+WIP · `rollback_failed` surfacing · enable-eligibility gate · structural pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)