### PR TITLE
feat(SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001): block AskUserQuestion for autonomous fleet workers

### DIFF
--- a/scripts/hooks/askuser-worker-policy.cjs
+++ b/scripts/hooks/askuser-worker-policy.cjs
@@ -1,0 +1,42 @@
+// askuser-worker-policy.cjs — pure predicate for the AskUserQuestion PreToolUse guard.
+// SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001.
+//
+// AskUserQuestion pauses an autonomous /loop worker indefinitely waiting for a human who is
+// not watching — stalling the SD and holding a worker slot. Workers must escalate via /signal
+// (options + recommendation + default-proceed) instead. This module decides WHICH sessions
+// are blocked. Extracted as a pure, side-effect-free function so the policy is unit-testable
+// without the hook's stdin/process machinery.
+//
+// POSITIVE detection (only a CONFIRMED autonomous fleet worker is blocked):
+//   - has a fleet identity / callsign (assigned by the fleet roster — workers in /loop), AND
+//   - is NOT the coordinator (metadata.is_coordinator), Adam (metadata.role==='adam'), or
+//     non_fleet (metadata.non_fleet — chairman/adam helper sessions).
+// Everything else is EXEMPT (returns false → AskUserQuestion allowed): the operator/chairman
+// interactive session (no fleet identity), coordinator, Adam, solo, and — critically — any
+// session whose metadata could not be resolved (null/garbage). Failing OPEN here means a
+// detection error never wedges a tool the operator legitimately needs.
+
+/**
+ * @param {object|null} meta - claude_sessions.metadata for the calling session (or null if unresolved)
+ * @returns {boolean} true ⇢ block AskUserQuestion for this session
+ */
+function isBlockableWorker(meta) {
+  if (!meta || typeof meta !== 'object') return false;   // unresolved/garbage → fail-open ALLOW
+  if (meta.is_coordinator === true) return false;        // coordinator exempt
+  if (meta.role === 'adam') return false;                // Adam exempt
+  if (meta.non_fleet === true) return false;             // non-fleet (chairman/adam helpers) exempt
+  const callsign = (meta.fleet_identity && meta.fleet_identity.callsign) || meta.callsign;
+  return Boolean(callsign);                              // block ONLY a confirmed fleet worker
+}
+
+/** The deny message shown when AskUserQuestion is blocked — names the /signal escalation contract. */
+const ASKUSER_DENY_MESSAGE =
+  '[BLOCKED ENF-NO-ASKUSER-WORKER] AskUserQuestion is disabled for autonomous fleet workers — it pauses ' +
+  'the /loop indefinitely waiting for a human who is not watching, stalling the SD and holding a worker ' +
+  'slot. Resolve it autonomously, OR escalate to the coordinator via /signal:\n' +
+  '  /signal <type> "<question> — options: [A] …, [B] …; recommendation: <A|B>; default if no reply: proceed with <A|B>"\n' +
+  '(types: stuck | prd-ambiguous | spec-conflict | need-sweep | feedback | other). The coordinator/operator ' +
+  'replies, or the default proceeds — so the loop never hangs. (Coordinator, Adam, and operator/chairman ' +
+  'sessions are exempt and may use AskUserQuestion.)';
+
+module.exports = { isBlockableWorker, ASKUSER_DENY_MESSAGE };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -146,9 +146,19 @@ async function auditAndExit(auditPromise, code, timeoutMs) {
     auditPromise,
     new Promise(resolve => setTimeout(resolve, ms))
   ]).catch(() => { /* audit never blocks enforcement */ });
-  // Tear down undici's keep-alive socket pool BEFORE process.exit. Without
-  // this, Windows libuv asserts on src\win\async.c:76 when process.exit races
-  // with in-flight HTTP socket cleanup, surfacing as STATUS_STACK_BUFFER_OVERRUN.
+  await drainUndiciPool();
+  process.exit(code);
+}
+
+/**
+ * Tear down undici's keep-alive socket pool BEFORE process.exit. Without this,
+ * Windows libuv asserts on src\win\async.c:76 (`!(handle->flags &
+ * UV_HANDLE_CLOSING)`) when process.exit races with an in-flight HTTP socket's
+ * async-handle cleanup, surfacing as STATUS_STACK_BUFFER_OVERRUN (0xC0000409).
+ * EVERY exit that follows a fetch() in this hook must drain first — not just the
+ * block paths. Fail-open: undici unavailable means there is no pool to drain.
+ */
+async function drainUndiciPool() {
   try {
     const undici = require('undici');
     if (undici && typeof undici.getGlobalDispatcher === 'function') {
@@ -161,7 +171,6 @@ async function auditAndExit(auditPromise, code, timeoutMs) {
       }
     }
   } catch { /* fail-open: undici unavailable means no pool to drain */ }
-  process.exit(code);
 }
 
 // Derive session ID once at module load time. QF-20260504-932: stdin payload
@@ -247,6 +256,37 @@ async function resolveSessionClaimedSdKey(sessionId) {
     return row && row.sd_key ? row.sd_key : null;
   } catch {
     return null;
+  }
+}
+
+// SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001: resolve THIS session's claude_sessions.metadata
+// (mirrors resolveSessionClaimedSdKey: REST + 1.5s timeout + fail-open → null on any error).
+// Used only by the AskUserQuestion guard, so the lookup happens at most once per
+// AskUserQuestion call (a rare tool), never on the hot path of other tools.
+const { isBlockableWorker, ASKUSER_DENY_MESSAGE } = require('./askuser-worker-policy.cjs');
+async function resolveSessionMetadata(sessionId) {
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey || !sessionId || sessionId === 'unknown') return null;
+    const url = supabaseUrl +
+      '/rest/v1/claude_sessions?session_id=eq.' +
+      encodeURIComponent(sessionId) + '&select=metadata&limit=1';
+    // clearTimeout in finally: when fetch wins the race, the timeout promise would
+    // otherwise stay pending and reject at 1500ms with NO handler → an unhandled
+    // rejection that crashes node on the fall-through (non-block) path. Clearing the
+    // timer makes the helper safe whether it blocks or exempts the caller.
+    let _timer;
+    const resp = await Promise.race([
+      fetch(url, { headers: { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey } }),
+      new Promise((_, reject) => { _timer = setTimeout(() => reject(new Error('timeout')), 1500); }),
+    ]).finally(() => clearTimeout(_timer));
+    if (!resp || !resp.ok) return null;
+    const rows = await resp.json();
+    const row = Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+    return row && row.metadata && typeof row.metadata === 'object' ? row.metadata : null;
+  } catch {
+    return null; // fail-open: a resolution error must NEVER block a tool call
   }
 }
 
@@ -452,6 +492,35 @@ async function main() {
     input = JSON.parse(TOOL_INPUT_RAW);
   } catch {
     // Not JSON or empty - nothing to enforce
+    process.exit(0);
+  }
+
+  // --- ENFORCEMENT 12: Block AskUserQuestion in autonomous fleet-worker sessions ---
+  // SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001: AskUserQuestion pauses the /loop forever
+  // waiting for an absent human, stalling the SD + holding a worker slot. Workers must
+  // escalate via /signal (options + recommendation + default-proceed) instead. Detection is
+  // POSITIVE (only a confirmed fleet worker is blocked — has a fleet callsign and is not
+  // coordinator/Adam/non_fleet); operator/chairman/coordinator/Adam and any unresolved
+  // session are EXEMPT. The metadata lookup runs ONLY for this (rare) tool, and fail-OPEN
+  // (any resolution error → meta=null → not blockable) so it can never wedge a tool call.
+  if (TOOL_NAME === 'AskUserQuestion') {
+    const meta = await resolveSessionMetadata(_SESSION_ID);
+    if (isBlockableWorker(meta)) {
+      const auditPromise = auditPermissionDecision(
+        _SESSION_ID, TOOL_NAME, 'ENF-NO-ASKUSER-WORKER',
+        'AskUserQuestion blocked for autonomous fleet worker', 'block',
+        { callsign: (meta.fleet_identity && meta.fleet_identity.callsign) || meta.callsign || null }
+      );
+      process.stderr.write(ASKUSER_DENY_MESSAGE + '\n');
+      await auditAndExit(auditPromise, 2, 800);
+    }
+    // EXEMPT (coordinator/Adam/operator/unresolved): allow. No other enforcement
+    // applies to AskUserQuestion, so exit now — but drain undici FIRST. The
+    // resolveSessionMetadata fetch above leaves a keep-alive socket whose libuv
+    // async-handle is still closing; a raw process.exit here races it and trips
+    // src\win\async.c:76 → STATUS_STACK_BUFFER_OVERRUN (verified: bare exit/fall-
+    // through both crashed exempt sessions; draining the pool fixes it).
+    await drainUndiciPool();
     process.exit(0);
   }
 

--- a/tests/unit/askuser-worker-policy.test.js
+++ b/tests/unit/askuser-worker-policy.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001 — AskUserQuestion is blocked for autonomous
+ * fleet workers (it pauses the /loop), but EXEMPT for coordinator / Adam / operator-chairman
+ * and on any unresolved metadata (fail-open). These tests pin isBlockableWorker, the pure
+ * predicate the PreToolUse guard (pre-tool-enforce.cjs) uses to decide.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { isBlockableWorker, ASKUSER_DENY_MESSAGE } = require('../../scripts/hooks/askuser-worker-policy.cjs');
+
+describe('isBlockableWorker — AskUserQuestion block policy (SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001)', () => {
+  it('BLOCKS a fleet worker (fleet_identity.callsign present, not privileged)', () => {
+    expect(isBlockableWorker({ fleet_identity: { callsign: 'Echo' }, auto_proceed: true })).toBe(true);
+  });
+
+  it('BLOCKS a fleet worker that carries a top-level callsign', () => {
+    expect(isBlockableWorker({ callsign: 'Foxtrot' })).toBe(true);
+  });
+
+  it('EXEMPTS the coordinator (metadata.is_coordinator)', () => {
+    expect(isBlockableWorker({ is_coordinator: true })).toBe(false);
+  });
+
+  it('EXEMPTS the coordinator even if it also has a callsign (privilege wins)', () => {
+    expect(isBlockableWorker({ is_coordinator: true, fleet_identity: { callsign: 'X' } })).toBe(false);
+  });
+
+  it('EXEMPTS Adam (metadata.role === "adam")', () => {
+    expect(isBlockableWorker({ role: 'adam', non_fleet: true })).toBe(false);
+  });
+
+  it('EXEMPTS a non_fleet session (chairman/adam helper)', () => {
+    expect(isBlockableWorker({ non_fleet: true, fleet_identity: { callsign: 'Y' } })).toBe(false);
+  });
+
+  it('EXEMPTS an operator / chairman interactive session (no fleet identity)', () => {
+    expect(isBlockableWorker({ auto_proceed: true, chain_orchestrators: true })).toBe(false);
+  });
+
+  it('FAILS OPEN (exempt) when metadata is null / undefined / garbage', () => {
+    expect(isBlockableWorker(null)).toBe(false);
+    expect(isBlockableWorker(undefined)).toBe(false);
+    expect(isBlockableWorker('not-an-object')).toBe(false);
+    expect(isBlockableWorker({})).toBe(false);
+  });
+
+  it('deny message names the /signal escalation path with the options+recommendation+default contract', () => {
+    expect(ASKUSER_DENY_MESSAGE).toMatch(/\/signal/);
+    expect(ASKUSER_DENY_MESSAGE).toMatch(/options/);
+    expect(ASKUSER_DENY_MESSAGE).toMatch(/recommendation/);
+    expect(ASKUSER_DENY_MESSAGE).toMatch(/default/);
+    expect(ASKUSER_DENY_MESSAGE).toMatch(/exempt/i);
+  });
+});


### PR DESCRIPTION
## Summary
AskUserQuestion silently pauses a /loop fleet worker waiting for a human who is not watching — stalling the SD and holding a worker slot. This adds a PreToolUse guard that blocks AskUserQuestion **only** for confirmed autonomous fleet workers, redirecting them to escalate via `/signal` (question + options + recommendation + default-proceed) so the loop never hangs.

**POSITIVE detection** — blocks only a session with `metadata.fleet_identity.callsign` and no privilege flag. EXEMPT (fail-open ALLOW): coordinator (`is_coordinator`), Adam (`role=adam`), `non_fleet`, operator/chairman interactive sessions (no fleet identity), and any session whose metadata can't be resolved.

## Changes
- `scripts/hooks/askuser-worker-policy.cjs` — pure, unit-tested predicate `isBlockableWorker` + the `ENF-NO-ASKUSER-WORKER` deny message naming the `/signal` contract.
- `scripts/hooks/pre-tool-enforce.cjs` — `resolveSessionMetadata` lookup + the AskUserQuestion matcher; factor the undici-pool drain out of `auditAndExit` into a shared `drainUndiciPool()` and call it on the exempt exit too.
- `tests/unit/askuser-worker-policy.test.js` — 9 cases (block worker / exempt privileged / fail-open / deny-message contract).

## Fleet-critical crash fixed
The hook runs on **every tool call for every session**. A raw `process.exit` after the new metadata `fetch` raced undici's keep-alive socket teardown and tripped a Windows libuv assertion (`src\win\async.c:76` → `STATUS_STACK_BUFFER_OVERRUN` / `0xC0000409`) **only** on the coordinator/exempt path. Caught behaviorally (unit tests were 9/9 green and could not see it); fixed by draining undici before the exempt exit.

## Verification
- Unit: 9/9 pass.
- Behavioral matrix: worker+AskUserQuestion→block (exit 2, `ENF-NO-ASKUSER-WORKER`); worker+Read→allow (0); coordinator/Adam/operator/unresolved+AskUserQuestion→allow (0, **no crash across ≥4 consecutive runs**).
- TESTING sub-agent: PASS (95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)