### PR TITLE
feat(SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001): LEO gate for cross-repo stage-config drift

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/cross-repo-stage-config-drift.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/cross-repo-stage-config-drift.js
@@ -1,0 +1,246 @@
+/**
+ * CROSS_REPO_STAGE_CONFIG_DRIFT — PLAN-TO-LEAD gate
+ * SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001
+ *
+ * THE GAP THIS CLOSES: the `venture_stages` SSOT (EHG_Engineer DB) drives a GENERATED file
+ * in the sibling `ehg` repo, `ehg/src/config/venture-workflow.ts`. A CI job
+ * (.github/workflows/venture-stages-drift-guard.yml, currently advisory/continue-on-error)
+ * enforces byte-parity via `node scripts/generate-stage-config.cjs --check`. But that regen
+ * step is INVISIBLE to LEO — no handoff gate runs it — so a worker who changes the stage SSOT
+ * reaches LEAD_FINAL believing done while the cross-repo merge is structurally blocked by a
+ * stale ehg file. This gate makes the drift VISIBLE to LEO at PLAN-TO-LEAD (the "believing
+ * done" checkpoint), before LEAD-FINAL.
+ *
+ * FLEET-SAFE BY DESIGN (the cross-repo dependency-blocks lesson):
+ *  - SCOPED BLOCK: only BLOCK when THIS SD touched stage-config SSOT inputs AND drift is real.
+ *    Drift on an UNRELATED SD (pre-existing, advisory-mode) is surfaced as a WARN, never a
+ *    block — one stale artifact must not wedge the whole fleet.
+ *  - FAIL-OPEN: any EXECUTION error (DB unreachable, sibling repo absent, generator throws,
+ *    git error) returns passed:true + warning. Unavailability never hard-blocks.
+ *  - RELEVANCE FAIL-SAFE: if changed-file detection itself errors, treat the SD as RELEVANT
+ *    so a parse error cannot silently downgrade a real regression from BLOCK to WARN.
+ *
+ * v1 SCOPE / KNOWN LIMIT (deferred to parts b/c of the SD): `--check` and the sibling
+ * git-status sub-check read the LOCAL sibling working tree, so "committed locally but not
+ * pushed/merged" still slips through. v1 catches the dominant failure mode (a stale/uncommitted
+ * sibling file). Push/merge-landing enforcement is the deferred `related_prs` + landing-order work.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export const GATE_NAME = 'CROSS_REPO_STAGE_CONFIG_DRIFT';
+
+/** Changed-file paths (relative, forward-slash) that ALWAYS mark an SD stage-config-relevant. */
+export const SSOT_INPUT_FILES = [
+  'scripts/generate-stage-config.cjs',
+  'lib/proving-companion/stage-config.js',
+  'src/config/venture-workflow.ts', // if the sibling artifact is edited from within this repo's tree
+];
+
+/** A changed migration is relevant only if its body references the venture_stages SSOT table. */
+const MIGRATION_DIR = 'database/migrations/';
+const VENTURE_STAGES_RE = /venture_stages/i;
+
+/**
+ * Classify the exit/output of `generate-stage-config.cjs --check` into drift vs execution-error.
+ * Real drift emits "CHECK FAILED: ... out of date ..." / "... byte-parity broken". An execution
+ * error (DB down, sibling absent, generator threw) exits non-zero WITHOUT those drift messages.
+ * Pure + exported for unit testing.
+ * @returns {{driftDetected:boolean, executionError:boolean}}
+ */
+export function classifyCheckOutput(exitCode, output) {
+  const text = String(output || '');
+  if (exitCode === 0) return { driftDetected: false, executionError: false };
+  const isDrift = /CHECK FAILED:[^\n]*(out of date|byte-parity)/i.test(text);
+  if (isDrift) return { driftDetected: true, executionError: false };
+  // non-zero but not a recognized drift message -> treat as an execution problem (fail-open).
+  return { driftDetected: false, executionError: true };
+}
+
+/**
+ * Decide the final gate verdict from the four boolean signals. Pure + exported for testing.
+ *  - executionError -> FAIL-OPEN (pass + warning), regardless of anything else.
+ *  - drift OR sibling-uncommitted, AND relevant -> BLOCK.
+ *  - drift OR sibling-uncommitted, but NOT relevant -> WARN (pass + warning).
+ *  - otherwise -> clean PASS.
+ * @returns {{passed:boolean, outcome:'PASS'|'BLOCK'|'WARN'|'FAIL_OPEN', reason:string}}
+ */
+export function decideVerdict({ relevant, driftDetected, siblingUncommitted, executionError }) {
+  if (executionError) {
+    return { passed: true, outcome: 'FAIL_OPEN', reason: 'Could not evaluate cross-repo stage-config parity (execution error) — failing open.' };
+  }
+  const hasDrift = Boolean(driftDetected || siblingUncommitted);
+  if (!hasDrift) {
+    return { passed: true, outcome: 'PASS', reason: 'venture_stages SSOT and the sibling ehg venture-workflow.ts are in sync.' };
+  }
+  if (relevant) {
+    return { passed: false, outcome: 'BLOCK', reason: 'This SD changed stage-config SSOT inputs and the sibling ehg venture-workflow.ts is stale/uncommitted — the cross-repo merge would be blocked by drift CI.' };
+  }
+  return { passed: true, outcome: 'WARN', reason: 'Pre-existing stage-config drift detected, but this SD did not touch stage-config inputs — surfaced as a warning, not blocking unrelated work.' };
+}
+
+const BLOCK_REMEDIATION =
+  'Cross-repo stage-config drift. In EHG_Engineer run `npm run venture-stages:generate` (node scripts/generate-stage-config.cjs --write), then COMMIT the regenerated `ehg/src/config/venture-workflow.ts` in the sibling ehg repo and open/merge its PR before LEAD-FINAL. Verify with `npm run venture-stages:check`.';
+
+// ---- default (real) I/O helpers; injectable via deps for unit tests -------------------------
+
+function defaultGitRoot(ctx) {
+  if (ctx?.gitContext?.gitRoot) return ctx.gitContext.gitRoot;
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8', timeout: 10000 }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function defaultChangedFiles(rootDir) {
+  // Resolve a base ref, then list changed files for this SD's branch. Throws on total failure
+  // so the caller can apply the relevance fail-safe (treat as relevant).
+  const refs = ['origin/main', 'main', 'HEAD~10'];
+  for (const ref of refs) {
+    try {
+      const out = execSync(`git diff --name-only ${ref}...HEAD`, { cwd: rootDir, encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] });
+      return out.split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch { /* try next ref */ }
+  }
+  throw new Error('git diff failed for all candidate base refs');
+}
+
+function defaultResolveSiblingRepo(rootDir) {
+  // env override (mirrors the CI) -> registry -> ../ehg fallback.
+  if (process.env.EHG_APP_PATH) return process.env.EHG_APP_PATH;
+  try {
+    const { resolveRepoPath } = require('../../../../../../lib/repo-paths.cjs');
+    const p = resolveRepoPath('ehg');
+    if (p) return p;
+  } catch { /* fall through */ }
+  return path.resolve(rootDir, '..', 'ehg');
+}
+
+function defaultRunCheck(rootDir) {
+  try {
+    const out = execSync('node scripts/generate-stage-config.cjs --check', { cwd: rootDir, encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'] });
+    return { exitCode: 0, output: out };
+  } catch (err) {
+    // execSync throws on non-zero; gather stdout+stderr for classification.
+    const output = `${err.stdout || ''}\n${err.stderr || ''}\n${err.message || ''}`;
+    const exitCode = typeof err.status === 'number' ? err.status : 1;
+    return { exitCode, output };
+  }
+}
+
+function defaultSiblingUncommitted(siblingRepo) {
+  // Returns { present, uncommitted }. Absent sibling repo -> present:false (caller fails open
+  // only if --check also could not run; sibling-absence alone is an execution concern).
+  const wf = path.join(siblingRepo, 'src', 'config', 'venture-workflow.ts');
+  if (!existsSync(siblingRepo) || !existsSync(wf)) return { present: false, uncommitted: false };
+  try {
+    const out = execSync('git status --porcelain -- src/config/venture-workflow.ts', { cwd: siblingRepo, encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] });
+    return { present: true, uncommitted: out.trim().length > 0 };
+  } catch {
+    return { present: false, uncommitted: false }; // git error in sibling -> treat as not-evaluable
+  }
+}
+
+/**
+ * Determine whether the SD's changed files touch stage-config SSOT inputs.
+ * relevant if: a known SSOT input file changed, OR a changed migration body references
+ * venture_stages. readMigration(rel) returns the file body (or null). Pure-ish + exported.
+ */
+export function isStageConfigRelevant(changedFiles, readMigration) {
+  const files = (changedFiles || []).map((f) => f.replace(/\\/g, '/'));
+  for (const f of files) {
+    if (SSOT_INPUT_FILES.some((s) => f === s || f.endsWith('/' + s))) return true;
+  }
+  for (const f of files) {
+    if (f.startsWith(MIGRATION_DIR) && /\.sql$/i.test(f)) {
+      let body = null;
+      try { body = readMigration(f); } catch { body = null; }
+      if (body && VENTURE_STAGES_RE.test(body)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Factory for the gate. `deps` lets tests inject all I/O.
+ */
+export function createCrossRepoStageConfigDriftGate(supabase, deps = {}) {
+  const {
+    gitRoot = defaultGitRoot,
+    changedFiles = defaultChangedFiles,
+    resolveSibling = defaultResolveSiblingRepo,
+    runCheck = defaultRunCheck,
+    siblingStatus = defaultSiblingUncommitted,
+    readMigration = null, // resolved per-rootDir below if not injected
+  } = deps;
+
+  return {
+    name: GATE_NAME,
+    required: true, // gate runs every PLAN-TO-LEAD; it only BLOCKS on a relevant SD's real drift
+    validator: async (ctx) => {
+      const rootDir = gitRoot(ctx);
+      const readMig = readMigration || ((rel) => readFileSync(path.join(rootDir, rel), 'utf8'));
+
+      // 1) Relevance — fail-safe to RELEVANT if detection errors.
+      let relevant;
+      try {
+        const files = changedFiles(rootDir);
+        relevant = isStageConfigRelevant(files, readMig);
+      } catch {
+        relevant = true; // must-fix #1: a detection error must not downgrade BLOCK -> WARN
+      }
+
+      // 2) Parity check + sibling-uncommitted probe.
+      let driftDetected = false;
+      let executionError = false;
+      let siblingUncommitted = false;
+      const details = {};
+      try {
+        const { exitCode, output } = runCheck(rootDir);
+        const cls = classifyCheckOutput(exitCode, output);
+        driftDetected = cls.driftDetected;
+        executionError = cls.executionError;
+        details.check_exit = exitCode;
+
+        const siblingRepo = resolveSibling(rootDir);
+        const sib = siblingStatus(siblingRepo);
+        details.sibling_present = sib.present;
+        if (sib.present) {
+          siblingUncommitted = sib.uncommitted;
+        } else if (!driftDetected) {
+          // sibling repo not resolvable AND --check did not positively detect drift -> fail open
+          executionError = true;
+        }
+      } catch {
+        executionError = true; // any unexpected throw -> fail open
+      }
+
+      // 3) Decide.
+      const verdict = decideVerdict({ relevant, driftDetected, siblingUncommitted, executionError });
+      details.relevant = relevant;
+      details.drift_detected = driftDetected;
+      details.sibling_uncommitted = siblingUncommitted;
+      details.execution_error = executionError;
+      details.outcome = verdict.outcome;
+
+      const isBlock = verdict.outcome === 'BLOCK';
+      return {
+        passed: verdict.passed,
+        score: verdict.passed ? 100 : 0,
+        max_score: 100,
+        issues: isBlock ? [`${GATE_NAME}: ${verdict.reason}`] : [],
+        warnings: verdict.passed && verdict.outcome !== 'PASS' ? [`${GATE_NAME} (${verdict.outcome}): ${verdict.reason}`] : [],
+        details,
+        ...(isBlock ? { remediation: BLOCK_REMEDIATION } : {}),
+      };
+    },
+  };
+}
+
+export default createCrossRepoStageConfigDriftGate;

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/cross-repo-stage-config-drift.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/cross-repo-stage-config-drift.test.js
@@ -1,0 +1,195 @@
+// Tests for SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001 — the CROSS_REPO_STAGE_CONFIG_DRIFT gate.
+// Proves: scoped-block (only a stage-config-relevant SD's real drift blocks), WARN on unrelated
+// pre-existing drift, FAIL-OPEN on execution error, and the relevance fail-safe.
+
+import { describe, it, expect } from 'vitest';
+import {
+  GATE_NAME,
+  classifyCheckOutput,
+  decideVerdict,
+  isStageConfigRelevant,
+  createCrossRepoStageConfigDriftGate,
+} from './cross-repo-stage-config-drift.js';
+
+describe('classifyCheckOutput', () => {
+  it('exit 0 → in sync (no drift, no error)', () => {
+    expect(classifyCheckOutput(0, 'CHECK PASSED: ... in sync.')).toEqual({ driftDetected: false, executionError: false });
+  });
+  it('exit 1 with "out of date" → real drift', () => {
+    expect(classifyCheckOutput(1, 'CHECK FAILED: venture-workflow.ts is out of date vs venture_stages')).toEqual({ driftDetected: true, executionError: false });
+  });
+  it('exit 1 with "byte-parity" → real drift', () => {
+    expect(classifyCheckOutput(1, 'CHECK FAILED: venture-workflow.ts ... (byte-parity broken). Run ...')).toEqual({ driftDetected: true, executionError: false });
+  });
+  it('exit 1 with a thrown DB error → execution error (fail-open)', () => {
+    expect(classifyCheckOutput(1, 'Error: supabaseUrl is required\n  at ...')).toEqual({ driftDetected: false, executionError: true });
+  });
+  it('non-zero with no recognizable drift message → execution error', () => {
+    expect(classifyCheckOutput(127, 'command not found')).toEqual({ driftDetected: false, executionError: true });
+  });
+});
+
+describe('decideVerdict', () => {
+  it('execution error → FAIL_OPEN (pass)', () => {
+    const v = decideVerdict({ relevant: true, driftDetected: true, siblingUncommitted: true, executionError: true });
+    expect(v.passed).toBe(true);
+    expect(v.outcome).toBe('FAIL_OPEN');
+  });
+  it('drift + relevant → BLOCK (fail)', () => {
+    const v = decideVerdict({ relevant: true, driftDetected: true, siblingUncommitted: false, executionError: false });
+    expect(v.passed).toBe(false);
+    expect(v.outcome).toBe('BLOCK');
+  });
+  it('sibling uncommitted + relevant → BLOCK (fail)', () => {
+    const v = decideVerdict({ relevant: true, driftDetected: false, siblingUncommitted: true, executionError: false });
+    expect(v.passed).toBe(false);
+    expect(v.outcome).toBe('BLOCK');
+  });
+  it('drift + NOT relevant → WARN (pass)', () => {
+    const v = decideVerdict({ relevant: false, driftDetected: true, siblingUncommitted: false, executionError: false });
+    expect(v.passed).toBe(true);
+    expect(v.outcome).toBe('WARN');
+  });
+  it('no drift → clean PASS', () => {
+    const v = decideVerdict({ relevant: true, driftDetected: false, siblingUncommitted: false, executionError: false });
+    expect(v.passed).toBe(true);
+    expect(v.outcome).toBe('PASS');
+  });
+});
+
+describe('isStageConfigRelevant', () => {
+  const noMig = () => null;
+  it('a changed SSOT input file (the generator) → relevant', () => {
+    expect(isStageConfigRelevant(['scripts/generate-stage-config.cjs', 'README.md'], noMig)).toBe(true);
+  });
+  it('a changed stage-config artifact → relevant', () => {
+    expect(isStageConfigRelevant(['lib/proving-companion/stage-config.js'], noMig)).toBe(true);
+  });
+  it('a migration whose body references venture_stages → relevant', () => {
+    const read = (f) => (f.endsWith('20260601_x.sql') ? 'ALTER TABLE venture_stages ADD COLUMN foo text;' : null);
+    expect(isStageConfigRelevant(['database/migrations/20260601_x.sql'], read)).toBe(true);
+  });
+  it('a migration NOT referencing venture_stages → not relevant', () => {
+    const read = () => 'ALTER TABLE other_table ADD COLUMN bar text;';
+    expect(isStageConfigRelevant(['database/migrations/20260601_y.sql'], read)).toBe(false);
+  });
+  it('unrelated files → not relevant', () => {
+    expect(isStageConfigRelevant(['src/components/Foo.tsx', 'docs/x.md'], noMig)).toBe(false);
+  });
+  it('a migration read that throws is swallowed (not relevant on its own)', () => {
+    const read = () => { throw new Error('ENOENT'); };
+    expect(isStageConfigRelevant(['database/migrations/20260601_z.sql'], read)).toBe(false);
+  });
+});
+
+// ---- gate validator via injected deps -------------------------------------------------------
+
+function makeGate(over = {}) {
+  const deps = {
+    gitRoot: () => '/repo',
+    changedFiles: () => over.changedFiles ?? [],
+    resolveSibling: () => '/repo/../ehg',
+    runCheck: () => over.runCheck ?? { exitCode: 0, output: 'CHECK PASSED' },
+    siblingStatus: () => over.siblingStatus ?? { present: true, uncommitted: false },
+    readMigration: () => over.migrationBody ?? null,
+  };
+  // allow function-valued overrides (e.g. changedFiles that throws)
+  if (typeof over.changedFiles === 'function') deps.changedFiles = over.changedFiles;
+  if (typeof over.runCheck === 'function') deps.runCheck = over.runCheck;
+  if (typeof over.siblingStatus === 'function') deps.siblingStatus = over.siblingStatus;
+  return createCrossRepoStageConfigDriftGate({}, deps);
+}
+
+describe('createCrossRepoStageConfigDriftGate validator', () => {
+  it('exposes the canonical gate name and is required', () => {
+    const g = makeGate();
+    expect(g.name).toBe(GATE_NAME);
+    expect(g.name).toBe('CROSS_REPO_STAGE_CONFIG_DRIFT');
+    expect(g.required).toBe(true);
+  });
+
+  it('relevant SD + real drift → BLOCK (passed:false, remediation present)', async () => {
+    const g = makeGate({
+      changedFiles: ['scripts/generate-stage-config.cjs'],
+      runCheck: { exitCode: 1, output: 'CHECK FAILED: venture-workflow.ts is out of date vs venture_stages' },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.issues[0]).toContain(GATE_NAME);
+    expect(r.remediation).toMatch(/venture-stages:generate|venture-workflow\.ts/);
+    expect(r.details.outcome).toBe('BLOCK');
+  });
+
+  it('UNRELATED SD + drift → WARN (passed:true, warning, no remediation)', async () => {
+    const g = makeGate({
+      changedFiles: ['src/components/Foo.tsx'],
+      runCheck: { exitCode: 1, output: 'CHECK FAILED: venture-workflow.ts is out of date vs venture_stages' },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(true);
+    expect(r.warnings.length).toBe(1);
+    expect(r.warnings[0]).toContain('WARN');
+    expect(r.remediation).toBeUndefined();
+    expect(r.details.outcome).toBe('WARN');
+  });
+
+  it('relevant SD + sibling uncommitted (check clean) → BLOCK', async () => {
+    const g = makeGate({
+      changedFiles: ['lib/proving-companion/stage-config.js'],
+      runCheck: { exitCode: 0, output: 'CHECK PASSED' },
+      siblingStatus: { present: true, uncommitted: true },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(false);
+    expect(r.details.outcome).toBe('BLOCK');
+    expect(r.details.sibling_uncommitted).toBe(true);
+  });
+
+  it('execution error (check throws DB error) → FAIL-OPEN (passed:true + warning)', async () => {
+    const g = makeGate({
+      changedFiles: ['scripts/generate-stage-config.cjs'],
+      runCheck: { exitCode: 1, output: 'Error: supabaseUrl is required' },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(true);
+    expect(r.details.outcome).toBe('FAIL_OPEN');
+    expect(r.warnings[0]).toContain('FAIL_OPEN');
+  });
+
+  it('sibling repo absent AND no positive drift → FAIL-OPEN', async () => {
+    const g = makeGate({
+      changedFiles: ['scripts/generate-stage-config.cjs'],
+      runCheck: { exitCode: 0, output: 'CHECK PASSED' },
+      siblingStatus: { present: false, uncommitted: false },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(true);
+    expect(r.details.outcome).toBe('FAIL_OPEN');
+  });
+
+  it('relevance detection error → treated as RELEVANT (must-fix #1: no silent downgrade)', async () => {
+    const g = makeGate({
+      changedFiles: () => { throw new Error('git diff failed'); },
+      runCheck: { exitCode: 1, output: 'CHECK FAILED: byte-parity broken' },
+    });
+    const r = await g.validator({});
+    expect(r.details.relevant).toBe(true);
+    expect(r.passed).toBe(false); // real drift + forced-relevant → BLOCK, not WARN
+    expect(r.details.outcome).toBe('BLOCK');
+  });
+
+  it('clean (in sync, sibling committed) → PASS with no warnings/issues', async () => {
+    const g = makeGate({
+      changedFiles: ['scripts/generate-stage-config.cjs'],
+      runCheck: { exitCode: 0, output: 'CHECK PASSED' },
+      siblingStatus: { present: true, uncommitted: false },
+    });
+    const r = await g.validator({});
+    expect(r.passed).toBe(true);
+    expect(r.outcome).toBeUndefined();
+    expect(r.details.outcome).toBe('PASS');
+    expect(r.issues).toEqual([]);
+    expect(r.warnings).toEqual([]);
+  });
+});

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
@@ -39,3 +39,9 @@ export { createVisionFidelityGate } from './vision-fidelity.js';
 // Reuses the EXEC-TO-PLAN gate creator — readEnforcementMode + Pocock
 // /diagnose Phase-1 discipline applies to RCA results emitted in either phase.
 export { createRcaFeedbackLoopGate } from '../../exec-to-plan/gates/rca-feedback-loop-gate.js';
+
+// Cross-Repo Stage-Config Drift (SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001)
+// Makes the venture_stages SSOT -> sibling ehg venture-workflow.ts byte-parity drift VISIBLE
+// to LEO at PLAN-TO-LEAD. Scoped-block (only a stage-config-relevant SD's real drift),
+// WARN on unrelated pre-existing drift, fail-open on execution error.
+export { createCrossRepoStageConfigDriftGate } from './cross-repo-stage-config-drift.js';

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -49,7 +49,8 @@ import {
   createScopeAuditGate,
   createChildScopeCoverageGate,
   // Vision Fidelity Gate (SD-LEO-INFRA-VISION-FIDELITY-GATE-001 FR-2)
-  createVisionFidelityGate
+  createVisionFidelityGate,
+  createCrossRepoStageConfigDriftGate
 } from './gates/index.js';
 // Note: requiresTraceabilityGates is re-exported via 'export * from ./gates/index.js'
 
@@ -338,6 +339,13 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // Semantic Validation Gates (SD-LEO-FEAT-SEMANTIC-VALIDATION-GATES-002)
     gates.push(createScopeAuditGate(this.supabase));
     gates.push(createChildScopeCoverageGate(this.supabase));
+
+    // Cross-Repo Stage-Config Drift (SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001)
+    // Runs generate-stage-config.cjs --check + a sibling-uncommitted probe so the
+    // venture_stages SSOT -> ehg/src/config/venture-workflow.ts drift is VISIBLE to LEO before
+    // LEAD-FINAL. Scoped-block (only this SD's real drift), WARN on unrelated pre-existing
+    // drift, fail-open on execution error (DB down / sibling repo absent / git error).
+    gates.push(createCrossRepoStageConfigDriftGate(this.supabase));
 
     // DB Content Parity — runs before /learn (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)
     gates.push(createDbContentParityGate());


### PR DESCRIPTION
## Summary
The `venture_stages` SSOT (EHG_Engineer DB) drives a **generated** file in the sibling `ehg` repo (`ehg/src/config/venture-workflow.ts`). Byte-parity was enforced only by an **advisory** CI job (`venture-stages-drift-guard.yml`, `continue-on-error`) — **invisible to LEO**. So a worker who changes the stage SSOT reaches LEAD_FINAL believing done while the cross-repo merge is structurally blocked by a stale ehg file. Recurs on every SSOT/stage change.

Adds a **PLAN-TO-LEAD gate `CROSS_REPO_STAGE_CONFIG_DRIFT`** that runs `node scripts/generate-stage-config.cjs --check` + probes the sibling repo for an uncommitted `venture-workflow.ts`, making the drift **visible to LEO** at the "believing done" checkpoint.

## Fleet-safe by design
- **Scoped block** — blocks only when *this SD* touched stage-config SSOT inputs (the generator/artifact, or a `venture_stages` migration) **and** drift is real.
- **WARN** on pre-existing drift from an unrelated SD — never wedges the fleet.
- **Fail-open** on any execution error (DB down, sibling repo absent, git/script error).
- **Relevance fail-safe** — a changed-file detection error is treated as RELEVANT, so a parse error can't silently downgrade a real regression from BLOCK → WARN.

## Dogfood
This SD's own PLAN-TO-LEAD ran the new gate: because its changed files are gate files (not stage-config inputs) it was correctly classified **unrelated → WARN** (real pre-existing drift surfaced, not blocked). ✅

## Changes
- `plan-to-lead/gates/cross-repo-stage-config-drift.js` — gate + pure classifiers (`classifyCheckOutput`, `decideVerdict`, `isStageConfigRelevant`) + factory with injectable I/O.
- Registered in `plan-to-lead/gates/index.js` + `getRequiredGates()`.
- 24 vitest cases.

## v1 limit (deferred)
`--check`/git-status read the **local** sibling tree, so "committed locally but not pushed/merged" still slips through. Push/merge-landing enforcement (`related_prs` schema + landing-order automation) is deferred to follow-up SDs.

SD: SD-FDBK-INFRA-SYSTEMIC-CROSS-REPO-001 (infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)