### PR TITLE
fix(SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001): guard coordinator dispatch targets before session_coordination insert

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -1,0 +1,131 @@
+/**
+ * Coordinator dispatch guard — SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001
+ *
+ * Centralizes coordinator-side session_coordination inserts behind one validated
+ * path. REFUSES to insert a row unless target_session is either:
+ *   - a documented sentinel (broadcast / broadcast-coordinator), OR
+ *   - a full UUID that matches a LIVE row in claude_sessions.
+ *
+ * RCA (2026-06-07): a coordinator dispatched WORK_ASSIGNMENT rows addressed to
+ * truncated 8-char session_id PREFIXES. Workers poll WHERE target_session=<full-uuid>,
+ * so those rows never matched and dead-lettered — two workers polled fruitlessly for
+ * 24+ min. This guard fails CLOSED on a bad target so the coordinator sees the error
+ * instead of silently dead-lettering.
+ *
+ * CommonJS so both .cjs callers (require) and .mjs callers (createRequire) can consume it.
+ *
+ * @module lib/coordinator/dispatch
+ */
+
+// Single canonical full-UUID matcher (8-4-4-4-12). Do NOT hand-roll a second copy —
+// the prefix-only isUuidLike in stale-session-sweep.cjs is for the cleanup path.
+const FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Documented non-UUID targets that are intentionally allowed. broadcast =
+// coordinator→all; broadcast-coordinator = worker→coordinator. Sentinels
+// short-circuit the live-session lookup (they are not a single session row).
+const SENTINEL_TARGETS = Object.freeze(['broadcast', 'broadcast-coordinator']);
+const SENTINEL_SET = new Set(SENTINEL_TARGETS);
+
+/** Pure: true iff s is a full 8-4-4-4-12 hex UUID. */
+function isFullUuid(s) {
+  return typeof s === 'string' && FULL_UUID_RE.test(s);
+}
+
+/** Pure: true iff target is a documented sentinel. */
+function isSentinelTarget(s) {
+  return SENTINEL_SET.has(s);
+}
+
+/**
+ * Validate a dispatch target. Resolves when the target is dispatchable; throws a
+ * tagged Error (code on err.code) otherwise. Validation order:
+ *   sentinel allowlist (short-circuit) -> full-UUID shape -> live claude_sessions row.
+ *
+ * @param {object} supabase - Supabase client (only queried for non-sentinel UUIDs)
+ * @param {string} target - target_session value
+ * @param {object} [logger=console]
+ * @returns {Promise<{ok:true, kind:'sentinel'|'live_session'}>}
+ */
+async function assertValidTarget(supabase, target, logger = console) {
+  if (isSentinelTarget(target)) {
+    return { ok: true, kind: 'sentinel' };
+  }
+  if (!isFullUuid(target)) {
+    const msg = `[dispatch] REFUSED insert: target_session ${JSON.stringify(target)} is not a full UUID `
+      + `(expected 8-4-4-4-12 hex, e.g. 0f8d45d8-9531-4ab8-a1b9-6961c405e1ec) and not a sentinel `
+      + `(${SENTINEL_TARGETS.join(', ')}). Truncated/prefix targets dead-letter — workers poll on the full UUID.`;
+    logger && logger.error && logger.error(msg);
+    const e = new Error(msg);
+    e.code = 'DISPATCH_TARGET_INVALID';
+    throw e;
+  }
+  // Well-formed UUID — confirm it names a live session (FR-3, the dominant new check).
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id')
+    .eq('session_id', target)
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    const e = new Error(`[dispatch] live-session lookup failed for ${target}: ${error.message}`);
+    e.code = 'DISPATCH_LOOKUP_FAILED';
+    throw e; // fail closed — do not insert on an unverifiable target
+  }
+  if (!data) {
+    const msg = `[dispatch] REFUSED insert: target_session ${target} matches no claude_sessions row `
+      + `(unknown/dead target) — would dead-letter. Re-target to a live worker UUID or a sentinel.`;
+    logger && logger.error && logger.error(msg);
+    const e = new Error(msg);
+    e.code = 'DISPATCH_TARGET_UNKNOWN';
+    throw e;
+  }
+  return { ok: true, kind: 'live_session' };
+}
+
+/**
+ * Validated session_coordination insert. The single code path coordinator-side
+ * inserts route through. Validates row.target_session, then performs the insert.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} row - session_coordination row (must include target_session)
+ * @param {object} [opts]
+ * @param {object} [opts.logger=console]
+ * @param {string} [opts.select] - optional columns to .select() after insert (e.g. 'id')
+ * @param {boolean} [opts.single] - if true with select, append .single()
+ * @returns {Promise<{data:any,error:any}>} the Supabase insert result
+ * @throws {Error} with err.code DISPATCH_TARGET_INVALID|DISPATCH_TARGET_UNKNOWN|DISPATCH_LOOKUP_FAILED on refusal
+ */
+async function insertCoordinationRow(supabase, row, opts = {}) {
+  const { logger = console, select = null, single = false } = opts;
+  if (!row || typeof row !== 'object') {
+    const e = new Error('[dispatch] row must be an object');
+    e.code = 'DISPATCH_BAD_ROW';
+    throw e;
+  }
+  await assertValidTarget(supabase, row.target_session, logger);
+  let q = supabase.from('session_coordination').insert(row);
+  if (select) {
+    q = q.select(select);
+    if (single) q = q.single();
+  }
+  return await q;
+}
+
+/**
+ * Thin convenience wrapper for coordinator→worker dispatch. Same guarantees as
+ * insertCoordinationRow; exists so call sites read intentionally.
+ */
+async function dispatchToWorker(supabase, row, opts = {}) {
+  return insertCoordinationRow(supabase, row, opts);
+}
+
+module.exports = {
+  FULL_UUID_RE,
+  SENTINEL_TARGETS,
+  isFullUuid,
+  isSentinelTarget,
+  assertValidTarget,
+  insertCoordinationRow,
+  dispatchToWorker,
+};

--- a/lib/coordinator/dispatch.test.js
+++ b/lib/coordinator/dispatch.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the coordinator dispatch guard.
+ * SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001 (FR-6).
+ *
+ * Network-free: an injected fake supabase records insert calls and returns a
+ * configurable claude_sessions lookup result.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  isFullUuid,
+  isSentinelTarget,
+  SENTINEL_TARGETS,
+  insertCoordinationRow,
+} = require('./dispatch.cjs');
+
+const LIVE_UUID = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const UNKNOWN_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+// Fake supabase: claude_sessions lookup returns `sessionRow` (or null); every
+// session_coordination insert is recorded in `inserts`.
+function makeFakeSupabase({ sessionRow = null, lookupError = null } = {}) {
+  const inserts = [];
+  const sb = {
+    from(table) {
+      if (table === 'claude_sessions') {
+        const b = {
+          select() { return b; },
+          eq() { return b; },
+          limit() { return b; },
+          maybeSingle() { return Promise.resolve({ data: sessionRow, error: lookupError }); },
+        };
+        return b;
+      }
+      if (table === 'session_coordination') {
+        return {
+          insert(row) {
+            inserts.push(row);
+            const res = { data: [{ id: 'row-1' }], error: null };
+            const thenable = {
+              select() { return thenable; },
+              single() { return Promise.resolve({ data: { id: 'row-1' }, error: null }); },
+              then(resolve) { return Promise.resolve(res).then(resolve); },
+            };
+            return thenable;
+          },
+        };
+      }
+      throw new Error('unexpected table ' + table);
+    },
+  };
+  return { sb, inserts };
+}
+
+const silent = { error() {} };
+
+describe('dispatch guard — pure helpers', () => {
+  it('isFullUuid accepts a full 8-4-4-4-12 UUID', () => {
+    expect(isFullUuid(LIVE_UUID)).toBe(true);
+  });
+  it('isFullUuid rejects an 8-char prefix and a partial UUID', () => {
+    expect(isFullUuid('0f8d45d8')).toBe(false);
+    expect(isFullUuid('0f8d45d8-9531-4ab8')).toBe(false);
+    expect(isFullUuid(null)).toBe(false);
+  });
+  it('sentinels are exactly broadcast / broadcast-coordinator', () => {
+    expect(SENTINEL_TARGETS).toContain('broadcast');
+    expect(SENTINEL_TARGETS).toContain('broadcast-coordinator');
+    expect(isSentinelTarget('broadcast')).toBe(true);
+    expect(isSentinelTarget('not-a-sentinel')).toBe(false);
+  });
+});
+
+describe('insertCoordinationRow — accept/reject matrix (FR-2/3/4)', () => {
+  it('ACCEPTS a full UUID matching a live claude_sessions row', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID } });
+    await insertCoordinationRow(sb, { target_session: LIVE_UUID, message_type: 'WORK_ASSIGNMENT' }, { logger: silent });
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].target_session).toBe(LIVE_UUID);
+  });
+
+  it('REFUSES an 8-char prefix target — no insert (FR-2)', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID } });
+    await expect(
+      insertCoordinationRow(sb, { target_session: '0f8d45d8', message_type: 'WORK_ASSIGNMENT' }, { logger: silent })
+    ).rejects.toMatchObject({ code: 'DISPATCH_TARGET_INVALID' });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('REFUSES a partial (8-4-4) UUID that the old prefix regex would pass — no insert', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID } });
+    await expect(
+      insertCoordinationRow(sb, { target_session: '0f8d45d8-9531-4ab8', message_type: 'COACHING' }, { logger: silent })
+    ).rejects.toMatchObject({ code: 'DISPATCH_TARGET_INVALID' });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('REFUSES a well-formed but unknown UUID (no live session) — no insert (FR-3)', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: null });
+    await expect(
+      insertCoordinationRow(sb, { target_session: UNKNOWN_UUID, message_type: 'WORK_ASSIGNMENT' }, { logger: silent })
+    ).rejects.toMatchObject({ code: 'DISPATCH_TARGET_UNKNOWN' });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('ACCEPTS sentinel broadcast WITHOUT a live-session lookup (FR-4)', async () => {
+    // sessionRow=null would reject any UUID; sentinel must short-circuit and still insert.
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: null });
+    await insertCoordinationRow(sb, { target_session: 'broadcast', message_type: 'COACHING' }, { logger: silent });
+    expect(inserts).toHaveLength(1);
+  });
+
+  it('ACCEPTS sentinel broadcast-coordinator WITHOUT a live-session lookup (FR-4)', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: null });
+    await insertCoordinationRow(sb, { target_session: 'broadcast-coordinator', message_type: 'INFO' }, { logger: silent });
+    expect(inserts).toHaveLength(1);
+  });
+
+  it('fails CLOSED when the live-session lookup errors — no insert', async () => {
+    const { sb, inserts } = makeFakeSupabase({ lookupError: { message: 'db down' } });
+    await expect(
+      insertCoordinationRow(sb, { target_session: LIVE_UUID, message_type: 'WORK_ASSIGNMENT' }, { logger: silent })
+    ).rejects.toMatchObject({ code: 'DISPATCH_LOOKUP_FAILED' });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('supports select/single for callers needing the inserted id', async () => {
+    const { sb } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID } });
+    const res = await insertCoordinationRow(
+      sb, { target_session: LIVE_UUID, message_type: 'INFO' }, { logger: silent, select: 'id', single: true }
+    );
+    expect(res.data.id).toBe('row-1');
+  });
+});

--- a/scripts/coordinator-comms-check.mjs
+++ b/scripts/coordinator-comms-check.mjs
@@ -16,6 +16,10 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'module';
+// SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001: route coordinator dispatch through
+// the validated guard (refuses non-full-UUID / dead targets before insert).
+const { insertCoordinationRow } = createRequire(import.meta.url)('../lib/coordinator/dispatch.cjs');
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -58,7 +62,7 @@ const ACK_RE = /comms.?check ack|read you/i;
       console.log('  ⚠ NO-ACK   ' + String(wid).slice(0, 8) + '  (' + cs + ')  ping ' + age + 'm unacked' + (lastPing.read_at ? ' (read, no reply)' : ' (never read → worker not polling inbox)') + ' — re-send + fix prompt');
     }
     const body = '📡 COMMS CHECK (radio check) from coordinator ' + String(me).slice(0, 8) + '. Confirm the two-way link: reply ONCE with  /signal feedback "comms-check ack — read you"  then continue your work. One-line ack only.';
-    await db.from('session_coordination').insert({ sender_session: me, target_session: wid, message_type: 'COACHING', subject: 'COMMS CHECK', payload: { body, kind: 'comms_check', sent_at: new Date().toISOString() }, created_at: new Date().toISOString() });
+    await insertCoordinationRow(db, { sender_session: me, target_session: wid, message_type: 'COACHING', subject: 'COMMS CHECK', payload: { body, kind: 'comms_check', sent_at: new Date().toISOString() }, created_at: new Date().toISOString() });
     if (!lastPing) console.log('  📨 SENT     ' + String(wid).slice(0, 8) + '  (' + cs + ')  comms-check ping — awaiting ack');
   }
   console.log('[ACTION] ✓=link good · ⏳=wait a tick · ⚠=worker not reading inbox (add an inbox-poll + ack step to its loop prompt).');

--- a/scripts/coordinator-revive.cjs
+++ b/scripts/coordinator-revive.cjs
@@ -16,6 +16,10 @@
 
 require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
+// SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001: validated dispatch guard
+// (the SPAWN_REQUEST broadcast below uses the 'broadcast' sentinel, which the
+// guard short-circuits — exercising the sentinel-allowlist path).
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 
 const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
 
@@ -70,7 +74,7 @@ async function reviveOne(supabase, callsign, requestedBySessionId) {
 
   // Broadcast SPAWN_REQUEST on session_coordination (best-effort — broadcast failure
   // does NOT undo the row insert; the row is the canonical contract surface).
-  await supabase.from('session_coordination').insert({
+  await insertCoordinationRow(supabase, {
     target_session: 'broadcast',
     message_type: 'SPAWN_REQUEST',
     subject: `Spawn request: ${callsign}`,
@@ -78,6 +82,8 @@ async function reviveOne(supabase, callsign, requestedBySessionId) {
     payload: { callsign, request_id: data.id, expires_at: data.expires_at }
   }).then(({ error: bcErr }) => {
     if (bcErr) console.warn(`  [warn] broadcast emit failed: ${bcErr.message} (row still inserted)`);
+  }).catch((gErr) => {
+    console.warn(`  [warn] broadcast guard refused: ${gErr.message} (worker_spawn_requests row still inserted)`);
   });
 
   return { inserted: true, alreadyPending: false, error: null, row: data };

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -9,6 +9,9 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
+import { createRequire } from 'module';
+// SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001: validated dispatch guard.
+const { insertCoordinationRow } = createRequire(import.meta.url)('../lib/coordinator/dispatch.cjs');
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -56,7 +59,7 @@ const RE = /COORDINATOR-FEEDBACK|COORD-REVIEW/i;
   let solicited = 0;
   const body = 'COORDINATOR-FEEDBACK REQUEST (recurring review of the COORDINATOR, triggered by ' + delta + ' SDs shipped since the last review): candid critique of how the coordinator is running the fleet — (1) what worked (routing/sourcing/RCA/conflict-resolution/keeping you fed), (2) friction caused BY the coordinator (slow/missing replies, mis-routing, bad SD sourcing, unclear guidance, missed signals), (3) ONE concrete thing to do differently. Be blunt. Reply: /signal feedback, prefix "COORDINATOR-FEEDBACK".';
   for (const w of workers) {
-    await db.from('session_coordination').insert({ target_session: w, sender_session: me, subject: 'Coordinator review (every ' + REVIEW_EVERY + ' SDs) — your candid feedback', message_type: 'COACHING', payload: { kind: 'coordinator_reply', body } });
+    await insertCoordinationRow(db, { target_session: w, sender_session: me, subject: 'Coordinator review (every ' + REVIEW_EVERY + ' SDs) — your candid feedback', message_type: 'COACHING', payload: { kind: 'coordinator_reply', body } });
     solicited++;
   }
   try { writeFileSync(STATE, JSON.stringify({ lastReviewCompletedCount: completedNow, lastReviewAt: t })); } catch {}


### PR DESCRIPTION
## SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001

**RCA (2026-06-07):** a coordinator dispatched `WORK_ASSIGNMENT` rows whose `target_session` was an **8-char session_id prefix**. Workers poll `WHERE target_session=<full-uuid>`, so those rows never matched and **dead-lettered** — two workers polled fruitlessly for 24+ min.

**Fix:** new `lib/coordinator/dispatch.cjs` — a single validated insert path (`insertCoordinationRow`) that **refuses** a `session_coordination` row unless `target_session` is:
- a documented **sentinel** (`broadcast` / `broadcast-coordinator`) — short-circuits the lookup, or
- a **full 8-4-4-4-12 UUID** matching a **live `claude_sessions` row**.

Fails **closed** (surfaces the error to the coordinator) instead of silently dead-lettering. Reuses one canonical full-UUID regex (no second hand-rolled copy).

**Wrapped (interactive coordinator dispatch — where a constructed target can be truncated):** `coordinator-comms-check.mjs`, `coordinator-self-review.mjs`, `coordinator-revive.cjs`.

**Intentionally NOT wrapped (documented):** the `stale-session-sweep` `WORK_ASSIGNMENT`/`CLAIM_RELEASED` inserts use DB-sourced full-UUID targets (the truncation class can't occur), and guarding `CLAIM_RELEASED`-to-evicted-session would risk false refusals. `coordination-events.cjs` broadcast-coordinator alert left as-is (sentinel).

**Tests:** `lib/coordinator/dispatch.test.js` — 11 cases (full-UUID+live accept; 8-char & partial-UUID reject; unknown-UUID reject; both sentinels accept *without* lookup; fail-closed on lookup error; select/single). **11/11 pass; full `lib/coordinator` suite 93/93, no regressions.**

**Gates:** LEAD-TO-PLAN 93 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 98. VALIDATION CONDITIONAL_PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)