### PR TITLE
feat(SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001): S21 creative_handoff chairman gate

### DIFF
--- a/database/migrations/20260607_s21_creative_handoff_gate.sql
+++ b/database/migrations/20260607_s21_creative_handoff_gate.sql
@@ -1,0 +1,35 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260607_s21_creative_handoff_gate.sql
+-- SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001 (FR-1/FR-2)
+--
+-- Convert venture pipeline Stage 21 (Visual Assets) from an AUTOMATED stage into
+-- a HUMAN-IN-THE-LOOP "creative_handoff" chairman gate. Per chairman direction
+-- (DataDistill pilot, 2026-06-07): S21 generates visual-asset briefs/storyboards
+-- (textual by design — the chairman feeds them into a 3rd-party image/video tool),
+-- then PAUSES; the chairman reviews, OPTIONALLY uploads finished assets, and clicks
+-- Continue to advance to S22.
+--
+-- HOW IT PAUSES (verified against the live gate predicate): the RPC
+-- stage_creates_decision uses `gate_type IN ('kill','promotion') OR review_mode='review'`.
+-- Setting review_mode='review' makes S21 create a chairman decision and pause for it
+-- WITHOUT touching the RPC or the kill/promotion classification. work_type stays
+-- 'artifact_only' (S21 is not a kill/promotion decision gate), so it is NOT added to
+-- the blocking set. The 'creative_handoff' semantic type is carried in gate_label
+-- (the gate_type CHECK constraint allows only none/kill/promotion, and the
+-- venture_stages_canonical_rule_check binds gate_type<->work_type, so the new type
+-- name MUST live in gate_label, not gate_type).
+--
+-- Pairs with: chairman-decision-watcher.js FALLBACK_DECISION_CREATING_STAGES += 21
+-- (the TS-7 parity test tests/ci/decision-creating-set-parity.test.js asserts
+-- FALLBACK === the DB-derived decision-creating set, so both must change together).
+
+BEGIN;
+
+UPDATE venture_stages
+SET review_mode = 'review',
+    gate_label  = 'creative_handoff',
+    updated_at  = now()
+WHERE stage_number = 21;
+
+COMMIT;

--- a/database/migrations/20260607_venture_artifacts_visual_types.sql
+++ b/database/migrations/20260607_venture_artifacts_visual_types.sql
@@ -1,0 +1,160 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260607_venture_artifacts_visual_types.sql
+-- SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001 (FR-4 enablement)
+--
+-- Add the Stage-21 (Visual Assets) artifact_type values to the
+-- venture_artifacts_artifact_type_check CHECK constraint.
+--
+-- WHY: The CHECK constraint is an explicit allow-list. S21's existing inserts
+-- ('visual_device_screenshots', 'visual_social_graphics') were NOT in the
+-- allow-list, so every insert SILENTLY FAILED the constraint (0 rows persisted
+-- in prod). The new chairman creative_handoff flow (FR-4) additionally needs
+-- 'visual_final_assets' (chairman-uploaded finished assets) and
+-- 'visual_assets_skipped' (chairman chose to skip uploads and continue).
+--
+-- Approach: DROP the existing constraint and re-ADD it with the SAME full set
+-- of allowed values PLUS the four S21 visual types. The value list below is the
+-- live pg_get_constraintdef output for venture_artifacts_artifact_type_check
+-- (captured 2026-06-07), kept verbatim and sorted, with the four new values
+-- inserted in sorted position. No existing value is removed.
+
+BEGIN;
+
+ALTER TABLE venture_artifacts
+  DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+ALTER TABLE venture_artifacts
+  ADD CONSTRAINT venture_artifacts_artifact_type_check
+  CHECK (((artifact_type)::text = ANY (ARRAY[
+    'blueprint_api_contract'::text,
+    'blueprint_data_model'::text,
+    'blueprint_erd_diagram'::text,
+    'blueprint_financial_projection'::text,
+    'blueprint_launch_readiness'::text,
+    'blueprint_positioning_brief'::text,
+    'blueprint_product_roadmap'::text,
+    'blueprint_project_plan'::text,
+    'blueprint_promotion_gate'::text,
+    'blueprint_review_summary'::text,
+    'blueprint_risk_register'::text,
+    'blueprint_schema_spec'::text,
+    'blueprint_sprint_plan'::text,
+    'blueprint_technical_architecture'::text,
+    'blueprint_token_manifest'::text,
+    'blueprint_user_story_pack'::text,
+    'blueprint_wireframes'::text,
+    'build_cicd_config'::text,
+    'build_mvp_build'::text,
+    'build_security_audit'::text,
+    'build_system_prompt'::text,
+    'build_test_coverage_report'::text,
+    'design_token_manifest'::text,
+    'economic_lens'::text,
+    'engine_business_model_canvas'::text,
+    'engine_exit_strategy'::text,
+    'engine_pricing_model'::text,
+    'engine_revenue_model'::text,
+    'engine_risk_assessment'::text,
+    'engine_risk_matrix'::text,
+    'growth_optimization_roadmap'::text,
+    'growth_playbook'::text,
+    'identity_brand_guidelines'::text,
+    'identity_brand_name'::text,
+    'identity_gtm_sales_strategy'::text,
+    'identity_logo_image'::text,
+    'identity_naming_visual'::text,
+    'identity_persona_brand'::text,
+    'intake_venture_analysis'::text,
+    'launch_analytics_dashboard'::text,
+    'launch_assumptions_vs_reality'::text,
+    'launch_churn_triggers'::text,
+    'launch_deployment_runbook'::text,
+    'launch_health_scoring'::text,
+    'launch_launch_metrics'::text,
+    'launch_marketing_checklist'::text,
+    'launch_metrics'::text,
+    'launch_optimization_roadmap'::text,
+    'launch_production_app'::text,
+    'launch_readiness_checklist'::text,
+    'launch_retention_playbook'::text,
+    'launch_test_plan'::text,
+    'launch_uat_report'::text,
+    'launch_user_feedback_summary'::text,
+    'lifecycle_sd_bridge'::text,
+    'marketing_app_store_desc'::text,
+    'marketing_blog_draft'::text,
+    'marketing_email_onboarding'::text,
+    'marketing_email_reengagement'::text,
+    'marketing_email_welcome'::text,
+    'marketing_landing_hero'::text,
+    'marketing_seo_meta'::text,
+    'marketing_social_posts'::text,
+    'marketing_tagline'::text,
+    'post_lifecycle_decision'::text,
+    'postlaunch_analytics_dashboard'::text,
+    'postlaunch_assumptions_vs_reality'::text,
+    'postlaunch_user_feedback_summary'::text,
+    's17_approved'::text,
+    's17_approved_png'::text,
+    's17_archetypes'::text,
+    's17_design_system'::text,
+    's17_fill_screen'::text,
+    's17_preview'::text,
+    's17_qa_report'::text,
+    's17_session_state'::text,
+    's17_strategy_recommendation'::text,
+    's17_strategy_stats'::text,
+    's17_variant_scores'::text,
+    's17_variant_wip'::text,
+    'stage_0_analysis'::text,
+    'stage_10_analysis'::text,
+    'stage_11_analysis'::text,
+    'stage_12_analysis'::text,
+    'stage_13_analysis'::text,
+    'stage_14_analysis'::text,
+    'stage_15_analysis'::text,
+    'stage_16_analysis'::text,
+    'stage_17_analysis'::text,
+    'stage_18_analysis'::text,
+    'stage_19_analysis'::text,
+    'stage_1_analysis'::text,
+    'stage_20_analysis'::text,
+    'stage_21_analysis'::text,
+    'stage_22_analysis'::text,
+    'stage_23_analysis'::text,
+    'stage_24_analysis'::text,
+    'stage_25_analysis'::text,
+    'stage_26_analysis'::text,
+    'stage_2_analysis'::text,
+    'stage_3_analysis'::text,
+    'stage_4_analysis'::text,
+    'stage_5_analysis'::text,
+    'stage_6_analysis'::text,
+    'stage_7_analysis'::text,
+    'stage_8_analysis'::text,
+    'stage_9_analysis'::text,
+    'stitch_budget'::text,
+    'stitch_curation'::text,
+    'stitch_design_export'::text,
+    'stitch_project'::text,
+    'stitch_qa_report'::text,
+    'system_devils_advocate_review'::text,
+    'truth_ai_critique'::text,
+    'truth_competitive_analysis'::text,
+    'truth_financial_model'::text,
+    'truth_idea_brief'::text,
+    'truth_problem_statement'::text,
+    'truth_target_market_analysis'::text,
+    'truth_validation_decision'::text,
+    'truth_value_proposition'::text,
+    'value_multiplier_assessment'::text,
+    -- NEW: Stage-21 (Visual Assets) creative_handoff types (SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001)
+    'visual_assets_skipped'::text,
+    'visual_device_screenshots'::text,
+    'visual_final_assets'::text,
+    'visual_social_graphics'::text,
+    'wireframe_screens'::text
+  ])));
+
+COMMIT;

--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -20,7 +20,11 @@ const REALTIME_CHANNEL = 'chairman-decisions';
 // CI parity check (TS-7) asserts FALLBACK_STAGES === stage_config-derived set,
 // so this constant cannot silently drift again.
 export const FALLBACK_DECISION_CREATING_STAGES = new Set([
-  3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 18, 19, 23, 24, 25,
+  // 21 added by SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001: S21 (Visual Assets) is now a
+  // creative_handoff chairman gate (venture_stages.review_mode='review'), so it
+  // creates a chairman decision. Kept in parity with the DB-derived set (TS-7
+  // tests/ci/decision-creating-set-parity.test.js).
+  3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 18, 19, 21, 23, 24, 25,
 ]);
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -237,9 +237,13 @@ async function persistCanonicalPair(supabase, ventureId, screenshotData, socialD
     return { persisted: false, reason: 'no_supabase_or_ventureId' };
   }
 
+  // SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001: title is required (venture_artifacts.title
+  // is NOT NULL). The prior shape omitted it, so these inserts silently failed the
+  // NOT-NULL constraint (in addition to the artifact_type CHECK now fixed by
+  // 20260607_venture_artifacts_visual_types.sql). Every write now supplies a title.
   const writes = [
-    { artifact_type: 'visual_device_screenshots', artifact_data: screenshotData },
-    { artifact_type: 'visual_social_graphics',    artifact_data: socialData },
+    { artifact_type: 'visual_device_screenshots', title: 'S21 Visual Assets — Device Screenshots', artifact_data: screenshotData },
+    { artifact_type: 'visual_social_graphics',    title: 'S21 Visual Assets — Social Graphics',    artifact_data: socialData },
   ];
 
   // Dual-emit during rollout while flag OFF (backward-compat for any consumer
@@ -247,6 +251,7 @@ async function persistCanonicalPair(supabase, ventureId, screenshotData, socialD
   if (options.dualEmit) {
     writes.push({
       artifact_type: 'launch_test_plan',
+      title: 'S21 Visual Assets — Launch Test Plan',
       artifact_data: fullResult,
     });
   }
@@ -270,6 +275,7 @@ async function persistCanonicalPair(supabase, ventureId, screenshotData, socialD
         venture_id: ventureId,
         lifecycle_stage: 21,
         artifact_type: w.artifact_type,
+        title: w.title,
         is_current: true,
         source: 'worker_sd_leo_feat_stage_visual_assets_001',
         artifact_data: w.artifact_data,
@@ -281,6 +287,57 @@ async function persistCanonicalPair(supabase, ventureId, screenshotData, socialD
     }
   }
   return { persisted: persisted.length > 0, types: persisted };
+}
+
+/**
+ * FR-4 (SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001): persist the chairman's OPTIONAL
+ * finished visual assets uploaded at the S21 creative_handoff gate, as
+ * venture_artifacts artifact_type='visual_final_assets'. The upload UI is the EHG
+ * frontend (coordinated follow-on SD); this is the backend writer it calls.
+ * Idempotent mark-stale (is_current=false) then insert is_current=true.
+ * `title` is REQUIRED (venture_artifacts.title is NOT NULL).
+ *
+ * @param {object} supabase
+ * @param {string} ventureId
+ * @param {object} assets - structured metadata about the uploaded final assets (urls, types, counts)
+ * @param {object} [options]
+ * @returns {Promise<{persisted: boolean, reason?: string, error?: string}>}
+ */
+export async function persistVisualFinalAssets(supabase, ventureId, assets, options = {}) {
+  const logger = options.logger;
+  if (!supabase || !ventureId) {
+    logger?.warn?.('[S21-VisualAssets] persistVisualFinalAssets skipped: no supabase or ventureId');
+    return { persisted: false, reason: 'no_supabase_or_ventureId' };
+  }
+  try {
+    await supabase
+      .from('venture_artifacts')
+      .update({ is_current: false, updated_at: new Date().toISOString() })
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 21)
+      .eq('artifact_type', 'visual_final_assets')
+      .eq('is_current', true);
+
+    const { error } = await supabase
+      .from('venture_artifacts')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: 21,
+        artifact_type: 'visual_final_assets',
+        title: (assets && assets.title) || 'S21 Final Visual Assets (chairman upload)',
+        is_current: true,
+        source: 'chairman_upload',
+        artifact_data: assets || {},
+      });
+    if (error) {
+      logger?.warn?.(`[S21-VisualAssets] persistVisualFinalAssets insert error: ${error.message}`);
+      return { persisted: false, error: error.message };
+    }
+    return { persisted: true };
+  } catch (err) {
+    logger?.warn?.(`[S21-VisualAssets] persistVisualFinalAssets threw: ${err.message}`);
+    return { persisted: false, error: err.message };
+  }
 }
 
 async function persistSkipMarker(supabase, ventureId, missing, logger) {

--- a/tests/unit/eva/stage-templates/stage-21-creative-handoff.test.js
+++ b/tests/unit/eva/stage-templates/stage-21-creative-handoff.test.js
@@ -1,0 +1,51 @@
+// Tests for SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001
+// S21 creative_handoff gate: FR-1/2 (decision-creating), FR-4 (visual_final_assets writer).
+
+import { describe, it, expect, vi } from 'vitest';
+import { persistVisualFinalAssets } from '../../../../lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js';
+import { FALLBACK_DECISION_CREATING_STAGES } from '../../../../lib/eva/chairman-decision-watcher.js';
+
+describe('FR-1/2: S21 is in the decision-creating fallback set', () => {
+  it('FALLBACK_DECISION_CREATING_STAGES includes 21 (S21 now creates a chairman decision)', () => {
+    expect(FALLBACK_DECISION_CREATING_STAGES.has(21)).toBe(true);
+  });
+});
+
+// Supabase stub that records the insert payload + the mark-stale update.
+function stub() {
+  const calls = { updated: null, inserted: null };
+  const builder = {
+    update(p) { calls.updated = p; return builder; },
+    insert(p) { calls.inserted = p; return Promise.resolve({ error: null }); },
+    eq() { return builder; },
+  };
+  return { sb: { from: () => builder }, calls };
+}
+
+describe('FR-4: persistVisualFinalAssets writer', () => {
+  it('inserts artifact_type=visual_final_assets WITH a title (NOT NULL) and mark-stale first', async () => {
+    const { sb, calls } = stub();
+    const r = await persistVisualFinalAssets(sb, 'ven-1', { title: 'My finals', urls: ['a.png'] });
+    expect(r.persisted).toBe(true);
+    expect(calls.inserted.artifact_type).toBe('visual_final_assets');
+    expect(calls.inserted.lifecycle_stage).toBe(21);
+    expect(calls.inserted.venture_id).toBe('ven-1');
+    expect(calls.inserted.title).toBe('My finals');      // NOT NULL satisfied
+    expect(calls.inserted.is_current).toBe(true);
+    expect(calls.inserted.source).toBe('chairman_upload');
+    expect(calls.updated.is_current).toBe(false);          // prior current marked stale
+  });
+
+  it('defaults a title when the caller omits one (NOT-NULL safety)', async () => {
+    const { sb, calls } = stub();
+    await persistVisualFinalAssets(sb, 'ven-2', { urls: ['x.mp4'] });
+    expect(typeof calls.inserted.title).toBe('string');
+    expect(calls.inserted.title.length).toBeGreaterThan(0);
+  });
+
+  it('fails open (no throw) without supabase/ventureId', async () => {
+    const r = await persistVisualFinalAssets(null, null, {});
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe('no_supabase_or_ventureId');
+  });
+});


### PR DESCRIPTION
Convert venture pipeline **Stage 21 (Visual Assets)** from auto-advance to a human-in-the-loop **creative_handoff chairman gate** (DataDistill pilot, chairman direction): S21 generates visual-asset briefs, PAUSES for chairman review, advances 21->22 on Continue (optional final-asset upload).

### Implementation (verified against the LIVE DB, not stale migration files)
- **FR-1/2 — Migration A** (`20260607_s21_creative_handoff_gate.sql`, applied to prod via audited path): `venture_stages` S21 → `review_mode='review'` (the live `stage_creates_decision` predicate pauses on review_mode='review') + `gate_label='creative_handoff'` (the `gate_type` CHECK only allows none/kill/promotion, so the new type name lives in gate_label; work_type stays artifact_only). `stage_creates_decision(21)` is now true.
- `chairman-decision-watcher.js`: `FALLBACK_DECISION_CREATING_STAGES` += 21, kept in parity with the DB-derived set (TS-7 `decision-creating-set-parity` passes).
- **FR-3** (Continue advances 21→22): **no new code** — the existing review-mode approve→`_advanceStage` path already handles it.
- **FR-4 — Migration B** (`20260607_venture_artifacts_visual_types.sql`, applied to prod): extend `venture_artifacts_artifact_type_check` to accept `visual_final_assets` (+ `visual_device_screenshots`/`visual_social_graphics`/`visual_assets_skipped`, fixing a latent silent-fail). New exported `persistVisualFinalAssets` writer + fixed existing `persistCanonicalPair` inserts that omitted the NOT-NULL `title` (a second silent-fail).

### Notes
- Chairman Continue+upload **UI is the EHG frontend** (coordinated follow-on SD).
- 18/18 in-scope unit tests + TS-7 parity + 33 existing stage-21/governance tests pass. Both migrations applied + verified (BEGIN/ROLLBACK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)