### PR TITLE
fix(SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001): genuine-worker count in coordinator-audit (shared predicate)

### DIFF
--- a/lib/fleet/genuine-worker.mjs
+++ b/lib/fleet/genuine-worker.mjs
@@ -1,0 +1,47 @@
+// SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001 — single source of truth for "is this
+// claude_sessions row a GENUINE fleet worker", so the coordinator audit, the
+// executive email, and the dashboard never disagree on the worker count.
+//
+// Extracted verbatim from coordinator-email-summary.mjs (QF-20260607-608), which
+// itself mirrors fleet-dashboard.cjs's worker-set QA. The bug this closes: each
+// consumer had its own inline copy and they drifted — coordinator-audit.mjs counted
+// every session heartbeating <15m regardless of role/status/claim-history, so its
+// FLOW/LIVENESS gauges over-counted Adam, non_fleet, released, and never-claimed
+// (ghost) sessions.
+//
+// A genuine worker is:
+//   1. NOT the coordinator, NOT Adam (metadata.role==='adam'), NOT non_fleet;
+//   2. live by status — only 'active'/'idle' (released/exited/stale are warm ghosts);
+//   3. has EVER held a claim (everClaimed) — drops transient sessions that registered
+//      but never claimed.
+
+/** Ghost-filter: has this session ever held a claim? */
+export const everClaimed = (s) =>
+  !!(s.sd_key || s.claimed_at || s.worktree_path || (s.continuous_sds_completed > 0));
+
+/**
+ * Is this claude_sessions row a genuine fleet worker (excluding the coordinator)?
+ * @param {object} s - claude_sessions row (needs session_id, status, metadata, and the everClaimed columns)
+ * @param {string} coordinatorId - the active coordinator's session_id (excluded)
+ */
+export const isFleetWorker = (s, coordinatorId) =>
+  s.session_id !== coordinatorId &&
+  s.metadata?.role !== 'adam' &&
+  !s.metadata?.non_fleet &&
+  ['active', 'idle'].includes(s.status) &&
+  everClaimed(s);
+
+/**
+ * Filter a list of sessions to the LIVE genuine workers (genuine + heartbeat within window).
+ * @param {Array<object>} sessions
+ * @param {string} coordinatorId
+ * @param {number} nowMs - current time in ms
+ * @param {number} [windowMs=900000] - liveness window (default 15 min, matches the sweep)
+ */
+export const liveFleetWorkers = (sessions, coordinatorId, nowMs, windowMs = 900000) =>
+  (sessions || []).filter(
+    (s) =>
+      isFleetWorker(s, coordinatorId) &&
+      s.heartbeat_at &&
+      nowMs - new Date(s.heartbeat_at).getTime() < windowMs
+  );

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 import { countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
+import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -41,9 +42,12 @@ const unclaimed = sds.filter(s => !s.claiming_session_id);
 const claimed = sds.length - unclaimed.length;
 const stuck = unclaimed.filter(s => s.status === 'in_progress');
 
-// workers
-const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state').order('heartbeat_at', { ascending: false }).limit(60);
-const live = (sessRaw || []).filter(s => s.session_id !== me && s.heartbeat_at && (t - new Date(s.heartbeat_at).getTime()) < 900000);
+// workers — SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001: count GENUINE workers via the shared
+// predicate (same one coordinator-email-summary.mjs uses, mirroring the dashboard) so the
+// audit's FLOW/LIVENESS gauges stop over-counting Adam / non_fleet / released / never-claimed
+// (ghost) sessions. Previously this only excluded `me` and any heartbeat <15m.
+const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,metadata,claimed_at,worktree_path,continuous_sds_completed').order('heartbeat_at', { ascending: false }).limit(60);
+const live = liveFleetWorkers(sessRaw, me, t);
 const builders = live.filter(s => s.sd_key).length;
 const liveIdle = live.filter(s => !s.sd_key).length;
 

--- a/scripts/coordinator-email-summary.mjs
+++ b/scripts/coordinator-email-summary.mjs
@@ -15,6 +15,7 @@ import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { readFileSync, writeFileSync } from 'fs';
+import { liveFleetWorkers, isFleetWorker } from '../lib/fleet/genuine-worker.mjs';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -60,10 +61,10 @@ const { data: sessRaw } = await db.from('claude_sessions').select('session_id,he
 //   3. ghost-filter — only a session that has EVER held a claim (current sd_key, or claimed_at /
 //      worktree_path / continuous_sds_completed history) is a worker; drops transient/churning sessions
 //      that registered but never claimed.
-const everClaimed = (s) => !!(s.sd_key || s.claimed_at || s.worktree_path || (s.continuous_sds_completed > 0));
-const isFleetWorker = (s) => s.session_id !== me && s.metadata?.role !== 'adam' && !s.metadata?.non_fleet
-  && ['active', 'idle'].includes(s.status) && everClaimed(s);
-const live = (sessRaw || []).filter(s => isFleetWorker(s) && s.heartbeat_at && (t - new Date(s.heartbeat_at).getTime()) < 900000);
+// SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001: the genuine-worker predicate now lives in
+// lib/fleet/genuine-worker.mjs (shared verbatim with coordinator-audit.mjs) so the email
+// and the audit can never disagree on the worker count.
+const live = liveFleetWorkers(sessRaw, me, t);
 const builderKeys = new Set(live.filter(s => s.sd_key).map(s => s.sd_key));
 const liveWorkers = live.length;
 const builders = live.filter(s => s.sd_key).length;
@@ -137,7 +138,7 @@ const shippedSince = (typeof snap.completedCount === 'number') ? Math.max(0, (co
 //   parked/quiet provisioned worker keeps showing as "incognito" until it's genuinely gone, and
 //   report TOTAL provisioned headcount (= live + incognito), not just live.
 const PROVISIONED_WINDOW = parseInt(process.env.COORD_PROVISIONED_WINDOW_MIN || '480', 10) * 60000;
-const recentSeen = (sessRaw || []).filter(s => isFleetWorker(s) && s.heartbeat_at && (t - new Date(s.heartbeat_at).getTime()) < PROVISIONED_WINDOW);
+const recentSeen = (sessRaw || []).filter(s => isFleetWorker(s, me) && s.heartbeat_at && (t - new Date(s.heartbeat_at).getTime()) < PROVISIONED_WINDOW);
 const incognito = Math.max(0, recentSeen.length - liveWorkers);   // provisioned but quiet >15m = incognito (needs a wake re-paste)
 const totalWorkers = liveWorkers + incognito;                     // TRUE provisioned headcount the operator stood up
 

--- a/tests/unit/fleet/genuine-worker.test.js
+++ b/tests/unit/fleet/genuine-worker.test.js
@@ -1,0 +1,85 @@
+/**
+ * SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001 — shared genuine-worker predicate.
+ *
+ * coordinator-audit.mjs over-counted workers (counted every session heartbeating <15m
+ * regardless of role/status/claim-history), disagreeing with coordinator-email-summary.mjs
+ * and the dashboard. The predicate is now shared in lib/fleet/genuine-worker.mjs. These
+ * tests pin that it excludes the coordinator, Adam, non_fleet, non-live statuses, and
+ * never-claimed ghosts.
+ */
+import { describe, it, expect } from 'vitest';
+import { everClaimed, isFleetWorker, liveFleetWorkers } from '../../../lib/fleet/genuine-worker.mjs';
+
+const ME = 'coord-1';
+const fresh = () => new Date().toISOString();
+
+// a baseline genuine worker: active, ever-claimed (has sd_key), fresh heartbeat
+const worker = (over = {}) => ({
+  session_id: 'w1', status: 'active', metadata: {}, sd_key: 'SD-X-001',
+  claimed_at: null, worktree_path: null, continuous_sds_completed: 0,
+  heartbeat_at: fresh(), ...over,
+});
+
+describe('everClaimed (ghost-filter)', () => {
+  it('true when any claim signal is present', () => {
+    expect(everClaimed({ sd_key: 'SD-X' })).toBe(true);
+    expect(everClaimed({ claimed_at: '2026-01-01' })).toBe(true);
+    expect(everClaimed({ worktree_path: '/wt' })).toBe(true);
+    expect(everClaimed({ continuous_sds_completed: 2 })).toBe(true);
+  });
+  it('false when the session never held a claim (a ghost)', () => {
+    expect(everClaimed({ sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0 })).toBe(false);
+  });
+});
+
+describe('isFleetWorker', () => {
+  it('accepts a genuine active worker', () => {
+    expect(isFleetWorker(worker(), ME)).toBe(true);
+  });
+  it('accepts a genuine idle worker that ever claimed (no current sd_key)', () => {
+    expect(isFleetWorker(worker({ session_id: 'w2', sd_key: null, status: 'idle', continuous_sds_completed: 3 }), ME)).toBe(true);
+  });
+  it('excludes the coordinator itself', () => {
+    expect(isFleetWorker(worker({ session_id: ME }), ME)).toBe(false);
+  });
+  it('excludes Adam (metadata.role=adam)', () => {
+    expect(isFleetWorker(worker({ metadata: { role: 'adam' } }), ME)).toBe(false);
+  });
+  it('excludes non_fleet sessions', () => {
+    expect(isFleetWorker(worker({ metadata: { non_fleet: true } }), ME)).toBe(false);
+  });
+  it('excludes non-live statuses (released/exited/stale ghosts)', () => {
+    for (const status of ['released', 'exited', 'stale', 'completed']) {
+      expect(isFleetWorker(worker({ status }), ME)).toBe(false);
+    }
+  });
+  it('excludes a never-claimed ghost even when active', () => {
+    expect(isFleetWorker(worker({ session_id: 'g1', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0 }), ME)).toBe(false);
+  });
+});
+
+describe('liveFleetWorkers (the over-count regression)', () => {
+  it('counts only genuine live workers from a mixed session list', () => {
+    const now = Date.now();
+    const sessions = [
+      worker({ session_id: 'builder', sd_key: 'SD-A' }),                                   // genuine builder ✓
+      worker({ session_id: 'idle', sd_key: null, status: 'idle', continuous_sds_completed: 1 }), // genuine idle ✓
+      worker({ session_id: ME }),                                                           // coordinator ✗
+      worker({ session_id: 'adam', metadata: { role: 'adam' } }),                           // Adam ✗
+      worker({ session_id: 'nf', metadata: { non_fleet: true } }),                          // non_fleet ✗
+      worker({ session_id: 'released', status: 'released' }),                               // released ghost ✗
+      worker({ session_id: 'ghost', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0 }), // never-claimed ✗
+      worker({ session_id: 'stale', heartbeat_at: new Date(now - 20 * 60 * 1000).toISOString() }), // heartbeat >15m ✗
+    ];
+    const live = liveFleetWorkers(sessions, ME, now);
+    expect(live.map((s) => s.session_id).sort()).toEqual(['builder', 'idle']);
+    // the FLOW/LIVENESS gauges the audit derives:
+    expect(live.filter((s) => s.sd_key).length).toBe(1);   // builders
+    expect(live.filter((s) => !s.sd_key).length).toBe(1);  // live-idle
+  });
+
+  it('returns [] for null/empty input (fail-open)', () => {
+    expect(liveFleetWorkers(null, ME, Date.now())).toEqual([]);
+    expect(liveFleetWorkers([], ME, Date.now())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
`coordinator-audit.mjs` FLOW/LIVENESS gauges over-counted workers — its query counted **every** `claude_sessions` row heartbeating <15m, excluding only the coordinator, so Adam (`role=adam`), `non_fleet`, released/exited ghosts, and never-claimed sessions inflated `builders`/`live-idle` and skewed the sourcing decision. Same over-count class QF-20260607-608 fixed in `coordinator-email-summary.mjs`; it persisted because each consumer kept its own inline copy of the predicate and they drifted.

## Fix
Extract the genuine-worker predicate into a shared module **`lib/fleet/genuine-worker.mjs`** (`everClaimed` + `isFleetWorker(s, coordinatorId)` + `liveFleetWorkers`) and use it in `coordinator-audit.mjs`. Also refactor `coordinator-email-summary.mjs` to import the **same** helper — so the email and the audit share **one** definition and can never drift again (the root cause). `fleet-dashboard.cjs` is CommonJS (can't statically import the `.mjs`) and reads a different source — left as a documented follow-up.

> ⚠️ The email refactor initially missed a *second* `isFleetWorker` call (line 141) and imported only `liveFleetWorkers` → `ReferenceError` on the default-ON exec-email cron. **Caught by validation-agent and fixed** (import `isFleetWorker` too); both consumers now smoke clean and report matching counts.

## Tests
11 vitest unit tests for the predicate (coordinator/Adam/non_fleet/non-live-status/ghost exclusions + the mixed-list over-count regression + fail-open). Live smoke: `coordinator-audit.mjs` → `2 building, 0 live-idle`; `COORD_EMAIL_DRYRUN=1 coordinator-email-summary.mjs` → no ReferenceError, `totalWorkers=2` (**matches the audit**).

## LEO
bugfix (low-pri internal tooling) · gates 94/92/96/97 · retro 100 · validation-agent CONDITIONAL_PASS→addressed (3cc30efe) · testing-agent PASS 92 (6d2e8ce9). Follow-up: migrate `fleet-dashboard.cjs` to the shared predicate via a CJS bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)