### PR TITLE
feat(SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B): Adam advisory clean comms lane

### DIFF
--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -61,6 +61,7 @@ const PAYLOAD_KINDS = Object.freeze({
   COORDINATOR_REQUEST: 'coordinator_request',
   COORDINATOR_REPLY: 'coordinator_reply',
   WORK_ASSIGNMENT: 'work_assignment',
+  ADAM_ADVISORY: 'adam_advisory',     // SD-...-001-B: Adam advisory clean lane (off friction router)
 });
 
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;

--- a/package.json
+++ b/package.json
@@ -295,6 +295,7 @@
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
     "adam:register": "node scripts/adam-register.cjs",
+    "adam:advisory": "node scripts/adam-advisory.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Adam advisory comms lane (clean, non-friction)
+ * SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
+ *
+ * Gives the Adam role a dedicated lane to send advisories to the coordinator
+ * WITHOUT polluting the worker-friction signal-router. An advisory is a
+ * session_coordination row: message_type=INFO + payload.kind=adam_advisory and
+ * deliberately NO payload.signal_type (so lib/coordinator/signal-router.cjs
+ * loadRecentSignals — which filters payload->>signal_type IS NOT NULL — never
+ * scoops it) and NO payload.intent_action (so the deconfliction sweep ignores it).
+ *
+ * Builds on (does NOT duplicate) SD-LEO-INFRA-WORKER-CHECKIN-HANDSHAKE-001:
+ * reuses scripts/worker-signal.cjs (redact, BODY_HARD_CAP, awaitCoordinatorReply),
+ * lib/coordinator/resolve.cjs (getActiveCoordinatorId, isTwoWayV2Enabled), and the
+ * existing scripts/coordinator-reply.cjs for the reply leg. No migration.
+ *
+ * Usage:
+ *   node scripts/adam-advisory.cjs send "<advisory body>"
+ *   node scripts/adam-advisory.cjs request "<question>" [--timeout 30000]   (awaits a coordinator reply; needs COORDINATOR_TWOWAY_V2=on)
+ */
+
+const crypto = require('crypto');
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signal.cjs');
+const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
+const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
+
+/**
+ * Pure: build the advisory payload. INVARIANT: carries payload.kind=adam_advisory
+ * and NEVER signal_type / intent_action (so neither the friction router nor the
+ * intent sweep scoops it). Exported for tests.
+ */
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId }) {
+  const payload = {
+    kind: PAYLOAD_KINDS.ADAM_ADVISORY,
+    sender_callsign: senderCallsign || null,
+    repo: repo || null,
+  };
+  if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);
+  if (correlationId) {
+    payload.correlation_id = correlationId;
+    payload.expects_reply = true;
+  }
+  // INVARIANT: no signal_type, no intent_action.
+  return payload;
+}
+
+async function snapshotSender(supabase, sessionId) {
+  try {
+    const { data } = await supabase.from('claude_sessions').select('metadata').eq('session_id', sessionId).maybeSingle();
+    return data?.metadata?.fleet_identity?.callsign || data?.metadata?.callsign || null;
+  } catch { return null; }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const mode = argv[0];
+  if (mode !== 'send' && mode !== 'request') {
+    console.error('Usage: node scripts/adam-advisory.cjs send "<body>"  |  request "<question>" [--timeout <ms>]');
+    process.exit(2);
+  }
+  const tIdx = argv.indexOf('--timeout');
+  const timeoutMs = tIdx >= 0 ? Number(argv[tIdx + 1]) || 30000 : 30000;
+  const body = argv.slice(1).filter((a, i) => !(a === '--timeout' || argv[i] === '--timeout')).join(' ').trim();
+  if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
+
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) { console.error('ERROR: CLAUDE_SESSION_ID required (SessionStart hook).'); process.exit(1); }
+
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+
+  const coordinatorId = await getActiveCoordinatorId(supabase);
+  const target = coordinatorId || 'broadcast-coordinator';
+  const senderCallsign = await snapshotSender(supabase, sessionId);
+
+  if (mode === 'request' && !isTwoWayV2Enabled()) {
+    console.error('ERROR: request/await is gated by COORDINATOR_TWOWAY_V2=on (currently OFF). Use `send` for fire-and-forget.');
+    process.exit(3);
+  }
+
+  const correlationId = mode === 'request' ? crypto.randomUUID() : null;
+  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId });
+  const subject = `[ADAM_ADVISORY] ${payload.body.slice(0, 80)}`;
+  const expiresAt = new Date(Date.now() + (mode === 'request' ? timeoutMs + 5 * 60_000 : 24 * 60 * 60_000)).toISOString();
+
+  const { data: inserted, error } = await supabase
+    .from('session_coordination')
+    .insert({ sender_session: sessionId, sender_type: 'adam', target_session: target, message_type: 'INFO', subject, body: payload.body, payload, expires_at: expiresAt })
+    .select('id')
+    .single();
+  if (error) { console.error('ERROR: failed to insert advisory:', error.message); process.exit(1); }
+
+  console.log('✓ Adam advisory sent');
+  console.log('  advisory_id:', inserted.id);
+  console.log('  target:', target);
+  console.log('  callsign:', senderCallsign || '(none)');
+
+  if (mode === 'request') {
+    console.log('  correlation_id:', correlationId, '— awaiting coordinator reply…');
+    const result = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs });
+    if (result.timedOut) { console.log('⌛ No reply within timeout (reply may arrive later as a coordinator_reply row).'); process.exit(0); }
+    try { await supabase.from('session_coordination').update({ read_at: new Date().toISOString(), acknowledged_at: new Date().toISOString() }).eq('id', result.reply.id); } catch {}
+    console.log('✓ Reply:', (result.reply.payload && result.reply.payload.body) || result.reply.body || '(empty)');
+  }
+}
+
+module.exports = { buildAdvisoryPayload };
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}

--- a/scripts/adam-advisory.test.js
+++ b/scripts/adam-advisory.test.js
@@ -1,0 +1,38 @@
+// Tests for SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
+// scripts/adam-advisory.cjs — Adam advisory clean-lane writer.
+
+import { describe, it, expect } from 'vitest';
+
+const { buildAdvisoryPayload } = require('./adam-advisory.cjs');
+const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
+
+describe('FR-2: PAYLOAD_KINDS registry', () => {
+  it('registers adam_advisory as the canonical discriminator', () => {
+    expect(PAYLOAD_KINDS.ADAM_ADVISORY).toBe('adam_advisory');
+  });
+});
+
+describe('buildAdvisoryPayload', () => {
+  it('carries kind=adam_advisory and NEVER signal_type/intent_action (clean lane)', () => {
+    const p = buildAdvisoryPayload({ body: 'venture X stalled at S17', senderCallsign: 'Adam', repo: '/r' });
+    expect(p.kind).toBe('adam_advisory');
+    expect(p.signal_type).toBeUndefined();   // friction router filters signal_type IS NOT NULL → excluded
+    expect(p.intent_action).toBeUndefined(); // intent sweep ignores it
+    expect(p.sender_callsign).toBe('Adam');
+    expect(p.body).toBe('venture X stalled at S17');
+  });
+
+  it('redacts secrets and is correlation-free for fire-and-forget send', () => {
+    const p = buildAdvisoryPayload({ body: 'token ghp_' + 'a'.repeat(36), senderCallsign: null, repo: '/r' });
+    expect(p.body).toContain('[REDACTED:GH_TOKEN]');
+    expect(p.correlation_id).toBeUndefined();
+    expect(p.expects_reply).toBeUndefined();
+  });
+
+  it('adds correlation_id + expects_reply in request mode', () => {
+    const p = buildAdvisoryPayload({ body: 'q?', senderCallsign: 'Adam', repo: '/r', correlationId: 'corr-9' });
+    expect(p.correlation_id).toBe('corr-9');
+    expect(p.expects_reply).toBe(true);
+    expect(p.signal_type).toBeUndefined(); // still no signal_type even in request mode
+  });
+});

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1132,6 +1132,74 @@ async function printInbox() {
   console.log('');
 }
 
+// ── Section: Adam advisory inbox (SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B) ──
+// Surfaces Adam advisories (payload.kind=adam_advisory) in a SEPARATE section from
+// the worker-friction inbox (printInbox). Adam advisories deliberately omit
+// payload.signal_type, so printInbox's signal_type-NOT-NULL filter never shows them;
+// this section is their dedicated render. The per-session coordination-inbox drainer
+// skips adam_advisory so rows survive to be surfaced here.
+async function printAdamInbox() {
+  const getActiveCoordinatorId = _getActiveCoordinatorIdForInbox;
+
+  console.log('ADAM ADVISORY INBOX');
+  console.log('─'.repeat(72));
+
+  const coordinatorId = await getActiveCoordinatorId(supabase);
+  if (!coordinatorId) {
+    console.log('  (no active coordinator detected — run /coordinator start first)');
+    console.log('');
+    return;
+  }
+
+  const { data: advisories, error } = await supabase
+    .from('session_coordination')
+    .select('id, sender_session, sender_type, subject, body, payload, created_at')
+    .eq('target_session', coordinatorId)
+    .eq('payload->>kind', 'adam_advisory')
+    .is('read_at', null)
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) {
+    console.log('  (adam inbox query failed: ' + error.message + ')');
+    console.log('');
+    return;
+  }
+
+  if (!advisories || advisories.length === 0) {
+    console.log('  (no unread Adam advisories)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + advisories.length + ' unread advisory(ies)');
+  console.log('');
+  console.log('  ' + pad('Callsign', 12) + pad('Reply?', 8) + pad('Age', 8) + 'Body');
+  console.log('  ' + '─'.repeat(68));
+
+  const ids = [];
+  for (const a of advisories) {
+    const callsign = a.payload?.sender_callsign || '(none)';
+    const wantsReply = a.payload?.expects_reply ? 'yes' : '-';
+    const ageMin = Math.floor((Date.now() - new Date(a.created_at).getTime()) / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    const bodyPreview = (a.body || a.payload?.body || '').replace(/\n/g, ' ').substring(0, 32);
+    console.log('  ' + pad(callsign, 12) + pad(wantsReply, 8) + pad(ageStr, 8) + bodyPreview);
+    ids.push(a.id);
+  }
+
+  // Mark surfaced advisories read so they don't re-surface. A coordinator reply
+  // (coordinator-reply.cjs) is keyed by correlation_id, independent of read_at.
+  if (ids.length > 0) {
+    await supabase
+      .from('session_coordination')
+      .update({ read_at: new Date().toISOString() })
+      .in('id', ids);
+  }
+
+  console.log('');
+}
+
 // ── Section: Feedback work-store (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001) ──
 // READ-ONLY / additive: surfaces the feedback table (untriaged feedback + harness
 // backlog) on the coordinator single-pane view so pending feedback work is never
@@ -1228,6 +1296,7 @@ async function main() {
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
     inbox:         async () => await printInbox(),
+    adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
     all:           async () => {
@@ -1241,6 +1310,7 @@ async function main() {
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
+      await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
       await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);
       printHealth(d);
@@ -1253,7 +1323,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, feedback, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, feedback, team, all');
     process.exit(1);
   }
 

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -456,6 +456,13 @@ async function main() {
       if (amCoordinator && msg.message_type === 'INFO' && msg.payload && msg.payload.signal_type) {
         continue;
       }
+      // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B: defer Adam advisories to the
+      // coordinator's dedicated inbox section (fleet-dashboard printAdamInbox).
+      // Leave them UNREAD so that section surfaces them instead of this per-session
+      // drainer marking them read_at first (same hazard as the FR-3a signal skip).
+      if (amCoordinator && msg.message_type === 'INFO' && msg.payload && msg.payload.kind === 'adam_advisory') {
+        continue;
+      }
       // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-6 (P0-1): leave coordinator-reply
       // rows for the worker's awaitCoordinatorReply() to consume (default-OFF).
       if (shouldSkipCoordinatorReply(msg)) {


### PR DESCRIPTION
Child B of the ADAM-ROLE-FORMALIZATION orchestrator — a non-friction comms lane for the Adam role, additive over the merged CHECKIN-HANDSHAKE transport (no transport re-implementation, no migration).

- **lib/fleet/worker-status.cjs**: PAYLOAD_KINDS.ADAM_ADVISORY='adam_advisory'.
- **scripts/adam-advisory.cjs**: writer (send) + request/await. Emits session_coordination INFO + payload.kind=adam_advisory with NO signal_type/intent_action → signal-router.loadRecentSignals (filters signal_type IS NOT NULL) structurally never scoops it. Reuses worker-signal.cjs (redact/awaitCoordinatorReply) + resolve.cjs; request gated by COORDINATOR_TWOWAY_V2; reply leg reuses coordinator-reply.cjs.
- **scripts/fleet-dashboard.cjs**: new printAdamInbox() (payload->>kind='adam_advisory') as a SEPARATE section; printInbox untouched; registered in dispatch + 'all'.
- **scripts/hooks/coordination-inbox.cjs**: coordinator-mode drainer skip for adam_advisory (mirrors signal + coordinator_reply skips) so advisories aren't marked read before surfacing.
- **package.json**: adam:advisory wired.

4/4 unit tests + 3/3 syntax checks. Parent: SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)