### PR TITLE
fix(QF-20260609-943): route SD-AUDIT generation through scoreSDAtConception

### DIFF
--- a/scripts/audit-to-sd.mjs
+++ b/scripts/audit-to-sd.mjs
@@ -16,6 +16,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+// QF-20260609-943: score auto-generated audit SDs at conception (leo-create-sd guards its CLI behind isMainModule, so this import is side-effect-free).
+import { scoreSDAtConception } from './leo-create-sd.js';
 
 // Load environment variables
 dotenv.config();
@@ -322,6 +324,20 @@ async function generateSDs(filePath, options = {}) {
     } else {
       result.sdsGenerated += (data?.length || 0);
       console.log(`  Created SD batch ${Math.floor(i / batchSize) + 1}: ${data?.length || 0} SDs`);
+
+      // QF-20260609-943: route each created SD through scoreSDAtConception so SD-AUDIT-* rows get an
+      // eva_vision_scores row (they set metadata.auto_generated=true, which exempts them from
+      // GATE_VISION_SCORE and would otherwise mask the missing score). Mirrors leo-create-sd.js;
+      // non-blocking — a scoring failure must never fail audit-SD generation.
+      const createdIds = new Set((data || []).map((row) => row.id));
+      for (const sd of batch) {
+        if (createdIds.size > 0 && !createdIds.has(sd.id)) continue; // only score rows that inserted
+        try {
+          await scoreSDAtConception(sd.id, sd.title, sd.description, supabase);
+        } catch (scoreErr) {
+          result.errors.push(`Vision scoring skipped for ${sd.id}: ${scoreErr.message}`);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`scripts/audit-to-sd.mjs` direct-inserted generated `SD-AUDIT-*` rows without calling `scoreSDAtConception`, so they got no `eva_vision_scores` entry — masked by `metadata.auto_generated=true` (the GATE_VISION_SCORE exemption), a latent gate-coverage hole. **Fix**: after each successful batch insert, call `scoreSDAtConception(id, title, description, supabase)` per created SD, non-blocking (failures → `result.errors`, never fails generation), mirroring leo-create-sd.js; only rows confirmed inserted are scored. Import is side-effect-free (leo-create-sd guards its CLI behind isMainModule). Closes the residual left open by SD-LEO-INFRA-FIX-GEN-CLASS-001 (c422350f). ~14 LOC. Verified: `node --check` clean; scoreSDAtConception imports cleanly as a function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)