### PR TITLE
fix(SD-LEO-FIX-FIX-TRIAGE-GATE-001): read real content column in lookupArchPlanLOC

### DIFF
--- a/scripts/modules/triage-gate.js
+++ b/scripts/modules/triage-gate.js
@@ -68,7 +68,7 @@ export function isHardGateSource(source) {
  * @param {string} archKey - Architecture plan key (e.g., ARCH-SKILL-AB-TEST-001)
  * @returns {Promise<number|null>} Estimated LOC from arch plan, or null
  */
-async function lookupArchPlanLOC(archKey) {
+export async function lookupArchPlanLOC(archKey) {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key || !archKey) return null;
@@ -77,18 +77,21 @@ async function lookupArchPlanLOC(archKey) {
     const sb = createClient(url, key);
     const { data } = await sb
       .from('eva_architecture_plans')
-      .select('plan_content')
+      // SD-LEO-FIX-FIX-TRIAGE-GATE-001: the column is `content` (markdown text), NOT
+      // `plan_content` (which does not exist) — the old name silently returned no row,
+      // making the arch-plan LOC auto-escalation a permanent no-op.
+      .select('content')
       .eq('plan_key', archKey)
       .order('version', { ascending: false })
       .limit(1)
       .single();
 
-    if (!data?.plan_content) return null;
+    if (!data?.content) return null;
 
     // Look for LOC estimate in plan content
-    const content = typeof data.plan_content === 'string'
-      ? data.plan_content
-      : JSON.stringify(data.plan_content);
+    const content = typeof data.content === 'string'
+      ? data.content
+      : JSON.stringify(data.content);
 
     const locMatch = content.match(/estimated[_\s-]*loc[:\s]*(\d+)/i)
       || content.match(/(\d+)\s*(?:lines?\s*of\s*code|LOC)/i);

--- a/tests/unit/scripts/triage-gate-arch-loc.test.js
+++ b/tests/unit/scripts/triage-gate-arch-loc.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-FIX-FIX-TRIAGE-GATE-001 — regression test for lookupArchPlanLOC().
+ *
+ * The bug: lookupArchPlanLOC queried a NON-EXISTENT column `plan_content` on
+ * eva_architecture_plans (the real column is `content`), so the query silently
+ * returned nothing and the arch-plan LOC-based Tier-3 auto-escalation was a
+ * permanent no-op. These tests assert it now reads `content` and extracts LOC.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn() }));
+
+import { createClient } from '@supabase/supabase-js';
+import { lookupArchPlanLOC } from '../../../scripts/modules/triage-gate.js';
+
+// Chainable builder whose .single() resolves to the given {data,error}.
+function makeClient(single, error = null) {
+  const chain = {
+    select() { return chain; },
+    eq() { return chain; },
+    order() { return chain; },
+    limit() { return chain; },
+    single() { return Promise.resolve({ data: single, error }); },
+  };
+  return { from: () => chain };
+}
+
+const ORIG = { url: process.env.SUPABASE_URL, key: process.env.SUPABASE_SERVICE_ROLE_KEY };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The function guards on these env vars before querying.
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+});
+
+afterEach(() => {
+  process.env.SUPABASE_URL = ORIG.url;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = ORIG.key;
+});
+
+describe('lookupArchPlanLOC (SD-LEO-FIX-FIX-TRIAGE-GATE-001)', () => {
+  it('returns the LOC estimate from the real `content` column (was the no-op bug)', async () => {
+    createClient.mockReturnValue(makeClient({ content: '# Plan\n\nEstimated LOC: 240\n' }));
+    const loc = await lookupArchPlanLOC('ARCH-X-001');
+    expect(loc).toBe(240);
+  });
+
+  it('matches the "<n> lines of code" phrasing as well', async () => {
+    createClient.mockReturnValue(makeClient({ content: 'This change is roughly 130 lines of code total.' }));
+    expect(await lookupArchPlanLOC('ARCH-X-001')).toBe(130);
+  });
+
+  it('selects the `content` column — a row exposing only the old `plan_content` yields null', async () => {
+    // Proves the fix: had we still selected/read `plan_content`, this would parse it.
+    createClient.mockReturnValue(makeClient({ plan_content: 'Estimated LOC: 999' }));
+    expect(await lookupArchPlanLOC('ARCH-X-001')).toBeNull();
+  });
+
+  it('returns null when content has no LOC estimate', async () => {
+    createClient.mockReturnValue(makeClient({ content: '# Plan\n\nNo size hint here.' }));
+    expect(await lookupArchPlanLOC('ARCH-X-001')).toBeNull();
+  });
+
+  it('returns null (no throw) when the env/archKey guard is not satisfied', async () => {
+    delete process.env.SUPABASE_URL;
+    expect(await lookupArchPlanLOC('ARCH-X-001')).toBeNull();
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    expect(await lookupArchPlanLOC('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/modules/triage-gate.js` `lookupArchPlanLOC()` queried a **non-existent** column `plan_content` on `eva_architecture_plans` (verified live: the real column is `content`, a markdown string). The query silently returned no row, so the **arch-plan LOC-based Tier-3 auto-escalation was a permanent no-op** — work items whose arch plan implied a large change were never escalated by this path (only the hard "arch plan exists → Tier 3" rule still fired).

## Fix
- `.select('content')` + read `data.content` (4 references); the existing `plan_key`/`version` query shape and the string LOC-extraction regex are unchanged and compatible with the markdown-string content shape.
- Exported `lookupArchPlanLOC` and added a regression test (`tests/unit/scripts/triage-gate-arch-loc.test.js`): content-read returns the LOC, the old `plan_content`-only shape returns null, no-estimate returns null, and the env/archKey guard returns null without throwing.

## Testing
5 new unit tests pass; existing `corrective-triage` suite (11) green; lint clean. No DDL, no threshold/routing changes — pure read-path column fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)