### PR TITLE
fix(SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001): hot-reload stage-template fixes (watch lib/eva)

### DIFF
--- a/scripts/lib/stage-worker-watch.js
+++ b/scripts/lib/stage-worker-watch.js
@@ -1,0 +1,54 @@
+/**
+ * Stage-worker supervisor watch-set composition (pure).
+ *
+ * SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001
+ *
+ * The stage-execution-worker supervised by scripts/start-stage-worker.js auto-restarts
+ * the worker (child_process.fork — fresh V8, clean module cache) when watched source
+ * changes. The original watch-set covered only three paths
+ * (lib/eva/stage-execution-worker.js, lib/eva/bridge/, lib/eva/artifact-persistence-service.js),
+ * but a dependency-graph audit found the worker's runtime spans ~90% of lib/eva: the
+ * eva-orchestrator + ~20 core modules, ALL stage templates in lib/eva/stage-templates/
+ * (the reported symptom), and the utils/, contracts/, quality-findings/, config/
+ * directories those templates import. Synced fixes to any of those were on-disk-correct
+ * but never hot-reloaded (Adam's deploy-gap canary, 2026-06-07).
+ *
+ * Watching the lib/eva ROOT recursively is the single robust watch that (a) subsumes the
+ * prior three paths, (b) covers the entire runtime graph, and (c) stays correct as new
+ * stage templates are added — without enumerating fragile per-file paths. This module is
+ * pure (no IO, no process/fs side effects) so the watch-set is unit-testable.
+ *
+ * @module scripts/lib/stage-worker-watch
+ */
+
+import { resolve, sep } from 'path';
+
+/**
+ * The chokidar watch roots for the stage-worker supervisor. The whole lib/eva tree is the
+ * worker's runtime source, so watching its root triggers a respawn on any runtime-relevant
+ * change (stage templates + every dependency) and never goes stale as files are added.
+ *
+ * @param {string} projectRoot - absolute path to the repo root
+ * @returns {string[]} absolute watch roots
+ */
+export function buildWatchPaths(projectRoot) {
+  return [resolve(projectRoot, 'lib', 'eva')];
+}
+
+/**
+ * Pure predicate: is `filePath` inside one of the watch roots? Uses path-segment-aware
+ * containment (root, or root + sep prefix) so a sibling directory that merely shares the
+ * root's name prefix (e.g. lib/eva-extra vs lib/eva) is NOT considered watched.
+ *
+ * @param {string[]} watchPaths - watch roots (from buildWatchPaths)
+ * @param {string} filePath - candidate path
+ * @returns {boolean}
+ */
+export function isPathWatched(watchPaths, filePath) {
+  if (!filePath) return false;
+  const target = resolve(filePath);
+  return (watchPaths || []).some((root) => {
+    const r = resolve(root);
+    return target === r || target.startsWith(r + sep);
+  });
+}

--- a/scripts/lib/stage-worker-watch.test.js
+++ b/scripts/lib/stage-worker-watch.test.js
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the stage-worker supervisor watch-set composition.
+ * SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001.
+ *
+ * Pure / process-free: verifies the watch root covers the worker's runtime graph
+ * (the reported stage-templates gap plus the audit-identified dependency dirs and the
+ * previously-watched paths) and stays bounded to lib/eva.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'path';
+import { buildWatchPaths, isPathWatched } from './stage-worker-watch.js';
+
+const ROOT = resolve('/repo-root');
+const wp = buildWatchPaths(ROOT);
+const p = (rel) => resolve(ROOT, rel);
+
+describe('buildWatchPaths', () => {
+  it('watches the lib/eva runtime root', () => {
+    expect(wp).toEqual([resolve(ROOT, 'lib', 'eva')]);
+  });
+});
+
+describe('isPathWatched — covers the reported bug + the full runtime graph', () => {
+  it('covers stage templates (the SD symptom) including new + nested', () => {
+    expect(isPathWatched(wp, p('lib/eva/stage-templates/stage-21-visual-assets.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/stage-templates/stage-27.js'))).toBe(true); // future template
+    expect(isPathWatched(wp, p('lib/eva/stage-templates/analysis-steps/stage-20-code-quality.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/stage-templates/index.js'))).toBe(true);
+  });
+
+  it('still covers the three previously-watched paths (no regression)', () => {
+    expect(isPathWatched(wp, p('lib/eva/stage-execution-worker.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/bridge/lifecycle-sd-bridge.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/artifact-persistence-service.js'))).toBe(true);
+  });
+
+  it('covers the audit-identified dependency dirs + orchestrator', () => {
+    expect(isPathWatched(wp, p('lib/eva/utils/parse-json.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/contracts/financial-contract.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/quality-findings/finding-shape.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/config/house-tech-stack.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/eva-orchestrator.js'))).toBe(true);
+    expect(isPathWatched(wp, p('lib/eva/stage-03.js'))).toBe(true); // stage-NN constants imported by analysis-steps
+  });
+});
+
+describe('isPathWatched — bounded to lib/eva (no over-broad respawn)', () => {
+  it('does NOT watch paths outside lib/eva', () => {
+    expect(isPathWatched(wp, p('scripts/start-stage-worker.js'))).toBe(false);
+    expect(isPathWatched(wp, p('lib/coordinator/resolve.cjs'))).toBe(false);
+    expect(isPathWatched(wp, p('node_modules/chokidar/index.js'))).toBe(false);
+  });
+
+  it('does NOT match a sibling dir that shares the lib/eva name prefix', () => {
+    expect(isPathWatched(wp, p('lib/eva-extra/x.js'))).toBe(false);
+    expect(isPathWatched(wp, p('lib/evaluation/y.js'))).toBe(false);
+  });
+
+  it('handles empty / missing inputs without throwing', () => {
+    expect(isPathWatched(wp, '')).toBe(false);
+    expect(isPathWatched([], p('lib/eva/stage-templates/stage-21.js'))).toBe(false);
+    expect(isPathWatched(undefined, p('lib/eva/x.js'))).toBe(false);
+  });
+});

--- a/scripts/start-stage-worker.js
+++ b/scripts/start-stage-worker.js
@@ -38,6 +38,8 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { fork } from 'child_process';
 import chokidar from 'chokidar';
+// SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001: pure watch-set composition (unit-tested).
+import { buildWatchPaths } from './lib/stage-worker-watch.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -181,11 +183,11 @@ function runSupervisor() {
   let restartDebounce = null;
   if (process.env.STAGE_WORKER_WATCH !== 'false') {
     const projectRoot = resolve(__dirname, '..');
-    const watchPaths = [
-      resolve(projectRoot, 'lib/eva/stage-execution-worker.js'),
-      resolve(projectRoot, 'lib/eva/bridge'),
-      resolve(projectRoot, 'lib/eva/artifact-persistence-service.js'),
-    ];
+    // SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001: watch the whole lib/eva runtime root (subsumes the
+    // prior stage-execution-worker.js + bridge/ + artifact-persistence-service.js) so a synced
+    // fix to ANY worker-runtime source — stage templates plus the utils/contracts/quality-findings/
+    // config/orchestrator deps they import — triggers a respawn that reloads via a fresh fork().
+    const watchPaths = buildWatchPaths(projectRoot);
 
     const watcher = chokidar.watch(watchPaths, {
       ignored: /(^|[/\\])\../, // dotfiles
@@ -193,9 +195,11 @@ function runSupervisor() {
       awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
     });
 
-    watcher.on('change', (path) => {
+    // Shared debounced reload, reused for change/add/unlink so a multi-file git sync yields a
+    // single respawn and reload-restarts bypass the circuit breaker.
+    const scheduleReload = (event) => (path) => {
       if (shuttingDown) return;
-      console.log(`[supervisor] File changed: ${path}`);
+      console.log(`[supervisor] File ${event}: ${path}`);
       // Debounce: batch multiple saves (e.g. git merges touching many files)
       if (restartDebounce) clearTimeout(restartDebounce);
       restartDebounce = setTimeout(() => {
@@ -206,10 +210,16 @@ function runSupervisor() {
         child.kill('SIGTERM');
         // supervisor's child.on('exit') will spawn a new one
       }, 1000);
-    });
+    };
+
+    // 'add'/'unlink' (not just 'change') so newly added or deleted stage templates also reload —
+    // stage-templates/index.js auto-discovers stage-NN.js via readdirSync at process start.
+    watcher.on('change', scheduleReload('changed'));
+    watcher.on('add', scheduleReload('added'));
+    watcher.on('unlink', scheduleReload('removed'));
 
     watcher.on('ready', () => {
-      console.log('[supervisor] File watcher active — auto-restart on code changes in lib/eva/');
+      console.log('[supervisor] File watcher active — auto-restart on lib/eva code changes (change/add/unlink)');
     });
 
     watcher.on('error', (err) => {


### PR DESCRIPTION
## Summary
The stage-worker supervisor (`scripts/start-stage-worker.js`) chokidar watch-set covered only `lib/eva/stage-execution-worker.js` + `bridge/` + `artifact-persistence-service.js` — **not** `lib/eva/stage-templates/`. So a synced fix to a stage-NN template was on-disk-correct but the **running worker kept executing pre-sync template code** until a manual SIGKILL+respawn (root-caused by Adam's deploy-gap canary, 2026-06-07).

## Fix
A dependency-graph audit found the worker's runtime spans ~90% of `lib/eva` (orchestrator + ~20 core modules + all stage templates), so the robust fix is to **watch the `lib/eva` root recursively** — it subsumes the prior 3 paths, covers the whole runtime graph, and stays correct as new stage templates are added (no fragile per-file enumeration).

- **NEW `scripts/lib/stage-worker-watch.js`**: pure `buildWatchPaths(projectRoot)` → `[lib/eva]` + an `isPathWatched` segment-aware prefix guard (so `lib/eva-extra` ≠ `lib/eva`). Pure → unit-testable.
- `start-stage-worker.js`: import + use `buildWatchPaths`; respawn/debounce/circuit-breaker logic unchanged.

## Tests
7 vitest tests (watch root, no-regression on the prior 3 paths, future/nested templates, dependency-dir + sibling-prefix exclusion, empty inputs). testing-agent PASS (no defects: no `node_modules`-watch risk, respawn logic intact, prefix guard correct).

## LEO
bugfix · resumed a peer's in-flight EXEC · **rebased the branch onto current main (it was 14 commits behind — would have reverted main otherwise)** · gates 96/98 · retro 100 · testing-agent PASS 92. Follow-up (optional): add `*.test.js`/`__tests__/` to chokidar `ignored` to avoid respawns on eva test edits during live operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)