### PR TITLE
fix(SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001): auto-recover SDs stranded at pending_approval/LEAD_FINAL

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -52,6 +52,7 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 | `action` | What the CLI did | What you do next | Then |
 |----------|------------------|------------------|------|
 | `resume` | You already claim `sd` | Run `node scripts/sd-start.js <sd>` to (re)attach the worktree, then continue that SD. | On completion, re-run `/checkin`. |
+| `resume_final` | Re-claimed an SD **stranded** at `pending_approval/LEAD_FINAL` (claim was cleared — one handoff from shipped). | Run `node scripts/sd-start.js <sd>` to re-attach the worktree, then `node scripts/handoff.js execute LEAD-FINAL-APPROVAL <sd>` (Bash `timeout: 300000` — the final gate is slow). If `PR_MERGE_VERIFICATION` blocks, merge the PR first (`gh pr merge <#> --squash --admin`), then re-run. Then run the post-completion tail. **NOT** a full rebuild — the SD is already built, gated, and retro'd; it only needs the final approval handoff. | On completion, re-run `/checkin`. |
 | `claimed_assignment` | Claimed the coordinator's assigned `sd` via `claim_sd` | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
 | `self_claimed` | No assignment, so claimed the top of `sd:next` (`sd`) | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
 | `self_claimed_qf` | No claimable SD, so self-claimed an open quick-fix (`qf`) from the open-QF queue | Run `node scripts/read-quick-fix.js <qf>`, then the `/quick-fix` workflow (implement ≤50 LOC on branch `qf/<qf>`, run tests, then `node scripts/complete-quick-fix.js <qf>`) — **NOT** `sd-start.js` (it only knows `strategic_directives_v2` and would exit "SD not found" for a QF id). | On completion, re-run `/checkin`. |
@@ -60,8 +61,9 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 
 This is an autonomous-fleet contract: a `/loop` worker must keep moving. Decide from the JSON, act, and proceed. Never end a check-in by asking the operator what to do (no human watches the loop window).
 
-**The cycle never terminates on its own.** For `resume` / `claimed_assignment` /
-`self_claimed`: build the SD through completion, then **re-run `/checkin`** to pull the next
+**The cycle never terminates on its own.** For `resume` / `resume_final` / `claimed_assignment` /
+`self_claimed`: build the SD through completion (for `resume_final`, just run the final
+LEAD-FINAL-APPROVAL handoff + post-completion tail), then **re-run `/checkin`** to pull the next
 one — if you instead just stop after finishing the SD, the loop never fires again and you go
 incognito with a non-empty queue. For `self_claimed_qf`: work the quick-fix through the
 `/quick-fix` workflow to completion (`complete-quick-fix.js`), then **re-run `/checkin`** —
@@ -91,3 +93,14 @@ Thin wrapper around the worker-checkin CLI:
 ```bash
 node scripts/worker-checkin.cjs
 ```
+
+## Metadata
+
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.1.0
+- **Last Updated**: 2026-06-08
+- **Tags**: fleet, worker, checkin, self-claim, recovery
+- **Author**: SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001
+
+---

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -300,6 +300,50 @@ async function selfClaimDraftSd(sb, sessionId, base) {
   return null;
 }
 
+// SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001: recover SDs STRANDED at pending_approval/LEAD_FINAL
+// with the claim cleared. RECURRING bug (2nd occurrence): a worker reaches LEAD_FINAL (PLAN-TO-LEAD
+// accepted, gates passed, retro exists, PR usually merged) then RELEASES its claim and goes idle
+// WITHOUT running the final LEAD-FINAL-APPROVAL handoff. The SD is then one step from shipped but
+// un-completable: self-claim skips pending_approval (only draft/active), and a coordinator running
+// `handoff.js execute LEAD-FINAL-APPROVAL` from main with the claim cleared FAILS the claim-validity
+// worktree-isolation gate (lib/claim-validity-gate.js: claiming_session_id must match + cwd in the
+// worktree). The ONLY reliable unblock today is a human window-pasting `sd-start` in a worker. This
+// tier AUTOMATES that: re-claim the stranded SD so a worker re-attaches the worktree (sd-start) and
+// runs LEAD-FINAL-APPROVAL with a VALID matching claim — the gate then passes. Idempotent (a re-strand
+// is simply re-recovered next checkin). Highest self-claim priority: finishing a near-shipped SD beats
+// starting new work. Fail-open; returns a resume_final result or null.
+const STRANDED_CANDIDATE_LIMIT = 5;
+// Only recover SDs that have been parked a while, so we never race a worker mid-finalize (the brief
+// window between a transition and the next handoff). A genuinely stranded SD sits indefinitely.
+const STRANDED_MIN_AGE_MS = 5 * 60 * 1000;
+
+async function recoverStrandedFinal(sb, sessionId, base) {
+  try {
+    const cutoffIso = new Date(Date.now() - STRANDED_MIN_AGE_MS).toISOString();
+    const { data: stranded } = await sb
+      .from('strategic_directives_v2')
+      .select('sd_key, status, current_phase, updated_at')
+      .eq('status', 'pending_approval')
+      .eq('current_phase', 'LEAD_FINAL')
+      .is('claiming_session_id', null)
+      .lt('updated_at', cutoffIso)            // parked > STRANDED_MIN_AGE_MS — not a mid-finalize race
+      .order('updated_at', { ascending: true }) // oldest stranded first
+      .limit(STRANDED_CANDIDATE_LIMIT);
+    for (const sd of (stranded || [])) {
+      const claimed = await tryClaim(sb, sd.sd_key, sessionId);
+      if (claimed.ok) {
+        return {
+          ...base,
+          action: 'resume_final',
+          sd: sd.sd_key,
+          message: `Recovered stranded SD ${sd.sd_key} (was pending_approval/LEAD_FINAL with claim cleared — one handoff from shipped). Re-attach + finish: node scripts/sd-start.js ${sd.sd_key}, then node scripts/handoff.js execute LEAD-FINAL-APPROVAL ${sd.sd_key}. If PR_MERGE_VERIFICATION blocks, merge the PR first (gh pr merge), then re-run.`,
+        };
+      }
+    }
+  } catch { /* fail-open -> caller continues to normal self-claim */ }
+  return null;
+}
+
 /**
  * Dedup guard: should this SD candidate be SKIPPED by self-claim because it is already
  * being built? v_sd_next_candidates only filters completed/cancelled/deferred and
@@ -383,6 +427,13 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
     }
   }
 
+  // 5.7 SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001: recover a STRANDED pending_approval/LEAD_FINAL SD
+  //      (claim cleared, one handoff from shipped) BEFORE self-claiming new work — finishing a
+  //      near-shipped SD beats starting fresh. Re-claiming lets a worker run LEAD-FINAL-APPROVAL with
+  //      a valid matching claim (passing the claim-validity gate the coordinator-from-main path fails).
+  const recovered = await recoverStrandedFinal(sb, sessionId, base);
+  if (recovered) return recovered;
+
   // 5.5 SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001: ensure an active execution baseline exists
   //      BEFORE reading v_sd_next_candidates. With zero active baseline the view returns 0 rows
   //      and self-claim silently idles with a full queue. Fail-open: a failure here degrades to
@@ -447,7 +498,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, isSdInFlight, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, isSdInFlight, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -35,6 +35,7 @@ function makeStub(cfg) {
       eq(k, v) { state.filters[k] = v; return chain; },
       in(k, v) { state.filters[k] = v; return chain; },
       neq(k, v) { state.filters['neq_' + k] = v; return chain; },
+      lt(k, v) { state.filters['lt_' + k] = v; return chain; },
       gte() { return chain; },
       is() { return chain; },
       order() { return chain; },
@@ -62,6 +63,16 @@ function makeStub(cfg) {
       }
       if (table === 'v_sd_next_candidates') return Promise.resolve({ data: cfg.candidates || [], error: null });
       if (table === 'strategic_directives_v2') {
+        // recoverStrandedFinal listing: .eq('status','pending_approval') sets a STRING filter
+        // (the draft tier uses .in('status', [...]) -> an ARRAY). Distinguish on that to return
+        // the stranded fixture; honor the .lt('updated_at', cutoff) staleness guard if provided.
+        if (state.filters.status === 'pending_approval') {
+          let rows = cfg.stranded || [];
+          if (state.filters.lt_updated_at !== undefined) {
+            rows = rows.filter((r) => !r.updated_at || r.updated_at < state.filters.lt_updated_at);
+          }
+          return Promise.resolve({ data: rows, error: null });
+        }
         // un-baselined-draft self-claim listing; honor the server-side `.neq('sd_type', …)` filter
         // so the orchestrator-parent exclusion is genuinely exercised by the stub.
         let rows = cfg.drafts || [];
@@ -544,5 +555,79 @@ describe('FIX-DEDUP: runCheckin skips in-flight SDs in BOTH self-claim tiers', (
     const r = await runCheckin(sb, 'me', noCoord);
     expect(r.action).toBe('self_claimed');
     expect(r.sd).toBe('SD-DRAFT-FREE-002');
+  });
+});
+
+// SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001: recover SDs stranded at pending_approval/LEAD_FINAL with
+// the claim cleared. Re-claiming lets a worker run LEAD-FINAL-APPROVAL with a valid matching claim,
+// passing the claim-validity gate the coordinator-from-main path fails. Runs BEFORE self-claiming new
+// work (finishing a near-shipped SD beats starting fresh).
+describe('FIX-RECURRING-2ND: recover stranded pending_approval/LEAD_FINAL SDs', () => {
+  const sess = { session: { metadata: { callsign: 'Bravo' }, sd_key: null }, messages: [] };
+  const old = '2020-01-01T00:00:00Z'; // safely older than the staleness cutoff
+  const strand = (sd_key, over = {}) => ({ sd_key, status: 'pending_approval', current_phase: 'LEAD_FINAL', updated_at: old, ...over });
+
+  it('recovers a stranded LEAD_FINAL SD with action=resume_final and finish instructions', async () => {
+    const sb = makeStub({ ...sess, stranded: [strand('SD-STRANDED-001')], candidates: [], claimResults: { 'SD-STRANDED-001': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_final');
+    expect(r.sd).toBe('SD-STRANDED-001');
+    expect(r.message).toMatch(/LEAD-FINAL-APPROVAL SD-STRANDED-001/);
+    expect(r.message).toMatch(/sd-start\.js SD-STRANDED-001/);
+  });
+
+  it('recovery WINS over self-claiming new baselined work (step 5.7 before step 6)', async () => {
+    const sb = makeStub({
+      ...sess,
+      stranded: [strand('SD-STRANDED-001')],
+      candidates: [{ sd_id: 'SD-NEWWORK-001', track: 'A' }],
+      drafts: [{ sd_key: 'SD-DRAFT-001', status: 'draft', sd_type: 'feature', priority: 'critical', created_at: '2026-01-01T00:00:00Z', dependencies: [] }],
+      claimResults: { 'SD-STRANDED-001': true, 'SD-NEWWORK-001': true, 'SD-DRAFT-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_final');
+    expect(r.sd).toBe('SD-STRANDED-001');
+  });
+
+  it('falls through to self-claim when no SD is stranded', async () => {
+    const sb = makeStub({
+      ...sess,
+      stranded: [],
+      candidates: [{ sd_id: 'SD-NEWWORK-001', track: 'A' }],
+      sdRows: { 'SD-NEWWORK-001': { current_phase: 'LEAD', sd_type: 'bugfix', dependencies: [] } }, // baselinedCandidateEligible lookup
+      claimResults: { 'SD-NEWWORK-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('self_claimed');
+    expect(r.sd).toBe('SD-NEWWORK-001');
+  });
+
+  it('falls through when the only stranded SD loses the claim race (peer recovered it)', async () => {
+    const sb = makeStub({ ...sess, stranded: [strand('SD-CONTESTED-001')], candidates: [], claimResults: { 'SD-CONTESTED-001': false } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle'); // no stranded claimable + no other work
+    expect(r.ok).toBe(true);
+  });
+
+  it('claims the OLDEST stranded SD first (returned updated_at-ascending)', async () => {
+    const sb = makeStub({
+      ...sess,
+      stranded: [strand('SD-OLDEST-001', { updated_at: '2020-01-01T00:00:00Z' }), strand('SD-NEWER-002', { updated_at: '2020-06-01T00:00:00Z' })],
+      candidates: [],
+      claimResults: { 'SD-OLDEST-001': true, 'SD-NEWER-002': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_final');
+    expect(r.sd).toBe('SD-OLDEST-001');
+  });
+
+  it('recoverStrandedFinal returns null (not throw) on a query error — fail-open', async () => {
+    const throwingSb = {
+      from: () => ({
+        select: () => ({ eq: () => ({ eq: () => ({ is: () => ({ lt: () => ({ order: () => ({ limit: () => Promise.reject(new Error('db down')) }) }) }) }) }) }),
+      }),
+    };
+    const r = await recoverStrandedFinal(throwingSb, 'sess-1', { ok: true });
+    expect(r).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
**Recurring bug (2nd occurrence).** SDs strand at `status='pending_approval'` / `current_phase='LEAD_FINAL'` with `claiming_session_id` **cleared** — a worker reaches LEAD_FINAL (gates passed, retro exists, PR merged) then releases its claim and goes idle **without** running the final `LEAD-FINAL-APPROVAL` handoff. The SD is one handoff from shipped but un-completable: self-claim skips `pending_approval` (only `draft`/`active`), and a coordinator running `LEAD-FINAL-APPROVAL` from main with the claim cleared fails the claim-validity worktree-isolation gate. The only reliable unblock today is a human window-pasting `sd-start` in a worker.

## Fix
A new worker-checkin recovery tier `recoverStrandedFinal()` at **step 5.7** (after a coordinator assignment, **before** self-claiming new work — finishing a near-shipped SD beats starting fresh) re-claims a stranded SD and returns a new action `resume_final`. The worker then re-attaches the worktree (`sd-start`) and runs `LEAD-FINAL-APPROVAL` with a **valid matching claim** — passing the gate the from-main path fails. **This automates the proven human recovery.**

- Staleness guard (parked > 5 min) so it never races a worker mid-finalize; oldest-first; idempotent; fail-open.
- Discriminator `current_phase='LEAD_FINAL'` is safe: a human LEAD-review pause is `current_phase='LEAD'` (distinct). `claim_sd` doesn't mutate status/phase, so re-claiming preserves the exact state the final approval needs.
- New `resume_final` action documented in `.claude/commands/checkin.md`.
- +6 vitest cases (50 total green).

## Follow-up
A preventive complement (worker `/loop` runs LEAD-FINAL-APPROVAL **before** releasing) is flagged — this PR is the **recovery** half.

SD: SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001 (bugfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)