### PR TITLE
fix(SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001): audit gate_label changes on venture_stages

### DIFF
--- a/database/migrations/20260608_venture_stages_audit_add_gate_label.sql
+++ b/database/migrations/20260608_venture_stages_audit_add_gate_label.sql
@@ -1,0 +1,96 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001
+-- Add gate_label to the venture_stages_audit trigger
+--
+-- Bug: fn_venture_stages_audit_trigger() audits every business column of
+-- venture_stages EXCEPT gate_label — a chairman-gate-control column added by
+-- 20260529_childD_venture_stages_app_fields.sql and set by the S21/S22 chairman
+-- gate migrations (which UPDATE review_mode AND gate_label together). The other
+-- two chairman-gate-control columns (gate_type, review_mode) are already audited,
+-- so chairman gate-label changes were silently leaving no audit trail.
+--
+-- Fix: CREATE OR REPLACE the trigger function with its existing 16-column body
+-- PLUS a per-column gate_label check, mirroring the existing pattern. No schema
+-- change (venture_stages_audit.old_value/new_value are already TEXT) and no
+-- trigger re-creation needed — CREATE OR REPLACE atomically swaps the body and
+-- the existing trg_venture_stages_audit keeps pointing at it. Idempotent.
+
+CREATE OR REPLACE FUNCTION public.fn_venture_stages_audit_trigger()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF OLD.stage_name IS DISTINCT FROM NEW.stage_name THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'stage_name', OLD.stage_name, NEW.stage_name);
+  END IF;
+  IF OLD.stage_key IS DISTINCT FROM NEW.stage_key THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'stage_key', OLD.stage_key, NEW.stage_key);
+  END IF;
+  IF OLD.description IS DISTINCT FROM NEW.description THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'description', OLD.description, NEW.description);
+  END IF;
+  IF OLD.phase_number IS DISTINCT FROM NEW.phase_number THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'phase_number', OLD.phase_number::text, NEW.phase_number::text);
+  END IF;
+  IF OLD.phase_name IS DISTINCT FROM NEW.phase_name THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'phase_name', OLD.phase_name, NEW.phase_name);
+  END IF;
+  IF OLD.chunk IS DISTINCT FROM NEW.chunk THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'chunk', OLD.chunk, NEW.chunk);
+  END IF;
+  IF OLD.gate_type IS DISTINCT FROM NEW.gate_type THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'gate_type', OLD.gate_type, NEW.gate_type);
+  END IF;
+  IF OLD.review_mode IS DISTINCT FROM NEW.review_mode THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'review_mode', OLD.review_mode, NEW.review_mode);
+  END IF;
+  IF OLD.work_type IS DISTINCT FROM NEW.work_type THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'work_type', OLD.work_type, NEW.work_type);
+  END IF;
+  IF OLD.sd_required IS DISTINCT FROM NEW.sd_required THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'sd_required', OLD.sd_required::text, NEW.sd_required::text);
+  END IF;
+  IF OLD.sd_suffix IS DISTINCT FROM NEW.sd_suffix THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'sd_suffix', OLD.sd_suffix, NEW.sd_suffix);
+  END IF;
+  IF OLD.advisory_enabled IS DISTINCT FROM NEW.advisory_enabled THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'advisory_enabled', OLD.advisory_enabled::text, NEW.advisory_enabled::text);
+  END IF;
+  IF OLD.depends_on IS DISTINCT FROM NEW.depends_on THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'depends_on', OLD.depends_on::text, NEW.depends_on::text);
+  END IF;
+  IF OLD.required_artifacts IS DISTINCT FROM NEW.required_artifacts THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'required_artifacts', OLD.required_artifacts::text, NEW.required_artifacts::text);
+  END IF;
+  IF OLD.metadata IS DISTINCT FROM NEW.metadata THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'metadata', OLD.metadata::text, NEW.metadata::text);
+  END IF;
+  IF OLD.component_path IS DISTINCT FROM NEW.component_path THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'component_path', OLD.component_path, NEW.component_path);
+  END IF;
+  -- SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001: audit chairman gate-label changes.
+  IF OLD.gate_label IS DISTINCT FROM NEW.gate_label THEN
+    INSERT INTO venture_stages_audit (stage_number, changed_column, old_value, new_value)
+    VALUES (NEW.stage_number, 'gate_label', OLD.gate_label, NEW.gate_label);
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/tests/database/venture-stages-audit-gate-label.test.js
+++ b/tests/database/venture-stages-audit-gate-label.test.js
@@ -1,0 +1,68 @@
+/**
+ * SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001
+ * The venture_stages_audit trigger (fn_venture_stages_audit_trigger) must record
+ * gate_label changes — a chairman-gate-control column that was previously omitted
+ * (gate_type and review_mode were audited; gate_label was not), so chairman gate
+ * decisions left no audit trail.
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips
+ * cleanly without real credentials. It mutates one stage's gate_label, asserts a
+ * venture_stages_audit row is written by the trigger, then restores the original
+ * value (net-zero).
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+// A gate stage that carries a gate_label in the seeded data.
+const STAGE = 17;
+
+describe.skipIf(!HAS_REAL_DB)('venture_stages_audit tracks gate_label (SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001)', () => {
+  let original;
+
+  afterAll(async () => {
+    if (original !== undefined) {
+      await supabase.from('venture_stages').update({ gate_label: original }).eq('stage_number', STAGE);
+    }
+  });
+
+  it('writes a venture_stages_audit row when gate_label changes, with correct old/new values', async () => {
+    const { data: before, error: be } = await supabase
+      .from('venture_stages').select('gate_label').eq('stage_number', STAGE).single();
+    expect(be).toBeNull();
+    original = before.gate_label;
+
+    const marker = (original || '') + ' [AUDIT-TEST]';
+    const ts = new Date().toISOString();
+
+    const { error: ue } = await supabase
+      .from('venture_stages').update({ gate_label: marker }).eq('stage_number', STAGE);
+    expect(ue).toBeNull();
+
+    const { data: rows, error: ae } = await supabase
+      .from('venture_stages_audit')
+      .select('changed_column, old_value, new_value, changed_at')
+      .eq('stage_number', STAGE).eq('changed_column', 'gate_label')
+      .gte('changed_at', ts).order('changed_at', { ascending: false }).limit(1);
+    expect(ae).toBeNull();
+    expect(rows && rows.length).toBe(1);
+    expect(rows[0].old_value).toBe(original);
+    expect(rows[0].new_value).toBe(marker);
+
+    // restore (also handled in afterAll as a backstop)
+    const { error: re } = await supabase
+      .from('venture_stages').update({ gate_label: original }).eq('stage_number', STAGE);
+    expect(re).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
The `venture_stages_audit` trigger (`fn_venture_stages_audit_trigger`) audited every business column of `venture_stages` **except `gate_label`** — a chairman-gate-control column set by the S21 creative_handoff / S22 spend_approval gate work (those migrations UPDATE `review_mode` AND `gate_label` together). `gate_type` and `review_mode` were already audited, so chairman gate-label decisions left **no audit trail**.

## Fix
A function-only, idempotent migration (`database/migrations/20260608_venture_stages_audit_add_gate_label.sql`): `CREATE OR REPLACE` the trigger function with its existing 16-column body **plus** a per-column `gate_label IS DISTINCT FROM` check, mirroring the existing pattern.
- **No schema change** — `venture_stages_audit.old_value/new_value` are already `TEXT`.
- **No trigger re-creation** — `CREATE OR REPLACE FUNCTION` atomically swaps the body; the existing `trg_venture_stages_audit` keeps firing (no audit gap during deploy).

## Verification
- Applied live: `apply-migration.js ... --prod-deploy` → **MIGRATION_APPLY_PROD_PASS**.
- Behavioral: updating stage 17's `gate_label` now writes a `venture_stages_audit` row with `changed_column='gate_label'` and correct old/new values; value restored (net-zero).
- DATABASE sub-agent PASS (row `01a0860c` — independently confirmed 17 INSERT blocks live, trigger still wired `tgenabled=O`); TESTING sub-agent PASS (row `2815d185`).
- `+1` CI-gated live-DB integration test (`tests/database/venture-stages-audit-gate-label.test.js`, 1/1; skips cleanly without creds).

## Note
PLAN-TO-LEAD used `--bypass-validation` for a confirmed `CROSS_REPO_STAGE_CONFIG_DRIFT` **false positive**: this audit-trigger-only migration changes no stage-config data (`generate-stage-config --check` = CHECK PASSED), but the gate's relevance heuristic flags any `venture_stages`-referencing migration and a peer's unrelated in-flight stage-resequence regen left `ehg/.../venture-workflow.ts` uncommitted. Gate-bug filed to harness_backlog.

## LEO
SD-FDBK-FIX-GOVERNANCE-GAP-VENTURE-001 (bugfix, FAST) · gates 93/92/94/91 · retro 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)