### PR TITLE
fix(SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001): exempt succeeding polls from RCA blind-retry guard

### DIFF
--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -130,10 +130,26 @@ function digestStderr(stderr) {
     // Skip writes that would yield no signal (no exit code AND no stderr).
     if (exitCode === null && !stderrSha) return;
 
+    // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: capture command_sha so the next PreToolUse
+    // can scope the succeeding-poll exemption to the SAME command (recordAndCount compares
+    // it to bashCmdHash(currentCommand) = sha256(cmd).slice(0,16)). Best-effort; left empty
+    // when the command is unavailable (an empty value never matches a real hash → no false
+    // exemption, preserving fail-open/back-compat).
+    const command =
+      payload.tool_input && typeof payload.tool_input.command === 'string'
+        ? payload.tool_input.command
+        : typeof resp.command === 'string'
+          ? resp.command
+          : '';
+    const commandSha = command
+      ? crypto.createHash('sha256').update(command).digest('hex').slice(0, 16)
+      : '';
+
     const outcome = {
       tool_name: toolName,
       exit_code: exitCode,
       stderr_sha: stderrSha,
+      command_sha: commandSha,
       captured_at: new Date().toISOString(),
     };
 

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -87,12 +87,24 @@ function stateFilePath(sessionId) {
  *        Without it, returns the legacy command-only signature (back-compat).
  * @returns {string|null}
  */
+/**
+ * SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: canonical Bash command hash, shared by
+ * signatureFor() and the succeeding-poll exemption in recordAndCount() so the
+ * command_sha written by post-tool-rca-outcome.cjs compares equal to the current
+ * command's hash.
+ * @param {string} cmd
+ * @returns {string} sha256(cmd) first 16 hex chars
+ */
+function bashCmdHash(cmd) {
+  return crypto.createHash('sha256').update(cmd).digest('hex').slice(0, 16);
+}
+
 function signatureFor(toolName, input, lastOutcome) {
   if (!toolName || !input) return null;
   if (toolName === 'Bash') {
     const cmd = typeof input.command === 'string' ? input.command : '';
     if (!cmd) return null;
-    const hash = crypto.createHash('sha256').update(cmd).digest('hex').slice(0, 16);
+    const hash = bashCmdHash(cmd);
     // Outcome admixture (back-compat: missing/malformed lastOutcome → command-only signature).
     if (
       lastOutcome &&
@@ -316,6 +328,26 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
     return { attempts: 0, signature, rcaResetApplied: false };
   }
 
+  // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: a blind retry is, by definition, re-running
+  // a FAILED command. If the immediately-prior invocation of THIS SAME command exited 0,
+  // this is a succeeding poll (e.g. a recurring monitor cron), not a retry — do not
+  // accumulate toward the 3-strikes guard. COMMAND-SCOPED: lastOutcome.command_sha must
+  // match the current command's hash, so an interleaved success of a DIFFERENT command
+  // can never exempt a genuine failure loop. STRICT: only exit_code 0/'0' exempts;
+  // null/undefined/non-zero codes still accumulate. FAIL-OPEN/back-compat: a legacy
+  // lastOutcome without command_sha (or a non-Bash tool) never exempts.
+  if (toolName === 'Bash') {
+    const lo = opts.lastOutcome;
+    const cmd = typeof (toolInput && toolInput.command) === 'string' ? toolInput.command : '';
+    if (
+      lo && typeof lo === 'object' && cmd &&
+      lo.command_sha === bashCmdHash(cmd) &&
+      (lo.exit_code === 0 || lo.exit_code === '0')
+    ) {
+      return { attempts: 0, signature, rcaResetApplied: false };
+    }
+  }
+
   const now = typeof opts.now === 'number' ? opts.now : Date.now();
   const rcaCheck = opts.rcaCheck || fetchRcaInvocationSince;
 
@@ -353,6 +385,7 @@ module.exports = {
   pruneStale,
   stateFilePath,
   isExempt,
+  bashCmdHash,
   RETRY_WINDOW_MS,
   UUID_REGEX,
   // Test-only export for cache reset between test cases

--- a/tests/unit/retry-state-manager-polling-exemption.test.js
+++ b/tests/unit/retry-state-manager-polling-exemption.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001 — succeeding-poll exemption.
+ *
+ * The RCA tiered-enforcement guard hard-blocks the 3rd invocation of the same
+ * Bash command within 10 minutes. A recurring polling cron that runs an identical
+ * SUCCEEDING command (exit 0, identical stderr) produced an identical signature
+ * every run and false-tripped the block. Fix: a blind retry is re-running a FAILED
+ * command, so recordAndCount exempts an invocation when the immediately-prior
+ * invocation of the SAME command exited 0 (command-scoped via lastOutcome.command_sha).
+ * Failures, unknown exit codes, different commands, and legacy outcomes still accumulate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const { recordAndCount, bashCmdHash } = require('../../scripts/hooks/retry-state-manager.cjs');
+
+const SESSION = 'sess-poll-exemption';
+const POLL_CMD = 'node scripts/fleet-inbox-monitor.cjs --once';
+const OTHER_CMD = 'node scripts/something-else.cjs';
+const noReset = async () => null; // never reset counters from the DB
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-poll-'));
+  process.env.LEO_RETRY_STATE_DIR = tmpDir;
+});
+
+afterEach(() => {
+  delete process.env.LEO_RETRY_STATE_DIR;
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function call(cmd, lastOutcome, now) {
+  return recordAndCount(SESSION, null, 'Bash', { command: cmd }, { rcaCheck: noReset, now, lastOutcome });
+}
+
+describe('recordAndCount succeeding-poll exemption (SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001)', () => {
+  it('succeeding poll x4 (same command, prior exit 0, matching command_sha) never accumulates', async () => {
+    const lo = { exit_code: 0, stderr_sha: '', command_sha: bashCmdHash(POLL_CMD) };
+    for (let i = 0; i < 4; i++) {
+      const r = await call(POLL_CMD, lo, 1000 + i * 1000);
+      expect(r.attempts).toBe(0); // exempted every time → never reaches the 3-strikes block
+    }
+  });
+
+  it('failing command x3 still accumulates and reaches the block threshold', async () => {
+    const lo = { exit_code: 2, stderr_sha: 'deadbeefdeadbeef', command_sha: bashCmdHash(POLL_CMD) };
+    const r1 = await call(POLL_CMD, lo, 1000);
+    const r2 = await call(POLL_CMD, lo, 2000);
+    const r3 = await call(POLL_CMD, lo, 3000);
+    expect(r1.attempts).toBe(1);
+    expect(r2.attempts).toBe(2);
+    expect(r3.attempts).toBe(3); // blind-retry detection preserved (would hard-block)
+  });
+
+  it('interleaved: prior success of a DIFFERENT command does NOT exempt a failing command (command-scoped)', async () => {
+    // lastOutcome is exit 0 but command_sha is for OTHER_CMD, not POLL_CMD.
+    const lo = { exit_code: 0, stderr_sha: '', command_sha: bashCmdHash(OTHER_CMD) };
+    const r = await call(POLL_CMD, lo, 1000);
+    expect(r.attempts).toBe(1); // NOT exempted → accumulates (no leak masking a real retry loop)
+  });
+
+  it('unknown/null exit_code does NOT exempt (strict success check)', async () => {
+    const lo = { exit_code: null, stderr_sha: 'abc', command_sha: bashCmdHash(POLL_CMD) };
+    const r = await call(POLL_CMD, lo, 1000);
+    expect(r.attempts).toBe(1); // null is not success → accumulates
+  });
+
+  it('legacy lastOutcome without command_sha does NOT exempt (back-compat / fail-open)', async () => {
+    const lo = { exit_code: 0, stderr_sha: '' }; // no command_sha (pre-fix outcome file)
+    const r = await call(POLL_CMD, lo, 1000);
+    expect(r.attempts).toBe(1); // command_sha absent → no exemption → current behavior
+  });
+
+  it('missing lastOutcome entirely does NOT exempt (current behavior preserved)', async () => {
+    const r = await call(POLL_CMD, undefined, 1000);
+    expect(r.attempts).toBe(1);
+  });
+
+  it("accepts string '0' exit_code as success (coercion-safe)", async () => {
+    const lo = { exit_code: '0', stderr_sha: '', command_sha: bashCmdHash(POLL_CMD) };
+    const r = await call(POLL_CMD, lo, 1000);
+    expect(r.attempts).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
The RCA tiered-enforcement PreToolUse guard hard-blocks the 3rd invocation of the same Bash command within 10 minutes (to force an rca-agent call before blind retries). It **false-positived on legitimate recurring polling crons**: a 5-min cron running an identical *succeeding* command (exit 0, identical stderr) produced an identical signature every run and tripped the block. SIGNATURE-001 outcome-mixing only discriminates *differing* outcomes; the hardcoded `EXEMPT_PATTERNS` allowlist doesn't generalize.

## Fix
A blind retry is, by definition, re-running a **failed** command — a succeeding re-run is a poll, not a retry. So `recordAndCount` now exempts an invocation when the immediately-prior invocation of the **same** command exited 0.

- **`post-tool-rca-outcome.cjs`**: capture `command_sha = sha256(command).slice(0,16)` in the outcome file.
- **`retry-state-manager.cjs`**: shared `bashCmdHash` helper + command-scoped success exemption — exempt only when `lastOutcome.command_sha === bashCmdHash(currentCommand)` **and** `exit_code === 0`.

**Command-scoped** (so interleaved `[fail A, success B, fail A]` does *not* exempt A — closes the leak flagged by validation-agent), **strict** (null/unknown exit codes still accumulate), and **fail-open/back-compat** (a legacy outcome without `command_sha` never exempts). Failures still block on the 3rd; rca-reset and `EMERGENCY_RCA_BYPASS` unaffected.

## Tests
7 new regression tests (poll ×4 → no block; fail ×3 → still blocks; interleaved-different-command → still accumulates; null / no-command_sha / no-lastOutcome → still accumulate; string-'0' → exempt). **25/25 vitest pass.** Integration smoke confirms producer/consumer `command_sha` agree (`1de700c29687cae3`).

## LEO
SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001 (bugfix, coordinator-assigned) · gates LEAD-TO-PLAN / PLAN-TO-EXEC / EXEC-TO-PLAN 96 / PLAN-TO-LEAD 97 · retro 100 · validation-agent CONDITIONAL_PASS 82 (0dd75353) · testing-agent PASS 95 (acce23f5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)