### PR TITLE
feat(SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001): fix v_sd_next_candidates root cause (trigger sd_key + deps_satisfied + reversible reconciliation)

### DIFF
--- a/database/migrations/20260608_fix_baseline_sync_sdkey_and_deps_satisfied.sql
+++ b/database/migrations/20260608_fix_baseline_sync_sdkey_and_deps_satisfied.sql
@@ -1,0 +1,291 @@
+-- Migration: Fix v_sd_next_candidates root cause
+-- SD: SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001
+--
+-- THREE coupled defects break the worker self_claim queue:
+--   1. fn_sync_sd_to_baseline() writes sd_baseline_items.sd_id = NEW.id (UUID),
+--      but v_sd_next_candidates JOINs bi.sd_id = sd.sd_key (TEXT). No FK exists,
+--      so every trigger-synced row silently fails the JOIN and vanishes from the
+--      candidate queue.
+--   2. v_sd_next_candidates.deps_satisfied mis-resolves OBJECT-shaped dependency
+--      snapshots ({"sd_id":..}/{"sd_key":..}/{"orchestrator":..}) because it ran
+--      split_part() over the jsonb TEXT of each element.
+--   3. (JS, separate file) scripts/sd-baseline.js had a `|| sd.id` UUID fallback.
+--
+-- This migration: (A) rewrites the trigger function to write/match sd_key;
+-- (B) rewrites the view's deps_satisfied to resolve string/object/null shapes;
+-- (C) reversibly reconciles existing resolvable UUID-shaped rows to sd_key
+--     (snapshot to backup table, dedup-before-convert). Mass purge of unjoinable
+--     test-pollution/orphan rows is DESCOPED (filed as a follow-up SD).
+--
+-- Reversible: see 20260608_fix_baseline_sync_sdkey_and_deps_satisfied_down.sql
+-- No schema changes (function body + view body + data only).
+
+-- ============================================================================
+-- (A) TRIGGER FUNCTION: write/match NEW.sd_key instead of NEW.id
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.fn_sync_sd_to_baseline()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_active_baseline_id UUID;
+  v_baseline_item_exists BOOLEAN;
+  v_track TEXT;
+BEGIN
+  SELECT id INTO v_active_baseline_id
+  FROM sd_execution_baselines
+  WHERE is_active = true
+  LIMIT 1;
+  IF v_active_baseline_id IS NULL THEN
+    RAISE NOTICE 'fn_sync_sd_to_baseline: No active baseline found. SD % not auto-synced.', NEW.sd_key;
+    RETURN NEW;
+  END IF;
+  v_track := CASE
+    WHEN LOWER(NEW.category) IN ('infrastructure', 'platform') THEN 'A'
+    WHEN LOWER(NEW.category) IN ('quality', 'testing', 'qa') THEN 'C'
+    ELSE 'B'  -- Default to Features track
+  END;
+  IF TG_OP = 'INSERT' THEN
+    -- LOAD-BEARING: sd_id MUST be NEW.sd_key (the v_sd_next_candidates JOIN key).
+    SELECT EXISTS(
+      SELECT 1 FROM sd_baseline_items
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.sd_key
+    ) INTO v_baseline_item_exists;
+    IF NOT v_baseline_item_exists THEN
+      INSERT INTO sd_baseline_items (
+        baseline_id,
+        sd_id,
+        sequence_rank,
+        track,
+        is_ready,
+        created_at
+      ) VALUES (
+        v_active_baseline_id,
+        NEW.sd_key,
+        COALESCE(
+          (SELECT MAX(sequence_rank) + 1 FROM sd_baseline_items WHERE baseline_id = v_active_baseline_id),
+          1
+        ),
+        v_track,
+        false,  -- New SDs are not ready by default
+        NOW()
+      );
+      RAISE NOTICE 'fn_sync_sd_to_baseline: Added SD % to baseline % (Track %)', NEW.sd_key, v_active_baseline_id, v_track;
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.status IS DISTINCT FROM NEW.status THEN
+      IF NEW.status = 'completed' THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nCompleted: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Marked SD % as completed in baseline', NEW.sd_key;
+      ELSIF OLD.status = 'completed' AND NEW.status IN ('active', 'planning', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nReactivated: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Reactivated SD % in baseline', NEW.sd_key;
+      ELSIF NEW.status IN ('active', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET is_ready = true
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+      END IF;
+    END IF;
+    IF OLD.category IS DISTINCT FROM NEW.category THEN
+      UPDATE sd_baseline_items
+      SET track = v_track
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.sd_key;
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================================
+-- (B) VIEW: multi-shape deps_satisfied resolution
+-- ============================================================================
+-- deps_satisfied is FALSE only when a dependency element resolves to a REAL,
+-- KNOWN strategic directive (by sd_key OR id) that is NOT completed. none/null/
+-- empty/prose/unresolvable refs are treated as satisfied (fail-open), preserving
+-- the prior COALESCE(count(*)=0, true) intent. Resolves string, object
+-- ({sd_key}/{sd_id}/{orchestrator}) and null/empty array shapes.
+CREATE OR REPLACE VIEW public.v_sd_next_candidates AS
+ WITH active_baseline AS (
+         SELECT sd_execution_baselines.id
+           FROM sd_execution_baselines
+          WHERE sd_execution_baselines.is_active = true
+         LIMIT 1
+        ), dependency_status AS (
+         SELECT bi_1.sd_id,
+            bi_1.sequence_rank,
+            bi_1.track,
+            bi_1.dependencies_snapshot,
+            COALESCE((
+              SELECT count(*) = 0
+              FROM jsonb_array_elements(
+                     CASE WHEN jsonb_typeof(bi_1.dependencies_snapshot) = 'array'
+                          THEN bi_1.dependencies_snapshot
+                          ELSE '[]'::jsonb END) AS dep(value)
+              CROSS JOIN LATERAL (
+                SELECT CASE
+                         WHEN jsonb_typeof(dep.value) = 'string'
+                           THEN split_part(dep.value #>> '{}', ' '::text, 1)
+                         WHEN jsonb_typeof(dep.value) = 'object'
+                           THEN COALESCE(dep.value ->> 'sd_key', dep.value ->> 'sd_id', dep.value ->> 'orchestrator')
+                         ELSE NULL
+                       END AS ref
+              ) r
+              WHERE r.ref IS NOT NULL
+                AND lower(r.ref) <> 'none'
+                AND EXISTS (
+                  SELECT 1
+                  FROM strategic_directives_v2 sd2
+                  WHERE (sd2.sd_key = r.ref OR sd2.id::text = r.ref)
+                    AND sd2.status::text <> 'completed'::text)
+            ), true) AS deps_satisfied
+           FROM sd_baseline_items bi_1
+          WHERE bi_1.baseline_id = (( SELECT active_baseline.id
+                   FROM active_baseline))
+        )
+ SELECT bi.sd_id,
+    sd.title,
+    sd.priority,
+    sd.status,
+    sd.progress_percentage,
+    bi.sequence_rank,
+    bi.track,
+    bi.track_name,
+    bi.estimated_effort_hours,
+    bi.dependency_health_score,
+    ds.deps_satisfied,
+    ea.status AS execution_status,
+    sd.is_working_on,
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END AS readiness_priority
+   FROM sd_baseline_items bi
+     JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key
+     JOIN dependency_status ds ON bi.sd_id = ds.sd_id
+     LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id AND ea.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline))
+  WHERE bi.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline)) AND (sd.status::text <> ALL (ARRAY['completed'::character varying::text, 'cancelled'::character varying::text, 'deferred'::character varying::text]))
+  ORDER BY (
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END), bi.sequence_rank;
+
+-- ============================================================================
+-- (C) REVERSIBLE RECONCILIATION of resolvable UUID-shaped rows -> sd_key
+-- ============================================================================
+-- Atomic + advisory-locked DO block. Snapshots affected rows to a persistent
+-- backup table BEFORE any mutation. Dedup-before-convert avoids 23505 on
+-- UNIQUE(baseline_id, sd_id). Naturally idempotent: after conversion the
+-- resolvable-UUID set is empty, so re-running is a no-op. Bounded to the active
+-- baseline and to UUID rows that resolve to a real SD by id. Unjoinable
+-- test-pollution / orphan rows are intentionally left untouched.
+
+-- Backup table (persists for migration-down). No constraints -> safe to hold
+-- both converted survivors and deleted colliders.
+CREATE TABLE IF NOT EXISTS public.sd_baseline_items_recon_backup (
+  backup_id         BIGSERIAL PRIMARY KEY,
+  recon_action      TEXT NOT NULL,         -- 'converted' | 'deleted'
+  resolved_sd_key   TEXT,                  -- the sd_key the UUID resolved to
+  backed_up_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  item_id           UUID,                  -- original sd_baseline_items.id
+  baseline_id       UUID,
+  sd_id             TEXT,                  -- ORIGINAL (UUID) sd_id
+  sequence_rank     INTEGER,
+  track             TEXT,
+  track_name        TEXT,
+  dependencies_snapshot JSONB,
+  dependency_health_score NUMERIC,
+  is_ready          BOOLEAN,
+  notes             TEXT,
+  estimated_effort_hours NUMERIC,
+  created_at        TIMESTAMPTZ
+);
+
+DO $recon$
+DECLARE
+  v_active_baseline_id UUID;
+  v_converted INTEGER := 0;
+  v_deleted INTEGER := 0;
+BEGIN
+  -- Serialize against concurrent runs / fleet trigger churn.
+  PERFORM pg_advisory_xact_lock(hashtext('sd_baseline_items_recon_SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001'));
+
+  SELECT id INTO v_active_baseline_id
+  FROM sd_execution_baselines WHERE is_active = true LIMIT 1;
+  IF v_active_baseline_id IS NULL THEN
+    RAISE NOTICE 'reconciliation: no active baseline; nothing to do.';
+    RETURN;
+  END IF;
+
+  -- Resolve each UUID-shaped row to its SD by id (only rows that join to a real SD).
+  CREATE TEMP TABLE _resolvable ON COMMIT DROP AS
+  SELECT bi.id AS item_id, bi.sd_id AS uuid_sd_id, sd.sd_key AS target_sd_key
+  FROM sd_baseline_items bi
+  JOIN strategic_directives_v2 sd ON sd.id::text = bi.sd_id
+  WHERE bi.baseline_id = v_active_baseline_id
+    AND bi.sd_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+  -- Classify: collider (a key-shaped row for target_sd_key already exists) -> delete; else convert.
+  CREATE TEMP TABLE _classified ON COMMIT DROP AS
+  SELECT r.item_id, r.uuid_sd_id, r.target_sd_key,
+         EXISTS (
+           SELECT 1 FROM sd_baseline_items k
+           WHERE k.baseline_id = v_active_baseline_id
+             AND k.sd_id = r.target_sd_key
+         ) AS is_collider
+  FROM _resolvable r;
+
+  -- Snapshot ALL affected rows BEFORE mutation.
+  INSERT INTO public.sd_baseline_items_recon_backup
+    (recon_action, resolved_sd_key, item_id, baseline_id, sd_id, sequence_rank,
+     track, track_name, dependencies_snapshot, dependency_health_score, is_ready,
+     notes, estimated_effort_hours, created_at)
+  SELECT CASE WHEN c.is_collider THEN 'deleted' ELSE 'converted' END,
+         c.target_sd_key, bi.id, bi.baseline_id, bi.sd_id, bi.sequence_rank,
+         bi.track, bi.track_name, bi.dependencies_snapshot, bi.dependency_health_score,
+         bi.is_ready, bi.notes, bi.estimated_effort_hours, bi.created_at
+  FROM _classified c
+  JOIN sd_baseline_items bi ON bi.id = c.item_id;
+
+  -- Delete colliders (the key-shaped row already represents the SD).
+  DELETE FROM sd_baseline_items bi
+  USING _classified c
+  WHERE bi.id = c.item_id AND c.is_collider;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  -- Convert survivors UUID -> sd_key.
+  UPDATE sd_baseline_items bi
+  SET sd_id = c.target_sd_key
+  FROM _classified c
+  WHERE bi.id = c.item_id AND NOT c.is_collider;
+  GET DIAGNOSTICS v_converted = ROW_COUNT;
+
+  RAISE NOTICE 'reconciliation: converted=%, deleted_colliders=% (baseline %)',
+    v_converted, v_deleted, v_active_baseline_id;
+END
+$recon$;

--- a/database/migrations/20260608_fix_baseline_sync_sdkey_and_deps_satisfied_down.sql
+++ b/database/migrations/20260608_fix_baseline_sync_sdkey_and_deps_satisfied_down.sql
@@ -1,0 +1,210 @@
+-- DOWN migration (reversal) for:
+--   20260608_fix_baseline_sync_sdkey_and_deps_satisfied.sql
+-- SD: SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001
+--
+-- Restores: (A) prior trigger body (writes NEW.id), (B) prior view def (string-
+-- only deps_satisfied), (C) reverses the data reconciliation from the backup
+-- table sd_baseline_items_recon_backup (re-insert deleted colliders, restore
+-- converted rows' sd_id to the original UUID).
+--
+-- WARNING: reversing the data re-introduces the UUID-shaped rows that the forward
+-- migration's trigger fix prevents. Only run this together with the function/view
+-- restore below (which is what this file does), so the system is internally
+-- consistent with its pre-fix state.
+
+-- ============================================================================
+-- (A) RESTORE prior trigger function (writes/matches NEW.id)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.fn_sync_sd_to_baseline()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_active_baseline_id UUID;
+  v_baseline_item_exists BOOLEAN;
+  v_track TEXT;
+BEGIN
+  SELECT id INTO v_active_baseline_id
+  FROM sd_execution_baselines
+  WHERE is_active = true
+  LIMIT 1;
+  IF v_active_baseline_id IS NULL THEN
+    RAISE NOTICE 'fn_sync_sd_to_baseline: No active baseline found. SD % not auto-synced.', NEW.id;
+    RETURN NEW;
+  END IF;
+  v_track := CASE
+    WHEN LOWER(NEW.category) IN ('infrastructure', 'platform') THEN 'A'
+    WHEN LOWER(NEW.category) IN ('quality', 'testing', 'qa') THEN 'C'
+    ELSE 'B'  -- Default to Features track
+  END;
+  IF TG_OP = 'INSERT' THEN
+    SELECT EXISTS(
+      SELECT 1 FROM sd_baseline_items
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.id
+    ) INTO v_baseline_item_exists;
+    IF NOT v_baseline_item_exists THEN
+      INSERT INTO sd_baseline_items (
+        baseline_id,
+        sd_id,
+        sequence_rank,
+        track,
+        is_ready,
+        created_at
+      ) VALUES (
+        v_active_baseline_id,
+        NEW.id,
+        COALESCE(
+          (SELECT MAX(sequence_rank) + 1 FROM sd_baseline_items WHERE baseline_id = v_active_baseline_id),
+          1
+        ),
+        v_track,
+        false,
+        NOW()
+      );
+      RAISE NOTICE 'fn_sync_sd_to_baseline: Added SD % to baseline % (Track %)', NEW.id, v_active_baseline_id, v_track;
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.status IS DISTINCT FROM NEW.status THEN
+      IF NEW.status = 'completed' THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nCompleted: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.id;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Marked SD % as completed in baseline', NEW.id;
+      ELSIF OLD.status = 'completed' AND NEW.status IN ('active', 'planning', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nReactivated: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.id;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Reactivated SD % in baseline', NEW.id;
+      ELSIF NEW.status IN ('active', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET is_ready = true
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.id;
+      END IF;
+    END IF;
+    IF OLD.category IS DISTINCT FROM NEW.category THEN
+      UPDATE sd_baseline_items
+      SET track = v_track
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.id;
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================================
+-- (B) RESTORE prior view definition (string-only split_part deps_satisfied)
+-- ============================================================================
+CREATE OR REPLACE VIEW public.v_sd_next_candidates AS
+ WITH active_baseline AS (
+         SELECT sd_execution_baselines.id
+           FROM sd_execution_baselines
+          WHERE sd_execution_baselines.is_active = true
+         LIMIT 1
+        ), dependency_status AS (
+         SELECT bi_1.sd_id,
+            bi_1.sequence_rank,
+            bi_1.track,
+            bi_1.dependencies_snapshot,
+            COALESCE(( SELECT count(*) = 0
+                   FROM jsonb_array_elements_text(bi_1.dependencies_snapshot) dep(value)
+                  WHERE NOT (EXISTS ( SELECT 1
+                           FROM strategic_directives_v2 sd2
+                          WHERE sd2.sd_key = split_part(dep.value, ' '::text, 1) AND sd2.status::text = 'completed'::text))), true) AS deps_satisfied
+           FROM sd_baseline_items bi_1
+          WHERE bi_1.baseline_id = (( SELECT active_baseline.id
+                   FROM active_baseline))
+        )
+ SELECT bi.sd_id,
+    sd.title,
+    sd.priority,
+    sd.status,
+    sd.progress_percentage,
+    bi.sequence_rank,
+    bi.track,
+    bi.track_name,
+    bi.estimated_effort_hours,
+    bi.dependency_health_score,
+    ds.deps_satisfied,
+    ea.status AS execution_status,
+    sd.is_working_on,
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END AS readiness_priority
+   FROM sd_baseline_items bi
+     JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key
+     JOIN dependency_status ds ON bi.sd_id = ds.sd_id
+     LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id AND ea.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline))
+  WHERE bi.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline)) AND (sd.status::text <> ALL (ARRAY['completed'::character varying::text, 'cancelled'::character varying::text, 'deferred'::character varying::text]))
+  ORDER BY (
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END), bi.sequence_rank;
+
+-- ============================================================================
+-- (C) REVERSE the data reconciliation from the backup table
+-- ============================================================================
+DO $undo$
+DECLARE
+  v_restored_converted INTEGER := 0;
+  v_reinserted INTEGER := 0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('sd_baseline_items_recon_SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001'));
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables
+                 WHERE table_schema = 'public' AND table_name = 'sd_baseline_items_recon_backup') THEN
+    RAISE NOTICE 'down: backup table absent; no data to reverse.';
+    RETURN;
+  END IF;
+
+  -- Restore converted rows' sd_id back to the original UUID (keyed on the PK).
+  UPDATE sd_baseline_items bi
+  SET sd_id = b.sd_id
+  FROM public.sd_baseline_items_recon_backup b
+  WHERE b.recon_action = 'converted'
+    AND bi.id = b.item_id
+    AND bi.sd_id = b.resolved_sd_key;  -- only if still in converted state
+  GET DIAGNOSTICS v_restored_converted = ROW_COUNT;
+
+  -- Re-insert deleted colliders with their original identity.
+  INSERT INTO sd_baseline_items
+    (id, baseline_id, sd_id, sequence_rank, track, track_name,
+     dependencies_snapshot, dependency_health_score, is_ready, notes,
+     estimated_effort_hours, created_at)
+  SELECT b.item_id, b.baseline_id, b.sd_id, b.sequence_rank, b.track, b.track_name,
+         b.dependencies_snapshot, b.dependency_health_score, b.is_ready, b.notes,
+         b.estimated_effort_hours, b.created_at
+  FROM public.sd_baseline_items_recon_backup b
+  WHERE b.recon_action = 'deleted'
+  ON CONFLICT (id) DO NOTHING;
+  GET DIAGNOSTICS v_reinserted = ROW_COUNT;
+
+  RAISE NOTICE 'down: restored_converted=%, reinserted_colliders=%', v_restored_converted, v_reinserted;
+
+  -- Leave the backup table in place for audit. To fully clean up after a
+  -- confirmed-good rollback, drop it manually:
+  --   DROP TABLE public.sd_baseline_items_recon_backup;
+END
+$undo$;

--- a/lib/sd-baseline/deps-resolve.js
+++ b/lib/sd-baseline/deps-resolve.js
@@ -1,0 +1,55 @@
+/**
+ * lib/sd-baseline/deps-resolve.js
+ *
+ * SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001
+ *
+ * Pure JS mirror of the v_sd_next_candidates.deps_satisfied SQL logic
+ * (migration 20260608_fix_baseline_sync_sdkey_and_deps_satisfied.sql, part B).
+ * Kept in lockstep with the SQL so the dependency-shape semantics are unit-
+ * testable network-free. If you change one, change the other (TS-2 guards this).
+ *
+ * Element-shape resolution (must match the SQL CROSS JOIN LATERAL ref):
+ *   - string  -> first space-delimited token  ("SD-X (foundational)" -> "SD-X")
+ *   - object  -> sd_key ?? sd_id ?? orchestrator
+ *   - other   -> null
+ *
+ * A dependency BLOCKS (makes deps_satisfied=false) ONLY when its ref resolves to
+ * a real, KNOWN strategic directive (by sd_key or id) that is NOT completed.
+ * none / null / empty / prose / unresolvable refs are treated as satisfied
+ * (fail-open), preserving the prior COALESCE(count(*)=0, true) intent.
+ */
+
+/**
+ * Resolve one dependency-snapshot element to its SD reference string.
+ * @param {*} element - a jsonb array element (string | object | other)
+ * @returns {string|null} the resolved ref, or null if unresolvable
+ */
+export function resolveDepRef(element) {
+  if (typeof element === 'string') {
+    const token = element.trim().split(' ')[0];
+    return token || null;
+  }
+  if (element && typeof element === 'object' && !Array.isArray(element)) {
+    return element.sd_key ?? element.sd_id ?? element.orchestrator ?? null;
+  }
+  return null;
+}
+
+/**
+ * @param {*} snapshot - dependencies_snapshot (expected array; anything else => [])
+ * @param {(ref:string)=>('completed'|'incomplete'|null)} lookup
+ *        Resolves a ref to the referenced SD's completion state, or null if the
+ *        ref matches NO known SD (by sd_key or id).
+ * @returns {boolean} deps_satisfied
+ */
+export function computeDepsSatisfied(snapshot, lookup) {
+  const arr = Array.isArray(snapshot) ? snapshot : [];
+  for (const el of arr) {
+    const ref = resolveDepRef(el);
+    if (ref == null) continue;                  // unresolvable / prose -> satisfied
+    if (String(ref).toLowerCase() === 'none') continue; // explicit no-dep
+    if (lookup(ref) === 'incomplete') return false;     // real, known, not-completed -> blocks
+    // completed or unknown(null) -> not blocking (fail-open)
+  }
+  return true;
+}

--- a/scripts/sd-baseline.js
+++ b/scripts/sd-baseline.js
@@ -130,6 +130,13 @@ class SDBaselineManager {
     // Create baseline items
     const items = [];
     for (const sd of sds) {
+      // sd_id MUST be sd_key (the v_sd_next_candidates JOIN key) — never the UUID.
+      // SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001: skip an SD missing sd_key rather than
+      // falling back to sd.id (a UUID is a silent view drop; there is no FK).
+      if (!sd.sd_key) {
+        console.log(`${colors.yellow}Skipping SD ${sd.id}: missing sd_key (cannot key sd_baseline_items).${colors.reset}`);
+        continue;
+      }
       const track = sd.metadata?.execution_track || 'UNASSIGNED';
       const trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
                        track === 'Feature' ? 'B' :
@@ -146,7 +153,7 @@ class SDBaselineManager {
 
       items.push({
         baseline_id: baseline.id,
-        sd_id: sd.sd_key || sd.id,
+        sd_id: sd.sd_key,
         sequence_rank: sd.sequence_rank,
         track: trackKey,
         track_name: trackName,
@@ -167,8 +174,8 @@ class SDBaselineManager {
     }
 
     // Create initial actuals records
-    const actuals = sds.map(sd => ({
-      sd_id: sd.sd_key || sd.id,
+    const actuals = sds.filter(sd => sd.sd_key).map(sd => ({
+      sd_id: sd.sd_key,
       baseline_id: baseline.id,
       status: sd.progress_percentage > 0 ? 'in_progress' : 'not_started'
     }));
@@ -397,6 +404,12 @@ class SDBaselineManager {
     if (sds && sds.length > 0) {
       const items = [];
       for (const sd of sds) {
+        // sd_id MUST be sd_key (the v_sd_next_candidates JOIN key) — never the UUID.
+        // SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001: skip SDs missing sd_key.
+        if (!sd.sd_key) {
+          console.log(`${colors.yellow}Skipping SD ${sd.id}: missing sd_key.${colors.reset}`);
+          continue;
+        }
         const track = sd.metadata?.execution_track || 'UNASSIGNED';
         const trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
                          track === 'Feature' ? 'B' :
@@ -406,7 +419,7 @@ class SDBaselineManager {
 
         items.push({
           baseline_id: newBaseline.id,
-          sd_id: sd.sd_key || sd.id,
+          sd_id: sd.sd_key,
           sequence_rank: sd.sequence_rank,
           track: trackKey,
           track_name: trackKey === 'A' ? 'Infrastructure/Safety' :

--- a/tests/integration/baseline-sync-rootcause.test.js
+++ b/tests/integration/baseline-sync-rootcause.test.js
@@ -1,0 +1,112 @@
+/**
+ * SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001
+ * HAS_REAL_DB behavioral tests for the v_sd_next_candidates root-cause fix.
+ *
+ * READ-ONLY / net-zero: no writes to sd_baseline_items or any table. The
+ * deps_satisfied SQL is exercised against synthetic jsonb VALUES using real
+ * completed/incomplete sd_keys, so it tests the actual Postgres semantics of the
+ * resolver without touching the live active baseline (which integration tests
+ * must NOT pollute — see the test-isolation follow-up SD).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+
+const describeDb = describe.skipIf(!HAS_REAL_DB);
+
+// The deps_satisfied scalar — MUST mirror migration part B
+// (20260608_fix_baseline_sync_sdkey_and_deps_satisfied.sql) and
+// lib/sd-baseline/deps-resolve.js.
+const DEPS_EXPR = `
+  COALESCE((
+    SELECT count(*) = 0
+    FROM jsonb_array_elements(
+           CASE WHEN jsonb_typeof($1::jsonb) = 'array' THEN $1::jsonb ELSE '[]'::jsonb END) AS dep(value)
+    CROSS JOIN LATERAL (
+      SELECT CASE
+               WHEN jsonb_typeof(dep.value) = 'string'
+                 THEN split_part(dep.value #>> '{}', ' ', 1)
+               WHEN jsonb_typeof(dep.value) = 'object'
+                 THEN COALESCE(dep.value ->> 'sd_key', dep.value ->> 'sd_id', dep.value ->> 'orchestrator')
+               ELSE NULL
+             END AS ref
+    ) r
+    WHERE r.ref IS NOT NULL
+      AND lower(r.ref) <> 'none'
+      AND EXISTS (
+        SELECT 1 FROM strategic_directives_v2 sd2
+        WHERE (sd2.sd_key = r.ref OR sd2.id::text = r.ref)
+          AND sd2.status::text <> 'completed'::text)
+  ), true) AS deps_satisfied`;
+
+describeDb('v_sd_next_candidates root-cause fix (live DB)', () => {
+  let client;
+  let completedKey;
+  let incompleteKey;
+
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    client = await createDatabaseClient('engineer', { verify: false });
+    const done = await client.query(
+      "SELECT sd_key FROM strategic_directives_v2 WHERE status = 'completed' AND sd_key IS NOT NULL LIMIT 1;");
+    const open = await client.query(
+      "SELECT sd_key FROM strategic_directives_v2 WHERE status NOT IN ('completed','cancelled','deferred') AND sd_key IS NOT NULL LIMIT 1;");
+    completedKey = done.rows[0]?.sd_key;
+    incompleteKey = open.rows[0]?.sd_key;
+  });
+
+  afterAll(async () => { if (client) await client.end(); });
+
+  const deps = async (snapshotJson) => {
+    const { rows } = await client.query(`SELECT ${DEPS_EXPR}`, [snapshotJson]);
+    return rows[0].deps_satisfied;
+  };
+
+  it('object dep referencing a COMPLETED SD -> satisfied', async () => {
+    expect(completedKey).toBeTruthy();
+    expect(await deps(JSON.stringify([{ sd_id: completedKey }]))).toBe(true);
+  });
+
+  it('object dep referencing a NON-completed SD -> NOT satisfied', async () => {
+    expect(incompleteKey).toBeTruthy();
+    expect(await deps(JSON.stringify([{ sd_id: incompleteKey }]))).toBe(false);
+  });
+
+  it('string dep "<incomplete> (foundational)" -> NOT satisfied', async () => {
+    expect(await deps(JSON.stringify([`${incompleteKey} (foundational)`]))).toBe(false);
+  });
+
+  it('none / null / empty / prose / unresolvable -> satisfied (fail-open)', async () => {
+    expect(await deps(JSON.stringify([{ sd_key: 'none', description: 'No blocking dependencies' }]))).toBe(true);
+    expect(await deps('null')).toBe(true);
+    expect(await deps(JSON.stringify([]))).toBe(true);
+    expect(await deps(JSON.stringify(['Access to EHG application codebase']))).toBe(true);
+    expect(await deps(JSON.stringify([{ sd_id: 'SD-DOES-NOT-EXIST-ZZZ-999' }]))).toBe(true);
+  });
+
+  it('mixed completed + incomplete -> NOT satisfied', async () => {
+    expect(await deps(JSON.stringify([{ sd_id: completedKey }, { sd_id: incompleteKey }]))).toBe(false);
+  });
+
+  // Soft post-migration assertions: only enforced once the migration is applied,
+  // so this suite stays green on a DB that has not yet run the migration.
+  it('reports live trigger/view fix state (soft until migration applied)', async () => {
+    const fn = await client.query("SELECT pg_get_functiondef('fn_sync_sd_to_baseline'::regproc) AS def;");
+    const view = await client.query("SELECT pg_get_viewdef('v_sd_next_candidates'::regclass, true) AS def;");
+    const fnDef = fn.rows[0].def;
+    const viewDef = view.rows[0].def;
+    const fnFixed = fnDef.includes('NEW.sd_key');
+    const viewFixed = viewDef.includes('orchestrator');
+    if (fnFixed) {
+      expect(fnDef).toContain('NEW.sd_key');
+      expect(fnDef).not.toMatch(/VALUES\s*\([^)]*NEW\.id/s); // INSERT no longer writes NEW.id
+    } else {
+      console.warn('[soft] fn_sync_sd_to_baseline not yet migrated to sd_key — apply the migration.');
+    }
+    if (viewFixed) {
+      expect(viewDef).toContain('orchestrator');
+    } else {
+      console.warn('[soft] v_sd_next_candidates deps_satisfied not yet migrated — apply the migration.');
+    }
+    expect(true).toBe(true);
+  });
+});

--- a/tests/unit/baseline-deps-resolve.test.js
+++ b/tests/unit/baseline-deps-resolve.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001
+ * Network-free unit tests for the deps_satisfied dependency-shape resolver
+ * (lib/sd-baseline/deps-resolve.js), the JS mirror of the v_sd_next_candidates
+ * SQL. Also asserts buildBaselineItemRow never emits a UUID sd_id (regression
+ * for the removed `|| sd.id` fallback).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveDepRef, computeDepsSatisfied } from '../../lib/sd-baseline/deps-resolve.js';
+import { buildBaselineItemRow } from '../../lib/sd-baseline/build-item.js';
+
+// lookup fixtures: SD-DONE-001 completed, SD-OPEN-001 incomplete, anything else unknown.
+const lookup = (ref) =>
+  ref === 'SD-DONE-001' ? 'completed'
+  : ref === 'SD-OPEN-001' ? 'incomplete'
+  : null;
+
+describe('resolveDepRef — element shapes', () => {
+  it('string: first space-delimited token', () => {
+    expect(resolveDepRef('SD-OPEN-001 (foundational)')).toBe('SD-OPEN-001');
+    expect(resolveDepRef('SD-DONE-001')).toBe('SD-DONE-001');
+  });
+  it('object: sd_key > sd_id > orchestrator precedence', () => {
+    expect(resolveDepRef({ sd_key: 'SD-OPEN-001' })).toBe('SD-OPEN-001');
+    expect(resolveDepRef({ sd_id: 'SD-OPEN-001' })).toBe('SD-OPEN-001');
+    expect(resolveDepRef({ orchestrator: 'SD-OPEN-001' })).toBe('SD-OPEN-001');
+    expect(resolveDepRef({ sd_key: 'SD-A', sd_id: 'SD-B' })).toBe('SD-A');
+  });
+  it('null / empty / non-object -> null', () => {
+    expect(resolveDepRef(null)).toBeNull();
+    expect(resolveDepRef({})).toBeNull();
+    expect(resolveDepRef(42)).toBeNull();
+    expect(resolveDepRef([])).toBeNull();
+  });
+});
+
+describe('computeDepsSatisfied — fail-open semantics', () => {
+  it('object dep referencing a COMPLETED SD -> satisfied (TS-1)', () => {
+    expect(computeDepsSatisfied([{ sd_id: 'SD-DONE-001' }], lookup)).toBe(true);
+  });
+  it('object dep referencing a NON-completed SD -> NOT satisfied (TS-2)', () => {
+    expect(computeDepsSatisfied([{ sd_id: 'SD-OPEN-001' }], lookup)).toBe(false);
+  });
+  it('string dep "SD-OPEN-001 (foundational)" referencing non-completed -> NOT satisfied', () => {
+    expect(computeDepsSatisfied(['SD-OPEN-001 (foundational)'], lookup)).toBe(false);
+  });
+  it('none / null snapshot / prose / unresolvable -> satisfied (TS-3)', () => {
+    expect(computeDepsSatisfied([{ sd_key: 'none', description: 'No blocking dependencies' }], lookup)).toBe(true);
+    expect(computeDepsSatisfied(null, lookup)).toBe(true);
+    expect(computeDepsSatisfied([], lookup)).toBe(true);
+    expect(computeDepsSatisfied(['Access to EHG application codebase'], lookup)).toBe(true);
+    expect(computeDepsSatisfied([{ sd_id: 'SD-UNKNOWN-999' }], lookup)).toBe(true);
+  });
+  it('mixed: one completed + one incomplete -> NOT satisfied (any blocker blocks)', () => {
+    expect(computeDepsSatisfied([{ sd_id: 'SD-DONE-001' }, { sd_id: 'SD-OPEN-001' }], lookup)).toBe(false);
+  });
+});
+
+describe('buildBaselineItemRow — never emits a UUID sd_id (TS-6)', () => {
+  it('uses sd_key, not the UUID id', () => {
+    const row = buildBaselineItemRow({
+      sd: { sd_key: 'SD-FOO-001', id: '11111111-2222-3333-4444-555555555555', dependencies: null, metadata: {} },
+      baselineId: 'b-1', sequenceRank: 1, healthScore: 1.0,
+    });
+    expect(row.sd_id).toBe('SD-FOO-001');
+    expect(row.sd_id).not.toMatch(/^[0-9a-f]{8}-/);
+  });
+  it('throws when sd_key is absent (no silent UUID fallback)', () => {
+    expect(() => buildBaselineItemRow({
+      sd: { id: '11111111-2222-3333-4444-555555555555' },
+      baselineId: 'b-1', sequenceRank: 1, healthScore: 1.0,
+    })).toThrow(/sd_key is required/);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the root cause of the fleet-wide worker self_claim queue being dead (`v_sd_next_candidates` returned ~0 rows, propped up only by the `sd-baseline add-item` workaround). **Verified live: queue went 0 → 7 workable rows.**

### Three coupled defects fixed
1. **Trigger** `fn_sync_sd_to_baseline()` wrote `sd_baseline_items.sd_id = NEW.id` (UUID) while the view JOINs `bi.sd_id = sd.sd_key` (TEXT) — no FK, so every trigger-synced row silently failed the JOIN. Now writes/matches `NEW.sd_key`.
2. **`deps_satisfied`** mis-resolved object-shaped dependency snapshots (`{sd_key|sd_id|orchestrator}`) — object deps are the fleet majority (1595 vs 581 string). Now resolves string + object + null shapes with fail-open semantics.
3. **`scripts/sd-baseline.js`** had a `|| sd.id` UUID fallback (3 sites) — removed + added `sd_key` guards.

### Reversible reconciliation
Migration snapshots affected active-baseline rows to `sd_baseline_items_recon_backup`, then dedup-then-convert (DELETE 14 colliders, UPDATE 27 survivors) of the 41 resolvable UUID rows → `sd_key`. Advisory-locked, idempotent, with a migration-down. Mass purge of ~5900 test-pollution/orphan rows is **descoped** to a follow-up SD.

## Testing
- 42/42 pass: 10 deps-resolver unit + 6 live-DB behavioral (read-only, net-zero) + 26 add-item regression.
- Migration applied to consolidated DB; idempotency confirmed (0 resolvable UUID rows remain); function + view verified.

## Gates
LEAD-TO-PLAN 96 · PLAN-TO-EXEC 94 · EXEC-TO-PLAN 91 · PLAN-TO-LEAD 98 · DATABASE+TESTING EXEC evidence PASS · retro 90.

SD: SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)