### PR TITLE
feat(SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001): auto-maintain execution baseline so worker self-claim never silently idles

### DIFF
--- a/lib/fleet/ensure-active-baseline.cjs
+++ b/lib/fleet/ensure-active-baseline.cjs
@@ -1,0 +1,150 @@
+'use strict';
+/**
+ * ensure-active-baseline — SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001
+ *
+ * Auto-maintains the SD execution baseline so worker self-claim never silently idles
+ * with a full queue. worker-checkin self-claim reads v_sd_next_candidates, which JOINs
+ * sd_baseline_items of the baseline WHERE is_active=TRUE; with ZERO active baseline the
+ * view returns 0 rows and EVERY /checkin reports "nothing claimable" — even with workable
+ * draft SDs. (Verified: v_sd_next_candidates flipped 0->14 the instant `sd:baseline create`
+ * ran.) This helper closes that gap: when no active baseline exists, it auto-creates one,
+ * mirroring scripts/sd-baseline.js createBaseline (the proven manual fix).
+ *
+ * Contract: idempotent (creates AT MOST ONE baseline; SELECT short-circuits when one exists),
+ * fail-open (NEVER throws — the whole body is wrapped; any error returns {created:false,
+ * reason:'error:...'}), concurrency-safe (the partial unique index idx_sd_baselines_single_active
+ * makes exactly one winner of a parallel-create race; the loser treats 23505 as a benign no-op).
+ *
+ * LIVE-VERIFIED facts (not migration files — those were stale):
+ *  - sd_baseline_items.sd_id holds the sd_KEY string (e.g. "SD-EHG-WEBSITE-001"), and
+ *    v_sd_next_candidates JOINs sd_baseline_items.sd_id = strategic_directives_v2.sd_key.
+ *    => items MUST be inserted with sd_id = sd.sd_key (matching createBaseline).
+ *  - The view computes deps_satisfied LIVE from dependencies_snapshot vs strategic_directives_v2
+ *    .status and IGNORES the stored is_ready / dependency_health_score columns — so those are
+ *    ornamental defaults here (true / 1.0); a later LEAD rebaseline recomputes them.
+ *
+ * @param {object} sb  an already-constructed supabase service client (injected; unit-testable)
+ * @returns {Promise<{created:boolean, baselineId:string|null, itemCount:number, reason:string}>}
+ */
+async function ensureActiveBaseline(sb) {
+  try {
+    // 1) Short-circuit if an active baseline already exists (idempotent steady state).
+    const { data: existing } = await sb
+      .from('sd_execution_baselines')
+      .select('id')
+      .eq('is_active', true)
+      .maybeSingle();
+    if (existing && existing.id) {
+      return { created: false, baselineId: existing.id, itemCount: 0, reason: 'exists' };
+    }
+
+    // 2) Candidate SDs — SAME query as sd-baseline.js createBaseline (the proven fix).
+    const { data: sds } = await sb
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, sequence_rank, priority, status, dependencies, metadata, progress_percentage')
+      .not('sequence_rank', 'is', null)
+      .in('status', ['draft', 'active', 'in_progress'])
+      .order('sequence_rank')
+      .limit(50);
+    if (!sds || sds.length === 0) {
+      // Genuine empty queue (or no SDs have sequence_rank) — a legitimate idle, not a failure.
+      return { created: false, baselineId: null, itemCount: 0, reason: 'no_sds' };
+    }
+
+    // 3) Insert the baseline (is_active=true). The partial unique index resolves races.
+    const today = new Date().toISOString().split('T')[0];
+    const nowIso = new Date().toISOString();
+    const { data: baseline, error: blErr } = await sb
+      .from('sd_execution_baselines')
+      .insert({
+        baseline_name: `${today} Auto-Maintained Baseline`,
+        baseline_type: 'auto_maintained',
+        is_active: true,
+        created_by: 'auto-maintain',
+        approved_by: 'auto-maintain',
+        approved_at: nowIso,
+        notes: `Auto-created by worker-checkin to unblock self-claim (${sds.length} SDs).`,
+      })
+      .select('id')
+      .maybeSingle();
+
+    if (blErr) {
+      // Lost the create race (peer won) — the active baseline now exists, which is our goal.
+      const code = blErr.code || '';
+      const msg = blErr.message || '';
+      if (code === '23505' || /idx_sd_baselines_single_active|duplicate key/i.test(msg)) {
+        const { data: winner } = await sb
+          .from('sd_execution_baselines')
+          .select('id')
+          .eq('is_active', true)
+          .maybeSingle();
+        return { created: false, baselineId: winner ? winner.id : null, itemCount: 0, reason: 'race_lost' };
+      }
+      return { created: false, baselineId: null, itemCount: 0, reason: `error:${msg || 'baseline_insert_failed'}` };
+    }
+    if (!baseline || !baseline.id) {
+      return { created: false, baselineId: null, itemCount: 0, reason: 'error:baseline_insert_no_id' };
+    }
+
+    // 4) Insert baseline items. sd_id MUST be sd.sd_key (the view JOIN key — live-verified).
+    const items = sds.map((sd) => {
+      const track = (sd.metadata && sd.metadata.execution_track) || 'UNASSIGNED';
+      const trackKey = (track === 'Infrastructure' || track === 'Safety') ? 'A'
+        : track === 'Feature' ? 'B'
+        : track === 'Quality' ? 'C'
+        : track === 'STANDALONE' ? 'STANDALONE' : null;
+      const trackName = trackKey === 'A' ? 'Infrastructure/Safety'
+        : trackKey === 'B' ? 'Feature/Stages'
+        : trackKey === 'C' ? 'Quality'
+        : trackKey === 'STANDALONE' ? 'Standalone' : 'Unassigned';
+      return {
+        baseline_id: baseline.id,
+        sd_id: sd.sd_key, // JOIN key — see header note
+        sequence_rank: sd.sequence_rank,
+        track: trackKey,
+        track_name: trackName,
+        dependencies_snapshot: sd.dependencies != null ? sd.dependencies : null,
+        dependency_health_score: 1.0, // ornamental — view ignores it (computes deps live)
+        is_ready: true, // ornamental — view ignores it
+        notes: (sd.metadata && sd.metadata.rationale) || null,
+      };
+    });
+
+    const { error: itErr } = await sb.from('sd_baseline_items').insert(items);
+    if (itErr) {
+      // Never leave an active-but-empty baseline (it would itself re-cause silent-idle).
+      // Best-effort rollback; the delete must NOT throw out of the helper.
+      try {
+        await sb.from('sd_execution_baselines').delete().eq('id', baseline.id);
+      } catch (_) { /* swallow — orphan superseded by next rebaseline; fail-open */ }
+      return { created: false, baselineId: null, itemCount: 0, reason: `items_failed:${itErr.message || 'items_insert_failed'}` };
+    }
+
+    // 5) Best-effort actuals (view LEFT-JOINs — non-fatal if this fails).
+    try {
+      const actuals = sds.map((sd) => ({
+        sd_id: sd.sd_key,
+        baseline_id: baseline.id,
+        status: sd.progress_percentage > 0 ? 'in_progress' : 'not_started',
+      }));
+      await sb.from('sd_execution_actuals').insert(actuals);
+    } catch (_) { /* swallow — actuals are display/burnrate only */ }
+
+    // 6) Loud notice ONLY now (after baseline+items committed). stderr so it never
+    //    corrupts the JSON-on-stdout that the /checkin skill parses. Never let logging throw.
+    try {
+      console.error(
+        `[ensure-active-baseline] No active execution baseline found — auto-created `
+        + `'${today} Auto-Maintained Baseline' (is_active=true) with ${items.length} SD(s) so worker `
+        + `self-claim has a ranked queue. v_sd_next_candidates is now populated; run \`npm run sd:baseline\` to review or rebaseline.`
+      );
+    } catch (_) { /* swallow logging errors */ }
+
+    return { created: true, baselineId: baseline.id, itemCount: items.length, reason: 'created' };
+  } catch (e) {
+    // Outer guard — the helper NEVER throws; degrades to today's behavior (worker idles).
+    return { created: false, baselineId: null, itemCount: 0, reason: `error:${(e && e.message) || e}` };
+  }
+}
+
+module.exports = { ensureActiveBaseline };

--- a/lib/fleet/ensure-active-baseline.test.js
+++ b/lib/fleet/ensure-active-baseline.test.js
@@ -1,0 +1,134 @@
+/**
+ * Unit tests — SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001
+ * ensureActiveBaseline: auto-create an active execution baseline when none exists so worker
+ * self-claim never silently idles. Network-free: a self-contained fake supabase client +
+ * dependency injection (the helper takes `sb` as an arg) make every path deterministic.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import mod from './ensure-active-baseline.cjs';
+
+const { ensureActiveBaseline } = mod;
+
+// Fake supabase modelling exactly the chains the helper uses.
+function makeFake(cfg = {}) {
+  const calls = { baselineInserts: [], itemInserts: [], deletes: [], actualInserts: [] };
+  let baselineInserted = false;
+  function terminal(st) {
+    if (cfg.throwOnBaselineSelect && st.table === 'sd_execution_baselines' && st.op === 'select') {
+      throw new Error('connection lost');
+    }
+    if (st.table === 'sd_execution_baselines') {
+      if (st.op === 'select') {
+        return { data: baselineInserted ? (cfg.raceWinner || null) : (cfg.activeBaseline || null), error: null };
+      }
+      if (st.op === 'insert') {
+        calls.baselineInserts.push(st.payload);
+        baselineInserted = true;
+        if (cfg.baselineInsertError) return { data: null, error: cfg.baselineInsertError };
+        return { data: { id: cfg.newBaselineId || 'bl-new' }, error: null };
+      }
+      if (st.op === 'delete') { calls.deletes.push(true); return { error: cfg.deleteError || null }; }
+    }
+    if (st.table === 'strategic_directives_v2') return { data: cfg.sds || [], error: null };
+    if (st.table === 'sd_baseline_items' && st.op === 'insert') { calls.itemInserts.push(st.payload); return { error: cfg.itemsInsertError || null }; }
+    if (st.table === 'sd_execution_actuals' && st.op === 'insert') { calls.actualInserts.push(st.payload); return { error: cfg.actualsInsertError || null }; }
+    return { data: null, error: null };
+  }
+  function builder(table) {
+    const st = { table, op: 'select', payload: null };
+    const api = {
+      select: () => api, eq: () => api, in: () => api, not: () => api, order: () => api, limit: () => api,
+      insert: (p) => { st.op = 'insert'; st.payload = p; return api; },
+      delete: () => { st.op = 'delete'; return api; },
+      maybeSingle: () => { try { return Promise.resolve(terminal(st)); } catch (e) { return Promise.reject(e); } },
+      then: (res, rej) => { try { res(terminal(st)); } catch (e) { rej(e); } },
+    };
+    return api;
+  }
+  return { sb: { from: builder }, calls };
+}
+
+let errSpy;
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => { errSpy.mockRestore(); });
+
+describe('ensureActiveBaseline', () => {
+  it('no-op (silent) when an active baseline already exists', async () => {
+    const { sb, calls } = makeFake({ activeBaseline: { id: 'bl-existing' } });
+    const r = await ensureActiveBaseline(sb);
+    expect(r).toEqual({ created: false, baselineId: 'bl-existing', itemCount: 0, reason: 'exists' });
+    expect(calls.baselineInserts).toHaveLength(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates baseline + items (sd_id === sd_key) and logs the notice once', async () => {
+    const sds = [
+      { id: 'u1', sd_key: 'SD-A-001', sequence_rank: 1, status: 'draft', dependencies: [], metadata: {}, progress_percentage: 0 },
+      { id: 'u2', sd_key: 'SD-B-002', sequence_rank: 2, status: 'active', dependencies: ['SD-X'], metadata: { execution_track: 'Feature' }, progress_percentage: 50 },
+    ];
+    const { sb, calls } = makeFake({ activeBaseline: null, sds, newBaselineId: 'bl-new' });
+    const r = await ensureActiveBaseline(sb);
+    expect(r).toEqual({ created: true, baselineId: 'bl-new', itemCount: 2, reason: 'created' });
+    const items = calls.itemInserts[0];
+    expect(items.map((i) => i.sd_id)).toEqual(['SD-A-001', 'SD-B-002']); // JOIN key MUST be sd_key
+    expect(items.map((i) => i.sequence_rank)).toEqual([1, 2]);
+    expect(items[1].track).toBe('B'); // Feature -> B
+    expect(items[0].track).toBeNull(); // unmapped -> null (STANDALONE default downstream)
+    expect(calls.actualInserts).toHaveLength(1);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0][0])).toContain('auto-created');
+  });
+
+  it('treats a 23505 create-race as a benign SILENT no-op (race_lost) and recovers the winner id', async () => {
+    const { sb, calls } = makeFake({
+      activeBaseline: null,
+      sds: [{ id: 'u1', sd_key: 'SD-A-001', sequence_rank: 1, status: 'draft', dependencies: [], metadata: {}, progress_percentage: 0 }],
+      baselineInsertError: { code: '23505', message: 'duplicate key value violates unique constraint "idx_sd_baselines_single_active"' },
+      raceWinner: { id: 'bl-peer-won' },
+    });
+    const r = await ensureActiveBaseline(sb);
+    expect(r).toEqual({ created: false, baselineId: 'bl-peer-won', itemCount: 0, reason: 'race_lost' });
+    expect(calls.itemInserts).toHaveLength(0); // items not attempted after the failed baseline insert
+    expect(errSpy).not.toHaveBeenCalled(); // we did not create it -> no notice
+  });
+
+  it('returns no_sds silently when the candidate query is empty', async () => {
+    const { sb, calls } = makeFake({ activeBaseline: null, sds: [] });
+    const r = await ensureActiveBaseline(sb);
+    expect(r).toEqual({ created: false, baselineId: null, itemCount: 0, reason: 'no_sds' });
+    expect(calls.baselineInserts).toHaveLength(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the orphan baseline when items insert fails (never leaves active-but-empty)', async () => {
+    const { sb, calls } = makeFake({
+      activeBaseline: null,
+      sds: [{ id: 'u1', sd_key: 'SD-A-001', sequence_rank: 1, status: 'draft', dependencies: [], metadata: {}, progress_percentage: 0 }],
+      newBaselineId: 'bl-new',
+      itemsInsertError: { message: 'constraint violation' },
+    });
+    const r = await ensureActiveBaseline(sb);
+    expect(r.created).toBe(false);
+    expect(r.reason).toMatch(/^items_failed/);
+    expect(calls.deletes).toHaveLength(1); // orphan baseline deleted
+    expect(errSpy).not.toHaveBeenCalled(); // no success notice
+  });
+
+  it('is fail-open: an unexpected error is swallowed and returned, never thrown', async () => {
+    const { sb } = makeFake({ throwOnBaselineSelect: true });
+    const r = await ensureActiveBaseline(sb); // must not throw
+    expect(r.created).toBe(false);
+    expect(r.reason).toMatch(/^error:/);
+  });
+
+  it('actuals insert failure is non-fatal (baseline still created)', async () => {
+    const { sb } = makeFake({
+      activeBaseline: null,
+      sds: [{ id: 'u1', sd_key: 'SD-A-001', sequence_rank: 1, status: 'draft', dependencies: [], metadata: {}, progress_percentage: 0 }],
+      newBaselineId: 'bl-new',
+      actualsInsertError: { message: 'actuals boom' },
+    });
+    const r = await ensureActiveBaseline(sb);
+    expect(r).toEqual({ created: true, baselineId: 'bl-new', itemCount: 1, reason: 'created' });
+  });
+});

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -27,6 +27,7 @@
 
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const ws = require('../lib/fleet/worker-status.cjs');
+const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cjs');
 
 const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
 const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
@@ -58,7 +59,8 @@ function extractSdFromAssignment(msg) {
 async function resolveTrack(sb, sdKey, fallback) {
   if (fallback) return fallback;
   try {
-    const { data } = await sb.from('sd_baseline_items').select('track').eq('sd_key', sdKey).maybeSingle();
+    // SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001: column is sd_id (holds the sd_key string), NOT sd_key.
+    const { data } = await sb.from('sd_baseline_items').select('track').eq('sd_id', sdKey).maybeSingle();
     return (data && data.track) || 'STANDALONE';
   } catch {
     return 'STANDALONE';
@@ -176,6 +178,12 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
       base.assignment_claim_error = claimed.error;
     }
   }
+
+  // 5.5 SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001: ensure an active execution baseline exists
+  //      BEFORE reading v_sd_next_candidates. With zero active baseline the view returns 0 rows
+  //      and self-claim silently idles with a full queue. Fail-open: a failure here degrades to
+  //      today's behavior (read returns [] -> idle), never an error action.
+  try { await ensureActiveBaseline(sb); } catch { /* fail-open: never block the checkin */ }
 
   // 6. self-claim top of sd:next (v_sd_next_candidates is baseline-ranked)
   try {


### PR DESCRIPTION
## Summary
**Root cause:** worker-checkin self-claim reads `v_sd_next_candidates`, which JOINs `sd_baseline_items` of the baseline `WHERE is_active=TRUE`. With **zero active baseline** the view returns 0 rows, so every `/checkin` reports "nothing claimable" — even with a full queue of workable draft SDs (verified: the view flips **0→14** the instant `sd:baseline create` runs). This silently idled the whole fleet.

**Fix** (`lib/fleet/ensure-active-baseline.cjs`, fail-open · idempotent · concurrency-safe):
- When no active baseline exists, auto-create one (mirrors the proven `sd-baseline.js createBaseline`), wired **fail-open** into `worker-checkin.cjs` immediately before the candidate read so a fresh baseline makes self-claim non-empty in the same pass.
- NEVER throws (whole body wrapped). The `23505` create-race is a **benign silent no-op** (the partial unique index `idx_sd_baselines_single_active` picks one winner). Items-insert failure **rolls back the orphan** so no active-but-empty baseline persists. Loud stderr notice **only** on actual create.
- Also fixes `resolveTrack` — `sd_baseline_items` has no `sd_key` column (only `sd_id`), so `.eq('sd_key',…)` always fell back to STANDALONE; now `.eq('sd_id',…)`.

**Live-verified** (not migration files — three stale migrations gave three different JOIN keys): `sd_baseline_items.sd_id` holds the **sd_key** string (the view JOIN key); `is_ready`/`dependency_health_score` are ornamental (the view computes deps live).

## Test plan
- `lib/fleet/ensure-active-baseline.test.js` — 7 network-free vitest cases: exists no-op, create with `sd_id===sd_key`, `23505` race_lost (silent), no_sds, items_failed rollback, fail-open, actuals-non-fatal.
- Existing `worker-checkin.test.js` still green (**16/16** total).
- Live **exists-path** validated against the real DB (no fleet disruption — an active baseline currently exists, so the fix is preventive).

Design hardened via a 10-agent design + adversarial-verification workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)