### PR TITLE
fix(SD-LEO-FIX-FIX-STAGE-VISUAL-001): Stage 21 Visual Assets runs instead of NO_PRECONDITIONS-skip for all ventures

### DIFF
--- a/lib/eva/__tests__/stage-21-visual-assets-preconditions.test.js
+++ b/lib/eva/__tests__/stage-21-visual-assets-preconditions.test.js
@@ -1,0 +1,148 @@
+/**
+ * SD-LEO-FIX-FIX-STAGE-VISUAL-001 — regression tests for the Stage 21 Visual Assets
+ * NO_PRECONDITIONS skip-for-all-ventures bug.
+ *
+ * Root cause (verify_before_build_finding_v2):
+ *   1. CROSS_STAGE_DEPS[21] was the stale [19,20] — the engine never fetched S11/S17,
+ *      so stage11Data/stage17Data never reached the analyzer.
+ *   2. The analyzer read granular keys (stage11ColorData/…/deploymentUrl) nothing
+ *      populated, and checked an s17_archetypes artifact_type S17 doesn't emit.
+ *
+ * These tests pin the corrected contract: Stage 21 RUNS (not skips) for a venture with
+ * S11 brand identity + S17 designs + a resolvable deployment, and SKIPS with the right
+ * skip_reason when each precondition is absent. Network-free: the LLM is mocked to throw
+ * (forcing the deterministic fallback) and supabase is a hand-rolled chainable stub.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Force the LLM fallback path so the test never makes a network call.
+// Resolves to the same module the analyzer imports (lib/llm/index.js).
+vi.mock('../../llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => { throw new Error('no-llm-in-test'); } }),
+}));
+
+const {
+  analyzeStage21VisualAssets,
+  validateEntryPreconditions,
+  resolveDeploymentUrl,
+} = await import('../stage-templates/analysis-steps/stage-21-visual-assets.js');
+
+/**
+ * Minimal chainable supabase stub. Every builder method returns the same thenable;
+ * awaiting it resolves to a response derived from the table + operation.
+ *   config = { ventureResources: [...], ventures: {...}|null }
+ */
+function makeSupabase(config = {}) {
+  const makeQuery = (table) => {
+    const state = { table, op: 'select' };
+    const resolve = () => {
+      if (state.op === 'insert' || state.op === 'update') return { data: null, error: null };
+      if (table === 'venture_resources') return { data: config.ventureResources ?? [], error: null };
+      if (table === 'ventures') return { data: config.ventures ?? null, error: null };
+      if (table === 'leo_feature_flags') return { data: null, error: null };
+      return { data: null, error: null };
+    };
+    const q = {
+      select() { return q; },
+      insert() { state.op = 'insert'; return q; },
+      update() { state.op = 'update'; return q; },
+      eq() { return q; },
+      in() { return q; },
+      order() { return q; },
+      limit() { return q; },
+      maybeSingle() { return Promise.resolve(resolve()); },
+      single() { return Promise.resolve(resolve()); },
+      then(onF, onR) { return Promise.resolve(resolve()).then(onF, onR); },
+    };
+    return q;
+  };
+  return { from: (t) => makeQuery(t) };
+}
+
+const COMPLETE_S11 = { visualIdentity: { primary: '#0A0A0A', accent: '#22D3EE' }, logoSpec: { mark: 'wordmark' }, brandExpression: { tone: 'confident' } };
+const COMPLETE_S17 = { s17_approved: true, s17_strategy_recommendation: 'ship' };
+const silent = { info() {}, warn() {}, log() {}, error() {} };
+
+describe('validateEntryPreconditions (pure)', () => {
+  it('passes when S11 identity + S17 designs + deployment are all present', () => {
+    const r = validateEntryPreconditions({ stage11Data: COMPLETE_S11, stage17Data: COMPLETE_S17, deploymentUrl: 'https://x.repl.co' });
+    expect(r.ok).toBe(true);
+    expect(r.missing).toHaveLength(0);
+  });
+
+  it('flags S11 (source_stage 11) when stage11Data has no visual identity content', () => {
+    const r = validateEntryPreconditions({ stage11Data: { __byType: {} }, stage17Data: COMPLETE_S17, deploymentUrl: 'https://x' });
+    expect(r.ok).toBe(false);
+    expect(r.missing.some((m) => m.source_stage === 11)).toBe(true);
+  });
+
+  it('flags S17 (source_stage 17) when stage17Data is empty', () => {
+    const r = validateEntryPreconditions({ stage11Data: COMPLETE_S11, stage17Data: {}, deploymentUrl: 'https://x' });
+    expect(r.missing.some((m) => m.source_stage === 17)).toBe(true);
+  });
+
+  it('flags deployment when deploymentUrl is blank', () => {
+    const r = validateEntryPreconditions({ stage11Data: COMPLETE_S11, stage17Data: COMPLETE_S17, deploymentUrl: '' });
+    expect(r.missing.some((m) => m.artifact_type === 'venture_resources.deployment_url')).toBe(true);
+  });
+});
+
+describe('resolveDeploymentUrl', () => {
+  it('returns the venture_resources replit_deployment resource_url', async () => {
+    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co', metadata: {} }] });
+    expect(await resolveDeploymentUrl(sb, 'v1')).toBe('https://app.repl.co');
+  });
+
+  it('falls back to ventures.deployment_url when venture_resources has none', async () => {
+    const sb = makeSupabase({ ventureResources: [], ventures: { deployment_url: 'https://fallback.example' } });
+    expect(await resolveDeploymentUrl(sb, 'v1')).toBe('https://fallback.example');
+  });
+
+  it('returns empty string when no deployment exists anywhere', async () => {
+    const sb = makeSupabase({ ventureResources: [], ventures: null });
+    expect(await resolveDeploymentUrl(sb, 'v1')).toBe('');
+  });
+});
+
+describe('analyzeStage21VisualAssets — RUN vs SKIP', () => {
+  it('RUNS (not skips) for a venture with S11 + S17 + deployment, emitting assets', async () => {
+    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const out = await analyzeStage21VisualAssets({
+      stage11Data: COMPLETE_S11, stage17Data: COMPLETE_S17, stage10Data: {},
+      ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    });
+    expect(out._skip).not.toBe(true);
+    expect(out.device_screenshots.length).toBeGreaterThanOrEqual(2);
+    expect(out.social_graphics.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('SKIPS NO_S11_VISUAL_IDENTITY when S11 brand identity is absent', async () => {
+    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const out = await analyzeStage21VisualAssets({
+      stage17Data: COMPLETE_S17, stage10Data: {},
+      ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    });
+    expect(out._skip).toBe(true);
+    expect(out.skip_reason).toBe('NO_S11_VISUAL_IDENTITY');
+  });
+
+  it('SKIPS NO_S17_APPROVED_DESIGNS when S17 designs are absent', async () => {
+    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const out = await analyzeStage21VisualAssets({
+      stage11Data: COMPLETE_S11, stage10Data: {},
+      ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    });
+    expect(out._skip).toBe(true);
+    expect(out.skip_reason).toBe('NO_S17_APPROVED_DESIGNS');
+  });
+
+  it('SKIPS NO_DEPLOYMENT_URL when no deployment resolves', async () => {
+    const sb = makeSupabase({ ventureResources: [], ventures: null });
+    const out = await analyzeStage21VisualAssets({
+      stage11Data: COMPLETE_S11, stage17Data: COMPLETE_S17, stage10Data: {},
+      ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    });
+    expect(out._skip).toBe(true);
+    expect(out.skip_reason).toBe('NO_DEPLOYMENT_URL');
+  });
+});

--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -633,7 +633,7 @@ export const CROSS_STAGE_DEPS = {
   18: [1, 4, 7, 8, 10, 11, 12, 13, 15, 16],  // Marketing copy: idea+competitive+pricing+model+persona/brand+naming+GTM+roadmap+stories+financials
   19: [13, 14, 17, 18],      // Sprint planning: roadmap + arch + blueprint review + readiness
   20: [18, 19],              // Build execution: readiness + sprint plan
-  21: [19, 20],              // QA & testing: sprint plan + build execution
+  21: [10, 11, 17],          // Visual Assets: persona + S11 brand identity + S17 blueprint-review designs (SD-LEO-FIX-FIX-STAGE-VISUAL-001: was the stale [19,20] from the old QA-stage-21; deployment comes from venture_resources, not an upstream stage)
   22: [17, 18, 19, 20, 21],  // Build review: full build phase
   // Phase 5->6: Release Readiness (Stage 23)
   23: [1, 18, 19, 20, 21, 22], // Release readiness: idea + full build loop stages

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -35,11 +35,21 @@ const SOCIAL_SIZES = [
   { platform: 'opengraph', format: 'card',     width: 1200, height: 630,  required: false },
 ];
 
+// SD-LEO-FIX-FIX-STAGE-VISUAL-001: preconditions read the WHOLE-STAGE upstream keys
+// the execution engine actually provides (stage<N>Data from fetchUpstreamArtifacts),
+// not granular per-artifact keys (stage11ColorData/…/deploymentUrl) that nothing
+// populates. S11 brand identity lives inside stage11Data (visualIdentity / logoSpec /
+// brandExpression); S17 approved designs are signalled by a non-empty stage17Data.
+// The deployment precondition is resolved separately from venture_resources.
 const REQUIRED_UPSTREAM = [
-  { artifact_type: 'visual_color_palette', source_stage: 11, param_key: 'stage11ColorData' },
-  { artifact_type: 'visual_typography',    source_stage: 11, param_key: 'stage11TypographyData' },
-  { artifact_type: 'visual_logo_spec',     source_stage: 11, param_key: 'stage11LogoData' },
-  { artifact_type: 's17_archetypes',       source_stage: 17, param_key: 'stage17Data' },
+  {
+    artifact_type: 'identity_visual', source_stage: 11, param_key: 'stage11Data',
+    hasContent: (d) => Boolean(d && typeof d === 'object' && (d.visualIdentity || d.logoSpec || d.brandExpression)),
+  },
+  {
+    artifact_type: 's17_designs', source_stage: 17, param_key: 'stage17Data',
+    hasContent: (d) => Boolean(d && typeof d === 'object' && Object.keys(d).some((k) => k !== '__byType')),
+  },
 ];
 
 const FEATURE_FLAG_KEY = 'LEO_S21_REQUIRED_ARTIFACTS_GATE';
@@ -96,15 +106,58 @@ export function validateEntryPreconditions(params) {
   const missing = [];
   for (const req of REQUIRED_UPSTREAM) {
     const data = params[req.param_key];
-    const present = data && typeof data === 'object' && Object.keys(data).length > 0;
+    const present = typeof req.hasContent === 'function'
+      ? req.hasContent(data)
+      : Boolean(data && typeof data === 'object' && Object.keys(data).length > 0);
     if (!present) missing.push({ artifact_type: req.artifact_type, source_stage: req.source_stage });
   }
   // Special-case: deployment_url comes from venture_resources, not venture_artifacts.
-  // Caller passes it as deploymentUrl. Per FR-4 spec, it's required.
+  // The analyzer resolves it via resolveDeploymentUrl() and passes it as deploymentUrl.
   if (!params.deploymentUrl || typeof params.deploymentUrl !== 'string' || params.deploymentUrl.trim().length === 0) {
     missing.push({ artifact_type: 'venture_resources.deployment_url', source_stage: 19 });
   }
   return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Resolve the venture's live deployment URL. Primary source is venture_resources
+ * (resource_type='replit_deployment'); falls back to ventures.deployment_url. Returns
+ * '' when none is found. All DB errors are swallowed → '' so the precondition simply
+ * reports NO_DEPLOYMENT_URL rather than throwing. The engine never passes a
+ * deploymentUrl param, so this is the canonical resolver.
+ */
+export async function resolveDeploymentUrl(supabase, ventureId) {
+  if (!supabase || !ventureId) return '';
+  const pick = (row) => {
+    if (!row) return '';
+    const url = row.resource_url || row.metadata?.deployment_url || row.metadata?.url || '';
+    return (typeof url === 'string' && url.trim()) ? url.trim() : '';
+  };
+  try {
+    const { data, error } = await supabase
+      .from('venture_resources')
+      .select('resource_url, metadata, status')
+      .eq('venture_id', ventureId)
+      .eq('resource_type', 'replit_deployment')
+      .limit(5);
+    if (!error && Array.isArray(data)) {
+      for (const row of data) {
+        const url = pick(row);
+        if (url) return url;
+      }
+    }
+  } catch { /* fall through to ventures fallback */ }
+  try {
+    const { data, error } = await supabase
+      .from('ventures')
+      .select('deployment_url')
+      .eq('id', ventureId)
+      .maybeSingle();
+    if (!error && data?.deployment_url && typeof data.deployment_url === 'string' && data.deployment_url.trim()) {
+      return data.deployment_url.trim();
+    }
+  } catch { /* ignore */ }
+  return '';
 }
 
 /**
@@ -270,16 +323,20 @@ async function persistSkipMarker(supabase, ventureId, missing, logger) {
 export async function analyzeStage21VisualAssets(params) {
   const {
     stage17Data, stage11Data, stage10Data,
-    stage11ColorData, stage11TypographyData, stage11LogoData,
-    deploymentUrl,
     ventureName, ventureId, supabase,
     logger = console,
   } = params;
 
   logger.info?.(`[S21-VisualAssets] Generating visual asset specs for ${ventureName || 'unknown'}`);
 
-  // FR-4: entry-precondition check. Refuse to fabricate visual assets without source material.
-  const preflight = validateEntryPreconditions(params);
+  // SD-LEO-FIX-FIX-STAGE-VISUAL-001: the execution engine never passes a deploymentUrl
+  // param — resolve it from venture_resources here. Honour an explicit override when a
+  // caller/test pre-resolves it.
+  const deploymentUrl = params.deploymentUrl || await resolveDeploymentUrl(supabase, ventureId);
+
+  // FR-4: entry-precondition check. Refuse to fabricate visual assets without source
+  // material. Check the whole-stage upstream keys the engine provides + resolved deployment.
+  const preflight = validateEntryPreconditions({ stage11Data, stage17Data, deploymentUrl });
   if (!preflight.ok) {
     const skipResult = await persistSkipMarker(supabase, ventureId, preflight.missing, logger);
     logger.warn?.(
@@ -302,11 +359,14 @@ export async function analyzeStage21VisualAssets(params) {
 
   const flagEnabled = await readFeatureFlag(supabase, logger);
 
+  // SD-LEO-FIX-FIX-STAGE-VISUAL-001: brand inputs come from S11's stage11Data
+  // (visualIdentity holds palette/typography, logoSpec holds the logo) — not the
+  // granular stage11*Data params the engine never produced.
   const context = {
     designs: stage17Data || {},
-    brand_palette: stage11ColorData || {},
-    brand_typography: stage11TypographyData || {},
-    brand_logo: stage11LogoData || {},
+    brand_palette: stage11Data?.visualIdentity || {},
+    brand_typography: stage11Data?.brandExpression || stage11Data?.visualIdentity || {},
+    brand_logo: stage11Data?.logoSpec || {},
     persona: stage10Data || {},
     deployment_url: deploymentUrl,
     venture_name: ventureName,


### PR DESCRIPTION
## Summary
EVA **Stage 21 (Visual Assets)** was skipping with `skip_reason=NO_PRECONDITIONS` for **every venture**, so `visual_device_screenshots` + `visual_social_graphics` were never generated. Two compounding defects:

1. **Stale dependency map** — `CROSS_STAGE_DEPS[21]` was `[19,20]` (leftover from the old QA-stage-21 before the S18–S26 marketing-first renumber). The execution engine therefore only fetched `stage19Data`/`stage20Data` and **never fetched the S11 brand identity or S17 designs** the Visual Assets analyzer consumes → the analyzer's upstream params were all `undefined`. Corrected to `[10,11,17]`.
2. **Analyzer read the wrong keys** — `analyzeStage21VisualAssets` destructured granular params (`stage11ColorData`/`stage11TypographyData`/`stage11LogoData`/`deploymentUrl`) that `fetchUpstreamArtifacts` never produces, and checked an `s17_archetypes` artifact_type S17 doesn't emit. Rewrote the preconditions/context to read the **whole-stage keys** the engine actually provides (`stage11Data.visualIdentity`/`.logoSpec`, `stage17Data`) and added `resolveDeploymentUrl()` which queries `venture_resources` (`resource_type='replit_deployment'`) with a `ventures.deployment_url` fallback.

Both fixes are required — correcting only one still skips.

## Changes
- `lib/eva/contracts/stage-contracts.js` — `CROSS_STAGE_DEPS[21]` → `[10,11,17]`
- `lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js` — precondition + context rewrite, new `resolveDeploymentUrl()`
- `lib/eva/__tests__/stage-21-visual-assets-preconditions.test.js` — new network-free regression (11 cases)

## Verification
- New regression suite: **11/11** green (RUN-not-skip with complete S11/S17/deployment; correct `skip_reason` for each missing precondition; deployment-resolver branches).
- Adjacent contract test `stage-18-worker-autogen` still **7/7** (no regression from the deps edit).
- TESTING sub-agent verdict: **PASS**.

## Out of scope (logged)
`getAnalysisStep()` in `analysis-steps/index.js` maps stage 21 → `stage-21-quality-assurance.js` — legacy drift, **not** the engine path (the engine uses `loadStageTemplate` → `stage-21.js`). Flagged for a follow-up, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)