### PR TITLE
fix(QF-20260609-703): De-noise the chairman/coordinator harness-backlog view

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1225,11 +1225,11 @@ async function printFeedback(d, deps = {}) {
   // Harness backlog: deferred harness-hardening work captured during product sessions.
   const { data: backlog, error: bErr } = await sb
     .from('feedback')
-    .select('id, title, status, created_at')
+    .select('id, title, status, created_at, metadata')
     .eq('category', 'harness_backlog')
     .neq('status', 'resolved')
     .order('created_at', { ascending: false })
-    .limit(15);
+    .limit(100); // QF-20260609-703: fetch wider, then de-noise via sourceableBacklog before the 15-row display
 
   // Graceful degradation: a failed query prints a short notice and returns without
   // throwing, so the overall /coordinator all render never crashes (mirrors printInbox).
@@ -1240,7 +1240,10 @@ async function printFeedback(d, deps = {}) {
   }
 
   const uRows = untriaged || [];
-  const bRows = backlog || [];
+  // QF-20260609-703: drop completion-flag / fleet-retro / coordinator-review AUTO-CAPTURE closure
+  // artifacts (~90% of harness_backlog) so the dashboard shows genuine sourceable work only.
+  const { sourceableBacklog } = await import('./lib/sourceable-backlog.mjs');
+  const bRows = sourceableBacklog(backlog || []);
 
   if (uRows.length === 0 && bRows.length === 0) {
     console.log('  (no pending feedback or harness backlog)');
@@ -1264,7 +1267,7 @@ async function printFeedback(d, deps = {}) {
   if (bRows.length === 0) {
     console.log('    (none)');
   } else {
-    for (const b of bRows) {
+    for (const b of bRows.slice(0, 15)) {
       console.log('    ' + pad(ageOf(b.created_at), 6) + (b.title || '').substring(0, 52));
     }
   }

--- a/tests/unit/coordinator/fleet-dashboard-feedback.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-feedback.test.js
@@ -72,6 +72,25 @@ describe('printFeedback — populated', () => {
   });
 });
 
+describe('printFeedback — harness-backlog de-noise (QF-20260609-703)', () => {
+  test('drops completion-flag / fleet-retro auto-captures, keeps genuine items', async () => {
+    const sb = mockSupabase({
+      untriaged: [],
+      backlog: [
+        { id: 'g1', title: 'Genuine harness gap to source', status: 'new', created_at: hoursAgo(1), metadata: {} },
+        { id: 'a1', title: 'Completion flag (harness) — SD-X', status: 'new', created_at: hoursAgo(2), metadata: { flag_class: 'harness' } },
+        { id: 'a2', title: 'Fleet retro 2026-06-09 — coordinator', status: 'new', created_at: hoursAgo(3), metadata: {} },
+      ],
+    });
+    await printFeedback({}, { supabase: sb });
+    const out = output();
+    expect(out).toContain('Harness backlog (1)');        // only the genuine item survives the filter
+    expect(out).toContain('Genuine harness gap to source');
+    expect(out).not.toContain('Completion flag (harness)'); // dropped via metadata.flag_class
+    expect(out).not.toContain('Fleet retro');                // dropped via title fallback
+  });
+});
+
 describe('printFeedback — empty state', () => {
   test('prints explicit no-pending line when both queries return zero rows', async () => {
     const sb = mockSupabase({ untriaged: [], backlog: [] });


### PR DESCRIPTION
## Quick-Fix: QF-20260609-703

**Type:** bug
**Severity:** high

### Issue Description
Apply the existing sourceableBacklog filter (scripts/lib/sourceable-backlog.mjs) to fleet-dashboard.cjs printFeedback (L1226-1232, currently raw: 114 rows ~90 percent auto-capture noise) AND unify the two split chairman decision queues: make adam-exec-summary.mjs NEEDS-YOU also query operator_question feedback rows (the live authoritative queue) with .adam-chairman-decisions.json as an optional overlay. Needs cjs-to-mjs import + add metadata to the dashboard select. Context: docs/protocol/README.md (LEO Harness overview).




### Changes
- **Files Changed:** 2
  - scripts/fleet-dashboard.cjs
  - tests/unit/coordinator/fleet-dashboard-feedback.test.js
- **LOC:** 960 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Part 1 de-noise shipped; part 2 descoped (operator_question 0 rows + adam-exec-summary.mjs untracked), signaled coordinator.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol