### PR TITLE
fix(SD-LEO-FIX-FIX-STAGE-DEPLOYMENT-001): S21 deployment-URL resolver reads deployment_url (not non-existent resource_url)

### DIFF
--- a/lib/eva/__tests__/stage-21-visual-assets-preconditions.test.js
+++ b/lib/eva/__tests__/stage-21-visual-assets-preconditions.test.js
@@ -88,8 +88,8 @@ describe('validateEntryPreconditions (pure)', () => {
 });
 
 describe('resolveDeploymentUrl', () => {
-  it('returns the venture_resources replit_deployment resource_url', async () => {
-    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co', metadata: {} }] });
+  it('returns the venture_resources replit_deployment deployment_url', async () => {
+    const sb = makeSupabase({ ventureResources: [{ deployment_url: 'https://app.repl.co', metadata: {} }] });
     expect(await resolveDeploymentUrl(sb, 'v1')).toBe('https://app.repl.co');
   });
 
@@ -102,11 +102,36 @@ describe('resolveDeploymentUrl', () => {
     const sb = makeSupabase({ ventureResources: [], ventures: null });
     expect(await resolveDeploymentUrl(sb, 'v1')).toBe('');
   });
+
+  // SD-LEO-FIX-FIX-STAGE-DEPLOYMENT-001 regression guards: the resolver read a
+  // non-existent venture_resources.resource_url column → always '' → S21 false-skip.
+  it('SELECTs the deployment_url column, not resource_url (column-name pin)', async () => {
+    let vrSelect = null;
+    const sb = {
+      from(table) {
+        const q = {
+          select(cols) { if (table === 'venture_resources') vrSelect = cols; return q; },
+          eq() { return q; },
+          limit() { return Promise.resolve({ data: [{ deployment_url: 'https://x.dev/' }], error: null }); },
+          maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        };
+        return q;
+      },
+    };
+    await resolveDeploymentUrl(sb, 'v1');
+    expect(vrSelect).toContain('deployment_url');
+    expect(vrSelect).not.toContain('resource_url');
+  });
+
+  it('does NOT resolve a row carrying only the old resource_url column → "" (guards against reverting)', async () => {
+    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://wrong.dev/' }], ventures: null });
+    expect(await resolveDeploymentUrl(sb, 'v1')).toBe('');
+  });
 });
 
 describe('analyzeStage21VisualAssets — RUN vs SKIP', () => {
   it('RUNS (not skips) for a venture with S11 + S17 + deployment, emitting assets', async () => {
-    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const sb = makeSupabase({ ventureResources: [{ deployment_url: 'https://app.repl.co' }] });
     const out = await analyzeStage21VisualAssets({
       stage11Data: COMPLETE_S11, stage17Data: COMPLETE_S17, stage10Data: {},
       ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
@@ -117,7 +142,7 @@ describe('analyzeStage21VisualAssets — RUN vs SKIP', () => {
   });
 
   it('SKIPS NO_S11_VISUAL_IDENTITY when S11 brand identity is absent', async () => {
-    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const sb = makeSupabase({ ventureResources: [{ deployment_url: 'https://app.repl.co' }] });
     const out = await analyzeStage21VisualAssets({
       stage17Data: COMPLETE_S17, stage10Data: {},
       ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
@@ -127,7 +152,7 @@ describe('analyzeStage21VisualAssets — RUN vs SKIP', () => {
   });
 
   it('SKIPS NO_S17_APPROVED_DESIGNS when S17 designs are absent', async () => {
-    const sb = makeSupabase({ ventureResources: [{ resource_url: 'https://app.repl.co' }] });
+    const sb = makeSupabase({ ventureResources: [{ deployment_url: 'https://app.repl.co' }] });
     const out = await analyzeStage21VisualAssets({
       stage11Data: COMPLETE_S11, stage10Data: {},
       ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -130,13 +130,16 @@ export async function resolveDeploymentUrl(supabase, ventureId) {
   if (!supabase || !ventureId) return '';
   const pick = (row) => {
     if (!row) return '';
-    const url = row.resource_url || row.metadata?.deployment_url || row.metadata?.url || '';
+    // SD-LEO-FIX-FIX-STAGE-DEPLOYMENT-001: venture_resources has no `resource_url`
+    // column — the live deployment URL lives in `deployment_url`. Reading the wrong
+    // column always yielded '' → S21 false-skipped every deployed venture (NO_DEPLOYMENT_URL).
+    const url = row.deployment_url || row.metadata?.deployment_url || row.metadata?.url || '';
     return (typeof url === 'string' && url.trim()) ? url.trim() : '';
   };
   try {
     const { data, error } = await supabase
       .from('venture_resources')
-      .select('resource_url, metadata, status')
+      .select('deployment_url, metadata, status')
       .eq('venture_id', ventureId)
       .eq('resource_type', 'replit_deployment')
       .limit(5);


### PR DESCRIPTION
## SD-LEO-FIX-FIX-STAGE-DEPLOYMENT-001

`resolveDeploymentUrl()` in `lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js` selected + read **`resource_url`** — a column that does not exist on `venture_resources` (real column: **`deployment_url`**, information_schema-confirmed). It therefore always returned `''`, so the Stage 21 preflight reported `venture_resources.deployment_url` missing and **S21 false-skipped every deployed venture** with `NO_DEPLOYMENT_URL`, blocking the post-build pipeline (S21→22→23). Data-verified on DataDistill (510177ba): the row holds a live Replit `deployment_url` while the old code returned `''`.

**Fix (read-side, no schema change):**
- L139 `.select('resource_url, metadata, status')` → `.select('deployment_url, metadata, status')`
- L133 `row.resource_url` → `row.deployment_url` (metadata + `ventures.deployment_url` fallbacks preserved)

**Tests:** updated #4332's preconditions-test mocks (`resource_url`→`deployment_url`) so this column fix doesn't regress its 4 RUN/SKIP assertions, + 2 regression guards (column-name SELECT pin; `resource_url`-only row → `''`). **13/13 pass; 84% line coverage.**

**Out of scope (deferred + signaled):** the legacy `tests/unit/.../stage-21-visual-assets.test.js` has 10 **pre-existing** failures from sibling #4332's `REQUIRED_UPSTREAM` 4→2 contract change (identical on clean main; this PR doesn't touch that file). A separate test-migration QF owns it (RCA-confirmed).

**Gates:** LEAD-TO-PLAN 94 · PLAN-TO-EXEC 92 · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 98. VALIDATION + TESTING PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)