### PR TITLE
feat(SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001): coordinator worktree-pool watchdog — prevent silent fleet stalls

### DIFF
--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -9,6 +9,7 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -16,6 +17,14 @@ const t = Date.now();
 const OPEN = ['new', 'in_progress', 'open', 'triaged', 'snoozed'];
 const TERMINAL = ['completed', 'cancelled', 'archived', 'deferred'];
 const termList = '(' + TERMINAL.join(',') + ')';
+
+// SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-003): pool-utilization threshold.
+// Mirror the watchdog default (0.8) so the audit warns at the same point the
+// watchdog acts. Override with WORKTREE_POOL_THRESHOLD.
+const POOL_THRESHOLD = (() => {
+  const n = parseFloat((process.env.WORKTREE_POOL_THRESHOLD || '').trim());
+  return Number.isFinite(n) && n > 0 && n <= 1 ? n : 0.8;
+})();
 
 // (1) harness backlog
 const { data: hb } = await db.from('feedback').select('id,title,status,severity,created_at').eq('category', 'harness_backlog').in('status', OPEN).order('created_at', { ascending: false });
@@ -39,6 +48,15 @@ const liveIdle = live.filter(s => !s.sd_key).length;
 const { data: sig } = await db.from('session_coordination').select('id').eq('target_session', me).is('read_at', null).not('payload->>signal_type', 'is', null);
 const unread = (sig || []).length;
 
+// (4) worktree pool utilization — silent 20/20 cap stalls the whole fleet.
+// countActiveWorktrees never throws (returns [] on git failure → 0).
+let poolUsed = 0;
+let poolCap = MAX_WORKTREE_COUNT;
+try { poolUsed = countActiveWorktrees(process.cwd()); } catch { poolUsed = 0; }
+const poolUtil = poolCap > 0 ? poolUsed / poolCap : 0;
+const poolPct = Math.round(poolUtil * 100);
+const poolWarn = poolUtil >= POOL_THRESHOLD;
+
 // sourcing decision: feed the fleet only if there is idle capacity AND the queue can't fill it
 const capacity = builders + liveIdle;
 const starving = backlog.length > 0 && liveIdle > 0 && unclaimed.length < capacity;
@@ -49,6 +67,8 @@ console.log('  HARNESS BACKLOG : ' + backlog.length + ' open (' + high.length + 
 for (const r of backlog.slice(0, 10)) console.log('      [' + r.status + '/' + (r.severity || '-') + '] ' + String(r.title || '').slice(0, 78));
 console.log('  SD QUEUE        : ' + sds.length + ' non-terminal | ' + claimed + ' claimed | ' + unclaimed.length + ' unclaimed | ' + stuck.length + ' stuck(in_progress,unclaimed)');
 console.log('  WORKERS         : ' + builders + ' building, ' + liveIdle + ' live-idle');
+console.log('  WORKTREE POOL   : ' + poolUsed + '/' + poolCap + ' (' + poolPct + '%)' +
+  (poolWarn ? '  ⚠️  WARNING ≥' + Math.round(POOL_THRESHOLD * 100) + '% — run worktree reaper Stage-0 (terminal-SD reclaim) to avoid a 20/20 cap stall' : ''));
 console.log('  INBOX           : ' + unread + ' unread signals');
 console.log('  SOURCE BACKLOG? : ' + (starving
   ? 'YES — source ' + toSource + ' high-priority backlog item(s) into DRAFT SDs (idle capacity + thin queue)'

--- a/scripts/fleet/worktree-reaper-tick.cjs
+++ b/scripts/fleet/worktree-reaper-tick.cjs
@@ -20,11 +20,17 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 
 const DEFAULT_CADENCE = 12; // every 12th sweep ≈ 1 hour at 5-min intervals
 const STATE_RELATIVE = path.join('.claude', 'worktree-reaper-state.json');
 const STATE_SCHEMA_VERSION = 1;
+
+// SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-002): pool-utilization watchdog.
+// Mirrors lib/worktree-quota.js::MAX_WORKTREE_COUNT (kept in sync; the .cjs tick
+// cannot `require` the ESM quota module, so the cap is duplicated as a constant).
+const MAX_WORKTREE_COUNT = 20;
+const DEFAULT_POOL_THRESHOLD = 0.8;
 
 function readState(statePath) {
   // SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001: last_pid/last_spawn_at are additive
@@ -86,6 +92,67 @@ function resolveExecuteMode() {
   return { execute: false, stage2: false };
 }
 
+// ── Pool-utilization watchdog (SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001) ──
+
+/**
+ * Resolve the watchdog threshold from WORKTREE_POOL_THRESHOLD (a fraction in
+ * (0,1]); falls back to DEFAULT_POOL_THRESHOLD on absent/invalid input.
+ */
+function resolvePoolThreshold() {
+  const raw = (process.env.WORKTREE_POOL_THRESHOLD || '').trim();
+  if (!raw) return DEFAULT_POOL_THRESHOLD;
+  const n = parseFloat(raw);
+  if (Number.isFinite(n) && n > 0 && n <= 1) return n;
+  return DEFAULT_POOL_THRESHOLD;
+}
+
+/**
+ * Count git-registered worktrees (excluding the main checkout) for repoRoot.
+ * Duplicates lib/worktree-quota.js::countActiveWorktrees because this CJS tick
+ * cannot import the ESM module. Returns null on any git failure (watchdog then
+ * no-ops rather than acting on a bad count).
+ */
+function countActiveWorktrees(repoRoot, runner = spawnSync) {
+  let res;
+  try {
+    res = runner('git', ['worktree', 'list', '--porcelain'], {
+      cwd: repoRoot, encoding: 'utf8', windowsHide: true,
+    });
+  } catch { return null; }
+  if (!res || res.status !== 0 || typeof res.stdout !== 'string') return null;
+  const normRoot = path.resolve(repoRoot).replace(/\\/g, '/');
+  let count = 0;
+  let current = null;
+  let bare = false;
+  const flush = () => {
+    if (current) {
+      const p = path.resolve(current).replace(/\\/g, '/');
+      if (!bare && p !== normRoot) count++;
+    }
+    current = null; bare = false;
+  };
+  for (const line of res.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) { flush(); current = line.slice('worktree '.length).trim(); }
+    else if (line === 'bare') { bare = true; }
+  }
+  flush();
+  return count;
+}
+
+/**
+ * Pure watchdog decision: given used/cap/threshold, decide whether Stage-0
+ * reclaim should fire. Returns { triggered, used, cap, utilization, percent,
+ * threshold }. Stays pure (no I/O) so it is trivially unit-testable.
+ */
+function poolWatchdogDecision({ used, cap = MAX_WORKTREE_COUNT, threshold = DEFAULT_POOL_THRESHOLD }) {
+  const safeCap = cap > 0 ? cap : MAX_WORKTREE_COUNT;
+  const utilization = (Number.isFinite(used) ? used : 0) / safeCap;
+  return {
+    triggered: Number.isFinite(used) && utilization >= threshold,
+    used, cap: safeCap, utilization, percent: Math.round(utilization * 100), threshold,
+  };
+}
+
 /**
  * Tick the counter and invoke the reaper when due.
  * Returns the post-invocation state for caller visibility.
@@ -140,7 +207,28 @@ function tick(opts = {}) {
   if (execute) args.push('--execute');
   if (stage2) args.push('--stage2', '--yes');
 
-  logger(`WORKTREE REAPER TICK: sweep=${state.sweep_counter} cadence=${cadence} execute=${execute} stage2=${stage2}`);
+  // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-002): pool-utilization watchdog.
+  // When the pool is at/above threshold, proactively run Stage-0 (terminal-SD
+  // reclaim) so the fleet never silently stalls at the 20/20 cap. Stage-0 is
+  // age-agnostic but still claim-guarded + activeSdSet-guarded inside the reaper,
+  // and idempotent (a second tick over the same state reclaims nothing new).
+  // Disable with WORKTREE_POOL_WATCHDOG=off. Forcing --execute here is intentional:
+  // a watchdog that only dry-runs cannot relieve the cap.
+  const watchdogEnabled = !['false', '0', 'off', 'no'].includes(
+    (process.env.WORKTREE_POOL_WATCHDOG || '').trim().toLowerCase(),
+  );
+  let watchdog = null;
+  if (watchdogEnabled) {
+    const used = countActiveWorktrees(repoRoot);
+    watchdog = poolWatchdogDecision({ used, cap: MAX_WORKTREE_COUNT, threshold: resolvePoolThreshold() });
+    if (watchdog.triggered) {
+      if (!args.includes('--stage0')) args.push('--stage0');
+      if (!args.includes('--execute')) args.push('--execute');
+      logger(`WORKTREE POOL WATCHDOG: ${watchdog.used}/${watchdog.cap} (${watchdog.percent}%) ≥ ${Math.round(watchdog.threshold * 100)}% → Stage-0 reclaim armed`);
+    }
+  }
+
+  logger(`WORKTREE REAPER TICK: sweep=${state.sweep_counter} cadence=${cadence} execute=${execute || (watchdog && watchdog.triggered)} stage2=${stage2}${watchdog && watchdog.triggered ? ' stage0=true' : ''}`);
 
   // SD-FDBK-INFRA-WORKTREE-REAPER-RELIABILITY-001: run the reaper OUT-OF-BAND.
   // Previously this blocked the sweep on a synchronous spawnSync (timeout 5 min).
@@ -186,7 +274,7 @@ function tick(opts = {}) {
   }
   writeState(statePath, state);
 
-  return { invoked: result === 'spawned', counter: state.sweep_counter, cadence, result, pid, enabled: true };
+  return { invoked: result === 'spawned', counter: state.sweep_counter, cadence, result, pid, enabled: true, watchdog };
 }
 
 module.exports = {
@@ -196,6 +284,11 @@ module.exports = {
   isEnabled,
   isPidAlive,
   resolveExecuteMode,
+  resolvePoolThreshold,
+  countActiveWorktrees,
+  poolWatchdogDecision,
   DEFAULT_CADENCE,
+  DEFAULT_POOL_THRESHOLD,
+  MAX_WORKTREE_COUNT,
   STATE_RELATIVE,
 };

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -56,7 +56,7 @@ import { fileURLToPath } from 'node:url';
 
 import { createClient } from '@supabase/supabase-js';
 
-import { listActiveWorktrees } from '../lib/worktree-quota.js';
+import { listActiveWorktrees, countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../lib/worktree-manager.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
 // These three used to be defined locally below; the canonical home is now
@@ -72,6 +72,14 @@ import {
 
 const SCHEMA_VERSION = '1.0';
 const DEFAULT_IDLE_DAYS = 7;
+
+// SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001: terminal SD statuses whose worktrees
+// are pure cleanup. A worktree whose basename sd_key resolves to one of these is
+// reclaimable regardless of the 7-day idle gate (Stage-0, age-agnostic) — but ONLY
+// when it has no active claim and is NOT in activeSdSet.
+const TERMINAL_SD_STATUSES = ['completed', 'cancelled', 'archived'];
+// Pool-utilization threshold at/above which the watchdog proactively runs Stage-0.
+const DEFAULT_POOL_THRESHOLD = 0.8;
 const PRESERVE_EXEMPT_RE = /^(tmp-|scratch-|\.claude[\\/]|\.workflow-patterns|\.worktree\.json$|\.ehg-session\.json$)/;
 
 // ── CLI parsing ────────────────────────────────────────────────────────
@@ -80,12 +88,14 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const opts = {
     execute: args.includes('--execute') || args.includes('-e'),
+    stage0: args.includes('--stage0'),
     stage2: args.includes('--stage2'),
     yes: args.includes('--yes'),
     verbose: args.includes('--verbose') || args.includes('-v'),
     phantomOnly: args.includes('--phantom-only'),
     help: args.includes('--help') || args.includes('-h'),
     days: DEFAULT_IDLE_DAYS,
+    threshold: DEFAULT_POOL_THRESHOLD,
     preserveRoot: null,
     repo: null,
   };
@@ -93,6 +103,11 @@ function parseArgs(argv) {
   if (daysIdx !== -1 && args[daysIdx + 1]) {
     const n = parseInt(args[daysIdx + 1], 10);
     if (Number.isFinite(n) && n > 0) opts.days = n;
+  }
+  const thrIdx = args.findIndex((a) => a === '--threshold');
+  if (thrIdx !== -1 && args[thrIdx + 1]) {
+    const n = parseFloat(args[thrIdx + 1]);
+    if (Number.isFinite(n) && n > 0 && n <= 1) opts.threshold = n;
   }
   const prIdx = args.findIndex((a) => a === '--preserve-root');
   if (prIdx !== -1 && args[prIdx + 1]) {
@@ -113,7 +128,11 @@ Usage:
 
 Options:
   --execute, -e         Remove Stage 1 worktrees (default: dry-run)
+  --stage0              Stage-0 mode: also reclaim worktrees whose SD is TERMINAL
+                        (completed/cancelled/archived) regardless of idle age.
+                        Combine with --execute to actually remove them.
   --execute --stage2    Also remove Stage 2 worktrees (zombie/orphan/idle)
+  --threshold <0..1>    Pool-utilization threshold for the watchdog (default: ${DEFAULT_POOL_THRESHOLD})
   --yes                 Skip interactive confirmation for Stage 2
   --days <n>            Idle threshold in days (default: ${DEFAULT_IDLE_DAYS})
   --preserve-root <p>   Override preserve destination root (default: scratch/preserved-from-*)
@@ -124,6 +143,8 @@ Options:
   --help, -h            Show this help
 
 Stages:
+  Stage 0 (terminal-SD): worktree sd_key resolves to completed/cancelled/archived
+                         SD — reclaimed age-agnostically (opt-in via --stage0).
   Stage 1 (auto-safe):  AC2 nested, AC4 shipped-stale
   Stage 2 (reviewed):   AC1 zombie-on-main, AC3 orphan-SD, AC5 idle
 
@@ -294,7 +315,9 @@ async function loadSdKeySets(supabase) {
   const qfMap = new Set();
   // SD-FDBK-ENH-WORKTREE-REAPER-MJS-001: always return activeSdSet (empty when no supabase)
   // so callers/ctx never see it undefined.
-  if (!supabase) return { sdMap, qfMap, activeSdSet: new Set() };
+  // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001: also return terminalSdSet (sd_keys whose
+  // status IN completed/cancelled/archived) so Stage-0 can reclaim them age-agnostically.
+  if (!supabase) return { sdMap, qfMap, activeSdSet: new Set(), terminalSdSet: new Set() };
 
   // Supabase defaults to 1000 rows per select even with .limit(5000). Paginate
   // explicitly with .range() to ensure the full set is loaded — otherwise
@@ -341,7 +364,26 @@ async function loadSdKeySets(supabase) {
     }
   } catch { /* best-effort */ }
 
-  return { sdMap, qfMap, activeSdSet };
+  // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001: sd_keys of SDs in a TERMINAL state
+  // (completed/cancelled/archived). Their worktrees are pure cleanup and Stage-0 may
+  // reclaim them regardless of idle age. Best-effort: empty on error → Stage-0 simply
+  // finds nothing to reclaim (no over-reap).
+  const terminalSdSet = new Set();
+  try {
+    const pageSize = 1000;
+    for (let start = 0; start < 20000; start += pageSize) {
+      const { data, error } = await supabase
+        .from('strategic_directives_v2')
+        .select('sd_key, status')
+        .in('status', TERMINAL_SD_STATUSES)
+        .range(start, start + pageSize - 1);
+      if (error || !data || data.length === 0) break;
+      for (const r of data) if (r.sd_key) terminalSdSet.add(r.sd_key);
+      if (data.length < pageSize) break;
+    }
+  } catch { /* best-effort */ }
+
+  return { sdMap, qfMap, activeSdSet, terminalSdSet };
 }
 
 // ── Git / Gh runners ───────────────────────────────────────────────────
@@ -471,6 +513,145 @@ function shipStatus(reasons) {
       : 'absorbed_no_pr';
   }
   return 'not_on_main';
+}
+
+// ── Stage-0 terminal-SD reclaim (SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001) ──
+
+/**
+ * Pure Stage-0 classifier for a single worktree. A worktree is a Stage-0
+ * reclaim candidate when its basename sd_key resolves to a TERMINAL SD status
+ * (completed/cancelled/archived) AND it is not protected. This is age-agnostic:
+ * it intentionally ignores the 7-day idle gate (the whole point of the
+ * watchdog is to reclaim terminal-SD worktrees fast at high utilization).
+ *
+ * ALL existing guards are preserved here, in priority order:
+ *   1. active claim (v_active_sessions) → ALWAYS keep
+ *   2. activeSdSet (draft/active/in_progress) → ALWAYS keep (suppresses even
+ *      a stale terminal-status row; never reap a still-worked SD)
+ *   3. terminalSdSet membership → reclaim
+ *
+ * Pure + dependency-injected: takes the worktree, the claim map, and the two
+ * SD-status sets. No git, no DB, no fs. The injected `statusResolver` (optional)
+ * lets tests supply a function instead of sets; when present it wins.
+ *
+ * @param {{ path: string, branch?: string }} wt
+ * @param {{
+ *   claimMap?: Map<string, object>,
+ *   activeSdSet?: Set<string>,
+ *   terminalSdSet?: Set<string>,
+ *   statusResolver?: (sdKey: string) => ('terminal'|'active'|'unknown')
+ * }} ctx
+ * @returns {{ reclaim: boolean, reason: string, sd_key: string }}
+ */
+export function classifyStage0(wt, ctx = {}) {
+  const sdKey = path.basename(wt.path || '');
+
+  // Guard 1: active claim protection (AC8) — never touch a live-claimed worktree.
+  const claim = ctx.claimMap?.get(normalizePath(wt.path));
+  if (claim) {
+    return { reclaim: false, reason: 'active_claim_protected', sd_key: sdKey };
+  }
+
+  // Guard 2: activeSdSet (draft/active/in_progress) — never reap a still-worked SD,
+  // even if a stale terminal row exists for the same key.
+  if (ctx.activeSdSet && ctx.activeSdSet.has(sdKey)) {
+    return { reclaim: false, reason: 'active_sd_protected', sd_key: sdKey };
+  }
+
+  // Resolve terminal status. statusResolver (if injected) is authoritative.
+  let isTerminal;
+  if (typeof ctx.statusResolver === 'function') {
+    const verdict = ctx.statusResolver(sdKey);
+    if (verdict === 'active') {
+      return { reclaim: false, reason: 'active_sd_protected', sd_key: sdKey };
+    }
+    isTerminal = verdict === 'terminal';
+  } else {
+    isTerminal = !!(ctx.terminalSdSet && ctx.terminalSdSet.has(sdKey));
+  }
+
+  if (isTerminal) {
+    return { reclaim: true, reason: 'terminal_sd_reclaim', sd_key: sdKey };
+  }
+  return { reclaim: false, reason: 'not_terminal_sd', sd_key: sdKey };
+}
+
+/**
+ * Pure selection over an injected worktree listing. Returns the subset of
+ * worktrees that Stage-0 would reclaim, each tagged with its classification.
+ * No I/O — callers pass in the already-enumerated worktrees, claim map, and
+ * status sets. This is the unit the watchdog and the CLI both drive.
+ *
+ * @param {Array<{ path: string, branch?: string }>} worktrees
+ * @param {object} ctx - same shape as classifyStage0's ctx
+ * @returns {Array<{ path: string, branch?: string, sd_key: string, reason: string }>}
+ */
+export function selectStage0Reclaim(worktrees, ctx = {}) {
+  const out = [];
+  for (const wt of worktrees || []) {
+    if (isCursorWorktree(wt.path)) continue; // inherit cursor-protection convention
+    const v = classifyStage0(wt, ctx);
+    if (v.reclaim) out.push({ path: wt.path, branch: wt.branch, sd_key: v.sd_key, reason: v.reason });
+  }
+  return out;
+}
+
+/**
+ * Compute pool utilization as a fraction in [0,1].
+ *
+ * @param {number} used - active worktree count
+ * @param {number} [cap=MAX_WORKTREE_COUNT]
+ * @returns {{ used: number, cap: number, utilization: number, percent: number }}
+ */
+export function computePoolUtilization(used, cap = MAX_WORKTREE_COUNT) {
+  const safeCap = cap > 0 ? cap : MAX_WORKTREE_COUNT;
+  const utilization = used / safeCap;
+  return { used, cap: safeCap, utilization, percent: Math.round(utilization * 100) };
+}
+
+/**
+ * Pool watchdog (FR-002). Computes utilization from the injected used/cap and,
+ * when at/above the threshold, selects the Stage-0 reclaim set. PURE by default:
+ * it does NOT remove anything — it returns the decision + candidate list so the
+ * caller (the tick / CLI) performs the claim-guarded, preserve-before-delete
+ * removal through the existing removeWorktree path. Idempotent: a second call on
+ * the same state returns the same (or empty, once reclaimed) candidate set.
+ *
+ * An optional `reclaim` callback may be supplied to actually act on the
+ * candidates (used by the tick); it is invoked only when triggered.
+ *
+ * @param {{
+ *   worktrees: Array<{path:string, branch?:string}>,
+ *   used?: number,
+ *   cap?: number,
+ *   threshold?: number,
+ *   claimMap?: Map<string, object>,
+ *   activeSdSet?: Set<string>,
+ *   terminalSdSet?: Set<string>,
+ *   statusResolver?: Function,
+ *   reclaim?: (candidates: Array) => any
+ * }} ctx
+ * @returns {{ triggered: boolean, used: number, cap: number, utilization: number,
+ *             percent: number, threshold: number, candidates: Array, acted: boolean }}
+ */
+export function poolWatchdog(ctx = {}) {
+  const worktrees = ctx.worktrees || [];
+  const cap = ctx.cap > 0 ? ctx.cap : MAX_WORKTREE_COUNT;
+  const used = Number.isFinite(ctx.used) ? ctx.used : worktrees.length;
+  const threshold = Number.isFinite(ctx.threshold) && ctx.threshold > 0 ? ctx.threshold : DEFAULT_POOL_THRESHOLD;
+  const { utilization, percent } = computePoolUtilization(used, cap);
+  const triggered = utilization >= threshold;
+
+  let candidates = [];
+  let acted = false;
+  if (triggered) {
+    candidates = selectStage0Reclaim(worktrees, ctx);
+    if (typeof ctx.reclaim === 'function' && candidates.length > 0) {
+      ctx.reclaim(candidates);
+      acted = true;
+    }
+  }
+  return { triggered, used, cap, utilization, percent, threshold, candidates, acted };
 }
 
 // ── Preserve-before-delete ─────────────────────────────────────────────
@@ -658,19 +839,19 @@ export async function main(argv = process.argv) {
   }
 
   // Load reference data (best-effort — reaper is useful even with empty maps).
-  const [claimMap, { sdMap, qfMap, activeSdSet }] = await Promise.all([
+  const [claimMap, { sdMap, qfMap, activeSdSet, terminalSdSet }] = await Promise.all([
     loadClaimMap(supabase),
     loadSdKeySets(supabase),
   ]);
 
   const idleThresholdMs = opts.days * 24 * 60 * 60 * 1000;
-  const ctx = { repoRoot, claimMap, sdMap, qfMap, activeSdSet, idleThresholdMs };
+  const ctx = { repoRoot, claimMap, sdMap, qfMap, activeSdSet, terminalSdSet, idleThresholdMs };
 
   const header = humanTableHeader();
   const now = Date.now();
   const records = [];
 
-  console.log(`\n🔍 WORKTREE REAPER — ${opts.execute ? 'EXECUTE' : 'DRY-RUN'} mode`);
+  console.log(`\n🔍 WORKTREE REAPER — ${opts.execute ? 'EXECUTE' : 'DRY-RUN'} mode${opts.stage0 ? ' (+Stage-0 terminal-SD)' : ''}`);
   console.log('═'.repeat(header.length));
   console.log(`   Repo root: ${repoRoot}`);
   console.log(`   Worktrees scanned: ${allWorktrees.length}`);
@@ -742,6 +923,23 @@ export async function main(argv = process.argv) {
     verdict = staged.verdict;
     reasonText = categories[0] || 'no_match';
 
+    // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-001): opt-in Stage-0.
+    // When --stage0 is set and a worktree's SD is TERMINAL (completed/cancelled/
+    // archived), reclaim it age-agnostically — even if no other category matched.
+    // All earlier guards still hold: active-claimed worktrees never reach here
+    // (early continue above), and classifyStage0 re-checks activeSdSet so a
+    // still-worked SD is never reaped.
+    if (opts.stage0 && stage == null) {
+      const s0 = classifyStage0(wtInput, ctx);
+      if (s0.reclaim) {
+        stage = 0;
+        verdict = 'stage0_remove';
+        reasonText = s0.reason;
+        categories = [...categories, 'terminal-sd'];
+        reasons = { ...reasons, 'terminal-sd': { matched: true, reason: s0.reason, sd_key: s0.sd_key } };
+      }
+    }
+
     const rec = buildRecord({
       schema_version: SCHEMA_VERSION, wt: wtInput, categories, verdict,
       reason: reasonText, claim_status: 'absent', dirtyCount: dirty.dirtyCount,
@@ -754,16 +952,18 @@ export async function main(argv = process.argv) {
   }
 
   // Collect removal candidates.
+  const stage0 = records.filter((r) => r._stage === 0);
   const stage1 = records.filter((r) => r._stage === 1);
   const stage2 = records.filter((r) => r._stage === 2);
 
   console.log('─'.repeat(header.length));
+  if (opts.stage0) console.log(`Stage 0 (terminal-SD):     ${stage0.length}`);
   console.log(`Stage 1 (auto-safe):       ${stage1.length}`);
   console.log(`Stage 2 (analyzed):        ${stage2.length}`);
-  console.log(`Kept (including active):   ${records.length - stage1.length - stage2.length}`);
+  console.log(`Kept (including active):   ${records.length - stage0.length - stage1.length - stage2.length}`);
 
   if (!opts.execute) {
-    console.log('\n(Dry-run — no changes made. Pass --execute to remove Stage 1, or --execute --stage2 for all.)');
+    console.log('\n(Dry-run — no changes made. Pass --execute to remove Stage 1, --stage0 for terminal-SD, or --execute --stage2 for all.)');
     return 0;
   }
 
@@ -772,8 +972,10 @@ export async function main(argv = process.argv) {
     return 3;
   }
 
-  // Stage 1 removals (unconditional with --execute).
-  const removeList = [...stage1];
+  // Stage 0 (terminal-SD) + Stage 1 removals (unconditional with --execute).
+  // Stage-0 is auto-safe: the SD is already terminal and the active-claim /
+  // activeSdSet guards have both been applied during classification.
+  const removeList = [...stage0, ...stage1];
 
   // Stage 2 removals (only with --execute --stage2).
   if (opts.stage2 && stage2.length > 0) {

--- a/tests/unit/worktree-reaper/pool-watchdog.test.js
+++ b/tests/unit/worktree-reaper/pool-watchdog.test.js
@@ -1,0 +1,232 @@
+/**
+ * SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 — coordinator worktree-pool watchdog.
+ *
+ * Network-free unit tests for the Stage-0 terminal-SD reclaim, the pool-utilization
+ * watchdog, and the coordinator-audit pool-utilization surfacing. Everything is
+ * driven by INJECTED worktree listings + claim maps + an injected SD-status
+ * resolver — no real git, no real DB.
+ *
+ * Coverage:
+ *   (a) Stage-0 reaps a completed/cancelled SD worktree that is <7 days old (age-agnostic)
+ *   (b) Stage-0 PRESERVES a worktree with a live claim (v_active_sessions)
+ *   (c) Stage-0 PRESERVES a draft/active/in_progress SD worktree
+ *   (d) the watchdog triggers Stage-0 at 16/20 (>=80%) but NOT at 15/20
+ *   (e) coordinator-audit surfaces utilization and warns at >=80%
+ */
+import { describe, test, expect } from 'vitest';
+import path from 'node:path';
+
+import {
+  classifyStage0,
+  selectStage0Reclaim,
+  computePoolUtilization,
+  poolWatchdog,
+} from '../../../scripts/worktree-reaper.mjs';
+
+import { poolWatchdogDecision } from '../../../scripts/fleet/worktree-reaper-tick.cjs';
+
+// normalizePath in the reaper resolves+lowercases; build claim-map keys the same way
+// so an injected claim lines up with the worktree path regardless of platform.
+function claimKey(p) {
+  return path.resolve(p).replace(/\\/g, '/').toLowerCase();
+}
+
+const WT = (sdKey, branch) => ({
+  path: path.join('/repo', '.worktrees', sdKey),
+  branch: branch || `feat/${sdKey}`,
+});
+
+describe('classifyStage0 — terminal-SD reclaim (FR-001)', () => {
+  test('(a) reaps a COMPLETED SD worktree regardless of age (age-agnostic)', () => {
+    const wt = WT('SD-DONE-001');
+    const v = classifyStage0(wt, {
+      claimMap: new Map(),
+      activeSdSet: new Set(),
+      terminalSdSet: new Set(['SD-DONE-001']),
+    });
+    expect(v.reclaim).toBe(true);
+    expect(v.reason).toBe('terminal_sd_reclaim');
+    expect(v.sd_key).toBe('SD-DONE-001');
+  });
+
+  test('(a) reaps a CANCELLED SD worktree (via injected statusResolver)', () => {
+    const wt = WT('SD-CANCELLED-002');
+    const v = classifyStage0(wt, {
+      claimMap: new Map(),
+      activeSdSet: new Set(),
+      statusResolver: (k) => (k === 'SD-CANCELLED-002' ? 'terminal' : 'unknown'),
+    });
+    expect(v.reclaim).toBe(true);
+  });
+
+  test('(b) PRESERVES a worktree with a live claim (v_active_sessions)', () => {
+    const wt = WT('SD-DONE-001');
+    // Terminal SD AND an active claim → claim wins, never reaped.
+    const claimMap = new Map([[claimKey(wt.path), { sd_key: 'SD-DONE-001', session_id: 's1' }]]);
+    const v = classifyStage0(wt, {
+      claimMap,
+      activeSdSet: new Set(),
+      terminalSdSet: new Set(['SD-DONE-001']),
+    });
+    expect(v.reclaim).toBe(false);
+    expect(v.reason).toBe('active_claim_protected');
+  });
+
+  test('(c) PRESERVES a draft/active/in_progress SD worktree (activeSdSet guard)', () => {
+    const wt = WT('SD-ACTIVE-003');
+    // Even with a stale terminal row, the activeSdSet guard suppresses reclaim.
+    const v = classifyStage0(wt, {
+      claimMap: new Map(),
+      activeSdSet: new Set(['SD-ACTIVE-003']),
+      terminalSdSet: new Set(['SD-ACTIVE-003']),
+    });
+    expect(v.reclaim).toBe(false);
+    expect(v.reason).toBe('active_sd_protected');
+  });
+
+  test('(c) statusResolver returning "active" also preserves', () => {
+    const wt = WT('SD-ACTIVE-004');
+    const v = classifyStage0(wt, {
+      claimMap: new Map(),
+      statusResolver: () => 'active',
+    });
+    expect(v.reclaim).toBe(false);
+    expect(v.reason).toBe('active_sd_protected');
+  });
+
+  test('keeps a non-terminal, unknown-status worktree (no over-reap)', () => {
+    const wt = WT('SD-UNKNOWN-005');
+    const v = classifyStage0(wt, {
+      claimMap: new Map(),
+      activeSdSet: new Set(),
+      terminalSdSet: new Set(),
+    });
+    expect(v.reclaim).toBe(false);
+    expect(v.reason).toBe('not_terminal_sd');
+  });
+});
+
+describe('selectStage0Reclaim — pure selection over an injected listing', () => {
+  test('selects only the terminal-SD worktree; preserves claimed + active ones', () => {
+    const done = WT('SD-DONE-001');
+    const claimed = WT('SD-DONE-CLAIMED-002');
+    const active = WT('SD-ACTIVE-003');
+
+    const worktrees = [done, claimed, active];
+    const ctx = {
+      claimMap: new Map([[claimKey(claimed.path), { sd_key: 'SD-DONE-CLAIMED-002' }]]),
+      activeSdSet: new Set(['SD-ACTIVE-003']),
+      terminalSdSet: new Set(['SD-DONE-001', 'SD-DONE-CLAIMED-002', 'SD-ACTIVE-003']),
+    };
+
+    const picked = selectStage0Reclaim(worktrees, ctx);
+    expect(picked.map((p) => p.sd_key)).toEqual(['SD-DONE-001']);
+  });
+
+  test('is idempotent: removing the picked worktree yields an empty second pass', () => {
+    const done = WT('SD-DONE-001');
+    const ctx = { claimMap: new Map(), activeSdSet: new Set(), terminalSdSet: new Set(['SD-DONE-001']) };
+    expect(selectStage0Reclaim([done], ctx)).toHaveLength(1);
+    // Simulate post-removal state (worktree gone) → nothing to do.
+    expect(selectStage0Reclaim([], ctx)).toHaveLength(0);
+  });
+});
+
+describe('computePoolUtilization', () => {
+  test('16/20 = 80%, 15/20 = 75%', () => {
+    expect(computePoolUtilization(16, 20).utilization).toBeCloseTo(0.8);
+    expect(computePoolUtilization(16, 20).percent).toBe(80);
+    expect(computePoolUtilization(15, 20).percent).toBe(75);
+  });
+  test('guards a zero/invalid cap (falls back to MAX_WORKTREE_COUNT=20)', () => {
+    expect(computePoolUtilization(10, 0).cap).toBe(20);
+  });
+});
+
+describe('poolWatchdog — triggers Stage-0 at/above threshold (FR-002)', () => {
+  const terminalSdSet = new Set(['SD-DONE-001']);
+  // 16 worktrees, one of which is a terminal-SD reclaim candidate.
+  const make = (count) => {
+    const list = [];
+    for (let i = 0; i < count - 1; i++) list.push(WT(`SD-LIVE-${String(i).padStart(3, '0')}`));
+    list.push(WT('SD-DONE-001'));
+    return list;
+  };
+
+  test('(d) triggers at 16/20 (>=80%) and selects the terminal-SD candidate', () => {
+    const worktrees = make(16);
+    const res = poolWatchdog({
+      worktrees, used: 16, cap: 20, threshold: 0.8,
+      claimMap: new Map(), activeSdSet: new Set(), terminalSdSet,
+    });
+    expect(res.triggered).toBe(true);
+    expect(res.percent).toBe(80);
+    expect(res.candidates.map((c) => c.sd_key)).toEqual(['SD-DONE-001']);
+  });
+
+  test('(d) does NOT trigger at 15/20 (75% < 80%)', () => {
+    const worktrees = make(15);
+    const res = poolWatchdog({
+      worktrees, used: 15, cap: 20, threshold: 0.8,
+      claimMap: new Map(), activeSdSet: new Set(), terminalSdSet,
+    });
+    expect(res.triggered).toBe(false);
+    expect(res.candidates).toHaveLength(0);
+  });
+
+  test('invokes the injected reclaim callback only when triggered', () => {
+    let called = null;
+    poolWatchdog({
+      worktrees: make(16), used: 16, cap: 20, threshold: 0.8,
+      claimMap: new Map(), activeSdSet: new Set(), terminalSdSet,
+      reclaim: (c) => { called = c; },
+    });
+    expect(called).not.toBeNull();
+    expect(called.map((c) => c.sd_key)).toEqual(['SD-DONE-001']);
+
+    let called2 = 'untouched';
+    poolWatchdog({
+      worktrees: make(15), used: 15, cap: 20, threshold: 0.8,
+      claimMap: new Map(), activeSdSet: new Set(), terminalSdSet,
+      reclaim: () => { called2 = 'called'; },
+    });
+    expect(called2).toBe('untouched');
+  });
+});
+
+describe('tick poolWatchdogDecision — same threshold semantics (FR-002 wiring)', () => {
+  test('(d) triggers at 16/20, not at 15/20', () => {
+    expect(poolWatchdogDecision({ used: 16, cap: 20, threshold: 0.8 }).triggered).toBe(true);
+    expect(poolWatchdogDecision({ used: 15, cap: 20, threshold: 0.8 }).triggered).toBe(false);
+  });
+  test('non-finite used never triggers (bad count → no-op)', () => {
+    expect(poolWatchdogDecision({ used: null, cap: 20, threshold: 0.8 }).triggered).toBe(false);
+  });
+});
+
+/**
+ * (e) coordinator-audit surfacing. The audit script is a top-level-await ESM
+ * module that connects to a DB on import, so we don't import it. Instead we
+ * assert the SAME pure utilization+warning arithmetic the audit uses, proving
+ * the surfaced number and the >=80% warning trigger are correct.
+ */
+describe('coordinator-audit pool utilization surfacing (FR-003)', () => {
+  const POOL_THRESHOLD = 0.8;
+  const audit = (used, cap = 20) => {
+    const util = cap > 0 ? used / cap : 0;
+    return { used, cap, percent: Math.round(util * 100), warn: util >= POOL_THRESHOLD };
+  };
+
+  test('(e) surfaces used/cap + percent', () => {
+    const a = audit(16, 20);
+    expect(a.used).toBe(16);
+    expect(a.cap).toBe(20);
+    expect(a.percent).toBe(80);
+  });
+
+  test('(e) warns at >=80%, not below', () => {
+    expect(audit(16, 20).warn).toBe(true);
+    expect(audit(20, 20).warn).toBe(true);
+    expect(audit(15, 20).warn).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The worktree pool cap (20, `lib/worktree-quota.js MAX_WORKTREE_COUNT`) silently stalls the whole fleet when full — `sd-start` hard-fails and the worker exits with no claim. The existing reaper only reaps 7-day-idle worktrees hourly, so it never proactively prevents the 20/20 cap (stalled the fleet **twice on 2026-06-07** — I hit it this session and had to signal the coordinator for a manual reap).

This adds a coordinator watchdog that proactively reclaims **terminal-SD** worktrees at a utilization threshold, building on the existing reaper rather than duplicating it.

## Changes
- **`scripts/worktree-reaper.mjs`** — opt-in **Stage-0** mode (`--stage0`/`--threshold`): reclaims worktrees whose backing SD is TERMINAL (completed/cancelled/archived) **age-agnostically**. Preserves every guard: `v_active_sessions` active-claim protection, `activeSdSet` (draft/active/in_progress) suppression, preserve-before-delete, dry-run default, idempotency. Default behavior unchanged when off. New pure DI'd fns: `classifyStage0`, `selectStage0Reclaim`, `computePoolUtilization`, `poolWatchdog`.
- **`scripts/fleet/worktree-reaper-tick.cjs`** — utilization watchdog (env-gated `WORKTREE_POOL_WATCHDOG` / `WORKTREE_POOL_THRESHOLD`, default 0.8); at ≥80% it arms `--stage0 --execute` on the existing detached reaper spawn.
- **`scripts/coordinator-audit.mjs`** — surfaces pool utilization (used/cap + %) and warns at ≥threshold before the cap stalls the fleet.
- **`tests/unit/worktree-reaper/pool-watchdog.test.js`** — network-free, dependency-injected.

## Verification
- New suite **17/17**; adjacent reaper suite **63/63** (no regression).
- TESTING sub-agent verdict: **PASS** (confidence 96) — guards individually exercised.

## Notable deviation
The watchdog drives the reaper via spawn args (the tick is CJS, the reaper/quota are ESM, and the reaper already runs detached), computing utilization in-process. The reaper itself enforces every guard, keeping it claim-guarded + idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)