### PR TITLE
fix(QF-20260609-666): post-compaction read points to unified-session-state.json

### DIFF
--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1241,7 +1241,7 @@ For SQL migrations, use the Supabase CLI or dashboard SQL editor:
 
 4. **NEVER Compress Away**:
    - The `.claude/session-state.md` reference
-   - The `.claude/compaction-snapshot.md` reference
+   - The `.claude/unified-session-state.json` reference
    - Active PRD requirements
    - User's explicit instructions from this session
 
@@ -1252,7 +1252,7 @@ For SQL migrations, use the Supabase CLI or dashboard SQL editor:
    - Historical handoff details (older than current phase)
 
 **After compaction, IMMEDIATELY read:**
-- `.claude/compaction-snapshot.md` (git state)
+- `.claude/unified-session-state.json` (git state)
 - `.claude/session-state.md` (work state)
 
 **Session Restoration Protocol**: If you notice context seems sparse or you're missing critical details, proactively ask: "I may have lost context during compaction. Let me check .claude/session-state.md for current work state."


### PR DESCRIPTION
## Issue
CLAUDE_CORE.md (Compaction Instructions, leo_protocol_sections id=414) told workers to read `.claude/compaction-snapshot.md` after compaction, but the PreCompact hook `scripts/hooks/precompact-snapshot.ps1` writes `.claude/unified-session-state.json` — workers read a non-existent file and lost captured git/SD state.

## Fix
Updated the two references (item 4 'NEVER Compress Away' + the 'After compaction, IMMEDIATELY read' list) to `.claude/unified-session-state.json`. The DB source-of-truth (`leo_protocol_sections` id=414) was updated to match so the daily KB regen stays idempotent. `.claude/session-state.md` left unchanged (verified it is a real file the hook handles).

2-line change. QF-20260609-666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)