### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001): coordinator startup onboarding ritual + six-loop verifier

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -161,23 +161,35 @@ node scripts/fleet-dashboard.cjs all
 ```
 Display the output.
 
-**Step 4: Set up automated cron loops using CronCreate**
+**Step 4: Coordinator onboarding check (surface role + verify the six-loop set)**
+```bash
+node scripts/coordinator-startup-check.mjs
+```
+This (a) surfaces the durable coordinator role context and prints a roles/responsibilities summary (MANAGER-not-IC, keep-workers-busy=KPI, recurring 3-source audit, teardown discipline), and (b) emits the canonical set of **six** standard cron loops, each with a ready CronCreate spec. It is fail-open (warns, exits 0). `CronList`/`CronCreate` are HARNESS tools (not Node-callable), so the helper EMITS the spec — YOU compare it against `CronList` and arm only the loops not already present. To get an explicit armed|MISSING verdict, re-run with the prompts already in CronList: `node scripts/coordinator-startup-check.mjs --armed "<prompt1>,<prompt2>,…"`.
 
-Create three recurring cron jobs:
+**Step 5: Set up automated cron loops using CronCreate**
+
+Arm all **six** standard loops (idempotent — skip any already in `CronList`):
 1. **Sweep every 5 minutes**: `cron: "*/5 * * * *"`, `prompt: "node scripts/stale-session-sweep.cjs"`, `recurring: true`
 2. **Dashboard every 5 minutes (offset by 2 min)**: `cron: "2,7,12,17,22,27,32,37,42,47,52,57 * * * *"`, `prompt: "node scripts/fleet-dashboard.cjs all"`, `recurring: true`
 3. **Identity refresh every 5 minutes (offset by 4 min)**: `cron: "4,9,14,19,24,29,34,39,44,49,54,59 * * * *"`, `prompt: "node scripts/assign-fleet-identities.cjs"`, `recurring: true`
+4. **Inbox every 2 minutes**: `cron: "*/2 * * * *"`, `prompt: "node scripts/fleet-dashboard.cjs inbox"`, `recurring: true` — surfaces unread worker `/signal` traffic (also re-asserts the coordinator pointer).
+5. **Coordinator 3-source audit every 15 minutes**: `cron: "*/15 * * * *"`, `prompt: "node scripts/coordinator-audit.mjs"`, `recurring: true` — SD queue / harness backlog / inbox, with the source-vs-wake decision.
+6. **Executive email summary every 30 minutes (default-on)**: `cron: "*/30 * * * *"`, `prompt: "node scripts/coordinator-email-summary.mjs"`, `recurring: true` — operator is usually away; this is the fleet-health gauge + question escalation.
 
 The identity refresh loop detects new workers that joined since the last assignment and gives them a color/callsign. Existing assignments are preserved (the script reads current metadata and only assigns to workers without an identity).
 
-**Step 5: Confirm setup**
+**Step 6: Confirm setup**
 
 Display:
 ```
-Coordinator initialized.
+Coordinator initialized (role context surfaced; six standard loops armed).
   Sweep loop: every 5 minutes (auto-releases dead claims, resolves conflicts, QA fixes)
   Dashboard loop: every 5 minutes (offset 2min from sweep)
   Identity loop: every 5 minutes (offset 4min — assigns colors/callsigns to new workers)
+  Inbox loop: every 2 minutes (surfaces worker /signal traffic; re-asserts the coordinator pointer)
+  Audit loop: every 15 minutes (3-source audit: SD queue / harness backlog / inbox)
+  Executive email: every 30 minutes (default-on fleet-health gauge + question escalation)
   All loops auto-expire after 3 days or when this session exits.
 
   Fleet is now running on autopilot. You will see sweep and dashboard output automatically.

--- a/package.json
+++ b/package.json
@@ -295,6 +295,7 @@
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
+    "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -1,0 +1,149 @@
+// coordinator-startup-check.mjs — coordinator startup onboarding ritual.
+//   SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001
+//
+// On `/coordinator start` this helper:
+//   (FR-1) surfaces the DURABLE coordinator role context + prints a roles/responsibilities summary,
+//   (FR-2) reports armed|MISSING status for ALL SIX standard cron loops and emits the exact
+//          CronCreate spec for any missing loop, and
+//   (FR-4) is FAIL-OPEN — a missing role-context doc or any hiccup warns but never blocks startup.
+//
+// DESIGN CONSTRAINT: CronList/CronCreate are HARNESS tools, NOT Node-callable. This helper therefore
+// EMITS the canonical six-loop spec; the agent running /coordinator start compares it against CronList
+// and arms only the missing loops (idempotent). To compute armed|MISSING the agent passes the currently
+// -armed cron script basenames via --armed "a.cjs,b.mjs" (or COORD_ARMED_CRONS env, comma-separated).
+// With no armed-set provided, every loop is reported as "unverified" and its CronCreate spec is emitted.
+//
+// Exit code is ALWAYS 0 (fail-open). Model: peer of scripts/coordinator-audit.mjs.
+
+import 'dotenv/config';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+// ── Durable role context source (FR-1). This doc is the memory-independent source of truth. ──
+export const ROLE_CONTEXT_DOC = 'docs/protocol/fleet-coordinator-and-worker-behavior.md';
+
+// Concise, always-rendered responsibilities summary (surfaced even if the source doc is unreadable).
+export const RESPONSIBILITIES = [
+  'MANAGER, not IC — delegate mechanical/parallelizable work (SD creation, audits, investigations, cleanups) to sub-agents or the fleet queue; reserve your cycles for judgment (prioritization, sensitive RCA, the execute step of destructive actions). Verify sub-agent output.',
+  'KEEP WORKERS BUSY is the KPI — continuously source claimable work; idle workers + available work is a problem to solve. The coordinator is EITHER delegating/sourcing OR torn down, never idling in between.',
+  'RECURRING 3-SOURCE AUDIT — check SD queue, harness backlog (feedback category=harness_backlog), and inbox; source backlog into DRAFT SDs only when the queue would starve idle workers.',
+  'BACKGROUND MONITORING during operator conversations — run the cron ticks but surface only important events (stuck worker, empty-queue+idle, claim/worktree conflict, a worker question, a completion).',
+  'EXECUTIVE EMAIL is default-on — the operator is usually away; the email is the single gauge (active workers vs min(workable SDs, target)) + question escalation.',
+  'TEARDOWN DISCIPLINE — when no claimable AND no sourceable work AND zero workers (sustained): CronDelete ALL loops first, then clear the coordinator pointer + final email. Do not idle loops past a finished campaign.',
+  'You CANNOT start a worker\'s execution — only /loop or a human paste in the worker window can. To restore a thinned fleet, hand the operator the wake-up prompt.',
+];
+
+// ── Canonical SIX standard cron loops (FR-2). The three existing intervals match coordinator.md Step 4. ──
+export const STANDARD_LOOPS = [
+  { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
+    prompt: 'node scripts/stale-session-sweep.cjs' },
+  { key: 'dashboard',   label: 'Fleet dashboard',      script: 'fleet-dashboard.cjs',       cron: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *',
+    prompt: 'node scripts/fleet-dashboard.cjs all' },
+  { key: 'identity',    label: 'Fleet identity refresh', script: 'assign-fleet-identities.cjs', cron: '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',
+    prompt: 'node scripts/assign-fleet-identities.cjs' },
+  { key: 'inbox',       label: 'Coordinator inbox',    script: 'fleet-dashboard.cjs',       cron: '*/2 * * * *',
+    prompt: 'node scripts/fleet-dashboard.cjs inbox' },
+  { key: 'audit',       label: 'Coordinator 3-source audit', script: 'coordinator-audit.mjs', cron: '*/15 * * * *',
+    prompt: 'node scripts/coordinator-audit.mjs' },
+  { key: 'email',       label: 'Executive email summary (default-on)', script: 'coordinator-email-summary.mjs', cron: '*/30 * * * *',
+    prompt: 'node scripts/coordinator-email-summary.mjs' },
+];
+
+// Parse the armed-cron basenames the agent passes from its CronList output.
+// Sources (first non-empty wins): --armed "a.cjs,b.mjs" arg, then COORD_ARMED_CRONS env.
+export function parseArmedSet(argv = [], env = {}) {
+  let raw = '';
+  const idx = argv.indexOf('--armed');
+  if (idx !== -1 && argv[idx + 1]) raw = argv[idx + 1];
+  else {
+    const eq = argv.find((a) => a.startsWith('--armed='));
+    if (eq) raw = eq.slice('--armed='.length);
+    else if (env.COORD_ARMED_CRONS) raw = env.COORD_ARMED_CRONS;
+  }
+  const provided = raw.trim().length > 0;
+  const set = new Set(
+    raw.split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  return { provided, set };
+}
+
+// A loop is "armed" when an armed-set was provided AND it contains the loop's prompt (script + args)
+// or the loop's script basename. inbox + dashboard share fleet-dashboard.cjs, so we match on the full
+// prompt first (so `fleet-dashboard.cjs all` ≠ `fleet-dashboard.cjs inbox`), falling back to basename.
+export function loopStatus(loop, armed) {
+  if (!armed.provided) return 'unverified';
+  if (armed.set.has(loop.prompt)) return 'armed';
+  if (armed.set.has(loop.script) && loop.script !== 'fleet-dashboard.cjs') return 'armed';
+  return 'MISSING';
+}
+
+// Render the responsibilities summary (FR-1). Fail-open: never throws.
+export function renderResponsibilities(repoRoot = REPO_ROOT) {
+  const lines = [];
+  lines.push('═══ COORDINATOR ROLE — responsibilities (MANAGER, not IC) ═══');
+  RESPONSIBILITIES.forEach((r, i) => lines.push(`  ${i + 1}. ${r}`));
+  let docOk = false;
+  try {
+    const doc = readFileSync(resolve(repoRoot, ROLE_CONTEXT_DOC), 'utf8');
+    docOk = doc.includes('Coordinator responsibilities');
+  } catch {
+    docOk = false;
+  }
+  if (docOk) {
+    lines.push(`  (durable role context: ${ROLE_CONTEXT_DOC})`);
+  } else {
+    lines.push(`  ⚠️  role-context doc not found/readable at ${ROLE_CONTEXT_DOC} — summary above is the fallback (fail-open).`);
+  }
+  return lines.join('\n');
+}
+
+// Render the six-loop status + CronCreate specs for missing/unverified loops (FR-2).
+export function renderLoops(armed) {
+  const lines = [];
+  lines.push('═══ STANDARD CRON LOOPS (six) — verify all armed ═══');
+  if (!armed.provided) {
+    lines.push('  (no --armed set supplied — run CronList and re-invoke with --armed "<script1>,<script2>,…" to get armed|MISSING; emitting full spec below)');
+  }
+  const toArm = [];
+  for (const loop of STANDARD_LOOPS) {
+    const status = loopStatus(loop, armed);
+    const badge = status === 'armed' ? '✅ armed' : status === 'MISSING' ? '❌ MISSING' : '… unverified';
+    lines.push(`  [${badge}] ${loop.key.padEnd(10)} ${loop.label}`);
+    lines.push(`              cron: ${loop.cron}   prompt: ${loop.prompt}`);
+    if (status !== 'armed') toArm.push(loop);
+  }
+  lines.push('');
+  if (toArm.length === 0 && armed.provided) {
+    lines.push('  ✅ All six standard loops armed. Nothing to arm.');
+  } else {
+    lines.push(`  → Arm the ${armed.provided ? toArm.length + ' missing' : 'not-yet-armed'} loop(s) via CronCreate (idempotent — skip any already in CronList):`);
+    for (const loop of toArm) {
+      lines.push(`     CronCreate({ cron: ${JSON.stringify(loop.cron)}, prompt: ${JSON.stringify(loop.prompt)}, recurring: true })`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
+  const armed = parseArmedSet(argv, env);
+  return [renderResponsibilities(repoRoot), '', renderLoops(armed)].join('\n');
+}
+
+// ── Main (fail-open: always exit 0) ──
+function main() {
+  try {
+    console.log('[COORD-STARTUP] ' + (process.env.CLAUDE_SESSION_ID ? 'session=' + process.env.CLAUDE_SESSION_ID : 'session=unknown'));
+    console.log(buildReport(process.argv.slice(2), process.env));
+  } catch (err) {
+    console.warn('⚠️  coordinator-startup-check hiccup (non-blocking, fail-open): ' + (err && err.message ? err.message : String(err)));
+  }
+  process.exit(0);
+}
+
+// Only run main when invoked directly (not when imported by tests).
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invokedDirectly) main();

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -1,0 +1,104 @@
+// Tests for scripts/coordinator-startup-check.mjs
+// SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  STANDARD_LOOPS,
+  RESPONSIBILITIES,
+  parseArmedSet,
+  loopStatus,
+  renderResponsibilities,
+  renderLoops,
+  buildReport,
+  ROLE_CONTEXT_DOC,
+} from '../../scripts/coordinator-startup-check.mjs';
+
+test('STANDARD_LOOPS has exactly six standard loops with the expected keys', () => {
+  assert.equal(STANDARD_LOOPS.length, 6);
+  const keys = STANDARD_LOOPS.map((l) => l.key);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'email']);
+});
+
+test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
+  for (const loop of STANDARD_LOOPS) {
+    for (const field of ['label', 'script', 'cron', 'prompt']) {
+      assert.ok(typeof loop[field] === 'string' && loop[field].trim().length > 0,
+        `loop ${loop.key} field ${field} must be a non-empty string`);
+    }
+  }
+});
+
+test('the two new loops (audit, email) and the inbox loop are present in the standard set', () => {
+  const byKey = Object.fromEntries(STANDARD_LOOPS.map((l) => [l.key, l]));
+  assert.equal(byKey.audit.script, 'coordinator-audit.mjs');
+  assert.equal(byKey.email.script, 'coordinator-email-summary.mjs');
+  assert.match(byKey.inbox.prompt, /fleet-dashboard\.cjs inbox/);
+});
+
+test('responsibilities summary renders the MANAGER-not-IC role context (FR-1)', () => {
+  assert.ok(RESPONSIBILITIES.length >= 5);
+  const out = renderResponsibilities();
+  assert.match(out, /MANAGER, not IC/);
+  assert.match(out, /KEEP WORKERS BUSY/);
+});
+
+test('fail-open: a missing role-context doc warns but does not throw (FR-4)', () => {
+  let out;
+  assert.doesNotThrow(() => { out = renderResponsibilities('/no/such/repo/root'); });
+  // Still renders the fallback summary text...
+  assert.match(out, /MANAGER, not IC/);
+  // ...and flags the missing source doc.
+  assert.match(out, new RegExp('role-context doc not found'));
+  assert.match(out, new RegExp(ROLE_CONTEXT_DOC.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('parseArmedSet reads --armed arg, --armed= form, and COORD_ARMED_CRONS env', () => {
+  assert.equal(parseArmedSet([], {}).provided, false);
+  const a = parseArmedSet(['--armed', 'a.cjs, b.mjs'], {});
+  assert.equal(a.provided, true);
+  assert.ok(a.set.has('a.cjs') && a.set.has('b.mjs'));
+  const b = parseArmedSet(['--armed=c.cjs'], {});
+  assert.ok(b.provided && b.set.has('c.cjs'));
+  const c = parseArmedSet([], { COORD_ARMED_CRONS: 'd.mjs' });
+  assert.ok(c.provided && c.set.has('d.mjs'));
+});
+
+test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboard (FR-2)', () => {
+  const byKey = Object.fromEntries(STANDARD_LOOPS.map((l) => [l.key, l]));
+  // No armed-set → unverified for all
+  const none = parseArmedSet([], {});
+  assert.equal(loopStatus(byKey.sweep, none), 'unverified');
+  // Armed by full prompt
+  const armed = parseArmedSet(['--armed', 'node scripts/coordinator-email-summary.mjs,node scripts/fleet-dashboard.cjs inbox'], {});
+  assert.equal(loopStatus(byKey.email, armed), 'armed');
+  assert.equal(loopStatus(byKey.inbox, armed), 'armed');
+  // dashboard (fleet-dashboard.cjs all) is NOT armed just because the inbox prompt is present
+  assert.equal(loopStatus(byKey.dashboard, armed), 'MISSING');
+  // basename match arms non-shared scripts
+  const armed2 = parseArmedSet(['--armed', 'stale-session-sweep.cjs'], {});
+  assert.equal(loopStatus(byKey.sweep, armed2), 'armed');
+});
+
+test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
+  const none = parseArmedSet([], {});
+  const out = renderLoops(none);
+  assert.match(out, /STANDARD CRON LOOPS \(six\)/);
+  // All six prompts emitted as CronCreate specs when nothing is armed
+  for (const loop of STANDARD_LOOPS) {
+    assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
+  }
+  assert.match(out, /CronCreate\(\{/);
+});
+
+test('renderLoops reports all-armed cleanly when every loop is armed', () => {
+  const allPrompts = STANDARD_LOOPS.map((l) => l.prompt).join(',');
+  const armed = parseArmedSet(['--armed', allPrompts], {});
+  const out = renderLoops(armed);
+  assert.match(out, /All six standard loops armed/);
+});
+
+test('buildReport combines responsibilities + loop sections', () => {
+  const report = buildReport([], {});
+  assert.match(report, /COORDINATOR ROLE/);
+  assert.match(report, /STANDARD CRON LOOPS/);
+});


### PR DESCRIPTION
## SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001 — Coordinator startup onboarding ritual

**Problem:** `/coordinator start` had no step to re-ground the coordinator in its role, and Step 4 armed only THREE cron loops (sweep/dashboard/identity). A 2026-06-07 RCA showed a coordinator dispatching to 8-char session-id PREFIXES (dead-lettered; two workers stalled 24+ min) and starting without the executive-email/audit/inbox loops, so operator visibility and dispatch-drift watching silently never ran.

**Change (additive, fail-open):**
- NEW `scripts/coordinator-startup-check.mjs` — surfaces the durable role context + MANAGER-not-IC responsibilities summary (FR-1); emits the canonical **six** standard cron loops (sweep, dashboard, identity, inbox, coordinator-audit, coordinator-email-summary) with armed|MISSING status + a CronCreate spec for each missing loop (FR-2). Fail-open: warns, exits 0 (FR-4).
- `.claude/commands/coordinator.md` — **EXTENDED** Step 0-5 in place: new Step 4 onboarding check, Step 5 arms all six loops, Step 6 banner (FR-3). No duplication.
- `tests/unit/coordinator-startup-check.test.mjs` — 10 node:test cases (all pass).
- `package.json` — wired `coordinator:startup-check` (WIRE_CHECK_GATE).

**Design note:** CronList/CronCreate are HARNESS tools (not Node-callable), so the helper EMITS the six-loop spec and accepts the currently-armed prompts via `--armed`; the agent arms only missing loops idempotently. inbox/dashboard share fleet-dashboard.cjs → armed-matching keys on the full prompt (`…all` vs `…inbox`).

Gates: LEAD-TO-PLAN 93 · PLAN-TO-EXEC 95 · EXEC-TO-PLAN 92 · PLAN-TO-LEAD 96. validation-agent PASS 95% (ba2ec238). retro quality 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)