### PR TITLE
fix(QF-20260609-564): Fix dead sd-start.js resume-integrity queries (sd_key->sd_id)

### DIFF
--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -257,15 +257,25 @@ function getPhaseContextFile(phase) {
  * @returns {{ valid: boolean, lastHandoff: Object|null, message: string, recoveryOptions: string[] }}
  */
 async function verifyHandoffIntegrity(sdUuid) {
+  // QF-20260609-564: sd_phase_handoffs is keyed by sd_id (the SD UUID). The prior query
+  // filtered the wrong (non-existent) text-key column, so every call hit the error path and
+  // silently returned valid:true, disabling resume-integrity verification entirely (the
+  // accepted/rejected/missing-handoff checks below never ran). Correct pattern matches
+  // sd-start.js:~1465 and sd-recover.js:53.
   const { data: handoffs, error } = await supabase
     .from('sd_phase_handoffs')
-    .select('id, sd_key, from_phase, to_phase, status, created_at, rejection_reason, resolved_at')
-    .eq('sd_key', sdUuid)
+    .select('id, from_phase, to_phase, status, created_at, rejection_reason, resolved_at')
+    .eq('sd_id', sdUuid)
     .order('created_at', { ascending: false })
     .limit(1);
 
   if (error) {
-    return { valid: true, lastHandoff: null, message: 'Could not query handoffs (proceeding)', recoveryOptions: [] };
+    // QF-20260609-564: surface the error instead of silently swallowing it. Stay fail-open
+    // (the consumer hard-exits on valid:false without --force, so a transient DB hiccup must
+    // not block resume), but log loudly so a real/persistent query error can never hide again
+    // the way the dead-column bug did.
+    console.warn(`⚠️  verifyHandoffIntegrity: handoff query failed (${error.code || 'error'}: ${error.message}) — proceeding without integrity check`);
+    return { valid: true, lastHandoff: null, message: `Could not query handoffs: ${error.message} (proceeding)`, recoveryOptions: [] };
   }
 
   if (!handoffs || handoffs.length === 0) {
@@ -1789,7 +1799,7 @@ async function main() {
     const { data: handoffRows } = await supabase
       .from('sd_phase_handoffs')
       .select('id', { count: 'exact', head: false })
-      .eq('sd_key', sd.id);
+      .eq('sd_id', sd.id); // QF-20260609-564: keyed by sd_id (UUID), not the non-existent text-key column (the >=3-handoffs warning never fired)
     const handoffCount = handoffRows?.length || 0;
     if (handoffCount >= 3) {
       console.log(`\n${colors.yellow}⚠️  PRIOR WORK WARNING: This SD has ${handoffCount} prior handoffs.${colors.reset}`);

--- a/tests/unit/sd-start-handoff-integrity-query.test.js
+++ b/tests/unit/sd-start-handoff-integrity-query.test.js
@@ -1,0 +1,53 @@
+// QF-20260609-564: sd-start.js queried the non-existent column sd_phase_handoffs.sd_key in two
+// places (verifyHandoffIntegrity + the >=3-handoffs PRIOR WORK warning), so both silently died:
+// verifyHandoffIntegrity's error path returned valid:true (resume-integrity verification disabled)
+// and the "another session built this" warning never fired. The real FK is sd_id (UUID).
+// These are static source-pins (verifyHandoffIntegrity is an un-exported internal in a large CLI
+// script) — matching the tests/unit/harness/block-claims-cancelled.test.js convention.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const src = fs.readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf-8');
+
+describe('QF-20260609-564: sd-start.js handoff queries use sd_id, not sd_key', () => {
+  it('verifyHandoffIntegrity filters sd_phase_handoffs by sd_id (not the non-existent sd_key column)', () => {
+    const start = src.indexOf('async function verifyHandoffIntegrity');
+    expect(start).toBeGreaterThan(0);
+    const fnBlock = src.slice(start, start + 1200);
+    // The integrity query must filter by sd_id...
+    expect(fnBlock).toMatch(/\.eq\(['"]sd_id['"],\s*sdUuid\)/);
+    // ...and must NOT reference the non-existent sd_key column anywhere in the function.
+    expect(fnBlock).not.toMatch(/sd_key/);
+  });
+
+  it('the PRIOR WORK (>=3 handoffs) warning filters sd_phase_handoffs by sd_id', () => {
+    const idx = src.indexOf('PRIOR WORK WARNING');
+    expect(idx).toBeGreaterThan(0);
+    // Look at the query just above the warning text.
+    const block = src.slice(idx - 400, idx);
+    expect(block).toMatch(/\.from\(['"]sd_phase_handoffs['"]\)/);
+    expect(block).toMatch(/\.eq\(['"]sd_id['"],\s*sd\.id\)/);
+    expect(block).not.toMatch(/\.eq\(['"]sd_key['"]/);
+  });
+
+  it('no sd_phase_handoffs query in sd-start.js filters by sd_key (dead-column regression guard)', () => {
+    // Pair every sd_phase_handoffs .from(...) ... .eq('sd_key', ...) would be a regression.
+    // Simplest robust check: the file must not contain a .eq('sd_key' immediately associated
+    // with handoff queries. Since sd-start.js only ever queries sd_phase_handoffs by sd_id now,
+    // assert the dead pattern is absent entirely for this column on that table.
+    const deadPattern = /sd_phase_handoffs[\s\S]{0,200}?\.eq\(['"]sd_key['"]/;
+    expect(src).not.toMatch(deadPattern);
+  });
+
+  it('verifyHandoffIntegrity surfaces (logs) a query error instead of silently swallowing it', () => {
+    const start = src.indexOf('async function verifyHandoffIntegrity');
+    const fnBlock = src.slice(start, start + 1200);
+    // The error branch must log the error (no longer a silent return).
+    expect(fnBlock).toMatch(/if \(error\) \{[\s\S]*?console\.(warn|error)\(/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260609-564

**Type:** bug
**Severity:** high

### Issue Description
scripts/sd-start.js verifyHandoffIntegrity (L262-263) and the PRIOR WORK warning (L1789-1792) query non-existent column sd_phase_handoffs.sd_key and silently die (error path returns valid:true); the 'another session built this - find the worktree, do not rebuild' >=3-handoffs warning never fires. Fix both .eq(sd_key,uuid) to .eq(sd_id, sd.id) (correct pattern already at sd-start.js:1465 / sd-recover.js:53); drop sd_key from the L262 select; stop verifyHandoffIntegrity swallowing a real PostgrestError as valid; add a regression test. Context: docs/protocol/README.md (LEO Harness overview).




### Changes
- **Files Changed:** 2
  - scripts/sd-start.js
  - tests/unit/sd-start-handoff-integrity-query.test.js
- **LOC:** 18 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Fixed dead sd_phase_handoffs.sd_key queries (->sd_id) in verifyHandoffIntegrity + PRIOR WORK warning; error path now logs instead of silently returning valid:true. UAT live: .eq(sd_id,<uuid>) returns 7 handoff rows; .eq(sd_key,...) errors 'column does not exist'. 4/4 regression tests pass; node --check OK. Production change 18 LOC sd-start.js; 53-line regression test is QF-mandated scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol