### PR TITLE
fix(SD-LEO-FIX-CLAIM-RPC-TERMINAL-001): claim_sd terminal-status guard

### DIFF
--- a/database/migrations/20260609_claim_sd_terminal_status_guard.sql
+++ b/database/migrations/20260609_claim_sd_terminal_status_guard.sql
@@ -1,0 +1,311 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001
+-- claim_sd RPC: terminal-status guard — reject claiming SDs/QFs whose lifecycle has ended.
+--
+-- Bug (PAT-OPTIMISTIC-RPC residual): the predecessor SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 added an
+-- existence guard (sd_not_found) but claim_sd still claimed an SD whose status was already
+-- terminal (completed/cancelled/deferred), stomping claiming_session_id. trigger 393
+-- (enforce_no_claim_on_cancelled_sd) covered only cancelled, via a raw P0001 (claim_sd has no
+-- handler around its UPDATE). This adds a clean terminal-status guard INSIDE claim_sd that fires
+-- BEFORE any UPDATE: SD terminal = {completed,cancelled,deferred}; QF terminal =
+-- {completed,cancelled,escalated}. Returns {success:false, error:'sd_terminal_status', status}.
+-- Generated from 20260608_claim_sd_validate_id_exists.sql via CRLF-safe exact-string-replace;
+-- the entire function body (existence guard, takeover/auto-stale logic, cross-table writes,
+-- worktree-column clearing, audit emission) is carried VERBATIM. CREATE OR REPLACE with the
+-- unchanged claim_sd(text,text,text,boolean) signature, so EXECUTE grants are preserved.
+
+CREATE OR REPLACE FUNCTION public.claim_sd(
+  p_sd_id          text,
+  p_session_id     text,
+  p_track          text,
+  p_force_takeover boolean DEFAULT FALSE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_session    text;
+  v_existing_hb_age     numeric;
+  v_existing_status     text;
+  v_existing_wt_path    text;
+  v_existing_wt_branch  text;
+  v_sd_claiming_id      text;
+  v_sd_parent_id        text;
+  v_drift_detected      boolean := FALSE;
+  v_takeover            boolean := FALSE;
+  v_takeover_reason     text;
+  v_caller_parent_id    text;
+  v_audit_event_id      uuid;
+  v_conflict            RECORD;
+  v_is_qf               boolean := p_sd_id LIKE 'QF-%';
+  v_sd_status           text;
+  v_qf_status           text;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- 2a. Capture prior session's worktree state (for audit metadata) under the
+  --     SAME FOR UPDATE row lock as the existing-session check.
+  SELECT cs.session_id, cs.status,
+         EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+         cs.worktree_path, cs.worktree_branch
+    INTO v_existing_session, v_existing_status, v_existing_hb_age,
+         v_existing_wt_path, v_existing_wt_branch
+    FROM claude_sessions cs
+   WHERE cs.sd_key = p_sd_id
+     AND cs.session_id != p_session_id
+     AND cs.status IN ('active', 'idle')
+   ORDER BY cs.heartbeat_at DESC
+   LIMIT 1
+     FOR UPDATE;
+
+  IF NOT v_is_qf THEN
+    SELECT sd.claiming_session_id, sd.parent_sd_id, sd.status
+      INTO v_sd_claiming_id, v_sd_parent_id, v_sd_status
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_sd_id
+       FOR UPDATE;
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: reject phantom (non-existent) SD ids instead of
+    -- optimistically returning success. claim_sd was OPTIMISTIC — a typo / stale sd_key used
+    -- to self-claim a non-existent SD and write claude_sessions.sd_key. The existing FOR UPDATE
+    -- SELECT above sets FOUND only when an sd_key row exists, so this is the minimal guard.
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: terminal-status guard. Refuse to claim an SD whose
+    -- lifecycle has already ended (completed/cancelled/deferred) instead of optimistically
+    -- stomping claiming_session_id. Orthogonal to the sd_not_found guard above; fires BEFORE
+    -- the claim UPDATE so it pre-empts trigger 393's raw P0001 with a clean structured failure
+    -- and additionally covers completed/deferred which that cancelled-only trigger does not.
+    IF v_sd_status IN ('completed', 'cancelled', 'deferred') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_sd_status,
+        'message', format('[CLAIM_SD_TERMINAL] SD %s is in terminal status %s — refusing to claim a finished/cancelled/deferred SD.', p_sd_id, v_sd_status));
+    END IF;
+  ELSE
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: same guard for the QF path (claim_sd resolves QFs
+    -- by quick_fixes.id = p_sd_id, mirrored from the QF UPDATE below).
+    SELECT qf.status INTO v_qf_status FROM quick_fixes qf WHERE qf.id = p_sd_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: QF terminal-status guard. 'escalated' is a one-way
+    -- promotion to a full SD (classify-quick-fix.js never reverts it), so claiming an escalated
+    -- QF resumes superseded work. Mirrors the SD terminal guard; fires before the QF UPDATE.
+    IF v_qf_status IN ('completed', 'cancelled', 'escalated') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_qf_status,
+        'message', format('[CLAIM_QF_TERMINAL] Quick-fix %s is in terminal status %s — refusing to claim a finished/cancelled/escalated quick-fix.', p_sd_id, v_qf_status));
+    END IF;
+  END IF;
+
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_existing_session IS NULL
+  THEN
+    v_drift_detected := TRUE;
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age < 900 THEN
+    IF NOT p_force_takeover THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'already_claimed',
+        'message', format(
+          '[CLAIM_PEER_ACTIVE] SD %s is already claimed by active session %s (heartbeat %ss ago). Use --force to take over or wait for release.',
+          p_sd_id, v_existing_session, ROUND(v_existing_hb_age)),
+        'claimed_by', v_existing_session,
+        'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+      );
+    END IF;
+
+    SELECT cs2.sd_key INTO v_caller_parent_id
+      FROM claude_sessions cs2
+     WHERE cs2.session_id = p_session_id
+       AND cs2.status IN ('active', 'idle')
+     LIMIT 1;
+
+    IF v_existing_hb_age >= 60 THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_heartbeat_threshold';
+    ELSIF v_sd_parent_id IS NOT NULL
+          AND v_caller_parent_id = v_sd_parent_id THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_parent_authority';
+    ELSE
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'unauthorized_force',
+        'message', format(
+          '[CLAIM_FORCE_DENIED] SD %s force-takeover refused: caller session %s lacks authority (prior heartbeat %ss < 60s threshold and no parent SD authority). Use sd:release first or wait.',
+          p_sd_id, p_session_id, ROUND(v_existing_hb_age))
+      );
+    END IF;
+  END IF;
+
+  IF v_drift_detected AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'drift_recovery';
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'auto_stale_takeover';
+  END IF;
+
+  IF NOT v_is_qf AND NOT v_takeover THEN
+    SELECT cm.*, cs_other.sd_key AS active_sd, cs_other.session_id AS active_session
+      INTO v_conflict
+      FROM sd_conflict_matrix cm
+      JOIN claude_sessions cs_other ON (
+        (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_key) OR
+        (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_key)
+      )
+     WHERE cm.conflict_severity = 'blocking'
+       AND cm.resolved_at IS NULL
+       AND cs_other.sd_key IS NOT NULL
+       AND cs_other.status IN ('active', 'idle')
+       AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+       AND cs_other.session_id != p_session_id
+     LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+  END IF;
+
+  -- ============================================================================
+  -- TAKEOVER PATH: NULL the prior session's claim AND its worktree state.
+  -- (FR-1 of SD-LEO-INFRA-LEO-INFRA-SESSION-001 — only the worktree_* columns
+  -- are new vs. 20260427.)
+  -- ============================================================================
+  IF v_takeover AND v_existing_session IS NOT NULL THEN
+    UPDATE claude_sessions
+       SET sd_key = NULL,
+           track = NULL,
+           claimed_at = NULL,
+           released_at = NOW(),
+           released_reason = v_takeover_reason,
+           status = 'idle',
+           updated_at = NOW(),
+           worktree_path = NULL,
+           worktree_branch = NULL
+     WHERE session_id = v_existing_session;
+  END IF;
+
+  -- Claim-switch path: caller is releasing some OTHER SD to claim p_sd_id.
+  UPDATE claude_sessions
+     SET sd_key = NULL,
+         track = NULL,
+         claimed_at = NULL,
+         released_at = NOW(),
+         released_reason = 'claim_switch',
+         status = 'idle',
+         worktree_path = NULL,
+         worktree_branch = NULL
+   WHERE session_id = p_session_id
+     AND sd_key IS NOT NULL
+     AND sd_key != p_sd_id
+     AND (v_sd_parent_id IS NULL OR sd_key != v_sd_parent_id);
+
+  -- New-claim UPDATE intentionally does NOT set worktree_path / worktree_branch.
+  -- sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after
+  -- createWorktree completes. Keeping them NULL here means the FR-5 CHECK
+  -- constraint is never violated transiently.
+  UPDATE claude_sessions
+     SET sd_key = p_sd_id,
+         track = p_track,
+         claimed_at = NOW(),
+         released_at = NULL,
+         released_reason = NULL,
+         heartbeat_at = NOW(),
+         status = 'active'
+   WHERE session_id = p_session_id;
+
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+       SET claiming_session_id = p_session_id,
+           status = 'in_progress'
+     WHERE id = p_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+       SET claiming_session_id = p_session_id,
+           active_session_id = p_session_id,
+           is_working_on = TRUE
+     WHERE sd_key = p_sd_id;
+  END IF;
+
+  -- ============================================================================
+  -- AUDIT EMISSION: gains worktree_path_before / worktree_branch_before
+  -- per TR-1 risk-mitigation observability addition.
+  -- ============================================================================
+  IF v_takeover THEN
+    INSERT INTO session_lifecycle_events (
+      event_type,
+      session_id,
+      reason,
+      metadata
+    ) VALUES (
+      CASE
+        WHEN v_takeover_reason = 'auto_stale_takeover' THEN 'CLAIM_AUTO_RECLAIM'
+        ELSE 'CLAIM_TAKEOVER'
+      END,
+      p_session_id,
+      v_takeover_reason,
+      jsonb_build_object(
+        'sd_key', p_sd_id,
+        'prior_session_id', v_existing_session,
+        'prior_heartbeat_age_seconds', ROUND(COALESCE(v_existing_hb_age, 0)),
+        'drift_detected', v_drift_detected,
+        'force_authorized_by', CASE
+          WHEN v_takeover_reason LIKE 'force_%' THEN v_takeover_reason
+          ELSE NULL
+        END,
+        'sd_claiming_id_before', v_sd_claiming_id,
+        'worktree_path_before', v_existing_wt_path,
+        'worktree_branch_before', v_existing_wt_branch
+      )
+    )
+    RETURNING id INTO v_audit_event_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_sd_parent_id IS NOT NULL,
+    'takeover', v_takeover,
+    'takeover_reason', v_takeover_reason,
+    'prior_session_id', v_existing_session,
+    'prior_heartbeat_age_seconds', CASE
+      WHEN v_existing_hb_age IS NOT NULL THEN ROUND(v_existing_hb_age)
+      ELSE NULL
+    END,
+    'drift_detected', v_drift_detected,
+    'audit_event_id', v_audit_event_id
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.claim_sd(text, text, text, boolean) IS
+  'Cross-table consistent claim_sd with atomic worktree-state clearing on takeover and claim-switch. Worktree columns left NULL on the new-claim UPDATE — sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after createWorktree. Audit metadata includes worktree_path_before / worktree_branch_before. SD-LEO-INFRA-LEO-INFRA-SESSION-001 (FR-1).';

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -305,6 +305,18 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       cancellation_reason: sdStatusRow.cancellation_reason || null
     };
   }
+  // SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: refuse the other terminal lifecycle states too
+  // (completed/deferred) so claimGuard does not optimistically claim a finished SD, and
+  // formatClaimFailure can render an accurate terminal banner instead of the misleading
+  // "claimed by another session". Same FAIL-OPEN contract as cancelled above; the claim_sd
+  // RPC guard backstops the QF path and any caller that bypasses claimGuard.
+  if (!sdStatusError && sdStatusRow && (sdStatusRow.status === 'completed' || sdStatusRow.status === 'deferred')) {
+    return {
+      success: false,
+      error: 'sd_terminal_status',
+      status: sdStatusRow.status
+    };
+  }
 
   // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: Fetch TTL from config on first call.
   // SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19): resolve a LOCAL sd_type-aware
@@ -636,6 +648,24 @@ export function formatClaimFailure(result) {
       '',
       '  This SD has status=cancelled. Cancelled SDs cannot be claimed.',
       '  Pick a different SD; if this is wrong, re-open the SD first.',
+      '',
+    ].join('\n');
+  }
+
+  // SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: distinct banner for a terminal-status refusal
+  // (completed/deferred SD, or completed/cancelled/escalated QF from the claim_sd RPC guard).
+  // This is NOT a foreign-claim conflict, so it must not read "claimed by another session".
+  if (result.error === 'sd_terminal_status') {
+    const st = result.status || 'terminal';
+    return [
+      '╔══════════════════════════════════════════════════════════╗',
+      '║  CLAIM GUARD: ITEM IS TERMINAL — CANNOT CLAIM          ║',
+      '╚══════════════════════════════════════════════════════════╝',
+      `  Status:    ${st}`,
+      '',
+      `  This item has status=${st} (a finished/closed lifecycle state).`,
+      '  Terminal items cannot be claimed. Pick a different SD/QF;',
+      '  if this is wrong, re-open it first.',
       '',
     ].join('\n');
   }

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -417,13 +417,30 @@ async function runCheckin(sb, sessionId, { getCoordinator = getActiveCoordinator
   if (assignment) {
     const sdKey = extractSdFromAssignment(assignment);
     if (sdKey) {
-      const claimed = await tryClaim(sb, sdKey, sessionId);
-      if (claimed.ok) {
+      // SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: purge a STALE assignment whose target SD reached a
+      // terminal status (completed/cancelled/deferred) AFTER the assignment was created — the
+      // in_progress->terminal race. claim_sd now refuses terminal claims, but a never-ACKed
+      // assignment would re-fire every tick (the "retried on every tick" symptom), so ACK it
+      // here and fall through to self-claim. Fail-open: a query error skips the purge and lets
+      // the normal claim path (now guarded by the RPC) handle it.
+      let terminalStatus = null;
+      try {
+        const { data: tgt } = await sb.from('strategic_directives_v2')
+          .select('status').eq('sd_key', sdKey).maybeSingle();
+        if (tgt && ['completed', 'cancelled', 'deferred'].includes(tgt.status)) terminalStatus = tgt.status;
+      } catch { /* fail-open: leave terminalStatus null, attempt the claim below */ }
+      if (terminalStatus) {
         await ackMessage(sb, assignment.id);
-        return { ...base, action: 'claimed_assignment', sd: sdKey, message: `Claimed assigned ${sdKey} via claim_sd. Run: node scripts/sd-start.js ${sdKey}` };
+        base.stale_assignment_purged = { sd: sdKey, status: terminalStatus };
+      } else {
+        const claimed = await tryClaim(sb, sdKey, sessionId);
+        if (claimed.ok) {
+          await ackMessage(sb, assignment.id);
+          return { ...base, action: 'claimed_assignment', sd: sdKey, message: `Claimed assigned ${sdKey} via claim_sd. Run: node scripts/sd-start.js ${sdKey}` };
+        }
+        // could not claim the assigned SD -> fall through to self-claim
+        base.assignment_claim_error = claimed.error;
       }
-      // could not claim the assigned SD -> fall through to self-claim
-      base.assignment_claim_error = claimed.error;
     }
   }
 

--- a/tests/database/claim-sd-terminal-status.test.js
+++ b/tests/database/claim-sd-terminal-status.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-LEO-FIX-CLAIM-RPC-TERMINAL-001 — claim_sd must reject claiming terminal-status items.
+ *
+ * The predecessor SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 added the sd_not_found existence guard,
+ * but claim_sd still optimistically claimed an SD/QF whose lifecycle had ended, stomping
+ * claiming_session_id. This guard returns {success:false, error:'sd_terminal_status', status}
+ * BEFORE any write for terminal SDs (completed/cancelled/deferred) and terminal QFs
+ * (completed/cancelled/escalated) — while leaving real claims and the existence guard intact.
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips cleanly
+ * without service-role creds. The guard fires before any UPDATE, so the terminal probes are
+ * inherently net-zero (asserted explicitly).
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const PROBE_SESSION = 'test-claim-terminal-status-session';
+
+async function firstSdWithStatus(status) {
+  const { data } = await supabase.from('strategic_directives_v2')
+    .select('sd_key, claiming_session_id').eq('status', status).limit(1);
+  return data && data[0] ? data[0] : null;
+}
+
+describe.skipIf(!HAS_REAL_DB)('claim_sd rejects terminal-status items (SD-LEO-FIX-CLAIM-RPC-TERMINAL-001)', () => {
+  afterAll(async () => {
+    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+  });
+
+  it('rejects a completed SD with sd_terminal_status and does NOT stomp claiming_session_id', async () => {
+    const sd = await firstSdWithStatus('completed');
+    if (!sd) return; // env-dependent
+    const before = sd.claiming_session_id ?? null;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: sd.sd_key, p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('completed');
+    // net-zero: claiming_session_id unchanged (guard fired before any write)
+    const { data: after } = await supabase.from('strategic_directives_v2')
+      .select('claiming_session_id').eq('sd_key', sd.sd_key).maybeSingle();
+    expect(after?.claiming_session_id ?? null).toBe(before);
+    // and the probe session must NOT have acquired the key
+    const { data: sess } = await supabase.from('claude_sessions').select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key ?? null).not.toBe(sd.sd_key);
+  });
+
+  it('rejects a cancelled SD with clean sd_terminal_status JSON (not trigger-393 raw P0001)', async () => {
+    const sd = await firstSdWithStatus('cancelled');
+    if (!sd) return;
+    const { data, error } = await supabase.rpc('claim_sd', { p_sd_id: sd.sd_key, p_session_id: PROBE_SESSION, p_track: null });
+    // The guard returns structured JSON BEFORE the UPDATE, so trigger 393 never raises.
+    expect(error).toBeNull();
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('cancelled');
+  });
+
+  it('rejects a deferred SD with sd_terminal_status (skipped if none exist)', async () => {
+    const sd = await firstSdWithStatus('deferred');
+    if (!sd) return;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: sd.sd_key, p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('deferred');
+  });
+
+  it('rejects an escalated quick-fix with sd_terminal_status (skipped if none exist)', async () => {
+    const { data: qf } = await supabase.from('quick_fixes').select('id').eq('status', 'escalated').limit(1);
+    if (!qf || !qf[0]) return;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: qf[0].id, p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('escalated');
+  });
+
+  it('still claims a real unclaimed draft/active SD (terminal guard does not break the happy path)', async () => {
+    const { data: cand } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, active_session_id, is_working_on')
+      .is('claiming_session_id', null).in('status', ['draft', 'active']).limit(1);
+    if (!cand || !cand[0]) return; // env-dependent
+    const key = cand[0].sd_key;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: key, p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(true);
+    // restore (net-zero)
+    await supabase.from('strategic_directives_v2').update({
+      claiming_session_id: cand[0].claiming_session_id,
+      active_session_id: cand[0].active_session_id,
+      is_working_on: cand[0].is_working_on,
+    }).eq('sd_key', key);
+    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+  });
+
+  it('still returns sd_not_found for a non-existent id (existence guard non-regression)', async () => {
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: 'SD-FAKE-PROBE-000', p_session_id: PROBE_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_not_found');
+  });
+});

--- a/tests/unit/harness/claim-terminal-status-guard.test.js
+++ b/tests/unit/harness/claim-terminal-status-guard.test.js
@@ -1,0 +1,86 @@
+// SD-LEO-FIX-CLAIM-RPC-TERMINAL-001 — terminal-status guard across the claim surface.
+//
+// Orthogonal follow-up to SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 (sd_not_found existence guard).
+// Three layers must refuse claiming a finished/closed item:
+//   1. claim_sd RPC (migration)  — universal data-layer backstop (SD + QF)
+//   2. lib/claim-guard.mjs       — pre-acquire refusal + accurate terminal banner
+//   3. scripts/worker-checkin.cjs — purge a stale WORK_ASSIGNMENT whose target went terminal
+// formatClaimFailure is exported + pure, so it gets a real functional assertion; the other two
+// layers are pinned by static source assertion (CI-runnable, no DB), matching the
+// block-claims-cancelled.test.js convention.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const guardSrc = fs.readFileSync(path.join(repoRoot, 'lib/claim-guard.mjs'), 'utf-8');
+const checkinSrc = fs.readFileSync(path.join(repoRoot, 'scripts/worker-checkin.cjs'), 'utf-8');
+const migrationPath = path.join(repoRoot, 'database/migrations/20260609_claim_sd_terminal_status_guard.sql');
+const migSrc = fs.existsSync(migrationPath) ? fs.readFileSync(migrationPath, 'utf-8') : '';
+
+describe('formatClaimFailure renders a terminal banner for sd_terminal_status', () => {
+  it('shows a TERMINAL banner naming the status, NOT the foreign-claim banner', async () => {
+    const { formatClaimFailure } = await import('../../../lib/claim-guard.mjs');
+    const out = formatClaimFailure({ success: false, error: 'sd_terminal_status', status: 'completed' });
+    expect(out).toMatch(/TERMINAL/);
+    expect(out).toMatch(/completed/);
+    expect(out).not.toMatch(/CLAIMED BY ANOTHER SESSION/);
+  });
+
+  it('still renders the distinct cancelled banner (no regression)', async () => {
+    const { formatClaimFailure } = await import('../../../lib/claim-guard.mjs');
+    const out = formatClaimFailure({ success: false, error: 'sd_cancelled', cancelled: true, cancellation_reason: 'x' });
+    expect(out).toMatch(/CANCELLED/);
+  });
+
+  it('deferred status is named in the terminal banner too', async () => {
+    const { formatClaimFailure } = await import('../../../lib/claim-guard.mjs');
+    const out = formatClaimFailure({ success: false, error: 'sd_terminal_status', status: 'deferred' });
+    expect(out).toMatch(/deferred/);
+  });
+});
+
+describe('claim-guard.mjs pre-acquire refuses completed/deferred (FAIL-OPEN, preserves cancelled)', () => {
+  it('returns sd_terminal_status for completed/deferred, gated fail-open on row+no-error', () => {
+    expect(guardSrc).toMatch(/error:\s*['"]sd_terminal_status['"]/);
+    // FAIL-OPEN: only a definite terminal status blocks (matches the cancelled guard contract).
+    expect(guardSrc).toMatch(/!sdStatusError\s*&&\s*sdStatusRow\s*&&\s*\(sdStatusRow\.status === ['"]completed['"]\s*\|\|\s*sdStatusRow\.status === ['"]deferred['"]\)/);
+  });
+  it('preserves the cancelled-only sd_cancelled refusal unchanged', () => {
+    expect(guardSrc).toMatch(/!sdStatusError\s*&&\s*sdStatusRow\s*&&\s*sdStatusRow\.status === ['"]cancelled['"]/);
+    expect(guardSrc).toMatch(/error:\s*['"]sd_cancelled['"]/);
+  });
+});
+
+describe('worker-checkin.cjs purges a stale terminal WORK_ASSIGNMENT', () => {
+  it('checks the assigned SD status and ACKs (purges) when terminal, falling through', () => {
+    expect(checkinSrc).toMatch(/terminalStatus/);
+    expect(checkinSrc).toMatch(/\[['"]completed['"],\s*['"]cancelled['"],\s*['"]deferred['"]\]\.includes\(tgt\.status\)/);
+    // It ACKs the stale assignment (purge) rather than re-claiming.
+    const idx = checkinSrc.indexOf('stale_assignment_purged');
+    expect(idx).toBeGreaterThan(0);
+  });
+});
+
+describe('migration 20260609 adds the claim_sd terminal-status guard (SD + QF)', () => {
+  it('the migration file exists and is a CREATE OR REPLACE of claim_sd (signature preserved)', () => {
+    expect(migSrc.length).toBeGreaterThan(0);
+    expect(migSrc).toMatch(/CREATE OR REPLACE FUNCTION public\.claim_sd\(/);
+  });
+  it('fetches sd.status in the FOR UPDATE SELECT and guards SD terminal states before any write', () => {
+    expect(migSrc).toMatch(/SELECT sd\.claiming_session_id, sd\.parent_sd_id, sd\.status/);
+    expect(migSrc).toMatch(/IF v_sd_status IN \('completed', 'cancelled', 'deferred'\) THEN/);
+    expect(migSrc).toMatch(/'error', 'sd_terminal_status'/);
+  });
+  it('guards QF terminal states (completed/cancelled/escalated) on the QF path', () => {
+    expect(migSrc).toMatch(/SELECT qf\.status INTO v_qf_status FROM quick_fixes qf WHERE qf\.id = p_sd_id FOR UPDATE/);
+    expect(migSrc).toMatch(/IF v_qf_status IN \('completed', 'cancelled', 'escalated'\) THEN/);
+  });
+  it('preserves the predecessor sd_not_found existence guard (no regression)', () => {
+    expect(migSrc).toMatch(/'error', 'sd_not_found'/);
+    expect(migSrc).toMatch(/\[CLAIM_SD_NOT_FOUND\]/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a **terminal-status guard** to the fleet-critical `claim_sd` Postgres RPC so it refuses to claim an SD (`completed`/`cancelled`/`deferred`) or quick-fix (`completed`/`cancelled`/`escalated`) whose lifecycle has already ended, returning `{success:false, error:'sd_terminal_status', status}` **before any UPDATE** instead of optimistically stomping `claiming_session_id`.

Orthogonal follow-up to the completed **SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001** (`sd_not_found` existence guard) — same PAT-OPTIMISTIC-RPC family.

## Why
`claim_sd` was optimistic for terminal items: a stale `WORK_ASSIGNMENT` pointed at a SD that completed mid-flight, and `claim_sd` claimed it (the HARDEN-LEO-HANDOFF completed case). trigger 393 covered only `cancelled`, via a raw P0001 (claim_sd has no handler around its UPDATE) — not `completed`/`deferred`.

## Changes (three-layer defense)
- **`database/migrations/20260609_claim_sd_terminal_status_guard.sql`** — `CREATE OR REPLACE claim_sd`, generated CRLF-safe from the authoritative `20260608` migration (body verbatim, signature + grants preserved). Fetches `sd.status` in the `FOR UPDATE` SELECT; guards SD + QF terminal states before any write. Pre-empts trigger 393's P0001 with clean JSON and additionally covers `completed`/`deferred`.
- **`lib/claim-guard.mjs`** — co-equal consumer: pre-acquire refusal for `completed`/`deferred` (→ `sd_terminal_status`, fail-open; `cancelled` path unchanged) + `formatClaimFailure` terminal banner (so a terminal refusal is not mislabeled 'claimed by another session').
- **`scripts/worker-checkin.cjs`** — purge a stale `WORK_ASSIGNMENT` whose target SD went terminal (ACK + fall through) instead of re-firing every tick.

## Verification
- **DATABASE sub-agent** (evidence `cf0f46ef`): migration applied live, **prosrc byte-identical**, **grants preserved**, **6/6 regression PASS** (before-probe reproduced the original stomping bug).
- **Tests: 16 passing** — `tests/database/claim-sd-terminal-status.test.js` (6 live-DB) + `tests/unit/harness/claim-terminal-status-guard.test.js` (10 unit + banner).
- Two unrelated pre-existing claim-guard test-pin failures confirmed on main (logged as harness backlog `73593153`), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)