### PR TITLE
chore(SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001): wire record-fr-descope.js as npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,6 +298,7 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",
     "adam:retro": "node scripts/adam-retro.cjs",


### PR DESCRIPTION
Follow-up to merged PR #4386. WIRE_CHECK_GATE flagged `scripts/record-fr-descope.js` (the approver-gated FR-descope operator CLI) as unreachable from any entry point. It's a standalone CLI by design — expose it as `npm run fr:descope -- <SD-KEY> <FR-ID> --approved-by "<approver>"` so it's a discoverable, wired entry point. 1-line package.json change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)