### PR TITLE
feat(SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-A): /adam command + idempotent role register

### DIFF
--- a/.claude/commands/adam.md
+++ b/.claude/commands/adam.md
@@ -1,0 +1,48 @@
+<!-- reasoning_effort: medium -->
+
+---
+description: "Activate the Adam role: the Chairman-attached advisory/analysis session. Emits the canonical Adam role definition, registers/verifies the role=adam/non_fleet=true session tag, and prints the Adam→coordinator protocol. Per SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001."
+---
+
+# /adam — Activate the Adam advisory/analysis role
+
+`Adam` is a first-class LEO session role, parallel to the **coordinator** and the **worker** — but distinct from both. Run `/adam` at the start of an Adam session (and any time you need to re-assert the role).
+
+## Step 1 — Register/verify the role tag (idempotent)
+
+```bash
+node scripts/adam-register.cjs
+```
+
+(Equivalent: `npm run adam:register`. Self-loads `.env`; uses `CLAUDE_SESSION_ID` from the SessionStart hook.)
+
+This tags the current session in `claude_sessions.metadata` with `role=adam` and `non_fleet=true` (a JSONB merge — preserves existing keys, no migration). It is **verify-first**: if the session is already tagged it reports `verified` and writes nothing. The output is one JSON object — `action` is `tagged`, `verified`, or `error`.
+
+> Why the tag matters: Adam **heartbeats like any live session**, so natural inactivity-based exclusion does NOT keep Adam out of the fleet. The explicit `role=adam`/`non_fleet=true` tag is what excludes Adam from worker counts, ETA math, revival requests, and claim-sweep targeting.
+
+## Step 2 — Load the canonical role contract (graceful)
+
+The authoritative Adam role contract lives in **`CLAUDE_ADAM.md`** (generated from `leo_protocol_sections`, delivered by Child C `SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C`). If it exists, read it — it is the source of truth and supersedes the inline summary below:
+
+```
+Read tool: CLAUDE_ADAM.md   (if present)
+```
+
+If `CLAUDE_ADAM.md` is not present yet, proceed with the inline definition below and note that the canonical doc is pending Child C — do **not** block.
+
+## Canonical Adam role definition (inline summary)
+
+- **Who Adam is:** the Chairman's operator-attached **advisory / analysis** session.
+- **What Adam does:** SOURCES work (surfaces candidate SDs/feedback/gaps) and DIAGNOSES (RCA, audits, investigations, status synthesis) for the Chairman.
+- **What Adam is NOT:** Adam is **not a worker** (never claims SDs, never consumes the fleet queue, never drives LEAD→EXEC) and **not the coordinator** (does not assign work, run sweeps, or own fleet lifecycle).
+- **Tag:** `claude_sessions.metadata.role = 'adam'`, `non_fleet = true` — heartbeats, but excluded from all fleet accounting.
+
+## Step 3 — Adam → coordinator protocol
+
+- Adam communicates advisories to the **active coordinator** (resolve via `lib/coordinator/resolve.cjs` `getActiveCoordinatorId`).
+- Adam advisories use a **dedicated, non-friction lane** (`payload.kind=adam_advisory`) so they never pollute the worker-friction signal-router — that lane is delivered by Child B (`SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B`). Until Child B ships, route advisories through the existing coordinator comms and label them clearly as advisory.
+- **Boundary (hard):** Adam never claims an SD and never consumes the fleet queue. If Adam identifies work, it SOURCES it (drafts/surfaces it for the coordinator to dispatch) — it does not execute it.
+
+## Result
+
+After `/adam`: the session is tagged `role=adam`/`non_fleet=true` (idempotent), the role contract is loaded (or noted pending), and the coordination protocol is established. Adam is now active as an advisory/analysis session, invisible to fleet accounting.

--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "adam:register": "node scripts/adam-register.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "sd:start": "node scripts/sd-start.js",

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Adam role register/verify
+ * SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-A
+ *
+ * Idempotently tags the CURRENT session in claude_sessions.metadata with
+ * role=adam and non_fleet=true, so the coordinator's fleet accounting (worker
+ * counts, ETA math, revival requests, claim-sweep targeting) excludes this
+ * heartbeating-but-non-fleet advisory/analysis session.
+ *
+ * VERIFY-FIRST: the live Adam session already carried the tag set ad-hoc, so a
+ * blind write would be wrong — we read current metadata and only update on diff,
+ * otherwise report "verified" (no-op). JSONB merge preserves existing keys
+ * (callsign, fleet_identity, etc.). No migration — metadata is free-form JSONB.
+ *
+ * Self-env-loading (reuses lib/supabase-client.cjs ancestor .env walk) so /adam
+ * works without `node --env-file=.env`.
+ *
+ * Usage: node scripts/adam-register.cjs            (CLAUDE_SESSION_ID from env)
+ *        npm run adam:register
+ * Output: one JSON object { ok, action: tagged|verified|error, ... }.
+ */
+
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+
+const ADAM_ROLE = 'adam';
+
+/**
+ * Pure: given current metadata, decide whether a write is needed and produce the
+ * merged metadata. Exported for unit testing (no DB).
+ * @param {object|null} current - existing claude_sessions.metadata
+ * @returns {{ alreadyTagged: boolean, merged: object }}
+ */
+function computeAdamTag(current) {
+  const meta = (current && typeof current === 'object' && !Array.isArray(current)) ? current : {};
+  const alreadyTagged = meta.role === ADAM_ROLE && meta.non_fleet === true;
+  const merged = { ...meta, role: ADAM_ROLE, non_fleet: true };
+  return { alreadyTagged, merged };
+}
+
+/**
+ * Register/verify the Adam tag for a session. Injectable supabase for tests.
+ * Never throws — returns a structured result object.
+ */
+async function registerAdam(supabase, sessionId) {
+  if (!sessionId) {
+    return { ok: false, action: 'error', error: 'CLAUDE_SESSION_ID env var required (set by the SessionStart hook).' };
+  }
+  let row;
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) return { ok: false, action: 'error', error: error.message };
+    row = data;
+  } catch (e) {
+    return { ok: false, action: 'error', error: e.message };
+  }
+  if (!row) {
+    return { ok: false, action: 'error', error: `session ${sessionId} not found in claude_sessions (is the SessionStart register hook run?).` };
+  }
+
+  const { alreadyTagged, merged } = computeAdamTag(row.metadata);
+  if (alreadyTagged) {
+    return { ok: true, action: 'verified', session_id: sessionId, role: ADAM_ROLE, non_fleet: true, message: 'Session already tagged role=adam, non_fleet=true (verified, no change).' };
+  }
+  try {
+    const { error } = await supabase.from('claude_sessions').update({ metadata: merged }).eq('session_id', sessionId);
+    if (error) return { ok: false, action: 'error', error: error.message };
+  } catch (e) {
+    return { ok: false, action: 'error', error: e.message };
+  }
+  return { ok: true, action: 'tagged', session_id: sessionId, role: ADAM_ROLE, non_fleet: true, message: 'Session tagged role=adam, non_fleet=true (excluded from fleet accounting).' };
+}
+
+async function main() {
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  let supabase;
+  try {
+    supabase = createSupabaseServiceClient();
+  } catch (e) {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: `supabase client unavailable: ${e.message}` }, null, 2));
+    process.exit(1);
+  }
+  const result = await registerAdam(supabase, sessionId);
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+module.exports = { computeAdamTag, registerAdam, ADAM_ROLE };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: err.message || String(err) }, null, 2));
+    process.exit(1);
+  });
+}

--- a/scripts/adam-register.test.js
+++ b/scripts/adam-register.test.js
@@ -1,0 +1,77 @@
+// Tests for SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-A
+// scripts/adam-register.cjs — idempotent verify-first Adam role tagger.
+
+import { describe, it, expect, vi } from 'vitest';
+
+const { computeAdamTag, registerAdam, ADAM_ROLE } = require('./adam-register.cjs');
+
+describe('computeAdamTag (pure)', () => {
+  it('tags an untagged metadata and preserves existing keys', () => {
+    const { alreadyTagged, merged } = computeAdamTag({ callsign: 'Adam', cc_pid: 123 });
+    expect(alreadyTagged).toBe(false);
+    expect(merged.role).toBe('adam');
+    expect(merged.non_fleet).toBe(true);
+    expect(merged.callsign).toBe('Adam'); // preserved
+    expect(merged.cc_pid).toBe(123);
+  });
+
+  it('detects already-tagged (idempotent no-op)', () => {
+    const { alreadyTagged } = computeAdamTag({ role: 'adam', non_fleet: true, callsign: 'X' });
+    expect(alreadyTagged).toBe(true);
+  });
+
+  it('treats role-only or non_fleet-only as NOT fully tagged', () => {
+    expect(computeAdamTag({ role: 'adam' }).alreadyTagged).toBe(false);
+    expect(computeAdamTag({ non_fleet: true }).alreadyTagged).toBe(false);
+  });
+
+  it('handles null/array metadata defensively', () => {
+    expect(computeAdamTag(null).merged.role).toBe('adam');
+    expect(computeAdamTag([]).merged.non_fleet).toBe(true);
+  });
+});
+
+function stub({ row, updateErr = null, selectErr = null }) {
+  const calls = { updated: null };
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () => Promise.resolve({ data: row, error: selectErr }),
+    update: (payload) => { calls.updated = payload; return { eq: () => Promise.resolve({ error: updateErr }) }; },
+  };
+  return { sb: { from: () => chain }, calls };
+}
+
+describe('registerAdam', () => {
+  it('errors without a session id', async () => {
+    const { sb } = stub({ row: null });
+    const r = await registerAdam(sb, '');
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe('error');
+  });
+
+  it('errors when the session row is absent', async () => {
+    const { sb } = stub({ row: null });
+    const r = await registerAdam(sb, 'sess-x');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/);
+  });
+
+  it('tags an untagged session (writes merged metadata)', async () => {
+    const { sb, calls } = stub({ row: { session_id: 'sess-1', metadata: { callsign: 'Adam' } } });
+    const r = await registerAdam(sb, 'sess-1');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('tagged');
+    expect(calls.updated.metadata.role).toBe(ADAM_ROLE);
+    expect(calls.updated.metadata.non_fleet).toBe(true);
+    expect(calls.updated.metadata.callsign).toBe('Adam'); // preserved
+  });
+
+  it('verifies (no write) when already tagged', async () => {
+    const { sb, calls } = stub({ row: { session_id: 'sess-2', metadata: { role: 'adam', non_fleet: true } } });
+    const r = await registerAdam(sb, 'sess-2');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('verified');
+    expect(calls.updated).toBeNull(); // idempotent: no update issued
+  });
+});


### PR DESCRIPTION
Child A of the ADAM-ROLE-FORMALIZATION orchestrator — worker-facing entry point for the Adam advisory/analysis role (role=adam/non_fleet=true; Chairman-attached; never consumes the fleet queue).

- **scripts/adam-register.cjs** — verify-first idempotent tagger (JSONB merge into claude_sessions.metadata; preserves keys; no migration; no-op when already tagged — the live Adam session was tagged ad-hoc, so idempotency is required). Self-env-loading.
- **.claude/commands/adam.md** — /adam skill: emits the canonical role definition, runs register/verify, prints the Adam→coordinator protocol, degrades gracefully until Child C ships CLAUDE_ADAM.md.
- **package.json** — npm run adam:register (WIRE_CHECK).

8/8 unit tests (computeAdamTag purity + registerAdam tag/verify/preserve/error). Live self-tag intentionally NOT run (would mis-tag the worker session).

Parent: SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001 (orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)