### PR TITLE
docs(QF-20260609-756): correct folklore + stale comments across harness scripts

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -215,7 +215,7 @@ Coordinator initialized (role context surfaced; eight standard loops armed).
   Audit loop: every 15 minutes (3-source audit: SD queue / harness backlog / inbox; REVIEW HEALTH gauge)
   Executive email: every 30 minutes (default-on fleet-health gauge + question escalation)
   Self-review loop: every 5 minutes (work-triggered tri-party review; no-op below COORD_REVIEW_EVERY)
-  All loops auto-expire after 3 days or when this session exits.
+  All loops auto-expire after 7 days (CronCreate's recurring-job limit) or when this session exits — re-arm weekly to keep the fleet supervised.
 
   Fleet is now running on autopilot. You will see sweep and dashboard output automatically.
   Use /coordinator help to see all subcommands.
@@ -352,7 +352,7 @@ Getting Started:
   1. Runs an initial sweep to clean fleet state
   2. Shows the full dashboard
   3. Sets up automated 5-min cron loops for sweep and dashboard
-  The cron loops are session-scoped (auto-expire after 3 days or session exit).
+  The cron loops are session-scoped (auto-expire after 7 days — CronCreate's recurring-job limit — or session exit; re-arm weekly).
 
 Automated QA Fixes (run every sweep):
   - STUCK_100: SDs at 100%/pending_approval auto-completed

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -20,9 +20,11 @@
  * The `dependencies` array is heterogeneously shaped across the fleet: plain text
  * ("SD-X needs Y"), {sd_id:"SD-X"}, {sd_key:"SD-X"}, {sd_key:"none"} sentinel, and free-form
  * {type,status,dependency} notes with NO SD ref. Each element resolves to a referenced sd_key;
- * elements with no SD ref (or the "none" sentinel) are non-blocking. Re-implemented here because
- * v_sd_next_candidates.deps_satisfied is BROKEN for object-shaped deps (it text-compares the whole
- * JSON object, never matching a completed key).
+ * elements with no SD ref (or the "none" sentinel) are non-blocking. Re-implemented here rather than
+ * trusting v_sd_next_candidates.deps_satisfied: that column historically mis-evaluated object-shaped
+ * deps (it text-compared the whole JSON object, never matching a completed key); the 2026-06-08 view
+ * fix (SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001) corrected it, but this DB-backed re-check is retained as
+ * a claim-time guard independent of the view (and the view never gated on sd_type/orchestrator-parent).
  *
  * Error semantics are caller-selectable so the two dispatch paths can differ safely:
  *   - default ({ throwOnError:false }) -> returns false on a query error (worker-checkin self_claim:

--- a/scripts/hooks/persist-session-state.cjs
+++ b/scripts/hooks/persist-session-state.cjs
@@ -4,11 +4,14 @@
  * Persist Session State Hook
  * SD-CLAUDE-CODE-2.1.0-LEO-001 - Phase 2 Hook Infrastructure
  *
- * PostToolUse hook that persists session state as a checkpoint after each
- * tool execution. This enables crash recovery by providing restore points.
+ * PostToolUse hook that persists session state as a LOCAL checkpoint file
+ * ($HOME/.claude-checkpoints) after each tool execution. This is a single-machine
+ * restore aid for re-attaching after a local restart on the SAME host — NOT a
+ * distributed crash-recovery system. The authoritative cross-session/cross-machine
+ * source of truth is the DB (claude_sessions); these files are a convenience cache.
  *
  * Hook Type: PostToolUse (after every tool)
- * Purpose: Session state persistence for crash recovery
+ * Purpose: Single-machine local-checkpoint restore aid (DB is authoritative)
  * User Story: SD-CLAUDE-CODE-2-1-0-LEO-001:US-003
  */
 

--- a/scripts/hooks/recover-session-state.cjs
+++ b/scripts/hooks/recover-session-state.cjs
@@ -4,13 +4,16 @@
  * Recover Session State Script
  * SD-CLAUDE-CODE-2.1.0-LEO-001 - Phase 2 Hook Infrastructure
  *
- * Recovery script that restores session state from the most recent checkpoint
- * after a crash or unexpected termination. Target: recovery within 60 seconds.
+ * Restores session state from the most recent LOCAL checkpoint file
+ * ($HOME/.claude-checkpoints) after a restart on the SAME host. This is a
+ * single-machine restore aid — NOT distributed crash recovery; the authoritative
+ * cross-session/cross-machine state lives in the DB (claude_sessions). Use this only
+ * to re-attach quickly after a local restart; for true session identity/state, query the DB.
  *
  * Can be invoked manually or as a PreToolUse (once) hook for session init.
  *
  * Hook Type: Manual or PreToolUse (once: true) on new session
- * Purpose: Crash recovery from checkpoints
+ * Purpose: Single-machine local-checkpoint restore aid (DB is authoritative)
  * User Story: SD-CLAUDE-CODE-2-1-0-LEO-001:US-003
  */
 


### PR DESCRIPTION
Comment/doc-only cleanup (no logic change), ~11 net lines:

- **coordinator.md**: loop auto-expiry is **7 days, not 3** — verified against CronCreate's own schema (*"Recurring tasks auto-expire after 7 days"*); added a weekly re-arm note.
- **worker-checkin.cjs**: the two comments calling `v_sd_next_candidates.deps_satisfied` **BROKEN** are stale — the 2026-06-08 view fix (SD-LEO-INFRA-FIX-NEXT-CANDIDATES-001) corrected it. Reworded: view corrected; the DB-backed JS re-check is retained as a claim-time guard (and the view never gated on sd_type/orchestrator-parent anyway).
- **persist/recover-session-state.cjs**: demoted the misleading "crash recovery" docstrings to what they actually are — single-machine LOCAL-checkpoint restore aids (`$HOME/.claude-checkpoints`); the DB (`claude_sessions`) is the authoritative cross-session/cross-machine source of truth.

Skipped the optional resolver-consolidation (behavior change, out of scope for a documentation QF). All 3 touched .cjs files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)