### PR TITLE
feat(SD-LEO-GEN-DEFENSE-DEPTH-ADD-001): internal chairman authz guards on privileged SECURITY DEFINER functions

### DIFF
--- a/database/migrations/20260608_secdef_chairman_authz_guards.sql
+++ b/database/migrations/20260608_secdef_chairman_authz_guards.sql
@@ -1,0 +1,289 @@
+-- Migration: internal chairman authorization guards on privileged SECURITY DEFINER functions
+-- SD: SD-LEO-GEN-DEFENSE-DEPTH-ADD-001
+--
+-- delete_venture / set_stage_override / set_global_auto_proceed are SECURITY DEFINER and
+-- still EXECUTE-able by `authenticated` (only `anon` was revoked by 20260603_03), with no
+-- chairman-level internal check — so any logged-in non-chairman could hard-delete a venture
+-- or mutate chairman_dashboard_config. This adds internal guards (mirroring kill_venture's
+-- fn_is_chairman() pattern) that close the hole independent of EXECUTE grants.
+--
+-- Function-only CREATE OR REPLACE. Each body is byte-identical to the live definition apart
+-- from the added guard. EXECUTE grants are NOT changed (revoking `authenticated` would break
+-- the authenticated-chairman UI path; the internal guard is the correct fix). Each function's
+-- exact SET search_path is preserved. Reversible: *_down.sql restores the prior bodies.
+--
+-- Guard rationale: inside a SECURITY DEFINER function only auth.role() reflects the CALLER's
+-- role (current_user becomes the owner; session_user is the authenticator). delete_venture
+-- admits auth.role()='service_role' (its backend caller lib/deleteVentureFully.js); the two
+-- config setters are chairman-only (no service-role caller exists). delete_venture returns its
+-- standard {success:false} shape rather than RAISE (its EXCEPTION WHEN OTHERS handler would
+-- otherwise swallow a raise); the setters RAISE insufficient_privilege (they have no handler).
+
+-- ============================================================================
+-- delete_venture(uuid) — add fn_is_chairman() OR service_role guard
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.delete_venture(p_venture_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_name TEXT;
+  v_deleted_counts JSONB := '{}'::JSONB;
+  v_count INT;
+BEGIN
+  -- SD-LEO-GEN-DEFENSE-DEPTH-ADD-001: internal authorization guard (defense-in-depth +
+  -- closes the live authenticated-exposed hole). Only a chairman or the service role may
+  -- hard-delete a venture. Returns the function's standard failure shape (its EXCEPTION
+  -- WHEN OTHERS handler would convert a RAISE into this anyway).
+  IF NOT (public.fn_is_chairman() OR auth.role() = 'service_role') THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'insufficient_privilege: chairman or service role required to delete a venture',
+      'detail', '42501'
+    );
+  END IF;
+
+  SELECT name INTO v_name FROM ventures WHERE id = p_venture_id;
+  IF v_name IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found');
+  END IF;
+
+  -- RESTRICT children (must be deleted explicitly) ------------------------------------
+  DELETE FROM chairman_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_decisions', v_count);
+  DELETE FROM chairman_directives WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_directives', v_count);
+  DELETE FROM governance_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('governance_decisions', v_count);
+  DELETE FROM compliance_gate_events WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('compliance_gate_events', v_count);
+  DELETE FROM risk_escalation_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_escalation_log', v_count);
+  DELETE FROM risk_gate_passage_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_gate_passage_log', v_count);
+
+  -- NO ACTION children (block the delete unless removed first) -------------------------
+  DELETE FROM blueprint_quality_assessments WHERE venture_id = p_venture_id;
+  DELETE FROM deep_research_results       WHERE venture_id = p_venture_id;
+  DELETE FROM factory_guardrail_state     WHERE venture_id = p_venture_id;
+  DELETE FROM ops_agent_health            WHERE venture_id = p_venture_id;
+  DELETE FROM ops_customer_health_scores  WHERE venture_id = p_venture_id;
+  DELETE FROM ops_friday_scorecards       WHERE venture_id = p_venture_id;
+  DELETE FROM ops_health_alerts           WHERE venture_id = p_venture_id;
+  DELETE FROM ops_product_health          WHERE venture_id = p_venture_id;
+  DELETE FROM ops_quarterly_assessments   WHERE venture_id = p_venture_id;
+  DELETE FROM ops_revenue_alerts          WHERE venture_id = p_venture_id;
+  DELETE FROM ops_revenue_metrics         WHERE venture_id = p_venture_id;
+  DELETE FROM persona_behavioral_data     WHERE venture_id = p_venture_id;
+  DELETE FROM product_hunt_cache          WHERE venture_id = p_venture_id;
+  DELETE FROM risk_forecasts              WHERE venture_id = p_venture_id;
+  DELETE FROM service_tasks               WHERE venture_id = p_venture_id;
+  DELETE FROM service_telemetry           WHERE venture_id = p_venture_id;
+  DELETE FROM stage_proving_journal       WHERE venture_id = p_venture_id;
+  DELETE FROM venture_artifact_summaries  WHERE venture_id = p_venture_id;
+  DELETE FROM venture_exit_readiness      WHERE venture_id = p_venture_id;
+  DELETE FROM venture_service_bindings    WHERE venture_id = p_venture_id;
+
+  -- Vision artifacts: eva_vision_documents.venture_id is ON DELETE CASCADE, but its
+  -- children are RESTRICT/NO ACTION. Clear them (and the docs) before the venture delete.
+  DELETE FROM eva_vision_scores
+    WHERE vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_vision_iterations
+    WHERE vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_architecture_plans
+    WHERE venture_id = p_venture_id
+       OR vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM strategic_roadmaps
+    WHERE vision_key IN (SELECT vision_key FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM strategic_themes
+    WHERE vision_key IN (SELECT vision_key FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_vision_documents WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('eva_vision_documents', v_count);
+
+  -- SD-LEO-FEAT-CHAIRMAN-VENTURE-DELETE-001: cancel NON-TERMINAL linked SDs BEFORE the
+  -- venture_id=NULL orphaning, so deletion leaves a cancellation audit trail.
+  UPDATE strategic_directives_v2
+  SET status = 'cancelled',
+      cancellation_reason = 'Cancelled by venture deletion (' || v_name || ')',
+      metadata = COALESCE(metadata, '{}'::jsonb)
+                 || jsonb_build_object('cancelled_due_to_venture', p_venture_id, 'cancelled_at', now()),
+      updated_at = now()
+  WHERE venture_id = p_venture_id
+    AND status NOT IN ('completed', 'cancelled');
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('strategic_directives_cancelled', v_count);
+
+  UPDATE strategic_directives_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_phase_handoffs SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_proposals SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE product_requirements_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE venture_dependencies SET dependent_venture_id = NULL WHERE dependent_venture_id = p_venture_id;
+  UPDATE venture_dependencies SET provider_venture_id = NULL WHERE provider_venture_id = p_venture_id;
+  UPDATE venture_capabilities SET origin_venture_id = NULL WHERE origin_venture_id = p_venture_id;
+  UPDATE venture_templates SET source_venture_id = NULL WHERE source_venture_id = p_venture_id;
+  UPDATE venture_nursery SET promoted_to_venture_id = NULL WHERE promoted_to_venture_id = p_venture_id;
+  UPDATE agent_registry SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE ventures SET
+    brief_id = NULL,
+    vision_id = NULL,
+    architecture_plan_id = NULL,
+    ceo_agent_id = NULL,
+    portfolio_id = NULL,
+    company_id = NULL,
+    source_blueprint_id = NULL
+  WHERE id = p_venture_id;
+
+  DELETE FROM ventures WHERE id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  IF v_count = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture delete returned 0 rows');
+  END IF;
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_name,
+    'deleted_counts', v_deleted_counts
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'detail', SQLSTATE
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- set_stage_override(int,bool,text) — tighten any-authenticated -> chairman-only
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.set_stage_override(p_stage_number integer, p_auto_proceed boolean, p_reason text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_gate_type text;
+  v_user_id uuid := auth.uid();
+  v_current jsonb;
+  v_updated jsonb;
+  v_key text;
+  v_entry jsonb;
+BEGIN
+  -- SD-LEO-GEN-DEFENSE-DEPTH-ADD-001: chairman-only guard (was any-authenticated).
+  -- fn_is_chairman() is false for a NULL auth.uid(), so this also subsumes the prior
+  -- AUTHENTICATION_REQUIRED check.
+  IF NOT public.fn_is_chairman() THEN
+    RAISE EXCEPTION 'insufficient_privilege: chairman role required to set a stage override'
+      USING ERRCODE = 'insufficient_privilege',
+            HINT = 'Caller must be an authenticated chairman/admin/owner.';
+  END IF;
+
+  SELECT gate_type INTO v_gate_type
+  FROM public.venture_stages
+  WHERE stage_number = p_stage_number;
+
+  IF v_gate_type IS NULL THEN
+    RAISE EXCEPTION 'INVALID_STAGE_NUMBER: %', p_stage_number
+      USING HINT = 'No row in venture_stages for the given stage_number.';
+  END IF;
+
+  -- Defense-in-depth: kill/promotion gates are NEVER overrideable to auto-advance.
+  IF p_auto_proceed = true AND v_gate_type IN ('kill', 'promotion') THEN
+    RAISE EXCEPTION 'KILL_PROMOTION_NOT_OVERRIDABLE: stage % has gate_type %', p_stage_number, v_gate_type
+      USING HINT = 'Kill and promotion gates require manual chairman approval and cannot be auto-advanced.';
+  END IF;
+
+  v_key := 'stage_' || p_stage_number;
+
+  SELECT stage_overrides INTO v_current
+  FROM public.chairman_dashboard_config
+  WHERE config_key = 'default';
+
+  IF v_current IS NULL THEN
+    v_current := '{}'::jsonb;
+  END IF;
+
+  IF p_auto_proceed IS NULL THEN
+    -- DELETE the key (clear override; revert to default).
+    v_updated := v_current - v_key;
+  ELSE
+    v_entry := jsonb_build_object(
+      'auto_proceed', p_auto_proceed,
+      'reason', COALESCE(p_reason, CASE
+        WHEN p_auto_proceed = true THEN 'Opted in to auto-advance by Chairman'
+        ELSE 'Paused by Chairman'
+      END),
+      'set_by', v_user_id::text,
+      'set_at', NOW()::text
+    );
+    v_updated := v_current || jsonb_build_object(v_key, v_entry);
+  END IF;
+
+  UPDATE public.chairman_dashboard_config
+  SET stage_overrides = v_updated,
+      updated_at = NOW()
+  WHERE config_key = 'default';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CONFIG_ROW_MISSING: chairman_dashboard_config row with config_key=default not found'
+      USING HINT = 'Seed the default row before calling this function.';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'stage_number', p_stage_number,
+    'auto_proceed', p_auto_proceed,
+    'gate_type', v_gate_type,
+    'set_by', v_user_id::text,
+    'cleared', p_auto_proceed IS NULL
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- set_global_auto_proceed(bool) — tighten any-authenticated -> chairman-only
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.set_global_auto_proceed(p_enabled boolean)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  -- SD-LEO-GEN-DEFENSE-DEPTH-ADD-001: chairman-only guard (was any-authenticated).
+  IF NOT public.fn_is_chairman() THEN
+    RAISE EXCEPTION 'insufficient_privilege: chairman role required to set global auto-proceed'
+      USING ERRCODE = 'insufficient_privilege',
+            HINT = 'Caller must be an authenticated chairman/admin/owner.';
+  END IF;
+
+  IF p_enabled IS NULL THEN
+    RAISE EXCEPTION 'INVALID_VALUE: p_enabled must be true or false (not null)';
+  END IF;
+
+  UPDATE public.chairman_dashboard_config
+  SET global_auto_proceed = p_enabled,
+      updated_at = NOW()
+  WHERE config_key = 'default';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CONFIG_ROW_MISSING: chairman_dashboard_config row with config_key=default not found';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'global_auto_proceed', p_enabled,
+    'set_by', v_user_id::text
+  );
+END;
+$function$;

--- a/database/migrations/20260608_secdef_chairman_authz_guards_down.sql
+++ b/database/migrations/20260608_secdef_chairman_authz_guards_down.sql
@@ -1,0 +1,247 @@
+-- DOWN migration (reversal) for 20260608_secdef_chairman_authz_guards.sql
+-- SD: SD-LEO-GEN-DEFENSE-DEPTH-ADD-001
+-- Restores the exact pre-change bodies (delete_venture without the authz guard; the two
+-- config setters with the prior any-authenticated auth.uid() IS NULL check).
+-- WARNING: re-opens the authenticated-exposed authz hole this SD closed. Only for rollback.
+
+-- ============================================================================
+-- delete_venture(uuid) — restore (no internal guard)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.delete_venture(p_venture_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_name TEXT;
+  v_deleted_counts JSONB := '{}'::JSONB;
+  v_count INT;
+BEGIN
+  SELECT name INTO v_name FROM ventures WHERE id = p_venture_id;
+  IF v_name IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found');
+  END IF;
+
+  DELETE FROM chairman_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_decisions', v_count);
+  DELETE FROM chairman_directives WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('chairman_directives', v_count);
+  DELETE FROM governance_decisions WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('governance_decisions', v_count);
+  DELETE FROM compliance_gate_events WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('compliance_gate_events', v_count);
+  DELETE FROM risk_escalation_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_escalation_log', v_count);
+  DELETE FROM risk_gate_passage_log WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('risk_gate_passage_log', v_count);
+
+  DELETE FROM blueprint_quality_assessments WHERE venture_id = p_venture_id;
+  DELETE FROM deep_research_results       WHERE venture_id = p_venture_id;
+  DELETE FROM factory_guardrail_state     WHERE venture_id = p_venture_id;
+  DELETE FROM ops_agent_health            WHERE venture_id = p_venture_id;
+  DELETE FROM ops_customer_health_scores  WHERE venture_id = p_venture_id;
+  DELETE FROM ops_friday_scorecards       WHERE venture_id = p_venture_id;
+  DELETE FROM ops_health_alerts           WHERE venture_id = p_venture_id;
+  DELETE FROM ops_product_health          WHERE venture_id = p_venture_id;
+  DELETE FROM ops_quarterly_assessments   WHERE venture_id = p_venture_id;
+  DELETE FROM ops_revenue_alerts          WHERE venture_id = p_venture_id;
+  DELETE FROM ops_revenue_metrics         WHERE venture_id = p_venture_id;
+  DELETE FROM persona_behavioral_data     WHERE venture_id = p_venture_id;
+  DELETE FROM product_hunt_cache          WHERE venture_id = p_venture_id;
+  DELETE FROM risk_forecasts              WHERE venture_id = p_venture_id;
+  DELETE FROM service_tasks               WHERE venture_id = p_venture_id;
+  DELETE FROM service_telemetry           WHERE venture_id = p_venture_id;
+  DELETE FROM stage_proving_journal       WHERE venture_id = p_venture_id;
+  DELETE FROM venture_artifact_summaries  WHERE venture_id = p_venture_id;
+  DELETE FROM venture_exit_readiness      WHERE venture_id = p_venture_id;
+  DELETE FROM venture_service_bindings    WHERE venture_id = p_venture_id;
+
+  DELETE FROM eva_vision_scores
+    WHERE vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_vision_iterations
+    WHERE vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_architecture_plans
+    WHERE venture_id = p_venture_id
+       OR vision_id IN (SELECT id FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM strategic_roadmaps
+    WHERE vision_key IN (SELECT vision_key FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM strategic_themes
+    WHERE vision_key IN (SELECT vision_key FROM eva_vision_documents WHERE venture_id = p_venture_id);
+  DELETE FROM eva_vision_documents WHERE venture_id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('eva_vision_documents', v_count);
+
+  UPDATE strategic_directives_v2
+  SET status = 'cancelled',
+      cancellation_reason = 'Cancelled by venture deletion (' || v_name || ')',
+      metadata = COALESCE(metadata, '{}'::jsonb)
+                 || jsonb_build_object('cancelled_due_to_venture', p_venture_id, 'cancelled_at', now()),
+      updated_at = now()
+  WHERE venture_id = p_venture_id
+    AND status NOT IN ('completed', 'cancelled');
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_deleted_counts := v_deleted_counts || jsonb_build_object('strategic_directives_cancelled', v_count);
+
+  UPDATE strategic_directives_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_phase_handoffs SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE sd_proposals SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE product_requirements_v2 SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE venture_dependencies SET dependent_venture_id = NULL WHERE dependent_venture_id = p_venture_id;
+  UPDATE venture_dependencies SET provider_venture_id = NULL WHERE provider_venture_id = p_venture_id;
+  UPDATE venture_capabilities SET origin_venture_id = NULL WHERE origin_venture_id = p_venture_id;
+  UPDATE venture_templates SET source_venture_id = NULL WHERE source_venture_id = p_venture_id;
+  UPDATE venture_nursery SET promoted_to_venture_id = NULL WHERE promoted_to_venture_id = p_venture_id;
+  UPDATE agent_registry SET venture_id = NULL WHERE venture_id = p_venture_id;
+  UPDATE ventures SET
+    brief_id = NULL,
+    vision_id = NULL,
+    architecture_plan_id = NULL,
+    ceo_agent_id = NULL,
+    portfolio_id = NULL,
+    company_id = NULL,
+    source_blueprint_id = NULL
+  WHERE id = p_venture_id;
+
+  DELETE FROM ventures WHERE id = p_venture_id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  IF v_count = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture delete returned 0 rows');
+  END IF;
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_name,
+    'deleted_counts', v_deleted_counts
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'detail', SQLSTATE
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- set_stage_override(int,bool,text) — restore any-authenticated check
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.set_stage_override(p_stage_number integer, p_auto_proceed boolean, p_reason text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_gate_type text;
+  v_user_id uuid := auth.uid();
+  v_current jsonb;
+  v_updated jsonb;
+  v_key text;
+  v_entry jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'AUTHENTICATION_REQUIRED'
+      USING HINT = 'Caller must be an authenticated user.';
+  END IF;
+
+  SELECT gate_type INTO v_gate_type
+  FROM public.venture_stages
+  WHERE stage_number = p_stage_number;
+
+  IF v_gate_type IS NULL THEN
+    RAISE EXCEPTION 'INVALID_STAGE_NUMBER: %', p_stage_number
+      USING HINT = 'No row in venture_stages for the given stage_number.';
+  END IF;
+
+  IF p_auto_proceed = true AND v_gate_type IN ('kill', 'promotion') THEN
+    RAISE EXCEPTION 'KILL_PROMOTION_NOT_OVERRIDABLE: stage % has gate_type %', p_stage_number, v_gate_type
+      USING HINT = 'Kill and promotion gates require manual chairman approval and cannot be auto-advanced.';
+  END IF;
+
+  v_key := 'stage_' || p_stage_number;
+
+  SELECT stage_overrides INTO v_current
+  FROM public.chairman_dashboard_config
+  WHERE config_key = 'default';
+
+  IF v_current IS NULL THEN
+    v_current := '{}'::jsonb;
+  END IF;
+
+  IF p_auto_proceed IS NULL THEN
+    v_updated := v_current - v_key;
+  ELSE
+    v_entry := jsonb_build_object(
+      'auto_proceed', p_auto_proceed,
+      'reason', COALESCE(p_reason, CASE
+        WHEN p_auto_proceed = true THEN 'Opted in to auto-advance by Chairman'
+        ELSE 'Paused by Chairman'
+      END),
+      'set_by', v_user_id::text,
+      'set_at', NOW()::text
+    );
+    v_updated := v_current || jsonb_build_object(v_key, v_entry);
+  END IF;
+
+  UPDATE public.chairman_dashboard_config
+  SET stage_overrides = v_updated,
+      updated_at = NOW()
+  WHERE config_key = 'default';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CONFIG_ROW_MISSING: chairman_dashboard_config row with config_key=default not found'
+      USING HINT = 'Seed the default row before calling this function.';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'stage_number', p_stage_number,
+    'auto_proceed', p_auto_proceed,
+    'gate_type', v_gate_type,
+    'set_by', v_user_id::text,
+    'cleared', p_auto_proceed IS NULL
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- set_global_auto_proceed(bool) — restore any-authenticated check
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.set_global_auto_proceed(p_enabled boolean)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'AUTHENTICATION_REQUIRED';
+  END IF;
+
+  IF p_enabled IS NULL THEN
+    RAISE EXCEPTION 'INVALID_VALUE: p_enabled must be true or false (not null)';
+  END IF;
+
+  UPDATE public.chairman_dashboard_config
+  SET global_auto_proceed = p_enabled,
+      updated_at = NOW()
+  WHERE config_key = 'default';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CONFIG_ROW_MISSING: chairman_dashboard_config row with config_key=default not found';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'global_auto_proceed', p_enabled,
+    'set_by', v_user_id::text
+  );
+END;
+$function$;

--- a/tests/integration/secdef-chairman-authz.test.js
+++ b/tests/integration/secdef-chairman-authz.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-LEO-GEN-DEFENSE-DEPTH-ADD-001
+ * HAS_REAL_DB behavioral tests for the internal chairman authorization guards on
+ * delete_venture / set_stage_override / set_global_auto_proceed.
+ *
+ * NET-ZERO: every call runs inside a transaction that is ROLLBACK'd; delete_venture
+ * is only ever invoked with a NON-EXISTENT venture id (it returns before any DELETE).
+ * Caller identity is simulated via `SET LOCAL request.jwt.claims` (what auth.uid() /
+ * auth.role() read), so no real users are needed for the negative cases.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+
+const describeDb = describe.skipIf(!HAS_REAL_DB);
+
+// A uuid that will not match any venture (negative-path safe).
+const ABSENT_VENTURE = '00000000-0000-4000-8000-000000000000';
+// A uuid that is (almost certainly) not a chairman in auth.users.
+const NON_CHAIRMAN_UID = '11111111-1111-4111-8111-111111111111';
+
+describeDb('SECURITY DEFINER chairman authz guards (live DB)', () => {
+  let client;
+
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    client = await createDatabaseClient('engineer', { verify: false });
+  });
+  afterAll(async () => { if (client) await client.end(); });
+
+  async function asCaller(claims, fn) {
+    await client.query('BEGIN');
+    try {
+      await client.query(`SET LOCAL request.jwt.claims = '${JSON.stringify(claims)}'`);
+      return await fn();
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  }
+
+  it('non-chairman authenticated -> set_global_auto_proceed RAISES insufficient_privilege (42501)', async () => {
+    await asCaller({ sub: NON_CHAIRMAN_UID, role: 'authenticated' }, async () => {
+      await expect(client.query('SELECT public.set_global_auto_proceed(true)')).rejects.toMatchObject({ code: '42501' });
+    });
+  });
+
+  it('non-chairman authenticated -> set_stage_override RAISES insufficient_privilege (42501)', async () => {
+    await asCaller({ sub: NON_CHAIRMAN_UID, role: 'authenticated' }, async () => {
+      await expect(client.query('SELECT public.set_stage_override(21, true, null)')).rejects.toMatchObject({ code: '42501' });
+    });
+  });
+
+  it('non-chairman authenticated -> delete_venture returns success:false / insufficient_privilege (no delete)', async () => {
+    await asCaller({ sub: NON_CHAIRMAN_UID, role: 'authenticated' }, async () => {
+      const r = await client.query('SELECT public.delete_venture($1) AS res', [ABSENT_VENTURE]);
+      expect(r.rows[0].res.success).toBe(false);
+      expect(JSON.stringify(r.rows[0].res)).toMatch(/insufficient_privilege/i);
+    });
+  });
+
+  it('service_role -> delete_venture guard ADMITS (reaches "Venture not found" for an absent id)', async () => {
+    await asCaller({ role: 'service_role' }, async () => {
+      const r = await client.query('SELECT public.delete_venture($1) AS res', [ABSENT_VENTURE]);
+      expect(r.rows[0].res.success).toBe(false);
+      // proves the guard let it through (it hit the not-found branch, not the authz reject)
+      expect(r.rows[0].res.error).toMatch(/Venture not found/i);
+    });
+  });
+
+  it('introspection: guards present + exact search_path preserved', async () => {
+    const defs = {};
+    for (const fn of ['delete_venture', 'set_stage_override', 'set_global_auto_proceed']) {
+      const r = await client.query(
+        'SELECT pg_get_functiondef(p.oid) AS def FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE p.proname=$1 AND n.nspname=$2 LIMIT 1',
+        [fn, 'public'],
+      );
+      defs[fn] = r.rows[0].def;
+    }
+    // guards
+    expect(defs.delete_venture).toMatch(/fn_is_chairman\(\)\s+OR\s+auth\.role\(\)\s*=\s*'service_role'/);
+    expect(defs.set_stage_override).toMatch(/NOT\s+public\.fn_is_chairman\(\)/);
+    expect(defs.set_global_auto_proceed).toMatch(/NOT\s+public\.fn_is_chairman\(\)/);
+    // search_path preserved
+    expect(defs.delete_venture).toMatch(/SET search_path TO 'public'/);
+    expect(defs.set_stage_override).toMatch(/SET search_path TO 'public', 'pg_temp'/);
+    expect(defs.set_global_auto_proceed).toMatch(/SET search_path TO 'public', 'pg_temp'/);
+  });
+
+  it('open questions: no 3-arg approve_chairman_decision; no anon EXECUTE on park_venture_decision / bootstrap_venture_workflow', async () => {
+    const overloads = await client.query(
+      "SELECT pg_get_function_identity_arguments(p.oid) AS args FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE p.proname='approve_chairman_decision' AND n.nspname='public'",
+    );
+    // none of the remaining overloads is the unguarded 3-arg (uuid,text,text) form
+    expect(overloads.rows.every((r) => r.args.split(',').length !== 3)).toBe(true);
+    for (const fn of ['park_venture_decision', 'bootstrap_venture_workflow']) {
+      const g = await client.query(
+        "SELECT has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_exec FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE p.proname=$1 AND n.nspname='public' LIMIT 1",
+        [fn],
+      );
+      if (g.rows.length) expect(g.rows[0].anon_exec).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds internal chairman authorization guards to three privileged SECURITY DEFINER functions, **closing a live authz hole**: the SD's filed premise (EXECUTE revoked from authenticated) was wrong — only `anon` was revoked; `authenticated` still had EXECUTE, so any logged-in non-chairman could hard-delete any venture or mutate `chairman_dashboard_config` via the ehg browser client.

## Fix (mirrors kill_venture's fn_is_chairman() pattern)
- `delete_venture(uuid)`: reject unless `fn_is_chairman() OR auth.role()='service_role'` (returns its standard `{success:false}` shape — its `EXCEPTION WHEN OTHERS` would swallow a RAISE).
- `set_stage_override` / `set_global_auto_proceed`: `RAISE insufficient_privilege` unless `fn_is_chairman()` (was any-authenticated).

Key insight: inside a SECURITY DEFINER function only `auth.role()` reflects the caller (`current_user`→owner, `session_user`→authenticator), so the service-role escape uses `auth.role()='service_role'`. EXECUTE grants are **not** changed (revoking authenticated would break the chairman UI; the internal guard is the fix). Function-only CREATE OR REPLACE, exact bodies + per-function `search_path` preserved, reversible down migration.

## Testing
6/6 HAS_REAL_DB net-zero behavioral tests (rolled-back txns; `delete_venture` only ever called with an absent uuid). Migration applied live + verified. SECURITY (100) + DATABASE + TESTING EXEC evidence all PASS.

Deferred to a follow-up: 4 additional same-class unguarded functions (park_venture_decision, bootstrap_venture_workflow, log_stage_advance_override, reset_eva_circuit).

Gates: LEAD-TO-PLAN 94 / PLAN-TO-EXEC 87 / EXEC-TO-PLAN 93 / PLAN-TO-LEAD 95 (GATE4_WORKFLOW_ROI 89/90 documented-bypassed). SD: SD-LEO-GEN-DEFENSE-DEPTH-ADD-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)