### PR TITLE
fix(SD-FDBK-FIX-SELF-CLAIM-DEDUP-001): dedup guard so self_claim never rebuilds an in-flight SD

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -258,6 +258,7 @@ async function selfClaimDraftSd(sb, sessionId, base) {
     );
     for (const d of ordered) {
       if (!(await draftDepsSatisfied(sb, d))) continue; // skip dependency-blocked
+      if (await isSdInFlight(sb, d.sd_key, sessionId)) continue; // dedup: skip SDs already started or live-foreign-held
       const claimed = await tryClaim(sb, d.sd_key, sessionId);
       if (claimed.ok) {
         return {
@@ -270,6 +271,40 @@ async function selfClaimDraftSd(sb, sessionId, base) {
     }
   } catch { /* fail-open -> caller continues to QF/idle */ }
   return null;
+}
+
+/**
+ * Dedup guard: should this SD candidate be SKIPPED by self-claim because it is already
+ * being built? v_sd_next_candidates only filters completed/cancelled/deferred and
+ * selfClaimDraftSd only filters claiming_session_id IS NULL, so both can surface an SD
+ * another session is mid-build on; claim_sd's 900s guard misses long-build heartbeat
+ * lapses (auto_stale_takeover). Returns true to SKIP when the SD is (a) past LEAD
+ * (started — current_phase != 'LEAD'; phase only advances on an ACCEPTED handoff, so this
+ * avoids the rejected-first-handoff false positive that raw handoff-row presence has) OR
+ * (b) held by a LIVE foreign session (v_active_sessions.is_alive — a generous liveness
+ * signal that covers heartbeat gaps beyond claim_sd's 900s backstop). Fails OPEN (any
+ * error -> false -> never blocks self_claim). SD-FDBK-FIX-SELF-CLAIM-DEDUP-001.
+ */
+async function isSdInFlight(sb, sdKey, mySessionId) {
+  try {
+    // (a) already started past the initial LEAD draft
+    const { data: sd } = await sb
+      .from('strategic_directives_v2')
+      .select('current_phase')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (sd && sd.current_phase && sd.current_phase !== 'LEAD') return true;
+    // (b) a live foreign session already holds it
+    const { data: live } = await sb
+      .from('v_active_sessions')
+      .select('session_id')
+      .eq('sd_key', sdKey)
+      .neq('session_id', mySessionId)
+      .eq('is_alive', true)
+      .limit(1);
+    if (live && live.length) return true;
+  } catch { /* fail-open: never block self_claim on a guard error */ }
+  return false;
 }
 
 async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinatorId } = {}) {
@@ -334,6 +369,7 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
       .select('sd_id, track, status, priority')
       .limit(SELF_CLAIM_CANDIDATE_LIMIT);
     for (const c of (cands || [])) {
+      if (await isSdInFlight(sb, c.sd_id, sessionId)) continue;  // dedup: skip SDs already started or live-foreign-held
       const claimed = await tryClaim(sb, c.sd_id, sessionId, c.track);
       if (claimed.ok) {
         return { ...base, action: 'self_claimed', sd: c.sd_id, track: c.track, message: `Self-claimed ${c.sd_id} from sd:next. Run: node scripts/sd-start.js ${c.sd_id}` };
@@ -381,7 +417,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, isSdInFlight, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -47,6 +47,11 @@ function makeStub(cfg) {
       if (table === 'claude_sessions') return Promise.resolve({ data: cfg.session || null, error: null });
       if (table === 'sd_baseline_items') return Promise.resolve({ data: { track: 'STANDALONE' }, error: null });
       if (table === 'session_coordination' && state.op === 'insert') return Promise.resolve({ data: { id: 'rollcall-new' }, error: null });
+      // isSdInFlight (a): SELECT current_phase ... WHERE sd_key=? .maybeSingle()
+      if (table === 'strategic_directives_v2') {
+        if (cfg.inFlightThrow) return Promise.reject(new Error('isSdInFlight query failed'));
+        return Promise.resolve({ data: (cfg.sdRows && cfg.sdRows[state.filters.sd_key]) || null, error: null });
+      }
       return Promise.resolve({ data: null, error: null });
     }
     function resolveList() {
@@ -66,6 +71,14 @@ function makeStub(cfg) {
       if (table === 'quick_fixes') {
         if (cfg.quickFixesThrow) return Promise.reject(new Error('quick_fixes query failed'));
         return Promise.resolve({ data: cfg.quickFixes || [], error: null });
+      }
+      // isSdInFlight (b): live foreign session on this sd_key (eq sd_key, neq session_id, eq is_alive=true)
+      if (table === 'v_active_sessions') {
+        const rows = (cfg.activeSessions || []).filter((r) =>
+          r.sd_key === state.filters.sd_key &&
+          r.session_id !== state.filters.neq_session_id &&
+          r.is_alive === true);
+        return Promise.resolve({ data: rows, error: null });
       }
       return Promise.resolve({ data: [], error: null });
     }
@@ -392,5 +405,62 @@ describe('SELF-001: draftDepsSatisfied dependency-shape handling', () => {
     const sb = makeStub({ depRows: [] }); // no SD rows; should still be satisfied
     const deps = [{ sd_key: 'none' }, { sd_key: 'None' }, { type: 'note', status: 'pending', dependency: 'design review' }];
     expect(await draftDepsSatisfied(sb, { dependencies: deps })).toBe(true);
+  });
+});
+
+// SD-FDBK-FIX-SELF-CLAIM-DEDUP-001: self_claim must not duplicate an in-flight SD.
+describe('FIX-DEDUP: isSdInFlight predicate', () => {
+  it('true when the SD is past LEAD (started — phase only advances on an accepted handoff)', async () => {
+    const sb = makeStub({ sdRows: { 'SD-X-001': { current_phase: 'EXEC' } } });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(true);
+  });
+  it('false for a fresh LEAD draft with no live foreign session', async () => {
+    const sb = makeStub({ sdRows: { 'SD-X-001': { current_phase: 'LEAD' } }, activeSessions: [] });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(false);
+  });
+  it('false when current_phase=LEAD even though a first handoff was rejected (uses phase, not raw handoff presence)', async () => {
+    const sb = makeStub({ sdRows: { 'SD-X-001': { current_phase: 'LEAD' } } });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(false);
+  });
+  it('true when a LIVE foreign session already holds the SD', async () => {
+    const sb = makeStub({ sdRows: { 'SD-X-001': { current_phase: 'LEAD' } }, activeSessions: [{ sd_key: 'SD-X-001', session_id: 'other', is_alive: true }] });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(true);
+  });
+  it('false when only MY OWN session is live on it (not a foreign holder)', async () => {
+    const sb = makeStub({ sdRows: { 'SD-X-001': { current_phase: 'LEAD' } }, activeSessions: [{ sd_key: 'SD-X-001', session_id: 'me', is_alive: true }] });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(false);
+  });
+  it('false (fail-open) when the guard query throws', async () => {
+    const sb = makeStub({ inFlightThrow: true });
+    expect(await isSdInFlight(sb, 'SD-X-001', 'me')).toBe(false);
+  });
+});
+
+describe('FIX-DEDUP: runCheckin skips in-flight SDs in BOTH self-claim tiers', () => {
+  const base = { session: { metadata: {}, sd_key: null }, messages: [] };
+  it('step 6 (v_sd_next_candidates): skips a past-LEAD candidate and claims the next fresh one', async () => {
+    const sb = makeStub({ ...base,
+      candidates: [{ sd_id: 'SD-INFLIGHT-001', track: 'A' }, { sd_id: 'SD-FRESH-002', track: 'B' }],
+      sdRows: { 'SD-INFLIGHT-001': { current_phase: 'EXEC' }, 'SD-FRESH-002': { current_phase: 'LEAD' } },
+      claimResults: { 'SD-INFLIGHT-001': true, 'SD-FRESH-002': true },
+    });
+    const r = await runCheckin(sb, 'me', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-FRESH-002'); // the claimable-but-in-flight top candidate was skipped
+  });
+  it('selfClaimDraftSd: skips a live-foreign-held draft and claims the next free one', async () => {
+    const sb = makeStub({ ...base,
+      candidates: [],
+      drafts: [
+        { sd_key: 'SD-DRAFT-LIVE-001', status: 'draft', sd_type: 'feature', priority: 'high', dependencies: [] },
+        { sd_key: 'SD-DRAFT-FREE-002', status: 'draft', sd_type: 'feature', priority: 'high', dependencies: [] },
+      ],
+      sdRows: { 'SD-DRAFT-LIVE-001': { current_phase: 'LEAD' }, 'SD-DRAFT-FREE-002': { current_phase: 'LEAD' } },
+      activeSessions: [{ sd_key: 'SD-DRAFT-LIVE-001', session_id: 'other', is_alive: true }],
+      claimResults: { 'SD-DRAFT-LIVE-001': true, 'SD-DRAFT-FREE-002': true },
+    });
+    const r = await runCheckin(sb, 'me', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-DRAFT-FREE-002');
   });
 });


### PR DESCRIPTION
## Summary
`worker-checkin.cjs` `runCheckin()` has **two** SD self-claim tiers — step 6 (`v_sd_next_candidates`) and step 6.25 `selfClaimDraftSd` — and neither excluded an SD another session is already building. The view filters only `completed/cancelled/deferred`; the draft tier filters only `claiming_session_id IS NULL`. `claim_sd`'s 900s foreign-holder guard misses a long build whose heartbeat lapses past 900s (`auto_stale_takeover`), so worker `059eb732` self-claimed an SD another session was building → **wasted duplicate** (incident: `SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001`, PR #4369).

## Fix (no migration)
A shared **`isSdInFlight(sb, sdKey, mySessionId)`** guard, called before `tryClaim` in **both** tiers, skips a candidate that is:
- **(a) past LEAD** — `strategic_directives_v2.current_phase != 'LEAD'`. Phase only advances on an **accepted** handoff, so this is the correct "started / non-terminal handoffs" signal and avoids the false positive of raw handoff-row presence (which over-triggers on a *rejected* first handoff — the handoffs table is 11.5k rejected / 1.1k blocked, not all accepted), **or**
- **(b) held by a live foreign session** — a `v_active_sessions` row with `sd_key`=candidate, a different `session_id`, `is_alive=true` (generous liveness covering heartbeat gaps beyond `claim_sd`'s 900s).

Fails **open** (any guard query error → not-in-flight → never blocks self_claim). `claim_sd`'s 900s guard stays the backstop. The QF self-claim tier is already deduped by `claim_sd` + `status='open'` and is out of scope.

## Testing
- **44/44** unit tests (8 new: predicate boundaries incl. own-session, rejected-first-handoff-stays-LEAD, fail-open; + both-tier integration — past-LEAD skipped in step 6, live-foreign skipped in `selfClaimDraftSd`).
- Live-verified `isSdInFlight` against the real schema (true for an in-flight EXEC SD, false for a non-existent key).

## Out of scope
`claim_sd`/release/sweep (unchanged); QF self-claim tier; reclamation of genuinely-abandoned mid-builds (the sweep/reaper's job — skipping past-LEAD SDs is the intended conservative behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)