### PR TITLE
feat(SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B): S22 distribution spend-approval chairman gate

### DIFF
--- a/database/migrations/20260607_s22_spend_approval_gate.sql
+++ b/database/migrations/20260607_s22_spend_approval_gate.sql
@@ -1,0 +1,40 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260607_s22_spend_approval_gate.sql
+-- SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B (FR-1)
+--
+-- Convert venture pipeline Stage 22 (Distribution Setup) from an AUTOMATED
+-- auto-advance stage into a HUMAN-IN-THE-LOOP "spend_approval" chairman gate.
+-- Today S22 drafts distribution channels, budget allocation, and ad copy, then
+-- auto-advances to S23 (Launch Readiness) with no chairman review before launch
+-- spend. Per chairman direction (post-build lifecycle parity with the S21
+-- creative_handoff gate, SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001): S22 must PAUSE
+-- after drafting so the chairman reviews/edits channels+budget+copy and clicks
+-- Continue before any budget is committed downstream (advances 22 -> 23).
+--
+-- HOW IT PAUSES (verified against the live gate predicate): the RPC
+-- stage_creates_decision uses `gate_type IN ('kill','promotion') OR review_mode='review'`.
+-- Setting review_mode='review' makes S22 create a chairman decision and pause for it
+-- WITHOUT touching the RPC or the kill/promotion classification. work_type stays
+-- 'artifact_only' (S22 is not a kill/promotion decision gate), so it is NOT added to
+-- the blocking set. The 'spend_approval' semantic type is carried in gate_label
+-- (the gate_type CHECK constraint allows only none/kill/promotion, and the
+-- venture_stages_canonical_rule_check binds gate_type<->work_type, so the new type
+-- name MUST live in gate_label, not gate_type).
+--
+-- Pairs with: chairman-decision-watcher.js FALLBACK_DECISION_CREATING_STAGES += 22
+-- (the TS-7 parity test tests/ci/decision-creating-set-parity.test.js asserts
+-- FALLBACK === the DB-derived decision-creating set, so both must change together).
+--
+-- Rollback: UPDATE venture_stages SET review_mode='auto', gate_label=NULL WHERE
+-- stage_number=22; and remove 22 from FALLBACK_DECISION_CREATING_STAGES.
+
+BEGIN;
+
+UPDATE venture_stages
+SET review_mode = 'review',
+    gate_label  = 'spend_approval',
+    updated_at  = now()
+WHERE stage_number = 22;
+
+COMMIT;

--- a/database/migrations/20260607_venture_artifacts_distribution_types.sql
+++ b/database/migrations/20260607_venture_artifacts_distribution_types.sql
@@ -1,0 +1,165 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260607_venture_artifacts_distribution_types.sql
+-- SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B (FR-4 enablement)
+--
+-- Add the Stage-22 (Distribution Setup) artifact_type values to the
+-- venture_artifacts_artifact_type_check CHECK constraint.
+--
+-- WHY: The CHECK constraint is an explicit allow-list. S22's existing inserts
+-- ('distribution_channel_config', 'distribution_ad_copy', 'distribution_skip_marker')
+-- are NOT in the allow-list, so every insert SILENTLY FAILS the constraint
+-- (0 distribution_* rows persisted in prod — confirmed via live probe). The new
+-- chairman spend_approval gate is hollow if the chairman has no drafted
+-- channels/budget/copy to review, so these drafts MUST persist.
+--
+-- Approach: DROP the existing constraint and re-ADD it with the SAME full set of
+-- allowed values PLUS the three S22 distribution types. The value list below is
+-- the live pg_get_constraintdef output for venture_artifacts_artifact_type_check
+-- (post-S21, captured 2026-06-07 and verified live: visual_final_assets is
+-- accepted), kept verbatim and sorted, with the three new values inserted in
+-- sorted position (after 'design_token_manifest', before 'economic_lens').
+-- No existing value is removed.
+
+BEGIN;
+
+ALTER TABLE venture_artifacts
+  DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+ALTER TABLE venture_artifacts
+  ADD CONSTRAINT venture_artifacts_artifact_type_check
+  CHECK (((artifact_type)::text = ANY (ARRAY[
+    'blueprint_api_contract'::text,
+    'blueprint_data_model'::text,
+    'blueprint_erd_diagram'::text,
+    'blueprint_financial_projection'::text,
+    'blueprint_launch_readiness'::text,
+    'blueprint_positioning_brief'::text,
+    'blueprint_product_roadmap'::text,
+    'blueprint_project_plan'::text,
+    'blueprint_promotion_gate'::text,
+    'blueprint_review_summary'::text,
+    'blueprint_risk_register'::text,
+    'blueprint_schema_spec'::text,
+    'blueprint_sprint_plan'::text,
+    'blueprint_technical_architecture'::text,
+    'blueprint_token_manifest'::text,
+    'blueprint_user_story_pack'::text,
+    'blueprint_wireframes'::text,
+    'build_cicd_config'::text,
+    'build_mvp_build'::text,
+    'build_security_audit'::text,
+    'build_system_prompt'::text,
+    'build_test_coverage_report'::text,
+    'design_token_manifest'::text,
+    -- NEW: Stage-22 (Distribution Setup) spend_approval types (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B)
+    'distribution_ad_copy'::text,
+    'distribution_channel_config'::text,
+    'distribution_skip_marker'::text,
+    'economic_lens'::text,
+    'engine_business_model_canvas'::text,
+    'engine_exit_strategy'::text,
+    'engine_pricing_model'::text,
+    'engine_revenue_model'::text,
+    'engine_risk_assessment'::text,
+    'engine_risk_matrix'::text,
+    'growth_optimization_roadmap'::text,
+    'growth_playbook'::text,
+    'identity_brand_guidelines'::text,
+    'identity_brand_name'::text,
+    'identity_gtm_sales_strategy'::text,
+    'identity_logo_image'::text,
+    'identity_naming_visual'::text,
+    'identity_persona_brand'::text,
+    'intake_venture_analysis'::text,
+    'launch_analytics_dashboard'::text,
+    'launch_assumptions_vs_reality'::text,
+    'launch_churn_triggers'::text,
+    'launch_deployment_runbook'::text,
+    'launch_health_scoring'::text,
+    'launch_launch_metrics'::text,
+    'launch_marketing_checklist'::text,
+    'launch_metrics'::text,
+    'launch_optimization_roadmap'::text,
+    'launch_production_app'::text,
+    'launch_readiness_checklist'::text,
+    'launch_retention_playbook'::text,
+    'launch_test_plan'::text,
+    'launch_uat_report'::text,
+    'launch_user_feedback_summary'::text,
+    'lifecycle_sd_bridge'::text,
+    'marketing_app_store_desc'::text,
+    'marketing_blog_draft'::text,
+    'marketing_email_onboarding'::text,
+    'marketing_email_reengagement'::text,
+    'marketing_email_welcome'::text,
+    'marketing_landing_hero'::text,
+    'marketing_seo_meta'::text,
+    'marketing_social_posts'::text,
+    'marketing_tagline'::text,
+    'post_lifecycle_decision'::text,
+    'postlaunch_analytics_dashboard'::text,
+    'postlaunch_assumptions_vs_reality'::text,
+    'postlaunch_user_feedback_summary'::text,
+    's17_approved'::text,
+    's17_approved_png'::text,
+    's17_archetypes'::text,
+    's17_design_system'::text,
+    's17_fill_screen'::text,
+    's17_preview'::text,
+    's17_qa_report'::text,
+    's17_session_state'::text,
+    's17_strategy_recommendation'::text,
+    's17_strategy_stats'::text,
+    's17_variant_scores'::text,
+    's17_variant_wip'::text,
+    'stage_0_analysis'::text,
+    'stage_10_analysis'::text,
+    'stage_11_analysis'::text,
+    'stage_12_analysis'::text,
+    'stage_13_analysis'::text,
+    'stage_14_analysis'::text,
+    'stage_15_analysis'::text,
+    'stage_16_analysis'::text,
+    'stage_17_analysis'::text,
+    'stage_18_analysis'::text,
+    'stage_19_analysis'::text,
+    'stage_1_analysis'::text,
+    'stage_20_analysis'::text,
+    'stage_21_analysis'::text,
+    'stage_22_analysis'::text,
+    'stage_23_analysis'::text,
+    'stage_24_analysis'::text,
+    'stage_25_analysis'::text,
+    'stage_26_analysis'::text,
+    'stage_2_analysis'::text,
+    'stage_3_analysis'::text,
+    'stage_4_analysis'::text,
+    'stage_5_analysis'::text,
+    'stage_6_analysis'::text,
+    'stage_7_analysis'::text,
+    'stage_8_analysis'::text,
+    'stage_9_analysis'::text,
+    'stitch_budget'::text,
+    'stitch_curation'::text,
+    'stitch_design_export'::text,
+    'stitch_project'::text,
+    'stitch_qa_report'::text,
+    'system_devils_advocate_review'::text,
+    'truth_ai_critique'::text,
+    'truth_competitive_analysis'::text,
+    'truth_financial_model'::text,
+    'truth_idea_brief'::text,
+    'truth_problem_statement'::text,
+    'truth_target_market_analysis'::text,
+    'truth_validation_decision'::text,
+    'truth_value_proposition'::text,
+    'value_multiplier_assessment'::text,
+    'visual_assets_skipped'::text,
+    'visual_device_screenshots'::text,
+    'visual_final_assets'::text,
+    'visual_social_graphics'::text,
+    'wireframe_screens'::text
+  ])));
+
+COMMIT;

--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -24,7 +24,11 @@ export const FALLBACK_DECISION_CREATING_STAGES = new Set([
   // creative_handoff chairman gate (venture_stages.review_mode='review'), so it
   // creates a chairman decision. Kept in parity with the DB-derived set (TS-7
   // tests/ci/decision-creating-set-parity.test.js).
-  3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 18, 19, 21, 23, 24, 25,
+  // 22 added by SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B: S22 (Distribution Setup) is now a
+  // spend_approval chairman gate (venture_stages.review_mode='review'), so it creates a
+  // chairman decision and PAUSES before any budget is committed (advances 22->23 on
+  // Continue). Kept in parity with the DB-derived set (same TS-7 parity test).
+  3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 18, 19, 21, 22, 23, 24, 25,
 ]);
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -225,20 +225,25 @@ async function readFeatureFlag(supabase, logger) {
   }
 }
 
-async function persistCanonicalPair(supabase, ventureId, channelConfig, adCopy, fullResult, options) {
+export async function persistCanonicalPair(supabase, ventureId, channelConfig, adCopy, fullResult, options) {
   if (!supabase || !ventureId) {
     options.logger?.warn?.('[S22-Distribution] persistCanonicalPair skipped: no supabase or ventureId');
     return { persisted: false, reason: 'no_supabase_or_ventureId' };
   }
 
+  // venture_artifacts.title is NOT NULL. Omitting it silently fails every insert
+  // (the constraint violation only surfaces as a logger.warn), so the chairman has
+  // no drafted channels/budget/copy to review at the S22 spend_approval gate.
+  // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B FR-4.
   const writes = [
-    { artifact_type: 'distribution_channel_config', artifact_data: channelConfig },
-    { artifact_type: 'distribution_ad_copy',        artifact_data: adCopy },
+    { artifact_type: 'distribution_channel_config', title: 'Distribution channel config', artifact_data: channelConfig },
+    { artifact_type: 'distribution_ad_copy',        title: 'Distribution ad copy',        artifact_data: adCopy },
   ];
 
   if (options.dualEmit) {
     writes.push({
       artifact_type: 'launch_deployment_runbook',
+      title: 'Launch deployment runbook',
       artifact_data: fullResult,
     });
   }
@@ -262,6 +267,7 @@ async function persistCanonicalPair(supabase, ventureId, channelConfig, adCopy, 
         venture_id: ventureId,
         lifecycle_stage: 22,
         artifact_type: w.artifact_type,
+        title: w.title,
         is_current: true,
         source: `worker_sd_leo_feat_stage_distribution_setup_001`,
         artifact_data: w.artifact_data,
@@ -275,7 +281,7 @@ async function persistCanonicalPair(supabase, ventureId, channelConfig, adCopy, 
   return { persisted: persisted.length > 0, types: persisted };
 }
 
-async function persistSkipMarker(supabase, ventureId, missing, logger) {
+export async function persistSkipMarker(supabase, ventureId, missing, logger) {
   if (!supabase || !ventureId) return { persisted: false };
   try {
     const { error } = await supabase
@@ -284,6 +290,7 @@ async function persistSkipMarker(supabase, ventureId, missing, logger) {
         venture_id: ventureId,
         lifecycle_stage: 22,
         artifact_type: 'distribution_skip_marker',
+        title: 'Distribution skipped',  // venture_artifacts.title is NOT NULL (FR-4)
         is_current: true,
         source: 'worker_sd_leo_feat_stage_distribution_setup_001',
         artifact_data: {

--- a/tests/unit/eva/stage-templates/stage-22-spend-approval.test.js
+++ b/tests/unit/eva/stage-templates/stage-22-spend-approval.test.js
@@ -1,0 +1,92 @@
+// Tests for SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B
+// S22 spend_approval gate: FR-2 (decision-creating fallback parity), FR-4 (drafted
+// distribution artifacts persist with a NOT-NULL title + accepted artifact_type).
+
+import { describe, it, expect } from 'vitest';
+import {
+  persistCanonicalPair,
+  persistSkipMarker,
+} from '../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js';
+import { FALLBACK_DECISION_CREATING_STAGES } from '../../../../lib/eva/chairman-decision-watcher.js';
+
+describe('FR-2: S22 is in the decision-creating fallback set', () => {
+  it('FALLBACK_DECISION_CREATING_STAGES includes 22 (S22 now creates a chairman decision)', () => {
+    expect(FALLBACK_DECISION_CREATING_STAGES.has(22)).toBe(true);
+  });
+
+  it('still includes 21 (S22 change must not disturb the S21 gate)', () => {
+    expect(FALLBACK_DECISION_CREATING_STAGES.has(21)).toBe(true);
+  });
+});
+
+// Supabase stub that records every insert payload + every mark-stale update.
+function stub() {
+  const calls = { updates: [], inserts: [] };
+  const builder = {
+    update(p) { calls.updates.push(p); return builder; },
+    insert(p) { calls.inserts.push(p); return Promise.resolve({ error: null }); },
+    eq() { return builder; },
+  };
+  return { sb: { from: () => builder }, calls };
+}
+
+const silent = { warn() {}, info() {} };
+
+describe('FR-4: persistCanonicalPair writes titled, allow-listed distribution artifacts', () => {
+  it('inserts distribution_channel_config + distribution_ad_copy WITH a NOT-NULL title and mark-stale first', async () => {
+    const { sb, calls } = stub();
+    const r = await persistCanonicalPair(
+      sb, 'ven-1',
+      { channels: [], total_channels: 0 },
+      { channels_with_copy: [] },
+      { full: true },
+      { dualEmit: false, logger: silent },
+    );
+    expect(r.persisted).toBe(true);
+    expect(calls.inserts).toHaveLength(2);
+    const byType = Object.fromEntries(calls.inserts.map(i => [i.artifact_type, i]));
+    expect(Object.keys(byType).sort()).toEqual(['distribution_ad_copy', 'distribution_channel_config']);
+    for (const ins of calls.inserts) {
+      expect(typeof ins.title).toBe('string');
+      expect(ins.title.length).toBeGreaterThan(0);   // NOT NULL satisfied
+      expect(ins.lifecycle_stage).toBe(22);
+      expect(ins.venture_id).toBe('ven-1');
+      expect(ins.is_current).toBe(true);
+    }
+    expect(calls.updates).toHaveLength(2);             // prior current marked stale per write
+    expect(calls.updates.every(u => u.is_current === false)).toBe(true);
+  });
+
+  it('dual-emits a titled legacy launch_deployment_runbook when the gate flag is off', async () => {
+    const { sb, calls } = stub();
+    await persistCanonicalPair(sb, 'ven-2', {}, {}, { full: true }, { dualEmit: true, logger: silent });
+    expect(calls.inserts).toHaveLength(3);
+    const legacy = calls.inserts.find(i => i.artifact_type === 'launch_deployment_runbook');
+    expect(legacy).toBeTruthy();
+    expect(typeof legacy.title).toBe('string');
+    expect(legacy.title.length).toBeGreaterThan(0);
+  });
+
+  it('fails open (no throw) without supabase/ventureId', async () => {
+    const r = await persistCanonicalPair(null, null, {}, {}, {}, { logger: silent });
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe('no_supabase_or_ventureId');
+  });
+});
+
+describe('FR-4: persistSkipMarker writes a titled distribution_skip_marker', () => {
+  it('inserts artifact_type=distribution_skip_marker WITH a title (NOT NULL) at lifecycle_stage 22', async () => {
+    const { sb, calls } = stub();
+    const r = await persistSkipMarker(sb, 'ven-3', [{ artifact_type: 'engine_pricing_model', source_stage: 7 }], silent);
+    expect(r.persisted).toBe(true);
+    expect(calls.inserts).toHaveLength(1);
+    expect(calls.inserts[0].artifact_type).toBe('distribution_skip_marker');
+    expect(calls.inserts[0].title).toBe('Distribution skipped');
+    expect(calls.inserts[0].lifecycle_stage).toBe(22);
+  });
+
+  it('fails open (no throw) without supabase/ventureId', async () => {
+    const r = await persistSkipMarker(null, null, []);
+    expect(r.persisted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Convert venture pipeline **Stage 22 (Distribution Setup)** from auto-advance to a human-in-the-loop **spend_approval chairman gate** — the backend mirror of the S21 creative_handoff gate (SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001). The machine drafts channels/budget/copy, S22 PAUSES for chairman review, and advances 22→23 on Continue **before any budget is committed**.

Child of orchestrator SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001.

## Changes
- **Migration A** (`20260607_s22_spend_approval_gate.sql`, FR-1): `venture_stages` S22 → `review_mode='review'` + `gate_label='spend_approval'`. The live `stage_creates_decision` RPC predicate (`gate_type IN (kill,promotion) OR review_mode='review'`) makes S22 create a chairman decision and pause — no RPC/classification change. `work_type` stays `artifact_only`.
- **chairman-decision-watcher.js** (FR-2): `FALLBACK_DECISION_CREATING_STAGES += 22`, kept in TS-7 parity with the DB-derived set.
- **FR-3**: Continue advances 22→23 via the existing review-mode `approve→_advanceStage` path — **no new code**.
- **Migration B** (`20260607_venture_artifacts_distribution_types.sql`) + code (FR-4): extend `venture_artifacts_artifact_type_check` to accept `distribution_channel_config` / `distribution_ad_copy` / `distribution_skip_marker`, and add the **NOT-NULL `title`** omitted by `persistCanonicalPair` / `persistSkipMarker`. These two latent silent-fails meant **0 distribution artifacts ever persisted** — a spend-approval gate is hollow without drafts for the chairman to review.

Both migrations applied to prod via the audited path (BEGIN/ROLLBACK rehearsal + audit row).

## Testing
- 7 new unit tests (`stage-22-spend-approval.test.js`) ✅
- TS-7 `decision-creating-set-parity.test.js` (live DB) ✅
- S21 gate tests + broader stage-22/chairman suites ✅
- Live verification: S22 `review_mode=review`, `stage_creates_decision(22)=true`, `distribution_channel_config` insert now succeeds.

Pre-existing unrelated failures in `chairman-decision-allowlist.test.js` (stages 16/20 hardcoded-list drift) are **not** touched by this change (confirmed identical on `main`).

## Out of scope
Chairman approve/edit/Continue **UI** (EHG frontend, coordinated follow-on, same boundary as S21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)