### PR TITLE
feat(SD-FDBK-INFRA-FLOW-IMPEDIMENT-COORDINATOR-001): baseline add-item makes sourced SDs self-claimable without rebaseline

### DIFF
--- a/lib/sd-baseline/build-item.js
+++ b/lib/sd-baseline/build-item.js
@@ -1,0 +1,210 @@
+/**
+ * lib/sd-baseline/build-item.js
+ *
+ * Pure + dependency-injected helpers for the `sd-baseline add-item` subcommand
+ * (SD-FDBK-INFRA-FLOW-IMPEDIMENT-COORDINATOR-001).
+ *
+ * Goal: let a coordinator APPEND a single sourced SD to the ACTIVE execution
+ * baseline's sd_baseline_items WITHOUT a full LEAD-approval-gated rebaseline, so
+ * the SD becomes a first-class candidate in v_sd_next_candidates (readiness 3)
+ * and is self-claimable by a worker /checkin (step 6).
+ *
+ * This module has NO top-level side effects (no DB client, no CLI run), so unit
+ * tests import it network-free. scripts/sd-baseline.js auto-runs its CLI on
+ * import, so its orchestration lives here as the injectable `addItemCore`.
+ *
+ * LOAD-BEARING: sd_baseline_items.sd_id MUST be the sd_key STRING. The live view
+ * v_sd_next_candidates JOINs `bi.sd_id = sd.sd_key` (def 20260606012331 line 63)
+ * and there is NO foreign key to catch a UUID — writing sd.id is a silent view
+ * drop (the exact defect of the live fn_sync_sd_to_baseline trigger).
+ */
+
+// sd_baseline_items.track CHECK whitelist. NULL is also accepted by the CHECK
+// (createBaseline inserts null for unmapped tracks), so deriveTrack returns null
+// for unknown metadata rather than guessing.
+export const TRACK_WHITELIST = ['A', 'B', 'C', 'STANDALONE', 'DEFERRED'];
+
+const TERMINAL_STATUSES = ['completed', 'cancelled', 'deferred'];
+
+/**
+ * Map metadata.execution_track (+ optional explicit --track flag) to a track code.
+ * Mirrors scripts/sd-baseline.js createBaseline (unknown -> null, NOT STANDALONE).
+ * An explicit --track flag wins but must be CHECK-safe or it throws (user error).
+ */
+export function deriveTrack(metadataExecutionTrack, trackFlag) {
+  if (trackFlag !== undefined && trackFlag !== null && trackFlag !== '') {
+    const t = String(trackFlag).toUpperCase();
+    if (!TRACK_WHITELIST.includes(t)) {
+      throw new Error(`Invalid --track "${trackFlag}": must be one of ${TRACK_WHITELIST.join(', ')}`);
+    }
+    return t;
+  }
+  const track = metadataExecutionTrack;
+  return track === 'Infrastructure' || track === 'Safety' ? 'A'
+    : track === 'Feature' ? 'B'
+    : track === 'Quality' ? 'C'
+    : track === 'STANDALONE' ? 'STANDALONE'
+    : null;
+}
+
+export function trackName(trackKey) {
+  return trackKey === 'A' ? 'Infrastructure/Safety'
+    : trackKey === 'B' ? 'Feature/Stages'
+    : trackKey === 'C' ? 'Quality'
+    : trackKey === 'STANDALONE' ? 'Standalone'
+    : 'Unassigned';
+}
+
+/**
+ * Next sequence_rank: an explicit requestedRank (validated positive int) wins;
+ * otherwise MAX(existingRanks)+1, or 1 when the baseline has no items.
+ */
+export function computeNextRank(existingRanks, requestedRank) {
+  if (requestedRank !== undefined && requestedRank !== null && requestedRank !== '') {
+    const n = Number(requestedRank);
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`Invalid --rank "${requestedRank}": must be a positive integer`);
+    }
+    return n;
+  }
+  const ranks = (existingRanks || []).map(Number).filter((n) => Number.isFinite(n));
+  return ranks.length === 0 ? 1 : Math.max(...ranks) + 1;
+}
+
+/**
+ * Build one sd_baseline_items row. Pure. sd_id is ALWAYS sd.sd_key (never sd.id).
+ */
+export function buildBaselineItemRow({ sd, baselineId, sequenceRank, trackFlag, healthScore }) {
+  if (!sd || !sd.sd_key) {
+    throw new Error('buildBaselineItemRow: sd.sd_key is required (the v_sd_next_candidates JOIN key)');
+  }
+  const track = deriveTrack(sd.metadata && sd.metadata.execution_track, trackFlag);
+  const score = typeof healthScore === 'number' ? healthScore : 1.0;
+  return {
+    baseline_id: baselineId,
+    sd_id: sd.sd_key, // MUST be sd_key — a UUID here is a silent view drop (no FK)
+    sequence_rank: sequenceRank,
+    track,
+    track_name: trackName(track),
+    dependencies_snapshot: sd.dependencies == null ? null : sd.dependencies,
+    dependency_health_score: score,
+    is_ready: score >= 1.0,
+    notes: `Coordinator-added (incremental, no rebaseline): ${sd.title || sd.sd_key}`,
+  };
+}
+
+export function isTerminalStatus(status) {
+  return TERMINAL_STATUSES.includes(status);
+}
+
+/**
+ * Dependency-injected orchestration for `add-item`. Returns a structured result
+ * (so tests assert without parsing logs) AND prints via the injected `log`.
+ *
+ * @param {object}   deps
+ * @param {object}   deps.supabase   - Supabase-style client (real or fake).
+ * @param {string}   deps.sdKey      - the sd_key to add.
+ * @param {object}   [deps.opts]     - { track, rank }.
+ * @param {function} deps.calcHealth - async (dependencies) => number (0..1).
+ * @param {function} [deps.log]      - console.log-style sink.
+ * @returns {Promise<{action:'added'|'noop'|'guidance'|'error', message:string, row?:object}>}
+ */
+export async function addItemCore({ supabase, sdKey, opts = {}, calcHealth, log = console.log }) {
+  if (!sdKey) {
+    const message = 'Usage: sd:baseline add-item <sd_key> [--track A|B|C|STANDALONE] [--rank N]';
+    log(message);
+    return { action: 'error', message };
+  }
+
+  // 1) Active baseline must exist (do NOT silently auto-create — that is ensure-active-baseline's job on /checkin).
+  const { data: baseline } = await supabase
+    .from('sd_execution_baselines')
+    .select('id, baseline_name')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (!baseline) {
+    const message = "No active baseline. Run 'npm run sd:baseline create' (or it auto-creates on the next worker /checkin), then retry.";
+    log(message);
+    return { action: 'guidance', message };
+  }
+
+  // 2) Fetch the SD; refuse terminal status.
+  const { data: sd, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, priority, dependencies, metadata')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (sdErr || !sd) {
+    const message = `SD not found: ${sdKey}`;
+    log(message);
+    return { action: 'error', message };
+  }
+  if (isTerminalStatus(sd.status)) {
+    const message = `Refusing: ${sdKey} is ${sd.status} (terminal). add-item is for active/draft work.`;
+    log(message);
+    return { action: 'error', message };
+  }
+
+  // 3) Idempotency pre-check on UNIQUE(baseline_id, sd_id).
+  const { data: existing } = await supabase
+    .from('sd_baseline_items')
+    .select('id')
+    .eq('baseline_id', baseline.id)
+    .eq('sd_id', sd.sd_key)
+    .maybeSingle();
+  if (existing) {
+    const message = `${sdKey} is already in the active baseline (no-op).`;
+    log(message);
+    return { action: 'noop', message };
+  }
+
+  // 4) Build + insert with a single bounded retry on sequence_rank collision
+  //    (re-reading MAX+1). A 23505 on sd_id is treated as an idempotent no-op.
+  const healthScore = await calcHealth(sd.dependencies);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const { data: rankRows } = await supabase
+      .from('sd_baseline_items')
+      .select('sequence_rank')
+      .eq('baseline_id', baseline.id);
+    const existingRanks = (rankRows || []).map((r) => r.sequence_rank);
+
+    let row;
+    try {
+      const sequenceRank = computeNextRank(existingRanks, attempt === 0 ? opts.rank : undefined);
+      row = buildBaselineItemRow({ sd, baselineId: baseline.id, sequenceRank, trackFlag: opts.track, healthScore });
+    } catch (e) {
+      log(e.message);
+      return { action: 'error', message: e.message };
+    }
+
+    const { error: insErr } = await supabase.from('sd_baseline_items').insert(row);
+    if (!insErr) {
+      // best-effort actuals (matches createBaseline; swallow errors)
+      try {
+        await supabase.from('sd_execution_actuals').insert({ sd_id: sd.sd_key, baseline_id: baseline.id, status: 'not_started' });
+      } catch { /* non-fatal */ }
+      const message = `Added ${sdKey} to active baseline '${baseline.baseline_name}' (rank ${row.sequence_rank}, track ${row.track || 'Unassigned'}). It will appear in v_sd_next_candidates (readiness_priority 3 if deps satisfied + draft/active) and be self-claimable via worker /checkin.`;
+      log(message);
+      return { action: 'added', message, row };
+    }
+
+    if (insErr.code === '23505') {
+      const blob = `${insErr.message || ''} ${insErr.details || ''}`;
+      if (blob.includes('sequence_rank')) {
+        continue; // rank race — retry with a freshly re-read MAX+1
+      }
+      // sd_id duplicate (concurrent add) — idempotent no-op
+      const message = `${sdKey} already in the active baseline (concurrent add, no-op).`;
+      log(message);
+      return { action: 'noop', message };
+    }
+
+    const message = `Error adding item: ${insErr.message}`;
+    log(message);
+    return { action: 'error', message };
+  }
+
+  const message = 'sequence_rank collision after retry — another session is adding concurrently; re-run add-item.';
+  log(message);
+  return { action: 'error', message };
+}

--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
     "sd:baseline": "node scripts/sd-baseline.js",
     "sd:baseline:create": "node scripts/sd-baseline.js create",
     "sd:baseline:view": "node scripts/sd-baseline.js view",
+    "sd:baseline:add-item": "node scripts/sd-baseline.js add-item",
     "sd:baseline:intelligent": "node scripts/sd-baseline-intelligent.js",
     "sd:baseline:intelligent:preview": "node scripts/sd-baseline-intelligent.js --preview",
     "sd:baseline:intelligent:dry": "node scripts/sd-baseline-intelligent.js --dry-run",

--- a/scripts/sd-baseline.js
+++ b/scripts/sd-baseline.js
@@ -17,6 +17,7 @@
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import dotenv from 'dotenv';
 import readline from 'readline';
+import { addItemCore } from '../lib/sd-baseline/build-item.js';
 
 dotenv.config();
 
@@ -57,6 +58,9 @@ class SDBaselineManager {
         break;
       case 'rebaseline':
         await this.rebaseline();
+        break;
+      case 'add-item':
+        await this.addItem(this.args[0], this.parseAddFlags());
         break;
       default:
         this.showHelp();
@@ -458,6 +462,40 @@ class SDBaselineManager {
     return Math.round((completedCount / deps.length) * 100) / 100;
   }
 
+  // Parse `add-item <sd_key> [--track A|B|C|STANDALONE] [--rank N]` flags from this.args.
+  parseAddFlags() {
+    const a = this.args;
+    const opts = {};
+    for (let i = 1; i < a.length; i++) {
+      const arg = a[i];
+      if (arg === '--track') opts.track = a[++i];
+      else if (arg.startsWith('--track=')) opts.track = arg.slice('--track='.length);
+      else if (arg === '--rank') opts.rank = a[++i];
+      else if (arg.startsWith('--rank=')) opts.rank = arg.slice('--rank='.length);
+    }
+    return opts;
+  }
+
+  // Append a single sourced SD to the ACTIVE baseline (incremental, no rebaseline,
+  // no LEAD gate). Thin wrapper over the injectable, network-free addItemCore.
+  // SD-FDBK-INFRA-FLOW-IMPEDIMENT-COORDINATOR-001.
+  async addItem(sdKey, opts = {}) {
+    const c = colors;
+    await addItemCore({
+      supabase,
+      sdKey,
+      opts,
+      calcHealth: (deps) => this.calculateDependencyHealthScore(deps),
+      log: (msg) => {
+        // colorize by leading keyword for parity with the rest of the CLI
+        if (/^Added /.test(msg)) console.log(`${c.green}${msg}${c.reset}`);
+        else if (/already in the active baseline|No active baseline/.test(msg)) console.log(`${c.yellow}${msg}${c.reset}`);
+        else if (/^(Error|Refusing|SD not found|Invalid|sequence_rank collision|Usage)/.test(msg)) console.log(`${c.red}${msg}${c.reset}`);
+        else console.log(msg);
+      },
+    });
+  }
+
   showHelp() {
     console.log(`
 ${colors.bold}SD Baseline Management${colors.reset}
@@ -468,6 +506,7 @@ ${colors.cyan}Commands:${colors.reset}
   list       List all baselines
   activate   Activate a specific baseline (requires LEAD approval)
   rebaseline Create new baseline, superseding the current one
+  add-item   Append ONE sourced SD to the active baseline (coordinator; no rebaseline/LEAD gate)
 
 ${colors.cyan}Usage:${colors.reset}
   npm run sd:baseline              View active baseline
@@ -475,6 +514,7 @@ ${colors.cyan}Usage:${colors.reset}
   npm run sd:baseline list         List all baselines
   npm run sd:baseline activate <id> Activate a baseline
   npm run sd:baseline rebaseline   Create a rebaseline
+  npm run sd:baseline add-item <sd_key> [--track A] [--rank N]  Append one SD to the active baseline
 
 ${colors.cyan}Notes:${colors.reset}
   - Only one baseline can be active at a time

--- a/tests/unit/sd-baseline-add-item.test.js
+++ b/tests/unit/sd-baseline-add-item.test.js
@@ -1,0 +1,289 @@
+/**
+ * SD-FDBK-INFRA-FLOW-IMPEDIMENT-COORDINATOR-001
+ * Unit tests for the `sd-baseline add-item` helpers + orchestration.
+ *
+ * Network-free: imports ONLY lib/sd-baseline/build-item.js (no side effects) and
+ * drives addItemCore with a hand-rolled fake Supabase client. Never imports
+ * scripts/sd-baseline.js (which auto-runs the CLI on import).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveTrack,
+  trackName,
+  computeNextRank,
+  buildBaselineItemRow,
+  isTerminalStatus,
+  addItemCore,
+  TRACK_WHITELIST,
+} from '../../lib/sd-baseline/build-item.js';
+
+// ── Fake Supabase client tuned to addItemCore's exact call sequence ──────────
+// plan: { baseline, sd, sdError, existingItem, ranksSeq[], insertSeq[], actuals }
+function makeFakeClient(plan = {}) {
+  const calls = { itemInserts: [], actualsInserts: 0, rankReads: 0 };
+  let insertIdx = 0;
+  let rankIdx = 0;
+
+  function builder(table) {
+    const state = { table, op: 'select', cols: '', filters: {}, row: null };
+    const api = {
+      select(cols) { state.op = 'select'; state.cols = cols || ''; return api; },
+      eq(col, val) { state.filters[col] = val; return api; },
+      insert(row) { state.op = 'insert'; state.row = row; return api; },
+      maybeSingle() { return Promise.resolve(resolveSingle()); },
+      single() { return Promise.resolve(resolveSingle()); },
+      then(onF, onR) { return Promise.resolve(resolveTerminal()).then(onF, onR); },
+    };
+
+    function resolveSingle() {
+      if (state.table === 'sd_execution_baselines') return { data: plan.baseline ?? null, error: null };
+      if (state.table === 'strategic_directives_v2') return { data: plan.sd ?? null, error: plan.sdError ?? null };
+      if (state.table === 'sd_baseline_items') {
+        // select('id') with sd_id filter == idempotency pre-check
+        return { data: plan.existingItem ?? null, error: null };
+      }
+      return { data: null, error: null };
+    }
+    function resolveTerminal() {
+      if (state.op === 'insert' && state.table === 'sd_baseline_items') {
+        calls.itemInserts.push(state.row);
+        const res = plan.insertSeq?.[insertIdx++] ?? { error: null };
+        return res;
+      }
+      if (state.op === 'insert' && state.table === 'sd_execution_actuals') {
+        calls.actualsInserts++;
+        return plan.actuals ?? { error: null };
+      }
+      if (state.op === 'select' && state.table === 'sd_baseline_items') {
+        // rank list read
+        calls.rankReads++;
+        const rows = plan.ranksSeq?.[rankIdx++] ?? [];
+        return { data: rows, error: null };
+      }
+      return { data: null, error: null };
+    }
+    return api;
+  }
+
+  return { from: (t) => builder(t), __calls: calls };
+}
+
+const SD = {
+  id: 'uuid-1111',
+  sd_key: 'SD-TEST-ADD-001',
+  title: 'Test SD',
+  status: 'draft',
+  priority: 'medium',
+  dependencies: [],
+  metadata: { execution_track: 'Infrastructure' },
+};
+const BASELINE = { id: 'baseline-1', baseline_name: 'Active BL' };
+const calcHealth1 = async () => 1.0;
+const silent = () => {};
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+describe('buildBaselineItemRow (pure)', () => {
+  it('TS-1: sd_id is sd_key, never the UUID id', () => {
+    const row = buildBaselineItemRow({ sd: SD, baselineId: 'b1', sequenceRank: 5, healthScore: 1.0 });
+    expect(row.sd_id).toBe('SD-TEST-ADD-001');
+    expect(row.sd_id).not.toBe(SD.id);
+  });
+
+  it('TS-4: is_ready boundary at healthScore >= 1.0', () => {
+    expect(buildBaselineItemRow({ sd: SD, baselineId: 'b', sequenceRank: 1, healthScore: 0.99 }).is_ready).toBe(false);
+    expect(buildBaselineItemRow({ sd: SD, baselineId: 'b', sequenceRank: 1, healthScore: 1.0 }).is_ready).toBe(true);
+    expect(buildBaselineItemRow({ sd: SD, baselineId: 'b', sequenceRank: 1, healthScore: 1.01 }).is_ready).toBe(true);
+  });
+
+  it('TS-4: notes carries the incremental audit marker', () => {
+    const row = buildBaselineItemRow({ sd: SD, baselineId: 'b', sequenceRank: 1, healthScore: 1.0 });
+    expect(row.notes).toContain('Coordinator-added (incremental, no rebaseline)');
+    expect(row.notes).toContain(SD.title);
+  });
+
+  it('throws when sd.sd_key is missing (load-bearing JOIN key)', () => {
+    expect(() => buildBaselineItemRow({ sd: { id: 'x' }, baselineId: 'b', sequenceRank: 1, healthScore: 1 }))
+      .toThrow(/sd_key is required/);
+  });
+
+  it('dependencies_snapshot passes through (null when absent)', () => {
+    expect(buildBaselineItemRow({ sd: { sd_key: 'X', dependencies: [{ sd_key: 'SD-DEP' }] }, baselineId: 'b', sequenceRank: 1, healthScore: 1 }).dependencies_snapshot)
+      .toEqual([{ sd_key: 'SD-DEP' }]);
+    expect(buildBaselineItemRow({ sd: { sd_key: 'X' }, baselineId: 'b', sequenceRank: 1, healthScore: 1 }).dependencies_snapshot).toBeNull();
+  });
+});
+
+describe('deriveTrack (pure)', () => {
+  it('TS-2: maps metadata.execution_track to track codes (unknown -> null)', () => {
+    expect(deriveTrack('Infrastructure')).toBe('A');
+    expect(deriveTrack('Safety')).toBe('A');
+    expect(deriveTrack('Feature')).toBe('B');
+    expect(deriveTrack('Quality')).toBe('C');
+    expect(deriveTrack('STANDALONE')).toBe('STANDALONE');
+    expect(deriveTrack('SomethingElse')).toBeNull();
+    expect(deriveTrack(undefined)).toBeNull();
+  });
+
+  it('TS-2: an explicit --track flag overrides metadata and is upper-cased', () => {
+    expect(deriveTrack('Infrastructure', 'c')).toBe('C');
+    expect(deriveTrack('Quality', 'STANDALONE')).toBe('STANDALONE');
+  });
+
+  it('TS-2: track output is ALWAYS null or in the CHECK whitelist (avoids 23514)', () => {
+    for (const m of ['Infrastructure', 'Safety', 'Feature', 'Quality', 'STANDALONE', 'weird', undefined, null]) {
+      const t = deriveTrack(m);
+      expect(t === null || TRACK_WHITELIST.includes(t)).toBe(true);
+    }
+  });
+
+  it('TS-2: an invalid --track flag throws (user error, not a silent 23514)', () => {
+    expect(() => deriveTrack('Feature', 'Z')).toThrow(/Invalid --track/);
+  });
+
+  it('trackName maps codes to human labels', () => {
+    expect(trackName('A')).toBe('Infrastructure/Safety');
+    expect(trackName(null)).toBe('Unassigned');
+  });
+});
+
+describe('computeNextRank (pure)', () => {
+  it('TS-3: MAX+1 when no requested rank', () => {
+    expect(computeNextRank([3, 7, 12])).toBe(13);
+  });
+  it('TS-3: 1 when the baseline is empty', () => {
+    expect(computeNextRank([])).toBe(1);
+    expect(computeNextRank(undefined)).toBe(1);
+  });
+  it('TS-3: an explicit requested rank wins', () => {
+    expect(computeNextRank([3, 7], 5)).toBe(5);
+  });
+  it('TS-3: an invalid requested rank throws', () => {
+    expect(() => computeNextRank([1], 0)).toThrow(/Invalid --rank/);
+    expect(() => computeNextRank([1], 'abc')).toThrow(/Invalid --rank/);
+  });
+});
+
+describe('isTerminalStatus (pure)', () => {
+  it('flags completed/cancelled/deferred only', () => {
+    expect(isTerminalStatus('completed')).toBe(true);
+    expect(isTerminalStatus('cancelled')).toBe(true);
+    expect(isTerminalStatus('deferred')).toBe(true);
+    expect(isTerminalStatus('draft')).toBe(false);
+    expect(isTerminalStatus('active')).toBe(false);
+  });
+});
+
+// ── addItemCore orchestration (DI fake client) ───────────────────────────────
+describe('addItemCore (DI)', () => {
+  it('errors with usage when sdKey is missing', async () => {
+    const c = makeFakeClient({});
+    const r = await addItemCore({ supabase: c, sdKey: '', calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('error');
+    expect(c.__calls.itemInserts).toHaveLength(0);
+  });
+
+  it('TS-5: no active baseline -> guidance, no insert', async () => {
+    const c = makeFakeClient({ baseline: null });
+    const r = await addItemCore({ supabase: c, sdKey: 'SD-X', calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('guidance');
+    expect(c.__calls.itemInserts).toHaveLength(0);
+  });
+
+  it('SD not found -> error, no insert', async () => {
+    const c = makeFakeClient({ baseline: BASELINE, sd: null });
+    const r = await addItemCore({ supabase: c, sdKey: 'SD-MISSING', calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('error');
+    expect(c.__calls.itemInserts).toHaveLength(0);
+  });
+
+  it('TS-6: terminal-status SD is refused, no insert', async () => {
+    const c = makeFakeClient({ baseline: BASELINE, sd: { ...SD, status: 'completed' } });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('error');
+    expect(c.__calls.itemInserts).toHaveLength(0);
+  });
+
+  it('TS-7: idempotent pre-check (already in baseline) -> noop, no insert', async () => {
+    const c = makeFakeClient({ baseline: BASELINE, sd: SD, existingItem: { id: 'item-1' } });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('noop');
+    expect(c.__calls.itemInserts).toHaveLength(0);
+  });
+
+  it('TS-9: happy path -> added; one item insert with sd_id=sd_key; actuals inserted', async () => {
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[{ sequence_rank: 3 }, { sequence_rank: 7 }]],
+      insertSeq: [{ error: null }],
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('added');
+    expect(c.__calls.itemInserts).toHaveLength(1);
+    expect(c.__calls.itemInserts[0].sd_id).toBe(SD.sd_key);
+    expect(c.__calls.itemInserts[0].sequence_rank).toBe(8); // MAX(3,7)+1
+    expect(c.__calls.actualsInserts).toBe(1);
+  });
+
+  it('TS-9: --rank override is honored on the first attempt', async () => {
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[{ sequence_rank: 3 }]],
+      insertSeq: [{ error: null }],
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, opts: { rank: '99' }, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('added');
+    expect(c.__calls.itemInserts[0].sequence_rank).toBe(99);
+  });
+
+  it('TS-7b: 23505 on sd_id during insert -> idempotent noop', async () => {
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[{ sequence_rank: 1 }]],
+      insertSeq: [{ error: { code: '23505', message: 'duplicate key value violates unique constraint "sd_baseline_items_baseline_id_sd_id_key"', details: 'Key (baseline_id, sd_id)=(...) already exists.' } }],
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('noop');
+    expect(c.__calls.itemInserts).toHaveLength(1);
+  });
+
+  it('TS-8: 23505 on sequence_rank -> retry once with re-read MAX+1, then success', async () => {
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[{ sequence_rank: 5 }], [{ sequence_rank: 5 }, { sequence_rank: 6 }]], // 2nd read sees a new rank
+      insertSeq: [
+        { error: { code: '23505', message: 'duplicate key value violates unique constraint "sd_baseline_items_baseline_id_sequence_rank_key"', details: 'Key (baseline_id, sequence_rank)=(...) already exists.' } },
+        { error: null },
+      ],
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('added');
+    expect(c.__calls.itemInserts).toHaveLength(2);
+    expect(c.__calls.rankReads).toBe(2); // re-read before retry
+    expect(c.__calls.itemInserts[0].sequence_rank).toBe(6); // MAX(5)+1
+    expect(c.__calls.itemInserts[1].sequence_rank).toBe(7); // MAX(5,6)+1 after re-read
+  });
+
+  it('TS-8b: 23505 on sequence_rank twice -> error (collision after bounded retry)', async () => {
+    const seqErr = { error: { code: '23505', message: 'unique constraint "sd_baseline_items_baseline_id_sequence_rank_key"', details: 'Key (baseline_id, sequence_rank)=(...) already exists.' } };
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[{ sequence_rank: 1 }], [{ sequence_rank: 1 }]],
+      insertSeq: [seqErr, seqErr],
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('error');
+    expect(c.__calls.itemInserts).toHaveLength(2);
+  });
+
+  it('actuals insert error is swallowed -> still added', async () => {
+    const c = makeFakeClient({
+      baseline: BASELINE, sd: SD, existingItem: null,
+      ranksSeq: [[]],
+      insertSeq: [{ error: null }],
+      actuals: { error: { code: 'XX', message: 'actuals boom' } },
+    });
+    const r = await addItemCore({ supabase: c, sdKey: SD.sd_key, calcHealth: calcHealth1, log: silent });
+    expect(r.action).toBe('added');
+    expect(c.__calls.itemInserts[0].sequence_rank).toBe(1); // empty baseline -> rank 1
+  });
+});


### PR DESCRIPTION
## SD-FDBK-INFRA-FLOW-IMPEDIMENT-COORDINATOR-001 — coordinator baseline `add-item`

### Problem
`v_sd_next_candidates` (the self-claim queue read by worker-checkin step 6, `sd:next`, and coordinator dispatch) is driven **only** by `sd_baseline_items` rows in the singleton active baseline. Both populate paths filter on non-null `sequence_rank`, so a freshly-**sourced** draft never enters the active baseline. A coordinator doing the conveyor-belt duty couldn't make a sourced SD a first-class candidate without a full **LEAD-approval-gated rebaseline** (`sd-baseline.js rebaseline` blocks on an interactive `LEAD APPROVED` prompt). Until now such SDs only surfaced via the lower-priority step-6.25 `selfClaimDraftSd` fallback.

### Fix (Option A — surgical, additive)
A coordinator-runnable `node scripts/sd-baseline.js add-item <sd_key> [--track A|B|C|STANDALONE] [--rank N]` that **appends one SD** to the active baseline's `sd_baseline_items` (sequence_rank = MAX+1 or `--rank`; track from `metadata.execution_track`), so it surfaces in `v_sd_next_candidates` at `readiness_priority 3` and is self-claimable via worker `/checkin`. **No rebaseline, no LEAD gate, no schema/view/worker-checkin change.** Appending to an already-LEAD-approved baseline is not a rebaseline (which mints/supersedes a snapshot — that's what the LEAD gate protects); it matches the existing no-prompt programmatic writes in `ensure-active-baseline.cjs`.

**Load-bearing correctness:** the row writes `sd_id = sd.sd_key` (the live view JOIN key, def `20260606012331` line 63) — never the UUID. There is no FK, so a UUID would be a silent view drop.

### Files
- `lib/sd-baseline/build-item.js` (NEW) — pure `buildBaselineItemRow` / `computeNextRank` / `deriveTrack` + the injectable, network-free `addItemCore` (no import side effects).
- `scripts/sd-baseline.js` — `addItem()` + `parseAddFlags()` + `run()` `add-item` case + help (imports `addItemCore`).
- `package.json` — `sd:baseline:add-item` npm alias (WIRE_CHECK).
- `tests/unit/sd-baseline-add-item.test.js` (NEW) — 26 network-free scenarios.

### Verification
- **26/26 unit tests pass** (1.56s, zero network): sd_id=sd_key not UUID, track CHECK-parity, is_ready boundary, computeNextRank, idempotency (23505 on sd_id → no-op), rank-race (23505 on sequence_rank → single retry re-reading MAX+1), no-baseline + terminal-status guards, happy path.
- **Live activation chain proven then cleaned up (net-zero):** `add-item SD-FDBK-FIX-DRIFT-CHECK-FAILS-001` → the SD appeared in `v_sd_next_candidates` at `readiness_priority=3, deps_satisfied=true`; idempotent re-run was a clean no-op; test rows then deleted.
- Idempotent + safe alongside the live auto-sync trigger.

### Out of scope (sibling SD — signaled to coordinator `63e239fc`)
Prospective sub-agents (validation `3bb2b12c`, testing `0e61f63a`) found a **fleet-wide root cause**: the live trigger `fn_sync_sd_to_baseline()` auto-appends every new SD with `sd_id = NEW.id` (UUID) the view cannot join — the active baseline has **3082 dead UUID rows** + 343 terminal `sd_key` rows, so `v_sd_next_candidates` returns **0 rows fleet-wide**. Held out of scope (scope-lock); flagged for a sibling SD to fix the trigger to write `NEW.sd_key` + purge dead rows. `add-item` writes joinable `sd_key` rows, so it works despite the pollution.

### PR size
540 insertions (251 production incl. ~70 lines of JSDoc on the load-bearing helper; 289 network-free tests). Logic-only ≈150 LOC. The test suite + DI module extraction (required for network-free testing of a CLI that auto-runs on import) account for the bulk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
