### PR TITLE
fix(SD-FDBK-FIX-DRIFT-CHECK-FAILS-001): graceful-skip sibling-EHG checkout in cross-repo drift workflows

### DIFF
--- a/.github/workflows/design-prompts-cross-repo.yml
+++ b/.github/workflows/design-prompts-cross-repo.yml
@@ -38,7 +38,14 @@ jobs:
       - name: Checkout EHG_Engineer
         uses: actions/checkout@v4
 
+      # SD-FDBK-FIX-DRIFT-CHECK-FAILS-001: rickfelix/ehg is PRIVATE; the default
+      # GITHUB_TOKEN cannot cross-access it, so this 404s whenever GH_TOKEN_CROSS_REPO
+      # is absent. continue-on-error + an id turn that 404 into a clean skip (not a
+      # confusing red step); the compare below is guarded on this step's outcome so it
+      # still runs unchanged whenever the cross-repo token IS configured.
       - name: Checkout sibling EHG repo
+        id: sibling_checkout
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: rickfelix/ehg
@@ -46,12 +53,19 @@ jobs:
           token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.GITHUB_TOKEN }}
           fetch-depth: 1
 
+      - name: Sibling repo unreachable (advisory skip)
+        if: steps.sibling_checkout.outcome != 'success'
+        run: |
+          echo "::warning ::Could not check out the sibling rickfelix/ehg repo (private; needs the GH_TOKEN_CROSS_REPO secret). Skipping the S17/S19 design-prompts cross-repo comparison. Set GH_TOKEN_CROSS_REPO to enable it. SD-FDBK-FIX-DRIFT-CHECK-FAILS-001."
+
       - name: Setup Node
+        if: steps.sibling_checkout.outcome == 'success'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Compare shared design-prompts checksum across repos
+        if: steps.sibling_checkout.outcome == 'success'
         run: node scripts/design-prompts-cross-repo-check.mjs ehg-sibling/src/components/stage17/gvos/shared-design-prompts.json
 
       - name: Note about advisory mode

--- a/.github/workflows/venture-stages-drift-guard.yml
+++ b/.github/workflows/venture-stages-drift-guard.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Checkout EHG_Engineer
         uses: actions/checkout@v4
 
+      # SD-FDBK-FIX-DRIFT-CHECK-FAILS-001: rickfelix/ehg is PRIVATE; the default
+      # GITHUB_TOKEN cannot cross-access it, so this 404s whenever GH_TOKEN_CROSS_REPO
+      # is absent. continue-on-error + an id turn that 404 into a clean skip (not a
+      # confusing red step); the deps/compare below are guarded on this step's outcome
+      # so they still run unchanged whenever the cross-repo token IS configured.
       - name: Checkout sibling EHG repo
+        id: sibling_checkout
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: rickfelix/ehg
@@ -51,15 +58,23 @@ jobs:
           token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.GITHUB_TOKEN }}
           fetch-depth: 1
 
+      - name: Sibling repo unreachable (advisory skip)
+        if: steps.sibling_checkout.outcome != 'success'
+        run: |
+          echo "::warning ::Could not check out the sibling rickfelix/ehg repo (private; needs the GH_TOKEN_CROSS_REPO secret). Skipping the venture_stages cross-repo drift check. Set GH_TOKEN_CROSS_REPO to enable it. SD-FDBK-FIX-DRIFT-CHECK-FAILS-001."
+
       - name: Setup Node
+        if: steps.sibling_checkout.outcome == 'success'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install minimal deps
+        if: steps.sibling_checkout.outcome == 'success'
         run: npm install --no-audit --no-fund @supabase/supabase-js dotenv
 
       - name: Check venture_stages <-> artifacts drift
+        if: steps.sibling_checkout.outcome == 'success'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
## Summary
The two advisory cross-repo "drift" workflows — `design-prompts-cross-repo.yml` and `venture-stages-drift-guard.yml` — **404 at their "Checkout sibling EHG repo" step** because `rickfelix/ehg` is **private** and the default `GITHUB_TOKEN` can't cross-access it when the `GH_TOKEN_CROSS_REPO` secret is absent. The red step misleads workers into thinking it's real code drift.

## Fix (graceful skip)
The real-token fix needs a repo-admin secret; the code-side fix makes the check non-confusing:
- The "Checkout sibling EHG repo" step gets `id: sibling_checkout` + `continue-on-error: true` → a 404 records an outcome instead of failing red.
- Setup Node / Install deps / the cross-repo compare are guarded with `if: steps.sibling_checkout.outcome == 'success'` → they **skip cleanly** when the sibling is unreachable and run **unchanged** (real drift still caught) when `GH_TOKEN_CROSS_REPO` is configured.
- A visible `::warning::` explains the skip so the advisory signal isn't silent.

## Scope / safety
- Report said "ALL PRs"; both workflows are actually **path-filtered**, so they only run/redden on PRs touching `shared-design-prompts.*` or `venture_stages` files.
- Both jobs were already **job-level `continue-on-error`** (advisory) — this only turns a red **step** into a clean skip.
- Two-file YAML change; both lint clean; `e2e-human-like.yml` (same-repo checkout) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)