### PR TITLE
feat(SD-FDBK-INFRA-NODE-CLOCK-SKEW-001): DB-relative clock for coordinator staleness checks

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -331,16 +331,23 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
   let activeClaims = [];
   if (claims && claims.length > 0) {
     const sessionIds = claims.map(c => c.session_id);
-    const { data: sessions } = await supabase
-      .from('claude_sessions')
-      .select('session_id, terminal_id, pid, hostname, tty, codebase, heartbeat_at, status')
-      .in('session_id', sessionIds);
+    // SD-FDBK-INFRA-NODE-CLOCK-SKEW-001: age heartbeats against the DB server clock (not the
+    // node clock) so a skewed coordinator node can't false-stale (computed_status) a live claim.
+    // Batched with the session fetch (no added latency); fail-open (getDbNowMs -> node clock).
+    const { getDbNowMs } = await import('./fleet/db-clock.mjs');
+    const [{ data: sessions }, dbNowMs] = await Promise.all([
+      supabase
+        .from('claude_sessions')
+        .select('session_id, terminal_id, pid, hostname, tty, codebase, heartbeat_at, status')
+        .in('session_id', sessionIds),
+      getDbNowMs(supabase),
+    ]);
 
     const sessionMap = Object.fromEntries((sessions || []).map(s => [s.session_id, s]));
     activeClaims = claims.map(c => {
       const s = sessionMap[c.session_id] || {};
       const heartbeatAge = s.heartbeat_at
-        ? (Date.now() - new Date(s.heartbeat_at).getTime()) / 1000
+        ? (dbNowMs - new Date(s.heartbeat_at).getTime()) / 1000
         : 9999;
       return {
         ...c,

--- a/lib/fleet/db-clock.cjs
+++ b/lib/fleet/db-clock.cjs
@@ -1,0 +1,59 @@
+'use strict';
+/**
+ * db-clock — SD-FDBK-INFRA-NODE-CLOCK-SKEW-001
+ *
+ * Coordinator staleness checks compute age as (node-process clock - a DB timestamp).
+ * When the node clock skews from the DB server clock (observed ~3-4h on this host),
+ * those node-relative comparisons flip the staleness verdict → false HEARTBEAT_TIMEOUT
+ * and false claim/coordinator/worktree releases.
+ *
+ * getDbNowMs() returns the DB SERVER clock in epoch-ms so a check can use a clock
+ * reference that matches the stored DB timestamps, removing the reader's node-clock
+ * skew from the verdict. It derives DB-now WITHOUT a new DB function/migration by
+ * reading one fresh v_active_sessions row: that view already computes
+ *   heartbeat_age_seconds = EXTRACT(epoch FROM now() - heartbeat_at)   [DB-side]
+ * so  Date.parse(heartbeat_at) + heartbeat_age_seconds*1000 == the DB server now()
+ * (the heartbeat_at term cancels — even if it was written by a skewed worker clock).
+ *
+ * CONTRACT:
+ *  - FAIL-OPEN: on any error / no row / NaN, returns the node clock (legacy behavior)
+ *    after a one-line warn. NEVER throws → adoption can never regress availability.
+ *  - PER-CHECK: the returned value is DB-now AS OF this call. Use it immediately within
+ *    one staleness decision; do NOT cache it across a multi-minute run (it would age).
+ *  - THRESHOLD-AGNOSTIC: returns an absolute clock only; each caller keeps its OWN
+ *    threshold (the documented 300s claim-liveness vs 600s display two-threshold model).
+ *
+ * CJS so both .cjs (resolve, sweep) and .mjs (claim-guard, coordinator-audit) callers
+ * can consume it (the latter via lib/fleet/db-clock.mjs, which re-exports this file).
+ *
+ * @param {object} supabase  a supabase client that can SELECT from v_active_sessions
+ * @returns {Promise<number>} DB server clock in epoch-ms (or node clock on fail-open)
+ */
+async function getDbNowMs(supabase) {
+  try {
+    const { data, error } = await supabase
+      .from('v_active_sessions')
+      .select('heartbeat_at, heartbeat_age_seconds')
+      .order('heartbeat_at', { ascending: false })
+      .limit(1);
+    const row = Array.isArray(data) ? data[0] : data;
+    if (error || !row || !row.heartbeat_at || row.heartbeat_age_seconds == null) {
+      return nodeFallback('no fresh v_active_sessions row');
+    }
+    const base = Date.parse(row.heartbeat_at);
+    const ageMs = Number(row.heartbeat_age_seconds) * 1000;
+    if (!Number.isFinite(base) || !Number.isFinite(ageMs)) {
+      return nodeFallback('unparseable heartbeat_at / heartbeat_age_seconds');
+    }
+    return base + ageMs;
+  } catch (e) {
+    return nodeFallback((e && e.message) || 'getDbNowMs threw');
+  }
+}
+
+function nodeFallback(why) {
+  try { console.warn(`[db-clock] DB clock unavailable (${why}) — falling back to node clock; skew protection lost this check.`); } catch (_) { /* swallow */ }
+  return Date.now();
+}
+
+module.exports = { getDbNowMs };

--- a/lib/fleet/db-clock.mjs
+++ b/lib/fleet/db-clock.mjs
@@ -1,0 +1,7 @@
+// SD-FDBK-INFRA-NODE-CLOCK-SKEW-001 — ESM re-export of the CJS db-clock helper so .mjs
+// consumers (claim-guard.mjs, coordinator-audit.mjs) share ONE implementation. Single
+// source of truth = ./db-clock.cjs.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { getDbNowMs } = require('./db-clock.cjs');
+export { getDbNowMs };

--- a/lib/fleet/db-clock.test.js
+++ b/lib/fleet/db-clock.test.js
@@ -1,0 +1,73 @@
+/**
+ * Unit tests — SD-FDBK-INFRA-NODE-CLOCK-SKEW-001
+ * getDbNowMs derives the DB server clock (skew-immune) and is fail-open; the
+ * liveFleetWorkers skew-injection proves that consuming DB-now (as coordinator-audit
+ * now does) keeps the staleness verdict correct under a multi-hour node-clock skew.
+ * Network-free: a fake supabase + injected clock values, no real DB.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import dbClock from './db-clock.cjs';
+import { liveFleetWorkers } from './genuine-worker.mjs';
+
+const { getDbNowMs } = dbClock;
+
+// Fake supabase for the v_active_sessions read getDbNowMs makes.
+function fakeSb(result, { throwOnFrom = false } = {}) {
+  const api = {
+    select: () => api,
+    order: () => api,
+    limit: () => api,
+    then: (res, rej) => { try { res(result); } catch (e) { rej(e); } },
+  };
+  return { from: () => { if (throwOnFrom) throw new Error('connection boom'); return api; } };
+}
+
+let warnSpy;
+beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+afterEach(() => { warnSpy.mockRestore(); });
+
+describe('getDbNowMs', () => {
+  it('derives DB-now from a v_active_sessions row (heartbeat_at cancels)', async () => {
+    const hb = '2026-06-08T10:00:00.000Z';
+    const r = await getDbNowMs(fakeSb({ data: [{ heartbeat_at: hb, heartbeat_age_seconds: 42 }], error: null }));
+    expect(r).toBe(Date.parse(hb) + 42_000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('is fail-open on a query error (returns the node clock, warns)', async () => {
+    const r = await getDbNowMs(fakeSb({ data: null, error: { message: 'rls denied' } }));
+    expect(Math.abs(r - Date.now())).toBeLessThan(2000);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is fail-open on an empty fleet (no rows)', async () => {
+    const r = await getDbNowMs(fakeSb({ data: [], error: null }));
+    expect(Math.abs(r - Date.now())).toBeLessThan(2000);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is fail-open on a thrown client error and never throws', async () => {
+    const r = await getDbNowMs(fakeSb(null, { throwOnFrom: true }));
+    expect(Math.abs(r - Date.now())).toBeLessThan(2000);
+  });
+
+  it('is fail-open on a null/unparseable heartbeat_at', async () => {
+    const r = await getDbNowMs(fakeSb({ data: [{ heartbeat_at: null, heartbeat_age_seconds: 5 }], error: null }));
+    expect(Math.abs(r - Date.now())).toBeLessThan(2000);
+  });
+});
+
+describe('liveFleetWorkers under node-clock skew (proves the coordinator-audit fix)', () => {
+  const DB_NOW = Date.parse('2026-06-08T12:00:00.000Z');
+  const worker = { session_id: 'w1', status: 'active', metadata: {}, sd_key: 'SD-X', heartbeat_at: new Date(DB_NOW - 60_000).toISOString() };
+  const sessions = [worker];
+
+  it('a +4h-skewed node clock FALSE-EXCLUDES a live worker (the bug)', () => {
+    const skewedNow = DB_NOW + 4 * 3600_000;
+    expect(liveFleetWorkers(sessions, 'coord', skewedNow, 900_000)).toHaveLength(0);
+  });
+
+  it('passing DB-now classifies the same worker LIVE (the fix)', () => {
+    expect(liveFleetWorkers(sessions, 'coord', DB_NOW, 900_000)).toHaveLength(1);
+  });
+});

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -13,11 +13,16 @@ import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 import { countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
 import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
+import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
-const t = Date.now();
+// SD-FDBK-INFRA-NODE-CLOCK-SKEW-001: use the DB server clock (not the node clock) as the
+// age reference so node-clock skew can't make all workers/SDs read as stale. Every
+// downstream age calc (liveFleetWorkers nowMs, SD aging, dep-stale aging) consumes `t`.
+// Fail-open: getDbNowMs returns the node clock if the DB read fails (no worse than before).
+const t = await getDbNowMs(db);
 const OPEN = ['new', 'in_progress', 'open', 'triaged', 'snoozed'];
 const TERMINAL = ['completed', 'cancelled', 'archived', 'deferred'];
 const termList = '(' + TERMINAL.join(',') + ')';


### PR DESCRIPTION
## Summary
Coordinator staleness checks computed age as **(node-process clock − a DB timestamp)**. When the node clock skews from the DB server clock (~3–4h observed on this host), those node-relative comparisons flip the staleness verdict → **false HEARTBEAT_TIMEOUT** and **false claim/coordinator releases**.

**Fix** (reuse the DB-side age the `v_active_sessions` view already computes; **no migration**):
- `lib/fleet/db-clock.cjs` (+ `.mjs` ESM shim): **`getDbNowMs(supabase)`** returns the DB server clock in ms, derived from one fresh `v_active_sessions` row (`Date.parse(heartbeat_at)+heartbeat_age_seconds*1000` — the `heartbeat_at` term **cancels**, so it tracks the DB clock even if that row was written by a skewed worker). **Fail-open**: returns the node clock (with a warn) on any error/empty → can never regress availability. Per-check + threshold-agnostic (callers keep their own 300s/600s thresholds).
- `lib/claim-guard.mjs`: age the enrichment heartbeat against `getDbNowMs` (batched in the existing `Promise.all` — **no added latency**) so a skewed coordinator node can't false-stale a live claim.
- `scripts/coordinator-audit.mjs`: `t = await getDbNowMs(db)` as the single age reference.

**Deferred to a tracked fast-follow** (higher-risk live election/reaper machinery, can't validate end-to-end while clocks are synced): `lib/coordinator/resolve.cjs` (3 election cutoffs) + `scripts/worktree-reaper.mjs` (loadClaimMap). Fail-open means those un-migrated sites are no worse than before.

## Test plan
- `lib/fleet/db-clock.test.js` — **7/7** network-free vitest cases: DB-now derivation, 4 fail-open paths, and a **+4h skew-injection** on `liveFleetWorkers` proving the node clock false-excludes a live worker while DB-now classifies it LIVE.
- Live `getDbNowMs` validated (delta ~0 at synced clocks).
- Pre-existing `lib/claim-guard.test.js` failures (10, mock debt at line 297) are **unchanged** by this PR (verified by stashing the change and re-running).

Design hardened via an 8-agent design + adversarial-verification workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)