### PR TITLE
fix(SD-FDBK-FIX-STAGE-LIKELY-SHARES-001): verify Stage 22 precondition mismatch (no defect) + pin whole-stage-key invariant

### DIFF
--- a/tests/unit/eva/stage-templates/analysis-steps/stage-precondition-whole-stage-key-invariant.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-precondition-whole-stage-key-invariant.test.js
@@ -1,0 +1,57 @@
+/**
+ * SD-FDBK-FIX-STAGE-LIKELY-SHARES-001 — Stage 22 precondition artifact-type mismatch.
+ *
+ * VERIFICATION OUTCOME: the hypothesised Stage 22 defect does NOT exist. The Stage 21 fix
+ * (SD-LEO-FIX-FIX-STAGE-VISUAL-001) changed the Visual Assets analyzer's REQUIRED_UPSTREAM
+ * from granular keys (e.g. stage11ColorData) that fetchUpstreamArtifacts never populated to
+ * WHOLE-stage keys (stage11Data); the 21<->22 swap then made numeric stage 22 = Visual
+ * Assets (same file, stage-21-visual-assets.js), so the fix carried forward. The sibling
+ * Distribution Setup analyzer (stage-22-distribution-setup.js, numeric stage 21) was already
+ * correct (whole-stage keys stage7Data/stage10Data/stage12Data; hardened by
+ * SD-LEO-FIX-FIX-POST-BUILD-001's normalizeUpstreamParams).
+ *
+ * This test PINS the invariant so the granular-key mismatch class cannot reappear in either
+ * pre-launch analyzer: every REQUIRED_UPSTREAM param_key must be a whole-stage `stage{N}Data`
+ * key (the shape fetchUpstreamArtifacts returns), and its N must equal source_stage.
+ */
+import { describe, it, expect } from 'vitest';
+import { REQUIRED_UPSTREAM as VISUAL_ASSETS_UPSTREAM } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js';
+import { REQUIRED_UPSTREAM as DISTRIBUTION_UPSTREAM } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js';
+
+const WHOLE_STAGE_KEY = /^stage(\d+)Data$/;
+
+const ANALYZERS = [
+  { name: 'Visual Assets (numeric stage 22, stage-21-visual-assets.js)', upstream: VISUAL_ASSETS_UPSTREAM },
+  { name: 'Distribution Setup (numeric stage 21, stage-22-distribution-setup.js)', upstream: DISTRIBUTION_UPSTREAM },
+];
+
+describe('pre-launch analyzers use whole-stage REQUIRED_UPSTREAM param_keys (SD-FDBK-FIX-STAGE-LIKELY-SHARES-001)', () => {
+  for (const { name, upstream } of ANALYZERS) {
+    describe(name, () => {
+      it('declares at least one upstream requirement', () => {
+        expect(Array.isArray(upstream)).toBe(true);
+        expect(upstream.length).toBeGreaterThan(0);
+      });
+
+      it('every param_key is a whole-stage `stage{N}Data` key (no granular keys that fetchUpstreamArtifacts never populates)', () => {
+        for (const req of upstream) {
+          expect(req.param_key, `${name}: param_key "${req.param_key}" must match stage{N}Data`).toMatch(WHOLE_STAGE_KEY);
+        }
+      });
+
+      it('each param_key stage number equals its source_stage (no producer/consumer drift)', () => {
+        for (const req of upstream) {
+          const n = Number(WHOLE_STAGE_KEY.exec(req.param_key)?.[1]);
+          expect(n, `${name}: param_key "${req.param_key}" stage number must equal source_stage ${req.source_stage}`).toBe(req.source_stage);
+        }
+      });
+
+      it('declares an artifact_type for every requirement', () => {
+        for (const req of upstream) {
+          expect(typeof req.artifact_type, `${name}: missing artifact_type`).toBe('string');
+          expect(req.artifact_type.length).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## SD-FDBK-FIX-STAGE-LIKELY-SHARES-001 — Verify Stage 22 precondition mismatch (verified NO defect; pin invariant)

**Outcome: verify-and-close.** The hypothesised Stage 22 defect ("analyzer destructures granular upstream params like `stage22ColorData` that `fetchUpstreamArtifacts` never populates, so `validateEntryPreconditions` always fails") does **NOT** reproduce. Per the SD's explicit instruction, no speculative no-op production change was made — the durable evidence is an executable regression test.

### Evidence (all three stage-22 analyzers + the producer use whole-stage keys)
- `stage-22-distribution-setup.js` — `REQUIRED_UPSTREAM` = whole-stage `stage7Data`/`stage10Data`/`stage12Data`; `normalizeUpstreamParams` (SD-LEO-FIX-FIX-POST-BUILD-001) consumes the producer's `stage{N}Data`/`__byType` shape, and `validateEntryPreconditions` runs on the **normalized** params.
- `stage-21-visual-assets.js` (numeric stage 22 after the 21↔22 swap) — `REQUIRED_UPSTREAM` already converted to whole-stage `stage11Data`/`stage17Data` by SD-LEO-FIX-FIX-STAGE-VISUAL-001.
- `stage-22-build-review.js` — `analyzeStage22` destructures whole-stage `stage21Data`/`stage20Data`.
- `fetchUpstreamArtifacts` (`lib/eva/stage-execution-engine.js`) emits `stage${N}Data`-keyed maps with a lossless `__byType` sub-map — exactly what every consumer expects.
- No granular `stage22*`-style `param_key` exists in any analyzer.

### Change (test-only, +57 LOC)
`tests/unit/eva/stage-templates/analysis-steps/stage-precondition-whole-stage-key-invariant.test.js` — pins, for both pre-launch analyzers, that every `REQUIRED_UPSTREAM.param_key` matches `/^stage(\d+)Data$/` with `N === source_stage` and a non-empty `artifact_type`. **8/8 tests pass.** A reintroduced granular key (e.g. `stage11ColorData`) fails the test. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
