### PR TITLE
feat(SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001): real per-FR delivery gate + default-OFF enforcement + approver descope

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -47,6 +47,10 @@ import { createProtocolFileReadGate } from '../../gates/protocol-file-read-gate.
 // Scope Completion Verification Gate (SD-LEO-INFRA-COMPLETION-SCOPE-VERIFICATION-001)
 import { createScopeCompletionGate } from '../../gates/scope-completion-gate.js';
 
+// FR Delivery Traceability Gate (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001) — real per-FR
+// delivery, default-OFF warn-only via LEO_FR_TRACEABILITY_ENFORCE.
+import { createFrDeliveryTraceabilityGate } from '../../gates/fr-delivery-traceability-gate.js';
+
 // Parent Orchestrator Detection (SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-1, FR-2)
 import { isParentOrchestrator as isParentOrchestratorAsync } from '../../../../../lib/handoff/parent-detection.js';
 import { getParentOrchestratorExecToPlanGates } from './parent-orchestrator.js';
@@ -263,6 +267,10 @@ export class ExecToPlanExecutor extends BaseExecutor {
       // Scope Completion Verification (applies to children too)
       gates.push(createScopeCompletionGate());
 
+      // FR Delivery Traceability — orchestrator children were the most exposed boundary
+      // (proxy-only gate set); the incident SD 001-A was a child. SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+      gates.push(createFrDeliveryTraceabilityGate(this.supabase));
+
       return gates;
     }
 
@@ -349,6 +357,10 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // Scope Completion Verification (SD-LEO-INFRA-COMPLETION-SCOPE-VERIFICATION-001)
     // Verifies arch plan deliverables exist in codebase before marking EXEC complete
     gates.push(createScopeCompletionGate());
+
+    // FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001) — real per-FR delivery
+    // at the completion boundary for normal SDs too; default-OFF warn-only.
+    gates.push(createFrDeliveryTraceabilityGate(this.supabase));
 
     return gates;
   }

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -14,6 +14,7 @@ import { getFilteredRetrospective } from '../../retro-filters.js';
 
 // Core Protocol Gate - SD Start Gate (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
 import { createSdStartGate } from '../../gates/core-protocol-gate.js';
+import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from '../../gates/fr-delivery-classifier.js';
 
 // Pipeline Flow Verifier (SD-LEO-INFRA-INTEGRATION-AWARE-PRD-001 FR-5)
 import { verifyPipelineFlow, requiresPipelineFlowVerification } from '../../../../../lib/pipeline-flow-verifier.js';
@@ -938,50 +939,38 @@ export function createFRDeliveryVerificationGate(supabase, prdRepo) {
         return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No FRs defined in PRD'] };
       }
 
-      console.log(`   📋 Checking ${frs.length} functional requirements...`);
+      console.log(`   📋 Checking ${frs.length} functional requirements (per-FR mapping)...`);
 
-      // Evidence sources: completed user stories + accepted handoffs
-      const { data: stories } = await supabase
-        .from('user_stories')
-        .select('id, title, status')
-        .eq('sd_id', ctx.sd.id);
-
-      const completedStories = (stories || []).filter(s =>
-        s.status === 'completed' || s.status === 'done' || s.status === 'validated'
-      );
-
-      const { data: handoffs } = await supabase
-        .from('sd_phase_handoffs')
-        .select('handoff_type, status')
-        .eq('sd_id', ctx.sd.id)
-        .eq('status', 'accepted');
-
-      const hasExecHandoff = (handoffs || []).some(h => h.handoff_type === 'PLAN-TO-LEAD');
-
-      const frResults = [];
-      for (const fr of frs) {
-        const frId = fr.id || `FR-${frs.indexOf(fr) + 1}`;
-        const evidenced = completedStories.length > 0 || hasExecHandoff;
-        frResults.push({ id: frId, description: safeTruncate(fr.description || '', 80), evidenced });
-        console.log(`   ${evidenced ? '✅' : '❌'} ${frId}: ${safeTruncate(fr.description || '', 60)}`);
+      // SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001: real per-FR classification (validated story
+      // REFERENCING the FR id, or approver-gated descope) — NOT the prior any-completed-story
+      // proxy that marked every FR delivered if any story existed. Enforcement is gated by
+      // LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only) so this strict path cannot brick
+      // the ~every in-flight SD whose stories do not yet reference FR ids.
+      const classification = await classifyFrDelivery(supabase, {
+        sdId: ctx.sd.id,
+        sdMetadata: ctx.sd.metadata || {},
+        functionalRequirements: frs,
+        requesterSessionId: ctx.sessionId || ctx.session_id || null,
+      });
+      for (const f of classification.frs) {
+        const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
+        console.log(`   ${mark} ${f.id} [${f.status}]: ${safeTruncate(f.description || '', 56)}`);
       }
-
-      const evidencedCount = frResults.filter(r => r.evidenced).length;
-      const coveragePct = Math.round((evidencedCount / frs.length) * 100);
-      console.log(`\n   📊 FR Coverage: ${evidencedCount}/${frs.length} (${coveragePct}%)`);
-
-      if (coveragePct < 100) {
-        const missing = frResults.filter(r => !r.evidenced);
-        return {
-          passed: false, score: coveragePct, max_score: 100,
-          issues: [`FR delivery coverage ${coveragePct}% — ${missing.length} FR(s) lack evidence`, ...missing.map(m => `  Missing: ${m.id}`)],
-          warnings: [], details: { frResults, coveragePct }
-        };
+      const enforced = isFrTraceabilityEnforced();
+      console.log(`\n   📊 FR delivery: ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+      const result = projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_VERIFICATION' });
+      if (!result.passed) {
+        console.log(`   ❌ FR delivery FAILED — ${classification.undelivered}/${classification.total} undelivered`);
+      } else if (result.warnings.length) {
+        console.log('   ⚠️  FR delivery passed (warn-only) with undelivered FRs');
+      } else {
+        console.log('   ✅ All FRs delivered or approver-descoped');
       }
-
-      console.log('   ✅ All FRs have delivery evidence');
-      return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: { frResults, coveragePct: 100 } };
+      return result;
     },
+    // `required` is decided dynamically inside the validator result (projectGateResult sets it
+    // from the enforcement flag). Keep the static flag true so the orchestrator consults the
+    // result; the OFF path returns required:false to stay warn-only.
     required: true
   };
 }

--- a/scripts/modules/handoff/gates/fr-delivery-classifier.js
+++ b/scripts/modules/handoff/gates/fr-delivery-classifier.js
@@ -1,0 +1,155 @@
+/**
+ * FR Delivery Classifier — shared per-FR delivery status for completion gates.
+ * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+ *
+ * Single source of truth used by BOTH the LEAD-FINAL FR_DELIVERY_VERIFICATION gate
+ * and the EXEC-TO-PLAN FR_DELIVERY_TRACEABILITY gate. Reads the AUTHORITATIVE FR list
+ * (product_requirements_v2.functional_requirements) and classifies each FR:
+ *   - DELIVERED : a validated/completed user_story REFERENCES the FR id (title / user_want /
+ *                 acceptance_criteria / technical_notes). This is real per-FR mapping, NOT the
+ *                 prior any-completed-story-marks-all-FRs proxy.
+ *   - DESCOPED  : the SD has an APPROVER-GATED descope record for the FR
+ *                 (strategic_directives_v2.metadata.descoped_frs[].approved_by non-empty and
+ *                 != the requester).
+ *   - UNDELIVERED: neither of the above.
+ *
+ * Enforcement is gated by LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only). The
+ * classifier ALWAYS runs; the gate wrappers project status -> {passed, required} per the flag.
+ */
+
+/** True when strict FR-delivery enforcement is turned on. Default OFF (warn-only). */
+export function isFrTraceabilityEnforced(env = process.env) {
+  const v = env.LEO_FR_TRACEABILITY_ENFORCE;
+  if (v == null) return false;
+  const s = String(v).trim().toLowerCase();
+  return s === '1' || s === 'true' || s === 'on' || s === 'yes';
+}
+
+/** Stable FR id for an FR entry (falls back to FR-<n> by 1-based index). */
+export function frIdOf(fr, index) {
+  return (fr && (fr.id || fr.fr_id)) || `FR-${index + 1}`;
+}
+
+/**
+ * Pure: does this user story reference the given FR id in any of its text fields?
+ * Uses a word-boundary match on the exact FR id (e.g. "FR-004") so "FR-04" / "FR-0040"
+ * do not false-match.
+ */
+export function frReferencesId(story, frId) {
+  if (!story || !frId) return false;
+  const esc = String(frId).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(^|[^\\w-])${esc}([^\\w-]|$)`, 'i');
+  const fields = [];
+  const push = (v) => { if (v == null) return; fields.push(typeof v === 'string' ? v : JSON.stringify(v)); };
+  push(story.title);
+  push(story.user_want);
+  push(story.acceptance_criteria);
+  push(story.technical_notes);
+  push(story.description);
+  return fields.some((f) => re.test(f));
+}
+
+/** A story counts as a delivery signal only when it is validated/completed. */
+export function isValidatedStory(story) {
+  const s = (story && story.status) || '';
+  const vs = (story && story.validation_status) || '';
+  return s === 'completed' || s === 'done' || s === 'validated' || vs === 'validated';
+}
+
+/** Approver-gated descope lookup for an FR id. requesterSessionId is excluded as a self-approver. */
+export function descopeFor(sdMetadata, frId, requesterSessionId = null) {
+  const list = (sdMetadata && Array.isArray(sdMetadata.descoped_frs)) ? sdMetadata.descoped_frs : [];
+  return list.find((d) => {
+    if (!d || (d.fr_id !== frId && d.id !== frId)) return false;
+    const approver = typeof d.approved_by === 'string' ? d.approved_by.trim() : '';
+    if (!approver) return false;                        // descope without a named approver is ignored
+    if (requesterSessionId && approver === requesterSessionId) return false; // no self-approval
+    return true;
+  }) || null;
+}
+
+/**
+ * Classify every FR for an SD. Injectable supabase for testing.
+ * @returns {Promise<{frs: Array<{id,description,status:'delivered'|'descoped'|'undelivered',evidence}>,
+ *   total:number, delivered:number, descoped:number, undelivered:number}>}
+ */
+export async function classifyFrDelivery(supabase, { sdId, sdMetadata = {}, functionalRequirements = null, requesterSessionId = null } = {}) {
+  let frs = functionalRequirements;
+  if (!Array.isArray(frs)) {
+    const { data: prd } = await supabase
+      .from('product_requirements_v2')
+      .select('functional_requirements')
+      .eq('directive_id', sdId)
+      .maybeSingle();
+    frs = (prd && prd.functional_requirements) || [];
+  }
+
+  const { data: stories } = await supabase
+    .from('user_stories')
+    .select('id, title, user_want, acceptance_criteria, technical_notes, description, status, validation_status')
+    .eq('sd_id', sdId);
+  const validated = (stories || []).filter(isValidatedStory);
+
+  const out = [];
+  for (let i = 0; i < frs.length; i++) {
+    const fr = frs[i];
+    const id = frIdOf(fr, i);
+    const desc = (fr && (fr.requirement || fr.description || fr.title)) || '';
+    const deliveredBy = validated.find((s) => frReferencesId(s, id));
+    if (deliveredBy) {
+      out.push({ id, description: desc, status: 'delivered', evidence: `Validated story ${deliveredBy.id} references ${id}` });
+      continue;
+    }
+    const descope = descopeFor(sdMetadata, id, requesterSessionId);
+    if (descope) {
+      out.push({ id, description: desc, status: 'descoped', evidence: `Descoped by ${descope.approved_by}${descope.reason ? `: ${descope.reason}` : ''}` });
+      continue;
+    }
+    out.push({ id, description: desc, status: 'undelivered', evidence: 'No validated story references this FR id and no approver-gated descope' });
+  }
+
+  return {
+    frs: out,
+    total: out.length,
+    delivered: out.filter((f) => f.status === 'delivered').length,
+    descoped: out.filter((f) => f.status === 'descoped').length,
+    undelivered: out.filter((f) => f.status === 'undelivered').length,
+  };
+}
+
+/**
+ * Project a classification into a gate result, honoring the enforcement flag.
+ * OFF (default): passed:true / required:false, undelivered FRs surface as WARNINGS only
+ * (byte-identical pass outcome regardless of undelivered count -> zero blast radius).
+ * ON: passed:false / required:true on any undelivered FR (hard-fails via gate.required!==false).
+ */
+export function projectGateResult(classification, { enforced = isFrTraceabilityEnforced(), gateName = 'FR_DELIVERY' } = {}) {
+  const { frs, total, delivered, descoped, undelivered } = classification;
+  const satisfied = delivered + descoped;
+  const score = total === 0 ? 100 : Math.round((satisfied / total) * 100);
+  const undeliveredList = frs.filter((f) => f.status === 'undelivered').map((f) => `${f.id}: ${f.description}`.trim());
+
+  if (total === 0) {
+    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements in PRD'], required: false, details: classification };
+  }
+  if (undelivered === 0) {
+    return { passed: true, score, max_score: 100, issues: [], warnings: [], required: enforced, details: classification };
+  }
+  // There ARE undelivered FRs.
+  if (enforced) {
+    return {
+      passed: false, score, max_score: 100, required: true,
+      issues: [`${gateName}: ${undelivered}/${total} FR(s) undelivered (no validated story reference and no approver-gated descope)`, ...undeliveredList.map((u) => `  Undelivered: ${u}`)],
+      warnings: [], details: classification,
+    };
+  }
+  // OFF = warn-only: pass with FULL score (100) so the averaged handoff normalizedScore is NOT
+  // diluted — a sub-100 score here could soft-block a borderline SD, which would break the
+  // promised zero-blast-radius. Undelivered detail lives only in warnings + details.raw_score.
+  return {
+    passed: true, score: 100, max_score: 100, required: false,
+    issues: [],
+    warnings: [`${gateName} (warn-only; set LEO_FR_TRACEABILITY_ENFORCE to enforce): ${undelivered}/${total} FR(s) lack a validated story reference or approver-gated descope`, ...undeliveredList.map((u) => `  Undelivered: ${u}`)],
+    details: { ...classification, raw_score: score },
+  };
+}

--- a/scripts/modules/handoff/gates/fr-delivery-classifier.js
+++ b/scripts/modules/handoff/gates/fr-delivery-classifier.js
@@ -45,7 +45,6 @@ export function frReferencesId(story, frId) {
   push(story.user_want);
   push(story.acceptance_criteria);
   push(story.technical_notes);
-  push(story.description);
   return fields.some((f) => re.test(f));
 }
 
@@ -73,20 +72,25 @@ export function descopeFor(sdMetadata, frId, requesterSessionId = null) {
  * @returns {Promise<{frs: Array<{id,description,status:'delivered'|'descoped'|'undelivered',evidence}>,
  *   total:number, delivered:number, descoped:number, undelivered:number}>}
  */
-export async function classifyFrDelivery(supabase, { sdId, sdMetadata = {}, functionalRequirements = null, requesterSessionId = null } = {}) {
+export async function classifyFrDelivery(supabase, { sdId, directiveId = null, sdMetadata = {}, functionalRequirements = null, requesterSessionId = null } = {}) {
   let frs = functionalRequirements;
   if (!Array.isArray(frs)) {
+    // product_requirements_v2.directive_id stores the SD KEY (e.g. SD-FOO-001), not the UUID.
+    // Callers that only have the UUID must pass directiveId=sd_key; fall back to sdId otherwise.
+    const lookupKey = directiveId || sdId;
     const { data: prd } = await supabase
       .from('product_requirements_v2')
       .select('functional_requirements')
-      .eq('directive_id', sdId)
+      .eq('directive_id', lookupKey)
       .maybeSingle();
     frs = (prd && prd.functional_requirements) || [];
   }
 
+  // NOTE: user_stories has NO `description` column — selecting it errors the whole query
+  // (data -> null -> every FR wrongly flagged undelivered). Stick to real columns.
   const { data: stories } = await supabase
     .from('user_stories')
-    .select('id, title, user_want, acceptance_criteria, technical_notes, description, status, validation_status')
+    .select('id, title, user_want, acceptance_criteria, technical_notes, status, validation_status')
     .eq('sd_id', sdId);
   const validated = (stories || []).filter(isValidatedStory);
 

--- a/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
+++ b/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
@@ -29,6 +29,9 @@ export function createFrDeliveryTraceabilityGate(supabase) {
 
       const classification = await classifyFrDelivery(supabase, {
         sdId: sd.id,
+        // product_requirements_v2.directive_id stores the sd_key, not the UUID — pass it so
+        // the PRD/FR lookup resolves at this boundary (UUID-only would vacuously find 0 FRs).
+        directiveId: sd.sd_key || sd.id,
         sdMetadata: sd.metadata || {},
         requesterSessionId: ctx.sessionId || ctx.session_id || null,
       });

--- a/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
+++ b/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
@@ -1,0 +1,51 @@
+/**
+ * FR Delivery Traceability gate for the EXEC-TO-PLAN completion boundary.
+ * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+ *
+ * Closes the gap where orchestrator CHILDREN (and normal SDs) reached EXEC-TO-PLAN with only
+ * proxy gates and FR delivery was never checked until LEAD-FINAL (and even then via an
+ * any-story proxy). Reuses the SAME shared per-FR classifier as the LEAD-FINAL gate, so the
+ * logic cannot drift between boundaries. Enforcement gated by LEO_FR_TRACEABILITY_ENFORCE
+ * (default OFF = warn-only -> zero blast radius).
+ */
+import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from './fr-delivery-classifier.js';
+
+export function createFrDeliveryTraceabilityGate(supabase) {
+  return {
+    name: 'FR_DELIVERY_TRACEABILITY',
+    validator: async (ctx) => {
+      console.log('\n🔒 GATE: FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001)');
+      console.log('-'.repeat(50));
+      const sd = ctx.sd || {};
+      // Orchestrator PARENTS delegate FR delivery to their children — skip here.
+      const { data: children } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sd.id);
+      if (children && children.length > 0) {
+        console.log('   ℹ️  Orchestrator parent — FR delivery delegated to children');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator parent — FR delivery delegated to children'], required: false };
+      }
+
+      const classification = await classifyFrDelivery(supabase, {
+        sdId: sd.id,
+        sdMetadata: sd.metadata || {},
+        requesterSessionId: ctx.sessionId || ctx.session_id || null,
+      });
+
+      if (classification.total === 0) {
+        console.log('   ℹ️  No functional requirements in PRD (or no PRD) — nothing to verify');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements found for FR delivery traceability'], required: false };
+      }
+
+      for (const f of classification.frs) {
+        const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
+        console.log(`   ${mark} ${f.id} [${f.status}]`);
+      }
+      const enforced = isFrTraceabilityEnforced();
+      console.log(`   📊 ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+      return projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_TRACEABILITY' });
+    },
+    required: true
+  };
+}

--- a/scripts/record-fr-descope.js
+++ b/scripts/record-fr-descope.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * record-fr-descope — approver-gated descope of a functional requirement.
+ * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+ *
+ * Writes an entry to strategic_directives_v2.metadata.descoped_frs so the FR delivery gate
+ * (fr-delivery-classifier.js) counts the FR as satisfied-by-descope INSTEAD of UNDELIVERED.
+ * A descope is honored ONLY when approved_by is a non-empty approver identity (and, at the
+ * gate, not the requester's own session). This makes scope cuts explicit and attributable
+ * rather than silent worker self-descopes. No migration — metadata is jsonb.
+ *
+ * Usage:
+ *   node scripts/record-fr-descope.js <SD-KEY> <FR-ID> --approved-by "<approver>" --reason "<why>"
+ *
+ * Example:
+ *   node scripts/record-fr-descope.js SD-FOO-001 FR-005 --approved-by chairman --reason "deferred to follow-on"
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--approved-by') { out.approvedBy = argv[++i]; }
+    else if (a === '--reason') { out.reason = argv[++i]; }
+    else if (a === '--approved-at') { out.approvedAt = argv[++i]; }
+    else out._.push(a);
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const [sdKey, frId] = args._;
+  if (!sdKey || !frId) {
+    console.error('Usage: node scripts/record-fr-descope.js <SD-KEY> <FR-ID> --approved-by "<approver>" [--reason "<why>"]');
+    process.exit(2);
+  }
+  if (!args.approvedBy || !String(args.approvedBy).trim()) {
+    console.error('ERROR: --approved-by "<approver>" is REQUIRED. A descope without a named approver is ignored by the FR delivery gate.');
+    process.exit(2);
+  }
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data: sd, error: e1 } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, metadata')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (e1) { console.error('DB error:', e1.message); process.exit(1); }
+  if (!sd) { console.error(`SD not found: ${sdKey}`); process.exit(1); }
+
+  const metadata = sd.metadata && typeof sd.metadata === 'object' ? sd.metadata : {};
+  const list = Array.isArray(metadata.descoped_frs) ? metadata.descoped_frs.slice() : [];
+  const entry = {
+    fr_id: frId,
+    approved_by: String(args.approvedBy).trim(),
+    reason: args.reason || null,
+    approved_at: args.approvedAt || new Date().toISOString(),
+  };
+  const existingIdx = list.findIndex((d) => d && (d.fr_id === frId || d.id === frId));
+  if (existingIdx >= 0) list[existingIdx] = entry; else list.push(entry);
+  metadata.descoped_frs = list;
+
+  const { error: e2 } = await supabase
+    .from('strategic_directives_v2')
+    .update({ metadata })
+    .eq('id', sd.id);
+  if (e2) { console.error('Update failed:', e2.message); process.exit(1); }
+
+  console.log(`✅ Recorded FR descope: ${sdKey} / ${frId} approved_by="${entry.approved_by}"${entry.reason ? ` reason="${entry.reason}"` : ''}`);
+  console.log(`   descoped_frs now has ${list.length} entr${list.length === 1 ? 'y' : 'ies'}.`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/unit/handoff/gates/fr-delivery-classifier.test.js
+++ b/tests/unit/handoff/gates/fr-delivery-classifier.test.js
@@ -1,0 +1,150 @@
+// Tests for SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001
+// Real per-FR delivery classification + default-OFF warn-only enforcement + approver descope.
+
+import { describe, it, expect } from 'vitest';
+import {
+  isFrTraceabilityEnforced,
+  frIdOf,
+  frReferencesId,
+  isValidatedStory,
+  descopeFor,
+  classifyFrDelivery,
+  projectGateResult,
+} from '../../../../scripts/modules/handoff/gates/fr-delivery-classifier.js';
+
+describe('FR-2: isFrTraceabilityEnforced — default OFF', () => {
+  it('OFF when unset', () => expect(isFrTraceabilityEnforced({})).toBe(false));
+  it('OFF for falsey strings', () => {
+    for (const v of ['', '0', 'false', 'off', 'no']) expect(isFrTraceabilityEnforced({ LEO_FR_TRACEABILITY_ENFORCE: v })).toBe(false);
+  });
+  it('ON for truthy strings', () => {
+    for (const v of ['1', 'true', 'on', 'YES']) expect(isFrTraceabilityEnforced({ LEO_FR_TRACEABILITY_ENFORCE: v })).toBe(true);
+  });
+});
+
+describe('FR-1: frReferencesId — real per-FR mapping (word-boundary)', () => {
+  it('matches the FR id in title/want/AC/notes', () => {
+    expect(frReferencesId({ title: 'Implement FR-004 growth playbook' }, 'FR-004')).toBe(true);
+    expect(frReferencesId({ user_want: 'as a user I want FR-005' }, 'FR-005')).toBe(true);
+    expect(frReferencesId({ acceptance_criteria: [{ then: 'satisfies FR-001' }] }, 'FR-001')).toBe(true);
+    expect(frReferencesId({ technical_notes: '{"fr":"FR-002"}' }, 'FR-002')).toBe(true);
+  });
+  it('does not false-match a different id (word boundary)', () => {
+    expect(frReferencesId({ title: 'FR-0040 something' }, 'FR-004')).toBe(false);
+    expect(frReferencesId({ title: 'XFR-004' }, 'FR-004')).toBe(false);
+    expect(frReferencesId({ title: 'no fr here' }, 'FR-004')).toBe(false);
+  });
+  it('handles missing story/id', () => {
+    expect(frReferencesId(null, 'FR-1')).toBe(false);
+    expect(frReferencesId({ title: 'x' }, null)).toBe(false);
+  });
+});
+
+describe('isValidatedStory', () => {
+  it('true for completed/done/validated status or validation_status=validated', () => {
+    for (const s of ['completed', 'done', 'validated']) expect(isValidatedStory({ status: s })).toBe(true);
+    expect(isValidatedStory({ status: 'ready', validation_status: 'validated' })).toBe(true);
+  });
+  it('false for in-progress/draft', () => {
+    expect(isValidatedStory({ status: 'ready' })).toBe(false);
+    expect(isValidatedStory({ status: 'draft' })).toBe(false);
+  });
+});
+
+describe('FR-4: descopeFor — approver-gated', () => {
+  const md = { descoped_frs: [
+    { fr_id: 'FR-005', approved_by: 'chairman', reason: 'deferred' },
+    { fr_id: 'FR-006', approved_by: '' },             // no approver -> ignored
+    { fr_id: 'FR-007', approved_by: 'me-session' },   // self-approval guarded below
+  ] };
+  it('honors a descope with a named approver', () => {
+    expect(descopeFor(md, 'FR-005')).toBeTruthy();
+  });
+  it('ignores a descope without an approver', () => {
+    expect(descopeFor(md, 'FR-006')).toBeNull();
+  });
+  it('rejects self-approval (approver == requester)', () => {
+    expect(descopeFor(md, 'FR-007', 'me-session')).toBeNull();
+    expect(descopeFor(md, 'FR-007', 'other-session')).toBeTruthy();
+  });
+  it('null when no descope list', () => expect(descopeFor({}, 'FR-1')).toBeNull());
+});
+
+// Injectable supabase stub: returns FRs from the PRD query and stories from user_stories.
+function stub({ stories = [] } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        then(res) {
+          if (table === 'user_stories') return Promise.resolve({ data: stories, error: null }).then(res);
+          return Promise.resolve({ data: [], error: null }).then(res);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+const FRS = [{ id: 'FR-001', requirement: 'a' }, { id: 'FR-002', requirement: 'b' }, { id: 'FR-003', requirement: 'c' }];
+
+describe('FR-1: classifyFrDelivery', () => {
+  it('classifies delivered / descoped / undelivered per-FR', async () => {
+    const stories = [
+      { id: 's1', title: 'do FR-001', status: 'completed' },
+      { id: 's2', title: 'do FR-002', status: 'ready' }, // not validated -> not a delivery signal
+    ];
+    const c = await classifyFrDelivery(stub({ stories }), {
+      sdId: 'sd-1', functionalRequirements: FRS,
+      sdMetadata: { descoped_frs: [{ fr_id: 'FR-003', approved_by: 'lead-final' }] },
+    });
+    const byId = Object.fromEntries(c.frs.map((f) => [f.id, f.status]));
+    expect(byId['FR-001']).toBe('delivered');     // validated story references it
+    expect(byId['FR-002']).toBe('undelivered');   // story exists but not validated
+    expect(byId['FR-003']).toBe('descoped');      // approver-gated descope
+    expect(c).toMatchObject({ total: 3, delivered: 1, descoped: 1, undelivered: 1 });
+  });
+});
+
+describe('FR-2: projectGateResult — flag gating', () => {
+  const undeliveredClass = { frs: [{ id: 'FR-002', description: 'b', status: 'undelivered' }, { id: 'FR-001', description: 'a', status: 'delivered' }], total: 2, delivered: 1, descoped: 0, undelivered: 1 };
+  const allGoodClass = { frs: [{ id: 'FR-001', description: 'a', status: 'delivered' }], total: 1, delivered: 1, descoped: 0, undelivered: 0 };
+
+  it('ON + undelivered -> hard fail (passed:false, required:true)', () => {
+    const r = projectGateResult(undeliveredClass, { enforced: true });
+    expect(r.passed).toBe(false);
+    expect(r.required).toBe(true);
+    expect(r.issues.join(' ')).toMatch(/undelivered/i);
+  });
+  it('OFF + undelivered -> warn-only (passed:true, required:false, FULL score, warning lists FR)', () => {
+    const r = projectGateResult(undeliveredClass, { enforced: false });
+    expect(r.passed).toBe(true);
+    expect(r.required).toBe(false);
+    expect(r.score).toBe(100);                 // NOT diluted -> zero blast radius
+    expect(r.warnings.join(' ')).toMatch(/FR-002/);
+    expect(r.details.raw_score).toBe(50);      // real coverage preserved in details
+  });
+  it('OFF pass-path is invariant regardless of undelivered count', () => {
+    const many = { frs: [], total: 5, delivered: 0, descoped: 0, undelivered: 5 };
+    const r = projectGateResult(many, { enforced: false });
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(100);
+  });
+  it('all delivered -> pass either way; required mirrors the flag', () => {
+    expect(projectGateResult(allGoodClass, { enforced: false })).toMatchObject({ passed: true, required: false });
+    expect(projectGateResult(allGoodClass, { enforced: true })).toMatchObject({ passed: true, required: true });
+  });
+  it('no FRs -> pass, required:false', () => {
+    const r = projectGateResult({ frs: [], total: 0, delivered: 0, descoped: 0, undelivered: 0 }, { enforced: true });
+    expect(r).toMatchObject({ passed: true, required: false });
+  });
+});
+
+describe('frIdOf', () => {
+  it('uses fr.id then falls back to FR-<n>', () => {
+    expect(frIdOf({ id: 'FR-009' }, 0)).toBe('FR-009');
+    expect(frIdOf({}, 3)).toBe('FR-4');
+  });
+});

--- a/tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js
+++ b/tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js
@@ -1,0 +1,73 @@
+// Tests for SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001 — the EXEC-TO-PLAN FR delivery gate
+// and its registration in BOTH the orchestrator-child and normal gate sets.
+
+import { describe, it, expect } from 'vitest';
+import { createFrDeliveryTraceabilityGate } from '../../../../scripts/modules/handoff/gates/fr-delivery-traceability-gate.js';
+
+// supabase stub: no children, FRs from PRD, stories from user_stories
+function stub({ children = [], frs = [], stories = [] } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() {
+          if (table === 'product_requirements_v2') return Promise.resolve({ data: { functional_requirements: frs }, error: null });
+          return Promise.resolve({ data: null, error: null });
+        },
+        then(res) {
+          if (table === 'strategic_directives_v2') return Promise.resolve({ data: children, error: null }).then(res);
+          if (table === 'user_stories') return Promise.resolve({ data: stories, error: null }).then(res);
+          return Promise.resolve({ data: [], error: null }).then(res);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+const ctx = { sd: { id: 'sd-1', metadata: {} } };
+
+describe('FR-3: createFrDeliveryTraceabilityGate', () => {
+  it('has the expected gate shape', () => {
+    const g = createFrDeliveryTraceabilityGate(stub());
+    expect(g.name).toBe('FR_DELIVERY_TRACEABILITY');
+    expect(typeof g.validator).toBe('function');
+  });
+
+  it('orchestrator PARENT delegates to children (pass)', async () => {
+    const g = createFrDeliveryTraceabilityGate(stub({ children: [{ id: 'child-1' }] }));
+    const r = await g.validator(ctx);
+    expect(r.passed).toBe(true);
+    expect(r.warnings.join(' ')).toMatch(/delegated to children/i);
+  });
+
+  it('OFF (default): undelivered FR -> warn-only pass (no env set)', async () => {
+    const prev = process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    delete process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    try {
+      const g = createFrDeliveryTraceabilityGate(stub({ frs: [{ id: 'FR-001' }], stories: [] }));
+      const r = await g.validator(ctx);
+      expect(r.passed).toBe(true);
+      expect(r.required).toBe(false);
+      expect(r.warnings.join(' ')).toMatch(/FR-001/);
+    } finally { if (prev === undefined) delete process.env.LEO_FR_TRACEABILITY_ENFORCE; else process.env.LEO_FR_TRACEABILITY_ENFORCE = prev; }
+  });
+
+  it('ON: undelivered FR -> hard fail', async () => {
+    const prev = process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    process.env.LEO_FR_TRACEABILITY_ENFORCE = '1';
+    try {
+      const g = createFrDeliveryTraceabilityGate(stub({ frs: [{ id: 'FR-001' }], stories: [] }));
+      const r = await g.validator(ctx);
+      expect(r.passed).toBe(false);
+      expect(r.required).toBe(true);
+    } finally { if (prev === undefined) delete process.env.LEO_FR_TRACEABILITY_ENFORCE; else process.env.LEO_FR_TRACEABILITY_ENFORCE = prev; }
+  });
+
+  it('delivered FR -> pass', async () => {
+    const g = createFrDeliveryTraceabilityGate(stub({ frs: [{ id: 'FR-001' }], stories: [{ id: 's1', title: 'do FR-001', status: 'completed' }] }));
+    const r = await g.validator(ctx);
+    expect(r.passed).toBe(true);
+  });
+});

--- a/tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js
+++ b/tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js
@@ -4,15 +4,23 @@
 import { describe, it, expect } from 'vitest';
 import { createFrDeliveryTraceabilityGate } from '../../../../scripts/modules/handoff/gates/fr-delivery-traceability-gate.js';
 
-// supabase stub: no children, FRs from PRD, stories from user_stories
+// supabase stub: no children, FRs from PRD (keyed on directive_id == PRD_KEY to catch the
+// UUID-vs-sd_key lookup bug), stories from user_stories.
+const PRD_KEY = 'SD-FR-001'; // the sd_key; PRD.directive_id stores this, NOT the UUID
 function stub({ children = [], frs = [], stories = [] } = {}) {
   return {
     from(table) {
+      const state = { filters: {} };
       const chain = {
         select() { return chain; },
-        eq() { return chain; },
+        eq(k, v) { state.filters[k] = v; return chain; },
         maybeSingle() {
-          if (table === 'product_requirements_v2') return Promise.resolve({ data: { functional_requirements: frs }, error: null });
+          if (table === 'product_requirements_v2') {
+            // Only resolve FRs when the lookup keyed on the sd_key (directive_id), proving the
+            // gate passed directiveId=sd_key rather than the UUID.
+            const data = state.filters.directive_id === PRD_KEY ? { functional_requirements: frs } : null;
+            return Promise.resolve({ data, error: null });
+          }
           return Promise.resolve({ data: null, error: null });
         },
         then(res) {
@@ -26,7 +34,7 @@ function stub({ children = [], frs = [], stories = [] } = {}) {
   };
 }
 
-const ctx = { sd: { id: 'sd-1', metadata: {} } };
+const ctx = { sd: { id: 'sd-uuid-1', sd_key: PRD_KEY, metadata: {} } };
 
 describe('FR-3: createFrDeliveryTraceabilityGate', () => {
   it('has the expected gate shape', () => {


### PR DESCRIPTION
## Summary
Harden LEO completion gating so an SD cannot complete with functional requirements silently undelivered. **RCA:** SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A completed with FR-004/005 undelivered. The existing `FR_DELIVERY_VERIFICATION` gate marked **every** FR delivered if *any* completed story existed (`evidenced = completedStories.length > 0 || hasExecHandoff`) — per-FR in name only — and ran only at LEAD-FINAL, **absent from the orchestrator-child gate set** (the incident SD was a child).

## What this does (hardens the existing gate — does NOT duplicate it)
- **Shared per-FR classifier** (`gates/fr-delivery-classifier.js`): reads the authoritative `product_requirements_v2.functional_requirements`, classifies each FR **DELIVERED** (a *validated* user_story **references** the FR id, word-boundary match) / **DESCOPED** (approver-gated `metadata.descoped_frs`) / **UNDELIVERED**. One source of truth for both gates.
- **LEAD-FINAL** `createFRDeliveryVerificationGate` now uses the shared classifier (the any-story proxy is gone).
- **EXEC-TO-PLAN** registers a new `FR_DELIVERY_TRACEABILITY` gate in **both** the orchestrator-child reduced set **and** the normal set — closing the boundary the incident child was never checked at.
- **Approver-gated descope** (`scripts/record-fr-descope.js`): a missing FR is satisfiable only by a descope naming an approver (`--approved-by` required; self-approval ignored). No migration — `metadata.descoped_frs` jsonb.

## Rollout safety (load-bearing — shipped OFF)
`LEO_FR_TRACEABILITY_ENFORCE`, **default OFF**. ~0/500 existing stories reference an FR id today, so strict+required would hard-fail nearly every SD. **OFF** → `passed:true` / `required:false` with **full score** (no averaged-score dilution → truly zero blast radius), undelivered FRs as warnings only. **ON** → `passed:false` / `required:true` on any undelivered FR (hard-fails via the existing `gate.required!==false` lever). Operators backfill FR↔story refs, then a follow-on flips enforcement on.

## Testing
- **24 new unit tests**: classifier matching (incl. word-boundary non-false-match), flag ON hard-fail, **flag OFF warn-only invariant + full-score**, descope with/without approver + self-approval guard, parent-delegation + delivered paths. Existing LEAD-FINAL gate tests pass; exec-to-plan executor imports clean.

## Out of scope (deferred follow-on)
FR↔story linkage (`fr_id` column + backfill + baseline) needed before enforcement can be flipped ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)