### PR TITLE
feat(SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-D): Adam self-improvement loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
     "checkin": "node scripts/worker-checkin.cjs",
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",
+    "adam:retro": "node scripts/adam-retro.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",

--- a/scripts/adam-retro.cjs
+++ b/scripts/adam-retro.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Adam self-improvement retro loop
+ * SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-D (FR-1/2/3)
+ *
+ * The Adam analog of scripts/coordinator-fleet-retro.mjs. Adam sessions emit an
+ * ADAM-RETRO entry per analysis session (what worked / friction in the
+ * coordinator<->Adam collaboration / one improvement idea). This script:
+ *   (1) CAPTURE: pulls ADAM-RETRO entries from the (ephemeral) coordination
+ *       channel into the durable `feedback` table (category='adam_retro') so they
+ *       survive the coordination sweep and accumulate. Deduped via metadata.retro_key.
+ *   (2) SYNTHESIZE: aggregates recent adam_retro feedback over a rolling 7-day window.
+ *   (3) DISTILL: surfaces the accumulated lessons for incorporation into the
+ *       canonical Adam contract (CLAUDE_ADAM.md / leo_protocol_sections id=601,
+ *       Child C) and the /adam skill (Child A) — it SURFACES a report (mirrors the
+ *       fleet-retro/learn philosophy), it does not silently auto-edit the protocol doc.
+ *
+ * feedback.category is free-text (fleet_retro/coordinator_review added the same way)
+ * → NO migration. Mirrors the coordinator-fleet-retro.mjs insert + dedup shape.
+ *
+ * Usage:
+ *   node scripts/adam-retro.cjs            (capture + synthesize + distill)
+ *   node scripts/adam-retro.cjs distill    (synthesize + distill only)
+ */
+
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+
+const RETRO_RE = /ADAM[\s-]?RETRO/i;
+const ADAM_RETRO_CATEGORY = 'adam_retro';
+
+/** Pure: dedup key for an ADAM-RETRO row (mirrors fleet-retro). Exported for tests. */
+function buildRetroKey(senderSession, createdAt) {
+  return String(senderSession || '').slice(0, 8) + ':' + String(createdAt || '').slice(0, 16);
+}
+
+/** Pure: does a coordination row body look like an ADAM-RETRO? Exported for tests. */
+function isAdamRetro(payload) {
+  const body = String((payload || {}).body || (payload || {}).message || '');
+  return RETRO_RE.test(body);
+}
+
+/** Pure: the durable feedback row for an ADAM-RETRO (mirrors fleet-retro shape). Exported for tests. */
+function buildAdamRetroRow(sig) {
+  const body = String((sig.payload || {}).body || (sig.payload || {}).message || '');
+  const key = buildRetroKey(sig.sender_session, sig.created_at);
+  return {
+    type: 'enhancement',
+    source_application: 'EHG_Engineer',
+    category: ADAM_RETRO_CATEGORY,
+    source_type: 'auto_capture',
+    title: 'Adam retro — ' + key,
+    description: body,
+    status: 'new',
+    severity: 'low',
+    metadata: { retro_key: key, sender_session: sig.sender_session },
+  };
+}
+
+async function main() {
+  const distillOnly = process.argv[2] === 'distill';
+  const db = createSupabaseServiceClient();
+  const t = Date.now();
+  let captured = 0, errs = 0;
+
+  // ── 1) CAPTURE (skipped in distill-only mode) ──
+  if (!distillOnly) {
+    const since = new Date(t - 24 * 3600 * 1000).toISOString();
+    const { data: sigs } = await db.from('session_coordination')
+      .select('id,sender_session,payload,created_at')
+      .gt('created_at', since).order('created_at', { ascending: false }).limit(150);
+    const retros = (sigs || []).filter(s => isAdamRetro(s.payload));
+    for (const s of retros) {
+      const key = buildRetroKey(s.sender_session, s.created_at);
+      const { data: ex } = await db.from('feedback').select('id')
+        .eq('category', ADAM_RETRO_CATEGORY).eq('metadata->>retro_key', key).limit(1);
+      if (ex && ex.length) continue; // idempotent dedup
+      const { error } = await db.from('feedback').insert(buildAdamRetroRow(s));
+      if (error) { errs++; if (errs === 1) console.log('  [insert note] ' + error.message); }
+      else captured++;
+    }
+  }
+
+  // ── 2) SYNTHESIZE: durable adam_retro over a rolling 7-day window ──
+  const since7 = new Date(t - 7 * 24 * 3600 * 1000).toISOString();
+  const { data: all } = await db.from('feedback').select('description,created_at')
+    .eq('category', ADAM_RETRO_CATEGORY).gte('created_at', since7)
+    .order('created_at', { ascending: false }).limit(50);
+
+  console.log('[ADAM-RETRO] captured ' + captured + ' new this run'
+    + (errs ? ' (' + errs + ' insert errors)' : '') + '; ' + (all || []).length + ' adam retros in last 7d.');
+
+  // ── 3) DISTILL: surface lessons for the Adam contract (Child C) + /adam (Child A) ──
+  if ((all || []).length) {
+    console.log('--- recent Adam retros (distill themes; incorporate into the Adam contract) ---');
+    for (const r of (all || []).slice(0, 15)) {
+      console.log('  ' + (r.created_at || '').slice(5, 16) + ' | ' + String(r.description || '').replace(/\s+/g, ' ').slice(0, 170));
+    }
+    console.log('[DISTILL TARGET] Fold recurring lessons into the canonical Adam contract: '
+      + 'leo_protocol_sections id=601 / CLAUDE_ADAM.md (Child C) + the /adam skill (Child A). '
+      + 'Surface a digest to the operator/Adam; do NOT silently auto-edit the protocol doc.');
+  } else {
+    console.log('(no Adam retros yet — Adam emits them per analysis session via /signal, prefix "ADAM-RETRO")');
+  }
+}
+
+module.exports = { buildRetroKey, isAdamRetro, buildAdamRetroRow, RETRO_RE, ADAM_RETRO_CATEGORY };
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}

--- a/scripts/adam-retro.test.js
+++ b/scripts/adam-retro.test.js
@@ -1,0 +1,64 @@
+// Tests for SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-D
+// scripts/adam-retro.cjs (capture helpers) + coordinator-self-review.mjs
+// partitionParticipants (default-OFF byte-identical participant split).
+
+import { describe, it, expect } from 'vitest';
+
+const { buildRetroKey, isAdamRetro, buildAdamRetroRow, ADAM_RETRO_CATEGORY } = require('./adam-retro.cjs');
+import { partitionParticipants } from './coordinator-self-review.mjs';
+
+describe('FR-1: adam-retro capture helpers', () => {
+  it('isAdamRetro matches ADAM-RETRO / ADAM RETRO bodies, ignores others', () => {
+    expect(isAdamRetro({ body: 'ADAM-RETRO: comms latency was high' })).toBe(true);
+    expect(isAdamRetro({ body: 'adam retro - good dependency handling' })).toBe(true);
+    expect(isAdamRetro({ message: 'FLEET-RETRO: not mine' })).toBe(false);
+    expect(isAdamRetro({ body: 'unrelated advisory' })).toBe(false);
+    expect(isAdamRetro(null)).toBe(false);
+  });
+
+  it('buildRetroKey is the fleet-retro-style dedup key (8-char session : 16-char ts)', () => {
+    expect(buildRetroKey('abcdef1234567890', '2026-06-07T12:34:56Z')).toBe('abcdef12:2026-06-07T12:34');
+  });
+
+  it('buildAdamRetroRow mirrors the fleet-retro feedback shape with category=adam_retro', () => {
+    const row = buildAdamRetroRow({ sender_session: 'sess-1234abcd', created_at: '2026-06-07T01:02:03Z', payload: { body: 'ADAM-RETRO: x' } });
+    expect(row.category).toBe(ADAM_RETRO_CATEGORY);
+    expect(row.category).toBe('adam_retro');
+    expect(row.type).toBe('enhancement');             // NOT NULL contract
+    expect(row.source_type).toBe('auto_capture');
+    expect(row.source_application).toBe('EHG_Engineer');
+    expect(row.metadata.retro_key).toBe('sess-123:2026-06-07T01:02'); // dedup lives in metadata, not source_id
+    expect(row.description).toBe('ADAM-RETRO: x');
+  });
+});
+
+describe('FR-4: partitionParticipants (default-OFF byte-identical)', () => {
+  const sessions = [
+    { session_id: 'coord-1', metadata: { is_coordinator: true } },
+    { session_id: 'me-1', metadata: {} },
+    { session_id: 'worker-1', metadata: {} },
+    { session_id: 'worker-2', metadata: { role: 'worker' } },
+    { session_id: 'adam-1', metadata: { role: 'adam', non_fleet: true } },
+  ];
+
+  it('flag OFF: Adam stays in workers (byte-identical to prior behavior), adamParticipants empty', () => {
+    const { workers, adamParticipants } = partitionParticipants(sessions, 'me-1', false);
+    expect(workers.sort()).toEqual(['adam-1', 'worker-1', 'worker-2']); // adam INCLUDED, coordinator + me excluded
+    expect(adamParticipants).toEqual([]);
+  });
+
+  it('flag ON: Adam pulled out of workers into adamParticipants', () => {
+    const { workers, adamParticipants } = partitionParticipants(sessions, 'me-1', true);
+    expect(workers.sort()).toEqual(['worker-1', 'worker-2']); // adam EXCLUDED from worker-framed review
+    expect(adamParticipants).toEqual(['adam-1']);
+  });
+
+  it('always excludes the coordinator and self', () => {
+    const off = partitionParticipants(sessions, 'me-1', false);
+    const on = partitionParticipants(sessions, 'me-1', true);
+    for (const set of [off.workers, on.workers, on.adamParticipants]) {
+      expect(set).not.toContain('coord-1');
+      expect(set).not.toContain('me-1');
+    }
+  });
+});

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -19,8 +19,30 @@ const t = Date.now();
 const STATE = resolve('.coord-review-last.json');
 const REVIEW_EVERY = parseInt(process.env.COORD_REVIEW_EVERY || '8', 10);
 const RE = /COORDINATOR-FEEDBACK|COORD-REVIEW/i;
+// SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-D / FR-5: Adam's reciprocal response marker.
+const ADAM_RE = /ADAM-COORD-FEEDBACK|ADAM-REVIEW/i;
 
-(async () => {
+// SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-D / FR-4: split active sessions into
+// worker vs Adam participants. DEFAULT-OFF (COORD_ADAM_REVIEW_V1): when OFF this is
+// byte-identical to the prior behavior — Adam, like any non-coordinator session,
+// stays in `workers`. When ON, role=adam sessions are pulled OUT of the
+// worker-framed review into their own bidirectional coordinator<->Adam lane so they
+// are not mis-framed with a worker prompt. Pure + exported for unit testing.
+export function partitionParticipants(sess, me, adamReviewOn) {
+  const active = (sess || []).filter(r => !(r.metadata || {}).is_coordinator && r.session_id !== me);
+  const uniq = (rows) => [...new Set(rows.map(r => r.session_id))];
+  if (!adamReviewOn) {
+    return { workers: uniq(active), adamParticipants: [] };
+  }
+  return {
+    workers: uniq(active.filter(r => (r.metadata || {}).role !== 'adam')),
+    adamParticipants: uniq(active.filter(r => (r.metadata || {}).role === 'adam')),
+  };
+}
+
+// SD-...-001-D: wrapped in a named fn + main-guard so partitionParticipants is
+// importable by tests without executing this DB-touching body on import.
+export async function selfReviewMain() {
   // 1) ALWAYS capture responses -> durable feedback (cheap; dedup by metadata.review_key)
   const since = new Date(t - 24 * 3600 * 1000).toISOString();
   const { data: sigs } = await db.from('session_coordination').select('id,sender_session,payload,created_at')
@@ -40,6 +62,25 @@ const RE = /COORDINATOR-FEEDBACK|COORD-REVIEW/i;
     if (!error) captured++;
   }
 
+  // 1b) SD-...-001-D / FR-5: capture Adam's reciprocal responses into a DISTINCT
+  // category (coordinator_adam_review), flag-gated (default-OFF → byte-identical).
+  const adamReviewOn = process.env.COORD_ADAM_REVIEW_V1 === 'on';
+  if (adamReviewOn) {
+    for (const s of (sigs || [])) {
+      const b = String((s.payload || {}).body || (s.payload || {}).message || '');
+      if (!ADAM_RE.test(b)) continue;
+      const key = String(s.sender_session || '').slice(0, 8) + ':' + (s.created_at || '').slice(0, 16);
+      const { data: ex } = await db.from('feedback').select('id').eq('category', 'coordinator_adam_review').eq('metadata->>review_key', key).limit(1);
+      if (ex && ex.length) continue;
+      const { error } = await db.from('feedback').insert({
+        type: 'enhancement', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+        category: 'coordinator_adam_review', status: 'new', severity: 'low',
+        title: 'Coordinator<->Adam review — ' + key, description: b, metadata: { review_key: key, sender_session: s.sender_session }
+      });
+      if (!error) captured++;
+    }
+  }
+
   // 2) WORK GATE — fire the review only after REVIEW_EVERY completed SDs since the last review
   const { count: completedNow } = await db.from('strategic_directives_v2').select('sd_key', { count: 'exact', head: true }).eq('status', 'completed');
   let state = {}; try { state = JSON.parse(readFileSync(STATE, 'utf8')); } catch { state = {}; }
@@ -55,21 +96,36 @@ const RE = /COORDINATOR-FEEDBACK|COORD-REVIEW/i;
 
   // 3) DUE — solicit fresh critique from active workers + synthesize, then reset the counter
   const { data: sess } = await db.from('claude_sessions').select('session_id,metadata,heartbeat_at').gte('heartbeat_at', new Date(t - 30 * 60000).toISOString());
-  const workers = [...new Set((sess || []).filter(r => !(r.metadata || {}).is_coordinator && r.session_id !== me).map(r => r.session_id))];
+  // SD-...-001-D / FR-4: split workers vs Adam participants (default-OFF byte-identical).
+  const { workers, adamParticipants } = partitionParticipants(sess, me, adamReviewOn);
   let solicited = 0;
   const body = 'COORDINATOR-FEEDBACK REQUEST (recurring review of the COORDINATOR, triggered by ' + delta + ' SDs shipped since the last review): candid critique of how the coordinator is running the fleet — (1) what worked (routing/sourcing/RCA/conflict-resolution/keeping you fed), (2) friction caused BY the coordinator (slow/missing replies, mis-routing, bad SD sourcing, unclear guidance, missed signals), (3) ONE concrete thing to do differently. Be blunt. Reply: /signal feedback, prefix "COORDINATOR-FEEDBACK".';
   for (const w of workers) {
     await insertCoordinationRow(db, { target_session: w, sender_session: me, subject: 'Coordinator review (every ' + REVIEW_EVERY + ' SDs) — your candid feedback', message_type: 'COACHING', payload: { kind: 'coordinator_reply', body } });
     solicited++;
   }
+  // SD-...-001-D / FR-5: bidirectional coordinator<->Adam solicitation (default-OFF).
+  let adamSolicited = 0;
+  if (adamReviewOn && adamParticipants.length) {
+    const adamBody = 'ADAM-REVIEW REQUEST (bidirectional coordinator<->Adam review, ' + delta + ' SDs shipped since last review): candid critique of how the COORDINATOR works WITH Adam — (1) assignment clarity, (2) comms latency / reply timeliness on the advisory lane, (3) dependency handling for Adam-sourced work. Adam: reciprocate with your OWN friction. Reply: /signal feedback, prefix "ADAM-COORD-FEEDBACK". Both sides self-improve (coordinator.md + CLAUDE_ADAM.md).';
+    for (const a of adamParticipants) {
+      await insertCoordinationRow(db, { target_session: a, sender_session: me, subject: 'Coordinator<->Adam review (every ' + REVIEW_EVERY + ' SDs) — candid bidirectional feedback', message_type: 'COACHING', payload: { kind: 'coordinator_reply', body: adamBody } });
+      adamSolicited++;
+    }
+  }
   try { writeFileSync(STATE, JSON.stringify({ lastReviewCompletedCount: completedNow, lastReviewAt: t })); } catch {}
 
   const since7 = new Date(t - 14 * 24 * 3600 * 1000).toISOString();
   const { data: all } = await db.from('feedback').select('description,created_at').eq('category', 'coordinator_review').gte('created_at', since7).order('created_at', { ascending: false }).limit(30);
-  console.log('[COORD-REVIEW] DUE (' + delta + ' SDs since last review). captured ' + captured + ' new; solicited ' + solicited + '; ' + ((all || []).length) + ' reviews on file.');
+  console.log('[COORD-REVIEW] DUE (' + delta + ' SDs since last review). captured ' + captured + ' new; solicited ' + solicited + ' worker(s)' + (adamReviewOn ? ' + ' + adamSolicited + ' adam' : '') + '; ' + ((all || []).length) + ' reviews on file.');
   if ((all || []).length) {
     console.log('--- recent coordinator reviews (cluster what-worked / friction / one-fix; ADJUST + source concrete fixes as DRAFT SDs) ---');
     for (const r of (all || []).slice(0, 12)) console.log('  ' + (r.created_at || '').slice(5, 16) + ' | ' + String(r.description || '').replace(/\s+/g, ' ').slice(0, 160));
     console.log('[ACTION] Coordinator: cluster -> ADJUST + source concrete coordinator-tooling fixes as SDs; surface a digest to the operator.');
   }
-})();
+}
+
+// Main-guard: run only when invoked directly (the cron path), not on import (tests).
+if (process.argv[1] && /coordinator-self-review\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
+  selfReviewMain();
+}


### PR DESCRIPTION
Child D (final child) of the ADAM-ROLE-FORMALIZATION orchestrator — the Adam analog of the fleet self-improvement loop + a bidirectional coordinator<->Adam review. No migration (feedback.category is free-text).

- **scripts/adam-retro.cjs**: capture ADAM-RETRO -> durable feedback (category=adam_retro, source_type=auto_capture, type=enhancement, deduped via metadata.retro_key) mirroring coordinator-fleet-retro.mjs; synthesize 7d; distill SURFACES lessons for the Adam contract (CLAUDE_ADAM.md / leo_protocol_sections id=601 + /adam) rather than silently auto-editing.
- **scripts/coordinator-self-review.mjs**: exported pure partitionParticipants() + a main-guard (importable for tests). DEFAULT-OFF COORD_ADAM_REVIEW_V1: flag-OFF byte-identical (Adam stays in workers); flag-ON pulls role=adam into a bidirectional coordinator<->Adam review captured under coordinator_adam_review (so Adam is no longer mis-swept into the worker-framed review).
- **package.json**: adam:retro wired.

6/6 unit tests + 2/2 syntax (capture contract + partitionParticipants flag-OFF byte-identical/flag-ON split). Completes the 4-child epic (A/B/C already merged). Parent: SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)