### PR TITLE
feat(SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-C): formalize building->operations transition at S26 terminal (FR-1 + FR-2)

### DIFF
--- a/docs/06_deployment/eva-operations-mode.md
+++ b/docs/06_deployment/eva-operations-mode.md
@@ -19,7 +19,7 @@ Tags: eva, operations, background-workers, post-pipeline
 
 ## Overview
 
-Operations Mode is the post-pipeline phase of the EVA venture lifecycle. It activates automatically when a venture completes Stage 25 (Launch Execution), the terminus of the 25-stage evaluation-build-launch pipeline. At that point the venture's `pipeline_mode` column transitions from `'launch'` to `'operations'` and six background workers take over ongoing venture management.
+Operations Mode is the post-pipeline phase of the EVA venture lifecycle. It activates when a venture completes the terminal stage (Stage 26, Growth Playbook) of the staged pipeline and its exit-gates pass. At that point `processLifecycleTerminal()` (`lib/eva/stage-execution-engine.js`) transitions the venture's `pipeline_mode` column from `'building'` to `'operations'` (guarded and idempotent — see the Pipeline Mode Lifecycle section) and six background workers take over ongoing venture management.
 
 Operations Mode replaces the staged gate-driven evaluation model with a continuous, cadence-driven service layer. Workers run on fixed schedules managed by the EVA Master Scheduler. Unlike pipeline stages, there is no exit gate — a venture stays in Operations Mode until it is explicitly parked (`'parked'`) or killed (`'killed'`).
 
@@ -68,11 +68,11 @@ The `pipeline_mode` column on the `ventures` table controls which phase of the E
 | `evaluation` | Stages 0–17 (Evaluation) | Venture is created and enters Stage 0 |
 | `build` | Stages 18–22 (Build) | Venture passes Stage 17 promotion gate |
 | `launch` | Stages 23–25 (Launch) | Venture passes Stage 22 release gate |
-| `operations` | Post-pipeline Operations | Stage 25 (Launch Execution) completes |
+| `operations` | Post-pipeline Operations | Terminal stage (Stage 26, Growth Playbook) completes with exit-gates passed |
 | `parked` | Suspended | Manual operator action |
 | `killed` | Terminated | Manual operator action or kill-gate failure |
 
-**Transition rule**: only Stage 25's completion handler writes `pipeline_mode = 'operations'`. No other path should set this value directly.
+**Transition rule**: the `building → operations` transition is written by `processLifecycleTerminal()` in `lib/eva/stage-execution-engine.js` when the terminal stage (Stage 26) completes and exit-gates pass. It is guarded (transitions only from `'building'`/null, so a venture already in a later mode is never demoted) and idempotent. No other path should set `'operations'` directly. (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-C FR-1)
 
 **Parked vs. killed**:
 - `parked` — workers stop running for this venture; the venture can be un-parked.

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -71,6 +71,24 @@ export async function processLifecycleTerminal({ supabase, ventureId, stageNumbe
       logger.log(`   ↺ Lifecycle terminal: venture ${ventureId} already completed (idempotent no-op)`);
       return { handled: true, completed: false, idempotent: true };
     }
+    // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-C FR-1: formalize the building->operations
+    // transition. The staged pipeline is finite and ends at the terminal stage (S26); on a
+    // successful terminal completion the venture enters the persistent Operations mode
+    // (ventures.pipeline_mode). The lifecycle docs claimed this happened automatically, but no
+    // code performed it, so ventures stayed in 'building' forever. Guarded so a venture already
+    // in a later mode (growth/scaling/exit_prep/divesting/sold) is never demoted, and idempotent
+    // (a re-entry that already transitioned matches zero rows). Non-blocking: a failed transition
+    // does not invalidate the completed pipeline — mirrors the workflow_status semantics above.
+    const { error: modeError } = await supabase
+      .from('ventures')
+      .update({ pipeline_mode: 'operations' })
+      .eq('id', ventureId)
+      .or('pipeline_mode.eq.building,pipeline_mode.is.null');
+    if (modeError) {
+      logger.warn(`   ⚠️ Lifecycle terminal: pipeline_mode building→operations transition failed (non-blocking): ${modeError.message}`);
+    } else {
+      logger.log(`   ✅ Lifecycle terminal: venture ${ventureId} pipeline_mode → operations`);
+    }
     logger.log(`   ✅ Lifecycle terminal: venture ${ventureId} workflow_status → completed (S${stageNumber} terminal exit-gates passed)`);
     return { handled: true, completed: true, idempotent: false };
   } catch (terminalErr) {

--- a/tests/unit/eva/stage-execution-engine-lifecycle-terminal.test.js
+++ b/tests/unit/eva/stage-execution-engine-lifecycle-terminal.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-C FR-1 — processLifecycleTerminal building->operations transition.
+ *
+ * The staged venture pipeline is finite and ends at the terminal stage (S26). On a successful
+ * terminal completion the venture must enter the persistent Operations mode by writing
+ * ventures.pipeline_mode='operations'. Pre-fix, processLifecycleTerminal set only
+ * workflow_status='completed' and never touched pipeline_mode, so ventures stayed in 'building'
+ * forever (the lifecycle docs claimed the transition was automatic, but no code performed it).
+ *
+ * These tests assert the transition is: performed on terminal success, idempotent, guarded so a
+ * venture already in a later pipeline_mode is never demoted (no-clobber via the building/null
+ * filter), and non-blocking on failure (mirrors the existing workflow_status semantics).
+ *
+ * @module tests/unit/eva/stage-execution-engine-lifecycle-terminal.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/eva/lifecycle/exit-gate-enforcer.js', () => ({
+  checkExitGates: vi.fn(),
+}));
+
+import { processLifecycleTerminal } from '../../../lib/eva/stage-execution-engine.js';
+import { checkExitGates } from '../../../lib/eva/lifecycle/exit-gate-enforcer.js';
+
+// Mock supabase that records the two distinct ventures UPDATE chains:
+//   workflow_status: .update({workflow_status,..}).eq('id',x).neq('workflow_status','completed') -> {error,count}
+//   pipeline_mode:   .update({pipeline_mode}).eq('id',x).or('<guard>')                            -> {error}
+function createMockSupabase({ wfCount = 1, wfError = null, modeError = null } = {}) {
+  const calls = { wfPatch: null, modePatch: null, modeOrFilter: null, modeUpdateCount: 0 };
+  return {
+    _calls: calls,
+    from: vi.fn(() => ({
+      update: vi.fn((patch) => {
+        const isMode = Object.prototype.hasOwnProperty.call(patch, 'pipeline_mode');
+        if (isMode) { calls.modePatch = patch; calls.modeUpdateCount += 1; }
+        else { calls.wfPatch = patch; }
+        const chain = {
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => Promise.resolve({ error: wfError, count: wfCount })),
+          or: vi.fn((filter) => { calls.modeOrFilter = filter; return Promise.resolve({ error: modeError }); }),
+        };
+        return chain;
+      }),
+    })),
+  };
+}
+
+const mockLogger = () => ({ log: vi.fn(), warn: vi.fn() });
+const terminalArgs = (supabase, logger) => ({
+  supabase, ventureId: 'venture-uuid-1', stageNumber: 26,
+  output: { lifecycle_terminal: 'request' }, validation: { valid: true },
+  dryRun: false, logger,
+});
+
+describe('FR-1: processLifecycleTerminal building->operations transition', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets pipeline_mode=operations (guarded building/null) on a successful S26 terminal completion', async () => {
+    checkExitGates.mockResolvedValue({ allowed: true });
+    const supabase = createMockSupabase({ wfCount: 1 });
+    const logger = mockLogger();
+
+    const result = await processLifecycleTerminal(terminalArgs(supabase, logger));
+
+    expect(result).toEqual({ handled: true, completed: true, idempotent: false });
+    expect(supabase._calls.wfPatch).toMatchObject({ workflow_status: 'completed' });
+    expect(supabase._calls.modePatch).toEqual({ pipeline_mode: 'operations' });
+    // No-clobber: the transition only targets ventures still in building (or null), never a later mode.
+    expect(supabase._calls.modeOrFilter).toBe('pipeline_mode.eq.building,pipeline_mode.is.null');
+  });
+
+  it('is idempotent: an already-completed venture (count=0) does NOT run the pipeline_mode transition', async () => {
+    checkExitGates.mockResolvedValue({ allowed: true });
+    const supabase = createMockSupabase({ wfCount: 0 });
+    const logger = mockLogger();
+
+    const result = await processLifecycleTerminal(terminalArgs(supabase, logger));
+
+    expect(result).toEqual({ handled: true, completed: false, idempotent: true });
+    expect(supabase._calls.modeUpdateCount).toBe(0);
+    expect(supabase._calls.modePatch).toBeNull();
+  });
+
+  it('is non-blocking: a pipeline_mode UPDATE error does NOT fail the completed terminal', async () => {
+    checkExitGates.mockResolvedValue({ allowed: true });
+    const supabase = createMockSupabase({ wfCount: 1, modeError: { message: 'transient' } });
+    const logger = mockLogger();
+
+    const result = await processLifecycleTerminal(terminalArgs(supabase, logger));
+
+    // workflow_status completion still stands; the mode failure is warned, not thrown.
+    expect(result).toEqual({ handled: true, completed: true, idempotent: false });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('pipeline_mode'));
+  });
+
+  it('does not transition when exit-gates block the terminal', async () => {
+    checkExitGates.mockResolvedValue({ allowed: false, blocked_by: ['gate-x'] });
+    const supabase = createMockSupabase({ wfCount: 1 });
+    const logger = mockLogger();
+
+    const result = await processLifecycleTerminal(terminalArgs(supabase, logger));
+
+    expect(result).toMatchObject({ handled: true, completed: false, blockedBy: ['gate-x'] });
+    expect(supabase._calls.modeUpdateCount).toBe(0);
+    expect(supabase._calls.wfPatch).toBeNull();
+  });
+
+  it('no-ops on non-terminal / dryRun / invalid input (guard clause)', async () => {
+    const supabase = createMockSupabase();
+    const logger = mockLogger();
+    const r1 = await processLifecycleTerminal({ ...terminalArgs(supabase, logger), output: { lifecycle_terminal: 'none' } });
+    const r2 = await processLifecycleTerminal({ ...terminalArgs(supabase, logger), dryRun: true });
+    const r3 = await processLifecycleTerminal({ ...terminalArgs(supabase, logger), validation: { valid: false } });
+    for (const r of [r1, r2, r3]) expect(r).toEqual({ handled: false, completed: false, idempotent: false });
+    expect(checkExitGates).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Child of SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001 (post-build lifecycle redesign). Ships the EHG_Engineer backend foundation: the previously-missing building->operations pipeline_mode transition.

## What
- **FR-1 (keystone)**: `processLifecycleTerminal()` (lib/eva/stage-execution-engine.js) now sets `ventures.pipeline_mode='operations'` on a successful S26 terminal completion, in addition to `workflow_status='completed'`. Guarded (only transitions from `building`/null — never demotes a venture already in a later mode), idempotent, non-blocking on error. +5 regression tests (all pass); existing stage-execution-engine tests 7/7 green.
- **FR-2**: aligned docs/06_deployment/eva-operations-mode.md to the real transition point (the doc claimed an automatic Stage-25 flip of a 25-stage pipeline that no code performed).

## Why
The lifecycle docs claimed the transition was automatic, but no code performed it — ventures stayed in `building` forever after launch, so the Operations dashboard never took ownership. Verified live: processLifecycleTerminal set only workflow_status; pipeline_mode appeared nowhere in the file.

## Split
FR-3 (EHG useVentureMode verification test) and FR-4/5/6 (EHG OperationsMode/Stage25/Stage26 UI de-duplication) are substantial cross-repo frontend work and are split to a follow-up child SD to keep this PR reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)