### PR TITLE
fix(QF-20260609-689): activate dormant coordinator escalation flags (ACK_V1 + AUTO_PROCEED_V1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "SWEEP_RESPECT_INFLIGHT_AGENT": "1",
     "COORDINATOR_TWOWAY_V2": "on",
-    "COORD_ADAM_REVIEW_V1": "on"
+    "COORD_ADAM_REVIEW_V1": "on",
+    "COORD_ADAM_ACTION_ACK_V1": "on",
+    "COORD_QUESTION_AUTO_PROCEED_V1": "on"
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
Chairman-approved 2026-06-09. Enables two write-disabled coordinator escalation modules via .claude/settings.json env flags:
- COORD_ADAM_ACTION_ACK_V1 (wake-only escalation for aged un-actioned adam action handoffs; lowest blast)
- COORD_QUESTION_AUTO_PROCEED_V1 (non-critical operator questions auto-resolve on the recommended default after ~8min timeout; CRITICAL categories/keywords always hard-wait for the chairman)

Config-only (2 flags). Verified live first: 0 aged adam_action_required handoffs (no wake-row storm), 0 pending questions (no premature proceed). Flag names verified against escalationEnabled()/autoProceedEnabled().

🤖 Generated with [Claude Code](https://claude.com/claude-code)