### PR TITLE
fix(SD-LEO-FIX-FIX-POST-BUILD-001): load S7/10/12 + map S21 __byType into stage-22 distribution preconditions

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -634,7 +634,13 @@ export const CROSS_STAGE_DEPS = {
   19: [13, 14, 17, 18],      // Sprint planning: roadmap + arch + blueprint review + readiness
   20: [18, 19],              // Build execution: readiness + sprint plan
   21: [19, 20],              // QA & testing: sprint plan + build execution
-  22: [17, 18, 19, 20, 21],  // Build review: full build phase
+  // SD-LEO-FIX-FIX-POST-BUILD-001: Stage 22 was repurposed from "Build review" to
+  // "Distribution Setup", but this deps set was left stale and omitted the producer's
+  // required upstream source stages 7/10/12 (engine_pricing_model, identity_persona_brand,
+  // identity_gtm_sales_strategy) — so stage7Data/stage10Data/stage12Data arrived undefined
+  // and the producer skipped with precondition_missing even though the artifacts existed.
+  // Added 7/10/12 (mirrors the already-aligned CROSS_STAGE_DEPS[18]); 17-21 kept for context.
+  22: [7, 10, 12, 17, 18, 19, 20, 21],  // Distribution Setup: pricing(7)+persona(10)+GTM(12) preconditions + build-phase context
   // Phase 5->6: Release Readiness (Stage 23)
   23: [1, 18, 19, 20, 21, 22], // Release readiness: idea + full build loop stages
 

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -74,6 +74,48 @@ Rules:
 - Targeting should use persona demographics (age, interests, pain points)`;
 
 /**
+ * Pure helper. Normalizes worker-provided upstream params into the bespoke
+ * param_keys this producer's REQUIRED_UPSTREAM declares.
+ *
+ * The generic worker loader (lib/eva/stage-execution-engine.js fetchUpstreamArtifacts)
+ * keys upstream data as `stage${N}Data` (merged-by-stage) with a `__byType` sub-map
+ * keyed by artifact_type. Params whose param_key already follows the `stage${N}Data`
+ * convention (stage7Data/stage10Data/stage12Data) arrive correctly. The two
+ * per-artifact-type S21 keys (stage21SocialData / stage21ScreenshotData) are NOT
+ * produced by the loader and must be derived from stage21Data.__byType.
+ *
+ * Mirrors the `extractUpstreamByType` pattern in stage-18-marketing-copy.js, but
+ * maps to this producer's declared param_keys via REQUIRED_UPSTREAM. Pure + DB-less:
+ * operates only on the passed-in params, returns a shallow copy (does not mutate
+ * input), and tolerates absent stages / missing __byType.
+ *
+ * SD-LEO-FIX-FIX-POST-BUILD-001.
+ */
+export function normalizeUpstreamParams(params) {
+  const out = { ...(params || {}) };
+  for (const req of REQUIRED_UPSTREAM) {
+    // Already populated under the declared param_key (e.g. stage7Data from the
+    // loader's stage{N}Data convention)? Leave it untouched.
+    const existing = out[req.param_key];
+    if (existing && typeof existing === 'object' && Object.keys(existing).length > 0) continue;
+
+    const stageData = out[`stage${req.source_stage}Data`];
+    if (!stageData || typeof stageData !== 'object') continue;
+
+    const byTypeEntry = stageData.__byType && stageData.__byType[req.artifact_type];
+    if (byTypeEntry && typeof byTypeEntry === 'object') {
+      // fetchUpstreamArtifacts stores the unwrapped artifact_data under __byType;
+      // tolerate a {artifact_data}/{content} wrapper defensively.
+      const data = byTypeEntry.artifact_data || byTypeEntry.content || byTypeEntry;
+      if (data && typeof data === 'object' && Object.keys(data).length > 0) {
+        out[req.param_key] = data;
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Pure helper. Returns {ok, missing[]} where missing names which upstream
  * artifact_type is absent. Does not call the database.
  */
@@ -262,15 +304,19 @@ async function persistSkipMarker(supabase, ventureId, missing, logger) {
 }
 
 export async function analyzeStage22Distribution(params) {
+  // SD-LEO-FIX-FIX-POST-BUILD-001: derive this producer's bespoke param_keys
+  // (notably the per-artifact-type stage21SocialData/stage21ScreenshotData) from
+  // the worker loader's stage{N}Data + __byType shape before gating.
+  const normalized = normalizeUpstreamParams(params);
   const {
     stage12Data, stage10Data, stage18Data, stage7Data,
     ventureName, ventureId, supabase,
     logger = console,
-  } = params;
+  } = normalized;
 
   logger.info?.(`[S22-Distribution] Configuring channels for ${ventureName || 'unknown'}`);
 
-  const preflight = validateEntryPreconditions(params);
+  const preflight = validateEntryPreconditions(normalized);
   if (!preflight.ok) {
     logger.warn?.(
       `[S22-Distribution] SKIP — missing preconditions: ${preflight.missing.map(m => m.artifact_type).join(', ')}`

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
@@ -24,11 +24,13 @@ import {
   validateEntryPreconditions,
   validateChannelCoverage,
   splitArtifacts,
+  normalizeUpstreamParams,
   CHANNELS,
   REQUIRED_UPSTREAM,
   FEATURE_FLAG_KEY,
 } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
+import { CROSS_STAGE_DEPS } from '../../../../../lib/eva/contracts/stage-contracts.js';
 
 // Helper — full happy-path LLM response (all 6 channels, 3 active).
 function makeLLMResponse(overrides = {}) {
@@ -348,5 +350,120 @@ describe('analyzeStage22Distribution — integration (FR-1/3/4)', () => {
     const out = await analyzeStage22Distribution(params);
     expect(out._canonical_pair).toBeDefined();
     expect(out._flag_enabled).toBe(false); // defaults OFF when no supabase
+  });
+});
+
+// SD-LEO-FIX-FIX-POST-BUILD-001 — the worker upstream-loading fix.
+// The generic worker (fetchUpstreamArtifacts) keys upstream data as stage{N}Data
+// merged-by-stage with a __byType sub-map keyed by artifact_type. Before this fix
+// (a) CROSS_STAGE_DEPS[22] omitted source stages 7/10/12 so stage7Data/stage10Data/
+// stage12Data never arrived, and (b) the per-artifact-type S21 keys were never derived.
+describe('SD-LEO-FIX-FIX-POST-BUILD-001 — worker upstream-loading fix', () => {
+  // Shape the loader actually produces: stage{N}Data with a __byType sub-map.
+  function makeWorkerShapeUpstream({ includeS21 = true } = {}) {
+    const upstream = {
+      stage7Data:  { tier: 'pro', __byType: { engine_pricing_model: { tier: 'pro' } } },
+      stage10Data: { name: 'Pragmatic Priya', __byType: { identity_persona_brand: { name: 'Pragmatic Priya' } } },
+      stage12Data: { strategy: 'PLG', __byType: { identity_gtm_sales_strategy: { strategy: 'PLG' } } },
+      stage18Data: { copy: 'tagline', __byType: { content_marketing_copy: { copy: 'tagline' } } },
+    };
+    if (includeS21) {
+      upstream.stage21Data = {
+        // merged top-level (one type wins) + lossless __byType for both visual types
+        url: 'social',
+        __byType: {
+          visual_social_graphics:    { social_url: 'https://cdn/social.png' },
+          visual_device_screenshots: { screenshot_url: 'https://cdn/shot.png' },
+        },
+      };
+    }
+    return upstream;
+  }
+
+  describe('FR-1 — CROSS_STAGE_DEPS[22] alignment', () => {
+    it('includes the producer-required source stages 7, 10 and 12', () => {
+      for (const stage of [7, 10, 12]) {
+        expect(CROSS_STAGE_DEPS[22]).toContain(stage);
+      }
+    });
+
+    it('retains the build-phase context stages 17-21 (additive change only)', () => {
+      for (const stage of [17, 18, 19, 20, 21]) {
+        expect(CROSS_STAGE_DEPS[22]).toContain(stage);
+      }
+    });
+
+    it('every REQUIRED_UPSTREAM source_stage is present in CROSS_STAGE_DEPS[22]', () => {
+      const deps = new Set(CROSS_STAGE_DEPS[22]);
+      for (const req of REQUIRED_UPSTREAM) {
+        expect(deps.has(req.source_stage)).toBe(true);
+      }
+    });
+  });
+
+  describe('FR-2 — normalizeUpstreamParams (per-artifact-type S21 key derivation)', () => {
+    it('derives stage21SocialData / stage21ScreenshotData from stage21Data.__byType', () => {
+      const out = normalizeUpstreamParams(makeWorkerShapeUpstream());
+      expect(out.stage21SocialData).toEqual({ social_url: 'https://cdn/social.png' });
+      expect(out.stage21ScreenshotData).toEqual({ screenshot_url: 'https://cdn/shot.png' });
+    });
+
+    it('leaves already-populated stage{N}Data keys untouched (stage7/10/12)', () => {
+      const input = makeWorkerShapeUpstream();
+      const out = normalizeUpstreamParams(input);
+      expect(out.stage7Data).toBe(input.stage7Data);
+      expect(out.stage10Data).toBe(input.stage10Data);
+      expect(out.stage12Data).toBe(input.stage12Data);
+    });
+
+    it('is pure — does not mutate the input params', () => {
+      const input = makeWorkerShapeUpstream();
+      normalizeUpstreamParams(input);
+      expect(input.stage21SocialData).toBeUndefined();
+      expect(input.stage21ScreenshotData).toBeUndefined();
+    });
+
+    it('tolerates absent stage21Data / missing __byType without throwing', () => {
+      expect(() => normalizeUpstreamParams({})).not.toThrow();
+      expect(() => normalizeUpstreamParams({ stage21Data: {} })).not.toThrow();
+      expect(() => normalizeUpstreamParams(null)).not.toThrow();
+    });
+  });
+
+  describe('FR-3 — producer runs / skips correctly on worker-loader shape', () => {
+    it('RUNS (preconditions ok) when all five upstream artifacts arrive in worker shape', () => {
+      const normalized = normalizeUpstreamParams(makeWorkerShapeUpstream());
+      const result = validateEntryPreconditions(normalized);
+      expect(result.ok).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it('does NOT skip end-to-end for a fully-built venture (worker shape)', async () => {
+      setupMockLLM(makeLLMResponse());
+      const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
+      const out = await analyzeStage22Distribution({
+        ...makeWorkerShapeUpstream(),
+        ventureName: 'DataDistill',
+        ventureId: 'venture-datadistill',
+        supabase: sb,
+        logger: { info: () => {}, warn: () => {} },
+      });
+      expect(out._skip).toBeUndefined();
+      expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeDefined();
+    });
+
+    it('gracefully skips on absent S21 visuals — but NO LONGER falsely reports S7/S10/S12 missing', () => {
+      const normalized = normalizeUpstreamParams(makeWorkerShapeUpstream({ includeS21: false }));
+      const result = validateEntryPreconditions(normalized);
+      expect(result.ok).toBe(false);
+      const missingTypes = result.missing.map(m => m.artifact_type);
+      // The genuinely-absent S21 visuals are still reported...
+      expect(missingTypes).toContain('visual_social_graphics');
+      expect(missingTypes).toContain('visual_device_screenshots');
+      // ...but the false-negative on S7/S10/S12 is fixed.
+      expect(missingTypes).not.toContain('engine_pricing_model');
+      expect(missingTypes).not.toContain('identity_persona_brand');
+      expect(missingTypes).not.toContain('identity_gtm_sales_strategy');
+    });
   });
 });


### PR DESCRIPTION
## SD-LEO-FIX-FIX-POST-BUILD-001 — Fix post-build stage upstream loading

**Problem:** Stage 22 (Distribution Setup) and post-build producers skipped with `precondition_missing` even when their upstream artifacts existed in `venture_artifacts`. Data-verified on venture **DataDistill**: `engine_pricing_model` (S7), `identity_persona_brand` (S10), `identity_gtm_sales_strategy` (S12) all existed but were reported missing.

**Root cause** (verify-before-build confirmed — the worker upstream-loading contract was misaligned with the producer's declared `REQUIRED_UPSTREAM`):
1. `CROSS_STAGE_DEPS[22]` was the stale *Build-Review* set `[17,18,19,20,21]` and **omitted source stages 7/10/12** — never updated when Stage 22 was repurposed to Distribution Setup. So `fetchUpstreamArtifacts` never loaded them → `stage7Data/stage10Data/stage12Data` arrived `undefined`.
2. `fetchUpstreamArtifacts` keys data as `stage{N}Data` merged-by-stage with a `__byType` sub-map, but the producer expects the bespoke per-artifact-type keys `stage21SocialData`/`stage21ScreenshotData` that the loader never produced.

**Fix:**
- `lib/eva/contracts/stage-contracts.js`: `CROSS_STAGE_DEPS[22]` → `[7,10,12,17,18,19,20,21]` (mirrors the already-aligned `CROSS_STAGE_DEPS[18]`).
- `lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js`: added a pure, DB-less `normalizeUpstreamParams` helper (mirrors stage-18 `extractUpstreamByType`) that derives the S21 bespoke keys from `stage21Data.__byType` before `validateEntryPreconditions`.

**Scope guard:** No stage-21 code touched — the S21 visual name-drift is owned by **SD-LEO-FIX-FIX-STAGE-VISUAL-001** (disjoint files, independently mergeable).

**Tests:** 10 new unit tests (deps-pin for 7/10/12, `REQUIRED_UPSTREAM` source_stage coverage guard, `__byType` derivation, purity/no-mutation, producer-runs-on-worker-shape end-to-end, graceful-skip without false S7/S10/S12 missing). **30/30** stage-22 suite pass, **7/7** stage-18 regression pass, **85.93%** line coverage.

**Gates:** LEAD-TO-PLAN 96 · PLAN-TO-EXEC 95 · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 99. Sub-agent evidence: VALIDATION PASS, TESTING PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)