### PR TITLE
fix(SD-FDBK-FIX-WORKER-SELF-CLAIM-001): step-6 self_claim skips orchestrator parents + dep-blocked SDs

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -232,6 +232,33 @@ async function draftDepsSatisfied(sb, sd) {
 }
 
 /**
+ * SD-FDBK-FIX-WORKER-SELF-CLAIM-001: gate a baselined v_sd_next_candidates row (step 6) before
+ * self-claiming it. The view surfaces deps_satisfied=false rows AND orchestrator PARENTS, and the
+ * self-claim loop called claim_sd WITHOUT filtering on either (claim_sd enforces neither — it is
+ * advisory-only). Result after the baseline populated 2026-06-07: a worker self-claimed a blocked
+ * child (depends_on an in-flight SD on the same write-surface) and another self-claimed an
+ * orchestrator PARENT (parents auto-complete on their children — must never be worker-claimed).
+ * Re-check sd_type + dependencies against strategic_directives_v2 — the SAME guard step 6.25 already
+ * applies — because v_sd_next_candidates.deps_satisfied is BROKEN for object-shaped deps (see
+ * draftDepsSatisfied). Conservative: any uncertainty -> skip the candidate (false), never claim.
+ * `sdKey` is the v_sd_next_candidates.sd_id column, which holds the sd_KEY string (bi.sd_id=sd.sd_key).
+ */
+async function baselinedCandidateEligible(sb, sdKey) {
+  try {
+    const { data } = await sb
+      .from('strategic_directives_v2')
+      .select('sd_type, dependencies')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (!data) return false;                            // can't verify -> don't claim
+    if (data.sd_type === 'orchestrator') return false;  // never claim an orchestrator parent
+    return await draftDepsSatisfied(sb, data);          // every referenced dep must be completed
+  } catch {
+    return false; // conservative: skip this candidate on a query error (fall through to the next)
+  }
+}
+
+/**
  * Self-claim tier for claimable UN-BASELINED draft SDs. v_sd_next_candidates is built from
  * sd_baseline_items, so a newly-created DRAFT SD that isn't baselined yet is INVISIBLE to step 6
  * — and draft is the normal LEAD starting state, so the bulk of the belt was structurally
@@ -369,6 +396,9 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
       .select('sd_id, track, status, priority')
       .limit(SELF_CLAIM_CANDIDATE_LIMIT);
     for (const c of (cands || [])) {
+      // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: skip dependency-blocked SDs and orchestrator PARENTS
+      // (the view surfaces both; claim_sd enforces neither). Mirrors the step-6.25 guard.
+      if (!(await baselinedCandidateEligible(sb, c.sd_id))) continue;
       if (await isSdInFlight(sb, c.sd_id, sessionId)) continue;  // dedup: skip SDs already started or live-foreign-held
       const claimed = await tryClaim(sb, c.sd_id, sessionId, c.track);
       if (claimed.ok) {
@@ -417,7 +447,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, isSdInFlight, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, isSdInFlight, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -145,6 +145,12 @@ describe('FR-2: runCheckin deterministic resolution', () => {
       session: { metadata: {}, sd_key: null },
       messages: [],
       candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }, { sd_id: 'SD-NEXT-002', track: 'B' }],
+      // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: step 6 now validates each candidate's sd_type +
+      // dependencies (and current_phase via isSdInFlight) against strategic_directives_v2.
+      sdRows: {
+        'SD-TOP-001': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] },
+        'SD-NEXT-002': { current_phase: 'LEAD', sd_type: 'feature', dependencies: [] },
+      },
       claimResults: { 'SD-TOP-001': true },
     });
     const r = await runCheckin(sb, 'sess-1', noCoord);
@@ -157,6 +163,10 @@ describe('FR-2: runCheckin deterministic resolution', () => {
       session: { metadata: {}, sd_key: null },
       messages: [],
       candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }, { sd_id: 'SD-NEXT-002', track: 'B' }],
+      sdRows: {
+        'SD-TOP-001': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] },
+        'SD-NEXT-002': { current_phase: 'LEAD', sd_type: 'feature', dependencies: [] },
+      },
       claimResults: { 'SD-TOP-001': false, 'SD-NEXT-002': true },
     });
     const r = await runCheckin(sb, 'sess-1', noCoord);
@@ -170,6 +180,75 @@ describe('FR-2: runCheckin deterministic resolution', () => {
     expect(r.action).toBe('idle');
     expect(r.recommended_wakeup_seconds).toBe(DEFAULT_IDLE_WAKEUP_SECONDS);
     expect(r.ok).toBe(true);
+  });
+});
+
+// SD-FDBK-FIX-WORKER-SELF-CLAIM-001: step-6 self_claim must NOT grab orchestrator PARENTS or
+// dependency-blocked SDs from v_sd_next_candidates (the view surfaces both; claim_sd enforces
+// neither). baselinedCandidateEligible re-checks sd_type + dependencies, mirroring step 6.25.
+describe('SD-FDBK-FIX-WORKER-SELF-CLAIM-001: baselinedCandidateEligible gates step-6 candidates', () => {
+  it('rejects an orchestrator parent (auto-completes on children — never worker-claim)', async () => {
+    const sb = makeStub({ sdRows: { 'SD-ORCH-001': { sd_type: 'orchestrator', dependencies: [] } } });
+    expect(await baselinedCandidateEligible(sb, 'SD-ORCH-001')).toBe(false);
+  });
+
+  it('rejects a dependency-blocked SD (a referenced dep is not completed)', async () => {
+    const sb = makeStub({
+      sdRows: { 'SD-CHILD-001': { sd_type: 'feature', dependencies: [{ sd_id: 'SD-PARENT-999' }] } },
+      depRows: [{ sd_key: 'SD-PARENT-999', status: 'in_progress' }],
+    });
+    expect(await baselinedCandidateEligible(sb, 'SD-CHILD-001')).toBe(false);
+  });
+
+  it('accepts a non-orchestrator SD with all deps completed', async () => {
+    const sb = makeStub({
+      sdRows: { 'SD-OK-002': { sd_type: 'feature', dependencies: [{ sd_id: 'SD-DONE-001' }] } },
+      depRows: [{ sd_key: 'SD-DONE-001', status: 'completed' }],
+    });
+    expect(await baselinedCandidateEligible(sb, 'SD-OK-002')).toBe(true);
+  });
+
+  it('accepts a non-orchestrator SD with no dependencies', async () => {
+    const sb = makeStub({ sdRows: { 'SD-OK-001': { sd_type: 'bugfix', dependencies: [] } } });
+    expect(await baselinedCandidateEligible(sb, 'SD-OK-001')).toBe(true);
+  });
+
+  it('conservatively rejects an SD that cannot be verified (row missing)', async () => {
+    const sb = makeStub({ sdRows: {} });
+    expect(await baselinedCandidateEligible(sb, 'SD-GONE-001')).toBe(false);
+  });
+
+  it('runCheckin SKIPS an orchestrator candidate and self-claims the next eligible one (even though claim_sd would accept the parent)', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null },
+      messages: [],
+      candidates: [{ sd_id: 'SD-ORCH-001', track: 'A' }, { sd_id: 'SD-GOOD-002', track: 'B' }],
+      sdRows: {
+        'SD-ORCH-001': { current_phase: 'LEAD', sd_type: 'orchestrator', dependencies: [] },
+        'SD-GOOD-002': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] },
+      },
+      claimResults: { 'SD-ORCH-001': true, 'SD-GOOD-002': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-GOOD-002'); // the orchestrator parent was skipped BEFORE tryClaim
+  });
+
+  it('runCheckin SKIPS a dependency-blocked candidate and self-claims the clear one', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null },
+      messages: [],
+      candidates: [{ sd_id: 'SD-BLOCKED-001', track: 'A' }, { sd_id: 'SD-CLEAR-002', track: 'B' }],
+      sdRows: {
+        'SD-BLOCKED-001': { current_phase: 'LEAD', sd_type: 'feature', dependencies: [{ sd_id: 'SD-DEP-999' }] },
+        'SD-CLEAR-002': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] },
+      },
+      depRows: [{ sd_key: 'SD-DEP-999', status: 'in_progress' }],
+      claimResults: { 'SD-BLOCKED-001': true, 'SD-CLEAR-002': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-CLEAR-002'); // the dep-blocked child was skipped
   });
 });
 
@@ -221,7 +300,7 @@ describe('QF self-claim: runCheckin QF tier (FR-1/3/4/6)', () => {
   });
 
   it('ALWAYS prefers a claimable SD over a QF (QF tier never reached)', async () => {
-    const sb = makeStub({ ...base, candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }], quickFixes: [freshQF('QF-20260601-001')], claimResults: { 'SD-TOP-001': true, 'QF-20260601-001': true } });
+    const sb = makeStub({ ...base, candidates: [{ sd_id: 'SD-TOP-001', track: 'A' }], sdRows: { 'SD-TOP-001': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] } }, quickFixes: [freshQF('QF-20260601-001')], claimResults: { 'SD-TOP-001': true, 'QF-20260601-001': true } });
     const r = await runCheckin(sb, 'sess-1', noCoord);
     expect(r.action).toBe('self_claimed');
     expect(r.sd).toBe('SD-TOP-001');
@@ -288,6 +367,9 @@ describe('SELF-001: un-baselined draft self-claim tier', () => {
     const sb = makeStub({
       ...sess,
       candidates: [{ sd_id: 'SD-VIEW-001', track: 'A' }],
+      // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: step 6 now validates the candidate (eligible: not an
+      // orchestrator, no unmet deps, current_phase=LEAD so isSdInFlight passes).
+      sdRows: { 'SD-VIEW-001': { current_phase: 'LEAD', sd_type: 'feature', dependencies: [] } },
       drafts: [draft('SD-DRAFT-001', { priority: 'critical' })],
       claimResults: { 'SD-VIEW-001': true, 'SD-DRAFT-001': true },
     });


### PR DESCRIPTION
## Summary
`worker-checkin.cjs` **step 6** self-claimed the top of `v_sd_next_candidates` by calling `claim_sd` **without filtering on `deps_satisfied` or `sd_type`**. The view surfaces `deps_satisfied=false` rows (its `deps_satisfied` is broken for object-shaped deps — it text-compares the whole JSON object) **and** orchestrator parents, and `claim_sd` enforces neither (advisory-only).

After the execution baseline populated 2026-06-07 this caused two real incidents:
- a worker self-claimed a **dependency-blocked child** whose dependency was an in-flight SD on the same `venture_stages` write-surface → collision;
- another self-claimed an **orchestrator PARENT** (parents auto-complete on their children and must never be worker-claimed).

## Fix
New `baselinedCandidateEligible(sb, sdKey)` re-checks `sd_type` + `dependencies` against `strategic_directives_v2` — the **same guard step 6.25 (`selfClaimDraftSd`) already applies** — and the step-6 loop skips any candidate that fails it **before** `tryClaim`. Reuses `draftDepsSatisfied` (the view's `deps_satisfied` can't be trusted). Conservative: any uncertainty → skip, never claim.

This was a writer/consumer asymmetry: the un-baselined-draft tier (6.25) had the guard; the baselined tier (6) didn't. Complements `SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001` (claim-time enforcement) — this is the sourcing-time filter.

## Testing
- `npx vitest run scripts/worker-checkin.test.js` → **51 passed**
- +7 tests (4 unit on the guard, 2 `runCheckin` integration proving the orchestrator/dep-blocked candidate is skipped even when `claim_sd` would accept it, + export); 3 existing precedence tests updated to supply the candidate metadata the new validation reads.
- TESTING sub-agent verdict: PASS (row `e7729a88`)

## LEO
SD-FDBK-FIX-WORKER-SELF-CLAIM-001 (bugfix, FAST) · gates 93/94/94/96 · retro 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)