### PR TITLE
fix(SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001): enforce declared dependencies at sd-start claim time

### DIFF
--- a/lib/sd-start/dependency-gate.mjs
+++ b/lib/sd-start/dependency-gate.mjs
@@ -1,0 +1,57 @@
+/**
+ * Pre-claim DEPENDENCY gate — pure decision logic.
+ * SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001
+ *
+ * Dependency BLOCKS were advisory-only: the sweep/dashboard computed and
+ * displayed BLOCKED, but sd-start.js never enforced it, so workers repeatedly
+ * claimed dependency-blocked child SDs. This converts the advisory BLOCK into an
+ * enforced one at claim time: refuse the claim when a declared dependency SD is
+ * not yet 'completed', with a --force warn-and-proceed override.
+ *
+ * Kept as a pure function (no DB/IO) so it is unit-testable without a live claim.
+ */
+
+/** A dependency is satisfied iff its referenced SD has reached this status. */
+export const SATISFIED_STATUS = 'completed';
+
+/**
+ * Decide whether a claim may proceed given the resolved statuses of an SD's
+ * declared dependencies.
+ *
+ * @param {Array<{sd_id: string, status: string|null}>} resolved
+ *   One entry per declared dependency. `status` is the referenced SD's current
+ *   status, or null when the reference could not be resolved.
+ * @param {{force?: boolean}} [opts]
+ * @returns {{verdict: 'proceed'|'refuse', blocking: Array, unresolved: Array, warn: boolean}}
+ */
+export function evaluateDependencyGate(resolved, opts = {}) {
+  const list = Array.isArray(resolved) ? resolved : [];
+  const force = Boolean(opts.force);
+
+  // Confirmed-incomplete dependencies: resolved to a real, non-completed status.
+  const blocking = list.filter(d => d && d.status && d.status !== SATISFIED_STATUS);
+  // Unresolvable references (deleted / typo'd): surfaced as a warning, never a
+  // hard block — blocking on a bad reference would strand the SD forever.
+  const unresolved = list.filter(d => d && !d.status);
+
+  if (blocking.length === 0) {
+    return { verdict: 'proceed', blocking, unresolved, warn: unresolved.length > 0 };
+  }
+  if (force) {
+    return { verdict: 'proceed', blocking, unresolved, warn: true };
+  }
+  return { verdict: 'refuse', blocking, unresolved, warn: false };
+}
+
+/**
+ * Human-readable body listing the offending dependencies (one per line).
+ * @param {Array<{sd_id: string, status: string|null}>} blocking
+ * @param {Array<{sd_id: string, status: string|null}>} unresolved
+ * @returns {string}
+ */
+export function formatDependencyRefusal(blocking = [], unresolved = []) {
+  const lines = [];
+  for (const d of blocking) lines.push(`  • ${d.sd_id} — status='${d.status}' (not completed)`);
+  for (const d of unresolved) lines.push(`  • ${d.sd_id} — could not resolve (deleted or typo?)`);
+  return lines.join('\n');
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -62,10 +62,88 @@ import {
 // SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
 import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
 import { shouldShowVenturePipelinePointer, VENTURE_PIPELINE_POINTER } from '../lib/leo/venture-pipeline-pointer.js';
+// SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: enforce declared dependencies at claim time.
+import { evaluateDependencyGate, formatDependencyRefusal } from '../lib/sd-start/dependency-gate.mjs';
 
 dotenv.config();
 
 const supabase = createSupabaseServiceClient();
+
+// SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: pre-claim DEPENDENCY gate.
+// Dependency BLOCKS were advisory-only (computed by the sweep/dashboard but never
+// enforced), so workers repeatedly claimed dependency-blocked child SDs. This
+// resolves the effective SD's declared dependencies (strategic_directives_v2.
+// dependencies JSONB) and REFUSES the claim when any is not 'completed'. --force
+// warns and proceeds; any resolution error fails OPEN so a transient DB issue can
+// never block every claim. Pure decision logic lives in lib/sd-start/dependency-gate.mjs.
+async function enforceDependencyGate(sd, effectiveId) {
+  let resolved;
+  try {
+    // dependencies is not fetched by getSDDetails — read it for the effective SD.
+    const { data: row, error: depErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('dependencies')
+      .eq('id', sd.id)
+      .maybeSingle();
+    if (depErr) throw depErr;
+
+    const deps = Array.isArray(row?.dependencies) ? row.dependencies : [];
+    const refs = deps
+      .map(d => (d && typeof d === 'object' ? d.sd_id : d))
+      .filter(v => typeof v === 'string' && v.length > 0);
+    if (refs.length === 0) return; // no declared dependencies — nothing to enforce
+
+    // Resolve each ref (sd_key OR uuid) to its current status in one query.
+    const { data: depRows, error: resErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status')
+      .or(`sd_key.in.(${refs.join(',')}),id.in.(${refs.join(',')})`);
+    if (resErr) throw resErr;
+
+    const byRef = new Map();
+    for (const r of depRows || []) {
+      if (r.sd_key) byRef.set(r.sd_key, r.status);
+      if (r.id) byRef.set(r.id, r.status);
+    }
+    resolved = refs.map(ref => ({ sd_id: ref, status: byRef.has(ref) ? byRef.get(ref) : null }));
+  } catch (err) {
+    // Fail-open: a transient DB/resolution error must never block every claim.
+    console.warn(`${colors.dim}(dependency gate skipped — resolution error, fail-open: ${err.message})${colors.reset}`);
+    return;
+  }
+
+  const force = process.argv.includes('--force');
+  const result = evaluateDependencyGate(resolved, { force });
+
+  if (result.verdict === 'refuse') {
+    console.log(`\n${colors.red}${colors.bold}🚫 Unmet dependencies — claim refused for ${effectiveId}${colors.reset}`);
+    console.log(`${colors.red}${formatDependencyRefusal(result.blocking, result.unresolved)}${colors.reset}`);
+    console.log(`   ${colors.dim}Wait for the dependencies to reach 'completed', or pass --force to override (warn + proceed).${colors.reset}`);
+    try {
+      await supabase.from('audit_log').insert({
+        event_type: 'DEPENDENCY_GATE_REFUSED',
+        entity_type: 'strategic_directive',
+        entity_id: sd.id,
+        metadata: {
+          sd_key: effectiveId,
+          blocking: result.blocking,
+          unresolved: result.unresolved,
+          operator_session_id: process.env.CLAUDE_SESSION_ID || null,
+        },
+        severity: 'info',
+      });
+    } catch (auditErr) {
+      console.warn(`${colors.dim}(audit-log refusal record failed non-blocking: ${auditErr.message})${colors.reset}`);
+    }
+    process.exit(1);
+  }
+
+  if (result.warn && (result.blocking.length || result.unresolved.length)) {
+    const why = force && result.blocking.length ? '--force override' : 'unresolved reference(s)';
+    console.log(`\n${colors.yellow}⚠️  Proceeding despite unmet dependencies (${why}) for ${effectiveId}:${colors.reset}`);
+    console.log(`${colors.yellow}${formatDependencyRefusal(result.blocking, result.unresolved)}${colors.reset}`);
+  }
+}
 
 const MAX_FALLBACK_ATTEMPTS = 3;
 
@@ -820,6 +898,11 @@ async function main() {
       } // close else (route-to-leaf)
     }
   }
+
+  // 1.6. SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: pre-claim dependency gate.
+  // Enforces the SD's declared dependencies (refuses the claim when a declared
+  // dependency SD is not yet 'completed'; --force overrides; fail-open on error).
+  await enforceDependencyGate(sd, effectiveId);
 
   // 1.7. Day-28 blocking age gate (FR-001: SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03)
   // Block SDs older than threshold (default 28 days). Chairman override via --force.

--- a/tests/sd-start-dependency-gate.test.mjs
+++ b/tests/sd-start-dependency-gate.test.mjs
@@ -1,0 +1,64 @@
+/**
+ * Tests for the pre-claim dependency gate decision logic.
+ * SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001 (FR-004)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateDependencyGate, formatDependencyRefusal } from '../lib/sd-start/dependency-gate.mjs';
+
+test('refuses when a dependency is not completed (FR-002)', () => {
+  const r = evaluateDependencyGate([{ sd_id: 'SD-A', status: 'in_progress' }], { force: false });
+  assert.equal(r.verdict, 'refuse');
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].sd_id, 'SD-A');
+});
+
+test('proceeds when all dependencies are completed (FR-001)', () => {
+  const r = evaluateDependencyGate([
+    { sd_id: 'SD-A', status: 'completed' },
+    { sd_id: 'SD-B', status: 'completed' },
+  ]);
+  assert.equal(r.verdict, 'proceed');
+  assert.equal(r.warn, false);
+  assert.equal(r.blocking.length, 0);
+});
+
+test('proceeds (no block) when there are no dependencies (FR-001)', () => {
+  assert.equal(evaluateDependencyGate([]).verdict, 'proceed');
+  assert.equal(evaluateDependencyGate(null).verdict, 'proceed');
+  assert.equal(evaluateDependencyGate(undefined).verdict, 'proceed');
+});
+
+test('--force converts a refusal into warn-and-proceed (FR-003)', () => {
+  const r = evaluateDependencyGate([{ sd_id: 'SD-A', status: 'draft' }], { force: true });
+  assert.equal(r.verdict, 'proceed');
+  assert.equal(r.warn, true);
+  assert.equal(r.blocking.length, 1);
+});
+
+test('unresolved references warn but never hard-block (fail-safe, FR-003)', () => {
+  const r = evaluateDependencyGate([{ sd_id: 'SD-GONE', status: null }]);
+  assert.equal(r.verdict, 'proceed');
+  assert.equal(r.warn, true);
+  assert.equal(r.unresolved.length, 1);
+});
+
+test('mixed: one completed + one in_progress still refuses', () => {
+  const r = evaluateDependencyGate([
+    { sd_id: 'SD-DONE', status: 'completed' },
+    { sd_id: 'SD-WIP', status: 'in_progress' },
+  ]);
+  assert.equal(r.verdict, 'refuse');
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].sd_id, 'SD-WIP');
+});
+
+test('formatDependencyRefusal lists blocking and unresolved entries', () => {
+  const body = formatDependencyRefusal(
+    [{ sd_id: 'SD-WIP', status: 'in_progress' }],
+    [{ sd_id: 'SD-GONE', status: null }],
+  );
+  assert.match(body, /SD-WIP/);
+  assert.match(body, /in_progress/);
+  assert.match(body, /SD-GONE/);
+});


### PR DESCRIPTION
## SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001 — enforce dependency BLOCKS at claim time

### Problem
Dependency BLOCKS were **advisory-only**: the sweep/dashboard computed BLOCKED, but `sd-start.js` never checked unmet dependencies before granting a claim. So workers repeatedly **claimed dependency-blocked child SDs** (e.g. Adam-A and POST-BUILD-LIFECYCLE-001-A claimed while their deps were still `in_progress`) — and `/checkin` mis-assigned dependency-blocked work multiple times this session.

### Fix
- `lib/sd-start/dependency-gate.mjs` — pure `evaluateDependencyGate(resolved, {force})`: **refuse** the claim when any declared dependency has a *confirmed* non-`completed` status. Unresolved/deleted refs **warn, never hard-block** (a bad ref can't strand an SD). `--force` = warn-and-proceed.
- `scripts/sd-start.js` — `enforceDependencyGate` at the pre-claim point resolves declared deps (by `sd_key` **or** uuid) to live status, **fails open** on any DB/resolution error (a transient issue can never block *every* claim), audit-logs `DEPENDENCY_GATE_REFUSED`, and exits on refuse.

### Safety (fleet-wide gate — every `sd-start` flows through it)
Adversarial TESTING confirmed all five invariants: fail-open on error, warn-not-block on unresolved refs, `--force` override, refuse only on confirmed-incomplete, no-deps SDs unaffected. **7/7 tests pass.**

### Note
This was resumed from a prior worker's committed EXEC (`ad5ea329e4`) — verified-before-ship (read gate + wiring + ran tests), not rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)