### PR TITLE
fix(SD-LEO-GEN-PIN-SEARCH-PATH-001): pin search_path=public on three LEO functions

### DIFF
--- a/database/migrations/20260608_pin_search_path_leo_functions.sql
+++ b/database/migrations/20260608_pin_search_path_leo_functions.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- SD-LEO-GEN-PIN-SEARCH-PATH-001
+-- Pin search_path on three LEO plpgsql functions (function_search_path_mutable)
+-- ----------------------------------------------------------------------------
+-- WHY: The Supabase database-linter WARNs that three public-schema plpgsql
+-- functions have a role-mutable search_path (pg_proc.proconfig IS NULL):
+--   - reset_cancelled_sd_patterns(text, text)
+--   - trg_fn_reset_patterns_on_sd_cancel()
+--   - leo_auto_exec_audit_append_only()
+-- A mutable search_path is a theoretical search-path-injection vector. It is not
+-- reachable by anon/authenticated here (an attacker would already need to create
+-- objects earlier on the resolution path), so this is standard hardening, not an
+-- active hole.
+--
+-- NOTE (verify-before-build): the live catalog shows all three functions are
+-- SECURITY INVOKER (pg_proc.prosecdef = false), NOT SECURITY DEFINER as the SD
+-- title states — so the practical risk is even lower (the function runs with the
+-- caller's privileges, not the owner's). The linter still flags the mutable path;
+-- pinning it resolves the warning and removes the ambiguity either way.
+--
+-- WHAT: pin each function's search_path to `public` (the established repo
+-- convention — see database/migrations/20251211_fix_check_sd_can_complete_security.sql
+-- and the 20251011_fix_progress_trigger_rls* migrations). pg_catalog is always
+-- searched first implicitly, so built-ins still resolve; bare public-object refs
+-- in the bodies keep working. ALTER FUNCTION ... SET is idempotent (re-run = no-op).
+-- Rollback is the commented DOWN block.
+-- ============================================================================
+
+ALTER FUNCTION public.reset_cancelled_sd_patterns(text, text)  SET search_path = public;
+ALTER FUNCTION public.trg_fn_reset_patterns_on_sd_cancel()     SET search_path = public;
+ALTER FUNCTION public.leo_auto_exec_audit_append_only()        SET search_path = public;
+
+-- ============================================================================
+-- DOWN / ROLLBACK  (apply manually to reverse this migration)
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--   ALTER FUNCTION public.reset_cancelled_sd_patterns(text, text)  RESET search_path;
+--   ALTER FUNCTION public.trg_fn_reset_patterns_on_sd_cancel()     RESET search_path;
+--   ALTER FUNCTION public.leo_auto_exec_audit_append_only()        RESET search_path;
+--   -- NOTE: this re-introduces the function_search_path_mutable linter WARN.
+-- COMMIT;
+-- ============================================================================


### PR DESCRIPTION
## Summary
Supabase linter WARN `function_search_path_mutable`: three LEO public-schema plpgsql functions have a role-mutable search_path (`proconfig` NULL) — a theoretical search-path-injection vector. **Verify-before-build correction:** the live catalog shows all three are `SECURITY INVOKER` (`prosecdef=false`), not DEFINER as the SD title stated, so the practical risk is even lower. Standard hardening.

## Fix
`database/migrations/20260608_pin_search_path_leo_functions.sql`:
```sql
ALTER FUNCTION public.reset_cancelled_sd_patterns(text, text)  SET search_path = public;
ALTER FUNCTION public.trg_fn_reset_patterns_on_sd_cancel()     SET search_path = public;
ALTER FUNCTION public.leo_auto_exec_audit_append_only()        SET search_path = public;
```
`= public` matches the established repo convention. `pg_catalog` stays implicit-first and bare public refs resolve, so **zero behavior change**. Idempotent (`ALTER FUNCTION SET` is a no-op on re-run); DOWN/rollback block included.

## Validation
Dry-run clean (4 statements). Signatures verified live via `pg_get_function_identity_arguments`. SECURITY + TESTING sub-agents validate. Production apply deferred to the deliberate `apply-migration.js` prod-deploy token handshake (PR-reviewed + merged before apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)