### PR TITLE
fix(SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001): setActiveCoordinator upsert + heartbeat stamp

### DIFF
--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -176,10 +176,19 @@ async function setActiveCoordinator(supabase, sessionId) {
     coordinator_since: new Date().toISOString()
   };
 
+  // SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001: UPSERT (not UPDATE) so a coordinator
+  // whose session has no claude_sessions row still registers a DB pointer, and stamp a fresh
+  // heartbeat_at + status so getActiveCoordinatorId's freshness check (STALE_THRESHOLD_MIN)
+  // resolves it. The prior UPDATE-only write was a silent no-op when the row was absent and
+  // never bumped heartbeat_at, so the DB pointer was either missing or immediately stale.
   await supabase
     .from('claude_sessions')
-    .update({ metadata: merged })
-    .eq('session_id', sessionId);
+    .upsert({
+      session_id: sessionId,
+      metadata: merged,
+      heartbeat_at: new Date().toISOString(),
+      status: 'active'
+    }, { onConflict: 'session_id' });
 }
 
 async function clearActiveCoordinator(supabase, sessionId, opts = {}) {

--- a/lib/coordinator/resolve.test.js
+++ b/lib/coordinator/resolve.test.js
@@ -74,7 +74,10 @@ function buildSupabaseMock(handlers) {
             })
           })
         }),
-        update: vi.fn().mockReturnValue(updateChain())
+        update: vi.fn().mockReturnValue(updateChain()),
+        // SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001: setActiveCoordinator now writes
+        // claude_sessions via upsert() (awaited directly, no .eq()), so the mock must expose it.
+        upsert: vi.fn().mockResolvedValue({ data: null, error: null })
       };
     })
   };
@@ -173,37 +176,70 @@ describe('RES-9: setActiveCoordinator writes pointer file', () => {
   });
 });
 
-describe('RES-10: setActiveCoordinator merges metadata.is_coordinator', () => {
-  it('preserves existing metadata while adding is_coordinator flag', async () => {
-    let updateCalledWith = null;
-    const sb = {
-      from: vi.fn((table) => {
-        if (table === 'session_coordination') {
-          // No-op drain chain for QF-20260504-964 FIX 2 — only verify metadata merge here.
-          const chain = {
-            eq: vi.fn(() => chain),
-            gte: vi.fn(() => chain),
-            then: (resolve, reject) => Promise.resolve({ data: null, error: null }).then(resolve, reject)
-          };
-          return { update: vi.fn(() => chain) };
-        }
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              maybeSingle: vi.fn().mockResolvedValue({ data: { metadata: { existing_key: 'preserved' } }, error: null })
-            })
-          }),
-          update: vi.fn((payload) => {
-            updateCalledWith = payload;
-            return { eq: vi.fn().mockResolvedValue({ data: null, error: null }) };
-          })
+// Helper: build a supabase mock that captures the claude_sessions upsert payload + options,
+// returning a configurable existing metadata row from the read-then-merge SELECT.
+function buildUpsertCaptureMock(existingMetadata) {
+  const captured = { payload: null, opts: null };
+  const sb = {
+    from: vi.fn((table) => {
+      if (table === 'session_coordination') {
+        // No-op drain chain for QF-20260504-964 FIX 2.
+        const chain = {
+          eq: vi.fn(() => chain),
+          gte: vi.fn(() => chain),
+          then: (resolve, reject) => Promise.resolve({ data: null, error: null }).then(resolve, reject)
         };
-      })
-    };
+        return { update: vi.fn(() => chain) };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: existingMetadata === undefined ? null : { metadata: existingMetadata },
+              error: null
+            })
+          })
+        }),
+        upsert: vi.fn((payload, opts) => {
+          captured.payload = payload;
+          captured.opts = opts;
+          return Promise.resolve({ data: null, error: null });
+        })
+      };
+    })
+  };
+  return { sb, captured };
+}
+
+describe('RES-10: setActiveCoordinator merges metadata.is_coordinator via upsert', () => {
+  it('preserves existing metadata while adding is_coordinator flag (FR-3)', async () => {
+    const { sb, captured } = buildUpsertCaptureMock({ existing_key: 'preserved' });
     await resolve.setActiveCoordinator(sb, 'session-merge');
-    expect(updateCalledWith.metadata.existing_key).toBe('preserved');
-    expect(updateCalledWith.metadata.is_coordinator).toBe(true);
-    expect(updateCalledWith.metadata.coordinator_since).toBeTruthy();
+    expect(captured.payload.metadata.existing_key).toBe('preserved');
+    expect(captured.payload.metadata.is_coordinator).toBe(true);
+    expect(captured.payload.metadata.coordinator_since).toBeTruthy();
+  });
+});
+
+describe('UPSERT-1: setActiveCoordinator inserts when no claude_sessions row exists (FR-1)', () => {
+  it('uses upsert (not a no-op update) keyed on session_id so identity registers', async () => {
+    const { sb, captured } = buildUpsertCaptureMock(undefined); // no existing row
+    await resolve.setActiveCoordinator(sb, 'fresh-coord');
+    expect(captured.payload.session_id).toBe('fresh-coord');
+    expect(captured.payload.metadata.is_coordinator).toBe(true);
+    expect(captured.opts).toEqual({ onConflict: 'session_id' });
+  });
+});
+
+describe('UPSERT-2: setActiveCoordinator stamps fresh heartbeat_at + status (FR-2)', () => {
+  it('writes heartbeat_at ~now and status=active so getActiveCoordinatorId resolves it', async () => {
+    const { sb, captured } = buildUpsertCaptureMock({});
+    await resolve.setActiveCoordinator(sb, 'hb-coord');
+    expect(captured.payload.status).toBe('active');
+    expect(typeof captured.payload.heartbeat_at).toBe('string');
+    const hbMs = new Date(captured.payload.heartbeat_at).getTime();
+    expect(Date.now() - hbMs).toBeGreaterThanOrEqual(0);
+    expect(Date.now() - hbMs).toBeLessThan(10_000); // within 10s of now
   });
 });
 
@@ -240,16 +276,15 @@ describe('DRAIN-1: setActiveCoordinator drains broadcast-coordinator buffer (QF-
             })
           };
         }
-        // claude_sessions chain — same shape as the existing resolve tests
+        // claude_sessions chain — same shape as the existing resolve tests.
+        // SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001: write path is now upsert().
         return {
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
               maybeSingle: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null })
             })
           }),
-          update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: null, error: null })
-          })
+          upsert: vi.fn().mockResolvedValue({ data: null, error: null })
         };
       })
     };


### PR DESCRIPTION
## Summary
`setActiveCoordinator` in `lib/coordinator/resolve.cjs` registered coordinator identity via `.update({metadata}).eq('session_id',…)` — a silent no-op when the coordinator session had no `claude_sessions` row, and it never stamped `heartbeat_at`. Coordinators with no heartbeating row (Windows shared SSE port, `CLAUDE_SESSION_ID` unset) wrote the pointer file but **no resolvable DB pointer**, so `getActiveCoordinatorId` returned null, the inbox reported 'no active coordinator', and worker `/signal` traffic was lost.

This reproduced **live during the build**: the active coordinator `a315e7e7` was invisible to DB resolution.

## Fix
Change the write to:
```js
.upsert({ session_id, metadata: merged, heartbeat_at: new Date().toISOString(), status: 'active' }, { onConflict: 'session_id' })
```
so identity registers even when the row is absent and the freshness check (`STALE_THRESHOLD_MIN`) resolves it. Metadata read-merge and the broadcast-coordinator drain are preserved; read paths and `clearActiveCoordinator` are unchanged. No schema change, no feature flag (restores intended behavior).

## Tests
- Converted `RES-10`/`DRAIN-1`/`buildSupabaseMock` to the upsert write path
- Added `UPSERT-1` (insert-when-missing + `onConflict`) and `UPSERT-2` (`heartbeat_at` ~now + `status='active'`)
- **30/30 vitest pass**; live DB smoke confirmed insert path + idempotent update (no NOT-NULL blocker)

## LEO
SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001 (infrastructure) · gates LEAD-TO-PLAN 93 / PLAN-TO-EXEC 95 / EXEC-TO-PLAN / PLAN-TO-LEAD 99 · retro 90 · validation-agent PASS 92 (4c4cd2f9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)