### PR TITLE
feat(SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001): deterministic worker check-in handshake

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -1,0 +1,54 @@
+<!-- reasoning_effort: low -->
+
+---
+description: "Check in with the active coordinator: one deterministic handshake that resolves to claim / self-claim / idle. Use when a worker session starts, finishes an SD, or is told to 'check in'. Per SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001."
+---
+
+# /checkin — Deterministic worker check-in handshake
+
+The worker-PULL counterpart to coordinator-PUSH. One verb that ALWAYS resolves to a single action and **never** waits on a human. Use it when:
+- a worker session starts and needs work,
+- a worker finishes an SD and needs the next one,
+- the operator says "check in with the coordinator".
+
+## Run it
+
+```bash
+node scripts/worker-checkin.cjs
+```
+
+(Equivalent: `npm run checkin`. No `--env-file` needed — the CLI self-loads `.env` via `lib/fleet/worker-status.cjs`. `CLAUDE_SESSION_ID` comes from the SessionStart hook.)
+
+The CLI prints **one JSON object** describing the resolved action. It does the whole handshake itself: resolve the active coordinator (`lib/coordinator/resolve.cjs`), confirm callsign, register availability with an idempotent `payload.kind=roll_call` row (off the friction channel), then resolve work.
+
+## Act on the result (NEVER stop to ask the human)
+
+| `action` | What the CLI did | What you do next |
+|----------|------------------|------------------|
+| `resume` | You already claim `sd` | Run `node scripts/sd-start.js <sd>` to (re)attach the worktree, then continue that SD. |
+| `claimed_assignment` | Claimed the coordinator's assigned `sd` via `claim_sd` | Run `node scripts/sd-start.js <sd>`, load phase context, build it. |
+| `self_claimed` | No assignment, so claimed the top of `sd:next` (`sd`) | Run `node scripts/sd-start.js <sd>`, load phase context, build it. |
+| `idle` | Nothing claimable right now | Call `ScheduleWakeup(delaySeconds=recommended_wakeup_seconds)` and proceed — do **not** wait on a human. On the next wake, run `/checkin` again. |
+| `error` | `CLAUDE_SESSION_ID` missing or DB unavailable | Report the `error` field; do not loop blindly. |
+
+This is an autonomous-fleet contract: a `/loop` worker must keep moving. Decide from the JSON, act, and proceed. Never end a check-in by asking the operator what to do (no human watches the loop window).
+
+## Two-way (optional)
+
+When `COORDINATOR_TWOWAY_V2=on` (set in `.claude/settings.json` env), you can also ask the coordinator a question and await a reply:
+
+```bash
+node scripts/worker-signal.cjs request "<question>" --timeout 30000
+```
+
+## What it writes
+
+A single `session_coordination` row, `message_type=INFO`, `payload.kind=roll_call` (deliberately **no** `payload.signal_type` / `intent_action`, so the friction signal-router and the deconfliction sweep never scoop it). Re-running within 5 minutes is a no-op (idempotent).
+
+## Implementation
+
+Thin wrapper around the worker-checkin CLI:
+
+```bash
+node scripts/worker-checkin.cjs
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "SWEEP_RESPECT_INFLIGHT_AGENT": "1"
+    "SWEEP_RESPECT_INFLIGHT_AGENT": "1",
+    "COORDINATOR_TWOWAY_V2": "on"
   },
   "statusLine": {
     "type": "command",

--- a/lib/coordinator/worker-signal.request.test.js
+++ b/lib/coordinator/worker-signal.request.test.js
@@ -1,0 +1,110 @@
+// Tests for SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 / FR-1
+// Proves the worker->coordinator two-way `request` round-trip is no longer
+// gated off (exit 3) when COORDINATOR_TWOWAY_V2=on, and that the request
+// payload + awaitCoordinatorReply round-trip completes.
+//
+// worker-signal.cjs `request` does: if (!isTwoWayV2Enabled()) process.exit(3).
+// So proving isTwoWayV2Enabled() is true with the flag on === proving the
+// request path is no longer a no-op. The reply consumption is proven by
+// driving awaitCoordinatorReply() against an injected supabase stub.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { isTwoWayV2Enabled } = require('./resolve.cjs');
+const { buildRequestPayload, awaitCoordinatorReply } = require('../../scripts/worker-signal.cjs');
+
+describe('FR-1: COORDINATOR_TWOWAY_V2 gate (no more exit 3)', () => {
+  const prev = process.env.COORDINATOR_TWOWAY_V2;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.COORDINATOR_TWOWAY_V2;
+    else process.env.COORDINATOR_TWOWAY_V2 = prev;
+  });
+
+  it('request path is gated OFF (would exit 3) when flag unset', () => {
+    delete process.env.COORDINATOR_TWOWAY_V2;
+    expect(isTwoWayV2Enabled()).toBe(false);
+  });
+
+  it('request path is ENABLED when COORDINATOR_TWOWAY_V2=on', () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    expect(isTwoWayV2Enabled()).toBe(true);
+  });
+});
+
+describe('FR-1: request payload contract', () => {
+  it('builds a coordinator_request payload with a correlation id and no friction/intent discriminators', () => {
+    const payload = buildRequestPayload({
+      correlationId: 'corr-123',
+      body: 'checking in — what should I work on?',
+      senderCallsign: 'Alpha',
+      repo: '/repo'
+    });
+    expect(payload.kind).toBe('coordinator_request');
+    expect(payload.correlation_id).toBe('corr-123');
+    expect(payload.expects_reply).toBe(true);
+    expect(payload.sender_callsign).toBe('Alpha');
+    // INVARIANT: request rows must NOT carry signal_type (friction channel) or
+    // intent_action (deconfliction sweep) or signal-router / the intent sweep
+    // would scoop them.
+    expect(payload.signal_type).toBeUndefined();
+    expect(payload.intent_action).toBeUndefined();
+  });
+});
+
+describe('FR-1: awaitCoordinatorReply round-trip', () => {
+  // Minimal supabase stub: session_coordination.select(...).eq().eq().order().limit()
+  // resolves to whatever rows we queue.
+  function buildSupabaseStub(rowsSequence) {
+    let call = 0;
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => {
+        const rows = rowsSequence[Math.min(call, rowsSequence.length - 1)];
+        call += 1;
+        return Promise.resolve({ data: rows, error: null });
+      }),
+    };
+    return { from: vi.fn(() => chain) };
+  }
+
+  it('resolves ok=true when a correlated coordinator reply row is present', async () => {
+    const replyRow = {
+      id: 'reply-1',
+      payload: { reply_to: 'corr-123', body: 'work on SD-FOO-001' },
+      body: 'work on SD-FOO-001',
+      sender_session: 'coordinator-xyz',
+      created_at: '2026-06-07T12:00:00Z',
+    };
+    const supabase = buildSupabaseStub([[replyRow]]);
+    const result = await awaitCoordinatorReply(supabase, {
+      sessionId: 'worker-1',
+      correlationId: 'corr-123',
+      timeoutMs: 5000,
+      pollMs: 10,
+      now: () => 0,
+      sleep: async () => {},
+    });
+    expect(result.ok).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.reply.id).toBe('reply-1');
+    expect(result.reply.payload.reply_to).toBe('corr-123');
+  });
+
+  it('times out (ok=false) when no reply arrives before the deadline', async () => {
+    const supabase = buildSupabaseStub([[]]); // never any rows
+    let t = 0;
+    const result = await awaitCoordinatorReply(supabase, {
+      sessionId: 'worker-1',
+      correlationId: 'corr-404',
+      timeoutMs: 50,
+      pollMs: 10,
+      now: () => { const v = t; t += 20; return v; }, // advances past deadline
+      sleep: async () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.reply).toBeNull();
+  });
+});

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -1,0 +1,131 @@
+/**
+ * Fleet worker-status schema-contract helper
+ * SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 / FR-3
+ *
+ * Two jobs, both of which kill a tax that every fresh worker session re-pays
+ * (the ~12-tool-call reverse-engineering documented in the SD / PAT-FLEET-CHECKIN-001):
+ *
+ *   1. ENV TAX — expose a self-env-loading supabase client. Reuses
+ *      lib/supabase-client.cjs, which walks up from cwd to find `.env`, so
+ *      callers never need `node --env-file=.env` (the #1 first-query failure
+ *      "supabaseUrl is required").
+ *
+ *   2. SCHEMA-FOLKLORE TAX — export the CANONICAL column names for the fleet
+ *      tables, verified against the live DB (2026-06-07). Folklore names that
+ *      do NOT exist and cost wasted queries:
+ *        - session_coordination: `from_session`/`to_session`  -> WRONG
+ *        - claude_sessions:       `last_heartbeat`             -> WRONG
+ *      The correct names are below. Import the contract instead of guessing.
+ *
+ * NOTE: this file is `.cjs` (not `.js`) on purpose. package.json has
+ * `type: module`, so a bare `.js` here would be ESM and could NOT be required
+ * by scripts/worker-checkin.cjs (CommonJS). This mirrors lib/coordinator/*.cjs.
+ */
+
+const { createSupabaseServiceClient, createSupabaseClient } = require('../supabase-client.cjs');
+
+// --- Canonical column contract (verified against live DB 2026-06-07) ---
+
+const SESSION_COORDINATION_COLUMNS = Object.freeze({
+  id: 'id',
+  targetSession: 'target_session',   // NOT to_session
+  targetSd: 'target_sd',
+  messageType: 'message_type',
+  subject: 'subject',
+  body: 'body',
+  payload: 'payload',
+  senderSession: 'sender_session',   // NOT from_session
+  senderType: 'sender_type',
+  createdAt: 'created_at',
+  expiresAt: 'expires_at',
+  readAt: 'read_at',
+  acknowledgedAt: 'acknowledged_at',
+});
+
+const CLAUDE_SESSIONS_COLUMNS = Object.freeze({
+  sessionId: 'session_id',
+  sdKey: 'sd_key',
+  status: 'status',
+  heartbeatAt: 'heartbeat_at',        // NOT last_heartbeat
+  worktreePath: 'worktree_path',
+  metadata: 'metadata',
+  claimingSessionId: 'claiming_session_id',
+  expectedSilenceUntil: 'expected_silence_until',
+});
+
+// payload.kind discriminators carried on the existing INFO message_type. Using
+// payload.kind (NOT payload.signal_type) keeps roll-call / request / reply rows
+// OFF the friction signal-router and the intent-deconfliction sweep.
+const PAYLOAD_KINDS = Object.freeze({
+  ROLL_CALL: 'roll_call',             // FR-2 worker availability registration
+  COORDINATOR_REQUEST: 'coordinator_request',
+  COORDINATOR_REPLY: 'coordinator_reply',
+  WORK_ASSIGNMENT: 'work_assignment',
+});
+
+const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Self-env-loading service client (RLS-bypass). Throws only if no URL/service
+ * key can be found after the ancestor `.env` walk.
+ */
+function getServiceClient() {
+  return createSupabaseServiceClient();
+}
+
+/**
+ * Self-env-loading read client. Prefers the service client (so reads are not
+ * RLS-filtered); falls back to the anon client when no service key is present.
+ */
+function getReadClient() {
+  try {
+    return createSupabaseServiceClient();
+  } catch {
+    return createSupabaseClient();
+  }
+}
+
+/**
+ * Sessions that have heartbeat within `withinMs` (default 15m), newest first.
+ * Uses heartbeat_at (the correct column) so callers don't trip on last_heartbeat.
+ */
+async function getActiveSessions(sb, { withinMs = FLEET_ACTIVE_WINDOW_MS } = {}) {
+  const C = CLAUDE_SESSIONS_COLUMNS;
+  const since = new Date(Date.now() - withinMs).toISOString();
+  const { data, error } = await sb
+    .from('claude_sessions')
+    .select([C.sessionId, C.sdKey, C.status, C.heartbeatAt, C.worktreePath, C.metadata].join(', '))
+    .gte(C.heartbeatAt, since)
+    .order(C.heartbeatAt, { ascending: false });
+  if (error) throw error;
+  return data || [];
+}
+
+/**
+ * Coordination messages addressed to a session, newest first. Uses
+ * target_session/sender_session/created_at (the correct columns).
+ */
+async function getMessagesForSession(sb, sessionId, { sinceIso = null, unreadOnly = false } = {}) {
+  const C = SESSION_COORDINATION_COLUMNS;
+  let q = sb
+    .from('session_coordination')
+    .select([C.id, C.messageType, C.subject, C.body, C.payload, C.senderType, C.createdAt, C.readAt].join(', '))
+    .eq(C.targetSession, sessionId)
+    .order(C.createdAt, { ascending: false });
+  if (sinceIso) q = q.gte(C.createdAt, sinceIso);
+  if (unreadOnly) q = q.is(C.readAt, null);
+  const { data, error } = await q;
+  if (error) throw error;
+  return data || [];
+}
+
+module.exports = {
+  SESSION_COORDINATION_COLUMNS,
+  CLAUDE_SESSIONS_COLUMNS,
+  PAYLOAD_KINDS,
+  FLEET_ACTIVE_WINDOW_MS,
+  getServiceClient,
+  getReadClient,
+  getActiveSessions,
+  getMessagesForSession,
+};

--- a/lib/fleet/worker-status.test.js
+++ b/lib/fleet/worker-status.test.js
@@ -1,0 +1,62 @@
+// Tests for SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 / FR-3
+// lib/fleet/worker-status.cjs — schema-contract helper.
+// Pins the canonical column names (so the from_session/to_session/last_heartbeat
+// folklore can never silently creep back) and proves the query helpers issue
+// queries against the CORRECT columns.
+
+import { describe, it, expect, vi } from 'vitest';
+
+const ws = require('./worker-status.cjs');
+
+describe('FR-3: canonical column contract', () => {
+  it('session_coordination uses sender_session/target_session (NOT from_session/to_session)', () => {
+    expect(ws.SESSION_COORDINATION_COLUMNS.senderSession).toBe('sender_session');
+    expect(ws.SESSION_COORDINATION_COLUMNS.targetSession).toBe('target_session');
+    expect(Object.values(ws.SESSION_COORDINATION_COLUMNS)).not.toContain('from_session');
+    expect(Object.values(ws.SESSION_COORDINATION_COLUMNS)).not.toContain('to_session');
+  });
+
+  it('claude_sessions uses heartbeat_at (NOT last_heartbeat)', () => {
+    expect(ws.CLAUDE_SESSIONS_COLUMNS.heartbeatAt).toBe('heartbeat_at');
+    expect(Object.values(ws.CLAUDE_SESSIONS_COLUMNS)).not.toContain('last_heartbeat');
+  });
+
+  it('roll_call discriminator rides on payload.kind, not signal_type', () => {
+    expect(ws.PAYLOAD_KINDS.ROLL_CALL).toBe('roll_call');
+    expect(ws.PAYLOAD_KINDS.COORDINATOR_REQUEST).toBe('coordinator_request');
+  });
+});
+
+// A supabase stub that records the exact columns passed to query builders, so we
+// can assert the helper does NOT regress to a folklore column name.
+function recordingStub() {
+  const calls = { table: null, eq: [], gte: [], order: [], is: [], select: null };
+  const chain = {
+    select: vi.fn((cols) => { calls.select = cols; return chain; }),
+    eq: vi.fn((col, val) => { calls.eq.push([col, val]); return chain; }),
+    gte: vi.fn((col, val) => { calls.gte.push([col, val]); return chain; }),
+    is: vi.fn((col, val) => { calls.is.push([col, val]); return chain; }),
+    order: vi.fn((col, opts) => { calls.order.push([col, opts]); return Promise.resolve({ data: [], error: null }); }),
+  };
+  return { sb: { from: vi.fn((t) => { calls.table = t; return chain; }) }, calls };
+}
+
+describe('FR-3: query helpers use correct columns', () => {
+  it('getMessagesForSession queries session_coordination by target_session', async () => {
+    const { sb, calls } = recordingStub();
+    await ws.getMessagesForSession(sb, 'worker-1');
+    expect(calls.table).toBe('session_coordination');
+    expect(calls.eq).toContainEqual(['target_session', 'worker-1']);
+    expect(calls.order[0][0]).toBe('created_at');
+    // never the folklore name
+    expect(calls.eq.map(e => e[0])).not.toContain('to_session');
+  });
+
+  it('getActiveSessions filters claude_sessions by heartbeat_at', async () => {
+    const { sb, calls } = recordingStub();
+    await ws.getActiveSessions(sb, { withinMs: 60000 });
+    expect(calls.table).toBe('claude_sessions');
+    expect(calls.gte[0][0]).toBe('heartbeat_at');
+    expect(calls.order[0][0]).toBe('heartbeat_at');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
     "sd:park": "node scripts/sd-park.js park",
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
+    "checkin": "node scripts/worker-checkin.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "sd:start": "node scripts/sd-start.js",

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Worker check-in handshake (worker-PULL, first-class + deterministic)
+ * SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 / FR-2
+ *
+ * THE single worker check-in verb. One idempotent handshake that ALWAYS
+ * resolves to exactly one action and NEVER asks the human:
+ *
+ *   1. resolve the active coordinator (lib/coordinator/resolve.cjs)
+ *   2. confirm callsign (coordinator-push; reported, not demanded)
+ *   3. register availability via session_coordination payload.kind=roll_call
+ *      (NOT payload.signal_type — stays OFF the friction channel)  [idempotent]
+ *   4. if already claiming an SD -> action=resume
+ *   5. else pull a pending WORK_ASSIGNMENT and claim it via the claim_sd RPC
+ *      -> action=claimed_assignment
+ *   6. else self-claim the top of the sd:next queue (v_sd_next_candidates)
+ *      -> action=self_claimed
+ *   7. else -> action=idle (the /checkin skill then calls ScheduleWakeup; that
+ *      is a HARNESS tool, NOT Node-callable, so we only RECOMMEND it here)
+ *
+ * Output is a single JSON object (parsed by the /checkin skill). The CLI never
+ * reads stdin and never blocks on input — fail-open at every step.
+ *
+ * Usage: node scripts/worker-checkin.cjs            (CLAUDE_SESSION_ID from env)
+ *        node scripts/worker-checkin.cjs --json      (same; JSON is the default)
+ */
+
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const ws = require('../lib/fleet/worker-status.cjs');
+
+const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
+const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
+const DEFAULT_IDLE_WAKEUP_SECONDS = 1200;    // ~20m, matches the fleet idle cadence
+const SELF_CLAIM_CANDIDATE_LIMIT = 5;
+
+const SD_KEY_RE = /SD-[A-Z0-9]+(?:-[A-Z0-9]+)+/;
+
+/**
+ * Pure: extract the target SD key from a WORK_ASSIGNMENT row, trying the
+ * structured payload first, then the subject/body text. Returns null if none.
+ * Exported for unit testing.
+ */
+function extractSdFromAssignment(msg) {
+  if (!msg) return null;
+  const p = msg.payload || {};
+  if (typeof p.assigned_sd === 'string' && p.assigned_sd) return p.assigned_sd;
+  if (typeof p.sd_key === 'string' && p.sd_key) return p.sd_key;
+  if (Array.isArray(p.available_sds) && p.available_sds.length) return p.available_sds[0];
+  // current_sd is what the worker is ALREADY on — only use it as a last resort
+  // when nothing else names a target (an assignment can reference the same SD).
+  const text = `${msg.subject || ''} ${msg.body || ''} ${p.body || ''}`;
+  const m = text.match(SD_KEY_RE);
+  if (m) return m[0];
+  if (typeof p.current_sd === 'string' && p.current_sd) return p.current_sd;
+  return null;
+}
+
+async function resolveTrack(sb, sdKey, fallback) {
+  if (fallback) return fallback;
+  try {
+    const { data } = await sb.from('sd_baseline_items').select('track').eq('sd_key', sdKey).maybeSingle();
+    return (data && data.track) || 'STANDALONE';
+  } catch {
+    return 'STANDALONE';
+  }
+}
+
+/** Attempt a claim via the canonical claim_sd RPC. Never throws. */
+async function tryClaim(sb, sdKey, sessionId, track) {
+  try {
+    const p_track = await resolveTrack(sb, sdKey, track);
+    const { data, error } = await sb.rpc('claim_sd', { p_sd_id: sdKey, p_session_id: sessionId, p_track });
+    if (error) return { ok: false, error: error.message };
+    if (data && data.success === false) return { ok: false, error: data.error || 'claim_rejected', owner: data.claimed_by };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
+/** Register availability with an idempotent roll_call row. Never throws. */
+async function registerRollCall(sb, { sessionId, coordinatorId, callsign, mySd }) {
+  try {
+    const C = ws.SESSION_COORDINATION_COLUMNS;
+    const sinceIso = new Date(Date.now() - ROLL_CALL_DEDUP_MS).toISOString();
+    const { data: recent } = await sb
+      .from('session_coordination')
+      .select(`${C.id}, ${C.createdAt}, ${C.payload}`)
+      .eq(C.senderSession, sessionId)
+      .gte(C.createdAt, sinceIso)
+      .order(C.createdAt, { ascending: false })
+      .limit(5);
+    const dup = (recent || []).find(r => r.payload && r.payload.kind === ws.PAYLOAD_KINDS.ROLL_CALL);
+    if (dup) return { id: dup.id, deduped: true };
+
+    const payload = {
+      kind: ws.PAYLOAD_KINDS.ROLL_CALL,   // discriminator on the INFO type — NOT signal_type
+      sender_callsign: callsign || null,
+      sd_key: mySd || null,
+      available: !mySd,
+      repo: process.cwd(),
+    };
+    const { data, error } = await sb
+      .from('session_coordination')
+      .insert({
+        sender_session: sessionId,
+        sender_type: 'worker',
+        target_session: coordinatorId || 'broadcast-coordinator',
+        message_type: 'INFO',
+        subject: `[ROLL_CALL] ${callsign || 'unassigned'} ${mySd ? 'working ' + mySd : 'available'}`,
+        body: null,
+        payload,
+        expires_at: new Date(Date.now() + ROLL_CALL_TTL_MS).toISOString(),
+      })
+      .select('id')
+      .single();
+    if (error) return { id: null, error: error.message };
+    return { id: data && data.id, deduped: false };
+  } catch (e) {
+    return { id: null, error: e.message };
+  }
+}
+
+async function ackMessage(sb, id) {
+  try {
+    const now = new Date().toISOString();
+    await sb.from('session_coordination').update({ read_at: now, acknowledged_at: now }).eq('id', id);
+  } catch { /* best-effort */ }
+}
+
+/**
+ * Run the full handshake. Pure-ish: takes an injected supabase client + session
+ * id so it is unit-testable without env/network. Returns the resolution object
+ * (the same object printed as JSON by the CLI). NEVER throws, NEVER reads stdin.
+ */
+async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinatorId } = {}) {
+  // 1. resolve coordinator (fail-open to null -> broadcast)
+  let coordinatorId = null;
+  try { coordinatorId = await getCoordinator(sb); } catch { coordinatorId = null; }
+
+  // 2. confirm callsign + current claim
+  let callsign = null, mySd = null;
+  try {
+    const { data } = await sb.from('claude_sessions').select('metadata, sd_key').eq('session_id', sessionId).maybeSingle();
+    if (data) {
+      callsign = (data.metadata && (data.metadata.fleet_identity?.callsign || data.metadata.callsign)) || null;
+      mySd = data.sd_key || null;
+    }
+  } catch { /* fail-open */ }
+
+  // 3. register availability (idempotent)
+  const rollCall = await registerRollCall(sb, { sessionId, coordinatorId, callsign, mySd });
+
+  const base = { ok: true, callsign, coordinator: coordinatorId, roll_call_id: rollCall.id, two_way: process.env.COORDINATOR_TWOWAY_V2 === 'on' };
+
+  // 4. already working -> resume
+  if (mySd) {
+    return { ...base, action: 'resume', sd: mySd, message: `Already claiming ${mySd}; resume work (run sd-start to (re)attach the worktree).` };
+  }
+
+  // 5. pending WORK_ASSIGNMENT -> claim via claim_sd RPC
+  let assignment = null;
+  try {
+    const msgs = await ws.getMessagesForSession(sb, sessionId, { unreadOnly: true });
+    assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
+  } catch { /* fail-open */ }
+  if (assignment) {
+    const sdKey = extractSdFromAssignment(assignment);
+    if (sdKey) {
+      const claimed = await tryClaim(sb, sdKey, sessionId);
+      if (claimed.ok) {
+        await ackMessage(sb, assignment.id);
+        return { ...base, action: 'claimed_assignment', sd: sdKey, message: `Claimed assigned ${sdKey} via claim_sd. Run: node scripts/sd-start.js ${sdKey}` };
+      }
+      // could not claim the assigned SD -> fall through to self-claim
+      base.assignment_claim_error = claimed.error;
+    }
+  }
+
+  // 6. self-claim top of sd:next (v_sd_next_candidates is baseline-ranked)
+  try {
+    const { data: cands } = await sb
+      .from('v_sd_next_candidates')
+      .select('sd_id, track, status, priority')
+      .limit(SELF_CLAIM_CANDIDATE_LIMIT);
+    for (const c of (cands || [])) {
+      const claimed = await tryClaim(sb, c.sd_id, sessionId, c.track);
+      if (claimed.ok) {
+        return { ...base, action: 'self_claimed', sd: c.sd_id, track: c.track, message: `Self-claimed ${c.sd_id} from sd:next. Run: node scripts/sd-start.js ${c.sd_id}` };
+      }
+    }
+  } catch { /* fail-open */ }
+
+  // 7. idle -> recommend a wakeup (ScheduleWakeup is a HARNESS tool, not Node-callable)
+  return {
+    ...base,
+    action: 'idle',
+    recommended_wakeup_seconds: DEFAULT_IDLE_WAKEUP_SECONDS,
+    message: `No assignment and nothing claimable. IDLE. The /checkin skill must now call ScheduleWakeup(~${DEFAULT_IDLE_WAKEUP_SECONDS}s) and proceed — never wait on a human.`,
+  };
+}
+
+async function main() {
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: 'CLAUDE_SESSION_ID env var required (set by the SessionStart hook).' }, null, 2));
+    process.exit(1);
+  }
+  let sb;
+  try {
+    sb = ws.getServiceClient();
+  } catch (e) {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: `supabase client unavailable: ${e.message}` }, null, 2));
+    process.exit(1);
+  }
+  const result = await runCheckin(sb, sessionId);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: err.message || String(err) }, null, 2));
+    process.exit(1);
+  });
+}

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -1,0 +1,135 @@
+// Tests for SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 / FR-2
+// scripts/worker-checkin.cjs — the deterministic worker check-in handshake.
+// Proves the handshake ALWAYS resolves to exactly one action and never hangs
+// on a human, across resume / claimed_assignment / self_claimed / idle.
+
+import { describe, it, expect, vi } from 'vitest';
+
+const { extractSdFromAssignment, runCheckin, DEFAULT_IDLE_WAKEUP_SECONDS } = require('./worker-checkin.cjs');
+
+describe('FR-2: extractSdFromAssignment', () => {
+  it('prefers payload.sd_key', () => {
+    expect(extractSdFromAssignment({ payload: { sd_key: 'SD-FOO-BAR-001' } })).toBe('SD-FOO-BAR-001');
+  });
+  it('uses available_sds[0]', () => {
+    expect(extractSdFromAssignment({ payload: { available_sds: ['SD-A-B-001', 'SD-C-D-002'] } })).toBe('SD-A-B-001');
+  });
+  it('parses an SD key out of the subject text', () => {
+    expect(extractSdFromAssignment({ subject: 'Assignment: create+build SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001', payload: {} })).toBe('SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001');
+  });
+  it('returns null when nothing names an SD', () => {
+    expect(extractSdFromAssignment({ subject: 'no key here', payload: {} })).toBeNull();
+  });
+});
+
+// Handler-based supabase stub. Each table maps to a function returning the
+// terminal value; the chainable builder records filters and forwards them.
+function makeStub(cfg) {
+  const claimResults = cfg.claimResults || {};
+  function builder(table) {
+    const state = { table, op: 'select', filters: {}, payload: null };
+    const chain = {
+      select() { return chain; },
+      insert(p) { state.op = 'insert'; state.payload = p; return chain; },
+      update(p) { state.op = 'update'; state.payload = p; return chain; },
+      eq(k, v) { state.filters[k] = v; return chain; },
+      gte() { return chain; },
+      is() { return chain; },
+      order() { return chain; },
+      limit() { return resolveList(); },
+      maybeSingle() { return resolveSingle(); },
+      single() { return resolveSingle(); },
+      then(res, rej) { return Promise.resolve(resolveDefault()).then(res, rej); },
+    };
+    function resolveSingle() {
+      if (table === 'claude_sessions') return Promise.resolve({ data: cfg.session || null, error: null });
+      if (table === 'sd_baseline_items') return Promise.resolve({ data: { track: 'STANDALONE' }, error: null });
+      if (table === 'session_coordination' && state.op === 'insert') return Promise.resolve({ data: { id: 'rollcall-new' }, error: null });
+      return Promise.resolve({ data: null, error: null });
+    }
+    function resolveList() {
+      if (table === 'session_coordination') {
+        // recent roll_calls dedup query (sender_session filter) vs messages query (target_session)
+        if ('sender_session' in state.filters) return Promise.resolve({ data: cfg.recentRollCalls || [], error: null });
+        return Promise.resolve({ data: cfg.messages || [], error: null });
+      }
+      if (table === 'v_sd_next_candidates') return Promise.resolve({ data: cfg.candidates || [], error: null });
+      return Promise.resolve({ data: [], error: null });
+    }
+    function resolveDefault() {
+      // messages query terminates on .order() (await) — return messages
+      if (table === 'session_coordination' && state.op === 'select' && 'target_session' in state.filters) {
+        return { data: cfg.messages || [], error: null };
+      }
+      if (table === 'session_coordination' && state.op === 'update') return { data: null, error: null };
+      return { data: null, error: null };
+    }
+    return chain;
+  }
+  return {
+    from: vi.fn(builder),
+    rpc: vi.fn((name, args) => {
+      if (name === 'claim_sd') {
+        const r = claimResults[args.p_sd_id];
+        if (r === undefined || r === true) return Promise.resolve({ data: { success: true }, error: null });
+        return Promise.resolve({ data: { success: false, error: 'claim_rejected' }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    }),
+  };
+}
+
+const noCoord = { getCoordinator: async () => null };
+
+describe('FR-2: runCheckin deterministic resolution', () => {
+  it('resume when the session already claims an SD', async () => {
+    const sb = makeStub({ session: { metadata: { callsign: 'Alpha' }, sd_key: 'SD-MINE-001' } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume');
+    expect(r.sd).toBe('SD-MINE-001');
+    expect(r.callsign).toBe('Alpha');
+  });
+
+  it('claims a pending WORK_ASSIGNMENT via claim_sd', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null },
+      messages: [{ id: 'm1', message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-ASSIGNED-001' } }],
+      claimResults: { 'SD-ASSIGNED-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('claimed_assignment');
+    expect(r.sd).toBe('SD-ASSIGNED-001');
+  });
+
+  it('self-claims the top sd:next candidate when no assignment', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null },
+      messages: [],
+      candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }, { sd_id: 'SD-NEXT-002', track: 'B' }],
+      claimResults: { 'SD-TOP-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-TOP-001');
+  });
+
+  it('falls through to the next candidate if the top is already claimed', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null },
+      messages: [],
+      candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }, { sd_id: 'SD-NEXT-002', track: 'B' }],
+      claimResults: { 'SD-TOP-001': false, 'SD-NEXT-002': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-NEXT-002');
+  });
+
+  it('idles with a recommended wakeup when nothing is claimable (never asks human)', async () => {
+    const sb = makeStub({ session: { metadata: {}, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+    expect(r.recommended_wakeup_seconds).toBe(DEFAULT_IDLE_WAKEUP_SECONDS);
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001 — make worker-PULL first-class and deterministic

**Problem (RCA-confirmed, PAT-FLEET-CHECKIN-001):** coordinator-PUSH (SET_IDENTITY/WORK_ASSIGNMENT) is automated, but worker-PULL was neither first-class nor deterministic. A worker told to "check in" had no entry point and burned ~12 tool calls reverse-engineering the mechanism (env not loaded in subprocess, fleet column-name guessing, multi-step coordinator discovery, two-way reply gated OFF, no check-in semantic).

### Deliverables
- **FR-1** — enable `COORDINATOR_TWOWAY_V2=on` in `.claude/settings.json` so `worker-signal.cjs request` completes a request→await→reply round-trip (no more exit 3). Proven by `lib/coordinator/worker-signal.request.test.js`.
- **FR-2** — `scripts/worker-checkin.cjs` + `/checkin` skill (`.claude/commands/checkin.md`): one idempotent handshake that ALWAYS resolves to a single action — resume / claimed_assignment (via `claim_sd` RPC) / self_claimed (top of `v_sd_next_candidates`) / idle (recommend ScheduleWakeup). Fail-open; never reads stdin / never asks the human. Wired as `npm run checkin` for WIRE_CHECK_GATE.
- **FR-3** — `lib/fleet/worker-status.cjs`: canonical fleet column contract (`sender_session`/`target_session`/`heartbeat_at`) + self-env-loading supabase client, killing the env + schema-folklore tax.

### Design notes
- No new tables/enums/migrations — availability rides on the existing `INFO` message type via `payload.kind=roll_call` (NOT `signal_type`, so the friction router/intent sweep never scoop it).
- Builds on already-shipped-but-default-OFF two-way machinery (SD-LEO-INFRA-COMPLETE-TWO-WAY-001) — this SD is enablement + a discoverable verb, not a rebuild.

### Testing
3 test files, **19/19 unit tests pass**; live end-to-end verified (`action=resume` for the claiming session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)