### PR TITLE
fix(SD-LEO-INFRA-HARDEN-ADD-PRD-001): harden add-prd CLI — shape-check components + EPIPE-safe stdout

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -172,6 +172,19 @@ export function validateContentPayloadShape(payload) {
   expectObject('system_architecture');
   expectObject('implementation_approach');
 
+  // SD-LEO-INFRA-HARDEN-ADD-PRD-001: recurse into system_architecture.components — a string/object
+  // value passes expectObject('system_architecture') but then crashes downstream at
+  // scripts/prd/formatters.js (arch.components.forEach is not a function). Assert it's an array when present.
+  if (
+    payload.system_architecture &&
+    typeof payload.system_architecture === 'object' &&
+    !Array.isArray(payload.system_architecture) &&
+    'components' in payload.system_architecture &&
+    !Array.isArray(payload.system_architecture.components)
+  ) {
+    errors.push(`.system_architecture.components: expected array, got ${typeOf(payload.system_architecture.components)}`);
+  }
+
   if (errors.length > 0) {
     const e = new Error(`--content: SHAPE_VIOLATIONS (${errors.length}):\n  - ${errors.join('\n  - ')}`);
     e.code = 'CONTENT_SHAPE_VIOLATION';
@@ -208,6 +221,14 @@ if (isMainModule(import.meta.url)) {
   if (heartbeatActive) {
     startHeartbeat(process.env.CLAUDE_SESSION_ID, { ownershipMode: 'cooperative' });
   }
+
+  // SD-LEO-INFRA-HARDEN-ADD-PRD-001: EPIPE-tolerant stdout/stderr. This CLI emits ~180KB before the
+  // async DB insert; piping it through `head`/`grep` closes the read end, and the next console.log
+  // would raise an unhandled 'error' (EPIPE) that crashes the process BEFORE persistence on POSIX/CI
+  // (Windows git-bash masks it). Swallow EPIPE on both streams so a closed pipe never aborts the run.
+  const ignoreEpipe = (err) => { if (!err || err.code === 'EPIPE') return; throw err; };
+  process.stdout.on('error', ignoreEpipe);
+  process.stderr.on('error', ignoreEpipe);
 
   const argv = process.argv.slice(2);
   if (argv.length < 1) {

--- a/scripts/prd/formatters.js
+++ b/scripts/prd/formatters.js
@@ -190,7 +190,9 @@ ${llmContent.technical_requirements.map(req => {
     const arch = llmContent.system_architecture;
     const archLines = ['## System Architecture'];
     if (arch.overview) archLines.push(`\n### Overview\n${arch.overview}`);
-    if (arch.components && arch.components.length > 0) {
+    // SD-LEO-INFRA-HARDEN-ADD-PRD-001: guard with Array.isArray — a string .components has a
+    // truthy .length but no .forEach (the downstream crash the shape-check now also blocks).
+    if (Array.isArray(arch.components) && arch.components.length > 0) {
       archLines.push('\n### Components');
       arch.components.forEach(comp => {
         archLines.push(`\n#### ${comp.name}`);
@@ -199,7 +201,7 @@ ${llmContent.technical_requirements.map(req => {
       });
     }
     if (arch.data_flow) archLines.push(`\n### Data Flow\n${arch.data_flow}`);
-    if (arch.integration_points && arch.integration_points.length > 0) {
+    if (Array.isArray(arch.integration_points) && arch.integration_points.length > 0) {
       archLines.push('\n### Integration Points');
       arch.integration_points.forEach(point => archLines.push(`- ${point}`));
     }

--- a/tests/unit/add-prd-shape-components-epipe.test.js
+++ b/tests/unit/add-prd-shape-components-epipe.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-HARDEN-ADD-PRD-001
+ * Two robustness defects in the add-prd-to-database CLI:
+ *  (1) validateContentPayloadShape did not recurse into system_architecture.components, so a
+ *      non-array .components passed SHAPE-CHECK then crashed downstream (formatters.js
+ *      arch.components.forEach is not a function).
+ *  (2) No EPIPE-safe stdout handling — piping the ~180KB output through head/grep crashed the
+ *      process (unhandled EPIPE) before the async DB insert on POSIX/CI.
+ *
+ * Behavioral coverage for (1) via the exported validateContentPayloadShape; static-guard pins for
+ * the formatters Array.isArray hardening and the CLI EPIPE handler.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateContentPayloadShape } from '../../scripts/add-prd-to-database.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const read = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const base = () => ({ title: 'X', executive_summary: 'Y' });
+
+describe('SD-LEO-INFRA-HARDEN-ADD-PRD-001: shape check recurses into system_architecture.components', () => {
+  it('THROWS CONTENT_SHAPE_VIOLATION when .components is a string (the downstream-crash payload)', () => {
+    let err;
+    try {
+      validateContentPayloadShape({ ...base(), system_architecture: { overview: 'o', components: 'not-an-array' } });
+    } catch (e) { err = e; }
+    expect(err).toBeDefined();
+    expect(err.code).toBe('CONTENT_SHAPE_VIOLATION');
+    expect(err.message).toMatch(/system_architecture\.components/);
+  });
+
+  it('THROWS when .components is an object (also non-array)', () => {
+    expect(() =>
+      validateContentPayloadShape({ ...base(), system_architecture: { components: { a: 1 } } })
+    ).toThrow(/CONTENT_SHAPE_VIOLATION|system_architecture\.components/);
+  });
+
+  it('PASSES when .components is an array', () => {
+    expect(() =>
+      validateContentPayloadShape({ ...base(), system_architecture: { components: [{ name: 'C' }] } })
+    ).not.toThrow();
+  });
+
+  it('PASSES when system_architecture has no .components key (optional)', () => {
+    expect(() =>
+      validateContentPayloadShape({ ...base(), system_architecture: { overview: 'o' } })
+    ).not.toThrow();
+  });
+
+  it('still rejects a non-object system_architecture (pre-existing behavior preserved)', () => {
+    expect(() =>
+      validateContentPayloadShape({ ...base(), system_architecture: 'a string' })
+    ).toThrow(/CONTENT_SHAPE_VIOLATION|system_architecture/);
+  });
+});
+
+describe('SD-LEO-INFRA-HARDEN-ADD-PRD-001: formatters.js guards components with Array.isArray', () => {
+  const src = read('scripts/prd/formatters.js');
+  it('guards arch.components with Array.isArray (no more bare .length/.forEach on a string)', () => {
+    expect(src).toMatch(/Array\.isArray\(arch\.components\)/);
+    expect(src).not.toMatch(/if \(arch\.components && arch\.components\.length/);
+  });
+  it('guards arch.integration_points with Array.isArray too', () => {
+    expect(src).toMatch(/Array\.isArray\(arch\.integration_points\)/);
+  });
+});
+
+describe('SD-LEO-INFRA-HARDEN-ADD-PRD-001: add-prd CLI has an EPIPE-tolerant stdout handler', () => {
+  const src = read('scripts/add-prd-to-database.js');
+  it('registers a process.stdout error handler', () => {
+    expect(src).toMatch(/process\.stdout\.on\(\s*['"]error['"]/);
+  });
+  it('swallows EPIPE specifically (does not crash on a closed pipe)', () => {
+    expect(src).toMatch(/EPIPE/);
+  });
+});


### PR DESCRIPTION
## Summary
Two Adam-verified robustness defects in `scripts/add-prd-to-database.js` (the most-used PRD-creation CLI):

1. **Shape-check didn't recurse into `system_architecture.components`** — `validateContentPayloadShape` asserted `system_architecture` is an object but never `.components`, so a non-array `.components` passed SHAPE-CHECK then crashed downstream at `scripts/prd/formatters.js` (`arch.components.forEach is not a function`). **Fix**: assert `system_architecture.components` is an array when present (fail fast, `CONTENT_SHAPE_VIOLATION`) + `Array.isArray` guards on `arch.components`/`integration_points` in formatters.js. Extends QF-20260526-436.
2. **No EPIPE-safe stdout** — the CLI emits ~180KB before the async DB insert, so piping through `head`/`grep` closes the read end and the next `console.log` raised an unhandled EPIPE that crashed the process **before persistence** on POSIX/CI (Windows git-bash masks it). **Fix**: EPIPE-tolerant `process.stdout`/`stderr` `'error'` handler at the CLI entry (CLI-only path; swallows only `EPIPE`, rethrows the rest).

## Verification
- **24/24 unit tests** (9 new: behavioral shape-check incl the string-components crash payload + static guards for the formatters `Array.isArray` hardening and the EPIPE handler; 15 existing static guards green).
- `node --check` clean on both changed files. CLI/formatter robustness only — no auth/schema/migration. TESTING PASS 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)