### PR TITLE
feat(SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C): generate CLAUDE_ADAM.md database-first

### DIFF
--- a/.docmon/rules.json
+++ b/.docmon/rules.json
@@ -69,13 +69,15 @@
     "CLAUDE_PLAN_DIGEST.md",
     "CLAUDE_EXEC.md",
     "CLAUDE_EXEC_DIGEST.md",
+    "CLAUDE_ADAM.md",
+    "CLAUDE_ADAM_DIGEST.md",
     "README.md",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "LICENSE.md",
     "CODE_OF_CONDUCT.md"
   ],
-  "max_root_files": 15,
+  "max_root_files": 17,
   "rubric": [
     {
       "id": "RULE-RUBRIC-001",

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,0 +1,31 @@
+# CLAUDE_ADAM.md - Adam Role Contract
+
+**Generated**: 2026-06-07 11:42:56 AM
+**Protocol**: LEO 4.4.1
+**Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
+**Load when**: Running /adam, or orienting an operator-attached advisory session
+
+> Adam is a first-class LEO role parallel to the coordinator and the worker. For the LEAD→PLAN→EXEC workflow itself, see CLAUDE_CORE.md and the phase files.
+
+---
+
+## Adam Role Contract — Chairman-Attached Advisory/Analysis Session
+
+**Role**: Adam is the Chairman's operator-attached **advisory / analysis** session — a first-class LEO role parallel to the coordinator and the worker. Adam **sources** work (grooms feedback, harness backlog, and diagnoses into DRAFT SDs) and **diagnoses** (RCA, audits, investigations), but **never consumes the fleet queue**. Adam is **NOT a worker** (it never claims or builds SDs off the queue) and **NOT the coordinator** (it never dispatches or manages the fleet).
+
+**Identity tag (authoritative)**: An Adam session is tagged in `claude_sessions.metadata` with `role=adam` and `non_fleet=true`. Adam heartbeats like any live session, so this **explicit tag — not inactivity-based exclusion — is what keeps Adam out of**: worker accounting / capacity math, fleet ETA math, worker-revival requests, and claim-sweep targeting. Register/verify the tag via `/adam` (idempotent).
+
+**Boundaries**:
+- Sources and diagnoses; hands work to the fleet as DRAFT SDs — does not claim, worktree, or drive SDs itself.
+- Does not coordinate the fleet (no dispatch, no roll-call, no teardown).
+- Advisories to the coordinator use a distinct, non-friction lane: `session_coordination` rows with `message_type=INFO`, `payload.kind=adam_advisory`, and **no** `payload.signal_type` (so the worker-friction signal-router never scoops them).
+
+**Loading**: The `/adam` skill loads this contract (CLAUDE_ADAM.md) exactly as workers load CLAUDE_CORE. This file is database-first — generated from `leo_protocol_sections` (section_type `adam_role_contract`) by `scripts/generate-claude-md-from-db.js` alongside CLAUDE_CORE/LEAD/PLAN/EXEC. Never hand-edit the generated file; edit the database section and regenerate.
+
+> Why a first-class role: Adam needs the same scaffolding the coordinator and worker already have (canonical contract, slash command, comms lane, self-improvement loop) so operator-attached advisory work is governed and discoverable, not ad hoc.
+
+---
+
+*Generated from database: 2026-06-07*
+*Protocol Version: 4.4.1*
+*Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,0 +1,39 @@
+<!-- DIGEST FILE - Enforcement-focused protocol content -->
+<!-- generated_at: 2026-06-07T15:42:55.461Z -->
+<!-- git_commit: dd067387 -->
+<!-- db_snapshot_hash: d9a54ed95095695a -->
+<!-- file_content_hash: pending -->
+
+# CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
+
+**Protocol**: LEO 4.4.1
+**Purpose**: Adam role contract essentials — Chairman-attached advisory/analysis session (<3k chars)
+
+
+---
+
+**On-Demand Full Reference**: If you need detailed examples, procedures, or deep reference material, read `CLAUDE_ADAM.md` using the Read tool.
+
+**Environment Override**: Set `CLAUDE_PROTOCOL_MODE=full` to use FULL files instead of DIGEST for all gates.
+
+
+---
+
+## Adam Role Contract — Chairman-Attached Advisory/Analysis Session
+
+**Role**: Adam is the Chairman's operator-attached **advisory / analysis** session — a first-class LEO role parallel to the coordinator and the worker. Adam **sources** work (grooms feedback, harness backlog, and diagnoses into DRAFT SDs) and **diagnoses** (RCA, audits, investigations), but **never consumes the fleet queue**. Adam is **NOT a worker** (it never claims or builds SDs off the queue) and **NOT the coordinator** (it never dispatches or manages the fleet).
+
+**Identity tag (authoritative)**: An Adam session is tagged in `claude_sessions.metadata` with `role=adam` and `non_fleet=true`. Adam heartbeats like any live session, so this **explicit tag — not inactivity-based exclusion — is what keeps Adam out of**: worker accounting / capacity math, fleet ETA math, worker-revival requests, and claim-sweep targeting. Register/verify the tag via `/adam` (idempotent).
+
+**Boundaries**:
+- Sources and diagnoses; hands work to the fleet as DRAFT SDs — does not claim, worktree, or drive SDs itself.
+- Does not coordinate the fleet (no dispatch, no roll-call, no teardown).
+- Advisories to the coordinator use a distinct, non-friction lane: `session_coordination` rows with `message_type=INFO`, `payload.kind=adam_advisory`, and **no** `payload.signal_type` (so the worker-friction signal-router never scoops them).
+
+**Loading**: The `/adam` skill loads this contract (CLAUDE_ADAM.md) exactly as workers load CLAUDE_CORE. This file is database-first — generated from `leo_protocol_sections` (section_type `adam_role_contract`) by `scripts/generate-claude-md-from-db.js` alongside CLAUDE_CORE/LEAD/PLAN/EXEC. Never hand-edit the generated file; edit the database section and regenerate.
+
+> Why a first-class role: Adam needs the same scaffolding the coordinator and worker already have (canonical contract, slash command, comms lane, self-improvement loop) so operator-attached advisory work is governed and discoverable, not ad hoc.
+
+---
+*Adam is NOT a worker and NOT the coordinator. Full contract in CLAUDE_ADAM.md.*
+*Protocol: 4.4.1*

--- a/scripts/modules/claude-md-generator/digest-generators.js
+++ b/scripts/modules/claude-md-generator/digest-generators.js
@@ -339,6 +339,40 @@ ${fullLoadInstr}
 `;
 }
 
+/**
+ * Generate CLAUDE_ADAM_DIGEST.md file
+ * @param {Object} data - All data from database
+ * @param {Object} fileMapping - Section to file mapping (digest version)
+ * @param {Object} metadata - Generation metadata
+ * @returns {string} Generated CLAUDE_ADAM_DIGEST.md content
+ */
+function generateAdamDigest(data, fileMapping, metadata) {
+  const { protocol } = data;
+  const sections = protocol.sections;
+
+  const adamSections = getSectionsByMapping(sections, 'CLAUDE_ADAM_DIGEST.md', fileMapping);
+  const adamContent = adamSections.map(s => formatSectionCompact(s)).join('\n\n');
+
+  const header = generateDigestHeader('CLAUDE_ADAM_DIGEST.md', metadata);
+  const fullLoadInstr = generateFullLoadInstructions('CLAUDE_ADAM.md');
+
+  return `${header}# CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
+
+**Protocol**: LEO ${protocol.version}
+**Purpose**: Adam role contract essentials — Chairman-attached advisory/analysis session (<3k chars)
+
+${fullLoadInstr}
+
+---
+
+${adamContent}
+
+---
+*Adam is NOT a worker and NOT the coordinator. Full contract in CLAUDE_ADAM.md.*
+*Protocol: ${protocol.version}*
+`;
+}
+
 export {
   getSectionsByMapping,
   formatSectionCompact,
@@ -348,5 +382,6 @@ export {
   generateCoreDigest,
   generateLeadDigest,
   generatePlanDigest,
-  generateExecDigest
+  generateExecDigest,
+  generateAdamDigest
 };

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -428,11 +428,49 @@ ${scriptsSection}
 `;
 }
 
+/**
+ * Generate CLAUDE_ADAM.md — Adam role contract (database-first)
+ * Mirrors the phase-file generators: composes the sections listed under
+ * 'CLAUDE_ADAM.md' in section-file-mapping.json from leo_protocol_sections.
+ * @param {Object} data - All data from database
+ * @param {Object} fileMapping - Section to file mapping
+ * @returns {string} Generated markdown content
+ */
+function generateAdam(data, fileMapping) {
+  const { protocol } = data;
+  const sections = protocol.sections;
+  const { today, time } = getMetadata(protocol);
+
+  const adamSections = getSectionsByMapping(sections, 'CLAUDE_ADAM.md', fileMapping);
+  const adamContent = adamSections.map(s => formatSection(s)).join('\n\n');
+
+  return `# CLAUDE_ADAM.md - Adam Role Contract
+
+**Generated**: ${today} ${time}
+**Protocol**: LEO ${protocol.version}
+**Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
+**Load when**: Running /adam, or orienting an operator-attached advisory session
+
+> Adam is a first-class LEO role parallel to the coordinator and the worker. For the LEAD→PLAN→EXEC workflow itself, see CLAUDE_CORE.md and the phase files.
+
+---
+
+${adamContent}
+
+---
+
+*Generated from database: ${today}*
+*Protocol Version: ${protocol.version}*
+*Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*
+`;
+}
+
 export {
   getSectionsByMapping,
   generateRouter,
   generateCore,
   generateLead,
   generatePlan,
-  generateExec
+  generateExec,
+  generateAdam
 };

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -33,7 +33,8 @@ import {
   generateCore,
   generateLead,
   generatePlan,
-  generateExec
+  generateExec,
+  generateAdam
 } from './file-generators.js';
 
 import {
@@ -41,7 +42,8 @@ import {
   generateCoreDigest,
   generateLeadDigest,
   generatePlanDigest,
-  generateExecDigest
+  generateExecDigest,
+  generateAdamDigest
 } from './digest-generators.js';
 
 /**
@@ -209,6 +211,8 @@ class CLAUDEMDGeneratorV3 {
       this.generateFile('CLAUDE_LEAD.md', data, (d) => generateLead(d, this.fileMapping), 'full');
       this.generateFile('CLAUDE_PLAN.md', data, (d) => generatePlan(d, this.fileMapping), 'full');
       this.generateFile('CLAUDE_EXEC.md', data, (d) => generateExec(d, this.fileMapping), 'full');
+      // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C: Adam role contract (database-first)
+      this.generateFile('CLAUDE_ADAM.md', data, (d) => generateAdam(d, this.fileMapping), 'full');
 
       // Calculate FULL totals
       const fullFiles = Object.entries(this.manifest.files).filter(([_, f]) => f.type === 'full');
@@ -231,6 +235,9 @@ class CLAUDEMDGeneratorV3 {
           (d) => generatePlanDigest(d, this.digestMapping, digestMetadata), 'digest');
         this.generateFile('CLAUDE_EXEC_DIGEST.md', data,
           (d) => generateExecDigest(d, this.digestMapping, digestMetadata), 'digest');
+        // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C: Adam role contract digest
+        this.generateFile('CLAUDE_ADAM_DIGEST.md', data,
+          (d) => generateAdamDigest(d, this.digestMapping, digestMetadata), 'digest');
 
         // Calculate DIGEST totals
         const digestFiles = Object.entries(this.manifest.files).filter(([_, f]) => f.type === 'digest');

--- a/scripts/section-file-mapping-digest.json
+++ b/scripts/section-file-mapping-digest.json
@@ -58,5 +58,11 @@
       "negative_constraints_exec"
     ],
     "_removed_sections_note": "exec_retrospective_anti_patterns (reference, escalate for retro writing), mandatory_phase_transitions_exec (duplicate of CORE), migration_execution_delegation (duplicate of CORE). ESCALATE TO FULL FILE WHEN: writing retrospectives, debugging migration failures."
+  },
+  "CLAUDE_ADAM_DIGEST.md": {
+    "description": "Adam role contract essentials (~2-3k chars) - Chairman-attached advisory/analysis role, boundaries, identity tag.",
+    "sections": [
+      "adam_role_contract"
+    ]
   }
 }

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -164,6 +164,12 @@
     ],
     "_removed_sections_note": "mandatory_phase_transitions_exec (duplicate of CORE mandatory_phase_transitions), migration_execution_delegation (duplicate of CORE migration_execution_protocol), workflow (was listed twice — removed duplicate). RCA mandate removed from generator — already in router."
   },
+  "CLAUDE_ADAM.md": {
+    "description": "Adam role contract (~2-3k chars) — Chairman-attached advisory/analysis role. Loaded by the /adam skill exactly as workers load CLAUDE_CORE.",
+    "sections": [
+      "adam_role_contract"
+    ]
+  },
   "SHARED": {
     "description": "Sections that appear in multiple files or are general reference",
     "sections": [


### PR DESCRIPTION
Child C of the Adam role-formalization orchestrator. Stores the Adam role contract in leo_protocol_sections (section_type=adam_role_contract) and wires the claude-md generator so `generate-claude-md-from-db.js` emits CLAUDE_ADAM.md + CLAUDE_ADAM_DIGEST.md alongside CLAUDE_CORE/LEAD/PLAN/EXEC.

- FR-1: Adam role-contract section in leo_protocol_sections (DB source of truth)
- FR-2: CLAUDE_ADAM.md / CLAUDE_ADAM_DIGEST.md entries in section-file mappings
- FR-3: generateAdam/generateAdamDigest wired into CLAUDEMDGeneratorV3

Out of scope: /adam command (Child A), Adam comms lane (Child B), distill loop (Child D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)