### PR TITLE
fix(SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001): guard coordinator/sweep CLAIM_FIX against orchestrator-parent + dep-blocked dispatch

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -1,0 +1,88 @@
+'use strict';
+/**
+ * Shared SD dispatch-eligibility predicate (SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001).
+ *
+ * Single source of truth for "may this SD be dispatched/claimed onto a worker?" — used by BOTH
+ * the worker-PULL path (scripts/worker-checkin.cjs self_claim) and the coordinator/sweep-PUSH path
+ * (scripts/stale-session-sweep.cjs CLAIM_FIX). Previously the self_claim path guarded
+ * orchestrator-parents + dep-blocked SDs (SD-FDBK-FIX-WORKER-SELF-CLAIM-001) while CLAIM_FIX did
+ * not — a PAT-WRITER-CONSUMER-ASYMMETRY that let coordinator-push route an orchestrator PARENT
+ * (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001) onto a worker. Sharing the predicate prevents the drift
+ * from recurring.
+ *
+ * Eligibility rules (an SD is INELIGIBLE for worker dispatch when):
+ *   - sd_type === 'orchestrator' (a parent — auto-completes on its children; never worker-built), OR
+ *   - any referenced dependency is not status='completed' (dep-blocked).
+ */
+
+/**
+ * Are ALL of this SD's dependencies satisfied (each referenced SD completed)?
+ * The `dependencies` array is heterogeneously shaped across the fleet: plain text
+ * ("SD-X needs Y"), {sd_id:"SD-X"}, {sd_key:"SD-X"}, {sd_key:"none"} sentinel, and free-form
+ * {type,status,dependency} notes with NO SD ref. Each element resolves to a referenced sd_key;
+ * elements with no SD ref (or the "none" sentinel) are non-blocking. Re-implemented here because
+ * v_sd_next_candidates.deps_satisfied is BROKEN for object-shaped deps (it text-compares the whole
+ * JSON object, never matching a completed key).
+ *
+ * Error semantics are caller-selectable so the two dispatch paths can differ safely:
+ *   - default ({ throwOnError:false }) -> returns false on a query error (worker-checkin self_claim:
+ *     conservative skip; never claim a maybe-blocked SD). This preserves the prior behavior exactly.
+ *   - { throwOnError:true } -> rethrows the query error so the sweep's CLAIM_FIX can treat an error
+ *     as "uncertain -> no-op this cycle" rather than "confirmed dep-blocked -> clear the claim".
+ */
+async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
+  const deps = Array.isArray(sd.dependencies) ? sd.dependencies : [];
+  const refKeys = [];
+  for (const e of deps) {
+    let k = null;
+    if (typeof e === 'string') k = e.split(/\s/)[0];
+    else if (e && typeof e === 'object') k = e.sd_id || e.sd_key || null;
+    if (!k || k === 'none' || k === 'None') continue; // no SD ref / sentinel -> non-blocking
+    refKeys.push(k);
+  }
+  if (!refKeys.length) return true;
+  try {
+    const { data, error } = await sb.from('strategic_directives_v2').select('sd_key, status').in('sd_key', refKeys);
+    if (error) throw error;
+    const statusByKey = Object.fromEntries((data || []).map((r) => [r.sd_key, r.status]));
+    return refKeys.every((k) => statusByKey[k] === 'completed');
+  } catch (e) {
+    if (throwOnError) throw e;
+    return false; // conservative: don't claim a maybe-blocked SD on a query error
+  }
+}
+
+/**
+ * Evaluate whether an SD may be dispatched/claimed onto a worker. Returns a discriminated verdict
+ * so callers can distinguish CONFIRMED-ineligible from a query error:
+ *   { eligible: true }
+ *   { eligible: false, reason: 'orchestrator_parent' | 'dep_blocked' | 'sd_not_found' }
+ * THROWS on a query error (the lookup or the dep-status check) — the caller decides how to degrade.
+ * `sdKey` is the sd_KEY string (v_sd_next_candidates.sd_id holds the key; claude_sessions.sd_key too).
+ */
+async function evaluateDispatchEligibility(sb, sdKey) {
+  const { data, error } = await sb
+    .from('strategic_directives_v2')
+    .select('sd_type, dependencies')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (error) throw error;                                       // uncertain -> caller decides
+  if (!data) return { eligible: false, reason: 'sd_not_found' }; // can't verify -> not dispatchable
+  if (data.sd_type === 'orchestrator') return { eligible: false, reason: 'orchestrator_parent' };
+  const depsOk = await draftDepsSatisfied(sb, data, { throwOnError: true }); // propagate dep-query errors
+  return depsOk ? { eligible: true } : { eligible: false, reason: 'dep_blocked' };
+}
+
+/**
+ * Boolean wrapper preserving the worker-checkin self_claim contract: false for orchestrator parents,
+ * dep-blocked SDs, not-found, OR any query error (conservative: never claim on uncertainty).
+ */
+async function baselinedCandidateEligible(sb, sdKey) {
+  try {
+    return (await evaluateDispatchEligibility(sb, sdKey)).eligible;
+  } catch {
+    return false; // conservative: skip this candidate on a query error
+  }
+}
+
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible };

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -26,6 +26,9 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
+// SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
+// worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
+const { evaluateDispatchEligibility } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): single shared definition of which
 // classified session statuses count as "currently holding the SD claim" — used
 // by BOTH the available-to-claim filter and the worker-render filter below so
@@ -1365,22 +1368,59 @@ async function main() {
       continue;
     }
 
-    // Fix broken claim: session thinks it owns SD but SD doesn't know
-    if (sd.claiming_session_id !== s.session_id) {
-      await supabase
-        .from('strategic_directives_v2')
-        .update({ claiming_session_id: s.session_id, is_working_on: true })
-        .eq('sd_key', s.sd_key)
-        .select();
-      actions.push('CLAIM_FIX: set claiming_session_id on ' + s.sd_key + ' → ' + s.session_id.substring(0, 20));
-    } else if (!sd.is_working_on) {
-      // Fix incomplete claim: claiming_session_id matches but is_working_on is false
-      await supabase
-        .from('strategic_directives_v2')
-        .update({ is_working_on: true })
-        .eq('sd_key', s.sd_key)
-        .select();
-      actions.push('CLAIM_FIX: set is_working_on=true on ' + s.sd_key);
+    // Fix broken/incomplete claim — but FIRST gate on dispatch-eligibility.
+    // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: the worker self_claim path refuses orchestrator
+    // PARENTS + dep-blocked SDs (SD-FDBK-FIX-WORKER-SELF-CLAIM-001); CLAIM_FIX did not, so it
+    // re-affirmed a stale sd_key pointing at an orchestrator parent onto the worker (observed live:
+    // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001). Reuse the SHARED predicate. Tri-state:
+    //   confirmed-ineligible -> bilateral clear (like the terminal-status path above);
+    //   query error           -> no-op this cycle (NEVER clear a legit claim on a transient error);
+    //   eligible              -> existing re-assert (unchanged).
+    const needsClaimFix = sd.claiming_session_id !== s.session_id || !sd.is_working_on;
+    if (needsClaimFix) {
+      let verdict;
+      try {
+        verdict = await evaluateDispatchEligibility(supabase, s.sd_key);
+      } catch (eligErr) {
+        warnings.push('CLAIM_FIX: eligibility check errored for ' + s.sd_key + ' — skipped this cycle (' + eligErr.message + ')');
+        continue;
+      }
+      if (!verdict.eligible) {
+        // Orchestrator parent / dep-blocked / not-found: never re-affirm onto a worker. Clear the
+        // session's stale sd_key (bilateral release), mirroring the terminal-status clear above.
+        await supabase
+          .from('claude_sessions')
+          .update({
+            sd_key: null,
+            status: s.status === 'ACTIVE' ? 'idle' : 'released',
+            released_at: now.toISOString(),
+            released_reason: 'SWEEP_SD_INELIGIBLE_CLAIM_FIX',
+            worktree_path: null,
+            worktree_branch: null,
+            current_branch: null,
+          })
+          .eq('session_id', s.session_id)
+          .eq('sd_key', s.sd_key); // race guard: only clear if still pointing at this SD
+        actions.push('CLAIM_FIX: cleared stale sd_key on session ' + s.session_id.substring(0, 20) + ' (SD ' + s.sd_key + ' ineligible: ' + verdict.reason + ')');
+        continue;
+      }
+      // Eligible -> existing re-assert behavior (unchanged).
+      if (sd.claiming_session_id !== s.session_id) {
+        await supabase
+          .from('strategic_directives_v2')
+          .update({ claiming_session_id: s.session_id, is_working_on: true })
+          .eq('sd_key', s.sd_key)
+          .select();
+        actions.push('CLAIM_FIX: set claiming_session_id on ' + s.sd_key + ' → ' + s.session_id.substring(0, 20));
+      } else if (!sd.is_working_on) {
+        // Fix incomplete claim: claiming_session_id matches but is_working_on is false
+        await supabase
+          .from('strategic_directives_v2')
+          .update({ is_working_on: true })
+          .eq('sd_key', s.sd_key)
+          .select();
+        actions.push('CLAIM_FIX: set is_working_on=true on ' + s.sd_key);
+      }
     }
   }
 

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -28,6 +28,9 @@
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const ws = require('../lib/fleet/worker-status.cjs');
 const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cjs');
+// SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
+// scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
+const { draftDepsSatisfied, baselinedCandidateEligible } = require('../lib/fleet/claim-eligibility.cjs');
 
 const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
 const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
@@ -202,61 +205,14 @@ async function selfClaimQuickFix(sb, sessionId, base) {
 const DRAFT_CANDIDATE_LIMIT = 10;
 const PRIORITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
 
-/**
- * Are ALL of this SD's dependencies satisfied (each referenced SD completed)?
- * The `dependencies` array is heterogeneously shaped across the fleet: plain text
- * ("SD-X needs Y"), {sd_id:"SD-X"}, {sd_key:"SD-X"}, {sd_key:"none"} sentinel, and free-form
- * {type,status,dependency} notes with NO SD ref. Each element resolves to a referenced sd_key;
- * elements with no SD ref (or the "none" sentinel) are non-blocking. We re-implement this here
- * because v_sd_next_candidates.deps_satisfied is BROKEN for object-shaped deps (it text-compares
- * the whole JSON object, never matching a completed key). Conservative on error: returns false.
- */
-async function draftDepsSatisfied(sb, sd) {
-  const deps = Array.isArray(sd.dependencies) ? sd.dependencies : [];
-  const refKeys = [];
-  for (const e of deps) {
-    let k = null;
-    if (typeof e === 'string') k = e.split(/\s/)[0];
-    else if (e && typeof e === 'object') k = e.sd_id || e.sd_key || null;
-    if (!k || k === 'none' || k === 'None') continue; // no SD ref / sentinel -> non-blocking
-    refKeys.push(k);
-  }
-  if (!refKeys.length) return true;
-  try {
-    const { data } = await sb.from('strategic_directives_v2').select('sd_key, status').in('sd_key', refKeys);
-    const statusByKey = Object.fromEntries((data || []).map((r) => [r.sd_key, r.status]));
-    return refKeys.every((k) => statusByKey[k] === 'completed');
-  } catch {
-    return false; // conservative: don't claim a maybe-blocked SD on a query error
-  }
-}
-
-/**
- * SD-FDBK-FIX-WORKER-SELF-CLAIM-001: gate a baselined v_sd_next_candidates row (step 6) before
- * self-claiming it. The view surfaces deps_satisfied=false rows AND orchestrator PARENTS, and the
- * self-claim loop called claim_sd WITHOUT filtering on either (claim_sd enforces neither — it is
- * advisory-only). Result after the baseline populated 2026-06-07: a worker self-claimed a blocked
- * child (depends_on an in-flight SD on the same write-surface) and another self-claimed an
- * orchestrator PARENT (parents auto-complete on their children — must never be worker-claimed).
- * Re-check sd_type + dependencies against strategic_directives_v2 — the SAME guard step 6.25 already
- * applies — because v_sd_next_candidates.deps_satisfied is BROKEN for object-shaped deps (see
- * draftDepsSatisfied). Conservative: any uncertainty -> skip the candidate (false), never claim.
- * `sdKey` is the v_sd_next_candidates.sd_id column, which holds the sd_KEY string (bi.sd_id=sd.sd_key).
- */
-async function baselinedCandidateEligible(sb, sdKey) {
-  try {
-    const { data } = await sb
-      .from('strategic_directives_v2')
-      .select('sd_type, dependencies')
-      .eq('sd_key', sdKey)
-      .maybeSingle();
-    if (!data) return false;                            // can't verify -> don't claim
-    if (data.sd_type === 'orchestrator') return false;  // never claim an orchestrator parent
-    return await draftDepsSatisfied(sb, data);          // every referenced dep must be completed
-  } catch {
-    return false; // conservative: skip this candidate on a query error (fall through to the next)
-  }
-}
+// SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: draftDepsSatisfied + baselinedCandidateEligible were
+// EXTRACTED to ../lib/fleet/claim-eligibility.cjs (required above) so the worker-PULL self_claim path
+// (here) and the coordinator/sweep-PUSH CLAIM_FIX path (scripts/stale-session-sweep.cjs) share ONE
+// eligibility predicate. CLAIM_FIX previously lacked the orchestrator-parent + dep-blocked guard the
+// self_claim path had (SD-FDBK-FIX-WORKER-SELF-CLAIM-001) — a PAT-WRITER-CONSUMER-ASYMMETRY that let
+// coordinator-push route an orchestrator PARENT onto a worker. Self_claim behavior here is unchanged:
+// baselinedCandidateEligible(sb, sdKey) still returns false for orchestrator parents, dep-blocked SDs,
+// not-found, and on any query error (conservative skip).
 
 /**
  * Self-claim tier for claimable UN-BASELINED draft SDs. v_sd_next_candidates is built from

--- a/tests/unit/claim-eligibility.test.js
+++ b/tests/unit/claim-eligibility.test.js
@@ -1,0 +1,144 @@
+// Tests for SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001
+// lib/fleet/claim-eligibility.cjs — the SHARED dispatch-eligibility predicate used by BOTH
+// worker-checkin.cjs (self_claim) and stale-session-sweep.cjs (CLAIM_FIX). Proves: orchestrator
+// parents + dep-blocked SDs are ineligible; leaf drafts with satisfied deps are eligible; the
+// tri-state error semantics differ correctly (boolean wrapper = false-on-error for worker parity;
+// evaluateDispatchEligibility THROWS so CLAIM_FIX can no-op instead of clearing a legit claim).
+
+import { describe, it, expect } from 'vitest';
+
+const { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible } = require('../../lib/fleet/claim-eligibility.cjs');
+
+// Minimal supabase stub supporting both query chains the predicate uses:
+//   .from(t).select(c).eq('sd_key', k).maybeSingle()  -> { data, error }
+//   .from(t).select(c).in('sd_key', arr)              -> { data, error }
+function makeSb(sdRows, opts = {}) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle: async () => {
+                  if (opts.errorOnSingle) return { data: null, error: { message: 'single boom' } };
+                  return { data: null, error: null }; // unused path in these tests (eq+maybeSingle handled via _key below)
+                },
+              };
+            },
+            in: async (_col, arr) => {
+              if (opts.errorOnIn) return { data: null, error: { message: 'deps boom' } };
+              const data = arr.map((k) => (sdRows[k] ? { sd_key: k, status: sdRows[k].status } : null)).filter(Boolean);
+              return { data, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+// evaluateDispatchEligibility uses .eq('sd_key', sdKey).maybeSingle(); give the stub the key.
+function makeSbForEligibility(sdRows, opts = {}) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            eq(_col, val) {
+              return {
+                maybeSingle: async () => {
+                  if (opts.errorOnSingle) return { data: null, error: { message: 'single boom' } };
+                  const row = sdRows[val];
+                  return { data: row ? { sd_type: row.sd_type, dependencies: row.dependencies || [] } : null, error: null };
+                },
+              };
+            },
+            in: async (_col, arr) => {
+              if (opts.errorOnIn) return { data: null, error: { message: 'deps boom' } };
+              const data = arr.map((k) => (sdRows[k] ? { sd_key: k, status: sdRows[k].status } : null)).filter(Boolean);
+              return { data, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('draftDepsSatisfied', () => {
+  it('true when there are no dependencies', async () => {
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [] })).toBe(true);
+  });
+  it('true when every referenced dep is completed (object + string shapes)', async () => {
+    const sb = makeSb({ 'SD-A': { status: 'completed' }, 'SD-B': { status: 'completed' } });
+    expect(await draftDepsSatisfied(sb, { dependencies: [{ sd_key: 'SD-A' }, 'SD-B needs prep'] })).toBe(true);
+  });
+  it('false when a referenced dep is not completed', async () => {
+    const sb = makeSb({ 'SD-A': { status: 'in_progress' } });
+    expect(await draftDepsSatisfied(sb, { dependencies: [{ sd_id: 'SD-A' }] })).toBe(false);
+  });
+  it('treats the "none" sentinel and ref-less notes as non-blocking', async () => {
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [{ sd_key: 'none' }, { type: 'note' }] })).toBe(true);
+  });
+  it('default: returns false on a deps-query error (worker-checkin conservative skip)', async () => {
+    const sb = makeSb({}, { errorOnIn: true });
+    expect(await draftDepsSatisfied(sb, { dependencies: [{ sd_key: 'SD-A' }] })).toBe(false);
+  });
+  it('throwOnError:true: rethrows the deps-query error (sweep tri-state)', async () => {
+    const sb = makeSb({}, { errorOnIn: true });
+    await expect(draftDepsSatisfied(sb, { dependencies: [{ sd_key: 'SD-A' }] }, { throwOnError: true })).rejects.toBeTruthy();
+  });
+});
+
+describe('evaluateDispatchEligibility (discriminated verdict; throws on query error)', () => {
+  it('orchestrator parent -> ineligible(orchestrator_parent)', async () => {
+    const sb = makeSbForEligibility({ 'SD-ORCH-001': { sd_type: 'orchestrator', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-ORCH-001')).toEqual({ eligible: false, reason: 'orchestrator_parent' });
+  });
+  it('dep-blocked leaf -> ineligible(dep_blocked)', async () => {
+    const sb = makeSbForEligibility({ 'SD-CHILD-001': { sd_type: 'bugfix', dependencies: [{ sd_key: 'SD-DEP' }] }, 'SD-DEP': { status: 'in_progress' } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-CHILD-001')).toEqual({ eligible: false, reason: 'dep_blocked' });
+  });
+  it('leaf with satisfied deps -> eligible', async () => {
+    const sb = makeSbForEligibility({ 'SD-OK-001': { sd_type: 'bugfix', dependencies: [{ sd_key: 'SD-DEP' }] }, 'SD-DEP': { status: 'completed' } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-OK-001')).toEqual({ eligible: true });
+  });
+  it('leaf with no deps -> eligible', async () => {
+    const sb = makeSbForEligibility({ 'SD-OK-002': { sd_type: 'feature', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-OK-002')).toEqual({ eligible: true });
+  });
+  it('not-found -> ineligible(sd_not_found)', async () => {
+    expect(await evaluateDispatchEligibility(makeSbForEligibility({}), 'SD-GONE')).toEqual({ eligible: false, reason: 'sd_not_found' });
+  });
+  it('lookup error -> THROWS (so CLAIM_FIX can no-op rather than clear a legit claim)', async () => {
+    const sb = makeSbForEligibility({}, { errorOnSingle: true });
+    await expect(evaluateDispatchEligibility(sb, 'SD-X')).rejects.toBeTruthy();
+  });
+});
+
+describe('baselinedCandidateEligible (boolean wrapper; false-on-error = worker-checkin parity)', () => {
+  it('orchestrator parent -> false', async () => {
+    const sb = makeSbForEligibility({ 'SD-ORCH-001': { sd_type: 'orchestrator', dependencies: [] } });
+    expect(await baselinedCandidateEligible(sb, 'SD-ORCH-001')).toBe(false);
+  });
+  it('dep-blocked -> false', async () => {
+    const sb = makeSbForEligibility({ 'SD-C': { sd_type: 'bugfix', dependencies: [{ sd_key: 'SD-DEP' }] }, 'SD-DEP': { status: 'draft' } });
+    expect(await baselinedCandidateEligible(sb, 'SD-C')).toBe(false);
+  });
+  it('leaf with deps satisfied -> true', async () => {
+    const sb = makeSbForEligibility({ 'SD-OK': { sd_type: 'bugfix', dependencies: [] } });
+    expect(await baselinedCandidateEligible(sb, 'SD-OK')).toBe(true);
+  });
+  it('not-found -> false', async () => {
+    expect(await baselinedCandidateEligible(makeSbForEligibility({}), 'SD-GONE')).toBe(false);
+  });
+  it('lookup error -> false (conservative skip, NOT a throw)', async () => {
+    const sb = makeSbForEligibility({}, { errorOnSingle: true });
+    expect(await baselinedCandidateEligible(sb, 'SD-X')).toBe(false);
+  });
+  it('deps-query error -> false (conservative skip)', async () => {
+    const sb = makeSbForEligibility({ 'SD-C': { sd_type: 'bugfix', dependencies: [{ sd_key: 'SD-DEP' }] } }, { errorOnIn: true });
+    expect(await baselinedCandidateEligible(sb, 'SD-C')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Closes a PAT-WRITER-CONSUMER-ASYMMETRY between the two claim-dispatch paths. The worker **self_claim** path (worker-checkin.cjs) refuses to dispatch orchestrator **parents** and dep-blocked SDs (shipped via SD-FDBK-FIX-WORKER-SELF-CLAIM-001), but the coordinator/sweep **CLAIM_FIX** re-assert path in `stale-session-sweep.cjs` did not — so a stale `sd_key` pointing at an orchestrator parent got re-affirmed onto a worker. **Observed live this session**: the sweep routed orchestrator parent `SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001` to a worker.

## Fix
- **NEW `lib/fleet/claim-eligibility.cjs`** — single shared eligibility predicate:
  - `draftDepsSatisfied(sb, sd, {throwOnError})` — every referenced dep completed (heterogeneous dep shapes).
  - `evaluateDispatchEligibility(sb, sdKey)` → `{eligible, reason}`; **THROWS on query error**.
  - `baselinedCandidateEligible(sb, sdKey)` → boolean, **false-on-error** (worker-checkin parity wrapper).
- **worker-checkin.cjs** imports the shared predicate; local copies removed (behavior-preserving; `module.exports` surface unchanged).
- **stale-session-sweep.cjs** CLAIM_FIX re-assert is now gated by a **tri-state**:
  - confirmed-ineligible (orchestrator / dep-blocked / not-found) → **bilateral clear** the stale `sd_key` (`released_reason='SWEEP_SD_INELIGIBLE_CLAIM_FIX'`), mirroring the existing terminal-status path;
  - **query error → no-op this cycle** (never clears a legit claim on a transient error);
  - eligible → existing re-assert (unchanged). Terminal-status clear unchanged.

## Verification
- 90/90 unit tests pass (new `tests/unit/claim-eligibility.test.js` + the full `worker-checkin` suite proving the refactor is behavior-preserving + the existing sweep suites proving no regression). +16 adjacent sweep-guard tests green.
- TESTING sub-agent PASS (92); net-zero (mocked client, no DB writes); `node --check` clean on all 3 files.
- Code-only, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)