### PR TITLE
fix(QF-20260609-255): Fix ci_failure dedup hash (workflow+branch, not runId)

### DIFF
--- a/scripts/clockwork/gh-failure-monitor.cjs
+++ b/scripts/clockwork/gh-failure-monitor.cjs
@@ -27,9 +27,13 @@ function mapSeverity(workflowName) {
   return 'medium';
 }
 
-function computeErrorHash(workflowName, runId) {
+// QF-20260609-255: key the dedup hash on workflowName + headBranch (NOT runId). runId
+// (run.databaseId) is unique per run, so the old hash never matched across distinct failed
+// runs of the same workflow/branch — every re-failure inserted a new feedback row (962 dup
+// rows; LEO-Bypass alone = 305) and burned a fresh LLM triage call each time.
+function computeErrorHash(workflowName, headBranch) {
   return crypto.createHash('sha256')
-    .update(`${workflowName}:${runId}`)
+    .update(`${workflowName}:${headBranch}`)
     .digest('hex');
 }
 
@@ -61,8 +65,19 @@ async function insertFailures(supabase, failures, repo) {
   let updated = 0;
 
   for (const run of failures) {
-    const errorHash = computeErrorHash(run.name, run.databaseId);
+    const errorHash = computeErrorHash(run.name, run.headBranch);
     const title = sanitizeInput(`${run.name} failed on ${run.headBranch}`);
+    // QF-20260609-255: latest-run metadata reused on BOTH the dedup-update and the insert,
+    // so a deduped row always reflects the most recent run_id/run_url, not the first sighting.
+    const metadata = {
+      run_id: run.databaseId,
+      run_url: run.url,
+      workflow_name: sanitizeInput(run.name),
+      branch: sanitizeInput(run.headBranch),
+      repo,
+      conclusion: run.conclusion,
+      gh_created_at: run.createdAt
+    };
 
     // Check for existing entry (dedup)
     const { data: existing } = await supabase
@@ -78,7 +93,8 @@ async function insertFailures(supabase, failures, repo) {
         .update({
           occurrence_count: (existing[0].occurrence_count || 1) + 1,
           last_seen: new Date().toISOString(),
-          updated_at: new Date().toISOString()
+          updated_at: new Date().toISOString(),
+          metadata
         })
         .eq('id', existing[0].id);
       updated++;
@@ -97,15 +113,7 @@ async function insertFailures(supabase, failures, repo) {
           severity: mapSeverity(run.name),
           category: 'ci_failure',
           status: 'new',
-          metadata: {
-            run_id: run.databaseId,
-            run_url: run.url,
-            workflow_name: sanitizeInput(run.name),
-            branch: sanitizeInput(run.headBranch),
-            repo,
-            conclusion: run.conclusion,
-            gh_created_at: run.createdAt
-          },
+          metadata,
           first_seen: new Date().toISOString(),
           last_seen: new Date().toISOString()
         });
@@ -192,9 +200,14 @@ async function main() {
   console.log('[Clockwork:GH-Monitor] Done.');
 }
 
-main().catch(err => {
-  console.error('[Clockwork:GH-Monitor] Fatal error:', err.message);
-  process.exit(1);
-});
+// QF-20260609-255: only auto-run when invoked directly (the clockwork cron runs
+// `node gh-failure-monitor.cjs`). Guarding lets the exported helpers be required by tests
+// without triggering a live GH fetch + DB writes on import.
+if (require.main === module) {
+  main().catch(err => {
+    console.error('[Clockwork:GH-Monitor] Fatal error:', err.message);
+    process.exit(1);
+  });
+}
 
 module.exports = { mapSeverity, computeErrorHash, sanitizeInput, fetchFailedRuns };

--- a/tests/unit/gh-failure-monitor-dedup.test.js
+++ b/tests/unit/gh-failure-monitor-dedup.test.js
@@ -1,0 +1,39 @@
+// QF-20260609-255: the ci_failure dedup hash must key on workflowName + headBranch, NOT runId.
+// run.databaseId (runId) is unique per run, so the old sha256(`${workflowName}:${runId}`) never
+// matched across distinct failed runs — every re-failure inserted a new feedback row (962 dup
+// rows; LEO-Bypass alone = 305) and burned a fresh LLM triage call. computeErrorHash is exported
+// (and the module now guards main() behind require.main === module, so requiring it is side-effect
+// free). Functional unit test, no DB.
+import 'dotenv/config';
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { computeErrorHash } = require('../../scripts/clockwork/gh-failure-monitor.cjs');
+
+describe('QF-20260609-255: gh-failure-monitor computeErrorHash dedup', () => {
+  it('is deterministic for the same workflow + branch', () => {
+    expect(computeErrorHash('CI', 'main')).toBe(computeErrorHash('CI', 'main'));
+  });
+
+  it('dedups across distinct runs of the same workflow + branch (the fix)', () => {
+    // Callers now pass headBranch (not the per-run databaseId), so two distinct failed runs of
+    // the same workflow on the same branch collapse to one hash → one deduped feedback row.
+    expect(computeErrorHash('LEO Protocol Bypass Detection', 'main'))
+      .toBe(computeErrorHash('LEO Protocol Bypass Detection', 'main'));
+  });
+
+  it('distinguishes different branches', () => {
+    expect(computeErrorHash('CI', 'main')).not.toBe(computeErrorHash('CI', 'feature/x'));
+  });
+
+  it('distinguishes different workflows', () => {
+    expect(computeErrorHash('CI', 'main')).not.toBe(computeErrorHash('Deploy', 'main'));
+  });
+
+  it('does NOT vary by runId (regression guard: the hash ignores any per-run id)', () => {
+    // computeErrorHash(workflowName, headBranch) uses exactly two inputs; a stray 3rd arg
+    // (an old runId) must not change the hash — that was the bug.
+    expect(computeErrorHash('CI', 'main', 111)).toBe(computeErrorHash('CI', 'main', 222));
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260609-255

**Type:** bug
**Severity:** high

### Issue Description
scripts/clockwork/gh-failure-monitor.cjs:30-34 hashes sha256(workflowName:runId); runId is unique per run so dedup only matches re-runs of the same runId, never across distinct failed runs (962 rows; LEO-Bypass alone=305 dup rows, each a wasted LLM triage call). Change computeErrorHash to key on workflowName+headBranch (drop runId); keep latest run_id/url in metadata; update the exported callsite + tests. Context: docs/protocol/README.md (LEO Harness overview).




### Changes
- **Files Changed:** 2
  - scripts/clockwork/gh-failure-monitor.cjs
  - tests/unit/gh-failure-monitor-dedup.test.js
- **LOC:** 30 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
computeErrorHash now keys on workflowName+headBranch (drop per-run databaseId); callsite + metadata reuse updated so deduped rows keep latest run_id/url; main() guarded behind require.main so helpers are testable. UAT = 5/5 unit test (tests/unit/gh-failure-monitor-dedup.test.js): same workflow+branch dedups across distinct runs, different branch/workflow produce different hashes, runId ignored. node --check OK. Production ~30 LOC.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol