### PR TITLE
fix(SD-LEO-FIX-FIX-STAGE-SKIP-001): stop mislabeled Stage-21 skip-artifact bloat

### DIFF
--- a/lib/eva/__tests__/stage-21-skip-idempotent.test.js
+++ b/lib/eva/__tests__/stage-21-skip-idempotent.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-LEO-FIX-FIX-STAGE-SKIP-001 — regression tests for the Stage 21 skip-marker bloat.
+ *
+ * Root cause (RCA, supersedes the SD's stated replit-reentry-adapter.js:219 diagnosis):
+ *   The worker re-runs S21 every ~30s while a precondition stays unmet. Each run wrote a
+ *   NEW venture_artifacts row, accumulating 380+ duplicates over 6.6 days, AND the row was
+ *   mislabeled `build_security_audit` (the generic orchestrator fallback resolved
+ *   artifactType via the stale stage_artifact_requirements id=18 exit-gate type).
+ *
+ * The fix makes the skip marker idempotent (one row, refreshed in place) and the skip type
+ * is always the canonical `visual_assets_skipped` — never `build_security_audit`. The
+ * orchestrator-side suppression of the generic fallback for `_skip` payloads is verified
+ * separately by inspection (eva-orchestrator.js: the `_skip` branch persists nothing).
+ *
+ * Network-free: the LLM is mocked to throw (forcing the deterministic path) and supabase is
+ * a recording stub that tracks venture_artifacts INSERT vs UPDATE.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => { throw new Error('no-llm-in-test'); } }),
+}));
+
+const { analyzeStage21VisualAssets } = await import('../stage-templates/analysis-steps/stage-21-visual-assets.js');
+
+const COMPLETE_S17 = { s17_approved: true, s17_strategy_recommendation: 'ship' };
+const silent = { info() {}, warn() {}, log() {}, error() {} };
+
+/**
+ * Recording supabase stub. Tracks every venture_artifacts INSERT/UPDATE so the test can
+ * assert idempotency (1 insert + N-1 updates, never N inserts) and that no write ever uses
+ * artifact_type='build_security_audit'. Simulates a single current skip row that the second
+ * call finds and updates.
+ */
+function makeRecordingSupabase() {
+  const writes = []; // { op, table, values }
+  let currentSkipRow = null; // the one is_current visual_assets_skipped row, if any
+  const makeQuery = (table) => {
+    const state = { table, op: 'select', payload: null, filters: {} };
+    const resolve = () => {
+      if (state.op === 'insert') {
+        writes.push({ op: 'insert', table, values: state.payload });
+        if (table === 'venture_artifacts' && state.payload?.artifact_type === 'visual_assets_skipped') {
+          currentSkipRow = { id: 'skip-row-1' };
+        }
+        return { data: null, error: null };
+      }
+      if (state.op === 'update') {
+        writes.push({ op: 'update', table, values: state.payload });
+        return { data: null, error: null };
+      }
+      // select for the existing current skip marker
+      if (table === 'venture_artifacts' && state.filters.artifact_type === 'visual_assets_skipped') {
+        return { data: currentSkipRow ? [currentSkipRow] : [], error: null };
+      }
+      if (table === 'venture_resources') return { data: [], error: null };
+      if (table === 'ventures') return { data: null, error: null };
+      return { data: null, error: null };
+    };
+    const q = {
+      select() { return q; },
+      insert(v) { state.op = 'insert'; state.payload = v; return q; },
+      update(v) { state.op = 'update'; state.payload = v; return q; },
+      eq(col, val) { state.filters[col] = val; return q; },
+      in() { return q; },
+      order() { return q; },
+      limit() { return q; },
+      maybeSingle() { return Promise.resolve(resolve()); },
+      single() { return Promise.resolve(resolve()); },
+      then(onF, onR) { return Promise.resolve(resolve()).then(onF, onR); },
+    };
+    return q;
+  };
+  return { from: (t) => makeQuery(t), __writes: writes };
+}
+
+describe('SD-LEO-FIX-FIX-STAGE-SKIP-001 — S21 skip marker is idempotent and correctly typed', () => {
+  it('writes ONE visual_assets_skipped row across repeated skips (no per-poll bloat)', async () => {
+    const sb = makeRecordingSupabase();
+    const params = {
+      stage11Data: COMPLETE_S17 /* present S17, absent S11 → skip */, stage17Data: COMPLETE_S17,
+      stage10Data: {}, ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    };
+    // Simulate three consecutive worker polls on the same unmet-precondition state.
+    await analyzeStage21VisualAssets({ ...params, stage11Data: undefined });
+    await analyzeStage21VisualAssets({ ...params, stage11Data: undefined });
+    await analyzeStage21VisualAssets({ ...params, stage11Data: undefined });
+
+    const skipWrites = sb.__writes.filter(
+      (w) => w.table === 'venture_artifacts' &&
+        (w.values?.artifact_type === 'visual_assets_skipped' || w.op === 'update')
+    );
+    const inserts = skipWrites.filter((w) => w.op === 'insert');
+    const updates = skipWrites.filter((w) => w.op === 'update');
+    expect(inserts).toHaveLength(1);        // exactly one INSERT (first poll)
+    expect(updates.length).toBeGreaterThanOrEqual(2); // subsequent polls UPDATE in place
+  });
+
+  it('NEVER persists a skip marker typed build_security_audit', async () => {
+    const sb = makeRecordingSupabase();
+    await analyzeStage21VisualAssets({
+      stage17Data: COMPLETE_S17, stage10Data: {},
+      ventureName: 'TestCo', ventureId: 'v1', supabase: sb, logger: silent,
+    });
+    const badTypes = sb.__writes.filter((w) => w.values?.artifact_type === 'build_security_audit');
+    expect(badTypes).toHaveLength(0);
+    const insertedSkip = sb.__writes.find((w) => w.op === 'insert' && w.table === 'venture_artifacts');
+    expect(insertedSkip?.values?.artifact_type).toBe('visual_assets_skipped');
+  });
+});

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -437,6 +437,17 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
               ...(a.gaps ? { gaps: a.gaps } : {}),
             });
           }
+        } else if (stepResult._skip === true) {
+          // SD-LEO-FIX-FIX-STAGE-SKIP-001: a precondition-skip is OWNED by the stage's
+          // own skip-marker writer (e.g. persistSkipMarker → `<stage>_skipped`). Do NOT
+          // persist a generic fallback artifact here: the fallback resolves artifactType
+          // via `requiredArtifacts[0]` (a stale stage exit-gate type — e.g.
+          // `build_security_audit` for S21 Visual Assets, from stage_artifact_requirements
+          // id=18) and, combined with the worker re-run loop, INSERTs a mislabeled
+          // duplicate every ~30s poll (unbounded venture_artifacts bloat: 380+ rows for one
+          // venture over 6.6 days). Suppressing the generic persist for `_skip` payloads
+          // applies to every stage that returns a skip; normal (non-skip) writes unaffected.
+          logger.info?.(`[Eva] Stage ${resolvedStage} step returned _skip (reason=${stepResult.skip_reason || 'unknown'}); skip marker owned by the stage — no generic fallback artifact persisted.`);
         } else {
           artifacts.push({
             artifactType: stepResult.artifactType || step.artifactType || requiredArtifacts[0] || (ARTIFACT_TYPE_BY_STAGE[resolvedStage]?.[0]) || (() => { throw new Error(`No artifact type configured for stage ${resolvedStage} — check stage_artifact_requirements and ARTIFACT_TYPE_BY_STAGE`); })(),

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -294,21 +294,42 @@ async function persistSkipMarker(supabase, ventureId, missing, logger) {
   }
 
   try {
-    const { error } = await supabase
+    // SD-LEO-FIX-FIX-STAGE-SKIP-001: idempotent skip marker. The worker re-runs S21 on
+    // every poll (~30s) while the precondition stays unmet, so a plain INSERT would grow
+    // venture_artifacts unboundedly. Refresh the existing current marker in place; only
+    // INSERT when none exists. Result: exactly one `visual_assets_skipped` row per venture.
+    const artifactData = {
+      skip_reason: skipReason,
+      missing_preconditions: missing.map(m => m.artifact_type),
+      attempted_at: new Date().toISOString(),
+      required_upstream: REQUIRED_UPSTREAM,
+    };
+    const { data: existing } = await supabase
       .from('venture_artifacts')
-      .insert({
-        venture_id: ventureId,
-        lifecycle_stage: 21,
-        artifact_type: 'visual_assets_skipped',
-        is_current: true,
-        source: 'worker_sd_leo_feat_stage_visual_assets_001',
-        artifact_data: {
-          skip_reason: skipReason,
-          missing_preconditions: missing.map(m => m.artifact_type),
-          attempted_at: new Date().toISOString(),
-          required_upstream: REQUIRED_UPSTREAM,
-        },
-      });
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 21)
+      .eq('artifact_type', 'visual_assets_skipped')
+      .eq('is_current', true)
+      .limit(1);
+    let error;
+    if (existing && existing.length > 0) {
+      ({ error } = await supabase
+        .from('venture_artifacts')
+        .update({ artifact_data: artifactData })
+        .eq('id', existing[0].id));
+    } else {
+      ({ error } = await supabase
+        .from('venture_artifacts')
+        .insert({
+          venture_id: ventureId,
+          lifecycle_stage: 21,
+          artifact_type: 'visual_assets_skipped',
+          is_current: true,
+          source: 'worker_sd_leo_feat_stage_visual_assets_001',
+          artifact_data: artifactData,
+        }));
+    }
     if (error) {
       logger?.warn?.(`[S21-VisualAssets] SKIP marker persist error: ${error.message}`);
       return { persisted: false, error: error.message };


### PR DESCRIPTION
## Summary
Stage 21 (Visual Assets) precondition-skips were persisted as **mislabeled, duplicated** `venture_artifacts` rows (`artifact_type='build_security_audit'`, `source='stage-21'`) — **380+ rows for one venture over 6.6 days**, growing ~1 every 30s.

## RCA superseded the SD's stated cause
The SD blamed `replit-reentry-adapter.js:219` — **wrong** (that's the Stage-22 artifact). Real cause (RCA `aefe00a81967282aa`): when the S21 step returns a `_skip` payload, `eva-orchestrator.js` persisted a **generic fallback** artifact whose type resolved via `requiredArtifacts[0]` = the stale `stage_artifact_requirements` id=18 exit-gate type `build_security_audit` (S21 was renumbered to Visual Assets). Combined with the worker's ~30s re-run loop → a new duplicate every poll.

## Fix (contained to `_skip` payloads; normal writes unaffected)
1. **`eva-orchestrator.js`** — when `stepResult._skip===true`, persist **no** generic fallback artifact (the stage owns its skip marker).
2. **`persistSkipMarker` (stage-21-visual-assets.js)** — **idempotent**: UPDATE the existing current `visual_assets_skipped` row in place, INSERT only if none → one row per venture.
3. **Regression test** — repeated skips ⇒ 1 insert + N updates; skip marker never typed `build_security_audit`. (2/2 new, 11/11 existing pass.)

## ⚠️ Deploy-gap (operator action)
The live `stage-execution-worker` runs **OLD** code (proof: `visual_assets_skipped`=0 while `build_security_audit` grew). This fix is inert until the worker **process is RESTARTED** — SYNC → RESTART → CANARY-VERIFY.

## Deferred (follow-ups)
`stage_artifact_requirements` id=18 exit-gate correctness (gating blast-radius); the 380-row cleanup (futile pre-restart); the systemic **S19 (803 rows) / S22 (38 rows)** sibling bloat (coordinator signal `59cb32a7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)