### PR TITLE
feat(SD-LEO-INFRA-MAKE-OPEN-QFS-001): self-claim open quick_fixes in worker-checkin

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -54,6 +54,7 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 | `resume` | You already claim `sd` | Run `node scripts/sd-start.js <sd>` to (re)attach the worktree, then continue that SD. | On completion, re-run `/checkin`. |
 | `claimed_assignment` | Claimed the coordinator's assigned `sd` via `claim_sd` | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
 | `self_claimed` | No assignment, so claimed the top of `sd:next` (`sd`) | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
+| `self_claimed_qf` | No claimable SD, so self-claimed an open quick-fix (`qf`) from the open-QF queue | Run `node scripts/read-quick-fix.js <qf>`, then the `/quick-fix` workflow (implement ≤50 LOC on branch `qf/<qf>`, run tests, then `node scripts/complete-quick-fix.js <qf>`) — **NOT** `sd-start.js` (it only knows `strategic_directives_v2` and would exit "SD not found" for a QF id). | On completion, re-run `/checkin`. |
 | `idle` | Nothing claimable right now | Call `ScheduleWakeup(delaySeconds=recommended_wakeup_seconds)` (~1200s) and proceed — do **not** wait on a human. | On the next wake, re-run `/checkin`. |
 | `error` | `CLAUDE_SESSION_ID` missing or DB unavailable | Report the `error` field; do not loop blindly. | Fix the cause, then re-run `/checkin`. |
 
@@ -62,7 +63,9 @@ This is an autonomous-fleet contract: a `/loop` worker must keep moving. Decide 
 **The cycle never terminates on its own.** For `resume` / `claimed_assignment` /
 `self_claimed`: build the SD through completion, then **re-run `/checkin`** to pull the next
 one — if you instead just stop after finishing the SD, the loop never fires again and you go
-incognito with a non-empty queue. For `idle`: you MUST have armed a
+incognito with a non-empty queue. For `self_claimed_qf`: work the quick-fix through the
+`/quick-fix` workflow to completion (`complete-quick-fix.js`), then **re-run `/checkin`** —
+same rule, just `read-quick-fix.js` instead of `sd-start.js`. For `idle`: you MUST have armed a
 `ScheduleWakeup(~1200s)` before ending the turn. **Under `/loop` the re-fire is automatic
 (step 1 polls the inbox / runs the check-in cycle each pass); the table above is what you do
 inside each pass.** Running `/checkin` bare (not under `/loop`)? Then arm the `ScheduleWakeup`

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -216,9 +216,14 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
 
   const base = { ok: true, callsign, coordinator: coordinatorId, roll_call_id: rollCall.id, two_way: process.env.COORDINATOR_TWOWAY_V2 === 'on' };
 
-  // 4. already working -> resume
+  // 4. already working -> resume. A self-claimed quick-fix lands in claude_sessions.sd_key
+  // too (claim_sd writes it for QF-% ids), so a QF claim must resume into the /quick-fix
+  // workflow — NOT sd-start, which is SD-only (QFs have no worktree / LEAD-PLAN-EXEC).
   if (mySd) {
-    return { ...base, action: 'resume', sd: mySd, message: `Already claiming ${mySd}; resume work (run sd-start to (re)attach the worktree).` };
+    const isQf = /^QF-/.test(mySd);
+    return { ...base, action: 'resume', sd: mySd, message: isQf
+      ? `Already claiming quick-fix ${mySd}; resume it: node scripts/read-quick-fix.js ${mySd}, then run the /quick-fix workflow (do NOT run sd-start.js for a QF).`
+      : `Already claiming ${mySd}; resume work (run sd-start to (re)attach the worktree).` };
   }
 
   // 5. pending WORK_ASSIGNMENT -> claim via claim_sd RPC

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -32,6 +32,8 @@ const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
 const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
 const DEFAULT_IDLE_WAKEUP_SECONDS = 1200;    // ~20m, matches the fleet idle cadence
 const SELF_CLAIM_CANDIDATE_LIMIT = 5;
+const QF_CANDIDATE_LIMIT = 25;               // open quick_fixes to consider for self-claim
+const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
 
 const SD_KEY_RE = /SD-[A-Z0-9]+(?:-[A-Z0-9]+)+/;
 
@@ -133,6 +135,59 @@ async function ackMessage(sb, id) {
  * id so it is unit-testable without env/network. Returns the resolution object
  * (the same object printed as JSON by the CLI). NEVER throws, NEVER reads stdin.
  */
+/**
+ * Pure predicate: is this quick_fixes row safe to AUTO-start via the worker
+ * self-claim path? Mirrors (inverts) the verify-first gate in
+ * scripts/modules/sd-next/display/quick-fixes.js. Re-implemented INLINE because
+ * worker-checkin.cjs is CommonJS and that module is ESM (package.json
+ * type:module), so it cannot be require()d here. SD-LEO-INFRA-MAKE-OPEN-QFS-001.
+ */
+function isAutoStartableQF(qf, nowMs) {
+  if (!qf || qf.status !== 'open') return false;
+  if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
+  const created = qf.created_at ? Date.parse(qf.created_at) : NaN;
+  if (!Number.isFinite(created)) return false;
+  const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
+  return ageDays < STALE_QF_DAYS;                       // exclude stale/verify-first QFs
+}
+
+/**
+ * Self-claim tier for open quick_fixes — sourced ONLY here because
+ * v_sd_next_candidates is SD-only. Sits strictly BELOW the SD self-claim loop
+ * and ABOVE the idle return, so SD work is always preferred. Reuses the
+ * already-QF-aware claim_sd RPC via tryClaim() (no new RPC/schema); claim_sd is
+ * the authoritative race/liveness arbiter (it refuses a live foreign holder ->
+ * tryClaim ok:false -> we skip to the next QF). Returns a self_claimed_qf result
+ * or null (caller then falls through to idle). Never throws (fail-open).
+ * SD-LEO-INFRA-MAKE-OPEN-QFS-001.
+ */
+async function selfClaimQuickFix(sb, sessionId, base) {
+  try {
+    const { data: qfs } = await sb
+      .from('quick_fixes')
+      .select('id, status, pr_url, commit_sha, created_at')
+      .eq('status', 'open')
+      .is('pr_url', null)
+      .is('commit_sha', null)
+      .order('created_at', { ascending: true })
+      .limit(QF_CANDIDATE_LIMIT);
+    const nowMs = Date.now();
+    for (const qf of (qfs || [])) {
+      if (!isAutoStartableQF(qf, nowMs)) continue;
+      const claimed = await tryClaim(sb, qf.id, sessionId);
+      if (claimed.ok) {
+        return {
+          ...base,
+          action: 'self_claimed_qf',
+          qf: qf.id,
+          message: `Self-claimed quick-fix ${qf.id} from the open-QF queue. Load it: node scripts/read-quick-fix.js ${qf.id} — then run the /quick-fix workflow (implement <=50 LOC on branch qf/${qf.id}, run tests, then node scripts/complete-quick-fix.js ${qf.id}). Do NOT run sd-start.js for a QF. On completion, re-run /checkin.`,
+        };
+      }
+    }
+  } catch { /* fail-open -> caller returns idle */ }
+  return null;
+}
+
 async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinatorId } = {}) {
   // 1. resolve coordinator (fail-open to null -> broadcast)
   let coordinatorId = null;
@@ -191,6 +246,13 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
     }
   } catch { /* fail-open */ }
 
+  // 6.5 self-claim an open quick_fix. v_sd_next_candidates is SD-only, so open
+  // QFs are sourced here — strictly BELOW SD candidates and ABOVE idle, so a
+  // worker pulls an open QF instead of idling, but SD work always wins.
+  // SD-LEO-INFRA-MAKE-OPEN-QFS-001.
+  const qfClaimed = await selfClaimQuickFix(sb, sessionId, base);
+  if (qfClaimed) return qfClaimed;
+
   // 7. idle -> recommend a wakeup (ScheduleWakeup is a HARNESS tool, not Node-callable)
   return {
     ...base,
@@ -217,7 +279,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -34,6 +34,12 @@ const DEFAULT_IDLE_WAKEUP_SECONDS = 1200;    // ~20m, matches the fleet idle cad
 const SELF_CLAIM_CANDIDATE_LIMIT = 5;
 const QF_CANDIDATE_LIMIT = 25;               // open quick_fixes to consider for self-claim
 const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
+// Tier-3 risk keywords (CLAUDE.md Work Item Routing). Auto-self-claim is for small,
+// low-risk QFs only. The sd-next display path excludes _escalate via a LIVE re-triage
+// (runTriageGate, ESM); a .cjs can't run that pipeline, so we approximate parity with the
+// PERSISTED routing_tier PLUS this keyword scan — holding risk-bearing QFs for the
+// triage/human path. SD-LEO-INFRA-MAKE-OPEN-QFS-001 (SECURITY re-triage-parity advisory).
+const TIER3_RISK_RE = /\b(auth|authentication|authorization|rls|payments?|credentials?|migration|schema|alter\s+table|create\s+table|drop\s+table)\b/i;
 
 const SD_KEY_RE = /SD-[A-Z0-9]+(?:-[A-Z0-9]+)+/;
 
@@ -145,6 +151,8 @@ async function ackMessage(sb, id) {
 function isAutoStartableQF(qf, nowMs) {
   if (!qf || qf.status !== 'open') return false;
   if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
+  if (qf.routing_tier != null && Number(qf.routing_tier) >= 3) return false;  // persisted Tier-3 -> full SD, not auto-QF
+  if (TIER3_RISK_RE.test(qf.title || '')) return false;                        // risk-keyword drift -> hold for triage/human
   const created = qf.created_at ? Date.parse(qf.created_at) : NaN;
   if (!Number.isFinite(created)) return false;
   const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
@@ -165,7 +173,7 @@ async function selfClaimQuickFix(sb, sessionId, base) {
   try {
     const { data: qfs } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at')
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title')
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -157,6 +157,15 @@ describe('QF self-claim: isAutoStartableQF predicate (FR-2)', () => {
     const old = freshQF('QF-1', { created_at: new Date(Date.now() - (STALE_QF_DAYS + 1) * DAY).toISOString() });
     expect(isAutoStartableQF(old, Date.now())).toBe(false);
   });
+  it('rejects a persisted Tier-3 QF (routing_tier>=3 -> full SD, not auto-QF)', () => {
+    expect(isAutoStartableQF(freshQF('QF-1', { routing_tier: 3 }), Date.now())).toBe(false);
+    expect(isAutoStartableQF(freshQF('QF-1', { routing_tier: 1 }), Date.now())).toBe(true);
+  });
+  it('rejects a risk-keyword title (untriaged Tier-3 drift), accepts a benign one', () => {
+    expect(isAutoStartableQF(freshQF('QF-1', { title: 'Fix the auth token migration' }), Date.now())).toBe(false);
+    expect(isAutoStartableQF(freshQF('QF-1', { title: 'rotate payment credentials' }), Date.now())).toBe(false);
+    expect(isAutoStartableQF(freshQF('QF-1', { title: 'Tidy a docs typo' }), Date.now())).toBe(true);
+  });
   it('rejects a QF with a missing/invalid created_at', () => {
     expect(isAutoStartableQF(freshQF('QF-1', { created_at: null }), Date.now())).toBe(false);
     expect(isAutoStartableQF(null, Date.now())).toBe(false);
@@ -198,6 +207,15 @@ describe('QF self-claim: runCheckin QF tier (FR-1/3/4/6)', () => {
     const r = await runCheckin(sb, 'sess-1', noCoord);
     expect(r.action).toBe('self_claimed_qf');
     expect(r.qf).toBe('QF-FREE');
+  });
+
+  it('skips a persisted Tier-3 / risk-keyword QF and idles (re-triage parity)', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixes: [
+      freshQF('QF-T3', { routing_tier: 3 }),
+      freshQF('QF-RISK', { title: 'rotate database credentials' }),
+    ] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
   });
 
   it('fails open to idle when the quick_fixes query throws (SD/idle contract intact)', async () => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -94,6 +94,17 @@ describe('FR-2: runCheckin deterministic resolution', () => {
     expect(r.callsign).toBe('Alpha');
   });
 
+  it('resume on a self-claimed QF routes to /quick-fix, NOT sd-start', async () => {
+    const sb = makeStub({ session: { metadata: {}, sd_key: 'QF-20260607-583' } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume');
+    expect(r.sd).toBe('QF-20260607-583');
+    expect(r.message).toMatch(/quick-fix/i);
+    expect(r.message).toMatch(/read-quick-fix\.js QF-20260607-583/);
+    // must NOT use the SD-resume phrasing (which tells the worker to sd-start/re-attach a worktree)
+    expect(r.message).not.toMatch(/re\)?attach the worktree/i);
+  });
+
   it('claims a pending WORK_ASSIGNMENT via claim_sd', async () => {
     const sb = makeStub({
       session: { metadata: {}, sd_key: null },

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, DEFAULT_IDLE_WAKEUP_SECONDS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -54,6 +54,10 @@ function makeStub(cfg) {
         return Promise.resolve({ data: cfg.messages || [], error: null });
       }
       if (table === 'v_sd_next_candidates') return Promise.resolve({ data: cfg.candidates || [], error: null });
+      if (table === 'quick_fixes') {
+        if (cfg.quickFixesThrow) return Promise.reject(new Error('quick_fixes query failed'));
+        return Promise.resolve({ data: cfg.quickFixes || [], error: null });
+      }
       return Promise.resolve({ data: [], error: null });
     }
     function resolveDefault() {
@@ -131,5 +135,81 @@ describe('FR-2: runCheckin deterministic resolution', () => {
     expect(r.action).toBe('idle');
     expect(r.recommended_wakeup_seconds).toBe(DEFAULT_IDLE_WAKEUP_SECONDS);
     expect(r.ok).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-MAKE-OPEN-QFS-001: open quick_fixes are self-claimable below the SD tier.
+const DAY = 24 * 60 * 60 * 1000;
+const freshQF = (id, over = {}) => ({ id, status: 'open', pr_url: null, commit_sha: null, created_at: new Date(Date.now() - 1 * DAY).toISOString(), ...over });
+
+describe('QF self-claim: isAutoStartableQF predicate (FR-2)', () => {
+  it('accepts an open, fresh, no-pr/commit QF', () => {
+    expect(isAutoStartableQF(freshQF('QF-1'), Date.now())).toBe(true);
+  });
+  it('rejects a non-open QF', () => {
+    expect(isAutoStartableQF(freshQF('QF-1', { status: 'in_progress' }), Date.now())).toBe(false);
+  });
+  it('rejects a QF that already has a pr_url or commit_sha (verify-first / merge-race guard)', () => {
+    expect(isAutoStartableQF(freshQF('QF-1', { pr_url: 'http://x' }), Date.now())).toBe(false);
+    expect(isAutoStartableQF(freshQF('QF-1', { commit_sha: 'abc123' }), Date.now())).toBe(false);
+  });
+  it('rejects a stale QF older than STALE_QF_DAYS', () => {
+    const old = freshQF('QF-1', { created_at: new Date(Date.now() - (STALE_QF_DAYS + 1) * DAY).toISOString() });
+    expect(isAutoStartableQF(old, Date.now())).toBe(false);
+  });
+  it('rejects a QF with a missing/invalid created_at', () => {
+    expect(isAutoStartableQF(freshQF('QF-1', { created_at: null }), Date.now())).toBe(false);
+    expect(isAutoStartableQF(null, Date.now())).toBe(false);
+  });
+});
+
+describe('QF self-claim: runCheckin QF tier (FR-1/3/4/6)', () => {
+  const base = { session: { metadata: {}, sd_key: null }, messages: [] };
+
+  it('self-claims an open fresh QF when no SD is claimable, routing to the /quick-fix workflow', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixes: [freshQF('QF-20260601-001')], claimResults: { 'QF-20260601-001': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed_qf');
+    expect(r.qf).toBe('QF-20260601-001');
+    expect(r.message).toMatch(/read-quick-fix\.js/);
+    expect(r.message).toMatch(/complete-quick-fix\.js/);
+    expect(r.message).toMatch(/Do NOT run sd-start\.js/i);  // explicit guard: never route a QF into sd-start
+  });
+
+  it('ALWAYS prefers a claimable SD over a QF (QF tier never reached)', async () => {
+    const sb = makeStub({ ...base, candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }], quickFixes: [freshQF('QF-20260601-001')], claimResults: { 'SD-TOP-001': true, 'QF-20260601-001': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-TOP-001');
+    expect(r.qf).toBeUndefined();
+  });
+
+  it('skips stale and pr/commit QFs, then idles', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixes: [
+      freshQF('QF-OLD', { created_at: new Date(Date.now() - (STALE_QF_DAYS + 2) * DAY).toISOString() }),
+      freshQF('QF-HASPR', { pr_url: 'http://pr' }),
+    ] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+  });
+
+  it('skips a foreign-held QF (claim_sd refuses) to the next claimable QF', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixes: [freshQF('QF-HELD'), freshQF('QF-FREE')], claimResults: { 'QF-HELD': false, 'QF-FREE': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed_qf');
+    expect(r.qf).toBe('QF-FREE');
+  });
+
+  it('fails open to idle when the quick_fixes query throws (SD/idle contract intact)', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixesThrow: true });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+    expect(r.ok).toBe(true);
+  });
+
+  it('claims the first eligible QF in the returned (created_at ascending) order', async () => {
+    const sb = makeStub({ ...base, candidates: [], quickFixes: [freshQF('QF-OLDEST'), freshQF('QF-NEWER')], claimResults: { 'QF-OLDEST': true, 'QF-NEWER': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.qf).toBe('QF-OLDEST');
   });
 });


### PR DESCRIPTION
## Summary
Make open `quick_fixes` self-claimable by autonomous workers. `runCheckin()` (scripts/worker-checkin.cjs) sourced self-claim candidates **only** from `v_sd_next_candidates` (an SD-only view), so a worker went **idle even while open, unworked quick-fixes existed**. This adds a QF self-claim tier — strictly **below** SD candidates and **above** idle — so a worker pulls an open QF instead of idling, while SD work is always preferred.

## How (minimal, reuse-only)
- **New step 6.5** in `runCheckin()`: source open QFs (`status='open'`, `pr_url IS NULL`, `commit_sha IS NULL`, oldest-first, limit 25) → inline pure-CJS freshness predicate `isAutoStartableQF` (`ageDays < SD_NEXT_QF_STALE_DAYS`, default 3) → claim via the **existing** `tryClaim()`/`claim_sd` RPC.
- `claim_sd` is **already QF-aware** (migration `20260306`: branches on `p_sd_id LIKE 'QF-%'`, writes both `claude_sessions` and `quick_fixes.claiming_session_id`+`status='in_progress'`, with a 900s foreign-holder liveness guard) — **verified live** by claiming + restoring `QF-20260607-720`. **No new RPC/schema/column/view.**
- The freshness predicate is **inlined** (~8 lines) because `worker-checkin.cjs` is CommonJS and the display-side helpers are ESM (`package.json` `type:module`) — a `.cjs` can't `require()` them. It reuses the same `SD_NEXT_QF_STALE_DAYS` env var/default so CLI and `sd:next` display agree.
- **New action `self_claimed_qf`** (carries `qf:<id>`) routes the worker to `read-quick-fix.js` + the `/quick-fix` workflow — **not** `sd-start.js` (which only knows `strategic_directives_v2`). Fail-open: any `quick_fixes` error falls through to the unchanged idle return.
- `.claude/commands/checkin.md` action table + prose document the new action.

## Testing
- **20/20** unit tests pass (14 existing handshake + 6 new): SD-always-preferred-over-QF, stale/pr-skip, foreign-holder skip, fail-open-to-idle, oldest-first, and the `isAutoStartableQF` predicate.
- Live (zero-mutation) verification: the sourcing query returns the 2 current open QFs, both correctly auto-startable.

## Out of scope
`claim_sd`/release/stale-session-sweep/orphan-qf-reaper (already QF-aware, unchanged); Tier-3/escalation QFs (only positively-clearable open/fresh/no-pr QFs are self-claimed); in_progress-with-dead-holder reclamation (left to orphan-qf-reaper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)