### PR TITLE
fix(SD-FDBK-FIX-STAGE-WORKER-SUPERVISOR-001): chokidar basename dotfile-ignore (worktree hot-reload)

### DIFF
--- a/scripts/lib/watch-ignore.mjs
+++ b/scripts/lib/watch-ignore.mjs
@@ -1,0 +1,19 @@
+// scripts/lib/watch-ignore.mjs — SD-FDBK-FIX-STAGE-WORKER-SUPERVISOR-001
+import { basename } from 'path';
+
+/**
+ * chokidar `ignored` predicate: ignore dotfiles by BASENAME only.
+ *
+ * The previous inline regex `/(^|[/\\])\../` matched a dotted segment ANYWHERE in the
+ * path, so a `.worktrees` (or any dotted) ANCESTOR excluded the ENTIRE watch tree —
+ * silently disabling hot-reload when the stage-worker supervisor runs from inside a git
+ * worktree. Matching only the leaf basename still ignores real dotfiles (.git, .env,
+ * .cache) without excluding a tree that merely lives under a dotted ancestor.
+ *
+ * chokidar v4 calls `ignored` with the full path of each watched entry; we look only at
+ * its basename so ancestor segments never trigger a tree-wide exclusion.
+ *
+ * @param {string} p path chokidar is considering (absolute or relative)
+ * @returns {boolean} true to ignore the entry
+ */
+export const isDotfileBasename = (p) => basename(String(p)).startsWith('.');

--- a/scripts/lib/watch-ignore.test.js
+++ b/scripts/lib/watch-ignore.test.js
@@ -1,0 +1,36 @@
+/**
+ * Unit tests — SD-FDBK-FIX-STAGE-WORKER-SUPERVISOR-001
+ * isDotfileBasename ignores dotfiles by BASENAME only, so a '.worktrees' (or any dotted)
+ * ANCESTOR no longer excludes the whole stage-worker watch tree.
+ */
+import { describe, it, expect } from 'vitest';
+import { isDotfileBasename } from './watch-ignore.mjs';
+
+const OLD_REGEX = /(^|[/\\])\../; // the buggy path-wide matcher we replaced
+
+describe('isDotfileBasename', () => {
+  it('ignores real dotfiles by basename', () => {
+    expect(isDotfileBasename('/repo/.git')).toBe(true);
+    expect(isDotfileBasename('/repo/lib/eva/.env')).toBe(true);
+    expect(isDotfileBasename('/repo/.cache/x')).toBe(false); // .cache is an ancestor here; leaf is 'x'
+    expect(isDotfileBasename('/repo/lib/eva/.cache')).toBe(true); // .cache is the leaf
+  });
+
+  it('does NOT ignore a tree that merely lives under a dotted ancestor (the fix)', () => {
+    const underWorktree = 'C:/repo/.worktrees/SD-X/lib/eva/foo.js';
+    expect(isDotfileBasename(underWorktree)).toBe(false);
+    expect(isDotfileBasename('C:/repo/.worktrees/SD-X/lib/eva')).toBe(false);
+    // Regression control: the OLD regex WOULD have excluded the whole tree.
+    expect(OLD_REGEX.test(underWorktree)).toBe(true);
+    expect(isDotfileBasename(underWorktree)).not.toBe(OLD_REGEX.test(underWorktree));
+  });
+
+  it('still ignores a real dotfile leaf even under a dotted ancestor', () => {
+    expect(isDotfileBasename('C:/repo/.worktrees/SD-X/.git')).toBe(true);
+  });
+
+  it('handles non-string / empty input without throwing', () => {
+    expect(isDotfileBasename('')).toBe(false);
+    expect(isDotfileBasename(undefined)).toBe(false); // String(undefined)='undefined' -> basename 'undefined'
+  });
+});

--- a/scripts/start-stage-worker.js
+++ b/scripts/start-stage-worker.js
@@ -35,6 +35,7 @@ dotenv.config();
 import { createClient } from '@supabase/supabase-js';
 import { writeFileSync, unlinkSync } from 'fs';
 import { resolve, dirname } from 'path';
+import { isDotfileBasename } from './lib/watch-ignore.mjs';
 import { fileURLToPath } from 'url';
 import { fork } from 'child_process';
 import chokidar from 'chokidar';
@@ -190,7 +191,10 @@ function runSupervisor() {
     const watchPaths = buildWatchPaths(projectRoot);
 
     const watcher = chokidar.watch(watchPaths, {
-      ignored: /(^|[/\\])\../, // dotfiles
+      // SD-FDBK-FIX-STAGE-WORKER-SUPERVISOR-001: ignore dotfiles by BASENAME only. The prior
+      // regex /(^|[/\\])\../ matched a dotted segment ANYWHERE in the path, so a '.worktrees'
+      // ancestor (running from a git worktree) silently excluded the ENTIRE watch tree.
+      ignored: isDotfileBasename,
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
     });


### PR DESCRIPTION
## Summary
`scripts/start-stage-worker.js` watched files with `ignored: /(^|[/\])\../` — a dotfile regex that matches a dotted segment **anywhere in the path**. Running the supervisor from inside a git worktree (path contains `.worktrees`) therefore matched the ancestor and **silently excluded the entire watch tree**, disabling all hot-reload. (Harmless in prod — the supervisor runs from the main checkout — but a footgun for worktree-based dev/testing; found verifying PR #4369.)

**Fix:** replace the path-wide regex with a **basename-only** predicate — `scripts/lib/watch-ignore.mjs` `isDotfileBasename = (p) => basename(p).startsWith('.')`, a chokidar-v4 `ignored` function. Real dotfiles (`.git`/`.env`/`.cache` leaves) are still ignored; a tree under a dotted ancestor is no longer excluded.

The predicate lives in its own module because `start-stage-worker.js` has **no main-guard** (it calls `runSupervisor()` at load), so importing it for a test would launch the supervisor.

## Test plan
- `scripts/lib/watch-ignore.test.js` — **4/4** network-free vitest cases incl. a **regression control** asserting the OLD regex matched a `.worktrees` path while `isDotfileBasename` does not. Plus real-dotfile, dotfile-leaf-under-dotted-ancestor, and empty-input cases.
- `node --check scripts/start-stage-worker.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)