### PR TITLE
fix(SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001): claim_sd rejects non-existent ids (sd_not_found)

### DIFF
--- a/database/migrations/20260608_claim_sd_validate_id_exists.sql
+++ b/database/migrations/20260608_claim_sd_validate_id_exists.sql
@@ -1,0 +1,283 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001
+-- claim_sd RPC: validate p_sd_id exists before claiming (return sd_not_found).
+--
+-- Bug: claim_sd was OPTIMISTIC — calling it with a non-existent id (e.g. SD-FAKE-PROBE-000
+-- or QF-00000000-000) returned {success:true} and wrote claude_sessions.sd_key, silently
+-- self-claiming a phantom. This adds an existence guard (mirroring how claim_sd already
+-- resolves SDs by sd_key and QFs by quick_fixes.id) that returns {success:false,
+-- error:'sd_not_found'} for ids with no backing row. ALL other claim_sd behavior — the QF
+-- branch, the 900s/60s takeover/auto-stale logic, cross-table writes, worktree-column
+-- clearing, and audit emission — is preserved verbatim from 20260502 (CREATE OR REPLACE,
+-- no signature change, grants preserved).
+
+CREATE OR REPLACE FUNCTION public.claim_sd(
+  p_sd_id          text,
+  p_session_id     text,
+  p_track          text,
+  p_force_takeover boolean DEFAULT FALSE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_session    text;
+  v_existing_hb_age     numeric;
+  v_existing_status     text;
+  v_existing_wt_path    text;
+  v_existing_wt_branch  text;
+  v_sd_claiming_id      text;
+  v_sd_parent_id        text;
+  v_drift_detected      boolean := FALSE;
+  v_takeover            boolean := FALSE;
+  v_takeover_reason     text;
+  v_caller_parent_id    text;
+  v_audit_event_id      uuid;
+  v_conflict            RECORD;
+  v_is_qf               boolean := p_sd_id LIKE 'QF-%';
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- 2a. Capture prior session's worktree state (for audit metadata) under the
+  --     SAME FOR UPDATE row lock as the existing-session check.
+  SELECT cs.session_id, cs.status,
+         EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+         cs.worktree_path, cs.worktree_branch
+    INTO v_existing_session, v_existing_status, v_existing_hb_age,
+         v_existing_wt_path, v_existing_wt_branch
+    FROM claude_sessions cs
+   WHERE cs.sd_key = p_sd_id
+     AND cs.session_id != p_session_id
+     AND cs.status IN ('active', 'idle')
+   ORDER BY cs.heartbeat_at DESC
+   LIMIT 1
+     FOR UPDATE;
+
+  IF NOT v_is_qf THEN
+    SELECT sd.claiming_session_id, sd.parent_sd_id
+      INTO v_sd_claiming_id, v_sd_parent_id
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_sd_id
+       FOR UPDATE;
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: reject phantom (non-existent) SD ids instead of
+    -- optimistically returning success. claim_sd was OPTIMISTIC — a typo / stale sd_key used
+    -- to self-claim a non-existent SD and write claude_sessions.sd_key. The existing FOR UPDATE
+    -- SELECT above sets FOUND only when an sd_key row exists, so this is the minimal guard.
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+  ELSE
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: same guard for the QF path (claim_sd resolves QFs
+    -- by quick_fixes.id = p_sd_id, mirrored from the QF UPDATE below).
+    IF NOT EXISTS (SELECT 1 FROM quick_fixes WHERE id = p_sd_id) THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+  END IF;
+
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_existing_session IS NULL
+  THEN
+    v_drift_detected := TRUE;
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age < 900 THEN
+    IF NOT p_force_takeover THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'already_claimed',
+        'message', format(
+          '[CLAIM_PEER_ACTIVE] SD %s is already claimed by active session %s (heartbeat %ss ago). Use --force to take over or wait for release.',
+          p_sd_id, v_existing_session, ROUND(v_existing_hb_age)),
+        'claimed_by', v_existing_session,
+        'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+      );
+    END IF;
+
+    SELECT cs2.sd_key INTO v_caller_parent_id
+      FROM claude_sessions cs2
+     WHERE cs2.session_id = p_session_id
+       AND cs2.status IN ('active', 'idle')
+     LIMIT 1;
+
+    IF v_existing_hb_age >= 60 THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_heartbeat_threshold';
+    ELSIF v_sd_parent_id IS NOT NULL
+          AND v_caller_parent_id = v_sd_parent_id THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_parent_authority';
+    ELSE
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'unauthorized_force',
+        'message', format(
+          '[CLAIM_FORCE_DENIED] SD %s force-takeover refused: caller session %s lacks authority (prior heartbeat %ss < 60s threshold and no parent SD authority). Use sd:release first or wait.',
+          p_sd_id, p_session_id, ROUND(v_existing_hb_age))
+      );
+    END IF;
+  END IF;
+
+  IF v_drift_detected AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'drift_recovery';
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'auto_stale_takeover';
+  END IF;
+
+  IF NOT v_is_qf AND NOT v_takeover THEN
+    SELECT cm.*, cs_other.sd_key AS active_sd, cs_other.session_id AS active_session
+      INTO v_conflict
+      FROM sd_conflict_matrix cm
+      JOIN claude_sessions cs_other ON (
+        (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_key) OR
+        (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_key)
+      )
+     WHERE cm.conflict_severity = 'blocking'
+       AND cm.resolved_at IS NULL
+       AND cs_other.sd_key IS NOT NULL
+       AND cs_other.status IN ('active', 'idle')
+       AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+       AND cs_other.session_id != p_session_id
+     LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+  END IF;
+
+  -- ============================================================================
+  -- TAKEOVER PATH: NULL the prior session's claim AND its worktree state.
+  -- (FR-1 of SD-LEO-INFRA-LEO-INFRA-SESSION-001 — only the worktree_* columns
+  -- are new vs. 20260427.)
+  -- ============================================================================
+  IF v_takeover AND v_existing_session IS NOT NULL THEN
+    UPDATE claude_sessions
+       SET sd_key = NULL,
+           track = NULL,
+           claimed_at = NULL,
+           released_at = NOW(),
+           released_reason = v_takeover_reason,
+           status = 'idle',
+           updated_at = NOW(),
+           worktree_path = NULL,
+           worktree_branch = NULL
+     WHERE session_id = v_existing_session;
+  END IF;
+
+  -- Claim-switch path: caller is releasing some OTHER SD to claim p_sd_id.
+  UPDATE claude_sessions
+     SET sd_key = NULL,
+         track = NULL,
+         claimed_at = NULL,
+         released_at = NOW(),
+         released_reason = 'claim_switch',
+         status = 'idle',
+         worktree_path = NULL,
+         worktree_branch = NULL
+   WHERE session_id = p_session_id
+     AND sd_key IS NOT NULL
+     AND sd_key != p_sd_id
+     AND (v_sd_parent_id IS NULL OR sd_key != v_sd_parent_id);
+
+  -- New-claim UPDATE intentionally does NOT set worktree_path / worktree_branch.
+  -- sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after
+  -- createWorktree completes. Keeping them NULL here means the FR-5 CHECK
+  -- constraint is never violated transiently.
+  UPDATE claude_sessions
+     SET sd_key = p_sd_id,
+         track = p_track,
+         claimed_at = NOW(),
+         released_at = NULL,
+         released_reason = NULL,
+         heartbeat_at = NOW(),
+         status = 'active'
+   WHERE session_id = p_session_id;
+
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+       SET claiming_session_id = p_session_id,
+           status = 'in_progress'
+     WHERE id = p_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+       SET claiming_session_id = p_session_id,
+           active_session_id = p_session_id,
+           is_working_on = TRUE
+     WHERE sd_key = p_sd_id;
+  END IF;
+
+  -- ============================================================================
+  -- AUDIT EMISSION: gains worktree_path_before / worktree_branch_before
+  -- per TR-1 risk-mitigation observability addition.
+  -- ============================================================================
+  IF v_takeover THEN
+    INSERT INTO session_lifecycle_events (
+      event_type,
+      session_id,
+      reason,
+      metadata
+    ) VALUES (
+      CASE
+        WHEN v_takeover_reason = 'auto_stale_takeover' THEN 'CLAIM_AUTO_RECLAIM'
+        ELSE 'CLAIM_TAKEOVER'
+      END,
+      p_session_id,
+      v_takeover_reason,
+      jsonb_build_object(
+        'sd_key', p_sd_id,
+        'prior_session_id', v_existing_session,
+        'prior_heartbeat_age_seconds', ROUND(COALESCE(v_existing_hb_age, 0)),
+        'drift_detected', v_drift_detected,
+        'force_authorized_by', CASE
+          WHEN v_takeover_reason LIKE 'force_%' THEN v_takeover_reason
+          ELSE NULL
+        END,
+        'sd_claiming_id_before', v_sd_claiming_id,
+        'worktree_path_before', v_existing_wt_path,
+        'worktree_branch_before', v_existing_wt_branch
+      )
+    )
+    RETURNING id INTO v_audit_event_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_sd_parent_id IS NOT NULL,
+    'takeover', v_takeover,
+    'takeover_reason', v_takeover_reason,
+    'prior_session_id', v_existing_session,
+    'prior_heartbeat_age_seconds', CASE
+      WHEN v_existing_hb_age IS NOT NULL THEN ROUND(v_existing_hb_age)
+      ELSE NULL
+    END,
+    'drift_detected', v_drift_detected,
+    'audit_event_id', v_audit_event_id
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.claim_sd(text, text, text, boolean) IS
+  'Cross-table consistent claim_sd with atomic worktree-state clearing on takeover and claim-switch. Worktree columns left NULL on the new-claim UPDATE — sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after createWorktree. Audit metadata includes worktree_path_before / worktree_branch_before. SD-LEO-INFRA-LEO-INFRA-SESSION-001 (FR-1).';

--- a/tests/database/claim-sd-validate-exists.test.js
+++ b/tests/database/claim-sd-validate-exists.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 — claim_sd must reject non-existent ids.
+ *
+ * claim_sd was OPTIMISTIC: calling it with a non-existent id (SD-FAKE-PROBE-000 /
+ * QF-00000000-000) returned {success:true} and wrote claude_sessions.sd_key, silently
+ * self-claiming a phantom. The fix adds an existence guard (SDs by sd_key, QFs by
+ * quick_fixes.id) that returns {success:false, error:'sd_not_found'} for phantom ids —
+ * while leaving real claims (and the takeover/QF/cross-table logic) unchanged.
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips
+ * cleanly without service-role creds.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const PROBE_SESSION = 'test-claim-validate-exists-session';
+
+describe.skipIf(!HAS_REAL_DB)('claim_sd rejects non-existent ids (SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001)', () => {
+  afterAll(async () => {
+    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+  });
+
+  it('returns sd_not_found for a non-existent SD id (no phantom self-claim)', async () => {
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: 'SD-FAKE-PROBE-000', p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_not_found');
+    // and it must NOT have written the phantom key onto the session
+    const { data: sess } = await supabase.from('claude_sessions').select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key ?? null).not.toBe('SD-FAKE-PROBE-000');
+  });
+
+  it('returns sd_not_found for a non-existent QF id', async () => {
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: 'QF-00000000-000', p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_not_found');
+  });
+
+  it('still claims a real unclaimed SD (existence guard does not break the happy path)', async () => {
+    const { data: cand } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, active_session_id, is_working_on')
+      .is('claiming_session_id', null).in('status', ['draft', 'active']).limit(1);
+    if (!cand || !cand[0]) return; // no unclaimed SD available — environment-dependent, skip assertion
+    const key = cand[0].sd_key;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: key, p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(true);
+    // restore (net-zero)
+    await supabase.from('strategic_directives_v2').update({
+      claiming_session_id: cand[0].claiming_session_id,
+      active_session_id: cand[0].active_session_id,
+      is_working_on: cand[0].is_working_on,
+    }).eq('sd_key', key);
+    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+  });
+});


### PR DESCRIPTION
## Summary
The `claim_sd` Postgres RPC was **optimistic** — calling it with a non-existent id (`SD-FAKE-PROBE-000` or `QF-00000000-000`) returned `{success:true}` and wrote `claude_sessions.sd_key`, silently self-claiming a phantom. A typo / stale id self-claimed a non-existent SD. This caused a real incident **this session**: a stale coordinator assignment optimistically re-claimed an already-completed SD.

## Fix
An existence guard at the top of `claim_sd`, reusing its own resolution keys:
- **SD path**: `IF NOT FOUND` after the existing `FOR UPDATE SELECT … WHERE sd_key = p_sd_id`
- **QF path** (`p_sd_id LIKE 'QF-%'`): `IF NOT EXISTS (SELECT 1 FROM quick_fixes WHERE id = p_sd_id)`

A phantom id now returns `{success:false, error:'sd_not_found'}` and writes nothing. The **entire rest of `claim_sd` is preserved verbatim** from `20260502` (CREATE OR REPLACE, signature unchanged, grants preserved) — the 900s/60s takeover + parent-authority logic, cross-table writes, worktree-column clearing, and audit emission are all unchanged.

The migration was generated **programmatically** from the authoritative `20260502` body (exact string-replace, no hand transcription) to eliminate the risk of dropping logic in a ~250-line fleet-critical function.

## Verification
- Applied live: `apply-migration.js --prod-deploy` → **MIGRATION_APPLY_PROD_PASS**.
- DATABASE sub-agent PASS (row `214f343d`): confirmed the **live deployed body is byte-identical to the migration** with only +19 guard lines; no signature drift, grants intact, no injection / search_path risk.
- TESTING sub-agent PASS (row `248b0368`): **9/9** — 3 new (`claim-sd-validate-exists.test.js`: phantom SD/QF → `sd_not_found`, real SD still claims) + 6 existing `claim-sd-cross-table` (regression, green against the new function).

## LEO
SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 (bugfix) · gates 93/92/94/96 · retro 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)