### PR TITLE
fix(SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-002): exclude completion-flag auto-captures from SOURCE BACKLOG verdict

### DIFF
--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -14,6 +14,7 @@ import { createClient } from '@supabase/supabase-js';
 import { countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
 import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
 import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
+import { sourceableBacklog } from './lib/sourceable-backlog.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -36,9 +37,14 @@ const POOL_THRESHOLD = (() => {
 })();
 
 // (1) harness backlog
-const { data: hb } = await db.from('feedback').select('id,title,status,severity,created_at').eq('category', 'harness_backlog').in('status', OPEN).order('created_at', { ascending: false });
+const { data: hb } = await db.from('feedback').select('id,title,status,severity,created_at,metadata').eq('category', 'harness_backlog').in('status', OPEN).order('created_at', { ascending: false });
 const backlog = hb || [];
-const high = backlog.filter(r => ['high', 'critical'].includes((r.severity || '').toLowerCase()));
+// SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-002: the SOURCE BACKLOG verdict was a false-positive — the
+// harness_backlog feed is dominated by completion-flag / fleet-retro AUTO-CAPTURES (closure
+// witnesses filed at SD completion, metadata.flag_class set, titled "Completion flag (...) — SD-").
+// Source the verdict from GENUINE, non-capture items only.
+const sourceable = sourceableBacklog(backlog);
+const high = sourceable.filter(r => ['high', 'critical'].includes((r.severity || '').toLowerCase()));
 
 // (2) SD queue
 const { data: sd } = await db.from('strategic_directives_v2').select('sd_key,status,current_phase,claiming_session_id,updated_at,dependencies').not('status', 'in', termList);
@@ -71,11 +77,11 @@ const poolWarn = poolUtil >= POOL_THRESHOLD;
 
 // sourcing decision: feed the fleet only if there is idle capacity AND the queue can't fill it
 const capacity = builders + liveIdle;
-const starving = backlog.length > 0 && liveIdle > 0 && unclaimed.length < capacity;
-const toSource = starving ? Math.min(backlog.length, capacity - unclaimed.length) : 0;
+const starving = sourceable.length > 0 && liveIdle > 0 && unclaimed.length < capacity;
+const toSource = starving ? Math.min(sourceable.length, capacity - unclaimed.length) : 0;
 
 console.log('[COORD-AUDIT] ' + new Date(t).toISOString());
-console.log('  HARNESS BACKLOG : ' + backlog.length + ' open (' + high.length + ' high/critical)');
+console.log('  HARNESS BACKLOG : ' + backlog.length + ' open (' + sourceable.length + ' sourceable, ' + high.length + ' high/critical; ' + (backlog.length - sourceable.length) + ' auto-capture closure artifacts excluded)');
 for (const r of backlog.slice(0, 10)) console.log('      [' + r.status + '/' + (r.severity || '-') + '] ' + String(r.title || '').slice(0, 78));
 console.log('  SD QUEUE        : ' + sds.length + ' non-terminal | ' + claimed + ' claimed | ' + unclaimed.length + ' unclaimed | ' + stuck.length + ' stuck(in_progress,unclaimed)');
 console.log('  WORKERS         : ' + builders + ' building, ' + liveIdle + ' live-idle');
@@ -84,7 +90,7 @@ console.log('  WORKTREE POOL   : ' + poolUsed + '/' + poolCap + ' (' + poolPct +
 console.log('  INBOX           : ' + unread + ' unread signals');
 console.log('  SOURCE BACKLOG? : ' + (starving
   ? 'YES — source ' + toSource + ' high-priority backlog item(s) into DRAFT SDs (idle capacity + thin queue)'
-  : 'no — ' + (backlog.length === 0 ? 'backlog empty'
+  : 'no — ' + (sourceable.length === 0 ? 'no sourceable backlog (all auto-capture closure artifacts)'
     : liveIdle === 0 ? 'no idle workers to feed'
     : 'queue has surplus (' + unclaimed.length + ' unclaimed ≥ ' + capacity + ' capacity) → worker-bound, wake workers instead')));
 

--- a/scripts/lib/sourceable-backlog.mjs
+++ b/scripts/lib/sourceable-backlog.mjs
@@ -1,0 +1,30 @@
+// scripts/lib/sourceable-backlog.mjs — SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-002
+//
+// The coordinator-audit SOURCE BACKLOG verdict counted EVERY open category='harness_backlog'
+// feedback row. But capture-completion-flags.js routes completion-flag captures (friction /
+// harness / feedback flags filed at SD completion) into category='harness_backlog' with
+// metadata.flag_class set and a title like "Completion flag (harness) — SD-XXX". Those are
+// CLOSURE WITNESSES from already-completed SDs, not curated work to source into NEW draft SDs —
+// counting them produced a false "source N high-priority" verdict (repro: 101 open / only 1 truly
+// high-critical, but the verdict said "source 2-3"). This filters the backlog down to GENUINE,
+// non-capture sourceable items so the verdict reflects real work.
+
+/**
+ * Is this feedback row a completion-flag / fleet-retro / coordinator-review AUTO-CAPTURE
+ * (a closure artifact), as opposed to a genuine sourceable harness-backlog item?
+ * Primary signal: metadata.flag_class (set by capture-completion-flags.js). Title fallback
+ * covers rows fetched without metadata.
+ * @param {{title?:string, metadata?:object}} r feedback row
+ * @returns {boolean}
+ */
+export const isAutoCaptureFeedback = (r) => {
+  if (r && r.metadata && r.metadata.flag_class) return true;
+  return /^\s*(completion flag|fleet retro|coordinator review)\b/i.test(String((r && r.title) || ''));
+};
+
+/**
+ * Filter a harness_backlog list to the genuine, sourceable items (drops auto-captures).
+ * @param {Array} backlog
+ * @returns {Array}
+ */
+export const sourceableBacklog = (backlog) => (backlog || []).filter((r) => !isAutoCaptureFeedback(r));

--- a/scripts/lib/sourceable-backlog.test.js
+++ b/scripts/lib/sourceable-backlog.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests — SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-002
+ * sourceableBacklog drops completion-flag / fleet-retro auto-captures (closure witnesses) from
+ * the harness_backlog feed so the coordinator-audit SOURCE BACKLOG verdict reflects genuine work.
+ */
+import { describe, it, expect } from 'vitest';
+import { isAutoCaptureFeedback, sourceableBacklog } from './sourceable-backlog.mjs';
+
+describe('isAutoCaptureFeedback', () => {
+  it('flags rows with metadata.flag_class as auto-captures', () => {
+    expect(isAutoCaptureFeedback({ title: 'whatever', metadata: { flag_class: 'harness' } })).toBe(true);
+    expect(isAutoCaptureFeedback({ title: 'x', metadata: { flag_class: 'feedback' } })).toBe(true);
+  });
+
+  it('flags completion-flag / fleet-retro / coordinator-review titles (metadata fallback)', () => {
+    expect(isAutoCaptureFeedback({ title: 'Completion flag (harness) — SD-FOO-001' })).toBe(true);
+    expect(isAutoCaptureFeedback({ title: 'Fleet retro — SD-BAR-002' })).toBe(true);
+    expect(isAutoCaptureFeedback({ title: 'Coordinator review of SD-BAZ' })).toBe(true);
+  });
+
+  it('does NOT flag a genuine harness-backlog item', () => {
+    expect(isAutoCaptureFeedback({ title: 'COORDINATION-CHANNEL BUG: messages auto-marked read', metadata: {} })).toBe(false);
+    expect(isAutoCaptureFeedback({ title: 'sd-start leaves a locked orphan worktree', metadata: null })).toBe(false);
+  });
+
+  it('handles missing/empty input safely', () => {
+    expect(isAutoCaptureFeedback({})).toBe(false);
+    expect(isAutoCaptureFeedback({ title: '' })).toBe(false);
+    expect(isAutoCaptureFeedback(null)).toBe(false);
+  });
+});
+
+describe('sourceableBacklog', () => {
+  it('keeps genuine items and drops auto-captures (the 101->genuine fix)', () => {
+    const backlog = [
+      { id: 1, title: 'Completion flag (harness) — SD-A', metadata: { flag_class: 'harness' } },
+      { id: 2, title: 'Completion flag (feedback) — SD-B', metadata: { flag_class: 'feedback' } },
+      { id: 3, title: 'GENUINE: coordinator inbox bug', metadata: {} },
+      { id: 4, title: 'Fleet retro — SD-C' },
+      { id: 5, title: 'log-harness-bug: worktree cap stalls fleet', metadata: null },
+    ];
+    const out = sourceableBacklog(backlog);
+    expect(out.map((r) => r.id)).toEqual([3, 5]);
+  });
+
+  it('returns [] for null/empty', () => {
+    expect(sourceableBacklog(null)).toEqual([]);
+    expect(sourceableBacklog([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
`coordinator-audit.mjs`'s **SOURCE BACKLOG** verdict counted **every** open `category='harness_backlog'` feedback row. But `capture-completion-flags.js` routes completion-flag captures (friction/harness/feedback flags filed **at SD completion**) into `harness_backlog` with `metadata.flag_class` set and titles like `"Completion flag (...) — SD-XXX"`. Those are **closure witnesses** from already-completed SDs, not curated work to source into new draft SDs — so the verdict was a false-positive (repro: **101 open / only 1 truly high-critical**, but it said "source 2-3 high-priority").

**Fix:** source the verdict from a **genuine, non-capture** set.
- `scripts/lib/sourceable-backlog.mjs` — new testable `isAutoCaptureFeedback` (`metadata.flag_class` primary, with a "Completion flag/Fleet retro/Coordinator review" title fallback) + `sourceableBacklog` filter. Own module because `coordinator-audit.mjs` has no main-guard (executes at import).
- `coordinator-audit.mjs` — fetch `metadata`; base the high/critical count, `starving`/`toSource`, the verdict, and the display on `sourceable` (raw open-count still shown).

**Live dry-run:** `HARNESS BACKLOG : 101 open (13 sourceable, 1 high/critical; 88 auto-capture closure artifacts excluded)` — the false "source 2-3" is gone.

**Deferred to fast-follow:** de-dupe `sourceable` vs in-flight SD scope (fuzzy title overlap).

## Test plan
- `scripts/lib/sourceable-backlog.test.js` — **6/6** network-free vitest cases (metadata signal, title fallback, genuine negatives, null-safety, the 101→genuine reduction).
- `node --check scripts/coordinator-audit.mjs` clean; live audit dry-run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)