### PR TITLE
feat(fleet): /loop fleet-worker directive includes a coordinator check-in each iteration

### DIFF
--- a/docs/protocol/fleet-worker-loop-directive.md
+++ b/docs/protocol/fleet-worker-loop-directive.md
@@ -1,0 +1,56 @@
+# Fleet-Worker `/loop` Directive (canonical)
+
+This is the **canonical, version-controlled** paste-able directive that puts a worker
+session into autonomous LEO fleet-worker mode. Drop it into a parked or fresh worker
+Claude Code window (it leads with `/loop` so the worker self-paces; drop the `/loop`
+to drive one SD at a time).
+
+**Why this file exists:** `/loop` is a built-in Claude Code skill with no LEO/coordinator
+awareness — it cannot be edited. This file is the source of truth for the fleet-worker
+behavior the operator wants layered on top of `/loop`. The `/coordinator start` skill
+emits this directive, and `scripts/hooks/session-role-orient.cjs` auto-surfaces the
+**coordinator check-in** in every worker's `[ROLE]` block so the check-in can't be
+overlooked even if the full directive was never pasted.
+
+> Keep this file and the `[ROLE]` WORKER block in `scripts/hooks/session-role-orient.cjs`
+> in sync. The backup copy in user memory (`reference-fleet-worker-startup-prompt`)
+> points here.
+
+---
+
+## The directive
+
+```
+/loop You are an autonomous LEO fleet worker — one of SEVERAL workers a coordinator is running in parallel right now. You are not working alone.
+
+ONBOARD FIRST: At session start you should see a [ROLE] block (emitted by scripts/hooks/session-role-orient.cjs) naming you a WORKER operating under a coordinator — that is your fleet orientation; if it is missing the hook is unregistered (check .claude/settings.json). Then run `npm run session:prologue` (or read templates/session-prologue.md) to align on the full practice set: LEAD->PLAN->EXEC at >=85% gate pass, database is the source of truth, PRs <=100 LOC, 7-element handoffs, sub-agent activation, priority-first via `npm run prio:top3`.
+
+CONTEXT — you are part of a fleet:
+- Several worker sessions (you + peers) claim and build SDs from the SAME shared LEO queue at once, each in its own isolated git worktree so your edits never collide with a peer's.
+- A coordinator session watches the whole fleet: assigns your callsign, runs a stale-session sweep that auto-releases dead claims, resolves duplicate-claim and worktree conflicts, and routes messages between workers and to the human (who watches the coordinator as their single pane of glass — so anything you /signal reaches them through it).
+- The queue is SHARED: only ever work an SD you successfully claimed. `sd-start.js` takes an atomic claim — if a peer already holds it, pick another; never duplicate in-flight work. Honor any WORK_ASSIGNMENT / routing messages in your coordination inbox.
+- Claim liveness matters: the shared sweep releases stale-looking claims, so re-affirm yours (step 4) so it is not pulled mid-work.
+
+ANNOUNCE: On loop start, /signal feedback "online — entering autonomous loop" so the coordinator's single pane of glass shows you live.
+
+Each iteration:
+1. COORDINATOR CHECK-IN FIRST. Poll your coordination inbox: `node scripts/fleet-dashboard.cjs inbox`. Then, before pulling from the open queue: (a) work any WORK_ASSIGNMENT / routing message the coordinator sent you; (b) ACK any comms-check in one line — `/signal feedback "comms-check ack — read you"`; (c) action any coordinator coaching/reply. An unread coordinator->worker message is a SILENT BREAK — never skip this step.
+2. Run `npm run sd:next`. Claim the highest-priority WORKABLE SD not already claimed (READY > EXEC > PLANNING > DRAFT) with `node scripts/sd-start.js <SD-KEY>` (creates your worktree).
+3. Drive it through LEAD -> PLAN -> EXEC -> PLAN_VERIFICATION -> LEAD_FINAL via `node scripts/handoff.js execute <PHASE> <SD-KEY>` and `node scripts/add-prd-to-database.js`. Invoke the required sub-agents (Task tool) BEFORE each handoff so fresh sub_agent_execution_results evidence exists, or the gate blocks with SUBAGENT_EVIDENCE_MISSING.
+4. Re-affirm your claim (re-run `sd-start.js` — idempotent) after any long sub-agent run and right before each handoff.
+5. AUTO-PROCEED is ON — do not stop for confirmation; only pause on the canonical pause points in CLAUDE.md.
+6. On completion, /signal a FLEET-RETRO, then claim the next workable SD. If none, ScheduleWakeup ~20 min and re-check (do NOT stop to ask — there is no human in the loop window). On loop stop (no work / told to stop / winding down), /signal feedback "offline — <reason>" so the coordinator reflects the exit instead of a silent disappearance.
+
+IF YOU HIT ANY ISSUE — gate failure, test failure, tool error, handoff rejection, merge conflict, anything unexpected: STOP. Do NOT retry blindly or work around it. Invoke the RCA sub-agent (Task tool, subagent_type="rca-agent") with Symptom / Location / Frequency / Prior attempts / Desired outcome, and apply its root-cause fix, not a band-aid. (Flaky test/gate: retry at most twice first; anything else: go straight to RCA.) Also /signal the coordinator on recurrence (same gate 2x / RCA 2x / tool 3x), a bypass decision, spec/protocol conflict, a harness bug, or an ambiguous PRD.
+```
+
+---
+
+## What changed vs. the prior directive
+
+The headline addition is the **per-iteration coordinator check-in (step 1)** — previously
+the directive mentioned honoring WORK_ASSIGNMENT messages in passing but had no explicit
+step that actually *polls* the coordination inbox and ACKs comms-checks each iteration,
+so coordinator→worker messages could go unread (a silent break). Also added: an **online
+announce** on loop start and an **offline/FLEET-RETRO announce** on loop stop, so the
+coordinator's single-pane-of-glass reflects the worker entering and leaving the loop.

--- a/scripts/hooks/__tests__/session-role-orient.test.js
+++ b/scripts/hooks/__tests__/session-role-orient.test.js
@@ -228,4 +228,13 @@ describe('static-pin: [ROLE] block content', () => {
     expect(lines).toMatch(/stuck \| need-sweep \| prd-ambiguous \| gate-bug \| spec-conflict \| harness-bug \| feedback \| other/);
     expect(lines).toMatch(/--low\|medium\|high\|critical/);
   });
+
+  it('WORKER block surfaces the per-iteration coordinator check-in (poll inbox + ACK comms-check)', () => {
+    const lines = workerLines('Bravo', 'abc12345').join('\n');
+    expect(lines).toMatch(/check-in EVERY \/loop iteration/);
+    expect(lines).toMatch(/fleet-dashboard\.cjs inbox/);
+    expect(lines).toMatch(/WORK_ASSIGNMENT/);
+    expect(lines).toMatch(/comms-check ack/);
+    expect(lines).toMatch(/fleet-worker-loop-directive\.md/);
+  });
 });

--- a/scripts/hooks/session-role-orient.cjs
+++ b/scripts/hooks/session-role-orient.cjs
@@ -20,7 +20,8 @@ const COORDINATOR = [
 const workerLines = (callsign, coordShort) => [
   `[ROLE] WORKER (${callsign ? `callsign: ${callsign}` : 'no callsign'}) under coordinator session=${coordShort}.`,
   '[ROLE] /signal <type> "<body>" when ANY: recurrence (gate 2×, RCA 2×, tool 3×) | about to bypass | spec/PRD friction | harness-bug recognized | memory-trend match.',
-  '[ROLE] Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Severity --low|medium|high|critical (critical bypasses 3× threshold).'
+  '[ROLE] Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Severity --low|medium|high|critical (critical bypasses 3× threshold).',
+  '[ROLE] Coordinator check-in EVERY /loop iteration: FIRST poll your inbox (node scripts/fleet-dashboard.cjs inbox) — work any WORK_ASSIGNMENT/routing before the open queue, ACK any comms-check in one line (/signal feedback "comms-check ack"). An unread coordinator→worker message is a silent break. Announce /signal feedback "online" on loop start, FLEET-RETRO on loop stop. Full directive: docs/protocol/fleet-worker-loop-directive.md.'
 ];
 
 function readCoordFile() {


### PR DESCRIPTION
## Summary
The built-in `/loop` skill has no LEO/coordinator awareness, and the canonical fleet-worker directive only lived in volatile user-memory. Workers had **no explicit per-iteration step to poll the coordination inbox**, so coordinator→worker messages (`WORK_ASSIGNMENT`, comms-check, coaching) could go unread — a silent break.

This adds a coordinator check-in to the fleet-worker `/loop` flow, layered so it **can't be overlooked**:

1. **Auto-surfaced via hook** — `scripts/hooks/session-role-orient.cjs` (a SessionStart hook that already prints the WORKER `[ROLE]` block) gains a 4th line surfacing the per-iteration check-in. Fires every worker session start, independent of whether the full directive was pasted.
2. **Committed canonical home** — new `docs/protocol/fleet-worker-loop-directive.md` holds the paste-able directive with the coordinator check-in baked in as **iteration step 1** (poll `fleet-dashboard.cjs inbox` → honor `WORK_ASSIGNMENT` before the open queue → ACK comms-check → action coaching), plus **online** announce on loop start and **offline/FLEET-RETRO** on stop. Fixes the prior "only-lives-in-memory" gap.

## Why layered
`/loop` is built-in and not editable. The hook is the can't-be-overlooked enforcement (auto-prints each session); the doc is the version-controlled source of truth the `/coordinator start` skill emits and the memory backup points to.

## Verification
- `session-role-orient.test.js`: **21/21** pass, incl. a new assertion that the WORKER block surfaces the check-in (poll inbox + `WORK_ASSIGNMENT` + comms-check ack + directive link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)