### PR TITLE
fix(SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001): npm-wire coordinator-audit for WIRE_CHECK reachability

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
     "test:cold-recovery": "vitest run tests/unit/coordinator-cold-recovery.test.js --project unit",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "coordinator:self-review": "node scripts/coordinator-self-review.mjs",
+    "coordinator:audit": "node scripts/coordinator-audit.mjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",
     "sd:recover": "node scripts/sd-recover.js",


### PR DESCRIPTION
Follow-up to #4387. WIRE_CHECK_GATE (hard at LEAD-FINAL) flagged `lib/fleet/review-health.mjs` as unreachable — it is imported only by `scripts/coordinator-audit.mjs`, which was not a discoverable entry point (not in `package.json`). Adds a `coordinator:audit` npm script (consistent with the other `coordinator:*` crons) so the static call graph reaches `review-health.mjs` through it.

1-line change. SD: SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)