### PR TITLE
fix(SD-FDBK-FIX-STALE-CLAIM-AFTER-001): release claim on SD completion (repair releaseSessionClaim)

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -430,7 +430,11 @@ export async function releaseSessionClaim(sd, supabase) {
     try {
       const { resolveOwnSession } = await import('../../../../../lib/resolve-own-session.js');
       const resolved = await resolveOwnSession(supabase, {
-        select: 'session_id, sd_id, status',
+        // SD-FDBK-FIX-STALE-CLAIM-AFTER-001: claude_sessions has NO sd_id column
+        // (verified live: "column claude_sessions.sd_id does not exist"). The claim
+        // column is sd_key; selecting sd_id made this query error → session null →
+        // release never fired → the claim stayed stale after completion.
+        select: 'session_id, sd_key, status',
         warnOnFallback: false
       });
       if (resolved.data && resolved.source !== 'heartbeat_fallback') {
@@ -453,10 +457,16 @@ export async function releaseSessionClaim(sd, supabase) {
 
     const claimId = sd.sd_key || sd.id;
 
-    if (session.sd_id === claimId) {
+    // SD-FDBK-FIX-STALE-CLAIM-AFTER-001: compare sd_key (the real claim column),
+    // not the non-existent sd_id; otherwise the guard was always false and the
+    // release below never ran.
+    if (session.sd_key === claimId) {
       const { error } = await supabase.rpc('release_sd', {
         p_session_id: session.session_id,
-        p_release_reason: 'completed'
+        // SD-FDBK-FIX-STALE-CLAIM-AFTER-001: the live release_sd signature is
+        // (p_session_id, p_reason); p_release_reason caused PGRST202 ("function not
+        // found"), so even a reached guard would have silently failed to release.
+        p_reason: 'completed'
       });
 
       if (error) {

--- a/tests/unit/stale-claim-release-on-completion.test.js
+++ b/tests/unit/stale-claim-release-on-completion.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-FDBK-FIX-STALE-CLAIM-AFTER-001 — releaseSessionClaim actually releases on completion.
+ *
+ * LEAD-FINAL's releaseSessionClaim() was triply broken, so the claim was NEVER released
+ * after an SD completed → /checkin then returned action='resume' for the just-completed SD
+ * and a worker would loop on completed work:
+ *   (1) it selected a non-existent column sd_id (claude_sessions's claim column is sd_key),
+ *       so the resolve query errored and the session resolved null;
+ *   (2) it guarded on `session.sd_id === claimId` which was always false (no sd_id field);
+ *   (3) it called release_sd with `p_release_reason`, but the live RPC signature is
+ *       release_sd(p_session_id, p_reason) — p_release_reason returns PGRST202.
+ * These tests pin the corrected behavior.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const { resolveOwnSession } = vi.hoisted(() => ({ resolveOwnSession: vi.fn() }));
+vi.mock('../../lib/resolve-own-session.js', () => ({ resolveOwnSession }));
+vi.mock('../../lib/heartbeat-manager.mjs', () => ({
+  isHeartbeatActive: () => ({ active: false, sessionId: null }),
+  stopHeartbeat: vi.fn(),
+}));
+vi.mock('../../lib/session-manager.mjs', () => ({ getOrCreateSession: vi.fn().mockResolvedValue(null) }));
+
+import { releaseSessionClaim } from '../../scripts/modules/handoff/executors/lead-final-approval/helpers.js';
+
+const okRpc = () => vi.fn().mockResolvedValue({ error: null });
+
+beforeEach(() => { resolveOwnSession.mockReset(); });
+
+describe('releaseSessionClaim (SD-FDBK-FIX-STALE-CLAIM-AFTER-001)', () => {
+  test('releases via release_sd with p_reason when the session holds the completed SD (by sd_key)', async () => {
+    resolveOwnSession.mockResolvedValue({ data: { session_id: 'sess-1', sd_key: 'SD-X-001', status: 'active' }, source: 'terminal_id' });
+    const sb = { rpc: okRpc() };
+    await releaseSessionClaim({ sd_key: 'SD-X-001' }, sb);
+    expect(sb.rpc).toHaveBeenCalledTimes(1);
+    const [fn, args] = sb.rpc.mock.calls[0];
+    expect(fn).toBe('release_sd');
+    expect(args).toEqual({ p_session_id: 'sess-1', p_reason: 'completed' });
+    expect(args.p_release_reason).toBeUndefined(); // the old, broken arg name must be gone
+  });
+
+  test('guard scopes by sd_key: does NOT release when the session holds a different SD', async () => {
+    resolveOwnSession.mockResolvedValue({ data: { session_id: 'sess-2', sd_key: 'SD-OTHER-001', status: 'active' }, source: 'terminal_id' });
+    const sb = { rpc: okRpc() };
+    await releaseSessionClaim({ sd_key: 'SD-X-001' }, sb);
+    expect(sb.rpc).not.toHaveBeenCalled();
+  });
+
+  test('resolves the session selecting sd_key, never the non-existent sd_id', async () => {
+    resolveOwnSession.mockResolvedValue({ data: { session_id: 's', sd_key: 'SD-X-001', status: 'active' }, source: 'terminal_id' });
+    await releaseSessionClaim({ sd_key: 'SD-X-001' }, { rpc: okRpc() });
+    const opts = resolveOwnSession.mock.calls[0][1];
+    expect(opts.select).toContain('sd_key');
+    expect(opts.select).not.toContain('sd_id');
+  });
+
+  test('falls back to sd.id as the claim id when sd_key is absent', async () => {
+    resolveOwnSession.mockResolvedValue({ data: { session_id: 's3', sd_key: 'UUID-123', status: 'active' }, source: 'terminal_id' });
+    const sb = { rpc: okRpc() };
+    await releaseSessionClaim({ id: 'UUID-123' }, sb); // no sd_key on the SD record
+    expect(sb.rpc).toHaveBeenCalledTimes(1);
+    expect(sb.rpc.mock.calls[0][1]).toEqual({ p_session_id: 's3', p_reason: 'completed' });
+  });
+
+  test('fail-open: a release error never throws (completion must not be blocked)', async () => {
+    resolveOwnSession.mockResolvedValue({ data: { session_id: 's', sd_key: 'SD-X-001', status: 'active' }, source: 'terminal_id' });
+    const sb = { rpc: vi.fn().mockResolvedValue({ error: { message: 'boom' } }) };
+    await expect(releaseSessionClaim({ sd_key: 'SD-X-001' }, sb)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
After an SD reaches LEAD-FINAL-APPROVAL the worker's claim should be released so the next `/checkin` moves on. It wasn't — `releaseSessionClaim()` (`scripts/modules/handoff/executors/lead-final-approval/helpers.js`) was **triply broken**, so `release_sd` never fired and `claude_sessions.sd_key` + `strategic_directives_v2.claiming_session_id` stayed stale. `/checkin` step-4 reads `sd_key` and returns `action='resume'`, so a worker **looped on the just-completed SD** (hit twice this session; manual claim-clears were needed).

## Root cause (all verified live)
1. selected non-existent column `sd_id` — `claude_sessions`'s claim column is `sd_key` (live: *"column claude_sessions.sd_id does not exist"*) → the resolve query errored → session resolved null.
2. guard `session.sd_id === claimId` was **always false** → `release_sd` unreachable.
3. called `release_sd` with `p_release_reason`, but the live signature is `release_sd(p_session_id, p_reason)` (`p_release_reason` → PGRST202).

## Fix
**3 single-token edits** so the *existing* release fires: `sd_key` select, `sd_key` guard, `p_reason` arg. `release_sd` then NULLs `claude_sessions.sd_key`/worktree cols (satisfying `ck_claude_sessions_worktree_state_consistency`) **and** the SD's `claiming_session_id`/`active_session_id`/`is_working_on`. `/checkin` then sees `sd_key=NULL` and falls through to idle — **no `/checkin` band-aid** (rejected: it would mask the symptom while leaving the claim columns poisoned for fleet identity/sweep). **Tail-safety verified**: the post-completion tail + Stop hook key off `sd_key`/state-file, never the claim, and the release already runs after the tail-state file is written.

## Tests
5 vitest regression tests (`p_reason` arg, `sd_key` guard scoping, `sd_key` select, `sd.id` fallback, fail-open). **16/16 pass** (incl. the sibling claim-guard suite — no regression). Live `release_sd` signature reconfirmed (`p_reason` OK, `p_release_reason` PGRST202).

## LEO
bugfix · coordinator-flagged · gates 93/94/96/98 · retro 100 · validation-agent PASS 92 (a7ee6d00) · testing-agent PASS 95 (9cdfc1c4). Out of scope (follow-ups): orphan `enforce_completed_phase_alignment()`; backfill of already-stuck completed SDs (0 currently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)