### PR TITLE
fix(QF-20260609-811): validate-doc-metadata Metadata section uses $ end anchor (not literal \Z)

### DIFF
--- a/scripts/validate-doc-metadata.js
+++ b/scripts/validate-doc-metadata.js
@@ -87,7 +87,7 @@ function shouldSkipFile(filename) {
 /**
  * Parse YAML frontmatter from markdown content
  */
-function parseFrontmatter(content) {
+export function parseFrontmatter(content) {
   // Check for YAML frontmatter (--- ... ---)
   const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (yamlMatch) {
@@ -124,7 +124,11 @@ function parseFrontmatter(content) {
   }
 
   // Check for markdown metadata section (## Metadata)
-  const mdMatch = content.match(/##\s*Metadata\s*\n([\s\S]*?)(?=\n##|\n---|\Z)/i);
+  // QF-20260609-811: terminate the Metadata section at the next `## `, a `---`, or
+  // end-of-input. The prior `\Z` was a literal "Z" in JS regex (not an end anchor), so any
+  // field value containing a Z (e.g. `Category: CANONICALIZE`) truncated the section there
+  // and all later fields were falsely reported MISSING. `$` (no `m` flag) is the real EOI anchor.
+  const mdMatch = content.match(/##\s*Metadata\s*\n([\s\S]*?)(?=\n##|\n---|$)/i);
   if (mdMatch) {
     const section = mdMatch[1];
     const metadata = {};
@@ -374,7 +378,10 @@ async function main() {
   process.exit(report.summary.invalid > 0 ? EXIT_CODES.VALIDATION_FAILED : EXIT_CODES.PASS);
 }
 
-main().catch(error => {
-  console.error(`Runtime error: ${error.message}`);
-  process.exit(EXIT_CODES.RUNTIME_ERROR);
-});
+// QF-20260609-811: only run the CLI when invoked directly, not when imported (e.g. by tests).
+if (process.argv[1] === __filename) {
+  main().catch(error => {
+    console.error(`Runtime error: ${error.message}`);
+    process.exit(EXIT_CODES.RUNTIME_ERROR);
+  });
+}

--- a/tests/unit/validate-doc-metadata.test.js
+++ b/tests/unit/validate-doc-metadata.test.js
@@ -1,0 +1,53 @@
+/**
+ * QF-20260609-811 — validate-doc-metadata parseFrontmatter Metadata-section terminator.
+ *
+ * Regression: the `## Metadata` section regex used `\Z` (a LITERAL "Z" in JS regex, not an
+ * end anchor). With the non-greedy capture, any field value containing a Z (e.g.
+ * `Category: CANONICALIZE`) truncated the section at that Z and all later fields were reported
+ * MISSING. The fix uses `$` (no `m` flag) — the real end-of-input anchor. These tests pin that
+ * a Z-bearing value no longer truncates, and that the section terminates correctly at the next
+ * `##`, a `---`, or end-of-input.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseFrontmatter } from '../../scripts/validate-doc-metadata.js';
+
+const mdSection = (extra = '') =>
+  `# Some Doc\n\n## Metadata\n- **Category**: CANONICALIZE\n- **Status**: Approved\n- **Version**: 1.0.0\n- **Author**: Test\n- **Tags**: a, b${extra}`;
+
+describe('QF-20260609-811: parseFrontmatter Metadata-section terminator', () => {
+  it('does NOT truncate at a Z in a field value (CANONICALIZE) — all fields parsed (the regression)', () => {
+    const r = parseFrontmatter(mdSection()); // section runs to EOF
+    expect(r?.type).toBe('markdown');
+    expect(r.metadata.Category).toBe('CANONICALIZE');
+    expect(r.metadata.Status).toBe('Approved');
+    expect(r.metadata.Version).toBe('1.0.0');
+    expect(r.metadata.Author).toBe('Test');
+    expect(r.metadata.Tags).toBe('a, b');
+  });
+
+  it('terminates at the next `##` heading (does not leak following content)', () => {
+    const r = parseFrontmatter(mdSection('\n\n## Overview\n- **Category**: LEAKED\nbody text'));
+    expect(r.metadata.Category).toBe('CANONICALIZE'); // not LEAKED
+    expect(r.metadata.Tags).toBe('a, b');
+    expect(r.raw).not.toContain('LEAKED');
+  });
+
+  it('terminates at a `---` horizontal rule', () => {
+    const r = parseFrontmatter(mdSection('\n\n---\n- **Category**: BELOW_RULE'));
+    expect(r.metadata.Category).toBe('CANONICALIZE');
+    expect(r.metadata.Author).toBe('Test');
+    expect(r.raw).not.toContain('BELOW_RULE');
+  });
+
+  it('terminates at end-of-input (no trailing terminator) with all fields', () => {
+    const r = parseFrontmatter(mdSection());
+    expect(Object.keys(r.metadata)).toEqual(['Category', 'Status', 'Version', 'Author', 'Tags']);
+  });
+
+  it('YAML frontmatter path still works (unaffected by the fix)', () => {
+    const r = parseFrontmatter('---\nCategory: CANONICALIZE\nStatus: Approved\n---\n# Body');
+    expect(r.type).toBe('yaml');
+    expect(r.metadata.Category).toBe('CANONICALIZE');
+    expect(r.metadata.Status).toBe('Approved');
+  });
+});


### PR DESCRIPTION
scripts/validate-doc-metadata.js parseFrontmatter() terminated the `## Metadata` section regex with `\Z` — a LITERAL 'Z' in JS regex, not an end anchor. With the non-greedy capture, any field value containing a Z (e.g. `Category: CANONICALIZE`) truncated the section there, so Status/Version/Author/Tags were falsely reported MISSING in DOCMON (20+ repo docs flow through this path).

## Fix
`\Z` → `$` (no `m` flag) = real end-of-input anchor. Also exported `parseFrontmatter` + added a main-guard (CLI runs only when invoked directly, not on import) to enable the regression test.

## Tests
+5 vitest tests (all pass): the CANONICALIZE no-truncate regression, plus the next-`##`, `---`, and EOF terminators, and an unaffected-YAML-path control.

Source: Adam verify wf_c6d577ae, belt rank 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)