### PR TITLE
fix(SD-LEO-INFRA-FIX-GEN-CLASS-001): exempt GEN-class auto-generated SDs from GATE4_WORKFLOW_ROI

### DIFF
--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -61,12 +61,32 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD when available
     const sdLookup = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, sd_type')
+      .select('id, sd_key, sd_type, metadata')
       .or(`sd_key.eq.${sd_id},id.eq.${sd_id}`)
       .single()).data;
     if (sdLookup) {
       prdLookupId = sdLookup.sd_key || sd_id;
       handoffLookupId = sdLookup.id || sd_id;
+    }
+
+    // ── GEN-class auto-generated SD exemption (SD-LEO-INFRA-FIX-GEN-CLASS-001) ──
+    // GEN-class auto-generated standalone SDs (audit-to-sd / feedback generators set
+    // metadata.auto_generated=true) have no venture workflow to score for ROI — the SAME
+    // root cause that already exempts them from GATE_VISION_SCORE (lead-to-plan/gates/
+    // vision-score.js checks `sd.metadata?.auto_generated`). Without a mirror here, a
+    // security/governance-type GEN SD (not in the gate2-skip list below) scores 0 and is
+    // doomed on a SECOND content-based gate — the gate-family gap the coordinator observed
+    // (vision cleared via the existing exemption, then GATE4_WORKFLOW_ROI rejected score=0).
+    // This is a systemic policy carve-out for a class that legitimately has no workflow-ROI
+    // content — the same pattern as the corrective/orchestrator/auto_generated vision exempts
+    // — NOT a --bypass band-aid.
+    if (sdLookup?.metadata?.auto_generated) {
+      console.log('   ⏭️  GEN-class auto-generated SD detected — exempt from workflow-ROI scoring');
+      console.log('   ✅ No venture workflow to score (mirrors the GATE_VISION_SCORE auto_generated exemption)');
+      validation.score = 100;
+      validation.details.gen_class_exempt = true;
+      validation.warnings.push('GEN-class auto-generated SD: workflow-ROI scoring exempted (no venture workflow; same basis as the GATE_VISION_SCORE auto_generated exemption)');
+      return validation;
     }
 
     // SD-LEARN-FIX-ADDRESS-PAT-AUTO-035: Determine if EXEC-TO-PLAN (gate2) is required for this SD type

--- a/tests/unit/gate4-gen-class-exemption.test.js
+++ b/tests/unit/gate4-gen-class-exemption.test.js
@@ -1,0 +1,68 @@
+/**
+ * SD-LEO-INFRA-FIX-GEN-CLASS-001 — GATE4_WORKFLOW_ROI must exempt GEN-class
+ * auto-generated SDs, mirroring the existing GATE_VISION_SCORE auto_generated
+ * exemption. Without it, a security/governance-type GEN SD (not in GATE4's
+ * gate2-skip list) scores 0 on empty content and is doomed on a second
+ * content-based gate after vision already exempted it.
+ *
+ * The exemption returns early (before the PRD fetch), so the SD lookup mock is
+ * all that's needed.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('child_process', () => ({ exec: vi.fn((cmd, cb) => cb && cb(null, '', '')) }));
+vi.mock('util', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, promisify: () => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }) };
+});
+vi.mock('../../scripts/modules/adaptive-threshold-calculator.js', () => ({
+  calculateAdaptiveThreshold: vi.fn().mockResolvedValue({ threshold: 60 })
+}));
+vi.mock('../../scripts/modules/pattern-tracking.js', () => ({
+  getPatternStats: vi.fn().mockResolvedValue({ total: 0, resolved: 0 })
+}));
+
+import { validateGate4LeadFinal } from '../../scripts/modules/workflow-roi-validation.js';
+
+// Minimal supabase mock: only the strategic_directives_v2 lookup matters for the
+// early exemption path. The fallthrough (non-GEN) path also hits product_requirements_v2.
+function buildMock({ metadata = null, sdType = 'security', prd = null } = {}) {
+  return {
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return { select: () => ({ or: () => ({ single: () => Promise.resolve({ data: { id: 'uuid-gen', sd_key: 'SD-AUDIT-SEC-001', sd_type: sdType, metadata }, error: null }) }) }) };
+      }
+      if (table === 'product_requirements_v2') {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: prd, error: prd ? null : { code: 'PGRST116', message: 'no rows' } }) }) }) };
+      }
+      return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null, error: null }), order: () => Promise.resolve({ data: [], error: null }) }) }) };
+    }),
+  };
+}
+
+describe('SD-LEO-INFRA-FIX-GEN-CLASS-001: GATE4 exempts GEN-class auto-generated SDs', () => {
+  it('exempts a security-type GEN SD with metadata.auto_generated=true (score 100, gen_class_exempt)', async () => {
+    const supabase = buildMock({ metadata: { auto_generated: true }, sdType: 'security' });
+    const v = await validateGate4LeadFinal('SD-AUDIT-SEC-001', supabase, {});
+    expect(v.passed).toBe(true);
+    expect(v.score).toBe(100);
+    expect(v.details.gen_class_exempt).toBe(true);
+    expect(v.warnings.some((w) => /GEN-class auto-generated/.test(w))).toBe(true);
+  });
+
+  it('exempts a governance-type GEN SD too (gate2-skip list does not cover governance)', async () => {
+    const supabase = buildMock({ metadata: { auto_generated: true }, sdType: 'governance' });
+    const v = await validateGate4LeadFinal('SD-AUDIT-GOV-001', supabase, {});
+    expect(v.score).toBe(100);
+    expect(v.details.gen_class_exempt).toBe(true);
+  });
+
+  it('does NOT take the GEN-class exemption for a normal (non-auto-generated) SD', async () => {
+    // No metadata.auto_generated and no PRD analysis → falls through to the normal
+    // path (which skips Gate 4 for "no DESIGN/DATABASE analysis"), so gen_class_exempt
+    // must be ABSENT — proving the exemption is scoped to the GEN-class signal only.
+    const supabase = buildMock({ metadata: { source: 'feedback' }, sdType: 'security', prd: { metadata: {}, directive_id: 'SD-NORMAL-001', title: 'x', created_at: '2026-06-08T00:00:00Z' } });
+    const v = await validateGate4LeadFinal('SD-NORMAL-001', supabase, {});
+    expect(v.details.gen_class_exempt).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
GEN-class auto-generated SDs (audit-to-sd / feedback generators set `metadata.auto_generated=true`; sd_type security/governance/infra) were hard-blocked by the content-based gate family. A two-tick diagnosis showed `GATE_VISION_SCORE` **already** exempts `metadata.auto_generated` (`vision-score.js:377`, alongside the orchestrator-child and corrective-SD exempts) — so the vision half was already solved. The remaining gap: `GATE4_WORKFLOW_ROI`'s gate2-skip list covers `infrastructure/documentation/fix/corrective` but **not** `security/governance`, so a security/governance-type GEN SD cleared vision then scored **0** at GATE4 (the live failure the coordinator observed).

## Fix
Mirror the existing vision exemption onto GATE4: an early return in `validateGate4LeadFinal` (`workflow-roi-validation.js`) when `sd.metadata?.auto_generated` is true (`score=100`, `details.gen_class_exempt=true`), scoped to that GEN-class signal only. `GATE_VISION_SCORE` is **not** modified (already exempt).

This is a precedented systemic policy carve-out (same pattern as the existing corrective/orchestrator/auto_generated vision exempts), explicitly **not** a `--bypass-validation` band-aid.

## Diagnosis notes (in the PRD)
- No live GEN SDs currently exist (the "SD-LEO-GEN-" naming was illustrative); the real generator is `audit-to-sd.mjs` (`SD-AUDIT-*`, `auto_generated=true`).
- `scoreSDAtConception` (the SD's recommended "Option B") is already wired (`leo-create-sd.js:1928`) and insufficient alone — GEN SDs have no venture vision to score against. Hence the exemption approach.

## Testing
- `npx vitest run tests/unit/gate4-gen-class-exemption.test.js` → **3 passed** (security GEN exempt, governance GEN exempt, normal SD NOT exempt)
- `npx vitest run tests/unit/workflow-roi-strategic-review-handoff-type.test.js` → **3 passed** (existing suite, no regression)
- TESTING sub-agent: PASS (row `1803e557`, 6/6)

## LEO
SD-LEO-INFRA-FIX-GEN-CLASS-001 (infrastructure) · gates 93/94/94/97 · retro 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)