### PR TITLE
fix(QF-20260609-660): heal sd-persist never reports PASS when a score failed to persist

### DIFF
--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -687,6 +687,7 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
     .single();
 
   const insertedIds = [];
+  const persistFailures = []; // QF-20260609-660: SDs whose score failed to persist — must NOT yield HEAL_STATUS=PASS
 
   for (const sdScore of parsed.sd_scores) {
     const dimensionScores = {};
@@ -697,6 +698,15 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
         reasoning: dim.reasoning,
         source: 'sd-heal',
       };
+    }
+
+    // QF-20260609-660: a null / non-finite aggregate would violate the eva_vision_scores
+    // total_score NOT NULL constraint and silently drop the row — record it as a persist
+    // failure so the verdict can never report PASS while writing nothing.
+    if (typeof sdScore.total_score !== 'number' || !Number.isFinite(sdScore.total_score)) {
+      persistFailures.push({ sdKey: sdScore.sd_key, reason: `invalid total_score (${sdScore.total_score})` });
+      console.error(`Skipping ${sdScore.sd_key}: invalid total_score (${sdScore.total_score}) — not persisted`);
+      continue;
     }
 
     // SD-WRITERCONSUMER-ASYMMETRY-DETECTION-SCOPECOMPLETION-ORCH-001-0 / FR-C0-5
@@ -743,6 +753,7 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
 
     if (error) {
       console.error(`Failed to persist score for ${sdScore.sd_key}: ${error.message}`);
+      persistFailures.push({ sdKey: sdScore.sd_key, reason: error.message }); // QF-20260609-660
       continue;
     }
 
@@ -763,6 +774,17 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
   console.log('\n\u2500\u2500\u2500 SD Heal Summary \u2500\u2500\u2500');
   console.log(`  Overall: ${parsed.overall_score}/100`);
   console.log(`  SDs scored: ${insertedIds.length}`);
+
+  // QF-20260609-660: if any SD's score FAILED to persist (e.g. a null/invalid total_score
+  // violating the eva_vision_scores NOT NULL constraint), the verdict must NOT be PASS — a
+  // heal gate that reports PASS while writing nothing silently loses learning data.
+  if (persistFailures.length > 0) {
+    console.log(`\n  ⚠️  ${persistFailures.length} SD score(s) FAILED to persist:`);
+    for (const f of persistFailures) console.log(`    ${f.sdKey}: ${f.reason}`);
+    console.log(`\nHEAL_STATUS=PERSIST_FAILED`);
+    console.log(`HEAL_PERSIST_FAILED=${persistFailures.map(f => f.sdKey).join(',')}`);
+    return;
+  }
 
   const needsCorrection = insertedIds.filter(s => s.action !== 'accept');
   if (needsCorrection.length > 0) {

--- a/tests/unit/eva/heal-persist-verdict.test.js
+++ b/tests/unit/eva/heal-persist-verdict.test.js
@@ -1,0 +1,58 @@
+// QF-20260609-660 — heal-command sd-persist must NOT emit HEAL_STATUS=PASS when a score
+// failed to persist (e.g. a null/invalid total_score violating the eva_vision_scores NOT NULL
+// constraint). Previously a failed insert was console.error'd + `continue`d, dropping the SD
+// from insertedIds; if all failed, insertedIds was empty -> the verdict else-branch emitted
+// PASS while writing zero rows (silent false-pass losing learning data).
+//
+// Mirrors the repo's heal-command test style (heal-low-confidence-unverified.test.js): the full
+// CLI/DB path is gated by Supabase availability, so this asserts the pure verdict + validation
+// logic via small mocks of the exact code paths.
+import { describe, it, expect } from 'vitest';
+
+// Mirrors the new guard in cmdSDPersist (heal-command.mjs): a total_score that is not a finite
+// number is treated as a persist failure (it would violate the NOT NULL constraint).
+function isValidTotalScore(s) {
+  return typeof s === 'number' && Number.isFinite(s);
+}
+
+// Mirrors the verdict precedence in cmdSDPersist after the QF-20260609-660 fix.
+function computeHealVerdict({ insertedIds = [], persistFailures = [], inProgress = false }) {
+  if (persistFailures.length > 0) return 'PERSIST_FAILED';
+  const needsCorrection = insertedIds.filter((s) => s.action !== 'accept');
+  if (needsCorrection.length > 0) return inProgress ? 'NEEDS_CORRECTION_DEFERRED' : 'NEEDS_CORRECTION';
+  return 'PASS';
+}
+
+describe('heal sd-persist: invalid total_score detection (QF-20260609-660)', () => {
+  it('treats null/undefined/NaN/non-number total_score as invalid (would not persist)', () => {
+    expect(isValidTotalScore(null)).toBe(false);
+    expect(isValidTotalScore(undefined)).toBe(false);
+    expect(isValidTotalScore(NaN)).toBe(false);
+    expect(isValidTotalScore('80')).toBe(false);
+    expect(isValidTotalScore({})).toBe(false);
+  });
+  it('accepts finite numeric total_score (including 0)', () => {
+    expect(isValidTotalScore(0)).toBe(true);
+    expect(isValidTotalScore(100)).toBe(true);
+    expect(isValidTotalScore(72.5)).toBe(true);
+  });
+});
+
+describe('heal sd-persist: verdict never PASS when a score failed to persist (QF-20260609-660)', () => {
+  it('THE BUG: all inserts failed -> PERSIST_FAILED, never PASS', () => {
+    // pre-fix this produced empty insertedIds -> else-branch -> PASS (silent false-pass)
+    expect(computeHealVerdict({ insertedIds: [], persistFailures: [{ sdKey: 'SD-X', reason: 'null total_score' }] }))
+      .toBe('PERSIST_FAILED');
+  });
+  it('mixed: some persisted (even accept) + a failure -> failure takes precedence', () => {
+    expect(computeHealVerdict({ insertedIds: [{ action: 'accept' }], persistFailures: [{ sdKey: 'SD-Y', reason: 'boom' }] }))
+      .toBe('PERSIST_FAILED');
+  });
+  it('all persisted, none below threshold -> PASS', () => {
+    expect(computeHealVerdict({ insertedIds: [{ action: 'accept' }, { action: 'accept' }] })).toBe('PASS');
+  });
+  it('persisted with a sub-threshold score -> NEEDS_CORRECTION (not masked)', () => {
+    expect(computeHealVerdict({ insertedIds: [{ action: 'escalate' }] })).toBe('NEEDS_CORRECTION');
+    expect(computeHealVerdict({ insertedIds: [{ action: 'escalate' }], inProgress: true })).toBe('NEEDS_CORRECTION_DEFERRED');
+  });
+});


### PR DESCRIPTION
## Issue
Per-SD heal scoring in `scripts/eva/heal-command.mjs` `console.error`'d + `continue`'d a failed insert (e.g. a null/invalid `total_score` violating the `eva_vision_scores` NOT NULL constraint), dropping the SD from `insertedIds`. If all inserts failed, `insertedIds` was empty → the verdict else-branch emitted **`HEAL_STATUS=PASS` while writing zero rows** — a silent false-pass that loses learning data (a gate reporting PASS while writing nothing).

## Fix
- Validate `total_score` before insert (non-finite → recorded as a persist failure, not silently dropped).
- Record insert errors in a `persistFailures` list.
- Before the PASS/NEEDS_CORRECTION verdict, if any score failed to persist, emit **`HEAL_STATUS=PERSIST_FAILED`** (never PASS) and list the failures.

+6 unit tests mirroring the repo's pure-helper test style (verdict precedence + `total_score` validity); 10/10 with the existing heal test. 22 source LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)