### PR TITLE
feat(SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001): LOOP_EXPIRY_WARNING + STALLED_LOOP detectors

### DIFF
--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -40,6 +40,9 @@ function resolveThresholds(env) {
     stuckWorkerMs: (Number(env.COORD_STUCK_WORKER_X_MIN) || 60) * 60 * 1000,
     // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: grace window before a running session on stale code is flagged.
     deployGapMs: (Number(env.COORD_DEPLOY_GAP_MIN) || 240) * 60 * 1000,
+    // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: warn at 6 days (7-day hard-expiry looms); "looks alive" = 10 min.
+    loopExpiryWarnMs: (Number(env.COORD_LOOP_EXPIRY_WARN_MIN) || 8640) * 60 * 1000,
+    stalledLoopFreshMs: (Number(env.COORD_STALLED_LOOP_FRESH_MIN) || 10) * 60 * 1000,
   };
 }
 
@@ -97,7 +100,8 @@ async function gatherDetectorInputs(supabase, opts) {
     const { data } = await supabase
       .from('claude_sessions')
       // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: + created_at (immutable session-start anchor for DEPLOY_GAP).
-      .select('session_id, sd_key, status, heartbeat_at, metadata, current_phase, created_at');
+      // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: + loop_state, expected_silence_until (loop-liveness detectors).
+      .select('session_id, sd_key, status, heartbeat_at, metadata, current_phase, created_at, loop_state, expected_silence_until');
     sessions = data || [];
   } catch (_) { sessions = []; }
 
@@ -108,7 +112,9 @@ async function gatherDetectorInputs(supabase, opts) {
   bundle.idleWorkers = sessions.filter((s) => !s.sd_key && HOLDING_STATUSES.has(s.status) && fresh(s)).length;
   // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: preserve created_at + metadata so detectDeployGap can
   // anchor on session start time and resolve role.
-  bundle.sessions = sessions.filter((s) => HOLDING_STATUSES.has(s.status)).map((s) => ({ session_id: s.session_id, sd_key: s.sd_key, created_at: s.created_at, metadata: s.metadata }));
+  // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: also preserve loop_state, heartbeat_at, expected_silence_until
+  // so detectLoopExpiry / detectStalledLoop can anchor on loop liveness.
+  bundle.sessions = sessions.filter((s) => HOLDING_STATUSES.has(s.status)).map((s) => ({ session_id: s.session_id, sd_key: s.sd_key, created_at: s.created_at, metadata: s.metadata, loop_state: s.loop_state, heartbeat_at: s.heartbeat_at, expected_silence_until: s.expected_silence_until }));
   // Latest-merge times per role for DEPLOY_GAP (fail-open → {} on any error; repoRoot = repo top from this file).
   try { bundle.mergesByRole = computeMergesByRole(require('path').resolve(__dirname, '../..')); } catch (_) { bundle.mergesByRole = {}; }
 
@@ -217,6 +223,9 @@ async function runAndLogDetectors(supabase, data, opts) {
       stuckWorkerMs: thresholds.stuckWorkerMs,
       priorPhases: opts.priorPhases,
       deployGapMs: thresholds.deployGapMs, // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001
+      // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001
+      loopExpiryWarnMs: thresholds.loopExpiryWarnMs,
+      stalledLoopFreshMs: thresholds.stalledLoopFreshMs,
     });
   } catch (e) {
     console.warn(`   ⚠️  [COORD_DETECTORS_THREW] ${(e && e.message) || e} (non-fatal)`);

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -243,10 +243,98 @@ function detectDeployGap(data, opts) {
   };
 }
 
+// SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: two read-only loop-liveness detectors so the
+// supervisory layer gets programmatic warning before two silent-failure modes take it dark.
+/** /loop sessions live in these loop_state values (active = looping, awaiting_tick = parked). */
+const LOOP_ACTIVE_STATES = Object.freeze(['active', 'awaiting_tick']);
+/** Default LOOP_EXPIRY_WARNING threshold (ms): 6 days — the verified hard-expiry is 7 days. */
+const DEFAULT_LOOP_EXPIRY_WARN_MS = 6 * 24 * 60 * 60 * 1000;
+/** Default STALLED_LOOP freshness window (ms): a heartbeat within 10 min "looks alive". */
+const DEFAULT_STALLED_LOOP_FRESH_MS = 10 * 60 * 1000;
+
+/**
+ * LOOP_EXPIRY_WARNING — a /loop session (worker or coordinator cron) approaching the verified
+ * 7-day hard-expiry, after which it fires once more and self-deletes with no warning. Flags
+ * sessions whose (now - created_at) exceeds an env-tunable warn threshold (~6 days) AND whose
+ * loop_state is active/awaiting_tick. Modeled on detectDeployGap (created_at is the immutable
+ * session-start anchor). PURE — no I/O. Fail-open: a session with no usable created_at, or not
+ * in a loop state, is SKIPPED (never a false flag).
+ * @param {{ sessions?: Array, now?: number }} data
+ * @param {{ warnMs?: number }} [opts]
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectLoopExpiry(data, opts) {
+  opts = opts || {};
+  const now = (data && data.now) ?? Date.now();
+  const warnMs = opts.warnMs ?? DEFAULT_LOOP_EXPIRY_WARN_MS;
+  const expiring = [];
+  for (const s of ((data && data.sessions) || [])) {
+    if (!s || !LOOP_ACTIVE_STATES.includes(s.loop_state)) continue; // not a live loop → skip
+    const startMs = toMs(s.created_at);
+    if (!startMs) continue;                  // unknown start → skip (fail-open)
+    const ageMs = now - startMs;
+    if (ageMs < warnMs) continue;            // not yet near the 7-day hard-expiry
+    if (expiring.length < 10) {
+      expiring.push({ session_id: s.session_id, loop_state: s.loop_state, created_at: s.created_at, age_ms: ageMs });
+    }
+  }
+  if (expiring.length === 0) {
+    return { matched: false, reason: 'all_loops_within_lifetime', evidence: { threshold_ms: warnMs } };
+  }
+  const maxAge = expiring.reduce((m, e) => Math.max(m, e.age_ms), 0);
+  return {
+    matched: true,
+    reason: 'loop_sessions_approaching_hard_expiry',
+    evidence: { expiring_count: expiring.length, max_age_ms: maxAge, threshold_ms: warnMs, samples: expiring, advisory: 're-launch the session before the 7-day hard-expiry self-deletes the loop' },
+  };
+}
+
+/**
+ * STALLED_LOOP — a session that LOOKS alive (loop_state 'active' + a fresh heartbeat) yet holds
+ * NO claim while claimable work waits (unclaimedItems > 0). This is the heartbeat-masks-a-stall
+ * mode documented at docs/protocol/fleet-coordinator-and-worker-behavior.md (a parked-at-a-decision
+ * loop the staleness sweep never reaps). Complements detectStuckWorker (claim-bound; it skips
+ * no-claim sessions). PURE — no I/O. Fail-open: skips sessions with no usable heartbeat; never
+ * throws. Excludes legitimately-parked sessions: loop_state 'awaiting_tick' is not flagged, and a
+ * future-dated expected_silence_until suppresses the flag (no false-positive on parked workers).
+ * @param {{ sessions?: Array, unclaimedItems?: number, now?: number, freshMs?: number }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectStalledLoop(data) {
+  const now = (data && data.now) ?? Date.now();
+  const freshMs = (data && data.freshMs) ?? DEFAULT_STALLED_LOOP_FRESH_MS;
+  const unclaimed = Number((data && data.unclaimedItems) ?? 0);
+  if (unclaimed <= 0) {
+    return { matched: false, reason: 'no_unclaimed_work', evidence: { unclaimed_items: unclaimed } };
+  }
+  const stalled = [];
+  for (const s of ((data && data.sessions) || [])) {
+    if (!s || s.loop_state !== 'active') continue;       // only actively-looping (parked awaiting_tick excluded)
+    if (s.sd_key) continue;                               // holds a claim → not stalled (detectStuckWorker covers it)
+    const silenceUntil = toMs(s.expected_silence_until);
+    if (silenceUntil && silenceUntil > now) continue;     // legitimately parked with a future silence window
+    const hbMs = toMs(s.heartbeat_at);
+    if (!hbMs) continue;                                  // no usable heartbeat → skip (fail-open)
+    const hbAge = now - hbMs;
+    if (hbAge > freshMs) continue;                        // not fresh → looks dead, the staleness sweep handles it
+    if (stalled.length < 10) {
+      stalled.push({ session_id: s.session_id, loop_state: s.loop_state, heartbeat_age_ms: hbAge });
+    }
+  }
+  if (stalled.length === 0) {
+    return { matched: false, reason: 'no_stalled_loops', evidence: { unclaimed_items: unclaimed, fresh_ms: freshMs } };
+  }
+  return {
+    matched: true,
+    reason: 'live_loops_holding_no_claim_while_work_waits',
+    evidence: { stalled_count: stalled.length, unclaimed_items: unclaimed, fresh_ms: freshMs, samples: stalled, advisory: 're-paste the wake prompt into these windows (alive but parked with claimable work waiting)' },
+  };
+}
+
 /**
  * Run all detectors over an injected data bundle. PURE — no I/O.
  * @param {object} data
- * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases, deployGapMs }
+ * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases, deployGapMs, loopExpiryWarnMs, stalledLoopFreshMs }
  * @returns {Array<{ event_type: string, severity: string, reason: string, evidence: object }>}
  */
 function runDetectors(data, opts) {
@@ -261,6 +349,9 @@ function runDetectors(data, opts) {
     // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: advisory (severity 'info' — coordination_events.severity
     // CHECK allows only info/warning/critical; DEPLOY_GAP is discriminated by event_type + payload).
     { event_type: 'DEPLOY_GAP', severity: 'info', res: detectDeployGap({ sessions: data && data.sessions, mergesByRole: data && data.mergesByRole, now }, { maxGapMs: opts.deployGapMs }) },
+    // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: loop-liveness detectors (warning; advisory observability).
+    { event_type: 'LOOP_EXPIRY_WARNING', severity: 'warning', res: detectLoopExpiry({ sessions: data && data.sessions, now }, { warnMs: opts.loopExpiryWarnMs }) },
+    { event_type: 'STALLED_LOOP', severity: 'warning', res: detectStalledLoop({ sessions: data && data.sessions, unclaimedItems: data && data.unclaimedItems, now, freshMs: opts.stalledLoopFreshMs }) },
   ];
   return results
     .filter((r) => r.res.matched)
@@ -319,4 +410,10 @@ module.exports = {
   sessionRole,
   ROLE_CODE_PATHS,
   DEFAULT_DEPLOY_GAP_MS,
+  // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001
+  detectLoopExpiry,
+  detectStalledLoop,
+  LOOP_ACTIVE_STATES,
+  DEFAULT_LOOP_EXPIRY_WARN_MS,
+  DEFAULT_STALLED_LOOP_FRESH_MS,
 };

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -17,6 +17,8 @@ import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
 import { sourceableBacklog } from './lib/sourceable-backlog.mjs';
 import { readFileSync } from 'node:fs';
 import { computeReviewHealth } from '../lib/fleet/review-health.mjs';
+// SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: reuse the pure detectors as the single source for the gauges.
+import { detectLoopExpiry, detectStalledLoop } from '../lib/coordinator/detectors.cjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -59,7 +61,8 @@ const stuck = unclaimed.filter(s => s.status === 'in_progress');
 // predicate (same one coordinator-email-summary.mjs uses, mirroring the dashboard) so the
 // audit's FLOW/LIVENESS gauges stop over-counting Adam / non_fleet / released / never-claimed
 // (ghost) sessions. Previously this only excluded `me` and any heartbeat <15m.
-const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,metadata,claimed_at,worktree_path,continuous_sds_completed').order('heartbeat_at', { ascending: false }).limit(60);
+// SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: + created_at, expected_silence_until for the loop-liveness gauges.
+const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,metadata,claimed_at,worktree_path,continuous_sds_completed,created_at,expected_silence_until').order('heartbeat_at', { ascending: false }).limit(60);
 const live = liveFleetWorkers(sessRaw, me, t);
 const builders = live.filter(s => s.sd_key).length;
 const liveIdle = live.filter(s => !s.sd_key).length;
@@ -140,6 +143,22 @@ try {
   loopLine = 'active=' + dist.active + ' awaiting_tick=' + dist.awaiting_tick + ' exited=' + dist.exited + ' null=' + dist.null + (dist.other ? ' other=' + dist.other : '');
 } catch (e) { loopLine = 'unavailable (' + e.message + ')'; }
 
+// (d2) LIVENESS — loop-liveness detectors (SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001).
+// Reuse the pure detectors (single source) over the live workers; fail-open per gauge.
+let loopExpiryLine, stalledLoopLine;
+try {
+  const exp = detectLoopExpiry({ sessions: live, now: t });
+  loopExpiryLine = exp.matched
+    ? exp.evidence.expiring_count + ' loop(s) near the 7d hard-expiry ⚠ re-launch (oldest ' + ageStr(exp.evidence.max_age_ms) + ')'
+    : 'none (all live loops within lifetime)';
+} catch (e) { loopExpiryLine = 'unavailable (' + e.message + ')'; }
+try {
+  const st = detectStalledLoop({ sessions: live, unclaimedItems: unclaimed.length, now: t });
+  stalledLoopLine = st.matched
+    ? st.evidence.stalled_count + ' live loop(s) parked w/o claim while ' + unclaimed.length + ' unclaimed ⚠ re-paste wake prompt'
+    : 'none (' + unclaimed.length + ' unclaimed)';
+} catch (e) { stalledLoopLine = 'unavailable (' + e.message + ')'; }
+
 // (e) DEPENDENCY / CRITICAL-PATH — blocked vs ready, plus stale-blocked anomalies
 let depLine, depStale = [];
 try {
@@ -168,6 +187,8 @@ console.log('  FLOW (aging)    : ' + agingLine);
 for (const a of agingTop) console.log('      ' + a.k + '  [' + a.ph + ']  ' + ageStr(a.age));
 console.log('  FLOW (idle/work): ' + idleWorkLine);
 console.log('  LIVENESS (loop) : ' + loopLine + '  (live workers)');
+console.log('  LIVENESS (expiry): ' + loopExpiryLine);
+console.log('  LIVENESS (stall): ' + stalledLoopLine);
 console.log('  DEPENDENCY      : ' + depLine);
 for (const k of depStale.slice(0, 5)) console.log('      stale-blocked: ' + k);
 

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -12,6 +12,8 @@ import {
   detectReplyStarvation,
   detectStuckWorker,
   detectClaimHalfWrite,
+  detectLoopExpiry,
+  detectStalledLoop,
   runDetectors,
 } from '../../../lib/coordinator/detectors.cjs';
 import {
@@ -104,6 +106,57 @@ describe('detectClaimHalfWrite', () => {
   });
 });
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (d) => new Date(NOW - d * DAY_MS).toISOString();
+
+describe('detectLoopExpiry', () => {
+  it('matches a loop session older than the warn threshold (active or awaiting_tick)', () => {
+    const sessions = [
+      { session_id: 'old-active', loop_state: 'active', created_at: daysAgo(7) },
+      { session_id: 'old-parked', loop_state: 'awaiting_tick', created_at: daysAgo(6.5) },
+    ];
+    const r = detectLoopExpiry({ sessions, now: NOW });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.expiring_count).toBe(2);
+    expect(r.evidence.samples[0].session_id).toBe('old-active');
+  });
+  it('does not match young loops, non-loop states, or unknown created_at (fail-open)', () => {
+    const sessions = [
+      { session_id: 'young', loop_state: 'active', created_at: daysAgo(2) },        // within lifetime
+      { session_id: 'exited', loop_state: 'exited', created_at: daysAgo(30) },       // not a live loop
+      { session_id: 'no-anchor', loop_state: 'active', created_at: null },           // unknown start → skip
+    ];
+    expect(detectLoopExpiry({ sessions, now: NOW }).matched).toBe(false);
+  });
+  it('is env-tunable via opts.warnMs', () => {
+    const sessions = [{ session_id: 'mid', loop_state: 'active', created_at: daysAgo(3) }];
+    expect(detectLoopExpiry({ sessions, now: NOW }).matched).toBe(false);                  // default 6d → no
+    expect(detectLoopExpiry({ sessions, now: NOW }, { warnMs: 2 * DAY_MS }).matched).toBe(true); // 2d → yes
+  });
+});
+
+describe('detectStalledLoop', () => {
+  const stalled = { session_id: 'w1', loop_state: 'active', sd_key: null, heartbeat_at: minsAgo(2), expected_silence_until: null };
+  it('matches a live active loop holding no claim while work waits', () => {
+    const r = detectStalledLoop({ sessions: [stalled], unclaimedItems: 3, now: NOW });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.stalled_count).toBe(1);
+    expect(r.evidence.samples[0].session_id).toBe('w1');
+  });
+  it('does not match when there is no unclaimed work', () => {
+    expect(detectStalledLoop({ sessions: [stalled], unclaimedItems: 0, now: NOW }).matched).toBe(false);
+  });
+  it('excludes claimed, parked (awaiting_tick / future silence), and stale-heartbeat sessions', () => {
+    const sessions = [
+      { ...stalled, session_id: 'has-claim', sd_key: 'SD-X' },                                   // holds a claim
+      { ...stalled, session_id: 'parked', loop_state: 'awaiting_tick' },                          // parked, not 'active'
+      { ...stalled, session_id: 'silenced', expected_silence_until: new Date(NOW + 60_000).toISOString() }, // future silence window
+      { ...stalled, session_id: 'stale', heartbeat_at: minsAgo(30) },                             // not fresh → looks dead
+    ];
+    expect(detectStalledLoop({ sessions, unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+});
+
 describe('runDetectors', () => {
   it('returns only matched detectors with event_type + severity', () => {
     const data = {
@@ -114,6 +167,18 @@ describe('runDetectors', () => {
     const matches = runDetectors(data, { now: NOW });
     expect(matches.map((m) => m.event_type)).toEqual(['SPLIT_BRAIN']);
     expect(matches[0].severity).toBe('critical');
+  });
+  it('surfaces LOOP_EXPIRY_WARNING + STALLED_LOOP (both severity warning) when conditions hold', () => {
+    const data = {
+      coordinatorCount: 0, idleWorkers: 0, unclaimedItems: 2,
+      signals: [], claims: [], sdClaims: [],
+      sessions: [
+        { session_id: 'old', loop_state: 'active', created_at: daysAgo(7), sd_key: null, heartbeat_at: minsAgo(1), expected_silence_until: null },
+      ],
+    };
+    const byType = Object.fromEntries(runDetectors(data, { now: NOW }).map((m) => [m.event_type, m]));
+    expect(byType.LOOP_EXPIRY_WARNING?.severity).toBe('warning');
+    expect(byType.STALLED_LOOP?.severity).toBe('warning');
   });
 });
 
@@ -126,6 +191,11 @@ describe('coordDetectorsEnabled', () => {
   it('resolveThresholds honors env overrides with safe defaults', () => {
     expect(resolveThresholds({}).replyStarvationMs).toBe(1800 * 1000);
     expect(resolveThresholds({ COORD_REPLY_STARVATION_T_SEC: '60' }).replyStarvationMs).toBe(60 * 1000);
+    // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001 thresholds: 6-day warn + 10-min freshness defaults, env-tunable.
+    expect(resolveThresholds({}).loopExpiryWarnMs).toBe(8640 * 60 * 1000);
+    expect(resolveThresholds({}).stalledLoopFreshMs).toBe(10 * 60 * 1000);
+    expect(resolveThresholds({ COORD_LOOP_EXPIRY_WARN_MIN: '120' }).loopExpiryWarnMs).toBe(120 * 60 * 1000);
+    expect(resolveThresholds({ COORD_STALLED_LOOP_FRESH_MIN: '5' }).stalledLoopFreshMs).toBe(5 * 60 * 1000);
   });
 });
 


### PR DESCRIPTION
## Summary
Two pure, read-only, fail-open coordinator detectors so the LEO supervisory layer gets programmatic warning before two silent-failure modes take it dark:

- **`detectLoopExpiry`** — flags `/loop` sessions (worker or coordinator cron) past an env-tunable ~6-day warn threshold (`COORD_LOOP_EXPIRY_WARN_MIN`, default 8640 min) before the verified **7-day hard-expiry** self-deletes them. Modeled on `detectDeployGap` (uses immutable `created_at`). Matches `loop_state` ∈ {active, awaiting_tick}.
- **`detectStalledLoop`** — flags a session that *looks* alive (`loop_state==='active'`, fresh heartbeat) but holds **no claim while claimable work waits** (`unclaimedItems>0`) — the heartbeat-masks-a-stall mode. Complements the claim-bound `detectStuckWorker`. **Excludes legitimately-parked sessions**: `awaiting_tick` is not flagged, and a future-dated `expected_silence_until` suppresses the flag (the SD's no-false-positive acceptance criterion).

Both register in `runDetectors` at severity `warning`, wire through `coordination-events.cjs` (thresholds + data gather), and surface as two SRE gauges in `coordinator-audit.mjs`.

## Files
- `lib/coordinator/detectors.cjs` — the two pure detectors + constants + `runDetectors` registration + exports
- `lib/coordinator/coordination-events.cjs` — `resolveThresholds` + `gatherDetectorInputs` select/map + emit-path opts
- `scripts/coordinator-audit.mjs` — two SRE gauge lines (single-source reuse of the detectors)
- `tests/unit/coordinator/detectors.test.js` — +10 cases

## Testing
- **44/44** unit tests pass (`detectors.test.js` + `detectors-deploy-gap.test.js` + `inert-worker.test.js`). TESTING sub-agent verdict PASS (92).
- No DB migration: `coordination_events.event_type` is free-text (probe-verified). ESM→CJS named import verified under native node ESM.
- Pure / read-only / fail-open — no claim-state writes, no new tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)