### PR TITLE
fix(SD-FDBK-FIX-COMPLETE-QUICK-FIX-001): close residual non-interactive prompt gaps in complete-quick-fix

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -39,7 +39,7 @@ export function prompt(question) {
   if (_nonInteractiveMode) {
     return Promise.reject(new Error(
       `[NON_INTERACTIVE] Refusing to prompt under --non-interactive mode. Question was: ${question.trim()}. ` +
-      `Pass the value explicitly via CLI flag (e.g., --uat-verified yes, --verification-notes "...", --force-complete --reason "...").`
+      `Pass the value explicitly via CLI flag (e.g., --uat-verified yes, --verification-notes "...", --actual-loc <N>, --force-complete --reason "...").`
     ));
   }
 
@@ -48,10 +48,26 @@ export function prompt(question) {
     output: process.stdout
   });
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let answered = false;
     rl.question(question, (answer) => {
+      answered = true;
       rl.close();
       resolve(answer);
+    });
+    // SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: a caller who FORGOT --non-interactive used to HANG forever
+    // here — under the Bash tool / cron / CI, process.stdin.isTTY is `undefined` (not false), so an
+    // isTTY check is unreliable; instead readline reaches EOF immediately and `close` fires with the
+    // answer callback never invoked, while supabase/heartbeat timers keep the event loop alive
+    // (indefinite hang → the 2-min Bash timeout). Reject fast on EOF-without-answer. PIPED input
+    // (e.g. `printf 'no\n' | ...`) still resolves normally because the answer callback fires first.
+    rl.on('close', () => {
+      if (!answered) {
+        reject(new Error(
+          `[NON_INTERACTIVE] stdin closed with no answer to: ${question.trim()}. ` +
+          `Pass the value via a CLI flag (--uat-verified yes / --actual-loc <N> / --non-interactive / --force-complete --reason "..."), or pipe an answer.`
+        ));
+      }
     });
   });
 }

--- a/scripts/modules/complete-quick-fix/compliance-loop.js
+++ b/scripts/modules/complete-quick-fix/compliance-loop.js
@@ -92,8 +92,11 @@ export async function runComplianceWithRefinement(qfId, qf, context, prompt, fla
       // 9th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 (sibling miss
       // in QF-20260509-552 which patched validateTests + git-operations.js
       // prompts but not this one).
-      const refineChoice = flags.forceComplete
-        ? (console.log('\n   --force-complete set — auto-skipping refinement.\n'), 'skip')
+      // SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: --non-interactive must auto-skip too (sibling parity
+      // with --force-complete; PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY — this site was guarded for
+      // --force-complete only, so a plain --non-interactive run still rejected here).
+      const refineChoice = (flags.forceComplete || flags.nonInteractive)
+        ? (console.log('\n   --force-complete/--non-interactive set — auto-skipping refinement.\n'), 'skip')
         : await prompt('\n   Attempt auto-refinement? (yes/no/skip): ');
 
       if (refineChoice.toLowerCase() === 'skip') {

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -167,7 +167,9 @@ export async function completeQuickFix(qfId, options = {}) {
     reason: options.reason,
     overCapReason: options.overCapReason,
     // SD-FDBK-ENH-COMPLETE-QUICK-FIX-002: thread pure-deletion LOC so the cap is net-aware
-    sourceDeletionLoc
+    sourceDeletionLoc,
+    // SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: thread non-interactive so the escalate prompt fails-fast
+    nonInteractive: options.nonInteractive
   });
   if (!locValid) {
     process.exit(1);
@@ -458,7 +460,9 @@ export async function completeQuickFix(qfId, options = {}) {
   // asymmetry; sibling miss in QF-20260509-552).
   const { complianceResults } = await runComplianceWithRefinement(qfId, qf, complianceContext, prompt, {
     forceComplete: options.forceComplete,
-    reason: options.reason
+    reason: options.reason,
+    // SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: thread non-interactive so the refinement prompt auto-skips
+    nonInteractive: options.nonInteractive
   });
   // QF-20260508-407: forward {forceComplete, reason} so validateCompliance can
   // short-circuit the WARN-verdict prompt under --non-interactive (sibling parity

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -81,6 +81,12 @@ export async function validateLOC(sourceLoc, testLoc, qfId, supabase, prompt, fl
   console.log('⚠️  This issue must be escalated to a full Strategic Directive.\n');
   console.log('   To bypass with audit trail: --force-complete --reason "<text>"\n');
 
+  // SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: under --non-interactive, don't wedge on the escalate prompt.
+  // An over-cap QF must fail LOUD (pass --force-complete --reason to bypass) rather than hang.
+  if (flags.nonInteractive) {
+    console.log('   --non-interactive: refusing to auto-escalate. Pass --force-complete --reason "<text>" to bypass the LOC cap.\n');
+    return false;
+  }
   const escalate = await prompt('Auto-escalate to SD? (yes/no): ');
 
   if (escalate.toLowerCase().startsWith('y')) {

--- a/tests/unit/complete-quick-fix-noninteractive-prompts.test.js
+++ b/tests/unit/complete-quick-fix-noninteractive-prompts.test.js
@@ -22,6 +22,14 @@ const gitOpsPath = fileURLToPath(
 const orch = readFileSync(orchPath, 'utf8');
 const gitOps = readFileSync(gitOpsPath, 'utf8');
 
+// SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: the remaining prompt sites + the TTY safety net.
+const compliancePath = fileURLToPath(new URL('../../scripts/modules/complete-quick-fix/compliance-loop.js', import.meta.url));
+const verificationPath = fileURLToPath(new URL('../../scripts/modules/complete-quick-fix/verification.js', import.meta.url));
+const cliPath = fileURLToPath(new URL('../../scripts/modules/complete-quick-fix/cli.js', import.meta.url));
+const compliance = readFileSync(compliancePath, 'utf8');
+const verification = readFileSync(verificationPath, 'utf8');
+const cli = readFileSync(cliPath, 'utf8');
+
 describe('complete-quick-fix prompts guarded under --non-interactive (QF-20260529-888)', () => {
   it('verificationNotes prompt is skipped under --non-interactive / --force-complete', () => {
     expect(orch).toMatch(
@@ -44,5 +52,40 @@ describe('complete-quick-fix prompts guarded under --non-interactive (QF-2026052
     expect(gitOps).toMatch(/await prompt\('   Merge to main now\?/);
     expect(gitOps).toMatch(/await prompt\('   Commit these changes\?/);
     expect(orch).toMatch(/await prompt\('\\nVerification notes/);
+  });
+});
+
+describe('SD-FDBK-FIX-COMPLETE-QUICK-FIX-001: residual prompt gaps closed under --non-interactive', () => {
+  it('compliance-loop refinement prompt auto-skips under --non-interactive (not only --force-complete)', () => {
+    // guard widened from `flags.forceComplete` to include `|| flags.nonInteractive`
+    expect(compliance).toMatch(/\(flags\.forceComplete \|\| flags\.nonInteractive\)/);
+    // ordering: the widened guard precedes the auto-refinement prompt
+    const idxGuard = compliance.indexOf('flags.nonInteractive');
+    const idxPrompt = compliance.indexOf("Attempt auto-refinement?");
+    expect(idxGuard).toBeGreaterThan(-1);
+    expect(idxGuard).toBeLessThan(idxPrompt);
+  });
+
+  it('validateLOC escalate prompt is skipped (returns false) under --non-interactive', () => {
+    const idxGuard = verification.indexOf('flags.nonInteractive');
+    const idxPrompt = verification.indexOf("await prompt('Auto-escalate to SD?");
+    expect(idxGuard).toBeGreaterThan(-1);
+    expect(idxPrompt).toBeGreaterThan(-1);
+    expect(idxGuard).toBeLessThan(idxPrompt); // guard BEFORE the prompt
+    expect(verification).toMatch(/if \(flags\.nonInteractive\)[\s\S]*?return false/);
+  });
+
+  it('orchestrator threads nonInteractive into validateLOC and runComplianceWithRefinement (no dead-code guards)', () => {
+    expect(orch).toMatch(/validateLOC\([^;]*nonInteractive:\s*options\.nonInteractive/);
+    expect(orch).toMatch(/runComplianceWithRefinement\([^;]*nonInteractive:\s*options\.nonInteractive/);
+  });
+
+  it('cli prompt() rejects on EOF-without-answer (forgotten --non-interactive) so it fails-fast not hangs; piped input still resolves', () => {
+    // isTTY is unreliable (undefined under the Bash tool), so use readline close + an answered-guard.
+    expect(cli).toMatch(/rl\.on\('close'/);
+    expect(cli).toMatch(/let answered = false/);
+    expect(cli).toMatch(/if \(!answered\)/);
+    // the answer callback sets answered=true so a piped/typed answer wins over the close-reject
+    expect(cli).toMatch(/answered = true/);
   });
 });


### PR DESCRIPTION
## Summary
`complete-quick-fix` hung indefinitely for autonomous `/loop` fleet workers and CI. A 4-agent verify-before-build pass showed most non-interactive support already existed (`--non-interactive` flag + commit/push/merge/UAT/PR/notes/low-confidence/compliance-warn guards), so this scopes only the **genuine residual gaps**:

- **`cli.js prompt()`** — a caller who FORGOT `--non-interactive` hung forever. Under the Bash tool / cron / CI, `process.stdin.isTTY` is `undefined` (not `false`), so readline reaches EOF with the answer callback never firing while supabase/heartbeat timers keep the loop alive. Fix: reject fast on readline `'close'` with no answer (an `answered` guard). Piped input (`printf 'no\n' | …`) still resolves.
- **`compliance-loop.js`** — refinement prompt auto-skipped only under `--force-complete` → widened to `|| flags.nonInteractive` (+ threaded at the orchestrator call site).
- **`verification.js` `validateLOC`** — the over-cap "Auto-escalate to SD?" prompt had no non-interactive guard → fail loud (`return false`) under `--non-interactive` (+ threaded).

`orchestrator.js` threads `nonInteractive` into both call sites so the new guards aren't dead code (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY).

## Testing
- `npx vitest run tests/unit/complete-quick-fix` → **20 files / 214 tests, 0 failures**
- +4 regression tests across all 5 sites; behavioral validation confirms EOF→reject and piped→resolve
- TESTING sub-agent verdict: PASS (row `fa3e81e9`)

## LEO
SD-FDBK-FIX-COMPLETE-QUICK-FIX-001 (bugfix, FAST track) · gates LEAD-TO-PLAN 93 / PLAN-TO-EXEC 94 / EXEC-TO-PLAN 94 / PLAN-TO-LEAD 97 · retro 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)