### PR TITLE
feat(SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001): arm + canonicalize coordinator self-review

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -183,21 +183,23 @@ node scripts/fleet-dashboard.cjs all
 ```
 Display the output.
 
-**Step 4: Coordinator onboarding check (surface role + verify the six-loop set)**
+**Step 4: Coordinator onboarding check (surface role + verify the eight-loop set)**
 ```bash
 node scripts/coordinator-startup-check.mjs
 ```
-This (a) surfaces the durable coordinator role context and prints a roles/responsibilities summary (MANAGER-not-IC, keep-workers-busy=KPI, recurring 3-source audit, teardown discipline), and (b) emits the canonical set of **six** standard cron loops, each with a ready CronCreate spec. It is fail-open (warns, exits 0). `CronList`/`CronCreate` are HARNESS tools (not Node-callable), so the helper EMITS the spec — YOU compare it against `CronList` and arm only the loops not already present. To get an explicit armed|MISSING verdict, re-run with the prompts already in CronList: `node scripts/coordinator-startup-check.mjs --armed "<prompt1>,<prompt2>,…"`.
+This (a) surfaces the durable coordinator role context and prints a roles/responsibilities summary (MANAGER-not-IC, keep-workers-busy=KPI, recurring 3-source audit, teardown discipline), and (b) emits the canonical set of **eight** standard cron loops, each with a ready CronCreate spec. It is fail-open (warns, exits 0). `CronList`/`CronCreate` are HARNESS tools (not Node-callable), so the helper EMITS the spec — YOU compare it against `CronList` and arm only the loops not already present. To get an explicit armed|MISSING verdict, re-run with the prompts already in CronList: `node scripts/coordinator-startup-check.mjs --armed "<prompt1>,<prompt2>,…"`.
 
 **Step 5: Set up automated cron loops using CronCreate**
 
-Arm all **six** standard loops (idempotent — skip any already in `CronList`):
+Arm all **eight** standard loops (idempotent — skip any already in `CronList`):
 1. **Sweep every 5 minutes**: `cron: "*/5 * * * *"`, `prompt: "node scripts/stale-session-sweep.cjs"`, `recurring: true`
 2. **Dashboard every 5 minutes (offset by 2 min)**: `cron: "2,7,12,17,22,27,32,37,42,47,52,57 * * * *"`, `prompt: "node scripts/fleet-dashboard.cjs all"`, `recurring: true`
 3. **Identity refresh every 5 minutes (offset by 4 min)**: `cron: "4,9,14,19,24,29,34,39,44,49,54,59 * * * *"`, `prompt: "node scripts/assign-fleet-identities.cjs"`, `recurring: true`
 4. **Inbox every 2 minutes**: `cron: "*/2 * * * *"`, `prompt: "node scripts/fleet-dashboard.cjs inbox"`, `recurring: true` — surfaces unread worker `/signal` traffic (also re-asserts the coordinator pointer).
 5. **Coordinator 3-source audit every 15 minutes**: `cron: "*/15 * * * *"`, `prompt: "node scripts/coordinator-audit.mjs"`, `recurring: true` — SD queue / harness backlog / inbox, with the source-vs-wake decision.
 6. **Executive email summary every 30 minutes (default-on)**: `cron: "*/30 * * * *"`, `prompt: "node scripts/coordinator-email-summary.mjs"`, `recurring: true` — operator is usually away; this is the fleet-health gauge + question escalation.
+7. **Feature-flag governance review daily at 09:00**: `cron: "0 9 * * *"`, `prompt: "node scripts/flag-governance-review.mjs"`, `recurring: true` — gated default-OFF behind `leo_feature_flags FLAG_GOVERNANCE_REVIEW_V1` (cheap no-op until enabled). SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001.
+8. **Coordinator self-review every 5 minutes (work-triggered, cheap poller)**: `cron: "*/5 * * * *"`, `prompt: "node scripts/coordinator-self-review.mjs"`, `recurring: true` — captures any worker `COORDINATOR-FEEDBACK` / Adam `ADAM-COORD-FEEDBACK` responses every tick; SOLICITS fresh tri-party (coordinator↔workers↔Adam) critique only when the completed-SD delta reaches `COORD_REVIEW_EVERY` (default 8). No-op below threshold, so it is safe to leave armed. The Adam bidirectional lane is gated by `COORD_ADAM_REVIEW_V1` (now `on` in `.claude/settings.json`). The `*/15` audit surfaces a **REVIEW HEALTH** gauge that flags a STUCK counter if this loop ever stops firing.
 
 The identity refresh loop detects new workers that joined since the last assignment and gives them a color/callsign. Existing assignments are preserved (the script reads current metadata and only assigns to workers without an identity).
 
@@ -205,13 +207,14 @@ The identity refresh loop detects new workers that joined since the last assignm
 
 Display:
 ```
-Coordinator initialized (role context surfaced; six standard loops armed).
+Coordinator initialized (role context surfaced; eight standard loops armed).
   Sweep loop: every 5 minutes (auto-releases dead claims, resolves conflicts, QA fixes)
   Dashboard loop: every 5 minutes (offset 2min from sweep)
   Identity loop: every 5 minutes (offset 4min — assigns colors/callsigns to new workers)
   Inbox loop: every 2 minutes (surfaces worker /signal traffic; re-asserts the coordinator pointer)
-  Audit loop: every 15 minutes (3-source audit: SD queue / harness backlog / inbox)
+  Audit loop: every 15 minutes (3-source audit: SD queue / harness backlog / inbox; REVIEW HEALTH gauge)
   Executive email: every 30 minutes (default-on fleet-health gauge + question escalation)
+  Self-review loop: every 5 minutes (work-triggered tri-party review; no-op below COORD_REVIEW_EVERY)
   All loops auto-expire after 3 days or when this session exits.
 
   Fleet is now running on autopilot. You will see sweep and dashboard output automatically.
@@ -719,3 +722,12 @@ If a worker session crashes mid-write, its file claims auto-release after 10 min
 ### Emergency disable
 
 Set `FILE_CLAIM_ENFORCED=off` in `.env` and restart the session to disable ENFORCEMENT 14 entirely. The coordinator should be notified — disabling the file-claim layer reverts to the pre-2026-05-09 lucky-convergence behavior where peer sessions can silently overwrite each other's work-in-progress.
+
+## Metadata
+
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Last Updated**: 2026-06-08
+- **Tags**: fleet, coordinator, cron, self-review, standard-loops
+- **Author**: SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "SWEEP_RESPECT_INFLIGHT_AGENT": "1",
-    "COORDINATOR_TWOWAY_V2": "on"
+    "COORDINATOR_TWOWAY_V2": "on",
+    "COORD_ADAM_REVIEW_V1": "on"
   },
   "statusLine": {
     "type": "command",

--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -1,5 +1,14 @@
 # Fleet Coordinator & Worker Behavior (durable protocol)
 
+## Metadata
+
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.1.0
+- **Last Updated**: 2026-06-08
+- **Tags**: fleet, coordinator, worker, cron, self-review, adam
+- **Author**: SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001
+
 Memory-independent source of truth for how the LEO fleet **coordinator** and its **worker** sessions
 behave. It exists so these behaviors survive even if an agent's personal auto-memory is lost, or a
 different agent/machine runs the fleet. Enforced by `.claude/commands/coordinator.md` (the
@@ -99,6 +108,14 @@ The fleet continuously improves how the coordinator and workers collaborate — 
 - **Capture + synthesize (coordinator):** `scripts/coordinator-fleet-retro.mjs` (recurring cron) captures FLEET-RETRO signals into the durable `feedback` table (`category='fleet_retro'`) so they survive the coordination-message sweep and ACCUMULATE, then prints a synthesis.
 - **Adjust (coordinator):** cluster the retros (what-worked / friction / suggestions) and ADJUST — update the wake-up prompt or coordinator behavior, file a harness SD for recurring friction, and surface a digest to the operator when a clear pattern emerges.
 - Distinct from `/learn` (which retros the SD WORK → `issue_patterns` / `retrospectives`); this retros the FLEET PROCESS. The two are complementary.
+
+### Work-triggered tri-party coordinator self-review (`coordinator-self-review.mjs`)
+
+Separate from the FLEET-RETRO capture above, the coordinator runs a **performance self-review** that is **work-triggered, not wall-clock** (operator 2026-06-06: cadence should track work volume, not a clock). It is the **7th** canonical standard cron loop (armed by `scripts/coordinator-startup-check.mjs`; `cron */5`, a cheap poller). SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.
+- **Capture (every tick):** harvests any worker `COORDINATOR-FEEDBACK` and Adam `ADAM-COORD-FEEDBACK` responses (cheap, always runs).
+- **Solicit + synthesize (when due):** once the completed-SD delta reaches `COORD_REVIEW_EVERY` (default 8), it solicits fresh candid critique from the live fleet — **tri-party**: coordinator ↔ workers, and coordinator ↔ **Adam** (the bidirectional lane, gated by `COORD_ADAM_REVIEW_V1`, now `on` in `.claude/settings.json`; FR-4/FR-5 of the Adam role formalization). Then it synthesizes and resets the counter in `.coord-review-last.json`.
+- **No-op below threshold** so it is safe to leave armed through idle stretches; the coordinator tears down during genuine idle so nothing runs while nothing happens.
+- **Stuck-counter guard:** the `*/15` audit (`coordinator-audit.mjs`) prints a **REVIEW HEALTH** gauge (via `lib/fleet/review-health.mjs`) that flags **STUCK** when the completed-SD delta is ≥ 2× the threshold with no fire — the signature of the self-review cron not being armed (the dormancy this SD fixed: the counter had frozen at delta 45 vs threshold 8).
 
 ## Known attrition root causes (live-confirmed 2026-06-06, from revival diagnostics)
 

--- a/lib/fleet/review-health.mjs
+++ b/lib/fleet/review-health.mjs
@@ -1,0 +1,38 @@
+// review-health.mjs — SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001
+// Pure stuck-counter health gauge for the work-triggered coordinator self-review.
+//
+// The self-review (scripts/coordinator-self-review.mjs) fires once per COORD_REVIEW_EVERY completed-SD
+// delta and writes .coord-review-last.json. If that cron is NOT armed (e.g. a coordinator restart that
+// re-armed only the documented loops), the state file silently freezes while completed SDs keep growing —
+// the exact dormancy this SD fixes. This gauge makes that freeze VISIBLE in coordinator-audit so it is an
+// alert, not a silent stall. Pure + exported for unit testing; the caller supplies the live counts.
+
+/**
+ * @param {object} p
+ * @param {number} p.completedCount   live count of status='completed' SDs
+ * @param {number|null} p.lastReviewCount  state.lastReviewCompletedCount (null/undefined if never written)
+ * @param {number} [p.threshold=8]    COORD_REVIEW_EVERY
+ * @returns {{ delta:number, dueWindows:number, stuck:boolean, line:string }}
+ */
+export function computeReviewHealth({ completedCount, lastReviewCount, threshold = 8 }) {
+  const total = Number.isFinite(completedCount) ? completedCount : 0;
+  const thr = threshold > 0 ? threshold : 8;
+
+  // Never-initialized state file: not stuck — the next self-review run seeds it.
+  if (lastReviewCount === null || lastReviewCount === undefined) {
+    return { delta: 0, dueWindows: 0, stuck: false, line: `review state uninitialized (no .coord-review-last.json yet) — will seed on next run` };
+  }
+
+  const delta = Math.max(0, total - lastReviewCount);
+  const dueWindows = Math.floor(delta / thr);
+  // STUCK = at least two full review windows have elapsed with no fire (delta >= 2*threshold).
+  // A single pending window (delta in [threshold, 2*threshold)) is normal between cron ticks.
+  const stuck = delta >= thr * 2;
+  const base = `${delta} completed SDs since last self-review (threshold ${thr}, ~${dueWindows} window(s) due)`;
+  const line = stuck
+    ? `${base} ⚠ STUCK — self-review cron likely NOT armed; arm 'coordinator:self-review' or reset .coord-review-last.json`
+    : base;
+  return { delta, dueWindows, stuck, line };
+}
+
+export default computeReviewHealth;

--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "test:cold-recovery": "vitest run tests/unit/coordinator-cold-recovery.test.js --project unit",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
+    "coordinator:self-review": "node scripts/coordinator-self-review.mjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",
     "sd:recover": "node scripts/sd-recover.js",

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -15,6 +15,8 @@ import { countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.
 import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
 import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
 import { sourceableBacklog } from './lib/sourceable-backlog.mjs';
+import { readFileSync } from 'node:fs';
+import { computeReviewHealth } from '../lib/fleet/review-health.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -168,3 +170,19 @@ console.log('  FLOW (idle/work): ' + idleWorkLine);
 console.log('  LIVENESS (loop) : ' + loopLine + '  (live workers)');
 console.log('  DEPENDENCY      : ' + depLine);
 for (const k of depStale.slice(0, 5)) console.log('      stale-blocked: ' + k);
+
+// REVIEW HEALTH — stuck-counter gauge for the work-triggered self-review.
+// Visible alert when the self-review cron is NOT armed (state file frozen while completed SDs grow).
+// SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.
+let reviewLine;
+try {
+  const { count: completedNow } = await db.from('strategic_directives_v2').select('sd_key', { count: 'exact', head: true }).eq('status', 'completed');
+  let lastReviewCount = null;
+  try {
+    const st = JSON.parse(readFileSync(path.resolve(repoRoot, '.coord-review-last.json'), 'utf8'));
+    if (typeof st.lastReviewCompletedCount === 'number') lastReviewCount = st.lastReviewCompletedCount;
+  } catch { /* no state file yet — computeReviewHealth treats null as uninitialized */ }
+  const threshold = parseInt(process.env.COORD_REVIEW_EVERY || '8', 10);
+  reviewLine = computeReviewHealth({ completedCount: completedNow || 0, lastReviewCount, threshold }).line;
+} catch (e) { reviewLine = 'unavailable (' + e.message + ')'; }
+console.log('  REVIEW HEALTH   : ' + reviewLine);

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -3,12 +3,12 @@
 //
 // On `/coordinator start` this helper:
 //   (FR-1) surfaces the DURABLE coordinator role context + prints a roles/responsibilities summary,
-//   (FR-2) reports armed|MISSING status for ALL SIX standard cron loops and emits the exact
+//   (FR-2) reports armed|MISSING status for ALL standard cron loops and emits the exact
 //          CronCreate spec for any missing loop, and
 //   (FR-4) is FAIL-OPEN — a missing role-context doc or any hiccup warns but never blocks startup.
 //
 // DESIGN CONSTRAINT: CronList/CronCreate are HARNESS tools, NOT Node-callable. This helper therefore
-// EMITS the canonical six-loop spec; the agent running /coordinator start compares it against CronList
+// EMITS the canonical standard-loop spec; the agent running /coordinator start compares it against CronList
 // and arms only the missing loops (idempotent). To compute armed|MISSING the agent passes the currently
 // -armed cron script basenames via --armed "a.cjs,b.mjs" (or COORD_ARMED_CRONS env, comma-separated).
 // With no armed-set provided, every loop is reported as "unverified" and its CronCreate spec is emitted.
@@ -38,7 +38,9 @@ export const RESPONSIBILITIES = [
 ];
 
 // ── Canonical standard cron loops (FR-2). The three original intervals match coordinator.md Step 4.
-// SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001 (FR-5) added the daily flag-governance review loop. ──
+// SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001 (FR-5) added the daily flag-governance review loop.
+// SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001 added the work-triggered tri-party self-review loop so a
+// coordinator restart re-arms it instead of leaving it dormant (its state file had silently frozen). ──
 export const STANDARD_LOOPS = [
   { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
     prompt: 'node scripts/stale-session-sweep.cjs' },
@@ -56,6 +58,10 @@ export const STANDARD_LOOPS = [
   // Gated default-OFF behind leo_feature_flags FLAG_GOVERNANCE_REVIEW_V1 → cheap no-op until enabled.
   { key: 'flag-review', label: 'Feature-flag governance review', script: 'flag-governance-review.mjs', cron: '0 9 * * *',
     prompt: 'node scripts/flag-governance-review.mjs' },
+  // Work-triggered tri-party self-review: cheap poller (no-op below COORD_REVIEW_EVERY completed-SD delta),
+  // fires the coordinator<->workers<->Adam review only when due. SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.
+  { key: 'self-review', label: 'Coordinator self-review (work-triggered tri-party)', script: 'coordinator-self-review.mjs', cron: '*/5 * * * *',
+    prompt: 'node scripts/coordinator-self-review.mjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/coordinator-self-review-canonicalize.test.js
+++ b/tests/unit/coordinator-self-review-canonicalize.test.js
@@ -1,0 +1,62 @@
+// SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001 — the self-review cron is canonical + the stuck-counter guard.
+import { describe, it, expect } from 'vitest';
+import { STANDARD_LOOPS } from '../../scripts/coordinator-startup-check.mjs';
+import { computeReviewHealth } from '../../lib/fleet/review-health.mjs';
+
+describe('coordinator self-review is in the canonical standard cron set', () => {
+  it('STANDARD_LOOPS includes the self-review loop (count grows as other loops are added)', () => {
+    // The set also carries flag-review (SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001); assert presence,
+    // not an exact count, so this test does not regress when peers add canonical loops.
+    expect(STANDARD_LOOPS.some((l) => l.key === 'self-review')).toBe(true);
+    expect(STANDARD_LOOPS.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('includes the work-triggered self-review loop with the correct command', () => {
+    const sr = STANDARD_LOOPS.find((l) => l.key === 'self-review');
+    expect(sr).toBeTruthy();
+    expect(sr.script).toBe('coordinator-self-review.mjs');
+    expect(sr.prompt).toBe('node scripts/coordinator-self-review.mjs');
+    expect(sr.cron).toBe('*/5 * * * *'); // cheap poller cadence
+  });
+
+  it('keeps the prior six loops intact (no regression)', () => {
+    for (const key of ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'email']) {
+      expect(STANDARD_LOOPS.find((l) => l.key === key)).toBeTruthy();
+    }
+  });
+});
+
+describe('computeReviewHealth — stuck-counter guard', () => {
+  it('uninitialized state (no .coord-review-last.json) is NOT stuck', () => {
+    const r = computeReviewHealth({ completedCount: 2990, lastReviewCount: null, threshold: 8 });
+    expect(r.stuck).toBe(false);
+    expect(r.line).toMatch(/uninitialized/i);
+  });
+
+  it('delta below threshold is NOT stuck', () => {
+    const r = computeReviewHealth({ completedCount: 2950, lastReviewCount: 2945, threshold: 8 }); // delta 5
+    expect(r.delta).toBe(5);
+    expect(r.stuck).toBe(false);
+  });
+
+  it('a single pending window (delta in [threshold, 2*threshold)) is NOT stuck', () => {
+    const r = computeReviewHealth({ completedCount: 2957, lastReviewCount: 2945, threshold: 8 }); // delta 12
+    expect(r.dueWindows).toBe(1);
+    expect(r.stuck).toBe(false);
+  });
+
+  it('delta >= 2*threshold is STUCK (the live dormancy: 2990 vs 2945, threshold 8 -> delta 45)', () => {
+    const r = computeReviewHealth({ completedCount: 2990, lastReviewCount: 2945, threshold: 8 });
+    expect(r.delta).toBe(45);
+    expect(r.dueWindows).toBe(5);
+    expect(r.stuck).toBe(true);
+    expect(r.line).toMatch(/STUCK/);
+    expect(r.line).toMatch(/coordinator:self-review|arm/i);
+  });
+
+  it('defaults threshold to 8 and clamps a negative delta to 0', () => {
+    const r = computeReviewHealth({ completedCount: 100, lastReviewCount: 120 });
+    expect(r.delta).toBe(0);
+    expect(r.stuck).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/coordinator-self-review.mjs` — the work-triggered tri-party **coordinator↔workers↔Adam** performance review — was fully built but **dormant**: not in the canonical standard-cron set emitted by `coordinator-startup-check.mjs`, not documented, not npm-wired. A coordinator restart that re-arms only the documented loops never re-armed it.

**Live evidence:** completed-SD count ≈2990 while `.coord-review-last.json` was frozen at **2945** (delta 45 ≫ threshold 8 — it should have fired ~5×). The Adam bidirectional lane was additionally gated **off** (`COORD_ADAM_REVIEW_V1`), so it had literally never run.

## Changes
- **Canonicalize**: 7th `STANDARD_LOOPS` entry (`self-review`, cron `*/5`) in `coordinator-startup-check.mjs` → `/coordinator start` re-arms it. Cheap poller: no-op below the completed-SD threshold.
- **npm-wire**: `coordinator:self-review` in `package.json`.
- **Enable Adam lane**: `COORD_ADAM_REVIEW_V1=on` in `.claude/settings.json` (env mechanism, same as `COORDINATOR_TWOWAY_V2`). Double-gated + role-partitioned → no Adam present = zero Adam rows. Governance-registry migration of the flag **deferred**.
- **Stuck-counter guard**: new pure `lib/fleet/review-health.mjs` `computeReviewHealth()` + a **REVIEW HEALTH** gauge in `coordinator-audit.mjs` that flags **STUCK** when delta ≥ 2× threshold with no fire (so a frozen counter is a visible alert, not a silent stall). Fail-opens.
- **Docs**: `coordinator.md` (six→seven + the self-review spec) and the fleet behavior doc (work-triggered tri-party review subsection).
- **8 vitest cases.**

## Test plan
- `npx vitest run tests/unit/coordinator-self-review-canonicalize.test.js` → 8/8.
- `node scripts/coordinator-audit.mjs` prints the REVIEW HEALTH gauge (no throw).
- DOCMON changed-only → 0 violations.

SD: SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001 (infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)